### PR TITLE
feat: preserve extended text and hyperlinks in paged scrollback

### DIFF
--- a/src/NovaTerminal.VT/Buffer/ScrollbackPages.cs
+++ b/src/NovaTerminal.VT/Buffer/ScrollbackPages.cs
@@ -103,7 +103,13 @@ namespace NovaTerminal.Core.Storage
         /// </summary>
         /// <param name="row">Read-only span of exactly <see cref="_cols"/> cells.</param>
         /// <param name="isWrapped">Whether this row is wrapped (flows into the next).</param>
-        public void AppendRow(ReadOnlySpan<TerminalCell> row, bool isWrapped = false)
+        /// <param name="extendedText">Optional extended grapheme clusters keyed by column index.</param>
+        /// <param name="hyperlinks">Optional hyperlink URIs keyed by column index.</param>
+        public long AppendRow(
+            ReadOnlySpan<TerminalCell> row,
+            bool isWrapped = false,
+            SmallMap<string>? extendedText = null,
+            SmallMap<string>? hyperlinks = null)
         {
             if (row.Length != _cols)
                 throw new ArgumentException($"Row length {row.Length} must equal Cols {_cols}.", nameof(row));
@@ -120,10 +126,15 @@ namespace NovaTerminal.Core.Storage
             int rowIndex = currentPage.UsedRows;
             row.CopyTo(currentPage.GetRowSpan(rowIndex));
             currentPage.SetRowWrapped(rowIndex, isWrapped);
+            if (extendedText != null && extendedText.Count > 0)
+                currentPage.SetExtendedTextFromMap(rowIndex, extendedText);
+            if (hyperlinks != null && hyperlinks.Count > 0)
+                currentPage.SetHyperlinkFromMap(rowIndex, hyperlinks);
             currentPage.UsedRows++;
             _totalRowsAppended++;
 
             TryEvictUntilWithinBudget();
+            return _totalRowsAppended - 1; // absolute row index just appended
         }
 
         /// <summary>
@@ -198,6 +209,46 @@ namespace NovaTerminal.Core.Storage
         public void CopyRowTo(int logicalIndex, Span<TerminalCell> destination)
         {
             GetRow(logicalIndex).CopyTo(destination);
+        }
+
+        /// <summary>Returns the extended text SmallMap for the given logical row, or null if none.</summary>
+        public SmallMap<string>? GetExtendedTextMap(int logicalIndex)
+        {
+            (TerminalPage page, int rowInPage) = FindPage(logicalIndex);
+            return page.GetExtendedTextMap(rowInPage);
+        }
+
+        /// <summary>Returns the hyperlink SmallMap for the given logical row, or null if none.</summary>
+        public SmallMap<string>? GetHyperlinkMap(int logicalIndex)
+        {
+            (TerminalPage page, int rowInPage) = FindPage(logicalIndex);
+            return page.GetHyperlinkMap(rowInPage);
+        }
+
+        /// <summary>
+        /// Helper to find the <see cref="TerminalPage"/> and row index within that page
+        /// for a given logical row index.
+        /// </summary>
+        private (TerminalPage page, int rowInPage) FindPage(int logicalIndex)
+        {
+            if ((uint)logicalIndex >= (uint)Count)
+                throw new ArgumentOutOfRangeException(nameof(logicalIndex));
+
+            long absRow = _totalRowsEvicted + logicalIndex;
+            long pageStartAbs = _totalRowsEvicted;
+
+            foreach (var page in _pages)
+            {
+                long pageEndAbs = pageStartAbs + page.UsedRows;
+                if (absRow < pageEndAbs)
+                {
+                    int rowInPage = (int)(absRow - pageStartAbs);
+                    return (page, rowInPage);
+                }
+                pageStartAbs = pageEndAbs;
+            }
+
+            throw new InvalidOperationException($"Row {logicalIndex} not found in pages (absRow={absRow}).");
         }
 
         /// <summary>

--- a/src/NovaTerminal.VT/Buffer/SmallMap.cs
+++ b/src/NovaTerminal.VT/Buffer/SmallMap.cs
@@ -30,6 +30,23 @@ namespace NovaTerminal.Core.Storage
         public int Count => _dictionary?.Count ?? _count;
 
         /// <summary>
+        /// Iterates over all key-value pairs without allocation.
+        /// </summary>
+        public void ForEach(System.Action<int, T> action)
+        {
+            if (_dictionary != null)
+            {
+                foreach (var kvp in _dictionary) action(kvp.Key, kvp.Value);
+                return;
+            }
+            if (_entries != null)
+            {
+                for (int i = 0; i < _count; i++)
+                    action(_entries[i].Key, _entries[i].Value);
+            }
+        }
+
+        /// <summary>
         /// Attempts to get the value associated with the specified key.
         /// </summary>
         public bool TryGet(int key, out T? value)

--- a/src/NovaTerminal.VT/Buffer/TerminalPage.cs
+++ b/src/NovaTerminal.VT/Buffer/TerminalPage.cs
@@ -37,6 +37,11 @@ namespace NovaTerminal.Core.Storage
         
         private ulong _isWrappedMask;
 
+        // Sparse per-row metadata side-channels. null = no extended text/hyperlinks on any row in this page.
+        // Indexed by rowIndex (0..RowsInPage-1). Each element is null if that row has no metadata.
+        private SmallMap<string>?[]? _extendedText;
+        private SmallMap<string>?[]? _hyperlinks;
+
         public TerminalPage(int rowsInPage, int cols)
         {
             if (rowsInPage <= 0) throw new ArgumentOutOfRangeException(nameof(rowsInPage));
@@ -99,7 +104,7 @@ namespace NovaTerminal.Core.Storage
         }
 
         /// <summary>
-        /// Resets all rows to default cells and sets UsedRows to 0.
+        /// <summary>Resets all rows to default cells and sets UsedRows to 0.
         /// Called by the pool before returning the page for reuse.
         /// </summary>
         public void Reset()
@@ -107,6 +112,8 @@ namespace NovaTerminal.Core.Storage
             UsedRows = 0;
             _returned = false;
             _isWrappedMask = 0;
+            _extendedText = null;
+            _hyperlinks = null;
             ResetCells();
         }
 
@@ -119,6 +126,8 @@ namespace NovaTerminal.Core.Storage
             if (_returned) return;
             _returned = true;
             _isWrappedMask = 0;
+            _extendedText = null;
+            _hyperlinks = null;
             // Clear the usable portion so pooled memory doesn't retain stale data.
             Cells.AsSpan(0, RowsInPage * Cols).Clear();
             ArrayPool<TerminalCell>.Shared.Return(Cells, clearArray: false);
@@ -136,6 +145,61 @@ namespace NovaTerminal.Core.Storage
             if (wrapped) _isWrappedMask |= (1UL << rowIndex);
             else _isWrappedMask &= ~(1UL << rowIndex);
         }
+
+        // ── Extended Text Metadata ───────────────────────────────────────────────
+
+        /// <summary>Gets the extended text (grapheme cluster) for a cell, or null if none.</summary>
+        public string? GetExtendedText(int rowIndex, int col)
+        {
+            if (_extendedText == null) return null;
+            var map = _extendedText[rowIndex];
+            if (map == null) return null;
+            return map.TryGet(col, out var text) ? text : null;
+        }
+
+        /// <summary>Sets the extended text for a cell in the specified row.</summary>
+        public void SetExtendedText(int rowIndex, int col, string? text)
+        {
+            if (string.IsNullOrEmpty(text)) return;
+            _extendedText ??= new SmallMap<string>?[RowsInPage];
+            _extendedText[rowIndex] ??= new SmallMap<string>();
+            _extendedText[rowIndex]!.Set(col, text);
+        }
+
+        /// <summary>Copies all extended text entries from an existing SmallMap into the specified row.</summary>
+        public void SetExtendedTextFromMap(int rowIndex, SmallMap<string>? source)
+        {
+            if (source == null || source.Count == 0) return;
+            _extendedText ??= new SmallMap<string>?[RowsInPage];
+            _extendedText[rowIndex] = source;
+        }
+
+        /// <summary>Returns the raw SmallMap for the row's extended text (null if none).</summary>
+        public SmallMap<string>? GetExtendedTextMap(int rowIndex) =>
+            _extendedText?[rowIndex];
+
+        // ── Hyperlink Metadata ───────────────────────────────────────────────────
+
+        /// <summary>Gets the hyperlink URL for a cell, or null if none.</summary>
+        public string? GetHyperlink(int rowIndex, int col)
+        {
+            if (_hyperlinks == null) return null;
+            var map = _hyperlinks[rowIndex];
+            if (map == null) return null;
+            return map.TryGet(col, out var link) ? link : null;
+        }
+
+        /// <summary>Copies all hyperlink entries from an existing SmallMap into the specified row.</summary>
+        public void SetHyperlinkFromMap(int rowIndex, SmallMap<string>? source)
+        {
+            if (source == null || source.Count == 0) return;
+            _hyperlinks ??= new SmallMap<string>?[RowsInPage];
+            _hyperlinks[rowIndex] = source;
+        }
+
+        /// <summary>Returns the raw SmallMap for the row's hyperlinks (null if none).</summary>
+        public SmallMap<string>? GetHyperlinkMap(int rowIndex) =>
+            _hyperlinks?[rowIndex];
 
         /// <summary>
         /// Updates cells that rely on default foreground or background colors to a new theme.

--- a/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
@@ -118,7 +118,9 @@ namespace NovaTerminal.Core
                         var row = new TerminalRow(oldCols, Theme.Foreground, Theme.Background);
                         rowCells.CopyTo(row.Cells);
                         row.IsWrapped = _scrollback.IsRowWrapped(i);
-                        // NOTE: Extended text is lost in scrollback until Step 5
+                        // Restore extended graphemes and hyperlinks from the paged scrollback side-channel.
+                        _scrollback.GetExtendedTextMap(i)?.ForEach((col, text) => row.SetExtendedText(col, text));
+                        _scrollback.GetHyperlinkMap(i)?.ForEach((col, link) => row.SetHyperlink(col, link));
                         allPhysicalRows[i] = row;
                     }
                     for (int i = 0; i < vpRowsToTake; i++)

--- a/src/NovaTerminal.VT/TerminalBuffer.WritePath.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.WritePath.cs
@@ -419,7 +419,13 @@ namespace NovaTerminal.Core
                 
                 // This copies the cell array into the page-based store;
                 // No TerminalRow object is stored in scrollback anymore.
-                _scrollback.AppendRow(_viewport[0].Cells, _viewport[0].IsWrapped);
+                var evictingRow = _viewport[0];
+                _scrollback.AppendRow(
+                    evictingRow.Cells,
+                    evictingRow.IsWrapped,
+                    evictingRow.GetExtendedTextMap(),
+                    evictingRow.GetHyperlinkMap());
+
 
                 long newlyEvicted = _scrollback.TotalRowsEvicted - prevEvicted;
 

--- a/src/NovaTerminal.VT/TerminalRow.cs
+++ b/src/NovaTerminal.VT/TerminalRow.cs
@@ -65,6 +65,18 @@ namespace NovaTerminal.Core
             _hyperlinks = null;
         }
 
+        /// <summary>
+        /// Returns the raw SmallMap backing extended text (grapheme clusters) for this row.
+        /// This is intended for preservation into paged scrollback — do not cache or mutate.
+        /// </summary>
+        public Storage.SmallMap<string>? GetExtendedTextMap() => _extendedText;
+
+        /// <summary>
+        /// Returns the raw SmallMap backing hyperlinks for this row.
+        /// This is intended for preservation into paged scrollback — do not cache or mutate.
+        /// </summary>
+        public Storage.SmallMap<string>? GetHyperlinkMap() => _hyperlinks;
+
         public TerminalRow(int cols)
         {
             Id = System.Threading.Interlocked.Increment(ref _nextId);

--- a/tests/NovaTerminal.Tests/BufferTests/ScrollbackMetadataTests.cs
+++ b/tests/NovaTerminal.Tests/BufferTests/ScrollbackMetadataTests.cs
@@ -1,0 +1,173 @@
+using System;
+using Xunit;
+using NovaTerminal.Core;
+using NovaTerminal.Core.Storage;
+
+namespace NovaTerminal.Tests.BufferTests
+{
+    /// <summary>
+    /// Tests for extended text and hyperlink preservation in paged scrollback.
+    /// </summary>
+    public class ScrollbackMetadataTests
+    {
+        [Fact]
+        public void AppendRow_WithExtendedText_IsRetained()
+        {
+            var pool = new TerminalPagePool();
+            var scrollback = new ScrollbackPages(10, pool, maxScrollbackBytes: 16L * 1024 * 1024);
+
+            var ext = new SmallMap<string>();
+            ext.Set(2, "🎉"); // emoji at column 2
+
+            var row = new TerminalCell[10];
+            scrollback.AppendRow(row, false, extendedText: ext);
+
+            Assert.Equal(1, scrollback.Count);
+            var retrieved = scrollback.GetExtendedTextMap(0);
+            Assert.NotNull(retrieved);
+            Assert.True(retrieved!.TryGet(2, out var emoji));
+            Assert.Equal("🎉", emoji);
+
+            pool.Clear();
+        }
+
+        [Fact]
+        public void AppendRow_WithHyperlink_IsRetained()
+        {
+            var pool = new TerminalPagePool();
+            var scrollback = new ScrollbackPages(10, pool, maxScrollbackBytes: 16L * 1024 * 1024);
+
+            var links = new SmallMap<string>();
+            links.Set(5, "https://example.com");
+
+            var row = new TerminalCell[10];
+            scrollback.AppendRow(row, false, hyperlinks: links);
+
+            Assert.Equal(1, scrollback.Count);
+            var retrieved = scrollback.GetHyperlinkMap(0);
+            Assert.NotNull(retrieved);
+            Assert.True(retrieved!.TryGet(5, out var url));
+            Assert.Equal("https://example.com", url);
+
+            pool.Clear();
+        }
+
+        [Fact]
+        public void AppendRow_MultipleRowsOnSamePage_AllMetadataRetained()
+        {
+            var pool = new TerminalPagePool();
+            var scrollback = new ScrollbackPages(10, pool, maxScrollbackBytes: 16L * 1024 * 1024);
+
+            var row = new TerminalCell[10];
+
+            // Row 0: emoji in col 0
+            var ext0 = new SmallMap<string>(); ext0.Set(0, "あ");
+            scrollback.AppendRow(row, false, extendedText: ext0);
+
+            // Row 1: no metadata
+            scrollback.AppendRow(row);
+
+            // Row 2: hyperlink in col 3
+            var links2 = new SmallMap<string>(); links2.Set(3, "https://nova.dev");
+            scrollback.AppendRow(row, false, hyperlinks: links2);
+
+            Assert.Equal(3, scrollback.Count);
+
+            var m0 = scrollback.GetExtendedTextMap(0);
+            Assert.NotNull(m0);
+            Assert.True(m0!.TryGet(0, out var c0));
+            Assert.Equal("あ", c0);
+
+            Assert.Null(scrollback.GetExtendedTextMap(1));
+            Assert.Null(scrollback.GetHyperlinkMap(1));
+
+            var m2 = scrollback.GetHyperlinkMap(2);
+            Assert.NotNull(m2);
+            Assert.True(m2!.TryGet(3, out var u2));
+            Assert.Equal("https://nova.dev", u2);
+
+            pool.Clear();
+        }
+
+        [Fact]
+        public void AppendRow_NoMetadata_GettersReturnNull()
+        {
+            var pool = new TerminalPagePool();
+            var scrollback = new ScrollbackPages(10, pool, maxScrollbackBytes: 16L * 1024 * 1024);
+
+            var row = new TerminalCell[10];
+            scrollback.AppendRow(row);
+
+            Assert.Null(scrollback.GetExtendedTextMap(0));
+            Assert.Null(scrollback.GetHyperlinkMap(0));
+
+            pool.Clear();
+        }
+
+        [Fact]
+        public void SmallMap_ForEach_IteratesAllEntries()
+        {
+            var map = new SmallMap<string>();
+            map.Set(1, "one");
+            map.Set(3, "three");
+            map.Set(5, "five");
+
+            var collected = new System.Collections.Generic.Dictionary<int, string>();
+            map.ForEach((k, v) => collected[k] = v);
+
+            Assert.Equal(3, collected.Count);
+            Assert.Equal("one", collected[1]);
+            Assert.Equal("three", collected[3]);
+            Assert.Equal("five", collected[5]);
+        }
+
+        [Fact]
+        public void TerminalRow_GetExtendedTextMap_ReturnsMapAfterSet()
+        {
+            var row = new TerminalRow(10);
+            row.SetExtendedText(4, "é");
+
+            var map = row.GetExtendedTextMap();
+            Assert.NotNull(map);
+            Assert.True(map!.TryGet(4, out var text));
+            Assert.Equal("é", text);
+        }
+
+        [Fact]
+        public void TerminalRow_GetHyperlinkMap_ReturnsMapAfterSet()
+        {
+            var row = new TerminalRow(10);
+            row.SetHyperlink(7, "https://example.org");
+
+            var map = row.GetHyperlinkMap();
+            Assert.NotNull(map);
+            Assert.True(map!.TryGet(7, out var link));
+            Assert.Equal("https://example.org", link);
+        }
+
+        [Fact]
+        public void TerminalPage_Metadata_SurvivesAcrossRows()
+        {
+            var page = new TerminalPage(64, 10);
+
+            // Row 0: extended text — build map separately and attach
+            var extMap = new SmallMap<string>();
+            extMap.Set(1, "ñ");
+            page.SetExtendedTextFromMap(0, extMap);
+
+            // Row 1: hyperlink — build map separately and attach
+            var linkMap = new SmallMap<string>();
+            linkMap.Set(9, "http://test.io");
+            page.SetHyperlinkFromMap(1, linkMap);
+
+            Assert.Equal("ñ", page.GetExtendedText(0, 1));
+            Assert.Equal("http://test.io", page.GetHyperlink(1, 9));
+
+            // Row 2 has nothing
+            Assert.Null(page.GetExtendedTextMap(2));
+            Assert.Null(page.GetHyperlinkMap(2));
+
+            page.ReturnToPool();
+        }
+    }
+}


### PR DESCRIPTION
- SmallMap<T>: add ForEach(Action<int,T>) for O(count) iteration without allocation
- TerminalRow: expose GetExtendedTextMap()/GetHyperlinkMap() raw accessors
- TerminalPage: add sparse SmallMap<string>?[] side-channels per row
  - lazy-allocated (null when no metadata exists on the page)
  - cleared on Reset()/ReturnToPool()
  - accessors: GetExtendedText/SetExtendedText/SetExtendedTextFromMap/GetExtendedTextMap
  -            GetHyperlink/SetHyperlinkFromMap/GetHyperlinkMap
- ScrollbackPages.AppendRow: accept optional extendedText/hyperlinks maps
  - stored into the current page via SetExtendedTextFromMap/SetHyperlinkFromMap
  - returns absolute row index for diagnostics
- ScrollbackPages: add GetExtendedTextMap()/GetHyperlinkMap() by logical index
- ScrollbackPages: add private FindPage() helper for metadata delegation
- TerminalBuffer.WritePath.ScrollUpInternal: pass TerminalRow metadata to AppendRow
- TerminalBuffer.ReflowEngine: restore metadata from scrollback into rebuilt rows
  during resize using SmallMap.ForEach (O(count) per row instead of O(cols) scan)
- Tests: ScrollbackMetadataTests (8 tests covering all new paths)