### PR TITLE
Fix PowerShell path completion separators on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -500,3 +500,11 @@ test_repro*.txt
 # temporary output
 _temp_out/
 .act-artifacts/
+
+#novaindex
+.novaindex/
+
+# Embedded Rust native build outputs
+src/NovaTerminal.App/native/target/
+src/NovaTerminal.App/native/target_linux/
+src/NovaTerminal.App/native/rusty_ssh/target/

--- a/docs/command-assist/CommandAssist_SmokeTest_Scenarios_2026-03-14.md
+++ b/docs/command-assist/CommandAssist_SmokeTest_Scenarios_2026-03-14.md
@@ -1,0 +1,75 @@
+# Command Assist Smoke Test Scenarios
+
+Date: 2026-03-14
+Scope: Shell-first Tab behavior, explicit history mode, local path suggestions, and AOT parity.
+
+## Preconditions
+
+- Command Assist is enabled in settings.
+- Test in both `pwsh` and `cmd`.
+- Keep at least a few known history items (for `git`, `dotnet`, `cd`).
+- Have at least one path containing a space (for escape behavior checks).
+
+## Scenarios
+
+1. Tab is shell-owned in PowerShell:
+   Type `cd ~/h`, press `Tab`.
+   Expected: Native shell path completion runs; Command Assist does not accept a suggestion.
+
+2. Tab is shell-owned in CMD:
+   Type `cd \Us`, press `Tab`.
+   Expected: Native shell completion runs; Command Assist does not accept a suggestion.
+
+3. Passive typing does not show history:
+   With history containing `git ...` commands, type `git ` without opening assist.
+   Expected: No history/snippet rows are shown.
+
+4. Passive typing shows path suggestions:
+   Type `cd ./` or `cd ~/`.
+   Expected: Filesystem path rows appear.
+
+5. Path insertion appends suffix only:
+   Start with partial path, accept a path suggestion.
+   Expected: Existing typed text is preserved; only missing suffix is inserted.
+
+6. PowerShell escaping for spaces:
+   With folder `My Folder`, type `cd .\M` in `pwsh`, accept path suggestion.
+   Expected: Inserted text escapes space correctly (backtick escaping).
+
+7. Explicit assist mode enables history/snippets:
+   Press `Ctrl+Space`, then type `git st`.
+   Expected: History/snippet rows are available and selectable.
+
+8. History search mode is history-focused:
+   Press `Ctrl+R`, search for `git`.
+   Expected: History results appear in popup history mode.
+
+9. Accept selected suggestion uses `Ctrl+Enter`:
+   With a row selected, press `Ctrl+Enter`.
+   Expected: Selected suggestion is inserted into command line.
+
+10. Pin/unpin shortcut works:
+    In explicit mode on history/snippet item, press `Ctrl+Shift+P`.
+    Expected: Item pin state toggles and persists.
+
+11. Alt-screen auto-hide:
+    Open fullscreen TUI app (alternate screen).
+    Expected: Command Assist UI hides while alternate screen is active.
+
+12. Placement sanity:
+    Trigger suggestions near top/middle/bottom of viewport.
+    Expected: Assist surface anchors near prompt and avoids unnecessary overlap.
+
+13. Paste behavior:
+    Paste command text into prompt.
+    Expected: No accidental suggestion acceptance; prompt text remains correct.
+
+14. AOT parity check:
+    Run same checks (1, 3, 4, 7, 9) on AOT build output.
+    Expected: Same behavior as non-AOT build.
+
+## Pass Criteria
+
+- All scenarios behave as expected in both `pwsh` and `cmd`.
+- No scenario causes unintended command replacement on `Tab`.
+- No visual corruption/regression appears in AOT build.

--- a/docs/native-ssh/NovaTerminal_Native_SSH_Codex_Pack-PR1-PR3.md
+++ b/docs/native-ssh/NovaTerminal_Native_SSH_Codex_Pack-PR1-PR3.md
@@ -1,0 +1,55 @@
+
+# NovaTerminal Native SSH – Codex Execution Pack (PR1–PR3)
+
+This file contains ready-to-use prompts for Codex / Antigravity.
+
+---
+
+## PR1 — Backend Split Foundation
+
+**Branch:** feat/ssh-native-backend-foundation
+
+### Prompt
+Build the architectural split for SSH backends in NovaTerminal without changing current behavior. Add SshBackendKind to SshProfile with default OpenSsh. Introduce SshSessionFactory, OpenSshSession, and a stub NativeSshSession. Introduce a lower-level IRemoteTerminalTransport abstraction for future native SSH, but do not wire any native implementation yet. Update TerminalPane and SessionManager to construct SSH sessions through the factory. Keep OpenSSH behavior exactly as it works today.
+
+### Acceptance
+- No behavior change
+- Direct SSH still works
+- Profiles load/save correctly
+
+---
+
+## PR2 — Native Rust SSH Spike
+
+**Branch:** feat/ssh-native-rust-spike
+
+### Prompt
+Create a new Rust crate native/rusty_ssh as a spike for NovaTerminal native SSH. Use a Rust SSH library and implement only the minimum interactive terminal flow: connect, auth, host key eventing, PTY request, shell channel, read/write, resize, exit status, close. Expose a C ABI using poll-style functions rather than callbacks. Do not implement forwarding, jump hosts, or reconnect yet. Optimize for correctness and a narrow interop surface.
+
+### Acceptance
+- Can connect to SSH server
+- Interactive shell works
+- Resize works
+- Exit status received
+
+---
+
+## PR3 — Native SSH Session Wrapper
+
+**Branch:** feat/ssh-native-session-wrapper
+
+### Prompt
+Implement NativeSshSession in C# by wrapping the Rust native SSH spike behind the existing terminal session model. Use a background poll/event loop, decode bytes safely, and integrate with the current terminal output/input lifecycle. Route SSH backend selection through SshSessionFactory so profiles can choose Native or OpenSsh. Do not force native SSH into the RustPtySession model.
+
+### Acceptance
+- Native backend selectable
+- Output renders in terminal
+- Resize works
+- Clean shutdown
+
+---
+
+## Notes
+- Do NOT remove OpenSSH backend
+- Use poll-based FFI
+- Keep architecture clean and layered

--- a/docs/native-ssh/NovaTerminal_Native_SSH_Codex_Pack_PR4-PR8.md
+++ b/docs/native-ssh/NovaTerminal_Native_SSH_Codex_Pack_PR4-PR8.md
@@ -1,0 +1,345 @@
+# NovaTerminal Native SSH – Codex Execution Pack (PR4–PR8)
+
+This pack expands the native SSH execution plan for NovaTerminal into ready-to-use prompts for Codex / Antigravity.
+
+These prompts assume PR1–PR3 already exist:
+- backend split foundation
+- Rust native SSH spike
+- C# native session wrapper
+
+---
+
+## Global rules
+
+Apply these rules to every PR in this pack.
+
+- Do not remove or regress the current OpenSSH backend.
+- Do not force native SSH through `RustPtySession`.
+- Keep `OpenSshConfigCompiler`, `SshLaunchPlanner`, and `SshArgBuilder` scoped to the OpenSSH backend.
+- Prefer narrow, poll/event-style interop over callback-heavy FFI.
+- Preserve terminal correctness first; do not optimize prematurely.
+- Keep UI coordination for auth and host key prompts outside terminal text parsing.
+- Add tests where practical, especially for persistence and state handling.
+- Avoid plaintext secret storage.
+
+---
+
+# PR4 — SSH Interaction UX Service
+
+**Branch:** `feat/ssh-native-auth-hostkey-ux`
+
+## Goal
+Handle native SSH host key and authentication flows through explicit UI/services rather than scraping terminal text.
+
+## Prompt
+Add a UI-facing SSH interaction service for native SSH authentication and host key verification. Implement dialogs and view models for trust-on-first-use host key prompts, changed host key warnings, password entry, passphrase entry, and keyboard-interactive prompts. Wire `NativeSshSession` to request responses through the interaction service. Do not parse terminal output for these flows. Keep the service general enough to support both modal dialogs now and richer inline UX later.
+
+## Scope
+Implement support for:
+- unknown host key
+- changed host key
+- password auth
+- key passphrase prompt
+- keyboard-interactive prompts
+
+### Suggested files to add
+- `src/NovaTerminal.App/Services/Ssh/ISshInteractionService.cs`
+- `src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs`
+- `src/NovaTerminal.App/Models/Ssh/SshInteractionRequest.cs`
+- `src/NovaTerminal.App/Models/Ssh/SshInteractionResponse.cs`
+- `src/NovaTerminal.App/ViewModels/Ssh/HostKeyPromptViewModel.cs`
+- `src/NovaTerminal.App/ViewModels/Ssh/AuthPromptViewModel.cs`
+- matching views/dialogs
+
+### Suggested files to modify
+- `src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs`
+- `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs`
+- dialog host / main window wiring as needed
+
+## Acceptance criteria
+- Native SSH can complete first-time trust flow.
+- Password auth succeeds through UI prompt.
+- Keyboard-interactive auth succeeds.
+- Changed host key shows a clear warning path.
+- No terminal text parsing is used for native SSH auth/trust flows.
+- Cancellation is handled cleanly and closes/fails the session predictably.
+
+## Notes
+- Keep the interaction service backend-agnostic if reasonable.
+- Surface enough metadata to the UI:
+  - hostname
+  - port
+  - key algorithm
+  - fingerprint
+  - prompt text
+  - whether retry is allowed
+
+---
+
+# PR5 — Known Hosts + Backend-Safe Persistence
+
+**Branch:** `feat/ssh-native-known-hosts-persistence`
+
+## Goal
+Persist trust decisions for native SSH and ensure profile/backend restore behavior is safe and stable.
+
+## Prompt
+Add native SSH known-hosts persistence and backend-aware profile persistence and restore. Implement an app-managed known-hosts store for the native backend, fingerprint formatting, mismatch detection, and trust decisions. Update profile serialization and session restoration so backend selection is preserved safely. Keep current OpenSSH behavior unchanged.
+
+## Scope
+Implement:
+- app-managed known hosts file or structured store for native backend
+- fingerprint formatting helpers
+- host key lookup and mismatch detection
+- persist backend selection in profile store
+- preserve backend on session restore
+
+### Suggested files to add
+- `src/NovaTerminal.Core/Ssh/Native/NativeKnownHostsStore.cs`
+- `src/NovaTerminal.Core/Ssh/Native/HostKeyFingerprintFormatter.cs`
+- `src/NovaTerminal.Core/Ssh/Native/KnownHostEntry.cs` (optional)
+- tests for known host matching and mismatch
+
+### Suggested files to modify
+- `src/NovaTerminal.Core/Ssh/Storage/JsonSshProfileStore.cs`
+- `src/NovaTerminal.Core/Ssh/Storage/SshJsonContext.cs`
+- `src/NovaTerminal.App/Core/SessionManager.cs`
+- `src/NovaTerminal.Core/Ssh/Models/SshProfile.cs` if migration or metadata is needed
+
+## Acceptance criteria
+- Trusted native hosts are remembered across app restarts.
+- Host key mismatch is detected and produces a warning/error path.
+- Session restore preserves `SshBackendKind`.
+- Existing OpenSSH profiles continue to load and run unchanged.
+- Tests cover:
+  - first trust
+  - repeat trust
+  - mismatch
+  - backend restore persistence
+
+## Notes
+- Do not store secrets in the known hosts store.
+- Keep format/versioning explicit if using structured JSON.
+- If using OpenSSH-style known_hosts formatting, isolate that logic cleanly.
+
+---
+
+# PR6 — Local Port Forwarding Parity
+
+**Branch:** `feat/ssh-native-local-forwarding`
+
+## Goal
+Add the first real feature-parity capability beyond shell access: local port forwarding.
+
+## Prompt
+Add local port forwarding to the native SSH backend in NovaTerminal. Reuse existing profile forward definitions where possible. Implement listener lifecycle, channel opening, backpressure-safe byte copying, and clean teardown. Do not implement remote forwarding, dynamic forwarding, or jump hosts in this PR. Optimize for correctness, shutdown hygiene, and observability.
+
+## Scope
+Implement:
+- local forwards only
+- multiple simultaneous local forwards
+- listener lifecycle tied to session lifecycle
+- safe teardown on disconnect or close
+
+### Suggested files to add
+- `src/NovaTerminal.Core/Ssh/Native/NativePortForwardSession.cs`
+- `src/NovaTerminal.Core/Ssh/Transport/PortForwardModels.cs` if needed
+- tests or harness support for forward setup validation
+
+### Suggested files to modify
+- `src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs`
+- `src/NovaTerminal.Core/Ssh/Models/SshProfile.cs` only if required
+- Rust crate in `native/rusty_ssh/` to support direct-tcpip or equivalent forwarding channels
+
+## Acceptance criteria
+- Native SSH profile with one or more local forwards works.
+- Local listeners bind and route traffic correctly.
+- Clean shutdown removes listeners and closes channels.
+- Failure to bind one forward is surfaced clearly.
+- Terminal shell still works while forwards are active.
+
+## Notes
+- Do not block session startup forever on a single bad listener.
+- Decide and document policy:
+  - fail session if any enabled forward fails
+  - or continue with partial success and clear warning
+- Favor clear logging and metrics.
+
+---
+
+# PR7 — Jump Host Support
+
+**Branch:** `feat/ssh-native-jump-hosts`
+
+## Goal
+Reach practical workflow parity with existing Direct SSH for common bastion/jump-host setups.
+
+## Prompt
+Add first-pass jump host support to NovaTerminal native SSH. Prefer a simple and explicit architecture rather than a clever one. One-hop support is sufficient for this PR. If multi-hop is significantly more complex, structure the code for it but do not complete it yet. Fail clearly for unsupported combinations rather than hiding them. Keep the OpenSSH backend as a fallback option.
+
+## Scope
+Implement first:
+- one-hop jump host support for native backend
+- explicit connector abstraction for future multi-hop
+- clear error/fallback messaging
+
+### Suggested files to add
+- `src/NovaTerminal.Core/Ssh/Native/NativeJumpHostConnector.cs`
+- `src/NovaTerminal.Core/Ssh/Native/JumpHostConnectPlan.cs`
+- tests around profile translation to jump-host connect plan
+
+### Suggested files to modify
+- `src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs`
+- `src/NovaTerminal.Core/Ssh/Sessions/SshSessionFactory.cs`
+- `src/NovaTerminal.Core/Ssh/Models/SshProfile.cs` only if native-specific metadata is required
+- Rust crate in `native/rusty_ssh/` for tunneled/chained connection support
+
+## Acceptance criteria
+- One-hop jump host works end-to-end.
+- Unsupported multi-hop combinations fail clearly or fall back intentionally.
+- Native and OpenSSH backends remain selectable per profile.
+- Logging makes the chosen path obvious.
+
+## Notes
+- Do not implement a complex generic proxy graph yet.
+- Explicitly document whether native jump host uses:
+  - chained SSH connections
+  - tunneled stream proxying
+  - or a hybrid approach
+
+---
+
+# PR8 — Hardening, Diagnostics, and Rollout Controls
+
+**Branch:** `feat/ssh-native-hardening-rollout`
+
+## Goal
+Make native SSH testable, operable, and safe to ship gradually.
+
+## Prompt
+Add rollout controls, diagnostics, and hardening for NovaTerminal native SSH. Expose backend selection in profile UI, add experimental gating, collect metrics for connect/auth/output timing, classify failures, and make fallback to OpenSSH straightforward. Optimize for operability, observability, and staged rollout rather than feature creep.
+
+## Scope
+Implement:
+- per-profile backend selector in UI
+- experimental feature flag / global toggle if needed
+- metrics and structured logs
+- failure classification
+- clear fallback path to OpenSSH
+
+### Suggested files to add
+- `src/NovaTerminal.Core/Ssh/Native/NativeSshMetrics.cs`
+- `src/NovaTerminal.Core/Ssh/Native/NativeSshFailureClassifier.cs`
+- optional settings model additions
+- optional diagnostics view model / UI elements
+
+### Suggested files to modify
+- `src/NovaTerminal.App/ViewModels/Ssh/*`
+- `src/NovaTerminal.App/Views/Ssh/*`
+- `src/NovaTerminal.App/SettingsWindow*` or equivalent
+- `src/NovaTerminal.Core/Ssh/Sessions/SshSessionFactory.cs`
+- `src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs`
+
+## Suggested metrics
+- connect latency
+- host key verification duration
+- auth duration
+- time to first output byte
+- disconnect reason
+- forward setup success/failure counts
+
+## Acceptance criteria
+- Backend can be selected per profile.
+- Native SSH can be globally gated or marked experimental.
+- Failures are classified into useful buckets:
+  - DNS/connect timeout
+  - auth failure
+  - host key mismatch
+  - channel open failure
+  - forwarding bind failure
+  - remote disconnect
+- User can switch a failing native profile back to OpenSSH easily.
+- Logs/diagnostics are sufficient to debug real-world failures.
+
+## Notes
+- Keep rollout conservative.
+- Prefer “experimental, opt-in, easy fallback” over bold defaults.
+
+---
+
+# Recommended milestone mapping
+
+## M5.2
+- PR4 — SSH Interaction UX Service
+
+## M5.3
+- PR5 — Known Hosts + Backend-Safe Persistence
+
+## M5.4
+- PR6 — Local Port Forwarding Parity
+
+## M5.5
+- PR7 — Jump Host Support
+
+## M5.6
+- PR8 — Hardening, Diagnostics, and Rollout Controls
+
+---
+
+# Implementation order advice
+
+Follow this order:
+
+1. PR4
+2. PR5
+3. PR6
+4. PR7
+5. PR8
+
+That order keeps the system sane:
+- first auth/trust UX
+- then persistence
+- then feature parity
+- then bastion workflows
+- then hardening and rollout
+
+Trying to do jump hosts before auth/trust UX is how one accidentally creates a debugging hobby instead of a product.
+
+---
+
+# Optional test matrix
+
+Use this matrix once PR4–PR8 start landing:
+
+## Auth
+- password
+- public key
+- encrypted private key
+- keyboard-interactive
+
+## Host keys
+- first connection
+- trusted reconnect
+- changed host key
+
+## Shell
+- simple shell
+- vim
+- lazygit
+- full-screen TUI resize
+
+## Forwards
+- one local forward
+- multiple local forwards
+- bad local bind
+- disconnect while forward active
+
+## Jump hosts
+- one-hop bastion
+- bad bastion credentials
+- bad target after valid bastion
+
+## Rollout
+- switch backend OpenSSH -> Native
+- switch backend Native -> OpenSSH
+- restored profile preserves backend

--- a/docs/plans/2026-03-31-native-ssh-implementation-plan.md
+++ b/docs/plans/2026-03-31-native-ssh-implementation-plan.md
@@ -1,0 +1,618 @@
+# Native SSH Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add an opt-in native SSH backend to NovaTerminal while preserving the current OpenSSH path and keeping terminal rendering untouched.
+
+**Architecture:** Keep OpenSSH and native SSH as separate backends behind a small factory. Leave `OpenSshConfigCompiler`, `SshLaunchPlanner`, and `SshArgBuilder` OpenSSH-only. Keep native SSH session logic in core/session layers, keep Avalonia dialogs in app/services layers, and use a narrow poll-based Rust FFI surface under the existing app native build flow.
+
+**Tech Stack:** C#/.NET 10, Avalonia 11, xUnit/Avalonia.Headless, Rust `cdylib`, existing `RustPtySession` packaging pattern, existing SSH profile store/session restore infrastructure.
+
+---
+
+## Repo-Specific Decisions
+
+- Do not create a new top-level `native/` tree. Put the new crate at `src/NovaTerminal.App/native/rusty_ssh/` and build/copy it alongside the existing `rusty_pty` crate.
+- Do not push native SSH through `RustPtySession`. `NativeSshSession` should implement `ITerminalSession` directly.
+- Do not put Avalonia dialog types into `NovaTerminal.Core`. Core should expose small interaction request/response contracts; App should implement them.
+- Do not change VT parsing or rendering code unless a bug proves it is necessary.
+
+### Task 1: Backend Split Foundation (PR1)
+
+**Files:**
+- Create: `src/NovaTerminal.Core/Ssh/Models/SshBackendKind.cs`
+- Create: `src/NovaTerminal.Core/Ssh/Sessions/ISshSessionFactory.cs`
+- Create: `src/NovaTerminal.Core/Ssh/Sessions/SshSessionFactory.cs`
+- Create: `src/NovaTerminal.Core/Ssh/Sessions/OpenSshSession.cs`
+- Create: `src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs`
+- Create: `src/NovaTerminal.Core/Ssh/Transport/IRemoteTerminalTransport.cs`
+- Modify: `src/NovaTerminal.Core/Ssh/Models/SshProfile.cs`
+- Modify: `src/NovaTerminal.Core/Ssh/Storage/JsonSshProfileStore.cs`
+- Modify: `src/NovaTerminal.Core/Ssh/Storage/SshJsonContext.cs`
+- Modify: `src/NovaTerminal.App/Core/TerminalProfile.cs`
+- Modify: `src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs`
+- Modify: `src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs`
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs`
+- Test: `tests/NovaTerminal.Core.Tests/Ssh/SshSessionFactoryTests.cs`
+- Test: `tests/NovaTerminal.Core.Tests/Ssh/JsonSshProfileStoreTests.cs`
+- Test: `tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs`
+- Test: `tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs`
+
+**Step 1: Write failing tests for backend persistence and factory routing**
+
+Add tests that assert:
+- `SshProfile` defaults `BackendKind` to `OpenSsh`.
+- JSON store round-trips `BackendKind`.
+- `SshConnectionService` projects backend selection into runtime `TerminalProfile`.
+- `SshSessionFactory` returns `OpenSshSession` for `OpenSsh` and a stub `NativeSshSession` for `Native`.
+
+**Step 2: Run tests to verify failure**
+
+Run:
+- `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~JsonSshProfileStoreTests"`
+- `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~SshSessionFactoryTests"`
+- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~SshConnectionServiceTests|FullyQualifiedName~NewSshConnectionViewModelTests"`
+
+Expected: FAIL because backend selection does not exist yet.
+
+**Step 3: Implement minimal backend split without behavior change**
+
+Implement:
+- `SshBackendKind` with `OpenSsh = 0`, `Native = 1`.
+- `SshProfile.BackendKind` defaulting to `OpenSsh`.
+- Matching runtime field on `TerminalProfile` so the app can carry backend choice after profile projection.
+- `OpenSshSession` as the current `SshSession` behavior moved behind a dedicated class.
+- `NativeSshSession` stub that throws `NotSupportedException("Native SSH backend is not implemented yet.")`.
+- `SshSessionFactory` that chooses backend by profile, but still preserves current OpenSSH behavior.
+- `TerminalPane.InitializeSession` routing SSH session creation through `SshSessionFactory` instead of directly constructing `SshSession`.
+- Keep `OpenSshConfigCompiler`, `SshLaunchPlanner`, and `SshArgBuilder` untouched and OpenSSH-only.
+
+**Step 4: Run tests to verify pass**
+
+Run:
+- `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~JsonSshProfileStoreTests|FullyQualifiedName~SshSessionFactoryTests"`
+- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~SshConnectionServiceTests|FullyQualifiedName~NewSshConnectionViewModelTests"`
+
+Expected: PASS and existing SSH launch behavior remains OpenSSH-backed.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.Core/Ssh/Models/SshBackendKind.cs \
+        src/NovaTerminal.Core/Ssh/Sessions/ISshSessionFactory.cs \
+        src/NovaTerminal.Core/Ssh/Sessions/SshSessionFactory.cs \
+        src/NovaTerminal.Core/Ssh/Sessions/OpenSshSession.cs \
+        src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs \
+        src/NovaTerminal.Core/Ssh/Transport/IRemoteTerminalTransport.cs \
+        src/NovaTerminal.Core/Ssh/Models/SshProfile.cs \
+        src/NovaTerminal.Core/Ssh/Storage/JsonSshProfileStore.cs \
+        src/NovaTerminal.Core/Ssh/Storage/SshJsonContext.cs \
+        src/NovaTerminal.App/Core/TerminalProfile.cs \
+        src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs \
+        src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs \
+        src/NovaTerminal.App/Controls/TerminalPane.axaml.cs \
+        tests/NovaTerminal.Core.Tests/Ssh/SshSessionFactoryTests.cs \
+        tests/NovaTerminal.Core.Tests/Ssh/JsonSshProfileStoreTests.cs \
+        tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs \
+        tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs
+git commit -m "Split SSH backends behind a factory"
+```
+
+### Task 2: Native Rust SSH Spike (PR2)
+
+**Files:**
+- Create: `src/NovaTerminal.App/native/rusty_ssh/Cargo.toml`
+- Create: `src/NovaTerminal.App/native/rusty_ssh/src/lib.rs`
+- Create: `src/NovaTerminal.App/native/rusty_ssh/examples/smoke.rs`
+- Modify: `src/NovaTerminal.App/NovaTerminal.App.csproj`
+- Test: `src/NovaTerminal.App/native/rusty_ssh/tests/ffi_contract.rs`
+
+**Step 1: Write failing Rust tests for the poll/event contract**
+
+Add Rust tests that assert:
+- a session handle can be created and closed safely.
+- poll returns stable event ordering.
+- resize/input/close requests validate null or invalid handles cleanly.
+- event payload structs stay fixed-width and ABI-safe.
+
+**Step 2: Run tests to verify failure**
+
+Run:
+- `cargo test --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml --release`
+
+Expected: FAIL because the crate and ABI do not exist yet.
+
+**Step 3: Implement the minimal native SSH crate and packaging**
+
+Implement:
+- A new additive crate at `src/NovaTerminal.App/native/rusty_ssh/`.
+- C ABI functions for:
+  - create/connect
+  - poll next event
+  - write stdin bytes
+  - resize PTY
+  - provide auth/host-key response
+  - close/free handle
+- Poll/event model that covers:
+  - stdout/stderr bytes
+  - host key prompt
+  - changed host key warning
+  - password prompt
+  - passphrase prompt
+  - keyboard-interactive prompt
+  - connected
+  - exit status
+  - disconnected/error
+- Minimal interactive shell flow only.
+- App project build/copy targets so `rusty_ssh` is built and copied next to `rusty_pty`.
+
+**Step 4: Run tests and smoke harness**
+
+Run:
+- `cargo test --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml --release`
+- `cargo run --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml --release --example smoke -- --help`
+
+Expected: tests PASS and smoke harness prints usage/help without crashing.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/native/rusty_ssh/Cargo.toml \
+        src/NovaTerminal.App/native/rusty_ssh/src/lib.rs \
+        src/NovaTerminal.App/native/rusty_ssh/examples/smoke.rs \
+        src/NovaTerminal.App/native/rusty_ssh/tests/ffi_contract.rs \
+        src/NovaTerminal.App/NovaTerminal.App.csproj
+git commit -m "Add native SSH Rust spike with poll-based ABI"
+```
+
+### Task 3: Native SSH Session Wrapper (PR3)
+
+**Files:**
+- Create: `src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs`
+- Create: `src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs`
+- Create: `src/NovaTerminal.Core/Ssh/Native/NativeSshEvent.cs`
+- Create: `src/NovaTerminal.Core/Ssh/Native/NativeSshConnectionOptions.cs`
+- Modify: `src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs`
+- Modify: `src/NovaTerminal.Core/Ssh/Sessions/SshSessionFactory.cs`
+- Test: `tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs`
+
+**Step 1: Write failing tests for the C# wrapper session lifecycle**
+
+Add tests that assert:
+- stdout bytes are decoded incrementally and emitted through `OnOutputReceived`.
+- `SendInput` forwards bytes through interop.
+- `Resize` forwards terminal dimensions.
+- exit/disconnect events trigger one `OnExit`.
+- dispose shuts down the poll loop cleanly.
+
+Use a fake `INativeSshInterop` in tests; do not depend on live Rust/DLL loading for unit coverage.
+
+**Step 2: Run tests to verify failure**
+
+Run:
+- `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~NativeSshSessionTests"`
+
+Expected: FAIL because the wrapper session and interop abstraction do not exist yet.
+
+**Step 3: Implement the wrapper with a background poll loop**
+
+Implement:
+- `NativeSshInterop` with `DllImport`/`LibraryImport` bindings to `rusty_ssh`.
+- `NativeSshSession` with:
+  - background poll loop
+  - stateful UTF-8 decoding
+  - input/resize forwarding
+  - clean cancellation and close
+  - no dependency on `RustPtySession`
+- `SshSessionFactory` creating `NativeSshSession` when `BackendKind == Native`.
+
+**Step 4: Run tests to verify pass**
+
+Run:
+- `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~NativeSshSessionTests|FullyQualifiedName~SshSessionFactoryTests"`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs \
+        src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs \
+        src/NovaTerminal.Core/Ssh/Native/NativeSshEvent.cs \
+        src/NovaTerminal.Core/Ssh/Native/NativeSshConnectionOptions.cs \
+        src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs \
+        src/NovaTerminal.Core/Ssh/Sessions/SshSessionFactory.cs \
+        tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
+git commit -m "Wrap native SSH crate behind NativeSshSession"
+```
+
+### Task 4: SSH Interaction UX Service (PR4)
+
+**Files:**
+- Create: `src/NovaTerminal.Core/Ssh/Interactions/SshInteractionKind.cs`
+- Create: `src/NovaTerminal.Core/Ssh/Interactions/SshInteractionRequest.cs`
+- Create: `src/NovaTerminal.Core/Ssh/Interactions/SshInteractionResponse.cs`
+- Create: `src/NovaTerminal.Core/Ssh/Interactions/ISshInteractionHandler.cs`
+- Create: `src/NovaTerminal.App/Services/Ssh/ISshInteractionService.cs`
+- Create: `src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs`
+- Create: `src/NovaTerminal.App/ViewModels/Ssh/HostKeyPromptViewModel.cs`
+- Create: `src/NovaTerminal.App/ViewModels/Ssh/AuthPromptViewModel.cs`
+- Create: `src/NovaTerminal.App/Views/Ssh/HostKeyPromptDialog.axaml`
+- Create: `src/NovaTerminal.App/Views/Ssh/HostKeyPromptDialog.axaml.cs`
+- Create: `src/NovaTerminal.App/Views/Ssh/AuthPromptDialog.axaml`
+- Create: `src/NovaTerminal.App/Views/Ssh/AuthPromptDialog.axaml.cs`
+- Modify: `src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs`
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs`
+- Modify: `src/NovaTerminal.App/MainWindow.axaml.cs`
+- Test: `tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionInteractionTests.cs`
+- Test: `tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs`
+
+**Step 1: Write failing tests for request/response prompting**
+
+Add tests that assert:
+- native session pauses poll progression while waiting for host-key/auth responses.
+- cancellation returns a deterministic reject/cancel response.
+- App interaction service maps host key, password, passphrase, and keyboard-interactive requests to dialogs/view models.
+
+**Step 2: Run tests to verify failure**
+
+Run:
+- `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~NativeSshSessionInteractionTests"`
+- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~SshInteractionServiceTests"`
+
+Expected: FAIL because the interaction contracts and service do not exist yet.
+
+**Step 3: Implement core interaction contracts and Avalonia service**
+
+Implement:
+- Core interaction DTOs/interfaces so `NativeSshSession` stays UI-agnostic.
+- Avalonia interaction service that shows dialogs for:
+  - unknown host key
+  - changed host key
+  - password auth
+  - key passphrase
+  - keyboard-interactive prompts
+- Main window wiring so sessions can access the service through composition, not static UI calls.
+- No terminal text scraping for auth/trust flows.
+
+**Step 4: Run tests to verify pass**
+
+Run:
+- `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~NativeSshSessionInteractionTests"`
+- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~SshInteractionServiceTests"`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.Core/Ssh/Interactions/SshInteractionKind.cs \
+        src/NovaTerminal.Core/Ssh/Interactions/SshInteractionRequest.cs \
+        src/NovaTerminal.Core/Ssh/Interactions/SshInteractionResponse.cs \
+        src/NovaTerminal.Core/Ssh/Interactions/ISshInteractionHandler.cs \
+        src/NovaTerminal.App/Services/Ssh/ISshInteractionService.cs \
+        src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs \
+        src/NovaTerminal.App/ViewModels/Ssh/HostKeyPromptViewModel.cs \
+        src/NovaTerminal.App/ViewModels/Ssh/AuthPromptViewModel.cs \
+        src/NovaTerminal.App/Views/Ssh/HostKeyPromptDialog.axaml \
+        src/NovaTerminal.App/Views/Ssh/HostKeyPromptDialog.axaml.cs \
+        src/NovaTerminal.App/Views/Ssh/AuthPromptDialog.axaml \
+        src/NovaTerminal.App/Views/Ssh/AuthPromptDialog.axaml.cs \
+        src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs \
+        src/NovaTerminal.App/Controls/TerminalPane.axaml.cs \
+        src/NovaTerminal.App/MainWindow.axaml.cs \
+        tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionInteractionTests.cs \
+        tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs
+git commit -m "Add native SSH interaction service and dialogs"
+```
+
+### Task 5: Known Hosts And Backend-Safe Persistence (PR5)
+
+**Files:**
+- Create: `src/NovaTerminal.Core/Ssh/Native/KnownHostEntry.cs`
+- Create: `src/NovaTerminal.Core/Ssh/Native/HostKeyFingerprintFormatter.cs`
+- Create: `src/NovaTerminal.Core/Ssh/Native/NativeKnownHostsStore.cs`
+- Modify: `src/NovaTerminal.App/Core/AppPaths.cs`
+- Modify: `src/NovaTerminal.Core/Ssh/Storage/JsonSshProfileStore.cs`
+- Modify: `src/NovaTerminal.Core/Ssh/Storage/SshJsonContext.cs`
+- Modify: `src/NovaTerminal.App/Core/SessionManager.cs`
+- Test: `tests/NovaTerminal.Core.Tests/Ssh/NativeKnownHostsStoreTests.cs`
+- Test: `tests/NovaTerminal.Tests/Core/AppPathsTests.cs`
+
+**Step 1: Write failing tests for trust persistence and restore behavior**
+
+Add tests that assert:
+- first trust persists a host key entry.
+- reconnect to same key passes lookup.
+- changed key is flagged as mismatch.
+- app paths expose a stable native known-hosts location.
+- restored SSH sessions preserve backend selection through store-backed profile resolution.
+
+**Step 2: Run tests to verify failure**
+
+Run:
+- `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~NativeKnownHostsStoreTests"`
+- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~AppPathsTests|FullyQualifiedName~SessionManager"`
+
+Expected: FAIL because native known-hosts storage does not exist yet.
+
+**Step 3: Implement native known-hosts storage and backend-safe restore**
+
+Implement:
+- App-owned known-hosts file path under `AppPaths`, for example `AppPaths.RootDirectory/ssh/native_known_hosts.json`.
+- Deterministic fingerprint formatting helpers.
+- Lookup/add/mismatch logic in `NativeKnownHostsStore`.
+- Keep profile/backend restore store-backed; only change session restore schema if a test proves store lookup is insufficient.
+- Do not store secrets in the known-hosts file.
+
+**Step 4: Run tests to verify pass**
+
+Run:
+- `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~NativeKnownHostsStoreTests|FullyQualifiedName~JsonSshProfileStoreTests"`
+- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~AppPathsTests"`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.Core/Ssh/Native/KnownHostEntry.cs \
+        src/NovaTerminal.Core/Ssh/Native/HostKeyFingerprintFormatter.cs \
+        src/NovaTerminal.Core/Ssh/Native/NativeKnownHostsStore.cs \
+        src/NovaTerminal.App/Core/AppPaths.cs \
+        src/NovaTerminal.Core/Ssh/Storage/JsonSshProfileStore.cs \
+        src/NovaTerminal.Core/Ssh/Storage/SshJsonContext.cs \
+        src/NovaTerminal.App/Core/SessionManager.cs \
+        tests/NovaTerminal.Core.Tests/Ssh/NativeKnownHostsStoreTests.cs \
+        tests/NovaTerminal.Tests/Core/AppPathsTests.cs
+git commit -m "Persist native SSH host trust and backend restore state"
+```
+
+### Task 6: Local Port Forwarding Parity (PR6)
+
+**Files:**
+- Create: `src/NovaTerminal.Core/Ssh/Native/NativePortForwardSession.cs`
+- Create: `src/NovaTerminal.Core/Ssh/Transport/PortForwardModels.cs`
+- Modify: `src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs`
+- Modify: `src/NovaTerminal.App/native/rusty_ssh/src/lib.rs`
+- Test: `tests/NovaTerminal.Core.Tests/Ssh/NativePortForwardSessionTests.cs`
+
+**Step 1: Write failing tests for forward lifecycle**
+
+Add tests that assert:
+- local forward listeners bind from `SshProfile.Forwards`.
+- multiple forwards can coexist.
+- listener/channel teardown occurs on session dispose.
+- one bind failure is surfaced deterministically.
+
+**Step 2: Run tests to verify failure**
+
+Run:
+- `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~NativePortForwardSessionTests"`
+
+Expected: FAIL because native forwarding orchestration does not exist yet.
+
+**Step 3: Implement local forwarding only**
+
+Implement:
+- `NativePortForwardSession` for listener lifecycle and byte shuttling.
+- Rust support for `direct-tcpip` or equivalent channel open path.
+- Startup policy documented in code and logs:
+  - either continue with partial success and warn
+  - or fail whole session on any enabled bind failure
+- Keep terminal shell usable while forwards are active.
+
+**Step 4: Run tests to verify pass**
+
+Run:
+- `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~NativePortForwardSessionTests"`
+- `cargo test --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml --release`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.Core/Ssh/Native/NativePortForwardSession.cs \
+        src/NovaTerminal.Core/Ssh/Transport/PortForwardModels.cs \
+        src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs \
+        src/NovaTerminal.App/native/rusty_ssh/src/lib.rs \
+        tests/NovaTerminal.Core.Tests/Ssh/NativePortForwardSessionTests.cs
+git commit -m "Add native SSH local port forwarding"
+```
+
+### Task 7: Jump Host Support (PR7)
+
+**Files:**
+- Create: `src/NovaTerminal.Core/Ssh/Native/JumpHostConnectPlan.cs`
+- Create: `src/NovaTerminal.Core/Ssh/Native/NativeJumpHostConnector.cs`
+- Modify: `src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs`
+- Modify: `src/NovaTerminal.Core/Ssh/Sessions/SshSessionFactory.cs`
+- Modify: `src/NovaTerminal.App/native/rusty_ssh/src/lib.rs`
+- Test: `tests/NovaTerminal.Core.Tests/Ssh/JumpHostConnectPlanTests.cs`
+
+**Step 1: Write failing tests for one-hop jump planning**
+
+Add tests that assert:
+- `SshProfile.JumpHops` becomes a one-hop native connect plan.
+- multi-hop profiles fail with a clear unsupported result in this PR.
+- factory/session logging makes the selected backend/path visible.
+
+**Step 2: Run tests to verify failure**
+
+Run:
+- `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~JumpHostConnectPlanTests"`
+
+Expected: FAIL because native jump-host planning does not exist yet.
+
+**Step 3: Implement one-hop jump host support**
+
+Implement:
+- explicit `JumpHostConnectPlan`.
+- `NativeJumpHostConnector` for one-hop only.
+- clear unsupported handling for multi-hop instead of hidden fallback.
+- keep OpenSSH backend available as manual fallback.
+
+**Step 4: Run tests to verify pass**
+
+Run:
+- `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~JumpHostConnectPlanTests"`
+- `cargo test --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml --release`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.Core/Ssh/Native/JumpHostConnectPlan.cs \
+        src/NovaTerminal.Core/Ssh/Native/NativeJumpHostConnector.cs \
+        src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs \
+        src/NovaTerminal.Core/Ssh/Sessions/SshSessionFactory.cs \
+        src/NovaTerminal.App/native/rusty_ssh/src/lib.rs \
+        tests/NovaTerminal.Core.Tests/Ssh/JumpHostConnectPlanTests.cs
+git commit -m "Add one-hop jump host support for native SSH"
+```
+
+### Task 8: Hardening, Diagnostics, And Rollout Controls (PR8)
+
+**Files:**
+- Create: `src/NovaTerminal.Core/Ssh/Native/NativeSshMetrics.cs`
+- Create: `src/NovaTerminal.Core/Ssh/Native/NativeSshFailureClassifier.cs`
+- Modify: `src/NovaTerminal.App/Core/TerminalSettings.cs`
+- Modify: `src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs`
+- Modify: `src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml`
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs`
+- Modify: `src/NovaTerminal.App/MainWindow.axaml.cs`
+- Modify: `src/NovaTerminal.Core/Ssh/Sessions/SshSessionFactory.cs`
+- Modify: `src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs`
+- Test: `tests/NovaTerminal.Core.Tests/Ssh/NativeSshFailureClassifierTests.cs`
+- Test: `tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs`
+
+**Step 1: Write failing tests for backend selection and rollout gating**
+
+Add tests that assert:
+- profile editor can store `OpenSsh` or `Native`.
+- global experimental toggle can disable native session creation.
+- failure classifier maps known native errors into stable buckets.
+
+**Step 2: Run tests to verify failure**
+
+Run:
+- `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~NativeSshFailureClassifierTests"`
+- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~NewSshConnectionViewModelTests"`
+
+Expected: FAIL because backend selector, gating, and classifier do not exist yet.
+
+**Step 3: Implement conservative rollout controls**
+
+Implement:
+- per-profile backend selector in the SSH editor UI.
+- global experimental setting in `TerminalSettings`.
+- `SshSessionFactory` refusal path when native backend is disabled.
+- metrics for:
+  - connect latency
+  - host key duration
+  - auth duration
+  - time to first output byte
+  - disconnect reason
+  - forward setup results
+- failure classification buckets for timeout, auth, host key mismatch, channel open, forward bind, and remote disconnect.
+- explicit user-visible path to switch the profile back to OpenSSH.
+
+**Step 4: Run tests to verify pass**
+
+Run:
+- `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~NativeSshFailureClassifierTests|FullyQualifiedName~NativeSshSessionTests"`
+- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~NewSshConnectionViewModelTests|FullyQualifiedName~SshConnectionServiceTests"`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.Core/Ssh/Native/NativeSshMetrics.cs \
+        src/NovaTerminal.Core/Ssh/Native/NativeSshFailureClassifier.cs \
+        src/NovaTerminal.App/Core/TerminalSettings.cs \
+        src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs \
+        src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml \
+        src/NovaTerminal.App/Controls/TerminalPane.axaml.cs \
+        src/NovaTerminal.App/MainWindow.axaml.cs \
+        src/NovaTerminal.Core/Ssh/Sessions/SshSessionFactory.cs \
+        src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs \
+        tests/NovaTerminal.Core.Tests/Ssh/NativeSshFailureClassifierTests.cs \
+        tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs
+git commit -m "Add native SSH rollout controls and diagnostics"
+```
+
+### Task 9: Full Verification And Documentation
+
+**Files:**
+- Modify: `docs/SSH_ROADMAP.md`
+- Create: `docs/native-ssh/Native_SSH_Test_Matrix.md`
+- Verify only: `src/NovaTerminal.Core/Ssh/**`, `src/NovaTerminal.App/Views/Ssh/**`, `src/NovaTerminal.App/native/rusty_ssh/**`
+
+**Step 1: Run focused .NET SSH suites**
+
+Run:
+- `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~Ssh"`
+- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~Ssh"`
+
+Expected: PASS.
+
+**Step 2: Run native crate tests**
+
+Run:
+- `cargo test --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml --release`
+
+Expected: PASS.
+
+**Step 3: Run broader app smoke**
+
+Run:
+- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~PtySmoke|FullyQualifiedName~SessionAuthSurfaceTests"`
+
+Expected: PASS and no password-injection API regressions.
+
+**Step 4: Manual matrix**
+
+Verify:
+- OpenSSH backend still connects exactly as before.
+- Native backend works for password, key, encrypted key, and keyboard-interactive auth.
+- first trust, trusted reconnect, and changed host key paths behave correctly.
+- native shell survives resize and fullscreen TUI usage.
+- one local forward and one-hop jump host work.
+- switching a broken native profile back to OpenSSH is obvious and safe.
+
+**Step 5: Update docs and commit**
+
+```bash
+git add docs/SSH_ROADMAP.md docs/native-ssh/Native_SSH_Test_Matrix.md
+git commit -m "Document native SSH verification matrix and rollout guidance"
+```
+
+## Recommended Execution Order
+
+1. Task 1
+2. Task 2
+3. Task 3
+4. Task 4
+5. Task 5
+6. Task 6
+7. Task 7
+8. Task 8
+9. Task 9
+
+## Risks To Watch During Execution
+
+- The current app assumes all SSH sessions are OpenSSH-backed and shell-command based. Keep `TerminalPane` changes narrow.
+- `src/NovaTerminal.App/native` currently builds one crate. Keep the new native SSH crate additive and do not break `rusty_pty`.
+- Session restore is profile-store driven today. Verify whether backend persistence is fully covered by the profile store before expanding `NovaSession`.
+- Avoid mixing host-key/auth UX into terminal output parsing. That would violate both the doc pack and the repo architecture rules.
+
+Plan complete and saved to `docs/plans/2026-03-31-native-ssh-implementation-plan.md`. Two execution options:
+
+**1. Subagent-Driven (this session)** - I dispatch fresh subagent per task, review between tasks, fast iteration
+
+**2. Parallel Session (separate)** - Open new session with executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/docs/plans/2026-03-31-native-ssh-password-memory-design.md
+++ b/docs/plans/2026-03-31-native-ssh-password-memory-design.md
@@ -1,0 +1,141 @@
+# Native SSH Password Memory Design
+
+**Date:** 2026-03-31
+
+## Goal
+
+Add a native-SSH-only way to remember a password securely so repeat connections can authenticate without prompting every time.
+
+## Scope
+
+- Native SSH backend only
+- Password prompts only
+- Secure storage via existing `VaultService`
+- Profile-level opt-in in the new SSH editor
+- Runtime prompt support for saving a password after first successful entry
+
+## Non-Goals
+
+- No password storage in `SshProfile` JSON
+- No OpenSSH password saving
+- No private-key passphrase persistence in this change
+- No keyboard-interactive answer persistence in this change
+- No large refactor of SSH profile storage
+
+## Existing Context
+
+- The new SSH profile flow is built around `NovaTerminal.Core.Ssh.Models.SshProfile` and `NewSshConnectionViewModel`.
+- `SshProfile` currently has no password field.
+- `VaultService` already supports storing and resolving SSH passwords by profile id through `GetCanonicalSshProfileKey`, `GetSshPasswordForProfile`, and `SetSshPasswordForProfile`.
+- The native SSH runtime prompt path goes through `SshInteractionService`.
+- The legacy settings window still contains an old password textbox, but the current SSH manager/editor does not expose password storage.
+
+## Recommended Approach
+
+Use a native-only, vault-backed remember-password flow:
+
+1. Add a native-only `Remember password in system vault` option in the new SSH connection editor.
+2. Keep the password secret itself out of all profile JSON and runtime profile serialization.
+3. Store and load the password through `VaultService`, keyed by the profile id.
+4. On native password prompts, try the vault first and auto-answer if a saved password exists.
+5. If no saved password exists, show the existing password dialog with an added `Remember password` checkbox for password prompts only.
+6. If the user submits a password and checks remember, persist it immediately to the vault.
+
+This keeps the profile model clean, uses the secure storage that already exists, and limits the feature to the native backend exactly as requested.
+
+## UX
+
+### SSH Editor
+
+- Show a checkbox only when `BackendKind == Native`.
+- Suggested label: `Remember password in system vault`
+- This checkbox means:
+  - if checked, the app may store a password for this profile in `VaultService`
+  - if unchecked, any existing saved password for that profile should be removed
+
+Important detail: the checkbox represents intent, not the password value itself. The profile editor does not need a persistent plaintext password textbox.
+
+### Runtime Password Prompt
+
+- Only native password prompts get save behavior.
+- Add a checkbox to the auth prompt dialog when the prompt kind is `Password`.
+- Suggested label: `Remember password`
+- If a saved password already exists and the profile is configured to remember it, the dialog should not appear; the stored password should be submitted automatically.
+
+Passphrase and keyboard-interactive prompts should keep the current transient behavior.
+
+## Data Model
+
+### Persisted Profile Data
+
+Add a small boolean flag to `SshProfile`, for example:
+
+- `RememberPasswordInVault`
+
+This is safe to persist because it is only a preference flag and contains no secret material.
+
+### Secret Storage
+
+- Store the actual password using `VaultService.SetSshPasswordForProfile(...)`
+- Read it using `VaultService.GetSshPasswordForProfile(...)`
+- Use the existing canonical key format based on profile id
+
+## Data Flow
+
+### Save Flow
+
+1. User edits a native SSH profile.
+2. User checks or unchecks `Remember password in system vault`.
+3. `SshConnectionService.SaveProfile(...)` persists the profile preference flag.
+4. If the flag is turned off, any stored password for that profile is removed from the vault.
+
+### Connect Flow
+
+1. Native SSH session starts for a saved profile.
+2. `SshInteractionService` receives a password prompt.
+3. If the profile backend is native and `RememberPasswordInVault` is enabled:
+   - resolve the runtime `TerminalProfile` / profile id
+   - check `VaultService` for an existing password
+4. If a saved password exists, return it immediately without showing a dialog.
+5. Otherwise show the password dialog.
+6. If the user checks `Remember password`, store the entered password after submission.
+
+## Architecture Notes
+
+- Keep all UI concerns in Avalonia view models and dialogs.
+- Keep secure storage interactions in app-layer services, not terminal core.
+- Do not change the VT/parser/rendering path.
+- Do not add fallback behavior that silently leaks into OpenSSH.
+
+## Risks
+
+### Profile Context In Runtime Prompts
+
+`SshInteractionService` currently receives an `SshInteractionRequest`, but the save/load decision also needs profile identity. The implementation should pass enough native-profile context into the interaction service without mixing UI into core session logic.
+
+### Accidental OpenSSH Wiring
+
+The editor checkbox and runtime storage logic must be explicitly gated on `SshBackendKind.Native`.
+
+### Existing Saved Secrets
+
+Turning off the remember option should remove any stored password for that profile so the UX stays predictable.
+
+## Testing Strategy
+
+- View model tests for native-only remember flag behavior
+- Connection service tests for profile preference persistence
+- Vault tests for canonical key usage and removal behavior
+- Interaction service tests for:
+  - auto-using a saved native password
+  - showing a password prompt when none exists
+  - saving a password when the prompt checkbox is selected
+  - not applying remember behavior to passphrase or keyboard-interactive prompts
+
+## Success Criteria
+
+- Native SSH users can opt into saving passwords securely
+- Saved passwords are reused automatically on later native password prompts
+- Passwords are never written to profile JSON
+- OpenSSH behavior remains unchanged
+- Passphrase and keyboard-interactive prompts remain unchanged

--- a/docs/plans/2026-03-31-native-ssh-password-memory.md
+++ b/docs/plans/2026-03-31-native-ssh-password-memory.md
@@ -1,0 +1,259 @@
+# Native SSH Password Memory Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add native-SSH-only password memory backed by `VaultService`, with profile-level opt-in and runtime prompt save support.
+
+**Architecture:** Persist only a native-only preference flag on `SshProfile`, keep the actual password in `VaultService`, and resolve/save the secret from `SshInteractionService` during native password prompts. UI changes stay in the Avalonia SSH editor and auth dialog; terminal core remains unaware of secret storage details.
+
+**Tech Stack:** C#, Avalonia UI, `System.Text.Json`, existing `VaultService`, xUnit, Avalonia.Headless.XUnit
+
+---
+
+### Task 1: Add failing tests for the profile preference flag
+
+**Files:**
+- Modify: `tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs`
+- Modify: `tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs`
+- Modify: `src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs`
+- Modify: `src/NovaTerminal.Core/Ssh/Models/SshProfile.cs`
+
+**Step 1: Write the failing test**
+
+Add tests that assert:
+- a native profile can persist a `RememberPasswordInVault` preference
+- an OpenSSH profile does not expose or preserve that preference through the editor flow
+
+**Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~NewSshConnectionViewModelTests|FullyQualifiedName~SshConnectionServiceTests"`
+
+Expected: FAIL because the preference does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add:
+- `RememberPasswordInVault` to `SshProfile`
+- matching VM state in `NewSshConnectionViewModel`
+- mapping in `ToSshProfile`, `ApplySshProfile`, and `SshConnectionService`
+
+Keep the property gated logically to native profiles.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command and confirm the new tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs src/NovaTerminal.Core/Ssh/Models/SshProfile.cs src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
+git commit -m "Add native SSH remember-password profile flag"
+```
+
+### Task 2: Add the native-only editor UI
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml`
+- Modify: `src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml.cs`
+- Modify: `src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs`
+- Test: `tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs`
+
+**Step 1: Write the failing test**
+
+Add tests that assert:
+- the native backend enables the remember-password checkbox state
+- switching away from native clears or disables the remember-password option predictably
+
+**Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~NewSshConnectionViewModelTests"`
+
+Expected: FAIL because the backend gating does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Update the editor:
+- add a checkbox under the `Auth` tab
+- show it only for `BackendKind == Native`
+- bind it to the new VM property
+
+Do not add a persistent password textbox.
+
+**Step 4: Run test to verify it passes**
+
+Run the same test command and confirm the new behavior passes.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml.cs src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs
+git commit -m "Add native SSH remember-password editor option"
+```
+
+### Task 3: Add failing tests for vault preference handling
+
+**Files:**
+- Modify: `tests/NovaTerminal.Tests/Core/VaultServiceSshKeyTests.cs`
+- Modify: `tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs`
+- Modify: `src/NovaTerminal.App/Core/VaultService.cs`
+- Modify: `src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs`
+
+**Step 1: Write the failing test**
+
+Add tests that assert:
+- turning off the remember-password flag removes the stored password for that profile
+- canonical profile-id keys continue to be used
+
+**Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~VaultServiceSshKeyTests|FullyQualifiedName~SshConnectionServiceTests"`
+
+Expected: FAIL because save/remove behavior is not wired yet.
+
+**Step 3: Write minimal implementation**
+
+Add a small app-layer seam so saving a profile can:
+- leave vault contents untouched when remember is enabled and no new password is supplied
+- remove the stored password when remember is disabled
+
+Prefer a small explicit helper rather than scattering vault logic across the UI.
+
+**Step 4: Run test to verify it passes**
+
+Run the same test command and confirm the vault behavior passes.
+
+**Step 5: Commit**
+
+```bash
+git add tests/NovaTerminal.Tests/Core/VaultServiceSshKeyTests.cs tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs src/NovaTerminal.App/Core/VaultService.cs src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
+git commit -m "Wire native SSH password preference to vault cleanup"
+```
+
+### Task 4: Add failing tests for runtime password reuse
+
+**Files:**
+- Modify: `tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs`
+- Modify: `src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs`
+- Modify: `src/NovaTerminal.App/Core/VaultService.cs`
+
+**Step 1: Write the failing test**
+
+Add tests that assert:
+- when a native profile has `RememberPasswordInVault` enabled and a saved password exists, password prompts are answered without showing the dialog
+- passphrase prompts still show the dialog even if a password exists in the vault
+
+**Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~SshInteractionServiceTests"`
+
+Expected: FAIL because the interaction service does not resolve stored secrets yet.
+
+**Step 3: Write minimal implementation**
+
+Extend `SshInteractionService` so it can receive enough profile context to:
+- identify the native SSH profile id
+- query `VaultService`
+- auto-return `SshInteractionResponse.FromSecret(...)` for password prompts only
+
+Keep this native-only.
+
+**Step 4: Run test to verify it passes**
+
+Run the same test command and confirm the new tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs src/NovaTerminal.App/Core/VaultService.cs
+git commit -m "Auto-use saved password for native SSH prompts"
+```
+
+### Task 5: Add failing tests for prompt-side save behavior
+
+**Files:**
+- Modify: `tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs`
+- Modify: `src/NovaTerminal.App/ViewModels/Ssh/AuthPromptViewModel.cs`
+- Modify: `src/NovaTerminal.App/Views/Ssh/AuthPromptDialog.axaml`
+- Modify: `src/NovaTerminal.App/Views/Ssh/AuthPromptDialog.axaml.cs`
+- Modify: `src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs`
+
+**Step 1: Write the failing test**
+
+Add tests that assert:
+- native password prompts expose a `Remember password` option
+- selecting it causes the submitted password to be stored in the vault
+- leaving it unchecked submits the password without storing it
+
+**Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~SshInteractionServiceTests"`
+
+Expected: FAIL because the auth prompt view model does not support remember state yet.
+
+**Step 3: Write minimal implementation**
+
+Update the dialog/view model to support:
+- an optional remember-password checkbox
+- a response shape that carries the remember decision
+
+Then persist the password in `SshInteractionService` after prompt submission when:
+- prompt kind is `Password`
+- backend is native
+- remember is checked
+
+**Step 4: Run test to verify it passes**
+
+Run the same test command and confirm the new tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs src/NovaTerminal.App/ViewModels/Ssh/AuthPromptViewModel.cs src/NovaTerminal.App/Views/Ssh/AuthPromptDialog.axaml src/NovaTerminal.App/Views/Ssh/AuthPromptDialog.axaml.cs src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs
+git commit -m "Add remember-password option to native SSH prompt"
+```
+
+### Task 6: Verify end-to-end native-only behavior
+
+**Files:**
+- Test: `tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs`
+- Test: `tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs`
+- Test: `tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs`
+- Test: `tests/NovaTerminal.Tests/Core/VaultServiceSshKeyTests.cs`
+- Build: `src/NovaTerminal.App/NovaTerminal.App.csproj`
+
+**Step 1: Run the targeted automated tests**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~NewSshConnectionViewModelTests|FullyQualifiedName~SshConnectionServiceTests|FullyQualifiedName~SshInteractionServiceTests|FullyQualifiedName~VaultServiceSshKeyTests"
+```
+
+Expected: PASS
+
+**Step 2: Run compile verification**
+
+Run:
+
+```bash
+dotnet msbuild src/NovaTerminal.App/NovaTerminal.App.csproj /t:Compile /p:Configuration=Release /p:SKIP_RUST_NATIVE_BUILD=1
+```
+
+Expected: PASS
+
+**Step 3: Manual verification**
+
+Verify:
+- native profile shows remember-password checkbox
+- OpenSSH profile does not show the checkbox
+- first native password login can save to vault
+- second native password login reuses saved password without prompting
+- unchecking the profile option removes the stored password
+- passphrase prompt still behaves as transient input only
+
+**Step 4: Commit**
+
+```bash
+git add .
+git commit -m "Verify native SSH password memory flow"
+```

--- a/src/NovaTerminal.App/CommandAssist/Domain/FileSystemPathSuggestionProvider.cs
+++ b/src/NovaTerminal.App/CommandAssist/Domain/FileSystemPathSuggestionProvider.cs
@@ -159,8 +159,9 @@ public sealed class FileSystemPathSuggestionProvider : IPathSuggestionProvider
 
         string tokenForFilesystem = StripLeadingQuote(activeToken, out string quotePrefix);
 
-        preferredSeparator = tokenForFilesystem.Contains('/')
-            ? '/'
+        int lastSeparatorIndex = tokenForFilesystem.LastIndexOfAny(['/', '\\']);
+        preferredSeparator = lastSeparatorIndex >= 0
+            ? tokenForFilesystem[lastSeparatorIndex]
             : Path.DirectorySeparatorChar;
 
         string? homeDirectory = ResolveHomeDirectory();

--- a/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
@@ -20,6 +20,7 @@ public sealed class NativeSshSession : ITerminalSession
     private readonly Action<string> _log;
     private readonly NativeSshMetrics _metrics = new();
     private readonly object _exitHandlerGate = new();
+    private readonly object _outputHandlerGate = new();
 
     private ReplayWriter? _recorder;
     private TerminalBuffer? _buffer;
@@ -31,6 +32,9 @@ public sealed class NativeSshSession : ITerminalSession
     private int _exitNotified;
     private int? _exitCode;
     private Action<int>? _onExit;
+    private Action<string>? _onOutputReceived;
+    private List<string>? _pendingOutputReplay;
+    private bool _hasOutputSubscriberEver;
 
     public NativeSshSession(
         SshProfile profile,
@@ -92,7 +96,48 @@ public sealed class NativeSshSession : ITerminalSession
     public int? ExitCode => _exitCode;
     public bool IsRecording => _recorder != null;
 
-    public event Action<string>? OnOutputReceived;
+    public event Action<string>? OnOutputReceived
+    {
+        add
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            List<string>? replay = null;
+            lock (_outputHandlerGate)
+            {
+                _onOutputReceived += value;
+                if (!_hasOutputSubscriberEver)
+                {
+                    _hasOutputSubscriberEver = true;
+                    replay = _pendingOutputReplay;
+                    _pendingOutputReplay = null;
+                }
+            }
+
+            if (replay != null)
+            {
+                foreach (string text in replay)
+                {
+                    value(text);
+                }
+            }
+        }
+        remove
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            lock (_outputHandlerGate)
+            {
+                _onOutputReceived -= value;
+            }
+        }
+    }
     public event Action<int>? OnExit
     {
         add
@@ -282,7 +327,7 @@ public sealed class NativeSshSession : ITerminalSession
                 _metrics.MarkDisconnected(failure.Kind.ToString());
                 _log($"[NativeSshSession] Poll loop failed: {ex.Message}");
                 _log($"[NativeSshSession] failure={failure.Kind}");
-                OnOutputReceived?.Invoke($"Native SSH session failed: {ex.Message}{Environment.NewLine}");
+                EmitText($"Native SSH session failed: {ex.Message}{Environment.NewLine}");
                 TryNotifyExit(-1);
             }
         }
@@ -302,7 +347,7 @@ public sealed class NativeSshSession : ITerminalSession
         int charCount = _utf8Decoder.GetChars(payload, 0, payload.Length, chars, 0, flush: false);
         if (charCount > 0)
         {
-            OnOutputReceived?.Invoke(new string(chars, 0, charCount));
+            EmitText(new string(chars, 0, charCount));
         }
     }
 
@@ -317,7 +362,7 @@ public sealed class NativeSshSession : ITerminalSession
 
         if (nextEvent.Payload.Length > 0)
         {
-            OnOutputReceived?.Invoke($"{message}{Environment.NewLine}");
+            EmitText($"{message}{Environment.NewLine}");
         }
 
         TryNotifyExit(nextEvent.StatusCode == 0 ? -1 : nextEvent.StatusCode);
@@ -374,6 +419,23 @@ public sealed class NativeSshSession : ITerminalSession
 
             handler?.Invoke(_exitCode.Value);
         }
+    }
+
+    private void EmitText(string text)
+    {
+        Action<string>? handler;
+        lock (_outputHandlerGate)
+        {
+            handler = _onOutputReceived;
+            if (!_hasOutputSubscriberEver && handler == null)
+            {
+                _pendingOutputReplay ??= new List<string>();
+                _pendingOutputReplay.Add(text);
+                return;
+            }
+        }
+
+        handler?.Invoke(text);
     }
 
     private void CloseNativeHandle()

--- a/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
@@ -19,6 +19,7 @@ public sealed class NativeSshSession : ITerminalSession
     private readonly Decoder _utf8Decoder = Encoding.UTF8.GetDecoder();
     private readonly Action<string> _log;
     private readonly NativeSshMetrics _metrics = new();
+    private readonly object _exitHandlerGate = new();
 
     private ReplayWriter? _recorder;
     private TerminalBuffer? _buffer;
@@ -29,6 +30,7 @@ public sealed class NativeSshSession : ITerminalSession
     private int _isRunning;
     private int _exitNotified;
     private int? _exitCode;
+    private Action<int>? _onExit;
 
     public NativeSshSession(
         SshProfile profile,
@@ -91,7 +93,46 @@ public sealed class NativeSshSession : ITerminalSession
     public bool IsRecording => _recorder != null;
 
     public event Action<string>? OnOutputReceived;
-    public event Action<int>? OnExit;
+    public event Action<int>? OnExit
+    {
+        add
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            int? replayExitCode = null;
+            lock (_exitHandlerGate)
+            {
+                if (Volatile.Read(ref _exitNotified) == 0)
+                {
+                    _onExit += value;
+                }
+                else
+                {
+                    replayExitCode = _exitCode;
+                }
+            }
+
+            if (replayExitCode.HasValue)
+            {
+                value(replayExitCode.Value);
+            }
+        }
+        remove
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            lock (_exitHandlerGate)
+            {
+                _onExit -= value;
+            }
+        }
+    }
 
     public void SendInput(string input)
     {
@@ -325,7 +366,13 @@ public sealed class NativeSshSession : ITerminalSession
         _exitCode ??= exitCode;
         if (Interlocked.Exchange(ref _exitNotified, 1) == 0)
         {
-            OnExit?.Invoke(_exitCode.Value);
+            Action<int>? handler;
+            lock (_exitHandlerGate)
+            {
+                handler = _onExit;
+            }
+
+            handler?.Invoke(_exitCode.Value);
         }
     }
 

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
@@ -91,6 +91,23 @@ public sealed class NativeSshSessionTests
     }
 
     [Fact]
+    public async Task LateOutputSubscriberReceivesBufferedOutput()
+    {
+        var interop = new FakeNativeSshInterop();
+        interop.Enqueue(NativeSshEvent.Data(Encoding.UTF8.GetBytes("hello")));
+        interop.Enqueue(NativeSshEvent.ExitStatus(0));
+        interop.Enqueue(NativeSshEvent.Closed(Array.Empty<byte>()));
+        var outputs = new List<string>();
+
+        using var session = new NativeSshSession(CreateProfile(), interop: interop);
+        await WaitUntilAsync(() => interop.CloseCallCount > 0);
+
+        session.OnOutputReceived += outputs.Add;
+
+        Assert.Equal(new[] { "hello" }, outputs);
+    }
+
+    [Fact]
     public async Task DisposeClosesNativeHandleAndStopsPollLoop()
     {
         var interop = new FakeNativeSshInterop();

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
@@ -75,6 +75,22 @@ public sealed class NativeSshSessionTests
     }
 
     [Fact]
+    public async Task LateOnExitSubscriberReceivesRecordedExitCode()
+    {
+        var interop = new FakeNativeSshInterop();
+        interop.Enqueue(NativeSshEvent.ExitStatus(17));
+        interop.Enqueue(NativeSshEvent.Closed(Array.Empty<byte>()));
+        var exit = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var session = new NativeSshSession(CreateProfile(), interop: interop);
+        await WaitUntilAsync(() => interop.CloseCallCount > 0);
+
+        session.OnExit += code => exit.TrySetResult(code);
+
+        Assert.Equal(17, await exit.Task.WaitAsync(TimeSpan.FromSeconds(2)));
+    }
+
+    [Fact]
     public async Task DisposeClosesNativeHandleAndStopsPollLoop()
     {
         var interop = new FakeNativeSshInterop();

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
@@ -727,6 +727,12 @@ public sealed class CommandAssistControllerTests
         controller.ToggleAssist();
         controller.HandleTextInput("git st");
 
+        await historyStore.WaitForSearchSettledAsync();
+        await snippetStore.WaitForReadAsync();
+
+        Assert.Equal("git status", controller.ViewModel.TopSuggestionText);
+        Assert.Equal(AssistSuggestionType.History, controller.Suggestions[0].Type);
+
         bool toggled = await controller.TogglePinSelectionAsync();
         IReadOnlyList<CommandSnippet> snippets = await snippetStore.GetAllAsync();
 

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
@@ -296,6 +296,7 @@ public sealed class CommandAssistControllerTests
 
         controller.HandleTextInput("git ");
         await historyStore.WaitForSearchSettledAsync();
+        await WaitForConditionAsync(() => controller.ViewModel.TopSuggestionText == "git status");
 
         Assert.Equal("git ", controller.ViewModel.QueryText);
         Assert.Equal("git status", controller.ViewModel.TopSuggestionText);
@@ -729,6 +730,8 @@ public sealed class CommandAssistControllerTests
 
         await historyStore.WaitForSearchSettledAsync();
         await snippetStore.WaitForReadAsync();
+        await WaitForConditionAsync(() => controller.ViewModel.TopSuggestionText == "git status" &&
+                                          controller.Suggestions.Count > 0);
 
         Assert.Equal("git status", controller.ViewModel.TopSuggestionText);
         Assert.Equal(AssistSuggestionType.History, controller.Suggestions[0].Type);
@@ -839,6 +842,21 @@ public sealed class CommandAssistControllerTests
             IsRedacted: false,
             Source: CommandCaptureSource.Heuristic,
             DurationMs: null);
+    }
+
+    private static async Task WaitForConditionAsync(Func<bool> predicate, int timeoutMs = 1000)
+    {
+        int elapsed = 0;
+        while (!predicate())
+        {
+            if (elapsed >= timeoutMs)
+            {
+                throw new TimeoutException("Timed out waiting for test condition.");
+            }
+
+            await Task.Delay(10);
+            elapsed += 10;
+        }
     }
 
     private sealed class InMemoryHistoryStore : IHistoryStore

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
@@ -439,6 +439,8 @@ public sealed class CommandAssistControllerTests
         controller.OpenHistorySearch();
         controller.HandleTextInput("git st");
         await historyStore.WaitForSearchSettledAsync();
+        await WaitForConditionAsync(() => controller.Suggestions.Count > 1 &&
+                                          controller.ViewModel.TopSuggestionText == "git status");
 
         bool moved = controller.MoveSelectionDown();
 
@@ -472,6 +474,8 @@ public sealed class CommandAssistControllerTests
         controller.ToggleAssist();
         controller.HandleTextInput("git st");
         await historyStore.WaitForSearchSettledAsync();
+        await WaitForConditionAsync(() => controller.Suggestions.Count > 1 &&
+                                          controller.ViewModel.TopSuggestionText == "git status");
         controller.MoveSelectionDown();
 
         bool inserted = controller.TryGetInsertionText(out string? insertionText);
@@ -781,6 +785,8 @@ public sealed class CommandAssistControllerTests
         controller.HandleTextInput("git st");
         await historyStore.WaitForSearchSettledAsync();
         await snippetStore.WaitForReadAsync();
+        await WaitForConditionAsync(() => controller.ViewModel.TopSuggestionText == "Git Status" &&
+                                          controller.Suggestions.Count > 0);
 
         bool toggled = await controller.TogglePinSelectionAsync();
         IReadOnlyList<CommandSnippet> snippets = await snippetStore.GetAllAsync();


### PR DESCRIPTION
## Summary
- preserve the last separator the user actually typed when building path completions
- keep PowerShell-style backslash completions stable on Linux instead of mixing `\\` input with `/` suffixes
- leave slash-based completions unchanged

## Root cause
`FileSystemPathSuggestionProvider` defaulted to `Path.DirectorySeparatorChar` unless the token contained `/`.
On Ubuntu, PowerShell inputs like `cd .\\M` therefore produced completions such as `cd .\\My Folder/`, which broke the existing tests and the intended shell behavior.

## Verification
- `wsl bash -lc "cd /mnt/d/projects/nova2 && /snap/bin/dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release -p:SKIP_RUST_NATIVE_BUILD=1 --filter 'FullyQualifiedName~FileSystemPathSuggestionProviderTests'"`
- `dotnet test tests\\NovaTerminal.Tests\\NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~FileSystemPathSuggestionProviderTests"`