### PR TITLE
Implement Command Assist M3 shell integration foundation

### DIFF
--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistController.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistController.cs
@@ -179,7 +179,7 @@ public sealed class CommandAssistController
         _hostId = hostId;
         _isRemote = isRemote;
         _isShellIntegrationEnabled = isShellIntegrated;
-        _hasObservedShellIntegrationMarker = false;
+        _hasObservedShellIntegrationMarker = _hasObservedShellIntegrationMarker && isShellIntegrated;
     }
 
     public void SetShellIntegrationEnabled(bool isEnabled)

--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistController.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistController.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using NovaTerminal.CommandAssist.Domain;
 using NovaTerminal.CommandAssist.Models;
+using NovaTerminal.CommandAssist.ShellIntegration.Contracts;
 using NovaTerminal.CommandAssist.ViewModels;
 
 namespace NovaTerminal.CommandAssist.Application;
@@ -18,9 +19,12 @@ public sealed class CommandAssistController
     private string? _sessionId;
     private string? _hostId;
     private bool _isRemote;
+    private bool _isShellIntegrationEnabled;
+    private bool _hasObservedShellIntegrationMarker;
     private bool _ignoreCurrentSubmission;
     private int _refreshVersion;
     private string? _pendingHistoryEntryId;
+    private string? _pendingHistoryCommandText;
     private readonly List<AssistSuggestion> _suggestions = new();
     private readonly Action<Action> _dispatch;
 
@@ -120,6 +124,7 @@ public sealed class CommandAssistController
         {
             string submission = ViewModel.QueryText.Trim();
             bool shouldPersist = !_isAltScreenActive &&
+                                 !IsStructuredShellIntegrationActive() &&
                                  !_ignoreCurrentSubmission &&
                                  !string.IsNullOrWhiteSpace(submission) &&
                                  !submission.Contains('\n') &&
@@ -140,10 +145,12 @@ public sealed class CommandAssistController
                     ExitCode: null,
                     IsRemote: _isRemote,
                     IsRedacted: redaction.WasRedacted,
-                    Source: CommandCaptureSource.Heuristic);
+                    Source: CommandCaptureSource.Heuristic,
+                    DurationMs: null);
 
                 await HistoryStore.AppendAsync(entry);
                 _pendingHistoryEntryId = entry.Id;
+                _pendingHistoryCommandText = NormalizeCommandText(submission);
             }
         }
         catch
@@ -162,7 +169,8 @@ public sealed class CommandAssistController
         string? profileId,
         string? sessionId,
         string? hostId,
-        bool isRemote)
+        bool isRemote,
+        bool isShellIntegrated = false)
     {
         _shellKind = shellKind;
         _workingDirectory = workingDirectory;
@@ -170,6 +178,17 @@ public sealed class CommandAssistController
         _sessionId = sessionId;
         _hostId = hostId;
         _isRemote = isRemote;
+        _isShellIntegrationEnabled = isShellIntegrated;
+        _hasObservedShellIntegrationMarker = false;
+    }
+
+    public void SetShellIntegrationEnabled(bool isEnabled)
+    {
+        _isShellIntegrationEnabled = isEnabled;
+        if (!isEnabled)
+        {
+            _hasObservedShellIntegrationMarker = false;
+        }
     }
 
     public void Dismiss()
@@ -261,11 +280,43 @@ public sealed class CommandAssistController
 
         try
         {
-            await HistoryStore.TryUpdateExitCodeAsync(pendingEntryId, exitCode);
+            await HistoryStore.TryUpdateExecutionResultAsync(pendingEntryId, exitCode, durationMs: null);
         }
         catch
         {
             // History metadata enrichment is best-effort only.
+        }
+    }
+
+    public async Task HandleShellIntegrationEventAsync(ShellIntegrationEvent shellEvent)
+    {
+        if (shellEvent.WorkingDirectory != null)
+        {
+            _workingDirectory = shellEvent.WorkingDirectory;
+        }
+
+        if (shellEvent.Type is ShellIntegrationEventType.PromptReady or
+            ShellIntegrationEventType.CommandAccepted or
+            ShellIntegrationEventType.CommandStarted or
+            ShellIntegrationEventType.CommandFinished)
+        {
+            _hasObservedShellIntegrationMarker = true;
+        }
+
+        switch (shellEvent.Type)
+        {
+            case ShellIntegrationEventType.WorkingDirectoryChanged:
+            case ShellIntegrationEventType.PromptReady:
+            case ShellIntegrationEventType.CommandStarted:
+                return;
+
+            case ShellIntegrationEventType.CommandAccepted:
+                await HandleShellIntegratedCommandAcceptedAsync(shellEvent);
+                return;
+
+            case ShellIntegrationEventType.CommandFinished:
+                await HandleShellIntegratedCommandFinishedAsync(shellEvent);
+                return;
         }
     }
 
@@ -473,5 +524,87 @@ public sealed class CommandAssistController
         }
 
         return string.Join("  |  ", parts);
+    }
+
+    private async Task HandleShellIntegratedCommandAcceptedAsync(ShellIntegrationEvent shellEvent)
+    {
+        if (!_isShellIntegrationEnabled || _isAltScreenActive)
+        {
+            return;
+        }
+
+        string commandText = shellEvent.CommandText?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(commandText))
+        {
+            return;
+        }
+
+        string normalizedCommandText = NormalizeCommandText(commandText);
+        if (!string.IsNullOrWhiteSpace(_pendingHistoryEntryId) &&
+            string.Equals(_pendingHistoryCommandText, normalizedCommandText, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        try
+        {
+            RedactionResult redaction = SecretsFilter.Redact(commandText);
+            var entry = new CommandHistoryEntry(
+                Id: Guid.NewGuid().ToString("N"),
+                CommandText: redaction.RedactedText,
+                ExecutedAt: shellEvent.Timestamp,
+                ShellKind: _shellKind ?? "unknown",
+                WorkingDirectory: shellEvent.WorkingDirectory ?? _workingDirectory,
+                ProfileId: _profileId,
+                SessionId: _sessionId,
+                HostId: _hostId,
+                ExitCode: null,
+                IsRemote: _isRemote,
+                IsRedacted: redaction.WasRedacted,
+                Source: CommandCaptureSource.ShellIntegration,
+                DurationMs: null);
+
+            await HistoryStore.AppendAsync(entry);
+            _pendingHistoryEntryId = entry.Id;
+            _pendingHistoryCommandText = normalizedCommandText;
+        }
+        catch
+        {
+            // Structured capture is best-effort and must not affect shell execution.
+        }
+    }
+
+    private async Task HandleShellIntegratedCommandFinishedAsync(ShellIntegrationEvent shellEvent)
+    {
+        string? pendingEntryId = _pendingHistoryEntryId;
+        if (string.IsNullOrWhiteSpace(pendingEntryId))
+        {
+            return;
+        }
+
+        long? durationMs = shellEvent.Duration.HasValue
+            ? (long)Math.Round(shellEvent.Duration.Value.TotalMilliseconds)
+            : null;
+
+        try
+        {
+            await HistoryStore.TryUpdateExecutionResultAsync(pendingEntryId, shellEvent.ExitCode, durationMs);
+            _pendingHistoryEntryId = null;
+            _pendingHistoryCommandText = null;
+        }
+        catch
+        {
+            // Structured metadata updates are best-effort only.
+        }
+    }
+
+    private bool IsStructuredShellIntegrationActive()
+    {
+        return _isShellIntegrationEnabled && _hasObservedShellIntegrationMarker;
+    }
+
+    private static string NormalizeCommandText(string commandText)
+    {
+        return commandText.Trim();
     }
 }

--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistInfrastructure.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistInfrastructure.cs
@@ -1,5 +1,8 @@
 using System;
 using NovaTerminal.CommandAssist.Domain;
+using NovaTerminal.CommandAssist.ShellIntegration.Contracts;
+using NovaTerminal.CommandAssist.ShellIntegration.PowerShell;
+using NovaTerminal.CommandAssist.ShellIntegration.Runtime;
 using NovaTerminal.CommandAssist.Storage;
 using NovaTerminal.Core;
 
@@ -13,6 +16,10 @@ public static class CommandAssistInfrastructure
     private static int _historyMaxEntries = -1;
     private static readonly ISecretsFilter SecretsFilterInstance = new SecretsFilter();
     private static readonly ISuggestionEngine SuggestionEngineInstance = new CommandAssistSuggestionEngine();
+    private static readonly ShellIntegrationRegistry ShellIntegrationRegistryInstance = new(new IShellIntegrationProvider[]
+    {
+        new PowerShellShellIntegrationProvider()
+    });
 
     public static IHistoryStore GetHistoryStore(TerminalSettings settings)
     {
@@ -42,4 +49,6 @@ public static class CommandAssistInfrastructure
     public static ISecretsFilter GetSecretsFilter() => SecretsFilterInstance;
 
     public static ISuggestionEngine GetSuggestionEngine() => SuggestionEngineInstance;
+
+    public static ShellIntegrationRegistry GetShellIntegrationRegistry() => ShellIntegrationRegistryInstance;
 }

--- a/src/NovaTerminal.App/CommandAssist/Domain/IHistoryStore.cs
+++ b/src/NovaTerminal.App/CommandAssist/Domain/IHistoryStore.cs
@@ -10,6 +10,7 @@ public interface IHistoryStore
     Task AppendAsync(CommandHistoryEntry entry, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<CommandHistoryEntry>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<CommandHistoryEntry>> GetRecentAsync(int maxResults, CancellationToken cancellationToken = default);
+    Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default);
     Task<bool> TryUpdateExitCodeAsync(string entryId, int? exitCode, CancellationToken cancellationToken = default);
     Task ClearAsync(CancellationToken cancellationToken = default);
 }

--- a/src/NovaTerminal.App/CommandAssist/Models/CommandCaptureSource.cs
+++ b/src/NovaTerminal.App/CommandAssist/Models/CommandCaptureSource.cs
@@ -2,5 +2,6 @@ namespace NovaTerminal.CommandAssist.Models;
 
 public enum CommandCaptureSource
 {
-    Heuristic
+    Heuristic,
+    ShellIntegration
 }

--- a/src/NovaTerminal.App/CommandAssist/Models/CommandHistoryEntry.cs
+++ b/src/NovaTerminal.App/CommandAssist/Models/CommandHistoryEntry.cs
@@ -14,4 +14,5 @@ public sealed record CommandHistoryEntry(
     int? ExitCode,
     bool IsRemote,
     bool IsRedacted,
-    CommandCaptureSource Source);
+    CommandCaptureSource Source,
+    long? DurationMs);

--- a/src/NovaTerminal.App/CommandAssist/ShellIntegration/Contracts/IShellIntegrationProvider.cs
+++ b/src/NovaTerminal.App/CommandAssist/ShellIntegration/Contracts/IShellIntegrationProvider.cs
@@ -1,0 +1,13 @@
+using NovaTerminal.Core;
+
+namespace NovaTerminal.CommandAssist.ShellIntegration.Contracts;
+
+public interface IShellIntegrationProvider
+{
+    bool CanIntegrate(string? shellKind, TerminalProfile? profile);
+
+    ShellIntegrationLaunchPlan CreateLaunchPlan(
+        string shellCommand,
+        string? shellArguments,
+        string? workingDirectory);
+}

--- a/src/NovaTerminal.App/CommandAssist/ShellIntegration/Contracts/ShellIntegrationEvent.cs
+++ b/src/NovaTerminal.App/CommandAssist/ShellIntegration/Contracts/ShellIntegrationEvent.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace NovaTerminal.CommandAssist.ShellIntegration.Contracts;
+
+public sealed record ShellIntegrationEvent(
+    ShellIntegrationEventType Type,
+    DateTimeOffset Timestamp,
+    string? CommandText,
+    string? WorkingDirectory,
+    int? ExitCode,
+    TimeSpan? Duration);

--- a/src/NovaTerminal.App/CommandAssist/ShellIntegration/Contracts/ShellIntegrationEventType.cs
+++ b/src/NovaTerminal.App/CommandAssist/ShellIntegration/Contracts/ShellIntegrationEventType.cs
@@ -1,0 +1,10 @@
+namespace NovaTerminal.CommandAssist.ShellIntegration.Contracts;
+
+public enum ShellIntegrationEventType
+{
+    WorkingDirectoryChanged,
+    PromptReady,
+    CommandAccepted,
+    CommandStarted,
+    CommandFinished
+}

--- a/src/NovaTerminal.App/CommandAssist/ShellIntegration/Contracts/ShellIntegrationLaunchPlan.cs
+++ b/src/NovaTerminal.App/CommandAssist/ShellIntegration/Contracts/ShellIntegrationLaunchPlan.cs
@@ -1,0 +1,7 @@
+namespace NovaTerminal.CommandAssist.ShellIntegration.Contracts;
+
+public sealed record ShellIntegrationLaunchPlan(
+    bool IsIntegrated,
+    string ShellCommand,
+    string? ShellArguments,
+    string? BootstrapScriptPath);

--- a/src/NovaTerminal.App/CommandAssist/ShellIntegration/PowerShell/PowerShellBootstrapBuilder.cs
+++ b/src/NovaTerminal.App/CommandAssist/ShellIntegration/PowerShell/PowerShellBootstrapBuilder.cs
@@ -1,0 +1,74 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace NovaTerminal.CommandAssist.ShellIntegration.PowerShell;
+
+public static class PowerShellBootstrapBuilder
+{
+    public static string BuildScript()
+    {
+        const string nl = "\n";
+        var builder = new StringBuilder();
+        builder.Append("$ErrorActionPreference = 'Stop'").Append(nl);
+        builder.Append("$esc = [char]27").Append(nl);
+        builder.Append("$bel = [char]7").Append(nl);
+        builder.Append("$script:NovaCommandStart = $null").Append(nl);
+        builder.Append(nl);
+        builder.Append("function Write-NovaSequence([string]$sequence) {").Append(nl);
+        builder.Append("    [Console]::Out.Write(\"$esc$sequence$bel\")").Append(nl);
+        builder.Append("}").Append(nl);
+        builder.Append(nl);
+        builder.Append("function Write-NovaPwd() {").Append(nl);
+        builder.Append("    $cwd = [Uri]::EscapeUriString((Get-Location).Path)").Append(nl);
+        builder.Append("    Write-NovaSequence \"]7;file://$env:COMPUTERNAME/$cwd\"").Append(nl);
+        builder.Append("}").Append(nl);
+        builder.Append(nl);
+        builder.Append("function Write-NovaPromptReady() {").Append(nl);
+        builder.Append("    Write-NovaPwd").Append(nl);
+        builder.Append("    Write-NovaSequence ']133;A'").Append(nl);
+        builder.Append("}").Append(nl);
+        builder.Append(nl);
+        builder.Append("function Global:prompt {").Append(nl);
+        builder.Append("    Write-NovaPromptReady").Append(nl);
+        builder.Append("    'PS ' + (Get-Location) + '> '").Append(nl);
+        builder.Append("}").Append(nl);
+        builder.Append(nl);
+        builder.Append("Set-PSReadLineOption -AddToHistoryHandler {").Append(nl);
+        builder.Append("    param($line)").Append(nl);
+        builder.Append("    if ([string]::IsNullOrWhiteSpace($line)) { return $true }").Append(nl);
+        builder.Append("    $script:NovaCommandStart = [DateTimeOffset]::UtcNow").Append(nl);
+        builder.Append("    $encoded = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($line))").Append(nl);
+        builder.Append("    Write-NovaSequence \"]133;C;$encoded\"").Append(nl);
+        builder.Append("    Write-NovaSequence ']133;B'").Append(nl);
+        builder.Append("    return $true").Append(nl);
+        builder.Append("}").Append(nl);
+        builder.Append(nl);
+        builder.Append("Register-EngineEvent PowerShell.OnIdle -SupportEvent -Action {").Append(nl);
+        builder.Append("    if ($global:LASTEXITCODE -ne $null -or $?) {").Append(nl);
+        builder.Append("        $durationMs = $null").Append(nl);
+        builder.Append("        if ($script:NovaCommandStart -ne $null) {").Append(nl);
+        builder.Append("            $durationMs = [math]::Round((([DateTimeOffset]::UtcNow) - $script:NovaCommandStart).TotalMilliseconds)").Append(nl);
+        builder.Append("        }").Append(nl);
+        builder.Append("        $exitCode = if ($?) { 0 } elseif ($global:LASTEXITCODE -ne $null) { $global:LASTEXITCODE } else { 1 }").Append(nl);
+        builder.Append("        if ($durationMs -ne $null) {").Append(nl);
+        builder.Append("            Write-NovaSequence \"]133;D;$exitCode;$durationMs\"").Append(nl);
+        builder.Append("        } else {").Append(nl);
+        builder.Append("            Write-NovaSequence \"]133;D;$exitCode\"").Append(nl);
+        builder.Append("        }").Append(nl);
+        builder.Append("        $script:NovaCommandStart = $null").Append(nl);
+        builder.Append("    }").Append(nl);
+        builder.Append("} | Out-Null").Append(nl);
+        builder.Append(nl);
+        builder.Append("Write-NovaPromptReady").Append(nl);
+        return builder.ToString();
+    }
+
+    public static string WriteScript(string targetDirectory)
+    {
+        Directory.CreateDirectory(targetDirectory);
+        string path = Path.Combine(targetDirectory, "command-assist-bootstrap.ps1");
+        File.WriteAllText(path, BuildScript(), Encoding.UTF8);
+        return path;
+    }
+}

--- a/src/NovaTerminal.App/CommandAssist/ShellIntegration/PowerShell/PowerShellShellIntegrationProvider.cs
+++ b/src/NovaTerminal.App/CommandAssist/ShellIntegration/PowerShell/PowerShellShellIntegrationProvider.cs
@@ -20,6 +20,15 @@ public sealed class PowerShellShellIntegrationProvider : IShellIntegrationProvid
 
     public ShellIntegrationLaunchPlan CreateLaunchPlan(string shellCommand, string? shellArguments, string? workingDirectory)
     {
+        if (ContainsUserScriptFile(shellArguments))
+        {
+            return new ShellIntegrationLaunchPlan(
+                IsIntegrated: false,
+                ShellCommand: shellCommand,
+                ShellArguments: shellArguments,
+                BootstrapScriptPath: null);
+        }
+
         string bootstrapScriptPath = PowerShellBootstrapBuilder.WriteScript(AppPaths.CommandAssistDirectory);
         string mergedArguments = BuildPowerShellArguments(shellArguments, bootstrapScriptPath);
         return new ShellIntegrationLaunchPlan(
@@ -56,5 +65,11 @@ public sealed class PowerShellShellIntegrationProvider : IShellIntegrationProvid
         }
 
         return original.Trim();
+    }
+
+    private static bool ContainsUserScriptFile(string? shellArguments)
+    {
+        return !string.IsNullOrWhiteSpace(shellArguments) &&
+               shellArguments.Contains("-File", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/NovaTerminal.App/CommandAssist/ShellIntegration/PowerShell/PowerShellShellIntegrationProvider.cs
+++ b/src/NovaTerminal.App/CommandAssist/ShellIntegration/PowerShell/PowerShellShellIntegrationProvider.cs
@@ -1,0 +1,60 @@
+using System;
+using NovaTerminal.CommandAssist.ShellIntegration.Contracts;
+using NovaTerminal.Core;
+
+namespace NovaTerminal.CommandAssist.ShellIntegration.PowerShell;
+
+public sealed class PowerShellShellIntegrationProvider : IShellIntegrationProvider
+{
+    public bool CanIntegrate(string? shellKind, TerminalProfile? profile)
+    {
+        if (string.Equals(shellKind, "pwsh", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        string command = profile?.Command ?? string.Empty;
+        return command.Contains("pwsh", StringComparison.OrdinalIgnoreCase) ||
+               command.Contains("powershell", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public ShellIntegrationLaunchPlan CreateLaunchPlan(string shellCommand, string? shellArguments, string? workingDirectory)
+    {
+        string bootstrapScriptPath = PowerShellBootstrapBuilder.WriteScript(AppPaths.CommandAssistDirectory);
+        string mergedArguments = BuildPowerShellArguments(shellArguments, bootstrapScriptPath);
+        return new ShellIntegrationLaunchPlan(
+            IsIntegrated: true,
+            ShellCommand: shellCommand,
+            ShellArguments: mergedArguments,
+            BootstrapScriptPath: bootstrapScriptPath);
+    }
+
+    private static string BuildPowerShellArguments(string? shellArguments, string bootstrapScriptPath)
+    {
+        string original = shellArguments?.Trim() ?? string.Empty;
+        string quotedBootstrapPath = $"\"{bootstrapScriptPath}\"";
+
+        if (!original.Contains("-NoLogo", StringComparison.OrdinalIgnoreCase))
+        {
+            original = string.IsNullOrWhiteSpace(original)
+                ? "-NoLogo"
+                : $"-NoLogo {original}";
+        }
+
+        if (!original.Contains("-NoExit", StringComparison.OrdinalIgnoreCase))
+        {
+            original = string.IsNullOrWhiteSpace(original)
+                ? "-NoExit"
+                : $"{original} -NoExit";
+        }
+
+        if (!original.Contains("-File", StringComparison.OrdinalIgnoreCase))
+        {
+            original = string.IsNullOrWhiteSpace(original)
+                ? $"-File {quotedBootstrapPath}"
+                : $"{original} -File {quotedBootstrapPath}";
+        }
+
+        return original.Trim();
+    }
+}

--- a/src/NovaTerminal.App/CommandAssist/ShellIntegration/Runtime/OrderedAsyncEventDispatcher.cs
+++ b/src/NovaTerminal.App/CommandAssist/ShellIntegration/Runtime/OrderedAsyncEventDispatcher.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NovaTerminal.CommandAssist.ShellIntegration.Runtime;
+
+public sealed class OrderedAsyncEventDispatcher
+{
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public async Task EnqueueAsync(Func<Task> work)
+    {
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            await work().ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+}

--- a/src/NovaTerminal.App/CommandAssist/ShellIntegration/Runtime/ShellIntegrationRegistry.cs
+++ b/src/NovaTerminal.App/CommandAssist/ShellIntegration/Runtime/ShellIntegrationRegistry.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Linq;
+using NovaTerminal.CommandAssist.ShellIntegration.Contracts;
+using NovaTerminal.Core;
+
+namespace NovaTerminal.CommandAssist.ShellIntegration.Runtime;
+
+public sealed class ShellIntegrationRegistry
+{
+    private readonly IReadOnlyList<IShellIntegrationProvider> _providers;
+
+    public ShellIntegrationRegistry(IEnumerable<IShellIntegrationProvider> providers)
+    {
+        _providers = providers.ToList();
+    }
+
+    public IShellIntegrationProvider? GetProvider(string? shellKind, TerminalProfile? profile)
+    {
+        return _providers.FirstOrDefault(provider => provider.CanIntegrate(shellKind, profile));
+    }
+}

--- a/src/NovaTerminal.App/CommandAssist/ShellIntegration/Runtime/ShellLifecycleTracker.cs
+++ b/src/NovaTerminal.App/CommandAssist/ShellIntegration/Runtime/ShellLifecycleTracker.cs
@@ -1,0 +1,73 @@
+using System;
+using NovaTerminal.CommandAssist.ShellIntegration.Contracts;
+
+namespace NovaTerminal.CommandAssist.ShellIntegration.Runtime;
+
+public sealed class ShellLifecycleTracker
+{
+    private readonly Func<DateTimeOffset> _nowProvider;
+    private string? _workingDirectory;
+    private DateTimeOffset? _commandStartedAt;
+
+    public ShellLifecycleTracker(Func<DateTimeOffset>? nowProvider = null)
+    {
+        _nowProvider = nowProvider ?? (() => DateTimeOffset.UtcNow);
+    }
+
+    public event Action<ShellIntegrationEvent>? EventObserved;
+
+    public void HandleWorkingDirectoryChanged(string? workingDirectory)
+    {
+        _workingDirectory = workingDirectory;
+        Emit(ShellIntegrationEventType.WorkingDirectoryChanged, commandText: null, exitCode: null, duration: null);
+    }
+
+    public void HandlePromptReady()
+    {
+        Emit(ShellIntegrationEventType.PromptReady, commandText: null, exitCode: null, duration: null);
+    }
+
+    public void HandleCommandAccepted(string? commandText)
+    {
+        Emit(ShellIntegrationEventType.CommandAccepted, commandText, exitCode: null, duration: null);
+    }
+
+    public void HandleCommandStarted()
+    {
+        _commandStartedAt = _nowProvider();
+        Emit(ShellIntegrationEventType.CommandStarted, commandText: null, exitCode: null, duration: null);
+    }
+
+    public void HandleCommandFinished(int? exitCode, long? durationMs = null)
+    {
+        TimeSpan? duration = null;
+        DateTimeOffset now = _nowProvider();
+        if (durationMs.HasValue)
+        {
+            duration = TimeSpan.FromMilliseconds(durationMs.Value);
+        }
+        else if (_commandStartedAt.HasValue)
+        {
+            duration = now - _commandStartedAt.Value;
+        }
+
+        _commandStartedAt = null;
+        Emit(ShellIntegrationEventType.CommandFinished, commandText: null, exitCode, duration, now);
+    }
+
+    private void Emit(
+        ShellIntegrationEventType type,
+        string? commandText,
+        int? exitCode,
+        TimeSpan? duration,
+        DateTimeOffset? timestamp = null)
+    {
+        EventObserved?.Invoke(new ShellIntegrationEvent(
+            Type: type,
+            Timestamp: timestamp ?? _nowProvider(),
+            CommandText: commandText,
+            WorkingDirectory: _workingDirectory,
+            ExitCode: exitCode,
+            Duration: duration));
+    }
+}

--- a/src/NovaTerminal.App/CommandAssist/Storage/JsonHistoryStore.cs
+++ b/src/NovaTerminal.App/CommandAssist/Storage/JsonHistoryStore.cs
@@ -101,7 +101,12 @@ public sealed class JsonHistoryStore : IHistoryStore
         }
     }
 
-    public async Task<bool> TryUpdateExitCodeAsync(string entryId, int? exitCode, CancellationToken cancellationToken = default)
+    public Task<bool> TryUpdateExitCodeAsync(string entryId, int? exitCode, CancellationToken cancellationToken = default)
+    {
+        return TryUpdateExecutionResultAsync(entryId, exitCode, durationMs: null, cancellationToken);
+    }
+
+    public async Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default)
     {
         await _gate.WaitAsync(cancellationToken);
         try
@@ -113,7 +118,11 @@ public sealed class JsonHistoryStore : IHistoryStore
                 return false;
             }
 
-            entries[index] = entries[index] with { ExitCode = exitCode };
+            entries[index] = entries[index] with
+            {
+                ExitCode = exitCode,
+                DurationMs = durationMs ?? entries[index].DurationMs
+            };
             await SaveEntriesUnsafeAsync(entries, cancellationToken);
             return true;
         }

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -64,6 +64,7 @@ namespace NovaTerminal.Controls
         private CommandAssistController? _commandAssistController;
         private ShellLifecycleTracker? _shellLifecycleTracker;
         private bool _isShellIntegrationActive;
+        private readonly OrderedAsyncEventDispatcher _shellIntegrationEventDispatcher = new();
 
         public bool IsRecording => Session?.IsRecording ?? false;
         public string? CurrentWorkingDirectory { get; private set; }
@@ -1253,7 +1254,7 @@ namespace NovaTerminal.Controls
 
         private void OnShellIntegrationEventObserved(ShellIntegrationEvent shellEvent)
         {
-            _ = HandleShellIntegrationEventAsync(shellEvent);
+            _ = _shellIntegrationEventDispatcher.EnqueueAsync(() => HandleShellIntegrationEventAsync(shellEvent));
         }
 
         private async Task HandleShellIntegrationEventAsync(ShellIntegrationEvent shellEvent)

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -15,6 +15,9 @@ using Avalonia.Controls.Shapes;
 using Avalonia.Automation;
 using Avalonia.Platform.Storage;
 using NovaTerminal.CommandAssist.Application;
+using NovaTerminal.CommandAssist.ShellIntegration.Contracts;
+using NovaTerminal.CommandAssist.ShellIntegration.PowerShell;
+using NovaTerminal.CommandAssist.ShellIntegration.Runtime;
 using NovaTerminal.Core.Ssh.Launch;
 using NovaTerminal.Core.Ssh.Sessions;
 
@@ -59,6 +62,8 @@ namespace NovaTerminal.Controls
         private string? _pendingPasteFilePath;
         private string? _pendingEscapedPath;
         private CommandAssistController? _commandAssistController;
+        private ShellLifecycleTracker? _shellLifecycleTracker;
+        private bool _isShellIntegrationActive;
 
         public bool IsRecording => Session?.IsRecording ?? false;
         public string? CurrentWorkingDirectory { get; private set; }
@@ -447,7 +452,8 @@ namespace NovaTerminal.Controls
                 profileId: Profile?.Id.ToString(),
                 sessionId: Session?.Id.ToString(),
                 hostId: Profile?.Type == ConnectionType.SSH ? Profile.SshHost : null,
-                isRemote: Profile?.Type == ConnectionType.SSH);
+                isRemote: Profile?.Type == ConnectionType.SSH,
+                isShellIntegrated: _isShellIntegrationActive);
         }
 
         private bool TryInsertSelectedCommandAssistSuggestion()
@@ -520,6 +526,7 @@ namespace NovaTerminal.Controls
             };
             Parser.OnWorkingDirectoryChanged += cwd =>
             {
+                _shellLifecycleTracker?.HandleWorkingDirectoryChanged(cwd);
                 Dispatcher.UIThread.Post(() =>
                 {
                     CurrentWorkingDirectory = cwd;
@@ -535,8 +542,17 @@ namespace NovaTerminal.Controls
                     TitleChanged?.Invoke(this, title);
                 });
             };
+            Parser.OnPromptReady += () =>
+            {
+                _shellLifecycleTracker?.HandlePromptReady();
+            };
+            Parser.OnCommandAccepted += commandText =>
+            {
+                _shellLifecycleTracker?.HandleCommandAccepted(commandText);
+            };
             Parser.OnCommandStarted += () =>
             {
+                _shellLifecycleTracker?.HandleCommandStarted();
                 Dispatcher.UIThread.Post(() =>
                 {
                     LastExitCode = null;
@@ -553,8 +569,15 @@ namespace NovaTerminal.Controls
                     }
 
                     CommandFinished?.Invoke(this, exitCode);
-                    _ = _commandAssistController?.HandleCommandFinishedAsync(exitCode);
+                    if (!_isShellIntegrationActive)
+                    {
+                        _ = _commandAssistController?.HandleCommandFinishedAsync(exitCode);
+                    }
                 });
+            };
+            Parser.OnCommandFinishedDetailed += (exitCode, durationMs) =>
+            {
+                _shellLifecycleTracker?.HandleCommandFinished(exitCode, durationMs);
             };
 
             // Sync initial metrics
@@ -566,6 +589,8 @@ namespace NovaTerminal.Controls
             // Setup Session
             string effectiveShell = shell ?? ShellHelper.GetDefaultShell();
             string args = explicitArgs ?? profile?.Arguments ?? "";
+            _shellLifecycleTracker = null;
+            _isShellIntegrationActive = false;
 
             // Update SFTP Menu Visibility
             // If it's not an SSH session, detach the context menu entirely to avoid "tiny empty box" artifacts
@@ -591,6 +616,13 @@ namespace NovaTerminal.Controls
 
                 ShellCommand = effectiveShell;
                 ShellArgs = args;
+
+                if (profile == null || profile.Type != ConnectionType.SSH)
+                {
+                    ApplyShellIntegrationLaunchPlan(profile, ref effectiveShell, ref args, startingDir);
+                    ShellCommand = effectiveShell;
+                    ShellArgs = args;
+                }
 
                 if (profile != null && profile.Type == ConnectionType.SSH)
                 {
@@ -618,7 +650,13 @@ namespace NovaTerminal.Controls
                     }
                 }
 
-                Session ??= new RustPtySession(effectiveShell, cols, rows, args, startingDir);
+                Session ??= new RustPtySession(
+                    effectiveShell,
+                    cols,
+                    rows,
+                    args,
+                    startingDir,
+                    skipPowerShellPostLaunchInit: _isShellIntegrationActive);
                 Session.AttachBuffer(Buffer);
 
                 TermView.SetSession(Session);
@@ -708,6 +746,8 @@ namespace NovaTerminal.Controls
                 BellAudioEnabled = settings.BellAudioEnabled,
                 BellVisualEnabled = settings.BellVisualEnabled,
                 SmoothScrolling = settings.SmoothScrolling,
+                CommandAssistShellIntegrationEnabled = settings.CommandAssistShellIntegrationEnabled,
+                CommandAssistPowerShellIntegrationEnabled = settings.CommandAssistPowerShellIntegrationEnabled,
                 Profiles = settings.Profiles,
                 DefaultProfileId = settings.DefaultProfileId
             };
@@ -1162,6 +1202,75 @@ namespace NovaTerminal.Controls
                 return listeners.Any(l => l.Port == port);
             }
             catch { return false; }
+        }
+
+        private void ApplyShellIntegrationLaunchPlan(
+            TerminalProfile? profile,
+            ref string effectiveShell,
+            ref string args,
+            string startingDirectory)
+        {
+            if (_settings == null || !_settings.CommandAssistShellIntegrationEnabled)
+            {
+                return;
+            }
+
+            string shellKind = DetermineShellKind(effectiveShell);
+            var registry = CommandAssistInfrastructure.GetShellIntegrationRegistry();
+            IShellIntegrationProvider? provider = registry.GetProvider(shellKind, profile);
+            if (provider == null)
+            {
+                return;
+            }
+
+            if (!_settings.CommandAssistPowerShellIntegrationEnabled &&
+                provider is PowerShellShellIntegrationProvider)
+            {
+                return;
+            }
+
+            ShellIntegrationLaunchPlan plan;
+            try
+            {
+                plan = provider.CreateLaunchPlan(effectiveShell, args, startingDirectory);
+            }
+            catch
+            {
+                return;
+            }
+
+            if (!plan.IsIntegrated)
+            {
+                return;
+            }
+
+            effectiveShell = plan.ShellCommand;
+            args = plan.ShellArguments ?? string.Empty;
+            _isShellIntegrationActive = true;
+            _shellLifecycleTracker = new ShellLifecycleTracker();
+            _shellLifecycleTracker.EventObserved += OnShellIntegrationEventObserved;
+        }
+
+        private void OnShellIntegrationEventObserved(ShellIntegrationEvent shellEvent)
+        {
+            _ = HandleShellIntegrationEventAsync(shellEvent);
+        }
+
+        private async Task HandleShellIntegrationEventAsync(ShellIntegrationEvent shellEvent)
+        {
+            if (_commandAssistController == null)
+            {
+                return;
+            }
+
+            try
+            {
+                await _commandAssistController.HandleShellIntegrationEventAsync(shellEvent);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[TerminalPane] Shell integration event handling failed: {ex.Message}");
+            }
         }
     }
 }

--- a/src/NovaTerminal.App/Core/TerminalSettings.cs
+++ b/src/NovaTerminal.App/Core/TerminalSettings.cs
@@ -37,6 +37,8 @@ namespace NovaTerminal.Core
         public bool CommandAssistHistoryEnabled { get; set; } = true;
         public int CommandAssistMaxHistoryEntries { get; set; } = 5000;
         public bool CommandAssistAutoHideInAltScreen { get; set; } = true;
+        public bool CommandAssistShellIntegrationEnabled { get; set; } = true;
+        public bool CommandAssistPowerShellIntegrationEnabled { get; set; } = true;
 
         public System.Collections.Generic.List<TerminalProfile> Profiles { get; set; } = new();
         public Guid DefaultProfileId { get; set; }

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -165,7 +165,13 @@ namespace NovaTerminal.Core
         private int _cols;
         private int _rows;
 
-        public RustPtySession(string shellCommand, int cols = 120, int rows = 30, string? args = null, string? cwd = null)
+        public RustPtySession(
+            string shellCommand,
+            int cols = 120,
+            int rows = 30,
+            string? args = null,
+            string? cwd = null,
+            bool skipPowerShellPostLaunchInit = false)
         {
             ShellCommand = shellCommand;
             ShellArguments = args;
@@ -186,7 +192,10 @@ namespace NovaTerminal.Core
                 else if (shellLower.Contains("powershell") || shellLower.Contains("pwsh"))
                 {
                     effectiveShell = shellCommand;
-                    combinedArgs = "-NoLogo " + combinedArgs;
+                    if (!combinedArgs.Contains("-NoLogo", StringComparison.OrdinalIgnoreCase))
+                    {
+                        combinedArgs = "-NoLogo " + combinedArgs;
+                    }
                 }
             }
 
@@ -203,7 +212,8 @@ namespace NovaTerminal.Core
             _processTask = Task.Run(ProcessLoop);
 
             // POST-LAUNCH INJECTION for PowerShell
-            if (shellLower.Contains("powershell") || shellLower.Contains("pwsh"))
+            if (!skipPowerShellPostLaunchInit &&
+                (shellLower.Contains("powershell") || shellLower.Contains("pwsh")))
             {
                 Task.Delay(300).ContinueWith(_ =>
                 {

--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -3,6 +3,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Text;
 
 namespace NovaTerminal.Core
 {
@@ -45,8 +46,11 @@ namespace NovaTerminal.Core
         public Action? OnBell { get; set; }
         public Action<string>? OnWorkingDirectoryChanged { get; set; }
         public Action<string>? OnTitleChanged { get; set; }
+        public Action? OnPromptReady { get; set; }
+        public Action<string>? OnCommandAccepted { get; set; }
         public Action? OnCommandStarted { get; set; }
         public Action<int?>? OnCommandFinished { get; set; }
+        public Action<int?, long?>? OnCommandFinishedDetailed { get; set; }
 
         public AnsiParser(TerminalBuffer buffer, bool? forceConPtyFiltering = null)
         {
@@ -1187,28 +1191,61 @@ namespace NovaTerminal.Core
 
             // OSC 133: shell integration markers.
             // Common terminals/shell integrations emit:
+            //   OSC 133;A     -> prompt ready
             //   OSC 133;B   -> command started
-            //   OSC 133;D;N -> command finished with exit code N
+            //   OSC 133;C;X -> command accepted with base64-encoded command X
+            //   OSC 133;D;N[;M] -> command finished with exit code N and optional duration M
             if (code == "133")
             {
                 if (string.IsNullOrWhiteSpace(data)) return;
 
                 string[] parts = data.Split(';', StringSplitOptions.None);
                 string marker = parts[0];
-                if (string.Equals(marker, "B", StringComparison.Ordinal))
+                if (string.Equals(marker, "A", StringComparison.Ordinal))
+                {
+                    OnPromptReady?.Invoke();
+                }
+                else if (string.Equals(marker, "B", StringComparison.Ordinal))
                 {
                     OnCommandStarted?.Invoke();
+                }
+                else if (string.Equals(marker, "C", StringComparison.Ordinal))
+                {
+                    if (parts.Length > 1 && !string.IsNullOrWhiteSpace(parts[1]))
+                    {
+                        try
+                        {
+                            byte[] bytes = Convert.FromBase64String(parts[1]);
+                            string commandText = Encoding.UTF8.GetString(bytes);
+                            if (!string.IsNullOrWhiteSpace(commandText))
+                            {
+                                OnCommandAccepted?.Invoke(commandText);
+                            }
+                        }
+                        catch
+                        {
+                            // Ignore malformed command payloads and preserve terminal behavior.
+                        }
+                    }
                 }
                 else if (string.Equals(marker, "D", StringComparison.Ordinal))
                 {
                     int? exitCode = null;
+                    long? durationMs = null;
                     if (parts.Length > 1 &&
                         int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsed))
                     {
                         exitCode = parsed;
                     }
 
+                    if (parts.Length > 2 &&
+                        long.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out long parsedDuration))
+                    {
+                        durationMs = parsedDuration;
+                    }
+
                     OnCommandFinished?.Invoke(exitCode);
+                    OnCommandFinishedDetailed?.Invoke(exitCode, durationMs);
                 }
 
                 return;

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
@@ -1,6 +1,7 @@
 using NovaTerminal.CommandAssist.Application;
 using NovaTerminal.CommandAssist.Domain;
 using NovaTerminal.CommandAssist.Models;
+using NovaTerminal.CommandAssist.ShellIntegration.Contracts;
 using System.Diagnostics;
 
 namespace NovaTerminal.Tests.CommandAssist;
@@ -201,6 +202,118 @@ public sealed class CommandAssistControllerTests
     }
 
     [Fact]
+    public async Task HandleShellIntegrationEventAsync_WhenCommandAccepted_PersistsShellIntegratedEntry()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        var controller = CreateController(historyStore);
+        controller.SetShellIntegrationEnabled(true);
+
+        await controller.HandleShellIntegrationEventAsync(new ShellIntegrationEvent(
+            Type: ShellIntegrationEventType.CommandAccepted,
+            Timestamp: DateTimeOffset.Parse("2026-03-09T12:00:00+00:00"),
+            CommandText: "gh auth login --password hunter2",
+            WorkingDirectory: @"C:\repo",
+            ExitCode: null,
+            Duration: null));
+
+        Assert.Single(historyStore.Entries);
+        Assert.Equal("gh auth login --password [REDACTED]", historyStore.Entries[0].CommandText);
+        Assert.True(historyStore.Entries[0].IsRedacted);
+        Assert.Equal(CommandCaptureSource.ShellIntegration, historyStore.Entries[0].Source);
+    }
+
+    [Fact]
+    public async Task HandleEnterAsync_WhenShellIntegrationEnabled_DoesNotPersistHeuristicEntry()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        var controller = CreateController(historyStore);
+        controller.SetShellIntegrationEnabled(true);
+        await controller.HandleShellIntegrationEventAsync(new ShellIntegrationEvent(
+            Type: ShellIntegrationEventType.PromptReady,
+            Timestamp: DateTimeOffset.Parse("2026-03-09T11:59:59+00:00"),
+            CommandText: null,
+            WorkingDirectory: @"C:\repo",
+            ExitCode: null,
+            Duration: null));
+        controller.HandleTextInput("git status");
+
+        await controller.HandleEnterAsync();
+
+        Assert.Empty(historyStore.Entries);
+    }
+
+    [Fact]
+    public async Task HandleEnterAsync_WhenShellIntegrationConfiguredButNotConfirmed_PersistsHeuristicFallback()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        var controller = CreateController(historyStore);
+        controller.SetShellIntegrationEnabled(true);
+        controller.HandleTextInput("git status");
+
+        await controller.HandleEnterAsync();
+
+        Assert.Single(historyStore.Entries);
+        Assert.Equal(CommandCaptureSource.Heuristic, historyStore.Entries[0].Source);
+    }
+
+    [Fact]
+    public async Task HandleShellIntegrationEventAsync_WhenCommandFinished_UpdatesExitCodeAndDuration()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        var controller = CreateController(historyStore);
+        controller.SetShellIntegrationEnabled(true);
+
+        await controller.HandleShellIntegrationEventAsync(new ShellIntegrationEvent(
+            Type: ShellIntegrationEventType.CommandAccepted,
+            Timestamp: DateTimeOffset.Parse("2026-03-09T12:00:00+00:00"),
+            CommandText: "git status",
+            WorkingDirectory: @"C:\repo",
+            ExitCode: null,
+            Duration: null));
+        await controller.HandleShellIntegrationEventAsync(new ShellIntegrationEvent(
+            Type: ShellIntegrationEventType.CommandFinished,
+            Timestamp: DateTimeOffset.Parse("2026-03-09T12:00:03+00:00"),
+            CommandText: null,
+            WorkingDirectory: @"C:\repo",
+            ExitCode: 7,
+            Duration: TimeSpan.FromSeconds(3)));
+
+        Assert.Single(historyStore.Entries);
+        Assert.Equal(7, historyStore.Entries[0].ExitCode);
+        Assert.Equal(3000, historyStore.Entries[0].DurationMs);
+    }
+
+    [Fact]
+    public async Task HandleShellIntegrationEventAsync_WhenAcceptedMatchesPendingHeuristic_DoesNotCreateDuplicateEntry()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        var controller = CreateController(historyStore);
+        controller.SetShellIntegrationEnabled(true);
+        controller.HandleTextInput("git status");
+
+        await controller.HandleEnterAsync();
+        await controller.HandleShellIntegrationEventAsync(new ShellIntegrationEvent(
+            Type: ShellIntegrationEventType.CommandAccepted,
+            Timestamp: DateTimeOffset.Parse("2026-03-09T12:00:00+00:00"),
+            CommandText: "git status",
+            WorkingDirectory: @"C:\repo",
+            ExitCode: null,
+            Duration: null));
+        await controller.HandleShellIntegrationEventAsync(new ShellIntegrationEvent(
+            Type: ShellIntegrationEventType.CommandFinished,
+            Timestamp: DateTimeOffset.Parse("2026-03-09T12:00:01+00:00"),
+            CommandText: null,
+            WorkingDirectory: @"C:\repo",
+            ExitCode: 0,
+            Duration: TimeSpan.FromSeconds(1)));
+
+        Assert.Single(historyStore.Entries);
+        Assert.Equal(CommandCaptureSource.Heuristic, historyStore.Entries[0].Source);
+        Assert.Equal(0, historyStore.Entries[0].ExitCode);
+        Assert.Equal(1000, historyStore.Entries[0].DurationMs);
+    }
+
+    [Fact]
     public async Task HandleTextInput_WhenPinnedSnippetMatches_ShowsSnippetAsTopSuggestion()
     {
         var historyStore = new InMemoryHistoryStore();
@@ -301,7 +414,8 @@ public sealed class CommandAssistControllerTests
             ExitCode: 0,
             IsRemote: false,
             IsRedacted: false,
-            Source: CommandCaptureSource.Heuristic);
+            Source: CommandCaptureSource.Heuristic,
+            DurationMs: null);
     }
 
     private sealed class InMemoryHistoryStore : IHistoryStore
@@ -351,6 +465,22 @@ public sealed class CommandAssistControllerTests
             return Task.FromResult(true);
         }
 
+        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default)
+        {
+            int index = _entries.FindIndex(x => x.Id == entryId);
+            if (index < 0)
+            {
+                return Task.FromResult(false);
+            }
+
+            _entries[index] = _entries[index] with
+            {
+                ExitCode = exitCode,
+                DurationMs = durationMs ?? _entries[index].DurationMs
+            };
+            return Task.FromResult(true);
+        }
+
         public void Seed(params CommandHistoryEntry[] entries)
         {
             _entries.AddRange(entries);
@@ -396,6 +526,9 @@ public sealed class CommandAssistControllerTests
         public Task<bool> TryUpdateExitCodeAsync(string entryId, int? exitCode, CancellationToken cancellationToken = default)
             => Task.FromResult(false);
 
+        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+
         public Task WaitForLastSearchAsync() => _lastSearchTask;
     }
 
@@ -414,6 +547,9 @@ public sealed class CommandAssistControllerTests
             => Task.FromResult<IReadOnlyList<CommandHistoryEntry>>(Array.Empty<CommandHistoryEntry>());
 
         public Task<bool> TryUpdateExitCodeAsync(string entryId, int? exitCode, CancellationToken cancellationToken = default)
+            => Task.FromException<bool>(new InvalidOperationException("simulated write failure"));
+
+        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default)
             => Task.FromException<bool>(new InvalidOperationException("simulated write failure"));
     }
 

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
@@ -314,6 +314,35 @@ public sealed class CommandAssistControllerTests
     }
 
     [Fact]
+    public async Task UpdateSessionContext_WhenStructuredMarkersWereObserved_KeepsStructuredCaptureActive()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        var controller = CreateController(historyStore);
+        controller.SetShellIntegrationEnabled(true);
+        await controller.HandleShellIntegrationEventAsync(new ShellIntegrationEvent(
+            Type: ShellIntegrationEventType.PromptReady,
+            Timestamp: DateTimeOffset.Parse("2026-03-09T11:59:59+00:00"),
+            CommandText: null,
+            WorkingDirectory: @"C:\repo-a",
+            ExitCode: null,
+            Duration: null));
+
+        controller.UpdateSessionContext(
+            shellKind: "pwsh",
+            workingDirectory: @"C:\repo-b",
+            profileId: "profile-1",
+            sessionId: "session-1",
+            hostId: null,
+            isRemote: false,
+            isShellIntegrated: true);
+        controller.HandleTextInput("git status");
+
+        await controller.HandleEnterAsync();
+
+        Assert.Empty(historyStore.Entries);
+    }
+
+    [Fact]
     public async Task HandleTextInput_WhenPinnedSnippetMatches_ShowsSnippetAsTopSuggestion()
     {
         var historyStore = new InMemoryHistoryStore();

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistSuggestionEngineTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistSuggestionEngineTests.cs
@@ -116,7 +116,8 @@ public sealed class CommandAssistSuggestionEngineTests
             ExitCode: exitCode,
             IsRemote: false,
             IsRedacted: false,
-            Source: CommandCaptureSource.Heuristic);
+            Source: CommandCaptureSource.Heuristic,
+            DurationMs: null);
     }
 
     private static CommandSnippet CreateSnippet(string name, string commandText, bool isPinned)

--- a/tests/NovaTerminal.Tests/CommandAssist/HistorySuggestionEngineTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/HistorySuggestionEngineTests.cs
@@ -107,6 +107,7 @@ public sealed class HistorySuggestionEngineTests
             ExitCode: 0,
             IsRemote: false,
             IsRedacted: false,
-            Source: CommandCaptureSource.Heuristic);
+            Source: CommandCaptureSource.Heuristic,
+            DurationMs: null);
     }
 }

--- a/tests/NovaTerminal.Tests/CommandAssist/JsonHistoryStoreTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/JsonHistoryStoreTests.cs
@@ -112,6 +112,29 @@ public sealed class JsonHistoryStoreTests : IDisposable
         Assert.Equal(17, entries[0].ExitCode);
     }
 
+    [Fact]
+    public async Task TryUpdateExecutionResultAsync_PersistsDurationAcrossStoreInstances()
+    {
+        string filePath = Path.Combine(_tempRoot, "history.json");
+        var store = new JsonHistoryStore(filePath, maxEntries: 50);
+        CommandHistoryEntry entry = CreateEntry(
+            "git status",
+            executedAt: DateTimeOffset.Parse("2026-03-01T10:00:00+00:00"),
+            exitCode: null);
+
+        await store.AppendAsync(entry);
+
+        bool updated = await store.TryUpdateExecutionResultAsync(entry.Id, 0, 2500);
+
+        var reloaded = new JsonHistoryStore(filePath, maxEntries: 50);
+        IReadOnlyList<CommandHistoryEntry> entries = await reloaded.GetRecentAsync(10);
+
+        Assert.True(updated);
+        Assert.Single(entries);
+        Assert.Equal(0, entries[0].ExitCode);
+        Assert.Equal(2500, entries[0].DurationMs);
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_tempRoot))
@@ -137,6 +160,7 @@ public sealed class JsonHistoryStoreTests : IDisposable
             ExitCode: exitCode,
             IsRemote: false,
             IsRedacted: false,
-            Source: CommandCaptureSource.Heuristic);
+            Source: CommandCaptureSource.Heuristic,
+            DurationMs: null);
     }
 }

--- a/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/OrderedAsyncEventDispatcherTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/OrderedAsyncEventDispatcherTests.cs
@@ -1,0 +1,38 @@
+using NovaTerminal.CommandAssist.ShellIntegration.Runtime;
+
+namespace NovaTerminal.Tests.CommandAssist.ShellIntegration;
+
+public sealed class OrderedAsyncEventDispatcherTests
+{
+    [Fact]
+    public async Task EnqueueAsync_RunsWorkInSubmissionOrder()
+    {
+        var dispatcher = new OrderedAsyncEventDispatcher();
+        var order = new List<int>();
+        var firstCanComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task first = dispatcher.EnqueueAsync(async () =>
+        {
+            order.Add(1);
+            await firstCanComplete.Task;
+            order.Add(2);
+        });
+
+        Task second = dispatcher.EnqueueAsync(() =>
+        {
+            order.Add(3);
+            secondStarted.SetResult();
+            return Task.CompletedTask;
+        });
+
+        await Task.Delay(50);
+        Assert.Equal(new[] { 1 }, order);
+
+        firstCanComplete.SetResult();
+        await Task.WhenAll(first, second);
+        await secondStarted.Task;
+
+        Assert.Equal(new[] { 1, 2, 3 }, order);
+    }
+}

--- a/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/PowerShellBootstrapBuilderTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/PowerShellBootstrapBuilderTests.cs
@@ -1,0 +1,44 @@
+using NovaTerminal.CommandAssist.ShellIntegration.PowerShell;
+
+namespace NovaTerminal.Tests.CommandAssist.ShellIntegration;
+
+public sealed class PowerShellBootstrapBuilderTests : IDisposable
+{
+    private readonly string _tempRoot;
+
+    public PowerShellBootstrapBuilderTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), $"nova_command_assist_bootstrap_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempRoot);
+    }
+
+    [Fact]
+    public void BuildScript_ContainsExpectedLifecycleMarkers()
+    {
+        string script = PowerShellBootstrapBuilder.BuildScript();
+
+        Assert.Contains("]7;", script);
+        Assert.Contains("]133;A", script);
+        Assert.Contains("]133;B", script);
+        Assert.Contains("]133;C;", script);
+        Assert.Contains("]133;D;", script);
+    }
+
+    [Fact]
+    public void WriteScript_WritesBootstrapIntoRequestedDirectory()
+    {
+        string path = PowerShellBootstrapBuilder.WriteScript(_tempRoot);
+
+        Assert.True(File.Exists(path));
+        Assert.StartsWith(_tempRoot, path, StringComparison.OrdinalIgnoreCase);
+        Assert.EndsWith(".ps1", path, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+        {
+            Directory.Delete(_tempRoot, recursive: true);
+        }
+    }
+}

--- a/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/PowerShellShellIntegrationProviderTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/PowerShellShellIntegrationProviderTests.cs
@@ -1,0 +1,36 @@
+using NovaTerminal.CommandAssist.ShellIntegration.Contracts;
+using NovaTerminal.CommandAssist.ShellIntegration.PowerShell;
+
+namespace NovaTerminal.Tests.CommandAssist.ShellIntegration;
+
+public sealed class PowerShellShellIntegrationProviderTests
+{
+    [Fact]
+    public void CreateLaunchPlan_WhenPowerShellEnabled_ReturnsIntegratedPlan()
+    {
+        var provider = new PowerShellShellIntegrationProvider();
+
+        ShellIntegrationLaunchPlan plan = provider.CreateLaunchPlan(
+            shellCommand: "pwsh.exe",
+            shellArguments: "-NoLogo",
+            workingDirectory: @"C:\repo");
+
+        Assert.True(plan.IsIntegrated);
+        Assert.Equal("pwsh.exe", plan.ShellCommand);
+        Assert.Contains("-NoLogo", plan.ShellArguments);
+        Assert.Contains("-NoExit", plan.ShellArguments);
+        Assert.Contains("-File", plan.ShellArguments);
+        Assert.Contains(plan.BootstrapScriptPath!, plan.ShellArguments, StringComparison.OrdinalIgnoreCase);
+        Assert.NotNull(plan.BootstrapScriptPath);
+    }
+
+    [Fact]
+    public void CanIntegrate_WhenShellKindIsPwsh_ReturnsTrue()
+    {
+        var provider = new PowerShellShellIntegrationProvider();
+
+        bool supported = provider.CanIntegrate("pwsh", null);
+
+        Assert.True(supported);
+    }
+}

--- a/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/PowerShellShellIntegrationProviderTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/PowerShellShellIntegrationProviderTests.cs
@@ -33,4 +33,20 @@ public sealed class PowerShellShellIntegrationProviderTests
 
         Assert.True(supported);
     }
+
+    [Fact]
+    public void CreateLaunchPlan_WhenUserAlreadySuppliesFileScript_DoesNotClaimIntegration()
+    {
+        var provider = new PowerShellShellIntegrationProvider();
+
+        ShellIntegrationLaunchPlan plan = provider.CreateLaunchPlan(
+            shellCommand: "pwsh.exe",
+            shellArguments: "-File .\\user-script.ps1",
+            workingDirectory: @"C:\repo");
+
+        Assert.False(plan.IsIntegrated);
+        Assert.Equal("pwsh.exe", plan.ShellCommand);
+        Assert.Equal("-File .\\user-script.ps1", plan.ShellArguments);
+        Assert.Null(plan.BootstrapScriptPath);
+    }
 }

--- a/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/ShellIntegrationRegistryTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/ShellIntegrationRegistryTests.cs
@@ -1,0 +1,40 @@
+using NovaTerminal.CommandAssist.ShellIntegration.Contracts;
+using NovaTerminal.CommandAssist.ShellIntegration.PowerShell;
+using NovaTerminal.CommandAssist.ShellIntegration.Runtime;
+using NovaTerminal.Core;
+
+namespace NovaTerminal.Tests.CommandAssist.ShellIntegration;
+
+public sealed class ShellIntegrationRegistryTests
+{
+    [Fact]
+    public void GetProvider_ForPwshProfile_ReturnsPowerShellProvider()
+    {
+        var registry = new ShellIntegrationRegistry(new IShellIntegrationProvider[]
+        {
+            new PowerShellShellIntegrationProvider()
+        });
+
+        IShellIntegrationProvider? provider = registry.GetProvider(
+            shellKind: "pwsh",
+            profile: new TerminalProfile { Command = "pwsh.exe" });
+
+        Assert.NotNull(provider);
+        Assert.IsType<PowerShellShellIntegrationProvider>(provider);
+    }
+
+    [Fact]
+    public void GetProvider_ForUnsupportedShell_ReturnsNull()
+    {
+        var registry = new ShellIntegrationRegistry(new IShellIntegrationProvider[]
+        {
+            new PowerShellShellIntegrationProvider()
+        });
+
+        IShellIntegrationProvider? provider = registry.GetProvider(
+            shellKind: "posix",
+            profile: new TerminalProfile { Command = "/bin/bash" });
+
+        Assert.Null(provider);
+    }
+}

--- a/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/ShellIntegrationSettingsTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/ShellIntegrationSettingsTests.cs
@@ -1,0 +1,15 @@
+using NovaTerminal.Core;
+
+namespace NovaTerminal.Tests.CommandAssist.ShellIntegration;
+
+public sealed class ShellIntegrationSettingsTests
+{
+    [Fact]
+    public void TerminalSettings_DefaultsEnableShellIntegration()
+    {
+        var settings = new TerminalSettings();
+
+        Assert.True(settings.CommandAssistShellIntegrationEnabled);
+        Assert.True(settings.CommandAssistPowerShellIntegrationEnabled);
+    }
+}

--- a/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/ShellLifecycleTrackerTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/ShellLifecycleTrackerTests.cs
@@ -1,0 +1,94 @@
+using NovaTerminal.CommandAssist.ShellIntegration.Contracts;
+using NovaTerminal.CommandAssist.ShellIntegration.Runtime;
+
+namespace NovaTerminal.Tests.CommandAssist.ShellIntegration;
+
+public sealed class ShellLifecycleTrackerTests
+{
+    [Fact]
+    public void HandleCommandStartedThenFinished_EmitsStructuredEventsWithDuration()
+    {
+        DateTimeOffset now = new(2026, 3, 9, 12, 0, 0, TimeSpan.Zero);
+        var tracker = new ShellLifecycleTracker(() => now);
+        var events = new List<ShellIntegrationEvent>();
+        tracker.EventObserved += events.Add;
+
+        tracker.HandleWorkingDirectoryChanged("/repo");
+        tracker.HandleCommandStarted();
+        now = now.AddSeconds(2);
+        tracker.HandleCommandFinished(17);
+
+        Assert.Collection(
+            events,
+            evt =>
+            {
+                Assert.Equal(ShellIntegrationEventType.WorkingDirectoryChanged, evt.Type);
+                Assert.Equal("/repo", evt.WorkingDirectory);
+                Assert.Null(evt.ExitCode);
+                Assert.Null(evt.Duration);
+            },
+            evt =>
+            {
+                Assert.Equal(ShellIntegrationEventType.CommandStarted, evt.Type);
+                Assert.Equal("/repo", evt.WorkingDirectory);
+                Assert.Null(evt.ExitCode);
+                Assert.Null(evt.Duration);
+            },
+            evt =>
+            {
+                Assert.Equal(ShellIntegrationEventType.CommandFinished, evt.Type);
+                Assert.Equal("/repo", evt.WorkingDirectory);
+                Assert.Equal(17, evt.ExitCode);
+                Assert.Equal(TimeSpan.FromSeconds(2), evt.Duration);
+            });
+    }
+
+    [Fact]
+    public void HandleCommandFinishedWithoutStart_EmitsFinishedWithoutDuration()
+    {
+        var tracker = new ShellLifecycleTracker();
+        var events = new List<ShellIntegrationEvent>();
+        tracker.EventObserved += events.Add;
+
+        tracker.HandleWorkingDirectoryChanged("/repo");
+        tracker.HandleCommandFinished(0);
+
+        Assert.Collection(
+            events,
+            evt => Assert.Equal(ShellIntegrationEventType.WorkingDirectoryChanged, evt.Type),
+            evt =>
+            {
+                Assert.Equal(ShellIntegrationEventType.CommandFinished, evt.Type);
+                Assert.Equal("/repo", evt.WorkingDirectory);
+                Assert.Equal(0, evt.ExitCode);
+                Assert.Null(evt.Duration);
+            });
+    }
+
+    [Fact]
+    public void HandlePromptReadyAndCommandAccepted_EmitsStructuredEventsWithCurrentWorkingDirectory()
+    {
+        var tracker = new ShellLifecycleTracker();
+        var events = new List<ShellIntegrationEvent>();
+        tracker.EventObserved += events.Add;
+
+        tracker.HandleWorkingDirectoryChanged("/repo");
+        tracker.HandlePromptReady();
+        tracker.HandleCommandAccepted("git status");
+
+        Assert.Collection(
+            events,
+            evt => Assert.Equal(ShellIntegrationEventType.WorkingDirectoryChanged, evt.Type),
+            evt =>
+            {
+                Assert.Equal(ShellIntegrationEventType.PromptReady, evt.Type);
+                Assert.Equal("/repo", evt.WorkingDirectory);
+            },
+            evt =>
+            {
+                Assert.Equal(ShellIntegrationEventType.CommandAccepted, evt.Type);
+                Assert.Equal("/repo", evt.WorkingDirectory);
+                Assert.Equal("git status", evt.CommandText);
+            });
+    }
+}

--- a/tests/NovaTerminal.Tests/OscShellIntegrationTests.cs
+++ b/tests/NovaTerminal.Tests/OscShellIntegrationTests.cs
@@ -49,4 +49,44 @@ public sealed class OscShellIntegrationTests
         Assert.True(fired);
         Assert.Null(exitCode);
     }
+
+    [Fact]
+    public void Osc133A_RaisesPromptReady()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var parser = new AnsiParser(buffer);
+        bool fired = false;
+
+        parser.OnPromptReady += () => fired = true;
+        parser.Process("\x1b]133;A\x07");
+
+        Assert.True(fired);
+    }
+
+    [Fact]
+    public void Osc133C_WithBase64Command_RaisesCommandAccepted()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var parser = new AnsiParser(buffer);
+        string? acceptedCommand = null;
+
+        parser.OnCommandAccepted += command => acceptedCommand = command;
+        parser.Process("\x1b]133;C;Z2l0IHN0YXR1cw==\x07");
+
+        Assert.Equal("git status", acceptedCommand);
+    }
+
+    [Fact]
+    public void Osc133D_WithExitCodeAndDuration_RaisesDetailedCommandFinished()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var parser = new AnsiParser(buffer);
+        (int? ExitCode, long? DurationMs) result = default;
+
+        parser.OnCommandFinishedDetailed += (exitCode, durationMs) => result = (exitCode, durationMs);
+        parser.Process("\x1b]133;D;17;2450\x07");
+
+        Assert.Equal(17, result.ExitCode);
+        Assert.Equal(2450, result.DurationMs);
+    }
 }


### PR DESCRIPTION
## Summary
- add PowerShell-first Command Assist shell integration contracts, registry, lifecycle tracking, and bootstrap generation
- wire structured shell lifecycle events into Command Assist persistence with fallback and duplicate suppression
- add minimal OSC parser support for prompt-ready, command-accepted, and detailed command-finished markers

## Verification
- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "OscShellIntegrationTests|CommandAssistControllerTests|CommandAssistSuggestionEngineTests|HistorySuggestionEngineTests|JsonHistoryStoreTests|SecretsFilterTests|AlternateScreenTests|HeadlessUITests|ShellIntegration" --logger "console;verbosity=minimal"`
  - `67 passed, 0 failed`