### PR TITLE
[codex] Implement PR2 cursor positioning completion

### DIFF
--- a/docs/vt_coverage_matrix.md
+++ b/docs/vt_coverage_matrix.md
@@ -67,12 +67,12 @@ It is designed to be:
 | Feature / CSI | Notes | Status | Evidence | Ownership | Known deviations |
 |---|---|---:|---|---|---|
 | CUU/CUD/CUF/CUB (A/B/C/D) | Cursor up/down/forward/back | ✅ Supported | Replay: `...` | Parser+Buffer | |
-| CUP / HVP (H/f) | Positioning, default params | ⚠ Partial | VTTEST: cursor scenario | Parser+Buffer | Default param edge cases |
+| CUP / HVP (H/f) | Positioning, default params | ✅ Supported | Unit + Replay: `tests/NovaTerminal.Tests/CursorPositioningCompletionTests.cs`, `tests/NovaTerminal.Tests/ReplayTests/RegressionTests.cs` | Parser+Buffer | |
 | CHA/CPL/CNL (G/F/E) | Horizontal absolute / prev/next line | ⚠ Partial | Replay | Parser+Buffer | |
 | CHT (I) | Cursor forward tabulation | ❌ Not supported | — | Parser+Buffer | |
 | CBT (Z) | Cursor backward tabulation | ❌ Not supported | — | Parser+Buffer | |
-| VPA/HPA (d/G) | Absolute row/col | ⚠ Partial | Unit | Parser+Buffer | |
-| HPR/VPR (a/e) | Relative row/col | ⚠ Partial | Unit | Parser+Buffer | |
+| VPA/HPA (d/G/`) | Absolute row/col | ✅ Supported | Unit: `tests/NovaTerminal.Tests/CursorPositioningCompletionTests.cs` | Parser+Buffer | |
+| HPR/VPR (a/e) | Relative row/col | ✅ Supported | Unit: `tests/NovaTerminal.Tests/CursorPositioningCompletionTests.cs` | Parser+Buffer | |
 
 ---
 

--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -596,7 +596,7 @@ namespace NovaTerminal.Core
                         break;
                     case 'd': // VPA - Vertical Position Absolute
                         {
-                            int vpaRow = Math.Max(1, arg0) - 1;
+                            int vpaRow = GetCsiParamOrDefaultOne(validArgs, 0) - 1;
                             if (_buffer.Modes.IsOriginMode) vpaRow += _buffer.ScrollTop;
                             // NOTE: _verticalOffset intentionally NOT applied here — it's a ConPTY
                             // image-rendering artifact that must not affect general cursor positioning.
@@ -605,7 +605,8 @@ namespace NovaTerminal.Core
                         }
                         break;
                     case 'C': // Cursor Forward
-                        _buffer.CursorCol = Math.Min(_buffer.Cols - 1, _buffer.CursorCol + Math.Max(1, arg0));
+                    case 'a': // HPR - Horizontal Position Relative
+                        _buffer.CursorCol = Math.Min(_buffer.Cols - 1, _buffer.CursorCol + GetCsiParamOrDefaultOne(validArgs, 0));
                         _buffer.Invalidate();
                         break;
                     case 'D': // Cursor Back
@@ -614,8 +615,8 @@ namespace NovaTerminal.Core
                         break;
                     case 'H': // Cursor Position (row;col)
                     case 'f':
-                        int row = (argCount > 0 ? validArgs[0] : 1) - 1;
-                        int col = (argCount > 1 ? validArgs[1] : 1) - 1;
+                        int row = GetCsiParamOrDefaultOne(validArgs, 0) - 1;
+                        int col = GetCsiParamOrDefaultOne(validArgs, 1) - 1;
 
                         if (_buffer.Modes.IsOriginMode)
                         {
@@ -630,10 +631,20 @@ namespace NovaTerminal.Core
                         _buffer.Invalidate();
                         break;
                     case 'G': // Cursor Horizontal Absolute (CHA)
-                        int val = (argCount > 0 ? validArgs[0] : 1) - 1;
-                        int oldCol = _buffer.CursorCol;
+                    case '`': // HPA - Horizontal Position Absolute
+                        int val = GetCsiParamOrDefaultOne(validArgs, 0) - 1;
                         _buffer.CursorCol = Math.Clamp(val, 0, _buffer.Cols - 1);
                         _buffer.Invalidate();
+                        break;
+                    case 'e': // VPR - Vertical Position Relative
+                        {
+                            int dist = GetCsiParamOrDefaultOne(validArgs, 0);
+                            if (_buffer.CursorRow >= _buffer.ScrollTop && _buffer.CursorRow <= _buffer.ScrollBottom)
+                                _buffer.CursorRow = Math.Min(_buffer.ScrollBottom, _buffer.CursorRow + dist);
+                            else
+                                _buffer.CursorRow = Math.Min(_buffer.Rows - 1, _buffer.CursorRow + dist);
+                            _buffer.Invalidate();
+                        }
                         break;
                     case 'J': // Erase in Display
                         int displayMode = argCount > 0 ? validArgs[0] : 0;
@@ -857,6 +868,16 @@ namespace NovaTerminal.Core
                 return Math.Clamp(row, _buffer.ScrollTop, _buffer.ScrollBottom);
             }
             return Math.Clamp(row, 0, _buffer.Rows - 1);
+        }
+
+        private static int GetCsiParamOrDefaultOne(ReadOnlySpan<int> args, int index)
+        {
+            if (index >= args.Length)
+            {
+                return 1;
+            }
+
+            return args[index] == 0 ? 1 : args[index];
         }
 
         /// <summary>

--- a/tests/NovaTerminal.Tests/CursorPositioningCompletionTests.cs
+++ b/tests/NovaTerminal.Tests/CursorPositioningCompletionTests.cs
@@ -1,0 +1,122 @@
+using NovaTerminal.Core;
+
+namespace NovaTerminal.Tests;
+
+public class CursorPositioningCompletionTests
+{
+    private static AnsiParser CreateParser(TerminalBuffer buffer) => new(buffer);
+
+    [Theory]
+    [InlineData("\x1b[H", 0, 0)]
+    [InlineData("\x1b[f", 0, 0)]
+    [InlineData("\x1b[0;0H", 0, 0)]
+    [InlineData("\x1b[5;H", 4, 0)]
+    [InlineData("\x1b[;7f", 0, 6)]
+    [InlineData("\x1b[0;9H", 0, 8)]
+    public void CupAndHvp_DefaultMissingAndZeroParametersToOne(string sequence, int expectedRow, int expectedCol)
+    {
+        var buffer = new TerminalBuffer(12, 10);
+        var parser = CreateParser(buffer);
+
+        parser.Process("\x1b[8;10H");
+        parser.Process(sequence);
+
+        Assert.Equal(expectedRow, buffer.CursorRow);
+        Assert.Equal(expectedCol, buffer.CursorCol);
+    }
+
+    [Fact]
+    public void CupAndVpa_OriginMode_UseScrollRegionHomeAndClampToMargins()
+    {
+        var buffer = new TerminalBuffer(12, 12);
+        var parser = CreateParser(buffer);
+
+        parser.Process("\x1b[5;10r");
+        parser.Process("\x1b[?6h");
+
+        parser.Process("\x1b[0;0H");
+        Assert.Equal(4, buffer.CursorRow);
+        Assert.Equal(0, buffer.CursorCol);
+
+        parser.Process("\x1b[999;1f");
+        Assert.Equal(9, buffer.CursorRow);
+        Assert.Equal(0, buffer.CursorCol);
+
+        parser.Process("\x1b[0d");
+        Assert.Equal(4, buffer.CursorRow);
+
+        parser.Process("\x1b[999d");
+        Assert.Equal(9, buffer.CursorRow);
+    }
+
+    [Theory]
+    [InlineData("\x1b[G", 0)]
+    [InlineData("\x1b[0G", 0)]
+    [InlineData("\x1b[7G", 6)]
+    [InlineData("\x1b[7`", 6)]
+    [InlineData("\x1b[999`", 11)]
+    public void ChaAndHpa_DefaultZeroAndLargeParametersClampConsistently(string sequence, int expectedCol)
+    {
+        var buffer = new TerminalBuffer(12, 6);
+        var parser = CreateParser(buffer);
+
+        parser.Process("\x1b[4;4H");
+        parser.Process(sequence);
+
+        Assert.Equal(3, buffer.CursorRow);
+        Assert.Equal(expectedCol, buffer.CursorCol);
+    }
+
+    [Fact]
+    public void Hpr_DefaultZeroAndLargeParametersMoveRightAndClamp()
+    {
+        var buffer = new TerminalBuffer(12, 6);
+        var parser = CreateParser(buffer);
+
+        parser.Process("\x1b[2;2H");
+        parser.Process("\x1b[a");
+        Assert.Equal(2, buffer.CursorCol);
+
+        parser.Process("\x1b[0a");
+        Assert.Equal(3, buffer.CursorCol);
+
+        parser.Process("\x1b[3a");
+        Assert.Equal(6, buffer.CursorCol);
+
+        parser.Process("\x1b[999a");
+        Assert.Equal(11, buffer.CursorCol);
+    }
+
+    [Fact]
+    public void Vpr_ClampsToScrollRegionWhenCursorStartsInsideMargins()
+    {
+        var buffer = new TerminalBuffer(12, 8);
+        var parser = CreateParser(buffer);
+
+        parser.Process("\x1b[3;6r");
+        parser.Process("\x1b[?6h");
+
+        parser.Process("\x1b[e");
+        Assert.Equal(3, buffer.CursorRow);
+
+        parser.Process("\x1b[0e");
+        Assert.Equal(4, buffer.CursorRow);
+
+        parser.Process("\x1b[999e");
+        Assert.Equal(5, buffer.CursorRow);
+    }
+
+    [Fact]
+    public void Vpr_UsesViewportBoundsWhenCursorStartsOutsideScrollRegion()
+    {
+        var buffer = new TerminalBuffer(12, 8);
+        var parser = CreateParser(buffer);
+
+        parser.Process("\x1b[3;6r");
+        parser.Process("\x1b[1;1H");
+        parser.Process("\x1b[999e");
+
+        Assert.Equal(7, buffer.CursorRow);
+        Assert.Equal(0, buffer.CursorCol);
+    }
+}


### PR DESCRIPTION
## Summary
- normalize CSI cursor-positioning defaults so omitted and explicit zero parameters resolve consistently for CUP/HVP and VPA
- implement the missing HPA (`CSI Ps ``), HPR (`CSI Ps a`), and VPR (`CSI Ps e`) handlers with mode-aware clamping
- add focused unit coverage for defaults, zero params, bounds, and origin-mode interactions, and update the VT coverage matrix

## Validation
- dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter CursorPositioningCompletionTests
- dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "CursorPositioningCompletionTests|DecModeTests"
- dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --no-build --filter "FullyQualifiedName~NovaTerminal.Tests.ReplayTests.RegressionTests.Replay_Vttest_Cursor_MatchesGoldenMaster"
- dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --no-restore
