### PR TITLE
Add native SSH rollout controls and diagnostics

### DIFF
--- a/docs/plans/2026-03-31-native-ssh-rollout-controls-design.md
+++ b/docs/plans/2026-03-31-native-ssh-rollout-controls-design.md
@@ -1,0 +1,36 @@
+# Native SSH Rollout Controls Design
+
+Date: 2026-03-31
+
+## Goal
+
+Add conservative rollout controls for the native SSH backend without hiding failures or silently falling back to OpenSSH.
+
+## Approved Design
+
+- Add a global `ExperimentalNativeSshEnabled` setting in `TerminalSettings`, defaulting to `false`.
+- Keep per-profile `BackendKind` editable in the SSH profile editor.
+- When native SSH is selected on a profile but the global toggle is disabled, refuse native session creation explicitly instead of falling back to OpenSSH.
+- Keep diagnostics and failure bucketing in native SSH core code, not in Avalonia views.
+- Provide a visible path for the user to switch the profile back to OpenSSH.
+
+## Rationale
+
+- Preserves saved native profiles without mutating user data.
+- Makes rollout state explicit and debuggable.
+- Avoids hidden behavior changes between backends.
+- Keeps the UI change additive and localized.
+
+## Scope
+
+- Global native SSH experimental toggle
+- SSH profile backend selector
+- Native session factory refusal path when disabled
+- Native failure classifier
+- Native metrics surface for timing and disconnect reasons
+
+## Out Of Scope
+
+- Silent fallback from native SSH to OpenSSH
+- Broad settings-system refactors
+- Changes to terminal rendering or VT behavior

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -1127,7 +1127,9 @@ namespace NovaTerminal.Controls
                 {
                     try
                     {
-                        var sessionFactory = new SshSessionFactory(nativeInteractionHandler: SshInteractionHandler);
+                        var sessionFactory = new SshSessionFactory(
+                            nativeInteractionHandler: SshInteractionHandler,
+                            nativeSshEnabled: _settings?.ExperimentalNativeSshEnabled ?? false);
                         Session = sessionFactory.Create(
                             profile.Id,
                             cols,

--- a/src/NovaTerminal.App/Core/TerminalSettings.cs
+++ b/src/NovaTerminal.App/Core/TerminalSettings.cs
@@ -39,6 +39,7 @@ namespace NovaTerminal.Core
         public bool CommandAssistAutoHideInAltScreen { get; set; } = true;
         public bool CommandAssistShellIntegrationEnabled { get; set; } = true;
         public bool CommandAssistPowerShellIntegrationEnabled { get; set; } = true;
+        public bool ExperimentalNativeSshEnabled { get; set; } = false;
 
         public System.Collections.Generic.List<TerminalProfile> Profiles { get; set; } = new();
         public Guid DefaultProfileId { get; set; }

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -3870,6 +3870,8 @@ namespace NovaTerminal
         private async Task ShowNewSshConnectionDialogAsync(TerminalProfile? existingProfile)
         {
             var vm = _sshConnectionService.CreateEditorViewModel(existingProfile);
+            vm.BackendKind ??= NovaTerminal.Core.Ssh.Models.SshBackendKind.OpenSsh;
+            vm.ExperimentalNativeSshEnabled = _settings.ExperimentalNativeSshEnabled;
             var dialog = new NewSshConnectionView(vm);
             ApplyThemeToDialogWindow(dialog);
             bool saved = await dialog.ShowDialog<bool>(this);
@@ -3888,6 +3890,15 @@ namespace NovaTerminal
 
                 if (vm.ConnectAfterSave)
                 {
+                    if (profile.SshBackendKind == NovaTerminal.Core.Ssh.Models.SshBackendKind.Native &&
+                        !_settings.ExperimentalNativeSshEnabled)
+                    {
+                        await ShowSimpleMessageDialogAsync(
+                            "Native SSH disabled",
+                            "This profile was saved with the Native backend, but native SSH is disabled globally. Enable ExperimentalNativeSshEnabled in settings or switch the profile back to OpenSSH.");
+                        return;
+                    }
+
                     AddTab(profile, SshDiagnosticsLevel.None);
                 }
             }

--- a/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
+++ b/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
@@ -37,6 +37,7 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
     private int _controlPersistSeconds = 90;
     private string _extraSshArgs = string.Empty;
     private bool _connectAfterSave;
+    private bool _experimentalNativeSshEnabled;
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -132,7 +133,13 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
     public SshBackendKind? BackendKind
     {
         get => _backendKind;
-        set => SetField(ref _backendKind, value);
+        set
+        {
+            if (SetField(ref _backendKind, value))
+            {
+                OnPropertyChanged(nameof(BackendWarning));
+            }
+        }
     }
 
     public int KeepAliveIntervalSeconds
@@ -170,6 +177,23 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
         get => _connectAfterSave;
         set => SetField(ref _connectAfterSave, value);
     }
+
+    public bool ExperimentalNativeSshEnabled
+    {
+        get => _experimentalNativeSshEnabled;
+        set
+        {
+            if (SetField(ref _experimentalNativeSshEnabled, value))
+            {
+                OnPropertyChanged(nameof(BackendWarning));
+            }
+        }
+    }
+
+    public string BackendWarning =>
+        BackendKind == SshBackendKind.Native && !ExperimentalNativeSshEnabled
+            ? "Native SSH is disabled globally. Enable ExperimentalNativeSshEnabled in settings or switch this profile back to OpenSSH."
+            : string.Empty;
 
     public bool Validate()
     {

--- a/src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml
+++ b/src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml
@@ -29,7 +29,7 @@
     <Grid RowDefinitions="*,Auto,Auto" Margin="16">
         <TabControl>
             <TabItem Header="Basic">
-                <Grid Margin="0,10,0,0" ColumnDefinitions="170,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto" RowSpacing="10">
+                <Grid Margin="0,10,0,0" ColumnDefinitions="170,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" RowSpacing="10">
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="Name" VerticalAlignment="Center" />
                     <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Name}" Watermark="My server" />
 
@@ -42,14 +42,17 @@
                     <TextBlock Grid.Row="3" Grid.Column="0" Text="Port" VerticalAlignment="Center" />
                     <NumericUpDown Grid.Row="3" Grid.Column="1" Minimum="1" Maximum="65535" Value="{Binding Port}" />
 
-                    <TextBlock Grid.Row="4" Grid.Column="0" Text="Accent" VerticalAlignment="Center" />
-                    <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding AccentColor}" Watermark="#0078D4 (optional)" />
+                    <TextBlock Grid.Row="4" Grid.Column="0" Text="Backend" VerticalAlignment="Center" />
+                    <ComboBox Grid.Row="4" Grid.Column="1" Name="BackendKindCombo" SelectedItem="{Binding BackendKind}" />
 
-                    <TextBlock Grid.Row="5" Grid.Column="0" Text="Favorite" VerticalAlignment="Center" />
-                    <CheckBox Grid.Row="5" Grid.Column="1" IsChecked="{Binding IsFavorite}" Content="Pin in Connections list" />
+                    <TextBlock Grid.Row="5" Grid.Column="0" Text="Accent" VerticalAlignment="Center" />
+                    <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding AccentColor}" Watermark="#0078D4 (optional)" />
 
-                    <TextBlock Grid.Row="6" Grid.Column="0" Text="Notes" VerticalAlignment="Top" />
-                    <TextBox Grid.Row="6"
+                    <TextBlock Grid.Row="6" Grid.Column="0" Text="Favorite" VerticalAlignment="Center" />
+                    <CheckBox Grid.Row="6" Grid.Column="1" IsChecked="{Binding IsFavorite}" Content="Pin in Connections list" />
+
+                    <TextBlock Grid.Row="7" Grid.Column="0" Text="Notes" VerticalAlignment="Top" />
+                    <TextBox Grid.Row="7"
                              Grid.Column="1"
                              Text="{Binding Notes}"
                              AcceptsReturn="True"
@@ -154,6 +157,10 @@
         </TabControl>
 
         <StackPanel Grid.Row="1" Margin="0,8,0,8" Spacing="4">
+            <TextBlock Text="{Binding BackendWarning}"
+                       Foreground="#D7BA7D"
+                       TextWrapping="Wrap"
+                       IsVisible="{Binding BackendWarning, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
             <TextBlock Text="{Binding ValidationError}"
                        Foreground="#E06C75"
                        TextWrapping="Wrap"

--- a/src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml.cs
+++ b/src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml.cs
@@ -15,6 +15,7 @@ public partial class NewSshConnectionView : Window
     {
         InitializeComponent();
         ConfigureAuthModeCombo();
+        ConfigureBackendKindCombo();
         ConfigureForwardKindCombo();
     }
 
@@ -36,6 +37,15 @@ public partial class NewSshConnectionView : Window
         if (combo != null)
         {
             combo.ItemsSource = Enum.GetValues<NewSshAuthMode>();
+        }
+    }
+
+    private void ConfigureBackendKindCombo()
+    {
+        var combo = this.FindControl<ComboBox>("BackendKindCombo");
+        if (combo != null)
+        {
+            combo.ItemsSource = Enum.GetValues<SshBackendKind>();
         }
     }
 

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshFailureClassifier.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshFailureClassifier.cs
@@ -1,0 +1,52 @@
+namespace NovaTerminal.Core.Ssh.Native;
+
+public enum NativeSshFailureKind
+{
+    Unknown = 0,
+    Timeout = 1,
+    Authentication = 2,
+    HostKeyMismatch = 3,
+    ChannelOpen = 4,
+    ForwardBind = 5,
+    RemoteDisconnect = 6
+}
+
+public sealed class NativeSshFailure
+{
+    public NativeSshFailure(NativeSshFailureKind kind, string message)
+    {
+        Kind = kind;
+        Message = message ?? string.Empty;
+    }
+
+    public NativeSshFailureKind Kind { get; }
+    public string Message { get; }
+}
+
+public static class NativeSshFailureClassifier
+{
+    public static NativeSshFailure Classify(string? message)
+    {
+        string text = message?.Trim() ?? string.Empty;
+        string lower = text.ToLowerInvariant();
+
+        NativeSshFailureKind kind = lower switch
+        {
+            _ when lower.Contains("timed out", StringComparison.Ordinal) || lower.Contains("timeout", StringComparison.Ordinal)
+                => NativeSshFailureKind.Timeout,
+            _ when lower.Contains("authentication failed", StringComparison.Ordinal) || lower.Contains("prompt canceled", StringComparison.Ordinal)
+                => NativeSshFailureKind.Authentication,
+            _ when lower.Contains("host key", StringComparison.Ordinal) && (lower.Contains("changed", StringComparison.Ordinal) || lower.Contains("mismatch", StringComparison.Ordinal))
+                => NativeSshFailureKind.HostKeyMismatch,
+            _ when lower.Contains("channelopenfailure", StringComparison.Ordinal) || lower.Contains("channel open", StringComparison.Ordinal)
+                => NativeSshFailureKind.ChannelOpen,
+            _ when lower.Contains("bind local forward", StringComparison.Ordinal) || lower.Contains("failed to bind local forward", StringComparison.Ordinal)
+                => NativeSshFailureKind.ForwardBind,
+            _ when lower.Contains("remote disconnect", StringComparison.Ordinal) || lower.Contains("disconnect", StringComparison.Ordinal)
+                => NativeSshFailureKind.RemoteDisconnect,
+            _ => NativeSshFailureKind.Unknown
+        };
+
+        return new NativeSshFailure(kind, text);
+    }
+}

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshMetrics.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshMetrics.cs
@@ -1,0 +1,75 @@
+namespace NovaTerminal.Core.Ssh.Native;
+
+public sealed class NativeSshMetrics
+{
+    private readonly DateTimeOffset _connectStartedUtc = DateTimeOffset.UtcNow;
+    private DateTimeOffset? _connectedUtc;
+    private DateTimeOffset? _hostKeyPromptStartedUtc;
+    private DateTimeOffset? _authPromptStartedUtc;
+    private DateTimeOffset? _firstOutputUtc;
+
+    public TimeSpan? ConnectLatency { get; private set; }
+    public TimeSpan? HostKeyDuration { get; private set; }
+    public TimeSpan? AuthenticationDuration { get; private set; }
+    public TimeSpan? TimeToFirstOutput { get; private set; }
+    public string DisconnectReason { get; private set; } = string.Empty;
+    public List<string> ForwardSetupResults { get; } = [];
+
+    public void MarkConnected()
+    {
+        _connectedUtc = DateTimeOffset.UtcNow;
+        ConnectLatency ??= _connectedUtc.Value - _connectStartedUtc;
+    }
+
+    public void MarkHostKeyPromptStarted()
+    {
+        _hostKeyPromptStartedUtc ??= DateTimeOffset.UtcNow;
+    }
+
+    public void MarkHostKeyPromptCompleted()
+    {
+        if (_hostKeyPromptStartedUtc.HasValue)
+        {
+            HostKeyDuration = DateTimeOffset.UtcNow - _hostKeyPromptStartedUtc.Value;
+            _hostKeyPromptStartedUtc = null;
+        }
+    }
+
+    public void MarkAuthenticationPromptStarted()
+    {
+        _authPromptStartedUtc ??= DateTimeOffset.UtcNow;
+    }
+
+    public void MarkAuthenticationPromptCompleted()
+    {
+        if (_authPromptStartedUtc.HasValue)
+        {
+            AuthenticationDuration = DateTimeOffset.UtcNow - _authPromptStartedUtc.Value;
+            _authPromptStartedUtc = null;
+        }
+    }
+
+    public void MarkFirstOutput()
+    {
+        if (_firstOutputUtc.HasValue)
+        {
+            return;
+        }
+
+        _firstOutputUtc = DateTimeOffset.UtcNow;
+        TimeToFirstOutput = _firstOutputUtc.Value - _connectStartedUtc;
+    }
+
+    public void RecordForwardSetup(string result)
+    {
+        if (!string.IsNullOrWhiteSpace(result))
+        {
+            ForwardSetupResults.Add(result.Trim());
+        }
+    }
+
+    public void MarkDisconnected(string? reason)
+    {
+        DisconnectReason = reason?.Trim() ?? string.Empty;
+    }
+}

--- a/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
@@ -19,6 +19,7 @@ public sealed class NativeSshSession : ITerminalSession
     private readonly Task _pollTask;
     private readonly Decoder _utf8Decoder = Encoding.UTF8.GetDecoder();
     private readonly Action<string> _log;
+    private readonly NativeSshMetrics _metrics = new();
 
     private ReplayWriter? _recorder;
     private TerminalBuffer? _buffer;
@@ -64,6 +65,10 @@ public sealed class NativeSshSession : ITerminalSession
             if (profile.Forwards.Count != 0)
             {
                 _portForwardSession = new NativePortForwardSession(_sessionHandle, profile.Forwards, _interop, _log);
+                foreach (PortForward forward in profile.Forwards)
+                {
+                    _metrics.RecordForwardSetup(forward.ToString());
+                }
             }
 
             _isRunning = 1;
@@ -165,6 +170,7 @@ public sealed class NativeSshSession : ITerminalSession
     {
         StopRecording();
         _pollCts.Cancel();
+        _metrics.MarkDisconnected("Disposed");
         _portForwardSession?.Dispose();
         CloseNativeHandle();
         try
@@ -195,6 +201,9 @@ public sealed class NativeSshSession : ITerminalSession
 
                 switch (nextEvent.Kind)
                 {
+                    case NativeSshEventKind.Connected:
+                        _metrics.MarkConnected();
+                        break;
                     case NativeSshEventKind.Data:
                         EmitOutput(nextEvent.Payload);
                         break;
@@ -216,6 +225,7 @@ public sealed class NativeSshSession : ITerminalSession
                         await HandleInteractionAsync(nextEvent).ConfigureAwait(false);
                         break;
                     case NativeSshEventKind.Closed:
+                        _metrics.MarkDisconnected("Closed");
                         TryNotifyExit(_exitCode ?? 0);
                         return;
                 }
@@ -228,7 +238,10 @@ public sealed class NativeSshSession : ITerminalSession
         {
             if (!_pollCts.IsCancellationRequested)
             {
+                NativeSshFailure failure = NativeSshFailureClassifier.Classify(ex.Message);
+                _metrics.MarkDisconnected(failure.Kind.ToString());
                 _log($"[NativeSshSession] Poll loop failed: {ex.Message}");
+                _log($"[NativeSshSession] failure={failure.Kind}");
                 OnOutputReceived?.Invoke($"Native SSH session failed: {ex.Message}{Environment.NewLine}");
                 TryNotifyExit(-1);
             }
@@ -242,6 +255,7 @@ public sealed class NativeSshSession : ITerminalSession
 
     private void EmitOutput(byte[] payload)
     {
+        _metrics.MarkFirstOutput();
         _recorder?.RecordChunk(payload, payload.Length);
 
         char[] chars = new char[Encoding.UTF8.GetMaxCharCount(payload.Length)];
@@ -254,9 +268,16 @@ public sealed class NativeSshSession : ITerminalSession
 
     private void EmitErrorAndExit(NativeSshEvent nextEvent)
     {
+        string message = nextEvent.Payload.Length > 0
+            ? Encoding.UTF8.GetString(nextEvent.Payload)
+            : "Native SSH error";
+        NativeSshFailure failure = NativeSshFailureClassifier.Classify(message);
+        _metrics.MarkDisconnected(failure.Kind.ToString());
+        _log($"[NativeSshSession] failure={failure.Kind}");
+
         if (nextEvent.Payload.Length > 0)
         {
-            OnOutputReceived?.Invoke($"{Encoding.UTF8.GetString(nextEvent.Payload)}{Environment.NewLine}");
+            OnOutputReceived?.Invoke($"{message}{Environment.NewLine}");
         }
 
         TryNotifyExit(nextEvent.StatusCode == 0 ? -1 : nextEvent.StatusCode);
@@ -264,6 +285,15 @@ public sealed class NativeSshSession : ITerminalSession
 
     private async Task HandleInteractionAsync(NativeSshEvent nextEvent)
     {
+        if (nextEvent.Kind == NativeSshEventKind.HostKeyPrompt)
+        {
+            _metrics.MarkHostKeyPromptStarted();
+        }
+        else
+        {
+            _metrics.MarkAuthenticationPromptStarted();
+        }
+
         SshInteractionRequest request = CreateInteractionRequest(nextEvent);
         SshInteractionResponse response = _interactionHandler == null
             ? SshInteractionResponse.Cancel()
@@ -280,6 +310,15 @@ public sealed class NativeSshSession : ITerminalSession
 
         byte[] payload = BuildInteractionPayload(responseKind, response);
         _interop.SubmitResponse(_sessionHandle, responseKind, payload);
+
+        if (nextEvent.Kind == NativeSshEventKind.HostKeyPrompt)
+        {
+            _metrics.MarkHostKeyPromptCompleted();
+        }
+        else
+        {
+            _metrics.MarkAuthenticationPromptCompleted();
+        }
     }
 
     private void TryNotifyExit(int exitCode)

--- a/src/NovaTerminal.Core/Ssh/Sessions/SshSessionFactory.cs
+++ b/src/NovaTerminal.Core/Ssh/Sessions/SshSessionFactory.cs
@@ -12,6 +12,7 @@ public sealed class SshSessionFactory : ISshSessionFactory
     private readonly ISshProcessLauncher? _launcher;
     private readonly INativeSshInterop? _nativeInterop;
     private readonly ISshInteractionHandler? _nativeInteractionHandler;
+    private readonly bool _nativeSshEnabled;
 
     public SshSessionFactory(ISshProfileStore profileStore)
         : this(profileStore, null, null)
@@ -22,19 +23,22 @@ public sealed class SshSessionFactory : ISshSessionFactory
         ISshProfileStore profileStore,
         ISshProcessLauncher? launcher = null,
         INativeSshInterop? nativeInterop = null,
-        ISshInteractionHandler? nativeInteractionHandler = null)
+        ISshInteractionHandler? nativeInteractionHandler = null,
+        bool nativeSshEnabled = true)
     {
         _profileStore = profileStore ?? throw new ArgumentNullException(nameof(profileStore));
         _launcher = launcher;
         _nativeInterop = nativeInterop;
         _nativeInteractionHandler = nativeInteractionHandler;
+        _nativeSshEnabled = nativeSshEnabled;
     }
 
     public SshSessionFactory(
         ISshProcessLauncher? launcher = null,
         INativeSshInterop? nativeInterop = null,
-        ISshInteractionHandler? nativeInteractionHandler = null)
-        : this(new JsonSshProfileStore(), launcher, nativeInterop, nativeInteractionHandler)
+        ISshInteractionHandler? nativeInteractionHandler = null,
+        bool nativeSshEnabled = true)
+        : this(new JsonSshProfileStore(), launcher, nativeInterop, nativeInteractionHandler, nativeSshEnabled)
     {
     }
 
@@ -64,6 +68,12 @@ public sealed class SshSessionFactory : ISshSessionFactory
         IReadOnlyList<string>? extraArgs,
         Action<string>? log)
     {
+        if (!_nativeSshEnabled)
+        {
+            throw new InvalidOperationException(
+                "Native SSH is disabled globally. Switch this profile back to OpenSSH or enable ExperimentalNativeSshEnabled.");
+        }
+
         string path = profile.JumpHops.Count switch
         {
             0 => "direct",

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshFailureClassifierTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshFailureClassifierTests.cs
@@ -1,0 +1,29 @@
+using NovaTerminal.Core.Ssh.Native;
+
+namespace NovaTerminal.Core.Tests.Ssh;
+
+public sealed class NativeSshFailureClassifierTests
+{
+    [Theory]
+    [InlineData("connection timed out", NativeSshFailureKind.Timeout)]
+    [InlineData("SSH authentication failed", NativeSshFailureKind.Authentication)]
+    [InlineData("Host key changed for server", NativeSshFailureKind.HostKeyMismatch)]
+    [InlineData("ChannelOpenFailure(ConnectFailed)", NativeSshFailureKind.ChannelOpen)]
+    [InlineData("Failed to bind local forward 127.0.0.1:8080", NativeSshFailureKind.ForwardBind)]
+    [InlineData("remote disconnect: connection lost", NativeSshFailureKind.RemoteDisconnect)]
+    public void Classify_KnownMessages_ReturnsStableBucket(string message, NativeSshFailureKind expected)
+    {
+        NativeSshFailure result = NativeSshFailureClassifier.Classify(message);
+
+        Assert.Equal(expected, result.Kind);
+        Assert.Equal(message, result.Message);
+    }
+
+    [Fact]
+    public void Classify_UnknownMessage_ReturnsUnknownBucket()
+    {
+        NativeSshFailure result = NativeSshFailureClassifier.Classify("unhandled native ssh issue");
+
+        Assert.Equal(NativeSshFailureKind.Unknown, result.Kind);
+    }
+}

--- a/tests/NovaTerminal.Core.Tests/Ssh/SshSessionFactoryTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/SshSessionFactoryTests.cs
@@ -53,6 +53,27 @@ public sealed class SshSessionFactoryTests
         Assert.Contains(logs, message => message.Contains("path=jump-host", StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public void Create_ForNativeProfileWhenExperimentalToggleDisabled_ThrowsClearError()
+    {
+        var profileId = Guid.Parse("76b0d0aa-cdde-4eb5-835d-f94df74485b6");
+        var store = new InMemorySshProfileStore(new SshProfile
+        {
+            Id = profileId,
+            Name = "native-disabled",
+            Host = "native.internal",
+            User = "nova",
+            BackendKind = SshBackendKind.Native
+        });
+
+        var factory = new SshSessionFactory(store, launcher: null, nativeInterop: new StubNativeSshInterop(), nativeSshEnabled: false);
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => factory.Create(profileId));
+
+        Assert.Contains("disabled", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("OpenSSH", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     private sealed class InMemorySshProfileStore : ISshProfileStore
     {
         public InMemorySshProfileStore(SshProfile profile)

--- a/tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs
@@ -173,4 +173,30 @@ public sealed class NewSshConnectionViewModelTests
         SshProfile roundTripped = vm.ToSshProfile();
         Assert.Equal("Native", backendProperty.GetValue(roundTripped)?.ToString());
     }
+
+    [Fact]
+    public void BackendWarning_WhenNativeSelectedAndExperimentalToggleDisabled_IsVisible()
+    {
+        var vm = new NewSshConnectionViewModel
+        {
+            HostName = "native.internal",
+            ExperimentalNativeSshEnabled = false,
+            BackendKind = SshBackendKind.Native
+        };
+
+        Assert.Contains("disabled globally", vm.BackendWarning, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BackendWarning_WhenNativeSelectedAndExperimentalToggleEnabled_IsCleared()
+    {
+        var vm = new NewSshConnectionViewModel
+        {
+            HostName = "native.internal",
+            ExperimentalNativeSshEnabled = true,
+            BackendKind = SshBackendKind.Native
+        };
+
+        Assert.Equal(string.Empty, vm.BackendWarning);
+    }
 }


### PR DESCRIPTION
## Summary
- add conservative rollout controls for native SSH with a global experimental toggle, explicit factory refusal, and editor guidance for switching profiles back to OpenSSH
- add native SSH diagnostics primitives for stable failure classification and lightweight timing/forward setup metrics
- expose backend selection in the SSH editor and cover gating/classification behavior with focused core and app tests

## Test Plan
- dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~NativeSshFailureClassifierTests|FullyQualifiedName~NativeSshSessionTests" /nodeReuse:false
- dotnet test tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~NewSshConnectionViewModelTests|FullyQualifiedName~SshConnectionServiceTests" /nodeReuse:false
- dotnet build src\NovaTerminal.App\NovaTerminal.App.csproj -c Release -p:SKIP_RUST_NATIVE_BUILD=1 /nodeReuse:false
