### PR TITLE
Polish native SFTP sidebar layout and transfer flow

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -90,11 +90,15 @@ Transfer behavior depends on the SSH backend:
 - **OpenSSH profiles** use the system `scp` executable.
 - **Native SSH profiles** use NovaTerminal's built-in native SFTP path for file and folder upload/download.
 
+Native SSH panes also expose a pane-local `Remote Files` sidebar from the pane context menu. The sidebar is lightly navigable, opens from the pane's current remote directory when available, and keeps upload/download actions grounded in the directory or entry you are looking at. `Upload File` and `Upload Folder` target the directory currently shown in the sidebar, while `Download Selected` uses the selected remote file or folder.
+
 Current Native SSH transfer notes:
 
 - Transfers use the native backend's known-hosts store and do not silently fall back to OpenSSH.
 - Password and identity-file authentication are supported for non-interactive transfers.
 - The transfer dialog offers remote path autocomplete when the same profile already has an active Native SSH session.
+- Sidebar-initiated transfers still use the existing local picker and transfer dialog flow, but the remote side is prefilled from the sidebar context instead of defaulting to `~`.
+- The `Remote Files` sidebar hides automatically while alternate-screen/fullscreen terminal applications are active.
 - Single-file transfers show live byte progress when the total size is known.
 - Folder transfers report per-file progress callbacks; they do not show a precomputed total for the entire tree.
 - Cancellation is supported from the Transfer Center for native transfers.

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -90,14 +90,16 @@ Transfer behavior depends on the SSH backend:
 - **OpenSSH profiles** use the system `scp` executable.
 - **Native SSH profiles** use NovaTerminal's built-in native SFTP path for file and folder upload/download.
 
-Native SSH panes also expose a pane-local `Remote Files` sidebar from the pane context menu. The sidebar is lightly navigable, opens from the pane's current remote directory when available, and keeps upload/download actions grounded in the directory or entry you are looking at. `Upload File` and `Upload Folder` target the directory currently shown in the sidebar, while `Download Selected` uses the selected remote file or folder.
+Native SSH panes also expose a pane-local `Remote Files` sidebar from the pane context menu. The sidebar is lightly navigable, opens from the pane's current remote directory when available, and keeps upload/download actions grounded in the directory or entry you are looking at. The compact rail shows the active host identity, current remote path, and per-entry modified dates so you can quickly spot recently changed files. `Upload File` and `Upload Folder` target the directory currently shown in the sidebar, while `Download Selected` uses the selected remote file or folder.
 
 Current Native SSH transfer notes:
 
 - Transfers use the native backend's known-hosts store and do not silently fall back to OpenSSH.
 - Password and identity-file authentication are supported for non-interactive transfers.
 - The transfer dialog offers remote path autocomplete when the same profile already has an active Native SSH session.
-- Sidebar-initiated transfers still use the existing local picker and transfer dialog flow, but the remote side is prefilled from the sidebar context instead of defaulting to `~`.
+- Sidebar-initiated uploads go straight to a local file or folder picker, then start the transfer directly into the sidebar's current remote directory.
+- Sidebar-initiated file downloads use a save picker with the remote filename prefilled; sidebar folder downloads use a local folder picker.
+- Manual `SFTP:` command-palette flows still use the transfer dialog, including remote path autocomplete when an active Native SSH session is available.
 - The `Remote Files` sidebar hides automatically while alternate-screen/fullscreen terminal applications are active.
 - Single-file transfers show live byte progress when the total size is known.
 - Folder transfers report per-file progress callbacks; they do not show a precomputed total for the entire tree.

--- a/docs/plans/2026-04-30-native-sftp-sidebar-design.md
+++ b/docs/plans/2026-04-30-native-sftp-sidebar-design.md
@@ -1,0 +1,271 @@
+# Native SFTP Sidebar Design
+
+## Goal
+
+Improve NovaTerminal's Native SFTP transfer UX by replacing the disconnected right-click-plus-modal flow with a pane-local, lightly navigable remote sidebar that stays terminal-first and does not become a general file browser.
+
+## Scope
+
+This design adds:
+
+1. A pane-local Native SFTP sidebar
+2. Lightweight remote directory navigation
+3. Transfer actions grounded in visible remote context
+4. CWD-aware defaulting for remote operations
+
+This design does not add:
+
+- VT parsing or rendering changes
+- transfer UI inside terminal grid content
+- an OpenSSH remote browser
+- recursive tree browsing
+- file preview, rename, delete, or other file-manager behaviors
+
+## Constraints
+
+- Use Avalonia for all new UI.
+- Keep SFTP UX separate from terminal core logic.
+- Prefer additive changes over refactors.
+- Preserve current `SftpService` ownership of transfer queueing and progress.
+- Auto-hide the sidebar in alternate-screen/fullscreen TUI mode.
+
+## Problem Summary
+
+The current SFTP UX feels disconnected for two reasons:
+
+1. Transfer initiation starts from a generic pane context menu rather than from a visible remote context.
+2. The transfer dialog defaults remote input to `profile.DefaultRemoteDir ?? "~"` rather than the pane's active remote working directory.
+
+That leaves upload and download feeling like detached utility actions instead of part of the SSH pane workflow.
+
+## Chosen Direction
+
+Use a pane-local right sidebar on Native SSH panes as the primary transfer-entry surface.
+
+The sidebar should:
+
+- open from the active pane
+- show the current remote path
+- list one remote directory at a time
+- allow lightweight navigation
+- let upload target the displayed directory
+- let download act on the selected remote file or folder
+
+The existing transfer dialog can remain as a fallback/manual path surface, but it should stop being the primary Native SSH flow.
+
+## Alternatives Considered
+
+### 1. Pane-Local Slide-Out Sidebar
+
+Recommended.
+
+Pros:
+
+- feels connected to the active SSH pane
+- keeps remote context visible while preserving terminal visibility
+- makes upload and download target selection much clearer
+- fits existing pane-local overlay patterns
+
+Cons:
+
+- broader scope than a dialog-only fix
+- needs careful limits to avoid drifting into file-manager territory
+
+### 2. Persistent Docked Remote Sidebar
+
+Rejected for v1.
+
+Pros:
+
+- very discoverable
+- always visible
+
+Cons:
+
+- permanently consumes pane width
+- too expensive for small panes
+- competes with terminal-first usage
+
+### 3. Larger Popup Browser
+
+Rejected as the primary surface.
+
+Pros:
+
+- cheaper than a docked rail
+- can still provide remote context
+
+Cons:
+
+- still feels transient and utility-like
+- does not fix the "part of the pane" feel as well as a sidebar
+
+## Product Direction
+
+NovaTerminal should remain terminal-first, not file-manager-first.
+
+That means the sidebar must stay intentionally narrow:
+
+- one directory at a time
+- no tree
+- no preview
+- no mutation actions beyond starting transfers
+- keyboard-friendly, minimal chrome
+
+The target feel is "remote transfer helper attached to a pane", not "embedded SFTP client."
+
+## Sidebar Surface
+
+### Placement
+
+- Right side of the active `TerminalPane`
+- Pane-owned, not `MainWindow`-global
+- Visible only for Native SSH panes with an active session
+
+### Sections
+
+- Header: remote path, back, refresh, close
+- Body: current directory listing
+- Footer: `Upload File`, `Upload Folder`, `Download Selected`
+
+### Navigation
+
+Supported:
+
+- enter folder
+- go up one level
+- go back through visited directories
+- refresh current directory
+
+Not supported:
+
+- recursive tree expansion
+- multi-select
+- drag-and-drop between local and remote surfaces
+
+## Session And Path Rules
+
+### Availability
+
+The sidebar is available only when:
+
+- the pane is an SSH pane
+- the backend is `SshBackendKind.Native`
+- there is an active session for that pane
+
+### Initial Path
+
+When opening the sidebar, resolve the starting path in this order:
+
+1. pane's best-known remote current working directory
+2. `profile.DefaultRemoteDir`
+3. `~`
+
+### Shell CWD Changes
+
+If the shell current directory changes while the sidebar is open:
+
+- do not forcibly re-navigate the sidebar
+- show a small `Jump To Current Directory` affordance instead
+
+This keeps the user's browsing context stable while still acknowledging live shell context.
+
+## Directory Listing Behavior
+
+- One directory is listed per query.
+- Directories sort before files.
+- Names sort alphabetically within their rank group.
+- Selection is single-item only.
+- Files are selectable and downloadable.
+- Directories are selectable, downloadable, and navigable.
+
+Keyboard behavior:
+
+- `Up` / `Down` changes selection
+- `Enter` opens a selected directory
+- `Backspace` navigates up one level when the list has focus
+- `Alt+Left` navigates back
+- `Escape` closes the sidebar
+
+Double-click on a directory should also navigate into it.
+
+## Transfer Behavior
+
+### Upload
+
+- `Upload File` picks a local file and uploads it into the currently displayed remote directory.
+- `Upload Folder` picks a local folder and uploads it into the currently displayed remote directory.
+- The sidebar removes the need to type a remote destination for common uploads.
+
+### Download
+
+- `Download Selected` is enabled only when a remote file or folder is selected.
+- Download acts on the selected entry.
+- Local destination selection can still use the existing local picker flow.
+
+### Execution Boundary
+
+The sidebar should not own transfer execution. It only produces clearer transfer requests. `SftpService` remains the execution and progress boundary.
+
+## Failure And State Handling
+
+- No active session: entry point hidden or disabled.
+- Directory listing failure: show inline error and `Retry`, no modal.
+- Missing path or permission error: show inline error, keep navigation controls available.
+- Session disconnect while open: freeze list actions, show disconnected state, allow close.
+- Transfer start failure: continue to surface through existing transfer job error handling.
+- Long-running transfer progress remains in the existing Transfer Center / status UI rather than moving into the sidebar.
+
+## Implementation Shape
+
+Preferred split:
+
+- `TerminalPane`: owns sidebar visibility, placement, keyboard routing, alt-screen hiding, and pane/session context
+- sidebar view model/controller: owns path, entries, selection, loading/error state, and back-stack
+- remote directory browser service: owns native directory listing calls and navigation/path normalization
+- `SftpService`: continues to own job queueing, progress, cancellation, and result state
+
+This keeps UI concerns out of terminal core logic and keeps the SFTP helper additive.
+
+## Testing Strategy
+
+### Deterministic unit tests
+
+- initial-path resolution
+- directories-first sorting
+- back-stack behavior
+- jump-to-current-directory state changes
+- disabled download with no selection
+- inline listing error state transitions
+
+### Pane/UI tests
+
+- sidebar opens only for eligible Native SSH panes
+- sidebar hides in alternate-screen mode
+- keyboard navigation updates selection and path correctly
+- directory double-click / `Enter` opens child folder
+
+### Existing transfer tests remain
+
+- `SftpService` tests keep execution coverage
+- native SFTP interop and Docker E2E tests remain the backend confidence layer
+
+Avoid snapshot-heavy UI tests.
+
+## Rollout Order
+
+1. add remote directory browser state/service
+2. add pane-local sidebar control and host integration
+3. wire upload/download actions through the sidebar
+4. add alt-screen and disconnect behavior
+5. keep manual dialog flow as fallback where still useful
+
+## Expected Outcome
+
+After this work:
+
+- Native SFTP actions feel attached to the active SSH pane
+- remote defaults come from live session context instead of `~`
+- downloads can start from visible remote entries instead of typed paths
+- uploads target the currently shown remote directory
+- NovaTerminal remains terminal-first without becoming a full SFTP browser

--- a/docs/plans/2026-04-30-native-sftp-sidebar-design.md
+++ b/docs/plans/2026-04-30-native-sftp-sidebar-design.md
@@ -202,6 +202,7 @@ Double-click on a directory should also navigate into it.
 - `Download Selected` is enabled only when a remote file or folder is selected.
 - Download acts on the selected entry.
 - Local destination selection can still use the existing local picker flow.
+- Sidebar-originated transfers continue using the existing dialog/picker flow, but the remote path is prefilled from the active sidebar context rather than a generic default.
 
 ### Execution Boundary
 
@@ -212,7 +213,7 @@ The sidebar should not own transfer execution. It only produces clearer transfer
 - No active session: entry point hidden or disabled.
 - Directory listing failure: show inline error and `Retry`, no modal.
 - Missing path or permission error: show inline error, keep navigation controls available.
-- Session disconnect while open: freeze list actions, show disconnected state, allow close.
+- Session disconnect while open: keep the sidebar visible, freeze list/transfer actions, show disconnected state, allow close.
 - Transfer start failure: continue to surface through existing transfer job error handling.
 - Long-running transfer progress remains in the existing Transfer Center / status UI rather than moving into the sidebar.
 

--- a/docs/plans/2026-04-30-native-sftp-sidebar-implementation-plan.md
+++ b/docs/plans/2026-04-30-native-sftp-sidebar-implementation-plan.md
@@ -1,0 +1,550 @@
+# Native SFTP Sidebar Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a pane-local, lightly navigable Native SFTP sidebar that uses live SSH context for transfer actions while keeping `SftpService` as the execution boundary.
+
+**Architecture:** Add a small app-layer remote directory browser service plus a pane-local sidebar view model and Avalonia control hosted by `TerminalPane`. Reuse the existing native remote directory listing path and active session registry for data, keep alternate-screen hiding in the pane layer, and continue routing actual transfer jobs through `SftpService` and the existing local picker flow.
+
+**Tech Stack:** C#, .NET 10, Avalonia, existing Native SSH interop, `SftpService`, xUnit, Avalonia.Headless.XUnit
+
+---
+
+### Task 1: Define sidebar models and directory browser contract
+
+**Files:**
+- Create: `src/NovaTerminal.App/Models/RemoteSidebarEntry.cs`
+- Create: `src/NovaTerminal.App/Models/RemoteSidebarListingResult.cs`
+- Create: `src/NovaTerminal.App/Services/Ssh/IRemoteDirectoryBrowserService.cs`
+- Create: `src/NovaTerminal.App/Services/Ssh/RemoteSidebarStartPathResolver.cs`
+- Test: `tests/NovaTerminal.Tests/Ssh/RemoteSidebarStartPathResolverTests.cs`
+
+**Step 1: Write the failing test**
+
+```csharp
+[Fact]
+public void ResolveStartPath_PrefersPaneWorkingDirectory_OverProfileDefault()
+{
+    string resolved = RemoteSidebarStartPathResolver.Resolve(
+        currentWorkingDirectory: "/srv/app",
+        defaultRemoteDirectory: "~/downloads");
+
+    Assert.Equal("/srv/app", resolved);
+}
+```
+
+Add a second test that falls back from blank cwd to `profile.DefaultRemoteDir`, and then to `~`.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "FullyQualifiedName~RemoteSidebarStartPathResolverTests" -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because the resolver and sidebar models do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add small explicit models:
+
+```csharp
+public sealed record RemoteSidebarEntry(
+    string Name,
+    string FullPath,
+    bool IsDirectory);
+```
+
+```csharp
+public static class RemoteSidebarStartPathResolver
+{
+    public static string Resolve(string? currentWorkingDirectory, string? defaultRemoteDirectory)
+    {
+        if (!string.IsNullOrWhiteSpace(currentWorkingDirectory))
+        {
+            return currentWorkingDirectory.Trim();
+        }
+
+        if (!string.IsNullOrWhiteSpace(defaultRemoteDirectory))
+        {
+            return defaultRemoteDirectory.Trim();
+        }
+
+        return "~";
+    }
+}
+```
+
+Define a browser contract such as:
+
+```csharp
+public interface IRemoteDirectoryBrowserService
+{
+    Task<RemoteSidebarListingResult> ListDirectoryAsync(
+        Guid profileId,
+        Guid sessionId,
+        string remotePath,
+        CancellationToken cancellationToken);
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Models/RemoteSidebarEntry.cs src/NovaTerminal.App/Models/RemoteSidebarListingResult.cs src/NovaTerminal.App/Services/Ssh/IRemoteDirectoryBrowserService.cs src/NovaTerminal.App/Services/Ssh/RemoteSidebarStartPathResolver.cs tests/NovaTerminal.Tests/Ssh/RemoteSidebarStartPathResolverTests.cs
+git commit -m "feat: define remote sidebar contracts"
+```
+
+### Task 2: Implement the remote directory browser service
+
+**Files:**
+- Create: `src/NovaTerminal.App/Services/Ssh/RemoteDirectoryBrowserService.cs`
+- Modify: `src/NovaTerminal.App/Services/Ssh/ActiveSshSessionRegistry.cs`
+- Modify: `src/NovaTerminal.App/Services/Ssh/RemotePathAutocompleteService.cs`
+- Test: `tests/NovaTerminal.Tests/Ssh/RemoteDirectoryBrowserServiceTests.cs`
+- Test: `tests/NovaTerminal.Tests/Ssh/ActiveSshSessionRegistryTests.cs`
+
+**Step 1: Write the failing test**
+
+```csharp
+[Fact]
+public async Task ListDirectoryAsync_WhenActiveNativeSessionExists_ReturnsDirectoriesBeforeFiles()
+{
+    Guid profileId = Guid.NewGuid();
+    Guid sessionId = Guid.NewGuid();
+    var registry = new ActiveSshSessionRegistry();
+    registry.Register(new ActiveSshSessionDescriptor(sessionId, profileId, SshBackendKind.Native));
+
+    var interop = new RecordingNativeSshInterop(
+        new[]
+        {
+            new NativeRemotePathEntry("b.txt", "/srv/b.txt", false),
+            new NativeRemotePathEntry("alpha", "/srv/alpha", true)
+        });
+
+    var service = CreateService(registry, interop, CreateSshService(profileId));
+    RemoteSidebarListingResult result = await service.ListDirectoryAsync(profileId, sessionId, "/srv", CancellationToken.None);
+
+    Assert.True(result.IsSuccess);
+    Assert.Collection(
+        result.Entries,
+        entry => Assert.Equal("alpha", entry.Name),
+        entry => Assert.Equal("b.txt", entry.Name));
+}
+```
+
+Add tests for:
+
+- non-Native or missing session returns a failed/empty result without throwing
+- permission/listing errors become inline error payloads
+- blank remote path normalizes to `~`
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "FullyQualifiedName~RemoteDirectoryBrowserServiceTests" -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because the service does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Implement `RemoteDirectoryBrowserService` by reusing the same native connection preparation rules already used by `RemotePathAutocompleteService`:
+
+- require an active Native SSH session from `ActiveSshSessionRegistry`
+- load the profile from `SshConnectionService`
+- build `NativeSshConnectionOptions`
+- call `INativeSshInterop.ListRemoteDirectory(...)`
+- sort directories first, then files, alphabetically
+- return a result object with `Entries`, `ResolvedPath`, `IsSuccess`, and `ErrorMessage`
+
+If shared native-connection setup emerges naturally, extract a small helper instead of duplicating large blocks.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2, then also run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "FullyQualifiedName~ActiveSshSessionRegistryTests" -m:1 --nologo -v:minimal
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Services/Ssh/RemoteDirectoryBrowserService.cs src/NovaTerminal.App/Services/Ssh/ActiveSshSessionRegistry.cs src/NovaTerminal.App/Services/Ssh/RemotePathAutocompleteService.cs tests/NovaTerminal.Tests/Ssh/RemoteDirectoryBrowserServiceTests.cs tests/NovaTerminal.Tests/Ssh/ActiveSshSessionRegistryTests.cs
+git commit -m "feat: add native remote directory browser service"
+```
+
+### Task 3: Add a sidebar view model with navigation and state transitions
+
+**Files:**
+- Create: `src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarViewModel.cs`
+- Create: `src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarEntryViewModel.cs`
+- Test: `tests/NovaTerminal.Tests/Ssh/RemoteFilesSidebarViewModelTests.cs`
+
+**Step 1: Write the failing test**
+
+```csharp
+[Fact]
+public async Task OpenAsync_LoadsInitialPath_AndDisablesDownloadUntilSelectionExists()
+{
+    var service = new FakeRemoteDirectoryBrowserService("/srv", new[]
+    {
+        new RemoteSidebarEntry("logs", "/srv/logs", true)
+    });
+
+    var viewModel = new RemoteFilesSidebarViewModel(service);
+    await viewModel.OpenAsync(
+        profileId: Guid.NewGuid(),
+        sessionId: Guid.NewGuid(),
+        initialPath: "/srv",
+        CancellationToken.None);
+
+    Assert.True(viewModel.IsOpen);
+    Assert.Equal("/srv", viewModel.CurrentPath);
+    Assert.False(viewModel.CanDownloadSelected);
+}
+```
+
+Add tests for:
+
+- selecting an entry enables download
+- navigating into a directory pushes back-stack state
+- `NavigateUpAsync()` moves to parent
+- `SetJumpToCurrentDirectoryCandidate("/srv/api")` exposes the jump affordance without forcing navigation
+- listing failure sets inline error state and keeps the sidebar open
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "FullyQualifiedName~RemoteFilesSidebarViewModelTests" -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because the view model does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create a small stateful view model with:
+
+- `IsOpen`
+- `IsLoading`
+- `IsDisconnected`
+- `CurrentPath`
+- `JumpToCurrentDirectoryPath`
+- `ObservableCollection<RemoteFilesSidebarEntryViewModel> Entries`
+- `SelectedEntry`
+- `CanDownloadSelected`
+- `CanNavigateBack`
+- `ErrorMessage`
+
+Add async methods:
+
+- `OpenAsync(...)`
+- `Close()`
+- `RefreshAsync()`
+- `NavigateIntoSelectedDirectoryAsync()`
+- `NavigateUpAsync()`
+- `NavigateBackAsync()`
+- `JumpToCurrentDirectoryAsync()`
+- `MarkDisconnected()`
+
+Keep navigation logic inside the view model so `TerminalPane` only routes events.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarViewModel.cs src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarEntryViewModel.cs tests/NovaTerminal.Tests/Ssh/RemoteFilesSidebarViewModelTests.cs
+git commit -m "feat: add remote files sidebar state model"
+```
+
+### Task 4: Add the Avalonia sidebar control
+
+**Files:**
+- Create: `src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml`
+- Create: `src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml.cs`
+- Test: `tests/NovaTerminal.Tests/Core/RemoteFilesSidebarTests.cs`
+
+**Step 1: Write the failing test**
+
+```csharp
+[AvaloniaFact]
+public void DownloadButton_IsDisabled_WhenNothingIsSelected()
+{
+    var viewModel = new RemoteFilesSidebarViewModel(new FakeRemoteDirectoryBrowserService());
+    var control = new RemoteFilesSidebar
+    {
+        DataContext = viewModel
+    };
+
+    Button button = control.FindControl<Button>("BtnDownloadSelected")!;
+    Assert.False(button.IsEnabled);
+}
+```
+
+Add tests for:
+
+- inline error text visibility when `ErrorMessage` is set
+- jump-to-current-directory button visibility
+- selected row activation triggers directory navigation for directories
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "FullyQualifiedName~RemoteFilesSidebarTests" -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because the control does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create a narrow right-rail control with named elements:
+
+```xml
+<Button Name="BtnNavigateBack" />
+<Button Name="BtnNavigateUp" />
+<Button Name="BtnRefresh" />
+<Button Name="BtnCloseSidebar" />
+<Button Name="BtnJumpToCwd" />
+<ListBox Name="RemoteEntriesList" />
+<TextBlock Name="InlineErrorText" />
+<Button Name="BtnUploadFile" />
+<Button Name="BtnUploadFolder" />
+<Button Name="BtnDownloadSelected" />
+```
+
+Bind enablement and visibility to the sidebar view model. Keep visuals simple and keyboard-friendly.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml.cs tests/NovaTerminal.Tests/Core/RemoteFilesSidebarTests.cs
+git commit -m "feat: add remote files sidebar ui"
+```
+
+### Task 5: Host the sidebar in TerminalPane and wire pane lifecycle
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml`
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs`
+- Modify: `src/NovaTerminal.App/MainWindow.axaml.cs`
+- Test: `tests/NovaTerminal.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs`
+
+**Step 1: Write the failing test**
+
+```csharp
+[AvaloniaFact]
+public void Sidebar_HidesImmediately_WhenAltScreenBecomesActive()
+{
+    var pane = new TerminalPane();
+    pane.ShowRemoteFilesSidebarForTest();
+
+    pane.Buffer!.IsAltScreenActive = true;
+    pane.HandleAltScreenChangedForTest(true);
+
+    Assert.False(pane.IsRemoteFilesSidebarVisibleForTest());
+}
+```
+
+Add tests for:
+
+- sidebar entry point is disabled or hidden for non-Native SSH panes
+- opening the sidebar uses cwd first, then profile default
+- `WorkingDirectoryChanged` updates jump-to-current-directory affordance instead of forcing navigation
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "FullyQualifiedName~TerminalPaneRemoteFilesSidebarTests" -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because the sidebar host and test hooks do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+In `TerminalPane.axaml`, add a sidebar host beside the terminal layer rather than inside terminal content.
+
+In `TerminalPane.axaml.cs`:
+
+- create and bind a `RemoteFilesSidebarViewModel`
+- add a pane-local toggle action
+- hide the sidebar when alt-screen is active
+- close or disable it on disconnect
+- update jump-to-current-directory state from pane cwd changes
+
+In `MainWindow.axaml.cs`, keep transfer/job initiation in the window layer, but let pane-originated sidebar actions flow upward through explicit events.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Controls/TerminalPane.axaml src/NovaTerminal.App/Controls/TerminalPane.axaml.cs src/NovaTerminal.App/MainWindow.axaml.cs tests/NovaTerminal.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs
+git commit -m "feat: host remote files sidebar in terminal pane"
+```
+
+### Task 6: Route sidebar upload and download actions through the existing transfer system
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs`
+- Modify: `src/NovaTerminal.App/MainWindow.axaml.cs`
+- Modify: `src/NovaTerminal.App/Models/TransferDialogRequest.cs`
+- Modify: `src/NovaTerminal.App/Controls/TransferDialog.axaml.cs`
+- Test: `tests/NovaTerminal.Tests/Core/MainWindowTransferFlowTests.cs`
+- Test: `tests/NovaTerminal.Tests/Core/TransferDialogRequestTests.cs`
+
+**Step 1: Write the failing test**
+
+```csharp
+[Fact]
+public async Task SidebarDownload_UsesSelectedRemoteEntry_AsTransferRemotePath()
+{
+    var window = new TestMainWindow
+    {
+        NextTransferDialogResult = TransferDialogResult.CreateConfirmed(
+            localPath: @"D:\downloads\logs",
+            remotePath: "/srv/logs")
+    };
+
+    await window.StartSidebarDownloadForTest(
+        profile: CreateNativeProfile(),
+        sessionId: Guid.NewGuid(),
+        selectedRemotePath: "/srv/logs",
+        kind: TransferKind.Folder);
+
+    Assert.NotNull(window.QueuedJob);
+    Assert.Equal("/srv/logs", window.QueuedJob!.RemotePath);
+}
+```
+
+Add tests for:
+
+- sidebar upload targets the currently displayed directory
+- download remains disabled without selection
+- manual transfer dialog fallback still works for explicit typed-path flows
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "FullyQualifiedName~MainWindowTransferFlowTests|FullyQualifiedName~TransferDialogRequestTests" -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because sidebar-originated transfer requests do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add explicit pane-to-window events for:
+
+- upload file to current remote directory
+- upload folder to current remote directory
+- download selected remote entry
+
+Update `TransferDialogRequest` only if needed to distinguish:
+
+- manual transfer flow with editable remote path
+- sidebar flow with preselected remote path or remote directory target
+
+Keep `SftpService` job creation in `MainWindow.axaml.cs` so transfer ownership does not move into the pane.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Controls/TerminalPane.axaml.cs src/NovaTerminal.App/MainWindow.axaml.cs src/NovaTerminal.App/Models/TransferDialogRequest.cs src/NovaTerminal.App/Controls/TransferDialog.axaml.cs tests/NovaTerminal.Tests/Core/MainWindowTransferFlowTests.cs tests/NovaTerminal.Tests/Core/TransferDialogRequestTests.cs
+git commit -m "feat: route sidebar transfers through sftp service"
+```
+
+### Task 7: Document and harden the new sidebar flow
+
+**Files:**
+- Modify: `docs/USER_MANUAL.md`
+- Modify: `docs/plans/2026-04-30-native-sftp-sidebar-design.md`
+- Test: `tests/NovaTerminal.Tests/Ssh/RemoteDirectoryBrowserServiceTests.cs`
+- Test: `tests/NovaTerminal.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs`
+
+**Step 1: Write the failing test**
+
+Add one narrow regression test such as:
+
+```csharp
+[Fact]
+public async Task MarkDisconnected_KeepsSidebarOpenButDisablesTransferActions()
+{
+    var viewModel = new RemoteFilesSidebarViewModel(new FakeRemoteDirectoryBrowserService("/srv", []));
+    await viewModel.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), "/srv", CancellationToken.None);
+
+    viewModel.MarkDisconnected();
+
+    Assert.True(viewModel.IsOpen);
+    Assert.True(viewModel.IsDisconnected);
+    Assert.False(viewModel.CanDownloadSelected);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "FullyQualifiedName~RemoteFilesSidebarViewModelTests.MarkDisconnected|FullyQualifiedName~TerminalPaneRemoteFilesSidebarTests" -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL until disconnect hardening is complete.
+
+**Step 3: Write minimal implementation**
+
+- tighten disconnect and retry behavior
+- ensure alt-screen hide/show behavior remains deterministic
+- update `docs/USER_MANUAL.md` to describe the new Native SSH sidebar flow and the remaining manual dialog fallback
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2, then the broader sidebar-related test filters.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add docs/USER_MANUAL.md tests/NovaTerminal.Tests/Ssh/RemoteDirectoryBrowserServiceTests.cs tests/NovaTerminal.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarViewModel.cs
+git commit -m "docs: describe native sftp sidebar flow"
+```

--- a/docs/plans/2026-05-04-native-sftp-sidebar-v2-design.md
+++ b/docs/plans/2026-05-04-native-sftp-sidebar-v2-design.md
@@ -1,0 +1,121 @@
+# Native SFTP Sidebar V2 Design
+
+## Goal
+
+Refine the Native SSH remote-files UX so the sidebar is more compact and sidebar-initiated transfers no longer bounce through the generic transfer dialog.
+
+## Product Direction
+
+The sidebar should be the primary contextual transfer surface for Native SSH panes.
+
+The command palette should remain the manual or advanced path-based transfer surface.
+
+The pane right-click menu should stop exposing the old upload and download commands. Its only SFTP-related job should be opening `Remote Files`.
+
+This gives each surface one clear purpose:
+
+- pane context menu: open the remote files surface
+- remote files sidebar: everyday contextual transfers
+- command palette: manual typed-path transfer flow
+
+## UX Changes
+
+### 1. Compact the sidebar
+
+The current sidebar is heavier than necessary. It reads like a panel with several stacked control bands rather than a compact utility rail.
+
+V2 should tighten it to:
+
+- width around `272-288`
+- one compact toolbar row with `Back`, `Up`, path text, `Refresh`, `Close`
+- `Jump to Current Directory` shown only as a small conditional chip
+- denser listing rows
+- no always-visible full path under each row
+- a lighter footer with only primary transfer actions
+
+The visual goal is "small attached utility rail", not "mini file manager."
+
+### 2. Make sidebar transfers picker-only
+
+Sidebar actions should stop opening `TransferDialog`.
+
+The sidebar already provides the remote-side context, so only the local-side choice still needs UI.
+
+Sidebar upload flow:
+
+- `Upload File` -> local file picker -> upload into sidebar `CurrentPath`
+- `Upload Folder` -> local folder picker -> upload into sidebar `CurrentPath`
+
+Sidebar download flow:
+
+- selected remote file -> `SaveFilePicker` with filename prefilled
+- selected remote folder -> local folder picker
+
+After the picker returns a local target, `MainWindow` should enqueue the transfer directly through `SftpService`.
+
+### 3. Keep the transfer dialog for manual flows only
+
+The existing transfer dialog still has value for command-palette or explicit manual SFTP actions where the user wants to type or edit both sides.
+
+That means:
+
+- pane/sidebar contextual flow: no transfer dialog
+- command palette/manual flow: keep transfer dialog
+
+This keeps the advanced path available without forcing it into the common case.
+
+## Architecture
+
+The ownership split should stay the same:
+
+- `TerminalPane` owns the compact sidebar surface and raises explicit sidebar-originated transfer requests
+- `MainWindow` owns local picker invocation and transfer job creation
+- `SftpService` remains the execution boundary
+- `TransferDialog` remains in place only for manual command flows
+
+The main architectural change is removing sidebar dependence on `TransferDialogRequest.ForSidebarAction(...)` and replacing it with direct picker-based transfer helpers in `MainWindow`.
+
+## Command Surface
+
+For Native SSH panes:
+
+- remove `Upload File`, `Upload Folder`, `Download File`, `Download Folder` from the pane context menu
+- keep only `Remote Files` there
+
+For the command palette:
+
+- keep manual `SFTP: Upload File...`, `SFTP: Upload Folder...`, `SFTP: Download File...`, `SFTP: Download Folder...`
+
+This removes the current split-brain UX where the same pane exposes both the new contextual model and the old generic dialog model side by side.
+
+## Error Handling
+
+Sidebar transfer actions should stay quiet and direct:
+
+- if the user cancels a local picker, do nothing
+- if no remote selection exists for download, action remains disabled
+- if the SSH session is disconnected, sidebar actions remain disabled
+- transfer start failures still surface through the existing transfer error path
+
+The sidebar should not become a second transfer-progress surface.
+
+## Testing
+
+Update coverage to reflect the new split:
+
+- sidebar upload tests should assert local file or folder picker usage plus `CurrentPath` targeting
+- sidebar file download tests should assert `SaveFilePicker` usage with the remote filename
+- sidebar folder download tests should assert local folder picker usage
+- manual transfer tests should continue asserting `TransferDialog` usage
+- pane menu tests should assert that only `Remote Files` remains in the Native SSH context menu
+
+The existing disconnect and alt-screen behavior stays part of the sidebar regression surface.
+
+## Expected Outcome
+
+After this pass:
+
+- the sidebar feels lighter and more purposeful
+- contextual transfers no longer ask the user to confirm the already-known remote side
+- manual typed-path transfers still exist, but only where users expect them
+- the right-click menu becomes simpler and less duplicative

--- a/docs/plans/2026-05-04-native-sftp-sidebar-v2-implementation-plan.md
+++ b/docs/plans/2026-05-04-native-sftp-sidebar-v2-implementation-plan.md
@@ -1,0 +1,323 @@
+# Native SFTP Sidebar V2 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the Native SSH remote-files sidebar more compact, route sidebar transfers directly through local pickers plus `SftpService`, and remove the old pane-context transfer commands.
+
+**Architecture:** Keep `TerminalPane` as the pane-local sidebar host and event source, keep `MainWindow` as the owner of picker invocation and transfer job creation, and keep `TransferDialog` only for manual command-palette flows. The implementation should remove sidebar dependence on dialog-backed transfer requests without disturbing the existing manual SFTP path.
+
+**Tech Stack:** C#, .NET 10, Avalonia, `SftpService`, xUnit, Avalonia.Headless.XUnit
+
+---
+
+### Task 1: Compact the Remote Files sidebar layout
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml`
+- Modify: `src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml.cs`
+- Test: `tests/NovaTerminal.Tests/Core/RemoteFilesSidebarTests.cs`
+
+**Step 1: Write the failing test**
+
+Add a UI test that asserts the compact surface shape:
+
+```csharp
+[AvaloniaFact]
+public void Sidebar_UsesCompactWidth_AndHidesSecondaryPathText()
+{
+    var control = new RemoteFilesSidebar();
+
+    Assert.Equal(288, control.FindControl<Border>("SidebarChrome")!.Width);
+    Assert.Null(control.FindControl<TextBlock>("EntryPathText"));
+}
+```
+
+Add a second test that asserts the footer exposes `BtnUpload`, `BtnDownload`, and no longer exposes separate `BtnUploadFile` and `BtnUploadFolder` buttons if the implementation consolidates upload into a small menu.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "FullyQualifiedName~RemoteFilesSidebarTests" -c Release -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because the current control is still the wider multi-row layout.
+
+**Step 3: Write minimal implementation**
+
+- reduce the sidebar width to the approved compact target
+- collapse the header and navigation rows into one compact toolbar
+- remove always-visible per-entry full-path text
+- reduce footer actions to the approved compact set
+- keep keyboard navigation and current bindings intact
+
+If upload remains split into file/folder actions, make those controls visually compact and keep the test aligned with the final chosen control names.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml.cs tests/NovaTerminal.Tests/Core/RemoteFilesSidebarTests.cs
+git commit -m "feat: compact remote files sidebar layout"
+```
+
+### Task 2: Route sidebar uploads directly through local pickers
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs`
+- Modify: `src/NovaTerminal.App/MainWindow.axaml.cs`
+- Test: `tests/NovaTerminal.Tests/Core/MainWindowTransferFlowTests.cs`
+
+**Step 1: Write the failing test**
+
+Add tests similar to:
+
+```csharp
+[Fact]
+public async Task SidebarUploadFile_UsesLocalFilePicker_AndCurrentRemoteDirectory()
+{
+    var window = new TestMainWindow
+    {
+        NextPickedLocalFilePath = @"D:\temp\report.txt"
+    };
+
+    await window.StartSidebarUploadForTest(
+        profile: CreateNativeProfile(),
+        sessionId: Guid.NewGuid(),
+        remoteDirectory: "/srv/app",
+        kind: TransferKind.File);
+
+    Assert.Equal("/srv/app", window.QueuedJob!.RemotePath);
+    Assert.Equal(@"D:\temp\report.txt", window.QueuedJob.LocalPath);
+    Assert.True(window.FilePickerWasShown);
+    Assert.False(window.TransferDialogWasShown);
+}
+```
+
+Add a second test for folder upload using a local folder picker.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "FullyQualifiedName~MainWindowTransferFlowTests.SidebarUpload" -c Release -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because sidebar upload still routes through `TransferDialog`.
+
+**Step 3: Write minimal implementation**
+
+- keep `TerminalPane` sidebar-originated upload events explicit
+- in `MainWindow`, replace sidebar upload dialog usage with direct local file or folder picking helpers
+- if the picker returns no value, exit without queuing a job
+- enqueue the resulting upload job through the existing `SftpService` path
+
+Make the picker entry points `internal virtual` where needed so the tests can override them cleanly.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Controls/TerminalPane.axaml.cs src/NovaTerminal.App/MainWindow.axaml.cs tests/NovaTerminal.Tests/Core/MainWindowTransferFlowTests.cs
+git commit -m "feat: route sidebar uploads through local pickers"
+```
+
+### Task 3: Route sidebar downloads directly through save and folder pickers
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs`
+- Modify: `src/NovaTerminal.App/MainWindow.axaml.cs`
+- Test: `tests/NovaTerminal.Tests/Core/MainWindowTransferFlowTests.cs`
+
+**Step 1: Write the failing test**
+
+Add tests similar to:
+
+```csharp
+[Fact]
+public async Task SidebarDownloadFile_UsesSavePicker_WithRemoteFileName()
+{
+    var window = new TestMainWindow
+    {
+        NextSavedLocalFilePath = @"D:\downloads\logs.txt"
+    };
+
+    await window.StartSidebarDownloadForTest(
+        profile: CreateNativeProfile(),
+        sessionId: Guid.NewGuid(),
+        selectedRemotePath: "/srv/logs.txt",
+        kind: TransferKind.File);
+
+    Assert.Equal("/srv/logs.txt", window.QueuedJob!.RemotePath);
+    Assert.Equal(@"D:\downloads\logs.txt", window.QueuedJob.LocalPath);
+    Assert.Equal("logs.txt", window.LastSuggestedSaveFileName);
+    Assert.True(window.SavePickerWasShown);
+    Assert.False(window.TransferDialogWasShown);
+}
+```
+
+Add a second test for folder download using a local folder picker.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "FullyQualifiedName~MainWindowTransferFlowTests.SidebarDownload" -c Release -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because sidebar download still routes through `TransferDialog`.
+
+**Step 3: Write minimal implementation**
+
+- for file download, invoke `SaveFilePicker` with the selected remote filename as the suggested file name
+- for folder download, invoke a local folder picker
+- if the picker is canceled, do nothing
+- queue the download job directly without showing `TransferDialog`
+
+Keep the existing manual SFTP download flow unchanged.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Controls/TerminalPane.axaml.cs src/NovaTerminal.App/MainWindow.axaml.cs tests/NovaTerminal.Tests/Core/MainWindowTransferFlowTests.cs
+git commit -m "feat: route sidebar downloads through local pickers"
+```
+
+### Task 4: Remove pane-context SFTP transfer commands and keep manual dialog coverage
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml`
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs`
+- Modify: `src/NovaTerminal.App/Models/TransferDialogRequest.cs`
+- Modify: `src/NovaTerminal.App/Controls/TransferDialog.axaml.cs`
+- Test: `tests/NovaTerminal.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs`
+- Test: `tests/NovaTerminal.Tests/Core/TransferDialogRequestTests.cs`
+
+**Step 1: Write the failing test**
+
+Add tests such as:
+
+```csharp
+[AvaloniaFact]
+public void NativeSshPane_ContextMenu_KeepsOnlyRemoteFilesEntry()
+{
+    var pane = CreateNativePane();
+
+    IReadOnlyList<string> names = pane.GetSftpContextMenuItemNamesForTest();
+
+    Assert.Equal(new[] { "MenuToggleRemoteFilesSidebar" }, names);
+}
+```
+
+Add a second test that still verifies manual `TransferDialogRequest.ForAction(...)` keeps the current dialog defaults.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "FullyQualifiedName~TerminalPaneRemoteFilesSidebarTests|FullyQualifiedName~TransferDialogRequestTests" -c Release -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL because the pane context menu still includes the older transfer commands and sidebar-specific dialog request code still exists.
+
+**Step 3: Write minimal implementation**
+
+- remove the old pane-context upload/download items from the SFTP menu
+- keep `Remote Files` as the only pane-context SFTP-related entry
+- delete or simplify sidebar-only dialog request plumbing that is no longer used
+- keep manual dialog focus/default behavior intact for command-palette flows
+
+If `TransferDialogRequest.ForSidebarAction(...)` becomes dead code, remove it and update tests accordingly.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Controls/TerminalPane.axaml src/NovaTerminal.App/Controls/TerminalPane.axaml.cs src/NovaTerminal.App/Models/TransferDialogRequest.cs src/NovaTerminal.App/Controls/TransferDialog.axaml.cs tests/NovaTerminal.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs tests/NovaTerminal.Tests/Core/TransferDialogRequestTests.cs
+git commit -m "refactor: keep manual sftp dialog flow separate"
+```
+
+### Task 5: Refresh docs and run the sidebar transfer regression slice
+
+**Files:**
+- Modify: `docs/USER_MANUAL.md`
+- Modify: `docs/plans/2026-05-04-native-sftp-sidebar-v2-design.md`
+- Test: `tests/NovaTerminal.Tests/Core/MainWindowTransferFlowTests.cs`
+- Test: `tests/NovaTerminal.Tests/Core/RemoteFilesSidebarTests.cs`
+- Test: `tests/NovaTerminal.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs`
+
+**Step 1: Write the failing test**
+
+Add one narrow regression asserting the manual and sidebar flows remain distinct:
+
+```csharp
+[Fact]
+public async Task ManualTransferFlow_StillUsesTransferDialog_WhenSidebarFlowDoesNot()
+{
+    var window = new TestMainWindow
+    {
+        NextTransferDialogResult = TransferDialogResult.CreateConfirmed(
+            localPath: @"D:\downloads\logs",
+            remotePath: "/srv/logs")
+    };
+
+    await window.StartManualTransferForTest(CreateNativeProfile(), TransferDirection.Download, TransferKind.Folder);
+
+    Assert.True(window.TransferDialogWasShown);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "FullyQualifiedName~MainWindowTransferFlowTests|FullyQualifiedName~RemoteFilesSidebarTests|FullyQualifiedName~TerminalPaneRemoteFilesSidebarTests" -c Release -m:1 --nologo -v:minimal
+```
+
+Expected: FAIL until the docs and regression surface fully match the new picker-only sidebar flow.
+
+**Step 3: Write minimal implementation**
+
+- update `docs/USER_MANUAL.md` to describe the compact sidebar as the primary Native SSH transfer path
+- note that manual SFTP commands remain available in the command palette
+- refresh the design doc if implementation details changed slightly
+- make any final test-harness cleanup needed for the picker-based flow
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add docs/USER_MANUAL.md docs/plans/2026-05-04-native-sftp-sidebar-v2-design.md tests/NovaTerminal.Tests/Core/MainWindowTransferFlowTests.cs tests/NovaTerminal.Tests/Core/RemoteFilesSidebarTests.cs tests/NovaTerminal.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs
+git commit -m "docs: describe compact picker-first sftp sidebar"
+```

--- a/docs/plans/2026-05-04-native-sftp-sidebar-v3-design.md
+++ b/docs/plans/2026-05-04-native-sftp-sidebar-v3-design.md
@@ -51,7 +51,7 @@ This pass does not add:
 
 Use a compact right rail with a dense two-column list:
 
-- primary column: name with file or folder icon
+- primary column: name-first entry label with stronger directory emphasis
 - secondary column: modified time only
 
 This keeps the rail compact enough for terminal use while adding the single most useful secondary signal for SSH workflows such as log inspection, config browsing, and runtime validation.
@@ -106,7 +106,7 @@ The pane context menu should not reintroduce generic upload/download actions bes
 
 The current entry contract is too small for the desired list presentation. The sidebar list should expand from name/path/directory metadata to include modified-time metadata.
 
-Recommended model shape:
+Implemented model shape:
 
 - `Name`
 - `FullPath`
@@ -119,7 +119,7 @@ Optional later follow-up:
 
 Recommendation:
 
-Store raw metadata in the app-layer model and format it in the view or view model. Do not bake display strings into the service contract unless backend constraints make that unavoidable.
+Store raw metadata in the app-layer model and format it in the view model. Do not bake display strings into the service contract unless backend constraints make that unavoidable.
 
 If modified metadata is unavailable for an entry, the sidebar should still render the listing and show a simple placeholder such as `-`.
 
@@ -182,6 +182,7 @@ After this pass:
 - the sidebar looks materially closer to a polished NovaTerminal surface
 - the rail remains compact and pane-local
 - remote context is clearer
+- recently modified entries are visible without opening a second details surface
 - users can quickly see what changed recently in the current directory
 - the UX remains aligned with NovaTerminal's terminal-first philosophy
 - the product does not drift into an embedded SFTP client or file manager

--- a/docs/plans/2026-05-04-native-sftp-sidebar-v3-design.md
+++ b/docs/plans/2026-05-04-native-sftp-sidebar-v3-design.md
@@ -1,0 +1,187 @@
+# Native SFTP Sidebar V3 Design
+
+## Goal
+
+Polish NovaTerminal's Native SSH remote-files sidebar into a denser, more legible pane-local utility rail while preserving its terminal-first scope.
+
+## Product Direction
+
+The sidebar should stay a remote transfer helper attached to a terminal pane, not evolve into an embedded file manager.
+
+The design target is a narrowed version of the provided mockup:
+
+- keep the compact right rail
+- keep strong host identity and current path context
+- keep a denser remote listing
+- keep contextual upload and download actions
+- do not add a second transfer-progress surface
+- do not add file mutation workflows
+- do not add multi-select or file-manager behaviors
+
+## Scope
+
+This pass adds:
+
+1. a refined compact sidebar presentation
+2. a dense two-column remote listing
+3. a secondary `Modified` column
+4. stronger visual identity for the active remote host
+
+This pass does not add:
+
+- VT parsing or rendering changes
+- transfer UI inside terminal grid content
+- an embedded transfer queue
+- drag-and-drop upload surfaces
+- recursive tree browsing
+- remote search across directories
+- multi-select
+- rename, edit, delete, chmod, or preview actions
+
+## Constraints
+
+- Use Avalonia for all new UI.
+- Keep SFTP UX separate from terminal core logic.
+- Keep `SftpService` as the transfer execution and progress boundary.
+- Keep the sidebar pane-local inside `TerminalPane`.
+- Auto-hide the sidebar in alternate-screen/fullscreen TUI mode.
+- Prefer additive changes over broad refactors.
+
+## Chosen Direction
+
+Use a compact right rail with a dense two-column list:
+
+- primary column: name with file or folder icon
+- secondary column: modified time only
+
+This keeps the rail compact enough for terminal use while adding the single most useful secondary signal for SSH workflows such as log inspection, config browsing, and runtime validation.
+
+`Modified` is a better first secondary column than `Size` because it supports the more terminal-native question of "what changed recently?" without pulling the UI toward a download manager. `Size` can remain a follow-up if later product work shows a strong need.
+
+## Sidebar Shape
+
+### Layout
+
+- Header row:
+  - host label
+  - connection subtitle
+  - compact utility actions
+  - close action
+- Path row:
+  - current remote path with truncation
+  - refresh
+  - item count
+- Body:
+  - dense two-column listing
+  - `Name`
+  - `Modified`
+- Footer:
+  - `Upload File`
+  - `Upload Folder`
+  - `Download Selected`
+
+### Visual Intent
+
+The target feel is "small attached utility rail", not "mini file manager."
+
+That means:
+
+- tighter row height
+- clearer host context
+- stronger column rhythm
+- minimal chrome
+- no bottom transfer dashboard
+
+## Command Surface
+
+The command split should remain:
+
+- pane context menu: open `Remote Files`
+- sidebar: contextual transfers grounded in visible remote context
+- command palette: manual typed-path transfer flow
+
+The pane context menu should not reintroduce generic upload/download actions beside the sidebar entry.
+
+## Directory Listing Model
+
+The current entry contract is too small for the desired list presentation. The sidebar list should expand from name/path/directory metadata to include modified-time metadata.
+
+Recommended model shape:
+
+- `Name`
+- `FullPath`
+- `IsDirectory`
+- `ModifiedAtUtc` or equivalent raw timestamp when available
+
+Optional later follow-up:
+
+- `SizeBytes` for non-directory entries
+
+Recommendation:
+
+Store raw metadata in the app-layer model and format it in the view or view model. Do not bake display strings into the service contract unless backend constraints make that unavoidable.
+
+If modified metadata is unavailable for an entry, the sidebar should still render the listing and show a simple placeholder such as `-`.
+
+## Behavior
+
+Behavior stays intentionally narrow:
+
+- one directory listing at a time
+- single selection only
+- directory-first sorting, then alphabetical
+- `Enter` navigates into a selected directory
+- `Download Selected` operates on the current selected entry
+- uploads still target the currently displayed directory
+- downloads still use the picker-first flow already established in V2
+
+No embedded transfer queue should appear in the sidebar. Long-running transfer state remains in the existing Transfer Center and status surfaces.
+
+## Inline Upload Surface
+
+Do not add a drag-and-drop upload panel in this pass.
+
+Keep upload initiation compact:
+
+- `Upload File`
+- `Upload Folder`
+
+That keeps the rail small, reduces visual weight, and avoids pulling the design toward a browser-like transfer workspace.
+
+## Architecture
+
+The ownership split remains:
+
+- `TerminalPane`
+  - owns sidebar hosting, visibility, and alt-screen hiding
+- remote directory browser service
+  - fetches one directory listing at a time
+  - expands to include modified metadata
+- sidebar view model
+  - owns navigation, loading, selection, and list presentation state
+- `MainWindow`
+  - owns local picker invocation and transfer job creation
+- `SftpService`
+  - remains the execution and progress boundary
+
+This should be treated as a sidebar polish pass, not as a remote-files feature expansion.
+
+## Testing
+
+Update coverage in four areas:
+
+- remote directory browser tests for modified metadata mapping
+- sidebar view model tests for metadata handling and placeholder behavior
+- headless Avalonia sidebar tests for the dense two-column layout
+- existing transfer-flow and alt-screen/disconnect regression tests to confirm no behavioral regressions
+
+## Expected Outcome
+
+After this pass:
+
+- the sidebar looks materially closer to a polished NovaTerminal surface
+- the rail remains compact and pane-local
+- remote context is clearer
+- users can quickly see what changed recently in the current directory
+- the UX remains aligned with NovaTerminal's terminal-first philosophy
+- the product does not drift into an embedded SFTP client or file manager

--- a/docs/plans/2026-05-04-native-sftp-sidebar-v3-implementation-plan.md
+++ b/docs/plans/2026-05-04-native-sftp-sidebar-v3-implementation-plan.md
@@ -1,0 +1,294 @@
+# Native SFTP Sidebar V3 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Refine the Native SSH remote-files sidebar into a denser two-column utility rail with host identity and modified-time metadata while preserving NovaTerminal's terminal-first SFTP boundaries.
+
+**Architecture:** Keep `TerminalPane` as the pane-local host, keep the remote directory browser service as a one-directory-at-a-time listing boundary, expand the remote entry contract to carry modified metadata, and keep `MainWindow` plus `SftpService` responsible for picker invocation and transfer execution. This is a visual and metadata polish pass, not a remote file-manager expansion.
+
+**Tech Stack:** C#, .NET 10, Avalonia, xUnit, Avalonia.Headless.XUnit, existing Native SSH remote directory browser service and sidebar view model.
+
+---
+
+### Task 1: Extend remote sidebar entry metadata
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Models/RemoteSidebarEntry.cs`
+- Modify: `src/NovaTerminal.App/Models/RemoteSidebarListingResult.cs`
+- Modify: `src/NovaTerminal.App/Services/Ssh/RemoteDirectoryBrowserService.cs`
+- Test: `tests/NovaTerminal.Tests/Ssh/RemoteDirectoryBrowserServiceTests.cs`
+
+**Step 1: Write the failing test**
+
+Add a test that verifies a remote listing entry can carry modified-time metadata through the directory browser service result.
+
+Example shape:
+
+```csharp
+[Fact]
+public async Task ListDirectoryAsync_PreservesModifiedTimeMetadata()
+{
+    RemoteSidebarListingResult result = await service.ListDirectoryAsync(profileId, sessionId, "/srv", CancellationToken.None);
+
+    RemoteSidebarEntry entry = Assert.Single(result.Entries);
+    Assert.Equal(new DateTime(2026, 5, 4, 20, 15, 0, DateTimeKind.Utc), entry.ModifiedAtUtc);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+dotnet test tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj --filter "FullyQualifiedName~RemoteDirectoryBrowserServiceTests" /p:UseAppHost=false /p:OutDir=D:\projects\nova2\.artifacts\sidebar-v3-build\
+```
+
+Expected: FAIL because `RemoteSidebarEntry` does not expose modified metadata yet.
+
+**Step 3: Write minimal implementation**
+
+- add nullable modified metadata to `RemoteSidebarEntry`
+- keep constructors explicit and small
+- map modified timestamps from the remote listing response in `RemoteDirectoryBrowserService`
+- preserve existing success/failure behavior in `RemoteSidebarListingResult`
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Models/RemoteSidebarEntry.cs src/NovaTerminal.App/Models/RemoteSidebarListingResult.cs src/NovaTerminal.App/Services/Ssh/RemoteDirectoryBrowserService.cs tests/NovaTerminal.Tests/Ssh/RemoteDirectoryBrowserServiceTests.cs
+git commit -m "feat: add remote sidebar modified metadata"
+```
+
+### Task 2: Surface modified metadata in the sidebar view model
+
+**Files:**
+- Modify: `src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarEntryViewModel.cs`
+- Modify: `src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarViewModel.cs`
+- Test: `tests/NovaTerminal.Tests/Ssh/RemoteFilesSidebarViewModelTests.cs`
+
+**Step 1: Write the failing test**
+
+Add tests that verify:
+
+- modified metadata is surfaced on each sidebar entry view model
+- missing metadata falls back to a placeholder-safe display value
+
+Example shape:
+
+```csharp
+[Fact]
+public async Task OpenAsync_MapsModifiedMetadataToEntryViewModels()
+{
+    await viewModel.OpenAsync(profileId, sessionId, "/srv", CancellationToken.None);
+
+    RemoteFilesSidebarEntryViewModel entry = Assert.Single(viewModel.Entries);
+    Assert.Equal("May 04", entry.ModifiedDisplayText);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+dotnet test tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj --filter "FullyQualifiedName~RemoteFilesSidebarViewModelTests" /p:UseAppHost=false /p:OutDir=D:\projects\nova2\.artifacts\sidebar-v3-build\
+```
+
+Expected: FAIL because the entry view model does not expose modified display data yet.
+
+**Step 3: Write minimal implementation**
+
+- add a display-ready modified property to `RemoteFilesSidebarEntryViewModel`
+- keep formatting compact and deterministic for tests
+- do not change navigation, selection, or download enablement behavior
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarEntryViewModel.cs src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarViewModel.cs tests/NovaTerminal.Tests/Ssh/RemoteFilesSidebarViewModelTests.cs
+git commit -m "feat: expose modified metadata in sidebar entries"
+```
+
+### Task 3: Redesign the sidebar header and path chrome
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml`
+- Modify: `src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml.cs`
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs`
+- Test: `tests/NovaTerminal.Tests/Core/RemoteFilesSidebarTests.cs`
+
+**Step 1: Write the failing test**
+
+Add a headless Avalonia test that asserts the new compact header structure exists.
+
+Example shape:
+
+```csharp
+[AvaloniaFact]
+public void Sidebar_UsesHostHeader_AndCompactPathRow()
+{
+    var control = new RemoteFilesSidebar();
+
+    Assert.NotNull(control.FindControl<TextBlock>("HostTitleText"));
+    Assert.NotNull(control.FindControl<TextBlock>("HostSubtitleText"));
+    Assert.NotNull(control.FindControl<TextBlock>("CurrentPathText"));
+    Assert.NotNull(control.FindControl<TextBlock>("ItemCountText"));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+dotnet test tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj --filter "FullyQualifiedName~RemoteFilesSidebarTests" /p:UseAppHost=false /p:OutDir=D:\projects\nova2\.artifacts\sidebar-v3-build\
+```
+
+Expected: FAIL because the current XAML does not expose the new host-first header shape.
+
+**Step 3: Write minimal implementation**
+
+- reshape the header into host identity plus compact utility actions
+- keep width within the current compact rail target
+- add a path row with truncation and item count
+- do not introduce transfer-progress UI in the sidebar
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml.cs src/NovaTerminal.App/Controls/TerminalPane.axaml.cs tests/NovaTerminal.Tests/Core/RemoteFilesSidebarTests.cs
+git commit -m "feat: restyle remote files sidebar header"
+```
+
+### Task 4: Convert the listing to a dense two-column layout
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml`
+- Test: `tests/NovaTerminal.Tests/Core/RemoteFilesSidebarTests.cs`
+
+**Step 1: Write the failing test**
+
+Add a UI test that asserts:
+
+- the list row contains a primary name column
+- the row contains a secondary modified column
+- full-path subtext is not rendered
+
+Example shape:
+
+```csharp
+[AvaloniaFact]
+public void Sidebar_UsesTwoColumnDenseEntryTemplate()
+{
+    var control = new RemoteFilesSidebar();
+
+    Assert.NotNull(control.FindControl<Grid>("EntryRowGrid"));
+    Assert.Null(control.FindControl<TextBlock>("EntryPathText"));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run the same command as Task 3 Step 2.
+
+Expected: FAIL because the current template is a simple single-text row.
+
+**Step 3: Write minimal implementation**
+
+- replace the current list item template with a dense two-column layout
+- keep directory/file icons simple
+- show modified placeholder text when metadata is missing
+- preserve keyboard and double-click navigation
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml tests/NovaTerminal.Tests/Core/RemoteFilesSidebarTests.cs
+git commit -m "feat: add dense two-column remote sidebar list"
+```
+
+### Task 5: Preserve behavior boundaries and refresh docs
+
+**Files:**
+- Modify: `docs/USER_MANUAL.md`
+- Modify: `docs/plans/2026-05-04-native-sftp-sidebar-v3-design.md`
+- Test: `tests/NovaTerminal.Tests/Core/MainWindowTransferFlowTests.cs`
+- Test: `tests/NovaTerminal.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs`
+
+**Step 1: Write the failing test**
+
+Add one regression test that confirms the new visual polish does not change the existing picker-first transfer split.
+
+Example shape:
+
+```csharp
+[AvaloniaFact]
+public async Task SidebarPolish_DoesNotReintroduceTransferDialogForSidebarDownloads()
+{
+    var window = new TestMainWindow
+    {
+        NextSavedLocalFilePath = @"D:\downloads\access.log"
+    };
+
+    await window.StartSidebarDownloadForTest(CreateNativeProfile(), Guid.NewGuid(), "/srv/access.log", TransferKind.File);
+
+    Assert.False(window.TransferDialogWasShown);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+dotnet test tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj --filter "FullyQualifiedName~MainWindowTransferFlowTests|FullyQualifiedName~TerminalPaneRemoteFilesSidebarTests" /p:UseAppHost=false /p:OutDir=D:\projects\nova2\.artifacts\sidebar-v3-build\
+```
+
+Expected: FAIL if any polish work accidentally reintroduces the old flow.
+
+**Step 3: Write minimal implementation**
+
+- update `docs/USER_MANUAL.md` to describe the refined host-first, modified-aware sidebar
+- refresh the design doc if implementation details shifted
+- keep the current picker-first transfer flow and pane-local boundaries intact
+
+**Step 4: Run test to verify it passes**
+
+Run the same command as Step 2, then run the broader sidebar slice:
+
+```powershell
+dotnet test tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj --filter "FullyQualifiedName~MainWindowTransferFlowTests|FullyQualifiedName~RemoteFilesSidebarTests|FullyQualifiedName~TerminalPaneRemoteFilesSidebarTests|FullyQualifiedName~RemoteFilesSidebarViewModelTests|FullyQualifiedName~RemoteDirectoryBrowserServiceTests" /p:UseAppHost=false /p:OutDir=D:\projects\nova2\.artifacts\sidebar-v3-build\
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add docs/USER_MANUAL.md docs/plans/2026-05-04-native-sftp-sidebar-v3-design.md tests/NovaTerminal.Tests/Core/MainWindowTransferFlowTests.cs tests/NovaTerminal.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs
+git commit -m "docs: describe refined native sftp sidebar"
+```

--- a/src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml
+++ b/src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml
@@ -30,7 +30,7 @@
             <Grid Grid.Row="1"
                   ColumnDefinitions="Auto,Auto,Auto,*"
                   ColumnSpacing="6"
-                  IsEnabled="{Binding !IsLoading}">
+                  IsEnabled="{Binding CanInteractWithRemote}">
                 <Button Name="BtnNavigateBack"
                         Content="Back"
                         Padding="10,4"
@@ -55,7 +55,7 @@
                     HorizontalAlignment="Left"
                     Content="Jump to Current Directory"
                     Padding="10,4"
-                    IsEnabled="{Binding !IsLoading}"
+                    IsEnabled="{Binding CanInteractWithRemote}"
                     IsVisible="{Binding JumpToCurrentDirectoryPath, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                     Click="JumpToCwd_Click"/>
 
@@ -64,7 +64,7 @@
                      Background="#16181C"
                      BorderBrush="#2A2F35"
                      BorderThickness="1"
-                     IsEnabled="{Binding !IsLoading}"
+                     IsEnabled="{Binding CanInteractWithRemote}"
                      ItemsSource="{Binding Entries}"
                      SelectedItem="{Binding SelectedEntry, Mode=TwoWay}"
                      DoubleTapped="RemoteEntriesList_DoubleTapped"
@@ -96,12 +96,12 @@
                     <Button Name="BtnUploadFile"
                             Content="Upload File"
                             Padding="10,4"
-                            IsEnabled="{Binding IsOpen}"/>
+                            IsEnabled="{Binding CanInteractWithRemote}"/>
                     <Button Name="BtnUploadFolder"
                             Grid.Column="1"
                             Content="Upload Folder"
                             Padding="10,4"
-                            IsEnabled="{Binding IsOpen}"/>
+                            IsEnabled="{Binding CanInteractWithRemote}"/>
                     <Button Name="BtnDownloadSelected"
                             Grid.Column="2"
                             HorizontalAlignment="Stretch"

--- a/src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml
+++ b/src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml
@@ -27,7 +27,10 @@
                         Click="CloseSidebar_Click"/>
             </Grid>
 
-            <Grid Grid.Row="1" ColumnDefinitions="Auto,Auto,Auto,*" ColumnSpacing="6">
+            <Grid Grid.Row="1"
+                  ColumnDefinitions="Auto,Auto,Auto,*"
+                  ColumnSpacing="6"
+                  IsEnabled="{Binding !IsLoading}">
                 <Button Name="BtnNavigateBack"
                         Content="Back"
                         Padding="10,4"
@@ -52,6 +55,7 @@
                     HorizontalAlignment="Left"
                     Content="Jump to Current Directory"
                     Padding="10,4"
+                    IsEnabled="{Binding !IsLoading}"
                     IsVisible="{Binding JumpToCurrentDirectoryPath, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                     Click="JumpToCwd_Click"/>
 
@@ -60,6 +64,7 @@
                      Background="#16181C"
                      BorderBrush="#2A2F35"
                      BorderThickness="1"
+                     IsEnabled="{Binding !IsLoading}"
                      ItemsSource="{Binding Entries}"
                      SelectedItem="{Binding SelectedEntry, Mode=TwoWay}"
                      DoubleTapped="RemoteEntriesList_DoubleTapped"

--- a/src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml
+++ b/src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml
@@ -10,7 +10,7 @@
             BorderBrush="#31353A"
             BorderThickness="1,0,0,0"
             Padding="10">
-        <Grid RowDefinitions="Auto,Auto,Auto,*,Auto" RowSpacing="8">
+        <Grid RowDefinitions="Auto,Auto,Auto,*,Auto" RowSpacing="2">
             <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="6">
                 <StackPanel Spacing="1">
                     <TextBlock Name="HostTitleText"
@@ -29,14 +29,14 @@
                 <Button Name="BtnRefresh"
                         Grid.Column="1"
                         Content="Refresh"
-                        Padding="8,3"
+                        Padding="6,2"
                         IsEnabled="{Binding CanInteractWithRemote}"
                         Click="Refresh_Click"/>
 
                 <Button Name="BtnCloseSidebar"
                         Grid.Column="2"
                         Content="Close"
-                        Padding="8,3"
+                        Padding="6,2"
                         Click="CloseSidebar_Click"/>
             </Grid>
 
@@ -45,7 +45,7 @@
                     BorderBrush="#2A2F35"
                     BorderThickness="1"
                     CornerRadius="6"
-                    Padding="8,6">
+                    Padding="3,2">
                 <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
                     <TextBlock Name="CurrentPathText"
                                VerticalAlignment="Center"
@@ -59,7 +59,7 @@
                                VerticalAlignment="Center"
                                Text="{Binding ItemCountLabel, RelativeSource={RelativeSource AncestorType=controls:RemoteFilesSidebar}}"
                                Foreground="#7F8895"
-                               FontSize="10"/>
+                               FontSize="11"/>
                 </Grid>
             </Border>
 
@@ -68,20 +68,38 @@
                   ColumnSpacing="6"
                   IsEnabled="{Binding CanInteractWithRemote}">
                 <Button Name="BtnNavigateBack"
-                        Content="Back"
-                        Padding="8,3"
+                        Padding="3,2"
                         IsEnabled="{Binding CanNavigateBack}"
-                        Click="NavigateBack_Click"/>
+                        Click="NavigateBack_Click">
+                    <StackPanel Orientation="Horizontal" Spacing="4">
+                        <PathIcon Name="NavigateBackIcon"
+                                  Width="12"
+                                  Height="12"
+                                  VerticalAlignment="Center"
+                                  Data="M20,11V13H7.83L13.42,18.59L12,20L4,12L12,4L13.41,5.41L7.83,11H20Z"/>
+                        <TextBlock VerticalAlignment="Center"
+                                   Text="Back"/>
+                    </StackPanel>
+                </Button>
                 <Button Name="BtnNavigateUp"
                         Grid.Column="1"
-                        Content="Up"
-                        Padding="8,3"
-                        Click="NavigateUp_Click"/>
+                        Padding="3,2"
+                        Click="NavigateUp_Click">
+                    <StackPanel Orientation="Horizontal" Spacing="4">
+                        <PathIcon Name="NavigateUpIcon"
+                                  Width="12"
+                                  Height="12"
+                                  VerticalAlignment="Center"
+                                  Data="M12,8L6,14H10V20H14V14H18L12,8Z"/>
+                        <TextBlock VerticalAlignment="Center"
+                                   Text="Up"/>
+                    </StackPanel>
+                </Button>
                 <Button Name="BtnJumpToCwd"
                         Grid.Column="2"
                         HorizontalAlignment="Right"
                         Content="Jump to cwd"
-                        Padding="8,3"
+                        Padding="3,2"
                         IsEnabled="{Binding CanInteractWithRemote}"
                         IsVisible="{Binding JumpToCurrentDirectoryPath, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                         Click="JumpToCwd_Click"/>
@@ -97,13 +115,55 @@
                      SelectedItem="{Binding SelectedEntry, Mode=TwoWay}"
                      DoubleTapped="RemoteEntriesList_DoubleTapped"
                      KeyDown="RemoteEntriesList_KeyDown">
+                <ListBox.ItemContainerTheme>
+                    <ControlTheme TargetType="ListBoxItem">
+                        <Setter Property="Padding" Value="2,2,2,2"/>
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                        <Setter Property="Background" Value="Transparent"/>
+                        <Setter Property="BorderBrush" Value="Transparent"/>
+                        <Setter Property="BorderThickness" Value="1"/>
+                        <Setter Property="CornerRadius" Value="4"/>
+
+                        <Style Selector="^:pointerover">
+                            <Setter Property="Background" Value="#202B35"/>
+                            <Setter Property="BorderBrush" Value="#314352"/>
+                        </Style>
+
+                        <Style Selector="^:selected">
+                            <Setter Property="Background" Value="#25384B"/>
+                            <Setter Property="BorderBrush" Value="#4E6A86"/>
+                        </Style>
+                    </ControlTheme>
+                </ListBox.ItemContainerTheme>
                 <ListBox.ItemTemplate>
                     <DataTemplate x:DataType="vm:RemoteFilesSidebarEntryViewModel">
-                        <Border BorderBrush="#252A30"
-                                BorderThickness="0,0,0,1"
-                                Padding="8,5">
-                            <TextBlock Text="{Binding Name}"
-                                       TextTrimming="CharacterEllipsis"/>
+                        <Border Name="EntryRowBorder"
+                                BorderBrush="#252A30"
+                                BorderThickness="0,0,0,1">
+                            <Grid Name="EntryRowGrid"
+                                  ColumnDefinitions="Auto,*,Auto"
+                                  ColumnSpacing="6">
+                                <PathIcon Name="EntryTypeIcon"
+                                          Width="11"
+                                          Height="11"
+                                          VerticalAlignment="Center"
+                                          Data="{Binding EntryIconData}"
+                                          Foreground="#8FA0B5"/>
+                                <TextBlock Name="EntryNameText"
+                                           Grid.Column="1"
+                                           VerticalAlignment="Center"
+                                           Text="{Binding Name}"
+                                           Foreground="#E7EDF5"
+                                           FontSize="14"
+                                           TextTrimming="CharacterEllipsis"/>
+                                <TextBlock Name="EntryModifiedText"
+                                           Grid.Column="2"
+                                           VerticalAlignment="Center"
+                                           Text="{Binding ModifiedDisplayText}"
+                                           Foreground="#8490A0"
+                                           FontSize="12"
+                                           HorizontalAlignment="Right"/>
+                            </Grid>
                         </Border>
                     </DataTemplate>
                 </ListBox.ItemTemplate>
@@ -119,20 +179,50 @@
 
                 <Grid ColumnDefinitions="Auto,Auto,*" ColumnSpacing="6">
                     <Button Name="BtnUploadFile"
-                            Content="File"
-                            Padding="8,3"
-                            IsEnabled="{Binding CanInteractWithRemote}"/>
+                            Padding="6,2"
+                            IsEnabled="{Binding CanInteractWithRemote}">
+                        <StackPanel Orientation="Horizontal" Spacing="4">
+                            <PathIcon Name="UploadFileIcon"
+                                      Width="12"
+                                      Height="12"
+                                      VerticalAlignment="Center"
+                                      Data="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M12,18V12.83L9.41,15.41L8,14L13,9L18,14L16.59,15.41L14,12.83V18H12M14,9V3.5L19.5,9H14Z"/>
+                            <TextBlock Name="UploadFileLabel"
+                                       VerticalAlignment="Center"
+                                       Text="File"/>
+                        </StackPanel>
+                    </Button>
                     <Button Name="BtnUploadFolder"
                             Grid.Column="1"
-                            Content="Folder"
-                            Padding="8,3"
-                            IsEnabled="{Binding CanInteractWithRemote}"/>
+                            Padding="6,2"
+                            IsEnabled="{Binding CanInteractWithRemote}">
+                        <StackPanel Orientation="Horizontal" Spacing="4">
+                            <PathIcon Name="UploadFolderIcon"
+                                      Width="12"
+                                      Height="12"
+                                      VerticalAlignment="Center"
+                                      Data="M12,19V13.83L9.41,16.41L8,15L13,10L18,15L16.59,16.41L14,13.83V19H12M10,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V8A2,2 0 0,0 20,6H12L10,4Z"/>
+                            <TextBlock Name="UploadFolderLabel"
+                                       VerticalAlignment="Center"
+                                       Text="Folder"/>
+                        </StackPanel>
+                    </Button>
                     <Button Name="BtnDownloadSelected"
                             Grid.Column="2"
                             HorizontalAlignment="Stretch"
-                            Content="Download"
-                            Padding="8,3"
-                            IsEnabled="{Binding CanDownloadSelected}"/>
+                            Padding="6,2"
+                            IsEnabled="{Binding CanDownloadSelected}">
+                        <StackPanel Orientation="Horizontal" Spacing="4">
+                            <PathIcon Name="DownloadSelectedIcon"
+                                      Width="12"
+                                      Height="12"
+                                      VerticalAlignment="Center"
+                                      Data="M5,20H19V18H5M19,9H15V3H9V9H5L12,16L19,9Z"/>
+                            <TextBlock Name="DownloadSelectedLabel"
+                                       VerticalAlignment="Center"
+                                       Text="Download"/>
+                        </StackPanel>
+                    </Button>
                 </Grid>
             </StackPanel>
         </Grid>

--- a/src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml
+++ b/src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml
@@ -3,64 +3,56 @@
              xmlns:vm="clr-namespace:NovaTerminal.ViewModels.Ssh"
              x:Class="NovaTerminal.Controls.RemoteFilesSidebar"
              x:DataType="vm:RemoteFilesSidebarViewModel">
-    <Border Width="320"
+    <Border Name="SidebarChrome"
+            Width="288"
             Background="#1B1D21"
             BorderBrush="#31353A"
             BorderThickness="1,0,0,0"
-            Padding="12">
-        <Grid RowDefinitions="Auto,Auto,Auto,*,Auto" RowSpacing="10">
-            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
-                <StackPanel Spacing="2">
-                    <TextBlock Text="Remote Files"
-                               FontSize="14"
-                               FontWeight="SemiBold"/>
-                    <TextBlock Text="{Binding CurrentPath}"
-                               Foreground="#9AA4B2"
-                               FontSize="11"
-                               TextTrimming="CharacterEllipsis"/>
-                </StackPanel>
-
-                <Button Name="BtnCloseSidebar"
-                        Grid.Column="1"
-                        Content="Close"
-                        Padding="10,4"
-                        Click="CloseSidebar_Click"/>
-            </Grid>
-
-            <Grid Grid.Row="1"
-                  ColumnDefinitions="Auto,Auto,Auto,*"
-                  ColumnSpacing="6"
-                  IsEnabled="{Binding CanInteractWithRemote}">
+            Padding="10">
+        <Grid RowDefinitions="Auto,Auto,*,Auto" RowSpacing="8">
+            <Grid ColumnDefinitions="Auto,Auto,*,Auto,Auto" ColumnSpacing="6">
                 <Button Name="BtnNavigateBack"
                         Content="Back"
-                        Padding="10,4"
+                        Padding="8,3"
                         IsEnabled="{Binding CanNavigateBack}"
                         Click="NavigateBack_Click"/>
                 <Button Name="BtnNavigateUp"
                         Grid.Column="1"
                         Content="Up"
-                        Padding="10,4"
-                        IsEnabled="{Binding IsOpen}"
+                        Padding="8,3"
+                        IsEnabled="{Binding CanInteractWithRemote}"
                         Click="NavigateUp_Click"/>
+                <TextBlock Grid.Column="2"
+                           VerticalAlignment="Center"
+                           Text="{Binding CurrentPath}"
+                           Foreground="#C5CDD8"
+                           FontSize="11"
+                           FontWeight="SemiBold"
+                           TextTrimming="CharacterEllipsis"/>
                 <Button Name="BtnRefresh"
-                        Grid.Column="2"
+                        Grid.Column="3"
                         Content="Refresh"
-                        Padding="10,4"
-                        IsEnabled="{Binding IsOpen}"
+                        Padding="8,3"
+                        IsEnabled="{Binding CanInteractWithRemote}"
                         Click="Refresh_Click"/>
+                <Button Name="BtnCloseSidebar"
+                        Grid.Column="4"
+                        Content="Close"
+                        Padding="8,3"
+                        Click="CloseSidebar_Click"/>
             </Grid>
 
             <Button Name="BtnJumpToCwd"
-                    Grid.Row="2"
+                    Grid.Row="1"
                     HorizontalAlignment="Left"
-                    Content="Jump to Current Directory"
-                    Padding="10,4"
+                    Content="Jump to cwd"
+                    Padding="8,3"
                     IsEnabled="{Binding CanInteractWithRemote}"
                     IsVisible="{Binding JumpToCurrentDirectoryPath, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                     Click="JumpToCwd_Click"/>
 
             <ListBox Name="RemoteEntriesList"
-                     Grid.Row="3"
+                     Grid.Row="2"
                      Background="#16181C"
                      BorderBrush="#2A2F35"
                      BorderThickness="1"
@@ -71,42 +63,39 @@
                      KeyDown="RemoteEntriesList_KeyDown">
                 <ListBox.ItemTemplate>
                     <DataTemplate x:DataType="vm:RemoteFilesSidebarEntryViewModel">
-                        <Border BorderBrush="#252A30" BorderThickness="0,0,0,1" Padding="8,6">
-                            <StackPanel Spacing="2">
-                                <TextBlock Text="{Binding Name}"
-                                           TextTrimming="CharacterEllipsis"/>
-                                <TextBlock Text="{Binding FullPath}"
-                                           Foreground="#7D8794"
-                                           FontSize="11"
-                                           TextTrimming="CharacterEllipsis"/>
-                            </StackPanel>
+                        <Border BorderBrush="#252A30"
+                                BorderThickness="0,0,0,1"
+                                Padding="8,5">
+                            <TextBlock Text="{Binding Name}"
+                                       TextTrimming="CharacterEllipsis"/>
                         </Border>
                     </DataTemplate>
                 </ListBox.ItemTemplate>
             </ListBox>
 
-            <StackPanel Grid.Row="4" Spacing="10">
+            <StackPanel Grid.Row="3" Spacing="8">
                 <TextBlock Name="InlineErrorText"
                            Text="{Binding ErrorMessage}"
                            Foreground="#F16C6C"
+                           FontSize="11"
                            TextWrapping="Wrap"
                            IsVisible="{Binding ErrorMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
 
                 <Grid ColumnDefinitions="Auto,Auto,*" ColumnSpacing="6">
                     <Button Name="BtnUploadFile"
-                            Content="Upload File"
-                            Padding="10,4"
+                            Content="File"
+                            Padding="8,3"
                             IsEnabled="{Binding CanInteractWithRemote}"/>
                     <Button Name="BtnUploadFolder"
                             Grid.Column="1"
-                            Content="Upload Folder"
-                            Padding="10,4"
+                            Content="Folder"
+                            Padding="8,3"
                             IsEnabled="{Binding CanInteractWithRemote}"/>
                     <Button Name="BtnDownloadSelected"
                             Grid.Column="2"
                             HorizontalAlignment="Stretch"
-                            Content="Download Selected"
-                            Padding="10,4"
+                            Content="Download"
+                            Padding="8,3"
                             IsEnabled="{Binding CanDownloadSelected}"/>
                 </Grid>
             </StackPanel>

--- a/src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml
+++ b/src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml
@@ -1,5 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:NovaTerminal.Controls"
              xmlns:vm="clr-namespace:NovaTerminal.ViewModels.Ssh"
              x:Class="NovaTerminal.Controls.RemoteFilesSidebar"
              x:DataType="vm:RemoteFilesSidebarViewModel">
@@ -9,53 +10,85 @@
             BorderBrush="#31353A"
             BorderThickness="1,0,0,0"
             Padding="10">
-        <Grid RowDefinitions="Auto,Auto,*,Auto" RowSpacing="8">
-            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
-                <Grid ColumnDefinitions="Auto,Auto,*,Auto"
-                      ColumnSpacing="6"
-                      IsEnabled="{Binding CanInteractWithRemote}">
-                    <Button Name="BtnNavigateBack"
-                            Content="Back"
-                            Padding="8,3"
-                            IsEnabled="{Binding CanNavigateBack}"
-                            Click="NavigateBack_Click"/>
-                    <Button Name="BtnNavigateUp"
-                            Grid.Column="1"
-                            Content="Up"
-                            Padding="8,3"
-                            Click="NavigateUp_Click"/>
-                    <TextBlock Grid.Column="2"
+        <Grid RowDefinitions="Auto,Auto,Auto,*,Auto" RowSpacing="8">
+            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="6">
+                <StackPanel Spacing="1">
+                    <TextBlock Name="HostTitleText"
+                               Text="{Binding HostTitle, RelativeSource={RelativeSource AncestorType=controls:RemoteFilesSidebar}}"
+                               Foreground="#F3F6FA"
+                               FontSize="13"
+                               FontWeight="SemiBold"
+                               TextTrimming="CharacterEllipsis"/>
+                    <TextBlock Name="HostSubtitleText"
+                               Text="{Binding HostSubtitle, RelativeSource={RelativeSource AncestorType=controls:RemoteFilesSidebar}}"
+                               Foreground="#96A0AE"
+                               FontSize="11"
+                               TextTrimming="CharacterEllipsis"/>
+                </StackPanel>
+
+                <Button Name="BtnRefresh"
+                        Grid.Column="1"
+                        Content="Refresh"
+                        Padding="8,3"
+                        IsEnabled="{Binding CanInteractWithRemote}"
+                        Click="Refresh_Click"/>
+
+                <Button Name="BtnCloseSidebar"
+                        Grid.Column="2"
+                        Content="Close"
+                        Padding="8,3"
+                        Click="CloseSidebar_Click"/>
+            </Grid>
+
+            <Border Grid.Row="1"
+                    Background="#16181C"
+                    BorderBrush="#2A2F35"
+                    BorderThickness="1"
+                    CornerRadius="6"
+                    Padding="8,6">
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                    <TextBlock Name="CurrentPathText"
                                VerticalAlignment="Center"
                                Text="{Binding CurrentPath}"
                                Foreground="#C5CDD8"
                                FontSize="11"
                                FontWeight="SemiBold"
                                TextTrimming="CharacterEllipsis"/>
-                    <Button Name="BtnRefresh"
-                            Grid.Column="3"
-                            Content="Refresh"
-                            Padding="8,3"
-                            Click="Refresh_Click"/>
+                    <TextBlock Name="ItemCountText"
+                               Grid.Column="1"
+                               VerticalAlignment="Center"
+                               Text="{Binding ItemCountLabel, RelativeSource={RelativeSource AncestorType=controls:RemoteFilesSidebar}}"
+                               Foreground="#7F8895"
+                               FontSize="10"/>
                 </Grid>
+            </Border>
 
-                <Button Name="BtnCloseSidebar"
-                        Grid.Column="1"
-                        Content="Close"
+            <Grid Grid.Row="2"
+                  ColumnDefinitions="Auto,Auto,*"
+                  ColumnSpacing="6"
+                  IsEnabled="{Binding CanInteractWithRemote}">
+                <Button Name="BtnNavigateBack"
+                        Content="Back"
                         Padding="8,3"
-                        Click="CloseSidebar_Click"/>
+                        IsEnabled="{Binding CanNavigateBack}"
+                        Click="NavigateBack_Click"/>
+                <Button Name="BtnNavigateUp"
+                        Grid.Column="1"
+                        Content="Up"
+                        Padding="8,3"
+                        Click="NavigateUp_Click"/>
+                <Button Name="BtnJumpToCwd"
+                        Grid.Column="2"
+                        HorizontalAlignment="Right"
+                        Content="Jump to cwd"
+                        Padding="8,3"
+                        IsEnabled="{Binding CanInteractWithRemote}"
+                        IsVisible="{Binding JumpToCurrentDirectoryPath, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                        Click="JumpToCwd_Click"/>
             </Grid>
 
-            <Button Name="BtnJumpToCwd"
-                    Grid.Row="1"
-                    HorizontalAlignment="Left"
-                    Content="Jump to cwd"
-                    Padding="8,3"
-                    IsEnabled="{Binding CanInteractWithRemote}"
-                    IsVisible="{Binding JumpToCurrentDirectoryPath, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
-                    Click="JumpToCwd_Click"/>
-
             <ListBox Name="RemoteEntriesList"
-                     Grid.Row="2"
+                     Grid.Row="3"
                      Background="#16181C"
                      BorderBrush="#2A2F35"
                      BorderThickness="1"
@@ -76,7 +109,7 @@
                 </ListBox.ItemTemplate>
             </ListBox>
 
-            <StackPanel Grid.Row="3" Spacing="8">
+            <StackPanel Grid.Row="4" Spacing="8">
                 <TextBlock Name="InlineErrorText"
                            Text="{Binding ErrorMessage}"
                            Foreground="#F16C6C"

--- a/src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml
+++ b/src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml
@@ -1,0 +1,110 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:NovaTerminal.ViewModels.Ssh"
+             x:Class="NovaTerminal.Controls.RemoteFilesSidebar"
+             x:DataType="vm:RemoteFilesSidebarViewModel">
+    <Border Width="320"
+            Background="#1B1D21"
+            BorderBrush="#31353A"
+            BorderThickness="1,0,0,0"
+            Padding="12">
+        <Grid RowDefinitions="Auto,Auto,Auto,*,Auto" RowSpacing="10">
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                <StackPanel Spacing="2">
+                    <TextBlock Text="Remote Files"
+                               FontSize="14"
+                               FontWeight="SemiBold"/>
+                    <TextBlock Text="{Binding CurrentPath}"
+                               Foreground="#9AA4B2"
+                               FontSize="11"
+                               TextTrimming="CharacterEllipsis"/>
+                </StackPanel>
+
+                <Button Name="BtnCloseSidebar"
+                        Grid.Column="1"
+                        Content="Close"
+                        Padding="10,4"
+                        Click="CloseSidebar_Click"/>
+            </Grid>
+
+            <Grid Grid.Row="1" ColumnDefinitions="Auto,Auto,Auto,*" ColumnSpacing="6">
+                <Button Name="BtnNavigateBack"
+                        Content="Back"
+                        Padding="10,4"
+                        IsEnabled="{Binding CanNavigateBack}"
+                        Click="NavigateBack_Click"/>
+                <Button Name="BtnNavigateUp"
+                        Grid.Column="1"
+                        Content="Up"
+                        Padding="10,4"
+                        IsEnabled="{Binding IsOpen}"
+                        Click="NavigateUp_Click"/>
+                <Button Name="BtnRefresh"
+                        Grid.Column="2"
+                        Content="Refresh"
+                        Padding="10,4"
+                        IsEnabled="{Binding IsOpen}"
+                        Click="Refresh_Click"/>
+            </Grid>
+
+            <Button Name="BtnJumpToCwd"
+                    Grid.Row="2"
+                    HorizontalAlignment="Left"
+                    Content="Jump to Current Directory"
+                    Padding="10,4"
+                    IsVisible="{Binding JumpToCurrentDirectoryPath, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                    Click="JumpToCwd_Click"/>
+
+            <ListBox Name="RemoteEntriesList"
+                     Grid.Row="3"
+                     Background="#16181C"
+                     BorderBrush="#2A2F35"
+                     BorderThickness="1"
+                     ItemsSource="{Binding Entries}"
+                     SelectedItem="{Binding SelectedEntry, Mode=TwoWay}"
+                     DoubleTapped="RemoteEntriesList_DoubleTapped"
+                     KeyDown="RemoteEntriesList_KeyDown">
+                <ListBox.ItemTemplate>
+                    <DataTemplate x:DataType="vm:RemoteFilesSidebarEntryViewModel">
+                        <Border BorderBrush="#252A30" BorderThickness="0,0,0,1" Padding="8,6">
+                            <StackPanel Spacing="2">
+                                <TextBlock Text="{Binding Name}"
+                                           TextTrimming="CharacterEllipsis"/>
+                                <TextBlock Text="{Binding FullPath}"
+                                           Foreground="#7D8794"
+                                           FontSize="11"
+                                           TextTrimming="CharacterEllipsis"/>
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+
+            <StackPanel Grid.Row="4" Spacing="10">
+                <TextBlock Name="InlineErrorText"
+                           Text="{Binding ErrorMessage}"
+                           Foreground="#F16C6C"
+                           TextWrapping="Wrap"
+                           IsVisible="{Binding ErrorMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+
+                <Grid ColumnDefinitions="Auto,Auto,*" ColumnSpacing="6">
+                    <Button Name="BtnUploadFile"
+                            Content="Upload File"
+                            Padding="10,4"
+                            IsEnabled="{Binding IsOpen}"/>
+                    <Button Name="BtnUploadFolder"
+                            Grid.Column="1"
+                            Content="Upload Folder"
+                            Padding="10,4"
+                            IsEnabled="{Binding IsOpen}"/>
+                    <Button Name="BtnDownloadSelected"
+                            Grid.Column="2"
+                            HorizontalAlignment="Stretch"
+                            Content="Download Selected"
+                            Padding="10,4"
+                            IsEnabled="{Binding CanDownloadSelected}"/>
+                </Grid>
+            </StackPanel>
+        </Grid>
+    </Border>
+</UserControl>

--- a/src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml
+++ b/src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml
@@ -10,33 +10,36 @@
             BorderThickness="1,0,0,0"
             Padding="10">
         <Grid RowDefinitions="Auto,Auto,*,Auto" RowSpacing="8">
-            <Grid ColumnDefinitions="Auto,Auto,*,Auto,Auto" ColumnSpacing="6">
-                <Button Name="BtnNavigateBack"
-                        Content="Back"
-                        Padding="8,3"
-                        IsEnabled="{Binding CanNavigateBack}"
-                        Click="NavigateBack_Click"/>
-                <Button Name="BtnNavigateUp"
-                        Grid.Column="1"
-                        Content="Up"
-                        Padding="8,3"
-                        IsEnabled="{Binding CanInteractWithRemote}"
-                        Click="NavigateUp_Click"/>
-                <TextBlock Grid.Column="2"
-                           VerticalAlignment="Center"
-                           Text="{Binding CurrentPath}"
-                           Foreground="#C5CDD8"
-                           FontSize="11"
-                           FontWeight="SemiBold"
-                           TextTrimming="CharacterEllipsis"/>
-                <Button Name="BtnRefresh"
-                        Grid.Column="3"
-                        Content="Refresh"
-                        Padding="8,3"
-                        IsEnabled="{Binding CanInteractWithRemote}"
-                        Click="Refresh_Click"/>
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
+                <Grid ColumnDefinitions="Auto,Auto,*,Auto"
+                      ColumnSpacing="6"
+                      IsEnabled="{Binding CanInteractWithRemote}">
+                    <Button Name="BtnNavigateBack"
+                            Content="Back"
+                            Padding="8,3"
+                            IsEnabled="{Binding CanNavigateBack}"
+                            Click="NavigateBack_Click"/>
+                    <Button Name="BtnNavigateUp"
+                            Grid.Column="1"
+                            Content="Up"
+                            Padding="8,3"
+                            Click="NavigateUp_Click"/>
+                    <TextBlock Grid.Column="2"
+                               VerticalAlignment="Center"
+                               Text="{Binding CurrentPath}"
+                               Foreground="#C5CDD8"
+                               FontSize="11"
+                               FontWeight="SemiBold"
+                               TextTrimming="CharacterEllipsis"/>
+                    <Button Name="BtnRefresh"
+                            Grid.Column="3"
+                            Content="Refresh"
+                            Padding="8,3"
+                            Click="Refresh_Click"/>
+                </Grid>
+
                 <Button Name="BtnCloseSidebar"
-                        Grid.Column="4"
+                        Grid.Column="1"
                         Content="Close"
                         Padding="8,3"
                         Click="CloseSidebar_Click"/>

--- a/src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml.cs
+++ b/src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml.cs
@@ -1,4 +1,8 @@
+using System;
+using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Threading.Tasks;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -8,12 +12,59 @@ namespace NovaTerminal.Controls;
 
 public partial class RemoteFilesSidebar : UserControl
 {
+    public static readonly StyledProperty<string> HostTitleProperty =
+        AvaloniaProperty.Register<RemoteFilesSidebar, string>(
+            nameof(HostTitle),
+            "Remote Files");
+
+    public static readonly StyledProperty<string> HostSubtitleProperty =
+        AvaloniaProperty.Register<RemoteFilesSidebar, string>(
+            nameof(HostSubtitle),
+            "Native SFTP");
+
+    public static readonly StyledProperty<string> ItemCountLabelProperty =
+        AvaloniaProperty.Register<RemoteFilesSidebar, string>(
+            nameof(ItemCountLabel),
+            "0 items");
+
+    private RemoteFilesSidebarViewModel? _observedViewModel;
+
     public RemoteFilesSidebar()
     {
         InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+        UpdateObservedViewModel(ViewModel);
+    }
+
+    public string HostTitle
+    {
+        get => GetValue(HostTitleProperty);
+        set => SetValue(HostTitleProperty, value);
+    }
+
+    public string HostSubtitle
+    {
+        get => GetValue(HostSubtitleProperty);
+        set => SetValue(HostSubtitleProperty, value);
+    }
+
+    public string ItemCountLabel
+    {
+        get => GetValue(ItemCountLabelProperty);
+        set => SetValue(ItemCountLabelProperty, value);
     }
 
     private RemoteFilesSidebarViewModel? ViewModel => DataContext as RemoteFilesSidebarViewModel;
+
+    public void SetHostIdentity(string? title, string? subtitle)
+    {
+        HostTitle = string.IsNullOrWhiteSpace(title)
+            ? "Remote Files"
+            : title.Trim();
+        HostSubtitle = string.IsNullOrWhiteSpace(subtitle)
+            ? "Native SFTP"
+            : subtitle.Trim();
+    }
 
     private async void NavigateBack_Click(object? sender, RoutedEventArgs e)
     {
@@ -84,5 +135,51 @@ public partial class RemoteFilesSidebar : UserControl
     private void StartDirectoryNavigation()
     {
         _ = NavigateIntoSelectedDirectoryAsync();
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        UpdateObservedViewModel(ViewModel);
+    }
+
+    private void UpdateObservedViewModel(RemoteFilesSidebarViewModel? viewModel)
+    {
+        if (_observedViewModel != null)
+        {
+            _observedViewModel.PropertyChanged -= OnViewModelPropertyChanged;
+            _observedViewModel.Entries.CollectionChanged -= OnEntriesCollectionChanged;
+        }
+
+        _observedViewModel = viewModel;
+
+        if (_observedViewModel != null)
+        {
+            _observedViewModel.PropertyChanged += OnViewModelPropertyChanged;
+            _observedViewModel.Entries.CollectionChanged += OnEntriesCollectionChanged;
+        }
+
+        UpdateItemCountLabel();
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(RemoteFilesSidebarViewModel.IsOpen) ||
+            e.PropertyName == nameof(RemoteFilesSidebarViewModel.IsLoading))
+        {
+            UpdateItemCountLabel();
+        }
+    }
+
+    private void OnEntriesCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        UpdateItemCountLabel();
+    }
+
+    private void UpdateItemCountLabel()
+    {
+        int itemCount = _observedViewModel?.Entries.Count ?? 0;
+        ItemCountLabel = itemCount == 1
+            ? "1 item"
+            : $"{itemCount} items";
     }
 }

--- a/src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml.cs
+++ b/src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml.cs
@@ -1,0 +1,83 @@
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using NovaTerminal.ViewModels.Ssh;
+
+namespace NovaTerminal.Controls;
+
+public partial class RemoteFilesSidebar : UserControl
+{
+    public RemoteFilesSidebar()
+    {
+        InitializeComponent();
+    }
+
+    private RemoteFilesSidebarViewModel? ViewModel => DataContext as RemoteFilesSidebarViewModel;
+
+    private async void NavigateBack_Click(object? sender, RoutedEventArgs e)
+    {
+        if (ViewModel is null)
+        {
+            return;
+        }
+
+        await ViewModel.NavigateBackAsync();
+    }
+
+    private async void NavigateUp_Click(object? sender, RoutedEventArgs e)
+    {
+        if (ViewModel is null)
+        {
+            return;
+        }
+
+        await ViewModel.NavigateUpAsync();
+    }
+
+    private async void Refresh_Click(object? sender, RoutedEventArgs e)
+    {
+        if (ViewModel is null)
+        {
+            return;
+        }
+
+        await ViewModel.RefreshAsync();
+    }
+
+    private void CloseSidebar_Click(object? sender, RoutedEventArgs e)
+    {
+        ViewModel?.Close();
+    }
+
+    private async void JumpToCwd_Click(object? sender, RoutedEventArgs e)
+    {
+        if (ViewModel is null)
+        {
+            return;
+        }
+
+        await ViewModel.JumpToCurrentDirectoryAsync();
+    }
+
+    private async void RemoteEntriesList_DoubleTapped(object? sender, RoutedEventArgs e)
+    {
+        await NavigateIntoSelectedDirectoryAsync();
+    }
+
+    private async void RemoteEntriesList_KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key != Key.Enter)
+        {
+            return;
+        }
+
+        await NavigateIntoSelectedDirectoryAsync();
+        e.Handled = true;
+    }
+
+    private Task NavigateIntoSelectedDirectoryAsync()
+    {
+        return ViewModel?.NavigateIntoSelectedDirectoryAsync() ?? Task.CompletedTask;
+    }
+}

--- a/src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml.cs
+++ b/src/NovaTerminal.App/Controls/RemoteFilesSidebar.axaml.cs
@@ -60,24 +60,29 @@ public partial class RemoteFilesSidebar : UserControl
         await ViewModel.JumpToCurrentDirectoryAsync();
     }
 
-    private async void RemoteEntriesList_DoubleTapped(object? sender, RoutedEventArgs e)
+    private void RemoteEntriesList_DoubleTapped(object? sender, RoutedEventArgs e)
     {
-        await NavigateIntoSelectedDirectoryAsync();
+        StartDirectoryNavigation();
     }
 
-    private async void RemoteEntriesList_KeyDown(object? sender, KeyEventArgs e)
+    private void RemoteEntriesList_KeyDown(object? sender, KeyEventArgs e)
     {
         if (e.Key != Key.Enter)
         {
             return;
         }
 
-        await NavigateIntoSelectedDirectoryAsync();
         e.Handled = true;
+        StartDirectoryNavigation();
     }
 
     private Task NavigateIntoSelectedDirectoryAsync()
     {
         return ViewModel?.NavigateIntoSelectedDirectoryAsync() ?? Task.CompletedTask;
+    }
+
+    private void StartDirectoryNavigation()
+    {
+        _ = NavigateIntoSelectedDirectoryAsync();
     }
 }

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml
@@ -36,12 +36,6 @@
                     </MenuItem>
                     <MenuItem Header="SFTP">
                         <MenuItem Header="Remote Files" Name="MenuToggleRemoteFilesSidebar" />
-                        <Separator />
-                        <MenuItem Header="Upload File..." Name="MenuUploadFile" />
-                        <MenuItem Header="Upload Folder..." Name="MenuUploadFolder" />
-                        <Separator />
-                        <MenuItem Header="Download File..." Name="MenuDownloadFile" />
-                        <MenuItem Header="Download Folder..." Name="MenuDownloadFolder" />
                     </MenuItem>
                     <MenuItem Header="Explain Selection" Name="MenuExplainSelection" IsVisible="False" />
                 </ContextMenu>

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:core="clr-namespace:NovaTerminal.Core"
              xmlns:assist="clr-namespace:NovaTerminal.CommandAssist.Views"
+             xmlns:controls="clr-namespace:NovaTerminal.Controls"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="NovaTerminal.Controls.TerminalPane"
              Focusable="True"
@@ -34,6 +35,8 @@
                         <MenuItem Header="Close Pane" Name="MenuPaneClose" />
                     </MenuItem>
                     <MenuItem Header="SFTP">
+                        <MenuItem Header="Remote Files" Name="MenuToggleRemoteFilesSidebar" />
+                        <Separator />
                         <MenuItem Header="Upload File..." Name="MenuUploadFile" />
                         <MenuItem Header="Upload Folder..." Name="MenuUploadFolder" />
                         <Separator />
@@ -44,89 +47,100 @@
                 </ContextMenu>
             </Grid.ContextMenu>
 
-            <!-- Terminal View Layer -->
-            <core:TerminalView x:Name="TermView" Grid.Row="0" />
-            <Border Name="InactiveOverlay"
-                    Background="#66000000"
-                    IsVisible="False"
-                    IsHitTestVisible="False"
-                    ZIndex="20"
-                    Grid.Row="0" />
-
-            <!-- ScrollBar Overlay -->
-            <ScrollBar x:Name="TermScrollBar"
-                       Grid.Row="0"
-                       Orientation="Vertical"
-                       AllowAutoHide="True"
-                       Visibility="Visible"
-                       HorizontalAlignment="Right"
-                       Width="10"
-                       Minimum="0" Maximum="0"
-                       ViewportSize="20"/>
-
-            <!-- Action Toast Panel -->
-            <Border Name="ToastPanel" IsVisible="False" VerticalAlignment="Top" HorizontalAlignment="Center"
-                    Margin="0,20,0,0" Background="#383838" CornerRadius="6" Padding="12,8"
-                    BorderBrush="#505050" BorderThickness="1" ZIndex="250" Grid.Row="0">
-                <Border.Effect>
-                    <DropShadowEffect BlurRadius="8" Opacity="0.5" OffsetY="2" Color="Black" />
-                </Border.Effect>
-                <Grid ColumnDefinitions="Auto, *, Auto, Auto, Auto">
-                    <TextBlock Grid.Column="0" Text="📄" Foreground="#AAA" VerticalAlignment="Center" Margin="0,0,8,0" />
-                    <TextBlock Name="ToastMessageText" Grid.Column="1" Text="Paste contents of filename.txt?" 
-                               Foreground="White" VerticalAlignment="Center" Margin="0,0,16,0" />
-                    <Button Name="ToastPastePathBtn" Grid.Column="2" Content="Paste path" 
-                            Background="#333" Foreground="White" BorderThickness="1" BorderBrush="#555" CornerRadius="4" Padding="8,4" Margin="0,0,8,0" Cursor="Hand" />
-                    <Button Name="ToastActionBtn" Grid.Column="3" Content="Paste contents" 
-                            Background="#0078D7" Foreground="White" BorderThickness="0" CornerRadius="4" Padding="8,4" Margin="0,0,8,0" Cursor="Hand" />
-                    <Button Name="ToastCloseBtn" Grid.Column="4" Content="✕" 
-                            Background="Transparent" Foreground="#AAA" BorderThickness="0" VerticalAlignment="Center" Padding="4" Cursor="Hand" />
-                </Grid>
-            </Border>
-
-            <!-- Search Overlay -->
-            <Border Name="SearchPanel" IsVisible="False" VerticalAlignment="Top" HorizontalAlignment="Right" 
-                    Margin="0,10,24,0" Background="#383838" CornerRadius="4" Padding="6" Width="400"
-                    BorderBrush="#505050" BorderThickness="1" ZIndex="200"
-                    Grid.Row="0">
-                <Border.Resources>
-                    <SolidColorBrush x:Key="TextControlBackground">#1a1a1a</SolidColorBrush>
-                    <SolidColorBrush x:Key="TextControlForeground">White</SolidColorBrush>
-                </Border.Resources>
-                <Grid ColumnDefinitions="*, Auto, Auto, Auto, Auto, Auto, Auto">
-                    <TextBox Name="SearchBox" Watermark="Search..." 
-                             BorderThickness="1" BorderBrush="#505050" 
-                             VerticalContentAlignment="Center" 
-                             Padding="8,4" Margin="2"/>
-                    
-                    <ToggleButton Name="SearchCaseSensitive" Grid.Column="1" Content="Aa" 
-                                  Background="Transparent" Foreground="#AAA" BorderThickness="0" Margin="2" Width="30" 
-                                  ToolTip.Tip="Match Case"/>
-                    <ToggleButton Name="SearchRegex" Grid.Column="2" Content=".*" 
-                                  Background="Transparent" Foreground="#AAA" BorderThickness="0" Margin="2" Width="30" 
-                                  ToolTip.Tip="Use Regular Expression"/>
-
-                    <TextBlock Name="SearchCount" Grid.Column="3" Text="0/0" Foreground="#AAA" 
-                               VerticalAlignment="Center" Margin="8,0" FontSize="12"/>
-                    <Button Name="SearchPrev" Grid.Column="4" Content="▲" Background="Transparent" Foreground="#AAA" BorderThickness="0" Margin="2" Width="30" Focusable="False"/>
-                    <Button Name="SearchNext" Grid.Column="5" Content="▼" Background="Transparent" Foreground="#AAA" BorderThickness="0" Margin="2" Width="30" Focusable="False"/>
-                    <Button Name="SearchClose" Grid.Column="6" Content="✕" Background="Transparent" Foreground="#AAA" BorderThickness="0" Margin="2" Width="30" Focusable="False"/>
-                </Grid>
-            </Border>
-
-            <Grid x:Name="CommandAssistOverlayHost"
+            <Grid x:Name="PaneContentGrid"
                   Grid.Row="0"
-                  ZIndex="150"
-                  IsVisible="False"
-                  IsHitTestVisible="False">
-                <assist:CommandAssistPopupView x:Name="CommandAssistPopup"
-                                               HorizontalAlignment="Left"
-                                               VerticalAlignment="Top"
-                                               Margin="16,16,16,84" />
-                <assist:CommandAssistBubbleView x:Name="CommandAssistBubble"
-                                                HorizontalAlignment="Left"
-                                                VerticalAlignment="Top"
-                                                Margin="16,16,16,24" />
+                  ColumnDefinitions="*,Auto">
+                <Grid x:Name="TerminalLayerHost"
+                      Grid.Column="0">
+                    <!-- Terminal View Layer -->
+                    <core:TerminalView x:Name="TermView" Grid.Row="0" />
+                    <Border Name="InactiveOverlay"
+                            Background="#66000000"
+                            IsVisible="False"
+                            IsHitTestVisible="False"
+                            ZIndex="20"
+                            Grid.Row="0" />
+
+                    <!-- ScrollBar Overlay -->
+                    <ScrollBar x:Name="TermScrollBar"
+                               Grid.Row="0"
+                               Orientation="Vertical"
+                               AllowAutoHide="True"
+                               Visibility="Visible"
+                               HorizontalAlignment="Right"
+                               Width="10"
+                               Minimum="0" Maximum="0"
+                               ViewportSize="20"/>
+
+                    <!-- Action Toast Panel -->
+                    <Border Name="ToastPanel" IsVisible="False" VerticalAlignment="Top" HorizontalAlignment="Center"
+                            Margin="0,20,0,0" Background="#383838" CornerRadius="6" Padding="12,8"
+                            BorderBrush="#505050" BorderThickness="1" ZIndex="250" Grid.Row="0">
+                        <Border.Effect>
+                            <DropShadowEffect BlurRadius="8" Opacity="0.5" OffsetY="2" Color="Black" />
+                        </Border.Effect>
+                        <Grid ColumnDefinitions="Auto, *, Auto, Auto, Auto">
+                            <TextBlock Grid.Column="0" Text="📄" Foreground="#AAA" VerticalAlignment="Center" Margin="0,0,8,0" />
+                            <TextBlock Name="ToastMessageText" Grid.Column="1" Text="Paste contents of filename.txt?" 
+                                       Foreground="White" VerticalAlignment="Center" Margin="0,0,16,0" />
+                            <Button Name="ToastPastePathBtn" Grid.Column="2" Content="Paste path" 
+                                    Background="#333" Foreground="White" BorderThickness="1" BorderBrush="#555" CornerRadius="4" Padding="8,4" Margin="0,0,8,0" Cursor="Hand" />
+                            <Button Name="ToastActionBtn" Grid.Column="3" Content="Paste contents" 
+                                    Background="#0078D7" Foreground="White" BorderThickness="0" CornerRadius="4" Padding="8,4" Margin="0,0,8,0" Cursor="Hand" />
+                            <Button Name="ToastCloseBtn" Grid.Column="4" Content="✕" 
+                                    Background="Transparent" Foreground="#AAA" BorderThickness="0" VerticalAlignment="Center" Padding="4" Cursor="Hand" />
+                        </Grid>
+                    </Border>
+
+                    <!-- Search Overlay -->
+                    <Border Name="SearchPanel" IsVisible="False" VerticalAlignment="Top" HorizontalAlignment="Right" 
+                            Margin="0,10,24,0" Background="#383838" CornerRadius="4" Padding="6" Width="400"
+                            BorderBrush="#505050" BorderThickness="1" ZIndex="200"
+                            Grid.Row="0">
+                        <Border.Resources>
+                            <SolidColorBrush x:Key="TextControlBackground">#1a1a1a</SolidColorBrush>
+                            <SolidColorBrush x:Key="TextControlForeground">White</SolidColorBrush>
+                        </Border.Resources>
+                        <Grid ColumnDefinitions="*, Auto, Auto, Auto, Auto, Auto, Auto">
+                            <TextBox Name="SearchBox" Watermark="Search..." 
+                                     BorderThickness="1" BorderBrush="#505050" 
+                                     VerticalContentAlignment="Center" 
+                                     Padding="8,4" Margin="2"/>
+                            
+                            <ToggleButton Name="SearchCaseSensitive" Grid.Column="1" Content="Aa" 
+                                          Background="Transparent" Foreground="#AAA" BorderThickness="0" Margin="2" Width="30" 
+                                          ToolTip.Tip="Match Case"/>
+                            <ToggleButton Name="SearchRegex" Grid.Column="2" Content=".*" 
+                                          Background="Transparent" Foreground="#AAA" BorderThickness="0" Margin="2" Width="30" 
+                                          ToolTip.Tip="Use Regular Expression"/>
+
+                            <TextBlock Name="SearchCount" Grid.Column="3" Text="0/0" Foreground="#AAA" 
+                                       VerticalAlignment="Center" Margin="8,0" FontSize="12"/>
+                            <Button Name="SearchPrev" Grid.Column="4" Content="▲" Background="Transparent" Foreground="#AAA" BorderThickness="0" Margin="2" Width="30" Focusable="False"/>
+                            <Button Name="SearchNext" Grid.Column="5" Content="▼" Background="Transparent" Foreground="#AAA" BorderThickness="0" Margin="2" Width="30" Focusable="False"/>
+                            <Button Name="SearchClose" Grid.Column="6" Content="✕" Background="Transparent" Foreground="#AAA" BorderThickness="0" Margin="2" Width="30" Focusable="False"/>
+                        </Grid>
+                    </Border>
+
+                    <Grid x:Name="CommandAssistOverlayHost"
+                          Grid.Row="0"
+                          ZIndex="150"
+                          IsVisible="False"
+                          IsHitTestVisible="False">
+                        <assist:CommandAssistPopupView x:Name="CommandAssistPopup"
+                                                       HorizontalAlignment="Left"
+                                                       VerticalAlignment="Top"
+                                                       Margin="16,16,16,84" />
+                        <assist:CommandAssistBubbleView x:Name="CommandAssistBubble"
+                                                        HorizontalAlignment="Left"
+                                                        VerticalAlignment="Top"
+                                                        Margin="16,16,16,24" />
+                    </Grid>
+                </Grid>
+
+                <controls:RemoteFilesSidebar x:Name="RemoteFilesSidebarHost"
+                                             Grid.Column="1"
+                                             IsVisible="False" />
             </Grid>
 
             <!-- Port Forwarding Status Bar -->

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -484,9 +484,12 @@ namespace NovaTerminal.Controls
 
             bool isSupported = IsRemoteFilesSidebarSupported();
             bool isBlockedByAltScreen = Buffer?.IsAltScreenActive == true;
+            bool isSidebarOpen = _remoteFilesSidebarViewModel?.IsOpen == true;
+            bool isSidebarDisconnected = _remoteFilesSidebarViewModel?.IsDisconnected == true;
+            bool canOpen = (isSidebarOpen && !isSidebarDisconnected) || Session?.IsProcessRunning == true;
             MenuToggleRemoteFilesSidebar.IsVisible = isSupported;
-            MenuToggleRemoteFilesSidebar.IsEnabled = isSupported && !isBlockedByAltScreen;
-            MenuToggleRemoteFilesSidebar.Header = _remoteFilesSidebarViewModel?.IsOpen == true
+            MenuToggleRemoteFilesSidebar.IsEnabled = isSupported && !isBlockedByAltScreen && canOpen;
+            MenuToggleRemoteFilesSidebar.Header = isSidebarOpen
                 ? "Hide Remote Files"
                 : "Remote Files";
         }
@@ -1917,6 +1920,11 @@ namespace NovaTerminal.Controls
             return _remoteFilesSidebarViewModel?.JumpToCurrentDirectoryPath;
         }
 
+        internal bool IsRemoteFilesSidebarDisconnectedForTest()
+        {
+            return _remoteFilesSidebarViewModel?.IsDisconnected == true;
+        }
+
         internal void HandleSessionExitForTesting(int code)
         {
             HandleSessionExit(Session, code);
@@ -1933,7 +1941,13 @@ namespace NovaTerminal.Controls
 
             if (Profile?.Type == ConnectionType.SSH)
             {
-                CloseRemoteFilesSidebar();
+                if (_remoteFilesSidebarViewModel?.IsOpen == true)
+                {
+                    _remoteFilesSidebarViewModel.MarkDisconnected();
+                    UpdateRemoteFilesSidebarVisibility();
+                    UpdateRemoteFilesSidebarEntryPointState();
+                }
+
                 WriteSshDisconnectedBanner(code);
             }
 

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -11,12 +11,14 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
+using System.Threading;
 using System.Net.NetworkInformation;
 using System.Linq;
 using Avalonia.Controls.Shapes;
 using Avalonia.Automation;
 using Avalonia.Platform.Storage;
 using System.ComponentModel;
+using System.Reflection;
 using NovaTerminal.CommandAssist.Application;
 using NovaTerminal.CommandAssist.Models;
 using NovaTerminal.CommandAssist.ViewModels;
@@ -27,7 +29,9 @@ using NovaTerminal.Core.Ssh.Launch;
 using NovaTerminal.Core.Ssh.Interactions;
 using NovaTerminal.Core.Ssh.Models;
 using NovaTerminal.Core.Ssh.Sessions;
+using NovaTerminal.Models;
 using NovaTerminal.Services.Ssh;
+using NovaTerminal.ViewModels.Ssh;
 
 namespace NovaTerminal.Controls
 {
@@ -83,6 +87,9 @@ namespace NovaTerminal.Controls
         private int _sshAssistCorrectionPassCount;
         private readonly CommandAssistBubbleViewModel _hiddenCommandAssistBubbleViewModel = new() { IsVisible = false };
         private readonly CommandAssistPopupViewModel _hiddenCommandAssistPopupViewModel = new(new ObservableCollection<CommandAssistSuggestionItemViewModel>()) { IsVisible = false };
+        private IRemoteDirectoryBrowserService _remoteDirectoryBrowserService = new RemoteDirectoryBrowserService();
+        private RemoteFilesSidebarViewModel? _remoteFilesSidebarViewModel;
+        private bool _isRemoteFilesSidebarTestServiceConfigured;
         private const double CommandAssistBubbleWidth = 420;
         private const double CommandAssistBubbleHeight = 36;
         private const double CommandAssistPopupWidth = 520;
@@ -173,10 +180,22 @@ namespace NovaTerminal.Controls
             Profile = profile;
             TermView.ShellOverride = profile.ShellOverride;
             UpdateCommandAssistContext();
+            if (!IsRemoteFilesSidebarSupported())
+            {
+                CloseRemoteFilesSidebar();
+            }
+
+            UpdateRemoteFilesSidebarCurrentDirectoryState();
+            UpdateRemoteFilesSidebarEntryPointState();
         }
 
         public Control ActiveControl => TermView;
         public ISshInteractionHandler? SshInteractionHandler { get; set; }
+
+        public void ToggleRemoteFilesSidebar()
+        {
+            _ = ToggleRemoteFilesSidebarAsync();
+        }
 
         public TerminalPane()
         {
@@ -383,8 +402,190 @@ namespace NovaTerminal.Controls
                 }
             }
 
+            InitializeRemoteFilesSidebar();
+        }
 
+        private void InitializeRemoteFilesSidebar()
+        {
+            SetRemoteFilesSidebarService(_remoteDirectoryBrowserService);
 
+            if (MenuToggleRemoteFilesSidebar != null)
+            {
+                MenuToggleRemoteFilesSidebar.Click += async (_, _) => await ToggleRemoteFilesSidebarAsync();
+            }
+
+            if (RemoteFilesSidebarHost != null)
+            {
+                if (RemoteFilesSidebarHost.FindControl<Button>("BtnUploadFile") is Button uploadFileButton)
+                {
+                    uploadFileButton.Click += (_, _) => RequestSftpTransfer?.Invoke(this, TransferDirection.Upload, TransferKind.File);
+                }
+
+                if (RemoteFilesSidebarHost.FindControl<Button>("BtnUploadFolder") is Button uploadFolderButton)
+                {
+                    uploadFolderButton.Click += (_, _) => RequestSftpTransfer?.Invoke(this, TransferDirection.Upload, TransferKind.Folder);
+                }
+
+                if (RemoteFilesSidebarHost.FindControl<Button>("BtnDownloadSelected") is Button downloadSelectedButton)
+                {
+                    downloadSelectedButton.Click += (_, _) => RequestRemoteFilesSidebarDownload();
+                }
+            }
+
+            UpdateRemoteFilesSidebarCurrentDirectoryState();
+            UpdateRemoteFilesSidebarVisibility();
+            UpdateRemoteFilesSidebarEntryPointState();
+        }
+
+        private void SetRemoteFilesSidebarService(IRemoteDirectoryBrowserService directoryBrowserService)
+        {
+            ArgumentNullException.ThrowIfNull(directoryBrowserService);
+
+            if (_remoteFilesSidebarViewModel != null)
+            {
+                _remoteFilesSidebarViewModel.PropertyChanged -= OnRemoteFilesSidebarViewModelPropertyChanged;
+            }
+
+            _remoteDirectoryBrowserService = directoryBrowserService;
+            _remoteFilesSidebarViewModel = new RemoteFilesSidebarViewModel(directoryBrowserService);
+            _remoteFilesSidebarViewModel.PropertyChanged += OnRemoteFilesSidebarViewModelPropertyChanged;
+
+            if (RemoteFilesSidebarHost != null)
+            {
+                RemoteFilesSidebarHost.DataContext = _remoteFilesSidebarViewModel;
+            }
+        }
+
+        private void OnRemoteFilesSidebarViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            UpdateRemoteFilesSidebarCurrentDirectoryState();
+            UpdateRemoteFilesSidebarVisibility();
+            UpdateRemoteFilesSidebarEntryPointState();
+        }
+
+        private bool IsRemoteFilesSidebarSupported()
+        {
+            return Profile?.Type == ConnectionType.SSH &&
+                   Profile.SshBackendKind == SshBackendKind.Native;
+        }
+
+        private void UpdateRemoteFilesSidebarEntryPointState()
+        {
+            if (MenuToggleRemoteFilesSidebar == null)
+            {
+                return;
+            }
+
+            bool isSupported = IsRemoteFilesSidebarSupported();
+            bool isBlockedByAltScreen = Buffer?.IsAltScreenActive == true;
+            MenuToggleRemoteFilesSidebar.IsVisible = isSupported;
+            MenuToggleRemoteFilesSidebar.IsEnabled = isSupported && !isBlockedByAltScreen;
+            MenuToggleRemoteFilesSidebar.Header = _remoteFilesSidebarViewModel?.IsOpen == true
+                ? "Hide Remote Files"
+                : "Remote Files";
+        }
+
+        private void UpdateRemoteFilesSidebarVisibility()
+        {
+            if (RemoteFilesSidebarHost == null)
+            {
+                return;
+            }
+
+            RemoteFilesSidebarHost.IsVisible =
+                _remoteFilesSidebarViewModel?.IsOpen == true &&
+                !(Buffer?.IsAltScreenActive ?? false) &&
+                IsRemoteFilesSidebarSupported();
+        }
+
+        private void UpdateRemoteFilesSidebarCurrentDirectoryState()
+        {
+            if (_remoteFilesSidebarViewModel == null)
+            {
+                return;
+            }
+
+            if (!_remoteFilesSidebarViewModel.IsOpen)
+            {
+                _remoteFilesSidebarViewModel.SetJumpToCurrentDirectoryCandidate(null);
+                return;
+            }
+
+            string? currentWorkingDirectory = string.IsNullOrWhiteSpace(CurrentWorkingDirectory)
+                ? null
+                : CurrentWorkingDirectory.Trim();
+            string? jumpTarget = string.Equals(
+                currentWorkingDirectory,
+                _remoteFilesSidebarViewModel.CurrentPath,
+                StringComparison.Ordinal)
+                ? null
+                : currentWorkingDirectory;
+            _remoteFilesSidebarViewModel.SetJumpToCurrentDirectoryCandidate(jumpTarget);
+        }
+
+        private async Task ToggleRemoteFilesSidebarAsync()
+        {
+            if (_remoteFilesSidebarViewModel == null)
+            {
+                return;
+            }
+
+            if (_remoteFilesSidebarViewModel.IsOpen)
+            {
+                CloseRemoteFilesSidebar();
+                return;
+            }
+
+            if (!IsRemoteFilesSidebarSupported() ||
+                Profile == null ||
+                Session == null ||
+                Session.Id == Guid.Empty ||
+                Buffer?.IsAltScreenActive == true)
+            {
+                return;
+            }
+
+            await OpenRemoteFilesSidebarAsync(Profile.Id, Session.Id);
+        }
+
+        private async Task OpenRemoteFilesSidebarAsync(Guid profileId, Guid sessionId)
+        {
+            if (_remoteFilesSidebarViewModel == null)
+            {
+                return;
+            }
+
+            string startPath = RemoteSidebarStartPathResolver.Resolve(
+                CurrentWorkingDirectory,
+                Profile?.DefaultRemoteDir);
+            await _remoteFilesSidebarViewModel.OpenAsync(
+                profileId,
+                sessionId,
+                startPath,
+                CancellationToken.None);
+            UpdateRemoteFilesSidebarCurrentDirectoryState();
+            UpdateRemoteFilesSidebarVisibility();
+            UpdateRemoteFilesSidebarEntryPointState();
+        }
+
+        private void CloseRemoteFilesSidebar()
+        {
+            _remoteFilesSidebarViewModel?.Close();
+            UpdateRemoteFilesSidebarVisibility();
+            UpdateRemoteFilesSidebarEntryPointState();
+        }
+
+        private void RequestRemoteFilesSidebarDownload()
+        {
+            if (_remoteFilesSidebarViewModel?.SelectedEntry is not { } selectedEntry)
+            {
+                return;
+            }
+
+            TransferKind kind = selectedEntry.IsDirectory
+                ? TransferKind.Folder
+                : TransferKind.File;
+            RequestSftpTransfer?.Invoke(this, TransferDirection.Download, kind);
         }
 
         private void InitializeCommandAssist()
@@ -847,7 +1048,14 @@ namespace NovaTerminal.Controls
 
         private void OnBufferScreenSwitched(bool isAltScreen)
         {
-            Dispatcher.UIThread.Post(() => _commandAssistController?.HandleAltScreenChanged(isAltScreen));
+            Dispatcher.UIThread.Post(() => HandleAltScreenChanged(isAltScreen));
+        }
+
+        private void HandleAltScreenChanged(bool isAltScreen)
+        {
+            _commandAssistController?.HandleAltScreenChanged(isAltScreen);
+            UpdateRemoteFilesSidebarVisibility();
+            UpdateRemoteFilesSidebarEntryPointState();
         }
 
         private void OnCommandAssistEnterObserved()
@@ -892,6 +1100,8 @@ namespace NovaTerminal.Controls
 
         private void UpdatePaneContextMenuState()
         {
+            UpdateRemoteFilesSidebarEntryPointState();
+
             if (RootGrid.ContextMenu?.Items is not IEnumerable<object> items)
             {
                 return;
@@ -1042,9 +1252,7 @@ namespace NovaTerminal.Controls
                 _shellLifecycleTracker?.HandleWorkingDirectoryChanged(cwd);
                 Dispatcher.UIThread.Post(() =>
                 {
-                    CurrentWorkingDirectory = cwd;
-                    UpdateCommandAssistContext();
-                    WorkingDirectoryChanged?.Invoke(this, cwd);
+                    HandleWorkingDirectoryChanged(cwd);
                 });
             };
             Parser.OnTitleChanged += title =>
@@ -1109,6 +1317,8 @@ namespace NovaTerminal.Controls
             {
                 RootGrid.ContextMenu = null;
             }
+
+            UpdateRemoteFilesSidebarEntryPointState();
 
             string startingDir = profile?.StartingDirectory ?? "";
             Session = null;
@@ -1231,6 +1441,14 @@ namespace NovaTerminal.Controls
                     Parser.CellHeight = ch;
                 }
             };
+        }
+
+        private void HandleWorkingDirectoryChanged(string cwd)
+        {
+            CurrentWorkingDirectory = cwd;
+            UpdateCommandAssistContext();
+            UpdateRemoteFilesSidebarCurrentDirectoryState();
+            WorkingDirectoryChanged?.Invoke(this, cwd);
         }
 
 
@@ -1575,6 +1793,8 @@ namespace NovaTerminal.Controls
 
         public void Reconnect()
         {
+            CloseRemoteFilesSidebar();
+
             if (Session != null)
             {
                 ITerminalSession session = Session;
@@ -1596,6 +1816,77 @@ namespace NovaTerminal.Controls
             return session == null || !session.IsProcessRunning;
         }
 
+        internal void ConfigureRemoteFilesSidebarForTest(IRemoteDirectoryBrowserService directoryBrowserService)
+        {
+            _isRemoteFilesSidebarTestServiceConfigured = true;
+            SetRemoteFilesSidebarService(directoryBrowserService);
+            UpdateRemoteFilesSidebarCurrentDirectoryState();
+            UpdateRemoteFilesSidebarVisibility();
+            UpdateRemoteFilesSidebarEntryPointState();
+        }
+
+        internal void ShowRemoteFilesSidebarForTest()
+        {
+            if (!_isRemoteFilesSidebarTestServiceConfigured)
+            {
+                ConfigureRemoteFilesSidebarForTest(new TestRemoteDirectoryBrowserService());
+            }
+
+            if (!IsRemoteFilesSidebarSupported())
+            {
+                Profile = new TerminalProfile
+                {
+                    Name = "Test Native SSH",
+                    Type = ConnectionType.SSH,
+                    SshBackendKind = SshBackendKind.Native,
+                    SshHost = "test.example",
+                    SshUser = "nova"
+                };
+            }
+
+            OpenRemoteFilesSidebarAsync(Profile?.Id ?? Guid.NewGuid(), Session?.Id ?? Guid.NewGuid())
+                .GetAwaiter()
+                .GetResult();
+        }
+
+        internal void HandleAltScreenChangedForTest(bool isAltScreen)
+        {
+            if (Buffer != null)
+            {
+                FieldInfo? field = typeof(TerminalBuffer).GetField("_isAltScreen", BindingFlags.Instance | BindingFlags.NonPublic);
+                field?.SetValue(Buffer, isAltScreen);
+            }
+
+            HandleAltScreenChanged(isAltScreen);
+        }
+
+        internal void HandleWorkingDirectoryChangedForTest(string cwd)
+        {
+            HandleWorkingDirectoryChanged(cwd);
+        }
+
+        internal bool IsRemoteFilesSidebarVisibleForTest()
+        {
+            return RemoteFilesSidebarHost?.IsVisible == true;
+        }
+
+        internal bool IsRemoteFilesSidebarEntryAvailableForTest()
+        {
+            UpdateRemoteFilesSidebarEntryPointState();
+            return MenuToggleRemoteFilesSidebar?.IsVisible == true &&
+                   MenuToggleRemoteFilesSidebar.IsEnabled;
+        }
+
+        internal string GetRemoteFilesSidebarCurrentPathForTest()
+        {
+            return _remoteFilesSidebarViewModel?.CurrentPath ?? string.Empty;
+        }
+
+        internal string? GetRemoteFilesSidebarJumpTargetForTest()
+        {
+            return _remoteFilesSidebarViewModel?.JumpToCurrentDirectoryPath;
+        }
+
         internal void HandleSessionExitForTesting(int code)
         {
             HandleSessionExit(Session, code);
@@ -1612,6 +1903,7 @@ namespace NovaTerminal.Controls
 
             if (Profile?.Type == ConnectionType.SSH)
             {
+                CloseRemoteFilesSidebar();
                 WriteSshDisconnectedBanner(code);
             }
 
@@ -1654,6 +1946,8 @@ namespace NovaTerminal.Controls
 
         public void Dispose()
         {
+            CloseRemoteFilesSidebar();
+
             if (Buffer != null)
             {
                 Buffer.OnScreenSwitched -= OnBufferScreenSwitched;
@@ -2030,5 +2324,20 @@ namespace NovaTerminal.Controls
             double BubbleHeight,
             double PopupWidth,
             double PopupHeight);
+
+        private sealed class TestRemoteDirectoryBrowserService : IRemoteDirectoryBrowserService
+        {
+            public Task<RemoteSidebarListingResult> ListDirectoryAsync(
+                Guid profileId,
+                Guid sessionId,
+                string remotePath,
+                CancellationToken cancellationToken)
+            {
+                string resolvedPath = string.IsNullOrWhiteSpace(remotePath) ? "~" : remotePath;
+                return Task.FromResult(RemoteSidebarListingResult.Success(
+                    resolvedPath,
+                    Array.Empty<RemoteSidebarEntry>()));
+            }
+        }
     }
 }

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -45,6 +45,11 @@ namespace NovaTerminal.Controls
         Close
     }
 
+    public readonly record struct SidebarTransferRequest(
+        TransferDirection Direction,
+        TransferKind Kind,
+        string RemotePath);
+
     public partial class TerminalPane : UserControl, IDisposable
     {
         public ITerminalSession? Session { get; private set; }
@@ -56,6 +61,7 @@ namespace NovaTerminal.Controls
         public Guid PaneId { get; set; } = Guid.NewGuid();
 
         public event Action<TerminalPane, TransferDirection, TransferKind>? RequestSftpTransfer;
+        public event Action<TerminalPane, SidebarTransferRequest>? RequestRemoteFilesSidebarTransfer;
         public event Action<bool>? RecordingStateChanged;
         public event Action<TerminalPane, string>? WorkingDirectoryChanged;
         public event Action<TerminalPane, string>? TitleChanged;
@@ -418,17 +424,17 @@ namespace NovaTerminal.Controls
             {
                 if (RemoteFilesSidebarHost.FindControl<Button>("BtnUploadFile") is Button uploadFileButton)
                 {
-                    uploadFileButton.Click += (_, _) => RequestSftpTransfer?.Invoke(this, TransferDirection.Upload, TransferKind.File);
+                    uploadFileButton.Click += (_, _) => RequestRemoteFilesSidebarUploadForCurrentDirectory(TransferKind.File);
                 }
 
                 if (RemoteFilesSidebarHost.FindControl<Button>("BtnUploadFolder") is Button uploadFolderButton)
                 {
-                    uploadFolderButton.Click += (_, _) => RequestSftpTransfer?.Invoke(this, TransferDirection.Upload, TransferKind.Folder);
+                    uploadFolderButton.Click += (_, _) => RequestRemoteFilesSidebarUploadForCurrentDirectory(TransferKind.Folder);
                 }
 
                 if (RemoteFilesSidebarHost.FindControl<Button>("BtnDownloadSelected") is Button downloadSelectedButton)
                 {
-                    downloadSelectedButton.Click += (_, _) => RequestRemoteFilesSidebarDownload();
+                    downloadSelectedButton.Click += (_, _) => RequestRemoteFilesSidebarTransferForSelectedEntry();
                 }
             }
 
@@ -575,7 +581,7 @@ namespace NovaTerminal.Controls
             UpdateRemoteFilesSidebarEntryPointState();
         }
 
-        private void RequestRemoteFilesSidebarDownload()
+        private void RequestRemoteFilesSidebarTransferForSelectedEntry()
         {
             if (_remoteFilesSidebarViewModel?.SelectedEntry is not { } selectedEntry)
             {
@@ -585,7 +591,31 @@ namespace NovaTerminal.Controls
             TransferKind kind = selectedEntry.IsDirectory
                 ? TransferKind.Folder
                 : TransferKind.File;
-            RequestSftpTransfer?.Invoke(this, TransferDirection.Download, kind);
+            RequestRemoteFilesSidebarTransfer?.Invoke(
+                this,
+                new SidebarTransferRequest(
+                    TransferDirection.Download,
+                    kind,
+                    selectedEntry.FullPath));
+        }
+
+        private void RequestRemoteFilesSidebarUploadForCurrentDirectory(TransferKind kind)
+        {
+            string remoteDirectory = _remoteFilesSidebarViewModel?.CurrentPath
+                ?? CurrentWorkingDirectory
+                ?? Profile?.DefaultRemoteDir
+                ?? "~";
+            if (string.IsNullOrWhiteSpace(remoteDirectory))
+            {
+                return;
+            }
+
+            RequestRemoteFilesSidebarTransfer?.Invoke(
+                this,
+                new SidebarTransferRequest(
+                    TransferDirection.Upload,
+                    kind,
+                    remoteDirectory));
         }
 
         private void InitializeCommandAssist()

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -60,7 +60,6 @@ namespace NovaTerminal.Controls
         public TerminalProfile? Profile { get; private set; }
         public Guid PaneId { get; set; } = Guid.NewGuid();
 
-        public event Action<TerminalPane, TransferDirection, TransferKind>? RequestSftpTransfer;
         public event Action<TerminalPane, SidebarTransferRequest>? RequestRemoteFilesSidebarTransfer;
         public event Action<bool>? RecordingStateChanged;
         public event Action<TerminalPane, string>? WorkingDirectoryChanged;
@@ -186,6 +185,7 @@ namespace NovaTerminal.Controls
             Profile = profile;
             TermView.ShellOverride = profile.ShellOverride;
             UpdateCommandAssistContext();
+            UpdateRemoteFilesSidebarHostIdentity();
             if (!IsRemoteFilesSidebarSupported())
             {
                 CloseRemoteFilesSidebar();
@@ -375,18 +375,6 @@ namespace NovaTerminal.Controls
             {
                 contextMenu.Opening += (_, _) => UpdatePaneContextMenuState();
 
-                var sftpMenu = contextMenu.Items.OfType<MenuItem>().FirstOrDefault(m => (string?)m.Header == "SFTP");
-                if (sftpMenu != null)
-                {
-                    foreach (var sub in sftpMenu.Items.OfType<MenuItem>())
-                    {
-                        if (sub.Name == "MenuUploadFile") sub.Click += (s, e) => RequestSftpTransfer?.Invoke(this, TransferDirection.Upload, TransferKind.File);
-                        if (sub.Name == "MenuUploadFolder") sub.Click += (s, e) => RequestSftpTransfer?.Invoke(this, TransferDirection.Upload, TransferKind.Folder);
-                        if (sub.Name == "MenuDownloadFile") sub.Click += (s, e) => RequestSftpTransfer?.Invoke(this, TransferDirection.Download, TransferKind.File);
-                        if (sub.Name == "MenuDownloadFolder") sub.Click += (s, e) => RequestSftpTransfer?.Invoke(this, TransferDirection.Download, TransferKind.Folder);
-                    }
-                }
-
                 var paneMenu = contextMenu.Items.OfType<MenuItem>().FirstOrDefault(m => (string?)m.Header == "Pane");
                 if (paneMenu != null)
                 {
@@ -438,6 +426,7 @@ namespace NovaTerminal.Controls
                 }
             }
 
+            UpdateRemoteFilesSidebarHostIdentity();
             UpdateRemoteFilesSidebarCurrentDirectoryState();
             UpdateRemoteFilesSidebarVisibility();
             UpdateRemoteFilesSidebarEntryPointState();
@@ -460,6 +449,8 @@ namespace NovaTerminal.Controls
             {
                 RemoteFilesSidebarHost.DataContext = _remoteFilesSidebarViewModel;
             }
+
+            UpdateRemoteFilesSidebarHostIdentity();
         }
 
         private void OnRemoteFilesSidebarViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -505,6 +496,38 @@ namespace NovaTerminal.Controls
                 _remoteFilesSidebarViewModel?.IsOpen == true &&
                 !(Buffer?.IsAltScreenActive ?? false) &&
                 IsRemoteFilesSidebarSupported();
+        }
+
+        private void UpdateRemoteFilesSidebarHostIdentity()
+        {
+            RemoteFilesSidebarHost?.SetHostIdentity(
+                string.IsNullOrWhiteSpace(Profile?.Name) ? null : Profile.Name,
+                BuildRemoteFilesSidebarSubtitle(Profile));
+        }
+
+        private static string? BuildRemoteFilesSidebarSubtitle(TerminalProfile? profile)
+        {
+            if (profile?.Type != ConnectionType.SSH)
+            {
+                return null;
+            }
+
+            string host = profile.SshHost?.Trim() ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(host))
+            {
+                return null;
+            }
+
+            string subtitle = string.IsNullOrWhiteSpace(profile.SshUser)
+                ? host
+                : $"{profile.SshUser.Trim()}@{host}";
+
+            if (profile.SshPort > 0 && profile.SshPort != 22)
+            {
+                subtitle = $"{subtitle}:{profile.SshPort}";
+            }
+
+            return subtitle;
         }
 
         private void UpdateRemoteFilesSidebarCurrentDirectoryState()
@@ -1908,6 +1931,26 @@ namespace NovaTerminal.Controls
             UpdateRemoteFilesSidebarEntryPointState();
             return MenuToggleRemoteFilesSidebar?.IsVisible == true &&
                    MenuToggleRemoteFilesSidebar.IsEnabled;
+        }
+
+        internal IReadOnlyList<string> GetSftpContextMenuItemNamesForTest()
+        {
+            if (RootGrid.ContextMenu?.Items is not IEnumerable<object> items)
+            {
+                return Array.Empty<string>();
+            }
+
+            MenuItem? sftpMenu = items.OfType<MenuItem>().FirstOrDefault(m => (string?)m.Header == "SFTP");
+            if (sftpMenu?.Items is null)
+            {
+                return Array.Empty<string>();
+            }
+
+            return sftpMenu.Items
+                .OfType<MenuItem>()
+                .Select(item => item.Name ?? string.Empty)
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .ToArray();
         }
 
         internal string GetRemoteFilesSidebarCurrentPathForTest()

--- a/src/NovaTerminal.App/Controls/TransferDialog.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TransferDialog.axaml.cs
@@ -73,6 +73,12 @@ public partial class TransferDialog : Window
 
     private void OnOpened(object? sender, EventArgs e)
     {
+        if (_request.PreferLocalPathOnOpen)
+        {
+            _localPathBox.Focus();
+            return;
+        }
+
         _remotePathInput.FocusTextBox();
     }
 

--- a/src/NovaTerminal.App/Core/TerminalProfile.cs
+++ b/src/NovaTerminal.App/Core/TerminalProfile.cs
@@ -64,6 +64,7 @@ namespace NovaTerminal.Core
         public string SshUser { get; set; } = "";
         public string SshKeyPath { get; set; } = "";
         public SshBackendKind SshBackendKind { get; set; } = SshBackendKind.OpenSsh;
+        public RemoteShellKind RemoteShellKind { get; set; } = RemoteShellKind.Auto;
 
         public ShellOverride ShellOverride { get; set; } = ShellOverride.Auto;
 

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -2167,7 +2167,6 @@ namespace NovaTerminal
         private void WirePane(TerminalPane pane)
         {
             pane.SshInteractionHandler = _sshInteractionService;
-            pane.RequestSftpTransfer -= OnPaneRequestSftpTransfer;
             pane.RequestRemoteFilesSidebarTransfer -= OnPaneRequestRemoteFilesSidebarTransfer;
             pane.WorkingDirectoryChanged -= OnPaneWorkingDirectoryChanged;
             pane.TitleChanged -= OnPaneTitleChanged;
@@ -2178,7 +2177,6 @@ namespace NovaTerminal
             pane.CommandFinished -= OnPaneCommandFinished;
             pane.ProcessExited -= OnPaneProcessExited;
 
-            pane.RequestSftpTransfer += OnPaneRequestSftpTransfer;
             pane.RequestRemoteFilesSidebarTransfer += OnPaneRequestRemoteFilesSidebarTransfer;
             pane.WorkingDirectoryChanged += OnPaneWorkingDirectoryChanged;
             pane.TitleChanged += OnPaneTitleChanged;
@@ -2192,7 +2190,6 @@ namespace NovaTerminal
 
         private void UnwirePane(TerminalPane pane)
         {
-            pane.RequestSftpTransfer -= OnPaneRequestSftpTransfer;
             pane.RequestRemoteFilesSidebarTransfer -= OnPaneRequestRemoteFilesSidebarTransfer;
             pane.WorkingDirectoryChanged -= OnPaneWorkingDirectoryChanged;
             pane.TitleChanged -= OnPaneTitleChanged;
@@ -2202,11 +2199,6 @@ namespace NovaTerminal
             pane.CommandStarted -= OnPaneCommandStarted;
             pane.CommandFinished -= OnPaneCommandFinished;
             pane.ProcessExited -= OnPaneProcessExited;
-        }
-
-        private void OnPaneRequestSftpTransfer(TerminalPane srcPane, TransferDirection direction, TransferKind kind)
-        {
-            _ = InitiateSftpTransfer(srcPane, direction, kind);
         }
 
         private void OnPaneRequestRemoteFilesSidebarTransfer(TerminalPane srcPane, SidebarTransferRequest request)
@@ -3717,15 +3709,10 @@ namespace NovaTerminal
                 return;
             }
 
-            var request = TransferDialogRequest.ForSidebarAction(
-                direction,
-                kind,
-                remotePath,
-                profile.Id,
-                sessionId);
-
-            TransferDialogResult? result = await ShowTransferDialogAsync(request);
-            if (result is not { IsConfirmed: true })
+            string? localDownloadPath = kind == TransferKind.File
+                ? await PickLocalDownloadFilePathAsync(ResolveSuggestedDownloadFileName(remotePath))
+                : await PickLocalDownloadFolderPathAsync();
+            if (string.IsNullOrWhiteSpace(localDownloadPath))
             {
                 return;
             }
@@ -3737,8 +3724,8 @@ namespace NovaTerminal
                 ProfileName = profile.Name,
                 Direction = direction,
                 Kind = kind,
-                LocalPath = result.LocalPath,
-                RemotePath = result.RemotePath
+                LocalPath = localDownloadPath,
+                RemotePath = remotePath
             };
 
             EnqueueTransferJob(job);
@@ -3784,10 +3771,58 @@ namespace NovaTerminal
             return folders.Count > 0 ? folders[0].Path.LocalPath : null;
         }
 
+        internal virtual async Task<string?> PickLocalDownloadFilePathAsync(string suggestedFileName)
+        {
+            TopLevel? topLevel = TopLevel.GetTopLevel(this);
+            if (topLevel?.StorageProvider == null)
+            {
+                return null;
+            }
+
+            IStorageFile? file = await topLevel.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            {
+                Title = "Select Local Destination",
+                SuggestedFileName = suggestedFileName
+            });
+
+            return file?.Path.LocalPath;
+        }
+
+        internal virtual async Task<string?> PickLocalDownloadFolderPathAsync()
+        {
+            TopLevel? topLevel = TopLevel.GetTopLevel(this);
+            if (topLevel?.StorageProvider == null)
+            {
+                return null;
+            }
+
+            IReadOnlyList<IStorageFolder> folders = await topLevel.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+            {
+                Title = "Select Local Destination Folder",
+                AllowMultiple = false
+            });
+
+            return folders.Count > 0 ? folders[0].Path.LocalPath : null;
+        }
+
         internal virtual void EnqueueTransferJob(TransferJob job)
         {
             SftpService.Instance.AddJob(job);
             ShowTransferCenter();
+        }
+
+        private static string ResolveSuggestedDownloadFileName(string remotePath)
+        {
+            string trimmed = remotePath.Trim().TrimEnd('/', '\\');
+            if (string.IsNullOrWhiteSpace(trimmed))
+            {
+                return "download";
+            }
+
+            string fileName = Path.GetFileName(trimmed);
+            return string.IsNullOrWhiteSpace(fileName)
+                ? "download"
+                : fileName;
         }
 
         private void InitializeCommandPaletteUI()

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -2168,6 +2168,7 @@ namespace NovaTerminal
         {
             pane.SshInteractionHandler = _sshInteractionService;
             pane.RequestSftpTransfer -= OnPaneRequestSftpTransfer;
+            pane.RequestRemoteFilesSidebarTransfer -= OnPaneRequestRemoteFilesSidebarTransfer;
             pane.WorkingDirectoryChanged -= OnPaneWorkingDirectoryChanged;
             pane.TitleChanged -= OnPaneTitleChanged;
             pane.PaneActionRequested -= OnPaneActionRequested;
@@ -2178,6 +2179,7 @@ namespace NovaTerminal
             pane.ProcessExited -= OnPaneProcessExited;
 
             pane.RequestSftpTransfer += OnPaneRequestSftpTransfer;
+            pane.RequestRemoteFilesSidebarTransfer += OnPaneRequestRemoteFilesSidebarTransfer;
             pane.WorkingDirectoryChanged += OnPaneWorkingDirectoryChanged;
             pane.TitleChanged += OnPaneTitleChanged;
             pane.PaneActionRequested += OnPaneActionRequested;
@@ -2191,6 +2193,7 @@ namespace NovaTerminal
         private void UnwirePane(TerminalPane pane)
         {
             pane.RequestSftpTransfer -= OnPaneRequestSftpTransfer;
+            pane.RequestRemoteFilesSidebarTransfer -= OnPaneRequestRemoteFilesSidebarTransfer;
             pane.WorkingDirectoryChanged -= OnPaneWorkingDirectoryChanged;
             pane.TitleChanged -= OnPaneTitleChanged;
             pane.PaneActionRequested -= OnPaneActionRequested;
@@ -2204,6 +2207,11 @@ namespace NovaTerminal
         private void OnPaneRequestSftpTransfer(TerminalPane srcPane, TransferDirection direction, TransferKind kind)
         {
             _ = InitiateSftpTransfer(srcPane, direction, kind);
+        }
+
+        private void OnPaneRequestRemoteFilesSidebarTransfer(TerminalPane srcPane, SidebarTransferRequest request)
+        {
+            _ = InitiateSidebarSftpTransfer(srcPane, request.Direction, request.Kind, request.RemotePath);
         }
 
         private void OnPaneWorkingDirectoryChanged(TerminalPane srcPane, string cwd)
@@ -3595,6 +3603,36 @@ namespace NovaTerminal
             return InitiateSftpTransferAsync(profile, sessionId, direction, kind);
         }
 
+        internal Task StartSidebarDownloadForTest(
+            TerminalProfile profile,
+            Guid sessionId,
+            string selectedRemotePath,
+            TransferKind kind)
+        {
+            ArgumentNullException.ThrowIfNull(profile);
+            return InitiateSidebarSftpTransferAsync(
+                profile,
+                sessionId,
+                TransferDirection.Download,
+                kind,
+                selectedRemotePath);
+        }
+
+        internal Task StartSidebarUploadForTest(
+            TerminalProfile profile,
+            Guid sessionId,
+            string remoteDirectory,
+            TransferKind kind)
+        {
+            ArgumentNullException.ThrowIfNull(profile);
+            return InitiateSidebarSftpTransferAsync(
+                profile,
+                sessionId,
+                TransferDirection.Upload,
+                kind,
+                remoteDirectory);
+        }
+
         private async Task InitiateSftpTransferAsync(
             TerminalProfile profile,
             Guid sessionId,
@@ -3605,6 +3643,59 @@ namespace NovaTerminal
                 direction,
                 kind,
                 profile.DefaultRemoteDir ?? "~",
+                profile.Id,
+                sessionId);
+
+            TransferDialogResult? result = await ShowTransferDialogAsync(request);
+            if (result is not { IsConfirmed: true })
+            {
+                return;
+            }
+
+            var job = new TransferJob
+            {
+                SessionId = sessionId,
+                ProfileId = profile.Id,
+                ProfileName = profile.Name,
+                Direction = direction,
+                Kind = kind,
+                LocalPath = result.LocalPath,
+                RemotePath = result.RemotePath
+            };
+
+            EnqueueTransferJob(job);
+        }
+
+        private Task InitiateSidebarSftpTransfer(
+            TerminalPane srcPane,
+            TransferDirection direction,
+            TransferKind kind,
+            string remotePath)
+        {
+            if (srcPane.Profile == null || srcPane.Session == null)
+            {
+                return Task.CompletedTask;
+            }
+
+            return InitiateSidebarSftpTransferAsync(
+                srcPane.Profile,
+                srcPane.Session.Id,
+                direction,
+                kind,
+                remotePath);
+        }
+
+        private async Task InitiateSidebarSftpTransferAsync(
+            TerminalProfile profile,
+            Guid sessionId,
+            TransferDirection direction,
+            TransferKind kind,
+            string remotePath)
+        {
+            var request = TransferDialogRequest.ForSidebarAction(
+                direction,
+                kind,
+                remotePath,
                 profile.Id,
                 sessionId);
 

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -3515,6 +3515,7 @@ namespace NovaTerminal
             }, "");
 
             // SFTP Actions
+            CommandRegistry.Register("SFTP: Toggle Remote Files", "Remote", () => _currentPane?.ToggleRemoteFilesSidebar(), "");
             CommandRegistry.Register("SFTP: Upload File...", "Remote", () => _ = InitiateSftpTransfer(null, TransferDirection.Upload, TransferKind.File), "");
             CommandRegistry.Register("SFTP: Upload Folder...", "Remote", () => _ = InitiateSftpTransfer(null, TransferDirection.Upload, TransferKind.Folder), "");
             CommandRegistry.Register("SFTP: Download File...", "Remote", () => _ = InitiateSftpTransfer(null, TransferDirection.Download, TransferKind.File), "");

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -3692,6 +3692,31 @@ namespace NovaTerminal
             TransferKind kind,
             string remotePath)
         {
+            if (direction == TransferDirection.Upload)
+            {
+                string? localPath = kind == TransferKind.File
+                    ? await PickLocalUploadFilePathAsync()
+                    : await PickLocalUploadFolderPathAsync();
+                if (string.IsNullOrWhiteSpace(localPath))
+                {
+                    return;
+                }
+
+                var uploadJob = new TransferJob
+                {
+                    SessionId = sessionId,
+                    ProfileId = profile.Id,
+                    ProfileName = profile.Name,
+                    Direction = direction,
+                    Kind = kind,
+                    LocalPath = localPath,
+                    RemotePath = remotePath
+                };
+
+                EnqueueTransferJob(uploadJob);
+                return;
+            }
+
             var request = TransferDialogRequest.ForSidebarAction(
                 direction,
                 kind,
@@ -3723,6 +3748,40 @@ namespace NovaTerminal
         {
             var dialog = new TransferDialog(request);
             return await dialog.ShowDialog<TransferDialogResult?>(this);
+        }
+
+        internal virtual async Task<string?> PickLocalUploadFilePathAsync()
+        {
+            TopLevel? topLevel = TopLevel.GetTopLevel(this);
+            if (topLevel?.StorageProvider == null)
+            {
+                return null;
+            }
+
+            IReadOnlyList<IStorageFile> files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+            {
+                Title = "Select File to Upload",
+                AllowMultiple = false
+            });
+
+            return files.Count > 0 ? files[0].Path.LocalPath : null;
+        }
+
+        internal virtual async Task<string?> PickLocalUploadFolderPathAsync()
+        {
+            TopLevel? topLevel = TopLevel.GetTopLevel(this);
+            if (topLevel?.StorageProvider == null)
+            {
+                return null;
+            }
+
+            IReadOnlyList<IStorageFolder> folders = await topLevel.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+            {
+                Title = "Select Folder to Upload",
+                AllowMultiple = false
+            });
+
+            return folders.Count > 0 ? folders[0].Path.LocalPath : null;
         }
 
         internal virtual void EnqueueTransferJob(TransferJob job)

--- a/src/NovaTerminal.App/Models/RemoteSidebarEntry.cs
+++ b/src/NovaTerminal.App/Models/RemoteSidebarEntry.cs
@@ -1,0 +1,6 @@
+namespace NovaTerminal.Models;
+
+public sealed record RemoteSidebarEntry(
+    string Name,
+    string FullPath,
+    bool IsDirectory);

--- a/src/NovaTerminal.App/Models/RemoteSidebarEntry.cs
+++ b/src/NovaTerminal.App/Models/RemoteSidebarEntry.cs
@@ -1,6 +1,24 @@
+using System;
+
 namespace NovaTerminal.Models;
 
 public sealed record RemoteSidebarEntry(
     string Name,
     string FullPath,
-    bool IsDirectory);
+    bool IsDirectory)
+{
+    public DateTime? ModifiedAtUtc { get; init; }
+
+    public bool Equals(RemoteSidebarEntry? other)
+    {
+        return other is not null &&
+            string.Equals(Name, other.Name, StringComparison.Ordinal) &&
+            string.Equals(FullPath, other.FullPath, StringComparison.Ordinal) &&
+            IsDirectory == other.IsDirectory;
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Name, FullPath, IsDirectory);
+    }
+}

--- a/src/NovaTerminal.App/Models/RemoteSidebarListingResult.cs
+++ b/src/NovaTerminal.App/Models/RemoteSidebarListingResult.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NovaTerminal.Models;
 
@@ -29,9 +30,11 @@ public sealed class RemoteSidebarListingResult
         ArgumentException.ThrowIfNullOrWhiteSpace(resolvedPath);
         ArgumentNullException.ThrowIfNull(entries);
 
+        RemoteSidebarEntry[] snapshot = entries.ToArray();
+
         return new RemoteSidebarListingResult(
             resolvedPath,
-            entries,
+            snapshot,
             isSuccess: true,
             errorMessage: null);
     }

--- a/src/NovaTerminal.App/Models/RemoteSidebarListingResult.cs
+++ b/src/NovaTerminal.App/Models/RemoteSidebarListingResult.cs
@@ -1,9 +1,52 @@
+using System;
 using System.Collections.Generic;
 
 namespace NovaTerminal.Models;
 
-public sealed record RemoteSidebarListingResult(
-    string ResolvedPath,
-    IReadOnlyList<RemoteSidebarEntry> Entries,
-    bool IsSuccess,
-    string? ErrorMessage);
+public sealed class RemoteSidebarListingResult
+{
+    private RemoteSidebarListingResult(
+        string resolvedPath,
+        IReadOnlyList<RemoteSidebarEntry> entries,
+        bool isSuccess,
+        string? errorMessage)
+    {
+        ResolvedPath = resolvedPath;
+        Entries = entries;
+        IsSuccess = isSuccess;
+        ErrorMessage = errorMessage;
+    }
+
+    public string ResolvedPath { get; }
+    public IReadOnlyList<RemoteSidebarEntry> Entries { get; }
+    public bool IsSuccess { get; }
+    public string? ErrorMessage { get; }
+
+    public static RemoteSidebarListingResult Success(
+        string resolvedPath,
+        IReadOnlyList<RemoteSidebarEntry> entries)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(resolvedPath);
+        ArgumentNullException.ThrowIfNull(entries);
+
+        return new RemoteSidebarListingResult(
+            resolvedPath,
+            entries,
+            isSuccess: true,
+            errorMessage: null);
+    }
+
+    public static RemoteSidebarListingResult Failure(
+        string resolvedPath,
+        string errorMessage)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(resolvedPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
+
+        return new RemoteSidebarListingResult(
+            resolvedPath,
+            Array.Empty<RemoteSidebarEntry>(),
+            isSuccess: false,
+            errorMessage: errorMessage);
+    }
+}

--- a/src/NovaTerminal.App/Models/RemoteSidebarListingResult.cs
+++ b/src/NovaTerminal.App/Models/RemoteSidebarListingResult.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace NovaTerminal.Models;
+
+public sealed record RemoteSidebarListingResult(
+    string ResolvedPath,
+    IReadOnlyList<RemoteSidebarEntry> Entries,
+    bool IsSuccess,
+    string? ErrorMessage);

--- a/src/NovaTerminal.App/Models/TransferDialogRequest.cs
+++ b/src/NovaTerminal.App/Models/TransferDialogRequest.cs
@@ -10,6 +10,7 @@ public sealed class TransferDialogRequest
     public string RemotePath { get; init; } = string.Empty;
     public Guid ProfileId { get; init; }
     public Guid SessionId { get; init; }
+    public bool PreferLocalPathOnOpen { get; init; }
 
     public static TransferDialogRequest ForAction(
         TransferDirection direction,
@@ -24,7 +25,26 @@ public sealed class TransferDialogRequest
             Kind = kind,
             RemotePath = defaultRemotePath,
             ProfileId = profileId,
-            SessionId = sessionId
+            SessionId = sessionId,
+            PreferLocalPathOnOpen = false
+        };
+    }
+
+    public static TransferDialogRequest ForSidebarAction(
+        TransferDirection direction,
+        TransferKind kind,
+        string remotePath,
+        Guid profileId,
+        Guid sessionId)
+    {
+        return new TransferDialogRequest
+        {
+            Direction = direction,
+            Kind = kind,
+            RemotePath = remotePath,
+            ProfileId = profileId,
+            SessionId = sessionId,
+            PreferLocalPathOnOpen = true
         };
     }
 }

--- a/src/NovaTerminal.App/Models/TransferDialogRequest.cs
+++ b/src/NovaTerminal.App/Models/TransferDialogRequest.cs
@@ -29,22 +29,4 @@ public sealed class TransferDialogRequest
             PreferLocalPathOnOpen = false
         };
     }
-
-    public static TransferDialogRequest ForSidebarAction(
-        TransferDirection direction,
-        TransferKind kind,
-        string remotePath,
-        Guid profileId,
-        Guid sessionId)
-    {
-        return new TransferDialogRequest
-        {
-            Direction = direction,
-            Kind = kind,
-            RemotePath = remotePath,
-            ProfileId = profileId,
-            SessionId = sessionId,
-            PreferLocalPathOnOpen = true
-        };
-    }
 }

--- a/src/NovaTerminal.App/Services/Ssh/ActiveSshSessionRegistry.cs
+++ b/src/NovaTerminal.App/Services/Ssh/ActiveSshSessionRegistry.cs
@@ -20,9 +20,23 @@ public sealed class ActiveSshSessionRegistry
 
     public bool TryGet(Guid sessionId, out ActiveSshSessionDescriptor? descriptor)
     {
-        bool found = _sessions.TryGetValue(sessionId, out ActiveSshSessionDescriptor stored);
+        bool found = _sessions.TryGetValue(sessionId, out ActiveSshSessionDescriptor? stored);
         descriptor = found ? stored : null;
         return found;
+    }
+
+    public bool TryGetActiveNativeSession(Guid profileId, Guid sessionId, out ActiveSshSessionDescriptor? descriptor)
+    {
+        if (!TryGet(sessionId, out descriptor) ||
+            descriptor is null ||
+            descriptor.ProfileId != profileId ||
+            descriptor.BackendKind != SshBackendKind.Native)
+        {
+            descriptor = null;
+            return false;
+        }
+
+        return true;
     }
 
     public void Unregister(Guid sessionId)

--- a/src/NovaTerminal.App/Services/Ssh/IRemoteDirectoryBrowserService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/IRemoteDirectoryBrowserService.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NovaTerminal.Models;
+
+namespace NovaTerminal.Services.Ssh;
+
+public interface IRemoteDirectoryBrowserService
+{
+    Task<RemoteSidebarListingResult> ListDirectoryAsync(
+        Guid profileId,
+        Guid sessionId,
+        string remotePath,
+        CancellationToken cancellationToken);
+}

--- a/src/NovaTerminal.App/Services/Ssh/RemoteDirectoryBrowserService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/RemoteDirectoryBrowserService.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NovaTerminal.Core;
+using NovaTerminal.Core.Ssh.Models;
+using NovaTerminal.Core.Ssh.Native;
+using NovaTerminal.Core.Ssh.Storage;
+using NovaTerminal.Models;
+
+namespace NovaTerminal.Services.Ssh;
+
+public sealed class RemoteDirectoryBrowserService : IRemoteDirectoryBrowserService
+{
+    private const string InactiveSessionErrorMessage = "Remote directory listing requires an active native SSH session.";
+    private const string MissingProfileErrorMessage = "The SSH connection profile could not be loaded for remote directory listing.";
+    private const string UnsupportedProfileErrorMessage = "Remote directory listing requires a native SSH profile.";
+    private const string ListingFailedErrorMessage = "Unable to list the remote directory.";
+
+    private readonly INativeSshInterop _nativeInterop;
+    private readonly ActiveSshSessionRegistry _sessionRegistry;
+    private readonly Func<SshConnectionService> _sshServiceFactory;
+    private readonly Func<TerminalProfile, string?> _passwordResolver;
+
+    public RemoteDirectoryBrowserService(
+        INativeSshInterop? nativeInterop = null,
+        ActiveSshSessionRegistry? sessionRegistry = null,
+        Func<SshConnectionService>? sshServiceFactory = null,
+        Func<TerminalProfile, string?>? passwordResolver = null)
+    {
+        _nativeInterop = nativeInterop ?? new NativeSshInterop();
+        _sessionRegistry = sessionRegistry ?? ActiveSshSessionRegistry.Instance;
+        _sshServiceFactory = sshServiceFactory ?? (() => new SshConnectionService());
+        _passwordResolver = passwordResolver ?? (profile => new VaultService().GetSshPasswordForProfile(profile));
+    }
+
+    public async Task<RemoteSidebarListingResult> ListDirectoryAsync(
+        Guid profileId,
+        Guid sessionId,
+        string remotePath,
+        CancellationToken cancellationToken)
+    {
+        string resolvedPath = NormalizeRemotePath(remotePath);
+
+        if (!TryCreateNativeListingConnection(
+                profileId,
+                sessionId,
+                _sessionRegistry,
+                _sshServiceFactory,
+                _passwordResolver,
+                out NativeSshConnectionOptions? connectionOptions,
+                out string errorMessage))
+        {
+            return RemoteSidebarListingResult.Failure(resolvedPath, errorMessage);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        try
+        {
+            IReadOnlyList<NativeRemotePathEntry> entries = await BackgroundWork.RunBlockingAsync(
+                token => _nativeInterop.ListRemoteDirectory(connectionOptions!, resolvedPath, token),
+                cancellationToken);
+
+            RemoteSidebarEntry[] mappedEntries = entries
+                .OrderBy(entry => entry.IsDirectory ? 0 : 1)
+                .ThenBy(entry => entry.Name, StringComparer.OrdinalIgnoreCase)
+                .Select(entry => new RemoteSidebarEntry(entry.Name, entry.FullPath, entry.IsDirectory))
+                .ToArray();
+
+            return RemoteSidebarListingResult.Success(resolvedPath, mappedEntries);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return RemoteSidebarListingResult.Failure(resolvedPath, GetErrorMessage(ex, ListingFailedErrorMessage));
+        }
+    }
+
+    internal static bool TryCreateNativeListingConnection(
+        Guid profileId,
+        Guid sessionId,
+        ActiveSshSessionRegistry sessionRegistry,
+        Func<SshConnectionService> sshServiceFactory,
+        Func<TerminalProfile, string?> passwordResolver,
+        out NativeSshConnectionOptions? connectionOptions,
+        out string errorMessage)
+    {
+        ArgumentNullException.ThrowIfNull(sessionRegistry);
+        ArgumentNullException.ThrowIfNull(sshServiceFactory);
+        ArgumentNullException.ThrowIfNull(passwordResolver);
+
+        connectionOptions = null;
+        errorMessage = InactiveSessionErrorMessage;
+
+        if (profileId == Guid.Empty || sessionId == Guid.Empty ||
+            !sessionRegistry.TryGetActiveNativeSession(profileId, sessionId, out _))
+        {
+            return false;
+        }
+
+        try
+        {
+            SshConnectionService sshService = sshServiceFactory();
+            TerminalProfile? profile = sshService.GetConnectionProfile(profileId);
+            if (profile == null)
+            {
+                errorMessage = MissingProfileErrorMessage;
+                return false;
+            }
+
+            if (profile.SshBackendKind != SshBackendKind.Native)
+            {
+                errorMessage = UnsupportedProfileErrorMessage;
+                return false;
+            }
+
+            NativeSshConnectionOptions baseOptions = SftpService.BuildNativeTransferConnectionOptions(
+                sshService,
+                profile,
+                sshService.GetConnectionProfiles());
+            bool prefersIdentityFile = !string.IsNullOrWhiteSpace(baseOptions.IdentityFilePath);
+            string? resolvedPassword = prefersIdentityFile
+                ? null
+                : (sessionRegistry.TryGetRuntimePassword(sessionId, out string? runtimePassword)
+                    ? runtimePassword
+                    : passwordResolver(profile));
+
+            connectionOptions = new NativeSshConnectionOptions
+            {
+                Host = baseOptions.Host,
+                Port = baseOptions.Port,
+                User = baseOptions.User,
+                Cols = baseOptions.Cols,
+                Rows = baseOptions.Rows,
+                Term = baseOptions.Term,
+                Password = string.IsNullOrWhiteSpace(resolvedPassword) ? null : resolvedPassword,
+                IdentityFilePath = baseOptions.IdentityFilePath,
+                KnownHostsFilePath = string.IsNullOrWhiteSpace(baseOptions.KnownHostsFilePath)
+                    ? AppPaths.NativeKnownHostsFilePath
+                    : baseOptions.KnownHostsFilePath,
+                JumpHost = baseOptions.JumpHost == null
+                    ? null
+                    : new SshJumpHop
+                    {
+                        Host = baseOptions.JumpHost.Host,
+                        User = baseOptions.JumpHost.User,
+                        Port = baseOptions.JumpHost.Port
+                    }
+            };
+
+            errorMessage = string.Empty;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            errorMessage = GetErrorMessage(ex, ListingFailedErrorMessage);
+            return false;
+        }
+    }
+
+    private static string NormalizeRemotePath(string remotePath)
+    {
+        return string.IsNullOrWhiteSpace(remotePath)
+            ? "~"
+            : remotePath.Trim();
+    }
+
+    private static string GetErrorMessage(Exception ex, string fallback)
+    {
+        return string.IsNullOrWhiteSpace(ex.Message) ? fallback : ex.Message;
+    }
+}

--- a/src/NovaTerminal.App/Services/Ssh/RemoteDirectoryBrowserService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/RemoteDirectoryBrowserService.cs
@@ -138,6 +138,8 @@ public sealed class RemoteDirectoryBrowserService : IRemoteDirectoryBrowserServi
                 Cols = baseOptions.Cols,
                 Rows = baseOptions.Rows,
                 Term = baseOptions.Term,
+                KeepAliveIntervalSeconds = baseOptions.KeepAliveIntervalSeconds,
+                KeepAliveCountMax = baseOptions.KeepAliveCountMax,
                 Password = string.IsNullOrWhiteSpace(resolvedPassword) ? null : resolvedPassword,
                 IdentityFilePath = baseOptions.IdentityFilePath,
                 KnownHostsFilePath = string.IsNullOrWhiteSpace(baseOptions.KnownHostsFilePath)
@@ -165,9 +167,7 @@ public sealed class RemoteDirectoryBrowserService : IRemoteDirectoryBrowserServi
 
     private static string NormalizeRemotePath(string remotePath)
     {
-        return string.IsNullOrWhiteSpace(remotePath)
-            ? "~"
-            : remotePath.Trim();
+        return string.IsNullOrWhiteSpace(remotePath) ? "~" : remotePath;
     }
 
     private static string GetErrorMessage(Exception ex, string fallback)

--- a/src/NovaTerminal.App/Services/Ssh/RemoteDirectoryBrowserService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/RemoteDirectoryBrowserService.cs
@@ -66,7 +66,10 @@ public sealed class RemoteDirectoryBrowserService : IRemoteDirectoryBrowserServi
             RemoteSidebarEntry[] mappedEntries = entries
                 .OrderBy(entry => entry.IsDirectory ? 0 : 1)
                 .ThenBy(entry => entry.Name, StringComparer.OrdinalIgnoreCase)
-                .Select(entry => new RemoteSidebarEntry(entry.Name, entry.FullPath, entry.IsDirectory))
+                .Select(entry => new RemoteSidebarEntry(entry.Name, entry.FullPath, entry.IsDirectory)
+                {
+                    ModifiedAtUtc = entry.ModifiedAtUtc
+                })
                 .ToArray();
 
             return RemoteSidebarListingResult.Success(resolvedPath, mappedEntries);

--- a/src/NovaTerminal.App/Services/Ssh/RemotePathAutocompleteService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/RemotePathAutocompleteService.cs
@@ -42,61 +42,26 @@ public sealed class RemotePathAutocompleteService : IRemotePathAutocompleteServi
             return [];
         }
 
-        if (!_sessionRegistry.TryGet(sessionId, out ActiveSshSessionDescriptor? descriptor) ||
-            descriptor is null ||
-            descriptor.ProfileId != profileId ||
-            descriptor.BackendKind != SshBackendKind.Native)
-        {
-            return [];
-        }
-
         cancellationToken.ThrowIfCancellationRequested();
 
         try
         {
-            SshConnectionService sshService = _sshServiceFactory();
-            TerminalProfile? profile = sshService.GetConnectionProfile(profileId);
-            if (profile == null || profile.SshBackendKind != SshBackendKind.Native)
+            if (!RemoteDirectoryBrowserService.TryCreateNativeListingConnection(
+                    profileId,
+                    sessionId,
+                    _sessionRegistry,
+                    _sshServiceFactory,
+                    _passwordResolver,
+                    out NativeSshConnectionOptions? connectionOptions,
+                    out _))
             {
                 return [];
             }
 
             RemotePathAutocompleteQuery query = RemotePathAutocompleteQuery.Parse(input);
-            NativeSshConnectionOptions baseOptions = SftpService.BuildNativeTransferConnectionOptions(
-                sshService,
-                profile,
-                sshService.GetConnectionProfiles());
-            bool prefersIdentityFile = !string.IsNullOrWhiteSpace(baseOptions.IdentityFilePath);
-            string? resolvedPassword = prefersIdentityFile
-                ? null
-                : (_sessionRegistry.TryGetRuntimePassword(sessionId, out string? runtimePassword)
-                    ? runtimePassword
-                    : _passwordResolver(profile));
-            var connectionOptions = new NativeSshConnectionOptions
-            {
-                Host = baseOptions.Host,
-                Port = baseOptions.Port,
-                User = baseOptions.User,
-                Cols = baseOptions.Cols,
-                Rows = baseOptions.Rows,
-                Term = baseOptions.Term,
-                Password = string.IsNullOrWhiteSpace(resolvedPassword) ? null : resolvedPassword,
-                IdentityFilePath = baseOptions.IdentityFilePath,
-                KnownHostsFilePath = string.IsNullOrWhiteSpace(baseOptions.KnownHostsFilePath)
-                    ? AppPaths.NativeKnownHostsFilePath
-                    : baseOptions.KnownHostsFilePath,
-                JumpHost = baseOptions.JumpHost == null
-                    ? null
-                    : new SshJumpHop
-                    {
-                        Host = baseOptions.JumpHost.Host,
-                        User = baseOptions.JumpHost.User,
-                        Port = baseOptions.JumpHost.Port
-                    }
-            };
 
             IReadOnlyList<NativeRemotePathEntry> entries = await BackgroundWork.RunBlockingAsync(
-                token => _nativeInterop.ListRemoteDirectory(connectionOptions, query.ParentPath, token),
+                token => _nativeInterop.ListRemoteDirectory(connectionOptions!, query.ParentPath, token),
                 cancellationToken);
 
             return RemotePathAutocompleteQuery.Rank(

--- a/src/NovaTerminal.App/Services/Ssh/RemoteSidebarStartPathResolver.cs
+++ b/src/NovaTerminal.App/Services/Ssh/RemoteSidebarStartPathResolver.cs
@@ -1,0 +1,19 @@
+namespace NovaTerminal.Services.Ssh;
+
+public static class RemoteSidebarStartPathResolver
+{
+    public static string Resolve(string? currentWorkingDirectory, string? defaultRemoteDirectory)
+    {
+        if (!string.IsNullOrWhiteSpace(currentWorkingDirectory))
+        {
+            return currentWorkingDirectory.Trim();
+        }
+
+        if (!string.IsNullOrWhiteSpace(defaultRemoteDirectory))
+        {
+            return defaultRemoteDirectory.Trim();
+        }
+
+        return "~";
+    }
+}

--- a/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
@@ -127,6 +127,7 @@ public sealed class SshLaunchDetails
         candidate.AccentColor = profile.AccentColor?.Trim() ?? string.Empty;
         candidate.GroupPath = profile.Group?.Trim() ?? candidate.GroupPath;
         candidate.BackendKind = profile.SshBackendKind;
+        candidate.RemoteShellKind = profile.RemoteShellKind;
 
         bool favorite = profile.Tags?.Any(IsFavoriteTag) == true;
         candidate.Tags = NormalizeTags(profile.Tags, favorite);
@@ -324,6 +325,7 @@ public sealed class SshLaunchDetails
             SshUser = profile.User,
             SshPort = profile.Port > 0 ? profile.Port : 22,
             SshBackendKind = profile.BackendKind,
+            RemoteShellKind = profile.RemoteShellKind,
             UseSshAgent = !useIdentityFile,
             IdentityFilePath = useIdentityFile ? profile.IdentityFilePath : string.Empty,
             SshKeyPath = useIdentityFile ? profile.IdentityFilePath : string.Empty,
@@ -349,6 +351,7 @@ public sealed class SshLaunchDetails
             Notes = profile.Notes?.Trim() ?? string.Empty,
             AccentColor = profile.AccentColor?.Trim() ?? string.Empty,
             Tags = NormalizeTags(profile.Tags, profile.Tags?.Any(IsFavoriteTag) == true),
+            RemoteShellKind = profile.RemoteShellKind,
             AuthMode = !profile.UseSshAgent && (!string.IsNullOrWhiteSpace(profile.IdentityFilePath) || !string.IsNullOrWhiteSpace(profile.SshKeyPath))
                 ? SshAuthMode.IdentityFile
                 : SshAuthMode.Agent,
@@ -593,7 +596,8 @@ public sealed class SshLaunchDetails
             ServerAliveIntervalSeconds = profile.ServerAliveIntervalSeconds,
             ServerAliveCountMax = profile.ServerAliveCountMax,
             ExtraSshArgs = profile.ExtraSshArgs,
-            WorkingDirectory = profile.WorkingDirectory
+            WorkingDirectory = profile.WorkingDirectory,
+            RemoteShellKind = profile.RemoteShellKind
         };
     }
 

--- a/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
+++ b/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
@@ -39,6 +39,7 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
     private string _extraSshArgs = string.Empty;
     private bool _connectAfterSave;
     private bool _experimentalNativeSshEnabled;
+    private RemoteShellKind _remoteShellKind = RemoteShellKind.Auto;
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -199,6 +200,12 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
         }
     }
 
+    public RemoteShellKind RemoteShellKind
+    {
+        get => _remoteShellKind;
+        set => SetField(ref _remoteShellKind, value);
+    }
+
     public string BackendWarning =>
         BackendKind == SshBackendKind.Native && !ExperimentalNativeSshEnabled
             ? "Native SSH is disabled globally. Enable ExperimentalNativeSshEnabled in settings or switch this profile back to OpenSSH."
@@ -304,7 +311,8 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
             },
             ServerAliveIntervalSeconds = keepAliveInterval,
             ServerAliveCountMax = keepAliveCountMax,
-            ExtraSshArgs = ExtraSshArgs?.Trim() ?? string.Empty
+            ExtraSshArgs = ExtraSshArgs?.Trim() ?? string.Empty,
+            RemoteShellKind = RemoteShellKind
         };
     }
 
@@ -329,6 +337,7 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
             IsFavorite = profile.Tags.Any(tag => string.Equals(tag, "favorite", StringComparison.OrdinalIgnoreCase)),
             Notes = profile.Notes ?? string.Empty,
             BackendKind = profile.SshBackendKind,
+            RemoteShellKind = profile.RemoteShellKind,
             AuthMode = hasIdentityFile ? NewSshAuthMode.IdentityFile : NewSshAuthMode.Agent,
             IdentityFilePath = !string.IsNullOrWhiteSpace(profile.IdentityFilePath)
                 ? profile.IdentityFilePath!
@@ -395,6 +404,7 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
         EnableMux = sshProfile.MuxOptions.Enabled;
         ControlPersistSeconds = sshProfile.MuxOptions.ControlPersistSeconds >= 0 ? sshProfile.MuxOptions.ControlPersistSeconds : 90;
         ExtraSshArgs = sshProfile.ExtraSshArgs ?? string.Empty;
+        RemoteShellKind = sshProfile.RemoteShellKind;
     }
 
     private static PortForward? ConvertLegacyForward(ForwardingRule legacy)

--- a/src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarEntryViewModel.cs
+++ b/src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarEntryViewModel.cs
@@ -1,0 +1,17 @@
+using NovaTerminal.Models;
+
+namespace NovaTerminal.ViewModels.Ssh;
+
+public sealed class RemoteFilesSidebarEntryViewModel
+{
+    public RemoteFilesSidebarEntryViewModel(RemoteSidebarEntry entry)
+    {
+        Name = entry.Name;
+        FullPath = entry.FullPath;
+        IsDirectory = entry.IsDirectory;
+    }
+
+    public string Name { get; }
+    public string FullPath { get; }
+    public bool IsDirectory { get; }
+}

--- a/src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarEntryViewModel.cs
+++ b/src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarEntryViewModel.cs
@@ -6,18 +6,23 @@ namespace NovaTerminal.ViewModels.Ssh;
 
 public sealed class RemoteFilesSidebarEntryViewModel
 {
+    private const string DirectoryIconData = "M10,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V8A2,2 0 0,0 20,6H12L10,4Z";
+    private const string FileIconData = "M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M14,9V3.5L19.5,9H14Z";
+
     public RemoteFilesSidebarEntryViewModel(RemoteSidebarEntry entry)
     {
         Name = entry.Name;
         FullPath = entry.FullPath;
         IsDirectory = entry.IsDirectory;
         ModifiedDisplayText = FormatModifiedDisplayText(entry.ModifiedAtUtc);
+        EntryIconData = entry.IsDirectory ? DirectoryIconData : FileIconData;
     }
 
     public string Name { get; }
     public string FullPath { get; }
     public bool IsDirectory { get; }
     public string ModifiedDisplayText { get; }
+    public string EntryIconData { get; }
 
     private static string FormatModifiedDisplayText(DateTime? modifiedAtUtc)
     {

--- a/src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarEntryViewModel.cs
+++ b/src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarEntryViewModel.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Globalization;
 using NovaTerminal.Models;
 
 namespace NovaTerminal.ViewModels.Ssh;
@@ -9,9 +11,16 @@ public sealed class RemoteFilesSidebarEntryViewModel
         Name = entry.Name;
         FullPath = entry.FullPath;
         IsDirectory = entry.IsDirectory;
+        ModifiedDisplayText = FormatModifiedDisplayText(entry.ModifiedAtUtc);
     }
 
     public string Name { get; }
     public string FullPath { get; }
     public bool IsDirectory { get; }
+    public string ModifiedDisplayText { get; }
+
+    private static string FormatModifiedDisplayText(DateTime? modifiedAtUtc)
+    {
+        return modifiedAtUtc?.ToString("MMM dd", CultureInfo.InvariantCulture) ?? "-";
+    }
 }

--- a/src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarViewModel.cs
+++ b/src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarViewModel.cs
@@ -14,6 +14,7 @@ public sealed class RemoteFilesSidebarViewModel : INotifyPropertyChanged
 {
     private readonly IRemoteDirectoryBrowserService _directoryBrowserService;
     private readonly Stack<string> _backStack = new();
+    private readonly HashSet<long> _pendingLoadVersions = new();
     private Guid _profileId;
     private Guid _sessionId;
     private bool _isOpen;
@@ -23,6 +24,8 @@ public sealed class RemoteFilesSidebarViewModel : INotifyPropertyChanged
     private string? _jumpToCurrentDirectoryPath;
     private RemoteFilesSidebarEntryViewModel? _selectedEntry;
     private string? _errorMessage;
+    private long _latestRequestedLoadVersion;
+    private long _nextLoadVersion;
 
     public RemoteFilesSidebarViewModel(IRemoteDirectoryBrowserService directoryBrowserService)
     {
@@ -94,17 +97,19 @@ public sealed class RemoteFilesSidebarViewModel : INotifyPropertyChanged
         _profileId = profileId;
         _sessionId = sessionId;
         _backStack.Clear();
+        InvalidatePendingLoads();
         OnPropertyChanged(nameof(CanNavigateBack));
         IsDisconnected = false;
         IsOpen = true;
         JumpToCurrentDirectoryPath = null;
 
-        await LoadDirectoryAsync(initialPath, pushCurrentPathToBackStack: false, cancellationToken).ConfigureAwait(false);
+        await LoadDirectoryAsync(initialPath, BackStackMutation.None, backStackPath: null, cancellationToken);
     }
 
     public void Close()
     {
         _backStack.Clear();
+        InvalidatePendingLoads();
         OnPropertyChanged(nameof(CanNavigateBack));
         Entries.Clear();
         SelectedEntry = null;
@@ -123,7 +128,7 @@ public sealed class RemoteFilesSidebarViewModel : INotifyPropertyChanged
             return Task.CompletedTask;
         }
 
-        return LoadDirectoryAsync(CurrentPath, pushCurrentPathToBackStack: false, cancellationToken);
+        return LoadDirectoryAsync(CurrentPath, BackStackMutation.None, backStackPath: null, cancellationToken);
     }
 
     public Task NavigateIntoSelectedDirectoryAsync(CancellationToken cancellationToken = default)
@@ -133,7 +138,11 @@ public sealed class RemoteFilesSidebarViewModel : INotifyPropertyChanged
             return Task.CompletedTask;
         }
 
-        return LoadDirectoryAsync(SelectedEntry.FullPath, pushCurrentPathToBackStack: true, cancellationToken);
+        return LoadDirectoryAsync(
+            SelectedEntry.FullPath,
+            BackStackMutation.Push,
+            backStackPath: CurrentPath,
+            cancellationToken);
     }
 
     public Task NavigateUpAsync(CancellationToken cancellationToken = default)
@@ -144,7 +153,11 @@ public sealed class RemoteFilesSidebarViewModel : INotifyPropertyChanged
             return Task.CompletedTask;
         }
 
-        return LoadDirectoryAsync(parentPath, pushCurrentPathToBackStack: true, cancellationToken);
+        return LoadDirectoryAsync(
+            parentPath,
+            BackStackMutation.Push,
+            backStackPath: CurrentPath,
+            cancellationToken);
     }
 
     public Task NavigateBackAsync(CancellationToken cancellationToken = default)
@@ -154,9 +167,12 @@ public sealed class RemoteFilesSidebarViewModel : INotifyPropertyChanged
             return Task.CompletedTask;
         }
 
-        string previousPath = _backStack.Pop();
-        OnPropertyChanged(nameof(CanNavigateBack));
-        return LoadDirectoryAsync(previousPath, pushCurrentPathToBackStack: false, cancellationToken);
+        string previousPath = _backStack.Peek();
+        return LoadDirectoryAsync(
+            previousPath,
+            BackStackMutation.PopOnSuccess,
+            backStackPath: previousPath,
+            cancellationToken);
     }
 
     public Task JumpToCurrentDirectoryAsync(CancellationToken cancellationToken = default)
@@ -166,7 +182,11 @@ public sealed class RemoteFilesSidebarViewModel : INotifyPropertyChanged
             return Task.CompletedTask;
         }
 
-        return LoadDirectoryAsync(JumpToCurrentDirectoryPath, pushCurrentPathToBackStack: true, cancellationToken);
+        return LoadDirectoryAsync(
+            JumpToCurrentDirectoryPath,
+            BackStackMutation.Push,
+            backStackPath: CurrentPath,
+            cancellationToken);
     }
 
     public void SetJumpToCurrentDirectoryCandidate(string? remotePath)
@@ -178,36 +198,79 @@ public sealed class RemoteFilesSidebarViewModel : INotifyPropertyChanged
 
     public void MarkDisconnected()
     {
+        InvalidatePendingLoads();
         IsDisconnected = true;
         IsLoading = false;
     }
 
     private async Task LoadDirectoryAsync(
         string remotePath,
-        bool pushCurrentPathToBackStack,
+        BackStackMutation backStackMutation,
+        string? backStackPath,
         CancellationToken cancellationToken)
     {
-        string previousPath = CurrentPath;
-        IsLoading = true;
-        IsDisconnected = false;
+        long loadVersion = BeginLoad();
 
         try
         {
             RemoteSidebarListingResult result = await _directoryBrowserService
-                .ListDirectoryAsync(_profileId, _sessionId, remotePath, cancellationToken)
-                .ConfigureAwait(false);
+                .ListDirectoryAsync(_profileId, _sessionId, remotePath, cancellationToken);
 
-            if (pushCurrentPathToBackStack && !string.IsNullOrWhiteSpace(previousPath))
+            if (loadVersion != _latestRequestedLoadVersion || !IsOpen)
             {
-                _backStack.Push(previousPath);
-                OnPropertyChanged(nameof(CanNavigateBack));
+                return;
             }
 
+            ApplyBackStackMutation(backStackMutation, backStackPath, result.IsSuccess);
             ApplyListingResult(result);
         }
         finally
         {
-            IsLoading = false;
+            EndLoad(loadVersion);
+        }
+    }
+
+    private long BeginLoad()
+    {
+        long loadVersion = ++_nextLoadVersion;
+        _latestRequestedLoadVersion = loadVersion;
+        _pendingLoadVersions.Add(loadVersion);
+        IsLoading = true;
+        IsDisconnected = false;
+        return loadVersion;
+    }
+
+    private void EndLoad(long loadVersion)
+    {
+        _pendingLoadVersions.Remove(loadVersion);
+        IsLoading = _pendingLoadVersions.Count > 0;
+    }
+
+    private void ApplyBackStackMutation(
+        BackStackMutation mutation,
+        string? backStackPath,
+        bool isSuccess)
+    {
+        if (!isSuccess || string.IsNullOrWhiteSpace(backStackPath))
+        {
+            return;
+        }
+
+        switch (mutation)
+        {
+            case BackStackMutation.Push:
+                _backStack.Push(backStackPath);
+                OnPropertyChanged(nameof(CanNavigateBack));
+                break;
+
+            case BackStackMutation.PopOnSuccess:
+                if (_backStack.Count > 0 && string.Equals(_backStack.Peek(), backStackPath, StringComparison.Ordinal))
+                {
+                    _backStack.Pop();
+                    OnPropertyChanged(nameof(CanNavigateBack));
+                }
+
+                break;
         }
     }
 
@@ -267,5 +330,19 @@ public sealed class RemoteFilesSidebarViewModel : INotifyPropertyChanged
     private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
     {
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+
+    private void InvalidatePendingLoads()
+    {
+        _latestRequestedLoadVersion = ++_nextLoadVersion;
+        _pendingLoadVersions.Clear();
+        IsLoading = false;
+    }
+
+    private enum BackStackMutation
+    {
+        None = 0,
+        Push = 1,
+        PopOnSuccess = 2
     }
 }

--- a/src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarViewModel.cs
+++ b/src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarViewModel.cs
@@ -37,19 +37,39 @@ public sealed class RemoteFilesSidebarViewModel : INotifyPropertyChanged
     public bool IsOpen
     {
         get => _isOpen;
-        private set => SetField(ref _isOpen, value);
+        private set
+        {
+            if (SetField(ref _isOpen, value))
+            {
+                OnPropertyChanged(nameof(CanInteractWithRemote));
+                OnPropertyChanged(nameof(CanDownloadSelected));
+            }
+        }
     }
 
     public bool IsLoading
     {
         get => _isLoading;
-        private set => SetField(ref _isLoading, value);
+        private set
+        {
+            if (SetField(ref _isLoading, value))
+            {
+                OnPropertyChanged(nameof(CanInteractWithRemote));
+            }
+        }
     }
 
     public bool IsDisconnected
     {
         get => _isDisconnected;
-        private set => SetField(ref _isDisconnected, value);
+        private set
+        {
+            if (SetField(ref _isDisconnected, value))
+            {
+                OnPropertyChanged(nameof(CanInteractWithRemote));
+                OnPropertyChanged(nameof(CanDownloadSelected));
+            }
+        }
     }
 
     public string CurrentPath
@@ -78,7 +98,9 @@ public sealed class RemoteFilesSidebarViewModel : INotifyPropertyChanged
         }
     }
 
-    public bool CanDownloadSelected => SelectedEntry is not null;
+    public bool CanInteractWithRemote => IsOpen && !IsDisconnected && !IsLoading;
+
+    public bool CanDownloadSelected => SelectedEntry is not null && IsOpen && !IsDisconnected;
 
     public bool CanNavigateBack => _backStack.Count > 0;
 
@@ -199,6 +221,9 @@ public sealed class RemoteFilesSidebarViewModel : INotifyPropertyChanged
     public void MarkDisconnected()
     {
         InvalidatePendingLoads();
+        JumpToCurrentDirectoryPath = null;
+        SelectedEntry = null;
+        ErrorMessage = "SSH session disconnected.";
         IsDisconnected = true;
         IsLoading = false;
     }

--- a/src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarViewModel.cs
+++ b/src/NovaTerminal.App/ViewModels/Ssh/RemoteFilesSidebarViewModel.cs
@@ -1,0 +1,271 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using NovaTerminal.Models;
+using NovaTerminal.Services.Ssh;
+
+namespace NovaTerminal.ViewModels.Ssh;
+
+public sealed class RemoteFilesSidebarViewModel : INotifyPropertyChanged
+{
+    private readonly IRemoteDirectoryBrowserService _directoryBrowserService;
+    private readonly Stack<string> _backStack = new();
+    private Guid _profileId;
+    private Guid _sessionId;
+    private bool _isOpen;
+    private bool _isLoading;
+    private bool _isDisconnected;
+    private string _currentPath = string.Empty;
+    private string? _jumpToCurrentDirectoryPath;
+    private RemoteFilesSidebarEntryViewModel? _selectedEntry;
+    private string? _errorMessage;
+
+    public RemoteFilesSidebarViewModel(IRemoteDirectoryBrowserService directoryBrowserService)
+    {
+        _directoryBrowserService = directoryBrowserService ?? throw new ArgumentNullException(nameof(directoryBrowserService));
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public bool IsOpen
+    {
+        get => _isOpen;
+        private set => SetField(ref _isOpen, value);
+    }
+
+    public bool IsLoading
+    {
+        get => _isLoading;
+        private set => SetField(ref _isLoading, value);
+    }
+
+    public bool IsDisconnected
+    {
+        get => _isDisconnected;
+        private set => SetField(ref _isDisconnected, value);
+    }
+
+    public string CurrentPath
+    {
+        get => _currentPath;
+        private set => SetField(ref _currentPath, value);
+    }
+
+    public string? JumpToCurrentDirectoryPath
+    {
+        get => _jumpToCurrentDirectoryPath;
+        private set => SetField(ref _jumpToCurrentDirectoryPath, value);
+    }
+
+    public ObservableCollection<RemoteFilesSidebarEntryViewModel> Entries { get; } = new();
+
+    public RemoteFilesSidebarEntryViewModel? SelectedEntry
+    {
+        get => _selectedEntry;
+        set
+        {
+            if (SetField(ref _selectedEntry, value))
+            {
+                OnPropertyChanged(nameof(CanDownloadSelected));
+            }
+        }
+    }
+
+    public bool CanDownloadSelected => SelectedEntry is not null;
+
+    public bool CanNavigateBack => _backStack.Count > 0;
+
+    public string? ErrorMessage
+    {
+        get => _errorMessage;
+        private set => SetField(ref _errorMessage, value);
+    }
+
+    public async Task OpenAsync(
+        Guid profileId,
+        Guid sessionId,
+        string initialPath,
+        CancellationToken cancellationToken)
+    {
+        _profileId = profileId;
+        _sessionId = sessionId;
+        _backStack.Clear();
+        OnPropertyChanged(nameof(CanNavigateBack));
+        IsDisconnected = false;
+        IsOpen = true;
+        JumpToCurrentDirectoryPath = null;
+
+        await LoadDirectoryAsync(initialPath, pushCurrentPathToBackStack: false, cancellationToken).ConfigureAwait(false);
+    }
+
+    public void Close()
+    {
+        _backStack.Clear();
+        OnPropertyChanged(nameof(CanNavigateBack));
+        Entries.Clear();
+        SelectedEntry = null;
+        ErrorMessage = null;
+        JumpToCurrentDirectoryPath = null;
+        CurrentPath = string.Empty;
+        IsLoading = false;
+        IsDisconnected = false;
+        IsOpen = false;
+    }
+
+    public Task RefreshAsync(CancellationToken cancellationToken = default)
+    {
+        if (!IsOpen || string.IsNullOrWhiteSpace(CurrentPath))
+        {
+            return Task.CompletedTask;
+        }
+
+        return LoadDirectoryAsync(CurrentPath, pushCurrentPathToBackStack: false, cancellationToken);
+    }
+
+    public Task NavigateIntoSelectedDirectoryAsync(CancellationToken cancellationToken = default)
+    {
+        if (SelectedEntry is null || !SelectedEntry.IsDirectory)
+        {
+            return Task.CompletedTask;
+        }
+
+        return LoadDirectoryAsync(SelectedEntry.FullPath, pushCurrentPathToBackStack: true, cancellationToken);
+    }
+
+    public Task NavigateUpAsync(CancellationToken cancellationToken = default)
+    {
+        string? parentPath = GetParentPath(CurrentPath);
+        if (parentPath is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        return LoadDirectoryAsync(parentPath, pushCurrentPathToBackStack: true, cancellationToken);
+    }
+
+    public Task NavigateBackAsync(CancellationToken cancellationToken = default)
+    {
+        if (_backStack.Count == 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        string previousPath = _backStack.Pop();
+        OnPropertyChanged(nameof(CanNavigateBack));
+        return LoadDirectoryAsync(previousPath, pushCurrentPathToBackStack: false, cancellationToken);
+    }
+
+    public Task JumpToCurrentDirectoryAsync(CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(JumpToCurrentDirectoryPath))
+        {
+            return Task.CompletedTask;
+        }
+
+        return LoadDirectoryAsync(JumpToCurrentDirectoryPath, pushCurrentPathToBackStack: true, cancellationToken);
+    }
+
+    public void SetJumpToCurrentDirectoryCandidate(string? remotePath)
+    {
+        JumpToCurrentDirectoryPath = string.IsNullOrWhiteSpace(remotePath)
+            ? null
+            : remotePath.Trim();
+    }
+
+    public void MarkDisconnected()
+    {
+        IsDisconnected = true;
+        IsLoading = false;
+    }
+
+    private async Task LoadDirectoryAsync(
+        string remotePath,
+        bool pushCurrentPathToBackStack,
+        CancellationToken cancellationToken)
+    {
+        string previousPath = CurrentPath;
+        IsLoading = true;
+        IsDisconnected = false;
+
+        try
+        {
+            RemoteSidebarListingResult result = await _directoryBrowserService
+                .ListDirectoryAsync(_profileId, _sessionId, remotePath, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (pushCurrentPathToBackStack && !string.IsNullOrWhiteSpace(previousPath))
+            {
+                _backStack.Push(previousPath);
+                OnPropertyChanged(nameof(CanNavigateBack));
+            }
+
+            ApplyListingResult(result);
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    private void ApplyListingResult(RemoteSidebarListingResult result)
+    {
+        CurrentPath = result.ResolvedPath;
+        ErrorMessage = result.ErrorMessage;
+        Entries.Clear();
+
+        foreach (RemoteSidebarEntry entry in result.Entries)
+        {
+            Entries.Add(new RemoteFilesSidebarEntryViewModel(entry));
+        }
+
+        SelectedEntry = null;
+    }
+
+    private static string? GetParentPath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        string normalizedPath = path.TrimEnd('/');
+        if (normalizedPath.Length == 0 || normalizedPath == "/" || normalizedPath == "~")
+        {
+            return null;
+        }
+
+        int separatorIndex = normalizedPath.LastIndexOf('/');
+        if (separatorIndex < 0)
+        {
+            return null;
+        }
+
+        if (separatorIndex == 0)
+        {
+            return "/";
+        }
+
+        return normalizedPath[..separatorIndex];
+    }
+
+    private bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return false;
+        }
+
+        field = value;
+        OnPropertyChanged(propertyName);
+        return true;
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml
+++ b/src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml
@@ -29,7 +29,7 @@
     <Grid RowDefinitions="*,Auto,Auto" Margin="16">
         <TabControl>
             <TabItem Header="Basic">
-                <Grid Margin="0,10,0,0" ColumnDefinitions="170,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" RowSpacing="10">
+                <Grid Margin="0,10,0,0" ColumnDefinitions="170,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" RowSpacing="10">
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="Name" VerticalAlignment="Center" />
                     <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Name}" Watermark="My server" />
 
@@ -48,11 +48,14 @@
                     <TextBlock Grid.Row="5" Grid.Column="0" Text="Accent" VerticalAlignment="Center" />
                     <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding AccentColor}" Watermark="#0078D4 (optional)" />
 
-                    <TextBlock Grid.Row="6" Grid.Column="0" Text="Favorite" VerticalAlignment="Center" />
-                    <CheckBox Grid.Row="6" Grid.Column="1" IsChecked="{Binding IsFavorite}" Content="Pin in Connections list" />
+                    <TextBlock Grid.Row="6" Grid.Column="0" Text="Remote shell" VerticalAlignment="Center" />
+                    <ComboBox Grid.Row="6" Grid.Column="1" Name="RemoteShellKindCombo" SelectedItem="{Binding RemoteShellKind}" />
 
-                    <TextBlock Grid.Row="7" Grid.Column="0" Text="Notes" VerticalAlignment="Top" />
-                    <TextBox Grid.Row="7"
+                    <TextBlock Grid.Row="7" Grid.Column="0" Text="Favorite" VerticalAlignment="Center" />
+                    <CheckBox Grid.Row="7" Grid.Column="1" IsChecked="{Binding IsFavorite}" Content="Pin in Connections list" />
+
+                    <TextBlock Grid.Row="8" Grid.Column="0" Text="Notes" VerticalAlignment="Top" />
+                    <TextBox Grid.Row="8"
                              Grid.Column="1"
                              Text="{Binding Notes}"
                              AcceptsReturn="True"

--- a/src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml.cs
+++ b/src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Avalonia.Platform.Storage;
+using NovaTerminal.Core;
 using NovaTerminal.Core.Ssh.Models;
 using NovaTerminal.ViewModels.Ssh;
 
@@ -16,6 +17,7 @@ public partial class NewSshConnectionView : Window
         InitializeComponent();
         ConfigureAuthModeCombo();
         ConfigureBackendKindCombo();
+        ConfigureRemoteShellKindCombo();
         ConfigureForwardKindCombo();
     }
 
@@ -46,6 +48,15 @@ public partial class NewSshConnectionView : Window
         if (combo != null)
         {
             combo.ItemsSource = Enum.GetValues<SshBackendKind>();
+        }
+    }
+
+    private void ConfigureRemoteShellKindCombo()
+    {
+        var combo = this.FindControl<ComboBox>("RemoteShellKindCombo");
+        if (combo != null)
+        {
+            combo.ItemsSource = Enum.GetValues<RemoteShellKind>();
         }
     }
 

--- a/src/NovaTerminal.App/native/rusty_ssh/examples/smoke.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/examples/smoke.rs
@@ -47,6 +47,11 @@ fn main() {
         jump_port: 0,
         keepalive_interval_seconds: 30,
         keepalive_count_max: 3,
+        remote_shell_kind: 0,
+        shell_detection_command: std::ptr::null(),
+        bash_cwd_bootstrap: std::ptr::null(),
+        zsh_cwd_bootstrap: std::ptr::null(),
+        fish_cwd_bootstrap: std::ptr::null(),
     };
 
     let session = nova_ssh_connect(&connect_args);

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -45,6 +45,11 @@ pub struct NovaSshConnectArgs {
     pub jump_port: u16,
     pub keepalive_interval_seconds: u32,
     pub keepalive_count_max: u32,
+    pub remote_shell_kind: u32,
+    pub shell_detection_command: *const c_char,
+    pub bash_cwd_bootstrap: *const c_char,
+    pub zsh_cwd_bootstrap: *const c_char,
+    pub fish_cwd_bootstrap: *const c_char,
 }
 
 #[repr(C)]
@@ -158,6 +163,20 @@ struct ConnectConfig {
     jump_host: Option<JumpHostConfig>,
     keepalive_interval_seconds: u32,
     keepalive_count_max: u32,
+    remote_shell_kind: RemoteShellKind,
+    shell_detection_command: Option<String>,
+    bash_cwd_bootstrap: Option<String>,
+    zsh_cwd_bootstrap: Option<String>,
+    fish_cwd_bootstrap: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RemoteShellKind {
+    Auto,
+    Bash,
+    Zsh,
+    Fish,
+    Pwsh,
 }
 
 #[derive(Clone)]
@@ -989,8 +1008,123 @@ impl ConnectConfig {
             } else {
                 args.keepalive_count_max
             },
+            remote_shell_kind: parse_remote_shell_kind(args.remote_shell_kind),
+            shell_detection_command: read_c_string(args.shell_detection_command),
+            bash_cwd_bootstrap: read_c_string(args.bash_cwd_bootstrap),
+            zsh_cwd_bootstrap: read_c_string(args.zsh_cwd_bootstrap),
+            fish_cwd_bootstrap: read_c_string(args.fish_cwd_bootstrap),
         })
     }
+}
+
+fn parse_remote_shell_kind(value: u32) -> RemoteShellKind {
+    match value {
+        1 => RemoteShellKind::Bash,
+        2 => RemoteShellKind::Zsh,
+        3 => RemoteShellKind::Fish,
+        4 => RemoteShellKind::Pwsh,
+        _ => RemoteShellKind::Auto,
+    }
+}
+
+fn detect_login_shell_output_to_kind(output: &str) -> RemoteShellKind {
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        return RemoteShellKind::Auto;
+    }
+
+    let token = trimmed
+        .split_whitespace()
+        .next()
+        .unwrap_or(trimmed)
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(trimmed)
+        .trim_end_matches(".exe")
+        .to_ascii_lowercase();
+
+    match token.as_str() {
+        "bash" => RemoteShellKind::Bash,
+        "zsh" => RemoteShellKind::Zsh,
+        "fish" => RemoteShellKind::Fish,
+        "pwsh" | "powershell" => RemoteShellKind::Pwsh,
+        _ => RemoteShellKind::Auto,
+    }
+}
+
+fn shell_single_quote(value: &str) -> String {
+    value.replace('\'', "'\"'\"'")
+}
+
+fn wrap_posix_startup_command(command: String) -> String {
+    format!("sh -lc '{}'", shell_single_quote(&command))
+}
+
+fn build_startup_command(shell_kind: RemoteShellKind, config: &ConnectConfig) -> Option<String> {
+    match shell_kind {
+        RemoteShellKind::Bash => {
+            let bootstrap = config.bash_cwd_bootstrap.as_deref()?;
+            Some(wrap_posix_startup_command(format!(
+                "tmp_rc=$(mktemp)\ncat >\"$tmp_rc\" <<'__NOVA_BASHRC__'\nif [ -f ~/.bashrc ]; then . ~/.bashrc; fi\n{bootstrap}\n__NOVA_BASHRC__\nexec bash --rcfile \"$tmp_rc\" -i"
+            )))
+        }
+        RemoteShellKind::Zsh => {
+            let bootstrap = config.zsh_cwd_bootstrap.as_deref()?;
+            Some(wrap_posix_startup_command(format!(
+                "tmp_dir=$(mktemp -d)\ncat >\"$tmp_dir/.zshrc\" <<'__NOVA_ZSHRC__'\nif [ -f ~/.zshrc ]; then source ~/.zshrc; fi\n{bootstrap}\n__NOVA_ZSHRC__\nZDOTDIR=\"$tmp_dir\" exec zsh -i"
+            )))
+        }
+        RemoteShellKind::Fish => {
+            let bootstrap = config.fish_cwd_bootstrap.as_deref()?;
+            Some(wrap_posix_startup_command(format!(
+                "tmp_dir=$(mktemp -d)\nmkdir -p \"$tmp_dir/fish\"\ncat >\"$tmp_dir/fish/config.fish\" <<'__NOVA_FISHRC__'\nif test -f ~/.config/fish/config.fish\n    source ~/.config/fish/config.fish\nend\n{bootstrap}\n__NOVA_FISHRC__\nXDG_CONFIG_HOME=\"$tmp_dir\" exec fish -i"
+            )))
+        }
+        RemoteShellKind::Auto | RemoteShellKind::Pwsh => None,
+    }
+}
+
+async fn detect_login_shell<H>(
+    session: &mut client::Handle<H>,
+    command: &str,
+) -> anyhow::Result<RemoteShellKind>
+where
+    H: client::Handler + Send + 'static,
+{
+    let mut channel = session.channel_open_session().await?;
+    channel.exec(true, command).await?;
+
+    let mut output = Vec::new();
+    loop {
+        match channel.wait().await {
+            Some(ChannelMsg::Data { data }) => output.extend_from_slice(data.as_ref()),
+            Some(ChannelMsg::ExtendedData { .. }) => {}
+            Some(ChannelMsg::ExitStatus { .. })
+            | Some(ChannelMsg::ExitSignal { .. })
+            | Some(ChannelMsg::Success)
+            | Some(ChannelMsg::Failure)
+            | Some(ChannelMsg::WindowAdjusted { .. })
+            | Some(ChannelMsg::XonXoff { .. })
+            | Some(ChannelMsg::Open { .. })
+            | Some(ChannelMsg::OpenFailure(_)) => {}
+            Some(ChannelMsg::Eof) | Some(ChannelMsg::Close) | None => break,
+            Some(ChannelMsg::RequestPty { .. })
+            | Some(ChannelMsg::RequestShell { .. })
+            | Some(ChannelMsg::Exec { .. })
+            | Some(ChannelMsg::Signal { .. })
+            | Some(ChannelMsg::RequestSubsystem { .. })
+            | Some(ChannelMsg::RequestX11 { .. })
+            | Some(ChannelMsg::SetEnv { .. })
+            | Some(ChannelMsg::WindowChange { .. })
+            | Some(ChannelMsg::AgentForward { .. })
+            | Some(_) => {}
+        }
+    }
+
+    let _ = channel.close().await;
+    Ok(detect_login_shell_output_to_kind(
+        String::from_utf8_lossy(&output).as_ref(),
+    ))
 }
 
 fn read_c_string(value: *const c_char) -> Option<String> {
@@ -2116,6 +2250,14 @@ fn run_session(
         )
         .await?;
 
+        let effective_shell_kind = if config.remote_shell_kind != RemoteShellKind::Auto {
+            config.remote_shell_kind
+        } else if let Some(command) = config.shell_detection_command.as_deref() {
+            detect_login_shell(&mut session, command).await?
+        } else {
+            RemoteShellKind::Auto
+        };
+
         let mut channel = session.channel_open_session().await?;
         channel
             .request_pty(
@@ -2128,7 +2270,11 @@ fn run_session(
                 &[],
             )
             .await?;
-        channel.request_shell(true).await?;
+        if let Some(startup_command) = build_startup_command(effective_shell_kind, &config) {
+            channel.exec(true, startup_command).await?;
+        } else {
+            channel.request_shell(true).await?;
+        }
 
         shared.queue_event(QueuedEvent {
             kind: NovaSshEventKind::Connected,
@@ -2747,12 +2893,89 @@ mod tests {
             jump_port: 0,
             keepalive_interval_seconds: 15,
             keepalive_count_max: 7,
+            remote_shell_kind: 0,
+            shell_detection_command: ptr::null(),
+            bash_cwd_bootstrap: ptr::null(),
+            zsh_cwd_bootstrap: ptr::null(),
+            fish_cwd_bootstrap: ptr::null(),
         };
 
         let config = ConnectConfig::from_args(&args).expect("config should parse");
 
         assert_eq!(15, config.keepalive_interval_seconds);
         assert_eq!(7, config.keepalive_count_max);
+    }
+
+    #[test]
+    fn connect_config_reads_remote_shell_fields_from_ffi_args() {
+        let host = CString::new("native.example").unwrap();
+        let user = CString::new("nova").unwrap();
+        let term = CString::new("xterm-256color").unwrap();
+        let shell_detection_command = CString::new("sh -lc 'printf test'").unwrap();
+        let bash_cwd_bootstrap = CString::new("bash-bootstrap").unwrap();
+        let zsh_cwd_bootstrap = CString::new("zsh-bootstrap").unwrap();
+        let fish_cwd_bootstrap = CString::new("fish-bootstrap").unwrap();
+
+        let args = NovaSshConnectArgs {
+            host: host.as_ptr(),
+            user: user.as_ptr(),
+            port: 22,
+            cols: 120,
+            rows: 30,
+            term: term.as_ptr(),
+            identity_file: ptr::null(),
+            jump_host: ptr::null(),
+            jump_user: ptr::null(),
+            jump_port: 0,
+            keepalive_interval_seconds: 15,
+            keepalive_count_max: 7,
+            remote_shell_kind: 2,
+            shell_detection_command: shell_detection_command.as_ptr(),
+            bash_cwd_bootstrap: bash_cwd_bootstrap.as_ptr(),
+            zsh_cwd_bootstrap: zsh_cwd_bootstrap.as_ptr(),
+            fish_cwd_bootstrap: fish_cwd_bootstrap.as_ptr(),
+        };
+
+        let config = ConnectConfig::from_args(&args).expect("config should parse");
+
+        assert_eq!(RemoteShellKind::Zsh, config.remote_shell_kind);
+        assert_eq!(
+            Some("sh -lc 'printf test'".to_owned()),
+            config.shell_detection_command
+        );
+        assert_eq!(
+            Some("bash-bootstrap".to_owned()),
+            config.bash_cwd_bootstrap
+        );
+        assert_eq!(Some("zsh-bootstrap".to_owned()), config.zsh_cwd_bootstrap);
+        assert_eq!(
+            Some("fish-bootstrap".to_owned()),
+            config.fish_cwd_bootstrap
+        );
+    }
+
+    #[test]
+    fn detect_login_shell_output_to_kind_maps_known_tokens() {
+        assert_eq!(
+            RemoteShellKind::Bash,
+            detect_login_shell_output_to_kind("/bin/bash")
+        );
+        assert_eq!(
+            RemoteShellKind::Zsh,
+            detect_login_shell_output_to_kind("zsh")
+        );
+        assert_eq!(
+            RemoteShellKind::Fish,
+            detect_login_shell_output_to_kind("/usr/local/bin/fish")
+        );
+        assert_eq!(
+            RemoteShellKind::Pwsh,
+            detect_login_shell_output_to_kind("powershell")
+        );
+        assert_eq!(
+            RemoteShellKind::Auto,
+            detect_login_shell_output_to_kind("tcsh")
+        );
     }
 
     #[test]
@@ -2768,6 +2991,11 @@ mod tests {
             jump_host: None,
             keepalive_interval_seconds: 15,
             keepalive_count_max: 7,
+            remote_shell_kind: RemoteShellKind::Auto,
+            shell_detection_command: None,
+            bash_cwd_bootstrap: None,
+            zsh_cwd_bootstrap: None,
+            fish_cwd_bootstrap: None,
         };
 
         let client_config = build_client_config(&config);
@@ -2778,6 +3006,87 @@ mod tests {
             client_config.keepalive_interval
         );
         assert_eq!(7, client_config.keepalive_max);
+    }
+
+    #[test]
+    fn build_startup_command_wraps_bash_bootstrap() {
+        let config = ConnectConfig {
+            host: "native.example".to_owned(),
+            user: "nova".to_owned(),
+            port: 22,
+            cols: 120,
+            rows: 30,
+            term: "xterm-256color".to_owned(),
+            identity_file: None,
+            jump_host: None,
+            keepalive_interval_seconds: 30,
+            keepalive_count_max: 3,
+            remote_shell_kind: RemoteShellKind::Bash,
+            shell_detection_command: None,
+            bash_cwd_bootstrap: Some("printf 'cwd'".to_owned()),
+            zsh_cwd_bootstrap: None,
+            fish_cwd_bootstrap: None,
+        };
+
+        let command = build_startup_command(RemoteShellKind::Bash, &config)
+            .expect("bash command should be generated");
+
+        assert!(command.starts_with("sh -lc '"));
+        assert!(command.contains("tmp_rc=$(mktemp)"));
+        assert!(command.contains("exec bash --rcfile"));
+        assert!(command.contains("~/.bashrc"));
+    }
+
+    #[test]
+    fn build_startup_command_wraps_fish_bootstrap_in_posix_shell() {
+        let config = ConnectConfig {
+            host: "native.example".to_owned(),
+            user: "nova".to_owned(),
+            port: 22,
+            cols: 120,
+            rows: 30,
+            term: "xterm-256color".to_owned(),
+            identity_file: None,
+            jump_host: None,
+            keepalive_interval_seconds: 30,
+            keepalive_count_max: 3,
+            remote_shell_kind: RemoteShellKind::Fish,
+            shell_detection_command: None,
+            bash_cwd_bootstrap: None,
+            zsh_cwd_bootstrap: None,
+            fish_cwd_bootstrap: Some("printf 'cwd'".to_owned()),
+        };
+
+        let command = build_startup_command(RemoteShellKind::Fish, &config)
+            .expect("fish command should be generated");
+
+        assert!(command.starts_with("sh -lc '"));
+        assert!(command.contains("exec fish -i"));
+        assert!(command.contains("XDG_CONFIG_HOME"));
+    }
+
+    #[test]
+    fn build_startup_command_returns_none_for_auto_or_pwsh() {
+        let config = ConnectConfig {
+            host: "native.example".to_owned(),
+            user: "nova".to_owned(),
+            port: 22,
+            cols: 120,
+            rows: 30,
+            term: "xterm-256color".to_owned(),
+            identity_file: None,
+            jump_host: None,
+            keepalive_interval_seconds: 30,
+            keepalive_count_max: 3,
+            remote_shell_kind: RemoteShellKind::Auto,
+            shell_detection_command: Some("sh -lc 'printf bash'".to_owned()),
+            bash_cwd_bootstrap: Some("printf 'cwd'".to_owned()),
+            zsh_cwd_bootstrap: Some("print cwd".to_owned()),
+            fish_cwd_bootstrap: Some("printf cwd".to_owned()),
+        };
+
+        assert_eq!(None, build_startup_command(RemoteShellKind::Auto, &config));
+        assert_eq!(None, build_startup_command(RemoteShellKind::Pwsh, &config));
     }
 
     #[test]

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -336,6 +336,7 @@ struct RemotePathListEntry {
     name: String,
     full_path: String,
     is_directory: bool,
+    modified_at_unix_seconds: Option<u64>,
 }
 
 #[derive(Clone)]
@@ -1690,6 +1691,7 @@ where
                 name,
                 full_path,
                 is_directory: entry.metadata().is_dir(),
+                modified_at_unix_seconds: entry.metadata().mtime.map(|value| value as u64),
             }
         })
         .collect();
@@ -2860,6 +2862,34 @@ mod tests {
                 .unwrap_or_default()
                 .contains("incomplete")
         );
+
+        nova_ssh_string_free(response);
+    }
+
+    #[test]
+    fn remote_path_list_response_serializes_modified_unix_seconds() {
+        let mut response = ptr::null_mut();
+        let entries = vec![RemotePathListEntry {
+            name: "access.log".to_owned(),
+            full_path: "/srv/access.log".to_owned(),
+            is_directory: false,
+            modified_at_unix_seconds: Some(1_777_925_700),
+        }];
+
+        let rc = write_remote_path_list_response_json(
+            &mut response,
+            NOVA_SSH_RESULT_OK,
+            "ok",
+            "listed",
+            entries,
+        );
+
+        assert_eq!(NOVA_SSH_RESULT_OK, rc);
+        assert!(!response.is_null());
+
+        let response_json = unsafe { CStr::from_ptr(response) }.to_str().unwrap();
+        let payload: serde_json::Value = serde_json::from_str(response_json).unwrap();
+        assert_eq!(1_777_925_700u64, payload["entries"][0]["modifiedAtUnixSeconds"]);
 
         nova_ssh_string_free(response);
     }

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -20,6 +20,8 @@ use tokio::sync::mpsc;
 
 const COPY_BUFFER_SIZE: usize = 64 * 1024;
 const CANCELLATION_CHECK_INTERVAL_BYTES: u64 = 1024 * 1024;
+const SHELL_DETECTION_TIMEOUT: Duration = Duration::from_secs(3);
+const SHELL_DETECTION_MAX_OUTPUT_BYTES: usize = 4096;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default)]
@@ -954,7 +956,13 @@ pub extern "C" fn nova_ssh_sftp_list_directory(
         ),
         Err(error) => {
             let (result, status, message) = classify_sftp_transfer_error(&error);
-            write_remote_path_list_response_json(response_json, result, status, &message, Vec::new())
+            write_remote_path_list_response_json(
+                response_json,
+                result,
+                status,
+                &message,
+                Vec::new(),
+            )
         }
     }
 }
@@ -1060,18 +1068,41 @@ fn wrap_posix_startup_command(command: String) -> String {
     format!("sh -lc '{}'", shell_single_quote(&command))
 }
 
+fn bash_login_startup() -> &'static str {
+    "if [ -f ~/.bash_profile ]; then . ~/.bash_profile; \
+elif [ -f ~/.bash_login ]; then . ~/.bash_login; \
+elif [ -f ~/.profile ]; then . ~/.profile; \
+fi"
+}
+
+fn zsh_login_startup() -> &'static str {
+    "if [ -f ~/.zprofile ]; then source ~/.zprofile; fi"
+}
+
+fn append_bounded_shell_detection_output(output: &mut Vec<u8>, data: &[u8]) -> bool {
+    let remaining = SHELL_DETECTION_MAX_OUTPUT_BYTES.saturating_sub(output.len());
+    if remaining == 0 {
+        return true;
+    }
+
+    output.extend_from_slice(&data[..data.len().min(remaining)]);
+    output.len() >= SHELL_DETECTION_MAX_OUTPUT_BYTES
+}
+
 fn build_startup_command(shell_kind: RemoteShellKind, config: &ConnectConfig) -> Option<String> {
     match shell_kind {
         RemoteShellKind::Bash => {
             let bootstrap = config.bash_cwd_bootstrap.as_deref()?;
             Some(wrap_posix_startup_command(format!(
-                "tmp_rc=$(mktemp)\ncat >\"$tmp_rc\" <<'__NOVA_BASHRC__'\nif [ -f ~/.bashrc ]; then . ~/.bashrc; fi\n{bootstrap}\n__NOVA_BASHRC__\nexec bash --rcfile \"$tmp_rc\" -i"
+                "tmp_rc=$(mktemp)\ncat >\"$tmp_rc\" <<'__NOVA_BASHRC__'\n{bash_login_startup}\nif [ -f ~/.bashrc ]; then . ~/.bashrc; fi\n{bootstrap}\n__NOVA_BASHRC__\nexec bash --rcfile \"$tmp_rc\" -i",
+                bash_login_startup = bash_login_startup()
             )))
         }
         RemoteShellKind::Zsh => {
             let bootstrap = config.zsh_cwd_bootstrap.as_deref()?;
             Some(wrap_posix_startup_command(format!(
-                "tmp_dir=$(mktemp -d)\ncat >\"$tmp_dir/.zshrc\" <<'__NOVA_ZSHRC__'\nif [ -f ~/.zshrc ]; then source ~/.zshrc; fi\n{bootstrap}\n__NOVA_ZSHRC__\nZDOTDIR=\"$tmp_dir\" exec zsh -i"
+                "tmp_dir=$(mktemp -d)\ncat >\"$tmp_dir/.zprofile\" <<'__NOVA_ZPROFILE__'\n{zsh_login_startup}\n__NOVA_ZPROFILE__\ncat >\"$tmp_dir/.zshrc\" <<'__NOVA_ZSHRC__'\nif [ -f ~/.zshrc ]; then source ~/.zshrc; fi\n{bootstrap}\n__NOVA_ZSHRC__\nZDOTDIR=\"$tmp_dir\" exec zsh -il",
+                zsh_login_startup = zsh_login_startup()
             )))
         }
         RemoteShellKind::Fish => {
@@ -1094,37 +1125,47 @@ where
     let mut channel = session.channel_open_session().await?;
     channel.exec(true, command).await?;
 
-    let mut output = Vec::new();
-    loop {
-        match channel.wait().await {
-            Some(ChannelMsg::Data { data }) => output.extend_from_slice(data.as_ref()),
-            Some(ChannelMsg::ExtendedData { .. }) => {}
-            Some(ChannelMsg::ExitStatus { .. })
-            | Some(ChannelMsg::ExitSignal { .. })
-            | Some(ChannelMsg::Success)
-            | Some(ChannelMsg::Failure)
-            | Some(ChannelMsg::WindowAdjusted { .. })
-            | Some(ChannelMsg::XonXoff { .. })
-            | Some(ChannelMsg::Open { .. })
-            | Some(ChannelMsg::OpenFailure(_)) => {}
-            Some(ChannelMsg::Eof) | Some(ChannelMsg::Close) | None => break,
-            Some(ChannelMsg::RequestPty { .. })
-            | Some(ChannelMsg::RequestShell { .. })
-            | Some(ChannelMsg::Exec { .. })
-            | Some(ChannelMsg::Signal { .. })
-            | Some(ChannelMsg::RequestSubsystem { .. })
-            | Some(ChannelMsg::RequestX11 { .. })
-            | Some(ChannelMsg::SetEnv { .. })
-            | Some(ChannelMsg::WindowChange { .. })
-            | Some(ChannelMsg::AgentForward { .. })
-            | Some(_) => {}
+    let detection_result = tokio::time::timeout(SHELL_DETECTION_TIMEOUT, async {
+        let mut output = Vec::new();
+        loop {
+            match channel.wait().await {
+                Some(ChannelMsg::Data { data }) => {
+                    if append_bounded_shell_detection_output(&mut output, data.as_ref()) {
+                        break;
+                    }
+                }
+                Some(ChannelMsg::ExtendedData { .. }) => {}
+                Some(ChannelMsg::ExitStatus { .. })
+                | Some(ChannelMsg::ExitSignal { .. })
+                | Some(ChannelMsg::Success)
+                | Some(ChannelMsg::Failure)
+                | Some(ChannelMsg::WindowAdjusted { .. })
+                | Some(ChannelMsg::XonXoff { .. })
+                | Some(ChannelMsg::Open { .. })
+                | Some(ChannelMsg::OpenFailure(_)) => {}
+                Some(ChannelMsg::Eof) | Some(ChannelMsg::Close) | None => break,
+                Some(ChannelMsg::RequestPty { .. })
+                | Some(ChannelMsg::RequestShell { .. })
+                | Some(ChannelMsg::Exec { .. })
+                | Some(ChannelMsg::Signal { .. })
+                | Some(ChannelMsg::RequestSubsystem { .. })
+                | Some(ChannelMsg::RequestX11 { .. })
+                | Some(ChannelMsg::SetEnv { .. })
+                | Some(ChannelMsg::WindowChange { .. })
+                | Some(ChannelMsg::AgentForward { .. })
+                | Some(_) => {}
+            }
         }
-    }
+
+        detect_login_shell_output_to_kind(String::from_utf8_lossy(&output).as_ref())
+    })
+    .await;
 
     let _ = channel.close().await;
-    Ok(detect_login_shell_output_to_kind(
-        String::from_utf8_lossy(&output).as_ref(),
-    ))
+    match detection_result {
+        Ok(shell_kind) => Ok(shell_kind),
+        Err(_) => Err(anyhow::anyhow!("shell detection timed out")),
+    }
 }
 
 fn read_c_string(value: *const c_char) -> Option<String> {
@@ -1339,7 +1380,10 @@ fn normalize_known_host_fingerprint(fingerprint: &str) -> String {
     }
 }
 
-fn run_sftp_transfer(request: SftpTransferRequest, progress: SftpProgressEmitter) -> anyhow::Result<()> {
+fn run_sftp_transfer(
+    request: SftpTransferRequest,
+    progress: SftpProgressEmitter,
+) -> anyhow::Result<()> {
     validate_supported_sftp_mode(&request.transfer)?;
 
     let runtime = Builder::new_current_thread().enable_all().build()?;
@@ -1408,7 +1452,9 @@ fn run_sftp_transfer(request: SftpTransferRequest, progress: SftpProgressEmitter
     })
 }
 
-fn run_remote_path_list(request: RemotePathListRequest) -> anyhow::Result<Vec<RemotePathListEntry>> {
+fn run_remote_path_list(
+    request: RemotePathListRequest,
+) -> anyhow::Result<Vec<RemotePathListEntry>> {
     let runtime = Builder::new_current_thread().enable_all().build()?;
     runtime.block_on(async move {
         let known_hosts =
@@ -1553,9 +1599,12 @@ where
             .await?;
         }
         ("upload", "file") => {
-            let remote_target =
-                resolve_upload_file_target(&sftp, Path::new(&transfer.local_path), &transfer.remote_path)
-                    .await?;
+            let remote_target = resolve_upload_file_target(
+                &sftp,
+                Path::new(&transfer.local_path),
+                &transfer.remote_path,
+            )
+            .await?;
             upload_file_to_remote(
                 &sftp,
                 Path::new(&transfer.local_path),
@@ -1567,8 +1616,8 @@ where
             .await?;
         }
         ("download", "directory") => {
-            let local_root = PathBuf::from(&transfer.local_path)
-                .join(remote_basename(&transfer.remote_path)?);
+            let local_root =
+                PathBuf::from(&transfer.local_path).join(remote_basename(&transfer.remote_path)?);
             download_directory_from_remote(
                 &sftp,
                 &transfer.remote_path,
@@ -1652,8 +1701,7 @@ where
 fn validate_supported_sftp_mode(transfer: &SftpTransferRequestBody) -> anyhow::Result<()> {
     let direction = transfer.direction.trim().to_ascii_lowercase();
     let kind = transfer.kind.trim().to_ascii_lowercase();
-    if (direction == "download" || direction == "upload")
-        && (kind == "file" || kind == "directory")
+    if (direction == "download" || direction == "upload") && (kind == "file" || kind == "directory")
     {
         return Ok(());
     }
@@ -1718,7 +1766,9 @@ async fn upload_file_to_remote(
     progress: SftpProgressEmitter,
     copy_buffer: &mut [u8],
 ) -> anyhow::Result<()> {
-    let total_bytes = std::fs::metadata(local_path).ok().map(|metadata| metadata.len());
+    let total_bytes = std::fs::metadata(local_path)
+        .ok()
+        .map(|metadata| metadata.len());
     let mut local_file = TokioFile::open(local_path)
         .await
         .map_err(|error| map_local_transfer_error(local_path, error))?;
@@ -1849,8 +1899,8 @@ async fn upload_directory_to_remote(
     let mut pending = VecDeque::from([(local_root.to_path_buf(), remote_root.to_owned())]);
     while let Some((local_dir, remote_dir)) = pending.pop_front() {
         ensure_transfer_not_canceled(cancellation_marker_path)?;
-        let mut entries = std::fs::read_dir(&local_dir)?
-            .collect::<Result<Vec<_>, std::io::Error>>()?;
+        let mut entries =
+            std::fs::read_dir(&local_dir)?.collect::<Result<Vec<_>, std::io::Error>>()?;
         entries.sort_by_key(|entry| entry.file_name());
 
         for entry in entries {
@@ -1893,7 +1943,9 @@ async fn resolve_upload_directory_target(
         .file_name()
         .and_then(|value| value.to_str())
         .filter(|value| !value.trim().is_empty())
-        .ok_or_else(|| anyhow::anyhow!("Local directory name is required for native SFTP upload."))?;
+        .ok_or_else(|| {
+            anyhow::anyhow!("Local directory name is required for native SFTP upload.")
+        })?;
     let normalized_remote = normalize_remote_directory_path(remote_path)?;
 
     if sftp
@@ -2108,7 +2160,9 @@ fn remote_basename(path: &str) -> anyhow::Result<String> {
         .rsplit('/')
         .find(|segment| !segment.is_empty())
         .map(str::to_owned)
-        .ok_or_else(|| anyhow::anyhow!("Remote directory name is required for native SFTP transfer."))
+        .ok_or_else(|| {
+            anyhow::anyhow!("Remote directory name is required for native SFTP transfer.")
+        })
 }
 
 fn resolve_upload_file_destination_path(
@@ -2136,27 +2190,21 @@ fn expand_remote_home_path(path: &str, home_directory: Option<&str>) -> anyhow::
     }
 
     if trimmed == "~" {
-        return normalize_remote_directory_path(
-            home_directory
-                .ok_or_else(|| {
-                    anyhow::Error::new(NativeSftpTransferError::new(
-                        NativeSftpTransferErrorKind::InvalidArgument,
-                        "Remote home directory is unavailable for native SFTP upload.",
-                    ))
-                })?,
-        );
+        return normalize_remote_directory_path(home_directory.ok_or_else(|| {
+            anyhow::Error::new(NativeSftpTransferError::new(
+                NativeSftpTransferErrorKind::InvalidArgument,
+                "Remote home directory is unavailable for native SFTP upload.",
+            ))
+        })?);
     }
 
     if let Some(relative_path) = trimmed.strip_prefix("~/") {
-        let home_directory = normalize_remote_directory_path(
-            home_directory
-                .ok_or_else(|| {
-                    anyhow::Error::new(NativeSftpTransferError::new(
-                        NativeSftpTransferErrorKind::InvalidArgument,
-                        "Remote home directory is unavailable for native SFTP upload.",
-                    ))
-                })?,
-        )?;
+        let home_directory = normalize_remote_directory_path(home_directory.ok_or_else(|| {
+            anyhow::Error::new(NativeSftpTransferError::new(
+                NativeSftpTransferErrorKind::InvalidArgument,
+                "Remote home directory is unavailable for native SFTP upload.",
+            ))
+        })?)?;
         return Ok(join_remote_path(&home_directory, relative_path));
     }
 
@@ -2253,7 +2301,10 @@ fn run_session(
         let effective_shell_kind = if config.remote_shell_kind != RemoteShellKind::Auto {
             config.remote_shell_kind
         } else if let Some(command) = config.shell_detection_command.as_deref() {
-            detect_login_shell(&mut session, command).await?
+            match detect_login_shell(&mut session, command).await {
+                Ok(shell_kind) => shell_kind,
+                Err(_) => RemoteShellKind::Auto,
+            }
         } else {
             RemoteShellKind::Auto
         };
@@ -2803,10 +2854,12 @@ mod tests {
         let response_json = unsafe { CStr::from_ptr(response) }.to_str().unwrap();
         let payload: serde_json::Value = serde_json::from_str(response_json).unwrap();
         assert_eq!("invalid-argument", payload["status"]);
-        assert!(payload["message"]
-            .as_str()
-            .unwrap_or_default()
-            .contains("incomplete"));
+        assert!(
+            payload["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("incomplete")
+        );
 
         nova_ssh_string_free(response);
     }
@@ -2943,15 +2996,9 @@ mod tests {
             Some("sh -lc 'printf test'".to_owned()),
             config.shell_detection_command
         );
-        assert_eq!(
-            Some("bash-bootstrap".to_owned()),
-            config.bash_cwd_bootstrap
-        );
+        assert_eq!(Some("bash-bootstrap".to_owned()), config.bash_cwd_bootstrap);
         assert_eq!(Some("zsh-bootstrap".to_owned()), config.zsh_cwd_bootstrap);
-        assert_eq!(
-            Some("fish-bootstrap".to_owned()),
-            config.fish_cwd_bootstrap
-        );
+        assert_eq!(Some("fish-bootstrap".to_owned()), config.fish_cwd_bootstrap);
     }
 
     #[test]
@@ -3034,6 +3081,9 @@ mod tests {
         assert!(command.starts_with("sh -lc '"));
         assert!(command.contains("tmp_rc=$(mktemp)"));
         assert!(command.contains("exec bash --rcfile"));
+        assert!(command.contains("~/.bash_profile"));
+        assert!(command.contains("~/.bash_login"));
+        assert!(command.contains("~/.profile"));
         assert!(command.contains("~/.bashrc"));
     }
 
@@ -3066,6 +3116,36 @@ mod tests {
     }
 
     #[test]
+    fn build_startup_command_wraps_zsh_bootstrap_with_login_startup() {
+        let config = ConnectConfig {
+            host: "native.example".to_owned(),
+            user: "nova".to_owned(),
+            port: 22,
+            cols: 120,
+            rows: 30,
+            term: "xterm-256color".to_owned(),
+            identity_file: None,
+            jump_host: None,
+            keepalive_interval_seconds: 30,
+            keepalive_count_max: 3,
+            remote_shell_kind: RemoteShellKind::Zsh,
+            shell_detection_command: None,
+            bash_cwd_bootstrap: None,
+            zsh_cwd_bootstrap: Some("print cwd".to_owned()),
+            fish_cwd_bootstrap: None,
+        };
+
+        let command = build_startup_command(RemoteShellKind::Zsh, &config)
+            .expect("zsh command should be generated");
+
+        assert!(command.starts_with("sh -lc '"));
+        assert!(command.contains("$tmp_dir/.zprofile"));
+        assert!(command.contains("~/.zprofile"));
+        assert!(command.contains("exec zsh -il"));
+        assert!(command.contains("$tmp_dir/.zshrc"));
+    }
+
+    #[test]
     fn build_startup_command_returns_none_for_auto_or_pwsh() {
         let config = ConnectConfig {
             host: "native.example".to_owned(),
@@ -3087,6 +3167,17 @@ mod tests {
 
         assert_eq!(None, build_startup_command(RemoteShellKind::Auto, &config));
         assert_eq!(None, build_startup_command(RemoteShellKind::Pwsh, &config));
+    }
+
+    #[test]
+    fn append_bounded_shell_detection_output_truncates_at_limit() {
+        let mut output = vec![b'x'; SHELL_DETECTION_MAX_OUTPUT_BYTES - 2];
+
+        let reached_limit = append_bounded_shell_detection_output(&mut output, b"abcd");
+
+        assert!(reached_limit);
+        assert_eq!(SHELL_DETECTION_MAX_OUTPUT_BYTES, output.len());
+        assert_eq!(&output[output.len() - 2..], b"ab");
     }
 
     #[test]
@@ -3206,9 +3297,8 @@ mod tests {
 
     #[test]
     fn resolve_upload_file_destination_path_appends_local_name_for_existing_directory() {
-        let resolved =
-            resolve_upload_file_destination_path("upload.txt", "/tmp", None, true)
-                .expect("directory target should resolve");
+        let resolved = resolve_upload_file_destination_path("upload.txt", "/tmp", None, true)
+            .expect("directory target should resolve");
 
         assert_eq!("/tmp/upload.txt", resolved);
     }
@@ -3225,8 +3315,12 @@ mod tests {
     #[test]
     fn should_check_for_cancellation_only_after_interval_is_reached() {
         assert!(!should_check_for_cancellation(64 * 1024));
-        assert!(!should_check_for_cancellation(CANCELLATION_CHECK_INTERVAL_BYTES - 1));
-        assert!(should_check_for_cancellation(CANCELLATION_CHECK_INTERVAL_BYTES));
+        assert!(!should_check_for_cancellation(
+            CANCELLATION_CHECK_INTERVAL_BYTES - 1
+        ));
+        assert!(should_check_for_cancellation(
+            CANCELLATION_CHECK_INTERVAL_BYTES
+        ));
     }
 
     #[test]

--- a/src/NovaTerminal.Core/RemoteShellKind.cs
+++ b/src/NovaTerminal.Core/RemoteShellKind.cs
@@ -1,0 +1,10 @@
+namespace NovaTerminal.Core;
+
+public enum RemoteShellKind
+{
+    Auto,
+    Bash,
+    Zsh,
+    Fish,
+    Pwsh
+}

--- a/src/NovaTerminal.Core/Ssh/Models/SshProfile.cs
+++ b/src/NovaTerminal.Core/Ssh/Models/SshProfile.cs
@@ -31,4 +31,5 @@ public sealed class SshProfile
     public int ServerAliveCountMax { get; set; } = 3;
     public string ExtraSshArgs { get; set; } = string.Empty;
     public string WorkingDirectory { get; set; } = string.Empty;
+    public RemoteShellKind RemoteShellKind { get; set; } = RemoteShellKind.Auto;
 }

--- a/src/NovaTerminal.Core/Ssh/Native/NativeRemotePathModels.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeRemotePathModels.cs
@@ -1,15 +1,35 @@
+using System;
+
 namespace NovaTerminal.Core.Ssh.Native;
 
 public sealed class NativeRemotePathEntry
 {
-    public NativeRemotePathEntry(string name, string fullPath, bool isDirectory)
+    public NativeRemotePathEntry(string name, string fullPath, bool isDirectory, DateTime? modifiedAtUtc = null)
     {
         Name = name;
         FullPath = fullPath;
         IsDirectory = isDirectory;
+        ModifiedAtUtc = NormalizeModifiedAtUtc(modifiedAtUtc);
     }
 
     public string Name { get; }
     public string FullPath { get; }
     public bool IsDirectory { get; }
+    public DateTime? ModifiedAtUtc { get; }
+
+    private static DateTime? NormalizeModifiedAtUtc(DateTime? modifiedAtUtc)
+    {
+        if (!modifiedAtUtc.HasValue)
+        {
+            return null;
+        }
+
+        DateTime value = modifiedAtUtc.Value;
+        return value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+        };
+    }
 }

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshConnectionOptions.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshConnectionOptions.cs
@@ -19,6 +19,11 @@ public sealed class NativeSshConnectionOptions
     public SshJumpHop? JumpHost { get; init; }
     public int KeepAliveIntervalSeconds { get; init; } = DefaultKeepAliveIntervalSeconds;
     public int KeepAliveCountMax { get; init; } = DefaultKeepAliveCountMax;
+    public RemoteShellKind RemoteShellKind { get; init; } = RemoteShellKind.Auto;
+    public string? ShellDetectionCommand { get; init; }
+    public string? BashCwdBootstrap { get; init; }
+    public string? ZshCwdBootstrap { get; init; }
+    public string? FishCwdBootstrap { get; init; }
 
     public static NativeSshConnectionOptions FromProfile(SshProfile profile, int cols, int rows)
     {
@@ -39,7 +44,8 @@ public sealed class NativeSshConnectionOptions
                 : DefaultKeepAliveCountMax,
             IdentityFilePath = string.IsNullOrWhiteSpace(profile.IdentityFilePath)
                 ? null
-                : profile.IdentityFilePath
+                : profile.IdentityFilePath,
+            RemoteShellKind = profile.RemoteShellKind
         };
     }
 }

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
@@ -667,7 +667,7 @@ public sealed partial class NativeSshInterop : INativeSshInterop
             NativeSshTransferJsonContext.Default.RemotePathListResponse);
 
         return response?.Entries?
-            .Select(entry => new NativeRemotePathEntry(entry.Name, entry.FullPath, entry.IsDirectory))
+            .Select(entry => new NativeRemotePathEntry(entry.Name, entry.FullPath, entry.IsDirectory, entry.ModifiedAtUtc))
             .ToList() ?? [];
     }
 
@@ -812,6 +812,7 @@ public sealed partial class NativeSshInterop : INativeSshInterop
         public string Name { get; init; } = string.Empty;
         public string FullPath { get; init; } = string.Empty;
         public bool IsDirectory { get; init; }
+        public DateTime? ModifiedAtUtc { get; init; }
     }
 
     [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
@@ -696,8 +696,31 @@ public sealed partial class NativeSshInterop : INativeSshInterop
             NativeSshTransferJsonContext.Default.RemotePathListResponse);
 
         return response?.Entries?
-            .Select(entry => new NativeRemotePathEntry(entry.Name, entry.FullPath, entry.IsDirectory, entry.ModifiedAtUtc))
+            .Select(entry => new NativeRemotePathEntry(
+                entry.Name,
+                entry.FullPath,
+                entry.IsDirectory,
+                entry.ModifiedAtUtc ?? ConvertUnixSecondsToUtc(entry.ModifiedAtUnixSeconds)))
             .ToList() ?? [];
+    }
+
+    private static DateTime? ConvertUnixSecondsToUtc(ulong? modifiedAtUnixSeconds)
+    {
+        if (!modifiedAtUnixSeconds.HasValue)
+        {
+            return null;
+        }
+
+        try
+        {
+            return DateTimeOffset
+                .FromUnixTimeSeconds(checked((long)modifiedAtUnixSeconds.Value))
+                .UtcDateTime;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return null;
+        }
     }
 
     private static string? TakeNativeUtf8AndFree(ref IntPtr pointer)
@@ -847,6 +870,7 @@ public sealed partial class NativeSshInterop : INativeSshInterop
         public string FullPath { get; init; } = string.Empty;
         public bool IsDirectory { get; init; }
         public DateTime? ModifiedAtUtc { get; init; }
+        public ulong? ModifiedAtUnixSeconds { get; init; }
     }
 
     [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]

--- a/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
+++ b/src/NovaTerminal.Core/Ssh/Native/NativeSshInterop.cs
@@ -27,6 +27,10 @@ public sealed partial class NativeSshInterop : INativeSshInterop
         IntPtr userPtr = IntPtr.Zero;
         IntPtr termPtr = IntPtr.Zero;
         IntPtr identityPtr = IntPtr.Zero;
+        IntPtr shellDetectionCommandPtr = IntPtr.Zero;
+        IntPtr bashCwdBootstrapPtr = IntPtr.Zero;
+        IntPtr zshCwdBootstrapPtr = IntPtr.Zero;
+        IntPtr fishCwdBootstrapPtr = IntPtr.Zero;
 
         try
         {
@@ -36,6 +40,22 @@ public sealed partial class NativeSshInterop : INativeSshInterop
             if (!string.IsNullOrWhiteSpace(options.IdentityFilePath))
             {
                 identityPtr = Marshal.StringToCoTaskMemUTF8(options.IdentityFilePath);
+            }
+            if (!string.IsNullOrWhiteSpace(options.ShellDetectionCommand))
+            {
+                shellDetectionCommandPtr = Marshal.StringToCoTaskMemUTF8(options.ShellDetectionCommand);
+            }
+            if (!string.IsNullOrWhiteSpace(options.BashCwdBootstrap))
+            {
+                bashCwdBootstrapPtr = Marshal.StringToCoTaskMemUTF8(options.BashCwdBootstrap);
+            }
+            if (!string.IsNullOrWhiteSpace(options.ZshCwdBootstrap))
+            {
+                zshCwdBootstrapPtr = Marshal.StringToCoTaskMemUTF8(options.ZshCwdBootstrap);
+            }
+            if (!string.IsNullOrWhiteSpace(options.FishCwdBootstrap))
+            {
+                fishCwdBootstrapPtr = Marshal.StringToCoTaskMemUTF8(options.FishCwdBootstrap);
             }
 
             IntPtr jumpHostPtr = IntPtr.Zero;
@@ -65,7 +85,12 @@ public sealed partial class NativeSshInterop : INativeSshInterop
                     JumpUser = jumpUserPtr,
                     JumpPort = checked((ushort)(options.JumpHost?.Port ?? 0)),
                     KeepAliveIntervalSeconds = checked((uint)Math.Max(0, options.KeepAliveIntervalSeconds)),
-                    KeepAliveCountMax = checked((uint)Math.Max(0, options.KeepAliveCountMax))
+                    KeepAliveCountMax = checked((uint)Math.Max(0, options.KeepAliveCountMax)),
+                    RemoteShellKind = (uint)options.RemoteShellKind,
+                    ShellDetectionCommand = shellDetectionCommandPtr,
+                    BashCwdBootstrap = bashCwdBootstrapPtr,
+                    ZshCwdBootstrap = zshCwdBootstrapPtr,
+                    FishCwdBootstrap = fishCwdBootstrapPtr
                 };
 
                 IntPtr handle = NativeMethods.nova_ssh_connect(in args);
@@ -88,6 +113,10 @@ public sealed partial class NativeSshInterop : INativeSshInterop
             FreeUtf8(userPtr);
             FreeUtf8(termPtr);
             FreeUtf8(identityPtr);
+            FreeUtf8(shellDetectionCommandPtr);
+            FreeUtf8(bashCwdBootstrapPtr);
+            FreeUtf8(zshCwdBootstrapPtr);
+            FreeUtf8(fishCwdBootstrapPtr);
         }
     }
 
@@ -704,6 +733,11 @@ public sealed partial class NativeSshInterop : INativeSshInterop
         public ushort JumpPort;
         public uint KeepAliveIntervalSeconds;
         public uint KeepAliveCountMax;
+        public uint RemoteShellKind;
+        public IntPtr ShellDetectionCommand;
+        public IntPtr BashCwdBootstrap;
+        public IntPtr ZshCwdBootstrap;
+        public IntPtr FishCwdBootstrap;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Core/Ssh/Sessions/NativeSshSession.cs
@@ -71,7 +71,7 @@ public sealed class NativeSshSession : ITerminalSession
         _profileHost = profile.Host;
         _allowVaultPasswordReuse = profile.Id != Guid.Empty;
         JumpHostConnectPlan connectPlan = JumpHostConnectPlan.Create(profile);
-        NativeSshConnectionOptions connectionOptions = _jumpHostConnector.CreateConnectionOptions(connectPlan, profile, cols, rows);
+        NativeSshConnectionOptions connectionOptions = CreateConnectionOptions(connectPlan, profile, cols, rows);
         _log($"[NativeSshSession] backend=native path={_jumpHostConnector.DescribePath(connectPlan)} target={connectionOptions.User}@{connectionOptions.Host}:{connectionOptions.Port}");
         _sessionHandle = _interop.Connect(connectionOptions);
 
@@ -258,6 +258,58 @@ public sealed class NativeSshSession : ITerminalSession
     public void AttachBuffer(TerminalBuffer buffer)
     {
         _buffer = buffer;
+    }
+
+    private NativeSshConnectionOptions CreateConnectionOptions(
+        JumpHostConnectPlan connectPlan,
+        SshProfile profile,
+        int cols,
+        int rows)
+    {
+        NativeSshConnectionOptions baseOptions = _jumpHostConnector.CreateConnectionOptions(connectPlan, profile, cols, rows);
+        RemoteShellKind remoteShellKind = profile.RemoteShellKind;
+
+        return new NativeSshConnectionOptions
+        {
+            Host = baseOptions.Host,
+            User = baseOptions.User,
+            Port = baseOptions.Port,
+            Cols = baseOptions.Cols,
+            Rows = baseOptions.Rows,
+            Term = baseOptions.Term,
+            Password = baseOptions.Password,
+            IdentityFilePath = baseOptions.IdentityFilePath,
+            KnownHostsFilePath = baseOptions.KnownHostsFilePath,
+            JumpHost = baseOptions.JumpHost,
+            KeepAliveIntervalSeconds = baseOptions.KeepAliveIntervalSeconds,
+            KeepAliveCountMax = baseOptions.KeepAliveCountMax,
+            RemoteShellKind = remoteShellKind,
+            ShellDetectionCommand = remoteShellKind == RemoteShellKind.Auto
+                ? "sh -lc 'printf \"%s\" \"${SHELL##*/}\"' 2>/dev/null"
+                : null,
+            BashCwdBootstrap = string.Join(
+                "\n",
+                "__nova_emit_cwd() {",
+                "  printf '\\033]7;%s\\007' \"$PWD\"",
+                "}",
+                "PROMPT_COMMAND=\"__nova_emit_cwd${PROMPT_COMMAND:+;$PROMPT_COMMAND}\""),
+            ZshCwdBootstrap = string.Join(
+                "\n",
+                "autoload -Uz add-zsh-hook",
+                "__nova_emit_cwd() {",
+                "  printf '\\033]7;%s\\007' \"$PWD\"",
+                "}",
+                "add-zsh-hook precmd __nova_emit_cwd"),
+            FishCwdBootstrap = string.Join(
+                "\n",
+                "functions -q fish_prompt; and functions -c fish_prompt __nova_original_fish_prompt",
+                "function fish_prompt",
+                "    printf '\\033]7;%s\\007' \"$PWD\"",
+                "    if functions -q __nova_original_fish_prompt",
+                "        __nova_original_fish_prompt",
+                "    end",
+                "end")
+        };
     }
 
     public void TakeSnapshot()

--- a/src/NovaTerminal.Core/Ssh/Storage/JsonSshProfileStore.cs
+++ b/src/NovaTerminal.Core/Ssh/Storage/JsonSshProfileStore.cs
@@ -255,6 +255,9 @@ public sealed class JsonSshProfileStore : ISshProfileStore
         normalized.IdentityFilePath = normalized.IdentityFilePath?.Trim() ?? string.Empty;
         SshProfileNormalizer.NormalizeRememberPasswordPreference(normalized);
         normalized.WorkingDirectory = normalized.WorkingDirectory?.Trim() ?? string.Empty;
+        normalized.RemoteShellKind = Enum.IsDefined(normalized.RemoteShellKind)
+            ? normalized.RemoteShellKind
+            : RemoteShellKind.Auto;
         normalized.ServerAliveIntervalSeconds = normalized.ServerAliveIntervalSeconds > 0
             ? normalized.ServerAliveIntervalSeconds
             : 30;
@@ -331,7 +334,8 @@ public sealed class JsonSshProfileStore : ISshProfileStore
             ServerAliveIntervalSeconds = profile.ServerAliveIntervalSeconds,
             ServerAliveCountMax = profile.ServerAliveCountMax,
             ExtraSshArgs = profile.ExtraSshArgs,
-            WorkingDirectory = profile.WorkingDirectory
+            WorkingDirectory = profile.WorkingDirectory,
+            RemoteShellKind = profile.RemoteShellKind
         };
     }
 

--- a/tests/NovaTerminal.Core.Tests/Ssh/DockerSshFixture.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/DockerSshFixture.cs
@@ -5,7 +5,7 @@ namespace NovaTerminal.Core.Tests.Ssh;
 
 internal sealed class DockerSshFixture : IAsyncDisposable
 {
-    private const string ImageTag = "novaterm-native-ssh-e2e:local";
+    private const string ImageTag = "novaterm-native-ssh-e2e:v2";
     private string _containerName = string.Empty;
     private bool _started;
 
@@ -64,6 +64,14 @@ internal sealed class DockerSshFixture : IAsyncDisposable
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
 
         await RunDockerCommandAsync($"exec {_containerName} mkdir -p {path}")
+            .ConfigureAwait(false);
+    }
+
+    public async Task SetLoginShellAsync(string shellPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(shellPath);
+
+        await RunDockerCommandAsync($"exec {_containerName} usermod -s {shellPath} {UserName}")
             .ConfigureAwait(false);
     }
 

--- a/tests/NovaTerminal.Core.Tests/Ssh/JsonSshProfileStoreTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/JsonSshProfileStoreTests.cs
@@ -152,6 +152,35 @@ public sealed class JsonSshProfileStoreTests
     }
 
     [Fact]
+    public void SaveAndLoad_RoundTripsRemoteShellKind()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string storePath = Path.Combine(tempRoot, "profiles.json");
+            var store = new JsonSshProfileStore(storePath);
+            var profile = new SshProfile
+            {
+                Id = Guid.Parse("2b7ca4ee-dc11-4a0e-bb7c-c6db8d3f5e25"),
+                Name = "bash",
+                Host = "bash.internal",
+                RemoteShellKind = RemoteShellKind.Bash
+            };
+
+            store.SaveProfile(profile);
+
+            SshProfile? loaded = store.GetProfile(profile.Id);
+
+            Assert.NotNull(loaded);
+            Assert.Equal(RemoteShellKind.Bash, loaded!.RemoteShellKind);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
     public void NormalizeRememberPasswordPreference_PreservesNativeProfiles()
     {
         var profile = new SshProfile

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshDockerE2eTests.cs
@@ -4,6 +4,7 @@ using NovaTerminal.Core.Ssh.Native;
 using NovaTerminal.Core.Ssh.Sessions;
 using NovaTerminal.Core.Tests.Infra;
 using System.Text;
+using NovaTerminal.Core;
 
 namespace NovaTerminal.Core.Tests.Ssh;
 
@@ -822,6 +823,30 @@ public sealed class NativeSshDockerE2eTests
         Assert.DoesNotContain(after.Lines.Take(20), line => line.Contains("line 01", StringComparison.Ordinal));
     }
 
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
+    public Task NativeSsh_AutoRemoteShellKind_EmitsCwdUpdatesForBash()
+    {
+        return AssertAutoRemoteShellKindEmitsCwdUpdatesAsync("/bin/bash");
+    }
+
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
+    public Task NativeSsh_AutoRemoteShellKind_EmitsCwdUpdatesForZsh()
+    {
+        return AssertAutoRemoteShellKindEmitsCwdUpdatesAsync("/usr/bin/zsh");
+    }
+
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
+    public Task NativeSsh_AutoRemoteShellKind_EmitsCwdUpdatesForFish()
+    {
+        return AssertAutoRemoteShellKindEmitsCwdUpdatesAsync("/usr/bin/fish");
+    }
+
     private static SshProfile CreateProfile(DockerSshFixture fixture)
     {
         return new SshProfile
@@ -833,6 +858,57 @@ public sealed class NativeSshDockerE2eTests
             User = fixture.UserName,
             Port = fixture.Port
         };
+    }
+
+    private static async Task AssertAutoRemoteShellKindEmitsCwdUpdatesAsync(string loginShellPath)
+    {
+        await using var fixture = await DockerSshFixture.StartAsync();
+        await fixture.SetLoginShellAsync(loginShellPath);
+
+        var buffer = new TerminalBuffer(120, 30);
+        var parser = new AnsiParser(buffer);
+        var handler = new NativeSshTestInteractionHandler(fixture.Password);
+        var cwdEvents = new List<string>();
+
+        parser.OnWorkingDirectoryChanged += cwd =>
+        {
+            lock (cwdEvents)
+            {
+                cwdEvents.Add(cwd);
+            }
+        };
+
+        SshProfile profile = CreateProfile(fixture);
+        profile.RemoteShellKind = RemoteShellKind.Auto;
+
+        using var session = new NativeSshSession(
+            profile,
+            cols: 120,
+            rows: 30,
+            interactionHandler: handler);
+
+        session.AttachBuffer(buffer);
+        session.OnOutputReceived += parser.Process;
+
+        await WaitUntilAsync(
+            () => GetLatestCwd(cwdEvents) == "/home/nova",
+            TimeSpan.FromSeconds(20),
+            $"initial cwd from {loginShellPath}");
+
+        session.SendInput("cd /tmp\n");
+
+        await WaitUntilAsync(
+            () => GetLatestCwd(cwdEvents) == "/tmp",
+            TimeSpan.FromSeconds(20),
+            $"cwd change after cd in {loginShellPath}");
+    }
+
+    private static string? GetLatestCwd(List<string> cwdEvents)
+    {
+        lock (cwdEvents)
+        {
+            return cwdEvents.Count == 0 ? null : cwdEvents[^1];
+        }
     }
 
     private static bool SnapshotContains(TerminalBuffer buffer, string value)

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshRemotePathInteropTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshRemotePathInteropTests.cs
@@ -47,10 +47,25 @@ public sealed class NativeSshRemotePathInteropTests
     }
 
     [Fact]
-    public void DeserializeRemotePathListResponse_MapsAndNormalizesModifiedAtUtcMetadata()
+    public void DeserializeRemotePathListResponse_MapsModifiedUnixSecondsMetadata()
     {
         const string json = """
-        {"entries":[{"name":"movies","fullPath":"/mnt/media/movies","isDirectory":true,"modifiedAtUtc":"2026-05-04T20:15:00"},{"name":"logs","fullPath":"/mnt/media/logs","isDirectory":true,"modifiedAtUtc":null}]}
+        {"entries":[{"name":"movies","fullPath":"/mnt/media/movies","isDirectory":true,"modifiedAtUnixSeconds":1777925700},{"name":"logs","fullPath":"/mnt/media/logs","isDirectory":true,"modifiedAtUnixSeconds":null}]}
+        """;
+
+        IReadOnlyList<NativeRemotePathEntry> entries = NativeSshInterop.DeserializeRemotePathListResponseForTests(json);
+
+        Assert.Equal(2, entries.Count);
+        Assert.Equal(new DateTime(2026, 5, 4, 20, 15, 0, DateTimeKind.Utc), entries[0].ModifiedAtUtc);
+        Assert.Equal(DateTimeKind.Utc, entries[0].ModifiedAtUtc!.Value.Kind);
+        Assert.Null(entries[1].ModifiedAtUtc);
+    }
+
+    [Fact]
+    public void DeserializeRemotePathListResponse_PreservesLegacyModifiedAtUtcMetadata()
+    {
+        const string json = """
+        {"entries":[{"name":"archive","fullPath":"/mnt/media/archive","isDirectory":true,"modifiedAtUtc":"2026-05-04T20:15:00"},{"name":"logs","fullPath":"/mnt/media/logs","isDirectory":true,"modifiedAtUtc":null}]}
         """;
 
         IReadOnlyList<NativeRemotePathEntry> entries = NativeSshInterop.DeserializeRemotePathListResponseForTests(json);

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshRemotePathInteropTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshRemotePathInteropTests.cs
@@ -43,5 +43,21 @@ public sealed class NativeSshRemotePathInteropTests
         Assert.Equal("movies", entries[0].Name);
         Assert.Equal("/mnt/media/movies", entries[0].FullPath);
         Assert.True(entries[0].IsDirectory);
+        Assert.Null(entries[0].ModifiedAtUtc);
+    }
+
+    [Fact]
+    public void DeserializeRemotePathListResponse_MapsAndNormalizesModifiedAtUtcMetadata()
+    {
+        const string json = """
+        {"entries":[{"name":"movies","fullPath":"/mnt/media/movies","isDirectory":true,"modifiedAtUtc":"2026-05-04T20:15:00"},{"name":"logs","fullPath":"/mnt/media/logs","isDirectory":true,"modifiedAtUtc":null}]}
+        """;
+
+        IReadOnlyList<NativeRemotePathEntry> entries = NativeSshInterop.DeserializeRemotePathListResponseForTests(json);
+
+        Assert.Equal(2, entries.Count);
+        Assert.Equal(new DateTime(2026, 5, 4, 20, 15, 0, DateTimeKind.Utc), entries[0].ModifiedAtUtc);
+        Assert.Equal(DateTimeKind.Utc, entries[0].ModifiedAtUtc!.Value.Kind);
+        Assert.Null(entries[1].ModifiedAtUtc);
     }
 }

--- a/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
+++ b/tests/NovaTerminal.Core.Tests/Ssh/NativeSshSessionTests.cs
@@ -168,6 +168,42 @@ public sealed class NativeSshSessionTests
         Assert.Equal(7, interop.LastConnectOptions.KeepAliveCountMax);
     }
 
+    [Fact]
+    public async Task Connect_WithAutoRemoteShellKind_PassesProbeAndSupportedBootstraps()
+    {
+        var interop = new FakeNativeSshInterop();
+        SshProfile profile = CreateProfile();
+        profile.RemoteShellKind = RemoteShellKind.Auto;
+
+        using var session = new NativeSshSession(profile, interop: interop);
+
+        await WaitUntilAsync(() => interop.LastConnectOptions != null);
+
+        Assert.NotNull(interop.LastConnectOptions);
+        Assert.Equal(RemoteShellKind.Auto, interop.LastConnectOptions!.RemoteShellKind);
+        Assert.Contains("sh -lc", interop.LastConnectOptions.ShellDetectionCommand, StringComparison.Ordinal);
+        Assert.Contains("PROMPT_COMMAND", interop.LastConnectOptions.BashCwdBootstrap, StringComparison.Ordinal);
+        Assert.Contains("add-zsh-hook precmd", interop.LastConnectOptions.ZshCwdBootstrap, StringComparison.Ordinal);
+        Assert.Contains("fish_prompt", interop.LastConnectOptions.FishCwdBootstrap, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Connect_WithExplicitBashRemoteShellKind_SkipsProbeButPassesBootstrap()
+    {
+        var interop = new FakeNativeSshInterop();
+        SshProfile profile = CreateProfile();
+        profile.RemoteShellKind = RemoteShellKind.Bash;
+
+        using var session = new NativeSshSession(profile, interop: interop);
+
+        await WaitUntilAsync(() => interop.LastConnectOptions != null);
+
+        Assert.NotNull(interop.LastConnectOptions);
+        Assert.Equal(RemoteShellKind.Bash, interop.LastConnectOptions!.RemoteShellKind);
+        Assert.Null(interop.LastConnectOptions.ShellDetectionCommand);
+        Assert.Contains("PROMPT_COMMAND", interop.LastConnectOptions.BashCwdBootstrap, StringComparison.Ordinal);
+    }
+
     private static SshProfile CreateProfile()
     {
         return new SshProfile

--- a/tests/NovaTerminal.ExternalSuites/NativeSsh/Dockerfile
+++ b/tests/NovaTerminal.ExternalSuites/NativeSsh/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:12-slim
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends openssh-server bash ca-certificates vim-tiny \
+    && apt-get install -y --no-install-recommends openssh-server bash zsh fish ca-certificates vim-tiny \
     && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m -s /bin/bash nova \
@@ -21,6 +21,9 @@ RUN mkdir -p /var/run/sshd /home/nova/.ssh \
 RUN ssh-keygen -A
 
 RUN printf "export PS1='nova$ '\n" > /home/nova/.bashrc \
+    && printf "PROMPT='nova$ '\n" > /home/nova/.zshrc \
+    && mkdir -p /home/nova/.config/fish \
+    && printf "function fish_prompt\n    printf 'nova$ '\nend\n" > /home/nova/.config/fish/config.fish \
     && printf "if [ -f ~/.bashrc ]; then . ~/.bashrc; fi\n" > /home/nova/.bash_profile \
     && chown -R nova:nova /home/nova
 

--- a/tests/NovaTerminal.Tests/Core/MainWindowTransferFlowTests.cs
+++ b/tests/NovaTerminal.Tests/Core/MainWindowTransferFlowTests.cs
@@ -37,13 +37,102 @@ public sealed class MainWindowTransferFlowTests
         Assert.Equal(TransferKind.File, job.Kind);
     }
 
+    [AvaloniaFact]
+    public async Task SidebarDownload_UsesSelectedRemoteEntry_AsTransferRemotePath()
+    {
+        var window = new TestMainWindow
+        {
+            NextTransferDialogResult = TransferDialogResult.CreateConfirmed(
+                localPath: @"D:\downloads\logs",
+                remotePath: "/srv/logs")
+        };
+
+        await window.StartSidebarDownloadForTest(
+            profile: CreateNativeProfile(),
+            sessionId: Guid.Parse("2af2fbad-a4d3-4aeb-bf1d-e8884c0ad6f0"),
+            selectedRemotePath: "/srv/logs",
+            kind: TransferKind.Folder);
+
+        Assert.NotNull(window.LastTransferDialogRequest);
+        Assert.Equal("/srv/logs", window.LastTransferDialogRequest!.RemotePath);
+        Assert.True(window.LastTransferDialogRequest.PreferLocalPathOnOpen);
+        Assert.NotNull(window.QueuedJob);
+        Assert.Equal("/srv/logs", window.QueuedJob!.RemotePath);
+        Assert.Equal(TransferKind.Folder, window.QueuedJob.Kind);
+    }
+
+    [AvaloniaFact]
+    public async Task SidebarUpload_UsesCurrentRemoteDirectory_AsInitialRemotePath()
+    {
+        foreach (TransferKind kind in new[] { TransferKind.File, TransferKind.Folder })
+        {
+            var window = new TestMainWindow
+            {
+                NextTransferDialogResult = TransferDialogResult.CreateConfirmed(
+                    localPath: @"D:\downloads\payload.txt",
+                    remotePath: "/srv/app")
+            };
+
+            await window.StartSidebarUploadForTest(
+                profile: CreateNativeProfile(),
+                sessionId: Guid.Parse("3165a397-02ad-4dd2-913a-1b98b20ae7ef"),
+                remoteDirectory: "/srv/app",
+                kind: kind);
+
+            Assert.NotNull(window.LastTransferDialogRequest);
+            Assert.Equal("/srv/app", window.LastTransferDialogRequest!.RemotePath);
+            Assert.True(window.LastTransferDialogRequest.PreferLocalPathOnOpen);
+            Assert.Equal(kind, window.LastTransferDialogRequest.Kind);
+            Assert.NotNull(window.QueuedJob);
+            Assert.Equal("/srv/app", window.QueuedJob!.RemotePath);
+            Assert.Equal(kind, window.QueuedJob.Kind);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task ManualTransferFlow_StillUsesProfileDefaultRemotePath()
+    {
+        var window = new TestMainWindow
+        {
+            NextTransferDialogResult = TransferDialogResult.CreateConfirmed(
+                localPath: @"D:\downloads\sample.txt",
+                remotePath: "~/downloads")
+        };
+
+        TerminalProfile profile = CreateNativeProfile();
+
+        await window.InitiateSftpTransferForTest(
+            profile,
+            Guid.Parse("5196f302-0ebe-4cdf-9777-4fe5bc1fa60a"),
+            TransferDirection.Upload,
+            TransferKind.File);
+
+        Assert.NotNull(window.LastTransferDialogRequest);
+        Assert.Equal(profile.DefaultRemoteDir, window.LastTransferDialogRequest!.RemotePath);
+        Assert.False(window.LastTransferDialogRequest.PreferLocalPathOnOpen);
+    }
+
+    private static TerminalProfile CreateNativeProfile()
+    {
+        return new TerminalProfile
+        {
+            Id = Guid.Parse("4f13d6d8-ea72-4d88-9430-fc5d5f2490c7"),
+            Name = "server3",
+            Type = ConnectionType.SSH,
+            SshBackendKind = NovaTerminal.Core.Ssh.Models.SshBackendKind.Native,
+            DefaultRemoteDir = "~/downloads"
+        };
+    }
+
     private sealed class TestMainWindow : NovaTerminal.MainWindow
     {
         public TransferDialogResult? NextTransferDialogResult { get; set; }
         public TransferJob? QueuedJob { get; private set; }
+        public TransferDialogRequest? LastTransferDialogRequest { get; private set; }
 
         internal override Task<TransferDialogResult?> ShowTransferDialogAsync(TransferDialogRequest request)
         {
+            LastTransferDialogRequest = request;
             return Task.FromResult(NextTransferDialogResult);
         }
 

--- a/tests/NovaTerminal.Tests/Core/MainWindowTransferFlowTests.cs
+++ b/tests/NovaTerminal.Tests/Core/MainWindowTransferFlowTests.cs
@@ -43,9 +43,7 @@ public sealed class MainWindowTransferFlowTests
     {
         var window = new TestMainWindow
         {
-            NextTransferDialogResult = TransferDialogResult.CreateConfirmed(
-                localPath: @"D:\downloads\logs",
-                remotePath: "/srv/logs")
+            NextPickedLocalFolderPath = @"D:\downloads\logs"
         };
 
         await window.StartSidebarDownloadForTest(
@@ -54,12 +52,34 @@ public sealed class MainWindowTransferFlowTests
             selectedRemotePath: "/srv/logs",
             kind: TransferKind.Folder);
 
-        Assert.NotNull(window.LastTransferDialogRequest);
-        Assert.Equal("/srv/logs", window.LastTransferDialogRequest!.RemotePath);
-        Assert.True(window.LastTransferDialogRequest.PreferLocalPathOnOpen);
         Assert.NotNull(window.QueuedJob);
         Assert.Equal("/srv/logs", window.QueuedJob!.RemotePath);
+        Assert.Equal(@"D:\downloads\logs", window.QueuedJob.LocalPath);
         Assert.Equal(TransferKind.Folder, window.QueuedJob.Kind);
+        Assert.True(window.FolderPickerWasShown);
+        Assert.False(window.TransferDialogWasShown);
+    }
+
+    [AvaloniaFact]
+    public async Task SidebarDownloadFile_UsesSavePicker_WithRemoteFileName()
+    {
+        var window = new TestMainWindow
+        {
+            NextSavedLocalFilePath = @"D:\downloads\logs.txt"
+        };
+
+        await window.StartSidebarDownloadForTest(
+            profile: CreateNativeProfile(),
+            sessionId: Guid.Parse("2a6228c7-fc68-46f6-b620-60650ee2f4d0"),
+            selectedRemotePath: "/srv/logs.txt",
+            kind: TransferKind.File);
+
+        Assert.NotNull(window.QueuedJob);
+        Assert.Equal("/srv/logs.txt", window.QueuedJob!.RemotePath);
+        Assert.Equal(@"D:\downloads\logs.txt", window.QueuedJob.LocalPath);
+        Assert.Equal("logs.txt", window.LastSuggestedSaveFileName);
+        Assert.True(window.SavePickerWasShown);
+        Assert.False(window.TransferDialogWasShown);
     }
 
     [AvaloniaFact]
@@ -131,6 +151,25 @@ public sealed class MainWindowTransferFlowTests
         Assert.False(window.LastTransferDialogRequest.PreferLocalPathOnOpen);
     }
 
+    [AvaloniaFact]
+    public async Task ManualTransferFlow_StillUsesTransferDialog_WhenSidebarFlowDoesNot()
+    {
+        var window = new TestMainWindow
+        {
+            NextTransferDialogResult = TransferDialogResult.CreateConfirmed(
+                localPath: @"D:\downloads\logs",
+                remotePath: "/srv/logs")
+        };
+
+        await window.InitiateSftpTransferForTest(
+            CreateNativeProfile(),
+            Guid.Parse("f3cbca88-8445-4e12-8e31-aa2b7f6d9f76"),
+            TransferDirection.Download,
+            TransferKind.Folder);
+
+        Assert.True(window.TransferDialogWasShown);
+    }
+
     private static TerminalProfile CreateNativeProfile()
     {
         return new TerminalProfile
@@ -148,11 +187,14 @@ public sealed class MainWindowTransferFlowTests
         public TransferDialogResult? NextTransferDialogResult { get; set; }
         public string? NextPickedLocalFilePath { get; set; }
         public string? NextPickedLocalFolderPath { get; set; }
+        public string? NextSavedLocalFilePath { get; set; }
         public TransferJob? QueuedJob { get; private set; }
         public TransferDialogRequest? LastTransferDialogRequest { get; private set; }
         public bool TransferDialogWasShown { get; private set; }
         public bool FilePickerWasShown { get; private set; }
         public bool FolderPickerWasShown { get; private set; }
+        public bool SavePickerWasShown { get; private set; }
+        public string? LastSuggestedSaveFileName { get; private set; }
 
         internal override Task<TransferDialogResult?> ShowTransferDialogAsync(TransferDialogRequest request)
         {
@@ -168,6 +210,19 @@ public sealed class MainWindowTransferFlowTests
         }
 
         internal override Task<string?> PickLocalUploadFolderPathAsync()
+        {
+            FolderPickerWasShown = true;
+            return Task.FromResult<string?>(NextPickedLocalFolderPath);
+        }
+
+        internal override Task<string?> PickLocalDownloadFilePathAsync(string suggestedFileName)
+        {
+            SavePickerWasShown = true;
+            LastSuggestedSaveFileName = suggestedFileName;
+            return Task.FromResult<string?>(NextSavedLocalFilePath);
+        }
+
+        internal override Task<string?> PickLocalDownloadFolderPathAsync()
         {
             FolderPickerWasShown = true;
             return Task.FromResult<string?>(NextPickedLocalFolderPath);

--- a/tests/NovaTerminal.Tests/Core/MainWindowTransferFlowTests.cs
+++ b/tests/NovaTerminal.Tests/Core/MainWindowTransferFlowTests.cs
@@ -35,6 +35,7 @@ public sealed class MainWindowTransferFlowTests
         Assert.Equal(@"D:\downloads\a.mkv", job.LocalPath);
         Assert.Equal(TransferDirection.Download, job.Direction);
         Assert.Equal(TransferKind.File, job.Kind);
+        Assert.True(window.TransferDialogWasShown);
     }
 
     [AvaloniaFact]
@@ -62,31 +63,49 @@ public sealed class MainWindowTransferFlowTests
     }
 
     [AvaloniaFact]
-    public async Task SidebarUpload_UsesCurrentRemoteDirectory_AsInitialRemotePath()
+    public async Task SidebarUploadFile_UsesLocalFilePicker_AndCurrentRemoteDirectory()
     {
-        foreach (TransferKind kind in new[] { TransferKind.File, TransferKind.Folder })
+        var window = new TestMainWindow
         {
-            var window = new TestMainWindow
-            {
-                NextTransferDialogResult = TransferDialogResult.CreateConfirmed(
-                    localPath: @"D:\downloads\payload.txt",
-                    remotePath: "/srv/app")
-            };
+            NextPickedLocalFilePath = @"D:\temp\report.txt"
+        };
 
-            await window.StartSidebarUploadForTest(
-                profile: CreateNativeProfile(),
-                sessionId: Guid.Parse("3165a397-02ad-4dd2-913a-1b98b20ae7ef"),
-                remoteDirectory: "/srv/app",
-                kind: kind);
+        await window.StartSidebarUploadForTest(
+            profile: CreateNativeProfile(),
+            sessionId: Guid.Parse("3165a397-02ad-4dd2-913a-1b98b20ae7ef"),
+            remoteDirectory: "/srv/app",
+            kind: TransferKind.File);
 
-            Assert.NotNull(window.LastTransferDialogRequest);
-            Assert.Equal("/srv/app", window.LastTransferDialogRequest!.RemotePath);
-            Assert.True(window.LastTransferDialogRequest.PreferLocalPathOnOpen);
-            Assert.Equal(kind, window.LastTransferDialogRequest.Kind);
-            Assert.NotNull(window.QueuedJob);
-            Assert.Equal("/srv/app", window.QueuedJob!.RemotePath);
-            Assert.Equal(kind, window.QueuedJob.Kind);
-        }
+        Assert.NotNull(window.QueuedJob);
+        Assert.Equal("/srv/app", window.QueuedJob!.RemotePath);
+        Assert.Equal(@"D:\temp\report.txt", window.QueuedJob.LocalPath);
+        Assert.Equal(TransferKind.File, window.QueuedJob.Kind);
+        Assert.True(window.FilePickerWasShown);
+        Assert.False(window.FolderPickerWasShown);
+        Assert.False(window.TransferDialogWasShown);
+    }
+
+    [AvaloniaFact]
+    public async Task SidebarUploadFolder_UsesLocalFolderPicker_AndCurrentRemoteDirectory()
+    {
+        var window = new TestMainWindow
+        {
+            NextPickedLocalFolderPath = @"D:\temp\payload"
+        };
+
+        await window.StartSidebarUploadForTest(
+            profile: CreateNativeProfile(),
+            sessionId: Guid.Parse("f619f165-642b-4f83-9fef-785ca3473af5"),
+            remoteDirectory: "/srv/app",
+            kind: TransferKind.Folder);
+
+        Assert.NotNull(window.QueuedJob);
+        Assert.Equal("/srv/app", window.QueuedJob!.RemotePath);
+        Assert.Equal(@"D:\temp\payload", window.QueuedJob.LocalPath);
+        Assert.Equal(TransferKind.Folder, window.QueuedJob.Kind);
+        Assert.False(window.FilePickerWasShown);
+        Assert.True(window.FolderPickerWasShown);
+        Assert.False(window.TransferDialogWasShown);
     }
 
     [AvaloniaFact]
@@ -127,13 +146,31 @@ public sealed class MainWindowTransferFlowTests
     private sealed class TestMainWindow : NovaTerminal.MainWindow
     {
         public TransferDialogResult? NextTransferDialogResult { get; set; }
+        public string? NextPickedLocalFilePath { get; set; }
+        public string? NextPickedLocalFolderPath { get; set; }
         public TransferJob? QueuedJob { get; private set; }
         public TransferDialogRequest? LastTransferDialogRequest { get; private set; }
+        public bool TransferDialogWasShown { get; private set; }
+        public bool FilePickerWasShown { get; private set; }
+        public bool FolderPickerWasShown { get; private set; }
 
         internal override Task<TransferDialogResult?> ShowTransferDialogAsync(TransferDialogRequest request)
         {
             LastTransferDialogRequest = request;
+            TransferDialogWasShown = true;
             return Task.FromResult(NextTransferDialogResult);
+        }
+
+        internal override Task<string?> PickLocalUploadFilePathAsync()
+        {
+            FilePickerWasShown = true;
+            return Task.FromResult<string?>(NextPickedLocalFilePath);
+        }
+
+        internal override Task<string?> PickLocalUploadFolderPathAsync()
+        {
+            FolderPickerWasShown = true;
+            return Task.FromResult<string?>(NextPickedLocalFolderPath);
         }
 
         internal override void EnqueueTransferJob(TransferJob job)

--- a/tests/NovaTerminal.Tests/Core/RemoteFilesSidebarTests.cs
+++ b/tests/NovaTerminal.Tests/Core/RemoteFilesSidebarTests.cs
@@ -109,6 +109,85 @@ public sealed class RemoteFilesSidebarTests
     }
 
     [AvaloniaFact]
+    public async Task BackButton_IsDisabled_WhileLoadingNavigation()
+    {
+        var service = new ControlledRemoteDirectoryBrowserService();
+        service.EnqueueImmediate("/srv", RemoteSidebarListingResult.Success("/srv", new[]
+        {
+            new RemoteSidebarEntry("logs", "/srv/logs", true)
+        }));
+        service.EnqueueImmediate("/srv/logs", RemoteSidebarListingResult.Success("/srv/logs", Array.Empty<RemoteSidebarEntry>()));
+
+        var viewModel = new RemoteFilesSidebarViewModel(service);
+        var control = new RemoteFilesSidebar
+        {
+            DataContext = viewModel
+        };
+
+        await viewModel.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), "/srv", CancellationToken.None);
+
+        ListBox entriesList = control.FindControl<ListBox>("RemoteEntriesList")!;
+        Button navigateBackButton = control.FindControl<Button>("BtnNavigateBack")!;
+        entriesList.SelectedIndex = 0;
+        entriesList.RaiseEvent(new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Key = Key.Enter,
+            Source = entriesList
+        });
+        await WaitForConditionAsync(() => viewModel.CurrentPath == "/srv/logs");
+
+        Task navigateBackTask = viewModel.NavigateBackAsync();
+        await service.WaitForRequestAsync("/srv");
+
+        Assert.True(viewModel.CanNavigateBack);
+        Assert.True(viewModel.IsLoading);
+        Assert.False(navigateBackButton.IsEffectivelyEnabled);
+
+        service.CompletePending("/srv", RemoteSidebarListingResult.Success("/srv", Array.Empty<RemoteSidebarEntry>()));
+        await navigateBackTask;
+    }
+
+    [AvaloniaFact]
+    public async Task BackButton_IsDisabled_AfterDisconnect()
+    {
+        var service = new ControlledRemoteDirectoryBrowserService();
+        service.EnqueueImmediate("/srv", RemoteSidebarListingResult.Success("/srv", new[]
+        {
+            new RemoteSidebarEntry("logs", "/srv/logs", true)
+        }));
+        service.EnqueueImmediate("/srv/logs", RemoteSidebarListingResult.Success("/srv/logs", Array.Empty<RemoteSidebarEntry>()));
+
+        var viewModel = new RemoteFilesSidebarViewModel(service);
+        var control = new RemoteFilesSidebar
+        {
+            DataContext = viewModel
+        };
+
+        await viewModel.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), "/srv", CancellationToken.None);
+
+        ListBox entriesList = control.FindControl<ListBox>("RemoteEntriesList")!;
+        Button navigateBackButton = control.FindControl<Button>("BtnNavigateBack")!;
+        entriesList.SelectedIndex = 0;
+        entriesList.RaiseEvent(new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Key = Key.Enter,
+            Source = entriesList
+        });
+
+        await WaitForConditionAsync(() => viewModel.CurrentPath == "/srv/logs");
+        Assert.True(viewModel.CanNavigateBack);
+        Assert.True(navigateBackButton.IsEffectivelyEnabled);
+
+        viewModel.MarkDisconnected();
+
+        Assert.True(viewModel.CanNavigateBack);
+        Assert.True(viewModel.IsDisconnected);
+        Assert.False(navigateBackButton.IsEffectivelyEnabled);
+    }
+
+    [AvaloniaFact]
     public async Task EnterActivation_HandlesKeyEvent_BeforeAsyncNavigationCompletes()
     {
         var service = new ControlledRemoteDirectoryBrowserService();

--- a/tests/NovaTerminal.Tests/Core/RemoteFilesSidebarTests.cs
+++ b/tests/NovaTerminal.Tests/Core/RemoteFilesSidebarTests.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Media;
 using NovaTerminal.Controls;
 using NovaTerminal.Models;
 using NovaTerminal.Services.Ssh;
@@ -18,6 +19,20 @@ public sealed class RemoteFilesSidebarTests
 
         Border chrome = control.FindControl<Border>("SidebarChrome")!;
         Assert.Equal(288d, chrome.Width);
+    }
+
+    [AvaloniaFact]
+    public void Sidebar_UsesHostHeader_AndCompactPathRow()
+    {
+        var control = new RemoteFilesSidebar();
+
+        Assert.NotNull(control.FindControl<TextBlock>("HostTitleText"));
+        Assert.NotNull(control.FindControl<TextBlock>("HostSubtitleText"));
+
+        TextBlock currentPathText = control.FindControl<TextBlock>("CurrentPathText")!;
+        Assert.Equal(TextTrimming.CharacterEllipsis, currentPathText.TextTrimming);
+
+        Assert.NotNull(control.FindControl<TextBlock>("ItemCountText"));
     }
 
     [AvaloniaFact]

--- a/tests/NovaTerminal.Tests/Core/RemoteFilesSidebarTests.cs
+++ b/tests/NovaTerminal.Tests/Core/RemoteFilesSidebarTests.cs
@@ -60,15 +60,85 @@ public sealed class RemoteFilesSidebarTests
     }
 
     [AvaloniaFact]
-    public async Task ActivatingSelectedDirectory_NavigatesIntoDirectory()
+    public async Task NavigationButtons_AreDisabled_WhileLoading()
     {
+        var service = new ControlledRemoteDirectoryBrowserService();
         var viewModel = new RemoteFilesSidebarViewModel(
-            new FakeRemoteDirectoryBrowserService(
-                RemoteSidebarListingResult.Success("/srv", new[]
-                {
-                    new RemoteSidebarEntry("logs", "/srv/logs", true)
-                }),
-                RemoteSidebarListingResult.Success("/srv/logs", Array.Empty<RemoteSidebarEntry>())));
+            service);
+        var control = new RemoteFilesSidebar
+        {
+            DataContext = viewModel
+        };
+
+        Button navigateUpButton = control.FindControl<Button>("BtnNavigateUp")!;
+        Button refreshButton = control.FindControl<Button>("BtnRefresh")!;
+        Button jumpToCwdButton = control.FindControl<Button>("BtnJumpToCwd")!;
+
+        Task openTask = viewModel.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), "/srv", CancellationToken.None);
+        await service.WaitForRequestAsync("/srv");
+        viewModel.SetJumpToCurrentDirectoryCandidate("/srv/api");
+
+        Assert.True(viewModel.IsLoading);
+        Assert.False(navigateUpButton.IsEffectivelyEnabled);
+        Assert.False(refreshButton.IsEffectivelyEnabled);
+        Assert.False(jumpToCwdButton.IsEffectivelyEnabled);
+
+        service.CompletePending("/srv", RemoteSidebarListingResult.Success("/srv", Array.Empty<RemoteSidebarEntry>()));
+        await openTask;
+    }
+
+    [AvaloniaFact]
+    public async Task EnterActivation_HandlesKeyEvent_BeforeAsyncNavigationCompletes()
+    {
+        var service = new ControlledRemoteDirectoryBrowserService();
+        service.EnqueueImmediate("/srv", RemoteSidebarListingResult.Success("/srv", new[]
+        {
+            new RemoteSidebarEntry("logs", "/srv/logs", true)
+        }));
+
+        var viewModel = new RemoteFilesSidebarViewModel(service);
+        var control = new RemoteFilesSidebar
+        {
+            DataContext = viewModel
+        };
+
+        bool bubbledToParent = false;
+        control.AddHandler(InputElement.KeyDownEvent, (_, _) => bubbledToParent = true, RoutingStrategies.Bubble);
+
+        await viewModel.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), "/srv", CancellationToken.None);
+
+        ListBox entriesList = control.FindControl<ListBox>("RemoteEntriesList")!;
+        entriesList.SelectedIndex = 0;
+        var args = new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Key = Key.Enter,
+            Source = entriesList
+        };
+
+        entriesList.RaiseEvent(args);
+
+        Assert.True(args.Handled);
+        Assert.False(bubbledToParent);
+        Assert.True(viewModel.IsLoading);
+
+        await service.WaitForRequestAsync("/srv/logs");
+        service.CompletePending("/srv/logs", RemoteSidebarListingResult.Success("/srv/logs", Array.Empty<RemoteSidebarEntry>()));
+        await WaitForConditionAsync(() => viewModel.CurrentPath == "/srv/logs");
+
+        Assert.Equal("/srv/logs", viewModel.CurrentPath);
+    }
+
+    [AvaloniaFact]
+    public async Task DoubleTapActivation_NavigatesIntoDirectory()
+    {
+        var service = new ControlledRemoteDirectoryBrowserService();
+        service.EnqueueImmediate("/srv", RemoteSidebarListingResult.Success("/srv", new[]
+        {
+            new RemoteSidebarEntry("logs", "/srv/logs", true)
+        }));
+
+        var viewModel = new RemoteFilesSidebarViewModel(service);
         var control = new RemoteFilesSidebar
         {
             DataContext = viewModel
@@ -78,14 +148,28 @@ public sealed class RemoteFilesSidebarTests
 
         ListBox entriesList = control.FindControl<ListBox>("RemoteEntriesList")!;
         entriesList.SelectedIndex = 0;
-        entriesList.RaiseEvent(new KeyEventArgs
-        {
-            RoutedEvent = InputElement.KeyDownEvent,
-            Key = Key.Enter,
-            Source = entriesList
-        });
+        entriesList.RaiseEvent(new RoutedEventArgs(InputElement.DoubleTappedEvent));
+
+        await service.WaitForRequestAsync("/srv/logs");
+        service.CompletePending("/srv/logs", RemoteSidebarListingResult.Success("/srv/logs", Array.Empty<RemoteSidebarEntry>()));
+        await WaitForConditionAsync(() => viewModel.CurrentPath == "/srv/logs");
 
         Assert.Equal("/srv/logs", viewModel.CurrentPath);
+    }
+
+    private static async Task WaitForConditionAsync(Func<bool> predicate)
+    {
+        for (int attempt = 0; attempt < 50; attempt++)
+        {
+            if (predicate())
+            {
+                return;
+            }
+
+            await Task.Delay(10);
+        }
+
+        Assert.True(predicate(), "Timed out waiting for condition.");
     }
 
     private sealed class FakeRemoteDirectoryBrowserService : IRemoteDirectoryBrowserService
@@ -114,6 +198,94 @@ public sealed class RemoteFilesSidebarTests
             }
 
             return Task.FromResult(_results.Dequeue());
+        }
+    }
+
+    private sealed class ControlledRemoteDirectoryBrowserService : IRemoteDirectoryBrowserService
+    {
+        private readonly Dictionary<string, Queue<TaskCompletionSource<RemoteSidebarListingResult>>> _pendingRequests = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, Queue<RemoteSidebarListingResult>> _immediateResults = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, TaskCompletionSource<object?>> _requestSignals = new(StringComparer.Ordinal);
+
+        public void EnqueueImmediate(string remotePath, RemoteSidebarListingResult result)
+        {
+            if (!_immediateResults.TryGetValue(remotePath, out Queue<RemoteSidebarListingResult>? results))
+            {
+                results = new Queue<RemoteSidebarListingResult>();
+                _immediateResults[remotePath] = results;
+            }
+
+            results.Enqueue(result);
+        }
+
+        public async Task WaitForRequestAsync(string remotePath)
+        {
+            TaskCompletionSource<object?> signal;
+
+            lock (_requestSignals)
+            {
+                if (!_requestSignals.TryGetValue(remotePath, out signal!))
+                {
+                    signal = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    _requestSignals[remotePath] = signal;
+                }
+            }
+
+            await signal.Task;
+        }
+
+        public void CompletePending(string remotePath, RemoteSidebarListingResult result)
+        {
+            TaskCompletionSource<RemoteSidebarListingResult> pending;
+
+            lock (_pendingRequests)
+            {
+                pending = _pendingRequests[remotePath].Dequeue();
+            }
+
+            pending.SetResult(result);
+        }
+
+        public Task<RemoteSidebarListingResult> ListDirectoryAsync(
+            Guid profileId,
+            Guid sessionId,
+            string remotePath,
+            CancellationToken cancellationToken)
+        {
+            lock (_requestSignals)
+            {
+                if (_requestSignals.TryGetValue(remotePath, out TaskCompletionSource<object?>? existingSignal))
+                {
+                    existingSignal.TrySetResult(null);
+                }
+                else
+                {
+                    var signal = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    signal.SetResult(null);
+                    _requestSignals[remotePath] = signal;
+                }
+            }
+
+            if (_immediateResults.TryGetValue(remotePath, out Queue<RemoteSidebarListingResult>? immediateResults)
+                && immediateResults.Count > 0)
+            {
+                return Task.FromResult(immediateResults.Dequeue());
+            }
+
+            var pending = new TaskCompletionSource<RemoteSidebarListingResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            lock (_pendingRequests)
+            {
+                if (!_pendingRequests.TryGetValue(remotePath, out Queue<TaskCompletionSource<RemoteSidebarListingResult>>? requests))
+                {
+                    requests = new Queue<TaskCompletionSource<RemoteSidebarListingResult>>();
+                    _pendingRequests[remotePath] = requests;
+                }
+
+                requests.Enqueue(pending);
+            }
+
+            return pending.Task;
         }
     }
 }

--- a/tests/NovaTerminal.Tests/Core/RemoteFilesSidebarTests.cs
+++ b/tests/NovaTerminal.Tests/Core/RemoteFilesSidebarTests.cs
@@ -12,6 +12,27 @@ namespace NovaTerminal.Tests.Core;
 public sealed class RemoteFilesSidebarTests
 {
     [AvaloniaFact]
+    public void Sidebar_UsesCompactChromeWidth()
+    {
+        var control = new RemoteFilesSidebar();
+
+        Border chrome = control.FindControl<Border>("SidebarChrome")!;
+        Assert.Equal(288d, chrome.Width);
+    }
+
+    [AvaloniaFact]
+    public void Footer_UsesCompactDownloadActionLabel_AndPreservesExistingButtonBindings()
+    {
+        var control = new RemoteFilesSidebar();
+
+        Assert.NotNull(control.FindControl<Button>("BtnUploadFile"));
+        Assert.NotNull(control.FindControl<Button>("BtnUploadFolder"));
+
+        Button downloadButton = control.FindControl<Button>("BtnDownloadSelected")!;
+        Assert.Equal("Download", downloadButton.Content);
+    }
+
+    [AvaloniaFact]
     public void DownloadButton_IsDisabled_WhenNothingIsSelected()
     {
         var viewModel = new RemoteFilesSidebarViewModel(new FakeRemoteDirectoryBrowserService());

--- a/tests/NovaTerminal.Tests/Core/RemoteFilesSidebarTests.cs
+++ b/tests/NovaTerminal.Tests/Core/RemoteFilesSidebarTests.cs
@@ -1,12 +1,16 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
+using Avalonia.VisualTree;
 using NovaTerminal.Controls;
 using NovaTerminal.Models;
 using NovaTerminal.Services.Ssh;
 using NovaTerminal.ViewModels.Ssh;
+using System.IO;
+using System.Linq;
 
 namespace NovaTerminal.Tests.Core;
 
@@ -42,9 +46,146 @@ public sealed class RemoteFilesSidebarTests
 
         Assert.NotNull(control.FindControl<Button>("BtnUploadFile"));
         Assert.NotNull(control.FindControl<Button>("BtnUploadFolder"));
+        Assert.NotNull(control.FindControl<Button>("BtnDownloadSelected"));
+    }
 
-        Button downloadButton = control.FindControl<Button>("BtnDownloadSelected")!;
-        Assert.Equal("Download", downloadButton.Content);
+    [AvaloniaFact]
+    public async Task Sidebar_UsesEntryAndActionIcons()
+    {
+        var viewModel = new RemoteFilesSidebarViewModel(
+            new FakeRemoteDirectoryBrowserService(
+                "/srv",
+                new[]
+                {
+                    new RemoteSidebarEntry("alpha", "/srv/alpha", true),
+                    new RemoteSidebarEntry("access.log", "/srv/access.log", false)
+                }));
+        var control = new RemoteFilesSidebar
+        {
+            DataContext = viewModel
+        };
+        var window = new Window
+        {
+            Width = 320,
+            Height = 480,
+            Content = control
+        };
+
+        await viewModel.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), "/srv", CancellationToken.None);
+        window.Measure(new Size(320, 480));
+        window.Arrange(new Rect(0, 0, 320, 480));
+
+        PathIcon[] entryIcons = control.GetVisualDescendants()
+            .OfType<PathIcon>()
+            .Where(icon => icon.Name == "EntryTypeIcon")
+            .ToArray();
+        PathIcon? uploadFileIcon = control.GetVisualDescendants().OfType<PathIcon>().FirstOrDefault(icon => icon.Name == "UploadFileIcon");
+        PathIcon? uploadFolderIcon = control.GetVisualDescendants().OfType<PathIcon>().FirstOrDefault(icon => icon.Name == "UploadFolderIcon");
+        PathIcon? downloadSelectedIcon = control.GetVisualDescendants().OfType<PathIcon>().FirstOrDefault(icon => icon.Name == "DownloadSelectedIcon");
+        TextBlock? uploadFileLabel = control.GetVisualDescendants().OfType<TextBlock>().FirstOrDefault(text => text.Name == "UploadFileLabel");
+        TextBlock? uploadFolderLabel = control.GetVisualDescendants().OfType<TextBlock>().FirstOrDefault(text => text.Name == "UploadFolderLabel");
+        TextBlock? downloadSelectedLabel = control.GetVisualDescendants().OfType<TextBlock>().FirstOrDefault(text => text.Name == "DownloadSelectedLabel");
+
+        Assert.NotEmpty(entryIcons);
+        Assert.NotNull(uploadFileIcon);
+        Assert.NotNull(uploadFolderIcon);
+        Assert.NotNull(downloadSelectedIcon);
+        Assert.Equal("File", uploadFileLabel?.Text);
+        Assert.Equal("Folder", uploadFolderLabel?.Text);
+        Assert.Equal("Download", downloadSelectedLabel?.Text);
+    }
+
+    [AvaloniaFact]
+    public void NavigationButtons_UseIcons()
+    {
+        var control = new RemoteFilesSidebar();
+
+        Assert.NotNull(control.FindControl<PathIcon>("NavigateBackIcon"));
+        Assert.NotNull(control.FindControl<PathIcon>("NavigateUpIcon"));
+    }
+
+    [AvaloniaFact]
+    public async Task Sidebar_UsesMoreCompactItemAndButtonSizing()
+    {
+        var viewModel = new RemoteFilesSidebarViewModel(
+            new FakeRemoteDirectoryBrowserService(
+                "/srv",
+                new[]
+                {
+                    new RemoteSidebarEntry("access.log", "/srv/access.log", false)
+                }));
+        var control = new RemoteFilesSidebar
+        {
+            DataContext = viewModel
+        };
+        var window = new Window
+        {
+            Width = 320,
+            Height = 480,
+            Content = control
+        };
+
+        await viewModel.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), "/srv", CancellationToken.None);
+        window.Measure(new Size(320, 480));
+        window.Arrange(new Rect(0, 0, 320, 480));
+
+        ListBoxItem? listBoxItem = control.GetVisualDescendants().OfType<ListBoxItem>().FirstOrDefault();
+        Button navigateBackButton = control.FindControl<Button>("BtnNavigateBack")!;
+        Button uploadFileButton = control.FindControl<Button>("BtnUploadFile")!;
+
+        Assert.NotNull(listBoxItem);
+        Assert.Equal(new Thickness(2), listBoxItem!.Padding);
+        Assert.Equal(new Thickness(3, 2), navigateBackButton.Padding);
+        Assert.Equal(new Thickness(6, 2), uploadFileButton.Padding);
+    }
+
+    [AvaloniaFact]
+    public void Sidebar_DefinesVisibleSelectedEntryStyle()
+    {
+        string sidebarPath = FindRepoFile("src", "NovaTerminal.App", "Controls", "RemoteFilesSidebar.axaml");
+        string xaml = File.ReadAllText(sidebarPath);
+
+        Assert.Contains("<Style Selector=\"^:selected\">", xaml);
+        Assert.Contains("<Setter Property=\"Background\" Value=\"#25384B\"/>", xaml);
+        Assert.Contains("<Setter Property=\"BorderBrush\" Value=\"#4E6A86\"/>", xaml);
+    }
+
+    [AvaloniaFact]
+    public async Task Sidebar_UsesDenseTwoColumnEntryTemplate()
+    {
+        var viewModel = new RemoteFilesSidebarViewModel(
+            new FakeRemoteDirectoryBrowserService(
+                "/srv",
+                new[]
+                {
+                    new RemoteSidebarEntry("access.log", "/srv/access.log", false)
+                    {
+                        ModifiedAtUtc = new DateTime(2026, 5, 4, 20, 15, 0, DateTimeKind.Utc)
+                    }
+                }));
+        var control = new RemoteFilesSidebar
+        {
+            DataContext = viewModel
+        };
+        var window = new Window
+        {
+            Width = 320,
+            Height = 480,
+            Content = control
+        };
+
+        await viewModel.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), "/srv", CancellationToken.None);
+        window.Measure(new Size(320, 480));
+        window.Arrange(new Rect(0, 0, 320, 480));
+
+        Grid? rowGrid = control.GetVisualDescendants().OfType<Grid>().FirstOrDefault(grid => grid.Name == "EntryRowGrid");
+        TextBlock? modifiedText = control.GetVisualDescendants().OfType<TextBlock>().FirstOrDefault(text => text.Name == "EntryModifiedText");
+        TextBlock? pathText = control.GetVisualDescendants().OfType<TextBlock>().FirstOrDefault(text => text.Name == "EntryPathText");
+
+        Assert.NotNull(rowGrid);
+        Assert.NotNull(modifiedText);
+        Assert.Equal("May 04", modifiedText!.Text);
+        Assert.Null(pathText);
     }
 
     [AvaloniaFact]
@@ -285,6 +426,24 @@ public sealed class RemoteFilesSidebarTests
         }
 
         Assert.True(predicate(), "Timed out waiting for condition.");
+    }
+
+    private static string FindRepoFile(params string[] relativeSegments)
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+
+        while (directory != null)
+        {
+            string candidate = Path.Combine(new[] { directory.FullName }.Concat(relativeSegments).ToArray());
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException($"Could not locate repo file: {Path.Combine(relativeSegments)}");
     }
 
     private sealed class FakeRemoteDirectoryBrowserService : IRemoteDirectoryBrowserService

--- a/tests/NovaTerminal.Tests/Core/RemoteFilesSidebarTests.cs
+++ b/tests/NovaTerminal.Tests/Core/RemoteFilesSidebarTests.cs
@@ -1,0 +1,119 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using NovaTerminal.Controls;
+using NovaTerminal.Models;
+using NovaTerminal.Services.Ssh;
+using NovaTerminal.ViewModels.Ssh;
+
+namespace NovaTerminal.Tests.Core;
+
+public sealed class RemoteFilesSidebarTests
+{
+    [AvaloniaFact]
+    public void DownloadButton_IsDisabled_WhenNothingIsSelected()
+    {
+        var viewModel = new RemoteFilesSidebarViewModel(new FakeRemoteDirectoryBrowserService());
+        var control = new RemoteFilesSidebar
+        {
+            DataContext = viewModel
+        };
+
+        Button button = control.FindControl<Button>("BtnDownloadSelected")!;
+        Assert.False(button.IsEnabled);
+    }
+
+    [AvaloniaFact]
+    public async Task InlineErrorText_IsVisible_WhenErrorMessageIsSet()
+    {
+        var viewModel = new RemoteFilesSidebarViewModel(
+            new FakeRemoteDirectoryBrowserService(
+                RemoteSidebarListingResult.Failure("/srv", "permission denied")));
+        var control = new RemoteFilesSidebar
+        {
+            DataContext = viewModel
+        };
+
+        await viewModel.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), "/srv", CancellationToken.None);
+
+        TextBlock errorText = control.FindControl<TextBlock>("InlineErrorText")!;
+        Assert.True(errorText.IsVisible);
+        Assert.Equal("permission denied", errorText.Text);
+    }
+
+    [AvaloniaFact]
+    public async Task JumpToCurrentDirectoryButton_IsVisible_WhenCandidatePathExists()
+    {
+        var viewModel = new RemoteFilesSidebarViewModel(
+            new FakeRemoteDirectoryBrowserService("/srv", Array.Empty<RemoteSidebarEntry>()));
+        var control = new RemoteFilesSidebar
+        {
+            DataContext = viewModel
+        };
+
+        await viewModel.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), "/srv", CancellationToken.None);
+        viewModel.SetJumpToCurrentDirectoryCandidate("/srv/api");
+
+        Button button = control.FindControl<Button>("BtnJumpToCwd")!;
+        Assert.True(button.IsVisible);
+    }
+
+    [AvaloniaFact]
+    public async Task ActivatingSelectedDirectory_NavigatesIntoDirectory()
+    {
+        var viewModel = new RemoteFilesSidebarViewModel(
+            new FakeRemoteDirectoryBrowserService(
+                RemoteSidebarListingResult.Success("/srv", new[]
+                {
+                    new RemoteSidebarEntry("logs", "/srv/logs", true)
+                }),
+                RemoteSidebarListingResult.Success("/srv/logs", Array.Empty<RemoteSidebarEntry>())));
+        var control = new RemoteFilesSidebar
+        {
+            DataContext = viewModel
+        };
+
+        await viewModel.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), "/srv", CancellationToken.None);
+
+        ListBox entriesList = control.FindControl<ListBox>("RemoteEntriesList")!;
+        entriesList.SelectedIndex = 0;
+        entriesList.RaiseEvent(new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Key = Key.Enter,
+            Source = entriesList
+        });
+
+        Assert.Equal("/srv/logs", viewModel.CurrentPath);
+    }
+
+    private sealed class FakeRemoteDirectoryBrowserService : IRemoteDirectoryBrowserService
+    {
+        private readonly Queue<RemoteSidebarListingResult> _results;
+
+        public FakeRemoteDirectoryBrowserService(string resolvedPath, IReadOnlyList<RemoteSidebarEntry> entries)
+            : this(RemoteSidebarListingResult.Success(resolvedPath, entries))
+        {
+        }
+
+        public FakeRemoteDirectoryBrowserService(params RemoteSidebarListingResult[] results)
+        {
+            _results = new Queue<RemoteSidebarListingResult>(results);
+        }
+
+        public Task<RemoteSidebarListingResult> ListDirectoryAsync(
+            Guid profileId,
+            Guid sessionId,
+            string remotePath,
+            CancellationToken cancellationToken)
+        {
+            if (_results.Count == 0)
+            {
+                throw new InvalidOperationException("No more results configured.");
+            }
+
+            return Task.FromResult(_results.Dequeue());
+        }
+    }
+}

--- a/tests/NovaTerminal.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs
+++ b/tests/NovaTerminal.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs
@@ -1,0 +1,150 @@
+using Avalonia.Headless.XUnit;
+using NovaTerminal.Controls;
+using NovaTerminal.Core;
+using NovaTerminal.Core.Ssh.Models;
+using NovaTerminal.Models;
+using NovaTerminal.Services.Ssh;
+
+namespace NovaTerminal.Tests.Core;
+
+public sealed class TerminalPaneRemoteFilesSidebarTests
+{
+    [AvaloniaFact]
+    public void Sidebar_HidesImmediately_WhenAltScreenBecomesActive()
+    {
+        var pane = new TerminalPane();
+
+        pane.ShowRemoteFilesSidebarForTest();
+        pane.HandleAltScreenChangedForTest(true);
+
+        Assert.False(pane.IsRemoteFilesSidebarVisibleForTest());
+    }
+
+    [AvaloniaFact]
+    public void SidebarEntryPoint_IsUnavailable_ForLocalPane()
+    {
+        var pane = new TerminalPane(new TerminalProfile
+        {
+            Name = "PowerShell",
+            Type = ConnectionType.Local,
+            Command = "pwsh.exe"
+        });
+
+        Assert.False(pane.IsRemoteFilesSidebarEntryAvailableForTest());
+    }
+
+    [AvaloniaFact]
+    public void SidebarEntryPoint_IsUnavailable_ForOpenSshPane()
+    {
+        var pane = new TerminalPane(new TerminalProfile
+        {
+            Name = "OpenSSH",
+            Type = ConnectionType.SSH,
+            SshBackendKind = SshBackendKind.OpenSsh,
+            SshHost = "server.example",
+            SshUser = "nova"
+        });
+
+        Assert.False(pane.IsRemoteFilesSidebarEntryAvailableForTest());
+    }
+
+    [AvaloniaFact]
+    public void OpeningSidebar_PrefersPaneWorkingDirectory_OverProfileDefault()
+    {
+        var service = new RecordingRemoteDirectoryBrowserService(
+            RemoteSidebarListingResult.Success("/srv/app", Array.Empty<RemoteSidebarEntry>()));
+        var pane = new TerminalPane(new TerminalProfile
+        {
+            Name = "Native SSH",
+            Type = ConnectionType.SSH,
+            SshBackendKind = SshBackendKind.Native,
+            SshHost = "server.example",
+            SshUser = "nova",
+            DefaultRemoteDir = "~/downloads"
+        });
+
+        pane.ConfigureRemoteFilesSidebarForTest(service);
+        pane.HandleWorkingDirectoryChangedForTest("/srv/app");
+
+        pane.ShowRemoteFilesSidebarForTest();
+
+        Assert.Equal(new[] { "/srv/app" }, service.RequestedPaths);
+        Assert.Equal("/srv/app", pane.GetRemoteFilesSidebarCurrentPathForTest());
+    }
+
+    [AvaloniaFact]
+    public void OpeningSidebar_FallsBackToProfileDefault_WhenPaneWorkingDirectoryIsMissing()
+    {
+        var service = new RecordingRemoteDirectoryBrowserService(
+            RemoteSidebarListingResult.Success("~/downloads", Array.Empty<RemoteSidebarEntry>()));
+        var pane = new TerminalPane(new TerminalProfile
+        {
+            Name = "Native SSH",
+            Type = ConnectionType.SSH,
+            SshBackendKind = SshBackendKind.Native,
+            SshHost = "server.example",
+            SshUser = "nova",
+            DefaultRemoteDir = "~/downloads"
+        });
+
+        pane.ConfigureRemoteFilesSidebarForTest(service);
+
+        pane.ShowRemoteFilesSidebarForTest();
+
+        Assert.Equal(new[] { "~/downloads" }, service.RequestedPaths);
+        Assert.Equal("~/downloads", pane.GetRemoteFilesSidebarCurrentPathForTest());
+    }
+
+    [AvaloniaFact]
+    public void WorkingDirectoryChanged_UpdatesJumpAffordance_WithoutForcingNavigation()
+    {
+        var service = new RecordingRemoteDirectoryBrowserService(
+            RemoteSidebarListingResult.Success("~/downloads", Array.Empty<RemoteSidebarEntry>()));
+        var pane = new TerminalPane(new TerminalProfile
+        {
+            Name = "Native SSH",
+            Type = ConnectionType.SSH,
+            SshBackendKind = SshBackendKind.Native,
+            SshHost = "server.example",
+            SshUser = "nova",
+            DefaultRemoteDir = "~/downloads"
+        });
+
+        pane.ConfigureRemoteFilesSidebarForTest(service);
+        pane.ShowRemoteFilesSidebarForTest();
+
+        pane.HandleWorkingDirectoryChangedForTest("/srv/app");
+
+        Assert.Equal("~/downloads", pane.GetRemoteFilesSidebarCurrentPathForTest());
+        Assert.Equal("/srv/app", pane.GetRemoteFilesSidebarJumpTargetForTest());
+        Assert.Equal(new[] { "~/downloads" }, service.RequestedPaths);
+    }
+
+    private sealed class RecordingRemoteDirectoryBrowserService : IRemoteDirectoryBrowserService
+    {
+        private readonly Queue<RemoteSidebarListingResult> _results;
+
+        public RecordingRemoteDirectoryBrowserService(params RemoteSidebarListingResult[] results)
+        {
+            _results = new Queue<RemoteSidebarListingResult>(results);
+        }
+
+        public List<string> RequestedPaths { get; } = new();
+
+        public Task<RemoteSidebarListingResult> ListDirectoryAsync(
+            Guid profileId,
+            Guid sessionId,
+            string remotePath,
+            CancellationToken cancellationToken)
+        {
+            RequestedPaths.Add(remotePath);
+
+            if (_results.Count == 0)
+            {
+                throw new InvalidOperationException("No more sidebar results configured.");
+            }
+
+            return Task.FromResult(_results.Dequeue());
+        }
+    }
+}

--- a/tests/NovaTerminal.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs
+++ b/tests/NovaTerminal.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs
@@ -10,6 +10,23 @@ namespace NovaTerminal.Tests.Core;
 public sealed class TerminalPaneRemoteFilesSidebarTests
 {
     [AvaloniaFact]
+    public void NativeSshPane_ContextMenu_KeepsOnlyRemoteFilesEntry()
+    {
+        var pane = new TerminalPane(new TerminalProfile
+        {
+            Name = "Native SSH",
+            Type = ConnectionType.SSH,
+            SshBackendKind = SshBackendKind.Native,
+            SshHost = "server.example",
+            SshUser = "nova"
+        });
+
+        IReadOnlyList<string> names = pane.GetSftpContextMenuItemNamesForTest();
+
+        Assert.Equal(new[] { "MenuToggleRemoteFilesSidebar" }, names);
+    }
+
+    [AvaloniaFact]
     public void Sidebar_HidesImmediately_WhenAltScreenBecomesActive()
     {
         var pane = new TerminalPane();

--- a/tests/NovaTerminal.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs
+++ b/tests/NovaTerminal.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs
@@ -120,6 +120,30 @@ public sealed class TerminalPaneRemoteFilesSidebarTests
         Assert.Equal(new[] { "~/downloads" }, service.RequestedPaths);
     }
 
+    [AvaloniaFact]
+    public void SessionExit_KeepsSidebarVisibleInDisconnectedState()
+    {
+        var pane = new TerminalPane(new TerminalProfile
+        {
+            Name = "Native SSH",
+            Type = ConnectionType.SSH,
+            SshBackendKind = SshBackendKind.Native,
+            SshHost = "server.example",
+            SshUser = "nova",
+            DefaultRemoteDir = "~/downloads"
+        });
+
+        pane.ConfigureRemoteFilesSidebarForTest(new RecordingRemoteDirectoryBrowserService(
+            RemoteSidebarListingResult.Success("~/downloads", Array.Empty<RemoteSidebarEntry>())));
+        pane.ShowRemoteFilesSidebarForTest();
+
+        pane.HandleSessionExitForTesting(255);
+
+        Assert.True(pane.IsRemoteFilesSidebarVisibleForTest());
+        Assert.True(pane.IsRemoteFilesSidebarDisconnectedForTest());
+        Assert.False(pane.IsRemoteFilesSidebarEntryAvailableForTest());
+    }
+
     private sealed class RecordingRemoteDirectoryBrowserService : IRemoteDirectoryBrowserService
     {
         private readonly Queue<RemoteSidebarListingResult> _results;

--- a/tests/NovaTerminal.Tests/Core/TransferDialogRequestTests.cs
+++ b/tests/NovaTerminal.Tests/Core/TransferDialogRequestTests.cs
@@ -26,26 +26,6 @@ public sealed class TransferDialogRequestTests
     }
 
     [Fact]
-    public void ForSidebarAction_UsesProvidedRemotePath_AndPrefersLocalPathFocus()
-    {
-        Guid profileId = Guid.Parse("9a3c66f6-0aab-4b6d-9c0f-9d8d8568a0ee");
-        Guid sessionId = Guid.Parse("65e3dbca-7df7-4698-b6ee-9e12d2f3c7e5");
-        TransferDialogRequest request = TransferDialogRequest.ForSidebarAction(
-            direction: TransferDirection.Download,
-            kind: TransferKind.Folder,
-            remotePath: "/srv/logs",
-            profileId: profileId,
-            sessionId: sessionId);
-
-        Assert.Equal(TransferDirection.Download, request.Direction);
-        Assert.Equal(TransferKind.Folder, request.Kind);
-        Assert.Equal("/srv/logs", request.RemotePath);
-        Assert.Equal(profileId, request.ProfileId);
-        Assert.Equal(sessionId, request.SessionId);
-        Assert.True(request.PreferLocalPathOnOpen);
-    }
-
-    [Fact]
     public void Result_CreateConfirmed_PreservesSelectedPaths()
     {
         TransferDialogResult result = TransferDialogResult.CreateConfirmed(

--- a/tests/NovaTerminal.Tests/Core/TransferDialogRequestTests.cs
+++ b/tests/NovaTerminal.Tests/Core/TransferDialogRequestTests.cs
@@ -22,6 +22,27 @@ public sealed class TransferDialogRequestTests
         Assert.Equal("~/downloads", request.RemotePath);
         Assert.Equal(profileId, request.ProfileId);
         Assert.Equal(sessionId, request.SessionId);
+        Assert.False(request.PreferLocalPathOnOpen);
+    }
+
+    [Fact]
+    public void ForSidebarAction_UsesProvidedRemotePath_AndPrefersLocalPathFocus()
+    {
+        Guid profileId = Guid.Parse("9a3c66f6-0aab-4b6d-9c0f-9d8d8568a0ee");
+        Guid sessionId = Guid.Parse("65e3dbca-7df7-4698-b6ee-9e12d2f3c7e5");
+        TransferDialogRequest request = TransferDialogRequest.ForSidebarAction(
+            direction: TransferDirection.Download,
+            kind: TransferKind.Folder,
+            remotePath: "/srv/logs",
+            profileId: profileId,
+            sessionId: sessionId);
+
+        Assert.Equal(TransferDirection.Download, request.Direction);
+        Assert.Equal(TransferKind.Folder, request.Kind);
+        Assert.Equal("/srv/logs", request.RemotePath);
+        Assert.Equal(profileId, request.ProfileId);
+        Assert.Equal(sessionId, request.SessionId);
+        Assert.True(request.PreferLocalPathOnOpen);
     }
 
     [Fact]

--- a/tests/NovaTerminal.Tests/Ssh/ActiveSshSessionRegistryTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/ActiveSshSessionRegistryTests.cs
@@ -69,4 +69,38 @@ public sealed class ActiveSshSessionRegistryTests
 
         Assert.False(registry.TryGetRuntimePassword(sessionId, out _));
     }
+
+    [Fact]
+    public void TryGetActiveNativeSession_WhenProfileAndBackendMatch_ReturnsDescriptor()
+    {
+        var registry = new ActiveSshSessionRegistry();
+        Guid sessionId = Guid.NewGuid();
+        Guid profileId = Guid.NewGuid();
+        registry.Register(new ActiveSshSessionDescriptor(sessionId, profileId, SshBackendKind.Native));
+
+        Assert.True(registry.TryGetActiveNativeSession(profileId, sessionId, out ActiveSshSessionDescriptor? descriptor));
+        Assert.NotNull(descriptor);
+        Assert.Equal(sessionId, descriptor!.SessionId);
+    }
+
+    [Fact]
+    public void TryGetActiveNativeSession_WhenProfileDiffers_ReturnsFalse()
+    {
+        var registry = new ActiveSshSessionRegistry();
+        Guid sessionId = Guid.NewGuid();
+        registry.Register(new ActiveSshSessionDescriptor(sessionId, Guid.NewGuid(), SshBackendKind.Native));
+
+        Assert.False(registry.TryGetActiveNativeSession(Guid.NewGuid(), sessionId, out _));
+    }
+
+    [Fact]
+    public void TryGetActiveNativeSession_WhenBackendIsNotNative_ReturnsFalse()
+    {
+        var registry = new ActiveSshSessionRegistry();
+        Guid sessionId = Guid.NewGuid();
+        Guid profileId = Guid.NewGuid();
+        registry.Register(new ActiveSshSessionDescriptor(sessionId, profileId, SshBackendKind.OpenSsh));
+
+        Assert.False(registry.TryGetActiveNativeSession(profileId, sessionId, out _));
+    }
 }

--- a/tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs
@@ -1,3 +1,4 @@
+using NovaTerminal.Core;
 using NovaTerminal.Core.Ssh.Models;
 using NovaTerminal.ViewModels.Ssh;
 
@@ -205,6 +206,25 @@ public sealed class NewSshConnectionViewModelTests
         SshProfile profile = vm.ToSshProfile();
 
         Assert.False(profile.RememberPasswordInVault);
+    }
+
+    [Fact]
+    public void RemoteShellKind_RoundTripsBetweenViewModelAndSshProfile()
+    {
+        var vm = new NewSshConnectionViewModel
+        {
+            Name = "Bash Host",
+            HostName = "bash.internal",
+            RemoteShellKind = RemoteShellKind.Bash
+        };
+
+        SshProfile profile = vm.ToSshProfile();
+        Assert.Equal(RemoteShellKind.Bash, profile.RemoteShellKind);
+
+        var roundTripped = new NewSshConnectionViewModel();
+        roundTripped.ApplySshProfile(profile);
+
+        Assert.Equal(RemoteShellKind.Bash, roundTripped.RemoteShellKind);
     }
 
     [Fact]

--- a/tests/NovaTerminal.Tests/Ssh/RemoteDirectoryBrowserServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/RemoteDirectoryBrowserServiceTests.cs
@@ -1,0 +1,231 @@
+using NovaTerminal.Core;
+using NovaTerminal.Core.Ssh.Models;
+using NovaTerminal.Core.Ssh.Native;
+using NovaTerminal.Core.Ssh.Storage;
+using NovaTerminal.Models;
+using NovaTerminal.Services.Ssh;
+
+namespace NovaTerminal.Tests.Ssh;
+
+public sealed class RemoteDirectoryBrowserServiceTests
+{
+    [Fact]
+    public async Task ListDirectoryAsync_WhenActiveNativeSessionExists_ReturnsDirectoriesBeforeFiles()
+    {
+        Guid profileId = Guid.NewGuid();
+        Guid sessionId = Guid.NewGuid();
+        var registry = new ActiveSshSessionRegistry();
+        registry.Register(new ActiveSshSessionDescriptor(sessionId, profileId, SshBackendKind.Native));
+
+        var interop = new RecordingNativeSshInterop(
+            new[]
+            {
+                new NativeRemotePathEntry("b.txt", "/srv/b.txt", false),
+                new NativeRemotePathEntry("alpha", "/srv/alpha", true)
+            });
+
+        var service = CreateService(registry, interop, CreateSshService(profileId));
+        RemoteSidebarListingResult result = await service.ListDirectoryAsync(profileId, sessionId, "/srv", CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Collection(
+            result.Entries,
+            entry => Assert.Equal("alpha", entry.Name),
+            entry => Assert.Equal("b.txt", entry.Name));
+    }
+
+    [Fact]
+    public async Task ListDirectoryAsync_WhenNoActiveNativeSessionExists_ReturnsFailureWithoutThrowing()
+    {
+        Guid profileId = Guid.NewGuid();
+        Guid sessionId = Guid.NewGuid();
+        var service = CreateService(
+            new ActiveSshSessionRegistry(),
+            new RecordingNativeSshInterop(Array.Empty<NativeRemotePathEntry>()),
+            CreateSshService(profileId));
+
+        RemoteSidebarListingResult result = await service.ListDirectoryAsync(profileId, sessionId, "/srv", CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("/srv", result.ResolvedPath);
+        Assert.Empty(result.Entries);
+        Assert.NotNull(result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ListDirectoryAsync_WhenSessionIsNotNative_ReturnsFailureWithoutThrowing()
+    {
+        Guid profileId = Guid.NewGuid();
+        Guid sessionId = Guid.NewGuid();
+        var registry = new ActiveSshSessionRegistry();
+        registry.Register(new ActiveSshSessionDescriptor(sessionId, profileId, SshBackendKind.OpenSsh));
+        var service = CreateService(
+            registry,
+            new RecordingNativeSshInterop(Array.Empty<NativeRemotePathEntry>()),
+            CreateSshService(profileId));
+
+        RemoteSidebarListingResult result = await service.ListDirectoryAsync(profileId, sessionId, "/srv", CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("/srv", result.ResolvedPath);
+        Assert.Empty(result.Entries);
+        Assert.NotNull(result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ListDirectoryAsync_WhenListingFails_ReturnsInlineErrorPayload()
+    {
+        Guid profileId = Guid.NewGuid();
+        Guid sessionId = Guid.NewGuid();
+        var registry = new ActiveSshSessionRegistry();
+        registry.Register(new ActiveSshSessionDescriptor(sessionId, profileId, SshBackendKind.Native));
+        var service = CreateService(
+            registry,
+            new ThrowingNativeSshInterop(new InvalidOperationException("permission denied")),
+            CreateSshService(profileId));
+
+        RemoteSidebarListingResult result = await service.ListDirectoryAsync(profileId, sessionId, "/srv", CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("/srv", result.ResolvedPath);
+        Assert.Empty(result.Entries);
+        Assert.Equal("permission denied", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ListDirectoryAsync_WhenRemotePathIsBlank_NormalizesToHomeDirectory()
+    {
+        Guid profileId = Guid.NewGuid();
+        Guid sessionId = Guid.NewGuid();
+        var registry = new ActiveSshSessionRegistry();
+        registry.Register(new ActiveSshSessionDescriptor(sessionId, profileId, SshBackendKind.Native));
+        var interop = new RecordingNativeSshInterop(
+            new[]
+            {
+                new NativeRemotePathEntry("logs", "~/logs", true)
+            });
+        var service = CreateService(registry, interop, CreateSshService(profileId));
+
+        RemoteSidebarListingResult result = await service.ListDirectoryAsync(profileId, sessionId, "   ", CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("~", result.ResolvedPath);
+        Assert.Equal("~", interop.LastRemotePath);
+    }
+
+    private static RemoteDirectoryBrowserService CreateService(
+        ActiveSshSessionRegistry registry,
+        INativeSshInterop interop,
+        SshConnectionService sshService,
+        Func<TerminalProfile, string?>? passwordResolver = null)
+    {
+        return new RemoteDirectoryBrowserService(
+            interop,
+            registry,
+            () => sshService,
+            passwordResolver);
+    }
+
+    private static SshConnectionService CreateSshService(Guid profileId)
+    {
+        var store = new TestSshProfileStore();
+        store.SaveProfile(new SshProfile
+        {
+            Id = profileId,
+            Name = "server3",
+            BackendKind = SshBackendKind.Native,
+            Host = "prod.internal",
+            User = "ops",
+            Port = 2200,
+            AuthMode = SshAuthMode.Default
+        });
+
+        return new SshConnectionService(store);
+    }
+
+    private sealed class TestSshProfileStore : ISshProfileStore
+    {
+        private readonly Dictionary<Guid, SshProfile> _profiles = new();
+
+        public IReadOnlyList<SshProfile> GetProfiles() => _profiles.Values.ToList();
+
+        public SshProfile? GetProfile(Guid profileId)
+        {
+            return _profiles.TryGetValue(profileId, out SshProfile? profile) ? profile : null;
+        }
+
+        public void SaveProfile(SshProfile profile)
+        {
+            _profiles[profile.Id] = profile;
+        }
+
+        public bool DeleteProfile(Guid profileId) => _profiles.Remove(profileId);
+    }
+
+    private sealed class RecordingNativeSshInterop : INativeSshInterop
+    {
+        private readonly IReadOnlyList<NativeRemotePathEntry> _entries;
+
+        public RecordingNativeSshInterop(IReadOnlyList<NativeRemotePathEntry> entries)
+        {
+            _entries = entries;
+        }
+
+        public string? LastRemotePath { get; private set; }
+        public NativeSshConnectionOptions? LastConnectionOptions { get; private set; }
+
+        public IntPtr Connect(NativeSshConnectionOptions options) => throw new NotSupportedException();
+
+        public IReadOnlyList<NativeRemotePathEntry> ListRemoteDirectory(
+            NativeSshConnectionOptions connectionOptions,
+            string remotePath,
+            CancellationToken cancellationToken)
+        {
+            LastConnectionOptions = connectionOptions;
+            LastRemotePath = remotePath;
+            return _entries;
+        }
+
+        public void RunSftpTransfer(NativeSshConnectionOptions connectionOptions, NativeSftpTransferOptions transferOptions, Action<NativeSftpTransferProgress>? progress, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public NativeSshEvent? PollEvent(IntPtr sessionHandle) => throw new NotSupportedException();
+        public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void Resize(IntPtr sessionHandle, int cols, int rows) => throw new NotSupportedException();
+        public int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options) => throw new NotSupportedException();
+        public void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void SendChannelEof(IntPtr sessionHandle, int channelId) => throw new NotSupportedException();
+        public void CloseChannel(IntPtr sessionHandle, int channelId) => throw new NotSupportedException();
+        public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void Close(IntPtr sessionHandle) => throw new NotSupportedException();
+    }
+
+    private sealed class ThrowingNativeSshInterop : INativeSshInterop
+    {
+        private readonly Exception _exception;
+
+        public ThrowingNativeSshInterop(Exception exception)
+        {
+            _exception = exception;
+        }
+
+        public IntPtr Connect(NativeSshConnectionOptions options) => throw new NotSupportedException();
+
+        public IReadOnlyList<NativeRemotePathEntry> ListRemoteDirectory(
+            NativeSshConnectionOptions connectionOptions,
+            string remotePath,
+            CancellationToken cancellationToken)
+        {
+            throw _exception;
+        }
+
+        public void RunSftpTransfer(NativeSshConnectionOptions connectionOptions, NativeSftpTransferOptions transferOptions, Action<NativeSftpTransferProgress>? progress, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public NativeSshEvent? PollEvent(IntPtr sessionHandle) => throw new NotSupportedException();
+        public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void Resize(IntPtr sessionHandle, int cols, int rows) => throw new NotSupportedException();
+        public int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options) => throw new NotSupportedException();
+        public void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void SendChannelEof(IntPtr sessionHandle, int channelId) => throw new NotSupportedException();
+        public void CloseChannel(IntPtr sessionHandle, int channelId) => throw new NotSupportedException();
+        public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void Close(IntPtr sessionHandle) => throw new NotSupportedException();
+    }
+}

--- a/tests/NovaTerminal.Tests/Ssh/RemoteDirectoryBrowserServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/RemoteDirectoryBrowserServiceTests.cs
@@ -35,6 +35,28 @@ public sealed class RemoteDirectoryBrowserServiceTests
     }
 
     [Fact]
+    public async Task ListDirectoryAsync_PreservesModifiedTimeMetadata()
+    {
+        DateTime modifiedAtUtc = new(2026, 5, 4, 20, 15, 0, DateTimeKind.Utc);
+        Guid profileId = Guid.NewGuid();
+        Guid sessionId = Guid.NewGuid();
+        var registry = new ActiveSshSessionRegistry();
+        registry.Register(new ActiveSshSessionDescriptor(sessionId, profileId, SshBackendKind.Native));
+
+        var interop = new RecordingNativeSshInterop(
+            new[]
+            {
+                new NativeRemotePathEntry("access.log", "/srv/access.log", false, modifiedAtUtc)
+            });
+
+        var service = CreateService(registry, interop, CreateSshService(profileId));
+        RemoteSidebarListingResult result = await service.ListDirectoryAsync(profileId, sessionId, "/srv", CancellationToken.None);
+
+        RemoteSidebarEntry entry = Assert.Single(result.Entries);
+        Assert.Equal(modifiedAtUtc, entry.ModifiedAtUtc);
+    }
+
+    [Fact]
     public async Task ListDirectoryAsync_WhenNoActiveNativeSessionExists_ReturnsFailureWithoutThrowing()
     {
         Guid profileId = Guid.NewGuid();

--- a/tests/NovaTerminal.Tests/Ssh/RemoteDirectoryBrowserServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/RemoteDirectoryBrowserServiceTests.cs
@@ -113,6 +113,53 @@ public sealed class RemoteDirectoryBrowserServiceTests
         Assert.Equal("~", interop.LastRemotePath);
     }
 
+    [Fact]
+    public async Task ListDirectoryAsync_WhenRemotePathIsNonBlank_PreservesOriginalWhitespace()
+    {
+        Guid profileId = Guid.NewGuid();
+        Guid sessionId = Guid.NewGuid();
+        var registry = new ActiveSshSessionRegistry();
+        registry.Register(new ActiveSshSessionDescriptor(sessionId, profileId, SshBackendKind.Native));
+        var interop = new RecordingNativeSshInterop(
+            new[]
+            {
+                new NativeRemotePathEntry("logs", "/srv/logs", true)
+            });
+        const string remotePath = "  /srv/app  ";
+        var service = CreateService(registry, interop, CreateSshService(profileId));
+
+        RemoteSidebarListingResult result = await service.ListDirectoryAsync(profileId, sessionId, remotePath, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(remotePath, result.ResolvedPath);
+        Assert.Equal(remotePath, interop.LastRemotePath);
+    }
+
+    [Fact]
+    public async Task ListDirectoryAsync_PropagatesKeepAliveSettings_ToNativeListingConnection()
+    {
+        Guid profileId = Guid.NewGuid();
+        Guid sessionId = Guid.NewGuid();
+        var registry = new ActiveSshSessionRegistry();
+        registry.Register(new ActiveSshSessionDescriptor(sessionId, profileId, SshBackendKind.Native));
+        var interop = new RecordingNativeSshInterop(
+            new[]
+            {
+                new NativeRemotePathEntry("logs", "/srv/logs", true)
+            });
+        var service = CreateService(
+            registry,
+            interop,
+            CreateSshService(profileId, keepAliveIntervalSeconds: 45, keepAliveCountMax: 6));
+
+        RemoteSidebarListingResult result = await service.ListDirectoryAsync(profileId, sessionId, "/srv", CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(interop.LastConnectionOptions);
+        Assert.Equal(45, interop.LastConnectionOptions!.KeepAliveIntervalSeconds);
+        Assert.Equal(6, interop.LastConnectionOptions.KeepAliveCountMax);
+    }
+
     private static RemoteDirectoryBrowserService CreateService(
         ActiveSshSessionRegistry registry,
         INativeSshInterop interop,
@@ -126,7 +173,10 @@ public sealed class RemoteDirectoryBrowserServiceTests
             passwordResolver);
     }
 
-    private static SshConnectionService CreateSshService(Guid profileId)
+    private static SshConnectionService CreateSshService(
+        Guid profileId,
+        int keepAliveIntervalSeconds = 30,
+        int keepAliveCountMax = 3)
     {
         var store = new TestSshProfileStore();
         store.SaveProfile(new SshProfile
@@ -137,7 +187,9 @@ public sealed class RemoteDirectoryBrowserServiceTests
             Host = "prod.internal",
             User = "ops",
             Port = 2200,
-            AuthMode = SshAuthMode.Default
+            AuthMode = SshAuthMode.Default,
+            ServerAliveIntervalSeconds = keepAliveIntervalSeconds,
+            ServerAliveCountMax = keepAliveCountMax
         });
 
         return new SshConnectionService(store);

--- a/tests/NovaTerminal.Tests/Ssh/RemoteFilesSidebarViewModelTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/RemoteFilesSidebarViewModelTests.cs
@@ -1,0 +1,143 @@
+using NovaTerminal.Models;
+using NovaTerminal.Services.Ssh;
+using NovaTerminal.ViewModels.Ssh;
+
+namespace NovaTerminal.Tests.Ssh;
+
+public sealed class RemoteFilesSidebarViewModelTests
+{
+    [Fact]
+    public async Task OpenAsync_LoadsInitialPath_AndDisablesDownloadUntilSelectionExists()
+    {
+        var service = new FakeRemoteDirectoryBrowserService("/srv", new[]
+        {
+            new RemoteSidebarEntry("logs", "/srv/logs", true)
+        });
+
+        var viewModel = new RemoteFilesSidebarViewModel(service);
+        await viewModel.OpenAsync(
+            profileId: Guid.NewGuid(),
+            sessionId: Guid.NewGuid(),
+            initialPath: "/srv",
+            CancellationToken.None);
+
+        Assert.True(viewModel.IsOpen);
+        Assert.Equal("/srv", viewModel.CurrentPath);
+        Assert.False(viewModel.CanDownloadSelected);
+    }
+
+    [Fact]
+    public async Task SelectingEntry_EnablesDownload()
+    {
+        var service = new FakeRemoteDirectoryBrowserService("/srv", new[]
+        {
+            new RemoteSidebarEntry("logs", "/srv/logs", true)
+        });
+
+        var viewModel = new RemoteFilesSidebarViewModel(service);
+        await viewModel.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), "/srv", CancellationToken.None);
+
+        viewModel.SelectedEntry = Assert.Single(viewModel.Entries);
+
+        Assert.True(viewModel.CanDownloadSelected);
+    }
+
+    [Fact]
+    public async Task NavigateIntoSelectedDirectoryAsync_LoadsChildPath_AndEnablesNavigateBack()
+    {
+        var service = new FakeRemoteDirectoryBrowserService(
+            RemoteSidebarListingResult.Success("/srv", new[]
+            {
+                new RemoteSidebarEntry("logs", "/srv/logs", true)
+            }),
+            RemoteSidebarListingResult.Success("/srv/logs", Array.Empty<RemoteSidebarEntry>()));
+
+        var viewModel = new RemoteFilesSidebarViewModel(service);
+        await viewModel.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), "/srv", CancellationToken.None);
+        viewModel.SelectedEntry = Assert.Single(viewModel.Entries);
+
+        await viewModel.NavigateIntoSelectedDirectoryAsync();
+
+        Assert.Equal("/srv/logs", viewModel.CurrentPath);
+        Assert.True(viewModel.CanNavigateBack);
+        Assert.Equal(new[] { "/srv", "/srv/logs" }, service.RequestedPaths);
+    }
+
+    [Fact]
+    public async Task NavigateUpAsync_MovesToParentDirectory()
+    {
+        var service = new FakeRemoteDirectoryBrowserService(
+            RemoteSidebarListingResult.Success("/srv/api", Array.Empty<RemoteSidebarEntry>()),
+            RemoteSidebarListingResult.Success("/srv", Array.Empty<RemoteSidebarEntry>()));
+
+        var viewModel = new RemoteFilesSidebarViewModel(service);
+        await viewModel.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), "/srv/api", CancellationToken.None);
+
+        await viewModel.NavigateUpAsync();
+
+        Assert.Equal("/srv", viewModel.CurrentPath);
+        Assert.Equal(new[] { "/srv/api", "/srv" }, service.RequestedPaths);
+    }
+
+    [Fact]
+    public async Task SetJumpToCurrentDirectoryCandidate_ExposesJumpAffordance_WithoutNavigating()
+    {
+        var service = new FakeRemoteDirectoryBrowserService("/srv", Array.Empty<RemoteSidebarEntry>());
+        var viewModel = new RemoteFilesSidebarViewModel(service);
+        await viewModel.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), "/srv", CancellationToken.None);
+
+        viewModel.SetJumpToCurrentDirectoryCandidate("/srv/api");
+
+        Assert.Equal("/srv/api", viewModel.JumpToCurrentDirectoryPath);
+        Assert.Equal("/srv", viewModel.CurrentPath);
+        Assert.Equal(new[] { "/srv" }, service.RequestedPaths);
+    }
+
+    [Fact]
+    public async Task OpenAsync_WhenListingFails_SetsInlineError_AndKeepsSidebarOpen()
+    {
+        var service = new FakeRemoteDirectoryBrowserService(
+            RemoteSidebarListingResult.Failure("/srv", "permission denied"));
+
+        var viewModel = new RemoteFilesSidebarViewModel(service);
+        await viewModel.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), "/srv", CancellationToken.None);
+
+        Assert.True(viewModel.IsOpen);
+        Assert.Equal("/srv", viewModel.CurrentPath);
+        Assert.Equal("permission denied", viewModel.ErrorMessage);
+        Assert.False(viewModel.IsLoading);
+    }
+
+    private sealed class FakeRemoteDirectoryBrowserService : IRemoteDirectoryBrowserService
+    {
+        private readonly Queue<RemoteSidebarListingResult> _results;
+
+        public FakeRemoteDirectoryBrowserService(string resolvedPath, IReadOnlyList<RemoteSidebarEntry> entries)
+            : this(RemoteSidebarListingResult.Success(resolvedPath, entries))
+        {
+        }
+
+        public FakeRemoteDirectoryBrowserService(params RemoteSidebarListingResult[] results)
+        {
+            _results = new Queue<RemoteSidebarListingResult>(results);
+        }
+
+        public List<string> RequestedPaths { get; } = new();
+
+        public Task<RemoteSidebarListingResult> ListDirectoryAsync(
+            Guid profileId,
+            Guid sessionId,
+            string remotePath,
+            CancellationToken cancellationToken)
+        {
+            RequestedPaths.Add(remotePath);
+
+            if (_results.Count == 0)
+            {
+                throw new InvalidOperationException("No more results configured.");
+            }
+
+            return Task.FromResult(_results.Dequeue());
+        }
+    }
+}

--- a/tests/NovaTerminal.Tests/Ssh/RemoteFilesSidebarViewModelTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/RemoteFilesSidebarViewModelTests.cs
@@ -145,6 +145,28 @@ public sealed class RemoteFilesSidebarViewModelTests
     }
 
     [Fact]
+    public async Task MarkDisconnected_KeepsSidebarOpenButDisablesTransferActions()
+    {
+        var service = new FakeRemoteDirectoryBrowserService("/srv", new[]
+        {
+            new RemoteSidebarEntry("logs", "/srv/logs", true)
+        });
+
+        var viewModel = new RemoteFilesSidebarViewModel(service);
+        await viewModel.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), "/srv", CancellationToken.None);
+        viewModel.SelectedEntry = Assert.Single(viewModel.Entries);
+
+        viewModel.MarkDisconnected();
+
+        Assert.True(viewModel.IsOpen);
+        Assert.True(viewModel.IsDisconnected);
+        Assert.False(viewModel.CanInteractWithRemote);
+        Assert.False(viewModel.CanDownloadSelected);
+        Assert.Null(viewModel.SelectedEntry);
+        Assert.Equal("SSH session disconnected.", viewModel.ErrorMessage);
+    }
+
+    [Fact]
     public async Task LaterLoadCompletion_WinsOverEarlierStaleCompletion()
     {
         var service = new ControlledRemoteDirectoryBrowserService();

--- a/tests/NovaTerminal.Tests/Ssh/RemoteFilesSidebarViewModelTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/RemoteFilesSidebarViewModelTests.cs
@@ -70,6 +70,36 @@ public sealed class RemoteFilesSidebarViewModelTests
     }
 
     [Fact]
+    public async Task NavigateBackAsync_WhenLoadFails_KeepsBackStackAvailableForRetry()
+    {
+        var service = new FakeRemoteDirectoryBrowserService(
+            RemoteSidebarListingResult.Success("/srv", new[]
+            {
+                new RemoteSidebarEntry("logs", "/srv/logs", true)
+            }),
+            RemoteSidebarListingResult.Success("/srv/logs", Array.Empty<RemoteSidebarEntry>()),
+            RemoteSidebarListingResult.Failure("/srv", "permission denied"),
+            RemoteSidebarListingResult.Success("/srv", Array.Empty<RemoteSidebarEntry>()));
+
+        var viewModel = new RemoteFilesSidebarViewModel(service);
+        await viewModel.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), "/srv", CancellationToken.None);
+        viewModel.SelectedEntry = Assert.Single(viewModel.Entries);
+        await viewModel.NavigateIntoSelectedDirectoryAsync();
+
+        await viewModel.NavigateBackAsync();
+
+        Assert.True(viewModel.CanNavigateBack);
+        Assert.Equal("permission denied", viewModel.ErrorMessage);
+
+        await viewModel.NavigateBackAsync();
+
+        Assert.Equal("/srv", viewModel.CurrentPath);
+        Assert.False(viewModel.CanNavigateBack);
+        Assert.Null(viewModel.ErrorMessage);
+        Assert.Equal(new[] { "/srv", "/srv/logs", "/srv", "/srv" }, service.RequestedPaths);
+    }
+
+    [Fact]
     public async Task NavigateUpAsync_MovesToParentDirectory()
     {
         var service = new FakeRemoteDirectoryBrowserService(
@@ -114,6 +144,40 @@ public sealed class RemoteFilesSidebarViewModelTests
         Assert.False(viewModel.IsLoading);
     }
 
+    [Fact]
+    public async Task LaterLoadCompletion_WinsOverEarlierStaleCompletion()
+    {
+        var service = new ControlledRemoteDirectoryBrowserService();
+        service.EnqueueImmediate("/srv", RemoteSidebarListingResult.Success("/srv", new[]
+        {
+            new RemoteSidebarEntry("logs", "/srv/logs", true)
+        }));
+
+        var viewModel = new RemoteFilesSidebarViewModel(service);
+        await viewModel.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), "/srv", CancellationToken.None);
+        viewModel.SelectedEntry = Assert.Single(viewModel.Entries);
+
+        Task navigateIntoTask = viewModel.NavigateIntoSelectedDirectoryAsync();
+        await service.WaitForRequestAsync("/srv/logs");
+
+        viewModel.SetJumpToCurrentDirectoryCandidate("/srv/api");
+        Task jumpTask = viewModel.JumpToCurrentDirectoryAsync();
+        await service.WaitForRequestAsync("/srv/api");
+
+        service.CompletePending("/srv/api", RemoteSidebarListingResult.Success("/srv/api", Array.Empty<RemoteSidebarEntry>()));
+        await jumpTask;
+
+        Assert.Equal("/srv/api", viewModel.CurrentPath);
+        Assert.True(viewModel.CanNavigateBack);
+
+        service.CompletePending("/srv/logs", RemoteSidebarListingResult.Success("/srv/logs", Array.Empty<RemoteSidebarEntry>()));
+        await navigateIntoTask;
+
+        Assert.Equal("/srv/api", viewModel.CurrentPath);
+        Assert.True(viewModel.CanNavigateBack);
+        Assert.Equal(new[] { "/srv", "/srv/logs", "/srv/api" }, service.RequestedPaths);
+    }
+
     private sealed class FakeRemoteDirectoryBrowserService : IRemoteDirectoryBrowserService
     {
         private readonly Queue<RemoteSidebarListingResult> _results;
@@ -144,6 +208,98 @@ public sealed class RemoteFilesSidebarViewModelTests
             }
 
             return Task.FromResult(_results.Dequeue());
+        }
+    }
+
+    private sealed class ControlledRemoteDirectoryBrowserService : IRemoteDirectoryBrowserService
+    {
+        private readonly Dictionary<string, Queue<TaskCompletionSource<RemoteSidebarListingResult>>> _pendingRequests = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, Queue<RemoteSidebarListingResult>> _immediateResults = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, TaskCompletionSource<object?>> _requestSignals = new(StringComparer.Ordinal);
+
+        public List<string> RequestedPaths { get; } = new();
+
+        public void EnqueueImmediate(string remotePath, RemoteSidebarListingResult result)
+        {
+            if (!_immediateResults.TryGetValue(remotePath, out Queue<RemoteSidebarListingResult>? results))
+            {
+                results = new Queue<RemoteSidebarListingResult>();
+                _immediateResults[remotePath] = results;
+            }
+
+            results.Enqueue(result);
+        }
+
+        public async Task WaitForRequestAsync(string remotePath)
+        {
+            TaskCompletionSource<object?> signal;
+
+            lock (_requestSignals)
+            {
+                if (!_requestSignals.TryGetValue(remotePath, out signal!))
+                {
+                    signal = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    _requestSignals[remotePath] = signal;
+                }
+            }
+
+            await signal.Task;
+        }
+
+        public void CompletePending(string remotePath, RemoteSidebarListingResult result)
+        {
+            TaskCompletionSource<RemoteSidebarListingResult> pending;
+
+            lock (_pendingRequests)
+            {
+                pending = _pendingRequests[remotePath].Dequeue();
+            }
+
+            pending.SetResult(result);
+        }
+
+        public Task<RemoteSidebarListingResult> ListDirectoryAsync(
+            Guid profileId,
+            Guid sessionId,
+            string remotePath,
+            CancellationToken cancellationToken)
+        {
+            RequestedPaths.Add(remotePath);
+
+            lock (_requestSignals)
+            {
+                if (_requestSignals.TryGetValue(remotePath, out TaskCompletionSource<object?>? existingSignal))
+                {
+                    existingSignal.TrySetResult(null);
+                }
+                else
+                {
+                    var signal = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    signal.SetResult(null);
+                    _requestSignals[remotePath] = signal;
+                }
+            }
+
+            if (_immediateResults.TryGetValue(remotePath, out Queue<RemoteSidebarListingResult>? immediateResults)
+                && immediateResults.Count > 0)
+            {
+                return Task.FromResult(immediateResults.Dequeue());
+            }
+
+            var pending = new TaskCompletionSource<RemoteSidebarListingResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            lock (_pendingRequests)
+            {
+                if (!_pendingRequests.TryGetValue(remotePath, out Queue<TaskCompletionSource<RemoteSidebarListingResult>>? requests))
+                {
+                    requests = new Queue<TaskCompletionSource<RemoteSidebarListingResult>>();
+                    _pendingRequests[remotePath] = requests;
+                }
+
+                requests.Enqueue(pending);
+            }
+
+            return pending.Task;
         }
     }
 }

--- a/tests/NovaTerminal.Tests/Ssh/RemoteFilesSidebarViewModelTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/RemoteFilesSidebarViewModelTests.cs
@@ -43,6 +43,39 @@ public sealed class RemoteFilesSidebarViewModelTests
     }
 
     [Fact]
+    public async Task OpenAsync_MapsModifiedMetadataToEntryViewModels()
+    {
+        var service = new FakeRemoteDirectoryBrowserService("/srv", new[]
+        {
+            new RemoteSidebarEntry("logs", "/srv/logs", true)
+            {
+                ModifiedAtUtc = new DateTime(2026, 5, 4, 20, 15, 0, DateTimeKind.Utc)
+            }
+        });
+
+        var viewModel = new RemoteFilesSidebarViewModel(service);
+        await viewModel.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), "/srv", CancellationToken.None);
+
+        RemoteFilesSidebarEntryViewModel entry = Assert.Single(viewModel.Entries);
+        Assert.Equal("May 04", entry.ModifiedDisplayText);
+    }
+
+    [Fact]
+    public async Task OpenAsync_UsesPlaceholderWhenModifiedMetadataIsMissing()
+    {
+        var service = new FakeRemoteDirectoryBrowserService("/srv", new[]
+        {
+            new RemoteSidebarEntry("logs", "/srv/logs", true)
+        });
+
+        var viewModel = new RemoteFilesSidebarViewModel(service);
+        await viewModel.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), "/srv", CancellationToken.None);
+
+        RemoteFilesSidebarEntryViewModel entry = Assert.Single(viewModel.Entries);
+        Assert.Equal("-", entry.ModifiedDisplayText);
+    }
+
+    [Fact]
     public async Task NavigateIntoSelectedDirectoryAsync_ThenNavigateBackAsync_ReturnsToPreviousPath()
     {
         var service = new FakeRemoteDirectoryBrowserService(

--- a/tests/NovaTerminal.Tests/Ssh/RemoteFilesSidebarViewModelTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/RemoteFilesSidebarViewModelTests.cs
@@ -43,14 +43,15 @@ public sealed class RemoteFilesSidebarViewModelTests
     }
 
     [Fact]
-    public async Task NavigateIntoSelectedDirectoryAsync_LoadsChildPath_AndEnablesNavigateBack()
+    public async Task NavigateIntoSelectedDirectoryAsync_ThenNavigateBackAsync_ReturnsToPreviousPath()
     {
         var service = new FakeRemoteDirectoryBrowserService(
             RemoteSidebarListingResult.Success("/srv", new[]
             {
                 new RemoteSidebarEntry("logs", "/srv/logs", true)
             }),
-            RemoteSidebarListingResult.Success("/srv/logs", Array.Empty<RemoteSidebarEntry>()));
+            RemoteSidebarListingResult.Success("/srv/logs", Array.Empty<RemoteSidebarEntry>()),
+            RemoteSidebarListingResult.Success("/srv", Array.Empty<RemoteSidebarEntry>()));
 
         var viewModel = new RemoteFilesSidebarViewModel(service);
         await viewModel.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), "/srv", CancellationToken.None);
@@ -60,7 +61,12 @@ public sealed class RemoteFilesSidebarViewModelTests
 
         Assert.Equal("/srv/logs", viewModel.CurrentPath);
         Assert.True(viewModel.CanNavigateBack);
-        Assert.Equal(new[] { "/srv", "/srv/logs" }, service.RequestedPaths);
+
+        await viewModel.NavigateBackAsync();
+
+        Assert.Equal("/srv", viewModel.CurrentPath);
+        Assert.False(viewModel.CanNavigateBack);
+        Assert.Equal(new[] { "/srv", "/srv/logs", "/srv" }, service.RequestedPaths);
     }
 
     [Fact]

--- a/tests/NovaTerminal.Tests/Ssh/RemoteFilesSidebarViewModelTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/RemoteFilesSidebarViewModelTests.cs
@@ -61,6 +61,22 @@ public sealed class RemoteFilesSidebarViewModelTests
     }
 
     [Fact]
+    public async Task OpenAsync_MapsDistinctEntryIcons_ForDirectoriesAndFiles()
+    {
+        var service = new FakeRemoteDirectoryBrowserService("/srv", new[]
+        {
+            new RemoteSidebarEntry("logs", "/srv/logs", true),
+            new RemoteSidebarEntry("access.log", "/srv/access.log", false)
+        });
+
+        var viewModel = new RemoteFilesSidebarViewModel(service);
+        await viewModel.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), "/srv", CancellationToken.None);
+
+        Assert.Equal(2, viewModel.Entries.Count);
+        Assert.NotEqual(viewModel.Entries[0].EntryIconData, viewModel.Entries[1].EntryIconData);
+    }
+
+    [Fact]
     public async Task OpenAsync_UsesPlaceholderWhenModifiedMetadataIsMissing()
     {
         var service = new FakeRemoteDirectoryBrowserService("/srv", new[]

--- a/tests/NovaTerminal.Tests/Ssh/RemoteSidebarStartPathResolverTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/RemoteSidebarStartPathResolverTests.cs
@@ -25,6 +25,16 @@ public sealed class RemoteSidebarStartPathResolverTests
         Assert.Equal("/srv/app", resolved);
     }
 
+    [Fact]
+    public void ResolveStartPath_TrimsDefaultRemoteDirectory_WhenCwdIsBlank()
+    {
+        string resolved = RemoteSidebarStartPathResolver.Resolve(
+            currentWorkingDirectory: "   ",
+            defaultRemoteDirectory: "  ~/downloads  ");
+
+        Assert.Equal("~/downloads", resolved);
+    }
+
     [Theory]
     [InlineData("   ", "~/downloads", "~/downloads")]
     [InlineData(null, "   ", "~")]
@@ -52,8 +62,25 @@ public sealed class RemoteSidebarStartPathResolverTests
 
         Assert.True(result.IsSuccess);
         Assert.Equal("/srv", result.ResolvedPath);
-        Assert.Same(entries, result.Entries);
+        Assert.NotSame(entries, result.Entries);
+        Assert.Single(result.Entries);
+        Assert.Equal("logs", result.Entries[0].Name);
         Assert.Null(result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ListingResultSuccess_TakesStableSnapshot_OfEntries()
+    {
+        RemoteSidebarEntry[] entries =
+        {
+            new("logs", "/srv/logs", true)
+        };
+
+        RemoteSidebarListingResult result = RemoteSidebarListingResult.Success("/srv", entries);
+        entries[0] = new RemoteSidebarEntry("tmp", "/srv/tmp", true);
+
+        Assert.Single(result.Entries);
+        Assert.Equal("logs", result.Entries[0].Name);
     }
 
     [Fact]
@@ -65,5 +92,41 @@ public sealed class RemoteSidebarStartPathResolverTests
         Assert.Equal("/srv", result.ResolvedPath);
         Assert.Empty(result.Entries);
         Assert.Equal("permission denied", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ListingResultSuccess_Throws_WhenResolvedPathIsBlank()
+    {
+        ArgumentException exception = Assert.Throws<ArgumentException>(
+            () => RemoteSidebarListingResult.Success("   ", Array.Empty<RemoteSidebarEntry>()));
+
+        Assert.Equal("resolvedPath", exception.ParamName);
+    }
+
+    [Fact]
+    public void ListingResultSuccess_Throws_WhenEntriesAreNull()
+    {
+        ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+            () => RemoteSidebarListingResult.Success("/srv", entries: null!));
+
+        Assert.Equal("entries", exception.ParamName);
+    }
+
+    [Fact]
+    public void ListingResultFailure_Throws_WhenResolvedPathIsBlank()
+    {
+        ArgumentException exception = Assert.Throws<ArgumentException>(
+            () => RemoteSidebarListingResult.Failure("   ", "permission denied"));
+
+        Assert.Equal("resolvedPath", exception.ParamName);
+    }
+
+    [Fact]
+    public void ListingResultFailure_Throws_WhenErrorMessageIsBlank()
+    {
+        ArgumentException exception = Assert.Throws<ArgumentException>(
+            () => RemoteSidebarListingResult.Failure("/srv", "   "));
+
+        Assert.Equal("errorMessage", exception.ParamName);
     }
 }

--- a/tests/NovaTerminal.Tests/Ssh/RemoteSidebarStartPathResolverTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/RemoteSidebarStartPathResolverTests.cs
@@ -1,3 +1,4 @@
+using NovaTerminal.Models;
 using NovaTerminal.Services.Ssh;
 
 namespace NovaTerminal.Tests.Ssh;
@@ -10,6 +11,16 @@ public sealed class RemoteSidebarStartPathResolverTests
         string resolved = RemoteSidebarStartPathResolver.Resolve(
             currentWorkingDirectory: "/srv/app",
             defaultRemoteDirectory: "~/downloads");
+
+        Assert.Equal("/srv/app", resolved);
+    }
+
+    [Fact]
+    public void ResolveStartPath_TrimsWhitespace_FromSelectedSource()
+    {
+        string resolved = RemoteSidebarStartPathResolver.Resolve(
+            currentWorkingDirectory: "  /srv/app  ",
+            defaultRemoteDirectory: "  ~/downloads  ");
 
         Assert.Equal("/srv/app", resolved);
     }
@@ -27,5 +38,32 @@ public sealed class RemoteSidebarStartPathResolverTests
             defaultRemoteDirectory);
 
         Assert.Equal(expected, resolved);
+    }
+
+    [Fact]
+    public void ListingResultSuccess_ClearsError_AndPreservesEntries()
+    {
+        RemoteSidebarEntry[] entries =
+        {
+            new("logs", "/srv/logs", true)
+        };
+
+        RemoteSidebarListingResult result = RemoteSidebarListingResult.Success("/srv", entries);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("/srv", result.ResolvedPath);
+        Assert.Same(entries, result.Entries);
+        Assert.Null(result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ListingResultFailure_CarriesError_AndReturnsEmptyEntries()
+    {
+        RemoteSidebarListingResult result = RemoteSidebarListingResult.Failure("/srv", "permission denied");
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("/srv", result.ResolvedPath);
+        Assert.Empty(result.Entries);
+        Assert.Equal("permission denied", result.ErrorMessage);
     }
 }

--- a/tests/NovaTerminal.Tests/Ssh/RemoteSidebarStartPathResolverTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/RemoteSidebarStartPathResolverTests.cs
@@ -1,0 +1,31 @@
+using NovaTerminal.Services.Ssh;
+
+namespace NovaTerminal.Tests.Ssh;
+
+public sealed class RemoteSidebarStartPathResolverTests
+{
+    [Fact]
+    public void ResolveStartPath_PrefersPaneWorkingDirectory_OverProfileDefault()
+    {
+        string resolved = RemoteSidebarStartPathResolver.Resolve(
+            currentWorkingDirectory: "/srv/app",
+            defaultRemoteDirectory: "~/downloads");
+
+        Assert.Equal("/srv/app", resolved);
+    }
+
+    [Theory]
+    [InlineData("   ", "~/downloads", "~/downloads")]
+    [InlineData(null, "   ", "~")]
+    public void ResolveStartPath_FallsBackFromBlankCwd_ToProfileDefault_ThenHome(
+        string? currentWorkingDirectory,
+        string? defaultRemoteDirectory,
+        string expected)
+    {
+        string resolved = RemoteSidebarStartPathResolver.Resolve(
+            currentWorkingDirectory,
+            defaultRemoteDirectory);
+
+        Assert.Equal(expected, resolved);
+    }
+}

--- a/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
@@ -656,6 +656,33 @@ public sealed class SshConnectionServiceTests
         }
     }
 
+    [Fact]
+    public void GetConnectionProfiles_ProjectsRemoteShellKindIntoRuntimeProfile()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string path = Path.Combine(tempRoot, "profiles.json");
+            var store = new JsonSshProfileStore(path);
+            var service = new SshConnectionService(store);
+            store.SaveProfile(new SshProfile
+            {
+                Id = Guid.Parse("5eef2d64-8877-44e5-945a-afdc676a44c8"),
+                Name = "bash",
+                Host = "bash.internal",
+                RemoteShellKind = RemoteShellKind.Bash
+            });
+
+            TerminalProfile runtime = service.GetConnectionProfiles().Single();
+
+            Assert.Equal(RemoteShellKind.Bash, runtime.RemoteShellKind);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
     private sealed class RecordingSshPasswordVault : ISshPasswordVault
     {
         public Dictionary<string, string> Secrets { get; } = new(StringComparer.Ordinal);


### PR DESCRIPTION
## Summary
- compact the native SFTP sidebar and add clearer entry, navigation, and action affordances
- route sidebar-initiated transfers through direct local pickers while keeping manual SFTP flows on the transfer dialog
- surface modified-time metadata in remote listings and sync focused docs/tests

## Test Plan
- cargo test --manifest-path src\NovaTerminal.App\native\rusty_ssh\Cargo.toml
- dotnet test tests\NovaTerminal.Core.Tests\NovaTerminal.Core.Tests.csproj --filter "FullyQualifiedName~NativeSshRemotePathInteropTests" -m:1 --nologo -v:minimal
- dotnet test tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj --filter "FullyQualifiedName~MainWindowTransferFlowTests|FullyQualifiedName~RemoteFilesSidebarTests|FullyQualifiedName~TerminalPaneRemoteFilesSidebarTests|FullyQualifiedName~TransferDialogRequestTests|FullyQualifiedName~RemoteFilesSidebarViewModelTests" -m:1 --nologo -v:minimal