### PR TITLE
[codex] rebalance CI and add release publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["windows-latest","ubuntu-latest"]') }}
+        os: [windows-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -214,7 +214,7 @@ jobs:
   pty_smoke_tests:
     name: PTY Smoke Tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 20
     needs: [build_and_unit_tests, build_native]
     strategy:
@@ -290,7 +290,7 @@ jobs:
   render_metrics_tests:
     name: Render Metrics (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 20
     needs: [build_and_unit_tests, build_native]
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,8 @@ jobs:
         run: |
           cd src/NovaTerminal.App/native
           cargo build --release
-          # Binary stays in target/release/rusty_pty.dll
+          cd rusty_ssh
+          cargo build --release
 
       - name: Build Rust (Linux)
         if: matrix.os == 'ubuntu-latest'
@@ -98,13 +99,16 @@ jobs:
           cargo build --release
           mkdir -p ../native/target_linux/release
           cp target/release/librusty_pty.so ../native/target_linux/release/
+          cd rusty_ssh
+          cargo build --release
 
       - name: Build Rust (macOS)
         if: matrix.os == 'macos-latest'
         run: |
           cd src/NovaTerminal.App/native
           cargo build --release
-          # Binary stays in target/release/librusty_pty.dylib
+          cd rusty_ssh
+          cargo build --release
 
       - name: Upload Native Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,171 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Release tag to publish (for example v0.1.1)"
+        required: true
+        type: string
+      target_commitish:
+        description: "Branch, tag, or commit to build when dispatching manually"
+        required: false
+        default: "main"
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  CONFIGURATION: Release
+
+jobs:
+  release_metadata:
+    name: Resolve Release Metadata
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.meta.outputs.release_tag }}
+      checkout_ref: ${{ steps.meta.outputs.checkout_ref }}
+    steps:
+      - name: Resolve tag and checkout ref
+        id: meta
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            echo "release_tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+            echo "checkout_ref=${{ github.ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "release_tag=${{ inputs.tag_name }}" >> "$GITHUB_OUTPUT"
+            echo "checkout_ref=${{ inputs.target_commitish }}" >> "$GITHUB_OUTPUT"
+          fi
+
+  create_release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: [release_metadata]
+    steps:
+
+      - name: Create or update release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.release_metadata.outputs.release_tag }}
+          target_commitish: ${{ needs.release_metadata.outputs.checkout_ref }}
+          generate_release_notes: true
+
+  build_native:
+    name: Build Native (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    needs: [release_metadata]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release_metadata.outputs.checkout_ref }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src/NovaTerminal.App/native
+
+      - name: Build Rust (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          cd src/NovaTerminal.App/native
+          cargo build --release
+          # Binary stays in target/release/rusty_pty.dll
+
+      - name: Build Rust (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          cd src/NovaTerminal.App/native
+          cargo build --release
+          mkdir -p ../native/target_linux/release
+          cp target/release/librusty_pty.so ../native/target_linux/release/
+
+      - name: Build Rust (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          cd src/NovaTerminal.App/native
+          cargo build --release
+          # Binary stays in target/release/librusty_pty.dylib
+
+      - name: Upload Native Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-${{ matrix.os }}
+          path: |
+            src/NovaTerminal.App/native/target*/**/release/*pty.*
+            src/NovaTerminal.App/native/rusty_ssh/target*/**/release/*ssh.*
+
+  publish_aot:
+    name: Publish AOT (${{ matrix.rid }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
+    needs: [release_metadata, create_release, build_native]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            rid: win-x64
+          - os: ubuntu-latest
+            rid: linux-x64
+          - os: macos-latest
+            rid: osx-arm64
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release_metadata.outputs.checkout_ref }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Download Native Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: native-${{ matrix.os }}
+          path: src/NovaTerminal.App/native
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Publish AOT
+        env:
+          SKIP_RUST_NATIVE_BUILD: "1"
+        run: dotnet publish src/NovaTerminal.App/NovaTerminal.App.csproj -c ${{ env.CONFIGURATION }} -r ${{ matrix.rid }} --self-contained true -p:PublishAot=true -o artifacts/publish/${{ matrix.rid }}
+
+      - name: Archive bundle
+        shell: pwsh
+        run: |
+          $rid = "${{ matrix.rid }}"
+          $source = "artifacts/publish/$rid"
+          $dest = "artifacts/release/NovaTerminal-$rid-${{ needs.release_metadata.outputs.release_tag }}.zip"
+          New-Item -ItemType Directory -Force -Path "artifacts/release" | Out-Null
+          if (Test-Path $dest) { Remove-Item $dest -Force }
+          Compress-Archive -Path "$source/*" -DestinationPath $dest
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.release_metadata.outputs.release_tag }}
+          files: artifacts/release/NovaTerminal-${{ matrix.rid }}-${{ needs.release_metadata.outputs.release_tag }}.zip

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ replay parity prevents silent behavioral drift.
 
 ## Install
 
-Pre-built binaries are not yet published. NovaTerminal currently ships as
-**build-from-source**; installers and GitHub Releases are planned for an
-upcoming milestone.
+GitHub release assets are produced as Native AOT bundles for `win-x64`,
+`linux-x64`, and `osx-arm64`. Installer packaging is not available yet, so
+if a release does not include the bundle you need, build from source.
 
 For build steps, jump to [Build & test](#build--test) below.
 
@@ -180,6 +180,22 @@ dotnet test -c Release --no-build --filter "Category!=Replay&Category!=RenderMet
 
 Use `ci/run.sh` (Linux/macOS) or `ci/run.ps1` (Windows) for the full local
 CI-style sequence.
+
+### Native AOT publish
+
+NovaTerminal is configured for **Native AOT** publish in
+[`src/NovaTerminal.App/NovaTerminal.App.csproj`](src/NovaTerminal.App/NovaTerminal.App.csproj).
+The project supports `win-x64`, `linux-x64`, and `osx-arm64` publish targets.
+The release workflow publishes Native AOT bundles for those targets to the
+corresponding GitHub Release.
+
+Example publish command:
+
+```bash
+dotnet publish src/NovaTerminal.App/NovaTerminal.App.csproj -c Release -r win-x64 --self-contained true -p:PublishAot=true -o artifacts/publish/win-x64
+```
+
+Swap `win-x64` for `linux-x64` or `osx-arm64` as needed.
 
 ---
 

--- a/docs/plans/2026-04-22-ci-rebalance-and-release-publishing.md
+++ b/docs/plans/2026-04-22-ci-rebalance-and-release-publishing.md
@@ -1,0 +1,321 @@
+# CI Rebalance And Release Publishing Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Re-enable a balanced set of pull-request CI lanes and add a tag-driven release workflow that publishes Windows, Linux, and macOS Native AOT bundles to GitHub Releases.
+
+**Architecture:** Keep the existing `ci.yml` as the main validation workflow and expand only the PR-relevant matrices/conditions there. Add a separate `release.yml` that triggers on `v*` tags, rebuilds the needed native dependencies, publishes Native AOT bundles for each target RID, archives them, and uploads them to the matching GitHub Release.
+
+**Tech Stack:** GitHub Actions, .NET 10 SDK, Rust toolchain, Native AOT publish, PowerShell/`pwsh`, Markdown docs.
+
+---
+
+### Task 1: Rebalance PR CI In `ci.yml`
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Reference: `docs/plans/2026-04-22-ci-rebalance-and-release-publishing-design.md`
+
+**Step 1: Update the PR OS matrix for build-and-unit-tests**
+
+Change the `build_and_unit_tests` matrix so pull requests run on both Windows and Linux instead of Linux only.
+
+Replace the current matrix expression with:
+
+```yaml
+      matrix:
+        os: ${{ fromJSON(github.event_name == 'pull_request' && '["windows-latest","ubuntu-latest"]' || '["windows-latest","ubuntu-latest"]') }}
+```
+
+Then simplify it to the clearer equivalent:
+
+```yaml
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+```
+
+**Step 2: Re-enable PTY smoke tests on PRs**
+
+Update the `pty_smoke_tests` job condition from:
+
+```yaml
+    if: github.event_name != 'pull_request'
+```
+
+to:
+
+```yaml
+    if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+```
+
+Keep the existing Windows/Linux matrix unchanged.
+
+**Step 3: Re-enable render metrics tests on PRs**
+
+Update the `render_metrics_tests` job condition from:
+
+```yaml
+    if: github.event_name != 'pull_request'
+```
+
+to:
+
+```yaml
+    if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+```
+
+Keep the existing Windows/Linux matrix unchanged.
+
+**Step 4: Leave heavy lanes unchanged**
+
+Do **not** broaden these jobs in this task:
+
+- `replay_tests`
+- `parity_compare`
+- `aot_publish`
+- macOS inclusion in the main CI workflow
+
+The purpose of this task is a balanced PR CI increase, not full-cost parity.
+
+**Step 5: Run targeted validation**
+
+Run:
+
+```bash
+rg -n "build_and_unit_tests|pty_smoke_tests|render_metrics_tests|if: github.event_name" .github/workflows/ci.yml
+git diff --check
+```
+
+Expected:
+
+- `build_and_unit_tests` shows Windows and Linux on PRs
+- `pty_smoke_tests` and `render_metrics_tests` are no longer excluded from PRs
+- `git diff --check` prints no whitespace errors
+
+**Step 6: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: rebalance pull request coverage"
+```
+
+### Task 2: Add Tag-Driven Release Publishing Workflow
+
+**Files:**
+- Create: `.github/workflows/release.yml`
+- Reference: `.github/workflows/ci.yml`
+- Reference: `src/NovaTerminal.App/NovaTerminal.App.csproj`
+
+**Step 1: Create the release workflow shell**
+
+Create `.github/workflows/release.yml` with these top-level triggers:
+
+```yaml
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+```
+
+Add shared env:
+
+```yaml
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  CONFIGURATION: Release
+```
+
+**Step 2: Add native build job for all three release OSes**
+
+Mirror the native build logic from `ci.yml`, but include:
+
+```yaml
+strategy:
+  fail-fast: false
+  matrix:
+    os: [windows-latest, ubuntu-latest, macos-latest]
+```
+
+Preserve the existing per-OS Rust build handling and upload native artifacts under names like:
+
+```yaml
+name: native-${{ matrix.os }}
+```
+
+**Step 3: Add AOT publish matrix job**
+
+Add a `publish_aot` job with:
+
+```yaml
+strategy:
+  fail-fast: false
+  matrix:
+    include:
+      - os: windows-latest
+        rid: win-x64
+      - os: ubuntu-latest
+        rid: linux-x64
+      - os: macos-latest
+        rid: osx-arm64
+```
+
+Publish with:
+
+```yaml
+run: dotnet publish src/NovaTerminal.App/NovaTerminal.App.csproj -c ${{ env.CONFIGURATION }} -r ${{ matrix.rid }} --self-contained true -p:PublishAot=true -o artifacts/publish/${{ matrix.rid }}
+```
+
+**Step 4: Archive each publish folder into a release asset**
+
+Use `pwsh` so the archive step stays consistent across runners:
+
+```yaml
+      - name: Archive bundle
+        shell: pwsh
+        run: |
+          $rid = "${{ matrix.rid }}"
+          $source = "artifacts/publish/$rid"
+          $dest = "artifacts/release/NovaTerminal-$rid-${{ github.ref_name }}.zip"
+          New-Item -ItemType Directory -Force -Path "artifacts/release" | Out-Null
+          if (Test-Path $dest) { Remove-Item $dest -Force }
+          Compress-Archive -Path "$source/*" -DestinationPath $dest
+```
+
+**Step 5: Upload archived assets to the GitHub Release**
+
+Use `softprops/action-gh-release@v2` in the publish job after the archive step:
+
+```yaml
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/release/NovaTerminal-${{ matrix.rid }}-${{ github.ref_name }}.zip
+```
+
+This workflow assumes the release tag already exists because it is triggered by tag push.
+
+**Step 6: Run targeted validation**
+
+Run:
+
+```bash
+rg -n "name: Release|push:|tags:|macos-latest|PublishAot=true|softprops/action-gh-release" .github/workflows/release.yml
+git diff --check
+```
+
+Expected:
+
+- release workflow triggers on `v*`
+- matrices include Windows, Linux, and macOS
+- AOT publish command is present
+- release asset upload action is present
+- `git diff --check` prints no whitespace errors
+
+**Step 7: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci: publish release artifacts from tags"
+```
+
+### Task 3: Update Public Docs For AOT And Release Assets
+
+**Files:**
+- Modify: `README.md`
+
+**Step 1: Keep the new Native AOT section and extend it for releases**
+
+In the existing build/test area, ensure the README states:
+
+- Native AOT is configured in `src/NovaTerminal.App/NovaTerminal.App.csproj`
+- the project supports `win-x64`, `linux-x64`, and `osx-arm64` publish targets
+- tag-driven GitHub releases attach publish bundles for those targets
+
+Add a short release note such as:
+
+```md
+Tagged releases publish Native AOT bundles for `win-x64`, `linux-x64`, and `osx-arm64` to the corresponding GitHub Release.
+```
+
+**Step 2: Review wording against the actual workflows**
+
+Run:
+
+```bash
+rg -n "Native AOT|GitHub Release|win-x64|linux-x64|osx-arm64" README.md .github/workflows/ci.yml .github/workflows/release.yml
+git diff -- README.md
+```
+
+Expected:
+
+- README language matches the CI and release workflows
+- no stale claim says binaries are unavailable once release assets are being produced
+
+**Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document AOT release publishing"
+```
+
+### Task 4: Final Verification And Integration Check
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Create: `.github/workflows/release.yml`
+- Modify: `README.md`
+
+**Step 1: Review the final diff**
+
+Run:
+
+```bash
+git diff -- .github/workflows/ci.yml .github/workflows/release.yml README.md
+```
+
+Expected:
+
+- PR CI changes are limited to the balanced lanes
+- release workflow is tag-driven and separate from ordinary PR validation
+- README reflects both AOT local publish and release asset behavior
+
+**Step 2: Run whitespace and status checks**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected:
+
+- no whitespace or patch-format issues
+- only the intended workflow/docs files are modified
+
+**Step 3: Commit final cleanup if needed**
+
+If any small wording or workflow cleanup is required after review:
+
+```bash
+git add .github/workflows/ci.yml .github/workflows/release.yml README.md
+git commit -m "chore: finalize CI and release workflow cleanup"
+```
+
+**Step 4: Publish**
+
+```bash
+git push origin HEAD
+gh pr create --title "[codex] rebalance CI and add release publishing" --body-file <prepared-body-file>
+```
+
+Expected:
+
+- PR clearly separates balanced PR CI changes from release publishing additions
+- reviewers can validate the new release path without guessing at scope
+
+---

--- a/src/NovaTerminal.App/NovaTerminal.App.csproj
+++ b/src/NovaTerminal.App/NovaTerminal.App.csproj
@@ -115,7 +115,8 @@
     <ItemGroup>
       <ObsoleteCliShimBuildArtifacts Include="$(OutDir)NovaTerminal.Cli*" />
       <ObsoleteLegacyGuiArtifacts Include="$(OutDir)NovaTerminal.Gui*" />
-      <CliShimBuildArtifacts Include="$(CliBuildOutputDir)NovaTerminal.Cli.exe" />
+      <CliShimBuildArtifacts Include="$(CliBuildOutputDir)NovaTerminal.Cli.exe" Condition="Exists('$(CliBuildOutputDir)NovaTerminal.Cli.exe')" />
+      <CliShimBuildArtifacts Include="$(CliBuildOutputDir)NovaTerminal.Cli" Condition="Exists('$(CliBuildOutputDir)NovaTerminal.Cli')" />
       <CliShimBuildArtifacts Include="$(CliBuildOutputDir)NovaTerminal.Cli.dll" />
       <CliShimBuildArtifacts Include="$(CliBuildOutputDir)NovaTerminal.Cli.deps.json" />
       <CliShimBuildArtifacts Include="$(CliBuildOutputDir)NovaTerminal.Cli.runtimeconfig.json" />
@@ -142,7 +143,8 @@
     <ItemGroup>
       <ObsoleteCliShimPublishArtifacts Include="$(PublishDir)NovaTerminal.Cli*" />
       <ObsoleteLegacyGuiPublishArtifacts Include="$(PublishDir)NovaTerminal.Gui*" />
-      <CliShimPublishArtifacts Include="$(CliPublishOutputDir)NovaTerminal.Cli.exe" />
+      <CliShimPublishArtifacts Include="$(CliPublishOutputDir)NovaTerminal.Cli.exe" Condition="Exists('$(CliPublishOutputDir)NovaTerminal.Cli.exe')" />
+      <CliShimPublishArtifacts Include="$(CliPublishOutputDir)NovaTerminal.Cli" Condition="Exists('$(CliPublishOutputDir)NovaTerminal.Cli')" />
       <CliShimPublishArtifacts Include="$(CliPublishOutputDir)NovaTerminal.Cli.dll" />
       <CliShimPublishArtifacts Include="$(CliPublishOutputDir)NovaTerminal.Cli.deps.json" />
       <CliShimPublishArtifacts Include="$(CliPublishOutputDir)NovaTerminal.Cli.runtimeconfig.json" />

--- a/src/NovaTerminal.App/Resources/vt-conformance-report.json
+++ b/src/NovaTerminal.App/Resources/vt-conformance-report.json
@@ -114,8 +114,7 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/TabSystemTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\TabSystemTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -136,8 +135,7 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/AnsiParserHardeningTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\AnsiParserHardeningTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -172,8 +170,7 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/AnsiParserHardeningTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\AnsiParserHardeningTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -194,8 +191,7 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/AnsiParserHardeningTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\AnsiParserHardeningTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -218,13 +214,11 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/AnsiCorpusReplayTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\AnsiCorpusReplayTests.cs"
+          "exists": true
         },
         {
           "path": "tests/NovaTerminal.Tests/AnsiParserHardeningTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\AnsiParserHardeningTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -245,8 +239,7 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/PendingWrapTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\PendingWrapTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -268,13 +261,11 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/CursorPositioningCompletionTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\CursorPositioningCompletionTests.cs"
+          "exists": true
         },
         {
           "path": "tests/NovaTerminal.Tests/ReplayTests/RegressionTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\ReplayTests\\RegressionTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -311,8 +302,7 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/TabSystemTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\TabSystemTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -333,8 +323,7 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/TabSystemTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\TabSystemTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -355,8 +344,7 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/CursorPositioningCompletionTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\CursorPositioningCompletionTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -377,8 +365,7 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/CursorPositioningCompletionTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\CursorPositioningCompletionTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -401,18 +388,15 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Core.Tests/Ssh/NativeSshTerminalParityTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Core.Tests\\Ssh\\NativeSshTerminalParityTests.cs"
+          "exists": true
         },
         {
           "path": "tests/NovaTerminal.Tests/Fixtures/Replay/vttest_cursor.rec",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\Fixtures\\Replay\\vttest_cursor.rec"
+          "exists": true
         },
         {
           "path": "tests/NovaTerminal.Tests/ReplayTests/RegressionTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\ReplayTests\\RegressionTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -433,8 +417,7 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Core.Tests/Ssh/NativeSshTerminalParityTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Core.Tests\\Ssh\\NativeSshTerminalParityTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -551,8 +534,7 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/DecModeTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\DecModeTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -604,18 +586,15 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/AlternateScreenTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\AlternateScreenTests.cs"
+          "exists": true
         },
         {
           "path": "tests/NovaTerminal.Tests/ReplayTests/AlternateScreenReplayTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\ReplayTests\\AlternateScreenReplayTests.cs"
+          "exists": true
         },
         {
           "path": "tests/NovaTerminal.Tests/ReplayTests/NativeSshReplayParityTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\ReplayTests\\NativeSshReplayParityTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -637,13 +616,11 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/DecModeTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\DecModeTests.cs"
+          "exists": true
         },
         {
           "path": "tests/NovaTerminal.Tests/ReplayTests/ReplayV2Tests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\ReplayTests\\ReplayV2Tests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -730,8 +707,7 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/OscUxTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\OscUxTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -753,8 +729,7 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/SgrAttributeTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\SgrAttributeTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -837,8 +812,7 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/TabSystemTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\TabSystemTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -859,8 +833,7 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/TabSystemTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\TabSystemTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -898,8 +871,7 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/OscUxTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\OscUxTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -934,8 +906,7 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/OscUxTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\OscUxTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -956,8 +927,7 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/OscShellIntegrationTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\OscShellIntegrationTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -978,8 +948,7 @@
       "evidenceLinks": [
         {
           "path": "docs/qa/QA_GRAPHICS.md",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\docs\\qa\\QA_GRAPHICS.md"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": false,
@@ -1016,13 +985,11 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/AnsiParserHardeningTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\AnsiParserHardeningTests.cs"
+          "exists": true
         },
         {
           "path": "tests/NovaTerminal.Tests/GraphicsTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\GraphicsTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -1119,8 +1086,7 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/OscUxTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\OscUxTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -1142,18 +1108,15 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/Fixtures/Replay/mixed_unicode.rec",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\Fixtures\\Replay\\mixed_unicode.rec"
+          "exists": true
         },
         {
           "path": "tests/NovaTerminal.Tests/UnicodeWidthModelV2Tests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\UnicodeWidthModelV2Tests.cs"
+          "exists": true
         },
         {
           "path": "tests/NovaTerminal.Tests/WidthTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\WidthTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -1174,23 +1137,19 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/GraphemeAttachmentTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\GraphemeAttachmentTests.cs"
+          "exists": true
         },
         {
           "path": "tests/NovaTerminal.Tests/ScrollAndWrapCorrectnessTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\ScrollAndWrapCorrectnessTests.cs"
+          "exists": true
         },
         {
           "path": "tests/NovaTerminal.Tests/SurrogateTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\SurrogateTests.cs"
+          "exists": true
         },
         {
           "path": "tests/NovaTerminal.Tests/UnicodeWidthModelV2Tests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\UnicodeWidthModelV2Tests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,
@@ -1211,18 +1170,15 @@
       "evidenceLinks": [
         {
           "path": "tests/NovaTerminal.Tests/GraphemeAttachmentTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\GraphemeAttachmentTests.cs"
+          "exists": true
         },
         {
           "path": "tests/NovaTerminal.Tests/UnicodeWidthModelV2Tests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\UnicodeWidthModelV2Tests.cs"
+          "exists": true
         },
         {
           "path": "tests/NovaTerminal.Tests/WidthTests.cs",
-          "exists": true,
-          "fullPath": "D:\\projects\\nova2\\tests\\NovaTerminal.Tests\\WidthTests.cs"
+          "exists": true
         }
       ],
       "hasAutomatedEvidenceSignal": true,

--- a/src/NovaTerminal.App/Resources/vt-conformance-report.json
+++ b/src/NovaTerminal.App/Resources/vt-conformance-report.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "matrixPath": "docs/vt_coverage_matrix.md",
-  "matrixSha256": "4f2db6647b19739fa7ee9d79ffe27aec2ad66c4476e9fe8e0cb91d4ee962e743",
+  "matrixSha256": "2eed9f89b6fc771dad0e1da8407a1661381446eaf76553a1f0a15fc6de33c6f1",
   "summary": {
     "totalRows": 55,
     "supportedCount": 16,

--- a/src/NovaTerminal.Conformance/VtConformanceReportTool.cs
+++ b/src/NovaTerminal.Conformance/VtConformanceReportTool.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 
 namespace NovaTerminal.Conformance;
@@ -674,6 +675,7 @@ public sealed record VtConformanceRow(
 public sealed record VtEvidenceLink(
     string Path,
     bool Exists,
+    [property: JsonIgnore]
     string FullPath);
 
 public sealed record VtConformanceIssue(

--- a/src/NovaTerminal.Conformance/VtConformanceReportTool.cs
+++ b/src/NovaTerminal.Conformance/VtConformanceReportTool.cs
@@ -22,6 +22,7 @@ public static class VtConformanceReportTool
             : Path.Combine(repoRoot, matrixPath));
 
         string matrixText = File.ReadAllText(absoluteMatrixPath);
+        string normalizedMatrixText = NormalizeLineEndings(matrixText);
         string relativeMatrixPath = ToRepoRelativePath(repoRoot, absoluteMatrixPath);
 
         var rows = new List<VtConformanceRow>();
@@ -29,7 +30,7 @@ public static class VtConformanceReportTool
         var errors = new List<VtConformanceIssue>();
         var warnings = new List<VtConformanceIssue>();
 
-        ParseFeatureTables(repoRoot, relativeMatrixPath, absoluteMatrixPath, matrixText, rows, sections, errors, warnings);
+        ParseFeatureTables(repoRoot, relativeMatrixPath, absoluteMatrixPath, normalizedMatrixText, rows, sections, errors, warnings);
 
         ValidateRows(relativeMatrixPath, rows, errors, warnings);
 
@@ -37,7 +38,7 @@ public static class VtConformanceReportTool
         return new VtConformanceReport(
             SchemaVersion: 1,
             MatrixPath: relativeMatrixPath,
-            MatrixSha256: ComputeSha256(matrixText),
+            MatrixSha256: ComputeSha256(normalizedMatrixText),
             Summary: summary,
             Sections: sections,
             Rows: rows,
@@ -496,6 +497,9 @@ public static class VtConformanceReportTool
         byte[] hash = SHA256.HashData(bytes);
         return Convert.ToHexString(hash).ToLowerInvariant();
     }
+
+    private static string NormalizeLineEndings(string text)
+        => text.Replace("\r\n", "\n", StringComparison.Ordinal);
 
     private static string ToRepoRelativePath(string repoRoot, string absolutePath)
     {

--- a/tests/NovaTerminal.Core.Tests/Conformance/VtConformanceToolTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Conformance/VtConformanceToolTests.cs
@@ -1,4 +1,5 @@
 using NovaTerminal.Conformance;
+using System.Text.Json;
 
 namespace NovaTerminal.Core.Tests.Conformance;
 
@@ -24,8 +25,10 @@ public sealed class VtConformanceToolTests
         VtConformanceReport report = VtConformanceReportTool.Generate(repo.RootPath, Path.Combine(repo.RootPath, "docs", "vt_coverage_matrix.md"));
         string json1 = VtConformanceReportTool.Serialize(report);
         string json2 = VtConformanceReportTool.Serialize(report);
+        using JsonDocument document = JsonDocument.Parse(json1);
 
         Assert.Equal(json1, json2);
+        Assert.DoesNotContain("\"fullPath\"", json1, StringComparison.Ordinal);
         Assert.Equal(2, report.Summary.TotalRows);
         Assert.Equal(1, report.Summary.SupportedCount);
         Assert.Equal(1, report.Summary.PartialCount);
@@ -33,6 +36,8 @@ public sealed class VtConformanceToolTests
         Assert.Equal("1) Parsing", report.Sections[0].Title);
         Assert.Equal("CSI parser", report.Rows[0].Feature);
         Assert.Equal("tests/NovaTerminal.Tests/ParserTests.cs", report.Rows[0].EvidenceLinks[0].Path);
+        Assert.Equal(Path.Combine(repo.RootPath, "tests", "NovaTerminal.Tests", "ParserTests.cs"), report.Rows[0].EvidenceLinks[0].FullPath);
+        Assert.False(document.RootElement.GetProperty("rows")[0].GetProperty("evidenceLinks")[0].TryGetProperty("fullPath", out _));
         Assert.Empty(report.Errors);
     }
 

--- a/tests/NovaTerminal.Core.Tests/Conformance/VtConformanceToolTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Conformance/VtConformanceToolTests.cs
@@ -226,7 +226,10 @@ public sealed class VtConformanceToolTests
                 Directory.CreateDirectory(directory);
             }
 
-            File.WriteAllText(absolutePath, content.Replace("\n", newline, StringComparison.Ordinal));
+            string normalizedContent = content
+                .Replace("\r\n", "\n", StringComparison.Ordinal)
+                .Replace("\r", "\n", StringComparison.Ordinal);
+            File.WriteAllText(absolutePath, normalizedContent.Replace("\n", newline, StringComparison.Ordinal));
         }
 
         public void Dispose()

--- a/tests/NovaTerminal.Core.Tests/Conformance/VtConformanceToolTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Conformance/VtConformanceToolTests.cs
@@ -152,6 +152,34 @@ public sealed class VtConformanceToolTests
     }
 
     [Fact]
+    public void Generate_UsesLineEndingStableMatrixHash()
+    {
+        using var lfRepo = new TemporaryRepo();
+        using var crlfRepo = new TemporaryRepo();
+        const string relativeMatrixPath = "docs/vt_coverage_matrix.md";
+        const string matrix = """
+# VT Conformance Matrix
+
+## 1) Parsing
+
+| Feature / Sequence | Spec / Notes | Status | Evidence | Ownership (code) | Known deviations |
+|---|---|---:|---|---|---|
+| CSI parser | Basic | ✅ Supported | Unit: `tests/NovaTerminal.Tests/ParserTests.cs` | `Core/AnsiParser.cs` | |
+""";
+
+        lfRepo.WriteFile("tests/NovaTerminal.Tests/ParserTests.cs", "// parser tests");
+        crlfRepo.WriteFile("tests/NovaTerminal.Tests/ParserTests.cs", "// parser tests");
+        lfRepo.WriteFile(relativeMatrixPath, matrix, newline: "\n");
+        crlfRepo.WriteFile(relativeMatrixPath, matrix, newline: "\r\n");
+
+        VtConformanceReport lfReport = VtConformanceReportTool.Generate(lfRepo.RootPath, Path.Combine(lfRepo.RootPath, relativeMatrixPath));
+        VtConformanceReport crlfReport = VtConformanceReportTool.Generate(crlfRepo.RootPath, Path.Combine(crlfRepo.RootPath, relativeMatrixPath));
+
+        Assert.Equal(lfReport.MatrixSha256, crlfReport.MatrixSha256);
+        Assert.Equal(VtConformanceReportTool.Serialize(lfReport), VtConformanceReportTool.Serialize(crlfReport));
+    }
+
+    [Fact]
     public void Generate_CurrentRepositoryMatrix_HasNoValidationErrors()
     {
         string repoRoot = FindRepositoryRoot();
@@ -189,7 +217,7 @@ public sealed class VtConformanceToolTests
 
         public string RootPath { get; }
 
-        public void WriteFile(string relativePath, string content)
+        public void WriteFile(string relativePath, string content, string newline = "\n")
         {
             string absolutePath = Path.Combine(RootPath, relativePath.Replace('/', Path.DirectorySeparatorChar));
             string? directory = Path.GetDirectoryName(absolutePath);
@@ -198,7 +226,7 @@ public sealed class VtConformanceToolTests
                 Directory.CreateDirectory(directory);
             }
 
-            File.WriteAllText(absolutePath, content.Replace("\n", Environment.NewLine, StringComparison.Ordinal));
+            File.WriteAllText(absolutePath, content.Replace("\n", newline, StringComparison.Ordinal));
         }
 
         public void Dispose()

--- a/tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/CommandAssistControllerTests.cs
@@ -717,6 +717,9 @@ public sealed class CommandAssistControllerTests
 
         await historyStore.WaitForSearchSettledAsync();
         await snippetStore.WaitForReadAsync();
+        await WaitForConditionAsync(() => controller.ViewModel.TopSuggestionText == "Git Status" &&
+                                          controller.Suggestions.Count > 0 &&
+                                          controller.Suggestions[0].Type == AssistSuggestionType.Snippet);
 
         Assert.Equal("Git Status", controller.ViewModel.TopSuggestionText);
         Assert.Equal(AssistSuggestionType.Snippet, controller.Suggestions[0].Type);

--- a/tests/NovaTerminal.Tests/RenderTests/RenderPerfWriterTests.cs
+++ b/tests/NovaTerminal.Tests/RenderTests/RenderPerfWriterTests.cs
@@ -43,31 +43,32 @@ namespace NovaTerminal.Tests.RenderTests
                 Environment.SetEnvironmentVariable("NOVATERM_RENDER_METRICS", "1");
                 Environment.SetEnvironmentVariable("NOVATERM_RENDER_METRICS_OUT", outPath);
 
-                using RenderPerfWriter? writer = RenderPerfWriter.CreateFromEnvironment();
-                Assert.NotNull(writer);
-
-                var metrics = new RenderPerfMetrics
+                using (RenderPerfWriter? writer = RenderPerfWriter.CreateFromEnvironment())
                 {
-                    FrameIndex = 7,
-                    FrameTimeMs = 2.5,
-                    DirtyRows = 3,
-                    DirtySpansTotal = 3,
-                    DrawCallsText = 2,
-                    DrawCallsRects = 1,
-                    DrawCallsTotal = 3,
-                    RowPictureCacheHits = 4,
-                    RowPictureCacheMisses = 1,
-                    PictureBuilds = 1,
-                    FlushCount = 2,
-                    AtlasAlphaGlyphs = 5,
-                    AtlasColorGlyphs = 6,
-                    DirectDrawTextCount = 2,
-                    ShapedTextRuns = 1,
-                    AllocBytesThisFrame = 128
-                };
+                    Assert.NotNull(writer);
 
-                writer!.TryWrite(metrics);
-                writer.Dispose();
+                    var metrics = new RenderPerfMetrics
+                    {
+                        FrameIndex = 7,
+                        FrameTimeMs = 2.5,
+                        DirtyRows = 3,
+                        DirtySpansTotal = 3,
+                        DrawCallsText = 2,
+                        DrawCallsRects = 1,
+                        DrawCallsTotal = 3,
+                        RowPictureCacheHits = 4,
+                        RowPictureCacheMisses = 1,
+                        PictureBuilds = 1,
+                        FlushCount = 2,
+                        AtlasAlphaGlyphs = 5,
+                        AtlasColorGlyphs = 6,
+                        DirectDrawTextCount = 2,
+                        ShapedTextRuns = 1,
+                        AllocBytesThisFrame = 128
+                    };
+
+                    writer!.TryWrite(metrics);
+                }
 
                 Assert.True(File.Exists(outPath));
                 string[] lines = File.ReadAllLines(outPath);
@@ -125,22 +126,24 @@ namespace NovaTerminal.Tests.RenderTests
             try
             {
                 Directory.CreateDirectory(tempDir);
-                using RenderPerfWriter? writer = RenderPerfWriter.Create(outPath);
-                Assert.NotNull(writer);
-
-                writer!.TryWrite(new RenderPerfMetrics { FrameIndex = 1, FrameTimeMs = 1.0 });
-                Assert.True(File.Exists(outPath));
-
-                long lenAfterFirstWrite = new FileInfo(outPath).Length;
-                Assert.Equal(0, lenAfterFirstWrite);
-
-                for (int i = 2; i <= 60; i++)
+                using (RenderPerfWriter? writer = RenderPerfWriter.Create(outPath))
                 {
-                    writer.TryWrite(new RenderPerfMetrics { FrameIndex = i, FrameTimeMs = 1.0 });
-                }
+                    Assert.NotNull(writer);
 
-                long lenAfterThreshold = new FileInfo(outPath).Length;
-                Assert.True(lenAfterThreshold > 0);
+                    writer!.TryWrite(new RenderPerfMetrics { FrameIndex = 1, FrameTimeMs = 1.0 });
+                    Assert.True(File.Exists(outPath));
+
+                    long lenAfterFirstWrite = new FileInfo(outPath).Length;
+                    Assert.Equal(0, lenAfterFirstWrite);
+
+                    for (int i = 2; i <= 60; i++)
+                    {
+                        writer.TryWrite(new RenderPerfMetrics { FrameIndex = i, FrameTimeMs = 1.0 });
+                    }
+
+                    long lenAfterThreshold = new FileInfo(outPath).Length;
+                    Assert.True(lenAfterThreshold > 0);
+                }
             }
             finally
             {

--- a/tests/NovaTerminal.Tests/VtReportCliTests.cs
+++ b/tests/NovaTerminal.Tests/VtReportCliTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using NovaTerminal.Conformance;
 
@@ -74,7 +75,7 @@ public sealed class VtReportCliTests
     {
         string repoRoot = FindRepositoryRoot();
         string cliProjectPath = Path.Combine(repoRoot, "src", "NovaTerminal.Cli", "NovaTerminal.Cli.csproj");
-        string cliExecutablePath = Path.Combine(repoRoot, "src", "NovaTerminal.Cli", "bin", "Release", "net10.0", "NovaTerminal.Cli.exe");
+        string cliExecutablePath = GetExecutablePath(Path.Combine(repoRoot, "src", "NovaTerminal.Cli", "bin", "Release", "net10.0"), "NovaTerminal.Cli");
         (int buildExitCode, string buildStdOut, string buildStdErr) = RunProcessFromRepository(
             repoRoot,
             "dotnet",
@@ -98,7 +99,7 @@ public sealed class VtReportCliTests
     {
         string repoRoot = FindRepositoryRoot();
         string appProjectPath = Path.Combine(repoRoot, "src", "NovaTerminal.App", "NovaTerminal.App.csproj");
-        string appExecutablePath = Path.Combine(repoRoot, "src", "NovaTerminal.App", "bin", "Release", "net10.0", "NovaTerminal.exe");
+        string appExecutablePath = GetExecutablePath(Path.Combine(repoRoot, "src", "NovaTerminal.App", "bin", "Release", "net10.0"), "NovaTerminal");
         (int buildExitCode, string buildStdOut, string buildStdErr) = RunProcessFromRepository(
             repoRoot,
             "dotnet",
@@ -130,9 +131,9 @@ public sealed class VtReportCliTests
 
         Assert.Equal(0, buildExitCode);
         Assert.Equal(string.Empty, buildStdErr);
-        Assert.True(File.Exists(Path.Combine(appOutputDirectory, "NovaTerminal.exe")));
-        Assert.True(File.Exists(Path.Combine(appOutputDirectory, "NovaTerminal.Cli.exe")));
-        Assert.False(File.Exists(Path.Combine(appOutputDirectory, "NovaTerminal.Gui.exe")));
+        Assert.True(File.Exists(GetExecutablePath(appOutputDirectory, "NovaTerminal")));
+        Assert.True(File.Exists(GetExecutablePath(appOutputDirectory, "NovaTerminal.Cli")));
+        Assert.False(File.Exists(GetExecutablePath(appOutputDirectory, "NovaTerminal.Gui")));
     }
 
     [Fact]
@@ -186,6 +187,14 @@ public sealed class VtReportCliTests
         process.WaitForExit();
 
         return (process.ExitCode, stdout, stderr);
+    }
+
+    private static string GetExecutablePath(string directory, string baseName)
+    {
+        string fileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? $"{baseName}.exe"
+            : baseName;
+        return Path.Combine(directory, fileName);
     }
 
 }


### PR DESCRIPTION
## What changed
- rebalance PR CI so build and unit tests run on Windows and Linux
- re-enable PTY smoke and render metrics tests on pull requests
- add a dedicated tag-driven `release.yml` workflow for GitHub Releases and Native AOT bundles on `win-x64`, `linux-x64`, and `osx-arm64`
- document the release asset and Native AOT behavior in the README
- fix existing CI breakages discovered while preparing the release workflow by making the CLI shim copy/publish logic OS-aware and removing machine-specific absolute paths from the embedded VT conformance report JSON
- add the implementation plan doc used for the CI/release work

## Why
The repository moved public, so we can afford to restore a balanced amount of PR validation. At the same time, releases need first-class AOT/mac publishing support. The initial failed Actions review also showed two unrelated issues that would keep the repo red: Linux expected a Windows-only CLI shim filename, and the shipped VT conformance artifact encoded absolute machine paths.

## Impact
- PRs get stronger coverage on Windows and Linux without fully restoring every expensive lane
- release tags can publish downloadable Native AOT artifacts to GitHub Releases
- VT report validation is now environment-stable
- cross-platform app build/publish no longer assumes `.exe` for the CLI shim

## Validation
- `dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c Release --filter "FullyQualifiedName~VtConformanceToolTests.Generate_ParsesFeatureTablesAndProducesDeterministicJson"`
- `dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c Release --filter "FullyQualifiedName~VtReportCliTests.AppBuild_CopiesCliShim_AsNamedSidecar|FullyQualifiedName~VtReportCliTests.ShippedArtifact_MatchesFreshToolOutput|FullyQualifiedName~VtReportCliTests.CliShim_PrintsHumanReadableSummary|FullyQualifiedName~VtReportCliTests.AppBinary_PrintsHumanReadableSummary"`
- `dotnet build src/NovaTerminal.App/NovaTerminal.App.csproj -c Release --no-restore`
- `git diff --check`
