### PR TITLE
[codex] Implement Ghostty parser and scroll correctness fixes

### DIFF
--- a/docs/ghostty-gaps/ghostty_gap_roadmap.md
+++ b/docs/ghostty-gaps/ghostty_gap_roadmap.md
@@ -1,0 +1,133 @@
+# NovaTerminal vs Ghostty – Gap Roadmap
+
+This document defines the prioritized execution plan to close critical VT gaps between NovaTerminal and Ghostty, based on the VT Conformance Matrix.
+
+---
+
+## 🎯 Strategic Goal
+
+Move NovaTerminal from:
+- Partial VT correctness + strong architecture
+
+To:
+- High VT correctness + provable determinism (differentiator)
+
+---
+
+## 🔴 Phase 1 — Core Correctness (P0)
+
+### Objectives
+- Make TUIs (vim, less, htop, tmux) behave correctly
+- Eliminate cursor, scroll, and parser inconsistencies
+
+### Scope
+
+#### 1. Parser Hardening
+- C1 controls (7-bit + optional 8-bit handling)
+- ST termination (ESC \ vs BEL)
+- Unknown sequence policy (ignore/print/recover)
+- Malformed sequence recovery
+
+PR1 status notes:
+- 7-bit C1 handling is partial: CSI/OSC/DCS/APC and IND/NEL/RI recover correctly, unsupported `ESC @.._` controls are ignored.
+- BEL termination is treated as permissive recovery for DCS/APC, not strict spec compliance.
+- Unknown `ESC @.._` handling is ignore-with-recovery to keep parser state deterministic on broken streams.
+
+#### 2. Cursor & Positioning
+- CUP/HVP default parameter correctness
+- HPA/VPA/HPR/VPR correctness
+- Origin mode interactions
+
+#### 3. Scrolling & Margins
+- DECSTBM correctness
+- IND / RI behavior
+- Wraparound (DECAWM), including wide glyph edges
+
+#### 4. Alternate Screen
+- ?47 / ?1047 / ?1049 correctness
+- Cursor + attribute save/restore
+- Scrollback policy
+
+### Exit Criteria
+- No major rendering corruption in TUIs
+- Replay tests stable for full-screen apps
+- Matrix rows upgraded toward ✅
+
+---
+
+## 🟡 Phase 2 — Input & Interaction (P1)
+
+### Objectives
+- Make terminal interaction predictable and correct
+
+### Scope
+
+- Bracketed paste (?2004)
+- Mouse protocols (1000/1002/1003/1006)
+- Application cursor keys (?1)
+- Focus reporting (?1004)
+- Tab system (HT, CHT, CBT, tab stops)
+
+### Exit Criteria
+- vim/tmux/mc input behavior stable
+- No broken paste or mouse interactions
+- Tab system fully functional
+
+---
+
+## 🟢 Phase 3 — Unicode Excellence (P2)
+
+### Objectives
+- Achieve top-tier Unicode correctness
+
+### Scope
+
+- Grapheme clustering model
+- Width correctness (emoji, CJK, ZWJ)
+- Combining marks
+- Cursor movement over graphemes
+
+### Exit Criteria
+- No cursor drift on complex text
+- Correct rendering of emoji sequences
+- Replay tests for Unicode scenarios stable
+
+---
+
+## 🔵 Phase 4 — Differentiation (P3)
+
+### Objectives
+- Turn engineering rigor into product advantage
+
+### Scope
+
+- VT conformance report generator
+- Replay-based validation tooling
+- CI enforcement of matrix rules
+- Public compatibility reporting
+
+### Exit Criteria
+- Machine-readable VT support report
+- CI fails on unsupported “✅” rows
+- Public-facing compatibility claims
+
+---
+
+## ⚖️ Strategic Decisions
+
+### SIXEL
+Choose one:
+- ❌ De-prioritize (align with modern protocols)
+- ✅ Invest (differentiate for legacy/scientific use)
+
+---
+
+## 🏁 Final Outcome
+
+NovaTerminal becomes:
+
+- Not just “a terminal”
+- But:
+  - A **deterministic VT engine**
+  - With **provable correctness**
+  - And **auditable compatibility**

--- a/docs/vt_coverage_matrix.md
+++ b/docs/vt_coverage_matrix.md
@@ -54,11 +54,11 @@ It is designed to be:
 | Feature / Sequence | Spec / Notes | Status | Evidence | Ownership (code) | Known deviations |
 |---|---|---:|---|---|---|
 | C0 controls (BEL, BS, HT, LF, CR) | Basic control chars | ⚠ Partial | Replay: `tests/Replays/...` | `Core/AnsiParser.cs`, `Core/TerminalBuffer.cs` | (fill) |
-| C1 via 7-bit ESC (ESC @.._) | “7-bit C1” translation | ❌ Not supported | — | `Core/AnsiParser.cs` | (fill) |
+| C1 via 7-bit ESC (ESC @.._) | “7-bit C1” translation | ⚠ Partial | Unit: `tests/NovaTerminal.Tests/AnsiParserHardeningTests.cs` | `Core/AnsiParser.cs` | Recognizes CSI/OSC/DCS/APC plus IND/NEL/RI; unsupported `ESC @.._` controls are ignored with recovery rather than fully implemented |
 | 8-bit C1 bytes (0x80–0x9F) | If supported, must be explicit | ❌ Not supported | — | `Core/AnsiParser.cs` | (fill) |
-| String terminators (ST = ESC \\, BEL) | OSC/APC termination rules | ⚠ Partial | Unit/Replay | `Core/AnsiParser.cs` | (fill) |
-| Unknown sequence handling | Ignore/print/strict? | ⚠ Partial | Unit | `Core/AnsiParser.cs` | (fill) |
-| Error recovery on malformed sequences | Robustness | ⚠ Partial | Fuzz/Unit | `Core/AnsiParser.cs` | (fill) |
+| String terminators (ST = ESC \\, BEL) | OSC/APC termination rules | ⚠ Partial | Unit: `tests/NovaTerminal.Tests/AnsiParserHardeningTests.cs` | `Core/AnsiParser.cs` | OSC accepts BEL and ST; DCS/APC also accept BEL as permissive recovery behavior, not strict spec compliance |
+| Unknown sequence handling | Ignore/print/strict? | ⚠ Partial | Unit: `tests/NovaTerminal.Tests/AnsiParserHardeningTests.cs` | `Core/AnsiParser.cs` | Unknown `ESC @.._` sequences are ignored and parser resumes on the next valid escape or printable content |
+| Error recovery on malformed sequences | Robustness | ⚠ Partial | Fuzz/Unit: `tests/NovaTerminal.Tests/AnsiParserHardeningTests.cs`, `tests/NovaTerminal.Tests/AnsiCorpusReplayTests.cs` | `Core/AnsiParser.cs` | Malformed OSC/CSI/DCS/APC recover across chunk boundaries and nested ESC, but this is a best-effort parser policy rather than full conformance coverage |
 
 ---
 
@@ -82,10 +82,10 @@ It is designed to be:
 |---|---|---:|---|---|---|
 | ED (J) | 0/1/2 erase display | ✅ Supported | Replay | Parser+Buffer | |
 | EL (K) | 0/1/2 erase line | ✅ Supported | Replay | Parser+Buffer | |
-| ICH ( @ ) | Insert chars | ❌ Not supported | — | Buffer | |
-| DCH (P) | Delete chars | ❌ Not supported | — | Buffer | |
+| ICH ( @ ) | Insert chars | ⚠ Partial | Code path | Parser+Buffer | Implemented in parser/buffer; needs targeted unit coverage |
+| DCH (P) | Delete chars | ⚠ Partial | Code path | Parser+Buffer | Implemented in parser/buffer; needs targeted unit coverage |
 | IL (L) / DL (M) | Insert/delete lines | ⚠ Partial | Replay | Buffer | Scroll region interactions |
-| ECH (X) | Erase chars | ❌ Not supported | — | Buffer | |
+| ECH (X) | Erase chars | ⚠ Partial | Code path | Parser+Buffer | Implemented in parser/buffer; needs targeted unit coverage |
 
 ---
 
@@ -95,7 +95,7 @@ It is designed to be:
 |---|---|---:|---|---|---|
 | DECSTBM (CSI t;b r) | Set top/bottom margins | ⚠ Partial | VTTEST: scroll scenario | Parser+Buffer | |
 | IND (ESC D) / RI (ESC M) | Index / Reverse index | ⚠ Partial | Replay | Parser+Buffer | |
-| DECOM (origin mode) | Cursor relative to margins | ❌ Not supported | — | Buffer | |
+| DECOM (origin mode) | Cursor relative to margins | ✅ Supported | Unit: `tests/NovaTerminal.Tests/DecModeTests.cs` | Parser+Buffer | |
 | Wraparound DECAWM | Auto wrap | ⚠ Partial | Replay | Buffer | Wide glyph edge cases |
 | Smooth scroll | Not required for correctness | 🚫 Won’t support | — | — | Renderer concern |
 
@@ -107,9 +107,11 @@ It is designed to be:
 |---|---|---|---:|---|---|---|
 | Alternate screen | ?1049 / ?47 / ?1047 | Switch + save/restore cursor | ⚠ Partial | Replay: `AlternateScreenTests` | Buffer | |
 | Show cursor | ?25 | | ✅ Supported | Unit/Replay | Buffer+Renderer | |
-| Application cursor keys | ?1 | Impacts input mapping | ❌ Not supported | — | Input layer | |
+| Application cursor keys | ?1 | Impacts input mapping | ⚠ Partial | Unit/Code: `ReplayV2Tests`, app input paths | Parser+Input | Parser/UI wiring exists; needs targeted key-mapping tests |
+| Focus event reporting | ?1004 | Emits `CSI I` / `CSI O` on focus transitions | ⚠ Partial | Unit/Code: `DecModeTests`, `TerminalView` | Parser+Input | Mode flag tested; focus emission covered by app path, not headless UI test |
 | Bracketed paste | ?2004 | Input feature | ⚠ Partial | Unit | Input layer | |
 | Mouse reporting | ?1000/1002/1003/1006 etc | | ⚠ Partial | Manual/Unit | Input layer | |
+| Cursor style | CSI Ps SP q | DECSCUSR block/beam/underline + blink state | ✅ Supported | Unit: `tests/NovaTerminal.Tests/OscUxTests.cs` | Parser+Renderer | |
 
 ---
 
@@ -117,7 +119,7 @@ It is designed to be:
 
 | Feature | CSI | Notes | Status | Evidence | Ownership | Known deviations |
 |---|---|---:|---|---|---|
-| Basic SGR (0,1,2,4,7,22,24,27) | | Bold/dim/underline/reverse | ⚠ Partial | VTTEST: sgr scenario | Parser+Buffer | |
+| Basic SGR (0,1,2,3,4,5,7,9,22,23,24,25,27,29) | | Bold/dim/italic/underline/blink/reverse/strike | ⚠ Partial | Unit: `tests/NovaTerminal.Tests/SgrAttributeTests.cs`; VTTEST: sgr scenario | Parser+Buffer+Renderer | Underline style/color tracked separately |
 | 8/16 colors | 30–37/90–97, 40–47/100–107 | | ⚠ Partial | Replay | Parser+Buffer | |
 | 256-color | 38;5;N / 48;5;N | | ⚠ Partial | Replay | Parser+Buffer | |
 | Truecolor | 38;2;r;g;b / 48;2;r;g;b | | ⚠ Partial | Replay | Parser+Buffer | |
@@ -139,9 +141,10 @@ It is designed to be:
 | OSC | Purpose | Status | Evidence | Ownership | Known deviations |
 |---|---|---:|---|---|---|
 | OSC 0/2 | Set title | ⚠ Partial | Manual/Unit | App/UI | |
-| OSC 7 | CWD reporting | ❌ Not supported | — | App/UI | |
+| OSC 7 | CWD reporting | ✅ Supported | Unit: `tests/NovaTerminal.Tests/OscUxTests.cs` | Parser+App | |
 | OSC 52 | Clipboard | ❌ Not supported | — | App/UI | |
-| OSC 8 | Hyperlinks | ❌ Not supported | — | Renderer/UI | |
+| OSC 8 | Hyperlinks | ✅ Supported | Unit: `tests/NovaTerminal.Tests/OscUxTests.cs` | Parser+Renderer+UI | Ctrl-click open path is app-level |
+| OSC 133 | Shell integration lifecycle | ⚠ Partial | Unit: `tests/NovaTerminal.Tests/OscShellIntegrationTests.cs` | Parser+Command Assist | Supports A/B/C/D markers; broader semantic prompt extensions not audited |
 | OSC 1337 | iTerm2 inline images | ✅ Supported | Replay/Manual | Parser+Renderer | |
 | OSC 1339 | Windows conpty tunnel | 🧪 Experimental | Manual | Parser+Win | |
 
@@ -171,7 +174,7 @@ It is designed to be:
 |---|---|---:|---|---|---|
 | Selection model | UI behavior | ⚠ Partial | Manual | UI | |
 | Copy on select | Configurable | ❌ Not supported | — | UI | |
-| Hyperlinks | OSC 8 | ❌ Not supported | — | UI | |
+| Hyperlinks | OSC 8 | ✅ Supported | Unit: `tests/NovaTerminal.Tests/OscUxTests.cs` | Parser+UI | Ctrl-click open path is app-level |
 
 ---
 
@@ -180,8 +183,8 @@ It is designed to be:
 | Feature | Notes | Status | Evidence | Ownership | Known deviations |
 |---|---|---:|---|---|---|
 | wcwidth-like width | CJK/emoji width | ⚠ Partial | Replay | Buffer | |
-| Combining marks | Grapheme clusters | ❌ Not supported | — | Buffer | |
-| ZWJ emoji sequences | | ❌ Not supported | — | Buffer | |
+| Combining marks | Grapheme clusters | ⚠ Partial | Unit: `tests/NovaTerminal.Tests/GraphemeAttachmentTests.cs`, `tests/NovaTerminal.Tests/SurrogateTests.cs` | Buffer+Renderer | Common attachment cases covered; full Unicode conformance not claimed |
+| ZWJ emoji sequences | | ⚠ Partial | Unit: `tests/NovaTerminal.Tests/GraphemeAttachmentTests.cs`, `tests/NovaTerminal.Tests/WidthTests.cs` | Buffer+Renderer | Family emoji and regional indicators covered; full Unicode conformance not claimed |
 
 ---
 

--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -87,6 +87,74 @@ namespace NovaTerminal.Core
             }
         }
 
+        private void BeginCsi()
+        {
+            _state = State.Csi;
+            _paramLen = 0;
+        }
+
+        private void BeginOsc()
+        {
+            _state = State.Osc;
+            _oscStringBuffer.Clear();
+        }
+
+        private void BeginDcs()
+        {
+            _state = State.Dcs;
+            _dcsStringBuffer.Clear();
+        }
+
+        private void BeginApc()
+        {
+            _state = State.Apc;
+            _apcStringBuffer.Clear();
+        }
+
+        private bool TryHandle7BitC1(char c)
+        {
+            switch (c)
+            {
+                case '[':
+                    BeginCsi();
+                    return true;
+                case ']':
+                    BeginOsc();
+                    return true;
+                case 'P':
+                    BeginDcs();
+                    return true;
+                case '_':
+                    BeginApc();
+                    return true;
+                case 'D': // IND
+                    Index();
+                    _state = State.Normal;
+                    return true;
+                case 'E': // NEL
+                    _buffer.CursorCol = 0;
+                    Index();
+                    _state = State.Normal;
+                    return true;
+                case 'M': // RI
+                    ReverseIndex();
+                    _state = State.Normal;
+                    return true;
+                case '\\': // ST outside a string - ignore
+                    _state = State.Normal;
+                    return true;
+            }
+
+            if (c >= '@' && c <= '_')
+            {
+                // Unsupported 7-bit C1 control: ignore rather than leaking a printable byte.
+                _state = State.Normal;
+                return true;
+            }
+
+            return false;
+        }
+
         public void Process(string input)
         {
             if (string.IsNullOrEmpty(input)) return;
@@ -100,249 +168,252 @@ namespace NovaTerminal.Core
             _buffer.EnterBatchWrite();
             try
             {
-                foreach (char c in input)
+                for (int i = 0; i < input.Length; i++)
                 {
-                    switch (_state)
+                    char c = input[i];
+                    bool reprocessCurrent;
+                    do
                     {
-                        case State.Normal:
-                            if (c == '\x1b')
-                            {
-                                FlushText();
-                                _state = State.Esc;
-                            }
-                            else if (c >= 0x80 && c <= 0x9F) // C1 Controls
-                            {
-                                FlushText();
-                                switch (c)
+                        reprocessCurrent = false;
+
+                        switch (_state)
+                        {
+                            case State.Normal:
+                                if (c == '\x1b')
                                 {
-                                    case '\u009B': _state = State.Csi; _paramLen = 0; break;
-                                    case '\u0090': _state = State.Dcs; _dcsStringBuffer.Clear(); break;
-                                    case '\u009D': _state = State.Osc; _oscStringBuffer.Clear(); break;
-                                    case '\u009F': _state = State.Apc; _apcStringBuffer.Clear(); break;
-                                    default: _buffer.WriteChar(c); break;
+                                    FlushText();
+                                    _state = State.Esc;
                                 }
-                            }
-                            else if (c < 0x20 || c == 0x7F) // C0 Controls & DEL
-                            {
-                                FlushText();
-                                if (c == '\a')
+                                else if (c >= 0x80 && c <= 0x9F) // C1 Controls
                                 {
-                                    OnBell?.Invoke();
+                                    FlushText();
+                                    switch (c)
+                                    {
+                                        case '\u009B':
+                                            BeginCsi();
+                                            break;
+                                        case '\u0090':
+                                            BeginDcs();
+                                            break;
+                                        case '\u009D':
+                                            BeginOsc();
+                                            break;
+                                        case '\u009F':
+                                            BeginApc();
+                                            break;
+                                        case '\u009C':
+                                            _state = State.Normal;
+                                            break;
+                                        default:
+                                            _buffer.WriteChar(c);
+                                            break;
+                                    }
+                                }
+                                else if (c < 0x20 || c == 0x7F) // C0 Controls & DEL
+                                {
+                                    FlushText();
+                                    if (c == '\a')
+                                    {
+                                        OnBell?.Invoke();
+                                    }
+                                    else
+                                    {
+                                        if (_swallowNextNewline)
+                                        {
+                                            if (c == '\r' || c == '\n')
+                                            {
+                                                if (c == '\n') _swallowNextNewline = false;
+                                                continue;
+                                            }
+                                            else _swallowNextNewline = false;
+                                        }
+                                        _buffer.WriteChar(c);
+                                    }
                                 }
                                 else
                                 {
-                                    if (_swallowNextNewline)
+                                    // Printable Characters
+                                    _textBuffer.Append(c);
+                                }
+                                break;
+
+                            case State.Esc:
+                                if (TryHandle7BitC1(c))
+                                {
+                                    break;
+                                }
+
+                                if (c == '7') // Save Cursor
+                                {
+                                    _buffer.SaveCursor();
+                                    _state = State.Normal;
+                                }
+                                else if (c == '8') // Restore Cursor
+                                {
+                                    _buffer.RestoreCursor();
+                                    _state = State.Normal;
+                                }
+                                else if (c == 'c') // RIS - Reset to Initial State
+                                {
+                                    _buffer.Reset(); // Ensure TerminalBuffer has a Reset method or use Clear
+                                    _verticalOffset = 0;
+                                    _state = State.Normal;
+                                }
+                                else if (c == '=' || c == '>') // DECKPAM / DECKPNM
+                                {
+                                    // Keypad application/numeric mode does not render visible text.
+                                    _state = State.Normal;
+                                }
+                                else if (c == '(' || c == ')' || c == '*' || c == '+' || c == '-')
+                                {
+                                    // G0/G1 charset selection - wait for the next char but don't print
+                                    _state = State.Charset;
+                                }
+                                else if (c == '#')
+                                {
+                                    _state = State.EscHash;
+                                }
+                                else
+                                {
+                                    // Unknown escape sequence: ignore the introducer and current byte.
+                                    _state = State.Normal;
+                                }
+                                break;
+
+                            case State.Charset:
+                                // Consume the charset designation character (e.g. 'B' in ESC ( B)
+                                _state = State.Normal;
+                                break;
+
+                            case State.EscHash:
+                                if (c == '8') // DECALN - Screen Alignment Pattern
+                                {
+                                    _buffer.ScreenAlignmentPattern();
+                                }
+                                // 3, 4, 5, 6 are for single/double width/height lines.
+                                // We ignore them for now as we don't support per-line rendering attributes yet.
+                                _state = State.Normal;
+                                break;
+
+                            case State.Osc:
+                                if (c == '\a' || c == '\u009C')
+                                {
+                                    HandleOsc(new string(_oscStringBuffer.ToArray()));
+                                    _state = State.Normal;
+                                }
+                                else if (c == '\x1b')
+                                {
+                                    _state = State.OscEsc;
+                                }
+                                else
+                                {
+                                    _oscStringBuffer.Add(c);
+                                }
+                                break;
+
+                            case State.OscEsc:
+                                if (c == '\\')
+                                {
+                                    HandleOsc(new string(_oscStringBuffer.ToArray()));
+                                    _state = State.Normal;
+                                }
+                                else
+                                {
+                                    // Malformed OSC ESC sequence: abandon the string and treat this
+                                    // byte as the start of a fresh ESC sequence continuation.
+                                    _state = State.Esc;
+                                    reprocessCurrent = true;
+                                }
+                                break;
+
+                            case State.Dcs:
+                                if (c == '\x1b')
+                                {
+                                    _state = State.DcsEsc;
+                                }
+                                else if (c == '\a' || c == '\u009C')
+                                {
+                                    HandleDcs(new string(_dcsStringBuffer.ToArray()));
+                                    _state = State.Normal;
+                                }
+                                else
+                                {
+                                    _dcsStringBuffer.Add(c);
+                                }
+                                break;
+
+                            case State.DcsEsc:
+                                if (c == '\\')
+                                {
+                                    HandleDcs(new string(_dcsStringBuffer.ToArray()));
+                                    _state = State.Normal;
+                                }
+                                else
+                                {
+                                    _state = State.Esc;
+                                    reprocessCurrent = true;
+                                }
+                                break;
+
+                            case State.Apc:
+                                if (c == '\x1b')
+                                {
+                                    _state = State.ApcEsc;
+                                }
+                                else if (c == '\a' || c == '\u009C')
+                                {
+                                    HandleApc(new string(_apcStringBuffer.ToArray()));
+                                    _state = State.Normal;
+                                }
+                                else
+                                {
+                                    _apcStringBuffer.Add(c);
+                                }
+                                break;
+
+                            case State.ApcEsc:
+                                if (c == '\\')
+                                {
+                                    HandleApc(new string(_apcStringBuffer.ToArray()));
+                                    _state = State.Normal;
+                                }
+                                else
+                                {
+                                    _state = State.Esc;
+                                    reprocessCurrent = true;
+                                }
+                                break;
+
+                            case State.Csi:
+                                if (c == '\x1b')
+                                {
+                                    // Abort malformed CSI and treat ESC as a fresh introducer.
+                                    _paramLen = 0;
+                                    _state = State.Esc;
+                                }
+                                else if (c >= 0x20 && c <= 0x3F)
+                                {
+                                    // Collect params (grow up to a hard safety cap).
+                                    if (_paramLen < MaxCsiParamChars && EnsureCsiParamCapacity(_paramLen + 1))
                                     {
-                                        if (c == '\r' || c == '\n')
-                                        {
-                                            if (c == '\n') _swallowNextNewline = false;
-                                            continue;
-                                        }
-                                        else _swallowNextNewline = false;
+                                        _paramBuffer[_paramLen++] = c;
                                     }
-                                    _buffer.WriteChar(c);
                                 }
-                            }
-                            else
-                            {
-                                // Printable Characters
-                                _textBuffer.Append(c);
-                            }
-                            break;
-
-                        case State.Esc:
-                            // Log only in non-performance-critical scenarios if needed
-                            if (c == '[')
-                            {
-                                _state = State.Csi;
-                                _paramLen = 0;
-                            }
-                            else if (c == ']') // OSC Start
-                            {
-                                _state = State.Osc;
-                                _oscStringBuffer.Clear();
-                            }
-                            else if (c == 'P') // DCS Start (Device Control String) - Sixel, etc.
-                            {
-                                _state = State.Dcs;
-                                _dcsStringBuffer.Clear();
-                            }
-                            else if (c == '_') // APC Start
-                            {
-                                _state = State.Apc;
-                                _apcStringBuffer.Clear();
-                            }
-                            else if (c == '7') // Save Cursor
-                            {
-                                _buffer.SaveCursor();
-                                _state = State.Normal;
-                            }
-                            else if (c == '8') // Restore Cursor
-                            {
-                                _buffer.RestoreCursor();
-                                _state = State.Normal;
-                            }
-                            else if (c == 'c') // RIS - Reset to Initial State
-                            {
-                                _buffer.Reset(); // Ensure TerminalBuffer has a Reset method or use Clear
-                                _verticalOffset = 0;
-                                _state = State.Normal;
-                            }
-                            else if (c == 'D') // IND - Index
-                            {
-                                Index();
-                                _state = State.Normal;
-                            }
-                            else if (c == 'E') // NEL - Next Line
-                            {
-                                _buffer.CursorCol = 0;
-                                Index();
-                                _state = State.Normal;
-                            }
-                            else if (c == 'M') // RI - Reverse Index
-                            {
-                                ReverseIndex();
-                                _state = State.Normal;
-                            }
-                            else if (c == '=' || c == '>') // DECKPAM / DECKPNM
-                            {
-                                // Keypad application/numeric mode does not render visible text.
-                                _state = State.Normal;
-                            }
-                            else if (c == '(' || c == ')' || c == '*' || c == '+' || c == '-')
-                            {
-                                // G0/G1 charset selection - wait for the next char but don't print
-                                _state = State.Charset;
-                            }
-                            else if (c == '#')
-                            {
-                                _state = State.EscHash;
-                            }
-                            else if (c >= 0x20 && c <= 0x7E)
-                            {
-                                // Unknown escape sequence followed by printable char?
-                                // Treat as literal printable character (fallback)
-                                _buffer.WriteChar(c);
-                                _state = State.Normal;
-                            }
-                            else
-                            {
-                                _state = State.Normal;
-                            }
-                            break;
-
-                        case State.Charset:
-                            // Consume the charset designation character (e.g. 'B' in ESC ( B)
-                            _state = State.Normal;
-                            break;
-
-                        case State.EscHash:
-                            if (c == '8') // DECALN - Screen Alignment Pattern
-                            {
-                                _buffer.ScreenAlignmentPattern();
-                            }
-                            // 3, 4, 5, 6 are for single/double width/height lines.
-                            // We ignore them for now as we don't support per-line rendering attributes yet.
-                            _state = State.Normal;
-                            break;
-
-                        case State.Osc:
-                            if (c == '\a' || c == '\u009C')
-                            {
-                                HandleOsc(new string(_oscStringBuffer.ToArray()));
-                                _state = State.Normal;
-                            }
-                            else if (c == '\x1b')
-                            {
-                                _state = State.OscEsc;
-                            }
-                            else
-                            {
-                                if (_oscStringBuffer.Count < 50) // Only log the beginning of potential images to avoid huge logs
+                                else if (c >= 0x40 && c <= 0x7E)
                                 {
+                                    HandleCsi(c, _paramBuffer.AsSpan(0, _paramLen));
+                                    _paramLen = 0;
+                                    _state = State.Normal;
                                 }
-                                _oscStringBuffer.Add(c);
-                            }
-                            break;
-
-                        case State.OscEsc:
-                            if (c == '\\')
-                            {
-                                HandleOsc(new string(_oscStringBuffer.ToArray()));
-                                _state = State.Normal;
-                            }
-                            else
-                            {
-                                _state = State.Normal;
-                            }
-                            break;
-
-                        case State.Dcs:
-                            if (c == '\x1b') _state = State.DcsEsc;
-                            else _dcsStringBuffer.Add(c);
-                            break;
-
-                        case State.DcsEsc:
-                            if (c == '\\')
-                            {
-                                HandleDcs(new string(_dcsStringBuffer.ToArray()));
-                                _state = State.Normal;
-                            }
-                            else
-                            {
-                                _dcsStringBuffer.Add('\x1b');
-                                _dcsStringBuffer.Add(c);
-                                _state = State.Dcs;
-                            }
-                            break;
-
-                        case State.Apc:
-                            if (c == '\x1b')
-                            {
-                                _state = State.ApcEsc;
-                            }
-                            else if (c == '\u009C') // C1 ST
-                            {
-                                HandleApc(new string(_apcStringBuffer.ToArray()));
-                                _state = State.Normal;
-                            }
-                            else
-                            {
-                                _apcStringBuffer.Add(c);
-                            }
-                            break;
-
-                        case State.ApcEsc:
-                            if (c == '\\')
-                            {
-                                HandleApc(new string(_apcStringBuffer.ToArray()));
-                                _state = State.Normal;
-                            }
-                            else
-                            {
-                                _apcStringBuffer.Add('\x1b');
-                                _apcStringBuffer.Add(c);
-                                _state = State.Apc;
-                            }
-                            break;
-
-                        case State.Csi:
-                            if (c >= 0x20 && c <= 0x3F)
-                            {
-                                // Collect params (grow up to a hard safety cap).
-                                if (_paramLen < MaxCsiParamChars && EnsureCsiParamCapacity(_paramLen + 1))
+                                else
                                 {
-                                    _paramBuffer[_paramLen++] = c;
+                                    // Malformed/non-final CSI byte: drop the sequence.
+                                    _paramLen = 0;
+                                    _state = State.Normal;
                                 }
-                            }
-                            else
-                            {
-                                // Final byte
-                                HandleCsi(c, _paramBuffer.AsSpan(0, _paramLen));
-                                _state = State.Normal;
-                            }
-                            break;
-                    }
+                                break;
+                        }
+                    } while (reprocessCurrent);
                 }
                 FlushText();
 

--- a/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
@@ -498,15 +498,18 @@ namespace NovaTerminal.Core
             bool lockTaken = EnterWriteLockIfNeeded();
             try
             {
-                ScrollTop = Math.Clamp(top, 0, Rows - 1);
-                ScrollBottom = Math.Clamp(bottom, 0, Rows - 1);
+                int newTop = Math.Clamp(top, 0, Rows - 1);
+                int newBottom = Math.Clamp(bottom, 0, Rows - 1);
 
-                // Ensure valid region
-                if (ScrollTop > ScrollBottom)
+                // DECSTBM requires a region spanning at least two lines.
+                // Ignore invalid updates instead of silently resetting to full screen.
+                if (newTop >= newBottom)
                 {
-                    ScrollTop = 0;
-                    ScrollBottom = Rows - 1;
+                    return;
                 }
+
+                ScrollTop = newTop;
+                ScrollBottom = newBottom;
             }
             finally { ExitWriteLockIfNeeded(Lock, lockTaken); }
         }

--- a/src/NovaTerminal.VT/TerminalBuffer.WritePath.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.WritePath.cs
@@ -181,7 +181,7 @@ namespace NovaTerminal.Core
                 if (_lastCharCol >= 0 && _cursorCol >= _lastCharCol && _cursorCol <= _lastCharCol + 8)
                 {
                     // Verify if this is a suitable base for skin tones (look back for a non-space)
-                    int searchCol = _cursorCol - 1;
+                    int searchCol = Math.Min(_cursorCol, Cols - 1);
                     while (searchCol >= 0)
                     {
                         var target = _viewport[_cursorRow].Cells[searchCol];
@@ -235,16 +235,18 @@ namespace NovaTerminal.Core
                             {
                                 // Ensure next cell is a continuation
                                 ref var nextCell = ref row.Cells[attachCol + 1];
+                                bool expandedIntoNextCell = false;
                                 if (!nextCell.IsWideContinuation)
                                 {
                                     SyncPackedState();
                                     nextCell = new TerminalCell(' ', _packedFg, _packedBg, (ushort)(_packedFlags | (ushort)TerminalCellFlags.WideContinuation));
                                     row.SetExtendedText(attachCol + 1, null); // Ensure no old text remains
                                     row.SetHyperlink(attachCol + 1, row.GetHyperlink(attachCol));
+                                    expandedIntoNextCell = true;
                                 }
 
                                 // If the cursor was waiting at the next cell, and we just expanded into it, push the cursor forward.
-                                if (_cursorCol == attachCol + 1)
+                                if (expandedIntoNextCell && _cursorCol == attachCol + 1)
                                 {
                                     _cursorCol++;
                                     if (_cursorCol > Cols) _cursorCol = Cols;

--- a/tests/NovaTerminal.Tests/AnsiParserHardeningTests.cs
+++ b/tests/NovaTerminal.Tests/AnsiParserHardeningTests.cs
@@ -1,0 +1,159 @@
+using System.Linq;
+using NovaTerminal.Core;
+using Xunit;
+
+namespace NovaTerminal.Tests;
+
+public sealed class AnsiParserHardeningTests
+{
+    [Fact]
+    public void UnknownEscSequence_IsIgnored_AndFollowingTextContinues()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("\x1bZabc");
+
+        Assert.Equal("abc", GetVisiblePlainText(buffer).Trim());
+    }
+
+    [Fact]
+    public void Apc_Bel_TerminatesKittyQuery()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var parser = new AnsiParser(buffer, forceConPtyFiltering: true);
+        string? response = null;
+        parser.OnResponse = value => response = value;
+
+        parser.Process("\x1b_Ga=q,i=31\x07");
+
+        Assert.NotNull(response);
+        Assert.Contains(";ERR", response!);
+    }
+
+    [Fact]
+    public void Dcs_Bel_TerminatesPayload()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var parser = new AnsiParser(buffer);
+        var decoder = new RecordingImageDecoder();
+        parser.ImageDecoder = decoder;
+
+        parser.Process("\x1bPq#0!1~\x07");
+
+        Assert.Equal("q#0!1~", decoder.LastSixelPayload);
+    }
+
+    [Fact]
+    public void MalformedOsc_RecoversIntoFollowingCsiSequence()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("\x1b]0;bad-title\x1b[6 qX");
+
+        Assert.Equal(CursorStyle.Beam, buffer.Modes.CursorStyle);
+        Assert.Equal("X", GetVisiblePlainText(buffer).Trim());
+    }
+
+    [Fact]
+    public void MalformedOsc_SplitAcrossCalls_RecoversIntoFollowingCsiSequence()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("\x1b]0;bad-title\x1b");
+        parser.Process("[6 qX");
+
+        Assert.Equal(CursorStyle.Beam, buffer.Modes.CursorStyle);
+        Assert.Equal("X", GetVisiblePlainText(buffer).Trim());
+    }
+
+    [Fact]
+    public void MalformedCsi_RecoversIntoFollowingCsiSequence()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("\x1b[31\x1b[0mA");
+
+        Assert.Equal("A", GetVisiblePlainText(buffer).Trim());
+        Assert.True(buffer.IsDefaultForeground);
+        Assert.False(buffer.IsBold);
+    }
+
+    [Fact]
+    public void MalformedCsi_SplitAcrossCalls_RecoversBeforePrintableText()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("\x1b[31\x1b");
+        parser.Process("[0m");
+        parser.Process("A");
+
+        Assert.Equal("A", GetVisiblePlainText(buffer).Trim());
+        Assert.True(buffer.IsDefaultForeground);
+        Assert.False(buffer.IsBold);
+    }
+
+    [Theory]
+    [InlineData("\x1bPq#0!1~\x1b", "[6 qX")]
+    [InlineData("\x1b_Ga=q,i=31\x1b", "[6 qX")]
+    public void MalformedStringSequence_SplitAcrossCalls_RecoversIntoFollowingCsiSequence(string firstChunk, string secondChunk)
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var parser = new AnsiParser(buffer, forceConPtyFiltering: true);
+
+        parser.Process(firstChunk);
+        parser.Process(secondChunk);
+
+        Assert.Equal(CursorStyle.Beam, buffer.Modes.CursorStyle);
+        Assert.Equal("X", GetVisiblePlainText(buffer).Trim());
+    }
+
+    [Fact]
+    public void NestedEscRecovery_DoesNotDoubleProcessOrSwallowNextValidSequence()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var parser = new AnsiParser(buffer);
+        int startedCount = 0;
+        parser.OnCommandStarted = () => startedCount++;
+
+        parser.Process("\x1b]0;bad-title\x1b]133;B\x07X");
+
+        Assert.Equal(1, startedCount);
+        Assert.Equal("X", GetVisiblePlainText(buffer).Trim());
+    }
+
+    private static string GetVisiblePlainText(TerminalBuffer buffer)
+    {
+        return string.Join("\n", buffer.ViewportRows.Select(GetRowText)).TrimEnd();
+    }
+
+    private static string GetRowText(TerminalRow row)
+    {
+        var chars = row.Cells.Select(c => c.Character == '\0' ? ' ' : c.Character).ToArray();
+        return new string(chars).TrimEnd();
+    }
+
+    private sealed class RecordingImageDecoder : IImageDecoder
+    {
+        public string? LastSixelPayload { get; private set; }
+
+        public object? DecodeImageBytes(byte[] imageData, out int pixelWidth, out int pixelHeight)
+        {
+            pixelWidth = 0;
+            pixelHeight = 0;
+            return null;
+        }
+
+        public object? DecodeSixel(string sixelData, out int pixelWidth, out int pixelHeight)
+        {
+            LastSixelPayload = sixelData;
+            pixelWidth = 0;
+            pixelHeight = 0;
+            return null;
+        }
+    }
+}

--- a/tests/NovaTerminal.Tests/ReplayTests/ScrollAndWrapReplayTests.cs
+++ b/tests/NovaTerminal.Tests/ReplayTests/ScrollAndWrapReplayTests.cs
@@ -1,0 +1,79 @@
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using NovaTerminal.Core;
+using NovaTerminal.Core.Replay;
+using Xunit;
+
+namespace NovaTerminal.Tests.ReplayTests;
+
+public sealed class ScrollAndWrapReplayTests
+{
+    [Fact]
+    [Trait("Category", "Replay")]
+    public async Task Replay_BottomMarginPendingWrap_ScrollsWithinRegion()
+    {
+        string recPath = Path.Combine(Path.GetTempPath(), $"nova-scroll-wrap-{Path.GetRandomFileName()}.rec");
+
+        try
+        {
+            using (var recorder = new PtyRecorder(recPath, 3, 4))
+            {
+                Record(recorder, "aaa\r\nbbb\r\nccc\r\nddd");
+                Record(recorder, "\x1b[2;4r");
+                Record(recorder, "\x1b[4;3HXY");
+            }
+
+            var buffer = new TerminalBuffer(3, 4);
+            var parser = new AnsiParser(buffer);
+            var runner = new ReplayRunner(recPath);
+
+            await runner.RunAsync(async data =>
+            {
+                parser.Process(Encoding.UTF8.GetString(data));
+                await Task.CompletedTask;
+            });
+
+            BufferSnapshot snapshot = BufferSnapshot.Capture(buffer);
+
+            Assert.Equal("aaa", GetRowText(buffer, 0));
+            Assert.Equal("ccc", GetRowText(buffer, 1));
+            Assert.Equal("ddX", GetRowText(buffer, 2));
+            Assert.Equal("Y", GetRowText(buffer, 3));
+            Assert.Equal(1, buffer.CursorCol);
+            Assert.Equal(3, buffer.CursorRow);
+            Assert.False(snapshot.IsAltScreen);
+            Assert.Equal(1, snapshot.CursorCol);
+            Assert.Equal(3, snapshot.CursorRow);
+            Assert.Equal("aaa", snapshot.Lines[0]);
+            Assert.Equal("ccc", snapshot.Lines[1]);
+            Assert.Equal("ddX", snapshot.Lines[2]);
+            Assert.Equal("Y", snapshot.Lines[3].TrimEnd());
+        }
+        finally
+        {
+            if (File.Exists(recPath))
+            {
+                File.Delete(recPath);
+            }
+        }
+    }
+
+    private static void Record(PtyRecorder recorder, string text)
+    {
+        byte[] data = Encoding.UTF8.GetBytes(text);
+        recorder.RecordChunk(data, data.Length);
+    }
+
+    private static string GetRowText(TerminalBuffer buffer, int row)
+    {
+        char[] chars = new char[buffer.ViewportRows[row].Cells.Length];
+        for (int i = 0; i < chars.Length; i++)
+        {
+            char cell = buffer.ViewportRows[row].Cells[i].Character;
+            chars[i] = cell == '\0' ? ' ' : cell;
+        }
+
+        return new string(chars).TrimEnd();
+    }
+}

--- a/tests/NovaTerminal.Tests/ScrollAndWrapCorrectnessTests.cs
+++ b/tests/NovaTerminal.Tests/ScrollAndWrapCorrectnessTests.cs
@@ -1,0 +1,183 @@
+using System.Linq;
+using NovaTerminal.Core;
+using Xunit;
+
+namespace NovaTerminal.Tests;
+
+public sealed class ScrollAndWrapCorrectnessTests
+{
+    [Fact]
+    public void Decstbm_InvalidRegion_IsIgnored()
+    {
+        var buffer = new TerminalBuffer(10, 5);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("\x1b[2;4r");
+        Assert.Equal(1, buffer.ScrollTop);
+        Assert.Equal(3, buffer.ScrollBottom);
+
+        parser.Process("\x1b[4;2r");
+
+        Assert.Equal(1, buffer.ScrollTop);
+        Assert.Equal(3, buffer.ScrollBottom);
+    }
+
+    [Fact]
+    public void Ind_AtBottomMargin_ScrollsOnlyInsideRegion()
+    {
+        var buffer = new TerminalBuffer(2, 5);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("A\r\nB\r\nC\r\nD\r\nE");
+        parser.Process("\x1b[2;4r");
+        buffer.SetCursorPosition(0, 3);
+
+        parser.Process("\u001bD");
+
+        Assert.Equal("A", GetRowText(buffer, 0));
+        Assert.Equal("C", GetRowText(buffer, 1));
+        Assert.Equal("D", GetRowText(buffer, 2));
+        Assert.Equal(string.Empty, GetRowText(buffer, 3));
+        Assert.Equal("E", GetRowText(buffer, 4));
+        Assert.Equal(3, buffer.CursorRow);
+    }
+
+    [Fact]
+    public void Ri_AtTopMargin_ScrollsOnlyInsideRegion()
+    {
+        var buffer = new TerminalBuffer(2, 5);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("A\r\nB\r\nC\r\nD\r\nE");
+        parser.Process("\x1b[2;4r");
+        buffer.SetCursorPosition(0, 1);
+
+        parser.Process("\x1bM");
+
+        Assert.Equal("A", GetRowText(buffer, 0));
+        Assert.Equal(string.Empty, GetRowText(buffer, 1));
+        Assert.Equal("B", GetRowText(buffer, 2));
+        Assert.Equal("C", GetRowText(buffer, 3));
+        Assert.Equal("E", GetRowText(buffer, 4));
+        Assert.Equal(1, buffer.CursorRow);
+    }
+
+    [Fact]
+    public void PendingWrap_AtBottomMargin_ScrollsWithinRegion_OnNextPrintable()
+    {
+        var buffer = new TerminalBuffer(3, 4);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("aaa\r\nbbb\r\nccc\r\nddd");
+        parser.Process("\x1b[2;4r");
+        buffer.SetCursorPosition(2, 3);
+        buffer.WriteChar('X');
+
+        Assert.True(buffer.IsPendingWrap);
+
+        buffer.WriteChar('Y');
+
+        Assert.Equal("aaa", GetRowText(buffer, 0));
+        Assert.Equal("ccc", GetRowText(buffer, 1));
+        Assert.Equal("ddX", GetRowText(buffer, 2));
+        Assert.Equal("Y", GetRowText(buffer, 3));
+        Assert.Equal(1, buffer.CursorCol);
+        Assert.Equal(3, buffer.CursorRow);
+    }
+
+    [Fact]
+    public void CombiningMark_AfterLastColumnPendingWrap_AttachesToLastCell()
+    {
+        var buffer = new TerminalBuffer(5, 3);
+
+        buffer.SetCursorPosition(4, 0);
+        buffer.WriteChar('e');
+
+        Assert.True(buffer.IsPendingWrap);
+
+        buffer.WriteContent("\u0301");
+
+        Assert.Equal("e\u0301", GetGraphemeSafe(buffer, 4, 0));
+        Assert.Equal(" ", GetGraphemeSafe(buffer, 3, 0));
+        Assert.True(buffer.IsPendingWrap);
+        Assert.Equal(4, buffer.CursorCol);
+        Assert.Equal(0, buffer.CursorRow);
+    }
+
+    [Fact]
+    public void CombiningMark_AfterWideGlyphAtRightEdgePendingWrap_AttachesToWideBaseCell()
+    {
+        var buffer = new TerminalBuffer(5, 3);
+
+        buffer.SetCursorPosition(3, 0);
+        buffer.WriteContent("あ");
+
+        Assert.True(buffer.IsPendingWrap);
+
+        buffer.WriteContent("\u0301");
+
+        Assert.Equal("あ\u0301", GetGraphemeSafe(buffer, 3, 0));
+        Assert.Equal(" ", GetGraphemeSafe(buffer, 4, 0));
+        Assert.True(buffer.ViewportRows[0].Cells[4].IsWideContinuation);
+        Assert.True(buffer.IsPendingWrap);
+        Assert.Equal(4, buffer.CursorCol);
+        Assert.Equal(0, buffer.CursorRow);
+    }
+
+    [Fact]
+    public void WideGlyph_AtRightEdgeOfBottomMargin_WrapsAndScrollsInsideRegion()
+    {
+        var buffer = new TerminalBuffer(5, 4);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("aa\r\nbb\r\ncc\r\ndd");
+        parser.Process("\x1b[2;4r");
+        buffer.SetCursorPosition(4, 3);
+
+        buffer.WriteContent("あ");
+
+        Assert.Equal("aa", GetRowText(buffer, 0));
+        Assert.Equal("cc", GetRowText(buffer, 1));
+        Assert.Equal("dd", GetRowText(buffer, 2));
+        Assert.Equal("あ", GetRowText(buffer, 3));
+        Assert.Equal(2, buffer.CursorCol);
+        Assert.Equal(3, buffer.CursorRow);
+    }
+
+    [Fact]
+    public void Decstbm_ZeroOrOutOfBoundsInvalidRegion_IsIgnoredAndPreservesExistingRegion()
+    {
+        var buffer = new TerminalBuffer(10, 5);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("\x1b[2;4r");
+        Assert.Equal(1, buffer.ScrollTop);
+        Assert.Equal(3, buffer.ScrollBottom);
+
+        parser.Process("\x1b[0;1r");
+        Assert.Equal(1, buffer.ScrollTop);
+        Assert.Equal(3, buffer.ScrollBottom);
+
+        parser.Process("\x1b[99;100r");
+        Assert.Equal(1, buffer.ScrollTop);
+        Assert.Equal(3, buffer.ScrollBottom);
+    }
+
+    private static string GetRowText(TerminalBuffer buffer, int row)
+    {
+        return new string(buffer.ViewportRows[row].Cells.Select(c => c.Character == '\0' ? ' ' : c.Character).ToArray()).TrimEnd();
+    }
+
+    private static string GetGraphemeSafe(TerminalBuffer buffer, int col, int row)
+    {
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            return buffer.GetGrapheme(col, row);
+        }
+        finally
+        {
+            buffer.Lock.ExitReadLock();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- harden ANSI parser handling for 7-bit C1 translation, ST termination, malformed-sequence recovery, and unknown ESC recovery policy
- fix scroll-region and pending-wrap correctness around DECSTBM, IND/RI, last-column wrap, wide glyphs, and combining marks at the right edge
- add focused parser, wrap/scroll, replay, and roadmap/matrix coverage for the implemented behaviors

## Test Plan
- dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -p:BaseOutputPath='D:\projects\nova2\artifacts\testbuild\'
