### PR TITLE
feat: wrap native ssh crate behind NativeSshSession

### DIFF
--- a/src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs
@@ -1,0 +1,10 @@
+namespace NovaTerminal.Core.Ssh.Native;
+
+public interface INativeSshInterop
+{
+    IntPtr Connect(NativeSshConnectionOptions options);
+    NativeSshEvent? PollEvent(IntPtr sessionHandle);
+    void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data);
+    void Resize(IntPtr sessionHandle, int cols, int rows);
+    void Close(IntPtr sessionHandle);
+}

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshConnectionOptions.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshConnectionOptions.cs
@@ -1,0 +1,31 @@
+using NovaTerminal.Core.Ssh.Models;
+
+namespace NovaTerminal.Core.Ssh.Native;
+
+public sealed class NativeSshConnectionOptions
+{
+    public required string Host { get; init; }
+    public required string User { get; init; }
+    public int Port { get; init; } = 22;
+    public int Cols { get; init; } = 120;
+    public int Rows { get; init; } = 30;
+    public string Term { get; init; } = "xterm-256color";
+    public string? IdentityFilePath { get; init; }
+
+    public static NativeSshConnectionOptions FromProfile(SshProfile profile, int cols, int rows)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+
+        return new NativeSshConnectionOptions
+        {
+            Host = profile.Host,
+            User = profile.User,
+            Port = profile.Port,
+            Cols = cols,
+            Rows = rows,
+            IdentityFilePath = string.IsNullOrWhiteSpace(profile.IdentityFilePath)
+                ? null
+                : profile.IdentityFilePath
+        };
+    }
+}

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshEvent.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshEvent.cs
@@ -1,0 +1,52 @@
+namespace NovaTerminal.Core.Ssh.Native;
+
+[Flags]
+public enum NativeSshEventFlags
+{
+    None = 0,
+    Json = 1,
+    Binary = 2
+}
+
+public enum NativeSshEventKind
+{
+    None = 0,
+    Connected = 1,
+    Data = 2,
+    HostKeyPrompt = 3,
+    PasswordPrompt = 4,
+    PassphrasePrompt = 5,
+    KeyboardInteractivePrompt = 6,
+    ExitStatus = 7,
+    Error = 8,
+    Closed = 9
+}
+
+public sealed class NativeSshEvent
+{
+    public NativeSshEvent(
+        NativeSshEventKind kind,
+        byte[] payload,
+        int statusCode = 0,
+        NativeSshEventFlags flags = NativeSshEventFlags.None)
+    {
+        Kind = kind;
+        Payload = payload ?? Array.Empty<byte>();
+        StatusCode = statusCode;
+        Flags = flags;
+    }
+
+    public NativeSshEventKind Kind { get; }
+    public byte[] Payload { get; }
+    public int StatusCode { get; }
+    public NativeSshEventFlags Flags { get; }
+
+    public static NativeSshEvent Data(byte[] payload) =>
+        new(NativeSshEventKind.Data, payload, flags: NativeSshEventFlags.Binary);
+
+    public static NativeSshEvent ExitStatus(int statusCode, byte[]? payload = null) =>
+        new(NativeSshEventKind.ExitStatus, payload ?? Array.Empty<byte>(), statusCode, NativeSshEventFlags.Json);
+
+    public static NativeSshEvent Closed(byte[]? payload = null) =>
+        new(NativeSshEventKind.Closed, payload ?? Array.Empty<byte>(), flags: NativeSshEventFlags.Json);
+}

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
@@ -1,0 +1,192 @@
+using System.Runtime.InteropServices;
+
+namespace NovaTerminal.Core.Ssh.Native;
+
+public sealed class NativeSshInterop : INativeSshInterop
+{
+    private const string LibName = "rusty_ssh";
+    private const int ResultOk = 0;
+    private const int ResultEventReady = 1;
+    private const int ResultInvalidArgument = -1;
+    private const int ResultBufferTooSmall = -2;
+
+    public IntPtr Connect(NativeSshConnectionOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        IntPtr hostPtr = IntPtr.Zero;
+        IntPtr userPtr = IntPtr.Zero;
+        IntPtr termPtr = IntPtr.Zero;
+        IntPtr identityPtr = IntPtr.Zero;
+
+        try
+        {
+            hostPtr = Marshal.StringToCoTaskMemUTF8(options.Host);
+            userPtr = Marshal.StringToCoTaskMemUTF8(options.User);
+            termPtr = Marshal.StringToCoTaskMemUTF8(options.Term);
+            if (!string.IsNullOrWhiteSpace(options.IdentityFilePath))
+            {
+                identityPtr = Marshal.StringToCoTaskMemUTF8(options.IdentityFilePath);
+            }
+
+            NativeConnectArgs args = new()
+            {
+                Host = hostPtr,
+                User = userPtr,
+                Port = checked((ushort)options.Port),
+                Cols = checked((ushort)options.Cols),
+                Rows = checked((ushort)options.Rows),
+                Term = termPtr,
+                IdentityFile = identityPtr
+            };
+
+            IntPtr handle = NativeMethods.nova_ssh_connect(in args);
+            if (handle == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Failed to create native SSH session.");
+            }
+
+            return handle;
+        }
+        finally
+        {
+            FreeUtf8(hostPtr);
+            FreeUtf8(userPtr);
+            FreeUtf8(termPtr);
+            FreeUtf8(identityPtr);
+        }
+    }
+
+    public NativeSshEvent? PollEvent(IntPtr sessionHandle)
+    {
+        if (sessionHandle == IntPtr.Zero)
+        {
+            return null;
+        }
+
+        byte[] buffer = Array.Empty<byte>();
+        NativeEventHeader header = default;
+
+        while (true)
+        {
+            int rc = NativeMethods.nova_ssh_poll_event(sessionHandle, out header, buffer, (nuint)buffer.Length);
+            if (rc == ResultOk)
+            {
+                return null;
+            }
+
+            if (rc == ResultBufferTooSmall)
+            {
+                buffer = new byte[header.PayloadLength];
+                continue;
+            }
+
+            if (rc == ResultEventReady)
+            {
+                int payloadLength = checked((int)header.PayloadLength);
+                byte[] payload = payloadLength == 0
+                    ? Array.Empty<byte>()
+                    : buffer[..payloadLength];
+                return new NativeSshEvent((NativeSshEventKind)header.Kind, payload, header.StatusCode, (NativeSshEventFlags)header.Flags);
+            }
+
+            throw new InvalidOperationException($"Native SSH poll failed with result {rc}.");
+        }
+    }
+
+    public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data)
+    {
+        if (sessionHandle == IntPtr.Zero)
+        {
+            return;
+        }
+
+        byte[] payload = data.ToArray();
+        int rc = NativeMethods.nova_ssh_write(sessionHandle, payload, (nuint)payload.Length);
+        if (rc is ResultOk or ResultInvalidArgument)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException($"Native SSH write failed with result {rc}.");
+    }
+
+    public void Resize(IntPtr sessionHandle, int cols, int rows)
+    {
+        if (sessionHandle == IntPtr.Zero || cols <= 0 || rows <= 0)
+        {
+            return;
+        }
+
+        int rc = NativeMethods.nova_ssh_resize(sessionHandle, checked((ushort)cols), checked((ushort)rows));
+        if (rc is ResultOk or ResultInvalidArgument)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException($"Native SSH resize failed with result {rc}.");
+    }
+
+    public void Close(IntPtr sessionHandle)
+    {
+        if (sessionHandle == IntPtr.Zero)
+        {
+            return;
+        }
+
+        int rc = NativeMethods.nova_ssh_close(sessionHandle);
+        if (rc is ResultOk or ResultInvalidArgument)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException($"Native SSH close failed with result {rc}.");
+    }
+
+    private static void FreeUtf8(IntPtr pointer)
+    {
+        if (pointer != IntPtr.Zero)
+        {
+            Marshal.FreeCoTaskMem(pointer);
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NativeConnectArgs
+    {
+        public IntPtr Host;
+        public IntPtr User;
+        public ushort Port;
+        public ushort Cols;
+        public ushort Rows;
+        public IntPtr Term;
+        public IntPtr IdentityFile;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NativeEventHeader
+    {
+        public uint Kind;
+        public uint PayloadLength;
+        public int StatusCode;
+        public uint Flags;
+    }
+
+    private static class NativeMethods
+    {
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_connect")]
+        public static extern IntPtr nova_ssh_connect(in NativeConnectArgs args);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_poll_event")]
+        public static extern int nova_ssh_poll_event(IntPtr session, out NativeEventHeader @event, byte[] payload, nuint payloadCapacity);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_write")]
+        public static extern int nova_ssh_write(IntPtr session, byte[] data, nuint dataLength);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_resize")]
+        public static extern int nova_ssh_resize(IntPtr session, ushort cols, ushort rows);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_close")]
+        public static extern int nova_ssh_close(IntPtr session);
+    }
+}

--- a/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
@@ -1,55 +1,258 @@
+using System.Text;
+using NovaTerminal.Core.Replay;
 using NovaTerminal.Core.Ssh.Launch;
 using NovaTerminal.Core.Ssh.Models;
+using NovaTerminal.Core.Ssh.Native;
 
 namespace NovaTerminal.Core.Ssh.Sessions;
 
 public sealed class NativeSshSession : ITerminalSession
 {
+    private static readonly TimeSpan PollDelay = TimeSpan.FromMilliseconds(25);
+
+    private readonly INativeSshInterop _interop;
+    private readonly CancellationTokenSource _pollCts = new();
+    private readonly Task _pollTask;
+    private readonly Decoder _utf8Decoder = Encoding.UTF8.GetDecoder();
+    private readonly Action<string> _log;
+
+    private ReplayWriter? _recorder;
+    private TerminalBuffer? _buffer;
+    private IntPtr _sessionHandle;
+    private int _cols;
+    private int _rows;
+    private int _isRunning;
+    private int _exitNotified;
+    private int? _exitCode;
+
     public NativeSshSession(
         SshProfile profile,
         int cols = 120,
         int rows = 30,
         SshDiagnosticsLevel diagnosticsLevel = SshDiagnosticsLevel.None,
         IReadOnlyList<string>? extraArgs = null,
-        Action<string>? log = null)
+        Action<string>? log = null,
+        INativeSshInterop? interop = null)
     {
         ArgumentNullException.ThrowIfNull(profile);
-        _ = cols;
-        _ = rows;
+
+        if (profile.JumpHops.Count != 0 || profile.Forwards.Count != 0)
+        {
+            throw new NotSupportedException("Native SSH backend does not support jump hops or port forwards yet.");
+        }
+
         _ = diagnosticsLevel;
         _ = extraArgs;
-        _ = log;
-
-        throw new NotSupportedException("Native SSH backend is not implemented yet.");
+        _cols = cols;
+        _rows = rows;
+        _log = log ?? Console.WriteLine;
+        _interop = interop ?? new NativeSshInterop();
+        _sessionHandle = _interop.Connect(NativeSshConnectionOptions.FromProfile(profile, cols, rows));
+        _isRunning = 1;
+        ShellArguments = $"{profile.User}@{profile.Host}:{profile.Port}";
+        _pollTask = Task.Run(PollLoopAsync);
     }
 
-    public Guid Id => throw new NotSupportedException("Native SSH backend is not implemented yet.");
-    public string ShellCommand => throw new NotSupportedException("Native SSH backend is not implemented yet.");
-    public string? ShellArguments => throw new NotSupportedException("Native SSH backend is not implemented yet.");
-    public bool IsProcessRunning => throw new NotSupportedException("Native SSH backend is not implemented yet.");
-    public bool HasActiveChildProcesses => throw new NotSupportedException("Native SSH backend is not implemented yet.");
-    public int? ExitCode => throw new NotSupportedException("Native SSH backend is not implemented yet.");
-    public bool IsRecording => throw new NotSupportedException("Native SSH backend is not implemented yet.");
+    public Guid Id { get; } = Guid.NewGuid();
+    public string ShellCommand => "native-ssh";
+    public string? ShellArguments { get; }
+    public bool IsProcessRunning => Volatile.Read(ref _isRunning) == 1;
+    public bool HasActiveChildProcesses => false;
+    public int? ExitCode => _exitCode;
+    public bool IsRecording => _recorder != null;
 
-    public event Action<string>? OnOutputReceived
+    public event Action<string>? OnOutputReceived;
+    public event Action<int>? OnExit;
+
+    public void SendInput(string input)
     {
-        add => throw new NotSupportedException("Native SSH backend is not implemented yet.");
-        remove => throw new NotSupportedException("Native SSH backend is not implemented yet.");
+        if (_sessionHandle == IntPtr.Zero || string.IsNullOrEmpty(input))
+        {
+            return;
+        }
+
+        _recorder?.RecordInput(input);
+        _interop.Write(_sessionHandle, Encoding.UTF8.GetBytes(input));
     }
 
-    public event Action<int>? OnExit
+    public void Resize(int cols, int rows)
     {
-        add => throw new NotSupportedException("Native SSH backend is not implemented yet.");
-        remove => throw new NotSupportedException("Native SSH backend is not implemented yet.");
+        if (_sessionHandle == IntPtr.Zero || cols <= 0 || rows <= 0)
+        {
+            return;
+        }
+
+        _cols = cols;
+        _rows = rows;
+        _interop.Resize(_sessionHandle, cols, rows);
+        _recorder?.RecordResize(cols, rows);
     }
 
-    public void SendInput(string input) => throw new NotSupportedException("Native SSH backend is not implemented yet.");
-    public void Resize(int cols, int rows) => throw new NotSupportedException("Native SSH backend is not implemented yet.");
-    public void StartRecording(string filePath) => throw new NotSupportedException("Native SSH backend is not implemented yet.");
-    public void StopRecording() => throw new NotSupportedException("Native SSH backend is not implemented yet.");
-    public void AttachBuffer(TerminalBuffer buffer) => throw new NotSupportedException("Native SSH backend is not implemented yet.");
-    public void TakeSnapshot() => throw new NotSupportedException("Native SSH backend is not implemented yet.");
+    public void StartRecording(string filePath)
+    {
+        if (_recorder != null)
+        {
+            return;
+        }
+
+        var recorder = new ReplayWriter(filePath, _cols, _rows, ShellCommand);
+        recorder.RecordMarker("START");
+        if (_buffer != null)
+        {
+            recorder.RecordSnapshot(_buffer);
+        }
+
+        _recorder = recorder;
+    }
+
+    public void StopRecording()
+    {
+        var recorder = _recorder;
+        if (recorder == null)
+        {
+            return;
+        }
+
+        _recorder = null;
+        recorder.RecordMarker("END");
+        if (_buffer != null)
+        {
+            recorder.RecordSnapshot(_buffer);
+        }
+
+        recorder.Dispose();
+    }
+
+    public void AttachBuffer(TerminalBuffer buffer)
+    {
+        _buffer = buffer;
+    }
+
+    public void TakeSnapshot()
+    {
+        if (_buffer != null)
+        {
+            _recorder?.RecordSnapshot(_buffer);
+        }
+    }
+
     public void Dispose()
     {
+        StopRecording();
+        _pollCts.Cancel();
+        CloseNativeHandle();
+        try
+        {
+            _pollTask.Wait(TimeSpan.FromSeconds(2));
+        }
+        catch (AggregateException ex) when (ex.InnerExceptions.All(inner => inner is TaskCanceledException or OperationCanceledException))
+        {
+        }
+        finally
+        {
+            _pollCts.Dispose();
+        }
+    }
+
+    private async Task PollLoopAsync()
+    {
+        try
+        {
+            while (!_pollCts.IsCancellationRequested)
+            {
+                NativeSshEvent? nextEvent = _interop.PollEvent(_sessionHandle);
+                if (nextEvent == null)
+                {
+                    await Task.Delay(PollDelay, _pollCts.Token).ConfigureAwait(false);
+                    continue;
+                }
+
+                switch (nextEvent.Kind)
+                {
+                    case NativeSshEventKind.Data:
+                        EmitOutput(nextEvent.Payload);
+                        break;
+                    case NativeSshEventKind.ExitStatus:
+                        TryNotifyExit(nextEvent.StatusCode);
+                        break;
+                    case NativeSshEventKind.Error:
+                        EmitErrorAndExit(nextEvent);
+                        return;
+                    case NativeSshEventKind.HostKeyPrompt:
+                    case NativeSshEventKind.PasswordPrompt:
+                    case NativeSshEventKind.PassphrasePrompt:
+                    case NativeSshEventKind.KeyboardInteractivePrompt:
+                        EmitPromptUnsupported(nextEvent.Kind);
+                        return;
+                    case NativeSshEventKind.Closed:
+                        TryNotifyExit(_exitCode ?? 0);
+                        return;
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            if (!_pollCts.IsCancellationRequested)
+            {
+                _log($"[NativeSshSession] Poll loop failed: {ex.Message}");
+                OnOutputReceived?.Invoke($"Native SSH session failed: {ex.Message}{Environment.NewLine}");
+                TryNotifyExit(-1);
+            }
+        }
+        finally
+        {
+            Volatile.Write(ref _isRunning, 0);
+            CloseNativeHandle();
+        }
+    }
+
+    private void EmitOutput(byte[] payload)
+    {
+        _recorder?.RecordChunk(payload, payload.Length);
+
+        char[] chars = new char[Encoding.UTF8.GetMaxCharCount(payload.Length)];
+        int charCount = _utf8Decoder.GetChars(payload, 0, payload.Length, chars, 0, flush: false);
+        if (charCount > 0)
+        {
+            OnOutputReceived?.Invoke(new string(chars, 0, charCount));
+        }
+    }
+
+    private void EmitErrorAndExit(NativeSshEvent nextEvent)
+    {
+        if (nextEvent.Payload.Length > 0)
+        {
+            OnOutputReceived?.Invoke($"{Encoding.UTF8.GetString(nextEvent.Payload)}{Environment.NewLine}");
+        }
+
+        TryNotifyExit(nextEvent.StatusCode == 0 ? -1 : nextEvent.StatusCode);
+    }
+
+    private void EmitPromptUnsupported(NativeSshEventKind kind)
+    {
+        _log($"[NativeSshSession] Prompt event '{kind}' requires Task 4 interaction handling.");
+        OnOutputReceived?.Invoke("Native SSH prompt handling is not implemented yet." + Environment.NewLine);
+        TryNotifyExit(-1);
+    }
+
+    private void TryNotifyExit(int exitCode)
+    {
+        _exitCode ??= exitCode;
+        if (Interlocked.Exchange(ref _exitNotified, 1) == 0)
+        {
+            OnExit?.Invoke(_exitCode.Value);
+        }
+    }
+
+    private void CloseNativeHandle()
+    {
+        IntPtr handle = Interlocked.Exchange(ref _sessionHandle, IntPtr.Zero);
+        if (handle != IntPtr.Zero)
+        {
+            _interop.Close(handle);
+        }
     }
 }

--- a/src/NovaTerminal.Core/Ssh/Sessions/SshSessionFactory.cs
+++ b/src/NovaTerminal.Core/Ssh/Sessions/SshSessionFactory.cs
@@ -1,5 +1,6 @@
 using NovaTerminal.Core.Ssh.Launch;
 using NovaTerminal.Core.Ssh.Models;
+using NovaTerminal.Core.Ssh.Native;
 using NovaTerminal.Core.Ssh.Storage;
 
 namespace NovaTerminal.Core.Ssh.Sessions;
@@ -8,20 +9,25 @@ public sealed class SshSessionFactory : ISshSessionFactory
 {
     private readonly ISshProfileStore _profileStore;
     private readonly ISshProcessLauncher? _launcher;
+    private readonly INativeSshInterop? _nativeInterop;
 
     public SshSessionFactory(ISshProfileStore profileStore)
-        : this(profileStore, null)
+        : this(profileStore, null, null)
     {
     }
 
-    public SshSessionFactory(ISshProfileStore profileStore, ISshProcessLauncher? launcher = null)
+    public SshSessionFactory(
+        ISshProfileStore profileStore,
+        ISshProcessLauncher? launcher = null,
+        INativeSshInterop? nativeInterop = null)
     {
         _profileStore = profileStore ?? throw new ArgumentNullException(nameof(profileStore));
         _launcher = launcher;
+        _nativeInterop = nativeInterop;
     }
 
     public SshSessionFactory(ISshProcessLauncher? launcher = null)
-        : this(new JsonSshProfileStore(), launcher)
+        : this(new JsonSshProfileStore(), launcher, null)
     {
     }
 
@@ -38,7 +44,7 @@ public sealed class SshSessionFactory : ISshSessionFactory
 
         return profile.BackendKind switch
         {
-            SshBackendKind.Native => new NativeSshSession(profile, cols, rows, diagnosticsLevel, extraArgs, log),
+            SshBackendKind.Native => new NativeSshSession(profile, cols, rows, diagnosticsLevel, extraArgs, log, _nativeInterop),
             _ => new OpenSshSession(profile.Id, _profileStore, cols, rows, diagnosticsLevel, extraArgs, _launcher, log)
         };
     }

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
@@ -1,0 +1,164 @@
+using System.Collections.Concurrent;
+using System.Text;
+using NovaTerminal.Core.Ssh.Models;
+using NovaTerminal.Core.Ssh.Native;
+using NovaTerminal.Core.Ssh.Sessions;
+
+namespace NovaTerminal.Core.Tests.Ssh;
+
+public sealed class NativeSshSessionTests
+{
+    [Fact]
+    public async Task OutputBytesAreDecodedIncrementallyAcrossPollEvents()
+    {
+        var interop = new FakeNativeSshInterop();
+        interop.Enqueue(NativeSshEvent.Data(new byte[] { 0xE2, 0x82 }));
+        interop.Enqueue(NativeSshEvent.Data(new byte[] { 0xAC }));
+        interop.Enqueue(NativeSshEvent.ExitStatus(0));
+        interop.Enqueue(NativeSshEvent.Closed(Array.Empty<byte>()));
+
+        var outputs = new List<string>();
+        var exit = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var session = new NativeSshSession(CreateProfile(), interop: interop);
+        session.OnOutputReceived += outputs.Add;
+        session.OnExit += code => exit.TrySetResult(code);
+
+        Assert.Equal(0, await exit.Task.WaitAsync(TimeSpan.FromSeconds(2)));
+        Assert.Equal(new[] { "€" }, outputs);
+    }
+
+    [Fact]
+    public async Task SendInputForwardsUtf8BytesThroughInterop()
+    {
+        var interop = new FakeNativeSshInterop();
+        using var session = new NativeSshSession(CreateProfile(), interop: interop);
+
+        session.SendInput("echo €\n");
+
+        await WaitUntilAsync(() => interop.Writes.Count > 0);
+        Assert.Equal(Encoding.UTF8.GetBytes("echo €\n"), interop.Writes.Single());
+    }
+
+    [Fact]
+    public async Task ResizeForwardsTerminalDimensions()
+    {
+        var interop = new FakeNativeSshInterop();
+        using var session = new NativeSshSession(CreateProfile(), interop: interop);
+
+        session.Resize(132, 43);
+
+        await WaitUntilAsync(() => interop.Resizes.Count > 0);
+        Assert.Equal((132, 43), interop.Resizes.Single());
+    }
+
+    [Fact]
+    public async Task ExitAndClosedEventsOnlyRaiseOnExitOnce()
+    {
+        var interop = new FakeNativeSshInterop();
+        interop.Enqueue(NativeSshEvent.ExitStatus(23));
+        interop.Enqueue(NativeSshEvent.Closed(Array.Empty<byte>()));
+
+        var exits = new List<int>();
+        var exit = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var session = new NativeSshSession(CreateProfile(), interop: interop);
+        session.OnExit += code =>
+        {
+            exits.Add(code);
+            exit.TrySetResult(code);
+        };
+
+        Assert.Equal(23, await exit.Task.WaitAsync(TimeSpan.FromSeconds(2)));
+        await WaitUntilAsync(() => interop.CloseCallCount > 0);
+        Assert.Equal(new[] { 23 }, exits);
+    }
+
+    [Fact]
+    public async Task DisposeClosesNativeHandleAndStopsPollLoop()
+    {
+        var interop = new FakeNativeSshInterop();
+        var session = new NativeSshSession(CreateProfile(), interop: interop);
+
+        session.Dispose();
+
+        await WaitUntilAsync(() => interop.CloseCallCount > 0);
+        Assert.Equal(1, interop.CloseCallCount);
+    }
+
+    private static SshProfile CreateProfile()
+    {
+        return new SshProfile
+        {
+            Id = Guid.Parse("2f56e099-14f4-4219-9b64-fd16465d84fb"),
+            BackendKind = SshBackendKind.Native,
+            Host = "native.example",
+            User = "nova",
+            Port = 22
+        };
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> predicate)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(2);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (predicate())
+            {
+                return;
+            }
+
+            await Task.Delay(20);
+        }
+
+        Assert.True(predicate(), "Condition was not met before timeout.");
+    }
+
+    private sealed class FakeNativeSshInterop : INativeSshInterop
+    {
+        private readonly ConcurrentQueue<NativeSshEvent> _events = new();
+        private int _nextHandle = 1;
+
+        public List<byte[]> Writes { get; } = new();
+        public List<(int Cols, int Rows)> Resizes { get; } = new();
+        public int CloseCallCount { get; private set; }
+
+        public IntPtr Connect(NativeSshConnectionOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            return new IntPtr(_nextHandle++);
+        }
+
+        public NativeSshEvent? PollEvent(IntPtr sessionHandle)
+        {
+            if (sessionHandle == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Unexpected null handle.");
+            }
+
+            return _events.TryDequeue(out NativeSshEvent? nextEvent)
+                ? nextEvent
+                : null;
+        }
+
+        public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data)
+        {
+            Writes.Add(data.ToArray());
+        }
+
+        public void Resize(IntPtr sessionHandle, int cols, int rows)
+        {
+            Resizes.Add((cols, rows));
+        }
+
+        public void Close(IntPtr sessionHandle)
+        {
+            CloseCallCount++;
+        }
+
+        public void Enqueue(NativeSshEvent nextEvent)
+        {
+            _events.Enqueue(nextEvent);
+        }
+    }
+}

--- a/tests/NovaTerminal.Core.Tests/Ssh/SshSessionFactoryTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/SshSessionFactoryTests.cs
@@ -1,57 +1,30 @@
 using NovaTerminal.Core.Ssh.Launch;
 using NovaTerminal.Core.Ssh.Models;
+using NovaTerminal.Core.Ssh.Native;
+using NovaTerminal.Core.Ssh.Sessions;
 using NovaTerminal.Core.Ssh.Storage;
-using System.Reflection;
 
 namespace NovaTerminal.Core.Tests.Ssh;
 
 public sealed class SshSessionFactoryTests
 {
     [Fact]
-    public void Create_ForNativeProfileRoutesToNativeSessionStub()
+    public void Create_ForNativeProfileRoutesToNativeSession()
     {
-        var backendProperty = typeof(SshProfile).GetProperty("BackendKind");
-        Assert.NotNull(backendProperty);
-
         var profileId = Guid.Parse("e94d09da-1269-4ecf-86b2-81bd4ec483cc");
         var store = new InMemorySshProfileStore(new SshProfile
         {
             Id = profileId,
             Name = "native",
-            Host = "native.internal"
+            Host = "native.internal",
+            User = "nova",
+            BackendKind = SshBackendKind.Native
         });
-        backendProperty!.SetValue(store.Profile, Enum.Parse(backendProperty.PropertyType, "Native"));
 
-        var factoryType = typeof(SshProfile).Assembly.GetType("NovaTerminal.Core.Ssh.Sessions.SshSessionFactory");
-        Assert.NotNull(factoryType);
+        var factory = new SshSessionFactory(store, launcher: null, nativeInterop: new StubNativeSshInterop());
+        using ITerminalSession session = factory.Create(profileId);
 
-        object? factory = Activator.CreateInstance(factoryType!, store);
-        Assert.NotNull(factory);
-
-        var createMethod = factoryType!.GetMethod(
-            "Create",
-            new[]
-            {
-                typeof(Guid),
-                typeof(int),
-                typeof(int),
-                typeof(SshDiagnosticsLevel),
-                typeof(IReadOnlyList<string>),
-                typeof(Action<string>)
-            });
-
-        Assert.NotNull(createMethod);
-
-        var exception = Record.Exception(() => createMethod!.Invoke(
-            factory,
-            new object?[] { profileId, 120, 30, SshDiagnosticsLevel.None, null, null }));
-
-        Assert.NotNull(exception);
-        var actual = exception is TargetInvocationException tie && tie.InnerException != null
-            ? tie.InnerException
-            : exception;
-        Assert.IsType<NotSupportedException>(actual);
-        Assert.Contains("Native SSH", actual.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.IsType<NativeSshSession>(session);
     }
 
     private sealed class InMemorySshProfileStore : ISshProfileStore
@@ -70,5 +43,22 @@ public sealed class SshSessionFactoryTests
         public void SaveProfile(SshProfile profile) => throw new NotSupportedException();
 
         public bool DeleteProfile(Guid profileId) => throw new NotSupportedException();
+    }
+
+    private sealed class StubNativeSshInterop : INativeSshInterop
+    {
+        public IntPtr Connect(NativeSshConnectionOptions options) => new(1);
+        public NativeSshEvent? PollEvent(IntPtr sessionHandle) => null;
+        public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data)
+        {
+        }
+
+        public void Resize(IntPtr sessionHandle, int cols, int rows)
+        {
+        }
+
+        public void Close(IntPtr sessionHandle)
+        {
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add native SSH interop contracts and a `NativeSshInterop` binding for the new Rust ABI
- replace the native-session stub with a background poll-loop implementation that decodes output, forwards input/resize, and tracks exit
- update factory and tests to inject fake native interop instead of loading the real DLL in unit tests

## Verification
- `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~Ssh"`
- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~SshConnectionServiceTests|FullyQualifiedName~NewSshConnectionViewModelTests|FullyQualifiedName~SshManagerViewModelTests|FullyQualifiedName~SshLegacyProfileMigrationTests" /nodeReuse:false`
- `dotnet build src/NovaTerminal.App/NovaTerminal.App.csproj -c Release -p:SKIP_RUST_NATIVE_BUILD=1 /nodeReuse:false`
