### PR TITLE
[codex] Refresh Ghostty gap docs

### DIFF
--- a/docs/ghostty-gaps/ghostty_gap_execution_pack.md
+++ b/docs/ghostty-gaps/ghostty_gap_execution_pack.md
@@ -1,0 +1,194 @@
+# Execution Pack – Ghostty Gap Closure
+
+Each PR is independent and can be executed sequentially.
+
+---
+
+## PR1 — Parser Hardening
+
+### Goal
+Ensure parser robustness under malformed and uncommon sequences.
+
+### Tasks
+- Implement C1 7-bit translation layer
+- Define ST termination handling:
+  - ESC \\
+  - BEL
+- Define unknown sequence handling policy
+- Add malformed sequence recovery logic
+
+### Tests
+- Fuzz corpus (invalid/truncated sequences)
+- Replay tests with broken input streams
+
+### Done Criteria
+- No crashes on malformed input
+- Parser behavior deterministic and documented
+
+---
+
+## PR2 — Cursor Positioning Completion
+
+### Goal
+Fix all cursor positioning inconsistencies.
+
+### Tasks
+- Audit CUP/HVP default parameter behavior
+- Implement HPA/VPA/HPR/VPR correctly
+- Handle origin mode interactions
+
+### Tests
+- Unit tests for:
+  - missing params
+  - zero params
+  - out-of-range values
+
+### Done Criteria
+- Cursor positioning consistent across all cases
+
+---
+
+## PR3 — Scroll & Wrap Correctness
+
+### Goal
+Make full-screen TUIs stable.
+
+### Tasks
+- Implement DECSTBM fully
+- Fix IND / RI behavior
+- Fix wraparound (DECAWM)
+  - wide glyph at edge
+  - combining marks at boundary
+
+### Tests
+- Replay tests:
+  - vim-like redraw
+  - scrolling regions
+  - reverse index cases
+
+### Done Criteria
+- No visual corruption in TUIs
+
+---
+
+## PR4 — Alternate Screen
+
+### Goal
+Make alt-screen transitions correct and deterministic.
+
+### Tasks
+- Implement ?47 / ?1047 / ?1049
+- Save/restore cursor and attributes
+- Define scrollback behavior
+
+### Tests
+- Replay:
+  - shell → app → shell
+  - nested alt-screen transitions
+
+### Done Criteria
+- Stable alt-screen switching
+
+---
+
+## PR5 — Input Modes
+
+### Goal
+Fix interaction inconsistencies.
+
+### Tasks
+- Implement bracketed paste
+- Implement mouse protocols:
+  - 1000 / 1002 / 1003 / 1006
+- Implement application cursor keys
+- Implement focus reporting
+
+### Tests
+- Integration tests where possible
+- App-path verification (vim/tmux)
+
+### Done Criteria
+- No broken input behavior
+
+---
+
+## PR6 — Tab System
+
+### Goal
+Complete tab handling.
+
+### Tasks
+- Implement HT / CHT / CBT
+- Tab stop storage
+- ESC H (set tab stop)
+- CSI g (clear tab stops)
+
+### Tests
+- Replay:
+  - aligned text output
+  - tab-heavy CLI output
+
+### Done Criteria
+- Tabs behave like xterm
+
+---
+
+## PR7 — Unicode Width Model v2
+
+### Goal
+Improve grapheme correctness.
+
+### Tasks
+- Separate:
+  - storage unit
+  - render cluster
+  - cursor unit
+- Implement grapheme-aware cursor movement
+- Improve width calculation
+
+### Tests
+- Emoji sequences
+- ZWJ families
+- Combining marks
+- Regional indicators
+
+### Done Criteria
+- No cursor drift
+- Correct rendering of complex text
+
+---
+
+## PR8 — Conformance Tooling
+
+### Goal
+Expose correctness as a product feature.
+
+### Tasks
+- Generate VT support report from matrix
+- Validate:
+  - every ✅ has evidence
+- Add CI enforcement
+
+### Optional
+- CLI:
+  novaterminal --vt-report
+
+### Done Criteria
+- Machine-readable compatibility report
+- CI enforcement active
+
+---
+
+## Execution Order
+
+PR1 → PR3 → PR4 → PR5 → PR2 → PR6 → PR7 → PR8
+
+---
+
+## Notes
+
+- Do NOT mix rendering optimization with correctness fixes
+- Every change must add or update:
+  - matrix row
+  - test evidence
+- Replay tests are the primary correctness signal

--- a/docs/ghostty-gaps/nova_vs_ghostty_status.md
+++ b/docs/ghostty-gaps/nova_vs_ghostty_status.md
@@ -1,0 +1,120 @@
+NovaTerminal vs Ghostty --- refreshed status
+------------------------------------------
+
+### The short version
+
+-   **Core VT correctness**: NovaTerminal has closed most of the high-impact gaps (parser recovery, scroll/margins, alt-screen, input modes, tabs).
+-   **Unicode behavior**: now competitive thanks to a shared width model across storage + renderer.
+-   **Verification story**: NovaTerminal is now ahead with an auditable matrix + CI validation.
+-   **Remaining gaps**: some sequence families still **⚠ Partial** (e.g., full directional cursor family, OSC 1337 coverage breadth, deeper Unicode conformance tables).
+
+* * * * *
+
+### Where NovaTerminal clearly improved
+
+**1) Parser robustness (PR1)**
+
+-   Deterministic recovery from malformed ESC/CSI/OSC.
+-   No more "print junk on error" class of bugs.
+-   Evidence-backed and fuzz/regression covered.
+
+**2) Scrolling, margins, wrap (PR3)**
+
+-   Correct DECSTBM handling (including invalid-region preservation).
+-   IND/RI scoped to active margins.
+-   Right-edge + wide glyph + combining behavior fixed.
+
+**3) Alternate screen (PR4)**
+
+-   Clean separation of main vs alt live state.
+-   Correct semantics for `?47`, `?1047`, `?1049`.
+-   Deterministic shell → app → shell transitions.
+
+**4) Input modes (PR5)**
+
+-   Unified encoder for keys, paste, focus, mouse.
+-   Bracketed paste (`?2004`), focus (`?1004`), app cursor (`?1`) behave consistently.
+-   Modern mouse (SGR 1006) solid.
+
+**5) Cursor positioning (PR2)**
+
+-   Correct defaults (omitted/0 → 1) for CUP/HVP/HPA/VPA/HPR/VPR.
+-   Consistent clamping + DECOM interactions.
+
+**6) Tabs (PR6)**
+
+-   Real tab-stop model (8-col defaults).
+-   HT/CHT/CBT/HTS/TBC implemented.
+-   Deterministic reset + resize behavior.
+
+**7) Unicode width model (PR7)**
+
+-   **Single shared classifier** for buffer + renderer (no drift).
+-   Correct handling for ZWJ families, emoji modifiers, RI flags, VS15/VS16.
+-   Backspace operates on grapheme start, not continuation cells.
+
+**8) Conformance tooling (PR8 + PR8.1)**
+
+-   Machine-readable JSON report with SHA and row-level metadata.
+-   CI validation rules (no unsupported "✅").
+-   **0 errors / 0 warnings** after evidence tightening.
+
+* * * * *
+
+### Where Ghostty still likely leads
+
+**Breadth and maturity**
+
+-   Wider long-tail coverage of obscure CSI/OSC variants.
+-   More exhaustive Unicode conformance (pinned tables, edge scripts).
+
+**Deep compatibility polish**
+
+-   Fewer corner-case deviations across mixed sequences and legacy apps.
+-   Likely stronger coverage for rarely used modes and historical quirks.
+
+**Ecosystem surface**
+
+-   Embeddable core (`libghostty`) and broader integration story.
+
+* * * * *
+
+### Where NovaTerminal now leads
+
+**1) Auditable correctness**
+
+-   Every "✅ Supported" has **traceable evidence** (tests/replays/paths).
+-   Violations are caught automatically in CI.
+
+**2) Deterministic validation**
+
+-   Replay + snapshot model + matrix → **provable behavior**, not claims.
+
+**3) Storage/renderer alignment**
+
+-   Shared width model removes a classic class of terminal bugs.
+
+**4) Engineering clarity**
+
+-   Explicit deviations documented per row.
+-   Easier to reason about, maintain, and extend.
+
+* * * * *
+
+### Honest remaining gaps (from the matrix)
+
+-   Some sequence families still **⚠ Partial** (e.g., full CUU/CUD/CUF/CUB coverage).
+-   **OSC 1337**: parser support exists, but automated evidence breadth is limited.
+-   Unicode:
+    -   No pinned UAX #11 / #29 tables yet.
+    -   No guaranteed retroactive reflow for late width-changing selectors.
+-   Legacy mouse modes beyond SGR 1006 remain partial.
+
+* * * * *
+
+### Bottom line
+
+-   **Ghostty**: broader, mature, battle-tested compatibility.
+-   **NovaTerminal**: now *structurally correct*, test-driven, and **provably verifiable**.
+
+That's a credible position---and a strong foundation to surpass on correctness over time.

--- a/docs/vt_coverage_matrix.md
+++ b/docs/vt_coverage_matrix.md
@@ -66,7 +66,7 @@ It is designed to be:
 
 | Feature / CSI | Notes | Status | Evidence | Ownership | Known deviations |
 |---|---|---:|---|---|---|
-| CUU/CUD/CUF/CUB (A/B/C/D) | Cursor up/down/forward/back | ✅ Supported | Replay: `...` | Parser+Buffer | |
+| CUU/CUD/CUF/CUB (A/B/C/D) | Cursor up/down/forward/back | ⚠ Partial | Unit: `tests/NovaTerminal.Tests/PendingWrapTests.cs` | Parser+Buffer | Explicit CUF movement is covered via pending-wrap reset; dedicated CUU/CUD/CUB targeted coverage is still missing |
 | CUP / HVP (H/f) | Positioning, default params | ✅ Supported | Unit + Replay: `tests/NovaTerminal.Tests/CursorPositioningCompletionTests.cs`, `tests/NovaTerminal.Tests/ReplayTests/RegressionTests.cs` | Parser+Buffer | |
 | CHA/CPL/CNL (G/F/E) | Horizontal absolute / prev/next line | ⚠ Partial | Replay | Parser+Buffer | |
 | CHT (I) | Cursor forward tabulation | ✅ Supported | Unit: `tests/NovaTerminal.Tests/TabSystemTests.cs` | Parser+Buffer | |
@@ -80,8 +80,8 @@ It is designed to be:
 
 | Feature / CSI | Notes | Status | Evidence | Ownership | Known deviations |
 |---|---|---:|---|---|---|
-| ED (J) | 0/1/2 erase display | ✅ Supported | Replay | Parser+Buffer | |
-| EL (K) | 0/1/2 erase line | ✅ Supported | Replay | Parser+Buffer | |
+| ED (J) | 0/1/2 erase display | ✅ Supported | Replay: `tests/NovaTerminal.Tests/ReplayTests/RegressionTests.cs`, `tests/NovaTerminal.Tests/Fixtures/Replay/vttest_cursor.rec`; Unit: `tests/NovaTerminal.Core.Tests/Ssh/NativeSshTerminalParityTests.cs` | Parser+Buffer | |
+| EL (K) | 0/1/2 erase line | ✅ Supported | Unit: `tests/NovaTerminal.Core.Tests/Ssh/NativeSshTerminalParityTests.cs` | Parser+Buffer | |
 | ICH ( @ ) | Insert chars | ⚠ Partial | Code path | Parser+Buffer | Implemented in parser/buffer; needs targeted unit coverage |
 | DCH (P) | Delete chars | ⚠ Partial | Code path | Parser+Buffer | Implemented in parser/buffer; needs targeted unit coverage |
 | IL (L) / DL (M) | Insert/delete lines | ⚠ Partial | Replay | Buffer | Scroll region interactions |
@@ -106,7 +106,7 @@ It is designed to be:
 | Mode | CSI | Notes | Status | Evidence | Ownership | Known deviations |
 |---|---|---|---:|---|---|---|
 | Alternate screen | ?1049 / ?47 / ?1047 | Switch + save/restore cursor | ⚠ Partial | Unit: `tests/NovaTerminal.Tests/AlternateScreenTests.cs`; Replay: `tests/NovaTerminal.Tests/ReplayTests/AlternateScreenReplayTests.cs`, `tests/NovaTerminal.Tests/ReplayTests/NativeSshReplayParityTests.cs` | Buffer | Main scrollback is preserved and alt-screen output never enters scrollback. `?47` reuses the existing alternate buffer/state without clearing; `?1047` and `?1049` clear and home the alternate buffer on entry. Nested/redundant alt-screen enters are treated as no-op, and a `?1049` save is consumed by the first exit from alt-screen regardless of whether that exit uses `?47l`, `?1047l`, or `?1049l`. |
-| Show cursor | ?25 | | ✅ Supported | Unit/Replay | Buffer+Renderer | |
+| Show cursor | ?25 | | ✅ Supported | Unit: `tests/NovaTerminal.Tests/DecModeTests.cs`; Replay: `tests/NovaTerminal.Tests/ReplayTests/ReplayV2Tests.cs` | Buffer+Renderer | |
 | Application cursor keys | ?1 | Impacts input mapping | ⚠ Partial | Unit/Code: `ReplayV2Tests`, app input paths | Parser+Input | Parser/UI wiring exists; needs targeted key-mapping tests |
 | Focus event reporting | ?1004 | Emits `CSI I` / `CSI O` on focus transitions | ⚠ Partial | Unit/Code: `DecModeTests`, `TerminalView` | Parser+Input | Mode flag tested; focus emission covered by app path, not headless UI test |
 | Bracketed paste | ?2004 | Input feature | ⚠ Partial | Unit | Input layer | |
@@ -145,7 +145,7 @@ It is designed to be:
 | OSC 52 | Clipboard | ❌ Not supported | — | App/UI | |
 | OSC 8 | Hyperlinks | ✅ Supported | Unit: `tests/NovaTerminal.Tests/OscUxTests.cs` | Parser+Renderer+UI | Ctrl-click open path is app-level |
 | OSC 133 | Shell integration lifecycle | ⚠ Partial | Unit: `tests/NovaTerminal.Tests/OscShellIntegrationTests.cs` | Parser+Command Assist | Supports A/B/C/D markers; broader semantic prompt extensions not audited |
-| OSC 1337 | iTerm2 inline images | ✅ Supported | Replay/Manual | Parser+Renderer | |
+| OSC 1337 | iTerm2 inline images | ⚠ Partial | Manual: `docs/qa/QA_GRAPHICS.md` | Parser+Renderer | Parser support exists, but targeted automated replay/unit coverage for OSC 1337 is still missing |
 | OSC 1339 | Windows conpty tunnel | 🧪 Experimental | Manual | Parser+Win | |
 
 ---
@@ -154,7 +154,7 @@ It is designed to be:
 
 | Feature | Notes | Status | Evidence | Ownership | Known deviations |
 |---|---|---:|---|---|---|
-| Kitty graphics protocol | APC / OSC forms | ✅ Supported | Manual/Replay | Parser+Renderer | |
+| Kitty graphics protocol | APC / OSC forms | ✅ Supported | Unit: `tests/NovaTerminal.Tests/GraphicsTests.cs`, `tests/NovaTerminal.Tests/AnsiParserHardeningTests.cs` | Parser+Renderer | |
 | Placement, z-index, scrolling | Complex interactions | ⚠ Partial | Manual | Buffer+Renderer | |
 
 ---

--- a/docs/vt_ghostty_gap_matrix.md
+++ b/docs/vt_ghostty_gap_matrix.md
@@ -1,0 +1,80 @@
+# NovaTerminal VT vs Ghostty Gap Matrix
+
+Date: 2026-04-19
+
+Purpose: identify what NovaTerminal already has, where `docs/vt_coverage_matrix.md` is stale, and which Ghostty-level VT features are real gaps.
+
+Sources:
+- Nova local evidence: `src/NovaTerminal.VT/AnsiParser.cs`, `src/NovaTerminal.VT/ModeState.cs`, `src/NovaTerminal.App/Core/TerminalView.cs`, `tests/NovaTerminal.Tests/OscUxTests.cs`, `tests/NovaTerminal.Tests/DecModeTests.cs`, `tests/NovaTerminal.Tests/SgrAttributeTests.cs`, `docs/vt_coverage_matrix.md`
+- Ghostty docs: <https://ghostty.org/docs/help/terminfo>, <https://ghostty.org/docs/vt/reference>, <https://ghostty.org/docs/vt/external>, <https://ghostty.org/docs/vt/osc/52>, <https://ghostty.org/docs/install/release-notes/1-3-0>
+
+## Legend
+
+| Label | Meaning |
+|---|---|
+| Already have | Implemented in code and at least partially exercised by tests or app wiring. |
+| Doc stale | Current code is ahead of `docs/vt_coverage_matrix.md`. |
+| Partial | Implemented, but not Ghostty-level complete or not fully verified. |
+| Real gap | No meaningful implementation found in the current tree. |
+
+Priority:
+- P0: high impact for modern TUI/app compatibility or feature discovery.
+- P1: visible parity gap for power users and modern shells.
+- P2: useful but less likely to block daily workflows.
+
+## Executive Summary
+
+NovaTerminal is stronger than its current conformance matrix says. The matrix is stale for OSC 7, OSC 8, application cursor keys, DECOM, ICH/DCH/ECH, focus reporting, cursor style, and Unicode/grapheme support.
+
+The biggest real Ghostty parity gaps are not basic VT rendering. They are feature discovery, modern keyboard reporting, richer OSC support, complete shell-integration semantics, styled underline/color handling, and systematic conformance documentation.
+
+## Gap Matrix
+
+| Area | Nova state | Ghostty-level target | Classification | Priority | Evidence / notes |
+|---|---|---|---|---:|---|
+| TERM / terminfo advertisement | Forces `TERM=xterm-256color` with `COLORTERM=truecolor`. | Ghostty uses `xterm-ghostty` with a terminfo entry to advertise advanced capabilities. | Real gap | P0 | `src/NovaTerminal.App/native/src/lib.rs`, `src/NovaTerminal.Core/Ssh/Native/NativeSshConnectionOptions.cs`; Ghostty terminfo docs say fallback `xterm-256color` loses advanced features such as styled underlines. |
+| Canonical VT matrix accuracy | Several rows say not supported while code supports them. | Source-of-truth matrix should match implementation and evidence. | Doc stale | P0 | `docs/vt_coverage_matrix.md` conflicts with `AnsiParser.cs`, `ModeState.cs`, `OscUxTests.cs`, and `DecModeTests.cs`. |
+| Application cursor keys | Parser tracks `?1`, UI emits SS3 arrow sequences. | Correct DECCKM behavior. | Already have / doc stale | P0 | `ModeState.IsApplicationCursorKeys`, `TerminalView` and `MainWindow` key paths. |
+| Focus events | Parser tracks `?1004`; view sends `CSI I` / `CSI O` on focus transitions. | FocusIn/FocusOut reporting. | Already have / doc stale | P1 | `AnsiParser.cs`, `TerminalView.OnGotFocus`, `TerminalView.OnLostFocus`, `DecModeTests.FocusEventReporting_SetsModeFlag`. |
+| Bracketed paste | Parser tracks `?2004`; paste helper wraps content. | Standard bracketed paste behavior. | Already have | P1 | `TerminalInputSender.SendBracketedPaste`, `DecModeTests`, `TerminalInputSenderTests`. |
+| Mouse reporting | Supports X10/button/any/SGR mode flags and SGR/X10 event encoding. | Full xterm/SGR behavior, including any-event hover semantics and modifier precision. | Partial | P1 | Current `TerminalView.OnPointerMoved` only sends motion when a button is pressed, even if `?1003` is set. |
+| Kitty keyboard protocol / `CSI u` | No implementation found. | Ghostty supports modern keyboard protocols through its VT/input stack. | Real gap | P0 | No local matches for Kitty keyboard, `CSI u`, or `modifyOtherKeys`. |
+| `modifyOtherKeys` / xterm key modifier controls | Non-SGR `CSI > ... m` is intentionally ignored as non-style input. | Query/configure modified key behavior where expected by advanced apps. | Real gap | P1 | `SgrAttributeTests` guards against treating `CSI > ... m` as SGR, but there is no input-protocol implementation. |
+| Cursor style `DECSCUSR` | Parser maps `CSI Ps SP q`; renderer supports block/beam/underline and blink state. | Cursor style and blink control. | Already have / doc stale | P1 | `AnsiParser.ApplyCursorStyle`, `OscUxTests.CsiQ_UpdatesCursorStyleMode`, render snapshot cursor fields. |
+| Basic CSI editing | ICH, DCH, ECH, IL, DL exist in parser/buffer. | Ghostty reference includes ICH/DCH/ECH/IL/DL. | Already have / doc stale | P1 | `AnsiParser.cs` handles `@`, `P`, `X`, `L`, `M`; matrix still marks ICH/DCH/ECH unsupported. |
+| Tab controls | HT exists; CHT/CBT/TBC/custom tab stops not implemented in matrix. | Ghostty reference lists CHT, CBT, TBC. | Real gap | P1 | Matrix lists CHT/CBT/TBC as unsupported; no local tab-stop state found. |
+| Horizontal margins `DECSLRM` | No implementation found. | Ghostty reference lists `CSI Pl ; Pr s`. | Real gap | P2 | No local state for left/right margins. |
+| Repeat previous char `REP` | No implementation found. | Ghostty reference lists `CSI Pn b`. | Real gap | P2 | No local handler for CSI `b`. |
+| OSC 0/2 title | Parser emits title callback. | Change window title/icon title. | Already have | P1 | `AnsiParser.HandleOsc`. |
+| OSC 7 current directory | Parser emits working-directory callback; Command Assist docs rely on it. | Change current working directory metadata. | Already have / doc stale | P0 | `OscUxTests.Osc7_ReportsWorkingDirectory`; matrix still marks OSC 7 unsupported. |
+| OSC 8 hyperlinks | Parser stores hyperlink metadata and UI ctrl-click opens absolute URI. | Hyperlinks. | Already have / doc stale | P1 | `OscUxTests.Osc8_Hyperlink_IsAttachedToWrittenCells`, `TerminalView` ctrl-click path; matrix still marks unsupported. |
+| OSC 52 clipboard | No implementation found. | Ghostty supports query/change clipboard data with `OSC 52`. | Real gap | P0 | No local `OSC 52`; Ghostty has dedicated OSC 52 docs. |
+| OSC 4 / 10-19 / 104 / 110-119 colors | No implementation found. | Query/change/reset palette and dynamic colors. | Real gap | P1 | Ghostty VT reference lists palette, special, dynamic, and reset color OSCs. |
+| OSC 21 Kitty Color Protocol | No implementation found. | Query/change colors using Kitty Color Protocol. | Real gap | P2 | Ghostty external protocol docs list OSC 21 support. |
+| OSC 22 pointer shape | No implementation found. | Change pointer shape. | Real gap | P2 | Ghostty VT reference lists OSC 22. |
+| OSC 9 desktop notification and OSC 9;4 progress | No implementation found. | Notifications and progress state. | Real gap | P2 | Ghostty VT reference lists OSC 9 and 9;4. |
+| OSC 133 shell integration | Supports A/B/C/D and base64 command payload. | More complete semantic prompt behavior, click-to-move-cursor extensions, richer prompt/output regions. | Partial | P1 | `AnsiParser.cs` supports basic lifecycle markers; Ghostty 1.3 notes call out more complete OSC 133 plus click-events and `cl=line`. |
+| Command-finished notifications | Nova can observe OSC 133 finish; no Ghostty-style notification policy found. | Notify on long-running command finish via shell integration. | Real gap | P2 | Ghostty 1.3 release notes describe notification policy built on OSC 133. |
+| SGR italic/strike/faint/blink | Parser and renderer support italic/strike/faint/blink flags. | Core styling parity. | Already have / doc stale | P1 | `SgrAttributeTests`, `TerminalDrawOperation` decoration rendering. |
+| Styled underlines | `4:x` is parsed only as underline on/off; no distinct underline style model. | Colored and styled underlines advertised by Ghostty terminfo. | Partial | P1 | `AnsiParser` consumes underline style selector but collapses it; no `UnderlineStyle` storage. |
+| Underline color `SGR 58/59` | Parameters are consumed, but color is not rendered separately. | Colored underline support. | Partial | P1 | `AnsiParser` comments say underline color is not rendered separately. |
+| Unicode graphemes and emoji | Code and tests support combining attachment, ZWJ emoji, regional indicators, HarfBuzz shaping path. | Ghostty 1.3 calls out Unicode 17 and grapheme conformance for selection, cursor movement, width. | Partial / needs audit | P1 | Nova has `GraphemeAttachmentTests`, `WidthTests`, HarfBuzz renderer; no Unicode-version conformance target is documented. |
+| Complex script rendering | HarfBuzz shaping path and golden font tests exist. | Correct Brahmic/complex scripts and grapheme clustering. | Partial / likely close | P1 | `GoldenFontPngTests` covers Arabic and Devanagari; compare against Ghostty's broader claim before marking complete. |
+| Graphics protocols | Kitty graphics, iTerm2 inline images, Sixel, and OSC 1339 tunnel exist. | Robust graphics placement, scrolling, query, and platform behavior. | Partial | P1 | `IMAGE_PROTOCOL_SUPPORT.md` is strong; matrix still marks SIXEL scrolling unsupported and Kitty placement partial. |
+| Synchronized output | Parser maps `?2026` to `BeginSync`/`EndSync`. | Synchronized output behavior. | Already have / needs matrix precision | P2 | `AnsiParser.HandleDECPrivateMode`, `SynchronizedRenderingTests`. |
+| Parser robustness / fuzzing | Matrix says partial; fuzz/stress aspirations exist. | Ghostty reports AFL++ fuzzing and robust error-path testing. | Partial | P2 | Nova has tests and replay infra, but no comparable continuous fuzz target documented as release gate. |
+
+## Recommended Order
+
+1. Update `docs/vt_coverage_matrix.md` for rows that are plainly stale: OSC 7, OSC 8, DECOM, application cursor keys, ICH/DCH/ECH, focus events, cursor style, Unicode/graphemes.
+2. Add a terminfo/capability-advertising design before adding many more protocols. Without this, apps will keep treating Nova as plain `xterm-256color`.
+3. Implement Kitty keyboard protocol / `CSI u` and decide whether to support xterm `modifyOtherKeys`.
+4. Implement secure OSC 52 with explicit policy controls. This needs UI/security design, not just parser code.
+5. Add OSC color query/reset support and styled underline/underline-color rendering.
+6. Expand OSC 133 toward semantic prompt regions and click-to-move-cursor if Command Assist will use shell structure deeply.
+
+## Notes
+
+- This document is an audit aid, not the canonical conformance source. Once rows are confirmed, move the durable status into `docs/vt_coverage_matrix.md`.
+- Do not broaden VT parsing just for Command Assist. Keep Command Assist as a separate subsystem and expose only small parser events where needed.
+- Any OSC 52 implementation should default conservative because terminal-output-to-clipboard is a security-sensitive feature.


### PR DESCRIPTION
## Summary
- add the Ghostty gap execution pack and audit/status docs to the repo
- update `docs/vt_coverage_matrix.md` to replace the last generic supported-evidence rows with concrete repo-backed evidence or downgrade where evidence is not automated yet
- keep this change docs-only with no production code or test changes

## Validation
- `dotnet run --project src/NovaTerminal.Conformance/NovaTerminal.Conformance.csproj -- --validate`

## Notes
- validator result: `55` rows, `0` errors, `0` warnings
- `CUU/CUD/CUF/CUB` and `OSC 1337` were downgraded to `⚠ Partial` because concrete automated evidence was not broad enough to keep `✅`
