### PR TITLE
[codex] set release version to 0.1.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <Version>0.1.0</Version>
+    <AssemblyVersion>0.1.0.0</AssemblyVersion>
+    <FileVersion>0.1.0.0</FileVersion>
+    <InformationalVersion>0.1.0</InformationalVersion>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add central MSBuild version metadata at the repo root
- set the first public release version to 0.1.0 for app and supporting projects
- establish a single place to bump future release versions

## Validation
- git diff --check
- dotnet msbuild property queries for NovaTerminal.App, NovaTerminal.Cli, and NovaTerminal.Core confirming Version=0.1.0
