### PR TITLE
Reduce macOS usage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJSON(github.event_name == 'pull_request' && '["windows-latest","ubuntu-latest"]' || '["windows-latest","ubuntu-latest","macos-latest"]') }}
+        os: ${{ fromJSON(github.event_name == 'workflow_dispatch' && '["windows-latest","ubuntu-latest","macos-latest"]' || '["windows-latest","ubuntu-latest"]') }}
     
     steps:
       - uses: actions/checkout@v4
@@ -82,7 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["windows-latest","ubuntu-latest","macos-latest"]') }}
+        os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["windows-latest","ubuntu-latest"]') }}
 
     steps:
       - uses: actions/checkout@v4
@@ -163,7 +163,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -220,7 +220,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -275,12 +275,6 @@ jobs:
           name: replay-snapshots-ubuntu-latest
           path: parity/linux
 
-      - name: Download snapshots (macOS)
-        uses: actions/download-artifact@v4
-        with:
-          name: replay-snapshots-macos-latest
-          path: parity/macos
-
       - name: Inspect downloaded parity artifacts
         run: |
           echo "Downloaded files:"
@@ -288,11 +282,10 @@ jobs:
           echo "Snapshot counts:"
           echo "windows=$(find parity/windows -type f -name '*.snap' | wc -l)"
           echo "linux=$(find parity/linux -type f -name '*.snap' | wc -l)"
-          echo "macos=$(find parity/macos -type f -name '*.snap' | wc -l)"
 
       - name: Compare snapshots for parity
         run: |
-          python3 tests/tools/compare_snapshots.py parity/windows parity/linux parity/macos
+          python3 tests/tools/compare_snapshots.py parity/windows parity/linux
 
   render_metrics_tests:
     name: Render Metrics (${{ matrix.os }})
@@ -303,7 +296,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       full_matrix:
-        description: "Run Windows/macOS stress jobs in addition to Linux"
+        description: "Run Windows stress jobs in addition to Linux"
         required: false
         default: false
         type: boolean
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest]
+        os: [windows-latest]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- remove macOS runners from normal CI and nightly stress workflows
- keep macOS only in the manual release-style publish path
- reduce GitHub Actions runner cost while preserving Windows and Linux coverage

## Changes
- ci.yml: remove macOS from unit, replay, PTY smoke, render metrics, and parity compare lanes
- ci.yml: keep macOS only for workflow_dispatch native/release publishing
- nightly.yml: remove macOS from the optional full nightly matrix
