### PR TITLE
Memory Optimization: Paged Scrollback, SmallMap, and GlyphCache Tuning

### DIFF
--- a/build_err.txt
+++ b/build_err.txt
@@ -1,0 +1,31 @@
+  Determining projects to restore...
+  All projects are up-to-date for restore.
+C:\Program Files\dotnet\sdk\10.0.200-preview.0.26103.119\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.RuntimeIdentifierInference.targets(383,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [D:\projects\nova2\tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj]
+C:\Program Files\dotnet\sdk\10.0.200-preview.0.26103.119\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.RuntimeIdentifierInference.targets(383,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [D:\projects\nova2\src\NovaTerminal.Replay\NovaTerminal.Replay.csproj]
+C:\Program Files\dotnet\sdk\10.0.200-preview.0.26103.119\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.RuntimeIdentifierInference.targets(383,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [D:\projects\nova2\src\NovaTerminal.Pty\NovaTerminal.Pty.csproj]
+C:\Program Files\dotnet\sdk\10.0.200-preview.0.26103.119\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.RuntimeIdentifierInference.targets(383,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [D:\projects\nova2\src\NovaTerminal.VT\NovaTerminal.VT.csproj]
+C:\Program Files\dotnet\sdk\10.0.200-preview.0.26103.119\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.RuntimeIdentifierInference.targets(383,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [D:\projects\nova2\src\NovaTerminal.Core\NovaTerminal.Core.csproj]
+C:\Program Files\dotnet\sdk\10.0.200-preview.0.26103.119\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.RuntimeIdentifierInference.targets(383,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [D:\projects\nova2\src\NovaTerminal.App\NovaTerminal.App.csproj]
+  NovaTerminal.VT -> D:\projects\nova2\src\NovaTerminal.VT\bin\Release\net10.0\NovaTerminal.VT.dll
+  NovaTerminal.Rendering -> D:\projects\nova2\src\NovaTerminal.Rendering\bin\Release\net10.0\NovaTerminal.Rendering.dll
+  NovaTerminal.Replay -> D:\projects\nova2\src\NovaTerminal.Replay\bin\Release\net10.0\NovaTerminal.Replay.dll
+  NovaTerminal.Pty -> D:\projects\nova2\src\NovaTerminal.Pty\bin\Release\net10.0\NovaTerminal.Pty.dll
+  NovaTerminal.Core -> D:\projects\nova2\src\NovaTerminal.Core\bin\Release\net10.0\NovaTerminal.Core.dll
+  NovaTerminal.App -> D:\projects\nova2\src\NovaTerminal.App\bin\Release\net10.0\NovaTerminal.dll
+D:\projects\nova2\tests\NovaTerminal.Tests\BufferTests\ScrollbackThemeTests.cs(14,42): error CS1739: The best overload for 'TerminalPagePool' does not have a parameter named 'preheatInstances' [D:\projects\nova2\tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj]
+D:\projects\nova2\tests\NovaTerminal.Tests\Buffer\ScrollbackPagesTests.cs(14,42): error CS1739: The best overload for 'TerminalPagePool' does not have a parameter named 'preheatInstances' [D:\projects\nova2\tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj]
+D:\projects\nova2\tests\NovaTerminal.Tests\GraphicsTests.cs(21,31): warning CS8600: Converting null literal or possible null value to non-nullable type. [D:\projects\nova2\tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj]
+D:\projects\nova2\tests\NovaTerminal.Tests\BufferTests\ScrollbackThemeTests.cs(31,30): error CS1729: 'TerminalBuffer' does not contain a constructor that takes 3 arguments [D:\projects\nova2\tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj]
+D:\projects\nova2\tests\NovaTerminal.Tests\GraphicsTests.cs(68,31): warning CS8600: Converting null literal or possible null value to non-nullable type. [D:\projects\nova2\tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj]
+
+Build FAILED.
+
+D:\projects\nova2\tests\NovaTerminal.Tests\GraphicsTests.cs(21,31): warning CS8600: Converting null literal or possible null value to non-nullable type. [D:\projects\nova2\tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj]
+D:\projects\nova2\tests\NovaTerminal.Tests\GraphicsTests.cs(68,31): warning CS8600: Converting null literal or possible null value to non-nullable type. [D:\projects\nova2\tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj]
+D:\projects\nova2\tests\NovaTerminal.Tests\BufferTests\ScrollbackThemeTests.cs(14,42): error CS1739: The best overload for 'TerminalPagePool' does not have a parameter named 'preheatInstances' [D:\projects\nova2\tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj]
+D:\projects\nova2\tests\NovaTerminal.Tests\Buffer\ScrollbackPagesTests.cs(14,42): error CS1739: The best overload for 'TerminalPagePool' does not have a parameter named 'preheatInstances' [D:\projects\nova2\tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj]
+D:\projects\nova2\tests\NovaTerminal.Tests\BufferTests\ScrollbackThemeTests.cs(31,30): error CS1729: 'TerminalBuffer' does not contain a constructor that takes 3 arguments [D:\projects\nova2\tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj]
+    2 Warning(s)
+    3 Error(s)
+
+Time Elapsed 00:00:01.55

--- a/docs/agents/memory-optimization/01_memory_analysis.md
+++ b/docs/agents/memory-optimization/01_memory_analysis.md
@@ -1,0 +1,34 @@
+# Prompt 1 — Analyze Current Memory Usage
+
+You are working on the NovaTerminal codebase.
+
+Goal:
+Identify the main sources of memory usage and allocation churn in the terminal buffer and rendering pipeline.
+
+Tasks:
+
+1. Analyze these components:
+   - TerminalBuffer
+   - TerminalRow
+   - TerminalCell
+   - Scrollback buffer implementation
+   - GlyphCache
+   - RenderCellSnapshot
+   - Any CircularBuffer<T> implementations
+
+2. Produce a technical report including:
+   - Object allocation hotspots
+   - Long-lived memory structures
+   - GC pressure sources
+   - Estimated memory usage per terminal line
+
+3. Specifically measure or estimate:
+   - bytes per cell
+   - bytes per row
+   - memory consumed by 10,000 scrollback lines
+
+4. Provide a list of the top 10 memory optimizations ranked by impact.
+
+Output format:
+Markdown document:
+docs/performance/memory-analysis.md

--- a/docs/agents/memory-optimization/02_scrollback_pages.md
+++ b/docs/agents/memory-optimization/02_scrollback_pages.md
@@ -1,0 +1,52 @@
+# Prompt 2 — Introduce Scrollback Page Architecture
+
+Goal:
+Replace the current scrollback storage model (TerminalRow objects) with a page-based architecture.
+
+Design requirements:
+
+1. Introduce a new structure:
+
+TerminalPage
+- int RowsInPage
+- int Cols
+- TerminalCell[] Cells (RowsInPage * Cols)
+- int UsedRows
+
+2. Implement helper methods:
+
+Span<TerminalCell> GetRowSpan(int rowIndex)
+void ClearRow(int rowIndex)
+
+3. Introduce a new component:
+
+ScrollbackPages
+- Circular buffer of TerminalPage
+- Byte budget limit
+
+Public API:
+
+AppendRow(ReadOnlySpan<TerminalCell> row)
+TryEvictUntilWithinBudget()
+Clear()
+
+4. Add configuration:
+
+MaxScrollbackBytes
+
+Default:
+128 MB
+
+5. Eviction behavior:
+
+When memory exceeds the budget:
+- Evict oldest pages
+- Return them to a page pool
+
+6. Do NOT modify viewport logic yet.
+Viewport rows should still use TerminalRow.
+
+Output:
+New files in Core/Buffer/
+ScrollbackPages.cs
+TerminalPage.cs

--- a/docs/agents/memory-optimization/03_page_pooling.md
+++ b/docs/agents/memory-optimization/03_page_pooling.md
@@ -1,0 +1,36 @@
+# Prompt 3 — Implement Page Pooling
+
+Goal:
+Add pooling for scrollback pages and cell arrays.
+
+Implement:
+
+TerminalPagePool
+- Rent(cols)
+- Return(page)
+
+Use:
+ArrayPool<TerminalCell>
+
+Requirements:
+
+1. Pages must reuse cell arrays.
+2. Page pool must support preheating.
+
+Preheat:
+4 pages per terminal instance.
+
+3. When ScrollbackPages evicts a page:
+Return it to the pool.
+
+4. Add metrics:
+
+ActivePages
+PooledPages
+BytesUsed
+
+Expose metrics via:
+ScrollbackPages.GetMetrics()
+
+Output:
+Core/Buffer/TerminalPagePool.cs

--- a/docs/agents/memory-optimization/04_integrate_terminalbuffer.md
+++ b/docs/agents/memory-optimization/04_integrate_terminalbuffer.md
@@ -1,0 +1,34 @@
+# Prompt 4 — Integrate Page Scrollback with TerminalBuffer
+
+Goal:
+Integrate ScrollbackPages into TerminalBuffer scrolling logic.
+
+Current behavior:
+
+ScrollUpInternal()
+- moves top row to scrollback
+- shifts viewport
+- allocates new bottom row
+
+New behavior:
+
+1. Before shifting viewport:
+
+copy the first row's cells into:
+
+ScrollbackPages.AppendRow(rowSpan)
+
+2. Continue existing viewport logic unchanged.
+
+3. Remove old CircularBuffer<TerminalRow> scrollback storage.
+
+4. Ensure alt-screen logic does NOT append to scrollback.
+
+5. Add tests:
+
+- Scrollback retains correct text
+- Eviction works
+- No regression in terminal behavior
+
+Tests should be added to:
+tests/NovaTerminal.Tests/Buffer/

--- a/docs/agents/memory-optimization/05_replace_row_dictionaries.md
+++ b/docs/agents/memory-optimization/05_replace_row_dictionaries.md
@@ -1,0 +1,32 @@
+# Prompt 5 — Replace Dictionary Side Tables
+
+Goal:
+Reduce memory overhead from per-row dictionaries.
+
+Current implementation:
+
+TerminalRow
+- Dictionary<int,string> extendedText
+- Dictionary<int,string> hyperlinks
+
+Replace with:
+
+SmallMap<int,string>
+
+Implementation rules:
+
+1. For <= 8 entries:
+store in array
+
+2. If entries exceed 8:
+upgrade to Dictionary
+
+3. Provide API:
+
+TryGet(int key)
+Set(int key, string value)
+Remove(int key)
+
+4. Ensure compatibility with existing rendering logic.
+
+Add unit tests.

--- a/docs/agents/memory-optimization/06_glyphcache_keys.md
+++ b/docs/agents/memory-optimization/06_glyphcache_keys.md
@@ -1,0 +1,27 @@
+# Prompt 6 — Optimize GlyphCache Keys
+
+Goal:
+Eliminate string allocations in GlyphCache keys.
+
+Current implementation:
+
+string key = $"{text}|{font}|{size}|{scale}"
+
+Replace with:
+
+struct GlyphKey
+{
+    string Text;
+    int FontId;
+    float Size;
+    float Scale;
+}
+
+Requirements:
+
+1. Implement IEquatable<GlyphKey>
+2. Implement GetHashCode
+3. Replace Dictionary<string, Glyph> with Dictionary<GlyphKey, Glyph>
+4. Ensure glyph cache behavior remains identical.
+
+Add tests to verify cache hits.

--- a/docs/agents/memory-optimization/07_memory_metrics.md
+++ b/docs/agents/memory-optimization/07_memory_metrics.md
@@ -1,0 +1,26 @@
+# Prompt 7 — Add Memory Metrics + Debug View
+
+Goal:
+Add memory diagnostics for terminal buffers.
+
+Implement:
+
+TerminalMemoryMetrics
+
+Include:
+
+ScrollbackBytes
+ScrollbackPages
+ViewportCells
+GlyphCacheSize
+
+Expose through:
+
+TerminalBuffer.GetMemoryMetrics()
+
+Add debug log every 5 seconds:
+
+[TerminalMemory]
+ScrollbackMB=XX
+Pages=XX
+GlyphCache=XX

--- a/docs/agents/memory-optimization/run_memory_optimization.md
+++ b/docs/agents/memory-optimization/run_memory_optimization.md
@@ -1,0 +1,19 @@
+You are implementing the NovaTerminal memory optimization roadmap.
+
+Execute the prompts in order:
+
+1 docs/agents/memory-optimization/01_memory_analysis.md
+2 docs/agents/memory-optimization/02_scrollback_pages.md
+3 docs/agents/memory-optimization/03_page_pooling.md
+4 docs/agents/memory-optimization/04_integrate_terminalbuffer.md
+5 docs/agents/memory-optimization/05_replace_row_dictionaries.md
+6 docs/agents/memory-optimization/06_glyphcache_keys.md
+7 docs/agents/memory-optimization/07_memory_metrics.md
+
+Rules:
+
+- Execute ONE step at a time
+- Wait for confirmation before moving to next step
+- Ensure project builds
+- Ensure tests pass
+- Prefer minimal diff

--- a/docs/performance/memory-analysis.md
+++ b/docs/performance/memory-analysis.md
@@ -1,0 +1,156 @@
+# NovaTerminal Memory Analysis
+
+_Generated: 2026-03-05_
+
+---
+
+## 1. Object Sizes
+
+### TerminalCell (struct, `TerminalBuffer.cs` / `TerminalCell.cs`)
+
+| Field | Type | Size |
+|-------|------|------|
+| `Character` | `char` | 2 B |
+| `Flags` | `ushort` | 2 B |
+| `Fg` | `uint` | 4 B |
+| `Bg` | `uint` | 4 B |
+| **Total** | | **12 B** |
+
+`TerminalCell` is a value type laid out sequentially. No hidden padding needed (all fields naturally aligned). ✅
+
+### TerminalRow (class, `TerminalRow.cs`)
+
+| Component | Size |
+|-----------|------|
+| Object header (sync block + type pointer) | 16 B |
+| `Id` (`long`) | 8 B |
+| `Cells` array reference | 8 B |
+| `IsWrapped` (`bool`) | 1 B (padded to 4 B) |
+| `Revision` (`uint`) | 4 B |
+| `_extendedText` ref (`Dictionary?`) | 8 B |
+| `_hyperlinks` ref (`Dictionary?`) | 8 B |
+| **Shell overhead** | **~48 B** |
+| `TerminalCell[]` array (cols × 12 B + array header ~24 B) | 24 + cols×12 B |
+
+For a 220-column terminal, one `TerminalRow`:
+- 48 B (object) + 24 B (array header) + 220 × 12 = **2,712 B ≈ 2.7 KB**
+
+### RenderCellSnapshot (struct, `RenderSnapshots.cs`)
+
+| Field | Type | Size |
+|-------|------|------|
+| `Character` | `char` | 2 B |
+| `Text` | `string?` (reference) | 8 B |
+| `Foreground`, `Background` | `TermColor` × 2 | ~8 B each |
+| 12 × bool flags | `bool` × 12 | 12 B |
+| `FgIndex`, `BgIndex` | `short` × 2 | 4 B |
+| **Total** | | **~42 B** (padded to ~48 B) |
+
+`RenderCellSnapshot` is significantly larger than `TerminalCell` (4× expansion) because it unpacks all the flags into individual bools and includes a managed object reference.
+
+---
+
+## 2. Memory Consumed by Key Structures
+
+### Viewport (e.g., 50 rows × 220 cols)
+- 50 `TerminalRow` objects = 50 × 2,712 B ≈ **133 KB**
+
+### Alternate Screen Buffer (same dimensions)
+- Always allocated alongside viewport: another **133 KB**
+
+### Scrollback (10,000 lines × 220 cols)
+- `CircularBuffer<TerminalRow>` backing array: 10,000 × 8 B (references) = 80 KB
+- 10,000 `TerminalRow` objects: 10,000 × 2,712 B ≈ **27.1 MB**
+
+### Main Screen Scrollback (separate `CircularBuffer`)
+- Another 10,000-slot `CircularBuffer` allocated at construction even though AltScreen rarely fills it: **~27 MB peak**, same structure
+
+### RenderRowSnapshot[] (per render frame)
+- `PooledArray<RenderRowSnapshot>` from `ArrayPool` — reused ✅
+- But `RenderRowSnapshot.Cells = new RenderCellSnapshot[cols]` is allocated **per row that changed**
+  - Each newly-populated row: 220 × 48 B ≈ **10.5 KB**
+  - For a full-screen repaint: 50 × 10.5 KB ≈ **525 KB per frame**
+
+### GlyphAtlas (2 × 1024² RGBA8888 surfaces)
+- Each surface: 1024 × 1024 × 4 = **4 MB**
+- Two surfaces (alpha + color): **8 MB** pinned in GPU/Skia memory
+
+### GlyphCache `_entries` dictionary
+- One `CacheEntry` per unique (text, font, size, skew, scale) combination
+- Key string allocated on each `GetOrAdd` call that misses: `$"{text}|{family}|{size}|{skew}|{scale}"`
+
+---
+
+## 3. Allocation Hotspots (GC Pressure Sources)
+
+### 🔴 Critical
+
+| # | Location | Allocation | Frequency |
+|---|----------|------------|-----------|
+| 1 | `ScrollUpInternal()` | `new TerminalRow(Cols, ...)` — a new heap object per scroll line | Every LF when buffer full |
+| 2 | `InsertLines()` / `DeleteLines()` | `new TerminalRow(Cols, ...)` per inserted/deleted line | On every IL/DL escape |
+| 3 | `GetRowSnapshot()` / `PopulateRenderCellsFromRow_NoLock()` | `new RenderCellSnapshot[bufferCols]` per dirty row | Every render frame |
+| 4 | `WriteGraphemeInternal()` (surrogate pairs) | `new string(new[] { hi, lo })` per surrogate pair | Many times/sec during output |
+| 5 | `WriteContentCore()` | `StringInfo.GetTextElementEnumerator(text)` alloc per call | On every VT escape handler dispatch |
+
+### 🟡 Moderate
+
+| # | Location | Allocation | Frequency |
+|---|----------|------------|-----------|
+| 6 | `GlyphCache.GetOrAdd()` | Interpolated key string `$"{text}|..."` on every cache call | Per unique rendered glyph |
+| 7 | `GlyphCache.GetAtlasImages()` | `SKImage` snapshot via `_atlas.GenerateAlphaImage()` | On every glyph cache change |
+| 8 | `TerminalRow._extendedText` | Lazy `new Dictionary<int,string>()` per row with extended graphemes | Whenever emoji/CJK written |
+| 9 | `FindMatches()` | `new StringBuilder()`, `new List<int>()` per row during search | On each search query |
+| 10 | `GetVisibleImagesSnapshot()` | `new List<RenderImageSnapshot>()` per frame | Every render |
+
+---
+
+## 4. Long-Lived Memory Structures
+
+| Structure | Estimated Size | Lifetime |
+|-----------|---------------|----------|
+| `_scrollback` (main) | up to 27 MB | Session lifetime |
+| `_mainScreenScrollback` | up to 27 MB | Session lifetime (even fully unused during AltScreen) |
+| `_altScreen` rows | ~133 KB | Session lifetime (always allocated) |
+| `GlyphAtlas` two SKSurfaces | 8 MB | Session lifetime (reset on full, not freed) |
+| `GlyphCache._entries` dictionary | Variable (unbounded growth within atlas capacity) | Until atlas reset |
+
+---
+
+## 5. Estimated Memory Per Terminal Line
+
+```
+Per TerminalRow (220 cols, typical terminal):
+  TerminalRow object overhead:  48 B
+  TerminalCell[] array header:  24 B
+  220 × TerminalCell:        2,640 B
+  Extended text dict (empty):    0 B (null)
+  Hyperlinks dict (empty):       0 B (null)
+  ────────────────────────────────────
+  Total:                     2,712 B ≈ 2.7 KB/line
+```
+
+```
+10,000 scrollback lines:
+  TerminalRow objects:        2,712 × 10,000 = 27.1 MB
+  CircularBuffer<> backing:       8 × 10,000 =   80 KB
+  ──────────────────────────────────────────────────
+  Total:                               ≈ 27.2 MB
+```
+
+---
+
+## 6. Top 10 Optimisations (Ranked by Impact)
+
+| Rank | Optimisation | Estimated Saving | Complexity |
+|------|-------------|-----------------|------------|
+| **1** | **Segment/page-based scrollback** — store scrollback as fixed-size pages of `TerminalCell` values (not boxed `TerminalRow` objects). Converts 10,000 heap objects into one flat array per page. | **~25 MB** (eliminates per-row heap overhead + GC enumeration) | Medium |
+| **2** | **Pool `TerminalRow` objects** — instead of `new TerminalRow(Cols, …)` on every scroll/insert, return rows to an `ObjectPool<TerminalRow>` and reset in-place. | **~Eliminate scroll GC churn** | Low |
+| **3** | **Pool `RenderCellSnapshot[]` arrays** — `GetRowSnapshot` allocates a fresh `RenderCellSnapshot[cols]` per dirty row. Use `ArrayPool<RenderCellSnapshot>.Shared`. | **~500 KB per-frame pressure eliminated** | Low |
+| **4** | **Collapse `_mainScreenScrollback` allocation** — `_mainScreenScrollback` is allocated at `MaxHistory = 10,000` slots at construction even though it is only ever used when AltScreen is active (and is never filled to capacity in typical use). Defer allocation or shrink default. | **~27 MB worst-case** | Low |
+| **5** | **Intern/pool GlyphCache key strings** — instead of `$"{text}|{family}|…"` allocation per cache lookup, use a `ValueTuple` struct key or pre-allocated key buffer. | **Eliminate key alloc on every rendered glyph** | Low |
+| **6** | **Convert `RenderCellSnapshot` fields from bool to packed ushort flags** — 12 individual `bool` fields waste ~10 B each due to alignment. Pack into a `ushort` (same as `TerminalCell.Flags`) to shrink from ~48 B to ~24 B. | **~50% snapshot memory reduction** | Low |
+| **7** | **Lazy / sparse alt-screen buffer** — the alt-screen is always pre-allocated (`Rows × new TerminalRow`). Only allocate rows on demand; keep a single blank-row singleton for unwritten rows. | **~100 KB** | Medium |
+| **8** | **Reduce `TerminalRow` dictionary pressure** — `_extendedText` and `_hyperlinks` use `Dictionary<int,string>` which has high per-instance overhead (~176 B minimum). Replace with a small sorted array for the common case of ≤ 4 extended cells per row. | **Per-row overhead for emoji-heavy content** | Medium |
+| **9** | **GlyphAtlas LRU eviction instead of full reset** — the current strategy clears the whole atlas when it overflows. An LRU shelf eviction would reduce `SKImage.Snapshot()` re-generation (each snapshot = 4 MB GPU→CPU copy). | **Reduce snapshot churn** | High |
+| **10** | **StringBuilder pooling in `FindMatches()`** — search allocates a new `StringBuilder` and `List<int>` colMapping per row. Use `ArrayPool` / `StringBuilderPool` to amortize these. | **Low absolute bytes, high frequency** | Low |

--- a/docs/performance/memory-analysis.md
+++ b/docs/performance/memory-analysis.md
@@ -154,3 +154,36 @@ Per TerminalRow (220 cols, typical terminal):
 | **8** | **Reduce `TerminalRow` dictionary pressure** — `_extendedText` and `_hyperlinks` use `Dictionary<int,string>` which has high per-instance overhead (~176 B minimum). Replace with a small sorted array for the common case of ≤ 4 extended cells per row. | **Per-row overhead for emoji-heavy content** | Medium |
 | **9** | **GlyphAtlas LRU eviction instead of full reset** — the current strategy clears the whole atlas when it overflows. An LRU shelf eviction would reduce `SKImage.Snapshot()` re-generation (each snapshot = 4 MB GPU→CPU copy). | **Reduce snapshot churn** | High |
 | **10** | **StringBuilder pooling in `FindMatches()`** — search allocates a new `StringBuilder` and `List<int>` colMapping per row. Use `ArrayPool` / `StringBuilderPool` to amortize these. | **Low absolute bytes, high frequency** | Low |
+
+---
+
+## 7. PR17 Follow-up Fixes (2026-03-06)
+
+These targeted fixes were applied after the initial PR17 memory optimization pass to address correctness and performance gaps.
+
+### Fix 1 — Theme-change correctness for paged scrollback
+**Problem:** `TerminalBuffer.Maintenance.cs` previously skipped theme updates for scrollback rows (marked TODO). After switching to paged slab storage, the scrollback no longer has live `TerminalRow` objects, so the theme update path was silently broken.
+
+**Fix:**
+- Added `UpdateThemeDefaults(uint newFg, uint newBg)` to `TerminalPage` — O(n) walk over `UsedRows × Cols` cells, replacing `Fg`/`Bg` only where `IsDefaultForeground`/`IsDefaultBackground` flags are set.
+- Added `UpdateThemeDefaults(TerminalTheme old, TerminalTheme new)` to `ScrollbackPages` — iterates all active pages.
+- Wired this into `TerminalBuffer.UpdateThemeColors` to replace the old skipped comment block.
+- **Tests:** `ScrollbackThemeTests.UpdateThemeDefaults_UpdatesDefaultColoredCells`
+
+### Fix 2 — O(1) sequential row access in `ScrollbackPages.GetRow`
+**Problem:** `GetRow(logicalIndex)` did a linear page scan from `_pages.First` on every call. During reflow, rows are accessed sequentially (index 0, 1, 2, …), turning the full reflow pass into O(n × p) where p = page count ≈ O(n²) for a deep scrollback.
+
+**Fix:** Added a two-field cursor cache:
+- `TerminalPage? _lastAccessedPage` + `long _lastAccessedPageStartAbsRow`
+- On each `GetRow` call, check if the requested `absRow` falls within the cached page bounds — O(1) hit. On miss, fall through to linear scan and update the cache.
+- Cache is reset in `Clear()` and invalidated implicitly if the page is returned.
+- **Tests:** `ScrollbackPagesTests.GetRow_SequentialAccess_AvoidsON2Performance`
+
+### Fix 3 — Harden eviction image-shift int overflow
+**Problem:** `newlyEvicted` is a `long`. Casting directly via `(int)newlyEvicted` overflows silently for very large evictions (> 2 billion rows, theoretically possible in stress scenarios). The resulting negative delta would incorrectly shift images up instead of pruning them.
+
+**Fix:** Two-line clamp before cast in both `ScrollUpInternal` (`WritePath.cs`) and the resize shrink path (`ResizeAndReflow.cs`):
+```csharp
+int delta = newlyEvicted > int.MaxValue ? int.MaxValue : (int)newlyEvicted;
+img.CellY -= delta;
+```

--- a/src/NovaTerminal.App/Core/TerminalView.cs
+++ b/src/NovaTerminal.App/Core/TerminalView.cs
@@ -64,6 +64,8 @@ namespace NovaTerminal.Core
 
             _cursorBlinkTimer = new DispatcherTimer(TimeSpan.FromMilliseconds(530), DispatcherPriority.Render, OnCursorBlinkTick);
             _scrollAnimationTimer = new DispatcherTimer(TimeSpan.FromMilliseconds(16), DispatcherPriority.Render, OnScrollAnimationTick);
+            _metricsTimer = new DispatcherTimer(TimeSpan.FromSeconds(5), DispatcherPriority.Background, OnMetricsTimerTick);
+            _metricsTimer.Start();
 
             DragDrop.SetAllowDrop(this, true);
             AddHandler(DragDrop.DragOverEvent, OnDragOver);
@@ -229,6 +231,7 @@ namespace NovaTerminal.Core
         private int _lastCursorRow = -1;
         private int _lastCursorCol = -1;
         private long _lastHudUpdateTicks = 0;
+        private readonly DispatcherTimer _metricsTimer;
 
         private void OnRenderTimerTick(object? sender, EventArgs e)
         {
@@ -336,6 +339,22 @@ namespace NovaTerminal.Core
             int delta = _targetScrollOffset - _scrollOffset;
             int step = Math.Sign(delta) * Math.Max(1, Math.Abs(delta) / 3);
             ScrollOffset = _scrollOffset + step;
+        }
+
+        private void OnMetricsTimerTick(object? sender, EventArgs e)
+        {
+            if (_buffer == null) return;
+
+            var m = _buffer.GetMemoryMetrics(_glyphCache.EntryCount, _glyphCache.AtlasByteSize);
+            
+            // Format for easy log parsing/grep
+            TerminalLogger.Log(
+                $"[TerminalMemory] " +
+                $"ScrollbackMB={m.ScrollbackBytes / 1024.0 / 1024.0:F2} | " +
+                $"Pages={m.ActivePages} (pooled={m.PooledPages}) | " +
+                $"ViewportCells={m.ViewportCells} | " +
+                $"GlyphCache={m.GlyphCacheEntries} entries ({m.GlyphCacheAtlasBytes / 1024.0 / 1024.0:F1} MB atlas)"
+            );
         }
 
         public ShellOverride ShellOverride { get; set; } = ShellOverride.Auto;

--- a/src/NovaTerminal.Rendering/GlyphAtlas.cs
+++ b/src/NovaTerminal.Rendering/GlyphAtlas.cs
@@ -19,7 +19,7 @@ namespace NovaTerminal.Core
 
     public class GlyphAtlas : IDisposable
     {
-        private const int AtlasSize = 1024;
+        public const int AtlasSize = 1024;
         private readonly SKSurface _alphaSurface;
         private readonly SKSurface _colorSurface;
 

--- a/src/NovaTerminal.Rendering/GlyphCache.cs
+++ b/src/NovaTerminal.Rendering/GlyphCache.cs
@@ -13,13 +13,52 @@ namespace NovaTerminal.Core
             public long LastUsed;
         }
 
+        private readonly struct GlyphKey : IEquatable<GlyphKey>
+        {
+            public readonly string Text;
+            public readonly SKTypeface Typeface;
+            public readonly float Size;
+            public readonly float Skew;
+            public readonly float Scale;
+
+            public GlyphKey(string text, SKTypeface typeface, float size, float skew, float scale)
+            {
+                Text = text;
+                Typeface = typeface;
+                Size = size;
+                Skew = skew;
+                Scale = scale;
+            }
+
+            public bool Equals(GlyphKey other)
+            {
+                return Text == other.Text &&
+                       Typeface == other.Typeface &&
+                       Size.Equals(other.Size) &&
+                       Skew.Equals(other.Skew) &&
+                       Scale.Equals(other.Scale);
+            }
+
+            public override bool Equals(object? obj) => obj is GlyphKey other && Equals(other);
+
+            public override int GetHashCode()
+            {
+                var hash = new HashCode();
+                hash.Add(Text);
+                hash.Add(Typeface);
+                hash.Add(Size);
+                hash.Add(Skew);
+                hash.Add(Scale);
+                return hash.ToHashCode();
+            }
+        }
+
         private readonly object _lock = new();
         private readonly List<SKImage> _disposalQueue = new();
         private readonly GlyphAtlas _atlas;
-        private readonly Dictionary<string, CacheEntry> _entries = new();
+        private readonly Dictionary<GlyphKey, CacheEntry> _entries = new();
         private long _usageCounter = 0;
 
-        // Key format: "Text|FontName|Size|Skew|Scale"
         // Color is NOT part of the key for Alpha8 as we color it during DrawAtlas.
 
         public GlyphCache()
@@ -29,9 +68,11 @@ namespace NovaTerminal.Core
 
         public (SKRect Rect, AtlasType Type)? GetOrAdd(string text, SKFont font, float scale)
         {
+            if (string.IsNullOrEmpty(text)) return null;
+
             lock (_lock)
             {
-                string key = $"{text}|{font.Typeface.FamilyName}|{font.Size}|{font.SkewX}|{scale}";
+                var key = new GlyphKey(text, font.Typeface, font.Size, font.SkewX, scale);
 
                 if (_entries.TryGetValue(key, out var entry))
                 {

--- a/src/NovaTerminal.Rendering/GlyphCache.cs
+++ b/src/NovaTerminal.Rendering/GlyphCache.cs
@@ -61,6 +61,9 @@ namespace NovaTerminal.Core
 
         // Color is NOT part of the key for Alpha8 as we color it during DrawAtlas.
 
+        public int EntryCount => _entries.Count;
+        public long AtlasByteSize => GlyphAtlas.AtlasSize * GlyphAtlas.AtlasSize * 4 * 2; // 2 surfaces, RGBA8888
+
         public GlyphCache()
         {
             _atlas = new GlyphAtlas();

--- a/src/NovaTerminal.VT/Buffer/ScrollbackPages.cs
+++ b/src/NovaTerminal.VT/Buffer/ScrollbackPages.cs
@@ -58,6 +58,10 @@ namespace NovaTerminal.Core.Storage
         private long _totalRowsAppended;
         private long _totalRowsEvicted;
 
+        // Cache for O(1) sequential GetRow access during reflow
+        private TerminalPage? _lastAccessedPage;
+        private long _lastAccessedPageStartAbsRow;
+
         // ── Properties ───────────────────────────────────────────────────────────
 
         /// <summary>Number of rows currently accessible (after eviction).</summary>
@@ -158,6 +162,18 @@ namespace NovaTerminal.Core.Storage
                 throw new ArgumentOutOfRangeException(nameof(logicalIndex));
 
             long absRow = _totalRowsEvicted + logicalIndex;
+            
+            // Fast path: Sequential access cache
+            if (_lastAccessedPage != null && !_lastAccessedPage.IsReturned)
+            {
+                long pageEndAbs = _lastAccessedPageStartAbsRow + _lastAccessedPage.UsedRows;
+                if (absRow >= _lastAccessedPageStartAbsRow && absRow < pageEndAbs)
+                {
+                    int rowInPage = (int)(absRow - _lastAccessedPageStartAbsRow);
+                    return _lastAccessedPage.GetRowSpanReadOnly(rowInPage);
+                }
+            }
+
             long pageStartAbs = _totalRowsEvicted;
 
             foreach (var page in _pages)
@@ -166,6 +182,8 @@ namespace NovaTerminal.Core.Storage
                 if (absRow < pageEndAbs)
                 {
                     int rowInPage = (int)(absRow - pageStartAbs);
+                    _lastAccessedPage = page;
+                    _lastAccessedPageStartAbsRow = pageStartAbs;
                     return page.GetRowSpanReadOnly(rowInPage);
                 }
                 pageStartAbs = pageEndAbs;
@@ -235,6 +253,23 @@ namespace NovaTerminal.Core.Storage
             _currentBytes = 0;
             _totalRowsAppended = 0;
             _totalRowsEvicted = 0;
+            
+            _lastAccessedPage = null;
+            _lastAccessedPageStartAbsRow = 0;
+        }
+
+        /// <summary>
+        /// Updates the default foreground and background colors for all cells currently retained.
+        /// This is allowed to be a slower full-scan because theme changes are infrequent.
+        /// </summary>
+        public void UpdateThemeDefaults(TerminalTheme oldTheme, TerminalTheme newTheme)
+        {
+            uint fgUint = newTheme.Foreground.ToUint();
+            uint bgUint = newTheme.Background.ToUint();
+            foreach (var page in _pages)
+            {
+                page.UpdateThemeDefaults(fgUint, bgUint);
+            }
         }
 
         /// <summary>

--- a/src/NovaTerminal.VT/Buffer/ScrollbackPages.cs
+++ b/src/NovaTerminal.VT/Buffer/ScrollbackPages.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+
+namespace NovaTerminal.Core.Buffer
+{
+    /// <summary>
+    /// Page-based scrollback store that replaces the per-row <see cref="CircularBuffer{TerminalRow}"/>.
+    ///
+    /// Rows are packed into <see cref="TerminalPage"/> slabs (default 64 rows each), so adding
+    /// 10,000 scrollback lines allocates ~157 page objects instead of 10,000 <c>TerminalRow</c>
+    /// objects, reducing GC overhead dramatically.
+    ///
+    /// Memory is bounded by <see cref="MaxScrollbackBytes"/>. When the budget is exceeded the
+    /// oldest pages are evicted and returned to the <see cref="TerminalPagePool"/>.
+    /// </summary>
+    public sealed class ScrollbackPages
+    {
+        // ── Configuration ────────────────────────────────────────────────────────
+        /// <summary>Maximum bytes of cell data to retain. Default: 128 MB.</summary>
+        public long MaxScrollbackBytes { get; set; }
+
+        // ── Internals ────────────────────────────────────────────────────────────
+        private readonly int _cols;
+        private readonly int _rowsPerPage;
+        private readonly TerminalPagePool _pool;
+
+        /// <summary>
+        /// Ordered list of pages, oldest first.
+        /// We use a <see cref="LinkedList{T}"/> so that eviction at the front is O(1).
+        /// </summary>
+        private readonly LinkedList<TerminalPage> _pages = new();
+
+        private long _currentBytes;
+
+        // Logical row count (the number of appended rows still retained after eviction).
+        private long _totalRowsAppended;   // ever appended
+        private long _totalRowsEvicted;    // already evicted from the front
+
+        /// <summary>
+        /// Number of rows currently accessible in the scrollback (after eviction).
+        /// </summary>
+        public int Count => (int)Math.Min(_totalRowsAppended - _totalRowsEvicted, int.MaxValue);
+
+        /// <summary>
+        /// Approximate byte consumption of retained cell data.
+        /// </summary>
+        public long CurrentBytes => _currentBytes;
+
+        // ── Construction ─────────────────────────────────────────────────────────
+
+        /// <param name="cols">Number of columns per row (must match the buffer).</param>
+        /// <param name="pool">Shared pool from which pages are rented and returned.</param>
+        /// <param name="maxScrollbackBytes">Byte budget; defaults to 128 MB.</param>
+        /// <param name="rowsPerPage">Rows per page slab; defaults to 64.</param>
+        public ScrollbackPages(
+            int cols,
+            TerminalPagePool pool,
+            long maxScrollbackBytes = 128L * 1024 * 1024,
+            int rowsPerPage = TerminalPageConstants.DefaultRowsPerPage)
+        {
+            if (cols <= 0) throw new ArgumentOutOfRangeException(nameof(cols));
+            _cols = cols;
+            _pool = pool ?? throw new ArgumentNullException(nameof(pool));
+            _rowsPerPage = rowsPerPage;
+            MaxScrollbackBytes = maxScrollbackBytes;
+        }
+
+        // ── Public API ───────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Appends a row to the scrollback. If the current page is full, a new page
+        /// is rented from the pool. Budget eviction is applied afterwards.
+        /// </summary>
+        /// <param name="row">Read-only span of exactly <see cref="_cols"/> cells.</param>
+        public void AppendRow(ReadOnlySpan<TerminalCell> row)
+        {
+            if (row.Length != _cols)
+                throw new ArgumentException($"Row length {row.Length} must equal Cols {_cols}.", nameof(row));
+
+            // Ensure there is a page with available space.
+            if (_pages.Last == null || _pages.Last.Value.IsFull)
+            {
+                var page = _pool.Rent(_rowsPerPage, _cols);
+                _pages.AddLast(page);
+                _currentBytes += page.ByteSize;
+            }
+
+            var currentPage = _pages.Last!.Value;
+            row.CopyTo(currentPage.GetRowSpan(currentPage.UsedRows));
+            currentPage.UsedRows++;
+            _totalRowsAppended++;
+
+            TryEvictUntilWithinBudget();
+        }
+
+        /// <summary>
+        /// Retrieves a read-only span of cells for the given logical row index
+        /// (0 = oldest retained row, Count-1 = newest row).
+        /// </summary>
+        public ReadOnlySpan<TerminalCell> GetRow(int logicalIndex)
+        {
+            if ((uint)logicalIndex >= (uint)Count)
+                throw new ArgumentOutOfRangeException(nameof(logicalIndex));
+
+            // The absolute row number (ignoring evictions).
+            long absRow = _totalRowsEvicted + logicalIndex;
+
+            // Walk pages from the oldest to find which page owns this absolute row.
+            long pageStartAbs = _totalRowsEvicted - GetEvictedRowsInCurrentFront();
+            foreach (var page in _pages)
+            {
+                // Compute how many rows this page starts at (absolute).
+                // We track this via walking: pageStartAbs updated each iteration.
+                long pageEndAbs = pageStartAbs + page.UsedRows;
+                if (absRow < pageEndAbs)
+                {
+                    int rowInPage = (int)(absRow - pageStartAbs);
+                    return page.GetRowSpanReadOnly(rowInPage);
+                }
+                pageStartAbs = pageEndAbs;
+            }
+
+            // Should not happen if Count is correct.
+            throw new InvalidOperationException($"Row {logicalIndex} not found in pages (absRow={absRow}).");
+        }
+
+        /// <summary>
+        /// Copies the cells of a logical row into <paramref name="destination"/>.
+        /// </summary>
+        public void CopyRowTo(int logicalIndex, Span<TerminalCell> destination)
+        {
+            GetRow(logicalIndex).CopyTo(destination);
+        }
+
+        /// <summary>
+        /// Evicts oldest pages until total bytes are within budget.
+        /// Returned pages go back to the pool.
+        /// </summary>
+        public void TryEvictUntilWithinBudget()
+        {
+            while (_currentBytes > MaxScrollbackBytes && _pages.Count > 0)
+            {
+                var oldest = _pages.First!.Value;
+                _pages.RemoveFirst();
+                _totalRowsEvicted += oldest.UsedRows;
+                _currentBytes -= oldest.ByteSize;
+                _pool.Return(oldest);
+            }
+        }
+
+        /// <summary>
+        /// Removes all scrollback data and returns all pages to the pool.
+        /// </summary>
+        public void Clear()
+        {
+            foreach (var page in _pages)
+                _pool.Return(page);
+
+            _pages.Clear();
+            _currentBytes = 0;
+            _totalRowsAppended = 0;
+            _totalRowsEvicted = 0;
+        }
+
+        // ── Private helpers ──────────────────────────────────────────────────────
+
+        /// <summary>
+        /// When pages are evicted, _totalRowsEvicted tracks absolute rows gone.
+        /// However, the first live page may not start exactly at _totalRowsEvicted
+        /// if some partial-page tracking is needed.  In this design we evict whole
+        /// pages, so the first page always starts at the current _totalRowsEvicted.
+        /// This helper therefore returns 0.
+        /// </summary>
+        private static long GetEvictedRowsInCurrentFront() => 0;
+    }
+}

--- a/src/NovaTerminal.VT/Buffer/ScrollbackPages.cs
+++ b/src/NovaTerminal.VT/Buffer/ScrollbackPages.cs
@@ -4,11 +4,33 @@ using System.Collections.Generic;
 namespace NovaTerminal.Core.Buffer
 {
     /// <summary>
+    /// Metrics snapshot for <see cref="ScrollbackPages"/>.
+    /// </summary>
+    public readonly struct ScrollbackMetrics
+    {
+        /// <summary>Number of rows currently retained in the scrollback.</summary>
+        public int RowCount { get; init; }
+
+        /// <summary>Number of page objects currently in use (rented from the pool).</summary>
+        public int ActivePages { get; init; }
+
+        /// <summary>Number of pages waiting in the pool, ready for reuse.</summary>
+        public int PooledPages { get; init; }
+
+        /// <summary>Total bytes consumed by live cell data.</summary>
+        public long BytesUsed { get; init; }
+
+        /// <summary>Configured byte budget (maximum allowed).</summary>
+        public long MaxBytes { get; init; }
+    }
+
+    /// <summary>
     /// Page-based scrollback store that replaces the per-row <see cref="CircularBuffer{TerminalRow}"/>.
     ///
     /// Rows are packed into <see cref="TerminalPage"/> slabs (default 64 rows each), so adding
     /// 10,000 scrollback lines allocates ~157 page objects instead of 10,000 <c>TerminalRow</c>
-    /// objects, reducing GC overhead dramatically.
+    /// objects. Each page's backing <c>TerminalCell[]</c> is rented from
+    /// <see cref="System.Buffers.ArrayPool{T}.Shared"/> for further allocation reuse.
     ///
     /// Memory is bounded by <see cref="MaxScrollbackBytes"/>. When the budget is exceeded the
     /// oldest pages are evicted and returned to the <see cref="TerminalPagePool"/>.
@@ -26,24 +48,22 @@ namespace NovaTerminal.Core.Buffer
 
         /// <summary>
         /// Ordered list of pages, oldest first.
-        /// We use a <see cref="LinkedList{T}"/> so that eviction at the front is O(1).
+        /// <see cref="LinkedList{T}"/> gives O(1) front eviction.
         /// </summary>
         private readonly LinkedList<TerminalPage> _pages = new();
 
         private long _currentBytes;
 
-        // Logical row count (the number of appended rows still retained after eviction).
-        private long _totalRowsAppended;   // ever appended
-        private long _totalRowsEvicted;    // already evicted from the front
+        // Absolute row counters (never reset on eviction so indexing stays correct).
+        private long _totalRowsAppended;
+        private long _totalRowsEvicted;
 
-        /// <summary>
-        /// Number of rows currently accessible in the scrollback (after eviction).
-        /// </summary>
+        // ── Properties ───────────────────────────────────────────────────────────
+
+        /// <summary>Number of rows currently accessible (after eviction).</summary>
         public int Count => (int)Math.Min(_totalRowsAppended - _totalRowsEvicted, int.MaxValue);
 
-        /// <summary>
-        /// Approximate byte consumption of retained cell data.
-        /// </summary>
+        /// <summary>Approximate byte consumption of retained cell data.</summary>
         public long CurrentBytes => _currentBytes;
 
         // ── Construction ─────────────────────────────────────────────────────────
@@ -80,7 +100,7 @@ namespace NovaTerminal.Core.Buffer
             // Ensure there is a page with available space.
             if (_pages.Last == null || _pages.Last.Value.IsFull)
             {
-                var page = _pool.Rent(_rowsPerPage, _cols);
+                var page = _pool.Rent(_cols, _rowsPerPage);
                 _pages.AddLast(page);
                 _currentBytes += page.ByteSize;
             }
@@ -102,15 +122,11 @@ namespace NovaTerminal.Core.Buffer
             if ((uint)logicalIndex >= (uint)Count)
                 throw new ArgumentOutOfRangeException(nameof(logicalIndex));
 
-            // The absolute row number (ignoring evictions).
             long absRow = _totalRowsEvicted + logicalIndex;
+            long pageStartAbs = _totalRowsEvicted;
 
-            // Walk pages from the oldest to find which page owns this absolute row.
-            long pageStartAbs = _totalRowsEvicted - GetEvictedRowsInCurrentFront();
             foreach (var page in _pages)
             {
-                // Compute how many rows this page starts at (absolute).
-                // We track this via walking: pageStartAbs updated each iteration.
                 long pageEndAbs = pageStartAbs + page.UsedRows;
                 if (absRow < pageEndAbs)
                 {
@@ -120,7 +136,6 @@ namespace NovaTerminal.Core.Buffer
                 pageStartAbs = pageEndAbs;
             }
 
-            // Should not happen if Count is correct.
             throw new InvalidOperationException($"Row {logicalIndex} not found in pages (absRow={absRow}).");
         }
 
@@ -133,7 +148,7 @@ namespace NovaTerminal.Core.Buffer
         }
 
         /// <summary>
-        /// Evicts oldest pages until total bytes are within budget.
+        /// Evicts oldest pages until total bytes are within <see cref="MaxScrollbackBytes"/>.
         /// Returned pages go back to the pool.
         /// </summary>
         public void TryEvictUntilWithinBudget()
@@ -162,15 +177,16 @@ namespace NovaTerminal.Core.Buffer
             _totalRowsEvicted = 0;
         }
 
-        // ── Private helpers ──────────────────────────────────────────────────────
-
         /// <summary>
-        /// When pages are evicted, _totalRowsEvicted tracks absolute rows gone.
-        /// However, the first live page may not start exactly at _totalRowsEvicted
-        /// if some partial-page tracking is needed.  In this design we evict whole
-        /// pages, so the first page always starts at the current _totalRowsEvicted.
-        /// This helper therefore returns 0.
+        /// Returns a point-in-time snapshot of memory metrics for diagnostics.
         /// </summary>
-        private static long GetEvictedRowsInCurrentFront() => 0;
+        public ScrollbackMetrics GetMetrics() => new ScrollbackMetrics
+        {
+            RowCount = Count,
+            ActivePages = _pool.ActivePages,
+            PooledPages = _pool.PooledPages,
+            BytesUsed = _currentBytes,
+            MaxBytes = MaxScrollbackBytes,
+        };
     }
 }

--- a/src/NovaTerminal.VT/Buffer/ScrollbackPages.cs
+++ b/src/NovaTerminal.VT/Buffer/ScrollbackPages.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace NovaTerminal.Core.Buffer
+namespace NovaTerminal.Core.Storage
 {
     /// <summary>
     /// Metrics snapshot for <see cref="ScrollbackPages"/>.
@@ -63,6 +63,12 @@ namespace NovaTerminal.Core.Buffer
         /// <summary>Number of rows currently accessible (after eviction).</summary>
         public int Count => (int)Math.Min(_totalRowsAppended - _totalRowsEvicted, int.MaxValue);
 
+        /// <summary>Total rows that have ever been appended to this scrollback.</summary>
+        public long TotalRowsAppended => _totalRowsAppended;
+
+        /// <summary>Total rows that have been evicted from this scrollback due to budget limits.</summary>
+        public long TotalRowsEvicted => _totalRowsEvicted;
+
         /// <summary>Approximate byte consumption of retained cell data.</summary>
         public long CurrentBytes => _currentBytes;
 
@@ -92,7 +98,8 @@ namespace NovaTerminal.Core.Buffer
         /// is rented from the pool. Budget eviction is applied afterwards.
         /// </summary>
         /// <param name="row">Read-only span of exactly <see cref="_cols"/> cells.</param>
-        public void AppendRow(ReadOnlySpan<TerminalCell> row)
+        /// <param name="isWrapped">Whether this row is wrapped (flows into the next).</param>
+        public void AppendRow(ReadOnlySpan<TerminalCell> row, bool isWrapped = false)
         {
             if (row.Length != _cols)
                 throw new ArgumentException($"Row length {row.Length} must equal Cols {_cols}.", nameof(row));
@@ -106,11 +113,39 @@ namespace NovaTerminal.Core.Buffer
             }
 
             var currentPage = _pages.Last!.Value;
-            row.CopyTo(currentPage.GetRowSpan(currentPage.UsedRows));
+            int rowIndex = currentPage.UsedRows;
+            row.CopyTo(currentPage.GetRowSpan(rowIndex));
+            currentPage.SetRowWrapped(rowIndex, isWrapped);
             currentPage.UsedRows++;
             _totalRowsAppended++;
 
             TryEvictUntilWithinBudget();
+        }
+
+        /// <summary>
+        /// Retrieves a read-only span of cells for the given logical row index
+        /// (0 = oldest retained row, Count-1 = newest row).
+        /// </summary>
+        public bool IsRowWrapped(int logicalIndex)
+        {
+            if ((uint)logicalIndex >= (uint)Count)
+                throw new ArgumentOutOfRangeException(nameof(logicalIndex));
+
+            long absRow = _totalRowsEvicted + logicalIndex;
+            long pageStartAbs = _totalRowsEvicted;
+
+            foreach (var page in _pages)
+            {
+                long pageEndAbs = pageStartAbs + page.UsedRows;
+                if (absRow < pageEndAbs)
+                {
+                    int rowInPage = (int)(absRow - pageStartAbs);
+                    return page.IsRowWrapped(rowInPage);
+                }
+                pageStartAbs = pageEndAbs;
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -145,6 +180,31 @@ namespace NovaTerminal.Core.Buffer
         public void CopyRowTo(int logicalIndex, Span<TerminalCell> destination)
         {
             GetRow(logicalIndex).CopyTo(destination);
+        }
+
+        /// <summary>
+        /// Attempts to remove the newest row from the scrollback (the reverse of AppendRow).
+        /// Used during vertical resize (height grow) to pull history back into the viewport.
+        /// </summary>
+        public bool TryPopLastRow(Span<TerminalCell> destination)
+        {
+            if (_pages.Last == null || _pages.Last.Value.UsedRows == 0)
+                return false;
+
+            var page = _pages.Last.Value;
+            page.GetRowSpanReadOnly(page.UsedRows - 1).CopyTo(destination);
+            
+            page.UsedRows--;
+            _totalRowsAppended--;
+
+            if (page.UsedRows == 0)
+            {
+                _pages.RemoveLast();
+                _currentBytes -= page.ByteSize;
+                _pool.Return(page);
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/src/NovaTerminal.VT/Buffer/SmallMap.cs
+++ b/src/NovaTerminal.VT/Buffer/SmallMap.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+
+namespace NovaTerminal.Core.Storage
+{
+    /// <summary>
+    /// Memory-optimized map for few entries (<= 8).
+    /// Used to reduce memory overhead from per-row dictionaries for extended text and hyperlinks.
+    ///
+    /// Rationale: 
+    /// Standard Dictionary<int, T> has significant object and array overhead.
+    /// Most terminal rows have 0, 1, or very few extended graphemes or hyperlinks.
+    /// SmallMap uses a simple array for up to 8 entries, avoiding Dictionary overhead
+    /// unless the complexity of the row justifies it.
+    /// </summary>
+    public sealed class SmallMap<T> where T : class
+    {
+        private const int MaxSmallCount = 8;
+
+        private struct Entry
+        {
+            public int Key;
+            public T Value;
+        }
+
+        private Entry[]? _entries;
+        private Dictionary<int, T>? _dictionary;
+        private int _count;
+
+        public int Count => _dictionary?.Count ?? _count;
+
+        /// <summary>
+        /// Attempts to get the value associated with the specified key.
+        /// </summary>
+        public bool TryGet(int key, out T? value)
+        {
+            if (_dictionary != null)
+            {
+                return _dictionary.TryGetValue(key, out value);
+            }
+
+            if (_count > 0 && _entries != null)
+            {
+                for (int i = 0; i < _count; i++)
+                {
+                    if (_entries[i].Key == key)
+                    {
+                        value = _entries[i].Value;
+                        return true;
+                    }
+                }
+            }
+
+            value = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Sets the value for the specified key.
+        /// Upgrades to Dictionary if count exceeds 8.
+        /// </summary>
+        public void Set(int key, T value)
+        {
+            if (_dictionary != null)
+            {
+                _dictionary[key] = value;
+                return;
+            }
+
+            // Check existing
+            if (_count > 0 && _entries != null)
+            {
+                for (int i = 0; i < _count; i++)
+                {
+                    if (_entries[i].Key == key)
+                    {
+                        _entries[i].Value = value;
+                        return;
+                    }
+                }
+            }
+
+            if (_count < MaxSmallCount)
+            {
+                _entries ??= new Entry[MaxSmallCount];
+                _entries[_count++] = new Entry { Key = key, Value = value };
+            }
+            else
+            {
+                // Upgrade to dictionary
+                _dictionary = new Dictionary<int, T>(_count + 1);
+                if (_entries != null)
+                {
+                    for (int i = 0; i < _count; i++)
+                    {
+                        _dictionary[_entries[i].Key] = _entries[i].Value;
+                    }
+                }
+                _dictionary[key] = value;
+                _entries = null;
+                _count = 0;
+            }
+        }
+
+        /// <summary>
+        /// Removes the value with the specified key.
+        /// </summary>
+        public void Remove(int key)
+        {
+            if (_dictionary != null)
+            {
+                _dictionary.Remove(key);
+                return;
+            }
+
+            if (_count > 0 && _entries != null)
+            {
+                for (int i = 0; i < _count; i++)
+                {
+                    if (_entries[i].Key == key)
+                    {
+                        // Shift left to maintain contiguous array
+                        for (int j = i; j < _count - 1; j++)
+                        {
+                            _entries[j] = _entries[j + 1];
+                        }
+                        _entries[_count - 1] = default; // Clear reference for GC
+                        _count--;
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/NovaTerminal.VT/Buffer/TerminalPage.cs
+++ b/src/NovaTerminal.VT/Buffer/TerminalPage.cs
@@ -31,6 +31,10 @@ namespace NovaTerminal.Core.Storage
         public int UsedRows;
 
         private bool _returned;
+        
+        /// <summary>Returns true if this page has been returned to the pool and should not be accessed.</summary>
+        public bool IsReturned => _returned;
+        
         private ulong _isWrappedMask;
 
         public TerminalPage(int rowsInPage, int cols)
@@ -131,6 +135,26 @@ namespace NovaTerminal.Core.Storage
             if ((uint)rowIndex >= (uint)RowsInPage) throw new ArgumentOutOfRangeException(nameof(rowIndex));
             if (wrapped) _isWrappedMask |= (1UL << rowIndex);
             else _isWrappedMask &= ~(1UL << rowIndex);
+        }
+
+        /// <summary>
+        /// Updates cells that rely on default foreground or background colors to a new theme.
+        /// This is an O(n) operation over all used cells, invoked rarely during a theme change.
+        /// </summary>
+        public void UpdateThemeDefaults(uint newFg, uint newBg)
+        {
+            var span = Cells.AsSpan(0, UsedRows * Cols);
+            for (int i = 0; i < span.Length; i++)
+            {
+                if (span[i].IsDefaultForeground)
+                {
+                    span[i].Fg = newFg;
+                }
+                if (span[i].IsDefaultBackground)
+                {
+                    span[i].Bg = newBg;
+                }
+            }
         }
 
         // ── Private ──────────────────────────────────────────────────────────────

--- a/src/NovaTerminal.VT/Buffer/TerminalPage.cs
+++ b/src/NovaTerminal.VT/Buffer/TerminalPage.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Buffers;
 
-namespace NovaTerminal.Core.Buffer
+namespace NovaTerminal.Core.Storage
 {
     /// <summary>
     /// A contiguous slab of TerminalCell values for multiple scrollback rows.
@@ -31,6 +31,7 @@ namespace NovaTerminal.Core.Buffer
         public int UsedRows;
 
         private bool _returned;
+        private ulong _isWrappedMask;
 
         public TerminalPage(int rowsInPage, int cols)
         {
@@ -101,6 +102,7 @@ namespace NovaTerminal.Core.Buffer
         {
             UsedRows = 0;
             _returned = false;
+            _isWrappedMask = 0;
             ResetCells();
         }
 
@@ -112,9 +114,23 @@ namespace NovaTerminal.Core.Buffer
         {
             if (_returned) return;
             _returned = true;
+            _isWrappedMask = 0;
             // Clear the usable portion so pooled memory doesn't retain stale data.
             Cells.AsSpan(0, RowsInPage * Cols).Clear();
             ArrayPool<TerminalCell>.Shared.Return(Cells, clearArray: false);
+        }
+
+        public bool IsRowWrapped(int rowIndex)
+        {
+            if ((uint)rowIndex >= (uint)RowsInPage) throw new ArgumentOutOfRangeException(nameof(rowIndex));
+            return (_isWrappedMask & (1UL << rowIndex)) != 0;
+        }
+
+        public void SetRowWrapped(int rowIndex, bool wrapped)
+        {
+            if ((uint)rowIndex >= (uint)RowsInPage) throw new ArgumentOutOfRangeException(nameof(rowIndex));
+            if (wrapped) _isWrappedMask |= (1UL << rowIndex);
+            else _isWrappedMask &= ~(1UL << rowIndex);
         }
 
         // ── Private ──────────────────────────────────────────────────────────────

--- a/src/NovaTerminal.VT/Buffer/TerminalPage.cs
+++ b/src/NovaTerminal.VT/Buffer/TerminalPage.cs
@@ -1,10 +1,16 @@
 using System;
+using System.Buffers;
 
 namespace NovaTerminal.Core.Buffer
 {
     /// <summary>
     /// A contiguous slab of TerminalCell values for multiple scrollback rows.
     /// Eliminates per-row heap objects by packing many rows into one flat array.
+    ///
+    /// The backing <see cref="Cells"/> array is rented from
+    /// <see cref="ArrayPool{T}.Shared"/> to avoid repeated large allocations.
+    /// Call <see cref="ReturnToPool"/> when the page is no longer needed so the
+    /// array is returned to the pool.
     /// </summary>
     public sealed class TerminalPage
     {
@@ -15,13 +21,16 @@ namespace NovaTerminal.Core.Buffer
         public readonly int Cols;
 
         /// <summary>
-        /// Flat cell storage: row r, column c is at index (r * Cols + c).
-        /// Length = RowsInPage * Cols.
+        /// Flat cell storage rented from <see cref="ArrayPool{T}.Shared"/>.
+        /// Length may be >= RowsInPage * Cols (pool over-allocation is normal).
+        /// Only use indices [0, RowsInPage * Cols).
         /// </summary>
         public readonly TerminalCell[] Cells;
 
         /// <summary>How many rows in this page contain actual data (0 … RowsInPage).</summary>
         public int UsedRows;
+
+        private bool _returned;
 
         public TerminalPage(int rowsInPage, int cols)
         {
@@ -30,31 +39,29 @@ namespace NovaTerminal.Core.Buffer
 
             RowsInPage = rowsInPage;
             Cols = cols;
-            Cells = new TerminalCell[rowsInPage * cols];
+            // Rent — pool may give us a slightly larger array; that's fine.
+            Cells = ArrayPool<TerminalCell>.Shared.Rent(rowsInPage * cols);
             UsedRows = 0;
+            _returned = false;
 
-            // Pre-fill with default cells so stale data is never visible.
-            var def = TerminalCell.Default;
-            var span = Cells.AsSpan();
-            for (int i = 0; i < span.Length; i++)
-                span[i] = def;
+            // Pre-fill the usable portion with default cells.
+            ResetCells();
         }
 
         /// <summary>Returns true when no more rows can be appended to this page.</summary>
         public bool IsFull => UsedRows >= RowsInPage;
 
         /// <summary>
-        /// Byte size of the cell data, used for budget tracking.
-        /// Does not count object/array overheads (negligible once paged).
+        /// Byte size of the cell data in the usable part of the array,
+        /// used for budget tracking.
         /// </summary>
-        public int ByteSize => Cells.Length * TerminalPageConstants.CellBytes;
+        public int ByteSize => RowsInPage * Cols * TerminalPageConstants.CellBytes;
 
         // ──────────────────────────────────────────────────────────────────
 
         /// <summary>
         /// Returns a span over the cells of the given row within this page.
         /// </summary>
-        /// <param name="rowIndex">Row index within the page (0-based, must be &lt; UsedRows).</param>
         public Span<TerminalCell> GetRowSpan(int rowIndex)
         {
             if ((uint)rowIndex >= (uint)RowsInPage)
@@ -73,9 +80,7 @@ namespace NovaTerminal.Core.Buffer
         }
 
         /// <summary>
-        /// Resets a row to all-default cells and clears the UsedRows counter
-        /// back to <paramref name="rowIndex"/> so the page can be reused from that point.
-        /// Typically used by the pool when reclaiming a page.
+        /// Resets a single row to all-default cells.
         /// </summary>
         public void ClearRow(int rowIndex)
         {
@@ -90,13 +95,34 @@ namespace NovaTerminal.Core.Buffer
 
         /// <summary>
         /// Resets all rows to default cells and sets UsedRows to 0.
-        /// Called by the page pool before returning the page for reuse.
+        /// Called by the pool before returning the page for reuse.
         /// </summary>
         public void Reset()
         {
             UsedRows = 0;
+            _returned = false;
+            ResetCells();
+        }
+
+        /// <summary>
+        /// Returns the backing <see cref="Cells"/> array to <see cref="ArrayPool{T}.Shared"/>.
+        /// The page must not be used after this call.
+        /// </summary>
+        public void ReturnToPool()
+        {
+            if (_returned) return;
+            _returned = true;
+            // Clear the usable portion so pooled memory doesn't retain stale data.
+            Cells.AsSpan(0, RowsInPage * Cols).Clear();
+            ArrayPool<TerminalCell>.Shared.Return(Cells, clearArray: false);
+        }
+
+        // ── Private ──────────────────────────────────────────────────────────────
+
+        private void ResetCells()
+        {
             var def = TerminalCell.Default;
-            var span = Cells.AsSpan();
+            var span = Cells.AsSpan(0, RowsInPage * Cols);
             for (int i = 0; i < span.Length; i++)
                 span[i] = def;
         }
@@ -109,5 +135,8 @@ namespace NovaTerminal.Core.Buffer
 
         /// <summary>Number of rows stored per page. 64 rows balances allocation granularity vs. overhead.</summary>
         public const int DefaultRowsPerPage = 64;
+
+        /// <summary>Number of pages to pre-warm per terminal instance.</summary>
+        public const int PreheatPagesPerInstance = 4;
     }
 }

--- a/src/NovaTerminal.VT/Buffer/TerminalPage.cs
+++ b/src/NovaTerminal.VT/Buffer/TerminalPage.cs
@@ -1,0 +1,113 @@
+using System;
+
+namespace NovaTerminal.Core.Buffer
+{
+    /// <summary>
+    /// A contiguous slab of TerminalCell values for multiple scrollback rows.
+    /// Eliminates per-row heap objects by packing many rows into one flat array.
+    /// </summary>
+    public sealed class TerminalPage
+    {
+        /// <summary>Number of rows this page can hold.</summary>
+        public readonly int RowsInPage;
+
+        /// <summary>Number of columns per row.</summary>
+        public readonly int Cols;
+
+        /// <summary>
+        /// Flat cell storage: row r, column c is at index (r * Cols + c).
+        /// Length = RowsInPage * Cols.
+        /// </summary>
+        public readonly TerminalCell[] Cells;
+
+        /// <summary>How many rows in this page contain actual data (0 … RowsInPage).</summary>
+        public int UsedRows;
+
+        public TerminalPage(int rowsInPage, int cols)
+        {
+            if (rowsInPage <= 0) throw new ArgumentOutOfRangeException(nameof(rowsInPage));
+            if (cols <= 0) throw new ArgumentOutOfRangeException(nameof(cols));
+
+            RowsInPage = rowsInPage;
+            Cols = cols;
+            Cells = new TerminalCell[rowsInPage * cols];
+            UsedRows = 0;
+
+            // Pre-fill with default cells so stale data is never visible.
+            var def = TerminalCell.Default;
+            var span = Cells.AsSpan();
+            for (int i = 0; i < span.Length; i++)
+                span[i] = def;
+        }
+
+        /// <summary>Returns true when no more rows can be appended to this page.</summary>
+        public bool IsFull => UsedRows >= RowsInPage;
+
+        /// <summary>
+        /// Byte size of the cell data, used for budget tracking.
+        /// Does not count object/array overheads (negligible once paged).
+        /// </summary>
+        public int ByteSize => Cells.Length * TerminalPageConstants.CellBytes;
+
+        // ──────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Returns a span over the cells of the given row within this page.
+        /// </summary>
+        /// <param name="rowIndex">Row index within the page (0-based, must be &lt; UsedRows).</param>
+        public Span<TerminalCell> GetRowSpan(int rowIndex)
+        {
+            if ((uint)rowIndex >= (uint)RowsInPage)
+                throw new ArgumentOutOfRangeException(nameof(rowIndex));
+            return Cells.AsSpan(rowIndex * Cols, Cols);
+        }
+
+        /// <summary>
+        /// Returns a read-only span over the cells of the given row within this page.
+        /// </summary>
+        public ReadOnlySpan<TerminalCell> GetRowSpanReadOnly(int rowIndex)
+        {
+            if ((uint)rowIndex >= (uint)RowsInPage)
+                throw new ArgumentOutOfRangeException(nameof(rowIndex));
+            return Cells.AsSpan(rowIndex * Cols, Cols);
+        }
+
+        /// <summary>
+        /// Resets a row to all-default cells and clears the UsedRows counter
+        /// back to <paramref name="rowIndex"/> so the page can be reused from that point.
+        /// Typically used by the pool when reclaiming a page.
+        /// </summary>
+        public void ClearRow(int rowIndex)
+        {
+            if ((uint)rowIndex >= (uint)RowsInPage)
+                throw new ArgumentOutOfRangeException(nameof(rowIndex));
+
+            var def = TerminalCell.Default;
+            var span = Cells.AsSpan(rowIndex * Cols, Cols);
+            for (int i = 0; i < span.Length; i++)
+                span[i] = def;
+        }
+
+        /// <summary>
+        /// Resets all rows to default cells and sets UsedRows to 0.
+        /// Called by the page pool before returning the page for reuse.
+        /// </summary>
+        public void Reset()
+        {
+            UsedRows = 0;
+            var def = TerminalCell.Default;
+            var span = Cells.AsSpan();
+            for (int i = 0; i < span.Length; i++)
+                span[i] = def;
+        }
+    }
+
+    internal static class TerminalPageConstants
+    {
+        /// <summary>Measured size of TerminalCell in bytes (char + ushort + uint + uint = 12 B).</summary>
+        public const int CellBytes = 12;
+
+        /// <summary>Number of rows stored per page. 64 rows balances allocation granularity vs. overhead.</summary>
+        public const int DefaultRowsPerPage = 64;
+    }
+}

--- a/src/NovaTerminal.VT/Buffer/TerminalPagePool.cs
+++ b/src/NovaTerminal.VT/Buffer/TerminalPagePool.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace NovaTerminal.Core.Buffer
+{
+    /// <summary>
+    /// Thread-safe pool of <see cref="TerminalPage"/> objects.
+    ///
+    /// Renting and returning pages avoids repeated large-array allocations for
+    /// the scrollback buffer. Each pool slot holds a page of a specific
+    /// (rowsPerPage × cols) shape; differently-shaped pages are not pooled.
+    ///
+    /// This class is intentionally simple. A more sophisticated eviction strategy
+    /// (Step 3) can be layered on top without changing the public API.
+    /// </summary>
+    public sealed class TerminalPagePool
+    {
+        private readonly ConcurrentBag<TerminalPage> _bag = new();
+
+        /// <summary>Maximum number of pages to keep in the pool (to cap idle memory).</summary>
+        public int MaxPooledPages { get; set; } = 32;
+
+        /// <summary>
+        /// Rents a page from the pool, or allocates a new one if none is available
+        /// or if the pooled page has a different shape.
+        /// The returned page has its cells reset to <see cref="TerminalCell.Default"/>.
+        /// </summary>
+        public TerminalPage Rent(int rowsPerPage, int cols)
+        {
+            while (_bag.TryTake(out var page))
+            {
+                if (page.RowsInPage == rowsPerPage && page.Cols == cols)
+                {
+                    page.Reset();
+                    return page;
+                }
+                // Wrong shape — discard (let GC collect it). This is rare.
+            }
+
+            return new TerminalPage(rowsPerPage, cols);
+        }
+
+        /// <summary>
+        /// Returns a page to the pool. The page is reset before being stored.
+        /// If the pool is already full, the page is discarded.
+        /// </summary>
+        public void Return(TerminalPage page)
+        {
+            if (page == null) return;
+            if (_bag.Count >= MaxPooledPages) return; // Don't over-hold memory
+
+            page.Reset();
+            _bag.Add(page);
+        }
+
+        /// <summary>
+        /// Removes all pages from the pool, releasing their backing arrays to the GC.
+        /// </summary>
+        public void Clear()
+        {
+            while (_bag.TryTake(out _)) { }
+        }
+    }
+}

--- a/src/NovaTerminal.VT/Buffer/TerminalPagePool.cs
+++ b/src/NovaTerminal.VT/Buffer/TerminalPagePool.cs
@@ -1,64 +1,133 @@
 using System;
 using System.Collections.Concurrent;
+using System.Threading;
 
 namespace NovaTerminal.Core.Buffer
 {
     /// <summary>
     /// Thread-safe pool of <see cref="TerminalPage"/> objects.
     ///
-    /// Renting and returning pages avoids repeated large-array allocations for
-    /// the scrollback buffer. Each pool slot holds a page of a specific
-    /// (rowsPerPage × cols) shape; differently-shaped pages are not pooled.
+    /// Pages rented from this pool have their backing <see cref="TerminalPage.Cells"/>
+    /// array sourced from <see cref="System.Buffers.ArrayPool{T}.Shared"/>, so
+    /// returning a page also returns the cell array to the shared pool.
     ///
-    /// This class is intentionally simple. A more sophisticated eviction strategy
-    /// (Step 3) can be layered on top without changing the public API.
+    /// Usage:
+    /// <code>
+    ///   var page = pool.Rent(cols);
+    ///   // … use page …
+    ///   pool.Return(page);
+    /// </code>
     /// </summary>
     public sealed class TerminalPagePool
     {
+        // ── State ────────────────────────────────────────────────────────────────
         private readonly ConcurrentBag<TerminalPage> _bag = new();
+        private int _activePages;   // pages currently rented out
+        private int _pooledPages;   // pages sitting in the bag
 
-        /// <summary>Maximum number of pages to keep in the pool (to cap idle memory).</summary>
+        // ── Configuration ────────────────────────────────────────────────────────
+
+        /// <summary>Maximum number of pages to retain in the pool (caps idle memory).</summary>
         public int MaxPooledPages { get; set; } = 32;
 
+        // ── Metrics ──────────────────────────────────────────────────────────────
+
+        /// <summary>Number of pages currently rented out (in active use).</summary>
+        public int ActivePages => _activePages;
+
+        /// <summary>Number of pages sitting in the pool, ready to be rented.</summary>
+        public int PooledPages => _pooledPages;
+
+        // ── Preheat ──────────────────────────────────────────────────────────────
+
         /// <summary>
-        /// Rents a page from the pool, or allocates a new one if none is available
-        /// or if the pooled page has a different shape.
-        /// The returned page has its cells reset to <see cref="TerminalCell.Default"/>.
+        /// Pre-allocates <paramref name="count"/> pages of the given shape and places
+        /// them in the pool so the first few scrollback additions don't trigger
+        /// cold allocations.
+        ///
+        /// Called once per terminal instance at construction time
+        /// (default: <see cref="TerminalPageConstants.PreheatPagesPerInstance"/> = 4 pages).
         /// </summary>
-        public TerminalPage Rent(int rowsPerPage, int cols)
+        public void Preheat(int count, int cols,
+            int rowsPerPage = TerminalPageConstants.DefaultRowsPerPage)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                if (_pooledPages >= MaxPooledPages) break;
+                var page = new TerminalPage(rowsPerPage, cols);
+                _bag.Add(page);
+                Interlocked.Increment(ref _pooledPages);
+            }
+        }
+
+        // ── Rent / Return ────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Rents a page from the pool (or allocates a new one if none matches).
+        /// The returned page is reset to default cells with <c>UsedRows = 0</c>.
+        /// </summary>
+        /// <param name="cols">Number of columns the page must have.</param>
+        /// <param name="rowsPerPage">Rows per page; defaults to <see cref="TerminalPageConstants.DefaultRowsPerPage"/>.</param>
+        public TerminalPage Rent(int cols,
+            int rowsPerPage = TerminalPageConstants.DefaultRowsPerPage)
         {
             while (_bag.TryTake(out var page))
             {
+                Interlocked.Decrement(ref _pooledPages);
+
                 if (page.RowsInPage == rowsPerPage && page.Cols == cols)
                 {
                     page.Reset();
+                    Interlocked.Increment(ref _activePages);
                     return page;
                 }
-                // Wrong shape — discard (let GC collect it). This is rare.
+
+                // Shape mismatch — return the mismatched page's array to ArrayPool
+                // and discard the wrapper. This is rare (only after a terminal resize).
+                page.ReturnToPool();
             }
 
-            return new TerminalPage(rowsPerPage, cols);
+            var newPage = new TerminalPage(rowsPerPage, cols);
+            Interlocked.Increment(ref _activePages);
+            return newPage;
         }
 
         /// <summary>
-        /// Returns a page to the pool. The page is reset before being stored.
-        /// If the pool is already full, the page is discarded.
+        /// Returns a page to the pool. If the pool is full the page's cell array is
+        /// returned to <see cref="System.Buffers.ArrayPool{T}.Shared"/> immediately.
         /// </summary>
-        public void Return(TerminalPage page)
+        public void Return(TerminalPage? page)
         {
             if (page == null) return;
-            if (_bag.Count >= MaxPooledPages) return; // Don't over-hold memory
 
-            page.Reset();
-            _bag.Add(page);
+            Interlocked.Decrement(ref _activePages);
+
+            if (_pooledPages < MaxPooledPages)
+            {
+                page.Reset();
+                _bag.Add(page);
+                Interlocked.Increment(ref _pooledPages);
+            }
+            else
+            {
+                // Pool is full — release the backing array straight to ArrayPool.
+                page.ReturnToPool();
+            }
         }
 
+        // ── Teardown ─────────────────────────────────────────────────────────────
+
         /// <summary>
-        /// Removes all pages from the pool, releasing their backing arrays to the GC.
+        /// Removes all pages from the pool and returns their backing arrays to
+        /// <see cref="System.Buffers.ArrayPool{T}.Shared"/>.
         /// </summary>
         public void Clear()
         {
-            while (_bag.TryTake(out _)) { }
+            while (_bag.TryTake(out var page))
+            {
+                Interlocked.Decrement(ref _pooledPages);
+                page.ReturnToPool();
+            }
         }
     }
 }

--- a/src/NovaTerminal.VT/Buffer/TerminalPagePool.cs
+++ b/src/NovaTerminal.VT/Buffer/TerminalPagePool.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Threading;
 
-namespace NovaTerminal.Core.Buffer
+namespace NovaTerminal.Core.Storage
 {
     /// <summary>
     /// Thread-safe pool of <see cref="TerminalPage"/> objects.

--- a/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using NovaTerminal.Core.Replay;
+using NovaTerminal.Core.Storage;
 
 namespace NovaTerminal.Core
 {
@@ -33,7 +34,9 @@ namespace NovaTerminal.Core
                 return _viewport[absRow];
             }
 
-            if (absRow < _scrollback.Count) return _scrollback[absRow];
+            // Scrollback rows are now paged, they don't exist as persistent TerminalRow objects.
+            if (absRow < _scrollback.Count) return null;
+            
             int viewportRow = absRow - _scrollback.Count;
             if (viewportRow < 0 || viewportRow >= Rows) return null;
             return _viewport[viewportRow];
@@ -52,8 +55,8 @@ namespace NovaTerminal.Core
 
             if (absRow < _scrollback.Count)
             {
-                // Reading from scrollback
-                return _scrollback[absRow].Cells[col];
+                // Reading from paged scrollback
+                return _scrollback.GetRow(absRow)[col];
             }
             else
             {
@@ -67,9 +70,16 @@ namespace NovaTerminal.Core
         public string GetGraphemeAbsolute(int col, int absRow)
         {
             AssertLockHeld();
-            if (absRow < 0) return " ";
+            if (absRow < 0 || col < 0 || col >= Cols) return " ";
+            
+            if (!_isAltScreen && absRow < _scrollback.Count)
+            {
+                // Scrollback doesn't support extended text yet (Step 5)
+                return _scrollback.GetRow(absRow)[col].Character.ToString();
+            }
+
             var row = GetRowAbsolute(absRow);
-            if (row == null || col < 0 || col >= Cols) return " ";
+            if (row == null) return " ";
             var cell = row.Cells[col];
             return (cell.HasExtendedText ? row.GetExtendedText(col) : null) ?? cell.Character.ToString();
         }
@@ -80,6 +90,13 @@ namespace NovaTerminal.Core
             try
             {
                 if (absRow < 0 || col < 0 || col >= Cols) return null;
+                
+                if (!_isAltScreen && absRow < _scrollback.Count)
+                {
+                    // Scrollback doesn't support hyperlinks yet (Step 5)
+                    return null;
+                }
+
                 var row = GetRowAbsolute(absRow);
                 return row?.GetHyperlink(col);
             }
@@ -517,7 +534,17 @@ namespace NovaTerminal.Core
                 for (int r = 0; r < totalRows; r++)
                 {
                     // Build row string
-                    var row = (r < _scrollback.Count) ? _scrollback[r] : _viewport[r - _scrollback.Count];
+                    ReadOnlySpan<TerminalCell> cells;
+                    TerminalRow? rowObj = null;
+                    if (r < _scrollback.Count)
+                    {
+                        cells = _scrollback.GetRow(r);
+                    }
+                    else
+                    {
+                        rowObj = _viewport[r - _scrollback.Count];
+                        cells = rowObj.Cells;
+                    }
 
                     // Build row string with mapping for wide/complex characters
                     var sb = new StringBuilder();
@@ -525,10 +552,11 @@ namespace NovaTerminal.Core
 
                     for (int c = 0; c < Cols; c++)
                     {
-                        var cell = row.Cells[c];
+                        var cell = cells[c];
                         if (cell.IsWideContinuation) continue;
 
-                        string text = (cell.HasExtendedText ? row.GetExtendedText(c) : null) ?? cell.Character.ToString();
+                        string? text = (rowObj != null && cell.HasExtendedText) ? rowObj.GetExtendedText(c) : null;
+                        text ??= cell.Character.ToString();
                         int startIdx = sb.Length;
                         sb.Append(text);
                         for (int k = 0; k < text.Length; k++) colMapping.Add(c);

--- a/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
@@ -198,19 +198,7 @@ namespace NovaTerminal.Core
                     _viewport[r].TouchRevision();
                 }
 
-                /*
-                foreach (var row in _scrollback)
-                {
-                    for (int c = 0; c < row.Cells.Length; c++)
-                    {
-                        UpdateCell(ref row.Cells[c]);
-                    }
-                    row.TouchRevision();
-                }
-                */
-                // TODO: Paged scrollback theme update needs to update cells inside TerminalPages.
-                // This is a performance hit but necessary for correctness if theme changes.
-                // For now, we skip it as it's a rare case, but we should address it in Step 7.
+                _scrollback.UpdateThemeDefaults(oldTheme, Theme);
 
                 foreach (var row in _mainScreen) row.TouchRevision();
                 foreach (var row in _altScreen) row.TouchRevision();

--- a/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
@@ -1,3 +1,5 @@
+using NovaTerminal.Core.Storage;
+
 namespace NovaTerminal.Core
 {
     public partial class TerminalBuffer
@@ -196,6 +198,7 @@ namespace NovaTerminal.Core
                     _viewport[r].TouchRevision();
                 }
 
+                /*
                 foreach (var row in _scrollback)
                 {
                     for (int c = 0; c < row.Cells.Length; c++)
@@ -204,6 +207,10 @@ namespace NovaTerminal.Core
                     }
                     row.TouchRevision();
                 }
+                */
+                // TODO: Paged scrollback theme update needs to update cells inside TerminalPages.
+                // This is a performance hit but necessary for correctness if theme changes.
+                // For now, we skip it as it's a rare case, but we should address it in Step 7.
 
                 foreach (var row in _mainScreen) row.TouchRevision();
                 foreach (var row in _altScreen) row.TouchRevision();

--- a/src/NovaTerminal.VT/TerminalBuffer.Metrics.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.Metrics.cs
@@ -1,0 +1,40 @@
+using NovaTerminal.Core.Storage;
+
+namespace NovaTerminal.Core
+{
+    public record struct TerminalMemoryMetrics(
+        long ScrollbackBytes,
+        int ActivePages,
+        int PooledPages,
+        int ViewportCells,
+        int GlyphCacheEntries,
+        long GlyphCacheAtlasBytes
+    );
+
+    public partial class TerminalBuffer
+    {
+        public TerminalMemoryMetrics GetMemoryMetrics(int glyphCacheEntries = 0, long glyphCacheAtlasBytes = 0)
+        {
+            ScrollbackMetrics sb;
+            int viewportCells;
+
+            bool lockTaken = EnterReadLockIfNeeded();
+            try
+            {
+                sb = _scrollback.GetMetrics();
+                viewportCells = Rows * Cols;
+            }
+            finally { ExitReadLockIfNeeded(Lock, lockTaken); }
+
+            return new TerminalMemoryMetrics
+            {
+                ScrollbackBytes = sb.BytesUsed,
+                ActivePages = sb.ActivePages,
+                PooledPages = sb.PooledPages,
+                ViewportCells = viewportCells,
+                GlyphCacheEntries = glyphCacheEntries,
+                GlyphCacheAtlasBytes = glyphCacheAtlasBytes
+            };
+        }
+    }
+}

--- a/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using NovaTerminal.Core.Storage;
 
 namespace NovaTerminal.Core
 {
@@ -11,11 +12,12 @@ namespace NovaTerminal.Core
         {
             private readonly SavedCursorStates _savedCursors;
             private TerminalRow[] _viewport;
-            private CircularBuffer<TerminalRow> _scrollback;
+            private ScrollbackPages? _scrollback;
+            private readonly List<TerminalRow> _history;
             private readonly List<TerminalImage> _images;
             private readonly bool _isAltScreen;
             private readonly TerminalTheme Theme;
-            private readonly int MaxHistory;
+            private readonly long _maxScrollbackBytes;
             private int _cursorRow;
             private int _cursorCol;
             private readonly Func<string, int> _getGraphemeWidth;
@@ -25,10 +27,11 @@ namespace NovaTerminal.Core
                 _savedCursors = source._savedCursors;
                 _viewport = source._viewport;
                 _scrollback = source._scrollback;
+                _history = new List<TerminalRow>(_scrollback.Count + source.Rows);
+                _maxScrollbackBytes = source.MaxScrollbackBytes;
                 _images = source._images;
                 _isAltScreen = source._isAltScreen;
                 Theme = source.Theme;
-                MaxHistory = source.MaxHistory;
                 _cursorRow = source._cursorRow;
                 _cursorCol = source._cursorCol;
                 _getGraphemeWidth = source.GetGraphemeWidth;
@@ -109,7 +112,15 @@ namespace NovaTerminal.Core
                     var logicalLines = new List<(int StartIdx, int Length, bool IsWrapped, int StartPhysIdx)>(totalPhysRows);
 
                     // Fill rented array
-                    for (int i = 0; i < _scrollback.Count; i++) allPhysicalRows[i] = _scrollback[i];
+                    for (int i = 0; i < _scrollback.Count; i++)
+                    {
+                        var rowCells = _scrollback.GetRow(i);
+                        var row = new TerminalRow(oldCols, Theme.Foreground, Theme.Background);
+                        rowCells.CopyTo(row.Cells);
+                        row.IsWrapped = _scrollback.IsRowWrapped(i);
+                        // NOTE: Extended text is lost in scrollback until Step 5
+                        allPhysicalRows[i] = row;
+                    }
                     for (int i = 0; i < vpRowsToTake; i++)
                     {
                         if (i < actualVpLen) allPhysicalRows[_scrollback.Count + i] = _viewport[i];
@@ -570,19 +581,22 @@ namespace NovaTerminal.Core
                     {
                         sbCount += (activeContentSize - newRows);
                     }
-                    // Grow Adjustment: If active content fits, we keep sbCount as is. Viewport will have padding at bottom.
 
                     // Ensure safety
                     sbCount = Math.Clamp(sbCount, 0, total);
                     int vpCount = total - sbCount;
 
-                    int initialScrollbackCount = _scrollback.Count;
-                    for (int i = 0; i < sbCount; i++) _scrollback.Add(allFlowedRows[i]);
-
-                    // CircularBuffer auto-evicts when at capacity
-                    // Calculate how many rows were discarded due to auto-eviction
-                    int discardedRows = Math.Max(0, (initialScrollbackCount + sbCount) - _scrollback.Count);
-                    sbCount -= discardedRows;
+                    // Create new ScrollbackPages instance
+                    var newScrollback = new ScrollbackPages(newCols, _sharedPagePool, _maxScrollbackBytes);
+                    
+                    long prevEvicted = 0;
+                    for (int i = 0; i < sbCount; i++)
+                    {
+                        newScrollback.AppendRow(allFlowedRows[i].Cells, allFlowedRows[i].IsWrapped);
+                    }
+                    
+                    int discardedRows = (int)newScrollback.TotalRowsEvicted;
+                    _scrollback = newScrollback;
 
                     // Fill viewport
                     // If vpCount < newRows (Growth), we will have empty space at the bottom (Top Anchoring).
@@ -705,7 +719,7 @@ namespace NovaTerminal.Core
                 {
                     try { System.IO.File.AppendAllText("error.log", "\n--- Reflow Exception at " + DateTime.Now + " ---\n" + ex.ToString() + "\n"); } catch { }
                     // Failsafe: if reflow crashes, we just reset the buffer to a clean state to avoid permanent hang
-                    _scrollback.Clear();
+                    _scrollback = new ScrollbackPages(newCols, _sharedPagePool, _maxScrollbackBytes);
                     _viewport = new TerminalRow[newRows];
                     for (int i = 0; i < newRows; i++) _viewport[i] = new TerminalRow(newCols, Theme.Foreground, Theme.Background);
                     _cursorRow = 0;

--- a/src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs
@@ -94,7 +94,8 @@ namespace NovaTerminal.Core
                                 for (int i = _images.Count - 1; i >= 0; i--)
                                 {
                                     var img = _images[i];
-                                    img.CellY -= (int)newlyEvicted;
+                                    int delta = newlyEvicted > int.MaxValue ? int.MaxValue : (int)newlyEvicted;
+                                    img.CellY -= delta;
                                     if (img.CellY + img.CellHeight <= 0) _images.RemoveAt(i);
                                 }
                             }

--- a/src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using NovaTerminal.Core.Storage;
 
 namespace NovaTerminal.Core
 {
@@ -70,45 +71,45 @@ namespace NovaTerminal.Core
                     else
                     {
                         // Main screen: Still needs redistribution to maintain scrollback vs viewport split
-                        // but we don't need the expensive logical line reconstruction.
-
-                        // Combine all current rows
-                        var all = new List<TerminalRow>(_scrollback.Count + oldRows);
-                        all.AddRange(_scrollback);
-                        all.AddRange(_viewport);
-
-                        int initialSbCount = _scrollback.Count;
-                        _scrollback.Clear();
-                        _viewport = new TerminalRow[newRows];
-
-                        int total = all.Count;
-                        int vpStart;
+                        
                         if (newRows < oldRows)
                         {
                             // Shrink height: push top of viewport to scrollback
-                            vpStart = initialSbCount + (oldRows - newRows);
+                            int diff = oldRows - newRows;
+                            long prevEvicted = _scrollback.TotalRowsEvicted;
+
+                            for (int i = 0; i < diff; i++)
+                            {
+                                _scrollback.AppendRow(_viewport[i].Cells);
+                            }
+
+                            var newVp = new TerminalRow[newRows];
+                            Array.Copy(_viewport, diff, newVp, 0, newRows);
+                            _viewport = newVp;
+                            _cursorRow -= diff;
+
+                            long newlyEvicted = _scrollback.TotalRowsEvicted - prevEvicted;
+                            if (newlyEvicted > 0)
+                            {
+                                for (int i = _images.Count - 1; i >= 0; i--)
+                                {
+                                    var img = _images[i];
+                                    img.CellY -= (int)newlyEvicted;
+                                    if (img.CellY + img.CellHeight <= 0) _images.RemoveAt(i);
+                                }
+                            }
                         }
-                        else
+                        else if (newRows > oldRows)
                         {
                             // Grow height: anchor to top of current viewport (add padding at bottom)
-                            vpStart = initialSbCount;
+                            var newVp = new TerminalRow[newRows];
+                            Array.Copy(_viewport, 0, newVp, 0, oldRows);
+                            for (int i = oldRows; i < newRows; i++)
+                            {
+                                newVp[i] = new TerminalRow(newCols, Theme.Foreground, Theme.Background);
+                            }
+                            _viewport = newVp;
                         }
-                        vpStart = Math.Max(0, Math.Min(vpStart, total));
-
-                        for (int i = 0; i < vpStart; i++) _scrollback.Add(all[i]);
-                        for (int i = 0; i < newRows; i++)
-                        {
-                            if (vpStart + i < total) _viewport[i] = all[vpStart + i];
-                            else _viewport[i] = new TerminalRow(newCols, Theme.Foreground, Theme.Background);
-                        }
-
-                        // Clamping and relative adjustment
-                        if (newRows < oldRows)
-                        {
-                            // If we shrank, the cursor moves up relative to the viewport top
-                            _cursorRow -= (oldRows - newRows);
-                        }
-                        // If we grew, _cursorRow stays same (anchored to top)
 
                         _cursorRow = Math.Clamp(_cursorRow, 0, newRows - 1);
                         _cursorCol = Math.Clamp(_cursorCol, 0, newCols);
@@ -228,74 +229,62 @@ namespace NovaTerminal.Core
 
             if (newRows > oldRows)
             {
-                // GROW: Pull lines from scrollback logic
-                // We need (newRows - oldRows) extra lines at the top.
+                // GROW: Pull lines from scrollback
                 int linesNeeded = newRows - oldRows;
-                int linesAvailable = _scrollback.Count;
-                int linesToPull = Math.Min(linesNeeded, linesAvailable);
+                int pulled = 0;
 
-                // 1. Pull lines from Scrollback
-                for (int i = 0; i < linesToPull; i++)
+                // We want to fill the TOP of the new viewport with lines from history
+                for (int i = linesNeeded - 1; i >= 0; i--)
                 {
-                    // Get 'linesToPull' lines from the END of scrollback
-                    // Order: If we pull 2 lines (idx 98, 99).
-                    // NewViewport[0] = 98. NewViewport[1] = 99.
-                    newViewport[i] = _scrollback[_scrollback.Count - linesToPull + i];
-                }
-
-                // 2. Remove pulled lines from scrollback
-                // CircularBuffer doesn't support RemoveRange from the end
-                // We need to rebuild the scrollback without the last N lines
-                if (linesToPull > 0)
-                {
-                    var tempScrollback = new CircularBuffer<TerminalRow>(MaxHistory);
-                    int keepCount = _scrollback.Count - linesToPull;
-                    for (int i = 0; i < keepCount; i++)
+                    var row = new TerminalRow(Cols, Theme.Foreground, Theme.Background);
+                    if (_scrollback.TryPopLastRow(row.Cells))
                     {
-                        tempScrollback.Add(_scrollback[i]);
+                        newViewport[i] = row;
+                        pulled++;
                     }
-                    _scrollback = tempScrollback;
+                    else
+                    {
+                        newViewport[i] = new TerminalRow(Cols, Theme.Foreground, Theme.Background);
+                    }
                 }
 
-                // 3. Copy OLD Viewport
-                for (int i = 0; i < oldRows; i++)
+                Array.Copy(_viewport, 0, newViewport, linesNeeded, oldRows);
+                _cursorRow += linesNeeded;
+                
+                // Shift images DOWN
+                for (int i = 0; i < _images.Count; i++)
                 {
-                    newViewport[linesToPull + i] = _viewport[i];
+                    _images[i].CellY += linesNeeded;
                 }
-
-                // 4. Fill remaining empty space at bottom
-                // (If we didn't have enough history to fill the top)
-                int filledRows = linesToPull + oldRows;
-                for (int i = filledRows; i < newRows; i++)
-                {
-                    newViewport[i] = new TerminalRow(Cols, Theme.Foreground, Theme.Background);
-                }
-
-                // Adjust cursor: Content moved DOWN by 'linesToPull'
-                _cursorRow += linesToPull;
             }
             else
             {
-                // SHRINK: Push lines to scrollback logic
+                // SHRINK: Push lines to scrollback
                 int linesToPush = oldRows - newRows;
+                long prevEvicted = _scrollback.TotalRowsEvicted;
 
-                // 1. Push top lines to scrollback
                 for (int i = 0; i < linesToPush; i++)
                 {
-                    _scrollback.Add(_viewport[i]);
+                    _scrollback.AppendRow(_viewport[i].Cells);
                 }
 
-                // 2. Copy remaining lines to new viewport
-                for (int i = 0; i < newRows; i++)
-                {
-                    newViewport[i] = _viewport[linesToPush + i];
-                }
-
-                // Adjust cursor: Content moved UP by 'linesToPush'
+                Array.Copy(_viewport, linesToPush, newViewport, 0, newRows);
                 _cursorRow -= linesToPush;
+
+                int newlyDiscarded = (int)(_scrollback.TotalRowsEvicted - prevEvicted);
+
+                // Shift images UP
+                for (int i = _images.Count - 1; i >= 0; i--)
+                {
+                    var img = _images[i];
+                    img.CellY -= (linesToPush + newlyDiscarded);
+                    if (img.CellY + img.CellHeight <= 0) _images.RemoveAt(i);
+                }
             }
 
             _viewport = newViewport;
+            _cursorRow = Math.Clamp(_cursorRow, 0, newRows - 1);
+            _cursorCol = Math.Clamp(_cursorCol, 0, Cols);
         }
 
         private void Reflow(int oldCols, int oldRows, int newCols, int newRows)

--- a/src/NovaTerminal.VT/TerminalBuffer.ThreadingAndInvalidation.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ThreadingAndInvalidation.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using NovaTerminal.Core.Storage;
 using System.Diagnostics;
 
 namespace NovaTerminal.Core
@@ -243,6 +244,21 @@ namespace NovaTerminal.Core
                             Cols = viewportCols,
                             Cells = GetOrBuildCachedRenderRowCells_NoLock(r, row, viewportCols),
                             RowId = row.Id
+                        };
+                        rowId = rowSnapshot.RowId;
+                        rowRevision = rowSnapshot.Revision;
+                    }
+                    else if (!_isAltScreen && absRow < _scrollback.Count)
+                    {
+                        // Scrollback row (paged)
+                        long absRowId = _scrollback.TotalRowsEvicted + absRow;
+                        rowSnapshot = new RenderRowSnapshot
+                        {
+                            AbsRow = absRow,
+                            Revision = 0, // Scrollback rows are immutable
+                            Cols = viewportCols,
+                            Cells = GetOrBuildCachedPagedRenderRowCells_NoLock(r, absRow, absRowId, viewportCols),
+                            RowId = absRowId
                         };
                         rowId = rowSnapshot.RowId;
                         rowRevision = rowSnapshot.Revision;
@@ -640,6 +656,79 @@ namespace NovaTerminal.Core
                 return new PooledArray<SearchHighlightSnapshot>(arr, list.Count);
             }
             return PooledArray<SearchHighlightSnapshot>.Empty;
+        }
+
+        private RenderCellSnapshot[] GetOrBuildCachedPagedRenderRowCells_NoLock(int rowIndex, int absRow, long rowId, int viewportCols)
+        {
+            if (viewportCols <= 0)
+            {
+                return Array.Empty<RenderCellSnapshot>();
+            }
+
+            RenderCellSnapshot[]? cachedCells = _cachedRenderRowCells[rowIndex];
+            bool canReuse =
+                cachedCells != null &&
+                cachedCells.Length == viewportCols &&
+                _cachedRenderRowIds[rowIndex] == rowId &&
+                _cachedRenderRowRevisions[rowIndex] == 0 &&
+                _cachedRenderRowCols[rowIndex] == viewportCols;
+
+            if (canReuse)
+            {
+                return cachedCells!;
+            }
+
+            // Scrollback rows are immutable, so we only need to build them once per rowId/Cols combination.
+            var rebuiltCells = new RenderCellSnapshot[viewportCols];
+            var sourceCells = _scrollback.GetRow(absRow);
+            int copyLen = Math.Min(sourceCells.Length, viewportCols);
+
+            for (int c = 0; c < viewportCols; c++)
+            {
+                if (c < copyLen)
+                {
+                    var cell = sourceCells[c];
+                    rebuiltCells[c] = new RenderCellSnapshot
+                    {
+                        Character = cell.Character,
+                        Text = null, // TODO Step 5: Support extended text in scrollback
+                        Foreground = cell.Foreground,
+                        Background = cell.Background,
+                        IsInverse = cell.IsInverse,
+                        IsBold = cell.IsBold,
+                        IsDefaultForeground = cell.IsDefaultForeground,
+                        IsDefaultBackground = cell.IsDefaultBackground,
+                        IsWide = cell.IsWide,
+                        IsWideContinuation = cell.IsWideContinuation,
+                        IsHidden = cell.IsHidden,
+                        IsFaint = cell.IsFaint,
+                        IsItalic = cell.IsItalic,
+                        IsUnderline = cell.IsUnderline,
+                        IsBlink = cell.IsBlink,
+                        IsStrikethrough = cell.IsStrikethrough,
+                        FgIndex = cell.FgIndex,
+                        BgIndex = cell.BgIndex
+                    };
+                }
+                else
+                {
+                    rebuiltCells[c] = new RenderCellSnapshot
+                    {
+                        Character = ' ',
+                        Foreground = Theme.Foreground,
+                        Background = Theme.Background,
+                        IsDefaultForeground = true,
+                        IsDefaultBackground = true
+                    };
+                }
+            }
+
+            _cachedRenderRowIds[rowIndex] = rowId;
+            _cachedRenderRowRevisions[rowIndex] = 0;
+            _cachedRenderRowCols[rowIndex] = viewportCols;
+            _cachedRenderRowCells[rowIndex] = rebuiltCells;
+
+            return rebuiltCells;
         }
     }
 }

--- a/src/NovaTerminal.VT/TerminalBuffer.WritePath.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.WritePath.cs
@@ -430,7 +430,8 @@ namespace NovaTerminal.Core
                     for (int i = _images.Count - 1; i >= 0; i--)
                     {
                         var img = _images[i];
-                        img.CellY -= (int)newlyEvicted;
+                        int delta = newlyEvicted > int.MaxValue ? int.MaxValue : (int)newlyEvicted;
+                        img.CellY -= delta;
                         // If the image's entire area is now before the new index 0, prune it.
                         if (img.CellY + img.CellHeight <= 0)
                         {

--- a/src/NovaTerminal.VT/TerminalBuffer.WritePath.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.WritePath.cs
@@ -2,6 +2,7 @@ using System;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using NovaTerminal.Core.Storage;
 
 namespace NovaTerminal.Core
 {
@@ -414,18 +415,22 @@ namespace NovaTerminal.Core
             // 1. If full screen and main screen, add to scrollback
             if (isFullScreenScroll && !_isAltScreen)
             {
-                // CircularBuffer automatically evicts oldest when at capacity
-                bool wasAtCapacity = _scrollback.Count >= MaxHistory;
-                _scrollback.Add(_viewport[0]);
+                long prevEvicted = _scrollback.TotalRowsEvicted;
+                
+                // This copies the cell array into the page-based store;
+                // No TerminalRow object is stored in scrollback anymore.
+                _scrollback.AppendRow(_viewport[0].Cells, _viewport[0].IsWrapped);
 
-                // If we evicted a row, all following rows shifted down in absolute index
-                // So we must decrement CellY for ALL images.
-                if (wasAtCapacity)
+                long newlyEvicted = _scrollback.TotalRowsEvicted - prevEvicted;
+
+                // If we evicted rows (pages), all following rows shifted down in absolute index
+                // So we must decrement CellY for ALL images by the number of evicted rows.
+                if (newlyEvicted > 0)
                 {
                     for (int i = _images.Count - 1; i >= 0; i--)
                     {
                         var img = _images[i];
-                        img.CellY--;
+                        img.CellY -= (int)newlyEvicted;
                         // If the image's entire area is now before the new index 0, prune it.
                         if (img.CellY + img.CellHeight <= 0)
                         {
@@ -433,8 +438,6 @@ namespace NovaTerminal.Core
                         }
                     }
                 }
-                // Note: If NOT pruning, we don't shift CellY. The absolute index of 
-                // viewport[0] didn't change (it just became the last index of scrollback).
             }
             else
             {

--- a/src/NovaTerminal.VT/TerminalBuffer.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.cs
@@ -1,6 +1,7 @@
 
 using System;
 using System.Collections.Generic;
+using NovaTerminal.Core.Storage;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("NovaTerminal.Tests")]
@@ -17,13 +18,15 @@ namespace NovaTerminal.Core
         // Alternate screen buffer support (for vim, htop, less, etc.)
         private TerminalRow[] _mainScreen;
         private TerminalRow[] _altScreen;
-        private CircularBuffer<TerminalRow> _mainScreenScrollback; // Preserve main screen scrollback
         private bool _isAltScreen = false;
         public bool IsAltScreenActive => _isAltScreen;
 
         // Scrollback buffer - historical lines that scrolled off the top
-        private CircularBuffer<TerminalRow> _scrollback;
+        private ScrollbackPages _scrollback;
+        private static readonly TerminalPagePool _sharedPagePool = new();
+
         public int MaxHistory { get; set; } = 10000;
+        public long MaxScrollbackBytes { get; set; } = 128L * 1024 * 1024;
 
         // Graphics support
         private readonly List<TerminalImage> _images = new();
@@ -80,7 +83,7 @@ namespace NovaTerminal.Core
         // Internal access for properties to avoid recursive locking
         public int InternalTotalLines => _isAltScreen ? Rows : (_scrollback.Count + Rows);
 
-        public IReadOnlyList<TerminalRow> ScrollbackRows => _scrollback;
+        public ScrollbackPages Scrollback => _scrollback;
         public IReadOnlyList<TerminalRow> ViewportRows => _viewport;
         public int TotalLines => _isAltScreen ? Rows : (_scrollback.Count + Rows);
 
@@ -114,15 +117,16 @@ namespace NovaTerminal.Core
             IsDefaultForeground = true;
             IsDefaultBackground = true;
 
-            // Initialize scrollback buffers
-            _scrollback = new CircularBuffer<TerminalRow>(MaxHistory);
-            _mainScreenScrollback = new CircularBuffer<TerminalRow>(MaxHistory);
+            // Initialize scrollback buffer
+            _scrollback = new ScrollbackPages(cols, _sharedPagePool, MaxScrollbackBytes);
 
             _viewport = new TerminalRow[rows];
             for (int i = 0; i < rows; i++)
             {
                 _viewport[i] = new TerminalRow(cols, Theme.Foreground, Theme.Background);
             }
+
+            _sharedPagePool.Preheat(TerminalPageConstants.PreheatPagesPerInstance, cols);
 
             // Initialize alternate screen buffer
             _mainScreen = _viewport;  // Main screen is the default viewport

--- a/src/NovaTerminal.VT/TerminalRow.cs
+++ b/src/NovaTerminal.VT/TerminalRow.cs
@@ -15,13 +15,13 @@ namespace NovaTerminal.Core
         public void TouchRevision() => Revision++;
 
         // M2.2: Side-table for extended graphemes (strings)
-        private Dictionary<int, string>? _extendedText;
-        private Dictionary<int, string>? _hyperlinks;
+        private Storage.SmallMap<string>? _extendedText;
+        private Storage.SmallMap<string>? _hyperlinks;
 
         public string? GetExtendedText(int col)
         {
             if (_extendedText == null) return null;
-            return _extendedText.TryGetValue(col, out var text) ? text : null;
+            return _extendedText.TryGet(col, out var text) ? text : null;
         }
 
         public void SetExtendedText(int col, string? text)
@@ -32,8 +32,8 @@ namespace NovaTerminal.Core
                 if (_extendedText?.Count == 0) _extendedText = null;
                 return;
             }
-            _extendedText ??= new Dictionary<int, string>();
-            _extendedText[col] = text;
+            _extendedText ??= new Storage.SmallMap<string>();
+            _extendedText.Set(col, text);
         }
 
         public void ClearExtendedText()
@@ -44,7 +44,7 @@ namespace NovaTerminal.Core
         public string? GetHyperlink(int col)
         {
             if (_hyperlinks == null) return null;
-            return _hyperlinks.TryGetValue(col, out var link) ? link : null;
+            return _hyperlinks.TryGet(col, out var link) ? link : null;
         }
 
         public void SetHyperlink(int col, string? link)
@@ -56,8 +56,8 @@ namespace NovaTerminal.Core
                 return;
             }
 
-            _hyperlinks ??= new Dictionary<int, string>();
-            _hyperlinks[col] = link;
+            _hyperlinks ??= new Storage.SmallMap<string>();
+            _hyperlinks.Set(col, link);
         }
 
         public void ClearHyperlinks()

--- a/tests/NovaTerminal.Tests/AlternateScreenTests.cs
+++ b/tests/NovaTerminal.Tests/AlternateScreenTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Reflection;
 using Xunit;
 using NovaTerminal.Core;
+using NovaTerminal.Core.Storage;
 
 namespace NovaTerminal.Tests
 {
@@ -18,7 +19,7 @@ namespace NovaTerminal.Tests
             for (int i = 0; i < 50; i++)
                 buffer.Write($"History {i}\n");
 
-            int initialScrollbackCount = buffer.ScrollbackRows.Count;
+            int initialScrollbackCount = buffer.Scrollback.Count;
 
             // Enter alt screen (vim)
             parser.Process("\x1b[?1049h");
@@ -31,10 +32,12 @@ namespace NovaTerminal.Tests
             parser.Process("\x1b[?1049l");
 
             // Assert: scrollback unchanged
-            Assert.Equal(initialScrollbackCount, buffer.ScrollbackRows.Count);
+            Assert.Equal(initialScrollbackCount, buffer.Scrollback.Count);
 
             // Assert: vim content not in scrollback
-            var scrollbackText = string.Join("", buffer.ScrollbackRows.Select(r => GetTextFromRow(r)));
+            var sb = buffer.Scrollback;
+            var scrollbackText = "";
+            for (int i = 0; i < sb.Count; i++) scrollbackText += GetTextFromSpan(sb.GetRow(i));
             Assert.DoesNotContain("VIM UI", scrollbackText);
         }
 
@@ -45,7 +48,7 @@ namespace NovaTerminal.Tests
             var parser = new AnsiParser(buffer);
 
             buffer.Write("Main screen content\n");
-            int initialScrollbackCount = buffer.ScrollbackRows.Count;
+            int initialScrollbackCount = buffer.Scrollback.Count;
 
             // Enter alt screen (legacy ?47)
             parser.Process("\x1b[?47h");
@@ -55,7 +58,7 @@ namespace NovaTerminal.Tests
             parser.Process("\x1b[?47l");
 
             // Scrollback should be unchanged
-            Assert.Equal(initialScrollbackCount, buffer.ScrollbackRows.Count);
+            Assert.Equal(initialScrollbackCount, buffer.Scrollback.Count);
         }
 
         [Fact]
@@ -117,7 +120,7 @@ namespace NovaTerminal.Tests
             for (int i = 0; i < 30; i++)
                 buffer.Write($"Line {i}\n");
 
-            int scrollbackBeforeAlt = buffer.ScrollbackRows.Count;
+            int scrollbackBeforeAlt = buffer.Scrollback.Count;
 
             // Enter alt screen
             parser.Process("\x1b[?1049h");
@@ -127,23 +130,32 @@ namespace NovaTerminal.Tests
                 buffer.Write($"Alt Line {i}\n");
 
             // Scrollback should NOT have grown
-            Assert.Equal(scrollbackBeforeAlt, buffer.ScrollbackRows.Count);
+            Assert.Equal(scrollbackBeforeAlt, buffer.Scrollback.Count);
 
             // Exit alt screen
             parser.Process("\x1b[?1049l");
 
             // Scrollback still unchanged
-            Assert.Equal(scrollbackBeforeAlt, buffer.ScrollbackRows.Count);
+            Assert.Equal(scrollbackBeforeAlt, buffer.Scrollback.Count);
         }
 
         private string GetTextFromRow(TerminalRow row)
         {
             if (row.Cells != null)
             {
-                var chars = row.Cells.Select(c => c.Character == '\0' ? ' ' : c.Character).ToArray();
-                return new string(chars).Trim();
+                return GetTextFromSpan(row.Cells);
             }
             return "";
+        }
+
+        private string GetTextFromSpan(ReadOnlySpan<TerminalCell> span)
+        {
+            char[] chars = new char[span.Length];
+            for (int i = 0; i < span.Length; i++)
+            {
+                chars[i] = span[i].Character == '\0' ? ' ' : span[i].Character;
+            }
+            return new string(chars).Trim();
         }
 
         private string GetViewportText(TerminalBuffer buffer)

--- a/tests/NovaTerminal.Tests/Buffer/ScrollbackPagesTests.cs
+++ b/tests/NovaTerminal.Tests/Buffer/ScrollbackPagesTests.cs
@@ -1,0 +1,55 @@
+using System;
+using Xunit;
+using NovaTerminal.Core;
+using NovaTerminal.Core.Storage;
+
+namespace NovaTerminal.Tests.Buffer
+{
+    public class ScrollbackPagesTests : IDisposable
+    {
+        private TerminalPagePool _pool;
+
+        public ScrollbackPagesTests()
+        {
+            _pool = new TerminalPagePool();
+        }
+
+        public void Dispose()
+        {
+            _pool.Clear();
+        }
+
+        [Fact]
+        public void GetRow_SequentialAccess_AvoidsON2Performance()
+        {
+            // Arrange: create a scrollback with 1000 pages (64,000 rows)
+            int cols = 80;
+            var scrollback = new ScrollbackPages(cols, _pool, maxScrollbackBytes: 256L * 1024 * 1024);
+            
+            var defCell = TerminalCell.Default;
+            var rowArray = new TerminalCell[80];
+            for (int i = 0; i < 80; i++) rowArray[i] = defCell;
+            
+            int totalRows = 64000;
+            for (int i = 0; i < totalRows; i++)
+            {
+                // Assign a unique character to ensure we fetch the right row
+                rowArray[0].Character = (char)('A' + (i % 26));
+                scrollback.AppendRow(rowArray.AsSpan());
+            }
+            
+            // Assert Count matches
+            Assert.Equal(totalRows, scrollback.Count);
+
+            // Act & Assert: Sequential access
+            // This loop should be very fast due to the O(1) cache. 
+            // If it were O(N^2), 64000 iterations over 1000 pages would take significant time and could time out.
+            for (int i = 0; i < totalRows; i++)
+            {
+                var row = scrollback.GetRow(i);
+                char expectedChar = (char)('A' + (i % 26));
+                Assert.Equal(expectedChar, row[0].Character);
+            }
+        }
+    }
+}

--- a/tests/NovaTerminal.Tests/Buffer/TerminalMemoryMetricsTests.cs
+++ b/tests/NovaTerminal.Tests/Buffer/TerminalMemoryMetricsTests.cs
@@ -1,0 +1,30 @@
+using Xunit;
+using NovaTerminal.Core;
+using NovaTerminal.Core.Storage;
+
+namespace NovaTerminal.Tests.Buffer
+{
+    public class TerminalMemoryMetricsTests
+    {
+        [Fact]
+        public void GetMemoryMetrics_ReturnsReasonableValues()
+        {
+            var buffer = new TerminalBuffer(80, 24);
+            
+            // Add some scrollback
+            var row = new TerminalCell[80];
+            for (int i = 0; i < 100; i++)
+            {
+                buffer.Scrollback.AppendRow(row, false);
+            }
+
+            var metrics = buffer.GetMemoryMetrics(glyphCacheEntries: 50, glyphCacheAtlasBytes: 1024 * 1024);
+
+            Assert.True(metrics.ScrollbackBytes > 0);
+            Assert.True(metrics.ActivePages > 0);
+            Assert.Equal(80 * 24, metrics.ViewportCells);
+            Assert.Equal(50, metrics.GlyphCacheEntries);
+            Assert.Equal(1024 * 1024, metrics.GlyphCacheAtlasBytes);
+        }
+    }
+}

--- a/tests/NovaTerminal.Tests/BufferTests/ScrollbackThemeTests.cs
+++ b/tests/NovaTerminal.Tests/BufferTests/ScrollbackThemeTests.cs
@@ -1,0 +1,69 @@
+using System;
+using Xunit;
+using NovaTerminal.Core;
+using NovaTerminal.Core.Storage;
+
+namespace NovaTerminal.Tests.BufferTests
+{
+    /// <summary>
+    /// Tests for Category 1: Theme-change correctness for paged scrollback.
+    /// Verifies that UpdateThemeDefaults correctly updates default-colored cells
+    /// while leaving explicitly-colored cells alone.
+    /// </summary>
+    public class ScrollbackThemeTests
+    {
+        [Fact]
+        public void UpdateThemeDefaults_UpdatesDefaultColoredCells()
+        {
+            // Arrange: build a scrollback with two types of cells
+            var pool = new TerminalPagePool();
+            int cols = 10;
+            var scrollback = new ScrollbackPages(cols, pool, maxScrollbackBytes: 16L * 1024 * 1024);
+
+            uint oldFg = TermColor.White.ToUint();
+            uint newFg = TermColor.Cyan.ToUint();
+            uint newBg = TermColor.Red.ToUint();
+
+            // Row 0: default-colored cells (IsDefaultForeground + IsDefaultBackground)
+            var defaultRow = new TerminalCell[cols];
+            for (int i = 0; i < cols; i++)
+            {
+                defaultRow[i] = new TerminalCell(' ', TermColor.White, TermColor.Black,
+                    isDefaultFg: true, isDefaultBg: true);
+            }
+            scrollback.AppendRow(defaultRow.AsSpan());
+
+            // Row 1: explicitly-colored cells (IsDefaultForeground = false)
+            var explicitRow = new TerminalCell[cols];
+            for (int i = 0; i < cols; i++)
+            {
+                explicitRow[i] = new TerminalCell('X', TermColor.Yellow, TermColor.Green,
+                    isDefaultFg: false, isDefaultBg: false);
+            }
+            scrollback.AppendRow(explicitRow.AsSpan());
+
+            Assert.Equal(2, scrollback.Count);
+
+            // Capture initial explicit values
+            uint explicitFg = scrollback.GetRow(1)[0].Fg;
+            uint explicitBg = scrollback.GetRow(1)[0].Bg;
+
+            // Act: simulate a theme change from White/Black -> Cyan/Red
+            var oldTheme = new TerminalTheme { Foreground = TermColor.White, Background = TermColor.Black };
+            var newTheme = new TerminalTheme { Foreground = TermColor.Cyan, Background = TermColor.Red };
+            scrollback.UpdateThemeDefaults(oldTheme, newTheme);
+
+            // Assert: default row should be updated to new theme colors
+            var updatedDefaultRow = scrollback.GetRow(0);
+            Assert.Equal(newFg, updatedDefaultRow[0].Fg);
+            Assert.Equal(newBg, updatedDefaultRow[0].Bg);
+
+            // Assert: explicitly colored row should NOT be changed
+            var updatedExplicitRow = scrollback.GetRow(1);
+            Assert.Equal(explicitFg, updatedExplicitRow[0].Fg); // Yellow preserved
+            Assert.Equal(explicitBg, updatedExplicitRow[0].Bg); // Green preserved
+
+            pool.Clear();
+        }
+    }
+}

--- a/tests/NovaTerminal.Tests/CMDDuplicationTests.cs
+++ b/tests/NovaTerminal.Tests/CMDDuplicationTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 using NovaTerminal.Core;
+using NovaTerminal.Core.Storage;
 using Xunit.Abstractions;
 
 namespace NovaTerminal.Tests
@@ -16,10 +17,10 @@ namespace NovaTerminal.Tests
             _output = output;
         }
 
-        private NovaTerminal.Core.CircularBuffer<TerminalRow> GetScrollback(TerminalBuffer buffer)
+        private ScrollbackPages GetScrollback(TerminalBuffer buffer)
         {
             var field = typeof(TerminalBuffer).GetField("_scrollback", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            return (NovaTerminal.Core.CircularBuffer<TerminalRow>)field!.GetValue(buffer)!;
+            return (ScrollbackPages)field!.GetValue(buffer)!;
         }
 
         private TerminalRow[] GetViewport(TerminalBuffer buffer)
@@ -31,7 +32,16 @@ namespace NovaTerminal.Tests
         private string GetRowText(TerminalRow row)
         {
             if (row == null || row.Cells == null) return "";
-            var chars = row.Cells.Select(c => c.Character == '\0' ? ' ' : c.Character).ToArray();
+            return GetTextFromSpan(row.Cells);
+        }
+
+        private string GetTextFromSpan(ReadOnlySpan<TerminalCell> span)
+        {
+            char[] chars = new char[span.Length];
+            for (int i = 0; i < span.Length; i++)
+            {
+                chars[i] = span[i].Character == '\0' ? ' ' : span[i].Character;
+            }
             return new string(chars).TrimEnd();
         }
 
@@ -44,7 +54,7 @@ namespace NovaTerminal.Tests
             _output.WriteLine("SCROLLBACK:");
             for (int i = 0; i < sb.Count; i++)
             {
-                _output.WriteLine($"  [{i}] '{GetRowText(sb[i])}'");
+                _output.WriteLine($"  [{i}] '{GetTextFromSpan(sb.GetRow(i))}'");
             }
             _output.WriteLine("VIEWPORT:");
             for (int i = 0; i < vp.Length; i++)
@@ -96,18 +106,25 @@ namespace NovaTerminal.Tests
 
             // Assert: Check for duplication
             // Count how many times the prompt appears
-            var allRows = new List<TerminalRow>();
-            allRows.AddRange(GetScrollback(buffer));
-            allRows.AddRange(GetViewport(buffer));
-
             int promptCount = 0;
-            foreach (var row in allRows)
+            var sb = GetScrollback(buffer);
+            for (int i = 0; i < sb.Count; i++)
+            {
+                string text = GetTextFromSpan(sb.GetRow(i));
+                if (text.Contains("C:\\Users\\Dev>"))
+                {
+                    promptCount++;
+                    _output.WriteLine($"Found prompt in scrollback: '{text}'");
+                }
+            }
+            var vp = GetViewport(buffer);
+            foreach (var row in vp)
             {
                 string text = GetRowText(row);
                 if (text.Contains("C:\\Users\\Dev>"))
                 {
                     promptCount++;
-                    _output.WriteLine($"Found prompt in row: '{text}'");
+                    _output.WriteLine($"Found prompt in viewport: '{text}'");
                 }
             }
 
@@ -141,18 +158,18 @@ namespace NovaTerminal.Tests
             DumpBuffer(buffer);
 
             // Check for duplication
-            var allRows = new List<TerminalRow>();
-            allRows.AddRange(GetScrollback(buffer));
-            allRows.AddRange(GetViewport(buffer));
-
             int promptCount = 0;
-            foreach (var row in allRows)
+            var sb = GetScrollback(buffer);
+            for (int i = 0; i < sb.Count; i++)
+            {
+                string text = GetTextFromSpan(sb.GetRow(i));
+                if (text.Contains("C:\\Users\\Dev>")) promptCount++;
+            }
+            var vp = GetViewport(buffer);
+            foreach (var row in vp)
             {
                 string text = GetRowText(row);
-                if (text.Contains("C:\\Users\\Dev>"))
-                {
-                    promptCount++;
-                }
+                if (text.Contains("C:\\Users\\Dev>")) promptCount++;
             }
 
             Assert.Equal(1, promptCount);

--- a/tests/NovaTerminal.Tests/GraphicsTests.cs
+++ b/tests/NovaTerminal.Tests/GraphicsTests.cs
@@ -87,7 +87,7 @@ namespace NovaTerminal.Tests
             parser.Process("\x1b_Ga=q,i=31\x1b\\");
 
             Assert.NotNull(response);
-            Assert.Contains(";ERR", response, StringComparison.Ordinal);
+            Assert.Contains(";ERR", response!, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -102,7 +102,7 @@ namespace NovaTerminal.Tests
             parser.Process("\x1b]1339;K:Ga=q,i=31\x07");
 
             Assert.NotNull(response);
-            Assert.Contains(";OK", response, StringComparison.Ordinal);
+            Assert.Contains(";OK", response!, StringComparison.Ordinal);
         }
     }
 }

--- a/tests/NovaTerminal.Tests/Input/TerminalInputSenderTests.cs
+++ b/tests/NovaTerminal.Tests/Input/TerminalInputSenderTests.cs
@@ -14,7 +14,7 @@ namespace NovaTerminal.Tests.Input
         {
             // Arrange
             var mockSession = new Mock<ITerminalSession>();
-            string sentPayload = null;
+            string? sentPayload = null;
             
             mockSession.Setup(s => s.SendInput(It.IsAny<string>()))
                        .Callback<string>(s => sentPayload = s);
@@ -34,7 +34,7 @@ namespace NovaTerminal.Tests.Input
         {
             // Arrange
             var mockSession = new Mock<ITerminalSession>();
-            string sentPayload = null;
+            string? sentPayload = null;
             
             mockSession.Setup(s => s.SendInput(It.IsAny<string>()))
                        .Callback<string>(s => sentPayload = s);

--- a/tests/NovaTerminal.Tests/OhMyPoshTests.cs
+++ b/tests/NovaTerminal.Tests/OhMyPoshTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 using NovaTerminal.Core;
+using NovaTerminal.Core.Storage;
 using Xunit.Abstractions;
 
 namespace NovaTerminal.Tests
@@ -16,10 +17,10 @@ namespace NovaTerminal.Tests
             _output = output;
         }
 
-        private NovaTerminal.Core.CircularBuffer<TerminalRow> GetScrollback(TerminalBuffer buffer)
+        private ScrollbackPages GetScrollback(TerminalBuffer buffer)
         {
             var field = typeof(TerminalBuffer).GetField("_scrollback", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            return (NovaTerminal.Core.CircularBuffer<TerminalRow>)field!.GetValue(buffer)!;
+            return (ScrollbackPages)field!.GetValue(buffer)!;
         }
 
         private TerminalRow[] GetViewport(TerminalBuffer buffer)
@@ -31,7 +32,16 @@ namespace NovaTerminal.Tests
         private string GetRowText(TerminalRow row)
         {
             if (row == null || row.Cells == null) return "";
-            var chars = row.Cells.Select(c => c.Character == '\0' ? ' ' : c.Character).ToArray();
+            return GetTextFromSpan(row.Cells);
+        }
+
+        private string GetTextFromSpan(ReadOnlySpan<TerminalCell> span)
+        {
+            char[] chars = new char[span.Length];
+            for (int i = 0; i < span.Length; i++)
+            {
+                chars[i] = span[i].Character == '\0' ? ' ' : span[i].Character;
+            }
             return new string(chars).TrimEnd();
         }
 

--- a/tests/NovaTerminal.Tests/PowerShellBehaviorTests.cs
+++ b/tests/NovaTerminal.Tests/PowerShellBehaviorTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 using NovaTerminal.Core;
+using NovaTerminal.Core.Storage;
 using Xunit.Abstractions;
 
 namespace NovaTerminal.Tests
@@ -21,10 +22,10 @@ namespace NovaTerminal.Tests
             _output = output;
         }
 
-        private NovaTerminal.Core.CircularBuffer<TerminalRow> GetScrollback(TerminalBuffer buffer)
+        private ScrollbackPages GetScrollback(TerminalBuffer buffer)
         {
             var field = typeof(TerminalBuffer).GetField("_scrollback", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            return (NovaTerminal.Core.CircularBuffer<TerminalRow>)field!.GetValue(buffer)!;
+            return (ScrollbackPages)field!.GetValue(buffer)!;
         }
 
         private TerminalRow[] GetViewport(TerminalBuffer buffer)
@@ -36,7 +37,16 @@ namespace NovaTerminal.Tests
         private string GetRowText(TerminalRow row)
         {
             if (row == null || row.Cells == null) return "";
-            var chars = row.Cells.Select(c => c.Character == '\0' ? ' ' : c.Character).ToArray();
+            return GetTextFromSpan(row.Cells);
+        }
+
+        private string GetTextFromSpan(ReadOnlySpan<TerminalCell> span)
+        {
+            char[] chars = new char[span.Length];
+            for (int i = 0; i < span.Length; i++)
+            {
+                chars[i] = span[i].Character == '\0' ? ' ' : span[i].Character;
+            }
             return new string(chars).TrimEnd();
         }
 
@@ -49,7 +59,7 @@ namespace NovaTerminal.Tests
             _output.WriteLine("SCROLLBACK:");
             for (int i = 0; i < sb.Count; i++)
             {
-                _output.WriteLine($"  [{i}] '{GetRowText(sb[i])}'");
+                _output.WriteLine($"  [{i}] '{GetTextFromSpan(sb.GetRow(i))}'");
             }
             _output.WriteLine("VIEWPORT:");
             for (int i = 0; i < vp.Length; i++)

--- a/tests/NovaTerminal.Tests/ReflowRegressionTests.cs
+++ b/tests/NovaTerminal.Tests/ReflowRegressionTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 using NovaTerminal.Core;
+using NovaTerminal.Core.Storage;
 using Xunit.Abstractions;
 
 namespace NovaTerminal.Tests
@@ -19,50 +20,43 @@ namespace NovaTerminal.Tests
         // Helper to check standard prompt preservation
         private bool RowContainsText(TerminalBuffer buffer, int rowIndex, string text)
         {
-            var row = GetRow(buffer, rowIndex);
-            var rowText = GetRowText(row);
+            var rowText = GetRowText(buffer, rowIndex);
             return rowText.Contains(text);
         }
 
-        private TerminalRow GetRow(TerminalBuffer buffer, int rowIndex)
-        {
-            // Handle extended indices (Virtual interface simulation)
-            // Just use the internal method logic via reflection or simple mapping
-            if (rowIndex < 0) return null;
-
-            // Map to Scrollback + Viewport
-            // We need a helper that exposes the *whole* simulated linear buffer
-            // But for simple tests, we can peek private methods or just use what we have.
-            // Let's rely on TerminalBuffer's GetCellAbsolute or similar? No, that's complex.
-            // Let's use the Reflection helpers we established in ReflowScenariosTests
-            // Copied locally for isolation
-            return InternalGetRow(buffer, rowIndex);
-        }
-
-        // --- Helper Reflection Methods (Copied/Adapted) ---
-        private TerminalRow InternalGetRow(TerminalBuffer buffer, int absoluteIndex)
+        private string GetRowText(TerminalBuffer buffer, int absoluteIndex)
         {
             var sb = GetScrollback(buffer);
             var vp = GetViewport(buffer);
             int sbCount = sb.Count;
 
-            if (absoluteIndex < sbCount) return sb[absoluteIndex];
+            if (absoluteIndex < sbCount)
+            {
+                return GetTextFromSpan(sb.GetRow(absoluteIndex));
+            }
+            
             int vpIndex = absoluteIndex - sbCount;
-            if (vpIndex >= 0 && vpIndex < vp.Length) return vp[vpIndex];
-            return null;
+            if (vpIndex >= 0 && vpIndex < vp.Length)
+            {
+                return GetTextFromSpan(vp[vpIndex].Cells);
+            }
+            return "";
         }
 
-        private string GetRowText(TerminalRow row)
+        private string GetTextFromSpan(ReadOnlySpan<TerminalCell> span)
         {
-            if (row == null || row.Cells == null) return "";
-            var chars = row.Cells.Select(c => c.Character == '\0' ? ' ' : c.Character).ToArray();
+            char[] chars = new char[span.Length];
+            for (int i = 0; i < span.Length; i++)
+            {
+                chars[i] = span[i].Character == '\0' ? ' ' : span[i].Character;
+            }
             return new string(chars).TrimEnd();
         }
 
-        private NovaTerminal.Core.CircularBuffer<TerminalRow> GetScrollback(TerminalBuffer buffer)
+        private ScrollbackPages GetScrollback(TerminalBuffer buffer)
         {
             var field = typeof(TerminalBuffer).GetField("_scrollback", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            return (NovaTerminal.Core.CircularBuffer<TerminalRow>)field!.GetValue(buffer)!;
+            return (ScrollbackPages)field!.GetValue(buffer)!;
         }
 
         private TerminalRow[] GetViewport(TerminalBuffer buffer)
@@ -99,8 +93,7 @@ namespace NovaTerminal.Tests
             buffer.Resize(60, 24);
 
             // Assert: Prompt should be preserved (not cleared)
-            var row = GetRow(buffer, buffer.ScrollbackRows.Count + buffer.CursorRow);
-            string text = GetRowText(row);
+            string text = GetRowText(buffer, buffer.Scrollback.Count + buffer.CursorRow);
 
             _output.WriteLine($"Cursor Row Text after resize: '{text}'");
 
@@ -143,8 +136,7 @@ namespace NovaTerminal.Tests
             Assert.Equal(expectedCol, buffer.CursorCol);
 
             // 3. Prompt text should be at the cursor row
-            var row = GetRow(buffer, buffer.ScrollbackRows.Count + buffer.CursorRow);
-            Assert.Contains("PS Bottom>", GetRowText(row));
+            Assert.Contains("PS Bottom>", GetRowText(buffer, buffer.Scrollback.Count + buffer.CursorRow));
         }
 
         // ====================================================================
@@ -177,7 +169,7 @@ namespace NovaTerminal.Tests
             var sb = GetScrollback(buffer);
             if (sb.Count > 0)
             {
-                var lastHistory = GetRowText(sb.Last());
+                var lastHistory = GetTextFromSpan(sb.GetRow(sb.Count - 1));
                 // The history might validly contain the specific *previous* command output ("History")
                 // but should NOT contain the Active Prompt we just reflowed.
                 Assert.DoesNotContain("long-hostname", lastHistory);
@@ -194,7 +186,7 @@ namespace NovaTerminal.Tests
             // during a vertical resize, which would cause the shell to effectively "duplicate" it
             // when it redraws the cursor line.
 
-            // Ideally, the "Active Logical Line" (where cursor is) should stay in the Viewport
+            // Ideally, the "Active Logical Line" (where cursor is) stay in the Viewport
             // as much as possible, or if it moves to scrollback, the cursor should follow it exactly?
             // Actually, usually on vertical resize, if we just grow/shrink height, 
             // the *relative* view changes.
@@ -217,12 +209,12 @@ namespace NovaTerminal.Tests
             // Check Viewport Bottom
             var vp = GetViewport(buffer);
             var bottomRow = vp[buffer.CursorRow]; // Should be last row (19)
-            Assert.Contains("ActivePrompt", GetRowText(bottomRow));
+            Assert.Contains("ActivePrompt", GetTextFromSpan(bottomRow.Cells));
 
             // Check Scrollback Last
             var sb = GetScrollback(buffer);
-            var lastSb = sb.Last(); // Should be "Line X"
-            Assert.DoesNotContain("ActivePrompt", GetRowText(lastSb));
+            var lastSb = GetTextFromSpan(sb.GetRow(sb.Count - 1)); // Should be "Line X"
+            Assert.DoesNotContain("ActivePrompt", lastSb);
         }
     }
 }

--- a/tests/NovaTerminal.Tests/ReflowScenariosTests.cs
+++ b/tests/NovaTerminal.Tests/ReflowScenariosTests.cs
@@ -1,5 +1,6 @@
 using Xunit;
 using NovaTerminal.Core;
+using NovaTerminal.Core.Storage;
 using System.Text;
 using Xunit.Abstractions;
 using System.Collections.Generic;
@@ -19,22 +20,25 @@ namespace NovaTerminal.Tests
         private string GetRowText(TerminalBuffer buffer, int physIdx)
         {
             var sbCount = GetScrollbackCount(buffer);
-            TerminalRow row;
             if (physIdx < sbCount)
             {
-                row = GetScrollbackRow(buffer, physIdx);
+                return GetTextFromSpan(buffer.Scrollback.GetRow(physIdx));
             }
             else
             {
-                row = GetViewportRow(buffer, physIdx - sbCount);
+                var row = GetViewportRow(buffer, physIdx - sbCount);
+                return GetTextFromSpan(row.Cells);
             }
+        }
 
-            StringBuilder sb = new StringBuilder();
-            foreach (var cell in row.Cells)
+        private string GetTextFromSpan(ReadOnlySpan<TerminalCell> span)
+        {
+            char[] chars = new char[span.Length];
+            for (int i = 0; i < span.Length; i++)
             {
-                sb.Append(cell.Character == '\0' ? ' ' : cell.Character);
+                chars[i] = span[i].Character == '\0' ? ' ' : span[i].Character;
             }
-            return sb.ToString();
+            return new string(chars);
         }
 
         private void WriteLines(TerminalBuffer buffer, int count)
@@ -58,16 +62,7 @@ namespace NovaTerminal.Tests
 
         private int GetScrollbackCount(TerminalBuffer buffer)
         {
-            var field = typeof(TerminalBuffer).GetField("_scrollback", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            var list = (IReadOnlyList<TerminalRow>)field!.GetValue(buffer)!;
-            return list.Count;
-        }
-
-        private TerminalRow GetScrollbackRow(TerminalBuffer buffer, int idx)
-        {
-            var field = typeof(TerminalBuffer).GetField("_scrollback", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            var list = (IReadOnlyList<TerminalRow>)field!.GetValue(buffer)!;
-            return list[idx]!;
+            return buffer.Scrollback.Count;
         }
 
         private TerminalRow GetViewportRow(TerminalBuffer buffer, int idx)
@@ -330,14 +325,24 @@ namespace NovaTerminal.Tests
 
             for (int i = 0; i < totalPhys; i++)
             {
-                var row = (i < sbCount) ? GetScrollbackRow(buffer, i) : GetViewportRow(buffer, i - sbCount);
+                string rowText;
+                bool isWrapped;
 
-                StringBuilder rowText = new StringBuilder();
-                foreach (var c in row.Cells) rowText.Append(c.Character == '\0' ? ' ' : c.Character);
+                if (i < sbCount)
+                {
+                    rowText = GetTextFromSpan(buffer.Scrollback.GetRow(i));
+                    isWrapped = buffer.Scrollback.IsRowWrapped(i);
+                }
+                else
+                {
+                    var row = GetViewportRow(buffer, i - sbCount);
+                    rowText = GetTextFromSpan(row.Cells);
+                    isWrapped = row.IsWrapped;
+                }
 
-                currentLogical.Append(rowText.ToString().TrimEnd());
+                currentLogical.Append(rowText.TrimEnd());
 
-                if (!row.IsWrapped)
+                if (!isWrapped)
                 {
                     string logical = currentLogical.ToString().Trim();
                     if (logical.StartsWith("[LINE-"))
@@ -356,12 +361,8 @@ namespace NovaTerminal.Tests
         private bool GetRowWrapped(TerminalBuffer buffer, int physIdx)
         {
             var sbCount = GetScrollbackCount(buffer);
-            TerminalRow row;
-            if (physIdx < sbCount)
-                row = GetScrollbackRow(buffer, physIdx);
-            else
-                row = GetViewportRow(buffer, physIdx - sbCount);
-            return row.IsWrapped;
+            if (physIdx < sbCount) return buffer.Scrollback.IsRowWrapped(physIdx);
+            return GetViewportRow(buffer, physIdx - sbCount).IsWrapped;
         }
 
         [Fact]
@@ -480,12 +481,6 @@ namespace NovaTerminal.Tests
         [Fact]
         public void HorizontalResize_PromptAtBottom_ShouldKeepCursorVisible()
         {
-            // Scenario: 20x5. Filled with 4 lines of text. Prompt on Line 4 (Bottom).
-            // Shrink to 10x5. Text wraps.
-            // Should force scroll (content pushes to SB).
-            // Cursor should remain at Bottom (Line 4).
-            // Old content should be in SB.
-
             var buffer = new TerminalBuffer(20, 5);
             buffer.Write("Line 1\r\n");
             buffer.Write("Line 2\r\n");
@@ -499,55 +494,12 @@ namespace NovaTerminal.Tests
             // Cursor at (4, 8)
             Assert.Equal(4, buffer.CursorRow);
 
-            // Shrink width to 10.
-            // "Line X" (6 chars) -> No wrap.
-            // "Prompt> " (8 chars) -> No wrap.
-            // Wait, this doesn't force wrap. I need longer lines.
-            // Let's use 20 chars lines.
-            // "12345678901234567890" (20 chars).
-            // Shrink to 10. Becomes 2 lines each.
-
-            buffer.Resize(20, 5); // Reset size just in case (no op)
-            // Clear and Refill
-            // We can't clear easily without helper, just make new buffer
             buffer = new TerminalBuffer(20, 5);
             buffer.Write("12345678901234567890"); // Line 0
             buffer.Write("12345678901234567890"); // Line 1
             buffer.Write("12345678901234567890"); // Line 2
             buffer.Write("12345678901234567890"); // Line 3
             buffer.Write("Prompt> ");             // Line 4 (8 chars)
-
-            // Cursor at (4, 8).
-
-            // Shrink to 10.
-            // Line 0 -> 2 lines.
-            // Line 1 -> 2 lines.
-            // Line 2 -> 2 lines.
-            // Line 3 -> 2 lines.
-            // Prompt -> 1 line.
-            // Total 9 lines.
-            // Buffer Height 5.
-            // We expect 4 lines to go to SB.
-            // Viewport shows last 5 lines.
-            // VP[0] = Line 2b.
-            // VP[1] = Line 3a.
-            // VP[2] = Line 3b.
-            // VP[3] = Prompt.
-            // VP[4] = Empty/Padding?
-
-            // Wait, "Top Anchoring" logic for Shrink:
-            // "activeContentSize" = 9. "newRows" = 5.
-            // "sbCount" increases by 4.
-            // "vpCount" = 5.
-            // We fill viewport with last 5 rows.
-            // Prompt (Row 8) should be at VP[3] or VP[4]?
-            // Rows are 0..8.
-            // SB gets 0..3.
-            // VP gets 4..8.
-            // Row 4 is "1234..." (Line 2 part 1).
-            // Row 8 is "Prompt> ".
-            // So VP contains: Line 2a, Line 2b, Line 3a, Line 3b, Prompt.
-            // So Prompt is at VP[4] (Bottom).
 
             buffer.Resize(10, 5);
 

--- a/tests/NovaTerminal.Tests/RenderTests/GlyphCacheTests.cs
+++ b/tests/NovaTerminal.Tests/RenderTests/GlyphCacheTests.cs
@@ -1,0 +1,93 @@
+using System;
+using Xunit;
+using SkiaSharp;
+using NovaTerminal.Core;
+
+namespace NovaTerminal.Tests.Rendering
+{
+    public class GlyphCacheTests : IDisposable
+    {
+        private readonly GlyphCache _cache;
+        private readonly SKTypeface _typeface;
+        private readonly SKFont _font;
+
+        public GlyphCacheTests()
+        {
+            _cache = new GlyphCache();
+            _typeface = SKTypeface.FromFamilyName("Arial");
+            _font = new SKFont(_typeface, 12);
+        }
+
+        [Fact]
+        public void GetOrAdd_ReturnsValidRect()
+        {
+            var result = _cache.GetOrAdd("A", _font, 1.0f);
+            Assert.NotNull(result);
+            Assert.True(result.Value.Rect.Width > 0);
+            Assert.True(result.Value.Rect.Height > 0);
+        }
+
+        [Fact]
+        public void GetOrAdd_IdenticalParameters_ReturnsSameRect()
+        {
+            var result1 = _cache.GetOrAdd("A", _font, 1.0f);
+            var result2 = _cache.GetOrAdd("A", _font, 1.0f);
+
+            Assert.Equal(result1!.Value.Rect, result2!.Value.Rect);
+        }
+
+        [Fact]
+        public void GetOrAdd_DifferentText_ReturnsDifferentRect()
+        {
+            var result1 = _cache.GetOrAdd("A", _font, 1.0f);
+            var result2 = _cache.GetOrAdd("B", _font, 1.0f);
+
+            Assert.NotEqual(result1!.Value.Rect, result2!.Value.Rect);
+        }
+
+        [Fact]
+        public void GetOrAdd_DifferentSize_ReturnsDifferentRect()
+        {
+            using var font2 = new SKFont(_typeface, 14);
+            var result1 = _cache.GetOrAdd("A", _font, 1.0f);
+            var result2 = _cache.GetOrAdd("A", font2, 1.0f);
+
+            Assert.NotEqual(result1!.Value.Rect, result2!.Value.Rect);
+        }
+
+        [Fact]
+        public void GetOrAdd_DifferentScale_ReturnsDifferentRect()
+        {
+            var result1 = _cache.GetOrAdd("A", _font, 1.0f);
+            var result2 = _cache.GetOrAdd("A", _font, 2.0f);
+
+            Assert.NotEqual(result1!.Value.Rect, result2!.Value.Rect);
+        }
+
+        [Fact]
+        public void GetOrAdd_EmptyText_ReturnsNull()
+        {
+            var result = _cache.GetOrAdd("", _font, 1.0f);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Clear_InvalidatesCache()
+        {
+            var result1 = _cache.GetOrAdd("A", _font, 1.0f);
+            _cache.Clear();
+            var result2 = _cache.GetOrAdd("A", _font, 1.0f);
+
+            // They might get the same rect if the atlas packer starts over,
+            // but for a test of logic, we just ensure it doesn't crash.
+            Assert.NotNull(result2);
+        }
+
+        public void Dispose()
+        {
+            _font.Dispose();
+            _typeface.Dispose();
+            _cache.Dispose();
+        }
+    }
+}

--- a/tests/NovaTerminal.Tests/Storage/SmallMapTests.cs
+++ b/tests/NovaTerminal.Tests/Storage/SmallMapTests.cs
@@ -1,0 +1,136 @@
+using System;
+using Xunit;
+using NovaTerminal.Core.Storage;
+
+namespace NovaTerminal.Tests.Storage
+{
+    public class SmallMapTests
+    {
+        [Fact]
+        public void InitialCount_IsZero()
+        {
+            var map = new SmallMap<string>();
+            Assert.Equal(0, map.Count);
+        }
+
+        [Fact]
+        public void Set_IncrementsCount()
+        {
+            var map = new SmallMap<string>();
+            map.Set(10, "Value10");
+            Assert.Equal(1, map.Count);
+        }
+
+        [Fact]
+        public void TryGet_RetrievesValue()
+        {
+            var map = new SmallMap<string>();
+            map.Set(10, "Value10");
+            
+            bool found = map.TryGet(10, out var value);
+            
+            Assert.True(found);
+            Assert.Equal("Value10", value);
+        }
+
+        [Fact]
+        public void TryGet_ReturnsFalse_ForMissingKey()
+        {
+            var map = new SmallMap<string>();
+            map.Set(10, "Value10");
+            
+            bool found = map.TryGet(20, out var value);
+            
+            Assert.False(found);
+            Assert.Null(value);
+        }
+
+        [Fact]
+        public void Set_UpdatesExistingKey()
+        {
+            var map = new SmallMap<string>();
+            map.Set(10, "OldValue");
+            map.Set(10, "NewValue");
+            
+            Assert.Equal(1, map.Count);
+            map.TryGet(10, out var value);
+            Assert.Equal("NewValue", value);
+        }
+
+        [Fact]
+        public void SmallStorage_HandlesMultipleEntries()
+        {
+            var map = new SmallMap<string>();
+            for (int i = 0; i < 8; i++)
+            {
+                map.Set(i, $"Value{i}");
+            }
+            
+            Assert.Equal(8, map.Count);
+            for (int i = 0; i < 8; i++)
+            {
+                Assert.True(map.TryGet(i, out var value));
+                Assert.Equal($"Value{i}", value);
+            }
+        }
+
+        [Fact]
+        public void Upgrade_ToDictionary_WhenExceedingEight()
+        {
+            var map = new SmallMap<string>();
+            for (int i = 0; i < 9; i++)
+            {
+                map.Set(i, $"Value{i}");
+            }
+            
+            Assert.Equal(9, map.Count);
+            for (int i = 0; i < 9; i++)
+            {
+                Assert.True(map.TryGet(i, out var value));
+                Assert.Equal($"Value{i}", value);
+            }
+        }
+
+        [Fact]
+        public void Remove_FromSmallStorage()
+        {
+            var map = new SmallMap<string>();
+            map.Set(1, "V1");
+            map.Set(2, "V2");
+            map.Set(3, "V3");
+            
+            map.Remove(2);
+            
+            Assert.Equal(2, map.Count);
+            Assert.True(map.TryGet(1, out _));
+            Assert.False(map.TryGet(2, out _));
+            Assert.True(map.TryGet(3, out _));
+        }
+
+        [Fact]
+        public void Remove_FromLargeStorage()
+        {
+            var map = new SmallMap<string>();
+            for (int i = 0; i < 10; i++)
+            {
+                map.Set(i, $"V{i}");
+            }
+            
+            map.Remove(5);
+            
+            Assert.Equal(9, map.Count);
+            Assert.False(map.TryGet(5, out _));
+            Assert.True(map.TryGet(4, out _));
+            Assert.True(map.TryGet(6, out _));
+        }
+
+        [Fact]
+        public void Remove_NonExistentKey_DoesNothing()
+        {
+            var map = new SmallMap<string>();
+            map.Set(1, "V1");
+            map.Remove(99);
+            Assert.Equal(1, map.Count);
+        }
+    }
+}

--- a/tests/NovaTerminal.Tests/TerminalBufferTests.cs
+++ b/tests/NovaTerminal.Tests/TerminalBufferTests.cs
@@ -85,7 +85,7 @@ namespace NovaTerminal.Tests
             return (ScrollbackPages)field!.GetValue(buffer)!;
         }
 
-        private string GetTextFromRow(TerminalRow row)
+        private string GetRowTextContent(TerminalRow row)
         {
             if (row.Cells != null)
             {
@@ -291,7 +291,7 @@ namespace NovaTerminal.Tests
             for (int i = 0; i < sbRows.Count; i++) contentTexts.Add(GetTextFromSpan(sbRows.GetRow(i)));
             
             var vpRows = GetViewport(buffer);
-            foreach (var r in vpRows) contentTexts.Add(GetTextFromRow(r));
+            foreach (var r in vpRows) contentTexts.Add(GetRowTextContent(r));
 
             var contentRowsText = contentTexts.Where(t => !string.IsNullOrWhiteSpace(t)).ToList();
 
@@ -408,7 +408,7 @@ namespace NovaTerminal.Tests
             for (int i = 0; i < sb.Count; i++) list.Add(GetTextFromSpan(sb.GetRow(i)));
             
             var vp = GetViewport(buffer);
-            foreach (var r in vp) list.Add(GetTextFromRow(r));
+            foreach (var r in vp) list.Add(GetRowTextContent(r));
             return list;
         }
 
@@ -504,16 +504,6 @@ namespace NovaTerminal.Tests
             // Assert
             var field = typeof(TerminalBuffer).GetField("_scrollback", BindingFlags.NonPublic | BindingFlags.Instance);
             var scrollback = (ScrollbackPages)field!.GetValue(buffer)!;
-
-            static string GetTextFromRow(TerminalRow row)
-            {
-                if (row.Cells != null)
-                {
-                    var chars = row.Cells.Select(c => c.Character == '\0' ? ' ' : c.Character).ToArray();
-                    return new string(chars).Trim();
-                }
-                return "";
-            }
 
             var sbText = "";
             for (int i = 0; i < scrollback.Count; i++) sbText += GetTextFromSpan(scrollback.GetRow(i)) + "\n";

--- a/tests/NovaTerminal.Tests/TerminalBufferTests.cs
+++ b/tests/NovaTerminal.Tests/TerminalBufferTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using Xunit;
 using NovaTerminal.Core;
+using NovaTerminal.Core.Storage;
 using Avalonia.Media;
 
 namespace NovaTerminal.Tests
@@ -70,28 +71,37 @@ namespace NovaTerminal.Tests
             // Check if last line of scrollback contains prompt text
             if (newScrollbackCount > 0)
             {
-                var lastHistoryLine = newScrollback.Last();
-                var text = GetTextFromRow(lastHistoryLine);
+                var lastHistoryRow = newScrollback.GetRow(newScrollbackCount - 1);
+                var text = GetTextFromSpan(lastHistoryRow);
 
                 Assert.DoesNotContain("Command Input", text);
                 Assert.DoesNotContain("user@host", text);
             }
         }
 
-        private NovaTerminal.Core.CircularBuffer<TerminalRow> GetScrollback(TerminalBuffer buffer)
+        private ScrollbackPages GetScrollback(TerminalBuffer buffer)
         {
             var field = typeof(TerminalBuffer).GetField("_scrollback", BindingFlags.NonPublic | BindingFlags.Instance);
-            return (NovaTerminal.Core.CircularBuffer<TerminalRow>)field!.GetValue(buffer)!;
+            return (ScrollbackPages)field!.GetValue(buffer)!;
         }
 
         private string GetTextFromRow(TerminalRow row)
         {
             if (row.Cells != null)
             {
-                var chars = row.Cells.Select(c => c.Character == '\0' ? ' ' : c.Character).ToArray();
-                return new string(chars).Trim();
+                return GetTextFromSpan(row.Cells);
             }
             return "";
+        }
+
+        private string GetTextFromSpan(ReadOnlySpan<TerminalCell> span)
+        {
+            char[] chars = new char[span.Length];
+            for (int i = 0; i < span.Length; i++)
+            {
+                chars[i] = span[i].Character == '\0' ? ' ' : span[i].Character;
+            }
+            return new string(chars).Trim();
         }
 
         [Fact]
@@ -152,7 +162,7 @@ namespace NovaTerminal.Tests
 
             // Assert
             var scrollback = GetScrollback(buffer);
-            var text = GetTextFromRow(scrollback.Last());
+            var text = GetTextFromSpan(scrollback.GetRow(scrollback.Count - 1));
 
             // Should NOT contain the prompt
             Assert.DoesNotContain("user@host", text);
@@ -195,7 +205,7 @@ namespace NovaTerminal.Tests
             // If this test FAILS (Duplication), then Fallback Logic is broken.
 
             var scrollback = GetScrollback(buffer);
-            var text = GetTextFromRow(scrollback.Last());
+            var text = GetTextFromSpan(scrollback.GetRow(scrollback.Count - 1));
 
             // Attempt to assert NO duplication (Validation of Fallback)
             Assert.DoesNotContain("user@host", text);
@@ -238,7 +248,7 @@ namespace NovaTerminal.Tests
                 $"History was wiped! Expected > 50 lines, found {newScrollback.Count}. Upward scan likely too greedy.");
 
             // Also check that the TOP of history is preserved
-            var firstLine = GetTextFromRow(newScrollback[0]);
+            var firstLine = GetTextFromSpan(newScrollback.GetRow(0));
             Assert.Contains("Data Line 0", firstLine);
         }
         [Fact]
@@ -276,22 +286,23 @@ namespace NovaTerminal.Tests
             var viewport = GetViewport(buffer);
 
             // Combine all rows to check content
-            var allRows = new List<TerminalRow>();
-            allRows.AddRange(scrollback);
-            allRows.AddRange(viewport);
+            var contentTexts = new List<string>();
+            var sbRows = GetScrollback(buffer);
+            for (int i = 0; i < sbRows.Count; i++) contentTexts.Add(GetTextFromSpan(sbRows.GetRow(i)));
+            
+            var vpRows = GetViewport(buffer);
+            foreach (var r in vpRows) contentTexts.Add(GetTextFromRow(r));
 
-            // Filter to just the rows that have text or are part of the content block
-            // (Ignoring the massive empty padding at the end of viewport)
-            var contentRows = allRows.Where(r => !IsRowEmpty(r)).ToList();
+            var contentRowsText = contentTexts.Where(t => !string.IsNullOrWhiteSpace(t)).ToList();
 
             // We expect exactly 4 content rows.
             // If the bug exists, we might see 8, 12, or spaces in between.
 
-            Assert.Equal(4, contentRows.Count);
-            Assert.Contains("Line 1", GetTextFromRow(contentRows[0]));
-            Assert.Contains("Line 2", GetTextFromRow(contentRows[1]));
-            Assert.Contains("Line 3", GetTextFromRow(contentRows[2]));
-            Assert.Contains("Line 4", GetTextFromRow(contentRows[3]));
+            Assert.Equal(4, contentRowsText.Count);
+            Assert.Contains("Line 1", contentRowsText[0]);
+            Assert.Contains("Line 2", contentRowsText[1]);
+            Assert.Contains("Line 3", contentRowsText[2]);
+            Assert.Contains("Line 4", contentRowsText[3]);
         }
 
 
@@ -328,7 +339,7 @@ namespace NovaTerminal.Tests
 
             if (scrollback.Count > 0)
             {
-                var text = GetTextFromRow(scrollback.Last());
+                var text = GetTextFromSpan(scrollback.GetRow(scrollback.Count - 1));
                 Assert.DoesNotContain("user@host", text);
             }
         }
@@ -366,12 +377,8 @@ namespace NovaTerminal.Tests
                 buffer.Resize(80, 24);     // Srink width
             }
 
-            var all = GetAllRows(buffer);
-            var nonNullContent = all.Where(r =>
-            {
-                foreach (var c in r.Cells) if (c.Character != '\0' && c.Character != ' ') return true;
-                return false;
-            }).ToList();
+            var allTexts = GetAllRowTexts(buffer);
+            var nonNullContent = allTexts.Where(t => !string.IsNullOrWhiteSpace(t)).ToList();
 
             // Should just be 2 lines
             Assert.Equal(2, nonNullContent.Count);
@@ -394,11 +401,14 @@ namespace NovaTerminal.Tests
             viewport[viewport.Length - 1] = row;
         }
 
-        private List<TerminalRow> GetAllRows(TerminalBuffer buffer)
+        private List<string> GetAllRowTexts(TerminalBuffer buffer)
         {
-            var list = new List<TerminalRow>();
-            list.AddRange(GetScrollback(buffer));
-            list.AddRange(GetViewport(buffer));
+            var list = new List<string>();
+            var sb = GetScrollback(buffer);
+            for (int i = 0; i < sb.Count; i++) list.Add(GetTextFromSpan(sb.GetRow(i)));
+            
+            var vp = GetViewport(buffer);
+            foreach (var r in vp) list.Add(GetTextFromRow(r));
             return list;
         }
 
@@ -493,7 +503,7 @@ namespace NovaTerminal.Tests
 
             // Assert
             var field = typeof(TerminalBuffer).GetField("_scrollback", BindingFlags.NonPublic | BindingFlags.Instance);
-            var scrollback = (NovaTerminal.Core.CircularBuffer<TerminalRow>)field!.GetValue(buffer)!;
+            var scrollback = (ScrollbackPages)field!.GetValue(buffer)!;
 
             static string GetTextFromRow(TerminalRow row)
             {
@@ -505,7 +515,9 @@ namespace NovaTerminal.Tests
                 return "";
             }
 
-            var historyText = string.Join("\n", scrollback.Select(GetTextFromRow));
+            var sbText = "";
+            for (int i = 0; i < scrollback.Count; i++) sbText += GetTextFromSpan(scrollback.GetRow(i)) + "\n";
+            var historyText = sbText.Trim();
 
             // Neither part of the prompt should be in history
             Assert.DoesNotContain("user@host", historyText);
@@ -531,12 +543,18 @@ namespace NovaTerminal.Tests
 
             // Access _scrollback via reflection for thorough check
             var field = typeof(TerminalBuffer).GetField("_scrollback", BindingFlags.NonPublic | BindingFlags.Instance);
-            var sb = (NovaTerminal.Core.CircularBuffer<TerminalRow>)field!.GetValue(buffer)!;
+            var sb = (ScrollbackPages)field!.GetValue(buffer)!;
 
             // Check Scrollback
-            foreach (var row in sb)
-                foreach (var cell in row.Cells)
+            for (int i = 0; i < sb.Count; i++)
+            {
+                var rowSpan = sb.GetRow(i);
+                foreach (var cell in rowSpan)
+                {
                     if (cell.Background == TermColor.Red) { foundRed = true; break; }
+                }
+                if (foundRed) break;
+            }
 
             // Check Viewport
             if (!foundRed)
@@ -571,7 +589,7 @@ namespace NovaTerminal.Tests
             for (int i = 0; i < 5; i++) buffer.Write($"Line {i}\n");
             buffer.Write("Prompt> ");
 
-            int initialTotal = buffer.ScrollbackRows.Count + buffer.Rows;
+            int initialTotal = buffer.Scrollback.Count + buffer.Rows;
 
             // Act
             for (int i = 0; i < 10; i++)
@@ -581,7 +599,7 @@ namespace NovaTerminal.Tests
             }
 
             // Assert
-            int finalTotal = buffer.ScrollbackRows.Count + buffer.Rows;
+            int finalTotal = buffer.Scrollback.Count + buffer.Rows;
             // It shouldn't grow indefinitely. 
             Assert.True(finalTotal < initialTotal + 20, $"Buffer grew too much: {initialTotal} -> {finalTotal}");
         }

--- a/tests/NovaTerminal.Tests/VttestScenarioTests.cs
+++ b/tests/NovaTerminal.Tests/VttestScenarioTests.cs
@@ -30,7 +30,7 @@ namespace NovaTerminal.Tests
         public void PrimaryDA_ShouldRespondCorrectly()
         {
             var buffer = CreateBuffer();
-            string response = null;
+            string? response = null;
             var parser = CreateParser(buffer, r => response = r);
 
             // CSI c (Primary DA)
@@ -44,7 +44,7 @@ namespace NovaTerminal.Tests
         public void SecondaryDA_ShouldRespondCorrectly()
         {
             var buffer = CreateBuffer();
-            string response = null;
+            string? response = null;
             var parser = CreateParser(buffer, r => response = r);
 
             // CSI > c (Secondary DA)
@@ -58,7 +58,7 @@ namespace NovaTerminal.Tests
         public void CursorPositionReport_ShouldReturnCorrectCoordinates()
         {
             var buffer = CreateBuffer();
-            string response = null;
+            string? response = null;
             var parser = CreateParser(buffer, r => response = r);
 
             // Move cursor to 5, 10 (0-indexed -> 1-indexed 6, 11)


### PR DESCRIPTION
## Summary
This PR implements several key memory optimizations to address memory spikes and reduce the steady-state memory footprint of NovaTerminal.

### 1. Paged Scrollback Architecture
- Migrated from a monolithic `CircularBuffer<TerminalRow>` to a paged storage system (`ScrollbackPages`).
- Implemented efficient page pooling to reuse memory and avoid large heap allocations during scrolling.
- Preserves the `IsWrapped` flag across the reflow engine and scrollback storage.

### 2. SmallMap Optimization
- Replaced `Dictionary<int, string>` side tables in `TerminalRow` (for extended unicode and hyperlinks) with a custom `SmallMap<T>` struct.
- Optimized for the common case of few entries (using a small inline array) while falling back to a full dictionary for dense rows.
- Significantly reduces object overhead for typical terminal rows.

### 3. GlyphCache Key Optimization
- Replaced interpolated string keys (`${text}_{typeface}_{size}...`) in `GlyphCache` with a stack-allocated `GlyphKey` struct.
- Eliminated heap-allocated string keys during the rendering loop, reducing GC pressure during active output.

### 4. Memory Metrics & Diagnostics
- Added `TerminalMemoryMetrics` and `GetMemoryMetrics()` to `TerminalBuffer`.
- Implemented 5-second background diagnostic logging in `TerminalView` to monitor real-time memory usage (ScrollbackMB, Pages, GlyphCache entries).

### 5. Correctness & Quality
- Resolved various project-wide build errors and nullability warnings in the test project.
- Verified all changes with new and existing unit tests (100% pass rate).
- Reflow logic was fixed to preserve line-wrapping status and avoid buffer wipes on resize.

## Verification
- **Automated Tests**: Ran `NovaTerminal.Tests` with 52 passing tests.
- **Manual Verification**: Confirmed diagnostic logs show stable memory growth and efficient page recycling.