### PR TITLE
Add native SSH remote cwd sync

### DIFF
--- a/docs/plans/2026-04-30-native-sftp-sidebar-design.md
+++ b/docs/plans/2026-04-30-native-sftp-sidebar-design.md
@@ -1,0 +1,271 @@
+# Native SFTP Sidebar Design
+
+## Goal
+
+Improve NovaTerminal's Native SFTP transfer UX by replacing the disconnected right-click-plus-modal flow with a pane-local, lightly navigable remote sidebar that stays terminal-first and does not become a general file browser.
+
+## Scope
+
+This design adds:
+
+1. A pane-local Native SFTP sidebar
+2. Lightweight remote directory navigation
+3. Transfer actions grounded in visible remote context
+4. CWD-aware defaulting for remote operations
+
+This design does not add:
+
+- VT parsing or rendering changes
+- transfer UI inside terminal grid content
+- an OpenSSH remote browser
+- recursive tree browsing
+- file preview, rename, delete, or other file-manager behaviors
+
+## Constraints
+
+- Use Avalonia for all new UI.
+- Keep SFTP UX separate from terminal core logic.
+- Prefer additive changes over refactors.
+- Preserve current `SftpService` ownership of transfer queueing and progress.
+- Auto-hide the sidebar in alternate-screen/fullscreen TUI mode.
+
+## Problem Summary
+
+The current SFTP UX feels disconnected for two reasons:
+
+1. Transfer initiation starts from a generic pane context menu rather than from a visible remote context.
+2. The transfer dialog defaults remote input to `profile.DefaultRemoteDir ?? "~"` rather than the pane's active remote working directory.
+
+That leaves upload and download feeling like detached utility actions instead of part of the SSH pane workflow.
+
+## Chosen Direction
+
+Use a pane-local right sidebar on Native SSH panes as the primary transfer-entry surface.
+
+The sidebar should:
+
+- open from the active pane
+- show the current remote path
+- list one remote directory at a time
+- allow lightweight navigation
+- let upload target the displayed directory
+- let download act on the selected remote file or folder
+
+The existing transfer dialog can remain as a fallback/manual path surface, but it should stop being the primary Native SSH flow.
+
+## Alternatives Considered
+
+### 1. Pane-Local Slide-Out Sidebar
+
+Recommended.
+
+Pros:
+
+- feels connected to the active SSH pane
+- keeps remote context visible while preserving terminal visibility
+- makes upload and download target selection much clearer
+- fits existing pane-local overlay patterns
+
+Cons:
+
+- broader scope than a dialog-only fix
+- needs careful limits to avoid drifting into file-manager territory
+
+### 2. Persistent Docked Remote Sidebar
+
+Rejected for v1.
+
+Pros:
+
+- very discoverable
+- always visible
+
+Cons:
+
+- permanently consumes pane width
+- too expensive for small panes
+- competes with terminal-first usage
+
+### 3. Larger Popup Browser
+
+Rejected as the primary surface.
+
+Pros:
+
+- cheaper than a docked rail
+- can still provide remote context
+
+Cons:
+
+- still feels transient and utility-like
+- does not fix the "part of the pane" feel as well as a sidebar
+
+## Product Direction
+
+NovaTerminal should remain terminal-first, not file-manager-first.
+
+That means the sidebar must stay intentionally narrow:
+
+- one directory at a time
+- no tree
+- no preview
+- no mutation actions beyond starting transfers
+- keyboard-friendly, minimal chrome
+
+The target feel is "remote transfer helper attached to a pane", not "embedded SFTP client."
+
+## Sidebar Surface
+
+### Placement
+
+- Right side of the active `TerminalPane`
+- Pane-owned, not `MainWindow`-global
+- Visible only for Native SSH panes with an active session
+
+### Sections
+
+- Header: remote path, back, refresh, close
+- Body: current directory listing
+- Footer: `Upload File`, `Upload Folder`, `Download Selected`
+
+### Navigation
+
+Supported:
+
+- enter folder
+- go up one level
+- go back through visited directories
+- refresh current directory
+
+Not supported:
+
+- recursive tree expansion
+- multi-select
+- drag-and-drop between local and remote surfaces
+
+## Session And Path Rules
+
+### Availability
+
+The sidebar is available only when:
+
+- the pane is an SSH pane
+- the backend is `SshBackendKind.Native`
+- there is an active session for that pane
+
+### Initial Path
+
+When opening the sidebar, resolve the starting path in this order:
+
+1. pane's best-known remote current working directory
+2. `profile.DefaultRemoteDir`
+3. `~`
+
+### Shell CWD Changes
+
+If the shell current directory changes while the sidebar is open:
+
+- do not forcibly re-navigate the sidebar
+- show a small `Jump To Current Directory` affordance instead
+
+This keeps the user's browsing context stable while still acknowledging live shell context.
+
+## Directory Listing Behavior
+
+- One directory is listed per query.
+- Directories sort before files.
+- Names sort alphabetically within their rank group.
+- Selection is single-item only.
+- Files are selectable and downloadable.
+- Directories are selectable, downloadable, and navigable.
+
+Keyboard behavior:
+
+- `Up` / `Down` changes selection
+- `Enter` opens a selected directory
+- `Backspace` navigates up one level when the list has focus
+- `Alt+Left` navigates back
+- `Escape` closes the sidebar
+
+Double-click on a directory should also navigate into it.
+
+## Transfer Behavior
+
+### Upload
+
+- `Upload File` picks a local file and uploads it into the currently displayed remote directory.
+- `Upload Folder` picks a local folder and uploads it into the currently displayed remote directory.
+- The sidebar removes the need to type a remote destination for common uploads.
+
+### Download
+
+- `Download Selected` is enabled only when a remote file or folder is selected.
+- Download acts on the selected entry.
+- Local destination selection can still use the existing local picker flow.
+
+### Execution Boundary
+
+The sidebar should not own transfer execution. It only produces clearer transfer requests. `SftpService` remains the execution and progress boundary.
+
+## Failure And State Handling
+
+- No active session: entry point hidden or disabled.
+- Directory listing failure: show inline error and `Retry`, no modal.
+- Missing path or permission error: show inline error, keep navigation controls available.
+- Session disconnect while open: freeze list actions, show disconnected state, allow close.
+- Transfer start failure: continue to surface through existing transfer job error handling.
+- Long-running transfer progress remains in the existing Transfer Center / status UI rather than moving into the sidebar.
+
+## Implementation Shape
+
+Preferred split:
+
+- `TerminalPane`: owns sidebar visibility, placement, keyboard routing, alt-screen hiding, and pane/session context
+- sidebar view model/controller: owns path, entries, selection, loading/error state, and back-stack
+- remote directory browser service: owns native directory listing calls and navigation/path normalization
+- `SftpService`: continues to own job queueing, progress, cancellation, and result state
+
+This keeps UI concerns out of terminal core logic and keeps the SFTP helper additive.
+
+## Testing Strategy
+
+### Deterministic unit tests
+
+- initial-path resolution
+- directories-first sorting
+- back-stack behavior
+- jump-to-current-directory state changes
+- disabled download with no selection
+- inline listing error state transitions
+
+### Pane/UI tests
+
+- sidebar opens only for eligible Native SSH panes
+- sidebar hides in alternate-screen mode
+- keyboard navigation updates selection and path correctly
+- directory double-click / `Enter` opens child folder
+
+### Existing transfer tests remain
+
+- `SftpService` tests keep execution coverage
+- native SFTP interop and Docker E2E tests remain the backend confidence layer
+
+Avoid snapshot-heavy UI tests.
+
+## Rollout Order
+
+1. add remote directory browser state/service
+2. add pane-local sidebar control and host integration
+3. wire upload/download actions through the sidebar
+4. add alt-screen and disconnect behavior
+5. keep manual dialog flow as fallback where still useful
+
+## Expected Outcome
+
+After this work:
+
+- Native SFTP actions feel attached to the active SSH pane
+- remote defaults come from live session context instead of `~`
+- downloads can start from visible remote entries instead of typed paths
+- uploads target the currently shown remote directory
+- NovaTerminal remains terminal-first without becoming a full SFTP browser

--- a/docs/plans/2026-04-30-native-sftp-sidebar-implementation-plan.md
+++ b/docs/plans/2026-04-30-native-sftp-sidebar-implementation-plan.md
@@ -1,0 +1,550 @@
+# Native SFTP Sidebar Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a pane-local, lightly navigable Native SFTP sidebar that uses live SSH context for transfer actions while keeping `SftpService` as the execution boundary.
+
+**Architecture:** Add a small app-layer remote directory browser service plus a pane-local sidebar view model and Avalonia control hosted by `TerminalPane`. Reuse the existing native remote directory listing path and active session registry for data, keep alternate-screen hiding in the pane layer, and continue routing actual transfer jobs through `SftpService` and the existing local picker flow.
+
+**Tech Stack:** C#, .NET 10, Avalonia, existing Native SSH interop, `SftpService`, xUnit, Avalonia.Headless.XUnit
+
+---
+
+### Task 1: Define sidebar models and directory browser contract
+
+**Files:**
+- Create: `src/NovaTerminal.App/Models/RemoteSidebarEntry.cs`
+- Create: `src/NovaTerminal.App/Models/RemoteSidebarListingResult.cs`
+- Create: `src/NovaTerminal.App/Services/Ssh/IRemoteDirectoryBrowserService.cs`
+- Create: `src/NovaTerminal.App/Services/Ssh/RemoteSidebarStartPathResolver.cs`
+- Test: `tests/NovaTerminal.Tests/Ssh/RemoteSidebarStartPathResolverTests.cs`
+
+**Step 1: Write the failing test**
+
+```csharp
+[Fact]
+public void ResolveStartPath_PrefersPaneWorkingDirectory_OverProfileDefault()
+{
+    string resolved = RemoteSidebarStartPathResolver.Resolve(
+        currentWorkingDirectory: "/srv/app",
+        defaultRemoteDirectory: "~/downloads");
+
+    Assert.Equal("/srv/app", resolved);
+}
+```
+
+Add a second test that falls back from blank cwd to `profile.DefaultRemoteDir`, and then to `~`.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "FullyQualifiedName~RemoteSidebarStartPathResolverTests" -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because the resolver and sidebar models do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add small explicit models:
+
+```csharp
+public sealed record RemoteSidebarEntry(
+    string Name,
+    string FullPath,
+    bool IsDirectory);
+```
+
+```csharp
+public static class RemoteSidebarStartPathResolver
+{
+    public static string Resolve(string? currentWorkingDirectory, string? defaultRemoteDirectory)
+    {
+        if (!string.IsNullOrWhiteSpace(currentWorkingDirectory))
+        {
+            return currentWorkingDirectory.Trim();
+        }
+
+        if (!string.IsNullOrWhiteSpace(defaultRemoteDirectory))
+        {
+            return defaultRemoteDirectory.Trim();
+        }
+
+        return "~";
+    }
+}
+```
+
+Define a browser contract such as:
+
+```csharp
+public interface IRemoteDirectoryBrowserService
+{
+    Task<RemoteSidebarListingResult> ListDirectoryAsync(
+        Guid profileId,
+        Guid sessionId,
+        string remotePath,
+        CancellationToken cancellationToken);
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Models/RemoteSidebarEntry.cs src/NovaTerminal.App/Models/RemoteSidebarListingResult.cs src/NovaTerminal.App/Services/Ssh/IRemoteDirectoryBrowserService.cs src/NovaTerminal.App/Services/Ssh/RemoteSidebarStartPathResolver.cs tests/NovaTerminal.Tests/Ssh/RemoteSidebarStartPathResolverTests.cs
+git commit -m "feat: define remote sidebar contracts"
+```
+
+### Task 2: Implement the remote directory browser service
+
+**Files:**
+- Create: `src/NovaTerminal.App/Services/Ssh/RemoteDirectoryBrowserService.cs`
+- Modify: `src/NovaTerminal.App/Services/Ssh/ActiveSshSessionRegistry.cs`
+- Modify: `src/NovaTerminal.App/Services/Ssh/RemotePathAutocompleteService.cs`
+- Test: `tests/NovaTerminal.Tests/Ssh/RemoteDirectoryBrowserServiceTests.cs`
+- Test: `tests/NovaTerminal.Tests/Ssh/ActiveSshSessionRegistryTests.cs`
+
+**Step 1: Write the failing test**
+
+```csharp
+[Fact]
+public async Task ListDirectoryAsync_WhenActiveNativeSessionExists_ReturnsDirectoriesBeforeFiles()
+{
+    Guid profileId = Guid.NewGuid();
+    Guid sessionId = Guid.NewGuid();
+    var registry = new ActiveSshSessionRegistry();
+    registry.Register(new ActiveSshSessionDescriptor(sessionId, profileId, SshBackendKind.Native));
+
+    var interop = new RecordingNativeSshInterop(
+        new[]
+        {
+            new NativeRemotePathEntry("b.txt", "/srv/b.txt", false),
+            new NativeRemotePathEntry("alpha", "/srv/alpha", true)
+        });
+
+    var service = CreateService(registry, interop, CreateSshService(profileId));
+    RemoteSidebarListingResult result = await service.ListDirectoryAsync(profileId, sessionId, "/srv", CancellationToken.None);
+
+    Assert.True(result.IsSuccess);
+    Assert.Collection(
+        result.Entries,
+        entry => Assert.Equal("alpha", entry.Name),
+        entry => Assert.Equal("b.txt", entry.Name));
+}
+```
+
+Add tests for:
+
+- non-Native or missing session returns a failed/empty result without throwing
+- permission/listing errors become inline error payloads
+- blank remote path normalizes to `~`
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "FullyQualifiedName~RemoteDirectoryBrowserServiceTests" -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because the service does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Implement `RemoteDirectoryBrowserService` by reusing the same native connection preparation rules already used by `RemotePathAutocompleteService`:
+
+- require an active Native SSH session from `ActiveSshSessionRegistry`
+- load the profile from `SshConnectionService`
+- build `NativeSshConnectionOptions`
+- call `INativeSshInterop.ListRemoteDirectory(...)`
+- sort directories first, then files, alphabetically
+- return a result object with `Entries`, `ResolvedPath`, `IsSuccess`, and `ErrorMessage`
+
+If shared native-connection setup emerges naturally, extract a small helper instead of duplicating large blocks.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2, then also run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "FullyQualifiedName~ActiveSshSessionRegistryTests" -m:1 --nologo -v:minimal
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Services/Ssh/RemoteDirectoryBrowserService.cs src/NovaTerminal.App/Services/Ssh/ActiveSshSessionRegistry.cs src/NovaTerminal.App/Services/Ssh/RemotePathAutocompleteService.cs tests/NovaTerminal.Tests/Ssh/RemoteDirectoryBrowserServiceTests.cs tests/NovaTerminal.Tests/Ssh/ActiveSshSessionRegistryTests.cs
+git commit -m "feat: add native remote directory browser service"
+```
+
+### Task 3: Add a sidebar view model with navigation and state transitions
+
+**Files:**
+- Create: `src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarViewModel.cs`
+- Create: `src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarEntryViewModel.cs`
+- Test: `tests/NovaTerminal.Tests/Ssh/RemoteFilesSidebarViewModelTests.cs`
+
+**Step 1: Write the failing test**
+
+```csharp
+[Fact]
+public async Task OpenAsync_LoadsInitialPath_AndDisablesDownloadUntilSelectionExists()
+{
+    var service = new FakeRemoteDirectoryBrowserService("/srv", new[]
+    {
+        new RemoteSidebarEntry("logs", "/srv/logs", true)
+    });
+
+    var viewModel = new RemoteFilesSidebarViewModel(service);
+    await viewModel.OpenAsync(
+        profileId: Guid.NewGuid(),
+        sessionId: Guid.NewGuid(),
+        initialPath: "/srv",
+        CancellationToken.None);
+
+    Assert.True(viewModel.IsOpen);
+    Assert.Equal("/srv", viewModel.CurrentPath);
+    Assert.False(viewModel.CanDownloadSelected);
+}
+```
+
+Add tests for:
+
+- selecting an entry enables download
+- navigating into a directory pushes back-stack state
+- `NavigateUpAsync()` moves to parent
+- `SetJumpToCurrentDirectoryCandidate("/srv/api")` exposes the jump affordance without forcing navigation
+- listing failure sets inline error state and keeps the sidebar open
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "FullyQualifiedName~RemoteFilesSidebarViewModelTests" -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because the view model does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create a small stateful view model with:
+
+- `IsOpen`
+- `IsLoading`
+- `IsDisconnected`
+- `CurrentPath`
+- `JumpToCurrentDirectoryPath`
+- `ObservableCollection<RemoteFilesSidebarEntryViewModel> Entries`
+- `SelectedEntry`
+- `CanDownloadSelected`
+- `CanNavigateBack`
+- `ErrorMessage`
+
+Add async methods:
+
+- `OpenAsync(...)`
+- `Close()`
+- `RefreshAsync()`
+- `NavigateIntoSelectedDirectoryAsync()`
+- `NavigateUpAsync()`
+- `NavigateBackAsync()`
+- `JumpToCurrentDirectoryAsync()`
+- `MarkDisconnected()`
+
+Keep navigation logic inside the view model so `TerminalPane` only routes events.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarViewModel.cs src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarEntryViewModel.cs tests/NovaTerminal.Tests/Ssh/RemoteFilesSidebarViewModelTests.cs
+git commit -m "feat: add remote files sidebar state model"
+```
+
+### Task 4: Add the Avalonia sidebar control
+
+**Files:**
+- Create: `src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml`
+- Create: `src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml.cs`
+- Test: `tests/NovaTerminal.Tests/Core/RemoteFilesSidebarTests.cs`
+
+**Step 1: Write the failing test**
+
+```csharp
+[AvaloniaFact]
+public void DownloadButton_IsDisabled_WhenNothingIsSelected()
+{
+    var viewModel = new RemoteFilesSidebarViewModel(new FakeRemoteDirectoryBrowserService());
+    var control = new RemoteFilesSidebar
+    {
+        DataContext = viewModel
+    };
+
+    Button button = control.FindControl<Button>("BtnDownloadSelected")!;
+    Assert.False(button.IsEnabled);
+}
+```
+
+Add tests for:
+
+- inline error text visibility when `ErrorMessage` is set
+- jump-to-current-directory button visibility
+- selected row activation triggers directory navigation for directories
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "FullyQualifiedName~RemoteFilesSidebarTests" -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because the control does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create a narrow right-rail control with named elements:
+
+```xml
+<Button Name="BtnNavigateBack" />
+<Button Name="BtnNavigateUp" />
+<Button Name="BtnRefresh" />
+<Button Name="BtnCloseSidebar" />
+<Button Name="BtnJumpToCwd" />
+<ListBox Name="RemoteEntriesList" />
+<TextBlock Name="InlineErrorText" />
+<Button Name="BtnUploadFile" />
+<Button Name="BtnUploadFolder" />
+<Button Name="BtnDownloadSelected" />
+```
+
+Bind enablement and visibility to the sidebar view model. Keep visuals simple and keyboard-friendly.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml.cs tests/NovaTerminal.Tests/Core/RemoteFilesSidebarTests.cs
+git commit -m "feat: add remote files sidebar ui"
+```
+
+### Task 5: Host the sidebar in TerminalPane and wire pane lifecycle
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml`
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs`
+- Modify: `src/NovaTerminal.App/MainWindow.axaml.cs`
+- Test: `tests/NovaTerminal.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs`
+
+**Step 1: Write the failing test**
+
+```csharp
+[AvaloniaFact]
+public void Sidebar_HidesImmediately_WhenAltScreenBecomesActive()
+{
+    var pane = new TerminalPane();
+    pane.ShowRemoteFilesSidebarForTest();
+
+    pane.Buffer!.IsAltScreenActive = true;
+    pane.HandleAltScreenChangedForTest(true);
+
+    Assert.False(pane.IsRemoteFilesSidebarVisibleForTest());
+}
+```
+
+Add tests for:
+
+- sidebar entry point is disabled or hidden for non-Native SSH panes
+- opening the sidebar uses cwd first, then profile default
+- `WorkingDirectoryChanged` updates jump-to-current-directory affordance instead of forcing navigation
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "FullyQualifiedName~TerminalPaneRemoteFilesSidebarTests" -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because the sidebar host and test hooks do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+In `TerminalPane.axaml`, add a sidebar host beside the terminal layer rather than inside terminal content.
+
+In `TerminalPane.axaml.cs`:
+
+- create and bind a `RemoteFilesSidebarViewModel`
+- add a pane-local toggle action
+- hide the sidebar when alt-screen is active
+- close or disable it on disconnect
+- update jump-to-current-directory state from pane cwd changes
+
+In `MainWindow.axaml.cs`, keep transfer/job initiation in the window layer, but let pane-originated sidebar actions flow upward through explicit events.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Controls/TerminalPane.axaml src/NovaTerminal.App/Controls/TerminalPane.axaml.cs src/NovaTerminal.App/MainWindow.axaml.cs tests/NovaTerminal.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs
+git commit -m "feat: host remote files sidebar in terminal pane"
+```
+
+### Task 6: Route sidebar upload and download actions through the existing transfer system
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs`
+- Modify: `src/NovaTerminal.App/MainWindow.axaml.cs`
+- Modify: `src/NovaTerminal.App/Models/TransferDialogRequest.cs`
+- Modify: `src/NovaTerminal.App/Controls/TransferDialog.axaml.cs`
+- Test: `tests/NovaTerminal.Tests/Core/MainWindowTransferFlowTests.cs`
+- Test: `tests/NovaTerminal.Tests/Core/TransferDialogRequestTests.cs`
+
+**Step 1: Write the failing test**
+
+```csharp
+[Fact]
+public async Task SidebarDownload_UsesSelectedRemoteEntry_AsTransferRemotePath()
+{
+    var window = new TestMainWindow
+    {
+        NextTransferDialogResult = TransferDialogResult.CreateConfirmed(
+            localPath: @"D:\downloads\logs",
+            remotePath: "/srv/logs")
+    };
+
+    await window.StartSidebarDownloadForTest(
+        profile: CreateNativeProfile(),
+        sessionId: Guid.NewGuid(),
+        selectedRemotePath: "/srv/logs",
+        kind: TransferKind.Folder);
+
+    Assert.NotNull(window.QueuedJob);
+    Assert.Equal("/srv/logs", window.QueuedJob!.RemotePath);
+}
+```
+
+Add tests for:
+
+- sidebar upload targets the currently displayed directory
+- download remains disabled without selection
+- manual transfer dialog fallback still works for explicit typed-path flows
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "FullyQualifiedName~MainWindowTransferFlowTests|FullyQualifiedName~TransferDialogRequestTests" -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because sidebar-originated transfer requests do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add explicit pane-to-window events for:
+
+- upload file to current remote directory
+- upload folder to current remote directory
+- download selected remote entry
+
+Update `TransferDialogRequest` only if needed to distinguish:
+
+- manual transfer flow with editable remote path
+- sidebar flow with preselected remote path or remote directory target
+
+Keep `SftpService` job creation in `MainWindow.axaml.cs` so transfer ownership does not move into the pane.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Controls/TerminalPane.axaml.cs src/NovaTerminal.App/MainWindow.axaml.cs src/NovaTerminal.App/Models/TransferDialogRequest.cs src/NovaTerminal.App/Controls/TransferDialog.axaml.cs tests/NovaTerminal.Tests/Core/MainWindowTransferFlowTests.cs tests/NovaTerminal.Tests/Core/TransferDialogRequestTests.cs
+git commit -m "feat: route sidebar transfers through sftp service"
+```
+
+### Task 7: Document and harden the new sidebar flow
+
+**Files:**
+- Modify: `docs/USER_MANUAL.md`
+- Modify: `docs/plans/2026-04-30-native-sftp-sidebar-design.md`
+- Test: `tests/NovaTerminal.Tests/Ssh/RemoteDirectoryBrowserServiceTests.cs`
+- Test: `tests/NovaTerminal.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs`
+
+**Step 1: Write the failing test**
+
+Add one narrow regression test such as:
+
+```csharp
+[Fact]
+public async Task MarkDisconnected_KeepsSidebarOpenButDisablesTransferActions()
+{
+    var viewModel = new RemoteFilesSidebarViewModel(new FakeRemoteDirectoryBrowserService("/srv", []));
+    await viewModel.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), "/srv", CancellationToken.None);
+
+    viewModel.MarkDisconnected();
+
+    Assert.True(viewModel.IsOpen);
+    Assert.True(viewModel.IsDisconnected);
+    Assert.False(viewModel.CanDownloadSelected);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "FullyQualifiedName~RemoteFilesSidebarViewModelTests.MarkDisconnected|FullyQualifiedName~TerminalPaneRemoteFilesSidebarTests" -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL until disconnect hardening is complete.
+
+**Step 3: Write minimal implementation**
+
+- tighten disconnect and retry behavior
+- ensure alt-screen hide/show behavior remains deterministic
+- update `docs/USER_MANUAL.md` to describe the new Native SSH sidebar flow and the remaining manual dialog fallback
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2, then the broader sidebar-related test filters.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add docs/USER_MANUAL.md tests/NovaTerminal.Tests/Ssh/RemoteDirectoryBrowserServiceTests.cs tests/NovaTerminal.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarViewModel.cs
+git commit -m "docs: describe native sftp sidebar flow"
+```

--- a/src/NovaTerminal.App/Core/TerminalProfile.cs
+++ b/src/NovaTerminal.App/Core/TerminalProfile.cs
@@ -64,6 +64,7 @@ namespace NovaTerminal.Core
         public string SshUser { get; set; } = "";
         public string SshKeyPath { get; set; } = "";
         public SshBackendKind SshBackendKind { get; set; } = SshBackendKind.OpenSsh;
+        public RemoteShellKind RemoteShellKind { get; set; } = RemoteShellKind.Auto;
 
         public ShellOverride ShellOverride { get; set; } = ShellOverride.Auto;
 

--- a/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
@@ -127,6 +127,7 @@ public sealed class SshLaunchDetails
         candidate.AccentColor = profile.AccentColor?.Trim() ?? string.Empty;
         candidate.GroupPath = profile.Group?.Trim() ?? candidate.GroupPath;
         candidate.BackendKind = profile.SshBackendKind;
+        candidate.RemoteShellKind = profile.RemoteShellKind;
 
         bool favorite = profile.Tags?.Any(IsFavoriteTag) == true;
         candidate.Tags = NormalizeTags(profile.Tags, favorite);
@@ -324,6 +325,7 @@ public sealed class SshLaunchDetails
             SshUser = profile.User,
             SshPort = profile.Port > 0 ? profile.Port : 22,
             SshBackendKind = profile.BackendKind,
+            RemoteShellKind = profile.RemoteShellKind,
             UseSshAgent = !useIdentityFile,
             IdentityFilePath = useIdentityFile ? profile.IdentityFilePath : string.Empty,
             SshKeyPath = useIdentityFile ? profile.IdentityFilePath : string.Empty,
@@ -349,6 +351,7 @@ public sealed class SshLaunchDetails
             Notes = profile.Notes?.Trim() ?? string.Empty,
             AccentColor = profile.AccentColor?.Trim() ?? string.Empty,
             Tags = NormalizeTags(profile.Tags, profile.Tags?.Any(IsFavoriteTag) == true),
+            RemoteShellKind = profile.RemoteShellKind,
             AuthMode = !profile.UseSshAgent && (!string.IsNullOrWhiteSpace(profile.IdentityFilePath) || !string.IsNullOrWhiteSpace(profile.SshKeyPath))
                 ? SshAuthMode.IdentityFile
                 : SshAuthMode.Agent,
@@ -593,7 +596,8 @@ public sealed class SshLaunchDetails
             ServerAliveIntervalSeconds = profile.ServerAliveIntervalSeconds,
             ServerAliveCountMax = profile.ServerAliveCountMax,
             ExtraSshArgs = profile.ExtraSshArgs,
-            WorkingDirectory = profile.WorkingDirectory
+            WorkingDirectory = profile.WorkingDirectory,
+            RemoteShellKind = profile.RemoteShellKind
         };
     }
 

--- a/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
+++ b/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
@@ -39,6 +39,7 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
     private string _extraSshArgs = string.Empty;
     private bool _connectAfterSave;
     private bool _experimentalNativeSshEnabled;
+    private RemoteShellKind _remoteShellKind = RemoteShellKind.Auto;
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -199,6 +200,12 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
         }
     }
 
+    public RemoteShellKind RemoteShellKind
+    {
+        get => _remoteShellKind;
+        set => SetField(ref _remoteShellKind, value);
+    }
+
     public string BackendWarning =>
         BackendKind == SshBackendKind.Native && !ExperimentalNativeSshEnabled
             ? "Native SSH is disabled globally. Enable ExperimentalNativeSshEnabled in settings or switch this profile back to OpenSSH."
@@ -304,7 +311,8 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
             },
             ServerAliveIntervalSeconds = keepAliveInterval,
             ServerAliveCountMax = keepAliveCountMax,
-            ExtraSshArgs = ExtraSshArgs?.Trim() ?? string.Empty
+            ExtraSshArgs = ExtraSshArgs?.Trim() ?? string.Empty,
+            RemoteShellKind = RemoteShellKind
         };
     }
 
@@ -329,6 +337,7 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
             IsFavorite = profile.Tags.Any(tag => string.Equals(tag, "favorite", StringComparison.OrdinalIgnoreCase)),
             Notes = profile.Notes ?? string.Empty,
             BackendKind = profile.SshBackendKind,
+            RemoteShellKind = profile.RemoteShellKind,
             AuthMode = hasIdentityFile ? NewSshAuthMode.IdentityFile : NewSshAuthMode.Agent,
             IdentityFilePath = !string.IsNullOrWhiteSpace(profile.IdentityFilePath)
                 ? profile.IdentityFilePath!
@@ -395,6 +404,7 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
         EnableMux = sshProfile.MuxOptions.Enabled;
         ControlPersistSeconds = sshProfile.MuxOptions.ControlPersistSeconds >= 0 ? sshProfile.MuxOptions.ControlPersistSeconds : 90;
         ExtraSshArgs = sshProfile.ExtraSshArgs ?? string.Empty;
+        RemoteShellKind = sshProfile.RemoteShellKind;
     }
 
     private static PortForward? ConvertLegacyForward(ForwardingRule legacy)

--- a/src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml
+++ b/src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml
@@ -29,7 +29,7 @@
     <Grid RowDefinitions="*,Auto,Auto" Margin="16">
         <TabControl>
             <TabItem Header="Basic">
-                <Grid Margin="0,10,0,0" ColumnDefinitions="170,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" RowSpacing="10">
+                <Grid Margin="0,10,0,0" ColumnDefinitions="170,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" RowSpacing="10">
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="Name" VerticalAlignment="Center" />
                     <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Name}" Watermark="My server" />
 
@@ -48,11 +48,14 @@
                     <TextBlock Grid.Row="5" Grid.Column="0" Text="Accent" VerticalAlignment="Center" />
                     <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding AccentColor}" Watermark="#0078D4 (optional)" />
 
-                    <TextBlock Grid.Row="6" Grid.Column="0" Text="Favorite" VerticalAlignment="Center" />
-                    <CheckBox Grid.Row="6" Grid.Column="1" IsChecked="{Binding IsFavorite}" Content="Pin in Connections list" />
+                    <TextBlock Grid.Row="6" Grid.Column="0" Text="Remote shell" VerticalAlignment="Center" />
+                    <ComboBox Grid.Row="6" Grid.Column="1" Name="RemoteShellKindCombo" SelectedItem="{Binding RemoteShellKind}" />
 
-                    <TextBlock Grid.Row="7" Grid.Column="0" Text="Notes" VerticalAlignment="Top" />
-                    <TextBox Grid.Row="7"
+                    <TextBlock Grid.Row="7" Grid.Column="0" Text="Favorite" VerticalAlignment="Center" />
+                    <CheckBox Grid.Row="7" Grid.Column="1" IsChecked="{Binding IsFavorite}" Content="Pin in Connections list" />
+
+                    <TextBlock Grid.Row="8" Grid.Column="0" Text="Notes" VerticalAlignment="Top" />
+                    <TextBox Grid.Row="8"
                              Grid.Column="1"
                              Text="{Binding Notes}"
                              AcceptsReturn="True"

--- a/src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml.cs
+++ b/src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Avalonia.Platform.Storage;
+using NovaTerminal.Core;
 using NovaTerminal.Core.Ssh.Models;
 using NovaTerminal.ViewModels.Ssh;
 
@@ -16,6 +17,7 @@ public partial class NewSshConnectionView : Window
         InitializeComponent();
         ConfigureAuthModeCombo();
         ConfigureBackendKindCombo();
+        ConfigureRemoteShellKindCombo();
         ConfigureForwardKindCombo();
     }
 
@@ -46,6 +48,15 @@ public partial class NewSshConnectionView : Window
         if (combo != null)
         {
             combo.ItemsSource = Enum.GetValues<SshBackendKind>();
+        }
+    }
+
+    private void ConfigureRemoteShellKindCombo()
+    {
+        var combo = this.FindControl<ComboBox>("RemoteShellKindCombo");
+        if (combo != null)
+        {
+            combo.ItemsSource = Enum.GetValues<RemoteShellKind>();
         }
     }
 

--- a/src/NovaTerminal.App/native/rusty_ssh/examples/smoke.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/examples/smoke.rs
@@ -47,6 +47,11 @@ fn main() {
         jump_port: 0,
         keepalive_interval_seconds: 30,
         keepalive_count_max: 3,
+        remote_shell_kind: 0,
+        shell_detection_command: std::ptr::null(),
+        bash_cwd_bootstrap: std::ptr::null(),
+        zsh_cwd_bootstrap: std::ptr::null(),
+        fish_cwd_bootstrap: std::ptr::null(),
     };
 
     let session = nova_ssh_connect(&connect_args);

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -45,6 +45,11 @@ pub struct NovaSshConnectArgs {
     pub jump_port: u16,
     pub keepalive_interval_seconds: u32,
     pub keepalive_count_max: u32,
+    pub remote_shell_kind: u32,
+    pub shell_detection_command: *const c_char,
+    pub bash_cwd_bootstrap: *const c_char,
+    pub zsh_cwd_bootstrap: *const c_char,
+    pub fish_cwd_bootstrap: *const c_char,
 }
 
 #[repr(C)]
@@ -158,6 +163,20 @@ struct ConnectConfig {
     jump_host: Option<JumpHostConfig>,
     keepalive_interval_seconds: u32,
     keepalive_count_max: u32,
+    remote_shell_kind: RemoteShellKind,
+    shell_detection_command: Option<String>,
+    bash_cwd_bootstrap: Option<String>,
+    zsh_cwd_bootstrap: Option<String>,
+    fish_cwd_bootstrap: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RemoteShellKind {
+    Auto,
+    Bash,
+    Zsh,
+    Fish,
+    Pwsh,
 }
 
 #[derive(Clone)]
@@ -989,8 +1008,123 @@ impl ConnectConfig {
             } else {
                 args.keepalive_count_max
             },
+            remote_shell_kind: parse_remote_shell_kind(args.remote_shell_kind),
+            shell_detection_command: read_c_string(args.shell_detection_command),
+            bash_cwd_bootstrap: read_c_string(args.bash_cwd_bootstrap),
+            zsh_cwd_bootstrap: read_c_string(args.zsh_cwd_bootstrap),
+            fish_cwd_bootstrap: read_c_string(args.fish_cwd_bootstrap),
         })
     }
+}
+
+fn parse_remote_shell_kind(value: u32) -> RemoteShellKind {
+    match value {
+        1 => RemoteShellKind::Bash,
+        2 => RemoteShellKind::Zsh,
+        3 => RemoteShellKind::Fish,
+        4 => RemoteShellKind::Pwsh,
+        _ => RemoteShellKind::Auto,
+    }
+}
+
+fn detect_login_shell_output_to_kind(output: &str) -> RemoteShellKind {
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        return RemoteShellKind::Auto;
+    }
+
+    let token = trimmed
+        .split_whitespace()
+        .next()
+        .unwrap_or(trimmed)
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(trimmed)
+        .trim_end_matches(".exe")
+        .to_ascii_lowercase();
+
+    match token.as_str() {
+        "bash" => RemoteShellKind::Bash,
+        "zsh" => RemoteShellKind::Zsh,
+        "fish" => RemoteShellKind::Fish,
+        "pwsh" | "powershell" => RemoteShellKind::Pwsh,
+        _ => RemoteShellKind::Auto,
+    }
+}
+
+fn shell_single_quote(value: &str) -> String {
+    value.replace('\'', "'\"'\"'")
+}
+
+fn wrap_posix_startup_command(command: String) -> String {
+    format!("sh -lc '{}'", shell_single_quote(&command))
+}
+
+fn build_startup_command(shell_kind: RemoteShellKind, config: &ConnectConfig) -> Option<String> {
+    match shell_kind {
+        RemoteShellKind::Bash => {
+            let bootstrap = config.bash_cwd_bootstrap.as_deref()?;
+            Some(wrap_posix_startup_command(format!(
+                "tmp_rc=$(mktemp)\ncat >\"$tmp_rc\" <<'__NOVA_BASHRC__'\nif [ -f ~/.bashrc ]; then . ~/.bashrc; fi\n{bootstrap}\n__NOVA_BASHRC__\nexec bash --rcfile \"$tmp_rc\" -i"
+            )))
+        }
+        RemoteShellKind::Zsh => {
+            let bootstrap = config.zsh_cwd_bootstrap.as_deref()?;
+            Some(wrap_posix_startup_command(format!(
+                "tmp_dir=$(mktemp -d)\ncat >\"$tmp_dir/.zshrc\" <<'__NOVA_ZSHRC__'\nif [ -f ~/.zshrc ]; then source ~/.zshrc; fi\n{bootstrap}\n__NOVA_ZSHRC__\nZDOTDIR=\"$tmp_dir\" exec zsh -i"
+            )))
+        }
+        RemoteShellKind::Fish => {
+            let bootstrap = config.fish_cwd_bootstrap.as_deref()?;
+            Some(wrap_posix_startup_command(format!(
+                "tmp_dir=$(mktemp -d)\nmkdir -p \"$tmp_dir/fish\"\ncat >\"$tmp_dir/fish/config.fish\" <<'__NOVA_FISHRC__'\nif test -f ~/.config/fish/config.fish\n    source ~/.config/fish/config.fish\nend\n{bootstrap}\n__NOVA_FISHRC__\nXDG_CONFIG_HOME=\"$tmp_dir\" exec fish -i"
+            )))
+        }
+        RemoteShellKind::Auto | RemoteShellKind::Pwsh => None,
+    }
+}
+
+async fn detect_login_shell<H>(
+    session: &mut client::Handle<H>,
+    command: &str,
+) -> anyhow::Result<RemoteShellKind>
+where
+    H: client::Handler + Send + 'static,
+{
+    let mut channel = session.channel_open_session().await?;
+    channel.exec(true, command).await?;
+
+    let mut output = Vec::new();
+    loop {
+        match channel.wait().await {
+            Some(ChannelMsg::Data { data }) => output.extend_from_slice(data.as_ref()),
+            Some(ChannelMsg::ExtendedData { .. }) => {}
+            Some(ChannelMsg::ExitStatus { .. })
+            | Some(ChannelMsg::ExitSignal { .. })
+            | Some(ChannelMsg::Success)
+            | Some(ChannelMsg::Failure)
+            | Some(ChannelMsg::WindowAdjusted { .. })
+            | Some(ChannelMsg::XonXoff { .. })
+            | Some(ChannelMsg::Open { .. })
+            | Some(ChannelMsg::OpenFailure(_)) => {}
+            Some(ChannelMsg::Eof) | Some(ChannelMsg::Close) | None => break,
+            Some(ChannelMsg::RequestPty { .. })
+            | Some(ChannelMsg::RequestShell { .. })
+            | Some(ChannelMsg::Exec { .. })
+            | Some(ChannelMsg::Signal { .. })
+            | Some(ChannelMsg::RequestSubsystem { .. })
+            | Some(ChannelMsg::RequestX11 { .. })
+            | Some(ChannelMsg::SetEnv { .. })
+            | Some(ChannelMsg::WindowChange { .. })
+            | Some(ChannelMsg::AgentForward { .. })
+            | Some(_) => {}
+        }
+    }
+
+    let _ = channel.close().await;
+    Ok(detect_login_shell_output_to_kind(
+        String::from_utf8_lossy(&output).as_ref(),
+    ))
 }
 
 fn read_c_string(value: *const c_char) -> Option<String> {
@@ -2116,6 +2250,14 @@ fn run_session(
         )
         .await?;
 
+        let effective_shell_kind = if config.remote_shell_kind != RemoteShellKind::Auto {
+            config.remote_shell_kind
+        } else if let Some(command) = config.shell_detection_command.as_deref() {
+            detect_login_shell(&mut session, command).await?
+        } else {
+            RemoteShellKind::Auto
+        };
+
         let mut channel = session.channel_open_session().await?;
         channel
             .request_pty(
@@ -2128,7 +2270,11 @@ fn run_session(
                 &[],
             )
             .await?;
-        channel.request_shell(true).await?;
+        if let Some(startup_command) = build_startup_command(effective_shell_kind, &config) {
+            channel.exec(true, startup_command).await?;
+        } else {
+            channel.request_shell(true).await?;
+        }
 
         shared.queue_event(QueuedEvent {
             kind: NovaSshEventKind::Connected,
@@ -2747,12 +2893,89 @@ mod tests {
             jump_port: 0,
             keepalive_interval_seconds: 15,
             keepalive_count_max: 7,
+            remote_shell_kind: 0,
+            shell_detection_command: ptr::null(),
+            bash_cwd_bootstrap: ptr::null(),
+            zsh_cwd_bootstrap: ptr::null(),
+            fish_cwd_bootstrap: ptr::null(),
         };
 
         let config = ConnectConfig::from_args(&args).expect("config should parse");
 
         assert_eq!(15, config.keepalive_interval_seconds);
         assert_eq!(7, config.keepalive_count_max);
+    }
+
+    #[test]
+    fn connect_config_reads_remote_shell_fields_from_ffi_args() {
+        let host = CString::new("native.example").unwrap();
+        let user = CString::new("nova").unwrap();
+        let term = CString::new("xterm-256color").unwrap();
+        let shell_detection_command = CString::new("sh -lc 'printf test'").unwrap();
+        let bash_cwd_bootstrap = CString::new("bash-bootstrap").unwrap();
+        let zsh_cwd_bootstrap = CString::new("zsh-bootstrap").unwrap();
+        let fish_cwd_bootstrap = CString::new("fish-bootstrap").unwrap();
+
+        let args = NovaSshConnectArgs {
+            host: host.as_ptr(),
+            user: user.as_ptr(),
+            port: 22,
+            cols: 120,
+            rows: 30,
+            term: term.as_ptr(),
+            identity_file: ptr::null(),
+            jump_host: ptr::null(),
+            jump_user: ptr::null(),
+            jump_port: 0,
+            keepalive_interval_seconds: 15,
+            keepalive_count_max: 7,
+            remote_shell_kind: 2,
+            shell_detection_command: shell_detection_command.as_ptr(),
+            bash_cwd_bootstrap: bash_cwd_bootstrap.as_ptr(),
+            zsh_cwd_bootstrap: zsh_cwd_bootstrap.as_ptr(),
+            fish_cwd_bootstrap: fish_cwd_bootstrap.as_ptr(),
+        };
+
+        let config = ConnectConfig::from_args(&args).expect("config should parse");
+
+        assert_eq!(RemoteShellKind::Zsh, config.remote_shell_kind);
+        assert_eq!(
+            Some("sh -lc 'printf test'".to_owned()),
+            config.shell_detection_command
+        );
+        assert_eq!(
+            Some("bash-bootstrap".to_owned()),
+            config.bash_cwd_bootstrap
+        );
+        assert_eq!(Some("zsh-bootstrap".to_owned()), config.zsh_cwd_bootstrap);
+        assert_eq!(
+            Some("fish-bootstrap".to_owned()),
+            config.fish_cwd_bootstrap
+        );
+    }
+
+    #[test]
+    fn detect_login_shell_output_to_kind_maps_known_tokens() {
+        assert_eq!(
+            RemoteShellKind::Bash,
+            detect_login_shell_output_to_kind("/bin/bash")
+        );
+        assert_eq!(
+            RemoteShellKind::Zsh,
+            detect_login_shell_output_to_kind("zsh")
+        );
+        assert_eq!(
+            RemoteShellKind::Fish,
+            detect_login_shell_output_to_kind("/usr/local/bin/fish")
+        );
+        assert_eq!(
+            RemoteShellKind::Pwsh,
+            detect_login_shell_output_to_kind("powershell")
+        );
+        assert_eq!(
+            RemoteShellKind::Auto,
+            detect_login_shell_output_to_kind("tcsh")
+        );
     }
 
     #[test]
@@ -2768,6 +2991,11 @@ mod tests {
             jump_host: None,
             keepalive_interval_seconds: 15,
             keepalive_count_max: 7,
+            remote_shell_kind: RemoteShellKind::Auto,
+            shell_detection_command: None,
+            bash_cwd_bootstrap: None,
+            zsh_cwd_bootstrap: None,
+            fish_cwd_bootstrap: None,
         };
 
         let client_config = build_client_config(&config);
@@ -2778,6 +3006,87 @@ mod tests {
             client_config.keepalive_interval
         );
         assert_eq!(7, client_config.keepalive_max);
+    }
+
+    #[test]
+    fn build_startup_command_wraps_bash_bootstrap() {
+        let config = ConnectConfig {
+            host: "native.example".to_owned(),
+            user: "nova".to_owned(),
+            port: 22,
+            cols: 120,
+            rows: 30,
+            term: "xterm-256color".to_owned(),
+            identity_file: None,
+            jump_host: None,
+            keepalive_interval_seconds: 30,
+            keepalive_count_max: 3,
+            remote_shell_kind: RemoteShellKind::Bash,
+            shell_detection_command: None,
+            bash_cwd_bootstrap: Some("printf 'cwd'".to_owned()),
+            zsh_cwd_bootstrap: None,
+            fish_cwd_bootstrap: None,
+        };
+
+        let command = build_startup_command(RemoteShellKind::Bash, &config)
+            .expect("bash command should be generated");
+
+        assert!(command.starts_with("sh -lc '"));
+        assert!(command.contains("tmp_rc=$(mktemp)"));
+        assert!(command.contains("exec bash --rcfile"));
+        assert!(command.contains("~/.bashrc"));
+    }
+
+    #[test]
+    fn build_startup_command_wraps_fish_bootstrap_in_posix_shell() {
+        let config = ConnectConfig {
+            host: "native.example".to_owned(),
+            user: "nova".to_owned(),
+            port: 22,
+            cols: 120,
+            rows: 30,
+            term: "xterm-256color".to_owned(),
+            identity_file: None,
+            jump_host: None,
+            keepalive_interval_seconds: 30,
+            keepalive_count_max: 3,
+            remote_shell_kind: RemoteShellKind::Fish,
+            shell_detection_command: None,
+            bash_cwd_bootstrap: None,
+            zsh_cwd_bootstrap: None,
+            fish_cwd_bootstrap: Some("printf 'cwd'".to_owned()),
+        };
+
+        let command = build_startup_command(RemoteShellKind::Fish, &config)
+            .expect("fish command should be generated");
+
+        assert!(command.starts_with("sh -lc '"));
+        assert!(command.contains("exec fish -i"));
+        assert!(command.contains("XDG_CONFIG_HOME"));
+    }
+
+    #[test]
+    fn build_startup_command_returns_none_for_auto_or_pwsh() {
+        let config = ConnectConfig {
+            host: "native.example".to_owned(),
+            user: "nova".to_owned(),
+            port: 22,
+            cols: 120,
+            rows: 30,
+            term: "xterm-256color".to_owned(),
+            identity_file: None,
+            jump_host: None,
+            keepalive_interval_seconds: 30,
+            keepalive_count_max: 3,
+            remote_shell_kind: RemoteShellKind::Auto,
+            shell_detection_command: Some("sh -lc 'printf bash'".to_owned()),
+            bash_cwd_bootstrap: Some("printf 'cwd'".to_owned()),
+            zsh_cwd_bootstrap: Some("print cwd".to_owned()),
+            fish_cwd_bootstrap: Some("printf cwd".to_owned()),
+        };
+
+        assert_eq!(None, build_startup_command(RemoteShellKind::Auto, &config));
+        assert_eq!(None, build_startup_command(RemoteShellKind::Pwsh, &config));
     }
 
     #[test]

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -20,6 +20,8 @@ use tokio::sync::mpsc;
 
 const COPY_BUFFER_SIZE: usize = 64 * 1024;
 const CANCELLATION_CHECK_INTERVAL_BYTES: u64 = 1024 * 1024;
+const SHELL_DETECTION_TIMEOUT: Duration = Duration::from_secs(3);
+const SHELL_DETECTION_MAX_OUTPUT_BYTES: usize = 4096;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default)]
@@ -954,7 +956,13 @@ pub extern "C" fn nova_ssh_sftp_list_directory(
         ),
         Err(error) => {
             let (result, status, message) = classify_sftp_transfer_error(&error);
-            write_remote_path_list_response_json(response_json, result, status, &message, Vec::new())
+            write_remote_path_list_response_json(
+                response_json,
+                result,
+                status,
+                &message,
+                Vec::new(),
+            )
         }
     }
 }
@@ -1060,18 +1068,41 @@ fn wrap_posix_startup_command(command: String) -> String {
     format!("sh -lc '{}'", shell_single_quote(&command))
 }
 
+fn bash_login_startup() -> &'static str {
+    "if [ -f ~/.bash_profile ]; then . ~/.bash_profile; \
+elif [ -f ~/.bash_login ]; then . ~/.bash_login; \
+elif [ -f ~/.profile ]; then . ~/.profile; \
+fi"
+}
+
+fn zsh_login_startup() -> &'static str {
+    "if [ -f ~/.zprofile ]; then source ~/.zprofile; fi"
+}
+
+fn append_bounded_shell_detection_output(output: &mut Vec<u8>, data: &[u8]) -> bool {
+    let remaining = SHELL_DETECTION_MAX_OUTPUT_BYTES.saturating_sub(output.len());
+    if remaining == 0 {
+        return true;
+    }
+
+    output.extend_from_slice(&data[..data.len().min(remaining)]);
+    output.len() >= SHELL_DETECTION_MAX_OUTPUT_BYTES
+}
+
 fn build_startup_command(shell_kind: RemoteShellKind, config: &ConnectConfig) -> Option<String> {
     match shell_kind {
         RemoteShellKind::Bash => {
             let bootstrap = config.bash_cwd_bootstrap.as_deref()?;
             Some(wrap_posix_startup_command(format!(
-                "tmp_rc=$(mktemp)\ncat >\"$tmp_rc\" <<'__NOVA_BASHRC__'\nif [ -f ~/.bashrc ]; then . ~/.bashrc; fi\n{bootstrap}\n__NOVA_BASHRC__\nexec bash --rcfile \"$tmp_rc\" -i"
+                "tmp_rc=$(mktemp)\ncat >\"$tmp_rc\" <<'__NOVA_BASHRC__'\n{bash_login_startup}\nif [ -f ~/.bashrc ]; then . ~/.bashrc; fi\n{bootstrap}\n__NOVA_BASHRC__\nexec bash --rcfile \"$tmp_rc\" -i",
+                bash_login_startup = bash_login_startup()
             )))
         }
         RemoteShellKind::Zsh => {
             let bootstrap = config.zsh_cwd_bootstrap.as_deref()?;
             Some(wrap_posix_startup_command(format!(
-                "tmp_dir=$(mktemp -d)\ncat >\"$tmp_dir/.zshrc\" <<'__NOVA_ZSHRC__'\nif [ -f ~/.zshrc ]; then source ~/.zshrc; fi\n{bootstrap}\n__NOVA_ZSHRC__\nZDOTDIR=\"$tmp_dir\" exec zsh -i"
+                "tmp_dir=$(mktemp -d)\ncat >\"$tmp_dir/.zprofile\" <<'__NOVA_ZPROFILE__'\n{zsh_login_startup}\n__NOVA_ZPROFILE__\ncat >\"$tmp_dir/.zshrc\" <<'__NOVA_ZSHRC__'\nif [ -f ~/.zshrc ]; then source ~/.zshrc; fi\n{bootstrap}\n__NOVA_ZSHRC__\nZDOTDIR=\"$tmp_dir\" exec zsh -il",
+                zsh_login_startup = zsh_login_startup()
             )))
         }
         RemoteShellKind::Fish => {
@@ -1094,37 +1125,47 @@ where
     let mut channel = session.channel_open_session().await?;
     channel.exec(true, command).await?;
 
-    let mut output = Vec::new();
-    loop {
-        match channel.wait().await {
-            Some(ChannelMsg::Data { data }) => output.extend_from_slice(data.as_ref()),
-            Some(ChannelMsg::ExtendedData { .. }) => {}
-            Some(ChannelMsg::ExitStatus { .. })
-            | Some(ChannelMsg::ExitSignal { .. })
-            | Some(ChannelMsg::Success)
-            | Some(ChannelMsg::Failure)
-            | Some(ChannelMsg::WindowAdjusted { .. })
-            | Some(ChannelMsg::XonXoff { .. })
-            | Some(ChannelMsg::Open { .. })
-            | Some(ChannelMsg::OpenFailure(_)) => {}
-            Some(ChannelMsg::Eof) | Some(ChannelMsg::Close) | None => break,
-            Some(ChannelMsg::RequestPty { .. })
-            | Some(ChannelMsg::RequestShell { .. })
-            | Some(ChannelMsg::Exec { .. })
-            | Some(ChannelMsg::Signal { .. })
-            | Some(ChannelMsg::RequestSubsystem { .. })
-            | Some(ChannelMsg::RequestX11 { .. })
-            | Some(ChannelMsg::SetEnv { .. })
-            | Some(ChannelMsg::WindowChange { .. })
-            | Some(ChannelMsg::AgentForward { .. })
-            | Some(_) => {}
+    let detection_result = tokio::time::timeout(SHELL_DETECTION_TIMEOUT, async {
+        let mut output = Vec::new();
+        loop {
+            match channel.wait().await {
+                Some(ChannelMsg::Data { data }) => {
+                    if append_bounded_shell_detection_output(&mut output, data.as_ref()) {
+                        break;
+                    }
+                }
+                Some(ChannelMsg::ExtendedData { .. }) => {}
+                Some(ChannelMsg::ExitStatus { .. })
+                | Some(ChannelMsg::ExitSignal { .. })
+                | Some(ChannelMsg::Success)
+                | Some(ChannelMsg::Failure)
+                | Some(ChannelMsg::WindowAdjusted { .. })
+                | Some(ChannelMsg::XonXoff { .. })
+                | Some(ChannelMsg::Open { .. })
+                | Some(ChannelMsg::OpenFailure(_)) => {}
+                Some(ChannelMsg::Eof) | Some(ChannelMsg::Close) | None => break,
+                Some(ChannelMsg::RequestPty { .. })
+                | Some(ChannelMsg::RequestShell { .. })
+                | Some(ChannelMsg::Exec { .. })
+                | Some(ChannelMsg::Signal { .. })
+                | Some(ChannelMsg::RequestSubsystem { .. })
+                | Some(ChannelMsg::RequestX11 { .. })
+                | Some(ChannelMsg::SetEnv { .. })
+                | Some(ChannelMsg::WindowChange { .. })
+                | Some(ChannelMsg::AgentForward { .. })
+                | Some(_) => {}
+            }
         }
-    }
+
+        detect_login_shell_output_to_kind(String::from_utf8_lossy(&output).as_ref())
+    })
+    .await;
 
     let _ = channel.close().await;
-    Ok(detect_login_shell_output_to_kind(
-        String::from_utf8_lossy(&output).as_ref(),
-    ))
+    match detection_result {
+        Ok(shell_kind) => Ok(shell_kind),
+        Err(_) => Err(anyhow::anyhow!("shell detection timed out")),
+    }
 }
 
 fn read_c_string(value: *const c_char) -> Option<String> {
@@ -1339,7 +1380,10 @@ fn normalize_known_host_fingerprint(fingerprint: &str) -> String {
     }
 }
 
-fn run_sftp_transfer(request: SftpTransferRequest, progress: SftpProgressEmitter) -> anyhow::Result<()> {
+fn run_sftp_transfer(
+    request: SftpTransferRequest,
+    progress: SftpProgressEmitter,
+) -> anyhow::Result<()> {
     validate_supported_sftp_mode(&request.transfer)?;
 
     let runtime = Builder::new_current_thread().enable_all().build()?;
@@ -1408,7 +1452,9 @@ fn run_sftp_transfer(request: SftpTransferRequest, progress: SftpProgressEmitter
     })
 }
 
-fn run_remote_path_list(request: RemotePathListRequest) -> anyhow::Result<Vec<RemotePathListEntry>> {
+fn run_remote_path_list(
+    request: RemotePathListRequest,
+) -> anyhow::Result<Vec<RemotePathListEntry>> {
     let runtime = Builder::new_current_thread().enable_all().build()?;
     runtime.block_on(async move {
         let known_hosts =
@@ -1553,9 +1599,12 @@ where
             .await?;
         }
         ("upload", "file") => {
-            let remote_target =
-                resolve_upload_file_target(&sftp, Path::new(&transfer.local_path), &transfer.remote_path)
-                    .await?;
+            let remote_target = resolve_upload_file_target(
+                &sftp,
+                Path::new(&transfer.local_path),
+                &transfer.remote_path,
+            )
+            .await?;
             upload_file_to_remote(
                 &sftp,
                 Path::new(&transfer.local_path),
@@ -1567,8 +1616,8 @@ where
             .await?;
         }
         ("download", "directory") => {
-            let local_root = PathBuf::from(&transfer.local_path)
-                .join(remote_basename(&transfer.remote_path)?);
+            let local_root =
+                PathBuf::from(&transfer.local_path).join(remote_basename(&transfer.remote_path)?);
             download_directory_from_remote(
                 &sftp,
                 &transfer.remote_path,
@@ -1652,8 +1701,7 @@ where
 fn validate_supported_sftp_mode(transfer: &SftpTransferRequestBody) -> anyhow::Result<()> {
     let direction = transfer.direction.trim().to_ascii_lowercase();
     let kind = transfer.kind.trim().to_ascii_lowercase();
-    if (direction == "download" || direction == "upload")
-        && (kind == "file" || kind == "directory")
+    if (direction == "download" || direction == "upload") && (kind == "file" || kind == "directory")
     {
         return Ok(());
     }
@@ -1718,7 +1766,9 @@ async fn upload_file_to_remote(
     progress: SftpProgressEmitter,
     copy_buffer: &mut [u8],
 ) -> anyhow::Result<()> {
-    let total_bytes = std::fs::metadata(local_path).ok().map(|metadata| metadata.len());
+    let total_bytes = std::fs::metadata(local_path)
+        .ok()
+        .map(|metadata| metadata.len());
     let mut local_file = TokioFile::open(local_path)
         .await
         .map_err(|error| map_local_transfer_error(local_path, error))?;
@@ -1849,8 +1899,8 @@ async fn upload_directory_to_remote(
     let mut pending = VecDeque::from([(local_root.to_path_buf(), remote_root.to_owned())]);
     while let Some((local_dir, remote_dir)) = pending.pop_front() {
         ensure_transfer_not_canceled(cancellation_marker_path)?;
-        let mut entries = std::fs::read_dir(&local_dir)?
-            .collect::<Result<Vec<_>, std::io::Error>>()?;
+        let mut entries =
+            std::fs::read_dir(&local_dir)?.collect::<Result<Vec<_>, std::io::Error>>()?;
         entries.sort_by_key(|entry| entry.file_name());
 
         for entry in entries {
@@ -1893,7 +1943,9 @@ async fn resolve_upload_directory_target(
         .file_name()
         .and_then(|value| value.to_str())
         .filter(|value| !value.trim().is_empty())
-        .ok_or_else(|| anyhow::anyhow!("Local directory name is required for native SFTP upload."))?;
+        .ok_or_else(|| {
+            anyhow::anyhow!("Local directory name is required for native SFTP upload.")
+        })?;
     let normalized_remote = normalize_remote_directory_path(remote_path)?;
 
     if sftp
@@ -2108,7 +2160,9 @@ fn remote_basename(path: &str) -> anyhow::Result<String> {
         .rsplit('/')
         .find(|segment| !segment.is_empty())
         .map(str::to_owned)
-        .ok_or_else(|| anyhow::anyhow!("Remote directory name is required for native SFTP transfer."))
+        .ok_or_else(|| {
+            anyhow::anyhow!("Remote directory name is required for native SFTP transfer.")
+        })
 }
 
 fn resolve_upload_file_destination_path(
@@ -2136,27 +2190,21 @@ fn expand_remote_home_path(path: &str, home_directory: Option<&str>) -> anyhow::
     }
 
     if trimmed == "~" {
-        return normalize_remote_directory_path(
-            home_directory
-                .ok_or_else(|| {
-                    anyhow::Error::new(NativeSftpTransferError::new(
-                        NativeSftpTransferErrorKind::InvalidArgument,
-                        "Remote home directory is unavailable for native SFTP upload.",
-                    ))
-                })?,
-        );
+        return normalize_remote_directory_path(home_directory.ok_or_else(|| {
+            anyhow::Error::new(NativeSftpTransferError::new(
+                NativeSftpTransferErrorKind::InvalidArgument,
+                "Remote home directory is unavailable for native SFTP upload.",
+            ))
+        })?);
     }
 
     if let Some(relative_path) = trimmed.strip_prefix("~/") {
-        let home_directory = normalize_remote_directory_path(
-            home_directory
-                .ok_or_else(|| {
-                    anyhow::Error::new(NativeSftpTransferError::new(
-                        NativeSftpTransferErrorKind::InvalidArgument,
-                        "Remote home directory is unavailable for native SFTP upload.",
-                    ))
-                })?,
-        )?;
+        let home_directory = normalize_remote_directory_path(home_directory.ok_or_else(|| {
+            anyhow::Error::new(NativeSftpTransferError::new(
+                NativeSftpTransferErrorKind::InvalidArgument,
+                "Remote home directory is unavailable for native SFTP upload.",
+            ))
+        })?)?;
         return Ok(join_remote_path(&home_directory, relative_path));
     }
 
@@ -2253,7 +2301,10 @@ fn run_session(
         let effective_shell_kind = if config.remote_shell_kind != RemoteShellKind::Auto {
             config.remote_shell_kind
         } else if let Some(command) = config.shell_detection_command.as_deref() {
-            detect_login_shell(&mut session, command).await?
+            match detect_login_shell(&mut session, command).await {
+                Ok(shell_kind) => shell_kind,
+                Err(_) => RemoteShellKind::Auto,
+            }
         } else {
             RemoteShellKind::Auto
         };
@@ -2803,10 +2854,12 @@ mod tests {
         let response_json = unsafe { CStr::from_ptr(response) }.to_str().unwrap();
         let payload: serde_json::Value = serde_json::from_str(response_json).unwrap();
         assert_eq!("invalid-argument", payload["status"]);
-        assert!(payload["message"]
-            .as_str()
-            .unwrap_or_default()
-            .contains("incomplete"));
+        assert!(
+            payload["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("incomplete")
+        );
 
         nova_ssh_string_free(response);
     }
@@ -2943,15 +2996,9 @@ mod tests {
             Some("sh -lc 'printf test'".to_owned()),
             config.shell_detection_command
         );
-        assert_eq!(
-            Some("bash-bootstrap".to_owned()),
-            config.bash_cwd_bootstrap
-        );
+        assert_eq!(Some("bash-bootstrap".to_owned()), config.bash_cwd_bootstrap);
         assert_eq!(Some("zsh-bootstrap".to_owned()), config.zsh_cwd_bootstrap);
-        assert_eq!(
-            Some("fish-bootstrap".to_owned()),
-            config.fish_cwd_bootstrap
-        );
+        assert_eq!(Some("fish-bootstrap".to_owned()), config.fish_cwd_bootstrap);
     }
 
     #[test]
@@ -3034,6 +3081,9 @@ mod tests {
         assert!(command.starts_with("sh -lc '"));
         assert!(command.contains("tmp_rc=$(mktemp)"));
         assert!(command.contains("exec bash --rcfile"));
+        assert!(command.contains("~/.bash_profile"));
+        assert!(command.contains("~/.bash_login"));
+        assert!(command.contains("~/.profile"));
         assert!(command.contains("~/.bashrc"));
     }
 
@@ -3066,6 +3116,36 @@ mod tests {
     }
 
     #[test]
+    fn build_startup_command_wraps_zsh_bootstrap_with_login_startup() {
+        let config = ConnectConfig {
+            host: "native.example".to_owned(),
+            user: "nova".to_owned(),
+            port: 22,
+            cols: 120,
+            rows: 30,
+            term: "xterm-256color".to_owned(),
+            identity_file: None,
+            jump_host: None,
+            keepalive_interval_seconds: 30,
+            keepalive_count_max: 3,
+            remote_shell_kind: RemoteShellKind::Zsh,
+            shell_detection_command: None,
+            bash_cwd_bootstrap: None,
+            zsh_cwd_bootstrap: Some("print cwd".to_owned()),
+            fish_cwd_bootstrap: None,
+        };
+
+        let command = build_startup_command(RemoteShellKind::Zsh, &config)
+            .expect("zsh command should be generated");
+
+        assert!(command.starts_with("sh -lc '"));
+        assert!(command.contains("$tmp_dir/.zprofile"));
+        assert!(command.contains("~/.zprofile"));
+        assert!(command.contains("exec zsh -il"));
+        assert!(command.contains("$tmp_dir/.zshrc"));
+    }
+
+    #[test]
     fn build_startup_command_returns_none_for_auto_or_pwsh() {
         let config = ConnectConfig {
             host: "native.example".to_owned(),
@@ -3087,6 +3167,17 @@ mod tests {
 
         assert_eq!(None, build_startup_command(RemoteShellKind::Auto, &config));
         assert_eq!(None, build_startup_command(RemoteShellKind::Pwsh, &config));
+    }
+
+    #[test]
+    fn append_bounded_shell_detection_output_truncates_at_limit() {
+        let mut output = vec![b'x'; SHELL_DETECTION_MAX_OUTPUT_BYTES - 2];
+
+        let reached_limit = append_bounded_shell_detection_output(&mut output, b"abcd");
+
+        assert!(reached_limit);
+        assert_eq!(SHELL_DETECTION_MAX_OUTPUT_BYTES, output.len());
+        assert_eq!(&output[output.len() - 2..], b"ab");
     }
 
     #[test]
@@ -3206,9 +3297,8 @@ mod tests {
 
     #[test]
     fn resolve_upload_file_destination_path_appends_local_name_for_existing_directory() {
-        let resolved =
-            resolve_upload_file_destination_path("upload.txt", "/tmp", None, true)
-                .expect("directory target should resolve");
+        let resolved = resolve_upload_file_destination_path("upload.txt", "/tmp", None, true)
+            .expect("directory target should resolve");
 
         assert_eq!("/tmp/upload.txt", resolved);
     }
@@ -3225,8 +3315,12 @@ mod tests {
     #[test]
     fn should_check_for_cancellation_only_after_interval_is_reached() {
         assert!(!should_check_for_cancellation(64 * 1024));
-        assert!(!should_check_for_cancellation(CANCELLATION_CHECK_INTERVAL_BYTES - 1));
-        assert!(should_check_for_cancellation(CANCELLATION_CHECK_INTERVAL_BYTES));
+        assert!(!should_check_for_cancellation(
+            CANCELLATION_CHECK_INTERVAL_BYTES - 1
+        ));
+        assert!(should_check_for_cancellation(
+            CANCELLATION_CHECK_INTERVAL_BYTES
+        ));
     }
 
     #[test]

--- a/src/NovaTerminal.Core/RemoteShellKind.cs
+++ b/src/NovaTerminal.Core/RemoteShellKind.cs
@@ -1,0 +1,10 @@
+namespace NovaTerminal.Core;
+
+public enum RemoteShellKind
+{
+    Auto,
+    Bash,
+    Zsh,
+    Fish,
+    Pwsh
+}

--- a/src/NovaTerminal.Core/Ssh/Models/SshProfile.cs
+++ b/src/NovaTerminal.Core/Ssh/Models/SshProfile.cs
@@ -31,4 +31,5 @@ public sealed class SshProfile
     public int ServerAliveCountMax { get; set; } = 3;
     public string ExtraSshArgs { get; set; } = string.Empty;
     public string WorkingDirectory { get; set; } = string.Empty;
+    public RemoteShellKind RemoteShellKind { get; set; } = RemoteShellKind.Auto;
 }

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshConnectionOptions.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshConnectionOptions.cs
@@ -19,6 +19,11 @@ public sealed class NativeSshConnectionOptions
     public SshJumpHop? JumpHost { get; init; }
     public int KeepAliveIntervalSeconds { get; init; } = DefaultKeepAliveIntervalSeconds;
     public int KeepAliveCountMax { get; init; } = DefaultKeepAliveCountMax;
+    public RemoteShellKind RemoteShellKind { get; init; } = RemoteShellKind.Auto;
+    public string? ShellDetectionCommand { get; init; }
+    public string? BashCwdBootstrap { get; init; }
+    public string? ZshCwdBootstrap { get; init; }
+    public string? FishCwdBootstrap { get; init; }
 
     public static NativeSshConnectionOptions FromProfile(SshProfile profile, int cols, int rows)
     {
@@ -39,7 +44,8 @@ public sealed class NativeSshConnectionOptions
                 : DefaultKeepAliveCountMax,
             IdentityFilePath = string.IsNullOrWhiteSpace(profile.IdentityFilePath)
                 ? null
-                : profile.IdentityFilePath
+                : profile.IdentityFilePath,
+            RemoteShellKind = profile.RemoteShellKind
         };
     }
 }

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
@@ -27,6 +27,10 @@ public sealed partial class NativeSshInterop : INativeSshInterop
         IntPtr userPtr = IntPtr.Zero;
         IntPtr termPtr = IntPtr.Zero;
         IntPtr identityPtr = IntPtr.Zero;
+        IntPtr shellDetectionCommandPtr = IntPtr.Zero;
+        IntPtr bashCwdBootstrapPtr = IntPtr.Zero;
+        IntPtr zshCwdBootstrapPtr = IntPtr.Zero;
+        IntPtr fishCwdBootstrapPtr = IntPtr.Zero;
 
         try
         {
@@ -36,6 +40,22 @@ public sealed partial class NativeSshInterop : INativeSshInterop
             if (!string.IsNullOrWhiteSpace(options.IdentityFilePath))
             {
                 identityPtr = Marshal.StringToCoTaskMemUTF8(options.IdentityFilePath);
+            }
+            if (!string.IsNullOrWhiteSpace(options.ShellDetectionCommand))
+            {
+                shellDetectionCommandPtr = Marshal.StringToCoTaskMemUTF8(options.ShellDetectionCommand);
+            }
+            if (!string.IsNullOrWhiteSpace(options.BashCwdBootstrap))
+            {
+                bashCwdBootstrapPtr = Marshal.StringToCoTaskMemUTF8(options.BashCwdBootstrap);
+            }
+            if (!string.IsNullOrWhiteSpace(options.ZshCwdBootstrap))
+            {
+                zshCwdBootstrapPtr = Marshal.StringToCoTaskMemUTF8(options.ZshCwdBootstrap);
+            }
+            if (!string.IsNullOrWhiteSpace(options.FishCwdBootstrap))
+            {
+                fishCwdBootstrapPtr = Marshal.StringToCoTaskMemUTF8(options.FishCwdBootstrap);
             }
 
             IntPtr jumpHostPtr = IntPtr.Zero;
@@ -65,7 +85,12 @@ public sealed partial class NativeSshInterop : INativeSshInterop
                     JumpUser = jumpUserPtr,
                     JumpPort = checked((ushort)(options.JumpHost?.Port ?? 0)),
                     KeepAliveIntervalSeconds = checked((uint)Math.Max(0, options.KeepAliveIntervalSeconds)),
-                    KeepAliveCountMax = checked((uint)Math.Max(0, options.KeepAliveCountMax))
+                    KeepAliveCountMax = checked((uint)Math.Max(0, options.KeepAliveCountMax)),
+                    RemoteShellKind = (uint)options.RemoteShellKind,
+                    ShellDetectionCommand = shellDetectionCommandPtr,
+                    BashCwdBootstrap = bashCwdBootstrapPtr,
+                    ZshCwdBootstrap = zshCwdBootstrapPtr,
+                    FishCwdBootstrap = fishCwdBootstrapPtr
                 };
 
                 IntPtr handle = NativeMethods.nova_ssh_connect(in args);
@@ -88,6 +113,10 @@ public sealed partial class NativeSshInterop : INativeSshInterop
             FreeUtf8(userPtr);
             FreeUtf8(termPtr);
             FreeUtf8(identityPtr);
+            FreeUtf8(shellDetectionCommandPtr);
+            FreeUtf8(bashCwdBootstrapPtr);
+            FreeUtf8(zshCwdBootstrapPtr);
+            FreeUtf8(fishCwdBootstrapPtr);
         }
     }
 
@@ -704,6 +733,11 @@ public sealed partial class NativeSshInterop : INativeSshInterop
         public ushort JumpPort;
         public uint KeepAliveIntervalSeconds;
         public uint KeepAliveCountMax;
+        public uint RemoteShellKind;
+        public IntPtr ShellDetectionCommand;
+        public IntPtr BashCwdBootstrap;
+        public IntPtr ZshCwdBootstrap;
+        public IntPtr FishCwdBootstrap;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
@@ -71,7 +71,7 @@ public sealed class NativeSshSession : ITerminalSession
         _profileHost = profile.Host;
         _allowVaultPasswordReuse = profile.Id != Guid.Empty;
         JumpHostConnectPlan connectPlan = JumpHostConnectPlan.Create(profile);
-        NativeSshConnectionOptions connectionOptions = _jumpHostConnector.CreateConnectionOptions(connectPlan, profile, cols, rows);
+        NativeSshConnectionOptions connectionOptions = CreateConnectionOptions(connectPlan, profile, cols, rows);
         _log($"[NativeSshSession] backend=native path={_jumpHostConnector.DescribePath(connectPlan)} target={connectionOptions.User}@{connectionOptions.Host}:{connectionOptions.Port}");
         _sessionHandle = _interop.Connect(connectionOptions);
 
@@ -258,6 +258,58 @@ public sealed class NativeSshSession : ITerminalSession
     public void AttachBuffer(TerminalBuffer buffer)
     {
         _buffer = buffer;
+    }
+
+    private NativeSshConnectionOptions CreateConnectionOptions(
+        JumpHostConnectPlan connectPlan,
+        SshProfile profile,
+        int cols,
+        int rows)
+    {
+        NativeSshConnectionOptions baseOptions = _jumpHostConnector.CreateConnectionOptions(connectPlan, profile, cols, rows);
+        RemoteShellKind remoteShellKind = profile.RemoteShellKind;
+
+        return new NativeSshConnectionOptions
+        {
+            Host = baseOptions.Host,
+            User = baseOptions.User,
+            Port = baseOptions.Port,
+            Cols = baseOptions.Cols,
+            Rows = baseOptions.Rows,
+            Term = baseOptions.Term,
+            Password = baseOptions.Password,
+            IdentityFilePath = baseOptions.IdentityFilePath,
+            KnownHostsFilePath = baseOptions.KnownHostsFilePath,
+            JumpHost = baseOptions.JumpHost,
+            KeepAliveIntervalSeconds = baseOptions.KeepAliveIntervalSeconds,
+            KeepAliveCountMax = baseOptions.KeepAliveCountMax,
+            RemoteShellKind = remoteShellKind,
+            ShellDetectionCommand = remoteShellKind == RemoteShellKind.Auto
+                ? "sh -lc 'printf \"%s\" \"${SHELL##*/}\"' 2>/dev/null"
+                : null,
+            BashCwdBootstrap = string.Join(
+                "\n",
+                "__nova_emit_cwd() {",
+                "  printf '\\033]7;%s\\007' \"$PWD\"",
+                "}",
+                "PROMPT_COMMAND=\"__nova_emit_cwd${PROMPT_COMMAND:+;$PROMPT_COMMAND}\""),
+            ZshCwdBootstrap = string.Join(
+                "\n",
+                "autoload -Uz add-zsh-hook",
+                "__nova_emit_cwd() {",
+                "  printf '\\033]7;%s\\007' \"$PWD\"",
+                "}",
+                "add-zsh-hook precmd __nova_emit_cwd"),
+            FishCwdBootstrap = string.Join(
+                "\n",
+                "functions -q fish_prompt; and functions -c fish_prompt __nova_original_fish_prompt",
+                "function fish_prompt",
+                "    printf '\\033]7;%s\\007' \"$PWD\"",
+                "    if functions -q __nova_original_fish_prompt",
+                "        __nova_original_fish_prompt",
+                "    end",
+                "end")
+        };
     }
 
     public void TakeSnapshot()

--- a/src/NovaTerminal.Core/Ssh/Storage/JsonSshProfileStore.cs
+++ b/src/NovaTerminal.Core/Ssh/Storage/JsonSshProfileStore.cs
@@ -255,6 +255,9 @@ public sealed class JsonSshProfileStore : ISshProfileStore
         normalized.IdentityFilePath = normalized.IdentityFilePath?.Trim() ?? string.Empty;
         SshProfileNormalizer.NormalizeRememberPasswordPreference(normalized);
         normalized.WorkingDirectory = normalized.WorkingDirectory?.Trim() ?? string.Empty;
+        normalized.RemoteShellKind = Enum.IsDefined(normalized.RemoteShellKind)
+            ? normalized.RemoteShellKind
+            : RemoteShellKind.Auto;
         normalized.ServerAliveIntervalSeconds = normalized.ServerAliveIntervalSeconds > 0
             ? normalized.ServerAliveIntervalSeconds
             : 30;
@@ -331,7 +334,8 @@ public sealed class JsonSshProfileStore : ISshProfileStore
             ServerAliveIntervalSeconds = profile.ServerAliveIntervalSeconds,
             ServerAliveCountMax = profile.ServerAliveCountMax,
             ExtraSshArgs = profile.ExtraSshArgs,
-            WorkingDirectory = profile.WorkingDirectory
+            WorkingDirectory = profile.WorkingDirectory,
+            RemoteShellKind = profile.RemoteShellKind
         };
     }
 

--- a/tests/NovaTerminal.Core.Tests/Ssh/DockerSshFixture.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/DockerSshFixture.cs
@@ -5,7 +5,7 @@ namespace NovaTerminal.Core.Tests.Ssh;
 
 internal sealed class DockerSshFixture : IAsyncDisposable
 {
-    private const string ImageTag = "novaterm-native-ssh-e2e:local";
+    private const string ImageTag = "novaterm-native-ssh-e2e:v2";
     private string _containerName = string.Empty;
     private bool _started;
 
@@ -64,6 +64,14 @@ internal sealed class DockerSshFixture : IAsyncDisposable
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
 
         await RunDockerCommandAsync($"exec {_containerName} mkdir -p {path}")
+            .ConfigureAwait(false);
+    }
+
+    public async Task SetLoginShellAsync(string shellPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(shellPath);
+
+        await RunDockerCommandAsync($"exec {_containerName} usermod -s {shellPath} {UserName}")
             .ConfigureAwait(false);
     }
 

--- a/tests/NovaTerminal.Core.Tests/Ssh/JsonSshProfileStoreTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/JsonSshProfileStoreTests.cs
@@ -152,6 +152,35 @@ public sealed class JsonSshProfileStoreTests
     }
 
     [Fact]
+    public void SaveAndLoad_RoundTripsRemoteShellKind()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string storePath = Path.Combine(tempRoot, "profiles.json");
+            var store = new JsonSshProfileStore(storePath);
+            var profile = new SshProfile
+            {
+                Id = Guid.Parse("2b7ca4ee-dc11-4a0e-bb7c-c6db8d3f5e25"),
+                Name = "bash",
+                Host = "bash.internal",
+                RemoteShellKind = RemoteShellKind.Bash
+            };
+
+            store.SaveProfile(profile);
+
+            SshProfile? loaded = store.GetProfile(profile.Id);
+
+            Assert.NotNull(loaded);
+            Assert.Equal(RemoteShellKind.Bash, loaded!.RemoteShellKind);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
     public void NormalizeRememberPasswordPreference_PreservesNativeProfiles()
     {
         var profile = new SshProfile

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
@@ -4,6 +4,7 @@ using NovaTerminal.Core.Ssh.Native;
 using NovaTerminal.Core.Ssh.Sessions;
 using NovaTerminal.Core.Tests.Infra;
 using System.Text;
+using NovaTerminal.Core;
 
 namespace NovaTerminal.Core.Tests.Ssh;
 
@@ -822,6 +823,30 @@ public sealed class NativeSshDockerE2eTests
         Assert.DoesNotContain(after.Lines.Take(20), line => line.Contains("line 01", StringComparison.Ordinal));
     }
 
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
+    public Task NativeSsh_AutoRemoteShellKind_EmitsCwdUpdatesForBash()
+    {
+        return AssertAutoRemoteShellKindEmitsCwdUpdatesAsync("/bin/bash");
+    }
+
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
+    public Task NativeSsh_AutoRemoteShellKind_EmitsCwdUpdatesForZsh()
+    {
+        return AssertAutoRemoteShellKindEmitsCwdUpdatesAsync("/usr/bin/zsh");
+    }
+
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
+    public Task NativeSsh_AutoRemoteShellKind_EmitsCwdUpdatesForFish()
+    {
+        return AssertAutoRemoteShellKindEmitsCwdUpdatesAsync("/usr/bin/fish");
+    }
+
     private static SshProfile CreateProfile(DockerSshFixture fixture)
     {
         return new SshProfile
@@ -833,6 +858,57 @@ public sealed class NativeSshDockerE2eTests
             User = fixture.UserName,
             Port = fixture.Port
         };
+    }
+
+    private static async Task AssertAutoRemoteShellKindEmitsCwdUpdatesAsync(string loginShellPath)
+    {
+        await using var fixture = await DockerSshFixture.StartAsync();
+        await fixture.SetLoginShellAsync(loginShellPath);
+
+        var buffer = new TerminalBuffer(120, 30);
+        var parser = new AnsiParser(buffer);
+        var handler = new NativeSshTestInteractionHandler(fixture.Password);
+        var cwdEvents = new List<string>();
+
+        parser.OnWorkingDirectoryChanged += cwd =>
+        {
+            lock (cwdEvents)
+            {
+                cwdEvents.Add(cwd);
+            }
+        };
+
+        SshProfile profile = CreateProfile(fixture);
+        profile.RemoteShellKind = RemoteShellKind.Auto;
+
+        using var session = new NativeSshSession(
+            profile,
+            cols: 120,
+            rows: 30,
+            interactionHandler: handler);
+
+        session.AttachBuffer(buffer);
+        session.OnOutputReceived += parser.Process;
+
+        await WaitUntilAsync(
+            () => GetLatestCwd(cwdEvents) == "/home/nova",
+            TimeSpan.FromSeconds(20),
+            $"initial cwd from {loginShellPath}");
+
+        session.SendInput("cd /tmp\n");
+
+        await WaitUntilAsync(
+            () => GetLatestCwd(cwdEvents) == "/tmp",
+            TimeSpan.FromSeconds(20),
+            $"cwd change after cd in {loginShellPath}");
+    }
+
+    private static string? GetLatestCwd(List<string> cwdEvents)
+    {
+        lock (cwdEvents)
+        {
+            return cwdEvents.Count == 0 ? null : cwdEvents[^1];
+        }
     }
 
     private static bool SnapshotContains(TerminalBuffer buffer, string value)

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
@@ -168,6 +168,42 @@ public sealed class NativeSshSessionTests
         Assert.Equal(7, interop.LastConnectOptions.KeepAliveCountMax);
     }
 
+    [Fact]
+    public async Task Connect_WithAutoRemoteShellKind_PassesProbeAndSupportedBootstraps()
+    {
+        var interop = new FakeNativeSshInterop();
+        SshProfile profile = CreateProfile();
+        profile.RemoteShellKind = RemoteShellKind.Auto;
+
+        using var session = new NativeSshSession(profile, interop: interop);
+
+        await WaitUntilAsync(() => interop.LastConnectOptions != null);
+
+        Assert.NotNull(interop.LastConnectOptions);
+        Assert.Equal(RemoteShellKind.Auto, interop.LastConnectOptions!.RemoteShellKind);
+        Assert.Contains("sh -lc", interop.LastConnectOptions.ShellDetectionCommand, StringComparison.Ordinal);
+        Assert.Contains("PROMPT_COMMAND", interop.LastConnectOptions.BashCwdBootstrap, StringComparison.Ordinal);
+        Assert.Contains("add-zsh-hook precmd", interop.LastConnectOptions.ZshCwdBootstrap, StringComparison.Ordinal);
+        Assert.Contains("fish_prompt", interop.LastConnectOptions.FishCwdBootstrap, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Connect_WithExplicitBashRemoteShellKind_SkipsProbeButPassesBootstrap()
+    {
+        var interop = new FakeNativeSshInterop();
+        SshProfile profile = CreateProfile();
+        profile.RemoteShellKind = RemoteShellKind.Bash;
+
+        using var session = new NativeSshSession(profile, interop: interop);
+
+        await WaitUntilAsync(() => interop.LastConnectOptions != null);
+
+        Assert.NotNull(interop.LastConnectOptions);
+        Assert.Equal(RemoteShellKind.Bash, interop.LastConnectOptions!.RemoteShellKind);
+        Assert.Null(interop.LastConnectOptions.ShellDetectionCommand);
+        Assert.Contains("PROMPT_COMMAND", interop.LastConnectOptions.BashCwdBootstrap, StringComparison.Ordinal);
+    }
+
     private static SshProfile CreateProfile()
     {
         return new SshProfile

--- a/tests/NovaTerminal.ExternalSuites/NativeSsh/Dockerfile
+++ b/tests/NovaTerminal.ExternalSuites/NativeSsh/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:12-slim
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends openssh-server bash ca-certificates vim-tiny \
+    && apt-get install -y --no-install-recommends openssh-server bash zsh fish ca-certificates vim-tiny \
     && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m -s /bin/bash nova \
@@ -21,6 +21,9 @@ RUN mkdir -p /var/run/sshd /home/nova/.ssh \
 RUN ssh-keygen -A
 
 RUN printf "export PS1='nova$ '\n" > /home/nova/.bashrc \
+    && printf "PROMPT='nova$ '\n" > /home/nova/.zshrc \
+    && mkdir -p /home/nova/.config/fish \
+    && printf "function fish_prompt\n    printf 'nova$ '\nend\n" > /home/nova/.config/fish/config.fish \
     && printf "if [ -f ~/.bashrc ]; then . ~/.bashrc; fi\n" > /home/nova/.bash_profile \
     && chown -R nova:nova /home/nova
 

--- a/tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs
@@ -1,3 +1,4 @@
+using NovaTerminal.Core;
 using NovaTerminal.Core.Ssh.Models;
 using NovaTerminal.ViewModels.Ssh;
 
@@ -205,6 +206,25 @@ public sealed class NewSshConnectionViewModelTests
         SshProfile profile = vm.ToSshProfile();
 
         Assert.False(profile.RememberPasswordInVault);
+    }
+
+    [Fact]
+    public void RemoteShellKind_RoundTripsBetweenViewModelAndSshProfile()
+    {
+        var vm = new NewSshConnectionViewModel
+        {
+            Name = "Bash Host",
+            HostName = "bash.internal",
+            RemoteShellKind = RemoteShellKind.Bash
+        };
+
+        SshProfile profile = vm.ToSshProfile();
+        Assert.Equal(RemoteShellKind.Bash, profile.RemoteShellKind);
+
+        var roundTripped = new NewSshConnectionViewModel();
+        roundTripped.ApplySshProfile(profile);
+
+        Assert.Equal(RemoteShellKind.Bash, roundTripped.RemoteShellKind);
     }
 
     [Fact]

--- a/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
@@ -656,6 +656,33 @@ public sealed class SshConnectionServiceTests
         }
     }
 
+    [Fact]
+    public void GetConnectionProfiles_ProjectsRemoteShellKindIntoRuntimeProfile()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string path = Path.Combine(tempRoot, "profiles.json");
+            var store = new JsonSshProfileStore(path);
+            var service = new SshConnectionService(store);
+            store.SaveProfile(new SshProfile
+            {
+                Id = Guid.Parse("5eef2d64-8877-44e5-945a-afdc676a44c8"),
+                Name = "bash",
+                Host = "bash.internal",
+                RemoteShellKind = RemoteShellKind.Bash
+            });
+
+            TerminalProfile runtime = service.GetConnectionProfiles().Single();
+
+            Assert.Equal(RemoteShellKind.Bash, runtime.RemoteShellKind);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
     private sealed class RecordingSshPasswordVault : ISshPasswordVault
     {
         public Dictionary<string, string> Secrets { get; } = new(StringComparer.Ordinal);


### PR DESCRIPTION
## Summary
- add explicit remote shell metadata to native SSH profiles and runtime launch details
- resolve `Auto` remote shells at session startup and inject cwd shell integration for bash, zsh, and fish
- add Docker-backed native SSH end-to-end coverage for cwd sync across bash, zsh, and fish

## Test Plan
- [x] cargo test --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml
- [x] dotnet test tests/NovaTerminal.Core.Tests/NovaTerminal.Core.Tests.csproj --filter "FullyQualifiedName~NativeSshSessionTests|FullyQualifiedName~JsonSshProfileStoreTests|FullyQualifiedName~NativeSsh_AutoRemoteShellKind_EmitsCwdUpdates" -m:1 --nologo -v:minimal
- [x] dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "FullyQualifiedName~NewSshConnectionViewModelTests|FullyQualifiedName~SshConnectionServiceTests" -m:1 --nologo -v:minimal