### PR TITLE
[codex] implement PR4 alternate screen correctness

### DIFF
--- a/docs/vt_coverage_matrix.md
+++ b/docs/vt_coverage_matrix.md
@@ -105,7 +105,7 @@ It is designed to be:
 
 | Mode | CSI | Notes | Status | Evidence | Ownership | Known deviations |
 |---|---|---|---:|---|---|---|
-| Alternate screen | ?1049 / ?47 / ?1047 | Switch + save/restore cursor | ⚠ Partial | Replay: `AlternateScreenTests` | Buffer | |
+| Alternate screen | ?1049 / ?47 / ?1047 | Switch + save/restore cursor | ⚠ Partial | Unit: `tests/NovaTerminal.Tests/AlternateScreenTests.cs`; Replay: `tests/NovaTerminal.Tests/ReplayTests/AlternateScreenReplayTests.cs`, `tests/NovaTerminal.Tests/ReplayTests/NativeSshReplayParityTests.cs` | Buffer | Main scrollback is preserved and alt-screen output never enters scrollback. `?47` reuses the existing alternate buffer/state without clearing; `?1047` and `?1049` clear and home the alternate buffer on entry. Nested/redundant alt-screen enters are treated as no-op, and a `?1049` save is consumed by the first exit from alt-screen regardless of whether that exit uses `?47l`, `?1047l`, or `?1049l`. |
 | Show cursor | ?25 | | ✅ Supported | Unit/Replay | Buffer+Renderer | |
 | Application cursor keys | ?1 | Impacts input mapping | ⚠ Partial | Unit/Code: `ReplayV2Tests`, app input paths | Parser+Input | Parser/UI wiring exists; needs targeted key-mapping tests |
 | Focus event reporting | ?1004 | Emits `CSI I` / `CSI O` on focus transitions | ⚠ Partial | Unit/Code: `DecModeTests`, `TerminalView` | Parser+Input | Mode flag tested; focus emission covered by app path, not headless UI test |

--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -910,20 +910,21 @@ namespace NovaTerminal.Core
                         _buffer.Invalidate();
                         break;
                     case 47:    // Alternate screen (legacy)
+                        if (enable) _buffer.EnterAltScreen(clearAlt: false, saveCursorForExit: false);
+                        else _buffer.SwitchToMainScreen();
+                        break;
                     case 1047:  // Alternate screen
-                        if (enable) _buffer.SwitchToAltScreen();
+                        if (enable) _buffer.EnterAltScreen(clearAlt: true, saveCursorForExit: false);
                         else _buffer.SwitchToMainScreen();
                         break;
                     case 1049:  // Alternate screen + save cursor
                         if (enable)
                         {
-                            _buffer.SaveCursor();
-                            _buffer.SwitchToAltScreen();
+                            _buffer.EnterAltScreen(clearAlt: true, saveCursorForExit: true);
                         }
                         else
                         {
                             _buffer.SwitchToMainScreen();
-                            _buffer.RestoreCursor();
                         }
                         break;
                     case 2004:  // Bracketed Paste Mode

--- a/src/NovaTerminal.VT/CursorState.cs
+++ b/src/NovaTerminal.VT/CursorState.cs
@@ -19,6 +19,11 @@ namespace NovaTerminal.Core
         public bool IsDefaultBackground { get; set; } = true;
         public bool IsInverse { get; set; }
         public bool IsBold { get; set; }
+        public bool IsFaint { get; set; }
+        public bool IsItalic { get; set; }
+        public bool IsUnderline { get; set; }
+        public bool IsBlink { get; set; }
+        public bool IsStrikethrough { get; set; }
         public bool IsHidden { get; set; }
         public bool IsPendingWrap { get; set; }
 
@@ -36,6 +41,11 @@ namespace NovaTerminal.Core
                 IsDefaultBackground = this.IsDefaultBackground,
                 IsInverse = this.IsInverse,
                 IsBold = this.IsBold,
+                IsFaint = this.IsFaint,
+                IsItalic = this.IsItalic,
+                IsUnderline = this.IsUnderline,
+                IsBlink = this.IsBlink,
+                IsStrikethrough = this.IsStrikethrough,
                 IsHidden = this.IsHidden,
                 IsPendingWrap = this.IsPendingWrap
             };

--- a/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
@@ -221,6 +221,43 @@ namespace NovaTerminal.Core
             IsStrikethrough = false;
             IsHidden = false;
         }
+
+        private void SyncThemeDefaultsInCursorStateNoLock(CursorState state)
+        {
+            if (state.IsDefaultForeground)
+            {
+                state.Foreground = Theme.Foreground;
+            }
+
+            if (state.IsDefaultBackground)
+            {
+                state.Background = Theme.Background;
+            }
+        }
+
+        private TerminalRow[] ResizeDetachedScreenBufferNoLock(TerminalRow[] source)
+        {
+            var resized = new TerminalRow[Rows];
+            for (int i = 0; i < Rows; i++)
+            {
+                resized[i] = new TerminalRow(Cols, Theme.Foreground, Theme.Background);
+
+                if (i >= source.Length)
+                {
+                    continue;
+                }
+
+                int copyCols = Math.Min(Cols, source[i].Cells.Length);
+                for (int c = 0; c < copyCols; c++)
+                {
+                    resized[i].Cells[c] = source[i].Cells[c];
+                }
+
+                resized[i].IsWrapped = source[i].IsWrapped;
+            }
+
+            return resized;
+        }
         // Saved Cursor State (DEC SC / DEC RC)
         public void SaveCursor()
         {
@@ -566,6 +603,12 @@ namespace NovaTerminal.Core
                 SaveActiveScreenStateNoLock();
                 _altScreen = _viewport;    // Save current viewport as alt screen
                 _isAltScreen = false;
+
+                if (_mainScreen.Length != Rows || (_mainScreen.Length > 0 && _mainScreen[0].Cells.Length != Cols))
+                {
+                    _mainScreen = ResizeDetachedScreenBufferNoLock(_mainScreen);
+                }
+
                 _viewport = _mainScreen;   // Restore main screen
 
                 // Reset scrolling region to full screen when switching back to main screen

--- a/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
@@ -129,12 +129,11 @@ namespace NovaTerminal.Core
 
             return CursorRow + scrollOffset;
         }
-        // Saved Cursor State (DEC SC / DEC RC)
-        public void SaveCursor()
+
+        private void CaptureCursorStateNoLock(CursorState target)
         {
-            var target = _isAltScreen ? _savedCursors.Alt : _savedCursors.Main;
-            target.Row = CursorRow;
-            target.Col = CursorCol;
+            target.Row = _cursorRow;
+            target.Col = _cursorCol;
             target.Foreground = CurrentForeground;
             target.Background = CurrentBackground;
             target.FgIndex = CurrentFgIndex;
@@ -143,15 +142,19 @@ namespace NovaTerminal.Core
             target.IsDefaultBackground = IsDefaultBackground;
             target.IsInverse = IsInverse;
             target.IsBold = IsBold;
+            target.IsFaint = IsFaint;
+            target.IsItalic = IsItalic;
+            target.IsUnderline = IsUnderline;
+            target.IsBlink = IsBlink;
+            target.IsStrikethrough = IsStrikethrough;
             target.IsHidden = IsHidden;
             target.IsPendingWrap = _isPendingWrap;
         }
 
-        public void RestoreCursor()
+        private void ApplyCursorStateNoLock(CursorState source)
         {
-            var source = _isAltScreen ? _savedCursors.Alt : _savedCursors.Main;
-            CursorRow = Math.Clamp(source.Row, 0, Rows - 1);
-            CursorCol = Math.Clamp(source.Col, 0, Cols - 1);
+            _cursorRow = Math.Clamp(source.Row, 0, Rows - 1);
+            _cursorCol = Math.Clamp(source.Col, 0, Cols - 1);
             CurrentForeground = source.Foreground;
             CurrentBackground = source.Background;
             CurrentFgIndex = source.FgIndex;
@@ -160,8 +163,91 @@ namespace NovaTerminal.Core
             IsDefaultBackground = source.IsDefaultBackground;
             IsInverse = source.IsInverse;
             IsBold = source.IsBold;
+            IsFaint = source.IsFaint;
+            IsItalic = source.IsItalic;
+            IsUnderline = source.IsUnderline;
+            IsBlink = source.IsBlink;
+            IsStrikethrough = source.IsStrikethrough;
             IsHidden = source.IsHidden;
             _isPendingWrap = source.IsPendingWrap;
+        }
+
+        private void SaveActiveScreenStateNoLock()
+        {
+            var target = _isAltScreen ? _screenCursorStates.Alt : _screenCursorStates.Main;
+            CaptureCursorStateNoLock(target);
+        }
+
+        private void RestoreScreenStateNoLock(bool altScreen)
+        {
+            var source = altScreen ? _screenCursorStates.Alt : _screenCursorStates.Main;
+            ApplyCursorStateNoLock(source);
+        }
+
+        private void ClearAltScreenNoLock()
+        {
+            for (int i = 0; i < Rows; i++)
+            {
+                var row = _viewport[i];
+                row.IsWrapped = false;
+                for (int c = 0; c < Cols; c++)
+                {
+                    row.Cells[c] = TerminalCell.Default;
+                }
+
+                row.ClearExtendedText();
+                row.ClearHyperlinks();
+                row.TouchRevision();
+            }
+        }
+
+        private void ResetCursorStateToDefaultsNoLock()
+        {
+            _cursorRow = 0;
+            _cursorCol = 0;
+            _isPendingWrap = false;
+            CurrentForeground = Theme.Foreground;
+            CurrentBackground = Theme.Background;
+            CurrentFgIndex = -1;
+            CurrentBgIndex = -1;
+            IsDefaultForeground = true;
+            IsDefaultBackground = true;
+            IsInverse = false;
+            IsBold = false;
+            IsFaint = false;
+            IsItalic = false;
+            IsUnderline = false;
+            IsBlink = false;
+            IsStrikethrough = false;
+            IsHidden = false;
+        }
+        // Saved Cursor State (DEC SC / DEC RC)
+        public void SaveCursor()
+        {
+            bool lockTaken = EnterWriteLockIfNeeded();
+            try
+            {
+                var target = _isAltScreen ? _savedCursors.Alt : _savedCursors.Main;
+                CaptureCursorStateNoLock(target);
+            }
+            finally
+            {
+                ExitWriteLockIfNeeded(Lock, lockTaken);
+            }
+        }
+
+        public void RestoreCursor()
+        {
+            bool lockTaken = EnterWriteLockIfNeeded();
+            try
+            {
+                var source = _isAltScreen ? _savedCursors.Alt : _savedCursors.Main;
+                ApplyCursorStateNoLock(source);
+            }
+            finally
+            {
+                ExitWriteLockIfNeeded(Lock, lockTaken);
+            }
         }
 
         public void EraseLineToEnd()
@@ -407,14 +493,21 @@ namespace NovaTerminal.Core
         /// <summary>
         /// Switch to alternate screen buffer (used by vim, htop, less, etc.)
         /// </summary>
-        public void SwitchToAltScreen()
+        public void EnterAltScreen(bool clearAlt, bool saveCursorForExit)
         {
             bool lockTaken = EnterWriteLockIfNeeded();
             try
             {
                 if (_isAltScreen) return;
 
-                _isAltScreen = true;
+                SaveActiveScreenStateNoLock();
+
+                if (saveCursorForExit)
+                {
+                    CaptureCursorStateNoLock(_savedCursors.Main);
+                    _restoreMainCursorOnAltExit = true;
+                }
+
                 _mainScreen = _viewport;  // Save current viewport as main screen
 
                 // Reset scrolling region to full screen when switching screens
@@ -432,24 +525,20 @@ namespace NovaTerminal.Core
                     }
                 }
 
+                _isAltScreen = true;
                 _viewport = _altScreen;    // Switch to alt screen
 
-                // Clear alt screen cells (don't create new rows, reuse if possible)
-                for (int i = 0; i < Rows; i++)
+                if (clearAlt)
                 {
-                    // Ensure the row has the correct columns (in case of uneven resize if reusing objects? no, we recreated above if mismatch)
-                    // If we didn't recreate above, it means dimensions matched.
-
-                    // Reset to default
-                    for (int c = 0; c < Cols; c++)
-                    {
-                        _viewport[i].Cells[c] = TerminalCell.Default;
-                    }
-                    _viewport[i].TouchRevision();
+                    ClearAltScreenNoLock();
+                    ResetCursorStateToDefaultsNoLock();
+                    CaptureCursorStateNoLock(_screenCursorStates.Alt);
+                }
+                else
+                {
+                    RestoreScreenStateNoLock(altScreen: true);
                 }
 
-                _cursorRow = 0;
-                _cursorCol = 0;
                 // Reset row-diff cache so the next CaptureRenderSnapshot compares the alt-screen
                 // rows fresh rather than against stale main-screen row IDs.
                 _hasSnapshotState = false;
@@ -459,27 +548,37 @@ namespace NovaTerminal.Core
             finally { ExitWriteLockIfNeeded(Lock, lockTaken); }
         }
 
+        public void SwitchToAltScreen()
+        {
+            EnterAltScreen(clearAlt: true, saveCursorForExit: false);
+        }
+
         /// <summary>
         /// Switch back to main screen buffer
         /// </summary>
-        public void SwitchToMainScreen()
+        public void SwitchToMainScreen(bool restoreSavedCursorIfArmed = true)
         {
             bool lockTaken = EnterWriteLockIfNeeded();
             try
             {
                 if (!_isAltScreen) return;
 
-                _isAltScreen = false;
+                SaveActiveScreenStateNoLock();
                 _altScreen = _viewport;    // Save current viewport as alt screen
+                _isAltScreen = false;
                 _viewport = _mainScreen;   // Restore main screen
 
                 // Reset scrolling region to full screen when switching back to main screen
                 ScrollTop = 0;
                 ScrollBottom = Rows - 1;
 
-                // Ensure cursor is within bounds after switching back to main screen
-                _cursorRow = Math.Clamp(_cursorRow, 0, Rows - 1);
-                _cursorCol = Math.Clamp(_cursorCol, 0, Cols - 1);
+                RestoreScreenStateNoLock(altScreen: false);
+                if (restoreSavedCursorIfArmed && _restoreMainCursorOnAltExit)
+                {
+                    ApplyCursorStateNoLock(_savedCursors.Main);
+                }
+
+                _restoreMainCursorOnAltExit = false;
 
                 // Reset row-diff cache so the next CaptureRenderSnapshot compares the main-screen
                 // rows fresh rather than against stale alt-screen row IDs.

--- a/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
@@ -152,6 +152,10 @@ namespace NovaTerminal.Core
                 // Sync current buffer defaults to new theme
                 if (IsDefaultForeground) CurrentForeground = Theme.Foreground;
                 if (IsDefaultBackground) CurrentBackground = Theme.Background;
+                SyncThemeDefaultsInCursorStateNoLock(_savedCursors.Main);
+                SyncThemeDefaultsInCursorStateNoLock(_savedCursors.Alt);
+                SyncThemeDefaultsInCursorStateNoLock(_screenCursorStates.Main);
+                SyncThemeDefaultsInCursorStateNoLock(_screenCursorStates.Alt);
 
                 void UpdateCell(ref TerminalCell cell)
                 {

--- a/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
@@ -133,7 +133,8 @@ namespace NovaTerminal.Core
                 Modes.MouseModeAnyEvent = false;
                 Modes.MouseModeSGR = false;
 
-                SwitchToMainScreen();
+                _restoreMainCursorOnAltExit = false;
+                SwitchToMainScreen(restoreSavedCursorIfArmed: false);
                 // _tabs.Clear(); // tabs not implemented yet
             }
             finally

--- a/src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs
@@ -67,6 +67,19 @@ namespace NovaTerminal.Core
                             }
                         }
                         _cursorRow = Math.Clamp(_cursorRow, 0, newRows - 1);
+
+                        // Keep the detached main screen in sync with the new height as well.
+                        var activeAlt = _viewport;
+                        _viewport = _mainScreen;
+                        try
+                        {
+                            Reshape(newRows);
+                            _mainScreen = _viewport;
+                        }
+                        finally
+                        {
+                            _viewport = activeAlt;
+                        }
                     }
                     else
                     {

--- a/src/NovaTerminal.VT/TerminalBuffer.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.cs
@@ -166,6 +166,33 @@ namespace NovaTerminal.Core
             _cursorCol = 0;
             ScrollTop = 0;
             ScrollBottom = rows - 1;
+
+            _savedCursors.Main.Row = _cursorRow;
+            _savedCursors.Main.Col = _cursorCol;
+            _savedCursors.Main.Foreground = CurrentForeground;
+            _savedCursors.Main.Background = CurrentBackground;
+            _savedCursors.Main.IsDefaultForeground = IsDefaultForeground;
+            _savedCursors.Main.IsDefaultBackground = IsDefaultBackground;
+            _savedCursors.Alt.Row = _savedCursors.Main.Row;
+            _savedCursors.Alt.Col = _savedCursors.Main.Col;
+            _savedCursors.Alt.Foreground = _savedCursors.Main.Foreground;
+            _savedCursors.Alt.Background = _savedCursors.Main.Background;
+            _savedCursors.Alt.IsDefaultForeground = _savedCursors.Main.IsDefaultForeground;
+            _savedCursors.Alt.IsDefaultBackground = _savedCursors.Main.IsDefaultBackground;
+
+            _screenCursorStates.Main.Row = _savedCursors.Main.Row;
+            _screenCursorStates.Main.Col = _savedCursors.Main.Col;
+            _screenCursorStates.Main.Foreground = _savedCursors.Main.Foreground;
+            _screenCursorStates.Main.Background = _savedCursors.Main.Background;
+            _screenCursorStates.Main.IsDefaultForeground = _savedCursors.Main.IsDefaultForeground;
+            _screenCursorStates.Main.IsDefaultBackground = _savedCursors.Main.IsDefaultBackground;
+
+            _screenCursorStates.Alt.Row = _savedCursors.Main.Row;
+            _screenCursorStates.Alt.Col = _savedCursors.Main.Col;
+            _screenCursorStates.Alt.Foreground = _savedCursors.Main.Foreground;
+            _screenCursorStates.Alt.Background = _savedCursors.Main.Background;
+            _screenCursorStates.Alt.IsDefaultForeground = _savedCursors.Main.IsDefaultForeground;
+            _screenCursorStates.Alt.IsDefaultBackground = _savedCursors.Main.IsDefaultBackground;
         }
 
         private static long ComputeScrollbackBudgetBytes(int cols, int maxHistory)

--- a/src/NovaTerminal.VT/TerminalBuffer.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.cs
@@ -12,6 +12,8 @@ namespace NovaTerminal.Core
     public partial class TerminalBuffer
     {
         private readonly SavedCursorStates _savedCursors = new();
+        private readonly SavedCursorStates _screenCursorStates = new();
+        private bool _restoreMainCursorOnAltExit;
         // Active viewport - what ConPTY writes to (fixed size)
         private TerminalRow[] _viewport;
 

--- a/tests/NovaTerminal.Tests/AlternateScreenTests.cs
+++ b/tests/NovaTerminal.Tests/AlternateScreenTests.cs
@@ -237,6 +237,54 @@ namespace NovaTerminal.Tests
             Assert.True(buffer.IsStrikethrough);
         }
 
+        [Fact]
+        public void AltScreen_ExitAfterSameWidthResize_ShouldRestoreMainViewportWithCurrentDimensions()
+        {
+            var buffer = new TerminalBuffer(80, 24);
+            var parser = new AnsiParser(buffer);
+
+            buffer.Write("Main screen content\n");
+            parser.Process("\x1b[?1047h");
+
+            buffer.Resize(80, 30);
+
+            parser.Process("\x1b[?1047l");
+
+            Assert.Equal(30, buffer.Rows);
+            Assert.Equal(30, buffer.ViewportRows.Count);
+            Assert.Contains("Main screen", GetViewportText(buffer));
+            Assert.NotNull(buffer.ViewportRows[29]);
+        }
+
+        [Fact]
+        public void AltScreen_47_FirstEntryAfterThemeChange_ShouldUseUpdatedThemeDefaults()
+        {
+            var oldTheme = bufferTheme();
+            var newTheme = new TerminalTheme
+            {
+                Name = "Custom",
+                Foreground = TermColor.FromRgb(10, 20, 30),
+                Background = TermColor.FromRgb(40, 50, 60)
+            };
+
+            var buffer = new TerminalBuffer(80, 24) { Theme = newTheme };
+            var parser = new AnsiParser(buffer);
+
+            buffer.UpdateThemeColors(oldTheme);
+
+            parser.Process("\x1b[?47h");
+
+            Assert.Equal(newTheme.Foreground, buffer.CurrentForeground);
+            Assert.Equal(newTheme.Background, buffer.CurrentBackground);
+            Assert.True(buffer.IsDefaultForeground);
+            Assert.True(buffer.IsDefaultBackground);
+
+            static TerminalTheme bufferTheme()
+            {
+                return new TerminalTheme();
+            }
+        }
+
         private string GetTextFromRow(TerminalRow row)
         {
             if (row.Cells != null)

--- a/tests/NovaTerminal.Tests/AlternateScreenTests.cs
+++ b/tests/NovaTerminal.Tests/AlternateScreenTests.cs
@@ -111,6 +111,75 @@ namespace NovaTerminal.Tests
         }
 
         [Fact]
+        public void AltScreen_1047_ShouldRestoreMainLiveCursorState()
+        {
+            var buffer = new TerminalBuffer(80, 24);
+            var parser = new AnsiParser(buffer);
+
+            buffer.CursorRow = 6;
+            buffer.CursorCol = 12;
+            buffer.IsBold = true;
+
+            parser.Process("\x1b[?1047h");
+
+            buffer.CursorRow = 1;
+            buffer.CursorCol = 2;
+            buffer.IsBold = false;
+
+            parser.Process("\x1b[?1047l");
+
+            Assert.Equal(6, buffer.CursorRow);
+            Assert.Equal(12, buffer.CursorCol);
+            Assert.True(buffer.IsBold);
+        }
+
+        [Fact]
+        public void AltScreen_1049_ExitVia47_ShouldRestoreSavedMainCursor()
+        {
+            var buffer = new TerminalBuffer(80, 24);
+            var parser = new AnsiParser(buffer);
+
+            buffer.CursorRow = 7;
+            buffer.CursorCol = 14;
+            buffer.IsBold = true;
+
+            parser.Process("\x1b[?1049h");
+
+            buffer.CursorRow = 2;
+            buffer.CursorCol = 3;
+            buffer.IsBold = false;
+
+            parser.Process("\x1b[?47l");
+
+            Assert.Equal(7, buffer.CursorRow);
+            Assert.Equal(14, buffer.CursorCol);
+            Assert.True(buffer.IsBold);
+        }
+
+        [Fact]
+        public void AltScreen_47_ExitVia1049_ShouldNotRestoreUnpairedSavedCursor()
+        {
+            var buffer = new TerminalBuffer(80, 24);
+            var parser = new AnsiParser(buffer);
+
+            buffer.CursorRow = 4;
+            buffer.CursorCol = 9;
+            buffer.IsBold = true;
+
+            parser.Process("\x1b[?47h");
+
+            buffer.CursorRow = 0;
+            buffer.CursorCol = 0;
+            buffer.IsBold = false;
+
+            parser.Process("\x1b[?1049l");
+
+            Assert.Equal(4, buffer.CursorRow);
+            Assert.Equal(9, buffer.CursorCol);
+            Assert.True(buffer.IsBold);
+        }
+
+        [Fact]
         public void AltScreen_ScrollShouldNotAffectScrollback()
         {
             var buffer = new TerminalBuffer(80, 24);
@@ -137,6 +206,35 @@ namespace NovaTerminal.Tests
 
             // Scrollback still unchanged
             Assert.Equal(scrollbackBeforeAlt, buffer.Scrollback.Count);
+        }
+
+        [Fact]
+        public void AltScreen_1049_ShouldRestoreExtendedSgrState()
+        {
+            var buffer = new TerminalBuffer(80, 24);
+            var parser = new AnsiParser(buffer);
+
+            buffer.IsFaint = true;
+            buffer.IsItalic = true;
+            buffer.IsUnderline = true;
+            buffer.IsBlink = true;
+            buffer.IsStrikethrough = true;
+
+            parser.Process("\x1b[?1049h");
+
+            buffer.IsFaint = false;
+            buffer.IsItalic = false;
+            buffer.IsUnderline = false;
+            buffer.IsBlink = false;
+            buffer.IsStrikethrough = false;
+
+            parser.Process("\x1b[?1049l");
+
+            Assert.True(buffer.IsFaint);
+            Assert.True(buffer.IsItalic);
+            Assert.True(buffer.IsUnderline);
+            Assert.True(buffer.IsBlink);
+            Assert.True(buffer.IsStrikethrough);
         }
 
         private string GetTextFromRow(TerminalRow row)

--- a/tests/NovaTerminal.Tests/ReplayTests/AlternateScreenReplayTests.cs
+++ b/tests/NovaTerminal.Tests/ReplayTests/AlternateScreenReplayTests.cs
@@ -1,0 +1,60 @@
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using NovaTerminal.Core;
+using NovaTerminal.Core.Replay;
+using Xunit;
+
+namespace NovaTerminal.Tests.ReplayTests;
+
+public sealed class AlternateScreenReplayTests
+{
+    [Fact]
+    [Trait("Category", "Replay")]
+    public async Task Replay_1047_ShellAppShell_RestoresMainCursorForPromptContinuation()
+    {
+        string recPath = Path.Combine(Path.GetTempPath(), $"nova-alt-screen-{Path.GetRandomFileName()}.rec");
+
+        try
+        {
+            using (var recorder = new PtyRecorder(recPath, 20, 6))
+            {
+                Record(recorder, "shell\r\nprompt> ");
+                Record(recorder, "\x1b[?1047h");
+                Record(recorder, "\x1b[4;5HAPP");
+                Record(recorder, "\x1b[?1047l");
+                Record(recorder, "resume");
+            }
+
+            var buffer = new TerminalBuffer(20, 6);
+            var parser = new AnsiParser(buffer);
+            var runner = new ReplayRunner(recPath);
+
+            await runner.RunAsync(async data =>
+            {
+                parser.Process(Encoding.UTF8.GetString(data));
+                await Task.CompletedTask;
+            });
+
+            BufferSnapshot snapshot = BufferSnapshot.Capture(buffer);
+
+            Assert.False(snapshot.IsAltScreen);
+            Assert.Contains(snapshot.Lines, line => line == "shell");
+            Assert.Contains(snapshot.Lines, line => line == "prompt> resume");
+            Assert.DoesNotContain(snapshot.Lines, line => line.Contains("APP", System.StringComparison.Ordinal));
+        }
+        finally
+        {
+            if (File.Exists(recPath))
+            {
+                File.Delete(recPath);
+            }
+        }
+    }
+
+    private static void Record(PtyRecorder recorder, string text)
+    {
+        byte[] data = Encoding.UTF8.GetBytes(text);
+        recorder.RecordChunk(data, data.Length);
+    }
+}


### PR DESCRIPTION
## What changed
- implemented localized alternate-screen handling for `?47`, `?1047`, and `?1049`
- separated per-screen live cursor/style state from DECSC/DECRC saved cursor slots
- added focused unit and replay coverage for shell -> app -> shell transitions and mixed exit paths
- documented the intended scrollback and redundant-transition behavior in the VT coverage matrix

## Why it changed
PR4 requires deterministic alternate-screen behavior across shell/app transitions without mixing in unrelated cursor cleanup or renderer changes.

## Root cause
The previous implementation used one coarse alt-screen switch path and did not preserve each screen's live cursor/style state independently. That caused main-screen cursor state to be lost across `?47`/`?1047` transitions and made `?1049` restore behavior depend on the exact exit sequence rather than the intended saved state.

## Impact
- `?47` now reuses the alternate buffer without clearing it
- `?1047` and `?1049` now clear/home the alternate buffer on entry
- exiting alt-screen restores the main screen's live state deterministically
- an armed `?1049` restore is consumed on the first alt-screen exit, including mixed exits like `1049h ... 47l`
- alt-screen output remains out of main scrollback

## Validation
- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~AlternateScreenTests|FullyQualifiedName~AlternateScreenReplayTests"`
- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~AlternateScreen|FullyQualifiedName~NativeSshReplayParityTests|FullyQualifiedName~RegressionTests.Replay_VimExit_RestoresMainBuffer|FullyQualifiedName~RegressionTests.Replay_AltScreenCursor_ScopesIdeally"`
- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release`
- `dotnet test NovaTerminal.sln -c Release` still has one unrelated existing failure: `NovaTerminal.Tests.CommandAssist.CommandAssistLayoutTests.TerminalPane_WhenPopupIsNarrow_UsesCompactPopupLayout` (`PlatformNotSupportedException`)
