### PR TITLE
fix: reduce memory spikes from ~2GB to ~600MB for mc/AltScreen sessions

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -1,0 +1,118 @@
+# NovaTerminal User Manual
+
+Welcome to NovaTerminal, a modern, cross-platform terminal emulator focused on correctness, performance, and predictability. This manual covers every feature currently available to help you maximize your productivity.
+
+## 1. Getting Started
+### 1.1 Command Palette
+The **Command Palette** is the central hub for accessing all features and commands in NovaTerminal.
+- **Shortcut:** `Ctrl+Shift+P`
+- **Usage:** Type any feature name to filter and execute commands instantly.
+
+### 1.2 Settings & Customization
+- **Open Settings:** Access settings via the Command Palette (`Settings`). Changes apply live without requiring a restart.
+- **Themes:** Switch between `Solarized Dark` and `Default (Dark)` via the palette.
+- **Font & Sizing:** Increase (`Ctrl++`) or decrease (`Ctrl+-`) font sizes. You can also customize your preferred font family in Settings.
+
+---
+
+## 2. Window and Tab Management
+NovaTerminal offers advanced windowing capabilities, including tabs, workspaces, and workspace bundles.
+
+### 2.1 Tab Basics
+- **New Tab:** `Ctrl+Shift+T` (Opens the default profile)
+- **Close Tab:** `Ctrl+W`
+- **Switch Tabs (MRU):** Use `Ctrl+Tab` for the next tab and `Ctrl+Shift+Tab` for the previous tab in Most Recently Used order.
+- **Open Tab List:** `Ctrl+Shift+O` (Useful when you have many tabs hidden in overflow).
+
+### 2.2 Advanced Tab Actions
+- **Rename:** Use `Tab: Rename Current` to set a custom title.
+- **Pin & Protect:** Use `Tab: Toggle Pin` to pin a tab and `Tab: Toggle Protect` to protect it from accidental closure.
+- **Copy Title:** `Tab: Copy Current Title`
+- **Close Others:** `Tab: Close Others` removes all tabs except the currently active one.
+
+### 2.3 Workspaces & Templates
+Workspaces save your exact window state, including tabs, pane splits, and zooming.
+- **Save/Load:** `Workspace: Save Current` and `Workspace: Load...`
+- **Templates:** Save reusable layouts via `Workspace Template: Save Current` and apply them with `Workspace Template: Apply...`.
+- **Profile Rules:** Automatically apply a template whenever a specific profile launches (`Tab Rule: Set Template for Current Profile...`).
+
+### 2.4 Workspace Bundles (Portable Sessions)
+Bundles allow exporting and importing tabs and pane layouts as portable `.novaws.json` files.
+- **Exporting:** `Workspace: Export Bundle...` or `Workspace: Export Current Session Bundle...`
+- **Import/Open:** `Workspace: Import Bundle...` or `Workspace: Open Bundle...`
+*(Note: Enterprise policies may restrict bundle sharing in managed environments).*
+
+---
+
+## 3. Panes and Layouts
+Panes allow you to split a single tab into multiple terminal windows.
+
+### 3.1 Splitting and Navigation
+- **Split Vertical:** `Ctrl+Shift+D` (Places a new pane side-by-side).
+- **Split Horizontal:** `Ctrl+Shift+E` (Places a new pane below).
+- **Close Pane:** `Ctrl+Shift+W` (Closes only the active pane, leaving others open).
+- **Navigation:** Use `Alt+Left`, `Alt+Right`, `Alt+Up`, `Alt+Down` to move focus between panes.
+- **Equalize:** `Ctrl+Shift+G` resets pane sizes to be equal.
+
+### 3.2 Advanced Pane Features
+- **Zoom Pane:** `Ctrl+Shift+Z` toggles zooming of the active pane to fill the entire tab temporarily.
+- **Broadcast Input:** `Ctrl+Shift+B` toggles sending keystrokes to *all* panes in the current tab simultaneously.
+- **Find/Search:** `Ctrl+Shift+F` opens the search overlay for the active pane.
+
+---
+
+## 4. Remote Connections (SSH & SFTP)
+NovaTerminal supports high-performance SSH sessions integrated directly into the terminal, with built-in remote file management.
+
+### 4.1 SSH Profiles and Connection Manager
+- Easily maintain local and SSH profiles in your Settings.
+- **Security:** Credentials use secure platform vault backends. No unexpected password injections triggered by terminal output are allowed for your safety. Fast reconnects and config caching simplify remote work.
+
+### 4.2 Built-in SFTP Transfers
+Access the following commands via the palette to transfer files and folders between your local machine and the SSH host:
+- `SFTP: Upload File...` / `SFTP: Upload Folder...`
+- `SFTP: Download File...` / `SFTP: Download Folder...`
+- `SFTP: Show Transfers`: Toggles the Transfer Center overlay to monitor ongoing transfers.
+
+*(Note: SFTP commands only function when the active pane is an SSH session).*
+
+---
+
+## 5. Terminal Engine & UI Behavior
+
+### 5.1 Scrolling and Cursor
+- **Smooth Scrolling:** Toggle via `Scroll: Toggle Smooth`.
+- **Cursor Styles:** Choose between `Cursor: Block`, `Cursor: Beam`, or `Cursor: Underline`.
+- **Cursor Blink:** Toggle blinking on and off (`Cursor: Toggle Blink`). Note that TUI apps like `vim` or `yazi` may control their own blinking phase.
+
+### 5.2 Visual & Audio Feedback
+- **Audio Bell:** `Bell: Toggle Audio`.
+- **Visual Bell:** `Bell: Toggle Visual Flash`.
+- **Tab Indicators:** Tabs show status icons such as `•` (background activity), `🔔` (bell/attention), `✓` / `✖` (exit status), `📌` (pinned), and `🔒` (protected).
+
+### 5.3 Advanced Graphics Support
+NovaTerminal supports rendering rich images inline natively:
+- **Sixel Graphics** (via `libsixel`, `lsix`)
+- **iTerm2 Inline Images** (via `imgcat`)
+- **Kitty Graphics Protocol**
+
+---
+
+## 6. Exporting and Debugging
+Tools designed for diagnosing visual issues, performance profiling, and saving session output.
+
+### 6.1 Snapshot Export
+Export the current terminal state containing text, colors, and styles.
+- **Plain Text:** `Pane: Export Snapshot (Plain Text)`
+- **ANSI:** `Pane: Export Snapshot (ANSI)` (Preserves original styling & colors).
+- **PNG:** `Pane: Export Snapshot (PNG)`
+
+### 6.2 Render Performance HUD
+- **Toggle Render HUD:** Enables a real-time overlay showing frame time, dirty rows/cells, draw calls, and glyph cache hit rates. Use this when experiencing degraded visual performance.
+
+### 6.3 Debug Screens
+- **Box Drawing Test:** Accessible via `Debug: Box Drawing Test Screen` to verify font rendering, gaps, and line alignments.
+
+---
+
+*This manual covers NovaTerminal vNext features.*

--- a/src/NovaTerminal.App/Core/TerminalDrawOperation.cs
+++ b/src/NovaTerminal.App/Core/TerminalDrawOperation.cs
@@ -45,6 +45,7 @@ namespace NovaTerminal.Core
         private readonly int _cellHeightDevicePx;
         private readonly PixelGrid _pixelGrid;
         private readonly bool _showRenderHud;
+        private bool _wasAltScreenLastFrame;
 
         private static readonly bool GlyphDiagnosticsEnabled = IsEnvFlagEnabled("NOVATERM_DIAG_GLYPH");
         private static readonly bool GridDiagnosticsEnabled = IsEnvFlagEnabled("NOVATERM_DIAG_GRID");
@@ -255,7 +256,7 @@ namespace NovaTerminal.Core
             var canvas = lease.SkCanvas;
 
             canvas.Save();
-            DrawTerminalInternal(canvas);
+            using var snapshotToDispose = DrawTerminalInternal(canvas);
             canvas.Restore();
         }
 
@@ -275,7 +276,7 @@ namespace NovaTerminal.Core
         // 2) Preserves row->Y mapping even if some rows are missing (uses VisualRow)
         // 3) Uses a single snapshotted absDisplayStart for consistent image/overlay/cursor mapping
 
-        internal void DrawTerminalInternal(SKCanvas canvas)
+        internal TerminalRenderSnapshot? DrawTerminalInternal(SKCanvas canvas)
         {
             try
             {
@@ -305,7 +306,7 @@ namespace NovaTerminal.Core
                 var spansByRow = new List<DirtySpan>[bufferRows];
                 for (int i = 0; i < dirtySpanCount; i++)
                 {
-                    var span = renderSnapshot.DirtySpans[i];
+                    var span = renderSnapshot.DirtySpans.Array[i];
                     if ((uint)span.Row >= (uint)bufferRows)
                     {
                         continue;
@@ -334,14 +335,38 @@ namespace NovaTerminal.Core
                 frame.ThemeFg = new SKColor(renderSnapshot.Theme.Foreground.R, renderSnapshot.Theme.Foreground.G, renderSnapshot.Theme.Foreground.B, 255);
                 frame.CursorColor = new SKColor(renderSnapshot.Theme.CursorColor.R, renderSnapshot.Theme.CursorColor.G, renderSnapshot.Theme.CursorColor.B, 255);
                 frame.CursorStyle = renderSnapshot.CursorStyle;
-                frame.Images = renderSnapshot.Images.Length > 0 ? new List<RenderImageSnapshot>(renderSnapshot.Images) : new List<RenderImageSnapshot>();
+                
+                if (renderSnapshot.Images.Length > 0 && renderSnapshot.Images.Array != null)
+                {
+                    frame.Images = new List<RenderImageSnapshot>(renderSnapshot.Images.Length);
+                    for (int i = 0; i < renderSnapshot.Images.Length; i++)
+                    {
+                        frame.Images.Add(renderSnapshot.Images.Array[i]);
+                    }
+                }
+                else
+                {
+                    frame.Images = new List<RenderImageSnapshot>();
+                }
 
-                // IMPORTANT: Always add exactly one RowRenderItem per visual row
+                 // IMPORTANT: Always add exactly one RowRenderItem per visual row
                 // so render loop can safely use r for Y positioning.
+                // Skip row picture cache for AltScreen (mc, vim, htop etc.) — these apps
+                // redraw every row on every focus/resize, giving near-zero cache hit rate.
+                // Caching only wastes native Skia memory (~1-5MB per SKPicture × 90 entries).
+                bool isAltScreen = _buffer.IsAltScreenActive;
+                bool useRowCache = _rowCache != null && !isAltScreen;
+                if (!useRowCache && _rowCache != null && !_wasAltScreenLastFrame)
+                {
+                    // First AltScreen frame: clear any pictures cached from the main-screen session.
+                    _rowCache.RequestClear();
+                }
+                _wasAltScreenLastFrame = isAltScreen;
+
                 for (int r = 0; r < bufferRows; r++)
                 {
-                    RenderRowSnapshot rowSnapshot = r < renderSnapshot.RowsData.Length
-                        ? renderSnapshot.RowsData[r]
+                    RenderRowSnapshot rowSnapshot = r < renderSnapshot.RowsData.Length && renderSnapshot.RowsData.Array != null
+                        ? renderSnapshot.RowsData.Array[r]
                         : new RenderRowSnapshot
                         {
                             AbsRow = absDisplayStart + r,
@@ -361,7 +386,7 @@ namespace NovaTerminal.Core
                     bool hasRenderableRow = rowSnapshot.Cols > 0 && rowSnapshot.Cells.Length >= rowSnapshot.Cols && rowSnapshot.RowId != 0;
                     if (hasRenderableRow)
                     {
-                        item.CachedPicture = _rowCache?.Get(rowSnapshot.RowId, rowSnapshot.Revision);
+                        item.CachedPicture = useRowCache ? _rowCache?.Get(rowSnapshot.RowId, rowSnapshot.Revision) : null;
 
                         if (item.CachedPicture != null)
                         {
@@ -379,6 +404,7 @@ namespace NovaTerminal.Core
 
                     frame.RowItems.Add(item);
                 }
+
 
                 // --------------------
                 // Render Phase (LOCK RELEASED)
@@ -502,7 +528,8 @@ namespace NovaTerminal.Core
                             dirtyCells += dirtyCellsInRow;
 
                             // Refresh cache entry for the new revision (full-row picture for future frames).
-                            if (buildsThisFrame < maxBuilds)
+                            // Skip when useRowCache=false (AltScreen) — no point recording a picture we won't store.
+                            if (useRowCache && buildsThisFrame < maxBuilds)
                             {
                                 var recSw = System.Diagnostics.Stopwatch.StartNew();
                                 using var recorder = new SKPictureRecorder();
@@ -523,7 +550,7 @@ namespace NovaTerminal.Core
                                     drawBackgrounds: true);
 
                                 var picture = recorder.EndRecording();
-                                _rowCache?.Add(snapshot.RowId, snapshot.Revision, picture);
+                                _rowCache!.Add(snapshot.RowId, snapshot.Revision, picture);
                                 IncrementPictureBuild();
 
                                 recSw.Stop();
@@ -535,36 +562,57 @@ namespace NovaTerminal.Core
                         else if (buildsThisFrame < maxBuilds)
                         {
                             rowRenderCount++;
-                            var recSw = System.Diagnostics.Stopwatch.StartNew();
-                            using var recorder = new SKPictureRecorder();
-                            using var rowCanvas = recorder.BeginRecording(new SKRect(0, 0, (float)Bounds.Width, FromDevicePx(_pixelGrid.CellHeightPx)));
+                            if (useRowCache)
+                            {
+                                // Record into a picture so it can be cached and replayed on future frames.
+                                var recSw = System.Diagnostics.Stopwatch.StartNew();
+                                using var recorder = new SKPictureRecorder();
+                                using var rowCanvas = recorder.BeginRecording(new SKRect(0, 0, (float)Bounds.Width, FromDevicePx(_pixelGrid.CellHeightPx)));
 
-                            // Row-local coordinates for cached picture recording
-                            DrawRowTextFromSnapshot(
-                                rowCanvas,
-                                snapshot,
-                                rowTopY: 0f,
-                                baselineY: FromDevicePx(_pixelGrid.BaselineOffsetPx),
-                                colEdges: colEdges,
-                                font,
-                                fgPaint,
-                                frame.ThemeFg,
-                                frame.ThemeBg,
-                                renderSnapshot.Theme,
-                                alpha,
-                                tf,
-                                drawBackgrounds: true);
+                                DrawRowTextFromSnapshot(
+                                    rowCanvas,
+                                    snapshot,
+                                    rowTopY: 0f,
+                                    baselineY: FromDevicePx(_pixelGrid.BaselineOffsetPx),
+                                    colEdges: colEdges,
+                                    font,
+                                    fgPaint,
+                                    frame.ThemeFg,
+                                    frame.ThemeBg,
+                                    renderSnapshot.Theme,
+                                    alpha,
+                                    tf,
+                                    drawBackgrounds: true);
 
-                            var picture = recorder.EndRecording();
-                            _rowCache?.Add(snapshot.RowId, snapshot.Revision, picture);
-                            canvas.DrawPicture(picture, 0, rowTopY);
-                            IncrementOtherDrawCall();
-                            IncrementPictureBuild();
+                                var picture = recorder.EndRecording();
+                                _rowCache!.Add(snapshot.RowId, snapshot.Revision, picture);
+                                canvas.DrawPicture(picture, 0, rowTopY);
+                                IncrementOtherDrawCall();
+                                IncrementPictureBuild();
 
-                            recSw.Stop();
-                            RendererStatistics.RecordRowPictureRecorded();
-                            RendererStatistics.RecordRowPictureRecordTime(recSw.ElapsedMilliseconds);
-                            buildsThisFrame++;
+                                recSw.Stop();
+                                RendererStatistics.RecordRowPictureRecorded();
+                                RendererStatistics.RecordRowPictureRecordTime(recSw.ElapsedMilliseconds);
+                                buildsThisFrame++;
+                            }
+                            else
+                            {
+                                // AltScreen / cache disabled: draw directly — no SKPicture allocation.
+                                DrawRowTextFromSnapshot(
+                                    canvas,
+                                    snapshot,
+                                    rowTopY: rowTopY,
+                                    baselineY: baselineY,
+                                    colEdges: colEdges,
+                                    font,
+                                    fgPaint,
+                                    frame.ThemeFg,
+                                    frame.ThemeBg,
+                                    renderSnapshot.Theme,
+                                    alpha,
+                                    tf,
+                                    drawBackgrounds: true);
+                            }
                         }
                         else
                         {
@@ -630,8 +678,8 @@ namespace NovaTerminal.Core
                 // Pass 4: Overlays (Selection / Search)
                 int selectionIndex = 0;
                 int matchIndex = 0;
-                SelectionRowSnapshot[] selectionRows = renderSnapshot.SelectionRows;
-                SearchHighlightSnapshot[] searchHighlights = renderSnapshot.SearchHighlights;
+                var selectionRows = renderSnapshot.SelectionRows;
+                var searchHighlights = renderSnapshot.SearchHighlights;
                 for (int r = 0; r < bufferRows; r++)
                 {
                     float y = FromDevicePx(_pixelGrid.YForRowTop(r));
@@ -639,15 +687,15 @@ namespace NovaTerminal.Core
                     float rowHeight = rowBottom - y;
                     int absRow = absDisplayStart + r;
 
-                    while (selectionIndex < selectionRows.Length && selectionRows[selectionIndex].AbsRow < absRow)
+                    while (selectionIndex < selectionRows.Length && selectionRows.Array[selectionIndex].AbsRow < absRow)
                     {
                         selectionIndex++;
                     }
 
                     int selTemp = selectionIndex;
-                    while (selTemp < selectionRows.Length && selectionRows[selTemp].AbsRow == absRow)
+                    while (selTemp < selectionRows.Length && selectionRows.Array[selTemp].AbsRow == absRow)
                     {
-                        var sel = selectionRows[selTemp];
+                        var sel = selectionRows.Array[selTemp];
                         float x1 = GetColEdge(colEdges, sel.ColStart, paddingLeft);
                         float x2 = GetColEdge(colEdges, sel.ColEnd + 1, paddingLeft);
                         canvas.DrawRect(x1, y, x2 - x1, rowHeight, selectionPaint);
@@ -656,15 +704,15 @@ namespace NovaTerminal.Core
                     }
 
                     // Sub-linear scan for search matches (assumes highlights are sorted by AbsRow)
-                    while (matchIndex < searchHighlights.Length && searchHighlights[matchIndex].AbsRow < absRow)
+                    while (matchIndex < searchHighlights.Length && searchHighlights.Array[matchIndex].AbsRow < absRow)
                     {
                         matchIndex++;
                     }
 
                     int tempIdx = matchIndex;
-                    while (tempIdx < searchHighlights.Length && searchHighlights[tempIdx].AbsRow == absRow)
+                    while (tempIdx < searchHighlights.Length && searchHighlights.Array[tempIdx].AbsRow == absRow)
                     {
-                        var m = searchHighlights[tempIdx];
+                        var m = searchHighlights.Array[tempIdx];
                         var p = m.IsActive ? activeMatchPaint : matchPaint;
                         float x1 = GetColEdge(colEdges, m.StartCol, paddingLeft);
                         float x2 = GetColEdge(colEdges, m.EndCol + 1, paddingLeft);
@@ -742,6 +790,8 @@ namespace NovaTerminal.Core
                 }
 
                 CompleteFramePerfMetrics(perfWriter, frameSw.Elapsed.TotalMilliseconds, dirtyRowCount, dirtySpanCount);
+                
+                return renderSnapshot;
             }
             catch (Exception ex)
             {
@@ -755,7 +805,7 @@ namespace NovaTerminal.Core
             }
         }
 
-        private void DrawTerminal(SKCanvas canvas)
+        private TerminalRenderSnapshot? DrawTerminal(SKCanvas canvas)
             => DrawTerminalInternal(canvas);
 
         private void DrawPerformanceHud(SKCanvas canvas, RenderPerfMetrics metrics, byte alpha)

--- a/src/NovaTerminal.App/Core/TerminalDrawOperation.cs
+++ b/src/NovaTerminal.App/Core/TerminalDrawOperation.cs
@@ -469,6 +469,15 @@ namespace NovaTerminal.Core
                                     continue;
                                 }
 
+                                // OVERLAP FIX: Erase the dirty span bounding box before redrawing it.
+                                // DrawRowTextFromSnapshot skips default background painting, so drawing over previousRowPicture 
+                                // will leave ghost text mixed with the new text if not cleared.
+                                float sx1 = GetColEdge(colEdges, spanStart, paddingLeft);
+                                float sx2 = GetColEdge(colEdges, spanEndExclusive, paddingLeft);
+                                float sH = FromDevicePx(_pixelGrid.CellHeightPx);
+                                canvas.DrawRect(sx1, rowTopY, sx2 - sx1, sH, bgPaint);
+                                IncrementRectDrawCall();
+
                                 DrawRowTextFromSnapshot(
                                     canvas,
                                     snapshot,

--- a/src/NovaTerminal.App/Core/TerminalView.cs
+++ b/src/NovaTerminal.App/Core/TerminalView.cs
@@ -1087,44 +1087,9 @@ namespace NovaTerminal.Core
         // Throttle resize: limit how often we send resize to PTY (interval-based, not debounce)
         private DateTime _lastPtyResizeTime = DateTime.MinValue;
         private DispatcherTimer? _resizeThrottleTimer;
-        private const int ResizeThrottleMinMs = 16;
-        private const int ResizeThrottleMaxMs = 80;
-        private const int ResizeBurstResetMs = 280;
-        private int _activeResizeThrottleMs = ResizeThrottleMinMs;
-        private int _resizeBurstCount = 0;
-        private DateTime _lastResizeObservedAt = DateTime.MinValue;
         private int _pendingCols = 0;
         private int _pendingRows = 0;
         private DateTime _pendingResizeStartedAt = DateTime.MinValue;
-
-        private void UpdateAdaptiveResizeThrottle(DateTime now)
-        {
-            if (_lastResizeObservedAt == DateTime.MinValue ||
-                (now - _lastResizeObservedAt).TotalMilliseconds > ResizeBurstResetMs)
-            {
-                _resizeBurstCount = 0;
-            }
-
-            _resizeBurstCount++;
-            _lastResizeObservedAt = now;
-
-            if (_resizeBurstCount <= 2)
-            {
-                _activeResizeThrottleMs = ResizeThrottleMinMs;
-            }
-            else if (_resizeBurstCount <= 6)
-            {
-                _activeResizeThrottleMs = 24;
-            }
-            else if (_resizeBurstCount <= 14)
-            {
-                _activeResizeThrottleMs = 40;
-            }
-            else
-            {
-                _activeResizeThrottleMs = ResizeThrottleMaxMs;
-            }
-        }
 
         private void StartAutoScroll(int direction)
         {
@@ -1259,43 +1224,34 @@ namespace NovaTerminal.Core
 
                         if (dimensionsChanged)
                         {
-                            // INTERVAL-BASED THROTTLE: Send resize if enough time passed, otherwise schedule
+                            // STRICT INTERVAL THROTTLE: Limit resize dispatch to 60ms
                             _pendingCols = cols;
                             _pendingRows = rows;
                             var now = DateTime.UtcNow;
-                            UpdateAdaptiveResizeThrottle(now);
                             if (_pendingResizeStartedAt == DateTime.MinValue)
                             {
                                 _pendingResizeStartedAt = now;
                             }
 
+                            if (_resizeThrottleTimer == null)
+                            {
+                                _resizeThrottleTimer = new DispatcherTimer(DispatcherPriority.Normal)
+                                {
+                                    Interval = TimeSpan.FromMilliseconds(60)
+                                };
+                                _resizeThrottleTimer.Tick += OnResizeThrottleTick;
+                            }
+
                             var elapsed = (now - _lastPtyResizeTime).TotalMilliseconds;
 
-                            if (elapsed >= _activeResizeThrottleMs)
+                            if (elapsed >= 60 && !_resizeThrottleTimer.IsEnabled)
                             {
-                                // Enough time passed - send immediately
+                                // Enough time passed and no pending timer - send immediately
                                 SendThrottledResize();
                             }
-                            else
+                            else if (!_resizeThrottleTimer.IsEnabled)
                             {
-                                // Too soon - schedule for later (ensures we always send the final size)
-                                if (_resizeThrottleTimer == null)
-                                {
-                                    _resizeThrottleTimer = new DispatcherTimer(DispatcherPriority.Normal)
-                                    {
-                                        Interval = TimeSpan.FromMilliseconds(_activeResizeThrottleMs)
-                                    };
-                                    _resizeThrottleTimer.Tick += OnResizeThrottleTick;
-                                }
-                                else
-                                {
-                                    _resizeThrottleTimer.Interval = TimeSpan.FromMilliseconds(_activeResizeThrottleMs);
-                                }
-
-                                if (!_resizeThrottleTimer.IsEnabled)
-                                {
-                                    _resizeThrottleTimer.Start();
-                                }
+                                _resizeThrottleTimer.Start();
                             }
                         }
                     }
@@ -1320,7 +1276,7 @@ namespace NovaTerminal.Core
                     // THEN notify PTY (triggers SIGWINCH, new output uses new size)
                     // This prevents race where PTY sends data for new dimensions while buffer is mid-reflow
                     _buffer.Resize(_pendingCols, _pendingRows);
-                    _rowCache.MaxEntries = Math.Max(1000, _pendingRows * 10);
+                    _rowCache.MaxEntries = Math.Max(_pendingRows * 3, 50);
                     _rowCache.RequestClear();
                     OnResize?.Invoke(_pendingCols, _pendingRows);
                     if (_pendingResizeStartedAt != DateTime.MinValue)

--- a/src/NovaTerminal.Rendering/GlyphAtlas.cs
+++ b/src/NovaTerminal.Rendering/GlyphAtlas.cs
@@ -19,7 +19,7 @@ namespace NovaTerminal.Core
 
     public class GlyphAtlas : IDisposable
     {
-        private const int AtlasSize = 2048;
+        private const int AtlasSize = 1024;
         private readonly SKSurface _alphaSurface;
         private readonly SKSurface _colorSurface;
 
@@ -33,6 +33,10 @@ namespace NovaTerminal.Core
 
         public GlyphAtlas()
         {
+            // Both surfaces use Rgba8888 — required for DrawAtlas with SKBlendMode.Modulate,
+            // which multiplies texture RGB (must be white=255) by vertex color to tint glyphs.
+            // Alpha8 would give RGB=(0,0,0) → all glyphs render black.
+            // 1024² is a 4× reduction from the original 2048², saving 12MB per atlas.
             _alphaSurface = SKSurface.Create(new SKImageInfo(AtlasSize, AtlasSize, SKColorType.Rgba8888));
             _colorSurface = SKSurface.Create(new SKImageInfo(AtlasSize, AtlasSize, SKColorType.Rgba8888));
 

--- a/src/NovaTerminal.Rendering/RowCache.cs
+++ b/src/NovaTerminal.Rendering/RowCache.cs
@@ -26,7 +26,7 @@ namespace NovaTerminal.Core
 
         private bool _clearRequested;
 
-        public int MaxEntries { get; set; } = 1000;
+        public int MaxEntries { get; set; } = 150;
 
         private readonly struct Key : IEquatable<Key>
         {

--- a/src/NovaTerminal.VT/RenderSnapshots.cs
+++ b/src/NovaTerminal.VT/RenderSnapshots.cs
@@ -44,7 +44,29 @@ namespace NovaTerminal.Core
         public bool IsActive { get; init; }
     }
 
-    public readonly struct TerminalRenderSnapshot
+    public readonly struct PooledArray<T> : IDisposable
+    {
+        public readonly T[] Array;
+        public readonly int Length;
+
+        public PooledArray(T[] array, int length)
+        {
+            Array = array;
+            Length = length;
+        }
+
+        public void Dispose()
+        {
+            if (Array != null)
+            {
+                System.Buffers.ArrayPool<T>.Shared.Return(Array, clearArray: true);
+            }
+        }
+
+        public static PooledArray<T> Empty => new();
+    }
+
+    public readonly struct TerminalRenderSnapshot : IDisposable
     {
         public int ViewportRows { get; init; }
         public int ViewportCols { get; init; }
@@ -55,11 +77,20 @@ namespace NovaTerminal.Core
         public int CursorCol { get; init; }
         public CursorStyle CursorStyle { get; init; }
         public RenderThemeSnapshot Theme { get; init; }
-        public DirtySpan[] DirtySpans { get; init; }
-        public RenderRowSnapshot[] RowsData { get; init; }
-        public RenderImageSnapshot[] Images { get; init; }
-        public SelectionRowSnapshot[] SelectionRows { get; init; }
-        public SearchHighlightSnapshot[] SearchHighlights { get; init; }
+        public PooledArray<DirtySpan> DirtySpans { get; init; }
+        public PooledArray<RenderRowSnapshot> RowsData { get; init; }
+        public PooledArray<RenderImageSnapshot> Images { get; init; }
+        public PooledArray<SelectionRowSnapshot> SelectionRows { get; init; }
+        public PooledArray<SearchHighlightSnapshot> SearchHighlights { get; init; }
+
+        public void Dispose()
+        {
+            DirtySpans.Dispose();
+            RowsData.Dispose();
+            Images.Dispose();
+            SelectionRows.Dispose();
+            SearchHighlights.Dispose();
+        }
     }
 
     public struct RenderCellSnapshot

--- a/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
@@ -429,6 +429,9 @@ namespace NovaTerminal.Core
 
                 _cursorRow = 0;
                 _cursorCol = 0;
+                // Reset row-diff cache so the next CaptureRenderSnapshot compares the alt-screen
+                // rows fresh rather than against stale main-screen row IDs.
+                _hasSnapshotState = false;
                 Invalidate();
                 OnScreenSwitched?.Invoke(true); // Notify that we switched to alt screen
             }
@@ -457,6 +460,9 @@ namespace NovaTerminal.Core
                 _cursorRow = Math.Clamp(_cursorRow, 0, Rows - 1);
                 _cursorCol = Math.Clamp(_cursorCol, 0, Cols - 1);
 
+                // Reset row-diff cache so the next CaptureRenderSnapshot compares the main-screen
+                // rows fresh rather than against stale alt-screen row IDs.
+                _hasSnapshotState = false;
                 Invalidate();
                 OnScreenSwitched?.Invoke(false); // Notify that we switched back to main screen
             }

--- a/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
@@ -54,6 +54,9 @@ namespace NovaTerminal.Core
 
             private void Reflow(int oldCols, int oldRows, int newCols, int newRows)
             {
+                TerminalRow[]? allPhysicalRows = null;
+                (TerminalCell Cell, string? ExtendedText)[]? logicalCells = null;
+
                 try
                 {
                     if (newCols <= 0 || newRows <= 0) return;
@@ -95,53 +98,56 @@ namespace NovaTerminal.Core
                     int totalPhysRows = _scrollback.Count + vpRowsToTake;
 
                     // Rent array to avoid LOH/large allocation
-                    var allPhysicalRows = System.Buffers.ArrayPool<TerminalRow>.Shared.Rent(totalPhysRows);
+                    allPhysicalRows = System.Buffers.ArrayPool<TerminalRow>.Shared.Rent(totalPhysRows);
 
                     // 3. Metadata-Aware Logical Reconstruction
-                    var logicalLines = new List<(List<(TerminalCell Cell, string? ExtendedText)> Cells, bool IsWrapped, int StartPhysIdx)>(totalPhysRows);
+                    var logicalCellsPool = System.Buffers.ArrayPool<(TerminalCell Cell, string? ExtendedText)>.Shared;
+                    int maxLogicalCells = totalPhysRows * Math.Max(oldCols, newCols) + 1000;
+                    logicalCells = logicalCellsPool.Rent(maxLogicalCells);
+                    int logicalCellsCount = 0;
 
-                    try
+                    var logicalLines = new List<(int StartIdx, int Length, bool IsWrapped, int StartPhysIdx)>(totalPhysRows);
+
+                    // Fill rented array
+                    for (int i = 0; i < _scrollback.Count; i++) allPhysicalRows[i] = _scrollback[i];
+                    for (int i = 0; i < vpRowsToTake; i++)
                     {
-                        // Fill rented array
-                        for (int i = 0; i < _scrollback.Count; i++) allPhysicalRows[i] = _scrollback[i];
-                        for (int i = 0; i < vpRowsToTake; i++)
+                        if (i < actualVpLen) allPhysicalRows[_scrollback.Count + i] = _viewport[i];
+                        else allPhysicalRows[_scrollback.Count + i] = new TerminalRow(oldCols, Theme.Foreground, Theme.Background);
+                    }
+
+                    int currentLogStart = -1;
+                    int currentStartPhys = -1;
+
+                    // Iterate using totalPhysRows count
+                    for (int i = 0; i < totalPhysRows; i++)
+                    {
+                        var physRow = allPhysicalRows[i];
+
+                        if (currentLogStart == -1)
                         {
-                            if (i < actualVpLen) allPhysicalRows[_scrollback.Count + i] = _viewport[i];
-                            else allPhysicalRows[_scrollback.Count + i] = new TerminalRow(oldCols, Theme.Foreground, Theme.Background);
+                            currentLogStart = logicalCellsCount;
+                            currentStartPhys = i;
                         }
 
-                        List<(TerminalCell Cell, string? ExtendedText)>? currentLogical = null;
-                        int currentStartPhys = -1;
-
-                        // Iterate using totalPhysRows count
-                        for (int i = 0; i < totalPhysRows; i++)
+                        // Cursor Tracking
+                        if (i == absCursorPhysicalIdx)
                         {
-                            var physRow = allPhysicalRows[i];
+                            cursorLogicalIdx = logicalLines.Count;
+                            cursorInLogicalOffset = (logicalCellsCount - currentLogStart) + _cursorCol;
+                        }
 
-                            if (currentLogical == null)
-                            {
-                                currentLogical = new List<(TerminalCell Cell, string? ExtendedText)>();
-                                currentStartPhys = i;
-                            }
+                        if (i == absMainSavedIdx)
+                        {
+                            mainSavedLogicalIdx = logicalLines.Count;
+                            mainSavedInLogicalOffset = (logicalCellsCount - currentLogStart) + _savedCursors.Main.Col;
+                        }
 
-                            // Cursor Tracking
-                            if (i == absCursorPhysicalIdx)
-                            {
-                                cursorLogicalIdx = logicalLines.Count;
-                                cursorInLogicalOffset = currentLogical.Count + _cursorCol;
-                            }
-
-                            if (i == absMainSavedIdx)
-                            {
-                                mainSavedLogicalIdx = logicalLines.Count;
-                                mainSavedInLogicalOffset = currentLogical.Count + _savedCursors.Main.Col;
-                            }
-
-                            if (i == absAltSavedIdx)
-                            {
-                                altSavedLogicalIdx = logicalLines.Count;
-                                altSavedInLogicalOffset = currentLogical.Count + _savedCursors.Alt.Col;
-                            }
+                        if (i == absAltSavedIdx)
+                        {
+                            altSavedLogicalIdx = logicalLines.Count;
+                            altSavedInLogicalOffset = (logicalCellsCount - currentLogStart) + _savedCursors.Alt.Col;
+                        }
 
                             int validLen = physRow.Cells.Length;
 
@@ -329,21 +335,14 @@ namespace NovaTerminal.Core
                                     // Extract Left+Middle
                                     for (int k = 0; k < gapStart; k++)
                                     {
-                                        currentLogical.Add((physRow.Cells[k], physRow.GetExtendedText(k)));
-                                    }
-
-                                    // Extract Right Part
-                                    var rightCells = new List<(TerminalCell Cell, string? ExtendedText)>();
-                                    for (int k = rightStart; k <= rightEnd; k++)
-                                    {
-                                        rightCells.Add((physRow.Cells[k], physRow.GetExtendedText(k)));
+                                        logicalCells[logicalCellsCount++] = (physRow.Cells[k], physRow.GetExtendedText(k));
                                     }
 
                                     // Calculate new position
-                                    int rightBlockWidth = rightCells.Count;
+                                    int rightBlockWidth = rightEnd - rightStart + 1;
                                     int newRightPos = newCols - rightBlockWidth;
 
-                                    int currentPos = currentLogical.Count; // This is effectively gapStart
+                                    int currentPos = logicalCellsCount - currentLogStart; // This is effectively gapStart
 
                                     if (newRightPos > currentPos + 2 && (newRightPos + rightBlockWidth) <= newCols)
                                     {
@@ -351,25 +350,28 @@ namespace NovaTerminal.Core
                                         var spaceFill = new TerminalCell(' ', Theme.Foreground, Theme.Background, false, false, true, true);
                                         for (int s = currentPos; s < newRightPos; s++)
                                         {
-                                            currentLogical.Add((spaceFill, null));
+                                            logicalCells[logicalCellsCount++] = (spaceFill, null);
                                         }
                                         // Add right content
-                                        currentLogical.AddRange(rightCells);
+                                        for (int k = rightStart; k <= rightEnd; k++)
+                                        {
+                                            logicalCells[logicalCellsCount++] = (physRow.Cells[k], physRow.GetExtendedText(k));
+                                        }
                                     }
                                     else
                                     {
                                         // Truncate/Squish
                                         var spaceFill = new TerminalCell(' ', Theme.Foreground, Theme.Background, false, false, true, true);
-                                        currentLogical.Add((spaceFill, null));
-                                        currentLogical.Add((spaceFill, null));
+                                        logicalCells[logicalCellsCount++] = (spaceFill, null);
+                                        logicalCells[logicalCellsCount++] = (spaceFill, null);
 
-                                        int available = newCols - currentLogical.Count;
+                                        int available = newCols - (logicalCellsCount - currentLogStart);
                                         if (available > 0)
                                         {
-                                            int take = Math.Min(available, rightCells.Count);
-                                            int startOffset = rightCells.Count - take;
-                                            for (int k = startOffset; k < rightCells.Count; k++)
-                                                currentLogical.Add(rightCells[k]);
+                                            int take = Math.Min(available, rightBlockWidth);
+                                            int startOffset = rightBlockWidth - take;
+                                            for (int k = rightStart + startOffset; k <= rightEnd; k++)
+                                                logicalCells[logicalCellsCount++] = (physRow.Cells[k], physRow.GetExtendedText(k));
                                         }
                                     }
                                     isSparseRowRepositioned = true;
@@ -381,27 +383,20 @@ namespace NovaTerminal.Core
                             if (!isSparseRowRepositioned)
                             {
                                 for (int k = 0; k < validLen; k++)
-                                    currentLogical.Add((physRow.Cells[k], physRow.GetExtendedText(k)));
+                                    logicalCells[logicalCellsCount++] = (physRow.Cells[k], physRow.GetExtendedText(k));
                             }
 
                             if (!physRow.IsWrapped || ignoreWrap)
                             {
-                                logicalLines.Add((currentLogical, false, currentStartPhys));
-                                currentLogical = null;
+                                logicalLines.Add((currentLogStart, logicalCellsCount - currentLogStart, false, currentStartPhys));
+                                currentLogStart = -1;
                             }
                         }
 
-                        if (currentLogical != null)
+                        if (currentLogStart != -1)
                         {
-                            logicalLines.Add((currentLogical, true, currentStartPhys));
+                            logicalLines.Add((currentLogStart, logicalCellsCount - currentLogStart, true, currentStartPhys));
                         }
-                    }
-                    finally
-                    {
-                        System.Buffers.ArrayPool<TerminalRow>.Shared.Return(allPhysicalRows);
-                    }
-
-
                     // 5. Distribution logic
                     _scrollback.Clear();
                     _viewport = new TerminalRow[newRows];
@@ -463,12 +458,14 @@ namespace NovaTerminal.Core
 
                     for (int i = 0; i < logicalLines.Count; i++)
                     {
-                        var lineCells = logicalLines[i].Cells;
+                        var lineInfo = logicalLines[i];
+                        int lineStart = lineInfo.StartIdx;
+                        int lineCount = lineInfo.Length;
 
                         // Track start of this logical line in flowed rows
                         int startFlowIndex = allFlowedRows.Count;
 
-                        if (lineCells.Count == 0)
+                        if (lineCount == 0)
                         {
                             // If this is the WIPED prompt, place cursor here
                             if (i == cursorLogicalIdx) { newCursorPhysRow = allFlowedRows.Count; newCursorPhysCol = 0; }
@@ -479,13 +476,13 @@ namespace NovaTerminal.Core
                         else
                         {
                             int processed = 0;
-                            while (processed < lineCells.Count)
+                            while (processed < lineCount)
                             {
-                                int remaining = lineCells.Count - processed;
+                                int remaining = lineCount - processed;
                                 int take = Math.Min(remaining, newCols);
 
                                 // Prevent splitting a wide character across lines
-                                if (take < remaining && take > 0 && lineCells[processed + take - 1].Cell.IsWide)
+                                if (take < remaining && take > 0 && logicalCells[lineStart + processed + take - 1].Cell.IsWide)
                                 {
                                     take--; // This row will end with a space, wide char moves to next row
                                 }
@@ -530,7 +527,7 @@ namespace NovaTerminal.Core
                                 var row = new TerminalRow(newCols, Theme.Foreground, Theme.Background);
                                 for (int c = 0; c < take; c++)
                                 {
-                                    var entry = lineCells[processed + c];
+                                    var entry = logicalCells[lineStart + processed + c];
                                     row.Cells[c] = entry.Cell;
                                     row.SetExtendedText(c, entry.ExtendedText);
                                 }

--- a/src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs
@@ -45,10 +45,25 @@ namespace NovaTerminal.Core
                     {
                         var oldAlt = _viewport;
                         _viewport = new TerminalRow[newRows];
+                        
+                        var lastCell = new TerminalCell(' ', Theme.Foreground, Theme.Background, false, false, true, true);
+                        if (oldAlt.Length > 0 && oldCols > 0)
+                        {
+                            var src = oldAlt[oldAlt.Length - 1].Cells[oldCols - 1];
+                            lastCell = new TerminalCell(' ', src.Fg, src.Bg, src.Flags);
+                        }
+
                         for (int i = 0; i < newRows; i++)
                         {
-                            if (i < oldAlt.Length) _viewport[i] = oldAlt[i];
-                            else _viewport[i] = new TerminalRow(newCols, Theme.Foreground, Theme.Background);
+                            if (i < oldAlt.Length) 
+                            {
+                                _viewport[i] = oldAlt[i];
+                            }
+                            else 
+                            {
+                                _viewport[i] = new TerminalRow(newCols);
+                                for (int cx = 0; cx < newCols; cx++) _viewport[i].Cells[cx] = lastCell;
+                            }
                         }
                         _cursorRow = Math.Clamp(_cursorRow, 0, newRows - 1);
                     }
@@ -114,9 +129,26 @@ namespace NovaTerminal.Core
                     // We preserve what fits top-left to avoid flashing empty if redraw is slow.
                     var oldAlt = _viewport;
                     _viewport = new TerminalRow[newRows];
+                    
+                    var lastCell = new TerminalCell(' ', Theme.Foreground, Theme.Background, false, false, true, true);
+                    if (oldAlt.Length > 0 && oldCols > 0)
+                    {
+                        var src = oldAlt[oldAlt.Length - 1].Cells[oldCols - 1];
+                        lastCell = new TerminalCell(' ', src.Fg, src.Bg, src.Flags);
+                    }
+
                     for (int i = 0; i < newRows; i++)
                     {
-                        _viewport[i] = new TerminalRow(newCols, Theme.Foreground, Theme.Background);
+                        var rowCell = lastCell;
+                        if (i < oldAlt.Length && oldCols > 0)
+                        {
+                            var src = oldAlt[i].Cells[oldCols - 1];
+                            rowCell = new TerminalCell(' ', src.Fg, src.Bg, src.Flags);
+                        }
+
+                        _viewport[i] = new TerminalRow(newCols);
+                        for (int cx = 0; cx < newCols; cx++) _viewport[i].Cells[cx] = rowCell;
+
                         if (i < oldAlt.Length)
                         {
                             int copyCols = Math.Min(oldCols, newCols);

--- a/src/NovaTerminal.VT/TerminalBuffer.ThreadingAndInvalidation.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ThreadingAndInvalidation.cs
@@ -21,6 +21,7 @@ namespace NovaTerminal.Core
         private RenderCellSnapshot[][] _cachedRenderRowCells = Array.Empty<RenderCellSnapshot[]>();
         private int _lastSnapshotCols = -1;
         private bool _hasSnapshotState;
+        private TermColor[]? _cachedAnsiPalette;
 
         public bool IsSynchronizedOutput => _isSynchronizedOutput;
         public long CursorSuppressedUntilUtcTicks => _cursorSuppressedUntilUtcTicks;
@@ -206,9 +207,9 @@ namespace NovaTerminal.Core
             int cursorCol = 0;
             CursorStyle cursorStyle = CursorStyle.Block;
             RenderThemeSnapshot theme = default;
-            RenderRowSnapshot[] rowsData = viewportRows > 0 ? new RenderRowSnapshot[viewportRows] : Array.Empty<RenderRowSnapshot>();
-            RenderImageSnapshot[] images = Array.Empty<RenderImageSnapshot>();
-            DirtySpan[] dirtySpans = Array.Empty<DirtySpan>();
+            var rowsData = viewportRows > 0 ? new PooledArray<RenderRowSnapshot>(System.Buffers.ArrayPool<RenderRowSnapshot>.Shared.Rent(viewportRows), viewportRows) : PooledArray<RenderRowSnapshot>.Empty;
+            PooledArray<RenderImageSnapshot> images = PooledArray<RenderImageSnapshot>.Empty;
+            PooledArray<DirtySpan> dirtySpans = PooledArray<DirtySpan>.Empty;
 
             var lockSw = Stopwatch.StartNew();
             Lock.EnterReadLock();
@@ -262,7 +263,10 @@ namespace NovaTerminal.Core
                         _cachedRenderRowCells[r] = Array.Empty<RenderCellSnapshot>();
                     }
 
-                    rowsData[r] = rowSnapshot;
+                    if (viewportRows > 0 && rowsData.Array != null)
+                    {
+                        rowsData.Array[r] = rowSnapshot;
+                    }
 
                     bool fullRowDirty = !_hasSnapshotState ||
                                         _lastSnapshotCols != viewportCols ||
@@ -307,7 +311,12 @@ namespace NovaTerminal.Core
                 dirtySpans = NormalizeDirtySpans(dirtyList, viewportRows, viewportCols);
 
                 var visibleImages = GetVisibleImagesSnapshot(absDisplayStart, viewportRows);
-                images = visibleImages.Count > 0 ? visibleImages.ToArray() : Array.Empty<RenderImageSnapshot>();
+                if (visibleImages.Count > 0)
+                {
+                    var imgArray = System.Buffers.ArrayPool<RenderImageSnapshot>.Shared.Rent(visibleImages.Count);
+                    visibleImages.CopyTo(imgArray, 0);
+                    images = new PooledArray<RenderImageSnapshot>(imgArray, visibleImages.Count);
+                }
             }
             finally
             {
@@ -316,8 +325,8 @@ namespace NovaTerminal.Core
                 readLockMs = lockSw.ElapsedMilliseconds;
             }
 
-            SelectionRowSnapshot[] selectionRows = BuildSelectionRows(req.Selection, absDisplayStart, viewportRows, viewportCols);
-            SearchHighlightSnapshot[] searchHighlights = BuildSearchHighlights(req.SearchMatches, req.ActiveSearchIndex, absDisplayStart, viewportRows);
+            PooledArray<SelectionRowSnapshot> selectionRows = BuildSelectionRows(req.Selection, absDisplayStart, viewportRows, viewportCols);
+            PooledArray<SearchHighlightSnapshot> searchHighlights = BuildSearchHighlights(req.SearchMatches, req.ActiveSearchIndex, absDisplayStart, viewportRows);
 
             return new TerminalRenderSnapshot
             {
@@ -340,30 +349,33 @@ namespace NovaTerminal.Core
 
         private RenderThemeSnapshot CreateRenderThemeSnapshot_NoLock()
         {
+            // Reuse the palette array to avoid per-frame allocation.
+            if (_cachedAnsiPalette == null)
+            {
+                _cachedAnsiPalette = new TermColor[16];
+            }
+            _cachedAnsiPalette[0]  = Theme.Black;
+            _cachedAnsiPalette[1]  = Theme.Red;
+            _cachedAnsiPalette[2]  = Theme.Green;
+            _cachedAnsiPalette[3]  = Theme.Yellow;
+            _cachedAnsiPalette[4]  = Theme.Blue;
+            _cachedAnsiPalette[5]  = Theme.Magenta;
+            _cachedAnsiPalette[6]  = Theme.Cyan;
+            _cachedAnsiPalette[7]  = Theme.White;
+            _cachedAnsiPalette[8]  = Theme.BrightBlack;
+            _cachedAnsiPalette[9]  = Theme.BrightRed;
+            _cachedAnsiPalette[10] = Theme.BrightGreen;
+            _cachedAnsiPalette[11] = Theme.BrightYellow;
+            _cachedAnsiPalette[12] = Theme.BrightBlue;
+            _cachedAnsiPalette[13] = Theme.BrightMagenta;
+            _cachedAnsiPalette[14] = Theme.BrightCyan;
+            _cachedAnsiPalette[15] = Theme.BrightWhite;
             return new RenderThemeSnapshot
             {
                 Foreground = Theme.Foreground,
                 Background = Theme.Background,
                 CursorColor = Theme.CursorColor,
-                AnsiPalette = new[]
-                {
-                    Theme.Black,
-                    Theme.Red,
-                    Theme.Green,
-                    Theme.Yellow,
-                    Theme.Blue,
-                    Theme.Magenta,
-                    Theme.Cyan,
-                    Theme.White,
-                    Theme.BrightBlack,
-                    Theme.BrightRed,
-                    Theme.BrightGreen,
-                    Theme.BrightYellow,
-                    Theme.BrightBlue,
-                    Theme.BrightMagenta,
-                    Theme.BrightCyan,
-                    Theme.BrightWhite
-                }
+                AnsiPalette = _cachedAnsiPalette
             };
         }
 
@@ -482,11 +494,11 @@ namespace NovaTerminal.Core
                    a.BgIndex == b.BgIndex;
         }
 
-        private static DirtySpan[] NormalizeDirtySpans(List<DirtySpan> spans, int viewportRows, int viewportCols)
+        private static PooledArray<DirtySpan> NormalizeDirtySpans(List<DirtySpan> spans, int viewportRows, int viewportCols)
         {
             if (spans.Count == 0 || viewportRows <= 0 || viewportCols <= 0)
             {
-                return Array.Empty<DirtySpan>();
+                return PooledArray<DirtySpan>.Empty;
             }
 
             spans.Sort(static (a, b) =>
@@ -545,14 +557,20 @@ namespace NovaTerminal.Core
                 }
             }
 
-            return normalized.Count > 0 ? normalized.ToArray() : Array.Empty<DirtySpan>();
+            if (normalized.Count > 0)
+            {
+                var arr = System.Buffers.ArrayPool<DirtySpan>.Shared.Rent(normalized.Count);
+                normalized.CopyTo(arr, 0);
+                return new PooledArray<DirtySpan>(arr, normalized.Count);
+            }
+            return PooledArray<DirtySpan>.Empty;
         }
 
-        private static SelectionRowSnapshot[] BuildSelectionRows(SelectionState? selection, int absDisplayStart, int viewportRows, int viewportCols)
+        private static PooledArray<SelectionRowSnapshot> BuildSelectionRows(SelectionState? selection, int absDisplayStart, int viewportRows, int viewportCols)
         {
             if (selection == null || !selection.IsActive || viewportRows <= 0 || viewportCols <= 0)
             {
-                return Array.Empty<SelectionRowSnapshot>();
+                return PooledArray<SelectionRowSnapshot>.Empty;
             }
 
             var list = new List<SelectionRowSnapshot>();
@@ -580,14 +598,20 @@ namespace NovaTerminal.Core
                 });
             }
 
-            return list.Count > 0 ? list.ToArray() : Array.Empty<SelectionRowSnapshot>();
+            if (list.Count > 0)
+            {
+                var arr = System.Buffers.ArrayPool<SelectionRowSnapshot>.Shared.Rent(list.Count);
+                list.CopyTo(arr, 0);
+                return new PooledArray<SelectionRowSnapshot>(arr, list.Count);
+            }
+            return PooledArray<SelectionRowSnapshot>.Empty;
         }
 
-        private static SearchHighlightSnapshot[] BuildSearchHighlights(IReadOnlyList<SearchMatch>? matches, int activeSearchIndex, int absDisplayStart, int viewportRows)
+        private static PooledArray<SearchHighlightSnapshot> BuildSearchHighlights(IReadOnlyList<SearchMatch>? matches, int activeSearchIndex, int absDisplayStart, int viewportRows)
         {
             if (matches == null || matches.Count == 0 || viewportRows <= 0)
             {
-                return Array.Empty<SearchHighlightSnapshot>();
+                return PooledArray<SearchHighlightSnapshot>.Empty;
             }
 
             int absEnd = absDisplayStart + viewportRows;
@@ -609,7 +633,13 @@ namespace NovaTerminal.Core
                 });
             }
 
-            return list.Count > 0 ? list.ToArray() : Array.Empty<SearchHighlightSnapshot>();
+            if (list.Count > 0)
+            {
+                var arr = System.Buffers.ArrayPool<SearchHighlightSnapshot>.Shared.Rent(list.Count);
+                list.CopyTo(arr, 0);
+                return new PooledArray<SearchHighlightSnapshot>(arr, list.Count);
+            }
+            return PooledArray<SearchHighlightSnapshot>.Empty;
         }
     }
 }


### PR DESCRIPTION
## Problem

Memory usage would spike to ~2GB when switching tabs with \mc\ (or other AltScreen TUI apps like \im\, \htop\) running, particularly over SSH. Memory profiling showed the growth was entirely **native Skia memory** (managed GC heap stayed under 40MB throughout).

## Root Causes Found (via in-process memory profiling)

1. **RowImageCache was capped at 1000 entries minimum.** Each cached \SKPicture\ for a content-rich \mc\ row uses ~1-2MB of native Skia memory. 1000 × 1.5MB = ~1.5GB.

2. **AltScreen apps get near-zero row cache hit rate.** \mc\ redraws its entire screen on every focus event, making every cached row picture stale immediately. The cache was accumulating pictures with no benefit.

3. **\_hasSnapshotState\ was not reset on AltScreen switch.** Stale row IDs from the main screen caused all rows to fail their diff check on the first snapshot after switching, triggering a simultaneous bulk rebuild of all \RenderCellSnapshot[]\ arrays.

4. **\CreateRenderThemeSnapshot_NoLock\ allocated a new 16-element \AnsiPalette\ array every frame.**

5. **GlyphAtlas was 2048×2048 per surface** (32MB total), far larger than needed.

## Fixes

| Change | File |
|--------|------|
| Skip row picture cache entirely for AltScreen mode | \TerminalDrawOperation.cs\ |
| \RowImageCache\ default MaxEntries: 1000 → 150 | \RowCache.cs\ |
| Resize-time cache override: \max(1000, rows×10)\ → \max(rows×3, 50)\ | \TerminalView.cs\ |
| Reset \_hasSnapshotState\ in \SwitchToAltScreen\ / \SwitchToMainScreen\ | \TerminalBuffer.AccessAndSnapshot.cs\ |
| Cache 16-element \AnsiPalette\ array per buffer | \TerminalBuffer.ThreadingAndInvalidation.cs\ |
| GlyphAtlas size: 2048² → 1024² | \GlyphAtlas.cs\ |

## Results

| Scenario | Before | After |
|----------|--------|-------|
| mc running, rapid tab switching | ~2000MB peak, unbounded growth | ~600-750MB peak, stable |
| Steady state with mc | ~1600MB | ~560MB |

Working set is now stable — stops growing after initial Skia compositor setup (~560MB including Avalonia swap chain buffers).