### PR TITLE
Feature/ssh-profiles-separation-pr3

### DIFF
--- a/src/NovaTerminal.App/Controls/ConnectionManager.axaml
+++ b/src/NovaTerminal.App/Controls/ConnectionManager.axaml
@@ -8,12 +8,21 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="500">
     <Grid ColumnDefinitions="250,*" Margin="10">
         <Border Grid.Column="0" BorderBrush="#333" BorderThickness="0,0,1,0" Padding="0,0,10,0">
-            <Grid RowDefinitions="Auto,Auto,Auto,*">
+            <Grid RowDefinitions="Auto,Auto,Auto,Auto,*">
                 <TextBlock Text="Connections" FontSize="18" FontWeight="SemiBold" Margin="0,0,0,8" />
-                <Grid Grid.Row="1" ColumnDefinitions="*,Auto" Margin="0,0,0,10">
+                <Grid Grid.Row="1" ColumnDefinitions="*,Auto,Auto" Margin="0,0,0,10">
                     <TextBox Name="SearchInput" Watermark="Search name, host, tags, notes..." Margin="0,0,5,0" />
-                    <Button Name="BtnSync"
+                    <Button Name="BtnNewConnection"
                             Grid.Column="1"
+                            MinWidth="56"
+                            Height="30"
+                            Padding="10,4"
+                            Margin="0,0,5,0"
+                            Content="New"
+                            ToolTip.Tip="Create a new SSH connection"
+                            Click="OnNewConnectionClick" />
+                    <Button Name="BtnSync"
+                            Grid.Column="2"
                             Width="30"
                             Height="30"
                             Padding="5"

--- a/src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs
+++ b/src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs
@@ -20,6 +20,7 @@ namespace NovaTerminal.Controls
         public event Action<TerminalProfile, SshDiagnosticsLevel>? OnConnectionDetailsRequested;
         public event Action? OnProfilesChanged;
         public event Action? OnSyncRequested;
+        public event Action? OnNewConnectionRequested;
 
         private readonly SshManagerViewModel _viewModel = new();
 
@@ -101,6 +102,11 @@ namespace NovaTerminal.Controls
         private void OnSyncClick(object? sender, RoutedEventArgs e)
         {
             OnSyncRequested?.Invoke();
+        }
+
+        private void OnNewConnectionClick(object? sender, RoutedEventArgs e)
+        {
+            OnNewConnectionRequested?.Invoke();
         }
 
         private void OnEditClick(object? sender, RoutedEventArgs e)

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -1642,6 +1642,10 @@ namespace NovaTerminal
                     _sshConnectionService.SaveConnectionProfiles(connManager.GetAllProfiles());
                 };
                 connManager.OnSyncRequested += HandleSshSync;
+                connManager.OnNewConnectionRequested += async () =>
+                {
+                    await ShowNewSshConnectionDialogAsync(null);
+                };
                 connManager.OnEditProfile += async (profile) =>
                 {
                     await ShowNewSshConnectionDialogAsync(profile);

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -746,14 +746,7 @@ namespace NovaTerminal
         private async Task<string?> ShowTextPromptAsync(string title, string prompt, string defaultValue)
         {
             string? result = null;
-            var dialog = new Window
-            {
-                Title = title,
-                Width = 520,
-                Height = 190,
-                CanResize = false,
-                WindowStartupLocation = WindowStartupLocation.CenterOwner
-            };
+            var dialog = CreateThemedDialogWindow(title, 520, 190, canResize: false);
 
             var input = new TextBox
             {
@@ -794,6 +787,30 @@ namespace NovaTerminal
 
             await dialog.ShowDialog(this);
             return result;
+        }
+
+        private Window CreateThemedDialogWindow(string title, double width, double height, bool canResize)
+        {
+            var dialog = new Window
+            {
+                Title = title,
+                Width = width,
+                Height = height,
+                CanResize = canResize,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
+
+            ApplyThemeToDialogWindow(dialog);
+            return dialog;
+        }
+
+        private void ApplyThemeToDialogWindow(Window dialog)
+        {
+            var theme = _settings.ActiveTheme;
+            var contrast = theme.GetContrastForeground();
+            dialog.Background = new SolidColorBrush(theme.Background.ToAvaloniaColor());
+            dialog.Foreground = new SolidColorBrush(contrast.ToAvaloniaColor());
+            dialog.RequestedThemeVariant = contrast == TermColor.Black ? ThemeVariant.Light : ThemeVariant.Dark;
         }
 
         private async Task RenameSelectedTabAsync()
@@ -2753,14 +2770,7 @@ namespace NovaTerminal
         {
             bool confirmed = false;
 
-            var dialog = new Window
-            {
-                Title = "Close Running Pane",
-                Width = 460,
-                Height = 190,
-                CanResize = false,
-                WindowStartupLocation = WindowStartupLocation.CenterOwner
-            };
+            var dialog = CreateThemedDialogWindow("Close Running Pane", 460, 190, canResize: false);
 
             var messageBlock = new TextBlock
             {
@@ -3799,6 +3809,7 @@ namespace NovaTerminal
         {
             var vm = _sshConnectionService.CreateEditorViewModel(existingProfile);
             var dialog = new NewSshConnectionView(vm);
+            ApplyThemeToDialogWindow(dialog);
             bool saved = await dialog.ShowDialog<bool>(this);
 
             if (!saved)
@@ -3861,14 +3872,7 @@ namespace NovaTerminal
 
         private async Task ShowSimpleMessageDialogAsync(string title, string message)
         {
-            var dialog = new Window
-            {
-                Title = title,
-                Width = 520,
-                Height = 220,
-                CanResize = false,
-                WindowStartupLocation = WindowStartupLocation.CenterOwner
-            };
+            var dialog = CreateThemedDialogWindow(title, 520, 220, canResize: false);
 
             var closeButton = new Button { Content = "Close", Width = 92 };
             closeButton.Click += (_, __) => dialog.Close();
@@ -3901,14 +3905,7 @@ namespace NovaTerminal
 
         private async Task ShowConnectionDetailsDialogAsync(SshLaunchDetails details, SshDiagnosticsLevel diagnosticsLevel)
         {
-            var dialog = new Window
-            {
-                Title = "Connection details",
-                Width = 760,
-                Height = 340,
-                CanResize = false,
-                WindowStartupLocation = WindowStartupLocation.CenterOwner
-            };
+            var dialog = CreateThemedDialogWindow("Connection details", 760, 340, canResize: false);
 
             var sshPathBox = new TextBox { Text = details.SshPath, IsReadOnly = true };
             var configPathBox = new TextBox { Text = details.ConfigPath, IsReadOnly = true };

--- a/src/NovaTerminal.App/SettingsWindow.axaml
+++ b/src/NovaTerminal.App/SettingsWindow.axaml
@@ -226,7 +226,6 @@
                             <TextBlock Text="Import From:" Opacity="0.7" FontSize="11" Margin="0,0,0,2"/>
                             <StackPanel Orientation="Vertical" Spacing="5">
                                 <Button Name="BtnImportWT" Content="Windows Terminal" FontSize="11" Padding="8,4" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"/>
-                                <Button Name="BtnImportSSH" Content="SSH Config" FontSize="11" Padding="8,4" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"/>
                                 <TextBlock Name="ImportStatusText" Text="" Foreground="#00FF00" FontSize="11" HorizontalAlignment="Center" Margin="0,5,0,0"/>
                             </StackPanel>
                         </StackPanel>

--- a/src/NovaTerminal.App/SettingsWindow.axaml.cs
+++ b/src/NovaTerminal.App/SettingsWindow.axaml.cs
@@ -97,7 +97,6 @@ namespace NovaTerminal
             var bgOpacityDisplay = this.FindControl<TextBlock>("BgImageOpacityDisplay");
             var importStatus = this.FindControl<TextBlock>("ImportStatusText");
             var btnImportWT = this.FindControl<Button>("BtnImportWT");
-            var btnImportSSH = this.FindControl<Button>("BtnImportSSH");
             var btnAddRule = this.FindControl<Button>("BtnAddRule");
 
             // Theme Editor Controls
@@ -381,17 +380,6 @@ namespace NovaTerminal
                     else
                     {
                         if (importStatus != null) importStatus.Text = "No new profiles found.";
-                    }
-                };
-            }
-
-            if (btnImportSSH != null)
-            {
-                btnImportSSH.Click += (s, e) =>
-                {
-                    if (importStatus != null)
-                    {
-                        importStatus.Text = "SSH import moved to Connection Manager (use Sync).";
                     }
                 };
             }

--- a/src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml
+++ b/src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml
@@ -7,7 +7,25 @@
         Title="New SSH Connection"
         Width="760"
         Height="620"
-        CanResize="True">
+        CanResize="True"
+        WindowStartupLocation="CenterOwner">
+    <Window.Styles>
+        <Style Selector="TabItem">
+            <Setter Property="Foreground" Value="{Binding Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}" />
+            <Setter Property="FontSize" Value="14" />
+        </Style>
+        <Style Selector="TabItem:selected">
+            <Setter Property="Foreground" Value="{Binding Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+        </Style>
+        <Style Selector="TabItem:selected /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Foreground" Value="{Binding Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}" />
+        </Style>
+        <Style Selector="TabItem:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Foreground" Value="{Binding Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}" />
+        </Style>
+    </Window.Styles>
+
     <Grid RowDefinitions="*,Auto,Auto" Margin="16">
         <TabControl>
             <TabItem Header="Basic">

--- a/tests/NovaTerminal.Tests/Ssh/ConnectionManagerTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/ConnectionManagerTests.cs
@@ -1,0 +1,24 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
+using NovaTerminal.Controls;
+
+namespace NovaTerminal.Tests.Ssh;
+
+public sealed class ConnectionManagerTests
+{
+    [AvaloniaFact]
+    public void NewConnectionButton_RaisesEvent()
+    {
+        var control = new ConnectionManager();
+        bool raised = false;
+        control.OnNewConnectionRequested += () => raised = true;
+
+        Button? button = control.FindControl<Button>("BtnNewConnection");
+        Assert.NotNull(button);
+
+        button!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+        Assert.True(raised);
+    }
+}


### PR DESCRIPTION
Added a shared themed-dialog path in MainWindow so Connection Manager dialogs use the same theme/chrome direction as Settings.
Applied that styling to:
New SSH connection dialog
Connection details dialog
Simple message dialogs
Other MainWindow prompt/confirmation dialogs
Updated SSH editor window tabs to follow the same tab foreground/selected style pattern used by Settings.
Set SSH editor dialog startup location to center owner.