### PR TITLE
Fix native SSH interaction threading and JSON serialization

### DIFF
--- a/src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls;
+using Avalonia.Threading;
 using NovaTerminal.Core;
 using NovaTerminal.Core.Ssh.Interactions;
 using NovaTerminal.Core.Ssh.Native;
@@ -36,6 +37,23 @@ public sealed class SshInteractionService : ISshInteractionService
     {
         ArgumentNullException.ThrowIfNull(request);
 
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return await Task.FromCanceled<SshInteractionResponse>(cancellationToken);
+        }
+
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            return await Dispatcher.UIThread.InvokeAsync(
+                () => HandleOnUiThreadAsync(request, cancellationToken),
+                DispatcherPriority.Send);
+        }
+
+        return await HandleOnUiThreadAsync(request, cancellationToken);
+    }
+
+    private async Task<SshInteractionResponse> HandleOnUiThreadAsync(SshInteractionRequest request, CancellationToken cancellationToken)
+    {
         Window? owner = _ownerProvider();
         return request.Kind switch
         {

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshInteractionJson.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshInteractionJson.cs
@@ -1,0 +1,150 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NovaTerminal.Core.Ssh.Interactions;
+
+namespace NovaTerminal.Core.Ssh.Native;
+
+public static class NativeSshInteractionJson
+{
+    public static SshInteractionRequest ParseRequest(NativeSshEventKind eventKind, ReadOnlySpan<byte> payload)
+    {
+        return eventKind switch
+        {
+            NativeSshEventKind.HostKeyPrompt => CreateHostKeyRequest(payload),
+            NativeSshEventKind.PasswordPrompt => CreateTextPromptRequest(SshInteractionKind.Password, payload),
+            NativeSshEventKind.PassphrasePrompt => CreateTextPromptRequest(SshInteractionKind.Passphrase, payload),
+            NativeSshEventKind.KeyboardInteractivePrompt => CreateKeyboardRequest(payload),
+            _ => throw new InvalidOperationException($"Unsupported interaction event '{eventKind}'.")
+        };
+    }
+
+    public static byte[] BuildResponsePayload(NativeSshResponseKind responseKind, SshInteractionResponse response)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+
+        return responseKind switch
+        {
+            NativeSshResponseKind.HostKeyDecision => JsonSerializer.SerializeToUtf8Bytes(
+                new NativeHostKeyDecisionPayload { Accept = response.IsAccepted && !response.IsCanceled },
+                NativeSshInteractionJsonContext.Default.NativeHostKeyDecisionPayload),
+            NativeSshResponseKind.Password or NativeSshResponseKind.Passphrase => JsonSerializer.SerializeToUtf8Bytes(
+                new NativeTextResponsePayload { Text = response.IsCanceled ? string.Empty : response.Secret ?? string.Empty },
+                NativeSshInteractionJsonContext.Default.NativeTextResponsePayload),
+            NativeSshResponseKind.KeyboardInteractive => JsonSerializer.SerializeToUtf8Bytes(
+                new NativeKeyboardInteractiveResponsePayload
+                {
+                    Responses = response.IsCanceled ? Array.Empty<string>() : response.KeyboardResponses.ToArray()
+                },
+                NativeSshInteractionJsonContext.Default.NativeKeyboardInteractiveResponsePayload),
+            _ => throw new InvalidOperationException($"Unsupported native SSH response kind '{responseKind}'.")
+        };
+    }
+
+    private static SshInteractionRequest CreateHostKeyRequest(ReadOnlySpan<byte> payload)
+    {
+        NativeHostKeyPromptPayload? model = JsonSerializer.Deserialize(
+            payload,
+            NativeSshInteractionJsonContext.Default.NativeHostKeyPromptPayload);
+        if (model == null)
+        {
+            throw new InvalidOperationException("Failed to parse host key prompt payload.");
+        }
+
+        return new SshInteractionRequest
+        {
+            Kind = SshInteractionKind.UnknownHostKey,
+            Host = model.Host,
+            Port = model.Port,
+            Algorithm = model.Algorithm,
+            Fingerprint = model.Fingerprint
+        };
+    }
+
+    private static SshInteractionRequest CreateTextPromptRequest(SshInteractionKind kind, ReadOnlySpan<byte> payload)
+    {
+        NativeTextPromptPayload? model = JsonSerializer.Deserialize(
+            payload,
+            NativeSshInteractionJsonContext.Default.NativeTextPromptPayload);
+        if (model == null)
+        {
+            throw new InvalidOperationException("Failed to parse authentication prompt payload.");
+        }
+
+        return new SshInteractionRequest
+        {
+            Kind = kind,
+            Prompt = model.Prompt
+        };
+    }
+
+    private static SshInteractionRequest CreateKeyboardRequest(ReadOnlySpan<byte> payload)
+    {
+        NativeKeyboardInteractivePromptPayload? model = JsonSerializer.Deserialize(
+            payload,
+            NativeSshInteractionJsonContext.Default.NativeKeyboardInteractivePromptPayload);
+        if (model == null)
+        {
+            throw new InvalidOperationException("Failed to parse keyboard-interactive payload.");
+        }
+
+        return new SshInteractionRequest
+        {
+            Kind = SshInteractionKind.KeyboardInteractive,
+            Name = model.Name,
+            Instructions = model.Instructions,
+            KeyboardPrompts = model.Prompts.Select(prompt => new SshKeyboardPrompt(prompt.Prompt, prompt.Echo)).ToArray()
+        };
+    }
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(NativeHostKeyPromptPayload))]
+[JsonSerializable(typeof(NativeTextPromptPayload))]
+[JsonSerializable(typeof(NativeKeyboardInteractivePromptPayload))]
+[JsonSerializable(typeof(NativeHostKeyDecisionPayload))]
+[JsonSerializable(typeof(NativeTextResponsePayload))]
+[JsonSerializable(typeof(NativeKeyboardInteractiveResponsePayload))]
+internal partial class NativeSshInteractionJsonContext : JsonSerializerContext
+{
+}
+
+internal sealed class NativeHostKeyPromptPayload
+{
+    public string Host { get; set; } = string.Empty;
+    public int Port { get; set; }
+    public string Algorithm { get; set; } = string.Empty;
+    public string Fingerprint { get; set; } = string.Empty;
+}
+
+internal sealed class NativeTextPromptPayload
+{
+    public string Prompt { get; set; } = string.Empty;
+}
+
+internal sealed class NativeKeyboardInteractivePromptPayload
+{
+    public string Name { get; set; } = string.Empty;
+    public string Instructions { get; set; } = string.Empty;
+    public List<NativeKeyboardInteractivePromptItem> Prompts { get; set; } = new();
+}
+
+internal sealed class NativeKeyboardInteractivePromptItem
+{
+    public string Prompt { get; set; } = string.Empty;
+    public bool Echo { get; set; }
+}
+
+internal sealed class NativeHostKeyDecisionPayload
+{
+    public bool Accept { get; set; }
+}
+
+internal sealed class NativeTextResponsePayload
+{
+    public string Text { get; set; } = string.Empty;
+}
+
+internal sealed class NativeKeyboardInteractiveResponsePayload
+{
+    public string[] Responses { get; set; } = Array.Empty<string>();
+}

--- a/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using System.Text.Json;
 using NovaTerminal.Core.Replay;
 using NovaTerminal.Core.Ssh.Interactions;
 using NovaTerminal.Core.Ssh.Launch;
@@ -294,7 +293,7 @@ public sealed class NativeSshSession : ITerminalSession
             _metrics.MarkAuthenticationPromptStarted();
         }
 
-        SshInteractionRequest request = CreateInteractionRequest(nextEvent);
+        SshInteractionRequest request = NativeSshInteractionJson.ParseRequest(nextEvent.Kind, nextEvent.Payload);
         SshInteractionResponse response = _interactionHandler == null
             ? SshInteractionResponse.Cancel()
             : await _interactionHandler.HandleAsync(request, _pollCts.Token).ConfigureAwait(false);
@@ -308,7 +307,7 @@ public sealed class NativeSshSession : ITerminalSession
             _ => throw new InvalidOperationException($"Unsupported interaction event '{nextEvent.Kind}'.")
         };
 
-        byte[] payload = BuildInteractionPayload(responseKind, response);
+        byte[] payload = NativeSshInteractionJson.BuildResponsePayload(responseKind, response);
         _interop.SubmitResponse(_sessionHandle, responseKind, payload);
 
         if (nextEvent.Kind == NativeSshEventKind.HostKeyPrompt)
@@ -339,104 +338,4 @@ public sealed class NativeSshSession : ITerminalSession
         }
     }
 
-    private static SshInteractionRequest CreateInteractionRequest(NativeSshEvent nextEvent)
-    {
-        return nextEvent.Kind switch
-        {
-            NativeSshEventKind.HostKeyPrompt => CreateHostKeyRequest(nextEvent.Payload),
-            NativeSshEventKind.PasswordPrompt => CreateTextPromptRequest(SshInteractionKind.Password, nextEvent.Payload),
-            NativeSshEventKind.PassphrasePrompt => CreateTextPromptRequest(SshInteractionKind.Passphrase, nextEvent.Payload),
-            NativeSshEventKind.KeyboardInteractivePrompt => CreateKeyboardRequest(nextEvent.Payload),
-            _ => throw new InvalidOperationException($"Unsupported interaction event '{nextEvent.Kind}'.")
-        };
-    }
-
-    private static SshInteractionRequest CreateHostKeyRequest(byte[] payload)
-    {
-        HostKeyPromptPayload? model = JsonSerializer.Deserialize<HostKeyPromptPayload>(payload);
-        if (model == null)
-        {
-            throw new InvalidOperationException("Failed to parse host key prompt payload.");
-        }
-
-        return new SshInteractionRequest
-        {
-            Kind = SshInteractionKind.UnknownHostKey,
-            Host = model.Host,
-            Port = model.Port,
-            Algorithm = model.Algorithm,
-            Fingerprint = model.Fingerprint
-        };
-    }
-
-    private static SshInteractionRequest CreateTextPromptRequest(SshInteractionKind kind, byte[] payload)
-    {
-        TextPromptPayload? model = JsonSerializer.Deserialize<TextPromptPayload>(payload);
-        if (model == null)
-        {
-            throw new InvalidOperationException("Failed to parse authentication prompt payload.");
-        }
-
-        return new SshInteractionRequest
-        {
-            Kind = kind,
-            Prompt = model.Prompt
-        };
-    }
-
-    private static SshInteractionRequest CreateKeyboardRequest(byte[] payload)
-    {
-        KeyboardInteractivePromptPayload? model = JsonSerializer.Deserialize<KeyboardInteractivePromptPayload>(payload);
-        if (model == null)
-        {
-            throw new InvalidOperationException("Failed to parse keyboard-interactive payload.");
-        }
-
-        return new SshInteractionRequest
-        {
-            Kind = SshInteractionKind.KeyboardInteractive,
-            Name = model.Name,
-            Instructions = model.Instructions,
-            KeyboardPrompts = model.Prompts.Select(prompt => new SshKeyboardPrompt(prompt.Prompt, prompt.Echo)).ToArray()
-        };
-    }
-
-    private static byte[] BuildInteractionPayload(NativeSshResponseKind responseKind, SshInteractionResponse response)
-    {
-        object body = responseKind switch
-        {
-            NativeSshResponseKind.HostKeyDecision => new { accept = response.IsAccepted && !response.IsCanceled },
-            NativeSshResponseKind.Password or NativeSshResponseKind.Passphrase => new { text = response.IsCanceled ? string.Empty : response.Secret ?? string.Empty },
-            NativeSshResponseKind.KeyboardInteractive => new { responses = response.IsCanceled ? Array.Empty<string>() : response.KeyboardResponses.ToArray() },
-            _ => throw new InvalidOperationException($"Unsupported native SSH response kind '{responseKind}'.")
-        };
-
-        return Encoding.UTF8.GetBytes(JsonSerializer.Serialize(body));
-    }
-
-    private sealed class HostKeyPromptPayload
-    {
-        public string Host { get; set; } = string.Empty;
-        public int Port { get; set; }
-        public string Algorithm { get; set; } = string.Empty;
-        public string Fingerprint { get; set; } = string.Empty;
-    }
-
-    private sealed class TextPromptPayload
-    {
-        public string Prompt { get; set; } = string.Empty;
-    }
-
-    private sealed class KeyboardInteractivePromptPayload
-    {
-        public string Name { get; set; } = string.Empty;
-        public string Instructions { get; set; } = string.Empty;
-        public List<KeyboardInteractivePromptItem> Prompts { get; set; } = new();
-    }
-
-    private sealed class KeyboardInteractivePromptItem
-    {
-        public string Prompt { get; set; } = string.Empty;
-        public bool Echo { get; set; }
-    }
 }

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshInteractionJsonTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshInteractionJsonTests.cs
@@ -1,0 +1,32 @@
+using System.Text;
+using NovaTerminal.Core.Ssh.Interactions;
+using NovaTerminal.Core.Ssh.Native;
+
+namespace NovaTerminal.Core.Tests.Ssh;
+
+public sealed class NativeSshInteractionJsonTests
+{
+    [Fact]
+    public void ParseRequest_ParsesHostKeyPromptPayload()
+    {
+        SshInteractionRequest request = NativeSshInteractionJson.ParseRequest(
+            NativeSshEventKind.HostKeyPrompt,
+            Encoding.UTF8.GetBytes("""{"host":"srv","port":22,"algorithm":"ssh-ed25519","fingerprint":"SHA256:test"}"""));
+
+        Assert.Equal(SshInteractionKind.UnknownHostKey, request.Kind);
+        Assert.Equal("srv", request.Host);
+        Assert.Equal(22, request.Port);
+        Assert.Equal("ssh-ed25519", request.Algorithm);
+        Assert.Equal("SHA256:test", request.Fingerprint);
+    }
+
+    [Fact]
+    public void BuildResponsePayload_SerializesKeyboardInteractiveResponsesDeterministically()
+    {
+        byte[] payload = NativeSshInteractionJson.BuildResponsePayload(
+            NativeSshResponseKind.KeyboardInteractive,
+            SshInteractionResponse.FromKeyboardResponses("code", "backup"));
+
+        Assert.Equal("""{"responses":["code","backup"]}""", Encoding.UTF8.GetString(payload));
+    }
+}

--- a/tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs
@@ -1,3 +1,6 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
 using NovaTerminal.Core.Ssh.Interactions;
 using NovaTerminal.Core.Ssh.Native;
 using NovaTerminal.Services.Ssh;
@@ -7,6 +10,58 @@ namespace NovaTerminal.Tests.Ssh;
 
 public sealed class SshInteractionServiceTests
 {
+    [AvaloniaFact]
+    public async Task BackgroundThreadRequests_AreMarshalledToUiThread()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            var owner = new Window();
+            var knownHosts = new NativeKnownHostsStore(Path.Combine(tempRoot, "native_known_hosts.json"));
+            int presenterThreadId = -1;
+            int ownerThreadId = -1;
+
+            var service = new SshInteractionService(
+                ownerProvider: () =>
+                {
+                    Assert.True(Dispatcher.UIThread.CheckAccess());
+                    ownerThreadId = Environment.CurrentManagedThreadId;
+                    return owner;
+                },
+                hostKeyPresenter: (_, _, _) =>
+                {
+                    Assert.True(Dispatcher.UIThread.CheckAccess());
+                    presenterThreadId = Environment.CurrentManagedThreadId;
+                    return Task.FromResult(SshInteractionResponse.AcceptHostKey());
+                },
+                knownHostsStore: knownHosts);
+
+            int workerThreadId = -1;
+            var response = await Task.Run(async () =>
+            {
+                workerThreadId = Environment.CurrentManagedThreadId;
+                return await service.HandleAsync(new SshInteractionRequest
+                {
+                    Kind = SshInteractionKind.UnknownHostKey,
+                    Host = "example.internal",
+                    Port = 22,
+                    Algorithm = "ssh-ed25519",
+                    Fingerprint = "SHA256:test"
+                }, CancellationToken.None);
+            });
+
+            Assert.True(response.IsAccepted);
+            Assert.NotEqual(-1, ownerThreadId);
+            Assert.NotEqual(-1, presenterThreadId);
+            Assert.NotEqual(workerThreadId, ownerThreadId);
+            Assert.NotEqual(workerThreadId, presenterThreadId);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
     [Fact]
     public async Task HostKeyRequestsMapToHostKeyPromptViewModel()
     {


### PR DESCRIPTION
## Summary
- move native SSH interaction payload parsing/serialization onto a source-generated JSON context
- dispatch SSH interaction handling onto Avalonia's UI thread before resolving owners or showing dialogs
- add regression tests for native SSH interaction JSON payloads and background-thread UI marshalling

## Test Plan
- [x] manual native SSH validation accepted
- [x] `dotnet msbuild src/NovaTerminal.App/NovaTerminal.App.csproj /t:Compile /p:Configuration=Debug /p:SKIP_RUST_NATIVE_BUILD=1`
- [x] `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~Ssh"`
- [ ] full app-side test/build rerun after closing the running NovaTerminal process that is locking debug/release outputs
