### PR TITLE
feature/ssh reconnect and command palette

### DIFF
--- a/docs/plans/2026-03-14-command-assist-shell-first-tab-and-path-suggestions.md
+++ b/docs/plans/2026-03-14-command-assist-shell-first-tab-and-path-suggestions.md
@@ -1,0 +1,170 @@
+# Command Assist Shell-First Tab And Path Suggestions Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make `Tab` shell-owned for completion while adding Command Assist path suggestions that are accepted with `Ctrl+Enter`.
+
+**Architecture:** Keep terminal input behavior shell-first by changing Command Assist key arbitration so `Tab` is never consumed. Add a filesystem-backed path suggestion provider inside the Command Assist suggestion pipeline, scoped to local sessions only, and keep insertion additive through existing insertion-planner behavior.
+
+**Tech Stack:** C#/.NET 10, Avalonia key handling, existing Command Assist domain/application layers, xUnit/Avalonia.Headless tests.
+
+---
+
+### Task 1: Lock Key Arbitration To Shell-First Tab
+
+**Files:**
+- Modify: `src/NovaTerminal.App/CommandAssist/Application/CommandAssistKeyRouter.cs`
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs`
+- Modify: `src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistBubbleViewModel.cs`
+- Test: `tests/NovaTerminal.Tests/CommandAssist/CommandAssistKeyRouterTests.cs`
+- Test: `tests/NovaTerminal.Tests/CommandAssist/TerminalPaneCommandAssistShortcutTests.cs`
+
+**Step 1: Write failing tests for new key ownership contract**
+
+Add tests that assert:
+- `Tab` is not assist-owned even when assist is visible.
+- `Ctrl+Enter` is assist-owned when assist is visible.
+- `Ctrl+Enter` is not assist-owned when assist is hidden.
+
+**Step 2: Run tests to verify failure**
+
+Run: `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~CommandAssistKeyRouterTests"`
+
+Expected: FAIL on new assertions until router logic is updated.
+
+**Step 3: Implement minimal key routing changes**
+
+Update `CommandAssistKeyRouter.IsAssistOwnedKey`:
+- Remove `Key.Tab` from assist-owned keys.
+- Add `Ctrl+Enter` as assist-owned key.
+- Keep existing `Escape`, `Up`, `Down`, `Ctrl+Shift+P`.
+
+Update `TerminalPane.TryHandleCommandAssistKey`:
+- Remove `Tab` acceptance path.
+- Add `Ctrl+Enter` path that calls `TryInsertSelectedCommandAssistSuggestion()`.
+
+Update bubble hint text to reflect the new default keys (`Ctrl+Enter` accept, `Ctrl+Space` toggle).
+
+**Step 4: Run tests to verify pass**
+
+Run:
+- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~CommandAssistKeyRouterTests"`
+- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~TerminalPaneCommandAssistShortcutTests"`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/CommandAssist/Application/CommandAssistKeyRouter.cs \
+        src/NovaTerminal.App/Controls/TerminalPane.axaml.cs \
+        src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistBubbleViewModel.cs \
+        tests/NovaTerminal.Tests/CommandAssist/CommandAssistKeyRouterTests.cs \
+        tests/NovaTerminal.Tests/CommandAssist/TerminalPaneCommandAssistShortcutTests.cs
+git commit -m "Make Tab shell-owned and move assist accept to Ctrl+Enter"
+```
+
+### Task 2: Add Local Path Suggestion Provider For Command Assist
+
+**Files:**
+- Create: `src/NovaTerminal.App/CommandAssist/Domain/IPathSuggestionProvider.cs`
+- Create: `src/NovaTerminal.App/CommandAssist/Domain/FileSystemPathSuggestionProvider.cs`
+- Modify: `src/NovaTerminal.App/CommandAssist/Domain/CommandAssistSuggestionEngine.cs`
+- Modify: `src/NovaTerminal.App/CommandAssist/Models/AssistSuggestionType.cs`
+- Modify: `src/NovaTerminal.App/CommandAssist/Models/CommandAssistQueryContext.cs`
+- Modify: `src/NovaTerminal.App/CommandAssist/Application/CommandAssistController.cs`
+- Modify: `src/NovaTerminal.App/CommandAssist/Application/CommandAssistInfrastructure.cs`
+- Test: `tests/NovaTerminal.Tests/CommandAssist/CommandAssistSuggestionEngineTests.cs`
+- Test: `tests/NovaTerminal.Tests/CommandAssist/FileSystemPathSuggestionProviderTests.cs`
+
+**Step 1: Write failing tests for path suggestion behavior**
+
+Add deterministic tests for:
+- `cd ~/h` style prefix emits path suggestions.
+- Directory suggestions are listed before file suggestions.
+- Suggestions are additive continuations of the current input.
+- Local path suggestions are disabled when context is remote.
+
+Use temp directories/files in tests to avoid machine-specific dependencies.
+
+**Step 2: Run tests to verify failure**
+
+Run:
+- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~FileSystemPathSuggestionProviderTests"`
+- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~CommandAssistSuggestionEngineTests"`
+
+Expected: FAIL until provider + integration are implemented.
+
+**Step 3: Implement minimal provider and integrate**
+
+Add provider that:
+- Detects path context from current input token and common path commands (`cd`, `ls`, `cat`, `mv`, `cp`, `rm`).
+- Resolves candidates from current working directory.
+- Supports `~/` expansion.
+- Emits `AssistSuggestion` rows with `Type = AssistSuggestionType.Path`.
+- Returns insert text that strictly extends current query (for insertion planner compatibility).
+- Limits count and uses stable ordering (directories first, then name).
+
+Integrate provider into `CommandAssistSuggestionEngine` and `CommandAssistInfrastructure`.
+Pass remote-session flag by extending `CommandAssistQueryContext` and wiring `_isRemote` from `CommandAssistController`.
+
+**Step 4: Run tests to verify pass**
+
+Run:
+- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~FileSystemPathSuggestionProviderTests"`
+- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~CommandAssistSuggestionEngineTests"`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/CommandAssist/Domain/IPathSuggestionProvider.cs \
+        src/NovaTerminal.App/CommandAssist/Domain/FileSystemPathSuggestionProvider.cs \
+        src/NovaTerminal.App/CommandAssist/Domain/CommandAssistSuggestionEngine.cs \
+        src/NovaTerminal.App/CommandAssist/Models/AssistSuggestionType.cs \
+        src/NovaTerminal.App/CommandAssist/Models/CommandAssistQueryContext.cs \
+        src/NovaTerminal.App/CommandAssist/Application/CommandAssistController.cs \
+        src/NovaTerminal.App/CommandAssist/Application/CommandAssistInfrastructure.cs \
+        tests/NovaTerminal.Tests/CommandAssist/FileSystemPathSuggestionProviderTests.cs \
+        tests/NovaTerminal.Tests/CommandAssist/CommandAssistSuggestionEngineTests.cs
+git commit -m "Add local path suggestions to command assist without Tab hijacking"
+```
+
+### Task 3: Verify End-To-End Behavior And AOT Safety
+
+**Files:**
+- Verify only: `src/NovaTerminal.App/CommandAssist/**`, `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs`
+
+**Step 1: Run focused command-assist suite**
+
+Run: `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~CommandAssist"`
+
+Expected: PASS.
+
+**Step 2: Run PTY smoke lane**
+
+Run: `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "Category=PtySmoke"`
+
+Expected: PASS.
+
+**Step 3: Run AOT publish verification**
+
+Run: `dotnet publish src/NovaTerminal.App/NovaTerminal.App.csproj -c Release -r win-x64 --self-contained true -p:PublishAot=true -o artifacts/publish/win-x64`
+
+Expected: publish succeeds and no new Command Assist trim regressions.
+
+**Step 4: Manual smoke checklist**
+
+Verify:
+- `cd ~/h` + `Tab` uses shell completion (no assist insertion).
+- `Ctrl+Space` opens/refreshes assist.
+- Path suggestion rows appear for path-like input.
+- `Ctrl+Enter` accepts selected path suggestion.
+- SSH pane does not surface local filesystem path suggestions.
+
+**Step 5: Commit verification notes (optional)**
+
+```bash
+git commit --allow-empty -m "chore: verify command assist shell-first tab and path suggestion behavior"
+```

--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistAnchorCalculator.cs
@@ -57,12 +57,23 @@ public sealed class CommandAssistAnchorCalculator
         bool canPlacePopupRight = bubbleRect.Right + HorizontalGap + popupWidth <= paneWidth - PanePadding;
         bool canPlacePopupLeft = bubbleRect.Left - HorizontalGap - popupWidth >= PanePadding;
         bool hasMeaningfulVerticalRoom = Math.Max(spaceAbove, spaceBelow) >= popupHeight * 0.75;
+        bool bubbleSitsBelowPrompt = bubbleRect.Top >= promptRect.Bottom;
 
         CommandAssistPopupDirection popupDirection;
         double popupX;
         double popupY;
 
-        if (canPlacePopupUpward)
+        if (canPlacePopupUpward && canPlacePopupDownward)
+        {
+            popupDirection = bubbleSitsBelowPrompt
+                ? CommandAssistPopupDirection.Downward
+                : CommandAssistPopupDirection.Upward;
+            popupX = bubbleRect.X;
+            popupY = popupDirection == CommandAssistPopupDirection.Downward
+                ? downwardTop
+                : upwardTop;
+        }
+        else if (canPlacePopupUpward)
         {
             popupDirection = CommandAssistPopupDirection.Upward;
             popupX = bubbleRect.X;

--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistController.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistController.cs
@@ -580,7 +580,7 @@ public sealed class CommandAssistController
         int refreshVersion = Interlocked.Increment(ref _refreshVersion);
         CommandAssistMode requestedMode = _currentMode;
         string query = ViewModel.QueryText;
-        var context = new CommandAssistQueryContext(query, _workingDirectory, _shellKind, _profileId);
+        var context = new CommandAssistQueryContext(query, _workingDirectory, _shellKind, _profileId, _isRemote);
         _ = RefreshSuggestionsAsync(query, context, refreshVersion, requestedMode);
     }
 

--- a/src/NovaTerminal.App/CommandAssist/Application/CommandAssistKeyRouter.cs
+++ b/src/NovaTerminal.App/CommandAssist/Application/CommandAssistKeyRouter.cs
@@ -13,11 +13,12 @@ internal static class CommandAssistKeyRouter
 
         bool isCtrl = (modifiers & KeyModifiers.Control) != 0;
         bool isShift = (modifiers & KeyModifiers.Shift) != 0;
+        bool isAlt = (modifiers & KeyModifiers.Alt) != 0;
 
         return key == Key.Escape ||
                key == Key.Up ||
                key == Key.Down ||
-               key == Key.Tab ||
+               (isCtrl && !isShift && !isAlt && key == Key.Enter) ||
                (isCtrl && isShift && key == Key.P);
     }
 }

--- a/src/NovaTerminal.App/CommandAssist/Domain/CommandAssistSuggestionEngine.cs
+++ b/src/NovaTerminal.App/CommandAssist/Domain/CommandAssistSuggestionEngine.cs
@@ -7,6 +7,13 @@ namespace NovaTerminal.CommandAssist.Domain;
 
 public sealed class CommandAssistSuggestionEngine : ISuggestionEngine
 {
+    private readonly IPathSuggestionProvider _pathSuggestionProvider;
+
+    public CommandAssistSuggestionEngine(IPathSuggestionProvider? pathSuggestionProvider = null)
+    {
+        _pathSuggestionProvider = pathSuggestionProvider ?? new FileSystemPathSuggestionProvider();
+    }
+
     public IReadOnlyList<AssistSuggestion> GetSuggestions(
         IReadOnlyList<CommandHistoryEntry> historyEntries,
         CommandAssistQueryContext context,
@@ -28,6 +35,7 @@ public sealed class CommandAssistSuggestionEngine : ISuggestionEngine
 
         string query = context.Input?.Trim() ?? string.Empty;
         List<AssistSuggestion> results = new();
+        results.AddRange(_pathSuggestionProvider.GetSuggestions(context, maxResults));
         results.AddRange(BuildHistorySuggestions(historyEntries, context, query));
         results.AddRange(BuildSnippetSuggestions(snippets, context, query));
 

--- a/src/NovaTerminal.App/CommandAssist/Domain/FileSystemPathSuggestionProvider.cs
+++ b/src/NovaTerminal.App/CommandAssist/Domain/FileSystemPathSuggestionProvider.cs
@@ -1,0 +1,415 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using NovaTerminal.CommandAssist.Models;
+
+namespace NovaTerminal.CommandAssist.Domain;
+
+public sealed class FileSystemPathSuggestionProvider : IPathSuggestionProvider
+{
+    private static readonly HashSet<string> PathCommands = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "cd",
+        "ls",
+        "cat",
+        "mv",
+        "cp",
+        "rm",
+        "mkdir",
+        "rmdir",
+        "touch",
+        "code"
+    };
+
+    private readonly string? _homeDirectoryOverride;
+
+    public FileSystemPathSuggestionProvider(string? homeDirectoryOverride = null)
+    {
+        _homeDirectoryOverride = homeDirectoryOverride;
+    }
+
+    public IReadOnlyList<AssistSuggestion> GetSuggestions(CommandAssistQueryContext context, int maxResults)
+    {
+        if (maxResults <= 0 || context.IsRemote)
+        {
+            return Array.Empty<AssistSuggestion>();
+        }
+
+        if (!TryExtractCommandAndToken(context.Input, out string commandToken, out string activeToken))
+        {
+            return Array.Empty<AssistSuggestion>();
+        }
+        bool isQuotedToken = activeToken.StartsWith('"') || activeToken.StartsWith('\'');
+
+        if (!ShouldSuggestPath(commandToken, activeToken))
+        {
+            return Array.Empty<AssistSuggestion>();
+        }
+
+        if (!TryResolveSearchContext(
+                activeToken,
+                context.WorkingDirectory,
+                out string searchDirectory,
+                out string typedLeaf,
+                out string baseTokenPrefix,
+                out char preferredSeparator))
+        {
+            return Array.Empty<AssistSuggestion>();
+        }
+
+        List<(string Name, bool IsDirectory)> entries = EnumerateEntries(searchDirectory, typedLeaf);
+        if (entries.Count == 0)
+        {
+            return Array.Empty<AssistSuggestion>();
+        }
+
+        string queryPrefix = context.Input ?? string.Empty;
+        List<AssistSuggestion> suggestions = new(Math.Min(maxResults, entries.Count));
+
+        for (int i = 0; i < entries.Count && suggestions.Count < maxResults; i++)
+        {
+            (string entryName, bool isDirectory) = entries[i];
+            string completionToken = baseTokenPrefix + entryName + (isDirectory ? preferredSeparator : string.Empty);
+            if (!completionToken.StartsWith(activeToken, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            string appendText = completionToken[activeToken.Length..];
+            appendText = EscapeInsertionSuffix(appendText, context.ShellKind, isQuotedToken);
+            if (appendText.Length == 0)
+            {
+                continue;
+            }
+
+            suggestions.Add(new AssistSuggestion(
+                Id: $"path:{searchDirectory}:{entryName}:{isDirectory}",
+                Type: AssistSuggestionType.Path,
+                DisplayText: isDirectory ? $"{entryName}{preferredSeparator}" : entryName,
+                InsertText: queryPrefix + appendText,
+                Description: isDirectory ? "Directory" : "File",
+                Badges: isDirectory ? new[] { "Path", "Directory" } : new[] { "Path", "File" },
+                Score: (isDirectory ? 260 : 240) - i,
+                WorkingDirectory: context.WorkingDirectory,
+                LastUsedAt: null,
+                ExitCode: null,
+                CanExecuteDirectly: false));
+        }
+
+        return suggestions;
+    }
+
+    private static bool TryExtractCommandAndToken(string? input, out string commandToken, out string activeToken)
+    {
+        commandToken = string.Empty;
+        activeToken = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return false;
+        }
+
+        List<string> tokens = ParseTokens(input!);
+        if (tokens.Count == 0)
+        {
+            return false;
+        }
+
+        commandToken = tokens[0];
+        if (EndsWithTokenSeparatorOutsideQuotes(input!))
+        {
+            activeToken = string.Empty;
+            return true;
+        }
+
+        activeToken = tokens[^1];
+        return true;
+    }
+
+    private static bool ShouldSuggestPath(string commandToken, string activeToken)
+    {
+        if (PathCommands.Contains(commandToken))
+        {
+            return true;
+        }
+
+        return activeToken.StartsWith("./", StringComparison.Ordinal) ||
+               activeToken.StartsWith("../", StringComparison.Ordinal) ||
+               activeToken.StartsWith("~/", StringComparison.Ordinal) ||
+               activeToken.StartsWith(".\\", StringComparison.Ordinal) ||
+               activeToken.StartsWith("..\\", StringComparison.Ordinal) ||
+               activeToken.StartsWith("~\\", StringComparison.Ordinal) ||
+               activeToken.Contains('/') ||
+               activeToken.Contains('\\');
+    }
+
+    private bool TryResolveSearchContext(
+        string activeToken,
+        string? workingDirectory,
+        out string searchDirectory,
+        out string typedLeaf,
+        out string baseTokenPrefix,
+        out char preferredSeparator)
+    {
+        searchDirectory = string.Empty;
+        typedLeaf = string.Empty;
+        baseTokenPrefix = string.Empty;
+
+        string tokenForFilesystem = StripLeadingQuote(activeToken, out string quotePrefix);
+
+        preferredSeparator = tokenForFilesystem.Contains('/')
+            ? '/'
+            : Path.DirectorySeparatorChar;
+
+        string? homeDirectory = ResolveHomeDirectory();
+        string expandedToken = ExpandTilde(tokenForFilesystem, homeDirectory);
+
+        string absoluteCandidate;
+        if (expandedToken.Length == 0)
+        {
+            if (string.IsNullOrWhiteSpace(workingDirectory))
+            {
+                return false;
+            }
+
+            absoluteCandidate = workingDirectory!;
+        }
+        else if (Path.IsPathRooted(expandedToken))
+        {
+            absoluteCandidate = expandedToken;
+        }
+        else
+        {
+            if (string.IsNullOrWhiteSpace(workingDirectory))
+            {
+                return false;
+            }
+
+            absoluteCandidate = Path.Combine(workingDirectory!, expandedToken);
+        }
+
+        bool tokenEndsWithSeparator = tokenForFilesystem.EndsWith('/') || tokenForFilesystem.EndsWith('\\');
+        int leafSeparatorIndex = tokenForFilesystem.LastIndexOfAny(['/', '\\']);
+        string prefixWithoutLeaf = leafSeparatorIndex >= 0
+            ? tokenForFilesystem[..(leafSeparatorIndex + 1)]
+            : string.Empty;
+        baseTokenPrefix = quotePrefix + prefixWithoutLeaf;
+        typedLeaf = tokenEndsWithSeparator
+            ? string.Empty
+            : leafSeparatorIndex >= 0
+                ? tokenForFilesystem[(leafSeparatorIndex + 1)..]
+                : tokenForFilesystem;
+
+        if (tokenEndsWithSeparator || tokenForFilesystem.Length == 0)
+        {
+            searchDirectory = absoluteCandidate;
+        }
+        else
+        {
+            searchDirectory = Path.GetDirectoryName(absoluteCandidate) ?? string.Empty;
+            if (searchDirectory.Length == 0)
+            {
+                searchDirectory = workingDirectory ?? string.Empty;
+            }
+        }
+
+        return searchDirectory.Length > 0 && Directory.Exists(searchDirectory);
+    }
+
+    private string? ResolveHomeDirectory()
+    {
+        if (!string.IsNullOrWhiteSpace(_homeDirectoryOverride))
+        {
+            return _homeDirectoryOverride;
+        }
+
+        string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return string.IsNullOrWhiteSpace(home) ? null : home;
+    }
+
+    private static string ExpandTilde(string token, string? homeDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(homeDirectory) || !token.StartsWith('~'))
+        {
+            return token;
+        }
+
+        if (token.Length == 1)
+        {
+            return homeDirectory;
+        }
+
+        char next = token[1];
+        if (next is not ('/' or '\\'))
+        {
+            return token;
+        }
+
+        string relative = token[2..]
+            .Replace('\\', Path.DirectorySeparatorChar)
+            .Replace('/', Path.DirectorySeparatorChar);
+        return relative.Length == 0
+            ? homeDirectory
+            : Path.Combine(homeDirectory, relative);
+    }
+
+    private static string StripLeadingQuote(string token, out string quotePrefix)
+    {
+        quotePrefix = string.Empty;
+        if (token.Length == 0)
+        {
+            return token;
+        }
+
+        if (token[0] is '"' or '\'')
+        {
+            quotePrefix = token[0].ToString();
+            return token[1..];
+        }
+
+        return token;
+    }
+
+    private static List<string> ParseTokens(string input)
+    {
+        List<string> tokens = new();
+        int tokenStart = -1;
+        bool inSingleQuote = false;
+        bool inDoubleQuote = false;
+
+        for (int i = 0; i < input.Length; i++)
+        {
+            char ch = input[i];
+            bool isWhitespace = char.IsWhiteSpace(ch);
+
+            if (tokenStart < 0)
+            {
+                if (isWhitespace)
+                {
+                    continue;
+                }
+
+                tokenStart = i;
+            }
+
+            if (ch == '\'' && !inDoubleQuote)
+            {
+                inSingleQuote = !inSingleQuote;
+            }
+            else if (ch == '"' && !inSingleQuote)
+            {
+                inDoubleQuote = !inDoubleQuote;
+            }
+
+            if (isWhitespace && !inSingleQuote && !inDoubleQuote)
+            {
+                tokens.Add(input[tokenStart..i]);
+                tokenStart = -1;
+            }
+        }
+
+        if (tokenStart >= 0)
+        {
+            tokens.Add(input[tokenStart..]);
+        }
+
+        return tokens;
+    }
+
+    private static bool EndsWithTokenSeparatorOutsideQuotes(string input)
+    {
+        bool inSingleQuote = false;
+        bool inDoubleQuote = false;
+
+        for (int i = 0; i < input.Length; i++)
+        {
+            char ch = input[i];
+            if (ch == '\'' && !inDoubleQuote)
+            {
+                inSingleQuote = !inSingleQuote;
+            }
+            else if (ch == '"' && !inSingleQuote)
+            {
+                inDoubleQuote = !inDoubleQuote;
+            }
+        }
+
+        return !inSingleQuote &&
+               !inDoubleQuote &&
+               input.Length > 0 &&
+               char.IsWhiteSpace(input[^1]);
+    }
+
+    private static string EscapeInsertionSuffix(string appendText, string? shellKind, bool isQuotedToken)
+    {
+        if (appendText.Length == 0 || isQuotedToken || !IsPowerShellShell(shellKind))
+        {
+            return appendText;
+        }
+
+        var escaped = new StringBuilder(appendText.Length + 8);
+        foreach (char ch in appendText)
+        {
+            if (NeedsPowerShellEscape(ch))
+            {
+                escaped.Append('`');
+            }
+
+            if (ch == '`')
+            {
+                escaped.Append('`');
+            }
+
+            escaped.Append(ch);
+        }
+
+        return escaped.ToString();
+    }
+
+    private static bool IsPowerShellShell(string? shellKind)
+    {
+        if (string.IsNullOrWhiteSpace(shellKind))
+        {
+            return false;
+        }
+
+        return shellKind.Contains("pwsh", StringComparison.OrdinalIgnoreCase) ||
+               shellKind.Contains("powershell", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool NeedsPowerShellEscape(char ch)
+    {
+        return ch is ' ' or '\t' or '&' or '(' or ')' or '[' or ']' or '{' or '}' or ';' or ',' or '\'' or '"';
+    }
+
+    private static List<(string Name, bool IsDirectory)> EnumerateEntries(string directoryPath, string typedLeaf)
+    {
+        try
+        {
+            StringComparison comparison = OperatingSystem.IsWindows()
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
+            IEnumerable<string> directories = Directory.EnumerateDirectories(directoryPath)
+                .Select(Path.GetFileName)
+                .Where(name => !string.IsNullOrWhiteSpace(name) && name.StartsWith(typedLeaf, comparison))
+                .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)!;
+
+            IEnumerable<string> files = Directory.EnumerateFiles(directoryPath)
+                .Select(Path.GetFileName)
+                .Where(name => !string.IsNullOrWhiteSpace(name) && name.StartsWith(typedLeaf, comparison))
+                .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)!;
+
+            List<(string Name, bool IsDirectory)> results = new();
+            results.AddRange(directories.Select(name => (name!, true)));
+            results.AddRange(files.Select(name => (name!, false)));
+            return results;
+        }
+        catch
+        {
+            return new List<(string Name, bool IsDirectory)>();
+        }
+    }
+}

--- a/src/NovaTerminal.App/CommandAssist/Domain/IPathSuggestionProvider.cs
+++ b/src/NovaTerminal.App/CommandAssist/Domain/IPathSuggestionProvider.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+using NovaTerminal.CommandAssist.Models;
+
+namespace NovaTerminal.CommandAssist.Domain;
+
+public interface IPathSuggestionProvider
+{
+    IReadOnlyList<AssistSuggestion> GetSuggestions(CommandAssistQueryContext context, int maxResults);
+}

--- a/src/NovaTerminal.App/CommandAssist/Models/AssistSuggestionType.cs
+++ b/src/NovaTerminal.App/CommandAssist/Models/AssistSuggestionType.cs
@@ -4,6 +4,7 @@ public enum AssistSuggestionType
 {
     History,
     Snippet,
+    Path,
     Recipe,
     Doc,
     Fix

--- a/src/NovaTerminal.App/CommandAssist/Models/CommandAssistQueryContext.cs
+++ b/src/NovaTerminal.App/CommandAssist/Models/CommandAssistQueryContext.cs
@@ -4,4 +4,5 @@ public sealed record CommandAssistQueryContext(
     string Input,
     string? WorkingDirectory,
     string? ShellKind,
-    string? ProfileId);
+    string? ProfileId,
+    bool IsRemote = false);

--- a/src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistBubbleViewModel.cs
+++ b/src/NovaTerminal.App/CommandAssist/ViewModels/CommandAssistBubbleViewModel.cs
@@ -9,7 +9,7 @@ public sealed class CommandAssistBubbleViewModel : INotifyPropertyChanged
     private string _modeLabel = "Suggest";
     private string _queryText = string.Empty;
     private string _summaryText = string.Empty;
-    private string _shortcutHintText = "Tab insert  |  Ctrl+Shift+H help  |  Ctrl+R history";
+    private string _shortcutHintText = "Ctrl+Enter insert  |  Ctrl+Shift+H help  |  Ctrl+R history";
     private bool _showQueryText = true;
 
     public bool IsVisible

--- a/src/NovaTerminal.App/CommandAssist/Views/CommandAssistBubbleView.axaml
+++ b/src/NovaTerminal.App/CommandAssist/Views/CommandAssistBubbleView.axaml
@@ -1,6 +1,8 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:CompileBindings="False"
+             xmlns:viewModels="clr-namespace:NovaTerminal.CommandAssist.ViewModels"
+             x:CompileBindings="True"
+             x:DataType="viewModels:CommandAssistBubbleViewModel"
              x:Class="NovaTerminal.CommandAssist.Views.CommandAssistBubbleView"
              IsVisible="{Binding IsVisible}">
     <Border Background="#CC202020"

--- a/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml
+++ b/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml
@@ -1,6 +1,8 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:CompileBindings="False"
+             xmlns:viewModels="clr-namespace:NovaTerminal.CommandAssist.ViewModels"
+             x:CompileBindings="True"
+             x:DataType="viewModels:CommandAssistPopupViewModel"
              x:Class="NovaTerminal.CommandAssist.Views.CommandAssistPopupView"
              IsVisible="{Binding IsVisible}">
     <Border Background="#F01B1B1B"
@@ -36,7 +38,7 @@
                                       ItemsSource="{Binding Suggestions}"
                                       IsVisible="{Binding HasSuggestions}">
                             <ItemsControl.ItemTemplate>
-                                <DataTemplate>
+                                <DataTemplate x:DataType="viewModels:CommandAssistSuggestionItemViewModel">
                                     <Grid ColumnDefinitions="Auto,*,Auto"
                                           Margin="0,2">
                                         <TextBlock Text="{Binding SelectionGlyph}"
@@ -140,7 +142,7 @@
                         <ItemsControl ItemsSource="{Binding Suggestions}"
                                       IsVisible="{Binding HasSuggestions}">
                             <ItemsControl.ItemTemplate>
-                                <DataTemplate>
+                                <DataTemplate x:DataType="viewModels:CommandAssistSuggestionItemViewModel">
                                     <Grid ColumnDefinitions="Auto,*,Auto"
                                           Margin="0,2">
                                         <TextBlock Text="{Binding SelectionGlyph}"

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -1542,11 +1542,35 @@ namespace NovaTerminal.Controls
             // Copy/Paste (Ctrl+Shift+C/V) - TBD
             // Font Zoom - TBD
 
+            // Reconnect if dead
+            if ((Session == null || LastExitCode.HasValue) && e.Key == Key.Enter)
+            {
+                e.Handled = true;
+                Reconnect();
+                return;
+            }
+
             // Forward to PTY common handler
             // For now, we rely on Window forwarding, OR we implement it here.
             // PLAN: We will implement full OnKeyDown here in Phase 2.
 
             base.OnKeyDown(e);
+        }
+
+        public void Reconnect()
+        {
+            if (Session != null)
+            {
+                Session.Dispose();
+                Session = null;
+            }
+
+            LastExitCode = null;
+            if (Buffer != null)
+            {
+                Buffer.WriteContent("\r\n\x1b[90m[Reconnecting...]\x1b[0m\r\n", false);
+            }
+            InitializeSession(ShellCommand, Profile, TermView.Cols, TermView.Rows, ShellArgs);
         }
 
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -908,6 +908,7 @@ namespace NovaTerminal.Controls
 
             bool isCtrl = (modifiers & KeyModifiers.Control) != 0;
             bool isShift = (modifiers & KeyModifiers.Shift) != 0;
+            bool isAlt = (modifiers & KeyModifiers.Alt) != 0;
 
             if (key == Key.Escape)
             {
@@ -927,7 +928,7 @@ namespace NovaTerminal.Controls
                 return true;
             }
 
-            if (key == Key.Tab)
+            if (isCtrl && !isShift && !isAlt && key == Key.Enter)
             {
                 TryInsertSelectedCommandAssistSuggestion();
                 return true;

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -3424,6 +3424,15 @@ namespace NovaTerminal
                 }
             }
 
+            if (_sshConnectionService != null)
+            {
+                foreach (var profile in _sshConnectionService.GetConnectionProfiles())
+                {
+                    var capturedProfile = profile;
+                    CommandRegistry.Register($"New Connection (SSH): {profile.Name}", "SSH", () => AddTab(capturedProfile), "");
+                }
+            }
+
             var tabs = this.FindControl<TabControl>("Tabs");
             if (tabs != null)
             {
@@ -3484,6 +3493,7 @@ namespace NovaTerminal
             CommandRegistry.Register("Equalize Panes", "View", () => EqualizeCurrentSplit(), "Ctrl+Shift+G");
             CommandRegistry.Register("Pane: Toggle Zoom", "View", () => TogglePaneZoomForCurrentTab(), "Ctrl+Shift+Z");
             CommandRegistry.Register("Pane: Toggle Broadcast Input (Tab)", "View", () => ToggleBroadcastForCurrentTab(), "Ctrl+Shift+B");
+            CommandRegistry.Register("Pane: Reconnect", "View", () => _currentPane?.Reconnect(), "");
             CommandRegistry.Register("Focus Pane Left", "View", () => NavigatePane(MoveDirection.Left), "Alt+Left");
             CommandRegistry.Register("Focus Pane Right", "View", () => NavigatePane(MoveDirection.Right), "Alt+Right");
             CommandRegistry.Register("Focus Pane Up", "View", () => NavigatePane(MoveDirection.Up), "Alt+Up");

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistAnchorCalculatorTests.cs
@@ -113,6 +113,29 @@ public sealed class CommandAssistAnchorCalculatorTests
     }
 
     [Fact]
+    public void Calculate_WhenBubbleIsBelowPromptAndBothVerticalDirectionsFit_PrefersDownwardPopup()
+    {
+        var calculator = new CommandAssistAnchorCalculator();
+
+        CommandAssistAnchorLayout layout = calculator.Calculate(new CommandAssistAnchorRequest(
+            PaneWidth: 900,
+            PaneHeight: 700,
+            CellHeight: 18,
+            CursorVisualRow: 14,
+            VisibleRows: 30,
+            BubbleWidth: 360,
+            BubbleHeight: 36,
+            PopupWidth: 460,
+            PopupHeight: 220));
+
+        Assert.True(layout.BubbleRect.Top >= layout.PromptRect.Bottom,
+            $"Expected bubble to sit below prompt, but bubble top {layout.BubbleRect.Top} was above prompt bottom {layout.PromptRect.Bottom}.");
+        Assert.Equal(CommandAssistPopupDirection.Downward, layout.PopupDirection);
+        Assert.True(layout.PopupRect.Top >= layout.BubbleRect.Bottom,
+            $"Expected downward popup top {layout.PopupRect.Top} to be below bubble bottom {layout.BubbleRect.Bottom}.");
+    }
+
+    [Fact]
     public void Calculate_WhenPromptAnchorIsReliable_AlignsPromptTopToCursorRowWithoutExtraTopPadding()
     {
         var calculator = new CommandAssistAnchorCalculator();

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistKeyRouterTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistKeyRouterTests.cs
@@ -6,13 +6,28 @@ namespace NovaTerminal.Tests.CommandAssist;
 public sealed class CommandAssistKeyRouterTests
 {
     [Theory]
-    [InlineData(Key.Tab)]
     [InlineData(Key.Up)]
     [InlineData(Key.Down)]
     [InlineData(Key.Escape)]
     public void IsAssistOwnedKey_WhenAssistVisible_ConsumesNavigationKeys(Key key)
     {
         bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(true, key, KeyModifiers.None);
+
+        Assert.True(owned);
+    }
+
+    [Fact]
+    public void IsAssistOwnedKey_WhenAssistVisible_DoesNotConsumeTab()
+    {
+        bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(true, Key.Tab, KeyModifiers.None);
+
+        Assert.False(owned);
+    }
+
+    [Fact]
+    public void IsAssistOwnedKey_WhenAssistVisible_ConsumesCtrlEnter()
+    {
+        bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(true, Key.Enter, KeyModifiers.Control);
 
         Assert.True(owned);
     }
@@ -26,13 +41,20 @@ public sealed class CommandAssistKeyRouterTests
     }
 
     [Theory]
-    [InlineData(Key.Tab)]
     [InlineData(Key.Up)]
     [InlineData(Key.Down)]
     [InlineData(Key.Escape)]
     public void IsAssistOwnedKey_WhenAssistHidden_DoesNotConsumeNavigationKeys(Key key)
     {
         bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(false, key, KeyModifiers.None);
+
+        Assert.False(owned);
+    }
+
+    [Fact]
+    public void IsAssistOwnedKey_WhenAssistHidden_DoesNotConsumeCtrlEnter()
+    {
+        bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(false, Key.Enter, KeyModifiers.Control);
 
         Assert.False(owned);
     }

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistSuggestionEngineTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistSuggestionEngineTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using NovaTerminal.CommandAssist.Domain;
 using NovaTerminal.CommandAssist.Models;
 
@@ -143,6 +144,42 @@ public sealed class CommandAssistSuggestionEngineTests
         Assert.Empty(results);
     }
 
+    [Fact]
+    public void GetSuggestions_WhenPathProviderReturnsMatches_IncludesPathRows()
+    {
+        var engine = new CommandAssistSuggestionEngine(
+            pathSuggestionProvider: new FakePathSuggestionProvider(
+                new[]
+                {
+                    new AssistSuggestion(
+                        Id: "path-1",
+                        Type: AssistSuggestionType.Path,
+                        DisplayText: "docs/",
+                        InsertText: "cd ./docs/",
+                        Description: "Directory",
+                        Badges: ["Path", "Directory"],
+                        Score: 500,
+                        WorkingDirectory: @"C:\repo",
+                        LastUsedAt: null,
+                        ExitCode: null,
+                        CanExecuteDirectly: false)
+                }));
+        var context = new CommandAssistQueryContext(
+            Input: "cd ./d",
+            WorkingDirectory: @"C:\repo",
+            ShellKind: "pwsh",
+            ProfileId: "profile-1");
+
+        IReadOnlyList<AssistSuggestion> results = engine.GetSuggestions(
+            Array.Empty<CommandHistoryEntry>(),
+            Array.Empty<CommandSnippet>(),
+            context,
+            maxResults: 5);
+
+        Assert.NotEmpty(results);
+        Assert.Equal(AssistSuggestionType.Path, results[0].Type);
+    }
+
     private static CommandHistoryEntry CreateEntry(
         string commandText,
         string? profileId = "profile-1",
@@ -177,5 +214,20 @@ public sealed class CommandAssistSuggestionEngineTests
             IsPinned: isPinned,
             CreatedAt: DateTimeOffset.Parse("2026-03-01T09:00:00+00:00"),
             LastUsedAt: DateTimeOffset.Parse("2026-03-01T09:30:00+00:00"));
+    }
+
+    private sealed class FakePathSuggestionProvider : IPathSuggestionProvider
+    {
+        private readonly IReadOnlyList<AssistSuggestion> _suggestions;
+
+        public FakePathSuggestionProvider(IReadOnlyList<AssistSuggestion> suggestions)
+        {
+            _suggestions = suggestions;
+        }
+
+        public IReadOnlyList<AssistSuggestion> GetSuggestions(CommandAssistQueryContext context, int maxResults)
+        {
+            return _suggestions.Take(maxResults).ToArray();
+        }
     }
 }

--- a/tests/NovaTerminal.Tests/CommandAssist/FileSystemPathSuggestionProviderTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/FileSystemPathSuggestionProviderTests.cs
@@ -1,0 +1,126 @@
+using NovaTerminal.CommandAssist.Domain;
+using NovaTerminal.CommandAssist.Models;
+
+namespace NovaTerminal.Tests.CommandAssist;
+
+public sealed class FileSystemPathSuggestionProviderTests : IDisposable
+{
+    private readonly string _tempRoot;
+    private readonly string _homeRoot;
+
+    public FileSystemPathSuggestionProviderTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "nova2-path-provider-tests", Guid.NewGuid().ToString("N"));
+        _homeRoot = Path.Combine(_tempRoot, "home");
+        Directory.CreateDirectory(_tempRoot);
+        Directory.CreateDirectory(_homeRoot);
+    }
+
+    [Fact]
+    public void GetSuggestions_WhenPrefixMatchesDirAndFile_OrdersDirectoryBeforeFile()
+    {
+        Directory.CreateDirectory(Path.Combine(_tempRoot, "apps"));
+        File.WriteAllText(Path.Combine(_tempRoot, "apple.txt"), "x");
+
+        var provider = new FileSystemPathSuggestionProvider(homeDirectoryOverride: _homeRoot);
+        var context = new CommandAssistQueryContext(
+            Input: "cd app",
+            WorkingDirectory: _tempRoot,
+            ShellKind: "pwsh",
+            ProfileId: "profile-1");
+
+        IReadOnlyList<AssistSuggestion> suggestions = provider.GetSuggestions(context, maxResults: 10);
+
+        Assert.NotEmpty(suggestions);
+        Assert.Equal(AssistSuggestionType.Path, suggestions[0].Type);
+        Assert.Contains("Directory", suggestions[0].Badges);
+        Assert.DoesNotContain("File", suggestions[0].Badges);
+    }
+
+    [Fact]
+    public void GetSuggestions_WhenInputIsRemote_ReturnsNoLocalPathSuggestions()
+    {
+        Directory.CreateDirectory(Path.Combine(_tempRoot, "docs"));
+
+        var provider = new FileSystemPathSuggestionProvider(homeDirectoryOverride: _homeRoot);
+        var context = new CommandAssistQueryContext(
+            Input: "cd d",
+            WorkingDirectory: _tempRoot,
+            ShellKind: "pwsh",
+            ProfileId: "profile-1",
+            IsRemote: true);
+
+        IReadOnlyList<AssistSuggestion> suggestions = provider.GetSuggestions(context, maxResults: 10);
+
+        Assert.Empty(suggestions);
+    }
+
+    [Fact]
+    public void GetSuggestions_WhenUsingTildePrefix_ExtendsExistingQuery()
+    {
+        Directory.CreateDirectory(Path.Combine(_homeRoot, "docs"));
+
+        var provider = new FileSystemPathSuggestionProvider(homeDirectoryOverride: _homeRoot);
+        var context = new CommandAssistQueryContext(
+            Input: "cd ~/do",
+            WorkingDirectory: _tempRoot,
+            ShellKind: "pwsh",
+            ProfileId: "profile-1");
+
+        IReadOnlyList<AssistSuggestion> suggestions = provider.GetSuggestions(context, maxResults: 10);
+
+        AssistSuggestion suggestion = Assert.Single(suggestions);
+        Assert.StartsWith(context.Input, suggestion.InsertText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetSuggestions_WhenPwshPathContainsSpace_EscapesInsertedSuffix()
+    {
+        Directory.CreateDirectory(Path.Combine(_tempRoot, "My Folder"));
+
+        var provider = new FileSystemPathSuggestionProvider(homeDirectoryOverride: _homeRoot);
+        var context = new CommandAssistQueryContext(
+            Input: @"cd .\M",
+            WorkingDirectory: _tempRoot,
+            ShellKind: "pwsh",
+            ProfileId: "profile-1");
+
+        IReadOnlyList<AssistSuggestion> suggestions = provider.GetSuggestions(context, maxResults: 10);
+
+        AssistSuggestion suggestion = Assert.Single(suggestions);
+        Assert.Equal(@"cd .\My` Folder\", suggestion.InsertText);
+    }
+
+    [Fact]
+    public void GetSuggestions_WhenPwshPathTokenIsQuoted_DoesNotEscapeInsertedSuffix()
+    {
+        Directory.CreateDirectory(Path.Combine(_tempRoot, "My Folder"));
+
+        var provider = new FileSystemPathSuggestionProvider(homeDirectoryOverride: _homeRoot);
+        var context = new CommandAssistQueryContext(
+            Input: "cd \".\\M",
+            WorkingDirectory: _tempRoot,
+            ShellKind: "pwsh",
+            ProfileId: "profile-1");
+
+        IReadOnlyList<AssistSuggestion> suggestions = provider.GetSuggestions(context, maxResults: 10);
+
+        AssistSuggestion suggestion = Assert.Single(suggestions);
+        Assert.Equal("cd \".\\My Folder\\", suggestion.InsertText);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempRoot))
+            {
+                Directory.Delete(_tempRoot, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup for temp test folders.
+        }
+    }
+}

--- a/tests/NovaTerminal.Tests/CommandAssist/TerminalPaneCommandAssistShortcutTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/TerminalPaneCommandAssistShortcutTests.cs
@@ -22,6 +22,18 @@ public sealed class TerminalPaneCommandAssistShortcutTests
     }
 
     [AvaloniaFact]
+    public void TryHandleCommandAssistKey_WhenAssistVisible_DoesNotConsumeTab()
+    {
+        var pane = new TerminalPane();
+        ConfigureCommandAssist(pane);
+        pane.ToggleCommandAssist();
+
+        bool handled = pane.TryHandleCommandAssistKey(Key.Tab, KeyModifiers.None);
+
+        Assert.False(handled);
+    }
+
+    [AvaloniaFact]
     public void OpenCommandAssistHelp_WhenDisabledInSettings_ReturnsFalse()
     {
         var pane = new TerminalPane();


### PR DESCRIPTION
- **feat: preserve extended text and hyperlinks in paged scrollback**
- **Add Command Assist M1 scaffolding**
- **Add Command Assist planning docs**
- **Stabilize Ubuntu CI gating lanes**
- **Harden Command Assist review follow-ups**
- **Implement Command Assist M2 suggestions and snippets**
- **Tighten Command Assist snippet query matching**
- **Implement Command Assist M3 shell integration foundation**
- **Address Command Assist M3 review fixes**
- **Finish Command Assist M3.1 closeout**
- **Reduce CI macOS usage**
- **Guard Command Assist pin shortcut handling**
- **Add Command Assist M4 planning docs**
- **Add Command Assist planning documents**
- **Add Command Assist M4 helper contracts**
- **Add local Command Assist docs and recipe providers**
- **Add heuristic Command Assist fix insights**
- **Extend Command Assist row model for helper modes**
- **Add Command Assist M4 mode routing**
- **Add Command Assist helper result shaping**
- **Finalize Command Assist M4 helper surfaces**
- **Suppress exact-match Command Assist typo fixes**
- **Add Command Assist M4.2 UX planning docs**
- **Finalize Command Assist M4.2 and restore scrollback budget enforcement**
- **Finalize Command Assist M4.3 popup polish**
- **Polish Command Assist prompt-adjacent behavior**
- **Fix SSH command assist placement and prompt glyph fallback**
- **Stabilize collapsed suggest layout assertion**
- **Address command assist review fixes and settings toggle**
- **Fix SSH startup assist placement in top prompt band**
- **Adjust top-band command assist anchor threshold**
- **Stabilize startup fallback anchor with tiny-row guard**
- **Fix SSH startup command-assist anchor jitter**
- **Place fallback assist bubble below top-band prompts**
- **Use conservative short-pane fallback for assist bubble**
- **Suppress conservative SSH assist in short-pane startup band**
- **Use pane-estimated rows for conservative SSH assist anchoring**
- **Use short-pane conservative bubble placement for reliable anchors**
- **Add SSH command-assist anchor diagnostics**
- **Stabilize SSH assist overlay initialization and applied diagnostics**
- **Prevent SSH assist stale-frame flash via VM-gated host visibility**
- **Force-hide assist overlay host when VM is not visible**
- **Add SSH assist post-layout drift correction pass**
- **Hide SSH assist overlay until post-render anchor settles**
- **Fix SSH command assist startup overlay anchoring**
- **Fix command assist popup placement and AOT binding rendering**
- **Make Tab shell-owned and move assist accept to Ctrl+Enter**
- **Add local path suggestions with shell-aware insertion**
- **feat: add ssh reconnect and command palette support**
