### PR TITLE
Add Command Assist M1 scaffold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# NovaTerminal agent rules
+
+Architecture
+- Do not modify VT parsing/rendering unless explicitly required.
+- Command Assist must be a separate subsystem.
+- Keep UI concerns out of terminal core logic.
+
+UI
+- Use Avalonia for all Command Assist UI.
+- Do not render suggestions inside terminal grid content.
+- Auto-hide assist UI in alternate-screen/fullscreen TUI mode.
+
+Implementation
+- Prefer additive changes over refactors.
+- Keep interfaces small and explicit.
+- Preserve current performance-sensitive paths.
+
+Testing
+- Add tests for new domain/services code.
+- Prefer deterministic tests.
+- Avoid fragile UI snapshot dependencies unless already established.

--- a/docs/command-assist/CommandAssist.md
+++ b/docs/command-assist/CommandAssist.md
@@ -1,0 +1,617 @@
+# NovaTerminal Command Assist UI
+
+## Goal
+
+Add a dedicated command assistance surface that helps users:
+- find and reuse previous commands,
+- discover likely next commands,
+- access snippets and recipes,
+- get contextual help,
+- optionally use AI for explanation and repair,
+
+without mixing suggestion text into the terminal grid itself.
+
+This should feel modern, fast, and terminal-native rather than intrusive.
+
+---
+
+## 1. Product position
+
+### Core idea
+NovaTerminal remains a serious terminal emulator.
+
+The new feature is a separate UI layer called **Command Assist** that attaches to a terminal pane and activates only when relevant.
+
+This is **not**:
+- a shell replacement,
+- a permanent chat sidebar,
+- an always-on AI copilot,
+- an inline ghost text system inside the terminal grid.
+
+This **is**:
+- a contextual command helper,
+- a searchable history surface,
+- a snippet/recipe launcher,
+- a command/error explainer,
+- an optional AI-assisted workflow surface.
+
+---
+
+## 2. UX model
+
+### Primary surface: bottom assist bar
+Each terminal pane can host a compact **bottom docked assist bar**.
+
+It appears when:
+- the user starts typing at a prompt,
+- the user presses a shortcut like `Ctrl+Space`,
+- the last command failed,
+- the user explicitly opens search/help mode.
+
+It hides when:
+- the session enters alternate screen mode,
+- a fullscreen TUI is active,
+- the command completes and no relevant suggestion is needed,
+- the user dismisses it.
+
+### Secondary surface: command palette
+A global or per-pane command palette can expose:
+- history search,
+- snippets,
+- saved workflows,
+- helper actions,
+- AI actions.
+
+Shortcut example:
+- `Ctrl+Shift+P` for command palette
+- `Ctrl+R` for history-focused mode
+- `Ctrl+Space` for context assist
+
+### Tertiary surface: side helper panel
+For richer content:
+- command docs,
+- examples,
+- error explanations,
+- AI-generated suggestions,
+- selected-output analysis.
+
+This should be optional and not the default typing surface.
+
+---
+
+## 3. Main interaction modes
+
+### Mode A: Suggest
+Triggered while the user is typing at a prompt.
+
+Shows:
+- top history matches,
+- prefix-based matches,
+- same-directory matches,
+- pinned snippets,
+- recent successful commands.
+
+Primary actions:
+- Insert
+- Replace input
+- Execute
+- Pin
+- Copy
+
+### Mode B: Search
+Expanded fuzzy search over:
+- command history,
+- snippets,
+- saved recipes,
+- team/shared templates later.
+
+Shows ranked results with metadata.
+
+### Mode C: Help
+Activated explicitly or when the current command is recognized.
+
+Shows:
+- usage examples,
+- common flags,
+- recent variants from user history,
+- short distilled help.
+
+### Mode D: Fix
+Activated after a command exits non-zero or when stderr appears significant.
+
+Shows:
+- likely typo corrections,
+- missing flag hints,
+- cwd-related suggestions,
+- optional AI explanation.
+
+### Mode E: Ask AI
+Explicitly invoked only.
+
+Examples:
+- “Create a find command for files over 500MB modified this week”
+- “Explain this grep pipeline”
+- “Fix this PowerShell command”
+- “Turn this bash command into pwsh”
+
+---
+
+## 4. Detailed UI spec
+
+### 4.1 Collapsed assist bar
+Compact row at bottom of terminal pane.
+
+Contains:
+- current mode label
+- top suggestion text
+- 2–4 quick actions
+- tiny hint strip for hotkeys
+
+Example:
+- `Suggest | git checkout main | Tab insert | Enter run | ↑↓ browse | Esc close`
+
+### 4.2 Expanded assist panel
+Opens above the bar, still inside pane bounds.
+
+Sections:
+- result list
+- metadata area
+- action footer
+
+Each result row may show:
+- command text
+- badges: `Recent`, `Pinned`, `Same cwd`, `Worked`, `Snippet`, `AI`
+- timestamp
+- shell
+- cwd or shortened path
+- success/failure indicator
+
+### 4.3 Result metadata
+When a result is selected:
+- full command preview
+- when last used
+- how often used
+- success rate
+- shell/profile/host
+- source type: History / Snippet / AI / Recipe
+
+### 4.4 Empty states
+Examples:
+- “No matching history”
+- “No snippets yet”
+- “AI assist unavailable offline”
+- “Shell integration not detected; using heuristic mode”
+
+---
+
+## 5. Visual behavior rules
+
+### Must
+- stay visually separate from terminal content,
+- never write suggestion text into the terminal buffer,
+- animate lightly and quickly,
+- remain readable in compact pane sizes,
+- support theme integration.
+
+### Must not
+- obscure too much terminal output,
+- appear over alternate-screen TUIs,
+- steal focus unexpectedly,
+- auto-run commands without explicit confirmation.
+
+### Recommended size behavior
+- collapsed height: ~32–40 px
+- expanded panel height: 160–280 px typical
+- max width: pane width
+- responsive compaction for narrow panes
+
+---
+
+## 6. Ranking model
+
+Use a weighted ranking pipeline.
+
+### Signals
+- exact prefix match
+- token prefix match
+- fuzzy similarity
+- recency
+- frequency
+- same current working directory
+- same shell
+- same profile
+- same remote host/session
+- prior success
+- pin/snippet boost
+- command length penalty for noisy long entries
+
+### Example scoring formula
+Conceptually:
+
+```text
+score =
+  prefixScore * 5 +
+  tokenMatch * 3 +
+  fuzzyScore * 2 +
+  recencyWeight +
+  frequencyWeight +
+  cwdBoost +
+  shellBoost +
+  successBoost +
+  pinBoost
+```
+
+Do not overfit early. Keep ranking explainable.
+
+---
+
+## 7. Data model
+
+### 7.1 Command history entry
+
+```csharp
+public sealed record CommandHistoryEntry(
+    string Id,
+    string CommandText,
+    DateTimeOffset ExecutedAt,
+    string ShellKind,
+    string? WorkingDirectory,
+    string? ProfileId,
+    string? SessionId,
+    string? HostId,
+    int? ExitCode,
+    TimeSpan? Duration,
+    bool IsRemote,
+    bool IsRedacted,
+    string Source // Heuristic, ShellIntegration, Imported, SnippetExpansion
+);
+```
+
+### 7.2 Suggestion item
+
+```csharp
+public sealed record AssistSuggestion(
+    string Id,
+    AssistSuggestionType Type,
+    string DisplayText,
+    string InsertText,
+    string? Description,
+    IReadOnlyList<string> Badges,
+    double Score,
+    string? WorkingDirectory,
+    DateTimeOffset? LastUsedAt,
+    int? ExitCode,
+    bool CanExecuteDirectly
+);
+```
+
+### 7.3 Snippet item
+
+```csharp
+public sealed record CommandSnippet(
+    string Id,
+    string Title,
+    string CommandTemplate,
+    string? Description,
+    string ShellKind,
+    IReadOnlyList<string> Tags,
+    bool IsPinned,
+    bool RequiresInput
+);
+```
+
+---
+
+## 8. Architecture
+
+Keep this out of renderer/VT core.
+
+### Proposed subsystem layout
+
+#### Application layer
+- `CommandAssistController`
+- `CommandAssistViewModel`
+- `AssistOverlayHost`
+- `AssistInteractionRouter`
+
+#### Domain/services
+- `HistoryStore`
+- `HistoryIndexer`
+- `SuggestionEngine`
+- `SnippetStore`
+- `RecipeProvider`
+- `CommandClassifier`
+- `ErrorInsightService`
+- `SecretsFilter`
+- `ShellContextTracker`
+- `CommandBoundaryTracker`
+
+#### Optional providers
+- `IAiAssistProvider`
+- `ICommandDocsProvider`
+- `IShellIntegrationProvider`
+
+#### Pane/session integration
+- `ITerminalSessionContext`
+- `ITerminalInputObserver`
+- `ITerminalCommandEventSource`
+
+---
+
+## 9. Shell integration strategy
+
+This is the difference between “nice demo” and “feels real”.
+
+### Level 1: heuristic mode
+Works without shell integration.
+
+Possible signals:
+- local keystrokes
+- Enter press
+- visible prompt heuristics
+- paste detection
+- simple command line capture
+
+Pros:
+- works broadly
+- fast to ship
+
+Cons:
+- inaccurate boundaries
+- weak cwd awareness
+- harder multiline handling
+
+### Level 2: integrated mode
+Add shell integration scripts/plugins for:
+- PowerShell
+- bash
+- zsh
+- fish
+
+Want structured events for:
+- prompt ready
+- current cwd
+- command accepted
+- command completed
+- exit code
+- optional duration
+
+This enables much better ranking and timing.
+
+---
+
+## 10. Security and privacy
+
+### Rules
+- redact obvious secrets before persistence,
+- allow disabling history capture entirely,
+- allow per-profile opt-out,
+- allow excluded command patterns,
+- support “private session” mode,
+- do not send command text to AI unless explicitly allowed.
+
+### Secret detection examples
+- `--password`
+- `token=`
+- `Authorization: Bearer`
+- AWS keys
+- JWT-like blobs
+- connection strings
+- `sshpass`
+- cloud CLI secret flags
+
+### Storage
+- local persistent store
+- encrypted if feasible for sensitive metadata
+- bounded retention settings
+- user-clearable
+
+---
+
+## 11. TUI / alternate screen behavior
+
+Command Assist must disappear automatically when:
+- alternate screen is entered,
+- fullscreen TUI is active,
+- mouse/keyboard focus is clearly inside a TUI app.
+
+Examples:
+- `vim`
+- `nvim`
+- `htop`
+- `lazygit`
+- `btop`
+- `mc`
+
+Do not try to be clever here. Hide early, hide safely.
+
+---
+
+## 12. Performance requirements
+
+This feature must feel immediate.
+
+### Targets
+- collapsed assist display after trigger: ideally < 16 ms from ready state
+- incremental search update: < 30 ms on common history sizes
+- no UI jank during typing
+- no measurable impact on terminal render loop
+
+### Design notes
+- prebuild an index
+- query off UI thread
+- debounce lightly
+- cache recent contexts
+- avoid giant object churn
+- keep view model diffs small
+
+---
+
+## 13. Avalonia component breakdown
+
+### Suggested components
+
+#### Views
+- `CommandAssistBarView`
+- `CommandAssistPanelView`
+- `CommandAssistResultListView`
+- `CommandHelpPanelView`
+- `CommandFixPanelView`
+- `CommandPaletteView`
+
+#### ViewModels
+- `CommandAssistBarViewModel`
+- `CommandAssistPanelViewModel`
+- `CommandAssistResultItemViewModel`
+- `CommandHelpViewModel`
+- `CommandFixViewModel`
+
+#### Services
+- `ICommandAssistService`
+- `IHistorySearchService`
+- `ISnippetService`
+- `ICommandDocsService`
+- `IAssistTelemetry`
+
+---
+
+## 14. Suggested keyboard model
+
+### Defaults
+- `Ctrl+Space` → open/toggle assist for current pane
+- `Ctrl+R` → history search mode
+- `Ctrl+Shift+P` → command palette
+- `Tab` → insert selected suggestion
+- `Enter` → execute selected suggestion if focus is in assist list and user explicitly navigated there
+- `Esc` → dismiss
+- `Up/Down` → move selection
+- `Ctrl+Enter` → force execute selected suggestion
+- `Alt+Enter` → insert without execution
+
+Keep insert and execute clearly separate.
+
+---
+
+## 15. Suggested rollout roadmap
+
+### M1 — history foundation
+Deliver:
+- persistent history store
+- history capture in heuristic mode
+- secret redaction
+- bottom assist bar
+- fuzzy history search
+- basic ranking
+
+Exit criteria:
+- user can reopen recent commands fast
+- command assist feels useful without AI
+
+### M2 — richer suggestions
+Deliver:
+- prefix/token/fuzzy ranking
+- cwd-aware ranking
+- success-aware ranking
+- pinned snippets
+- metadata badges
+- improved keyboard navigation
+
+Exit criteria:
+- top 3 suggestions usually feel relevant
+- UX is faster than manual shell history for common cases
+
+### M3 — shell integration
+Deliver:
+- PowerShell integration first
+- bash/zsh/fish after
+- structured prompt/command events
+- better cwd/exit code tracking
+- robust multiline handling
+
+Exit criteria:
+- command boundaries are trustworthy in integrated shells
+
+### M4 — helper surfaces
+Deliver:
+- help mode
+- command examples
+- docs extraction
+- error/fix mode
+- selected-output explain action
+
+Exit criteria:
+- useful even when user does not remember exact syntax
+
+### M5 — AI layer
+Deliver:
+- explicit AI provider integration
+- NL → command
+- explain command
+- fix failed command
+- summarize selected output
+
+Exit criteria:
+- AI adds value without becoming noisy or defaulting itself into everything
+
+---
+
+## 16. Monetization-friendly extensions later
+
+Possible premium features:
+- synced command history
+- team snippet libraries
+- shared workflows
+- org policies/redaction rules
+- remote-host aware suggestions
+- execution analytics
+- AI command repair packs
+- per-project command spaces
+
+This is where the dedicated UI becomes strategically stronger than simple inline completion.
+
+---
+
+## 17. Risks
+
+### Product risks
+- feels too heavy for terminal purists
+- poor ranking makes it feel dumb
+- AI overreach erodes trust
+
+### Technical risks
+- weak shell integration
+- accidental overlay in TUIs
+- history pollution from pasted scripts
+- secret leakage
+- UI coupling to terminal internals
+
+### Mitigations
+- strong defaults
+- explicit AI
+- alternate-screen auto-hide
+- privacy controls
+- separate subsystem boundaries
+
+---
+
+## 18. Recommended first implementation choice
+
+If I were sequencing this for NovaTerminal, I would do:
+
+**M1 + M2 first, PowerShell-first shell integration in M3**
+
+Reason:
+- high user value quickly
+- manageable complexity
+- NovaTerminal gets a visible modern UX win
+- no need to contaminate VT/rendering core
+
+---
+
+## 19. Final recommendation
+
+The best version of this for NovaTerminal is:
+
+**a bottom docked command assist bar, backed by history/snippets/context ranking, with a command palette for search and an optional side panel for help/AI.**
+
+That gives you the Warp-like UX direction while still keeping NovaTerminal serious, modular, and monetizable.

--- a/docs/command-assist/CommandAssist_PromptPack.md
+++ b/docs/command-assist/CommandAssist_PromptPack.md
@@ -1,0 +1,339 @@
+# NovaTerminal Command Assist — Codex / Antigravity Prompt Pack
+
+Use these prompts milestone-by-milestone. They are written to push the coding agent toward a clean architecture, strict boundaries, and TDD-first implementation.
+
+---
+
+## Prompt 1 — Architecture and codebase reconnaissance
+
+You are working on NovaTerminal.
+
+Your task is to design and prepare a new feature called **Command Assist** with a Warp-like dedicated UI, but **without** inline ghost text rendered into the terminal grid.
+
+Goals:
+- add a bottom-docked assist UI per terminal pane,
+- support searchable command history,
+- support ranked suggestions,
+- keep it completely separate from VT parsing and render-core internals,
+- design for future shell integration, snippets, docs/help, and AI providers.
+
+Constraints:
+- do not couple this to renderer internals,
+- do not mutate terminal buffer contents for suggestions,
+- do not introduce feature logic into the VT engine,
+- preserve alternate-screen / fullscreen TUI behavior by auto-hiding assist UI,
+- design for Avalonia UI + C# architecture consistency.
+
+What to do:
+1. Inspect the current solution structure and identify the best projects/namespaces for:
+   - history persistence
+   - command assist domain services
+   - pane/session integration
+   - Avalonia views/viewmodels
+   - settings/config
+2. Produce a concise architecture note with:
+   - proposed folders/files
+   - interfaces to add
+   - event/data flow
+   - dependencies and boundaries
+3. Identify all likely integration points with current terminal session lifecycle, input handling, profile/session state, and overlay UI host infrastructure.
+4. Identify risks where the feature could accidentally leak into rendering core, and explicitly avoid them.
+5. Do not implement yet unless small scaffolding is clearly needed.
+
+Output format:
+- "Current architecture findings"
+- "Recommended subsystem placement"
+- "Required interfaces and models"
+- "Integration points"
+- "Risk list"
+- "First implementation slice"
+
+---
+
+## Prompt 2 — Milestone M1 foundation with strict TDD
+
+Implement **M1: history foundation** for NovaTerminal Command Assist.
+
+Requirements:
+- persistent command history store,
+- heuristic-mode history capture,
+- secrets redaction filter,
+- bottom assist bar UI scaffold,
+- fuzzy history search,
+- basic ranking,
+- per-pane activation,
+- no AI,
+- no shell integration scripts yet.
+
+Rules:
+- TDD first,
+- add failing tests before production code,
+- keep renderer and VT engine untouched except for minimal safe integration interfaces if necessary,
+- avoid speculative abstractions beyond what M1 needs,
+- ensure assist UI auto-hides in alternate screen mode.
+
+Implementation scope:
+1. Add domain models:
+   - CommandHistoryEntry
+   - AssistSuggestion
+2. Add services:
+   - IHistoryStore / HistoryStore
+   - ISecretsFilter / SecretsFilter
+   - ISuggestionEngine / basic history-backed SuggestionEngine
+3. Add persistence:
+   - local on-disk store with bounded retention
+   - safe handling for redacted commands
+4. Add heuristic capture path:
+   - capture likely executed commands from local typed input / Enter workflow where feasible
+   - clearly label source as Heuristic
+5. Add Avalonia scaffold:
+   - CommandAssistBarView
+   - CommandAssistBarViewModel
+   - assist bar host attached to terminal pane
+6. Add history search mode triggered by Ctrl+R or equivalent command binding.
+7. Add tests for:
+   - history persistence
+   - secret redaction
+   - ranking order
+   - alternate-screen auto-hide behavior
+   - assist bar activation/deactivation
+
+Deliverables:
+- code changes
+- test coverage
+- short architecture summary of what was added
+- list of known limitations of heuristic mode
+
+---
+
+## Prompt 3 — M2 ranked suggestions and snippets
+
+Implement **M2: richer suggestions** for NovaTerminal Command Assist.
+
+Requirements:
+- prefix + token + fuzzy ranking,
+- cwd-aware ranking,
+- success-aware ranking,
+- pinned snippets,
+- badges/metadata,
+- keyboard navigation refinement.
+
+Rules:
+- preserve M1 public contracts unless there is a strong reason to revise them,
+- any contract changes must be justified and covered by tests,
+- no AI yet,
+- no shell integration scripts yet,
+- maintain UI responsiveness.
+
+Implementation tasks:
+1. Extend ranking model to include:
+   - exact prefix
+   - token prefix
+   - fuzzy score
+   - recency
+   - frequency
+   - same cwd boost
+   - same shell/profile boost where available
+   - success boost
+   - pinned snippet boost
+2. Add snippet subsystem:
+   - CommandSnippet model
+   - ISnippetStore / local store
+   - ability to pin and unpin suggestions/snippets
+3. Expand assist panel UI:
+   - result list
+   - metadata preview
+   - badges such as Recent / Same cwd / Worked / Pinned / Snippet
+4. Add keyboard behaviors:
+   - Up/Down select
+   - Tab insert
+   - Esc dismiss
+   - explicit execute action separated from insert
+5. Add tests for:
+   - ranking relevance
+   - pinned behavior
+   - cwd influence
+   - successful-command preference
+   - keyboard interaction logic
+
+Output:
+- implementation summary
+- list of files changed
+- tests added
+- any ranking tuning notes
+
+---
+
+## Prompt 4 — M3 PowerShell-first shell integration
+
+Implement **M3 shell integration**, starting with PowerShell first.
+
+Goals:
+- move from heuristic command capture toward structured command lifecycle events,
+- improve prompt detection, cwd tracking, exit-code tracking, and multiline command handling,
+- keep graceful fallback to heuristic mode.
+
+Requirements:
+- design a generic shell integration contract,
+- implement PowerShell integration first,
+- do not break non-integrated shells,
+- expose structured events for prompt ready, command accepted, command completed, cwd changed, exit code, duration if available.
+
+Tasks:
+1. Add interfaces such as:
+   - IShellIntegrationProvider
+   - ShellCommandEvent / PromptReadyEvent / CwdChangedEvent
+2. Design how shell integration scripts are injected/configured/documented.
+3. Implement PowerShell integration path with minimal operational friction.
+4. Ensure command history entries produced by shell integration are clearly marked as ShellIntegration source.
+5. Update ranking/context pipeline to prefer structured data when available.
+6. Preserve fallback to heuristic mode when integration is unavailable.
+7. Add tests for:
+   - event parsing / ingestion
+   - cwd updates
+   - exit code capture
+   - multiline handling
+   - fallback behavior
+
+Output:
+- implementation
+- setup notes for PowerShell integration
+- known gaps for bash/zsh/fish
+
+---
+
+## Prompt 5 — M4 help and fix surfaces
+
+Implement **M4 helper surfaces** for Command Assist.
+
+Requirements:
+- help mode,
+- examples mode,
+- fix mode after failed commands,
+- selected-output explain entry point,
+- still no mandatory AI dependency.
+
+Tasks:
+1. Add command help abstractions:
+   - ICommandDocsProvider
+   - RecipeProvider
+   - ErrorInsightService
+2. Support these UI modes:
+   - Help
+   - Fix
+   - Search
+   - Suggest
+3. Trigger fix mode when:
+   - exit code non-zero, or
+   - obvious command-not-found / typo patterns are detected.
+4. Add examples / recipes surface for recognized commands.
+5. Add explain-selected-output action hook from terminal selection UI.
+6. Keep all helper content outside terminal grid.
+7. Add tests for:
+   - mode switching
+   - fix trigger behavior
+   - result shaping
+   - UI visibility rules in alternate screen mode
+
+Output:
+- implementation summary
+- extensibility notes for future docs providers
+- list of non-AI heuristics used in fix mode
+
+---
+
+## Prompt 6 — M5 optional AI provider
+
+Implement **M5 optional AI provider** for Command Assist.
+
+Requirements:
+- explicit opt-in,
+- clear visual labeling for AI suggestions,
+- no automatic transmission of command text without user consent,
+- support:
+  - NL → command
+  - explain command
+  - fix failed command
+  - summarize selected output
+
+Tasks:
+1. Add:
+   - IAiAssistProvider
+   - consent/settings gate
+   - AI-tagged suggestion/result types
+2. Ensure AI is only used when explicitly invoked or when user settings allow it for certain flows.
+3. Keep local history/snippet suggestions as the default fast path.
+4. Add tests for:
+   - consent gating
+   - provider absence
+   - labeling and source tagging
+   - fallback to non-AI paths
+5. Produce a short security/privacy note in code comments or docs.
+
+Output:
+- implementation summary
+- safety/privacy notes
+- settings and UX notes
+
+---
+
+## Prompt 7 — Hardening and polish pass
+
+Perform a hardening pass on NovaTerminal Command Assist.
+
+Focus:
+- performance,
+- privacy,
+- TUI coexistence,
+- UX polish,
+- maintainability.
+
+Tasks:
+1. Audit for renderer/VT-core leakage and remove any improper coupling.
+2. Verify assist UI never appears during alternate screen / fullscreen TUI apps.
+3. Audit history persistence for:
+   - secret leakage
+   - retention limits
+   - clear-history behavior
+4. Profile search/ranking path for typing latency and optimize obvious hotspots.
+5. Audit keyboard/focus behavior so assist UI never steals focus incorrectly.
+6. Improve empty states, badges, and compact layout behavior for narrow panes.
+7. Add or strengthen tests around:
+   - rapid typing
+   - pane switching
+   - session disposal
+   - remote session metadata
+   - settings toggles
+
+Output:
+- issues found
+- fixes applied
+- remaining backlog
+- recommended release criteria
+
+---
+
+## Prompt 8 — PR review checklist prompt
+
+Review the Command Assist implementation branch deeply.
+
+Check:
+- architecture boundaries
+- correctness
+- privacy/security
+- alternate-screen behavior
+- ranking quality
+- UI/UX consistency
+- settings discoverability
+- performance risks
+- test quality
+- future extensibility
+
+Return:
+1. Critical issues
+2. Important issues
+3. Nice-to-have improvements
+4. Suggested follow-up milestones
+5. Merge readiness verdict
+
+Be concrete. Reference exact files and code paths where possible.

--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistController.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistController.cs
@@ -53,17 +53,18 @@ public sealed class CommandAssistController
         ViewModel.IsVisible = !ViewModel.IsVisible;
     }
 
-    public void OpenHistorySearch()
+    public bool OpenHistorySearch()
     {
         if (_isAltScreenActive)
         {
             ViewModel.IsVisible = false;
-            return;
+            return false;
         }
 
         ViewModel.ModeLabel = "History";
         ViewModel.IsVisible = true;
         QueueRefreshSuggestions();
+        return true;
     }
 
     public void HandleTextInput(string text)
@@ -102,34 +103,43 @@ public sealed class CommandAssistController
 
     public async Task HandleEnterAsync()
     {
-        string submission = ViewModel.QueryText.Trim();
-        bool shouldPersist = !_isAltScreenActive &&
-                             !_ignoreCurrentSubmission &&
-                             !string.IsNullOrWhiteSpace(submission) &&
-                             !submission.Contains('\n') &&
-                             !submission.Contains('\r');
-
-        if (shouldPersist)
+        try
         {
-            RedactionResult redaction = SecretsFilter.Redact(submission);
-            var entry = new CommandHistoryEntry(
-                Id: Guid.NewGuid().ToString("N"),
-                CommandText: redaction.RedactedText,
-                ExecutedAt: DateTimeOffset.UtcNow,
-                ShellKind: _shellKind ?? "unknown",
-                WorkingDirectory: _workingDirectory,
-                ProfileId: _profileId,
-                SessionId: _sessionId,
-                HostId: _hostId,
-                ExitCode: null,
-                IsRemote: _isRemote,
-                IsRedacted: redaction.WasRedacted,
-                Source: CommandCaptureSource.Heuristic);
+            string submission = ViewModel.QueryText.Trim();
+            bool shouldPersist = !_isAltScreenActive &&
+                                 !_ignoreCurrentSubmission &&
+                                 !string.IsNullOrWhiteSpace(submission) &&
+                                 !submission.Contains('\n') &&
+                                 !submission.Contains('\r');
 
-            await HistoryStore.AppendAsync(entry);
+            if (shouldPersist)
+            {
+                RedactionResult redaction = SecretsFilter.Redact(submission);
+                var entry = new CommandHistoryEntry(
+                    Id: Guid.NewGuid().ToString("N"),
+                    CommandText: redaction.RedactedText,
+                    ExecutedAt: DateTimeOffset.UtcNow,
+                    ShellKind: _shellKind ?? "unknown",
+                    WorkingDirectory: _workingDirectory,
+                    ProfileId: _profileId,
+                    SessionId: _sessionId,
+                    HostId: _hostId,
+                    ExitCode: null,
+                    IsRemote: _isRemote,
+                    IsRedacted: redaction.WasRedacted,
+                    Source: CommandCaptureSource.Heuristic);
+
+                await HistoryStore.AppendAsync(entry);
+            }
         }
-
-        ResetSubmissionState();
+        catch
+        {
+            // Assist capture is best-effort; Enter should still reach the shell path even if persistence fails.
+        }
+        finally
+        {
+            ResetSubmissionState();
+        }
     }
 
     public void UpdateSessionContext(

--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistController.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistController.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NovaTerminal.CommandAssist.Domain;
+using NovaTerminal.CommandAssist.Models;
+using NovaTerminal.CommandAssist.ViewModels;
+
+namespace NovaTerminal.CommandAssist.Application;
+
+public sealed class CommandAssistController
+{
+    private bool _isAltScreenActive;
+    private string? _workingDirectory;
+    private string? _shellKind;
+    private string? _profileId;
+    private string? _sessionId;
+    private string? _hostId;
+    private bool _isRemote;
+    private bool _ignoreCurrentSubmission;
+    private int _refreshVersion;
+    private readonly List<AssistSuggestion> _suggestions = new();
+    private readonly Action<Action> _dispatch;
+
+    public CommandAssistController(
+        IHistoryStore historyStore,
+        ISecretsFilter secretsFilter,
+        ISuggestionEngine suggestionEngine,
+        Action<Action>? dispatch = null)
+    {
+        HistoryStore = historyStore;
+        SecretsFilter = secretsFilter;
+        SuggestionEngine = suggestionEngine;
+        ViewModel = new CommandAssistBarViewModel();
+        _dispatch = dispatch ?? (action => action());
+    }
+
+    public IHistoryStore HistoryStore { get; }
+    public ISecretsFilter SecretsFilter { get; }
+    public ISuggestionEngine SuggestionEngine { get; }
+    public CommandAssistBarViewModel ViewModel { get; }
+    public IReadOnlyList<AssistSuggestion> Suggestions => _suggestions;
+
+    public void ToggleAssist()
+    {
+        if (_isAltScreenActive)
+        {
+            ViewModel.IsVisible = false;
+            return;
+        }
+
+        ViewModel.IsVisible = !ViewModel.IsVisible;
+    }
+
+    public void OpenHistorySearch()
+    {
+        if (_isAltScreenActive)
+        {
+            ViewModel.IsVisible = false;
+            return;
+        }
+
+        ViewModel.ModeLabel = "History";
+        ViewModel.IsVisible = true;
+        QueueRefreshSuggestions();
+    }
+
+    public void HandleTextInput(string text)
+    {
+        if (_isAltScreenActive || string.IsNullOrEmpty(text))
+        {
+            return;
+        }
+
+        _ignoreCurrentSubmission = false;
+        ViewModel.QueryText += text;
+        ViewModel.ModeLabel = "Suggest";
+        ViewModel.IsVisible = true;
+        QueueRefreshSuggestions();
+    }
+
+    public void HandleBackspace()
+    {
+        if (_isAltScreenActive || string.IsNullOrEmpty(ViewModel.QueryText))
+        {
+            return;
+        }
+
+        ViewModel.QueryText = ViewModel.QueryText[..^1];
+        QueueRefreshSuggestions();
+    }
+
+    public void HandlePastedText(string text)
+    {
+        _ignoreCurrentSubmission = true;
+        ViewModel.QueryText = text ?? string.Empty;
+        ViewModel.ModeLabel = "Suggest";
+        ViewModel.IsVisible = !_isAltScreenActive;
+        QueueRefreshSuggestions();
+    }
+
+    public async Task HandleEnterAsync()
+    {
+        string submission = ViewModel.QueryText.Trim();
+        bool shouldPersist = !_isAltScreenActive &&
+                             !_ignoreCurrentSubmission &&
+                             !string.IsNullOrWhiteSpace(submission) &&
+                             !submission.Contains('\n') &&
+                             !submission.Contains('\r');
+
+        if (shouldPersist)
+        {
+            RedactionResult redaction = SecretsFilter.Redact(submission);
+            var entry = new CommandHistoryEntry(
+                Id: Guid.NewGuid().ToString("N"),
+                CommandText: redaction.RedactedText,
+                ExecutedAt: DateTimeOffset.UtcNow,
+                ShellKind: _shellKind ?? "unknown",
+                WorkingDirectory: _workingDirectory,
+                ProfileId: _profileId,
+                SessionId: _sessionId,
+                HostId: _hostId,
+                ExitCode: null,
+                IsRemote: _isRemote,
+                IsRedacted: redaction.WasRedacted,
+                Source: CommandCaptureSource.Heuristic);
+
+            await HistoryStore.AppendAsync(entry);
+        }
+
+        ResetSubmissionState();
+    }
+
+    public void UpdateSessionContext(
+        string? shellKind,
+        string? workingDirectory,
+        string? profileId,
+        string? sessionId,
+        string? hostId,
+        bool isRemote)
+    {
+        _shellKind = shellKind;
+        _workingDirectory = workingDirectory;
+        _profileId = profileId;
+        _sessionId = sessionId;
+        _hostId = hostId;
+        _isRemote = isRemote;
+    }
+
+    public void Dismiss()
+    {
+        CancelPendingRefreshes();
+        ViewModel.IsVisible = false;
+        ViewModel.TopSuggestionText = string.Empty;
+        _suggestions.Clear();
+    }
+
+    public void HandleAltScreenChanged(bool isAltScreenActive)
+    {
+        _isAltScreenActive = isAltScreenActive;
+        if (isAltScreenActive)
+        {
+            CancelPendingRefreshes();
+            ViewModel.IsVisible = false;
+            ViewModel.TopSuggestionText = string.Empty;
+            _suggestions.Clear();
+        }
+    }
+
+    private void QueueRefreshSuggestions()
+    {
+        int refreshVersion = Interlocked.Increment(ref _refreshVersion);
+        string query = ViewModel.QueryText;
+        var context = new CommandAssistQueryContext(query, _workingDirectory, _shellKind);
+        _ = RefreshSuggestionsAsync(query, context, refreshVersion);
+    }
+
+    private async Task RefreshSuggestionsAsync(string query, CommandAssistQueryContext context, int refreshVersion)
+    {
+        try
+        {
+            IReadOnlyList<CommandHistoryEntry> history = string.IsNullOrWhiteSpace(query)
+                ? await HistoryStore.GetRecentAsync(5)
+                : await HistoryStore.SearchAsync(query, 5);
+
+            IReadOnlyList<AssistSuggestion> suggestions = SuggestionEngine.GetSuggestions(history, context, 5);
+            _dispatch(() =>
+            {
+                if (refreshVersion != _refreshVersion)
+                {
+                    return;
+                }
+
+                _suggestions.Clear();
+                _suggestions.AddRange(suggestions);
+                ViewModel.TopSuggestionText = suggestions.FirstOrDefault()?.DisplayText ?? string.Empty;
+            });
+        }
+        catch
+        {
+            _dispatch(() =>
+            {
+                if (refreshVersion != _refreshVersion)
+                {
+                    return;
+                }
+
+                _suggestions.Clear();
+                ViewModel.TopSuggestionText = string.Empty;
+            });
+        }
+    }
+
+    private void CancelPendingRefreshes()
+    {
+        Interlocked.Increment(ref _refreshVersion);
+    }
+
+    private void ResetSubmissionState()
+    {
+        CancelPendingRefreshes();
+        _ignoreCurrentSubmission = false;
+        ViewModel.QueryText = string.Empty;
+        ViewModel.TopSuggestionText = string.Empty;
+        ViewModel.IsVisible = false;
+        _suggestions.Clear();
+    }
+}

--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistInfrastructure.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistInfrastructure.cs
@@ -1,0 +1,35 @@
+using System;
+using NovaTerminal.CommandAssist.Domain;
+using NovaTerminal.CommandAssist.Storage;
+using NovaTerminal.Core;
+
+namespace NovaTerminal.CommandAssist.Application;
+
+public static class CommandAssistInfrastructure
+{
+    private static readonly object Sync = new();
+    private static IHistoryStore? _historyStore;
+    private static int _historyMaxEntries = -1;
+    private static readonly ISecretsFilter SecretsFilterInstance = new SecretsFilter();
+    private static readonly ISuggestionEngine SuggestionEngineInstance = new HistorySuggestionEngine();
+
+    public static IHistoryStore GetHistoryStore(TerminalSettings settings)
+    {
+        int maxEntries = Math.Max(1, settings.CommandAssistMaxHistoryEntries);
+
+        lock (Sync)
+        {
+            if (_historyStore == null || _historyMaxEntries != maxEntries)
+            {
+                _historyStore = new JsonHistoryStore(AppPaths.CommandHistoryFilePath, maxEntries);
+                _historyMaxEntries = maxEntries;
+            }
+
+            return _historyStore;
+        }
+    }
+
+    public static ISecretsFilter GetSecretsFilter() => SecretsFilterInstance;
+
+    public static ISuggestionEngine GetSuggestionEngine() => SuggestionEngineInstance;
+}

--- a/src/NovaTerminal.App/CommandAssist/Domain/HistorySuggestionEngine.cs
+++ b/src/NovaTerminal.App/CommandAssist/Domain/HistorySuggestionEngine.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NovaTerminal.CommandAssist.Models;
+
+namespace NovaTerminal.CommandAssist.Domain;
+
+public sealed class HistorySuggestionEngine : ISuggestionEngine
+{
+    public IReadOnlyList<AssistSuggestion> GetSuggestions(
+        IReadOnlyList<CommandHistoryEntry> entries,
+        CommandAssistQueryContext context,
+        int maxResults)
+    {
+        if (entries.Count == 0 || maxResults <= 0)
+        {
+            return Array.Empty<AssistSuggestion>();
+        }
+
+        string query = context.Input?.Trim() ?? string.Empty;
+
+        var grouped = entries
+            .GroupBy(x => x.CommandText, StringComparer.OrdinalIgnoreCase)
+            .Select(group =>
+            {
+                CommandHistoryEntry latest = group.OrderByDescending(x => x.ExecutedAt).First();
+                int frequency = group.Count();
+                double score = Score(latest.CommandText, query, latest, context, frequency);
+                return new { Latest = latest, Frequency = frequency, Score = score };
+            })
+            .Where(x => x.Score > 0)
+            .OrderByDescending(x => x.Score)
+            .ThenByDescending(x => x.Latest.ExecutedAt)
+            .Take(maxResults)
+            .Select(x => new AssistSuggestion(
+                Id: x.Latest.Id,
+                Type: AssistSuggestionType.History,
+                DisplayText: x.Latest.CommandText,
+                InsertText: x.Latest.CommandText,
+                Badges: BuildBadges(x.Latest, context, x.Frequency),
+                Score: x.Score,
+                WorkingDirectory: x.Latest.WorkingDirectory,
+                LastUsedAt: x.Latest.ExecutedAt,
+                ExitCode: x.Latest.ExitCode,
+                CanExecuteDirectly: false))
+            .ToList();
+
+        return grouped;
+    }
+
+    private static double Score(
+        string commandText,
+        string query,
+        CommandHistoryEntry entry,
+        CommandAssistQueryContext context,
+        int frequency)
+    {
+        if (string.IsNullOrWhiteSpace(commandText))
+        {
+            return 0;
+        }
+
+        string normalizedCommand = commandText.Trim();
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return 1 + Math.Min(frequency, 5);
+        }
+
+        string normalizedQuery = query.Trim();
+        string lowerCommand = normalizedCommand.ToLowerInvariant();
+        string lowerQuery = normalizedQuery.ToLowerInvariant();
+
+        double prefixScore = lowerCommand.StartsWith(lowerQuery, StringComparison.Ordinal) ? 100 : 0;
+        double tokenPrefixScore = lowerCommand
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Any(token => token.StartsWith(lowerQuery, StringComparison.Ordinal))
+            ? 50
+            : 0;
+        double containsScore = lowerCommand.Contains(lowerQuery, StringComparison.Ordinal) ? 20 : 0;
+        double subsequenceScore = IsSubsequence(lowerQuery, lowerCommand) ? 10 : 0;
+
+        double recencyScore = entry.ExecutedAt.ToUnixTimeSeconds() / 1_000_000_000d;
+        double frequencyScore = frequency * 5;
+        double cwdScore = !string.IsNullOrWhiteSpace(context.WorkingDirectory) &&
+                          string.Equals(context.WorkingDirectory, entry.WorkingDirectory, StringComparison.OrdinalIgnoreCase)
+            ? 15
+            : 0;
+        double shellScore = !string.IsNullOrWhiteSpace(context.ShellKind) &&
+                            string.Equals(context.ShellKind, entry.ShellKind, StringComparison.OrdinalIgnoreCase)
+            ? 2
+            : 0;
+
+        return prefixScore + tokenPrefixScore + containsScore + subsequenceScore + recencyScore + frequencyScore + cwdScore + shellScore;
+    }
+
+    private static IReadOnlyList<string> BuildBadges(CommandHistoryEntry entry, CommandAssistQueryContext context, int frequency)
+    {
+        var badges = new List<string>();
+        if (frequency > 1)
+        {
+            badges.Add("Frequent");
+        }
+
+        if (!string.IsNullOrWhiteSpace(context.WorkingDirectory) &&
+            string.Equals(context.WorkingDirectory, entry.WorkingDirectory, StringComparison.OrdinalIgnoreCase))
+        {
+            badges.Add("Same cwd");
+        }
+
+        return badges;
+    }
+
+    private static bool IsSubsequence(string query, string command)
+    {
+        int queryIndex = 0;
+        for (int i = 0; i < command.Length && queryIndex < query.Length; i++)
+        {
+            if (command[i] == query[queryIndex])
+            {
+                queryIndex++;
+            }
+        }
+
+        return queryIndex == query.Length;
+    }
+}

--- a/src/NovaTerminal.App/CommandAssist/Domain/IHistoryStore.cs
+++ b/src/NovaTerminal.App/CommandAssist/Domain/IHistoryStore.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NovaTerminal.CommandAssist.Models;
+
+namespace NovaTerminal.CommandAssist.Domain;
+
+public interface IHistoryStore
+{
+    Task AppendAsync(CommandHistoryEntry entry, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<CommandHistoryEntry>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<CommandHistoryEntry>> GetRecentAsync(int maxResults, CancellationToken cancellationToken = default);
+    Task ClearAsync(CancellationToken cancellationToken = default);
+}

--- a/src/NovaTerminal.App/CommandAssist/Domain/ISecretsFilter.cs
+++ b/src/NovaTerminal.App/CommandAssist/Domain/ISecretsFilter.cs
@@ -1,0 +1,6 @@
+namespace NovaTerminal.CommandAssist.Domain;
+
+public interface ISecretsFilter
+{
+    RedactionResult Redact(string commandText);
+}

--- a/src/NovaTerminal.App/CommandAssist/Domain/ISuggestionEngine.cs
+++ b/src/NovaTerminal.App/CommandAssist/Domain/ISuggestionEngine.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using NovaTerminal.CommandAssist.Models;
+
+namespace NovaTerminal.CommandAssist.Domain;
+
+public interface ISuggestionEngine
+{
+    IReadOnlyList<AssistSuggestion> GetSuggestions(
+        IReadOnlyList<CommandHistoryEntry> entries,
+        CommandAssistQueryContext context,
+        int maxResults);
+}

--- a/src/NovaTerminal.App/CommandAssist/Domain/RedactionResult.cs
+++ b/src/NovaTerminal.App/CommandAssist/Domain/RedactionResult.cs
@@ -1,0 +1,3 @@
+namespace NovaTerminal.CommandAssist.Domain;
+
+public sealed record RedactionResult(string RedactedText, bool WasRedacted);

--- a/src/NovaTerminal.App/CommandAssist/Domain/SecretsFilter.cs
+++ b/src/NovaTerminal.App/CommandAssist/Domain/SecretsFilter.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace NovaTerminal.CommandAssist.Domain;
+
+public sealed partial class SecretsFilter : ISecretsFilter
+{
+    private static readonly Regex PasswordFlagRegex = PasswordFlag();
+    private static readonly Regex TokenQueryRegex = TokenQuery();
+    private static readonly Regex SshPassRegex = SshPass();
+    private static readonly Regex BearerRegex = BearerToken();
+    private static readonly Regex JwtAssignmentRegex = JwtAssignment();
+    private static readonly Regex ConnectionStringPasswordRegex = ConnectionStringPassword();
+
+    public RedactionResult Redact(string commandText)
+    {
+        if (string.IsNullOrWhiteSpace(commandText))
+        {
+            return new RedactionResult(commandText, false);
+        }
+
+        string redacted = commandText;
+        redacted = PasswordFlagRegex.Replace(redacted, "$1[REDACTED]");
+        redacted = TokenQueryRegex.Replace(redacted, "$1[REDACTED]");
+        redacted = SshPassRegex.Replace(redacted, "$1[REDACTED]");
+        redacted = BearerRegex.Replace(redacted, "$1[REDACTED]");
+        redacted = JwtAssignmentRegex.Replace(redacted, "$1[REDACTED]");
+        redacted = ConnectionStringPasswordRegex.Replace(redacted, "$1[REDACTED]$3");
+
+        return new RedactionResult(redacted, !string.Equals(commandText, redacted, StringComparison.Ordinal));
+    }
+
+    [GeneratedRegex(@"(--password\s+)(?:""[^""]*""|'[^']*'|\S+)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex PasswordFlag();
+
+    [GeneratedRegex(@"([?&]token=)([^&\s]+)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex TokenQuery();
+
+    [GeneratedRegex(@"(sshpass\s+-p\s+)(?:""[^""]*""|'[^']*'|\S+)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SshPass();
+
+    [GeneratedRegex(@"(Authorization:\s+Bearer\s+)([A-Za-z0-9\-_\.=]+)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex BearerToken();
+
+    [GeneratedRegex(@"(\bJWT=)([A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex JwtAssignment();
+
+    [GeneratedRegex(@"(\bPassword=)([^;]+)(;?)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex ConnectionStringPassword();
+}

--- a/src/NovaTerminal.App/CommandAssist/Models/AssistSuggestion.cs
+++ b/src/NovaTerminal.App/CommandAssist/Models/AssistSuggestion.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+
+namespace NovaTerminal.CommandAssist.Models;
+
+public sealed record AssistSuggestion(
+    string Id,
+    AssistSuggestionType Type,
+    string DisplayText,
+    string InsertText,
+    IReadOnlyList<string> Badges,
+    double Score,
+    string? WorkingDirectory,
+    DateTimeOffset? LastUsedAt,
+    int? ExitCode,
+    bool CanExecuteDirectly);

--- a/src/NovaTerminal.App/CommandAssist/Models/AssistSuggestionType.cs
+++ b/src/NovaTerminal.App/CommandAssist/Models/AssistSuggestionType.cs
@@ -1,0 +1,6 @@
+namespace NovaTerminal.CommandAssist.Models;
+
+public enum AssistSuggestionType
+{
+    History
+}

--- a/src/NovaTerminal.App/CommandAssist/Models/CommandAssistQueryContext.cs
+++ b/src/NovaTerminal.App/CommandAssist/Models/CommandAssistQueryContext.cs
@@ -1,0 +1,6 @@
+namespace NovaTerminal.CommandAssist.Models;
+
+public sealed record CommandAssistQueryContext(
+    string Input,
+    string? WorkingDirectory,
+    string? ShellKind);

--- a/src/NovaTerminal.App/CommandAssist/Models/CommandCaptureSource.cs
+++ b/src/NovaTerminal.App/CommandAssist/Models/CommandCaptureSource.cs
@@ -1,0 +1,6 @@
+namespace NovaTerminal.CommandAssist.Models;
+
+public enum CommandCaptureSource
+{
+    Heuristic
+}

--- a/src/NovaTerminal.App/CommandAssist/Models/CommandHistoryEntry.cs
+++ b/src/NovaTerminal.App/CommandAssist/Models/CommandHistoryEntry.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace NovaTerminal.CommandAssist.Models;
+
+public sealed record CommandHistoryEntry(
+    string Id,
+    string CommandText,
+    DateTimeOffset ExecutedAt,
+    string ShellKind,
+    string? WorkingDirectory,
+    string? ProfileId,
+    string? SessionId,
+    string? HostId,
+    int? ExitCode,
+    bool IsRemote,
+    bool IsRedacted,
+    CommandCaptureSource Source);

--- a/src/NovaTerminal.App/CommandAssist/Storage/JsonHistoryStore.cs
+++ b/src/NovaTerminal.App/CommandAssist/Storage/JsonHistoryStore.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using NovaTerminal.CommandAssist.Domain;
+using NovaTerminal.CommandAssist.Models;
+using NovaTerminal.Core;
+
+namespace NovaTerminal.CommandAssist.Storage;
+
+public sealed class JsonHistoryStore : IHistoryStore
+{
+    private readonly string _filePath;
+    private readonly int _maxEntries;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public JsonHistoryStore(string filePath, int maxEntries)
+    {
+        _filePath = filePath;
+        _maxEntries = Math.Max(1, maxEntries);
+    }
+
+    public async Task AppendAsync(CommandHistoryEntry entry, CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            List<CommandHistoryEntry> entries = await LoadEntriesUnsafeAsync(cancellationToken);
+            entries.Add(entry);
+            entries = entries
+                .OrderByDescending(x => x.ExecutedAt)
+                .Take(_maxEntries)
+                .ToList();
+
+            await SaveEntriesUnsafeAsync(entries, cancellationToken);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<IReadOnlyList<CommandHistoryEntry>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            List<CommandHistoryEntry> entries = await LoadEntriesUnsafeAsync(cancellationToken);
+            string normalized = query.Trim();
+
+            return entries
+                .Select(entry => new
+                {
+                    Entry = entry,
+                    Score = Score(entry.CommandText, normalized)
+                })
+                .Where(x => x.Score > 0)
+                .OrderByDescending(x => x.Score)
+                .ThenBy(x => x.Entry.CommandText.Length)
+                .ThenByDescending(x => x.Entry.ExecutedAt)
+                .Take(maxResults)
+                .Select(x => x.Entry)
+                .ToList();
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<IReadOnlyList<CommandHistoryEntry>> GetRecentAsync(int maxResults, CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            List<CommandHistoryEntry> entries = await LoadEntriesUnsafeAsync(cancellationToken);
+            return entries
+                .OrderByDescending(x => x.ExecutedAt)
+                .Take(maxResults)
+                .ToList();
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task ClearAsync(CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            await SaveEntriesUnsafeAsync(new List<CommandHistoryEntry>(), cancellationToken);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private async Task<List<CommandHistoryEntry>> LoadEntriesUnsafeAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_filePath))
+        {
+            return new List<CommandHistoryEntry>();
+        }
+
+        try
+        {
+            await using FileStream stream = File.OpenRead(_filePath);
+            List<CommandHistoryEntry>? entries = await JsonSerializer.DeserializeAsync(
+                stream,
+                AppJsonContext.Default.ListCommandHistoryEntry,
+                cancellationToken);
+
+            return entries ?? new List<CommandHistoryEntry>();
+        }
+        catch
+        {
+            return new List<CommandHistoryEntry>();
+        }
+    }
+
+    private async Task SaveEntriesUnsafeAsync(List<CommandHistoryEntry> entries, CancellationToken cancellationToken)
+    {
+        string? directory = Path.GetDirectoryName(_filePath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        await using FileStream stream = File.Create(_filePath);
+        await JsonSerializer.SerializeAsync(stream, entries, AppJsonContext.Default.ListCommandHistoryEntry, cancellationToken);
+    }
+
+    private static int Score(string commandText, string query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return 1;
+        }
+
+        string lowerCommand = commandText.ToLowerInvariant();
+        string lowerQuery = query.ToLowerInvariant();
+        if (lowerCommand.StartsWith(lowerQuery, StringComparison.Ordinal))
+        {
+            return 100;
+        }
+
+        string[] tokens = lowerCommand.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (tokens.Any(token => token.StartsWith(lowerQuery, StringComparison.Ordinal)))
+        {
+            return 80;
+        }
+
+        if (lowerCommand.Contains(lowerQuery, StringComparison.Ordinal))
+        {
+            return 40;
+        }
+
+        return IsSubsequence(lowerQuery, lowerCommand) ? 20 : 0;
+    }
+
+    private static bool IsSubsequence(string query, string command)
+    {
+        int queryIndex = 0;
+        for (int i = 0; i < command.Length && queryIndex < query.Length; i++)
+        {
+            if (command[i] == query[queryIndex])
+            {
+                queryIndex++;
+            }
+        }
+
+        return queryIndex == query.Length;
+    }
+}

--- a/src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistBarViewModel.cs
+++ b/src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistBarViewModel.cs
@@ -1,0 +1,79 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace NovaTerminal.CommandAssist.ViewModels;
+
+public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
+{
+    private bool _isVisible;
+    private string _modeLabel = "Suggest";
+    private string _queryText = string.Empty;
+    private string _topSuggestionText = string.Empty;
+
+    public bool IsVisible
+    {
+        get => _isVisible;
+        set
+        {
+            if (_isVisible == value)
+            {
+                return;
+            }
+
+            _isVisible = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public string ModeLabel
+    {
+        get => _modeLabel;
+        set
+        {
+            if (_modeLabel == value)
+            {
+                return;
+            }
+
+            _modeLabel = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public string QueryText
+    {
+        get => _queryText;
+        set
+        {
+            if (_queryText == value)
+            {
+                return;
+            }
+
+            _queryText = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public string TopSuggestionText
+    {
+        get => _topSuggestionText;
+        set
+        {
+            if (_topSuggestionText == value)
+            {
+                return;
+            }
+
+            _topSuggestionText = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/src/NovaTerminal.App/CommandAssist/Views/CommandAssistBarView.axaml
+++ b/src/NovaTerminal.App/CommandAssist/Views/CommandAssistBarView.axaml
@@ -1,0 +1,27 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:CompileBindings="False"
+             x:Class="NovaTerminal.CommandAssist.Views.CommandAssistBarView"
+             IsVisible="{Binding IsVisible}">
+    <Border Background="#CC202020"
+            BorderBrush="#404040"
+            BorderThickness="0,1,0,0"
+            Padding="10,6">
+        <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="12">
+            <TextBlock Text="{Binding ModeLabel}"
+                       Foreground="#8EC5FF"
+                       FontWeight="SemiBold"
+                       VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="1"
+                       Text="{Binding TopSuggestionText}"
+                       Foreground="White"
+                       TextTrimming="CharacterEllipsis"
+                       VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="2"
+                       Text="Ctrl+R history | Ctrl+Space toggle | Esc close"
+                       Foreground="#A0A0A0"
+                       FontSize="11"
+                       VerticalAlignment="Center"/>
+        </Grid>
+    </Border>
+</UserControl>

--- a/src/NovaTerminal.App/CommandAssist/Views/CommandAssistBarView.axaml.cs
+++ b/src/NovaTerminal.App/CommandAssist/Views/CommandAssistBarView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace NovaTerminal.CommandAssist.Views;
+
+public partial class CommandAssistBarView : UserControl
+{
+    public CommandAssistBarView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:core="clr-namespace:NovaTerminal.Core"
+             xmlns:assist="clr-namespace:NovaTerminal.CommandAssist.Views"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="NovaTerminal.Controls.TerminalPane"
              Focusable="True"
@@ -19,7 +20,7 @@
     </UserControl.Styles>
 
     <Border Padding="0">
-        <Grid x:Name="RootGrid" Background="Transparent" RowDefinitions="*,Auto">
+        <Grid x:Name="RootGrid" Background="Transparent" RowDefinitions="*,Auto,Auto">
             <!-- Context Menu for SFTP Actions -->
             <Grid.ContextMenu>
                 <ContextMenu Name="PaneContextMenu">
@@ -112,9 +113,12 @@
                 </Grid>
             </Border>
 
+            <assist:CommandAssistBarView x:Name="CommandAssistBar"
+                                         Grid.Row="1" />
+
             <!-- Port Forwarding Status Bar -->
             <Border Name="StatusBar" VerticalAlignment="Bottom" Height="22" Background="#CC1A1A1A" 
-                    BorderBrush="#333" BorderThickness="0,1,0,0" IsVisible="False" ZIndex="100" Grid.Row="1">
+                    BorderBrush="#333" BorderThickness="0,1,0,0" IsVisible="False" ZIndex="100" Grid.Row="2">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="10,0" Spacing="10">
                     <TextBlock Name="StatusBarLabel" Foreground="#AAA" FontSize="10" VerticalAlignment="Center"/>
                     <StackPanel Name="StatusBarRules" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center"/>
@@ -128,7 +132,7 @@
 
 
             <!-- Focus Indicator Border -->
-            <Border Name="FocusBorder" BorderThickness="1" BorderBrush="Transparent" IsHitTestVisible="False" ZIndex="300" Grid.RowSpan="2" />
+            <Border Name="FocusBorder" BorderThickness="1" BorderBrush="Transparent" IsHitTestVisible="False" ZIndex="300" Grid.RowSpan="3" />
         </Grid>
     </Border>
 </UserControl>

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -372,13 +372,7 @@ namespace NovaTerminal.Controls
 
             TermView.TextInputObserved += text => _commandAssistController?.HandleTextInput(text);
             TermView.BackspaceObserved += () => _commandAssistController?.HandleBackspace();
-            TermView.EnterObserved += async () =>
-            {
-                if (_commandAssistController != null)
-                {
-                    await _commandAssistController.HandleEnterAsync();
-                }
-            };
+            TermView.EnterObserved += OnCommandAssistEnterObserved;
             TermView.PasteObserved += text => _commandAssistController?.HandlePastedText(text);
 
             if (Buffer != null)
@@ -390,6 +384,28 @@ namespace NovaTerminal.Controls
         private void OnBufferScreenSwitched(bool isAltScreen)
         {
             Dispatcher.UIThread.Post(() => _commandAssistController?.HandleAltScreenChanged(isAltScreen));
+        }
+
+        private void OnCommandAssistEnterObserved()
+        {
+            _ = HandleCommandAssistEnterObservedAsync();
+        }
+
+        private async Task HandleCommandAssistEnterObservedAsync()
+        {
+            if (_commandAssistController == null)
+            {
+                return;
+            }
+
+            try
+            {
+                await _commandAssistController.HandleEnterAsync();
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[TerminalPane] Command Assist enter handling failed: {ex.Message}");
+            }
         }
 
         private void UpdateCommandAssistContext()
@@ -775,9 +791,9 @@ namespace NovaTerminal.Controls
             _commandAssistController?.ToggleAssist();
         }
 
-        public void OpenCommandAssistHistorySearch()
+        public bool OpenCommandAssistHistorySearch()
         {
-            _commandAssistController?.OpenHistorySearch();
+            return _commandAssistController?.OpenHistorySearch() ?? false;
         }
 
         public void NotifyCommandAssistPaste(string text)

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -14,6 +14,7 @@ using System.Linq;
 using Avalonia.Controls.Shapes;
 using Avalonia.Automation;
 using Avalonia.Platform.Storage;
+using NovaTerminal.CommandAssist.Application;
 using NovaTerminal.Core.Ssh.Launch;
 using NovaTerminal.Core.Ssh.Sessions;
 
@@ -57,6 +58,7 @@ namespace NovaTerminal.Controls
         private readonly SshDiagnosticsLevel _sshDiagnosticsLevel;
         private string? _pendingPasteFilePath;
         private string? _pendingEscapedPath;
+        private CommandAssistController? _commandAssistController;
 
         public bool IsRecording => Session?.IsRecording ?? false;
         public string? CurrentWorkingDirectory { get; private set; }
@@ -135,6 +137,7 @@ namespace NovaTerminal.Controls
         {
             Profile = profile;
             TermView.ShellOverride = profile.ShellOverride;
+            UpdateCommandAssistContext();
         }
 
         public Control ActiveControl => TermView;
@@ -197,6 +200,13 @@ namespace NovaTerminal.Controls
             };
             TermView.KeyDown += (_, e) =>
             {
+                if (e.Key == Key.Escape && _commandAssistController?.ViewModel.IsVisible == true)
+                {
+                    _commandAssistController.Dismiss();
+                    e.Handled = true;
+                    return;
+                }
+
                 if (e.Key != Key.LeftShift &&
                     e.Key != Key.RightShift &&
                     e.Key != Key.LeftCtrl &&
@@ -247,6 +257,7 @@ namespace NovaTerminal.Controls
 
             // Load Settings
             ApplySettings(TerminalSettings.Load());
+            InitializeCommandAssist();
             UpdateMinimumSizeConstraints();
             AutomationProperties.SetName(TermView, "Terminal Pane");
             AutomationProperties.SetName(this, "Terminal Pane");
@@ -332,6 +343,94 @@ namespace NovaTerminal.Controls
 
         }
 
+        private void InitializeCommandAssist()
+        {
+            if (_settings == null || !_settings.CommandAssistEnabled || !_settings.CommandAssistHistoryEnabled)
+            {
+                if (CommandAssistBar != null)
+                {
+                    CommandAssistBar.DataContext = null;
+                    CommandAssistBar.IsVisible = false;
+                }
+
+                return;
+            }
+
+            _commandAssistController = new CommandAssistController(
+                CommandAssistInfrastructure.GetHistoryStore(_settings),
+                CommandAssistInfrastructure.GetSecretsFilter(),
+                CommandAssistInfrastructure.GetSuggestionEngine(),
+                action => Dispatcher.UIThread.Post(action));
+
+            if (CommandAssistBar != null)
+            {
+                CommandAssistBar.DataContext = _commandAssistController.ViewModel;
+            }
+
+            _commandAssistController.HandleAltScreenChanged(Buffer?.IsAltScreenActive ?? false);
+            UpdateCommandAssistContext();
+
+            TermView.TextInputObserved += text => _commandAssistController?.HandleTextInput(text);
+            TermView.BackspaceObserved += () => _commandAssistController?.HandleBackspace();
+            TermView.EnterObserved += async () =>
+            {
+                if (_commandAssistController != null)
+                {
+                    await _commandAssistController.HandleEnterAsync();
+                }
+            };
+            TermView.PasteObserved += text => _commandAssistController?.HandlePastedText(text);
+
+            if (Buffer != null)
+            {
+                Buffer.OnScreenSwitched += OnBufferScreenSwitched;
+            }
+        }
+
+        private void OnBufferScreenSwitched(bool isAltScreen)
+        {
+            Dispatcher.UIThread.Post(() => _commandAssistController?.HandleAltScreenChanged(isAltScreen));
+        }
+
+        private void UpdateCommandAssistContext()
+        {
+            _commandAssistController?.UpdateSessionContext(
+                shellKind: DetermineShellKind(Session?.ShellCommand ?? ShellCommand),
+                workingDirectory: CurrentWorkingDirectory,
+                profileId: Profile?.Id.ToString(),
+                sessionId: Session?.Id.ToString(),
+                hostId: Profile?.Type == ConnectionType.SSH ? Profile.SshHost : null,
+                isRemote: Profile?.Type == ConnectionType.SSH);
+        }
+
+        private static string DetermineShellKind(string? shellCommand)
+        {
+            if (string.IsNullOrWhiteSpace(shellCommand))
+            {
+                return "unknown";
+            }
+
+            if (shellCommand.Contains("pwsh", StringComparison.OrdinalIgnoreCase) ||
+                shellCommand.Contains("powershell", StringComparison.OrdinalIgnoreCase))
+            {
+                return "pwsh";
+            }
+
+            if (shellCommand.Contains("cmd", StringComparison.OrdinalIgnoreCase))
+            {
+                return "cmd";
+            }
+
+            if (shellCommand.Contains("bash", StringComparison.OrdinalIgnoreCase) ||
+                shellCommand.Contains("zsh", StringComparison.OrdinalIgnoreCase) ||
+                shellCommand.Contains("sh", StringComparison.OrdinalIgnoreCase))
+            {
+                return "posix";
+            }
+
+            return "unknown";
+        }
+
         private void InitializeSession(string? shell, TerminalProfile? profile, int cols, int rows, string? explicitArgs = null)
         {
             if (Session != null || Buffer == null) return;
@@ -355,6 +454,7 @@ namespace NovaTerminal.Controls
                 Dispatcher.UIThread.Post(() =>
                 {
                     CurrentWorkingDirectory = cwd;
+                    UpdateCommandAssistContext();
                     WorkingDirectoryChanged?.Invoke(this, cwd);
                 });
             };
@@ -460,6 +560,7 @@ namespace NovaTerminal.Controls
                         ProcessExited?.Invoke(this, code);
                     });
                 };
+                UpdateCommandAssistContext();
             }
             catch (Exception ex)
             {
@@ -669,6 +770,21 @@ namespace NovaTerminal.Controls
             }
         }
 
+        public void ToggleCommandAssist()
+        {
+            _commandAssistController?.ToggleAssist();
+        }
+
+        public void OpenCommandAssistHistorySearch()
+        {
+            _commandAssistController?.OpenHistorySearch();
+        }
+
+        public void NotifyCommandAssistPaste(string text)
+        {
+            _commandAssistController?.HandlePastedText(text);
+        }
+
         public void ToggleRenderHud()
         {
             TermView.ShowRenderHud = !TermView.ShowRenderHud;
@@ -779,6 +895,10 @@ namespace NovaTerminal.Controls
 
         public void Dispose()
         {
+            if (Buffer != null)
+            {
+                Buffer.OnScreenSwitched -= OnBufferScreenSwitched;
+            }
             _statusTimer?.Stop();
             _statusTimer = null;
             SftpService.Instance.JobUpdated -= Sftp_JobUpdated;

--- a/src/NovaTerminal.App/Core/AppJsonContext.cs
+++ b/src/NovaTerminal.App/Core/AppJsonContext.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
+using System;
 using System.Text.Json.Serialization;
 using NovaTerminal.Core;
+using NovaTerminal.CommandAssist.Models;
 
 namespace NovaTerminal.Core
 {
@@ -8,9 +10,11 @@ namespace NovaTerminal.Core
     [JsonSerializable(typeof(TerminalProfile))]
     [JsonSerializable(typeof(TerminalTheme))]
     [JsonSerializable(typeof(ForwardingRule))]
+    [JsonSerializable(typeof(DateTimeOffset))]
     [JsonSerializable(typeof(List<TerminalProfile>))]
     [JsonSerializable(typeof(List<TabTemplateRule>))]
     [JsonSerializable(typeof(List<ForwardingRule>))]
+    [JsonSerializable(typeof(List<CommandHistoryEntry>))]
     [JsonSerializable(typeof(Dictionary<string, string>))]
     [JsonSerializable(typeof(WorkspacePolicyHooks))]
     [JsonSourceGenerationOptions(WriteIndented = true, Converters = new[] { typeof(JsonColorConverter), typeof(TermColorJsonConverter) })]

--- a/src/NovaTerminal.App/Core/AppPaths.cs
+++ b/src/NovaTerminal.App/Core/AppPaths.cs
@@ -32,6 +32,8 @@ namespace NovaTerminal.Core
         public static string WorkspacePolicyFilePath => Path.Combine(PolicyDirectory, "workspace_policy.json");
         public static string WorkspaceAuditLogPath => Path.Combine(LogsDirectory, "workspace_audit.log");
         public static string RecordingsDirectory => Path.Combine(RootDirectory, "recordings");
+        public static string CommandAssistDirectory => Path.Combine(RootDirectory, "command-assist");
+        public static string CommandHistoryFilePath => Path.Combine(CommandAssistDirectory, "history.json");
 
         public static void EnsureInitialized()
         {
@@ -51,6 +53,7 @@ namespace NovaTerminal.Core
                     Directory.CreateDirectory(WorkspaceTemplatesDirectory);
                     Directory.CreateDirectory(PolicyDirectory);
                     Directory.CreateDirectory(RecordingsDirectory);
+                    Directory.CreateDirectory(CommandAssistDirectory);
 
                     string legacyBaseDir = AppDomain.CurrentDomain.BaseDirectory;
                     string legacyRoamingRoot = Path.Combine(

--- a/src/NovaTerminal.App/Core/TerminalSettings.cs
+++ b/src/NovaTerminal.App/Core/TerminalSettings.cs
@@ -33,6 +33,10 @@ namespace NovaTerminal.Core
 
         public bool QuakeModeEnabled { get; set; } = true;
         public string GlobalHotkey { get; set; } = "Alt+OemTilde";
+        public bool CommandAssistEnabled { get; set; } = true;
+        public bool CommandAssistHistoryEnabled { get; set; } = true;
+        public int CommandAssistMaxHistoryEntries { get; set; } = 5000;
+        public bool CommandAssistAutoHideInAltScreen { get; set; } = true;
 
         public System.Collections.Generic.List<TerminalProfile> Profiles { get; set; } = new();
         public Guid DefaultProfileId { get; set; }

--- a/src/NovaTerminal.App/Core/TerminalView.cs
+++ b/src/NovaTerminal.App/Core/TerminalView.cs
@@ -85,6 +85,7 @@ namespace NovaTerminal.Core
             {
                 ResetCursorBlink();
                 _session.SendInput(e.Text);
+                TextInputObserved?.Invoke(e.Text);
                 e.Handled = true;
             }
         }
@@ -105,10 +106,12 @@ namespace NovaTerminal.Core
             {
                 case Key.Enter:
                     _session.SendInput("\r");
+                    EnterObserved?.Invoke();
                     e.Handled = true;
                     return;
                 case Key.Back:
                     _session.SendInput("\x7f");
+                    BackspaceObserved?.Invoke();
                     e.Handled = true;
                     return;
                 case Key.Tab:
@@ -366,6 +369,10 @@ namespace NovaTerminal.Core
         }
 
         public event EventHandler<TextFileDroppedEventArgs>? TextFileDropped;
+        public event Action<string>? TextInputObserved;
+        public event Action? BackspaceObserved;
+        public event Action? EnterObserved;
+        public event Action<string>? PasteObserved;
 
         private void OnDragOver(object? sender, DragEventArgs e)
         {
@@ -448,6 +455,7 @@ namespace NovaTerminal.Core
                         if (!string.IsNullOrEmpty(result.TextToSend))
                         {
                             _session.SendInput(result.TextToSend);
+                            PasteObserved?.Invoke(result.TextToSend);
                         }
                         
                         return;
@@ -458,6 +466,7 @@ namespace NovaTerminal.Core
             if (e.Data.GetText() is string text && !string.IsNullOrWhiteSpace(text))
             {
                 _session.SendInput(text);
+                PasteObserved?.Invoke(text);
                 e.Handled = true;
             }
         }

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -1826,6 +1826,20 @@ namespace NovaTerminal
                     return;
                 }
 
+                if (IsShortcut(e, "command_assist_toggle", "Ctrl+Space"))
+                {
+                    _currentPane?.ToggleCommandAssist();
+                    e.Handled = true;
+                    return;
+                }
+
+                if (IsShortcut(e, "command_assist_history", "Ctrl+R"))
+                {
+                    _currentPane?.OpenCommandAssistHistorySearch();
+                    e.Handled = true;
+                    return;
+                }
+
                 if (IsShortcut(e, "font_increase", "Ctrl+OemPlus") || IsShortcut(e, "font_increase_alt", "Ctrl+Add"))
                 {
                     _settings.FontSize++;
@@ -3259,6 +3273,7 @@ namespace NovaTerminal
                     {
                         // Normalize line endings to avoid double newlines on paste
                         text = text.Replace("\r\n", "\r");
+                        _currentPane.NotifyCommandAssistPaste(text);
 
                         // Handle Bracketed Paste Mode
                         if (_currentPane.Buffer != null && _currentPane.Buffer.Modes.IsBracketedPasteMode)

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -1835,9 +1835,11 @@ namespace NovaTerminal
 
                 if (IsShortcut(e, "command_assist_history", "Ctrl+R"))
                 {
-                    _currentPane?.OpenCommandAssistHistorySearch();
-                    e.Handled = true;
-                    return;
+                    if (_currentPane?.OpenCommandAssistHistorySearch() == true)
+                    {
+                        e.Handled = true;
+                        return;
+                    }
                 }
 
                 if (IsShortcut(e, "font_increase", "Ctrl+OemPlus") || IsShortcut(e, "font_increase_alt", "Ctrl+Add"))

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
@@ -1,0 +1,207 @@
+using NovaTerminal.CommandAssist.Application;
+using NovaTerminal.CommandAssist.Domain;
+using NovaTerminal.CommandAssist.Models;
+using System.Diagnostics;
+
+namespace NovaTerminal.Tests.CommandAssist;
+
+public sealed class CommandAssistControllerTests
+{
+    [Fact]
+    public void ToggleAssist_WhenNotInAltScreen_ShowsAssistBar()
+    {
+        var controller = CreateController();
+
+        controller.ToggleAssist();
+
+        Assert.True(controller.ViewModel.IsVisible);
+    }
+
+    [Fact]
+    public void HandleAltScreenChanged_WhenAssistIsVisible_HidesAssistBarImmediately()
+    {
+        var controller = CreateController();
+        controller.ToggleAssist();
+
+        controller.HandleAltScreenChanged(true);
+
+        Assert.False(controller.ViewModel.IsVisible);
+    }
+
+    [Fact]
+    public void HandleAltScreenChanged_WhenLeavingAltScreen_DoesNotAutoShowAssistAgain()
+    {
+        var controller = CreateController();
+        controller.ToggleAssist();
+        controller.HandleAltScreenChanged(true);
+
+        controller.HandleAltScreenChanged(false);
+
+        Assert.False(controller.ViewModel.IsVisible);
+    }
+
+    [Fact]
+    public void HandleTextInput_UpdatesQueryAndTopSuggestion()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        historyStore.Seed(
+            CreateEntry("git status"),
+            CreateEntry("dotnet test"));
+
+        var controller = CreateController(historyStore);
+
+        controller.HandleTextInput("git ");
+
+        Assert.Equal("git ", controller.ViewModel.QueryText);
+        Assert.Equal("git status", controller.ViewModel.TopSuggestionText);
+    }
+
+    [Fact]
+    public async Task HandleEnterAsync_PersistsSingleLineRedactedCommand()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        var controller = CreateController(historyStore);
+        controller.HandleTextInput("gh auth login --password hunter2");
+
+        await controller.HandleEnterAsync();
+
+        Assert.Single(historyStore.Entries);
+        Assert.Equal("gh auth login --password [REDACTED]", historyStore.Entries[0].CommandText);
+        Assert.True(historyStore.Entries[0].IsRedacted);
+        Assert.Equal(string.Empty, controller.ViewModel.QueryText);
+    }
+
+    [Fact]
+    public async Task HandleEnterAsync_DoesNotPersistMultiLineScriptLikeInput()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        var controller = CreateController(historyStore);
+        controller.HandleTextInput("echo one");
+        controller.HandlePastedText("echo one\necho two");
+
+        await controller.HandleEnterAsync();
+
+        Assert.Empty(historyStore.Entries);
+    }
+
+    [Fact]
+    public async Task HandleTextInput_DoesNotBlockWhileHistorySearchIsPending()
+    {
+        var historyStore = new DelayedHistoryStore(TimeSpan.FromMilliseconds(250), CreateEntry("git status"));
+        var controller = CreateController(historyStore);
+        var stopwatch = Stopwatch.StartNew();
+
+        controller.HandleTextInput("git");
+
+        stopwatch.Stop();
+
+        Assert.True(stopwatch.ElapsedMilliseconds < 100, $"HandleTextInput blocked for {stopwatch.ElapsedMilliseconds}ms");
+        Assert.Equal("git", controller.ViewModel.QueryText);
+
+        await historyStore.WaitForLastSearchAsync();
+    }
+
+    private static CommandAssistController CreateController(IHistoryStore? historyStore = null)
+    {
+        historyStore ??= new InMemoryHistoryStore();
+        var filter = new SecretsFilter();
+        var engine = new HistorySuggestionEngine();
+
+        return new CommandAssistController(historyStore, filter, engine);
+    }
+
+    private static CommandHistoryEntry CreateEntry(string commandText)
+    {
+        return new CommandHistoryEntry(
+            Id: Guid.NewGuid().ToString("N"),
+            CommandText: commandText,
+            ExecutedAt: DateTimeOffset.UtcNow,
+            ShellKind: "pwsh",
+            WorkingDirectory: @"C:\repo",
+            ProfileId: "profile-1",
+            SessionId: "session-1",
+            HostId: null,
+            ExitCode: 0,
+            IsRemote: false,
+            IsRedacted: false,
+            Source: CommandCaptureSource.Heuristic);
+    }
+
+    private sealed class InMemoryHistoryStore : IHistoryStore
+    {
+        private readonly List<CommandHistoryEntry> _entries = new();
+        public IReadOnlyList<CommandHistoryEntry> Entries => _entries;
+
+        public Task AppendAsync(CommandHistoryEntry entry, CancellationToken cancellationToken = default)
+        {
+            _entries.Add(entry);
+            return Task.CompletedTask;
+        }
+
+        public Task ClearAsync(CancellationToken cancellationToken = default)
+        {
+            _entries.Clear();
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<CommandHistoryEntry>> GetRecentAsync(int maxResults, CancellationToken cancellationToken = default)
+        {
+            IReadOnlyList<CommandHistoryEntry> results = _entries
+                .OrderByDescending(x => x.ExecutedAt)
+                .Take(maxResults)
+                .ToList();
+            return Task.FromResult(results);
+        }
+
+        public Task<IReadOnlyList<CommandHistoryEntry>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default)
+        {
+            IReadOnlyList<CommandHistoryEntry> results = _entries
+                .Where(x => x.CommandText.Contains(query, StringComparison.OrdinalIgnoreCase))
+                .Take(maxResults)
+                .ToList();
+            return Task.FromResult(results);
+        }
+
+        public void Seed(params CommandHistoryEntry[] entries)
+        {
+            _entries.AddRange(entries);
+        }
+    }
+
+    private sealed class DelayedHistoryStore : IHistoryStore
+    {
+        private readonly TimeSpan _delay;
+        private readonly IReadOnlyList<CommandHistoryEntry> _results;
+        private Task _lastSearchTask = Task.CompletedTask;
+
+        public DelayedHistoryStore(TimeSpan delay, params CommandHistoryEntry[] results)
+        {
+            _delay = delay;
+            _results = results;
+        }
+
+        public Task AppendAsync(CommandHistoryEntry entry, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task ClearAsync(CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task<IReadOnlyList<CommandHistoryEntry>> GetRecentAsync(int maxResults, CancellationToken cancellationToken = default)
+        {
+            _lastSearchTask = Task.Delay(_delay, cancellationToken);
+            return _lastSearchTask.ContinueWith(
+                _ => _results.Take(maxResults).ToList() as IReadOnlyList<CommandHistoryEntry>,
+                cancellationToken);
+        }
+
+        public Task<IReadOnlyList<CommandHistoryEntry>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default)
+        {
+            _lastSearchTask = Task.Delay(_delay, cancellationToken);
+            return _lastSearchTask.ContinueWith(
+                _ => _results.Take(maxResults).ToList() as IReadOnlyList<CommandHistoryEntry>,
+                cancellationToken);
+        }
+
+        public Task WaitForLastSearchAsync() => _lastSearchTask;
+    }
+}

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
@@ -41,6 +41,30 @@ public sealed class CommandAssistControllerTests
     }
 
     [Fact]
+    public void OpenHistorySearch_WhenNotInAltScreen_ReturnsTrue()
+    {
+        var controller = CreateController();
+
+        bool opened = controller.OpenHistorySearch();
+
+        Assert.True(opened);
+        Assert.True(controller.ViewModel.IsVisible);
+        Assert.Equal("History", controller.ViewModel.ModeLabel);
+    }
+
+    [Fact]
+    public void OpenHistorySearch_WhenAltScreenActive_ReturnsFalse()
+    {
+        var controller = CreateController();
+        controller.HandleAltScreenChanged(true);
+
+        bool opened = controller.OpenHistorySearch();
+
+        Assert.False(opened);
+        Assert.False(controller.ViewModel.IsVisible);
+    }
+
+    [Fact]
     public void HandleTextInput_UpdatesQueryAndTopSuggestion()
     {
         var historyStore = new InMemoryHistoryStore();
@@ -82,6 +106,18 @@ public sealed class CommandAssistControllerTests
         await controller.HandleEnterAsync();
 
         Assert.Empty(historyStore.Entries);
+    }
+
+    [Fact]
+    public async Task HandleEnterAsync_WhenHistoryStoreThrows_DoesNotPropagate()
+    {
+        var controller = CreateController(new ThrowingHistoryStore());
+        controller.HandleTextInput("git status");
+
+        await controller.HandleEnterAsync();
+
+        Assert.Equal(string.Empty, controller.ViewModel.QueryText);
+        Assert.False(controller.ViewModel.IsVisible);
     }
 
     [Fact]
@@ -203,5 +239,20 @@ public sealed class CommandAssistControllerTests
         }
 
         public Task WaitForLastSearchAsync() => _lastSearchTask;
+    }
+
+    private sealed class ThrowingHistoryStore : IHistoryStore
+    {
+        public Task AppendAsync(CommandHistoryEntry entry, CancellationToken cancellationToken = default)
+            => Task.FromException(new InvalidOperationException("simulated write failure"));
+
+        public Task ClearAsync(CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task<IReadOnlyList<CommandHistoryEntry>> GetRecentAsync(int maxResults, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<CommandHistoryEntry>>(Array.Empty<CommandHistoryEntry>());
+
+        public Task<IReadOnlyList<CommandHistoryEntry>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<CommandHistoryEntry>>(Array.Empty<CommandHistoryEntry>());
     }
 }

--- a/tests/NovaTerminal.Tests/CommandAssist/HistorySuggestionEngineTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/HistorySuggestionEngineTests.cs
@@ -1,0 +1,108 @@
+using NovaTerminal.CommandAssist.Domain;
+using NovaTerminal.CommandAssist.Models;
+
+namespace NovaTerminal.Tests.CommandAssist;
+
+public sealed class HistorySuggestionEngineTests
+{
+    [Fact]
+    public void GetSuggestions_ExactPrefixMatchRanksAboveFuzzyMatch()
+    {
+        var engine = new HistorySuggestionEngine();
+        var context = new CommandAssistQueryContext(
+            Input: "git sta",
+            WorkingDirectory: @"C:\repo",
+            ShellKind: "pwsh");
+
+        var entries = new[]
+        {
+            CreateEntry("git status", executedAt: DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")),
+            CreateEntry("grep git src/status.cs", executedAt: DateTimeOffset.Parse("2026-03-01T11:00:00+00:00"))
+        };
+
+        IReadOnlyList<AssistSuggestion> results = engine.GetSuggestions(entries, context, maxResults: 5);
+
+        Assert.Equal("git status", results[0].InsertText);
+    }
+
+    [Fact]
+    public void GetSuggestions_MoreRecentEntryWinsWhenTextMatchQualityIsEqual()
+    {
+        var engine = new HistorySuggestionEngine();
+        var context = new CommandAssistQueryContext(
+            Input: "dotnet t",
+            WorkingDirectory: @"C:\repo",
+            ShellKind: "pwsh");
+
+        var entries = new[]
+        {
+            CreateEntry("dotnet test", executedAt: DateTimeOffset.Parse("2026-03-01T09:00:00+00:00")),
+            CreateEntry("dotnet tool list", executedAt: DateTimeOffset.Parse("2026-03-01T10:00:00+00:00"))
+        };
+
+        IReadOnlyList<AssistSuggestion> results = engine.GetSuggestions(entries, context, maxResults: 5);
+
+        Assert.Equal("dotnet tool list", results[0].InsertText);
+    }
+
+    [Fact]
+    public void GetSuggestions_MoreFrequentEntryWinsWhenOtherSignalsAreSimilar()
+    {
+        var engine = new HistorySuggestionEngine();
+        var context = new CommandAssistQueryContext(
+            Input: "npm run",
+            WorkingDirectory: @"C:\repo",
+            ShellKind: "pwsh");
+
+        var entries = new[]
+        {
+            CreateEntry("npm run build", executedAt: DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")),
+            CreateEntry("npm run build", executedAt: DateTimeOffset.Parse("2026-03-01T10:01:00+00:00")),
+            CreateEntry("npm run test", executedAt: DateTimeOffset.Parse("2026-03-01T10:02:00+00:00"))
+        };
+
+        IReadOnlyList<AssistSuggestion> results = engine.GetSuggestions(entries, context, maxResults: 5);
+
+        Assert.Equal("npm run build", results[0].InsertText);
+    }
+
+    [Fact]
+    public void GetSuggestions_SameWorkingDirectoryGetsBoost()
+    {
+        var engine = new HistorySuggestionEngine();
+        var context = new CommandAssistQueryContext(
+            Input: "cargo t",
+            WorkingDirectory: @"C:\repo-a",
+            ShellKind: "pwsh");
+
+        var entries = new[]
+        {
+            CreateEntry("cargo test", workingDirectory: @"C:\repo-b", executedAt: DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")),
+            CreateEntry("cargo tree", workingDirectory: @"C:\repo-a", executedAt: DateTimeOffset.Parse("2026-03-01T09:59:00+00:00"))
+        };
+
+        IReadOnlyList<AssistSuggestion> results = engine.GetSuggestions(entries, context, maxResults: 5);
+
+        Assert.Equal("cargo tree", results[0].InsertText);
+    }
+
+    private static CommandHistoryEntry CreateEntry(
+        string commandText,
+        string? workingDirectory = null,
+        DateTimeOffset? executedAt = null)
+    {
+        return new CommandHistoryEntry(
+            Id: Guid.NewGuid().ToString("N"),
+            CommandText: commandText,
+            ExecutedAt: executedAt ?? DateTimeOffset.Parse("2026-03-01T10:00:00+00:00"),
+            ShellKind: "pwsh",
+            WorkingDirectory: workingDirectory ?? @"C:\repo",
+            ProfileId: "profile-1",
+            SessionId: "session-1",
+            HostId: null,
+            ExitCode: 0,
+            IsRemote: false,
+            IsRedacted: false,
+            Source: CommandCaptureSource.Heuristic);
+    }
+}

--- a/tests/NovaTerminal.Tests/CommandAssist/JsonHistoryStoreTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/JsonHistoryStoreTests.cs
@@ -1,0 +1,117 @@
+using System.Text.Json;
+using NovaTerminal.CommandAssist.Models;
+using NovaTerminal.CommandAssist.Storage;
+
+namespace NovaTerminal.Tests.CommandAssist;
+
+public sealed class JsonHistoryStoreTests : IDisposable
+{
+    private readonly string _tempRoot;
+
+    public JsonHistoryStoreTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), $"nova_command_assist_history_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempRoot);
+    }
+
+    [Fact]
+    public async Task AppendAsync_PersistsEntriesAcrossStoreInstances()
+    {
+        string filePath = Path.Combine(_tempRoot, "history.json");
+        var store = new JsonHistoryStore(filePath, maxEntries: 50);
+
+        await store.AppendAsync(CreateEntry("git status", executedAt: DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")));
+
+        var reloaded = new JsonHistoryStore(filePath, maxEntries: 50);
+        IReadOnlyList<CommandHistoryEntry> entries = await reloaded.GetRecentAsync(10);
+
+        Assert.Single(entries);
+        Assert.Equal("git status", entries[0].CommandText);
+    }
+
+    [Fact]
+    public async Task AppendAsync_EnforcesRetentionLimitByKeepingMostRecentEntries()
+    {
+        string filePath = Path.Combine(_tempRoot, "history.json");
+        var store = new JsonHistoryStore(filePath, maxEntries: 2);
+
+        await store.AppendAsync(CreateEntry("git status", executedAt: DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")));
+        await store.AppendAsync(CreateEntry("dotnet test", executedAt: DateTimeOffset.Parse("2026-03-01T10:01:00+00:00")));
+        await store.AppendAsync(CreateEntry("npm run build", executedAt: DateTimeOffset.Parse("2026-03-01T10:02:00+00:00")));
+
+        IReadOnlyList<CommandHistoryEntry> entries = await store.GetRecentAsync(10);
+
+        Assert.Equal(2, entries.Count);
+        Assert.DoesNotContain(entries, entry => entry.CommandText == "git status");
+        Assert.Equal("npm run build", entries[0].CommandText);
+        Assert.Equal("dotnet test", entries[1].CommandText);
+    }
+
+    [Fact]
+    public async Task ClearAsync_RemovesPersistedHistory()
+    {
+        string filePath = Path.Combine(_tempRoot, "history.json");
+        var store = new JsonHistoryStore(filePath, maxEntries: 50);
+
+        await store.AppendAsync(CreateEntry("git status"));
+        await store.ClearAsync();
+
+        IReadOnlyList<CommandHistoryEntry> entries = await store.GetRecentAsync(10);
+
+        Assert.Empty(entries);
+    }
+
+    [Fact]
+    public async Task GetRecentAsync_WhenFileContainsInvalidJson_ReturnsEmptyHistory()
+    {
+        string filePath = Path.Combine(_tempRoot, "history.json");
+        await File.WriteAllTextAsync(filePath, "{ this is not valid json");
+
+        var store = new JsonHistoryStore(filePath, maxEntries: 50);
+        IReadOnlyList<CommandHistoryEntry> entries = await store.GetRecentAsync(10);
+
+        Assert.Empty(entries);
+    }
+
+    [Fact]
+    public async Task SearchAsync_ReturnsPrefixAndFuzzyMatchesOrderedByRelevance()
+    {
+        string filePath = Path.Combine(_tempRoot, "history.json");
+        var store = new JsonHistoryStore(filePath, maxEntries: 50);
+
+        await store.AppendAsync(CreateEntry("git status", executedAt: DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")));
+        await store.AppendAsync(CreateEntry("git stash pop", executedAt: DateTimeOffset.Parse("2026-03-01T10:01:00+00:00")));
+        await store.AppendAsync(CreateEntry("docker status", executedAt: DateTimeOffset.Parse("2026-03-01T10:02:00+00:00")));
+
+        IReadOnlyList<CommandHistoryEntry> entries = await store.SearchAsync("git sta", maxResults: 5);
+
+        Assert.Equal(2, entries.Count);
+        Assert.Equal("git status", entries[0].CommandText);
+        Assert.Equal("git stash pop", entries[1].CommandText);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+        {
+            Directory.Delete(_tempRoot, recursive: true);
+        }
+    }
+
+    private static CommandHistoryEntry CreateEntry(string commandText, DateTimeOffset? executedAt = null)
+    {
+        return new CommandHistoryEntry(
+            Id: Guid.NewGuid().ToString("N"),
+            CommandText: commandText,
+            ExecutedAt: executedAt ?? DateTimeOffset.Parse("2026-03-01T10:00:00+00:00"),
+            ShellKind: "pwsh",
+            WorkingDirectory: @"C:\repo",
+            ProfileId: "profile-1",
+            SessionId: "session-1",
+            HostId: null,
+            ExitCode: 0,
+            IsRemote: false,
+            IsRedacted: false,
+            Source: CommandCaptureSource.Heuristic);
+    }
+}

--- a/tests/NovaTerminal.Tests/CommandAssist/SecretsFilterTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/SecretsFilterTests.cs
@@ -1,0 +1,34 @@
+using NovaTerminal.CommandAssist.Domain;
+
+namespace NovaTerminal.Tests.CommandAssist;
+
+public sealed class SecretsFilterTests
+{
+    [Theory]
+    [InlineData("gh auth login --password hunter2", "gh auth login --password [REDACTED]")]
+    [InlineData("curl https://example.test?token=abc123", "curl https://example.test?token=[REDACTED]")]
+    [InlineData("sshpass -p hunter2 ssh user@example.com", "sshpass -p [REDACTED] ssh user@example.com")]
+    [InlineData("Authorization: Bearer abc.def.ghi", "Authorization: Bearer [REDACTED]")]
+    [InlineData("export JWT=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abc.def", "export JWT=[REDACTED]")]
+    [InlineData("Server=db;User Id=app;Password=supersecret;", "Server=db;User Id=app;Password=[REDACTED];")]
+    public void Redact_WhenCommandContainsKnownSecretPatterns_RedactsSensitiveSegments(string input, string expected)
+    {
+        var filter = new SecretsFilter();
+
+        RedactionResult result = filter.Redact(input);
+
+        Assert.True(result.WasRedacted);
+        Assert.Equal(expected, result.RedactedText);
+    }
+
+    [Fact]
+    public void Redact_WhenCommandDoesNotContainSecrets_ReturnsOriginalText()
+    {
+        var filter = new SecretsFilter();
+
+        RedactionResult result = filter.Redact("git status");
+
+        Assert.False(result.WasRedacted);
+        Assert.Equal("git status", result.RedactedText);
+    }
+}


### PR DESCRIPTION
## Summary
- add the Command Assist M1 app-layer subsystem with persistent history, redaction, ranking, controller logic, and a bottom assist bar scaffold
- integrate Command Assist into pane and input flows without changing the VT parser, renderer, replay, or PTY behavior
- add Command Assist planning docs and focused tests covering persistence, redaction, ranking, controller behavior, and alt-screen auto-hide

## Test Plan
- dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "JsonHistoryStoreTests|SecretsFilterTests|HistorySuggestionEngineTests|CommandAssistControllerTests|AlternateScreenTests|OscShellIntegrationTests|HeadlessUITests" --no-restore