### PR TITLE
feat: persist native ssh host trust state

### DIFF
--- a/src/NovaTerminal.App/Core/AppPaths.cs
+++ b/src/NovaTerminal.App/Core/AppPaths.cs
@@ -35,6 +35,8 @@ namespace NovaTerminal.Core
         public static string CommandAssistDirectory => Path.Combine(RootDirectory, "command-assist");
         public static string CommandHistoryFilePath => Path.Combine(CommandAssistDirectory, "history.json");
         public static string CommandSnippetsFilePath => Path.Combine(CommandAssistDirectory, "snippets.json");
+        public static string SshDirectory => Path.Combine(RootDirectory, "ssh");
+        public static string NativeKnownHostsFilePath => Path.Combine(SshDirectory, "native_known_hosts.json");
 
         public static void EnsureInitialized()
         {
@@ -55,6 +57,7 @@ namespace NovaTerminal.Core
                     Directory.CreateDirectory(PolicyDirectory);
                     Directory.CreateDirectory(RecordingsDirectory);
                     Directory.CreateDirectory(CommandAssistDirectory);
+                    Directory.CreateDirectory(SshDirectory);
 
                     string legacyBaseDir = AppDomain.CurrentDomain.BaseDirectory;
                     string legacyRoamingRoot = Path.Combine(

--- a/src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs
@@ -2,7 +2,9 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls;
+using NovaTerminal.Core;
 using NovaTerminal.Core.Ssh.Interactions;
+using NovaTerminal.Core.Ssh.Native;
 using NovaTerminal.ViewModels.Ssh;
 using NovaTerminal.Views.Ssh;
 
@@ -14,32 +16,65 @@ public sealed class SshInteractionService : ISshInteractionService
     private readonly Action<Window>? _prepareDialog;
     private readonly Func<Window?, HostKeyPromptViewModel, CancellationToken, Task<SshInteractionResponse>> _hostKeyPresenter;
     private readonly Func<Window?, AuthPromptViewModel, CancellationToken, Task<SshInteractionResponse>> _authPresenter;
+    private readonly NativeKnownHostsStore _knownHostsStore;
 
     public SshInteractionService(
         Func<Window?>? ownerProvider = null,
         Action<Window>? prepareDialog = null,
         Func<Window?, HostKeyPromptViewModel, CancellationToken, Task<SshInteractionResponse>>? hostKeyPresenter = null,
-        Func<Window?, AuthPromptViewModel, CancellationToken, Task<SshInteractionResponse>>? authPresenter = null)
+        Func<Window?, AuthPromptViewModel, CancellationToken, Task<SshInteractionResponse>>? authPresenter = null,
+        NativeKnownHostsStore? knownHostsStore = null)
     {
         _ownerProvider = ownerProvider ?? (() => null);
         _prepareDialog = prepareDialog;
         _hostKeyPresenter = hostKeyPresenter ?? PresentHostKeyAsync;
         _authPresenter = authPresenter ?? PresentAuthAsync;
+        _knownHostsStore = knownHostsStore ?? new NativeKnownHostsStore(AppPaths.NativeKnownHostsFilePath);
     }
 
-    public Task<SshInteractionResponse> HandleAsync(SshInteractionRequest request, CancellationToken cancellationToken)
+    public async Task<SshInteractionResponse> HandleAsync(SshInteractionRequest request, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(request);
 
         Window? owner = _ownerProvider();
         return request.Kind switch
         {
-            SshInteractionKind.UnknownHostKey or SshInteractionKind.ChangedHostKey => _hostKeyPresenter(owner, CreateHostKeyViewModel(request), cancellationToken),
-            SshInteractionKind.Password => _authPresenter(owner, CreatePasswordViewModel(request), cancellationToken),
-            SshInteractionKind.Passphrase => _authPresenter(owner, CreatePassphraseViewModel(request), cancellationToken),
-            SshInteractionKind.KeyboardInteractive => _authPresenter(owner, CreateKeyboardViewModel(request), cancellationToken),
-            _ => Task.FromResult(SshInteractionResponse.Cancel())
+            SshInteractionKind.UnknownHostKey or SshInteractionKind.ChangedHostKey => await HandleHostKeyAsync(owner, request, cancellationToken),
+            SshInteractionKind.Password => await _authPresenter(owner, CreatePasswordViewModel(request), cancellationToken),
+            SshInteractionKind.Passphrase => await _authPresenter(owner, CreatePassphraseViewModel(request), cancellationToken),
+            SshInteractionKind.KeyboardInteractive => await _authPresenter(owner, CreateKeyboardViewModel(request), cancellationToken),
+            _ => SshInteractionResponse.Cancel()
         };
+    }
+
+    private async Task<SshInteractionResponse> HandleHostKeyAsync(Window? owner, SshInteractionRequest request, CancellationToken cancellationToken)
+    {
+        NativeKnownHostMatch match = _knownHostsStore.CheckHost(request.Host, request.Port, request.Algorithm, request.Fingerprint);
+        if (match == NativeKnownHostMatch.Trusted)
+        {
+            return SshInteractionResponse.AcceptHostKey();
+        }
+
+        SshInteractionRequest requestToPresent = request;
+        if (match == NativeKnownHostMatch.Mismatch)
+        {
+            requestToPresent = new SshInteractionRequest
+            {
+                Kind = SshInteractionKind.ChangedHostKey,
+                Host = request.Host,
+                Port = request.Port,
+                Algorithm = request.Algorithm,
+                Fingerprint = request.Fingerprint
+            };
+        }
+
+        SshInteractionResponse response = await _hostKeyPresenter(owner, CreateHostKeyViewModel(requestToPresent), cancellationToken);
+        if (response.IsAccepted && !response.IsCanceled)
+        {
+            _knownHostsStore.TrustHost(request.Host, request.Port, request.Algorithm, request.Fingerprint);
+        }
+
+        return response;
     }
 
     private async Task<SshInteractionResponse> PresentHostKeyAsync(Window? owner, HostKeyPromptViewModel viewModel, CancellationToken cancellationToken)

--- a/src/NovaTerminal.Core/Ssh/Native/HostKeyFingerprintFormatter.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/HostKeyFingerprintFormatter.cs
@@ -1,0 +1,21 @@
+namespace NovaTerminal.Core.Ssh.Native;
+
+public static class HostKeyFingerprintFormatter
+{
+    public static string Normalize(string fingerprint)
+    {
+        string normalized = fingerprint?.Trim() ?? string.Empty;
+        if (normalized.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        const string prefix = "SHA256:";
+        if (normalized.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return prefix + normalized[prefix.Length..].Trim();
+        }
+
+        return normalized;
+    }
+}

--- a/src/NovaTerminal.Core/Ssh/Native/KnownHostEntry.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/KnownHostEntry.cs
@@ -1,0 +1,10 @@
+namespace NovaTerminal.Core.Ssh.Native;
+
+public sealed class KnownHostEntry
+{
+    public string Host { get; set; } = string.Empty;
+    public int Port { get; set; } = 22;
+    public string Algorithm { get; set; } = string.Empty;
+    public string Fingerprint { get; set; } = string.Empty;
+    public DateTime TrustedAtUtc { get; set; } = DateTime.UtcNow;
+}

--- a/src/NovaTerminal.Core/Ssh/Native/NativeKnownHostsStore.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeKnownHostsStore.cs
@@ -1,0 +1,121 @@
+using System.Text.Json;
+using NovaTerminal.Core.Ssh.Storage;
+
+namespace NovaTerminal.Core.Ssh.Native;
+
+public enum NativeKnownHostMatch
+{
+    Unknown = 0,
+    Trusted = 1,
+    Mismatch = 2
+}
+
+public sealed class NativeKnownHostsStore
+{
+    private readonly object _syncRoot = new();
+    private readonly string _storeFilePath;
+
+    public NativeKnownHostsStore(string storeFilePath)
+    {
+        _storeFilePath = Path.GetFullPath(storeFilePath ?? throw new ArgumentNullException(nameof(storeFilePath)));
+    }
+
+    public string StoreFilePath => _storeFilePath;
+
+    public NativeKnownHostMatch CheckHost(string host, int port, string algorithm, string fingerprint)
+    {
+        lock (_syncRoot)
+        {
+            KnownHostEntry? existing = LoadEntriesLocked().FirstOrDefault(entry =>
+                string.Equals(entry.Host, NormalizeHost(host), StringComparison.OrdinalIgnoreCase) &&
+                entry.Port == NormalizePort(port));
+
+            if (existing == null)
+            {
+                return NativeKnownHostMatch.Unknown;
+            }
+
+            bool matches = string.Equals(existing.Algorithm, NormalizeAlgorithm(algorithm), StringComparison.Ordinal) &&
+                           string.Equals(existing.Fingerprint, HostKeyFingerprintFormatter.Normalize(fingerprint), StringComparison.Ordinal);
+
+            return matches ? NativeKnownHostMatch.Trusted : NativeKnownHostMatch.Mismatch;
+        }
+    }
+
+    public void TrustHost(string host, int port, string algorithm, string fingerprint)
+    {
+        lock (_syncRoot)
+        {
+            List<KnownHostEntry> entries = LoadEntriesLocked();
+            string normalizedHost = NormalizeHost(host);
+            int normalizedPort = NormalizePort(port);
+            string normalizedAlgorithm = NormalizeAlgorithm(algorithm);
+            string normalizedFingerprint = HostKeyFingerprintFormatter.Normalize(fingerprint);
+
+            int existingIndex = entries.FindIndex(entry =>
+                string.Equals(entry.Host, normalizedHost, StringComparison.OrdinalIgnoreCase) &&
+                entry.Port == normalizedPort);
+
+            var replacement = new KnownHostEntry
+            {
+                Host = normalizedHost,
+                Port = normalizedPort,
+                Algorithm = normalizedAlgorithm,
+                Fingerprint = normalizedFingerprint,
+                TrustedAtUtc = DateTime.UtcNow
+            };
+
+            if (existingIndex >= 0)
+            {
+                entries[existingIndex] = replacement;
+            }
+            else
+            {
+                entries.Add(replacement);
+            }
+
+            PersistEntriesLocked(entries);
+        }
+    }
+
+    private List<KnownHostEntry> LoadEntriesLocked()
+    {
+        if (!File.Exists(_storeFilePath))
+        {
+            return new List<KnownHostEntry>();
+        }
+
+        try
+        {
+            string json = File.ReadAllText(_storeFilePath);
+            return JsonSerializer.Deserialize(json, SshJsonContext.Default.ListKnownHostEntry) ?? new List<KnownHostEntry>();
+        }
+        catch
+        {
+            return new List<KnownHostEntry>();
+        }
+    }
+
+    private void PersistEntriesLocked(List<KnownHostEntry> entries)
+    {
+        string? directory = Path.GetDirectoryName(_storeFilePath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var ordered = entries
+            .OrderBy(entry => entry.Host, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(entry => entry.Port)
+            .ToList();
+
+        string json = JsonSerializer.Serialize(ordered, SshJsonContext.Default.ListKnownHostEntry);
+        File.WriteAllText(_storeFilePath, json);
+    }
+
+    private static string NormalizeHost(string host) => host?.Trim() ?? string.Empty;
+
+    private static string NormalizeAlgorithm(string algorithm) => algorithm?.Trim() ?? string.Empty;
+
+    private static int NormalizePort(int port) => port > 0 ? port : 22;
+}

--- a/src/NovaTerminal.Core/Ssh/Storage/SshJsonContext.cs
+++ b/src/NovaTerminal.Core/Ssh/Storage/SshJsonContext.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using NovaTerminal.Core.Ssh.Models;
+using NovaTerminal.Core.Ssh.Native;
 
 namespace NovaTerminal.Core.Ssh.Storage;
 
@@ -15,6 +16,8 @@ namespace NovaTerminal.Core.Ssh.Storage;
 [JsonSerializable(typeof(PortForward))]
 [JsonSerializable(typeof(List<PortForward>))]
 [JsonSerializable(typeof(SshMuxOptions))]
+[JsonSerializable(typeof(KnownHostEntry))]
+[JsonSerializable(typeof(List<KnownHostEntry>))]
 internal partial class SshJsonContext : JsonSerializerContext
 {
 }

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeKnownHostsStoreTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeKnownHostsStoreTests.cs
@@ -1,0 +1,71 @@
+using NovaTerminal.Core.Ssh.Native;
+
+namespace NovaTerminal.Core.Tests.Ssh;
+
+public sealed class NativeKnownHostsStoreTests
+{
+    [Fact]
+    public void TrustHost_FirstTimePersistsEntryAndTrustedLookup()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string path = Path.Combine(tempRoot, "native_known_hosts.json");
+            var store = new NativeKnownHostsStore(path);
+
+            Assert.Equal(
+                NativeKnownHostMatch.Unknown,
+                store.CheckHost("example.internal", 22, "ssh-ed25519", " sha256:test-fingerprint "));
+
+            store.TrustHost("example.internal", 22, "ssh-ed25519", " sha256:test-fingerprint ");
+
+            Assert.Equal(
+                NativeKnownHostMatch.Trusted,
+                store.CheckHost("EXAMPLE.INTERNAL", 22, "ssh-ed25519", "SHA256:test-fingerprint"));
+
+            string json = File.ReadAllText(path);
+            Assert.Contains("example.internal", json, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("password", json, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("passphrase", json, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CheckHost_WhenFingerprintChanges_ReturnsMismatch()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string path = Path.Combine(tempRoot, "native_known_hosts.json");
+            var store = new NativeKnownHostsStore(path);
+            store.TrustHost("example.internal", 22, "ssh-ed25519", "SHA256:trusted");
+
+            Assert.Equal(
+                NativeKnownHostMatch.Mismatch,
+                store.CheckHost("example.internal", 22, "ssh-ed25519", "SHA256:changed"));
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Formatter_NormalizesFingerprintDeterministically()
+    {
+        string normalized = HostKeyFingerprintFormatter.Normalize(" sha256:AbCdEf123= ");
+
+        Assert.Equal("SHA256:AbCdEf123=", normalized);
+    }
+
+    private static string CreateTempDirectory()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"nova_known_hosts_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/tests/NovaTerminal.Tests/Core/AppPathsTests.cs
+++ b/tests/NovaTerminal.Tests/Core/AppPathsTests.cs
@@ -91,6 +91,24 @@ public sealed class AppPathsTests
         }
     }
 
+    [Fact]
+    public void NativeKnownHostsFilePath_IsStableUnderRootDirectory()
+    {
+        string fullPath = Path.GetFullPath(AppPaths.NativeKnownHostsFilePath);
+        string root = Path.GetFullPath(AppPaths.RootDirectory);
+
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.StartsWith(root, fullPath, StringComparison.OrdinalIgnoreCase);
+        }
+        else
+        {
+            Assert.StartsWith(root, fullPath, StringComparison.Ordinal);
+        }
+
+        Assert.EndsWith(Path.Combine("ssh", "native_known_hosts.json"), fullPath);
+    }
+
     private static string CreateTempDirectory()
     {
         string path = Path.Combine(Path.GetTempPath(), $"nova_paths_test_{Guid.NewGuid():N}");

--- a/tests/NovaTerminal.Tests/Core/SessionManagerTests.cs
+++ b/tests/NovaTerminal.Tests/Core/SessionManagerTests.cs
@@ -1,0 +1,101 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using NovaTerminal.Controls;
+using NovaTerminal.Core;
+using NovaTerminal.Core.Ssh.Models;
+using NovaTerminal.Core.Ssh.Storage;
+
+namespace NovaTerminal.Tests.Core;
+
+public sealed class SessionManagerTests
+{
+    [AvaloniaFact]
+    public void RestoreSession_UsesStoreBackedSshProfileAndPreservesBackendKind()
+    {
+        string storePath = JsonSshProfileStore.GetDefaultStorePath();
+        string storeDirectory = Path.GetDirectoryName(storePath)!;
+        string backupPath = storePath + ".task5-test-backup";
+        bool hadExisting = File.Exists(storePath);
+
+        Directory.CreateDirectory(storeDirectory);
+        if (File.Exists(backupPath))
+        {
+            File.Delete(backupPath);
+        }
+
+        if (hadExisting)
+        {
+            File.Copy(storePath, backupPath, overwrite: true);
+        }
+
+        try
+        {
+            var store = new JsonSshProfileStore(storePath);
+            Guid sshId = Guid.Parse("4bcf6934-c30d-4100-99e8-a9b5a283fc5d");
+            store.SaveProfile(new SshProfile
+            {
+                Id = sshId,
+                Name = "Native SSH",
+                Host = "native.internal",
+                User = "ops",
+                Port = 22,
+                BackendKind = SshBackendKind.Native
+            });
+
+            var session = new NovaSession
+            {
+                Tabs =
+                {
+                    new TabSession
+                    {
+                        Title = "Native SSH",
+                        Root = new PaneNode
+                        {
+                            Type = NodeType.Leaf,
+                            ProfileId = sshId.ToString(),
+                            SshProfileId = sshId.ToString(),
+                            PaneId = Guid.NewGuid().ToString()
+                        }
+                    }
+                }
+            };
+
+            var tabs = new TabControl();
+            var window = new Window();
+            var settings = new TerminalSettings
+            {
+                Profiles = new List<TerminalProfile>
+                {
+                    new TerminalProfile
+                    {
+                        Id = Guid.Parse("6f9c6f43-f1e8-4873-ac64-08ae12722b9d"),
+                        Name = "Local",
+                        Type = ConnectionType.Local,
+                        Command = "pwsh.exe"
+                    }
+                }
+            };
+            settings.DefaultProfileId = settings.Profiles[0].Id;
+
+            SessionManager.RestoreSession(window, tabs, settings, session);
+
+            var tab = Assert.IsType<TabItem>(Assert.Single(tabs.Items));
+            var pane = Assert.IsType<TerminalPane>(tab.Content);
+            Assert.NotNull(pane.Profile);
+            Assert.Equal(ConnectionType.SSH, pane.Profile!.Type);
+            Assert.Equal(SshBackendKind.Native, pane.Profile.SshBackendKind);
+        }
+        finally
+        {
+            if (hadExisting)
+            {
+                File.Copy(backupPath, storePath, overwrite: true);
+                File.Delete(backupPath);
+            }
+            else if (File.Exists(storePath))
+            {
+                File.Delete(storePath);
+            }
+        }
+    }
+}

--- a/tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs
@@ -1,4 +1,5 @@
 using NovaTerminal.Core.Ssh.Interactions;
+using NovaTerminal.Core.Ssh.Native;
 using NovaTerminal.Services.Ssh;
 using NovaTerminal.ViewModels.Ssh;
 
@@ -9,30 +10,112 @@ public sealed class SshInteractionServiceTests
     [Fact]
     public async Task HostKeyRequestsMapToHostKeyPromptViewModel()
     {
-        HostKeyPromptViewModel? capturedVm = null;
-        var service = new SshInteractionService(
-            hostKeyPresenter: (_, vm, _) =>
-            {
-                capturedVm = vm;
-                return Task.FromResult(SshInteractionResponse.AcceptHostKey());
-            });
-
-        var response = await service.HandleAsync(new SshInteractionRequest
+        string tempRoot = CreateTempDirectory();
+        try
         {
-            Kind = SshInteractionKind.UnknownHostKey,
-            Host = "example.internal",
-            Port = 2222,
-            Algorithm = "ssh-ed25519",
-            Fingerprint = "SHA256:test"
-        }, CancellationToken.None);
+            HostKeyPromptViewModel? capturedVm = null;
+            var knownHosts = new NativeKnownHostsStore(Path.Combine(tempRoot, "native_known_hosts.json"));
+            var service = new SshInteractionService(
+                hostKeyPresenter: (_, vm, _) =>
+                {
+                    capturedVm = vm;
+                    return Task.FromResult(SshInteractionResponse.AcceptHostKey());
+                },
+                knownHostsStore: knownHosts);
 
-        Assert.NotNull(capturedVm);
-        Assert.Equal("example.internal", capturedVm!.Host);
-        Assert.Equal(2222, capturedVm.Port);
-        Assert.Equal("ssh-ed25519", capturedVm.Algorithm);
-        Assert.Equal("SHA256:test", capturedVm.Fingerprint);
-        Assert.False(capturedVm.IsChangedHostKey);
-        Assert.True(response.IsAccepted);
+            var response = await service.HandleAsync(new SshInteractionRequest
+            {
+                Kind = SshInteractionKind.UnknownHostKey,
+                Host = "example.internal",
+                Port = 2222,
+                Algorithm = "ssh-ed25519",
+                Fingerprint = "SHA256:test"
+            }, CancellationToken.None);
+
+            Assert.NotNull(capturedVm);
+            Assert.Equal("example.internal", capturedVm!.Host);
+            Assert.Equal(2222, capturedVm.Port);
+            Assert.Equal("ssh-ed25519", capturedVm.Algorithm);
+            Assert.Equal("SHA256:test", capturedVm.Fingerprint);
+            Assert.False(capturedVm.IsChangedHostKey);
+            Assert.True(response.IsAccepted);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task TrustedHostKey_SkipsDialogAndAcceptsImmediately()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            var knownHosts = new NativeKnownHostsStore(Path.Combine(tempRoot, "native_known_hosts.json"));
+            knownHosts.TrustHost("example.internal", 22, "ssh-ed25519", "SHA256:test");
+            int promptCount = 0;
+            var service = new SshInteractionService(
+                hostKeyPresenter: (_, _, _) =>
+                {
+                    promptCount++;
+                    return Task.FromResult(SshInteractionResponse.Cancel());
+                },
+                knownHostsStore: knownHosts);
+
+            var response = await service.HandleAsync(new SshInteractionRequest
+            {
+                Kind = SshInteractionKind.UnknownHostKey,
+                Host = "example.internal",
+                Port = 22,
+                Algorithm = "ssh-ed25519",
+                Fingerprint = "SHA256:test"
+            }, CancellationToken.None);
+
+            Assert.True(response.IsAccepted);
+            Assert.Equal(0, promptCount);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ChangedHostKey_MapsToChangedPromptViewModel()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            var knownHosts = new NativeKnownHostsStore(Path.Combine(tempRoot, "native_known_hosts.json"));
+            knownHosts.TrustHost("example.internal", 22, "ssh-ed25519", "SHA256:old");
+            HostKeyPromptViewModel? capturedVm = null;
+            var service = new SshInteractionService(
+                hostKeyPresenter: (_, vm, _) =>
+                {
+                    capturedVm = vm;
+                    return Task.FromResult(SshInteractionResponse.AcceptHostKey());
+                },
+                knownHostsStore: knownHosts);
+
+            var response = await service.HandleAsync(new SshInteractionRequest
+            {
+                Kind = SshInteractionKind.UnknownHostKey,
+                Host = "example.internal",
+                Port = 22,
+                Algorithm = "ssh-ed25519",
+                Fingerprint = "SHA256:new"
+            }, CancellationToken.None);
+
+            Assert.NotNull(capturedVm);
+            Assert.True(capturedVm!.IsChangedHostKey);
+            Assert.True(response.IsAccepted);
+            Assert.Equal(NativeKnownHostMatch.Trusted, knownHosts.CheckHost("example.internal", 22, "ssh-ed25519", "SHA256:new"));
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
     }
 
     [Fact]
@@ -114,5 +197,12 @@ public sealed class SshInteractionServiceTests
         Assert.Equal("Passcode:", capturedVm.Prompts[0].Prompt);
         Assert.True(capturedVm.Prompts[0].IsSecret);
         Assert.Equal(["code", "otp"], response.KeyboardResponses);
+    }
+
+    private static string CreateTempDirectory()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"nova_ssh_interaction_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
     }
 }


### PR DESCRIPTION
## Summary
- add a native known-host store and fingerprint normalization for the native SSH backend
- persist the app-side native known-hosts path and use it to auto-accept trusted keys or flag changed host keys
- add coverage for known-host persistence, session restore backend preservation, app paths, and SSH interaction flows

## Test Plan
- dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~Ssh" /nodeReuse:false
- dotnet test tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~AppPathsTests|FullyQualifiedName~SessionManagerTests|FullyQualifiedName~SshInteractionServiceTests|FullyQualifiedName~SshConnectionServiceTests|FullyQualifiedName~NewSshConnectionViewModelTests|FullyQualifiedName~SshManagerViewModelTests|FullyQualifiedName~SshLegacyProfileMigrationTests" /nodeReuse:false
- dotnet build src\NovaTerminal.App\NovaTerminal.App.csproj -c Release -p:SKIP_RUST_NATIVE_BUILD=1 /nodeReuse:false
