### PR TITLE
feat: add native ssh interaction service and dialogs

### DIFF
--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -24,6 +24,7 @@ using NovaTerminal.CommandAssist.ShellIntegration.Contracts;
 using NovaTerminal.CommandAssist.ShellIntegration.PowerShell;
 using NovaTerminal.CommandAssist.ShellIntegration.Runtime;
 using NovaTerminal.Core.Ssh.Launch;
+using NovaTerminal.Core.Ssh.Interactions;
 using NovaTerminal.Core.Ssh.Sessions;
 
 namespace NovaTerminal.Controls
@@ -173,6 +174,7 @@ namespace NovaTerminal.Controls
         }
 
         public Control ActiveControl => TermView;
+        public ISshInteractionHandler? SshInteractionHandler { get; set; }
 
         public TerminalPane()
         {
@@ -1125,7 +1127,7 @@ namespace NovaTerminal.Controls
                 {
                     try
                     {
-                        var sessionFactory = new SshSessionFactory();
+                        var sessionFactory = new SshSessionFactory(nativeInteractionHandler: SshInteractionHandler);
                         Session = sessionFactory.Create(
                             profile.Id,
                             cols,

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -60,6 +60,7 @@ namespace NovaTerminal
         private bool _closePaneInProgress;
         private bool _closeTabInProgress;
         private readonly SshConnectionService _sshConnectionService;
+        private readonly ISshInteractionService _sshInteractionService;
         private readonly SshLegacyProfileMigrationService _sshLegacyMigrationService;
         private static readonly TimeSpan BellDebounceWindow = TimeSpan.FromMilliseconds(750);
 
@@ -1589,6 +1590,7 @@ namespace NovaTerminal
             InitializeComponent();
             _settings = TerminalSettings.Load();
             _sshConnectionService = new SshConnectionService();
+            _sshInteractionService = new SshInteractionService(() => this, ApplyThemeToDialogWindow);
             _sshLegacyMigrationService = new SshLegacyProfileMigrationService();
 
             if (_sshLegacyMigrationService.MigrateLegacyProfiles(_settings))
@@ -2160,6 +2162,7 @@ namespace NovaTerminal
 
         private void WirePane(TerminalPane pane)
         {
+            pane.SshInteractionHandler = _sshInteractionService;
             pane.RequestSftpTransfer -= OnPaneRequestSftpTransfer;
             pane.WorkingDirectoryChanged -= OnPaneWorkingDirectoryChanged;
             pane.TitleChanged -= OnPaneTitleChanged;

--- a/src/NovaTerminal.App/Services/Ssh/ISshInteractionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/ISshInteractionService.cs
@@ -1,0 +1,7 @@
+using NovaTerminal.Core.Ssh.Interactions;
+
+namespace NovaTerminal.Services.Ssh;
+
+public interface ISshInteractionService : ISshInteractionHandler
+{
+}

--- a/src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using NovaTerminal.Core.Ssh.Interactions;
+using NovaTerminal.ViewModels.Ssh;
+using NovaTerminal.Views.Ssh;
+
+namespace NovaTerminal.Services.Ssh;
+
+public sealed class SshInteractionService : ISshInteractionService
+{
+    private readonly Func<Window?> _ownerProvider;
+    private readonly Action<Window>? _prepareDialog;
+    private readonly Func<Window?, HostKeyPromptViewModel, CancellationToken, Task<SshInteractionResponse>> _hostKeyPresenter;
+    private readonly Func<Window?, AuthPromptViewModel, CancellationToken, Task<SshInteractionResponse>> _authPresenter;
+
+    public SshInteractionService(
+        Func<Window?>? ownerProvider = null,
+        Action<Window>? prepareDialog = null,
+        Func<Window?, HostKeyPromptViewModel, CancellationToken, Task<SshInteractionResponse>>? hostKeyPresenter = null,
+        Func<Window?, AuthPromptViewModel, CancellationToken, Task<SshInteractionResponse>>? authPresenter = null)
+    {
+        _ownerProvider = ownerProvider ?? (() => null);
+        _prepareDialog = prepareDialog;
+        _hostKeyPresenter = hostKeyPresenter ?? PresentHostKeyAsync;
+        _authPresenter = authPresenter ?? PresentAuthAsync;
+    }
+
+    public Task<SshInteractionResponse> HandleAsync(SshInteractionRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        Window? owner = _ownerProvider();
+        return request.Kind switch
+        {
+            SshInteractionKind.UnknownHostKey or SshInteractionKind.ChangedHostKey => _hostKeyPresenter(owner, CreateHostKeyViewModel(request), cancellationToken),
+            SshInteractionKind.Password => _authPresenter(owner, CreatePasswordViewModel(request), cancellationToken),
+            SshInteractionKind.Passphrase => _authPresenter(owner, CreatePassphraseViewModel(request), cancellationToken),
+            SshInteractionKind.KeyboardInteractive => _authPresenter(owner, CreateKeyboardViewModel(request), cancellationToken),
+            _ => Task.FromResult(SshInteractionResponse.Cancel())
+        };
+    }
+
+    private async Task<SshInteractionResponse> PresentHostKeyAsync(Window? owner, HostKeyPromptViewModel viewModel, CancellationToken cancellationToken)
+    {
+        if (owner == null || cancellationToken.IsCancellationRequested)
+        {
+            return SshInteractionResponse.Cancel();
+        }
+
+        var dialog = new HostKeyPromptDialog(viewModel);
+        _prepareDialog?.Invoke(dialog);
+        return await dialog.ShowDialog<SshInteractionResponse?>(owner) ?? SshInteractionResponse.Cancel();
+    }
+
+    private async Task<SshInteractionResponse> PresentAuthAsync(Window? owner, AuthPromptViewModel viewModel, CancellationToken cancellationToken)
+    {
+        if (owner == null || cancellationToken.IsCancellationRequested)
+        {
+            return SshInteractionResponse.Cancel();
+        }
+
+        var dialog = new AuthPromptDialog(viewModel);
+        _prepareDialog?.Invoke(dialog);
+        return await dialog.ShowDialog<SshInteractionResponse?>(owner) ?? SshInteractionResponse.Cancel();
+    }
+
+    private static HostKeyPromptViewModel CreateHostKeyViewModel(SshInteractionRequest request)
+    {
+        return new HostKeyPromptViewModel
+        {
+            Host = request.Host,
+            Port = request.Port,
+            Algorithm = request.Algorithm,
+            Fingerprint = request.Fingerprint,
+            IsChangedHostKey = request.Kind == SshInteractionKind.ChangedHostKey
+        };
+    }
+
+    private static AuthPromptViewModel CreatePasswordViewModel(SshInteractionRequest request)
+    {
+        var viewModel = new AuthPromptViewModel
+        {
+            Title = "Password",
+            Message = "Enter the SSH password to continue."
+        };
+        viewModel.Prompts.Add(new AuthPromptEntryViewModel
+        {
+            Prompt = string.IsNullOrWhiteSpace(request.Prompt) ? "Password:" : request.Prompt,
+            IsSecret = true
+        });
+        return viewModel;
+    }
+
+    private static AuthPromptViewModel CreatePassphraseViewModel(SshInteractionRequest request)
+    {
+        var viewModel = new AuthPromptViewModel
+        {
+            Title = "Passphrase",
+            Message = "Enter the private key passphrase to continue."
+        };
+        viewModel.Prompts.Add(new AuthPromptEntryViewModel
+        {
+            Prompt = string.IsNullOrWhiteSpace(request.Prompt) ? "Passphrase:" : request.Prompt,
+            IsSecret = true
+        });
+        return viewModel;
+    }
+
+    private static AuthPromptViewModel CreateKeyboardViewModel(SshInteractionRequest request)
+    {
+        var viewModel = new AuthPromptViewModel
+        {
+            Title = string.IsNullOrWhiteSpace(request.Name) ? "Keyboard Interactive" : request.Name,
+            Message = request.Instructions
+        };
+
+        foreach (SshKeyboardPrompt prompt in request.KeyboardPrompts)
+        {
+            viewModel.Prompts.Add(new AuthPromptEntryViewModel
+            {
+                Prompt = prompt.Prompt,
+                IsSecret = !prompt.Echo
+            });
+        }
+
+        return viewModel;
+    }
+}

--- a/src/NovaTerminal.App/ViewModels/Ssh/AuthPromptViewModel.cs
+++ b/src/NovaTerminal.App/ViewModels/Ssh/AuthPromptViewModel.cs
@@ -1,0 +1,49 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using NovaTerminal.Core.Ssh.Interactions;
+
+namespace NovaTerminal.ViewModels.Ssh;
+
+public sealed class AuthPromptViewModel
+{
+    public string Title { get; init; } = string.Empty;
+    public string Message { get; init; } = string.Empty;
+    public ObservableCollection<AuthPromptEntryViewModel> Prompts { get; } = new();
+
+    public SshInteractionResponse BuildResponse()
+    {
+        if (Prompts.Count == 1)
+        {
+            return SshInteractionResponse.FromSecret(Prompts[0].Value);
+        }
+
+        return SshInteractionResponse.FromKeyboardResponses(Prompts.Select(prompt => prompt.Value).ToArray());
+    }
+}
+
+public sealed class AuthPromptEntryViewModel : INotifyPropertyChanged
+{
+    private string _value = string.Empty;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public string Prompt { get; init; } = string.Empty;
+    public bool IsSecret { get; init; }
+
+    public string Value
+    {
+        get => _value;
+        set
+        {
+            if (_value != value)
+            {
+                _value = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Value)));
+            }
+        }
+    }
+
+    public string PasswordCharText => IsSecret ? "*" : string.Empty;
+}

--- a/src/NovaTerminal.App/ViewModels/Ssh/HostKeyPromptViewModel.cs
+++ b/src/NovaTerminal.App/ViewModels/Ssh/HostKeyPromptViewModel.cs
@@ -1,0 +1,15 @@
+namespace NovaTerminal.ViewModels.Ssh;
+
+public sealed class HostKeyPromptViewModel
+{
+    public string Host { get; init; } = string.Empty;
+    public int Port { get; init; }
+    public string Algorithm { get; init; } = string.Empty;
+    public string Fingerprint { get; init; } = string.Empty;
+    public bool IsChangedHostKey { get; init; }
+
+    public string Title => IsChangedHostKey ? "Changed Host Key" : "Unknown Host Key";
+    public string Message => IsChangedHostKey
+        ? "The server host key changed. Only continue if you trust this change."
+        : "The server host key is not trusted yet. Continue only if you trust this host.";
+}

--- a/src/NovaTerminal.App/Views/Ssh/AuthPromptDialog.axaml
+++ b/src/NovaTerminal.App/Views/Ssh/AuthPromptDialog.axaml
@@ -1,0 +1,19 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="NovaTerminal.Views.Ssh.AuthPromptDialog"
+        Width="560"
+        Height="320"
+        CanResize="False"
+        WindowStartupLocation="CenterOwner">
+    <Border Padding="16">
+        <StackPanel Spacing="12">
+            <TextBlock Name="DialogTitle" FontSize="18" FontWeight="SemiBold" />
+            <TextBlock Name="DialogMessage" TextWrapping="Wrap" />
+            <StackPanel Name="PromptHost" Spacing="10" />
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+                <Button Content="Cancel" Width="96" Click="OnCancelClick" />
+                <Button Content="Submit" Width="96" Click="OnSubmitClick" />
+            </StackPanel>
+        </StackPanel>
+    </Border>
+</Window>

--- a/src/NovaTerminal.App/Views/Ssh/AuthPromptDialog.axaml.cs
+++ b/src/NovaTerminal.App/Views/Ssh/AuthPromptDialog.axaml.cs
@@ -1,0 +1,61 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml;
+using NovaTerminal.Core.Ssh.Interactions;
+using NovaTerminal.ViewModels.Ssh;
+
+namespace NovaTerminal.Views.Ssh;
+
+public partial class AuthPromptDialog : Window
+{
+    public AuthPromptDialog()
+    {
+        InitializeComponent();
+    }
+
+    public AuthPromptDialog(AuthPromptViewModel viewModel) : this()
+    {
+        DataContext = viewModel;
+        ApplyViewModel(viewModel);
+    }
+
+    private AuthPromptViewModel? ViewModel => DataContext as AuthPromptViewModel;
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private void ApplyViewModel(AuthPromptViewModel viewModel)
+    {
+        this.FindControl<TextBlock>("DialogTitle")!.Text = viewModel.Title;
+        this.FindControl<TextBlock>("DialogMessage")!.Text = viewModel.Message;
+
+        var host = this.FindControl<StackPanel>("PromptHost")!;
+        host.Children.Clear();
+
+        foreach (AuthPromptEntryViewModel prompt in viewModel.Prompts)
+        {
+            host.Children.Add(new TextBlock { Text = prompt.Prompt });
+            var textBox = new TextBox
+            {
+                PasswordChar = prompt.IsSecret ? '*' : default(char),
+                Text = prompt.Value,
+                HorizontalAlignment = HorizontalAlignment.Stretch
+            };
+            textBox.TextChanged += (_, __) => prompt.Value = textBox.Text ?? string.Empty;
+            host.Children.Add(textBox);
+        }
+    }
+
+    private void OnSubmitClick(object? sender, RoutedEventArgs e)
+    {
+        Close(ViewModel?.BuildResponse() ?? SshInteractionResponse.Cancel());
+    }
+
+    private void OnCancelClick(object? sender, RoutedEventArgs e)
+    {
+        Close(SshInteractionResponse.Cancel());
+    }
+}

--- a/src/NovaTerminal.App/Views/Ssh/HostKeyPromptDialog.axaml
+++ b/src/NovaTerminal.App/Views/Ssh/HostKeyPromptDialog.axaml
@@ -1,0 +1,30 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:NovaTerminal.ViewModels.Ssh"
+        x:Class="NovaTerminal.Views.Ssh.HostKeyPromptDialog"
+        x:DataType="vm:HostKeyPromptViewModel"
+        Width="560"
+        Height="280"
+        CanResize="False"
+        WindowStartupLocation="CenterOwner">
+    <Border Padding="16">
+        <StackPanel Spacing="12">
+            <TextBlock Text="{Binding Title}" FontSize="18" FontWeight="SemiBold" />
+            <TextBlock Text="{Binding Message}" TextWrapping="Wrap" />
+            <Grid ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto" RowSpacing="8">
+                <TextBlock Grid.Row="0" Grid.Column="0" Text="Host" />
+                <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding Host}" />
+                <TextBlock Grid.Row="1" Grid.Column="0" Text="Port" />
+                <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Port}" />
+                <TextBlock Grid.Row="2" Grid.Column="0" Text="Algorithm" />
+                <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Algorithm}" />
+                <TextBlock Grid.Row="3" Grid.Column="0" Text="Fingerprint" />
+                <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Fingerprint}" TextWrapping="Wrap" />
+            </Grid>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+                <Button Content="Cancel" Width="96" Click="OnCancelClick" />
+                <Button Content="Trust" Width="96" Click="OnAcceptClick" />
+            </StackPanel>
+        </StackPanel>
+    </Border>
+</Window>

--- a/src/NovaTerminal.App/Views/Ssh/HostKeyPromptDialog.axaml.cs
+++ b/src/NovaTerminal.App/Views/Ssh/HostKeyPromptDialog.axaml.cs
@@ -1,0 +1,35 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using NovaTerminal.Core.Ssh.Interactions;
+using NovaTerminal.ViewModels.Ssh;
+
+namespace NovaTerminal.Views.Ssh;
+
+public partial class HostKeyPromptDialog : Window
+{
+    public HostKeyPromptDialog()
+    {
+        InitializeComponent();
+    }
+
+    public HostKeyPromptDialog(HostKeyPromptViewModel viewModel) : this()
+    {
+        DataContext = viewModel;
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private void OnAcceptClick(object? sender, RoutedEventArgs e)
+    {
+        Close(SshInteractionResponse.AcceptHostKey());
+    }
+
+    private void OnCancelClick(object? sender, RoutedEventArgs e)
+    {
+        Close(SshInteractionResponse.Cancel());
+    }
+}

--- a/src/NovaTerminal.Core/Ssh/Interactions/ISshInteractionHandler.cs
+++ b/src/NovaTerminal.Core/Ssh/Interactions/ISshInteractionHandler.cs
@@ -1,0 +1,6 @@
+namespace NovaTerminal.Core.Ssh.Interactions;
+
+public interface ISshInteractionHandler
+{
+    Task<SshInteractionResponse> HandleAsync(SshInteractionRequest request, CancellationToken cancellationToken);
+}

--- a/src/NovaTerminal.Core/Ssh/Interactions/SshInteractionKind.cs
+++ b/src/NovaTerminal.Core/Ssh/Interactions/SshInteractionKind.cs
@@ -1,0 +1,10 @@
+namespace NovaTerminal.Core.Ssh.Interactions;
+
+public enum SshInteractionKind
+{
+    UnknownHostKey = 0,
+    ChangedHostKey = 1,
+    Password = 2,
+    Passphrase = 3,
+    KeyboardInteractive = 4
+}

--- a/src/NovaTerminal.Core/Ssh/Interactions/SshInteractionRequest.cs
+++ b/src/NovaTerminal.Core/Ssh/Interactions/SshInteractionRequest.cs
@@ -1,0 +1,26 @@
+namespace NovaTerminal.Core.Ssh.Interactions;
+
+public sealed class SshInteractionRequest
+{
+    public SshInteractionKind Kind { get; init; }
+    public string Host { get; init; } = string.Empty;
+    public int Port { get; init; }
+    public string Algorithm { get; init; } = string.Empty;
+    public string Fingerprint { get; init; } = string.Empty;
+    public string Prompt { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string Instructions { get; init; } = string.Empty;
+    public IReadOnlyList<SshKeyboardPrompt> KeyboardPrompts { get; init; } = Array.Empty<SshKeyboardPrompt>();
+}
+
+public sealed class SshKeyboardPrompt
+{
+    public SshKeyboardPrompt(string prompt, bool echo)
+    {
+        Prompt = prompt ?? string.Empty;
+        Echo = echo;
+    }
+
+    public string Prompt { get; }
+    public bool Echo { get; }
+}

--- a/src/NovaTerminal.Core/Ssh/Interactions/SshInteractionResponse.cs
+++ b/src/NovaTerminal.Core/Ssh/Interactions/SshInteractionResponse.cs
@@ -1,0 +1,18 @@
+namespace NovaTerminal.Core.Ssh.Interactions;
+
+public sealed class SshInteractionResponse
+{
+    public bool IsAccepted { get; init; }
+    public bool IsCanceled { get; init; }
+    public string Secret { get; init; } = string.Empty;
+    public IReadOnlyList<string> KeyboardResponses { get; init; } = Array.Empty<string>();
+
+    public static SshInteractionResponse AcceptHostKey() => new() { IsAccepted = true };
+
+    public static SshInteractionResponse Cancel() => new() { IsCanceled = true };
+
+    public static SshInteractionResponse FromSecret(string secret) => new() { Secret = secret ?? string.Empty };
+
+    public static SshInteractionResponse FromKeyboardResponses(params string[] responses) =>
+        new() { KeyboardResponses = responses ?? Array.Empty<string>() };
+}

--- a/src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs
@@ -6,5 +6,6 @@ public interface INativeSshInterop
     NativeSshEvent? PollEvent(IntPtr sessionHandle);
     void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data);
     void Resize(IntPtr sessionHandle, int cols, int rows);
+    void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data);
     void Close(IntPtr sessionHandle);
 }

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshEvent.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshEvent.cs
@@ -22,6 +22,14 @@ public enum NativeSshEventKind
     Closed = 9
 }
 
+public enum NativeSshResponseKind
+{
+    HostKeyDecision = 1,
+    Password = 2,
+    Passphrase = 3,
+    KeyboardInteractive = 4
+}
+
 public sealed class NativeSshEvent
 {
     public NativeSshEvent(

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
@@ -143,6 +143,23 @@ public sealed class NativeSshInterop : INativeSshInterop
         throw new InvalidOperationException($"Native SSH close failed with result {rc}.");
     }
 
+    public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data)
+    {
+        if (sessionHandle == IntPtr.Zero)
+        {
+            return;
+        }
+
+        byte[] payload = data.ToArray();
+        int rc = NativeMethods.nova_ssh_submit_response(sessionHandle, (uint)responseKind, payload, (nuint)payload.Length);
+        if (rc is ResultOk or ResultInvalidArgument)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException($"Native SSH submit response failed with result {rc}.");
+    }
+
     private static void FreeUtf8(IntPtr pointer)
     {
         if (pointer != IntPtr.Zero)
@@ -188,5 +205,8 @@ public sealed class NativeSshInterop : INativeSshInterop
 
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_close")]
         public static extern int nova_ssh_close(IntPtr session);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_submit_response")]
+        public static extern int nova_ssh_submit_response(IntPtr session, uint responseKind, byte[] data, nuint dataLength);
     }
 }

--- a/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
@@ -1,5 +1,7 @@
 using System.Text;
+using System.Text.Json;
 using NovaTerminal.Core.Replay;
+using NovaTerminal.Core.Ssh.Interactions;
 using NovaTerminal.Core.Ssh.Launch;
 using NovaTerminal.Core.Ssh.Models;
 using NovaTerminal.Core.Ssh.Native;
@@ -11,6 +13,7 @@ public sealed class NativeSshSession : ITerminalSession
     private static readonly TimeSpan PollDelay = TimeSpan.FromMilliseconds(25);
 
     private readonly INativeSshInterop _interop;
+    private readonly ISshInteractionHandler? _interactionHandler;
     private readonly CancellationTokenSource _pollCts = new();
     private readonly Task _pollTask;
     private readonly Decoder _utf8Decoder = Encoding.UTF8.GetDecoder();
@@ -32,7 +35,8 @@ public sealed class NativeSshSession : ITerminalSession
         SshDiagnosticsLevel diagnosticsLevel = SshDiagnosticsLevel.None,
         IReadOnlyList<string>? extraArgs = null,
         Action<string>? log = null,
-        INativeSshInterop? interop = null)
+        INativeSshInterop? interop = null,
+        ISshInteractionHandler? interactionHandler = null)
     {
         ArgumentNullException.ThrowIfNull(profile);
 
@@ -47,6 +51,7 @@ public sealed class NativeSshSession : ITerminalSession
         _rows = rows;
         _log = log ?? Console.WriteLine;
         _interop = interop ?? new NativeSshInterop();
+        _interactionHandler = interactionHandler;
         _sessionHandle = _interop.Connect(NativeSshConnectionOptions.FromProfile(profile, cols, rows));
         _isRunning = 1;
         ShellArguments = $"{profile.User}@{profile.Host}:{profile.Port}";
@@ -182,8 +187,8 @@ public sealed class NativeSshSession : ITerminalSession
                     case NativeSshEventKind.PasswordPrompt:
                     case NativeSshEventKind.PassphrasePrompt:
                     case NativeSshEventKind.KeyboardInteractivePrompt:
-                        EmitPromptUnsupported(nextEvent.Kind);
-                        return;
+                        await HandleInteractionAsync(nextEvent).ConfigureAwait(false);
+                        break;
                     case NativeSshEventKind.Closed:
                         TryNotifyExit(_exitCode ?? 0);
                         return;
@@ -231,11 +236,24 @@ public sealed class NativeSshSession : ITerminalSession
         TryNotifyExit(nextEvent.StatusCode == 0 ? -1 : nextEvent.StatusCode);
     }
 
-    private void EmitPromptUnsupported(NativeSshEventKind kind)
+    private async Task HandleInteractionAsync(NativeSshEvent nextEvent)
     {
-        _log($"[NativeSshSession] Prompt event '{kind}' requires Task 4 interaction handling.");
-        OnOutputReceived?.Invoke("Native SSH prompt handling is not implemented yet." + Environment.NewLine);
-        TryNotifyExit(-1);
+        SshInteractionRequest request = CreateInteractionRequest(nextEvent);
+        SshInteractionResponse response = _interactionHandler == null
+            ? SshInteractionResponse.Cancel()
+            : await _interactionHandler.HandleAsync(request, _pollCts.Token).ConfigureAwait(false);
+
+        NativeSshResponseKind responseKind = nextEvent.Kind switch
+        {
+            NativeSshEventKind.HostKeyPrompt => NativeSshResponseKind.HostKeyDecision,
+            NativeSshEventKind.PasswordPrompt => NativeSshResponseKind.Password,
+            NativeSshEventKind.PassphrasePrompt => NativeSshResponseKind.Passphrase,
+            NativeSshEventKind.KeyboardInteractivePrompt => NativeSshResponseKind.KeyboardInteractive,
+            _ => throw new InvalidOperationException($"Unsupported interaction event '{nextEvent.Kind}'.")
+        };
+
+        byte[] payload = BuildInteractionPayload(responseKind, response);
+        _interop.SubmitResponse(_sessionHandle, responseKind, payload);
     }
 
     private void TryNotifyExit(int exitCode)
@@ -254,5 +272,106 @@ public sealed class NativeSshSession : ITerminalSession
         {
             _interop.Close(handle);
         }
+    }
+
+    private static SshInteractionRequest CreateInteractionRequest(NativeSshEvent nextEvent)
+    {
+        return nextEvent.Kind switch
+        {
+            NativeSshEventKind.HostKeyPrompt => CreateHostKeyRequest(nextEvent.Payload),
+            NativeSshEventKind.PasswordPrompt => CreateTextPromptRequest(SshInteractionKind.Password, nextEvent.Payload),
+            NativeSshEventKind.PassphrasePrompt => CreateTextPromptRequest(SshInteractionKind.Passphrase, nextEvent.Payload),
+            NativeSshEventKind.KeyboardInteractivePrompt => CreateKeyboardRequest(nextEvent.Payload),
+            _ => throw new InvalidOperationException($"Unsupported interaction event '{nextEvent.Kind}'.")
+        };
+    }
+
+    private static SshInteractionRequest CreateHostKeyRequest(byte[] payload)
+    {
+        HostKeyPromptPayload? model = JsonSerializer.Deserialize<HostKeyPromptPayload>(payload);
+        if (model == null)
+        {
+            throw new InvalidOperationException("Failed to parse host key prompt payload.");
+        }
+
+        return new SshInteractionRequest
+        {
+            Kind = SshInteractionKind.UnknownHostKey,
+            Host = model.Host,
+            Port = model.Port,
+            Algorithm = model.Algorithm,
+            Fingerprint = model.Fingerprint
+        };
+    }
+
+    private static SshInteractionRequest CreateTextPromptRequest(SshInteractionKind kind, byte[] payload)
+    {
+        TextPromptPayload? model = JsonSerializer.Deserialize<TextPromptPayload>(payload);
+        if (model == null)
+        {
+            throw new InvalidOperationException("Failed to parse authentication prompt payload.");
+        }
+
+        return new SshInteractionRequest
+        {
+            Kind = kind,
+            Prompt = model.Prompt
+        };
+    }
+
+    private static SshInteractionRequest CreateKeyboardRequest(byte[] payload)
+    {
+        KeyboardInteractivePromptPayload? model = JsonSerializer.Deserialize<KeyboardInteractivePromptPayload>(payload);
+        if (model == null)
+        {
+            throw new InvalidOperationException("Failed to parse keyboard-interactive payload.");
+        }
+
+        return new SshInteractionRequest
+        {
+            Kind = SshInteractionKind.KeyboardInteractive,
+            Name = model.Name,
+            Instructions = model.Instructions,
+            KeyboardPrompts = model.Prompts.Select(prompt => new SshKeyboardPrompt(prompt.Prompt, prompt.Echo)).ToArray()
+        };
+    }
+
+    private static byte[] BuildInteractionPayload(NativeSshResponseKind responseKind, SshInteractionResponse response)
+    {
+        object body = responseKind switch
+        {
+            NativeSshResponseKind.HostKeyDecision => new { accept = response.IsAccepted && !response.IsCanceled },
+            NativeSshResponseKind.Password or NativeSshResponseKind.Passphrase => new { text = response.IsCanceled ? string.Empty : response.Secret ?? string.Empty },
+            NativeSshResponseKind.KeyboardInteractive => new { responses = response.IsCanceled ? Array.Empty<string>() : response.KeyboardResponses.ToArray() },
+            _ => throw new InvalidOperationException($"Unsupported native SSH response kind '{responseKind}'.")
+        };
+
+        return Encoding.UTF8.GetBytes(JsonSerializer.Serialize(body));
+    }
+
+    private sealed class HostKeyPromptPayload
+    {
+        public string Host { get; set; } = string.Empty;
+        public int Port { get; set; }
+        public string Algorithm { get; set; } = string.Empty;
+        public string Fingerprint { get; set; } = string.Empty;
+    }
+
+    private sealed class TextPromptPayload
+    {
+        public string Prompt { get; set; } = string.Empty;
+    }
+
+    private sealed class KeyboardInteractivePromptPayload
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Instructions { get; set; } = string.Empty;
+        public List<KeyboardInteractivePromptItem> Prompts { get; set; } = new();
+    }
+
+    private sealed class KeyboardInteractivePromptItem
+    {
+        public string Prompt { get; set; } = string.Empty;
+        public bool Echo { get; set; }
     }
 }

--- a/src/NovaTerminal.Core/Ssh/Sessions/SshSessionFactory.cs
+++ b/src/NovaTerminal.Core/Ssh/Sessions/SshSessionFactory.cs
@@ -1,4 +1,5 @@
 using NovaTerminal.Core.Ssh.Launch;
+using NovaTerminal.Core.Ssh.Interactions;
 using NovaTerminal.Core.Ssh.Models;
 using NovaTerminal.Core.Ssh.Native;
 using NovaTerminal.Core.Ssh.Storage;
@@ -10,6 +11,7 @@ public sealed class SshSessionFactory : ISshSessionFactory
     private readonly ISshProfileStore _profileStore;
     private readonly ISshProcessLauncher? _launcher;
     private readonly INativeSshInterop? _nativeInterop;
+    private readonly ISshInteractionHandler? _nativeInteractionHandler;
 
     public SshSessionFactory(ISshProfileStore profileStore)
         : this(profileStore, null, null)
@@ -19,15 +21,20 @@ public sealed class SshSessionFactory : ISshSessionFactory
     public SshSessionFactory(
         ISshProfileStore profileStore,
         ISshProcessLauncher? launcher = null,
-        INativeSshInterop? nativeInterop = null)
+        INativeSshInterop? nativeInterop = null,
+        ISshInteractionHandler? nativeInteractionHandler = null)
     {
         _profileStore = profileStore ?? throw new ArgumentNullException(nameof(profileStore));
         _launcher = launcher;
         _nativeInterop = nativeInterop;
+        _nativeInteractionHandler = nativeInteractionHandler;
     }
 
-    public SshSessionFactory(ISshProcessLauncher? launcher = null)
-        : this(new JsonSshProfileStore(), launcher, null)
+    public SshSessionFactory(
+        ISshProcessLauncher? launcher = null,
+        INativeSshInterop? nativeInterop = null,
+        ISshInteractionHandler? nativeInteractionHandler = null)
+        : this(new JsonSshProfileStore(), launcher, nativeInterop, nativeInteractionHandler)
     {
     }
 
@@ -44,7 +51,7 @@ public sealed class SshSessionFactory : ISshSessionFactory
 
         return profile.BackendKind switch
         {
-            SshBackendKind.Native => new NativeSshSession(profile, cols, rows, diagnosticsLevel, extraArgs, log, _nativeInterop),
+            SshBackendKind.Native => new NativeSshSession(profile, cols, rows, diagnosticsLevel, extraArgs, log, _nativeInterop, _nativeInteractionHandler),
             _ => new OpenSshSession(profile.Id, _profileStore, cols, rows, diagnosticsLevel, extraArgs, _launcher, log)
         };
     }

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionInteractionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionInteractionTests.cs
@@ -1,0 +1,153 @@
+using System.Collections.Concurrent;
+using System.Text;
+using NovaTerminal.Core.Ssh.Interactions;
+using NovaTerminal.Core.Ssh.Models;
+using NovaTerminal.Core.Ssh.Native;
+using NovaTerminal.Core.Ssh.Sessions;
+
+namespace NovaTerminal.Core.Tests.Ssh;
+
+public sealed class NativeSshSessionInteractionTests
+{
+    [Fact]
+    public async Task PromptWaitsForInteractionResponseBeforePollingFurtherEvents()
+    {
+        var interop = new FakeNativeSshInterop();
+        interop.Enqueue(new NativeSshEvent(
+            NativeSshEventKind.HostKeyPrompt,
+            Encoding.UTF8.GetBytes("""{"host":"srv","port":22,"algorithm":"ssh-ed25519","fingerprint":"SHA256:test"}"""),
+            flags: NativeSshEventFlags.Json));
+        interop.Enqueue(NativeSshEvent.Data(Encoding.UTF8.GetBytes("ready\n")));
+        interop.Enqueue(NativeSshEvent.ExitStatus(0));
+        interop.Enqueue(NativeSshEvent.Closed());
+
+        var handler = new PendingInteractionHandler();
+        var outputs = new List<string>();
+        var exit = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var session = new NativeSshSession(CreateProfile(), interop: interop, interactionHandler: handler);
+        session.OnOutputReceived += outputs.Add;
+        session.OnExit += code => exit.TrySetResult(code);
+
+        await handler.WaitForRequestAsync();
+        await Task.Delay(100);
+
+        Assert.Equal(1, interop.PollCallCount);
+        Assert.Empty(outputs);
+        Assert.Empty(interop.Submissions);
+
+        handler.Complete(SshInteractionResponse.AcceptHostKey());
+
+        Assert.Equal(0, await exit.Task.WaitAsync(TimeSpan.FromSeconds(2)));
+        Assert.Equal("""{"accept":true}""", interop.Submissions.Single().PayloadJson);
+        Assert.Contains("ready", outputs.Single());
+    }
+
+    [Fact]
+    public async Task PromptCancellationSubmitsDeterministicRejectPayload()
+    {
+        var interop = new FakeNativeSshInterop();
+        interop.Enqueue(new NativeSshEvent(
+            NativeSshEventKind.HostKeyPrompt,
+            Encoding.UTF8.GetBytes("""{"host":"srv","port":22,"algorithm":"ssh-ed25519","fingerprint":"SHA256:test"}"""),
+            flags: NativeSshEventFlags.Json));
+
+        var handler = new PendingInteractionHandler();
+        using var session = new NativeSshSession(CreateProfile(), interop: interop, interactionHandler: handler);
+
+        await handler.WaitForRequestAsync();
+        handler.Complete(SshInteractionResponse.Cancel());
+        await WaitUntilAsync(() => interop.Submissions.Count > 0);
+
+        var submission = interop.Submissions.Single();
+        Assert.Equal(NativeSshResponseKind.HostKeyDecision, submission.Kind);
+        Assert.Equal("""{"accept":false}""", submission.PayloadJson);
+    }
+
+    private static SshProfile CreateProfile()
+    {
+        return new SshProfile
+        {
+            Id = Guid.Parse("6892b728-776c-4cb0-8e31-5875f69e8086"),
+            BackendKind = SshBackendKind.Native,
+            Host = "native.example",
+            User = "nova",
+            Port = 22
+        };
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> predicate)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(2);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (predicate())
+            {
+                return;
+            }
+
+            await Task.Delay(20);
+        }
+
+        Assert.True(predicate(), "Condition was not met before timeout.");
+    }
+
+    private sealed class PendingInteractionHandler : ISshInteractionHandler
+    {
+        private readonly TaskCompletionSource<SshInteractionRequest> _request = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<SshInteractionResponse> _response = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<SshInteractionResponse> HandleAsync(SshInteractionRequest request, CancellationToken cancellationToken)
+        {
+            _request.TrySetResult(request);
+            return _response.Task.WaitAsync(cancellationToken);
+        }
+
+        public Task WaitForRequestAsync() => _request.Task;
+
+        public void Complete(SshInteractionResponse response)
+        {
+            _response.TrySetResult(response);
+        }
+    }
+
+    private sealed class FakeNativeSshInterop : INativeSshInterop
+    {
+        private readonly ConcurrentQueue<NativeSshEvent> _events = new();
+
+        public int PollCallCount { get; private set; }
+        public List<(NativeSshResponseKind Kind, string PayloadJson)> Submissions { get; } = new();
+
+        public IntPtr Connect(NativeSshConnectionOptions options) => new(1);
+
+        public NativeSshEvent? PollEvent(IntPtr sessionHandle)
+        {
+            PollCallCount++;
+            return _events.TryDequeue(out NativeSshEvent? nextEvent)
+                ? nextEvent
+                : null;
+        }
+
+        public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data)
+        {
+        }
+
+        public void Resize(IntPtr sessionHandle, int cols, int rows)
+        {
+        }
+
+        public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data)
+        {
+            Submissions.Add((responseKind, Encoding.UTF8.GetString(data)));
+        }
+
+        public void Close(IntPtr sessionHandle)
+        {
+        }
+
+        public void Enqueue(NativeSshEvent nextEvent)
+        {
+            _events.Enqueue(nextEvent);
+        }
+    }
+}

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
@@ -156,6 +156,10 @@ public sealed class NativeSshSessionTests
             CloseCallCount++;
         }
 
+        public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data)
+        {
+        }
+
         public void Enqueue(NativeSshEvent nextEvent)
         {
             _events.Enqueue(nextEvent);

--- a/tests/NovaTerminal.Core.Tests/Ssh/SshSessionFactoryTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/SshSessionFactoryTests.cs
@@ -60,5 +60,9 @@ public sealed class SshSessionFactoryTests
         public void Close(IntPtr sessionHandle)
         {
         }
+
+        public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data)
+        {
+        }
     }
 }

--- a/tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs
@@ -1,0 +1,118 @@
+using NovaTerminal.Core.Ssh.Interactions;
+using NovaTerminal.Services.Ssh;
+using NovaTerminal.ViewModels.Ssh;
+
+namespace NovaTerminal.Tests.Ssh;
+
+public sealed class SshInteractionServiceTests
+{
+    [Fact]
+    public async Task HostKeyRequestsMapToHostKeyPromptViewModel()
+    {
+        HostKeyPromptViewModel? capturedVm = null;
+        var service = new SshInteractionService(
+            hostKeyPresenter: (_, vm, _) =>
+            {
+                capturedVm = vm;
+                return Task.FromResult(SshInteractionResponse.AcceptHostKey());
+            });
+
+        var response = await service.HandleAsync(new SshInteractionRequest
+        {
+            Kind = SshInteractionKind.UnknownHostKey,
+            Host = "example.internal",
+            Port = 2222,
+            Algorithm = "ssh-ed25519",
+            Fingerprint = "SHA256:test"
+        }, CancellationToken.None);
+
+        Assert.NotNull(capturedVm);
+        Assert.Equal("example.internal", capturedVm!.Host);
+        Assert.Equal(2222, capturedVm.Port);
+        Assert.Equal("ssh-ed25519", capturedVm.Algorithm);
+        Assert.Equal("SHA256:test", capturedVm.Fingerprint);
+        Assert.False(capturedVm.IsChangedHostKey);
+        Assert.True(response.IsAccepted);
+    }
+
+    [Fact]
+    public async Task PasswordRequestsMapToSingleSecretPrompt()
+    {
+        AuthPromptViewModel? capturedVm = null;
+        var service = new SshInteractionService(
+            authPresenter: (_, vm, _) =>
+            {
+                capturedVm = vm;
+                return Task.FromResult(SshInteractionResponse.FromSecret("password"));
+            });
+
+        var response = await service.HandleAsync(new SshInteractionRequest
+        {
+            Kind = SshInteractionKind.Password,
+            Prompt = "Password:"
+        }, CancellationToken.None);
+
+        Assert.NotNull(capturedVm);
+        Assert.Equal("Password", capturedVm!.Title);
+        Assert.Single(capturedVm.Prompts);
+        Assert.True(capturedVm.Prompts[0].IsSecret);
+        Assert.Equal("Password:", capturedVm.Prompts[0].Prompt);
+        Assert.Equal("password", response.Secret);
+    }
+
+    [Fact]
+    public async Task PassphraseRequestsMapToSecretPrompt()
+    {
+        AuthPromptViewModel? capturedVm = null;
+        var service = new SshInteractionService(
+            authPresenter: (_, vm, _) =>
+            {
+                capturedVm = vm;
+                return Task.FromResult(SshInteractionResponse.FromSecret("hunter2"));
+            });
+
+        var response = await service.HandleAsync(new SshInteractionRequest
+        {
+            Kind = SshInteractionKind.Passphrase,
+            Prompt = "Key passphrase:"
+        }, CancellationToken.None);
+
+        Assert.NotNull(capturedVm);
+        Assert.Equal("Passphrase", capturedVm!.Title);
+        Assert.Single(capturedVm.Prompts);
+        Assert.True(capturedVm.Prompts[0].IsSecret);
+        Assert.Equal("hunter2", response.Secret);
+    }
+
+    [Fact]
+    public async Task KeyboardInteractiveRequestsMapAllPromptFields()
+    {
+        AuthPromptViewModel? capturedVm = null;
+        var service = new SshInteractionService(
+            authPresenter: (_, vm, _) =>
+            {
+                capturedVm = vm;
+                return Task.FromResult(SshInteractionResponse.FromKeyboardResponses("code", "otp"));
+            });
+
+        var response = await service.HandleAsync(new SshInteractionRequest
+        {
+            Kind = SshInteractionKind.KeyboardInteractive,
+            Name = "Duo",
+            Instructions = "Provide challenge response",
+            KeyboardPrompts =
+            [
+                new SshKeyboardPrompt("Passcode:", false),
+                new SshKeyboardPrompt("OTP:", false)
+            ]
+        }, CancellationToken.None);
+
+        Assert.NotNull(capturedVm);
+        Assert.Equal("Duo", capturedVm!.Title);
+        Assert.Equal("Provide challenge response", capturedVm.Message);
+        Assert.Equal(2, capturedVm.Prompts.Count);
+        Assert.Equal("Passcode:", capturedVm.Prompts[0].Prompt);
+        Assert.True(capturedVm.Prompts[0].IsSecret);
+        Assert.Equal(["code", "otp"], response.KeyboardResponses);
+    }
+}


### PR DESCRIPTION
## Summary
- add core SSH interaction contracts so native-session prompt handling stays UI-agnostic
- add an Avalonia interaction service with host-key and auth dialogs plus prompt view models
- wire `TerminalPane` and `MainWindow` so native sessions can request prompt responses through composition

## Verification
- `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~Ssh"`
- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~SshConnectionServiceTests|FullyQualifiedName~NewSshConnectionViewModelTests|FullyQualifiedName~SshManagerViewModelTests|FullyQualifiedName~SshLegacyProfileMigrationTests|FullyQualifiedName~SshInteractionServiceTests" /nodeReuse:false`
- `dotnet build src/NovaTerminal.App/NovaTerminal.App.csproj -c Release -p:SKIP_RUST_NATIVE_BUILD=1 /nodeReuse:false`
