### PR TITLE
ci(nightly): build Rust native PTY before dotnet build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,6 +29,34 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Rust native PTY — mirrors ci.yml so dotnet build can copy librusty_pty.so.
+      - name: Cache native binary
+        id: native-bin-cache
+        uses: actions/cache@v4
+        with:
+          path: src/NovaTerminal.App/native/target/release
+          key: native-bin-ubuntu-latest-${{ hashFiles('src/NovaTerminal.App/native/src/**', 'src/NovaTerminal.App/native/Cargo.toml', 'src/NovaTerminal.App/native/Cargo.lock') }}
+
+      - name: Install Rust
+        if: steps.native-bin-cache.outputs.cache-hit != 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust incremental build cache
+        if: steps.native-bin-cache.outputs.cache-hit != 'true'
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src/NovaTerminal.App/native
+
+      - name: Build Rust (Linux)
+        if: steps.native-bin-cache.outputs.cache-hit != 'true'
+        run: cd src/NovaTerminal.App/native && cargo build --release
+
+      - name: Stage Linux native binary
+        run: |
+          mkdir -p src/NovaTerminal.App/native/target_linux/release
+          cp src/NovaTerminal.App/native/target/release/librusty_pty.so \
+             src/NovaTerminal.App/native/target_linux/release/
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
@@ -66,6 +94,28 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      # Rust native PTY — Windows-only branch; csproj reads from native/target/release directly.
+      - name: Cache native binary
+        id: native-bin-cache
+        uses: actions/cache@v4
+        with:
+          path: src/NovaTerminal.App/native/target/release
+          key: native-bin-${{ matrix.os }}-${{ hashFiles('src/NovaTerminal.App/native/src/**', 'src/NovaTerminal.App/native/Cargo.toml', 'src/NovaTerminal.App/native/Cargo.lock') }}
+
+      - name: Install Rust
+        if: steps.native-bin-cache.outputs.cache-hit != 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust incremental build cache
+        if: steps.native-bin-cache.outputs.cache-hit != 'true'
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src/NovaTerminal.App/native
+
+      - name: Build Rust (Windows)
+        if: steps.native-bin-cache.outputs.cache-hit != 'true'
+        run: cd src/NovaTerminal.App/native && cargo build --release
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4


### PR DESCRIPTION
## Summary
- `dotnet build` on the nightly workflow has been failing with `MSB3030: Could not copy "librusty_pty.so" because it was not found` since the native PTY Rust spike landed, because the workflow never built the Rust crate.
- Add Rust toolchain setup + cargo build + Linux staging step to both `stress_replay_linux` and `stress_replay_extra`, mirroring `ci.yml`.

## Test plan
- [ ] Run the workflow via \`gh workflow run nightly.yml\` once this is merged and confirm the Linux job builds and the stress tests run.
- [ ] (Optional) Trigger with \`full_matrix=true\` to verify the Windows branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)