### PR TITLE
Add native SSH local port forwarding

### DIFF
--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -3,12 +3,13 @@ use russh::client::{self, AuthResult, KeyboardInteractiveAuthResponse};
 use russh::keys::{load_secret_key, ssh_key, PrivateKeyWithHashAlg};
 use russh::{ChannelMsg, Disconnect};
 use serde::Serialize;
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::ffi::CStr;
 use std::future::Future;
+use std::io::Cursor;
 use std::path::Path;
 use std::ptr;
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Condvar, Mutex, mpsc as std_mpsc};
 use std::thread;
 use std::time::Duration;
 use tokio::runtime::Builder;
@@ -35,6 +36,15 @@ pub struct NovaSshConnectArgs {
     pub identity_file: *const c_char,
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NovaSshDirectTcpIpArgs {
+    pub host_to_connect: *const c_char,
+    pub port_to_connect: u16,
+    pub originator_address: *const c_char,
+    pub originator_port: u16,
+}
+
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum NovaSshEventKind {
@@ -48,6 +58,9 @@ pub enum NovaSshEventKind {
     ExitStatus = 7,
     Error = 8,
     Closed = 9,
+    ForwardChannelData = 10,
+    ForwardChannelEof = 11,
+    ForwardChannelClosed = 12,
 }
 
 #[repr(u32)]
@@ -64,6 +77,7 @@ pub const NOVA_SSH_RESULT_EVENT_READY: c_int = 1;
 pub const NOVA_SSH_RESULT_INVALID_ARGUMENT: c_int = -1;
 pub const NOVA_SSH_RESULT_BUFFER_TOO_SMALL: c_int = -2;
 pub const NOVA_SSH_RESULT_CLOSED: c_int = -3;
+pub const NOVA_SSH_RESULT_CHANNEL_OPEN_FAILED: c_int = -4;
 
 const NOVA_SSH_EVENT_FLAG_JSON: u32 = 1;
 const NOVA_SSH_EVENT_FLAG_BINARY: u32 = 2;
@@ -96,6 +110,23 @@ struct QueuedResponse {
 enum WorkerCommand {
     Write(Vec<u8>),
     Resize { cols: u16, rows: u16 },
+    OpenDirectTcpIp {
+        host_to_connect: String,
+        port_to_connect: u32,
+        originator_address: String,
+        originator_port: u32,
+        reply: std_mpsc::Sender<anyhow::Result<u32>>,
+    },
+    WriteForwardChannel {
+        channel_id: u32,
+        data: Vec<u8>,
+    },
+    ForwardChannelEof {
+        channel_id: u32,
+    },
+    CloseForwardChannel {
+        channel_id: u32,
+    },
     Close,
 }
 
@@ -420,6 +451,118 @@ pub extern "C" fn nova_ssh_resize(
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn nova_ssh_open_direct_tcpip(
+    session: *mut NovaSshSession,
+    args: *const NovaSshDirectTcpIpArgs,
+) -> c_int {
+    if session.is_null() || args.is_null() {
+        return NOVA_SSH_RESULT_INVALID_ARGUMENT;
+    }
+
+    let args = unsafe { args.as_ref() }.expect("validated non-null args");
+    let host_to_connect = match read_c_string(args.host_to_connect) {
+        Some(value) => value,
+        None => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
+    };
+    let originator_address =
+        read_c_string(args.originator_address).unwrap_or_else(|| "127.0.0.1".to_owned());
+
+    let session = unsafe { &mut *session };
+    let tx = match &session.command_tx {
+        Some(sender) => sender,
+        None => return NOVA_SSH_RESULT_CLOSED,
+    };
+
+    let (reply_tx, reply_rx) = std_mpsc::channel();
+    let command = WorkerCommand::OpenDirectTcpIp {
+        host_to_connect,
+        port_to_connect: if args.port_to_connect == 0 {
+            0
+        } else {
+            args.port_to_connect as u32
+        },
+        originator_address,
+        originator_port: args.originator_port as u32,
+        reply: reply_tx,
+    };
+
+    if tx.send(command).is_err() {
+        return NOVA_SSH_RESULT_CLOSED;
+    }
+
+    match reply_rx.recv() {
+        Ok(Ok(channel_id)) => channel_id as c_int,
+        Ok(Err(_)) => NOVA_SSH_RESULT_CHANNEL_OPEN_FAILED,
+        Err(_) => NOVA_SSH_RESULT_CLOSED,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn nova_ssh_channel_write(
+    session: *mut NovaSshSession,
+    channel_id: u32,
+    data: *const u8,
+    data_len: usize,
+) -> c_int {
+    if session.is_null() || (data.is_null() && data_len != 0) {
+        return NOVA_SSH_RESULT_INVALID_ARGUMENT;
+    }
+
+    let session = unsafe { &mut *session };
+    let tx = match &session.command_tx {
+        Some(sender) => sender,
+        None => return NOVA_SSH_RESULT_CLOSED,
+    };
+
+    let bytes = if data_len == 0 {
+        Vec::new()
+    } else {
+        unsafe { std::slice::from_raw_parts(data, data_len) }.to_vec()
+    };
+
+    tx.send(WorkerCommand::WriteForwardChannel {
+        channel_id,
+        data: bytes,
+    })
+    .map(|_| NOVA_SSH_RESULT_OK)
+    .unwrap_or(NOVA_SSH_RESULT_CLOSED)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn nova_ssh_channel_eof(session: *mut NovaSshSession, channel_id: u32) -> c_int {
+    if session.is_null() {
+        return NOVA_SSH_RESULT_INVALID_ARGUMENT;
+    }
+
+    let session = unsafe { &mut *session };
+    let tx = match &session.command_tx {
+        Some(sender) => sender,
+        None => return NOVA_SSH_RESULT_CLOSED,
+    };
+
+    tx.send(WorkerCommand::ForwardChannelEof { channel_id })
+        .map(|_| NOVA_SSH_RESULT_OK)
+        .unwrap_or(NOVA_SSH_RESULT_CLOSED)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn nova_ssh_channel_close(session: *mut NovaSshSession, channel_id: u32) -> c_int {
+    if session.is_null() {
+        return NOVA_SSH_RESULT_INVALID_ARGUMENT;
+    }
+
+    let session = unsafe { &mut *session };
+    let tx = match &session.command_tx {
+        Some(sender) => sender,
+        None => return NOVA_SSH_RESULT_CLOSED,
+    };
+
+    tx.send(WorkerCommand::CloseForwardChannel { channel_id })
+        .map(|_| NOVA_SSH_RESULT_OK)
+        .unwrap_or(NOVA_SSH_RESULT_CLOSED)
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn nova_ssh_submit_response(
     session: *mut NovaSshSession,
     response_kind: u32,
@@ -514,6 +657,7 @@ fn run_session(
 ) -> anyhow::Result<()> {
     let runtime = Builder::new_current_thread().enable_all().build()?;
     runtime.block_on(async move {
+        let forward_channels = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
         let client_config = Arc::new(client::Config {
             inactivity_timeout: Some(Duration::from_secs(30)),
             ..<_>::default()
@@ -565,7 +709,36 @@ fn run_session(
                         Some(WorkerCommand::Resize { cols, rows }) => {
                             channel.window_change(cols as u32, rows as u32, 0, 0).await?;
                         }
+                        Some(WorkerCommand::OpenDirectTcpIp {
+                            host_to_connect,
+                            port_to_connect,
+                            originator_address,
+                            originator_port,
+                            reply,
+                        }) => {
+                            let result = open_direct_tcpip_channel(
+                                &session,
+                                forward_channels.clone(),
+                                shared.clone(),
+                                host_to_connect,
+                                port_to_connect,
+                                originator_address,
+                                originator_port,
+                            )
+                            .await;
+                            let _ = reply.send(result);
+                        }
+                        Some(WorkerCommand::WriteForwardChannel { channel_id, data }) => {
+                            write_forward_channel(forward_channels.clone(), channel_id, data).await?;
+                        }
+                        Some(WorkerCommand::ForwardChannelEof { channel_id }) => {
+                            send_forward_channel_eof(forward_channels.clone(), channel_id).await?;
+                        }
+                        Some(WorkerCommand::CloseForwardChannel { channel_id }) => {
+                            close_forward_channel(forward_channels.clone(), channel_id).await?;
+                        }
                         Some(WorkerCommand::Close) | None => {
+                            close_all_forward_channels(forward_channels.clone()).await;
                             let _ = channel.eof().await;
                             let _ = channel.close().await;
                             break;
@@ -612,6 +785,136 @@ fn run_session(
             .await;
         Ok(())
     })
+}
+
+async fn open_direct_tcpip_channel(
+    session: &client::Handle<NovaClientHandler>,
+    forward_channels: Arc<tokio::sync::Mutex<HashMap<u32, Arc<russh::ChannelWriteHalf<client::Msg>>>>>,
+    shared: Arc<SharedState>,
+    host_to_connect: String,
+    port_to_connect: u32,
+    originator_address: String,
+    originator_port: u32,
+) -> anyhow::Result<u32> {
+    let channel = session
+        .channel_open_direct_tcpip(
+            host_to_connect,
+            port_to_connect,
+            originator_address,
+            originator_port,
+        )
+        .await?;
+
+    let channel_id = u32::from(channel.id());
+    let (mut read_half, write_half) = channel.split();
+    forward_channels
+        .lock()
+        .await
+        .insert(channel_id, Arc::new(write_half));
+
+    let reader_shared = shared.clone();
+    let reader_channels = forward_channels.clone();
+    tokio::spawn(async move {
+        loop {
+            match read_half.wait().await {
+                Some(ChannelMsg::Data { data }) => {
+                    reader_shared.queue_event(QueuedEvent {
+                        kind: NovaSshEventKind::ForwardChannelData,
+                        payload: data.to_vec(),
+                        status_code: channel_id as i32,
+                        flags: NOVA_SSH_EVENT_FLAG_BINARY,
+                    });
+                }
+                Some(ChannelMsg::ExtendedData { data, .. }) => {
+                    reader_shared.queue_event(QueuedEvent {
+                        kind: NovaSshEventKind::ForwardChannelData,
+                        payload: data.to_vec(),
+                        status_code: channel_id as i32,
+                        flags: NOVA_SSH_EVENT_FLAG_BINARY,
+                    });
+                }
+                Some(ChannelMsg::Eof) => {
+                    reader_shared.queue_event(QueuedEvent {
+                        kind: NovaSshEventKind::ForwardChannelEof,
+                        payload: Vec::new(),
+                        status_code: channel_id as i32,
+                        flags: NOVA_SSH_EVENT_FLAG_JSON,
+                    });
+                }
+                Some(ChannelMsg::Close) | None => {
+                    reader_channels.lock().await.remove(&channel_id);
+                    reader_shared.queue_event(QueuedEvent {
+                        kind: NovaSshEventKind::ForwardChannelClosed,
+                        payload: Vec::new(),
+                        status_code: channel_id as i32,
+                        flags: NOVA_SSH_EVENT_FLAG_JSON,
+                    });
+                    break;
+                }
+                _ => {}
+            }
+        }
+    });
+
+    Ok(channel_id)
+}
+
+async fn write_forward_channel(
+    forward_channels: Arc<tokio::sync::Mutex<HashMap<u32, Arc<russh::ChannelWriteHalf<client::Msg>>>>>,
+    channel_id: u32,
+    data: Vec<u8>,
+) -> anyhow::Result<()> {
+    let writer = {
+        let channels = forward_channels.lock().await;
+        channels.get(&channel_id).cloned()
+    };
+
+    if let Some(writer) = writer {
+        writer.data(Cursor::new(data)).await?;
+    }
+
+    Ok(())
+}
+
+async fn send_forward_channel_eof(
+    forward_channels: Arc<tokio::sync::Mutex<HashMap<u32, Arc<russh::ChannelWriteHalf<client::Msg>>>>>,
+    channel_id: u32,
+) -> anyhow::Result<()> {
+    let writer = {
+        let channels = forward_channels.lock().await;
+        channels.get(&channel_id).cloned()
+    };
+
+    if let Some(writer) = writer {
+        writer.eof().await?;
+    }
+
+    Ok(())
+}
+
+async fn close_forward_channel(
+    forward_channels: Arc<tokio::sync::Mutex<HashMap<u32, Arc<russh::ChannelWriteHalf<client::Msg>>>>>,
+    channel_id: u32,
+) -> anyhow::Result<()> {
+    let writer = forward_channels.lock().await.remove(&channel_id);
+    if let Some(writer) = writer {
+        writer.close().await?;
+    }
+
+    Ok(())
+}
+
+async fn close_all_forward_channels(
+    forward_channels: Arc<tokio::sync::Mutex<HashMap<u32, Arc<russh::ChannelWriteHalf<client::Msg>>>>>,
+) {
+    let writers = {
+        let mut channels = forward_channels.lock().await;
+        channels.drain().map(|(_, writer)| writer).collect::<Vec<_>>()
+    };
+
+    for writer in writers {
+        let _ = writer.close().await;
+    }
 }
 
 async fn authenticate(
@@ -769,11 +1072,25 @@ mod tests {
     fn null_handle_operations_return_invalid_argument() {
         let resize = nova_ssh_resize(ptr::null_mut(), 120, 30);
         let write = nova_ssh_write(ptr::null_mut(), [1u8, 2, 3].as_ptr(), 3);
+        let forward_args = NovaSshDirectTcpIpArgs {
+            host_to_connect: ptr::null(),
+            port_to_connect: 80,
+            originator_address: ptr::null(),
+            originator_port: 1000,
+        };
+        let open = nova_ssh_open_direct_tcpip(ptr::null_mut(), &forward_args);
+        let channel_write = nova_ssh_channel_write(ptr::null_mut(), 1, [1u8, 2, 3].as_ptr(), 3);
+        let channel_eof = nova_ssh_channel_eof(ptr::null_mut(), 1);
+        let channel_close = nova_ssh_channel_close(ptr::null_mut(), 1);
         let respond = nova_ssh_submit_response(ptr::null_mut(), 1, br#"{}"#.as_ptr(), 2);
         let close = nova_ssh_close(ptr::null_mut());
 
         assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, resize);
         assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, write);
+        assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, open);
+        assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, channel_write);
+        assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, channel_eof);
+        assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, channel_close);
         assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, respond);
         assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, close);
     }

--- a/src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs
@@ -6,6 +6,10 @@ public interface INativeSshInterop
     NativeSshEvent? PollEvent(IntPtr sessionHandle);
     void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data);
     void Resize(IntPtr sessionHandle, int cols, int rows);
+    int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options);
+    void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data);
+    void SendChannelEof(IntPtr sessionHandle, int channelId);
+    void CloseChannel(IntPtr sessionHandle, int channelId);
     void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data);
     void Close(IntPtr sessionHandle);
 }

--- a/src/NovaTerminal.Core/Ssh/Native/NativePortForwardSession.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativePortForwardSession.cs
@@ -1,0 +1,297 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+using NovaTerminal.Core.Ssh.Models;
+
+namespace NovaTerminal.Core.Ssh.Native;
+
+public sealed class NativePortForwardSession : IDisposable
+{
+    private readonly IntPtr _sessionHandle;
+    private readonly INativeSshInterop _interop;
+    private readonly Action<string> _log;
+    private readonly CancellationTokenSource _lifetimeCts = new();
+    private readonly List<TcpListener> _listeners = [];
+    private readonly ConcurrentDictionary<int, ForwardChannelState> _channels = new();
+    private int _disposed;
+
+    public NativePortForwardSession(
+        IntPtr sessionHandle,
+        IReadOnlyList<PortForward> forwards,
+        INativeSshInterop interop,
+        Action<string>? log = null)
+    {
+        if (sessionHandle == IntPtr.Zero)
+        {
+            throw new ArgumentException("Native port forwarding requires a valid SSH session handle.", nameof(sessionHandle));
+        }
+
+        ArgumentNullException.ThrowIfNull(forwards);
+        ArgumentNullException.ThrowIfNull(interop);
+
+        _sessionHandle = sessionHandle;
+        _interop = interop;
+        _log = log ?? (_ => { });
+
+        try
+        {
+            foreach (PortForward forward in forwards)
+            {
+                if (forward.Kind != PortForwardKind.Local)
+                {
+                    throw new NotSupportedException("Native SSH currently supports local port forwards only.");
+                }
+
+                StartListener(forward);
+            }
+        }
+        catch
+        {
+            Dispose();
+            throw;
+        }
+    }
+
+    public void HandleEvent(NativeSshEvent nextEvent)
+    {
+        if (nextEvent == null)
+        {
+            return;
+        }
+
+        if (!_channels.TryGetValue(nextEvent.StatusCode, out ForwardChannelState? channel))
+        {
+            return;
+        }
+
+        try
+        {
+            switch (nextEvent.Kind)
+            {
+                case NativeSshEventKind.ForwardChannelData:
+                    channel.Stream.Write(nextEvent.Payload, 0, nextEvent.Payload.Length);
+                    break;
+                case NativeSshEventKind.ForwardChannelEof:
+                    TryShutdown(channel.Client, SocketShutdown.Send);
+                    break;
+                case NativeSshEventKind.ForwardChannelClosed:
+                    RemoveChannel(channel.ChannelId, closeInteropChannel: false);
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            _log($"[NativePortForwardSession] Forward channel {channel.ChannelId} failed: {ex.Message}");
+            RemoveChannel(channel.ChannelId, closeInteropChannel: true);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        _lifetimeCts.Cancel();
+
+        foreach (TcpListener listener in _listeners)
+        {
+            try
+            {
+                listener.Stop();
+            }
+            catch
+            {
+            }
+        }
+
+        foreach (int channelId in _channels.Keys.ToArray())
+        {
+            RemoveChannel(channelId, closeInteropChannel: true);
+        }
+
+        _lifetimeCts.Dispose();
+    }
+
+    private void StartListener(PortForward forward)
+    {
+        IPAddress address = ResolveBindAddress(forward.BindAddress);
+        var listener = new TcpListener(address, forward.SourcePort);
+
+        try
+        {
+            listener.Start();
+        }
+        catch (Exception ex)
+        {
+            // Startup policy for Task 6: fail the entire native session setup on any bind error.
+            throw new InvalidOperationException(
+                $"Failed to bind local forward {address}:{forward.SourcePort} -> {forward.DestinationHost}:{forward.DestinationPort}: {ex.Message}",
+                ex);
+        }
+
+        _listeners.Add(listener);
+        _ = Task.Run(() => AcceptLoopAsync(listener, forward, _lifetimeCts.Token));
+    }
+
+    private async Task AcceptLoopAsync(TcpListener listener, PortForward forward, CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            TcpClient? client = null;
+
+            try
+            {
+                client = await listener.AcceptTcpClientAsync(cancellationToken).ConfigureAwait(false);
+                IPEndPoint remoteEndPoint = (IPEndPoint)(client.Client.RemoteEndPoint ?? new IPEndPoint(IPAddress.Loopback, 0));
+                int channelId = _interop.OpenDirectTcpIp(
+                    _sessionHandle,
+                    new NativePortForwardOpenOptions
+                    {
+                        HostToConnect = forward.DestinationHost,
+                        PortToConnect = forward.DestinationPort,
+                        OriginatorAddress = remoteEndPoint.Address.ToString(),
+                        OriginatorPort = remoteEndPoint.Port
+                    });
+
+                var state = new ForwardChannelState(channelId, client);
+                if (!_channels.TryAdd(channelId, state))
+                {
+                    client.Dispose();
+                    _interop.CloseChannel(_sessionHandle, channelId);
+                    continue;
+                }
+
+                _ = Task.Run(() => PumpClientToSshAsync(state, cancellationToken));
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                client?.Dispose();
+                break;
+            }
+            catch (ObjectDisposedException) when (cancellationToken.IsCancellationRequested)
+            {
+                client?.Dispose();
+                break;
+            }
+            catch (Exception ex)
+            {
+                client?.Dispose();
+                _log($"[NativePortForwardSession] Accept loop for {forward} failed: {ex.Message}");
+            }
+        }
+    }
+
+    private async Task PumpClientToSshAsync(ForwardChannelState channel, CancellationToken cancellationToken)
+    {
+        byte[] buffer = new byte[16 * 1024];
+
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                int bytesRead = await channel.Stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+                if (bytesRead == 0)
+                {
+                    break;
+                }
+
+                _interop.WriteChannel(_sessionHandle, channel.ChannelId, buffer.AsSpan(0, bytesRead));
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (IOException)
+        {
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+        catch (Exception ex)
+        {
+            _log($"[NativePortForwardSession] Local socket pump for channel {channel.ChannelId} failed: {ex.Message}");
+        }
+        finally
+        {
+            try
+            {
+                _interop.SendChannelEof(_sessionHandle, channel.ChannelId);
+            }
+            catch (Exception ex)
+            {
+                _log($"[NativePortForwardSession] Failed to send EOF for channel {channel.ChannelId}: {ex.Message}");
+            }
+        }
+    }
+
+    private void RemoveChannel(int channelId, bool closeInteropChannel)
+    {
+        if (!_channels.TryRemove(channelId, out ForwardChannelState? channel))
+        {
+            return;
+        }
+
+        if (closeInteropChannel)
+        {
+            try
+            {
+                _interop.CloseChannel(_sessionHandle, channelId);
+            }
+            catch (Exception ex)
+            {
+                _log($"[NativePortForwardSession] Failed to close channel {channelId}: {ex.Message}");
+            }
+        }
+
+        try
+        {
+            channel.Client.Dispose();
+        }
+        catch
+        {
+        }
+    }
+
+    private static IPAddress ResolveBindAddress(string? bindAddress)
+    {
+        if (string.IsNullOrWhiteSpace(bindAddress) || bindAddress == "localhost")
+        {
+            return IPAddress.Loopback;
+        }
+
+        if (IPAddress.TryParse(bindAddress, out IPAddress? parsed))
+        {
+            return parsed;
+        }
+
+        IPAddress[] addresses = Dns.GetHostAddresses(bindAddress);
+        return addresses.First(address => address.AddressFamily is AddressFamily.InterNetwork or AddressFamily.InterNetworkV6);
+    }
+
+    private static void TryShutdown(TcpClient client, SocketShutdown how)
+    {
+        try
+        {
+            client.Client.Shutdown(how);
+        }
+        catch
+        {
+        }
+    }
+
+    private sealed class ForwardChannelState
+    {
+        public ForwardChannelState(int channelId, TcpClient client)
+        {
+            ChannelId = channelId;
+            Client = client;
+            Stream = client.GetStream();
+        }
+
+        public int ChannelId { get; }
+        public TcpClient Client { get; }
+        public NetworkStream Stream { get; }
+    }
+}

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshEvent.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshEvent.cs
@@ -19,7 +19,10 @@ public enum NativeSshEventKind
     KeyboardInteractivePrompt = 6,
     ExitStatus = 7,
     Error = 8,
-    Closed = 9
+    Closed = 9,
+    ForwardChannelData = 10,
+    ForwardChannelEof = 11,
+    ForwardChannelClosed = 12
 }
 
 public enum NativeSshResponseKind
@@ -57,4 +60,13 @@ public sealed class NativeSshEvent
 
     public static NativeSshEvent Closed(byte[]? payload = null) =>
         new(NativeSshEventKind.Closed, payload ?? Array.Empty<byte>(), flags: NativeSshEventFlags.Json);
+
+    public static NativeSshEvent ForwardChannelData(int channelId, byte[] payload) =>
+        new(NativeSshEventKind.ForwardChannelData, payload, channelId, NativeSshEventFlags.Binary);
+
+    public static NativeSshEvent ForwardChannelEof(int channelId) =>
+        new(NativeSshEventKind.ForwardChannelEof, Array.Empty<byte>(), channelId, NativeSshEventFlags.Json);
+
+    public static NativeSshEvent ForwardChannelClosed(int channelId) =>
+        new(NativeSshEventKind.ForwardChannelClosed, Array.Empty<byte>(), channelId, NativeSshEventFlags.Json);
 }

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
@@ -9,6 +9,7 @@ public sealed class NativeSshInterop : INativeSshInterop
     private const int ResultEventReady = 1;
     private const int ResultInvalidArgument = -1;
     private const int ResultBufferTooSmall = -2;
+    private const int ResultClosed = -3;
 
     public IntPtr Connect(NativeSshConnectionOptions options)
     {
@@ -127,6 +128,95 @@ public sealed class NativeSshInterop : INativeSshInterop
         throw new InvalidOperationException($"Native SSH resize failed with result {rc}.");
     }
 
+    public int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (sessionHandle == IntPtr.Zero)
+        {
+            throw new InvalidOperationException("Cannot open a native port-forward channel without a session handle.");
+        }
+
+        IntPtr hostPtr = IntPtr.Zero;
+        IntPtr originatorPtr = IntPtr.Zero;
+
+        try
+        {
+            hostPtr = Marshal.StringToCoTaskMemUTF8(options.HostToConnect);
+            originatorPtr = Marshal.StringToCoTaskMemUTF8(options.OriginatorAddress);
+
+            NativeDirectTcpIpOpenArgs args = new()
+            {
+                HostToConnect = hostPtr,
+                PortToConnect = checked((ushort)options.PortToConnect),
+                OriginatorAddress = originatorPtr,
+                OriginatorPort = checked((ushort)options.OriginatorPort)
+            };
+
+            int channelId = NativeMethods.nova_ssh_open_direct_tcpip(sessionHandle, in args);
+            if (channelId >= 0)
+            {
+                return channelId;
+            }
+
+            throw new InvalidOperationException($"Native SSH direct-tcpip open failed with result {channelId}.");
+        }
+        finally
+        {
+            FreeUtf8(hostPtr);
+            FreeUtf8(originatorPtr);
+        }
+    }
+
+    public void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data)
+    {
+        if (sessionHandle == IntPtr.Zero || channelId < 0)
+        {
+            return;
+        }
+
+        byte[] payload = data.ToArray();
+        int rc = NativeMethods.nova_ssh_channel_write(sessionHandle, checked((uint)channelId), payload, (nuint)payload.Length);
+        if (rc is ResultOk or ResultInvalidArgument or ResultClosed)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException($"Native SSH channel write failed with result {rc}.");
+    }
+
+    public void SendChannelEof(IntPtr sessionHandle, int channelId)
+    {
+        if (sessionHandle == IntPtr.Zero || channelId < 0)
+        {
+            return;
+        }
+
+        int rc = NativeMethods.nova_ssh_channel_eof(sessionHandle, checked((uint)channelId));
+        if (rc is ResultOk or ResultInvalidArgument or ResultClosed)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException($"Native SSH channel EOF failed with result {rc}.");
+    }
+
+    public void CloseChannel(IntPtr sessionHandle, int channelId)
+    {
+        if (sessionHandle == IntPtr.Zero || channelId < 0)
+        {
+            return;
+        }
+
+        int rc = NativeMethods.nova_ssh_channel_close(sessionHandle, checked((uint)channelId));
+        if (rc is ResultOk or ResultInvalidArgument or ResultClosed)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException($"Native SSH channel close failed with result {rc}.");
+    }
+
     public void Close(IntPtr sessionHandle)
     {
         if (sessionHandle == IntPtr.Zero)
@@ -189,6 +279,15 @@ public sealed class NativeSshInterop : INativeSshInterop
         public uint Flags;
     }
 
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NativeDirectTcpIpOpenArgs
+    {
+        public IntPtr HostToConnect;
+        public ushort PortToConnect;
+        public IntPtr OriginatorAddress;
+        public ushort OriginatorPort;
+    }
+
     private static class NativeMethods
     {
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_connect")]
@@ -202,6 +301,18 @@ public sealed class NativeSshInterop : INativeSshInterop
 
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_resize")]
         public static extern int nova_ssh_resize(IntPtr session, ushort cols, ushort rows);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_open_direct_tcpip")]
+        public static extern int nova_ssh_open_direct_tcpip(IntPtr session, in NativeDirectTcpIpOpenArgs args);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_channel_write")]
+        public static extern int nova_ssh_channel_write(IntPtr session, uint channelId, byte[] data, nuint dataLength);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_channel_eof")]
+        public static extern int nova_ssh_channel_eof(IntPtr session, uint channelId);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_channel_close")]
+        public static extern int nova_ssh_channel_close(IntPtr session, uint channelId);
 
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_close")]
         public static extern int nova_ssh_close(IntPtr session);

--- a/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
@@ -21,6 +21,7 @@ public sealed class NativeSshSession : ITerminalSession
 
     private ReplayWriter? _recorder;
     private TerminalBuffer? _buffer;
+    private NativePortForwardSession? _portForwardSession;
     private IntPtr _sessionHandle;
     private int _cols;
     private int _rows;
@@ -40,9 +41,14 @@ public sealed class NativeSshSession : ITerminalSession
     {
         ArgumentNullException.ThrowIfNull(profile);
 
-        if (profile.JumpHops.Count != 0 || profile.Forwards.Count != 0)
+        if (profile.JumpHops.Count != 0)
         {
-            throw new NotSupportedException("Native SSH backend does not support jump hops or port forwards yet.");
+            throw new NotSupportedException("Native SSH backend does not support jump hops yet.");
+        }
+
+        if (profile.Forwards.Any(forward => forward.Kind != PortForwardKind.Local))
+        {
+            throw new NotSupportedException("Native SSH backend currently supports local port forwards only.");
         }
 
         _ = diagnosticsLevel;
@@ -53,9 +59,24 @@ public sealed class NativeSshSession : ITerminalSession
         _interop = interop ?? new NativeSshInterop();
         _interactionHandler = interactionHandler;
         _sessionHandle = _interop.Connect(NativeSshConnectionOptions.FromProfile(profile, cols, rows));
-        _isRunning = 1;
-        ShellArguments = $"{profile.User}@{profile.Host}:{profile.Port}";
-        _pollTask = Task.Run(PollLoopAsync);
+
+        try
+        {
+            if (profile.Forwards.Count != 0)
+            {
+                _portForwardSession = new NativePortForwardSession(_sessionHandle, profile.Forwards, _interop, _log);
+            }
+
+            _isRunning = 1;
+            ShellArguments = $"{profile.User}@{profile.Host}:{profile.Port}";
+            _pollTask = Task.Run(PollLoopAsync);
+        }
+        catch
+        {
+            CloseNativeHandle();
+            _pollCts.Dispose();
+            throw;
+        }
     }
 
     public Guid Id { get; } = Guid.NewGuid();
@@ -145,6 +166,7 @@ public sealed class NativeSshSession : ITerminalSession
     {
         StopRecording();
         _pollCts.Cancel();
+        _portForwardSession?.Dispose();
         CloseNativeHandle();
         try
         {
@@ -176,6 +198,11 @@ public sealed class NativeSshSession : ITerminalSession
                 {
                     case NativeSshEventKind.Data:
                         EmitOutput(nextEvent.Payload);
+                        break;
+                    case NativeSshEventKind.ForwardChannelData:
+                    case NativeSshEventKind.ForwardChannelEof:
+                    case NativeSshEventKind.ForwardChannelClosed:
+                        _portForwardSession?.HandleEvent(nextEvent);
                         break;
                     case NativeSshEventKind.ExitStatus:
                         TryNotifyExit(nextEvent.StatusCode);

--- a/src/NovaTerminal.Core/Ssh/Transport/PortForwardModels.cs
+++ b/src/NovaTerminal.Core/Ssh/Transport/PortForwardModels.cs
@@ -1,0 +1,9 @@
+namespace NovaTerminal.Core.Ssh.Native;
+
+public sealed class NativePortForwardOpenOptions
+{
+    public required string HostToConnect { get; init; }
+    public int PortToConnect { get; init; }
+    public string OriginatorAddress { get; init; } = "127.0.0.1";
+    public int OriginatorPort { get; init; }
+}

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativePortForwardSessionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativePortForwardSessionTests.cs
@@ -1,0 +1,203 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+using NovaTerminal.Core.Ssh.Models;
+using NovaTerminal.Core.Ssh.Native;
+
+namespace NovaTerminal.Core.Tests.Ssh;
+
+public sealed class NativePortForwardSessionTests
+{
+    [Fact]
+    public async Task LocalForwardListenersBindFromConfiguredForwards()
+    {
+        var interop = new FakeNativeSshInterop();
+        int firstPort = GetFreePort();
+        int secondPort = GetFreePort();
+
+        using var session = new NativePortForwardSession(
+            new IntPtr(7),
+            [
+                CreateForward(firstPort, "svc-one.internal", 8080),
+                CreateForward(secondPort, "svc-two.internal", 9090)
+            ],
+            interop);
+
+        using TcpClient firstClient = await ConnectLoopbackAsync(firstPort);
+        using TcpClient secondClient = await ConnectLoopbackAsync(secondPort);
+
+        await WaitUntilAsync(() => interop.OpenRequests.Count == 2);
+
+        Assert.Contains(interop.OpenRequests, request =>
+            request.HostToConnect == "svc-one.internal" &&
+            request.PortToConnect == 8080 &&
+            request.OriginatorAddress == "127.0.0.1" &&
+            request.OriginatorPort > 0);
+        Assert.Contains(interop.OpenRequests, request =>
+            request.HostToConnect == "svc-two.internal" &&
+            request.PortToConnect == 9090 &&
+            request.OriginatorAddress == "127.0.0.1" &&
+            request.OriginatorPort > 0);
+    }
+
+    [Fact]
+    public async Task MultipleForwardConnectionsCanCoexist()
+    {
+        var interop = new FakeNativeSshInterop();
+        int listenPort = GetFreePort();
+
+        using var session = new NativePortForwardSession(
+            new IntPtr(9),
+            [CreateForward(listenPort, "svc.internal", 7000)],
+            interop);
+
+        using TcpClient firstClient = await ConnectLoopbackAsync(listenPort);
+        using TcpClient secondClient = await ConnectLoopbackAsync(listenPort);
+
+        await WaitUntilAsync(() => interop.OpenRequests.Count == 2);
+        Assert.Equal(2, interop.OpenRequests.Count);
+    }
+
+    [Fact]
+    public async Task DisposeClosesForwardChannelsAndListeners()
+    {
+        var interop = new FakeNativeSshInterop();
+        int listenPort = GetFreePort();
+
+        var session = new NativePortForwardSession(
+            new IntPtr(11),
+            [CreateForward(listenPort, "svc.internal", 5432)],
+            interop);
+
+        using TcpClient client = await ConnectLoopbackAsync(listenPort);
+        await WaitUntilAsync(() => interop.OpenRequests.Count == 1);
+
+        session.Dispose();
+
+        await WaitUntilAsync(() => interop.ClosedChannelIds.Count == 1);
+        Assert.Single(interop.ClosedChannelIds);
+        await Assert.ThrowsAnyAsync<SocketException>(() => ConnectLoopbackAsync(listenPort));
+    }
+
+    [Fact]
+    public void Constructor_WhenAnyBindFails_ThrowsDeterministicallyAndCleansUpEarlierListeners()
+    {
+        int firstPort = GetFreePort();
+        int occupiedPort = GetFreePort();
+        using var occupied = new TcpListener(IPAddress.Loopback, occupiedPort);
+        occupied.Start();
+
+        var interop = new FakeNativeSshInterop();
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() =>
+            new NativePortForwardSession(
+                new IntPtr(13),
+                [
+                    CreateForward(firstPort, "svc-one.internal", 80),
+                    CreateForward(occupiedPort, "svc-two.internal", 81)
+                ],
+                interop));
+
+        Assert.Contains(occupiedPort.ToString(), ex.Message, StringComparison.Ordinal);
+
+        using var probe = new TcpListener(IPAddress.Loopback, firstPort);
+        probe.Start();
+    }
+
+    private static PortForward CreateForward(int sourcePort, string destinationHost, int destinationPort)
+    {
+        return new PortForward
+        {
+            Kind = PortForwardKind.Local,
+            BindAddress = "127.0.0.1",
+            SourcePort = sourcePort,
+            DestinationHost = destinationHost,
+            DestinationPort = destinationPort
+        };
+    }
+
+    private static async Task<TcpClient> ConnectLoopbackAsync(int port)
+    {
+        var client = new TcpClient();
+        await client.ConnectAsync(IPAddress.Loopback, port);
+        return client;
+    }
+
+    private static int GetFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> predicate)
+    {
+        DateTime deadline = DateTime.UtcNow.AddSeconds(3);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (predicate())
+            {
+                return;
+            }
+
+            await Task.Delay(20);
+        }
+
+        Assert.True(predicate(), "Condition was not met before timeout.");
+    }
+
+    private sealed class FakeNativeSshInterop : INativeSshInterop
+    {
+        private readonly ConcurrentQueue<NativeSshEvent> _events = new();
+        private int _nextChannelId = 100;
+
+        public List<NativePortForwardOpenOptions> OpenRequests { get; } = [];
+        public List<int> ClosedChannelIds { get; } = [];
+
+        public IntPtr Connect(NativeSshConnectionOptions options) => new(1);
+
+        public NativeSshEvent? PollEvent(IntPtr sessionHandle)
+        {
+            return _events.TryDequeue(out NativeSshEvent? nextEvent)
+                ? nextEvent
+                : null;
+        }
+
+        public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data)
+        {
+        }
+
+        public void Resize(IntPtr sessionHandle, int cols, int rows)
+        {
+        }
+
+        public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data)
+        {
+        }
+
+        public int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options)
+        {
+            OpenRequests.Add(options);
+            return Interlocked.Increment(ref _nextChannelId);
+        }
+
+        public void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data)
+        {
+        }
+
+        public void SendChannelEof(IntPtr sessionHandle, int channelId)
+        {
+        }
+
+        public void CloseChannel(IntPtr sessionHandle, int channelId)
+        {
+            ClosedChannelIds.Add(channelId);
+        }
+
+        public void Close(IntPtr sessionHandle)
+        {
+        }
+    }
+}

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionInteractionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionInteractionTests.cs
@@ -136,6 +136,20 @@ public sealed class NativeSshSessionInteractionTests
         {
         }
 
+        public int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options) => 1;
+
+        public void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data)
+        {
+        }
+
+        public void SendChannelEof(IntPtr sessionHandle, int channelId)
+        {
+        }
+
+        public void CloseChannel(IntPtr sessionHandle, int channelId)
+        {
+        }
+
         public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data)
         {
             Submissions.Add((responseKind, Encoding.UTF8.GetString(data)));

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
@@ -151,6 +151,23 @@ public sealed class NativeSshSessionTests
             Resizes.Add((cols, rows));
         }
 
+        public int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options)
+        {
+            return 1;
+        }
+
+        public void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data)
+        {
+        }
+
+        public void SendChannelEof(IntPtr sessionHandle, int channelId)
+        {
+        }
+
+        public void CloseChannel(IntPtr sessionHandle, int channelId)
+        {
+        }
+
         public void Close(IntPtr sessionHandle)
         {
             CloseCallCount++;

--- a/tests/NovaTerminal.Core.Tests/Ssh/SshSessionFactoryTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/SshSessionFactoryTests.cs
@@ -57,6 +57,20 @@ public sealed class SshSessionFactoryTests
         {
         }
 
+        public int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options) => 1;
+
+        public void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data)
+        {
+        }
+
+        public void SendChannelEof(IntPtr sessionHandle, int channelId)
+        {
+        }
+
+        public void CloseChannel(IntPtr sessionHandle, int channelId)
+        {
+        }
+
         public void Close(IntPtr sessionHandle)
         {
         }


### PR DESCRIPTION
## Summary
- add a native local port-forward session manager that binds listeners, opens direct-tcpip channels, and tears channels down with the SSH session
- extend the native SSH interop contract and Rust worker to open, write, EOF, and close forwarded channels over russh
- add lifecycle tests for listener binding, concurrent forwards, deterministic bind failure, and teardown behavior

## Test Plan
- dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~NativePortForwardSessionTests"
- dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~Ssh"
- cargo test --manifest-path src\NovaTerminal.App\native\rusty_ssh\Cargo.toml --release
- dotnet build src\NovaTerminal.App\NovaTerminal.App.csproj -c Release -p:SKIP_RUST_NATIVE_BUILD=1 /nodeReuse:false
