### PR TITLE
Complete Command Assist post-merge polish and SSH fallback fixes

### DIFF
--- a/docs/plans/2026-03-10-command-assist-m4-2-prompt-adjacent-ux-design.md
+++ b/docs/plans/2026-03-10-command-assist-m4-2-prompt-adjacent-ux-design.md
@@ -1,0 +1,264 @@
+# Command Assist M4.2 Prompt-Adjacent UX Design
+
+Date: 2026-03-10
+Status: Approved design
+
+## Goal
+
+Replace the current bottom-docked Command Assist panel with a prompt-adjacent floating interaction model that preserves continuous typing flow.
+
+This change is a UX refactor, not a Command Assist domain rewrite.
+
+## Problem
+
+The current footer-style assist surface works functionally, but it competes with the bottom of the terminal where the user is already typing and reading output.
+
+Observed issues:
+- visual overlap with the active prompt area
+- too much eye travel away from the typed command
+- the panel feels like a second dashboard rather than an attached assistant
+- the bottom edge of the pane becomes visually crowded
+
+For a terminal-oriented product, this makes the assist feel heavier than it should.
+
+## Design Objective
+
+Optimize for continuous typing flow first.
+
+That means:
+- keep the user’s eyes close to the active command line
+- avoid resizing the pane or carving out a persistent footer
+- keep the assist visually light until the user explicitly asks for more
+- preserve the rule that assist content never renders into terminal grid content
+
+## Recommended UX Model
+
+Use a prompt-adjacent floating model with two layers:
+
+1. **Collapsed bubble**
+- small floating assist strip anchored near the prompt region
+- always lightweight
+- shows mode label, top suggestion or status, and compact hints
+
+2. **Expanded popup**
+- opens from the bubble when needed
+- shows result list, detail content, and helper states
+- used for search/help/fix and deeper suggestion browsing
+
+This replaces the bottom docked panel as the primary interaction surface.
+
+## Interaction Model
+
+### Suggest
+
+Default while typing.
+
+Behavior:
+- show only the collapsed bubble by default
+- open the popup only when the user browses, expands, or explicitly requests richer content
+
+This keeps typing flow fast and visually calm.
+
+### Search
+
+Behavior:
+- bubble plus popup
+- popup shows compact ranked results
+- remains close to the prompt region
+
+### Help
+
+Behavior:
+- explicit mode
+- popup opens with command docs/examples/recipes
+- more detail-first than list-first
+
+### Fix
+
+Behavior:
+- high-confidence failures may auto-open the popup
+- lower-confidence failures should show a subtle prompt-adjacent affordance rather than forcing a large panel open
+
+## Placement Strategy
+
+Placement should be stable and predictable, not clever.
+
+### Anchor model
+
+Do not attach to exact shell glyph geometry.
+
+Instead:
+- derive a prompt-region hint from the visible cursor row and terminal cell metrics
+- convert that into a safe pane-local anchor rectangle
+- clamp placement inside the pane with padding
+
+This keeps the assist close to the prompt without making it depend on perfect shell-line reconstruction.
+
+### Default placement
+
+- place the bubble slightly above the prompt region
+- left-align it near the active input row
+- keep it inside the pane bounds with safe margins
+
+### Popup placement
+
+Preferred order:
+1. expand upward from the bubble
+2. if insufficient room, expand downward
+3. if vertical space is poor, use a side-floating popup anchored to the bubble
+
+Never resize the terminal layout to make room.
+
+## Degraded Layouts
+
+The assist must remain usable in constrained panes.
+
+### Narrow panes
+
+- bubble keeps only mode plus top suggestion
+- hide verbose hotkey text
+- popup becomes single-column and narrower
+
+### Short panes
+
+- keep only the collapsed bubble by default
+- require explicit expansion for richer content
+
+### Unreliable anchor
+
+If prompt-region anchoring is uncertain:
+- snap to a stable lower-right or lower-left safe zone inside the pane
+- prefer stability over almost-correct tracking
+
+## Visual Behavior
+
+### Bubble
+
+- compact
+- soft contrast
+- subtle shadow/border
+- minimum motion
+- visually attached to the typing region, not the whole pane
+
+### Popup
+
+- compact floating card
+- bounded size
+- internal scrolling if content exceeds limits
+- not a full-height sheet or footer
+
+### Motion
+
+- short fade/slide only
+- no dramatic movement
+- the UI should feel attached to the prompt, not animated independently
+
+## Architecture Impact
+
+This should reuse the current Command Assist domain/controller stack.
+
+Keep:
+- `CommandAssistController`
+- provider interfaces and helper services
+- pane-local ownership in `TerminalPane`
+- alt-screen hide rules
+- existing key routing model
+
+Add:
+- `CommandAssistAnchorCalculator`
+- `CommandAssistBubbleView`
+- `CommandAssistBubbleViewModel`
+- `CommandAssistPopupView`
+- `CommandAssistPopupViewModel`
+
+Possible adapter:
+- a thin pane-local presentation state object that maps controller state into bubble/popup state without moving domain logic into the view
+
+## Responsibilities
+
+### Controller
+
+Still owns:
+- mode
+- results
+- selection
+- help/fix/search logic
+
+Should not own:
+- pixel placement
+- popup orientation
+- pane geometry decisions
+
+### TerminalPane
+
+Owns:
+- overlay composition
+- passing pane bounds / terminal metrics to placement logic
+- alt-screen visibility
+
+### Anchor calculator
+
+Owns:
+- prompt-region estimate
+- bubble rectangle
+- popup rectangle
+- fallback placement rules
+
+## Boundaries
+
+These remain unchanged:
+- VT parser
+- renderer
+- terminal buffer/grid behavior
+- PTY transport
+- shell integration contracts
+
+The refactor must remain App/Avalonia-side.
+
+## Risks
+
+### Technical
+
+- overfitting placement to exact cursor geometry and creating instability
+- popup positioning bugs in narrow or tiny panes
+- regressions in keyboard ownership between collapsed and expanded states
+
+### UX
+
+- popup appearing too often and still feeling intrusive
+- bubble becoming too dense with hotkey text
+- inconsistent placement if fallback rules are not strict
+
+### Mitigations
+
+- use prompt-region estimates, not exact shell reconstruction
+- design stable fallback positions
+- keep the bubble minimal
+- open the popup only when needed
+- test narrow panes, short panes, and alt-screen transitions explicitly
+
+## Rollout Recommendation
+
+Implement in two phases:
+
+### M4.2
+
+- replace the footer panel with prompt-adjacent bubble + popup
+- preserve existing controller and provider behavior
+- keep behavior changes minimal outside visual presentation and placement
+
+### M4.3
+
+- placement and density tuning
+- refine auto-open policy for popup
+- narrow/short pane polish
+
+## Definition Of Done
+
+M4.2 is complete when:
+- the bottom-docked assist panel is no longer the default interaction surface
+- a prompt-adjacent bubble appears near the active input region
+- richer content opens in a floating popup rather than a footer
+- no pane layout resizing occurs for assist UI
+- alt-screen still hides assist immediately
+- all content remains outside the terminal grid

--- a/docs/plans/2026-03-10-command-assist-m4-2-prompt-adjacent-ux-implementation-plan.md
+++ b/docs/plans/2026-03-10-command-assist-m4-2-prompt-adjacent-ux-implementation-plan.md
@@ -1,0 +1,500 @@
+# Command Assist M4.2 Prompt-Adjacent UX Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Refactor Command Assist from a bottom-docked footer panel into a prompt-adjacent floating bubble and popup while preserving the existing controller, helper, and shell-integration behavior.
+
+**Architecture:** Keep the current `CommandAssistController` and provider stack intact, and replace only the presentation/placement layer in `TerminalPane` and Avalonia views. Add a pane-local anchor calculator that computes safe bubble and popup rectangles from terminal metrics and a prompt-region estimate.
+
+**Tech Stack:** C#, .NET 10, Avalonia, xUnit, existing `NovaTerminal.App.CommandAssist` subsystem, pane-local overlay composition in `TerminalPane`.
+
+---
+
+### Task 1: Lock prompt-adjacent placement behavior with tests
+
+**Files:**
+- Create: `tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs`
+- Create: `src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs`
+
+**Step 1: Write the failing tests**
+
+Add tests for:
+- bubble placement above prompt region by default
+- popup flips when insufficient room above
+- placement clamps inside pane bounds
+- fallback anchor for uncertain prompt placement
+
+```csharp
+[Fact]
+public void Calculate_WhenSpaceExistsAbovePrompt_PlacesBubbleAbovePrompt()
+{
+    var calculator = new CommandAssistAnchorCalculator();
+
+    CommandAssistAnchorLayout layout = calculator.Calculate(new CommandAssistAnchorRequest(
+        PaneWidth: 1000,
+        PaneHeight: 700,
+        CellHeight: 18,
+        CursorVisualRow: 34,
+        VisibleRows: 36,
+        BubbleWidth: 420,
+        BubbleHeight: 36,
+        PopupWidth: 520,
+        PopupHeight: 220));
+
+    Assert.True(layout.BubbleRect.Bottom < layout.PromptRect.Top);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "CommandAssistAnchorCalculatorTests"
+```
+
+Expected: FAIL with missing calculator/layout types.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+- request/result records
+- deterministic placement logic
+- safe clamping rules
+
+Avoid any controller dependencies.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "CommandAssistAnchorCalculatorTests"
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
+git commit -m "Add Command Assist prompt anchor calculator"
+```
+
+### Task 2: Split the footer view model into bubble and popup state
+
+**Files:**
+- Create: `src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistBubbleViewModel.cs`
+- Create: `src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistPopupViewModel.cs`
+- Modify: `src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistBarViewModel.cs`
+- Modify: `tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs`
+
+**Step 1: Write the failing tests**
+
+Add tests for:
+- compact bubble text/state binding
+- popup-only visibility when expanded content is needed
+- hidden popup when suggest mode is collapsed
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "CommandAssistLayoutTests"
+```
+
+Expected: FAIL because the current single footer viewmodel cannot express bubble/popup split.
+
+**Step 3: Write minimal implementation**
+
+Refactor viewmodel state so:
+- the existing controller can still set mode/results
+- presentation state can be exposed as bubble state plus popup state
+- no ranking/help logic moves into the viewmodel
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "CommandAssistLayoutTests"
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistBubbleViewModel.cs src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistPopupViewModel.cs src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistBarViewModel.cs tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs
+git commit -m "Split Command Assist footer state into bubble and popup"
+```
+
+### Task 3: Add floating bubble and popup views
+
+**Files:**
+- Create: `src/NovaTerminal.App/CommandAssist/Views/CommandAssistBubbleView.axaml`
+- Create: `src/NovaTerminal.App/CommandAssist/Views/CommandAssistBubbleView.axaml.cs`
+- Create: `src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml`
+- Create: `src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml.cs`
+- Modify: `tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs`
+
+**Step 1: Write the failing tests**
+
+Add tests for:
+- bubble view exists and binds collapsed state
+- popup view exists and binds result list/detail state
+- popup remains separate from terminal layout rows
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "CommandAssistLayoutTests"
+```
+
+Expected: FAIL because views do not exist.
+
+**Step 3: Write minimal implementation**
+
+Build:
+- compact bubble view
+- floating popup view
+- no bottom dock row assumptions
+
+Keep styling intentionally light and compact.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "CommandAssistLayoutTests"
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/CommandAssist/Views/CommandAssistBubbleView.axaml src/NovaTerminal.App/CommandAssist/Views/CommandAssistBubbleView.axaml.cs src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml.cs tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs
+git commit -m "Add Command Assist floating bubble and popup views"
+```
+
+### Task 4: Replace footer hosting with overlay composition in TerminalPane
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml`
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs`
+- Modify: `tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs`
+
+**Step 1: Write the failing tests**
+
+Add tests for:
+- no dedicated bottom assist row remains in `TerminalPane`
+- assist views are hosted as overlays in the terminal layer
+- showing the assist does not change pane layout height allocation
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "CommandAssistLayoutTests"
+```
+
+Expected: FAIL because the footer-based host is still present.
+
+**Step 3: Write minimal implementation**
+
+Modify `TerminalPane` to host:
+- bubble overlay
+- popup overlay
+
+Do not use an `Auto` row for assist content.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "CommandAssistLayoutTests"
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Controls/TerminalPane.axaml src/NovaTerminal.App/Controls/TerminalPane.axaml.cs tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs
+git commit -m "Host Command Assist as prompt-adjacent overlays"
+```
+
+### Task 5: Feed terminal metrics and prompt hints into placement logic
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Core/TerminalView.cs`
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs`
+- Modify: `tests/NovaTerminal.Tests/CommandAssist/TerminalViewKeyHandlingTests.cs`
+- Modify: `tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs`
+
+**Step 1: Write the failing tests**
+
+Add tests for:
+- pane can derive a prompt-region estimate from visible cursor row and cell metrics
+- anchor updates when metrics or visible cursor placement change
+- no dependence on terminal buffer content mutation
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "CommandAssistAnchorCalculatorTests|TerminalViewKeyHandlingTests"
+```
+
+Expected: FAIL because prompt-region feed is not wired into placement yet.
+
+**Step 3: Write minimal implementation**
+
+Expose only the minimal pane-side information needed for anchor calculation:
+- visible cursor row hint
+- current cell metrics
+- pane bounds
+
+Keep this App-side and non-invasive.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "CommandAssistAnchorCalculatorTests|TerminalViewKeyHandlingTests"
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Core/TerminalView.cs src/NovaTerminal.App/Controls/TerminalPane.axaml.cs tests/NovaTerminal.Tests/CommandAssist/TerminalViewKeyHandlingTests.cs tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs
+git commit -m "Wire prompt-region hints into Command Assist placement"
+```
+
+### Task 6: Preserve current Command Assist behavior with collapsed/expanded states
+
+**Files:**
+- Modify: `src/NovaTerminal.App/CommandAssist/Application/CommandAssistController.cs`
+- Modify: `tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs`
+
+**Step 1: Write the failing tests**
+
+Add tests for:
+- suggest mode stays collapsed by default while typing
+- popup opens when browsing or explicit help/search/fix requires richer content
+- help/search/fix still populate the expanded content correctly
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "CommandAssistControllerTests"
+```
+
+Expected: FAIL because collapsed/expanded presentation state is not expressed yet.
+
+**Step 3: Write minimal implementation**
+
+Add presentation-state flags only:
+- collapsed bubble visible
+- popup visible
+- popup auto-open policy per mode
+
+Do not rework ranking/help/fix logic.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "CommandAssistControllerTests"
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/CommandAssist/Application/CommandAssistController.cs tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
+git commit -m "Add collapsed and expanded Command Assist presentation states"
+```
+
+### Task 7: Add constrained-pane fallback behavior
+
+**Files:**
+- Modify: `src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs`
+- Modify: `tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs`
+- Modify: `tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs`
+
+**Step 1: Write the failing tests**
+
+Add tests for:
+- narrow pane reduces bubble density
+- short pane keeps bubble but constrains popup
+- unreliable anchor falls back to stable lower safe zone
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "CommandAssistAnchorCalculatorTests|CommandAssistLayoutTests"
+```
+
+Expected: FAIL because degraded placement/layout rules are not implemented.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+- narrow-pane clamping
+- short-pane popup bounds
+- stable fallback anchor placement
+
+Keep rules explicit and deterministic.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "CommandAssistAnchorCalculatorTests|CommandAssistLayoutTests"
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs
+git commit -m "Add constrained-pane fallbacks for Command Assist overlays"
+```
+
+### Task 8: Preserve key ownership and alt-screen behavior
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs`
+- Modify: `tests/NovaTerminal.Tests/CommandAssist/CommandAssistKeyRouterTests.cs`
+- Modify: `tests/NovaTerminal.Tests/CommandAssist/TerminalPaneCommandAssistShortcutTests.cs`
+- Modify: `tests/NovaTerminal.Tests/CommandAssist/AlternateScreenTests.cs`
+
+**Step 1: Write the failing tests**
+
+Add tests for:
+- assist-owned keys still route correctly with bubble/popup split
+- alt-screen hides both bubble and popup immediately
+- popup visibility does not change shell key leakage behavior
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "CommandAssistKeyRouterTests|TerminalPaneCommandAssistShortcutTests|AlternateScreenTests"
+```
+
+Expected: FAIL if the refactor broke routing or hide rules.
+
+**Step 3: Write minimal implementation**
+
+Adjust pane routing only as needed to:
+- treat collapsed and expanded states correctly
+- keep shell leakage blocked when the assist owns the interaction
+- preserve the existing alt-screen hard hide
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "CommandAssistKeyRouterTests|TerminalPaneCommandAssistShortcutTests|AlternateScreenTests"
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Controls/TerminalPane.axaml.cs tests/NovaTerminal.Tests/CommandAssist/CommandAssistKeyRouterTests.cs tests/NovaTerminal.Tests/CommandAssist/TerminalPaneCommandAssistShortcutTests.cs tests/NovaTerminal.Tests/CommandAssist/AlternateScreenTests.cs
+git commit -m "Preserve Command Assist routing and alt-screen behavior"
+```
+
+### Task 9: Run targeted regressions and compile
+
+**Files:**
+- Modify: none unless regressions are found
+
+**Step 1: Run focused tests**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "CommandAssist|ShellIntegration|AlternateScreen|HeadlessUI" --logger "console;verbosity=minimal"
+```
+
+Expected: PASS
+
+**Step 2: Compile the App project**
+
+Run:
+
+```bash
+dotnet msbuild src/NovaTerminal.App/NovaTerminal.App.csproj /t:Compile /p:Configuration=Release /v:minimal
+```
+
+Expected: Build succeeded
+
+**Step 3: Fix any regressions**
+
+If anything fails, fix the smallest issue and rerun the same commands until clean.
+
+**Step 4: Commit stabilization**
+
+```bash
+git add -A
+git commit -m "Finalize prompt-adjacent Command Assist UX"
+```
+
+### Task 10: Prepare PR summary
+
+**Files:**
+- Modify: none required
+
+**Step 1: Gather the final diff**
+
+Run:
+
+```bash
+git diff --stat main...HEAD
+git log --oneline main..HEAD
+```
+
+**Step 2: Write the PR notes**
+
+Include:
+- footer removed as primary interaction model
+- prompt-adjacent bubble + popup added
+- no VT/render changes
+- no terminal layout resizing
+- alt-screen behavior preserved
+
+**Step 3: Push and open PR**
+
+Run:
+
+```bash
+git push -u origin <branch-name>
+```
+
+Then open the PR with the summary above.

--- a/docs/plans/2026-03-11-command-assist-m4-3-auto-open-policy-plan.md
+++ b/docs/plans/2026-03-11-command-assist-m4-3-auto-open-policy-plan.md
@@ -1,0 +1,55 @@
+# Command Assist M4.3 Auto-Open Policy Plan
+
+Date: 2026-03-11
+Status: In progress
+
+## Goal
+
+Refine popup auto-open behavior so Command Assist stays lightweight near the prompt and only expands when richer content is warranted.
+
+## Scope
+
+In scope:
+- popup visibility policy in `CommandAssistController`
+- bubble vs popup presentation mapping in `CommandAssistBarViewModel`
+- deterministic controller and layout tests for the refined policy
+
+Out of scope:
+- anchor geometry changes
+- VT/render/buffer changes
+- new providers or new terminal shortcuts
+
+## Policy
+
+### Suggest
+
+- bubble visible while typing or after paste
+- popup stays closed by default
+- popup opens when the user browses suggestions with assist-owned navigation
+
+### Search
+
+- explicit history search opens the popup immediately
+- popup remains explicit rather than inferred from mode label alone
+
+### Help
+
+- explicit help opens the popup immediately
+
+### Fix
+
+- high-confidence fix results open the popup immediately
+- low-confidence fix results show a collapsed bubble affordance instead of staying fully dormant
+- browsing low-confidence fix suggestions opens the popup
+
+## Implementation Notes
+
+- remove the `mode != Suggest` fallback that currently forces popup visibility in `CommandAssistBarViewModel`
+- make the controller set `IsPopupOpen` explicitly for every mode transition
+- keep assist-owned key routing unchanged for now; browsing already exists and is sufficient to trigger expansion
+
+## Verification
+
+- `CommandAssistControllerTests`
+- `CommandAssistLayoutTests`
+- `TerminalPaneCommandAssistShortcutTests`

--- a/docs/plans/2026-03-11-command-assist-m4-3-placement-density-plan.md
+++ b/docs/plans/2026-03-11-command-assist-m4-3-placement-density-plan.md
@@ -1,0 +1,44 @@
+# Command Assist M4.3 Placement And Density Plan
+
+Date: 2026-03-11
+Status: In progress
+
+## Goal
+
+Tune prompt-adjacent placement so the bubble and popup feel lighter in medium panes and remain stable in short panes.
+
+## Scope
+
+In scope:
+- responsive bubble and popup target sizing in `TerminalPane`
+- explicit side-floating popup fallback in `CommandAssistAnchorCalculator`
+- updated compact-density thresholds for the bubble
+- deterministic anchor and layout tests
+
+Out of scope:
+- controller mode changes
+- VT/render/core terminal changes
+- major popup view restructuring
+
+## Intended Behavior
+
+### Medium panes
+
+- do not always request the maximum `420/520` widths
+- scale the bubble and popup down toward the pane width so they feel attached to the prompt instead of pane-sized
+
+### Narrow panes
+
+- trigger compact bubble density earlier
+- keep the bubble readable by hiding query text when width pressure is real, not only at the smallest breakpoint
+
+### Short panes
+
+- if the popup cannot fit meaningfully above or below the bubble, place it beside the bubble when horizontal room exists
+- prefer a stable side-floating card over a vertically clamped card that crowds the prompt
+
+## Verification
+
+- `CommandAssistAnchorCalculatorTests`
+- `CommandAssistLayoutTests`
+- full `CommandAssist` filtered run after implementation

--- a/docs/plans/2026-03-11-command-assist-ssh-conservative-fallback-design.md
+++ b/docs/plans/2026-03-11-command-assist-ssh-conservative-fallback-design.md
@@ -1,0 +1,64 @@
+# Command Assist SSH Conservative Fallback Design
+
+Date: 2026-03-11
+Status: Approved
+
+## Goal
+
+Keep Command Assist visually close to the active input line in SSH heuristic sessions without claiming that the remote shell is integrated or that the prompt row is fully trustworthy.
+
+## Problem
+
+SSH sessions currently set `HasReliablePromptAnchor = false`, which avoids overlaps with login banners and prompt redraw noise, but it forces the bubble into a static lower safe zone. In stable remote shells this makes the UI feel detached from the prompt and input line.
+
+## Constraints
+
+- Keep Command Assist separate from terminal core logic.
+- Do not add shell-specific integration for SSH in this slice.
+- Preserve the conservative behavior that avoids anchoring directly to untrusted remote prompt metadata.
+- Keep popup behavior unchanged unless required by the new fallback placement.
+
+## Approach
+
+Add a second fallback placement mode for unreliable prompt anchors:
+
+- Keep `UsesPromptAnchor = false` for SSH heuristic sessions.
+- Continue using the existing lower safe zone when the cursor is near the top of the pane or there is not enough vertical room.
+- When the visible cursor row is in a stable lower region of the pane, place the bubble in a conservative band near that cursor row instead of at the pane bottom.
+- Keep explicit clearance from the cursor row so the bubble does not sit on top of typed input.
+
+This preserves the “do not trust SSH prompt metadata” policy while still making the UI feel prompt-adjacent once the session has settled.
+
+## Intended Behavior
+
+### Stable SSH prompt near the bottom
+
+- Bubble appears above the active input area.
+- Bubble remains visually near the cursor line.
+- Popup positioning still follows the existing calculator logic relative to the bubble.
+
+### SSH session near banners or early startup
+
+- Bubble stays in the lower safe zone.
+- No direct anchoring to the cursor row while the prompt is still too high in the pane.
+
+### Non-SSH integrated shells
+
+- No behavioral change.
+- Existing prompt-adjacent anchor rules remain authoritative.
+
+## Files
+
+- Modify: `src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs`
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs`
+- Modify: `tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs`
+- Modify: `tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs`
+
+## Verification
+
+- Add deterministic calculator coverage for unreliable-prompt cursor-band placement.
+- Add pane-level SSH layout coverage for:
+  - settled cursor near bottom => bubble near input
+  - high cursor near top => lower safe-zone fallback
+- Run focused `CommandAssist` tests.
+- Run full `NovaTerminal.Tests` suite.

--- a/docs/plans/2026-03-11-command-assist-ssh-conservative-fallback-plan.md
+++ b/docs/plans/2026-03-11-command-assist-ssh-conservative-fallback-plan.md
@@ -1,0 +1,122 @@
+# Command Assist SSH Conservative Fallback Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Keep Command Assist visually near the input line in SSH heuristic sessions without trusting remote prompt anchors.
+
+**Architecture:** Extend the app-layer anchor calculator with a second fallback mode for unreliable prompt anchors. `TerminalPane` will continue to classify SSH heuristic sessions as untrusted, but it will pass the visible cursor row through so the calculator can place the bubble in a conservative cursor-adjacent band when the pane looks settled.
+
+**Tech Stack:** C#, Avalonia, xUnit, existing Command Assist layout tests.
+
+---
+
+### Task 1: Add failing calculator tests for the SSH cursor-band fallback
+
+**Files:**
+- Modify: `tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs`
+
+**Step 1: Write the failing test**
+
+- Add one test that passes `HasReliablePromptAnchor: false` with a lower-half `CursorVisualRow` and asserts:
+  - `UsesPromptAnchor == false`
+  - `BubbleRect.Bottom` is clearly above the fallback prompt row
+  - `BubbleRect.Bottom` is higher than the old lower safe-zone placement
+- Add one test that passes `HasReliablePromptAnchor: false` with a top-of-pane `CursorVisualRow` and asserts the bubble remains in the lower safe zone.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~CommandAssistAnchorCalculatorTests"
+```
+
+Expected: FAIL because the current unreliable-anchor path always uses the static lower safe zone.
+
+### Task 2: Implement the calculator fallback
+
+**Files:**
+- Modify: `src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs`
+
+**Step 1: Write minimal implementation**
+
+- Add a cursor-band fallback path for `HasReliablePromptAnchor == false`.
+- Use the visible cursor row only when it is in a stable lower region of the pane.
+- Keep the existing lower safe-zone fallback when the cursor is too high or the computed bubble would crowd the pane.
+- Do not change popup direction logic except through the new bubble rect.
+
+**Step 2: Run tests to verify they pass**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~CommandAssistAnchorCalculatorTests"
+```
+
+Expected: PASS.
+
+### Task 3: Add failing pane-level SSH layout tests
+
+**Files:**
+- Modify: `tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs`
+
+**Step 1: Write the failing test**
+
+- Add one pane-level SSH test where the terminal cursor is near the bottom and assert the bubble is positioned near the input line rather than the lower safe-zone baseline.
+- Keep the existing SSH top-region test and tighten it if needed so it still proves the safe-zone fallback remains conservative.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~CommandAssistLayoutTests"
+```
+
+Expected: FAIL on the new settled-SSH case before `TerminalPane` feeds the calculator correctly.
+
+### Task 4: Wire the pane into the new fallback
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs`
+
+**Step 1: Write minimal implementation**
+
+- Keep `IsCommandAssistPromptAnchorReliable` conservative for SSH.
+- Ensure the current visible cursor row and metrics are still sent to the calculator for unreliable anchors.
+- Avoid changing controller behavior or popup open policy.
+
+**Step 2: Run pane tests**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~CommandAssistLayoutTests|FullyQualifiedName~CommandAssistAnchorCalculatorTests"
+```
+
+Expected: PASS.
+
+### Task 5: Verify Command Assist and full suite
+
+**Files:**
+- No code changes expected.
+
+**Step 1: Run focused Command Assist tests**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~NovaTerminal.Tests.CommandAssist"
+```
+
+Expected: PASS.
+
+**Step 2: Run full suite**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release
+```
+
+Expected: PASS.

--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
@@ -1,0 +1,130 @@
+using System;
+using Avalonia;
+
+namespace NovaTerminal.CommandAssist.Application;
+
+public sealed class CommandAssistAnchorCalculator
+{
+    private const double PanePadding = 12;
+    private const double VerticalGap = 8;
+    private const double MinimumPromptWidth = 120;
+
+    public CommandAssistAnchorLayout Calculate(CommandAssistAnchorRequest request)
+    {
+        double paneWidth = Math.Max(1, request.PaneWidth);
+        double paneHeight = Math.Max(1, request.PaneHeight);
+        double availableWidth = Math.Max(1, paneWidth - (PanePadding * 2));
+        double availableHeight = Math.Max(1, paneHeight - (PanePadding * 2));
+        double promptHeight = Math.Max(1, request.CellHeight);
+        double bubbleWidth = Math.Min(Math.Max(1, request.BubbleWidth), availableWidth);
+        double bubbleHeight = Math.Min(Math.Max(1, request.BubbleHeight), availableHeight);
+        double popupWidth = Math.Min(Math.Max(1, request.PopupWidth), availableWidth);
+        double popupHeight = Math.Min(Math.Max(1, request.PopupHeight), availableHeight);
+        bool useCompactBubbleLayout = paneWidth <= 480 || request.BubbleWidth > availableWidth;
+        bool usesPromptAnchor = request.HasReliablePromptAnchor &&
+                                request.VisibleRows > 0 &&
+                                request.CursorVisualRow >= 0 &&
+                                request.CellHeight > 0;
+
+        Rect promptRect = usesPromptAnchor
+            ? CreatePromptRect(request, paneWidth, paneHeight, promptHeight)
+            : CreateFallbackPromptRect(paneWidth, paneHeight, promptHeight);
+
+        Rect bubbleRect = usesPromptAnchor
+            ? CreateBubbleAbovePrompt(promptRect, bubbleWidth, bubbleHeight, paneWidth, paneHeight)
+            : CreateFallbackBubbleRect(bubbleWidth, bubbleHeight, paneWidth, paneHeight);
+
+        double upwardTop = bubbleRect.Top - VerticalGap - popupHeight;
+        bool canPlacePopupUpward = upwardTop >= PanePadding;
+        CommandAssistPopupDirection popupDirection = canPlacePopupUpward
+            ? CommandAssistPopupDirection.Upward
+            : CommandAssistPopupDirection.Downward;
+
+        double popupY = popupDirection == CommandAssistPopupDirection.Upward
+            ? upwardTop
+            : bubbleRect.Bottom + VerticalGap;
+        double popupX = bubbleRect.X;
+        Rect popupRect = ClampRect(new Rect(popupX, popupY, popupWidth, popupHeight), paneWidth, paneHeight);
+
+        return new CommandAssistAnchorLayout(promptRect, bubbleRect, popupRect, popupDirection, usesPromptAnchor, useCompactBubbleLayout);
+    }
+
+    private static Rect CreatePromptRect(
+        CommandAssistAnchorRequest request,
+        double paneWidth,
+        double paneHeight,
+        double promptHeight)
+    {
+        double promptWidth = Math.Min(Math.Max(MinimumPromptWidth, request.BubbleWidth * 0.5), paneWidth - (PanePadding * 2));
+        double promptY = PanePadding + (request.CursorVisualRow * request.CellHeight);
+        Rect promptRect = new(PanePadding, promptY, promptWidth, promptHeight);
+        return ClampRect(promptRect, paneWidth, paneHeight);
+    }
+
+    private static Rect CreateFallbackPromptRect(double paneWidth, double paneHeight, double promptHeight)
+    {
+        double promptWidth = Math.Min(Math.Max(MinimumPromptWidth, paneWidth * 0.35), paneWidth - (PanePadding * 2));
+        double promptY = paneHeight - PanePadding - promptHeight;
+        return ClampRect(new Rect(PanePadding, promptY, promptWidth, promptHeight), paneWidth, paneHeight);
+    }
+
+    private static Rect CreateBubbleAbovePrompt(
+        Rect promptRect,
+        double bubbleWidth,
+        double bubbleHeight,
+        double paneWidth,
+        double paneHeight)
+    {
+        double bubbleX = promptRect.X;
+        double bubbleY = promptRect.Top - VerticalGap - bubbleHeight;
+        return ClampRect(new Rect(bubbleX, bubbleY, bubbleWidth, bubbleHeight), paneWidth, paneHeight);
+    }
+
+    private static Rect CreateFallbackBubbleRect(
+        double bubbleWidth,
+        double bubbleHeight,
+        double paneWidth,
+        double paneHeight)
+    {
+        double bubbleX = paneWidth - PanePadding - bubbleWidth;
+        double bubbleY = paneHeight - PanePadding - bubbleHeight;
+        return ClampRect(new Rect(bubbleX, bubbleY, bubbleWidth, bubbleHeight), paneWidth, paneHeight);
+    }
+
+    private static Rect ClampRect(Rect rect, double paneWidth, double paneHeight)
+    {
+        double maxWidth = Math.Max(1, paneWidth - (PanePadding * 2));
+        double maxHeight = Math.Max(1, paneHeight - (PanePadding * 2));
+        double width = Math.Min(rect.Width, maxWidth);
+        double height = Math.Min(rect.Height, maxHeight);
+        double x = Math.Clamp(rect.X, PanePadding, Math.Max(PanePadding, paneWidth - PanePadding - width));
+        double y = Math.Clamp(rect.Y, PanePadding, Math.Max(PanePadding, paneHeight - PanePadding - height));
+        return new Rect(x, y, width, height);
+    }
+}
+
+public sealed record CommandAssistAnchorRequest(
+    double PaneWidth,
+    double PaneHeight,
+    double CellHeight,
+    int CursorVisualRow,
+    int VisibleRows,
+    double BubbleWidth,
+    double BubbleHeight,
+    double PopupWidth,
+    double PopupHeight,
+    bool HasReliablePromptAnchor = true);
+
+public sealed record CommandAssistAnchorLayout(
+    Rect PromptRect,
+    Rect BubbleRect,
+    Rect PopupRect,
+    CommandAssistPopupDirection PopupDirection,
+    bool UsesPromptAnchor,
+    bool UseCompactBubbleLayout);
+
+public enum CommandAssistPopupDirection
+{
+    Upward,
+    Downward,
+}

--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
@@ -6,7 +6,8 @@ namespace NovaTerminal.CommandAssist.Application;
 public sealed class CommandAssistAnchorCalculator
 {
     private const double PanePadding = 12;
-    private const double VerticalGap = 8;
+    private const double PromptBubbleGap = 4;
+    private const double BubblePopupGap = 8;
     private const double HorizontalGap = 12;
     private const double MinimumPromptWidth = 120;
     private const double CompactBubbleWidthThreshold = 320;
@@ -36,13 +37,13 @@ public sealed class CommandAssistAnchorCalculator
             : CreateFallbackPromptRect(paneWidth, paneHeight, promptHeight);
 
         Rect bubbleRect = usesPromptAnchor
-            ? CreateBubbleAbovePrompt(promptRect, bubbleWidth, bubbleHeight, paneWidth, paneHeight)
-            : CreateFallbackBubbleRect(bubbleWidth, bubbleHeight, paneWidth, paneHeight);
+            ? CreateBubbleAdjacentToPrompt(promptRect, bubbleWidth, bubbleHeight, paneWidth, paneHeight)
+            : CreateFallbackBubbleRect(promptRect, bubbleWidth, bubbleHeight, paneWidth, paneHeight);
 
-        double spaceAbove = Math.Max(0, bubbleRect.Top - VerticalGap - PanePadding);
-        double spaceBelow = Math.Max(0, paneHeight - PanePadding - (bubbleRect.Bottom + VerticalGap));
-        double upwardTop = bubbleRect.Top - VerticalGap - popupHeight;
-        double downwardTop = bubbleRect.Bottom + VerticalGap;
+        double spaceAbove = Math.Max(0, bubbleRect.Top - BubblePopupGap - PanePadding);
+        double spaceBelow = Math.Max(0, paneHeight - PanePadding - (bubbleRect.Bottom + BubblePopupGap));
+        double upwardTop = bubbleRect.Top - BubblePopupGap - popupHeight;
+        double downwardTop = bubbleRect.Bottom + BubblePopupGap;
         bool canPlacePopupUpward = upwardTop >= PanePadding;
         bool canPlacePopupDownward = downwardTop + popupHeight <= paneHeight - PanePadding;
         bool canPlacePopupRight = bubbleRect.Right + HorizontalGap + popupWidth <= paneWidth - PanePadding;
@@ -112,7 +113,7 @@ public sealed class CommandAssistAnchorCalculator
         return ClampRect(new Rect(PanePadding, promptY, promptWidth, promptHeight), paneWidth, paneHeight);
     }
 
-    private static Rect CreateBubbleAbovePrompt(
+    private static Rect CreateBubbleAdjacentToPrompt(
         Rect promptRect,
         double bubbleWidth,
         double bubbleHeight,
@@ -120,18 +121,30 @@ public sealed class CommandAssistAnchorCalculator
         double paneHeight)
     {
         double bubbleX = promptRect.X;
-        double bubbleY = promptRect.Top - VerticalGap - bubbleHeight;
+        double desiredAboveY = promptRect.Top - PromptBubbleGap - bubbleHeight;
+        double clampedAboveY = Math.Max(PanePadding, desiredAboveY);
+        bool clampedAbovePlacementOverlapsPrompt = clampedAboveY + bubbleHeight > promptRect.Top;
+        double bubbleY = clampedAbovePlacementOverlapsPrompt
+            ? promptRect.Bottom + PromptBubbleGap
+            : clampedAboveY;
+
+        if (bubbleY + bubbleHeight > paneHeight - PanePadding)
+        {
+            bubbleY = clampedAboveY;
+        }
+
         return ClampRect(new Rect(bubbleX, bubbleY, bubbleWidth, bubbleHeight), paneWidth, paneHeight);
     }
 
     private static Rect CreateFallbackBubbleRect(
+        Rect promptRect,
         double bubbleWidth,
         double bubbleHeight,
         double paneWidth,
         double paneHeight)
     {
-        double bubbleX = paneWidth - PanePadding - bubbleWidth;
-        double bubbleY = paneHeight - PanePadding - bubbleHeight;
+        double bubbleX = promptRect.X;
+        double bubbleY = promptRect.Top - PromptBubbleGap - bubbleHeight;
         return ClampRect(new Rect(bubbleX, bubbleY, bubbleWidth, bubbleHeight), paneWidth, paneHeight);
     }
 

--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
@@ -13,6 +13,7 @@ public sealed class CommandAssistAnchorCalculator
     private const double CompactBubbleWidthThreshold = 320;
     private const double CompactPaneWidthThreshold = 560;
     private const double UnreliableCursorBandStartRatio = 0.55;
+    private const double PromptUpperBandRatio = 0.45;
 
     public CommandAssistAnchorLayout Calculate(CommandAssistAnchorRequest request)
     {
@@ -138,7 +139,7 @@ public sealed class CommandAssistAnchorCalculator
         double bubbleX = promptRect.X;
         double desiredAboveY = promptRect.Top - PromptBubbleGap - bubbleHeight;
         double clampedAboveY = Math.Max(PanePadding, desiredAboveY);
-        bool isPromptInUpperStartupBand = desiredAboveY < PanePadding;
+        bool isPromptInUpperStartupBand = promptRect.Top <= paneHeight * PromptUpperBandRatio;
         double bubbleY = isPromptInUpperStartupBand
             ? promptRect.Bottom + PromptBubbleGap
             : clampedAboveY;

--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
@@ -15,6 +15,8 @@ public sealed class CommandAssistAnchorCalculator
     private const double UnreliableCursorBandStartRatio = 0.55;
     private const int UnreliableCursorBandMinVisibleRows = 8;
     private const double PromptUpperBandRatio = 0.45;
+    private const double FallbackShortPanePromptUpperBandRatio = 0.70;
+    private const double FallbackShortPaneHeightThreshold = 300;
 
     public CommandAssistAnchorLayout Calculate(CommandAssistAnchorRequest request)
     {
@@ -137,10 +139,21 @@ public sealed class CommandAssistAnchorCalculator
         double paneWidth,
         double paneHeight)
     {
+        return CreateBubbleAdjacentToPrompt(promptRect, bubbleWidth, bubbleHeight, paneWidth, paneHeight, PromptUpperBandRatio);
+    }
+
+    private static Rect CreateBubbleAdjacentToPrompt(
+        Rect promptRect,
+        double bubbleWidth,
+        double bubbleHeight,
+        double paneWidth,
+        double paneHeight,
+        double upperBandRatio)
+    {
         double bubbleX = promptRect.X;
         double desiredAboveY = promptRect.Top - PromptBubbleGap - bubbleHeight;
         double clampedAboveY = Math.Max(PanePadding, desiredAboveY);
-        bool isPromptInUpperStartupBand = promptRect.Top <= paneHeight * PromptUpperBandRatio;
+        bool isPromptInUpperStartupBand = promptRect.Top <= paneHeight * upperBandRatio;
         double bubbleY = isPromptInUpperStartupBand
             ? promptRect.Bottom + PromptBubbleGap
             : clampedAboveY;
@@ -160,9 +173,12 @@ public sealed class CommandAssistAnchorCalculator
         double paneWidth,
         double paneHeight)
     {
-        // Keep fallback behavior aligned with prompt-anchored behavior:
-        // if the prompt sits in the upper startup band, place the bubble below it.
-        return CreateBubbleAdjacentToPrompt(promptRect, bubbleWidth, bubbleHeight, paneWidth, paneHeight);
+        // Unreliable prompt anchors (for conservative SSH mode) should prefer below-placement
+        // more aggressively on short panes to avoid covering startup/login text.
+        double upperBandRatio = paneHeight <= FallbackShortPaneHeightThreshold
+            ? FallbackShortPanePromptUpperBandRatio
+            : PromptUpperBandRatio;
+        return CreateBubbleAdjacentToPrompt(promptRect, bubbleWidth, bubbleHeight, paneWidth, paneHeight, upperBandRatio);
     }
 
     private static Rect CreatePopupRect(

--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
@@ -15,8 +15,11 @@ public sealed class CommandAssistAnchorCalculator
     private const double UnreliableCursorBandStartRatio = 0.55;
     private const int UnreliableCursorBandMinVisibleRows = 8;
     private const double PromptUpperBandRatio = 0.45;
+    private const double ReliableShortPanePromptUpperBandRatio = 0.60;
     private const double FallbackShortPanePromptUpperBandRatio = 0.70;
     private const double FallbackShortPaneHeightThreshold = 300;
+    private const int StartupBandInputRowClearanceRows = 1;
+    private const double PromptVerticalOffset = 0;
 
     public CommandAssistAnchorLayout Calculate(CommandAssistAnchorRequest request)
     {
@@ -114,7 +117,7 @@ public sealed class CommandAssistAnchorCalculator
         double promptHeight)
     {
         double promptWidth = Math.Min(Math.Max(MinimumPromptWidth, request.BubbleWidth * 0.5), paneWidth - (PanePadding * 2));
-        double promptY = PanePadding + (request.CursorVisualRow * request.CellHeight);
+        double promptY = PromptVerticalOffset + (request.CursorVisualRow * request.CellHeight);
         Rect promptRect = new(PanePadding, promptY, promptWidth, promptHeight);
         return ClampRect(promptRect, paneWidth, paneHeight);
     }
@@ -127,7 +130,7 @@ public sealed class CommandAssistAnchorCalculator
     {
         double promptWidth = Math.Min(Math.Max(MinimumPromptWidth, request.BubbleWidth * 0.5), paneWidth - (PanePadding * 2));
         double promptY = ShouldUseUnreliableCursorBandFallback(request)
-            ? PanePadding + (request.CursorVisualRow * request.CellHeight)
+            ? PromptVerticalOffset + (request.CursorVisualRow * request.CellHeight)
             : paneHeight - PanePadding - promptHeight;
         return ClampRect(new Rect(PanePadding, promptY, promptWidth, promptHeight), paneWidth, paneHeight);
     }
@@ -140,9 +143,16 @@ public sealed class CommandAssistAnchorCalculator
         double paneHeight)
     {
         double upperBandRatio = paneHeight <= FallbackShortPaneHeightThreshold
-            ? FallbackShortPanePromptUpperBandRatio
+            ? ReliableShortPanePromptUpperBandRatio
             : PromptUpperBandRatio;
-        return CreateBubbleAdjacentToPrompt(promptRect, bubbleWidth, bubbleHeight, paneWidth, paneHeight, upperBandRatio);
+        return CreateBubbleAdjacentToPrompt(
+            promptRect,
+            bubbleWidth,
+            bubbleHeight,
+            paneWidth,
+            paneHeight,
+            upperBandRatio,
+            reserveInputRowClearance: true);
     }
 
     private static Rect CreateBubbleAdjacentToPrompt(
@@ -151,15 +161,26 @@ public sealed class CommandAssistAnchorCalculator
         double bubbleHeight,
         double paneWidth,
         double paneHeight,
-        double upperBandRatio)
+        double upperBandRatio,
+        bool reserveInputRowClearance)
     {
         double bubbleX = promptRect.X;
         double desiredAboveY = promptRect.Top - PromptBubbleGap - bubbleHeight;
         double clampedAboveY = Math.Max(PanePadding, desiredAboveY);
         bool isPromptInUpperStartupBand = promptRect.Top <= paneHeight * upperBandRatio;
+
+        double belowPromptY = promptRect.Bottom + PromptBubbleGap;
+        double guardedBelowPromptY = belowPromptY + (promptRect.Height * StartupBandInputRowClearanceRows);
         double bubbleY = isPromptInUpperStartupBand
-            ? promptRect.Bottom + PromptBubbleGap
+            ? (reserveInputRowClearance ? guardedBelowPromptY : belowPromptY)
             : clampedAboveY;
+
+        if (isPromptInUpperStartupBand &&
+            reserveInputRowClearance &&
+            bubbleY + bubbleHeight > paneHeight - PanePadding)
+        {
+            bubbleY = belowPromptY;
+        }
 
         if (bubbleY + bubbleHeight > paneHeight - PanePadding)
         {
@@ -181,7 +202,14 @@ public sealed class CommandAssistAnchorCalculator
         double upperBandRatio = paneHeight <= FallbackShortPaneHeightThreshold
             ? FallbackShortPanePromptUpperBandRatio
             : PromptUpperBandRatio;
-        return CreateBubbleAdjacentToPrompt(promptRect, bubbleWidth, bubbleHeight, paneWidth, paneHeight, upperBandRatio);
+        return CreateBubbleAdjacentToPrompt(
+            promptRect,
+            bubbleWidth,
+            bubbleHeight,
+            paneWidth,
+            paneHeight,
+            upperBandRatio,
+            reserveInputRowClearance: false);
     }
 
     private static Rect CreatePopupRect(

--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
@@ -160,9 +160,9 @@ public sealed class CommandAssistAnchorCalculator
         double paneWidth,
         double paneHeight)
     {
-        double bubbleX = promptRect.X;
-        double bubbleY = promptRect.Top - PromptBubbleGap - bubbleHeight;
-        return ClampRect(new Rect(bubbleX, bubbleY, bubbleWidth, bubbleHeight), paneWidth, paneHeight);
+        // Keep fallback behavior aligned with prompt-anchored behavior:
+        // if the prompt sits in the upper startup band, place the bubble below it.
+        return CreateBubbleAdjacentToPrompt(promptRect, bubbleWidth, bubbleHeight, paneWidth, paneHeight);
     }
 
     private static Rect CreatePopupRect(

--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
@@ -12,6 +12,7 @@ public sealed class CommandAssistAnchorCalculator
     private const double MinimumPromptWidth = 120;
     private const double CompactBubbleWidthThreshold = 320;
     private const double CompactPaneWidthThreshold = 560;
+    private const double UnreliableCursorBandStartRatio = 0.55;
 
     public CommandAssistAnchorLayout Calculate(CommandAssistAnchorRequest request)
     {
@@ -34,7 +35,7 @@ public sealed class CommandAssistAnchorCalculator
 
         Rect promptRect = usesPromptAnchor
             ? CreatePromptRect(request, paneWidth, paneHeight, promptHeight)
-            : CreateFallbackPromptRect(paneWidth, paneHeight, promptHeight);
+            : CreateFallbackPromptRect(request, paneWidth, paneHeight, promptHeight);
 
         Rect bubbleRect = usesPromptAnchor
             ? CreateBubbleAdjacentToPrompt(promptRect, bubbleWidth, bubbleHeight, paneWidth, paneHeight)
@@ -106,10 +107,16 @@ public sealed class CommandAssistAnchorCalculator
         return ClampRect(promptRect, paneWidth, paneHeight);
     }
 
-    private static Rect CreateFallbackPromptRect(double paneWidth, double paneHeight, double promptHeight)
+    private static Rect CreateFallbackPromptRect(
+        CommandAssistAnchorRequest request,
+        double paneWidth,
+        double paneHeight,
+        double promptHeight)
     {
-        double promptWidth = Math.Min(Math.Max(MinimumPromptWidth, paneWidth * 0.35), paneWidth - (PanePadding * 2));
-        double promptY = paneHeight - PanePadding - promptHeight;
+        double promptWidth = Math.Min(Math.Max(MinimumPromptWidth, request.BubbleWidth * 0.5), paneWidth - (PanePadding * 2));
+        double promptY = ShouldUseUnreliableCursorBandFallback(request)
+            ? PanePadding + (request.CursorVisualRow * request.CellHeight)
+            : paneHeight - PanePadding - promptHeight;
         return ClampRect(new Rect(PanePadding, promptY, promptWidth, promptHeight), paneWidth, paneHeight);
     }
 
@@ -157,6 +164,17 @@ public sealed class CommandAssistAnchorCalculator
         double x = Math.Clamp(rect.X, PanePadding, Math.Max(PanePadding, paneWidth - PanePadding - width));
         double y = Math.Clamp(rect.Y, PanePadding, Math.Max(PanePadding, paneHeight - PanePadding - height));
         return new Rect(x, y, width, height);
+    }
+
+    private static bool ShouldUseUnreliableCursorBandFallback(CommandAssistAnchorRequest request)
+    {
+        if (request.VisibleRows <= 1 || request.CursorVisualRow < 0 || request.CellHeight <= 0)
+        {
+            return false;
+        }
+
+        double normalizedCursorRow = request.CursorVisualRow / (double)(request.VisibleRows - 1);
+        return normalizedCursorRow >= UnreliableCursorBandStartRatio;
     }
 }
 

--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
@@ -13,6 +13,7 @@ public sealed class CommandAssistAnchorCalculator
     private const double CompactBubbleWidthThreshold = 320;
     private const double CompactPaneWidthThreshold = 560;
     private const double UnreliableCursorBandStartRatio = 0.55;
+    private const int UnreliableCursorBandMinVisibleRows = 8;
     private const double PromptUpperBandRatio = 0.45;
 
     public CommandAssistAnchorLayout Calculate(CommandAssistAnchorRequest request)
@@ -206,7 +207,7 @@ public sealed class CommandAssistAnchorCalculator
 
     private static bool ShouldUseUnreliableCursorBandFallback(CommandAssistAnchorRequest request)
     {
-        if (request.VisibleRows <= 1 || request.CursorVisualRow < 0 || request.CellHeight <= 0)
+        if (request.VisibleRows < UnreliableCursorBandMinVisibleRows || request.CursorVisualRow < 0 || request.CellHeight <= 0)
         {
             return false;
         }

--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
@@ -7,7 +7,10 @@ public sealed class CommandAssistAnchorCalculator
 {
     private const double PanePadding = 12;
     private const double VerticalGap = 8;
+    private const double HorizontalGap = 12;
     private const double MinimumPromptWidth = 120;
+    private const double CompactBubbleWidthThreshold = 320;
+    private const double CompactPaneWidthThreshold = 560;
 
     public CommandAssistAnchorLayout Calculate(CommandAssistAnchorRequest request)
     {
@@ -20,7 +23,9 @@ public sealed class CommandAssistAnchorCalculator
         double bubbleHeight = Math.Min(Math.Max(1, request.BubbleHeight), availableHeight);
         double popupWidth = Math.Min(Math.Max(1, request.PopupWidth), availableWidth);
         double popupHeight = Math.Min(Math.Max(1, request.PopupHeight), availableHeight);
-        bool useCompactBubbleLayout = paneWidth <= 480 || request.BubbleWidth > availableWidth;
+        bool useCompactBubbleLayout = paneWidth <= CompactPaneWidthThreshold ||
+                                      request.BubbleWidth > availableWidth ||
+                                      bubbleWidth <= CompactBubbleWidthThreshold;
         bool usesPromptAnchor = request.HasReliablePromptAnchor &&
                                 request.VisibleRows > 0 &&
                                 request.CursorVisualRow >= 0 &&
@@ -34,16 +39,55 @@ public sealed class CommandAssistAnchorCalculator
             ? CreateBubbleAbovePrompt(promptRect, bubbleWidth, bubbleHeight, paneWidth, paneHeight)
             : CreateFallbackBubbleRect(bubbleWidth, bubbleHeight, paneWidth, paneHeight);
 
+        double spaceAbove = Math.Max(0, bubbleRect.Top - VerticalGap - PanePadding);
+        double spaceBelow = Math.Max(0, paneHeight - PanePadding - (bubbleRect.Bottom + VerticalGap));
         double upwardTop = bubbleRect.Top - VerticalGap - popupHeight;
+        double downwardTop = bubbleRect.Bottom + VerticalGap;
         bool canPlacePopupUpward = upwardTop >= PanePadding;
-        CommandAssistPopupDirection popupDirection = canPlacePopupUpward
-            ? CommandAssistPopupDirection.Upward
-            : CommandAssistPopupDirection.Downward;
+        bool canPlacePopupDownward = downwardTop + popupHeight <= paneHeight - PanePadding;
+        bool canPlacePopupRight = bubbleRect.Right + HorizontalGap + popupWidth <= paneWidth - PanePadding;
+        bool canPlacePopupLeft = bubbleRect.Left - HorizontalGap - popupWidth >= PanePadding;
+        bool hasMeaningfulVerticalRoom = Math.Max(spaceAbove, spaceBelow) >= popupHeight * 0.75;
 
-        double popupY = popupDirection == CommandAssistPopupDirection.Upward
-            ? upwardTop
-            : bubbleRect.Bottom + VerticalGap;
-        double popupX = bubbleRect.X;
+        CommandAssistPopupDirection popupDirection;
+        double popupX;
+        double popupY;
+
+        if (canPlacePopupUpward)
+        {
+            popupDirection = CommandAssistPopupDirection.Upward;
+            popupX = bubbleRect.X;
+            popupY = upwardTop;
+        }
+        else if (canPlacePopupDownward)
+        {
+            popupDirection = CommandAssistPopupDirection.Downward;
+            popupX = bubbleRect.X;
+            popupY = downwardTop;
+        }
+        else if (!hasMeaningfulVerticalRoom && canPlacePopupRight)
+        {
+            popupDirection = CommandAssistPopupDirection.RightSide;
+            popupX = bubbleRect.Right + HorizontalGap;
+            popupY = bubbleRect.Top;
+        }
+        else if (!hasMeaningfulVerticalRoom && canPlacePopupLeft)
+        {
+            popupDirection = CommandAssistPopupDirection.LeftSide;
+            popupX = bubbleRect.Left - HorizontalGap - popupWidth;
+            popupY = bubbleRect.Top;
+        }
+        else
+        {
+            popupDirection = upwardTop >= PanePadding * 2
+                ? CommandAssistPopupDirection.Upward
+                : CommandAssistPopupDirection.Downward;
+            popupX = bubbleRect.X;
+            popupY = popupDirection == CommandAssistPopupDirection.Upward
+                ? upwardTop
+                : downwardTop;
+        }
+
         Rect popupRect = ClampRect(new Rect(popupX, popupY, popupWidth, popupHeight), paneWidth, paneHeight);
 
         return new CommandAssistAnchorLayout(promptRect, bubbleRect, popupRect, popupDirection, usesPromptAnchor, useCompactBubbleLayout);
@@ -127,4 +171,6 @@ public enum CommandAssistPopupDirection
 {
     Upward,
     Downward,
+    RightSide,
+    LeftSide,
 }

--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
@@ -139,7 +139,10 @@ public sealed class CommandAssistAnchorCalculator
         double paneWidth,
         double paneHeight)
     {
-        return CreateBubbleAdjacentToPrompt(promptRect, bubbleWidth, bubbleHeight, paneWidth, paneHeight, PromptUpperBandRatio);
+        double upperBandRatio = paneHeight <= FallbackShortPaneHeightThreshold
+            ? FallbackShortPanePromptUpperBandRatio
+            : PromptUpperBandRatio;
+        return CreateBubbleAdjacentToPrompt(promptRect, bubbleWidth, bubbleHeight, paneWidth, paneHeight, upperBandRatio);
     }
 
     private static Rect CreateBubbleAdjacentToPrompt(

--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
@@ -67,13 +67,13 @@ public sealed class CommandAssistAnchorCalculator
             popupX = bubbleRect.X;
             popupY = downwardTop;
         }
-        else if (!hasMeaningfulVerticalRoom && canPlacePopupRight)
+        else if (!hasMeaningfulVerticalRoom && canPlacePopupRight && bubbleRect.Top < promptRect.Top)
         {
             popupDirection = CommandAssistPopupDirection.RightSide;
             popupX = bubbleRect.Right + HorizontalGap;
             popupY = bubbleRect.Top;
         }
-        else if (!hasMeaningfulVerticalRoom && canPlacePopupLeft)
+        else if (!hasMeaningfulVerticalRoom && canPlacePopupLeft && bubbleRect.Top < promptRect.Top)
         {
             popupDirection = CommandAssistPopupDirection.LeftSide;
             popupX = bubbleRect.Left - HorizontalGap - popupWidth;
@@ -90,7 +90,15 @@ public sealed class CommandAssistAnchorCalculator
                 : downwardTop;
         }
 
-        Rect popupRect = ClampRect(new Rect(popupX, popupY, popupWidth, popupHeight), paneWidth, paneHeight);
+        Rect popupRect = CreatePopupRect(
+            popupDirection,
+            popupX,
+            popupY,
+            popupWidth,
+            popupHeight,
+            bubbleRect,
+            paneWidth,
+            paneHeight);
 
         return new CommandAssistAnchorLayout(promptRect, bubbleRect, popupRect, popupDirection, usesPromptAnchor, useCompactBubbleLayout);
     }
@@ -130,8 +138,8 @@ public sealed class CommandAssistAnchorCalculator
         double bubbleX = promptRect.X;
         double desiredAboveY = promptRect.Top - PromptBubbleGap - bubbleHeight;
         double clampedAboveY = Math.Max(PanePadding, desiredAboveY);
-        bool clampedAbovePlacementOverlapsPrompt = clampedAboveY + bubbleHeight > promptRect.Top;
-        double bubbleY = clampedAbovePlacementOverlapsPrompt
+        bool isPromptInUpperStartupBand = desiredAboveY < PanePadding;
+        double bubbleY = isPromptInUpperStartupBand
             ? promptRect.Bottom + PromptBubbleGap
             : clampedAboveY;
 
@@ -153,6 +161,35 @@ public sealed class CommandAssistAnchorCalculator
         double bubbleX = promptRect.X;
         double bubbleY = promptRect.Top - PromptBubbleGap - bubbleHeight;
         return ClampRect(new Rect(bubbleX, bubbleY, bubbleWidth, bubbleHeight), paneWidth, paneHeight);
+    }
+
+    private static Rect CreatePopupRect(
+        CommandAssistPopupDirection popupDirection,
+        double popupX,
+        double popupY,
+        double popupWidth,
+        double popupHeight,
+        Rect bubbleRect,
+        double paneWidth,
+        double paneHeight)
+    {
+        if (popupDirection == CommandAssistPopupDirection.Downward)
+        {
+            double minTop = bubbleRect.Bottom + BubblePopupGap;
+            double maxBottom = paneHeight - PanePadding;
+            double height = Math.Max(1, Math.Min(popupHeight, maxBottom - minTop));
+            return ClampRect(new Rect(popupX, minTop, popupWidth, height), paneWidth, paneHeight);
+        }
+
+        if (popupDirection == CommandAssistPopupDirection.Upward)
+        {
+            double maxBottom = bubbleRect.Top - BubblePopupGap;
+            double top = Math.Max(PanePadding, maxBottom - popupHeight);
+            double height = Math.Max(1, maxBottom - top);
+            return ClampRect(new Rect(popupX, top, popupWidth, height), paneWidth, paneHeight);
+        }
+
+        return ClampRect(new Rect(popupX, popupY, popupWidth, popupHeight), paneWidth, paneHeight);
     }
 
     private static Rect ClampRect(Rect rect, double paneWidth, double paneHeight)

--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistController.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistController.cs
@@ -160,7 +160,7 @@ public sealed class CommandAssistController
         ViewModel.QueryText += text;
         ViewModel.ModeLabel = "Suggest";
         ViewModel.IsPopupOpen = false;
-        ViewModel.IsVisible = true;
+        ViewModel.IsVisible = ViewModel.HasSuggestions;
         QueueRefreshSuggestions();
     }
 
@@ -182,7 +182,7 @@ public sealed class CommandAssistController
         ViewModel.QueryText = text ?? string.Empty;
         ViewModel.ModeLabel = "Suggest";
         ViewModel.IsPopupOpen = false;
-        ViewModel.IsVisible = !_isAltScreenActive;
+        ViewModel.IsVisible = !_isAltScreenActive && ViewModel.HasSuggestions;
         QueueRefreshSuggestions();
     }
 
@@ -613,6 +613,11 @@ public sealed class CommandAssistController
                 ViewModel.EmptyStateText = string.Empty;
                 ViewModel.ShowEmptyState = false;
                 SyncSuggestionViewModel();
+                if (requestedMode == CommandAssistMode.Suggest)
+                {
+                    ViewModel.IsPopupOpen = false;
+                    ViewModel.IsVisible = suggestions.Count > 0;
+                }
             });
         }
         catch
@@ -634,6 +639,11 @@ public sealed class CommandAssistController
                 ViewModel.ShowEmptyState = false;
                 ViewModel.HasSuggestions = false;
                 ViewModel.Suggestions.Clear();
+                if (requestedMode == CommandAssistMode.Suggest)
+                {
+                    ViewModel.IsPopupOpen = false;
+                    ViewModel.IsVisible = false;
+                }
             });
         }
     }

--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistController.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistController.cs
@@ -116,6 +116,7 @@ public sealed class CommandAssistController
 
         _currentMode = CommandAssistMode.Suggest;
         ViewModel.ModeLabel = "Suggest";
+        ViewModel.IsPopupOpen = false;
         ViewModel.IsVisible = !ViewModel.IsVisible;
     }
 
@@ -129,6 +130,7 @@ public sealed class CommandAssistController
 
         _currentMode = CommandAssistMode.Search;
         ViewModel.ModeLabel = "History";
+        ViewModel.IsPopupOpen = true;
         ViewModel.IsVisible = true;
         QueueRefreshSuggestions();
         return true;
@@ -157,6 +159,7 @@ public sealed class CommandAssistController
         _currentMode = CommandAssistMode.Suggest;
         ViewModel.QueryText += text;
         ViewModel.ModeLabel = "Suggest";
+        ViewModel.IsPopupOpen = false;
         ViewModel.IsVisible = true;
         QueueRefreshSuggestions();
     }
@@ -178,6 +181,7 @@ public sealed class CommandAssistController
         _currentMode = CommandAssistMode.Suggest;
         ViewModel.QueryText = text ?? string.Empty;
         ViewModel.ModeLabel = "Suggest";
+        ViewModel.IsPopupOpen = false;
         ViewModel.IsVisible = !_isAltScreenActive;
         QueueRefreshSuggestions();
     }
@@ -262,6 +266,7 @@ public sealed class CommandAssistController
         CancelPendingRefreshes();
         _currentMode = CommandAssistMode.Suggest;
         ViewModel.IsVisible = false;
+        ViewModel.IsPopupOpen = false;
         ViewModel.TopSuggestionText = string.Empty;
         ViewModel.SelectedIndex = -1;
         ViewModel.SelectedBadgesText = string.Empty;
@@ -336,6 +341,7 @@ public sealed class CommandAssistController
         ViewModel.QueryText = insertionText;
         _currentMode = CommandAssistMode.Suggest;
         ViewModel.ModeLabel = "Suggest";
+        ViewModel.IsPopupOpen = false;
         Dismiss();
         return true;
     }
@@ -532,6 +538,7 @@ public sealed class CommandAssistController
             CancelPendingRefreshes();
             _currentMode = CommandAssistMode.Suggest;
             ViewModel.IsVisible = false;
+            ViewModel.IsPopupOpen = false;
             ViewModel.TopSuggestionText = string.Empty;
             ViewModel.SelectedIndex = -1;
             ViewModel.SelectedBadgesText = string.Empty;
@@ -623,6 +630,7 @@ public sealed class CommandAssistController
         CancelPendingRefreshes();
         _ignoreCurrentSubmission = false;
         ViewModel.QueryText = string.Empty;
+        ViewModel.IsPopupOpen = false;
         ViewModel.TopSuggestionText = string.Empty;
         ViewModel.SelectedIndex = -1;
         ViewModel.SelectedBadgesText = string.Empty;
@@ -644,6 +652,11 @@ public sealed class CommandAssistController
         }
 
         ViewModel.SelectedIndex = index;
+        if (_currentMode == CommandAssistMode.Suggest)
+        {
+            ViewModel.IsPopupOpen = true;
+        }
+
         SyncSuggestionViewModel();
         return true;
     }
@@ -727,6 +740,7 @@ public sealed class CommandAssistController
         _currentMode = mode;
         ViewModel.ModeLabel = mode.ToString();
         ViewModel.QueryText = queryText ?? string.Empty;
+        ViewModel.IsPopupOpen = true;
         ViewModel.IsVisible = true;
         ViewModel.EmptyStateText = suggestions.Count == 0 ? emptyStateText : string.Empty;
         ViewModel.ShowEmptyState = suggestions.Count == 0;

--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistController.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistController.cs
@@ -402,7 +402,8 @@ public sealed class CommandAssistController
             _modeRouter.ChooseModeForHelpRequest(),
             queryText ?? ViewModel.QueryText,
             suggestions,
-            "No local help found."));
+            "No local help found.",
+            openPopup: true));
 
         return true;
     }
@@ -428,14 +429,31 @@ public sealed class CommandAssistController
         IReadOnlyList<CommandFixSuggestion> fixes = await _errorInsightService.AnalyzeAsync(context);
         double highestConfidence = fixes.Count == 0 ? 0 : fixes.Max(item => item.Confidence);
         CommandAssistMode mode = _modeRouter.ChooseModeForFailure(highestConfidence);
-        if (mode != CommandAssistMode.Fix)
+        IReadOnlyList<AssistSuggestion> suggestions = _resultBuilder.BuildFixSuggestions(fixes);
+
+        if (mode == CommandAssistMode.Fix)
+        {
+            _dispatch(() => ApplyHelperSuggestions(
+                CommandAssistMode.Fix,
+                context.CommandText,
+                suggestions,
+                "No likely local fix found.",
+                openPopup: true));
+            return true;
+        }
+
+        if (suggestions.Count == 0)
         {
             return false;
         }
 
-        IReadOnlyList<AssistSuggestion> suggestions = _resultBuilder.BuildFixSuggestions(fixes);
-        _dispatch(() => ApplyHelperSuggestions(mode, context.CommandText, suggestions, "No likely local fix found."));
-        return true;
+        _dispatch(() => ApplyHelperSuggestions(
+            CommandAssistMode.Fix,
+            context.CommandText,
+            suggestions,
+            "No likely local fix found.",
+            openPopup: false));
+        return false;
     }
 
     public async Task HandleShellIntegrationEventAsync(ShellIntegrationEvent shellEvent)
@@ -652,7 +670,7 @@ public sealed class CommandAssistController
         }
 
         ViewModel.SelectedIndex = index;
-        if (_currentMode == CommandAssistMode.Suggest)
+        if (!ViewModel.IsPopupOpen)
         {
             ViewModel.IsPopupOpen = true;
         }
@@ -734,13 +752,14 @@ public sealed class CommandAssistController
         CommandAssistMode mode,
         string? queryText,
         IReadOnlyList<AssistSuggestion> suggestions,
-        string emptyStateText)
+        string emptyStateText,
+        bool openPopup)
     {
         CancelPendingRefreshes();
         _currentMode = mode;
         ViewModel.ModeLabel = mode.ToString();
         ViewModel.QueryText = queryText ?? string.Empty;
-        ViewModel.IsPopupOpen = true;
+        ViewModel.IsPopupOpen = openPopup;
         ViewModel.IsVisible = true;
         ViewModel.EmptyStateText = suggestions.Count == 0 ? emptyStateText : string.Empty;
         ViewModel.ShowEmptyState = suggestions.Count == 0;

--- a/src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistBarViewModel.cs
+++ b/src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistBarViewModel.cs
@@ -1,4 +1,3 @@
-using System;
 using System.ComponentModel;
 using System.Collections.ObjectModel;
 using System.Runtime.CompilerServices;
@@ -233,7 +232,7 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
             ? TopSuggestionText
             : EmptyStateText;
 
-        Popup.IsVisible = IsVisible && (IsPopupOpen || !string.Equals(ModeLabel, "Suggest", StringComparison.OrdinalIgnoreCase));
+        Popup.IsVisible = IsVisible && IsPopupOpen;
         Popup.ModeLabel = ModeLabel;
         Popup.QueryText = QueryText;
         Popup.TopSuggestionText = TopSuggestionText;

--- a/src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistBarViewModel.cs
+++ b/src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistBarViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel;
 using System.Collections.ObjectModel;
 using System.Runtime.CompilerServices;
@@ -17,8 +18,18 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
     private string _emptyStateText = string.Empty;
     private bool _hasSuggestions;
     private bool _showEmptyState;
+    private bool _isPopupOpen;
+
+    public CommandAssistBarViewModel()
+    {
+        Bubble = new CommandAssistBubbleViewModel();
+        Popup = new CommandAssistPopupViewModel(Suggestions);
+        SyncPresentationState();
+    }
 
     public ObservableCollection<CommandAssistSuggestionItemViewModel> Suggestions { get; } = new();
+    public CommandAssistBubbleViewModel Bubble { get; }
+    public CommandAssistPopupViewModel Popup { get; }
 
     public bool IsVisible
     {
@@ -32,6 +43,7 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
 
             _isVisible = value;
             OnPropertyChanged();
+            SyncPresentationState();
         }
     }
 
@@ -47,6 +59,7 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
 
             _modeLabel = value;
             OnPropertyChanged();
+            SyncPresentationState();
         }
     }
 
@@ -62,6 +75,7 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
 
             _queryText = value;
             OnPropertyChanged();
+            SyncPresentationState();
         }
     }
 
@@ -77,6 +91,7 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
 
             _topSuggestionText = value;
             OnPropertyChanged();
+            SyncPresentationState();
         }
     }
 
@@ -107,6 +122,7 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
 
             _selectedBadgesText = value;
             OnPropertyChanged();
+            SyncPresentationState();
         }
     }
 
@@ -122,6 +138,7 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
 
             _selectedMetadataText = value;
             OnPropertyChanged();
+            SyncPresentationState();
         }
     }
 
@@ -137,6 +154,7 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
 
             _selectedDescriptionText = value;
             OnPropertyChanged();
+            SyncPresentationState();
         }
     }
 
@@ -152,6 +170,7 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
 
             _emptyStateText = value;
             OnPropertyChanged();
+            SyncPresentationState();
         }
     }
 
@@ -167,6 +186,7 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
 
             _hasSuggestions = value;
             OnPropertyChanged();
+            SyncPresentationState();
         }
     }
 
@@ -182,10 +202,48 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
 
             _showEmptyState = value;
             OnPropertyChanged();
+            SyncPresentationState();
+        }
+    }
+
+    public bool IsPopupOpen
+    {
+        get => _isPopupOpen;
+        set
+        {
+            if (_isPopupOpen == value)
+            {
+                return;
+            }
+
+            _isPopupOpen = value;
+            OnPropertyChanged();
+            SyncPresentationState();
         }
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void SyncPresentationState()
+    {
+        Bubble.IsVisible = IsVisible;
+        Bubble.ModeLabel = ModeLabel;
+        Bubble.QueryText = QueryText;
+        Bubble.SummaryText = !string.IsNullOrWhiteSpace(TopSuggestionText)
+            ? TopSuggestionText
+            : EmptyStateText;
+
+        Popup.IsVisible = IsVisible && (IsPopupOpen || !string.Equals(ModeLabel, "Suggest", StringComparison.OrdinalIgnoreCase));
+        Popup.ModeLabel = ModeLabel;
+        Popup.QueryText = QueryText;
+        Popup.TopSuggestionText = TopSuggestionText;
+        Popup.SelectedBadgesText = SelectedBadgesText;
+        Popup.SelectedMetadataText = SelectedMetadataText;
+        Popup.SelectedDescriptionText = SelectedDescriptionText;
+        Popup.EmptyStateText = EmptyStateText;
+        Popup.HasSuggestions = HasSuggestions;
+        Popup.ShowEmptyState = ShowEmptyState;
+    }
 
     private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
     {

--- a/src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistBubbleViewModel.cs
+++ b/src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistBubbleViewModel.cs
@@ -1,0 +1,63 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace NovaTerminal.CommandAssist.ViewModels;
+
+public sealed class CommandAssistBubbleViewModel : INotifyPropertyChanged
+{
+    private bool _isVisible;
+    private string _modeLabel = "Suggest";
+    private string _queryText = string.Empty;
+    private string _summaryText = string.Empty;
+    private string _shortcutHintText = "Tab insert  |  Ctrl+Shift+H help  |  Ctrl+R history";
+    private bool _showQueryText = true;
+
+    public bool IsVisible
+    {
+        get => _isVisible;
+        set => SetField(ref _isVisible, value);
+    }
+
+    public string ModeLabel
+    {
+        get => _modeLabel;
+        set => SetField(ref _modeLabel, value);
+    }
+
+    public string QueryText
+    {
+        get => _queryText;
+        set => SetField(ref _queryText, value);
+    }
+
+    public string SummaryText
+    {
+        get => _summaryText;
+        set => SetField(ref _summaryText, value);
+    }
+
+    public string ShortcutHintText
+    {
+        get => _shortcutHintText;
+        set => SetField(ref _shortcutHintText, value);
+    }
+
+    public bool ShowQueryText
+    {
+        get => _showQueryText;
+        set => SetField(ref _showQueryText, value);
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (Equals(field, value))
+        {
+            return;
+        }
+
+        field = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistPopupViewModel.cs
+++ b/src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistPopupViewModel.cs
@@ -1,0 +1,99 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace NovaTerminal.CommandAssist.ViewModels;
+
+public sealed class CommandAssistPopupViewModel : INotifyPropertyChanged
+{
+    private bool _isVisible;
+    private string _modeLabel = "Suggest";
+    private string _queryText = string.Empty;
+    private string _topSuggestionText = string.Empty;
+    private string _selectedBadgesText = string.Empty;
+    private string _selectedMetadataText = string.Empty;
+    private string _selectedDescriptionText = string.Empty;
+    private string _emptyStateText = string.Empty;
+    private bool _hasSuggestions;
+    private bool _showEmptyState;
+
+    public CommandAssistPopupViewModel(ObservableCollection<CommandAssistSuggestionItemViewModel> suggestions)
+    {
+        Suggestions = suggestions;
+    }
+
+    public bool IsVisible
+    {
+        get => _isVisible;
+        set => SetField(ref _isVisible, value);
+    }
+
+    public string ModeLabel
+    {
+        get => _modeLabel;
+        set => SetField(ref _modeLabel, value);
+    }
+
+    public string QueryText
+    {
+        get => _queryText;
+        set => SetField(ref _queryText, value);
+    }
+
+    public string TopSuggestionText
+    {
+        get => _topSuggestionText;
+        set => SetField(ref _topSuggestionText, value);
+    }
+
+    public string SelectedBadgesText
+    {
+        get => _selectedBadgesText;
+        set => SetField(ref _selectedBadgesText, value);
+    }
+
+    public string SelectedMetadataText
+    {
+        get => _selectedMetadataText;
+        set => SetField(ref _selectedMetadataText, value);
+    }
+
+    public string SelectedDescriptionText
+    {
+        get => _selectedDescriptionText;
+        set => SetField(ref _selectedDescriptionText, value);
+    }
+
+    public string EmptyStateText
+    {
+        get => _emptyStateText;
+        set => SetField(ref _emptyStateText, value);
+    }
+
+    public bool HasSuggestions
+    {
+        get => _hasSuggestions;
+        set => SetField(ref _hasSuggestions, value);
+    }
+
+    public bool ShowEmptyState
+    {
+        get => _showEmptyState;
+        set => SetField(ref _showEmptyState, value);
+    }
+
+    public ObservableCollection<CommandAssistSuggestionItemViewModel> Suggestions { get; }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (Equals(field, value))
+        {
+            return;
+        }
+
+        field = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistPopupViewModel.cs
+++ b/src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistPopupViewModel.cs
@@ -16,6 +16,7 @@ public sealed class CommandAssistPopupViewModel : INotifyPropertyChanged
     private string _emptyStateText = string.Empty;
     private bool _hasSuggestions;
     private bool _showEmptyState;
+    private bool _useCompactLayout;
 
     public CommandAssistPopupViewModel(ObservableCollection<CommandAssistSuggestionItemViewModel> suggestions)
     {
@@ -81,6 +82,24 @@ public sealed class CommandAssistPopupViewModel : INotifyPropertyChanged
         get => _showEmptyState;
         set => SetField(ref _showEmptyState, value);
     }
+
+    public bool UseCompactLayout
+    {
+        get => _useCompactLayout;
+        set
+        {
+            if (_useCompactLayout == value)
+            {
+                return;
+            }
+
+            _useCompactLayout = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(UseCompactLayout)));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(UseExpandedLayout)));
+        }
+    }
+
+    public bool UseExpandedLayout => !UseCompactLayout;
 
     public ObservableCollection<CommandAssistSuggestionItemViewModel> Suggestions { get; }
 

--- a/src/NovaTerminal.App/CommandAssist/Views/CommandAssistBubbleView.axaml
+++ b/src/NovaTerminal.App/CommandAssist/Views/CommandAssistBubbleView.axaml
@@ -1,0 +1,33 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:CompileBindings="False"
+             x:Class="NovaTerminal.CommandAssist.Views.CommandAssistBubbleView"
+             IsVisible="{Binding IsVisible}">
+    <Border Background="#CC202020"
+            BorderBrush="#404040"
+            BorderThickness="1"
+            CornerRadius="8"
+            Padding="10,6">
+        <Grid ColumnDefinitions="Auto,Auto,*" ColumnSpacing="10">
+            <TextBlock x:Name="BubbleModeLabelText"
+                       Text="{Binding ModeLabel}"
+                       Foreground="#8EC5FF"
+                       FontWeight="SemiBold"
+                       VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="1"
+                       x:Name="BubbleQueryText"
+                       Text="{Binding QueryText}"
+                       IsVisible="{Binding ShowQueryText}"
+                       Foreground="White"
+                       FontFamily="Consolas"
+                       VerticalAlignment="Center"
+                       TextTrimming="CharacterEllipsis"/>
+            <TextBlock x:Name="BubbleSummaryText"
+                       Grid.Column="2"
+                       Text="{Binding SummaryText}"
+                       Foreground="#D7E8FF"
+                       VerticalAlignment="Center"
+                       TextTrimming="CharacterEllipsis"/>
+        </Grid>
+    </Border>
+</UserControl>

--- a/src/NovaTerminal.App/CommandAssist/Views/CommandAssistBubbleView.axaml.cs
+++ b/src/NovaTerminal.App/CommandAssist/Views/CommandAssistBubbleView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace NovaTerminal.CommandAssist.Views;
+
+public partial class CommandAssistBubbleView : UserControl
+{
+    public CommandAssistBubbleView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml
+++ b/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml
@@ -1,0 +1,110 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:CompileBindings="False"
+             x:Class="NovaTerminal.CommandAssist.Views.CommandAssistPopupView"
+             IsVisible="{Binding IsVisible}">
+    <Border Background="#F01B1B1B"
+            BorderBrush="#404040"
+            BorderThickness="1"
+            CornerRadius="10"
+            Padding="12"
+            MinWidth="360">
+        <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*"
+              RowSpacing="10">
+            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
+                <TextBlock x:Name="PopupModeLabelText"
+                           Text="{Binding ModeLabel}"
+                           Foreground="#8EC5FF"
+                           FontWeight="SemiBold"
+                           VerticalAlignment="Center"/>
+                <TextBlock Grid.Column="1"
+                           Text="{Binding QueryText}"
+                           Foreground="White"
+                           FontFamily="Consolas"
+                           VerticalAlignment="Center"
+                           TextTrimming="CharacterEllipsis"/>
+            </Grid>
+
+            <Grid Grid.Row="1"
+                  ColumnDefinitions="3*,2*"
+                  ColumnSpacing="12">
+                <Border Background="#22101010"
+                        CornerRadius="6"
+                        Padding="8">
+                    <Grid>
+                        <ItemsControl x:Name="PopupSuggestionsList"
+                                      ItemsSource="{Binding Suggestions}"
+                                      IsVisible="{Binding HasSuggestions}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid ColumnDefinitions="Auto,*,Auto"
+                                          Margin="0,2">
+                                        <TextBlock Text="{Binding SelectionGlyph}"
+                                                   Foreground="#8EC5FF"
+                                                   Width="12"
+                                                   VerticalAlignment="Top"/>
+                                        <StackPanel Grid.Column="1"
+                                                    Spacing="1">
+                                            <TextBlock Text="{Binding DisplayText}"
+                                                       Foreground="White"
+                                                       FontFamily="Consolas"
+                                                       TextTrimming="CharacterEllipsis"/>
+                                            <TextBlock Text="{Binding DescriptionText}"
+                                                       Foreground="#C8E1FF"
+                                                       FontSize="11"
+                                                       TextWrapping="Wrap"/>
+                                            <TextBlock Text="{Binding MetadataText}"
+                                                       Foreground="#9CA3AF"
+                                                       FontSize="11"
+                                                       TextTrimming="CharacterEllipsis"/>
+                                        </StackPanel>
+                                        <TextBlock Grid.Column="2"
+                                                   Text="{Binding BadgesText}"
+                                                   Foreground="#C8E1FF"
+                                                   FontSize="11"
+                                                   HorizontalAlignment="Right"
+                                                   Margin="8,0,0,0"
+                                                   TextWrapping="Wrap"/>
+                                    </Grid>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+
+                        <TextBlock x:Name="PopupEmptyStateTextBlock"
+                                   Text="{Binding EmptyStateText}"
+                                   Foreground="#9CA3AF"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"
+                                   IsVisible="{Binding ShowEmptyState}"
+                                   TextWrapping="Wrap"/>
+                    </Grid>
+                </Border>
+
+                <Border Grid.Column="1"
+                        Background="#1C151515"
+                        CornerRadius="6"
+                        Padding="8">
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="{Binding TopSuggestionText}"
+                                   Foreground="White"
+                                   FontFamily="Consolas"
+                                   TextWrapping="Wrap"/>
+                        <TextBlock x:Name="PopupSelectedDescriptionTextBlock"
+                                   Text="{Binding SelectedDescriptionText}"
+                                   Foreground="#C8E1FF"
+                                   FontSize="11"
+                                   TextWrapping="Wrap"/>
+                        <TextBlock Text="{Binding SelectedBadgesText}"
+                                   Foreground="#C8E1FF"
+                                   FontSize="11"
+                                   TextWrapping="Wrap"/>
+                        <TextBlock Text="{Binding SelectedMetadataText}"
+                                   Foreground="#9CA3AF"
+                                   FontSize="11"
+                                   TextWrapping="Wrap"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </Grid>
+    </Border>
+</UserControl>

--- a/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml
+++ b/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml
@@ -7,8 +7,7 @@
             BorderBrush="#404040"
             BorderThickness="1"
             CornerRadius="10"
-            Padding="12"
-            MinWidth="360">
+            Padding="12">
         <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*"
               RowSpacing="10">
             <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">

--- a/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml
+++ b/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml
@@ -27,7 +27,8 @@
 
             <Grid Grid.Row="1"
                   ColumnDefinitions="3*,2*"
-                  ColumnSpacing="12">
+                  ColumnSpacing="12"
+                  IsVisible="{Binding UseExpandedLayout}">
                 <Border Background="#22101010"
                         CornerRadius="6"
                         Padding="8">
@@ -80,10 +81,12 @@
                     </Grid>
                 </Border>
 
-                <Border Grid.Column="1"
+                <Border x:Name="PopupDetailPanel"
+                        Grid.Column="1"
                         Background="#1C151515"
                         CornerRadius="6"
-                        Padding="8">
+                        Padding="8"
+                        IsVisible="{Binding UseExpandedLayout}">
                     <StackPanel Spacing="4">
                         <TextBlock Text="{Binding TopSuggestionText}"
                                    Foreground="White"
@@ -105,6 +108,82 @@
                     </StackPanel>
                 </Border>
             </Grid>
+
+            <Border Grid.Row="1"
+                    x:Name="PopupCompactPanel"
+                    Background="#22101010"
+                    CornerRadius="6"
+                    Padding="8"
+                    IsVisible="{Binding UseCompactLayout}">
+                <Grid RowDefinitions="Auto,Auto"
+                      RowSpacing="8">
+                    <StackPanel Spacing="4"
+                                IsVisible="{Binding HasSuggestions}">
+                        <TextBlock Text="{Binding TopSuggestionText}"
+                                   Foreground="White"
+                                   FontFamily="Consolas"
+                                   TextWrapping="Wrap"/>
+                        <TextBlock Text="{Binding SelectedDescriptionText}"
+                                   Foreground="#C8E1FF"
+                                   FontSize="11"
+                                   TextWrapping="Wrap"/>
+                        <TextBlock Text="{Binding SelectedBadgesText}"
+                                   Foreground="#C8E1FF"
+                                   FontSize="11"
+                                   TextWrapping="Wrap"/>
+                        <TextBlock Text="{Binding SelectedMetadataText}"
+                                   Foreground="#9CA3AF"
+                                   FontSize="11"
+                                   TextWrapping="Wrap"/>
+                    </StackPanel>
+
+                    <Grid Grid.Row="1">
+                        <ItemsControl ItemsSource="{Binding Suggestions}"
+                                      IsVisible="{Binding HasSuggestions}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid ColumnDefinitions="Auto,*,Auto"
+                                          Margin="0,2">
+                                        <TextBlock Text="{Binding SelectionGlyph}"
+                                                   Foreground="#8EC5FF"
+                                                   Width="12"
+                                                   VerticalAlignment="Top"/>
+                                        <StackPanel Grid.Column="1"
+                                                    Spacing="1">
+                                            <TextBlock Text="{Binding DisplayText}"
+                                                       Foreground="White"
+                                                       FontFamily="Consolas"
+                                                       TextTrimming="CharacterEllipsis"/>
+                                            <TextBlock Text="{Binding DescriptionText}"
+                                                       Foreground="#C8E1FF"
+                                                       FontSize="11"
+                                                       TextWrapping="Wrap"/>
+                                            <TextBlock Text="{Binding MetadataText}"
+                                                       Foreground="#9CA3AF"
+                                                       FontSize="11"
+                                                       TextTrimming="CharacterEllipsis"/>
+                                        </StackPanel>
+                                        <TextBlock Grid.Column="2"
+                                                   Text="{Binding BadgesText}"
+                                                   Foreground="#C8E1FF"
+                                                   FontSize="11"
+                                                   HorizontalAlignment="Right"
+                                                   Margin="8,0,0,0"
+                                                   TextWrapping="Wrap"/>
+                                    </Grid>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+
+                        <TextBlock Text="{Binding EmptyStateText}"
+                                   Foreground="#9CA3AF"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"
+                                   IsVisible="{Binding ShowEmptyState}"
+                                   TextWrapping="Wrap"/>
+                    </Grid>
+                </Grid>
+            </Border>
         </Grid>
     </Border>
 </UserControl>

--- a/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml.cs
+++ b/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace NovaTerminal.CommandAssist.Views;
+
+public partial class CommandAssistPopupView : UserControl
+{
+    public CommandAssistPopupView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml
@@ -114,10 +114,19 @@
                 </Grid>
             </Border>
 
-            <assist:CommandAssistBarView x:Name="CommandAssistBar"
-                                         Grid.Row="0"
-                                         VerticalAlignment="Bottom"
-                                         ZIndex="150" />
+            <Grid x:Name="CommandAssistOverlayHost"
+                  Grid.Row="0"
+                  ZIndex="150"
+                  IsHitTestVisible="False">
+                <assist:CommandAssistPopupView x:Name="CommandAssistPopup"
+                                               HorizontalAlignment="Left"
+                                               VerticalAlignment="Bottom"
+                                               Margin="16,16,16,84" />
+                <assist:CommandAssistBubbleView x:Name="CommandAssistBubble"
+                                                HorizontalAlignment="Left"
+                                                VerticalAlignment="Bottom"
+                                                Margin="16,16,16,24" />
+            </Grid>
 
             <!-- Port Forwarding Status Bar -->
             <Border Name="StatusBar" VerticalAlignment="Bottom" Height="22" Background="#CC1A1A1A" 

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml
@@ -120,11 +120,11 @@
                   IsHitTestVisible="False">
                 <assist:CommandAssistPopupView x:Name="CommandAssistPopup"
                                                HorizontalAlignment="Left"
-                                               VerticalAlignment="Bottom"
+                                               VerticalAlignment="Top"
                                                Margin="16,16,16,84" />
                 <assist:CommandAssistBubbleView x:Name="CommandAssistBubble"
                                                 HorizontalAlignment="Left"
-                                                VerticalAlignment="Bottom"
+                                                VerticalAlignment="Top"
                                                 Margin="16,16,16,24" />
             </Grid>
 

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml
@@ -117,6 +117,7 @@
             <Grid x:Name="CommandAssistOverlayHost"
                   Grid.Row="0"
                   ZIndex="150"
+                  IsVisible="False"
                   IsHitTestVisible="False">
                 <assist:CommandAssistPopupView x:Name="CommandAssistPopup"
                                                HorizontalAlignment="Left"

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -538,12 +538,15 @@ namespace NovaTerminal.Controls
                 }
 
                 CommandAssistBubble.Width = layout.BubbleRect.Width;
+                CommandAssistBubble.Height = layout.BubbleRect.Height;
+                CommandAssistBubble.MinHeight = layout.BubbleRect.Height;
                 CommandAssistBubble.MaxWidth = layout.BubbleRect.Width;
+                CommandAssistBubble.MaxHeight = layout.BubbleRect.Height;
                 CommandAssistBubble.Margin = new Thickness(
                     layout.BubbleRect.X,
+                    layout.BubbleRect.Y,
                     0,
-                    0,
-                    Math.Max(0, paneHeight - layout.BubbleRect.Bottom));
+                    0);
             }
 
             if (CommandAssistPopup != null)
@@ -556,13 +559,15 @@ namespace NovaTerminal.Controls
                 }
 
                 CommandAssistPopup.Width = layout.PopupRect.Width;
+                CommandAssistPopup.Height = layout.PopupRect.Height;
+                CommandAssistPopup.MinHeight = layout.PopupRect.Height;
                 CommandAssistPopup.MaxWidth = layout.PopupRect.Width;
                 CommandAssistPopup.MaxHeight = layout.PopupRect.Height;
                 CommandAssistPopup.Margin = new Thickness(
                     layout.PopupRect.X,
+                    layout.PopupRect.Y,
                     0,
-                    0,
-                    Math.Max(0, paneHeight - layout.PopupRect.Bottom));
+                    0);
             }
         }
 

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -9,6 +9,7 @@ using NovaTerminal.Core;
 using Avalonia.Controls.Presenters;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using System.Net.NetworkInformation;
 using System.Linq;
@@ -72,6 +73,8 @@ namespace NovaTerminal.Controls
         private readonly CommandAssistAnchorCalculator _commandAssistAnchorCalculator = new();
         private string? _lastRelevantCommandText;
         private CommandAssistBarViewModel? _boundCommandAssistViewModel;
+        private readonly CommandAssistBubbleViewModel _hiddenCommandAssistBubbleViewModel = new() { IsVisible = false };
+        private readonly CommandAssistPopupViewModel _hiddenCommandAssistPopupViewModel = new(new ObservableCollection<CommandAssistSuggestionItemViewModel>()) { IsVisible = false };
         private const double CommandAssistBubbleWidth = 420;
         private const double CommandAssistBubbleHeight = 36;
         private const double CommandAssistPopupWidth = 520;
@@ -373,8 +376,9 @@ namespace NovaTerminal.Controls
 
         private void InitializeCommandAssist()
         {
-            if (_settings == null || !_settings.CommandAssistEnabled || !_settings.CommandAssistHistoryEnabled)
+            if (!IsCommandAssistFeatureEnabled())
             {
+                _commandAssistController?.Dismiss();
                 ClearCommandAssistBindings();
 
                 return;
@@ -389,8 +393,9 @@ namespace NovaTerminal.Controls
                 return;
             }
 
+            TerminalSettings settings = _settings!;
             _commandAssistController = new CommandAssistController(
-                CommandAssistInfrastructure.GetHistoryStore(_settings),
+                CommandAssistInfrastructure.GetHistoryStore(settings),
                 CommandAssistInfrastructure.GetSecretsFilter(),
                 CommandAssistInfrastructure.GetSuggestionEngine(),
                 CommandAssistInfrastructure.GetSnippetStore(),
@@ -406,10 +411,28 @@ namespace NovaTerminal.Controls
             _commandAssistController.HandleAltScreenChanged(Buffer?.IsAltScreenActive ?? false);
             UpdateCommandAssistContext();
 
-            TermView.TextInputObserved += text => _commandAssistController?.HandleTextInput(text);
-            TermView.BackspaceObserved += () => _commandAssistController?.HandleBackspace();
+            TermView.TextInputObserved += text =>
+            {
+                if (IsCommandAssistFeatureEnabled())
+                {
+                    _commandAssistController?.HandleTextInput(text);
+                }
+            };
+            TermView.BackspaceObserved += () =>
+            {
+                if (IsCommandAssistFeatureEnabled())
+                {
+                    _commandAssistController?.HandleBackspace();
+                }
+            };
             TermView.EnterObserved += OnCommandAssistEnterObserved;
-            TermView.PasteObserved += text => _commandAssistController?.HandlePastedText(text);
+            TermView.PasteObserved += text =>
+            {
+                if (IsCommandAssistFeatureEnabled())
+                {
+                    _commandAssistController?.HandlePastedText(text);
+                }
+            };
 
             if (Buffer != null)
             {
@@ -437,13 +460,11 @@ namespace NovaTerminal.Controls
             if (CommandAssistBubble != null)
             {
                 CommandAssistBubble.DataContext = viewModel?.Bubble;
-                CommandAssistBubble.IsVisible = viewModel?.Bubble.IsVisible ?? false;
             }
 
             if (CommandAssistPopup != null)
             {
                 CommandAssistPopup.DataContext = viewModel?.Popup;
-                CommandAssistPopup.IsVisible = viewModel?.Popup.IsVisible ?? false;
             }
 
             UpdateCommandAssistOverlayPlacement();
@@ -459,15 +480,19 @@ namespace NovaTerminal.Controls
 
             if (CommandAssistBubble != null)
             {
-                CommandAssistBubble.DataContext = null;
-                CommandAssistBubble.IsVisible = false;
+                CommandAssistBubble.DataContext = _hiddenCommandAssistBubbleViewModel;
             }
 
             if (CommandAssistPopup != null)
             {
-                CommandAssistPopup.DataContext = null;
-                CommandAssistPopup.IsVisible = false;
+                CommandAssistPopup.DataContext = _hiddenCommandAssistPopupViewModel;
             }
+        }
+
+        private bool IsCommandAssistFeatureEnabled()
+        {
+            return _settings?.CommandAssistEnabled == true &&
+                   _settings.CommandAssistHistoryEnabled;
         }
 
         private void OnCommandAssistViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -601,7 +626,7 @@ namespace NovaTerminal.Controls
 
         private async Task HandleCommandAssistEnterObservedAsync()
         {
-            if (_commandAssistController == null)
+            if (!IsCommandAssistFeatureEnabled() || _commandAssistController == null)
             {
                 return;
             }
@@ -652,6 +677,11 @@ namespace NovaTerminal.Controls
 
         internal bool TryHandleCommandAssistKey(Key key, KeyModifiers modifiers)
         {
+            if (!IsCommandAssistFeatureEnabled())
+            {
+                return false;
+            }
+
             CommandAssistController? controller = _commandAssistController;
             bool isAssistVisible = controller?.ViewModel.IsVisible == true;
             if (!CommandAssistKeyRouter.IsAssistOwnedKey(isAssistVisible, key, modifiers))
@@ -1136,21 +1166,41 @@ namespace NovaTerminal.Controls
 
         public void ToggleCommandAssist()
         {
+            if (!IsCommandAssistFeatureEnabled())
+            {
+                return;
+            }
+
             _commandAssistController?.ToggleAssist();
         }
 
         public bool OpenCommandAssistHelp()
         {
+            if (!IsCommandAssistFeatureEnabled())
+            {
+                return false;
+            }
+
             return _commandAssistController?.OpenHelp() ?? false;
         }
 
         public bool OpenCommandAssistHistorySearch()
         {
+            if (!IsCommandAssistFeatureEnabled())
+            {
+                return false;
+            }
+
             return _commandAssistController?.OpenHistorySearch() ?? false;
         }
 
         public void NotifyCommandAssistPaste(string text)
         {
+            if (!IsCommandAssistFeatureEnabled())
+            {
+                return;
+            }
+
             if (!string.IsNullOrWhiteSpace(text))
             {
                 _lastRelevantCommandText = text.Trim();
@@ -1161,12 +1211,22 @@ namespace NovaTerminal.Controls
 
         internal bool CanExplainSelection(string? selectedTextOverride = null)
         {
+            if (!IsCommandAssistFeatureEnabled())
+            {
+                return false;
+            }
+
             string? selectedText = selectedTextOverride ?? TermView.GetSelectedText();
             return _commandAssistController != null && !string.IsNullOrWhiteSpace(selectedText);
         }
 
         internal async Task<bool> ExplainSelectionAsync(string? selectedTextOverride = null)
         {
+            if (!IsCommandAssistFeatureEnabled())
+            {
+                return false;
+            }
+
             if (_commandAssistController == null)
             {
                 return false;
@@ -1550,6 +1610,11 @@ namespace NovaTerminal.Controls
 
         internal async Task HandleCommandAssistCompletionAsync(int? exitCode)
         {
+            if (!IsCommandAssistFeatureEnabled())
+            {
+                return;
+            }
+
             if (_commandAssistController == null)
             {
                 return;
@@ -1585,7 +1650,7 @@ namespace NovaTerminal.Controls
 
         private async Task HandleShellIntegrationEventAsync(ShellIntegrationEvent shellEvent)
         {
-            if (_commandAssistController == null)
+            if (!IsCommandAssistFeatureEnabled() || _commandAssistController == null)
             {
                 return;
             }

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -76,6 +76,7 @@ namespace NovaTerminal.Controls
         private string? _lastCommandAssistAnchorDiagnosticSignature;
         private string? _lastCommandAssistAnchorAppliedSignature;
         private string? _lastCommandAssistAnchorCorrectionSignature;
+        private bool _suppressSshAssistOverlayUntilSettled;
         private readonly CommandAssistBubbleViewModel _hiddenCommandAssistBubbleViewModel = new() { IsVisible = false };
         private readonly CommandAssistPopupViewModel _hiddenCommandAssistPopupViewModel = new(new ObservableCollection<CommandAssistSuggestionItemViewModel>()) { IsVisible = false };
         private const double CommandAssistBubbleWidth = 420;
@@ -668,10 +669,15 @@ namespace NovaTerminal.Controls
         {
             CommandAssistAnchorLayout? layout = TryCalculateCommandAssistAnchorLayout();
             bool shouldShowOverlayHost = layout != null && (_boundCommandAssistViewModel?.IsVisible == true);
+            if (!shouldShowOverlayHost)
+            {
+                _suppressSshAssistOverlayUntilSettled = false;
+            }
+
             if (CommandAssistOverlayHost != null)
             {
                 CommandAssistOverlayHost.IsVisible = shouldShowOverlayHost;
-                CommandAssistOverlayHost.Opacity = shouldShowOverlayHost ? 1.0 : 0.0;
+                CommandAssistOverlayHost.Opacity = shouldShowOverlayHost && !_suppressSshAssistOverlayUntilSettled ? 1.0 : 0.0;
             }
 
             if (layout == null)
@@ -766,8 +772,17 @@ namespace NovaTerminal.Controls
                 double drift = Math.Abs(actualTop - expectedTop);
                 if (drift <= 2)
                 {
+                    if (_suppressSshAssistOverlayUntilSettled)
+                    {
+                        _suppressSshAssistOverlayUntilSettled = false;
+                        CommandAssistOverlayHost.Opacity = 1.0;
+                    }
+
                     return;
                 }
+
+                _suppressSshAssistOverlayUntilSettled = true;
+                CommandAssistOverlayHost.Opacity = 0.0;
 
                 // Re-apply anchored margins if the rendered position drifted from expected.
                 CommandAssistBubble.Margin = new Thickness(layout.BubbleRect.X, layout.BubbleRect.Y, 0, 0);
@@ -777,13 +792,18 @@ namespace NovaTerminal.Controls
                 }
 
                 string signature = $"expected={expectedTop:F0},actual={actualTop:F0},drift={drift:F0}";
-                if (string.Equals(signature, _lastCommandAssistAnchorCorrectionSignature, StringComparison.Ordinal))
+                if (!string.Equals(signature, _lastCommandAssistAnchorCorrectionSignature, StringComparison.Ordinal))
                 {
-                    return;
+                    _lastCommandAssistAnchorCorrectionSignature = signature;
+                    TerminalLogger.Log($"[AssistAnchor][SSH][Corrected] {signature}");
                 }
 
-                _lastCommandAssistAnchorCorrectionSignature = signature;
-                TerminalLogger.Log($"[AssistAnchor][SSH][Corrected] {signature}");
+                // Re-evaluate on the next render pass; keep host hidden until settled.
+                Dispatcher.UIThread.Post(() =>
+                {
+                    _suppressSshAssistOverlayUntilSettled = false;
+                    UpdateCommandAssistOverlayPlacement();
+                }, DispatcherPriority.Render);
             }
 
             if (Dispatcher.UIThread.CheckAccess())

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -74,6 +74,7 @@ namespace NovaTerminal.Controls
         private string? _lastRelevantCommandText;
         private CommandAssistBarViewModel? _boundCommandAssistViewModel;
         private string? _lastCommandAssistAnchorDiagnosticSignature;
+        private string? _lastCommandAssistAnchorAppliedSignature;
         private readonly CommandAssistBubbleViewModel _hiddenCommandAssistBubbleViewModel = new() { IsVisible = false };
         private readonly CommandAssistPopupViewModel _hiddenCommandAssistPopupViewModel = new(new ObservableCollection<CommandAssistSuggestionItemViewModel>()) { IsVisible = false };
         private const double CommandAssistBubbleWidth = 420;
@@ -714,6 +715,26 @@ namespace NovaTerminal.Controls
                     0,
                     0);
             }
+
+            LogCommandAssistAnchorAppliedDiagnostics(layout);
+        }
+
+        private void LogCommandAssistAnchorAppliedDiagnostics(CommandAssistAnchorLayout layout)
+        {
+            if (Profile?.Type != ConnectionType.SSH || CommandAssistBubble == null)
+            {
+                return;
+            }
+
+            string signature =
+                $"layoutY={layout.BubbleRect.Y:F0},layoutPromptY={layout.PromptRect.Y:F0},appliedBubbleTop={CommandAssistBubble.Margin.Top:F0},appliedBubbleVis={CommandAssistBubble.IsVisible},hostVis={CommandAssistOverlayHost?.IsVisible == true},vmVis={_boundCommandAssistViewModel?.IsVisible == true}";
+            if (string.Equals(signature, _lastCommandAssistAnchorAppliedSignature, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            _lastCommandAssistAnchorAppliedSignature = signature;
+            TerminalLogger.Log($"[AssistAnchor][SSH][Applied] {signature}");
         }
 
         private void OnBufferScreenSwitched(bool isAltScreen)
@@ -1448,6 +1469,7 @@ namespace NovaTerminal.Controls
             {
                 UpdateFocusVisuals(IsKeyboardFocusWithin);
                 TermView.InvalidateVisual();
+                UpdateCommandAssistOverlayPlacement();
             }, DispatcherPriority.Loaded);
         }
 

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -524,6 +524,17 @@ namespace NovaTerminal.Controls
             int fallbackVisibleRows = TermView.Rows > 0 ? TermView.Rows : 1;
             CommandAssistSurfaceSizing sizing = CalculateCommandAssistSurfaceSizing(paneWidth, paneHeight);
             bool hasReliablePromptAnchor = IsCommandAssistPromptAnchorReliable(promptHint);
+            float anchorCellHeight = promptHint?.CellHeight ?? fallbackCellHeight;
+            int hintCursorRow = promptHint?.VisibleCursorVisualRow ?? 0;
+            int hintVisibleRows = promptHint?.VisibleRows ?? fallbackVisibleRows;
+            int paneEstimatedVisibleRows = anchorCellHeight > 0
+                ? Math.Max(1, (int)Math.Floor(paneHeight / anchorCellHeight))
+                : hintVisibleRows;
+            bool shouldUsePaneEstimatedRows = Profile?.Type == ConnectionType.SSH &&
+                                              !hasReliablePromptAnchor &&
+                                              paneEstimatedVisibleRows > hintVisibleRows;
+            int anchorVisibleRows = shouldUsePaneEstimatedRows ? paneEstimatedVisibleRows : hintVisibleRows;
+            int anchorCursorRow = Math.Clamp(hintCursorRow, 0, Math.Max(0, anchorVisibleRows - 1));
             if (ShouldSuppressConservativeRemoteAssist(promptHint, hasReliablePromptAnchor, paneHeight))
             {
                 return null;
@@ -532,9 +543,9 @@ namespace NovaTerminal.Controls
             return _commandAssistAnchorCalculator.Calculate(new CommandAssistAnchorRequest(
                 PaneWidth: paneWidth,
                 PaneHeight: paneHeight,
-                CellHeight: promptHint?.CellHeight ?? fallbackCellHeight,
-                CursorVisualRow: promptHint?.VisibleCursorVisualRow ?? 0,
-                VisibleRows: promptHint?.VisibleRows ?? fallbackVisibleRows,
+                CellHeight: anchorCellHeight,
+                CursorVisualRow: anchorCursorRow,
+                VisibleRows: anchorVisibleRows,
                 BubbleWidth: sizing.BubbleWidth,
                 BubbleHeight: sizing.BubbleHeight,
                 PopupWidth: sizing.PopupWidth,

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -75,6 +75,7 @@ namespace NovaTerminal.Controls
         private CommandAssistBarViewModel? _boundCommandAssistViewModel;
         private string? _lastCommandAssistAnchorDiagnosticSignature;
         private string? _lastCommandAssistAnchorAppliedSignature;
+        private string? _lastCommandAssistAnchorCorrectionSignature;
         private readonly CommandAssistBubbleViewModel _hiddenCommandAssistBubbleViewModel = new() { IsVisible = false };
         private readonly CommandAssistPopupViewModel _hiddenCommandAssistPopupViewModel = new(new ObservableCollection<CommandAssistSuggestionItemViewModel>()) { IsVisible = false };
         private const double CommandAssistBubbleWidth = 420;
@@ -719,6 +720,7 @@ namespace NovaTerminal.Controls
             }
 
             LogCommandAssistAnchorAppliedDiagnostics(layout);
+            ScheduleCommandAssistPlacementCorrection(layout);
         }
 
         private void LogCommandAssistAnchorAppliedDiagnostics(CommandAssistAnchorLayout layout)
@@ -737,6 +739,61 @@ namespace NovaTerminal.Controls
 
             _lastCommandAssistAnchorAppliedSignature = signature;
             TerminalLogger.Log($"[AssistAnchor][SSH][Applied] {signature}");
+        }
+
+        private void ScheduleCommandAssistPlacementCorrection(CommandAssistAnchorLayout layout)
+        {
+            if (Profile?.Type != ConnectionType.SSH || _boundCommandAssistViewModel?.IsVisible != true)
+            {
+                return;
+            }
+
+            void CorrectPlacement()
+            {
+                if (CommandAssistBubble == null || CommandAssistOverlayHost == null || !CommandAssistOverlayHost.IsVisible)
+                {
+                    return;
+                }
+
+                Point? bubbleTopLeft = CommandAssistBubble.TranslatePoint(new Point(0, 0), this);
+                if (!bubbleTopLeft.HasValue)
+                {
+                    return;
+                }
+
+                double expectedTop = layout.BubbleRect.Y;
+                double actualTop = bubbleTopLeft.Value.Y;
+                double drift = Math.Abs(actualTop - expectedTop);
+                if (drift <= 2)
+                {
+                    return;
+                }
+
+                // Re-apply anchored margins if the rendered position drifted from expected.
+                CommandAssistBubble.Margin = new Thickness(layout.BubbleRect.X, layout.BubbleRect.Y, 0, 0);
+                if (CommandAssistPopup != null)
+                {
+                    CommandAssistPopup.Margin = new Thickness(layout.PopupRect.X, layout.PopupRect.Y, 0, 0);
+                }
+
+                string signature = $"expected={expectedTop:F0},actual={actualTop:F0},drift={drift:F0}";
+                if (string.Equals(signature, _lastCommandAssistAnchorCorrectionSignature, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                _lastCommandAssistAnchorCorrectionSignature = signature;
+                TerminalLogger.Log($"[AssistAnchor][SSH][Corrected] {signature}");
+            }
+
+            if (Dispatcher.UIThread.CheckAccess())
+            {
+                CorrectPlacement();
+            }
+            else
+            {
+                Dispatcher.UIThread.Post(CorrectPlacement, DispatcherPriority.Render);
+            }
         }
 
         private void OnBufferScreenSwitched(bool isAltScreen)

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -670,6 +670,7 @@ namespace NovaTerminal.Controls
             if (CommandAssistOverlayHost != null)
             {
                 CommandAssistOverlayHost.IsVisible = shouldShowOverlayHost;
+                CommandAssistOverlayHost.Opacity = shouldShowOverlayHost ? 1.0 : 0.0;
             }
 
             if (layout == null)

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -493,6 +493,7 @@ namespace NovaTerminal.Controls
             float fallbackCellHeight = TermView.Metrics.CellHeight > 0 ? TermView.Metrics.CellHeight : 18;
             int fallbackVisibleRows = TermView.Rows > 0 ? TermView.Rows : 1;
             CommandAssistSurfaceSizing sizing = CalculateCommandAssistSurfaceSizing(paneWidth, paneHeight);
+            bool hasReliablePromptAnchor = IsCommandAssistPromptAnchorReliable(promptHint);
 
             return _commandAssistAnchorCalculator.Calculate(new CommandAssistAnchorRequest(
                 PaneWidth: paneWidth,
@@ -504,7 +505,24 @@ namespace NovaTerminal.Controls
                 BubbleHeight: sizing.BubbleHeight,
                 PopupWidth: sizing.PopupWidth,
                 PopupHeight: sizing.PopupHeight,
-                HasReliablePromptAnchor: promptHint.HasValue));
+                HasReliablePromptAnchor: hasReliablePromptAnchor));
+        }
+
+        private bool IsCommandAssistPromptAnchorReliable(CommandAssistPromptHint? promptHint)
+        {
+            if (!promptHint.HasValue)
+            {
+                return false;
+            }
+
+            // SSH sessions currently stay on the heuristic path, so cursor-row hints are not
+            // trustworthy enough for prompt-adjacent anchoring.
+            if (Profile?.Type == ConnectionType.SSH)
+            {
+                return false;
+            }
+
+            return true;
         }
 
         private static CommandAssistSurfaceSizing CalculateCommandAssistSurfaceSizing(double paneWidth, double paneHeight)

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -507,8 +507,10 @@ namespace NovaTerminal.Controls
 
         private CommandAssistAnchorLayout? TryCalculateCommandAssistAnchorLayout()
         {
-            double paneWidth = TermView.Bounds.Width > 0 ? TermView.Bounds.Width : Bounds.Width;
-            double paneHeight = TermView.Bounds.Height > 0 ? TermView.Bounds.Height : Bounds.Height;
+            // During startup (especially SSH), TermView bounds can briefly report a partial height.
+            // Anchor against the host pane bounds first so overlays don't jump to the top band.
+            double paneWidth = Bounds.Width > 0 ? Bounds.Width : TermView.Bounds.Width;
+            double paneHeight = Bounds.Height > 0 ? Bounds.Height : TermView.Bounds.Height;
             if (paneWidth <= 0 || paneHeight <= 0)
             {
                 return null;

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -73,6 +73,7 @@ namespace NovaTerminal.Controls
         private readonly CommandAssistAnchorCalculator _commandAssistAnchorCalculator = new();
         private string? _lastRelevantCommandText;
         private CommandAssistBarViewModel? _boundCommandAssistViewModel;
+        private string? _lastCommandAssistAnchorDiagnosticSignature;
         private readonly CommandAssistBubbleViewModel _hiddenCommandAssistBubbleViewModel = new() { IsVisible = false };
         private readonly CommandAssistPopupViewModel _hiddenCommandAssistPopupViewModel = new(new ObservableCollection<CommandAssistSuggestionItemViewModel>()) { IsVisible = false };
         private const double CommandAssistBubbleWidth = 420;
@@ -535,12 +536,23 @@ namespace NovaTerminal.Controls
                                               paneEstimatedVisibleRows > hintVisibleRows;
             int anchorVisibleRows = shouldUsePaneEstimatedRows ? paneEstimatedVisibleRows : hintVisibleRows;
             int anchorCursorRow = Math.Clamp(hintCursorRow, 0, Math.Max(0, anchorVisibleRows - 1));
-            if (ShouldSuppressConservativeRemoteAssist(promptHint, hasReliablePromptAnchor, paneHeight))
+            bool shouldSuppress = ShouldSuppressConservativeRemoteAssist(promptHint, hasReliablePromptAnchor, paneHeight);
+            if (shouldSuppress)
             {
+                LogCommandAssistAnchorDiagnostics(
+                    paneWidth,
+                    paneHeight,
+                    hasReliablePromptAnchor,
+                    promptHint,
+                    anchorCellHeight,
+                    anchorCursorRow,
+                    anchorVisibleRows,
+                    shouldSuppress,
+                    layout: null);
                 return null;
             }
 
-            return _commandAssistAnchorCalculator.Calculate(new CommandAssistAnchorRequest(
+            CommandAssistAnchorLayout layout = _commandAssistAnchorCalculator.Calculate(new CommandAssistAnchorRequest(
                 PaneWidth: paneWidth,
                 PaneHeight: paneHeight,
                 CellHeight: anchorCellHeight,
@@ -551,6 +563,49 @@ namespace NovaTerminal.Controls
                 PopupWidth: sizing.PopupWidth,
                 PopupHeight: sizing.PopupHeight,
                 HasReliablePromptAnchor: hasReliablePromptAnchor));
+            LogCommandAssistAnchorDiagnostics(
+                paneWidth,
+                paneHeight,
+                hasReliablePromptAnchor,
+                promptHint,
+                anchorCellHeight,
+                anchorCursorRow,
+                anchorVisibleRows,
+                shouldSuppress,
+                layout);
+            return layout;
+        }
+
+        private void LogCommandAssistAnchorDiagnostics(
+            double paneWidth,
+            double paneHeight,
+            bool hasReliablePromptAnchor,
+            CommandAssistPromptHint? promptHint,
+            float anchorCellHeight,
+            int anchorCursorRow,
+            int anchorVisibleRows,
+            bool shouldSuppress,
+            CommandAssistAnchorLayout? layout)
+        {
+            if (Profile?.Type != ConnectionType.SSH)
+            {
+                return;
+            }
+
+            int hintCursorRow = promptHint?.VisibleCursorVisualRow ?? -1;
+            int hintVisibleRows = promptHint?.VisibleRows ?? -1;
+            string layoutState = layout == null
+                ? "none"
+                : $"bubbleY={layout.BubbleRect.Y:F0},bubbleBottom={layout.BubbleRect.Bottom:F0},promptY={layout.PromptRect.Y:F0},usesPrompt={layout.UsesPromptAnchor}";
+            string signature =
+                $"pw={paneWidth:F0},ph={paneHeight:F0},tw={TermView.Bounds.Width:F0},th={TermView.Bounds.Height:F0},rel={hasReliablePromptAnchor},sup={shouldSuppress},hintRow={hintCursorRow},hintRows={hintVisibleRows},cell={anchorCellHeight:F1},anchorRow={anchorCursorRow},anchorRows={anchorVisibleRows},vmVis={_boundCommandAssistViewModel?.IsVisible == true},{layoutState}";
+            if (string.Equals(signature, _lastCommandAssistAnchorDiagnosticSignature, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            _lastCommandAssistAnchorDiagnosticSignature = signature;
+            TerminalLogger.Log($"[AssistAnchor][SSH] {signature}");
         }
 
         private bool ShouldSuppressConservativeRemoteAssist(

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -15,8 +15,10 @@ using System.Linq;
 using Avalonia.Controls.Shapes;
 using Avalonia.Automation;
 using Avalonia.Platform.Storage;
+using System.ComponentModel;
 using NovaTerminal.CommandAssist.Application;
 using NovaTerminal.CommandAssist.Models;
+using NovaTerminal.CommandAssist.ViewModels;
 using NovaTerminal.CommandAssist.ShellIntegration.Contracts;
 using NovaTerminal.CommandAssist.ShellIntegration.PowerShell;
 using NovaTerminal.CommandAssist.ShellIntegration.Runtime;
@@ -67,7 +69,14 @@ namespace NovaTerminal.Controls
         private ShellLifecycleTracker? _shellLifecycleTracker;
         private bool _isShellIntegrationActive;
         private readonly OrderedAsyncEventDispatcher _shellIntegrationEventDispatcher = new();
+        private readonly CommandAssistAnchorCalculator _commandAssistAnchorCalculator = new();
         private string? _lastRelevantCommandText;
+        private CommandAssistBarViewModel? _boundCommandAssistViewModel;
+        private const double CommandAssistBubbleWidth = 420;
+        private const double CommandAssistBubbleHeight = 36;
+        private const double CommandAssistPopupWidth = 520;
+        private const double CommandAssistPopupHeight = 220;
+        internal CommandAssistBarViewModel? CommandAssistViewModel => _commandAssistController?.ViewModel;
 
         public bool IsRecording => Session?.IsRecording ?? false;
         public string? CurrentWorkingDirectory { get; private set; }
@@ -256,7 +265,13 @@ namespace NovaTerminal.Controls
             // Wire up focus syncing
             TermView.GotFocus += (s, e) => UpdateFocusVisuals(true);
             TermView.LostFocus += (s, e) => UpdateFocusVisuals(false);
-            TermView.MetricsChanged += (cw, ch) => UpdateMinimumSizeConstraints();
+            TermView.MetricsChanged += (cw, ch) =>
+            {
+                UpdateMinimumSizeConstraints();
+                UpdateCommandAssistOverlayPlacement();
+            };
+            TermView.CommandAssistAnchorHintChanged += () => UpdateCommandAssistOverlayPlacement();
+            SizeChanged += (_, _) => UpdateCommandAssistOverlayPlacement();
 
             // Load Settings
             ApplySettings(TerminalSettings.Load());
@@ -358,21 +373,14 @@ namespace NovaTerminal.Controls
         {
             if (_settings == null || !_settings.CommandAssistEnabled || !_settings.CommandAssistHistoryEnabled)
             {
-                if (CommandAssistBar != null)
-                {
-                    CommandAssistBar.DataContext = null;
-                    CommandAssistBar.IsVisible = false;
-                }
+                ClearCommandAssistBindings();
 
                 return;
             }
 
             if (_commandAssistController != null)
             {
-                if (CommandAssistBar != null)
-                {
-                    CommandAssistBar.DataContext = _commandAssistController.ViewModel;
-                }
+                BindCommandAssistViews(_commandAssistController.ViewModel);
 
                 _commandAssistController.HandleAltScreenChanged(Buffer?.IsAltScreenActive ?? false);
                 UpdateCommandAssistContext();
@@ -391,10 +399,7 @@ namespace NovaTerminal.Controls
                 resultBuilder: null,
                 action => Dispatcher.UIThread.Post(action));
 
-            if (CommandAssistBar != null)
-            {
-                CommandAssistBar.DataContext = _commandAssistController.ViewModel;
-            }
+            BindCommandAssistViews(_commandAssistController.ViewModel);
 
             _commandAssistController.HandleAltScreenChanged(Buffer?.IsAltScreenActive ?? false);
             UpdateCommandAssistContext();
@@ -407,6 +412,134 @@ namespace NovaTerminal.Controls
             if (Buffer != null)
             {
                 Buffer.OnScreenSwitched += OnBufferScreenSwitched;
+            }
+        }
+
+        private void BindCommandAssistViews(CommandAssistBarViewModel? viewModel)
+        {
+            if (!ReferenceEquals(_boundCommandAssistViewModel, viewModel))
+            {
+                if (_boundCommandAssistViewModel != null)
+                {
+                    _boundCommandAssistViewModel.PropertyChanged -= OnCommandAssistViewModelPropertyChanged;
+                }
+
+                _boundCommandAssistViewModel = viewModel;
+
+                if (_boundCommandAssistViewModel != null)
+                {
+                    _boundCommandAssistViewModel.PropertyChanged += OnCommandAssistViewModelPropertyChanged;
+                }
+            }
+
+            if (CommandAssistBubble != null)
+            {
+                CommandAssistBubble.DataContext = viewModel?.Bubble;
+                CommandAssistBubble.IsVisible = viewModel?.Bubble.IsVisible ?? false;
+            }
+
+            if (CommandAssistPopup != null)
+            {
+                CommandAssistPopup.DataContext = viewModel?.Popup;
+                CommandAssistPopup.IsVisible = viewModel?.Popup.IsVisible ?? false;
+            }
+
+            UpdateCommandAssistOverlayPlacement();
+        }
+
+        private void ClearCommandAssistBindings()
+        {
+            if (_boundCommandAssistViewModel != null)
+            {
+                _boundCommandAssistViewModel.PropertyChanged -= OnCommandAssistViewModelPropertyChanged;
+                _boundCommandAssistViewModel = null;
+            }
+
+            if (CommandAssistBubble != null)
+            {
+                CommandAssistBubble.DataContext = null;
+                CommandAssistBubble.IsVisible = false;
+            }
+
+            if (CommandAssistPopup != null)
+            {
+                CommandAssistPopup.DataContext = null;
+                CommandAssistPopup.IsVisible = false;
+            }
+        }
+
+        private void OnCommandAssistViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            UpdateCommandAssistOverlayPlacement();
+        }
+
+        internal CommandAssistAnchorLayout? CalculateCommandAssistAnchorLayoutForTest()
+        {
+            return TryCalculateCommandAssistAnchorLayout();
+        }
+
+        private CommandAssistAnchorLayout? TryCalculateCommandAssistAnchorLayout()
+        {
+            double paneWidth = TermView.Bounds.Width > 0 ? TermView.Bounds.Width : Bounds.Width;
+            double paneHeight = TermView.Bounds.Height > 0 ? TermView.Bounds.Height : Bounds.Height;
+            if (paneWidth <= 0 || paneHeight <= 0)
+            {
+                return null;
+            }
+
+            CommandAssistPromptHint? promptHint = TermView.GetCommandAssistPromptHint();
+            float fallbackCellHeight = TermView.Metrics.CellHeight > 0 ? TermView.Metrics.CellHeight : 18;
+            int fallbackVisibleRows = TermView.Rows > 0 ? TermView.Rows : 1;
+
+            return _commandAssistAnchorCalculator.Calculate(new CommandAssistAnchorRequest(
+                PaneWidth: paneWidth,
+                PaneHeight: paneHeight,
+                CellHeight: promptHint?.CellHeight ?? fallbackCellHeight,
+                CursorVisualRow: promptHint?.VisibleCursorVisualRow ?? 0,
+                VisibleRows: promptHint?.VisibleRows ?? fallbackVisibleRows,
+                BubbleWidth: CommandAssistBubbleWidth,
+                BubbleHeight: CommandAssistBubbleHeight,
+                PopupWidth: CommandAssistPopupWidth,
+                PopupHeight: CommandAssistPopupHeight,
+                HasReliablePromptAnchor: promptHint.HasValue));
+        }
+
+        private void UpdateCommandAssistOverlayPlacement()
+        {
+            CommandAssistAnchorLayout? layout = TryCalculateCommandAssistAnchorLayout();
+            if (layout == null)
+            {
+                return;
+            }
+
+            double paneHeight = TermView.Bounds.Height > 0 ? TermView.Bounds.Height : Bounds.Height;
+
+            if (CommandAssistBubble != null)
+            {
+                if (_boundCommandAssistViewModel != null)
+                {
+                    _boundCommandAssistViewModel.Bubble.ShowQueryText = !layout.UseCompactBubbleLayout;
+                }
+
+                CommandAssistBubble.Width = layout.BubbleRect.Width;
+                CommandAssistBubble.MaxWidth = layout.BubbleRect.Width;
+                CommandAssistBubble.Margin = new Thickness(
+                    layout.BubbleRect.X,
+                    0,
+                    0,
+                    Math.Max(0, paneHeight - layout.BubbleRect.Bottom));
+            }
+
+            if (CommandAssistPopup != null)
+            {
+                CommandAssistPopup.Width = layout.PopupRect.Width;
+                CommandAssistPopup.MaxWidth = layout.PopupRect.Width;
+                CommandAssistPopup.MaxHeight = layout.PopupRect.Height;
+                CommandAssistPopup.Margin = new Thickness(
+                    layout.PopupRect.X,
+                    0,
+                    0,
+                    Math.Max(0, paneHeight - layout.PopupRect.Bottom));
             }
         }
 

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -81,6 +81,9 @@ namespace NovaTerminal.Controls
         private const double CommandAssistPopupHeight = 220;
         private const double CompactPopupWidthThreshold = 420;
         private const double CompactPopupHeightThreshold = 180;
+        private const double ConservativeRemotePromptBandStartRatio = 0.55;
+        private const int ConservativeRemoteMinVisibleRows = 8;
+        private const double ConservativeRemoteShortPaneHeightThreshold = 300;
         internal CommandAssistBarViewModel? CommandAssistViewModel => _commandAssistController?.ViewModel;
 
         public bool IsRecording => Session?.IsRecording ?? false;
@@ -521,6 +524,10 @@ namespace NovaTerminal.Controls
             int fallbackVisibleRows = TermView.Rows > 0 ? TermView.Rows : 1;
             CommandAssistSurfaceSizing sizing = CalculateCommandAssistSurfaceSizing(paneWidth, paneHeight);
             bool hasReliablePromptAnchor = IsCommandAssistPromptAnchorReliable(promptHint);
+            if (ShouldSuppressConservativeRemoteAssist(promptHint, hasReliablePromptAnchor, paneHeight))
+            {
+                return null;
+            }
 
             return _commandAssistAnchorCalculator.Calculate(new CommandAssistAnchorRequest(
                 PaneWidth: paneWidth,
@@ -533,6 +540,30 @@ namespace NovaTerminal.Controls
                 PopupWidth: sizing.PopupWidth,
                 PopupHeight: sizing.PopupHeight,
                 HasReliablePromptAnchor: hasReliablePromptAnchor));
+        }
+
+        private bool ShouldSuppressConservativeRemoteAssist(
+            CommandAssistPromptHint? promptHint,
+            bool hasReliablePromptAnchor,
+            double paneHeight)
+        {
+            if (Profile?.Type != ConnectionType.SSH || hasReliablePromptAnchor || paneHeight > ConservativeRemoteShortPaneHeightThreshold)
+            {
+                return false;
+            }
+
+            if (!promptHint.HasValue)
+            {
+                return true;
+            }
+
+            if (promptHint.Value.VisibleRows < ConservativeRemoteMinVisibleRows)
+            {
+                return true;
+            }
+
+            double normalizedCursorRow = promptHint.Value.VisibleCursorVisualRow / (double)Math.Max(1, promptHint.Value.VisibleRows - 1);
+            return normalizedCursorRow < ConservativeRemotePromptBandStartRatio;
         }
 
         private bool IsCommandAssistPromptAnchorReliable(CommandAssistPromptHint? promptHint)
@@ -568,12 +599,15 @@ namespace NovaTerminal.Controls
         private void UpdateCommandAssistOverlayPlacement()
         {
             CommandAssistAnchorLayout? layout = TryCalculateCommandAssistAnchorLayout();
+            if (CommandAssistOverlayHost != null)
+            {
+                CommandAssistOverlayHost.IsVisible = layout != null;
+            }
+
             if (layout == null)
             {
                 return;
             }
-
-            double paneHeight = TermView.Bounds.Height > 0 ? TermView.Bounds.Height : Bounds.Height;
 
             if (CommandAssistBubble != null)
             {

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -77,6 +77,7 @@ namespace NovaTerminal.Controls
         private string? _lastCommandAssistAnchorAppliedSignature;
         private string? _lastCommandAssistAnchorCorrectionSignature;
         private bool _suppressSshAssistOverlayUntilSettled;
+        private int _sshAssistCorrectionPassCount;
         private readonly CommandAssistBubbleViewModel _hiddenCommandAssistBubbleViewModel = new() { IsVisible = false };
         private readonly CommandAssistPopupViewModel _hiddenCommandAssistPopupViewModel = new(new ObservableCollection<CommandAssistSuggestionItemViewModel>()) { IsVisible = false };
         private const double CommandAssistBubbleWidth = 420;
@@ -88,6 +89,7 @@ namespace NovaTerminal.Controls
         private const double ConservativeRemotePromptBandStartRatio = 0.55;
         private const int ConservativeRemoteMinVisibleRows = 8;
         private const double ConservativeRemoteShortPaneHeightThreshold = 300;
+        private const int MaxSshAssistCorrectionPasses = 6;
         internal CommandAssistBarViewModel? CommandAssistViewModel => _commandAssistController?.ViewModel;
 
         public bool IsRecording => Session?.IsRecording ?? false;
@@ -672,6 +674,7 @@ namespace NovaTerminal.Controls
             if (!shouldShowOverlayHost)
             {
                 _suppressSshAssistOverlayUntilSettled = false;
+                _sshAssistCorrectionPassCount = 0;
             }
 
             if (CommandAssistOverlayHost != null)
@@ -761,17 +764,29 @@ namespace NovaTerminal.Controls
                     return;
                 }
 
-                Point? bubbleTopLeft = CommandAssistBubble.TranslatePoint(new Point(0, 0), this);
-                if (!bubbleTopLeft.HasValue)
+                Control? anchorControl = CommandAssistBubble.IsVisible
+                    ? CommandAssistBubble
+                    : CommandAssistPopup != null && CommandAssistPopup.IsVisible
+                        ? CommandAssistPopup
+                        : null;
+                if (anchorControl == null)
                 {
                     return;
                 }
 
-                double expectedTop = layout.BubbleRect.Y;
-                double actualTop = bubbleTopLeft.Value.Y;
+                Point? anchorTopLeft = anchorControl.TranslatePoint(new Point(0, 0), this);
+                if (!anchorTopLeft.HasValue)
+                {
+                    return;
+                }
+
+                bool anchoredToBubble = ReferenceEquals(anchorControl, CommandAssistBubble);
+                double expectedTop = anchoredToBubble ? layout.BubbleRect.Y : layout.PopupRect.Y;
+                double actualTop = anchorTopLeft.Value.Y;
                 double drift = Math.Abs(actualTop - expectedTop);
                 if (drift <= 2)
                 {
+                    _sshAssistCorrectionPassCount = 0;
                     if (_suppressSshAssistOverlayUntilSettled)
                     {
                         _suppressSshAssistOverlayUntilSettled = false;
@@ -791,29 +806,29 @@ namespace NovaTerminal.Controls
                     CommandAssistPopup.Margin = new Thickness(layout.PopupRect.X, layout.PopupRect.Y, 0, 0);
                 }
 
-                string signature = $"expected={expectedTop:F0},actual={actualTop:F0},drift={drift:F0}";
+                string signature = $"anchor={(anchoredToBubble ? "bubble" : "popup")},expected={expectedTop:F0},actual={actualTop:F0},drift={drift:F0},pass={_sshAssistCorrectionPassCount}";
                 if (!string.Equals(signature, _lastCommandAssistAnchorCorrectionSignature, StringComparison.Ordinal))
                 {
                     _lastCommandAssistAnchorCorrectionSignature = signature;
                     TerminalLogger.Log($"[AssistAnchor][SSH][Corrected] {signature}");
                 }
 
-                // Re-evaluate on the next render pass; keep host hidden until settled.
-                Dispatcher.UIThread.Post(() =>
+                if (_sshAssistCorrectionPassCount >= MaxSshAssistCorrectionPasses)
                 {
                     _suppressSshAssistOverlayUntilSettled = false;
-                    UpdateCommandAssistOverlayPlacement();
-                }, DispatcherPriority.Render);
+                    _sshAssistCorrectionPassCount = 0;
+                    CommandAssistOverlayHost.Opacity = 1.0;
+                    TerminalLogger.Log("[AssistAnchor][SSH][Corrected] max-pass reached; showing overlay with best-known anchor.");
+                    return;
+                }
+
+                _sshAssistCorrectionPassCount++;
+
+                // Re-evaluate on the next render pass; keep host hidden until settled.
+                Dispatcher.UIThread.Post(UpdateCommandAssistOverlayPlacement, DispatcherPriority.Render);
             }
 
-            if (Dispatcher.UIThread.CheckAccess())
-            {
-                CorrectPlacement();
-            }
-            else
-            {
-                Dispatcher.UIThread.Post(CorrectPlacement, DispatcherPriority.Render);
-            }
+            Dispatcher.UIThread.Post(CorrectPlacement, DispatcherPriority.Render);
         }
 
         private void OnBufferScreenSwitched(bool isAltScreen)

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -666,9 +666,10 @@ namespace NovaTerminal.Controls
         private void UpdateCommandAssistOverlayPlacement()
         {
             CommandAssistAnchorLayout? layout = TryCalculateCommandAssistAnchorLayout();
+            bool shouldShowOverlayHost = layout != null && (_boundCommandAssistViewModel?.IsVisible == true);
             if (CommandAssistOverlayHost != null)
             {
-                CommandAssistOverlayHost.IsVisible = layout != null;
+                CommandAssistOverlayHost.IsVisible = shouldShowOverlayHost;
             }
 
             if (layout == null)
@@ -727,7 +728,7 @@ namespace NovaTerminal.Controls
             }
 
             string signature =
-                $"layoutY={layout.BubbleRect.Y:F0},layoutPromptY={layout.PromptRect.Y:F0},appliedBubbleTop={CommandAssistBubble.Margin.Top:F0},appliedBubbleVis={CommandAssistBubble.IsVisible},hostVis={CommandAssistOverlayHost?.IsVisible == true},vmVis={_boundCommandAssistViewModel?.IsVisible == true}";
+                $"layoutY={layout.BubbleRect.Y:F0},layoutPromptY={layout.PromptRect.Y:F0},appliedBubbleTop={CommandAssistBubble.Margin.Top:F0},appliedBubbleVis={CommandAssistBubble.IsVisible},hostVis={CommandAssistOverlayHost?.IsVisible == true},vmVis={_boundCommandAssistViewModel?.IsVisible == true},popupVm={_boundCommandAssistViewModel?.IsPopupOpen == true}";
             if (string.Equals(signature, _lastCommandAssistAnchorAppliedSignature, StringComparison.Ordinal))
             {
                 return;

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -76,6 +76,8 @@ namespace NovaTerminal.Controls
         private const double CommandAssistBubbleHeight = 36;
         private const double CommandAssistPopupWidth = 520;
         private const double CommandAssistPopupHeight = 220;
+        private const double CompactPopupWidthThreshold = 420;
+        private const double CompactPopupHeightThreshold = 180;
         internal CommandAssistBarViewModel? CommandAssistViewModel => _commandAssistController?.ViewModel;
 
         public bool IsRecording => Session?.IsRecording ?? false;
@@ -490,6 +492,7 @@ namespace NovaTerminal.Controls
             CommandAssistPromptHint? promptHint = TermView.GetCommandAssistPromptHint();
             float fallbackCellHeight = TermView.Metrics.CellHeight > 0 ? TermView.Metrics.CellHeight : 18;
             int fallbackVisibleRows = TermView.Rows > 0 ? TermView.Rows : 1;
+            CommandAssistSurfaceSizing sizing = CalculateCommandAssistSurfaceSizing(paneWidth, paneHeight);
 
             return _commandAssistAnchorCalculator.Calculate(new CommandAssistAnchorRequest(
                 PaneWidth: paneWidth,
@@ -497,11 +500,24 @@ namespace NovaTerminal.Controls
                 CellHeight: promptHint?.CellHeight ?? fallbackCellHeight,
                 CursorVisualRow: promptHint?.VisibleCursorVisualRow ?? 0,
                 VisibleRows: promptHint?.VisibleRows ?? fallbackVisibleRows,
-                BubbleWidth: CommandAssistBubbleWidth,
-                BubbleHeight: CommandAssistBubbleHeight,
-                PopupWidth: CommandAssistPopupWidth,
-                PopupHeight: CommandAssistPopupHeight,
+                BubbleWidth: sizing.BubbleWidth,
+                BubbleHeight: sizing.BubbleHeight,
+                PopupWidth: sizing.PopupWidth,
+                PopupHeight: sizing.PopupHeight,
                 HasReliablePromptAnchor: promptHint.HasValue));
+        }
+
+        private static CommandAssistSurfaceSizing CalculateCommandAssistSurfaceSizing(double paneWidth, double paneHeight)
+        {
+            double bubbleWidth = Math.Clamp(paneWidth * 0.44, 280, CommandAssistBubbleWidth);
+            double popupWidth = Math.Clamp(paneWidth * 0.58, 360, CommandAssistPopupWidth);
+            double popupHeight = Math.Clamp(paneHeight * 0.45, 160, CommandAssistPopupHeight);
+
+            return new CommandAssistSurfaceSizing(
+                BubbleWidth: bubbleWidth,
+                BubbleHeight: CommandAssistBubbleHeight,
+                PopupWidth: popupWidth,
+                PopupHeight: popupHeight);
         }
 
         private void UpdateCommandAssistOverlayPlacement()
@@ -532,6 +548,13 @@ namespace NovaTerminal.Controls
 
             if (CommandAssistPopup != null)
             {
+                if (_boundCommandAssistViewModel != null)
+                {
+                    _boundCommandAssistViewModel.Popup.UseCompactLayout =
+                        layout.PopupRect.Width <= CompactPopupWidthThreshold ||
+                        layout.PopupRect.Height <= CompactPopupHeightThreshold;
+                }
+
                 CommandAssistPopup.Width = layout.PopupRect.Width;
                 CommandAssistPopup.MaxWidth = layout.PopupRect.Width;
                 CommandAssistPopup.MaxHeight = layout.PopupRect.Height;
@@ -1553,5 +1576,11 @@ namespace NovaTerminal.Controls
                 System.Diagnostics.Debug.WriteLine($"[TerminalPane] Shell integration event handling failed: {ex.Message}");
             }
         }
+
+        private readonly record struct CommandAssistSurfaceSizing(
+            double BubbleWidth,
+            double BubbleHeight,
+            double PopupWidth,
+            double PopupHeight);
     }
 }

--- a/src/NovaTerminal.App/Core/TerminalDrawOperation.cs
+++ b/src/NovaTerminal.App/Core/TerminalDrawOperation.cs
@@ -1881,6 +1881,15 @@ namespace NovaTerminal.Core
         private static bool IsRegionalIndicatorRune(int codePoint)
             => codePoint >= 0x1F1E6 && codePoint <= 0x1F1FF;
 
+        private static bool IsAmbiguousSymbolCodePoint(int codePoint)
+            => codePoint >= 0x2600 && codePoint <= 0x27BF;
+
+        private static bool IsEmojiTypefaceFamily(SKTypeface? typeface)
+        {
+            string family = typeface?.FamilyName ?? string.Empty;
+            return family.IndexOf("Emoji", StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
         private void LogBoxRunDiagnostics(string runText, int runCells, SKFont runFont, float measuredWidth)
         {
             if (!GlyphDiagnosticsEnabled || !ContainsBoxDrawing(runText)) return;
@@ -2141,11 +2150,23 @@ namespace NovaTerminal.Core
             {
                 SKTypeface? found = null;
                 if ((codePoint >= 0x1F300 && codePoint <= 0x1FAFF) ||
-                    IsRegionalIndicatorRune(codePoint) ||
-                    (codePoint >= 0x2600 && codePoint <= 0x27BF))
+                    IsRegionalIndicatorRune(codePoint))
                 {
                     found = SKTypeface.FromFamilyName("Segoe UI Emoji");
                 }
+
+                if (found == null && IsAmbiguousSymbolCodePoint(codePoint))
+                {
+                    foreach (var tfChain in _fallbackChain)
+                    {
+                        if (!IsEmojiTypefaceFamily(tfChain) && tfChain.ContainsGlyph(codePoint))
+                        {
+                            found = tfChain;
+                            break;
+                        }
+                    }
+                }
+
                 if (found == null)
                 {
                     foreach (var tfChain in _fallbackChain)

--- a/src/NovaTerminal.App/Core/TerminalView.cs
+++ b/src/NovaTerminal.App/Core/TerminalView.cs
@@ -557,8 +557,8 @@ namespace NovaTerminal.Core
         private static readonly string[] PreferredMonospaceFonts = { "Cascadia Mono", "JetBrains Mono", "DejaVu Sans Mono", "Consolas", "Cascadia Code" };
 
         private static readonly string[] FallbackChainNames = {
-            "Segoe UI Emoji", "Apple Color Emoji", "Noto Color Emoji", // Emojis
             "Segoe UI Symbol", "Symbola",                              // Symbols
+            "Segoe UI Emoji", "Apple Color Emoji", "Noto Color Emoji", // Emojis
             "Cascadia Mono", "JetBrains Mono", "DejaVu Sans Mono", "Consolas", // Monospace-first
             "Cascadia Code", "Fira Code", "MesloLGS NF",                        // Alternate symbol sources
             "Courier New", "Monospace"                                 // Last Resort

--- a/src/NovaTerminal.App/Core/TerminalView.cs
+++ b/src/NovaTerminal.App/Core/TerminalView.cs
@@ -27,6 +27,12 @@ namespace NovaTerminal.Core
         public float Leading;
     }
 
+    public readonly record struct CommandAssistPromptHint(
+        int VisibleCursorVisualRow,
+        int VisibleRows,
+        float CellWidth,
+        float CellHeight);
+
     public class TerminalView : Control
     {
         private readonly RowImageCache _rowCache = new();
@@ -36,6 +42,7 @@ namespace NovaTerminal.Core
         /// Fired when font metrics (cell width/height) change.
         /// </summary>
         public event Action<float, float>? MetricsChanged;
+        public event Action? CommandAssistAnchorHintChanged;
 
         private bool _showRenderHud;
         public bool ShowRenderHud
@@ -294,6 +301,7 @@ namespace NovaTerminal.Core
                     {
                         _lastCursorRow = cursorRow;
                         _lastCursorCol = cursorCol;
+                        CommandAssistAnchorHintChanged?.Invoke();
                         
                         // Reset blink timer on VT cursor movement (like in Vim)
                         // Ensure we don't override the transient cursor suppression (used by AnsiParser for animated text)
@@ -607,6 +615,43 @@ namespace NovaTerminal.Core
 
         public int Cols => (_metrics.CellWidth > 0) ? (int)(Math.Max(0, Bounds.Width - 4) / _metrics.CellWidth) : 0;
         public int Rows => (_metrics.CellHeight > 0) ? (int)(Bounds.Height / _metrics.CellHeight) : 0;
+
+        internal CommandAssistPromptHint? GetCommandAssistPromptHint()
+        {
+            if (_buffer == null || _metrics.CellHeight <= 0 || Rows <= 0)
+            {
+                return null;
+            }
+
+            int visualCursorRow;
+            int visibleRows = Rows;
+            _buffer.Lock.EnterReadLock();
+            try
+            {
+                visualCursorRow = _buffer.GetVisualCursorRow(_scrollOffset);
+            }
+            finally
+            {
+                _buffer.Lock.ExitReadLock();
+            }
+
+            if (visibleRows <= 0 || visualCursorRow < 0 || visualCursorRow >= visibleRows)
+            {
+                return null;
+            }
+
+            return new CommandAssistPromptHint(
+                VisibleCursorVisualRow: visualCursorRow,
+                VisibleRows: visibleRows,
+                CellWidth: _metrics.CellWidth,
+                CellHeight: _metrics.CellHeight);
+        }
+
+        internal void SetMetricsForTest(float cellWidth, float cellHeight)
+        {
+            _metrics.CellWidth = cellWidth;
+            _metrics.CellHeight = cellHeight;
+        }
 
         public void ApplySettings(TerminalSettings settings)
         {
@@ -1028,6 +1073,7 @@ namespace NovaTerminal.Core
                     _scrollOffset = newValue;
                     _targetScrollOffset = newValue;
                     ScrollStateChanged?.Invoke(_scrollOffset, maxScroll);
+                    CommandAssistAnchorHintChanged?.Invoke();
                     InvalidateBuffer();
                 }
             }

--- a/src/NovaTerminal.App/SettingsWindow.axaml
+++ b/src/NovaTerminal.App/SettingsWindow.axaml
@@ -44,6 +44,9 @@
 
                         <!-- Enable Complex Shaping -->
                         <CheckBox Name="ComplexShapingToggle" Content="Enable Complex Shaping (Run-level HarfBuzz)" Margin="0,5,0,0"/>
+
+                        <!-- Command Assist -->
+                        <CheckBox Name="CommandAssistToggle" Content="Enable Command Assistant" Margin="0,5,0,0"/>
                         
                         <!-- Font Size -->
                         <StackPanel>

--- a/src/NovaTerminal.App/SettingsWindow.axaml.cs
+++ b/src/NovaTerminal.App/SettingsWindow.axaml.cs
@@ -1107,6 +1107,7 @@ namespace NovaTerminal
             var bgOpacityDisplay = this.FindControl<TextBlock>("BgImageOpacityDisplay");
             var bgStretchList = this.FindControl<ComboBox>("BgImageStretchList");
             var complexShapingToggle = this.FindControl<CheckBox>("ComplexShapingToggle");
+            var commandAssistToggle = this.FindControl<CheckBox>("CommandAssistToggle");
 
             if (fontSizeInput != null) fontSizeInput.Value = (decimal)_settings.FontSize;
             if (scrollbackInput != null) scrollbackInput.Value = (decimal)_settings.MaxHistory;
@@ -1119,6 +1120,7 @@ namespace NovaTerminal
 
             if (ligatureToggle != null) ligatureToggle.IsChecked = _settings.EnableLigatures;
             if (complexShapingToggle != null) complexShapingToggle.IsChecked = _settings.EnableComplexShaping;
+            if (commandAssistToggle != null) commandAssistToggle.IsChecked = _settings.CommandAssistEnabled;
 
             if (bgPathInput != null) bgPathInput.Text = _settings.BackgroundImagePath;
             if (bgOpacitySlider != null)
@@ -1315,6 +1317,7 @@ namespace NovaTerminal
             var opacitySlider = this.FindControl<Slider>("WindowOpacitySlider");
             var ligatureToggle = this.FindControl<CheckBox>("LigatureToggle");
             var complexShapingToggle = this.FindControl<CheckBox>("ComplexShapingToggle");
+            var commandAssistToggle = this.FindControl<CheckBox>("CommandAssistToggle");
 
             // Bg Image inputs
             var bgPathInput = this.FindControl<TextBox>("BgImagePathInput");
@@ -1327,6 +1330,7 @@ namespace NovaTerminal
             if (opacitySlider != null) _settings.WindowOpacity = opacitySlider.Value;
             if (ligatureToggle != null) _settings.EnableLigatures = ligatureToggle.IsChecked == true;
             if (complexShapingToggle != null) _settings.EnableComplexShaping = complexShapingToggle.IsChecked == true;
+            if (commandAssistToggle != null) _settings.CommandAssistEnabled = commandAssistToggle.IsChecked == true;
 
             if (fontList?.SelectedItem is ComboBoxItem fontItem)
                 _settings.FontFamily = fontItem.Content?.ToString() ?? "Consolas";

--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -188,6 +188,11 @@ namespace NovaTerminal.Core
                                 _verticalOffset = 0;
                                 _state = State.Normal;
                             }
+                            else if (c == '=' || c == '>') // DECKPAM / DECKPNM
+                            {
+                                // Keypad application/numeric mode does not render visible text.
+                                _state = State.Normal;
+                            }
                             else if (c == '(' || c == ')' || c == '*' || c == '+' || c == '-')
                             {
                                 // G0/G1 charset selection - wait for the next char but don't print

--- a/src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs
@@ -123,6 +123,7 @@ namespace NovaTerminal.Core
 
                 Cols = newCols;
                 Rows = newRows;
+                RecomputeScrollbackBudgetForCurrentWidth();
 
                 if (_isAltScreen)
                 {

--- a/src/NovaTerminal.VT/TerminalBuffer.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.cs
@@ -33,8 +33,7 @@ namespace NovaTerminal.Core
             set
             {
                 _maxHistory = Math.Max(1, value);
-                long computedBudget = ComputeScrollbackBudgetBytes(Cols, _maxHistory);
-                MaxScrollbackBytes = computedBudget;
+                RecomputeScrollbackBudgetForCurrentWidth();
             }
         }
 
@@ -170,6 +169,16 @@ namespace NovaTerminal.Core
         private static long ComputeScrollbackBudgetBytes(int cols, int maxHistory)
         {
             return Math.Max(1, cols) * (long)Math.Max(1, maxHistory) * TerminalPageConstants.CellBytes;
+        }
+
+        private void RecomputeScrollbackBudgetForCurrentWidth()
+        {
+            _maxScrollbackBytes = ComputeScrollbackBudgetBytes(Cols, _maxHistory);
+            if (_scrollback != null)
+            {
+                _scrollback.MaxScrollbackBytes = _maxScrollbackBytes;
+                _scrollback.TryEvictUntilWithinBudget();
+            }
         }
 
     }

--- a/src/NovaTerminal.VT/TerminalBuffer.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.cs
@@ -24,9 +24,33 @@ namespace NovaTerminal.Core
         // Scrollback buffer - historical lines that scrolled off the top
         private ScrollbackPages _scrollback;
         private static readonly TerminalPagePool _sharedPagePool = new();
+        private int _maxHistory = 10000;
+        private long _maxScrollbackBytes;
 
-        public int MaxHistory { get; set; } = 10000;
-        public long MaxScrollbackBytes { get; set; } = 128L * 1024 * 1024;
+        public int MaxHistory
+        {
+            get => _maxHistory;
+            set
+            {
+                _maxHistory = Math.Max(1, value);
+                long computedBudget = ComputeScrollbackBudgetBytes(Cols, _maxHistory);
+                MaxScrollbackBytes = computedBudget;
+            }
+        }
+
+        public long MaxScrollbackBytes
+        {
+            get => _maxScrollbackBytes;
+            set
+            {
+                _maxScrollbackBytes = Math.Max(ComputeScrollbackBudgetBytes(Cols, 1), value);
+                if (_scrollback != null)
+                {
+                    _scrollback.MaxScrollbackBytes = _maxScrollbackBytes;
+                    _scrollback.TryEvictUntilWithinBudget();
+                }
+            }
+        }
 
         // Graphics support
         private readonly List<TerminalImage> _images = new();
@@ -111,6 +135,7 @@ namespace NovaTerminal.Core
             Cols = cols;
             Rows = rows;
             ScrollBottom = rows - 1;  // Initialize scrolling region to full screen
+            _maxScrollbackBytes = ComputeScrollbackBudgetBytes(cols, _maxHistory);
 
             CurrentForeground = Theme.Foreground;
             CurrentBackground = Theme.Background;
@@ -140,6 +165,11 @@ namespace NovaTerminal.Core
             _cursorCol = 0;
             ScrollTop = 0;
             ScrollBottom = rows - 1;
+        }
+
+        private static long ComputeScrollbackBudgetBytes(int cols, int maxHistory)
+        {
+            return Math.Max(1, cols) * (long)Math.Max(1, maxHistory) * TerminalPageConstants.CellBytes;
         }
 
     }

--- a/tests/NovaTerminal.Tests/Buffer/TerminalBufferScrollbackBudgetTests.cs
+++ b/tests/NovaTerminal.Tests/Buffer/TerminalBufferScrollbackBudgetTests.cs
@@ -37,4 +37,20 @@ public sealed class TerminalBufferScrollbackBudgetTests
         Assert.True(buffer.Scrollback.Count <= 1000, $"Expected <= 1000 scrollback rows, got {buffer.Scrollback.Count}.");
         Assert.True(metrics.ScrollbackBytes <= expectedBudget + (80L * 64 * 12), $"Expected scrollback bytes near budget, got {metrics.ScrollbackBytes}.");
     }
+
+    [Fact]
+    public void Resize_WhenWidthChanges_RecomputesScrollbackBudget()
+    {
+        var buffer = new TerminalBuffer(80, 24)
+        {
+            MaxHistory = 1000
+        };
+
+        buffer.Resize(120, 24);
+
+        long expectedBytes = 120L * 1000 * 12;
+
+        Assert.Equal(expectedBytes, buffer.MaxScrollbackBytes);
+        Assert.Equal(expectedBytes, buffer.Scrollback.MaxScrollbackBytes);
+    }
 }

--- a/tests/NovaTerminal.Tests/Buffer/TerminalBufferScrollbackBudgetTests.cs
+++ b/tests/NovaTerminal.Tests/Buffer/TerminalBufferScrollbackBudgetTests.cs
@@ -1,0 +1,40 @@
+using NovaTerminal.Core;
+
+namespace NovaTerminal.Tests.Buffer;
+
+public sealed class TerminalBufferScrollbackBudgetTests
+{
+    [Fact]
+    public void MaxHistory_WhenUpdated_RecomputesScrollbackBudget()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+
+        buffer.MaxHistory = 1000;
+
+        long expectedBytes = 80L * 1000 * 12;
+
+        Assert.Equal(expectedBytes, buffer.MaxScrollbackBytes);
+        Assert.Equal(expectedBytes, buffer.Scrollback.MaxScrollbackBytes);
+    }
+
+    [Fact]
+    public void Scrollback_WhenFlooded_DoesNotRetainMoreRowsThanMaxHistoryBudget()
+    {
+        var buffer = new TerminalBuffer(80, 24)
+        {
+            MaxHistory = 1000
+        };
+
+        for (int i = 0; i < 10000; i++)
+        {
+            buffer.WriteContent(new string('X', 80));
+            buffer.WriteChar('\n');
+        }
+
+        TerminalMemoryMetrics metrics = buffer.GetMemoryMetrics();
+        long expectedBudget = 80L * 1000 * 12;
+
+        Assert.True(buffer.Scrollback.Count <= 1000, $"Expected <= 1000 scrollback rows, got {buffer.Scrollback.Count}.");
+        Assert.True(metrics.ScrollbackBytes <= expectedBudget + (80L * 64 * 12), $"Expected scrollback bytes near budget, got {metrics.ScrollbackBytes}.");
+    }
+}

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs
@@ -22,6 +22,7 @@ public sealed class CommandAssistAnchorCalculatorTests
             PopupHeight: 220));
 
         Assert.True(layout.BubbleRect.Bottom < layout.PromptRect.Top);
+        Assert.Equal(4, layout.PromptRect.Top - layout.BubbleRect.Bottom, precision: 1);
         Assert.Equal(CommandAssistPopupDirection.Upward, layout.PopupDirection);
         Assert.True(layout.PopupRect.Bottom <= layout.BubbleRect.Top);
     }
@@ -44,6 +45,29 @@ public sealed class CommandAssistAnchorCalculatorTests
 
         Assert.Equal(CommandAssistPopupDirection.Downward, layout.PopupDirection);
         Assert.True(layout.PopupRect.Top >= layout.BubbleRect.Bottom);
+    }
+
+    [Fact]
+    public void Calculate_WhenPromptIsOnTopVisibleRow_PlacesBubbleBelowPrompt()
+    {
+        var calculator = new CommandAssistAnchorCalculator();
+
+        CommandAssistAnchorLayout layout = calculator.Calculate(new CommandAssistAnchorRequest(
+            PaneWidth: 960,
+            PaneHeight: 540,
+            CellHeight: 18,
+            CursorVisualRow: 0,
+            VisibleRows: 24,
+            BubbleWidth: 360,
+            BubbleHeight: 36,
+            PopupWidth: 460,
+            PopupHeight: 180));
+
+        Assert.True(layout.BubbleRect.Top >= layout.PromptRect.Bottom,
+            $"Expected bubble top {layout.BubbleRect.Top} to be below prompt bottom {layout.PromptRect.Bottom}.");
+        Assert.Equal(4, layout.BubbleRect.Top - layout.PromptRect.Bottom, precision: 1);
+        Assert.True(layout.BubbleRect.Bottom <= layout.PopupRect.Top,
+            $"Expected upward popup to clear bubble bottom {layout.BubbleRect.Bottom}, but popup top was {layout.PopupRect.Top}.");
     }
 
     [Fact]

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs
@@ -47,6 +47,26 @@ public sealed class CommandAssistAnchorCalculatorTests
     }
 
     [Fact]
+    public void Calculate_WhenPaneIsShortButWide_UsesSideFloatingPopup()
+    {
+        var calculator = new CommandAssistAnchorCalculator();
+
+        CommandAssistAnchorLayout layout = calculator.Calculate(new CommandAssistAnchorRequest(
+            PaneWidth: 960,
+            PaneHeight: 220,
+            CellHeight: 18,
+            CursorVisualRow: 8,
+            VisibleRows: 12,
+            BubbleWidth: 320,
+            BubbleHeight: 36,
+            PopupWidth: 360,
+            PopupHeight: 180));
+
+        Assert.Equal(CommandAssistPopupDirection.RightSide, layout.PopupDirection);
+        Assert.True(layout.PopupRect.Left >= layout.BubbleRect.Right);
+    }
+
+    [Fact]
     public void Calculate_WhenRectsWouldOverflow_ClampsInsidePaneBounds()
     {
         var calculator = new CommandAssistAnchorCalculator();
@@ -136,6 +156,25 @@ public sealed class CommandAssistAnchorCalculatorTests
             BubbleWidth: 420,
             BubbleHeight: 36,
             PopupWidth: 520,
+            PopupHeight: 180));
+
+        Assert.True(layout.UseCompactBubbleLayout);
+    }
+
+    [Fact]
+    public void Calculate_WhenBubbleWidthIsTight_UsesCompactBubbleLayout()
+    {
+        var calculator = new CommandAssistAnchorCalculator();
+
+        CommandAssistAnchorLayout layout = calculator.Calculate(new CommandAssistAnchorRequest(
+            PaneWidth: 700,
+            PaneHeight: 420,
+            CellHeight: 18,
+            CursorVisualRow: 12,
+            VisibleRows: 20,
+            BubbleWidth: 300,
+            BubbleHeight: 36,
+            PopupWidth: 380,
             PopupHeight: 180));
 
         Assert.True(layout.UseCompactBubbleLayout);

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs
@@ -182,6 +182,28 @@ public sealed class CommandAssistAnchorCalculatorTests
     }
 
     [Fact]
+    public void Calculate_WhenPromptAnchorIsUnreliableAndVisibleRowsAreTiny_UsesLowerSafeZoneFallback()
+    {
+        var calculator = new CommandAssistAnchorCalculator();
+
+        CommandAssistAnchorLayout layout = calculator.Calculate(new CommandAssistAnchorRequest(
+            PaneWidth: 900,
+            PaneHeight: 540,
+            CellHeight: 18,
+            CursorVisualRow: 2,
+            VisibleRows: 4,
+            BubbleWidth: 380,
+            BubbleHeight: 36,
+            PopupWidth: 460,
+            PopupHeight: 180,
+            HasReliablePromptAnchor: false));
+
+        Assert.False(layout.UsesPromptAnchor);
+        Assert.True(layout.BubbleRect.Bottom > 540 * 0.5,
+            $"Expected tiny-row startup fallback bubble to stay in the lower safe zone, but bottom was {layout.BubbleRect.Bottom}.");
+    }
+
+    [Fact]
     public void Calculate_WhenCursorVisualRowChanges_MovesBubbleWithPrompt()
     {
         var calculator = new CommandAssistAnchorCalculator();

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs
@@ -92,6 +92,28 @@ public sealed class CommandAssistAnchorCalculatorTests
     }
 
     [Fact]
+    public void Calculate_WhenPromptAnchorIsReliableAndPaneIsShort_PlacesBubbleBelowPromptConservatively()
+    {
+        var calculator = new CommandAssistAnchorCalculator();
+
+        CommandAssistAnchorLayout layout = calculator.Calculate(new CommandAssistAnchorRequest(
+            PaneWidth: 900,
+            PaneHeight: 220,
+            CellHeight: 18,
+            CursorVisualRow: 5,
+            VisibleRows: 9,
+            BubbleWidth: 360,
+            BubbleHeight: 36,
+            PopupWidth: 460,
+            PopupHeight: 180));
+
+        Assert.True(layout.UsesPromptAnchor);
+        Assert.True(layout.BubbleRect.Top >= layout.PromptRect.Bottom,
+            $"Expected reliable short-pane bubble top {layout.BubbleRect.Top} to be below prompt bottom {layout.PromptRect.Bottom}.");
+        Assert.Equal(4, layout.BubbleRect.Top - layout.PromptRect.Bottom, precision: 1);
+    }
+
+    [Fact]
     public void Calculate_WhenPaneIsShortButWide_UsesSideFloatingPopup()
     {
         var calculator = new CommandAssistAnchorCalculator();

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs
@@ -65,7 +65,7 @@ public sealed class CommandAssistAnchorCalculatorTests
 
         Assert.True(layout.BubbleRect.Top >= layout.PromptRect.Bottom,
             $"Expected bubble top {layout.BubbleRect.Top} to be below prompt bottom {layout.PromptRect.Bottom}.");
-        Assert.Equal(4, layout.BubbleRect.Top - layout.PromptRect.Bottom, precision: 1);
+        Assert.Equal(layout.PromptRect.Height + 4, layout.BubbleRect.Top - layout.PromptRect.Bottom, precision: 1);
         Assert.True(layout.BubbleRect.Bottom <= layout.PopupRect.Top,
             $"Expected upward popup to clear bubble bottom {layout.BubbleRect.Bottom}, but popup top was {layout.PopupRect.Top}.");
     }
@@ -88,7 +88,74 @@ public sealed class CommandAssistAnchorCalculatorTests
 
         Assert.True(layout.BubbleRect.Top >= layout.PromptRect.Bottom,
             $"Expected startup-band bubble top {layout.BubbleRect.Top} to be below prompt bottom {layout.PromptRect.Bottom}.");
-        Assert.Equal(4, layout.BubbleRect.Top - layout.PromptRect.Bottom, precision: 1);
+        Assert.Equal(layout.PromptRect.Height + 4, layout.BubbleRect.Top - layout.PromptRect.Bottom, precision: 1);
+    }
+
+    [Fact]
+    public void Calculate_WhenPromptIsInUpperStartupBand_LeavesInputRowClearanceBelowPrompt()
+    {
+        var calculator = new CommandAssistAnchorCalculator();
+
+        CommandAssistAnchorLayout layout = calculator.Calculate(new CommandAssistAnchorRequest(
+            PaneWidth: 960,
+            PaneHeight: 540,
+            CellHeight: 18,
+            CursorVisualRow: 1,
+            VisibleRows: 24,
+            BubbleWidth: 360,
+            BubbleHeight: 36,
+            PopupWidth: 460,
+            PopupHeight: 180));
+
+        double expectedMinimumTop = layout.PromptRect.Bottom + layout.PromptRect.Height + 4;
+        Assert.True(layout.BubbleRect.Top >= expectedMinimumTop,
+            $"Expected startup-band bubble top {layout.BubbleRect.Top} to clear one input row below prompt bottom {layout.PromptRect.Bottom}, but expected at least {expectedMinimumTop}.");
+    }
+
+    [Fact]
+    public void Calculate_WhenPromptAnchorIsReliable_AlignsPromptTopToCursorRowWithoutExtraTopPadding()
+    {
+        var calculator = new CommandAssistAnchorCalculator();
+
+        const int cursorRow = 2;
+        const double cellHeight = 18;
+        CommandAssistAnchorLayout layout = calculator.Calculate(new CommandAssistAnchorRequest(
+            PaneWidth: 960,
+            PaneHeight: 540,
+            CellHeight: cellHeight,
+            CursorVisualRow: cursorRow,
+            VisibleRows: 24,
+            BubbleWidth: 360,
+            BubbleHeight: 36,
+            PopupWidth: 460,
+            PopupHeight: 180,
+            HasReliablePromptAnchor: true));
+
+        double expectedPromptTop = cursorRow * cellHeight;
+        Assert.Equal(expectedPromptTop, layout.PromptRect.Top, precision: 1);
+    }
+
+    [Fact]
+    public void Calculate_WhenPromptAnchorIsUnreliableAndCursorBandFallbackIsUsed_AlignsPromptTopToCursorRowWithoutExtraTopPadding()
+    {
+        var calculator = new CommandAssistAnchorCalculator();
+
+        const int cursorRow = 18;
+        const double cellHeight = 18;
+        CommandAssistAnchorLayout layout = calculator.Calculate(new CommandAssistAnchorRequest(
+            PaneWidth: 900,
+            PaneHeight: 540,
+            CellHeight: cellHeight,
+            CursorVisualRow: cursorRow,
+            VisibleRows: 24,
+            BubbleWidth: 380,
+            BubbleHeight: 36,
+            PopupWidth: 460,
+            PopupHeight: 180,
+            HasReliablePromptAnchor: false));
+
+        double expectedPromptTop = cursorRow * cellHeight;
+        Assert.Equal(expectedPromptTop, layout.PromptRect.Top, precision: 1);
     }
 
     [Fact]
@@ -110,7 +177,7 @@ public sealed class CommandAssistAnchorCalculatorTests
         Assert.True(layout.UsesPromptAnchor);
         Assert.True(layout.BubbleRect.Top >= layout.PromptRect.Bottom,
             $"Expected reliable short-pane bubble top {layout.BubbleRect.Top} to be below prompt bottom {layout.PromptRect.Bottom}.");
-        Assert.Equal(4, layout.BubbleRect.Top - layout.PromptRect.Bottom, precision: 1);
+        Assert.Equal(layout.PromptRect.Height + 4, layout.BubbleRect.Top - layout.PromptRect.Bottom, precision: 1);
     }
 
     [Fact]

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs
@@ -137,6 +137,30 @@ public sealed class CommandAssistAnchorCalculatorTests
     }
 
     [Fact]
+    public void Calculate_WhenPromptAnchorIsUnreliableButCursorIsSettledLow_PlacesBubbleNearCursorBand()
+    {
+        var calculator = new CommandAssistAnchorCalculator();
+
+        CommandAssistAnchorLayout layout = calculator.Calculate(new CommandAssistAnchorRequest(
+            PaneWidth: 900,
+            PaneHeight: 540,
+            CellHeight: 18,
+            CursorVisualRow: 18,
+            VisibleRows: 24,
+            BubbleWidth: 380,
+            BubbleHeight: 36,
+            PopupWidth: 460,
+            PopupHeight: 180,
+            HasReliablePromptAnchor: false));
+
+        Assert.False(layout.UsesPromptAnchor);
+        Assert.True(layout.BubbleRect.Bottom < 540 * 0.8,
+            $"Expected settled SSH fallback bubble to sit near the cursor band instead of the lower safe zone, but bottom was {layout.BubbleRect.Bottom}.");
+        Assert.True(layout.BubbleRect.Bottom <= layout.PromptRect.Top,
+            $"Expected settled fallback bubble bottom {layout.BubbleRect.Bottom} to clear heuristic prompt top {layout.PromptRect.Top}.");
+    }
+
+    [Fact]
     public void Calculate_WhenCursorVisualRowChanges_MovesBubbleWithPrompt()
     {
         var calculator = new CommandAssistAnchorCalculator();

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs
@@ -1,0 +1,151 @@
+using Avalonia;
+using NovaTerminal.CommandAssist.Application;
+
+namespace NovaTerminal.Tests.CommandAssist;
+
+public sealed class CommandAssistAnchorCalculatorTests
+{
+    [Fact]
+    public void Calculate_WhenSpaceExistsAbovePrompt_PlacesBubbleAbovePrompt()
+    {
+        var calculator = new CommandAssistAnchorCalculator();
+
+        CommandAssistAnchorLayout layout = calculator.Calculate(new CommandAssistAnchorRequest(
+            PaneWidth: 1000,
+            PaneHeight: 700,
+            CellHeight: 18,
+            CursorVisualRow: 34,
+            VisibleRows: 36,
+            BubbleWidth: 420,
+            BubbleHeight: 36,
+            PopupWidth: 520,
+            PopupHeight: 220));
+
+        Assert.True(layout.BubbleRect.Bottom < layout.PromptRect.Top);
+        Assert.Equal(CommandAssistPopupDirection.Upward, layout.PopupDirection);
+        Assert.True(layout.PopupRect.Bottom <= layout.BubbleRect.Top);
+    }
+
+    [Fact]
+    public void Calculate_WhenInsufficientRoomAbovePrompt_FlipsPopupBelowBubble()
+    {
+        var calculator = new CommandAssistAnchorCalculator();
+
+        CommandAssistAnchorLayout layout = calculator.Calculate(new CommandAssistAnchorRequest(
+            PaneWidth: 960,
+            PaneHeight: 240,
+            CellHeight: 18,
+            CursorVisualRow: 2,
+            VisibleRows: 12,
+            BubbleWidth: 360,
+            BubbleHeight: 36,
+            PopupWidth: 460,
+            PopupHeight: 180));
+
+        Assert.Equal(CommandAssistPopupDirection.Downward, layout.PopupDirection);
+        Assert.True(layout.PopupRect.Top >= layout.BubbleRect.Bottom);
+    }
+
+    [Fact]
+    public void Calculate_WhenRectsWouldOverflow_ClampsInsidePaneBounds()
+    {
+        var calculator = new CommandAssistAnchorCalculator();
+
+        CommandAssistAnchorLayout layout = calculator.Calculate(new CommandAssistAnchorRequest(
+            PaneWidth: 320,
+            PaneHeight: 160,
+            CellHeight: 18,
+            CursorVisualRow: 8,
+            VisibleRows: 9,
+            BubbleWidth: 420,
+            BubbleHeight: 36,
+            PopupWidth: 520,
+            PopupHeight: 220));
+
+        AssertRectWithin(layout.BubbleRect, 320, 160);
+        AssertRectWithin(layout.PopupRect, 320, 160);
+        AssertRectWithin(layout.PromptRect, 320, 160);
+        Assert.True(layout.UseCompactBubbleLayout);
+        Assert.True(layout.PopupRect.Height < 220);
+    }
+
+    [Fact]
+    public void Calculate_WhenPromptAnchorIsUnreliable_UsesStableLowerSafeZoneFallback()
+    {
+        var calculator = new CommandAssistAnchorCalculator();
+
+        CommandAssistAnchorLayout layout = calculator.Calculate(new CommandAssistAnchorRequest(
+            PaneWidth: 900,
+            PaneHeight: 540,
+            CellHeight: 18,
+            CursorVisualRow: 0,
+            VisibleRows: 0,
+            BubbleWidth: 380,
+            BubbleHeight: 36,
+            PopupWidth: 460,
+            PopupHeight: 180,
+            HasReliablePromptAnchor: false));
+
+        Assert.False(layout.UsesPromptAnchor);
+        Assert.True(layout.BubbleRect.Bottom > 540 * 0.5);
+        Assert.True(layout.BubbleRect.Right <= 900);
+        Assert.True(layout.PopupRect.Bottom <= layout.BubbleRect.Top);
+    }
+
+    [Fact]
+    public void Calculate_WhenCursorVisualRowChanges_MovesBubbleWithPrompt()
+    {
+        var calculator = new CommandAssistAnchorCalculator();
+
+        CommandAssistAnchorLayout upperLayout = calculator.Calculate(new CommandAssistAnchorRequest(
+            PaneWidth: 960,
+            PaneHeight: 540,
+            CellHeight: 18,
+            CursorVisualRow: 6,
+            VisibleRows: 24,
+            BubbleWidth: 360,
+            BubbleHeight: 36,
+            PopupWidth: 460,
+            PopupHeight: 180));
+        CommandAssistAnchorLayout lowerLayout = calculator.Calculate(new CommandAssistAnchorRequest(
+            PaneWidth: 960,
+            PaneHeight: 540,
+            CellHeight: 18,
+            CursorVisualRow: 12,
+            VisibleRows: 24,
+            BubbleWidth: 360,
+            BubbleHeight: 36,
+            PopupWidth: 460,
+            PopupHeight: 180));
+
+        Assert.True(lowerLayout.BubbleRect.Y > upperLayout.BubbleRect.Y);
+        Assert.True(lowerLayout.PromptRect.Y > upperLayout.PromptRect.Y);
+    }
+
+    [Fact]
+    public void Calculate_WhenPaneIsNarrow_UsesCompactBubbleLayout()
+    {
+        var calculator = new CommandAssistAnchorCalculator();
+
+        CommandAssistAnchorLayout layout = calculator.Calculate(new CommandAssistAnchorRequest(
+            PaneWidth: 420,
+            PaneHeight: 420,
+            CellHeight: 18,
+            CursorVisualRow: 12,
+            VisibleRows: 20,
+            BubbleWidth: 420,
+            BubbleHeight: 36,
+            PopupWidth: 520,
+            PopupHeight: 180));
+
+        Assert.True(layout.UseCompactBubbleLayout);
+    }
+
+    private static void AssertRectWithin(Rect rect, double paneWidth, double paneHeight)
+    {
+        Assert.True(rect.X >= 0, $"Expected rect.X >= 0 but was {rect.X}.");
+        Assert.True(rect.Y >= 0, $"Expected rect.Y >= 0 but was {rect.Y}.");
+        Assert.True(rect.Right <= paneWidth, $"Expected rect.Right <= {paneWidth} but was {rect.Right}.");
+        Assert.True(rect.Bottom <= paneHeight, $"Expected rect.Bottom <= {paneHeight} but was {rect.Bottom}.");
+    }
+}

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs
@@ -204,6 +204,31 @@ public sealed class CommandAssistAnchorCalculatorTests
     }
 
     [Fact]
+    public void Calculate_WhenPromptAnchorIsUnreliableAndCursorBandFallsInUpperArea_PlacesBubbleBelowPrompt()
+    {
+        var calculator = new CommandAssistAnchorCalculator();
+
+        CommandAssistAnchorLayout layout = calculator.Calculate(new CommandAssistAnchorRequest(
+            PaneWidth: 900,
+            PaneHeight: 540,
+            CellHeight: 18,
+            CursorVisualRow: 4,
+            VisibleRows: 8,
+            BubbleWidth: 380,
+            BubbleHeight: 36,
+            PopupWidth: 460,
+            PopupHeight: 180,
+            HasReliablePromptAnchor: false));
+
+        Assert.False(layout.UsesPromptAnchor);
+        Assert.True(layout.PromptRect.Top <= 540 * 0.45,
+            $"Expected fallback prompt to be in the upper area, but top was {layout.PromptRect.Top}.");
+        Assert.True(layout.BubbleRect.Top >= layout.PromptRect.Bottom,
+            $"Expected fallback bubble top {layout.BubbleRect.Top} to sit below prompt bottom {layout.PromptRect.Bottom}.");
+        Assert.Equal(4, layout.BubbleRect.Top - layout.PromptRect.Bottom, precision: 1);
+    }
+
+    [Fact]
     public void Calculate_WhenCursorVisualRowChanges_MovesBubbleWithPrompt()
     {
         var calculator = new CommandAssistAnchorCalculator();

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs
@@ -71,6 +71,27 @@ public sealed class CommandAssistAnchorCalculatorTests
     }
 
     [Fact]
+    public void Calculate_WhenPromptIsInUpperStartupBand_PlacesBubbleBelowPrompt()
+    {
+        var calculator = new CommandAssistAnchorCalculator();
+
+        CommandAssistAnchorLayout layout = calculator.Calculate(new CommandAssistAnchorRequest(
+            PaneWidth: 960,
+            PaneHeight: 540,
+            CellHeight: 18,
+            CursorVisualRow: 2,
+            VisibleRows: 24,
+            BubbleWidth: 360,
+            BubbleHeight: 36,
+            PopupWidth: 460,
+            PopupHeight: 180));
+
+        Assert.True(layout.BubbleRect.Top >= layout.PromptRect.Bottom,
+            $"Expected startup-band bubble top {layout.BubbleRect.Top} to be below prompt bottom {layout.PromptRect.Bottom}.");
+        Assert.Equal(4, layout.BubbleRect.Top - layout.PromptRect.Bottom, precision: 1);
+    }
+
+    [Fact]
     public void Calculate_WhenPaneIsShortButWide_UsesSideFloatingPopup()
     {
         var calculator = new CommandAssistAnchorCalculator();

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs
@@ -229,6 +229,29 @@ public sealed class CommandAssistAnchorCalculatorTests
     }
 
     [Fact]
+    public void Calculate_WhenFallbackPromptIsNearMidOnShortPane_PlacesBubbleBelowPromptConservatively()
+    {
+        var calculator = new CommandAssistAnchorCalculator();
+
+        CommandAssistAnchorLayout layout = calculator.Calculate(new CommandAssistAnchorRequest(
+            PaneWidth: 900,
+            PaneHeight: 220,
+            CellHeight: 18,
+            CursorVisualRow: 5,
+            VisibleRows: 9,
+            BubbleWidth: 380,
+            BubbleHeight: 36,
+            PopupWidth: 460,
+            PopupHeight: 180,
+            HasReliablePromptAnchor: false));
+
+        Assert.False(layout.UsesPromptAnchor);
+        Assert.True(layout.BubbleRect.Top >= layout.PromptRect.Bottom,
+            $"Expected conservative fallback bubble top {layout.BubbleRect.Top} to be below prompt bottom {layout.PromptRect.Bottom} on short panes.");
+        Assert.Equal(4, layout.BubbleRect.Top - layout.PromptRect.Bottom, precision: 1);
+    }
+
+    [Fact]
     public void Calculate_WhenCursorVisualRowChanges_MovesBubbleWithPrompt()
     {
         var calculator = new CommandAssistAnchorCalculator();

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
@@ -254,6 +254,36 @@ public sealed class CommandAssistControllerTests
     }
 
     [Fact]
+    public void HandleTextInput_WhenNoSuggestionsExist_HidesSuggestBubble()
+    {
+        var controller = CreateController(new InMemoryHistoryStore());
+
+        controller.HandleTextInput("zzzz");
+
+        Assert.Equal("zzzz", controller.ViewModel.QueryText);
+        Assert.False(controller.ViewModel.HasSuggestions);
+        Assert.False(controller.ViewModel.IsVisible);
+        Assert.False(controller.ViewModel.Bubble.IsVisible);
+        Assert.False(controller.ViewModel.Popup.IsVisible);
+    }
+
+    [Fact]
+    public async Task HandleTextInput_WhenNoSuggestionsExist_DoesNotFlashVisibleBeforeRefreshCompletes()
+    {
+        var historyStore = new DelayedHistoryStore(TimeSpan.FromMilliseconds(250));
+        var controller = CreateController(historyStore);
+
+        controller.HandleTextInput("zzzz");
+
+        Assert.False(controller.ViewModel.IsVisible);
+        Assert.False(controller.ViewModel.Bubble.IsVisible);
+
+        await historyStore.WaitForLastSearchAsync();
+        Assert.False(controller.ViewModel.IsVisible);
+        Assert.False(controller.ViewModel.Bubble.IsVisible);
+    }
+
+    [Fact]
     public async Task HandleEnterAsync_PersistsSingleLineRedactedCommand()
     {
         var historyStore = new InMemoryHistoryStore();

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
@@ -93,6 +93,8 @@ public sealed class CommandAssistControllerTests
         Assert.True(opened);
         Assert.True(controller.ViewModel.IsVisible);
         Assert.Equal("Help", controller.ViewModel.ModeLabel);
+        Assert.True(controller.ViewModel.IsPopupOpen);
+        Assert.True(controller.ViewModel.Popup.IsVisible);
         Assert.Contains(controller.Suggestions, item => item.Type == AssistSuggestionType.Doc);
         Assert.Contains(controller.Suggestions, item => item.Type == AssistSuggestionType.Recipe);
         Assert.Equal("git", docsProvider.LastQuery?.CommandToken);
@@ -110,6 +112,8 @@ public sealed class CommandAssistControllerTests
         Assert.True(opened);
         Assert.Equal("Fix", controller.ViewModel.ModeLabel);
         Assert.True(controller.ViewModel.IsVisible);
+        Assert.True(controller.ViewModel.IsPopupOpen);
+        Assert.True(controller.ViewModel.Popup.IsVisible);
         Assert.Equal(AssistSuggestionType.Fix, controller.Suggestions[0].Type);
     }
 
@@ -226,6 +230,8 @@ public sealed class CommandAssistControllerTests
 
         Assert.Equal("git ", controller.ViewModel.QueryText);
         Assert.Equal("git status", controller.ViewModel.TopSuggestionText);
+        Assert.False(controller.ViewModel.IsPopupOpen);
+        Assert.False(controller.ViewModel.Popup.IsVisible);
     }
 
     [Fact]
@@ -301,6 +307,8 @@ public sealed class CommandAssistControllerTests
 
         Assert.True(moved);
         Assert.Equal(1, controller.ViewModel.SelectedIndex);
+        Assert.True(controller.ViewModel.IsPopupOpen);
+        Assert.True(controller.ViewModel.Popup.IsVisible);
     }
 
     [Fact]

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
@@ -127,8 +127,27 @@ public sealed class CommandAssistControllerTests
         bool opened = await controller.HandleCommandFailureAsync(CreateFailureContext("gti status", 1, "command failed"));
 
         Assert.False(opened);
-        Assert.False(controller.ViewModel.IsVisible);
-        Assert.DoesNotContain(controller.Suggestions, item => item.Type == AssistSuggestionType.Fix);
+        Assert.True(controller.ViewModel.IsVisible);
+        Assert.Equal("Fix", controller.ViewModel.ModeLabel);
+        Assert.False(controller.ViewModel.IsPopupOpen);
+        Assert.False(controller.ViewModel.Popup.IsVisible);
+        Assert.Contains(controller.Suggestions, item => item.Type == AssistSuggestionType.Fix);
+    }
+
+    [Fact]
+    public async Task MoveSelectionDown_WhenLowConfidenceFixAffordanceIsVisible_OpensPopup()
+    {
+        var controller = CreateController(
+            errorInsightService: new RecordingErrorInsightService(
+                [new CommandFixSuggestion("Maybe try git status", "git status", "Low confidence.", 0.2, ["Fix"])]));
+
+        await controller.HandleCommandFailureAsync(CreateFailureContext("gti status", 1, "command failed"));
+
+        bool moved = controller.MoveSelectionDown();
+
+        Assert.True(moved);
+        Assert.True(controller.ViewModel.IsPopupOpen);
+        Assert.True(controller.ViewModel.Popup.IsVisible);
     }
 
     [Fact]

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs
@@ -221,6 +221,72 @@ public sealed class CommandAssistLayoutTests
     }
 
     [AvaloniaFact]
+    public void TerminalPane_WhenRemoteShellIsNotIntegrated_UsesFallbackAnchorInsteadOfPromptAnchor()
+    {
+        var pane = new TerminalPane
+        {
+            Width = 900,
+            Height = 500
+        };
+        ConfigureCommandAssist(pane);
+        pane.UpdateProfile(new TerminalProfile
+        {
+            Type = ConnectionType.SSH,
+            Command = "ssh.exe",
+            SshHost = "ubuntu.example"
+        });
+        pane.Measure(new Size(900, 500));
+        pane.Arrange(new Rect(0, 0, 900, 500));
+
+        TerminalView termView = Assert.IsType<TerminalView>(pane.FindControl<TerminalView>("TermView"));
+        Assert.NotNull(pane.Buffer);
+        termView.Measure(new Size(900, 500));
+        termView.Arrange(new Rect(0, 0, 900, 500));
+        termView.SetMetricsForTest(10, 18);
+        pane.Buffer.SetCursorPosition(0, 1);
+
+        CommandAssistAnchorLayout layout = Assert.IsType<CommandAssistAnchorLayout>(pane.CalculateCommandAssistAnchorLayoutForTest());
+
+        Assert.False(layout.UsesPromptAnchor);
+        Assert.True(layout.BubbleRect.Bottom > 500 * 0.5,
+            $"Expected fallback bubble to stay in the lower safe zone, but bottom was {layout.BubbleRect.Bottom}.");
+    }
+
+    [AvaloniaFact]
+    public void TerminalPane_WhenRemoteShellCursorIsSettledLow_UsesCursorBandFallbackNearInput()
+    {
+        var pane = new TerminalPane
+        {
+            Width = 900,
+            Height = 500
+        };
+        ConfigureCommandAssist(pane);
+        pane.UpdateProfile(new TerminalProfile
+        {
+            Type = ConnectionType.SSH,
+            Command = "ssh.exe",
+            SshHost = "ubuntu.example"
+        });
+        pane.Measure(new Size(900, 500));
+        pane.Arrange(new Rect(0, 0, 900, 500));
+
+        TerminalView termView = Assert.IsType<TerminalView>(pane.FindControl<TerminalView>("TermView"));
+        Assert.NotNull(pane.Buffer);
+        termView.Measure(new Size(900, 500));
+        termView.Arrange(new Rect(0, 0, 900, 500));
+        termView.SetMetricsForTest(10, 18);
+        pane.Buffer.SetCursorPosition(0, 18);
+
+        CommandAssistAnchorLayout layout = Assert.IsType<CommandAssistAnchorLayout>(pane.CalculateCommandAssistAnchorLayoutForTest());
+
+        Assert.False(layout.UsesPromptAnchor);
+        Assert.True(layout.BubbleRect.Bottom < 500 * 0.8,
+            $"Expected settled SSH fallback bubble to move near the input band, but bottom was {layout.BubbleRect.Bottom}.");
+        Assert.True(layout.BubbleRect.Bottom <= layout.PromptRect.Top,
+            $"Expected settled SSH fallback bubble bottom {layout.BubbleRect.Bottom} to clear prompt top {layout.PromptRect.Top}.");
+    }
+
+    [AvaloniaFact]
     public async Task TerminalPane_WhenPopupIsVisible_AnchorsPopupTopToCalculatedRect()
     {
         var pane = new TerminalPane

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs
@@ -319,6 +319,66 @@ public sealed class CommandAssistLayoutTests
     }
 
     [AvaloniaFact]
+    public void TerminalPane_WhenRemotePromptIsInUpperBandOnShortPane_SuppressesConservativeAssistLayout()
+    {
+        var pane = new TerminalPane
+        {
+            Width = 900,
+            Height = 220
+        };
+        ConfigureCommandAssist(pane);
+        pane.UpdateProfile(new TerminalProfile
+        {
+            Type = ConnectionType.SSH,
+            Command = "ssh.exe",
+            SshHost = "ubuntu.example"
+        });
+        pane.Measure(new Size(900, 220));
+        pane.Arrange(new Rect(0, 0, 900, 220));
+
+        TerminalView termView = Assert.IsType<TerminalView>(pane.FindControl<TerminalView>("TermView"));
+        Assert.NotNull(pane.Buffer);
+        termView.Measure(new Size(900, 220));
+        termView.Arrange(new Rect(0, 0, 900, 220));
+        termView.SetMetricsForTest(10, 18);
+        pane.Buffer.SetCursorPosition(0, 1);
+
+        CommandAssistAnchorLayout? layout = pane.CalculateCommandAssistAnchorLayoutForTest();
+
+        Assert.Null(layout);
+    }
+
+    [AvaloniaFact]
+    public void TerminalPane_WhenRemotePromptSettlesLowOnShortPane_ResumesConservativeAssistLayout()
+    {
+        var pane = new TerminalPane
+        {
+            Width = 900,
+            Height = 220
+        };
+        ConfigureCommandAssist(pane);
+        pane.UpdateProfile(new TerminalProfile
+        {
+            Type = ConnectionType.SSH,
+            Command = "ssh.exe",
+            SshHost = "ubuntu.example"
+        });
+        pane.Measure(new Size(900, 220));
+        pane.Arrange(new Rect(0, 0, 900, 220));
+
+        TerminalView termView = Assert.IsType<TerminalView>(pane.FindControl<TerminalView>("TermView"));
+        Assert.NotNull(pane.Buffer);
+        termView.Measure(new Size(900, 220));
+        termView.Arrange(new Rect(0, 0, 900, 220));
+        termView.SetMetricsForTest(10, 18);
+        pane.Buffer.SetCursorPosition(0, 7);
+
+        CommandAssistAnchorLayout layout = Assert.IsType<CommandAssistAnchorLayout>(pane.CalculateCommandAssistAnchorLayoutForTest());
+
+        Assert.False(layout.UsesPromptAnchor);
+    }
+
+    [AvaloniaFact]
     public async Task TerminalPane_WhenPopupIsVisible_AnchorsPopupTopToCalculatedRect()
     {
         var pane = new TerminalPane

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using System.Collections.ObjectModel;
+using NovaTerminal.CommandAssist.Application;
 using NovaTerminal.Controls;
 using NovaTerminal.CommandAssist.Models;
 using NovaTerminal.CommandAssist.ViewModels;
@@ -27,6 +28,23 @@ public sealed class CommandAssistLayoutTests
         Assert.Equal("Suggest", vm.Bubble.ModeLabel);
         Assert.Equal("git ", vm.Bubble.QueryText);
         Assert.Equal("git status", vm.Bubble.SummaryText);
+    }
+
+    [Fact]
+    public void CommandAssistBarViewModel_WhenPopupIsClosed_DoesNotForceHelperPopupVisible()
+    {
+        var vm = new CommandAssistBarViewModel
+        {
+            IsVisible = true,
+            ModeLabel = "Fix",
+            QueryText = "gti status",
+            TopSuggestionText = "git status",
+            HasSuggestions = true,
+            IsPopupOpen = false
+        };
+
+        Assert.True(vm.Bubble.IsVisible);
+        Assert.False(vm.Popup.IsVisible);
     }
 
     [AvaloniaFact]
@@ -135,6 +153,24 @@ public sealed class CommandAssistLayoutTests
     }
 
     [AvaloniaFact]
+    public void TerminalPane_WhenPaneIsMediumWidth_UsesReducedOverlayWidths()
+    {
+        var pane = new TerminalPane
+        {
+            Width = 700,
+            Height = 420
+        };
+        ConfigureCommandAssist(pane);
+        pane.Measure(new Size(700, 420));
+        pane.Arrange(new Rect(0, 0, 700, 420));
+
+        CommandAssistAnchorLayout layout = Assert.IsType<CommandAssistAnchorLayout>(pane.CalculateCommandAssistAnchorLayoutForTest());
+
+        Assert.True(layout.BubbleRect.Width < 420);
+        Assert.True(layout.PopupRect.Width < 520);
+    }
+
+    [AvaloniaFact]
     public async Task TerminalPane_WhenPaneIsShort_ConstrainsPopupHeight()
     {
         var pane = new TerminalPane
@@ -155,6 +191,31 @@ public sealed class CommandAssistLayoutTests
 
         Assert.True(popupView.MaxHeight > 0);
         Assert.True(popupView.MaxHeight < 220);
+    }
+
+    [AvaloniaFact]
+    public async Task TerminalPane_WhenPopupIsNarrow_UsesCompactPopupLayout()
+    {
+        var pane = new TerminalPane
+        {
+            Width = 420,
+            Height = 420
+        };
+        ConfigureCommandAssist(pane);
+        pane.Measure(new Size(420, 420));
+        pane.Arrange(new Rect(0, 0, 420, 420));
+        pane.NotifyCommandAssistPaste("Get-ChildItem");
+        pane.OpenCommandAssistHelp();
+        await Task.Delay(50);
+        pane.Measure(new Size(420, 420));
+        pane.Arrange(new Rect(0, 0, 420, 420));
+
+        CommandAssistPopupView popupView = Assert.IsType<CommandAssistPopupView>(pane.FindControl<CommandAssistPopupView>("CommandAssistPopup"));
+        CommandAssistPopupViewModel vm = Assert.IsType<CommandAssistPopupViewModel>(popupView.DataContext);
+        Border detailPanel = Assert.IsType<Border>(popupView.FindControl<Border>("PopupDetailPanel"));
+
+        Assert.True(vm.UseCompactLayout);
+        Assert.False(detailPanel.IsVisible);
     }
 
     [AvaloniaFact]
@@ -245,6 +306,39 @@ public sealed class CommandAssistLayoutTests
         Assert.Equal("Help", modeLabel.Text);
         Assert.Equal("Show working tree state.", description.Text);
         Assert.Single(vm.Suggestions);
+    }
+
+    [AvaloniaFact]
+    public void CommandAssistPopupView_WhenCompactLayout_HidesDetailPane()
+    {
+        var suggestions = new ObservableCollection<CommandAssistSuggestionItemViewModel>
+        {
+            new(
+                SelectionGlyph: ">",
+                DisplayText: "git status",
+                DescriptionText: "Show working tree state.",
+                BadgesText: "History",
+                MetadataText: @"C:\repo",
+                IsSelected: true,
+                Type: AssistSuggestionType.History)
+        };
+        var vm = new CommandAssistPopupViewModel(suggestions)
+        {
+            IsVisible = true,
+            ModeLabel = "Help",
+            TopSuggestionText = "git status",
+            SelectedDescriptionText = "Show working tree state.",
+            HasSuggestions = true,
+            UseCompactLayout = true
+        };
+        var view = new CommandAssistPopupView
+        {
+            DataContext = vm
+        };
+
+        Border detailPanel = Assert.IsType<Border>(view.FindControl<Border>("PopupDetailPanel"));
+
+        Assert.False(detailPanel.IsVisible);
     }
 
     [AvaloniaFact]

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs
@@ -1,7 +1,9 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using System.Collections.ObjectModel;
 using NovaTerminal.Controls;
+using NovaTerminal.CommandAssist.Models;
 using NovaTerminal.CommandAssist.ViewModels;
 using NovaTerminal.CommandAssist.Views;
 using NovaTerminal.Core;
@@ -10,19 +12,41 @@ namespace NovaTerminal.Tests.CommandAssist;
 
 public sealed class CommandAssistLayoutTests
 {
-    [AvaloniaFact]
-    public void CommandAssistBar_IsHostedInTerminalOverlayRow()
+    [Fact]
+    public void CommandAssistBarViewModel_MapsCompactBubbleState()
     {
-        var pane = new TerminalPane();
-        ConfigureCommandAssist(pane);
-        var commandAssistBar = pane.FindControl<CommandAssistBarView>("CommandAssistBar");
+        var vm = new CommandAssistBarViewModel
+        {
+            IsVisible = true,
+            ModeLabel = "Suggest",
+            QueryText = "git ",
+            TopSuggestionText = "git status"
+        };
 
-        Assert.NotNull(commandAssistBar);
-        Assert.Equal(0, Grid.GetRow(commandAssistBar));
+        Assert.True(vm.Bubble.IsVisible);
+        Assert.Equal("Suggest", vm.Bubble.ModeLabel);
+        Assert.Equal("git ", vm.Bubble.QueryText);
+        Assert.Equal("git status", vm.Bubble.SummaryText);
     }
 
     [AvaloniaFact]
-    public async Task CommandAssistBar_WhenHelpModeIsOpen_RendersModeAndDescriptionFields()
+    public void TerminalPane_HostsBubbleAndPopupAsOverlayViews()
+    {
+        var pane = new TerminalPane();
+        ConfigureCommandAssist(pane);
+        var bubbleView = pane.FindControl<CommandAssistBubbleView>("CommandAssistBubble");
+        var popupView = pane.FindControl<CommandAssistPopupView>("CommandAssistPopup");
+        var commandAssistBar = pane.FindControl<CommandAssistBarView>("CommandAssistBar");
+
+        Assert.NotNull(bubbleView);
+        Assert.NotNull(popupView);
+        Assert.Null(commandAssistBar);
+        Assert.Equal(0, Grid.GetRow(bubbleView));
+        Assert.Equal(0, Grid.GetRow(popupView));
+    }
+
+    [AvaloniaFact]
+    public async Task TerminalPane_WhenHelpModeIsOpen_BindsBubbleAndPopupState()
     {
         var pane = new TerminalPane();
         ConfigureCommandAssist(pane);
@@ -30,21 +54,28 @@ public sealed class CommandAssistLayoutTests
         pane.OpenCommandAssistHelp();
         await Task.Delay(50);
 
-        var commandAssistBar = pane.FindControl<CommandAssistBarView>("CommandAssistBar");
-        Assert.NotNull(commandAssistBar);
-        var vm = Assert.IsType<CommandAssistBarViewModel>(commandAssistBar.DataContext);
+        var bubbleView = pane.FindControl<CommandAssistBubbleView>("CommandAssistBubble");
+        var popupView = pane.FindControl<CommandAssistPopupView>("CommandAssistPopup");
+        Assert.NotNull(bubbleView);
+        Assert.NotNull(popupView);
 
-        var modeLabel = commandAssistBar.FindControl<TextBlock>("ModeLabelText");
-        var description = commandAssistBar.FindControl<TextBlock>("SelectedDescriptionTextBlock");
+        var bubbleVm = Assert.IsType<CommandAssistBubbleViewModel>(bubbleView.DataContext);
+        var popupVm = Assert.IsType<CommandAssistPopupViewModel>(popupView.DataContext);
 
-        Assert.NotNull(modeLabel);
-        Assert.NotNull(description);
-        Assert.Equal("Help", modeLabel.Text);
-        Assert.False(string.IsNullOrWhiteSpace(vm.SelectedDescriptionText));
+        var bubbleModeLabel = bubbleView.FindControl<TextBlock>("BubbleModeLabelText");
+        var popupDescription = popupView.FindControl<TextBlock>("PopupSelectedDescriptionTextBlock");
+
+        Assert.NotNull(bubbleModeLabel);
+        Assert.NotNull(popupDescription);
+        Assert.Equal("Help", bubbleModeLabel.Text);
+        Assert.True(bubbleVm.IsVisible);
+        Assert.True(popupVm.IsVisible);
+        Assert.Equal("Help", popupVm.ModeLabel);
+        Assert.False(string.IsNullOrWhiteSpace(popupVm.SelectedDescriptionText));
     }
 
     [AvaloniaFact]
-    public async Task CommandAssistBar_WhenHelperModeHasNoSuggestions_ShowsEmptyState()
+    public async Task TerminalPane_WhenHelperModeHasNoSuggestions_ShowsPopupEmptyState()
     {
         var pane = new TerminalPane();
         ConfigureCommandAssist(pane);
@@ -52,12 +83,189 @@ public sealed class CommandAssistLayoutTests
         pane.OpenCommandAssistHelp();
         await Task.Delay(50);
 
-        CommandAssistBarViewModel vm = Assert.IsType<CommandAssistBarViewModel>(pane.FindControl<CommandAssistBarView>("CommandAssistBar")!.DataContext);
-        var emptyState = pane.FindControl<CommandAssistBarView>("CommandAssistBar")!.FindControl<TextBlock>("EmptyStateTextBlock");
+        CommandAssistPopupView popupView = Assert.IsType<CommandAssistPopupView>(pane.FindControl<CommandAssistPopupView>("CommandAssistPopup"));
+        CommandAssistPopupViewModel vm = Assert.IsType<CommandAssistPopupViewModel>(popupView.DataContext);
+        var emptyState = popupView.FindControl<TextBlock>("PopupEmptyStateTextBlock");
 
+        Assert.True(vm.IsVisible);
         Assert.True(vm.ShowEmptyState);
         Assert.Equal("No local help found.", vm.EmptyStateText);
         Assert.NotNull(emptyState);
+        Assert.Equal("No local help found.", emptyState.Text);
+    }
+
+    [AvaloniaFact]
+    public async Task TerminalPane_WhenSuggestModeIsCollapsed_KeepsPopupHidden()
+    {
+        var pane = new TerminalPane();
+        ConfigureCommandAssist(pane);
+        pane.NotifyCommandAssistPaste("git st");
+        await Task.Delay(50);
+
+        CommandAssistBubbleView bubbleView = Assert.IsType<CommandAssistBubbleView>(pane.FindControl<CommandAssistBubbleView>("CommandAssistBubble"));
+        CommandAssistPopupView popupView = Assert.IsType<CommandAssistPopupView>(pane.FindControl<CommandAssistPopupView>("CommandAssistPopup"));
+        CommandAssistBubbleViewModel bubbleVm = Assert.IsType<CommandAssistBubbleViewModel>(bubbleView.DataContext);
+        CommandAssistPopupViewModel popupVm = Assert.IsType<CommandAssistPopupViewModel>(popupView.DataContext);
+
+        Assert.True(bubbleVm.IsVisible);
+        Assert.False(popupVm.IsVisible);
+    }
+
+    [AvaloniaFact]
+    public async Task TerminalPane_WhenPaneIsNarrow_HidesBubbleQueryText()
+    {
+        var pane = new TerminalPane
+        {
+            Width = 420,
+            Height = 420
+        };
+        ConfigureCommandAssist(pane);
+        pane.Measure(new Size(420, 420));
+        pane.Arrange(new Rect(0, 0, 420, 420));
+        pane.NotifyCommandAssistPaste("git status --short");
+        await Task.Delay(50);
+        pane.Measure(new Size(420, 420));
+        pane.Arrange(new Rect(0, 0, 420, 420));
+
+        CommandAssistBubbleView bubbleView = Assert.IsType<CommandAssistBubbleView>(pane.FindControl<CommandAssistBubbleView>("CommandAssistBubble"));
+        var queryText = bubbleView.FindControl<TextBlock>("BubbleQueryText");
+
+        Assert.NotNull(queryText);
+        Assert.False(queryText.IsVisible);
+    }
+
+    [AvaloniaFact]
+    public async Task TerminalPane_WhenPaneIsShort_ConstrainsPopupHeight()
+    {
+        var pane = new TerminalPane
+        {
+            Width = 700,
+            Height = 220
+        };
+        ConfigureCommandAssist(pane);
+        pane.Measure(new Size(700, 220));
+        pane.Arrange(new Rect(0, 0, 700, 220));
+        pane.NotifyCommandAssistPaste("Get-ChildItem");
+        pane.OpenCommandAssistHelp();
+        await Task.Delay(50);
+        pane.Measure(new Size(700, 220));
+        pane.Arrange(new Rect(0, 0, 700, 220));
+
+        CommandAssistPopupView popupView = Assert.IsType<CommandAssistPopupView>(pane.FindControl<CommandAssistPopupView>("CommandAssistPopup"));
+
+        Assert.True(popupView.MaxHeight > 0);
+        Assert.True(popupView.MaxHeight < 220);
+    }
+
+    [AvaloniaFact]
+    public async Task TerminalPane_WhenAssistBecomesVisible_DoesNotChangeTerminalRowHeight()
+    {
+        var pane = new TerminalPane
+        {
+            Width = 900,
+            Height = 500
+        };
+        ConfigureCommandAssist(pane);
+        pane.Measure(new Size(900, 500));
+        pane.Arrange(new Rect(0, 0, 900, 500));
+
+        var terminalView = pane.FindControl<NovaTerminal.Core.TerminalView>("TermView");
+        Assert.NotNull(terminalView);
+        double baselineHeight = terminalView.Bounds.Height;
+
+        pane.NotifyCommandAssistPaste("Get-ChildItem");
+        pane.OpenCommandAssistHelp();
+        await Task.Delay(50);
+        pane.Measure(new Size(900, 500));
+        pane.Arrange(new Rect(0, 0, 900, 500));
+
+        Assert.Equal(baselineHeight, terminalView.Bounds.Height);
+    }
+
+    [AvaloniaFact]
+    public void CommandAssistBubbleView_BindsCollapsedState()
+    {
+        var vm = new CommandAssistBubbleViewModel
+        {
+            IsVisible = true,
+            ModeLabel = "Suggest",
+            QueryText = "git st",
+            SummaryText = "git status"
+        };
+        var view = new CommandAssistBubbleView
+        {
+            DataContext = vm
+        };
+
+        var modeLabel = view.FindControl<TextBlock>("BubbleModeLabelText");
+        var summary = view.FindControl<TextBlock>("BubbleSummaryText");
+
+        Assert.NotNull(modeLabel);
+        Assert.NotNull(summary);
+        Assert.True(view.IsVisible);
+        Assert.Equal("Suggest", modeLabel.Text);
+        Assert.Equal("git status", summary.Text);
+    }
+
+    [AvaloniaFact]
+    public void CommandAssistPopupView_BindsResultListAndDetailState()
+    {
+        var suggestions = new ObservableCollection<CommandAssistSuggestionItemViewModel>
+        {
+            new(
+                SelectionGlyph: ">",
+                DisplayText: "git status",
+                DescriptionText: "Show working tree state.",
+                BadgesText: "History",
+                MetadataText: @"C:\repo",
+                IsSelected: true,
+                Type: AssistSuggestionType.History)
+        };
+        var vm = new CommandAssistPopupViewModel(suggestions)
+        {
+            IsVisible = true,
+            ModeLabel = "Help",
+            TopSuggestionText = "git status",
+            SelectedDescriptionText = "Show working tree state.",
+            HasSuggestions = true
+        };
+        var view = new CommandAssistPopupView
+        {
+            DataContext = vm
+        };
+
+        var modeLabel = view.FindControl<TextBlock>("PopupModeLabelText");
+        var description = view.FindControl<TextBlock>("PopupSelectedDescriptionTextBlock");
+        var list = view.FindControl<ItemsControl>("PopupSuggestionsList");
+
+        Assert.NotNull(modeLabel);
+        Assert.NotNull(description);
+        Assert.NotNull(list);
+        Assert.True(view.IsVisible);
+        Assert.Equal("Help", modeLabel.Text);
+        Assert.Equal("Show working tree state.", description.Text);
+        Assert.Single(vm.Suggestions);
+    }
+
+    [AvaloniaFact]
+    public void CommandAssistPopupView_CanExistWithoutTerminalGridRowHost()
+    {
+        var vm = new CommandAssistPopupViewModel(new ObservableCollection<CommandAssistSuggestionItemViewModel>())
+        {
+            IsVisible = true,
+            ModeLabel = "History",
+            EmptyStateText = "No local help found.",
+            ShowEmptyState = true
+        };
+        var view = new CommandAssistPopupView
+        {
+            DataContext = vm
+        };
+
+        var emptyState = view.FindControl<TextBlock>("PopupEmptyStateTextBlock");
+
+        Assert.NotNull(emptyState);
+        Assert.Equal(0, Grid.GetRow(view));
         Assert.Equal("No local help found.", emptyState.Text);
     }
 

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs
@@ -194,6 +194,56 @@ public sealed class CommandAssistLayoutTests
     }
 
     [AvaloniaFact]
+    public async Task TerminalPane_WhenBubbleIsVisible_KeepsBubbleAbovePromptAnchor()
+    {
+        var pane = new TerminalPane
+        {
+            Width = 900,
+            Height = 500
+        };
+        ConfigureCommandAssist(pane);
+        pane.Measure(new Size(900, 500));
+        pane.Arrange(new Rect(0, 0, 900, 500));
+        pane.NotifyCommandAssistPaste("git st");
+        await Task.Delay(50);
+        pane.Measure(new Size(900, 500));
+        pane.Arrange(new Rect(0, 0, 900, 500));
+
+        CommandAssistBubbleView bubbleView = Assert.IsType<CommandAssistBubbleView>(pane.FindControl<CommandAssistBubbleView>("CommandAssistBubble"));
+        CommandAssistAnchorLayout layout = Assert.IsType<CommandAssistAnchorLayout>(pane.CalculateCommandAssistAnchorLayoutForTest());
+
+        Assert.True(layout.BubbleRect.Bottom <= layout.PromptRect.Top,
+            $"Expected layout bubble bottom {layout.BubbleRect.Bottom} to clear prompt top {layout.PromptRect.Top}.");
+        Assert.Equal(layout.BubbleRect.Top, bubbleView.Margin.Top, precision: 1);
+        double bubbleBottom = bubbleView.Margin.Top + bubbleView.Height;
+        Assert.True(bubbleBottom <= layout.PromptRect.Top,
+            $"Expected bubble bottom {bubbleBottom} to clear prompt top {layout.PromptRect.Top}.");
+    }
+
+    [AvaloniaFact]
+    public async Task TerminalPane_WhenPopupIsVisible_AnchorsPopupTopToCalculatedRect()
+    {
+        var pane = new TerminalPane
+        {
+            Width = 900,
+            Height = 500
+        };
+        ConfigureCommandAssist(pane);
+        pane.Measure(new Size(900, 500));
+        pane.Arrange(new Rect(0, 0, 900, 500));
+        pane.NotifyCommandAssistPaste("Get-ChildItem");
+        pane.OpenCommandAssistHelp();
+        await Task.Delay(50);
+        pane.Measure(new Size(900, 500));
+        pane.Arrange(new Rect(0, 0, 900, 500));
+
+        CommandAssistPopupView popupView = Assert.IsType<CommandAssistPopupView>(pane.FindControl<CommandAssistPopupView>("CommandAssistPopup"));
+        CommandAssistAnchorLayout layout = Assert.IsType<CommandAssistAnchorLayout>(pane.CalculateCommandAssistAnchorLayoutForTest());
+
+        Assert.Equal(layout.PopupRect.Top, popupView.Margin.Top, precision: 1);
+    }
+
+    [AvaloniaFact]
     public async Task TerminalPane_WhenPopupIsNarrow_UsesCompactPopupLayout()
     {
         var pane = new TerminalPane

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs
@@ -379,6 +379,38 @@ public sealed class CommandAssistLayoutTests
     }
 
     [AvaloniaFact]
+    public void TerminalPane_WhenRemotePromptHintRowsLagPaneHeight_UsesPaneEstimatedRowsForConservativeFallback()
+    {
+        var pane = new TerminalPane
+        {
+            Width = 900,
+            Height = 500
+        };
+        ConfigureCommandAssist(pane);
+        pane.UpdateProfile(new TerminalProfile
+        {
+            Type = ConnectionType.SSH,
+            Command = "ssh.exe",
+            SshHost = "ubuntu.example"
+        });
+        pane.Measure(new Size(900, 500));
+        pane.Arrange(new Rect(0, 0, 900, 500));
+
+        TerminalView termView = Assert.IsType<TerminalView>(pane.FindControl<TerminalView>("TermView"));
+        Assert.NotNull(pane.Buffer);
+        termView.SetMetricsForTest(10, 18);
+        termView.Measure(new Size(900, 160));
+        termView.Arrange(new Rect(0, 0, 900, 160));
+        pane.Buffer.SetCursorPosition(0, 5);
+
+        CommandAssistAnchorLayout layout = Assert.IsType<CommandAssistAnchorLayout>(pane.CalculateCommandAssistAnchorLayoutForTest());
+
+        Assert.False(layout.UsesPromptAnchor);
+        Assert.True(layout.BubbleRect.Bottom > 500 * 0.5,
+            $"Expected conservative fallback to stay in lower safe zone when prompt hint rows lag pane height, but bottom was {layout.BubbleRect.Bottom}.");
+    }
+
+    [AvaloniaFact]
     public async Task TerminalPane_WhenPopupIsVisible_AnchorsPopupTopToCalculatedRect()
     {
         var pane = new TerminalPane

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs
@@ -125,7 +125,7 @@ public sealed class CommandAssistLayoutTests
         CommandAssistBubbleViewModel bubbleVm = Assert.IsType<CommandAssistBubbleViewModel>(bubbleView.DataContext);
         CommandAssistPopupViewModel popupVm = Assert.IsType<CommandAssistPopupViewModel>(popupView.DataContext);
 
-        Assert.True(bubbleVm.IsVisible);
+        Assert.Equal(!string.IsNullOrWhiteSpace(bubbleVm.SummaryText), bubbleVm.IsVisible);
         Assert.False(popupVm.IsVisible);
     }
 

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistLayoutTests.cs
@@ -287,6 +287,38 @@ public sealed class CommandAssistLayoutTests
     }
 
     [AvaloniaFact]
+    public void TerminalPane_WhenSshStartupHasTransientTermViewBounds_UsesPaneBoundsForFallbackLayout()
+    {
+        var pane = new TerminalPane
+        {
+            Width = 900,
+            Height = 500
+        };
+        ConfigureCommandAssist(pane);
+        pane.UpdateProfile(new TerminalProfile
+        {
+            Type = ConnectionType.SSH,
+            Command = "ssh.exe",
+            SshHost = "ubuntu.example"
+        });
+        pane.Measure(new Size(900, 500));
+        pane.Arrange(new Rect(0, 0, 900, 500));
+
+        TerminalView termView = Assert.IsType<TerminalView>(pane.FindControl<TerminalView>("TermView"));
+        Assert.NotNull(pane.Buffer);
+        termView.SetMetricsForTest(10, 18);
+        termView.Measure(new Size(900, 120));
+        termView.Arrange(new Rect(0, 0, 900, 120));
+        pane.Buffer.SetCursorPosition(0, 1);
+
+        CommandAssistAnchorLayout layout = Assert.IsType<CommandAssistAnchorLayout>(pane.CalculateCommandAssistAnchorLayoutForTest());
+
+        Assert.False(layout.UsesPromptAnchor);
+        Assert.True(layout.BubbleRect.Bottom > 500 * 0.5,
+            $"Expected startup SSH fallback bubble to stay in the lower safe zone despite transient term bounds, but bottom was {layout.BubbleRect.Bottom}.");
+    }
+
+    [AvaloniaFact]
     public async Task TerminalPane_WhenPopupIsVisible_AnchorsPopupTopToCalculatedRect()
     {
         var pane = new TerminalPane

--- a/tests/NovaTerminal.Tests/CommandAssist/TerminalPaneCommandAssistShortcutTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/TerminalPaneCommandAssistShortcutTests.cs
@@ -138,9 +138,7 @@ public sealed class TerminalPaneCommandAssistShortcutTests
 
     private static CommandAssistBarViewModel AssertViewModel(TerminalPane pane)
     {
-        var commandAssistBar = pane.FindControl<Control>("CommandAssistBar");
-        Assert.NotNull(commandAssistBar);
-        return Assert.IsType<CommandAssistBarViewModel>(commandAssistBar.DataContext);
+        return Assert.IsType<CommandAssistBarViewModel>(pane.CommandAssistViewModel);
     }
 
     private static void ConfigureCommandAssist(TerminalPane pane)

--- a/tests/NovaTerminal.Tests/CommandAssist/TerminalPaneCommandAssistShortcutTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/TerminalPaneCommandAssistShortcutTests.cs
@@ -22,6 +22,21 @@ public sealed class TerminalPaneCommandAssistShortcutTests
     }
 
     [AvaloniaFact]
+    public void OpenCommandAssistHelp_WhenDisabledInSettings_ReturnsFalse()
+    {
+        var pane = new TerminalPane();
+        var settings = TerminalSettings.Load();
+        settings.CommandAssistEnabled = false;
+        settings.CommandAssistHistoryEnabled = true;
+        pane.ApplySettings(settings);
+
+        bool handled = pane.OpenCommandAssistHelp();
+
+        Assert.False(handled);
+        Assert.False(pane.CommandAssistViewModel?.IsVisible ?? false);
+    }
+
+    [AvaloniaFact]
     public async Task OpenCommandAssistHelp_WhenQueryPresent_UsesPaneInfrastructure()
     {
         var pane = new TerminalPane();

--- a/tests/NovaTerminal.Tests/CommandAssist/TerminalViewKeyHandlingTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/TerminalViewKeyHandlingTests.cs
@@ -1,6 +1,8 @@
+using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
 using Moq;
+using NovaTerminal.Controls;
 using NovaTerminal.Core;
 
 namespace NovaTerminal.Tests.CommandAssist;
@@ -32,5 +34,70 @@ public sealed class TerminalViewKeyHandlingTests
 
         Assert.True(handled);
         session.Verify(x => x.SendInput("\t"), Times.Once);
+    }
+
+    [AvaloniaFact]
+    public void GetCommandAssistPromptHint_WhenMetricsAndCursorAreAvailable_ReturnsVisibleCursorRow()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var view = new TerminalView();
+        view.SetBuffer(buffer);
+        view.Measure(new Avalonia.Size(800, 432));
+        view.Arrange(new Avalonia.Rect(0, 0, 800, 432));
+        view.SetMetricsForTest(10, 18);
+        buffer.SetCursorPosition(3, 7);
+
+        CommandAssistPromptHint? hint = view.GetCommandAssistPromptHint();
+
+        Assert.NotNull(hint);
+        Assert.Equal(7, hint.Value.VisibleCursorVisualRow);
+        Assert.Equal(view.Rows, hint.Value.VisibleRows);
+        Assert.Equal(18, hint.Value.CellHeight);
+    }
+
+    [AvaloniaFact]
+    public void PromptHintAndPaneAnchorLayout_WhenCursorRowOrMetricsChange_UpdateWithoutBufferMutation()
+    {
+        var pane = new TerminalPane
+        {
+            Width = 900,
+            Height = 500
+        };
+        var settings = TerminalSettings.Load();
+        settings.CommandAssistEnabled = true;
+        settings.CommandAssistHistoryEnabled = true;
+        pane.ApplySettings(settings);
+        pane.Measure(new Avalonia.Size(900, 500));
+        pane.Arrange(new Avalonia.Rect(0, 0, 900, 500));
+
+        var view = pane.FindControl<TerminalView>("TermView");
+        Assert.NotNull(view);
+        Assert.NotNull(pane.Buffer);
+        view.Measure(new Avalonia.Size(900, 478));
+        view.Arrange(new Avalonia.Rect(0, 0, 900, 478));
+
+        view.SetMetricsForTest(10, 18);
+        pane.Buffer.SetCursorPosition(0, 5);
+        CommandAssistPromptHint? firstHint = view.GetCommandAssistPromptHint();
+        var firstLayout = pane.CalculateCommandAssistAnchorLayoutForTest();
+
+        pane.Buffer.SetCursorPosition(0, 10);
+        CommandAssistPromptHint? secondHint = view.GetCommandAssistPromptHint();
+
+        view.SetMetricsForTest(10, 20);
+        CommandAssistPromptHint? thirdHint = view.GetCommandAssistPromptHint();
+        var secondLayout = pane.CalculateCommandAssistAnchorLayoutForTest();
+
+        Assert.NotNull(firstHint);
+        Assert.NotNull(secondHint);
+        Assert.NotNull(thirdHint);
+        Assert.NotNull(firstLayout);
+        Assert.NotNull(secondLayout);
+        Assert.Equal(5, firstHint.Value.VisibleCursorVisualRow);
+        Assert.Equal(10, secondHint.Value.VisibleCursorVisualRow);
+        Assert.Equal(20, thirdHint.Value.CellHeight);
+        Assert.True(firstLayout!.UsesPromptAnchor);
+        Assert.True(secondLayout!.UsesPromptAnchor);
+        Assert.True(secondLayout.PromptRect.Y > firstLayout.PromptRect.Y);
     }
 }

--- a/tests/NovaTerminal.Tests/DecModeTests.cs
+++ b/tests/NovaTerminal.Tests/DecModeTests.cs
@@ -70,6 +70,21 @@ namespace NovaTerminal.Tests
         }
 
         [Fact]
+        public void KeypadModeEscapes_DoNotRenderLiteralCharacters()
+        {
+            var buffer = new TerminalBuffer(80, 24);
+            var parser = new AnsiParser(buffer);
+
+            parser.Process("Prompt");
+            parser.Process("\x1b=");
+            parser.Process("\x1b>");
+
+            Assert.Equal("Prompt", GetVisiblePlainText(buffer).Trim());
+            Assert.Equal(6, buffer.CursorCol);
+            Assert.Equal(0, buffer.CursorRow);
+        }
+
+        [Fact]
         public void CursorVisibility_HideAndShowInSeparateChunks_DoesNotArmTransientSuppression()
         {
             var buffer = new TerminalBuffer(80, 24);
@@ -223,6 +238,19 @@ namespace NovaTerminal.Tests
             Assert.True(buffer.Modes.IsFocusEventReporting);
             parser.Process("\x1b[?1004l");
             Assert.False(buffer.Modes.IsFocusEventReporting);
+        }
+
+        private static string GetVisiblePlainText(TerminalBuffer buffer)
+        {
+            var field = typeof(TerminalBuffer).GetField("_viewport", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var viewport = (TerminalRow[])field!.GetValue(buffer)!;
+            return string.Join("\n", viewport.Select(GetRowText)).TrimEnd();
+        }
+
+        private static string GetRowText(TerminalRow row)
+        {
+            var chars = row.Cells.Select(c => c.Character == '\0' ? ' ' : c.Character).ToArray();
+            return new string(chars).TrimEnd();
         }
     }
 }

--- a/tests/NovaTerminal.Tests/RenderTests/GlyphFallbackTests.cs
+++ b/tests/NovaTerminal.Tests/RenderTests/GlyphFallbackTests.cs
@@ -1,0 +1,50 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using NovaTerminal.Core;
+using NovaTerminal;
+using SkiaSharp;
+using Xunit;
+
+namespace NovaTerminal.Tests.RenderTests;
+
+public sealed class GlyphFallbackTests
+{
+    [Fact]
+    public void ResolveTypefaceForCodePoint_DingbatArrow_PrefersSymbolFallbackOverEmojiShortcut()
+    {
+        using var primary = SKTypeface.FromFamilyName("Consolas");
+        using var emoji = SKTypeface.FromFamilyName("Segoe UI Emoji");
+        using var symbol = SKTypeface.FromFamilyName("Segoe UI Symbol");
+
+        if (primary == null || emoji == null || symbol == null)
+        {
+            return;
+        }
+
+        if (primary.ContainsGlyph(0x279C) || !symbol.ContainsGlyph(0x279C))
+        {
+            return;
+        }
+
+        object operation = System.Runtime.CompilerServices.RuntimeHelpers
+            .GetUninitializedObject(typeof(TerminalDrawOperation));
+
+        SetField(operation, "_fallbackCache", new ConcurrentDictionary<string, SKTypeface?>());
+        SetField(operation, "_fallbackChain", new[] { emoji, symbol });
+
+        MethodInfo resolve = typeof(TerminalDrawOperation).GetMethod(
+            "ResolveTypefaceForCodePoint",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        var resolved = (SKTypeface)resolve.Invoke(operation, new object[] { 0x279C, primary })!;
+
+        Assert.Equal(symbol.FamilyName, resolved.FamilyName);
+    }
+
+    private static void SetField(object instance, string fieldName, object value)
+    {
+        FieldInfo field = typeof(TerminalDrawOperation).GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)!;
+        field.SetValue(instance, value);
+    }
+}


### PR DESCRIPTION
Summary:
- move all commits since 49e1a77 onto feature/command-assist-post-merge
- include SSH conservative fallback, prompt glyph fallback, and keypad escape fixes

Verification:
- dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter FullyQualifiedName~NovaTerminal.Tests.CommandAssist
- dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release