### PR TITLE
Implement Command Assist M2 suggestions and snippets

### DIFF
--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistController.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistController.cs
@@ -20,6 +20,7 @@ public sealed class CommandAssistController
     private bool _isRemote;
     private bool _ignoreCurrentSubmission;
     private int _refreshVersion;
+    private string? _pendingHistoryEntryId;
     private readonly List<AssistSuggestion> _suggestions = new();
     private readonly Action<Action> _dispatch;
 
@@ -28,15 +29,27 @@ public sealed class CommandAssistController
         ISecretsFilter secretsFilter,
         ISuggestionEngine suggestionEngine,
         Action<Action>? dispatch = null)
+        : this(historyStore, secretsFilter, suggestionEngine, snippetStore: null, dispatch)
+    {
+    }
+
+    public CommandAssistController(
+        IHistoryStore historyStore,
+        ISecretsFilter secretsFilter,
+        ISuggestionEngine suggestionEngine,
+        ISnippetStore? snippetStore,
+        Action<Action>? dispatch = null)
     {
         HistoryStore = historyStore;
         SecretsFilter = secretsFilter;
         SuggestionEngine = suggestionEngine;
+        SnippetStore = snippetStore;
         ViewModel = new CommandAssistBarViewModel();
         _dispatch = dispatch ?? (action => action());
     }
 
     public IHistoryStore HistoryStore { get; }
+    public ISnippetStore? SnippetStore { get; }
     public ISecretsFilter SecretsFilter { get; }
     public ISuggestionEngine SuggestionEngine { get; }
     public CommandAssistBarViewModel ViewModel { get; }
@@ -130,6 +143,7 @@ public sealed class CommandAssistController
                     Source: CommandCaptureSource.Heuristic);
 
                 await HistoryStore.AppendAsync(entry);
+                _pendingHistoryEntryId = entry.Id;
             }
         }
         catch
@@ -163,7 +177,150 @@ public sealed class CommandAssistController
         CancelPendingRefreshes();
         ViewModel.IsVisible = false;
         ViewModel.TopSuggestionText = string.Empty;
+        ViewModel.SelectedIndex = -1;
+        ViewModel.SelectedBadgesText = string.Empty;
+        ViewModel.SelectedMetadataText = string.Empty;
+        ViewModel.HasSuggestions = false;
+        ViewModel.Suggestions.Clear();
         _suggestions.Clear();
+    }
+
+    public bool HandleEscape()
+    {
+        if (!ViewModel.IsVisible)
+        {
+            return false;
+        }
+
+        Dismiss();
+        return true;
+    }
+
+    public bool MoveSelectionDown()
+    {
+        if (_suggestions.Count == 0)
+        {
+            return false;
+        }
+
+        int nextIndex = ViewModel.SelectedIndex < 0
+            ? 0
+            : Math.Min(ViewModel.SelectedIndex + 1, _suggestions.Count - 1);
+
+        return SetSelectedIndex(nextIndex);
+    }
+
+    public bool MoveSelectionUp()
+    {
+        if (_suggestions.Count == 0)
+        {
+            return false;
+        }
+
+        int nextIndex = ViewModel.SelectedIndex <= 0
+            ? 0
+            : ViewModel.SelectedIndex - 1;
+
+        return SetSelectedIndex(nextIndex);
+    }
+
+    public bool TryGetInsertionText(out string? insertionText)
+    {
+        AssistSuggestion? selected = GetSelectedSuggestion();
+        if (selected == null || _ignoreCurrentSubmission || _isAltScreenActive)
+        {
+            insertionText = null;
+            return false;
+        }
+
+        insertionText = selected.InsertText;
+        return true;
+    }
+
+    public bool TryAcceptSelection(out string? insertionText)
+    {
+        if (!TryGetInsertionText(out insertionText) || string.IsNullOrWhiteSpace(insertionText))
+        {
+            return false;
+        }
+
+        ViewModel.QueryText = insertionText;
+        ViewModel.ModeLabel = "Suggest";
+        Dismiss();
+        return true;
+    }
+
+    public async Task HandleCommandFinishedAsync(int? exitCode)
+    {
+        string? pendingEntryId = _pendingHistoryEntryId;
+        _pendingHistoryEntryId = null;
+        if (string.IsNullOrWhiteSpace(pendingEntryId))
+        {
+            return;
+        }
+
+        try
+        {
+            await HistoryStore.TryUpdateExitCodeAsync(pendingEntryId, exitCode);
+        }
+        catch
+        {
+            // History metadata enrichment is best-effort only.
+        }
+    }
+
+    public async Task<bool> TogglePinSelectionAsync()
+    {
+        if (SnippetStore == null)
+        {
+            return false;
+        }
+
+        AssistSuggestion? selected = GetSelectedSuggestion();
+        if (selected == null)
+        {
+            return false;
+        }
+
+        try
+        {
+            IReadOnlyList<CommandSnippet> snippets = await SnippetStore.GetAllAsync();
+            CommandSnippet? existing = snippets.FirstOrDefault(x => x.Id == selected.Id) ??
+                                       snippets.FirstOrDefault(x =>
+                                           string.Equals(x.CommandText, selected.InsertText, StringComparison.OrdinalIgnoreCase) &&
+                                           string.Equals(x.ShellKind ?? string.Empty, _shellKind ?? string.Empty, StringComparison.OrdinalIgnoreCase));
+
+            if (existing != null)
+            {
+                await SnippetStore.UpsertAsync(existing with
+                {
+                    IsPinned = !existing.IsPinned,
+                    LastUsedAt = DateTimeOffset.UtcNow
+                });
+            }
+            else
+            {
+                var snippet = new CommandSnippet(
+                    Id: Guid.NewGuid().ToString("N"),
+                    Name: selected.DisplayText,
+                    CommandText: selected.InsertText,
+                    Description: null,
+                    ShellKind: _shellKind,
+                    WorkingDirectory: _workingDirectory,
+                    IsPinned: true,
+                    CreatedAt: DateTimeOffset.UtcNow,
+                    LastUsedAt: selected.LastUsedAt);
+
+                await SnippetStore.UpsertAsync(snippet);
+            }
+
+            QueueRefreshSuggestions();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     public void HandleAltScreenChanged(bool isAltScreenActive)
@@ -174,6 +331,11 @@ public sealed class CommandAssistController
             CancelPendingRefreshes();
             ViewModel.IsVisible = false;
             ViewModel.TopSuggestionText = string.Empty;
+            ViewModel.SelectedIndex = -1;
+            ViewModel.SelectedBadgesText = string.Empty;
+            ViewModel.SelectedMetadataText = string.Empty;
+            ViewModel.HasSuggestions = false;
+            ViewModel.Suggestions.Clear();
             _suggestions.Clear();
         }
     }
@@ -182,7 +344,7 @@ public sealed class CommandAssistController
     {
         int refreshVersion = Interlocked.Increment(ref _refreshVersion);
         string query = ViewModel.QueryText;
-        var context = new CommandAssistQueryContext(query, _workingDirectory, _shellKind);
+        var context = new CommandAssistQueryContext(query, _workingDirectory, _shellKind, _profileId);
         _ = RefreshSuggestionsAsync(query, context, refreshVersion);
     }
 
@@ -193,8 +355,11 @@ public sealed class CommandAssistController
             IReadOnlyList<CommandHistoryEntry> history = string.IsNullOrWhiteSpace(query)
                 ? await HistoryStore.GetRecentAsync(5)
                 : await HistoryStore.SearchAsync(query, 5);
+            IReadOnlyList<CommandSnippet> snippets = SnippetStore == null
+                ? Array.Empty<CommandSnippet>()
+                : await SnippetStore.GetAllAsync();
 
-            IReadOnlyList<AssistSuggestion> suggestions = SuggestionEngine.GetSuggestions(history, context, 5);
+            IReadOnlyList<AssistSuggestion> suggestions = SuggestionEngine.GetSuggestions(history, snippets, context, 5);
             _dispatch(() =>
             {
                 if (refreshVersion != _refreshVersion)
@@ -204,7 +369,8 @@ public sealed class CommandAssistController
 
                 _suggestions.Clear();
                 _suggestions.AddRange(suggestions);
-                ViewModel.TopSuggestionText = suggestions.FirstOrDefault()?.DisplayText ?? string.Empty;
+                ViewModel.SelectedIndex = suggestions.Count > 0 ? 0 : -1;
+                SyncSuggestionViewModel();
             });
         }
         catch
@@ -218,6 +384,11 @@ public sealed class CommandAssistController
 
                 _suggestions.Clear();
                 ViewModel.TopSuggestionText = string.Empty;
+                ViewModel.SelectedIndex = -1;
+                ViewModel.SelectedBadgesText = string.Empty;
+                ViewModel.SelectedMetadataText = string.Empty;
+                ViewModel.HasSuggestions = false;
+                ViewModel.Suggestions.Clear();
             });
         }
     }
@@ -233,7 +404,74 @@ public sealed class CommandAssistController
         _ignoreCurrentSubmission = false;
         ViewModel.QueryText = string.Empty;
         ViewModel.TopSuggestionText = string.Empty;
+        ViewModel.SelectedIndex = -1;
+        ViewModel.SelectedBadgesText = string.Empty;
+        ViewModel.SelectedMetadataText = string.Empty;
+        ViewModel.HasSuggestions = false;
+        ViewModel.Suggestions.Clear();
         ViewModel.IsVisible = false;
         _suggestions.Clear();
+    }
+
+    private bool SetSelectedIndex(int index)
+    {
+        if (index < 0 || index >= _suggestions.Count)
+        {
+            return false;
+        }
+
+        ViewModel.SelectedIndex = index;
+        SyncSuggestionViewModel();
+        return true;
+    }
+
+    private AssistSuggestion? GetSelectedSuggestion()
+    {
+        return ViewModel.SelectedIndex >= 0 && ViewModel.SelectedIndex < _suggestions.Count
+            ? _suggestions[ViewModel.SelectedIndex]
+            : null;
+    }
+
+    private void SyncSuggestionViewModel()
+    {
+        AssistSuggestion? selected = GetSelectedSuggestion();
+        ViewModel.TopSuggestionText = selected?.DisplayText ?? string.Empty;
+        ViewModel.SelectedBadgesText = selected == null ? string.Empty : string.Join("  ", selected.Badges);
+        ViewModel.SelectedMetadataText = selected == null ? string.Empty : BuildMetadataText(selected);
+        ViewModel.HasSuggestions = _suggestions.Count > 0;
+        ViewModel.Suggestions.Clear();
+
+        for (int i = 0; i < _suggestions.Count; i++)
+        {
+            AssistSuggestion suggestion = _suggestions[i];
+            ViewModel.Suggestions.Add(new CommandAssistSuggestionItemViewModel(
+                SelectionGlyph: i == ViewModel.SelectedIndex ? ">" : " ",
+                DisplayText: suggestion.DisplayText,
+                BadgesText: string.Join("  ", suggestion.Badges),
+                MetadataText: BuildMetadataText(suggestion),
+                IsSelected: i == ViewModel.SelectedIndex,
+                Type: suggestion.Type));
+        }
+    }
+
+    private static string BuildMetadataText(AssistSuggestion suggestion)
+    {
+        List<string> parts = new();
+        if (!string.IsNullOrWhiteSpace(suggestion.WorkingDirectory))
+        {
+            parts.Add(suggestion.WorkingDirectory!);
+        }
+
+        if (suggestion.LastUsedAt.HasValue)
+        {
+            parts.Add($"Used {suggestion.LastUsedAt.Value:yyyy-MM-dd HH:mm}");
+        }
+
+        if (suggestion.ExitCode.HasValue)
+        {
+            parts.Add(suggestion.ExitCode.Value == 0 ? "Exit 0" : $"Exit {suggestion.ExitCode.Value}");
+        }
+
+        return string.Join("  |  ", parts);
     }
 }

--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistInfrastructure.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistInfrastructure.cs
@@ -9,9 +9,10 @@ public static class CommandAssistInfrastructure
 {
     private static readonly object Sync = new();
     private static IHistoryStore? _historyStore;
+    private static ISnippetStore? _snippetStore;
     private static int _historyMaxEntries = -1;
     private static readonly ISecretsFilter SecretsFilterInstance = new SecretsFilter();
-    private static readonly ISuggestionEngine SuggestionEngineInstance = new HistorySuggestionEngine();
+    private static readonly ISuggestionEngine SuggestionEngineInstance = new CommandAssistSuggestionEngine();
 
     public static IHistoryStore GetHistoryStore(TerminalSettings settings)
     {
@@ -26,6 +27,15 @@ public static class CommandAssistInfrastructure
             }
 
             return _historyStore;
+        }
+    }
+
+    public static ISnippetStore GetSnippetStore()
+    {
+        lock (Sync)
+        {
+            _snippetStore ??= new JsonSnippetStore(AppPaths.CommandSnippetsFilePath);
+            return _snippetStore;
         }
     }
 

--- a/src/NovaTerminal.App/CommandAssist/Domain/CommandAssistSuggestionEngine.cs
+++ b/src/NovaTerminal.App/CommandAssist/Domain/CommandAssistSuggestionEngine.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NovaTerminal.CommandAssist.Models;
+
+namespace NovaTerminal.CommandAssist.Domain;
+
+public sealed class CommandAssistSuggestionEngine : ISuggestionEngine
+{
+    public IReadOnlyList<AssistSuggestion> GetSuggestions(
+        IReadOnlyList<CommandHistoryEntry> historyEntries,
+        CommandAssistQueryContext context,
+        int maxResults)
+    {
+        return GetSuggestions(historyEntries, Array.Empty<CommandSnippet>(), context, maxResults);
+    }
+
+    public IReadOnlyList<AssistSuggestion> GetSuggestions(
+        IReadOnlyList<CommandHistoryEntry> historyEntries,
+        IReadOnlyList<CommandSnippet> snippets,
+        CommandAssistQueryContext context,
+        int maxResults)
+    {
+        if (maxResults <= 0)
+        {
+            return Array.Empty<AssistSuggestion>();
+        }
+
+        string query = context.Input?.Trim() ?? string.Empty;
+        List<AssistSuggestion> results = new();
+        results.AddRange(BuildHistorySuggestions(historyEntries, context, query));
+        results.AddRange(BuildSnippetSuggestions(snippets, context, query));
+
+        return results
+            .OrderByDescending(x => x.Score)
+            .ThenByDescending(x => x.LastUsedAt ?? DateTimeOffset.MinValue)
+            .ThenBy(x => x.DisplayText, StringComparer.OrdinalIgnoreCase)
+            .Take(maxResults)
+            .ToList();
+    }
+
+    private static IEnumerable<AssistSuggestion> BuildHistorySuggestions(
+        IReadOnlyList<CommandHistoryEntry> historyEntries,
+        CommandAssistQueryContext context,
+        string query)
+    {
+        return historyEntries
+            .GroupBy(x => x.CommandText, StringComparer.OrdinalIgnoreCase)
+            .Select(group =>
+            {
+                CommandHistoryEntry latest = group.OrderByDescending(x => x.ExecutedAt).First();
+                int frequency = group.Count();
+                double score = ScoreText(
+                    latest.CommandText,
+                    query,
+                    latest.WorkingDirectory,
+                    latest.ShellKind,
+                    latest.ProfileId,
+                    latest.ExitCode,
+                    context,
+                    frequency,
+                    isPinned: false);
+
+                return new
+                {
+                    Latest = latest,
+                    Frequency = frequency,
+                    Score = score
+                };
+            })
+            .Where(x => x.Score > 0)
+            .Select(x => new AssistSuggestion(
+                Id: x.Latest.Id,
+                Type: AssistSuggestionType.History,
+                DisplayText: x.Latest.CommandText,
+                InsertText: x.Latest.CommandText,
+                Badges: BuildHistoryBadges(x.Latest, context, x.Frequency),
+                Score: x.Score,
+                WorkingDirectory: x.Latest.WorkingDirectory,
+                LastUsedAt: x.Latest.ExecutedAt,
+                ExitCode: x.Latest.ExitCode,
+                CanExecuteDirectly: false));
+    }
+
+    private static IEnumerable<AssistSuggestion> BuildSnippetSuggestions(
+        IReadOnlyList<CommandSnippet> snippets,
+        CommandAssistQueryContext context,
+        string query)
+    {
+        return snippets
+            .Select(snippet =>
+            {
+                double score = ScoreText(
+                    snippet.CommandText,
+                    query,
+                    snippet.WorkingDirectory,
+                    snippet.ShellKind,
+                    profileId: null,
+                    exitCode: 0,
+                    context,
+                    frequency: 1,
+                    isPinned: snippet.IsPinned);
+
+                // Snippets should remain discoverable even with empty query.
+                if (string.IsNullOrWhiteSpace(query))
+                {
+                    score += 8;
+                }
+
+                return new
+                {
+                    Snippet = snippet,
+                    Score = score
+                };
+            })
+            .Where(x => x.Score > 0)
+            .Select(x => new AssistSuggestion(
+                Id: x.Snippet.Id,
+                Type: AssistSuggestionType.Snippet,
+                DisplayText: x.Snippet.Name,
+                InsertText: x.Snippet.CommandText,
+                Badges: BuildSnippetBadges(x.Snippet, context),
+                Score: x.Score,
+                WorkingDirectory: x.Snippet.WorkingDirectory,
+                LastUsedAt: x.Snippet.LastUsedAt ?? x.Snippet.CreatedAt,
+                ExitCode: null,
+                CanExecuteDirectly: false));
+    }
+
+    private static double ScoreText(
+        string text,
+        string query,
+        string? workingDirectory,
+        string? shellKind,
+        string? profileId,
+        int? exitCode,
+        CommandAssistQueryContext context,
+        int frequency,
+        bool isPinned)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return 0;
+        }
+
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return 1 + Math.Min(frequency, 5) + (isPinned ? 20 : 0);
+        }
+
+        string normalizedText = text.Trim();
+        string normalizedQuery = query.Trim();
+        string lowerText = normalizedText.ToLowerInvariant();
+        string lowerQuery = normalizedQuery.ToLowerInvariant();
+
+        double prefixScore = lowerText.StartsWith(lowerQuery, StringComparison.Ordinal) ? 120 : 0;
+        double tokenPrefixScore = lowerText
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Any(token => token.StartsWith(lowerQuery, StringComparison.Ordinal))
+            ? 70
+            : 0;
+        double containsScore = lowerText.Contains(lowerQuery, StringComparison.Ordinal) ? 25 : 0;
+        double subsequenceScore = IsSubsequence(lowerQuery, lowerText) ? 12 : 0;
+        double frequencyScore = frequency * 4;
+        double cwdScore = Matches(context.WorkingDirectory, workingDirectory) ? 12 : 0;
+        double shellScore = Matches(context.ShellKind, shellKind) ? 4 : 0;
+        double profileScore = Matches(context.ProfileId, profileId) ? 20 : 0;
+        double successScore = exitCode == 0 ? 18 : exitCode.HasValue ? -8 : 0;
+        double pinScore = isPinned ? 40 : 0;
+
+        return prefixScore + tokenPrefixScore + containsScore + subsequenceScore + frequencyScore + cwdScore + shellScore + profileScore + successScore + pinScore;
+    }
+
+    private static IReadOnlyList<string> BuildHistoryBadges(CommandHistoryEntry entry, CommandAssistQueryContext context, int frequency)
+    {
+        List<string> badges = new();
+        if (frequency > 1)
+        {
+            badges.Add("Frequent");
+        }
+
+        if (Matches(context.WorkingDirectory, entry.WorkingDirectory))
+        {
+            badges.Add("Same cwd");
+        }
+
+        if (entry.ExitCode == 0)
+        {
+            badges.Add("Worked");
+        }
+
+        return badges;
+    }
+
+    private static IReadOnlyList<string> BuildSnippetBadges(CommandSnippet snippet, CommandAssistQueryContext context)
+    {
+        List<string> badges = new() { "Snippet" };
+        if (snippet.IsPinned)
+        {
+            badges.Add("Pinned");
+        }
+
+        if (Matches(context.WorkingDirectory, snippet.WorkingDirectory))
+        {
+            badges.Add("Same cwd");
+        }
+
+        return badges;
+    }
+
+    private static bool Matches(string? left, string? right)
+    {
+        return !string.IsNullOrWhiteSpace(left) &&
+               !string.IsNullOrWhiteSpace(right) &&
+               string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsSubsequence(string query, string text)
+    {
+        int index = 0;
+        for (int i = 0; i < text.Length && index < query.Length; i++)
+        {
+            if (text[i] == query[index])
+            {
+                index++;
+            }
+        }
+
+        return index == query.Length;
+    }
+}

--- a/src/NovaTerminal.App/CommandAssist/Domain/CommandAssistSuggestionEngine.cs
+++ b/src/NovaTerminal.App/CommandAssist/Domain/CommandAssistSuggestionEngine.cs
@@ -161,6 +161,12 @@ public sealed class CommandAssistSuggestionEngine : ISuggestionEngine
             : 0;
         double containsScore = lowerText.Contains(lowerQuery, StringComparison.Ordinal) ? 25 : 0;
         double subsequenceScore = IsSubsequence(lowerQuery, lowerText) ? 12 : 0;
+        double textMatchScore = prefixScore + tokenPrefixScore + containsScore + subsequenceScore;
+        if (textMatchScore <= 0)
+        {
+            return 0;
+        }
+
         double frequencyScore = frequency * 4;
         double cwdScore = Matches(context.WorkingDirectory, workingDirectory) ? 12 : 0;
         double shellScore = Matches(context.ShellKind, shellKind) ? 4 : 0;
@@ -168,7 +174,7 @@ public sealed class CommandAssistSuggestionEngine : ISuggestionEngine
         double successScore = exitCode == 0 ? 18 : exitCode.HasValue ? -8 : 0;
         double pinScore = isPinned ? 40 : 0;
 
-        return prefixScore + tokenPrefixScore + containsScore + subsequenceScore + frequencyScore + cwdScore + shellScore + profileScore + successScore + pinScore;
+        return textMatchScore + frequencyScore + cwdScore + shellScore + profileScore + successScore + pinScore;
     }
 
     private static IReadOnlyList<string> BuildHistoryBadges(CommandHistoryEntry entry, CommandAssistQueryContext context, int frequency)

--- a/src/NovaTerminal.App/CommandAssist/Domain/IHistoryStore.cs
+++ b/src/NovaTerminal.App/CommandAssist/Domain/IHistoryStore.cs
@@ -10,5 +10,6 @@ public interface IHistoryStore
     Task AppendAsync(CommandHistoryEntry entry, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<CommandHistoryEntry>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<CommandHistoryEntry>> GetRecentAsync(int maxResults, CancellationToken cancellationToken = default);
+    Task<bool> TryUpdateExitCodeAsync(string entryId, int? exitCode, CancellationToken cancellationToken = default);
     Task ClearAsync(CancellationToken cancellationToken = default);
 }

--- a/src/NovaTerminal.App/CommandAssist/Domain/ISnippetStore.cs
+++ b/src/NovaTerminal.App/CommandAssist/Domain/ISnippetStore.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NovaTerminal.CommandAssist.Models;
+
+namespace NovaTerminal.CommandAssist.Domain;
+
+public interface ISnippetStore
+{
+    Task<IReadOnlyList<CommandSnippet>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task UpsertAsync(CommandSnippet snippet, CancellationToken cancellationToken = default);
+    Task RemoveAsync(string snippetId, CancellationToken cancellationToken = default);
+}

--- a/src/NovaTerminal.App/CommandAssist/Domain/ISuggestionEngine.cs
+++ b/src/NovaTerminal.App/CommandAssist/Domain/ISuggestionEngine.cs
@@ -9,4 +9,13 @@ public interface ISuggestionEngine
         IReadOnlyList<CommandHistoryEntry> entries,
         CommandAssistQueryContext context,
         int maxResults);
+
+    IReadOnlyList<AssistSuggestion> GetSuggestions(
+        IReadOnlyList<CommandHistoryEntry> entries,
+        IReadOnlyList<CommandSnippet> snippets,
+        CommandAssistQueryContext context,
+        int maxResults)
+    {
+        return GetSuggestions(entries, context, maxResults);
+    }
 }

--- a/src/NovaTerminal.App/CommandAssist/Models/AssistSuggestionType.cs
+++ b/src/NovaTerminal.App/CommandAssist/Models/AssistSuggestionType.cs
@@ -2,5 +2,6 @@ namespace NovaTerminal.CommandAssist.Models;
 
 public enum AssistSuggestionType
 {
-    History
+    History,
+    Snippet
 }

--- a/src/NovaTerminal.App/CommandAssist/Models/CommandAssistQueryContext.cs
+++ b/src/NovaTerminal.App/CommandAssist/Models/CommandAssistQueryContext.cs
@@ -3,4 +3,5 @@ namespace NovaTerminal.CommandAssist.Models;
 public sealed record CommandAssistQueryContext(
     string Input,
     string? WorkingDirectory,
-    string? ShellKind);
+    string? ShellKind,
+    string? ProfileId);

--- a/src/NovaTerminal.App/CommandAssist/Models/CommandSnippet.cs
+++ b/src/NovaTerminal.App/CommandAssist/Models/CommandSnippet.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace NovaTerminal.CommandAssist.Models;
+
+public sealed record CommandSnippet(
+    string Id,
+    string Name,
+    string CommandText,
+    string? Description,
+    string? ShellKind,
+    string? WorkingDirectory,
+    bool IsPinned,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset? LastUsedAt);

--- a/src/NovaTerminal.App/CommandAssist/Storage/JsonHistoryStore.cs
+++ b/src/NovaTerminal.App/CommandAssist/Storage/JsonHistoryStore.cs
@@ -101,6 +101,28 @@ public sealed class JsonHistoryStore : IHistoryStore
         }
     }
 
+    public async Task<bool> TryUpdateExitCodeAsync(string entryId, int? exitCode, CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            List<CommandHistoryEntry> entries = await LoadEntriesUnsafeAsync(cancellationToken);
+            int index = entries.FindIndex(x => x.Id == entryId);
+            if (index < 0)
+            {
+                return false;
+            }
+
+            entries[index] = entries[index] with { ExitCode = exitCode };
+            await SaveEntriesUnsafeAsync(entries, cancellationToken);
+            return true;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
     private async Task<List<CommandHistoryEntry>> LoadEntriesUnsafeAsync(CancellationToken cancellationToken)
     {
         if (!File.Exists(_filePath))

--- a/src/NovaTerminal.App/CommandAssist/Storage/JsonSnippetStore.cs
+++ b/src/NovaTerminal.App/CommandAssist/Storage/JsonSnippetStore.cs
@@ -1,0 +1,114 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using NovaTerminal.CommandAssist.Domain;
+using NovaTerminal.CommandAssist.Models;
+using NovaTerminal.Core;
+
+namespace NovaTerminal.CommandAssist.Storage;
+
+public sealed class JsonSnippetStore : ISnippetStore
+{
+    private readonly string _filePath;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public JsonSnippetStore(string filePath)
+    {
+        _filePath = filePath;
+    }
+
+    public async Task<IReadOnlyList<CommandSnippet>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            return await LoadSnippetsUnsafeAsync(cancellationToken);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task UpsertAsync(CommandSnippet snippet, CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            List<CommandSnippet> snippets = await LoadSnippetsUnsafeAsync(cancellationToken);
+            int existingIndex = snippets.FindIndex(x => x.Id == snippet.Id);
+            if (existingIndex >= 0)
+            {
+                snippets[existingIndex] = snippet;
+            }
+            else
+            {
+                snippets.Add(snippet);
+            }
+
+            snippets = snippets
+                .OrderByDescending(x => x.IsPinned)
+                .ThenBy(x => x.Name, System.StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            await SaveSnippetsUnsafeAsync(snippets, cancellationToken);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task RemoveAsync(string snippetId, CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            List<CommandSnippet> snippets = await LoadSnippetsUnsafeAsync(cancellationToken);
+            snippets.RemoveAll(x => x.Id == snippetId);
+            await SaveSnippetsUnsafeAsync(snippets, cancellationToken);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private async Task<List<CommandSnippet>> LoadSnippetsUnsafeAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_filePath))
+        {
+            return new List<CommandSnippet>();
+        }
+
+        try
+        {
+            await using FileStream stream = File.OpenRead(_filePath);
+            List<CommandSnippet>? snippets = await JsonSerializer.DeserializeAsync(
+                stream,
+                AppJsonContext.Default.ListCommandSnippet,
+                cancellationToken);
+
+            return snippets ?? new List<CommandSnippet>();
+        }
+        catch
+        {
+            return new List<CommandSnippet>();
+        }
+    }
+
+    private async Task SaveSnippetsUnsafeAsync(List<CommandSnippet> snippets, CancellationToken cancellationToken)
+    {
+        string? directory = Path.GetDirectoryName(_filePath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        await using FileStream stream = File.Create(_filePath);
+        await JsonSerializer.SerializeAsync(stream, snippets, AppJsonContext.Default.ListCommandSnippet, cancellationToken);
+    }
+}

--- a/src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistBarViewModel.cs
+++ b/src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistBarViewModel.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Collections.ObjectModel;
 using System.Runtime.CompilerServices;
 
 namespace NovaTerminal.CommandAssist.ViewModels;
@@ -9,6 +10,12 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
     private string _modeLabel = "Suggest";
     private string _queryText = string.Empty;
     private string _topSuggestionText = string.Empty;
+    private int _selectedIndex = -1;
+    private string _selectedBadgesText = string.Empty;
+    private string _selectedMetadataText = string.Empty;
+    private bool _hasSuggestions;
+
+    public ObservableCollection<CommandAssistSuggestionItemViewModel> Suggestions { get; } = new();
 
     public bool IsVisible
     {
@@ -66,6 +73,66 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
             }
 
             _topSuggestionText = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public int SelectedIndex
+    {
+        get => _selectedIndex;
+        set
+        {
+            if (_selectedIndex == value)
+            {
+                return;
+            }
+
+            _selectedIndex = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public string SelectedBadgesText
+    {
+        get => _selectedBadgesText;
+        set
+        {
+            if (_selectedBadgesText == value)
+            {
+                return;
+            }
+
+            _selectedBadgesText = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public string SelectedMetadataText
+    {
+        get => _selectedMetadataText;
+        set
+        {
+            if (_selectedMetadataText == value)
+            {
+                return;
+            }
+
+            _selectedMetadataText = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public bool HasSuggestions
+    {
+        get => _hasSuggestions;
+        set
+        {
+            if (_hasSuggestions == value)
+            {
+                return;
+            }
+
+            _hasSuggestions = value;
             OnPropertyChanged();
         }
     }

--- a/src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistSuggestionItemViewModel.cs
+++ b/src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistSuggestionItemViewModel.cs
@@ -1,0 +1,11 @@
+using NovaTerminal.CommandAssist.Models;
+
+namespace NovaTerminal.CommandAssist.ViewModels;
+
+public sealed record CommandAssistSuggestionItemViewModel(
+    string SelectionGlyph,
+    string DisplayText,
+    string BadgesText,
+    string MetadataText,
+    bool IsSelected,
+    AssistSuggestionType Type);

--- a/src/NovaTerminal.App/CommandAssist/Views/CommandAssistBarView.axaml
+++ b/src/NovaTerminal.App/CommandAssist/Views/CommandAssistBarView.axaml
@@ -6,22 +6,91 @@
     <Border Background="#CC202020"
             BorderBrush="#404040"
             BorderThickness="0,1,0,0"
-            Padding="10,6">
-        <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="12">
-            <TextBlock Text="{Binding ModeLabel}"
-                       Foreground="#8EC5FF"
-                       FontWeight="SemiBold"
-                       VerticalAlignment="Center"/>
-            <TextBlock Grid.Column="1"
-                       Text="{Binding TopSuggestionText}"
-                       Foreground="White"
-                       TextTrimming="CharacterEllipsis"
-                       VerticalAlignment="Center"/>
-            <TextBlock Grid.Column="2"
-                       Text="Ctrl+R history | Ctrl+Space toggle | Esc close"
-                       Foreground="#A0A0A0"
-                       FontSize="11"
-                       VerticalAlignment="Center"/>
+            Padding="10,8">
+        <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="2*,*" RowSpacing="8" ColumnSpacing="16">
+            <Grid Grid.Row="0" Grid.ColumnSpan="2" ColumnDefinitions="Auto,Auto,*,Auto" ColumnSpacing="12">
+                <TextBlock Text="{Binding ModeLabel}"
+                           Foreground="#8EC5FF"
+                           FontWeight="SemiBold"
+                           VerticalAlignment="Center"/>
+                <TextBlock Grid.Column="1"
+                           Text="{Binding QueryText}"
+                           Foreground="White"
+                           FontFamily="Consolas"
+                           VerticalAlignment="Center"/>
+                <TextBlock Grid.Column="2"
+                           Text="{Binding TopSuggestionText}"
+                           Foreground="#D7E8FF"
+                           TextTrimming="CharacterEllipsis"
+                           VerticalAlignment="Center"/>
+                <TextBlock Grid.Column="3"
+                           Text="Up/Down select | Tab insert | Ctrl+Shift+P pin | Ctrl+R history | Esc close"
+                           Foreground="#A0A0A0"
+                           FontSize="11"
+                           VerticalAlignment="Center"/>
+            </Grid>
+
+            <Border Grid.Row="1"
+                    Grid.Column="0"
+                    Background="#22101010"
+                    CornerRadius="4"
+                    Padding="8"
+                    MinHeight="70">
+                <ItemsControl ItemsSource="{Binding Suggestions}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Grid ColumnDefinitions="Auto,*,Auto" Margin="0,2">
+                                <TextBlock Text="{Binding SelectionGlyph}"
+                                           Foreground="#8EC5FF"
+                                           Width="12"
+                                           VerticalAlignment="Top"/>
+                                <StackPanel Grid.Column="1" Spacing="1">
+                                    <TextBlock Text="{Binding DisplayText}"
+                                               Foreground="White"
+                                               FontFamily="Consolas"
+                                               TextTrimming="CharacterEllipsis"/>
+                                    <TextBlock Text="{Binding MetadataText}"
+                                               Foreground="#9CA3AF"
+                                               FontSize="11"
+                                               TextTrimming="CharacterEllipsis"/>
+                                </StackPanel>
+                                <TextBlock Grid.Column="2"
+                                           Text="{Binding BadgesText}"
+                                           Foreground="#C8E1FF"
+                                           FontSize="11"
+                                           HorizontalAlignment="Right"
+                                           Margin="8,0,0,0"
+                                           TextWrapping="Wrap"/>
+                            </Grid>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </Border>
+
+            <Border Grid.Row="1"
+                    Grid.Column="1"
+                    Background="#1C151515"
+                    CornerRadius="4"
+                    Padding="8"
+                    MinHeight="70">
+                <StackPanel Spacing="4">
+                    <TextBlock Text="Selected"
+                               Foreground="#8EC5FF"
+                               FontWeight="SemiBold"/>
+                    <TextBlock Text="{Binding TopSuggestionText}"
+                               Foreground="White"
+                               FontFamily="Consolas"
+                               TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding SelectedBadgesText}"
+                               Foreground="#C8E1FF"
+                               FontSize="11"
+                               TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding SelectedMetadataText}"
+                               Foreground="#9CA3AF"
+                               FontSize="11"
+                               TextWrapping="Wrap"/>
+                </StackPanel>
+            </Border>
         </Grid>
     </Border>
 </UserControl>

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -200,11 +200,41 @@ namespace NovaTerminal.Controls
             };
             TermView.KeyDown += (_, e) =>
             {
-                if (e.Key == Key.Escape && _commandAssistController?.ViewModel.IsVisible == true)
+                if (_commandAssistController?.ViewModel.IsVisible == true)
                 {
-                    _commandAssistController.Dismiss();
-                    e.Handled = true;
-                    return;
+                    bool isCtrl = (e.KeyModifiers & KeyModifiers.Control) != 0;
+                    bool isShift = (e.KeyModifiers & KeyModifiers.Shift) != 0;
+
+                    if (e.Key == Key.Escape && _commandAssistController.HandleEscape())
+                    {
+                        e.Handled = true;
+                        return;
+                    }
+
+                    if (e.Key == Key.Down && _commandAssistController.MoveSelectionDown())
+                    {
+                        e.Handled = true;
+                        return;
+                    }
+
+                    if (e.Key == Key.Up && _commandAssistController.MoveSelectionUp())
+                    {
+                        e.Handled = true;
+                        return;
+                    }
+
+                    if (e.Key == Key.Tab && TryInsertSelectedCommandAssistSuggestion())
+                    {
+                        e.Handled = true;
+                        return;
+                    }
+
+                    if (isCtrl && isShift && e.Key == Key.P)
+                    {
+                        _ = _commandAssistController.TogglePinSelectionAsync();
+                        e.Handled = true;
+                        return;
+                    }
                 }
 
                 if (e.Key != Key.LeftShift &&
@@ -360,6 +390,7 @@ namespace NovaTerminal.Controls
                 CommandAssistInfrastructure.GetHistoryStore(_settings),
                 CommandAssistInfrastructure.GetSecretsFilter(),
                 CommandAssistInfrastructure.GetSuggestionEngine(),
+                CommandAssistInfrastructure.GetSnippetStore(),
                 action => Dispatcher.UIThread.Post(action));
 
             if (CommandAssistBar != null)
@@ -417,6 +448,28 @@ namespace NovaTerminal.Controls
                 sessionId: Session?.Id.ToString(),
                 hostId: Profile?.Type == ConnectionType.SSH ? Profile.SshHost : null,
                 isRemote: Profile?.Type == ConnectionType.SSH);
+        }
+
+        private bool TryInsertSelectedCommandAssistSuggestion()
+        {
+            if (_commandAssistController == null || Session == null)
+            {
+                return false;
+            }
+
+            string existingQuery = _commandAssistController.ViewModel.QueryText;
+            if (!_commandAssistController.TryAcceptSelection(out string? insertionText) || insertionText == null)
+            {
+                return false;
+            }
+
+            if (!string.IsNullOrEmpty(existingQuery))
+            {
+                Session.SendInput(new string('\x7f', existingQuery.Length));
+            }
+
+            Session.SendInput(insertionText);
+            return true;
         }
 
         private static string DetermineShellKind(string? shellCommand)
@@ -500,6 +553,7 @@ namespace NovaTerminal.Controls
                     }
 
                     CommandFinished?.Invoke(this, exitCode);
+                    _ = _commandAssistController?.HandleCommandFinishedAsync(exitCode);
                 });
             };
 

--- a/src/NovaTerminal.App/Core/AppJsonContext.cs
+++ b/src/NovaTerminal.App/Core/AppJsonContext.cs
@@ -15,6 +15,7 @@ namespace NovaTerminal.Core
     [JsonSerializable(typeof(List<TabTemplateRule>))]
     [JsonSerializable(typeof(List<ForwardingRule>))]
     [JsonSerializable(typeof(List<CommandHistoryEntry>))]
+    [JsonSerializable(typeof(List<CommandSnippet>))]
     [JsonSerializable(typeof(Dictionary<string, string>))]
     [JsonSerializable(typeof(WorkspacePolicyHooks))]
     [JsonSourceGenerationOptions(WriteIndented = true, Converters = new[] { typeof(JsonColorConverter), typeof(TermColorJsonConverter) })]

--- a/src/NovaTerminal.App/Core/AppPaths.cs
+++ b/src/NovaTerminal.App/Core/AppPaths.cs
@@ -34,6 +34,7 @@ namespace NovaTerminal.Core
         public static string RecordingsDirectory => Path.Combine(RootDirectory, "recordings");
         public static string CommandAssistDirectory => Path.Combine(RootDirectory, "command-assist");
         public static string CommandHistoryFilePath => Path.Combine(CommandAssistDirectory, "history.json");
+        public static string CommandSnippetsFilePath => Path.Combine(CommandAssistDirectory, "snippets.json");
 
         public static void EnsureInitialized()
         {

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
@@ -137,21 +137,162 @@ public sealed class CommandAssistControllerTests
         await historyStore.WaitForLastSearchAsync();
     }
 
-    private static CommandAssistController CreateController(IHistoryStore? historyStore = null)
+    [Fact]
+    public void MoveSelectionDown_WhenSuggestionsAreVisible_AdvancesSelectedSuggestion()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        historyStore.Seed(
+            CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")),
+            CreateEntry("git stash", DateTimeOffset.Parse("2026-03-01T09:59:00+00:00")));
+
+        var controller = CreateController(historyStore);
+        controller.OpenHistorySearch();
+        controller.HandleTextInput("git st");
+
+        bool moved = controller.MoveSelectionDown();
+
+        Assert.True(moved);
+        Assert.Equal(1, controller.ViewModel.SelectedIndex);
+    }
+
+    [Fact]
+    public void HandleEscape_WhenAssistIsVisible_DismissesAssist()
+    {
+        var controller = CreateController();
+        controller.ToggleAssist();
+
+        bool handled = controller.HandleEscape();
+
+        Assert.True(handled);
+        Assert.False(controller.ViewModel.IsVisible);
+    }
+
+    [Fact]
+    public async Task TryInsertSelection_WhenBufferIsSimpleReplacement_ReturnsSelectedCommandText()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        historyStore.Seed(
+            CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")),
+            CreateEntry("git stash", DateTimeOffset.Parse("2026-03-01T09:59:00+00:00")));
+
+        var controller = CreateController(historyStore);
+        controller.HandleTextInput("git st");
+        await historyStore.WaitForSearchSettledAsync();
+        controller.MoveSelectionDown();
+
+        bool inserted = controller.TryGetInsertionText(out string? insertionText);
+
+        Assert.True(inserted);
+        Assert.Equal("git stash", insertionText);
+    }
+
+    [Fact]
+    public async Task HandleCommandFinished_WhenPendingEntryExists_UpdatesHistoryExitCode()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        var controller = CreateController(historyStore);
+        controller.HandleTextInput("git status");
+
+        await controller.HandleEnterAsync();
+        await controller.HandleCommandFinishedAsync(23);
+
+        Assert.Single(historyStore.Entries);
+        Assert.Equal(23, historyStore.Entries[0].ExitCode);
+    }
+
+    [Fact]
+    public async Task HandleTextInput_WhenPinnedSnippetMatches_ShowsSnippetAsTopSuggestion()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        historyStore.Seed(CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")));
+        var snippetStore = new InMemorySnippetStore();
+        snippetStore.Seed(new CommandSnippet(
+            Id: "snippet-1",
+            Name: "Git Status",
+            CommandText: "git status",
+            Description: null,
+            ShellKind: "pwsh",
+            WorkingDirectory: @"C:\repo",
+            IsPinned: true,
+            CreatedAt: DateTimeOffset.Parse("2026-03-01T09:00:00+00:00"),
+            LastUsedAt: DateTimeOffset.Parse("2026-03-01T09:30:00+00:00")));
+
+        var controller = CreateController(historyStore, snippetStore, new CommandAssistSuggestionEngine());
+        controller.HandleTextInput("git st");
+
+        await snippetStore.WaitForReadAsync();
+
+        Assert.Equal("Git Status", controller.ViewModel.TopSuggestionText);
+        Assert.Equal(AssistSuggestionType.Snippet, controller.Suggestions[0].Type);
+    }
+
+    [Fact]
+    public async Task TogglePinSelectionAsync_WhenHistorySuggestionSelected_CreatesPinnedSnippet()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        historyStore.Seed(CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")));
+        var snippetStore = new InMemorySnippetStore();
+        var controller = CreateController(historyStore, snippetStore, new CommandAssistSuggestionEngine());
+        controller.HandleTextInput("git st");
+
+        bool toggled = await controller.TogglePinSelectionAsync();
+        IReadOnlyList<CommandSnippet> snippets = await snippetStore.GetAllAsync();
+
+        Assert.True(toggled);
+        Assert.Single(snippets);
+        Assert.True(snippets[0].IsPinned);
+        Assert.Equal("git status", snippets[0].CommandText);
+    }
+
+    [Fact]
+    public async Task TogglePinSelectionAsync_WhenPinnedSnippetSelected_UnpinsSnippet()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        historyStore.Seed(CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")));
+        var snippetStore = new InMemorySnippetStore();
+        snippetStore.Seed(new CommandSnippet(
+            Id: "snippet-1",
+            Name: "Git Status",
+            CommandText: "git status",
+            Description: null,
+            ShellKind: "pwsh",
+            WorkingDirectory: @"C:\repo",
+            IsPinned: true,
+            CreatedAt: DateTimeOffset.Parse("2026-03-01T09:00:00+00:00"),
+            LastUsedAt: DateTimeOffset.Parse("2026-03-01T09:30:00+00:00")));
+
+        var controller = CreateController(historyStore, snippetStore, new CommandAssistSuggestionEngine());
+        controller.HandleTextInput("git st");
+        await snippetStore.WaitForReadAsync();
+
+        bool toggled = await controller.TogglePinSelectionAsync();
+        IReadOnlyList<CommandSnippet> snippets = await snippetStore.GetAllAsync();
+
+        Assert.True(toggled);
+        Assert.Single(snippets);
+        Assert.False(snippets[0].IsPinned);
+    }
+
+    private static CommandAssistController CreateController(
+        IHistoryStore? historyStore = null,
+        ISnippetStore? snippetStore = null,
+        ISuggestionEngine? suggestionEngine = null)
     {
         historyStore ??= new InMemoryHistoryStore();
         var filter = new SecretsFilter();
-        var engine = new HistorySuggestionEngine();
+        var engine = suggestionEngine ?? new HistorySuggestionEngine();
 
-        return new CommandAssistController(historyStore, filter, engine);
+        return snippetStore == null
+            ? new CommandAssistController(historyStore, filter, engine)
+            : new CommandAssistController(historyStore, filter, engine, snippetStore);
     }
 
-    private static CommandHistoryEntry CreateEntry(string commandText)
+    private static CommandHistoryEntry CreateEntry(string commandText, DateTimeOffset? executedAt = null)
     {
         return new CommandHistoryEntry(
             Id: Guid.NewGuid().ToString("N"),
             CommandText: commandText,
-            ExecutedAt: DateTimeOffset.UtcNow,
+            ExecutedAt: executedAt ?? DateTimeOffset.UtcNow,
             ShellKind: "pwsh",
             WorkingDirectory: @"C:\repo",
             ProfileId: "profile-1",
@@ -198,10 +339,24 @@ public sealed class CommandAssistControllerTests
             return Task.FromResult(results);
         }
 
+        public Task<bool> TryUpdateExitCodeAsync(string entryId, int? exitCode, CancellationToken cancellationToken = default)
+        {
+            int index = _entries.FindIndex(x => x.Id == entryId);
+            if (index < 0)
+            {
+                return Task.FromResult(false);
+            }
+
+            _entries[index] = _entries[index] with { ExitCode = exitCode };
+            return Task.FromResult(true);
+        }
+
         public void Seed(params CommandHistoryEntry[] entries)
         {
             _entries.AddRange(entries);
         }
+
+        public Task WaitForSearchSettledAsync() => Task.Delay(50);
     }
 
     private sealed class DelayedHistoryStore : IHistoryStore
@@ -238,6 +393,9 @@ public sealed class CommandAssistControllerTests
                 cancellationToken);
         }
 
+        public Task<bool> TryUpdateExitCodeAsync(string entryId, int? exitCode, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+
         public Task WaitForLastSearchAsync() => _lastSearchTask;
     }
 
@@ -254,5 +412,48 @@ public sealed class CommandAssistControllerTests
 
         public Task<IReadOnlyList<CommandHistoryEntry>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<CommandHistoryEntry>>(Array.Empty<CommandHistoryEntry>());
+
+        public Task<bool> TryUpdateExitCodeAsync(string entryId, int? exitCode, CancellationToken cancellationToken = default)
+            => Task.FromException<bool>(new InvalidOperationException("simulated write failure"));
+    }
+
+    private sealed class InMemorySnippetStore : ISnippetStore
+    {
+        private readonly List<CommandSnippet> _snippets = new();
+        private Task _lastReadTask = Task.CompletedTask;
+
+        public Task<IReadOnlyList<CommandSnippet>> GetAllAsync(CancellationToken cancellationToken = default)
+        {
+            _lastReadTask = Task.CompletedTask;
+            return Task.FromResult<IReadOnlyList<CommandSnippet>>(_snippets.ToList());
+        }
+
+        public Task UpsertAsync(CommandSnippet snippet, CancellationToken cancellationToken = default)
+        {
+            int index = _snippets.FindIndex(x => x.Id == snippet.Id);
+            if (index >= 0)
+            {
+                _snippets[index] = snippet;
+            }
+            else
+            {
+                _snippets.Add(snippet);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveAsync(string snippetId, CancellationToken cancellationToken = default)
+        {
+            _snippets.RemoveAll(x => x.Id == snippetId);
+            return Task.CompletedTask;
+        }
+
+        public void Seed(params CommandSnippet[] snippets)
+        {
+            _snippets.AddRange(snippets);
+        }
+
+        public Task WaitForReadAsync() => _lastReadTask;
     }
 }

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistSuggestionEngineTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistSuggestionEngineTests.cs
@@ -74,6 +74,30 @@ public sealed class CommandAssistSuggestionEngineTests
         Assert.Equal("cargo tree", results[0].InsertText);
     }
 
+    [Fact]
+    public void GetSuggestions_UnrelatedNonEmptyQuery_DoesNotReturnPinnedSnippet()
+    {
+        var engine = new CommandAssistSuggestionEngine();
+        var context = new CommandAssistQueryContext(
+            Input: "kubectl",
+            WorkingDirectory: @"C:\repo",
+            ShellKind: "pwsh",
+            ProfileId: "profile-1");
+
+        var snippets = new[]
+        {
+            CreateSnippet("Git Status", "git status", isPinned: true)
+        };
+
+        IReadOnlyList<AssistSuggestion> results = engine.GetSuggestions(
+            Array.Empty<CommandHistoryEntry>(),
+            snippets,
+            context,
+            maxResults: 5);
+
+        Assert.Empty(results);
+    }
+
     private static CommandHistoryEntry CreateEntry(
         string commandText,
         string? profileId = "profile-1",

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistSuggestionEngineTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistSuggestionEngineTests.cs
@@ -1,0 +1,111 @@
+using NovaTerminal.CommandAssist.Domain;
+using NovaTerminal.CommandAssist.Models;
+
+namespace NovaTerminal.Tests.CommandAssist;
+
+public sealed class CommandAssistSuggestionEngineTests
+{
+    [Fact]
+    public void GetSuggestions_PinnedSnippetRanksAboveHistoryWithSimilarMatch()
+    {
+        var engine = new CommandAssistSuggestionEngine();
+        var context = new CommandAssistQueryContext(
+            Input: "git st",
+            WorkingDirectory: @"C:\repo",
+            ShellKind: "pwsh",
+            ProfileId: "profile-1");
+
+        var history = new[]
+        {
+            CreateEntry("git status", executedAt: DateTimeOffset.Parse("2026-03-01T10:00:00+00:00"))
+        };
+
+        var snippets = new[]
+        {
+            CreateSnippet("Git Status", "git status", isPinned: true)
+        };
+
+        IReadOnlyList<AssistSuggestion> results = engine.GetSuggestions(history, snippets, context, maxResults: 5);
+
+        Assert.Equal(AssistSuggestionType.Snippet, results[0].Type);
+        Assert.Contains("Pinned", results[0].Badges);
+    }
+
+    [Fact]
+    public void GetSuggestions_SuccessfulCommandBeatsFailedCommandWhenTextSignalsMatch()
+    {
+        var engine = new CommandAssistSuggestionEngine();
+        var context = new CommandAssistQueryContext(
+            Input: "dotnet t",
+            WorkingDirectory: @"C:\repo",
+            ShellKind: "pwsh",
+            ProfileId: "profile-1");
+
+        var history = new[]
+        {
+            CreateEntry("dotnet test", executedAt: DateTimeOffset.Parse("2026-03-01T10:00:00+00:00"), exitCode: 1),
+            CreateEntry("dotnet tool list", executedAt: DateTimeOffset.Parse("2026-03-01T09:59:00+00:00"), exitCode: 0)
+        };
+
+        IReadOnlyList<AssistSuggestion> results = engine.GetSuggestions(history, Array.Empty<CommandSnippet>(), context, maxResults: 5);
+
+        Assert.Equal("dotnet tool list", results[0].InsertText);
+        Assert.Contains("Worked", results[0].Badges);
+    }
+
+    [Fact]
+    public void GetSuggestions_SameProfileBoostBreaksOtherwiseEquivalentMatches()
+    {
+        var engine = new CommandAssistSuggestionEngine();
+        var context = new CommandAssistQueryContext(
+            Input: "cargo t",
+            WorkingDirectory: @"C:\repo",
+            ShellKind: "pwsh",
+            ProfileId: "profile-a");
+
+        var history = new[]
+        {
+            CreateEntry("cargo test", profileId: "profile-b", executedAt: DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")),
+            CreateEntry("cargo tree", profileId: "profile-a", executedAt: DateTimeOffset.Parse("2026-03-01T09:59:00+00:00"))
+        };
+
+        IReadOnlyList<AssistSuggestion> results = engine.GetSuggestions(history, Array.Empty<CommandSnippet>(), context, maxResults: 5);
+
+        Assert.Equal("cargo tree", results[0].InsertText);
+    }
+
+    private static CommandHistoryEntry CreateEntry(
+        string commandText,
+        string? profileId = "profile-1",
+        DateTimeOffset? executedAt = null,
+        int? exitCode = 0)
+    {
+        return new CommandHistoryEntry(
+            Id: Guid.NewGuid().ToString("N"),
+            CommandText: commandText,
+            ExecutedAt: executedAt ?? DateTimeOffset.Parse("2026-03-01T10:00:00+00:00"),
+            ShellKind: "pwsh",
+            WorkingDirectory: @"C:\repo",
+            ProfileId: profileId,
+            SessionId: "session-1",
+            HostId: null,
+            ExitCode: exitCode,
+            IsRemote: false,
+            IsRedacted: false,
+            Source: CommandCaptureSource.Heuristic);
+    }
+
+    private static CommandSnippet CreateSnippet(string name, string commandText, bool isPinned)
+    {
+        return new CommandSnippet(
+            Id: Guid.NewGuid().ToString("N"),
+            Name: name,
+            CommandText: commandText,
+            Description: null,
+            ShellKind: "pwsh",
+            WorkingDirectory: @"C:\repo",
+            IsPinned: isPinned,
+            CreatedAt: DateTimeOffset.Parse("2026-03-01T09:00:00+00:00"),
+            LastUsedAt: DateTimeOffset.Parse("2026-03-01T09:30:00+00:00"));
+    }
+}

--- a/tests/NovaTerminal.Tests/CommandAssist/HistorySuggestionEngineTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/HistorySuggestionEngineTests.cs
@@ -12,7 +12,8 @@ public sealed class HistorySuggestionEngineTests
         var context = new CommandAssistQueryContext(
             Input: "git sta",
             WorkingDirectory: @"C:\repo",
-            ShellKind: "pwsh");
+            ShellKind: "pwsh",
+            ProfileId: "profile-1");
 
         var entries = new[]
         {
@@ -32,7 +33,8 @@ public sealed class HistorySuggestionEngineTests
         var context = new CommandAssistQueryContext(
             Input: "dotnet t",
             WorkingDirectory: @"C:\repo",
-            ShellKind: "pwsh");
+            ShellKind: "pwsh",
+            ProfileId: "profile-1");
 
         var entries = new[]
         {
@@ -52,7 +54,8 @@ public sealed class HistorySuggestionEngineTests
         var context = new CommandAssistQueryContext(
             Input: "npm run",
             WorkingDirectory: @"C:\repo",
-            ShellKind: "pwsh");
+            ShellKind: "pwsh",
+            ProfileId: "profile-1");
 
         var entries = new[]
         {
@@ -73,7 +76,8 @@ public sealed class HistorySuggestionEngineTests
         var context = new CommandAssistQueryContext(
             Input: "cargo t",
             WorkingDirectory: @"C:\repo-a",
-            ShellKind: "pwsh");
+            ShellKind: "pwsh",
+            ProfileId: "profile-1");
 
         var entries = new[]
         {

--- a/tests/NovaTerminal.Tests/CommandAssist/JsonHistoryStoreTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/JsonHistoryStoreTests.cs
@@ -90,6 +90,28 @@ public sealed class JsonHistoryStoreTests : IDisposable
         Assert.Equal("git stash pop", entries[1].CommandText);
     }
 
+    [Fact]
+    public async Task TryUpdateExitCodeAsync_PersistsExitCodeAcrossStoreInstances()
+    {
+        string filePath = Path.Combine(_tempRoot, "history.json");
+        var store = new JsonHistoryStore(filePath, maxEntries: 50);
+        CommandHistoryEntry entry = CreateEntry(
+            "git status",
+            executedAt: DateTimeOffset.Parse("2026-03-01T10:00:00+00:00"),
+            exitCode: null);
+
+        await store.AppendAsync(entry);
+
+        bool updated = await store.TryUpdateExitCodeAsync(entry.Id, 17);
+
+        var reloaded = new JsonHistoryStore(filePath, maxEntries: 50);
+        IReadOnlyList<CommandHistoryEntry> entries = await reloaded.GetRecentAsync(10);
+
+        Assert.True(updated);
+        Assert.Single(entries);
+        Assert.Equal(17, entries[0].ExitCode);
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_tempRoot))
@@ -98,7 +120,10 @@ public sealed class JsonHistoryStoreTests : IDisposable
         }
     }
 
-    private static CommandHistoryEntry CreateEntry(string commandText, DateTimeOffset? executedAt = null)
+    private static CommandHistoryEntry CreateEntry(
+        string commandText,
+        DateTimeOffset? executedAt = null,
+        int? exitCode = 0)
     {
         return new CommandHistoryEntry(
             Id: Guid.NewGuid().ToString("N"),
@@ -109,7 +134,7 @@ public sealed class JsonHistoryStoreTests : IDisposable
             ProfileId: "profile-1",
             SessionId: "session-1",
             HostId: null,
-            ExitCode: 0,
+            ExitCode: exitCode,
             IsRemote: false,
             IsRedacted: false,
             Source: CommandCaptureSource.Heuristic);

--- a/tests/NovaTerminal.Tests/CommandAssist/JsonSnippetStoreTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/JsonSnippetStoreTests.cs
@@ -1,0 +1,73 @@
+using NovaTerminal.CommandAssist.Models;
+using NovaTerminal.CommandAssist.Storage;
+
+namespace NovaTerminal.Tests.CommandAssist;
+
+public sealed class JsonSnippetStoreTests : IDisposable
+{
+    private readonly string _tempRoot;
+
+    public JsonSnippetStoreTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), $"nova_command_assist_snippets_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempRoot);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_PersistsPinnedSnippetAcrossStoreInstances()
+    {
+        string filePath = Path.Combine(_tempRoot, "snippets.json");
+        var store = new JsonSnippetStore(filePath);
+        var snippet = new CommandSnippet(
+            Id: "snippet-1",
+            Name: "Git Status",
+            CommandText: "git status",
+            Description: "Show working tree state",
+            ShellKind: "pwsh",
+            WorkingDirectory: @"C:\repo",
+            IsPinned: true,
+            CreatedAt: DateTimeOffset.Parse("2026-03-01T10:00:00+00:00"),
+            LastUsedAt: DateTimeOffset.Parse("2026-03-01T10:01:00+00:00"));
+
+        await store.UpsertAsync(snippet);
+
+        var reloaded = new JsonSnippetStore(filePath);
+        IReadOnlyList<CommandSnippet> snippets = await reloaded.GetAllAsync();
+
+        Assert.Single(snippets);
+        Assert.True(snippets[0].IsPinned);
+        Assert.Equal("git status", snippets[0].CommandText);
+    }
+
+    [Fact]
+    public async Task RemoveAsync_DeletesSnippetFromPersistence()
+    {
+        string filePath = Path.Combine(_tempRoot, "snippets.json");
+        var store = new JsonSnippetStore(filePath);
+        var snippet = new CommandSnippet(
+            Id: "snippet-1",
+            Name: "Git Status",
+            CommandText: "git status",
+            Description: null,
+            ShellKind: "pwsh",
+            WorkingDirectory: null,
+            IsPinned: false,
+            CreatedAt: DateTimeOffset.Parse("2026-03-01T10:00:00+00:00"),
+            LastUsedAt: null);
+
+        await store.UpsertAsync(snippet);
+        await store.RemoveAsync(snippet.Id);
+
+        IReadOnlyList<CommandSnippet> snippets = await store.GetAllAsync();
+
+        Assert.Empty(snippets);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+        {
+            Directory.Delete(_tempRoot, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Command Assist M2 ranked suggestions with mixed history and snippet sources, success-aware boosts, cwd/profile awareness, and pinning support
- expand the bottom docked assist bar with a compact result list, selected-item metadata, and pane-scoped keyboard interactions for select, insert, dismiss, and pin
- extend Command Assist persistence and tests with snippet storage and history exit-code metadata updates while keeping VT, renderer, replay, and PTY layers untouched

## Test Plan
- [x] `dotnet test tests\\NovaTerminal.Tests\\NovaTerminal.Tests.csproj -c Release --filter "JsonHistoryStoreTests|JsonSnippetStoreTests|SecretsFilterTests|HistorySuggestionEngineTests|CommandAssistSuggestionEngineTests|CommandAssistControllerTests|AlternateScreenTests|OscShellIntegrationTests|HeadlessUITests" --logger "console;verbosity=minimal"`
- [x] `dotnet msbuild src\\NovaTerminal.App\\NovaTerminal.App.csproj /t:Compile /p:Configuration=Release /v:minimal`