### PR TITLE
[codex] add MIT license and align docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ Performance PRs without metrics will be rejected.
 Feature work is welcome **only if it does not violate roadmap gates**.
 
 Before starting feature work:
-- check `ROADMAP.md`
+- check `docs/ROADMAP.md`
 - ensure Phase −1 and Phase 0 gates are respected
 
 Features that bypass correctness phases will be rejected.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Behnam Yousefi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.internal.md
+++ b/README.internal.md
@@ -37,17 +37,21 @@ Any change that weakens determinism, parity, or replayability is rejected.
 
 ## Architecture Boundaries
 
-The solution enforces a strict Directed Acyclic Graph (DAG) to prevent circular dependencies and ensure the VT core remains pure:
+The solution keeps terminal semantics isolated behind small project boundaries so the VT core remains pure and reusable:
 
-**NovaTerminal.App** (UI)  
-  ↘ **NovaTerminal.Rendering** (Skia)  
-  ↘ **NovaTerminal.Replay** (Recording)  
-  ↘ **NovaTerminal.Pty** (OS Integration)  
-  ↘ **NovaTerminal.VT** (Core State)
+- **NovaTerminal.App** owns Avalonia UI, interaction, and app composition.
+- **NovaTerminal.Core** owns shared application/domain services and orchestration outside the VT parser/buffer.
+- **NovaTerminal.VT** owns terminal state, parsing, buffer semantics, and reflow.
+- **NovaTerminal.Rendering** owns Skia-based drawing from immutable buffer snapshots.
+- **NovaTerminal.Pty** owns OS/process and stream integration.
+- **NovaTerminal.Replay** owns recording and replay infrastructure.
+
+Key constraints:
 
 - **NovaTerminal.VT** contains **no** Avalonia or SkiaSharp references.
-- **NovaTerminal.Rendering** contains **no** Avalonia references.
-- **NovaTerminal.Pty** is strictly for stream management and binary interop.
+- **NovaTerminal.Rendering** contains **no** Avalonia references and does not fix semantic bugs.
+- **NovaTerminal.Pty** is strictly for stream/process management and binary interop.
+- UI concerns stay out of the terminal core logic.
 
 ---
 
@@ -89,9 +93,9 @@ A change is acceptable only if:
 
 ## Useful Docs
 
-- `ROADMAP.md` – test-gated product roadmap
-- `MODULE_OWNERSHIP.md` – invariant ownership
-- `IMPLEMENTATION_WORK_PLAN.md` – correctness-first execution plan
+- `docs/ROADMAP.md` – test-gated product roadmap
+- `docs/MODULE_OWNERSHIP.md` – invariant ownership
+- `docs/IMPLEMENTATION_WORK_PLAN.md` – correctness-first execution plan
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ Notes:
 Under active development. Current focus and upcoming milestones are tracked
 in [`docs/ROADMAP.md`](docs/ROADMAP.md).
 
+License: [`MIT`](LICENSE).
+
 ---
 
 ### Contributing

--- a/docs/PRODUCTION_ROADMAP.md
+++ b/docs/PRODUCTION_ROADMAP.md
@@ -471,7 +471,7 @@ gantt
 ### M5.3 — Launch *(1 week)*
 
 **Tasks**:
-- [ ] Public release on GitHub (MIT or source-available license — decision deferred)
+- [ ] Public release on GitHub under the MIT license
 - [ ] Website with download links, feature highlights, replay demo
 - [ ] Announce on HackerNews, Reddit r/commandline, Twitter/X
 
@@ -548,10 +548,8 @@ These are decisions you should make *before* starting each milestone:
 
 ### Before M5
 > **Q: What license?**
-> - MIT: Maximum adoption, zero revenue protection
-> - BSL (Business Source License): Source-available, prevents competing hosted services
-> - Dual license (MIT core + proprietary enterprise features): Most flexible
-> - **Recommendation**: Defer until beta feedback clarifies whether enterprise or community is the audience. Ship beta as source-available (BSL), convert to MIT if community growth is the priority.
+> - **Decision**: MIT
+> - Rationale: prioritize broad adoption, low contribution friction, and straightforward downstream use.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a root MIT license file for the repository
- update README and internal contributor docs to reference the license and current docs paths
- align the production roadmap with the MIT license decision

## Validation
- git diff --check
- reviewed scoped docs/license diff only; no build or test run because this change is documentation and licensing only
