### PR TITLE
Add one-hop jump host support for native SSH

### DIFF
--- a/src/NovaTerminal.App/native/rusty_ssh/examples/smoke.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/examples/smoke.rs
@@ -42,6 +42,9 @@ fn main() {
         rows: 30,
         term: term.as_ptr(),
         identity_file: identity.as_ref().map_or(std::ptr::null(), |value| value.as_ptr()),
+        jump_host: std::ptr::null(),
+        jump_user: std::ptr::null(),
+        jump_port: 0,
     };
 
     let session = nova_ssh_connect(&connect_args);

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -34,6 +34,9 @@ pub struct NovaSshConnectArgs {
     pub rows: u16,
     pub term: *const c_char,
     pub identity_file: *const c_char,
+    pub jump_host: *const c_char,
+    pub jump_user: *const c_char,
+    pub jump_port: u16,
 }
 
 #[repr(C)]
@@ -139,6 +142,14 @@ struct ConnectConfig {
     rows: u16,
     term: String,
     identity_file: Option<String>,
+    jump_host: Option<JumpHostConfig>,
+}
+
+#[derive(Clone)]
+struct JumpHostConfig {
+    host: String,
+    user: String,
+    port: u16,
 }
 
 #[derive(Clone)]
@@ -624,6 +635,13 @@ impl ConnectConfig {
         let user = read_c_string(args.user)?;
         let term = read_c_string(args.term).unwrap_or_else(|| "xterm-256color".to_owned());
         let identity_file = read_c_string(args.identity_file);
+        let jump_host = read_c_string(args.jump_host);
+        let jump_user = read_c_string(args.jump_user);
+        let effective_jump_host = jump_host.map(|host| JumpHostConfig {
+            host,
+            user: jump_user.unwrap_or_else(|| user.clone()),
+            port: if args.jump_port == 0 { 22 } else { args.jump_port },
+        });
 
         Some(Self {
             host,
@@ -633,6 +651,7 @@ impl ConnectConfig {
             rows: if args.rows == 0 { 30 } else { args.rows },
             term,
             identity_file,
+            jump_host: effective_jump_host,
         })
     }
 }
@@ -663,16 +682,56 @@ fn run_session(
             ..<_>::default()
         });
 
+        let jump_session = if let Some(jump_host) = &config.jump_host {
+            let jump_handler = NovaClientHandler {
+                shared: shared.clone(),
+                host: jump_host.host.clone(),
+                port: jump_host.port,
+            };
+
+            let mut jump = client::connect(
+                client_config.clone(),
+                (jump_host.host.as_str(), jump_host.port),
+                jump_handler,
+            )
+            .await?;
+
+            authenticate(
+                &jump_host.user,
+                config.identity_file.as_deref(),
+                &shared,
+                &mut jump,
+            )
+            .await?;
+            Some(jump)
+        } else {
+            None
+        };
+
         let handler = NovaClientHandler {
             shared: shared.clone(),
             host: config.host.clone(),
             port: config.port,
         };
 
-        let mut session =
-            client::connect(client_config, (config.host.as_str(), config.port), handler).await?;
+        let mut session = if let Some(jump) = &jump_session {
+            let stream = jump
+                .channel_open_direct_tcpip(config.host.clone(), config.port as u32, "127.0.0.1", 0)
+                .await?
+                .into_stream();
 
-        authenticate(&config, &shared, &mut session).await?;
+            client::connect_stream(client_config.clone(), stream, handler).await?
+        } else {
+            client::connect(client_config.clone(), (config.host.as_str(), config.port), handler).await?
+        };
+
+        authenticate(
+            &config.user,
+            config.identity_file.as_deref(),
+            &shared,
+            &mut session,
+        )
+        .await?;
 
         let mut channel = session.channel_open_session().await?;
         channel
@@ -783,6 +842,11 @@ fn run_session(
         let _ = session
             .disconnect(Disconnect::ByApplication, "Closed by NovaTerminal", "en")
             .await;
+        if let Some(jump) = jump_session {
+            let _ = jump
+                .disconnect(Disconnect::ByApplication, "Closed by NovaTerminal", "en")
+                .await;
+        }
         Ok(())
     })
 }
@@ -918,12 +982,13 @@ async fn close_all_forward_channels(
 }
 
 async fn authenticate(
-    config: &ConnectConfig,
+    user: &str,
+    identity_file: Option<&str>,
     shared: &Arc<SharedState>,
     session: &mut client::Handle<NovaClientHandler>,
 ) -> anyhow::Result<()> {
-    if let Some(identity_file) = &config.identity_file {
-        if let Some(auth_result) = try_public_key_auth(config, shared, session, identity_file).await? {
+    if let Some(identity_file) = identity_file {
+        if let Some(auth_result) = try_public_key_auth(user, shared, session, identity_file).await? {
             if auth_result.success() {
                 return Ok(());
             }
@@ -932,13 +997,13 @@ async fn authenticate(
 
     let password = prompt_text(shared, NovaSshEventKind::PasswordPrompt, "Password:", NovaSshResponseKind::Password)?;
     let password_auth = session
-        .authenticate_password(config.user.clone(), password)
+        .authenticate_password(user.to_owned(), password)
         .await?;
     if password_auth.success() {
         return Ok(());
     }
 
-    let keyboard_auth = authenticate_keyboard_interactive(config, shared, session).await?;
+    let keyboard_auth = authenticate_keyboard_interactive(user, shared, session).await?;
     if keyboard_auth {
         return Ok(());
     }
@@ -947,7 +1012,7 @@ async fn authenticate(
 }
 
 async fn try_public_key_auth(
-    config: &ConnectConfig,
+    user: &str,
     shared: &Arc<SharedState>,
     session: &mut client::Handle<NovaClientHandler>,
     identity_file: &str,
@@ -968,7 +1033,7 @@ async fn try_public_key_auth(
     let hash_alg = session.best_supported_rsa_hash().await?.flatten();
     let auth = session
         .authenticate_publickey(
-            config.user.clone(),
+            user.to_owned(),
             PrivateKeyWithHashAlg::new(Arc::new(key), hash_alg),
         )
         .await?;
@@ -976,12 +1041,12 @@ async fn try_public_key_auth(
 }
 
 async fn authenticate_keyboard_interactive(
-    config: &ConnectConfig,
+    user: &str,
     shared: &Arc<SharedState>,
     session: &mut client::Handle<NovaClientHandler>,
 ) -> anyhow::Result<bool> {
     let mut response = session
-        .authenticate_keyboard_interactive_start(config.user.clone(), None::<String>)
+        .authenticate_keyboard_interactive_start(user.to_owned(), None::<String>)
         .await?;
 
     loop {

--- a/src/NovaTerminal.Core/Ssh/Native/JumpHostConnectPlan.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/JumpHostConnectPlan.cs
@@ -1,0 +1,41 @@
+using NovaTerminal.Core.Ssh.Models;
+
+namespace NovaTerminal.Core.Ssh.Native;
+
+public sealed class JumpHostConnectPlan
+{
+    private JumpHostConnectPlan()
+    {
+    }
+
+    public required string TargetHost { get; init; }
+    public required string TargetUser { get; init; }
+    public int TargetPort { get; init; } = 22;
+    public SshJumpHop? JumpHost { get; init; }
+    public bool HasJumpHost => JumpHost != null;
+
+    public static JumpHostConnectPlan Create(SshProfile profile)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+
+        if (profile.JumpHops.Count > 1)
+        {
+            throw new NotSupportedException("Multiple jump hops are not supported by the native SSH backend yet.");
+        }
+
+        return new JumpHostConnectPlan
+        {
+            TargetHost = profile.Host,
+            TargetUser = profile.User,
+            TargetPort = profile.Port > 0 ? profile.Port : 22,
+            JumpHost = profile.JumpHops.Count == 0
+                ? null
+                : new SshJumpHop
+                {
+                    Host = profile.JumpHops[0].Host,
+                    User = profile.JumpHops[0].User,
+                    Port = profile.JumpHops[0].Port > 0 ? profile.JumpHops[0].Port : 22
+                }
+        };
+    }
+}

--- a/src/NovaTerminal.Core/Ssh/Native/NativeJumpHostConnector.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeJumpHostConnector.cs
@@ -1,0 +1,45 @@
+using NovaTerminal.Core.Ssh.Models;
+
+namespace NovaTerminal.Core.Ssh.Native;
+
+public sealed class NativeJumpHostConnector
+{
+    public NativeSshConnectionOptions CreateConnectionOptions(SshProfile profile, int cols, int rows)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+
+        return CreateConnectionOptions(JumpHostConnectPlan.Create(profile), profile, cols, rows);
+    }
+
+    public NativeSshConnectionOptions CreateConnectionOptions(JumpHostConnectPlan plan, SshProfile profile, int cols, int rows)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(profile);
+
+        return new NativeSshConnectionOptions
+        {
+            Host = plan.TargetHost,
+            User = plan.TargetUser,
+            Port = plan.TargetPort,
+            Cols = cols,
+            Rows = rows,
+            IdentityFilePath = string.IsNullOrWhiteSpace(profile.IdentityFilePath)
+                ? null
+                : profile.IdentityFilePath,
+            JumpHost = plan.JumpHost == null
+                ? null
+                : new SshJumpHop
+                {
+                    Host = plan.JumpHost.Host,
+                    User = string.IsNullOrWhiteSpace(plan.JumpHost.User) ? plan.TargetUser : plan.JumpHost.User,
+                    Port = plan.JumpHost.Port > 0 ? plan.JumpHost.Port : 22
+                }
+        };
+    }
+
+    public string DescribePath(JumpHostConnectPlan plan)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        return plan.HasJumpHost ? "jump-host" : "direct";
+    }
+}

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshConnectionOptions.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshConnectionOptions.cs
@@ -11,6 +11,7 @@ public sealed class NativeSshConnectionOptions
     public int Rows { get; init; } = 30;
     public string Term { get; init; } = "xterm-256color";
     public string? IdentityFilePath { get; init; }
+    public SshJumpHop? JumpHost { get; init; }
 
     public static NativeSshConnectionOptions FromProfile(SshProfile profile, int cols, int rows)
     {

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
@@ -30,24 +30,47 @@ public sealed class NativeSshInterop : INativeSshInterop
                 identityPtr = Marshal.StringToCoTaskMemUTF8(options.IdentityFilePath);
             }
 
-            NativeConnectArgs args = new()
-            {
-                Host = hostPtr,
-                User = userPtr,
-                Port = checked((ushort)options.Port),
-                Cols = checked((ushort)options.Cols),
-                Rows = checked((ushort)options.Rows),
-                Term = termPtr,
-                IdentityFile = identityPtr
-            };
+            IntPtr jumpHostPtr = IntPtr.Zero;
+            IntPtr jumpUserPtr = IntPtr.Zero;
 
-            IntPtr handle = NativeMethods.nova_ssh_connect(in args);
-            if (handle == IntPtr.Zero)
+            try
             {
-                throw new InvalidOperationException("Failed to create native SSH session.");
+                if (options.JumpHost != null)
+                {
+                    jumpHostPtr = Marshal.StringToCoTaskMemUTF8(options.JumpHost.Host);
+                    if (!string.IsNullOrWhiteSpace(options.JumpHost.User))
+                    {
+                        jumpUserPtr = Marshal.StringToCoTaskMemUTF8(options.JumpHost.User);
+                    }
+                }
+
+                NativeConnectArgs args = new()
+                {
+                    Host = hostPtr,
+                    User = userPtr,
+                    Port = checked((ushort)options.Port),
+                    Cols = checked((ushort)options.Cols),
+                    Rows = checked((ushort)options.Rows),
+                    Term = termPtr,
+                    IdentityFile = identityPtr,
+                    JumpHost = jumpHostPtr,
+                    JumpUser = jumpUserPtr,
+                    JumpPort = checked((ushort)(options.JumpHost?.Port ?? 0))
+                };
+
+                IntPtr handle = NativeMethods.nova_ssh_connect(in args);
+                if (handle == IntPtr.Zero)
+                {
+                    throw new InvalidOperationException("Failed to create native SSH session.");
+                }
+
+                return handle;
             }
-
-            return handle;
+            finally
+            {
+                FreeUtf8(jumpHostPtr);
+                FreeUtf8(jumpUserPtr);
+            }
         }
         finally
         {
@@ -268,6 +291,9 @@ public sealed class NativeSshInterop : INativeSshInterop
         public ushort Rows;
         public IntPtr Term;
         public IntPtr IdentityFile;
+        public IntPtr JumpHost;
+        public IntPtr JumpUser;
+        public ushort JumpPort;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
@@ -14,6 +14,7 @@ public sealed class NativeSshSession : ITerminalSession
 
     private readonly INativeSshInterop _interop;
     private readonly ISshInteractionHandler? _interactionHandler;
+    private readonly NativeJumpHostConnector _jumpHostConnector = new();
     private readonly CancellationTokenSource _pollCts = new();
     private readonly Task _pollTask;
     private readonly Decoder _utf8Decoder = Encoding.UTF8.GetDecoder();
@@ -41,11 +42,6 @@ public sealed class NativeSshSession : ITerminalSession
     {
         ArgumentNullException.ThrowIfNull(profile);
 
-        if (profile.JumpHops.Count != 0)
-        {
-            throw new NotSupportedException("Native SSH backend does not support jump hops yet.");
-        }
-
         if (profile.Forwards.Any(forward => forward.Kind != PortForwardKind.Local))
         {
             throw new NotSupportedException("Native SSH backend currently supports local port forwards only.");
@@ -58,7 +54,10 @@ public sealed class NativeSshSession : ITerminalSession
         _log = log ?? Console.WriteLine;
         _interop = interop ?? new NativeSshInterop();
         _interactionHandler = interactionHandler;
-        _sessionHandle = _interop.Connect(NativeSshConnectionOptions.FromProfile(profile, cols, rows));
+        JumpHostConnectPlan connectPlan = JumpHostConnectPlan.Create(profile);
+        NativeSshConnectionOptions connectionOptions = _jumpHostConnector.CreateConnectionOptions(connectPlan, profile, cols, rows);
+        _log($"[NativeSshSession] backend=native path={_jumpHostConnector.DescribePath(connectPlan)} target={connectionOptions.User}@{connectionOptions.Host}:{connectionOptions.Port}");
+        _sessionHandle = _interop.Connect(connectionOptions);
 
         try
         {

--- a/src/NovaTerminal.Core/Ssh/Sessions/SshSessionFactory.cs
+++ b/src/NovaTerminal.Core/Ssh/Sessions/SshSessionFactory.cs
@@ -51,8 +51,27 @@ public sealed class SshSessionFactory : ISshSessionFactory
 
         return profile.BackendKind switch
         {
-            SshBackendKind.Native => new NativeSshSession(profile, cols, rows, diagnosticsLevel, extraArgs, log, _nativeInterop, _nativeInteractionHandler),
+            SshBackendKind.Native => CreateNativeSession(profile, cols, rows, diagnosticsLevel, extraArgs, log),
             _ => new OpenSshSession(profile.Id, _profileStore, cols, rows, diagnosticsLevel, extraArgs, _launcher, log)
         };
+    }
+
+    private NativeSshSession CreateNativeSession(
+        SshProfile profile,
+        int cols,
+        int rows,
+        SshDiagnosticsLevel diagnosticsLevel,
+        IReadOnlyList<string>? extraArgs,
+        Action<string>? log)
+    {
+        string path = profile.JumpHops.Count switch
+        {
+            0 => "direct",
+            1 => "jump-host",
+            _ => "jump-host-unsupported"
+        };
+
+        log?.Invoke($"[SshSessionFactory] backend=native path={path} profile={profile.Name}");
+        return new NativeSshSession(profile, cols, rows, diagnosticsLevel, extraArgs, log, _nativeInterop, _nativeInteractionHandler);
     }
 }

--- a/tests/NovaTerminal.Core.Tests/Ssh/JumpHostConnectPlanTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/JumpHostConnectPlanTests.cs
@@ -1,0 +1,163 @@
+using System.Collections.Concurrent;
+using NovaTerminal.Core.Ssh.Models;
+using NovaTerminal.Core.Ssh.Native;
+using NovaTerminal.Core.Ssh.Sessions;
+
+namespace NovaTerminal.Core.Tests.Ssh;
+
+public sealed class JumpHostConnectPlanTests
+{
+    [Fact]
+    public void Create_FromProfileWithoutJumpHops_UsesDirectPlan()
+    {
+        JumpHostConnectPlan plan = JumpHostConnectPlan.Create(CreateProfile());
+
+        Assert.False(plan.HasJumpHost);
+        Assert.Null(plan.JumpHost);
+        Assert.Equal("target.internal", plan.TargetHost);
+        Assert.Equal(22, plan.TargetPort);
+        Assert.Equal("nova", plan.TargetUser);
+    }
+
+    [Fact]
+    public void Create_FromProfileWithOneJumpHop_UsesSingleHopPlan()
+    {
+        SshProfile profile = CreateProfile();
+        profile.JumpHops.Add(new SshJumpHop
+        {
+            Host = "jump.internal",
+            User = "ops",
+            Port = 2200
+        });
+
+        JumpHostConnectPlan plan = JumpHostConnectPlan.Create(profile);
+
+        Assert.True(plan.HasJumpHost);
+        Assert.NotNull(plan.JumpHost);
+        Assert.Equal("jump.internal", plan.JumpHost!.Host);
+        Assert.Equal("ops", plan.JumpHost.User);
+        Assert.Equal(2200, plan.JumpHost.Port);
+        Assert.Equal("target.internal", plan.TargetHost);
+    }
+
+    [Fact]
+    public void Create_FromProfileWithMultipleJumpHops_ThrowsClearUnsupportedError()
+    {
+        SshProfile profile = CreateProfile();
+        profile.JumpHops.Add(new SshJumpHop { Host = "jump-one.internal" });
+        profile.JumpHops.Add(new SshJumpHop { Host = "jump-two.internal" });
+
+        NotSupportedException ex = Assert.Throws<NotSupportedException>(() => JumpHostConnectPlan.Create(profile));
+
+        Assert.Contains("Multiple jump hops", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task NativeSession_WithOneJumpHop_ConnectsUsingJumpPlanAndLogsPath()
+    {
+        var interop = new CapturingNativeSshInterop();
+        var logs = new ConcurrentQueue<string>();
+        SshProfile profile = CreateProfile();
+        profile.JumpHops.Add(new SshJumpHop
+        {
+            Host = "jump.internal",
+            User = "ops",
+            Port = 2222
+        });
+
+        using var session = new NativeSshSession(profile, interop: interop, log: logs.Enqueue);
+
+        await WaitUntilAsync(() => interop.LastConnectOptions != null);
+
+        Assert.NotNull(interop.LastConnectOptions);
+        Assert.NotNull(interop.LastConnectOptions!.JumpHost);
+        Assert.Equal("jump.internal", interop.LastConnectOptions.JumpHost!.Host);
+        Assert.Equal("ops", interop.LastConnectOptions.JumpHost.User);
+        Assert.Equal(2222, interop.LastConnectOptions.JumpHost.Port);
+        Assert.Contains(logs, message => message.Contains("backend=native", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(logs, message => message.Contains("path=jump-host", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void NativeSession_WithMultipleJumpHops_ThrowsClearUnsupportedError()
+    {
+        SshProfile profile = CreateProfile();
+        profile.JumpHops.Add(new SshJumpHop { Host = "jump-one.internal" });
+        profile.JumpHops.Add(new SshJumpHop { Host = "jump-two.internal" });
+
+        NotSupportedException ex = Assert.Throws<NotSupportedException>(() => new NativeSshSession(profile, interop: new CapturingNativeSshInterop()));
+
+        Assert.Contains("Multiple jump hops", ex.Message, StringComparison.Ordinal);
+    }
+
+    private static SshProfile CreateProfile()
+    {
+        return new SshProfile
+        {
+            Id = Guid.Parse("22c57d51-794f-4df3-8a13-314a789ca829"),
+            BackendKind = SshBackendKind.Native,
+            Host = "target.internal",
+            User = "nova",
+            Port = 22
+        };
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> predicate)
+    {
+        DateTime deadline = DateTime.UtcNow.AddSeconds(2);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (predicate())
+            {
+                return;
+            }
+
+            await Task.Delay(20);
+        }
+
+        Assert.True(predicate(), "Condition was not met before timeout.");
+    }
+
+    private sealed class CapturingNativeSshInterop : INativeSshInterop
+    {
+        public NativeSshConnectionOptions? LastConnectOptions { get; private set; }
+
+        public IntPtr Connect(NativeSshConnectionOptions options)
+        {
+            LastConnectOptions = options;
+            return new IntPtr(1);
+        }
+
+        public NativeSshEvent? PollEvent(IntPtr sessionHandle) => NativeSshEvent.Closed();
+
+        public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data)
+        {
+        }
+
+        public void Resize(IntPtr sessionHandle, int cols, int rows)
+        {
+        }
+
+        public int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options) => 1;
+
+        public void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data)
+        {
+        }
+
+        public void SendChannelEof(IntPtr sessionHandle, int channelId)
+        {
+        }
+
+        public void CloseChannel(IntPtr sessionHandle, int channelId)
+        {
+        }
+
+        public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data)
+        {
+        }
+
+        public void Close(IntPtr sessionHandle)
+        {
+        }
+    }
+}

--- a/tests/NovaTerminal.Core.Tests/Ssh/SshSessionFactoryTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/SshSessionFactoryTests.cs
@@ -27,6 +27,32 @@ public sealed class SshSessionFactoryTests
         Assert.IsType<NativeSshSession>(session);
     }
 
+    [Fact]
+    public void Create_ForNativeJumpHostProfile_LogsSelectedPath()
+    {
+        var profileId = Guid.Parse("d786b616-6b8a-4f57-b095-2e8f8b0d6907");
+        var store = new InMemorySshProfileStore(new SshProfile
+        {
+            Id = profileId,
+            Name = "native-jump",
+            Host = "target.internal",
+            User = "nova",
+            BackendKind = SshBackendKind.Native,
+            JumpHops =
+            [
+                new SshJumpHop { Host = "jump.internal" }
+            ]
+        });
+        var logs = new List<string>();
+
+        var factory = new SshSessionFactory(store, launcher: null, nativeInterop: new StubNativeSshInterop());
+        using ITerminalSession session = factory.Create(profileId, log: logs.Add);
+
+        Assert.IsType<NativeSshSession>(session);
+        Assert.Contains(logs, message => message.Contains("backend=native", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(logs, message => message.Contains("path=jump-host", StringComparison.OrdinalIgnoreCase));
+    }
+
     private sealed class InMemorySshProfileStore : ISshProfileStore
     {
         public InMemorySshProfileStore(SshProfile profile)


### PR DESCRIPTION
## Summary
- add an explicit one-hop native jump-host connect plan and connector instead of silently rejecting every jump configuration
- extend the native SSH connect options and Rust FFI/bootstrap path to use a jump-host direct-tcpip stream for the target connection
- add tests for direct vs one-hop planning, multi-hop unsupported behavior, and backend/path logging visibility

## Test Plan
- dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~JumpHostConnectPlanTests"
- cargo test --manifest-path src\NovaTerminal.App\native\rusty_ssh\Cargo.toml --release
- dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~Ssh"
- dotnet build src\NovaTerminal.App\NovaTerminal.App.csproj -c Release -p:SKIP_RUST_NATIVE_BUILD=1 /nodeReuse:false
