### PR TITLE
[codex] implement PR5 input modes

### DIFF
--- a/src/NovaTerminal.App/Core/TerminalInputModeEncoder.cs
+++ b/src/NovaTerminal.App/Core/TerminalInputModeEncoder.cs
@@ -1,0 +1,188 @@
+using System;
+using Avalonia.Input;
+
+namespace NovaTerminal.Core
+{
+    internal enum TerminalMouseButton
+    {
+        None = -1,
+        Left = 0,
+        Middle = 1,
+        Right = 2,
+        WheelUp = 64,
+        WheelDown = 65
+    }
+
+    internal enum TerminalMouseEventKind
+    {
+        Press,
+        Release,
+        Move,
+        Wheel
+    }
+
+    internal readonly record struct TerminalMouseEvent(
+        TerminalMouseEventKind Kind,
+        TerminalMouseButton Button,
+        int Column,
+        int Row,
+        KeyModifiers Modifiers);
+
+    internal static class TerminalInputModeEncoder
+    {
+        public static string? EncodeSpecialKey(Key key, ModeState? modes)
+        {
+            bool applicationCursorKeys = modes?.IsApplicationCursorKeys == true;
+
+            return key switch
+            {
+                Key.Up => applicationCursorKeys ? "\x1bOA" : "\x1b[A",
+                Key.Down => applicationCursorKeys ? "\x1bOB" : "\x1b[B",
+                Key.Right => applicationCursorKeys ? "\x1bOC" : "\x1b[C",
+                Key.Left => applicationCursorKeys ? "\x1bOD" : "\x1b[D",
+                Key.Home => applicationCursorKeys ? "\x1bOH" : "\x1b[H",
+                Key.End => applicationCursorKeys ? "\x1bOF" : "\x1b[F",
+                Key.Delete => "\x1b[3~",
+                Key.Insert => "\x1b[2~",
+                Key.PageUp => "\x1b[5~",
+                Key.PageDown => "\x1b[6~",
+                Key.F1 => "\x1bOP",
+                Key.F2 => "\x1bOQ",
+                Key.F3 => "\x1bOR",
+                Key.F4 => "\x1bOS",
+                Key.F5 => "\x1b[15~",
+                Key.F6 => "\x1b[17~",
+                Key.F7 => "\x1b[18~",
+                Key.F8 => "\x1b[19~",
+                Key.F9 => "\x1b[20~",
+                Key.F10 => "\x1b[21~",
+                Key.F11 => "\x1b[23~",
+                Key.F12 => "\x1b[24~",
+                _ => null
+            };
+        }
+
+        public static string? EncodeFocusChanged(ModeState? modes, bool isFocused)
+        {
+            if (modes?.IsFocusEventReporting != true)
+            {
+                return null;
+            }
+
+            return isFocused ? "\x1b[I" : "\x1b[O";
+        }
+
+        public static string? EncodeMouseEvent(ModeState modes, TerminalMouseEvent mouseEvent)
+        {
+            if (!ShouldReportMouseEvent(modes, mouseEvent))
+            {
+                return null;
+            }
+
+            int buttonCode = GetButtonCode(mouseEvent);
+            if (buttonCode < 0)
+            {
+                return null;
+            }
+
+            int x = Math.Max(1, mouseEvent.Column);
+            int y = Math.Max(1, mouseEvent.Row);
+
+            if (modes.MouseModeSGR)
+            {
+                char finalChar = mouseEvent.Kind == TerminalMouseEventKind.Release ? 'm' : 'M';
+                return $"\x1b[<{buttonCode};{x};{y}{finalChar}";
+            }
+
+            if (x >= 223 || y >= 223)
+            {
+                char finalChar = mouseEvent.Kind == TerminalMouseEventKind.Release ? 'm' : 'M';
+                return $"\x1b[<{buttonCode};{x};{y}{finalChar}";
+            }
+
+            if (mouseEvent.Kind == TerminalMouseEventKind.Release)
+            {
+                buttonCode = 3 + GetModifierBits(mouseEvent.Modifiers);
+            }
+
+            char buttonChar = (char)(32 + buttonCode);
+            char xChar = (char)(32 + Math.Clamp(x, 1, 223));
+            char yChar = (char)(32 + Math.Clamp(y, 1, 223));
+            return $"\x1b[M{buttonChar}{xChar}{yChar}";
+        }
+
+        private static bool ShouldReportMouseEvent(ModeState modes, TerminalMouseEvent mouseEvent)
+        {
+            if (!(modes.MouseModeX10 || modes.MouseModeButtonEvent || modes.MouseModeAnyEvent))
+            {
+                return false;
+            }
+
+            return mouseEvent.Kind switch
+            {
+                TerminalMouseEventKind.Press => IsButtonPress(mouseEvent.Button),
+                TerminalMouseEventKind.Release => IsButtonPress(mouseEvent.Button),
+                TerminalMouseEventKind.Wheel => mouseEvent.Button is TerminalMouseButton.WheelUp or TerminalMouseButton.WheelDown,
+                TerminalMouseEventKind.Move => modes.MouseModeAnyEvent || (modes.MouseModeButtonEvent && IsButtonPress(mouseEvent.Button)),
+                _ => false
+            };
+        }
+
+        private static int GetButtonCode(TerminalMouseEvent mouseEvent)
+        {
+            int modifiers = GetModifierBits(mouseEvent.Modifiers);
+            int baseCode = mouseEvent.Kind switch
+            {
+                TerminalMouseEventKind.Move => GetMotionBaseCode(mouseEvent.Button),
+                TerminalMouseEventKind.Wheel => mouseEvent.Button switch
+                {
+                    TerminalMouseButton.WheelUp => 64,
+                    TerminalMouseButton.WheelDown => 65,
+                    _ => -1
+                },
+                TerminalMouseEventKind.Press or TerminalMouseEventKind.Release => GetButtonBaseCode(mouseEvent.Button),
+                _ => -1
+            };
+
+            return baseCode >= 0 ? baseCode + modifiers : -1;
+        }
+
+        private static int GetMotionBaseCode(TerminalMouseButton button)
+        {
+            return button switch
+            {
+                TerminalMouseButton.Left => 32,
+                TerminalMouseButton.Middle => 33,
+                TerminalMouseButton.Right => 34,
+                TerminalMouseButton.None => 35,
+                _ => -1
+            };
+        }
+
+        private static int GetButtonBaseCode(TerminalMouseButton button)
+        {
+            return button switch
+            {
+                TerminalMouseButton.Left => 0,
+                TerminalMouseButton.Middle => 1,
+                TerminalMouseButton.Right => 2,
+                TerminalMouseButton.None => 3,
+                _ => -1
+            };
+        }
+
+        private static bool IsButtonPress(TerminalMouseButton button)
+        {
+            return button is TerminalMouseButton.Left or TerminalMouseButton.Middle or TerminalMouseButton.Right;
+        }
+
+        private static int GetModifierBits(KeyModifiers modifiers)
+        {
+            int bits = 0;
+            if ((modifiers & KeyModifiers.Shift) != 0) bits += 4;
+            if ((modifiers & KeyModifiers.Alt) != 0) bits += 8;
+            if ((modifiers & KeyModifiers.Control) != 0) bits += 16;
+            return bits;
+        }
+    }
+}

--- a/src/NovaTerminal.App/Core/TerminalView.cs
+++ b/src/NovaTerminal.App/Core/TerminalView.cs
@@ -126,7 +126,6 @@ namespace NovaTerminal.Core
 
             // Handle keys that don't generate text input (Control codes, arrows, etc.)
             // Logic copied from MainWindow
-            string? sequence = null;
             bool isCtrl = (keyModifiers & KeyModifiers.Control) != 0;
 
             switch (key)
@@ -192,40 +191,9 @@ namespace NovaTerminal.Core
                     break;
 
                 // Arrows
-                case Key.Up:
-                    sequence = _buffer != null && _buffer.Modes.IsApplicationCursorKeys ? "\x1bOA" : "\x1b[A";
-                    break;
-                case Key.Down:
-                    sequence = _buffer != null && _buffer.Modes.IsApplicationCursorKeys ? "\x1bOB" : "\x1b[B";
-                    break;
-                case Key.Right:
-                    sequence = _buffer != null && _buffer.Modes.IsApplicationCursorKeys ? "\x1bOC" : "\x1b[C";
-                    break;
-                case Key.Left:
-                    sequence = _buffer != null && _buffer.Modes.IsApplicationCursorKeys ? "\x1bOD" : "\x1b[D";
-                    break;
-                case Key.Home: sequence = "\x1b[H"; break;
-                case Key.End: sequence = "\x1b[F"; break;
-
-                // Function Keys
-                case Key.F1: sequence = "\x1bOP"; break;
-                case Key.F2: sequence = "\x1bOQ"; break;
-                case Key.F3: sequence = "\x1bOR"; break;
-                case Key.F4: sequence = "\x1bOS"; break;
-                case Key.F5: sequence = "\x1b[15~"; break;
-                case Key.F6: sequence = "\x1b[17~"; break;
-                case Key.F7: sequence = "\x1b[18~"; break;
-                case Key.F8: sequence = "\x1b[19~"; break;
-                case Key.F9: sequence = "\x1b[20~"; break;
-                case Key.F10: sequence = "\x1b[21~"; break;
-                case Key.F11: sequence = "\x1b[23~"; break;
-                case Key.F12: sequence = "\x1b[24~"; break;
-                case Key.Delete: sequence = "\x1b[3~"; break;
-                case Key.Insert: sequence = "\x1b[2~"; break;
-                case Key.PageUp: sequence = "\x1b[5~"; break;
-                case Key.PageDown: sequence = "\x1b[6~"; break;
             }
 
+            string? sequence = TerminalInputModeEncoder.EncodeSpecialKey(key, _buffer?.Modes);
             if (sequence != null)
             {
                 _session.SendInput(sequence);
@@ -783,9 +751,10 @@ namespace NovaTerminal.Core
         protected override void OnGotFocus(GotFocusEventArgs e)
         {
             base.OnGotFocus(e);
-            if (_session != null && _buffer != null && _buffer.Modes.IsFocusEventReporting)
+            string? sequence = TerminalInputModeEncoder.EncodeFocusChanged(_buffer?.Modes, isFocused: true);
+            if (_session != null && sequence != null)
             {
-                _session.SendInput("\x1b[I");
+                _session.SendInput(sequence);
             }
             _isDirty = true;
             InvalidateVisual();
@@ -794,9 +763,10 @@ namespace NovaTerminal.Core
         protected override void OnLostFocus(RoutedEventArgs e)
         {
             base.OnLostFocus(e);
-            if (_session != null && _buffer != null && _buffer.Modes.IsFocusEventReporting)
+            string? sequence = TerminalInputModeEncoder.EncodeFocusChanged(_buffer?.Modes, isFocused: false);
+            if (_session != null && sequence != null)
             {
-                _session.SendInput("\x1b[O");
+                _session.SendInput(sequence);
             }
             _isDirty = true;
             InvalidateVisual();
@@ -1546,31 +1516,15 @@ namespace NovaTerminal.Core
             // If mouse reporting is active, send wheel events to the session
             if (_buffer.IsMouseReportingActive())
             {
-                // Wheel Up: button 64, Wheel Down: button 65
-                int button = e.Delta.Y > 0 ? 64 : 65;
-
-                // Add modifiers if needed (not strictly required for basic wheel, 
-                // but SGR supports it. For now, just button + 32 if motion, but wheel isn't motion)
-
                 var point = e.GetCurrentPoint(this);
                 var (row, col) = ScreenToTerminal(point.Position);
-                int x = col + 1;
-                int y = row + 1;
-
-                if (_buffer.Modes.MouseModeSGR)
-                {
-                    string sequence = $"\x1b[<{button};{x};{y}M";
-                    _session?.SendInput(sequence);
-                }
-                else
-                {
-                    // Fallback to legacy X10 if possible, though wheel is mostly an SGR/URXVT extension
-                    char buttonChar = (char)(32 + button);
-                    char xChar = (char)(32 + Math.Clamp(x, 1, 223));
-                    char yChar = (char)(32 + Math.Clamp(y, 1, 223));
-                    string sequence = $"\x1b[M{buttonChar}{xChar}{yChar}";
-                    _session?.SendInput(sequence);
-                }
+                var mouseEvent = new TerminalMouseEvent(
+                    TerminalMouseEventKind.Wheel,
+                    e.Delta.Y > 0 ? TerminalMouseButton.WheelUp : TerminalMouseButton.WheelDown,
+                    col + 1,
+                    row + 1,
+                    e.KeyModifiers);
+                SendMouseEvent(mouseEvent);
                 e.Handled = true;
                 return;
             }
@@ -1599,18 +1553,28 @@ namespace NovaTerminal.Core
             base.OnPointerPressed(e);
 
             var point = e.GetCurrentPoint(this);
+            bool leftPressed = point.Properties.IsLeftButtonPressed;
 
-            if (point.Properties.IsLeftButtonPressed)
+            // Check if application has enabled mouse reporting
+            if (_buffer != null && _buffer.IsMouseReportingActive())
             {
-                // Check if application has enabled mouse reporting
-                if (_buffer != null && _buffer.IsMouseReportingActive())
+                TerminalMouseButton button = GetPressedMouseButton(point.Properties);
+                if (button != TerminalMouseButton.None)
                 {
-                    // Forward mouse event to shell
-                    SendMouseEvent(e, pressed: true);
+                    var (reportRow, reportCol) = ScreenToTerminal(point.Position);
+                    SendMouseEvent(new TerminalMouseEvent(
+                        TerminalMouseEventKind.Press,
+                        button,
+                        reportCol + 1,
+                        reportRow + 1,
+                        e.KeyModifiers));
                     e.Handled = true;
                     return;
                 }
+            }
 
+            if (leftPressed)
+            {
                 // Normal mode: Handle selection
                 var (row, col) = ScreenToTerminal(point.Position);
 
@@ -1672,17 +1636,14 @@ namespace NovaTerminal.Core
             if (_buffer != null && _buffer.IsMouseReportingActive())
             {
                 var point = e.GetCurrentPoint(this);
-
-                // Only send motion when a button is actually pressed (drag)
-                // Mode 1003 should track motion during button press, not on hover
-                bool anyButtonPressed = point.Properties.IsLeftButtonPressed ||
-                                       point.Properties.IsMiddleButtonPressed ||
-                                       point.Properties.IsRightButtonPressed;
-
-                if (anyButtonPressed)
-                {
-                    SendMouseEvent(e, pressed: true, motion: true);
-                }
+                TerminalMouseButton button = GetPressedMouseButton(point.Properties);
+                var (row, col) = ScreenToTerminal(point.Position);
+                SendMouseEvent(new TerminalMouseEvent(
+                    TerminalMouseEventKind.Move,
+                    button,
+                    col + 1,
+                    row + 1,
+                    e.KeyModifiers));
 
                 e.Handled = true;
                 return;
@@ -1724,7 +1685,14 @@ namespace NovaTerminal.Core
             // Forward release events if mouse reporting is active
             if (_buffer != null && _buffer.IsMouseReportingActive())
             {
-                SendMouseEvent(e, pressed: false);
+                var point = e.GetCurrentPoint(this);
+                var (row, col) = ScreenToTerminal(point.Position);
+                SendMouseEvent(new TerminalMouseEvent(
+                    TerminalMouseEventKind.Release,
+                    GetReleasedMouseButton(e),
+                    col + 1,
+                    row + 1,
+                    e.KeyModifiers));
                 e.Handled = true;
                 return;
             }
@@ -1743,67 +1711,34 @@ namespace NovaTerminal.Core
             }
         }
 
-        /// <summary>
-        /// Sends a mouse event to the shell in SGR format when mouse reporting is enabled.
-        /// </summary>
-        private void SendMouseEvent(PointerEventArgs e, bool pressed, bool motion = false)
+        private void SendMouseEvent(TerminalMouseEvent mouseEvent)
         {
             if (_session == null || _buffer == null) return;
 
-            var point = e.GetCurrentPoint(this);
-            var (row, col) = ScreenToTerminal(point.Position);
-
-            // Convert to 1-indexed coordinates
-            int x = col + 1;
-            int y = row + 1;
-
-            // Determine button
-            int button = 0;
-            if (point.Properties.IsLeftButtonPressed) button = 0;
-            else if (point.Properties.IsMiddleButtonPressed) button = 1;
-            else if (point.Properties.IsRightButtonPressed) button = 2;
-
-            // Add motion flag if this is a motion event and AnyEvent mode is active
-            if (motion && _buffer.Modes.MouseModeAnyEvent)
+            string? sequence = TerminalInputModeEncoder.EncodeMouseEvent(_buffer.Modes, mouseEvent);
+            if (sequence != null)
             {
-                button += 32; // Motion indicator
-            }
-
-            // Only send if we have SGR mode enabled
-            if (_buffer.Modes.MouseModeSGR)
-            {
-                // SGR format: CSI < button ; x ; y M/m
-                char finalChar = pressed ? 'M' : 'm';
-                string sequence = $"\x1b[<{button};{x};{y}{finalChar}";
-
                 _session.SendInput(sequence);
             }
-            else if (_buffer.IsMouseReportingActive())
+        }
+
+        private static TerminalMouseButton GetPressedMouseButton(PointerPointProperties properties)
+        {
+            if (properties.IsLeftButtonPressed) return TerminalMouseButton.Left;
+            if (properties.IsMiddleButtonPressed) return TerminalMouseButton.Middle;
+            if (properties.IsRightButtonPressed) return TerminalMouseButton.Right;
+            return TerminalMouseButton.None;
+        }
+
+        private static TerminalMouseButton GetReleasedMouseButton(PointerReleasedEventArgs e)
+        {
+            return e.InitialPressMouseButton switch
             {
-                // X10/Legacy format: CSI M bxy (fallback for WSL)
-                // Only send press events in X10 mode (no release)
-                if (pressed)
-                {
-                    // FALLBACK: If coordinates exceed X10 limits (223), try force-sending SGR
-                    // because X10 cannot represent them. Most modern terminals accept SGR even if not explicitly requested.
-                    if (x >= 223 || y >= 223)
-                    {
-                        char finalChar = pressed ? 'M' : 'm';
-                        string sequence = $"\x1b[<{button};{x};{y}{finalChar}";
-                        _session.SendInput(sequence);
-                        return;
-                    }
-
-                    // X10 format: button and coordinates are sent as single bytes offset by 32
-                    char buttonChar = (char)(32 + button);
-                    char xChar = (char)(32 + x);
-                    char yChar = (char)(32 + y);
-
-                    // Clamp Check (redundant now but safe)
-                    string seqX10 = $"\x1b[M{buttonChar}{xChar}{yChar}";
-                    _session.SendInput(seqX10);
-                }
-            }
+                MouseButton.Left => TerminalMouseButton.Left,
+                MouseButton.Middle => TerminalMouseButton.Middle,
+                MouseButton.Right => TerminalMouseButton.Right,
+                _ => TerminalMouseButton.None
+            };
         }
 
         /// <summary>

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -1488,28 +1488,12 @@ namespace NovaTerminal
                 case Key.Back: sequence = "\x7f"; return true;
                 case Key.Tab: sequence = "\t"; return true;
                 case Key.Escape: sequence = "\x1b"; return true;
-                case Key.Up: sequence = buffer != null && buffer.Modes.IsApplicationCursorKeys ? "\x1bOA" : "\x1b[A"; return true;
-                case Key.Down: sequence = buffer != null && buffer.Modes.IsApplicationCursorKeys ? "\x1bOB" : "\x1b[B"; return true;
-                case Key.Right: sequence = buffer != null && buffer.Modes.IsApplicationCursorKeys ? "\x1bOC" : "\x1b[C"; return true;
-                case Key.Left: sequence = buffer != null && buffer.Modes.IsApplicationCursorKeys ? "\x1bOD" : "\x1b[D"; return true;
-                case Key.Home: sequence = "\x1b[H"; return true;
-                case Key.End: sequence = "\x1b[F"; return true;
-                case Key.Delete: sequence = "\x1b[3~"; return true;
-                case Key.Insert: sequence = "\x1b[2~"; return true;
-                case Key.PageUp: sequence = "\x1b[5~"; return true;
-                case Key.PageDown: sequence = "\x1b[6~"; return true;
-                case Key.F1: sequence = "\x1bOP"; return true;
-                case Key.F2: sequence = "\x1bOQ"; return true;
-                case Key.F3: sequence = "\x1bOR"; return true;
-                case Key.F4: sequence = "\x1bOS"; return true;
-                case Key.F5: sequence = "\x1b[15~"; return true;
-                case Key.F6: sequence = "\x1b[17~"; return true;
-                case Key.F7: sequence = "\x1b[18~"; return true;
-                case Key.F8: sequence = "\x1b[19~"; return true;
-                case Key.F9: sequence = "\x1b[20~"; return true;
-                case Key.F10: sequence = "\x1b[21~"; return true;
-                case Key.F11: sequence = "\x1b[23~"; return true;
-                case Key.F12: sequence = "\x1b[24~"; return true;
+            }
+
+            sequence = TerminalInputModeEncoder.EncodeSpecialKey(e.Key, buffer?.Modes);
+            if (sequence != null)
+            {
+                return true;
             }
 
             if (isCtrl && !isShift && e.Key >= Key.A && e.Key <= Key.Z)
@@ -3301,14 +3285,10 @@ namespace NovaTerminal
                     if (!string.IsNullOrEmpty(text) && _currentPane?.Session != null)
                     {
                         // Normalize line endings to avoid double newlines on paste
-                        text = text.Replace("\r\n", "\r");
                         _currentPane.NotifyCommandAssistPaste(text);
-
-                        // Handle Bracketed Paste Mode
-                        if (_currentPane.Buffer != null && _currentPane.Buffer.Modes.IsBracketedPasteMode)
-                        {
-                            text = $"\x1b[200~{text}\x1b[201~";
-                        }
+                        text = NovaTerminal.Core.Input.TerminalInputSender.PreparePaste(
+                            text,
+                            _currentPane.Buffer?.Modes.IsBracketedPasteMode == true);
 
                         _currentPane.Session.SendInput(text);
                     }

--- a/src/NovaTerminal.Core/Input/TerminalInputSender.cs
+++ b/src/NovaTerminal.Core/Input/TerminalInputSender.cs
@@ -4,6 +4,28 @@ namespace NovaTerminal.Core.Input
 {
     public static class TerminalInputSender
     {
+        private const string BracketedPasteStart = "\x1b[200~";
+        private const string BracketedPasteEnd = "\x1b[201~";
+
+        public static string PreparePaste(string content, bool bracketedPasteModeEnabled)
+        {
+            if (string.IsNullOrEmpty(content))
+            {
+                return string.Empty;
+            }
+
+            string normalizedContent = content.Replace("\r\n", "\r");
+            if (!bracketedPasteModeEnabled)
+            {
+                return normalizedContent;
+            }
+
+            // If the content itself contains the end sequence, it could be a bracketed paste hijacking attack.
+            // A conservative approach is to strip the embedded terminator before wrapping the paste block.
+            string safeContent = normalizedContent.Replace(BracketedPasteEnd, "");
+            return BracketedPasteStart + safeContent + BracketedPasteEnd;
+        }
+
         public static void SendBracketedPaste(ITerminalSession session, string content)
         {
             if (session == null || string.IsNullOrEmpty(content))
@@ -11,18 +33,7 @@ namespace NovaTerminal.Core.Input
                 return;
             }
 
-            // Standard VT sequence for starting a pasted block of text
-            const string bracketedPasteStart = "\x1b[200~";
-            // Standard VT sequence for ending a pasted block of text
-            const string bracketedPasteEnd = "\x1b[201~";
-
-            // If the content itself contains the end sequence, it could be a bracketed paste hijacking attack.
-            // But for a simple terminal emulator where we are reading *local* files that the user dragged in,
-            // the risk is lower (they chose to paste it).
-            // A safest approach: remove or escape trailing the end sequence.
-            string safeContent = content.Replace(bracketedPasteEnd, "");
-            safeContent = safeContent.Replace("\r\n", "\r");
-            session.SendInput(bracketedPasteStart + safeContent + bracketedPasteEnd);
+            session.SendInput(PreparePaste(content, bracketedPasteModeEnabled: true));
         }
     }
 }

--- a/tests/NovaTerminal.Tests/CommandAssist/TerminalViewKeyHandlingTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/TerminalViewKeyHandlingTests.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Moq;
 using NovaTerminal.Controls;
 using NovaTerminal.Core;
@@ -9,6 +10,19 @@ namespace NovaTerminal.Tests.CommandAssist;
 
 public sealed class TerminalViewKeyHandlingTests
 {
+    private sealed class TestTerminalView : TerminalView
+    {
+        public void RaiseGotFocusForTest()
+        {
+            OnGotFocus(new GotFocusEventArgs());
+        }
+
+        public void RaiseLostFocusForTest()
+        {
+            OnLostFocus(new RoutedEventArgs());
+        }
+    }
+
     [AvaloniaFact]
     public void HandleKeyDownCore_WhenInterceptorHandlesTab_DoesNotForwardTabToSession()
     {
@@ -34,6 +48,48 @@ public sealed class TerminalViewKeyHandlingTests
 
         Assert.True(handled);
         session.Verify(x => x.SendInput("\t"), Times.Once);
+    }
+
+    [AvaloniaFact]
+    public void HandleKeyDownCore_WhenApplicationCursorKeysEnabled_UsesSs3ForArrowsAndHomeEnd()
+    {
+        var session = new Mock<ITerminalSession>();
+        var view = new TerminalView();
+        var buffer = new TerminalBuffer(80, 24);
+        buffer.Modes.IsApplicationCursorKeys = true;
+        view.SetBuffer(buffer);
+        view.SetSession(session.Object);
+
+        Assert.True(view.HandleKeyDownCore(Key.Up, KeyModifiers.None));
+        Assert.True(view.HandleKeyDownCore(Key.Down, KeyModifiers.None));
+        Assert.True(view.HandleKeyDownCore(Key.Right, KeyModifiers.None));
+        Assert.True(view.HandleKeyDownCore(Key.Left, KeyModifiers.None));
+        Assert.True(view.HandleKeyDownCore(Key.Home, KeyModifiers.None));
+        Assert.True(view.HandleKeyDownCore(Key.End, KeyModifiers.None));
+
+        session.Verify(x => x.SendInput("\x1bOA"), Times.Once);
+        session.Verify(x => x.SendInput("\x1bOB"), Times.Once);
+        session.Verify(x => x.SendInput("\x1bOC"), Times.Once);
+        session.Verify(x => x.SendInput("\x1bOD"), Times.Once);
+        session.Verify(x => x.SendInput("\x1bOH"), Times.Once);
+        session.Verify(x => x.SendInput("\x1bOF"), Times.Once);
+    }
+
+    [AvaloniaFact]
+    public void FocusReporting_WhenEnabled_EmitsFocusInAndFocusOut()
+    {
+        var session = new Mock<ITerminalSession>();
+        var view = new TestTerminalView();
+        var buffer = new TerminalBuffer(80, 24);
+        buffer.Modes.IsFocusEventReporting = true;
+        view.SetBuffer(buffer);
+        view.SetSession(session.Object);
+
+        view.RaiseGotFocusForTest();
+        view.RaiseLostFocusForTest();
+
+        session.Verify(x => x.SendInput("\x1b[I"), Times.Once);
+        session.Verify(x => x.SendInput("\x1b[O"), Times.Once);
     }
 
     [AvaloniaFact]

--- a/tests/NovaTerminal.Tests/DecModeTests.cs
+++ b/tests/NovaTerminal.Tests/DecModeTests.cs
@@ -240,6 +240,40 @@ namespace NovaTerminal.Tests
             Assert.False(buffer.Modes.IsFocusEventReporting);
         }
 
+        [Fact]
+        public void ApplicationCursorKeys_SetsModeFlag()
+        {
+            var buffer = new TerminalBuffer(80, 24);
+            var parser = new AnsiParser(buffer);
+
+            Assert.False(buffer.Modes.IsApplicationCursorKeys);
+            parser.Process("\x1b[?1h");
+            Assert.True(buffer.Modes.IsApplicationCursorKeys);
+            parser.Process("\x1b[?1l");
+            Assert.False(buffer.Modes.IsApplicationCursorKeys);
+        }
+
+        [Fact]
+        public void MouseReportingModes_SetModeFlags()
+        {
+            var buffer = new TerminalBuffer(80, 24);
+            var parser = new AnsiParser(buffer);
+
+            parser.Process("\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h");
+
+            Assert.True(buffer.Modes.MouseModeX10);
+            Assert.True(buffer.Modes.MouseModeButtonEvent);
+            Assert.True(buffer.Modes.MouseModeAnyEvent);
+            Assert.True(buffer.Modes.MouseModeSGR);
+
+            parser.Process("\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l");
+
+            Assert.False(buffer.Modes.MouseModeX10);
+            Assert.False(buffer.Modes.MouseModeButtonEvent);
+            Assert.False(buffer.Modes.MouseModeAnyEvent);
+            Assert.False(buffer.Modes.MouseModeSGR);
+        }
+
         private static string GetVisiblePlainText(TerminalBuffer buffer)
         {
             var field = typeof(TerminalBuffer).GetField("_viewport", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);

--- a/tests/NovaTerminal.Tests/Input/TerminalInputModeEncoderTests.cs
+++ b/tests/NovaTerminal.Tests/Input/TerminalInputModeEncoderTests.cs
@@ -1,0 +1,94 @@
+using Avalonia.Input;
+using NovaTerminal.Core;
+using Xunit;
+
+namespace NovaTerminal.Tests.Input
+{
+    public class TerminalInputModeEncoderTests
+    {
+        [Fact]
+        public void EncodeMouseEvent_ButtonEventTrackingWithSgr_EncodesDragMotion()
+        {
+            var modes = new ModeState
+            {
+                MouseModeButtonEvent = true,
+                MouseModeSGR = true
+            };
+
+            string? sequence = TerminalInputModeEncoder.EncodeMouseEvent(
+                modes,
+                new TerminalMouseEvent(TerminalMouseEventKind.Move, TerminalMouseButton.Left, 12, 7, KeyModifiers.None));
+
+            Assert.Equal("\x1b[<32;12;7M", sequence);
+        }
+
+        [Fact]
+        public void EncodeMouseEvent_AnyEventWithSgr_EncodesHoverMotion()
+        {
+            var modes = new ModeState
+            {
+                MouseModeAnyEvent = true,
+                MouseModeSGR = true
+            };
+
+            string? sequence = TerminalInputModeEncoder.EncodeMouseEvent(
+                modes,
+                new TerminalMouseEvent(TerminalMouseEventKind.Move, TerminalMouseButton.None, 9, 4, KeyModifiers.None));
+
+            Assert.Equal("\x1b[<35;9;4M", sequence);
+        }
+
+        [Fact]
+        public void EncodeMouseEvent_SgrRelease_PreservesReleasedButtonAndModifiers()
+        {
+            var modes = new ModeState
+            {
+                MouseModeX10 = true,
+                MouseModeSGR = true
+            };
+
+            string? sequence = TerminalInputModeEncoder.EncodeMouseEvent(
+                modes,
+                new TerminalMouseEvent(
+                    TerminalMouseEventKind.Release,
+                    TerminalMouseButton.Right,
+                    3,
+                    4,
+                    KeyModifiers.Control | KeyModifiers.Shift));
+
+            Assert.Equal("\x1b[<22;3;4m", sequence);
+        }
+
+        [Fact]
+        public void EncodeMouseEvent_ButtonEventTracking_IgnoresHoverWithoutPressedButton()
+        {
+            var modes = new ModeState
+            {
+                MouseModeButtonEvent = true,
+                MouseModeSGR = true
+            };
+
+            string? sequence = TerminalInputModeEncoder.EncodeMouseEvent(
+                modes,
+                new TerminalMouseEvent(TerminalMouseEventKind.Move, TerminalMouseButton.None, 9, 4, KeyModifiers.None));
+
+            Assert.Null(sequence);
+        }
+
+        [Fact]
+        public void EncodeFocusChanged_RequiresFocusReportingMode()
+        {
+            Assert.Null(TerminalInputModeEncoder.EncodeFocusChanged(new ModeState(), isFocused: true));
+            Assert.Equal(
+                "\x1b[I",
+                TerminalInputModeEncoder.EncodeFocusChanged(
+                    new ModeState { IsFocusEventReporting = true },
+                    isFocused: true));
+            Assert.Equal(
+                "\x1b[O",
+                TerminalInputModeEncoder.EncodeFocusChanged(
+                    new ModeState { IsFocusEventReporting = true },
+                    isFocused: false));
+        }
+    }
+}

--- a/tests/NovaTerminal.Tests/Input/TerminalInputSenderTests.cs
+++ b/tests/NovaTerminal.Tests/Input/TerminalInputSenderTests.cs
@@ -51,5 +51,21 @@ namespace NovaTerminal.Tests.Input
             // The interior \x1b[201~ should be stripped out.
             Assert.Equal("\x1b[200~echo 'hijacked'\nrm -rf /\x1b[201~", sentPayload);
         }
+
+        [Fact]
+        public void PreparePaste_WhenBracketedPasteDisabled_NormalizesLineEndingsWithoutWrapping()
+        {
+            string prepared = TerminalInputSender.PreparePaste("line 1\r\nline 2", bracketedPasteModeEnabled: false);
+
+            Assert.Equal("line 1\rline 2", prepared);
+        }
+
+        [Fact]
+        public void PreparePaste_WhenBracketedPasteEnabled_NormalizesAndWraps()
+        {
+            string prepared = TerminalInputSender.PreparePaste("line 1\r\nline 2", bracketedPasteModeEnabled: true);
+
+            Assert.Equal("\x1b[200~line 1\rline 2\x1b[201~", prepared);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement PR5 input mode handling for bracketed paste, application cursor keys, focus reporting, and modern mouse reporting with SGR 1006 support
- centralize key, focus, mouse, and paste encoding paths so TerminalView and broadcast input stay consistent
- add targeted regression tests for DEC mode flags and input encoding behavior

## Validation
- dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "FullyQualifiedName~TerminalViewKeyHandlingTests|FullyQualifiedName~TerminalInputModeEncoderTests|FullyQualifiedName~TerminalInputSenderTests|FullyQualifiedName~DecModeTests"
- dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj

## Notes
- intentionally leaves untracked docs files out of this PR
- legacy non-SGR mouse handling remains partial; SGR 1006 is the primary supported modern path