### PR TITLE
[codex] Add native SFTP transfers for NativeSSH

### DIFF
--- a/docs/SSH_ROADMAP.md
+++ b/docs/SSH_ROADMAP.md
@@ -1,6 +1,6 @@
 # NovaTerminal SSH Roadmap
 
-_Last reviewed: 2026-04-21._
+_Last reviewed: 2026-04-27._
 
 NovaTerminal supports two SSH backends:
 
@@ -13,7 +13,7 @@ NovaTerminal supports two SSH backends:
 
 ## Native SSH status (current)
 
-_Source date: 2026-04-08, updated through 2026-04-21._
+_Source date: 2026-04-08, updated through 2026-04-27._
 
 The native SSH initiative is implemented behind conservative rollout controls.
 
@@ -23,6 +23,7 @@ The native SSH initiative is implemented behind conservative rollout controls.
 - Native Rust SSH crate with poll-based ABI
 - Avalonia host-key and auth dialogs
 - App-managed native known-host trust store
+- Native SFTP file and folder upload/download
 - Local port forwarding
 - Direct-host dynamic port forwarding (SOCKS5)
 - One-hop jump-host support
@@ -37,6 +38,8 @@ The native SSH initiative is implemented behind conservative rollout controls.
 - `OpenSsh` remains the default backend.
 - `Native` is gated by `TerminalSettings.ExperimentalNativeSshEnabled`.
 - Native SSH does **not** silently fall back to OpenSSH on failure.
+- Native SSH file transfers use the built-in native SFTP path.
+- OpenSSH file transfers still use the system `scp` path.
 - Native SSH supports local forwards and direct-host dynamic forwards.
 - Dynamic forwarding through a one-hop jump host is **not** yet supported.
 - Remote forwarding is **not** supported in the native backend.

--- a/docs/SSH_ROADMAP.md
+++ b/docs/SSH_ROADMAP.md
@@ -39,6 +39,7 @@ The native SSH initiative is implemented behind conservative rollout controls.
 - `Native` is gated by `TerminalSettings.ExperimentalNativeSshEnabled`.
 - Native SSH does **not** silently fall back to OpenSSH on failure.
 - Native SSH file transfers use the built-in native SFTP path.
+- Native SSH transfer dialogs can autocomplete remote paths when an active session for that profile already exists.
 - Native SSH single-file transfers show live byte progress when the total size is known; folder transfers report per-file progress only.
 - OpenSSH file transfers still use the system `scp` path.
 - Native SSH supports local forwards and direct-host dynamic forwards.

--- a/docs/SSH_ROADMAP.md
+++ b/docs/SSH_ROADMAP.md
@@ -39,6 +39,7 @@ The native SSH initiative is implemented behind conservative rollout controls.
 - `Native` is gated by `TerminalSettings.ExperimentalNativeSshEnabled`.
 - Native SSH does **not** silently fall back to OpenSSH on failure.
 - Native SSH file transfers use the built-in native SFTP path.
+- Native SSH single-file transfers show live byte progress when the total size is known; folder transfers report per-file progress only.
 - OpenSSH file transfers still use the system `scp` path.
 - Native SSH supports local forwards and direct-host dynamic forwards.
 - Dynamic forwarding through a one-hop jump host is **not** yet supported.

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -85,6 +85,17 @@ Access the following commands via the palette to transfer files and folders betw
 
 *(Note: SFTP commands only function when the active pane is an SSH session).*
 
+Transfer behavior depends on the SSH backend:
+
+- **OpenSSH profiles** use the system `scp` executable.
+- **Native SSH profiles** use NovaTerminal's built-in native SFTP path for file and folder upload/download.
+
+Current Native SSH transfer notes:
+
+- Transfers use the native backend's known-hosts store and do not silently fall back to OpenSSH.
+- Password and identity-file authentication are supported for non-interactive transfers.
+- Cancellation is supported from the Transfer Center for native transfers.
+
 ---
 
 ## 5. Terminal Engine & UI Behavior

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -94,6 +94,8 @@ Current Native SSH transfer notes:
 
 - Transfers use the native backend's known-hosts store and do not silently fall back to OpenSSH.
 - Password and identity-file authentication are supported for non-interactive transfers.
+- Single-file transfers show live byte progress when the total size is known.
+- Folder transfers report per-file progress callbacks; they do not show a precomputed total for the entire tree.
 - Cancellation is supported from the Transfer Center for native transfers.
 
 ---

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -94,6 +94,7 @@ Current Native SSH transfer notes:
 
 - Transfers use the native backend's known-hosts store and do not silently fall back to OpenSSH.
 - Password and identity-file authentication are supported for non-interactive transfers.
+- The transfer dialog offers remote path autocomplete when the same profile already has an active Native SSH session.
 - Single-file transfers show live byte progress when the total size is known.
 - Folder transfers report per-file progress callbacks; they do not show a precomputed total for the entire tree.
 - Cancellation is supported from the Transfer Center for native transfers.

--- a/docs/plans/2026-04-25-native-sftp-transfers.md
+++ b/docs/plans/2026-04-25-native-sftp-transfers.md
@@ -1,0 +1,796 @@
+# Native SFTP Transfers Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace NativeSSH profile transfers' external `scp` dependency with native SFTP upload/download support built on `russh-sftp`.
+
+**Architecture:** Keep the transfer subsystem separate from terminal VT parsing/rendering. Add a NativeSSH transfer path beside the existing external OpenSSH `scp` path, and route only `SshBackendKind.Native` jobs through the new native SFTP bridge. The Rust backend owns SSH/SFTP protocol work; C# `SftpService` owns queueing, progress, job state, and UI notifications.
+
+**Tech Stack:** C#/.NET 10, Avalonia, existing `SftpService`, Rust native backend in `src/NovaTerminal.App/native/rusty_ssh`, `russh`, `russh-sftp`, FFI exported from Rust to C#.
+
+---
+
+## Non-Goals
+
+- Do not modify VT parsing/rendering.
+- Do not render transfer UI inside terminal grid content.
+- Do not replace the OpenSSH profile transfer path in this project phase.
+- Do not build a full file browser.
+- Do not implement native SCP protocol unless `russh-sftp` proves unusable.
+
+## Target Behavior
+
+- OpenSSH profiles continue to use the current external `scp` implementation.
+- NativeSSH profiles use native SFTP for upload/download.
+- File transfers report progress as bytes done/total where the remote server exposes size.
+- Folder transfers recurse deterministically.
+- Failed native transfers produce actionable `TransferJob.LastError` text.
+- Existing Transfer Center/status UI continues to work through `SftpService.JobUpdated`.
+
+## Task 1: Add Rust SFTP Dependency And Compile Boundary
+
+**Files:**
+- Modify: `src/NovaTerminal.App/native/rusty_ssh/Cargo.toml`
+- Modify: `src/NovaTerminal.App/native/rusty_ssh/Cargo.lock`
+
+**Step 1: Add the dependency**
+
+Add `russh-sftp` using a version compatible with the existing `russh` dependency in `Cargo.toml`.
+
+Example shape:
+
+```toml
+russh-sftp = "2"
+```
+
+If the selected version pulls an incompatible `russh`, prefer a compatible `russh-sftp` version before changing Nova's existing `russh` version.
+
+**Step 2: Build to expose version conflicts**
+
+Run:
+
+```powershell
+cargo build --manifest-path src\NovaTerminal.App\native\rusty_ssh\Cargo.toml
+```
+
+Expected: either build succeeds, or dependency errors clearly identify version mismatch.
+
+**Step 3: Resolve dependency mismatch only if needed**
+
+If `russh-sftp` requires a different `russh`, test the smallest compatible version adjustment. Do not refactor session code in this task.
+
+**Step 4: Commit**
+
+```powershell
+git add src/NovaTerminal.App/native/rusty_ssh/Cargo.toml src/NovaTerminal.App/native/rusty_ssh/Cargo.lock
+git commit -m "build: add native sftp dependency"
+```
+
+## Task 2: Define Native Transfer FFI Contract
+
+**Files:**
+- Modify: `src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs`
+- Modify: `src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs`
+- Create: `src/NovaTerminal.Core/Ssh/Native/NativeSftpTransferModels.cs`
+- Test: `tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs`
+
+**Step 1: Write failing model/interop tests**
+
+Create tests for DTO defaults and interop argument validation:
+
+```csharp
+using NovaTerminal.Core.Ssh.Native;
+
+namespace NovaTerminal.Core.Tests.Ssh;
+
+public sealed class NativeSftpTransferInteropTests
+{
+    [Fact]
+    public void TransferOptions_RequireLocalAndRemotePaths()
+    {
+        var options = new NativeSftpTransferOptions();
+
+        Assert.Throws<ArgumentException>(() => options.Validate());
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+$env:SKIP_RUST_NATIVE_BUILD='1'
+dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c NativeSftpPlan --filter "FullyQualifiedName~NativeSftpTransferInteropTests" --no-restore -m:1
+```
+
+Expected: compile failure because the model does not exist.
+
+**Step 3: Add C# models**
+
+Create `NativeSftpTransferModels.cs`:
+
+```csharp
+namespace NovaTerminal.Core.Ssh.Native;
+
+public enum NativeSftpTransferDirection
+{
+    Upload,
+    Download
+}
+
+public enum NativeSftpTransferKind
+{
+    File,
+    Directory
+}
+
+public sealed class NativeSftpTransferOptions
+{
+    public NativeSftpTransferDirection Direction { get; set; }
+    public NativeSftpTransferKind Kind { get; set; }
+    public string LocalPath { get; set; } = string.Empty;
+    public string RemotePath { get; set; } = string.Empty;
+
+    public void Validate()
+    {
+        if (string.IsNullOrWhiteSpace(LocalPath))
+        {
+            throw new ArgumentException("Local path is required.", nameof(LocalPath));
+        }
+
+        if (string.IsNullOrWhiteSpace(RemotePath))
+        {
+            throw new ArgumentException("Remote path is required.", nameof(RemotePath));
+        }
+    }
+}
+
+public sealed class NativeSftpTransferProgress
+{
+    public long BytesDone { get; init; }
+    public long BytesTotal { get; init; }
+    public string CurrentPath { get; init; } = string.Empty;
+}
+```
+
+**Step 4: Add interop surface**
+
+Extend `INativeSshInterop` with a transfer method that takes an existing NativeSSH connection profile/options rather than an existing terminal session handle:
+
+```csharp
+void RunSftpTransfer(
+    NativeSshConnectionOptions connectionOptions,
+    NativeSftpTransferOptions transferOptions,
+    Action<NativeSftpTransferProgress>? progress,
+    CancellationToken cancellationToken);
+```
+
+Rationale: first implementation can open a separate native SSH connection for transfer. Do not try to share the live terminal session handle yet.
+
+**Step 5: Run tests**
+
+Expected: model tests pass; interop compile may fail until `NativeSshInterop` is updated.
+
+**Step 6: Add throwing stub in `NativeSshInterop`**
+
+Implement the interface with:
+
+```csharp
+public void RunSftpTransfer(
+    NativeSshConnectionOptions connectionOptions,
+    NativeSftpTransferOptions transferOptions,
+    Action<NativeSftpTransferProgress>? progress,
+    CancellationToken cancellationToken)
+{
+    throw new NotImplementedException("Native SFTP transfer is not implemented yet.");
+}
+```
+
+**Step 7: Run tests**
+
+Expected: tests compile/pass.
+
+**Step 8: Commit**
+
+```powershell
+git add src/NovaTerminal.Core/Ssh/Native tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs
+git commit -m "feat: define native sftp transfer interop contract"
+```
+
+## Task 3: Route NativeSSH Transfer Jobs Separately
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Core/SftpService.cs`
+- Test: `tests/NovaTerminal.Tests/Core/SftpServiceTests.cs`
+
+**Step 1: Write failing routing tests**
+
+Add tests proving Native profiles do not build external `scp` start info:
+
+```csharp
+[Fact]
+public void SelectTransferBackend_ForNativeProfile_UsesNativeSftp()
+{
+    var profile = new TerminalProfile
+    {
+        Type = ConnectionType.SSH,
+        SshBackendKind = SshBackendKind.Native
+    };
+
+    Assert.Equal(SftpTransferBackend.NativeSftp, SftpService.SelectTransferBackend(profile));
+}
+
+[Fact]
+public void SelectTransferBackend_ForOpenSshProfile_UsesExternalScp()
+{
+    var profile = new TerminalProfile
+    {
+        Type = ConnectionType.SSH,
+        SshBackendKind = SshBackendKind.OpenSsh
+    };
+
+    Assert.Equal(SftpTransferBackend.ExternalScp, SftpService.SelectTransferBackend(profile));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+$env:SKIP_RUST_NATIVE_BUILD='1'
+dotnet test tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj -c NativeSftpPlan --filter "FullyQualifiedName~SftpServiceTests" --no-restore -p:SkipCliShim=true -m:1
+```
+
+Expected: compile failure because `SftpTransferBackend` and `SelectTransferBackend` do not exist.
+
+**Step 3: Add backend selector**
+
+In `SftpService.cs`, add:
+
+```csharp
+internal enum SftpTransferBackend
+{
+    ExternalScp,
+    NativeSftp
+}
+
+internal static SftpTransferBackend SelectTransferBackend(TerminalProfile profile)
+{
+    ArgumentNullException.ThrowIfNull(profile);
+    return profile.SshBackendKind == SshBackendKind.Native
+        ? SftpTransferBackend.NativeSftp
+        : SftpTransferBackend.ExternalScp;
+}
+```
+
+Use the fully-qualified or imported `SshBackendKind` already used in this file.
+
+**Step 4: Update `RunJobAsync` branch**
+
+Refactor:
+
+```csharp
+if (SelectTransferBackend(profile) == SftpTransferBackend.NativeSftp)
+{
+    await RunNativeSftpJobAsync(job, profile, cancellationToken: default);
+}
+else
+{
+    await RunExternalScpJobAsync(job, profile, settings, storeProfiles);
+}
+```
+
+Keep the current external `scp` code in `RunExternalScpJobAsync` with minimal movement.
+
+**Step 5: Add temporary native stub behavior**
+
+`RunNativeSftpJobAsync` should throw:
+
+```csharp
+throw new NotImplementedException("Native SFTP transfers are not implemented yet.");
+```
+
+This keeps routing explicit before implementing Rust.
+
+**Step 6: Run tests**
+
+Expected: routing tests pass.
+
+**Step 7: Commit**
+
+```powershell
+git add src/NovaTerminal.App/Core/SftpService.cs tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
+git commit -m "feat: route native ssh transfers to native sftp backend"
+```
+
+## Task 4: Build Native Connection Options For Transfer
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Core/SftpService.cs`
+- Modify: `src/NovaTerminal.Core/Ssh/Native/NativeJumpHostConnector.cs` if needed
+- Test: `tests/NovaTerminal.Tests/Core/SftpServiceTests.cs`
+
+**Step 1: Write failing options test**
+
+Add a test that turns a `TerminalProfile` into native connection options with host/user/port and profile context.
+
+Example:
+
+```csharp
+[Fact]
+public void BuildNativeTransferConnectionOptions_UsesProfileTarget()
+{
+    var profile = new TerminalProfile
+    {
+        Id = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        Type = ConnectionType.SSH,
+        SshBackendKind = SshBackendKind.Native,
+        SshHost = "prod.internal",
+        SshUser = "ops",
+        SshPort = 2200
+    };
+
+    NativeSshConnectionOptions options = SftpService.BuildNativeTransferConnectionOptions(profile);
+
+    Assert.Equal("prod.internal", options.Host);
+    Assert.Equal("ops", options.User);
+    Assert.Equal(2200, options.Port);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Expected: compile failure because helper is absent.
+
+**Step 3: Implement helper using existing NativeSSH connection planning**
+
+Prefer existing code in `NativeJumpHostConnector` rather than duplicating jump-host logic. If its current method is inaccessible, add a small public/internal method rather than copying logic into `SftpService`.
+
+**Step 4: Run tests**
+
+Expected: pass.
+
+**Step 5: Commit**
+
+```powershell
+git add src/NovaTerminal.App/Core/SftpService.cs src/NovaTerminal.Core/Ssh/Native/NativeJumpHostConnector.cs tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
+git commit -m "feat: build native transfer connection options"
+```
+
+## Task 5: Implement Rust FFI Transfer Skeleton
+
+**Files:**
+- Modify: `src/NovaTerminal.App/native/rusty_ssh/src/lib.rs`
+- Modify: `src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs`
+- Test: `tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs`
+
+**Step 1: Write failing interop call test with fake invalid args**
+
+Test that `NativeSshInterop.RunSftpTransfer` validates null/empty paths before calling native code.
+
+```csharp
+[Fact]
+public void RunSftpTransfer_WithEmptyPaths_ThrowsArgumentException()
+{
+    var interop = new NativeSshInterop();
+    var connection = new NativeSshConnectionOptions { Host = "example", User = "u", Port = 22 };
+    var transfer = new NativeSftpTransferOptions();
+
+    Assert.Throws<ArgumentException>(() =>
+        interop.RunSftpTransfer(connection, transfer, null, CancellationToken.None));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Expected: fails until validation is wired.
+
+**Step 3: Add Rust exported function stub**
+
+In `lib.rs`, export a function such as:
+
+```rust
+#[no_mangle]
+pub extern "C" fn nova_ssh_sftp_transfer(
+    request_json: *const c_char,
+    response_json: *mut *mut c_char,
+) -> c_int {
+    // Parse later. For now return NOT_IMPLEMENTED.
+}
+```
+
+Use the repo's existing result-code and string-freeing patterns. Do not invent a second ownership model.
+
+**Step 4: Add C# P/Invoke declaration**
+
+In `NativeSshInterop.NativeMethods`, add the matching DllImport.
+
+**Step 5: Implement validation and call path**
+
+`RunSftpTransfer` should:
+
+- validate connection options
+- validate transfer options
+- serialize a request DTO
+- call native function
+- throw clear exception on non-zero result
+
+**Step 6: Run tests**
+
+Expected: validation tests pass; not-implemented test can assert clear `NotImplementedException` or `InvalidOperationException` message.
+
+**Step 7: Commit**
+
+```powershell
+git add src/NovaTerminal.App/native/rusty_ssh/src/lib.rs src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs
+git commit -m "feat: add native sftp ffi skeleton"
+```
+
+## Task 6: Implement Native File Download
+
+**Files:**
+- Modify: `src/NovaTerminal.App/native/rusty_ssh/src/lib.rs`
+- Modify: `src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs`
+- Test: `tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs`
+
+**Step 1: Add Docker E2E failing test**
+
+Add a trait-marked test using the existing Docker SSH fixture. It should create a remote file, download it with native SFTP, and compare contents.
+
+Pseudo-shape:
+
+```csharp
+[Fact]
+[Trait("Target", "NativeSsh")]
+public async Task NativeSftp_CanDownloadFile()
+{
+    using DockerSshFixture fixture = await DockerSshFixture.StartAsync();
+    string localPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.txt");
+
+    var interop = new NativeSshInterop();
+    var connection = fixture.CreateNativeConnectionOptions();
+    var transfer = new NativeSftpTransferOptions
+    {
+        Direction = NativeSftpTransferDirection.Download,
+        Kind = NativeSftpTransferKind.File,
+        RemotePath = "/tmp/native-sftp-source.txt",
+        LocalPath = localPath
+    };
+
+    interop.RunSftpTransfer(connection, transfer, null, CancellationToken.None);
+
+    Assert.Equal("expected", File.ReadAllText(localPath));
+}
+```
+
+Adapt to actual fixture APIs. If fixture lacks a command helper, add setup by existing SSH session command.
+
+**Step 2: Run test to verify it fails**
+
+Run only this test; expect native not-implemented failure.
+
+**Step 3: Implement Rust download**
+
+Rust implementation outline:
+
+- create runtime or reuse current runtime setup pattern
+- connect using existing native SSH auth path
+- open SFTP subsystem with `russh-sftp`
+- stat remote file to get size if possible
+- create local file parent directory if needed
+- read remote file in chunks
+- write to local file
+- emit progress after each chunk
+- close handles
+
+**Step 4: Wire progress JSON**
+
+If the initial FFI cannot callback progress safely, write progress as final response only for this task. Add real callbacks in Task 8.
+
+**Step 5: Run Docker E2E test**
+
+Expected: pass.
+
+**Step 6: Commit**
+
+```powershell
+git add src/NovaTerminal.App/native/rusty_ssh/src/lib.rs src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
+git commit -m "feat: support native sftp file download"
+```
+
+## Task 7: Implement Native File Upload
+
+**Files:**
+- Modify: `src/NovaTerminal.App/native/rusty_ssh/src/lib.rs`
+- Test: `tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs`
+
+**Step 1: Add failing upload E2E test**
+
+Create local temp file, upload to `/tmp`, then verify by reading through remote command or downloading back.
+
+**Step 2: Run test to verify it fails**
+
+Expected: upload not implemented.
+
+**Step 3: Implement Rust upload**
+
+Implementation outline:
+
+- open local file
+- ensure remote parent path exists only if explicitly requested; do not silently create arbitrary parent dirs for file upload in this task
+- create/truncate remote file
+- stream chunks local to remote
+- close handles
+
+**Step 4: Run upload/download E2E tests**
+
+Expected: pass.
+
+**Step 5: Commit**
+
+```powershell
+git add src/NovaTerminal.App/native/rusty_ssh/src/lib.rs tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
+git commit -m "feat: support native sftp file upload"
+```
+
+## Task 8: Wire Native SFTP Into `SftpService`
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Core/SftpService.cs`
+- Test: `tests/NovaTerminal.Tests/Core/SftpServiceTests.cs`
+
+**Step 1: Add failing service test with fake native transfer runner**
+
+Introduce a small interface only if needed:
+
+```csharp
+internal interface INativeSftpTransferRunner
+{
+    void Run(
+        NativeSshConnectionOptions connectionOptions,
+        NativeSftpTransferOptions transferOptions,
+        Action<NativeSftpTransferProgress>? progress,
+        CancellationToken cancellationToken);
+}
+```
+
+Test that a Native profile job calls this runner and marks completion.
+
+**Step 2: Run test to verify it fails**
+
+Expected: compile failure or service still uses stub.
+
+**Step 3: Inject runner into service**
+
+Because `SftpService.Instance` is static today, keep production constructor behavior intact and add an internal constructor for tests:
+
+```csharp
+internal SftpService(INativeSftpTransferRunner? nativeRunner)
+{
+    _nativeRunner = nativeRunner ?? new NativeSftpTransferRunner(new NativeSshInterop());
+}
+```
+
+Do not change public API unless needed.
+
+**Step 4: Implement `RunNativeSftpJobAsync`**
+
+Map:
+
+- `TransferDirection.Upload` -> `NativeSftpTransferDirection.Upload`
+- `TransferDirection.Download` -> `NativeSftpTransferDirection.Download`
+- `TransferKind.File` -> `NativeSftpTransferKind.File`
+- `TransferKind.Folder` -> `NativeSftpTransferKind.Directory`
+
+Progress callback updates:
+
+```csharp
+job.BytesDone = progress.BytesDone;
+job.BytesTotal = progress.BytesTotal;
+job.Progress = progress.BytesTotal > 0
+    ? Math.Clamp((double)progress.BytesDone / progress.BytesTotal, 0, 1)
+    : 0;
+```
+
+Always marshal `JobUpdated` through `Dispatcher.UIThread.Post`, matching existing service behavior.
+
+**Step 5: Run service tests**
+
+Expected: pass.
+
+**Step 6: Commit**
+
+```powershell
+git add src/NovaTerminal.App/Core/SftpService.cs tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
+git commit -m "feat: wire native sftp transfers into service"
+```
+
+## Task 9: Add Directory Transfer Recursion
+
+**Files:**
+- Modify: `src/NovaTerminal.App/native/rusty_ssh/src/lib.rs`
+- Test: `tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs`
+
+**Step 1: Add failing directory download test**
+
+Remote directory:
+
+```text
+/tmp/native-sftp-dir/a.txt
+/tmp/native-sftp-dir/nested/b.txt
+```
+
+Download to local temp directory and assert both files exist with exact contents.
+
+**Step 2: Add failing directory upload test**
+
+Local directory with nested file uploads to `/tmp/native-sftp-uploaded-dir`; verify remote files.
+
+**Step 3: Implement deterministic recursion**
+
+Rules:
+
+- directory download to selected local folder should create a child directory named after remote directory basename
+- directory upload to remote destination should create a child directory named after local directory basename unless remote path already clearly names target directory
+- skip symlink traversal in first version; copy symlink target only if SFTP server reports it as regular file
+- sort directory entries by name before transferring for deterministic tests
+
+**Step 4: Run directory E2E tests**
+
+Expected: pass.
+
+**Step 5: Commit**
+
+```powershell
+git add src/NovaTerminal.App/native/rusty_ssh/src/lib.rs tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
+git commit -m "feat: support native sftp directory transfers"
+```
+
+## Task 10: Add Cancellation And Better Errors
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Core/SftpService.cs`
+- Modify: `src/NovaTerminal.App/native/rusty_ssh/src/lib.rs`
+- Test: `tests/NovaTerminal.Tests/Core/SftpServiceTests.cs`
+- Test: `tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs`
+
+**Step 1: Add cancellation tests at service level**
+
+Test cancellation marks `TransferState.Canceled` and does not mark completed.
+
+**Step 2: Add error mapping tests**
+
+Cover:
+
+- remote file missing
+- local file missing on upload
+- permission denied
+- auth failed
+
+**Step 3: Implement cancellation token checks**
+
+Check cancellation:
+
+- before opening connection
+- between file chunks
+- between directory entries
+
+**Step 4: Implement stable error messages**
+
+Map Rust errors to short messages:
+
+- `Remote path not found: <path>`
+- `Local path not found: <path>`
+- `Permission denied: <path>`
+- `Authentication failed`
+- `Native SFTP failed: <details>`
+
+**Step 5: Run focused tests**
+
+Expected: pass.
+
+**Step 6: Commit**
+
+```powershell
+git add src/NovaTerminal.App/Core/SftpService.cs src/NovaTerminal.App/native/rusty_ssh/src/lib.rs tests
+git commit -m "feat: add native sftp cancellation and errors"
+```
+
+## Task 11: Remove NativeSSH AskPass Bridge From Transfer Path
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Core/SftpService.cs`
+- Modify: `tests/NovaTerminal.Tests/Core/SftpServiceTests.cs`
+- Optional Modify: `src/NovaTerminal.App/Core/SshAskPassCommand.cs`
+
+**Step 1: Update tests**
+
+Replace current tests that assert NativeSSH configures `SSH_ASKPASS` with tests asserting NativeSSH selects `NativeSftp` and does not build `scp` start info.
+
+**Step 2: Run tests to verify they fail**
+
+Expected: fail while old askpass branch remains.
+
+**Step 3: Remove NativeSSH askpass transfer branch**
+
+Keep `SshAskPassCommand` only if still needed for OpenSSH profile UX. If it is only used by NativeSSH transfers, delete it and remove CLI/App mode wiring.
+
+**Step 4: Run tests**
+
+Expected: pass.
+
+**Step 5: Commit**
+
+```powershell
+git add src/NovaTerminal.App/Core/SftpService.cs tests/NovaTerminal.Tests/Core/SftpServiceTests.cs src/NovaTerminal.App/Core/SshAskPassCommand.cs src/NovaTerminal.App/Program.cs src/NovaTerminal.Cli/Program.cs
+git commit -m "refactor: remove native ssh transfer askpass bridge"
+```
+
+## Task 12: Documentation And Manual Verification
+
+**Files:**
+- Modify: `docs/USER_MANUAL.md`
+- Modify: `docs/SSH_ROADMAP.md` if present/relevant
+- Modify: `docs/ROADMAP.md` if status needs updating
+
+**Step 1: Update user docs**
+
+Document:
+
+- OpenSSH transfers use system `scp`
+- NativeSSH transfers use built-in native SFTP
+- Native SFTP supports file/folder upload/download
+- known limitations, if any
+
+**Step 2: Manual verification checklist**
+
+Run the app and verify:
+
+- NativeSSH password-auth profile: download file
+- NativeSSH password-auth profile: upload file
+- NativeSSH identity-file profile: download file
+- NativeSSH folder download
+- NativeSSH folder upload
+- OpenSSH profile still transfers through existing path
+- Transfer Center status updates
+- cancel during large transfer
+- missing remote path shows useful error
+
+**Step 3: Full focused test command**
+
+Run:
+
+```powershell
+$env:SKIP_RUST_NATIVE_BUILD='1'
+dotnet test tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj -c NativeSftpFinal --filter "FullyQualifiedName~SftpServiceTests" --no-restore -p:SkipCliShim=true -m:1
+dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c NativeSftpFinal --filter "FullyQualifiedName~NativeSftp|FullyQualifiedName~NativeSshDockerE2eTests" --no-restore -m:1
+```
+
+Expected: all focused tests pass.
+
+**Step 4: Commit**
+
+```powershell
+git add docs tests src
+git commit -m "docs: document native sftp transfers"
+```
+
+## Rollout Notes
+
+- Keep the external `scp` path as fallback for OpenSSH profiles.
+- If native SFTP fails for a NativeSSH profile, do not silently fall back to external `scp`; report the native error. Silent fallback would reintroduce duplicate auth and platform-specific behavior.
+- If `russh-sftp` integration blocks on version incompatibility for more than one day, stop and reassess before writing protocol code from scratch.
+
+## Final Verification
+
+Before claiming completion:
+
+```powershell
+$env:SKIP_RUST_NATIVE_BUILD='1'
+dotnet test tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj -c NativeSftpFinal --no-restore -p:SkipCliShim=true -m:1
+dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c NativeSftpFinal --no-restore -m:1
+```
+
+Expected: all tests pass, or any unrelated failures are documented with exact test names and failure messages.

--- a/docs/plans/2026-04-27-native-sftp-progress-callbacks.md
+++ b/docs/plans/2026-04-27-native-sftp-progress-callbacks.md
@@ -1,0 +1,303 @@
+# Native SFTP Progress Callbacks Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add real live byte progress for NativeSSH transfers by streaming Rust SFTP copy progress into C# `TransferJob` updates.
+
+**Architecture:** Keep the current NativeSSH one-shot transfer API, but extend it with a native callback function pointer and opaque user-data payload. Rust emits per-file byte progress during copy loops, `NativeSshInterop` marshals it into `NativeSftpTransferProgress`, and `SftpService` continues to own job updates and UI notifications.
+
+**Tech Stack:** C#, .NET 10, Avalonia, P/Invoke, Rust, `russh`, `russh-sftp`, xUnit
+
+---
+
+### Task 1: Define The Managed Progress Contract
+
+**Files:**
+- Modify: `src/NovaTerminal.Core/Ssh/Native/NativeSftpTransferModels.cs`
+- Modify: `src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs`
+- Test: `tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs`
+
+**Step 1: Write the failing tests**
+
+Add tests that describe the progress payload shape and callback forwarding contract:
+
+```csharp
+[Fact]
+public void ProgressPayload_AllowsKnownTotalAndCurrentPath()
+{
+    var progress = new NativeSftpTransferProgress
+    {
+        BytesDone = 128,
+        BytesTotal = 1024,
+        CurrentPath = "/tmp/report.txt"
+    };
+
+    Assert.Equal(128, progress.BytesDone);
+    Assert.Equal(1024, progress.BytesTotal);
+    Assert.Equal("/tmp/report.txt", progress.CurrentPath);
+}
+```
+
+Also add an interop-focused test scaffold that will fail until `NativeSshInterop` can translate a native callback into the managed `Action<NativeSftpTransferProgress>`.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c NativeSftpPlan --filter "FullyQualifiedName~NativeSftpTransferInteropTests" --no-restore -m:1
+```
+
+Expected: FAIL because the callback translation test is not implemented yet.
+
+**Step 3: Write minimal contract changes**
+
+- Keep `NativeSftpTransferProgress` as the managed payload type
+- Do not widen `INativeSshInterop.RunSftpTransfer(...)` beyond the existing `Action<NativeSftpTransferProgress>? progress`
+- Add only the interop support types needed to marshal native callback data
+
+**Step 4: Run test to verify the simple payload test passes and the callback test still drives the next task**
+
+Run the same command.
+
+Expected: one payload test PASS, callback translation test still FAIL.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.Core/Ssh/Native/NativeSftpTransferModels.cs src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs
+git commit -m "test: define native sftp progress contract"
+```
+
+### Task 2: Add Managed Native Callback Marshaling
+
+**Files:**
+- Modify: `src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs`
+- Test: `tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs`
+
+**Step 1: Write the failing tests**
+
+Add a focused test that proves native callback payloads become managed progress updates. Do this by extracting a small internal helper instead of trying to invoke the real DLL from the test:
+
+```csharp
+[Fact]
+public void NativeProgressCallback_TranslatesPayloadToManagedProgress()
+{
+    NativeSftpTransferProgress? observed = null;
+
+    NativeSshInterop.InvokeManagedProgressCallbackForTest(
+        progress => observed = progress,
+        bytesDone: 512,
+        bytesTotal: 2048,
+        currentPath: "/tmp/archive.tar");
+
+    Assert.NotNull(observed);
+    Assert.Equal(512, observed!.BytesDone);
+    Assert.Equal(2048, observed.BytesTotal);
+    Assert.Equal("/tmp/archive.tar", observed.CurrentPath);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c NativeSftpPlan --filter "FullyQualifiedName~NativeSftpTransferInteropTests.NativeProgressCallback_TranslatesPayloadToManagedProgress" --no-restore -m:1
+```
+
+Expected: FAIL because the helper/callback marshaling does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+In `NativeSshInterop.cs`:
+
+- add a private delegate matching the native callback ABI
+- add a private callback state object holding the managed `Action<NativeSftpTransferProgress>`
+- add a small internal helper for test-only callback translation
+- pass the callback function pointer and user data into the native `nova_ssh_sftp_transfer` call
+- make callback exceptions non-fatal to the transfer
+
+Do not redesign the public `INativeSshInterop` surface.
+
+**Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c NativeSftpPlan --filter "FullyQualifiedName~NativeSftpTransferInteropTests" --no-restore -m:1
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs
+git commit -m "feat: marshal native sftp progress callbacks"
+```
+
+### Task 3: Emit Progress From Rust File Copy Loops
+
+**Files:**
+- Modify: `src/NovaTerminal.App/native/rusty_ssh/src/lib.rs`
+- Modify: `src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs`
+- Test: `tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs`
+
+**Step 1: Write the failing end-to-end test**
+
+Add a Docker-backed NativeSSH transfer test that records progress callbacks during a real file transfer:
+
+```csharp
+[Fact]
+public async Task NativeSftp_CanReportProgressDuringDownload()
+{
+    // arrange remote file with enough content to produce multiple callbacks
+    // capture progress payloads into a list
+    // run NativeSshInterop.RunSftpTransfer(...)
+    // assert at least one callback arrived before completion
+    // assert one callback had BytesTotal > 0
+}
+```
+
+Keep it file-based first. Do not start with directory aggregation.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c NativeSftpPlan --filter "FullyQualifiedName~NativeSshDockerE2eTests.NativeSftp_CanReportProgressDuringDownload" --no-restore -m:1
+```
+
+Expected: FAIL because the native layer does not emit callbacks yet, or SKIP if Docker is unavailable locally. If skipped locally, still keep the test as the red test for CI/manual Docker runs.
+
+**Step 3: Write minimal Rust implementation**
+
+In `lib.rs`:
+
+- extend the exported `nova_ssh_sftp_transfer(...)` signature to accept:
+  - callback function pointer
+  - callback user-data pointer
+- define a small Rust progress emitter helper
+- look up local file size for uploads and remote metadata size for downloads when available
+- update `copy_file_with_cancellation(...)` to:
+  - accumulate bytes copied
+  - invoke the callback after each chunk
+  - pass `current_path`
+- for directory transfers, emit progress for each current file without attempting recursive total precomputation
+
+In `NativeSshInterop.cs`:
+
+- update the P/Invoke signature to match the new native ABI
+
+**Step 4: Run verification**
+
+Run:
+
+```bash
+cargo build --manifest-path src\NovaTerminal.App\native\rusty_ssh\Cargo.toml
+dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c NativeSftpPlan --filter "FullyQualifiedName~NativeSftpTransferInteropTests|FullyQualifiedName~NativeSshDockerE2eTests.NativeSftp_CanReportProgressDuringDownload" --no-restore -m:1
+```
+
+Expected: Rust build PASS. Interop tests PASS. Docker progress test PASS when Docker is available.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/native/rusty_ssh/src/lib.rs src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
+git commit -m "feat: emit native sftp file progress"
+```
+
+### Task 4: Verify Service/UI Consumption Of Native Progress
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Core/SftpService.cs`
+- Test: `tests/NovaTerminal.Tests/Core/SftpServiceTests.cs`
+- Test: `tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs`
+
+**Step 1: Write the failing tests**
+
+Add one service-level test that proves repeated native progress callbacks mutate the job correctly:
+
+```csharp
+[Fact]
+public void ApplyNativeTransferProgress_UpdatesDisplayStateForKnownTotals()
+{
+    var job = new TransferJob { State = TransferState.Running };
+
+    SftpService.ApplyNativeTransferProgress(job, new NativeSftpTransferProgress
+    {
+        BytesDone = 1024,
+        BytesTotal = 4096,
+        CurrentPath = "/tmp/sample.bin"
+    });
+
+    Assert.Equal(0.25, job.Progress, 3);
+    Assert.False(job.IsProgressIndeterminate);
+    Assert.Contains("25%", job.StatusText, StringComparison.Ordinal);
+}
+```
+
+Add one Docker directory-transfer test that confirms progress callbacks occur during a folder transfer, even if totals remain file-scoped.
+
+**Step 2: Run tests to verify they fail or skip appropriately**
+
+Run:
+
+```bash
+dotnet test tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj -c NativeSftpPlanApp --filter "FullyQualifiedName~SftpServiceTests" --no-restore -p:SkipCliShim=true -m:1
+dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c NativeSftpPlan --filter "FullyQualifiedName~NativeSshDockerE2eTests.NativeSftp_CanReportProgressDuringDirectoryDownload" --no-restore -m:1
+```
+
+Expected: service test FAIL until formatting/state behavior matches; Docker directory test FAIL or SKIP until callbacks are observed.
+
+**Step 3: Write minimal implementation**
+
+- keep `SftpService.ApplyNativeTransferProgress(...)` as the single job-update mapping point
+- only adjust it if needed for:
+  - known-total percentage
+  - indeterminate state when total is zero
+  - current-path-aware display text if that becomes necessary
+
+Do not add new UI surfaces in this task.
+
+**Step 4: Run verification**
+
+Run:
+
+```bash
+dotnet build src\NovaTerminal.App\NovaTerminal.App.csproj -c NativeSftpPlanApp --no-restore -p:SkipCliShim=true
+dotnet test tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj -c NativeSftpPlanApp --filter "FullyQualifiedName~SftpServiceTests" --no-restore -p:SkipCliShim=true -m:1
+dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c NativeSftpPlan --filter "FullyQualifiedName~NativeSftpTransferInteropTests|FullyQualifiedName~NativeSshDockerE2eTests" --no-restore -m:1
+```
+
+Expected: build PASS, service tests PASS, native Docker tests PASS when Docker is available.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Core/SftpService.cs tests/NovaTerminal.Tests/Core/SftpServiceTests.cs tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
+git commit -m "test: verify native sftp progress propagation"
+```
+
+### Task 5: Update Docs And PR Notes
+
+**Files:**
+- Modify: `docs/USER_MANUAL.md`
+- Modify: `docs/SSH_ROADMAP.md`
+
+**Step 1: Write the minimal doc changes**
+
+Document that NativeSSH transfers now show live native progress for file transfers and per-file progress for folder transfers when totals are known.
+
+**Step 2: Verify docs reflect reality**
+
+Manually confirm the text does not claim OpenSSH progress changes or recursive total aggregation that the code does not implement.
+
+**Step 3: Commit**
+
+```bash
+git add docs/USER_MANUAL.md docs/SSH_ROADMAP.md
+git commit -m "docs: describe native sftp live progress"
+```

--- a/docs/plans/2026-04-27-native-sftp-progress-design.md
+++ b/docs/plans/2026-04-27-native-sftp-progress-design.md
@@ -1,0 +1,113 @@
+# Native SFTP Progress Design
+
+**Date:** 2026-04-27
+
+**Goal:** Add real live transfer progress for NativeSSH file and folder transfers without changing the OpenSSH `scp` path.
+
+## Scope
+
+- NativeSSH transfers only
+- Byte-based progress when total size is known
+- Indeterminate progress when total size is unknown
+- Reuse the existing `TransferJob` UI path in `SftpService`, `TransferCenter`, and `TerminalPane`
+- No redesign of the OpenSSH transfer path in this change
+
+## Current Problem
+
+The NativeSSH transfer path now uses built-in SFTP, but the Rust interop is still a one-shot call. C# waits until the native transfer returns, so there is no reliable stream of byte progress into the UI. The recent UI fixes made job state visible, but they cannot show true live byte progress until the native backend emits progress during the copy loop.
+
+## Chosen Approach
+
+Add a Rust-to-C# progress callback to the existing native transfer call.
+
+Why this approach:
+
+- Smallest change that unlocks real progress
+- Keeps transfers separate from terminal session events
+- Preserves the current `SftpService` ownership of queueing, job state, and UI notifications
+- Avoids inventing a larger start/poll/finish transfer handle API
+
+## Rejected Approaches
+
+### 1. Polling transfer handles
+
+This would create a cleaner long-term transfer API, but it is too much surface area for this problem. It would force a broader redesign of the native interop boundary and cancellation flow.
+
+### 2. Reusing native terminal session events
+
+This mixes transfer concerns into the terminal-session event channel. The current architecture intentionally keeps transfers separate from terminal rendering and PTY flow. Reusing session events would weaken that boundary.
+
+### 3. Synthetic estimated progress
+
+This would show movement even when totals are unknown, but it would be misleading. The chosen behavior is determinate only when the backend can provide a real byte total.
+
+## Architecture
+
+### Native interop boundary
+
+Extend the `nova_ssh_sftp_transfer` ABI so C# can provide a callback function pointer plus opaque user data. Rust will invoke the callback with:
+
+- `bytes_done`
+- `bytes_total`
+- `current_path`
+
+The callback is advisory only. It must not own transfer state or UI logic.
+
+### Rust transfer behavior
+
+The Rust SFTP layer will:
+
+- determine file size when available before starting a file copy
+- emit progress after each chunk written
+- emit per-file progress for directory transfers using the current file path
+- preserve cancellation checks during the same copy loops
+
+For directory transfers, the first version will report progress for the current file, not a precomputed recursive total for the entire tree. That keeps the implementation honest and small.
+
+### C# transfer behavior
+
+`NativeSshInterop` will:
+
+- marshal the callback into managed code
+- translate native progress payloads into `NativeSftpTransferProgress`
+- invoke the existing `progress` delegate already accepted by `RunSftpTransfer`
+
+`SftpService` already knows how to apply native progress to `TransferJob`. It will continue to own job-level updates and UI notifications.
+
+### UI behavior
+
+No new transfer surface is required for this step. Existing UI should improve automatically once native progress starts flowing:
+
+- `TransferCenter` shows determinate progress when `BytesTotal > 0`
+- `TransferCenter` shows indeterminate progress when total is unknown
+- `TerminalPane` status text can show meaningful percentages when available
+
+## Error Handling
+
+- Progress callback failures in managed code must not crash the transfer process
+- If a native path cannot determine size, the transfer continues with `BytesTotal = 0`
+- Existing cancellation and transfer error mapping stay in place
+
+## Testing Strategy
+
+### C# tests
+
+- interop unit test that proves a native progress callback is translated into `NativeSftpTransferProgress`
+- `SftpService` test that proves job progress/state properties update from native callback payloads
+
+### Rust/native tests
+
+- targeted unit test for progress payload serialization and callback invocation where practical
+- no change to VT, terminal rendering, or unrelated SSH session behavior
+
+### End-to-end tests
+
+- Docker NativeSSH file download/upload tests should observe progress updates before completion
+- directory transfer tests should observe current-file progress callbacks without requiring recursive byte pre-summing
+
+## Success Criteria
+
+- NativeSSH file transfers visibly update progress while running
+- NativeSSH folder transfers visibly update the active file progress while running
+- Unknown total size falls back to indeterminate progress
+- OpenSSH transfer behavior remains unchanged

--- a/docs/plans/2026-04-28-native-remote-path-autocomplete-design.md
+++ b/docs/plans/2026-04-28-native-remote-path-autocomplete-design.md
@@ -1,0 +1,234 @@
+# Native Remote Path Autocomplete Design
+
+## Goal
+
+Make remote path entry materially easier in NovaTerminal without turning the app into a remote file browser. The first user-facing integration point is the transfer dialog, but the implementation should be reusable for future remote-path inputs.
+
+## Scope
+
+This design adds:
+
+1. NativeSSH-only remote path autocomplete
+2. Active-session-gated suggestions
+3. Directory and file suggestions
+4. A reusable autocomplete input surface for remote-path text entry
+
+This design does not add:
+
+- OpenSSH support
+- recursive search
+- a remote file browser
+- terminal-grid rendering changes
+- autocomplete for inputs that are not tied to an active SSH session
+
+## Constraints
+
+- NativeSSH is the only supported backend for this feature
+- suggestions must not go through terminal stdout/stderr
+- autocomplete must remain optional help, never a blocker for manual typing
+- the implementation must be reusable outside the transfer dialog
+- active session presence is required before suggestions are fetched
+
+## Product Direction
+
+NovaTerminal remains terminal-first. Remote path autocomplete should feel closer to shell completion than to a file manager.
+
+That means:
+
+- text input stays primary
+- suggestions appear inline under the input
+- keyboard selection matters more than visual chrome
+- the user can always ignore suggestions and type the full path manually
+
+## Chosen Approach
+
+Use a dedicated NativeSSH remote listing query path, separate from terminal IO, and expose it through a reusable autocomplete service in the app layer.
+
+Suggestions are only available when:
+
+- the current profile uses NativeSSH
+- there is a live active SSH session associated with that profile/input context
+
+The presence of an active session is a product and UX gate. The actual suggestion query remains a dedicated native request path, not terminal output scraping.
+
+## Why This Approach
+
+### Rejected: reuse the terminal session stream
+
+Running completion commands through the visible terminal session would pollute terminal output, interfere with shell state, and create prompt-parsing edge cases. That is not acceptable in NovaTerminal.
+
+### Rejected: full remote browser
+
+That is a larger product surface with browsing, navigation, loading, refresh, and permissions concerns. It solves a different problem and would drag the transfer workflow toward a separate SFTP client.
+
+### Rejected: OpenSSH compatibility layer
+
+The user is explicitly moving away from OpenSSH. Designing for two backends here would add complexity without payoff.
+
+## Backend Query Model
+
+The native backend gets a small directory-listing request for autocomplete.
+
+Expected request shape:
+
+- connection options
+- remote parent path to list
+
+Expected response shape:
+
+- entry name
+- full path
+- `isDirectory`
+
+Optional metadata like size or mtime is out of scope for v1.
+
+The backend should list one directory at a time. The app layer will filter typed prefixes client-side. This keeps the number of native roundtrips low while preserving responsive typing.
+
+## Active Session Gating
+
+Autocomplete must only run when the app knows there is an active NativeSSH session for the relevant profile/input context.
+
+Because autocomplete is meant to be reusable, the app needs a lightweight active-session registry rather than hardcoding the transfer dialog to the current pane.
+
+The registry should track enough metadata to answer:
+
+- is this session still active?
+- which profile does it belong to?
+- is the backend NativeSSH?
+
+It should not become a new execution layer for terminal traffic. It is only a gate and lookup source for autocomplete.
+
+## Query Resolution Rules
+
+Given a typed remote path, the app resolves:
+
+1. the parent directory to query
+2. the leaf prefix to filter
+
+Examples:
+
+- `~/Do` -> query `~`, filter `Do`
+- `/mnt/media/mov` -> query `/mnt/media`, filter `mov`
+- `/mnt/media/movies/` -> query `/mnt/media/movies`, filter empty prefix
+
+The app should support:
+
+- absolute paths
+- `~`
+- partially typed final path segments
+
+Out of scope:
+
+- recursive globbing
+- shell variable expansion beyond `~`
+
+## Suggestion Ranking
+
+V1 ranking should stay simple and deterministic:
+
+1. prefix match before contains match
+2. directories before files when both are exact prefix matches
+3. alphabetical within the same rank group
+
+This is enough for a useful first pass and easy to test.
+
+## UI Behavior
+
+Each remote-path input using this feature should show a popup under the textbox.
+
+Behavior:
+
+- debounce user typing by about `150-250 ms`
+- fetch directory entries for the resolved parent path
+- filter and rank matches client-side
+- show both directories and files
+- visually distinguish directories
+
+Keyboard behavior:
+
+- `Down` / `Up` moves the selected suggestion
+- `Enter` accepts the selected suggestion
+- `Tab` accepts the selected suggestion if one exists
+- `Escape` closes only the suggestion popup first
+
+Completion behavior:
+
+- selecting a directory inserts the completed path and appends `/`
+- selecting a file inserts the full file path
+- focus stays in the input
+
+Failure behavior:
+
+- no active session -> no popup, plain typing still works
+- native query failure -> suppress suggestions for that cycle, no modal error
+
+## Reusable UI Surface
+
+There are no other active-session-aware remote-path inputs on this branch today besides the transfer dialog flow. To still satisfy reuse, the UI implementation should not be transfer-specific.
+
+The preferred shape is a reusable control or controller such as:
+
+- `RemotePathInput`
+- or a textbox-attached autocomplete controller plus popup
+
+The first integration target is `TransferDialog`. Future remote-path inputs should be able to adopt the same component without copying behavior.
+
+## App-Layer Service
+
+The app should expose a single autocomplete service abstraction that:
+
+- accepts the active session context
+- accepts the current remote input text
+- returns ranked suggestions
+
+Responsibilities:
+
+- validate gating rules
+- resolve parent path and prefix
+- invoke the native listing request
+- apply filtering and ranking
+
+This keeps the UI control thin and keeps query semantics testable without UI.
+
+## Testing Strategy
+
+### Deterministic unit tests
+
+- path splitting and parent resolution
+- ranking and filtering
+- active-session gating
+- `~` handling
+- directory completion appends `/`
+
+### Core interop tests
+
+- native list-directory request JSON
+- native response parsing
+
+### UI tests
+
+- popup opens when suggestions exist
+- keyboard selection and acceptance
+- popup closes on `Escape`
+- selecting a suggestion updates the textbox
+
+### Optional E2E
+
+- Docker-backed NativeSSH listing test for one known directory
+
+## Rollout
+
+1. add native list-directory interop
+2. add active NativeSSH session registry
+3. add autocomplete service and ranking logic
+4. add reusable remote-path autocomplete UI
+5. integrate into transfer dialog
+
+## Expected Outcome
+
+After this work:
+
+- remote path entry is significantly easier for NativeSSH transfers
+- terminal output remains untouched
+- the UI stays text-first and keyboard-friendly
+- the code path is reusable for future active-session-aware remote-path inputs

--- a/docs/plans/2026-04-28-native-remote-path-autocomplete-implementation-plan.md
+++ b/docs/plans/2026-04-28-native-remote-path-autocomplete-implementation-plan.md
@@ -1,0 +1,518 @@
+# Native Remote Path Autocomplete Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add NativeSSH-only remote path autocomplete for active-session-backed remote-path inputs, starting with the transfer dialog.
+
+**Architecture:** Add a dedicated native directory-listing request in the existing Rust/C# NativeSSH interop, gate autocomplete through an app-layer active-session registry, and surface suggestions through a reusable autocomplete control or controller instead of transfer-specific code. Keep completion traffic fully separate from the visible terminal stream.
+
+**Tech Stack:** Avalonia UI, NativeSSH interop (`NativeSshInterop` + `rusty_ssh`), xUnit, Avalonia.Headless.XUnit, existing NativeSSH Docker tests
+
+---
+
+### Task 1: Add autocomplete path parsing and ranking primitives
+
+**Files:**
+- Create: `src/NovaTerminal.App/Services/Ssh/RemotePathAutocompleteQuery.cs`
+- Create: `src/NovaTerminal.App/Models/RemotePathSuggestion.cs`
+- Test: `tests/NovaTerminal.Tests/Ssh/RemotePathAutocompleteQueryTests.cs`
+
+**Step 1: Write the failing tests**
+
+```csharp
+[Fact]
+public void Parse_WhenGivenPartialAbsolutePath_SplitsParentAndPrefix()
+{
+    var query = RemotePathAutocompleteQuery.Parse("/mnt/media/mov");
+
+    Assert.Equal("/mnt/media", query.ParentPath);
+    Assert.Equal("mov", query.Prefix);
+}
+
+[Fact]
+public void RankSuggestions_PrefersDirectoryPrefixMatchesBeforeFiles()
+{
+    var suggestions = RemotePathAutocompleteQuery.Rank(
+        new[]
+        {
+            new RemotePathSuggestion("movie.mkv", "/mnt/media/movie.mkv", isDirectory: false),
+            new RemotePathSuggestion("movies", "/mnt/media/movies", isDirectory: true)
+        },
+        prefix: "mov");
+
+    Assert.Equal("movies", suggestions[0].DisplayName);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c NativeSftpUiFixApp --filter "FullyQualifiedName~RemotePathAutocompleteQueryTests" -p:SkipCliShim=true -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because the query parser and suggestion model do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+
+- `RemotePathSuggestion`
+- `RemotePathAutocompleteQuery.Parse(string input)`
+- `RemotePathAutocompleteQuery.Rank(...)`
+
+Keep the rules minimal:
+
+- support `~`, `/`, and partial leaf names
+- directories rank before files within the same prefix-match tier
+- alphabetical within the same tier
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Services/Ssh/RemotePathAutocompleteQuery.cs src/NovaTerminal.App/Models/RemotePathSuggestion.cs tests/NovaTerminal.Tests/Ssh/RemotePathAutocompleteQueryTests.cs
+git commit -m "feat: add remote path autocomplete query primitives"
+```
+
+### Task 2: Add an active NativeSSH session registry
+
+**Files:**
+- Create: `src/NovaTerminal.App/Services/Ssh/ActiveSshSessionRegistry.cs`
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs`
+- Test: `tests/NovaTerminal.Tests/Ssh/ActiveSshSessionRegistryTests.cs`
+
+**Step 1: Write the failing test**
+
+```csharp
+[Fact]
+public void TryGetNativeSession_WhenRegisteredActiveNativeSessionExists_ReturnsDescriptor()
+{
+    var registry = new ActiveSshSessionRegistry();
+    Guid sessionId = Guid.NewGuid();
+    Guid profileId = Guid.NewGuid();
+
+    registry.Register(new ActiveSshSessionDescriptor(
+        sessionId,
+        profileId,
+        SshBackendKind.Native));
+
+    Assert.True(registry.TryGet(sessionId, out ActiveSshSessionDescriptor? descriptor));
+    Assert.Equal(profileId, descriptor!.ProfileId);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c NativeSftpUiFixApp --filter "FullyQualifiedName~ActiveSshSessionRegistryTests" -p:SkipCliShim=true -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because the registry does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- `ActiveSshSessionDescriptor`
+- register/unregister/try-get APIs
+- `TerminalPane` registration when an SSH session starts
+- `TerminalPane` cleanup when the session exits or the pane disposes
+
+Keep it as metadata only. Do not route terminal IO through the registry.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Services/Ssh/ActiveSshSessionRegistry.cs src/NovaTerminal.App/Controls/TerminalPane.axaml.cs tests/NovaTerminal.Tests/Ssh/ActiveSshSessionRegistryTests.cs
+git commit -m "feat: track active native ssh sessions for autocomplete"
+```
+
+### Task 3: Add native directory-listing interop in C#
+
+**Files:**
+- Modify: `src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs`
+- Modify: `src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs`
+- Test: `tests/NovaTerminal.Core.Tests/Ssh/NativeSshRemotePathInteropTests.cs`
+
+**Step 1: Write the failing tests**
+
+```csharp
+[Fact]
+public void SerializeDirectoryListRequest_UsesGeneratedJsonMetadata()
+{
+    string json = NativeSshInterop.SerializeRemotePathListRequestForTests(
+        connectionOptions,
+        "/mnt/media");
+
+    Assert.Contains("\"path\":\"/mnt/media\"", json);
+}
+
+[Fact]
+public void DeserializeDirectoryListResponse_ReadsDirectoryFlags()
+{
+    const string json = """
+    {"entries":[{"name":"movies","fullPath":"/mnt/media/movies","isDirectory":true}]}
+    """;
+
+    var entries = NativeSshInterop.DeserializeRemotePathListResponseForTests(json);
+
+    Assert.Single(entries);
+    Assert.True(entries[0].IsDirectory);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c NativeSftpPlan --filter "FullyQualifiedName~NativeSshRemotePathInteropTests" --no-restore -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because the request/response types and API do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add a new interop API, for example:
+
+```csharp
+IReadOnlyList<NativeRemotePathEntry> ListRemoteDirectory(
+    NativeSshConnectionOptions connectionOptions,
+    string remotePath,
+    CancellationToken cancellationToken);
+```
+
+Use source-generated JSON metadata just like the native transfer path. Keep the response shape small and explicit.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs tests/NovaTerminal.Core.Tests/Ssh/NativeSshRemotePathInteropTests.cs
+git commit -m "feat: add native remote path listing interop"
+```
+
+### Task 4: Implement the Rust native directory-listing request
+
+**Files:**
+- Modify: `src/NovaTerminal.App/native/rusty_ssh/src/lib.rs`
+- Test: `src/NovaTerminal.App/native/rusty_ssh/src/lib.rs` (unit tests)
+- Optional: modify `src/NovaTerminal.App/native/rusty_ssh/Cargo.toml` only if a new crate is truly required
+
+**Step 1: Write the failing Rust test**
+
+Add a focused unit test near the current transfer tests that validates the list request against a known directory response shape.
+
+Example shape:
+
+```rust
+#[test]
+fn sftp_list_directory_returns_entries_with_directory_flags() {
+    let response = run_list_directory_for_test("/tmp");
+    assert!(response.entries.iter().any(|entry| entry.is_directory));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cargo test --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml sftp_list_directory
+```
+
+Expected: FAIL because the native listing entry point does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add a new native export analogous to the transfer entry point:
+
+- parse request JSON
+- connect with the existing NativeSSH connection path
+- open an SFTP client
+- list one directory
+- return entry name, full path, and directory flag
+
+Do not add recursion, metadata expansion, or caching.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+git commit -m "feat: add native remote path listing request"
+```
+
+### Task 5: Add the app-layer remote path autocomplete service
+
+**Files:**
+- Create: `src/NovaTerminal.App/Services/Ssh/IRemotePathAutocompleteService.cs`
+- Create: `src/NovaTerminal.App/Services/Ssh/RemotePathAutocompleteService.cs`
+- Test: `tests/NovaTerminal.Tests/Ssh/RemotePathAutocompleteServiceTests.cs`
+
+**Step 1: Write the failing tests**
+
+```csharp
+[Fact]
+public async Task GetSuggestionsAsync_WhenNoActiveNativeSessionExists_ReturnsEmpty()
+{
+    var service = CreateServiceWithNoSession();
+
+    var results = await service.GetSuggestionsAsync(profileId, sessionId, "/mnt/media/mov", CancellationToken.None);
+
+    Assert.Empty(results);
+}
+
+[Fact]
+public async Task GetSuggestionsAsync_FiltersNativeEntriesUsingResolvedParentPath()
+{
+    var service = CreateServiceWithEntries(
+        "/mnt/media",
+        new[]
+        {
+            new NativeRemotePathEntry("movies", "/mnt/media/movies", true),
+            new NativeRemotePathEntry("music", "/mnt/media/music", true)
+        });
+
+    var results = await service.GetSuggestionsAsync(profileId, sessionId, "/mnt/media/mov", CancellationToken.None);
+
+    Assert.Single(results);
+    Assert.Equal("/mnt/media/movies", results[0].FullPath);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c NativeSftpUiFixApp --filter "FullyQualifiedName~RemotePathAutocompleteServiceTests" -p:SkipCliShim=true -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because the service does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Responsibilities:
+
+- check the active session registry
+- reject non-native or inactive sessions
+- build native connection options from the active profile
+- call the native listing API
+- rank/filter suggestions with `RemotePathAutocompleteQuery`
+
+Keep the service ignorant of popup/UI state.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Services/Ssh/IRemotePathAutocompleteService.cs src/NovaTerminal.App/Services/Ssh/RemotePathAutocompleteService.cs tests/NovaTerminal.Tests/Ssh/RemotePathAutocompleteServiceTests.cs
+git commit -m "feat: add remote path autocomplete service"
+```
+
+### Task 6: Add a reusable remote-path autocomplete input surface
+
+**Files:**
+- Create: `src/NovaTerminal.App/Controls/RemotePathInput.axaml`
+- Create: `src/NovaTerminal.App/Controls/RemotePathInput.axaml.cs`
+- Create: `src/NovaTerminal.App/Models/RemotePathInputContext.cs`
+- Test: `tests/NovaTerminal.Tests/Core/RemotePathInputTests.cs`
+
+**Step 1: Write the failing UI tests**
+
+```csharp
+[AvaloniaFact]
+public async Task RemotePathInput_WhenSuggestionsExist_ShowsPopupAndAcceptsTab()
+{
+    var control = new RemotePathInput();
+    control.SetSuggestionsForTests(new[]
+    {
+        new RemotePathSuggestion("movies", "/mnt/media/movies", isDirectory: true)
+    });
+
+    control.Text = "/mnt/media/mov";
+    await control.TriggerSuggestionsForTests();
+    control.RaiseKeyDown(Key.Tab);
+
+    Assert.Equal("/mnt/media/movies/", control.Text);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c NativeSftpUiFixApp --filter "FullyQualifiedName~RemotePathInputTests" -p:SkipCliShim=true -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because the reusable input control does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- textbox
+- popup/listbox under the textbox
+- debounce timer
+- keyboard handling for `Up`, `Down`, `Tab`, `Enter`, `Escape`
+- directory completion with trailing `/`
+
+Keep the control generic. Do not embed transfer-specific logic in it.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Controls/RemotePathInput.axaml src/NovaTerminal.App/Controls/RemotePathInput.axaml.cs src/NovaTerminal.App/Models/RemotePathInputContext.cs tests/NovaTerminal.Tests/Core/RemotePathInputTests.cs
+git commit -m "feat: add reusable remote path autocomplete input"
+```
+
+### Task 7: Integrate autocomplete into the transfer dialog
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Models/TransferDialogRequest.cs`
+- Modify: `src/NovaTerminal.App/Controls/TransferDialog.axaml`
+- Modify: `src/NovaTerminal.App/Controls/TransferDialog.axaml.cs`
+- Modify: `src/NovaTerminal.App/MainWindow.axaml.cs`
+- Test: `tests/NovaTerminal.Tests/Core/TransferDialogTests.cs`
+- Test: `tests/NovaTerminal.Tests/Core/MainWindowTransferFlowTests.cs`
+
+**Step 1: Write the failing tests**
+
+```csharp
+[AvaloniaFact]
+public void TransferDialog_BindsRemoteAutocompleteContext_FromRequest()
+{
+    var request = new TransferDialogRequest
+    {
+        Direction = TransferDirection.Download,
+        Kind = TransferKind.File,
+        RemotePath = "~/downloads",
+        SessionId = sessionId,
+        ProfileId = profileId
+    };
+
+    var dialog = new TransferDialog(request);
+
+    var remoteInput = dialog.FindControl<RemotePathInput>("RemotePathInput");
+    Assert.Equal(sessionId, remoteInput!.Context.SessionId);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c NativeSftpUiFixApp --filter "FullyQualifiedName~TransferDialogTests|FullyQualifiedName~MainWindowTransferFlowTests" -p:SkipCliShim=true -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because the transfer dialog request does not carry autocomplete context yet.
+
+**Step 3: Write minimal implementation**
+
+- extend `TransferDialogRequest` with the active session/profile context needed by autocomplete
+- replace the raw `RemotePathBox` with `RemotePathInput`
+- have `MainWindow` pass the active session/profile context when building the dialog request
+
+Manual typing must remain valid when no suggestions are available.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Models/TransferDialogRequest.cs src/NovaTerminal.App/Controls/TransferDialog.axaml src/NovaTerminal.App/Controls/TransferDialog.axaml.cs src/NovaTerminal.App/MainWindow.axaml.cs tests/NovaTerminal.Tests/Core/TransferDialogTests.cs tests/NovaTerminal.Tests/Core/MainWindowTransferFlowTests.cs
+git commit -m "feat: enable remote autocomplete in transfer dialog"
+```
+
+### Task 8: Verify the end-to-end NativeSSH autocomplete path
+
+**Files:**
+- Modify: `tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs`
+- Optional Docs: `docs/USER_MANUAL.md` if user-facing transfer instructions need one line of update
+
+**Step 1: Write the failing E2E test**
+
+Add one focused Docker test that lists a known remote directory and verifies at least one expected child entry is returned.
+
+Example shape:
+
+```csharp
+[DockerFact]
+public void NativeSftp_ListDirectory_ReturnsExpectedFixtureEntries()
+{
+    // Arrange docker fixture contents
+    // Act through NativeSshInterop list-directory API
+    // Assert expected file/directory names
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+$env:NOVATERM_ENABLE_DOCKER_E2E='1'
+dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj -c NativeSftpPlan --filter "FullyQualifiedName~NativeSshDockerE2eTests.NativeSftp_ListDirectory" --no-restore -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because the E2E coverage does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add the Docker-backed verification and, only if needed, a short user-manual note that remote autocomplete requires an active NativeSSH session.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs docs/USER_MANUAL.md
+git commit -m "test: cover native remote path autocomplete end to end"
+```

--- a/docs/plans/2026-04-28-transfer-ui-design.md
+++ b/docs/plans/2026-04-28-transfer-ui-design.md
@@ -1,0 +1,233 @@
+# Transfer UI Design
+
+## Goal
+
+Improve NovaTerminal's transfer UX without turning the app into a file browser. Keep the terminal-first model, keep the backend transfer work intact, and replace the current prompt-heavy transfer flow with a focused dialog and a more usable transfer manager surface.
+
+## Scope
+
+This design covers three UI areas:
+
+1. Transfer initiation
+2. Transfer Center behavior
+3. Transfer history management
+
+It does not change VT rendering, terminal parsing, or the native SFTP backend contract beyond small UI-facing metadata that may already exist.
+
+## Constraints
+
+- Use Avalonia for all new UI.
+- Keep UI concerns out of terminal core logic.
+- Prefer additive changes over refactors.
+- Keep the backend transfer execution path stable.
+- Avoid turning transfers into a full remote file explorer in this pass.
+
+## Problem Summary
+
+The current flow has three major problems:
+
+1. Starting a transfer is awkward:
+   - nested context menus
+   - a generic path prompt with little guidance
+   - weak keyboard focus behavior
+   - poor discoverability
+
+2. The Transfer Center is too static:
+   - fixed floating position
+   - no history cleanup affordances
+   - limited row actions
+
+3. Transfer state feedback is not good enough:
+   - weak confirmation of start
+   - stale finished/failed rows accumulate
+   - errors are visible but not presented cleanly
+
+## Chosen Direction
+
+Use a dedicated Transfer Dialog as the primary transfer-entry surface, and keep the Transfer Center as a lightweight movable floating manager for active and recent jobs.
+
+This is more aligned with NovaTerminal than a remote file browser because:
+
+- NovaTerminal is terminal-first, not file-manager-first
+- there is no existing remote browsing pattern to extend
+- the immediate UX problem is workflow and focus, not missing directory navigation
+- a file browser would expand scope into remote listing, navigation, loading, and permissions states
+
+## Alternatives Considered
+
+### 1. Dedicated Transfer Dialog
+
+Recommended.
+
+Pros:
+- clear and explicit
+- fixes focus and paste behavior directly
+- works for upload/download and file/folder without branching UI
+- minimal backend impact
+
+Cons:
+- still requires users to type remote paths
+- less discoverable than a browser for unknown server layouts
+
+### 2. Remote File Browser
+
+Rejected for this pass.
+
+Pros:
+- stronger discoverability
+- easier path selection when users do not know remote paths
+
+Cons:
+- much larger scope
+- pushes NovaTerminal toward a mini SFTP client
+- requires directory listing, navigation, refresh, and permissions UX
+
+### 3. Command Palette Only / Quick Actions
+
+Rejected as the primary flow.
+
+Pros:
+- fast for advanced users
+- low UI footprint
+
+Cons:
+- still weak for collecting both local and remote transfer inputs
+- does not solve the need for a proper form surface
+
+## Transfer Dialog
+
+### Purpose
+
+Provide a single coherent surface for creating upload/download jobs.
+
+### Behavior
+
+- Open directly from transfer actions.
+- Preselect the requested mode:
+  - Upload File
+  - Upload Folder
+  - Download File
+  - Download Folder
+- Show both sides of the transfer in one place:
+  - local path
+  - remote path
+- Keep keyboard focus inside the dialog:
+  - `Ctrl+V` pastes into the focused field
+  - `Enter` confirms when valid
+  - `Escape` cancels
+
+### Fields
+
+- Transfer direction selector
+- Transfer kind selector
+- Local path input with browse button
+- Remote path input with examples / placeholders
+
+### Defaults
+
+- Use the selected transfer action to prefill direction and kind.
+- Prefill remote path from `profile.DefaultRemoteDir ?? "~"`.
+- For download-file actions, when possible, use the remote leaf name as the suggested local filename once a remote path is chosen.
+
+### Validation
+
+- local path required
+- remote path required
+- file/folder mode must match the selected local picker path where practical
+- validation errors shown inline in the dialog instead of surfacing only after queueing
+
+### Entry Points
+
+- terminal context menu actions remain
+- command palette actions remain
+- both launch the same dialog
+
+## Transfer Center
+
+### Purpose
+
+Act as a lightweight transfer manager for active and recent jobs.
+
+### Behavior
+
+- Remain a floating overlay/tool surface
+- Open automatically when a new transfer starts
+- Avoid stealing focus aggressively
+- Become movable by dragging its title bar
+
+### Why Floating Instead Of Docked
+
+- transfers are secondary workflow state
+- a permanent docked panel would compete with terminal space
+- a modal would interrupt long-lived terminal usage too much
+
+### Row Presentation
+
+Each row should clearly show:
+
+- transfer name
+- running/completed/failed/canceled state
+- remote path
+- local path
+- progress bar when applicable
+- compact error text for failures
+
+### Row Actions
+
+- Running: `Cancel`
+- Finished / Failed / Canceled: removable via row action or bulk clear
+
+## History Management
+
+Add explicit cleanup affordances:
+
+- `Clear Finished`
+- `Clear Failed`
+- `Clear All Inactive`
+
+Rules:
+
+- running jobs cannot be cleared
+- canceled jobs are treated as inactive
+- clearing is UI-only history cleanup, not backend job mutation
+
+## Focus And Input Rules
+
+The dialog must own text input while open.
+
+Expected behavior:
+
+- typing edits the focused field
+- paste goes into the field, not the terminal
+- overlay dismissal should not leak keystrokes into the terminal session
+
+This replaces the current generic `PathPromptOverlay` behavior for transfer setup.
+
+## Implementation Shape
+
+- Add a dedicated Avalonia transfer dialog/window
+- Replace `PromptForRemotePathAsync` for transfer flows
+- Keep `SftpService` as the transfer execution/service layer
+- Add only small UI-supporting service/model changes
+- Upgrade `TransferCenter` into a draggable overlay with clear-history actions
+
+## Testing Strategy
+
+- deterministic service tests for history clearing and remote-path normalization if touched
+- headless Avalonia tests for dialog validation and transfer-center interactions where practical
+- avoid broad snapshot-based UI testing
+
+## Rollout Order
+
+1. Transfer Dialog
+2. Transfer Center movement + cleanup actions
+3. Removal of the old path-prompt transfer path
+
+## Expected Outcome
+
+After this work:
+
+- starting a transfer is a single, clear, keyboard-safe flow
+- transfer history is manageable
+- the Transfer Center behaves like a small tool window rather than a fixed overlay
+- backend NativeSSH/OpenSSH transfer behavior stays intact while the UI becomes materially easier to use

--- a/docs/plans/2026-04-28-transfer-ui-implementation-plan.md
+++ b/docs/plans/2026-04-28-transfer-ui-implementation-plan.md
@@ -1,0 +1,423 @@
+# Transfer UI Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace NovaTerminal's current SFTP prompt flow with a dedicated transfer dialog, add transfer-history cleanup controls, and make the Transfer Center a movable floating tool surface.
+
+**Architecture:** Keep `SftpService` as the transfer execution boundary and move transfer-input UX into a dedicated Avalonia dialog. The main window will translate entry-point actions into a single transfer-request flow, while the Transfer Center remains a lightweight overlay with better state management and history controls.
+
+**Tech Stack:** Avalonia UI, existing `SftpService` / `TransferJob` models, xUnit, Avalonia.Headless.XUnit
+
+---
+
+### Task 1: Add a dedicated transfer request model and dialog contract
+
+**Files:**
+- Create: `src/NovaTerminal.App/Models/TransferDialogRequest.cs`
+- Create: `src/NovaTerminal.App/Models/TransferDialogResult.cs`
+- Modify: `src/NovaTerminal.App/MainWindow.axaml.cs`
+- Test: `tests/NovaTerminal.Tests/Core/TransferDialogRequestTests.cs`
+
+**Step 1: Write the failing test**
+
+```csharp
+[Fact]
+public void TransferDialogRequest_ForDownloadFile_UsesRemoteDefaults()
+{
+    TransferDialogRequest request = TransferDialogRequest.ForAction(
+        direction: TransferDirection.Download,
+        kind: TransferKind.File,
+        defaultRemotePath: "~/downloads");
+
+    Assert.Equal(TransferDirection.Download, request.Direction);
+    Assert.Equal(TransferKind.File, request.Kind);
+    Assert.Equal("~/downloads", request.RemotePath);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c NativeSftpUiFixApp --filter "FullyQualifiedName~TransferDialogRequestTests" -p:SkipCliShim=true -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because the request types do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+```csharp
+public sealed class TransferDialogRequest
+{
+    public TransferDirection Direction { get; init; }
+    public TransferKind Kind { get; init; }
+    public string RemotePath { get; init; } = string.Empty;
+
+    public static TransferDialogRequest ForAction(
+        TransferDirection direction,
+        TransferKind kind,
+        string defaultRemotePath) =>
+        new()
+        {
+            Direction = direction,
+            Kind = kind,
+            RemotePath = defaultRemotePath
+        };
+}
+```
+
+Add `TransferDialogResult` with local/remote path payload for the dialog return value.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Models/TransferDialogRequest.cs src/NovaTerminal.App/Models/TransferDialogResult.cs tests/NovaTerminal.Tests/Core/TransferDialogRequestTests.cs src/NovaTerminal.App/MainWindow.axaml.cs
+git commit -m "feat: add transfer dialog request contract"
+```
+
+### Task 2: Add the Transfer Dialog UI and validation
+
+**Files:**
+- Create: `src/NovaTerminal.App/Controls/TransferDialog.axaml`
+- Create: `src/NovaTerminal.App/Controls/TransferDialog.axaml.cs`
+- Modify: `src/NovaTerminal.App/App.axaml` (only if a new converter/resource is required)
+- Test: `tests/NovaTerminal.Tests/Core/TransferDialogTests.cs`
+
+**Step 1: Write the failing test**
+
+```csharp
+[AvaloniaFact]
+public void TransferDialog_DisablesConfirm_WhenRemotePathIsBlank()
+{
+    var dialog = new TransferDialog(new TransferDialogRequest
+    {
+        Direction = TransferDirection.Download,
+        Kind = TransferKind.File,
+        RemotePath = ""
+    });
+
+    Button confirm = dialog.FindControl<Button>("BtnTransferConfirm")!;
+    Assert.False(confirm.IsEnabled);
+}
+```
+
+Add a second test to verify that the remote path `TextBox` receives focus on open and that local/remote validation messages are shown inline.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c NativeSftpUiFixApp --filter "FullyQualifiedName~TransferDialogTests" -p:SkipCliShim=true -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because the dialog does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create a small form surface with:
+
+```xml
+<TextBox Name="RemotePathBox" Watermark="~/downloads or /mnt/share" />
+<TextBox Name="LocalPathBox" />
+<Button Name="BtnBrowseLocal" />
+<Button Name="BtnTransferConfirm" />
+<TextBlock Name="ValidationMessage" />
+```
+
+In code-behind:
+
+```csharp
+private void RefreshValidation()
+{
+    bool valid = !string.IsNullOrWhiteSpace(RemotePathBox.Text)
+        && !string.IsNullOrWhiteSpace(LocalPathBox.Text);
+    BtnTransferConfirm.IsEnabled = valid;
+    ValidationMessage.Text = valid ? string.Empty : "Local and remote paths are required.";
+}
+```
+
+Ensure the dialog focuses `RemotePathBox` after load and traps Enter/Escape for confirm/cancel.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Controls/TransferDialog.axaml src/NovaTerminal.App/Controls/TransferDialog.axaml.cs tests/NovaTerminal.Tests/Core/TransferDialogTests.cs
+git commit -m "feat: add transfer dialog ui"
+```
+
+### Task 3: Replace the old path-prompt transfer flow with the dialog
+
+**Files:**
+- Modify: `src/NovaTerminal.App/MainWindow.axaml`
+- Modify: `src/NovaTerminal.App/MainWindow.axaml.cs`
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs` (only if entry-point wiring changes)
+- Test: `tests/NovaTerminal.Tests/Core/MainWindowTransferFlowTests.cs`
+
+**Step 1: Write the failing test**
+
+```csharp
+[Fact]
+public async Task InitiateTransfer_UsesDialogResultAndQueuesJob()
+{
+    var window = new TestMainWindow();
+    window.NextTransferDialogResult = new TransferDialogResult
+    {
+        LocalPath = @"D:\downloads\a.mkv",
+        RemotePath = "/mnt/box/movies/a.mkv"
+    };
+
+    await window.InitiateTransferForTest(TransferDirection.Download, TransferKind.File);
+
+    Assert.Single(SftpService.Instance.Jobs);
+    Assert.Equal("/mnt/box/movies/a.mkv", SftpService.Instance.Jobs[0].RemotePath);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c NativeSftpUiFixApp --filter "FullyQualifiedName~MainWindowTransferFlowTests" -p:SkipCliShim=true -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because the dialog-backed flow does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+- Add a small overridable dialog-launch method in `MainWindow.axaml.cs`
+- Replace calls to `PromptForRemotePathAsync(...)` inside `InitiateSftpTransfer(...)`
+- Remove the transfer use of `PathPromptOverlay`
+
+Example shape:
+
+```csharp
+internal virtual Task<TransferDialogResult?> ShowTransferDialogAsync(TransferDialogRequest request)
+{
+    var dialog = new TransferDialog(request);
+    return dialog.ShowAsync(this);
+}
+```
+
+Then:
+
+```csharp
+TransferDialogResult? result = await ShowTransferDialogAsync(request);
+if (result is null) return;
+```
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/MainWindow.axaml src/NovaTerminal.App/MainWindow.axaml.cs tests/NovaTerminal.Tests/Core/MainWindowTransferFlowTests.cs
+git commit -m "feat: route transfers through transfer dialog"
+```
+
+### Task 4: Add Transfer Center cleanup actions
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Controls/TransferCenter.axaml`
+- Modify: `src/NovaTerminal.App/Controls/TransferCenter.axaml.cs`
+- Modify: `src/NovaTerminal.App/Core/SftpService.cs`
+- Test: `tests/NovaTerminal.Tests/Core/SftpServiceTests.cs`
+
+**Step 1: Write the failing test**
+
+```csharp
+[Fact]
+public void ClearInactiveJobs_RemovesFinishedFailedAndCanceledOnly()
+{
+    var service = new SftpServiceForTests();
+    service.Jobs.Add(new TransferJob { State = TransferState.Running });
+    service.Jobs.Add(new TransferJob { State = TransferState.Completed });
+    service.Jobs.Add(new TransferJob { State = TransferState.Failed });
+
+    service.ClearInactiveJobs();
+
+    Assert.Single(service.Jobs);
+    Assert.Equal(TransferState.Running, service.Jobs[0].State);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c NativeSftpUiFixApp --filter "FullyQualifiedName~SftpServiceTests.ClearInactiveJobs" -p:SkipCliShim=true -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because cleanup APIs do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add service methods:
+
+```csharp
+public void ClearInactiveJobs() { ... }
+public void ClearFinishedJobs() { ... }
+public void ClearFailedJobs() { ... }
+```
+
+Add toolbar buttons in `TransferCenter.axaml`:
+
+```xml
+<Button Name="BtnClearFinished" Content="Clear Finished" />
+<Button Name="BtnClearFailed" Content="Clear Failed" />
+<Button Name="BtnClearInactive" Content="Clear Inactive" />
+```
+
+Wire button clicks to the new service methods.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2, then the broader `SftpServiceTests` filter.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Controls/TransferCenter.axaml src/NovaTerminal.App/Controls/TransferCenter.axaml.cs src/NovaTerminal.App/Core/SftpService.cs tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
+git commit -m "feat: add transfer history cleanup actions"
+```
+
+### Task 5: Make the Transfer Center movable
+
+**Files:**
+- Modify: `src/NovaTerminal.App/MainWindow.axaml`
+- Modify: `src/NovaTerminal.App/MainWindow.axaml.cs`
+- Test: `tests/NovaTerminal.Tests/Core/MainWindowTransferCenterTests.cs`
+
+**Step 1: Write the failing test**
+
+```csharp
+[AvaloniaFact]
+public void TransferCenterDrag_UpdatesOverlayMargin()
+{
+    var window = new NovaTerminal.MainWindow();
+    Thickness before = window.GetTransferOverlayMarginForTest();
+
+    window.MoveTransferOverlayForTest(new Vector(-120, -40));
+
+    Thickness after = window.GetTransferOverlayMarginForTest();
+    Assert.NotEqual(before, after);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c NativeSftpUiFixApp --filter "FullyQualifiedName~MainWindowTransferCenterTests" -p:SkipCliShim=true -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because drag behavior and test hooks do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+- Add pointer drag handling to the transfer title bar
+- Track overlay margin or translation in `MainWindow`
+- Clamp movement within the window bounds if needed
+
+Example shape:
+
+```csharp
+private void MoveTransferOverlay(Vector delta)
+{
+    TransferOverlay.Margin = new Thickness(
+        Math.Max(0, TransferOverlay.Margin.Left + delta.X),
+        Math.Max(0, TransferOverlay.Margin.Top + delta.Y),
+        0,
+        0);
+}
+```
+
+Keep this session-only; do not persist the position in settings in this pass.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/MainWindow.axaml src/NovaTerminal.App/MainWindow.axaml.cs tests/NovaTerminal.Tests/Core/MainWindowTransferCenterTests.cs
+git commit -m "feat: make transfer center movable"
+```
+
+### Task 6: Remove the old transfer prompt path and update docs
+
+**Files:**
+- Modify: `src/NovaTerminal.App/MainWindow.axaml`
+- Modify: `src/NovaTerminal.App/MainWindow.axaml.cs`
+- Modify: `docs/USER_MANUAL.md`
+- Modify: `docs/SSH_ROADMAP.md`
+
+**Step 1: Write the failing test**
+
+For this cleanup task, use a narrow assertion that the transfer flow no longer depends on the old prompt overlay names.
+
+```csharp
+[Fact]
+public void MainWindow_TransferFlow_NoLongerUsesPathPromptOverlay()
+{
+    string source = File.ReadAllText("src/NovaTerminal.App/MainWindow.axaml.cs");
+    Assert.DoesNotContain("PromptForRemotePathAsync", source, StringComparison.Ordinal);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run the relevant narrow test command.
+
+Expected: FAIL while the old flow remains.
+
+**Step 3: Write minimal implementation**
+
+- Remove the transfer dependency on `PathPromptOverlay`
+- Delete unused transfer-prompt wiring if no longer referenced
+- Update docs to describe:
+  - transfer dialog as the entry point
+  - movable Transfer Center
+  - clear-history actions
+
+**Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj -c NativeSftpUiFixApp --filter "FullyQualifiedName~TransferDialogTests|FullyQualifiedName~MainWindowTransferFlowTests|FullyQualifiedName~MainWindowTransferCenterTests|FullyQualifiedName~SftpServiceTests" -p:SkipCliShim=true -m:1 --nologo -v:minimal
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/MainWindow.axaml src/NovaTerminal.App/MainWindow.axaml.cs docs/USER_MANUAL.md docs/SSH_ROADMAP.md
+git commit -m "docs: update transfer ui workflow"
+```

--- a/src/NovaTerminal.App/Controls/RemotePathTextBox.axaml
+++ b/src/NovaTerminal.App/Controls/RemotePathTextBox.axaml
@@ -1,0 +1,45 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:models="clr-namespace:NovaTerminal.Models"
+             x:Class="NovaTerminal.Controls.RemotePathTextBox">
+    <Grid>
+        <TextBox Name="PathTextBox"/>
+        <Popup Name="SuggestionsPopup"
+               Placement="Bottom"
+               HorizontalOffset="0"
+               VerticalOffset="4"
+               IsLightDismissEnabled="True">
+            <Border Name="SuggestionsBorder"
+                    Background="#1E1E1E"
+                    BorderBrush="#3A3A3A"
+                    BorderThickness="1"
+                    CornerRadius="4"
+                    Padding="4">
+                <ListBox Name="SuggestionsList"
+                         MaxHeight="220"
+                        Background="Transparent"
+                         BorderThickness="0">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate x:DataType="models:RemotePathSuggestion">
+                            <Grid ColumnDefinitions="Auto,*" Margin="4,2">
+                                <TextBlock Text="{Binding KindText}"
+                                           Foreground="#B0B0B0"
+                                           Margin="0,0,8,0"
+                                           VerticalAlignment="Center"/>
+                                <StackPanel Grid.Column="1" Spacing="1">
+                                    <TextBlock Text="{Binding DisplayName}"
+                                               Foreground="White"
+                                               TextTrimming="CharacterEllipsis"/>
+                                    <TextBlock Text="{Binding FullPath}"
+                                               Foreground="#8A8A8A"
+                                               FontSize="11"
+                                               TextTrimming="CharacterEllipsis"/>
+                                </StackPanel>
+                            </Grid>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </Border>
+        </Popup>
+    </Grid>
+</UserControl>

--- a/src/NovaTerminal.App/Controls/RemotePathTextBox.axaml.cs
+++ b/src/NovaTerminal.App/Controls/RemotePathTextBox.axaml.cs
@@ -1,0 +1,341 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using NovaTerminal.Models;
+using NovaTerminal.Services.Ssh;
+
+namespace NovaTerminal.Controls;
+
+public partial class RemotePathTextBox : UserControl
+{
+    private readonly TextBox _pathTextBox;
+    private readonly Popup _suggestionsPopup;
+    private readonly Border _suggestionsBorder;
+    private readonly ListBox _suggestionsList;
+    private readonly ObservableCollection<RemotePathSuggestion> _suggestions = [];
+    private CancellationTokenSource? _suggestionsCts;
+    private bool _suppressSuggestionRefresh;
+
+    public RemotePathTextBox()
+    {
+        InitializeComponent();
+
+        _pathTextBox = this.FindControl<TextBox>("PathTextBox")
+            ?? throw new InvalidOperationException("PathTextBox was not found.");
+        _suggestionsPopup = this.FindControl<Popup>("SuggestionsPopup")
+            ?? throw new InvalidOperationException("SuggestionsPopup was not found.");
+        _suggestionsBorder = this.FindControl<Border>("SuggestionsBorder")
+            ?? throw new InvalidOperationException("SuggestionsBorder was not found.");
+        _suggestionsList = this.FindControl<ListBox>("SuggestionsList")
+            ?? throw new InvalidOperationException("SuggestionsList was not found.");
+
+        _suggestionsPopup.PlacementTarget = _pathTextBox;
+        _suggestionsList.ItemsSource = _suggestions;
+
+        _pathTextBox.PropertyChanged += OnPathTextBoxPropertyChanged;
+        _pathTextBox.KeyDown += OnPathTextBoxKeyDown;
+        _pathTextBox.GotFocus += (_, _) => ReopenSuggestionsIfAvailable();
+        _suggestionsList.DoubleTapped += OnSuggestionsListDoubleTapped;
+        _suggestionsList.KeyDown += OnSuggestionsListKeyDown;
+        _suggestionsList.SelectionChanged += OnSuggestionsListSelectionChanged;
+        _pathTextBox.SizeChanged += (_, _) => UpdatePopupWidth();
+
+        UpdatePopupWidth();
+    }
+
+    public Guid ProfileId { get; set; }
+
+    public Guid SessionId { get; set; }
+
+    public IRemotePathAutocompleteService? AutocompleteService { get; set; } = new RemotePathAutocompleteService();
+
+    public string Text
+    {
+        get => _pathTextBox.Text ?? string.Empty;
+        set => _pathTextBox.Text = value;
+    }
+
+    public string? Watermark
+    {
+        get => _pathTextBox.Watermark?.ToString();
+        set => _pathTextBox.Watermark = value;
+    }
+
+    public event EventHandler? TextChanged;
+
+    internal TimeSpan SuggestionDebounceDelay { get; set; } = TimeSpan.FromMilliseconds(180);
+
+    internal bool AreSuggestionsOpenForTest => _suggestionsPopup.IsOpen;
+
+    internal IReadOnlyList<RemotePathSuggestion> GetSuggestionsForTest()
+    {
+        return _suggestions.ToList();
+    }
+
+    internal async Task RefreshSuggestionsForTestAsync()
+    {
+        await RefreshSuggestionsAsync();
+    }
+
+    internal void SetTextForTest(string text)
+    {
+        Text = text;
+    }
+
+    internal void SelectSuggestionForTest(int index)
+    {
+        _suggestionsList.SelectedIndex = index;
+        _ = ApplySelectedSuggestionAsync(reopenForDirectory: false);
+    }
+
+    internal Task AcceptSelectedSuggestionForTestAsync(Key key)
+    {
+        return ApplySelectedSuggestionAsync(reopenForDirectory: key == Key.Tab);
+    }
+
+    internal bool FocusInnerTextBoxForTest()
+    {
+        return _pathTextBox.Focus();
+    }
+
+    public bool FocusTextBox()
+    {
+        return _pathTextBox.Focus();
+    }
+
+    private void OnPathTextBoxPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+    {
+        if (e.Property != TextBox.TextProperty)
+        {
+            return;
+        }
+
+        TextChanged?.Invoke(this, EventArgs.Empty);
+        if (!_suppressSuggestionRefresh)
+        {
+            _ = QueueSuggestionsRefreshAsync();
+        }
+    }
+
+    private async Task QueueSuggestionsRefreshAsync()
+    {
+        _suggestionsCts?.Cancel();
+        _suggestionsCts?.Dispose();
+
+        CancellationTokenSource cts = new();
+        _suggestionsCts = cts;
+
+        try
+        {
+            if (SuggestionDebounceDelay > TimeSpan.Zero)
+            {
+                await Task.Delay(SuggestionDebounceDelay, cts.Token);
+            }
+
+            await RefreshSuggestionsAsync(cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+
+    private async Task RefreshSuggestionsAsync(CancellationToken cancellationToken = default)
+    {
+        IRemotePathAutocompleteService? autocompleteService = AutocompleteService;
+        if (autocompleteService == null ||
+            ProfileId == Guid.Empty ||
+            SessionId == Guid.Empty ||
+            string.IsNullOrWhiteSpace(Text))
+        {
+            ClearSuggestions();
+            return;
+        }
+
+        IReadOnlyList<RemotePathSuggestion> suggestions = await autocompleteService.GetSuggestionsAsync(
+            ProfileId,
+            SessionId,
+            Text,
+            cancellationToken);
+
+        ReplaceSuggestions(suggestions);
+    }
+
+    private void ReplaceSuggestions(IReadOnlyList<RemotePathSuggestion> suggestions)
+    {
+        _suggestions.Clear();
+        foreach (RemotePathSuggestion suggestion in suggestions)
+        {
+            _suggestions.Add(suggestion);
+        }
+
+        if (_suggestions.Count == 0)
+        {
+            _suggestionsPopup.IsOpen = false;
+            return;
+        }
+
+        _suggestionsList.SelectedIndex = 0;
+        _suggestionsPopup.IsOpen = true;
+        UpdatePopupWidth();
+    }
+
+    private void ReopenSuggestionsIfAvailable()
+    {
+        if (_suggestions.Count > 0)
+        {
+            _suggestionsPopup.IsOpen = true;
+            UpdatePopupWidth();
+        }
+    }
+
+    private void ClearSuggestions()
+    {
+        _suggestions.Clear();
+        _suggestionsList.SelectedIndex = -1;
+        _suggestionsPopup.IsOpen = false;
+    }
+
+    private void OnPathTextBoxKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (!_suggestionsPopup.IsOpen || _suggestions.Count == 0)
+        {
+            return;
+        }
+
+        switch (e.Key)
+        {
+            case Key.Down:
+                MoveSelection(1);
+                e.Handled = true;
+                break;
+            case Key.Up:
+                MoveSelection(-1);
+                e.Handled = true;
+                break;
+            case Key.Enter:
+                if (TryStartApplySelectedSuggestionAsync(reopenForDirectory: false))
+                {
+                    e.Handled = true;
+                }
+
+                break;
+            case Key.Tab:
+                if (TryStartApplySelectedSuggestionAsync(reopenForDirectory: true))
+                {
+                    e.Handled = true;
+                }
+
+                break;
+            case Key.Escape:
+                _suggestionsPopup.IsOpen = false;
+                e.Handled = true;
+                break;
+        }
+    }
+
+    private void OnSuggestionsListKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter)
+        {
+            if (TryStartApplySelectedSuggestionAsync(reopenForDirectory: false))
+            {
+                e.Handled = true;
+            }
+        }
+        else if (e.Key == Key.Tab)
+        {
+            if (TryStartApplySelectedSuggestionAsync(reopenForDirectory: true))
+            {
+                e.Handled = true;
+            }
+        }
+    }
+
+    private void OnSuggestionsListDoubleTapped(object? sender, RoutedEventArgs e)
+    {
+        _ = ApplySelectedSuggestionAsync(reopenForDirectory: false);
+    }
+
+    private void OnSuggestionsListSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (_suggestionsList.SelectedIndex >= 0 && _suggestionsList.SelectedItem != null)
+        {
+            _suggestionsList.ScrollIntoView(_suggestionsList.SelectedItem);
+        }
+    }
+
+    private void MoveSelection(int delta)
+    {
+        if (_suggestions.Count == 0)
+        {
+            return;
+        }
+
+        int currentIndex = _suggestionsList.SelectedIndex;
+        if (currentIndex < 0)
+        {
+            currentIndex = 0;
+        }
+
+        int nextIndex = Math.Clamp(currentIndex + delta, 0, _suggestions.Count - 1);
+        _suggestionsList.SelectedIndex = nextIndex;
+    }
+
+    private bool TryStartApplySelectedSuggestionAsync(bool reopenForDirectory)
+    {
+        if (_suggestionsList.SelectedItem is not RemotePathSuggestion)
+        {
+            return false;
+        }
+
+        _ = ApplySelectedSuggestionAsync(reopenForDirectory);
+        return true;
+    }
+
+    private async Task ApplySelectedSuggestionAsync(bool reopenForDirectory)
+    {
+        if (_suggestionsList.SelectedItem is not RemotePathSuggestion suggestion)
+        {
+            return;
+        }
+
+        _suppressSuggestionRefresh = true;
+        try
+        {
+            Text = suggestion.IsDirectory
+                ? EnsureTrailingSlash(suggestion.FullPath)
+                : suggestion.FullPath;
+        }
+        finally
+        {
+            _suppressSuggestionRefresh = false;
+        }
+
+        _pathTextBox.CaretIndex = Text.Length;
+        ClearSuggestions();
+
+        if (reopenForDirectory && suggestion.IsDirectory)
+        {
+            await RefreshSuggestionsAsync();
+            _pathTextBox.Focus();
+        }
+    }
+
+    private static string EnsureTrailingSlash(string path)
+    {
+        return path.EndsWith("/", StringComparison.Ordinal) ? path : $"{path}/";
+    }
+
+    private void UpdatePopupWidth()
+    {
+        _suggestionsBorder.Width = Math.Max(_pathTextBox.Bounds.Width, 220);
+    }
+}

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -25,7 +25,9 @@ using NovaTerminal.CommandAssist.ShellIntegration.PowerShell;
 using NovaTerminal.CommandAssist.ShellIntegration.Runtime;
 using NovaTerminal.Core.Ssh.Launch;
 using NovaTerminal.Core.Ssh.Interactions;
+using NovaTerminal.Core.Ssh.Models;
 using NovaTerminal.Core.Ssh.Sessions;
+using NovaTerminal.Services.Ssh;
 
 namespace NovaTerminal.Controls
 {
@@ -1168,6 +1170,7 @@ namespace NovaTerminal.Controls
                         HandleSessionExit(session, code);
                     });
                 };
+                RegisterActiveSshSession(session, profile);
                 UpdateCommandAssistContext();
             }
             catch (Exception ex)
@@ -1565,6 +1568,7 @@ namespace NovaTerminal.Controls
             if (Session != null)
             {
                 ITerminalSession session = Session;
+                UnregisterActiveSshSession(session);
                 Session = null;
                 session.Dispose();
             }
@@ -1650,9 +1654,28 @@ namespace NovaTerminal.Controls
             if (Session != null)
             {
                 ITerminalSession session = Session;
+                UnregisterActiveSshSession(session);
                 Session = null;
                 session.Dispose();
             }
+        }
+
+        private static void RegisterActiveSshSession(ITerminalSession session, TerminalProfile? profile)
+        {
+            if (profile?.Type != ConnectionType.SSH || profile.SshBackendKind != SshBackendKind.Native)
+            {
+                return;
+            }
+
+            ActiveSshSessionRegistry.Instance.Register(new ActiveSshSessionDescriptor(
+                session.Id,
+                profile.Id,
+                profile.SshBackendKind));
+        }
+
+        private static void UnregisterActiveSshSession(ITerminalSession session)
+        {
+            ActiveSshSessionRegistry.Instance.Unregister(session.Id);
         }
 
         private void Sftp_JobUpdated(object? sender, TransferJob job)

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -417,7 +417,17 @@ namespace NovaTerminal.Controls
                 CommandAssistInfrastructure.GetErrorInsightService(),
                 modeRouter: null,
                 resultBuilder: null,
-                action => Dispatcher.UIThread.Post(action));
+                action =>
+                {
+                    if (Dispatcher.UIThread.CheckAccess())
+                    {
+                        action();
+                    }
+                    else
+                    {
+                        Dispatcher.UIThread.Post(action);
+                    }
+                });
 
             BindCommandAssistViews(_commandAssistController.ViewModel);
 

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -1667,9 +1667,15 @@ namespace NovaTerminal.Controls
 
                 if (activeJobs.Count > 0)
                 {
+                    TransferJob primaryJob = activeJobs
+                        .OrderByDescending(j => j.StartedAt)
+                        .First();
+
                     SftpStatus.IsVisible = true;
-                    SftpIcon.Text = activeJobs.Any(j => j.Direction == TransferDirection.Upload) ? "⬆" : "⬇";
-                    SftpText.Text = $"SFTP: {activeJobs.Count} active transfers";
+                    SftpIcon.Text = activeJobs.Count > 1
+                        ? "⇅"
+                        : primaryJob.Direction == TransferDirection.Upload ? "⬆" : "⬇";
+                    SftpText.Text = BuildRunningTransferStatus(primaryJob, activeJobs.Count);
                 }
                 else
                 {
@@ -1681,8 +1687,13 @@ namespace NovaTerminal.Controls
                     if (lastJob != null && lastJob.FinishedAt > DateTime.Now.AddSeconds(-10))
                     {
                         SftpStatus.IsVisible = true;
-                        SftpIcon.Text = lastJob.State == TransferState.Completed ? "✅" : "❌";
-                        SftpText.Text = lastJob.State == TransferState.Completed ? "SFTP complete" : $"SFTP failed: {lastJob.LastError}";
+                        SftpIcon.Text = lastJob.State switch
+                        {
+                            TransferState.Completed => "✅",
+                            TransferState.Canceled => "⏹",
+                            _ => "❌"
+                        };
+                        SftpText.Text = BuildCompletedTransferStatus(lastJob);
                     }
                     else
                     {
@@ -1690,6 +1701,28 @@ namespace NovaTerminal.Controls
                     }
                 }
             });
+        }
+
+        private static string BuildRunningTransferStatus(TransferJob job, int activeTransferCount)
+        {
+            string action = job.Direction == TransferDirection.Upload ? "Uploading" : "Downloading";
+            string detail = job.BytesTotal > 0
+                ? $" {Math.Round(job.Progress * 100)}%"
+                : string.Empty;
+            string prefix = activeTransferCount > 1 ? $"{activeTransferCount} transfers • " : string.Empty;
+            return $"{prefix}{action} {job.DisplayName}{detail}";
+        }
+
+        private static string BuildCompletedTransferStatus(TransferJob job)
+        {
+            return job.State switch
+            {
+                TransferState.Completed => $"{(job.Direction == TransferDirection.Upload ? "Uploaded" : "Downloaded")} {job.DisplayName}",
+                TransferState.Canceled => $"{(job.Direction == TransferDirection.Upload ? "Upload" : "Download")} canceled",
+                TransferState.Failed when !string.IsNullOrWhiteSpace(job.LastError) => $"Transfer failed: {job.LastError}",
+                TransferState.Failed => "Transfer failed",
+                _ => "Transfer updated"
+            };
         }
 
         private void UpdateForwardingStatus()

--- a/src/NovaTerminal.App/Controls/TransferCenter.axaml
+++ b/src/NovaTerminal.App/Controls/TransferCenter.axaml
@@ -2,8 +2,25 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:core="clr-namespace:NovaTerminal.Core"
              x:Class="NovaTerminal.Controls.TransferCenter">
-    <Grid>
-        <ListBox Name="JobsList" Background="#1E1E1E" BorderThickness="0">
+    <Grid RowDefinitions="Auto,*">
+        <Border Background="#252526" BorderBrush="#333333" BorderThickness="0,0,0,1" Padding="10,8">
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <Button Name="BtnClearFinished"
+                        Content="Clear Finished"
+                        Padding="8,2"
+                        FontSize="10"/>
+                <Button Name="BtnClearFailed"
+                        Content="Clear Failed"
+                        Padding="8,2"
+                        FontSize="10"/>
+                <Button Name="BtnClearInactive"
+                        Content="Clear Inactive"
+                        Padding="8,2"
+                        FontSize="10"/>
+            </StackPanel>
+        </Border>
+
+        <ListBox Name="JobsList" Grid.Row="1" Background="#1E1E1E" BorderThickness="0">
             <ListBox.ItemTemplate>
                 <DataTemplate x:DataType="core:TransferJob">
                     <Border BorderBrush="#333" BorderThickness="0,0,0,1" Padding="10">
@@ -38,7 +55,12 @@
                                         Padding="8,2"
                                         FontSize="10"
                                         Click="CancelTransfer_Click"
-                                        IsVisible="{Binding State, Converter={StaticResource RunningConverter}}"/>
+                                        IsVisible="{Binding CanCancel}"/>
+                                <Button Content="Remove"
+                                        Padding="8,2"
+                                        FontSize="10"
+                                        Click="RemoveTransfer_Click"
+                                        IsVisible="{Binding CanRemove}"/>
                             </StackPanel>
                             
                             <!-- Profile -->

--- a/src/NovaTerminal.App/Controls/TransferCenter.axaml
+++ b/src/NovaTerminal.App/Controls/TransferCenter.axaml
@@ -18,11 +18,14 @@
                             
                             <!-- Info -->
                             <StackPanel Grid.Column="1">
-                                <TextBlock Text="{Binding FileName}" Foreground="White" FontWeight="SemiBold"/>
-                                <TextBlock Text="{Binding RemotePath}" Foreground="#888" FontSize="11"/>
+                                <TextBlock Text="{Binding DisplayName}" Foreground="White" FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
+                                <TextBlock Text="{Binding StatusText}" Foreground="#AAA" FontSize="11"/>
+                                <TextBlock Text="{Binding RemotePathText}" Foreground="#888" FontSize="11" TextWrapping="Wrap"/>
+                                <TextBlock Text="{Binding LocalPathText}" Foreground="#777" FontSize="11" TextWrapping="Wrap"/>
                                 
                                 <ProgressBar Margin="0,5" Height="4" 
                                            Value="{Binding Progress}" Minimum="0" Maximum="1"
+                                           IsIndeterminate="{Binding IsProgressIndeterminate}"
                                            IsVisible="{Binding State, Converter={StaticResource RunningConverter}}"/>
                                 
                                 <TextBlock Text="{Binding LastError}" Foreground="#F44336" FontSize="10" 
@@ -31,10 +34,16 @@
                             </StackPanel>
                             
                             <!-- Status -->
-                            <TextBlock Grid.Column="2" Grid.Row="0" 
-                                       Text="{Binding State}" 
-                                       Foreground="{Binding State, Converter={StaticResource StateBrushConverter}}"
-                                       FontSize="11" VerticalAlignment="Top"/>
+                            <StackPanel Grid.Column="2" Grid.Row="0" Spacing="6" HorizontalAlignment="Right">
+                                <TextBlock Text="{Binding State}" 
+                                           Foreground="{Binding State, Converter={StaticResource StateBrushConverter}}"
+                                           FontSize="11" HorizontalAlignment="Right"/>
+                                <Button Content="Cancel"
+                                        Padding="8,2"
+                                        FontSize="10"
+                                        Click="CancelTransfer_Click"
+                                        IsVisible="{Binding State, Converter={StaticResource RunningConverter}}"/>
+                            </StackPanel>
                             
                             <!-- Profile -->
                             <TextBlock Grid.Column="1" Grid.Row="1" 

--- a/src/NovaTerminal.App/Controls/TransferCenter.axaml
+++ b/src/NovaTerminal.App/Controls/TransferCenter.axaml
@@ -2,12 +2,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:core="clr-namespace:NovaTerminal.Core"
              x:Class="NovaTerminal.Controls.TransferCenter">
-    <Grid RowDefinitions="Auto, *">
-        <Border Background="#2D2D2D" Padding="10">
-            <TextBlock Text="Recent Transfers" Foreground="White" FontWeight="Bold"/>
-        </Border>
-        
-        <ListBox Name="JobsList" Grid.Row="1" Background="#1E1E1E" BorderThickness="0">
+    <Grid>
+        <ListBox Name="JobsList" Background="#1E1E1E" BorderThickness="0">
             <ListBox.ItemTemplate>
                 <DataTemplate x:DataType="core:TransferJob">
                     <Border BorderBrush="#333" BorderThickness="0,0,0,1" Padding="10">

--- a/src/NovaTerminal.App/Controls/TransferCenter.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TransferCenter.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 using NovaTerminal.Core;
 
 namespace NovaTerminal.Controls
@@ -13,6 +14,16 @@ namespace NovaTerminal.Controls
             {
                 list.ItemsSource = SftpService.Instance.Jobs;
             }
+        }
+
+        private void CancelTransfer_Click(object? sender, RoutedEventArgs e)
+        {
+            if (sender is not Button { DataContext: TransferJob job })
+            {
+                return;
+            }
+
+            SftpService.Instance.CancelJob(job.Id);
         }
     }
 }

--- a/src/NovaTerminal.App/Controls/TransferCenter.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TransferCenter.axaml.cs
@@ -14,6 +14,24 @@ namespace NovaTerminal.Controls
             {
                 list.ItemsSource = SftpService.Instance.Jobs;
             }
+
+            var clearFinished = this.FindControl<Button>("BtnClearFinished");
+            if (clearFinished != null)
+            {
+                clearFinished.Click += (_, __) => SftpService.Instance.ClearFinishedJobs();
+            }
+
+            var clearFailed = this.FindControl<Button>("BtnClearFailed");
+            if (clearFailed != null)
+            {
+                clearFailed.Click += (_, __) => SftpService.Instance.ClearFailedJobs();
+            }
+
+            var clearInactive = this.FindControl<Button>("BtnClearInactive");
+            if (clearInactive != null)
+            {
+                clearInactive.Click += (_, __) => SftpService.Instance.ClearInactiveJobs();
+            }
         }
 
         private void CancelTransfer_Click(object? sender, RoutedEventArgs e)
@@ -24,6 +42,21 @@ namespace NovaTerminal.Controls
             }
 
             SftpService.Instance.CancelJob(job.Id);
+        }
+
+        private void RemoveTransfer_Click(object? sender, RoutedEventArgs e)
+        {
+            if (sender is not Button { DataContext: TransferJob job })
+            {
+                return;
+            }
+
+            if (!job.CanRemove)
+            {
+                return;
+            }
+
+            SftpService.Instance.RemoveJob(job.Id);
         }
     }
 }

--- a/src/NovaTerminal.App/Controls/TransferDialog.axaml
+++ b/src/NovaTerminal.App/Controls/TransferDialog.axaml
@@ -1,5 +1,6 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:NovaTerminal.Controls"
         x:Class="NovaTerminal.Controls.TransferDialog"
         Width="560"
         Height="280"
@@ -20,11 +21,10 @@
                        Foreground="#D0D0D0"
                        VerticalAlignment="Center"
                        Margin="0,0,12,0"/>
-            <TextBox Name="RemotePathBox"
-                     Grid.Row="1"
-                     Grid.Column="1"
-                     Watermark="~/downloads or /mnt/share"
-                     Margin="0,0,8,0"/>
+            <controls:RemotePathTextBox Name="RemotePathInput"
+                                        Grid.Row="1"
+                                        Grid.Column="1"
+                                        Margin="0,0,8,0"/>
 
             <TextBlock Grid.Row="2"
                        Text="Local"

--- a/src/NovaTerminal.App/Controls/TransferDialog.axaml
+++ b/src/NovaTerminal.App/Controls/TransferDialog.axaml
@@ -1,0 +1,69 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="NovaTerminal.Controls.TransferDialog"
+        Width="560"
+        Height="280"
+        CanResize="False"
+        WindowStartupLocation="CenterOwner"
+        Title="Transfer">
+    <Border Background="#252526" BorderBrush="#333333" BorderThickness="1" Padding="16">
+        <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="Auto,*,Auto">
+            <TextBlock Grid.ColumnSpan="3"
+                       Text="Transfer"
+                       Foreground="White"
+                       FontSize="16"
+                       FontWeight="SemiBold"
+                       Margin="0,0,0,12"/>
+
+            <TextBlock Grid.Row="1"
+                       Text="Remote"
+                       Foreground="#D0D0D0"
+                       VerticalAlignment="Center"
+                       Margin="0,0,12,0"/>
+            <TextBox Name="RemotePathBox"
+                     Grid.Row="1"
+                     Grid.Column="1"
+                     Watermark="~/downloads or /mnt/share"
+                     Margin="0,0,8,0"/>
+
+            <TextBlock Grid.Row="2"
+                       Text="Local"
+                       Foreground="#D0D0D0"
+                       VerticalAlignment="Center"
+                       Margin="0,12,12,0"/>
+            <TextBox Name="LocalPathBox"
+                     Grid.Row="2"
+                     Grid.Column="1"
+                     Margin="0,12,8,0"/>
+            <Button Name="BtnBrowseLocal"
+                    Grid.Row="2"
+                    Grid.Column="2"
+                    Content="Browse..."
+                    Margin="0,12,0,0"
+                    MinWidth="88"/>
+
+            <TextBlock Name="ValidationMessage"
+                       Grid.Row="3"
+                       Grid.ColumnSpan="3"
+                       Foreground="#F14C4C"
+                       Margin="0,12,0,0"
+                       TextWrapping="Wrap"/>
+
+            <StackPanel Grid.Row="4"
+                        Grid.ColumnSpan="3"
+                        Orientation="Horizontal"
+                        HorizontalAlignment="Right"
+                        Spacing="10"
+                        Margin="0,20,0,0">
+                <Button Name="BtnTransferCancel"
+                        Content="Cancel"
+                        MinWidth="88"/>
+                <Button Name="BtnTransferConfirm"
+                        Content="Start Transfer"
+                        MinWidth="110"
+                        Background="#007ACC"
+                        Foreground="White"/>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/src/NovaTerminal.App/Controls/TransferDialog.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TransferDialog.axaml.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Collections.Generic;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using Avalonia.Input;
+using Avalonia.Platform.Storage;
 using NovaTerminal.Core;
 using NovaTerminal.Models;
 
@@ -40,6 +43,8 @@ public partial class TransferDialog : Window
             ?? throw new InvalidOperationException("ValidationMessage was not found.");
         _confirmButton = this.FindControl<Button>("BtnTransferConfirm")
             ?? throw new InvalidOperationException("BtnTransferConfirm was not found.");
+        Button browseButton = this.FindControl<Button>("BtnBrowseLocal")
+            ?? throw new InvalidOperationException("BtnBrowseLocal was not found.");
 
         Button cancelButton = this.FindControl<Button>("BtnTransferCancel")
             ?? throw new InvalidOperationException("BtnTransferCancel was not found.");
@@ -50,7 +55,9 @@ public partial class TransferDialog : Window
         _localPathBox.PropertyChanged += OnPathBoxPropertyChanged;
         _confirmButton.Click += OnConfirmClick;
         cancelButton.Click += OnCancelClick;
+        browseButton.Click += OnBrowseLocalClick;
         Opened += OnOpened;
+        KeyDown += OnDialogKeyDown;
 
         RefreshValidation();
     }
@@ -81,11 +88,97 @@ public partial class TransferDialog : Window
         Result = TransferDialogResult.CreateConfirmed(
             _localPathBox.Text?.Trim() ?? string.Empty,
             _remotePathBox.Text?.Trim() ?? string.Empty);
+        Close(Result);
     }
 
     private void OnCancelClick(object? sender, RoutedEventArgs e)
     {
         Result = null;
+        Close(null);
+    }
+
+    private async void OnBrowseLocalClick(object? sender, RoutedEventArgs e)
+    {
+        TopLevel? topLevel = TopLevel.GetTopLevel(this);
+        if (topLevel?.StorageProvider == null)
+        {
+            return;
+        }
+
+        if (_request.Direction == TransferDirection.Upload)
+        {
+            if (_request.Kind == TransferKind.File)
+            {
+                IReadOnlyList<IStorageFile> files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+                {
+                    Title = "Select File to Upload",
+                    AllowMultiple = false
+                });
+
+                if (files.Count > 0)
+                {
+                    _localPathBox.Text = files[0].Path.LocalPath;
+                }
+            }
+            else
+            {
+                IReadOnlyList<IStorageFolder> folders = await topLevel.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+                {
+                    Title = "Select Folder to Upload",
+                    AllowMultiple = false
+                });
+
+                if (folders.Count > 0)
+                {
+                    _localPathBox.Text = folders[0].Path.LocalPath;
+                }
+            }
+
+            return;
+        }
+
+        if (_request.Kind == TransferKind.File)
+        {
+            IStorageFile? file = await topLevel.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            {
+                Title = "Select Local Destination",
+                SuggestedFileName = ResolveSuggestedFileName()
+            });
+
+            if (file != null)
+            {
+                _localPathBox.Text = file.Path.LocalPath;
+            }
+
+            return;
+        }
+
+        IReadOnlyList<IStorageFolder> destinationFolders = await topLevel.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+        {
+            Title = "Select Local Destination Folder",
+            AllowMultiple = false
+        });
+
+        if (destinationFolders.Count > 0)
+        {
+            _localPathBox.Text = destinationFolders[0].Path.LocalPath;
+        }
+    }
+
+    private void OnDialogKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            OnCancelClick(this, new RoutedEventArgs());
+            e.Handled = true;
+            return;
+        }
+
+        if (e.Key == Key.Enter && _confirmButton.IsEnabled)
+        {
+            OnConfirmClick(this, new RoutedEventArgs());
+            e.Handled = true;
+        }
     }
 
     private void RefreshValidation()
@@ -105,5 +198,18 @@ public partial class TransferDialog : Window
         string action = direction == TransferDirection.Upload ? "Upload" : "Download";
         string item = kind == TransferKind.Folder ? "Folder" : "File";
         return $"{action} {item}";
+    }
+
+    private string ResolveSuggestedFileName()
+    {
+        string remotePath = _remotePathBox.Text?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(remotePath))
+        {
+            return "download";
+        }
+
+        string trimmed = remotePath.TrimEnd('/', '\\');
+        string fileName = System.IO.Path.GetFileName(trimmed);
+        return string.IsNullOrWhiteSpace(fileName) ? "download" : fileName;
     }
 }

--- a/src/NovaTerminal.App/Controls/TransferDialog.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TransferDialog.axaml.cs
@@ -7,13 +7,14 @@ using Avalonia.Input;
 using Avalonia.Platform.Storage;
 using NovaTerminal.Core;
 using NovaTerminal.Models;
+using NovaTerminal.Services.Ssh;
 
 namespace NovaTerminal.Controls;
 
 public partial class TransferDialog : Window
 {
     private readonly TransferDialogRequest _request;
-    private readonly TextBox _remotePathBox;
+    private readonly RemotePathTextBox _remotePathInput;
     private readonly TextBox _localPathBox;
     private readonly TextBlock _validationMessage;
     private readonly Button _confirmButton;
@@ -28,15 +29,17 @@ public partial class TransferDialog : Window
     {
     }
 
-    public TransferDialog(TransferDialogRequest request)
+    public TransferDialog(
+        TransferDialogRequest request,
+        IRemotePathAutocompleteService? autocompleteService = null)
     {
         ArgumentNullException.ThrowIfNull(request);
 
         _request = request;
         InitializeComponent();
 
-        _remotePathBox = this.FindControl<TextBox>("RemotePathBox")
-            ?? throw new InvalidOperationException("RemotePathBox was not found.");
+        _remotePathInput = this.FindControl<RemotePathTextBox>("RemotePathInput")
+            ?? throw new InvalidOperationException("RemotePathInput was not found.");
         _localPathBox = this.FindControl<TextBox>("LocalPathBox")
             ?? throw new InvalidOperationException("LocalPathBox was not found.");
         _validationMessage = this.FindControl<TextBlock>("ValidationMessage")
@@ -50,8 +53,12 @@ public partial class TransferDialog : Window
             ?? throw new InvalidOperationException("BtnTransferCancel was not found.");
 
         Title = BuildTitle(request.Direction, request.Kind);
-        _remotePathBox.Text = request.RemotePath;
-        _remotePathBox.PropertyChanged += OnPathBoxPropertyChanged;
+        _remotePathInput.ProfileId = request.ProfileId;
+        _remotePathInput.SessionId = request.SessionId;
+        _remotePathInput.AutocompleteService = autocompleteService ?? new RemotePathAutocompleteService();
+        _remotePathInput.Watermark = "~/downloads or /mnt/share";
+        _remotePathInput.Text = request.RemotePath;
+        _remotePathInput.TextChanged += OnPathInputChanged;
         _localPathBox.PropertyChanged += OnPathBoxPropertyChanged;
         _confirmButton.Click += OnConfirmClick;
         cancelButton.Click += OnCancelClick;
@@ -66,7 +73,12 @@ public partial class TransferDialog : Window
 
     private void OnOpened(object? sender, EventArgs e)
     {
-        _remotePathBox.Focus();
+        _remotePathInput.FocusTextBox();
+    }
+
+    private void OnPathInputChanged(object? sender, EventArgs e)
+    {
+        RefreshValidation();
     }
 
     private void OnPathBoxPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
@@ -87,7 +99,7 @@ public partial class TransferDialog : Window
 
         Result = TransferDialogResult.CreateConfirmed(
             _localPathBox.Text?.Trim() ?? string.Empty,
-            _remotePathBox.Text?.Trim() ?? string.Empty);
+            _remotePathInput.Text.Trim());
         Close(Result);
     }
 
@@ -183,7 +195,7 @@ public partial class TransferDialog : Window
 
     private void RefreshValidation()
     {
-        bool hasRemote = !string.IsNullOrWhiteSpace(_remotePathBox.Text);
+        bool hasRemote = !string.IsNullOrWhiteSpace(_remotePathInput.Text);
         bool hasLocal = !string.IsNullOrWhiteSpace(_localPathBox.Text);
         bool valid = hasRemote && hasLocal;
 
@@ -202,7 +214,7 @@ public partial class TransferDialog : Window
 
     private string ResolveSuggestedFileName()
     {
-        string remotePath = _remotePathBox.Text?.Trim() ?? string.Empty;
+        string remotePath = _remotePathInput.Text.Trim();
         if (string.IsNullOrWhiteSpace(remotePath))
         {
             return "download";

--- a/src/NovaTerminal.App/Controls/TransferDialog.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TransferDialog.axaml.cs
@@ -1,0 +1,109 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using NovaTerminal.Core;
+using NovaTerminal.Models;
+
+namespace NovaTerminal.Controls;
+
+public partial class TransferDialog : Window
+{
+    private readonly TransferDialogRequest _request;
+    private readonly TextBox _remotePathBox;
+    private readonly TextBox _localPathBox;
+    private readonly TextBlock _validationMessage;
+    private readonly Button _confirmButton;
+
+    public TransferDialog()
+        : this(new TransferDialogRequest
+        {
+            Direction = TransferDirection.Download,
+            Kind = TransferKind.File,
+            RemotePath = string.Empty
+        })
+    {
+    }
+
+    public TransferDialog(TransferDialogRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        _request = request;
+        InitializeComponent();
+
+        _remotePathBox = this.FindControl<TextBox>("RemotePathBox")
+            ?? throw new InvalidOperationException("RemotePathBox was not found.");
+        _localPathBox = this.FindControl<TextBox>("LocalPathBox")
+            ?? throw new InvalidOperationException("LocalPathBox was not found.");
+        _validationMessage = this.FindControl<TextBlock>("ValidationMessage")
+            ?? throw new InvalidOperationException("ValidationMessage was not found.");
+        _confirmButton = this.FindControl<Button>("BtnTransferConfirm")
+            ?? throw new InvalidOperationException("BtnTransferConfirm was not found.");
+
+        Button cancelButton = this.FindControl<Button>("BtnTransferCancel")
+            ?? throw new InvalidOperationException("BtnTransferCancel was not found.");
+
+        Title = BuildTitle(request.Direction, request.Kind);
+        _remotePathBox.Text = request.RemotePath;
+        _remotePathBox.PropertyChanged += OnPathBoxPropertyChanged;
+        _localPathBox.PropertyChanged += OnPathBoxPropertyChanged;
+        _confirmButton.Click += OnConfirmClick;
+        cancelButton.Click += OnCancelClick;
+        Opened += OnOpened;
+
+        RefreshValidation();
+    }
+
+    public TransferDialogResult? Result { get; private set; }
+
+    private void OnOpened(object? sender, EventArgs e)
+    {
+        _remotePathBox.Focus();
+    }
+
+    private void OnPathBoxPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+    {
+        if (e.Property == TextBox.TextProperty)
+        {
+            RefreshValidation();
+        }
+    }
+
+    private void OnConfirmClick(object? sender, RoutedEventArgs e)
+    {
+        RefreshValidation();
+        if (!_confirmButton.IsEnabled)
+        {
+            return;
+        }
+
+        Result = TransferDialogResult.CreateConfirmed(
+            _localPathBox.Text?.Trim() ?? string.Empty,
+            _remotePathBox.Text?.Trim() ?? string.Empty);
+    }
+
+    private void OnCancelClick(object? sender, RoutedEventArgs e)
+    {
+        Result = null;
+    }
+
+    private void RefreshValidation()
+    {
+        bool hasRemote = !string.IsNullOrWhiteSpace(_remotePathBox.Text);
+        bool hasLocal = !string.IsNullOrWhiteSpace(_localPathBox.Text);
+        bool valid = hasRemote && hasLocal;
+
+        _confirmButton.IsEnabled = valid;
+        _validationMessage.Text = valid
+            ? string.Empty
+            : "Local and remote paths are required.";
+    }
+
+    private static string BuildTitle(TransferDirection direction, TransferKind kind)
+    {
+        string action = direction == TransferDirection.Upload ? "Upload" : "Download";
+        string item = kind == TransferKind.Folder ? "Folder" : "File";
+        return $"{action} {item}";
+    }
+}

--- a/src/NovaTerminal.App/Core/SftpService.cs
+++ b/src/NovaTerminal.App/Core/SftpService.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Threading;
 using NovaTerminal.Core.Ssh.Launch;
@@ -98,10 +99,10 @@ namespace NovaTerminal.Core
 
                 if (profile == null) throw new Exception("Profile not found");
 
-                switch (SelectTransferBackend(profile))
+                switch (SelectExecutionBackend(profile, job))
                 {
                     case SftpTransferBackend.NativeSftp:
-                        await RunNativeSftpJobAsync(job, profile);
+                        await RunNativeSftpJobAsync(job, profile, settings.Profiles, sshService);
                         break;
                     case SftpTransferBackend.ExternalScp:
                     default:
@@ -136,6 +137,19 @@ namespace NovaTerminal.Core
             return profile.SshBackendKind == NovaTerminal.Core.Ssh.Models.SshBackendKind.Native
                 ? SftpTransferBackend.NativeSftp
                 : SftpTransferBackend.ExternalScp;
+        }
+
+        internal static SftpTransferBackend SelectExecutionBackend(TerminalProfile profile, TransferJob job)
+        {
+            ArgumentNullException.ThrowIfNull(profile);
+            ArgumentNullException.ThrowIfNull(job);
+
+            if (job.Kind != TransferKind.File)
+            {
+                return SftpTransferBackend.ExternalScp;
+            }
+
+            return SelectTransferBackend(profile);
         }
 
         internal static NativeSshConnectionOptions BuildNativeTransferConnectionOptions(
@@ -261,12 +275,94 @@ namespace NovaTerminal.Core
             }
         }
 
-        private static Task RunNativeSftpJobAsync(TransferJob job, TerminalProfile profile)
+        private static Task RunNativeSftpJobAsync(
+            TransferJob job,
+            TerminalProfile profile,
+            IReadOnlyList<TerminalProfile>? allProfiles,
+            SshConnectionService sshService)
         {
             ArgumentNullException.ThrowIfNull(job);
             ArgumentNullException.ThrowIfNull(profile);
+            ArgumentNullException.ThrowIfNull(sshService);
 
-            throw new NotImplementedException("Native SFTP transfers are not implemented yet.");
+            ExecuteNativeSftpTransfer(
+                job,
+                profile,
+                sshService,
+                allProfiles,
+                interop: null,
+                passwordResolver: static transferProfile => new VaultService().GetSshPasswordForProfile(transferProfile),
+                knownHostsFilePath: AppPaths.NativeKnownHostsFilePath);
+
+            return Task.CompletedTask;
+        }
+
+        internal static void ExecuteNativeSftpTransfer(
+            TransferJob job,
+            TerminalProfile profile,
+            SshConnectionService sshService,
+            IReadOnlyList<TerminalProfile>? allProfiles = null,
+            INativeSshInterop? interop = null,
+            Func<TerminalProfile, string?>? passwordResolver = null,
+            string? knownHostsFilePath = null)
+        {
+            ArgumentNullException.ThrowIfNull(job);
+            ArgumentNullException.ThrowIfNull(profile);
+            ArgumentNullException.ThrowIfNull(sshService);
+
+            NativeSshConnectionOptions baseOptions = BuildNativeTransferConnectionOptions(sshService, profile, allProfiles);
+            bool prefersIdentityFile = !string.IsNullOrWhiteSpace(baseOptions.IdentityFilePath);
+            string? resolvedPassword = prefersIdentityFile ? null : passwordResolver?.Invoke(profile);
+            string effectiveKnownHostsPath = string.IsNullOrWhiteSpace(knownHostsFilePath)
+                ? AppPaths.NativeKnownHostsFilePath
+                : knownHostsFilePath;
+
+            var connectionOptions = new NativeSshConnectionOptions
+            {
+                Host = baseOptions.Host,
+                User = baseOptions.User,
+                Port = baseOptions.Port,
+                Cols = baseOptions.Cols,
+                Rows = baseOptions.Rows,
+                Term = baseOptions.Term,
+                Password = string.IsNullOrWhiteSpace(resolvedPassword) ? null : resolvedPassword,
+                IdentityFilePath = baseOptions.IdentityFilePath,
+                KnownHostsFilePath = effectiveKnownHostsPath,
+                JumpHost = baseOptions.JumpHost == null
+                    ? null
+                    : new NovaTerminal.Core.Ssh.Models.SshJumpHop
+                    {
+                        Host = baseOptions.JumpHost.Host,
+                        User = baseOptions.JumpHost.User,
+                        Port = baseOptions.JumpHost.Port
+                    },
+                KeepAliveIntervalSeconds = baseOptions.KeepAliveIntervalSeconds,
+                KeepAliveCountMax = baseOptions.KeepAliveCountMax
+            };
+            NativeSftpTransferOptions transferOptions = BuildNativeTransferOptions(job);
+
+            (interop ?? new NativeSshInterop()).RunSftpTransfer(
+                connectionOptions,
+                transferOptions,
+                progress: null,
+                CancellationToken.None);
+        }
+
+        internal static NativeSftpTransferOptions BuildNativeTransferOptions(TransferJob job)
+        {
+            ArgumentNullException.ThrowIfNull(job);
+
+            return new NativeSftpTransferOptions
+            {
+                Direction = job.Direction == TransferDirection.Upload
+                    ? NativeSftpTransferDirection.Upload
+                    : NativeSftpTransferDirection.Download,
+                Kind = job.Kind == TransferKind.Folder
+                    ? NativeSftpTransferKind.Directory
+                    : NativeSftpTransferKind.File,
+                LocalPath = job.LocalPath,
+                RemotePath = job.RemotePath
+            };
         }
 
         internal static string BuildScpArguments(

--- a/src/NovaTerminal.App/Core/SftpService.cs
+++ b/src/NovaTerminal.App/Core/SftpService.cs
@@ -262,7 +262,24 @@ namespace NovaTerminal.Core
 
         public void AddJob(TransferJob job)
         {
-            Dispatcher.UIThread.Post(() => Jobs.Insert(0, job));
+            ArgumentNullException.ThrowIfNull(job);
+
+            void initializeJob()
+            {
+                Jobs.Insert(0, job);
+                MarkJobRunning(job);
+                JobUpdated?.Invoke(this, job);
+            }
+
+            if (Dispatcher.UIThread.CheckAccess())
+            {
+                initializeJob();
+            }
+            else
+            {
+                Dispatcher.UIThread.Post(initializeJob);
+            }
+
             var cancellationTokenSource = new CancellationTokenSource();
             _activeTransfers[job.Id] = cancellationTokenSource;
             // In a real implementation, we would start a queue worker here.
@@ -285,13 +302,6 @@ namespace NovaTerminal.Core
 
         internal async Task RunJobAsync(TransferJob job, CancellationToken cancellationToken)
         {
-            Dispatcher.UIThread.Post(() =>
-            {
-                job.State = TransferState.Running;
-                job.StartedAt = DateTime.Now;
-                JobUpdated?.Invoke(this, job);
-            });
-
             try
             {
                 var settings = _settingsLoader();
@@ -601,6 +611,17 @@ namespace NovaTerminal.Core
             job.Progress = progress.BytesTotal > 0
                 ? Math.Clamp((double)progress.BytesDone / progress.BytesTotal, 0.0, 1.0)
                 : 0.0;
+        }
+
+        internal static void MarkJobRunning(TransferJob job)
+        {
+            ArgumentNullException.ThrowIfNull(job);
+
+            job.State = TransferState.Running;
+            if (job.StartedAt == default)
+            {
+                job.StartedAt = DateTime.Now;
+            }
         }
 
         internal static NativeSftpTransferOptions BuildNativeTransferOptions(TransferJob job)

--- a/src/NovaTerminal.App/Core/SftpService.cs
+++ b/src/NovaTerminal.App/Core/SftpService.cs
@@ -5,6 +5,8 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Threading;
@@ -41,25 +43,195 @@ namespace NovaTerminal.Core
         NativeSftp
     }
 
-    public class TransferJob
+    public class TransferJob : INotifyPropertyChanged
     {
-        public Guid Id { get; set; } = Guid.NewGuid();
-        public Guid SessionId { get; set; }
-        public Guid ProfileId { get; set; }
-        public string ProfileName { get; set; } = "";
-        public TransferDirection Direction { get; set; }
-        public TransferKind Kind { get; set; }
-        public string LocalPath { get; set; } = "";
-        public string RemotePath { get; set; } = "";
-        public TransferState State { get; set; } = TransferState.Queued;
-        public double Progress { get; set; } // 0..1
-        public long BytesTotal { get; set; }
-        public long BytesDone { get; set; }
-        public string? LastError { get; set; }
-        public DateTime StartedAt { get; set; }
-        public DateTime? FinishedAt { get; set; }
+        private Guid _id = Guid.NewGuid();
+        private Guid _sessionId;
+        private Guid _profileId;
+        private string _profileName = "";
+        private TransferDirection _direction;
+        private TransferKind _kind;
+        private string _localPath = "";
+        private string _remotePath = "";
+        private TransferState _state = TransferState.Queued;
+        private double _progress;
+        private long _bytesTotal;
+        private long _bytesDone;
+        private string? _lastError;
+        private DateTime _startedAt;
+        private DateTime? _finishedAt;
 
-        public string FileName => Path.GetFileName(LocalPath);
+        public Guid Id
+        {
+            get => _id;
+            set => SetProperty(ref _id, value);
+        }
+
+        public Guid SessionId
+        {
+            get => _sessionId;
+            set => SetProperty(ref _sessionId, value);
+        }
+
+        public Guid ProfileId
+        {
+            get => _profileId;
+            set => SetProperty(ref _profileId, value);
+        }
+
+        public string ProfileName
+        {
+            get => _profileName;
+            set => SetProperty(ref _profileName, value);
+        }
+
+        public TransferDirection Direction
+        {
+            get => _direction;
+            set => SetProperty(ref _direction, value);
+        }
+
+        public TransferKind Kind
+        {
+            get => _kind;
+            set => SetProperty(ref _kind, value);
+        }
+
+        public string LocalPath
+        {
+            get => _localPath;
+            set => SetProperty(ref _localPath, value);
+        }
+
+        public string RemotePath
+        {
+            get => _remotePath;
+            set => SetProperty(ref _remotePath, value);
+        }
+
+        public TransferState State
+        {
+            get => _state;
+            set => SetProperty(ref _state, value);
+        }
+
+        public double Progress
+        {
+            get => _progress;
+            set => SetProperty(ref _progress, value);
+        }
+
+        public long BytesTotal
+        {
+            get => _bytesTotal;
+            set => SetProperty(ref _bytesTotal, value);
+        }
+
+        public long BytesDone
+        {
+            get => _bytesDone;
+            set => SetProperty(ref _bytesDone, value);
+        }
+
+        public string? LastError
+        {
+            get => _lastError;
+            set => SetProperty(ref _lastError, value);
+        }
+
+        public DateTime StartedAt
+        {
+            get => _startedAt;
+            set => SetProperty(ref _startedAt, value);
+        }
+
+        public DateTime? FinishedAt
+        {
+            get => _finishedAt;
+            set => SetProperty(ref _finishedAt, value);
+        }
+
+        public string FileName => DisplayName;
+        public string DisplayName => ResolveDisplayName();
+        public string LocalPathText => string.IsNullOrWhiteSpace(LocalPath) ? string.Empty : $"Local: {LocalPath}";
+        public string RemotePathText => string.IsNullOrWhiteSpace(RemotePath) ? string.Empty : $"Remote: {RemotePath}";
+        public bool IsProgressIndeterminate => State == TransferState.Running && BytesTotal <= 0;
+        public string StatusText => BuildStatusText();
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        private bool SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value))
+            {
+                return false;
+            }
+
+            field = value;
+            OnPropertyChanged(propertyName);
+            OnDerivedPropertyChanged();
+            return true;
+        }
+
+        private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        private void OnDerivedPropertyChanged()
+        {
+            OnPropertyChanged(nameof(FileName));
+            OnPropertyChanged(nameof(DisplayName));
+            OnPropertyChanged(nameof(LocalPathText));
+            OnPropertyChanged(nameof(RemotePathText));
+            OnPropertyChanged(nameof(IsProgressIndeterminate));
+            OnPropertyChanged(nameof(StatusText));
+        }
+
+        private string ResolveDisplayName()
+        {
+            string preferredPath = Direction == TransferDirection.Download ? RemotePath : LocalPath;
+            if (string.IsNullOrWhiteSpace(preferredPath))
+            {
+                preferredPath = Direction == TransferDirection.Download ? LocalPath : RemotePath;
+            }
+
+            string trimmed = preferredPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar, '/');
+            string name = Path.GetFileName(trimmed);
+            return string.IsNullOrWhiteSpace(name) ? preferredPath : name;
+        }
+
+        private string BuildStatusText()
+        {
+            return State switch
+            {
+                TransferState.Queued => "Queued",
+                TransferState.Running when BytesTotal > 0 => $"{FormatBytes(BytesDone)} of {FormatBytes(BytesTotal)} ({Math.Round(Progress * 100)}%)",
+                TransferState.Running when BytesDone > 0 => $"{FormatBytes(BytesDone)} transferred",
+                TransferState.Running => "Transferring...",
+                TransferState.Completed => Direction == TransferDirection.Upload ? "Upload complete" : "Download complete",
+                TransferState.Canceled => "Canceled",
+                TransferState.Failed => "Failed",
+                _ => State.ToString()
+            };
+        }
+
+        private static string FormatBytes(long bytes)
+        {
+            string[] units = { "B", "KB", "MB", "GB", "TB" };
+            double value = bytes;
+            int unitIndex = 0;
+
+            while (value >= 1024 && unitIndex < units.Length - 1)
+            {
+                value /= 1024;
+                unitIndex++;
+            }
+
+            return unitIndex == 0
+                ? $"{bytes} {units[unitIndex]}"
+                : $"{value:0.#} {units[unitIndex]}";
+        }
     }
 
     public class SftpService
@@ -90,7 +262,7 @@ namespace NovaTerminal.Core
 
         public void AddJob(TransferJob job)
         {
-            Dispatcher.UIThread.Post(() => Jobs.Add(job));
+            Dispatcher.UIThread.Post(() => Jobs.Insert(0, job));
             var cancellationTokenSource = new CancellationTokenSource();
             _activeTransfers[job.Id] = cancellationTokenSource;
             // In a real implementation, we would start a queue worker here.

--- a/src/NovaTerminal.App/Core/SftpService.cs
+++ b/src/NovaTerminal.App/Core/SftpService.cs
@@ -156,6 +156,8 @@ namespace NovaTerminal.Core
         public string LocalPathText => string.IsNullOrWhiteSpace(LocalPath) ? string.Empty : $"Local: {LocalPath}";
         public string RemotePathText => string.IsNullOrWhiteSpace(RemotePath) ? string.Empty : $"Remote: {RemotePath}";
         public bool IsProgressIndeterminate => State == TransferState.Running && BytesTotal <= 0;
+        public bool CanCancel => State == TransferState.Running;
+        public bool CanRemove => State is TransferState.Completed or TransferState.Failed or TransferState.Canceled;
         public string StatusText => BuildStatusText();
 
         public event PropertyChangedEventHandler? PropertyChanged;
@@ -185,6 +187,8 @@ namespace NovaTerminal.Core
             OnPropertyChanged(nameof(LocalPathText));
             OnPropertyChanged(nameof(RemotePathText));
             OnPropertyChanged(nameof(IsProgressIndeterminate));
+            OnPropertyChanged(nameof(CanCancel));
+            OnPropertyChanged(nameof(CanRemove));
             OnPropertyChanged(nameof(StatusText));
         }
 
@@ -301,6 +305,28 @@ namespace NovaTerminal.Core
             return true;
         }
 
+        public void ClearFinishedJobs()
+        {
+            RemoveJobsWhere(job => job.State == TransferState.Completed);
+        }
+
+        public void ClearFailedJobs()
+        {
+            RemoveJobsWhere(job => job.State == TransferState.Failed);
+        }
+
+        public void ClearInactiveJobs()
+        {
+            RemoveJobsWhere(job => job.State is TransferState.Completed or TransferState.Failed or TransferState.Canceled);
+        }
+
+        public void RemoveJob(Guid jobId)
+        {
+            RemoveJobsWhere(job =>
+                job.Id == jobId &&
+                job.State is TransferState.Completed or TransferState.Failed or TransferState.Canceled);
+        }
+
         public event EventHandler<TransferJob>? JobUpdated;
 
         internal async Task RunJobAsync(TransferJob job, CancellationToken cancellationToken)
@@ -360,6 +386,34 @@ namespace NovaTerminal.Core
                 {
                     cancellationTokenSource.Dispose();
                 }
+            }
+        }
+
+        private void RemoveJobsWhere(Func<TransferJob, bool> predicate)
+        {
+            ArgumentNullException.ThrowIfNull(predicate);
+
+            void remove()
+            {
+                for (int i = Jobs.Count - 1; i >= 0; i--)
+                {
+                    if (predicate(Jobs[i]))
+                    {
+                        Jobs.RemoveAt(i);
+                    }
+                }
+            }
+
+            if (Dispatcher.UIThread.CheckAccess())
+            {
+                remove();
+            }
+            else
+            {
+                Dispatcher.UIThread
+                    .InvokeAsync(remove, DispatcherPriority.Send)
+                    .GetAwaiter()
+                    .GetResult();
             }
         }
 

--- a/src/NovaTerminal.App/Core/SftpService.cs
+++ b/src/NovaTerminal.App/Core/SftpService.cs
@@ -640,8 +640,31 @@ namespace NovaTerminal.Core
                     ? NativeSftpTransferKind.Directory
                     : NativeSftpTransferKind.File,
                 LocalPath = job.LocalPath,
-                RemotePath = job.RemotePath
+                RemotePath = NormalizeNativeRemotePath(job.RemotePath)
             };
+        }
+
+        internal static string NormalizeNativeRemotePath(string remotePath)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(remotePath);
+
+            ReadOnlySpan<char> shellEscapable = " \t\n\"'\\!#$&()*;<>?[]^`{|}~".AsSpan();
+            var normalized = new System.Text.StringBuilder(remotePath.Length);
+
+            for (int i = 0; i < remotePath.Length; i++)
+            {
+                char current = remotePath[i];
+                if (current == '\\' && i + 1 < remotePath.Length && shellEscapable.IndexOf(remotePath[i + 1]) >= 0)
+                {
+                    normalized.Append(remotePath[i + 1]);
+                    i++;
+                    continue;
+                }
+
+                normalized.Append(current);
+            }
+
+            return normalized.ToString();
         }
 
         internal static string BuildScpArguments(

--- a/src/NovaTerminal.App/Core/SftpService.cs
+++ b/src/NovaTerminal.App/Core/SftpService.cs
@@ -144,11 +144,6 @@ namespace NovaTerminal.Core
             ArgumentNullException.ThrowIfNull(profile);
             ArgumentNullException.ThrowIfNull(job);
 
-            if (job.Kind != TransferKind.File)
-            {
-                return SftpTransferBackend.ExternalScp;
-            }
-
             return SelectTransferBackend(profile);
         }
 
@@ -423,10 +418,7 @@ namespace NovaTerminal.Core
             }
 
             args.Append(" -O");
-            if (ShouldUseBatchMode(profile))
-            {
-                args.Append(" -B");
-            }
+            args.Append(" -B");
 
             string localPath = QuoteArg(job.LocalPath.Replace("\\", "/", StringComparison.Ordinal));
             string remotePath = QuoteArg(job.RemotePath);
@@ -447,71 +439,14 @@ namespace NovaTerminal.Core
             ArgumentException.ThrowIfNullOrWhiteSpace(scpExe);
             ArgumentNullException.ThrowIfNull(profile);
 
-            bool hideProcess = !RequiresVisibleAuthenticationPrompt(profile);
-            var startInfo = new ProcessStartInfo
+            return new ProcessStartInfo
             {
                 FileName = scpExe,
                 Arguments = args,
                 UseShellExecute = false,
-                RedirectStandardError = hideProcess,
-                CreateNoWindow = hideProcess
+                RedirectStandardError = true,
+                CreateNoWindow = true
             };
-
-            if (RequiresAskPass(profile))
-            {
-                ConfigureAskPass(startInfo, profile);
-            }
-
-            return startInfo;
-        }
-
-        private static bool ShouldUseBatchMode(TerminalProfile profile)
-        {
-            return !RequiresAskPass(profile);
-        }
-
-        private static bool RequiresAskPass(TerminalProfile profile)
-        {
-            return profile.SshBackendKind == NovaTerminal.Core.Ssh.Models.SshBackendKind.Native;
-        }
-
-        private static bool RequiresVisibleAuthenticationPrompt(TerminalProfile profile)
-        {
-            return RequiresAskPass(profile) && string.IsNullOrWhiteSpace(ResolveAskPassExecutablePath());
-        }
-
-        private static void ConfigureAskPass(ProcessStartInfo startInfo, TerminalProfile profile)
-        {
-            string? askPassPath = ResolveAskPassExecutablePath();
-            if (string.IsNullOrWhiteSpace(askPassPath))
-            {
-                return;
-            }
-
-            startInfo.Environment[SshAskPassCommand.ModeEnvironmentVariable] = "1";
-            startInfo.Environment["SSH_ASKPASS"] = askPassPath;
-            startInfo.Environment["SSH_ASKPASS_REQUIRE"] = "force";
-            startInfo.Environment["DISPLAY"] = "NovaTerminal";
-            startInfo.Environment[SshAskPassCommand.ProfileIdEnvironmentVariable] = profile.Id.ToString();
-            startInfo.Environment[SshAskPassCommand.ProfileNameEnvironmentVariable] = profile.Name ?? string.Empty;
-            startInfo.Environment[SshAskPassCommand.ProfileUserEnvironmentVariable] = profile.SshUser ?? string.Empty;
-            startInfo.Environment[SshAskPassCommand.ProfileHostEnvironmentVariable] = profile.SshHost ?? string.Empty;
-            startInfo.Environment[SshAskPassCommand.ProfilePortEnvironmentVariable] = profile.SshPort.ToString(System.Globalization.CultureInfo.InvariantCulture);
-        }
-
-        internal static string? ResolveAskPassExecutablePath()
-        {
-            string baseDirectory = AppContext.BaseDirectory;
-            string fileName = OperatingSystem.IsWindows()
-                ? "NovaTerminal.Cli.exe"
-                : "NovaTerminal.Cli";
-            string cliPath = Path.Combine(baseDirectory, fileName);
-            if (File.Exists(cliPath))
-            {
-                return cliPath;
-            }
-
-            return null;
         }
 
         private static string QuoteArg(string value)

--- a/src/NovaTerminal.App/Core/SftpService.cs
+++ b/src/NovaTerminal.App/Core/SftpService.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Threading;
 using NovaTerminal.Core.Ssh.Launch;
+using NovaTerminal.Core.Ssh.Native;
 using NovaTerminal.Services.Ssh;
 
 namespace NovaTerminal.Core
@@ -135,6 +136,37 @@ namespace NovaTerminal.Core
             return profile.SshBackendKind == NovaTerminal.Core.Ssh.Models.SshBackendKind.Native
                 ? SftpTransferBackend.NativeSftp
                 : SftpTransferBackend.ExternalScp;
+        }
+
+        internal static NativeSshConnectionOptions BuildNativeTransferConnectionOptions(
+            SshConnectionService sshService,
+            TerminalProfile profile,
+            IReadOnlyList<TerminalProfile>? allProfiles = null)
+        {
+            ArgumentNullException.ThrowIfNull(sshService);
+            ArgumentNullException.ThrowIfNull(profile);
+
+            var nativeConnector = new NativeJumpHostConnector();
+            var resolvedProfile = sshService.GetStoredProfile(profile.Id)
+                ?? SshConnectionService.MapLegacyTerminalProfile(profile, EnsureLegacyJumpHostProfiles(profile, allProfiles));
+            return nativeConnector.CreateConnectionOptions(resolvedProfile, cols: 120, rows: 30);
+        }
+
+        private static IReadOnlyList<TerminalProfile>? EnsureLegacyJumpHostProfiles(
+            TerminalProfile profile,
+            IReadOnlyList<TerminalProfile>? allProfiles)
+        {
+            if (!profile.JumpHostProfileId.HasValue)
+            {
+                return allProfiles;
+            }
+
+            if (allProfiles == null || allProfiles.Count == 0)
+            {
+                throw new InvalidOperationException("allProfiles is required when building native transfer options from a legacy profile with jump hosts.");
+            }
+
+            return allProfiles;
         }
 
         internal static TerminalProfile? ResolveProfileForJob(

--- a/src/NovaTerminal.App/Core/SftpService.cs
+++ b/src/NovaTerminal.App/Core/SftpService.cs
@@ -104,24 +104,21 @@ namespace NovaTerminal.Core
                 string scpExe = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows) ? "scp.exe" : "scp";
                 string args = BuildScpArguments(job, profile, launchDetails, settings.Profiles);
 
-                var startInfo = new ProcessStartInfo
-                {
-                    FileName = scpExe,
-                    Arguments = args,
-                    UseShellExecute = false,
-                    RedirectStandardError = true,
-                    CreateNoWindow = true
-                };
+                ProcessStartInfo startInfo = CreateScpStartInfo(scpExe, args, profile);
 
                 using var process = Process.Start(startInfo);
                 if (process == null) throw new Exception("Failed to start scp process");
 
-                string error = await process.StandardError.ReadToEndAsync();
+                string error = startInfo.RedirectStandardError
+                    ? await process.StandardError.ReadToEndAsync()
+                    : string.Empty;
                 await process.WaitForExitAsync();
 
                 if (process.ExitCode != 0)
                 {
-                    throw new Exception(error);
+                    throw new Exception(string.IsNullOrWhiteSpace(error)
+                        ? $"scp exited with code {process.ExitCode}."
+                        : error);
                 }
 
                 Dispatcher.UIThread.Post(() =>
@@ -252,7 +249,11 @@ namespace NovaTerminal.Core
                 remotePart = string.IsNullOrEmpty(profile.SshUser) ? profile.SshHost : $"{profile.SshUser}@{profile.SshHost}";
             }
 
-            args.Append(" -B");
+            args.Append(" -O");
+            if (ShouldUseBatchMode(profile))
+            {
+                args.Append(" -B");
+            }
 
             string localPath = QuoteArg(job.LocalPath.Replace("\\", "/", StringComparison.Ordinal));
             string remotePath = QuoteArg(job.RemotePath);
@@ -266,6 +267,78 @@ namespace NovaTerminal.Core
             }
 
             return args.ToString();
+        }
+
+        internal static ProcessStartInfo CreateScpStartInfo(string scpExe, string args, TerminalProfile profile)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(scpExe);
+            ArgumentNullException.ThrowIfNull(profile);
+
+            bool hideProcess = !RequiresVisibleAuthenticationPrompt(profile);
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = scpExe,
+                Arguments = args,
+                UseShellExecute = false,
+                RedirectStandardError = hideProcess,
+                CreateNoWindow = hideProcess
+            };
+
+            if (RequiresAskPass(profile))
+            {
+                ConfigureAskPass(startInfo, profile);
+            }
+
+            return startInfo;
+        }
+
+        private static bool ShouldUseBatchMode(TerminalProfile profile)
+        {
+            return !RequiresAskPass(profile);
+        }
+
+        private static bool RequiresAskPass(TerminalProfile profile)
+        {
+            return profile.SshBackendKind == NovaTerminal.Core.Ssh.Models.SshBackendKind.Native;
+        }
+
+        private static bool RequiresVisibleAuthenticationPrompt(TerminalProfile profile)
+        {
+            return RequiresAskPass(profile) && string.IsNullOrWhiteSpace(ResolveAskPassExecutablePath());
+        }
+
+        private static void ConfigureAskPass(ProcessStartInfo startInfo, TerminalProfile profile)
+        {
+            string? askPassPath = ResolveAskPassExecutablePath();
+            if (string.IsNullOrWhiteSpace(askPassPath))
+            {
+                return;
+            }
+
+            startInfo.Environment[SshAskPassCommand.ModeEnvironmentVariable] = "1";
+            startInfo.Environment["SSH_ASKPASS"] = askPassPath;
+            startInfo.Environment["SSH_ASKPASS_REQUIRE"] = "force";
+            startInfo.Environment["DISPLAY"] = "NovaTerminal";
+            startInfo.Environment[SshAskPassCommand.ProfileIdEnvironmentVariable] = profile.Id.ToString();
+            startInfo.Environment[SshAskPassCommand.ProfileNameEnvironmentVariable] = profile.Name ?? string.Empty;
+            startInfo.Environment[SshAskPassCommand.ProfileUserEnvironmentVariable] = profile.SshUser ?? string.Empty;
+            startInfo.Environment[SshAskPassCommand.ProfileHostEnvironmentVariable] = profile.SshHost ?? string.Empty;
+            startInfo.Environment[SshAskPassCommand.ProfilePortEnvironmentVariable] = profile.SshPort.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        internal static string? ResolveAskPassExecutablePath()
+        {
+            string baseDirectory = AppContext.BaseDirectory;
+            string fileName = OperatingSystem.IsWindows()
+                ? "NovaTerminal.Cli.exe"
+                : "NovaTerminal.Cli";
+            string cliPath = Path.Combine(baseDirectory, fileName);
+            if (File.Exists(cliPath))
+            {
+                return cliPath;
+            }
+
+            return null;
         }
 
         private static string QuoteArg(string value)

--- a/src/NovaTerminal.App/Core/SftpService.cs
+++ b/src/NovaTerminal.App/Core/SftpService.cs
@@ -266,8 +266,8 @@ namespace NovaTerminal.Core
 
             void initializeJob()
             {
-                Jobs.Insert(0, job);
                 MarkJobRunning(job);
+                Jobs.Insert(0, job);
                 JobUpdated?.Invoke(this, job);
             }
 
@@ -277,7 +277,10 @@ namespace NovaTerminal.Core
             }
             else
             {
-                Dispatcher.UIThread.Post(initializeJob);
+                Dispatcher.UIThread
+                    .InvokeAsync(initializeJob, DispatcherPriority.Send)
+                    .GetAwaiter()
+                    .GetResult();
             }
 
             var cancellationTokenSource = new CancellationTokenSource();

--- a/src/NovaTerminal.App/Core/SftpService.cs
+++ b/src/NovaTerminal.App/Core/SftpService.cs
@@ -32,6 +32,12 @@ namespace NovaTerminal.Core
         Canceled
     }
 
+    internal enum SftpTransferBackend
+    {
+        ExternalScp,
+        NativeSftp
+    }
+
     public class TransferJob
     {
         public Guid Id { get; set; } = Guid.NewGuid();
@@ -91,34 +97,15 @@ namespace NovaTerminal.Core
 
                 if (profile == null) throw new Exception("Profile not found");
 
-                SshLaunchDetails? launchDetails = null;
-                try
+                switch (SelectTransferBackend(profile))
                 {
-                    launchDetails = sshService.BuildLaunchDetails(profile, SshDiagnosticsLevel.None);
-                }
-                catch (Exception ex)
-                {
-                    Debug.WriteLine($"[SftpService] SSH launch details unavailable for '{profile.Name}', using legacy SCP args: {ex.Message}");
-                }
-
-                string scpExe = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows) ? "scp.exe" : "scp";
-                string args = BuildScpArguments(job, profile, launchDetails, settings.Profiles);
-
-                ProcessStartInfo startInfo = CreateScpStartInfo(scpExe, args, profile);
-
-                using var process = Process.Start(startInfo);
-                if (process == null) throw new Exception("Failed to start scp process");
-
-                string error = startInfo.RedirectStandardError
-                    ? await process.StandardError.ReadToEndAsync()
-                    : string.Empty;
-                await process.WaitForExitAsync();
-
-                if (process.ExitCode != 0)
-                {
-                    throw new Exception(string.IsNullOrWhiteSpace(error)
-                        ? $"scp exited with code {process.ExitCode}."
-                        : error);
+                    case SftpTransferBackend.NativeSftp:
+                        await RunNativeSftpJobAsync(job, profile);
+                        break;
+                    case SftpTransferBackend.ExternalScp:
+                    default:
+                        await RunExternalScpJobAsync(job, profile, settings.Profiles, sshService);
+                        break;
                 }
 
                 Dispatcher.UIThread.Post(() =>
@@ -139,6 +126,15 @@ namespace NovaTerminal.Core
                     JobUpdated?.Invoke(this, job);
                 });
             }
+        }
+
+        internal static SftpTransferBackend SelectTransferBackend(TerminalProfile profile)
+        {
+            ArgumentNullException.ThrowIfNull(profile);
+
+            return profile.SshBackendKind == NovaTerminal.Core.Ssh.Models.SshBackendKind.Native
+                ? SftpTransferBackend.NativeSftp
+                : SftpTransferBackend.ExternalScp;
         }
 
         internal static TerminalProfile? ResolveProfileForJob(
@@ -190,6 +186,55 @@ namespace NovaTerminal.Core
             }
 
             return null;
+        }
+
+        private static async Task RunExternalScpJobAsync(
+            TransferJob job,
+            TerminalProfile profile,
+            IReadOnlyList<TerminalProfile>? allProfiles,
+            SshConnectionService sshService)
+        {
+            ArgumentNullException.ThrowIfNull(job);
+            ArgumentNullException.ThrowIfNull(profile);
+            ArgumentNullException.ThrowIfNull(sshService);
+
+            SshLaunchDetails? launchDetails = null;
+            try
+            {
+                launchDetails = sshService.BuildLaunchDetails(profile, SshDiagnosticsLevel.None);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[SftpService] SSH launch details unavailable for '{profile.Name}', using legacy SCP args: {ex.Message}");
+            }
+
+            string scpExe = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows) ? "scp.exe" : "scp";
+            string args = BuildScpArguments(job, profile, launchDetails, allProfiles);
+
+            ProcessStartInfo startInfo = CreateScpStartInfo(scpExe, args, profile);
+
+            using var process = Process.Start(startInfo);
+            if (process == null) throw new Exception("Failed to start scp process");
+
+            string error = startInfo.RedirectStandardError
+                ? await process.StandardError.ReadToEndAsync()
+                : string.Empty;
+            await process.WaitForExitAsync();
+
+            if (process.ExitCode != 0)
+            {
+                throw new Exception(string.IsNullOrWhiteSpace(error)
+                    ? $"scp exited with code {process.ExitCode}."
+                    : error);
+            }
+        }
+
+        private static Task RunNativeSftpJobAsync(TransferJob job, TerminalProfile profile)
+        {
+            ArgumentNullException.ThrowIfNull(job);
+            ArgumentNullException.ThrowIfNull(profile);
+
+            throw new NotImplementedException("Native SFTP transfers are not implemented yet.");
         }
 
         internal static string BuildScpArguments(

--- a/src/NovaTerminal.App/Core/SftpService.cs
+++ b/src/NovaTerminal.App/Core/SftpService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -65,22 +66,52 @@ namespace NovaTerminal.Core
     {
         private static SftpService? _instance;
         public static SftpService Instance => _instance ??= new SftpService();
+        private readonly ConcurrentDictionary<Guid, CancellationTokenSource> _activeTransfers = new();
+        private readonly INativeSshInterop _nativeInterop;
+        private readonly Func<TerminalSettings> _settingsLoader;
+        private readonly Func<SshConnectionService> _sshServiceFactory;
 
         public ObservableCollection<TransferJob> Jobs { get; } = new();
 
-        private SftpService() { }
+        private SftpService()
+            : this(null, null, null)
+        {
+        }
+
+        internal SftpService(
+            INativeSshInterop? nativeInterop,
+            Func<TerminalSettings>? settingsLoader,
+            Func<SshConnectionService>? sshServiceFactory)
+        {
+            _nativeInterop = nativeInterop ?? new NativeSshInterop();
+            _settingsLoader = settingsLoader ?? TerminalSettings.Load;
+            _sshServiceFactory = sshServiceFactory ?? (() => new SshConnectionService());
+        }
 
         public void AddJob(TransferJob job)
         {
             Dispatcher.UIThread.Post(() => Jobs.Add(job));
+            var cancellationTokenSource = new CancellationTokenSource();
+            _activeTransfers[job.Id] = cancellationTokenSource;
             // In a real implementation, we would start a queue worker here.
             // For v1, we'll start it immediately.
-            Task.Run(() => RunJobAsync(job));
+            Task.Run(() => RunJobAsync(job, cancellationTokenSource.Token));
+        }
+
+        public bool CancelJob(Guid jobId)
+        {
+            if (!_activeTransfers.TryGetValue(jobId, out CancellationTokenSource? cancellationTokenSource))
+            {
+                return false;
+            }
+
+            cancellationTokenSource.Cancel();
+            return true;
         }
 
         public event EventHandler<TransferJob>? JobUpdated;
 
-        private async Task RunJobAsync(TransferJob job)
+        internal async Task RunJobAsync(TransferJob job, CancellationToken cancellationToken)
         {
             Dispatcher.UIThread.Post(() =>
             {
@@ -91,9 +122,9 @@ namespace NovaTerminal.Core
 
             try
             {
-                var settings = TerminalSettings.Load();
+                var settings = _settingsLoader();
                 settings.Profiles ??= new List<TerminalProfile>();
-                var sshService = new SshConnectionService();
+                var sshService = _sshServiceFactory();
                 IReadOnlyList<TerminalProfile> storeProfiles = sshService.GetConnectionProfiles();
                 TerminalProfile? profile = ResolveProfileForJob(job, settings.Profiles, storeProfiles);
 
@@ -102,11 +133,11 @@ namespace NovaTerminal.Core
                 switch (SelectExecutionBackend(profile, job))
                 {
                     case SftpTransferBackend.NativeSftp:
-                        await RunNativeSftpJobAsync(job, profile, settings.Profiles, sshService);
+                        await RunNativeSftpJobAsync(job, profile, settings.Profiles, sshService, cancellationToken);
                         break;
                     case SftpTransferBackend.ExternalScp:
                     default:
-                        await RunExternalScpJobAsync(job, profile, settings.Profiles, sshService);
+                        await RunExternalScpJobAsync(job, profile, settings.Profiles, sshService, cancellationToken);
                         break;
                 }
 
@@ -114,6 +145,16 @@ namespace NovaTerminal.Core
                 {
                     job.State = TransferState.Completed;
                     job.Progress = 1.0;
+                    job.FinishedAt = DateTime.Now;
+                    JobUpdated?.Invoke(this, job);
+                });
+            }
+            catch (OperationCanceledException)
+            {
+                Dispatcher.UIThread.Post(() =>
+                {
+                    job.State = TransferState.Canceled;
+                    job.LastError = null;
                     job.FinishedAt = DateTime.Now;
                     JobUpdated?.Invoke(this, job);
                 });
@@ -127,6 +168,13 @@ namespace NovaTerminal.Core
                     job.FinishedAt = DateTime.Now;
                     JobUpdated?.Invoke(this, job);
                 });
+            }
+            finally
+            {
+                if (_activeTransfers.TryRemove(job.Id, out CancellationTokenSource? cancellationTokenSource))
+                {
+                    cancellationTokenSource.Dispose();
+                }
             }
         }
 
@@ -233,7 +281,8 @@ namespace NovaTerminal.Core
             TransferJob job,
             TerminalProfile profile,
             IReadOnlyList<TerminalProfile>? allProfiles,
-            SshConnectionService sshService)
+            SshConnectionService sshService,
+            CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(job);
             ArgumentNullException.ThrowIfNull(profile);
@@ -256,11 +305,29 @@ namespace NovaTerminal.Core
 
             using var process = Process.Start(startInfo);
             if (process == null) throw new Exception("Failed to start scp process");
+            using CancellationTokenRegistration cancellationRegistration = cancellationToken.Register(() =>
+            {
+                try
+                {
+                    if (!process.HasExited)
+                    {
+                        process.Kill(entireProcessTree: true);
+                    }
+                }
+                catch
+                {
+                }
+            });
 
             string error = startInfo.RedirectStandardError
                 ? await process.StandardError.ReadToEndAsync()
                 : string.Empty;
             await process.WaitForExitAsync();
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                throw new OperationCanceledException("SCP transfer canceled.", cancellationToken);
+            }
 
             if (process.ExitCode != 0)
             {
@@ -270,11 +337,12 @@ namespace NovaTerminal.Core
             }
         }
 
-        private static Task RunNativeSftpJobAsync(
+        private Task RunNativeSftpJobAsync(
             TransferJob job,
             TerminalProfile profile,
             IReadOnlyList<TerminalProfile>? allProfiles,
-            SshConnectionService sshService)
+            SshConnectionService sshService,
+            CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(job);
             ArgumentNullException.ThrowIfNull(profile);
@@ -285,9 +353,15 @@ namespace NovaTerminal.Core
                 profile,
                 sshService,
                 allProfiles,
-                interop: null,
+                interop: _nativeInterop,
                 passwordResolver: static transferProfile => new VaultService().GetSshPasswordForProfile(transferProfile),
-                knownHostsFilePath: AppPaths.NativeKnownHostsFilePath);
+                knownHostsFilePath: AppPaths.NativeKnownHostsFilePath,
+                progress: nativeProgress => Dispatcher.UIThread.Post(() =>
+                {
+                    ApplyNativeTransferProgress(job, nativeProgress);
+                    JobUpdated?.Invoke(this, job);
+                }),
+                cancellationToken: cancellationToken);
 
             return Task.CompletedTask;
         }
@@ -299,7 +373,9 @@ namespace NovaTerminal.Core
             IReadOnlyList<TerminalProfile>? allProfiles = null,
             INativeSshInterop? interop = null,
             Func<TerminalProfile, string?>? passwordResolver = null,
-            string? knownHostsFilePath = null)
+            string? knownHostsFilePath = null,
+            Action<NativeSftpTransferProgress>? progress = null,
+            CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(job);
             ArgumentNullException.ThrowIfNull(profile);
@@ -339,8 +415,20 @@ namespace NovaTerminal.Core
             (interop ?? new NativeSshInterop()).RunSftpTransfer(
                 connectionOptions,
                 transferOptions,
-                progress: null,
-                CancellationToken.None);
+                progress,
+                cancellationToken);
+        }
+
+        internal static void ApplyNativeTransferProgress(TransferJob job, NativeSftpTransferProgress progress)
+        {
+            ArgumentNullException.ThrowIfNull(job);
+            ArgumentNullException.ThrowIfNull(progress);
+
+            job.BytesDone = progress.BytesDone;
+            job.BytesTotal = progress.BytesTotal;
+            job.Progress = progress.BytesTotal > 0
+                ? Math.Clamp((double)progress.BytesDone / progress.BytesTotal, 0.0, 1.0)
+                : 0.0;
         }
 
         internal static NativeSftpTransferOptions BuildNativeTransferOptions(TransferJob job)

--- a/src/NovaTerminal.App/Core/SshAskPassCommand.cs
+++ b/src/NovaTerminal.App/Core/SshAskPassCommand.cs
@@ -1,0 +1,258 @@
+using System;
+using System.IO;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Layout;
+using Avalonia.Threading;
+using Avalonia.Themes.Fluent;
+using NovaTerminal.Core;
+
+namespace NovaTerminal;
+
+internal static class SshAskPassCommand
+{
+    internal const string ModeFlag = "--ssh-askpass";
+    internal const string ModeEnvironmentVariable = "NOVA_SSH_ASKPASS";
+    internal const string ProfileIdEnvironmentVariable = "NOVA_SSH_ASKPASS_PROFILE_ID";
+    internal const string ProfileNameEnvironmentVariable = "NOVA_SSH_ASKPASS_PROFILE_NAME";
+    internal const string ProfileUserEnvironmentVariable = "NOVA_SSH_ASKPASS_PROFILE_USER";
+    internal const string ProfileHostEnvironmentVariable = "NOVA_SSH_ASKPASS_PROFILE_HOST";
+    internal const string ProfilePortEnvironmentVariable = "NOVA_SSH_ASKPASS_PROFILE_PORT";
+
+    public static bool IsSupportedCliMode(string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+        return Array.Exists(args, arg => string.Equals(arg, ModeFlag, StringComparison.Ordinal)) ||
+               string.Equals(Environment.GetEnvironmentVariable(ModeEnvironmentVariable), "1", StringComparison.Ordinal);
+    }
+
+    public static int Execute(string[] args, TextWriter stdout, TextWriter stderr)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(stdout);
+        ArgumentNullException.ThrowIfNull(stderr);
+
+        try
+        {
+            string prompt = GetPrompt(args);
+            TerminalProfile profile = CreateProfileFromEnvironment();
+
+            if (IsPasswordPrompt(prompt))
+            {
+                string? vaultPassword = new VaultService().GetSshPasswordForProfile(profile);
+                if (!string.IsNullOrEmpty(vaultPassword))
+                {
+                    stdout.WriteLine(vaultPassword);
+                    return 0;
+                }
+            }
+
+            var state = new AskPassState(prompt, profile);
+            BuildAskPassApp(state).StartWithClassicDesktopLifetime(
+                Array.Empty<string>(),
+                ShutdownMode.OnExplicitShutdown);
+
+            if (string.IsNullOrEmpty(state.Response))
+            {
+                return 1;
+            }
+
+            stdout.WriteLine(state.Response);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            stderr.WriteLine($"NovaTerminal SSH askpass failed: {ex.Message}");
+            return 2;
+        }
+    }
+
+    private static string GetPrompt(string[] args)
+    {
+        foreach (string arg in args)
+        {
+            if (!string.Equals(arg, ModeFlag, StringComparison.Ordinal))
+            {
+                return arg;
+            }
+        }
+
+        return "SSH authentication required.";
+    }
+
+    private static TerminalProfile CreateProfileFromEnvironment()
+    {
+        var profile = new TerminalProfile
+        {
+            Type = ConnectionType.SSH,
+            Name = Environment.GetEnvironmentVariable(ProfileNameEnvironmentVariable) ?? string.Empty,
+            SshUser = Environment.GetEnvironmentVariable(ProfileUserEnvironmentVariable) ?? string.Empty,
+            SshHost = Environment.GetEnvironmentVariable(ProfileHostEnvironmentVariable) ?? string.Empty
+        };
+
+        if (Guid.TryParse(Environment.GetEnvironmentVariable(ProfileIdEnvironmentVariable), out Guid profileId))
+        {
+            profile.Id = profileId;
+        }
+
+        if (int.TryParse(Environment.GetEnvironmentVariable(ProfilePortEnvironmentVariable), out int port) && port > 0)
+        {
+            profile.SshPort = port;
+        }
+
+        return profile;
+    }
+
+    private static AppBuilder BuildAskPassApp(AskPassState state)
+    {
+        return AppBuilder.Configure(() => new AskPassApplication(state))
+            .UsePlatformDetect()
+            .WithInterFont()
+            .LogToTrace();
+    }
+
+    private static bool IsPasswordPrompt(string prompt)
+    {
+        return prompt.Contains("password", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsSecretPrompt(string prompt)
+    {
+        return IsPasswordPrompt(prompt) ||
+               prompt.Contains("passphrase", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class AskPassState
+    {
+        public AskPassState(string prompt, TerminalProfile profile)
+        {
+            Prompt = string.IsNullOrWhiteSpace(prompt) ? "SSH authentication required." : prompt;
+            Profile = profile;
+        }
+
+        public string Prompt { get; }
+        public TerminalProfile Profile { get; }
+        public string? Response { get; set; }
+    }
+
+    private sealed class AskPassApplication : Application
+    {
+        private readonly AskPassState _state;
+
+        public AskPassApplication(AskPassState state)
+        {
+            _state = state;
+        }
+
+        public override void Initialize()
+        {
+            Styles.Add(new FluentTheme());
+        }
+
+        public override void OnFrameworkInitializationCompleted()
+        {
+            if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+            {
+                var window = new AskPassWindow(_state, () => desktop.Shutdown());
+                desktop.MainWindow = window;
+                window.Show();
+            }
+
+            base.OnFrameworkInitializationCompleted();
+        }
+    }
+
+    private sealed class AskPassWindow : Window
+    {
+        private readonly AskPassState _state;
+        private readonly Action _shutdown;
+        private readonly TextBox _input;
+        private readonly CheckBox _rememberPassword;
+
+        public AskPassWindow(AskPassState state, Action shutdown)
+        {
+            _state = state;
+            _shutdown = shutdown;
+
+            Title = "NovaTerminal SSH Authentication";
+            Width = 520;
+            Height = 240;
+            CanResize = false;
+            WindowStartupLocation = WindowStartupLocation.CenterScreen;
+
+            _input = new TextBox
+            {
+                PasswordChar = IsSecretPrompt(_state.Prompt) ? '*' : default(char),
+                HorizontalAlignment = HorizontalAlignment.Stretch
+            };
+
+            _rememberPassword = new CheckBox
+            {
+                Content = "Remember password",
+                IsVisible = IsPasswordPrompt(_state.Prompt) && _state.Profile.Id != Guid.Empty
+            };
+
+            Content = BuildContent();
+        }
+
+        private Control BuildContent()
+        {
+            var cancelButton = new Button { Content = "Cancel", Width = 96 };
+            cancelButton.Click += (_, _) => CloseWith(null);
+
+            var submitButton = new Button { Content = "Submit", Width = 96 };
+            submitButton.Click += (_, _) => CloseWith(_input.Text);
+
+            return new Border
+            {
+                Padding = new Thickness(16),
+                Child = new StackPanel
+                {
+                    Spacing = 12,
+                    Children =
+                    {
+                        new TextBlock
+                        {
+                            Text = "SSH authentication",
+                            FontSize = 18,
+                            FontWeight = Avalonia.Media.FontWeight.SemiBold
+                        },
+                        new TextBlock
+                        {
+                            Text = _state.Prompt,
+                            TextWrapping = Avalonia.Media.TextWrapping.Wrap
+                        },
+                        _input,
+                        _rememberPassword,
+                        new StackPanel
+                        {
+                            Orientation = Orientation.Horizontal,
+                            HorizontalAlignment = HorizontalAlignment.Right,
+                            Spacing = 8,
+                            Children = { cancelButton, submitButton }
+                        }
+                    }
+                }
+            };
+        }
+
+        protected override void OnOpened(EventArgs e)
+        {
+            base.OnOpened(e);
+            _input.Focus();
+        }
+
+        private void CloseWith(string? response)
+        {
+            _state.Response = response;
+            if (!string.IsNullOrEmpty(response) && _rememberPassword.IsChecked == true)
+            {
+                new VaultService().SetSshPasswordForProfile(_state.Profile, response);
+            }
+
+            Close();
+            Dispatcher.UIThread.Post(_shutdown);
+        }
+    }
+}

--- a/src/NovaTerminal.App/MainWindow.axaml
+++ b/src/NovaTerminal.App/MainWindow.axaml
@@ -265,7 +265,7 @@
                 Background="#1E1E1E" BorderBrush="#333" BorderThickness="1" CornerRadius="8"
                 ZIndex="600">
             <Grid RowDefinitions="Auto, *">
-                <Grid Background="#2D2D2D" Height="32">
+                <Grid Name="TransferTitleBar" Background="#2D2D2D" Height="32">
                     <TextBlock Text="Recent Transfers" VerticalAlignment="Center" Margin="10,0" FontSize="12" FontWeight="Bold"/>
                     <Button Name="BtnCloseTransfers" Content="✕" HorizontalAlignment="Right" Width="32" Background="Transparent" BorderThickness="0"/>
                 </Grid>
@@ -292,18 +292,5 @@
             </Border>
         </Grid>
 
-        <!-- SFTP Path Prompt Overlay -->
-        <Grid Name="PathPromptOverlay" ZIndex="1000" IsVisible="False" Background="#80000000">
-            <Border Width="500" Background="#252526" BorderBrush="#007ACC" BorderThickness="1" CornerRadius="4" VerticalAlignment="Top" Margin="0,150,0,0" Padding="15">
-                <Grid RowDefinitions="Auto, Auto, Auto">
-                    <TextBlock Name="PathPromptTitle" Text="Remote Path" Foreground="White" FontSize="14" FontWeight="Bold" Margin="0,0,0,10"/>
-                    <TextBox Name="PathPromptBox" Grid.Row="1" Watermark="e.g. ~/logs" Margin="0,0,0,15" />
-                    <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10">
-                        <Button Name="BtnPathCancel" Content="Cancel" Width="80" />
-                        <Button Name="BtnPathConfirm" Content="Confirm" Width="80" Background="#007ACC" Foreground="White" />
-                    </StackPanel>
-                </Grid>
-            </Border>
-        </Grid>
     </Grid>
 </Window>

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -3603,7 +3603,9 @@ namespace NovaTerminal
             var request = TransferDialogRequest.ForAction(
                 direction,
                 kind,
-                profile.DefaultRemoteDir ?? "~");
+                profile.DefaultRemoteDir ?? "~",
+                profile.Id,
+                sessionId);
 
             TransferDialogResult? result = await ShowTransferDialogAsync(request);
             if (result is not { IsConfirmed: true })

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -23,6 +23,7 @@ using SkiaSharp;
 using NovaTerminal.Controls;
 using NovaTerminal.Services.Ssh;
 using NovaTerminal.Core.Ssh.Launch;
+using NovaTerminal.Models;
 using NovaTerminal.ViewModels.Ssh;
 using NovaTerminal.Views.Ssh;
 
@@ -66,6 +67,10 @@ namespace NovaTerminal
         internal const double MinimumTabHeaderRightReserve = 440;
         internal const double MacOsTrafficLightReserve = 92;
         internal const double TabHeaderViewportPadding = 16;
+        private bool _isDraggingTransferOverlay;
+        private Point _transferOverlayDragStart;
+        private Point _transferOverlayOffsetStart;
+        private TranslateTransform? _transferOverlayTransform;
 
         private sealed class PaneZoomState
         {
@@ -3576,115 +3581,60 @@ namespace NovaTerminal
 
             var profile = pane.Profile;
             var sessionId = pane.Session?.Id ?? Guid.Empty;
-
-            string? localPath = null;
-            string? remotePath = null;
-
-            if (direction == TransferDirection.Upload)
-            {
-                // File Picker
-                var topLevel = TopLevel.GetTopLevel(this);
-                if (topLevel == null) return;
-
-                if (kind == TransferKind.File)
-                {
-                    var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions { Title = "Select File to Upload", AllowMultiple = false });
-                    if (files != null && files.Count > 0) localPath = files[0].Path.LocalPath;
-                }
-                else
-                {
-                    var folders = await topLevel.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions { Title = "Select Folder to Upload", AllowMultiple = false });
-                    if (folders != null && folders.Count > 0) localPath = folders[0].Path.LocalPath;
-                }
-
-                if (string.IsNullOrEmpty(localPath)) return;
-
-                remotePath = await PromptForRemotePathAsync("Remote Destination Path", profile!.DefaultRemoteDir ?? "~");
-            }
-            else
-            {
-                // Download
-                remotePath = await PromptForRemotePathAsync("Remote Source Path", profile!.DefaultRemoteDir ?? "~");
-                if (string.IsNullOrEmpty(remotePath)) return;
-
-                // Folder/File Picker for destination
-                var topLevel = TopLevel.GetTopLevel(this);
-                if (topLevel == null) return;
-
-                if (kind == TransferKind.File)
-                {
-                    var file = await topLevel.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions { Title = "Select Local Destination", SuggestedFileName = Path.GetFileName(remotePath) });
-                    if (file != null) localPath = file.Path.LocalPath;
-                }
-                else
-                {
-                    var folders = await topLevel.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions { Title = "Select Local Destination Folder", AllowMultiple = false });
-                    if (folders != null && folders.Count > 0) localPath = folders[0].Path.LocalPath;
-                }
-            }
-
-            if (!string.IsNullOrEmpty(localPath) && !string.IsNullOrEmpty(remotePath))
-            {
-                var job = new TransferJob
-                {
-                    SessionId = sessionId,
-                    ProfileId = profile.Id,
-                    ProfileName = profile.Name,
-                    Direction = direction,
-                    Kind = kind,
-                    LocalPath = localPath,
-                    RemotePath = remotePath
-                };
-                SftpService.Instance.AddJob(job);
-                ShowTransferCenter();
-            }
+            await InitiateSftpTransferAsync(profile, sessionId, direction, kind);
         }
 
-        private TaskCompletionSource<string?>? _pathPromptTcs;
-        private async Task<string?> PromptForRemotePathAsync(string title, string defaultValue)
+        internal Task InitiateSftpTransferForTest(
+            TerminalProfile profile,
+            Guid sessionId,
+            TransferDirection direction,
+            TransferKind kind)
         {
-            var overlay = this.FindControl<Grid>("PathPromptOverlay");
-            var titleBlock = this.FindControl<TextBlock>("PathPromptTitle");
-            var box = this.FindControl<TextBox>("PathPromptBox");
-            var btnConfirm = this.FindControl<Button>("BtnPathConfirm");
-            var btnCancel = this.FindControl<Button>("BtnPathCancel");
+            ArgumentNullException.ThrowIfNull(profile);
+            return InitiateSftpTransferAsync(profile, sessionId, direction, kind);
+        }
 
-            if (overlay == null || box == null || titleBlock == null || btnConfirm == null || btnCancel == null) return null;
+        private async Task InitiateSftpTransferAsync(
+            TerminalProfile profile,
+            Guid sessionId,
+            TransferDirection direction,
+            TransferKind kind)
+        {
+            var request = TransferDialogRequest.ForAction(
+                direction,
+                kind,
+                profile.DefaultRemoteDir ?? "~");
 
-            titleBlock.Text = title;
-            box.Text = defaultValue;
-            overlay.IsVisible = true;
-            box.Focus();
-
-            _pathPromptTcs = new TaskCompletionSource<string?>();
-
-            EventHandler<Avalonia.Interactivity.RoutedEventArgs>? confirmHandler = null;
-            EventHandler<Avalonia.Interactivity.RoutedEventArgs>? cancelHandler = null;
-
-            confirmHandler = (s, e) =>
+            TransferDialogResult? result = await ShowTransferDialogAsync(request);
+            if (result is not { IsConfirmed: true })
             {
-                overlay.IsVisible = false;
-                _pathPromptTcs.TrySetResult(box.Text);
+                return;
+            }
+
+            var job = new TransferJob
+            {
+                SessionId = sessionId,
+                ProfileId = profile.Id,
+                ProfileName = profile.Name,
+                Direction = direction,
+                Kind = kind,
+                LocalPath = result.LocalPath,
+                RemotePath = result.RemotePath
             };
 
-            cancelHandler = (s, e) =>
-            {
-                overlay.IsVisible = false;
-                _pathPromptTcs.TrySetResult(null);
-            };
+            EnqueueTransferJob(job);
+        }
 
-            btnConfirm.Click += confirmHandler;
-            btnCancel.Click += cancelHandler;
+        internal virtual async Task<TransferDialogResult?> ShowTransferDialogAsync(TransferDialogRequest request)
+        {
+            var dialog = new TransferDialog(request);
+            return await dialog.ShowDialog<TransferDialogResult?>(this);
+        }
 
-            try
-            {
-                return await _pathPromptTcs.Task;
-            }
-            finally
-            {
-                btnConfirm.Click -= confirmHandler;
-                btnCancel.Click -= cancelHandler;
-            }
+        internal virtual void EnqueueTransferJob(TransferJob job)
+        {
+            SftpService.Instance.AddJob(job);
+            ShowTransferCenter();
         }
 
         private void InitializeCommandPaletteUI()
@@ -3823,7 +3773,82 @@ namespace NovaTerminal
         private void InitializeTransferCenterUI()
         {
             var btnClose = this.FindControl<Button>("BtnCloseTransfers");
+            var overlay = this.FindControl<Border>("TransferOverlay");
+            var titleBar = this.FindControl<Grid>("TransferTitleBar");
+
             if (btnClose != null) btnClose.Click += (s, e) => ToggleTransferCenter();
+
+            if (overlay != null)
+            {
+                _transferOverlayTransform = overlay.RenderTransform as TranslateTransform;
+                if (_transferOverlayTransform == null)
+                {
+                    _transferOverlayTransform = new TranslateTransform();
+                    overlay.RenderTransform = _transferOverlayTransform;
+                }
+            }
+
+            if (titleBar != null)
+            {
+                titleBar.PointerPressed += OnTransferTitleBarPointerPressed;
+                titleBar.PointerMoved += OnTransferTitleBarPointerMoved;
+                titleBar.PointerReleased += OnTransferTitleBarPointerReleased;
+                titleBar.PointerCaptureLost += OnTransferTitleBarPointerCaptureLost;
+            }
+        }
+
+        private void OnTransferTitleBarPointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (sender is not Control titleBar || e.Source is Button)
+            {
+                return;
+            }
+
+            if (!e.GetCurrentPoint(titleBar).Properties.IsLeftButtonPressed)
+            {
+                return;
+            }
+
+            _isDraggingTransferOverlay = true;
+            _transferOverlayDragStart = e.GetPosition(this);
+            _transferOverlayOffsetStart = new Point(
+                _transferOverlayTransform?.X ?? 0,
+                _transferOverlayTransform?.Y ?? 0);
+            e.Pointer.Capture(titleBar);
+            e.Handled = true;
+        }
+
+        private void OnTransferTitleBarPointerMoved(object? sender, PointerEventArgs e)
+        {
+            if (!_isDraggingTransferOverlay || _transferOverlayTransform == null)
+            {
+                return;
+            }
+
+            Point current = e.GetPosition(this);
+            Vector delta = current - _transferOverlayDragStart;
+            _transferOverlayTransform.X = _transferOverlayOffsetStart.X + delta.X;
+            _transferOverlayTransform.Y = _transferOverlayOffsetStart.Y + delta.Y;
+        }
+
+        private void OnTransferTitleBarPointerReleased(object? sender, PointerReleasedEventArgs e)
+        {
+            StopTransferTitleBarDrag(sender, e);
+        }
+
+        private void OnTransferTitleBarPointerCaptureLost(object? sender, PointerCaptureLostEventArgs e)
+        {
+            _isDraggingTransferOverlay = false;
+        }
+
+        private void StopTransferTitleBarDrag(object? sender, PointerReleasedEventArgs e)
+        {
+            if (sender is Control titleBar)
+            {
+                e.Pointer.Capture(null);
+            }
+
+            _isDraggingTransferOverlay = false;
         }
 
         private async Task OpenSettings(int tabIndex, Guid? profileId = null)

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -3798,10 +3798,22 @@ namespace NovaTerminal
 
         private void ShowTransferCenter()
         {
-            var overlay = this.FindControl<Border>("TransferOverlay");
-            if (overlay != null)
+            void show()
             {
-                overlay.IsVisible = true;
+                var overlay = this.FindControl<Border>("TransferOverlay");
+                if (overlay != null)
+                {
+                    overlay.IsVisible = true;
+                }
+            }
+
+            if (Dispatcher.UIThread.CheckAccess())
+            {
+                show();
+            }
+            else
+            {
+                Dispatcher.UIThread.Post(show, DispatcherPriority.Loaded);
             }
         }
 

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -3813,7 +3813,10 @@ namespace NovaTerminal
             }
             else
             {
-                Dispatcher.UIThread.Post(show, DispatcherPriority.Loaded);
+                Dispatcher.UIThread
+                    .InvokeAsync(show, DispatcherPriority.Send)
+                    .GetAwaiter()
+                    .GetResult();
             }
         }
 

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -3636,6 +3636,7 @@ namespace NovaTerminal
                     RemotePath = remotePath
                 };
                 SftpService.Instance.AddJob(job);
+                ShowTransferCenter();
             }
         }
 
@@ -3792,6 +3793,15 @@ namespace NovaTerminal
             if (overlay != null)
             {
                 overlay.IsVisible = !overlay.IsVisible;
+            }
+        }
+
+        private void ShowTransferCenter()
+        {
+            var overlay = this.FindControl<Border>("TransferOverlay");
+            if (overlay != null)
+            {
+                overlay.IsVisible = true;
             }
         }
 

--- a/src/NovaTerminal.App/Models/RemotePathSuggestion.cs
+++ b/src/NovaTerminal.App/Models/RemotePathSuggestion.cs
@@ -1,0 +1,15 @@
+namespace NovaTerminal.Models;
+
+public sealed class RemotePathSuggestion
+{
+    public RemotePathSuggestion(string displayName, string fullPath, bool isDirectory)
+    {
+        DisplayName = displayName;
+        FullPath = fullPath;
+        IsDirectory = isDirectory;
+    }
+
+    public string DisplayName { get; }
+    public string FullPath { get; }
+    public bool IsDirectory { get; }
+}

--- a/src/NovaTerminal.App/Models/RemotePathSuggestion.cs
+++ b/src/NovaTerminal.App/Models/RemotePathSuggestion.cs
@@ -12,4 +12,5 @@ public sealed class RemotePathSuggestion
     public string DisplayName { get; }
     public string FullPath { get; }
     public bool IsDirectory { get; }
+    public string KindText => IsDirectory ? "DIR" : "FILE";
 }

--- a/src/NovaTerminal.App/Models/TransferDialogRequest.cs
+++ b/src/NovaTerminal.App/Models/TransferDialogRequest.cs
@@ -1,3 +1,4 @@
+using System;
 using NovaTerminal.Core;
 
 namespace NovaTerminal.Models;
@@ -7,17 +8,23 @@ public sealed class TransferDialogRequest
     public TransferDirection Direction { get; init; }
     public TransferKind Kind { get; init; }
     public string RemotePath { get; init; } = string.Empty;
+    public Guid ProfileId { get; init; }
+    public Guid SessionId { get; init; }
 
     public static TransferDialogRequest ForAction(
         TransferDirection direction,
         TransferKind kind,
-        string defaultRemotePath)
+        string defaultRemotePath,
+        Guid profileId,
+        Guid sessionId)
     {
         return new TransferDialogRequest
         {
             Direction = direction,
             Kind = kind,
-            RemotePath = defaultRemotePath
+            RemotePath = defaultRemotePath,
+            ProfileId = profileId,
+            SessionId = sessionId
         };
     }
 }

--- a/src/NovaTerminal.App/Models/TransferDialogRequest.cs
+++ b/src/NovaTerminal.App/Models/TransferDialogRequest.cs
@@ -1,0 +1,23 @@
+using NovaTerminal.Core;
+
+namespace NovaTerminal.Models;
+
+public sealed class TransferDialogRequest
+{
+    public TransferDirection Direction { get; init; }
+    public TransferKind Kind { get; init; }
+    public string RemotePath { get; init; } = string.Empty;
+
+    public static TransferDialogRequest ForAction(
+        TransferDirection direction,
+        TransferKind kind,
+        string defaultRemotePath)
+    {
+        return new TransferDialogRequest
+        {
+            Direction = direction,
+            Kind = kind,
+            RemotePath = defaultRemotePath
+        };
+    }
+}

--- a/src/NovaTerminal.App/Models/TransferDialogResult.cs
+++ b/src/NovaTerminal.App/Models/TransferDialogResult.cs
@@ -1,0 +1,18 @@
+namespace NovaTerminal.Models;
+
+public sealed class TransferDialogResult
+{
+    public bool IsConfirmed { get; init; }
+    public string LocalPath { get; init; } = string.Empty;
+    public string RemotePath { get; init; } = string.Empty;
+
+    public static TransferDialogResult CreateConfirmed(string localPath, string remotePath)
+    {
+        return new TransferDialogResult
+        {
+            IsConfirmed = true,
+            LocalPath = localPath,
+            RemotePath = remotePath
+        };
+    }
+}

--- a/src/NovaTerminal.App/NovaTerminal.App.csproj
+++ b/src/NovaTerminal.App/NovaTerminal.App.csproj
@@ -50,7 +50,17 @@
 
   <PropertyGroup>
     <NativeProjectDir>$(MSBuildProjectDirectory)\native\</NativeProjectDir>
+    <RustSshNativeProjectDir>$(NativeProjectDir)rusty_ssh\</RustSshNativeProjectDir>
+    <RustSshNativeOutput Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))">$(RustSshNativeProjectDir)target\release\rusty_ssh.dll</RustSshNativeOutput>
+    <RustSshNativeOutput Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))">$(RustSshNativeProjectDir)target\release\librusty_ssh.so</RustSshNativeOutput>
+    <RustSshNativeOutput Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))">$(RustSshNativeProjectDir)target\release\librusty_ssh.dylib</RustSshNativeOutput>
   </PropertyGroup>
+
+  <ItemGroup>
+    <RustSshNativeInputs Include="$(RustSshNativeProjectDir)Cargo.toml" />
+    <RustSshNativeInputs Include="$(RustSshNativeProjectDir)Cargo.lock" />
+    <RustSshNativeInputs Include="$(RustSshNativeProjectDir)src\**\*.rs" />
+  </ItemGroup>
 
   <Target Name="BuildRustNative"
     BeforeTargets="PrepareForBuild"
@@ -84,18 +94,14 @@
     Condition="'$(DesignTimeBuild)' != 'true'
       and '$(IsCrossTargetingBuild)' != 'true'
       and '$(SKIP_RUST_NATIVE_BUILD)' != '1'
-      and (
-        ($([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows))) and !Exists('$(NativeProjectDir)rusty_ssh\target\release\rusty_ssh.dll'))
-        or
-        ($([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux))) and !Exists('$(NativeProjectDir)rusty_ssh\target\release\librusty_ssh.so'))
-        or
-        ($([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX))) and !Exists('$(NativeProjectDir)rusty_ssh\target\release\librusty_ssh.dylib'))
-      )">
+      and '$(RustSshNativeOutput)' != ''"
+    Inputs="@(RustSshNativeInputs)"
+    Outputs="$(RustSshNativeOutput)">
 
     <Message Importance="high"
-      Text="[RustNative] Building Rust SSH native library in: $(NativeProjectDir)rusty_ssh" />
+      Text="[RustNative] Building Rust SSH native library in: $(RustSshNativeProjectDir)" />
 
-    <Exec WorkingDirectory="$(NativeProjectDir)rusty_ssh"
+    <Exec WorkingDirectory="$(RustSshNativeProjectDir)"
       Command="cargo build --release"
       EchoOff="false"
       ConsoleToMSBuild="true"

--- a/src/NovaTerminal.App/Program.cs
+++ b/src/NovaTerminal.App/Program.cs
@@ -21,6 +21,13 @@ class Program
                 return;
             }
 
+            if (SshAskPassCommand.IsSupportedCliMode(args))
+            {
+                CliConsoleBindings.Prepare();
+                Environment.ExitCode = SshAskPassCommand.Execute(args, Console.Out, Console.Error);
+                return;
+            }
+
             // Log startup info
             TerminalLogger.Log("NovaTerminal started with args: " + string.Join(" ", args));
             TerminalLogger.Log("Log file path: " + AppLogger.GetLogFilePath());

--- a/src/NovaTerminal.App/Services/BackgroundWork.cs
+++ b/src/NovaTerminal.App/Services/BackgroundWork.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NovaTerminal.Services;
+
+internal static class BackgroundWork
+{
+    internal static Task<T> RunBlockingAsync<T>(
+        Func<CancellationToken, T> work,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(work);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Task.Run(() =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return work(cancellationToken);
+        }, cancellationToken);
+    }
+}

--- a/src/NovaTerminal.App/Services/Ssh/ActiveSshSessionRegistry.cs
+++ b/src/NovaTerminal.App/Services/Ssh/ActiveSshSessionRegistry.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Concurrent;
+using NovaTerminal.Core.Ssh.Models;
+
+namespace NovaTerminal.Services.Ssh;
+
+public sealed class ActiveSshSessionRegistry
+{
+    private static readonly Lazy<ActiveSshSessionRegistry> Shared = new(() => new ActiveSshSessionRegistry());
+    private readonly ConcurrentDictionary<Guid, ActiveSshSessionDescriptor> _sessions = new();
+
+    public static ActiveSshSessionRegistry Instance => Shared.Value;
+
+    public void Register(ActiveSshSessionDescriptor descriptor)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+        _sessions[descriptor.SessionId] = descriptor;
+    }
+
+    public bool TryGet(Guid sessionId, out ActiveSshSessionDescriptor? descriptor)
+    {
+        bool found = _sessions.TryGetValue(sessionId, out ActiveSshSessionDescriptor stored);
+        descriptor = found ? stored : null;
+        return found;
+    }
+
+    public void Unregister(Guid sessionId)
+    {
+        _sessions.TryRemove(sessionId, out _);
+    }
+}
+
+public sealed class ActiveSshSessionDescriptor
+{
+    public ActiveSshSessionDescriptor(Guid sessionId, Guid profileId, SshBackendKind backendKind)
+    {
+        SessionId = sessionId;
+        ProfileId = profileId;
+        BackendKind = backendKind;
+    }
+
+    public Guid SessionId { get; }
+    public Guid ProfileId { get; }
+    public SshBackendKind BackendKind { get; }
+}

--- a/src/NovaTerminal.App/Services/Ssh/ActiveSshSessionRegistry.cs
+++ b/src/NovaTerminal.App/Services/Ssh/ActiveSshSessionRegistry.cs
@@ -8,6 +8,7 @@ public sealed class ActiveSshSessionRegistry
 {
     private static readonly Lazy<ActiveSshSessionRegistry> Shared = new(() => new ActiveSshSessionRegistry());
     private readonly ConcurrentDictionary<Guid, ActiveSshSessionDescriptor> _sessions = new();
+    private readonly ConcurrentDictionary<Guid, string> _runtimePasswords = new();
 
     public static ActiveSshSessionRegistry Instance => Shared.Value;
 
@@ -27,6 +28,30 @@ public sealed class ActiveSshSessionRegistry
     public void Unregister(Guid sessionId)
     {
         _sessions.TryRemove(sessionId, out _);
+        _runtimePasswords.TryRemove(sessionId, out _);
+    }
+
+    public void SetRuntimePassword(Guid sessionId, string? password)
+    {
+        if (sessionId == Guid.Empty)
+        {
+            return;
+        }
+
+        if (string.IsNullOrEmpty(password))
+        {
+            _runtimePasswords.TryRemove(sessionId, out _);
+            return;
+        }
+
+        _runtimePasswords[sessionId] = password;
+    }
+
+    public bool TryGetRuntimePassword(Guid sessionId, out string? password)
+    {
+        bool found = _runtimePasswords.TryGetValue(sessionId, out string? stored);
+        password = found ? stored : null;
+        return found;
     }
 }
 

--- a/src/NovaTerminal.App/Services/Ssh/IRemotePathAutocompleteService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/IRemotePathAutocompleteService.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NovaTerminal.Models;
+
+namespace NovaTerminal.Services.Ssh;
+
+public interface IRemotePathAutocompleteService
+{
+    Task<IReadOnlyList<RemotePathSuggestion>> GetSuggestionsAsync(
+        Guid profileId,
+        Guid sessionId,
+        string input,
+        CancellationToken cancellationToken);
+}

--- a/src/NovaTerminal.App/Services/Ssh/RemotePathAutocompleteQuery.cs
+++ b/src/NovaTerminal.App/Services/Ssh/RemotePathAutocompleteQuery.cs
@@ -29,6 +29,22 @@ public sealed class RemotePathAutocompleteQuery
             return new RemotePathAutocompleteQuery("~", string.Empty);
         }
 
+        if (normalized.EndsWith("/", StringComparison.Ordinal))
+        {
+            string directoryPath = normalized.TrimEnd('/');
+            if (string.IsNullOrEmpty(directoryPath))
+            {
+                return new RemotePathAutocompleteQuery("/", string.Empty);
+            }
+
+            if (directoryPath == "~")
+            {
+                return new RemotePathAutocompleteQuery("~", string.Empty);
+            }
+
+            return new RemotePathAutocompleteQuery(directoryPath, string.Empty);
+        }
+
         string trimmed = normalized.TrimEnd('/');
         int lastSlashIndex = trimmed.LastIndexOf('/');
         if (lastSlashIndex < 0)

--- a/src/NovaTerminal.App/Services/Ssh/RemotePathAutocompleteQuery.cs
+++ b/src/NovaTerminal.App/Services/Ssh/RemotePathAutocompleteQuery.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NovaTerminal.Models;
+
+namespace NovaTerminal.Services.Ssh;
+
+public sealed class RemotePathAutocompleteQuery
+{
+    private RemotePathAutocompleteQuery(string parentPath, string prefix)
+    {
+        ParentPath = parentPath;
+        Prefix = prefix;
+    }
+
+    public string ParentPath { get; }
+    public string Prefix { get; }
+
+    public static RemotePathAutocompleteQuery Parse(string input)
+    {
+        string normalized = (input ?? string.Empty).Trim();
+        if (string.IsNullOrEmpty(normalized))
+        {
+            return new RemotePathAutocompleteQuery("~", string.Empty);
+        }
+
+        if (normalized == "~")
+        {
+            return new RemotePathAutocompleteQuery("~", string.Empty);
+        }
+
+        string trimmed = normalized.TrimEnd('/');
+        int lastSlashIndex = trimmed.LastIndexOf('/');
+        if (lastSlashIndex < 0)
+        {
+            return new RemotePathAutocompleteQuery("~", trimmed);
+        }
+
+        if (lastSlashIndex == 0)
+        {
+            string prefix = trimmed.Length == 1 ? string.Empty : trimmed[1..];
+            return new RemotePathAutocompleteQuery("/", prefix);
+        }
+
+        string parentPath = trimmed[..lastSlashIndex];
+        string leafPrefix = trimmed[(lastSlashIndex + 1)..];
+        return new RemotePathAutocompleteQuery(parentPath, leafPrefix);
+    }
+
+    public static IReadOnlyList<RemotePathSuggestion> Rank(
+        IEnumerable<RemotePathSuggestion> suggestions,
+        string prefix)
+    {
+        ArgumentNullException.ThrowIfNull(suggestions);
+
+        string normalizedPrefix = prefix?.Trim() ?? string.Empty;
+
+        return suggestions
+            .Where(suggestion => string.IsNullOrWhiteSpace(normalizedPrefix) ||
+                                 suggestion.DisplayName.StartsWith(normalizedPrefix, StringComparison.OrdinalIgnoreCase) ||
+                                 suggestion.DisplayName.Contains(normalizedPrefix, StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(suggestion => suggestion.DisplayName.StartsWith(normalizedPrefix, StringComparison.OrdinalIgnoreCase))
+            .ThenByDescending(suggestion => suggestion.IsDirectory)
+            .ThenBy(suggestion => suggestion.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+}

--- a/src/NovaTerminal.App/Services/Ssh/RemotePathAutocompleteService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/RemotePathAutocompleteService.cs
@@ -31,7 +31,7 @@ public sealed class RemotePathAutocompleteService : IRemotePathAutocompleteServi
         _passwordResolver = passwordResolver ?? (profile => new VaultService().GetSshPasswordForProfile(profile));
     }
 
-    public Task<IReadOnlyList<RemotePathSuggestion>> GetSuggestionsAsync(
+    public async Task<IReadOnlyList<RemotePathSuggestion>> GetSuggestionsAsync(
         Guid profileId,
         Guid sessionId,
         string input,
@@ -39,7 +39,7 @@ public sealed class RemotePathAutocompleteService : IRemotePathAutocompleteServi
     {
         if (profileId == Guid.Empty || sessionId == Guid.Empty || string.IsNullOrWhiteSpace(input))
         {
-            return Task.FromResult<IReadOnlyList<RemotePathSuggestion>>([]);
+            return [];
         }
 
         if (!_sessionRegistry.TryGet(sessionId, out ActiveSshSessionDescriptor? descriptor) ||
@@ -47,8 +47,10 @@ public sealed class RemotePathAutocompleteService : IRemotePathAutocompleteServi
             descriptor.ProfileId != profileId ||
             descriptor.BackendKind != SshBackendKind.Native)
         {
-            return Task.FromResult<IReadOnlyList<RemotePathSuggestion>>([]);
+            return [];
         }
+
+        cancellationToken.ThrowIfCancellationRequested();
 
         try
         {
@@ -56,7 +58,7 @@ public sealed class RemotePathAutocompleteService : IRemotePathAutocompleteServi
             TerminalProfile? profile = sshService.GetConnectionProfile(profileId);
             if (profile == null || profile.SshBackendKind != SshBackendKind.Native)
             {
-                return Task.FromResult<IReadOnlyList<RemotePathSuggestion>>([]);
+                return [];
             }
 
             RemotePathAutocompleteQuery query = RemotePathAutocompleteQuery.Parse(input);
@@ -93,18 +95,15 @@ public sealed class RemotePathAutocompleteService : IRemotePathAutocompleteServi
                     }
             };
 
-            IReadOnlyList<NativeRemotePathEntry> entries = _nativeInterop.ListRemoteDirectory(
-                connectionOptions,
-                query.ParentPath,
+            IReadOnlyList<NativeRemotePathEntry> entries = await Task.Run(
+                () => _nativeInterop.ListRemoteDirectory(connectionOptions, query.ParentPath, cancellationToken),
                 cancellationToken);
 
-            IReadOnlyList<RemotePathSuggestion> ranked = RemotePathAutocompleteQuery.Rank(
-                entries.Select(entry => new RemotePathSuggestion(entry.Name, entry.FullPath, entry.IsDirectory)),
-                query.Prefix)
+            return RemotePathAutocompleteQuery.Rank(
+                    entries.Select(entry => new RemotePathSuggestion(entry.Name, entry.FullPath, entry.IsDirectory)),
+                    query.Prefix)
                 .Take(MaxSuggestions)
                 .ToList();
-
-            return Task.FromResult(ranked);
         }
         catch (OperationCanceledException)
         {
@@ -112,7 +111,7 @@ public sealed class RemotePathAutocompleteService : IRemotePathAutocompleteServi
         }
         catch
         {
-            return Task.FromResult<IReadOnlyList<RemotePathSuggestion>>([]);
+            return [];
         }
     }
 }

--- a/src/NovaTerminal.App/Services/Ssh/RemotePathAutocompleteService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/RemotePathAutocompleteService.cs
@@ -6,24 +6,29 @@ using System.Threading.Tasks;
 using NovaTerminal.Core;
 using NovaTerminal.Core.Ssh.Models;
 using NovaTerminal.Core.Ssh.Native;
+using NovaTerminal.Core.Ssh.Storage;
 using NovaTerminal.Models;
 
 namespace NovaTerminal.Services.Ssh;
 
 public sealed class RemotePathAutocompleteService : IRemotePathAutocompleteService
 {
+    private const int MaxSuggestions = 12;
     private readonly INativeSshInterop _nativeInterop;
     private readonly ActiveSshSessionRegistry _sessionRegistry;
     private readonly Func<SshConnectionService> _sshServiceFactory;
+    private readonly Func<TerminalProfile, string?> _passwordResolver;
 
     public RemotePathAutocompleteService(
         INativeSshInterop? nativeInterop = null,
         ActiveSshSessionRegistry? sessionRegistry = null,
-        Func<SshConnectionService>? sshServiceFactory = null)
+        Func<SshConnectionService>? sshServiceFactory = null,
+        Func<TerminalProfile, string?>? passwordResolver = null)
     {
         _nativeInterop = nativeInterop ?? new NativeSshInterop();
         _sessionRegistry = sessionRegistry ?? ActiveSshSessionRegistry.Instance;
         _sshServiceFactory = sshServiceFactory ?? (() => new SshConnectionService());
+        _passwordResolver = passwordResolver ?? (profile => new VaultService().GetSshPasswordForProfile(profile));
     }
 
     public Task<IReadOnlyList<RemotePathSuggestion>> GetSuggestionsAsync(
@@ -55,10 +60,38 @@ public sealed class RemotePathAutocompleteService : IRemotePathAutocompleteServi
             }
 
             RemotePathAutocompleteQuery query = RemotePathAutocompleteQuery.Parse(input);
-            NativeSshConnectionOptions connectionOptions = SftpService.BuildNativeTransferConnectionOptions(
+            NativeSshConnectionOptions baseOptions = SftpService.BuildNativeTransferConnectionOptions(
                 sshService,
                 profile,
                 sshService.GetConnectionProfiles());
+            bool prefersIdentityFile = !string.IsNullOrWhiteSpace(baseOptions.IdentityFilePath);
+            string? resolvedPassword = prefersIdentityFile
+                ? null
+                : (_sessionRegistry.TryGetRuntimePassword(sessionId, out string? runtimePassword)
+                    ? runtimePassword
+                    : _passwordResolver(profile));
+            var connectionOptions = new NativeSshConnectionOptions
+            {
+                Host = baseOptions.Host,
+                Port = baseOptions.Port,
+                User = baseOptions.User,
+                Cols = baseOptions.Cols,
+                Rows = baseOptions.Rows,
+                Term = baseOptions.Term,
+                Password = string.IsNullOrWhiteSpace(resolvedPassword) ? null : resolvedPassword,
+                IdentityFilePath = baseOptions.IdentityFilePath,
+                KnownHostsFilePath = string.IsNullOrWhiteSpace(baseOptions.KnownHostsFilePath)
+                    ? AppPaths.NativeKnownHostsFilePath
+                    : baseOptions.KnownHostsFilePath,
+                JumpHost = baseOptions.JumpHost == null
+                    ? null
+                    : new SshJumpHop
+                    {
+                        Host = baseOptions.JumpHost.Host,
+                        User = baseOptions.JumpHost.User,
+                        Port = baseOptions.JumpHost.Port
+                    }
+            };
 
             IReadOnlyList<NativeRemotePathEntry> entries = _nativeInterop.ListRemoteDirectory(
                 connectionOptions,
@@ -67,7 +100,9 @@ public sealed class RemotePathAutocompleteService : IRemotePathAutocompleteServi
 
             IReadOnlyList<RemotePathSuggestion> ranked = RemotePathAutocompleteQuery.Rank(
                 entries.Select(entry => new RemotePathSuggestion(entry.Name, entry.FullPath, entry.IsDirectory)),
-                query.Prefix);
+                query.Prefix)
+                .Take(MaxSuggestions)
+                .ToList();
 
             return Task.FromResult(ranked);
         }

--- a/src/NovaTerminal.App/Services/Ssh/RemotePathAutocompleteService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/RemotePathAutocompleteService.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NovaTerminal.Core;
+using NovaTerminal.Core.Ssh.Models;
+using NovaTerminal.Core.Ssh.Native;
+using NovaTerminal.Models;
+
+namespace NovaTerminal.Services.Ssh;
+
+public sealed class RemotePathAutocompleteService : IRemotePathAutocompleteService
+{
+    private readonly INativeSshInterop _nativeInterop;
+    private readonly ActiveSshSessionRegistry _sessionRegistry;
+    private readonly Func<SshConnectionService> _sshServiceFactory;
+
+    public RemotePathAutocompleteService(
+        INativeSshInterop? nativeInterop = null,
+        ActiveSshSessionRegistry? sessionRegistry = null,
+        Func<SshConnectionService>? sshServiceFactory = null)
+    {
+        _nativeInterop = nativeInterop ?? new NativeSshInterop();
+        _sessionRegistry = sessionRegistry ?? ActiveSshSessionRegistry.Instance;
+        _sshServiceFactory = sshServiceFactory ?? (() => new SshConnectionService());
+    }
+
+    public Task<IReadOnlyList<RemotePathSuggestion>> GetSuggestionsAsync(
+        Guid profileId,
+        Guid sessionId,
+        string input,
+        CancellationToken cancellationToken)
+    {
+        if (profileId == Guid.Empty || sessionId == Guid.Empty || string.IsNullOrWhiteSpace(input))
+        {
+            return Task.FromResult<IReadOnlyList<RemotePathSuggestion>>([]);
+        }
+
+        if (!_sessionRegistry.TryGet(sessionId, out ActiveSshSessionDescriptor? descriptor) ||
+            descriptor is null ||
+            descriptor.ProfileId != profileId ||
+            descriptor.BackendKind != SshBackendKind.Native)
+        {
+            return Task.FromResult<IReadOnlyList<RemotePathSuggestion>>([]);
+        }
+
+        try
+        {
+            SshConnectionService sshService = _sshServiceFactory();
+            TerminalProfile? profile = sshService.GetConnectionProfile(profileId);
+            if (profile == null || profile.SshBackendKind != SshBackendKind.Native)
+            {
+                return Task.FromResult<IReadOnlyList<RemotePathSuggestion>>([]);
+            }
+
+            RemotePathAutocompleteQuery query = RemotePathAutocompleteQuery.Parse(input);
+            NativeSshConnectionOptions connectionOptions = SftpService.BuildNativeTransferConnectionOptions(
+                sshService,
+                profile,
+                sshService.GetConnectionProfiles());
+
+            IReadOnlyList<NativeRemotePathEntry> entries = _nativeInterop.ListRemoteDirectory(
+                connectionOptions,
+                query.ParentPath,
+                cancellationToken);
+
+            IReadOnlyList<RemotePathSuggestion> ranked = RemotePathAutocompleteQuery.Rank(
+                entries.Select(entry => new RemotePathSuggestion(entry.Name, entry.FullPath, entry.IsDirectory)),
+                query.Prefix);
+
+            return Task.FromResult(ranked);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            return Task.FromResult<IReadOnlyList<RemotePathSuggestion>>([]);
+        }
+    }
+}

--- a/src/NovaTerminal.App/Services/Ssh/RemotePathAutocompleteService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/RemotePathAutocompleteService.cs
@@ -95,8 +95,8 @@ public sealed class RemotePathAutocompleteService : IRemotePathAutocompleteServi
                     }
             };
 
-            IReadOnlyList<NativeRemotePathEntry> entries = await Task.Run(
-                () => _nativeInterop.ListRemoteDirectory(connectionOptions, query.ParentPath, cancellationToken),
+            IReadOnlyList<NativeRemotePathEntry> entries = await BackgroundWork.RunBlockingAsync(
+                token => _nativeInterop.ListRemoteDirectory(connectionOptions, query.ParentPath, token),
                 cancellationToken);
 
             return RemotePathAutocompleteQuery.Rank(

--- a/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
@@ -52,6 +52,11 @@ public sealed class SshLaunchDetails
         return profile == null ? null : ToRuntimeProfile(profile);
     }
 
+    internal SshProfile? GetStoredProfile(Guid profileId)
+    {
+        return _profileStore.GetProfile(profileId);
+    }
+
     public NewSshConnectionViewModel CreateEditorViewModel(TerminalProfile? profile)
     {
         if (profile == null)

--- a/src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshInteractionService.cs
@@ -76,6 +76,11 @@ public sealed class SshInteractionService : ISshInteractionService
     private async Task<SshInteractionResponse> HandlePasswordAsync(Window? owner, SshInteractionRequest request, CancellationToken cancellationToken)
     {
         SshInteractionResponse response = await _authPresenter(owner, CreatePasswordViewModel(request), cancellationToken);
+        if (request.SessionId.HasValue && !response.IsCanceled && !string.IsNullOrEmpty(response.Secret))
+        {
+            ActiveSshSessionRegistry.Instance.SetRuntimePassword(request.SessionId.Value, response.Secret);
+        }
+
         if (ShouldStorePasswordInVault(request, response))
         {
             _vaultService.SetSshPasswordForProfile(CreateVaultProfile(request), response.Secret);
@@ -87,8 +92,21 @@ public sealed class SshInteractionService : ISshInteractionService
     private bool TryHandlePasswordFromVault(SshInteractionRequest request, out SshInteractionResponse response)
     {
         if (request.Kind != SshInteractionKind.Password ||
-            !request.ProfileId.HasValue ||
-            !request.AllowVaultPasswordReuse)
+            !request.ProfileId.HasValue)
+        {
+            response = SshInteractionResponse.Cancel();
+            return false;
+        }
+
+        if (request.SessionId.HasValue &&
+            ActiveSshSessionRegistry.Instance.TryGetRuntimePassword(request.SessionId.Value, out string? runtimePassword) &&
+            !string.IsNullOrEmpty(runtimePassword))
+        {
+            response = SshInteractionResponse.FromSecret(runtimePassword);
+            return true;
+        }
+
+        if (!request.AllowVaultPasswordReuse)
         {
             response = SshInteractionResponse.Cancel();
             return false;

--- a/src/NovaTerminal.App/native/rusty_ssh/Cargo.lock
+++ b/src/NovaTerminal.App/native/rusty_ssh/Cargo.lock
@@ -38,6 +38,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +123,9 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "blake2"
@@ -259,6 +275,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +317,12 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -539,6 +581,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flurry"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5efcf77a4da27927d3ab0509dec5b0954bb3bc59da5a1de9e52642ebd4cdf9"
+dependencies = [
+ "ahash",
+ "num_cpus",
+ "parking_lot",
+ "seize",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,6 +747,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -856,6 +916,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,6 +1007,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,6 +1083,29 @@ dependencies = [
  "tokio",
  "windows",
  "windows-strings",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -1229,6 +1331,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f66ee92bc15280519ef199a274fe0cafff4245d31bc39aaa31c011ad56cb1f05"
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1341,6 +1452,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "russh-sftp"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bb94393cafad0530145b8f626d8687f1ee1dedb93d7ba7740d6ae81868b13b5"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "chrono",
+ "flurry",
+ "log",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "russh-util"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1375,6 +1503,7 @@ dependencies = [
  "base64",
  "libc",
  "russh",
+ "russh-sftp",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -1389,6 +1518,12 @@ checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
  "cipher",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrypt"
@@ -1414,6 +1549,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "seize"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "689224d06523904ebcc9b482c6a3f4f7fb396096645c4cd10c0d2ff7371a34d3"
 
 [[package]]
 name = "semver"
@@ -1561,6 +1702,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1677,6 +1824,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,6 +1856,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/src/NovaTerminal.App/native/rusty_ssh/Cargo.toml
+++ b/src/NovaTerminal.App/native/rusty_ssh/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0"
 base64 = "0.22"
 libc = "0.2"
 russh = { version = "0.59.0", default-features = false, features = ["ring"] }
+russh-sftp = "2.1.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/src/NovaTerminal.App/native/rusty_ssh/Cargo.toml
+++ b/src/NovaTerminal.App/native/rusty_ssh/Cargo.toml
@@ -15,4 +15,4 @@ russh-sftp = "2.1.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
-tokio = { version = "1.48.0", features = ["io-util", "net", "rt", "sync", "time"] }
+tokio = { version = "1.48.0", features = ["fs", "io-util", "net", "rt", "sync", "time"] }

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -1,4 +1,4 @@
-use libc::{c_char, c_int};
+use libc::{c_char, c_int, c_void};
 use russh::client::{self, AuthResult, KeyboardInteractiveAuthResponse};
 use russh::keys::{PrivateKeyWithHashAlg, load_secret_key, ssh_key};
 use russh::{ChannelMsg, Disconnect};
@@ -303,6 +303,47 @@ struct NativeKnownHostEntry {
     port: u16,
     algorithm: String,
     fingerprint: String,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NovaSftpTransferProgressCallbackData {
+    pub bytes_done: u64,
+    pub bytes_total: u64,
+    pub current_path: *const c_char,
+}
+
+type NovaSftpTransferProgressCallback =
+    unsafe extern "C" fn(*mut c_void, NovaSftpTransferProgressCallbackData);
+
+#[derive(Clone, Copy)]
+struct SftpProgressEmitter {
+    callback: Option<NovaSftpTransferProgressCallback>,
+    context: *mut c_void,
+}
+
+impl SftpProgressEmitter {
+    fn emit(&self, bytes_done: u64, bytes_total: Option<u64>, current_path: &str) {
+        let Some(callback) = self.callback else {
+            return;
+        };
+
+        let current_path = match CString::new(current_path) {
+            Ok(value) => value,
+            Err(_) => return,
+        };
+
+        unsafe {
+            callback(
+                self.context,
+                NovaSftpTransferProgressCallbackData {
+                    bytes_done,
+                    bytes_total: bytes_total.unwrap_or(0),
+                    current_path: current_path.as_ptr(),
+                },
+            );
+        }
+    }
 }
 
 impl SharedState {
@@ -741,6 +782,8 @@ pub extern "C" fn nova_ssh_close(session: *mut NovaSshSession) -> c_int {
 #[unsafe(no_mangle)]
 pub extern "C" fn nova_ssh_sftp_transfer(
     request_json: *const c_char,
+    progress_callback: Option<NovaSftpTransferProgressCallback>,
+    progress_context: *mut c_void,
     response_json: *mut *mut c_char,
 ) -> c_int {
     if request_json.is_null() || response_json.is_null() {
@@ -784,7 +827,12 @@ pub extern "C" fn nova_ssh_sftp_transfer(
         );
     }
 
-    match run_sftp_transfer(request) {
+    let progress = SftpProgressEmitter {
+        callback: progress_callback,
+        context: progress_context,
+    };
+
+    match run_sftp_transfer(request, progress) {
         Ok(()) => write_sftp_response_json(
             response_json,
             NOVA_SSH_RESULT_OK,
@@ -1005,7 +1053,7 @@ fn normalize_known_host_fingerprint(fingerprint: &str) -> String {
     }
 }
 
-fn run_sftp_transfer(request: SftpTransferRequest) -> anyhow::Result<()> {
+fn run_sftp_transfer(request: SftpTransferRequest, progress: SftpProgressEmitter) -> anyhow::Result<()> {
     validate_supported_sftp_mode(&request.transfer)?;
 
     let runtime = Builder::new_current_thread().enable_all().build()?;
@@ -1070,7 +1118,7 @@ fn run_sftp_transfer(request: SftpTransferRequest) -> anyhow::Result<()> {
         };
 
         authenticate_transfer(&request.connection.user, &auth, &mut session).await?;
-        perform_sftp_transfer(&mut session, &request.transfer).await
+        perform_sftp_transfer(&mut session, &request.transfer, progress).await
     })
 }
 
@@ -1123,6 +1171,7 @@ where
 async fn perform_sftp_transfer<H>(
     session: &mut client::Handle<H>,
     transfer: &SftpTransferRequestBody,
+    progress: SftpProgressEmitter,
 ) -> anyhow::Result<()>
 where
     H: client::Handler + Send + 'static,
@@ -1144,6 +1193,7 @@ where
                 &transfer.remote_path,
                 Path::new(&transfer.local_path),
                 cancellation_marker_path,
+                progress,
             )
             .await?;
         }
@@ -1153,6 +1203,7 @@ where
                 Path::new(&transfer.local_path),
                 &transfer.remote_path,
                 cancellation_marker_path,
+                progress,
             )
             .await?;
         }
@@ -1164,6 +1215,7 @@ where
                 &transfer.remote_path,
                 &local_root,
                 cancellation_marker_path,
+                progress,
             )
             .await?;
         }
@@ -1176,6 +1228,7 @@ where
                 &local_root,
                 &remote_root,
                 cancellation_marker_path,
+                progress,
             )
             .await?;
         }
@@ -1211,7 +1264,13 @@ async fn download_file_from_remote(
     remote_path: &str,
     local_path: &Path,
     cancellation_marker_path: Option<&str>,
+    progress: SftpProgressEmitter,
 ) -> anyhow::Result<()> {
+    let total_bytes = sftp
+        .metadata(remote_path.to_owned())
+        .await
+        .map(|metadata| metadata.size)
+        .unwrap_or(None);
     let mut remote_file = sftp
         .open(remote_path.to_owned())
         .await
@@ -1229,6 +1288,9 @@ async fn download_file_from_remote(
         &mut remote_file,
         &mut local_file,
         cancellation_marker_path,
+        total_bytes,
+        remote_path,
+        progress,
     )
     .await?;
     local_file.flush().await?;
@@ -1241,7 +1303,9 @@ async fn upload_file_to_remote(
     local_path: &Path,
     remote_path: &str,
     cancellation_marker_path: Option<&str>,
+    progress: SftpProgressEmitter,
 ) -> anyhow::Result<()> {
+    let total_bytes = std::fs::metadata(local_path).ok().map(|metadata| metadata.len());
     let mut local_file = TokioFile::open(local_path)
         .await
         .map_err(|error| map_local_transfer_error(local_path, error))?;
@@ -1253,6 +1317,9 @@ async fn upload_file_to_remote(
         &mut local_file,
         &mut remote_file,
         cancellation_marker_path,
+        total_bytes,
+        &local_path.to_string_lossy(),
+        progress,
     )
     .await?;
     remote_file.shutdown().await?;
@@ -1264,6 +1331,7 @@ async fn download_directory_from_remote(
     remote_root: &str,
     local_root: &Path,
     cancellation_marker_path: Option<&str>,
+    progress: SftpProgressEmitter,
 ) -> anyhow::Result<()> {
     std::fs::create_dir_all(local_root)?;
 
@@ -1297,6 +1365,7 @@ async fn download_directory_from_remote(
                     &remote_child,
                     &local_child,
                     cancellation_marker_path,
+                    progress,
                 )
                 .await?;
             }
@@ -1311,6 +1380,7 @@ async fn upload_directory_to_remote(
     local_root: &Path,
     remote_root: &str,
     cancellation_marker_path: Option<&str>,
+    progress: SftpProgressEmitter,
 ) -> anyhow::Result<()> {
     ensure_remote_directory_exists(sftp, remote_root).await?;
 
@@ -1341,6 +1411,7 @@ async fn upload_directory_to_remote(
                     &local_child,
                     &remote_child,
                     cancellation_marker_path,
+                    progress,
                 )
                 .await?;
             }
@@ -1419,12 +1490,16 @@ async fn copy_file_with_cancellation<R, W>(
     reader: &mut R,
     writer: &mut W,
     cancellation_marker_path: Option<&str>,
+    total_bytes: Option<u64>,
+    current_path: &str,
+    progress: SftpProgressEmitter,
 ) -> anyhow::Result<()>
 where
     R: AsyncReadExt + Unpin,
     W: AsyncWriteExt + Unpin,
 {
     let mut buffer = vec![0u8; 64 * 1024];
+    let mut bytes_done = 0u64;
     loop {
         ensure_transfer_not_canceled(cancellation_marker_path)?;
         let read = reader.read(&mut buffer).await?;
@@ -1433,6 +1508,8 @@ where
         }
 
         writer.write_all(&buffer[..read]).await?;
+        bytes_done += read as u64;
+        progress.emit(bytes_done, total_bytes, current_path);
     }
 
     Ok(())
@@ -2081,7 +2158,7 @@ mod tests {
         let channel_close = nova_ssh_channel_close(ptr::null_mut(), 1);
         let respond = nova_ssh_submit_response(ptr::null_mut(), 1, br#"{}"#.as_ptr(), 2);
         let mut sftp_response = ptr::null_mut();
-        let sftp = nova_ssh_sftp_transfer(ptr::null(), &mut sftp_response);
+        let sftp = nova_ssh_sftp_transfer(ptr::null(), None, ptr::null_mut(), &mut sftp_response);
         let close = nova_ssh_close(ptr::null_mut());
 
         assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, resize);
@@ -2104,7 +2181,7 @@ mod tests {
         .unwrap();
         let mut response = ptr::null_mut();
 
-        let rc = nova_ssh_sftp_transfer(request.as_ptr(), &mut response);
+        let rc = nova_ssh_sftp_transfer(request.as_ptr(), None, ptr::null_mut(), &mut response);
 
         assert_eq!(NOVA_SSH_RESULT_NOT_IMPLEMENTED, rc);
         assert!(!response.is_null());

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -1,17 +1,20 @@
 use libc::{c_char, c_int};
 use russh::client::{self, AuthResult, KeyboardInteractiveAuthResponse};
-use russh::keys::{load_secret_key, ssh_key, PrivateKeyWithHashAlg};
+use russh::keys::{PrivateKeyWithHashAlg, load_secret_key, ssh_key};
 use russh::{ChannelMsg, Disconnect};
+use russh_sftp::client::SftpSession;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 use std::ffi::{CStr, CString};
 use std::future::Future;
 use std::io::Cursor;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::ptr;
 use std::sync::{Arc, Condvar, Mutex, mpsc as std_mpsc};
 use std::thread;
 use std::time::Duration;
+use tokio::fs::File as TokioFile;
+use tokio::io::{AsyncWriteExt, copy};
 use tokio::runtime::Builder;
 use tokio::sync::mpsc;
 
@@ -115,7 +118,10 @@ struct QueuedResponse {
 
 enum WorkerCommand {
     Write(Vec<u8>),
-    Resize { cols: u16, rows: u16 },
+    Resize {
+        cols: u16,
+        rows: u16,
+    },
     OpenDirectTcpIp {
         host_to_connect: String,
         port_to_connect: u32,
@@ -162,6 +168,19 @@ struct NovaClientHandler {
     shared: Arc<SharedState>,
     host: String,
     port: u16,
+}
+
+#[derive(Clone)]
+struct TransferClientHandler {
+    host: String,
+    port: u16,
+    known_hosts: NativeKnownHostsVerifier,
+}
+
+#[derive(Clone)]
+struct TransferAuthConfig {
+    password: Option<String>,
+    identity_file: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -240,7 +259,9 @@ struct SftpConnectionRequest {
     host: String,
     user: String,
     port: u16,
+    password: Option<String>,
     identity_file_path: Option<String>,
+    known_hosts_file_path: String,
     jump_host: Option<SftpJumpHostRequest>,
 }
 
@@ -268,6 +289,20 @@ struct SftpTransferResponse<'a> {
     message: &'a str,
 }
 
+#[derive(Clone)]
+struct NativeKnownHostsVerifier {
+    entries: Arc<Vec<NativeKnownHostEntry>>,
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct NativeKnownHostEntry {
+    host: String,
+    port: u16,
+    algorithm: String,
+    fingerprint: String,
+}
+
 impl SharedState {
     fn new() -> Self {
         Self {
@@ -283,7 +318,10 @@ impl SharedState {
             return;
         }
 
-        self.events.lock().expect("events mutex poisoned").push_back(event);
+        self.events
+            .lock()
+            .expect("events mutex poisoned")
+            .push_back(event);
     }
 
     fn peek_event(&self) -> Option<QueuedEvent> {
@@ -300,7 +338,11 @@ impl SharedState {
     }
 
     fn pop_event(&self) {
-        let _ = self.events.lock().expect("events mutex poisoned").pop_front();
+        let _ = self
+            .events
+            .lock()
+            .expect("events mutex poisoned")
+            .pop_front();
     }
 
     fn queue_response(&self, response: QueuedResponse) {
@@ -378,6 +420,28 @@ impl client::Handler for NovaClientHandler {
     }
 }
 
+impl client::Handler for TransferClientHandler {
+    type Error = anyhow::Error;
+
+    fn check_server_key(
+        &mut self,
+        server_public_key: &ssh_key::PublicKey,
+    ) -> impl Future<Output = Result<bool, Self::Error>> + Send {
+        let known_hosts = self.known_hosts.clone();
+        let host = self.host.clone();
+        let port = self.port;
+        let algorithm = server_public_key.algorithm().to_string();
+        let fingerprint = server_public_key
+            .fingerprint(ssh_key::HashAlg::Sha256)
+            .to_string();
+
+        async move {
+            known_hosts.verify(&host, port, &algorithm, &fingerprint)?;
+            Ok(true)
+        }
+    }
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn nova_ssh_connect(args: *const NovaSshConnectArgs) -> *mut NovaSshSession {
     let config = match ConnectConfig::from_args(args) {
@@ -404,8 +468,10 @@ pub extern "C" fn nova_ssh_connect(args: *const NovaSshConnectArgs) -> *mut Nova
 
         worker_shared.queue_event(QueuedEvent {
             kind: NovaSshEventKind::Closed,
-            payload: serde_json::to_vec(&ClosedPayload { reason: "session-ended" })
-                .unwrap_or_default(),
+            payload: serde_json::to_vec(&ClosedPayload {
+                reason: "session-ended",
+            })
+            .unwrap_or_default(),
             status_code: 0,
             flags: NOVA_SSH_EVENT_FLAG_JSON,
         });
@@ -487,11 +553,7 @@ pub extern "C" fn nova_ssh_write(
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn nova_ssh_resize(
-    session: *mut NovaSshSession,
-    cols: u16,
-    rows: u16,
-) -> c_int {
+pub extern "C" fn nova_ssh_resize(session: *mut NovaSshSession, cols: u16, rows: u16) -> c_int {
     if session.is_null() || cols == 0 || rows == 0 {
         return NOVA_SSH_RESULT_INVALID_ARGUMENT;
     }
@@ -720,12 +782,30 @@ pub extern "C" fn nova_ssh_sftp_transfer(
         );
     }
 
-    write_sftp_response_json(
-        response_json,
-        NOVA_SSH_RESULT_NOT_IMPLEMENTED,
-        "not-implemented",
-        "Native backend stub reached: SFTP transfer not implemented.",
-    )
+    match run_sftp_transfer(request) {
+        Ok(()) => write_sftp_response_json(
+            response_json,
+            NOVA_SSH_RESULT_OK,
+            "ok",
+            "Native SFTP transfer completed.",
+        ),
+        Err(error) => {
+            let message = error.to_string();
+            let lower = message.to_ascii_lowercase();
+            let (result, status) = if lower.contains("not implemented") {
+                (NOVA_SSH_RESULT_NOT_IMPLEMENTED, "not-implemented")
+            } else if lower.contains("invalid")
+                || lower.contains("requires either")
+                || lower.contains("known-hosts store path")
+            {
+                (NOVA_SSH_RESULT_INVALID_ARGUMENT, "invalid-argument")
+            } else {
+                (NOVA_SSH_RESULT_CLOSED, "error")
+            };
+
+            write_sftp_response_json(response_json, result, status, &message)
+        }
+    }
 }
 
 #[unsafe(no_mangle)]
@@ -751,7 +831,11 @@ impl ConnectConfig {
         let effective_jump_host = jump_host.map(|host| JumpHostConfig {
             host,
             user: jump_user.unwrap_or_else(|| user.clone()),
-            port: if args.jump_port == 0 { 22 } else { args.jump_port },
+            port: if args.jump_port == 0 {
+                22
+            } else {
+                args.jump_port
+            },
         });
 
         Some(Self {
@@ -782,7 +866,10 @@ fn read_c_string(value: *const c_char) -> Option<String> {
         return None;
     }
 
-    let string = unsafe { CStr::from_ptr(value) }.to_string_lossy().trim().to_owned();
+    let string = unsafe { CStr::from_ptr(value) }
+        .to_string_lossy()
+        .trim()
+        .to_owned();
     if string.is_empty() {
         None
     } else {
@@ -818,7 +905,10 @@ fn sftp_request_has_blank_fields(request: &SftpTransferRequest) -> bool {
         .as_ref()
         .is_some_and(|jump_host| {
             jump_host.host.trim().is_empty()
-                || jump_host.user.as_deref().is_some_and(|user| user.trim().is_empty())
+                || jump_host
+                    .user
+                    .as_deref()
+                    .is_some_and(|user| user.trim().is_empty())
                 || jump_host.port == 0
         });
 
@@ -827,14 +917,255 @@ fn sftp_request_has_blank_fields(request: &SftpTransferRequest) -> bool {
         || request.connection.port == 0
         || request
             .connection
+            .password
+            .as_deref()
+            .is_some_and(|password| password.trim().is_empty())
+        || request
+            .connection
             .identity_file_path
             .as_deref()
             .is_some_and(|path| path.trim().is_empty())
+        || request.connection.known_hosts_file_path.trim().is_empty()
         || jump_host_is_blank
         || request.transfer.direction.trim().is_empty()
         || request.transfer.kind.trim().is_empty()
         || request.transfer.local_path.trim().is_empty()
         || request.transfer.remote_path.trim().is_empty()
+}
+
+impl NativeKnownHostsVerifier {
+    fn load(path: &str) -> anyhow::Result<Self> {
+        let store_path = Path::new(path);
+        if !store_path.exists() {
+            return Ok(Self {
+                entries: Arc::new(Vec::new()),
+            });
+        }
+
+        let json = std::fs::read_to_string(store_path)?;
+        let entries = serde_json::from_str::<Vec<NativeKnownHostEntry>>(&json)?;
+        Ok(Self {
+            entries: Arc::new(entries),
+        })
+    }
+
+    fn verify(
+        &self,
+        host: &str,
+        port: u16,
+        algorithm: &str,
+        fingerprint: &str,
+    ) -> anyhow::Result<()> {
+        let expected_host = host.trim();
+        let expected_port = normalize_known_host_port(port);
+        let expected_algorithm = normalize_known_host_algorithm(algorithm);
+        let expected_fingerprint = normalize_known_host_fingerprint(fingerprint);
+
+        let existing = self.entries.iter().find(|entry| {
+            entry.host.trim().eq_ignore_ascii_case(expected_host)
+                && normalize_known_host_port(entry.port) == expected_port
+        });
+
+        match existing {
+            None => anyhow::bail!(
+                "Unknown host key for {}:{}. Add the server key to the native known-hosts store before transferring files.",
+                host,
+                port
+            ),
+            Some(entry)
+                if normalize_known_host_algorithm(&entry.algorithm) == expected_algorithm
+                    && normalize_known_host_fingerprint(&entry.fingerprint)
+                        == expected_fingerprint =>
+            {
+                Ok(())
+            }
+            Some(_) => anyhow::bail!(
+                "Host key mismatch for {}:{}. The native known-hosts store entry does not match the server key.",
+                host,
+                port
+            ),
+        }
+    }
+}
+
+fn normalize_known_host_port(port: u16) -> u16 {
+    if port == 0 { 22 } else { port }
+}
+
+fn normalize_known_host_algorithm(algorithm: &str) -> String {
+    algorithm.trim().to_owned()
+}
+
+fn normalize_known_host_fingerprint(fingerprint: &str) -> String {
+    let normalized = fingerprint.trim();
+    if normalized.is_empty() {
+        return String::new();
+    }
+
+    const PREFIX: &str = "SHA256:";
+    if normalized.len() >= PREFIX.len() && normalized[..PREFIX.len()].eq_ignore_ascii_case(PREFIX) {
+        format!("{}{}", PREFIX, normalized[PREFIX.len()..].trim())
+    } else {
+        normalized.to_owned()
+    }
+}
+
+fn run_sftp_transfer(request: SftpTransferRequest) -> anyhow::Result<()> {
+    validate_supported_sftp_mode(&request.transfer)?;
+
+    let runtime = Builder::new_current_thread().enable_all().build()?;
+    runtime.block_on(async move {
+        let known_hosts =
+            NativeKnownHostsVerifier::load(&request.connection.known_hosts_file_path)?;
+        let client_config = Arc::new(client::Config::default());
+        let auth = TransferAuthConfig {
+            password: request.connection.password.clone(),
+            identity_file: request.connection.identity_file_path.clone(),
+        };
+
+        let jump_session = if let Some(jump_host) = &request.connection.jump_host {
+            let jump_handler = TransferClientHandler {
+                host: jump_host.host.clone(),
+                port: jump_host.port,
+                known_hosts: known_hosts.clone(),
+            };
+
+            let mut jump = client::connect(
+                client_config.clone(),
+                (jump_host.host.as_str(), jump_host.port),
+                jump_handler,
+            )
+            .await?;
+
+            let jump_user = jump_host
+                .user
+                .as_deref()
+                .unwrap_or(request.connection.user.as_str());
+            authenticate_transfer(jump_user, &auth, &mut jump).await?;
+            Some(jump)
+        } else {
+            None
+        };
+
+        let target_handler = TransferClientHandler {
+            host: request.connection.host.clone(),
+            port: request.connection.port,
+            known_hosts: known_hosts.clone(),
+        };
+
+        let mut session = if let Some(jump) = &jump_session {
+            let stream = jump
+                .channel_open_direct_tcpip(
+                    request.connection.host.clone(),
+                    request.connection.port as u32,
+                    "127.0.0.1",
+                    0,
+                )
+                .await?
+                .into_stream();
+
+            client::connect_stream(client_config.clone(), stream, target_handler).await?
+        } else {
+            client::connect(
+                client_config.clone(),
+                (request.connection.host.as_str(), request.connection.port),
+                target_handler,
+            )
+            .await?
+        };
+
+        authenticate_transfer(&request.connection.user, &auth, &mut session).await?;
+        perform_sftp_transfer(&mut session, &request.transfer).await
+    })
+}
+
+async fn authenticate_transfer<H>(
+    user: &str,
+    auth: &TransferAuthConfig,
+    session: &mut client::Handle<H>,
+) -> anyhow::Result<()>
+where
+    H: client::Handler + Send + 'static,
+{
+    if let Some(password) = auth.password.as_deref() {
+        let result = session
+            .authenticate_password(user.to_owned(), password.to_owned())
+            .await?;
+        if result.success() {
+            return Ok(());
+        }
+
+        anyhow::bail!("SSH authentication failed");
+    }
+
+    if let Some(identity_file) = auth.identity_file.as_deref() {
+        let key = load_secret_key(Path::new(identity_file), None).map_err(|_| {
+            anyhow::anyhow!(
+                "Failed to load identity file '{}' for non-interactive native SFTP auth. Encrypted keys require interactive passphrase entry, which is not available for transfers.",
+                identity_file
+            )
+        })?;
+
+        let hash_alg = session.best_supported_rsa_hash().await?.flatten();
+        let result = session
+            .authenticate_publickey(
+                user.to_owned(),
+                PrivateKeyWithHashAlg::new(Arc::new(key), hash_alg),
+            )
+            .await?;
+        if result.success() {
+            return Ok(());
+        }
+
+        anyhow::bail!("SSH authentication failed");
+    }
+
+    anyhow::bail!(
+        "Native SFTP transfer requires either a password or an identity file for non-interactive authentication."
+    )
+}
+
+async fn perform_sftp_transfer<H>(
+    session: &mut client::Handle<H>,
+    transfer: &SftpTransferRequestBody,
+) -> anyhow::Result<()>
+where
+    H: client::Handler + Send + 'static,
+{
+    validate_supported_sftp_mode(transfer)?;
+
+    let channel = session.channel_open_session().await?;
+    channel.request_subsystem(true, "sftp").await?;
+    let sftp = SftpSession::new(channel.into_stream()).await?;
+    let mut remote_file = sftp.open(transfer.remote_path.clone()).await?;
+
+    let local_path = PathBuf::from(&transfer.local_path);
+    if let Some(parent) = local_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+
+    let mut local_file = TokioFile::create(&local_path).await?;
+    copy(&mut remote_file, &mut local_file).await?;
+    local_file.flush().await?;
+    remote_file.shutdown().await?;
+    sftp.close().await?;
+    Ok(())
+}
+
+fn validate_supported_sftp_mode(transfer: &SftpTransferRequestBody) -> anyhow::Result<()> {
+    let direction = transfer.direction.trim().to_ascii_lowercase();
+    let kind = transfer.kind.trim().to_ascii_lowercase();
+    if direction == "download" && kind == "file" {
+        return Ok(());
+    }
+
+    anyhow::bail!(
+        "Native SFTP transfer mode '{}/{}' is not implemented yet.",
+        direction,
+        kind
+    )
 }
 
 fn run_session(
@@ -1044,7 +1375,10 @@ fn coalesce_pending_resize_commands(
 
     loop {
         match command_rx.try_recv() {
-            Ok(WorkerCommand::Resize { cols: next_cols, rows: next_rows }) => {
+            Ok(WorkerCommand::Resize {
+                cols: next_cols,
+                rows: next_rows,
+            }) => {
                 cols = next_cols;
                 rows = next_rows;
             }
@@ -1052,7 +1386,8 @@ fn coalesce_pending_resize_commands(
                 pending_command = Some(command);
                 break;
             }
-            Err(mpsc::error::TryRecvError::Empty) | Err(mpsc::error::TryRecvError::Disconnected) => {
+            Err(mpsc::error::TryRecvError::Empty)
+            | Err(mpsc::error::TryRecvError::Disconnected) => {
                 break;
             }
         }
@@ -1063,7 +1398,9 @@ fn coalesce_pending_resize_commands(
 
 async fn open_direct_tcpip_channel(
     session: &client::Handle<NovaClientHandler>,
-    forward_channels: Arc<tokio::sync::Mutex<HashMap<u32, Arc<russh::ChannelWriteHalf<client::Msg>>>>>,
+    forward_channels: Arc<
+        tokio::sync::Mutex<HashMap<u32, Arc<russh::ChannelWriteHalf<client::Msg>>>>,
+    >,
     shared: Arc<SharedState>,
     host_to_connect: String,
     port_to_connect: u32,
@@ -1134,7 +1471,9 @@ async fn open_direct_tcpip_channel(
 }
 
 async fn write_forward_channel(
-    forward_channels: Arc<tokio::sync::Mutex<HashMap<u32, Arc<russh::ChannelWriteHalf<client::Msg>>>>>,
+    forward_channels: Arc<
+        tokio::sync::Mutex<HashMap<u32, Arc<russh::ChannelWriteHalf<client::Msg>>>>,
+    >,
     channel_id: u32,
     data: Vec<u8>,
 ) -> anyhow::Result<()> {
@@ -1151,7 +1490,9 @@ async fn write_forward_channel(
 }
 
 async fn send_forward_channel_eof(
-    forward_channels: Arc<tokio::sync::Mutex<HashMap<u32, Arc<russh::ChannelWriteHalf<client::Msg>>>>>,
+    forward_channels: Arc<
+        tokio::sync::Mutex<HashMap<u32, Arc<russh::ChannelWriteHalf<client::Msg>>>>,
+    >,
     channel_id: u32,
 ) -> anyhow::Result<()> {
     let writer = {
@@ -1167,7 +1508,9 @@ async fn send_forward_channel_eof(
 }
 
 async fn close_forward_channel(
-    forward_channels: Arc<tokio::sync::Mutex<HashMap<u32, Arc<russh::ChannelWriteHalf<client::Msg>>>>>,
+    forward_channels: Arc<
+        tokio::sync::Mutex<HashMap<u32, Arc<russh::ChannelWriteHalf<client::Msg>>>>,
+    >,
     channel_id: u32,
 ) -> anyhow::Result<()> {
     let writer = forward_channels.lock().await.remove(&channel_id);
@@ -1179,11 +1522,16 @@ async fn close_forward_channel(
 }
 
 async fn close_all_forward_channels(
-    forward_channels: Arc<tokio::sync::Mutex<HashMap<u32, Arc<russh::ChannelWriteHalf<client::Msg>>>>>,
+    forward_channels: Arc<
+        tokio::sync::Mutex<HashMap<u32, Arc<russh::ChannelWriteHalf<client::Msg>>>>,
+    >,
 ) {
     let writers = {
         let mut channels = forward_channels.lock().await;
-        channels.drain().map(|(_, writer)| writer).collect::<Vec<_>>()
+        channels
+            .drain()
+            .map(|(_, writer)| writer)
+            .collect::<Vec<_>>()
     };
 
     for writer in writers {
@@ -1198,14 +1546,20 @@ async fn authenticate(
     session: &mut client::Handle<NovaClientHandler>,
 ) -> anyhow::Result<()> {
     if let Some(identity_file) = identity_file {
-        if let Some(auth_result) = try_public_key_auth(user, shared, session, identity_file).await? {
+        if let Some(auth_result) = try_public_key_auth(user, shared, session, identity_file).await?
+        {
             if auth_result.success() {
                 return Ok(());
             }
         }
     }
 
-    let password = prompt_text(shared, NovaSshEventKind::PasswordPrompt, "Password:", NovaSshResponseKind::Password)?;
+    let password = prompt_text(
+        shared,
+        NovaSshEventKind::PasswordPrompt,
+        "Password:",
+        NovaSshResponseKind::Password,
+    )?;
     let password_auth = session
         .authenticate_password(user.to_owned(), password)
         .await?;
@@ -1288,7 +1642,9 @@ async fn authenticate_keyboard_interactive(
                 });
 
                 let responses = wait_keyboard_responses(shared)?;
-                response = session.authenticate_keyboard_interactive_respond(responses).await?;
+                response = session
+                    .authenticate_keyboard_interactive_respond(responses)
+                    .await?;
             }
         }
     }
@@ -1375,9 +1731,9 @@ mod tests {
     }
 
     #[test]
-    fn sftp_transfer_stub_returns_not_implemented_response() {
+    fn sftp_transfer_rejects_unsupported_modes() {
         let request = CString::new(
-            r#"{"connection":{"host":"example.com","user":"nova","port":22},"transfer":{"direction":"download","kind":"file","localPath":"local.txt","remotePath":"/tmp/remote.txt"}}"#,
+            r#"{"connection":{"host":"example.com","user":"nova","port":22,"password":"secret","knownHostsFilePath":"known_hosts.json"},"transfer":{"direction":"upload","kind":"directory","localPath":"local.txt","remotePath":"/tmp/remote.txt"}}"#,
         )
         .unwrap();
         let mut response = ptr::null_mut();
@@ -1391,7 +1747,7 @@ mod tests {
         let payload: serde_json::Value = serde_json::from_str(response_json).unwrap();
         assert_eq!("not-implemented", payload["status"]);
         assert_eq!(
-            "Native backend stub reached: SFTP transfer not implemented.",
+            "Native SFTP transfer mode 'upload/directory' is not implemented yet.",
             payload["message"]
         );
 
@@ -1506,7 +1862,10 @@ mod tests {
         let client_config = build_client_config(&config);
 
         assert_eq!(None, client_config.inactivity_timeout);
-        assert_eq!(Some(Duration::from_secs(15)), client_config.keepalive_interval);
+        assert_eq!(
+            Some(Duration::from_secs(15)),
+            client_config.keepalive_interval
+        );
         assert_eq!(7, client_config.keepalive_max);
     }
 
@@ -1517,13 +1876,22 @@ mod tests {
         runtime.block_on(async {
             let (command_tx, mut command_rx) = mpsc::unbounded_channel();
             command_tx
-                .send(WorkerCommand::Resize { cols: 120, rows: 30 })
+                .send(WorkerCommand::Resize {
+                    cols: 120,
+                    rows: 30,
+                })
                 .unwrap();
             command_tx
-                .send(WorkerCommand::Resize { cols: 140, rows: 40 })
+                .send(WorkerCommand::Resize {
+                    cols: 140,
+                    rows: 40,
+                })
                 .unwrap();
             command_tx
-                .send(WorkerCommand::Resize { cols: 160, rows: 50 })
+                .send(WorkerCommand::Resize {
+                    cols: 160,
+                    rows: 50,
+                })
                 .unwrap();
             drop(command_tx);
 
@@ -1554,16 +1922,25 @@ mod tests {
         runtime.block_on(async {
             let (command_tx, mut command_rx) = mpsc::unbounded_channel();
             command_tx
-                .send(WorkerCommand::Resize { cols: 120, rows: 30 })
+                .send(WorkerCommand::Resize {
+                    cols: 120,
+                    rows: 30,
+                })
                 .unwrap();
             command_tx
-                .send(WorkerCommand::Resize { cols: 140, rows: 40 })
+                .send(WorkerCommand::Resize {
+                    cols: 140,
+                    rows: 40,
+                })
                 .unwrap();
             command_tx
                 .send(WorkerCommand::Write(vec![1, 2, 3]))
                 .unwrap();
             command_tx
-                .send(WorkerCommand::Resize { cols: 160, rows: 50 })
+                .send(WorkerCommand::Resize {
+                    cols: 160,
+                    rows: 50,
+                })
                 .unwrap();
             drop(command_tx);
 
@@ -1611,7 +1988,9 @@ mod tests {
 fn build_client_config(config: &ConnectConfig) -> client::Config {
     client::Config {
         inactivity_timeout: None,
-        keepalive_interval: Some(Duration::from_secs(config.keepalive_interval_seconds as u64)),
+        keepalive_interval: Some(Duration::from_secs(
+            config.keepalive_interval_seconds as u64,
+        )),
         keepalive_max: config.keepalive_count_max as usize,
         ..<_>::default()
     }

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -310,9 +310,16 @@ struct NativeKnownHostEntry {
 pub struct NovaSftpTransferProgressCallbackData {
     pub bytes_done: u64,
     pub bytes_total: u64,
+    // ABI contract: current_path points to a transient UTF-8 string buffer that is
+    // only valid for the duration of the callback invocation that receives it.
     pub current_path: *const c_char,
 }
 
+// ABI contract for native SFTP progress reporting:
+// - callbacks are invoked synchronously during nova_ssh_sftp_transfer
+// - progress_context is borrowed and only valid for that call duration
+// - current_path in NovaSftpTransferProgressCallbackData is only valid for the
+//   duration of the callback invocation
 type NovaSftpTransferProgressCallback =
     unsafe extern "C" fn(*mut c_void, NovaSftpTransferProgressCallbackData);
 

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -18,6 +18,9 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::runtime::Builder;
 use tokio::sync::mpsc;
 
+const COPY_BUFFER_SIZE: usize = 64 * 1024;
+const CANCELLATION_CHECK_INTERVAL_BYTES: u64 = 1024 * 1024;
+
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default)]
 pub struct NovaSshEvent {
@@ -1400,6 +1403,7 @@ where
     let direction = transfer.direction.trim().to_ascii_lowercase();
     let kind = transfer.kind.trim().to_ascii_lowercase();
     let cancellation_marker_path = transfer.cancellation_marker_path.as_deref();
+    let mut copy_buffer = vec![0u8; COPY_BUFFER_SIZE];
     ensure_transfer_not_canceled(cancellation_marker_path)?;
 
     match (direction.as_str(), kind.as_str()) {
@@ -1410,6 +1414,7 @@ where
                 Path::new(&transfer.local_path),
                 cancellation_marker_path,
                 progress,
+                &mut copy_buffer,
             )
             .await?;
         }
@@ -1423,6 +1428,7 @@ where
                 &remote_target,
                 cancellation_marker_path,
                 progress,
+                &mut copy_buffer,
             )
             .await?;
         }
@@ -1435,6 +1441,7 @@ where
                 &local_root,
                 cancellation_marker_path,
                 progress,
+                &mut copy_buffer,
             )
             .await?;
         }
@@ -1448,6 +1455,7 @@ where
                 &remote_root,
                 cancellation_marker_path,
                 progress,
+                &mut copy_buffer,
             )
             .await?;
         }
@@ -1516,11 +1524,13 @@ fn validate_supported_sftp_mode(transfer: &SftpTransferRequestBody) -> anyhow::R
         return Ok(());
     }
 
-    anyhow::bail!(
-        "Native SFTP transfer mode '{}/{}' is not implemented yet.",
-        direction,
-        kind
-    )
+    Err(anyhow::Error::new(NativeSftpTransferError::new(
+        NativeSftpTransferErrorKind::NotImplemented,
+        format!(
+            "Native SFTP transfer mode '{}/{}' is not implemented yet.",
+            direction, kind
+        ),
+    )))
 }
 
 async fn download_file_from_remote(
@@ -1529,6 +1539,7 @@ async fn download_file_from_remote(
     local_path: &Path,
     cancellation_marker_path: Option<&str>,
     progress: SftpProgressEmitter,
+    copy_buffer: &mut [u8],
 ) -> anyhow::Result<()> {
     let total_bytes = sftp
         .metadata(remote_path.to_owned())
@@ -1541,7 +1552,9 @@ async fn download_file_from_remote(
         .map_err(|error| map_remote_transfer_error(remote_path, error))?;
     if let Some(parent) = local_path.parent() {
         if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent)?;
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|error| map_local_transfer_error(parent, error))?;
         }
     }
 
@@ -1555,6 +1568,7 @@ async fn download_file_from_remote(
         total_bytes,
         remote_path,
         progress,
+        copy_buffer,
     )
     .await?;
     local_file.flush().await?;
@@ -1568,6 +1582,7 @@ async fn upload_file_to_remote(
     remote_path: &str,
     cancellation_marker_path: Option<&str>,
     progress: SftpProgressEmitter,
+    copy_buffer: &mut [u8],
 ) -> anyhow::Result<()> {
     let total_bytes = std::fs::metadata(local_path).ok().map(|metadata| metadata.len());
     let mut local_file = TokioFile::open(local_path)
@@ -1584,6 +1599,7 @@ async fn upload_file_to_remote(
         total_bytes,
         &local_path.to_string_lossy(),
         progress,
+        copy_buffer,
     )
     .await?;
     remote_file.shutdown().await?;
@@ -1637,13 +1653,18 @@ async fn download_directory_from_remote(
     local_root: &Path,
     cancellation_marker_path: Option<&str>,
     progress: SftpProgressEmitter,
+    copy_buffer: &mut [u8],
 ) -> anyhow::Result<()> {
-    std::fs::create_dir_all(local_root)?;
+    tokio::fs::create_dir_all(local_root)
+        .await
+        .map_err(|error| map_local_transfer_error(local_root, error))?;
 
     let mut pending = VecDeque::from([(remote_root.to_owned(), local_root.to_path_buf())]);
     while let Some((remote_dir, local_dir)) = pending.pop_front() {
         ensure_transfer_not_canceled(cancellation_marker_path)?;
-        std::fs::create_dir_all(&local_dir)?;
+        tokio::fs::create_dir_all(&local_dir)
+            .await
+            .map_err(|error| map_local_transfer_error(&local_dir, error))?;
 
         let mut entries = sftp
             .read_dir(remote_dir.clone())
@@ -1671,6 +1692,7 @@ async fn download_directory_from_remote(
                     &local_child,
                     cancellation_marker_path,
                     progress,
+                    copy_buffer,
                 )
                 .await?;
             }
@@ -1686,6 +1708,7 @@ async fn upload_directory_to_remote(
     remote_root: &str,
     cancellation_marker_path: Option<&str>,
     progress: SftpProgressEmitter,
+    copy_buffer: &mut [u8],
 ) -> anyhow::Result<()> {
     ensure_remote_directory_exists(sftp, remote_root).await?;
 
@@ -1717,6 +1740,7 @@ async fn upload_directory_to_remote(
                     &remote_child,
                     cancellation_marker_path,
                     progress,
+                    copy_buffer,
                 )
                 .await?;
             }
@@ -1798,22 +1822,28 @@ async fn copy_file_with_cancellation<R, W>(
     total_bytes: Option<u64>,
     current_path: &str,
     progress: SftpProgressEmitter,
+    copy_buffer: &mut [u8],
 ) -> anyhow::Result<()>
 where
     R: AsyncReadExt + Unpin,
     W: AsyncWriteExt + Unpin,
 {
-    let mut buffer = vec![0u8; 64 * 1024];
     let mut bytes_done = 0u64;
+    let mut bytes_since_cancellation_check = 0u64;
+    ensure_transfer_not_canceled(cancellation_marker_path)?;
     loop {
-        ensure_transfer_not_canceled(cancellation_marker_path)?;
-        let read = reader.read(&mut buffer).await?;
+        let read = reader.read(copy_buffer).await?;
         if read == 0 {
             break;
         }
 
-        writer.write_all(&buffer[..read]).await?;
+        writer.write_all(&copy_buffer[..read]).await?;
         bytes_done += read as u64;
+        bytes_since_cancellation_check += read as u64;
+        if should_check_for_cancellation(bytes_since_cancellation_check) {
+            ensure_transfer_not_canceled(cancellation_marker_path)?;
+            bytes_since_cancellation_check = 0;
+        }
         progress.emit(bytes_done, total_bytes, current_path);
     }
 
@@ -1823,36 +1853,49 @@ where
 fn ensure_transfer_not_canceled(cancellation_marker_path: Option<&str>) -> anyhow::Result<()> {
     if let Some(path) = cancellation_marker_path {
         if Path::new(path).exists() {
-            anyhow::bail!("Transfer canceled.");
+            return Err(anyhow::Error::new(NativeSftpTransferError::new(
+                NativeSftpTransferErrorKind::Canceled,
+                "Transfer canceled.",
+            )));
         }
     }
 
     Ok(())
 }
 
+fn should_check_for_cancellation(bytes_since_last_check: u64) -> bool {
+    bytes_since_last_check >= CANCELLATION_CHECK_INTERVAL_BYTES
+}
+
 fn classify_sftp_transfer_error(error: &anyhow::Error) -> (c_int, &'static str, String) {
-    let message = error.to_string();
-    let lower = message.to_ascii_lowercase();
-    if lower.contains("transfer canceled") {
-        return (
-            NOVA_SSH_RESULT_CANCELED,
-            "canceled",
-            "Transfer canceled.".to_owned(),
-        );
+    if let Some(native_error) = error.downcast_ref::<NativeSftpTransferError>() {
+        return match native_error.kind {
+            NativeSftpTransferErrorKind::Canceled => (
+                NOVA_SSH_RESULT_CANCELED,
+                "canceled",
+                native_error.message.clone(),
+            ),
+            NativeSftpTransferErrorKind::NotImplemented => (
+                NOVA_SSH_RESULT_NOT_IMPLEMENTED,
+                "not-implemented",
+                native_error.message.clone(),
+            ),
+            NativeSftpTransferErrorKind::InvalidArgument => (
+                NOVA_SSH_RESULT_INVALID_ARGUMENT,
+                "invalid-argument",
+                native_error.message.clone(),
+            ),
+            NativeSftpTransferErrorKind::RemotePathNotFound
+            | NativeSftpTransferErrorKind::LocalPathNotFound
+            | NativeSftpTransferErrorKind::PermissionDenied => (
+                NOVA_SSH_RESULT_CLOSED,
+                "error",
+                native_error.message.clone(),
+            ),
+        };
     }
 
-    if lower.contains("not implemented") {
-        return (NOVA_SSH_RESULT_NOT_IMPLEMENTED, "not-implemented", message);
-    }
-
-    if lower.contains("invalid")
-        || lower.contains("requires either")
-        || lower.contains("known-hosts store path")
-    {
-        return (NOVA_SSH_RESULT_INVALID_ARGUMENT, "invalid-argument", message);
-    }
-
-    (NOVA_SSH_RESULT_CLOSED, "error", message)
+    (NOVA_SSH_RESULT_CLOSED, "error", error.to_string())
 }
 
 fn map_remote_transfer_error<E>(path: &str, error: E) -> anyhow::Error
@@ -1862,11 +1905,17 @@ where
     let message = error.to_string();
     let lower = message.to_ascii_lowercase();
     if lower.contains("permission denied") {
-        return anyhow::anyhow!("Permission denied: {}", path);
+        return anyhow::Error::new(NativeSftpTransferError::new(
+            NativeSftpTransferErrorKind::PermissionDenied,
+            format!("Permission denied: {}", path),
+        ));
     }
 
     if lower.contains("no such file") || lower.contains("not found") {
-        return anyhow::anyhow!("Remote path not found: {}", path);
+        return anyhow::Error::new(NativeSftpTransferError::new(
+            NativeSftpTransferErrorKind::RemotePathNotFound,
+            format!("Remote path not found: {}", path),
+        ));
     }
 
     anyhow::anyhow!(message)
@@ -1874,15 +1923,50 @@ where
 
 fn map_local_transfer_error(path: &Path, error: std::io::Error) -> anyhow::Error {
     match error.kind() {
-        std::io::ErrorKind::NotFound => {
-            anyhow::anyhow!("Local path not found: {}", path.display())
-        }
-        std::io::ErrorKind::PermissionDenied => {
-            anyhow::anyhow!("Permission denied: {}", path.display())
-        }
+        std::io::ErrorKind::NotFound => anyhow::Error::new(NativeSftpTransferError::new(
+            NativeSftpTransferErrorKind::LocalPathNotFound,
+            format!("Local path not found: {}", path.display()),
+        )),
+        std::io::ErrorKind::PermissionDenied => anyhow::Error::new(NativeSftpTransferError::new(
+            NativeSftpTransferErrorKind::PermissionDenied,
+            format!("Permission denied: {}", path.display()),
+        )),
         _ => anyhow::anyhow!(error),
     }
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NativeSftpTransferErrorKind {
+    Canceled,
+    NotImplemented,
+    InvalidArgument,
+    RemotePathNotFound,
+    LocalPathNotFound,
+    PermissionDenied,
+}
+
+#[derive(Debug)]
+struct NativeSftpTransferError {
+    kind: NativeSftpTransferErrorKind,
+    message: String,
+}
+
+impl NativeSftpTransferError {
+    fn new(kind: NativeSftpTransferErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for NativeSftpTransferError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for NativeSftpTransferError {}
 
 fn remote_basename(path: &str) -> anyhow::Result<String> {
     let normalized = normalize_remote_directory_path(path)?;
@@ -1911,20 +1995,33 @@ fn resolve_upload_file_destination_path(
 fn expand_remote_home_path(path: &str, home_directory: Option<&str>) -> anyhow::Result<String> {
     let trimmed = path.trim();
     if trimmed.is_empty() {
-        anyhow::bail!("Remote file path is required for native SFTP transfer.");
+        return Err(anyhow::Error::new(NativeSftpTransferError::new(
+            NativeSftpTransferErrorKind::InvalidArgument,
+            "Remote file path is required for native SFTP transfer.",
+        )));
     }
 
     if trimmed == "~" {
         return normalize_remote_directory_path(
             home_directory
-                .ok_or_else(|| anyhow::anyhow!("Remote home directory is unavailable for native SFTP upload."))?,
+                .ok_or_else(|| {
+                    anyhow::Error::new(NativeSftpTransferError::new(
+                        NativeSftpTransferErrorKind::InvalidArgument,
+                        "Remote home directory is unavailable for native SFTP upload.",
+                    ))
+                })?,
         );
     }
 
     if let Some(relative_path) = trimmed.strip_prefix("~/") {
         let home_directory = normalize_remote_directory_path(
             home_directory
-                .ok_or_else(|| anyhow::anyhow!("Remote home directory is unavailable for native SFTP upload."))?,
+                .ok_or_else(|| {
+                    anyhow::Error::new(NativeSftpTransferError::new(
+                        NativeSftpTransferErrorKind::InvalidArgument,
+                        "Remote home directory is unavailable for native SFTP upload.",
+                    ))
+                })?,
         )?;
         return Ok(join_remote_path(&home_directory, relative_path));
     }
@@ -1939,7 +2036,10 @@ fn normalize_remote_directory_path(path: &str) -> anyhow::Result<String> {
     }
 
     if trimmed == "." {
-        anyhow::bail!("Remote directory path '.' is not supported for native SFTP transfer.");
+        return Err(anyhow::Error::new(NativeSftpTransferError::new(
+            NativeSftpTransferErrorKind::InvalidArgument,
+            "Remote directory path '.' is not supported for native SFTP transfer.",
+        )));
     }
 
     Ok(trimmed.to_owned())
@@ -2811,6 +2911,28 @@ mod tests {
                 .expect("home directory shortcut should resolve");
 
         assert_eq!("/home/nova/upload.txt", resolved);
+    }
+
+    #[test]
+    fn should_check_for_cancellation_only_after_interval_is_reached() {
+        assert!(!should_check_for_cancellation(64 * 1024));
+        assert!(!should_check_for_cancellation(CANCELLATION_CHECK_INTERVAL_BYTES - 1));
+        assert!(should_check_for_cancellation(CANCELLATION_CHECK_INTERVAL_BYTES));
+    }
+
+    #[test]
+    fn classify_sftp_transfer_error_uses_structured_error_kind_when_available() {
+        let error = NativeSftpTransferError::new(
+            NativeSftpTransferErrorKind::RemotePathNotFound,
+            "Remote path not found: /tmp/missing",
+        );
+        let anyhow_error = anyhow::Error::new(error);
+
+        let (result, status, message) = classify_sftp_transfer_error(&anyhow_error);
+
+        assert_eq!(NOVA_SSH_RESULT_CLOSED, result);
+        assert_eq!("error", status);
+        assert_eq!("Remote path not found: /tmp/missing", message);
     }
 }
 

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -1137,19 +1137,36 @@ where
     let channel = session.channel_open_session().await?;
     channel.request_subsystem(true, "sftp").await?;
     let sftp = SftpSession::new(channel.into_stream()).await?;
-    let mut remote_file = sftp.open(transfer.remote_path.clone()).await?;
+    let direction = transfer.direction.trim().to_ascii_lowercase();
+    match direction.as_str() {
+        "download" => {
+            let mut remote_file = sftp.open(transfer.remote_path.clone()).await?;
 
-    let local_path = PathBuf::from(&transfer.local_path);
-    if let Some(parent) = local_path.parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent)?;
+            let local_path = PathBuf::from(&transfer.local_path);
+            if let Some(parent) = local_path.parent() {
+                if !parent.as_os_str().is_empty() {
+                    std::fs::create_dir_all(parent)?;
+                }
+            }
+
+            let mut local_file = TokioFile::create(&local_path).await?;
+            copy(&mut remote_file, &mut local_file).await?;
+            local_file.flush().await?;
+            remote_file.shutdown().await?;
         }
+        "upload" => {
+            let mut local_file = TokioFile::open(Path::new(&transfer.local_path)).await?;
+            let mut remote_file = sftp.create(transfer.remote_path.clone()).await?;
+            copy(&mut local_file, &mut remote_file).await?;
+            remote_file.shutdown().await?;
+        }
+        _ => anyhow::bail!(
+            "Native SFTP transfer mode '{}/{}' is not implemented yet.",
+            direction,
+            transfer.kind.trim().to_ascii_lowercase()
+        ),
     }
 
-    let mut local_file = TokioFile::create(&local_path).await?;
-    copy(&mut remote_file, &mut local_file).await?;
-    local_file.flush().await?;
-    remote_file.shutdown().await?;
     sftp.close().await?;
     Ok(())
 }
@@ -1157,7 +1174,7 @@ where
 fn validate_supported_sftp_mode(transfer: &SftpTransferRequestBody) -> anyhow::Result<()> {
     let direction = transfer.direction.trim().to_ascii_lowercase();
     let kind = transfer.kind.trim().to_ascii_lowercase();
-    if direction == "download" && kind == "file" {
+    if (direction == "download" || direction == "upload") && kind == "file" {
         return Ok(());
     }
 

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -2,9 +2,9 @@ use libc::{c_char, c_int};
 use russh::client::{self, AuthResult, KeyboardInteractiveAuthResponse};
 use russh::keys::{load_secret_key, ssh_key, PrivateKeyWithHashAlg};
 use russh::{ChannelMsg, Disconnect};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 use std::future::Future;
 use std::io::Cursor;
 use std::path::Path;
@@ -83,6 +83,7 @@ pub const NOVA_SSH_RESULT_INVALID_ARGUMENT: c_int = -1;
 pub const NOVA_SSH_RESULT_BUFFER_TOO_SMALL: c_int = -2;
 pub const NOVA_SSH_RESULT_CLOSED: c_int = -3;
 pub const NOVA_SSH_RESULT_CHANNEL_OPEN_FAILED: c_int = -4;
+pub const NOVA_SSH_RESULT_NOT_IMPLEMENTED: c_int = -5;
 
 const NOVA_SSH_EVENT_FLAG_JSON: u32 = 1;
 const NOVA_SSH_EVENT_FLAG_BINARY: u32 = 2;
@@ -224,6 +225,47 @@ struct TextResponse {
 #[derive(serde::Deserialize)]
 struct KeyboardInteractiveResponse {
     responses: Vec<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SftpTransferRequest {
+    connection: SftpConnectionRequest,
+    transfer: SftpTransferRequestBody,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SftpConnectionRequest {
+    host: String,
+    user: String,
+    port: u16,
+    identity_file_path: Option<String>,
+    jump_host: Option<SftpJumpHostRequest>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SftpJumpHostRequest {
+    host: String,
+    user: Option<String>,
+    port: u16,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SftpTransferRequestBody {
+    direction: String,
+    kind: String,
+    local_path: String,
+    remote_path: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SftpTransferResponse<'a> {
+    status: &'a str,
+    message: &'a str,
 }
 
 impl SharedState {
@@ -632,6 +674,71 @@ pub extern "C" fn nova_ssh_close(session: *mut NovaSshSession) -> c_int {
     NOVA_SSH_RESULT_OK
 }
 
+#[unsafe(no_mangle)]
+pub extern "C" fn nova_ssh_sftp_transfer(
+    request_json: *const c_char,
+    response_json: *mut *mut c_char,
+) -> c_int {
+    if request_json.is_null() || response_json.is_null() {
+        return NOVA_SSH_RESULT_INVALID_ARGUMENT;
+    }
+
+    unsafe {
+        *response_json = ptr::null_mut();
+    }
+
+    let request_text = match unsafe { CStr::from_ptr(request_json) }.to_str() {
+        Ok(value) => value,
+        Err(_) => {
+            return write_sftp_response_json(
+                response_json,
+                NOVA_SSH_RESULT_INVALID_ARGUMENT,
+                "invalid-argument",
+                "Native backend stub rejected a non-UTF8 SFTP request.",
+            );
+        }
+    };
+
+    let request = match serde_json::from_str::<SftpTransferRequest>(request_text) {
+        Ok(value) => value,
+        Err(_) => {
+            return write_sftp_response_json(
+                response_json,
+                NOVA_SSH_RESULT_INVALID_ARGUMENT,
+                "invalid-argument",
+                "Native backend stub rejected invalid SFTP request JSON.",
+            );
+        }
+    };
+
+    if sftp_request_has_blank_fields(&request) {
+        return write_sftp_response_json(
+            response_json,
+            NOVA_SSH_RESULT_INVALID_ARGUMENT,
+            "invalid-argument",
+            "Native backend stub rejected an incomplete SFTP request.",
+        );
+    }
+
+    write_sftp_response_json(
+        response_json,
+        NOVA_SSH_RESULT_NOT_IMPLEMENTED,
+        "not-implemented",
+        "Native backend stub reached: SFTP transfer not implemented.",
+    )
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn nova_ssh_string_free(value: *mut c_char) {
+    if value.is_null() {
+        return;
+    }
+
+    unsafe {
+        drop(CString::from_raw(value));
+    }
+}
+
 impl ConnectConfig {
     fn from_args(args: *const NovaSshConnectArgs) -> Option<Self> {
         let args = unsafe { args.as_ref()? };
@@ -681,6 +788,53 @@ fn read_c_string(value: *const c_char) -> Option<String> {
     } else {
         Some(string)
     }
+}
+
+fn write_sftp_response_json(
+    response_json: *mut *mut c_char,
+    result: c_int,
+    status: &str,
+    message: &str,
+) -> c_int {
+    let response = SftpTransferResponse { status, message };
+    let json = match serde_json::to_string(&response) {
+        Ok(value) => value,
+        Err(_) => return result,
+    };
+
+    match CString::new(json) {
+        Ok(value) => unsafe {
+            *response_json = value.into_raw();
+            result
+        },
+        Err(_) => result,
+    }
+}
+
+fn sftp_request_has_blank_fields(request: &SftpTransferRequest) -> bool {
+    let jump_host_is_blank = request
+        .connection
+        .jump_host
+        .as_ref()
+        .is_some_and(|jump_host| {
+            jump_host.host.trim().is_empty()
+                || jump_host.user.as_deref().is_some_and(|user| user.trim().is_empty())
+                || jump_host.port == 0
+        });
+
+    request.connection.host.trim().is_empty()
+        || request.connection.user.trim().is_empty()
+        || request.connection.port == 0
+        || request
+            .connection
+            .identity_file_path
+            .as_deref()
+            .is_some_and(|path| path.trim().is_empty())
+        || jump_host_is_blank
+        || request.transfer.direction.trim().is_empty()
+        || request.transfer.kind.trim().is_empty()
+        || request.transfer.local_path.trim().is_empty()
+        || request.transfer.remote_path.trim().is_empty()
 }
 
 fn run_session(
@@ -1188,7 +1342,6 @@ fn create_test_session_with_event(kind: NovaSshEventKind, payload: &[u8]) -> *mu
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ffi::CString;
 
     #[test]
     fn null_handle_operations_return_invalid_argument() {
@@ -1205,6 +1358,8 @@ mod tests {
         let channel_eof = nova_ssh_channel_eof(ptr::null_mut(), 1);
         let channel_close = nova_ssh_channel_close(ptr::null_mut(), 1);
         let respond = nova_ssh_submit_response(ptr::null_mut(), 1, br#"{}"#.as_ptr(), 2);
+        let mut sftp_response = ptr::null_mut();
+        let sftp = nova_ssh_sftp_transfer(ptr::null(), &mut sftp_response);
         let close = nova_ssh_close(ptr::null_mut());
 
         assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, resize);
@@ -1214,7 +1369,33 @@ mod tests {
         assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, channel_eof);
         assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, channel_close);
         assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, respond);
+        assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, sftp);
+        assert!(sftp_response.is_null());
         assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, close);
+    }
+
+    #[test]
+    fn sftp_transfer_stub_returns_not_implemented_response() {
+        let request = CString::new(
+            r#"{"connection":{"host":"example.com","user":"nova","port":22},"transfer":{"direction":"download","kind":"file","localPath":"local.txt","remotePath":"/tmp/remote.txt"}}"#,
+        )
+        .unwrap();
+        let mut response = ptr::null_mut();
+
+        let rc = nova_ssh_sftp_transfer(request.as_ptr(), &mut response);
+
+        assert_eq!(NOVA_SSH_RESULT_NOT_IMPLEMENTED, rc);
+        assert!(!response.is_null());
+
+        let response_json = unsafe { CStr::from_ptr(response) }.to_str().unwrap();
+        let payload: serde_json::Value = serde_json::from_str(response_json).unwrap();
+        assert_eq!("not-implemented", payload["status"]);
+        assert_eq!(
+            "Native backend stub reached: SFTP transfer not implemented.",
+            payload["message"]
+        );
+
+        nova_ssh_string_free(response);
     }
 
     #[test]

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Condvar, Mutex, mpsc as std_mpsc};
 use std::thread;
 use std::time::Duration;
 use tokio::fs::File as TokioFile;
-use tokio::io::{AsyncWriteExt, copy};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::runtime::Builder;
 use tokio::sync::mpsc;
 
@@ -87,6 +87,7 @@ pub const NOVA_SSH_RESULT_BUFFER_TOO_SMALL: c_int = -2;
 pub const NOVA_SSH_RESULT_CLOSED: c_int = -3;
 pub const NOVA_SSH_RESULT_CHANNEL_OPEN_FAILED: c_int = -4;
 pub const NOVA_SSH_RESULT_NOT_IMPLEMENTED: c_int = -5;
+pub const NOVA_SSH_RESULT_CANCELED: c_int = -6;
 
 const NOVA_SSH_EVENT_FLAG_JSON: u32 = 1;
 const NOVA_SSH_EVENT_FLAG_BINARY: u32 = 2;
@@ -280,6 +281,7 @@ struct SftpTransferRequestBody {
     kind: String,
     local_path: String,
     remote_path: String,
+    cancellation_marker_path: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -790,19 +792,7 @@ pub extern "C" fn nova_ssh_sftp_transfer(
             "Native SFTP transfer completed.",
         ),
         Err(error) => {
-            let message = error.to_string();
-            let lower = message.to_ascii_lowercase();
-            let (result, status) = if lower.contains("not implemented") {
-                (NOVA_SSH_RESULT_NOT_IMPLEMENTED, "not-implemented")
-            } else if lower.contains("invalid")
-                || lower.contains("requires either")
-                || lower.contains("known-hosts store path")
-            {
-                (NOVA_SSH_RESULT_INVALID_ARGUMENT, "invalid-argument")
-            } else {
-                (NOVA_SSH_RESULT_CLOSED, "error")
-            };
-
+            let (result, status, message) = classify_sftp_transfer_error(&error);
             write_sftp_response_json(response_json, result, status, &message)
         }
     }
@@ -931,6 +921,11 @@ fn sftp_request_has_blank_fields(request: &SftpTransferRequest) -> bool {
         || request.transfer.kind.trim().is_empty()
         || request.transfer.local_path.trim().is_empty()
         || request.transfer.remote_path.trim().is_empty()
+        || request
+            .transfer
+            .cancellation_marker_path
+            .as_deref()
+            .is_some_and(|path| path.trim().is_empty())
 }
 
 impl NativeKnownHostsVerifier {
@@ -1106,7 +1101,7 @@ where
             return Ok(());
         }
 
-        anyhow::bail!("SSH authentication failed");
+        anyhow::bail!("Authentication failed.");
     }
 
     if let Some(password) = auth.password.as_deref() {
@@ -1117,7 +1112,7 @@ where
             return Ok(());
         }
 
-        anyhow::bail!("SSH authentication failed");
+        anyhow::bail!("Authentication failed.");
     }
 
     anyhow::bail!(
@@ -1139,26 +1134,50 @@ where
     let sftp = SftpSession::new(channel.into_stream()).await?;
     let direction = transfer.direction.trim().to_ascii_lowercase();
     let kind = transfer.kind.trim().to_ascii_lowercase();
+    let cancellation_marker_path = transfer.cancellation_marker_path.as_deref();
+    ensure_transfer_not_canceled(cancellation_marker_path)?;
 
     match (direction.as_str(), kind.as_str()) {
         ("download", "file") => {
-            download_file_from_remote(&sftp, &transfer.remote_path, Path::new(&transfer.local_path))
-                .await?;
+            download_file_from_remote(
+                &sftp,
+                &transfer.remote_path,
+                Path::new(&transfer.local_path),
+                cancellation_marker_path,
+            )
+            .await?;
         }
         ("upload", "file") => {
-            upload_file_to_remote(&sftp, Path::new(&transfer.local_path), &transfer.remote_path)
-                .await?;
+            upload_file_to_remote(
+                &sftp,
+                Path::new(&transfer.local_path),
+                &transfer.remote_path,
+                cancellation_marker_path,
+            )
+            .await?;
         }
         ("download", "directory") => {
             let local_root = PathBuf::from(&transfer.local_path)
                 .join(remote_basename(&transfer.remote_path)?);
-            download_directory_from_remote(&sftp, &transfer.remote_path, &local_root).await?;
+            download_directory_from_remote(
+                &sftp,
+                &transfer.remote_path,
+                &local_root,
+                cancellation_marker_path,
+            )
+            .await?;
         }
         ("upload", "directory") => {
             let local_root = PathBuf::from(&transfer.local_path);
             let remote_root =
                 resolve_upload_directory_target(&sftp, &local_root, &transfer.remote_path).await?;
-            upload_directory_to_remote(&sftp, &local_root, &remote_root).await?;
+            upload_directory_to_remote(
+                &sftp,
+                &local_root,
+                &remote_root,
+                cancellation_marker_path,
+            )
+            .await?;
         }
         _ => anyhow::bail!(
             "Native SFTP transfer mode '{}/{}' is not implemented yet.",
@@ -1191,16 +1210,27 @@ async fn download_file_from_remote(
     sftp: &SftpSession,
     remote_path: &str,
     local_path: &Path,
+    cancellation_marker_path: Option<&str>,
 ) -> anyhow::Result<()> {
-    let mut remote_file = sftp.open(remote_path.to_owned()).await?;
+    let mut remote_file = sftp
+        .open(remote_path.to_owned())
+        .await
+        .map_err(|error| map_remote_transfer_error(remote_path, error))?;
     if let Some(parent) = local_path.parent() {
         if !parent.as_os_str().is_empty() {
             std::fs::create_dir_all(parent)?;
         }
     }
 
-    let mut local_file = TokioFile::create(local_path).await?;
-    copy(&mut remote_file, &mut local_file).await?;
+    let mut local_file = TokioFile::create(local_path)
+        .await
+        .map_err(|error| map_local_transfer_error(local_path, error))?;
+    copy_file_with_cancellation(
+        &mut remote_file,
+        &mut local_file,
+        cancellation_marker_path,
+    )
+    .await?;
     local_file.flush().await?;
     remote_file.shutdown().await?;
     Ok(())
@@ -1210,10 +1240,21 @@ async fn upload_file_to_remote(
     sftp: &SftpSession,
     local_path: &Path,
     remote_path: &str,
+    cancellation_marker_path: Option<&str>,
 ) -> anyhow::Result<()> {
-    let mut local_file = TokioFile::open(local_path).await?;
-    let mut remote_file = sftp.create(remote_path.to_owned()).await?;
-    copy(&mut local_file, &mut remote_file).await?;
+    let mut local_file = TokioFile::open(local_path)
+        .await
+        .map_err(|error| map_local_transfer_error(local_path, error))?;
+    let mut remote_file = sftp
+        .create(remote_path.to_owned())
+        .await
+        .map_err(|error| map_remote_transfer_error(remote_path, error))?;
+    copy_file_with_cancellation(
+        &mut local_file,
+        &mut remote_file,
+        cancellation_marker_path,
+    )
+    .await?;
     remote_file.shutdown().await?;
     Ok(())
 }
@@ -1222,20 +1263,24 @@ async fn download_directory_from_remote(
     sftp: &SftpSession,
     remote_root: &str,
     local_root: &Path,
+    cancellation_marker_path: Option<&str>,
 ) -> anyhow::Result<()> {
     std::fs::create_dir_all(local_root)?;
 
     let mut pending = VecDeque::from([(remote_root.to_owned(), local_root.to_path_buf())]);
     while let Some((remote_dir, local_dir)) = pending.pop_front() {
+        ensure_transfer_not_canceled(cancellation_marker_path)?;
         std::fs::create_dir_all(&local_dir)?;
 
         let mut entries = sftp
             .read_dir(remote_dir.clone())
-            .await?
+            .await
+            .map_err(|error| map_remote_transfer_error(&remote_dir, error))?
             .collect::<Vec<_>>();
         entries.sort_by_key(|entry| entry.file_name());
 
         for entry in entries {
+            ensure_transfer_not_canceled(cancellation_marker_path)?;
             let file_name = entry.file_name();
             let remote_child = join_remote_path(&remote_dir, &file_name);
             let local_child = local_dir.join(&file_name);
@@ -1247,7 +1292,13 @@ async fn download_directory_from_remote(
             }
 
             if metadata.is_regular() {
-                download_file_from_remote(sftp, &remote_child, &local_child).await?;
+                download_file_from_remote(
+                    sftp,
+                    &remote_child,
+                    &local_child,
+                    cancellation_marker_path,
+                )
+                .await?;
             }
         }
     }
@@ -1259,16 +1310,19 @@ async fn upload_directory_to_remote(
     sftp: &SftpSession,
     local_root: &Path,
     remote_root: &str,
+    cancellation_marker_path: Option<&str>,
 ) -> anyhow::Result<()> {
     ensure_remote_directory_exists(sftp, remote_root).await?;
 
     let mut pending = VecDeque::from([(local_root.to_path_buf(), remote_root.to_owned())]);
     while let Some((local_dir, remote_dir)) = pending.pop_front() {
+        ensure_transfer_not_canceled(cancellation_marker_path)?;
         let mut entries = std::fs::read_dir(&local_dir)?
             .collect::<Result<Vec<_>, std::io::Error>>()?;
         entries.sort_by_key(|entry| entry.file_name());
 
         for entry in entries {
+            ensure_transfer_not_canceled(cancellation_marker_path)?;
             let local_child = entry.path();
             let file_name = entry.file_name();
             let file_name = file_name.to_string_lossy().into_owned();
@@ -1282,7 +1336,13 @@ async fn upload_directory_to_remote(
             }
 
             if metadata.is_file() {
-                upload_file_to_remote(sftp, &local_child, &remote_child).await?;
+                upload_file_to_remote(
+                    sftp,
+                    &local_child,
+                    &remote_child,
+                    cancellation_marker_path,
+                )
+                .await?;
             }
         }
     }
@@ -1302,8 +1362,15 @@ async fn resolve_upload_directory_target(
         .ok_or_else(|| anyhow::anyhow!("Local directory name is required for native SFTP upload."))?;
     let normalized_remote = normalize_remote_directory_path(remote_path)?;
 
-    if sftp.try_exists(normalized_remote.clone()).await? {
-        let metadata = sftp.metadata(normalized_remote.clone()).await?;
+    if sftp
+        .try_exists(normalized_remote.clone())
+        .await
+        .map_err(|error| map_remote_transfer_error(&normalized_remote, error))?
+    {
+        let metadata = sftp
+            .metadata(normalized_remote.clone())
+            .await
+            .map_err(|error| map_remote_transfer_error(&normalized_remote, error))?;
         if metadata.is_dir() {
             return Ok(join_remote_path(&normalized_remote, local_name));
         }
@@ -1334,12 +1401,105 @@ async fn ensure_remote_directory_exists(sftp: &SftpSession, path: &str) -> anyho
             format!("{}/{}", current, part)
         };
 
-        if !sftp.try_exists(current.clone()).await? {
-            sftp.create_dir(current.clone()).await?;
+        if !sftp
+            .try_exists(current.clone())
+            .await
+            .map_err(|error| map_remote_transfer_error(&current, error))?
+        {
+            sftp.create_dir(current.clone())
+                .await
+                .map_err(|error| map_remote_transfer_error(&current, error))?;
         }
     }
 
     Ok(())
+}
+
+async fn copy_file_with_cancellation<R, W>(
+    reader: &mut R,
+    writer: &mut W,
+    cancellation_marker_path: Option<&str>,
+) -> anyhow::Result<()>
+where
+    R: AsyncReadExt + Unpin,
+    W: AsyncWriteExt + Unpin,
+{
+    let mut buffer = vec![0u8; 64 * 1024];
+    loop {
+        ensure_transfer_not_canceled(cancellation_marker_path)?;
+        let read = reader.read(&mut buffer).await?;
+        if read == 0 {
+            break;
+        }
+
+        writer.write_all(&buffer[..read]).await?;
+    }
+
+    Ok(())
+}
+
+fn ensure_transfer_not_canceled(cancellation_marker_path: Option<&str>) -> anyhow::Result<()> {
+    if let Some(path) = cancellation_marker_path {
+        if Path::new(path).exists() {
+            anyhow::bail!("Transfer canceled.");
+        }
+    }
+
+    Ok(())
+}
+
+fn classify_sftp_transfer_error(error: &anyhow::Error) -> (c_int, &'static str, String) {
+    let message = error.to_string();
+    let lower = message.to_ascii_lowercase();
+    if lower.contains("transfer canceled") {
+        return (
+            NOVA_SSH_RESULT_CANCELED,
+            "canceled",
+            "Transfer canceled.".to_owned(),
+        );
+    }
+
+    if lower.contains("not implemented") {
+        return (NOVA_SSH_RESULT_NOT_IMPLEMENTED, "not-implemented", message);
+    }
+
+    if lower.contains("invalid")
+        || lower.contains("requires either")
+        || lower.contains("known-hosts store path")
+    {
+        return (NOVA_SSH_RESULT_INVALID_ARGUMENT, "invalid-argument", message);
+    }
+
+    (NOVA_SSH_RESULT_CLOSED, "error", message)
+}
+
+fn map_remote_transfer_error<E>(path: &str, error: E) -> anyhow::Error
+where
+    E: std::fmt::Display,
+{
+    let message = error.to_string();
+    let lower = message.to_ascii_lowercase();
+    if lower.contains("permission denied") {
+        return anyhow::anyhow!("Permission denied: {}", path);
+    }
+
+    if lower.contains("no such file") || lower.contains("not found") {
+        return anyhow::anyhow!("Remote path not found: {}", path);
+    }
+
+    anyhow::anyhow!(message)
+}
+
+fn map_local_transfer_error(path: &Path, error: std::io::Error) -> anyhow::Error {
+    match error.kind() {
+        std::io::ErrorKind::NotFound => {
+            anyhow::anyhow!("Local path not found: {}", path.display())
+        }
+        std::io::ErrorKind::PermissionDenied => {
+            anyhow::anyhow!("Permission denied: {}", path.display())
+        }
+        _ => anyhow::anyhow!(error),
+    }
 }
 
 fn remote_basename(path: &str) -> anyhow::Result<String> {

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -1087,17 +1087,6 @@ async fn authenticate_transfer<H>(
 where
     H: client::Handler + Send + 'static,
 {
-    if let Some(password) = auth.password.as_deref() {
-        let result = session
-            .authenticate_password(user.to_owned(), password.to_owned())
-            .await?;
-        if result.success() {
-            return Ok(());
-        }
-
-        anyhow::bail!("SSH authentication failed");
-    }
-
     if let Some(identity_file) = auth.identity_file.as_deref() {
         let key = load_secret_key(Path::new(identity_file), None).map_err(|_| {
             anyhow::anyhow!(
@@ -1112,6 +1101,17 @@ where
                 user.to_owned(),
                 PrivateKeyWithHashAlg::new(Arc::new(key), hash_alg),
             )
+            .await?;
+        if result.success() {
+            return Ok(());
+        }
+
+        anyhow::bail!("SSH authentication failed");
+    }
+
+    if let Some(password) = auth.password.as_deref() {
+        let result = session
+            .authenticate_password(user.to_owned(), password.to_owned())
             .await?;
         if result.success() {
             return Ok(());
@@ -1138,32 +1138,32 @@ where
     channel.request_subsystem(true, "sftp").await?;
     let sftp = SftpSession::new(channel.into_stream()).await?;
     let direction = transfer.direction.trim().to_ascii_lowercase();
-    match direction.as_str() {
-        "download" => {
-            let mut remote_file = sftp.open(transfer.remote_path.clone()).await?;
+    let kind = transfer.kind.trim().to_ascii_lowercase();
 
-            let local_path = PathBuf::from(&transfer.local_path);
-            if let Some(parent) = local_path.parent() {
-                if !parent.as_os_str().is_empty() {
-                    std::fs::create_dir_all(parent)?;
-                }
-            }
-
-            let mut local_file = TokioFile::create(&local_path).await?;
-            copy(&mut remote_file, &mut local_file).await?;
-            local_file.flush().await?;
-            remote_file.shutdown().await?;
+    match (direction.as_str(), kind.as_str()) {
+        ("download", "file") => {
+            download_file_from_remote(&sftp, &transfer.remote_path, Path::new(&transfer.local_path))
+                .await?;
         }
-        "upload" => {
-            let mut local_file = TokioFile::open(Path::new(&transfer.local_path)).await?;
-            let mut remote_file = sftp.create(transfer.remote_path.clone()).await?;
-            copy(&mut local_file, &mut remote_file).await?;
-            remote_file.shutdown().await?;
+        ("upload", "file") => {
+            upload_file_to_remote(&sftp, Path::new(&transfer.local_path), &transfer.remote_path)
+                .await?;
+        }
+        ("download", "directory") => {
+            let local_root = PathBuf::from(&transfer.local_path)
+                .join(remote_basename(&transfer.remote_path)?);
+            download_directory_from_remote(&sftp, &transfer.remote_path, &local_root).await?;
+        }
+        ("upload", "directory") => {
+            let local_root = PathBuf::from(&transfer.local_path);
+            let remote_root =
+                resolve_upload_directory_target(&sftp, &local_root, &transfer.remote_path).await?;
+            upload_directory_to_remote(&sftp, &local_root, &remote_root).await?;
         }
         _ => anyhow::bail!(
             "Native SFTP transfer mode '{}/{}' is not implemented yet.",
             direction,
-            transfer.kind.trim().to_ascii_lowercase()
+            kind
         ),
     }
 
@@ -1174,7 +1174,9 @@ where
 fn validate_supported_sftp_mode(transfer: &SftpTransferRequestBody) -> anyhow::Result<()> {
     let direction = transfer.direction.trim().to_ascii_lowercase();
     let kind = transfer.kind.trim().to_ascii_lowercase();
-    if (direction == "download" || direction == "upload") && kind == "file" {
+    if (direction == "download" || direction == "upload")
+        && (kind == "file" || kind == "directory")
+    {
         return Ok(());
     }
 
@@ -1183,6 +1185,193 @@ fn validate_supported_sftp_mode(transfer: &SftpTransferRequestBody) -> anyhow::R
         direction,
         kind
     )
+}
+
+async fn download_file_from_remote(
+    sftp: &SftpSession,
+    remote_path: &str,
+    local_path: &Path,
+) -> anyhow::Result<()> {
+    let mut remote_file = sftp.open(remote_path.to_owned()).await?;
+    if let Some(parent) = local_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+
+    let mut local_file = TokioFile::create(local_path).await?;
+    copy(&mut remote_file, &mut local_file).await?;
+    local_file.flush().await?;
+    remote_file.shutdown().await?;
+    Ok(())
+}
+
+async fn upload_file_to_remote(
+    sftp: &SftpSession,
+    local_path: &Path,
+    remote_path: &str,
+) -> anyhow::Result<()> {
+    let mut local_file = TokioFile::open(local_path).await?;
+    let mut remote_file = sftp.create(remote_path.to_owned()).await?;
+    copy(&mut local_file, &mut remote_file).await?;
+    remote_file.shutdown().await?;
+    Ok(())
+}
+
+async fn download_directory_from_remote(
+    sftp: &SftpSession,
+    remote_root: &str,
+    local_root: &Path,
+) -> anyhow::Result<()> {
+    std::fs::create_dir_all(local_root)?;
+
+    let mut pending = VecDeque::from([(remote_root.to_owned(), local_root.to_path_buf())]);
+    while let Some((remote_dir, local_dir)) = pending.pop_front() {
+        std::fs::create_dir_all(&local_dir)?;
+
+        let mut entries = sftp
+            .read_dir(remote_dir.clone())
+            .await?
+            .collect::<Vec<_>>();
+        entries.sort_by_key(|entry| entry.file_name());
+
+        for entry in entries {
+            let file_name = entry.file_name();
+            let remote_child = join_remote_path(&remote_dir, &file_name);
+            let local_child = local_dir.join(&file_name);
+            let metadata = entry.metadata();
+
+            if metadata.is_dir() {
+                pending.push_back((remote_child, local_child));
+                continue;
+            }
+
+            if metadata.is_regular() {
+                download_file_from_remote(sftp, &remote_child, &local_child).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn upload_directory_to_remote(
+    sftp: &SftpSession,
+    local_root: &Path,
+    remote_root: &str,
+) -> anyhow::Result<()> {
+    ensure_remote_directory_exists(sftp, remote_root).await?;
+
+    let mut pending = VecDeque::from([(local_root.to_path_buf(), remote_root.to_owned())]);
+    while let Some((local_dir, remote_dir)) = pending.pop_front() {
+        let mut entries = std::fs::read_dir(&local_dir)?
+            .collect::<Result<Vec<_>, std::io::Error>>()?;
+        entries.sort_by_key(|entry| entry.file_name());
+
+        for entry in entries {
+            let local_child = entry.path();
+            let file_name = entry.file_name();
+            let file_name = file_name.to_string_lossy().into_owned();
+            let remote_child = join_remote_path(&remote_dir, &file_name);
+            let metadata = std::fs::symlink_metadata(&local_child)?;
+
+            if metadata.is_dir() {
+                ensure_remote_directory_exists(sftp, &remote_child).await?;
+                pending.push_back((local_child, remote_child));
+                continue;
+            }
+
+            if metadata.is_file() {
+                upload_file_to_remote(sftp, &local_child, &remote_child).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn resolve_upload_directory_target(
+    sftp: &SftpSession,
+    local_root: &Path,
+    remote_path: &str,
+) -> anyhow::Result<String> {
+    let local_name = local_root
+        .file_name()
+        .and_then(|value| value.to_str())
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| anyhow::anyhow!("Local directory name is required for native SFTP upload."))?;
+    let normalized_remote = normalize_remote_directory_path(remote_path)?;
+
+    if sftp.try_exists(normalized_remote.clone()).await? {
+        let metadata = sftp.metadata(normalized_remote.clone()).await?;
+        if metadata.is_dir() {
+            return Ok(join_remote_path(&normalized_remote, local_name));
+        }
+    }
+
+    Ok(normalized_remote)
+}
+
+async fn ensure_remote_directory_exists(sftp: &SftpSession, path: &str) -> anyhow::Result<()> {
+    let normalized = normalize_remote_directory_path(path)?;
+    if normalized == "/" {
+        return Ok(());
+    }
+
+    let is_absolute = normalized.starts_with('/');
+    let mut current = if is_absolute {
+        String::from("/")
+    } else {
+        String::new()
+    };
+
+    for part in normalized.split('/').filter(|part| !part.is_empty()) {
+        current = if current == "/" {
+            format!("/{}", part)
+        } else if current.is_empty() {
+            part.to_owned()
+        } else {
+            format!("{}/{}", current, part)
+        };
+
+        if !sftp.try_exists(current.clone()).await? {
+            sftp.create_dir(current.clone()).await?;
+        }
+    }
+
+    Ok(())
+}
+
+fn remote_basename(path: &str) -> anyhow::Result<String> {
+    let normalized = normalize_remote_directory_path(path)?;
+    normalized
+        .rsplit('/')
+        .find(|segment| !segment.is_empty())
+        .map(str::to_owned)
+        .ok_or_else(|| anyhow::anyhow!("Remote directory name is required for native SFTP transfer."))
+}
+
+fn normalize_remote_directory_path(path: &str) -> anyhow::Result<String> {
+    let trimmed = path.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        return Ok("/".to_owned());
+    }
+
+    if trimmed == "." {
+        anyhow::bail!("Remote directory path '.' is not supported for native SFTP transfer.");
+    }
+
+    Ok(trimmed.to_owned())
+}
+
+fn join_remote_path(base: &str, child: &str) -> String {
+    let trimmed_base = base.trim_end_matches('/');
+    let trimmed_child = child.trim_matches('/');
+    if trimmed_base.is_empty() || trimmed_base == "/" {
+        format!("/{}", trimmed_child)
+    } else {
+        format!("{}/{}", trimmed_base, trimmed_child)
+    }
 }
 
 fn run_session(
@@ -1750,7 +1939,7 @@ mod tests {
     #[test]
     fn sftp_transfer_rejects_unsupported_modes() {
         let request = CString::new(
-            r#"{"connection":{"host":"example.com","user":"nova","port":22,"password":"secret","knownHostsFilePath":"known_hosts.json"},"transfer":{"direction":"upload","kind":"directory","localPath":"local.txt","remotePath":"/tmp/remote.txt"}}"#,
+            r#"{"connection":{"host":"example.com","user":"nova","port":22,"password":"secret","knownHostsFilePath":"known_hosts.json"},"transfer":{"direction":"sync","kind":"directory","localPath":"local.txt","remotePath":"/tmp/remote.txt"}}"#,
         )
         .unwrap();
         let mut response = ptr::null_mut();
@@ -1764,7 +1953,7 @@ mod tests {
         let payload: serde_json::Value = serde_json::from_str(response_json).unwrap();
         assert_eq!("not-implemented", payload["status"]);
         assert_eq!(
-            "Native SFTP transfer mode 'upload/directory' is not implemented yet.",
+            "Native SFTP transfer mode 'sync/directory' is not implemented yet.",
             payload["message"]
         );
 

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -284,11 +284,34 @@ struct SftpTransferRequestBody {
     cancellation_marker_path: Option<String>,
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RemotePathListRequest {
+    connection: SftpConnectionRequest,
+    path: String,
+}
+
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct SftpTransferResponse<'a> {
     status: &'a str,
     message: &'a str,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RemotePathListResponse<'a> {
+    status: &'a str,
+    message: &'a str,
+    entries: Vec<RemotePathListEntry>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RemotePathListEntry {
+    name: String,
+    full_path: String,
+    is_directory: bool,
 }
 
 #[derive(Clone)]
@@ -854,6 +877,67 @@ pub extern "C" fn nova_ssh_sftp_transfer(
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn nova_ssh_sftp_list_directory(
+    request_json: *const c_char,
+    response_json: *mut *mut c_char,
+) -> c_int {
+    if request_json.is_null() || response_json.is_null() {
+        return NOVA_SSH_RESULT_INVALID_ARGUMENT;
+    }
+
+    unsafe {
+        *response_json = ptr::null_mut();
+    }
+
+    let request_text = match unsafe { CStr::from_ptr(request_json) }.to_str() {
+        Ok(value) => value,
+        Err(_) => {
+            return write_sftp_response_json(
+                response_json,
+                NOVA_SSH_RESULT_INVALID_ARGUMENT,
+                "invalid-argument",
+                "Native backend stub rejected a non-UTF8 remote path list request.",
+            );
+        }
+    };
+
+    let request = match serde_json::from_str::<RemotePathListRequest>(request_text) {
+        Ok(value) => value,
+        Err(_) => {
+            return write_sftp_response_json(
+                response_json,
+                NOVA_SSH_RESULT_INVALID_ARGUMENT,
+                "invalid-argument",
+                "Native backend stub rejected invalid remote path list request JSON.",
+            );
+        }
+    };
+
+    if remote_path_list_request_has_blank_fields(&request) {
+        return write_sftp_response_json(
+            response_json,
+            NOVA_SSH_RESULT_INVALID_ARGUMENT,
+            "invalid-argument",
+            "Native backend stub rejected an incomplete remote path list request.",
+        );
+    }
+
+    match run_remote_path_list(request) {
+        Ok(entries) => write_remote_path_list_response_json(
+            response_json,
+            NOVA_SSH_RESULT_OK,
+            "ok",
+            "Native remote path listing completed.",
+            entries,
+        ),
+        Err(error) => {
+            let (result, status, message) = classify_sftp_transfer_error(&error);
+            write_remote_path_list_response_json(response_json, result, status, &message, Vec::new())
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn nova_ssh_string_free(value: *mut c_char) {
     if value.is_null() {
         return;
@@ -943,6 +1027,32 @@ fn write_sftp_response_json(
     }
 }
 
+fn write_remote_path_list_response_json(
+    response_json: *mut *mut c_char,
+    result: c_int,
+    status: &str,
+    message: &str,
+    entries: Vec<RemotePathListEntry>,
+) -> c_int {
+    let response = RemotePathListResponse {
+        status,
+        message,
+        entries,
+    };
+    let json = match serde_json::to_string(&response) {
+        Ok(value) => value,
+        Err(_) => return result,
+    };
+
+    match CString::new(json) {
+        Ok(value) => unsafe {
+            *response_json = value.into_raw();
+            result
+        },
+        Err(_) => result,
+    }
+}
+
 fn sftp_request_has_blank_fields(request: &SftpTransferRequest) -> bool {
     let jump_host_is_blank = request
         .connection
@@ -981,6 +1091,38 @@ fn sftp_request_has_blank_fields(request: &SftpTransferRequest) -> bool {
             .cancellation_marker_path
             .as_deref()
             .is_some_and(|path| path.trim().is_empty())
+}
+
+fn remote_path_list_request_has_blank_fields(request: &RemotePathListRequest) -> bool {
+    let jump_host_is_blank = request
+        .connection
+        .jump_host
+        .as_ref()
+        .is_some_and(|jump_host| {
+            jump_host.host.trim().is_empty()
+                || jump_host
+                    .user
+                    .as_deref()
+                    .is_some_and(|user| user.trim().is_empty())
+                || jump_host.port == 0
+        });
+
+    request.connection.host.trim().is_empty()
+        || request.connection.user.trim().is_empty()
+        || request.connection.port == 0
+        || request
+            .connection
+            .password
+            .as_deref()
+            .is_some_and(|password| password.trim().is_empty())
+        || request
+            .connection
+            .identity_file_path
+            .as_deref()
+            .is_some_and(|path| path.trim().is_empty())
+        || request.connection.known_hosts_file_path.trim().is_empty()
+        || jump_host_is_blank
+        || request.path.trim().is_empty()
 }
 
 impl NativeKnownHostsVerifier {
@@ -1129,6 +1271,73 @@ fn run_sftp_transfer(request: SftpTransferRequest, progress: SftpProgressEmitter
     })
 }
 
+fn run_remote_path_list(request: RemotePathListRequest) -> anyhow::Result<Vec<RemotePathListEntry>> {
+    let runtime = Builder::new_current_thread().enable_all().build()?;
+    runtime.block_on(async move {
+        let known_hosts =
+            NativeKnownHostsVerifier::load(&request.connection.known_hosts_file_path)?;
+        let client_config = Arc::new(client::Config::default());
+        let auth = TransferAuthConfig {
+            password: request.connection.password.clone(),
+            identity_file: request.connection.identity_file_path.clone(),
+        };
+
+        let jump_session = if let Some(jump_host) = &request.connection.jump_host {
+            let jump_handler = TransferClientHandler {
+                host: jump_host.host.clone(),
+                port: jump_host.port,
+                known_hosts: known_hosts.clone(),
+            };
+
+            let mut jump = client::connect(
+                client_config.clone(),
+                (jump_host.host.as_str(), jump_host.port),
+                jump_handler,
+            )
+            .await?;
+
+            let jump_user = jump_host
+                .user
+                .as_deref()
+                .unwrap_or(request.connection.user.as_str());
+            authenticate_transfer(jump_user, &auth, &mut jump).await?;
+            Some(jump)
+        } else {
+            None
+        };
+
+        let target_handler = TransferClientHandler {
+            host: request.connection.host.clone(),
+            port: request.connection.port,
+            known_hosts: known_hosts.clone(),
+        };
+
+        let mut session = if let Some(jump) = &jump_session {
+            let stream = jump
+                .channel_open_direct_tcpip(
+                    request.connection.host.clone(),
+                    request.connection.port as u32,
+                    "127.0.0.1",
+                    0,
+                )
+                .await?
+                .into_stream();
+
+            client::connect_stream(client_config.clone(), stream, target_handler).await?
+        } else {
+            client::connect(
+                client_config.clone(),
+                (request.connection.host.as_str(), request.connection.port),
+                target_handler,
+            )
+            .await?
+        };
+
+        authenticate_transfer(&request.connection.user, &auth, &mut session).await?;
+        list_remote_directory(&mut session, &request.path).await
+    })
+}
+
 async fn authenticate_transfer<H>(
     user: &str,
     auth: &TransferAuthConfig,
@@ -1251,6 +1460,51 @@ where
 
     sftp.close().await?;
     Ok(())
+}
+
+async fn list_remote_directory<H>(
+    session: &mut client::Handle<H>,
+    remote_path: &str,
+) -> anyhow::Result<Vec<RemotePathListEntry>>
+where
+    H: client::Handler + Send + 'static,
+{
+    let channel = session.channel_open_session().await?;
+    channel.request_subsystem(true, "sftp").await?;
+    let sftp = SftpSession::new(channel.into_stream()).await?;
+
+    let home_directory = if remote_path.trim().starts_with('~') {
+        Some(
+            sftp.canonicalize(".")
+                .await
+                .map_err(|error| map_remote_transfer_error(".", error))?,
+        )
+    } else {
+        None
+    };
+    let expanded_remote_path = expand_remote_home_path(remote_path, home_directory.as_deref())?;
+    let mut entries = sftp
+        .read_dir(expanded_remote_path.clone())
+        .await
+        .map_err(|error| map_remote_transfer_error(&expanded_remote_path, error))?
+        .collect::<Vec<_>>();
+    entries.sort_by_key(|entry| entry.file_name());
+
+    let mapped = entries
+        .into_iter()
+        .map(|entry| {
+            let name = entry.file_name();
+            let full_path = join_remote_path(&expanded_remote_path, &name);
+            RemotePathListEntry {
+                name,
+                full_path,
+                is_directory: entry.metadata().is_dir(),
+            }
+        })
+        .collect();
+
+    sftp.close().await?;
+    Ok(mapped)
 }
 
 fn validate_supported_sftp_mode(transfer: &SftpTransferRequestBody) -> anyhow::Result<()> {
@@ -2283,6 +2537,30 @@ mod tests {
             "Native SFTP transfer mode 'sync/directory' is not implemented yet.",
             payload["message"]
         );
+
+        nova_ssh_string_free(response);
+    }
+
+    #[test]
+    fn sftp_list_directory_rejects_incomplete_requests() {
+        let request = CString::new(
+            r#"{"connection":{"host":"example.com","user":"nova","port":22,"password":"secret","knownHostsFilePath":"known_hosts.json"},"path":""}"#,
+        )
+        .unwrap();
+        let mut response = ptr::null_mut();
+
+        let rc = nova_ssh_sftp_list_directory(request.as_ptr(), &mut response);
+
+        assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, rc);
+        assert!(!response.is_null());
+
+        let response_json = unsafe { CStr::from_ptr(response) }.to_str().unwrap();
+        let payload: serde_json::Value = serde_json::from_str(response_json).unwrap();
+        assert_eq!("invalid-argument", payload["status"]);
+        assert!(payload["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("incomplete"));
 
         nova_ssh_string_free(response);
     }

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -1205,10 +1205,13 @@ where
             .await?;
         }
         ("upload", "file") => {
+            let remote_target =
+                resolve_upload_file_target(&sftp, Path::new(&transfer.local_path), &transfer.remote_path)
+                    .await?;
             upload_file_to_remote(
                 &sftp,
                 Path::new(&transfer.local_path),
-                &transfer.remote_path,
+                &remote_target,
                 cancellation_marker_path,
                 progress,
             )
@@ -1331,6 +1334,47 @@ async fn upload_file_to_remote(
     .await?;
     remote_file.shutdown().await?;
     Ok(())
+}
+
+async fn resolve_upload_file_target(
+    sftp: &SftpSession,
+    local_path: &Path,
+    remote_path: &str,
+) -> anyhow::Result<String> {
+    let local_name = local_path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| anyhow::anyhow!("Local file name is required for native SFTP upload."))?;
+    let home_directory = if remote_path.trim().starts_with('~') {
+        Some(
+            sftp.canonicalize(".")
+                .await
+                .map_err(|error| map_remote_transfer_error(".", error))?,
+        )
+    } else {
+        None
+    };
+    let expanded_remote_path = expand_remote_home_path(remote_path, home_directory.as_deref())?;
+    let remote_path_is_dir = if sftp
+        .try_exists(expanded_remote_path.clone())
+        .await
+        .map_err(|error| map_remote_transfer_error(&expanded_remote_path, error))?
+    {
+        sftp.metadata(expanded_remote_path.clone())
+            .await
+            .map_err(|error| map_remote_transfer_error(&expanded_remote_path, error))?
+            .is_dir()
+    } else {
+        false
+    };
+
+    resolve_upload_file_destination_path(
+        local_name,
+        remote_path,
+        home_directory.as_deref(),
+        remote_path_is_dir,
+    )
 }
 
 async fn download_directory_from_remote(
@@ -1593,6 +1637,45 @@ fn remote_basename(path: &str) -> anyhow::Result<String> {
         .find(|segment| !segment.is_empty())
         .map(str::to_owned)
         .ok_or_else(|| anyhow::anyhow!("Remote directory name is required for native SFTP transfer."))
+}
+
+fn resolve_upload_file_destination_path(
+    local_name: &str,
+    remote_path: &str,
+    home_directory: Option<&str>,
+    remote_path_is_dir: bool,
+) -> anyhow::Result<String> {
+    let trimmed_remote_path = remote_path.trim();
+    let expanded_remote_path = expand_remote_home_path(remote_path, home_directory)?;
+    if trimmed_remote_path == "~" || remote_path_is_dir {
+        return Ok(join_remote_path(&expanded_remote_path, local_name));
+    }
+
+    Ok(expanded_remote_path)
+}
+
+fn expand_remote_home_path(path: &str, home_directory: Option<&str>) -> anyhow::Result<String> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("Remote file path is required for native SFTP transfer.");
+    }
+
+    if trimmed == "~" {
+        return normalize_remote_directory_path(
+            home_directory
+                .ok_or_else(|| anyhow::anyhow!("Remote home directory is unavailable for native SFTP upload."))?,
+        );
+    }
+
+    if let Some(relative_path) = trimmed.strip_prefix("~/") {
+        let home_directory = normalize_remote_directory_path(
+            home_directory
+                .ok_or_else(|| anyhow::anyhow!("Remote home directory is unavailable for native SFTP upload."))?,
+        )?;
+        return Ok(join_remote_path(&home_directory, relative_path));
+    }
+
+    Ok(trimmed.to_owned())
 }
 
 fn normalize_remote_directory_path(path: &str) -> anyhow::Result<String> {
@@ -2432,6 +2515,24 @@ mod tests {
             assert!(pending_command.is_none());
             assert!(command_rx.recv().await.is_none());
         });
+    }
+
+    #[test]
+    fn resolve_upload_file_destination_path_appends_local_name_for_existing_directory() {
+        let resolved =
+            resolve_upload_file_destination_path("upload.txt", "/tmp", None, true)
+                .expect("directory target should resolve");
+
+        assert_eq!("/tmp/upload.txt", resolved);
+    }
+
+    #[test]
+    fn resolve_upload_file_destination_path_expands_home_directory_shortcut() {
+        let resolved =
+            resolve_upload_file_destination_path("upload.txt", "~", Some("/home/nova"), false)
+                .expect("home directory shortcut should resolve");
+
+        assert_eq!("/home/nova/upload.txt", resolved);
     }
 }
 

--- a/src/NovaTerminal.Cli/Program.cs
+++ b/src/NovaTerminal.Cli/Program.cs
@@ -1,9 +1,21 @@
 using NovaTerminal;
 
-if (VtReportCommand.IsSupportedCliMode(args))
+internal static class Program
 {
-    return VtReportCommand.Execute(args, Console.Out, Console.Error);
-}
+    [STAThread]
+    private static int Main(string[] args)
+    {
+        if (SshAskPassCommand.IsSupportedCliMode(args))
+        {
+            return SshAskPassCommand.Execute(args, Console.Out, Console.Error);
+        }
 
-Console.Error.WriteLine("Unsupported CLI mode.");
-return 2;
+        if (VtReportCommand.IsSupportedCliMode(args))
+        {
+            return VtReportCommand.Execute(args, Console.Out, Console.Error);
+        }
+
+        Console.Error.WriteLine("Unsupported CLI mode.");
+        return 2;
+    }
+}

--- a/src/NovaTerminal.Core/NovaTerminal.Core.csproj
+++ b/src/NovaTerminal.Core/NovaTerminal.Core.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="NovaTerminal.Core.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\NovaTerminal.Pty\NovaTerminal.Pty.csproj" />
   </ItemGroup>
 </Project>

--- a/src/NovaTerminal.Core/Ssh/Interactions/SshInteractionRequest.cs
+++ b/src/NovaTerminal.Core/Ssh/Interactions/SshInteractionRequest.cs
@@ -3,6 +3,7 @@ namespace NovaTerminal.Core.Ssh.Interactions;
 public sealed class SshInteractionRequest
 {
     public SshInteractionKind Kind { get; init; }
+    public Guid? SessionId { get; init; }
     public Guid? ProfileId { get; init; }
     public string ProfileName { get; init; } = string.Empty;
     public string ProfileUser { get; init; } = string.Empty;

--- a/src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs
@@ -3,6 +3,11 @@ namespace NovaTerminal.Core.Ssh.Native;
 public interface INativeSshInterop
 {
     IntPtr Connect(NativeSshConnectionOptions options);
+    void RunSftpTransfer(
+        NativeSshConnectionOptions connectionOptions,
+        NativeSftpTransferOptions transferOptions,
+        Action<NativeSftpTransferProgress>? progress,
+        CancellationToken cancellationToken);
     NativeSshEvent? PollEvent(IntPtr sessionHandle);
     void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data);
     void Resize(IntPtr sessionHandle, int cols, int rows);

--- a/src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs
@@ -1,4 +1,11 @@
+using System.Runtime.InteropServices;
+
 namespace NovaTerminal.Core.Ssh.Native;
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+public delegate void NativeSftpTransferProgressCallback(
+    IntPtr context,
+    NativeSftpTransferProgressCallbackData progress);
 
 public interface INativeSshInterop
 {

--- a/src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs
@@ -3,6 +3,10 @@ namespace NovaTerminal.Core.Ssh.Native;
 public interface INativeSshInterop
 {
     IntPtr Connect(NativeSshConnectionOptions options);
+    IReadOnlyList<NativeRemotePathEntry> ListRemoteDirectory(
+        NativeSshConnectionOptions connectionOptions,
+        string remotePath,
+        CancellationToken cancellationToken);
     void RunSftpTransfer(
         NativeSshConnectionOptions connectionOptions,
         NativeSftpTransferOptions transferOptions,

--- a/src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs
@@ -1,11 +1,4 @@
-using System.Runtime.InteropServices;
-
 namespace NovaTerminal.Core.Ssh.Native;
-
-[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-internal delegate void NativeSftpTransferProgressCallback(
-    IntPtr context,
-    NativeSftpTransferProgressCallbackData progress);
 
 public interface INativeSshInterop
 {

--- a/src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs
@@ -3,6 +3,8 @@ namespace NovaTerminal.Core.Ssh.Native;
 public interface INativeSshInterop
 {
     IntPtr Connect(NativeSshConnectionOptions options);
+
+    // Blocking FFI/network call. App/UI-facing services must offload this work before awaiting it.
     IReadOnlyList<NativeRemotePathEntry> ListRemoteDirectory(
         NativeSshConnectionOptions connectionOptions,
         string remotePath,

--- a/src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/INativeSshInterop.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 namespace NovaTerminal.Core.Ssh.Native;
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-public delegate void NativeSftpTransferProgressCallback(
+internal delegate void NativeSftpTransferProgressCallback(
     IntPtr context,
     NativeSftpTransferProgressCallbackData progress);
 

--- a/src/NovaTerminal.Core/Ssh/Native/NativeRemotePathModels.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeRemotePathModels.cs
@@ -1,0 +1,15 @@
+namespace NovaTerminal.Core.Ssh.Native;
+
+public sealed class NativeRemotePathEntry
+{
+    public NativeRemotePathEntry(string name, string fullPath, bool isDirectory)
+    {
+        Name = name;
+        FullPath = fullPath;
+        IsDirectory = isDirectory;
+    }
+
+    public string Name { get; }
+    public string FullPath { get; }
+    public bool IsDirectory { get; }
+}

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSftpTransferModels.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSftpTransferModels.cs
@@ -53,7 +53,7 @@ public sealed class NativeSftpTransferProgress
 }
 
 [StructLayout(LayoutKind.Sequential)]
-public struct NativeSftpTransferProgressCallbackData
+internal struct NativeSftpTransferProgressCallbackData
 {
     public ulong BytesDone;
     public ulong BytesTotal;

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSftpTransferModels.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSftpTransferModels.cs
@@ -1,0 +1,51 @@
+namespace NovaTerminal.Core.Ssh.Native;
+
+public enum NativeSftpTransferDirection
+{
+    Upload,
+    Download
+}
+
+public enum NativeSftpTransferKind
+{
+    File,
+    Directory
+}
+
+public sealed class NativeSftpTransferOptions
+{
+    public NativeSftpTransferDirection Direction { get; init; }
+    public NativeSftpTransferKind Kind { get; init; }
+    public string? LocalPath { get; init; }
+    public string? RemotePath { get; init; }
+
+    public void Validate()
+    {
+        if (!Enum.IsDefined(Direction))
+        {
+            throw new ArgumentOutOfRangeException(nameof(Direction), "Transfer direction must be a defined value.");
+        }
+
+        if (!Enum.IsDefined(Kind))
+        {
+            throw new ArgumentOutOfRangeException(nameof(Kind), "Transfer kind must be a defined value.");
+        }
+
+        if (string.IsNullOrWhiteSpace(LocalPath))
+        {
+            throw new ArgumentException("A local path is required for native SFTP transfers.", nameof(LocalPath));
+        }
+
+        if (string.IsNullOrWhiteSpace(RemotePath))
+        {
+            throw new ArgumentException("A remote path is required for native SFTP transfers.", nameof(RemotePath));
+        }
+    }
+}
+
+public sealed class NativeSftpTransferProgress
+{
+    public long BytesDone { get; init; }
+    public long BytesTotal { get; init; }
+    public string? CurrentPath { get; init; }
+}

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSftpTransferModels.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSftpTransferModels.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 namespace NovaTerminal.Core.Ssh.Native;
 
 public enum NativeSftpTransferDirection
@@ -48,4 +50,12 @@ public sealed class NativeSftpTransferProgress
     public long BytesDone { get; init; }
     public long BytesTotal { get; init; }
     public string? CurrentPath { get; init; }
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public struct NativeSftpTransferProgressCallbackData
+{
+    public ulong BytesDone { get; init; }
+    public ulong BytesTotal { get; init; }
+    public IntPtr CurrentPath { get; init; }
 }

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSftpTransferModels.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSftpTransferModels.cs
@@ -55,7 +55,7 @@ public sealed class NativeSftpTransferProgress
 [StructLayout(LayoutKind.Sequential)]
 public struct NativeSftpTransferProgressCallbackData
 {
-    public ulong BytesDone { get; init; }
-    public ulong BytesTotal { get; init; }
-    public IntPtr CurrentPath { get; init; }
+    public ulong BytesDone;
+    public ulong BytesTotal;
+    public IntPtr CurrentPath;
 }

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshConnectionOptions.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshConnectionOptions.cs
@@ -13,7 +13,9 @@ public sealed class NativeSshConnectionOptions
     public int Cols { get; init; } = 120;
     public int Rows { get; init; } = 30;
     public string Term { get; init; } = "xterm-256color";
+    public string? Password { get; init; }
     public string? IdentityFilePath { get; init; }
+    public string? KnownHostsFilePath { get; init; }
     public SshJumpHop? JumpHost { get; init; }
     public int KeepAliveIntervalSeconds { get; init; } = DefaultKeepAliveIntervalSeconds;
     public int KeepAliveCountMax { get; init; } = DefaultKeepAliveCountMax;

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
@@ -136,6 +136,8 @@ public sealed class NativeSshInterop : INativeSshInterop
             requestPtr = Marshal.StringToCoTaskMemUTF8(requestJson);
             if (progress is not null)
             {
+                // Native SFTP transfer callbacks are expected to stay synchronous within the
+                // nova_ssh_sftp_transfer call, so this GCHandle only needs to live for that invocation.
                 progressStateHandle = GCHandle.Alloc(new NativeSftpTransferProgressCallbackState(progress));
             }
 

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using System.Text.Json;
 
 namespace NovaTerminal.Core.Ssh.Native;
 
@@ -10,6 +11,7 @@ public sealed class NativeSshInterop : INativeSshInterop
     private const int ResultInvalidArgument = -1;
     private const int ResultBufferTooSmall = -2;
     private const int ResultClosed = -3;
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
     public IntPtr Connect(NativeSshConnectionOptions options)
     {
@@ -92,10 +94,34 @@ public sealed class NativeSshInterop : INativeSshInterop
         ArgumentNullException.ThrowIfNull(connectionOptions);
         ArgumentNullException.ThrowIfNull(transferOptions);
 
+        ValidateConnectionOptions(connectionOptions);
         transferOptions.Validate();
         cancellationToken.ThrowIfCancellationRequested();
 
-        throw new NotImplementedException("Native SFTP transfer is not implemented yet.");
+        SftpTransferRequest request = SftpTransferRequest.From(connectionOptions, transferOptions);
+        string requestJson = JsonSerializer.Serialize(request, JsonOptions);
+
+        IntPtr requestPtr = IntPtr.Zero;
+        IntPtr responsePtr = IntPtr.Zero;
+
+        try
+        {
+            requestPtr = Marshal.StringToCoTaskMemUTF8(requestJson);
+            int rc = NativeMethods.nova_ssh_sftp_transfer(requestPtr, out responsePtr);
+            string? responseJson = TakeNativeUtf8AndFree(ref responsePtr);
+            if (rc != ResultOk)
+            {
+                throw new InvalidOperationException(BuildSftpTransferFailureMessage(rc, responseJson));
+            }
+        }
+        finally
+        {
+            FreeUtf8(requestPtr);
+            if (responsePtr != IntPtr.Zero)
+            {
+                NativeMethods.nova_ssh_string_free(responsePtr);
+            }
+        }
     }
 
     public NativeSshEvent? PollEvent(IntPtr sessionHandle)
@@ -298,6 +324,78 @@ public sealed class NativeSshInterop : INativeSshInterop
         }
     }
 
+    private static void ValidateConnectionOptions(NativeSshConnectionOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.Host))
+        {
+            throw new ArgumentException("A host is required for native SSH operations.", nameof(options.Host));
+        }
+
+        if (string.IsNullOrWhiteSpace(options.User))
+        {
+            throw new ArgumentException("A user is required for native SSH operations.", nameof(options.User));
+        }
+
+        if (options.Port is < 1 or > 65535)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options.Port), "The SSH port must be between 1 and 65535.");
+        }
+
+        if (options.JumpHost is { } jumpHost)
+        {
+            if (string.IsNullOrWhiteSpace(jumpHost.Host))
+            {
+                throw new ArgumentException("A jump-host name is required when jump-host options are supplied.", nameof(options.JumpHost));
+            }
+
+            if (jumpHost.Port is < 1 or > 65535)
+            {
+                throw new ArgumentOutOfRangeException(nameof(options.JumpHost), "The jump-host port must be between 1 and 65535.");
+            }
+        }
+    }
+
+    private static string BuildSftpTransferFailureMessage(int resultCode, string? responseJson)
+    {
+        string message = $"Native SFTP transfer failed with result {resultCode}.";
+        if (string.IsNullOrWhiteSpace(responseJson))
+        {
+            return message;
+        }
+
+        try
+        {
+            NativeSftpTransferResponse? response = JsonSerializer.Deserialize<NativeSftpTransferResponse>(responseJson, JsonOptions);
+            if (!string.IsNullOrWhiteSpace(response?.Message))
+            {
+                return $"{message} {response.Message}";
+            }
+        }
+        catch (JsonException)
+        {
+        }
+
+        return $"{message} {responseJson}";
+    }
+
+    private static string? TakeNativeUtf8AndFree(ref IntPtr pointer)
+    {
+        if (pointer == IntPtr.Zero)
+        {
+            return null;
+        }
+
+        try
+        {
+            return Marshal.PtrToStringUTF8(pointer);
+        }
+        finally
+        {
+            NativeMethods.nova_ssh_string_free(pointer);
+            pointer = IntPtr.Zero;
+        }
+    }
+
     [StructLayout(LayoutKind.Sequential)]
     private struct NativeConnectArgs
     {
@@ -333,6 +431,53 @@ public sealed class NativeSshInterop : INativeSshInterop
         public ushort OriginatorPort;
     }
 
+    private sealed record SftpTransferRequest(SftpConnectionRequest Connection, SftpTransferRequestBody Transfer)
+    {
+        public static SftpTransferRequest From(NativeSshConnectionOptions connectionOptions, NativeSftpTransferOptions transferOptions)
+        {
+            SftpJumpHostRequest? jumpHost = connectionOptions.JumpHost is null
+                ? null
+                : new SftpJumpHostRequest(
+                    connectionOptions.JumpHost.Host,
+                    string.IsNullOrWhiteSpace(connectionOptions.JumpHost.User) ? null : connectionOptions.JumpHost.User,
+                    connectionOptions.JumpHost.Port);
+
+            return new SftpTransferRequest(
+                new SftpConnectionRequest(
+                    connectionOptions.Host,
+                    connectionOptions.User,
+                    connectionOptions.Port,
+                    string.IsNullOrWhiteSpace(connectionOptions.IdentityFilePath) ? null : connectionOptions.IdentityFilePath,
+                    jumpHost),
+                new SftpTransferRequestBody(
+                    transferOptions.Direction.ToString().ToLowerInvariant(),
+                    transferOptions.Kind.ToString().ToLowerInvariant(),
+                    transferOptions.LocalPath!,
+                    transferOptions.RemotePath!));
+        }
+    }
+
+    private sealed record SftpConnectionRequest(
+        string Host,
+        string User,
+        int Port,
+        string? IdentityFilePath,
+        SftpJumpHostRequest? JumpHost);
+
+    private sealed record SftpJumpHostRequest(string Host, string? User, int Port);
+
+    private sealed record SftpTransferRequestBody(
+        string Direction,
+        string Kind,
+        string LocalPath,
+        string RemotePath);
+
+    private sealed class NativeSftpTransferResponse
+    {
+        public string? Status { get; init; }
+        public string? Message { get; init; }
+    }
+
     private static class NativeMethods
     {
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_connect")]
@@ -364,5 +509,11 @@ public sealed class NativeSshInterop : INativeSshInterop
 
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_submit_response")]
         public static extern int nova_ssh_submit_response(IntPtr session, uint responseKind, byte[] data, nuint dataLength);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_sftp_transfer")]
+        public static extern int nova_ssh_sftp_transfer(IntPtr requestJson, out IntPtr responseJson);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_string_free")]
+        public static extern void nova_ssh_string_free(IntPtr value);
     }
 }

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
@@ -614,6 +614,11 @@ public sealed class NativeSshInterop : INativeSshInterop
         public string? Message { get; init; }
     }
 
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate void NativeSftpTransferProgressCallback(
+        IntPtr context,
+        NativeSftpTransferProgressCallbackData progress);
+
     private sealed class NativeSftpTransferProgressCallbackState
     {
         public NativeSftpTransferProgressCallbackState(Action<NativeSftpTransferProgress> progress)

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
@@ -13,6 +13,9 @@ public sealed class NativeSshInterop : INativeSshInterop
     private const int ResultClosed = -3;
     private const int ResultCanceled = -6;
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private static readonly NativeSftpTransferProgressCallback SftpTransferProgressCallback = OnNativeSftpTransferProgress;
+    private static readonly IntPtr SftpTransferProgressCallbackPointer =
+        Marshal.GetFunctionPointerForDelegate(SftpTransferProgressCallback);
 
     public IntPtr Connect(NativeSshConnectionOptions options)
     {
@@ -105,6 +108,7 @@ public sealed class NativeSshInterop : INativeSshInterop
 
         IntPtr requestPtr = IntPtr.Zero;
         IntPtr responsePtr = IntPtr.Zero;
+        GCHandle progressStateHandle = default;
         string cancellationMarkerPath = Path.Combine(
             Path.GetTempPath(),
             $"nova-sftp-cancel-{Guid.NewGuid():N}.signal");
@@ -130,7 +134,16 @@ public sealed class NativeSshInterop : INativeSshInterop
             };
             requestJson = JsonSerializer.Serialize(request, JsonOptions);
             requestPtr = Marshal.StringToCoTaskMemUTF8(requestJson);
-            int rc = NativeMethods.nova_ssh_sftp_transfer(requestPtr, out responsePtr);
+            if (progress is not null)
+            {
+                progressStateHandle = GCHandle.Alloc(new NativeSftpTransferProgressCallbackState(progress));
+            }
+
+            int rc = NativeMethods.nova_ssh_sftp_transfer(
+                requestPtr,
+                progressStateHandle.IsAllocated ? SftpTransferProgressCallbackPointer : IntPtr.Zero,
+                progressStateHandle.IsAllocated ? GCHandle.ToIntPtr(progressStateHandle) : IntPtr.Zero,
+                out responsePtr);
             string? responseJson = TakeNativeUtf8AndFree(ref responsePtr);
             if (rc == ResultCanceled)
             {
@@ -144,6 +157,11 @@ public sealed class NativeSshInterop : INativeSshInterop
         }
         finally
         {
+            if (progressStateHandle.IsAllocated)
+            {
+                progressStateHandle.Free();
+            }
+
             FreeUtf8(requestPtr);
             if (responsePtr != IntPtr.Zero)
             {
@@ -355,12 +373,76 @@ public sealed class NativeSshInterop : INativeSshInterop
         throw new InvalidOperationException($"Native SSH submit response failed with result {rc}.");
     }
 
+    internal static void InvokeManagedProgressCallbackForTest(
+        Action<NativeSftpTransferProgress> progress,
+        ulong bytesDone,
+        ulong bytesTotal,
+        string currentPath)
+    {
+        ArgumentNullException.ThrowIfNull(progress);
+
+        IntPtr currentPathPtr = IntPtr.Zero;
+
+        try
+        {
+            currentPathPtr = Marshal.StringToCoTaskMemUTF8(currentPath);
+            InvokeManagedProgressCallback(
+                progress,
+                new NativeSftpTransferProgressCallbackData
+                {
+                    BytesDone = bytesDone,
+                    BytesTotal = bytesTotal,
+                    CurrentPath = currentPathPtr
+                });
+        }
+        finally
+        {
+            FreeUtf8(currentPathPtr);
+        }
+    }
+
     private static void FreeUtf8(IntPtr pointer)
     {
         if (pointer != IntPtr.Zero)
         {
             Marshal.FreeCoTaskMem(pointer);
         }
+    }
+
+    private static void OnNativeSftpTransferProgress(IntPtr context, NativeSftpTransferProgressCallbackData progress)
+    {
+        if (context == IntPtr.Zero)
+        {
+            return;
+        }
+
+        GCHandle handle = GCHandle.FromIntPtr(context);
+        if (handle.Target is not NativeSftpTransferProgressCallbackState state)
+        {
+            return;
+        }
+
+        try
+        {
+            InvokeManagedProgressCallback(state.Progress, progress);
+        }
+        catch
+        {
+        }
+    }
+
+    private static void InvokeManagedProgressCallback(
+        Action<NativeSftpTransferProgress> progress,
+        NativeSftpTransferProgressCallbackData nativeProgress)
+    {
+        progress(new NativeSftpTransferProgress
+        {
+            BytesDone = checked((long)nativeProgress.BytesDone),
+            BytesTotal = checked((long)nativeProgress.BytesTotal),
+            CurrentPath = nativeProgress.CurrentPath == IntPtr.Zero
+                ? null
+                : Marshal.PtrToStringUTF8(nativeProgress.CurrentPath)
+        });
     }
 
     private static void ValidateConnectionOptions(NativeSshConnectionOptions options)
@@ -532,6 +614,16 @@ public sealed class NativeSshInterop : INativeSshInterop
         public string? Message { get; init; }
     }
 
+    private sealed class NativeSftpTransferProgressCallbackState
+    {
+        public NativeSftpTransferProgressCallbackState(Action<NativeSftpTransferProgress> progress)
+        {
+            Progress = progress;
+        }
+
+        public Action<NativeSftpTransferProgress> Progress { get; }
+    }
+
     private static class NativeMethods
     {
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_connect")]
@@ -565,7 +657,11 @@ public sealed class NativeSshInterop : INativeSshInterop
         public static extern int nova_ssh_submit_response(IntPtr session, uint responseKind, byte[] data, nuint dataLength);
 
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_sftp_transfer")]
-        public static extern int nova_ssh_sftp_transfer(IntPtr requestJson, out IntPtr responseJson);
+        public static extern int nova_ssh_sftp_transfer(
+            IntPtr requestJson,
+            IntPtr progressCallback,
+            IntPtr progressContext,
+            out IntPtr responseJson);
 
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_string_free")]
         public static extern void nova_ssh_string_free(IntPtr value);

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
@@ -83,6 +83,21 @@ public sealed class NativeSshInterop : INativeSshInterop
         }
     }
 
+    public void RunSftpTransfer(
+        NativeSshConnectionOptions connectionOptions,
+        NativeSftpTransferOptions transferOptions,
+        Action<NativeSftpTransferProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(connectionOptions);
+        ArgumentNullException.ThrowIfNull(transferOptions);
+
+        transferOptions.Validate();
+        cancellationToken.ThrowIfCancellationRequested();
+
+        throw new NotImplementedException("Native SFTP transfer is not implemented yet.");
+    }
+
     public NativeSshEvent? PollEvent(IntPtr sessionHandle)
     {
         if (sessionHandle == IntPtr.Zero)

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
@@ -11,6 +11,7 @@ public sealed class NativeSshInterop : INativeSshInterop
     private const int ResultInvalidArgument = -1;
     private const int ResultBufferTooSmall = -2;
     private const int ResultClosed = -3;
+    private const int ResultCanceled = -6;
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
     public IntPtr Connect(NativeSshConnectionOptions options)
@@ -104,12 +105,38 @@ public sealed class NativeSshInterop : INativeSshInterop
 
         IntPtr requestPtr = IntPtr.Zero;
         IntPtr responsePtr = IntPtr.Zero;
+        string cancellationMarkerPath = Path.Combine(
+            Path.GetTempPath(),
+            $"nova-sftp-cancel-{Guid.NewGuid():N}.signal");
+        using CancellationTokenRegistration cancellationRegistration = cancellationToken.Register(() =>
+        {
+            try
+            {
+                File.WriteAllText(cancellationMarkerPath, string.Empty);
+            }
+            catch
+            {
+            }
+        });
 
         try
         {
+            request = request with
+            {
+                Transfer = request.Transfer with
+                {
+                    CancellationMarkerPath = cancellationMarkerPath
+                }
+            };
+            requestJson = JsonSerializer.Serialize(request, JsonOptions);
             requestPtr = Marshal.StringToCoTaskMemUTF8(requestJson);
             int rc = NativeMethods.nova_ssh_sftp_transfer(requestPtr, out responsePtr);
             string? responseJson = TakeNativeUtf8AndFree(ref responsePtr);
+            if (rc == ResultCanceled)
+            {
+                throw new OperationCanceledException(BuildSftpTransferFailureMessage(rc, responseJson), cancellationToken);
+            }
+
             if (rc != ResultOk)
             {
                 throw new InvalidOperationException(BuildSftpTransferFailureMessage(rc, responseJson));
@@ -121,6 +148,17 @@ public sealed class NativeSshInterop : INativeSshInterop
             if (responsePtr != IntPtr.Zero)
             {
                 NativeMethods.nova_ssh_string_free(responsePtr);
+            }
+
+            try
+            {
+                if (File.Exists(cancellationMarkerPath))
+                {
+                    File.Delete(cancellationMarkerPath);
+                }
+            }
+            catch
+            {
             }
         }
     }
@@ -485,7 +523,8 @@ public sealed class NativeSshInterop : INativeSshInterop
         string Direction,
         string Kind,
         string LocalPath,
-        string RemotePath);
+        string RemotePath,
+        string? CancellationMarkerPath = null);
 
     private sealed class NativeSftpTransferResponse
     {

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
@@ -1,9 +1,10 @@
 using System.Runtime.InteropServices;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace NovaTerminal.Core.Ssh.Native;
 
-public sealed class NativeSshInterop : INativeSshInterop
+public sealed partial class NativeSshInterop : INativeSshInterop
 {
     private const string LibName = "rusty_ssh";
     private const int ResultOk = 0;
@@ -12,7 +13,6 @@ public sealed class NativeSshInterop : INativeSshInterop
     private const int ResultBufferTooSmall = -2;
     private const int ResultClosed = -3;
     private const int ResultCanceled = -6;
-    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
     private static readonly NativeSftpTransferProgressCallback SftpTransferProgressCallback = OnNativeSftpTransferProgress;
     private static readonly IntPtr SftpTransferProgressCallbackPointer =
         Marshal.GetFunctionPointerForDelegate(SftpTransferProgressCallback);
@@ -104,7 +104,7 @@ public sealed class NativeSshInterop : INativeSshInterop
         cancellationToken.ThrowIfCancellationRequested();
 
         SftpTransferRequest request = SftpTransferRequest.From(connectionOptions, transferOptions);
-        string requestJson = JsonSerializer.Serialize(request, JsonOptions);
+        string requestJson = SerializeSftpTransferRequest(request);
 
         IntPtr requestPtr = IntPtr.Zero;
         IntPtr responsePtr = IntPtr.Zero;
@@ -132,7 +132,7 @@ public sealed class NativeSshInterop : INativeSshInterop
                     CancellationMarkerPath = cancellationMarkerPath
                 }
             };
-            requestJson = JsonSerializer.Serialize(request, JsonOptions);
+            requestJson = SerializeSftpTransferRequest(request);
             requestPtr = Marshal.StringToCoTaskMemUTF8(requestJson);
             if (progress is not null)
             {
@@ -498,7 +498,9 @@ public sealed class NativeSshInterop : INativeSshInterop
 
         try
         {
-            NativeSftpTransferResponse? response = JsonSerializer.Deserialize<NativeSftpTransferResponse>(responseJson, JsonOptions);
+            NativeSftpTransferResponse? response = JsonSerializer.Deserialize(
+                responseJson,
+                NativeSshTransferJsonContext.Default.NativeSftpTransferResponse);
             if (!string.IsNullOrWhiteSpace(response?.Message))
             {
                 return $"{message} {response.Message}";
@@ -509,6 +511,35 @@ public sealed class NativeSshInterop : INativeSshInterop
         }
 
         return $"{message} {responseJson}";
+    }
+
+    internal static string SerializeSftpTransferRequestForTests(
+        NativeSshConnectionOptions connectionOptions,
+        NativeSftpTransferOptions transferOptions)
+    {
+        ArgumentNullException.ThrowIfNull(connectionOptions);
+        ArgumentNullException.ThrowIfNull(transferOptions);
+
+        return SerializeSftpTransferRequest(SftpTransferRequest.From(connectionOptions, transferOptions));
+    }
+
+    internal static string? DeserializeSftpTransferResponseMessageForTests(string responseJson)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(responseJson);
+
+        NativeSftpTransferResponse? response = JsonSerializer.Deserialize(
+            responseJson,
+            NativeSshTransferJsonContext.Default.NativeSftpTransferResponse);
+        return response?.Message;
+    }
+
+    private static string SerializeSftpTransferRequest(SftpTransferRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        return JsonSerializer.Serialize(
+            request,
+            NativeSshTransferJsonContext.Default.SftpTransferRequest);
     }
 
     private static string? TakeNativeUtf8AndFree(ref IntPtr pointer)
@@ -614,6 +645,16 @@ public sealed class NativeSshInterop : INativeSshInterop
     {
         public string? Status { get; init; }
         public string? Message { get; init; }
+    }
+
+    [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+    [JsonSerializable(typeof(SftpTransferRequest))]
+    [JsonSerializable(typeof(SftpConnectionRequest))]
+    [JsonSerializable(typeof(SftpJumpHostRequest))]
+    [JsonSerializable(typeof(SftpTransferRequestBody))]
+    [JsonSerializable(typeof(NativeSftpTransferResponse))]
+    private partial class NativeSshTransferJsonContext : JsonSerializerContext
+    {
     }
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -179,6 +181,56 @@ public sealed partial class NativeSshInterop : INativeSshInterop
             }
             catch
             {
+            }
+        }
+    }
+
+    public IReadOnlyList<NativeRemotePathEntry> ListRemoteDirectory(
+        NativeSshConnectionOptions connectionOptions,
+        string remotePath,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(connectionOptions);
+        ArgumentException.ThrowIfNullOrWhiteSpace(remotePath);
+
+        ValidateConnectionOptions(connectionOptions);
+        ValidateSftpConnectionOptions(connectionOptions);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        RemotePathListRequest request = RemotePathListRequest.From(connectionOptions, remotePath);
+        string requestJson = SerializeRemotePathListRequest(request);
+
+        IntPtr requestPtr = IntPtr.Zero;
+        IntPtr responsePtr = IntPtr.Zero;
+
+        try
+        {
+            requestPtr = Marshal.StringToCoTaskMemUTF8(requestJson);
+            int rc = NativeMethods.nova_ssh_sftp_list_directory(requestPtr, out responsePtr);
+            string? responseJson = TakeNativeUtf8AndFree(ref responsePtr);
+            if (rc == ResultCanceled)
+            {
+                throw new OperationCanceledException(BuildRemotePathListFailureMessage(rc, responseJson), cancellationToken);
+            }
+
+            if (rc != ResultOk)
+            {
+                throw new InvalidOperationException(BuildRemotePathListFailureMessage(rc, responseJson));
+            }
+
+            if (string.IsNullOrWhiteSpace(responseJson))
+            {
+                return [];
+            }
+
+            return DeserializeRemotePathListResponse(responseJson);
+        }
+        finally
+        {
+            FreeUtf8(requestPtr);
+            if (responsePtr != IntPtr.Zero)
+            {
+                NativeMethods.nova_ssh_string_free(responsePtr);
             }
         }
     }
@@ -513,6 +565,31 @@ public sealed partial class NativeSshInterop : INativeSshInterop
         return $"{message} {responseJson}";
     }
 
+    private static string BuildRemotePathListFailureMessage(int resultCode, string? responseJson)
+    {
+        string message = $"Native remote path listing failed with result {resultCode}.";
+        if (string.IsNullOrWhiteSpace(responseJson))
+        {
+            return message;
+        }
+
+        try
+        {
+            RemotePathListResponse? response = JsonSerializer.Deserialize(
+                responseJson,
+                NativeSshTransferJsonContext.Default.RemotePathListResponse);
+            if (!string.IsNullOrWhiteSpace(response?.Message))
+            {
+                return $"{message} {response.Message}";
+            }
+        }
+        catch (JsonException)
+        {
+        }
+
+        return $"{message} {responseJson}";
+    }
+
     internal static string SerializeSftpTransferRequestForTests(
         NativeSshConnectionOptions connectionOptions,
         NativeSftpTransferOptions transferOptions)
@@ -521,6 +598,16 @@ public sealed partial class NativeSshInterop : INativeSshInterop
         ArgumentNullException.ThrowIfNull(transferOptions);
 
         return SerializeSftpTransferRequest(SftpTransferRequest.From(connectionOptions, transferOptions));
+    }
+
+    internal static string SerializeRemotePathListRequestForTests(
+        NativeSshConnectionOptions connectionOptions,
+        string remotePath)
+    {
+        ArgumentNullException.ThrowIfNull(connectionOptions);
+        ArgumentException.ThrowIfNullOrWhiteSpace(remotePath);
+
+        return SerializeRemotePathListRequest(RemotePathListRequest.From(connectionOptions, remotePath));
     }
 
     internal static string? DeserializeSftpTransferResponseMessageForTests(string responseJson)
@@ -533,6 +620,12 @@ public sealed partial class NativeSshInterop : INativeSshInterop
         return response?.Message;
     }
 
+    internal static IReadOnlyList<NativeRemotePathEntry> DeserializeRemotePathListResponseForTests(string responseJson)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(responseJson);
+        return DeserializeRemotePathListResponse(responseJson);
+    }
+
     private static string SerializeSftpTransferRequest(SftpTransferRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -540,6 +633,26 @@ public sealed partial class NativeSshInterop : INativeSshInterop
         return JsonSerializer.Serialize(
             request,
             NativeSshTransferJsonContext.Default.SftpTransferRequest);
+    }
+
+    private static string SerializeRemotePathListRequest(RemotePathListRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        return JsonSerializer.Serialize(
+            request,
+            NativeSshTransferJsonContext.Default.RemotePathListRequest);
+    }
+
+    private static IReadOnlyList<NativeRemotePathEntry> DeserializeRemotePathListResponse(string responseJson)
+    {
+        RemotePathListResponse? response = JsonSerializer.Deserialize(
+            responseJson,
+            NativeSshTransferJsonContext.Default.RemotePathListResponse);
+
+        return response?.Entries?
+            .Select(entry => new NativeRemotePathEntry(entry.Name, entry.FullPath, entry.IsDirectory))
+            .ToList() ?? [];
     }
 
     private static string? TakeNativeUtf8AndFree(ref IntPtr pointer)
@@ -634,6 +747,30 @@ public sealed partial class NativeSshInterop : INativeSshInterop
 
     private sealed record SftpJumpHostRequest(string Host, string? User, int Port);
 
+    private sealed record RemotePathListRequest(SftpConnectionRequest Connection, string Path)
+    {
+        public static RemotePathListRequest From(NativeSshConnectionOptions connectionOptions, string remotePath)
+        {
+            SftpJumpHostRequest? jumpHost = connectionOptions.JumpHost is null
+                ? null
+                : new SftpJumpHostRequest(
+                    connectionOptions.JumpHost.Host,
+                    string.IsNullOrWhiteSpace(connectionOptions.JumpHost.User) ? null : connectionOptions.JumpHost.User,
+                    connectionOptions.JumpHost.Port);
+
+            return new RemotePathListRequest(
+                new SftpConnectionRequest(
+                    connectionOptions.Host,
+                    connectionOptions.User,
+                    connectionOptions.Port,
+                    string.IsNullOrWhiteSpace(connectionOptions.Password) ? null : connectionOptions.Password,
+                    string.IsNullOrWhiteSpace(connectionOptions.IdentityFilePath) ? null : connectionOptions.IdentityFilePath,
+                    connectionOptions.KnownHostsFilePath!,
+                    jumpHost),
+                remotePath);
+        }
+    }
+
     private sealed record SftpTransferRequestBody(
         string Direction,
         string Kind,
@@ -647,12 +784,29 @@ public sealed partial class NativeSshInterop : INativeSshInterop
         public string? Message { get; init; }
     }
 
+    private sealed class RemotePathListResponse
+    {
+        public List<RemotePathListResponseEntry>? Entries { get; init; }
+        public string? Status { get; init; }
+        public string? Message { get; init; }
+    }
+
+    private sealed class RemotePathListResponseEntry
+    {
+        public string Name { get; init; } = string.Empty;
+        public string FullPath { get; init; } = string.Empty;
+        public bool IsDirectory { get; init; }
+    }
+
     [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
     [JsonSerializable(typeof(SftpTransferRequest))]
     [JsonSerializable(typeof(SftpConnectionRequest))]
     [JsonSerializable(typeof(SftpJumpHostRequest))]
+    [JsonSerializable(typeof(RemotePathListRequest))]
     [JsonSerializable(typeof(SftpTransferRequestBody))]
     [JsonSerializable(typeof(NativeSftpTransferResponse))]
+    [JsonSerializable(typeof(RemotePathListResponse))]
+    [JsonSerializable(typeof(RemotePathListResponseEntry))]
     private partial class NativeSshTransferJsonContext : JsonSerializerContext
     {
     }
@@ -685,6 +839,9 @@ public sealed partial class NativeSshInterop : INativeSshInterop
 
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_resize")]
         public static extern int nova_ssh_resize(IntPtr session, ushort cols, ushort rows);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_sftp_list_directory")]
+        public static extern int nova_ssh_sftp_list_directory(IntPtr requestJson, out IntPtr responseJson);
 
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_open_direct_tcpip")]
         public static extern int nova_ssh_open_direct_tcpip(IntPtr session, in NativeDirectTcpIpOpenArgs args);

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
@@ -95,6 +95,7 @@ public sealed class NativeSshInterop : INativeSshInterop
         ArgumentNullException.ThrowIfNull(transferOptions);
 
         ValidateConnectionOptions(connectionOptions);
+        ValidateSftpConnectionOptions(connectionOptions);
         transferOptions.Validate();
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -355,6 +356,16 @@ public sealed class NativeSshInterop : INativeSshInterop
         }
     }
 
+    private static void ValidateSftpConnectionOptions(NativeSshConnectionOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.KnownHostsFilePath))
+        {
+            throw new ArgumentException(
+                "A known-hosts store path is required for native SFTP transfers.",
+                nameof(options.KnownHostsFilePath));
+        }
+    }
+
     private static string BuildSftpTransferFailureMessage(int resultCode, string? responseJson)
     {
         string message = $"Native SFTP transfer failed with result {resultCode}.";
@@ -447,7 +458,9 @@ public sealed class NativeSshInterop : INativeSshInterop
                     connectionOptions.Host,
                     connectionOptions.User,
                     connectionOptions.Port,
+                    string.IsNullOrWhiteSpace(connectionOptions.Password) ? null : connectionOptions.Password,
                     string.IsNullOrWhiteSpace(connectionOptions.IdentityFilePath) ? null : connectionOptions.IdentityFilePath,
+                    connectionOptions.KnownHostsFilePath!,
                     jumpHost),
                 new SftpTransferRequestBody(
                     transferOptions.Direction.ToString().ToLowerInvariant(),
@@ -461,7 +474,9 @@ public sealed class NativeSshInterop : INativeSshInterop
         string Host,
         string User,
         int Port,
+        string? Password,
         string? IdentityFilePath,
+        string KnownHostsFilePath,
         SftpJumpHostRequest? JumpHost);
 
     private sealed record SftpJumpHostRequest(string Host, string? User, int Port);

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
@@ -114,19 +114,20 @@ public sealed partial class NativeSshInterop : INativeSshInterop
         string cancellationMarkerPath = Path.Combine(
             Path.GetTempPath(),
             $"nova-sftp-cancel-{Guid.NewGuid():N}.signal");
-        using CancellationTokenRegistration cancellationRegistration = cancellationToken.Register(() =>
-        {
-            try
-            {
-                File.WriteAllText(cancellationMarkerPath, string.Empty);
-            }
-            catch
-            {
-            }
-        });
+        CancellationTokenRegistration cancellationRegistration = default;
 
         try
         {
+            cancellationRegistration = cancellationToken.Register(() =>
+            {
+                try
+                {
+                    File.WriteAllText(cancellationMarkerPath, string.Empty);
+                }
+                catch
+                {
+                }
+            });
             request = request with
             {
                 Transfer = request.Transfer with
@@ -172,16 +173,31 @@ public sealed partial class NativeSshInterop : INativeSshInterop
                 NativeMethods.nova_ssh_string_free(responsePtr);
             }
 
-            try
+            CleanupCancellationMarker(ref cancellationRegistration, cancellationMarkerPath);
+        }
+    }
+
+    internal static void CleanupCancellationMarkerForTests(
+        ref CancellationTokenRegistration cancellationRegistration,
+        string cancellationMarkerPath)
+    {
+        CleanupCancellationMarker(ref cancellationRegistration, cancellationMarkerPath);
+    }
+
+    private static void CleanupCancellationMarker(
+        ref CancellationTokenRegistration cancellationRegistration,
+        string cancellationMarkerPath)
+    {
+        cancellationRegistration.Dispose();
+        try
+        {
+            if (File.Exists(cancellationMarkerPath))
             {
-                if (File.Exists(cancellationMarkerPath))
-                {
-                    File.Delete(cancellationMarkerPath);
-                }
+                File.Delete(cancellationMarkerPath);
             }
-            catch
-            {
-            }
+        }
+        catch
+        {
         }
     }
 

--- a/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
@@ -433,6 +433,7 @@ public sealed class NativeSshSession : ITerminalSession
         SshInteractionRequest requestWithContext = new()
         {
             Kind = request.Kind,
+            SessionId = Id,
             ProfileId = _profileId,
             ProfileName = _profileName,
             ProfileUser = _profileUser,

--- a/tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj
+++ b/tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj
@@ -5,6 +5,10 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <NativeProjectDir>$(MSBuildProjectDirectory)\..\..\src\NovaTerminal.App\native\</NativeProjectDir>
+    <RustSshNativeProjectDir>$(NativeProjectDir)rusty_ssh\</RustSshNativeProjectDir>
+    <RustSshNativeOutput Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))">$(RustSshNativeProjectDir)target\release\rusty_ssh.dll</RustSshNativeOutput>
+    <RustSshNativeOutput Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))">$(RustSshNativeProjectDir)target\release\librusty_ssh.so</RustSshNativeOutput>
+    <RustSshNativeOutput Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))">$(RustSshNativeProjectDir)target\release\librusty_ssh.dylib</RustSshNativeOutput>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,20 +27,22 @@
     <ProjectReference Include="..\..\src\NovaTerminal.Conformance\NovaTerminal.Conformance.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <RustSshNativeInputs Include="$(RustSshNativeProjectDir)Cargo.toml" />
+    <RustSshNativeInputs Include="$(RustSshNativeProjectDir)Cargo.lock" />
+    <RustSshNativeInputs Include="$(RustSshNativeProjectDir)src\**\*.rs" />
+  </ItemGroup>
+
   <Target Name="BuildRustSshNativeForTests"
     BeforeTargets="PrepareForBuild"
     Condition="'$(DesignTimeBuild)' != 'true'
       and '$(IsCrossTargetingBuild)' != 'true'
       and '$(SKIP_RUST_NATIVE_BUILD)' != '1'
-      and (
-        ($([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows))) and !Exists('$(NativeProjectDir)rusty_ssh\target\release\rusty_ssh.dll'))
-        or
-        ($([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux))) and !Exists('$(NativeProjectDir)rusty_ssh\target\release\librusty_ssh.so'))
-        or
-        ($([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX))) and !Exists('$(NativeProjectDir)rusty_ssh\target\release\librusty_ssh.dylib'))
-      )">
+      and '$(RustSshNativeOutput)' != ''"
+    Inputs="@(RustSshNativeInputs)"
+    Outputs="$(RustSshNativeOutput)">
 
-    <Exec WorkingDirectory="$(NativeProjectDir)rusty_ssh"
+    <Exec WorkingDirectory="$(RustSshNativeProjectDir)"
       Command="cargo build --release"
       EchoOff="false"
       ConsoleToMSBuild="true"

--- a/tests/NovaTerminal.Core.Tests/Ssh/DockerSshFixture.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/DockerSshFixture.cs
@@ -59,6 +59,14 @@ internal sealed class DockerSshFixture : IAsyncDisposable
             .ConfigureAwait(false);
     }
 
+    public async Task CreateDirectoryAsync(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        await RunDockerCommandAsync($"exec {_containerName} mkdir -p {path}")
+            .ConfigureAwait(false);
+    }
+
     public static async Task<DockerSshFixture> StartAsync()
     {
         await EnsureDockerAvailableAsync().ConfigureAwait(false);

--- a/tests/NovaTerminal.Core.Tests/Ssh/DockerSshFixture.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/DockerSshFixture.cs
@@ -19,6 +19,38 @@ internal sealed class DockerSshFixture : IAsyncDisposable
     public string UserName => "nova";
     public string Password => "nova-pass";
 
+    public async Task WriteTextFileAsync(string path, string contents)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(contents);
+
+        string tempFile = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(tempFile, contents).ConfigureAwait(false);
+            await RunDockerCommandAsync($"cp \"{tempFile}\" {_containerName}:{path}")
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    public async Task<SshHostKeyInfo> GetHostKeyAsync()
+    {
+        string publicKey = await RunDockerCommandAsync(
+            $"exec {_containerName} cat /etc/ssh/ssh_host_ed25519_key.pub")
+            .ConfigureAwait(false);
+        string fingerprintOutput = await RunDockerCommandAsync(
+            $"exec {_containerName} ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub -E sha256")
+            .ConfigureAwait(false);
+
+        string algorithm = publicKey.Split(' ', StringSplitOptions.RemoveEmptyEntries)[0];
+        string fingerprint = fingerprintOutput.Split(' ', StringSplitOptions.RemoveEmptyEntries)[1];
+        return new SshHostKeyInfo(algorithm, fingerprint);
+    }
+
     public static async Task<DockerSshFixture> StartAsync()
     {
         await EnsureDockerAvailableAsync().ConfigureAwait(false);
@@ -173,3 +205,5 @@ internal sealed class DockerSshFixture : IAsyncDisposable
         return string.IsNullOrWhiteSpace(stdout) ? stderr.Trim() : stdout.Trim();
     }
 }
+
+internal sealed record SshHostKeyInfo(string Algorithm, string Fingerprint);

--- a/tests/NovaTerminal.Core.Tests/Ssh/DockerSshFixture.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/DockerSshFixture.cs
@@ -51,6 +51,14 @@ internal sealed class DockerSshFixture : IAsyncDisposable
         return new SshHostKeyInfo(algorithm, fingerprint);
     }
 
+    public async Task<string> ReadTextFileAsync(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        return await RunDockerCommandAsync($"exec {_containerName} cat {path}")
+            .ConfigureAwait(false);
+    }
+
     public static async Task<DockerSshFixture> StartAsync()
     {
         await EnsureDockerAvailableAsync().ConfigureAwait(false);

--- a/tests/NovaTerminal.Core.Tests/Ssh/JumpHostConnectPlanTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/JumpHostConnectPlanTests.cs
@@ -128,6 +128,11 @@ public sealed class JumpHostConnectPlanTests
             return new IntPtr(1);
         }
 
+        public void RunSftpTransfer(NativeSshConnectionOptions connectionOptions, NativeSftpTransferOptions transferOptions, Action<NativeSftpTransferProgress>? progress, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
         public NativeSshEvent? PollEvent(IntPtr sessionHandle) => NativeSshEvent.Closed();
 
         public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data)

--- a/tests/NovaTerminal.Core.Tests/Ssh/JumpHostConnectPlanTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/JumpHostConnectPlanTests.cs
@@ -133,6 +133,11 @@ public sealed class JumpHostConnectPlanTests
             throw new NotSupportedException();
         }
 
+        public IReadOnlyList<NativeRemotePathEntry> ListRemoteDirectory(NativeSshConnectionOptions connectionOptions, string remotePath, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
         public NativeSshEvent? PollEvent(IntPtr sessionHandle) => NativeSshEvent.Closed();
 
         public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data)

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativePortForwardSessionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativePortForwardSessionTests.cs
@@ -493,6 +493,11 @@ public sealed class NativePortForwardSessionTests
 
         public IntPtr Connect(NativeSshConnectionOptions options) => new(1);
 
+        public void RunSftpTransfer(NativeSshConnectionOptions connectionOptions, NativeSftpTransferOptions transferOptions, Action<NativeSftpTransferProgress>? progress, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
         public NativeSshEvent? PollEvent(IntPtr sessionHandle)
         {
             return _events.TryDequeue(out NativeSshEvent? nextEvent)

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativePortForwardSessionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativePortForwardSessionTests.cs
@@ -498,6 +498,11 @@ public sealed class NativePortForwardSessionTests
             throw new NotSupportedException();
         }
 
+        public IReadOnlyList<NativeRemotePathEntry> ListRemoteDirectory(NativeSshConnectionOptions connectionOptions, string remotePath, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
         public NativeSshEvent? PollEvent(IntPtr sessionHandle)
         {
             return _events.TryDequeue(out NativeSshEvent? nextEvent)

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs
@@ -1,0 +1,65 @@
+using NovaTerminal.Core.Ssh.Native;
+
+namespace NovaTerminal.Core.Tests.Ssh;
+
+public sealed class NativeSftpTransferInteropTests
+{
+    [Fact]
+    public void TransferOptions_RequireLocalAndRemotePaths()
+    {
+        NativeSftpTransferOptions options = new()
+        {
+            Direction = NativeSftpTransferDirection.Download,
+            Kind = NativeSftpTransferKind.File
+        };
+
+        Assert.Throws<ArgumentException>(() => options.Validate());
+    }
+
+    [Fact]
+    public void TransferOptions_AcceptExplicitLocalAndRemotePaths()
+    {
+        NativeSftpTransferOptions options = new()
+        {
+            Direction = NativeSftpTransferDirection.Upload,
+            Kind = NativeSftpTransferKind.Directory,
+            LocalPath = @"C:\downloads\logs",
+            RemotePath = "/var/tmp/logs"
+        };
+
+        options.Validate();
+
+        Assert.Equal(NativeSftpTransferDirection.Upload, options.Direction);
+        Assert.Equal(NativeSftpTransferKind.Directory, options.Kind);
+        Assert.Equal(@"C:\downloads\logs", options.LocalPath);
+        Assert.Equal("/var/tmp/logs", options.RemotePath);
+    }
+
+    [Fact]
+    public void RunSftpTransfer_ThrowsUntilNativeImplementationExists()
+    {
+        INativeSshInterop interop = new NativeSshInterop();
+        NativeSshConnectionOptions connectionOptions = new()
+        {
+            Host = "example.com",
+            User = "nova"
+        };
+        NativeSftpTransferOptions transferOptions = new()
+        {
+            Direction = NativeSftpTransferDirection.Download,
+            Kind = NativeSftpTransferKind.File,
+            LocalPath = @"C:\downloads\report.txt",
+            RemotePath = "/tmp/report.txt"
+        };
+
+        Action act = () => interop.RunSftpTransfer(
+            connectionOptions,
+            transferOptions,
+            progress: null,
+            CancellationToken.None);
+
+        NotImplementedException ex = Assert.Throws<NotImplementedException>(act);
+
+        Assert.Contains("Native SFTP transfer", ex.Message);
+    }
+}

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs
@@ -53,6 +53,26 @@ public sealed class NativeSftpTransferInteropTests
     }
 
     [Fact]
+    public void NativeProgressCallback_TranslatesPayloadToManagedProgress()
+    {
+        NativeSftpTransferProgress? observed = null;
+        MethodInfo? helperMethod = typeof(NativeSshInterop).GetMethod(
+            "InvokeManagedProgressCallbackForTest",
+            BindingFlags.Static | BindingFlags.NonPublic);
+
+        Assert.True(
+            helperMethod is not null,
+            "Expected NativeSshInterop to expose a nonpublic static InvokeManagedProgressCallbackForTest helper.");
+
+        helperMethod!.Invoke(null, [new Action<NativeSftpTransferProgress>(progress => observed = progress), 512UL, 2048UL, "/tmp/archive.tar"]);
+
+        Assert.NotNull(observed);
+        Assert.Equal(512, observed!.BytesDone);
+        Assert.Equal(2048, observed.BytesTotal);
+        Assert.Equal("/tmp/archive.tar", observed.CurrentPath);
+    }
+
+    [Fact]
     public void TransferOptions_RequireLocalAndRemotePaths()
     {
         NativeSftpTransferOptions options = new()

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs
@@ -1,9 +1,48 @@
 using NovaTerminal.Core.Ssh.Native;
+using System.Reflection;
+using System.Runtime.InteropServices;
 
 namespace NovaTerminal.Core.Tests.Ssh;
 
 public sealed class NativeSftpTransferInteropTests
 {
+    [Fact]
+    public void ProgressPayload_AllowsKnownTotalAndCurrentPath()
+    {
+        NativeSftpTransferProgress progress = new()
+        {
+            BytesDone = 128,
+            BytesTotal = 1024,
+            CurrentPath = "/tmp/report.txt"
+        };
+
+        Assert.Equal(128, progress.BytesDone);
+        Assert.Equal(1024, progress.BytesTotal);
+        Assert.Equal("/tmp/report.txt", progress.CurrentPath);
+    }
+
+    [Fact]
+    public void NativeSshInterop_ForwardsNativeSftpProgressCallbackToManagedProgressHandler()
+    {
+        Action<NativeSftpTransferProgress>? managedProgress = null;
+        NativeSftpTransferProgress? observed = null;
+        managedProgress = progress => observed = progress;
+
+        using NativeSftpTransferProgressCallbackDataHandle nativeProgress = new(128, 1024, "/tmp/report.txt");
+        MethodInfo? forwardMethod = typeof(NativeSshInterop).GetMethod(
+            "ForwardSftpTransferProgress",
+            BindingFlags.Static | BindingFlags.NonPublic);
+
+        Assert.NotNull(forwardMethod);
+
+        forwardMethod!.Invoke(null, [managedProgress, nativeProgress.Data]);
+
+        Assert.NotNull(observed);
+        Assert.Equal(128, observed!.BytesDone);
+        Assert.Equal(1024, observed.BytesTotal);
+        Assert.Equal("/tmp/report.txt", observed.CurrentPath);
+    }
+
     [Fact]
     public void TransferOptions_RequireLocalAndRemotePaths()
     {
@@ -91,5 +130,32 @@ public sealed class NativeSftpTransferInteropTests
         ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(act);
 
         Assert.Contains("direction", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class NativeSftpTransferProgressCallbackDataHandle : IDisposable
+    {
+        private IntPtr currentPath;
+
+        public NativeSftpTransferProgressCallbackDataHandle(ulong bytesDone, ulong bytesTotal, string currentPath)
+        {
+            this.currentPath = Marshal.StringToCoTaskMemUTF8(currentPath);
+            Data = new NativeSftpTransferProgressCallbackData
+            {
+                BytesDone = bytesDone,
+                BytesTotal = bytesTotal,
+                CurrentPath = this.currentPath
+            };
+        }
+
+        public NativeSftpTransferProgressCallbackData Data { get; }
+
+        public void Dispose()
+        {
+            if (currentPath != IntPtr.Zero)
+            {
+                Marshal.FreeCoTaskMem(currentPath);
+                currentPath = IntPtr.Zero;
+            }
+        }
     }
 }

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs
@@ -120,6 +120,50 @@ public sealed class NativeSftpTransferInteropTests
     }
 
     [Fact]
+    public void SerializeSftpTransferRequest_UsesGeneratedMetadataAndCamelCasePayload()
+    {
+        NativeSshConnectionOptions connectionOptions = new()
+        {
+            Host = "example.com",
+            User = "nova",
+            Port = 2222,
+            Password = "secret",
+            KnownHostsFilePath = @"C:\known-hosts.json",
+            JumpHost = new NovaTerminal.Core.Ssh.Models.SshJumpHop
+            {
+                Host = "jump.internal",
+                User = "jumper",
+                Port = 2200
+            }
+        };
+        NativeSftpTransferOptions transferOptions = new()
+        {
+            Direction = NativeSftpTransferDirection.Download,
+            Kind = NativeSftpTransferKind.File,
+            LocalPath = @"C:\downloads\movie.mkv",
+            RemotePath = "/mnt/box1/media/movies/Movie Name/movie.mkv"
+        };
+
+        string json = NativeSshInterop.SerializeSftpTransferRequestForTests(connectionOptions, transferOptions);
+
+        Assert.Contains("\"connection\":", json, StringComparison.Ordinal);
+        Assert.Contains("\"transfer\":", json, StringComparison.Ordinal);
+        Assert.Contains("\"knownHostsFilePath\":\"C:\\\\known-hosts.json\"", json, StringComparison.Ordinal);
+        Assert.Contains("\"jumpHost\":", json, StringComparison.Ordinal);
+        Assert.Contains("\"remotePath\":\"/mnt/box1/media/movies/Movie Name/movie.mkv\"", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DeserializeSftpTransferResponse_UsesGeneratedMetadata()
+    {
+        const string responseJson = "{\"status\":\"error\",\"message\":\"authentication failed\"}";
+
+        string? message = NativeSshInterop.DeserializeSftpTransferResponseMessageForTests(responseJson);
+
+        Assert.Equal("authentication failed", message);
+    }
+
+    [Fact]
     public void RunSftpTransfer_RequiresKnownHostsStorePath()
     {
         INativeSshInterop interop = new NativeSshInterop();

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs
@@ -76,7 +76,7 @@ public sealed class NativeSftpTransferInteropTests
         };
         NativeSftpTransferOptions transferOptions = new()
         {
-            Direction = NativeSftpTransferDirection.Upload,
+            Direction = (NativeSftpTransferDirection)99,
             Kind = NativeSftpTransferKind.Directory,
             LocalPath = @"C:\downloads\report.txt",
             RemotePath = "/tmp/report.txt"
@@ -88,9 +88,8 @@ public sealed class NativeSftpTransferInteropTests
             progress: null,
             CancellationToken.None);
 
-        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(act);
+        ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(act);
 
-        Assert.Contains("not implemented", ex.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("upload/directory", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("direction", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs
@@ -29,11 +29,20 @@ public sealed class NativeSftpTransferInteropTests
         managedProgress = progress => observed = progress;
 
         using NativeSftpTransferProgressCallbackDataHandle nativeProgress = new(128, 1024, "/tmp/report.txt");
-        MethodInfo? forwardMethod = typeof(NativeSshInterop).GetMethod(
-            "ForwardSftpTransferProgress",
-            BindingFlags.Static | BindingFlags.NonPublic);
+        MethodInfo? forwardMethod = typeof(NativeSshInterop)
+            .GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
+            .SingleOrDefault(static method =>
+            {
+                ParameterInfo[] parameters = method.GetParameters();
+                return method.ReturnType == typeof(void)
+                    && parameters.Length == 2
+                    && parameters[0].ParameterType == typeof(Action<NativeSftpTransferProgress>)
+                    && parameters[1].ParameterType == typeof(NativeSftpTransferProgressCallbackData);
+            });
 
-        Assert.NotNull(forwardMethod);
+        Assert.True(
+            forwardMethod is not null,
+            "Expected a nonpublic static native SFTP progress translator with signature (Action<NativeSftpTransferProgress>, NativeSftpTransferProgressCallbackData).");
 
         forwardMethod!.Invoke(null, [managedProgress, nativeProgress.Data]);
 

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs
@@ -36,7 +36,7 @@ public sealed class NativeSftpTransferInteropTests
     }
 
     [Fact]
-    public void RunSftpTransfer_ThrowsUntilNativeImplementationExists()
+    public void RunSftpTransfer_UsesNativeBackendStubResponse()
     {
         INativeSshInterop interop = new NativeSshInterop();
         NativeSshConnectionOptions connectionOptions = new()
@@ -58,8 +58,10 @@ public sealed class NativeSftpTransferInteropTests
             progress: null,
             CancellationToken.None);
 
-        NotImplementedException ex = Assert.Throws<NotImplementedException>(act);
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(act);
 
-        Assert.Contains("Native SFTP transfer", ex.Message);
+        Assert.Contains("result -5", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("native backend stub", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("not implemented", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs
@@ -73,6 +73,22 @@ public sealed class NativeSftpTransferInteropTests
     }
 
     [Fact]
+    public void NativeProgressCallback_DelegateAbi_IsNestedInsideNativeSshInterop()
+    {
+        Type? nestedDelegate = typeof(NativeSshInterop).GetNestedType(
+            "NativeSftpTransferProgressCallback",
+            BindingFlags.NonPublic);
+        Type? topLevelDelegate = typeof(INativeSshInterop).Assembly.GetType(
+            "NovaTerminal.Core.Ssh.Native.NativeSftpTransferProgressCallback",
+            throwOnError: false,
+            ignoreCase: false);
+
+        Assert.NotNull(nestedDelegate);
+        Assert.True(typeof(MulticastDelegate).IsAssignableFrom(nestedDelegate));
+        Assert.Null(topLevelDelegate);
+    }
+
+    [Fact]
     public void TransferOptions_RequireLocalAndRemotePaths()
     {
         NativeSftpTransferOptions options = new()

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs
@@ -1,4 +1,5 @@
 using NovaTerminal.Core.Ssh.Native;
+using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -219,6 +220,24 @@ public sealed class NativeSftpTransferInteropTests
         ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(act);
 
         Assert.Contains("direction", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CleanupCancellationMarker_DisposesRegistrationBeforeDeletingMarker()
+    {
+        string markerPath = Path.Combine(Path.GetTempPath(), $"nova-sftp-test-{Guid.NewGuid():N}.signal");
+        File.WriteAllText(markerPath, string.Empty);
+
+        using CancellationTokenSource cts = new();
+        CancellationTokenRegistration registration = cts.Token.Register(() =>
+        {
+            File.WriteAllText(markerPath, "canceled");
+        });
+
+        NativeSshInterop.CleanupCancellationMarkerForTests(ref registration, markerPath);
+        cts.Cancel();
+
+        Assert.False(File.Exists(markerPath));
     }
 
     private sealed class NativeSftpTransferProgressCallbackDataHandle : IDisposable

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSftpTransferInteropTests.cs
@@ -36,7 +36,7 @@ public sealed class NativeSftpTransferInteropTests
     }
 
     [Fact]
-    public void RunSftpTransfer_UsesNativeBackendStubResponse()
+    public void RunSftpTransfer_RequiresKnownHostsStorePath()
     {
         INativeSshInterop interop = new NativeSshInterop();
         NativeSshConnectionOptions connectionOptions = new()
@@ -58,10 +58,39 @@ public sealed class NativeSftpTransferInteropTests
             progress: null,
             CancellationToken.None);
 
+        ArgumentException ex = Assert.Throws<ArgumentException>(act);
+
+        Assert.Contains("known-hosts", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void RunSftpTransfer_ReturnsClearErrorForUnsupportedModes()
+    {
+        INativeSshInterop interop = new NativeSshInterop();
+        NativeSshConnectionOptions connectionOptions = new()
+        {
+            Host = "example.com",
+            User = "nova",
+            Password = "secret",
+            KnownHostsFilePath = @"C:\known-hosts.json"
+        };
+        NativeSftpTransferOptions transferOptions = new()
+        {
+            Direction = NativeSftpTransferDirection.Upload,
+            Kind = NativeSftpTransferKind.Directory,
+            LocalPath = @"C:\downloads\report.txt",
+            RemotePath = "/tmp/report.txt"
+        };
+
+        Action act = () => interop.RunSftpTransfer(
+            connectionOptions,
+            transferOptions,
+            progress: null,
+            CancellationToken.None);
+
         InvalidOperationException ex = Assert.Throws<InvalidOperationException>(act);
 
-        Assert.Contains("result -5", ex.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("native backend stub", ex.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("not implemented", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("upload/directory", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
@@ -61,6 +61,54 @@ public sealed class NativeSshDockerE2eTests
     [DockerFact]
     [Trait("Category", "DockerE2E")]
     [Trait("Target", "NativeSsh")]
+    public async Task NativeSftp_CanUploadFile()
+    {
+        await using var fixture = await DockerSshFixture.StartAsync();
+
+        string tempRoot = Path.Combine(Path.GetTempPath(), $"nova-native-sftp-upload-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+        try
+        {
+            const string expected = "native-sftp-upload";
+            const string remotePath = "/tmp/native-sftp-upload.txt";
+            string localPath = Path.Combine(tempRoot, "upload.txt");
+            await File.WriteAllTextAsync(localPath, expected);
+
+            SshHostKeyInfo hostKey = await fixture.GetHostKeyAsync();
+            string knownHostsPath = Path.Combine(tempRoot, "native_known_hosts.json");
+            var knownHosts = new NativeKnownHostsStore(knownHostsPath);
+            knownHosts.TrustHost(fixture.Host, fixture.Port, hostKey.Algorithm, hostKey.Fingerprint);
+
+            var interop = new NativeSshInterop();
+            var connection = new NativeSshConnectionOptions
+            {
+                Host = fixture.Host,
+                User = fixture.UserName,
+                Port = fixture.Port,
+                Password = fixture.Password,
+                KnownHostsFilePath = knownHostsPath
+            };
+            var transfer = new NativeSftpTransferOptions
+            {
+                Direction = NativeSftpTransferDirection.Upload,
+                Kind = NativeSftpTransferKind.File,
+                LocalPath = localPath,
+                RemotePath = remotePath
+            };
+
+            interop.RunSftpTransfer(connection, transfer, progress: null, CancellationToken.None);
+
+            Assert.Equal(expected, await fixture.ReadTextFileAsync(remotePath));
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
     public async Task NativeSsh_CanAuthenticate_RunCommand_AndReturnToPrompt()
     {
         await using var fixture = await DockerSshFixture.StartAsync();

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
@@ -226,6 +226,73 @@ public sealed class NativeSshDockerE2eTests
     [DockerFact]
     [Trait("Category", "DockerE2E")]
     [Trait("Target", "NativeSsh")]
+    public async Task NativeSftp_CanReportProgressDuringDirectoryDownload()
+    {
+        await using var fixture = await DockerSshFixture.StartAsync();
+
+        string tempRoot = Path.Combine(Path.GetTempPath(), $"nova-native-sftp-download-dir-progress-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+        try
+        {
+            const string remoteRoot = "/tmp/native-sftp-download-dir-progress";
+            string nestedRemotePath = $"{remoteRoot}/nested";
+            string remoteFileA = $"{remoteRoot}/a.txt";
+            string remoteFileB = $"{nestedRemotePath}/b.txt";
+            await fixture.CreateDirectoryAsync(nestedRemotePath);
+            await fixture.WriteTextFileAsync(remoteFileA, string.Concat(Enumerable.Repeat("alpha-", 32 * 1024)));
+            await fixture.WriteTextFileAsync(remoteFileB, string.Concat(Enumerable.Repeat("beta-", 32 * 1024)));
+
+            SshHostKeyInfo hostKey = await fixture.GetHostKeyAsync();
+            string knownHostsPath = Path.Combine(tempRoot, "native_known_hosts.json");
+            var knownHosts = new NativeKnownHostsStore(knownHostsPath);
+            knownHosts.TrustHost(fixture.Host, fixture.Port, hostKey.Algorithm, hostKey.Fingerprint);
+
+            var progressUpdates = new List<NativeSftpTransferProgress>();
+            var interop = new NativeSshInterop();
+            var connection = new NativeSshConnectionOptions
+            {
+                Host = fixture.Host,
+                User = fixture.UserName,
+                Port = fixture.Port,
+                Password = fixture.Password,
+                KnownHostsFilePath = knownHostsPath
+            };
+            var transfer = new NativeSftpTransferOptions
+            {
+                Direction = NativeSftpTransferDirection.Download,
+                Kind = NativeSftpTransferKind.Directory,
+                LocalPath = tempRoot,
+                RemotePath = remoteRoot
+            };
+
+            interop.RunSftpTransfer(
+                connection,
+                transfer,
+                progress: update => progressUpdates.Add(update),
+                CancellationToken.None);
+
+            string localRoot = Path.Combine(tempRoot, "native-sftp-download-dir-progress");
+            Assert.Equal(string.Concat(Enumerable.Repeat("alpha-", 32 * 1024)), await File.ReadAllTextAsync(Path.Combine(localRoot, "a.txt")));
+            Assert.Equal(string.Concat(Enumerable.Repeat("beta-", 32 * 1024)), await File.ReadAllTextAsync(Path.Combine(localRoot, "nested", "b.txt")));
+
+            Assert.True(progressUpdates.Count > 0, "Expected progress callbacks during directory download.");
+            Assert.All(
+                progressUpdates,
+                update => Assert.False(string.IsNullOrWhiteSpace(update.CurrentPath), "Expected each progress callback to include a current path."));
+            Assert.Contains(progressUpdates, update => string.Equals(update.CurrentPath, remoteFileA, StringComparison.Ordinal));
+            Assert.Contains(progressUpdates, update => string.Equals(update.CurrentPath, remoteFileB, StringComparison.Ordinal));
+            Assert.Contains(progressUpdates, update => update.BytesTotal > 0);
+            Assert.All(progressUpdates, update => Assert.True(update.BytesDone > 0, "Expected directory progress updates to report copied bytes."));
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
     public async Task NativeSftp_CanUploadDirectory()
     {
         await using var fixture = await DockerSshFixture.StartAsync();

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
@@ -182,6 +182,100 @@ public sealed class NativeSshDockerE2eTests
     [DockerFact]
     [Trait("Category", "DockerE2E")]
     [Trait("Target", "NativeSsh")]
+    public async Task NativeSftp_CanUploadFileToExistingRemoteDirectory()
+    {
+        await using var fixture = await DockerSshFixture.StartAsync();
+
+        string tempRoot = Path.Combine(Path.GetTempPath(), $"nova-native-sftp-upload-dir-target-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+        try
+        {
+            const string expected = "native-sftp-upload-dir-target";
+            string localPath = Path.Combine(tempRoot, "upload-to-dir.txt");
+            await File.WriteAllTextAsync(localPath, expected);
+
+            SshHostKeyInfo hostKey = await fixture.GetHostKeyAsync();
+            string knownHostsPath = Path.Combine(tempRoot, "native_known_hosts.json");
+            var knownHosts = new NativeKnownHostsStore(knownHostsPath);
+            knownHosts.TrustHost(fixture.Host, fixture.Port, hostKey.Algorithm, hostKey.Fingerprint);
+
+            var interop = new NativeSshInterop();
+            var connection = new NativeSshConnectionOptions
+            {
+                Host = fixture.Host,
+                User = fixture.UserName,
+                Port = fixture.Port,
+                Password = fixture.Password,
+                KnownHostsFilePath = knownHostsPath
+            };
+            var transfer = new NativeSftpTransferOptions
+            {
+                Direction = NativeSftpTransferDirection.Upload,
+                Kind = NativeSftpTransferKind.File,
+                LocalPath = localPath,
+                RemotePath = "/tmp"
+            };
+
+            interop.RunSftpTransfer(connection, transfer, progress: null, CancellationToken.None);
+
+            Assert.Equal(expected, await fixture.ReadTextFileAsync("/tmp/upload-to-dir.txt"));
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
+    public async Task NativeSftp_CanUploadFileToHomeDirectoryShortcut()
+    {
+        await using var fixture = await DockerSshFixture.StartAsync();
+
+        string tempRoot = Path.Combine(Path.GetTempPath(), $"nova-native-sftp-upload-home-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+        try
+        {
+            const string expected = "native-sftp-upload-home";
+            string localPath = Path.Combine(tempRoot, "upload-home.txt");
+            await File.WriteAllTextAsync(localPath, expected);
+
+            SshHostKeyInfo hostKey = await fixture.GetHostKeyAsync();
+            string knownHostsPath = Path.Combine(tempRoot, "native_known_hosts.json");
+            var knownHosts = new NativeKnownHostsStore(knownHostsPath);
+            knownHosts.TrustHost(fixture.Host, fixture.Port, hostKey.Algorithm, hostKey.Fingerprint);
+
+            var interop = new NativeSshInterop();
+            var connection = new NativeSshConnectionOptions
+            {
+                Host = fixture.Host,
+                User = fixture.UserName,
+                Port = fixture.Port,
+                Password = fixture.Password,
+                KnownHostsFilePath = knownHostsPath
+            };
+            var transfer = new NativeSftpTransferOptions
+            {
+                Direction = NativeSftpTransferDirection.Upload,
+                Kind = NativeSftpTransferKind.File,
+                LocalPath = localPath,
+                RemotePath = "~"
+            };
+
+            interop.RunSftpTransfer(connection, transfer, progress: null, CancellationToken.None);
+
+            Assert.Equal(expected, await fixture.ReadTextFileAsync("/home/nova/upload-home.txt"));
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
     public async Task NativeSftp_CanDownloadDirectory()
     {
         await using var fixture = await DockerSshFixture.StartAsync();

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
@@ -1,5 +1,6 @@
 using NovaTerminal.Core.Replay;
 using NovaTerminal.Core.Ssh.Models;
+using NovaTerminal.Core.Ssh.Native;
 using NovaTerminal.Core.Ssh.Sessions;
 using NovaTerminal.Core.Tests.Infra;
 using System.Text;
@@ -8,6 +9,55 @@ namespace NovaTerminal.Core.Tests.Ssh;
 
 public sealed class NativeSshDockerE2eTests
 {
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
+    public async Task NativeSftp_CanDownloadFile()
+    {
+        await using var fixture = await DockerSshFixture.StartAsync();
+
+        string tempRoot = Path.Combine(Path.GetTempPath(), $"nova-native-sftp-download-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+        try
+        {
+            const string remotePath = "/tmp/native-sftp-source.txt";
+            const string expected = "native-sftp-download";
+            await fixture.WriteTextFileAsync(remotePath, expected);
+
+            SshHostKeyInfo hostKey = await fixture.GetHostKeyAsync();
+            string knownHostsPath = Path.Combine(tempRoot, "native_known_hosts.json");
+            var knownHosts = new NativeKnownHostsStore(knownHostsPath);
+            knownHosts.TrustHost(fixture.Host, fixture.Port, hostKey.Algorithm, hostKey.Fingerprint);
+
+            string localPath = Path.Combine(tempRoot, "downloaded.txt");
+
+            var interop = new NativeSshInterop();
+            var connection = new NativeSshConnectionOptions
+            {
+                Host = fixture.Host,
+                User = fixture.UserName,
+                Port = fixture.Port,
+                Password = fixture.Password,
+                KnownHostsFilePath = knownHostsPath
+            };
+            var transfer = new NativeSftpTransferOptions
+            {
+                Direction = NativeSftpTransferDirection.Download,
+                Kind = NativeSftpTransferKind.File,
+                RemotePath = remotePath,
+                LocalPath = localPath
+            };
+
+            interop.RunSftpTransfer(connection, transfer, progress: null, CancellationToken.None);
+
+            Assert.Equal(expected, File.ReadAllText(localPath));
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
     [DockerFact]
     [Trait("Category", "DockerE2E")]
     [Trait("Target", "NativeSsh")]

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
@@ -207,6 +207,139 @@ public sealed class NativeSshDockerE2eTests
     [DockerFact]
     [Trait("Category", "DockerE2E")]
     [Trait("Target", "NativeSsh")]
+    public async Task NativeSftp_MissingRemotePath_ReturnsClearError()
+    {
+        await using var fixture = await DockerSshFixture.StartAsync();
+
+        string tempRoot = Path.Combine(Path.GetTempPath(), $"nova-native-sftp-missing-remote-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+        try
+        {
+            SshHostKeyInfo hostKey = await fixture.GetHostKeyAsync();
+            string knownHostsPath = Path.Combine(tempRoot, "native_known_hosts.json");
+            var knownHosts = new NativeKnownHostsStore(knownHostsPath);
+            knownHosts.TrustHost(fixture.Host, fixture.Port, hostKey.Algorithm, hostKey.Fingerprint);
+
+            var interop = new NativeSshInterop();
+            var connection = new NativeSshConnectionOptions
+            {
+                Host = fixture.Host,
+                User = fixture.UserName,
+                Port = fixture.Port,
+                Password = fixture.Password,
+                KnownHostsFilePath = knownHostsPath
+            };
+            var transfer = new NativeSftpTransferOptions
+            {
+                Direction = NativeSftpTransferDirection.Download,
+                Kind = NativeSftpTransferKind.File,
+                LocalPath = Path.Combine(tempRoot, "missing.txt"),
+                RemotePath = "/tmp/does-not-exist.txt"
+            };
+
+            InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+                () => interop.RunSftpTransfer(connection, transfer, progress: null, CancellationToken.None));
+
+            Assert.Contains("Remote path not found: /tmp/does-not-exist.txt", error.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
+    public async Task NativeSftp_MissingLocalPath_ReturnsClearError()
+    {
+        await using var fixture = await DockerSshFixture.StartAsync();
+
+        string tempRoot = Path.Combine(Path.GetTempPath(), $"nova-native-sftp-missing-local-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+        try
+        {
+            SshHostKeyInfo hostKey = await fixture.GetHostKeyAsync();
+            string knownHostsPath = Path.Combine(tempRoot, "native_known_hosts.json");
+            var knownHosts = new NativeKnownHostsStore(knownHostsPath);
+            knownHosts.TrustHost(fixture.Host, fixture.Port, hostKey.Algorithm, hostKey.Fingerprint);
+
+            var interop = new NativeSshInterop();
+            var connection = new NativeSshConnectionOptions
+            {
+                Host = fixture.Host,
+                User = fixture.UserName,
+                Port = fixture.Port,
+                Password = fixture.Password,
+                KnownHostsFilePath = knownHostsPath
+            };
+            var transfer = new NativeSftpTransferOptions
+            {
+                Direction = NativeSftpTransferDirection.Upload,
+                Kind = NativeSftpTransferKind.File,
+                LocalPath = Path.Combine(tempRoot, "does-not-exist.txt"),
+                RemotePath = "/tmp/upload.txt"
+            };
+
+            InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+                () => interop.RunSftpTransfer(connection, transfer, progress: null, CancellationToken.None));
+
+            Assert.Contains("Local path not found:", error.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
+    public async Task NativeSftp_BadPassword_ReturnsAuthenticationFailed()
+    {
+        await using var fixture = await DockerSshFixture.StartAsync();
+
+        string tempRoot = Path.Combine(Path.GetTempPath(), $"nova-native-sftp-auth-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+        try
+        {
+            await fixture.WriteTextFileAsync("/tmp/auth-check.txt", "auth");
+            SshHostKeyInfo hostKey = await fixture.GetHostKeyAsync();
+            string knownHostsPath = Path.Combine(tempRoot, "native_known_hosts.json");
+            var knownHosts = new NativeKnownHostsStore(knownHostsPath);
+            knownHosts.TrustHost(fixture.Host, fixture.Port, hostKey.Algorithm, hostKey.Fingerprint);
+
+            var interop = new NativeSshInterop();
+            var connection = new NativeSshConnectionOptions
+            {
+                Host = fixture.Host,
+                User = fixture.UserName,
+                Port = fixture.Port,
+                Password = "wrong-password",
+                KnownHostsFilePath = knownHostsPath
+            };
+            var transfer = new NativeSftpTransferOptions
+            {
+                Direction = NativeSftpTransferDirection.Download,
+                Kind = NativeSftpTransferKind.File,
+                LocalPath = Path.Combine(tempRoot, "auth.txt"),
+                RemotePath = "/tmp/auth-check.txt"
+            };
+
+            InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+                () => interop.RunSftpTransfer(connection, transfer, progress: null, CancellationToken.None));
+
+            Assert.Contains("Authentication failed", error.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
     public async Task NativeSsh_CanAuthenticate_RunCommand_AndReturnToPrompt()
     {
         await using var fixture = await DockerSshFixture.StartAsync();

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
@@ -109,6 +109,104 @@ public sealed class NativeSshDockerE2eTests
     [DockerFact]
     [Trait("Category", "DockerE2E")]
     [Trait("Target", "NativeSsh")]
+    public async Task NativeSftp_CanDownloadDirectory()
+    {
+        await using var fixture = await DockerSshFixture.StartAsync();
+
+        string tempRoot = Path.Combine(Path.GetTempPath(), $"nova-native-sftp-download-dir-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+        try
+        {
+            const string remoteRoot = "/tmp/native-sftp-download-dir";
+            await fixture.CreateDirectoryAsync($"{remoteRoot}/nested");
+            await fixture.WriteTextFileAsync($"{remoteRoot}/a.txt", "alpha");
+            await fixture.WriteTextFileAsync($"{remoteRoot}/nested/b.txt", "beta");
+
+            SshHostKeyInfo hostKey = await fixture.GetHostKeyAsync();
+            string knownHostsPath = Path.Combine(tempRoot, "native_known_hosts.json");
+            var knownHosts = new NativeKnownHostsStore(knownHostsPath);
+            knownHosts.TrustHost(fixture.Host, fixture.Port, hostKey.Algorithm, hostKey.Fingerprint);
+
+            var interop = new NativeSshInterop();
+            var connection = new NativeSshConnectionOptions
+            {
+                Host = fixture.Host,
+                User = fixture.UserName,
+                Port = fixture.Port,
+                Password = fixture.Password,
+                KnownHostsFilePath = knownHostsPath
+            };
+            var transfer = new NativeSftpTransferOptions
+            {
+                Direction = NativeSftpTransferDirection.Download,
+                Kind = NativeSftpTransferKind.Directory,
+                LocalPath = tempRoot,
+                RemotePath = remoteRoot
+            };
+
+            interop.RunSftpTransfer(connection, transfer, progress: null, CancellationToken.None);
+
+            string localRoot = Path.Combine(tempRoot, "native-sftp-download-dir");
+            Assert.Equal("alpha", await File.ReadAllTextAsync(Path.Combine(localRoot, "a.txt")));
+            Assert.Equal("beta", await File.ReadAllTextAsync(Path.Combine(localRoot, "nested", "b.txt")));
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
+    public async Task NativeSftp_CanUploadDirectory()
+    {
+        await using var fixture = await DockerSshFixture.StartAsync();
+
+        string tempRoot = Path.Combine(Path.GetTempPath(), $"nova-native-sftp-upload-dir-{Guid.NewGuid():N}");
+        string localRoot = Path.Combine(tempRoot, "native-sftp-upload-dir");
+        Directory.CreateDirectory(Path.Combine(localRoot, "nested"));
+        try
+        {
+            await File.WriteAllTextAsync(Path.Combine(localRoot, "a.txt"), "alpha");
+            await File.WriteAllTextAsync(Path.Combine(localRoot, "nested", "b.txt"), "beta");
+
+            SshHostKeyInfo hostKey = await fixture.GetHostKeyAsync();
+            string knownHostsPath = Path.Combine(tempRoot, "native_known_hosts.json");
+            var knownHosts = new NativeKnownHostsStore(knownHostsPath);
+            knownHosts.TrustHost(fixture.Host, fixture.Port, hostKey.Algorithm, hostKey.Fingerprint);
+
+            var interop = new NativeSshInterop();
+            var connection = new NativeSshConnectionOptions
+            {
+                Host = fixture.Host,
+                User = fixture.UserName,
+                Port = fixture.Port,
+                Password = fixture.Password,
+                KnownHostsFilePath = knownHostsPath
+            };
+            var transfer = new NativeSftpTransferOptions
+            {
+                Direction = NativeSftpTransferDirection.Upload,
+                Kind = NativeSftpTransferKind.Directory,
+                LocalPath = localRoot,
+                RemotePath = "/tmp"
+            };
+
+            interop.RunSftpTransfer(connection, transfer, progress: null, CancellationToken.None);
+
+            Assert.Equal("alpha", await fixture.ReadTextFileAsync("/tmp/native-sftp-upload-dir/a.txt"));
+            Assert.Equal("beta", await fixture.ReadTextFileAsync("/tmp/native-sftp-upload-dir/nested/b.txt"));
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
     public async Task NativeSsh_CanAuthenticate_RunCommand_AndReturnToPrompt()
     {
         await using var fixture = await DockerSshFixture.StartAsync();

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
@@ -61,6 +61,62 @@ public sealed class NativeSshDockerE2eTests
     [DockerFact]
     [Trait("Category", "DockerE2E")]
     [Trait("Target", "NativeSsh")]
+    public async Task NativeSftp_CanReportProgressDuringDownload()
+    {
+        await using var fixture = await DockerSshFixture.StartAsync();
+
+        string tempRoot = Path.Combine(Path.GetTempPath(), $"nova-native-sftp-progress-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+        try
+        {
+            const string remotePath = "/tmp/native-sftp-progress-source.txt";
+            string expected = string.Concat(Enumerable.Repeat("native-sftp-progress-", 32 * 1024));
+            await fixture.WriteTextFileAsync(remotePath, expected);
+
+            SshHostKeyInfo hostKey = await fixture.GetHostKeyAsync();
+            string knownHostsPath = Path.Combine(tempRoot, "native_known_hosts.json");
+            var knownHosts = new NativeKnownHostsStore(knownHostsPath);
+            knownHosts.TrustHost(fixture.Host, fixture.Port, hostKey.Algorithm, hostKey.Fingerprint);
+
+            string localPath = Path.Combine(tempRoot, "downloaded-progress.txt");
+            var progressUpdates = new List<NativeSftpTransferProgress>();
+
+            var interop = new NativeSshInterop();
+            var connection = new NativeSshConnectionOptions
+            {
+                Host = fixture.Host,
+                User = fixture.UserName,
+                Port = fixture.Port,
+                Password = fixture.Password,
+                KnownHostsFilePath = knownHostsPath
+            };
+            var transfer = new NativeSftpTransferOptions
+            {
+                Direction = NativeSftpTransferDirection.Download,
+                Kind = NativeSftpTransferKind.File,
+                RemotePath = remotePath,
+                LocalPath = localPath
+            };
+
+            interop.RunSftpTransfer(
+                connection,
+                transfer,
+                progress: update => progressUpdates.Add(update),
+                CancellationToken.None);
+
+            Assert.NotEmpty(progressUpdates);
+            Assert.Contains(progressUpdates, update => update.BytesTotal > 0);
+            Assert.Equal(expected, File.ReadAllText(localPath));
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
     public async Task NativeSftp_CanUploadFile()
     {
         await using var fixture = await DockerSshFixture.StartAsync();

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
@@ -238,9 +238,11 @@ public sealed class NativeSshDockerE2eTests
             string nestedRemotePath = $"{remoteRoot}/nested";
             string remoteFileA = $"{remoteRoot}/a.txt";
             string remoteFileB = $"{nestedRemotePath}/b.txt";
+            string expectedA = string.Concat(Enumerable.Repeat("alpha-", 32 * 1024));
+            string expectedB = string.Concat(Enumerable.Repeat("beta-", 32 * 1024));
             await fixture.CreateDirectoryAsync(nestedRemotePath);
-            await fixture.WriteTextFileAsync(remoteFileA, string.Concat(Enumerable.Repeat("alpha-", 32 * 1024)));
-            await fixture.WriteTextFileAsync(remoteFileB, string.Concat(Enumerable.Repeat("beta-", 32 * 1024)));
+            await fixture.WriteTextFileAsync(remoteFileA, expectedA);
+            await fixture.WriteTextFileAsync(remoteFileB, expectedB);
 
             SshHostKeyInfo hostKey = await fixture.GetHostKeyAsync();
             string knownHostsPath = Path.Combine(tempRoot, "native_known_hosts.json");
@@ -272,22 +274,55 @@ public sealed class NativeSshDockerE2eTests
                 CancellationToken.None);
 
             string localRoot = Path.Combine(tempRoot, "native-sftp-download-dir-progress");
-            Assert.Equal(string.Concat(Enumerable.Repeat("alpha-", 32 * 1024)), await File.ReadAllTextAsync(Path.Combine(localRoot, "a.txt")));
-            Assert.Equal(string.Concat(Enumerable.Repeat("beta-", 32 * 1024)), await File.ReadAllTextAsync(Path.Combine(localRoot, "nested", "b.txt")));
+            Assert.Equal(expectedA, await File.ReadAllTextAsync(Path.Combine(localRoot, "a.txt")));
+            Assert.Equal(expectedB, await File.ReadAllTextAsync(Path.Combine(localRoot, "nested", "b.txt")));
 
-            Assert.True(progressUpdates.Count > 0, "Expected progress callbacks during directory download.");
+            long expectedBytesA = Encoding.UTF8.GetByteCount(expectedA);
+            long expectedBytesB = Encoding.UTF8.GetByteCount(expectedB);
+            var updatesByPath = new Dictionary<string, List<NativeSftpTransferProgress>>(StringComparer.Ordinal);
+            foreach (NativeSftpTransferProgress update in progressUpdates)
+            {
+                string path = Assert.IsType<string>(update.CurrentPath);
+                if (!updatesByPath.TryGetValue(path, out List<NativeSftpTransferProgress>? updates))
+                {
+                    updates = new List<NativeSftpTransferProgress>();
+                    updatesByPath[path] = updates;
+                }
+
+                updates.Add(update);
+            }
+
+            Assert.True(progressUpdates.Count > 2, $"Expected multiple progress callbacks during directory download, but observed {progressUpdates.Count}.");
             Assert.All(
                 progressUpdates,
                 update => Assert.False(string.IsNullOrWhiteSpace(update.CurrentPath), "Expected each progress callback to include a current path."));
-            Assert.Contains(progressUpdates, update => string.Equals(update.CurrentPath, remoteFileA, StringComparison.Ordinal));
-            Assert.Contains(progressUpdates, update => string.Equals(update.CurrentPath, remoteFileB, StringComparison.Ordinal));
+            Assert.True(updatesByPath.ContainsKey(remoteFileA), $"Expected progress updates for {remoteFileA}.");
+            Assert.True(updatesByPath.ContainsKey(remoteFileB), $"Expected progress updates for {remoteFileB}.");
             Assert.Contains(progressUpdates, update => update.BytesTotal > 0);
             Assert.All(progressUpdates, update => Assert.True(update.BytesDone > 0, "Expected directory progress updates to report copied bytes."));
+            Assert.True(updatesByPath[remoteFileA].Count > 1, $"Expected multiple progress updates for {remoteFileA}, but observed {updatesByPath[remoteFileA].Count}.");
+            Assert.True(updatesByPath[remoteFileB].Count > 1, $"Expected multiple progress updates for {remoteFileB}, but observed {updatesByPath[remoteFileB].Count}.");
+            AssertPathProgress(remoteFileA, updatesByPath[remoteFileA], expectedBytesA);
+            AssertPathProgress(remoteFileB, updatesByPath[remoteFileB], expectedBytesB);
         }
         finally
         {
             Directory.Delete(tempRoot, recursive: true);
         }
+    }
+
+    private static void AssertPathProgress(string remotePath, IReadOnlyList<NativeSftpTransferProgress> updates, long expectedBytes)
+    {
+        Assert.All(updates, update => Assert.Equal(remotePath, update.CurrentPath));
+        Assert.Contains(updates, update => update.BytesTotal > 0);
+        for (int i = 1; i < updates.Count; i++)
+        {
+            Assert.True(
+                updates[i - 1].BytesDone <= updates[i].BytesDone,
+                $"Expected BytesDone for {remotePath} to be monotonic, but observed {updates[i - 1].BytesDone} then {updates[i].BytesDone}.");
+        }
+
+        Assert.Equal(expectedBytes, updates[^1].BytesDone);
     }
 
     [DockerFact]

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
@@ -104,8 +104,19 @@ public sealed class NativeSshDockerE2eTests
                 progress: update => progressUpdates.Add(update),
                 CancellationToken.None);
 
-            Assert.NotEmpty(progressUpdates);
+            long expectedBytes = Encoding.UTF8.GetByteCount(expected);
+
+            Assert.True(progressUpdates.Count > 1, $"Expected multiple progress updates for a multi-chunk download, but observed {progressUpdates.Count}.");
+            Assert.All(progressUpdates, update => Assert.Equal(remotePath, update.CurrentPath));
             Assert.Contains(progressUpdates, update => update.BytesTotal > 0);
+            Assert.All(progressUpdates, update => Assert.True(update.BytesDone > 0, "Expected progress updates to report copied bytes."));
+            for (int i = 1; i < progressUpdates.Count; i++)
+            {
+                Assert.True(
+                    progressUpdates[i - 1].BytesDone <= progressUpdates[i].BytesDone,
+                    $"Expected BytesDone to be monotonic, but observed {progressUpdates[i - 1].BytesDone} then {progressUpdates[i].BytesDone}.");
+            }
+            Assert.Equal(expectedBytes, progressUpdates[^1].BytesDone);
             Assert.Equal(expected, File.ReadAllText(localPath));
         }
         finally

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
@@ -110,6 +110,11 @@ public sealed class NativeSshDockerE2eTests
             Assert.All(progressUpdates, update => Assert.Equal(remotePath, update.CurrentPath));
             Assert.Contains(progressUpdates, update => update.BytesTotal > 0);
             Assert.All(progressUpdates, update => Assert.True(update.BytesDone > 0, "Expected progress updates to report copied bytes."));
+            Assert.Contains(progressUpdates, update => update.BytesDone < expectedBytes);
+            Assert.Contains(progressUpdates, update => update.BytesTotal == expectedBytes);
+            Assert.Contains(
+                Enumerable.Range(1, progressUpdates.Count - 1),
+                index => progressUpdates[index - 1].BytesDone < progressUpdates[index].BytesDone);
             for (int i = 1; i < progressUpdates.Count; i++)
             {
                 Assert.True(
@@ -117,6 +122,7 @@ public sealed class NativeSshDockerE2eTests
                     $"Expected BytesDone to be monotonic, but observed {progressUpdates[i - 1].BytesDone} then {progressUpdates[i].BytesDone}.");
             }
             Assert.Equal(expectedBytes, progressUpdates[^1].BytesDone);
+            Assert.Equal(expectedBytes, progressUpdates[^1].BytesTotal);
             Assert.Equal(expected, File.ReadAllText(localPath));
         }
         finally
@@ -315,6 +321,11 @@ public sealed class NativeSshDockerE2eTests
     {
         Assert.All(updates, update => Assert.Equal(remotePath, update.CurrentPath));
         Assert.Contains(updates, update => update.BytesTotal > 0);
+        Assert.Contains(updates, update => update.BytesDone < expectedBytes);
+        Assert.Contains(updates, update => update.BytesTotal == expectedBytes);
+        Assert.Contains(
+            Enumerable.Range(1, updates.Count - 1),
+            index => updates[index - 1].BytesDone < updates[index].BytesDone);
         for (int i = 1; i < updates.Count; i++)
         {
             Assert.True(
@@ -323,6 +334,7 @@ public sealed class NativeSshDockerE2eTests
         }
 
         Assert.Equal(expectedBytes, updates[^1].BytesDone);
+        Assert.Equal(expectedBytes, updates[^1].BytesTotal);
     }
 
     [DockerFact]

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshRemotePathInteropTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshRemotePathInteropTests.cs
@@ -1,0 +1,47 @@
+using NovaTerminal.Core.Ssh.Models;
+using NovaTerminal.Core.Ssh.Native;
+
+namespace NovaTerminal.Core.Tests.Ssh;
+
+public sealed class NativeSshRemotePathInteropTests
+{
+    [Fact]
+    public void SerializeRemotePathListRequest_UsesGeneratedMetadataAndCamelCasePayload()
+    {
+        NativeSshConnectionOptions connectionOptions = new()
+        {
+            Host = "example.com",
+            User = "nova",
+            Port = 2222,
+            Password = "secret",
+            KnownHostsFilePath = @"C:\known-hosts.json",
+            JumpHost = new SshJumpHop
+            {
+                Host = "jump.internal",
+                User = "jumper",
+                Port = 2200
+            }
+        };
+
+        string json = NativeSshInterop.SerializeRemotePathListRequestForTests(connectionOptions, "/mnt/media");
+
+        Assert.Contains("\"connection\":", json, StringComparison.Ordinal);
+        Assert.Contains("\"path\":\"/mnt/media\"", json, StringComparison.Ordinal);
+        Assert.Contains("\"knownHostsFilePath\":\"C:\\\\known-hosts.json\"", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DeserializeRemotePathListResponse_UsesGeneratedMetadata()
+    {
+        const string json = """
+        {"entries":[{"name":"movies","fullPath":"/mnt/media/movies","isDirectory":true}]}
+        """;
+
+        IReadOnlyList<NativeRemotePathEntry> entries = NativeSshInterop.DeserializeRemotePathListResponseForTests(json);
+
+        Assert.Single(entries);
+        Assert.Equal("movies", entries[0].Name);
+        Assert.Equal("/mnt/media/movies", entries[0].FullPath);
+        Assert.True(entries[0].IsDirectory);
+    }
+}

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionInteractionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionInteractionTests.cs
@@ -177,6 +177,11 @@ public sealed class NativeSshSessionInteractionTests
             throw new NotSupportedException();
         }
 
+        public IReadOnlyList<NativeRemotePathEntry> ListRemoteDirectory(NativeSshConnectionOptions connectionOptions, string remotePath, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
         public NativeSshEvent? PollEvent(IntPtr sessionHandle)
         {
             PollCallCount++;

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionInteractionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionInteractionTests.cs
@@ -172,6 +172,11 @@ public sealed class NativeSshSessionInteractionTests
 
         public IntPtr Connect(NativeSshConnectionOptions options) => new(1);
 
+        public void RunSftpTransfer(NativeSshConnectionOptions connectionOptions, NativeSftpTransferOptions transferOptions, Action<NativeSftpTransferProgress>? progress, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
         public NativeSshEvent? PollEvent(IntPtr sessionHandle)
         {
             PollCallCount++;

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
@@ -219,6 +219,11 @@ public sealed class NativeSshSessionTests
             throw new NotSupportedException();
         }
 
+        public IReadOnlyList<NativeRemotePathEntry> ListRemoteDirectory(NativeSshConnectionOptions connectionOptions, string remotePath, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
         public NativeSshEvent? PollEvent(IntPtr sessionHandle)
         {
             if (sessionHandle == IntPtr.Zero)

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
@@ -214,6 +214,11 @@ public sealed class NativeSshSessionTests
             return new IntPtr(_nextHandle++);
         }
 
+        public void RunSftpTransfer(NativeSshConnectionOptions connectionOptions, NativeSftpTransferOptions transferOptions, Action<NativeSftpTransferProgress>? progress, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
         public NativeSshEvent? PollEvent(IntPtr sessionHandle)
         {
             if (sessionHandle == IntPtr.Zero)

--- a/tests/NovaTerminal.Core.Tests/Ssh/SshSessionFactoryTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/SshSessionFactoryTests.cs
@@ -95,6 +95,7 @@ public sealed class SshSessionFactoryTests
     private sealed class StubNativeSshInterop : INativeSshInterop
     {
         public IntPtr Connect(NativeSshConnectionOptions options) => new(1);
+        public IReadOnlyList<NativeRemotePathEntry> ListRemoteDirectory(NativeSshConnectionOptions connectionOptions, string remotePath, CancellationToken cancellationToken) => throw new NotSupportedException();
         public void RunSftpTransfer(NativeSshConnectionOptions connectionOptions, NativeSftpTransferOptions transferOptions, Action<NativeSftpTransferProgress>? progress, CancellationToken cancellationToken) => throw new NotSupportedException();
         public NativeSshEvent? PollEvent(IntPtr sessionHandle) => null;
         public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data)

--- a/tests/NovaTerminal.Core.Tests/Ssh/SshSessionFactoryTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/SshSessionFactoryTests.cs
@@ -95,6 +95,7 @@ public sealed class SshSessionFactoryTests
     private sealed class StubNativeSshInterop : INativeSshInterop
     {
         public IntPtr Connect(NativeSshConnectionOptions options) => new(1);
+        public void RunSftpTransfer(NativeSshConnectionOptions connectionOptions, NativeSftpTransferOptions transferOptions, Action<NativeSftpTransferProgress>? progress, CancellationToken cancellationToken) => throw new NotSupportedException();
         public NativeSshEvent? PollEvent(IntPtr sessionHandle) => null;
         public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data)
         {

--- a/tests/NovaTerminal.Tests/Core/BackgroundWorkTests.cs
+++ b/tests/NovaTerminal.Tests/Core/BackgroundWorkTests.cs
@@ -1,0 +1,40 @@
+using NovaTerminal.Services;
+
+namespace NovaTerminal.Tests.Core;
+
+public sealed class BackgroundWorkTests
+{
+    [Fact]
+    public async Task RunBlockingAsync_ReturnsPendingTaskWhileBlockingWorkRuns()
+    {
+        using ManualResetEventSlim started = new(false);
+        using ManualResetEventSlim release = new(false);
+
+        Task<int> task = BackgroundWork.RunBlockingAsync(_ =>
+        {
+            started.Set();
+            release.Wait();
+            return 42;
+        });
+
+        Assert.True(started.Wait(TimeSpan.FromSeconds(1)));
+        Assert.False(task.IsCompleted);
+
+        release.Set();
+
+        int result = await task;
+
+        Assert.Equal(42, result);
+    }
+
+    [Fact]
+    public void RunBlockingAsync_ThrowsImmediatelyForCanceledToken()
+    {
+        using CancellationTokenSource cts = new();
+        cts.Cancel();
+
+        Action act = () => BackgroundWork.RunBlockingAsync(_ => 1, cts.Token);
+
+        Assert.Throws<OperationCanceledException>(act);
+    }
+}

--- a/tests/NovaTerminal.Tests/Core/BackgroundWorkTests.cs
+++ b/tests/NovaTerminal.Tests/Core/BackgroundWorkTests.cs
@@ -7,20 +7,20 @@ public sealed class BackgroundWorkTests
     [Fact]
     public async Task RunBlockingAsync_ReturnsPendingTaskWhileBlockingWorkRuns()
     {
-        using ManualResetEventSlim started = new(false);
-        using ManualResetEventSlim release = new(false);
+        TaskCompletionSource started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         Task<int> task = BackgroundWork.RunBlockingAsync(_ =>
         {
-            started.Set();
-            release.Wait();
+            started.SetResult();
+            release.Task.GetAwaiter().GetResult();
             return 42;
         });
 
-        Assert.True(started.Wait(TimeSpan.FromSeconds(1)));
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(10));
         Assert.False(task.IsCompleted);
 
-        release.Set();
+        release.SetResult();
 
         int result = await task;
 

--- a/tests/NovaTerminal.Tests/Core/MainWindowTransferFlowTests.cs
+++ b/tests/NovaTerminal.Tests/Core/MainWindowTransferFlowTests.cs
@@ -1,0 +1,55 @@
+using Avalonia.Headless.XUnit;
+using NovaTerminal.Core;
+using NovaTerminal.Models;
+
+namespace NovaTerminal.Tests.Core;
+
+public sealed class MainWindowTransferFlowTests
+{
+    [AvaloniaFact]
+    public async Task InitiateTransfer_UsesDialogResultAndQueuesJob()
+    {
+        var window = new TestMainWindow
+        {
+            NextTransferDialogResult = TransferDialogResult.CreateConfirmed(
+                localPath: @"D:\downloads\a.mkv",
+                remotePath: "/mnt/box/movies/a.mkv")
+        };
+
+        await window.InitiateSftpTransferForTest(
+            new TerminalProfile
+            {
+                Id = Guid.Parse("4f13d6d8-ea72-4d88-9430-fc5d5f2490c7"),
+                Name = "server3",
+                Type = ConnectionType.SSH,
+                SshBackendKind = NovaTerminal.Core.Ssh.Models.SshBackendKind.Native,
+                DefaultRemoteDir = "~/downloads"
+            },
+            Guid.Parse("35ef4c9d-8cc3-4a4f-a2f1-ef7e5215ad7d"),
+            TransferDirection.Download,
+            TransferKind.File);
+
+        Assert.NotNull(window.QueuedJob);
+        TransferJob job = window.QueuedJob!;
+        Assert.Equal("/mnt/box/movies/a.mkv", job.RemotePath);
+        Assert.Equal(@"D:\downloads\a.mkv", job.LocalPath);
+        Assert.Equal(TransferDirection.Download, job.Direction);
+        Assert.Equal(TransferKind.File, job.Kind);
+    }
+
+    private sealed class TestMainWindow : NovaTerminal.MainWindow
+    {
+        public TransferDialogResult? NextTransferDialogResult { get; set; }
+        public TransferJob? QueuedJob { get; private set; }
+
+        internal override Task<TransferDialogResult?> ShowTransferDialogAsync(TransferDialogRequest request)
+        {
+            return Task.FromResult(NextTransferDialogResult);
+        }
+
+        internal override void EnqueueTransferJob(TransferJob job)
+        {
+            QueuedJob = job;
+        }
+    }
+}

--- a/tests/NovaTerminal.Tests/Core/RemotePathTextBoxTests.cs
+++ b/tests/NovaTerminal.Tests/Core/RemotePathTextBoxTests.cs
@@ -1,0 +1,155 @@
+using Avalonia.Headless.XUnit;
+using NovaTerminal.Controls;
+using NovaTerminal.Models;
+using NovaTerminal.Services.Ssh;
+
+namespace NovaTerminal.Tests.Core;
+
+public sealed class RemotePathTextBoxTests
+{
+    [AvaloniaFact]
+    public async Task RemotePathTextBox_LoadsSuggestions_WhenProfileAndSessionArePresent()
+    {
+        var control = new RemotePathTextBox
+        {
+            ProfileId = Guid.Parse("04b9578d-ecb6-4e25-8ef4-a8212c57de7d"),
+            SessionId = Guid.Parse("cdc282f9-af28-4ad9-b3c2-9164bf9251d6"),
+            AutocompleteService = new FakeRemotePathAutocompleteService(
+                new RemotePathSuggestion("Downloads", "~/Downloads", isDirectory: true))
+        };
+
+        control.SetTextForTest("~/Do");
+
+        await control.RefreshSuggestionsForTestAsync();
+
+        Assert.True(control.AreSuggestionsOpenForTest);
+        Assert.Collection(
+            control.GetSuggestionsForTest(),
+            suggestion => Assert.Equal("Downloads", suggestion.DisplayName));
+    }
+
+    [AvaloniaFact]
+    public async Task RemotePathTextBox_AcceptsDirectorySuggestion_WithTrailingSlash()
+    {
+        var control = new RemotePathTextBox
+        {
+            ProfileId = Guid.Parse("77efbc01-e542-4c83-837f-2a8bd63f1c82"),
+            SessionId = Guid.Parse("a6a3d79c-c06c-4515-b4e7-bf5b1f1a2d98"),
+            AutocompleteService = new FakeRemotePathAutocompleteService(
+                new RemotePathSuggestion("Downloads", "~/Downloads", isDirectory: true))
+        };
+
+        control.SetTextForTest("~/Do");
+        await control.RefreshSuggestionsForTestAsync();
+
+        control.SelectSuggestionForTest(0);
+
+        Assert.Equal("~/Downloads/", control.Text);
+        Assert.False(control.AreSuggestionsOpenForTest);
+    }
+
+    [AvaloniaFact]
+    public async Task RemotePathTextBox_TabOnDirectorySuggestion_ReopensSuggestionsForCompletedDirectory()
+    {
+        var control = new RemotePathTextBox
+        {
+            ProfileId = Guid.Parse("8ee1fb83-f28a-4903-a3db-23c0f7d05e0f"),
+            SessionId = Guid.Parse("102c47f5-5f92-4e87-9fa6-df91d68e77f1"),
+            AutocompleteService = new CallbackRemotePathAutocompleteService(input =>
+            {
+                return input switch
+                {
+                    "~/Do" => [new RemotePathSuggestion("Downloads", "~/Downloads", isDirectory: true)],
+                    "~/Downloads/" => [new RemotePathSuggestion("server", "~/Downloads/server", isDirectory: true)],
+                    _ => []
+                };
+            })
+        };
+        control.SuggestionDebounceDelay = TimeSpan.Zero;
+
+        control.SetTextForTest("~/Do");
+        await control.RefreshSuggestionsForTestAsync();
+
+        await control.AcceptSelectedSuggestionForTestAsync(Avalonia.Input.Key.Tab);
+
+        Assert.Equal("~/Downloads/", control.Text);
+        Assert.True(control.AreSuggestionsOpenForTest);
+        Assert.Collection(
+            control.GetSuggestionsForTest(),
+            suggestion => Assert.Equal("server", suggestion.DisplayName));
+    }
+
+    [AvaloniaFact]
+    public async Task RemotePathTextBox_EnterOnDirectorySuggestion_ClosesSuggestions()
+    {
+        var control = new RemotePathTextBox
+        {
+            ProfileId = Guid.Parse("c28bec92-bd88-48e8-9d4b-6434f2ed8dc8"),
+            SessionId = Guid.Parse("23f85fa1-8632-4a32-a60c-6f77b4d3b966"),
+            AutocompleteService = new FakeRemotePathAutocompleteService(
+                new RemotePathSuggestion("Downloads", "~/Downloads", isDirectory: true))
+        };
+
+        control.SetTextForTest("~/Do");
+        await control.RefreshSuggestionsForTestAsync();
+
+        await control.AcceptSelectedSuggestionForTestAsync(Avalonia.Input.Key.Enter);
+
+        Assert.Equal("~/Downloads/", control.Text);
+        Assert.False(control.AreSuggestionsOpenForTest);
+    }
+
+    [AvaloniaFact]
+    public async Task RemotePathTextBox_TabOnFileSuggestion_CompletesAndClosesSuggestions()
+    {
+        var control = new RemotePathTextBox
+        {
+            ProfileId = Guid.Parse("ff0d46f3-ddf8-45d5-89dd-3f462c64f7e1"),
+            SessionId = Guid.Parse("7d0548dc-1a7a-4b80-a369-c7fe06f78564"),
+            AutocompleteService = new CallbackRemotePathAutocompleteService(input =>
+            {
+                return input switch
+                {
+                    "~/mo" => [new RemotePathSuggestion("movie.mkv", "~/movie.mkv", isDirectory: false)],
+                    _ => []
+                };
+            })
+        };
+        control.SuggestionDebounceDelay = TimeSpan.Zero;
+
+        control.SetTextForTest("~/mo");
+        await control.RefreshSuggestionsForTestAsync();
+
+        await control.AcceptSelectedSuggestionForTestAsync(Avalonia.Input.Key.Tab);
+
+        Assert.Equal("~/movie.mkv", control.Text);
+        Assert.False(control.AreSuggestionsOpenForTest);
+        Assert.Empty(control.GetSuggestionsForTest());
+    }
+
+    private sealed class FakeRemotePathAutocompleteService(params RemotePathSuggestion[] suggestions)
+        : IRemotePathAutocompleteService
+    {
+        public Task<IReadOnlyList<RemotePathSuggestion>> GetSuggestionsAsync(
+            Guid profileId,
+            Guid sessionId,
+            string input,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IReadOnlyList<RemotePathSuggestion>>(suggestions);
+        }
+    }
+
+    private sealed class CallbackRemotePathAutocompleteService(Func<string, IReadOnlyList<RemotePathSuggestion>> callback)
+        : IRemotePathAutocompleteService
+    {
+        public Task<IReadOnlyList<RemotePathSuggestion>> GetSuggestionsAsync(
+            Guid profileId,
+            Guid sessionId,
+            string input,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(callback(input));
+        }
+    }
+}

--- a/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
@@ -221,6 +221,19 @@ public sealed class SftpServiceTests
         Assert.Equal(0.25, job.Progress, 3);
         Assert.False(job.IsProgressIndeterminate);
         Assert.Contains("25%", job.StatusText, StringComparison.Ordinal);
+
+        SftpService.ApplyNativeTransferProgress(job, new NativeSftpTransferProgress
+        {
+            BytesDone = 3072,
+            BytesTotal = 4096,
+            CurrentPath = "/tmp/sample.bin"
+        });
+
+        Assert.Equal(3072, job.BytesDone);
+        Assert.Equal(4096, job.BytesTotal);
+        Assert.Equal(0.75, job.Progress, 3);
+        Assert.False(job.IsProgressIndeterminate);
+        Assert.Contains("75%", job.StatusText, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
@@ -23,6 +23,30 @@ public sealed class SftpServiceTests
     }
 
     [Fact]
+    public void SelectTransferBackend_ForNativeProfile_UsesNativeSftp()
+    {
+        var profile = new TerminalProfile
+        {
+            Type = ConnectionType.SSH,
+            SshBackendKind = SshBackendKind.Native
+        };
+
+        Assert.Equal(SftpTransferBackend.NativeSftp, SftpService.SelectTransferBackend(profile));
+    }
+
+    [Fact]
+    public void SelectTransferBackend_ForOpenSshProfile_UsesExternalScp()
+    {
+        var profile = new TerminalProfile
+        {
+            Type = ConnectionType.SSH,
+            SshBackendKind = SshBackendKind.OpenSsh
+        };
+
+        Assert.Equal(SftpTransferBackend.ExternalScp, SftpService.SelectTransferBackend(profile));
+    }
+
+    [Fact]
     public void ResolveProfileForJob_PrefersProfileIdOverDuplicateName()
     {
         var localProfiles = new List<TerminalProfile>

--- a/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
@@ -271,6 +271,38 @@ public sealed class SftpServiceTests
         Assert.Equal(startedAt, job.StartedAt);
     }
 
+    [Fact]
+    public void BuildNativeTransferOptions_UnescapesShellEscapedRemoteSpaces()
+    {
+        var job = new TransferJob
+        {
+            Direction = TransferDirection.Download,
+            Kind = TransferKind.File,
+            LocalPath = @"D:\downloads\Gravity.2013.1080p.Farsi.Dubbed.MegaMoviBot.mkv",
+            RemotePath = "/mnt/box1/media/movies/Gravity\\ 2013/Gravity.2013.1080p.Farsi.Dubbed.MegaMoviBot.mkv"
+        };
+
+        NativeSftpTransferOptions options = SftpService.BuildNativeTransferOptions(job);
+
+        Assert.Equal("/mnt/box1/media/movies/Gravity 2013/Gravity.2013.1080p.Farsi.Dubbed.MegaMoviBot.mkv", options.RemotePath);
+    }
+
+    [Fact]
+    public void BuildNativeTransferOptions_PreservesLiteralBackslashesThatAreNotShellEscapes()
+    {
+        var job = new TransferJob
+        {
+            Direction = TransferDirection.Download,
+            Kind = TransferKind.File,
+            LocalPath = @"D:\downloads\sample.txt",
+            RemotePath = "/mnt/share/folder\\backup/sample.txt"
+        };
+
+        NativeSftpTransferOptions options = SftpService.BuildNativeTransferOptions(job);
+
+        Assert.Equal("/mnt/share/folder\\backup/sample.txt", options.RemotePath);
+    }
+
     [AvaloniaFact]
     public async Task AddJob_FromBackgroundThread_LeavesJobRunningBeforeReturn()
     {

--- a/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
@@ -1,5 +1,7 @@
 using NovaTerminal.Core;
+using NovaTerminal.Core.Ssh.Native;
 using NovaTerminal.Core.Ssh.Models;
+using NovaTerminal.Core.Ssh.Storage;
 using NovaTerminal.Services.Ssh;
 
 namespace NovaTerminal.Tests.Core;
@@ -44,6 +46,114 @@ public sealed class SftpServiceTests
         };
 
         Assert.Equal(SftpTransferBackend.ExternalScp, SftpService.SelectTransferBackend(profile));
+    }
+
+    [Fact]
+    public void BuildNativeTransferConnectionOptions_UsesProfileTarget()
+    {
+        var service = new SshConnectionService(new InMemorySshProfileStore());
+        var profile = new TerminalProfile
+        {
+            Id = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            Type = ConnectionType.SSH,
+            SshBackendKind = SshBackendKind.Native,
+            SshHost = "prod.internal",
+            SshUser = "ops",
+            SshPort = 2200
+        };
+
+        NativeSshConnectionOptions options = SftpService.BuildNativeTransferConnectionOptions(service, profile);
+
+        Assert.Equal("prod.internal", options.Host);
+        Assert.Equal("ops", options.User);
+        Assert.Equal(2200, options.Port);
+    }
+
+    [Fact]
+    public void BuildNativeTransferConnectionOptions_UsesStoredProfileWhenAvailable()
+    {
+        Guid profileId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+        var store = new InMemorySshProfileStore();
+        store.SaveProfile(new SshProfile
+        {
+            Id = profileId,
+            Name = "Prod",
+            BackendKind = SshBackendKind.Native,
+            Host = "prod.internal",
+            User = "ops",
+            Port = 2200,
+            ServerAliveIntervalSeconds = 45,
+            ServerAliveCountMax = 6,
+            JumpHops = new List<SshJumpHop>
+            {
+                new() { Host = "jump.internal", User = "jumper", Port = 2222 }
+            }
+        });
+        var service = new SshConnectionService(store);
+        TerminalProfile runtimeProfile = service.GetConnectionProfiles().Single(profile => profile.Id == profileId);
+
+        NativeSshConnectionOptions options = SftpService.BuildNativeTransferConnectionOptions(service, runtimeProfile);
+
+        Assert.Equal("prod.internal", options.Host);
+        Assert.Equal("ops", options.User);
+        Assert.Equal(2200, options.Port);
+        Assert.Equal(45, options.KeepAliveIntervalSeconds);
+        Assert.Equal(6, options.KeepAliveCountMax);
+        Assert.NotNull(options.JumpHost);
+        Assert.Equal("jump.internal", options.JumpHost!.Host);
+        Assert.Equal("jumper", options.JumpHost.User);
+        Assert.Equal(2222, options.JumpHost.Port);
+    }
+
+    [Fact]
+    public void BuildNativeTransferConnectionOptions_ThrowsWhenJumpHostFallbackHasNoProfileList()
+    {
+        var service = new SshConnectionService(new InMemorySshProfileStore());
+        var targetProfile = new TerminalProfile
+        {
+            Id = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd"),
+            Type = ConnectionType.SSH,
+            SshBackendKind = SshBackendKind.Native,
+            SshHost = "prod.internal",
+            SshUser = "ops",
+            JumpHostProfileId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+        };
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => SftpService.BuildNativeTransferConnectionOptions(service, targetProfile));
+
+        Assert.Contains("allProfiles", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildNativeTransferConnectionOptions_UsesResolvedJumpHost()
+    {
+        var service = new SshConnectionService(new InMemorySshProfileStore());
+        Guid jumpId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        var jumpProfile = new TerminalProfile
+        {
+            Id = jumpId,
+            Type = ConnectionType.SSH,
+            SshHost = "jump.internal",
+            SshUser = "jumper",
+            SshPort = 2222
+        };
+        var targetProfile = new TerminalProfile
+        {
+            Id = Guid.Parse("cccccccc-cccc-cccc-cccc-ccccccccccce"),
+            Type = ConnectionType.SSH,
+            SshBackendKind = SshBackendKind.Native,
+            SshHost = "prod.internal",
+            SshUser = "ops",
+            JumpHostProfileId = jumpId
+        };
+
+        NativeSshConnectionOptions options = SftpService.BuildNativeTransferConnectionOptions(service, targetProfile, new[] { jumpProfile, targetProfile });
+
+        Assert.NotNull(options.JumpHost);
+        Assert.Equal("jump.internal", options.JumpHost!.Host);
+        Assert.Equal("jumper", options.JumpHost.User);
+        Assert.Equal(2222, options.JumpHost.Port);
     }
 
     [Fact]
@@ -233,5 +343,21 @@ public sealed class SftpServiceTests
 
         Assert.True(startInfo.RedirectStandardError);
         Assert.True(startInfo.CreateNoWindow);
+    }
+
+    private sealed class InMemorySshProfileStore : ISshProfileStore
+    {
+        private readonly Dictionary<Guid, SshProfile> _profiles = new();
+
+        public IReadOnlyList<SshProfile> GetProfiles() => _profiles.Values.ToArray();
+
+        public SshProfile? GetProfile(Guid profileId) => _profiles.GetValueOrDefault(profileId);
+
+        public void SaveProfile(SshProfile profile)
+        {
+            _profiles[profile.Id] = profile;
+        }
+
+        public bool DeleteProfile(Guid profileId) => _profiles.Remove(profileId);
     }
 }

--- a/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
@@ -49,7 +49,7 @@ public sealed class SftpServiceTests
     }
 
     [Fact]
-    public void SelectExecutionBackend_ForNativeFolder_UsesExternalScpUntilDirectorySupportExists()
+    public void SelectExecutionBackend_ForNativeFolder_UsesNativeSftp()
     {
         var profile = new TerminalProfile
         {
@@ -64,7 +64,7 @@ public sealed class SftpServiceTests
             RemotePath = "/tmp/folder"
         };
 
-        Assert.Equal(SftpTransferBackend.ExternalScp, SftpService.SelectExecutionBackend(profile, job));
+        Assert.Equal(SftpTransferBackend.NativeSftp, SftpService.SelectExecutionBackend(profile, job));
     }
 
     [Fact]
@@ -378,14 +378,14 @@ public sealed class SftpServiceTests
     }
 
     [Fact]
-    public void BuildScpArguments_ForNativeBackend_AllowsInteractiveAuthentication()
+    public void BuildScpArguments_ForOpenSshBackend_UsesBatchMode()
     {
         var profile = new TerminalProfile
         {
             Id = Guid.Parse("39292451-ad10-4f26-aeb7-2175527a66be"),
-            Name = "Native Prod",
+            Name = "OpenSSH Prod",
             Type = ConnectionType.SSH,
-            SshBackendKind = SshBackendKind.Native,
+            SshBackendKind = SshBackendKind.OpenSsh,
             SshHost = "prod.internal",
             SshUser = "ops"
         };
@@ -403,18 +403,18 @@ public sealed class SftpServiceTests
         string args = SftpService.BuildScpArguments(job, profile, launchDetails: null);
 
         Assert.Contains(" -O ", args, StringComparison.Ordinal);
-        Assert.DoesNotContain(" -B ", args, StringComparison.Ordinal);
+        Assert.Contains(" -B ", args, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void CreateScpStartInfo_ForNativeBackend_UsesAskPassAndStaysHidden()
+    public void CreateScpStartInfo_DoesNotConfigureAskPass()
     {
         var profile = new TerminalProfile
         {
             Id = Guid.Parse("e15099d2-ac29-40cb-bf1f-f466eb2622b7"),
-            Name = "Native Prod",
+            Name = "OpenSSH Prod",
             Type = ConnectionType.SSH,
-            SshBackendKind = SshBackendKind.Native,
+            SshBackendKind = SshBackendKind.OpenSsh,
             SshHost = "prod.internal",
             SshUser = "ops",
             SshPort = 2200
@@ -424,14 +424,8 @@ public sealed class SftpServiceTests
 
         Assert.True(startInfo.RedirectStandardError);
         Assert.True(startInfo.CreateNoWindow);
-        Assert.Equal("1", startInfo.Environment[SshAskPassCommand.ModeEnvironmentVariable]);
-        Assert.Equal("force", startInfo.Environment["SSH_ASKPASS_REQUIRE"]);
-        Assert.False(string.IsNullOrWhiteSpace(startInfo.Environment["SSH_ASKPASS"]));
-        Assert.Equal(profile.Id.ToString(), startInfo.Environment[SshAskPassCommand.ProfileIdEnvironmentVariable]);
-        Assert.Equal("Native Prod", startInfo.Environment[SshAskPassCommand.ProfileNameEnvironmentVariable]);
-        Assert.Equal("ops", startInfo.Environment[SshAskPassCommand.ProfileUserEnvironmentVariable]);
-        Assert.Equal("prod.internal", startInfo.Environment[SshAskPassCommand.ProfileHostEnvironmentVariable]);
-        Assert.Equal("2200", startInfo.Environment[SshAskPassCommand.ProfilePortEnvironmentVariable]);
+        Assert.False(startInfo.Environment.ContainsKey("SSH_ASKPASS"));
+        Assert.False(startInfo.Environment.ContainsKey("SSH_ASKPASS_REQUIRE"));
     }
 
     [Fact]

--- a/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
@@ -207,6 +207,23 @@ public sealed class SftpServiceTests
     }
 
     [Fact]
+    public void ApplyNativeTransferProgress_UpdatesDisplayStateForKnownTotals()
+    {
+        var job = new TransferJob { State = TransferState.Running };
+
+        SftpService.ApplyNativeTransferProgress(job, new NativeSftpTransferProgress
+        {
+            BytesDone = 1024,
+            BytesTotal = 4096,
+            CurrentPath = "/tmp/sample.bin"
+        });
+
+        Assert.Equal(0.25, job.Progress, 3);
+        Assert.False(job.IsProgressIndeterminate);
+        Assert.Contains("25%", job.StatusText, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void TransferJob_DownloadDisplayName_UsesRemoteLeaf()
     {
         var job = new TransferJob

--- a/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
@@ -153,6 +153,60 @@ public sealed class SftpServiceTests
     }
 
     [Fact]
+    public void ExecuteNativeSftpTransfer_ForwardsCancellationTokenToInterop()
+    {
+        var service = new SshConnectionService(new InMemorySshProfileStore());
+        var profile = new TerminalProfile
+        {
+            Id = Guid.Parse("01984da2-06b2-77a3-b8cd-cad971781eec"),
+            Type = ConnectionType.SSH,
+            SshBackendKind = SshBackendKind.Native,
+            SshHost = "prod.internal",
+            SshUser = "ops",
+            SshPort = 2200
+        };
+        var job = new TransferJob
+        {
+            Direction = TransferDirection.Download,
+            Kind = TransferKind.File,
+            LocalPath = @"C:\tmp\download.txt",
+            RemotePath = "/tmp/download.txt"
+        };
+        var interop = new CapturingNativeSshInterop();
+        using var cts = new CancellationTokenSource();
+
+        SftpService.ExecuteNativeSftpTransfer(
+            job,
+            profile,
+            service,
+            allProfiles: null,
+            interop: interop,
+            passwordResolver: static _ => "vault-pass",
+            knownHostsFilePath: @"C:\ssh\native_known_hosts.json",
+            cancellationToken: cts.Token);
+
+        Assert.True(interop.CancellationToken.CanBeCanceled);
+    }
+
+    [Fact]
+    public void ApplyNativeTransferProgress_MapsBytesAndFraction()
+    {
+        var job = new TransferJob();
+        var progress = new NativeSftpTransferProgress
+        {
+            BytesDone = 25,
+            BytesTotal = 100,
+            CurrentPath = "/tmp/file.txt"
+        };
+
+        SftpService.ApplyNativeTransferProgress(job, progress);
+
+        Assert.Equal(25, job.BytesDone);
+        Assert.Equal(100, job.BytesTotal);
+        Assert.Equal(0.25, job.Progress, 3);
+    }
+
+    [Fact]
     public void BuildNativeTransferConnectionOptions_UsesProfileTarget()
     {
         var service = new SshConnectionService(new InMemorySshProfileStore());
@@ -463,6 +517,7 @@ public sealed class SftpServiceTests
     {
         public NativeSshConnectionOptions? ConnectionOptions { get; private set; }
         public NativeSftpTransferOptions? TransferOptions { get; private set; }
+        public CancellationToken CancellationToken { get; private set; }
 
         public IntPtr Connect(NativeSshConnectionOptions options) => throw new NotSupportedException();
 
@@ -474,6 +529,7 @@ public sealed class SftpServiceTests
         {
             ConnectionOptions = connectionOptions;
             TransferOptions = transferOptions;
+            CancellationToken = cancellationToken;
         }
 
         public NativeSshEvent? PollEvent(IntPtr sessionHandle) => throw new NotSupportedException();

--- a/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
@@ -1,10 +1,27 @@
 using NovaTerminal.Core;
+using NovaTerminal.Core.Ssh.Models;
 using NovaTerminal.Services.Ssh;
 
 namespace NovaTerminal.Tests.Core;
 
 public sealed class SftpServiceTests
 {
+    [Fact]
+    public void SshAskPassCommand_IsSupportedCliMode_WhenEnvironmentFlagIsSet()
+    {
+        string? previous = Environment.GetEnvironmentVariable(SshAskPassCommand.ModeEnvironmentVariable);
+        try
+        {
+            Environment.SetEnvironmentVariable(SshAskPassCommand.ModeEnvironmentVariable, "1");
+
+            Assert.True(SshAskPassCommand.IsSupportedCliMode(Array.Empty<string>()));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(SshAskPassCommand.ModeEnvironmentVariable, previous);
+        }
+    }
+
     [Fact]
     public void ResolveProfileForJob_PrefersProfileIdOverDuplicateName()
     {
@@ -89,6 +106,108 @@ public sealed class SftpServiceTests
         Assert.Contains(" -F ", args, StringComparison.Ordinal);
         Assert.Contains("ssh_config.generated", args, StringComparison.Ordinal);
         Assert.Contains("nova_abc123:", args, StringComparison.Ordinal);
+        Assert.Contains(" -O ", args, StringComparison.Ordinal);
         Assert.DoesNotContain(" -J ", args, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildScpArguments_ForDownload_UsesLegacyScpProtocol()
+    {
+        var profile = new TerminalProfile
+        {
+            Id = Guid.Parse("81e8e7e4-4034-4c4b-9cc4-d0894a465d9d"),
+            Name = "Prod",
+            Type = ConnectionType.SSH,
+            SshHost = "prod.internal",
+            SshUser = "ops"
+        };
+
+        var job = new TransferJob
+        {
+            ProfileId = profile.Id,
+            ProfileName = profile.Name,
+            Direction = TransferDirection.Download,
+            Kind = TransferKind.File,
+            LocalPath = @"C:\tmp\remote.txt",
+            RemotePath = "/tmp/remote.txt"
+        };
+
+        string args = SftpService.BuildScpArguments(job, profile, launchDetails: null);
+
+        Assert.Contains(" -O ", args, StringComparison.Ordinal);
+        Assert.Contains("ops@prod.internal:", args, StringComparison.Ordinal);
+        Assert.Matches(@"ops@prod\.internal:""/tmp/remote\.txt""\s+""C:/tmp/remote\.txt""$", args);
+    }
+
+    [Fact]
+    public void BuildScpArguments_ForNativeBackend_AllowsInteractiveAuthentication()
+    {
+        var profile = new TerminalProfile
+        {
+            Id = Guid.Parse("39292451-ad10-4f26-aeb7-2175527a66be"),
+            Name = "Native Prod",
+            Type = ConnectionType.SSH,
+            SshBackendKind = SshBackendKind.Native,
+            SshHost = "prod.internal",
+            SshUser = "ops"
+        };
+
+        var job = new TransferJob
+        {
+            ProfileId = profile.Id,
+            ProfileName = profile.Name,
+            Direction = TransferDirection.Download,
+            Kind = TransferKind.File,
+            LocalPath = @"C:\tmp\remote.txt",
+            RemotePath = "/tmp/remote.txt"
+        };
+
+        string args = SftpService.BuildScpArguments(job, profile, launchDetails: null);
+
+        Assert.Contains(" -O ", args, StringComparison.Ordinal);
+        Assert.DoesNotContain(" -B ", args, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateScpStartInfo_ForNativeBackend_UsesAskPassAndStaysHidden()
+    {
+        var profile = new TerminalProfile
+        {
+            Id = Guid.Parse("e15099d2-ac29-40cb-bf1f-f466eb2622b7"),
+            Name = "Native Prod",
+            Type = ConnectionType.SSH,
+            SshBackendKind = SshBackendKind.Native,
+            SshHost = "prod.internal",
+            SshUser = "ops",
+            SshPort = 2200
+        };
+
+        var startInfo = SftpService.CreateScpStartInfo("scp.exe", "-O source target", profile);
+
+        Assert.True(startInfo.RedirectStandardError);
+        Assert.True(startInfo.CreateNoWindow);
+        Assert.Equal("1", startInfo.Environment[SshAskPassCommand.ModeEnvironmentVariable]);
+        Assert.Equal("force", startInfo.Environment["SSH_ASKPASS_REQUIRE"]);
+        Assert.False(string.IsNullOrWhiteSpace(startInfo.Environment["SSH_ASKPASS"]));
+        Assert.Equal(profile.Id.ToString(), startInfo.Environment[SshAskPassCommand.ProfileIdEnvironmentVariable]);
+        Assert.Equal("Native Prod", startInfo.Environment[SshAskPassCommand.ProfileNameEnvironmentVariable]);
+        Assert.Equal("ops", startInfo.Environment[SshAskPassCommand.ProfileUserEnvironmentVariable]);
+        Assert.Equal("prod.internal", startInfo.Environment[SshAskPassCommand.ProfileHostEnvironmentVariable]);
+        Assert.Equal("2200", startInfo.Environment[SshAskPassCommand.ProfilePortEnvironmentVariable]);
+    }
+
+    [Fact]
+    public void CreateScpStartInfo_ForOpenSshBackend_StaysHiddenAndCapturesErrors()
+    {
+        var profile = new TerminalProfile
+        {
+            Type = ConnectionType.SSH,
+            SshBackendKind = SshBackendKind.OpenSsh
+        };
+
+        var startInfo = SftpService.CreateScpStartInfo("scp.exe", "-O -B source target", profile);
+
+        Assert.True(startInfo.RedirectStandardError);
+        Assert.True(startInfo.CreateNoWindow);
     }
 }

--- a/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
@@ -304,6 +304,56 @@ public sealed class SftpServiceTests
     }
 
     [AvaloniaFact]
+    public void ClearInactiveJobs_RemovesFinishedFailedAndCanceledOnly()
+    {
+        var sut = new SftpService(null, null, null);
+        sut.Jobs.Add(new TransferJob { State = TransferState.Running, RemotePath = "/tmp/running" });
+        sut.Jobs.Add(new TransferJob { State = TransferState.Completed, RemotePath = "/tmp/completed" });
+        sut.Jobs.Add(new TransferJob { State = TransferState.Failed, RemotePath = "/tmp/failed" });
+        sut.Jobs.Add(new TransferJob { State = TransferState.Canceled, RemotePath = "/tmp/canceled" });
+
+        sut.ClearInactiveJobs();
+
+        Assert.Single(sut.Jobs);
+        Assert.Equal(TransferState.Running, sut.Jobs[0].State);
+    }
+
+    [AvaloniaFact]
+    public void ClearFailedJobs_RemovesOnlyFailedTransfers()
+    {
+        var sut = new SftpService(null, null, null);
+        sut.Jobs.Add(new TransferJob { State = TransferState.Running, RemotePath = "/tmp/running" });
+        sut.Jobs.Add(new TransferJob { State = TransferState.Failed, RemotePath = "/tmp/failed" });
+        sut.Jobs.Add(new TransferJob { State = TransferState.Completed, RemotePath = "/tmp/completed" });
+
+        sut.ClearFailedJobs();
+
+        Assert.Equal(2, sut.Jobs.Count);
+        Assert.DoesNotContain(sut.Jobs, job => job.State == TransferState.Failed);
+        Assert.Contains(sut.Jobs, job => job.State == TransferState.Running);
+        Assert.Contains(sut.Jobs, job => job.State == TransferState.Completed);
+    }
+
+    [AvaloniaFact]
+    public void RemoveJob_RemovesOnlyTheRequestedInactiveTransfer()
+    {
+        var sut = new SftpService(null, null, null);
+        var completed = new TransferJob { Id = Guid.NewGuid(), State = TransferState.Completed, RemotePath = "/tmp/completed" };
+        var failed = new TransferJob { Id = Guid.NewGuid(), State = TransferState.Failed, RemotePath = "/tmp/failed" };
+        var running = new TransferJob { Id = Guid.NewGuid(), State = TransferState.Running, RemotePath = "/tmp/running" };
+        sut.Jobs.Add(completed);
+        sut.Jobs.Add(failed);
+        sut.Jobs.Add(running);
+
+        sut.RemoveJob(failed.Id);
+
+        Assert.Equal(2, sut.Jobs.Count);
+        Assert.Contains(sut.Jobs, job => job.Id == completed.Id);
+        Assert.DoesNotContain(sut.Jobs, job => job.Id == failed.Id);
+        Assert.Contains(sut.Jobs, job => job.Id == running.Id);
+    }
+
+    [AvaloniaFact]
     public async Task AddJob_FromBackgroundThread_LeavesJobRunningBeforeReturn()
     {
         Guid profileId = Guid.Parse("d89c3426-bd78-4b6c-8bf8-3d2810b263c1");

--- a/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
@@ -237,6 +237,40 @@ public sealed class SftpServiceTests
     }
 
     [Fact]
+    public void MarkJobRunning_TransitionsQueuedJobToRunningImmediately()
+    {
+        var job = new TransferJob
+        {
+            Direction = TransferDirection.Download,
+            Kind = TransferKind.Folder,
+            RemotePath = "/tmp/archive"
+        };
+
+        SftpService.MarkJobRunning(job);
+
+        Assert.Equal(TransferState.Running, job.State);
+        Assert.NotEqual(default, job.StartedAt);
+        Assert.Equal("Transferring...", job.StatusText);
+        Assert.True(job.IsProgressIndeterminate);
+    }
+
+    [Fact]
+    public void MarkJobRunning_DoesNotOverwriteExistingStartTime()
+    {
+        DateTime startedAt = new(2026, 4, 28, 12, 0, 0, DateTimeKind.Local);
+        var job = new TransferJob
+        {
+            State = TransferState.Queued,
+            StartedAt = startedAt
+        };
+
+        SftpService.MarkJobRunning(job);
+
+        Assert.Equal(TransferState.Running, job.State);
+        Assert.Equal(startedAt, job.StartedAt);
+    }
+
+    [Fact]
     public void TransferJob_DownloadDisplayName_UsesRemoteLeaf()
     {
         var job = new TransferJob

--- a/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
@@ -49,6 +49,110 @@ public sealed class SftpServiceTests
     }
 
     [Fact]
+    public void SelectExecutionBackend_ForNativeFolder_UsesExternalScpUntilDirectorySupportExists()
+    {
+        var profile = new TerminalProfile
+        {
+            Type = ConnectionType.SSH,
+            SshBackendKind = SshBackendKind.Native
+        };
+        var job = new TransferJob
+        {
+            Direction = TransferDirection.Download,
+            Kind = TransferKind.Folder,
+            LocalPath = @"C:\tmp\folder",
+            RemotePath = "/tmp/folder"
+        };
+
+        Assert.Equal(SftpTransferBackend.ExternalScp, SftpService.SelectExecutionBackend(profile, job));
+    }
+
+    [Fact]
+    public void ExecuteNativeSftpTransfer_UsesVaultPasswordKnownHostsAndInterop()
+    {
+        var service = new SshConnectionService(new InMemorySshProfileStore());
+        var profile = new TerminalProfile
+        {
+            Id = Guid.Parse("01984d8a-2ab0-72c8-b66f-965f8491a6ae"),
+            Type = ConnectionType.SSH,
+            SshBackendKind = SshBackendKind.Native,
+            SshHost = "prod.internal",
+            SshUser = "ops",
+            SshPort = 2200
+        };
+        var job = new TransferJob
+        {
+            Direction = TransferDirection.Download,
+            Kind = TransferKind.File,
+            LocalPath = @"C:\tmp\download.txt",
+            RemotePath = "/tmp/download.txt"
+        };
+        var interop = new CapturingNativeSshInterop();
+
+        SftpService.ExecuteNativeSftpTransfer(
+            job,
+            profile,
+            service,
+            allProfiles: null,
+            interop: interop,
+            passwordResolver: static _ => "vault-pass",
+            knownHostsFilePath: @"C:\ssh\native_known_hosts.json");
+
+        Assert.NotNull(interop.ConnectionOptions);
+        Assert.NotNull(interop.TransferOptions);
+        Assert.Equal("prod.internal", interop.ConnectionOptions!.Host);
+        Assert.Equal("ops", interop.ConnectionOptions.User);
+        Assert.Equal(2200, interop.ConnectionOptions.Port);
+        Assert.Equal("vault-pass", interop.ConnectionOptions.Password);
+        Assert.Equal(@"C:\ssh\native_known_hosts.json", interop.ConnectionOptions.KnownHostsFilePath);
+        Assert.Equal(NativeSftpTransferDirection.Download, interop.TransferOptions!.Direction);
+        Assert.Equal(NativeSftpTransferKind.File, interop.TransferOptions.Kind);
+        Assert.Equal(@"C:\tmp\download.txt", interop.TransferOptions.LocalPath);
+        Assert.Equal("/tmp/download.txt", interop.TransferOptions.RemotePath);
+    }
+
+    [Fact]
+    public void ExecuteNativeSftpTransfer_PrefersIdentityFileOverVaultPassword()
+    {
+        Guid profileId = Guid.Parse("01984d8f-4c31-7ae9-b8f2-7de0093b5cf7");
+        var store = new InMemorySshProfileStore();
+        store.SaveProfile(new SshProfile
+        {
+            Id = profileId,
+            Name = "Keyed",
+            BackendKind = SshBackendKind.Native,
+            Host = "prod.internal",
+            User = "ops",
+            Port = 2200,
+            AuthMode = SshAuthMode.IdentityFile,
+            IdentityFilePath = @"C:\keys\id_ed25519"
+        });
+        var service = new SshConnectionService(store);
+        TerminalProfile profile = service.GetConnectionProfiles().Single(connection => connection.Id == profileId);
+        var job = new TransferJob
+        {
+            Direction = TransferDirection.Upload,
+            Kind = TransferKind.File,
+            LocalPath = @"C:\tmp\upload.txt",
+            RemotePath = "/tmp/upload.txt"
+        };
+        var interop = new CapturingNativeSshInterop();
+
+        SftpService.ExecuteNativeSftpTransfer(
+            job,
+            profile,
+            service,
+            allProfiles: null,
+            interop: interop,
+            passwordResolver: static _ => "stale-vault-password",
+            knownHostsFilePath: @"C:\ssh\native_known_hosts.json");
+
+        Assert.NotNull(interop.ConnectionOptions);
+        Assert.Equal(@"C:\keys\id_ed25519", interop.ConnectionOptions!.IdentityFilePath);
+        Assert.Null(interop.ConnectionOptions.Password);
+    }
+
+    [Fact]
     public void BuildNativeTransferConnectionOptions_UsesProfileTarget()
     {
         var service = new SshConnectionService(new InMemorySshProfileStore());
@@ -359,5 +463,33 @@ public sealed class SftpServiceTests
         }
 
         public bool DeleteProfile(Guid profileId) => _profiles.Remove(profileId);
+    }
+
+    private sealed class CapturingNativeSshInterop : INativeSshInterop
+    {
+        public NativeSshConnectionOptions? ConnectionOptions { get; private set; }
+        public NativeSftpTransferOptions? TransferOptions { get; private set; }
+
+        public IntPtr Connect(NativeSshConnectionOptions options) => throw new NotSupportedException();
+
+        public void RunSftpTransfer(
+            NativeSshConnectionOptions connectionOptions,
+            NativeSftpTransferOptions transferOptions,
+            Action<NativeSftpTransferProgress>? progress,
+            CancellationToken cancellationToken)
+        {
+            ConnectionOptions = connectionOptions;
+            TransferOptions = transferOptions;
+        }
+
+        public NativeSshEvent? PollEvent(IntPtr sessionHandle) => throw new NotSupportedException();
+        public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void Resize(IntPtr sessionHandle, int cols, int rows) => throw new NotSupportedException();
+        public int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options) => throw new NotSupportedException();
+        public void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void SendChannelEof(IntPtr sessionHandle, int channelId) => throw new NotSupportedException();
+        public void CloseChannel(IntPtr sessionHandle, int channelId) => throw new NotSupportedException();
+        public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void Close(IntPtr sessionHandle) => throw new NotSupportedException();
     }
 }

--- a/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
@@ -207,6 +207,42 @@ public sealed class SftpServiceTests
     }
 
     [Fact]
+    public void TransferJob_DownloadDisplayName_UsesRemoteLeaf()
+    {
+        var job = new TransferJob
+        {
+            Direction = TransferDirection.Download,
+            Kind = TransferKind.Folder,
+            LocalPath = @"C:\downloads",
+            RemotePath = "/var/log/archive/"
+        };
+
+        Assert.Equal("archive", job.DisplayName);
+        Assert.Equal("archive", job.FileName);
+        Assert.Equal("Remote: /var/log/archive/", job.RemotePathText);
+        Assert.Equal(@"Local: C:\downloads", job.LocalPathText);
+    }
+
+    [Fact]
+    public void TransferJob_StatusText_UpdatesWhenProgressChanges()
+    {
+        var job = new TransferJob
+        {
+            Direction = TransferDirection.Download,
+            Kind = TransferKind.File,
+            RemotePath = "/tmp/report.tar.gz",
+            State = TransferState.Running
+        };
+
+        job.BytesDone = 512;
+        job.BytesTotal = 1024;
+        job.Progress = 0.5;
+
+        Assert.Equal("512 B of 1 KB (50%)", job.StatusText);
+        Assert.False(job.IsProgressIndeterminate);
+    }
+
+    [Fact]
     public void BuildNativeTransferConnectionOptions_UsesProfileTarget()
     {
         var service = new SshConnectionService(new InMemorySshProfileStore());

--- a/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
@@ -1,3 +1,4 @@
+using Avalonia.Headless.XUnit;
 using NovaTerminal.Core;
 using NovaTerminal.Core.Ssh.Native;
 using NovaTerminal.Core.Ssh.Models;
@@ -268,6 +269,57 @@ public sealed class SftpServiceTests
 
         Assert.Equal(TransferState.Running, job.State);
         Assert.Equal(startedAt, job.StartedAt);
+    }
+
+    [AvaloniaFact]
+    public async Task AddJob_FromBackgroundThread_LeavesJobRunningBeforeReturn()
+    {
+        Guid profileId = Guid.Parse("d89c3426-bd78-4b6c-8bf8-3d2810b263c1");
+        var store = new InMemorySshProfileStore();
+        store.SaveProfile(new SshProfile
+        {
+            Id = profileId,
+            Name = "Native",
+            BackendKind = SshBackendKind.Native,
+            Host = "prod.internal",
+            User = "ops",
+            Port = 2200,
+            AuthMode = SshAuthMode.Default
+        });
+        var sshService = new SshConnectionService(store);
+        TerminalProfile profile = sshService.GetConnectionProfiles().Single(connection => connection.Id == profileId);
+        var interop = new BlockingNativeSshInterop();
+        var sut = new SftpService(
+            interop,
+            settingsLoader: () => new TerminalSettings { Profiles = new List<TerminalProfile> { profile } },
+            sshServiceFactory: () => sshService);
+        var job = new TransferJob
+        {
+            SessionId = Guid.NewGuid(),
+            ProfileId = profile.Id,
+            ProfileName = profile.Name,
+            Direction = TransferDirection.Download,
+            Kind = TransferKind.File,
+            LocalPath = @"C:\tmp\movie.mkv",
+            RemotePath = "/mnt/box/media/movies/movie.mkv"
+        };
+
+        TransferState stateAfterAddReturns = TransferState.Failed;
+        string statusAfterAddReturns = string.Empty;
+
+        await Task.Run(() =>
+        {
+            sut.AddJob(job);
+            stateAfterAddReturns = job.State;
+            statusAfterAddReturns = job.StatusText;
+        });
+
+        Assert.True(interop.Started.Wait(TimeSpan.FromSeconds(2)), "Native transfer worker did not start.");
+        Assert.Equal(TransferState.Running, stateAfterAddReturns);
+        Assert.Equal("Transferring...", statusAfterAddReturns);
+        Assert.Equal(TransferState.Running, job.State);
+
+        interop.Release.Set();
     }
 
     [Fact]
@@ -630,6 +682,34 @@ public sealed class SftpServiceTests
             ConnectionOptions = connectionOptions;
             TransferOptions = transferOptions;
             CancellationToken = cancellationToken;
+        }
+
+        public NativeSshEvent? PollEvent(IntPtr sessionHandle) => throw new NotSupportedException();
+        public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void Resize(IntPtr sessionHandle, int cols, int rows) => throw new NotSupportedException();
+        public int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options) => throw new NotSupportedException();
+        public void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void SendChannelEof(IntPtr sessionHandle, int channelId) => throw new NotSupportedException();
+        public void CloseChannel(IntPtr sessionHandle, int channelId) => throw new NotSupportedException();
+        public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void Close(IntPtr sessionHandle) => throw new NotSupportedException();
+    }
+
+    private sealed class BlockingNativeSshInterop : INativeSshInterop
+    {
+        public ManualResetEventSlim Started { get; } = new(false);
+        public ManualResetEventSlim Release { get; } = new(false);
+
+        public IntPtr Connect(NativeSshConnectionOptions options) => throw new NotSupportedException();
+
+        public void RunSftpTransfer(
+            NativeSshConnectionOptions connectionOptions,
+            NativeSftpTransferOptions transferOptions,
+            Action<NativeSftpTransferProgress>? progress,
+            CancellationToken cancellationToken)
+        {
+            Started.Set();
+            Release.Wait(cancellationToken);
         }
 
         public NativeSshEvent? PollEvent(IntPtr sessionHandle) => throw new NotSupportedException();

--- a/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Core/SftpServiceTests.cs
@@ -751,6 +751,7 @@ public sealed class SftpServiceTests
     {
         public NativeSshConnectionOptions? ConnectionOptions { get; private set; }
         public NativeSftpTransferOptions? TransferOptions { get; private set; }
+        public string? ListedRemotePath { get; private set; }
         public CancellationToken CancellationToken { get; private set; }
 
         public IntPtr Connect(NativeSshConnectionOptions options) => throw new NotSupportedException();
@@ -764,6 +765,17 @@ public sealed class SftpServiceTests
             ConnectionOptions = connectionOptions;
             TransferOptions = transferOptions;
             CancellationToken = cancellationToken;
+        }
+
+        public IReadOnlyList<NativeRemotePathEntry> ListRemoteDirectory(
+            NativeSshConnectionOptions connectionOptions,
+            string remotePath,
+            CancellationToken cancellationToken)
+        {
+            ConnectionOptions = connectionOptions;
+            ListedRemotePath = remotePath;
+            CancellationToken = cancellationToken;
+            return [];
         }
 
         public NativeSshEvent? PollEvent(IntPtr sessionHandle) => throw new NotSupportedException();
@@ -793,6 +805,11 @@ public sealed class SftpServiceTests
             Started.Set();
             Release.Wait(cancellationToken);
         }
+
+        public IReadOnlyList<NativeRemotePathEntry> ListRemoteDirectory(
+            NativeSshConnectionOptions connectionOptions,
+            string remotePath,
+            CancellationToken cancellationToken) => throw new NotSupportedException();
 
         public NativeSshEvent? PollEvent(IntPtr sessionHandle) => throw new NotSupportedException();
         public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data) => throw new NotSupportedException();

--- a/tests/NovaTerminal.Tests/Core/TransferDialogRequestTests.cs
+++ b/tests/NovaTerminal.Tests/Core/TransferDialogRequestTests.cs
@@ -1,0 +1,32 @@
+using NovaTerminal.Core;
+using NovaTerminal.Models;
+
+namespace NovaTerminal.Tests.Core;
+
+public sealed class TransferDialogRequestTests
+{
+    [Fact]
+    public void ForAction_UsesRequestedModeAndDefaultRemotePath()
+    {
+        TransferDialogRequest request = TransferDialogRequest.ForAction(
+            direction: TransferDirection.Download,
+            kind: TransferKind.File,
+            defaultRemotePath: "~/downloads");
+
+        Assert.Equal(TransferDirection.Download, request.Direction);
+        Assert.Equal(TransferKind.File, request.Kind);
+        Assert.Equal("~/downloads", request.RemotePath);
+    }
+
+    [Fact]
+    public void Result_CreateConfirmed_PreservesSelectedPaths()
+    {
+        TransferDialogResult result = TransferDialogResult.CreateConfirmed(
+            localPath: @"D:\downloads\a.mkv",
+            remotePath: "/mnt/box/movies/a.mkv");
+
+        Assert.True(result.IsConfirmed);
+        Assert.Equal(@"D:\downloads\a.mkv", result.LocalPath);
+        Assert.Equal("/mnt/box/movies/a.mkv", result.RemotePath);
+    }
+}

--- a/tests/NovaTerminal.Tests/Core/TransferDialogRequestTests.cs
+++ b/tests/NovaTerminal.Tests/Core/TransferDialogRequestTests.cs
@@ -8,14 +8,20 @@ public sealed class TransferDialogRequestTests
     [Fact]
     public void ForAction_UsesRequestedModeAndDefaultRemotePath()
     {
+        Guid profileId = Guid.Parse("aa16f38f-694c-4bbd-8c4e-eae16da5dd88");
+        Guid sessionId = Guid.Parse("79fbd43b-75e0-43cb-aebf-9f9919ddd528");
         TransferDialogRequest request = TransferDialogRequest.ForAction(
             direction: TransferDirection.Download,
             kind: TransferKind.File,
-            defaultRemotePath: "~/downloads");
+            defaultRemotePath: "~/downloads",
+            profileId: profileId,
+            sessionId: sessionId);
 
         Assert.Equal(TransferDirection.Download, request.Direction);
         Assert.Equal(TransferKind.File, request.Kind);
         Assert.Equal("~/downloads", request.RemotePath);
+        Assert.Equal(profileId, request.ProfileId);
+        Assert.Equal(sessionId, request.SessionId);
     }
 
     [Fact]

--- a/tests/NovaTerminal.Tests/Core/TransferDialogTests.cs
+++ b/tests/NovaTerminal.Tests/Core/TransferDialogTests.cs
@@ -1,0 +1,50 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using NovaTerminal.Controls;
+using NovaTerminal.Core;
+using NovaTerminal.Models;
+
+namespace NovaTerminal.Tests.Core;
+
+public sealed class TransferDialogTests
+{
+    [AvaloniaFact]
+    public void TransferDialog_DisablesConfirm_WhenRequiredPathsAreBlank()
+    {
+        var dialog = new TransferDialog(new TransferDialogRequest
+        {
+            Direction = TransferDirection.Download,
+            Kind = TransferKind.File,
+            RemotePath = string.Empty
+        });
+
+        Button? confirm = dialog.FindControl<Button>("BtnTransferConfirm");
+        TextBlock? validation = dialog.FindControl<TextBlock>("ValidationMessage");
+
+        Assert.NotNull(confirm);
+        Assert.NotNull(validation);
+        Assert.False(confirm!.IsEnabled);
+        Assert.Contains("required", validation!.Text ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [AvaloniaFact]
+    public void TransferDialog_EnablesConfirm_WhenLocalAndRemotePathsArePresent()
+    {
+        var dialog = new TransferDialog(new TransferDialogRequest
+        {
+            Direction = TransferDirection.Download,
+            Kind = TransferKind.File,
+            RemotePath = "/mnt/box/movies/a.mkv"
+        });
+
+        TextBox? localPath = dialog.FindControl<TextBox>("LocalPathBox");
+        Button? confirm = dialog.FindControl<Button>("BtnTransferConfirm");
+
+        Assert.NotNull(localPath);
+        Assert.NotNull(confirm);
+
+        localPath!.Text = @"D:\downloads\a.mkv";
+
+        Assert.True(confirm!.IsEnabled);
+    }
+}

--- a/tests/NovaTerminal.Tests/Core/TransferDialogTests.cs
+++ b/tests/NovaTerminal.Tests/Core/TransferDialogTests.cs
@@ -3,6 +3,7 @@ using Avalonia.Headless.XUnit;
 using NovaTerminal.Controls;
 using NovaTerminal.Core;
 using NovaTerminal.Models;
+using NovaTerminal.Services.Ssh;
 
 namespace NovaTerminal.Tests.Core;
 
@@ -46,5 +47,42 @@ public sealed class TransferDialogTests
         localPath!.Text = @"D:\downloads\a.mkv";
 
         Assert.True(confirm!.IsEnabled);
+    }
+
+    [AvaloniaFact]
+    public void TransferDialog_PassesProfileAndSessionContext_ToRemotePathInput()
+    {
+        Guid profileId = Guid.Parse("6b9ddc71-9bad-4121-9ecf-50bc3da67495");
+        Guid sessionId = Guid.Parse("5be0adf2-489f-4a77-8246-a183b6f7685d");
+        var autocompleteService = new FakeRemotePathAutocompleteService();
+        var dialog = new TransferDialog(
+            new TransferDialogRequest
+            {
+                Direction = TransferDirection.Download,
+                Kind = TransferKind.File,
+                RemotePath = "~/downloads",
+                ProfileId = profileId,
+                SessionId = sessionId
+            },
+            autocompleteService);
+
+        RemotePathTextBox? remotePathInput = dialog.FindControl<RemotePathTextBox>("RemotePathInput");
+
+        Assert.NotNull(remotePathInput);
+        Assert.Equal(profileId, remotePathInput!.ProfileId);
+        Assert.Equal(sessionId, remotePathInput.SessionId);
+        Assert.Same(autocompleteService, remotePathInput.AutocompleteService);
+    }
+
+    private sealed class FakeRemotePathAutocompleteService : IRemotePathAutocompleteService
+    {
+        public Task<IReadOnlyList<RemotePathSuggestion>> GetSuggestionsAsync(
+            Guid profileId,
+            Guid sessionId,
+            string input,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IReadOnlyList<RemotePathSuggestion>>([]);
+        }
     }
 }

--- a/tests/NovaTerminal.Tests/Ssh/ActiveSshSessionRegistryTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/ActiveSshSessionRegistryTests.cs
@@ -1,0 +1,40 @@
+using NovaTerminal.Core.Ssh.Models;
+using NovaTerminal.Services.Ssh;
+
+namespace NovaTerminal.Tests.Ssh;
+
+public sealed class ActiveSshSessionRegistryTests
+{
+    [Fact]
+    public void TryGet_WhenRegisteredActiveNativeSessionExists_ReturnsDescriptor()
+    {
+        var registry = new ActiveSshSessionRegistry();
+        Guid sessionId = Guid.NewGuid();
+        Guid profileId = Guid.NewGuid();
+
+        registry.Register(new ActiveSshSessionDescriptor(
+            sessionId,
+            profileId,
+            SshBackendKind.Native));
+
+        Assert.True(registry.TryGet(sessionId, out ActiveSshSessionDescriptor? descriptor));
+        Assert.NotNull(descriptor);
+        Assert.Equal(profileId, descriptor!.ProfileId);
+        Assert.Equal(SshBackendKind.Native, descriptor.BackendKind);
+    }
+
+    [Fact]
+    public void Unregister_RemovesRegisteredSession()
+    {
+        var registry = new ActiveSshSessionRegistry();
+        Guid sessionId = Guid.NewGuid();
+
+        registry.Register(new ActiveSshSessionDescriptor(
+            sessionId,
+            Guid.NewGuid(),
+            SshBackendKind.Native));
+        registry.Unregister(sessionId);
+
+        Assert.False(registry.TryGet(sessionId, out _));
+    }
+}

--- a/tests/NovaTerminal.Tests/Ssh/ActiveSshSessionRegistryTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/ActiveSshSessionRegistryTests.cs
@@ -37,4 +37,36 @@ public sealed class ActiveSshSessionRegistryTests
 
         Assert.False(registry.TryGet(sessionId, out _));
     }
+
+    [Fact]
+    public void SetRuntimePassword_StoresAndReturnsPassword_ForSession()
+    {
+        var registry = new ActiveSshSessionRegistry();
+        Guid sessionId = Guid.NewGuid();
+
+        registry.Register(new ActiveSshSessionDescriptor(
+            sessionId,
+            Guid.NewGuid(),
+            SshBackendKind.Native));
+        registry.SetRuntimePassword(sessionId, "session-secret");
+
+        Assert.True(registry.TryGetRuntimePassword(sessionId, out string? password));
+        Assert.Equal("session-secret", password);
+    }
+
+    [Fact]
+    public void Unregister_RemovesRuntimePassword_ForSession()
+    {
+        var registry = new ActiveSshSessionRegistry();
+        Guid sessionId = Guid.NewGuid();
+
+        registry.Register(new ActiveSshSessionDescriptor(
+            sessionId,
+            Guid.NewGuid(),
+            SshBackendKind.Native));
+        registry.SetRuntimePassword(sessionId, "session-secret");
+        registry.Unregister(sessionId);
+
+        Assert.False(registry.TryGetRuntimePassword(sessionId, out _));
+    }
 }

--- a/tests/NovaTerminal.Tests/Ssh/RemotePathAutocompleteQueryTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/RemotePathAutocompleteQueryTests.cs
@@ -1,0 +1,41 @@
+using NovaTerminal.Models;
+using NovaTerminal.Services.Ssh;
+
+namespace NovaTerminal.Tests.Ssh;
+
+public sealed class RemotePathAutocompleteQueryTests
+{
+    [Fact]
+    public void Parse_WhenGivenPartialAbsolutePath_SplitsParentAndPrefix()
+    {
+        RemotePathAutocompleteQuery query = RemotePathAutocompleteQuery.Parse("/mnt/media/mov");
+
+        Assert.Equal("/mnt/media", query.ParentPath);
+        Assert.Equal("mov", query.Prefix);
+    }
+
+    [Fact]
+    public void Parse_WhenGivenTildePathWithoutSeparator_UsesTildeAsParent()
+    {
+        RemotePathAutocompleteQuery query = RemotePathAutocompleteQuery.Parse("~/Do");
+
+        Assert.Equal("~", query.ParentPath);
+        Assert.Equal("Do", query.Prefix);
+    }
+
+    [Fact]
+    public void Rank_PrefersDirectoryPrefixMatchesBeforeFiles()
+    {
+        IReadOnlyList<RemotePathSuggestion> suggestions = RemotePathAutocompleteQuery.Rank(
+            new[]
+            {
+                new RemotePathSuggestion("movie.mkv", "/mnt/media/movie.mkv", isDirectory: false),
+                new RemotePathSuggestion("movies", "/mnt/media/movies", isDirectory: true)
+            },
+            prefix: "mov");
+
+        Assert.Equal(2, suggestions.Count);
+        Assert.Equal("movies", suggestions[0].DisplayName);
+        Assert.True(suggestions[0].IsDirectory);
+    }
+}

--- a/tests/NovaTerminal.Tests/Ssh/RemotePathAutocompleteQueryTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/RemotePathAutocompleteQueryTests.cs
@@ -24,6 +24,24 @@ public sealed class RemotePathAutocompleteQueryTests
     }
 
     [Fact]
+    public void Parse_WhenPathEndsWithSeparator_UsesDirectoryAsParentAndEmptyPrefix()
+    {
+        RemotePathAutocompleteQuery query = RemotePathAutocompleteQuery.Parse("~/code/");
+
+        Assert.Equal("~/code", query.ParentPath);
+        Assert.Equal(string.Empty, query.Prefix);
+    }
+
+    [Fact]
+    public void Parse_WhenRootPathEndsWithSeparator_UsesRootAsParentAndEmptyPrefix()
+    {
+        RemotePathAutocompleteQuery query = RemotePathAutocompleteQuery.Parse("/");
+
+        Assert.Equal("/", query.ParentPath);
+        Assert.Equal(string.Empty, query.Prefix);
+    }
+
+    [Fact]
     public void Rank_PrefersDirectoryPrefixMatchesBeforeFiles()
     {
         IReadOnlyList<RemotePathSuggestion> suggestions = RemotePathAutocompleteQuery.Rank(

--- a/tests/NovaTerminal.Tests/Ssh/RemotePathAutocompleteServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/RemotePathAutocompleteServiceTests.cs
@@ -195,6 +195,48 @@ public sealed class RemotePathAutocompleteServiceTests
         Assert.Equal(12, results.Count);
     }
 
+    [Fact]
+    public async Task GetSuggestionsAsync_ReturnsBeforeBlockingNativeLookupCompletes()
+    {
+        Guid profileId = Guid.NewGuid();
+        Guid sessionId = Guid.NewGuid();
+        var registry = new ActiveSshSessionRegistry();
+        registry.Register(new ActiveSshSessionDescriptor(sessionId, profileId, SshBackendKind.Native));
+        var interop = new BlockingNativeSshInterop(
+            new[]
+            {
+                new NativeRemotePathEntry("code", "/home/nova/code", true)
+            });
+        var service = CreateService(
+            registry,
+            interop,
+            CreateSshService(profileId),
+            _ => null);
+
+        Task<IReadOnlyList<RemotePathSuggestion>>? returnedTask = null;
+        Task invocation = Task.Run(() =>
+        {
+            returnedTask = service.GetSuggestionsAsync(
+                profileId,
+                sessionId,
+                "~/cod",
+                CancellationToken.None);
+        });
+
+        Assert.True(interop.Started.Wait(TimeSpan.FromSeconds(1)));
+        Task completed = await Task.WhenAny(invocation, Task.Delay(TimeSpan.FromSeconds(1)));
+        Assert.Same(invocation, completed);
+        Assert.NotNull(returnedTask);
+        Assert.False(returnedTask!.IsCompleted);
+
+        interop.Release.Set();
+
+        IReadOnlyList<RemotePathSuggestion> results = await returnedTask;
+
+        Assert.Single(results);
+        Assert.Equal("/home/nova/code", results[0].FullPath);
+    }
+
     private static RemotePathAutocompleteService CreateService(
         ActiveSshSessionRegistry registry,
         INativeSshInterop interop,
@@ -265,6 +307,42 @@ public sealed class RemotePathAutocompleteServiceTests
         {
             LastConnectionOptions = connectionOptions;
             LastRemotePath = remotePath;
+            return _entries;
+        }
+
+        public void RunSftpTransfer(NativeSshConnectionOptions connectionOptions, NativeSftpTransferOptions transferOptions, Action<NativeSftpTransferProgress>? progress, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public NativeSshEvent? PollEvent(IntPtr sessionHandle) => throw new NotSupportedException();
+        public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void Resize(IntPtr sessionHandle, int cols, int rows) => throw new NotSupportedException();
+        public int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options) => throw new NotSupportedException();
+        public void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void SendChannelEof(IntPtr sessionHandle, int channelId) => throw new NotSupportedException();
+        public void CloseChannel(IntPtr sessionHandle, int channelId) => throw new NotSupportedException();
+        public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void Close(IntPtr sessionHandle) => throw new NotSupportedException();
+    }
+
+    private sealed class BlockingNativeSshInterop : INativeSshInterop
+    {
+        private readonly IReadOnlyList<NativeRemotePathEntry> _entries;
+
+        public BlockingNativeSshInterop(IReadOnlyList<NativeRemotePathEntry> entries)
+        {
+            _entries = entries;
+        }
+
+        public ManualResetEventSlim Started { get; } = new(false);
+        public ManualResetEventSlim Release { get; } = new(false);
+
+        public IntPtr Connect(NativeSshConnectionOptions options) => throw new NotSupportedException();
+
+        public IReadOnlyList<NativeRemotePathEntry> ListRemoteDirectory(
+            NativeSshConnectionOptions connectionOptions,
+            string remotePath,
+            CancellationToken cancellationToken)
+        {
+            Started.Set();
+            Release.Wait(cancellationToken);
             return _entries;
         }
 

--- a/tests/NovaTerminal.Tests/Ssh/RemotePathAutocompleteServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/RemotePathAutocompleteServiceTests.cs
@@ -1,0 +1,138 @@
+using NovaTerminal.Core;
+using NovaTerminal.Core.Ssh.Models;
+using NovaTerminal.Core.Ssh.Native;
+using NovaTerminal.Core.Ssh.Storage;
+using NovaTerminal.Models;
+using NovaTerminal.Services.Ssh;
+
+namespace NovaTerminal.Tests.Ssh;
+
+public sealed class RemotePathAutocompleteServiceTests
+{
+    [Fact]
+    public async Task GetSuggestionsAsync_WhenNoActiveNativeSessionExists_ReturnsEmpty()
+    {
+        Guid profileId = Guid.NewGuid();
+        Guid sessionId = Guid.NewGuid();
+        var registry = new ActiveSshSessionRegistry();
+        var service = CreateService(
+            registry,
+            new RecordingNativeSshInterop(Array.Empty<NativeRemotePathEntry>()),
+            CreateSshService(profileId));
+
+        IReadOnlyList<RemotePathSuggestion> results = await service.GetSuggestionsAsync(
+            profileId,
+            sessionId,
+            "/mnt/media/mov",
+            CancellationToken.None);
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task GetSuggestionsAsync_FiltersNativeEntriesUsingResolvedParentPath()
+    {
+        Guid profileId = Guid.NewGuid();
+        Guid sessionId = Guid.NewGuid();
+        var registry = new ActiveSshSessionRegistry();
+        registry.Register(new ActiveSshSessionDescriptor(sessionId, profileId, SshBackendKind.Native));
+        var interop = new RecordingNativeSshInterop(
+            new[]
+            {
+                new NativeRemotePathEntry("movies", "/mnt/media/movies", true),
+                new NativeRemotePathEntry("music", "/mnt/media/music", true)
+            });
+        var service = CreateService(registry, interop, CreateSshService(profileId));
+
+        IReadOnlyList<RemotePathSuggestion> results = await service.GetSuggestionsAsync(
+            profileId,
+            sessionId,
+            "/mnt/media/mov",
+            CancellationToken.None);
+
+        Assert.Single(results);
+        Assert.Equal("/mnt/media", interop.LastRemotePath);
+        Assert.Equal("/mnt/media/movies", results[0].FullPath);
+    }
+
+    private static RemotePathAutocompleteService CreateService(
+        ActiveSshSessionRegistry registry,
+        INativeSshInterop interop,
+        SshConnectionService sshService)
+    {
+        return new RemotePathAutocompleteService(
+            interop,
+            registry,
+            () => sshService);
+    }
+
+    private static SshConnectionService CreateSshService(Guid profileId)
+    {
+        var store = new TestSshProfileStore();
+        store.SaveProfile(new SshProfile
+        {
+            Id = profileId,
+            Name = "server3",
+            BackendKind = SshBackendKind.Native,
+            Host = "prod.internal",
+            User = "ops",
+            Port = 2200,
+            AuthMode = SshAuthMode.Default
+        });
+
+        return new SshConnectionService(store);
+    }
+
+    private sealed class TestSshProfileStore : ISshProfileStore
+    {
+        private readonly Dictionary<Guid, SshProfile> _profiles = new();
+
+        public IReadOnlyList<SshProfile> GetProfiles() => _profiles.Values.ToList();
+
+        public SshProfile? GetProfile(Guid profileId)
+        {
+            return _profiles.TryGetValue(profileId, out SshProfile? profile) ? profile : null;
+        }
+
+        public void SaveProfile(SshProfile profile)
+        {
+            _profiles[profile.Id] = profile;
+        }
+
+        public bool DeleteProfile(Guid profileId) => _profiles.Remove(profileId);
+    }
+
+    private sealed class RecordingNativeSshInterop : INativeSshInterop
+    {
+        private readonly IReadOnlyList<NativeRemotePathEntry> _entries;
+
+        public RecordingNativeSshInterop(IReadOnlyList<NativeRemotePathEntry> entries)
+        {
+            _entries = entries;
+        }
+
+        public string? LastRemotePath { get; private set; }
+
+        public IntPtr Connect(NativeSshConnectionOptions options) => throw new NotSupportedException();
+
+        public IReadOnlyList<NativeRemotePathEntry> ListRemoteDirectory(
+            NativeSshConnectionOptions connectionOptions,
+            string remotePath,
+            CancellationToken cancellationToken)
+        {
+            LastRemotePath = remotePath;
+            return _entries;
+        }
+
+        public void RunSftpTransfer(NativeSshConnectionOptions connectionOptions, NativeSftpTransferOptions transferOptions, Action<NativeSftpTransferProgress>? progress, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public NativeSshEvent? PollEvent(IntPtr sessionHandle) => throw new NotSupportedException();
+        public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void Resize(IntPtr sessionHandle, int cols, int rows) => throw new NotSupportedException();
+        public int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options) => throw new NotSupportedException();
+        public void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void SendChannelEof(IntPtr sessionHandle, int channelId) => throw new NotSupportedException();
+        public void CloseChannel(IntPtr sessionHandle, int channelId) => throw new NotSupportedException();
+        public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void Close(IntPtr sessionHandle) => throw new NotSupportedException();
+    }
+}

--- a/tests/NovaTerminal.Tests/Ssh/RemotePathAutocompleteServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/RemotePathAutocompleteServiceTests.cs
@@ -55,15 +55,157 @@ public sealed class RemotePathAutocompleteServiceTests
         Assert.Equal("/mnt/media/movies", results[0].FullPath);
     }
 
+    [Fact]
+    public async Task GetSuggestionsAsync_UsesResolvedPassword_ForPasswordBasedProfiles()
+    {
+        Guid profileId = Guid.NewGuid();
+        Guid sessionId = Guid.NewGuid();
+        var registry = new ActiveSshSessionRegistry();
+        registry.Register(new ActiveSshSessionDescriptor(sessionId, profileId, SshBackendKind.Native));
+        var interop = new RecordingNativeSshInterop(
+            new[]
+            {
+                new NativeRemotePathEntry("movies", "/mnt/media/movies", true)
+            });
+        var service = CreateService(
+            registry,
+            interop,
+            CreateSshService(profileId),
+            _ => "top-secret");
+
+        await service.GetSuggestionsAsync(
+            profileId,
+            sessionId,
+            "/mnt/media/mov",
+            CancellationToken.None);
+
+        Assert.NotNull(interop.LastConnectionOptions);
+        Assert.Equal("top-secret", interop.LastConnectionOptions!.Password);
+    }
+
+    [Fact]
+    public async Task GetSuggestionsAsync_UsesRuntimeSessionPassword_WhenVaultPasswordIsUnavailable()
+    {
+        Guid profileId = Guid.NewGuid();
+        Guid sessionId = Guid.NewGuid();
+        var registry = new ActiveSshSessionRegistry();
+        registry.Register(new ActiveSshSessionDescriptor(sessionId, profileId, SshBackendKind.Native));
+        registry.SetRuntimePassword(sessionId, "runtime-secret");
+        var interop = new RecordingNativeSshInterop(
+            new[]
+            {
+                new NativeRemotePathEntry("movies", "/mnt/media/movies", true)
+            });
+        var service = CreateService(
+            registry,
+            interop,
+            CreateSshService(profileId),
+            _ => null);
+
+        await service.GetSuggestionsAsync(
+            profileId,
+            sessionId,
+            "/mnt/media/mov",
+            CancellationToken.None);
+
+        Assert.NotNull(interop.LastConnectionOptions);
+        Assert.Equal("runtime-secret", interop.LastConnectionOptions!.Password);
+    }
+
+    [Fact]
+    public async Task GetSuggestionsAsync_SetsKnownHostsPath_ForNativeListing()
+    {
+        Guid profileId = Guid.NewGuid();
+        Guid sessionId = Guid.NewGuid();
+        var registry = new ActiveSshSessionRegistry();
+        registry.Register(new ActiveSshSessionDescriptor(sessionId, profileId, SshBackendKind.Native));
+        var interop = new RecordingNativeSshInterop(
+            new[]
+            {
+                new NativeRemotePathEntry("code", "/home/nova/code", true)
+            });
+        var service = CreateService(
+            registry,
+            interop,
+            CreateSshService(profileId),
+            _ => null);
+
+        await service.GetSuggestionsAsync(
+            profileId,
+            sessionId,
+            "~/cod",
+            CancellationToken.None);
+
+        Assert.NotNull(interop.LastConnectionOptions);
+        Assert.Equal(AppPaths.NativeKnownHostsFilePath, interop.LastConnectionOptions!.KnownHostsFilePath);
+    }
+
+    [Fact]
+    public async Task GetSuggestionsAsync_WhenPathEndsWithSeparator_ListsDirectoryChildren()
+    {
+        Guid profileId = Guid.NewGuid();
+        Guid sessionId = Guid.NewGuid();
+        var registry = new ActiveSshSessionRegistry();
+        registry.Register(new ActiveSshSessionDescriptor(sessionId, profileId, SshBackendKind.Native));
+        var interop = new RecordingNativeSshInterop(
+            new[]
+            {
+                new NativeRemotePathEntry("server", "/home/nova/code/server", true)
+            });
+        var service = CreateService(
+            registry,
+            interop,
+            CreateSshService(profileId),
+            _ => null);
+
+        IReadOnlyList<RemotePathSuggestion> results = await service.GetSuggestionsAsync(
+            profileId,
+            sessionId,
+            "~/code/",
+            CancellationToken.None);
+
+        Assert.Equal("~/code", interop.LastRemotePath);
+        Assert.Single(results);
+        Assert.Equal("server", results[0].DisplayName);
+    }
+
+    [Fact]
+    public async Task GetSuggestionsAsync_WhenPrefixIsEmpty_ReturnsTopCappedEntries()
+    {
+        Guid profileId = Guid.NewGuid();
+        Guid sessionId = Guid.NewGuid();
+        var registry = new ActiveSshSessionRegistry();
+        registry.Register(new ActiveSshSessionDescriptor(sessionId, profileId, SshBackendKind.Native));
+        var entries = Enumerable.Range(1, 20)
+            .Select(index => new NativeRemotePathEntry($"item{index:00}", $"/home/nova/code/item{index:00}", index % 2 == 0))
+            .ToArray();
+        var interop = new RecordingNativeSshInterop(entries);
+        var service = CreateService(
+            registry,
+            interop,
+            CreateSshService(profileId),
+            _ => null);
+
+        IReadOnlyList<RemotePathSuggestion> results = await service.GetSuggestionsAsync(
+            profileId,
+            sessionId,
+            "~/code/",
+            CancellationToken.None);
+
+        Assert.Equal(12, results.Count);
+    }
+
     private static RemotePathAutocompleteService CreateService(
         ActiveSshSessionRegistry registry,
         INativeSshInterop interop,
-        SshConnectionService sshService)
+        SshConnectionService sshService,
+        Func<TerminalProfile, string?>? passwordResolver = null)
     {
         return new RemotePathAutocompleteService(
             interop,
             registry,
-            () => sshService);
+            () => sshService,
+            passwordResolver);
     }
 
     private static SshConnectionService CreateSshService(Guid profileId)
@@ -112,6 +254,7 @@ public sealed class RemotePathAutocompleteServiceTests
         }
 
         public string? LastRemotePath { get; private set; }
+        public NativeSshConnectionOptions? LastConnectionOptions { get; private set; }
 
         public IntPtr Connect(NativeSshConnectionOptions options) => throw new NotSupportedException();
 
@@ -120,6 +263,7 @@ public sealed class RemotePathAutocompleteServiceTests
             string remotePath,
             CancellationToken cancellationToken)
         {
+            LastConnectionOptions = connectionOptions;
             LastRemotePath = remotePath;
             return _entries;
         }

--- a/tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/SshInteractionServiceTests.cs
@@ -332,6 +332,51 @@ public sealed class SshInteractionServiceTests
     }
 
     [Fact]
+    public async Task NativePasswordRequests_StoreSubmittedPassword_InRuntimeSessionCache()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string vaultPath = Path.Combine(tempRoot, "vault.dat");
+            var vault = new VaultService(vaultPath);
+            Guid sessionId = Guid.Parse("6e392be4-b615-496f-b1f6-c559d7f4c4f3");
+            Guid profileId = Guid.Parse("b15431d2-30e6-46de-99cd-c984f4995aaf");
+            ActiveSshSessionRegistry.Instance.Unregister(sessionId);
+            ActiveSshSessionRegistry.Instance.Register(new ActiveSshSessionDescriptor(
+                sessionId,
+                profileId,
+                NovaTerminal.Core.Ssh.Models.SshBackendKind.Native));
+
+            var service = new SshInteractionService(
+                vaultService: vault,
+                authPresenter: (_, _, _) =>
+                    Task.FromResult(SshInteractionResponse.FromSecret("manual-secret")));
+
+            SshInteractionResponse response = await service.HandleAsync(new SshInteractionRequest
+            {
+                Kind = SshInteractionKind.Password,
+                Prompt = "Password:",
+                SessionId = sessionId,
+                ProfileId = profileId,
+                ProfileName = "Native Prod",
+                ProfileUser = "alice",
+                ProfileHost = "example.internal",
+                AllowVaultPasswordReuse = false
+            }, CancellationToken.None);
+
+            Assert.Equal("manual-secret", response.Secret);
+            Assert.True(ActiveSshSessionRegistry.Instance.TryGetRuntimePassword(sessionId, out string? password));
+            Assert.Equal("manual-secret", password);
+
+            ActiveSshSessionRegistry.Instance.Unregister(sessionId);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task NativePasswordRequests_LeavingRememberUnchecked_PreservesExistingVaultSecret()
     {
         string tempRoot = CreateTempDirectory();


### PR DESCRIPTION
## Summary
- replace NativeSSH profile transfers' external `scp` path with built-in native SFTP file and folder upload/download routed through `SftpService`
- add native transfer cancellation, progress mapping, known-hosts/password or identity-file auth handling, and clearer transfer error reporting in the Rust/C# interop layer
- document the backend split so OpenSSH profiles stay on system `scp` while NativeSSH profiles use the native SFTP path

## Root Cause
NativeSSH terminal sessions were still delegating transfers to an external `scp` process. That created duplicate auth flows, platform-specific prompting behavior, and left NativeSSH without a fully native transfer path.

## Validation
- `cargo build --manifest-path src\NovaTerminal.App\native\rusty_ssh\Cargo.toml`
- `dotnet test tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj -c NativeSftpPlanApp --filter "FullyQualifiedName~SftpServiceTests" --no-restore -p:SkipCliShim=true -m:1`
- `dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c NativeSftpPlan --filter "FullyQualifiedName~NativeSftpTransferInteropTests|FullyQualifiedName~NativeSshDockerE2eTests.NativeSftp_CanDownloadFile|FullyQualifiedName~NativeSshDockerE2eTests.NativeSftp_CanUploadFile|FullyQualifiedName~NativeSshDockerE2eTests.NativeSftp_CanDownloadDirectory|FullyQualifiedName~NativeSshDockerE2eTests.NativeSftp_CanUploadDirectory" --no-restore -m:1`
- `dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj -c NativeSftpPlan --filter "FullyQualifiedName~NativeSftpTransferInteropTests|FullyQualifiedName~NativeSshDockerE2eTests.NativeSftp_MissingRemotePath_ReturnsClearError|FullyQualifiedName~NativeSshDockerE2eTests.NativeSftp_MissingLocalPath_ReturnsClearError|FullyQualifiedName~NativeSshDockerE2eTests.NativeSftp_BadPassword_ReturnsAuthenticationFailed" --no-restore -m:1`

## Notes
- the Docker edge-case transfer tests are included but were skipped in the current environment
- manual runtime verification is still recommended for cancel behavior and the OpenSSH transfer path