### PR TITLE
Add native SSH dynamic forwarding

### DIFF
--- a/docs/SSH_ROADMAP.md
+++ b/docs/SSH_ROADMAP.md
@@ -140,7 +140,7 @@ Deliverable: release-ready SSH management feature set.
 
 * * * * *
 
-Native SSH Status (2026-03-31)
+Native SSH Status (2026-04-08)
 ==============================
 
 The native SSH initiative is now implemented behind conservative rollout controls.
@@ -152,6 +152,7 @@ Completed native SSH capabilities:
 - Avalonia host-key and auth dialogs for native SSH
 - app-managed native known-host trust store
 - local port forwarding for the native backend
+- direct-host dynamic port forwarding for the native backend
 - one-hop native jump-host support
 - rollout controls, backend selector, and stable failure classification
 
@@ -160,6 +161,9 @@ Rollout guidance:
 - `OpenSsh` remains the default backend.
 - `Native` is gated by `TerminalSettings.ExperimentalNativeSshEnabled`.
 - Native SSH does not silently fall back to OpenSSH on failure.
+- Native SSH supports local forwards and direct-host dynamic forwards.
+- Native SSH does not yet support dynamic forwarding through a one-hop jump host.
+- Remote forwarding remains unsupported in the native backend.
 - Multi-hop jump chains remain unsupported in the native backend.
 
 Verification references:

--- a/docs/native-ssh/Native_SSH_Test_Matrix.md
+++ b/docs/native-ssh/Native_SSH_Test_Matrix.md
@@ -1,19 +1,19 @@
 # Native SSH Test Matrix
 
-Date: 2026-03-31
+Date: 2026-04-08
 
 ## Automated Verification
 
-Executed in this repo on the native SSH completion branch:
+Executed in this repo on the native SSH dynamic forwarding branch:
 
 - `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~Ssh" /nodeReuse:false`
-  Result: PASS, 52/52
+  Result: PASS, 71/71
 - `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~Ssh" /nodeReuse:false`
-  Result: PASS, 45/45
+  Result: PASS, 76/76
 - `cargo test --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml --release`
   Result: PASS
-- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~PtySmoke|FullyQualifiedName~SessionAuthSurfaceTests" /nodeReuse:false`
-  Result: PASS, 2/2
+- `dotnet build src/NovaTerminal.App/NovaTerminal.App.csproj -c Release -p:SKIP_RUST_NATIVE_BUILD=1`
+  Result: PASS
 
 ## Coverage Summary
 
@@ -23,6 +23,7 @@ Verified by automated tests:
 - native host-key trust, trusted reconnect, and changed-host-key handling
 - native SSH interaction prompts for password, passphrase, and keyboard-interactive auth
 - native local port-forward listener lifecycle and teardown
+- native dynamic port-forward SOCKS5 `CONNECT` lifecycle and teardown for direct-host sessions
 - one-hop jump-host planning and explicit multi-hop rejection
 - native rollout gating and failure classification
 - native session input, resize, output decoding, and exit behavior
@@ -44,6 +45,8 @@ The following checks still require manual validation against real SSH endpoints.
 | Terminal behavior | Resize handling | Pending manual | Verify shell survives repeated resize |
 | Terminal behavior | Fullscreen/alt-screen TUI | Pending manual | Validate with a real TUI workload |
 | Forwarding | One local forward | Pending manual | Validate actual traffic through the forwarded port |
+| Forwarding | One direct-host dynamic forward | Pending manual | Validate actual SOCKS5 traffic through the forwarded port |
+| Forwarding | One-hop jump-host dynamic forward | Follow-up | Not implemented in the native backend yet |
 | Jump host | One-hop jump host | Pending manual | Validate end-to-end session through a real bastion |
 | Rollback | Broken native profile switched back to OpenSSH | Pending manual | Confirm backend selector flow is obvious and safe |
 
@@ -52,4 +55,7 @@ The following checks still require manual validation against real SSH endpoints.
 - Native SSH remains opt-in through `TerminalSettings.ExperimentalNativeSshEnabled`.
 - `OpenSsh` remains the default backend for new profiles.
 - Native backend refusal is explicit when the global experimental toggle is disabled.
+- Native backend now supports local and direct-host dynamic forwarding.
+- Remote forwarding remains unsupported in the native backend.
+- Dynamic forwarding through one-hop jump hosts remains follow-up work.
 - Multi-hop jump hosts are intentionally unsupported in the native backend at this stage.

--- a/docs/plans/2026-04-07-native-ssh-runtime-password-memory-design.md
+++ b/docs/plans/2026-04-07-native-ssh-runtime-password-memory-design.md
@@ -1,0 +1,135 @@
+# Native SSH Runtime Password Memory Design
+
+**Date:** 2026-04-07
+
+## Goal
+
+Make native SSH password saving a runtime dialog decision instead of a profile-editor setting, so users can save a native SSH password the first time they are prompted without having to preconfigure the profile.
+
+## Scope
+
+- Native SSH backend only
+- Password prompts only
+- Secure storage via existing `VaultService`
+- Runtime prompt support for saving a password after first successful entry
+- Automatic reuse of saved passwords for later native password prompts
+
+## Non-Goals
+
+- No OpenSSH password saving
+- No password storage in `SshProfile` JSON
+- No private-key passphrase persistence in this change
+- No keyboard-interactive answer persistence in this change
+- No deletion of existing saved passwords when a dialog submit leaves remember unchecked
+
+## Existing Context
+
+- The current native SSH password-memory flow is gated by a persisted `RememberPasswordInVault` preference on `SshProfile`.
+- The new SSH connection editor exposes a native-only `Remember password in system vault` checkbox.
+- The runtime auth dialog only shows `Remember password` when the profile preference is already enabled.
+- `VaultService` already supports storing and resolving SSH passwords by profile id through canonical SSH-profile keys.
+- `SshInteractionService` already owns the UI-facing auth prompt flow and is the correct place to decide whether to reuse a saved password or show the password dialog.
+
+## Problem
+
+The current UX hides the save-password option behind a profile editor setting:
+
+1. A native profile must first be edited.
+2. The user must enable `Remember password in system vault`.
+3. Only then does the runtime password dialog expose `Remember password`.
+
+That makes the feature easy to miss and forces an unnecessary editor round-trip before the first successful login.
+
+## Recommended Approach
+
+Use a runtime-only, vault-backed remember-password flow for native SSH:
+
+1. Remove the profile-level `Remember password in system vault` checkbox from the SSH editor.
+2. Stop using `SshProfile.RememberPasswordInVault` as the gate for runtime dialog behavior.
+3. For native password prompts, always try the vault first when profile identity is available.
+4. If a saved password exists, return it immediately without showing the dialog.
+5. If no saved password exists, show the existing password dialog with `Remember password` always available for native password prompts.
+6. If the user checks `Remember password`, persist the entered password in `VaultService` for that profile.
+7. If the user leaves `Remember password` unchecked, submit normally and leave any existing saved password untouched.
+
+This keeps secrets out of profile JSON, removes a hidden prerequisite from the UX, and constrains password memory to the native backend exactly as requested.
+
+## UX
+
+### SSH Editor
+
+- Remove the native-only `Remember password in system vault` checkbox.
+- The editor should no longer surface password-memory configuration.
+- Backend selection remains unchanged.
+
+### Runtime Password Prompt
+
+- Native password prompts always show `Remember password`.
+- If a saved password already exists for the native profile, the dialog should not appear; the stored password should be submitted automatically.
+- If the dialog is shown and the user checks `Remember password`, the password is stored after submission.
+- If the dialog is shown and the user leaves `Remember password` unchecked, the password is not updated or removed in the vault.
+
+Passphrase and keyboard-interactive prompts keep the current transient behavior.
+
+## Data Model
+
+### Persisted Profile Data
+
+- `RememberPasswordInVault` should no longer control runtime behavior.
+- For backward compatibility, the field can remain temporarily if removing it immediately would complicate profile migration or serialization, but it becomes ignored state.
+- New code should not treat the field as the source of truth for whether password memory is available.
+
+### Secret Storage
+
+- Store the actual password using `VaultService.SetSshPasswordForProfile(...)`
+- Read it using `VaultService.GetSshPasswordForProfile(...)`
+- Continue using canonical profile-id keys
+
+## Data Flow
+
+### Connect Flow
+
+1. Native SSH session starts for a saved profile.
+2. `SshInteractionService` receives a password prompt.
+3. If profile identity is available, query `VaultService` for an existing password for that profile.
+4. If a saved password exists, return it immediately without showing the dialog.
+5. Otherwise show the password dialog with `Remember password` enabled.
+6. If the user checks `Remember password`, store the entered password after submission.
+7. If the user does not check `Remember password`, return the entered password and do nothing to the vault.
+
+### Existing Saved Passwords
+
+- Existing saved native SSH passwords continue to work.
+- Users do not need to re-edit profiles to keep benefiting from previously saved secrets.
+- A normal dialog submit without remember must not erase an existing password.
+
+## Architecture Notes
+
+- Keep all UI concerns in Avalonia view models and dialogs.
+- Keep secure-storage interactions in app-layer services, not terminal core.
+- Do not change VT/parser/rendering paths.
+- Do not widen this feature to OpenSSH.
+
+## Risks
+
+### Hidden Dependency From Old Profile Flag
+
+If any runtime path still checks `RememberPasswordInVault`, the dialog can remain incorrectly hidden. The implementation must remove that gate everywhere relevant.
+
+### Unexpected Secret Deletion
+
+Unchecked dialog submit must not be treated as a signal to remove a saved password. This needs explicit tests.
+
+### Backend Leakage
+
+The runtime checkbox must remain native-password-only. Passphrase, keyboard-interactive, and OpenSSH paths must preserve current behavior.
+
+## Testing Strategy
+
+Add deterministic tests for:
+
+- editor VM and/or view behavior proving the profile-level remember-password option is no longer surfaced
+- native password prompts always exposing remember-password when the dialog is shown
+- native password prompts auto-using an existing saved password without any persisted profile gate
+- unchecked native password submissions leaving an existing saved password untouched
+- passphrase and keyboard-interactive prompts remaining transient

--- a/docs/plans/2026-04-07-native-ssh-runtime-password-memory.md
+++ b/docs/plans/2026-04-07-native-ssh-runtime-password-memory.md
@@ -1,0 +1,243 @@
+# Native SSH Runtime Password Memory Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the profile-gated native SSH password-memory UX with a runtime-only flow: native password prompts always offer `Remember password`, saved passwords are reused automatically, and unchecked submits never delete an existing saved password.
+
+**Architecture:** Keep secure storage in `VaultService` and runtime decision-making in `SshInteractionService`. Remove the editor-level remember-password affordance from the Avalonia SSH editor. Keep terminal core unaware of vault details, aside from passing enough native profile identity for app-layer lookup and save operations.
+
+**Tech Stack:** C#, Avalonia UI, `System.Text.Json`, existing `VaultService`, xUnit, Avalonia.Headless.XUnit
+
+---
+
+### Task 1: Remove the profile-level remember-password UI
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml`
+- Modify: `src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs`
+- Modify: `tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs`
+
+**Step 1: Write the failing test**
+
+Add tests that assert:
+- the SSH editor no longer exposes the native-only remember-password state
+- switching back and forth between backends no longer depends on a remember-password VM flag
+
+**Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~NewSshConnectionViewModelTests"`
+
+Expected: FAIL because the editor still exposes the profile-level remember-password option.
+
+**Step 3: Write minimal implementation**
+
+Remove:
+- the remember-password checkbox from the SSH editor view
+- the editor VM property and native-only visibility logic that only existed to surface this checkbox
+
+Preserve the rest of the auth/backend editor behavior.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command and confirm the new tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs
+git commit -m "Remove native SSH password memory editor toggle"
+```
+
+### Task 2: Make native password prompts always offer remember-password
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs`
+- Modify: `src/NovaTerminal.App/ViewModels/Ssh/AuthPromptViewModel.cs`
+- Modify: `src/NovaTerminal.App/Views/Ssh/AuthPromptDialog.axaml`
+- Modify: `src/NovaTerminal.App/Views/Ssh/AuthPromptDialog.axaml.cs`
+- Modify: `tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs`
+
+**Step 1: Write the failing test**
+
+Add tests that assert:
+- a native password prompt shows `Remember password` whenever the dialog is shown
+- passphrase prompts still do not surface the remember-password control
+
+**Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~SshInteractionServiceTests"`
+
+Expected: FAIL because the dialog is still gated by the old profile preference.
+
+**Step 3: Write minimal implementation**
+
+Change the interaction flow so:
+- native password prompts with profile identity enable remember-password in the dialog by default
+- passphrase and keyboard-interactive flows remain unchanged
+
+Keep the UI logic explicit and app-layer only.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command and confirm the new tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs src/NovaTerminal.App/ViewModels/Ssh/AuthPromptViewModel.cs src/NovaTerminal.App/Views/Ssh/AuthPromptDialog.axaml src/NovaTerminal.App/Views/Ssh/AuthPromptDialog.axaml.cs tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs
+git commit -m "Always offer remember-password for native SSH prompts"
+```
+
+### Task 3: Remove the old profile gate from vault reuse
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs`
+- Modify: `src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs`
+- Modify: `tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs`
+- Modify: `tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionInteractionTests.cs`
+
+**Step 1: Write the failing test**
+
+Add tests that assert:
+- a saved native password is reused automatically even when no profile remember-password flag is set
+- native password reuse still depends on profile identity and prompt type, not on OpenSSH or passphrase flows
+
+**Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~SshInteractionServiceTests"`  
+Run: `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~NativeSshSessionInteractionTests"`
+
+Expected: FAIL because runtime reuse is still gated by `RememberPasswordInVault`.
+
+**Step 3: Write minimal implementation**
+
+Refactor the native auth interaction path so vault lookup is driven by:
+- native backend
+- password prompt kind
+- available profile identity
+
+Do not require a persisted remember-password preference.
+
+**Step 4: Run test to verify it passes**
+
+Run the same commands and confirm the new tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionInteractionTests.cs
+git commit -m "Make native SSH password reuse runtime-driven"
+```
+
+### Task 4: Preserve saved passwords when remember is left unchecked
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs`
+- Modify: `tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs`
+- Modify: `tests/NovaTerminal.Tests/Core/VaultServiceSshKeyTests.cs`
+
+**Step 1: Write the failing test**
+
+Add tests that assert:
+- if a saved password already exists and the dialog is shown later, submitting with remember unchecked does not delete the saved password
+- only an explicit save operation updates vault contents
+
+**Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~SshInteractionServiceTests|FullyQualifiedName~VaultServiceSshKeyTests"`
+
+Expected: FAIL because current cleanup logic may still treat unchecked remember as opt-out.
+
+**Step 3: Write minimal implementation**
+
+Update the app-layer save path so:
+- checked remember stores/updates the password
+- unchecked remember leaves existing vault contents untouched
+
+Avoid adding implicit vault-cleanup behavior to transient auth prompts.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command and confirm the tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs tests/NovaTerminal.Tests/Core/VaultServiceSshKeyTests.cs
+git commit -m "Preserve saved native SSH passwords on unchecked prompts"
+```
+
+### Task 5: Reconcile persisted profile state and backward compatibility
+
+**Files:**
+- Modify: `src/NovaTerminal.Core/Ssh/Models/SshProfile.cs`
+- Modify: `src/NovaTerminal.Core/Ssh/Models/SshProfileNormalizer.cs`
+- Modify: `src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs`
+- Modify: `src/NovaTerminal.Core/Ssh/Storage/JsonSshProfileStore.cs`
+- Modify: `tests/NovaTerminal.Core.Tests/Ssh/JsonSshProfileStoreTests.cs`
+- Modify: `tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs`
+
+**Step 1: Write the failing test**
+
+Add tests that assert:
+- older profiles carrying `RememberPasswordInVault` still deserialize safely
+- new runtime behavior does not depend on that field
+- editor save/load no longer needs to round-trip the old preference as active UX state
+
+**Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~JsonSshProfileStoreTests"`  
+Run: `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~SshConnectionServiceTests"`
+
+Expected: FAIL because persistence and editor-service mappings still assume the old preference is active.
+
+**Step 3: Write minimal implementation**
+
+Choose the lightest safe compatibility approach:
+- either keep `RememberPasswordInVault` as ignored legacy state
+- or stop emitting it while still tolerating it on read
+
+Do not break existing saved profiles.
+
+**Step 4: Run test to verify it passes**
+
+Run the same commands and confirm the new behavior passes.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.Core/Ssh/Models/SshProfile.cs src/NovaTerminal.Core/Ssh/Models/SshProfileNormalizer.cs src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs src/NovaTerminal.Core/Ssh/Storage/JsonSshProfileStore.cs tests/NovaTerminal.Core.Tests/Ssh/JsonSshProfileStoreTests.cs tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
+git commit -m "Decouple native SSH password memory from profile settings"
+```
+
+### Task 6: Final verification
+
+**Files:**
+- No new product files
+
+**Step 1: Run focused automated verification**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~Ssh"
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~SshInteractionServiceTests|FullyQualifiedName~SshConnectionServiceTests|FullyQualifiedName~NewSshConnectionViewModelTests|FullyQualifiedName~VaultServiceSshKeyTests"
+dotnet build src/NovaTerminal.App/NovaTerminal.App.csproj -c Release -p:SKIP_RUST_NATIVE_BUILD=1
+```
+
+Expected: PASS
+
+**Step 2: Manual verification**
+
+Verify:
+- native password prompt shows `Remember password` without any profile preconfiguration
+- checking it stores the password and later connections skip the dialog
+- leaving it unchecked does not remove an already-saved password
+- OpenSSH and passphrase flows are unchanged
+
+**Step 3: Commit**
+
+```bash
+git add .
+git commit -m "Finalize runtime-only native SSH password memory"
+```

--- a/docs/plans/2026-04-08-native-ssh-dynamic-forwarding-design.md
+++ b/docs/plans/2026-04-08-native-ssh-dynamic-forwarding-design.md
@@ -1,0 +1,135 @@
+# Native SSH Dynamic Forwarding Design
+
+Date: 2026-04-08
+
+## Goal
+
+Add native SSH support for dynamic port forwarding (`SOCKS` proxy mode) for direct-host native sessions, without changing the existing SSH profile model or terminal rendering paths.
+
+## Current State
+
+- The SSH profile model already supports `PortForwardKind.Dynamic`.
+- OpenSSH already supports dynamic forwarding through argument/config generation.
+- Native SSH explicitly rejects any non-local forward in [NativeSshSession.cs](/d:/projects/nova2/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs) and [NativePortForwardSession.cs](/d:/projects/nova2/src/NovaTerminal.Core/Ssh/Native/NativePortForwardSession.cs).
+- The native Rust crate already supports opening `direct-tcpip` channels, which is sufficient for SOCKS `CONNECT`.
+
+## Chosen Approach
+
+Implement the SOCKS listener in C# inside the existing native forwarding subsystem and reuse the current Rust `direct-tcpip` channel support.
+
+Why this approach:
+
+- It is additive and fits the existing architecture.
+- Listener lifecycle already lives in C# for native local forwarding.
+- The Rust ABI does not need a new SOCKS-specific surface.
+- The terminal/session core remains unchanged.
+
+## Scope
+
+Included in v1:
+
+- Native dynamic forwarding for direct-host native SSH sessions
+- SOCKS5 `CONNECT`
+- IPv4, IPv6, and domain-name target parsing as supported by the SOCKS request
+- Clean teardown, bind failure handling, and deterministic tests
+
+Explicitly excluded from v1:
+
+- SOCKS4
+- SOCKS5 `BIND`
+- SOCKS5 `UDP ASSOCIATE`
+- Dynamic forwarding through native jump hosts
+
+## Follow-Up To Preserve
+
+Add a follow-up roadmap/test-matrix note for:
+
+- native dynamic forwarding through a one-hop jump host
+
+That should be tracked explicitly so it is not lost after the first direct-host implementation lands.
+
+## Architecture
+
+### Session Layer
+
+[NativeSshSession.cs](/d:/projects/nova2/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs) should stop rejecting `Dynamic` forwards. It should continue to reject unsupported native forward kinds, which after this change will only be `Remote`.
+
+### Forwarding Layer
+
+[NativePortForwardSession.cs](/d:/projects/nova2/src/NovaTerminal.Core/Ssh/Native/NativePortForwardSession.cs) becomes the main host for both native forward types:
+
+- `Local`: current fixed-destination listener behavior
+- `Dynamic`: a local SOCKS server that negotiates the target per client connection
+
+The forwarding layer should remain C#-owned because it already owns:
+
+- local bind/listener lifecycle
+- socket accept loops
+- channel-to-socket byte pumping
+- shutdown and cleanup policy
+
+### Rust Layer
+
+[lib.rs](/d:/projects/nova2/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs) should stay focused on SSH transport behavior:
+
+- open `direct-tcpip`
+- stream bytes
+- surface close/eof/data events
+
+No new SOCKS-specific ABI is required for v1.
+
+## SOCKS Behavior
+
+Implement only SOCKS5 `CONNECT`.
+
+Connection flow:
+
+1. Accept local TCP client on the configured bind address and source port
+2. Read SOCKS5 greeting and choose `NO AUTHENTICATION REQUIRED`
+3. Read SOCKS5 request
+4. Validate command is `CONNECT`
+5. Resolve target host/port from IPv4, IPv6, or domain-name form
+6. Open a native `direct-tcpip` channel to the requested target
+7. Return SOCKS success reply
+8. Reuse the existing bidirectional byte pump model
+
+Unsupported or invalid requests should be rejected with a protocol-correct SOCKS failure reply before the client socket is closed.
+
+## Error Handling
+
+Bind/setup policy should match the current native local-forward policy:
+
+- if any enabled forward fails to bind during startup, fail the native session setup
+
+Runtime failures should be logged clearly and closed cleanly:
+
+- invalid SOCKS greeting
+- unsupported auth method
+- unsupported SOCKS command
+- malformed destination payload
+- SSH `direct-tcpip` channel open failure
+
+## Testing Strategy
+
+Primary test coverage should stay in C#:
+
+- session accepts native dynamic forwards
+- SOCKS5 greeting + request produces expected `OpenDirectTcpIp`
+- unsupported SOCKS command is rejected deterministically
+- malformed handshake does not crash the listener
+- dispose tears down listeners and channels
+- local and dynamic forwards can coexist in one native profile
+
+Rust tests should remain minimal unless the implementation forces an interop change.
+
+## Docs Impact
+
+Update these after implementation:
+
+- [Native_SSH_Test_Matrix.md](/d:/projects/nova2/docs/native-ssh/Native_SSH_Test_Matrix.md)
+- [SSH_ROADMAP.md](/d:/projects/nova2/docs/SSH_ROADMAP.md)
+
+The docs should state:
+
+- native dynamic forwarding is supported for direct-host native sessions
+- native dynamic forwarding through one-hop jump hosts remains a follow-up item

--- a/docs/plans/2026-04-08-native-ssh-dynamic-forwarding.md
+++ b/docs/plans/2026-04-08-native-ssh-dynamic-forwarding.md
@@ -1,0 +1,337 @@
+# Native SSH Dynamic Forwarding Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add native SSH dynamic port forwarding for direct-host native sessions using SOCKS5 `CONNECT`, while keeping the existing profile model and native `direct-tcpip` transport path.
+
+**Architecture:** Keep SOCKS listener lifecycle in C# inside the native forwarding subsystem and reuse the Rust native SSH crate only for `direct-tcpip` channel open/read/write/close. This keeps the change additive, preserves terminal core boundaries, and avoids widening the FFI surface for v1.
+
+**Tech Stack:** C#, Avalonia app/core projects, Rust `russh`, xUnit
+
+---
+
+### Task 1: Lock native forwarding scope with failing tests
+
+**Files:**
+- Modify: `d:\projects\nova2\tests\NovaTerminal.Core.Tests\Ssh\NativeSshSessionTests.cs`
+- Modify: `d:\projects\nova2\tests\NovaTerminal.Core.Tests\Ssh\NativePortForwardSessionTests.cs`
+
+**Step 1: Write the failing tests**
+
+Add tests that prove:
+
+- a native profile with one `Dynamic` forward no longer throws at session construction
+- a SOCKS5 `CONNECT` request produces one `OpenDirectTcpIp` call with the requested host and port
+- a native forward set containing `Local` and `Dynamic` forwards can start together
+
+**Step 2: Run the tests to verify they fail**
+
+Run:
+
+```powershell
+dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~NativeSshSessionTests|FullyQualifiedName~NativePortForwardSessionTests"
+```
+
+Expected:
+
+- dynamic-forward native tests fail because non-local forwards are still rejected
+- existing local-forward tests remain green
+
+**Step 3: Commit**
+
+```powershell
+git add tests\NovaTerminal.Core.Tests\Ssh\NativeSshSessionTests.cs tests\NovaTerminal.Core.Tests\Ssh\NativePortForwardSessionTests.cs
+git commit -m "test: capture native dynamic forwarding expectations"
+```
+
+### Task 2: Allow native sessions to accept dynamic forwards
+
+**Files:**
+- Modify: `d:\projects\nova2\src\NovaTerminal.Core\Ssh\Sessions\NativeSshSession.cs`
+
+**Step 1: Write the minimal implementation**
+
+Change native forward validation so:
+
+- `Local` and `Dynamic` are accepted
+- `Remote` remains rejected with an explicit message
+
+Keep the rest of session construction unchanged.
+
+**Step 2: Run the focused tests**
+
+Run:
+
+```powershell
+dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~NativeSshSessionTests"
+```
+
+Expected:
+
+- session acceptance tests pass
+- SOCKS behavior tests still fail
+
+**Step 3: Commit**
+
+```powershell
+git add src\NovaTerminal.Core\Ssh\Sessions\NativeSshSession.cs tests\NovaTerminal.Core.Tests\Ssh\NativeSshSessionTests.cs
+git commit -m "feat: allow dynamic forwards in native ssh session setup"
+```
+
+### Task 3: Add SOCKS5 negotiation support to native forwarding
+
+**Files:**
+- Modify: `d:\projects\nova2\src\NovaTerminal.Core\Ssh\Native\NativePortForwardSession.cs`
+- Modify: `d:\projects\nova2\tests\NovaTerminal.Core.Tests\Ssh\NativePortForwardSessionTests.cs`
+
+**Step 1: Write the failing protocol tests**
+
+Add deterministic tests for:
+
+- SOCKS5 greeting with `NO AUTHENTICATION REQUIRED`
+- `CONNECT` request with domain-name destination
+- `CONNECT` request with IPv4 destination
+- unsupported command returns a failure response and does not call `OpenDirectTcpIp`
+
+Use real loopback sockets against the existing test fake interop so the tests exercise the actual listener path.
+
+**Step 2: Run the tests to verify they fail**
+
+Run:
+
+```powershell
+dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~NativePortForwardSessionTests"
+```
+
+Expected:
+
+- new SOCKS tests fail before implementation
+
+**Step 3: Write the minimal implementation**
+
+In `NativePortForwardSession`:
+
+- split listener startup by `PortForwardKind`
+- keep current local-forward flow intact
+- add a dynamic accept loop that:
+  - reads the SOCKS5 greeting
+  - selects `NO AUTHENTICATION REQUIRED`
+  - reads a single SOCKS request
+  - validates `CONNECT`
+  - extracts host/port
+  - calls `_interop.OpenDirectTcpIp(...)`
+  - sends success/failure reply
+  - reuses the existing channel/socket pump model
+
+Prefer small private helpers for:
+
+- greeting read/write
+- request parsing
+- reply building
+- dynamic channel setup
+
+**Step 4: Run the tests to verify they pass**
+
+Run:
+
+```powershell
+dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~NativePortForwardSessionTests"
+```
+
+Expected:
+
+- all local-forward and dynamic-forward tests pass
+
+**Step 5: Commit**
+
+```powershell
+git add src\NovaTerminal.Core\Ssh\Native\NativePortForwardSession.cs tests\NovaTerminal.Core.Tests\Ssh\NativePortForwardSessionTests.cs
+git commit -m "feat: add socks5 dynamic forwarding to native ssh"
+```
+
+### Task 4: Harden dynamic forwarding shutdown and mixed-forward behavior
+
+**Files:**
+- Modify: `d:\projects\nova2\src\NovaTerminal.Core\Ssh\Native\NativePortForwardSession.cs`
+- Modify: `d:\projects\nova2\tests\NovaTerminal.Core.Tests\Ssh\NativePortForwardSessionTests.cs`
+
+**Step 1: Add failing shutdown and coexistence tests**
+
+Cover:
+
+- disposing the native forward session closes dynamic listeners
+- open dynamic channels are closed on dispose
+- one `Local` and one `Dynamic` forward can coexist without interfering
+- malformed SOCKS greeting/request is handled without tearing down unrelated forwards
+
+**Step 2: Run the focused tests to verify they fail**
+
+Run:
+
+```powershell
+dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~NativePortForwardSessionTests"
+```
+
+**Step 3: Implement the hardening**
+
+Keep the implementation additive:
+
+- share channel cleanup between local and dynamic paths
+- ensure client sockets are always disposed on protocol failure
+- keep startup bind-failure policy unchanged
+
+**Step 4: Run the tests to verify they pass**
+
+Run:
+
+```powershell
+dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~NativePortForwardSessionTests"
+```
+
+**Step 5: Commit**
+
+```powershell
+git add src\NovaTerminal.Core\Ssh\Native\NativePortForwardSession.cs tests\NovaTerminal.Core.Tests\Ssh\NativePortForwardSessionTests.cs
+git commit -m "test: harden native dynamic forward teardown"
+```
+
+### Task 5: Verify Rust interop assumptions stay valid
+
+**Files:**
+- Review: `d:\projects\nova2\src\NovaTerminal.App\native\rusty_ssh\src\lib.rs`
+- Modify only if needed: `d:\projects\nova2\src\NovaTerminal.App\native\rusty_ssh\src\lib.rs`
+
+**Step 1: Run the existing native Rust tests**
+
+Run:
+
+```powershell
+cargo test --manifest-path src\NovaTerminal.App\native\rusty_ssh\Cargo.toml --release
+```
+
+Expected:
+
+- existing `direct-tcpip` coverage remains green without ABI changes
+
+**Step 2: If Rust changes are required, add the narrowest failing test first**
+
+Only touch `lib.rs` if the C# implementation exposes a real gap in:
+
+- `direct-tcpip` open semantics
+- channel close/eof ordering
+- event routing
+
+Keep v1 YAGNI: do not add Rust-side SOCKS parsing.
+
+**Step 3: Commit**
+
+```powershell
+git add src\NovaTerminal.App\native\rusty_ssh\src\lib.rs
+git commit -m "fix: align native ssh interop for dynamic forwarding"
+```
+
+Only make this commit if Rust code changed.
+
+### Task 6: Update docs and record the follow-up gap
+
+**Files:**
+- Modify: `d:\projects\nova2\docs\native-ssh\Native_SSH_Test_Matrix.md`
+- Modify: `d:\projects\nova2\docs\SSH_ROADMAP.md`
+
+**Step 1: Update the manual matrix**
+
+Add rows for:
+
+- native dynamic forward through a direct host
+- native dynamic forward through a one-hop jump host: follow-up / not yet supported
+
+Make the current native forwarding scope explicit:
+
+- local forward: supported
+- dynamic forward: supported after this work
+- remote forward: unsupported
+
+**Step 2: Update roadmap notes**
+
+Record:
+
+- native dynamic forwarding is implemented for direct-host native sessions
+- one-hop jump-host dynamic forwarding remains follow-up work
+
+**Step 3: Commit**
+
+```powershell
+git add docs\native-ssh\Native_SSH_Test_Matrix.md docs\SSH_ROADMAP.md
+git commit -m "docs: record native dynamic forwarding scope"
+```
+
+### Task 7: Full verification
+
+**Files:**
+- Verify only
+
+**Step 1: Run core SSH tests**
+
+```powershell
+dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~Ssh"
+```
+
+Expected:
+
+- PASS for the full core SSH slice
+
+**Step 2: Run app SSH tests**
+
+```powershell
+dotnet test tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~Ssh"
+```
+
+Expected:
+
+- PASS for the app SSH slice
+
+**Step 3: Run Rust tests**
+
+```powershell
+cargo test --manifest-path src\NovaTerminal.App\native\rusty_ssh\Cargo.toml --release
+```
+
+Expected:
+
+- PASS
+
+**Step 4: Build the app**
+
+```powershell
+dotnet build src\NovaTerminal.App\NovaTerminal.App.csproj -c Release -p:SKIP_RUST_NATIVE_BUILD=1
+```
+
+Expected:
+
+- PASS
+
+**Step 5: Manual spot-check list**
+
+Validate against a real endpoint:
+
+- native direct-host dynamic forward works as a SOCKS5 proxy
+- browser or CLI traffic traverses the proxy correctly
+- invalid SOCKS client request fails cleanly
+- native session shell remains usable while dynamic forward is active
+- reconnect/close tears down the SOCKS listener
+
+**Step 6: Final commit if verification/doc nits changed anything**
+
+```powershell
+git status --short
+```
+
+If any verification-driven adjustments were made, commit them with a focused message.
+
+## Follow-Up After This Plan
+
+Do not include in this implementation batch:
+
+- native dynamic forwarding through one-hop jump hosts
+- remote forwarding for native SSH
+- SOCKS4 or SOCKS5 UDP/BIND support

--- a/docs/plans/2026-04-08-native-ssh-fullscreen-exit-stall-design.md
+++ b/docs/plans/2026-04-08-native-ssh-fullscreen-exit-stall-design.md
@@ -1,0 +1,105 @@
+# Native SSH Fullscreen Exit Stall Design
+
+**Date:** 2026-04-08
+
+## Goal
+
+Eliminate the native SSH stall/flicker that can happen when a fullscreen TUI such as `mc` exits after aggressive resizing, without changing VT parsing or general rendering behavior.
+
+## Scope
+
+- Native SSH backend only
+- Resize handling between `TerminalView`, `NativeSshSession`, and the Rust `rusty_ssh` worker
+- Fullscreen/alternate-screen exit scenarios where resize storms overlap with remote redraw
+- Deterministic regression coverage for resize coalescing
+
+## Non-Goals
+
+- No OpenSSH behavior changes
+- No terminal parser/rendering refactor
+- No generic UI resize throttling changes for all terminal backends
+- No automatic reconnect or session lifecycle redesign
+- No Command Assist behavior changes unless a later investigation proves they are directly involved
+
+## Existing Context
+
+- The issue reproduces with native SSH, not OpenSSH.
+- It is easier to trigger with fullscreen TUIs such as `mc`, aggressive pane resizing, and then exiting the app.
+- The pane can appear stuck or flicker; another resize often causes recovery.
+- `TerminalView` already throttles resize events to roughly one PTY resize dispatch every 60 ms.
+- The native backend currently forwards every dispatched resize to `NativeSshSession.Resize(...)`, which immediately calls native interop.
+- The Rust worker processes commands sequentially; each resize becomes a separate `window-change` request on the SSH channel.
+
+## Problem
+
+Under heavy resize churn, the native backend can accumulate a backlog of stale `window-change` commands. When the fullscreen app exits and the remote shell redraws, those redraw-triggering resizes may still be queued and processed one by one. That can delay or destabilize the post-exit redraw path, which fits the observed pattern:
+
+- native only
+- easier to trigger with aggressive resize
+- often recovers on another resize
+
+This points to resize-command backlog rather than a parser bug or a pure repaint omission.
+
+## Recommended Approach
+
+Coalesce resize commands in the native backend so only the most recent dimensions survive backlog.
+
+### C# side
+
+- Keep `TerminalView` throttling unchanged.
+- Keep `NativeSshSession.Resize(...)` simple and backend-specific.
+- If needed, add a small native-session-side optimization later, but do not lead with extra state here.
+
+### Rust side
+
+- Change the worker command handling so a pending resize does not enqueue an unbounded sequence of stale `window-change` requests.
+- When the worker receives a resize command, drain any immediately pending resize commands from the command channel and retain only the latest `(cols, rows)` pair.
+- Apply one `channel.window_change(...)` call using the final coalesced dimensions.
+
+This targets the native-only bottleneck directly, preserves current UI behavior, and avoids broad side effects.
+
+## Why This Approach
+
+### Compared with stronger global resize throttling
+
+Increasing or debouncing `TerminalView` resize dispatch would affect all local and SSH sessions and make resize feel less responsive. It treats the symptom at the UI edge, not the native SSH command queue.
+
+### Compared with forcing extra redraws on alt-screen exit
+
+The current alt-screen path already triggers invalidation and screen-switch notifications. Extra redraw forcing may mask the issue, but it does not explain the native-only behavior nearly as well as resize backlog.
+
+## Architecture Notes
+
+- Keep the fix backend-specific to native SSH.
+- Preserve the current terminal-core and renderer behavior.
+- Keep the Rust worker as the authoritative place where sequential SSH commands are serialized.
+- Prefer coalescing rather than adding cross-layer complexity.
+
+## Testing Strategy
+
+Add deterministic tests that prove:
+
+- native session resize forwarding still works with the latest dimensions
+- the Rust worker applies only the last resize in a burst of back-to-back resize commands
+- no regression to ordinary native SSH output/exit behavior
+
+Manual verification should cover:
+
+- native SSH + `mc`
+- aggressive pane resize while `mc` is open
+- exit from `mc`
+- shell prompt redraw remains responsive without requiring another resize
+
+## Risks
+
+### Hidden Ordering Dependency
+
+If some other command must happen between two resizes, overly aggressive draining could accidentally reorder behavior. The implementation should coalesce only consecutive pending resize commands, not unrelated commands.
+
+### False Root Cause
+
+If resize coalescing alone does not resolve the issue, the next investigation target should be native-only post-alt-screen redraw timing, not a broad VT refactor.
+
+### Test Coverage Gap
+
+The exact runtime symptom is timing-sensitive, so the automated tests should assert queue/coalescing semantics rather than attempting flaky UI reproduction.

--- a/docs/plans/2026-04-08-native-ssh-fullscreen-exit-stall.md
+++ b/docs/plans/2026-04-08-native-ssh-fullscreen-exit-stall.md
@@ -1,0 +1,157 @@
+# Native SSH Fullscreen Exit Stall Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Prevent native SSH fullscreen apps from stalling or flickering after aggressive resize churn by coalescing stale resize commands before issuing SSH `window-change` requests.
+
+**Architecture:** Keep the fix native-backend-specific. Leave `TerminalView` resize throttling and VT/rendering untouched. Coalesce consecutive native resize commands in the Rust worker so only the latest dimensions are sent to the remote shell, and add regression tests around that queue behavior.
+
+**Tech Stack:** C#, Rust, Avalonia, `russh`, xUnit
+
+---
+
+### Task 1: Pin the native-side resize intent in core tests
+
+**Files:**
+- Modify: `tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs`
+
+**Step 1: Write the failing test**
+
+Add or extend a test that issues multiple `Resize(...)` calls on `NativeSshSession` and verifies the fake interop sees the latest dimensions as the effective intent for the session.
+
+**Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~NativeSshSessionTests"`
+
+Expected: FAIL if the current test suite does not yet pin burst-resize intent clearly enough.
+
+**Step 3: Write minimal implementation**
+
+Only adjust the test scaffolding needed to express the burst-resize scenario. Do not change production code in this task unless absolutely required for the failing-test seam.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command and confirm the targeted test passes.
+
+**Step 5: Commit**
+
+```bash
+git add tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
+git commit -m "Add native SSH burst resize intent test"
+```
+
+### Task 2: Add a Rust regression test for resize coalescing
+
+**Files:**
+- Modify: `src/NovaTerminal.App/native/rusty_ssh/src/lib.rs`
+
+**Step 1: Write the failing test**
+
+Add a Rust unit test around the worker-command handling that enqueues several consecutive resize commands and asserts only the last dimensions are applied to the channel-facing resize path.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml --release resize`
+
+Expected: FAIL because the worker currently processes each resize individually.
+
+**Step 3: Write minimal implementation**
+
+Add the smallest helper/test seam necessary to observe coalesced resize handling without spinning up a full SSH connection.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command and confirm the new resize test passes.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+git commit -m "Add native SSH resize coalescing regression test"
+```
+
+### Task 3: Coalesce consecutive native resize commands in Rust
+
+**Files:**
+- Modify: `src/NovaTerminal.App/native/rusty_ssh/src/lib.rs`
+
+**Step 1: Write the failing test**
+
+If Task 2 used only a narrow helper, add one more failing assertion proving unrelated commands are not swallowed when draining resizes.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml --release resize`
+
+Expected: FAIL because the worker still forwards stale intermediate dimensions or does not preserve command ordering around non-resize commands.
+
+**Step 3: Write minimal implementation**
+
+Update the Rust worker loop so:
+- when a `Resize` command is received, it drains immediately pending consecutive `Resize` commands
+- it keeps only the latest `(cols, rows)`
+- it issues a single `channel.window_change(...)`
+- it does not skip or reorder non-resize commands
+
+Keep the change local to native worker command handling.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command and confirm the resize tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+git commit -m "Coalesce native SSH resize commands"
+```
+
+### Task 4: Run focused native SSH verification
+
+**Files:**
+- No new product files
+
+**Step 1: Run core SSH verification**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~Ssh"
+```
+
+Expected: PASS
+
+**Step 2: Run Rust native verification**
+
+Run:
+
+```bash
+cargo test --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml --release
+```
+
+Expected: PASS
+
+**Step 3: Run app SSH slice**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~Ssh"
+```
+
+Expected: PASS
+
+**Step 4: Manual verification**
+
+Verify with native SSH:
+- open `mc`
+- resize aggressively for several seconds
+- exit `mc`
+- confirm the shell redraw does not stall and does not require another resize to recover
+
+**Step 5: Commit**
+
+```bash
+git add .
+git commit -m "Finalize native SSH fullscreen exit stall fix"
+```

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -1160,12 +1160,12 @@ namespace NovaTerminal.Controls
                 Session.AttachBuffer(Buffer);
 
                 TermView.SetSession(Session);
-                Session.OnExit += code =>
+                ITerminalSession session = Session;
+                session.OnExit += code =>
                 {
                     Dispatcher.UIThread.Post(() =>
                     {
-                        LastExitCode = code;
-                        ProcessExited?.Invoke(this, code);
+                        HandleSessionExit(session, code);
                     });
                 };
                 UpdateCommandAssistContext();
@@ -1546,7 +1546,7 @@ namespace NovaTerminal.Controls
             // Font Zoom - TBD
 
             // Reconnect if dead
-            if ((Session == null || LastExitCode.HasValue) && e.Key == Key.Enter)
+            if (ShouldReconnectOnEnter(Session) && e.Key == Key.Enter)
             {
                 e.Handled = true;
                 Reconnect();
@@ -1564,8 +1564,9 @@ namespace NovaTerminal.Controls
         {
             if (Session != null)
             {
-                Session.Dispose();
+                ITerminalSession session = Session;
                 Session = null;
+                session.Dispose();
             }
 
             LastExitCode = null;
@@ -1574,6 +1575,48 @@ namespace NovaTerminal.Controls
                 Buffer.WriteContent("\r\n\x1b[90m[Reconnecting...]\x1b[0m\r\n", false);
             }
             InitializeSession(ShellCommand, Profile, TermView.Cols, TermView.Rows, ShellArgs);
+        }
+
+        internal static bool ShouldReconnectOnEnter(ITerminalSession? session)
+        {
+            return session == null || !session.IsProcessRunning;
+        }
+
+        internal void HandleSessionExitForTesting(int code)
+        {
+            HandleSessionExit(Session, code);
+        }
+
+        private void HandleSessionExit(ITerminalSession? session, int code)
+        {
+            if (session != null && !ReferenceEquals(Session, session))
+            {
+                return;
+            }
+
+            LastExitCode = code;
+
+            if (Profile?.Type == ConnectionType.SSH)
+            {
+                WriteSshDisconnectedBanner(code);
+            }
+
+            ProcessExited?.Invoke(this, code);
+        }
+
+        private void WriteSshDisconnectedBanner(int code)
+        {
+            if (Buffer == null)
+            {
+                return;
+            }
+
+            string exitCodeLine = code == 0
+                ? string.Empty
+                : $"[Exit code: {code}]\r\n";
+            Buffer.WriteContent(
+                $"\r\n[SSH session disconnected]\r\n{exitCodeLine}[Press Enter to reconnect]\r\n",
+                false);
         }
 
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
@@ -1604,7 +1647,12 @@ namespace NovaTerminal.Controls
             _statusTimer?.Stop();
             _statusTimer = null;
             SftpService.Instance.JobUpdated -= Sftp_JobUpdated;
-            Session?.Dispose();
+            if (Session != null)
+            {
+                ITerminalSession session = Session;
+                Session = null;
+                session.Dispose();
+            }
         }
 
         private void Sftp_JobUpdated(object? sender, TransferJob job)

--- a/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
@@ -23,7 +23,6 @@ public sealed class SshLaunchDetails
         private const string FavoriteTag = "favorite";
 
         private readonly ISshProfileStore _profileStore;
-        private readonly ISshPasswordVault? _passwordVault;
 
         public SshConnectionService(ISshProfileStore? profileStore = null)
             : this(profileStore, null)
@@ -33,7 +32,7 @@ public sealed class SshLaunchDetails
         public SshConnectionService(ISshProfileStore? profileStore, ISshPasswordVault? passwordVault)
         {
             _profileStore = profileStore ?? new JsonSshProfileStore();
-            _passwordVault = passwordVault ?? new VaultService();
+            _ = passwordVault;
         }
 
     public IReadOnlyList<TerminalProfile> GetConnectionProfiles()
@@ -82,18 +81,19 @@ public sealed class SshLaunchDetails
 
         SshProfile incoming = viewModel.ToSshProfile();
         SshProfile? existing = _profileStore.GetProfile(incoming.Id);
-        if (existing != null && viewModel.BackendKind is null)
+        if (existing != null)
         {
-            incoming.BackendKind = existing.BackendKind;
             incoming.RememberPasswordInVault = existing.RememberPasswordInVault;
-        }
 
-        SshProfileNormalizer.NormalizeRememberPasswordPreference(incoming);
+            if (viewModel.BackendKind is null)
+            {
+                incoming.BackendKind = existing.BackendKind;
+            }
+        }
 
         SshProfile merged = MergeProfile(existing, incoming, viewModel.IsFavorite);
 
         _profileStore.SaveProfile(merged);
-        ApplyRememberPasswordPreference(ToRuntimeProfile(merged), existing, merged.RememberPasswordInVault);
         return _profileStore.GetProfile(merged.Id) ?? merged;
     }
 
@@ -132,10 +132,8 @@ public sealed class SshLaunchDetails
         bool useIdentity = !profile.UseSshAgent && !string.IsNullOrWhiteSpace(identityPath);
         candidate.AuthMode = useIdentity ? SshAuthMode.IdentityFile : SshAuthMode.Agent;
         candidate.IdentityFilePath = useIdentity ? identityPath : string.Empty;
-        SshProfileNormalizer.NormalizeRememberPasswordPreference(candidate);
 
         _profileStore.SaveProfile(candidate);
-        ApplyRememberPasswordPreference(profile, existing, candidate.RememberPasswordInVault);
     }
 
     public void SaveConnectionProfiles(IEnumerable<TerminalProfile> profiles)
@@ -146,21 +144,6 @@ public sealed class SshLaunchDetails
         {
             SaveConnectionProfile(profile);
         }
-    }
-
-    private void ApplyRememberPasswordPreference(TerminalProfile currentProfile, SshProfile? previousProfile, bool rememberPasswordInVault)
-    {
-        if (_passwordVault == null)
-        {
-            return;
-        }
-
-        if (previousProfile != null)
-        {
-            _passwordVault.ApplyRememberPasswordPreference(ToRuntimeProfile(previousProfile), rememberPasswordInVault);
-        }
-
-        _passwordVault.ApplyRememberPasswordPreference(currentProfile, rememberPasswordInVault);
     }
 
     public bool DeleteProfile(Guid profileId)
@@ -316,7 +299,6 @@ public sealed class SshLaunchDetails
 
         IEnumerable<string> sourceTags = (IEnumerable<string>?)existing?.Tags ?? Array.Empty<string>();
         merged.Tags = NormalizeTags(sourceTags, favorite);
-        SshProfileNormalizer.NormalizeRememberPasswordPreference(merged);
         return merged;
     }
 

--- a/src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs
@@ -87,7 +87,6 @@ public sealed class SshInteractionService : ISshInteractionService
     private bool TryHandlePasswordFromVault(SshInteractionRequest request, out SshInteractionResponse response)
     {
         if (request.Kind != SshInteractionKind.Password ||
-            !request.RememberPasswordInVault ||
             !request.ProfileId.HasValue ||
             !request.AllowVaultPasswordReuse)
         {
@@ -189,7 +188,7 @@ public sealed class SshInteractionService : ISshInteractionService
         {
             Title = "Password",
             Message = "Enter the SSH password to continue.",
-            CanRememberPassword = request.RememberPasswordInVault
+            CanRememberPassword = request.ProfileId.HasValue
         };
         viewModel.Prompts.Add(new AuthPromptEntryViewModel
         {
@@ -202,7 +201,6 @@ public sealed class SshInteractionService : ISshInteractionService
     private static bool ShouldStorePasswordInVault(SshInteractionRequest request, SshInteractionResponse response)
     {
         return request.Kind == SshInteractionKind.Password &&
-            request.RememberPasswordInVault &&
             request.ProfileId.HasValue &&
             !response.IsCanceled &&
             response.RememberPasswordInVault &&
@@ -244,3 +242,4 @@ public sealed class SshInteractionService : ISshInteractionService
         return viewModel;
     }
 }
+

--- a/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
+++ b/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
@@ -138,13 +138,7 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
         {
             if (SetField(ref _backendKind, value))
             {
-                if (value != SshBackendKind.Native)
-                {
-                    RememberPasswordInVault = false;
-                }
-
                 OnPropertyChanged(nameof(BackendWarning));
-                OnPropertyChanged(nameof(IsRememberPasswordVisible));
             }
         }
     }
@@ -275,8 +269,6 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
         int keepAliveInterval = KeepAliveIntervalSeconds > 0 ? KeepAliveIntervalSeconds : 30;
         int keepAliveCountMax = KeepAliveCountMax > 0 ? KeepAliveCountMax : 3;
         int controlPersistSeconds = ControlPersistSeconds >= 0 ? ControlPersistSeconds : 90;
-        bool rememberPassword = BackendKind == SshBackendKind.Native && RememberPasswordInVault;
-
         return new SshProfile
         {
             Id = id,
@@ -290,7 +282,6 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
             Port = port,
             AuthMode = IsIdentityFileAuth ? SshAuthMode.IdentityFile : SshAuthMode.Agent,
             IdentityFilePath = identityPath,
-            RememberPasswordInVault = rememberPassword,
             JumpHops = JumpHops.Select(h => new SshJumpHop
             {
                 Host = h.Host?.Trim() ?? string.Empty,
@@ -374,7 +365,6 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
         IsFavorite = sshProfile.Tags.Any(tag => string.Equals(tag, "favorite", StringComparison.OrdinalIgnoreCase));
         AuthMode = sshProfile.AuthMode == SshAuthMode.IdentityFile ? NewSshAuthMode.IdentityFile : NewSshAuthMode.Agent;
         IdentityFilePath = sshProfile.IdentityFilePath ?? string.Empty;
-        RememberPasswordInVault = sshProfile.BackendKind == SshBackendKind.Native && sshProfile.RememberPasswordInVault;
 
         JumpHops.Clear();
         foreach (SshJumpHop hop in sshProfile.JumpHops)
@@ -533,3 +523,4 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 }
+

--- a/src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml
+++ b/src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml
@@ -64,7 +64,7 @@
             </TabItem>
 
             <TabItem Header="Auth">
-                <Grid Margin="0,10,0,0" ColumnDefinitions="170,*" RowDefinitions="Auto,Auto,Auto" RowSpacing="10">
+                <Grid Margin="0,10,0,0" ColumnDefinitions="170,*" RowDefinitions="Auto,Auto" RowSpacing="10">
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="Auth mode" VerticalAlignment="Center" />
                     <ComboBox Grid.Row="0" Grid.Column="1" Name="AuthModeCombo" SelectedItem="{Binding AuthMode}" />
 
@@ -77,12 +77,6 @@
                         <TextBox Grid.Column="0" Text="{Binding IdentityFilePath}" Watermark="Path to private key" />
                         <Button Grid.Column="1" Content="Browse..." Click="OnBrowseIdentityFileClick" />
                     </Grid>
-
-                    <CheckBox Grid.Row="2"
-                              Grid.Column="1"
-                              Content="Remember password in vault"
-                              IsChecked="{Binding RememberPasswordInVault}"
-                              IsVisible="{Binding IsRememberPasswordVisible}" />
                 </Grid>
             </TabItem>
 

--- a/src/NovaTerminal.App/native/rusty_ssh/examples/smoke.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/examples/smoke.rs
@@ -45,6 +45,8 @@ fn main() {
         jump_host: std::ptr::null(),
         jump_user: std::ptr::null(),
         jump_port: 0,
+        keepalive_interval_seconds: 30,
+        keepalive_count_max: 3,
     };
 
     let session = nova_ssh_connect(&connect_args);

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -37,6 +37,8 @@ pub struct NovaSshConnectArgs {
     pub jump_host: *const c_char,
     pub jump_user: *const c_char,
     pub jump_port: u16,
+    pub keepalive_interval_seconds: u32,
+    pub keepalive_count_max: u32,
 }
 
 #[repr(C)]
@@ -143,6 +145,8 @@ struct ConnectConfig {
     term: String,
     identity_file: Option<String>,
     jump_host: Option<JumpHostConfig>,
+    keepalive_interval_seconds: u32,
+    keepalive_count_max: u32,
 }
 
 #[derive(Clone)]
@@ -652,6 +656,16 @@ impl ConnectConfig {
             term,
             identity_file,
             jump_host: effective_jump_host,
+            keepalive_interval_seconds: if args.keepalive_interval_seconds == 0 {
+                30
+            } else {
+                args.keepalive_interval_seconds
+            },
+            keepalive_count_max: if args.keepalive_count_max == 0 {
+                3
+            } else {
+                args.keepalive_count_max
+            },
         })
     }
 }
@@ -677,10 +691,7 @@ fn run_session(
     let runtime = Builder::new_current_thread().enable_all().build()?;
     runtime.block_on(async move {
         let forward_channels = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-        let client_config = Arc::new(client::Config {
-            inactivity_timeout: Some(Duration::from_secs(30)),
-            ..<_>::default()
-        });
+        let client_config = Arc::new(build_client_config(&config));
 
         let jump_session = if let Some(jump_host) = &config.jump_host {
             let jump_handler = NovaClientHandler {
@@ -1132,6 +1143,7 @@ fn create_test_session_with_event(kind: NovaSshEventKind, payload: &[u8]) -> *mu
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::CString;
 
     #[test]
     fn null_handle_operations_return_invalid_argument() {
@@ -1221,5 +1233,63 @@ mod tests {
 
         let close = nova_ssh_close(session);
         assert_eq!(NOVA_SSH_RESULT_OK, close);
+    }
+
+    #[test]
+    fn connect_config_reads_keepalive_settings_from_ffi_args() {
+        let host = CString::new("native.example").unwrap();
+        let user = CString::new("nova").unwrap();
+        let term = CString::new("xterm-256color").unwrap();
+
+        let args = NovaSshConnectArgs {
+            host: host.as_ptr(),
+            user: user.as_ptr(),
+            port: 22,
+            cols: 120,
+            rows: 30,
+            term: term.as_ptr(),
+            identity_file: ptr::null(),
+            jump_host: ptr::null(),
+            jump_user: ptr::null(),
+            jump_port: 0,
+            keepalive_interval_seconds: 15,
+            keepalive_count_max: 7,
+        };
+
+        let config = ConnectConfig::from_args(&args).expect("config should parse");
+
+        assert_eq!(15, config.keepalive_interval_seconds);
+        assert_eq!(7, config.keepalive_count_max);
+    }
+
+    #[test]
+    fn client_config_uses_keepalive_without_forcing_inactivity_timeout() {
+        let config = ConnectConfig {
+            host: "native.example".to_owned(),
+            user: "nova".to_owned(),
+            port: 22,
+            cols: 120,
+            rows: 30,
+            term: "xterm-256color".to_owned(),
+            identity_file: None,
+            jump_host: None,
+            keepalive_interval_seconds: 15,
+            keepalive_count_max: 7,
+        };
+
+        let client_config = build_client_config(&config);
+
+        assert_eq!(None, client_config.inactivity_timeout);
+        assert_eq!(Some(Duration::from_secs(15)), client_config.keepalive_interval);
+        assert_eq!(7, client_config.keepalive_max);
+    }
+}
+
+fn build_client_config(config: &ConnectConfig) -> client::Config {
+    client::Config {
+        inactivity_timeout: None,
+        keepalive_interval: Some(Duration::from_secs(config.keepalive_interval_seconds as u64)),
+        keepalive_max: config.keepalive_count_max as usize,
+        ..<_>::default()
     }
 }

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -1141,6 +1141,18 @@ fn create_test_session_with_event(kind: NovaSshEventKind, payload: &[u8]) -> *mu
 }
 
 #[cfg(test)]
+fn replay_resize_commands_for_test(
+    commands: &[WorkerCommand],
+    mut on_resize: impl FnMut(u16, u16),
+) {
+    for command in commands {
+        if let WorkerCommand::Resize { cols, rows } = command {
+            on_resize(*cols, *rows);
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use std::ffi::CString;
@@ -1282,6 +1294,22 @@ mod tests {
         assert_eq!(None, client_config.inactivity_timeout);
         assert_eq!(Some(Duration::from_secs(15)), client_config.keepalive_interval);
         assert_eq!(7, client_config.keepalive_max);
+    }
+
+    #[test]
+    fn worker_resize_burst_should_only_apply_latest_dimensions() {
+        let commands = vec![
+            WorkerCommand::Resize { cols: 120, rows: 30 },
+            WorkerCommand::Resize { cols: 140, rows: 40 },
+            WorkerCommand::Resize { cols: 160, rows: 50 },
+        ];
+
+        let mut applied = Vec::new();
+        replay_resize_commands_for_test(&commands, |cols, rows| {
+            applied.push((cols, rows));
+        });
+
+        assert_eq!(vec![(160, 50)], applied);
     }
 }
 

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -135,6 +135,14 @@ enum WorkerCommand {
     Close,
 }
 
+#[cfg(test)]
+#[derive(Debug, PartialEq, Eq)]
+enum RecordedWorkerEffect {
+    Resize(u16, u16),
+    Write,
+    Other,
+}
+
 #[derive(Clone)]
 struct ConnectConfig {
     host: String,
@@ -769,14 +777,22 @@ fn run_session(
             flags: NOVA_SSH_EVENT_FLAG_JSON,
         });
 
+        let mut pending_command: Option<WorkerCommand> = None;
         loop {
             tokio::select! {
-                command = command_rx.recv() => {
+                command = next_worker_command(&mut pending_command, &mut command_rx) => {
                     match command {
                         Some(WorkerCommand::Write(data)) => {
                             channel.data(&data[..]).await?;
                         }
                         Some(WorkerCommand::Resize { cols, rows }) => {
+                            let (cols, rows, pending_resize_command) = coalesce_pending_resize_commands(
+                                &mut command_rx,
+                                cols,
+                                rows,
+                            );
+                            pending_command = pending_resize_command;
+
                             channel.window_change(cols as u32, rows as u32, 0, 0).await?;
                         }
                         Some(WorkerCommand::OpenDirectTcpIp {
@@ -860,6 +876,43 @@ fn run_session(
         }
         Ok(())
     })
+}
+
+async fn next_worker_command(
+    pending_command: &mut Option<WorkerCommand>,
+    command_rx: &mut mpsc::UnboundedReceiver<WorkerCommand>,
+) -> Option<WorkerCommand> {
+    if let Some(command) = pending_command.take() {
+        return Some(command);
+    }
+
+    command_rx.recv().await
+}
+
+fn coalesce_pending_resize_commands(
+    command_rx: &mut mpsc::UnboundedReceiver<WorkerCommand>,
+    mut cols: u16,
+    mut rows: u16,
+) -> (u16, u16, Option<WorkerCommand>) {
+    let mut pending_command = None;
+
+    loop {
+        match command_rx.try_recv() {
+            Ok(WorkerCommand::Resize { cols: next_cols, rows: next_rows }) => {
+                cols = next_cols;
+                rows = next_rows;
+            }
+            Ok(command) => {
+                pending_command = Some(command);
+                break;
+            }
+            Err(mpsc::error::TryRecvError::Empty) | Err(mpsc::error::TryRecvError::Disconnected) => {
+                break;
+            }
+        }
+    }
+
+    (cols, rows, pending_command)
 }
 
 async fn open_direct_tcpip_channel(
@@ -1141,15 +1194,49 @@ fn create_test_session_with_event(kind: NovaSshEventKind, payload: &[u8]) -> *mu
 }
 
 #[cfg(test)]
-fn replay_resize_commands_for_test(
-    commands: &[WorkerCommand],
-    mut on_resize: impl FnMut(u16, u16),
-) {
+fn replay_resize_commands_for_test(commands: &[WorkerCommand], mut on_resize: impl FnMut(u16, u16)) {
+    let mut latest_resize = None;
     for command in commands {
         if let WorkerCommand::Resize { cols, rows } = command {
-            on_resize(*cols, *rows);
+            latest_resize = Some((*cols, *rows));
         }
     }
+
+    if let Some((cols, rows)) = latest_resize {
+        on_resize(cols, rows);
+    }
+}
+
+#[cfg(test)]
+fn record_worker_effects_for_test(commands: &[WorkerCommand]) -> Vec<RecordedWorkerEffect> {
+    let mut effects = Vec::new();
+    let mut latest_resize = None;
+
+    for command in commands {
+        match command {
+            WorkerCommand::Resize { cols, rows } => {
+                latest_resize = Some((*cols, *rows));
+            }
+            WorkerCommand::Write(_) => {
+                if let Some((cols, rows)) = latest_resize.take() {
+                    effects.push(RecordedWorkerEffect::Resize(cols, rows));
+                }
+                effects.push(RecordedWorkerEffect::Write);
+            }
+            _ => {
+                if let Some((cols, rows)) = latest_resize.take() {
+                    effects.push(RecordedWorkerEffect::Resize(cols, rows));
+                }
+                effects.push(RecordedWorkerEffect::Other);
+            }
+        }
+    }
+
+    if let Some((cols, rows)) = latest_resize {
+        effects.push(RecordedWorkerEffect::Resize(cols, rows));
+    }
+
+    effects
 }
 
 #[cfg(test)]
@@ -1305,11 +1392,30 @@ mod tests {
         ];
 
         let mut applied = Vec::new();
-        replay_resize_commands_for_test(&commands, |cols, rows| {
-            applied.push((cols, rows));
-        });
+        replay_resize_commands_for_test(&commands, |cols, rows| applied.push((cols, rows)));
 
         assert_eq!(vec![(160, 50)], applied);
+    }
+
+    #[test]
+    fn worker_resize_burst_preserves_intervening_non_resize_command_order() {
+        let commands = vec![
+            WorkerCommand::Resize { cols: 120, rows: 30 },
+            WorkerCommand::Resize { cols: 140, rows: 40 },
+            WorkerCommand::Write(vec![1, 2, 3]),
+            WorkerCommand::Resize { cols: 160, rows: 50 },
+        ];
+
+        let effects = record_worker_effects_for_test(&commands);
+
+        assert_eq!(
+            vec![
+                RecordedWorkerEffect::Resize(140, 40),
+                RecordedWorkerEffect::Write,
+                RecordedWorkerEffect::Resize(160, 50),
+            ],
+            effects
+        );
     }
 }
 

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -135,14 +135,6 @@ enum WorkerCommand {
     Close,
 }
 
-#[cfg(test)]
-#[derive(Debug, PartialEq, Eq)]
-enum RecordedWorkerEffect {
-    Resize(u16, u16),
-    Write,
-    Other,
-}
-
 #[derive(Clone)]
 struct ConnectConfig {
     host: String,
@@ -1194,52 +1186,6 @@ fn create_test_session_with_event(kind: NovaSshEventKind, payload: &[u8]) -> *mu
 }
 
 #[cfg(test)]
-fn replay_resize_commands_for_test(commands: &[WorkerCommand], mut on_resize: impl FnMut(u16, u16)) {
-    let mut latest_resize = None;
-    for command in commands {
-        if let WorkerCommand::Resize { cols, rows } = command {
-            latest_resize = Some((*cols, *rows));
-        }
-    }
-
-    if let Some((cols, rows)) = latest_resize {
-        on_resize(cols, rows);
-    }
-}
-
-#[cfg(test)]
-fn record_worker_effects_for_test(commands: &[WorkerCommand]) -> Vec<RecordedWorkerEffect> {
-    let mut effects = Vec::new();
-    let mut latest_resize = None;
-
-    for command in commands {
-        match command {
-            WorkerCommand::Resize { cols, rows } => {
-                latest_resize = Some((*cols, *rows));
-            }
-            WorkerCommand::Write(_) => {
-                if let Some((cols, rows)) = latest_resize.take() {
-                    effects.push(RecordedWorkerEffect::Resize(cols, rows));
-                }
-                effects.push(RecordedWorkerEffect::Write);
-            }
-            _ => {
-                if let Some((cols, rows)) = latest_resize.take() {
-                    effects.push(RecordedWorkerEffect::Resize(cols, rows));
-                }
-                effects.push(RecordedWorkerEffect::Other);
-            }
-        }
-    }
-
-    if let Some((cols, rows)) = latest_resize {
-        effects.push(RecordedWorkerEffect::Resize(cols, rows));
-    }
-
-    effects
-}
-
-#[cfg(test)]
 mod tests {
     use super::*;
     use std::ffi::CString;
@@ -1385,37 +1331,99 @@ mod tests {
 
     #[test]
     fn worker_resize_burst_should_only_apply_latest_dimensions() {
-        let commands = vec![
-            WorkerCommand::Resize { cols: 120, rows: 30 },
-            WorkerCommand::Resize { cols: 140, rows: 40 },
-            WorkerCommand::Resize { cols: 160, rows: 50 },
-        ];
+        let runtime = Builder::new_current_thread().enable_all().build().unwrap();
 
-        let mut applied = Vec::new();
-        replay_resize_commands_for_test(&commands, |cols, rows| applied.push((cols, rows)));
+        runtime.block_on(async {
+            let (command_tx, mut command_rx) = mpsc::unbounded_channel();
+            command_tx
+                .send(WorkerCommand::Resize { cols: 120, rows: 30 })
+                .unwrap();
+            command_tx
+                .send(WorkerCommand::Resize { cols: 140, rows: 40 })
+                .unwrap();
+            command_tx
+                .send(WorkerCommand::Resize { cols: 160, rows: 50 })
+                .unwrap();
+            drop(command_tx);
 
-        assert_eq!(vec![(160, 50)], applied);
+            let mut pending_command = None;
+            let first_command = next_worker_command(&mut pending_command, &mut command_rx)
+                .await
+                .expect("first resize command should be available");
+
+            let (cols, rows, pending_resize_command) = match first_command {
+                WorkerCommand::Resize { cols, rows } => {
+                    coalesce_pending_resize_commands(&mut command_rx, cols, rows)
+                }
+                _ => panic!("expected first worker command to be resize"),
+            };
+
+            pending_command = pending_resize_command;
+
+            assert_eq!((160, 50), (cols, rows));
+            assert!(pending_command.is_none());
+            assert!(command_rx.recv().await.is_none());
+        });
     }
 
     #[test]
     fn worker_resize_burst_preserves_intervening_non_resize_command_order() {
-        let commands = vec![
-            WorkerCommand::Resize { cols: 120, rows: 30 },
-            WorkerCommand::Resize { cols: 140, rows: 40 },
-            WorkerCommand::Write(vec![1, 2, 3]),
-            WorkerCommand::Resize { cols: 160, rows: 50 },
-        ];
+        let runtime = Builder::new_current_thread().enable_all().build().unwrap();
 
-        let effects = record_worker_effects_for_test(&commands);
+        runtime.block_on(async {
+            let (command_tx, mut command_rx) = mpsc::unbounded_channel();
+            command_tx
+                .send(WorkerCommand::Resize { cols: 120, rows: 30 })
+                .unwrap();
+            command_tx
+                .send(WorkerCommand::Resize { cols: 140, rows: 40 })
+                .unwrap();
+            command_tx
+                .send(WorkerCommand::Write(vec![1, 2, 3]))
+                .unwrap();
+            command_tx
+                .send(WorkerCommand::Resize { cols: 160, rows: 50 })
+                .unwrap();
+            drop(command_tx);
 
-        assert_eq!(
-            vec![
-                RecordedWorkerEffect::Resize(140, 40),
-                RecordedWorkerEffect::Write,
-                RecordedWorkerEffect::Resize(160, 50),
-            ],
-            effects
-        );
+            let mut pending_command = None;
+
+            let first_command = next_worker_command(&mut pending_command, &mut command_rx)
+                .await
+                .expect("first resize command should be available");
+            let (cols, rows, pending_resize_command) = match first_command {
+                WorkerCommand::Resize { cols, rows } => {
+                    coalesce_pending_resize_commands(&mut command_rx, cols, rows)
+                }
+                _ => panic!("expected first worker command to be resize"),
+            };
+
+            pending_command = pending_resize_command;
+            assert_eq!((140, 40), (cols, rows));
+
+            match next_worker_command(&mut pending_command, &mut command_rx)
+                .await
+                .expect("pending write command should be preserved")
+            {
+                WorkerCommand::Write(data) => assert_eq!(vec![1, 2, 3], data),
+                _ => panic!("expected pending worker command to be write"),
+            }
+
+            let second_command = next_worker_command(&mut pending_command, &mut command_rx)
+                .await
+                .expect("second resize command should still be queued");
+            let (cols, rows, pending_resize_command) = match second_command {
+                WorkerCommand::Resize { cols, rows } => {
+                    coalesce_pending_resize_commands(&mut command_rx, cols, rows)
+                }
+                _ => panic!("expected second worker command to be resize"),
+            };
+
+            pending_command = pending_resize_command;
+            assert_eq!((160, 50), (cols, rows));
+            assert!(pending_command.is_none());
+            assert!(command_rx.recv().await.is_none());
+        });
     }
 }
 

--- a/src/NovaTerminal.Core/Ssh/Models/SshProfileNormalizer.cs
+++ b/src/NovaTerminal.Core/Ssh/Models/SshProfileNormalizer.cs
@@ -5,10 +5,7 @@ public static class SshProfileNormalizer
     public static void NormalizeRememberPasswordPreference(SshProfile profile)
     {
         ArgumentNullException.ThrowIfNull(profile);
-
-        if (profile.BackendKind != SshBackendKind.Native)
-        {
-            profile.RememberPasswordInVault = false;
-        }
+        // Legacy compatibility: older profiles may carry this flag, but runtime
+        // password memory is now driven by vault state and prompt interaction.
     }
 }

--- a/src/NovaTerminal.Core/Ssh/Native/NativeJumpHostConnector.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeJumpHostConnector.cs
@@ -23,6 +23,12 @@ public sealed class NativeJumpHostConnector
             Port = plan.TargetPort,
             Cols = cols,
             Rows = rows,
+            KeepAliveIntervalSeconds = profile.ServerAliveIntervalSeconds > 0
+                ? profile.ServerAliveIntervalSeconds
+                : 30,
+            KeepAliveCountMax = profile.ServerAliveCountMax > 0
+                ? profile.ServerAliveCountMax
+                : 3,
             IdentityFilePath = string.IsNullOrWhiteSpace(profile.IdentityFilePath)
                 ? null
                 : profile.IdentityFilePath,

--- a/src/NovaTerminal.Core/Ssh/Native/NativePortForwardSession.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativePortForwardSession.cs
@@ -1,15 +1,29 @@
 using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Sockets;
+using System.Text;
 using NovaTerminal.Core.Ssh.Models;
 
 namespace NovaTerminal.Core.Ssh.Native;
 
 public sealed class NativePortForwardSession : IDisposable
 {
+    private const byte SocksVersion5 = 0x05;
+    private const byte SocksCommandConnect = 0x01;
+    private const byte SocksAuthNoAuthentication = 0x00;
+    private const byte SocksAuthNoAcceptableMethods = 0xFF;
+    private const byte SocksAddressTypeIpv4 = 0x01;
+    private const byte SocksAddressTypeDomainName = 0x03;
+    private const byte SocksAddressTypeIpv6 = 0x04;
+    private const byte SocksReplySucceeded = 0x00;
+    private const byte SocksReplyGeneralFailure = 0x01;
+    private const byte SocksReplyCommandNotSupported = 0x07;
+    private const byte SocksReplyAddressTypeNotSupported = 0x08;
+
     private readonly IntPtr _sessionHandle;
     private readonly INativeSshInterop _interop;
     private readonly Action<string> _log;
+    private readonly Func<NetworkStream, byte[], CancellationToken, Task> _socksReplyWriter;
     private readonly CancellationTokenSource _lifetimeCts = new();
     private readonly List<TcpListener> _listeners = [];
     private readonly ConcurrentDictionary<int, ForwardChannelState> _channels = new();
@@ -20,6 +34,16 @@ public sealed class NativePortForwardSession : IDisposable
         IReadOnlyList<PortForward> forwards,
         INativeSshInterop interop,
         Action<string>? log = null)
+        : this(sessionHandle, forwards, interop, log, WriteSocksReplyAsync)
+    {
+    }
+
+    private NativePortForwardSession(
+        IntPtr sessionHandle,
+        IReadOnlyList<PortForward> forwards,
+        INativeSshInterop interop,
+        Action<string>? log,
+        Func<NetworkStream, byte[], CancellationToken, Task> socksReplyWriter)
     {
         if (sessionHandle == IntPtr.Zero)
         {
@@ -32,14 +56,15 @@ public sealed class NativePortForwardSession : IDisposable
         _sessionHandle = sessionHandle;
         _interop = interop;
         _log = log ?? (_ => { });
+        _socksReplyWriter = socksReplyWriter ?? throw new ArgumentNullException(nameof(socksReplyWriter));
 
         try
         {
             foreach (PortForward forward in forwards)
             {
-                if (forward.Kind != PortForwardKind.Local)
+                if (forward.Kind is not PortForwardKind.Local and not PortForwardKind.Dynamic)
                 {
-                    throw new NotSupportedException("Native SSH currently supports local port forwards only.");
+                    throw new NotSupportedException("Native SSH currently supports local and dynamic port forwards only.");
                 }
 
                 StartListener(forward);
@@ -125,17 +150,19 @@ public sealed class NativePortForwardSession : IDisposable
         }
         catch (Exception ex)
         {
-            // Startup policy for Task 6: fail the entire native session setup on any bind error.
-            throw new InvalidOperationException(
-                $"Failed to bind local forward {address}:{forward.SourcePort} -> {forward.DestinationHost}:{forward.DestinationPort}: {ex.Message}",
-                ex);
+            throw new InvalidOperationException($"Failed to bind {DescribeForward(forward, address)}: {ex.Message}", ex);
         }
 
         _listeners.Add(listener);
-        _ = Task.Run(() => AcceptLoopAsync(listener, forward, _lifetimeCts.Token));
+        _ = forward.Kind switch
+        {
+            PortForwardKind.Local => Task.Run(() => AcceptLocalLoopAsync(listener, forward, _lifetimeCts.Token)),
+            PortForwardKind.Dynamic => Task.Run(() => AcceptDynamicLoopAsync(listener, forward, _lifetimeCts.Token)),
+            _ => throw new NotSupportedException("Native SSH currently supports local and dynamic port forwards only.")
+        };
     }
 
-    private async Task AcceptLoopAsync(TcpListener listener, PortForward forward, CancellationToken cancellationToken)
+    private async Task AcceptLocalLoopAsync(TcpListener listener, PortForward forward, CancellationToken cancellationToken)
     {
         while (!cancellationToken.IsCancellationRequested)
         {
@@ -180,6 +207,134 @@ public sealed class NativePortForwardSession : IDisposable
                 client?.Dispose();
                 _log($"[NativePortForwardSession] Accept loop for {forward} failed: {ex.Message}");
             }
+        }
+    }
+
+    private async Task AcceptDynamicLoopAsync(TcpListener listener, PortForward forward, CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            TcpClient? client = null;
+
+            try
+            {
+                client = await listener.AcceptTcpClientAsync(cancellationToken).ConfigureAwait(false);
+                TcpClient acceptedClient = client;
+                _ = Task.Run(() => HandleDynamicClientAsync(acceptedClient, forward, cancellationToken), cancellationToken);
+                client = null;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                client?.Dispose();
+                break;
+            }
+            catch (ObjectDisposedException) when (cancellationToken.IsCancellationRequested)
+            {
+                client?.Dispose();
+                break;
+            }
+            catch (Exception ex)
+            {
+                client?.Dispose();
+                _log($"[NativePortForwardSession] Dynamic accept loop for {forward} failed: {ex.Message}");
+            }
+        }
+    }
+
+    private async Task HandleDynamicClientAsync(TcpClient client, PortForward forward, CancellationToken cancellationToken)
+    {
+        try
+        {
+            NetworkStream stream = client.GetStream();
+            if (!await NegotiateSocks5Async(stream, cancellationToken).ConfigureAwait(false))
+            {
+                client.Dispose();
+                return;
+            }
+
+            SocksConnectRequest request = await ReadSocksRequestAsync(stream, cancellationToken).ConfigureAwait(false);
+            if (request.Command != SocksCommandConnect)
+            {
+                await SendSocksReplyAsync(stream, SocksReplyCommandNotSupported, cancellationToken).ConfigureAwait(false);
+                client.Dispose();
+                return;
+            }
+
+            IPEndPoint remoteEndPoint = (IPEndPoint)(client.Client.RemoteEndPoint ?? new IPEndPoint(IPAddress.Loopback, 0));
+
+            int channelId;
+            try
+            {
+                channelId = _interop.OpenDirectTcpIp(
+                    _sessionHandle,
+                    new NativePortForwardOpenOptions
+                    {
+                        HostToConnect = request.Host,
+                        PortToConnect = request.Port,
+                        OriginatorAddress = remoteEndPoint.Address.ToString(),
+                        OriginatorPort = remoteEndPoint.Port
+                    });
+            }
+            catch (Exception ex)
+            {
+                _log($"[NativePortForwardSession] Failed to open dynamic forward channel for {request.Host}:{request.Port}: {ex.Message}");
+                await SendSocksReplyAsync(stream, SocksReplyGeneralFailure, cancellationToken).ConfigureAwait(false);
+                client.Dispose();
+                return;
+            }
+
+            var state = new ForwardChannelState(channelId, client);
+            if (!_channels.TryAdd(channelId, state))
+            {
+                await SendSocksReplyAsync(stream, SocksReplyGeneralFailure, cancellationToken).ConfigureAwait(false);
+                client.Dispose();
+                _interop.CloseChannel(_sessionHandle, channelId);
+                return;
+            }
+
+            try
+            {
+                await SendSocksReplyAsync(stream, SocksReplySucceeded, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _log($"[NativePortForwardSession] Failed to write dynamic SOCKS success reply for {request.Host}:{request.Port}: {ex.Message}");
+                RemoveChannel(channelId, closeInteropChannel: true);
+                return;
+            }
+
+            _ = Task.Run(() => PumpClientToSshAsync(state, cancellationToken), cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            client.Dispose();
+        }
+        catch (SocksProtocolException ex)
+        {
+            _log($"[NativePortForwardSession] Dynamic SOCKS handshake for {forward} failed: {ex.Message}");
+            try
+            {
+                await SendSocksReplyAsync(client.GetStream(), ex.ReplyCode, cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+            }
+
+            client.Dispose();
+        }
+        catch (IOException ex)
+        {
+            _log($"[NativePortForwardSession] Dynamic client IO for {forward} failed: {ex.Message}");
+            client.Dispose();
+        }
+        catch (ObjectDisposedException) when (cancellationToken.IsCancellationRequested)
+        {
+            client.Dispose();
+        }
+        catch (Exception ex)
+        {
+            _log($"[NativePortForwardSession] Dynamic client setup for {forward} failed: {ex.Message}");
+            client.Dispose();
         }
     }
 
@@ -254,6 +409,109 @@ public sealed class NativePortForwardSession : IDisposable
         }
     }
 
+    private static async Task<bool> NegotiateSocks5Async(NetworkStream stream, CancellationToken cancellationToken)
+    {
+        byte[] header = await ReadExactlyAsync(stream, 2, cancellationToken).ConfigureAwait(false);
+        if (header[0] != SocksVersion5)
+        {
+            throw new SocksProtocolException("Only SOCKS5 is supported.", SocksReplyGeneralFailure);
+        }
+
+        int methodCount = header[1];
+        byte[] methods = await ReadExactlyAsync(stream, methodCount, cancellationToken).ConfigureAwait(false);
+        bool hasNoAuth = methods.Contains(SocksAuthNoAuthentication);
+        byte selectedMethod = hasNoAuth ? SocksAuthNoAuthentication : SocksAuthNoAcceptableMethods;
+
+        byte[] response = [SocksVersion5, selectedMethod];
+        await stream.WriteAsync(response, cancellationToken).ConfigureAwait(false);
+        await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+        return hasNoAuth;
+    }
+
+    private static async Task<SocksConnectRequest> ReadSocksRequestAsync(NetworkStream stream, CancellationToken cancellationToken)
+    {
+        byte[] header = await ReadExactlyAsync(stream, 4, cancellationToken).ConfigureAwait(false);
+        if (header[0] != SocksVersion5)
+        {
+            throw new SocksProtocolException("Only SOCKS5 is supported.", SocksReplyGeneralFailure);
+        }
+
+        if (header[2] != 0x00)
+        {
+            throw new SocksProtocolException("SOCKS reserved byte must be zero.", SocksReplyGeneralFailure);
+        }
+
+        string host = header[3] switch
+        {
+            SocksAddressTypeIpv4 => new IPAddress(await ReadExactlyAsync(stream, 4, cancellationToken).ConfigureAwait(false)).ToString(),
+            SocksAddressTypeDomainName => await ReadDomainNameAsync(stream, cancellationToken).ConfigureAwait(false),
+            SocksAddressTypeIpv6 => new IPAddress(await ReadExactlyAsync(stream, 16, cancellationToken).ConfigureAwait(false)).ToString(),
+            _ => throw new SocksProtocolException("SOCKS address type is not supported.", SocksReplyAddressTypeNotSupported)
+        };
+
+        byte[] portBytes = await ReadExactlyAsync(stream, 2, cancellationToken).ConfigureAwait(false);
+        int port = (portBytes[0] << 8) | portBytes[1];
+        return new SocksConnectRequest(header[1], host, port);
+    }
+
+    private static async Task<string> ReadDomainNameAsync(NetworkStream stream, CancellationToken cancellationToken)
+    {
+        byte[] lengthBuffer = await ReadExactlyAsync(stream, 1, cancellationToken).ConfigureAwait(false);
+        int length = lengthBuffer[0];
+        byte[] hostBytes = await ReadExactlyAsync(stream, length, cancellationToken).ConfigureAwait(false);
+        return Encoding.ASCII.GetString(hostBytes);
+    }
+
+    private async Task SendSocksReplyAsync(NetworkStream stream, byte replyCode, CancellationToken cancellationToken)
+    {
+        byte[] reply =
+        [
+            SocksVersion5,
+            replyCode,
+            0x00,
+            SocksAddressTypeIpv4,
+            0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00
+        ];
+
+        await _socksReplyWriter(stream, reply, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task WriteSocksReplyAsync(NetworkStream stream, byte[] reply, CancellationToken cancellationToken)
+    {
+        await stream.WriteAsync(reply, cancellationToken).ConfigureAwait(false);
+        await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<byte[]> ReadExactlyAsync(NetworkStream stream, int length, CancellationToken cancellationToken)
+    {
+        byte[] buffer = new byte[length];
+        int offset = 0;
+
+        while (offset < length)
+        {
+            int read = await stream.ReadAsync(buffer.AsMemory(offset, length - offset), cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+            {
+                throw new SocksProtocolException("Socket closed before the SOCKS request completed.", SocksReplyGeneralFailure);
+            }
+
+            offset += read;
+        }
+
+        return buffer;
+    }
+
+    private static string DescribeForward(PortForward forward, IPAddress address)
+    {
+        return forward.Kind switch
+        {
+            PortForwardKind.Local => $"local forward {address}:{forward.SourcePort} -> {forward.DestinationHost}:{forward.DestinationPort}",
+            PortForwardKind.Dynamic => $"dynamic forward {address}:{forward.SourcePort}",
+            _ => $"forward {address}:{forward.SourcePort}"
+        };
+    }
+
     private static IPAddress ResolveBindAddress(string? bindAddress)
     {
         if (string.IsNullOrWhiteSpace(bindAddress) || bindAddress == "localhost")
@@ -279,6 +537,19 @@ public sealed class NativePortForwardSession : IDisposable
         catch
         {
         }
+    }
+
+    private readonly record struct SocksConnectRequest(byte Command, string Host, int Port);
+
+    private sealed class SocksProtocolException : Exception
+    {
+        public SocksProtocolException(string message, byte replyCode)
+            : base(message)
+        {
+            ReplyCode = replyCode;
+        }
+
+        public byte ReplyCode { get; }
     }
 
     private sealed class ForwardChannelState

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshConnectionOptions.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshConnectionOptions.cs
@@ -4,6 +4,9 @@ namespace NovaTerminal.Core.Ssh.Native;
 
 public sealed class NativeSshConnectionOptions
 {
+    private const int DefaultKeepAliveIntervalSeconds = 30;
+    private const int DefaultKeepAliveCountMax = 3;
+
     public required string Host { get; init; }
     public required string User { get; init; }
     public int Port { get; init; } = 22;
@@ -12,6 +15,8 @@ public sealed class NativeSshConnectionOptions
     public string Term { get; init; } = "xterm-256color";
     public string? IdentityFilePath { get; init; }
     public SshJumpHop? JumpHost { get; init; }
+    public int KeepAliveIntervalSeconds { get; init; } = DefaultKeepAliveIntervalSeconds;
+    public int KeepAliveCountMax { get; init; } = DefaultKeepAliveCountMax;
 
     public static NativeSshConnectionOptions FromProfile(SshProfile profile, int cols, int rows)
     {
@@ -24,6 +29,12 @@ public sealed class NativeSshConnectionOptions
             Port = profile.Port,
             Cols = cols,
             Rows = rows,
+            KeepAliveIntervalSeconds = profile.ServerAliveIntervalSeconds > 0
+                ? profile.ServerAliveIntervalSeconds
+                : DefaultKeepAliveIntervalSeconds,
+            KeepAliveCountMax = profile.ServerAliveCountMax > 0
+                ? profile.ServerAliveCountMax
+                : DefaultKeepAliveCountMax,
             IdentityFilePath = string.IsNullOrWhiteSpace(profile.IdentityFilePath)
                 ? null
                 : profile.IdentityFilePath

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
@@ -55,7 +55,9 @@ public sealed class NativeSshInterop : INativeSshInterop
                     IdentityFile = identityPtr,
                     JumpHost = jumpHostPtr,
                     JumpUser = jumpUserPtr,
-                    JumpPort = checked((ushort)(options.JumpHost?.Port ?? 0))
+                    JumpPort = checked((ushort)(options.JumpHost?.Port ?? 0)),
+                    KeepAliveIntervalSeconds = checked((uint)Math.Max(0, options.KeepAliveIntervalSeconds)),
+                    KeepAliveCountMax = checked((uint)Math.Max(0, options.KeepAliveCountMax))
                 };
 
                 IntPtr handle = NativeMethods.nova_ssh_connect(in args);
@@ -294,6 +296,8 @@ public sealed class NativeSshInterop : INativeSshInterop
         public IntPtr JumpHost;
         public IntPtr JumpUser;
         public ushort JumpPort;
+        public uint KeepAliveIntervalSeconds;
+        public uint KeepAliveCountMax;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
@@ -23,7 +23,6 @@ public sealed class NativeSshSession : ITerminalSession
     private readonly string _profileName;
     private readonly string _profileUser;
     private readonly string _profileHost;
-    private readonly bool _rememberPasswordInVault;
     private bool _allowVaultPasswordReuse;
     private readonly object _exitHandlerGate = new();
     private readonly object _outputHandlerGate = new();
@@ -70,8 +69,7 @@ public sealed class NativeSshSession : ITerminalSession
         _profileName = profile.Name;
         _profileUser = profile.User;
         _profileHost = profile.Host;
-        _rememberPasswordInVault = profile.RememberPasswordInVault;
-        _allowVaultPasswordReuse = profile.RememberPasswordInVault;
+        _allowVaultPasswordReuse = profile.Id != Guid.Empty;
         JumpHostConnectPlan connectPlan = JumpHostConnectPlan.Create(profile);
         NativeSshConnectionOptions connectionOptions = _jumpHostConnector.CreateConnectionOptions(connectPlan, profile, cols, rows);
         _log($"[NativeSshSession] backend=native path={_jumpHostConnector.DescribePath(connectPlan)} target={connectionOptions.User}@{connectionOptions.Host}:{connectionOptions.Port}");
@@ -432,8 +430,8 @@ public sealed class NativeSshSession : ITerminalSession
             ProfileName = _profileName,
             ProfileUser = _profileUser,
             ProfileHost = _profileHost,
-            AllowVaultPasswordReuse = request.Kind == SshInteractionKind.Password && _allowVaultPasswordReuse,
-            RememberPasswordInVault = _rememberPasswordInVault,
+            AllowVaultPasswordReuse = request.Kind == SshInteractionKind.Password && _allowVaultPasswordReuse && _profileId != Guid.Empty,
+            RememberPasswordInVault = request.Kind == SshInteractionKind.Password && _profileId != Guid.Empty,
             Host = request.Host,
             Port = request.Port,
             Algorithm = request.Algorithm,
@@ -494,3 +492,4 @@ public sealed class NativeSshSession : ITerminalSession
     }
 
 }
+

--- a/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
@@ -77,25 +77,13 @@ public sealed class NativeSshSession : ITerminalSession
 
         try
         {
-            PortForward[] localForwards = profile.Forwards
-                .Where(forward => forward.Kind == PortForwardKind.Local)
-                .ToArray();
-            PortForward[] dynamicForwards = profile.Forwards
-                .Where(forward => forward.Kind == PortForwardKind.Dynamic)
-                .ToArray();
-
-            if (localForwards.Length != 0)
+            if (profile.Forwards.Count != 0)
             {
-                _portForwardSession = new NativePortForwardSession(_sessionHandle, localForwards, _interop, _log);
-                foreach (PortForward forward in localForwards)
+                _portForwardSession = new NativePortForwardSession(_sessionHandle, profile.Forwards, _interop, _log);
+                foreach (PortForward forward in profile.Forwards)
                 {
                     _metrics.RecordForwardSetup(forward.ToString());
                 }
-            }
-
-            if (dynamicForwards.Length != 0)
-            {
-                _log($"[NativeSshSession] dynamic forwards are accepted by profile validation but deferred until native SOCKS support lands; count={dynamicForwards.Length}");
             }
 
             _isRunning = 1;

--- a/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
@@ -53,9 +53,9 @@ public sealed class NativeSshSession : ITerminalSession
     {
         ArgumentNullException.ThrowIfNull(profile);
 
-        if (profile.Forwards.Any(forward => forward.Kind != PortForwardKind.Local))
+        if (profile.Forwards.Any(forward => forward.Kind is not PortForwardKind.Local and not PortForwardKind.Dynamic))
         {
-            throw new NotSupportedException("Native SSH backend currently supports local port forwards only.");
+            throw new NotSupportedException("Native SSH backend currently supports local and dynamic port forwards only.");
         }
 
         _ = diagnosticsLevel;
@@ -77,13 +77,25 @@ public sealed class NativeSshSession : ITerminalSession
 
         try
         {
-            if (profile.Forwards.Count != 0)
+            PortForward[] localForwards = profile.Forwards
+                .Where(forward => forward.Kind == PortForwardKind.Local)
+                .ToArray();
+            PortForward[] dynamicForwards = profile.Forwards
+                .Where(forward => forward.Kind == PortForwardKind.Dynamic)
+                .ToArray();
+
+            if (localForwards.Length != 0)
             {
-                _portForwardSession = new NativePortForwardSession(_sessionHandle, profile.Forwards, _interop, _log);
-                foreach (PortForward forward in profile.Forwards)
+                _portForwardSession = new NativePortForwardSession(_sessionHandle, localForwards, _interop, _log);
+                foreach (PortForward forward in localForwards)
                 {
                     _metrics.RecordForwardSetup(forward.ToString());
                 }
+            }
+
+            if (dynamicForwards.Length != 0)
+            {
+                _log($"[NativeSshSession] dynamic forwards are accepted by profile validation but deferred until native SOCKS support lands; count={dynamicForwards.Length}");
             }
 
             _isRunning = 1;

--- a/tests/NovaTerminal.Core.Tests/Ssh/JsonSshProfileStoreTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/JsonSshProfileStoreTests.cs
@@ -168,7 +168,7 @@ public sealed class JsonSshProfileStoreTests
     }
 
     [Fact]
-    public void NormalizeRememberPasswordPreference_ClearsOpenSshProfiles()
+    public void NormalizeRememberPasswordPreference_PreservesLegacyOpenSshState()
     {
         var profile = new SshProfile
         {
@@ -180,7 +180,7 @@ public sealed class JsonSshProfileStoreTests
 
         SshProfileNormalizer.NormalizeRememberPasswordPreference(profile);
 
-        Assert.False(profile.RememberPasswordInVault);
+        Assert.True(profile.RememberPasswordInVault);
     }
 
     [Fact]

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativePortForwardSessionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativePortForwardSessionTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
+using System.Reflection;
 using System.Text;
 using NovaTerminal.Core.Ssh.Models;
 using NovaTerminal.Core.Ssh.Native;
@@ -135,6 +136,189 @@ public sealed class NativePortForwardSessionTests
     }
 
     [Fact]
+    public async Task DynamicForward_SocksConnectWithIpv4TargetOpensRequestedChannel()
+    {
+        var interop = new FakeNativeSshInterop();
+        int listenPort = GetFreePort();
+
+        using var session = new NativePortForwardSession(
+            new IntPtr(16),
+            [CreateDynamicForward(listenPort)],
+            interop);
+
+        using TcpClient client = await ConnectLoopbackAsync(listenPort);
+        NetworkStream stream = client.GetStream();
+
+        await SendSocksGreetingAsync(stream);
+        await ReadExactlyAsync(stream, 2, TimeSpan.FromSeconds(2));
+
+        await SendSocksConnectRequestAsync(stream, IPAddress.Parse("10.20.30.40"), 9443);
+        byte[] reply = await ReadExactlyAsync(stream, 10, TimeSpan.FromSeconds(2));
+
+        await WaitUntilAsync(() => interop.OpenRequests.Count == 1);
+
+        Assert.Equal(new byte[] { 0x05, 0x00 }, reply[..2]);
+        Assert.Equal("10.20.30.40", interop.OpenRequests[0].HostToConnect);
+        Assert.Equal(9443, interop.OpenRequests[0].PortToConnect);
+    }
+
+    [Fact]
+    public async Task DynamicForward_UnsupportedCommandReturnsFailureWithoutOpeningChannel()
+    {
+        var interop = new FakeNativeSshInterop();
+        int listenPort = GetFreePort();
+
+        using var session = new NativePortForwardSession(
+            new IntPtr(18),
+            [CreateDynamicForward(listenPort)],
+            interop);
+
+        using TcpClient client = await ConnectLoopbackAsync(listenPort);
+        NetworkStream stream = client.GetStream();
+
+        await SendSocksGreetingAsync(stream);
+        await ReadExactlyAsync(stream, 2, TimeSpan.FromSeconds(2));
+
+        await SendSocksCommandRequestAsync(stream, 0x02, "svc.internal", 443);
+        byte[] reply = await ReadExactlyAsync(stream, 10, TimeSpan.FromSeconds(2));
+
+        Assert.Equal(0x05, reply[0]);
+        Assert.Equal(0x07, reply[1]);
+        // Unsupported commands are rejected before any direct-tcpip open is attempted.
+        Assert.Empty(interop.OpenRequests);
+    }
+
+    [Fact]
+    public async Task DynamicForward_NonZeroReservedByteReturnsProtocolFailureWithoutOpeningChannel()
+    {
+        var interop = new FakeNativeSshInterop();
+        int listenPort = GetFreePort();
+
+        using var session = new NativePortForwardSession(
+            new IntPtr(19),
+            [CreateDynamicForward(listenPort)],
+            interop);
+
+        using TcpClient client = await ConnectLoopbackAsync(listenPort);
+        NetworkStream stream = client.GetStream();
+
+        await SendSocksGreetingAsync(stream);
+        await ReadExactlyAsync(stream, 2, TimeSpan.FromSeconds(2));
+
+        await SendSocksCommandRequestAsync(stream, 0x01, "svc.internal", 443, reserved: 0x01);
+        byte[] reply = await ReadExactlyAsync(stream, 10, TimeSpan.FromSeconds(2));
+
+        Assert.Equal(0x05, reply[0]);
+        Assert.Equal(0x01, reply[1]);
+        Assert.Empty(interop.OpenRequests);
+    }
+
+    [Fact]
+    public async Task Dispose_ClosesDynamicForwardChannelAndListener()
+    {
+        var interop = new FakeNativeSshInterop();
+        int dynamicPort = GetFreePort();
+
+        var session = new NativePortForwardSession(
+            new IntPtr(20),
+            [CreateDynamicForward(dynamicPort)],
+            interop);
+
+        using TcpClient dynamicClient = await ConnectLoopbackAsync(dynamicPort);
+        NetworkStream stream = dynamicClient.GetStream();
+
+        await SendSocksGreetingAsync(stream);
+        await ReadExactlyAsync(stream, 2, TimeSpan.FromSeconds(2));
+
+        await SendSocksConnectRequestAsync(stream, "svc-dynamic.internal", 8443);
+        await ReadExactlyAsync(stream, 10, TimeSpan.FromSeconds(2));
+        await WaitUntilAsync(() => interop.OpenRequests.Count == 1);
+
+        session.Dispose();
+
+        await WaitUntilAsync(() => interop.ClosedChannelIds.Count == 1);
+        Assert.Single(interop.ClosedChannelIds);
+        await Assert.ThrowsAnyAsync<SocketException>(() => ConnectLoopbackAsync(dynamicPort));
+    }
+
+    [Fact]
+    public async Task DynamicForward_SuccessReplyWriteFailureClosesOpenedChannel()
+    {
+        var interop = new FakeNativeSshInterop();
+        int dynamicPort = GetFreePort();
+
+        using var session = CreateSessionWithReplyWriter(
+            new IntPtr(21),
+            [CreateDynamicForward(dynamicPort)],
+            interop,
+            (_, _, _) => throw new IOException("Injected reply write failure."));
+
+        using TcpClient dynamicClient = await ConnectLoopbackAsync(dynamicPort);
+        NetworkStream stream = dynamicClient.GetStream();
+
+        await SendSocksGreetingAsync(stream);
+        await ReadExactlyAsync(stream, 2, TimeSpan.FromSeconds(2));
+
+        await SendSocksConnectRequestAsync(stream, "svc-abort.internal", 8443);
+
+        await WaitUntilAsync(() => interop.OpenRequests.Count == 1);
+        await WaitUntilAsync(() => interop.ClosedChannelIds.Count == 1);
+
+        Assert.Single(interop.ClosedChannelIds);
+    }
+
+    [Fact]
+    public async Task MalformedDynamicRequestDoesNotBreakUnrelatedLocalOrDynamicForwards()
+    {
+        var interop = new FakeNativeSshInterop();
+        int localPort = GetFreePort();
+        int dynamicPort = GetFreePort();
+
+        using var session = new NativePortForwardSession(
+            new IntPtr(22),
+            [
+                CreateForward(localPort, "svc-local.internal", 8080),
+                CreateDynamicForward(dynamicPort)
+            ],
+            interop);
+
+        using (TcpClient badDynamicClient = await ConnectLoopbackAsync(dynamicPort))
+        {
+            NetworkStream stream = badDynamicClient.GetStream();
+            await SendSocksGreetingAsync(stream);
+            await ReadExactlyAsync(stream, 2, TimeSpan.FromSeconds(2));
+
+            await SendSocksCommandRequestAsync(stream, 0x01, "svc-bad.internal", 443, reserved: 0x01);
+            byte[] reply = await ReadExactlyAsync(stream, 10, TimeSpan.FromSeconds(2));
+
+            Assert.Equal(0x05, reply[0]);
+            Assert.Equal(0x01, reply[1]);
+        }
+
+        using (TcpClient localClient = await ConnectLoopbackAsync(localPort))
+        {
+            await WaitUntilAsync(() => interop.OpenRequests.Any(request => request.HostToConnect == "svc-local.internal"));
+        }
+
+        using (TcpClient goodDynamicClient = await ConnectLoopbackAsync(dynamicPort))
+        {
+            NetworkStream stream = goodDynamicClient.GetStream();
+            await SendSocksGreetingAsync(stream);
+            await ReadExactlyAsync(stream, 2, TimeSpan.FromSeconds(2));
+
+            await SendSocksConnectRequestAsync(stream, "svc-good.internal", 9443);
+            byte[] reply = await ReadExactlyAsync(stream, 10, TimeSpan.FromSeconds(2));
+
+            Assert.Equal(0x05, reply[0]);
+            Assert.Equal(0x00, reply[1]);
+        }
+
+        Assert.Contains(interop.OpenRequests, request => request.HostToConnect == "svc-local.internal" && request.PortToConnect == 8080);
+        Assert.Contains(interop.OpenRequests, request => request.HostToConnect == "svc-good.internal" && request.PortToConnect == 9443);
+        Assert.DoesNotContain(interop.OpenRequests, request => request.HostToConnect == "svc-bad.internal");
+    }
+
+    [Fact]
     public async Task LocalAndDynamicForwardsCanStartTogether()
     {
         var interop = new FakeNativeSshInterop();
@@ -212,11 +396,39 @@ public sealed class NativePortForwardSessionTests
 
     private static async Task SendSocksConnectRequestAsync(NetworkStream stream, string host, int port)
     {
-        byte[] hostBytes = Encoding.ASCII.GetBytes(host);
-        byte[] request = new byte[7 + hostBytes.Length];
+        await SendSocksCommandRequestAsync(stream, 0x01, host, port);
+    }
+
+    private static async Task SendSocksConnectRequestAsync(NetworkStream stream, IPAddress address, int port)
+    {
+        byte[] addressBytes = address.GetAddressBytes();
+        byte atyp = address.AddressFamily switch
+        {
+            AddressFamily.InterNetwork => 0x01,
+            AddressFamily.InterNetworkV6 => 0x04,
+            _ => throw new ArgumentOutOfRangeException(nameof(address), "Unsupported IP address family.")
+        };
+
+        byte[] request = new byte[6 + addressBytes.Length];
         request[0] = 0x05;
         request[1] = 0x01;
         request[2] = 0x00;
+        request[3] = atyp;
+        Buffer.BlockCopy(addressBytes, 0, request, 4, addressBytes.Length);
+        request[4 + addressBytes.Length] = (byte)((port >> 8) & 0xFF);
+        request[5 + addressBytes.Length] = (byte)(port & 0xFF);
+
+        await stream.WriteAsync(request);
+        await stream.FlushAsync();
+    }
+
+    private static async Task SendSocksCommandRequestAsync(NetworkStream stream, byte command, string host, int port, byte reserved = 0x00)
+    {
+        byte[] hostBytes = Encoding.ASCII.GetBytes(host);
+        byte[] request = new byte[7 + hostBytes.Length];
+        request[0] = 0x05;
+        request[1] = command;
+        request[2] = reserved;
         request[3] = 0x03;
         request[4] = (byte)hostBytes.Length;
         Buffer.BlockCopy(hostBytes, 0, request, 5, hostBytes.Length);
@@ -322,5 +534,27 @@ public sealed class NativePortForwardSessionTests
         public void Close(IntPtr sessionHandle)
         {
         }
+    }
+
+    private static NativePortForwardSession CreateSessionWithReplyWriter(
+        IntPtr sessionHandle,
+        IReadOnlyList<PortForward> forwards,
+        INativeSshInterop interop,
+        Func<NetworkStream, byte[], CancellationToken, Task> replyWriter)
+    {
+        ConstructorInfo ctor = typeof(NativePortForwardSession).GetConstructor(
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            [
+                typeof(IntPtr),
+                typeof(IReadOnlyList<PortForward>),
+                typeof(INativeSshInterop),
+                typeof(Action<string>),
+                typeof(Func<NetworkStream, byte[], CancellationToken, Task>)
+            ],
+            modifiers: null)
+            ?? throw new InvalidOperationException("Could not find NativePortForwardSession private reply-writer constructor.");
+
+        return (NativePortForwardSession)ctor.Invoke([sessionHandle, forwards, interop, null!, replyWriter]);
     }
 }

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativePortForwardSessionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativePortForwardSessionTests.cs
@@ -1,6 +1,8 @@
 using System.Collections.Concurrent;
+using System.IO;
 using System.Net;
 using System.Net.Sockets;
+using System.Text;
 using NovaTerminal.Core.Ssh.Models;
 using NovaTerminal.Core.Ssh.Native;
 
@@ -104,6 +106,74 @@ public sealed class NativePortForwardSessionTests
         probe.Start();
     }
 
+    [Fact]
+    public async Task DynamicForward_SocksConnectOpensRequestedTargetChannel()
+    {
+        var interop = new FakeNativeSshInterop();
+        int listenPort = GetFreePort();
+
+        using var session = new NativePortForwardSession(
+            new IntPtr(15),
+            [CreateDynamicForward(listenPort)],
+            interop);
+
+        using TcpClient client = await ConnectLoopbackAsync(listenPort);
+        NetworkStream stream = client.GetStream();
+
+        await SendSocksGreetingAsync(stream);
+        await ReadExactlyAsync(stream, 2, TimeSpan.FromSeconds(2));
+
+        await SendSocksConnectRequestAsync(stream, "svc.internal", 443);
+        byte[] reply = await ReadExactlyAsync(stream, 10, TimeSpan.FromSeconds(2));
+
+        await WaitUntilAsync(() => interop.OpenRequests.Count == 1);
+
+        Assert.Equal(new byte[] { 0x05, 0x00 }, reply[..2]);
+        Assert.Single(interop.OpenRequests);
+        Assert.Equal("svc.internal", interop.OpenRequests[0].HostToConnect);
+        Assert.Equal(443, interop.OpenRequests[0].PortToConnect);
+    }
+
+    [Fact]
+    public async Task LocalAndDynamicForwardsCanStartTogether()
+    {
+        var interop = new FakeNativeSshInterop();
+        int localPort = GetFreePort();
+        int dynamicPort = GetFreePort();
+
+        using var session = new NativePortForwardSession(
+            new IntPtr(17),
+            [
+                CreateForward(localPort, "svc-one.internal", 8080),
+                CreateDynamicForward(dynamicPort)
+            ],
+            interop);
+
+        using TcpClient localClient = await ConnectLoopbackAsync(localPort);
+        await WaitUntilAsync(() => interop.OpenRequests.Count == 1);
+
+        Assert.Single(interop.OpenRequests);
+        Assert.Equal("svc-one.internal", interop.OpenRequests[0].HostToConnect);
+        Assert.Equal(8080, interop.OpenRequests[0].PortToConnect);
+
+        using TcpClient dynamicClient = await ConnectLoopbackAsync(dynamicPort);
+        NetworkStream stream = dynamicClient.GetStream();
+
+        await SendSocksGreetingAsync(stream);
+        await ReadExactlyAsync(stream, 2, TimeSpan.FromSeconds(2));
+
+        await SendSocksConnectRequestAsync(stream, "svc-dynamic.internal", 8443);
+        byte[] reply = await ReadExactlyAsync(stream, 10, TimeSpan.FromSeconds(2));
+
+        await WaitUntilAsync(() => interop.OpenRequests.Count == 2);
+
+        Assert.Equal(new byte[] { 0x05, 0x00 }, reply[..2]);
+        Assert.Equal(2, interop.OpenRequests.Count);
+        Assert.Contains(interop.OpenRequests, request =>
+            request.HostToConnect == "svc-dynamic.internal" &&
+            request.PortToConnect == 8443);
+    }
+
     private static PortForward CreateForward(int sourcePort, string destinationHost, int destinationPort)
     {
         return new PortForward
@@ -116,11 +186,64 @@ public sealed class NativePortForwardSessionTests
         };
     }
 
+    private static PortForward CreateDynamicForward(int sourcePort)
+    {
+        return new PortForward
+        {
+            Kind = PortForwardKind.Dynamic,
+            BindAddress = "127.0.0.1",
+            SourcePort = sourcePort
+        };
+    }
+
     private static async Task<TcpClient> ConnectLoopbackAsync(int port)
     {
         var client = new TcpClient();
         await client.ConnectAsync(IPAddress.Loopback, port);
         return client;
+    }
+
+    private static async Task SendSocksGreetingAsync(NetworkStream stream)
+    {
+        byte[] greeting = [0x05, 0x01, 0x00];
+        await stream.WriteAsync(greeting);
+        await stream.FlushAsync();
+    }
+
+    private static async Task SendSocksConnectRequestAsync(NetworkStream stream, string host, int port)
+    {
+        byte[] hostBytes = Encoding.ASCII.GetBytes(host);
+        byte[] request = new byte[7 + hostBytes.Length];
+        request[0] = 0x05;
+        request[1] = 0x01;
+        request[2] = 0x00;
+        request[3] = 0x03;
+        request[4] = (byte)hostBytes.Length;
+        Buffer.BlockCopy(hostBytes, 0, request, 5, hostBytes.Length);
+        request[5 + hostBytes.Length] = (byte)((port >> 8) & 0xFF);
+        request[6 + hostBytes.Length] = (byte)(port & 0xFF);
+
+        await stream.WriteAsync(request);
+        await stream.FlushAsync();
+    }
+
+    private static async Task<byte[]> ReadExactlyAsync(NetworkStream stream, int length, TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        byte[] buffer = new byte[length];
+        int offset = 0;
+        while (offset < length)
+        {
+            int read = await stream.ReadAsync(buffer.AsMemory(offset, length - offset), cts.Token);
+            if (read == 0)
+            {
+                throw new EndOfStreamException("Socket closed before expected bytes were read.");
+            }
+
+            offset += read;
+        }
+
+        return buffer;
     }
 
     private static int GetFreePort()

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionInteractionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionInteractionTests.cs
@@ -80,7 +80,6 @@ public sealed class NativeSshSessionInteractionTests
         var requests = new List<SshInteractionRequest>();
         var handler = new RecordingInteractionHandler(requests);
         var profile = CreateProfile();
-        profile.RememberPasswordInVault = true;
 
         using var session = new NativeSshSession(profile, interop: interop, interactionHandler: handler);
 
@@ -93,6 +92,7 @@ public sealed class NativeSshSessionInteractionTests
         Assert.True(requests[0].RememberPasswordInVault);
         Assert.True(requests[0].AllowVaultPasswordReuse);
 
+        Assert.True(requests[1].RememberPasswordInVault);
         Assert.False(requests[1].AllowVaultPasswordReuse);
     }
 

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
@@ -53,6 +53,22 @@ public sealed class NativeSshSessionTests
     }
 
     [Fact]
+    public async Task ResizeBurst_RecordsLatestDimensionsAsEffectiveInteropIntent()
+    {
+        var interop = new FakeNativeSshInterop();
+        using var session = new NativeSshSession(CreateProfile(), interop: interop);
+
+        session.Resize(120, 30);
+        session.Resize(140, 40);
+        session.Resize(160, 50);
+
+        await WaitUntilAsync(() => interop.Resizes.Count >= 3);
+
+        Assert.Equal(3, interop.Resizes.Count);
+        Assert.Equal((160, 50), interop.Resizes[^1]);
+    }
+
+    [Fact]
     public async Task ExitAndClosedEventsOnlyRaiseOnExitOnce()
     {
         var interop = new FakeNativeSshInterop();

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
@@ -119,6 +119,23 @@ public sealed class NativeSshSessionTests
         Assert.Equal(1, interop.CloseCallCount);
     }
 
+    [Fact]
+    public async Task Connect_UsesProfileKeepAliveSettingsForNativeSession()
+    {
+        var interop = new FakeNativeSshInterop();
+        SshProfile profile = CreateProfile();
+        profile.ServerAliveIntervalSeconds = 15;
+        profile.ServerAliveCountMax = 7;
+
+        using var session = new NativeSshSession(profile, interop: interop);
+
+        await WaitUntilAsync(() => interop.LastConnectOptions != null);
+
+        Assert.NotNull(interop.LastConnectOptions);
+        Assert.Equal(15, interop.LastConnectOptions!.KeepAliveIntervalSeconds);
+        Assert.Equal(7, interop.LastConnectOptions.KeepAliveCountMax);
+    }
+
     private static SshProfile CreateProfile()
     {
         return new SshProfile
@@ -155,10 +172,12 @@ public sealed class NativeSshSessionTests
         public List<byte[]> Writes { get; } = new();
         public List<(int Cols, int Rows)> Resizes { get; } = new();
         public int CloseCallCount { get; private set; }
+        public NativeSshConnectionOptions? LastConnectOptions { get; private set; }
 
         public IntPtr Connect(NativeSshConnectionOptions options)
         {
             ArgumentNullException.ThrowIfNull(options);
+            LastConnectOptions = options;
             return new IntPtr(_nextHandle++);
         }
 

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
@@ -29,6 +29,22 @@ public sealed class NativeSshSessionTests
     }
 
     [Fact]
+    public void Constructor_AllowsDynamicForwardProfiles()
+    {
+        SshProfile profile = CreateProfile();
+        profile.Forwards.Add(new PortForward
+        {
+            Kind = PortForwardKind.Dynamic,
+            BindAddress = "127.0.0.1",
+            SourcePort = 1080
+        });
+
+        using var session = new NativeSshSession(profile, interop: new FakeNativeSshInterop());
+
+        Assert.NotNull(session);
+    }
+
+    [Fact]
     public async Task SendInputForwardsUtf8BytesThroughInterop()
     {
         var interop = new FakeNativeSshInterop();

--- a/tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs
@@ -175,7 +175,7 @@ public sealed class NewSshConnectionViewModelTests
     }
 
     [Fact]
-    public void ApplySshProfile_PreservesRememberPasswordPreferenceForNativeProfiles()
+    public void ApplySshProfile_DoesNotExposeRememberPasswordPreferenceFromStoredProfiles()
     {
         var vm = new NewSshConnectionViewModel();
         var profile = new SshProfile
@@ -188,86 +188,17 @@ public sealed class NewSshConnectionViewModelTests
 
         vm.ApplySshProfile(profile);
 
-        Assert.True(vm.RememberPasswordInVault);
-    }
-
-    [Fact]
-    public void ApplySshProfile_DoesNotExposeRememberPasswordPreferenceForOpenSshProfiles()
-    {
-        var vm = new NewSshConnectionViewModel();
-        var profile = new SshProfile
-        {
-            Name = "OpenSSH",
-            Host = "openssh.internal",
-            RememberPasswordInVault = true
-        };
-
-        vm.ApplySshProfile(profile);
-
         Assert.False(vm.RememberPasswordInVault);
     }
 
     [Fact]
-    public void BackendKind_WhenChangedAwayFromNative_ClearsRememberPasswordPreference()
-    {
-        var vm = new NewSshConnectionViewModel
-        {
-            BackendKind = SshBackendKind.Native,
-            RememberPasswordInVault = true
-        };
-
-        Assert.True(vm.IsRememberPasswordVisible);
-
-        bool propertyChangedRaised = false;
-        vm.PropertyChanged += (_, e) =>
-        {
-            if (e.PropertyName == nameof(NewSshConnectionViewModel.IsRememberPasswordVisible))
-            {
-                propertyChangedRaised = true;
-            }
-        };
-
-        vm.BackendKind = SshBackendKind.OpenSsh;
-
-        Assert.False(vm.RememberPasswordInVault);
-        Assert.False(vm.IsRememberPasswordVisible);
-        Assert.True(propertyChangedRaised);
-    }
-
-    [Fact]
-    public void BackendKind_WhenNative_ExposesRememberPasswordOption()
-    {
-        var vm = new NewSshConnectionViewModel
-        {
-            BackendKind = SshBackendKind.Native
-        };
-
-        Assert.True(vm.IsRememberPasswordVisible);
-    }
-
-    [Fact]
-    public void ToSshProfile_PreservesRememberPasswordPreferenceForNativeProfiles()
+    public void ToSshProfile_DoesNotPersistRememberPasswordPreferenceForNativeProfiles()
     {
         var vm = new NewSshConnectionViewModel
         {
             Name = "Native",
             HostName = "native.internal",
             BackendKind = SshBackendKind.Native,
-            RememberPasswordInVault = true
-        };
-
-        SshProfile profile = vm.ToSshProfile();
-
-        Assert.True(profile.RememberPasswordInVault);
-    }
-
-    [Fact]
-    public void ToSshProfile_DoesNotPersistRememberPasswordPreferenceForOpenSshProfiles()
-    {
-        var vm = new NewSshConnectionViewModel
-        {
-            Name = "OpenSSH",
-            HostName = "openssh.internal",
             RememberPasswordInVault = true
         };
 

--- a/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
@@ -207,7 +207,7 @@ public sealed class SshConnectionServiceTests
     }
 
     [Fact]
-    public void SaveProfile_PersistsRememberPasswordPreferenceForNativeProfiles()
+    public void SaveProfile_DoesNotPersistRememberPasswordPreferenceForNewProfiles()
     {
         string tempRoot = CreateTempDirectory();
         try
@@ -226,9 +226,9 @@ public sealed class SshConnectionServiceTests
 
             SshProfile saved = service.SaveProfile(vm);
 
-            Assert.True(saved.RememberPasswordInVault);
-            Assert.True(store.GetProfile(saved.Id)!.RememberPasswordInVault);
-            Assert.True(new JsonSshProfileStore(path).GetProfile(saved.Id)!.RememberPasswordInVault);
+            Assert.False(saved.RememberPasswordInVault);
+            Assert.False(store.GetProfile(saved.Id)!.RememberPasswordInVault);
+            Assert.False(new JsonSshProfileStore(path).GetProfile(saved.Id)!.RememberPasswordInVault);
         }
         finally
         {
@@ -237,7 +237,7 @@ public sealed class SshConnectionServiceTests
     }
 
     [Fact]
-    public void SaveProfile_DropsRememberPasswordPreferenceForOpenSshProfiles()
+    public void SaveProfile_PreservesLegacyRememberPasswordPreferenceForExistingProfiles()
     {
         string tempRoot = CreateTempDirectory();
         try
@@ -245,19 +245,31 @@ public sealed class SshConnectionServiceTests
             string path = Path.Combine(tempRoot, "profiles.json");
             var store = new JsonSshProfileStore(path);
             var service = new SshConnectionService(store);
+            var existingId = Guid.Parse("b3eaf7fe-75c8-4c37-9d9a-4fe08eaf5f65");
+
+            store.SaveProfile(new SshProfile
+            {
+                Id = existingId,
+                Name = "Native",
+                Host = "native.internal",
+                BackendKind = SshBackendKind.Native,
+                RememberPasswordInVault = true
+            });
 
             var vm = new NewSshConnectionViewModel
             {
-                Name = "OpenSSH",
-                HostName = "openssh.internal",
-                RememberPasswordInVault = true
+                ProfileId = existingId,
+                Name = "Native Updated",
+                HostName = "updated.internal",
+                UserName = "ops",
+                BackendKind = SshBackendKind.Native
             };
 
             SshProfile saved = service.SaveProfile(vm);
 
-            Assert.False(saved.RememberPasswordInVault);
-            Assert.False(store.GetProfile(saved.Id)!.RememberPasswordInVault);
-            Assert.False(new JsonSshProfileStore(path).GetProfile(saved.Id)!.RememberPasswordInVault);
+            Assert.True(saved.RememberPasswordInVault);
+            Assert.True(store.GetProfile(saved.Id)!.RememberPasswordInVault);
+            Assert.True(new JsonSshProfileStore(path).GetProfile(saved.Id)!.RememberPasswordInVault);
         }
         finally
         {
@@ -306,7 +318,7 @@ public sealed class SshConnectionServiceTests
     }
 
     [Fact]
-    public void CreateEditorViewModel_LoadsRememberPasswordPreferenceForNativeProfiles()
+    public void CreateEditorViewModel_DoesNotLoadRememberPasswordPreferenceForNativeProfiles()
     {
         string tempRoot = CreateTempDirectory();
         try
@@ -327,7 +339,7 @@ public sealed class SshConnectionServiceTests
             TerminalProfile runtimeProfile = service.GetConnectionProfile(saved.Id)!;
             NewSshConnectionViewModel editorVm = service.CreateEditorViewModel(runtimeProfile);
 
-            Assert.True(editorVm.RememberPasswordInVault);
+            Assert.False(editorVm.RememberPasswordInVault);
         }
         finally
         {
@@ -336,7 +348,7 @@ public sealed class SshConnectionServiceTests
     }
 
     [Fact]
-    public void SaveConnectionProfile_ClearsRememberPasswordPreferenceForOpenSshProfiles()
+    public void SaveConnectionProfile_PreservesLegacyRememberPasswordPreferenceForExistingProfiles()
     {
         string tempRoot = CreateTempDirectory();
         try
@@ -367,8 +379,8 @@ public sealed class SshConnectionServiceTests
 
             service.SaveConnectionProfile(runtimeProfile);
 
-            Assert.False(store.GetProfile(existing.Id)!.RememberPasswordInVault);
-            Assert.False(new JsonSshProfileStore(path).GetProfile(existing.Id)!.RememberPasswordInVault);
+            Assert.True(store.GetProfile(existing.Id)!.RememberPasswordInVault);
+            Assert.True(new JsonSshProfileStore(path).GetProfile(existing.Id)!.RememberPasswordInVault);
         }
         finally
         {
@@ -377,7 +389,7 @@ public sealed class SshConnectionServiceTests
     }
 
     [Fact]
-    public void SaveProfile_RemovesStoredPasswordWhenRememberPasswordIsDisabled()
+    public void SaveProfile_DoesNotTouchStoredPasswordWhenSavingProfiles()
     {
         string tempRoot = CreateTempDirectory();
         try
@@ -403,8 +415,8 @@ public sealed class SshConnectionServiceTests
             SshProfile saved = service.SaveProfile(vm);
 
             Assert.False(saved.RememberPasswordInVault);
-            Assert.DoesNotContain(canonical, vault.Secrets.Keys);
-            Assert.Contains(canonical, vault.RemovedKeys);
+            Assert.Equal("stored-secret", vault.Secrets[canonical]);
+            Assert.Empty(vault.RemovedKeys);
             Assert.Empty(vault.WrittenSecrets);
         }
         finally
@@ -414,7 +426,7 @@ public sealed class SshConnectionServiceTests
     }
 
     [Fact]
-    public void SaveProfile_RemovesLegacyStoredPasswordsWhenRememberPasswordIsDisabled()
+    public void SaveProfile_DoesNotTouchLegacyStoredPasswordsWhenRenamingProfiles()
     {
         string tempRoot = CreateTempDirectory();
         try
@@ -445,14 +457,11 @@ public sealed class SshConnectionServiceTests
 
             _ = service.SaveProfile(vm);
 
-            Assert.DoesNotContain(canonical, vault.Secrets.Keys);
-            Assert.DoesNotContain(namedLegacy, vault.Secrets.Keys);
-            Assert.DoesNotContain(idLegacy, vault.Secrets.Keys);
-            Assert.Contains(canonical, vault.RemovedKeys);
-            Assert.Contains(namedLegacy, vault.RemovedKeys);
-            Assert.Contains(idLegacy, vault.RemovedKeys);
+            Assert.Equal("canonical-secret", vault.Secrets[canonical]);
+            Assert.Equal("named-legacy-secret", vault.Secrets[namedLegacy]);
+            Assert.Equal("id-legacy-secret", vault.Secrets[idLegacy]);
             Assert.Equal("unnamed-legacy-secret", vault.Secrets[unnamedLegacy]);
-            Assert.DoesNotContain(unnamedLegacy, vault.RemovedKeys);
+            Assert.Empty(vault.RemovedKeys);
             Assert.Empty(vault.WrittenSecrets);
         }
         finally
@@ -462,7 +471,7 @@ public sealed class SshConnectionServiceTests
     }
 
     [Fact]
-    public void SaveProfile_RemovesStaleLegacyPasswordsFromPreviousProfileIdentityWhenDisabled()
+    public void SaveProfile_DoesNotTouchLegacyStoredPasswordsFromPreviousProfileIdentity()
     {
         string tempRoot = CreateTempDirectory();
         try
@@ -501,12 +510,13 @@ public sealed class SshConnectionServiceTests
 
             _ = service.SaveProfile(vm);
 
-            Assert.DoesNotContain("SSH:OldName:alice@old.internal", vault.Secrets.Keys);
-            Assert.DoesNotContain($"profile_{profileId}_password", vault.Secrets.Keys);
-            Assert.DoesNotContain(VaultService.GetCanonicalSshProfileKey(profileId), vault.Secrets.Keys);
-            Assert.DoesNotContain("SSH:NewName:bob@new.internal", vault.Secrets.Keys);
+            Assert.Equal("old-named-secret", vault.Secrets["SSH:OldName:alice@old.internal"]);
+            Assert.Equal("old-id-secret", vault.Secrets[$"profile_{profileId}_password"]);
+            Assert.Equal("canonical-secret", vault.Secrets[VaultService.GetCanonicalSshProfileKey(profileId)]);
+            Assert.Equal("new-named-secret", vault.Secrets["SSH:NewName:bob@new.internal"]);
             Assert.Equal("old-unnamed-secret", vault.Secrets["SSH:alice@old.internal"]);
             Assert.Equal("new-unnamed-secret", vault.Secrets["SSH:bob@new.internal"]);
+            Assert.Empty(vault.RemovedKeys);
         }
         finally
         {
@@ -515,7 +525,7 @@ public sealed class SshConnectionServiceTests
     }
 
     [Fact]
-    public void SaveProfile_LeavesStoredPasswordUntouchedWhenRememberPasswordIsEnabled()
+    public void SaveProfile_LeavesStoredPasswordUntouchedWhenEditorStillSetsRememberPassword()
     {
         string tempRoot = CreateTempDirectory();
         try
@@ -540,7 +550,7 @@ public sealed class SshConnectionServiceTests
 
             SshProfile saved = service.SaveProfile(vm);
 
-            Assert.True(saved.RememberPasswordInVault);
+            Assert.False(saved.RememberPasswordInVault);
             Assert.Equal("stored-secret", vault.Secrets[canonical]);
             Assert.Empty(vault.RemovedKeys);
             Assert.Empty(vault.WrittenSecrets);

--- a/tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs
@@ -200,7 +200,7 @@ public sealed class SshInteractionServiceTests
     }
 
     [Fact]
-    public async Task NativePasswordRequests_ExposeRememberPasswordOption()
+    public async Task NativePasswordRequests_WithProfileIdentity_ExposeRememberPasswordOption()
     {
         AuthPromptViewModel? capturedVm = null;
         var service = new SshInteractionService(
@@ -214,11 +214,35 @@ public sealed class SshInteractionServiceTests
         {
             Kind = SshInteractionKind.Password,
             Prompt = "Password:",
-            RememberPasswordInVault = true
+            ProfileId = Guid.Parse("531365f9-b488-4475-ab7d-7221e5056cae"),
+            ProfileName = "Native Prod",
+            ProfileUser = "alice",
+            ProfileHost = "example.internal"
         }, CancellationToken.None);
 
         Assert.NotNull(capturedVm);
         Assert.True(capturedVm!.CanRememberPassword);
+    }
+
+    [Fact]
+    public async Task PasswordRequests_WithoutProfileIdentity_DoNotExposeRememberPasswordOption()
+    {
+        AuthPromptViewModel? capturedVm = null;
+        var service = new SshInteractionService(
+            authPresenter: (_, vm, _) =>
+            {
+                capturedVm = vm;
+                return Task.FromResult(SshInteractionResponse.Cancel());
+            });
+
+        await service.HandleAsync(new SshInteractionRequest
+        {
+            Kind = SshInteractionKind.Password,
+            Prompt = "Password:"
+        }, CancellationToken.None);
+
+        Assert.NotNull(capturedVm);
+        Assert.False(capturedVm!.CanRememberPassword);
     }
 
     [Fact]
@@ -253,8 +277,7 @@ public sealed class SshInteractionServiceTests
                 ProfileName = profile.Name,
                 ProfileUser = profile.SshUser,
                 ProfileHost = profile.SshHost,
-                AllowVaultPasswordReuse = false,
-                RememberPasswordInVault = true
+                AllowVaultPasswordReuse = false
             }, CancellationToken.None);
 
             Assert.Equal("manual-secret", response.Secret);
@@ -296,8 +319,7 @@ public sealed class SshInteractionServiceTests
                 ProfileName = profile.Name,
                 ProfileUser = profile.SshUser,
                 ProfileHost = profile.SshHost,
-                AllowVaultPasswordReuse = false,
-                RememberPasswordInVault = true
+                AllowVaultPasswordReuse = false
             }, CancellationToken.None);
 
             Assert.Equal("manual-secret", response.Secret);
@@ -310,7 +332,50 @@ public sealed class SshInteractionServiceTests
     }
 
     [Fact]
-    public async Task PasswordRequests_AreAnsweredFromVaultWithoutShowingDialog_WhenRememberPasswordIsEnabled()
+    public async Task NativePasswordRequests_LeavingRememberUnchecked_PreservesExistingVaultSecret()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string vaultPath = Path.Combine(tempRoot, "vault.dat");
+            var vault = new VaultService(vaultPath);
+            var profile = new TerminalProfile
+            {
+                Id = Guid.Parse("6752a7e9-6fcb-4108-813a-45411cba6a6c"),
+                Type = ConnectionType.SSH,
+                Name = "Native Prod",
+                SshHost = "example.internal",
+                SshUser = "alice"
+            };
+            vault.SetSshPasswordForProfile(profile, "vault-secret");
+
+            var service = new SshInteractionService(
+                vaultService: vault,
+                authPresenter: (_, _, _) =>
+                    Task.FromResult(SshInteractionResponse.FromSecret("manual-secret")));
+
+            var response = await service.HandleAsync(new SshInteractionRequest
+            {
+                Kind = SshInteractionKind.Password,
+                Prompt = "Password:",
+                ProfileId = profile.Id,
+                ProfileName = profile.Name,
+                ProfileUser = profile.SshUser,
+                ProfileHost = profile.SshHost,
+                AllowVaultPasswordReuse = false
+            }, CancellationToken.None);
+
+            Assert.Equal("manual-secret", response.Secret);
+            Assert.Equal("vault-secret", vault.GetSshPasswordForProfile(profile));
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PasswordRequests_AreAnsweredFromVaultWithoutShowingDialog_WhenProfileIdentityIsProvided()
     {
         string tempRoot = CreateTempDirectory();
         try
@@ -344,8 +409,7 @@ public sealed class SshInteractionServiceTests
                 ProfileName = profile.Name,
                 ProfileUser = profile.SshUser,
                 ProfileHost = profile.SshHost,
-                AllowVaultPasswordReuse = true,
-                RememberPasswordInVault = true
+                AllowVaultPasswordReuse = true
             }, CancellationToken.None);
 
             Assert.Equal(0, promptCount);
@@ -394,8 +458,7 @@ public sealed class SshInteractionServiceTests
                 ProfileName = profile.Name,
                 ProfileUser = profile.SshUser,
                 ProfileHost = profile.SshHost,
-                AllowVaultPasswordReuse = true,
-                RememberPasswordInVault = true
+                AllowVaultPasswordReuse = true
             }, CancellationToken.None);
 
             Assert.Equal(0, promptCount);
@@ -442,8 +505,7 @@ public sealed class SshInteractionServiceTests
                 ProfileName = profile.Name,
                 ProfileUser = profile.SshUser,
                 ProfileHost = profile.SshHost,
-                AllowVaultPasswordReuse = false,
-                RememberPasswordInVault = true
+                AllowVaultPasswordReuse = false
             }, CancellationToken.None);
 
             Assert.Equal("manual-secret", response.Secret);
@@ -490,8 +552,7 @@ public sealed class SshInteractionServiceTests
                 ProfileId = profile.Id,
                 ProfileName = profile.Name,
                 ProfileUser = profile.SshUser,
-                ProfileHost = profile.SshHost,
-                RememberPasswordInVault = true
+                ProfileHost = profile.SshHost
             }, CancellationToken.None);
 
             Assert.Equal(1, promptCount);

--- a/tests/NovaTerminal.Tests/Ssh/TerminalPaneSshDisconnectTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/TerminalPaneSshDisconnectTests.cs
@@ -1,0 +1,125 @@
+using Avalonia.Headless.XUnit;
+using NovaTerminal.Controls;
+using NovaTerminal.Core;
+
+namespace NovaTerminal.Tests.Ssh;
+
+public sealed class TerminalPaneSshDisconnectTests
+{
+    [Fact]
+    public void ShouldReconnectOnEnter_ReturnsFalseForRunningSession()
+    {
+        Assert.False(TerminalPane.ShouldReconnectOnEnter(new StubTerminalSession(isProcessRunning: true)));
+    }
+
+    [Fact]
+    public void ShouldReconnectOnEnter_ReturnsTrueForStoppedSession()
+    {
+        Assert.True(TerminalPane.ShouldReconnectOnEnter(new StubTerminalSession(isProcessRunning: false)));
+    }
+
+    [AvaloniaFact]
+    public void HandleSessionExit_ForSshProfile_WritesDisconnectedBanner()
+    {
+        var profile = new TerminalProfile
+        {
+            Name = "Native SSH",
+            Type = ConnectionType.SSH,
+            SshHost = "server.example",
+            SshUser = "nova"
+        };
+        var pane = new TerminalPane(profile);
+
+        pane.HandleSessionExitForTesting(17);
+
+        string visibleText = GetVisiblePlainText(pane.Buffer!);
+        Assert.Equal(17, pane.LastExitCode);
+        Assert.Contains("SSH session disconnected", visibleText, StringComparison.Ordinal);
+        Assert.Contains("Press Enter to reconnect", visibleText, StringComparison.Ordinal);
+    }
+
+    [AvaloniaFact]
+    public void HandleSessionExit_ForLocalProfile_DoesNotWriteSshDisconnectedBanner()
+    {
+        var profile = new TerminalProfile
+        {
+            Name = "PowerShell",
+            Type = ConnectionType.Local,
+            Command = "pwsh.exe"
+        };
+        var pane = new TerminalPane(profile);
+
+        pane.HandleSessionExitForTesting(5);
+
+        string visibleText = GetVisiblePlainText(pane.Buffer!);
+        Assert.Equal(5, pane.LastExitCode);
+        Assert.DoesNotContain("SSH session disconnected", visibleText, StringComparison.Ordinal);
+    }
+
+    private static string GetVisiblePlainText(TerminalBuffer buffer)
+    {
+        var field = typeof(TerminalBuffer).GetField("_viewport", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var viewport = (TerminalRow[])field!.GetValue(buffer)!;
+        return string.Join("\n", viewport.Select(GetRowText)).TrimEnd();
+    }
+
+    private static string GetRowText(TerminalRow row)
+    {
+        char[] chars = row.Cells.Select(c => c.Character == '\0' ? ' ' : c.Character).ToArray();
+        return new string(chars).TrimEnd();
+    }
+
+    private sealed class StubTerminalSession : ITerminalSession
+    {
+        public StubTerminalSession(bool isProcessRunning)
+        {
+            IsProcessRunning = isProcessRunning;
+        }
+
+        public Guid Id => Guid.NewGuid();
+        public string ShellCommand => "stub";
+        public string? ShellArguments => null;
+        public bool IsProcessRunning { get; }
+        public bool HasActiveChildProcesses => false;
+        public int? ExitCode => null;
+        public bool IsRecording => false;
+        public event Action<string>? OnOutputReceived
+        {
+            add { }
+            remove { }
+        }
+
+        public event Action<int>? OnExit
+        {
+            add { }
+            remove { }
+        }
+        public void SendInput(string input)
+        {
+        }
+
+        public void Resize(int cols, int rows)
+        {
+        }
+
+        public void StartRecording(string filePath)
+        {
+        }
+
+        public void StopRecording()
+        {
+        }
+
+        public void AttachBuffer(TerminalBuffer buffer)
+        {
+        }
+
+        public void TakeSnapshot()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add native SSH SOCKS5 dynamic port forwarding for direct-host profiles using the existing direct-tcpip interop path
- harden native forwarding cleanup for malformed SOCKS requests, mixed local/dynamic listeners, and reply-write failure teardown
- update native SSH roadmap and test matrix to record direct-host dynamic forwarding support and the remaining jump-host follow-up

## Test Plan
- `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~Ssh"`
- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~Ssh"`
- `cargo test --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml --release`
- `dotnet build src/NovaTerminal.App/NovaTerminal.App.csproj -c Release -p:SKIP_RUST_NATIVE_BUILD=1`

## Notes
- native dynamic forwarding currently supports direct-host sessions only
- one-hop jump-host dynamic forwarding remains follow-up work
