### PR TITLE
[codex] Add VT conformance tooling

### DIFF
--- a/.github/workflows/vt-conformance.yml
+++ b/.github/workflows/vt-conformance.yml
@@ -1,0 +1,53 @@
+name: VT Conformance
+
+on:
+  pull_request:
+    paths:
+      - "docs/vt_coverage_matrix.md"
+      - "docs/ghostty-gaps/vt_conformance_tooling.md"
+      - "src/NovaTerminal.Conformance/**"
+      - ".github/workflows/vt-conformance.yml"
+  push:
+    branches: [main]
+    paths:
+      - "docs/vt_coverage_matrix.md"
+      - "docs/ghostty-gaps/vt_conformance_tooling.md"
+      - "src/NovaTerminal.Conformance/**"
+      - ".github/workflows/vt-conformance.yml"
+  workflow_dispatch:
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  CONFIGURATION: Release
+
+jobs:
+  validate:
+    name: Validate VT Matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Restore conformance tool
+        run: dotnet restore src/NovaTerminal.Conformance/NovaTerminal.Conformance.csproj
+
+      - name: Build conformance tool
+        run: dotnet build src/NovaTerminal.Conformance/NovaTerminal.Conformance.csproj -c ${{ env.CONFIGURATION }} --no-restore
+
+      - name: Validate matrix and generate report
+        run: dotnet run --project src/NovaTerminal.Conformance/NovaTerminal.Conformance.csproj -c ${{ env.CONFIGURATION }} --no-build -- --validate --report artifacts/vt-conformance/vt-conformance-report.json
+
+      - name: Upload VT conformance report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vt-conformance-report
+          retention-days: 5
+          path: artifacts/vt-conformance/vt-conformance-report.json

--- a/docs/ghostty-gaps/vt_conformance_tooling.md
+++ b/docs/ghostty-gaps/vt_conformance_tooling.md
@@ -1,0 +1,77 @@
+# VT Conformance Tooling
+
+This PR adds a focused validator/report generator for `docs/vt_coverage_matrix.md`.
+
+## Command
+
+Generate a deterministic JSON report and fail on validation errors:
+
+```powershell
+dotnet run --project src/NovaTerminal.Conformance/NovaTerminal.Conformance.csproj -- --validate --report artifacts/vt-conformance/vt-conformance-report.json
+```
+
+Defaults:
+
+- repo root: current working directory
+- matrix path: `docs/vt_coverage_matrix.md`
+- output: stdout unless `--report` is provided
+
+## Report Format
+
+The tool emits a stable JSON document with:
+
+- `schemaVersion`
+- `matrixPath`
+- `matrixSha256`
+- `summary`
+- `sections`
+- `rows`
+- `errors`
+- `warnings`
+
+Each row includes:
+
+- section title
+- feature name
+- status text
+- raw evidence text
+- normalized evidence kinds
+- extracted repo-linked evidence paths
+- ownership text
+- known deviations text
+- source line number
+
+No timestamps are included, so identical matrix content produces identical report bytes.
+
+## Validation Rules
+
+Hard failures:
+
+- feature tables must have consistent markdown columns
+- feature rows must use a known status symbol
+- `✅ Supported` rows must declare automated evidence
+- linked evidence paths must exist in the repo
+- `🚫 Won’t support` rows must include a rationale
+
+Warnings:
+
+- `✅ Supported` rows that mention evidence generically but do not yet link a concrete repo path
+
+Warnings are included in the report but do not fail CI.
+
+## CI
+
+`.github/workflows/vt-conformance.yml` runs the validator on:
+
+- `docs/vt_coverage_matrix.md`
+- conformance tooling source changes
+- workflow/doc updates for this tooling
+
+It uploads the JSON report as an artifact for PR review and push runs.
+
+## Intentional Limitations
+
+- The parser only reads markdown tables that include both `Status` and `Evidence` columns.
+- The tool does not infer support from source code; the matrix remains the canonical input.
+- Ownership paths are reported verbatim and are not path-validated.
+- Generic evidence text such as `Replay` or `Unit/Replay` is accepted for `✅ Supported` rows, but reported as a warning until concrete links are added.

--- a/src/NovaTerminal.Conformance/NovaTerminal.Conformance.csproj
+++ b/src/NovaTerminal.Conformance/NovaTerminal.Conformance.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/NovaTerminal.Conformance/Program.cs
+++ b/src/NovaTerminal.Conformance/Program.cs
@@ -1,0 +1,3 @@
+using NovaTerminal.Conformance;
+
+return await VtConformanceCli.RunAsync(args);

--- a/src/NovaTerminal.Conformance/VtConformanceReportTool.cs
+++ b/src/NovaTerminal.Conformance/VtConformanceReportTool.cs
@@ -1,0 +1,636 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace NovaTerminal.Conformance;
+
+public static class VtConformanceReportTool
+{
+    private static readonly Regex InlineCodeRegex = new("`([^`]+)`", RegexOptions.Compiled);
+
+    public static VtConformanceReport Generate(string repositoryRoot, string matrixPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repositoryRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(matrixPath);
+
+        string repoRoot = Path.GetFullPath(repositoryRoot);
+        string absoluteMatrixPath = Path.GetFullPath(Path.IsPathRooted(matrixPath)
+            ? matrixPath
+            : Path.Combine(repoRoot, matrixPath));
+
+        string matrixText = File.ReadAllText(absoluteMatrixPath);
+        string relativeMatrixPath = ToRepoRelativePath(repoRoot, absoluteMatrixPath);
+
+        var rows = new List<VtConformanceRow>();
+        var sections = new List<VtConformanceSection>();
+        var errors = new List<VtConformanceIssue>();
+        var warnings = new List<VtConformanceIssue>();
+
+        ParseFeatureTables(repoRoot, relativeMatrixPath, absoluteMatrixPath, matrixText, rows, sections, errors, warnings);
+
+        ValidateRows(relativeMatrixPath, rows, errors, warnings);
+
+        var summary = BuildSummary(rows, errors.Count, warnings.Count);
+        return new VtConformanceReport(
+            SchemaVersion: 1,
+            MatrixPath: relativeMatrixPath,
+            MatrixSha256: ComputeSha256(matrixText),
+            Summary: summary,
+            Sections: sections,
+            Rows: rows,
+            Errors: errors,
+            Warnings: warnings);
+    }
+
+    public static string Serialize(VtConformanceReport report)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+        return JsonSerializer.Serialize(report, JsonOptions);
+    }
+
+    public static void WriteReport(VtConformanceReport report, string outputPath)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+        ArgumentException.ThrowIfNullOrWhiteSpace(outputPath);
+
+        string absoluteOutputPath = Path.GetFullPath(outputPath);
+        string? directory = Path.GetDirectoryName(absoluteOutputPath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        File.WriteAllText(absoluteOutputPath, Serialize(report));
+    }
+
+    public static JsonSerializerOptions JsonOptions { get; } = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+
+    private static void ParseFeatureTables(
+        string repoRoot,
+        string relativeMatrixPath,
+        string absoluteMatrixPath,
+        string matrixText,
+        List<VtConformanceRow> rows,
+        List<VtConformanceSection> sections,
+        List<VtConformanceIssue> errors,
+        List<VtConformanceIssue> warnings)
+    {
+        string normalizedText = matrixText.Replace("\r\n", "\n");
+        string[] lines = normalizedText.Split('\n');
+        string currentHeading = "Document";
+        int sectionOrder = 0;
+
+        for (int index = 0; index < lines.Length; index++)
+        {
+            string line = lines[index].TrimEnd('\r');
+            if (TryReadHeading(line, out string? heading))
+            {
+                currentHeading = heading!;
+                continue;
+            }
+
+            if (!line.StartsWith('|'))
+            {
+                continue;
+            }
+
+            int tableStart = index;
+            var tableLines = new List<(int LineNumber, string Text)>();
+            while (index < lines.Length && lines[index].TrimStart().StartsWith('|'))
+            {
+                tableLines.Add((index + 1, lines[index].TrimEnd('\r')));
+                index++;
+            }
+
+            index--;
+
+            if (tableLines.Count < 2)
+            {
+                continue;
+            }
+
+            string[] headers = SplitMarkdownRow(tableLines[0].Text);
+            if (!LooksLikeFeatureTable(headers))
+            {
+                continue;
+            }
+
+            if (!IsSeparatorRow(tableLines[1].Text))
+            {
+                errors.Add(new VtConformanceIssue(
+                    Code: "table-missing-separator",
+                    Severity: IssueSeverity.Error,
+                    Message: $"Feature table '{currentHeading}' is missing a markdown separator row.",
+                    MatrixPath: relativeMatrixPath,
+                    LineNumber: tableLines[0].LineNumber,
+                    Feature: null));
+                continue;
+            }
+
+            int statusIndex = FindColumnIndex(headers, "Status");
+            int evidenceIndex = FindColumnIndex(headers, "Evidence");
+            int ownershipIndex = FindOptionalColumnIndex(headers, "Ownership");
+            if (ownershipIndex < 0)
+            {
+                ownershipIndex = FindOptionalColumnIndex(headers, "Ownership (code)");
+            }
+
+            int notesIndex = FindOptionalColumnIndex(headers, "Known deviations");
+            if (notesIndex < 0)
+            {
+                notesIndex = FindOptionalColumnIndex(headers, "Notes");
+            }
+
+            int specIndex = FindOptionalColumnIndex(headers, "Spec / Notes");
+            if (specIndex < 0)
+            {
+                specIndex = FindOptionalColumnIndex(headers, "Notes");
+            }
+
+            var sectionRows = new List<VtConformanceRow>();
+            for (int rowIndex = 2; rowIndex < tableLines.Count; rowIndex++)
+            {
+                (int lineNumber, string text) = tableLines[rowIndex];
+                string[] cells = SplitMarkdownRow(text);
+                if (cells.Length != headers.Length)
+                {
+                    errors.Add(new VtConformanceIssue(
+                        Code: "table-column-count-mismatch",
+                        Severity: IssueSeverity.Error,
+                        Message: $"Feature table '{currentHeading}' row has {cells.Length} columns; expected {headers.Length}.",
+                        MatrixPath: relativeMatrixPath,
+                        LineNumber: lineNumber,
+                        Feature: cells.Length > 0 ? NormalizeCell(cells[0]) : null));
+                    continue;
+                }
+
+                string feature = NormalizeCell(cells[0]);
+                string status = NormalizeCell(cells[statusIndex]);
+                string evidenceText = NormalizeCell(cells[evidenceIndex]);
+                string ownership = ownershipIndex >= 0 ? NormalizeCell(cells[ownershipIndex]) : string.Empty;
+                string notes = notesIndex >= 0 ? NormalizeCell(cells[notesIndex]) : string.Empty;
+                string specOrNotes = specIndex >= 0 ? NormalizeCell(cells[specIndex]) : string.Empty;
+
+                var evidenceKinds = GetEvidenceKinds(evidenceText);
+                var evidenceLinks = ExtractEvidenceLinks(repoRoot, evidenceText);
+
+                var row = new VtConformanceRow(
+                    Section: currentHeading,
+                    Feature: feature,
+                    Status: status,
+                    SpecOrNotes: specOrNotes,
+                    EvidenceText: evidenceText,
+                    EvidenceKinds: evidenceKinds,
+                    EvidenceLinks: evidenceLinks,
+                    HasAutomatedEvidenceSignal: HasAutomatedEvidenceSignal(evidenceKinds),
+                    HasLinkedEvidence: evidenceLinks.Any(link => link.Exists),
+                    Ownership: ownership,
+                    KnownDeviations: notes,
+                    SourceLine: lineNumber);
+
+                sectionRows.Add(row);
+            }
+
+            if (sectionRows.Count == 0)
+            {
+                warnings.Add(new VtConformanceIssue(
+                    Code: "empty-feature-table",
+                    Severity: IssueSeverity.Warning,
+                    Message: $"Feature table '{currentHeading}' does not contain any parsable rows.",
+                    MatrixPath: relativeMatrixPath,
+                    LineNumber: tableLines[0].LineNumber,
+                    Feature: null));
+                continue;
+            }
+
+            sections.Add(new VtConformanceSection(
+                Order: sectionOrder++,
+                Title: currentHeading,
+                StartLine: tableStart + 1,
+                EndLine: tableLines[^1].LineNumber,
+                RowCount: sectionRows.Count));
+
+            rows.AddRange(sectionRows);
+        }
+    }
+
+    private static void ValidateRows(
+        string relativeMatrixPath,
+        List<VtConformanceRow> rows,
+        List<VtConformanceIssue> errors,
+        List<VtConformanceIssue> warnings)
+    {
+        foreach (VtConformanceRow row in rows)
+        {
+            if (!IsKnownStatus(row.Status))
+            {
+                errors.Add(new VtConformanceIssue(
+                    Code: "unknown-status",
+                    Severity: IssueSeverity.Error,
+                    Message: $"Unknown status '{row.Status}' in feature row '{row.Feature}'.",
+                    MatrixPath: relativeMatrixPath,
+                    LineNumber: row.SourceLine,
+                    Feature: row.Feature));
+                continue;
+            }
+
+            foreach (VtEvidenceLink link in row.EvidenceLinks)
+            {
+                if (!link.Exists)
+                {
+                    errors.Add(new VtConformanceIssue(
+                        Code: "evidence-path-not-found",
+                        Severity: IssueSeverity.Error,
+                        Message: $"Evidence link '{link.Path}' does not exist for '{row.Feature}'.",
+                        MatrixPath: relativeMatrixPath,
+                        LineNumber: row.SourceLine,
+                        Feature: row.Feature));
+                }
+            }
+
+            if (IsSupportedStatus(row.Status) && !row.HasAutomatedEvidenceSignal && !row.HasLinkedEvidence)
+            {
+                errors.Add(new VtConformanceIssue(
+                    Code: "supported-missing-evidence",
+                    Severity: IssueSeverity.Error,
+                    Message: $"Supported row '{row.Feature}' must declare automated evidence.",
+                    MatrixPath: relativeMatrixPath,
+                    LineNumber: row.SourceLine,
+                    Feature: row.Feature));
+            }
+
+            if (IsSupportedStatus(row.Status) && !row.EvidenceLinks.Any())
+            {
+                warnings.Add(new VtConformanceIssue(
+                    Code: "supported-evidence-not-linked",
+                    Severity: IssueSeverity.Warning,
+                    Message: $"Supported row '{row.Feature}' does not link to a concrete repo path yet.",
+                    MatrixPath: relativeMatrixPath,
+                    LineNumber: row.SourceLine,
+                    Feature: row.Feature));
+            }
+
+            if (IsWontSupportStatus(row.Status) && string.IsNullOrWhiteSpace(row.KnownDeviations))
+            {
+                errors.Add(new VtConformanceIssue(
+                    Code: "wont-support-missing-rationale",
+                    Severity: IssueSeverity.Error,
+                    Message: $"Won't-support row '{row.Feature}' must include a rationale.",
+                    MatrixPath: relativeMatrixPath,
+                    LineNumber: row.SourceLine,
+                    Feature: row.Feature));
+            }
+        }
+    }
+
+    private static VtConformanceSummary BuildSummary(IReadOnlyList<VtConformanceRow> rows, int errorCount, int warningCount)
+    {
+        return new VtConformanceSummary(
+            TotalRows: rows.Count,
+            SupportedCount: rows.Count(row => row.Status.StartsWith("✅", StringComparison.Ordinal)),
+            PartialCount: rows.Count(row => row.Status.StartsWith("⚠", StringComparison.Ordinal)),
+            ExperimentalCount: rows.Count(row => row.Status.StartsWith("🧪", StringComparison.Ordinal)),
+            NotSupportedCount: rows.Count(row => row.Status.StartsWith("❌", StringComparison.Ordinal)),
+            WontSupportCount: rows.Count(row => row.Status.StartsWith("🚫", StringComparison.Ordinal)),
+            RowsWithLinkedEvidence: rows.Count(row => row.EvidenceLinks.Any(link => link.Exists)),
+            SupportedRowsWithLinkedEvidence: rows.Count(row => row.Status.StartsWith("✅", StringComparison.Ordinal) && row.EvidenceLinks.Any(link => link.Exists)),
+            ErrorCount: errorCount,
+            WarningCount: warningCount);
+    }
+
+    private static string[] SplitMarkdownRow(string row)
+    {
+        string trimmed = row.Trim();
+        if (trimmed.StartsWith('|'))
+        {
+            trimmed = trimmed[1..];
+        }
+
+        if (trimmed.EndsWith('|'))
+        {
+            trimmed = trimmed[..^1];
+        }
+
+        return trimmed.Split('|')
+            .Select(NormalizeCell)
+            .ToArray();
+    }
+
+    private static bool LooksLikeFeatureTable(string[] headers)
+        => headers.Any(header => header.Equals("Status", StringComparison.OrdinalIgnoreCase))
+           && headers.Any(header => header.Equals("Evidence", StringComparison.OrdinalIgnoreCase));
+
+    private static bool IsSeparatorRow(string row)
+    {
+        string candidate = row.Replace("|", string.Empty).Replace(":", string.Empty).Replace("-", string.Empty).Trim();
+        return candidate.Length == 0;
+    }
+
+    private static int FindColumnIndex(string[] headers, string expectedHeader)
+    {
+        int index = FindOptionalColumnIndex(headers, expectedHeader);
+        if (index < 0)
+        {
+            throw new InvalidOperationException($"Expected column '{expectedHeader}' was not found.");
+        }
+
+        return index;
+    }
+
+    private static int FindOptionalColumnIndex(string[] headers, string expectedHeader)
+        => Array.FindIndex(headers, header => header.Equals(expectedHeader, StringComparison.OrdinalIgnoreCase));
+
+    private static string NormalizeCell(string value)
+        => value.Replace("<br>", " ", StringComparison.OrdinalIgnoreCase).Trim();
+
+    private static bool TryReadHeading(string line, out string? heading)
+    {
+        heading = null;
+        if (!line.StartsWith('#'))
+        {
+            return false;
+        }
+
+        int markerCount = 0;
+        while (markerCount < line.Length && line[markerCount] == '#')
+        {
+            markerCount++;
+        }
+
+        if (markerCount == 0 || markerCount == line.Length || line[markerCount] != ' ')
+        {
+            return false;
+        }
+
+        heading = line[(markerCount + 1)..].Trim();
+        return !string.IsNullOrWhiteSpace(heading);
+    }
+
+    private static IReadOnlyList<string> GetEvidenceKinds(string evidenceText)
+    {
+        if (string.IsNullOrWhiteSpace(evidenceText) || evidenceText == "—")
+        {
+            return Array.Empty<string>();
+        }
+
+        string normalized = evidenceText.ToLowerInvariant();
+        var kinds = new List<string>();
+
+        AddEvidenceKindIfPresent(kinds, normalized, "unit", "unit");
+        AddEvidenceKindIfPresent(kinds, normalized, "replay", "replay");
+        AddEvidenceKindIfPresent(kinds, normalized, "external", "external");
+        AddEvidenceKindIfPresent(kinds, normalized, "vttest", "external");
+        AddEvidenceKindIfPresent(kinds, normalized, "fuzz", "fuzz");
+        AddEvidenceKindIfPresent(kinds, normalized, "manual", "manual");
+        AddEvidenceKindIfPresent(kinds, normalized, "code path", "code-path");
+        AddEvidenceKindIfPresent(kinds, normalized, "planned", "planned");
+
+        return kinds
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(kind => kind, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static void AddEvidenceKindIfPresent(List<string> kinds, string normalizedEvidenceText, string probe, string kind)
+    {
+        if (normalizedEvidenceText.Contains(probe, StringComparison.Ordinal))
+        {
+            kinds.Add(kind);
+        }
+    }
+
+    private static bool HasAutomatedEvidenceSignal(IReadOnlyList<string> kinds)
+        => kinds.Contains("unit", StringComparer.Ordinal)
+           || kinds.Contains("replay", StringComparer.Ordinal)
+           || kinds.Contains("external", StringComparer.Ordinal)
+           || kinds.Contains("fuzz", StringComparer.Ordinal);
+
+    private static IReadOnlyList<VtEvidenceLink> ExtractEvidenceLinks(string repoRoot, string evidenceText)
+    {
+        if (string.IsNullOrWhiteSpace(evidenceText))
+        {
+            return Array.Empty<VtEvidenceLink>();
+        }
+
+        var links = new List<VtEvidenceLink>();
+        foreach (Match match in InlineCodeRegex.Matches(evidenceText))
+        {
+            string candidate = match.Groups[1].Value.Trim();
+            if (!LooksLikeRepositoryPath(candidate))
+            {
+                continue;
+            }
+
+            string fullPath = Path.GetFullPath(Path.Combine(repoRoot, candidate.Replace('/', Path.DirectorySeparatorChar)));
+            bool exists = File.Exists(fullPath) || Directory.Exists(fullPath);
+            links.Add(new VtEvidenceLink(
+                Path: candidate.Replace('\\', '/'),
+                Exists: exists,
+                FullPath: fullPath));
+        }
+
+        return links
+            .DistinctBy(link => link.Path, StringComparer.Ordinal)
+            .OrderBy(link => link.Path, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static bool LooksLikeRepositoryPath(string candidate)
+    {
+        if (string.IsNullOrWhiteSpace(candidate))
+        {
+            return false;
+        }
+
+        if (candidate.Contains("://", StringComparison.Ordinal)
+            || candidate.Contains("...", StringComparison.Ordinal)
+            || candidate.Contains('*', StringComparison.Ordinal)
+            || candidate.Equals("—", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return candidate.Contains('/', StringComparison.Ordinal) || candidate.Contains('\\', StringComparison.Ordinal);
+    }
+
+    private static string ComputeSha256(string text)
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes(text);
+        byte[] hash = SHA256.HashData(bytes);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    private static string ToRepoRelativePath(string repoRoot, string absolutePath)
+    {
+        string relative = Path.GetRelativePath(repoRoot, absolutePath);
+        return relative.Replace('\\', '/');
+    }
+
+    private static bool IsKnownStatus(string status)
+        => IsSupportedStatus(status)
+           || status.StartsWith("⚠", StringComparison.Ordinal)
+           || status.StartsWith("🧪", StringComparison.Ordinal)
+           || status.StartsWith("❌", StringComparison.Ordinal)
+           || IsWontSupportStatus(status);
+
+    private static bool IsSupportedStatus(string status)
+        => status.StartsWith("✅", StringComparison.Ordinal);
+
+    private static bool IsWontSupportStatus(string status)
+        => status.StartsWith("🚫", StringComparison.Ordinal);
+}
+
+public static class VtConformanceCli
+{
+    public static Task<int> RunAsync(string[] args)
+    {
+        try
+        {
+            string repoRoot = Directory.GetCurrentDirectory();
+            string matrixPath = Path.Combine("docs", "vt_coverage_matrix.md");
+            string? reportPath = null;
+            bool validate = false;
+
+            for (int index = 0; index < args.Length; index++)
+            {
+                string arg = args[index];
+                switch (arg)
+                {
+                    case "--repo-root":
+                        repoRoot = RequireValue(args, ref index, arg);
+                        break;
+                    case "--matrix":
+                        matrixPath = RequireValue(args, ref index, arg);
+                        break;
+                    case "--report":
+                        reportPath = RequireValue(args, ref index, arg);
+                        break;
+                    case "--validate":
+                        validate = true;
+                        break;
+                    case "--help":
+                    case "-h":
+                        PrintUsage();
+                        return Task.FromResult(0);
+                    default:
+                        throw new InvalidOperationException($"Unknown argument '{arg}'.");
+                }
+            }
+
+            VtConformanceReport report = VtConformanceReportTool.Generate(repoRoot, matrixPath);
+
+            if (!string.IsNullOrWhiteSpace(reportPath))
+            {
+                VtConformanceReportTool.WriteReport(report, reportPath);
+                Console.WriteLine($"Wrote VT conformance report to '{Path.GetFullPath(reportPath)}'.");
+            }
+            else
+            {
+                Console.WriteLine(VtConformanceReportTool.Serialize(report));
+            }
+
+            Console.WriteLine($"Rows: {report.Summary.TotalRows}; errors: {report.Summary.ErrorCount}; warnings: {report.Summary.WarningCount}.");
+
+            foreach (VtConformanceIssue issue in report.Errors)
+            {
+                Console.Error.WriteLine($"ERROR {issue.Code} (line {issue.LineNumber}): {issue.Message}");
+            }
+
+            foreach (VtConformanceIssue issue in report.Warnings)
+            {
+                Console.WriteLine($"WARN {issue.Code} (line {issue.LineNumber}): {issue.Message}");
+            }
+
+            return Task.FromResult(validate && report.Errors.Count > 0 ? 1 : 0);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(ex.Message);
+            PrintUsage();
+            return Task.FromResult(2);
+        }
+    }
+
+    private static string RequireValue(string[] args, ref int index, string argumentName)
+    {
+        if (index + 1 >= args.Length)
+        {
+            throw new InvalidOperationException($"Missing value for '{argumentName}'.");
+        }
+
+        index++;
+        return args[index];
+    }
+
+    private static void PrintUsage()
+    {
+        Console.WriteLine("Usage: dotnet run --project src/NovaTerminal.Conformance -- [--repo-root <path>] [--matrix <path>] [--report <path>] [--validate]");
+    }
+}
+
+public sealed record VtConformanceReport(
+    int SchemaVersion,
+    string MatrixPath,
+    string MatrixSha256,
+    VtConformanceSummary Summary,
+    IReadOnlyList<VtConformanceSection> Sections,
+    IReadOnlyList<VtConformanceRow> Rows,
+    IReadOnlyList<VtConformanceIssue> Errors,
+    IReadOnlyList<VtConformanceIssue> Warnings);
+
+public sealed record VtConformanceSummary(
+    int TotalRows,
+    int SupportedCount,
+    int PartialCount,
+    int ExperimentalCount,
+    int NotSupportedCount,
+    int WontSupportCount,
+    int RowsWithLinkedEvidence,
+    int SupportedRowsWithLinkedEvidence,
+    int ErrorCount,
+    int WarningCount);
+
+public sealed record VtConformanceSection(
+    int Order,
+    string Title,
+    int StartLine,
+    int EndLine,
+    int RowCount);
+
+public sealed record VtConformanceRow(
+    string Section,
+    string Feature,
+    string Status,
+    string SpecOrNotes,
+    string EvidenceText,
+    IReadOnlyList<string> EvidenceKinds,
+    IReadOnlyList<VtEvidenceLink> EvidenceLinks,
+    bool HasAutomatedEvidenceSignal,
+    bool HasLinkedEvidence,
+    string Ownership,
+    string KnownDeviations,
+    int SourceLine);
+
+public sealed record VtEvidenceLink(
+    string Path,
+    bool Exists,
+    string FullPath);
+
+public sealed record VtConformanceIssue(
+    string Code,
+    IssueSeverity Severity,
+    string Message,
+    string? MatrixPath,
+    int LineNumber,
+    string? Feature);
+
+public enum IssueSeverity
+{
+    Warning = 1,
+    Error = 2
+}

--- a/tests/NovaTerminal.Core.Tests/Conformance/VtConformanceToolTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Conformance/VtConformanceToolTests.cs
@@ -1,0 +1,155 @@
+using NovaTerminal.Conformance;
+
+namespace NovaTerminal.Core.Tests.Conformance;
+
+public sealed class VtConformanceToolTests
+{
+    [Fact]
+    public void Generate_ParsesFeatureTablesAndProducesDeterministicJson()
+    {
+        using var repo = new TemporaryRepo();
+        repo.WriteFile("tests/NovaTerminal.Tests/ParserTests.cs", "// parser tests");
+        repo.WriteFile("tests/NovaTerminal.Tests/ReplayTests/CursorTests.cs", "// replay tests");
+        repo.WriteFile("docs/vt_coverage_matrix.md", """
+# VT Conformance Matrix
+
+## 1) Parsing
+
+| Feature / Sequence | Spec / Notes | Status | Evidence | Ownership (code) | Known deviations |
+|---|---|---:|---|---|---|
+| CSI parser | Basic | ✅ Supported | Unit: `tests/NovaTerminal.Tests/ParserTests.cs` | `Core/AnsiParser.cs` | |
+| Cursor move | Movement | ⚠ Partial | Replay: `tests/NovaTerminal.Tests/ReplayTests/CursorTests.cs` | `Core/AnsiParser.cs` | Edge case |
+""");
+
+        VtConformanceReport report = VtConformanceReportTool.Generate(repo.RootPath, Path.Combine(repo.RootPath, "docs", "vt_coverage_matrix.md"));
+        string json1 = VtConformanceReportTool.Serialize(report);
+        string json2 = VtConformanceReportTool.Serialize(report);
+
+        Assert.Equal(json1, json2);
+        Assert.Equal(2, report.Summary.TotalRows);
+        Assert.Equal(1, report.Summary.SupportedCount);
+        Assert.Equal(1, report.Summary.PartialCount);
+        Assert.Single(report.Sections);
+        Assert.Equal("1) Parsing", report.Sections[0].Title);
+        Assert.Equal("CSI parser", report.Rows[0].Feature);
+        Assert.Equal("tests/NovaTerminal.Tests/ParserTests.cs", report.Rows[0].EvidenceLinks[0].Path);
+        Assert.Empty(report.Errors);
+    }
+
+    [Fact]
+    public void Generate_ReportsErrorWhenSupportedRowHasNoAutomatedEvidence()
+    {
+        using var repo = new TemporaryRepo();
+        repo.WriteFile("docs/vt_coverage_matrix.md", """
+# VT Conformance Matrix
+
+## 1) Parsing
+
+| Feature / Sequence | Spec / Notes | Status | Evidence | Ownership (code) | Known deviations |
+|---|---|---:|---|---|---|
+| CSI parser | Basic | ✅ Supported | Manual | `Core/AnsiParser.cs` | |
+""");
+
+        VtConformanceReport report = VtConformanceReportTool.Generate(repo.RootPath, Path.Combine(repo.RootPath, "docs", "vt_coverage_matrix.md"));
+
+        Assert.Contains(report.Errors, issue => issue.Code == "supported-missing-evidence");
+    }
+
+    [Fact]
+    public void Generate_WarnsWhenSupportedRowHasNoConcreteEvidenceLink()
+    {
+        using var repo = new TemporaryRepo();
+        repo.WriteFile("docs/vt_coverage_matrix.md", """
+# VT Conformance Matrix
+
+## 1) Parsing
+
+| Feature / Sequence | Spec / Notes | Status | Evidence | Ownership (code) | Known deviations |
+|---|---|---:|---|---|---|
+| CSI parser | Basic | ✅ Supported | Replay | `Core/AnsiParser.cs` | |
+""");
+
+        VtConformanceReport report = VtConformanceReportTool.Generate(repo.RootPath, Path.Combine(repo.RootPath, "docs", "vt_coverage_matrix.md"));
+
+        Assert.Empty(report.Errors);
+        Assert.Contains(report.Warnings, issue => issue.Code == "supported-evidence-not-linked");
+    }
+
+    [Fact]
+    public void Generate_ReportsErrorWhenEvidencePathDoesNotExist()
+    {
+        using var repo = new TemporaryRepo();
+        repo.WriteFile("docs/vt_coverage_matrix.md", """
+# VT Conformance Matrix
+
+## 1) Parsing
+
+| Feature / Sequence | Spec / Notes | Status | Evidence | Ownership (code) | Known deviations |
+|---|---|---:|---|---|---|
+| Cursor move | Movement | ⚠ Partial | Unit: `tests/NovaTerminal.Tests/MissingTests.cs` | `Core/AnsiParser.cs` | Edge case |
+""");
+
+        VtConformanceReport report = VtConformanceReportTool.Generate(repo.RootPath, Path.Combine(repo.RootPath, "docs", "vt_coverage_matrix.md"));
+
+        Assert.Contains(report.Errors, issue => issue.Code == "evidence-path-not-found");
+    }
+
+    [Fact]
+    public void Generate_CurrentRepositoryMatrix_HasNoValidationErrors()
+    {
+        string repoRoot = FindRepositoryRoot();
+        string matrixPath = Path.Combine(repoRoot, "docs", "vt_coverage_matrix.md");
+
+        VtConformanceReport report = VtConformanceReportTool.Generate(repoRoot, matrixPath);
+
+        Assert.Empty(report.Errors);
+        Assert.NotEmpty(report.Rows);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "docs", "vt_coverage_matrix.md")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate repository root from test output path.");
+    }
+
+    private sealed class TemporaryRepo : IDisposable
+    {
+        public TemporaryRepo()
+        {
+            RootPath = Path.Combine(Path.GetTempPath(), $"nova_conformance_{Guid.NewGuid():N}");
+            Directory.CreateDirectory(RootPath);
+        }
+
+        public string RootPath { get; }
+
+        public void WriteFile(string relativePath, string content)
+        {
+            string absolutePath = Path.Combine(RootPath, relativePath.Replace('/', Path.DirectorySeparatorChar));
+            string? directory = Path.GetDirectoryName(absolutePath);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            File.WriteAllText(absolutePath, content.Replace("\n", Environment.NewLine, StringComparison.Ordinal));
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj
+++ b/tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\NovaTerminal.Core\NovaTerminal.Core.csproj" />
+    <ProjectReference Include="..\..\src\NovaTerminal.Conformance\NovaTerminal.Conformance.csproj" />
   </ItemGroup>
 
   <Target Name="BuildRustSshNativeForTests"


### PR DESCRIPTION
## Summary
- add a standalone VT conformance CLI that parses `docs/vt_coverage_matrix.md`, validates matrix rules, and emits deterministic JSON
- add focused conformance tests plus a dedicated GitHub Actions workflow for matrix validation/report artifacts
- document the report format, enforced rules, CI wiring, and intentional limitations

## Validation
- `dotnet test -c Release --filter "Category!=Replay&Category!=RenderMetrics&Category!=PtySmoke&Category!=Stress&Category!=GoldenSharedPng"`
- `dotnet run --project src/NovaTerminal.Conformance/NovaTerminal.Conformance.csproj -c Release -- --validate --report artifacts/vt-conformance/vt-conformance-report.json`

## Notes
- the validator passes with warnings only; six existing `✅ Supported` rows still use generic evidence text without concrete repo links
- two unrelated local untracked docs were intentionally excluded from this PR
