### PR TITLE
Add native SSH password memory

### DIFF
--- a/src/NovaTerminal.App/Core/VaultService.cs
+++ b/src/NovaTerminal.App/Core/VaultService.cs
@@ -8,7 +8,13 @@ using System.Runtime.InteropServices;
 
 namespace NovaTerminal.Core
 {
+    public interface ISshPasswordVault
+    {
+        void ApplyRememberPasswordPreference(Guid profileId, bool rememberPasswordInVault, string? password = null);
+    }
+
     public class VaultService
+        : ISshPasswordVault
     {
         private const string AppName = "NovaTerminal";
         private const string VaultFileName = "vault.dat";
@@ -43,6 +49,41 @@ namespace NovaTerminal.Core
         public static string GetCanonicalSshProfileKey(Guid profileId)
         {
             return $"SSH:PROFILE:{profileId:D}";
+        }
+
+        public static void ApplyRememberPasswordPreference(
+            Guid profileId,
+            bool rememberPasswordInVault,
+            string? password,
+            Action<string> removeSecret,
+            Action<string, string> writeSecret)
+        {
+            ArgumentNullException.ThrowIfNull(removeSecret);
+            ArgumentNullException.ThrowIfNull(writeSecret);
+
+            string canonicalKey = GetCanonicalSshProfileKey(profileId);
+            if (!rememberPasswordInVault)
+            {
+                removeSecret(canonicalKey);
+                return;
+            }
+
+            if (string.IsNullOrEmpty(password))
+            {
+                return;
+            }
+
+            writeSecret(canonicalKey, password);
+        }
+
+        public void ApplyRememberPasswordPreference(Guid profileId, bool rememberPasswordInVault, string? password = null)
+        {
+            ApplyRememberPasswordPreference(
+                profileId,
+                rememberPasswordInVault,
+                password,
+                key => _ = RemoveSecret(key),
+                SetSecret);
         }
 
         public static IEnumerable<string> GetLegacySshKeys(TerminalProfile profile)

--- a/src/NovaTerminal.App/Core/VaultService.cs
+++ b/src/NovaTerminal.App/Core/VaultService.cs
@@ -20,6 +20,7 @@ namespace NovaTerminal.Core
         private const string AppName = "NovaTerminal";
         private const string VaultFileName = "vault.dat";
         private readonly string _vaultPath;
+        private readonly bool _useFileBackedStore;
         private Dictionary<string, string> _secrets;
 
 #pragma warning disable CA1416 // Validate platform compatibility
@@ -28,6 +29,9 @@ namespace NovaTerminal.Core
         {
             try
             {
+                _useFileBackedStore = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    || !string.IsNullOrWhiteSpace(vaultPath);
+
                 if (!string.IsNullOrWhiteSpace(vaultPath))
                 {
                     _vaultPath = vaultPath;
@@ -37,8 +41,7 @@ namespace NovaTerminal.Core
                         Directory.CreateDirectory(vaultDirectory);
                     }
 
-                    _secrets = new Dictionary<string, string>();
-                    Load();
+                    _secrets = LoadSecretsOrEmpty();
                     return;
                 }
 
@@ -49,14 +52,13 @@ namespace NovaTerminal.Core
                     Directory.CreateDirectory(directory);
                 }
                 _vaultPath = Path.Combine(directory, VaultFileName);
-                _secrets = new Dictionary<string, string>();
-
-                Load();
+                _secrets = LoadSecretsOrEmpty();
             }
             catch
             {
                 // Fallback if filesystem access fails
                 _vaultPath = string.Empty;
+                _useFileBackedStore = true;
                 _secrets = new Dictionary<string, string>();
             }
         }
@@ -104,7 +106,7 @@ namespace NovaTerminal.Core
 
             if (!rememberPasswordInVault)
             {
-                foreach (string key in GetSshPasswordKeysForProfile(profile))
+                foreach (string key in GetProfileScopedSshPasswordKeysForProfile(profile))
                 {
                     removeSecret(key);
                 }
@@ -140,7 +142,7 @@ namespace NovaTerminal.Core
                 SetSecret);
         }
 
-        public static IEnumerable<string> GetLegacySshKeys(TerminalProfile profile)
+        public static IEnumerable<string> GetLegacySshKeys(TerminalProfile profile, bool includeSharedAlias = true)
         {
             ArgumentNullException.ThrowIfNull(profile);
 
@@ -155,7 +157,10 @@ namespace NovaTerminal.Core
                     yield return $"SSH:{name}:{user}@{host}";
                 }
 
-                yield return $"SSH:{user}@{host}";
+                if (includeSharedAlias)
+                {
+                    yield return $"SSH:{user}@{host}";
+                }
             }
 
             yield return $"profile_{profile.Id}_password";
@@ -167,6 +172,17 @@ namespace NovaTerminal.Core
 
             yield return GetCanonicalSshProfileKey(profile.Id);
             foreach (string legacyKey in GetLegacySshKeys(profile))
+            {
+                yield return legacyKey;
+            }
+        }
+
+        public static IEnumerable<string> GetProfileScopedSshPasswordKeysForProfile(TerminalProfile profile)
+        {
+            ArgumentNullException.ThrowIfNull(profile);
+
+            yield return GetCanonicalSshProfileKey(profile.Id);
+            foreach (string legacyKey in GetLegacySshKeys(profile, includeSharedAlias: false))
             {
                 yield return legacyKey;
             }
@@ -224,7 +240,7 @@ namespace NovaTerminal.Core
         {
             ReloadIfFileBacked();
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (UsesWindowsCredentialManager)
             {
                 // Native Windows Credential Manager
                 // Key format usually: "NovaTerminal:SSH:User@Host"
@@ -269,7 +285,7 @@ namespace NovaTerminal.Core
         {
             ReloadIfFileBacked();
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (UsesWindowsCredentialManager)
             {
                 string target = key.StartsWith("NovaTerminal:") ? key : $"NovaTerminal:{key}";
                 var cred = Native.Win32CredentialManager.Read(target);
@@ -287,7 +303,7 @@ namespace NovaTerminal.Core
         {
             ReloadIfFileBacked();
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (UsesWindowsCredentialManager)
             {
                 string target = key.StartsWith("NovaTerminal:") ? key : $"NovaTerminal:{key}";
                 return Native.Win32CredentialManager.Delete(target);
@@ -309,13 +325,15 @@ namespace NovaTerminal.Core
 
         private void ReloadIfFileBacked()
         {
-            if (string.IsNullOrEmpty(_vaultPath) || RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (!_useFileBackedStore)
             {
                 return;
             }
 
-            _secrets = new Dictionary<string, string>();
-            Load();
+            if (TryLoadSecrets(out Dictionary<string, string> secrets))
+            {
+                _secrets = secrets;
+            }
         }
 
         private void Save()
@@ -347,9 +365,20 @@ namespace NovaTerminal.Core
             }
         }
 
-        private void Load()
+        private Dictionary<string, string> LoadSecretsOrEmpty()
         {
-            if (string.IsNullOrEmpty(_vaultPath) || !File.Exists(_vaultPath)) return;
+            return TryLoadSecrets(out Dictionary<string, string> secrets)
+                ? secrets
+                : new Dictionary<string, string>();
+        }
+
+        private bool TryLoadSecrets(out Dictionary<string, string> secrets)
+        {
+            secrets = new Dictionary<string, string>();
+            if (string.IsNullOrEmpty(_vaultPath) || !File.Exists(_vaultPath))
+            {
+                return true;
+            }
 
             try
             {
@@ -371,14 +400,20 @@ namespace NovaTerminal.Core
                 var loaded = JsonSerializer.Deserialize(json, AppJsonContext.Default.DictionaryStringString);
                 if (loaded != null)
                 {
-                    _secrets = loaded;
+                    secrets = loaded;
                 }
+
+                return true;
             }
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"[Vault] Load failed: {ex.Message}");
+                return false;
             }
         }
+
+        private bool UsesWindowsCredentialManager =>
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !_useFileBackedStore;
 
         private byte[] EncryptFallback(byte[] data)
         {

--- a/src/NovaTerminal.App/Core/VaultService.cs
+++ b/src/NovaTerminal.App/Core/VaultService.cs
@@ -24,10 +24,24 @@ namespace NovaTerminal.Core
 
 #pragma warning disable CA1416 // Validate platform compatibility
 
-        public VaultService()
+        public VaultService(string? vaultPath = null)
         {
             try
             {
+                if (!string.IsNullOrWhiteSpace(vaultPath))
+                {
+                    _vaultPath = vaultPath;
+                    string? vaultDirectory = Path.GetDirectoryName(_vaultPath);
+                    if (!string.IsNullOrEmpty(vaultDirectory) && !Directory.Exists(vaultDirectory))
+                    {
+                        Directory.CreateDirectory(vaultDirectory);
+                    }
+
+                    _secrets = new Dictionary<string, string>();
+                    Load();
+                    return;
+                }
+
                 string appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
                 string directory = Path.Combine(appData, AppName);
                 if (!Directory.Exists(directory))

--- a/src/NovaTerminal.App/Core/VaultService.cs
+++ b/src/NovaTerminal.App/Core/VaultService.cs
@@ -11,6 +11,7 @@ namespace NovaTerminal.Core
     public interface ISshPasswordVault
     {
         void ApplyRememberPasswordPreference(Guid profileId, bool rememberPasswordInVault, string? password = null);
+        void ApplyRememberPasswordPreference(TerminalProfile profile, bool rememberPasswordInVault, string? password = null);
     }
 
     public class VaultService
@@ -76,10 +77,49 @@ namespace NovaTerminal.Core
             writeSecret(canonicalKey, password);
         }
 
+        public static void ApplyRememberPasswordPreference(
+            TerminalProfile profile,
+            bool rememberPasswordInVault,
+            string? password,
+            Action<string> removeSecret,
+            Action<string, string> writeSecret)
+        {
+            ArgumentNullException.ThrowIfNull(profile);
+            ArgumentNullException.ThrowIfNull(removeSecret);
+            ArgumentNullException.ThrowIfNull(writeSecret);
+
+            if (!rememberPasswordInVault)
+            {
+                foreach (string key in GetSshPasswordKeysForProfile(profile))
+                {
+                    removeSecret(key);
+                }
+
+                return;
+            }
+
+            if (string.IsNullOrEmpty(password))
+            {
+                return;
+            }
+
+            writeSecret(GetCanonicalSshProfileKey(profile.Id), password);
+        }
+
         public void ApplyRememberPasswordPreference(Guid profileId, bool rememberPasswordInVault, string? password = null)
         {
             ApplyRememberPasswordPreference(
                 profileId,
+                rememberPasswordInVault,
+                password,
+                key => _ = RemoveSecret(key),
+                SetSecret);
+        }
+
+        public void ApplyRememberPasswordPreference(TerminalProfile profile, bool rememberPasswordInVault, string? password = null)
+        {
+            ApplyRememberPasswordPreference(
+                profile,
                 rememberPasswordInVault,
                 password,
                 key => _ = RemoveSecret(key),
@@ -105,6 +145,17 @@ namespace NovaTerminal.Core
             }
 
             yield return $"profile_{profile.Id}_password";
+        }
+
+        public static IEnumerable<string> GetSshPasswordKeysForProfile(TerminalProfile profile)
+        {
+            ArgumentNullException.ThrowIfNull(profile);
+
+            yield return GetCanonicalSshProfileKey(profile.Id);
+            foreach (string legacyKey in GetLegacySshKeys(profile))
+            {
+                yield return legacyKey;
+            }
         }
 
         public static string? ResolveSshPasswordForProfile(

--- a/src/NovaTerminal.App/Core/VaultService.cs
+++ b/src/NovaTerminal.App/Core/VaultService.cs
@@ -222,6 +222,8 @@ namespace NovaTerminal.Core
 
         public void SetSecret(string key, string value)
         {
+            ReloadIfFileBacked();
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // Native Windows Credential Manager
@@ -265,6 +267,8 @@ namespace NovaTerminal.Core
 
         public string? GetSecret(string key)
         {
+            ReloadIfFileBacked();
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 string target = key.StartsWith("NovaTerminal:") ? key : $"NovaTerminal:{key}";
@@ -281,6 +285,8 @@ namespace NovaTerminal.Core
 
         public bool RemoveSecret(string key)
         {
+            ReloadIfFileBacked();
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 string target = key.StartsWith("NovaTerminal:") ? key : $"NovaTerminal:{key}";
@@ -297,7 +303,19 @@ namespace NovaTerminal.Core
 
         public IEnumerable<string> ListKeys()
         {
+            ReloadIfFileBacked();
             return _secrets.Keys;
+        }
+
+        private void ReloadIfFileBacked()
+        {
+            if (string.IsNullOrEmpty(_vaultPath) || RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
+            _secrets = new Dictionary<string, string>();
+            Load();
         }
 
         private void Save()

--- a/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
@@ -269,6 +269,7 @@ public sealed class SshConnectionService
         merged.Port = incoming.Port;
         merged.AuthMode = incoming.AuthMode;
         merged.IdentityFilePath = incoming.IdentityFilePath;
+        merged.RememberPasswordInVault = incoming.RememberPasswordInVault;
         merged.JumpHops = incoming.JumpHops.Select(CloneJumpHop).ToList();
         merged.Forwards = incoming.Forwards.Select(CloneForward).ToList();
         merged.MuxOptions = CloneMuxOptions(incoming.MuxOptions);
@@ -569,6 +570,7 @@ public sealed class SshConnectionService
             Port = profile.Port,
             AuthMode = profile.AuthMode,
             IdentityFilePath = profile.IdentityFilePath,
+            RememberPasswordInVault = profile.RememberPasswordInVault,
             JumpHops = profile.JumpHops.Select(CloneJumpHop).ToList(),
             Forwards = profile.Forwards.Select(CloneForward).ToList(),
             MuxOptions = CloneMuxOptions(profile.MuxOptions),

--- a/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
@@ -18,16 +18,23 @@ public sealed class SshLaunchDetails
     public required string CommandLine { get; init; }
 }
 
-public sealed class SshConnectionService
-{
-    private const string FavoriteTag = "favorite";
-
-    private readonly ISshProfileStore _profileStore;
-
-    public SshConnectionService(ISshProfileStore? profileStore = null)
+    public sealed class SshConnectionService
     {
-        _profileStore = profileStore ?? new JsonSshProfileStore();
-    }
+        private const string FavoriteTag = "favorite";
+
+        private readonly ISshProfileStore _profileStore;
+        private readonly ISshPasswordVault? _passwordVault;
+
+        public SshConnectionService(ISshProfileStore? profileStore = null)
+            : this(profileStore, null)
+        {
+        }
+
+        public SshConnectionService(ISshProfileStore? profileStore, ISshPasswordVault? passwordVault)
+        {
+            _profileStore = profileStore ?? new JsonSshProfileStore();
+            _passwordVault = passwordVault ?? new VaultService();
+        }
 
     public IReadOnlyList<TerminalProfile> GetConnectionProfiles()
     {
@@ -86,6 +93,7 @@ public sealed class SshConnectionService
         SshProfile merged = MergeProfile(existing, incoming, viewModel.IsFavorite);
 
         _profileStore.SaveProfile(merged);
+        _passwordVault?.ApplyRememberPasswordPreference(merged.Id, merged.RememberPasswordInVault);
         return _profileStore.GetProfile(merged.Id) ?? merged;
     }
 
@@ -127,6 +135,7 @@ public sealed class SshConnectionService
         SshProfileNormalizer.NormalizeRememberPasswordPreference(candidate);
 
         _profileStore.SaveProfile(candidate);
+        _passwordVault?.ApplyRememberPasswordPreference(candidate.Id, candidate.RememberPasswordInVault);
     }
 
     public void SaveConnectionProfiles(IEnumerable<TerminalProfile> profiles)

--- a/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
@@ -78,6 +78,7 @@ public sealed class SshConnectionService
         if (existing != null && viewModel.BackendKind is null)
         {
             incoming.BackendKind = existing.BackendKind;
+            incoming.RememberPasswordInVault = NormalizeRememberPasswordPreference(existing.BackendKind, existing.RememberPasswordInVault);
         }
 
         SshProfile merged = MergeProfile(existing, incoming, viewModel.IsFavorite);

--- a/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
@@ -121,6 +121,7 @@ public sealed class SshConnectionService
         bool useIdentity = !profile.UseSshAgent && !string.IsNullOrWhiteSpace(identityPath);
         candidate.AuthMode = useIdentity ? SshAuthMode.IdentityFile : SshAuthMode.Agent;
         candidate.IdentityFilePath = useIdentity ? identityPath : string.Empty;
+        candidate.RememberPasswordInVault = NormalizeRememberPasswordPreference(candidate.BackendKind, candidate.RememberPasswordInVault);
 
         _profileStore.SaveProfile(candidate);
     }
@@ -269,7 +270,7 @@ public sealed class SshConnectionService
         merged.Port = incoming.Port;
         merged.AuthMode = incoming.AuthMode;
         merged.IdentityFilePath = incoming.IdentityFilePath;
-        merged.RememberPasswordInVault = incoming.RememberPasswordInVault;
+        merged.RememberPasswordInVault = NormalizeRememberPasswordPreference(incoming.BackendKind, incoming.RememberPasswordInVault);
         merged.JumpHops = incoming.JumpHops.Select(CloneJumpHop).ToList();
         merged.Forwards = incoming.Forwards.Select(CloneForward).ToList();
         merged.MuxOptions = CloneMuxOptions(incoming.MuxOptions);
@@ -579,6 +580,11 @@ public sealed class SshConnectionService
             ExtraSshArgs = profile.ExtraSshArgs,
             WorkingDirectory = profile.WorkingDirectory
         };
+    }
+
+    private static bool NormalizeRememberPasswordPreference(SshBackendKind backendKind, bool rememberPasswordInVault)
+    {
+        return backendKind == SshBackendKind.Native && rememberPasswordInVault;
     }
 
     private static SshJumpHop CloneJumpHop(SshJumpHop hop)

--- a/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
@@ -78,8 +78,10 @@ public sealed class SshConnectionService
         if (existing != null && viewModel.BackendKind is null)
         {
             incoming.BackendKind = existing.BackendKind;
-            incoming.RememberPasswordInVault = NormalizeRememberPasswordPreference(existing.BackendKind, existing.RememberPasswordInVault);
+            incoming.RememberPasswordInVault = existing.RememberPasswordInVault;
         }
+
+        SshProfileNormalizer.NormalizeRememberPasswordPreference(incoming);
 
         SshProfile merged = MergeProfile(existing, incoming, viewModel.IsFavorite);
 
@@ -122,7 +124,7 @@ public sealed class SshConnectionService
         bool useIdentity = !profile.UseSshAgent && !string.IsNullOrWhiteSpace(identityPath);
         candidate.AuthMode = useIdentity ? SshAuthMode.IdentityFile : SshAuthMode.Agent;
         candidate.IdentityFilePath = useIdentity ? identityPath : string.Empty;
-        candidate.RememberPasswordInVault = NormalizeRememberPasswordPreference(candidate.BackendKind, candidate.RememberPasswordInVault);
+        SshProfileNormalizer.NormalizeRememberPasswordPreference(candidate);
 
         _profileStore.SaveProfile(candidate);
     }
@@ -271,7 +273,7 @@ public sealed class SshConnectionService
         merged.Port = incoming.Port;
         merged.AuthMode = incoming.AuthMode;
         merged.IdentityFilePath = incoming.IdentityFilePath;
-        merged.RememberPasswordInVault = NormalizeRememberPasswordPreference(incoming.BackendKind, incoming.RememberPasswordInVault);
+        merged.RememberPasswordInVault = incoming.RememberPasswordInVault;
         merged.JumpHops = incoming.JumpHops.Select(CloneJumpHop).ToList();
         merged.Forwards = incoming.Forwards.Select(CloneForward).ToList();
         merged.MuxOptions = CloneMuxOptions(incoming.MuxOptions);
@@ -290,6 +292,7 @@ public sealed class SshConnectionService
 
         IEnumerable<string> sourceTags = (IEnumerable<string>?)existing?.Tags ?? Array.Empty<string>();
         merged.Tags = NormalizeTags(sourceTags, favorite);
+        SshProfileNormalizer.NormalizeRememberPasswordPreference(merged);
         return merged;
     }
 
@@ -581,11 +584,6 @@ public sealed class SshConnectionService
             ExtraSshArgs = profile.ExtraSshArgs,
             WorkingDirectory = profile.WorkingDirectory
         };
-    }
-
-    private static bool NormalizeRememberPasswordPreference(SshBackendKind backendKind, bool rememberPasswordInVault)
-    {
-        return backendKind == SshBackendKind.Native && rememberPasswordInVault;
     }
 
     private static SshJumpHop CloneJumpHop(SshJumpHop hop)

--- a/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
@@ -93,7 +93,7 @@ public sealed class SshLaunchDetails
         SshProfile merged = MergeProfile(existing, incoming, viewModel.IsFavorite);
 
         _profileStore.SaveProfile(merged);
-        _passwordVault?.ApplyRememberPasswordPreference(ToRuntimeProfile(merged), merged.RememberPasswordInVault);
+        ApplyRememberPasswordPreference(ToRuntimeProfile(merged), existing, merged.RememberPasswordInVault);
         return _profileStore.GetProfile(merged.Id) ?? merged;
     }
 
@@ -135,7 +135,7 @@ public sealed class SshLaunchDetails
         SshProfileNormalizer.NormalizeRememberPasswordPreference(candidate);
 
         _profileStore.SaveProfile(candidate);
-        _passwordVault?.ApplyRememberPasswordPreference(profile, candidate.RememberPasswordInVault);
+        ApplyRememberPasswordPreference(profile, existing, candidate.RememberPasswordInVault);
     }
 
     public void SaveConnectionProfiles(IEnumerable<TerminalProfile> profiles)
@@ -146,6 +146,21 @@ public sealed class SshLaunchDetails
         {
             SaveConnectionProfile(profile);
         }
+    }
+
+    private void ApplyRememberPasswordPreference(TerminalProfile currentProfile, SshProfile? previousProfile, bool rememberPasswordInVault)
+    {
+        if (_passwordVault == null)
+        {
+            return;
+        }
+
+        if (previousProfile != null)
+        {
+            _passwordVault.ApplyRememberPasswordPreference(ToRuntimeProfile(previousProfile), rememberPasswordInVault);
+        }
+
+        _passwordVault.ApplyRememberPasswordPreference(currentProfile, rememberPasswordInVault);
     }
 
     public bool DeleteProfile(Guid profileId)

--- a/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
@@ -93,7 +93,7 @@ public sealed class SshLaunchDetails
         SshProfile merged = MergeProfile(existing, incoming, viewModel.IsFavorite);
 
         _profileStore.SaveProfile(merged);
-        _passwordVault?.ApplyRememberPasswordPreference(merged.Id, merged.RememberPasswordInVault);
+        _passwordVault?.ApplyRememberPasswordPreference(ToRuntimeProfile(merged), merged.RememberPasswordInVault);
         return _profileStore.GetProfile(merged.Id) ?? merged;
     }
 
@@ -135,7 +135,7 @@ public sealed class SshLaunchDetails
         SshProfileNormalizer.NormalizeRememberPasswordPreference(candidate);
 
         _profileStore.SaveProfile(candidate);
-        _passwordVault?.ApplyRememberPasswordPreference(candidate.Id, candidate.RememberPasswordInVault);
+        _passwordVault?.ApplyRememberPasswordPreference(profile, candidate.RememberPasswordInVault);
     }
 
     public void SaveConnectionProfiles(IEnumerable<TerminalProfile> profiles)

--- a/src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls;
@@ -20,7 +19,6 @@ public sealed class SshInteractionService : ISshInteractionService
     private readonly Func<Window?, AuthPromptViewModel, CancellationToken, Task<SshInteractionResponse>> _authPresenter;
     private readonly NativeKnownHostsStore _knownHostsStore;
     private readonly VaultService _vaultService;
-    private readonly ConcurrentDictionary<Guid, byte> _usedVaultPasswordsBySession = new();
 
     public SshInteractionService(
         Func<Window?>? ownerProvider = null,
@@ -79,14 +77,8 @@ public sealed class SshInteractionService : ISshInteractionService
     {
         if (request.Kind != SshInteractionKind.Password ||
             !request.RememberPasswordInVault ||
-            !request.ProfileId.HasValue)
-        {
-            response = SshInteractionResponse.Cancel();
-            return false;
-        }
-
-        if (request.SessionId.HasValue &&
-            _usedVaultPasswordsBySession.ContainsKey(request.SessionId.Value))
+            !request.ProfileId.HasValue ||
+            !request.AllowVaultPasswordReuse)
         {
             response = SshInteractionResponse.Cancel();
             return false;
@@ -97,11 +89,6 @@ public sealed class SshInteractionService : ISshInteractionService
         {
             response = SshInteractionResponse.Cancel();
             return false;
-        }
-
-        if (request.SessionId.HasValue)
-        {
-            _ = _usedVaultPasswordsBySession.TryAdd(request.SessionId.Value, 0);
         }
 
         response = SshInteractionResponse.FromSecret(password);

--- a/src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs
@@ -18,19 +18,22 @@ public sealed class SshInteractionService : ISshInteractionService
     private readonly Func<Window?, HostKeyPromptViewModel, CancellationToken, Task<SshInteractionResponse>> _hostKeyPresenter;
     private readonly Func<Window?, AuthPromptViewModel, CancellationToken, Task<SshInteractionResponse>> _authPresenter;
     private readonly NativeKnownHostsStore _knownHostsStore;
+    private readonly VaultService _vaultService;
 
     public SshInteractionService(
         Func<Window?>? ownerProvider = null,
         Action<Window>? prepareDialog = null,
         Func<Window?, HostKeyPromptViewModel, CancellationToken, Task<SshInteractionResponse>>? hostKeyPresenter = null,
         Func<Window?, AuthPromptViewModel, CancellationToken, Task<SshInteractionResponse>>? authPresenter = null,
-        NativeKnownHostsStore? knownHostsStore = null)
+        NativeKnownHostsStore? knownHostsStore = null,
+        VaultService? vaultService = null)
     {
         _ownerProvider = ownerProvider ?? (() => null);
         _prepareDialog = prepareDialog;
         _hostKeyPresenter = hostKeyPresenter ?? PresentHostKeyAsync;
         _authPresenter = authPresenter ?? PresentAuthAsync;
         _knownHostsStore = knownHostsStore ?? new NativeKnownHostsStore(AppPaths.NativeKnownHostsFilePath);
+        _vaultService = vaultService ?? new VaultService();
     }
 
     public async Task<SshInteractionResponse> HandleAsync(SshInteractionRequest request, CancellationToken cancellationToken)
@@ -54,6 +57,11 @@ public sealed class SshInteractionService : ISshInteractionService
 
     private async Task<SshInteractionResponse> HandleOnUiThreadAsync(SshInteractionRequest request, CancellationToken cancellationToken)
     {
+        if (TryHandlePasswordFromVault(request, out SshInteractionResponse response))
+        {
+            return response;
+        }
+
         Window? owner = _ownerProvider();
         return request.Kind switch
         {
@@ -63,6 +71,27 @@ public sealed class SshInteractionService : ISshInteractionService
             SshInteractionKind.KeyboardInteractive => await _authPresenter(owner, CreateKeyboardViewModel(request), cancellationToken),
             _ => SshInteractionResponse.Cancel()
         };
+    }
+
+    private bool TryHandlePasswordFromVault(SshInteractionRequest request, out SshInteractionResponse response)
+    {
+        if (request.Kind != SshInteractionKind.Password ||
+            !request.RememberPasswordInVault ||
+            !request.ProfileId.HasValue)
+        {
+            response = SshInteractionResponse.Cancel();
+            return false;
+        }
+
+        string? password = _vaultService.GetSshPasswordForProfile(new TerminalProfile { Id = request.ProfileId.Value });
+        if (string.IsNullOrEmpty(password))
+        {
+            response = SshInteractionResponse.Cancel();
+            return false;
+        }
+
+        response = SshInteractionResponse.FromSecret(password);
+        return true;
     }
 
     private async Task<SshInteractionResponse> HandleHostKeyAsync(Window? owner, SshInteractionRequest request, CancellationToken cancellationToken)

--- a/src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs
@@ -66,11 +66,22 @@ public sealed class SshInteractionService : ISshInteractionService
         return request.Kind switch
         {
             SshInteractionKind.UnknownHostKey or SshInteractionKind.ChangedHostKey => await HandleHostKeyAsync(owner, request, cancellationToken),
-            SshInteractionKind.Password => await _authPresenter(owner, CreatePasswordViewModel(request), cancellationToken),
+            SshInteractionKind.Password => await HandlePasswordAsync(owner, request, cancellationToken),
             SshInteractionKind.Passphrase => await _authPresenter(owner, CreatePassphraseViewModel(request), cancellationToken),
             SshInteractionKind.KeyboardInteractive => await _authPresenter(owner, CreateKeyboardViewModel(request), cancellationToken),
             _ => SshInteractionResponse.Cancel()
         };
+    }
+
+    private async Task<SshInteractionResponse> HandlePasswordAsync(Window? owner, SshInteractionRequest request, CancellationToken cancellationToken)
+    {
+        SshInteractionResponse response = await _authPresenter(owner, CreatePasswordViewModel(request), cancellationToken);
+        if (ShouldStorePasswordInVault(request, response))
+        {
+            _vaultService.SetSshPasswordForProfile(CreateVaultProfile(request), response.Secret);
+        }
+
+        return response;
     }
 
     private bool TryHandlePasswordFromVault(SshInteractionRequest request, out SshInteractionResponse response)
@@ -177,7 +188,8 @@ public sealed class SshInteractionService : ISshInteractionService
         var viewModel = new AuthPromptViewModel
         {
             Title = "Password",
-            Message = "Enter the SSH password to continue."
+            Message = "Enter the SSH password to continue.",
+            CanRememberPassword = request.RememberPasswordInVault
         };
         viewModel.Prompts.Add(new AuthPromptEntryViewModel
         {
@@ -185,6 +197,16 @@ public sealed class SshInteractionService : ISshInteractionService
             IsSecret = true
         });
         return viewModel;
+    }
+
+    private static bool ShouldStorePasswordInVault(SshInteractionRequest request, SshInteractionResponse response)
+    {
+        return request.Kind == SshInteractionKind.Password &&
+            request.RememberPasswordInVault &&
+            request.ProfileId.HasValue &&
+            !response.IsCanceled &&
+            response.RememberPasswordInVault &&
+            !string.IsNullOrEmpty(response.Secret);
     }
 
     private static AuthPromptViewModel CreatePassphraseViewModel(SshInteractionRequest request)

--- a/src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls;
@@ -19,6 +20,7 @@ public sealed class SshInteractionService : ISshInteractionService
     private readonly Func<Window?, AuthPromptViewModel, CancellationToken, Task<SshInteractionResponse>> _authPresenter;
     private readonly NativeKnownHostsStore _knownHostsStore;
     private readonly VaultService _vaultService;
+    private readonly ConcurrentDictionary<Guid, byte> _usedVaultPasswordsBySession = new();
 
     public SshInteractionService(
         Func<Window?>? ownerProvider = null,
@@ -83,15 +85,38 @@ public sealed class SshInteractionService : ISshInteractionService
             return false;
         }
 
-        string? password = _vaultService.GetSshPasswordForProfile(new TerminalProfile { Id = request.ProfileId.Value });
+        if (request.SessionId.HasValue &&
+            _usedVaultPasswordsBySession.ContainsKey(request.SessionId.Value))
+        {
+            response = SshInteractionResponse.Cancel();
+            return false;
+        }
+
+        string? password = _vaultService.GetSshPasswordForProfile(CreateVaultProfile(request));
         if (string.IsNullOrEmpty(password))
         {
             response = SshInteractionResponse.Cancel();
             return false;
         }
 
+        if (request.SessionId.HasValue)
+        {
+            _ = _usedVaultPasswordsBySession.TryAdd(request.SessionId.Value, 0);
+        }
+
         response = SshInteractionResponse.FromSecret(password);
         return true;
+    }
+
+    private static TerminalProfile CreateVaultProfile(SshInteractionRequest request)
+    {
+        return new TerminalProfile
+        {
+            Id = request.ProfileId!.Value,
+            Name = request.ProfileName,
+            SshUser = request.ProfileUser,
+            SshHost = request.ProfileHost
+        };
     }
 
     private async Task<SshInteractionResponse> HandleHostKeyAsync(Window? owner, SshInteractionRequest request, CancellationToken cancellationToken)

--- a/src/NovaTerminal.App/ViewModels/Ssh/AuthPromptViewModel.cs
+++ b/src/NovaTerminal.App/ViewModels/Ssh/AuthPromptViewModel.cs
@@ -10,13 +10,15 @@ public sealed class AuthPromptViewModel
 {
     public string Title { get; init; } = string.Empty;
     public string Message { get; init; } = string.Empty;
+    public bool CanRememberPassword { get; init; }
+    public bool RememberPassword { get; set; }
     public ObservableCollection<AuthPromptEntryViewModel> Prompts { get; } = new();
 
     public SshInteractionResponse BuildResponse()
     {
         if (Prompts.Count == 1)
         {
-            return SshInteractionResponse.FromSecret(Prompts[0].Value);
+            return SshInteractionResponse.FromSecret(Prompts[0].Value, RememberPassword);
         }
 
         return SshInteractionResponse.FromKeyboardResponses(Prompts.Select(prompt => prompt.Value).ToArray());

--- a/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
+++ b/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
@@ -144,6 +144,7 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
                 }
 
                 OnPropertyChanged(nameof(BackendWarning));
+                OnPropertyChanged(nameof(IsRememberPasswordVisible));
             }
         }
     }
@@ -153,6 +154,8 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
         get => _rememberPasswordInVault;
         set => SetField(ref _rememberPasswordInVault, value);
     }
+
+    public bool IsRememberPasswordVisible => BackendKind == SshBackendKind.Native;
 
     public int KeepAliveIntervalSeconds
     {

--- a/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
+++ b/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
@@ -31,6 +31,7 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
     private string _validationError = string.Empty;
     private string _validationWarning = string.Empty;
     private SshBackendKind? _backendKind;
+    private bool _rememberPasswordInVault;
     private int _keepAliveIntervalSeconds = 30;
     private int _keepAliveCountMax = 3;
     private bool _enableMux;
@@ -137,9 +138,20 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
         {
             if (SetField(ref _backendKind, value))
             {
+                if (value != SshBackendKind.Native)
+                {
+                    RememberPasswordInVault = false;
+                }
+
                 OnPropertyChanged(nameof(BackendWarning));
             }
         }
+    }
+
+    public bool RememberPasswordInVault
+    {
+        get => _rememberPasswordInVault;
+        set => SetField(ref _rememberPasswordInVault, value);
     }
 
     public int KeepAliveIntervalSeconds
@@ -260,6 +272,7 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
         int keepAliveInterval = KeepAliveIntervalSeconds > 0 ? KeepAliveIntervalSeconds : 30;
         int keepAliveCountMax = KeepAliveCountMax > 0 ? KeepAliveCountMax : 3;
         int controlPersistSeconds = ControlPersistSeconds >= 0 ? ControlPersistSeconds : 90;
+        bool rememberPassword = BackendKind == SshBackendKind.Native && RememberPasswordInVault;
 
         return new SshProfile
         {
@@ -274,6 +287,7 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
             Port = port,
             AuthMode = IsIdentityFileAuth ? SshAuthMode.IdentityFile : SshAuthMode.Agent,
             IdentityFilePath = identityPath,
+            RememberPasswordInVault = rememberPassword,
             JumpHops = JumpHops.Select(h => new SshJumpHop
             {
                 Host = h.Host?.Trim() ?? string.Empty,
@@ -357,6 +371,7 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
         IsFavorite = sshProfile.Tags.Any(tag => string.Equals(tag, "favorite", StringComparison.OrdinalIgnoreCase));
         AuthMode = sshProfile.AuthMode == SshAuthMode.IdentityFile ? NewSshAuthMode.IdentityFile : NewSshAuthMode.Agent;
         IdentityFilePath = sshProfile.IdentityFilePath ?? string.Empty;
+        RememberPasswordInVault = sshProfile.BackendKind == SshBackendKind.Native && sshProfile.RememberPasswordInVault;
 
         JumpHops.Clear();
         foreach (SshJumpHop hop in sshProfile.JumpHops)

--- a/src/NovaTerminal.App/Views/Ssh/AuthPromptDialog.axaml
+++ b/src/NovaTerminal.App/Views/Ssh/AuthPromptDialog.axaml
@@ -10,6 +10,7 @@
             <TextBlock Name="DialogTitle" FontSize="18" FontWeight="SemiBold" />
             <TextBlock Name="DialogMessage" TextWrapping="Wrap" />
             <StackPanel Name="PromptHost" Spacing="10" />
+            <CheckBox Name="RememberPasswordToggle" Content="Remember password" />
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
                 <Button Content="Cancel" Width="96" Click="OnCancelClick" />
                 <Button Content="Submit" Width="96" Click="OnSubmitClick" />

--- a/src/NovaTerminal.App/Views/Ssh/AuthPromptDialog.axaml.cs
+++ b/src/NovaTerminal.App/Views/Ssh/AuthPromptDialog.axaml.cs
@@ -31,6 +31,10 @@ public partial class AuthPromptDialog : Window
     {
         this.FindControl<TextBlock>("DialogTitle")!.Text = viewModel.Title;
         this.FindControl<TextBlock>("DialogMessage")!.Text = viewModel.Message;
+        var rememberPasswordToggle = this.FindControl<CheckBox>("RememberPasswordToggle")!;
+        rememberPasswordToggle.IsVisible = viewModel.CanRememberPassword;
+        rememberPasswordToggle.IsChecked = viewModel.RememberPassword;
+        rememberPasswordToggle.IsCheckedChanged += (_, __) => viewModel.RememberPassword = rememberPasswordToggle.IsChecked == true;
 
         var host = this.FindControl<StackPanel>("PromptHost")!;
         host.Children.Clear();

--- a/src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml
+++ b/src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml
@@ -64,7 +64,7 @@
             </TabItem>
 
             <TabItem Header="Auth">
-                <Grid Margin="0,10,0,0" ColumnDefinitions="170,*" RowDefinitions="Auto,Auto,Auto" RowSpacing="10">
+                <Grid Margin="0,10,0,0" ColumnDefinitions="170,*" RowDefinitions="Auto,Auto,Auto,Auto" RowSpacing="10">
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="Auth mode" VerticalAlignment="Center" />
                     <ComboBox Grid.Row="0" Grid.Column="1" Name="AuthModeCombo" SelectedItem="{Binding AuthMode}" />
 
@@ -77,6 +77,12 @@
                         <TextBox Grid.Column="0" Text="{Binding IdentityFilePath}" Watermark="Path to private key" />
                         <Button Grid.Column="1" Content="Browse..." Click="OnBrowseIdentityFileClick" />
                     </Grid>
+
+                    <CheckBox Grid.Row="2"
+                              Grid.Column="1"
+                              Content="Remember password in vault"
+                              IsChecked="{Binding RememberPasswordInVault}"
+                              IsVisible="{Binding IsRememberPasswordVisible}" />
                 </Grid>
             </TabItem>
 

--- a/src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml
+++ b/src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml
@@ -64,7 +64,7 @@
             </TabItem>
 
             <TabItem Header="Auth">
-                <Grid Margin="0,10,0,0" ColumnDefinitions="170,*" RowDefinitions="Auto,Auto,Auto,Auto" RowSpacing="10">
+                <Grid Margin="0,10,0,0" ColumnDefinitions="170,*" RowDefinitions="Auto,Auto,Auto" RowSpacing="10">
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="Auth mode" VerticalAlignment="Center" />
                     <ComboBox Grid.Row="0" Grid.Column="1" Name="AuthModeCombo" SelectedItem="{Binding AuthMode}" />
 

--- a/src/NovaTerminal.Core/Ssh/Interactions/SshInteractionRequest.cs
+++ b/src/NovaTerminal.Core/Ssh/Interactions/SshInteractionRequest.cs
@@ -4,6 +4,10 @@ public sealed class SshInteractionRequest
 {
     public SshInteractionKind Kind { get; init; }
     public Guid? ProfileId { get; init; }
+    public string ProfileName { get; init; } = string.Empty;
+    public string ProfileUser { get; init; } = string.Empty;
+    public string ProfileHost { get; init; } = string.Empty;
+    public Guid? SessionId { get; init; }
     public bool RememberPasswordInVault { get; init; }
     public string Host { get; init; } = string.Empty;
     public int Port { get; init; }

--- a/src/NovaTerminal.Core/Ssh/Interactions/SshInteractionRequest.cs
+++ b/src/NovaTerminal.Core/Ssh/Interactions/SshInteractionRequest.cs
@@ -7,7 +7,7 @@ public sealed class SshInteractionRequest
     public string ProfileName { get; init; } = string.Empty;
     public string ProfileUser { get; init; } = string.Empty;
     public string ProfileHost { get; init; } = string.Empty;
-    public Guid? SessionId { get; init; }
+    public bool AllowVaultPasswordReuse { get; init; }
     public bool RememberPasswordInVault { get; init; }
     public string Host { get; init; } = string.Empty;
     public int Port { get; init; }

--- a/src/NovaTerminal.Core/Ssh/Interactions/SshInteractionRequest.cs
+++ b/src/NovaTerminal.Core/Ssh/Interactions/SshInteractionRequest.cs
@@ -3,6 +3,8 @@ namespace NovaTerminal.Core.Ssh.Interactions;
 public sealed class SshInteractionRequest
 {
     public SshInteractionKind Kind { get; init; }
+    public Guid? ProfileId { get; init; }
+    public bool RememberPasswordInVault { get; init; }
     public string Host { get; init; } = string.Empty;
     public int Port { get; init; }
     public string Algorithm { get; init; } = string.Empty;

--- a/src/NovaTerminal.Core/Ssh/Interactions/SshInteractionResponse.cs
+++ b/src/NovaTerminal.Core/Ssh/Interactions/SshInteractionResponse.cs
@@ -5,13 +5,19 @@ public sealed class SshInteractionResponse
     public bool IsAccepted { get; init; }
     public bool IsCanceled { get; init; }
     public string Secret { get; init; } = string.Empty;
+    public bool RememberPasswordInVault { get; init; }
     public IReadOnlyList<string> KeyboardResponses { get; init; } = Array.Empty<string>();
 
     public static SshInteractionResponse AcceptHostKey() => new() { IsAccepted = true };
 
     public static SshInteractionResponse Cancel() => new() { IsCanceled = true };
 
-    public static SshInteractionResponse FromSecret(string secret) => new() { Secret = secret ?? string.Empty };
+    public static SshInteractionResponse FromSecret(string secret, bool rememberPasswordInVault = false) =>
+        new()
+        {
+            Secret = secret ?? string.Empty,
+            RememberPasswordInVault = rememberPasswordInVault
+        };
 
     public static SshInteractionResponse FromKeyboardResponses(params string[] responses) =>
         new() { KeyboardResponses = responses ?? Array.Empty<string>() };

--- a/src/NovaTerminal.Core/Ssh/Models/SshProfile.cs
+++ b/src/NovaTerminal.Core/Ssh/Models/SshProfile.cs
@@ -23,6 +23,7 @@ public sealed class SshProfile
     public int Port { get; set; } = 22;
     public SshAuthMode AuthMode { get; set; } = SshAuthMode.Default;
     public string IdentityFilePath { get; set; } = string.Empty;
+    public bool RememberPasswordInVault { get; set; }
     public List<SshJumpHop> JumpHops { get; set; } = new();
     public List<PortForward> Forwards { get; set; } = new();
     public SshMuxOptions MuxOptions { get; set; } = new();

--- a/src/NovaTerminal.Core/Ssh/Models/SshProfileNormalizer.cs
+++ b/src/NovaTerminal.Core/Ssh/Models/SshProfileNormalizer.cs
@@ -1,0 +1,14 @@
+namespace NovaTerminal.Core.Ssh.Models;
+
+public static class SshProfileNormalizer
+{
+    public static void NormalizeRememberPasswordPreference(SshProfile profile)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+
+        if (profile.BackendKind != SshBackendKind.Native)
+        {
+            profile.RememberPasswordInVault = false;
+        }
+    }
+}

--- a/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
@@ -19,6 +19,8 @@ public sealed class NativeSshSession : ITerminalSession
     private readonly Decoder _utf8Decoder = Encoding.UTF8.GetDecoder();
     private readonly Action<string> _log;
     private readonly NativeSshMetrics _metrics = new();
+    private readonly Guid _profileId;
+    private readonly bool _rememberPasswordInVault;
 
     private ReplayWriter? _recorder;
     private TerminalBuffer? _buffer;
@@ -54,6 +56,8 @@ public sealed class NativeSshSession : ITerminalSession
         _log = log ?? Console.WriteLine;
         _interop = interop ?? new NativeSshInterop();
         _interactionHandler = interactionHandler;
+        _profileId = profile.Id;
+        _rememberPasswordInVault = profile.RememberPasswordInVault;
         JumpHostConnectPlan connectPlan = JumpHostConnectPlan.Create(profile);
         NativeSshConnectionOptions connectionOptions = _jumpHostConnector.CreateConnectionOptions(connectPlan, profile, cols, rows);
         _log($"[NativeSshSession] backend=native path={_jumpHostConnector.DescribePath(connectPlan)} target={connectionOptions.User}@{connectionOptions.Host}:{connectionOptions.Port}");
@@ -293,7 +297,7 @@ public sealed class NativeSshSession : ITerminalSession
             _metrics.MarkAuthenticationPromptStarted();
         }
 
-        SshInteractionRequest request = NativeSshInteractionJson.ParseRequest(nextEvent.Kind, nextEvent.Payload);
+        SshInteractionRequest request = WithProfileContext(NativeSshInteractionJson.ParseRequest(nextEvent.Kind, nextEvent.Payload));
         SshInteractionResponse response = _interactionHandler == null
             ? SshInteractionResponse.Cancel()
             : await _interactionHandler.HandleAsync(request, _pollCts.Token).ConfigureAwait(false);
@@ -318,6 +322,29 @@ public sealed class NativeSshSession : ITerminalSession
         {
             _metrics.MarkAuthenticationPromptCompleted();
         }
+    }
+
+    private SshInteractionRequest WithProfileContext(SshInteractionRequest request)
+    {
+        if (_profileId == Guid.Empty)
+        {
+            return request;
+        }
+
+        return new SshInteractionRequest
+        {
+            Kind = request.Kind,
+            ProfileId = _profileId,
+            RememberPasswordInVault = _rememberPasswordInVault,
+            Host = request.Host,
+            Port = request.Port,
+            Algorithm = request.Algorithm,
+            Fingerprint = request.Fingerprint,
+            Prompt = request.Prompt,
+            Name = request.Name,
+            Instructions = request.Instructions,
+            KeyboardPrompts = request.KeyboardPrompts
+        };
     }
 
     private void TryNotifyExit(int exitCode)

--- a/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
@@ -24,6 +24,7 @@ public sealed class NativeSshSession : ITerminalSession
     private readonly string _profileUser;
     private readonly string _profileHost;
     private readonly bool _rememberPasswordInVault;
+    private bool _allowVaultPasswordReuse;
 
     private ReplayWriter? _recorder;
     private TerminalBuffer? _buffer;
@@ -64,6 +65,7 @@ public sealed class NativeSshSession : ITerminalSession
         _profileUser = profile.User;
         _profileHost = profile.Host;
         _rememberPasswordInVault = profile.RememberPasswordInVault;
+        _allowVaultPasswordReuse = profile.RememberPasswordInVault;
         JumpHostConnectPlan connectPlan = JumpHostConnectPlan.Create(profile);
         NativeSshConnectionOptions connectionOptions = _jumpHostConnector.CreateConnectionOptions(connectPlan, profile, cols, rows);
         _log($"[NativeSshSession] backend=native path={_jumpHostConnector.DescribePath(connectPlan)} target={connectionOptions.User}@{connectionOptions.Host}:{connectionOptions.Port}");
@@ -337,14 +339,14 @@ public sealed class NativeSshSession : ITerminalSession
             return request;
         }
 
-        return new SshInteractionRequest
+        SshInteractionRequest requestWithContext = new()
         {
             Kind = request.Kind,
             ProfileId = _profileId,
             ProfileName = _profileName,
             ProfileUser = _profileUser,
             ProfileHost = _profileHost,
-            SessionId = Id,
+            AllowVaultPasswordReuse = request.Kind == SshInteractionKind.Password && _allowVaultPasswordReuse,
             RememberPasswordInVault = _rememberPasswordInVault,
             Host = request.Host,
             Port = request.Port,
@@ -355,6 +357,13 @@ public sealed class NativeSshSession : ITerminalSession
             Instructions = request.Instructions,
             KeyboardPrompts = request.KeyboardPrompts
         };
+
+        if (request.Kind == SshInteractionKind.Password)
+        {
+            _allowVaultPasswordReuse = false;
+        }
+
+        return requestWithContext;
     }
 
     private void TryNotifyExit(int exitCode)

--- a/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
@@ -20,6 +20,9 @@ public sealed class NativeSshSession : ITerminalSession
     private readonly Action<string> _log;
     private readonly NativeSshMetrics _metrics = new();
     private readonly Guid _profileId;
+    private readonly string _profileName;
+    private readonly string _profileUser;
+    private readonly string _profileHost;
     private readonly bool _rememberPasswordInVault;
 
     private ReplayWriter? _recorder;
@@ -57,6 +60,9 @@ public sealed class NativeSshSession : ITerminalSession
         _interop = interop ?? new NativeSshInterop();
         _interactionHandler = interactionHandler;
         _profileId = profile.Id;
+        _profileName = profile.Name;
+        _profileUser = profile.User;
+        _profileHost = profile.Host;
         _rememberPasswordInVault = profile.RememberPasswordInVault;
         JumpHostConnectPlan connectPlan = JumpHostConnectPlan.Create(profile);
         NativeSshConnectionOptions connectionOptions = _jumpHostConnector.CreateConnectionOptions(connectPlan, profile, cols, rows);
@@ -335,6 +341,10 @@ public sealed class NativeSshSession : ITerminalSession
         {
             Kind = request.Kind,
             ProfileId = _profileId,
+            ProfileName = _profileName,
+            ProfileUser = _profileUser,
+            ProfileHost = _profileHost,
+            SessionId = Id,
             RememberPasswordInVault = _rememberPasswordInVault,
             Host = request.Host,
             Port = request.Port,

--- a/src/NovaTerminal.Core/Ssh/Storage/JsonSshProfileStore.cs
+++ b/src/NovaTerminal.Core/Ssh/Storage/JsonSshProfileStore.cs
@@ -323,6 +323,7 @@ public sealed class JsonSshProfileStore : ISshProfileStore
             Port = profile.Port,
             AuthMode = profile.AuthMode,
             IdentityFilePath = profile.IdentityFilePath,
+            RememberPasswordInVault = profile.RememberPasswordInVault,
             JumpHops = profile.JumpHops.Select(CloneJumpHop).ToList(),
             Forwards = profile.Forwards.Select(CloneForward).ToList(),
             MuxOptions = CloneMuxOptions(profile.MuxOptions),

--- a/src/NovaTerminal.Core/Ssh/Storage/JsonSshProfileStore.cs
+++ b/src/NovaTerminal.Core/Ssh/Storage/JsonSshProfileStore.cs
@@ -253,6 +253,7 @@ public sealed class JsonSshProfileStore : ISshProfileStore
         normalized.User = normalized.User?.Trim() ?? string.Empty;
         normalized.Port = normalized.Port > 0 ? normalized.Port : 22;
         normalized.IdentityFilePath = normalized.IdentityFilePath?.Trim() ?? string.Empty;
+        SshProfileNormalizer.NormalizeRememberPasswordPreference(normalized);
         normalized.WorkingDirectory = normalized.WorkingDirectory?.Trim() ?? string.Empty;
         normalized.ServerAliveIntervalSeconds = normalized.ServerAliveIntervalSeconds > 0
             ? normalized.ServerAliveIntervalSeconds

--- a/tests/NovaTerminal.Core.Tests/Ssh/JsonSshProfileStoreTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/JsonSshProfileStoreTests.cs
@@ -152,6 +152,38 @@ public sealed class JsonSshProfileStoreTests
     }
 
     [Fact]
+    public void NormalizeRememberPasswordPreference_PreservesNativeProfiles()
+    {
+        var profile = new SshProfile
+        {
+            Name = "native",
+            Host = "native.internal",
+            BackendKind = SshBackendKind.Native,
+            RememberPasswordInVault = true
+        };
+
+        SshProfileNormalizer.NormalizeRememberPasswordPreference(profile);
+
+        Assert.True(profile.RememberPasswordInVault);
+    }
+
+    [Fact]
+    public void NormalizeRememberPasswordPreference_ClearsOpenSshProfiles()
+    {
+        var profile = new SshProfile
+        {
+            Name = "openssh",
+            Host = "openssh.internal",
+            BackendKind = SshBackendKind.OpenSsh,
+            RememberPasswordInVault = true
+        };
+
+        SshProfileNormalizer.NormalizeRememberPasswordPreference(profile);
+
+        Assert.False(profile.RememberPasswordInVault);
+    }
+
+    [Fact]
     public void SaveProfile_DoesNotPersistPasswordOrPassphraseFields()
     {
         string tempRoot = CreateTempDirectory();

--- a/tests/NovaTerminal.Core.Tests/Ssh/JsonSshProfileStoreTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/JsonSshProfileStoreTests.cs
@@ -122,6 +122,36 @@ public sealed class JsonSshProfileStoreTests
     }
 
     [Fact]
+    public void SaveAndLoad_RoundTripsRememberPasswordPreference()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string storePath = Path.Combine(tempRoot, "profiles.json");
+            var store = new JsonSshProfileStore(storePath);
+            var profile = new SshProfile
+            {
+                Id = Guid.Parse("9f59e8e2-7a3f-4c02-9a69-8d6a4b37716f"),
+                Name = "native",
+                Host = "native.internal",
+                BackendKind = SshBackendKind.Native,
+                RememberPasswordInVault = true
+            };
+
+            store.SaveProfile(profile);
+
+            SshProfile? loaded = store.GetProfile(profile.Id);
+
+            Assert.NotNull(loaded);
+            Assert.True(loaded!.RememberPasswordInVault);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
     public void SaveProfile_DoesNotPersistPasswordOrPassphraseFields()
     {
         string tempRoot = CreateTempDirectory();
@@ -137,8 +167,8 @@ public sealed class JsonSshProfileStoreTests
             });
 
             string json = File.ReadAllText(storePath);
-            Assert.DoesNotContain("password", json, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain("passphrase", json, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("\"Password\":", json, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("\"Passphrase\":", json, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionInteractionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionInteractionTests.cs
@@ -82,6 +82,10 @@ public sealed class NativeSshSessionInteractionTests
         SshInteractionRequest request = await handler.WaitForRequestAsync();
 
         Assert.Equal(profile.Id, request.ProfileId);
+        Assert.Equal(profile.Name, request.ProfileName);
+        Assert.Equal(profile.User, request.ProfileUser);
+        Assert.Equal(profile.Host, request.ProfileHost);
+        Assert.Equal(session.Id, request.SessionId);
         Assert.True(request.RememberPasswordInVault);
 
         handler.Complete(SshInteractionResponse.Cancel());

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionInteractionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionInteractionTests.cs
@@ -72,23 +72,28 @@ public sealed class NativeSshSessionInteractionTests
             NativeSshEventKind.PasswordPrompt,
             Encoding.UTF8.GetBytes("""{"prompt":"Password:"}"""),
             flags: NativeSshEventFlags.Json));
+        interop.Enqueue(new NativeSshEvent(
+            NativeSshEventKind.PasswordPrompt,
+            Encoding.UTF8.GetBytes("""{"prompt":"Password:"}"""),
+            flags: NativeSshEventFlags.Json));
 
-        var handler = new PendingInteractionHandler();
+        var requests = new List<SshInteractionRequest>();
+        var handler = new RecordingInteractionHandler(requests);
         var profile = CreateProfile();
         profile.RememberPasswordInVault = true;
 
         using var session = new NativeSshSession(profile, interop: interop, interactionHandler: handler);
 
-        SshInteractionRequest request = await handler.WaitForRequestAsync();
+        await WaitUntilAsync(() => requests.Count >= 2);
 
-        Assert.Equal(profile.Id, request.ProfileId);
-        Assert.Equal(profile.Name, request.ProfileName);
-        Assert.Equal(profile.User, request.ProfileUser);
-        Assert.Equal(profile.Host, request.ProfileHost);
-        Assert.Equal(session.Id, request.SessionId);
-        Assert.True(request.RememberPasswordInVault);
+        Assert.Equal(profile.Id, requests[0].ProfileId);
+        Assert.Equal(profile.Name, requests[0].ProfileName);
+        Assert.Equal(profile.User, requests[0].ProfileUser);
+        Assert.Equal(profile.Host, requests[0].ProfileHost);
+        Assert.True(requests[0].RememberPasswordInVault);
+        Assert.True(requests[0].AllowVaultPasswordReuse);
 
-        handler.Complete(SshInteractionResponse.Cancel());
+        Assert.False(requests[1].AllowVaultPasswordReuse);
     }
 
     private static SshProfile CreateProfile()
@@ -135,6 +140,26 @@ public sealed class NativeSshSessionInteractionTests
         public void Complete(SshInteractionResponse response)
         {
             _response.TrySetResult(response);
+        }
+    }
+
+    private sealed class RecordingInteractionHandler : ISshInteractionHandler
+    {
+        private readonly List<SshInteractionRequest> _requests;
+
+        public RecordingInteractionHandler(List<SshInteractionRequest> requests)
+        {
+            _requests = requests;
+        }
+
+        public Task<SshInteractionResponse> HandleAsync(SshInteractionRequest request, CancellationToken cancellationToken)
+        {
+            lock (_requests)
+            {
+                _requests.Add(request);
+            }
+
+            return Task.FromResult(SshInteractionResponse.Cancel());
         }
     }
 

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionInteractionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionInteractionTests.cs
@@ -64,6 +64,29 @@ public sealed class NativeSshSessionInteractionTests
         Assert.Equal("""{"accept":false}""", submission.PayloadJson);
     }
 
+    [Fact]
+    public async Task PasswordPromptCarriesNativeProfileContext()
+    {
+        var interop = new FakeNativeSshInterop();
+        interop.Enqueue(new NativeSshEvent(
+            NativeSshEventKind.PasswordPrompt,
+            Encoding.UTF8.GetBytes("""{"prompt":"Password:"}"""),
+            flags: NativeSshEventFlags.Json));
+
+        var handler = new PendingInteractionHandler();
+        var profile = CreateProfile();
+        profile.RememberPasswordInVault = true;
+
+        using var session = new NativeSshSession(profile, interop: interop, interactionHandler: handler);
+
+        SshInteractionRequest request = await handler.WaitForRequestAsync();
+
+        Assert.Equal(profile.Id, request.ProfileId);
+        Assert.True(request.RememberPasswordInVault);
+
+        handler.Complete(SshInteractionResponse.Cancel());
+    }
+
     private static SshProfile CreateProfile()
     {
         return new SshProfile
@@ -103,7 +126,7 @@ public sealed class NativeSshSessionInteractionTests
             return _response.Task.WaitAsync(cancellationToken);
         }
 
-        public Task WaitForRequestAsync() => _request.Task;
+        public Task<SshInteractionRequest> WaitForRequestAsync() => _request.Task;
 
         public void Complete(SshInteractionResponse response)
         {

--- a/tests/NovaTerminal.Tests/Core/VaultServiceSshKeyTests.cs
+++ b/tests/NovaTerminal.Tests/Core/VaultServiceSshKeyTests.cs
@@ -39,6 +39,36 @@ public class VaultServiceSshKeyTests
     }
 
     [Fact]
+    public void ApplyRememberPasswordPreference_RemovesAllProfileSecrets_WhenDisabled()
+    {
+        TerminalProfile profile = CreateProfile();
+        string canonical = VaultService.GetCanonicalSshProfileKey(profile.Id);
+        string namedLegacy = $"SSH:{profile.Name}:{profile.SshUser}@{profile.SshHost}";
+        string unnamedLegacy = $"SSH:{profile.SshUser}@{profile.SshHost}";
+        string idLegacy = $"profile_{profile.Id}_password";
+
+        var store = new Dictionary<string, string>
+        {
+            [canonical] = "canonical-secret",
+            [namedLegacy] = "named-legacy-secret",
+            [unnamedLegacy] = "unnamed-legacy-secret",
+            [idLegacy] = "id-legacy-secret"
+        };
+
+        VaultService.ApplyRememberPasswordPreference(
+            profile,
+            rememberPasswordInVault: false,
+            password: null,
+            removeSecret: key => store.Remove(key),
+            writeSecret: (key, value) => store[key] = value);
+
+        Assert.DoesNotContain(canonical, store.Keys);
+        Assert.DoesNotContain(namedLegacy, store.Keys);
+        Assert.DoesNotContain(unnamedLegacy, store.Keys);
+        Assert.DoesNotContain(idLegacy, store.Keys);
+    }
+
+    [Fact]
     public void ApplyRememberPasswordPreference_LeavesCanonicalProfileSecretUntouched_WhenEnabledWithoutPassword()
     {
         TerminalProfile profile = CreateProfile();

--- a/tests/NovaTerminal.Tests/Core/VaultServiceSshKeyTests.cs
+++ b/tests/NovaTerminal.Tests/Core/VaultServiceSshKeyTests.cs
@@ -39,7 +39,7 @@ public class VaultServiceSshKeyTests
     }
 
     [Fact]
-    public void ApplyRememberPasswordPreference_RemovesAllProfileSecrets_WhenDisabled()
+    public void ApplyRememberPasswordPreference_RemovesProfileScopedSecrets_WhenDisabled()
     {
         TerminalProfile profile = CreateProfile();
         string canonical = VaultService.GetCanonicalSshProfileKey(profile.Id);
@@ -64,8 +64,44 @@ public class VaultServiceSshKeyTests
 
         Assert.DoesNotContain(canonical, store.Keys);
         Assert.DoesNotContain(namedLegacy, store.Keys);
-        Assert.DoesNotContain(unnamedLegacy, store.Keys);
         Assert.DoesNotContain(idLegacy, store.Keys);
+        Assert.Contains(unnamedLegacy, store.Keys);
+    }
+
+    [Fact]
+    public void ApplyRememberPasswordPreference_PreservesSharedLegacyAlias_ForOtherProfiles()
+    {
+        TerminalProfile profile = CreateProfile();
+        TerminalProfile siblingProfile = new()
+        {
+            Id = Guid.Parse("15edb0b0-7d62-4e7a-977f-fd36403f48bd"),
+            Name = "Prod 2",
+            Type = ConnectionType.SSH,
+            SshUser = profile.SshUser,
+            SshHost = profile.SshHost
+        };
+        string sharedLegacy = $"SSH:{profile.SshUser}@{profile.SshHost}";
+
+        var store = new Dictionary<string, string>
+        {
+            [sharedLegacy] = "shared-secret"
+        };
+
+        VaultService.ApplyRememberPasswordPreference(
+            profile,
+            rememberPasswordInVault: false,
+            password: null,
+            removeSecret: key => store.Remove(key),
+            writeSecret: (key, value) => store[key] = value);
+
+        Assert.Equal("shared-secret", store[sharedLegacy]);
+
+        string? siblingSecret = VaultService.ResolveSshPasswordForProfile(
+            siblingProfile,
+            key => store.TryGetValue(key, out var value) ? value : null,
+            (key, value) => store[key] = value);
+
+        Assert.Equal("shared-secret", siblingSecret);
     }
 
     [Fact]
@@ -88,6 +124,30 @@ public class VaultServiceSshKeyTests
 
             Assert.Null(writer.GetSshPasswordForProfile(profile));
             Assert.Null(remover.GetSshPasswordForProfile(profile));
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void FileBackedReload_PreservesCachedSecrets_WhenLoadFails()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string vaultPath = Path.Combine(tempRoot, "vault.dat");
+            var vault = new VaultService(vaultPath);
+
+            vault.SetSecret("alpha", "one");
+            File.WriteAllBytes(vaultPath, [0x01, 0x02, 0x03, 0x04]);
+
+            vault.SetSecret("beta", "two");
+
+            var reloaded = new VaultService(vaultPath);
+            Assert.Equal("one", reloaded.GetSecret("alpha"));
+            Assert.Equal("two", reloaded.GetSecret("beta"));
         }
         finally
         {

--- a/tests/NovaTerminal.Tests/Core/VaultServiceSshKeyTests.cs
+++ b/tests/NovaTerminal.Tests/Core/VaultServiceSshKeyTests.cs
@@ -15,6 +15,51 @@ public class VaultServiceSshKeyTests
     }
 
     [Fact]
+    public void ApplyRememberPasswordPreference_RemovesCanonicalProfileSecret_WhenDisabled()
+    {
+        TerminalProfile profile = CreateProfile();
+        string canonical = VaultService.GetCanonicalSshProfileKey(profile.Id);
+        string legacy = $"SSH:{profile.Name}:{profile.SshUser}@{profile.SshHost}";
+
+        var store = new Dictionary<string, string>
+        {
+            [canonical] = "canonical-secret",
+            [legacy] = "legacy-secret"
+        };
+
+        VaultService.ApplyRememberPasswordPreference(
+            profile.Id,
+            rememberPasswordInVault: false,
+            password: null,
+            removeSecret: key => store.Remove(key),
+            writeSecret: (key, value) => store[key] = value);
+
+        Assert.False(store.ContainsKey(canonical));
+        Assert.True(store.ContainsKey(legacy));
+    }
+
+    [Fact]
+    public void ApplyRememberPasswordPreference_LeavesCanonicalProfileSecretUntouched_WhenEnabledWithoutPassword()
+    {
+        TerminalProfile profile = CreateProfile();
+        string canonical = VaultService.GetCanonicalSshProfileKey(profile.Id);
+
+        var store = new Dictionary<string, string>
+        {
+            [canonical] = "canonical-secret"
+        };
+
+        VaultService.ApplyRememberPasswordPreference(
+            profile.Id,
+            rememberPasswordInVault: true,
+            password: null,
+            removeSecret: key => store.Remove(key),
+            writeSecret: (key, value) => store[key] = value);
+
+        Assert.Equal("canonical-secret", store[canonical]);
+    }
+
+    [Fact]
     public void Resolve_PrefersCanonicalAndDoesNotMigrate()
     {
         TerminalProfile profile = CreateProfile();

--- a/tests/NovaTerminal.Tests/Core/VaultServiceSshKeyTests.cs
+++ b/tests/NovaTerminal.Tests/Core/VaultServiceSshKeyTests.cs
@@ -69,6 +69,33 @@ public class VaultServiceSshKeyTests
     }
 
     [Fact]
+    public void FileBackedVaultInstances_SeeAndRemoveEachOthersSecrets()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string vaultPath = Path.Combine(tempRoot, "vault.dat");
+            TerminalProfile profile = CreateProfile();
+
+            var writer = new VaultService(vaultPath);
+            var remover = new VaultService(vaultPath);
+
+            writer.SetSshPasswordForProfile(profile, "shared-secret");
+
+            Assert.Equal("shared-secret", remover.GetSshPasswordForProfile(profile));
+
+            remover.ApplyRememberPasswordPreference(profile, rememberPasswordInVault: false);
+
+            Assert.Null(writer.GetSshPasswordForProfile(profile));
+            Assert.Null(remover.GetSshPasswordForProfile(profile));
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ApplyRememberPasswordPreference_LeavesCanonicalProfileSecretUntouched_WhenEnabledWithoutPassword()
     {
         TerminalProfile profile = CreateProfile();
@@ -176,5 +203,12 @@ public class VaultServiceSshKeyTests
             SshUser = "alice",
             SshHost = "example.internal"
         };
+    }
+
+    private static string CreateTempDirectory()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"nova_vault_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
     }
 }

--- a/tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs
@@ -216,14 +216,22 @@ public sealed class NewSshConnectionViewModelTests
             RememberPasswordInVault = true
         };
 
-        var rememberPasswordVisibleProperty = typeof(NewSshConnectionViewModel).GetProperty("IsRememberPasswordVisible");
-        Assert.NotNull(rememberPasswordVisibleProperty);
-        Assert.True((bool?)rememberPasswordVisibleProperty!.GetValue(vm));
+        Assert.True(vm.IsRememberPasswordVisible);
+
+        bool propertyChangedRaised = false;
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(NewSshConnectionViewModel.IsRememberPasswordVisible))
+            {
+                propertyChangedRaised = true;
+            }
+        };
 
         vm.BackendKind = SshBackendKind.OpenSsh;
 
         Assert.False(vm.RememberPasswordInVault);
-        Assert.False((bool?)rememberPasswordVisibleProperty.GetValue(vm));
+        Assert.False(vm.IsRememberPasswordVisible);
+        Assert.True(propertyChangedRaised);
     }
 
     [Fact]
@@ -234,9 +242,7 @@ public sealed class NewSshConnectionViewModelTests
             BackendKind = SshBackendKind.Native
         };
 
-        var rememberPasswordVisibleProperty = typeof(NewSshConnectionViewModel).GetProperty("IsRememberPasswordVisible");
-        Assert.NotNull(rememberPasswordVisibleProperty);
-        Assert.True((bool?)rememberPasswordVisibleProperty!.GetValue(vm));
+        Assert.True(vm.IsRememberPasswordVisible);
     }
 
     [Fact]

--- a/tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs
@@ -216,9 +216,27 @@ public sealed class NewSshConnectionViewModelTests
             RememberPasswordInVault = true
         };
 
+        var rememberPasswordVisibleProperty = typeof(NewSshConnectionViewModel).GetProperty("IsRememberPasswordVisible");
+        Assert.NotNull(rememberPasswordVisibleProperty);
+        Assert.True((bool?)rememberPasswordVisibleProperty!.GetValue(vm));
+
         vm.BackendKind = SshBackendKind.OpenSsh;
 
         Assert.False(vm.RememberPasswordInVault);
+        Assert.False((bool?)rememberPasswordVisibleProperty.GetValue(vm));
+    }
+
+    [Fact]
+    public void BackendKind_WhenNative_ExposesRememberPasswordOption()
+    {
+        var vm = new NewSshConnectionViewModel
+        {
+            BackendKind = SshBackendKind.Native
+        };
+
+        var rememberPasswordVisibleProperty = typeof(NewSshConnectionViewModel).GetProperty("IsRememberPasswordVisible");
+        Assert.NotNull(rememberPasswordVisibleProperty);
+        Assert.True((bool?)rememberPasswordVisibleProperty!.GetValue(vm));
     }
 
     [Fact]

--- a/tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs
@@ -208,6 +208,20 @@ public sealed class NewSshConnectionViewModelTests
     }
 
     [Fact]
+    public void BackendKind_WhenChangedAwayFromNative_ClearsRememberPasswordPreference()
+    {
+        var vm = new NewSshConnectionViewModel
+        {
+            BackendKind = SshBackendKind.Native,
+            RememberPasswordInVault = true
+        };
+
+        vm.BackendKind = SshBackendKind.OpenSsh;
+
+        Assert.False(vm.RememberPasswordInVault);
+    }
+
+    [Fact]
     public void ToSshProfile_PreservesRememberPasswordPreferenceForNativeProfiles()
     {
         var vm = new NewSshConnectionViewModel

--- a/tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs
@@ -175,6 +175,70 @@ public sealed class NewSshConnectionViewModelTests
     }
 
     [Fact]
+    public void ApplySshProfile_PreservesRememberPasswordPreferenceForNativeProfiles()
+    {
+        var vm = new NewSshConnectionViewModel();
+        var profile = new SshProfile
+        {
+            Name = "Native",
+            Host = "native.internal",
+            BackendKind = SshBackendKind.Native,
+            RememberPasswordInVault = true
+        };
+
+        vm.ApplySshProfile(profile);
+
+        Assert.True(vm.RememberPasswordInVault);
+    }
+
+    [Fact]
+    public void ApplySshProfile_DoesNotExposeRememberPasswordPreferenceForOpenSshProfiles()
+    {
+        var vm = new NewSshConnectionViewModel();
+        var profile = new SshProfile
+        {
+            Name = "OpenSSH",
+            Host = "openssh.internal",
+            RememberPasswordInVault = true
+        };
+
+        vm.ApplySshProfile(profile);
+
+        Assert.False(vm.RememberPasswordInVault);
+    }
+
+    [Fact]
+    public void ToSshProfile_PreservesRememberPasswordPreferenceForNativeProfiles()
+    {
+        var vm = new NewSshConnectionViewModel
+        {
+            Name = "Native",
+            HostName = "native.internal",
+            BackendKind = SshBackendKind.Native,
+            RememberPasswordInVault = true
+        };
+
+        SshProfile profile = vm.ToSshProfile();
+
+        Assert.True(profile.RememberPasswordInVault);
+    }
+
+    [Fact]
+    public void ToSshProfile_DoesNotPersistRememberPasswordPreferenceForOpenSshProfiles()
+    {
+        var vm = new NewSshConnectionViewModel
+        {
+            Name = "OpenSSH",
+            HostName = "openssh.internal",
+            RememberPasswordInVault = true
+        };
+
+        SshProfile profile = vm.ToSshProfile();
+
+        Assert.False(profile.RememberPasswordInVault);
+    }
+
+    [Fact]
     public void BackendWarning_WhenNativeSelectedAndExperimentalToggleDisabled_IsVisible()
     {
         var vm = new NewSshConnectionViewModel

--- a/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
@@ -462,6 +462,59 @@ public sealed class SshConnectionServiceTests
     }
 
     [Fact]
+    public void SaveProfile_RemovesStaleLegacyPasswordsFromPreviousProfileIdentityWhenDisabled()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string path = Path.Combine(tempRoot, "profiles.json");
+            var store = new JsonSshProfileStore(path);
+            var vault = new RecordingSshPasswordVault();
+            var service = new SshConnectionService(store, vault);
+            var profileId = Guid.Parse("8a5d3e1c-1d5f-4a2b-8c90-0d4f21a0d7b1");
+
+            store.SaveProfile(new SshProfile
+            {
+                Id = profileId,
+                Name = "OldName",
+                Host = "old.internal",
+                User = "alice",
+                BackendKind = SshBackendKind.Native
+            });
+
+            vault.Seed(VaultService.GetCanonicalSshProfileKey(profileId), "canonical-secret");
+            vault.Seed("SSH:OldName:alice@old.internal", "old-named-secret");
+            vault.Seed("SSH:alice@old.internal", "old-unnamed-secret");
+            vault.Seed($"profile_{profileId}_password", "old-id-secret");
+            vault.Seed("SSH:NewName:bob@new.internal", "new-named-secret");
+            vault.Seed("SSH:bob@new.internal", "new-unnamed-secret");
+
+            var vm = new NewSshConnectionViewModel
+            {
+                ProfileId = profileId,
+                Name = "NewName",
+                HostName = "new.internal",
+                UserName = "bob",
+                BackendKind = SshBackendKind.Native,
+                RememberPasswordInVault = false
+            };
+
+            _ = service.SaveProfile(vm);
+
+            Assert.DoesNotContain("SSH:OldName:alice@old.internal", vault.Secrets.Keys);
+            Assert.DoesNotContain("SSH:alice@old.internal", vault.Secrets.Keys);
+            Assert.DoesNotContain($"profile_{profileId}_password", vault.Secrets.Keys);
+            Assert.DoesNotContain(VaultService.GetCanonicalSshProfileKey(profileId), vault.Secrets.Keys);
+            Assert.DoesNotContain("SSH:NewName:bob@new.internal", vault.Secrets.Keys);
+            Assert.DoesNotContain("SSH:bob@new.internal", vault.Secrets.Keys);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
     public void SaveProfile_LeavesStoredPasswordUntouchedWhenRememberPasswordIsEnabled()
     {
         string tempRoot = CreateTempDirectory();

--- a/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
@@ -447,12 +447,12 @@ public sealed class SshConnectionServiceTests
 
             Assert.DoesNotContain(canonical, vault.Secrets.Keys);
             Assert.DoesNotContain(namedLegacy, vault.Secrets.Keys);
-            Assert.DoesNotContain(unnamedLegacy, vault.Secrets.Keys);
             Assert.DoesNotContain(idLegacy, vault.Secrets.Keys);
             Assert.Contains(canonical, vault.RemovedKeys);
             Assert.Contains(namedLegacy, vault.RemovedKeys);
-            Assert.Contains(unnamedLegacy, vault.RemovedKeys);
             Assert.Contains(idLegacy, vault.RemovedKeys);
+            Assert.Equal("unnamed-legacy-secret", vault.Secrets[unnamedLegacy]);
+            Assert.DoesNotContain(unnamedLegacy, vault.RemovedKeys);
             Assert.Empty(vault.WrittenSecrets);
         }
         finally
@@ -502,11 +502,11 @@ public sealed class SshConnectionServiceTests
             _ = service.SaveProfile(vm);
 
             Assert.DoesNotContain("SSH:OldName:alice@old.internal", vault.Secrets.Keys);
-            Assert.DoesNotContain("SSH:alice@old.internal", vault.Secrets.Keys);
             Assert.DoesNotContain($"profile_{profileId}_password", vault.Secrets.Keys);
             Assert.DoesNotContain(VaultService.GetCanonicalSshProfileKey(profileId), vault.Secrets.Keys);
             Assert.DoesNotContain("SSH:NewName:bob@new.internal", vault.Secrets.Keys);
-            Assert.DoesNotContain("SSH:bob@new.internal", vault.Secrets.Keys);
+            Assert.Equal("old-unnamed-secret", vault.Secrets["SSH:alice@old.internal"]);
+            Assert.Equal("new-unnamed-secret", vault.Secrets["SSH:bob@new.internal"]);
         }
         finally
         {

--- a/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
@@ -207,6 +207,49 @@ public sealed class SshConnectionServiceTests
     }
 
     [Fact]
+    public void SaveProfile_PersistsRememberPasswordPreferenceForNativeProfiles()
+    {
+        var store = new InMemorySshProfileStore();
+        var service = new SshConnectionService(store);
+
+        var vm = new NewSshConnectionViewModel
+        {
+            Name = "Native",
+            HostName = "native.internal",
+            BackendKind = SshBackendKind.Native,
+            RememberPasswordInVault = true
+        };
+
+        SshProfile saved = service.SaveProfile(vm);
+        SshProfile? persisted = store.GetProfile(saved.Id);
+
+        Assert.NotNull(persisted);
+        Assert.True(persisted!.RememberPasswordInVault);
+        Assert.True(saved.RememberPasswordInVault);
+    }
+
+    [Fact]
+    public void SaveProfile_DropsRememberPasswordPreferenceForOpenSshProfiles()
+    {
+        var store = new InMemorySshProfileStore();
+        var service = new SshConnectionService(store);
+
+        var vm = new NewSshConnectionViewModel
+        {
+            Name = "OpenSSH",
+            HostName = "openssh.internal",
+            RememberPasswordInVault = true
+        };
+
+        SshProfile saved = service.SaveProfile(vm);
+        SshProfile? persisted = store.GetProfile(saved.Id);
+
+        Assert.NotNull(persisted);
+        Assert.False(persisted!.RememberPasswordInVault);
+        Assert.False(saved.RememberPasswordInVault);
+    }
+
+    [Fact]
     public void GetConnectionProfiles_ProjectsStoredProfilesIntoRuntimeRows()
     {
         string tempRoot = CreateTempDirectory();
@@ -266,6 +309,76 @@ public sealed class SshConnectionServiceTests
         string path = Path.Combine(Path.GetTempPath(), $"nova_ssh_service_test_{Guid.NewGuid():N}");
         Directory.CreateDirectory(path);
         return path;
+    }
+
+    private sealed class InMemorySshProfileStore : ISshProfileStore
+    {
+        private readonly Dictionary<Guid, SshProfile> _profiles = new();
+
+        public IReadOnlyList<SshProfile> GetProfiles()
+        {
+            return _profiles.Values.Select(CloneProfile).ToArray();
+        }
+
+        public SshProfile? GetProfile(Guid profileId)
+        {
+            return _profiles.TryGetValue(profileId, out SshProfile? profile) ? CloneProfile(profile) : null;
+        }
+
+        public void SaveProfile(SshProfile profile)
+        {
+            _profiles[profile.Id] = CloneProfile(profile);
+        }
+
+        public bool DeleteProfile(Guid profileId)
+        {
+            return _profiles.Remove(profileId);
+        }
+
+        private static SshProfile CloneProfile(SshProfile profile)
+        {
+            return new SshProfile
+            {
+                Id = profile.Id,
+                BackendKind = profile.BackendKind,
+                Name = profile.Name,
+                GroupPath = profile.GroupPath,
+                Notes = profile.Notes,
+                AccentColor = profile.AccentColor,
+                Tags = profile.Tags.ToList(),
+                Host = profile.Host,
+                User = profile.User,
+                Port = profile.Port,
+                AuthMode = profile.AuthMode,
+                IdentityFilePath = profile.IdentityFilePath,
+                RememberPasswordInVault = profile.RememberPasswordInVault,
+                JumpHops = profile.JumpHops.Select(h => new SshJumpHop
+                {
+                    Host = h.Host,
+                    User = h.User,
+                    Port = h.Port
+                }).ToList(),
+                Forwards = profile.Forwards.Select(f => new PortForward
+                {
+                    Kind = f.Kind,
+                    BindAddress = f.BindAddress,
+                    SourcePort = f.SourcePort,
+                    DestinationHost = f.DestinationHost,
+                    DestinationPort = f.DestinationPort
+                }).ToList(),
+                MuxOptions = new SshMuxOptions
+                {
+                    Enabled = profile.MuxOptions.Enabled,
+                    ControlMasterAuto = profile.MuxOptions.ControlMasterAuto,
+                    ControlPath = profile.MuxOptions.ControlPath,
+                    ControlPersistSeconds = profile.MuxOptions.ControlPersistSeconds
+                },
+                ServerAliveIntervalSeconds = profile.ServerAliveIntervalSeconds,
+                ServerAliveCountMax = profile.ServerAliveCountMax,
+                ExtraSshArgs = profile.ExtraSshArgs,
+                WorkingDirectory = profile.WorkingDirectory
+            };
+        }
     }
 
     [Fact]

--- a/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
@@ -209,44 +209,90 @@ public sealed class SshConnectionServiceTests
     [Fact]
     public void SaveProfile_PersistsRememberPasswordPreferenceForNativeProfiles()
     {
-        var store = new InMemorySshProfileStore();
-        var service = new SshConnectionService(store);
-
-        var vm = new NewSshConnectionViewModel
+        string tempRoot = CreateTempDirectory();
+        try
         {
-            Name = "Native",
-            HostName = "native.internal",
-            BackendKind = SshBackendKind.Native,
-            RememberPasswordInVault = true
-        };
+            string path = Path.Combine(tempRoot, "profiles.json");
+            var store = new JsonSshProfileStore(path);
+            var service = new SshConnectionService(store);
 
-        SshProfile saved = service.SaveProfile(vm);
-        SshProfile? persisted = store.GetProfile(saved.Id);
+            var vm = new NewSshConnectionViewModel
+            {
+                Name = "Native",
+                HostName = "native.internal",
+                BackendKind = SshBackendKind.Native,
+                RememberPasswordInVault = true
+            };
 
-        Assert.NotNull(persisted);
-        Assert.True(persisted!.RememberPasswordInVault);
-        Assert.True(saved.RememberPasswordInVault);
+            SshProfile saved = service.SaveProfile(vm);
+
+            Assert.True(saved.RememberPasswordInVault);
+            Assert.True(store.GetProfile(saved.Id)!.RememberPasswordInVault);
+            Assert.True(new JsonSshProfileStore(path).GetProfile(saved.Id)!.RememberPasswordInVault);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
     }
 
     [Fact]
     public void SaveProfile_DropsRememberPasswordPreferenceForOpenSshProfiles()
     {
-        var store = new InMemorySshProfileStore();
-        var service = new SshConnectionService(store);
-
-        var vm = new NewSshConnectionViewModel
+        string tempRoot = CreateTempDirectory();
+        try
         {
-            Name = "OpenSSH",
-            HostName = "openssh.internal",
-            RememberPasswordInVault = true
-        };
+            string path = Path.Combine(tempRoot, "profiles.json");
+            var store = new JsonSshProfileStore(path);
+            var service = new SshConnectionService(store);
 
-        SshProfile saved = service.SaveProfile(vm);
-        SshProfile? persisted = store.GetProfile(saved.Id);
+            var vm = new NewSshConnectionViewModel
+            {
+                Name = "OpenSSH",
+                HostName = "openssh.internal",
+                RememberPasswordInVault = true
+            };
 
-        Assert.NotNull(persisted);
-        Assert.False(persisted!.RememberPasswordInVault);
-        Assert.False(saved.RememberPasswordInVault);
+            SshProfile saved = service.SaveProfile(vm);
+
+            Assert.False(saved.RememberPasswordInVault);
+            Assert.False(store.GetProfile(saved.Id)!.RememberPasswordInVault);
+            Assert.False(new JsonSshProfileStore(path).GetProfile(saved.Id)!.RememberPasswordInVault);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CreateEditorViewModel_LoadsRememberPasswordPreferenceForNativeProfiles()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string path = Path.Combine(tempRoot, "profiles.json");
+            var store = new JsonSshProfileStore(path);
+            var service = new SshConnectionService(store);
+
+            var vm = new NewSshConnectionViewModel
+            {
+                Name = "Native",
+                HostName = "native.internal",
+                BackendKind = SshBackendKind.Native,
+                RememberPasswordInVault = true
+            };
+
+            SshProfile saved = service.SaveProfile(vm);
+            TerminalProfile runtimeProfile = service.GetConnectionProfile(saved.Id)!;
+            NewSshConnectionViewModel editorVm = service.CreateEditorViewModel(runtimeProfile);
+
+            Assert.True(editorVm.RememberPasswordInVault);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
     }
 
     [Fact]
@@ -309,76 +355,6 @@ public sealed class SshConnectionServiceTests
         string path = Path.Combine(Path.GetTempPath(), $"nova_ssh_service_test_{Guid.NewGuid():N}");
         Directory.CreateDirectory(path);
         return path;
-    }
-
-    private sealed class InMemorySshProfileStore : ISshProfileStore
-    {
-        private readonly Dictionary<Guid, SshProfile> _profiles = new();
-
-        public IReadOnlyList<SshProfile> GetProfiles()
-        {
-            return _profiles.Values.Select(CloneProfile).ToArray();
-        }
-
-        public SshProfile? GetProfile(Guid profileId)
-        {
-            return _profiles.TryGetValue(profileId, out SshProfile? profile) ? CloneProfile(profile) : null;
-        }
-
-        public void SaveProfile(SshProfile profile)
-        {
-            _profiles[profile.Id] = CloneProfile(profile);
-        }
-
-        public bool DeleteProfile(Guid profileId)
-        {
-            return _profiles.Remove(profileId);
-        }
-
-        private static SshProfile CloneProfile(SshProfile profile)
-        {
-            return new SshProfile
-            {
-                Id = profile.Id,
-                BackendKind = profile.BackendKind,
-                Name = profile.Name,
-                GroupPath = profile.GroupPath,
-                Notes = profile.Notes,
-                AccentColor = profile.AccentColor,
-                Tags = profile.Tags.ToList(),
-                Host = profile.Host,
-                User = profile.User,
-                Port = profile.Port,
-                AuthMode = profile.AuthMode,
-                IdentityFilePath = profile.IdentityFilePath,
-                RememberPasswordInVault = profile.RememberPasswordInVault,
-                JumpHops = profile.JumpHops.Select(h => new SshJumpHop
-                {
-                    Host = h.Host,
-                    User = h.User,
-                    Port = h.Port
-                }).ToList(),
-                Forwards = profile.Forwards.Select(f => new PortForward
-                {
-                    Kind = f.Kind,
-                    BindAddress = f.BindAddress,
-                    SourcePort = f.SourcePort,
-                    DestinationHost = f.DestinationHost,
-                    DestinationPort = f.DestinationPort
-                }).ToList(),
-                MuxOptions = new SshMuxOptions
-                {
-                    Enabled = profile.MuxOptions.Enabled,
-                    ControlMasterAuto = profile.MuxOptions.ControlMasterAuto,
-                    ControlPath = profile.MuxOptions.ControlPath,
-                    ControlPersistSeconds = profile.MuxOptions.ControlPersistSeconds
-                },
-                ServerAliveIntervalSeconds = profile.ServerAliveIntervalSeconds,
-                ServerAliveCountMax = profile.ServerAliveCountMax,
-                ExtraSshArgs = profile.ExtraSshArgs,
-                WorkingDirectory = profile.WorkingDirectory
-            };
-        }
     }
 
     [Fact]

--- a/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
@@ -377,6 +377,80 @@ public sealed class SshConnectionServiceTests
     }
 
     [Fact]
+    public void SaveProfile_RemovesStoredPasswordWhenRememberPasswordIsDisabled()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string path = Path.Combine(tempRoot, "profiles.json");
+            var store = new JsonSshProfileStore(path);
+            var vault = new RecordingSshPasswordVault();
+            var service = new SshConnectionService(store, vault);
+            var profileId = Guid.Parse("9d2c0bc4-2d0b-4f66-8d50-66c74d1bc7a8");
+            string canonical = VaultService.GetCanonicalSshProfileKey(profileId);
+
+            vault.Seed(canonical, "stored-secret");
+
+            var vm = new NewSshConnectionViewModel
+            {
+                ProfileId = profileId,
+                Name = "Native",
+                HostName = "native.internal",
+                BackendKind = SshBackendKind.Native,
+                RememberPasswordInVault = false
+            };
+
+            SshProfile saved = service.SaveProfile(vm);
+
+            Assert.False(saved.RememberPasswordInVault);
+            Assert.DoesNotContain(canonical, vault.Secrets.Keys);
+            Assert.Equal(canonical, vault.RemovedKeys.Single());
+            Assert.Empty(vault.WrittenSecrets);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SaveProfile_LeavesStoredPasswordUntouchedWhenRememberPasswordIsEnabled()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string path = Path.Combine(tempRoot, "profiles.json");
+            var store = new JsonSshProfileStore(path);
+            var vault = new RecordingSshPasswordVault();
+            var service = new SshConnectionService(store, vault);
+            var profileId = Guid.Parse("c8e0c8f1-197b-47cf-a4c8-413fb1e1fb77");
+            string canonical = VaultService.GetCanonicalSshProfileKey(profileId);
+
+            vault.Seed(canonical, "stored-secret");
+
+            var vm = new NewSshConnectionViewModel
+            {
+                ProfileId = profileId,
+                Name = "Native",
+                HostName = "native.internal",
+                BackendKind = SshBackendKind.Native,
+                RememberPasswordInVault = true
+            };
+
+            SshProfile saved = service.SaveProfile(vm);
+
+            Assert.True(saved.RememberPasswordInVault);
+            Assert.Equal("stored-secret", vault.Secrets[canonical]);
+            Assert.Empty(vault.RemovedKeys);
+            Assert.Empty(vault.WrittenSecrets);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
     public void GetConnectionProfiles_ProjectsStoredProfilesIntoRuntimeRows()
     {
         string tempRoot = CreateTempDirectory();
@@ -468,6 +542,36 @@ public sealed class SshConnectionServiceTests
         finally
         {
             Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    private sealed class RecordingSshPasswordVault : ISshPasswordVault
+    {
+        public Dictionary<string, string> Secrets { get; } = new(StringComparer.Ordinal);
+        public List<string> RemovedKeys { get; } = new();
+        public List<(string Key, string Value)> WrittenSecrets { get; } = new();
+
+        public void Seed(string key, string value)
+        {
+            Secrets[key] = value;
+        }
+
+        public void ApplyRememberPasswordPreference(Guid profileId, bool rememberPasswordInVault, string? password = null)
+        {
+            VaultService.ApplyRememberPasswordPreference(
+                profileId,
+                rememberPasswordInVault,
+                password,
+                removeSecret: key =>
+                {
+                    RemovedKeys.Add(key);
+                    Secrets.Remove(key);
+                },
+                writeSecret: (key, value) =>
+                {
+                    WrittenSecrets.Add((key, value));
+                    Secrets[key] = value;
+                });
         }
     }
 }

--- a/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
@@ -296,6 +296,47 @@ public sealed class SshConnectionServiceTests
     }
 
     [Fact]
+    public void SaveConnectionProfile_ClearsRememberPasswordPreferenceForOpenSshProfiles()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string path = Path.Combine(tempRoot, "profiles.json");
+            var store = new JsonSshProfileStore(path);
+            var service = new SshConnectionService(store);
+            var existing = new SshProfile
+            {
+                Id = Guid.Parse("e5e221a0-77bf-4f50-a0c3-3136d1f90f9e"),
+                Name = "Native",
+                Host = "native.internal",
+                BackendKind = SshBackendKind.Native,
+                RememberPasswordInVault = true
+            };
+
+            store.SaveProfile(existing);
+
+            var runtimeProfile = new TerminalProfile
+            {
+                Id = existing.Id,
+                Name = "OpenSSH",
+                Type = ConnectionType.SSH,
+                SshHost = "openssh.internal",
+                SshBackendKind = SshBackendKind.OpenSsh,
+                UseSshAgent = true
+            };
+
+            service.SaveConnectionProfile(runtimeProfile);
+
+            Assert.False(store.GetProfile(existing.Id)!.RememberPasswordInVault);
+            Assert.False(new JsonSshProfileStore(path).GetProfile(existing.Id)!.RememberPasswordInVault);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
     public void GetConnectionProfiles_ProjectsStoredProfilesIntoRuntimeRows()
     {
         string tempRoot = CreateTempDirectory();

--- a/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
@@ -266,6 +266,46 @@ public sealed class SshConnectionServiceTests
     }
 
     [Fact]
+    public void SaveProfile_WithNullBackendPreservesNativeRememberPasswordPreference()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string path = Path.Combine(tempRoot, "profiles.json");
+            var store = new JsonSshProfileStore(path);
+            var service = new SshConnectionService(store);
+
+            var existing = new SshProfile
+            {
+                Id = Guid.Parse("b8f6f5c4-1f52-4cc6-8b8b-f8964ad2f1b3"),
+                Name = "Native",
+                Host = "native.internal",
+                BackendKind = SshBackendKind.Native,
+                RememberPasswordInVault = true
+            };
+            store.SaveProfile(existing);
+
+            var vm = new NewSshConnectionViewModel
+            {
+                ProfileId = existing.Id,
+                Name = "Native Updated",
+                HostName = "updated.internal",
+                UserName = "ops"
+            };
+
+            SshProfile saved = service.SaveProfile(vm);
+
+            Assert.Equal(SshBackendKind.Native, saved.BackendKind);
+            Assert.True(saved.RememberPasswordInVault);
+            Assert.True(store.GetProfile(saved.Id)!.RememberPasswordInVault);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
     public void CreateEditorViewModel_LoadsRememberPasswordPreferenceForNativeProfiles()
     {
         string tempRoot = CreateTempDirectory();

--- a/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
@@ -404,7 +404,55 @@ public sealed class SshConnectionServiceTests
 
             Assert.False(saved.RememberPasswordInVault);
             Assert.DoesNotContain(canonical, vault.Secrets.Keys);
-            Assert.Equal(canonical, vault.RemovedKeys.Single());
+            Assert.Contains(canonical, vault.RemovedKeys);
+            Assert.Empty(vault.WrittenSecrets);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SaveProfile_RemovesLegacyStoredPasswordsWhenRememberPasswordIsDisabled()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string path = Path.Combine(tempRoot, "profiles.json");
+            var store = new JsonSshProfileStore(path);
+            var vault = new RecordingSshPasswordVault();
+            var service = new SshConnectionService(store, vault);
+            var profileId = Guid.Parse("1fcb9d03-0d6f-4ed1-8c1d-9e8b2d865c6d");
+            var vm = new NewSshConnectionViewModel
+            {
+                ProfileId = profileId,
+                Name = "Prod",
+                HostName = "example.internal",
+                UserName = "alice",
+                BackendKind = SshBackendKind.Native,
+                RememberPasswordInVault = false
+            };
+
+            string canonical = VaultService.GetCanonicalSshProfileKey(profileId);
+            string namedLegacy = "SSH:Prod:alice@example.internal";
+            string unnamedLegacy = "SSH:alice@example.internal";
+            string idLegacy = $"profile_{profileId}_password";
+            vault.Seed(canonical, "canonical-secret");
+            vault.Seed(namedLegacy, "named-legacy-secret");
+            vault.Seed(unnamedLegacy, "unnamed-legacy-secret");
+            vault.Seed(idLegacy, "id-legacy-secret");
+
+            _ = service.SaveProfile(vm);
+
+            Assert.DoesNotContain(canonical, vault.Secrets.Keys);
+            Assert.DoesNotContain(namedLegacy, vault.Secrets.Keys);
+            Assert.DoesNotContain(unnamedLegacy, vault.Secrets.Keys);
+            Assert.DoesNotContain(idLegacy, vault.Secrets.Keys);
+            Assert.Contains(canonical, vault.RemovedKeys);
+            Assert.Contains(namedLegacy, vault.RemovedKeys);
+            Assert.Contains(unnamedLegacy, vault.RemovedKeys);
+            Assert.Contains(idLegacy, vault.RemovedKeys);
             Assert.Empty(vault.WrittenSecrets);
         }
         finally
@@ -558,20 +606,24 @@ public sealed class SshConnectionServiceTests
 
         public void ApplyRememberPasswordPreference(Guid profileId, bool rememberPasswordInVault, string? password = null)
         {
-            VaultService.ApplyRememberPasswordPreference(
-                profileId,
-                rememberPasswordInVault,
-                password,
-                removeSecret: key =>
-                {
-                    RemovedKeys.Add(key);
-                    Secrets.Remove(key);
-                },
-                writeSecret: (key, value) =>
-                {
-                    WrittenSecrets.Add((key, value));
-                    Secrets[key] = value;
-                });
+            VaultService.ApplyRememberPasswordPreference(profileId, rememberPasswordInVault, password, RemoveSecret, WriteSecret);
+        }
+
+        public void ApplyRememberPasswordPreference(TerminalProfile profile, bool rememberPasswordInVault, string? password = null)
+        {
+            VaultService.ApplyRememberPasswordPreference(profile, rememberPasswordInVault, password, RemoveSecret, WriteSecret);
+        }
+
+        private void RemoveSecret(string key)
+        {
+            RemovedKeys.Add(key);
+            Secrets.Remove(key);
+        }
+
+        private void WriteSecret(string key, string value)
+        {
+            WrittenSecrets.Add((key, value));
+            Secrets[key] = value;
         }
     }
 }

--- a/tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs
@@ -200,6 +200,116 @@ public sealed class SshInteractionServiceTests
     }
 
     [Fact]
+    public async Task NativePasswordRequests_ExposeRememberPasswordOption()
+    {
+        AuthPromptViewModel? capturedVm = null;
+        var service = new SshInteractionService(
+            authPresenter: (_, vm, _) =>
+            {
+                capturedVm = vm;
+                return Task.FromResult(SshInteractionResponse.Cancel());
+            });
+
+        await service.HandleAsync(new SshInteractionRequest
+        {
+            Kind = SshInteractionKind.Password,
+            Prompt = "Password:",
+            RememberPasswordInVault = true
+        }, CancellationToken.None);
+
+        Assert.NotNull(capturedVm);
+        Assert.True(capturedVm!.CanRememberPassword);
+    }
+
+    [Fact]
+    public async Task NativePasswordRequests_StoreSubmittedPassword_WhenRememberPasswordIsChecked()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string vaultPath = Path.Combine(tempRoot, "vault.dat");
+            var vault = new VaultService(vaultPath);
+            var profile = new TerminalProfile
+            {
+                Id = Guid.Parse("0c25f4e2-2c2d-4f16-9d70-4d01e7c8fdb1"),
+                Type = ConnectionType.SSH,
+                Name = "Native Prod",
+                SshHost = "example.internal",
+                SshUser = "alice"
+            };
+
+            var service = new SshInteractionService(
+                vaultService: vault,
+                authPresenter: (_, _, _) =>
+                {
+                    return Task.FromResult(SshInteractionResponse.FromSecret("manual-secret", rememberPasswordInVault: true));
+                });
+
+            var response = await service.HandleAsync(new SshInteractionRequest
+            {
+                Kind = SshInteractionKind.Password,
+                Prompt = "Password:",
+                ProfileId = profile.Id,
+                ProfileName = profile.Name,
+                ProfileUser = profile.SshUser,
+                ProfileHost = profile.SshHost,
+                AllowVaultPasswordReuse = false,
+                RememberPasswordInVault = true
+            }, CancellationToken.None);
+
+            Assert.Equal("manual-secret", response.Secret);
+            Assert.Equal("manual-secret", vault.GetSshPasswordForProfile(profile));
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task NativePasswordRequests_DoNotStoreSubmittedPassword_WhenRememberPasswordIsUnchecked()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string vaultPath = Path.Combine(tempRoot, "vault.dat");
+            var vault = new VaultService(vaultPath);
+            var profile = new TerminalProfile
+            {
+                Id = Guid.Parse("f0dbb9df-8e7e-4e11-9e0a-91de4a2f84be"),
+                Type = ConnectionType.SSH,
+                Name = "Native Prod",
+                SshHost = "example.internal",
+                SshUser = "alice"
+            };
+
+            var service = new SshInteractionService(
+                vaultService: vault,
+                authPresenter: (_, _, _) =>
+                    Task.FromResult(SshInteractionResponse.FromSecret("manual-secret")));
+
+            var response = await service.HandleAsync(new SshInteractionRequest
+            {
+                Kind = SshInteractionKind.Password,
+                Prompt = "Password:",
+                ProfileId = profile.Id,
+                ProfileName = profile.Name,
+                ProfileUser = profile.SshUser,
+                ProfileHost = profile.SshHost,
+                AllowVaultPasswordReuse = false,
+                RememberPasswordInVault = true
+            }, CancellationToken.None);
+
+            Assert.Equal("manual-secret", response.Secret);
+            Assert.Null(vault.GetSshPasswordForProfile(profile));
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task PasswordRequests_AreAnsweredFromVaultWithoutShowingDialog_WhenRememberPasswordIsEnabled()
     {
         string tempRoot = CreateTempDirectory();

--- a/tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs
@@ -234,6 +234,7 @@ public sealed class SshInteractionServiceTests
                 ProfileName = profile.Name,
                 ProfileUser = profile.SshUser,
                 ProfileHost = profile.SshHost,
+                AllowVaultPasswordReuse = true,
                 RememberPasswordInVault = true
             }, CancellationToken.None);
 
@@ -283,6 +284,7 @@ public sealed class SshInteractionServiceTests
                 ProfileName = profile.Name,
                 ProfileUser = profile.SshUser,
                 ProfileHost = profile.SshHost,
+                AllowVaultPasswordReuse = true,
                 RememberPasswordInVault = true
             }, CancellationToken.None);
 
@@ -296,7 +298,7 @@ public sealed class SshInteractionServiceTests
     }
 
     [Fact]
-    public async Task PasswordRequests_UseVaultOnlyOncePerNativeSession()
+    public async Task PasswordRequests_FallBackToDialog_WhenVaultReuseIsNotAllowed()
     {
         string tempRoot = CreateTempDirectory();
         try
@@ -322,9 +324,7 @@ public sealed class SshInteractionServiceTests
                     return Task.FromResult(SshInteractionResponse.FromSecret("manual-secret"));
                 });
 
-            Guid sessionId = Guid.Parse("7b936c2e-7c4f-4f75-bcb2-0b8b8ccbe6f5");
-
-            SshInteractionResponse first = await service.HandleAsync(new SshInteractionRequest
+            SshInteractionResponse response = await service.HandleAsync(new SshInteractionRequest
             {
                 Kind = SshInteractionKind.Password,
                 Prompt = "Password:",
@@ -332,24 +332,11 @@ public sealed class SshInteractionServiceTests
                 ProfileName = profile.Name,
                 ProfileUser = profile.SshUser,
                 ProfileHost = profile.SshHost,
-                SessionId = sessionId,
+                AllowVaultPasswordReuse = false,
                 RememberPasswordInVault = true
             }, CancellationToken.None);
 
-            SshInteractionResponse second = await service.HandleAsync(new SshInteractionRequest
-            {
-                Kind = SshInteractionKind.Password,
-                Prompt = "Password:",
-                ProfileId = profile.Id,
-                ProfileName = profile.Name,
-                ProfileUser = profile.SshUser,
-                ProfileHost = profile.SshHost,
-                SessionId = sessionId,
-                RememberPasswordInVault = true
-            }, CancellationToken.None);
-
-            Assert.Equal("vault-secret", first.Secret);
-            Assert.Equal("manual-secret", second.Secret);
+            Assert.Equal("manual-secret", response.Secret);
             Assert.Equal(1, promptCount);
         }
         finally
@@ -391,6 +378,9 @@ public sealed class SshInteractionServiceTests
                 Kind = SshInteractionKind.Passphrase,
                 Prompt = "Key passphrase:",
                 ProfileId = profile.Id,
+                ProfileName = profile.Name,
+                ProfileUser = profile.SshUser,
+                ProfileHost = profile.SshHost,
                 RememberPasswordInVault = true
             }, CancellationToken.None);
 

--- a/tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
+using NovaTerminal.Core;
 using NovaTerminal.Core.Ssh.Interactions;
 using NovaTerminal.Core.Ssh.Native;
 using NovaTerminal.Services.Ssh;
@@ -196,6 +197,96 @@ public sealed class SshInteractionServiceTests
         Assert.True(capturedVm.Prompts[0].IsSecret);
         Assert.Equal("Password:", capturedVm.Prompts[0].Prompt);
         Assert.Equal("password", response.Secret);
+    }
+
+    [Fact]
+    public async Task PasswordRequests_AreAnsweredFromVaultWithoutShowingDialog_WhenRememberPasswordIsEnabled()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string vaultPath = Path.Combine(tempRoot, "vault.dat");
+            var vault = new VaultService(vaultPath);
+            var profile = new TerminalProfile
+            {
+                Id = Guid.Parse("3b0a5c25-9b4d-4d6b-80b4-5cf8c2ef8e6a"),
+                Type = ConnectionType.SSH,
+                Name = "Native Prod",
+                SshHost = "example.internal",
+                SshUser = "alice"
+            };
+            vault.SetSshPasswordForProfile(profile, "vault-secret");
+
+            int promptCount = 0;
+            var service = new SshInteractionService(
+                vaultService: vault,
+                authPresenter: (_, _, _) =>
+                {
+                    promptCount++;
+                    return Task.FromResult(SshInteractionResponse.Cancel());
+                });
+
+            var response = await service.HandleAsync(new SshInteractionRequest
+            {
+                Kind = SshInteractionKind.Password,
+                Prompt = "Password:",
+                ProfileId = profile.Id,
+                RememberPasswordInVault = true
+            }, CancellationToken.None);
+
+            Assert.Equal(0, promptCount);
+            Assert.Equal("vault-secret", response.Secret);
+            Assert.False(response.IsCanceled);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PassphraseRequests_ShowDialogEvenWhenVaultHasPassword()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string vaultPath = Path.Combine(tempRoot, "vault.dat");
+            var vault = new VaultService(vaultPath);
+            var profile = new TerminalProfile
+            {
+                Id = Guid.Parse("6e1df53b-5b8f-4d5c-bfd7-9ad6f4d3d5d5"),
+                Type = ConnectionType.SSH,
+                Name = "Native Prod",
+                SshHost = "example.internal",
+                SshUser = "alice"
+            };
+            vault.SetSshPasswordForProfile(profile, "vault-secret");
+
+            int promptCount = 0;
+            var service = new SshInteractionService(
+                vaultService: vault,
+                authPresenter: (_, vm, _) =>
+                {
+                    promptCount++;
+                    Assert.Equal("Passphrase", vm.Title);
+                    return Task.FromResult(SshInteractionResponse.FromSecret("entered-passphrase"));
+                });
+
+            var response = await service.HandleAsync(new SshInteractionRequest
+            {
+                Kind = SshInteractionKind.Passphrase,
+                Prompt = "Key passphrase:",
+                ProfileId = profile.Id,
+                RememberPasswordInVault = true
+            }, CancellationToken.None);
+
+            Assert.Equal(1, promptCount);
+            Assert.Equal("entered-passphrase", response.Secret);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
     }
 
     [Fact]

--- a/tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs
@@ -231,12 +231,126 @@ public sealed class SshInteractionServiceTests
                 Kind = SshInteractionKind.Password,
                 Prompt = "Password:",
                 ProfileId = profile.Id,
+                ProfileName = profile.Name,
+                ProfileUser = profile.SshUser,
+                ProfileHost = profile.SshHost,
                 RememberPasswordInVault = true
             }, CancellationToken.None);
 
             Assert.Equal(0, promptCount);
             Assert.Equal("vault-secret", response.Secret);
             Assert.False(response.IsCanceled);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PasswordRequests_UseLegacyVaultSecret_WhenFullProfileIdentityIsProvided()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string vaultPath = Path.Combine(tempRoot, "vault.dat");
+            var vault = new VaultService(vaultPath);
+            var profile = new TerminalProfile
+            {
+                Id = Guid.Parse("19c4e5f0-62ed-4d56-90b1-1d53e4c90d19"),
+                Type = ConnectionType.SSH,
+                Name = "Legacy Prod",
+                SshHost = "legacy.internal",
+                SshUser = "alice"
+            };
+            string legacyKey = $"SSH:{profile.Name}:{profile.SshUser}@{profile.SshHost}";
+            vault.SetSecret(legacyKey, "legacy-secret");
+
+            int promptCount = 0;
+            var service = new SshInteractionService(
+                vaultService: vault,
+                authPresenter: (_, _, _) =>
+                {
+                    promptCount++;
+                    return Task.FromResult(SshInteractionResponse.Cancel());
+                });
+
+            var response = await service.HandleAsync(new SshInteractionRequest
+            {
+                Kind = SshInteractionKind.Password,
+                Prompt = "Password:",
+                ProfileId = profile.Id,
+                ProfileName = profile.Name,
+                ProfileUser = profile.SshUser,
+                ProfileHost = profile.SshHost,
+                RememberPasswordInVault = true
+            }, CancellationToken.None);
+
+            Assert.Equal(0, promptCount);
+            Assert.Equal("legacy-secret", response.Secret);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PasswordRequests_UseVaultOnlyOncePerNativeSession()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string vaultPath = Path.Combine(tempRoot, "vault.dat");
+            var vault = new VaultService(vaultPath);
+            var profile = new TerminalProfile
+            {
+                Id = Guid.Parse("52e5e0a7-51c6-4c9e-8d1a-7f74e9e6d7b8"),
+                Type = ConnectionType.SSH,
+                Name = "Native Prod",
+                SshHost = "example.internal",
+                SshUser = "alice"
+            };
+            vault.SetSshPasswordForProfile(profile, "vault-secret");
+
+            int promptCount = 0;
+            var service = new SshInteractionService(
+                vaultService: vault,
+                authPresenter: (_, _, _) =>
+                {
+                    promptCount++;
+                    return Task.FromResult(SshInteractionResponse.FromSecret("manual-secret"));
+                });
+
+            Guid sessionId = Guid.Parse("7b936c2e-7c4f-4f75-bcb2-0b8b8ccbe6f5");
+
+            SshInteractionResponse first = await service.HandleAsync(new SshInteractionRequest
+            {
+                Kind = SshInteractionKind.Password,
+                Prompt = "Password:",
+                ProfileId = profile.Id,
+                ProfileName = profile.Name,
+                ProfileUser = profile.SshUser,
+                ProfileHost = profile.SshHost,
+                SessionId = sessionId,
+                RememberPasswordInVault = true
+            }, CancellationToken.None);
+
+            SshInteractionResponse second = await service.HandleAsync(new SshInteractionRequest
+            {
+                Kind = SshInteractionKind.Password,
+                Prompt = "Password:",
+                ProfileId = profile.Id,
+                ProfileName = profile.Name,
+                ProfileUser = profile.SshUser,
+                ProfileHost = profile.SshHost,
+                SessionId = sessionId,
+                RememberPasswordInVault = true
+            }, CancellationToken.None);
+
+            Assert.Equal("vault-secret", first.Secret);
+            Assert.Equal("manual-secret", second.Secret);
+            Assert.Equal(1, promptCount);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- add a native-only remember-password preference to SSH profiles and editor flows
- add vault-backed native password reuse, prompt-side remember behavior, and one-shot per-session reuse
- keep file-backed vault state coherent across instances and cover the flow with focused SSH/vault tests

## Test Plan
- [x] `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~NewSshConnectionViewModelTests|FullyQualifiedName~SshConnectionServiceTests|FullyQualifiedName~SshInteractionServiceTests|FullyQualifiedName~VaultServiceSshKeyTests"`
- [x] `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~NativeSshSessionInteractionTests"`
- [x] `dotnet msbuild src/NovaTerminal.App/NovaTerminal.App.csproj /t:Compile /p:Configuration=Release /p:SKIP_RUST_NATIVE_BUILD=1`