### PR TITLE
[codex] fix macOS tab header inset

### DIFF
--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -63,6 +63,9 @@ namespace NovaTerminal
         private readonly ISshInteractionService _sshInteractionService;
         private readonly SshLegacyProfileMigrationService _sshLegacyMigrationService;
         private static readonly TimeSpan BellDebounceWindow = TimeSpan.FromMilliseconds(750);
+        private const double MinimumTabHeaderRightReserve = 440;
+        private const double MacOsTrafficLightReserve = 92;
+        private const double TabHeaderViewportPadding = 16;
 
         private sealed class PaneZoomState
         {
@@ -434,25 +437,37 @@ namespace NovaTerminal
                 .FirstOrDefault(s => s.Name == "PART_TabHeaderScrollViewer");
         }
 
+        internal static Thickness GetTabHeaderViewportMargin(
+            bool isMacOs,
+            double titleBarWidth,
+            double titleBarRightMargin,
+            double minimumRightReserve = MinimumTabHeaderRightReserve,
+            double macLeftReserve = MacOsTrafficLightReserve,
+            double viewportPadding = TabHeaderViewportPadding)
+        {
+            double reservedLeft = isMacOs ? macLeftReserve : 0;
+            double reservedRight = minimumRightReserve;
+
+            if (titleBarWidth > 0)
+            {
+                reservedRight = Math.Max(
+                    reservedRight,
+                    Math.Ceiling(titleBarWidth + Math.Max(0, titleBarRightMargin) + viewportPadding));
+            }
+
+            return new Thickness(reservedLeft, 0, reservedRight, 0);
+        }
+
         private void UpdateTabHeaderViewport()
         {
             var scrollViewer = FindTabHeaderScrollViewer();
             var titleBar = this.FindControl<Grid>("TitleBar");
             if (scrollViewer == null) return;
 
-            double reservedRight = 440;
-            if (titleBar != null)
-            {
-                double titleBarWidth = titleBar.Bounds.Width;
-                if (titleBarWidth > 0)
-                {
-                    reservedRight = Math.Max(
-                        reservedRight,
-                        Math.Ceiling(titleBarWidth + titleBar.Margin.Right + 16));
-                }
-            }
-
-            scrollViewer.Margin = new Thickness(0, 0, reservedRight, 0);
+            scrollViewer.Margin = GetTabHeaderViewportMargin(
+                RuntimeInformation.IsOSPlatform(OSPlatform.OSX),
+                titleBar?.Bounds.Width ?? 0,
+                titleBar?.Margin.Right ?? 0);
             scrollViewer.Height = 36;
             scrollViewer.ClipToBounds = true;
 

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -63,9 +63,9 @@ namespace NovaTerminal
         private readonly ISshInteractionService _sshInteractionService;
         private readonly SshLegacyProfileMigrationService _sshLegacyMigrationService;
         private static readonly TimeSpan BellDebounceWindow = TimeSpan.FromMilliseconds(750);
-        private const double MinimumTabHeaderRightReserve = 440;
-        private const double MacOsTrafficLightReserve = 92;
-        private const double TabHeaderViewportPadding = 16;
+        internal const double MinimumTabHeaderRightReserve = 440;
+        internal const double MacOsTrafficLightReserve = 92;
+        internal const double TabHeaderViewportPadding = 16;
 
         private sealed class PaneZoomState
         {

--- a/tests/NovaTerminal.Tests/Core/TabBehaviorTests.cs
+++ b/tests/NovaTerminal.Tests/Core/TabBehaviorTests.cs
@@ -64,7 +64,7 @@ public sealed class TabBehaviorTests
             titleBarRightMargin: 0);
 
         Assert.Equal(0, margin.Left);
-        Assert.Equal(440, margin.Right);
+        Assert.Equal(NovaTerminal.MainWindow.MinimumTabHeaderRightReserve, margin.Right);
     }
 
     [Fact]
@@ -75,8 +75,8 @@ public sealed class TabBehaviorTests
             titleBarWidth: 0,
             titleBarRightMargin: 0);
 
-        Assert.Equal(92, margin.Left);
-        Assert.Equal(440, margin.Right);
+        Assert.Equal(NovaTerminal.MainWindow.MacOsTrafficLightReserve, margin.Left);
+        Assert.Equal(NovaTerminal.MainWindow.MinimumTabHeaderRightReserve, margin.Right);
     }
 
     [Fact]
@@ -88,7 +88,10 @@ public sealed class TabBehaviorTests
             titleBarRightMargin: 140);
 
         Assert.Equal(0, margin.Left);
-        Assert.Equal(516, margin.Right);
+        double expectedRight = Math.Max(
+            NovaTerminal.MainWindow.MinimumTabHeaderRightReserve,
+            Math.Ceiling(360 + 140 + NovaTerminal.MainWindow.TabHeaderViewportPadding));
+        Assert.Equal(expectedRight, margin.Right);
     }
 
     [Fact]

--- a/tests/NovaTerminal.Tests/Core/TabBehaviorTests.cs
+++ b/tests/NovaTerminal.Tests/Core/TabBehaviorTests.cs
@@ -56,6 +56,42 @@ public sealed class TabBehaviorTests
     }
 
     [Fact]
+    public void GetTabHeaderViewportMargin_NonMac_UsesOnlyRightReservation()
+    {
+        var margin = NovaTerminal.MainWindow.GetTabHeaderViewportMargin(
+            isMacOs: false,
+            titleBarWidth: 0,
+            titleBarRightMargin: 0);
+
+        Assert.Equal(0, margin.Left);
+        Assert.Equal(440, margin.Right);
+    }
+
+    [Fact]
+    public void GetTabHeaderViewportMargin_Mac_AddsLeftReservation()
+    {
+        var margin = NovaTerminal.MainWindow.GetTabHeaderViewportMargin(
+            isMacOs: true,
+            titleBarWidth: 0,
+            titleBarRightMargin: 0);
+
+        Assert.Equal(92, margin.Left);
+        Assert.Equal(440, margin.Right);
+    }
+
+    [Fact]
+    public void GetTabHeaderViewportMargin_GrowsRightReservationToFitTitleBarActions()
+    {
+        var margin = NovaTerminal.MainWindow.GetTabHeaderViewportMargin(
+            isMacOs: false,
+            titleBarWidth: 360,
+            titleBarRightMargin: 140);
+
+        Assert.Equal(0, margin.Left);
+        Assert.Equal(516, margin.Right);
+    }
+
+    [Fact]
     public void TruncateTabLabel_TruncatesWithEllipsis()
     {
         string value = NovaTerminal.MainWindow.TruncateTabLabel("abcdefgh", 6);


### PR DESCRIPTION
## Summary
- reserve left-side tab header space on macOS so the traffic-light window controls do not overlap the first tabs
- keep the existing right-side reservation for Nova's custom title-bar actions
- add focused tests for the header viewport margin calculation

## Root Cause
The tab header viewport only reserved space on the right for Nova's title-bar controls. On macOS, the system window controls live on the left, so the first tabs could render underneath them.

## Validation
- dotnet test tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj --filter TabBehaviorTests -c Release --logger "console;verbosity=minimal"
