### PR TITLE
[codex] Implement PR6 tab system

### DIFF
--- a/docs/vt_coverage_matrix.md
+++ b/docs/vt_coverage_matrix.md
@@ -53,7 +53,7 @@ It is designed to be:
 
 | Feature / Sequence | Spec / Notes | Status | Evidence | Ownership (code) | Known deviations |
 |---|---|---:|---|---|---|
-| C0 controls (BEL, BS, HT, LF, CR) | Basic control chars | ⚠ Partial | Replay: `tests/Replays/...` | `Core/AnsiParser.cs`, `Core/TerminalBuffer.cs` | (fill) |
+| C0 controls (BEL, BS, HT, LF, CR) | Basic control chars | ⚠ Partial | Unit: `tests/NovaTerminal.Tests/TabSystemTests.cs`; Replay: `tests/Replays/...` | `Core/AnsiParser.cs`, `Core/TerminalBuffer.cs` | HT now follows stored tab stops instead of inserting spaces; broader C0 coverage is still only partially audited |
 | C1 via 7-bit ESC (ESC @.._) | “7-bit C1” translation | ⚠ Partial | Unit: `tests/NovaTerminal.Tests/AnsiParserHardeningTests.cs` | `Core/AnsiParser.cs` | Recognizes CSI/OSC/DCS/APC plus IND/NEL/RI; unsupported `ESC @.._` controls are ignored with recovery rather than fully implemented |
 | 8-bit C1 bytes (0x80–0x9F) | If supported, must be explicit | ❌ Not supported | — | `Core/AnsiParser.cs` | (fill) |
 | String terminators (ST = ESC \\, BEL) | OSC/APC termination rules | ⚠ Partial | Unit: `tests/NovaTerminal.Tests/AnsiParserHardeningTests.cs` | `Core/AnsiParser.cs` | OSC accepts BEL and ST; DCS/APC also accept BEL as permissive recovery behavior, not strict spec compliance |
@@ -69,8 +69,8 @@ It is designed to be:
 | CUU/CUD/CUF/CUB (A/B/C/D) | Cursor up/down/forward/back | ✅ Supported | Replay: `...` | Parser+Buffer | |
 | CUP / HVP (H/f) | Positioning, default params | ✅ Supported | Unit + Replay: `tests/NovaTerminal.Tests/CursorPositioningCompletionTests.cs`, `tests/NovaTerminal.Tests/ReplayTests/RegressionTests.cs` | Parser+Buffer | |
 | CHA/CPL/CNL (G/F/E) | Horizontal absolute / prev/next line | ⚠ Partial | Replay | Parser+Buffer | |
-| CHT (I) | Cursor forward tabulation | ❌ Not supported | — | Parser+Buffer | |
-| CBT (Z) | Cursor backward tabulation | ❌ Not supported | — | Parser+Buffer | |
+| CHT (I) | Cursor forward tabulation | ✅ Supported | Unit: `tests/NovaTerminal.Tests/TabSystemTests.cs` | Parser+Buffer | |
+| CBT (Z) | Cursor backward tabulation | ✅ Supported | Unit: `tests/NovaTerminal.Tests/TabSystemTests.cs` | Parser+Buffer | |
 | VPA/HPA (d/G/`) | Absolute row/col | ✅ Supported | Unit: `tests/NovaTerminal.Tests/CursorPositioningCompletionTests.cs` | Parser+Buffer | |
 | HPR/VPR (a/e) | Relative row/col | ✅ Supported | Unit: `tests/NovaTerminal.Tests/CursorPositioningCompletionTests.cs` | Parser+Buffer | |
 
@@ -131,8 +131,8 @@ It is designed to be:
 
 | Feature | Notes | Status | Evidence | Ownership | Known deviations |
 |---|---|---:|---|---|---|
-| HT (tab) movement | | ⚠ Partial | Unit | Buffer | |
-| Tab stops set/clear | ESC H, CSI g | ❌ Not supported | — | Buffer | |
+| HT (tab) movement | | ✅ Supported | Unit: `tests/NovaTerminal.Tests/TabSystemTests.cs` | Parser+Buffer | Custom tab stops are clipped on width shrink; columns exposed by width growth start with default 8-column tab stops |
+| Tab stops set/clear | ESC H, CSI g | ✅ Supported | Unit: `tests/NovaTerminal.Tests/TabSystemTests.cs` | Parser+Buffer | `CSI g` supports current-stop clear (`0`/default) and clear-all (`3`); other parameters are ignored |
 
 ---
 

--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -140,6 +140,10 @@ namespace NovaTerminal.Core
                     ReverseIndex();
                     _state = State.Normal;
                     return true;
+                case 'H': // HTS
+                    _buffer.SetTabStopAtCursor();
+                    _state = State.Normal;
+                    return true;
                 case '\\': // ST outside a string - ignore
                     _state = State.Normal;
                     return true;
@@ -576,6 +580,13 @@ namespace NovaTerminal.Core
                             _buffer.InsertCharacters(ichCount);
                         }
                         break;
+                    case 'I': // CHT - Cursor Forward Tabulation
+                        if (!isPrivate)
+                        {
+                            _buffer.HorizontalTab(GetCsiParamOrDefaultOne(validArgs, 0));
+                            _buffer.Invalidate();
+                        }
+                        break;
                     case 'P': // DCH - Delete Character
                         {
                             int dchCount = Math.Max(1, arg0);
@@ -613,6 +624,13 @@ namespace NovaTerminal.Core
                         _buffer.CursorCol = Math.Max(0, _buffer.CursorCol - Math.Max(1, arg0));
                         _buffer.Invalidate();
                         break;
+                    case 'Z': // CBT - Cursor Backward Tabulation
+                        if (!isPrivate)
+                        {
+                            _buffer.BackwardTab(GetCsiParamOrDefaultOne(validArgs, 0));
+                            _buffer.Invalidate();
+                        }
+                        break;
                     case 'H': // Cursor Position (row;col)
                     case 'f':
                         int row = GetCsiParamOrDefaultOne(validArgs, 0) - 1;
@@ -643,6 +661,21 @@ namespace NovaTerminal.Core
                                 _buffer.CursorRow = Math.Min(_buffer.ScrollBottom, _buffer.CursorRow + dist);
                             else
                                 _buffer.CursorRow = Math.Min(_buffer.Rows - 1, _buffer.CursorRow + dist);
+                            _buffer.Invalidate();
+                        }
+                        break;
+                    case 'g': // TBC - Tab Clear
+                        if (!isPrivate)
+                        {
+                            if (argCount > 0 && validArgs[0] == 3)
+                            {
+                                _buffer.ClearAllTabStops();
+                            }
+                            else
+                            {
+                                _buffer.ClearTabStopAtCursor();
+                            }
+
                             _buffer.Invalidate();
                         }
                         break;

--- a/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
@@ -135,7 +135,7 @@ namespace NovaTerminal.Core
 
                 _restoreMainCursorOnAltExit = false;
                 SwitchToMainScreen(restoreSavedCursorIfArmed: false);
-                // _tabs.Clear(); // tabs not implemented yet
+                ResetTabStopsToDefaultsNoLock();
             }
             finally
             {

--- a/src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs
@@ -136,6 +136,7 @@ namespace NovaTerminal.Core
 
                 Cols = newCols;
                 Rows = newRows;
+                ResizeTabStopsNoLock(oldCols, newCols);
                 RecomputeScrollbackBudgetForCurrentWidth();
 
                 if (_isAltScreen)

--- a/src/NovaTerminal.VT/TerminalBuffer.TabStops.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.TabStops.cs
@@ -1,0 +1,161 @@
+namespace NovaTerminal.Core
+{
+    public partial class TerminalBuffer
+    {
+        private static bool[] CreateDefaultTabStops(int cols)
+        {
+            var stops = new bool[Math.Max(0, cols)];
+            for (int col = 0; col < stops.Length; col++)
+            {
+                stops[col] = IsDefaultTabStopColumn(col);
+            }
+
+            return stops;
+        }
+
+        private static bool IsDefaultTabStopColumn(int col)
+        {
+            return col > 0 && (col % 8) == 0;
+        }
+
+        private void ResetTabStopsToDefaultsNoLock()
+        {
+            _tabStops = CreateDefaultTabStops(Cols);
+        }
+
+        private void ResizeTabStopsNoLock(int oldCols, int newCols)
+        {
+            if (newCols == oldCols)
+            {
+                return;
+            }
+
+            var resized = new bool[Math.Max(0, newCols)];
+            int sharedCols = System.Math.Min(oldCols, newCols);
+            for (int col = 0; col < sharedCols; col++)
+            {
+                resized[col] = col < _tabStops.Length && _tabStops[col];
+            }
+
+            for (int col = sharedCols; col < resized.Length; col++)
+            {
+                resized[col] = IsDefaultTabStopColumn(col);
+            }
+
+            _tabStops = resized;
+        }
+
+        private int FindNextTabStopNoLock(int startExclusive)
+        {
+            for (int col = System.Math.Max(0, startExclusive + 1); col < _tabStops.Length; col++)
+            {
+                if (_tabStops[col])
+                {
+                    return col;
+                }
+            }
+
+            return Cols > 0 ? Cols - 1 : 0;
+        }
+
+        private int FindPreviousTabStopNoLock(int startExclusive)
+        {
+            for (int col = System.Math.Min(startExclusive - 1, _tabStops.Length - 1); col >= 0; col--)
+            {
+                if (_tabStops[col])
+                {
+                    return col;
+                }
+            }
+
+            return 0;
+        }
+
+        public void HorizontalTab(int count = 1)
+        {
+            bool lockTaken = EnterWriteLockIfNeeded();
+            try
+            {
+                int remaining = System.Math.Max(1, count);
+                int col = System.Math.Clamp(_cursorCol, 0, System.Math.Max(0, Cols - 1));
+                while (remaining-- > 0)
+                {
+                    col = FindNextTabStopNoLock(col);
+                }
+
+                _cursorCol = col;
+                _isPendingWrap = false;
+            }
+            finally
+            {
+                ExitWriteLockIfNeeded(Lock, lockTaken);
+            }
+        }
+
+        public void BackwardTab(int count = 1)
+        {
+            bool lockTaken = EnterWriteLockIfNeeded();
+            try
+            {
+                int remaining = System.Math.Max(1, count);
+                int col = System.Math.Clamp(_cursorCol, 0, System.Math.Max(0, Cols - 1));
+                while (remaining-- > 0)
+                {
+                    col = FindPreviousTabStopNoLock(col);
+                }
+
+                _cursorCol = col;
+                _isPendingWrap = false;
+            }
+            finally
+            {
+                ExitWriteLockIfNeeded(Lock, lockTaken);
+            }
+        }
+
+        public void SetTabStopAtCursor()
+        {
+            bool lockTaken = EnterWriteLockIfNeeded();
+            try
+            {
+                if (_cursorCol >= 0 && _cursorCol < _tabStops.Length)
+                {
+                    _tabStops[_cursorCol] = true;
+                }
+            }
+            finally
+            {
+                ExitWriteLockIfNeeded(Lock, lockTaken);
+            }
+        }
+
+        public void ClearTabStopAtCursor()
+        {
+            bool lockTaken = EnterWriteLockIfNeeded();
+            try
+            {
+                if (_cursorCol >= 0 && _cursorCol < _tabStops.Length)
+                {
+                    _tabStops[_cursorCol] = false;
+                }
+            }
+            finally
+            {
+                ExitWriteLockIfNeeded(Lock, lockTaken);
+            }
+        }
+
+        public void ClearAllTabStops()
+        {
+            bool lockTaken = EnterWriteLockIfNeeded();
+            try
+            {
+                System.Array.Clear(_tabStops, 0, _tabStops.Length);
+            }
+            finally
+            {
+                ExitWriteLockIfNeeded(Lock, lockTaken);
+            }
+        }
+    }
+}

--- a/src/NovaTerminal.VT/TerminalBuffer.WritePath.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.WritePath.cs
@@ -109,9 +109,7 @@ namespace NovaTerminal.Core
             }
             else if (c == '\t')
             {
-                _isPendingWrap = false;
-                int spaces = 4 - (_cursorCol % 4);
-                for (int i = 0; i < spaces; i++) WriteContentCore(" ");
+                HorizontalTab();
             }
         }
 

--- a/src/NovaTerminal.VT/TerminalBuffer.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.cs
@@ -14,6 +14,7 @@ namespace NovaTerminal.Core
         private readonly SavedCursorStates _savedCursors = new();
         private readonly SavedCursorStates _screenCursorStates = new();
         private bool _restoreMainCursorOnAltExit;
+        private bool[] _tabStops;
         // Active viewport - what ConPTY writes to (fixed size)
         private TerminalRow[] _viewport;
 
@@ -135,6 +136,7 @@ namespace NovaTerminal.Core
         {
             Cols = cols;
             Rows = rows;
+            _tabStops = CreateDefaultTabStops(cols);
             ScrollBottom = rows - 1;  // Initialize scrolling region to full screen
             _maxScrollbackBytes = ComputeScrollbackBudgetBytes(cols, _maxHistory);
 

--- a/tests/NovaTerminal.Tests/TabSystemTests.cs
+++ b/tests/NovaTerminal.Tests/TabSystemTests.cs
@@ -1,0 +1,101 @@
+using System.Linq;
+using NovaTerminal.Core;
+
+namespace NovaTerminal.Tests;
+
+public sealed class TabSystemTests
+{
+    [Fact]
+    public void Ht_UsesDefaultEightColumnStops()
+    {
+        var buffer = new TerminalBuffer(32, 4);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("\t");
+
+        Assert.Equal(8, buffer.CursorCol);
+        Assert.Equal(0, buffer.CursorRow);
+    }
+
+    [Fact]
+    public void Cht_AdvancesAcrossDefaultTabStops()
+    {
+        var buffer = new TerminalBuffer(32, 4);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("\x1b[2I");
+
+        Assert.Equal(16, buffer.CursorCol);
+        Assert.Equal(0, buffer.CursorRow);
+    }
+
+    [Fact]
+    public void Cbt_MovesBackToPreviousDefaultTabStops()
+    {
+        var buffer = new TerminalBuffer(32, 4);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("\x1b[3I");
+        parser.Process("\x1b[2Z");
+
+        Assert.Equal(8, buffer.CursorCol);
+        Assert.Equal(0, buffer.CursorRow);
+    }
+
+    [Fact]
+    public void EscH_SetsCustomTabStopUsedByHt()
+    {
+        var buffer = new TerminalBuffer(32, 4);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("\x1b[6G");
+        parser.Process("\x1bH");
+        parser.Process("\r");
+        parser.Process("\t");
+
+        Assert.Equal(5, buffer.CursorCol);
+        Assert.Equal(0, buffer.CursorRow);
+    }
+
+    [Fact]
+    public void Csi0g_ClearsCurrentTabStop()
+    {
+        var buffer = new TerminalBuffer(32, 4);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("\x1b[6G");
+        parser.Process("\x1bH");
+        parser.Process("\x1b[0g");
+        parser.Process("\r");
+        parser.Process("\t");
+
+        Assert.Equal(8, buffer.CursorCol);
+        Assert.Equal(0, buffer.CursorRow);
+    }
+
+    [Fact]
+    public void Csi3g_ClearsAllTabStops_AndHtClampsToRightMargin()
+    {
+        var buffer = new TerminalBuffer(20, 4);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("\x1b[3g");
+        parser.Process("\t");
+
+        Assert.Equal(19, buffer.CursorCol);
+        Assert.Equal(0, buffer.CursorRow);
+    }
+
+    [Fact]
+    public void Ht_WithoutFurtherStops_ClampsToRightMargin()
+    {
+        var buffer = new TerminalBuffer(20, 4);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("\x1b[18G");
+        parser.Process("\t");
+
+        Assert.Equal(19, buffer.CursorCol);
+        Assert.Equal(0, buffer.CursorRow);
+    }
+}


### PR DESCRIPTION
## Summary
- implement VT tab-stop storage and default 8-column initialization in TerminalBuffer
- add HT, CHT, CBT, HTS (ESC H), and TBC (CSI g) handling without changing unrelated cursor or rendering paths
- add focused tab-system tests and update the VT coverage matrix for the remaining documented deviations

## Test Plan
- dotnet test tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj --filter FullyQualifiedName~TabSystemTests
- dotnet test tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj --filter "FullyQualifiedName~TabSystemTests|FullyQualifiedName~AnsiParserHardeningTests|FullyQualifiedName~CursorPositioningCompletionTests|FullyQualifiedName~PendingWrapTests|FullyQualifiedName~DecModeTests|FullyQualifiedName~ScrollAndWrapCorrectnessTests"
- dotnet test tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj
