### PR TITLE
Separate SSH connections from terminal profiles (PR1)

### DIFF
--- a/src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs
+++ b/src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs
@@ -130,10 +130,15 @@ namespace NovaTerminal.Controls
             }
         }
 
-        public void LoadProfiles(List<TerminalProfile> profiles)
+        public void LoadProfiles(IEnumerable<TerminalProfile> profiles)
         {
             _viewModel.LoadProfiles(profiles);
             UpdateResultCountText();
+        }
+
+        public IReadOnlyList<TerminalProfile> GetAllProfiles()
+        {
+            return _viewModel.GetAllProfiles();
         }
 
         private void OnFavoriteClick(object? sender, RoutedEventArgs e)

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -349,10 +349,8 @@ namespace NovaTerminal.Controls
             // ADVANCED SSH: Generate correct argument chain for ssh.exe
             if (profile != null && profile.Type == ConnectionType.SSH)
             {
-                // Fallback command line for legacy SSH profiles that are not in the SSH profile store.
-                var profiles = _settings?.Profiles ?? new System.Collections.Generic.List<TerminalProfile>();
                 effectiveShell = OperatingSystem.IsWindows() ? "ssh.exe" : "ssh";
-                args = profile.GenerateSshArguments(profiles);
+                args = BuildBasicSshFallbackArguments(profile);
             }
 
             // Update SFTP Menu Visibility
@@ -462,6 +460,36 @@ namespace NovaTerminal.Controls
                     Parser.CellHeight = ch;
                 }
             };
+        }
+
+        private static string BuildBasicSshFallbackArguments(TerminalProfile profile)
+        {
+            var args = new System.Text.StringBuilder();
+
+            string identityPath = !string.IsNullOrWhiteSpace(profile.IdentityFilePath)
+                ? profile.IdentityFilePath!
+                : profile.SshKeyPath ?? string.Empty;
+            bool useIdentity = !profile.UseSshAgent && !string.IsNullOrWhiteSpace(identityPath);
+            if (useIdentity)
+            {
+                args.Append($" -i \"{identityPath}\"");
+            }
+
+            if (profile.SshPort > 0 && profile.SshPort != 22)
+            {
+                args.Append($" -p {profile.SshPort}");
+            }
+
+            string target = string.IsNullOrWhiteSpace(profile.SshUser)
+                ? profile.SshHost
+                : $"{profile.SshUser}@{profile.SshHost}";
+            if (!string.IsNullOrWhiteSpace(target))
+            {
+                args.Append(' ');
+                args.Append(target);
+            }
+
+            return args.ToString().Trim();
         }
 
         public void ApplySettings(TerminalSettings settings)

--- a/src/NovaTerminal.App/Core/SessionManager.cs
+++ b/src/NovaTerminal.App/Core/SessionManager.cs
@@ -8,6 +8,7 @@ using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia;
 using NovaTerminal.Controls;
+using NovaTerminal.Services.Ssh;
 
 namespace NovaTerminal.Core
 {
@@ -95,6 +96,7 @@ namespace NovaTerminal.Core
                 {
                     Type = NodeType.Leaf,
                     ProfileId = pane.Profile?.Id.ToString(),
+                    SshProfileId = pane.Profile?.Type == ConnectionType.SSH ? pane.Profile.Id.ToString() : null,
                     PaneId = pane.PaneId.ToString(),
                     Command = pane.ShellCommand,
                     Arguments = pane.ShellArgs
@@ -243,8 +245,9 @@ namespace NovaTerminal.Core
             if (node.Type == NodeType.Leaf)
             {
                 // Reconstruct TerminalPane
-                TerminalProfile? profile = null;
-                if (!string.IsNullOrEmpty(node.ProfileId) && Guid.TryParse(node.ProfileId, out var profileGuid))
+                TerminalProfile? profile = ResolveSshProfile(node.SshProfileId);
+
+                if (profile == null && !string.IsNullOrEmpty(node.ProfileId) && Guid.TryParse(node.ProfileId, out var profileGuid))
                 {
                     profile = settings.Profiles?.Find(p => p.Id == profileGuid);
                 }
@@ -345,6 +348,24 @@ namespace NovaTerminal.Core
             }
 
             return null;
+        }
+
+        private static TerminalProfile? ResolveSshProfile(string? sshProfileId)
+        {
+            if (string.IsNullOrWhiteSpace(sshProfileId) || !Guid.TryParse(sshProfileId, out Guid parsedId))
+            {
+                return null;
+            }
+
+            try
+            {
+                var service = new SshConnectionService();
+                return service.GetConnectionProfile(parsedId);
+            }
+            catch
+            {
+                return null;
+            }
         }
     }
 }

--- a/src/NovaTerminal.App/Core/SftpService.cs
+++ b/src/NovaTerminal.App/Core/SftpService.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Threading;
+using NovaTerminal.Services.Ssh;
 
 namespace NovaTerminal.Core
 {
@@ -81,6 +83,14 @@ namespace NovaTerminal.Core
             {
                 var settings = TerminalSettings.Load();
                 var profile = settings.Profiles.Find(p => p.Name == job.ProfileName);
+                if (profile == null || profile.Type != ConnectionType.SSH)
+                {
+                    var sshService = new SshConnectionService();
+                    profile = sshService.GetConnectionProfiles()
+                        .FirstOrDefault(p => p.Type == ConnectionType.SSH &&
+                                             string.Equals(p.Name, job.ProfileName, StringComparison.OrdinalIgnoreCase));
+                }
+
                 if (profile == null) throw new Exception("Profile not found");
 
                 string scpExe = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows) ? "scp.exe" : "scp";

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -60,6 +60,7 @@ namespace NovaTerminal
         private bool _closePaneInProgress;
         private bool _closeTabInProgress;
         private readonly SshConnectionService _sshConnectionService;
+        private readonly SshLegacyProfileMigrationService _sshLegacyMigrationService;
         private static readonly TimeSpan BellDebounceWindow = TimeSpan.FromMilliseconds(750);
 
         private sealed class PaneZoomState
@@ -108,7 +109,7 @@ namespace NovaTerminal
                 overlay.IsVisible = !overlay.IsVisible;
                 if (overlay.IsVisible && connManager != null)
                 {
-                    connManager.LoadProfiles(_settings.Profiles);
+                    connManager.LoadProfiles(_sshConnectionService.GetConnectionProfiles());
                     // Focus search
                     var search = connManager.FindControl<TextBox>("SearchInput");
                     search?.Focus();
@@ -1559,6 +1560,12 @@ namespace NovaTerminal
             InitializeComponent();
             _settings = TerminalSettings.Load();
             _sshConnectionService = new SshConnectionService();
+            _sshLegacyMigrationService = new SshLegacyProfileMigrationService();
+
+            if (_sshLegacyMigrationService.MigrateLegacyProfiles(_settings))
+            {
+                _settings.Save();
+            }
 
             // Ensure visual tree is ready for initial tab border
             this.Loaded += (s, e) =>
@@ -1621,7 +1628,6 @@ namespace NovaTerminal
                 {
                     HandleSshQuickOpen(profile, target, diagnosticsLevel);
                     ToggleConnections();
-                    _settings.Save();
                 };
                 connManager.OnCopyLaunchCommandRequested += (profile, diagnosticsLevel) =>
                 {
@@ -1633,7 +1639,7 @@ namespace NovaTerminal
                 };
                 connManager.OnProfilesChanged += () =>
                 {
-                    _settings.Save();
+                    _sshConnectionService.SaveConnectionProfiles(connManager.GetAllProfiles());
                 };
                 connManager.OnSyncRequested += HandleSshSync;
                 connManager.OnEditProfile += async (profile) =>
@@ -1994,41 +2000,10 @@ namespace NovaTerminal
         {
             try
             {
-                var sshProfiles = NovaTerminal.Core.ProfileImporter.ImportSshConfig();
-                bool changed = false;
-
-                foreach (var newProfile in sshProfiles)
+                var importedProfiles = NovaTerminal.Core.ProfileImporter.ImportSshConfig();
+                int changed = _sshConnectionService.MergeImportedProfiles(importedProfiles);
+                if (changed > 0)
                 {
-                    // Match by Name and Type
-                    var existing = _settings.Profiles.FirstOrDefault(p => p.Name == newProfile.Name && p.Type == NovaTerminal.Core.ConnectionType.SSH);
-                    if (existing != null)
-                    {
-                        // MERGE: Update technical details, preserve user metadata (Groups, Tags, Icon, LastUsed)
-                        bool diff = existing.SshHost != newProfile.SshHost ||
-                                    existing.SshPort != newProfile.SshPort ||
-                                    existing.SshUser != newProfile.SshUser ||
-                                    existing.SshKeyPath != newProfile.SshKeyPath;
-
-                        if (diff)
-                        {
-                            existing.SshHost = newProfile.SshHost;
-                            existing.SshPort = newProfile.SshPort;
-                            existing.SshUser = newProfile.SshUser;
-                            existing.SshKeyPath = newProfile.SshKeyPath;
-                            changed = true;
-                        }
-                    }
-                    else
-                    {
-                        // ADD: New profile
-                        _settings.Profiles.Add(newProfile);
-                        changed = true;
-                    }
-                }
-
-                if (changed)
-                {
-                    _settings.Save();
                     RefreshProfileUIs();
                 }
             }
@@ -2046,7 +2021,9 @@ namespace NovaTerminal
                 // Refresh the profile object if possible to pick up overrides
                 if (pane.Profile != null)
                 {
-                    var updatedProfile = settings.Profiles.Find(p => p.Id == pane.Profile.Id);
+                    TerminalProfile? updatedProfile = pane.Profile.Type == ConnectionType.SSH
+                        ? _sshConnectionService.GetConnectionProfile(pane.Profile.Id)
+                        : settings.Profiles.Find(p => p.Id == pane.Profile.Id);
                     if (updatedProfile != null) pane.UpdateProfile(updatedProfile);
                 }
                 pane.ApplySettings(settings);
@@ -2892,7 +2869,9 @@ namespace NovaTerminal
                 return;
             }
 
-            TerminalProfile resolvedProfile = _settings.Profiles.Find(p => p.Id == profile.Id) ?? profile;
+            TerminalProfile resolvedProfile = profile.Type == ConnectionType.SSH
+                ? _sshConnectionService.GetConnectionProfile(profile.Id) ?? profile
+                : _settings.Profiles.Find(p => p.Id == profile.Id) ?? profile;
             var paneToReplace = _currentPane;
             var replacementPane = new TerminalPane(resolvedProfile, diagnosticsLevel);
             replacementPane.ApplySettings(_settings);
@@ -2979,9 +2958,21 @@ namespace NovaTerminal
             }
             else
             {
-                // REFRESH the profile from settings to ensure we have the latest version (e.g. updated overrides)
-                var freshProfile = _settings.Profiles.Find(p => p.Id == profile.Id);
-                if (freshProfile != null) profile = freshProfile;
+                if (profile.Type == ConnectionType.SSH)
+                {
+                    // SSH profiles are store-backed and independent from TerminalSettings.Profiles.
+                    TerminalProfile? sshProfile = _sshConnectionService.GetConnectionProfile(profile.Id);
+                    if (sshProfile != null)
+                    {
+                        profile = sshProfile;
+                    }
+                }
+                else
+                {
+                    // Refresh local profile from settings to pick up latest overrides.
+                    var freshProfile = _settings.Profiles.Find(p => p.Id == profile.Id);
+                    if (freshProfile != null) profile = freshProfile;
+                }
             }
 
             // Ensure the command exists on this platform (handles shared settings between Windows/Linux)
@@ -2999,7 +2990,7 @@ namespace NovaTerminal
             if (profile.Type == ConnectionType.SSH)
             {
                 profile.Command = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "ssh.exe" : "ssh";
-                profile.Arguments = profile.GenerateSshArguments(_settings.Profiles);
+                profile.Arguments = string.Empty;
             }
 
             if (TryApplyTemplateRuleForProfile(profile))
@@ -3071,7 +3062,7 @@ namespace NovaTerminal
             flyout.Items.Clear();
 
             // Add profiles
-            foreach (var profile in _settings.Profiles)
+            foreach (var profile in _settings.Profiles.Where(p => p.Type == ConnectionType.Local))
             {
                 // UI Polish: Show all profiles the user has configured.
                 // Previously we hid "invalid" ones, but that hides imported WSL profiles if not found in path.
@@ -3367,14 +3358,10 @@ namespace NovaTerminal
             // Dynamic Profile Tabs
             if (_settings.Profiles != null)
             {
-                foreach (var profile in _settings.Profiles)
+                foreach (var profile in _settings.Profiles.Where(p => p.Type == ConnectionType.Local))
                 {
-                    // UI Polish: Only register commands for profiles that make sense for the current platform
-                    if (profile.Type == ConnectionType.Local)
-                    {
-                        bool exists = File.Exists(profile.Command) || ShellHelper.InPath(profile.Command);
-                        if (!exists) continue;
-                    }
+                    bool exists = File.Exists(profile.Command) || ShellHelper.InPath(profile.Command);
+                    if (!exists) continue;
                     CommandRegistry.Register($"New Tab: {profile.Name}", "Shell", () => AddTab(profile), "");
                 }
             }
@@ -3785,6 +3772,11 @@ namespace NovaTerminal
                     _settings = TerminalSettings.Load();
                 }
 
+                if (_sshLegacyMigrationService.MigrateLegacyProfiles(_settings))
+                {
+                    _settings.Save();
+                }
+
                 RefreshProfileUIs();
                 ApplyThemeToUI();
                 ApplySettingsToAllTabs();
@@ -3794,7 +3786,7 @@ namespace NovaTerminal
                 var connManager = this.FindControl<NovaTerminal.Controls.ConnectionManager>("ConnectionManagerControl");
                 if (connManager != null)
                 {
-                    connManager.LoadProfiles(_settings.Profiles);
+                    connManager.LoadProfiles(_sshConnectionService.GetConnectionProfiles());
                 }
             }
         }
@@ -3812,8 +3804,9 @@ namespace NovaTerminal
 
             try
             {
-                TerminalProfile profile = _sshConnectionService.SaveProfile(vm, _settings.Profiles);
-                _settings.Save();
+                var savedProfile = _sshConnectionService.SaveProfile(vm);
+                TerminalProfile profile = _sshConnectionService.GetConnectionProfile(savedProfile.Id)
+                    ?? SshConnectionService.ToRuntimeProfile(savedProfile);
                 RefreshProfileUIs();
 
                 if (vm.ConnectAfterSave)
@@ -3976,7 +3969,7 @@ namespace NovaTerminal
             var connManager = this.FindControl<NovaTerminal.Controls.ConnectionManager>("ConnectionManagerControl");
             if (connManager != null)
             {
-                connManager.LoadProfiles(_settings.Profiles);
+                connManager.LoadProfiles(_sshConnectionService.GetConnectionProfiles());
             }
         }
 

--- a/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
@@ -20,6 +20,8 @@ public sealed class SshLaunchDetails
 
 public sealed class SshConnectionService
 {
+    private const string FavoriteTag = "favorite";
+
     private readonly ISshProfileStore _profileStore;
 
     public SshConnectionService(ISshProfileStore? profileStore = null)
@@ -27,79 +29,193 @@ public sealed class SshConnectionService
         _profileStore = profileStore ?? new JsonSshProfileStore();
     }
 
+    public IReadOnlyList<TerminalProfile> GetConnectionProfiles()
+    {
+        return _profileStore.GetProfiles()
+            .Select(ToRuntimeProfile)
+            .OrderByDescending(profile => profile.Tags.Any(IsFavoriteTag))
+            .ThenBy(profile => profile.Group ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(profile => profile.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(profile => profile.Id)
+            .ToArray();
+    }
+
+    public TerminalProfile? GetConnectionProfile(Guid profileId)
+    {
+        SshProfile? profile = _profileStore.GetProfile(profileId);
+        return profile == null ? null : ToRuntimeProfile(profile);
+    }
+
     public NewSshConnectionViewModel CreateEditorViewModel(TerminalProfile? profile)
     {
-        NewSshConnectionViewModel vm = NewSshConnectionViewModel.FromTerminalProfile(profile);
         if (profile == null)
         {
-            return vm;
+            return new NewSshConnectionViewModel();
         }
 
         SshProfile? stored = _profileStore.GetProfile(profile.Id);
+        var vm = new NewSshConnectionViewModel();
         if (stored != null)
         {
             vm.ApplySshProfile(stored);
-        }
-        else
-        {
-            vm.ApplySshProfile(MapLegacyTerminalProfile(profile));
+            return vm;
         }
 
-        return vm;
+        return NewSshConnectionViewModel.FromTerminalProfile(profile);
     }
 
-    public TerminalProfile SaveProfile(NewSshConnectionViewModel viewModel, IList<TerminalProfile> terminalProfiles)
+    public SshProfile SaveProfile(NewSshConnectionViewModel viewModel)
     {
         ArgumentNullException.ThrowIfNull(viewModel);
-        ArgumentNullException.ThrowIfNull(terminalProfiles);
 
         if (!viewModel.Validate())
         {
             throw new InvalidOperationException(viewModel.ValidationError);
         }
 
-        SshProfile sshProfile = viewModel.ToSshProfile();
-        _profileStore.SaveProfile(sshProfile);
+        SshProfile incoming = viewModel.ToSshProfile();
+        SshProfile? existing = _profileStore.GetProfile(incoming.Id);
+        SshProfile merged = MergeProfile(existing, incoming, viewModel.IsFavorite);
 
-        TerminalProfile terminalProfile = terminalProfiles.FirstOrDefault(p => p.Id == sshProfile.Id)
-            ?? CreateSshTerminalProfile(sshProfile.Id);
+        _profileStore.SaveProfile(merged);
+        return _profileStore.GetProfile(merged.Id) ?? merged;
+    }
 
-        terminalProfile.Name = sshProfile.Name;
-        terminalProfile.Type = ConnectionType.SSH;
-        terminalProfile.SshHost = sshProfile.Host;
-        terminalProfile.SshUser = sshProfile.User;
-        terminalProfile.SshPort = sshProfile.Port;
-        terminalProfile.Notes = viewModel.Notes?.Trim() ?? string.Empty;
-        terminalProfile.AccentColor = viewModel.AccentColor?.Trim() ?? string.Empty;
+    // Legacy overload retained for compatibility while settings/profile separation lands.
+    public TerminalProfile SaveProfile(NewSshConnectionViewModel viewModel, IList<TerminalProfile> terminalProfiles)
+    {
+        _ = terminalProfiles;
+        return ToRuntimeProfile(SaveProfile(viewModel));
+    }
 
-        bool useIdentityFile = sshProfile.AuthMode == SshAuthMode.IdentityFile &&
-                               !string.IsNullOrWhiteSpace(sshProfile.IdentityFilePath);
-        terminalProfile.UseSshAgent = !useIdentityFile;
-        terminalProfile.IdentityFilePath = useIdentityFile ? sshProfile.IdentityFilePath : string.Empty;
-        terminalProfile.SshKeyPath = useIdentityFile ? sshProfile.IdentityFilePath : string.Empty;
+    public void SaveConnectionProfile(TerminalProfile profile)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
 
-        terminalProfile.Tags ??= new List<string>();
-        terminalProfile.Tags.RemoveAll(tag => string.Equals(tag, "favorite", StringComparison.OrdinalIgnoreCase));
-        if (viewModel.IsFavorite)
+        SshProfile? existing = _profileStore.GetProfile(profile.Id);
+        SshProfile candidate = existing is null
+            ? MapLegacyTerminalProfile(profile)
+            : CloneProfile(existing);
+
+        candidate.Id = profile.Id;
+        candidate.Name = profile.Name?.Trim() ?? string.Empty;
+        candidate.Host = profile.SshHost?.Trim() ?? string.Empty;
+        candidate.User = profile.SshUser?.Trim() ?? string.Empty;
+        candidate.Port = profile.SshPort > 0 ? profile.SshPort : 22;
+        candidate.Notes = profile.Notes?.Trim() ?? string.Empty;
+        candidate.AccentColor = profile.AccentColor?.Trim() ?? string.Empty;
+        candidate.GroupPath = profile.Group?.Trim() ?? candidate.GroupPath;
+
+        bool favorite = profile.Tags?.Any(IsFavoriteTag) == true;
+        candidate.Tags = NormalizeTags(profile.Tags, favorite);
+
+        string identityPath = !string.IsNullOrWhiteSpace(profile.IdentityFilePath)
+            ? profile.IdentityFilePath!.Trim()
+            : profile.SshKeyPath?.Trim() ?? string.Empty;
+        bool useIdentity = !profile.UseSshAgent && !string.IsNullOrWhiteSpace(identityPath);
+        candidate.AuthMode = useIdentity ? SshAuthMode.IdentityFile : SshAuthMode.Agent;
+        candidate.IdentityFilePath = useIdentity ? identityPath : string.Empty;
+
+        _profileStore.SaveProfile(candidate);
+    }
+
+    public void SaveConnectionProfiles(IEnumerable<TerminalProfile> profiles)
+    {
+        ArgumentNullException.ThrowIfNull(profiles);
+
+        foreach (TerminalProfile profile in profiles)
         {
-            terminalProfile.Tags.Add("favorite");
+            SaveConnectionProfile(profile);
+        }
+    }
+
+    public bool DeleteProfile(Guid profileId)
+    {
+        return _profileStore.DeleteProfile(profileId);
+    }
+
+    public int MergeImportedProfiles(IEnumerable<TerminalProfile> importedLegacyProfiles)
+    {
+        ArgumentNullException.ThrowIfNull(importedLegacyProfiles);
+
+        int changedCount = 0;
+        Dictionary<string, SshProfile> byName = _profileStore.GetProfiles()
+            .GroupBy(profile => profile.Name, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
+
+        List<TerminalProfile> legacyProfiles = importedLegacyProfiles
+            .Where(profile => profile.Type == ConnectionType.SSH)
+            .ToList();
+
+        foreach (TerminalProfile imported in legacyProfiles)
+        {
+            SshProfile importedProfile = MapLegacyTerminalProfile(imported, legacyProfiles);
+            if (string.IsNullOrWhiteSpace(importedProfile.Host))
+            {
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(importedProfile.Name))
+            {
+                importedProfile.Name = importedProfile.Host;
+            }
+
+            if (byName.TryGetValue(importedProfile.Name, out SshProfile? existing))
+            {
+                SshProfile merged = CloneProfile(existing);
+                bool differs = !string.Equals(merged.Host, importedProfile.Host, StringComparison.Ordinal) ||
+                               !string.Equals(merged.User, importedProfile.User, StringComparison.Ordinal) ||
+                               merged.Port != importedProfile.Port ||
+                               merged.AuthMode != importedProfile.AuthMode ||
+                               !string.Equals(merged.IdentityFilePath, importedProfile.IdentityFilePath, StringComparison.Ordinal);
+
+                if (!differs)
+                {
+                    continue;
+                }
+
+                merged.Host = importedProfile.Host;
+                merged.User = importedProfile.User;
+                merged.Port = importedProfile.Port;
+                merged.AuthMode = importedProfile.AuthMode;
+                merged.IdentityFilePath = importedProfile.IdentityFilePath;
+                _profileStore.SaveProfile(merged);
+                changedCount++;
+                continue;
+            }
+
+            _profileStore.SaveProfile(importedProfile);
+            byName[importedProfile.Name] = importedProfile;
+            changedCount++;
         }
 
-        terminalProfile.Forwards = sshProfile.Forwards.Select(ConvertToLegacyForward).ToList();
-        terminalProfile.JumpHostProfileId = ResolveLegacyJumpHostProfileId(sshProfile.JumpHops, terminalProfiles);
-
-        if (!terminalProfiles.Any(p => p.Id == terminalProfile.Id))
-        {
-            terminalProfiles.Add(terminalProfile);
-        }
-
-        return terminalProfile;
+        return changedCount;
     }
 
     public SshLaunchDetails BuildLaunchDetails(TerminalProfile profile, SshDiagnosticsLevel diagnosticsLevel)
     {
         ArgumentNullException.ThrowIfNull(profile);
-        SshProfile sshProfile = EnsureStoreProfile(profile);
+        return BuildLaunchDetails(profile.Id, diagnosticsLevel, profile);
+    }
+
+    public SshLaunchDetails BuildLaunchDetails(Guid profileId, SshDiagnosticsLevel diagnosticsLevel)
+    {
+        return BuildLaunchDetails(profileId, diagnosticsLevel, null);
+    }
+
+    public string BuildLaunchCommand(TerminalProfile profile, SshDiagnosticsLevel diagnosticsLevel)
+    {
+        return BuildLaunchDetails(profile, diagnosticsLevel).CommandLine;
+    }
+
+    public string BuildLaunchCommand(Guid profileId, SshDiagnosticsLevel diagnosticsLevel)
+    {
+        return BuildLaunchDetails(profileId, diagnosticsLevel).CommandLine;
+    }
+
+    private SshLaunchDetails BuildLaunchDetails(Guid profileId, SshDiagnosticsLevel diagnosticsLevel, TerminalProfile? fallbackProfile)
+    {
+        SshProfile sshProfile = EnsureStoreProfile(profileId, fallbackProfile);
 
         var planner = new SshLaunchPlanner(_profileStore, new OpenSshConfigCompiler());
         SshLaunchPlan plan = planner.Plan(sshProfile.Id, diagnosticsLevel.ToArguments());
@@ -115,64 +231,105 @@ public sealed class SshConnectionService
         };
     }
 
-    public string BuildLaunchCommand(TerminalProfile profile, SshDiagnosticsLevel diagnosticsLevel)
+    private SshProfile EnsureStoreProfile(Guid profileId, TerminalProfile? fallbackProfile)
     {
-        return BuildLaunchDetails(profile, diagnosticsLevel).CommandLine;
-    }
-
-    private SshProfile EnsureStoreProfile(TerminalProfile profile)
-    {
-        SshProfile? existing = _profileStore.GetProfile(profile.Id);
+        SshProfile? existing = _profileStore.GetProfile(profileId);
         if (existing != null)
         {
             return existing;
         }
 
-        SshProfile converted = MapLegacyTerminalProfile(profile);
+        if (fallbackProfile == null)
+        {
+            throw new InvalidOperationException($"SSH profile '{profileId}' was not found.");
+        }
 
+        SshProfile converted = MapLegacyTerminalProfile(fallbackProfile);
         _profileStore.SaveProfile(converted);
         return converted;
     }
 
-    private static string QuoteToken(string token)
+    private static SshProfile MergeProfile(SshProfile? existing, SshProfile incoming, bool favorite)
     {
-        if (string.IsNullOrWhiteSpace(token))
+        SshProfile merged = existing is null
+            ? CloneProfile(incoming)
+            : CloneProfile(existing);
+
+        merged.Id = incoming.Id;
+        merged.Name = incoming.Name;
+        merged.Host = incoming.Host;
+        merged.User = incoming.User;
+        merged.Port = incoming.Port;
+        merged.AuthMode = incoming.AuthMode;
+        merged.IdentityFilePath = incoming.IdentityFilePath;
+        merged.JumpHops = incoming.JumpHops.Select(CloneJumpHop).ToList();
+        merged.Forwards = incoming.Forwards.Select(CloneForward).ToList();
+        merged.MuxOptions = CloneMuxOptions(incoming.MuxOptions);
+        merged.ServerAliveIntervalSeconds = incoming.ServerAliveIntervalSeconds;
+        merged.ServerAliveCountMax = incoming.ServerAliveCountMax;
+        merged.ExtraSshArgs = incoming.ExtraSshArgs;
+        merged.WorkingDirectory = incoming.WorkingDirectory;
+        merged.Notes = incoming.Notes;
+        merged.AccentColor = incoming.AccentColor;
+
+        // Group isn't editable in the minimal dialog yet, so preserve existing if present.
+        if (string.IsNullOrWhiteSpace(merged.GroupPath))
         {
-            return "\"\"";
+            merged.GroupPath = "General";
         }
 
-        return token.Any(char.IsWhiteSpace)
-            ? $"\"{token.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal)}\""
-            : token;
+        IEnumerable<string> sourceTags = (IEnumerable<string>?)existing?.Tags ?? Array.Empty<string>();
+        merged.Tags = NormalizeTags(sourceTags, favorite);
+        return merged;
     }
 
-    private static TerminalProfile CreateSshTerminalProfile(Guid id)
+    public static TerminalProfile ToRuntimeProfile(SshProfile profile)
     {
+        ArgumentNullException.ThrowIfNull(profile);
+
+        bool useIdentityFile = profile.AuthMode == SshAuthMode.IdentityFile &&
+                               !string.IsNullOrWhiteSpace(profile.IdentityFilePath);
+
         return new TerminalProfile
         {
-            Id = id,
-            Name = "SSH",
+            Id = profile.Id,
+            Name = profile.Name,
             Type = ConnectionType.SSH,
             Command = OperatingSystem.IsWindows() ? "ssh.exe" : "ssh",
-            SshPort = 22
+            SshHost = profile.Host,
+            SshUser = profile.User,
+            SshPort = profile.Port > 0 ? profile.Port : 22,
+            UseSshAgent = !useIdentityFile,
+            IdentityFilePath = useIdentityFile ? profile.IdentityFilePath : string.Empty,
+            SshKeyPath = useIdentityFile ? profile.IdentityFilePath : string.Empty,
+            Group = string.IsNullOrWhiteSpace(profile.GroupPath) ? "General" : profile.GroupPath,
+            Notes = profile.Notes ?? string.Empty,
+            AccentColor = profile.AccentColor ?? string.Empty,
+            Tags = (profile.Tags ?? new List<string>()).ToList(),
+            Forwards = profile.Forwards.Select(ConvertToLegacyForward).ToList()
         };
     }
 
-    private static SshProfile MapLegacyTerminalProfile(TerminalProfile profile)
+    public static SshProfile MapLegacyTerminalProfile(TerminalProfile profile, IReadOnlyList<TerminalProfile>? allProfiles = null)
     {
         var mapped = new SshProfile
         {
             Id = profile.Id,
-            Name = profile.Name,
+            Name = (profile.Name ?? string.Empty).Trim(),
             Host = profile.SshHost?.Trim() ?? string.Empty,
             User = profile.SshUser?.Trim() ?? string.Empty,
             Port = profile.SshPort > 0 ? profile.SshPort : 22,
+            GroupPath = profile.Group?.Trim() ?? "General",
+            Notes = profile.Notes?.Trim() ?? string.Empty,
+            AccentColor = profile.AccentColor?.Trim() ?? string.Empty,
+            Tags = NormalizeTags(profile.Tags, profile.Tags?.Any(IsFavoriteTag) == true),
             AuthMode = !profile.UseSshAgent && (!string.IsNullOrWhiteSpace(profile.IdentityFilePath) || !string.IsNullOrWhiteSpace(profile.SshKeyPath))
                 ? SshAuthMode.IdentityFile
                 : SshAuthMode.Agent,
             IdentityFilePath = !string.IsNullOrWhiteSpace(profile.IdentityFilePath)
                 ? profile.IdentityFilePath!.Trim()
-                : profile.SshKeyPath?.Trim() ?? string.Empty
+                : profile.SshKeyPath?.Trim() ?? string.Empty,
+            JumpHops = BuildJumpHopsFromLegacy(profile, allProfiles)
         };
 
         if (profile.Forwards != null)
@@ -188,6 +345,74 @@ public sealed class SshConnectionService
         }
 
         return mapped;
+    }
+
+    private static List<string> NormalizeTags(IEnumerable<string>? tags, bool favorite)
+    {
+        List<string> list = (tags ?? Array.Empty<string>())
+            .Where(tag => !string.IsNullOrWhiteSpace(tag))
+            .Select(tag => tag.Trim())
+            .Where(tag => !IsFavoriteTag(tag))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(tag => tag, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (favorite)
+        {
+            list.Insert(0, FavoriteTag);
+        }
+
+        return list;
+    }
+
+    private static bool IsFavoriteTag(string? tag)
+    {
+        return string.Equals(tag?.Trim(), FavoriteTag, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static List<SshJumpHop> BuildJumpHopsFromLegacy(TerminalProfile profile, IReadOnlyList<TerminalProfile>? allProfiles)
+    {
+        if (!profile.JumpHostProfileId.HasValue || allProfiles == null || allProfiles.Count == 0)
+        {
+            return new List<SshJumpHop>();
+        }
+
+        var chain = new List<SshJumpHop>();
+        var visited = new HashSet<Guid>();
+        Guid? current = profile.JumpHostProfileId;
+
+        while (current.HasValue && visited.Add(current.Value))
+        {
+            TerminalProfile? hop = allProfiles.FirstOrDefault(candidate => candidate.Id == current.Value);
+            if (hop == null || string.IsNullOrWhiteSpace(hop.SshHost))
+            {
+                break;
+            }
+
+            chain.Add(new SshJumpHop
+            {
+                Host = hop.SshHost?.Trim() ?? string.Empty,
+                User = hop.SshUser?.Trim() ?? string.Empty,
+                Port = hop.SshPort > 0 ? hop.SshPort : 22
+            });
+
+            current = hop.JumpHostProfileId;
+        }
+
+        chain.Reverse();
+        return chain;
+    }
+
+    private static string QuoteToken(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return "\"\"";
+        }
+
+        return token.Any(char.IsWhiteSpace)
+            ? $"\"{token.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal)}\""
+            : token;
     }
 
     private static PortForward? ConvertToCoreForward(ForwardingRule legacy)
@@ -277,23 +502,6 @@ public sealed class SshConnectionService
         };
     }
 
-    private static Guid? ResolveLegacyJumpHostProfileId(IEnumerable<SshJumpHop> jumpHops, IList<TerminalProfile> profiles)
-    {
-        SshJumpHop? firstHop = jumpHops?.FirstOrDefault(h => !string.IsNullOrWhiteSpace(h.Host));
-        if (firstHop == null)
-        {
-            return null;
-        }
-
-        TerminalProfile? matched = profiles.FirstOrDefault(p =>
-            p.Type == ConnectionType.SSH &&
-            string.Equals(p.SshHost?.Trim(), firstHop.Host?.Trim(), StringComparison.OrdinalIgnoreCase) &&
-            string.Equals(p.SshUser?.Trim(), firstHop.User?.Trim(), StringComparison.OrdinalIgnoreCase) &&
-            (p.SshPort > 0 ? p.SshPort : 22) == (firstHop.Port > 0 ? firstHop.Port : 22));
-
-        return matched?.Id;
-    }
-
     private static bool TryParseEndpoint(string value, out string bindAddress, out int port)
     {
         bindAddress = string.Empty;
@@ -334,5 +542,64 @@ public sealed class SshConnectionService
 
         host = trimmed[..colon].Trim();
         return !string.IsNullOrWhiteSpace(host) && int.TryParse(trimmed[(colon + 1)..].Trim(), out port);
+    }
+
+    private static SshProfile CloneProfile(SshProfile profile)
+    {
+        return new SshProfile
+        {
+            Id = profile.Id,
+            Name = profile.Name,
+            GroupPath = profile.GroupPath,
+            Notes = profile.Notes,
+            AccentColor = profile.AccentColor,
+            Tags = (profile.Tags ?? new List<string>()).ToList(),
+            Host = profile.Host,
+            User = profile.User,
+            Port = profile.Port,
+            AuthMode = profile.AuthMode,
+            IdentityFilePath = profile.IdentityFilePath,
+            JumpHops = profile.JumpHops.Select(CloneJumpHop).ToList(),
+            Forwards = profile.Forwards.Select(CloneForward).ToList(),
+            MuxOptions = CloneMuxOptions(profile.MuxOptions),
+            ServerAliveIntervalSeconds = profile.ServerAliveIntervalSeconds,
+            ServerAliveCountMax = profile.ServerAliveCountMax,
+            ExtraSshArgs = profile.ExtraSshArgs,
+            WorkingDirectory = profile.WorkingDirectory
+        };
+    }
+
+    private static SshJumpHop CloneJumpHop(SshJumpHop hop)
+    {
+        return new SshJumpHop
+        {
+            Host = hop.Host,
+            User = hop.User,
+            Port = hop.Port
+        };
+    }
+
+    private static PortForward CloneForward(PortForward forward)
+    {
+        return new PortForward
+        {
+            Kind = forward.Kind,
+            BindAddress = forward.BindAddress,
+            SourcePort = forward.SourcePort,
+            DestinationHost = forward.DestinationHost,
+            DestinationPort = forward.DestinationPort
+        };
+    }
+
+    private static SshMuxOptions CloneMuxOptions(SshMuxOptions? mux)
+    {
+        mux ??= new SshMuxOptions();
+        return new SshMuxOptions
+        {
+            Enabled = mux.Enabled,
+            ControlMasterAuto = mux.ControlMasterAuto,
+            ControlPath = mux.ControlPath,
+            ControlPersistSeconds = mux.ControlPersistSeconds
+        };
     }
 }

--- a/src/NovaTerminal.App/Services/Ssh/SshLegacyProfileMigrationService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshLegacyProfileMigrationService.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NovaTerminal.Core;
+using NovaTerminal.Core.Ssh.Models;
+using NovaTerminal.Core.Ssh.Storage;
+
+namespace NovaTerminal.Services.Ssh;
+
+/// <summary>
+/// One-way migration shim while SSH connections are separated from TerminalSettings.Profiles.
+/// Future native SSH storage can swap this service without touching MainWindow startup flow.
+/// </summary>
+public sealed class SshLegacyProfileMigrationService
+{
+    private readonly ISshProfileStore _profileStore;
+
+    public SshLegacyProfileMigrationService(ISshProfileStore? profileStore = null)
+    {
+        _profileStore = profileStore ?? new JsonSshProfileStore();
+    }
+
+    public bool MigrateLegacyProfiles(TerminalSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        settings.Profiles ??= new List<TerminalProfile>();
+        List<TerminalProfile> legacySsh = settings.Profiles
+            .Where(profile => profile.Type == ConnectionType.SSH)
+            .ToList();
+
+        bool changed = false;
+        if (legacySsh.Count > 0)
+        {
+            IReadOnlyList<TerminalProfile> snapshot = settings.Profiles.ToList();
+            foreach (TerminalProfile legacy in legacySsh)
+            {
+                SshProfile mapped = SshConnectionService.MapLegacyTerminalProfile(legacy, snapshot);
+                if (string.IsNullOrWhiteSpace(mapped.Host))
+                {
+                    continue;
+                }
+
+                _profileStore.SaveProfile(mapped);
+            }
+
+            settings.Profiles = settings.Profiles
+                .Where(profile => profile.Type != ConnectionType.SSH)
+                .ToList();
+            changed = true;
+        }
+
+        if (settings.Profiles.Count == 0)
+        {
+            settings.Profiles = TerminalSettings.GetDefaultProfiles()
+                .Where(profile => profile.Type == ConnectionType.Local)
+                .ToList();
+            changed = true;
+        }
+
+        bool defaultValid = settings.Profiles.Any(profile => profile.Id == settings.DefaultProfileId);
+        if (!defaultValid)
+        {
+            settings.DefaultProfileId = settings.Profiles[0].Id;
+            changed = true;
+        }
+
+        return changed;
+    }
+}

--- a/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
+++ b/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
@@ -234,6 +234,9 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
         {
             Id = id,
             Name = name,
+            Notes = Notes?.Trim() ?? string.Empty,
+            AccentColor = AccentColor?.Trim() ?? string.Empty,
+            Tags = BuildTags(IsFavorite),
             Host = host,
             User = user,
             Port = port,
@@ -311,10 +314,13 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
         ArgumentNullException.ThrowIfNull(sshProfile);
 
         ProfileId = sshProfile.Id;
-        Name = string.IsNullOrWhiteSpace(Name) ? sshProfile.Name : Name;
+        Name = sshProfile.Name;
         HostName = sshProfile.Host;
         UserName = sshProfile.User;
         Port = sshProfile.Port > 0 ? sshProfile.Port : 22;
+        Notes = sshProfile.Notes ?? string.Empty;
+        AccentColor = sshProfile.AccentColor ?? string.Empty;
+        IsFavorite = sshProfile.Tags.Any(tag => string.Equals(tag, "favorite", StringComparison.OrdinalIgnoreCase));
         AuthMode = sshProfile.AuthMode == SshAuthMode.IdentityFile ? NewSshAuthMode.IdentityFile : NewSshAuthMode.Agent;
         IdentityFilePath = sshProfile.IdentityFilePath ?? string.Empty;
 
@@ -446,6 +452,16 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
 
         host = trimmed[..colon].Trim();
         return !string.IsNullOrWhiteSpace(host) && int.TryParse(trimmed[(colon + 1)..].Trim(), out port);
+    }
+
+    private static List<string> BuildTags(bool isFavorite)
+    {
+        if (!isFavorite)
+        {
+            return new List<string>();
+        }
+
+        return new List<string> { "favorite" };
     }
 
     private bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)

--- a/src/NovaTerminal.App/ViewModels/Ssh/SshManagerViewModel.cs
+++ b/src/NovaTerminal.App/ViewModels/Ssh/SshManagerViewModel.cs
@@ -71,6 +71,11 @@ public sealed class SshManagerViewModel : INotifyPropertyChanged
         OpenRequested?.Invoke(row, target, DiagnosticsLevel);
     }
 
+    public IReadOnlyList<TerminalProfile> GetAllProfiles()
+    {
+        return _allRows.Select(row => row.Profile).ToArray();
+    }
+
     private void ApplyFilter()
     {
         string query = SearchText?.Trim() ?? string.Empty;

--- a/src/NovaTerminal.Core/Ssh/Models/SshProfile.cs
+++ b/src/NovaTerminal.Core/Ssh/Models/SshProfile.cs
@@ -13,6 +13,10 @@ public sealed class SshProfile
 {
     public Guid Id { get; set; } = Guid.NewGuid();
     public string Name { get; set; } = "New SSH Profile";
+    public string GroupPath { get; set; } = "General";
+    public string Notes { get; set; } = string.Empty;
+    public string AccentColor { get; set; } = string.Empty;
+    public List<string> Tags { get; set; } = new();
     public string Host { get; set; } = string.Empty;
     public string User { get; set; } = string.Empty;
     public int Port { get; set; } = 22;

--- a/src/NovaTerminal.Core/Ssh/Storage/JsonSshProfileStore.cs
+++ b/src/NovaTerminal.Core/Ssh/Storage/JsonSshProfileStore.cs
@@ -183,6 +183,15 @@ public sealed class JsonSshProfileStore : ISshProfileStore
     {
         var normalized = CloneProfile(profile);
         normalized.Name = normalized.Name?.Trim() ?? string.Empty;
+        normalized.GroupPath = normalized.GroupPath?.Trim() ?? string.Empty;
+        normalized.Notes = normalized.Notes?.Trim() ?? string.Empty;
+        normalized.AccentColor = normalized.AccentColor?.Trim() ?? string.Empty;
+        normalized.Tags = (normalized.Tags ?? new List<string>())
+            .Where(tag => !string.IsNullOrWhiteSpace(tag))
+            .Select(tag => tag.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(tag => tag, StringComparer.OrdinalIgnoreCase)
+            .ToList();
         normalized.Host = normalized.Host?.Trim() ?? string.Empty;
         normalized.User = normalized.User?.Trim() ?? string.Empty;
         normalized.Port = normalized.Port > 0 ? normalized.Port : 22;
@@ -247,6 +256,10 @@ public sealed class JsonSshProfileStore : ISshProfileStore
         {
             Id = profile.Id,
             Name = profile.Name,
+            GroupPath = profile.GroupPath,
+            Notes = profile.Notes,
+            AccentColor = profile.AccentColor,
+            Tags = (profile.Tags ?? new List<string>()).ToList(),
             Host = profile.Host,
             User = profile.User,
             Port = profile.Port,

--- a/src/NovaTerminal.Pty/SessionModels.cs
+++ b/src/NovaTerminal.Pty/SessionModels.cs
@@ -39,6 +39,7 @@ namespace NovaTerminal.Core
 
         // For Leafs
         public string? ProfileId { get; set; }
+        public string? SshProfileId { get; set; }
         public string? PaneId { get; set; }
 
         // Fallbacks for ad-hoc panes (no profile)

--- a/tests/NovaTerminal.Core.Tests/Ssh/JsonSshProfileStoreTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/JsonSshProfileStoreTests.cs
@@ -18,6 +18,10 @@ public sealed class JsonSshProfileStoreTests
             {
                 Id = Guid.Parse("aeb456e4-8dd2-4b33-a74d-cb473de0323b"),
                 Name = "prod",
+                GroupPath = "Prod/DB",
+                Notes = "critical",
+                AccentColor = "#3399EE",
+                Tags = new List<string> { "zeta", "Favorite", "alpha", "favorite" },
                 Host = "prod.internal",
                 User = "svc",
                 Port = 2222,
@@ -49,6 +53,10 @@ public sealed class JsonSshProfileStoreTests
 
             Assert.NotNull(loaded);
             Assert.Equal(profile.Name, loaded!.Name);
+            Assert.Equal("Prod/DB", loaded.GroupPath);
+            Assert.Equal("critical", loaded.Notes);
+            Assert.Equal("#3399EE", loaded.AccentColor);
+            Assert.Equal(new[] { "alpha", "Favorite", "zeta" }, loaded.Tags);
             Assert.Equal(profile.Host, loaded.Host);
             Assert.Equal(profile.User, loaded.User);
             Assert.Equal(profile.Port, loaded.Port);

--- a/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
@@ -9,7 +9,7 @@ namespace NovaTerminal.Tests.Ssh;
 public sealed class SshConnectionServiceTests
 {
     [Fact]
-    public void SaveProfile_AddsTerminalProfileAndPersistsSshProfile()
+    public void SaveProfile_PersistsSshProfileWithoutMutatingTerminalProfiles()
     {
         string tempRoot = CreateTempDirectory();
         try
@@ -17,7 +17,16 @@ public sealed class SshConnectionServiceTests
             string path = Path.Combine(tempRoot, "profiles.json");
             var store = new JsonSshProfileStore(path);
             var service = new SshConnectionService(store);
-            var profiles = new List<TerminalProfile>();
+            var localProfiles = new List<TerminalProfile>
+            {
+                new TerminalProfile
+                {
+                    Id = Guid.Parse("90bcf34a-83af-4e84-b0a3-4a74a9b62615"),
+                    Name = "PowerShell",
+                    Type = ConnectionType.Local,
+                    Command = "pwsh.exe"
+                }
+            };
 
             var vm = new NewSshConnectionViewModel
             {
@@ -28,15 +37,14 @@ public sealed class SshConnectionServiceTests
                 AuthMode = NewSshAuthMode.Agent
             };
 
-            TerminalProfile saved = service.SaveProfile(vm, profiles);
+            SshProfile saved = service.SaveProfile(vm);
 
-            Assert.Single(profiles);
-            Assert.Equal(ConnectionType.SSH, saved.Type);
+            Assert.Single(localProfiles);
             Assert.Equal("Prod", saved.Name);
-            Assert.Equal("prod.internal", saved.SshHost);
-            Assert.Equal("alice", saved.SshUser);
-            Assert.Equal(2200, saved.SshPort);
-            Assert.True(saved.UseSshAgent);
+            Assert.Equal("prod.internal", saved.Host);
+            Assert.Equal("alice", saved.User);
+            Assert.Equal(2200, saved.Port);
+            Assert.Equal(SshAuthMode.Agent, saved.AuthMode);
 
             var persisted = store.GetProfile(saved.Id);
             Assert.NotNull(persisted);
@@ -50,7 +58,7 @@ public sealed class SshConnectionServiceTests
     }
 
     [Fact]
-    public void SaveProfile_UpdatesExistingTerminalProfile()
+    public void SaveProfile_UpdatesExistingStoreProfile()
     {
         string tempRoot = CreateTempDirectory();
         try
@@ -60,17 +68,13 @@ public sealed class SshConnectionServiceTests
             var service = new SshConnectionService(store);
 
             var existingId = Guid.Parse("5d4bf55d-1b7a-48e9-b368-c03295dcbf1f");
-            var profiles = new List<TerminalProfile>
+            store.SaveProfile(new SshProfile
             {
-                new TerminalProfile
-                {
-                    Id = existingId,
-                    Name = "Old",
-                    Type = ConnectionType.SSH,
-                    SshHost = "old.internal",
-                    SshPort = 22
-                }
-            };
+                Id = existingId,
+                Name = "Old",
+                Host = "old.internal",
+                Port = 22
+            });
 
             var vm = new NewSshConnectionViewModel
             {
@@ -83,15 +87,14 @@ public sealed class SshConnectionServiceTests
                 IdentityFilePath = "C:\\keys\\id_ed25519"
             };
 
-            TerminalProfile saved = service.SaveProfile(vm, profiles);
+            SshProfile saved = service.SaveProfile(vm);
 
-            Assert.Single(profiles);
             Assert.Equal(existingId, saved.Id);
             Assert.Equal("Updated", saved.Name);
-            Assert.Equal("new.internal", saved.SshHost);
-            Assert.Equal("ops", saved.SshUser);
-            Assert.Equal(2222, saved.SshPort);
-            Assert.False(saved.UseSshAgent);
+            Assert.Equal("new.internal", saved.Host);
+            Assert.Equal("ops", saved.User);
+            Assert.Equal(2222, saved.Port);
+            Assert.Equal(SshAuthMode.IdentityFile, saved.AuthMode);
             Assert.Equal("C:\\keys\\id_ed25519", saved.IdentityFilePath);
         }
         finally
@@ -109,7 +112,6 @@ public sealed class SshConnectionServiceTests
             string path = Path.Combine(tempRoot, "profiles.json");
             var store = new JsonSshProfileStore(path);
             var service = new SshConnectionService(store);
-            var profiles = new List<TerminalProfile>();
 
             var vm = new NewSshConnectionViewModel
             {
@@ -136,7 +138,7 @@ public sealed class SshConnectionServiceTests
                 SourcePort = 1080
             });
 
-            TerminalProfile saved = service.SaveProfile(vm, profiles);
+            SshProfile saved = service.SaveProfile(vm);
             SshProfile? persisted = store.GetProfile(saved.Id);
 
             Assert.NotNull(persisted);
@@ -147,11 +149,64 @@ public sealed class SshConnectionServiceTests
             Assert.Equal("-o StrictHostKeyChecking=no", persisted.ExtraSshArgs);
             Assert.Single(persisted.JumpHops);
             Assert.Single(persisted.Forwards);
+            Assert.Equal("critical profile", persisted.Notes);
+            Assert.Equal("#11AA88", persisted.AccentColor);
+            Assert.Contains("favorite", persisted.Tags, StringComparer.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
 
-            Assert.Contains("favorite", saved.Tags, StringComparer.OrdinalIgnoreCase);
-            Assert.Equal("critical profile", saved.Notes);
-            Assert.Equal("#11AA88", saved.AccentColor);
-            Assert.Single(saved.Forwards);
+    [Fact]
+    public void GetConnectionProfiles_ProjectsStoredProfilesIntoRuntimeRows()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string path = Path.Combine(tempRoot, "profiles.json");
+            var store = new JsonSshProfileStore(path);
+            var service = new SshConnectionService(store);
+
+            var firstId = Guid.Parse("2f2a8e09-bb80-48cc-b386-969ea7b8558f");
+            store.SaveProfile(new SshProfile
+            {
+                Id = firstId,
+                Name = "Prod",
+                Host = "prod.internal",
+                User = "ops",
+                Port = 2200,
+                Notes = "critical",
+                AccentColor = "#66AAFF",
+                GroupPath = "Prod/API",
+                Tags = new List<string> { "favorite", "api" }
+            });
+
+            store.SaveProfile(new SshProfile
+            {
+                Id = Guid.Parse("f013020a-86d4-4829-a9e5-db06d4cd11dc"),
+                Name = "Stage",
+                Host = "stage.internal",
+                Port = 22,
+                GroupPath = "Stage",
+                Tags = new List<string> { "staging" }
+            });
+
+            IReadOnlyList<TerminalProfile> rows = service.GetConnectionProfiles();
+
+            Assert.Equal(2, rows.Count);
+            TerminalProfile prod = rows[0].Id == firstId ? rows[0] : rows[1];
+            Assert.Equal(ConnectionType.SSH, prod.Type);
+            Assert.Equal("Prod", prod.Name);
+            Assert.Equal("prod.internal", prod.SshHost);
+            Assert.Equal("ops", prod.SshUser);
+            Assert.Equal(2200, prod.SshPort);
+            Assert.Equal("critical", prod.Notes);
+            Assert.Equal("#66AAFF", prod.AccentColor);
+            Assert.Equal("Prod/API", prod.Group);
+            Assert.Contains("favorite", prod.Tags, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(OperatingSystem.IsWindows() ? "ssh.exe" : "ssh", prod.Command);
         }
         finally
         {

--- a/tests/NovaTerminal.Tests/Ssh/SshLegacyProfileMigrationTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/SshLegacyProfileMigrationTests.cs
@@ -1,0 +1,119 @@
+using NovaTerminal.Core;
+using NovaTerminal.Core.Ssh.Storage;
+using NovaTerminal.Services.Ssh;
+
+namespace NovaTerminal.Tests.Ssh;
+
+public sealed class SshLegacyProfileMigrationTests
+{
+    [Fact]
+    public void MigrateLegacyProfiles_MovesSshProfilesToStoreAndKeepsLocalProfilesInSettings()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string storePath = Path.Combine(tempRoot, "profiles.json");
+            var store = new JsonSshProfileStore(storePath);
+            var migration = new SshLegacyProfileMigrationService(store);
+
+            var localId = Guid.Parse("ec73be98-eb3f-4f55-a01e-24a31957e2fb");
+            var sshId = Guid.Parse("77ec18f4-99f1-4437-bdfe-d61728638e8f");
+            var settings = new TerminalSettings
+            {
+                Profiles = new List<TerminalProfile>
+                {
+                    new TerminalProfile
+                    {
+                        Id = localId,
+                        Name = "PowerShell",
+                        Type = ConnectionType.Local,
+                        Command = "pwsh.exe"
+                    },
+                    new TerminalProfile
+                    {
+                        Id = sshId,
+                        Name = "Prod SSH",
+                        Type = ConnectionType.SSH,
+                        SshHost = "prod.internal",
+                        SshUser = "ops",
+                        SshPort = 2200,
+                        Group = "Prod",
+                        Notes = "critical",
+                        AccentColor = "#FFAA11",
+                        Tags = new List<string> { "favorite", "prod" },
+                        UseSshAgent = false,
+                        IdentityFilePath = "C:\\keys\\prod"
+                    }
+                },
+                DefaultProfileId = sshId
+            };
+
+            bool changed = migration.MigrateLegacyProfiles(settings);
+
+            Assert.True(changed);
+            Assert.Single(settings.Profiles);
+            Assert.Equal(ConnectionType.Local, settings.Profiles[0].Type);
+            Assert.Equal(localId, settings.Profiles[0].Id);
+            Assert.Equal(localId, settings.DefaultProfileId);
+
+            var migrated = store.GetProfile(sshId);
+            Assert.NotNull(migrated);
+            Assert.Equal("prod.internal", migrated!.Host);
+            Assert.Equal("ops", migrated.User);
+            Assert.Equal(2200, migrated.Port);
+            Assert.Equal("Prod", migrated.GroupPath);
+            Assert.Equal("critical", migrated.Notes);
+            Assert.Equal("#FFAA11", migrated.AccentColor);
+            Assert.Contains("favorite", migrated.Tags, StringComparer.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void MigrateLegacyProfiles_NoLegacySsh_ReturnsFalse()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string storePath = Path.Combine(tempRoot, "profiles.json");
+            var store = new JsonSshProfileStore(storePath);
+            var migration = new SshLegacyProfileMigrationService(store);
+
+            var localId = Guid.Parse("28d69fd4-b59e-4e34-b5e6-fe8fbe78b94d");
+            var settings = new TerminalSettings
+            {
+                Profiles = new List<TerminalProfile>
+                {
+                    new TerminalProfile
+                    {
+                        Id = localId,
+                        Name = "PowerShell",
+                        Type = ConnectionType.Local,
+                        Command = "pwsh.exe"
+                    }
+                },
+                DefaultProfileId = localId
+            };
+
+            bool changed = migration.MigrateLegacyProfiles(settings);
+
+            Assert.False(changed);
+            Assert.Single(settings.Profiles);
+            Assert.Empty(store.GetProfiles());
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    private static string CreateTempDirectory()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"nova_ssh_migration_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}


### PR DESCRIPTION
What’s in this PR1 commit:

SSH connections now load from SSH store in Connection Manager, not TerminalSettings.Profiles.
Startup/settings-save legacy migration added: moves SSH entries out of settings into SSH store and keeps local profiles in settings.
SSH service refactored for store-backed profile lifecycle (GetConnectionProfiles, store-backed save/update, import merge).
Session persistence now stores SSH profile identity separately (PaneNode.SshProfileId) and restore resolves SSH from store.
SSH fallback args in pane are independent of settings profile list.
SFTP profile lookup now falls back to SSH store-backed connections.
SSH profile model/store extended for manager metadata (GroupPath, Notes, AccentColor, Tags) with deterministic normalization.