### PR TITLE
Polish connection management and recording UX

### DIFF
--- a/docs/plans/2026-05-21-connection-ui-review-fixes.md
+++ b/docs/plans/2026-05-21-connection-ui-review-fixes.md
@@ -1,0 +1,422 @@
+# Connection UI Review Fixes Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix the regressions introduced by the recent Settings and Connection Manager UI refresh while preserving the new layout direction.
+
+**Architecture:** Keep the fixes additive and local to `NovaTerminal.App`. Do not change VT/rendering paths. For Connection Manager, restore missing behavior and make filtering stable by keeping a permanent live collection for visible rows instead of rebinding the list to snapshots. For theming, preserve the new structure but drive the named brushes from the active `TerminalTheme` rather than hard-coding a dark palette.
+
+**Tech Stack:** Avalonia UI, C#, xUnit, Avalonia.Headless.XUnit
+
+---
+
+### Task 1: Stabilize Connection Manager filtering and result updates
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs`
+- Modify: `src/NovaTerminal.App/Controls/ConnectionManager.axaml`
+- Test: `tests/NovaTerminal.Tests/Ssh/ConnectionManagerTests.cs`
+
+**Step 1: Write the failing tests**
+
+Add tests that cover:
+- The favorites filter removes a row immediately after the selected connection is unfavorited.
+- The result count updates after favorite toggles while a filter is active.
+- The list stays synchronized after search text changes and group changes.
+
+Suggested test shape:
+
+```csharp
+[AvaloniaFact]
+public void FavoriteFilter_RemovesRowImmediately_WhenFavoriteIsCleared()
+{
+    var control = CreateMeasuredConnectionManager();
+    control.LoadProfiles(new[]
+    {
+        new TerminalProfile { Type = ConnectionType.SSH, Name = "Prod", SshHost = "prod", Tags = new() { "favorite" } }
+    });
+
+    Click(control, "BtnGroupFav");
+    SelectFirstRow(control);
+    ClickByToolTip(control, "Toggle favorite");
+
+    Assert.Equal(0, GetConnectionList(control).ItemCount());
+    Assert.Equal("0 connections", control.FindControl<TextBlock>("ResultCountText")!.Text);
+}
+```
+
+**Step 2: Run the focused tests to verify they fail**
+
+Run:
+
+```powershell
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter ConnectionManagerTests
+```
+
+Expected: at least one failure showing stale list contents or stale count after filter changes.
+
+**Step 3: Implement minimal filtering fix**
+
+In `ConnectionManager.axaml.cs`:
+- Add a private `ObservableCollection<SshProfileRowViewModel> _visibleRows = new();`
+- Bind `ConnectionsList.ItemsSource` to `_visibleRows` once in the constructor.
+- Replace `ApplyFilters()` snapshot rebinding with a `RefreshVisibleRows()` method that:
+  - Starts from `_viewModel.FilteredRows`
+  - Applies group and supported status filters
+  - Clears and repopulates `_visibleRows`
+- Call `RefreshVisibleRows()` from:
+  - `LoadProfiles()`
+  - search input handler
+  - group button handler
+  - status chip handler
+  - `OnFavoriteClick()`
+- Keep `UpdateResultCountText()` based on `_visibleRows.Count`.
+
+Implementation sketch:
+
+```csharp
+private readonly ObservableCollection<SshProfileRowViewModel> _visibleRows = new();
+
+private void RefreshVisibleRows()
+{
+    IEnumerable<SshProfileRowViewModel> rows = _viewModel.FilteredRows;
+    rows = ApplyGroupFilter(rows);
+    rows = ApplyStatusFilter(rows);
+
+    _visibleRows.Clear();
+    foreach (var row in rows)
+    {
+        _visibleRows.Add(row);
+    }
+}
+```
+
+**Step 4: Run tests to verify the fix**
+
+Run:
+
+```powershell
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter ConnectionManagerTests
+```
+
+Expected: all `ConnectionManagerTests` pass.
+
+**Step 5: Commit**
+
+```powershell
+git add src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs src/NovaTerminal.App/Controls/ConnectionManager.axaml tests/NovaTerminal.Tests/Ssh/ConnectionManagerTests.cs
+git commit -m "fix: stabilize connection manager filtering"
+```
+
+### Task 2: Restore the launch-details action in Connection Manager
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Controls/ConnectionManager.axaml`
+- Modify: `src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs`
+- Test: `tests/NovaTerminal.Tests/Ssh/ConnectionManagerTests.cs`
+
+**Step 1: Write the failing test**
+
+Add a headless UI test that:
+- Loads one SSH profile
+- Selects the row
+- Clicks the details action in the detail header
+- Verifies `OnConnectionDetailsRequested` fires with the selected profile
+
+Suggested test shape:
+
+```csharp
+[AvaloniaFact]
+public void DetailsAction_RaisesConnectionDetailsRequested_ForSelectedRow()
+{
+    var control = CreateMeasuredConnectionManager();
+    control.LoadProfiles(new[] { CreateSshProfile("Prod") });
+    SelectFirstRow(control);
+
+    TerminalProfile? received = null;
+    control.OnConnectionDetailsRequested += (profile, _) => received = profile;
+
+    ClickByToolTip(control, "Connection details");
+
+    Assert.NotNull(received);
+    Assert.Equal("Prod", received!.Name);
+}
+```
+
+**Step 2: Run the focused tests to verify they fail**
+
+Run:
+
+```powershell
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter ConnectionManagerTests
+```
+
+Expected: failure because no button currently advertises or triggers the details action.
+
+**Step 3: Restore the UI affordance**
+
+In `ConnectionManager.axaml`:
+- Add a detail-header action button for `"Connection details"` next to copy/edit/favorite.
+- Reuse the existing `OnDetailsClick` handler and a square `IconBtn` hit target.
+
+In `ConnectionManager.axaml.cs`:
+- Keep `OnDetailsClick()` as-is.
+- Verify `TryGetRow()` still prefers `_selectedRow`.
+
+**Step 4: Run tests to verify the fix**
+
+Run:
+
+```powershell
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter ConnectionManagerTests
+```
+
+Expected: details-action test passes and existing action-hit-target test stays green.
+
+**Step 5: Commit**
+
+```powershell
+git add src/NovaTerminal.App/Controls/ConnectionManager.axaml src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs tests/NovaTerminal.Tests/Ssh/ConnectionManagerTests.cs
+git commit -m "fix: restore connection manager details action"
+```
+
+### Task 3: Remove misleading status filters or make them explicitly unsupported
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Controls/ConnectionManager.axaml`
+- Modify: `src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs`
+- Test: `tests/NovaTerminal.Tests/Ssh/ConnectionManagerTests.cs`
+
+**Step 1: Decide the minimal supported behavior**
+
+Do not invent live connection-state plumbing in this pass. The safe fix is:
+- Keep only `All` and `★ Favs`, or
+- Disable `Connected` and `Idle` with a tooltip such as `"Not available yet"`
+
+Recommended option: remove `Connected` and `Idle` entirely for now.
+
+**Step 2: Write or update the tests**
+
+Add a test that asserts only supported filter chips are interactive:
+
+```csharp
+[AvaloniaFact]
+public void StatusChips_ExposeOnlySupportedFilters()
+{
+    var control = new ConnectionManager();
+
+    Assert.NotNull(control.FindControl<ToggleButton>("ChipAll"));
+    Assert.NotNull(control.FindControl<ToggleButton>("ChipFav"));
+    Assert.Null(control.FindControl<ToggleButton>("ChipConn"));
+    Assert.Null(control.FindControl<ToggleButton>("ChipIdle"));
+}
+```
+
+If you choose disabled chips instead, assert `IsEnabled == false` and tooltip text.
+
+**Step 3: Implement the UI change**
+
+In `ConnectionManager.axaml`:
+- Remove the unsupported chips, or mark them disabled with explicit copy.
+
+In `ConnectionManager.axaml.cs`:
+- Remove dead branch handling for `"connected"` / `"idle"`.
+- Keep `_selectedStatusKey` limited to supported values.
+
+**Step 4: Run the focused tests**
+
+Run:
+
+```powershell
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter ConnectionManagerTests
+```
+
+Expected: no misleading interactive filters remain.
+
+**Step 5: Commit**
+
+```powershell
+git add src/NovaTerminal.App/Controls/ConnectionManager.axaml src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs tests/NovaTerminal.Tests/Ssh/ConnectionManagerTests.cs
+git commit -m "fix: remove unsupported connection status filters"
+```
+
+### Task 4: Restore theme-aware styling for Settings and Connection Manager
+
+**Files:**
+- Modify: `src/NovaTerminal.App/SettingsWindow.axaml`
+- Modify: `src/NovaTerminal.App/SettingsWindow.axaml.cs`
+- Modify: `src/NovaTerminal.App/Controls/ConnectionManager.axaml`
+- Modify: `src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs`
+- Verify: `src/NovaTerminal.App/MainWindow.axaml.cs`
+
+**Step 1: Preserve the new layout but move the palette back under theme control**
+
+Use the existing named brushes (`NtWindowBg`, `NtChromeBg`, `NtPanel`, `NtPanelAlt`, `NtHairline`, `NtFg*`, `NtBlue*`) as mutable theme resources instead of fixed dark values.
+
+**Step 2: Implement brush updates**
+
+In `SettingsWindow.axaml.cs`:
+- Extend `ApplyTheme()` to update the named brushes in `Resources`.
+- Keep `RequestedThemeVariant` behavior.
+
+In `ConnectionManager.axaml.cs`:
+- Restore `ApplyTheme(TerminalTheme theme)` to update the same resource set instead of being a no-op.
+- Keep the current structure and control classes intact.
+
+Suggested helper shape:
+
+```csharp
+private void UpdateBrush(string key, Color color)
+{
+    if (Resources[key] is SolidColorBrush brush)
+    {
+        brush.Color = color;
+    }
+    else
+    {
+        Resources[key] = new SolidColorBrush(color);
+    }
+}
+```
+
+**Step 3: Choose a conservative palette mapping**
+
+Do not build a large theming subsystem in this pass. Map:
+- `NtWindowBg` / `NtPanel*` from `theme.Background`
+- `NtFg*` from `theme.Foreground` plus lowered opacity / contrast adjustments
+- `NtBlue*` from `theme.Cursor` or a fixed accent fallback if the active theme lacks a usable accent
+
+This keeps the new UI readable without hard-coding a permanent dark mode.
+
+**Step 4: Verify manually**
+
+Run:
+
+```powershell
+dotnet run --project src/NovaTerminal.App/NovaTerminal.App.csproj
+```
+
+Manual checks:
+- Open Settings on at least one dark theme and one light theme.
+- Open Connection Manager from `MainWindow`.
+- Confirm text, borders, and action buttons remain legible.
+- Confirm changing the app theme still updates both surfaces.
+
+**Step 5: Commit**
+
+```powershell
+git add src/NovaTerminal.App/SettingsWindow.axaml src/NovaTerminal.App/SettingsWindow.axaml.cs src/NovaTerminal.App/Controls/ConnectionManager.axaml src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs
+git commit -m "fix: restore theme-aware settings and connection manager chrome"
+```
+
+### Task 5: Make the Connection Manager overlay responsive inside the main window
+
+**Files:**
+- Modify: `src/NovaTerminal.App/MainWindow.axaml`
+- Modify: `src/NovaTerminal.App/Controls/ConnectionManager.axaml`
+- Verify: `src/NovaTerminal.App/MainWindow.axaml.cs`
+- Test: `tests/NovaTerminal.Tests/Ssh/ConnectionManagerTests.cs`
+
+**Step 1: Replace hard fixed overlay sizing**
+
+In `MainWindow.axaml`:
+- Replace `Width="1080" Height="720"` with:
+  - `MaxWidth="1080"`
+  - `MaxHeight="720"`
+  - stretch alignment or centered layout with outer margin
+- Keep the overlay centered and modal-looking.
+
+Recommended shape:
+
+```xml
+<Border Name="ConnectionOverlay"
+        HorizontalAlignment="Stretch"
+        VerticalAlignment="Stretch"
+        Margin="24,56,24,24"
+        MaxWidth="1080"
+        MaxHeight="720">
+```
+
+**Step 2: Remove fixed internal column pressure**
+
+In `ConnectionManager.axaml`:
+- Replace `ColumnDefinitions="220,420,*"` with proportional columns such as `220,2*,3*`
+- Keep the groups column fixed
+- Let list/detail columns shrink before clipping
+
+**Step 3: Add a layout regression test**
+
+Add a headless measurement test:
+
+```csharp
+[AvaloniaFact]
+public void ConnectionManager_CanArrangeWithinSmallOverlay()
+{
+    var control = new ConnectionManager();
+    var host = new Window { Width = 760, Height = 520, Content = control };
+
+    host.Measure(new Size(760, 520));
+    host.Arrange(new Rect(0, 0, 760, 520));
+
+    Assert.True(control.Bounds.Width <= 760);
+    Assert.True(control.Bounds.Height <= 520);
+}
+```
+
+This is a coarse guard against reintroducing hard minimums.
+
+**Step 4: Verify manually**
+
+Run:
+
+```powershell
+dotnet run --project src/NovaTerminal.App/NovaTerminal.App.csproj
+```
+
+Manual checks:
+- Resize the main window near its minimum size.
+- Open Connection Manager.
+- Confirm the close button, search box, row list, and detail actions remain reachable.
+
+**Step 5: Commit**
+
+```powershell
+git add src/NovaTerminal.App/MainWindow.axaml src/NovaTerminal.App/Controls/ConnectionManager.axaml tests/NovaTerminal.Tests/Ssh/ConnectionManagerTests.cs
+git commit -m "fix: make connection manager overlay responsive"
+```
+
+### Task 6: Run full verification and clean up
+
+**Files:**
+- Verify only
+
+**Step 1: Run focused automated tests**
+
+```powershell
+dotnet test tests/NovaTerminal.Tests/NovaTerminal.Tests.csproj --filter "ConnectionManagerTests|SshManagerViewModelTests|SettingsWindow"
+```
+
+Expected: pass.
+
+**Step 2: Run full solution build**
+
+```powershell
+dotnet build
+```
+
+Expected: pass with no new warnings or errors caused by the fixes.
+
+**Step 3: Run one manual UX pass**
+
+Check:
+- Settings opens to Appearance and Profiles correctly from `OpenSettings(0)` and `OpenSettings(1)`.
+- Connection Manager search, group filters, favorite toggles, copy command, edit, details dialog, and open actions all work.
+- Theme switching still updates the refreshed UIs.
+- Small-window overlay remains usable.
+
+**Step 4: Final commit**
+
+```powershell
+git add .
+git commit -m "fix: resolve settings and connection manager review regressions"
+```

--- a/src/NovaTerminal.App/Controls/ConnectionManager.axaml
+++ b/src/NovaTerminal.App/Controls/ConnectionManager.axaml
@@ -5,154 +5,631 @@
              xmlns:sshvm="clr-namespace:NovaTerminal.ViewModels.Ssh"
              xmlns:local="clr-namespace:NovaTerminal.Controls"
              x:Class="NovaTerminal.Controls.ConnectionManager"
-             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="500">
-    <Grid ColumnDefinitions="250,*" Margin="10">
-        <Border Grid.Column="0" BorderBrush="#333" BorderThickness="0,0,1,0" Padding="0,0,10,0">
-            <Grid RowDefinitions="Auto,Auto,Auto,Auto,*">
-                <TextBlock Text="Connections" FontSize="18" FontWeight="SemiBold" Margin="0,0,0,8" />
-                <Grid Grid.Row="1" ColumnDefinitions="*,Auto,Auto" Margin="0,0,0,10">
-                    <TextBox Name="SearchInput" PlaceholderText="Search name, host, tags, notes..." Margin="0,0,5,0" />
-                    <Button Name="BtnNewConnection"
-                            Grid.Column="1"
-                            MinWidth="56"
-                            Height="30"
-                            Padding="10,4"
-                            Margin="0,0,5,0"
-                            Content="New"
-                            ToolTip.Tip="Create a new SSH connection"
-                            Click="OnNewConnectionClick" />
-                    <Button Name="BtnSync"
-                            Grid.Column="2"
-                            Width="30"
-                            Height="30"
-                            Padding="5"
-                            Background="Transparent"
-                            BorderThickness="0"
-                            ToolTip.Tip="Sync from ~/.ssh/config"
-                            Click="OnSyncClick">
-                        <PathIcon Data="M12,18A6,6 0 0,1 6,12C6,11 6.25,10.03 6.7,9.2L5.24,7.74C4.46,8.97 4,10.43 4,12A8,8 0 0,0 12,20V23L16,19L12,15M12,4V1L8,5L12,9V6A6,6 0 0,1 18,12C18,13 17.75,13.97 17.3,14.8L18.76,16.26C19.54,15.03 20,13.57 20,12A8,8 0 0,0 12,4Z" Width="16" Height="16"/>
+             mc:Ignorable="d"
+             d:DesignWidth="1080" d:DesignHeight="720"
+             HorizontalAlignment="Stretch"
+             VerticalAlignment="Stretch"
+             Background="#16181d"
+             Foreground="#e6e8ec"
+             FontFamily="Inter, Segoe UI, system-ui, sans-serif">
+
+    <UserControl.Resources>
+        <SolidColorBrush x:Key="NtWindowBg"   Color="#16181d"/>
+        <SolidColorBrush x:Key="NtChromeBg"   Color="#1c1f26"/>
+        <SolidColorBrush x:Key="NtPanel"      Color="#23272f"/>
+        <SolidColorBrush x:Key="NtPanelAlt"   Color="#1a1d23"/>
+        <SolidColorBrush x:Key="NtHairline"   Color="#2a2f38"/>
+        <SolidColorBrush x:Key="NtFg"         Color="#e6e8ec"/>
+        <SolidColorBrush x:Key="NtFg2"        Color="#b4bac4"/>
+        <SolidColorBrush x:Key="NtFg3"        Color="#8b93a1"/>
+        <SolidColorBrush x:Key="NtFg4"        Color="#5c6370"/>
+        <SolidColorBrush x:Key="NtBlue"       Color="#61afef"/>
+        <SolidColorBrush x:Key="NtBlueDim"    Color="#2461afef"/>
+        <SolidColorBrush x:Key="NtBlueFaint"  Color="#1561afef"/>
+        <SolidColorBrush x:Key="NtBlueBorder" Color="#4d61afef"/>
+        <SolidColorBrush x:Key="NtGreen"      Color="#98c379"/>
+        <SolidColorBrush x:Key="NtYellow"     Color="#e5c07b"/>
+        <SolidColorBrush x:Key="NtRed"        Color="#e06c75"/>
+        <SolidColorBrush x:Key="NtMagenta"    Color="#c678dd"/>
+
+        <FontFamily x:Key="NtMono">JetBrains Mono, Cascadia Mono, Consolas, Menlo, monospace</FontFamily>
+    </UserControl.Resources>
+
+    <UserControl.Styles>
+        <!-- Section header -->
+        <Style Selector="TextBlock.SectionHeader">
+            <Setter Property="FontSize" Value="10"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Foreground" Value="{StaticResource NtFg3}"/>
+            <Setter Property="LetterSpacing" Value="1.2"/>
+        </Style>
+
+        <!-- Search input -->
+        <Style Selector="TextBox.Search">
+            <Setter Property="Background" Value="{StaticResource NtPanelAlt}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource NtHairline}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="CornerRadius" Value="5"/>
+            <Setter Property="Padding" Value="28,5,8,5"/>
+            <Setter Property="Foreground" Value="{StaticResource NtFg}"/>
+            <Setter Property="CaretBrush" Value="{StaticResource NtBlue}"/>
+            <Setter Property="SelectionBrush" Value="{StaticResource NtBlueDim}"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="MinHeight" Value="30"/>
+        </Style>
+        <Style Selector="TextBox.Search:focus /template/ Border#PART_BorderElement">
+            <Setter Property="BorderBrush" Value="{StaticResource NtBlue}"/>
+        </Style>
+
+        <!-- Primary action button -->
+        <Style Selector="Button.Primary">
+            <Setter Property="Background" Value="{StaticResource NtBlue}"/>
+            <Setter Property="Foreground" Value="#0a1622"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="CornerRadius" Value="5"/>
+            <Setter Property="Padding" Value="12,6"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+        </Style>
+        <Style Selector="Button.Primary:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#7cc1f5"/>
+        </Style>
+        <Style Selector="Button.Primary:pressed /template/ ContentPresenter">
+            <Setter Property="Background" Value="#4f9bde"/>
+        </Style>
+
+        <!-- Secondary pill button -->
+        <Style Selector="Button.Pill">
+            <Setter Property="Background" Value="{StaticResource NtPanel}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource NtHairline}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="CornerRadius" Value="5"/>
+            <Setter Property="Padding" Value="10,5"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="Foreground" Value="{StaticResource NtFg}"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+        </Style>
+        <Style Selector="Button.Pill:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#2a2f38"/>
+        </Style>
+        <Style Selector="Button.Pill:pressed /template/ ContentPresenter">
+            <Setter Property="Background" Value="#353b46"/>
+        </Style>
+
+        <!-- Icon-only ghost button -->
+        <Style Selector="Button.IconBtn">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="6"/>
+            <Setter Property="CornerRadius" Value="4"/>
+            <Setter Property="Foreground" Value="{StaticResource NtFg3}"/>
+            <Setter Property="Width" Value="30"/>
+            <Setter Property="Height" Value="30"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+        </Style>
+        <Style Selector="Button.IconBtn:pointerover">
+            <Setter Property="Foreground" Value="{StaticResource NtFg}"/>
+        </Style>
+        <Style Selector="Button.IconBtn:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#2a2f38"/>
+        </Style>
+
+        <!-- Danger icon button (delete) -->
+        <Style Selector="Button.Danger">
+            <Setter Property="Foreground" Value="{StaticResource NtRed}"/>
+        </Style>
+
+        <!-- Filter chip toggle -->
+        <Style Selector="ToggleButton.Chip">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderBrush" Value="{StaticResource NtHairline}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="CornerRadius" Value="12"/>
+            <Setter Property="Padding" Value="9,3"/>
+            <Setter Property="FontSize" Value="11"/>
+            <Setter Property="Foreground" Value="{StaticResource NtFg3}"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="MinHeight" Value="22"/>
+        </Style>
+        <Style Selector="ToggleButton.Chip:checked">
+            <Setter Property="Background" Value="{StaticResource NtBlueDim}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource NtBlue}"/>
+            <Setter Property="Foreground" Value="{StaticResource NtBlue}"/>
+        </Style>
+        <Style Selector="ToggleButton.Chip:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#1f2730"/>
+        </Style>
+
+        <!-- Groups column item -->
+        <Style Selector="Button.GroupItem">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="2,0,0,0"/>
+            <Setter Property="BorderBrush" Value="Transparent"/>
+            <Setter Property="CornerRadius" Value="0"/>
+            <Setter Property="Padding" Value="12,6"/>
+            <Setter Property="Foreground" Value="{StaticResource NtFg2}"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="HorizontalAlignment" Value="Stretch"/>
+            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+        </Style>
+        <Style Selector="Button.GroupItem:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#1f2730"/>
+        </Style>
+        <Style Selector="Button.GroupItem.active">
+            <Setter Property="Background" Value="{StaticResource NtBlueDim}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource NtBlue}"/>
+            <Setter Property="Foreground" Value="{StaticResource NtFg}"/>
+        </Style>
+
+        <!-- Multi-select rail toggle -->
+        <Style Selector="ToggleButton.RailToggle">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="2,0,0,0"/>
+            <Setter Property="BorderBrush" Value="Transparent"/>
+            <Setter Property="CornerRadius" Value="0"/>
+            <Setter Property="Padding" Value="12,6"/>
+            <Setter Property="Foreground" Value="{StaticResource NtFg2}"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="HorizontalAlignment" Value="Stretch"/>
+            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+        </Style>
+        <Style Selector="ToggleButton.RailToggle:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#1f2730"/>
+        </Style>
+        <Style Selector="ToggleButton.RailToggle:checked">
+            <Setter Property="Background" Value="{StaticResource NtBlueDim}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource NtBlue}"/>
+            <Setter Property="Foreground" Value="{StaticResource NtFg}"/>
+        </Style>
+
+        <!-- List row (ListBoxItem) -->
+        <Style Selector="ListBoxItem.RowItem">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="Margin" Value="0"/>
+            <Setter Property="BorderThickness" Value="2,0,0,1"/>
+            <Setter Property="BorderBrush" Value="#002a2f38"/>
+            <Setter Property="CornerRadius" Value="0"/>
+            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+        </Style>
+        <Style Selector="ListBoxItem.RowItem /template/ ContentPresenter">
+            <Setter Property="BorderThickness" Value="2,0,0,1"/>
+            <Setter Property="BorderBrush" Value="#002a2f38"/>
+            <Setter Property="CornerRadius" Value="0"/>
+            <Setter Property="Padding" Value="0"/>
+        </Style>
+        <Style Selector="ListBoxItem.RowItem:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#1d2129"/>
+        </Style>
+        <Style Selector="ListBoxItem.RowItem:selected /template/ ContentPresenter">
+            <Setter Property="Background" Value="{StaticResource NtBlueDim}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource NtBlue}"/>
+        </Style>
+        <Style Selector="ListBoxItem.RowItem:selected:focus /template/ ContentPresenter">
+            <Setter Property="Background" Value="{StaticResource NtBlueDim}"/>
+        </Style>
+
+        <!-- ListBox container -->
+        <Style Selector="ListBox.Plain">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="0"/>
+        </Style>
+
+        <!-- ScrollViewer thin scroll -->
+        <Style Selector="ScrollBar:vertical">
+            <Setter Property="Width" Value="8"/>
+        </Style>
+
+        <!-- ComboBox -->
+        <Style Selector="ComboBox.Diag">
+            <Setter Property="Background" Value="{StaticResource NtPanel}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource NtHairline}"/>
+            <Setter Property="Foreground" Value="{StaticResource NtFg2}"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="MinHeight" Value="32"/>
+            <Setter Property="CornerRadius" Value="5"/>
+            <Setter Property="Padding" Value="10,5"/>
+        </Style>
+    </UserControl.Styles>
+
+    <Grid ColumnDefinitions="220,2*,3*" Background="{StaticResource NtWindowBg}">
+
+        <!-- ╭───────────── Groups column ─────────────╮ -->
+        <Border Grid.Column="0"
+                Background="{StaticResource NtChromeBg}"
+                BorderBrush="{StaticResource NtHairline}"
+                BorderThickness="0,0,1,0">
+            <Grid RowDefinitions="Auto,Auto,*,Auto">
+                <TextBlock Grid.Row="0"
+                           Classes="SectionHeader"
+                           Text="VIEWS"
+                           Margin="14,16,14,8"/>
+
+                <StackPanel Grid.Row="1" Spacing="0">
+                    <Button Name="BtnGroupAll" Classes="GroupItem active" Click="OnGroupClick" Tag="__all">
+                        <Grid ColumnDefinitions="14,*,Auto">
+                            <PathIcon Grid.Column="0"
+                                      Data="M12,2A10,10 0 1,0 12,22A10,10 0 1,0 12,2M12,4C13.4,5.5 14.3,7.4 14.7,9.5H9.3C9.7,7.4 10.6,5.5 12,4M5.1,10H8C7.9,10.7 7.9,11.3 7.9,12C7.9,12.7 7.9,13.3 8,14H5.1A8,8 0 0,1 5.1,10M5.1,16H8C8.3,17.4 8.7,18.7 9.3,19.8A8,8 0 0,1 5.1,16M9.8,16H14.2C13.8,17.7 13.1,19.2 12,20.4C10.9,19.2 10.2,17.7 9.8,16M9.8,14C9.7,13.3 9.7,12.7 9.7,12C9.7,11.3 9.7,10.7 9.8,10H14.2C14.3,10.7 14.3,11.3 14.3,12C14.3,12.7 14.3,13.3 14.2,14M14.7,19.8C15.3,18.7 15.7,17.4 16,16H18.9A8,8 0 0,1 14.7,19.8M16.1,14C16.2,13.3 16.2,12.7 16.2,12C16.2,11.3 16.2,10.7 16.1,10H19A8,8 0 0,1 19,14"
+                                      Width="14" Height="14"/>
+                            <TextBlock Grid.Column="1" Text="All connections" Margin="10,0,0,0" VerticalAlignment="Center"/>
+                            <TextBlock Name="CountAll" Grid.Column="2" Text="0" FontFamily="{StaticResource NtMono}" FontSize="11" Foreground="{StaticResource NtFg4}" VerticalAlignment="Center"/>
+                        </Grid>
                     </Button>
-                </Grid>
-                <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="8" Margin="0,0,0,10">
-                    <TextBlock Text="Diagnostics" VerticalAlignment="Center" />
-                    <ComboBox Name="DiagnosticsCombo" Width="145" SelectedIndex="0" />
+
+                    <Button Name="BtnGroupFav" Classes="GroupItem" Click="OnGroupClick" Tag="__fav">
+                        <Grid ColumnDefinitions="14,*,Auto">
+                            <PathIcon Grid.Column="0"
+                                      Data="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z"
+                                      Width="14" Height="14"
+                                      Foreground="{StaticResource NtYellow}"/>
+                            <TextBlock Grid.Column="1" Text="Favorites" Margin="10,0,0,0" VerticalAlignment="Center"/>
+                            <TextBlock Name="CountFav" Grid.Column="2" Text="0" FontFamily="{StaticResource NtMono}" FontSize="11" Foreground="{StaticResource NtFg4}" VerticalAlignment="Center"/>
+                        </Grid>
+                    </Button>
                 </StackPanel>
-                <TextBlock Grid.Row="3" Foreground="{Binding SecondaryForeground, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:ConnectionManager}}}" Text="Favorites are pinned. Use ⭐ to toggle." VerticalAlignment="Top" TextWrapping="Wrap" />
+
+                <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto">
+                    <StackPanel>
+                        <TextBlock Classes="SectionHeader" Text="GROUPS" Margin="14,16,14,8"/>
+                        <ItemsControl Name="GroupsList">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="local:GroupNode">
+                                    <Button Classes="GroupItem" Tag="{Binding Name}" Click="OnGroupClick">
+                                        <Grid ColumnDefinitions="14,*,Auto">
+                                            <Rectangle Grid.Column="0" Width="8" Height="8" RadiusX="2" RadiusY="2" Fill="{Binding Swatch}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
+                                            <TextBlock Grid.Column="1" Text="{Binding Name}" Margin="10,0,0,0" VerticalAlignment="Center"/>
+                                            <TextBlock Grid.Column="2" Text="{Binding Count}" FontFamily="{StaticResource NtMono}" FontSize="11" Foreground="{StaticResource NtFg4}" VerticalAlignment="Center"/>
+                                        </Grid>
+                                    </Button>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+
+                        <TextBlock Classes="SectionHeader" Text="TAGS" Margin="14,16,14,8"/>
+                        <ItemsControl Name="TagsList">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="local:TagNode">
+                                    <ToggleButton Classes="RailToggle"
+                                                  Tag="{Binding Name}"
+                                                  IsChecked="{Binding IsSelected}"
+                                                  Click="OnTagClick">
+                                        <Grid ColumnDefinitions="14,*,Auto">
+                                            <Rectangle Grid.Column="0" Width="8" Height="8" RadiusX="2" RadiusY="2" Fill="{Binding Swatch}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
+                                            <TextBlock Grid.Column="1" Text="{Binding Name}" Margin="10,0,0,0" VerticalAlignment="Center"/>
+                                            <TextBlock Grid.Column="2" Text="{Binding Count}" FontFamily="{StaticResource NtMono}" FontSize="11" Foreground="{StaticResource NtFg4}" VerticalAlignment="Center"/>
+                                        </Grid>
+                                    </ToggleButton>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+                </ScrollViewer>
+
+                <Border Grid.Row="3"
+                        BorderBrush="{StaticResource NtHairline}"
+                        BorderThickness="0,1,0,0"
+                        Padding="14,10">
+                    <TextBlock FontSize="11"
+                               Foreground="{StaticResource NtFg4}"
+                               TextWrapping="Wrap"
+                               Text="Credentials stored in OS keychain. Session passwords opt-in only."/>
+                </Border>
             </Grid>
         </Border>
 
-        <Grid Grid.Column="1" RowDefinitions="Auto,*" Margin="10,0,0,0">
-            <TextBlock Name="ResultCountText"
-                       Text="0 connections"
-                       Foreground="{Binding SecondaryForeground, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:ConnectionManager}}}"
-                       Margin="0,0,0,8" />
-            <ScrollViewer Grid.Row="1">
-                <ItemsControl Name="ConnectionsList">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate x:DataType="sshvm:SshProfileRowViewModel">
-                            <Border Background="{Binding CardBackground, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:ConnectionManager}}}"
-                                    BorderThickness="1"
-                                    BorderBrush="#333"
-                                    CornerRadius="6"
-                                    Margin="0,0,0,8"
-                                    Padding="10">
-                                <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="6">
-                                    <Grid ColumnDefinitions="*,Auto">
-                                        <StackPanel Grid.Column="0" Spacing="2">
-                                            <TextBlock Text="{Binding Name}" FontWeight="Bold" FontSize="14" />
-                                            <TextBlock Text="{Binding Endpoint}"
-                                                       FontSize="12"
-                                                       Foreground="{Binding SecondaryForeground, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:ConnectionManager}}}" />
-                                            <TextBlock Text="{Binding GroupPath}"
-                                                       FontSize="11"
-                                                       IsVisible="{Binding GroupPath, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
-                                                       Foreground="{Binding SecondaryForeground, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:ConnectionManager}}}" />
-                                        </StackPanel>
-                                        <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="4">
-                                            <Button Content="Open" Width="56" Tag="{Binding}" Click="OnOpenCurrentClick" ToolTip.Tip="Open in current pane" />
-                                            <Button Content="+Tab" Width="52" Tag="{Binding}" Click="OnOpenNewTabClick" ToolTip.Tip="Open in new tab" />
-                                            <Button Content="Split H" Width="62" Tag="{Binding}" Click="OnSplitHorizontalClick" ToolTip.Tip="Open in horizontal split" />
-                                            <Button Content="Split V" Width="62" Tag="{Binding}" Click="OnSplitVerticalClick" ToolTip.Tip="Open in vertical split" />
-                                        </StackPanel>
-                                    </Grid>
+        <!-- ╭───────────── List column ─────────────╮ -->
+        <Grid Grid.Column="1" RowDefinitions="Auto,Auto,*">
+            <Border Grid.Row="0"
+                    BorderBrush="{StaticResource NtHairline}"
+                    BorderThickness="0,0,1,1">
+                <Grid Margin="14,12" ColumnDefinitions="*,Auto,Auto">
+                    <Grid Grid.Column="0">
+                        <TextBox Name="SearchInput"
+                                 Classes="Search"
+                                 PlaceholderText="Search name, host, tags…"/>
+                        <PathIcon Data="M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z"
+                                  Width="14" Height="14"
+                                  Margin="10,0,0,0"
+                                  HorizontalAlignment="Left"
+                                  VerticalAlignment="Center"
+                                  Foreground="{StaticResource NtFg4}"
+                                  IsHitTestVisible="False"/>
+                    </Grid>
+                    <Button Name="BtnNewConnection"
+                            Grid.Column="1"
+                            Classes="Primary"
+                            Margin="8,0,0,0"
+                            ToolTip.Tip="Create a new SSH connection"
+                            Click="OnNewConnectionClick">
+                        <StackPanel Orientation="Horizontal" Spacing="6">
+                            <PathIcon Data="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z" Width="12" Height="12" Foreground="#0a1622"/>
+                            <TextBlock Text="New"/>
+                        </StackPanel>
+                    </Button>
+                    <Button Name="BtnSync"
+                            Grid.Column="2"
+                            Classes="IconBtn"
+                            Margin="4,0,0,0"
+                            ToolTip.Tip="Sync from ~/.ssh/config"
+                            Click="OnSyncClick">
+                        <PathIcon Data="M12,18A6,6 0 0,1 6,12C6,11 6.25,10.03 6.7,9.2L5.24,7.74C4.46,8.97 4,10.43 4,12A8,8 0 0,0 12,20V23L16,19L12,15M12,4V1L8,5L12,9V6A6,6 0 0,1 18,12C18,13 17.75,13.97 17.3,14.8L18.76,16.26C19.54,15.03 20,13.57 20,12A8,8 0 0,0 12,4Z" Width="14" Height="14"/>
+                    </Button>
+                </Grid>
+            </Border>
 
-                                    <ItemsControl Grid.Row="1" ItemsSource="{Binding Tags}">
-                                        <ItemsControl.ItemsPanel>
-                                            <ItemsPanelTemplate>
-                                                <StackPanel Orientation="Horizontal" Spacing="4" />
-                                            </ItemsPanelTemplate>
-                                        </ItemsControl.ItemsPanel>
-                                        <ItemsControl.ItemTemplate>
-                                            <DataTemplate>
-                                                <Border Background="#005A9E" CornerRadius="3" Padding="4,1">
-                                                    <TextBlock Text="{Binding}" FontSize="10" Foreground="White" />
-                                                </Border>
-                                            </DataTemplate>
-                                        </ItemsControl.ItemTemplate>
-                                    </ItemsControl>
+            <!-- Filter chips + result count -->
+            <Border Grid.Row="1"
+                    BorderBrush="{StaticResource NtHairline}"
+                    BorderThickness="0,0,1,1">
+                <Grid Margin="14,8" ColumnDefinitions="*,Auto">
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <ToggleButton Name="ChipAll"      Classes="Chip" Content="All"       IsChecked="True" Click="OnStatusFilterClick" Tag="all"/>
+                        <ToggleButton Name="ChipFav"      Classes="Chip" Content="★ Favs"    Click="OnStatusFilterClick" Tag="fav"/>
+                    </StackPanel>
+                    <TextBlock Name="ResultCountText"
+                               Grid.Column="1"
+                               Text="0 connections"
+                               VerticalAlignment="Center"
+                               Foreground="{StaticResource NtFg3}"
+                               FontSize="11"/>
+                </Grid>
+            </Border>
 
-                                    <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="4">
-                                        <Button Content="⭐"
-                                                Width="32"
-                                                Height="32"
-                                                Padding="0"
-                                                HorizontalContentAlignment="Center"
-                                                VerticalContentAlignment="Center"
-                                                Tag="{Binding}"
-                                                ToolTip.Tip="Toggle favorite"
-                                                Click="OnFavoriteClick" />
-                                        <Button Width="32"
-                                                Height="32"
-                                                Padding="0"
-                                                HorizontalContentAlignment="Center"
-                                                VerticalContentAlignment="Center"
-                                                Background="Transparent"
-                                                BorderThickness="0"
-                                                ToolTip.Tip="Edit connection"
-                                                Tag="{Binding}"
-                                                Click="OnEditClick">
-                                            <PathIcon Data="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z"
-                                                      Width="14"
-                                                      Height="14"
-                                                      Foreground="{Binding SecondaryForeground, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:ConnectionManager}}}" />
-                                        </Button>
-                                        <Button Width="32"
-                                                Height="32"
-                                                Padding="0"
-                                                HorizontalContentAlignment="Center"
-                                                VerticalContentAlignment="Center"
-                                                Background="Transparent"
-                                                BorderThickness="0"
-                                                ToolTip.Tip="Copy launch command"
-                                                Tag="{Binding}"
-                                                Click="OnCopyCommandClick">
-                                            <PathIcon Data="M16,19H8A2,2 0 0,1 6,17V7H8V17H16M18,5A2,2 0 0,1 20,7V15A2,2 0 0,1 18,17H11A2,2 0 0,1 9,15V7A2,2 0 0,1 11,5H18M18,7H11V15H18V7Z"
-                                                      Width="14"
-                                                      Height="14"
-                                                      Foreground="{Binding SecondaryForeground, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:ConnectionManager}}}" />
-                                        </Button>
-                                        <Button Width="32"
-                                                Height="32"
-                                                Padding="0"
-                                                HorizontalContentAlignment="Center"
-                                                VerticalContentAlignment="Center"
-                                                Background="Transparent"
-                                                BorderThickness="0"
-                                                ToolTip.Tip="Connection details"
-                                                Tag="{Binding}"
-                                                Click="OnDetailsClick">
-                                            <PathIcon Data="M11,17H13V11H11M12,9A1,1 0 0,0 13,8A1,1 0 0,0 12,7A1,1 0 0,0 11,8A1,1 0 0,0 12,9M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z"
-                                                      Width="14"
-                                                      Height="14"
-                                                      Foreground="{Binding SecondaryForeground, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:ConnectionManager}}}" />
-                                        </Button>
-                                    </StackPanel>
-                                </Grid>
+            <ListBox Name="ConnectionsList"
+                     Grid.Row="2"
+                     Classes="Plain"
+                     SelectionMode="Single"
+                     SelectionChanged="OnSelectionChanged"
+                     DoubleTapped="OnRowDoubleTapped"
+                     BorderBrush="{StaticResource NtHairline}"
+                     BorderThickness="0,0,1,0">
+                <ListBox.ItemContainerTheme>
+                    <ControlTheme TargetType="ListBoxItem" BasedOn="{StaticResource {x:Type ListBoxItem}}">
+                        <Setter Property="Classes.RowItem" Value="True"/>
+                    </ControlTheme>
+                </ListBox.ItemContainerTheme>
+                <ListBox.ItemTemplate>
+                    <DataTemplate x:DataType="sshvm:SshProfileRowViewModel">
+                        <Grid Margin="12,12" RowDefinitions="Auto,Auto,Auto" RowSpacing="4">
+                            <Grid Grid.Row="0" ColumnDefinitions="Auto,Auto,Auto,*,Auto">
+                                <Ellipse Width="8" Height="8" Fill="{StaticResource NtFg4}" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="1"
+                                           Margin="8,0,0,0"
+                                           Text="{Binding Name}"
+                                           Foreground="{StaticResource NtFg}"
+                                           FontWeight="SemiBold"
+                                           FontSize="13"
+                                           VerticalAlignment="Center"/>
+                                <PathIcon Grid.Column="2"
+                                          Margin="6,0,0,0"
+                                          Data="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z"
+                                          Width="11" Height="11"
+                                          Foreground="{StaticResource NtYellow}"
+                                          IsVisible="{Binding IsFavorite}"
+                                          VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="4"
+                                           Text="{Binding GroupPath}"
+                                           Foreground="{StaticResource NtFg4}"
+                                           FontSize="11"
+                                           VerticalAlignment="Center"/>
+                            </Grid>
+                            <TextBlock Grid.Row="1"
+                                       Text="{Binding Endpoint}"
+                                       FontFamily="{StaticResource NtMono}"
+                                       FontSize="12"
+                                       Foreground="{StaticResource NtFg3}"/>
+                            <ItemsControl Grid.Row="2"
+                                          ItemsSource="{Binding Tags}"
+                                          IsVisible="{Binding Tags.Count}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <StackPanel Orientation="Horizontal" Spacing="4"/>
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border Background="{StaticResource NtBlueFaint}"
+                                                BorderBrush="{StaticResource NtBlueBorder}"
+                                                BorderThickness="1"
+                                                CornerRadius="8"
+                                                Padding="6,1">
+                                            <TextBlock Text="{Binding}"
+                                                       FontSize="10"
+                                                       Foreground="{StaticResource NtBlue}"/>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </Grid>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+        </Grid>
+
+        <!-- ╭───────────── Detail column ─────────────╮ -->
+        <Grid Grid.Column="2" Name="DetailColumn">
+            <!-- Empty state (visible when nothing selected) -->
+            <StackPanel Name="DetailEmptyState"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Center"
+                        Spacing="8">
+                <PathIcon Data="M4,6H20V8H4V6M4,10.5H20V12.5H4V10.5M4,15H20V17H4V15Z"
+                          Width="40" Height="40"
+                          Foreground="{StaticResource NtFg4}"/>
+                <TextBlock Text="Select a connection"
+                           FontSize="14"
+                           Foreground="{StaticResource NtFg3}"
+                           HorizontalAlignment="Center"/>
+                <TextBlock Text="Pick from the list, or hit ⌘N to create one."
+                           FontSize="12"
+                           Foreground="{StaticResource NtFg4}"
+                           HorizontalAlignment="Center"/>
+            </StackPanel>
+
+            <!-- Detail content (visible when something selected) -->
+            <Grid Name="DetailContent" IsVisible="False" RowDefinitions="Auto,*">
+
+                <!-- Detail header -->
+                <Border Grid.Row="0"
+                        BorderBrush="{StaticResource NtHairline}"
+                        BorderThickness="0,0,0,1"
+                        Padding="24,20,24,16">
+                    <StackPanel Spacing="6">
+                        <Grid ColumnDefinitions="Auto,Auto,Auto,*,Auto">
+                            <Ellipse Width="10" Height="10" Fill="{StaticResource NtFg4}" VerticalAlignment="Center"/>
+                            <TextBlock Grid.Column="1"
+                                       Name="DetailTitle"
+                                       Margin="10,0,0,0"
+                                       Text="—"
+                                       FontSize="20"
+                                       FontWeight="SemiBold"
+                                       Foreground="{StaticResource NtFg}"
+                                       VerticalAlignment="Center"/>
+                            <PathIcon Grid.Column="2"
+                                      Name="DetailFavStar"
+                                      Margin="10,0,0,0"
+                                      Data="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z"
+                                      Width="16" Height="16"
+                                      Foreground="{StaticResource NtYellow}"
+                                      IsVisible="False"
+                                      VerticalAlignment="Center"/>
+                            <StackPanel Grid.Column="4"
+                                        Orientation="Horizontal"
+                                        Spacing="6"
+                                        VerticalAlignment="Center">
+                                <Ellipse Width="8" Height="8" Fill="{StaticResource NtFg4}" VerticalAlignment="Center"/>
+                                <TextBlock Text="IDLE"
+                                           FontSize="11"
+                                           LetterSpacing="1"
+                                           Foreground="{StaticResource NtFg3}"
+                                           VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </Grid>
+
+                        <TextBlock Name="DetailEndpoint"
+                                   Text="—"
+                                   FontFamily="{StaticResource NtMono}"
+                                   FontSize="13"
+                                   Foreground="{StaticResource NtFg3}"/>
+
+                        <!-- Action bar -->
+                        <Grid Margin="0,10,0,0" ColumnDefinitions="Auto,Auto,Auto,Auto,*,Auto,Auto,Auto,Auto,Auto">
+                            <Button Grid.Column="0"
+                                    Classes="Primary"
+                                    Click="OnOpenCurrentClick"
+                                    ToolTip.Tip="Open in current pane">
+                                <StackPanel Orientation="Horizontal" Spacing="6">
+                                    <PathIcon Data="M8,5.14V19.14L19,12.14L8,5.14Z" Width="11" Height="11" Foreground="#0a1622"/>
+                                    <TextBlock Text="Open"/>
+                                </StackPanel>
+                            </Button>
+                            <Button Grid.Column="1" Classes="Pill" Margin="6,0,0,0" Content="+ Tab"     Click="OnOpenNewTabClick"/>
+                            <Button Grid.Column="2" Classes="Pill" Margin="6,0,0,0" Content="Split ⇒"   Click="OnSplitHorizontalClick"/>
+                            <Button Grid.Column="3" Classes="Pill" Margin="6,0,0,0" Content="Split ⇓"   Click="OnSplitVerticalClick"/>
+
+                            <ComboBox Name="DiagnosticsCombo"
+                                      Grid.Column="5"
+                                      Classes="Diag"
+                                      Width="130"
+                                      Margin="6,0,8,0"
+                                      ToolTip.Tip="Diagnostics level"/>
+
+                            <Button Grid.Column="6" Classes="IconBtn" Click="OnFavoriteClick" ToolTip.Tip="Toggle favorite">
+                                <PathIcon Data="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z" Width="14" Height="14"/>
+                            </Button>
+                            <Button Grid.Column="7" Classes="IconBtn" Click="OnEditClick" ToolTip.Tip="Edit connection">
+                                <PathIcon Data="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z" Width="14" Height="14"/>
+                            </Button>
+                            <Button Grid.Column="8" Classes="IconBtn" Click="OnCopyCommandClick" ToolTip.Tip="Copy launch command">
+                                <PathIcon Data="M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M19,21H8V7H19V21Z" Width="14" Height="14"/>
+                            </Button>
+                            <Button Grid.Column="9" Classes="IconBtn" Click="OnDetailsClick" ToolTip.Tip="Connection details">
+                                <PathIcon Data="M11,17H13V11H11M12,9A1,1 0 0,0 13,8A1,1 0 0,0 12,7A1,1 0 0,0 11,8A1,1 0 0,0 12,9M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z" Width="14" Height="14"/>
+                            </Button>
+                        </Grid>
+                    </StackPanel>
+                </Border>
+
+                <!-- Detail body -->
+                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="24,20" Spacing="24">
+
+                        <!-- Connection details -->
+                        <StackPanel Spacing="10">
+                            <TextBlock Classes="SectionHeader" Text="CONNECTION"/>
+                            <Grid ColumnDefinitions="130,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto" Margin="0,0,0,0">
+                                <TextBlock Grid.Row="0" Grid.Column="0" Text="Host"        Foreground="{StaticResource NtFg3}" FontSize="13" Margin="0,4"/>
+                                <TextBlock Grid.Row="0" Grid.Column="1" Name="KvHost"  Text="—" FontFamily="{StaticResource NtMono}" FontSize="12.5" Foreground="{StaticResource NtFg}" Margin="0,4"/>
+                                <TextBlock Grid.Row="1" Grid.Column="0" Text="Port"        Foreground="{StaticResource NtFg3}" FontSize="13" Margin="0,4"/>
+                                <TextBlock Grid.Row="1" Grid.Column="1" Name="KvPort"  Text="—" FontFamily="{StaticResource NtMono}" FontSize="12.5" Foreground="{StaticResource NtFg}" Margin="0,4"/>
+                                <TextBlock Grid.Row="2" Grid.Column="0" Text="User"        Foreground="{StaticResource NtFg3}" FontSize="13" Margin="0,4"/>
+                                <TextBlock Grid.Row="2" Grid.Column="1" Name="KvUser"  Text="—" FontFamily="{StaticResource NtMono}" FontSize="12.5" Foreground="{StaticResource NtFg}" Margin="0,4"/>
+                                <TextBlock Grid.Row="3" Grid.Column="0" Text="Group"       Foreground="{StaticResource NtFg3}" FontSize="13" Margin="0,4"/>
+                                <TextBlock Grid.Row="3" Grid.Column="1" Name="KvGroup" Text="—" FontFamily="{StaticResource NtMono}" FontSize="12.5" Foreground="{StaticResource NtFg}" Margin="0,4"/>
+                                <TextBlock Grid.Row="4" Grid.Column="0" Text="Auth"        Foreground="{StaticResource NtFg3}" FontSize="13" Margin="0,4"/>
+                                <TextBlock Grid.Row="4" Grid.Column="1" Name="KvAuth"  Text="—" FontFamily="{StaticResource NtMono}" FontSize="12.5" Foreground="{StaticResource NtFg}" Margin="0,4"/>
+                            </Grid>
+                        </StackPanel>
+
+                        <!-- Tags & notes -->
+                        <StackPanel Spacing="10">
+                            <TextBlock Classes="SectionHeader" Text="TAGS &amp; NOTES"/>
+                            <ItemsControl Name="DetailTags">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <WrapPanel Orientation="Horizontal" ItemSpacing="4" LineSpacing="4"/>
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border Background="{StaticResource NtBlueFaint}"
+                                                BorderBrush="{StaticResource NtBlueBorder}"
+                                                BorderThickness="1"
+                                                CornerRadius="8"
+                                                Padding="7,1">
+                                            <TextBlock Text="{Binding}" FontSize="10" Foreground="{StaticResource NtBlue}"/>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                            <Border Name="DetailNotesContainer"
+                                    Padding="0">
+                                <TextBlock Name="DetailNotes"
+                                           Text=""
+                                           FontSize="12.5"
+                                           LineHeight="19"
+                                           Foreground="{StaticResource NtFg2}"
+                                           TextWrapping="Wrap"/>
                             </Border>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </ScrollViewer>
+                        </StackPanel>
+
+                        <!-- Launch preview -->
+                        <StackPanel Spacing="10">
+                            <TextBlock Classes="SectionHeader" Text="LAUNCH PREVIEW"/>
+                            <Border Background="{StaticResource NtPanel}"
+                                    BorderBrush="{StaticResource NtHairline}"
+                                    BorderThickness="1"
+                                    CornerRadius="6"
+                                    Padding="12">
+                                <TextBlock Name="LaunchPreviewText"
+                                           FontFamily="{StaticResource NtMono}"
+                                           FontSize="12"
+                                           Foreground="{StaticResource NtFg2}"
+                                           LineHeight="18"
+                                           TextWrapping="Wrap"
+                                           Text="Selected level: None&#x0a;SSH flags added: none&#x0a;Open, Copy command, and Connection details use this level."/>
+                            </Border>
+                        </StackPanel>
+
+                    </StackPanel>
+                </ScrollViewer>
+            </Grid>
         </Grid>
     </Grid>
 </UserControl>

--- a/src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs
+++ b/src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs
@@ -1,5 +1,7 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.VisualTree;
@@ -8,11 +10,16 @@ using NovaTerminal.Core.Ssh.Launch;
 using NovaTerminal.ViewModels.Ssh;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace NovaTerminal.Controls
 {
     public partial class ConnectionManager : UserControl
     {
+        private const string FavoriteTag = "favorite";
+
+        // Public API — preserved from the original control.
         public event Action<TerminalProfile, SshDiagnosticsLevel>? OnConnect;
         public event Action<TerminalProfile, SshQuickOpenTarget, SshDiagnosticsLevel>? OnQuickOpenRequested;
         public event Action<TerminalProfile>? OnEditProfile;
@@ -23,32 +30,53 @@ namespace NovaTerminal.Controls
         public event Action? OnNewConnectionRequested;
 
         private readonly SshManagerViewModel _viewModel = new();
+        private readonly ObservableCollection<GroupNode> _groups = new();
+        private readonly ObservableCollection<TagNode> _tags = new();
+        private readonly ObservableCollection<SshProfileRowViewModel> _visibleRows = new();
+        private readonly HashSet<string> _selectedTags = new(StringComparer.OrdinalIgnoreCase);
+        private string _selectedGroupKey = "__all";
+        private string _selectedStatusKey = "all";
+        private SshProfileRowViewModel? _selectedRow;
+
+        // Swatch palette cycled through derived groups.
+        private static readonly string[] GroupSwatches =
+        {
+            "#e06c75", "#e5c07b", "#56b6c2", "#c678dd", "#d19a66", "#98c379", "#61afef"
+        };
 
         public ConnectionManager()
         {
             InitializeComponent();
             DataContext = _viewModel;
 
+            // Search wiring (preserved).
             SearchInput.TextChanged += (_, _) =>
             {
                 _viewModel.SearchText = SearchInput.Text ?? string.Empty;
+                ApplyFilters();
                 UpdateResultCountText();
             };
 
-            var connectionsList = this.FindControl<ItemsControl>("ConnectionsList");
-            if (connectionsList != null)
+            // Connection list (now a ListBox — still an ItemsControl).
+            var list = this.FindControl<ListBox>("ConnectionsList");
+            if (list != null)
             {
-                connectionsList.ItemsSource = _viewModel.FilteredRows;
+                list.ItemsSource = _visibleRows;
             }
 
-            _viewModel.PropertyChanged += (_, e) =>
+            // Groups column.
+            var groupsList = this.FindControl<ItemsControl>("GroupsList");
+            if (groupsList != null)
             {
-                if (e.PropertyName == nameof(SshManagerViewModel.SearchText))
-                {
-                    UpdateResultCountText();
-                }
-            };
+                groupsList.ItemsSource = _groups;
+            }
+            var tagsList = this.FindControl<ItemsControl>("TagsList");
+            if (tagsList != null)
+            {
+                tagsList.ItemsSource = _tags;
+            }
 
+            // Diagnostics combo (preserved).
             var diagnosticsCombo = this.FindControl<ComboBox>("DiagnosticsCombo");
             if (diagnosticsCombo != null)
             {
@@ -57,13 +85,18 @@ namespace NovaTerminal.Controls
                 diagnosticsCombo.SelectionChanged += (_, _) =>
                 {
                     _viewModel.DiagnosticsLevel = GetSelectedDiagnosticsLevel();
+                    UpdateLaunchPreview();
                 };
             }
 
             _viewModel.DiagnosticsLevel = SshDiagnosticsLevel.None;
             UpdateResultCountText();
+            UpdateGroupCounts();
+            RenderEmptyDetail();
+            UpdateLaunchPreview();
         }
 
+        // ----- Kept for source compatibility; not used by the new visual. -----
         public static readonly StyledProperty<IBrush> CardBackgroundProperty =
             AvaloniaProperty.Register<ConnectionManager, IBrush>(nameof(CardBackground));
 
@@ -82,23 +115,347 @@ namespace NovaTerminal.Controls
             set => SetValue(SecondaryForegroundProperty, value);
         }
 
+        // Palette is fixed in the new design (matches the mockup). Kept as a no-op
+        // so callers (MainWindow) don't need to change.
         public void ApplyTheme(TerminalTheme theme)
         {
-            this.Background = new Avalonia.Media.SolidColorBrush(theme.Background.ToAvaloniaColor());
-            this.Foreground = new Avalonia.Media.SolidColorBrush(theme.Foreground.ToAvaloniaColor());
-
-            // Card background calculation
-            var bgColor = theme.Background.ToAvaloniaColor();
-            var cardColor = bgColor;
-            if (bgColor.R < 127) // Dark theme assumption
-                cardColor = Avalonia.Media.Color.FromRgb((byte)Math.Min(255, cardColor.R + 25), (byte)Math.Min(255, cardColor.G + 25), (byte)Math.Min(255, cardColor.B + 25));
-            else // Light theme assumption
-                cardColor = Avalonia.Media.Color.FromRgb((byte)Math.Max(0, cardColor.R - 15), (byte)Math.Max(0, cardColor.G - 15), (byte)Math.Max(0, cardColor.B - 15));
-
-            CardBackground = new Avalonia.Media.SolidColorBrush(cardColor);
-            SecondaryForeground = new Avalonia.Media.SolidColorBrush(theme.Foreground.ToAvaloniaColor()) { Opacity = 0.7 };
+            UpdatePaletteResources(theme);
         }
 
+        // ----- Public methods preserved. -----
+        public void LoadProfiles(IEnumerable<TerminalProfile> profiles)
+        {
+            _viewModel.LoadProfiles(profiles);
+            RebuildGroups();
+            RebuildTags();
+            ApplyFilters();
+            UpdateResultCountText();
+            UpdateGroupCounts();
+            RenderEmptyDetail();
+        }
+
+        public IReadOnlyList<TerminalProfile> GetAllProfiles() => _viewModel.GetAllProfiles();
+
+        // ----- Groups column -----
+        private void RebuildGroups()
+        {
+            _groups.Clear();
+            var all = _viewModel.GetAllProfiles();
+            var grouped = all
+                .Select(p => string.IsNullOrWhiteSpace(p.Group) ? "Ungrouped" : p.Group)
+                .GroupBy(g => g, StringComparer.OrdinalIgnoreCase)
+                .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            for (int i = 0; i < grouped.Count; i++)
+            {
+                var g = grouped[i];
+                _groups.Add(new GroupNode
+                {
+                    Name = g.Key ?? "Ungrouped",
+                    Count = g.Count(),
+                    Swatch = new SolidColorBrush(Color.Parse(GroupSwatches[i % GroupSwatches.Length])),
+                });
+            }
+        }
+
+        private void RebuildTags()
+        {
+            var grouped = _viewModel.GetAllProfiles()
+                .SelectMany(profile => profile.Tags ?? new List<string>())
+                .Where(tag => !string.IsNullOrWhiteSpace(tag))
+                .Select(tag => tag.Trim())
+                .Where(tag => !string.Equals(tag, FavoriteTag, StringComparison.OrdinalIgnoreCase))
+                .GroupBy(tag => tag, StringComparer.OrdinalIgnoreCase)
+                .OrderBy(group => group.Key, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var availableTags = new HashSet<string>(grouped.Select(group => group.Key), StringComparer.OrdinalIgnoreCase);
+            _selectedTags.RemoveWhere(tag => !availableTags.Contains(tag));
+
+            _tags.Clear();
+            for (int i = 0; i < grouped.Count; i++)
+            {
+                var group = grouped[i];
+                _tags.Add(new TagNode
+                {
+                    Name = group.Key,
+                    Count = group.Count(),
+                    Swatch = new SolidColorBrush(Color.Parse(GroupSwatches[i % GroupSwatches.Length])),
+                    IsSelected = _selectedTags.Contains(group.Key)
+                });
+            }
+        }
+
+        private void UpdateGroupCounts()
+        {
+            var all = _viewModel.GetAllProfiles();
+            var countAll = this.FindControl<TextBlock>("CountAll");
+            var countFav = this.FindControl<TextBlock>("CountFav");
+            if (countAll != null) countAll.Text = all.Count.ToString();
+            if (countFav != null) countFav.Text = all.Count(p => p.Tags != null && p.Tags.Any(t => string.Equals(t, "favorite", StringComparison.OrdinalIgnoreCase))).ToString();
+        }
+
+        private void OnGroupClick(object? sender, RoutedEventArgs e)
+        {
+            if (sender is not Button btn || btn.Tag is not string key)
+            {
+                return;
+            }
+
+            _selectedGroupKey = key;
+            UpdateGroupActiveClasses(btn);
+            ApplyFilters();
+            UpdateResultCountText();
+            e.Handled = true;
+        }
+
+        private void OnTagClick(object? sender, RoutedEventArgs e)
+        {
+            if (sender is not ToggleButton toggle || toggle.Tag is not string tag)
+            {
+                return;
+            }
+
+            if (toggle.IsChecked == true)
+            {
+                _selectedTags.Add(tag);
+            }
+            else
+            {
+                _selectedTags.Remove(tag);
+            }
+
+            if (toggle.DataContext is TagNode node)
+            {
+                node.IsSelected = toggle.IsChecked == true;
+            }
+
+            ApplyFilters();
+            UpdateResultCountText();
+            e.Handled = true;
+        }
+
+        private void UpdateGroupActiveClasses(Button activeBtn)
+        {
+            // Clear .active on built-in buttons.
+            foreach (var name in new[] { "BtnGroupAll", "BtnGroupFav" })
+            {
+                var b = this.FindControl<Button>(name);
+                if (b != null) b.Classes.Remove("active");
+            }
+            // And on dynamic group buttons.
+            var groupsList = this.FindControl<ItemsControl>("GroupsList");
+            if (groupsList != null)
+            {
+                foreach (var b in groupsList.GetVisualDescendants().OfType<Button>())
+                {
+                    b.Classes.Remove("active");
+                }
+            }
+
+            activeBtn.Classes.Add("active");
+        }
+
+        // ----- Status filter chips (mutually exclusive) -----
+        private void OnStatusFilterClick(object? sender, RoutedEventArgs e)
+        {
+            if (sender is not ToggleButton tb || tb.Tag is not string key)
+            {
+                return;
+            }
+
+            _selectedStatusKey = key;
+
+            foreach (var name in new[] { "ChipAll", "ChipFav" })
+            {
+                var chip = this.FindControl<ToggleButton>(name);
+                if (chip != null) chip.IsChecked = chip == tb;
+            }
+
+            ApplyFilters();
+            UpdateResultCountText();
+            e.Handled = true;
+        }
+
+        // ----- Filtering -----
+        private void ApplyFilters()
+        {
+            _viewModel.SearchText = SearchInput.Text ?? string.Empty;
+            IEnumerable<SshProfileRowViewModel> rows = _viewModel.FilteredRows;
+
+            if (!string.Equals(_selectedGroupKey, "__all", StringComparison.Ordinal))
+            {
+                if (string.Equals(_selectedGroupKey, "__fav", StringComparison.Ordinal))
+                {
+                    rows = rows.Where(r => r.IsFavorite);
+                }
+                else
+                {
+                    rows = rows.Where(r => string.Equals(r.GroupPath, _selectedGroupKey, StringComparison.OrdinalIgnoreCase)
+                        || (string.Equals(_selectedGroupKey, "Ungrouped", StringComparison.OrdinalIgnoreCase) && string.IsNullOrWhiteSpace(r.GroupPath)));
+                }
+            }
+
+            switch (_selectedStatusKey)
+            {
+                case "fav":
+                    rows = rows.Where(r => r.IsFavorite);
+                    break;
+            }
+
+            if (_selectedTags.Count > 0)
+            {
+                rows = rows.Where(row => row.Tags.Any(tag => _selectedTags.Contains(tag)));
+            }
+
+            _visibleRows.Clear();
+            foreach (var row in rows)
+            {
+                _visibleRows.Add(row);
+            }
+
+            var list = this.FindControl<ListBox>("ConnectionsList");
+            if (_selectedRow != null && _visibleRows.Contains(_selectedRow))
+            {
+                if (list != null && !ReferenceEquals(list.SelectedItem, _selectedRow))
+                {
+                    list.SelectedItem = _selectedRow;
+                }
+            }
+            else
+            {
+                _selectedRow = null;
+                if (list != null)
+                {
+                    list.SelectedItem = null;
+                }
+                RenderEmptyDetail();
+            }
+        }
+
+        // ----- Selection -----
+        private void OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (e.AddedItems != null && e.AddedItems.Count > 0 && e.AddedItems[0] is SshProfileRowViewModel row)
+            {
+                _selectedRow = row;
+                RenderDetail(row);
+            }
+            else
+            {
+                _selectedRow = null;
+                RenderEmptyDetail();
+            }
+        }
+
+        private void OnRowDoubleTapped(object? sender, TappedEventArgs e)
+        {
+            if (_selectedRow == null) return;
+
+            _viewModel.DiagnosticsLevel = GetSelectedDiagnosticsLevel();
+            _viewModel.RequestOpen(_selectedRow, SshQuickOpenTarget.CurrentPane);
+            OnQuickOpenRequested?.Invoke(_selectedRow.Profile, SshQuickOpenTarget.CurrentPane, _viewModel.DiagnosticsLevel);
+            OnConnect?.Invoke(_selectedRow.Profile, _viewModel.DiagnosticsLevel);
+            e.Handled = true;
+        }
+
+        // ----- Detail rendering -----
+        private void RenderEmptyDetail()
+        {
+            var empty = this.FindControl<StackPanel>("DetailEmptyState");
+            var content = this.FindControl<Grid>("DetailContent");
+            if (empty != null) empty.IsVisible = true;
+            if (content != null) content.IsVisible = false;
+        }
+
+        private void RenderDetail(SshProfileRowViewModel row)
+        {
+            var empty = this.FindControl<StackPanel>("DetailEmptyState");
+            var content = this.FindControl<Grid>("DetailContent");
+            if (empty != null) empty.IsVisible = false;
+            if (content != null) content.IsVisible = true;
+
+            SetText("DetailTitle", row.Name);
+            SetText("DetailEndpoint", row.Endpoint);
+            SetText("KvHost",  string.IsNullOrWhiteSpace(row.Host)  ? "—" : row.Host);
+            SetText("KvPort",  row.Port.ToString());
+            SetText("KvUser",  string.IsNullOrWhiteSpace(row.User)  ? "—" : row.User);
+            SetText("KvGroup", string.IsNullOrWhiteSpace(row.GroupPath) ? "Ungrouped" : row.GroupPath);
+            SetText("KvAuth",  DescribeAuth(row.Profile));
+
+            var fav = this.FindControl<PathIcon>("DetailFavStar");
+            if (fav != null) fav.IsVisible = row.IsFavorite;
+
+            var tagsControl = this.FindControl<ItemsControl>("DetailTags");
+            if (tagsControl != null) tagsControl.ItemsSource = row.Tags.Where(t => !string.Equals(t, "favorite", StringComparison.OrdinalIgnoreCase)).ToList();
+
+            var notes = this.FindControl<TextBlock>("DetailNotes");
+            if (notes != null) notes.Text = string.IsNullOrWhiteSpace(row.Notes) ? "(no notes)" : row.Notes;
+
+            UpdateLaunchPreview();
+        }
+
+        private void SetText(string controlName, string text)
+        {
+            var tb = this.FindControl<TextBlock>(controlName);
+            if (tb != null) tb.Text = text;
+        }
+
+        private static string DescribeAuth(TerminalProfile profile)
+        {
+            // Best-effort; the actual profile model may expose richer fields.
+            try
+            {
+                var prop = profile.GetType().GetProperty("AuthMode")
+                          ?? profile.GetType().GetProperty("SshAuthMode");
+                var idProp = profile.GetType().GetProperty("IdentityFilePath");
+                var mode = prop?.GetValue(profile)?.ToString() ?? "agent";
+                var id = idProp?.GetValue(profile) as string;
+                return string.IsNullOrWhiteSpace(id) ? mode : $"{mode} · {id}";
+            }
+            catch
+            {
+                return "agent";
+            }
+        }
+
+        private void UpdateLaunchPreview()
+        {
+            var preview = this.FindControl<TextBlock>("LaunchPreviewText");
+            if (preview == null)
+            {
+                return;
+            }
+
+            SshDiagnosticsLevel level = GetSelectedDiagnosticsLevel();
+            string flags = string.Join(" ", level.ToArguments());
+            if (string.IsNullOrWhiteSpace(flags))
+            {
+                flags = "none";
+            }
+
+            string target = _selectedRow == null
+                ? "the selected connection"
+                : _selectedRow.Endpoint;
+
+            preview.Text =
+                $"Selected level: {DescribeDiagnosticsLevel(level)}{Environment.NewLine}" +
+                $"SSH flags added: {flags}{Environment.NewLine}" +
+                $"Open, Copy command, and Connection details use this level for {target}.";
+        }
+
+        private static string DescribeDiagnosticsLevel(SshDiagnosticsLevel level)
+        {
+            return level switch
+            {
+                SshDiagnosticsLevel.Verbose => "Verbose",
+                SshDiagnosticsLevel.VeryVerbose => "Very verbose",
+                _ => "None"
+            };
+        }
+
+        // ----- Toolbar handlers (preserved) -----
         private void OnSyncClick(object? sender, RoutedEventArgs e)
         {
             OnSyncRequested?.Invoke();
@@ -109,6 +466,7 @@ namespace NovaTerminal.Controls
             OnNewConnectionRequested?.Invoke();
         }
 
+        // ----- Detail action handlers (preserved API, source row = _selectedRow) -----
         private void OnEditClick(object? sender, RoutedEventArgs e)
         {
             if (TryGetRow(sender, out var row))
@@ -136,17 +494,6 @@ namespace NovaTerminal.Controls
             }
         }
 
-        public void LoadProfiles(IEnumerable<TerminalProfile> profiles)
-        {
-            _viewModel.LoadProfiles(profiles);
-            UpdateResultCountText();
-        }
-
-        public IReadOnlyList<TerminalProfile> GetAllProfiles()
-        {
-            return _viewModel.GetAllProfiles();
-        }
-
         private void OnFavoriteClick(object? sender, RoutedEventArgs e)
         {
             if (!TryGetRow(sender, out var row))
@@ -156,31 +503,38 @@ namespace NovaTerminal.Controls
 
             e.Handled = true;
             _viewModel.ToggleFavorite(row);
+            ApplyFilters();
             UpdateResultCountText();
+            UpdateGroupCounts();
+            RebuildTags();
+
+            var fav = this.FindControl<PathIcon>("DetailFavStar");
+            if (fav != null) fav.IsVisible = row.IsFavorite;
+
             OnProfilesChanged?.Invoke();
         }
 
         private void OnOpenCurrentClick(object? sender, RoutedEventArgs e)
         {
-            RequestOpen(sender, SshQuickOpenTarget.CurrentPane);
+            RequestOpen(SshQuickOpenTarget.CurrentPane);
             e.Handled = true;
         }
 
         private void OnOpenNewTabClick(object? sender, RoutedEventArgs e)
         {
-            RequestOpen(sender, SshQuickOpenTarget.NewTab);
+            RequestOpen(SshQuickOpenTarget.NewTab);
             e.Handled = true;
         }
 
         private void OnSplitHorizontalClick(object? sender, RoutedEventArgs e)
         {
-            RequestOpen(sender, SshQuickOpenTarget.SplitHorizontal);
+            RequestOpen(SshQuickOpenTarget.SplitHorizontal);
             e.Handled = true;
         }
 
         private void OnSplitVerticalClick(object? sender, RoutedEventArgs e)
         {
-            RequestOpen(sender, SshQuickOpenTarget.SplitVertical);
+            RequestOpen(SshQuickOpenTarget.SplitVertical);
             e.Handled = true;
         }
 
@@ -191,12 +545,21 @@ namespace NovaTerminal.Controls
             {
                 return level;
             }
-
             return SshDiagnosticsLevel.None;
         }
 
+        // TryGetRow now prefers the selected row in the list (since action
+        // buttons live in the detail panel and aren't tagged per-row).
         private bool TryGetRow(object? sender, out SshProfileRowViewModel row)
         {
+            if (_selectedRow != null)
+            {
+                row = _selectedRow;
+                return true;
+            }
+
+            // Fallback: legacy ancestor walk (in case buttons get added back
+            // to the row template later).
             if (sender is Control control)
             {
                 if (control.Tag is SshProfileRowViewModel taggedRow)
@@ -220,7 +583,6 @@ namespace NovaTerminal.Controls
                             row = ancestorTaggedRow;
                             return true;
                         }
-
                         if (ancestorControl.DataContext is SshProfileRowViewModel ancestorDataContextRow)
                         {
                             row = ancestorDataContextRow;
@@ -234,32 +596,102 @@ namespace NovaTerminal.Controls
             return false;
         }
 
-        private void RequestOpen(object? sender, SshQuickOpenTarget target)
+        private void RequestOpen(SshQuickOpenTarget target)
         {
-            if (!TryGetRow(sender, out var row))
-            {
-                return;
-            }
+            if (_selectedRow == null) return;
 
             _viewModel.DiagnosticsLevel = GetSelectedDiagnosticsLevel();
-            _viewModel.RequestOpen(row, target);
-            OnQuickOpenRequested?.Invoke(row.Profile, target, _viewModel.DiagnosticsLevel);
+            _viewModel.RequestOpen(_selectedRow, target);
+            OnQuickOpenRequested?.Invoke(_selectedRow.Profile, target, _viewModel.DiagnosticsLevel);
 
             if (target == SshQuickOpenTarget.CurrentPane)
             {
-                // Backward-compat for existing handlers until all callers use quick-open targets.
-                OnConnect?.Invoke(row.Profile, _viewModel.DiagnosticsLevel);
+                OnConnect?.Invoke(_selectedRow.Profile, _viewModel.DiagnosticsLevel);
             }
         }
 
         private void UpdateResultCountText()
         {
             var resultCountText = this.FindControl<TextBlock>("ResultCountText");
-            if (resultCountText != null)
+            if (resultCountText == null) return;
+
+            int count = _visibleRows.Count;
+
+            resultCountText.Text = count == 1 ? "1 connection" : $"{count} connections";
+        }
+
+        private void UpdatePaletteResources(TerminalTheme theme)
+        {
+            var background = theme.Background.ToAvaloniaColor();
+            var foreground = theme.Foreground.ToAvaloniaColor();
+            bool dark = IsDark(background);
+
+            UpdateBrush("NtWindowBg", background);
+            UpdateBrush("NtChromeBg", Shift(background, dark ? 10 : -10));
+            UpdateBrush("NtPanel", Shift(background, dark ? 18 : -18));
+            UpdateBrush("NtPanelAlt", Shift(background, dark ? 6 : -6));
+            UpdateBrush("NtHairline", Shift(background, dark ? 28 : -28));
+            UpdateBrush("NtFg", foreground);
+            UpdateBrush("NtFg2", WithAlpha(foreground, 0xC8));
+            UpdateBrush("NtFg3", WithAlpha(foreground, 0x9A));
+            UpdateBrush("NtFg4", WithAlpha(foreground, 0x6E));
+            UpdateBrush("NtBlue", theme.Blue.ToAvaloniaColor());
+            UpdateBrush("NtBlueDim", WithAlpha(theme.Blue.ToAvaloniaColor(), 0x24));
+            UpdateBrush("NtBlueFaint", WithAlpha(theme.Blue.ToAvaloniaColor(), 0x15));
+            UpdateBrush("NtBlueBorder", WithAlpha(theme.Blue.ToAvaloniaColor(), 0x4D));
+            UpdateBrush("NtGreen", theme.Green.ToAvaloniaColor());
+            UpdateBrush("NtYellow", theme.Yellow.ToAvaloniaColor());
+            UpdateBrush("NtRed", theme.Red.ToAvaloniaColor());
+            UpdateBrush("NtMagenta", theme.Magenta.ToAvaloniaColor());
+        }
+
+        private void UpdateBrush(string key, Color color)
+        {
+            if (Resources[key] is SolidColorBrush brush)
             {
-                int count = _viewModel.FilteredRows.Count;
-                resultCountText.Text = count == 1 ? "1 connection" : $"{count} connections";
+                brush.Color = color;
+            }
+            else
+            {
+                Resources[key] = new SolidColorBrush(color);
             }
         }
+
+        private static bool IsDark(Color color)
+        {
+            double luminance = ((0.299 * color.R) + (0.587 * color.G) + (0.114 * color.B)) / 255.0;
+            return luminance < 0.5;
+        }
+
+        private static Color Shift(Color color, int delta)
+        {
+            return Color.FromArgb(
+                color.A,
+                Clamp(color.R + delta),
+                Clamp(color.G + delta),
+                Clamp(color.B + delta));
+        }
+
+        private static Color WithAlpha(Color color, byte alpha) => Color.FromArgb(alpha, color.R, color.G, color.B);
+
+        private static byte Clamp(int value) => (byte)Math.Max(0, Math.Min(255, value));
+
+    }
+
+    // Public POCO so XAML compiled bindings can resolve it. Used by the
+    // groups column ItemsControl in ConnectionManager.axaml.
+    public sealed class GroupNode
+    {
+        public string Name { get; init; } = "";
+        public int Count { get; init; }
+        public IBrush Swatch { get; init; } = Brushes.Gray;
+    }
+
+    public sealed class TagNode
+    {
+        public string Name { get; init; } = "";
+        public int Count { get; init; }
+        public IBrush Swatch { get; init; } = Brushes.Gray;
+        public bool IsSelected { get; set; }
     }
 }

--- a/src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs
+++ b/src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs
@@ -11,6 +11,8 @@ using NovaTerminal.ViewModels.Ssh;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Linq;
 
 namespace NovaTerminal.Controls
@@ -32,7 +34,7 @@ namespace NovaTerminal.Controls
         private readonly SshManagerViewModel _viewModel = new();
         private readonly ObservableCollection<GroupNode> _groups = new();
         private readonly ObservableCollection<TagNode> _tags = new();
-        private readonly ObservableCollection<SshProfileRowViewModel> _visibleRows = new();
+        private readonly ResettableObservableCollection<SshProfileRowViewModel> _visibleRows = new();
         private readonly HashSet<string> _selectedTags = new(StringComparer.OrdinalIgnoreCase);
         private string _selectedGroupKey = "__all";
         private string _selectedStatusKey = "all";
@@ -115,8 +117,7 @@ namespace NovaTerminal.Controls
             set => SetValue(SecondaryForegroundProperty, value);
         }
 
-        // Palette is fixed in the new design (matches the mockup). Kept as a no-op
-        // so callers (MainWindow) don't need to change.
+        // Preserved for source compatibility with MainWindow's theme refresh path.
         public void ApplyTheme(TerminalTheme theme)
         {
             UpdatePaletteResources(theme);
@@ -309,14 +310,11 @@ namespace NovaTerminal.Controls
                 rows = rows.Where(row => row.Tags.Any(tag => _selectedTags.Contains(tag)));
             }
 
-            _visibleRows.Clear();
-            foreach (var row in rows)
-            {
-                _visibleRows.Add(row);
-            }
+            var nextRows = rows.ToList();
+            _visibleRows.ReplaceAll(nextRows);
 
             var list = this.FindControl<ListBox>("ConnectionsList");
-            if (_selectedRow != null && _visibleRows.Contains(_selectedRow))
+            if (_selectedRow != null && nextRows.Contains(_selectedRow))
             {
                 if (list != null && !ReferenceEquals(list.SelectedItem, _selectedRow))
                 {
@@ -404,20 +402,12 @@ namespace NovaTerminal.Controls
 
         private static string DescribeAuth(TerminalProfile profile)
         {
-            // Best-effort; the actual profile model may expose richer fields.
-            try
+            if (!profile.UseSshAgent && !string.IsNullOrWhiteSpace(profile.IdentityFilePath))
             {
-                var prop = profile.GetType().GetProperty("AuthMode")
-                          ?? profile.GetType().GetProperty("SshAuthMode");
-                var idProp = profile.GetType().GetProperty("IdentityFilePath");
-                var mode = prop?.GetValue(profile)?.ToString() ?? "agent";
-                var id = idProp?.GetValue(profile) as string;
-                return string.IsNullOrWhiteSpace(id) ? mode : $"{mode} · {id}";
+                return $"identity file · {profile.IdentityFilePath.Trim()}";
             }
-            catch
-            {
-                return "agent";
-            }
+
+            return "agent";
         }
 
         private void UpdateLaunchPreview()
@@ -622,60 +612,25 @@ namespace NovaTerminal.Controls
 
         private void UpdatePaletteResources(TerminalTheme theme)
         {
-            var background = theme.Background.ToAvaloniaColor();
-            var foreground = theme.Foreground.ToAvaloniaColor();
-            bool dark = IsDark(background);
-
-            UpdateBrush("NtWindowBg", background);
-            UpdateBrush("NtChromeBg", Shift(background, dark ? 10 : -10));
-            UpdateBrush("NtPanel", Shift(background, dark ? 18 : -18));
-            UpdateBrush("NtPanelAlt", Shift(background, dark ? 6 : -6));
-            UpdateBrush("NtHairline", Shift(background, dark ? 28 : -28));
-            UpdateBrush("NtFg", foreground);
-            UpdateBrush("NtFg2", WithAlpha(foreground, 0xC8));
-            UpdateBrush("NtFg3", WithAlpha(foreground, 0x9A));
-            UpdateBrush("NtFg4", WithAlpha(foreground, 0x6E));
-            UpdateBrush("NtBlue", theme.Blue.ToAvaloniaColor());
-            UpdateBrush("NtBlueDim", WithAlpha(theme.Blue.ToAvaloniaColor(), 0x24));
-            UpdateBrush("NtBlueFaint", WithAlpha(theme.Blue.ToAvaloniaColor(), 0x15));
-            UpdateBrush("NtBlueBorder", WithAlpha(theme.Blue.ToAvaloniaColor(), 0x4D));
-            UpdateBrush("NtGreen", theme.Green.ToAvaloniaColor());
-            UpdateBrush("NtYellow", theme.Yellow.ToAvaloniaColor());
-            UpdateBrush("NtRed", theme.Red.ToAvaloniaColor());
-            UpdateBrush("NtMagenta", theme.Magenta.ToAvaloniaColor());
+            ThemePaletteResources.Apply(Resources, theme);
         }
 
-        private void UpdateBrush(string key, Color color)
+        private sealed class ResettableObservableCollection<T> : ObservableCollection<T>
         {
-            if (Resources[key] is SolidColorBrush brush)
+            public void ReplaceAll(IEnumerable<T> items)
             {
-                brush.Color = color;
-            }
-            else
-            {
-                Resources[key] = new SolidColorBrush(color);
+                CheckReentrancy();
+                Items.Clear();
+                foreach (var item in items)
+                {
+                    Items.Add(item);
+                }
+
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(Count)));
+                OnPropertyChanged(new PropertyChangedEventArgs("Item[]"));
+                OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
             }
         }
-
-        private static bool IsDark(Color color)
-        {
-            double luminance = ((0.299 * color.R) + (0.587 * color.G) + (0.114 * color.B)) / 255.0;
-            return luminance < 0.5;
-        }
-
-        private static Color Shift(Color color, int delta)
-        {
-            return Color.FromArgb(
-                color.A,
-                Clamp(color.R + delta),
-                Clamp(color.G + delta),
-                Clamp(color.B + delta));
-        }
-
-        private static Color WithAlpha(Color color, byte alpha) => Color.FromArgb(alpha, color.R, color.G, color.B);
-
-        private static byte Clamp(int value) => (byte)Math.Max(0, Math.Min(255, value));
-
     }
 
     // Public POCO so XAML compiled bindings can resolve it. Used by the

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -45,6 +45,22 @@ namespace NovaTerminal.Controls
         Close
     }
 
+    public enum RecordingNotificationKind
+    {
+        Started,
+        Stopped,
+        Failed
+    }
+
+    public sealed class RecordingNotificationEventArgs : EventArgs
+    {
+        public required RecordingNotificationKind Kind { get; init; }
+        public required bool IsRecording { get; init; }
+        public required string RecordingsDirectory { get; init; }
+        public string? FilePath { get; init; }
+        public string? ErrorMessage { get; init; }
+    }
+
     public readonly record struct SidebarTransferRequest(
         TransferDirection Direction,
         TransferKind Kind,
@@ -62,6 +78,7 @@ namespace NovaTerminal.Controls
 
         public event Action<TerminalPane, SidebarTransferRequest>? RequestRemoteFilesSidebarTransfer;
         public event Action<bool>? RecordingStateChanged;
+        public event Action<RecordingNotificationEventArgs>? RecordingNotification;
         public event Action<TerminalPane, string>? WorkingDirectoryChanged;
         public event Action<TerminalPane, string>? TitleChanged;
         public event Action<TerminalPane, PaneAction>? PaneActionRequested;
@@ -95,6 +112,7 @@ namespace NovaTerminal.Controls
         private IRemoteDirectoryBrowserService _remoteDirectoryBrowserService = new RemoteDirectoryBrowserService();
         private RemoteFilesSidebarViewModel? _remoteFilesSidebarViewModel;
         private bool _isRemoteFilesSidebarTestServiceConfigured;
+        private string? _currentRecordingFilePath;
         private const double CommandAssistBubbleWidth = 420;
         private const double CommandAssistBubbleHeight = 36;
         private const double CommandAssistPopupWidth = 520;
@@ -154,29 +172,56 @@ namespace NovaTerminal.Controls
         {
             if (Session == null) return;
 
+            string recordingsDirectory = AppPaths.RecordingsDirectory;
+
             if (Session.IsRecording)
             {
                 Session.StopRecording();
-                Buffer?.WriteContent("\r\n[Nova] Recording stopped.\r\n", false);
+                RecordingNotification?.Invoke(new RecordingNotificationEventArgs
+                {
+                    Kind = RecordingNotificationKind.Stopped,
+                    IsRecording = Session.IsRecording,
+                    FilePath = _currentRecordingFilePath,
+                    RecordingsDirectory = recordingsDirectory
+                });
+                _currentRecordingFilePath = null;
             }
             else
             {
                 try
                 {
-                    string recDir = AppPaths.RecordingsDirectory;
-                    if (!System.IO.Directory.Exists(recDir)) System.IO.Directory.CreateDirectory(recDir);
+                    if (!System.IO.Directory.Exists(recordingsDirectory))
+                    {
+                        System.IO.Directory.CreateDirectory(recordingsDirectory);
+                    }
 
                     string filename = $"nova_rec_{DateTime.Now:yyyyMMdd_HHmmss}.rec";
-                    string path = System.IO.Path.Combine(recDir, filename);
+                    string path = System.IO.Path.Combine(recordingsDirectory, filename);
 
                     Session.StartRecording(path);
-                    Buffer?.WriteContent($"\r\n[Nova] Recording started: {filename}\r\n", false);
+                    _currentRecordingFilePath = path;
+                    RecordingNotification?.Invoke(new RecordingNotificationEventArgs
+                    {
+                        Kind = RecordingNotificationKind.Started,
+                        IsRecording = Session.IsRecording,
+                        FilePath = path,
+                        RecordingsDirectory = recordingsDirectory
+                    });
                 }
                 catch (Exception ex)
                 {
-                    Buffer?.WriteContent($"\r\n[Nova] Failed to start recording: {ex.Message}\r\n", false);
+                    _currentRecordingFilePath = null;
+                    RecordingNotification?.Invoke(new RecordingNotificationEventArgs
+                    {
+                        Kind = RecordingNotificationKind.Failed,
+                        IsRecording = Session.IsRecording,
+                        FilePath = _currentRecordingFilePath,
+                        RecordingsDirectory = recordingsDirectory,
+                        ErrorMessage = ex.Message
+                    });
                 }
             }
+
             RecordingStateChanged?.Invoke(IsRecording);
         }
 

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -195,7 +195,7 @@ namespace NovaTerminal.Controls
                         System.IO.Directory.CreateDirectory(recordingsDirectory);
                     }
 
-                    string filename = $"nova_rec_{DateTime.Now:yyyyMMdd_HHmmss}.rec";
+                    string filename = BuildRecordingFileName(DateTime.Now, Guid.NewGuid().ToString("N"));
                     string path = System.IO.Path.Combine(recordingsDirectory, filename);
 
                     Session.StartRecording(path);
@@ -223,6 +223,19 @@ namespace NovaTerminal.Controls
             }
 
             RecordingStateChanged?.Invoke(IsRecording);
+        }
+
+        internal static string BuildRecordingFileName(DateTime timestamp, string uniqueSuffix)
+        {
+            string normalizedSuffix = string.IsNullOrWhiteSpace(uniqueSuffix)
+                ? Guid.NewGuid().ToString("N")
+                : uniqueSuffix.Trim().ToLowerInvariant();
+
+            string shortSuffix = normalizedSuffix.Length > 6
+                ? normalizedSuffix[..6]
+                : normalizedSuffix.PadRight(6, '0');
+
+            return $"nova_rec_{timestamp:yyyyMMdd_HHmmss}_{shortSuffix}.rec";
         }
 
         public void UpdateProfile(TerminalProfile profile)

--- a/src/NovaTerminal.App/Core/ThemePaletteResources.cs
+++ b/src/NovaTerminal.App/Core/ThemePaletteResources.cs
@@ -1,0 +1,66 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+
+namespace NovaTerminal.Core;
+
+internal static class ThemePaletteResources
+{
+    public static void Apply(IResourceDictionary resources, TerminalTheme theme)
+    {
+        var background = theme.Background.ToAvaloniaColor();
+        var foreground = theme.Foreground.ToAvaloniaColor();
+        bool dark = IsDark(background);
+
+        UpdateBrush(resources, "NtWindowBg", background);
+        UpdateBrush(resources, "NtChromeBg", Shift(background, dark ? 10 : -10));
+        UpdateBrush(resources, "NtPanel", Shift(background, dark ? 18 : -18));
+        UpdateBrush(resources, "NtPanelAlt", Shift(background, dark ? 6 : -6));
+        UpdateBrush(resources, "NtHairline", Shift(background, dark ? 28 : -28));
+        UpdateBrush(resources, "NtHairlineStrong", Shift(background, dark ? 40 : -40));
+        UpdateBrush(resources, "NtFg", foreground);
+        UpdateBrush(resources, "NtFg2", WithAlpha(foreground, 0xC8));
+        UpdateBrush(resources, "NtFg3", WithAlpha(foreground, 0x9A));
+        UpdateBrush(resources, "NtFg4", WithAlpha(foreground, 0x6E));
+        UpdateBrush(resources, "NtBlue", theme.Blue.ToAvaloniaColor());
+        UpdateBrush(resources, "NtBlueDim", WithAlpha(theme.Blue.ToAvaloniaColor(), 0x24));
+        UpdateBrush(resources, "NtBlueFaint", WithAlpha(theme.Blue.ToAvaloniaColor(), 0x15));
+        UpdateBrush(resources, "NtBlueBorder", WithAlpha(theme.Blue.ToAvaloniaColor(), 0x4D));
+        UpdateBrush(resources, "NtGreen", theme.Green.ToAvaloniaColor());
+        UpdateBrush(resources, "NtYellow", theme.Yellow.ToAvaloniaColor());
+        UpdateBrush(resources, "NtRed", theme.Red.ToAvaloniaColor());
+        UpdateBrush(resources, "NtMagenta", theme.Magenta.ToAvaloniaColor());
+    }
+
+    private static void UpdateBrush(IResourceDictionary resources, string key, Color color)
+    {
+        if (resources[key] is SolidColorBrush brush)
+        {
+            brush.Color = color;
+        }
+        else
+        {
+            resources[key] = new SolidColorBrush(color);
+        }
+    }
+
+    private static bool IsDark(Color color)
+    {
+        double luminance = ((0.299 * color.R) + (0.587 * color.G) + (0.114 * color.B)) / 255.0;
+        return luminance < 0.5;
+    }
+
+    private static Color Shift(Color color, int delta)
+    {
+        return Color.FromArgb(
+            color.A,
+            Clamp(color.R + delta),
+            Clamp(color.G + delta),
+            Clamp(color.B + delta));
+    }
+
+    private static Color WithAlpha(Color color, byte alpha) => Color.FromArgb(alpha, color.R, color.G, color.B);
+
+    private static byte Clamp(int value) => (byte)Math.Max(0, Math.Min(255, value));
+}

--- a/src/NovaTerminal.App/MainWindow.axaml
+++ b/src/NovaTerminal.App/MainWindow.axaml
@@ -28,13 +28,6 @@
             <Setter Property="Opacity" Value="1.0"/>
             <Setter Property="Background" Value="#40FFFFFF"/>
         </Style>
-        <Style Selector="Button#SettingsBtn">
-            <Setter Property="Opacity" Value="1.0"/>
-        </Style>
-        <Style Selector="Button#SettingsBtn:pointerover">
-            <Setter Property="Opacity" Value="1.0"/>
-            <Setter Property="Background" Value="#40FFFFFF"/>
-        </Style>
 
         <!-- TabItem Styles for Transparency -->
         <Style Selector="TabItem">
@@ -150,7 +143,7 @@
                         CornerRadius="4"
                         Margin="4,0,0,0"
                         ToolTip.Tip="Tab List">
-                    <PathIcon Data="M4,6H20V8H4V6M4,11H20V13H4V11M4,16H20V18H4V16Z" Width="16" Height="16"/>
+                    <PathIcon Name="IconTabList" Data="M4,6H20V8H4V6M4,11H20V13H4V11M4,16H20V18H4V16Z" Width="16" Height="16"/>
                     <Button.Flyout>
                         <MenuFlyout />
                     </Button.Flyout>
@@ -173,18 +166,6 @@
                     <PathIcon Name="IconRecord" Data="M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z" Width="14" Height="14"/>
                 </Button>
 
-                <Button Name="BtnOpenRec"
-                        Foreground="White"
-                        Background="Transparent"
-                        BorderThickness="0" Focusable="False" 
-                        Width="32" Height="32"
-                        Padding="4"
-                        CornerRadius="4"
-                        Margin="4,0,0,0"
-                        ToolTip.Tip="Open Recording">
-                    <PathIcon Data="M20,6A2,2 0 0,1 22,8V18A2,2 0 0,1 20,20H4C2.89,20 2,19.1 2,18V6C2,4.89 2.89,4 4,4H10L12,6H20M19,17V15H7V17H19M12,13L15.5,10H8.5L12,13Z" Width="16" Height="16"/>
-                </Button>
-
                 <Button Name="BtnConnections" 
                         Foreground="White"
                         Background="Transparent"
@@ -196,17 +177,55 @@
                         ToolTip.Tip="Connections">
                     <PathIcon Data="M19,15H5C3.34,15 2,16.34 2,18V20C2,21.66 3.34,23 5,23H19C20.66,23 22,21.66 22,20V18C22,16.34 20.66,15 19,15M8,20C7.45,20 7,19.55 7,19C7,18.45 7.45,18 8,18H9C9.55,18 10,18.45 10,19C10,19.55 9.55,20 9,20H8M19,9H5C3.34,9 2,10.34 2,12V14C2,15.66 3.34,17 5,17H19C20.66,17 22,15.66 22,14V12C22,10.34 20.66,9 19,9M8,14C7.45,14 7,13.55 7,13C7,12.45 7.45,12 8,12H9C9.55,12 10,12.45 10,13C10,13.55 9.55,14 9,14H8M19,3H5C3.34,3 2,4.34 2,6V8C2,9.66 3.34,11 5,11H19C20.66,11 22,9.66 22,8V6C22,4.34 20.66,3 19,3M8,8C7.45,8 7,7.55 7,7C7,6.45 7.45,6 8,6H9C9.55,6 10,6.45 10,7C10,7.55 9.55,8 9,8H8Z" Width="16" Height="16"/>
                 </Button>
-                <Button Name="SettingsBtn" Content="⚙" 
-                        Foreground="White"
-                        Background="Transparent"
-                        BorderThickness="0" Focusable="False" 
-                        FontSize="16"
-                        Padding="8,4" 
-                        CornerRadius="4"
-                        Margin="4,0,0,0"
-                        ToolTip.Tip="Settings"/>
             </StackPanel>
         </Grid>
+
+        <Border Name="RecordingToast"
+                IsVisible="False"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Top"
+                Margin="0,44,16,0"
+                MinWidth="320"
+                MaxWidth="440"
+                Padding="12"
+                Background="#20242C"
+                BorderBrush="#3A404A"
+                BorderThickness="1"
+                CornerRadius="8"
+                ZIndex="180">
+            <Grid RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="*,Auto">
+                <TextBlock Name="RecordingToastTitle"
+                           Text="Recording started"
+                           Foreground="White"
+                           FontWeight="SemiBold" />
+                <Button Name="RecordingToastClose"
+                        Grid.Column="1"
+                        Content="✕"
+                        Width="28"
+                        Height="28"
+                        Margin="8,0,0,0"
+                        Background="Transparent"
+                        Foreground="#C9CFD9"
+                        BorderThickness="0"
+                        Focusable="False"/>
+                <TextBlock Name="RecordingToastMessage"
+                           Grid.Row="1"
+                           Grid.ColumnSpan="2"
+                           Margin="0,8,0,0"
+                           Foreground="#C9CFD9"
+                           TextWrapping="Wrap" />
+                <StackPanel Grid.Row="2"
+                            Grid.ColumnSpan="2"
+                            Orientation="Horizontal"
+                            HorizontalAlignment="Right"
+                            Margin="0,10,0,0"
+                            Spacing="8">
+                    <Button Name="RecordingToastOpenFolder"
+                            Content="Open folder"
+                            Focusable="False"/>
+                </StackPanel>
+            </Grid>
+        </Border>
 
         <!-- Search Overlay -->
         <Border Name="SearchPanel" IsVisible="False" VerticalAlignment="Top" HorizontalAlignment="Right" 
@@ -243,11 +262,13 @@
         </Border>
 
         <!-- Connection Manager Overlay -->
-        <Border Name="ConnectionOverlay" IsVisible="False" 
-                HorizontalAlignment="Center" VerticalAlignment="Center"
-                Width="800" Height="500"
-                BorderBrush="#333" BorderThickness="1" CornerRadius="8"
-                ZIndex="500">
+        <Border Name="ConnectionOverlay" IsVisible="False"
+            HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+            Margin="24,56,24,24"
+            MaxWidth="1080" MaxHeight="720"
+            Background="#16181d"
+            BorderBrush="#2a2f38" BorderThickness="1" CornerRadius="8"
+            ZIndex="500">
             <Grid RowDefinitions="Auto, *">
                 <Grid Name="ConnectionTitleBar" Background="#2D2D2D" Height="40">
                     <TextBlock Name="ConnectionTitleText" Text="Connection Manager" VerticalAlignment="Center" Margin="15,0" FontWeight="Bold"/>
@@ -277,7 +298,7 @@
         <Grid Name="CommandPaletteOverlay" ZIndex="999" IsVisible="False" Background="#80000000">
             <Border Width="600" Height="400" Background="#252526" BorderBrush="#007ACC" BorderThickness="1" CornerRadius="4" VerticalAlignment="Top" Margin="0,80,0,0">
                 <Grid RowDefinitions="Auto, *">
-                    <TextBox Name="CommandSearchBox" PlaceholderText="Type a command..." FontSize="14" Padding="10" BorderThickness="0,0,0,1" BorderBrush="#333333" Background="Transparent" Foreground="White" />
+                    <TextBox Name="CommandSearchBox" PlaceholderText="Type a command..." FontSize="14" Padding="10" BorderThickness="0,0,0,1" BorderBrush="#333333" Background="Transparent" />
                     <ListBox Name="CommandList" Grid.Row="1" Background="Transparent" BorderThickness="0">
                         <ListBox.ItemTemplate>
                             <DataTemplate x:CompileBindings="False">

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -32,6 +32,10 @@ namespace NovaTerminal
 {
     public partial class MainWindow : Window
     {
+        internal readonly record struct ShellOpenRequest(string FileName, string? Arguments);
+        private const string SplitterHoverClass = "splitter-hover";
+        private const string SplitterDraggingClass = "splitter-dragging";
+
         private TerminalPane? _currentPaneValue;
         private TerminalPane? _currentPane
         {
@@ -72,6 +76,9 @@ namespace NovaTerminal
         private Point _transferOverlayDragStart;
         private Point _transferOverlayOffsetStart;
         private TranslateTransform? _transferOverlayTransform;
+        private readonly DispatcherTimer _recordingToastTimer = new() { Interval = TimeSpan.FromSeconds(6) };
+        private string? _recordingToastFolderPath;
+        private string? _recordingToastFilePath;
 
         private sealed class PaneZoomState
         {
@@ -88,6 +95,13 @@ namespace NovaTerminal
             public bool HasBell { get; set; }
             public DateTime LastBellUtc { get; set; }
             public int? LastExitCode { get; set; }
+        }
+
+        internal enum TabHeaderPointerAction
+        {
+            None,
+            OpenContextMenu,
+            CloseTab
         }
 
         protected override void OnOpened(EventArgs e)
@@ -317,6 +331,46 @@ namespace NovaTerminal
             return GetOrCreateTabState(tab).IsProtected;
         }
 
+        internal static bool CanCloseTab(bool isProtected)
+        {
+            return !isProtected;
+        }
+
+        internal static TabHeaderPointerAction ResolveTabHeaderPointerAction(bool isMiddlePressed, bool isRightPressed)
+        {
+            if (isMiddlePressed)
+            {
+                return TabHeaderPointerAction.CloseTab;
+            }
+
+            if (isRightPressed)
+            {
+                return TabHeaderPointerAction.OpenContextMenu;
+            }
+
+            return TabHeaderPointerAction.None;
+        }
+
+        internal static bool ShouldDeferTabContextMenuOpen(bool wasSelected)
+        {
+            return !wasSelected;
+        }
+
+        internal static bool ShouldSkipTabWhenClosingOthers(bool isPinned, bool isProtected)
+        {
+            return isPinned || isProtected;
+        }
+
+        internal static string GetPinTabActionLabel(bool isPinned)
+        {
+            return isPinned ? "Unpin Tab" : "Pin Tab";
+        }
+
+        internal static string GetProtectTabActionLabel(bool isProtected)
+        {
+            return isProtected ? "Unprotect Tab" : "Protect Tab";
+        }
+
         private void ClearTabAttention(TabItem tab)
         {
             var state = GetOrCreateTabState(tab);
@@ -403,14 +457,172 @@ namespace NovaTerminal
                 : (selectedIndex + 1) % mruCount;
         }
 
+        private static TextBlock? FindTabHeaderTextBlock(object? header)
+        {
+            return header switch
+            {
+                TextBlock tb => tb,
+                Border border => FindTabHeaderTextBlock(border.Child),
+                ContentControl contentControl => FindTabHeaderTextBlock(contentControl.Content),
+                Panel panel => panel.Children.Select(child => FindTabHeaderTextBlock(child)).FirstOrDefault(tb => tb != null),
+                Decorator decorator => FindTabHeaderTextBlock(decorator.Child),
+                _ => null
+            };
+        }
+
         private string GetTabHeaderText(TabItem tab)
         {
-            if (tab.Header is TextBlock tb)
+            if (FindTabHeaderTextBlock(tab.Header) is TextBlock tb)
             {
                 return string.IsNullOrWhiteSpace(tb.Text) ? "Terminal" : tb.Text;
             }
 
             return "Terminal";
+        }
+
+        private Border CreateTabHeaderHost(TabItem tab, string text)
+        {
+            var headerText = new TextBlock
+            {
+                Text = text,
+                Foreground = Brushes.White,
+                FontSize = 12,
+                VerticalAlignment = VerticalAlignment.Center
+            };
+
+            var headerHost = new Border
+            {
+                Background = Brushes.Transparent,
+                Padding = new Thickness(10, 4),
+                Child = headerText
+            };
+
+            headerHost.ContextFlyout = new MenuFlyout();
+            headerHost.PointerPressed += (_, e) => OnTabHeaderPointerPressed(tab, e);
+            ToolTip.SetTip(headerHost, text);
+            return headerHost;
+        }
+
+        private void ConfigureTabHeader(TabItem tab, string text)
+        {
+            tab.Header = CreateTabHeaderHost(tab, text);
+        }
+
+        private void OnTabHeaderPointerPressed(TabItem tab, PointerPressedEventArgs e)
+        {
+            var tabs = this.FindControl<TabControl>("Tabs");
+            bool wasSelected = tabs?.SelectedItem == tab;
+            if (tabs != null && tabs.SelectedItem != tab)
+            {
+                tabs.SelectedItem = tab;
+            }
+
+            var properties = e.GetCurrentPoint(this).Properties;
+            var action = ResolveTabHeaderPointerAction(
+                properties.IsMiddleButtonPressed,
+                properties.IsRightButtonPressed);
+
+            if (action == TabHeaderPointerAction.CloseTab)
+            {
+                e.Handled = true;
+                _ = CloseTabAsync(tab);
+                return;
+            }
+
+            if (action == TabHeaderPointerAction.OpenContextMenu)
+            {
+                if (FindTabHeaderHost(tab) is Control headerHost &&
+                    headerHost.ContextFlyout is MenuFlyout flyout)
+                {
+                    e.Handled = true;
+                    ShowTabContextMenu(tab, headerHost, flyout, ShouldDeferTabContextMenuOpen(wasSelected));
+                }
+            }
+        }
+
+        private void ShowTabContextMenu(TabItem tab, Control headerHost, MenuFlyout flyout, bool defer)
+        {
+            void open()
+            {
+                PopulateTabContextMenu(flyout, tab);
+                flyout.ShowAt(headerHost);
+            }
+
+            if (defer)
+            {
+                Dispatcher.UIThread.Post(open, DispatcherPriority.Input);
+            }
+            else
+            {
+                open();
+            }
+        }
+
+        private void PopulateTabContextMenu(MenuFlyout flyout, TabItem tab)
+        {
+            flyout.Items.Clear();
+            if (!_tabStateByTab.ContainsKey(tab) && !TryEnsureLiveTab(tab))
+            {
+                return;
+            }
+
+            var tabs = this.FindControl<TabControl>("Tabs");
+            if (tabs != null && tabs.SelectedItem != tab)
+            {
+                tabs.SelectedItem = tab;
+            }
+
+            var state = GetOrCreateTabState(tab);
+            bool hasClosableOthers = tabs?.Items
+                .Cast<TabItem>()
+                .Any(other => other != tab && !ShouldSkipTabWhenClosingOthers(IsTabPinned(other), IsTabProtected(other))) == true;
+
+            var closeItem = new MenuItem
+            {
+                Header = "Close",
+                IsEnabled = CanCloseTab(state.IsProtected)
+            };
+            closeItem.Click += async (_, __) => await CloseTabAsync(tab);
+            flyout.Items.Add(closeItem);
+
+            var closeOthersItem = new MenuItem
+            {
+                Header = "Close Others",
+                IsEnabled = hasClosableOthers
+            };
+            closeOthersItem.Click += async (_, __) => await CloseOtherTabsAsync(tab);
+            flyout.Items.Add(closeOthersItem);
+
+            flyout.Items.Add(new Separator());
+
+            var renameItem = new MenuItem { Header = "Rename..." };
+            renameItem.Click += async (_, __) => await RenameTabAsync(tab);
+            flyout.Items.Add(renameItem);
+
+            var copyTitleItem = new MenuItem { Header = "Copy Title" };
+            copyTitleItem.Click += async (_, __) => await CopyTabTitleAsync(tab);
+            flyout.Items.Add(copyTitleItem);
+
+            flyout.Items.Add(new Separator());
+
+            var pinItem = new MenuItem { Header = GetPinTabActionLabel(state.IsPinned) };
+            pinItem.Click += (_, __) => TogglePinTab(tab);
+            flyout.Items.Add(pinItem);
+
+            var protectItem = new MenuItem { Header = GetProtectTabActionLabel(state.IsProtected) };
+            protectItem.Click += (_, __) => ToggleProtectTab(tab);
+            flyout.Items.Add(protectItem);
+        }
+
+        private bool TryEnsureLiveTab(TabItem tab)
+        {
+            var tabs = this.FindControl<TabControl>("Tabs");
+            return tabs?.Items.Cast<TabItem>().Contains(tab) == true;
+        }
+
+        private static Control? FindTabHeaderHost(TabItem tab)
+        {
+            return tab.Header as Control;
         }
 
         private string GetTabMenuLabel(TabItem tab, int index)
@@ -598,11 +810,22 @@ namespace NovaTerminal
                 copyTitleItem.Click += async (_, __) => await CopySelectedTabTitleAsync();
                 flyout.Items.Add(copyTitleItem);
 
-                var closeCurrentItem = new MenuItem { Header = "Close Current Tab" };
+                bool canCloseCurrent = tabs.SelectedItem is not TabItem currentTab || CanCloseTab(IsTabProtected(currentTab));
+                var closeCurrentItem = new MenuItem
+                {
+                    Header = "Close Current Tab",
+                    IsEnabled = canCloseCurrent
+                };
                 closeCurrentItem.Click += async (_, __) => await CloseSelectedTabAsync();
                 flyout.Items.Add(closeCurrentItem);
 
-                var closeOthersItem = new MenuItem { Header = "Close Other Tabs" };
+                bool hasClosableOthers = tabs.SelectedItem is TabItem selectedForCloseOthers &&
+                    tabs.Items.Cast<TabItem>().Any(t => t != selectedForCloseOthers && !ShouldSkipTabWhenClosingOthers(IsTabPinned(t), IsTabProtected(t)));
+                var closeOthersItem = new MenuItem
+                {
+                    Header = "Close Other Tabs",
+                    IsEnabled = hasClosableOthers
+                };
                 closeOthersItem.Click += async (_, __) => await CloseOtherTabsAsync();
                 flyout.Items.Add(closeOthersItem);
 
@@ -610,11 +833,11 @@ namespace NovaTerminal
                 {
                     var selectedState = GetOrCreateTabState(selectedTab);
 
-                    var pinItem = new MenuItem { Header = selectedState.IsPinned ? "Unpin Tab" : "Pin Tab" };
+                    var pinItem = new MenuItem { Header = GetPinTabActionLabel(selectedState.IsPinned) };
                     pinItem.Click += (_, __) => TogglePinSelectedTab();
                     flyout.Items.Add(pinItem);
 
-                    var protectItem = new MenuItem { Header = selectedState.IsProtected ? "Unprotect Tab" : "Protect Tab" };
+                    var protectItem = new MenuItem { Header = GetProtectTabActionLabel(selectedState.IsProtected) };
                     protectItem.Click += (_, __) => ToggleProtectSelectedTab();
                     flyout.Items.Add(protectItem);
                 }
@@ -769,7 +992,11 @@ namespace NovaTerminal
         private async Task CopySelectedTabTitleAsync()
         {
             if (!TryGetSelectedTab(out var tab)) return;
+            await CopyTabTitleAsync(tab);
+        }
 
+        private async Task CopyTabTitleAsync(TabItem tab)
+        {
             var topLevel = TopLevel.GetTopLevel(this);
             if (topLevel?.Clipboard == null) return;
 
@@ -850,6 +1077,11 @@ namespace NovaTerminal
         private async Task RenameSelectedTabAsync()
         {
             if (!TryGetSelectedTab(out var tab)) return;
+            await RenameTabAsync(tab);
+        }
+
+        private async Task RenameTabAsync(TabItem tab)
+        {
             var state = GetOrCreateTabState(tab);
             string current = state.UserTitle ?? GetTabPrimaryTitle(tab);
             var updated = await ShowTextPromptAsync("Rename Tab", "Tab title", current);
@@ -877,13 +1109,19 @@ namespace NovaTerminal
 
         private async Task CloseOtherTabsAsync()
         {
+            if (!TryGetSelectedTab(out var selected)) return;
+            await CloseOtherTabsAsync(selected);
+        }
+
+        private async Task CloseOtherTabsAsync(TabItem selected)
+        {
             var tabs = this.FindControl<TabControl>("Tabs");
-            if (tabs?.SelectedItem is not TabItem selected) return;
+            if (tabs == null) return;
 
             var others = tabs.Items.Cast<TabItem>().Where(t => t != selected).ToList();
             foreach (var tab in others)
             {
-                if (GetOrCreateTabState(tab).IsPinned) continue;
+                if (ShouldSkipTabWhenClosingOthers(IsTabPinned(tab), IsTabProtected(tab))) continue;
                 await CloseTabAsync(tab);
             }
         }
@@ -891,15 +1129,25 @@ namespace NovaTerminal
         private void TogglePinSelectedTab()
         {
             if (!TryGetSelectedTab(out var tab)) return;
+            TogglePinTab(tab);
+        }
+
+        private void ToggleProtectSelectedTab()
+        {
+            if (!TryGetSelectedTab(out var tab)) return;
+            ToggleProtectTab(tab);
+        }
+
+        private void TogglePinTab(TabItem tab)
+        {
             var state = GetOrCreateTabState(tab);
             state.IsPinned = !state.IsPinned;
             UpdateTabVisuals(tab);
             PopulateTabListMenu();
         }
 
-        private void ToggleProtectSelectedTab()
+        private void ToggleProtectTab(TabItem tab)
         {
-            if (!TryGetSelectedTab(out var tab)) return;
             var state = GetOrCreateTabState(tab);
             state.IsProtected = !state.IsProtected;
             UpdateTabVisuals(tab);
@@ -1613,15 +1861,20 @@ namespace NovaTerminal
                     UpdateTabHeaderViewport();
                     EnsureSelectedTabHeaderVisible();
                     FocusCurrentTerminal(defer: true);
+                    SyncRecordingButtonState();
                 }, DispatcherPriority.Input);
             };
             this.Activated += (s, e) => FocusCurrentTerminal(defer: true);
             this.SizeChanged += (_, __) => Dispatcher.UIThread.Post(UpdateTabHeaderViewport, DispatcherPriority.Background);
+            _recordingToastTimer.Tick += (_, __) =>
+            {
+                _recordingToastTimer.Stop();
+                HideRecordingToast();
+            };
 
             var tabs = this.FindControl<TabControl>("Tabs");
             var btnNew = this.FindControl<Button>("BtnNewTab");
             var btnTabList = this.FindControl<Button>("BtnTabList");
-            var settingsBtn = this.FindControl<Button>("SettingsBtn");
             var titleBar = this.FindControl<Grid>("TitleBar");
             var dragBorder = this.FindControl<Border>("DragBorder");
 
@@ -1697,13 +1950,6 @@ namespace NovaTerminal
                 };
             }
 
-            if (settingsBtn != null) settingsBtn.Click += async (s, e) =>
-            {
-                await OpenSettings(0);
-            };
-
-
-
             if (tabs != null)
             {
                 tabs.SelectionChanged += (s, e) =>
@@ -1766,31 +2012,22 @@ namespace NovaTerminal
                 await ShowNewSshConnectionDialogAsync(null);
             };
 
-            var btnOpenRec = this.FindControl<Button>("BtnOpenRec");
-            if (btnOpenRec != null) btnOpenRec.Click += async (s, e) =>
-            {
-                var topLevel = TopLevel.GetTopLevel(this);
-                if (topLevel == null) return;
-
-                var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
-                {
-                    Title = "Open Replay File",
-                    AllowMultiple = false,
-                    FileTypeFilter = new[] { new FilePickerFileType("Nova Recordings") { Patterns = new[] { "*.rec", "*.cast" } } }
-                });
-
-                if (files.Count >= 1)
-                {
-                    var path = files[0].Path.LocalPath;
-                    var replayWin = new NovaTerminal.UI.Replay.ReplayWindow(path);
-                    replayWin.Show();
-                }
-            };
-
             var btnRecord = this.FindControl<Button>("BtnRecord");
             if (btnRecord != null)
             {
                 btnRecord.Click += (s, e) => _currentPane?.ToggleRecording();
+            }
+
+            var recordingToastClose = this.FindControl<Button>("RecordingToastClose");
+            if (recordingToastClose != null)
+            {
+                recordingToastClose.Click += (_, __) => HideRecordingToast();
+            }
+
+            var recordingToastOpenFolder = this.FindControl<Button>("RecordingToastOpenFolder");
+            if (recordingToastOpenFolder != null)
+            {
+                recordingToastOpenFolder.Click += (_, __) => OpenRecordingToastFolder();
             }
 
             // Global Focus Tracking
@@ -2014,6 +2251,7 @@ namespace NovaTerminal
             {
                 GetTabId(item);
                 GetOrCreateTabState(item);
+                ConfigureTabHeader(item, GetTabHeaderText(item));
                 if (item.Content is Control c) WireControlTree(c);
             }
 
@@ -2398,8 +2636,90 @@ namespace NovaTerminal
         private void WireSplitter(GridSplitter splitter, Grid ownerGrid)
         {
             splitter.Tag = ownerGrid;
+            splitter.PointerEntered -= OnSplitterPointerEntered;
+            splitter.PointerExited -= OnSplitterPointerExited;
+            splitter.PointerPressed -= OnSplitterPointerPressed;
+            splitter.PointerReleased -= OnSplitterPointerReleased;
+            splitter.PointerCaptureLost -= OnSplitterPointerCaptureLost;
             splitter.DoubleTapped -= OnSplitterDoubleTapped;
+            splitter.PointerEntered += OnSplitterPointerEntered;
+            splitter.PointerExited += OnSplitterPointerExited;
+            splitter.PointerPressed += OnSplitterPointerPressed;
+            splitter.PointerReleased += OnSplitterPointerReleased;
+            splitter.PointerCaptureLost += OnSplitterPointerCaptureLost;
             splitter.DoubleTapped += OnSplitterDoubleTapped;
+            ApplySplitterVisualState(splitter);
+        }
+
+        private void OnSplitterPointerEntered(object? sender, PointerEventArgs e)
+        {
+            if (sender is GridSplitter splitter)
+            {
+                SetSplitterStateClass(splitter, SplitterHoverClass, true);
+                ApplySplitterVisualState(splitter);
+            }
+        }
+
+        private void OnSplitterPointerExited(object? sender, PointerEventArgs e)
+        {
+            if (sender is GridSplitter splitter && !splitter.Classes.Contains(SplitterDraggingClass))
+            {
+                SetSplitterStateClass(splitter, SplitterHoverClass, false);
+                ApplySplitterVisualState(splitter);
+            }
+        }
+
+        private void OnSplitterPointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (sender is GridSplitter splitter && e.GetCurrentPoint(splitter).Properties.IsLeftButtonPressed)
+            {
+                SetSplitterStateClass(splitter, SplitterHoverClass, true);
+                SetSplitterStateClass(splitter, SplitterDraggingClass, true);
+                ApplySplitterVisualState(splitter);
+            }
+        }
+
+        private void OnSplitterPointerReleased(object? sender, PointerReleasedEventArgs e)
+        {
+            if (sender is GridSplitter splitter)
+            {
+                SetSplitterStateClass(splitter, SplitterDraggingClass, false);
+                SetSplitterStateClass(splitter, SplitterHoverClass, splitter.IsPointerOver);
+                ApplySplitterVisualState(splitter);
+            }
+        }
+
+        private void OnSplitterPointerCaptureLost(object? sender, PointerCaptureLostEventArgs e)
+        {
+            if (sender is GridSplitter splitter)
+            {
+                SetSplitterStateClass(splitter, SplitterDraggingClass, false);
+                SetSplitterStateClass(splitter, SplitterHoverClass, splitter.IsPointerOver);
+                ApplySplitterVisualState(splitter);
+            }
+        }
+
+        private void ApplySplitterVisualState(GridSplitter splitter)
+        {
+            var contrast = _settings.ActiveTheme.GetContrastForeground().ToAvaloniaColor();
+            var alpha = splitter.Classes.Contains(SplitterDraggingClass)
+                ? (byte)0x66
+                : splitter.Classes.Contains(SplitterHoverClass)
+                    ? (byte)0x44
+                    : (byte)0x24;
+
+            splitter.Background = new SolidColorBrush(Color.FromArgb(alpha, contrast.R, contrast.G, contrast.B));
+        }
+
+        private static void SetSplitterStateClass(GridSplitter splitter, string className, bool isActive)
+        {
+            if (isActive)
+            {
+                splitter.Classes.Add(className);
+                return;
+            }
+
+            splitter.Classes.Remove(className);
         }
 
         private void OnSplitterDoubleTapped(object? sender, RoutedEventArgs e)
@@ -2612,6 +2932,7 @@ namespace NovaTerminal
             if (_activePaneByTab.TryGetValue(ti, out var mapped) && _currentPane == mapped)
             {
                 _currentPane.RecordingStateChanged -= OnRecordingStateChanged;
+                _currentPane.RecordingNotification -= OnRecordingNotification;
                 _currentPane = null;
                 OnRecordingStateChanged(false);
             }
@@ -2959,7 +3280,7 @@ namespace NovaTerminal
             if (TryGetSelectedTab(out var selectedTab))
             {
                 _activePaneByTab[selectedTab] = replacementPane;
-                if (selectedTab.Header is TextBlock tabHeader)
+                if (FindTabHeaderTextBlock(selectedTab.Header) is TextBlock tabHeader)
                 {
                     tabHeader.Text = resolvedProfile.Name;
                 }
@@ -3073,11 +3394,8 @@ namespace NovaTerminal
             WirePane(pane);
 
             pane.ApplySettings(_settings);
-            var tabItem = new TabItem
-            {
-                Header = new TextBlock { Text = profile.Name, Foreground = Brushes.White, FontSize = 12, VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center, Padding = new Thickness(10, 4) },
-                Content = pane
-            };
+            var tabItem = new TabItem { Content = pane };
+            ConfigureTabHeader(tabItem, profile.Name);
             tabs.Items.Add(tabItem);
             tabs.SelectedItem = tabItem;
             GetTabId(tabItem);
@@ -3175,10 +3493,15 @@ namespace NovaTerminal
             {
                 ti.BorderBrush = ti.IsSelected ? borderBrush : Brushes.Transparent;
 
-                if (ti.Header is TextBlock tb)
+                if (FindTabHeaderTextBlock(ti.Header) is TextBlock tb)
                 {
                     tb.Foreground = contrastForeground;
                     tb.Text = labels[ti];
+                }
+
+                if (ti.Header is Control headerControl)
+                {
+                    ToolTip.SetTip(headerControl, BuildFullTabLabel(ti));
                 }
             }
 
@@ -3376,12 +3699,24 @@ namespace NovaTerminal
 
             // Apply to Title Bar Buttons
             var btnNew = this.FindControl<Button>("BtnNewTab");
-            var btnSettings = this.FindControl<Button>("SettingsBtn");
+            var btnTabList = this.FindControl<Button>("BtnTabList");
+            var iconTabList = this.FindControl<PathIcon>("IconTabList");
+            var btnRecord = this.FindControl<Button>("BtnRecord");
             var btnConns = this.FindControl<Button>("BtnConnections");
+            var commandSearchBox = this.FindControl<TextBox>("CommandSearchBox");
 
             if (btnNew != null) btnNew.Foreground = contrastForeground;
-            if (btnSettings != null) btnSettings.Foreground = contrastForeground;
+            if (btnTabList != null) btnTabList.Foreground = contrastForeground;
+            if (iconTabList != null) iconTabList.Foreground = contrastForeground;
             if (btnConns != null) btnConns.Foreground = contrastForeground;
+            if (btnRecord != null) btnRecord.Foreground = contrastForeground;
+            if (commandSearchBox != null) commandSearchBox.Foreground = contrastForeground;
+            foreach (var splitter in this.GetVisualDescendants().OfType<GridSplitter>())
+            {
+                ApplySplitterVisualState(splitter);
+            }
+
+            SyncRecordingButtonState();
 
             // Force update of tab borders (blue line) since theme color changed
             UpdateTabVisuals();
@@ -3521,6 +3856,8 @@ namespace NovaTerminal
             {
                 await OpenSettings(0);
             }, "");
+            CommandRegistry.Register("Open Recording...", "General", () => _ = ExecuteUiCommandAsync(ExecuteOpenRecordingCommandAsync, "Open Recording..."), "");
+            CommandRegistry.Register("Open Recordings Folder", "General", () => OpenRecordingsFolder(), "");
 
             // SFTP Actions
             CommandRegistry.Register("SFTP: Toggle Remote Files", "Remote", () => _currentPane?.ToggleRemoteFilesSidebar(), "");
@@ -4217,6 +4554,113 @@ namespace NovaTerminal
             await dialog.ShowDialog(this);
         }
 
+        protected virtual Task ExecuteOpenRecordingCommandAsync()
+        {
+            return OpenRecordingAsync();
+        }
+
+        private async Task OpenRecordingAsync()
+        {
+            var topLevel = TopLevel.GetTopLevel(this);
+            if (topLevel?.StorageProvider == null)
+            {
+                await ShowSimpleMessageDialogAsync("Open Recording", "File picker is not available in the current window.");
+                return;
+            }
+
+            var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+            {
+                Title = "Open Replay File",
+                AllowMultiple = false,
+                FileTypeFilter = new[] { new FilePickerFileType("Nova Recordings") { Patterns = new[] { "*.rec", "*.cast" } } }
+            });
+
+            if (files.Count < 1)
+            {
+                return;
+            }
+
+            var path = files[0].Path.LocalPath;
+            var replayWin = new NovaTerminal.UI.Replay.ReplayWindow(path);
+            replayWin.Show();
+        }
+
+        private async Task ExecuteUiCommandAsync(Func<Task> action, string commandTitle)
+        {
+            try
+            {
+                await action();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error executing command {commandTitle}: {ex.Message}");
+                await ShowSimpleMessageDialogAsync(commandTitle, ex.Message);
+            }
+        }
+
+        private void OpenRecordingsFolder()
+        {
+            try
+            {
+                Directory.CreateDirectory(AppPaths.RecordingsDirectory);
+                OpenPathInShell(new ShellOpenRequest(AppPaths.RecordingsDirectory, null));
+            }
+            catch
+            {
+                ShowRecordingToast(
+                    "Unable to open recordings folder",
+                    AppPaths.RecordingsDirectory,
+                    null,
+                    AppPaths.RecordingsDirectory,
+                    autoHide: true);
+            }
+        }
+
+        private void OpenRecordingToastFolder()
+        {
+            if (string.IsNullOrWhiteSpace(_recordingToastFolderPath))
+            {
+                OpenRecordingsFolder();
+                return;
+            }
+
+            try
+            {
+                Directory.CreateDirectory(_recordingToastFolderPath);
+                var request = ResolveRecordingRevealRequest(_recordingToastFilePath, _recordingToastFolderPath, OperatingSystem.IsWindows());
+                OpenPathInShell(request);
+            }
+            catch
+            {
+                ShowRecordingToast(
+                    "Unable to open recordings folder",
+                    _recordingToastFolderPath,
+                    _recordingToastFilePath,
+                    _recordingToastFolderPath,
+                    autoHide: true);
+            }
+        }
+
+        private static void OpenPathInShell(ShellOpenRequest request)
+        {
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = request.FileName,
+                Arguments = request.Arguments,
+                UseShellExecute = true
+            });
+        }
+
+        internal static ShellOpenRequest ResolveRecordingRevealRequest(string? filePath, string recordingsDirectory, bool isWindows)
+        {
+            if (isWindows && !string.IsNullOrWhiteSpace(filePath))
+            {
+                return new ShellOpenRequest("explorer.exe", $"/select,\"{filePath}\"");
+            }
+
+            return new ShellOpenRequest(recordingsDirectory, null);
+        }
+
         private async Task ShowConnectionDetailsDialogAsync(SshLaunchDetails details, SshDiagnosticsLevel diagnosticsLevel)
         {
             var dialog = CreateThemedDialogWindow("Connection details", 760, 340, canResize: false);
@@ -4291,14 +4735,17 @@ namespace NovaTerminal
         private void ExecuteCommand(TerminalCommand cmd)
         {
             ToggleCommandPalette(); // Close first
-            try
+            Dispatcher.UIThread.Post(() =>
             {
-                cmd.Action?.Invoke();
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Error executing command {cmd.Title}: {ex.Message}");
-            }
+                try
+                {
+                    cmd.Action?.Invoke();
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Error executing command {cmd.Title}: {ex.Message}");
+                }
+            }, DispatcherPriority.Background);
         }
 
 
@@ -4336,6 +4783,7 @@ namespace NovaTerminal
             if (_currentPane != null)
             {
                 _currentPane.RecordingStateChanged -= OnRecordingStateChanged;
+                _currentPane.RecordingNotification -= OnRecordingNotification;
             }
 
             _currentPane = pane;
@@ -4344,6 +4792,7 @@ namespace NovaTerminal
             if (_currentPane != null)
             {
                 _currentPane.RecordingStateChanged += OnRecordingStateChanged;
+                _currentPane.RecordingNotification += OnRecordingNotification;
             }
 
             // Initial UI sync
@@ -4443,23 +4892,111 @@ namespace NovaTerminal
 
         private void OnRecordingStateChanged(bool isRecording)
         {
+            Dispatcher.UIThread.Post(() =>
+            {
+                UpdateRecordButtonUi(isRecording);
+            });
+        }
+
+        private void OnRecordingNotification(RecordingNotificationEventArgs notification)
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                switch (notification.Kind)
+                {
+                    case RecordingNotificationKind.Started:
+                        ShowRecordingToast(
+                            "Recording started",
+                            BuildRecordingToastMessage(notification),
+                            notification.FilePath,
+                            notification.RecordingsDirectory,
+                            autoHide: true);
+                        break;
+                    case RecordingNotificationKind.Stopped:
+                        ShowRecordingToast(
+                            "Recording saved",
+                            BuildRecordingToastMessage(notification),
+                            notification.FilePath,
+                            notification.RecordingsDirectory,
+                            autoHide: true);
+                        break;
+                    case RecordingNotificationKind.Failed:
+                        ShowRecordingToast(
+                            "Recording failed",
+                            notification.ErrorMessage ?? "Unable to start recording.",
+                            notification.FilePath,
+                            notification.RecordingsDirectory,
+                            autoHide: true);
+                        break;
+                }
+            });
+        }
+
+        private static string BuildRecordingToastMessage(RecordingNotificationEventArgs notification)
+        {
+            if (!string.IsNullOrWhiteSpace(notification.FilePath))
+            {
+                return notification.FilePath!;
+            }
+
+            return notification.RecordingsDirectory;
+        }
+
+        private void ShowRecordingToast(string title, string message, string? filePath, string? folderPath, bool autoHide)
+        {
+            var toast = this.FindControl<Border>("RecordingToast");
+            var titleBlock = this.FindControl<TextBlock>("RecordingToastTitle");
+            var messageBlock = this.FindControl<TextBlock>("RecordingToastMessage");
+            if (toast == null || titleBlock == null || messageBlock == null)
+            {
+                return;
+            }
+
+            _recordingToastFilePath = filePath;
+            _recordingToastFolderPath = folderPath;
+            titleBlock.Text = title;
+            messageBlock.Text = message;
+            toast.IsVisible = true;
+
+            _recordingToastTimer.Stop();
+            if (autoHide)
+            {
+                _recordingToastTimer.Start();
+            }
+        }
+
+        private void HideRecordingToast()
+        {
+            _recordingToastTimer.Stop();
+            var toast = this.FindControl<Border>("RecordingToast");
+            if (toast != null)
+            {
+                toast.IsVisible = false;
+            }
+        }
+
+        private void SyncRecordingButtonState()
+        {
+            UpdateRecordButtonUi(_currentPane?.IsRecording ?? false);
+        }
+
+        private void UpdateRecordButtonUi(bool isRecording)
+        {
             var btnRecord = this.FindControl<Button>("BtnRecord");
             var iconRecord = this.FindControl<PathIcon>("IconRecord");
 
-            if (btnRecord == null || iconRecord == null) return;
-
-            Dispatcher.UIThread.Post(() =>
+            if (btnRecord == null || iconRecord == null)
             {
-                if (isRecording)
-                {
-                    btnRecord.Foreground = Brushes.Red;
-                    // Pulse animation or just red for now
-                }
-                else
-                {
-                    btnRecord.Foreground = SolidColorBrush.Parse("#CCCCCC");
-                }
-            });
+                return;
+            }
+
+            var activeBrush = new SolidColorBrush(Color.Parse("#F1636B"));
+            var inactiveBrush = new SolidColorBrush(_settings.ActiveTheme.GetContrastForeground().ToAvaloniaColor());
+
+            btnRecord.Foreground = isRecording ? activeBrush : inactiveBrush;
+            iconRecord.Foreground = isRecording ? activeBrush : inactiveBrush;
+            btnRecord.Background = isRecording ? new SolidColorBrush(Color.Parse("#30F1636B")) : Brushes.Transparent;
+            ToolTip.SetTip(btnRecord, isRecording ? "Stop Recording" : "Record Session");
         }
     }
 }

--- a/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
@@ -296,15 +296,8 @@ public sealed class SshLaunchDetails
         merged.WorkingDirectory = incoming.WorkingDirectory;
         merged.Notes = incoming.Notes;
         merged.AccentColor = incoming.AccentColor;
-
-        // Group isn't editable in the minimal dialog yet, so preserve existing if present.
-        if (string.IsNullOrWhiteSpace(merged.GroupPath))
-        {
-            merged.GroupPath = "General";
-        }
-
-        IEnumerable<string> sourceTags = (IEnumerable<string>?)existing?.Tags ?? Array.Empty<string>();
-        merged.Tags = NormalizeTags(sourceTags, favorite);
+        merged.GroupPath = string.IsNullOrWhiteSpace(incoming.GroupPath) ? "General" : incoming.GroupPath;
+        merged.Tags = NormalizeTags(incoming.Tags, favorite);
         return merged;
     }
 

--- a/src/NovaTerminal.App/SettingsWindow.axaml
+++ b/src/NovaTerminal.App/SettingsWindow.axaml
@@ -1,393 +1,779 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="NovaTerminal.SettingsWindow"
-        Title="Settings" Width="650" Height="500"
-        WindowStartupLocation="CenterOwner">
-    
+        Title="Settings"
+        Width="880" Height="620"
+        MinWidth="780" MinHeight="520"
+        WindowStartupLocation="CenterOwner"
+        Background="#16181d"
+        Foreground="#e6e8ec"
+        FontFamily="Inter, Segoe UI, system-ui, sans-serif">
+
+    <Window.Resources>
+        <SolidColorBrush x:Key="NtWindowBg"        Color="#16181d"/>
+        <SolidColorBrush x:Key="NtChromeBg"        Color="#1c1f26"/>
+        <SolidColorBrush x:Key="NtPanel"           Color="#23272f"/>
+        <SolidColorBrush x:Key="NtPanelAlt"        Color="#1a1d23"/>
+        <SolidColorBrush x:Key="NtHairline"        Color="#2a2f38"/>
+        <SolidColorBrush x:Key="NtHairlineStrong"  Color="#353b46"/>
+        <SolidColorBrush x:Key="NtFg"              Color="#e6e8ec"/>
+        <SolidColorBrush x:Key="NtFg2"             Color="#b4bac4"/>
+        <SolidColorBrush x:Key="NtFg3"             Color="#8b93a1"/>
+        <SolidColorBrush x:Key="NtFg4"             Color="#5c6370"/>
+        <SolidColorBrush x:Key="NtBlue"            Color="#61afef"/>
+        <SolidColorBrush x:Key="NtBlueDim"         Color="#2461afef"/>
+        <SolidColorBrush x:Key="NtGreen"           Color="#98c379"/>
+        <SolidColorBrush x:Key="NtYellow"          Color="#e5c07b"/>
+        <SolidColorBrush x:Key="NtRed"             Color="#e06c75"/>
+        <FontFamily x:Key="NtMono">JetBrains Mono, Cascadia Mono, Consolas, Menlo, monospace</FontFamily>
+    </Window.Resources>
+
     <Window.Styles>
-        <Style Selector="TabItem">
-            <Setter Property="Foreground" Value="{Binding Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}" />
-            <Setter Property="FontSize" Value="14" />
+        <!-- Hide the TabControl's header strip — sidebar drives selection. -->
+        <Style Selector="TabControl#MainTabs">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="0"/>
         </Style>
-        <Style Selector="TabItem:selected">
-            <Setter Property="Foreground" Value="{Binding Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}" />
-            <Setter Property="FontWeight" Value="SemiBold" />
+        <Style Selector="TabControl#MainTabs /template/ ItemsPresenter#PART_ItemsPresenter">
+            <Setter Property="IsVisible" Value="False"/>
         </Style>
-        <!-- Ensure template parts don't override the foreground -->
-        <Style Selector="TabItem:selected /template/ ContentPresenter#PART_ContentPresenter">
-            <Setter Property="Foreground" Value="{Binding Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}" />
+        <Style Selector="TabControl#MainTabs > TabItem">
+            <Setter Property="Height" Value="0"/>
+            <Setter Property="MinHeight" Value="0"/>
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="Margin" Value="0"/>
+            <Setter Property="Opacity" Value="0"/>
+            <Setter Property="IsHitTestVisible" Value="False"/>
         </Style>
-        <Style Selector="TabItem:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-             <Setter Property="Foreground" Value="{Binding Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}" />
+
+        <!-- Section header (uppercase, dim) -->
+        <Style Selector="TextBlock.SectionHeader">
+            <Setter Property="FontSize" Value="10"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Foreground" Value="{StaticResource NtFg3}"/>
+            <Setter Property="LetterSpacing" Value="1.2"/>
+        </Style>
+
+        <!-- Page title + subtitle -->
+        <Style Selector="TextBlock.H1">
+            <Setter Property="FontSize" Value="22"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Foreground" Value="{StaticResource NtFg}"/>
+        </Style>
+        <Style Selector="TextBlock.Subtitle">
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="Foreground" Value="{StaticResource NtFg3}"/>
+        </Style>
+
+        <!-- Row label / description -->
+        <Style Selector="TextBlock.RowLabel">
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="Foreground" Value="{StaticResource NtFg}"/>
+        </Style>
+        <Style Selector="TextBlock.RowDesc">
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="Foreground" Value="{StaticResource NtFg3}"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+        </Style>
+
+        <!-- Inputs (TextBox, NumericUpDown) -->
+        <Style Selector="TextBox">
+            <Setter Property="Background" Value="{StaticResource NtPanelAlt}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource NtHairline}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="CornerRadius" Value="5"/>
+            <Setter Property="Padding" Value="10,6"/>
+            <Setter Property="Foreground" Value="{StaticResource NtFg}"/>
+            <Setter Property="CaretBrush" Value="{StaticResource NtBlue}"/>
+            <Setter Property="SelectionBrush" Value="{StaticResource NtBlueDim}"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="MinHeight" Value="32"/>
+        </Style>
+        <Style Selector="TextBox:focus /template/ Border#PART_BorderElement">
+            <Setter Property="BorderBrush" Value="{StaticResource NtBlue}"/>
+        </Style>
+        <Style Selector="NumericUpDown">
+            <Setter Property="Background" Value="{StaticResource NtPanelAlt}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource NtHairline}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="CornerRadius" Value="5"/>
+            <Setter Property="Foreground" Value="{StaticResource NtFg}"/>
+            <Setter Property="FontSize" Value="13"/>
+        </Style>
+
+        <!-- ComboBox -->
+        <Style Selector="ComboBox">
+            <Setter Property="Background" Value="{StaticResource NtPanelAlt}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource NtHairline}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="CornerRadius" Value="5"/>
+            <Setter Property="Padding" Value="10,4"/>
+            <Setter Property="Foreground" Value="{StaticResource NtFg}"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="MinHeight" Value="32"/>
+        </Style>
+
+        <!-- Primary action button -->
+        <Style Selector="Button.Primary">
+            <Setter Property="Background" Value="{StaticResource NtBlue}"/>
+            <Setter Property="Foreground" Value="#0a1622"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="CornerRadius" Value="5"/>
+            <Setter Property="Padding" Value="16,7"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+        </Style>
+        <Style Selector="Button.Primary:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#7cc1f5"/>
+        </Style>
+        <Style Selector="Button.Primary:pressed /template/ ContentPresenter">
+            <Setter Property="Background" Value="#4f9bde"/>
+        </Style>
+
+        <!-- Secondary pill button -->
+        <Style Selector="Button.Pill">
+            <Setter Property="Background" Value="{StaticResource NtPanel}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource NtHairline}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="CornerRadius" Value="5"/>
+            <Setter Property="Padding" Value="14,6"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="Foreground" Value="{StaticResource NtFg}"/>
+        </Style>
+        <Style Selector="Button.Pill:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#2a2f38"/>
+        </Style>
+
+        <!-- Danger button (delete) -->
+        <Style Selector="Button.Danger">
+            <Setter Property="Background" Value="#3a1a1d"/>
+            <Setter Property="BorderBrush" Value="#5c2329"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Foreground" Value="{StaticResource NtRed}"/>
+            <Setter Property="CornerRadius" Value="5"/>
+            <Setter Property="Padding" Value="14,6"/>
+            <Setter Property="FontSize" Value="13"/>
+        </Style>
+        <Style Selector="Button.Danger:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#4a2024"/>
+        </Style>
+
+        <!-- Icon-only ghost button -->
+        <Style Selector="Button.IconBtn">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="6"/>
+            <Setter Property="CornerRadius" Value="4"/>
+            <Setter Property="Foreground" Value="{StaticResource NtFg3}"/>
+            <Setter Property="Width" Value="32"/>
+            <Setter Property="Height" Value="32"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+        </Style>
+        <Style Selector="Button.IconBtn:pointerover">
+            <Setter Property="Foreground" Value="{StaticResource NtFg}"/>
+        </Style>
+        <Style Selector="Button.IconBtn:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#2a2f38"/>
+        </Style>
+
+        <!-- Sidebar (ListBox + items) -->
+        <Style Selector="ListBox.SideNav">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="0"/>
+        </Style>
+        <Style Selector="ListBox.SideNav ListBoxItem">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="2,0,0,0"/>
+            <Setter Property="BorderBrush" Value="Transparent"/>
+            <Setter Property="Padding" Value="10,7"/>
+            <Setter Property="Margin" Value="6,1"/>
+            <Setter Property="CornerRadius" Value="5"/>
+            <Setter Property="Foreground" Value="{StaticResource NtFg2}"/>
+            <Setter Property="FontSize" Value="13"/>
+        </Style>
+        <Style Selector="ListBox.SideNav ListBoxItem:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#1f2730"/>
+        </Style>
+        <Style Selector="ListBox.SideNav ListBoxItem:selected /template/ ContentPresenter">
+            <Setter Property="Background" Value="{StaticResource NtBlueDim}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource NtBlue}"/>
+            <Setter Property="BorderThickness" Value="2,0,0,0"/>
+        </Style>
+        <Style Selector="ListBox.SideNav ListBoxItem:selected">
+            <Setter Property="Foreground" Value="{StaticResource NtFg}"/>
+        </Style>
+
+        <!-- Toggle-pill restyle for CheckBoxes that should look like toggles.
+             CheckBox type is preserved so the code-behind keeps finding them. -->
+        <Style Selector="CheckBox.Toggle">
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="Foreground" Value="{StaticResource NtFg}"/>
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <Grid ColumnDefinitions="*,Auto">
+                        <ContentPresenter Grid.Column="0"
+                                          Content="{TemplateBinding Content}"
+                                          VerticalAlignment="Center"
+                                          Foreground="{TemplateBinding Foreground}"
+                                          IsVisible="{Binding $parent[CheckBox].Content, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                        <Border Grid.Column="1"
+                                Name="PART_Track"
+                                Width="34" Height="20"
+                                CornerRadius="10"
+                                Background="{StaticResource NtHairlineStrong}"
+                                Margin="8,0,0,0">
+                            <Ellipse Name="PART_Knob"
+                                     Width="16" Height="16"
+                                     Fill="White"
+                                     HorizontalAlignment="Left"
+                                     Margin="2,0,0,0"/>
+                        </Border>
+                    </Grid>
+                </ControlTemplate>
+            </Setter>
+        </Style>
+        <Style Selector="CheckBox.Toggle:checked /template/ Border#PART_Track">
+            <Setter Property="Background" Value="{StaticResource NtBlue}"/>
+        </Style>
+        <Style Selector="CheckBox.Toggle:checked /template/ Ellipse#PART_Knob">
+            <Setter Property="HorizontalAlignment" Value="Right"/>
+            <Setter Property="Margin" Value="0,0,2,0"/>
+        </Style>
+
+        <!-- Slider -->
+        <Style Selector="Slider">
+            <Setter Property="Foreground" Value="{StaticResource NtBlue}"/>
+            <Setter Property="Background" Value="{StaticResource NtHairlineStrong}"/>
+            <Setter Property="MinHeight" Value="22"/>
+        </Style>
+
+        <!-- RadioButton -->
+        <Style Selector="RadioButton">
+            <Setter Property="Foreground" Value="{StaticResource NtFg}"/>
+            <Setter Property="FontSize" Value="13"/>
+        </Style>
+
+        <!-- Separator -->
+        <Style Selector="Separator">
+            <Setter Property="Background" Value="{StaticResource NtHairline}"/>
+            <Setter Property="Height" Value="1"/>
+            <Setter Property="Margin" Value="0,4"/>
         </Style>
     </Window.Styles>
-    
-    <Grid Margin="15" RowDefinitions="Auto, *, Auto">
-        <TextBlock Text="Terminal Settings" FontSize="22" FontWeight="Bold" Margin="0,0,0,15"/>
-        
-        <TabControl Name="MainTabs" Grid.Row="1">
-            <!-- Appearance Tab -->
-            <TabItem Header="Appearance">
-                <ScrollViewer Margin="0,10,0,0">
-                    <StackPanel Spacing="15" Margin="0,0,15,0">
-                        <!-- Font Family -->
-                        <StackPanel>
-                            <TextBlock Text="Font Family" Margin="0,0,0,5" Opacity="0.7" FontSize="12"/>
-                            <ComboBox Name="FontList" HorizontalAlignment="Stretch">
-                                <ComboBoxItem>Cascadia Mono PL</ComboBoxItem>
-                                <ComboBoxItem>JetBrains Mono</ComboBoxItem>
-                            </ComboBox>
-                        </StackPanel>
 
-                        <!-- Enable Ligatures -->
-                        <CheckBox Name="LigatureToggle" Content="Enable Programming Ligatures" Margin="0,5,0,0"/>
+    <Grid RowDefinitions="*,Auto">
 
-                        <!-- Enable Complex Shaping -->
-                        <CheckBox Name="ComplexShapingToggle" Content="Enable Complex Shaping (Run-level HarfBuzz)" Margin="0,5,0,0"/>
+        <!-- ╭───────── Body: sidebar + content ─────────╮ -->
+        <Grid Grid.Row="0" ColumnDefinitions="208,*">
 
-                        <!-- Command Assist -->
-                        <CheckBox Name="CommandAssistToggle" Content="Enable Command Assistant" Margin="0,5,0,0"/>
-                        
-                        <!-- Font Size -->
-                        <StackPanel>
-                            <TextBlock Text="Font Size" Margin="0,0,0,5" Opacity="0.7" FontSize="12"/>
-                            <NumericUpDown Name="FontSizeInput" Minimum="6" Maximum="72" Value="14"/>
-                        </StackPanel>
-                        
-                        <!-- Scrollback -->
-                        <StackPanel>
-                            <TextBlock Text="Scrollback Limit (Lines)" Margin="0,0,0,5" Opacity="0.7" FontSize="12"/>
-                            <NumericUpDown Name="ScrollbackInput" Minimum="100" Maximum="100000" Value="10000" Increment="1000"/>
-                        </StackPanel>
-                        
-                        <!-- Theme -->
-                        <StackPanel>
-                            <TextBlock Text="Theme" Margin="0,0,0,5" Opacity="0.7" FontSize="12"/>
-                            <Grid ColumnDefinitions="*, Auto, Auto, Auto">
-                                <ComboBox Name="ThemeList" HorizontalAlignment="Stretch">
-                                    <ComboBoxItem>Default (Dark)</ComboBoxItem>
-                                </ComboBox>
-                                <Button Name="BtnEditTheme" Grid.Column="1" Content="Edit" Margin="5,0,0,0" Padding="10,4" />
-                                <Button Name="BtnImportTheme" Grid.Column="2" Content="Import" Margin="5,0,0,0" Padding="10,4" />
-                                <Button Name="BtnNewTheme" Grid.Column="3" Content="+" Margin="5,0,0,0" Width="32" HorizontalContentAlignment="Center" ToolTip.Tip="New Theme" />
-                            </Grid>
-                            
-                            <!-- Theme Editor Panel (Hidden by default) -->
-                            <Border Name="ThemeEditorPanel" TextElement.Foreground="White" IsVisible="False" Margin="0,10,0,0" Padding="12" Background="#252525" BorderBrush="#444" BorderThickness="1" CornerRadius="4">
-                                <StackPanel Spacing="10">
-                                    <Grid ColumnDefinitions="*, Auto">
-                                        <TextBlock Text="Theme Editor" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                                        <Button Name="BtnCloseEditor" Grid.Column="1" Content="✕" Background="Transparent" BorderThickness="0" Padding="5,2"/>
-                                    </Grid>
-                                    
-                                    <StackPanel>
-                                        <TextBlock Text="Theme Name" Opacity="0.7" FontSize="10" Margin="0,0,0,3"/>
-                                        <TextBox Name="EditThemeNameInput" IsReadOnly="False" />
-                                    </StackPanel>
+            <!-- Sidebar -->
+            <Border Grid.Column="0"
+                    Background="{StaticResource NtChromeBg}"
+                    BorderBrush="{StaticResource NtHairline}"
+                    BorderThickness="0,0,1,0">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="0,16,0,16" Spacing="0">
+                        <TextBlock Classes="SectionHeader" Text="INTERFACE" Margin="14,0,14,8"/>
+                        <ListBox Name="SideNav"
+                                 Classes="SideNav"
+                                 SelectionMode="Single"
+                                 SelectedIndex="{Binding #MainTabs.SelectedIndex, Mode=TwoWay}">
+                            <ListBoxItem>
+                                <Grid ColumnDefinitions="20,*">
+                                    <TextBlock Grid.Column="0" Text="◐" FontSize="13" Foreground="{StaticResource NtBlue}" VerticalAlignment="Center"/>
+                                    <TextBlock Grid.Column="1" Text="Appearance" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                                </Grid>
+                            </ListBoxItem>
+                            <ListBoxItem>
+                                <Grid ColumnDefinitions="20,*">
+                                    <TextBlock Grid.Column="0" Text="&gt;_" FontFamily="{StaticResource NtMono}" FontSize="12" Foreground="{StaticResource NtFg3}" VerticalAlignment="Center"/>
+                                    <TextBlock Grid.Column="1" Text="Shells &amp; Profiles" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                                </Grid>
+                            </ListBoxItem>
+                        </ListBox>
 
-                                    <!-- Global Colors -->
-                                    <UniformGrid Columns="2">
-                                        <StackPanel Margin="0,0,5,0">
-                                            <TextBlock Text="Foreground" Opacity="0.7" FontSize="10" Margin="0,0,0,3"/>
-                                            <TextBox Name="EditThemeFgInput" PlaceholderText="#RRGGBB" />
-                                        </StackPanel>
-                                        <StackPanel Margin="5,0,0,0">
-                                            <TextBlock Text="Background" Opacity="0.7" FontSize="10" Margin="0,0,0,3"/>
-                                            <TextBox Name="EditThemeBgInput" PlaceholderText="#RRGGBB" />
-                                        </StackPanel>
-                                        <StackPanel Margin="0,5,5,0">
-                                            <TextBlock Text="Cursor" Opacity="0.7" FontSize="10" Margin="0,0,0,3"/>
-                                            <TextBox Name="EditThemeCursorInput" PlaceholderText="#RRGGBB" />
-                                        </StackPanel>
-                                    </UniformGrid>
-
-                                    <TextBlock Text="ANSI Palette" Opacity="0.7" FontSize="10" Margin="0,5,0,0"/>
-                                    <UniformGrid Rows="2" Columns="8" Name="EditorSwatchGrid">
-                                        <!-- Populated via binding or code, but let's put placeholders for layout -->
-                                        <Button Name="EditSwatch0" Width="24" Height="24" Margin="2" Background="Black" CornerRadius="2" />
-                                        <Button Name="EditSwatch1" Width="24" Height="24" Margin="2" Background="Black" CornerRadius="2" />
-                                        <Button Name="EditSwatch2" Width="24" Height="24" Margin="2" Background="Black" CornerRadius="2" />
-                                        <Button Name="EditSwatch3" Width="24" Height="24" Margin="2" Background="Black" CornerRadius="2" />
-                                        <Button Name="EditSwatch4" Width="24" Height="24" Margin="2" Background="Black" CornerRadius="2" />
-                                        <Button Name="EditSwatch5" Width="24" Height="24" Margin="2" Background="Black" CornerRadius="2" />
-                                        <Button Name="EditSwatch6" Width="24" Height="24" Margin="2" Background="Black" CornerRadius="2" />
-                                        <Button Name="EditSwatch7" Width="24" Height="24" Margin="2" Background="Black" CornerRadius="2" />
-                                        <Button Name="EditSwatch8" Width="24" Height="24" Margin="2" Background="Black" CornerRadius="2" />
-                                        <Button Name="EditSwatch9" Width="24" Height="24" Margin="2" Background="Black" CornerRadius="2" />
-                                        <Button Name="EditSwatch10" Width="24" Height="24" Margin="2" Background="Black" CornerRadius="2" />
-                                        <Button Name="EditSwatch11" Width="24" Height="24" Margin="2" Background="Black" CornerRadius="2" />
-                                        <Button Name="EditSwatch12" Width="24" Height="24" Margin="2" Background="Black" CornerRadius="2" />
-                                        <Button Name="EditSwatch13" Width="24" Height="24" Margin="2" Background="Black" CornerRadius="2" />
-                                        <Button Name="EditSwatch14" Width="24" Height="24" Margin="2" Background="Black" CornerRadius="2" />
-                                        <Button Name="EditSwatch15" Width="24" Height="24" Margin="2" Background="Black" CornerRadius="2" />
-                                    </UniformGrid>
-
-                                    <StackPanel Orientation="Horizontal" Spacing="10" Margin="0,10,0,0">
-                                        <Button Name="BtnSaveTheme" Content="Save Theme" Classes="accent" />
-                                        <Button Name="BtnDeleteTheme" Content="Delete" Background="#441111" />
-                                        <TextBlock Name="ThemeEditorStatus" VerticalAlignment="Center" FontSize="11" Opacity="0.7"/>
-                                    </StackPanel>
-                                </StackPanel>
-                            </Border>
-
-                            <!-- Visual Preview Area -->
-                            <Border Name="ThemePreviewArea" Margin="0,10,0,0" Padding="10" Background="#111" BorderBrush="#333" BorderThickness="1" CornerRadius="4">
-                                <StackPanel Spacing="10">
-                                    <TextBlock Text="Preview" FontSize="10" Opacity="0.7" Margin="0,0,0,5"/>
-                                    <TextBlock Text="Supports .png, .jpg, .bmp" FontSize="10" Opacity="0.5" FontStyle="Italic" Margin="0,2,0,5"/>
-                                    
-                                    <!-- Sample Text -->
-                                    <Border Name="SampleTextBorder" Padding="10" CornerRadius="4">
-                                        <TextBlock Name="SampleTextBlock" Text="The quick brown fox jumps over the lazy dog." />
-                                    </Border>
-                                    
-                                    <!-- ANSI Swatches -->
-                                    <UniformGrid Rows="2" Columns="8" HorizontalAlignment="Center">
-                                        <Border Name="Swatch0" Width="20" Height="20" Margin="2" CornerRadius="2" ToolTip.Tip="Black" />
-                                        <Border Name="Swatch1" Width="20" Height="20" Margin="2" CornerRadius="2" ToolTip.Tip="Red" />
-                                        <Border Name="Swatch2" Width="20" Height="20" Margin="2" CornerRadius="2" ToolTip.Tip="Green" />
-                                        <Border Name="Swatch3" Width="20" Height="20" Margin="2" CornerRadius="2" ToolTip.Tip="Yellow" />
-                                        <Border Name="Swatch4" Width="20" Height="20" Margin="2" CornerRadius="2" ToolTip.Tip="Blue" />
-                                        <Border Name="Swatch5" Width="20" Height="20" Margin="2" CornerRadius="2" ToolTip.Tip="Magenta" />
-                                        <Border Name="Swatch6" Width="20" Height="20" Margin="2" CornerRadius="2" ToolTip.Tip="Cyan" />
-                                        <Border Name="Swatch7" Width="20" Height="20" Margin="2" CornerRadius="2" ToolTip.Tip="White" />
-                                        
-                                        <Border Name="Swatch8" Width="20" Height="20" Margin="2" CornerRadius="2" ToolTip.Tip="Bright Black" />
-                                        <Border Name="Swatch9" Width="20" Height="20" Margin="2" CornerRadius="2" ToolTip.Tip="Bright Red" />
-                                        <Border Name="Swatch10" Width="20" Height="20" Margin="2" CornerRadius="2" ToolTip.Tip="Bright Green" />
-                                        <Border Name="Swatch11" Width="20" Height="20" Margin="2" CornerRadius="2" ToolTip.Tip="Bright Yellow" />
-                                        <Border Name="Swatch12" Width="20" Height="20" Margin="2" CornerRadius="2" ToolTip.Tip="Bright Blue" />
-                                        <Border Name="Swatch13" Width="20" Height="20" Margin="2" CornerRadius="2" ToolTip.Tip="Bright Magenta" />
-                                        <Border Name="Swatch14" Width="20" Height="20" Margin="2" CornerRadius="2" ToolTip.Tip="Bright Cyan" />
-                                        <Border Name="Swatch15" Width="20" Height="20" Margin="2" CornerRadius="2" ToolTip.Tip="Bright White" />
-                                    </UniformGrid>
-                                </StackPanel>
-                            </Border>
-                        </StackPanel>
-                        
-                        <Separator Background="#333" Margin="0,5"/>
-
-                        <!-- Window Opacity -->
-                        <StackPanel>
-                            <Grid ColumnDefinitions="*, Auto">
-                                <TextBlock Text="Window Opacity" Margin="0,0,0,5" Opacity="0.7" FontSize="12"/>
-                                <TextBlock Name="OpacityValueDisplay" Grid.Column="1" Text="100%" Opacity="0.7" HorizontalAlignment="Right" FontSize="12"/>
-                            </Grid>
-                            <Slider Name="WindowOpacitySlider" Minimum="0.2" Maximum="1.0" Value="1.0" TickFrequency="0.01" IsSnapToTickEnabled="True"/>
-                        </StackPanel>
-
-                        <!-- Blur -->
-                        <StackPanel>
-                            <TextBlock Text="Blur Effect" Margin="0,0,0,5" Opacity="0.7" FontSize="12"/>
-                            <ComboBox Name="BlurList" HorizontalAlignment="Stretch">
-                                <ComboBoxItem>Acrylic</ComboBoxItem>
-                                <ComboBoxItem>Mica</ComboBoxItem>
-                                <ComboBoxItem>None</ComboBoxItem>
-                            </ComboBox>
-                        </StackPanel>
-
-                        <TextBlock Text="Background Image" FontSize="16" Margin="0,10,0,5" FontWeight="SemiBold"/>
-                        <Grid ColumnDefinitions="*,Auto,Auto" Margin="0,0,0,10">
-                            <TextBox Name="BgImagePathInput" PlaceholderText="Path onto image file..." Margin="0,0,10,0"/>
-                            <Button Name="BtnBrowseImage" Content="..." Grid.Column="1" Width="40" Margin="0,0,5,0"/>
-                            <Button Name="BtnClearImage" Content="✕" Grid.Column="2" Width="40" HorizontalContentAlignment="Center" VerticalContentAlignment="Center"/>
-                        </Grid>
-
-                        <Grid ColumnDefinitions="Auto, *, Auto" Margin="0,0,0,10">
-                            <TextBlock Text="Image Opacity:" VerticalAlignment="Center" Width="100" Foreground="#AAA" FontSize="12"/>
-                            <Slider Name="BgImageOpacitySlider" Grid.Column="1" Minimum="0" Maximum="1" Margin="10,0"/>
-                            <TextBlock Name="BgImageOpacityDisplay" Grid.Column="2" Text="50%" VerticalAlignment="Center" FontSize="12"/>
-                        </Grid>
-                        
-                        <StackPanel Orientation="Horizontal" Spacing="10" Margin="0,0,0,10">
-                            <TextBlock Text="Stretch Mode:" VerticalAlignment="Center" Width="100" Foreground="#AAA" FontSize="12"/>
-                            <ComboBox Name="BgImageStretchList" Width="150">
-                                <ComboBoxItem>None</ComboBoxItem>
-                                <ComboBoxItem>Fill</ComboBoxItem>
-                                <ComboBoxItem>Uniform</ComboBoxItem>
-                                <ComboBoxItem>UniformToFill</ComboBoxItem>
-                            </ComboBox>
-                        </StackPanel>
+                        <Border Margin="14,18,14,8"
+                                Padding="0,12,0,0"
+                                BorderBrush="{StaticResource NtHairline}"
+                                BorderThickness="0,1,0,0">
+                            <StackPanel Spacing="4">
+                                <TextBlock FontSize="11"
+                                           Foreground="{StaticResource NtFg4}"
+                                           TextWrapping="Wrap"
+                                           Text="Changes apply live."/>
+                                <TextBlock FontSize="11"
+                                           Foreground="{StaticResource NtFg4}"
+                                           TextWrapping="Wrap"
+                                           Text="Hit ⌘S or click Save to persist."/>
+                            </StackPanel>
+                        </Border>
                     </StackPanel>
                 </ScrollViewer>
-            </TabItem>
+            </Border>
 
-            <!-- Profiles Tab -->
-            <TabItem Header="Profiles">
-                <Grid ColumnDefinitions="200, *" Margin="0,10,0,0">
-                    <!-- Profile List -->
-                    <Grid Grid.Column="0" RowDefinitions="*, Auto" Margin="0,0,10,0">
-                        <ListBox Name="ProfilesListBox" BorderThickness="0" Background="Transparent">
-                            <!-- Items populated in code -->
-                        </ListBox>
-                        <StackPanel Grid.Row="1" Orientation="Vertical" Spacing="5" Margin="0,5,10,0">
-                            <StackPanel Orientation="Horizontal" Spacing="5">
-                                <Button Name="BtnAddProfile" Content="Add New" FontSize="12" Padding="8,4"/>
-                                <Button Name="BtnDeleteProfile" Content="Delete" FontSize="12" Padding="8,4" Background="#AA3333" Foreground="White"/>
-                            </StackPanel>
-                            <Separator Opacity="0.2" Margin="0,5"/>
-                            <TextBlock Text="Import From:" Opacity="0.7" FontSize="11" Margin="0,0,0,2"/>
-                            <StackPanel Orientation="Vertical" Spacing="5">
-                                <Button Name="BtnImportWT" Content="Windows Terminal" FontSize="11" Padding="8,4" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"/>
-                                <TextBlock Name="ImportStatusText" Text="" Foreground="#00FF00" FontSize="11" HorizontalAlignment="Center" Margin="0,5,0,0"/>
-                            </StackPanel>
-                        </StackPanel>
-                    </Grid>
+            <!-- Content -->
+            <TabControl Name="MainTabs" Grid.Column="1" Padding="0">
 
-                    <!-- Profile Editor -->
-                    <ScrollViewer Grid.Column="1">
-                        <StackPanel Name="ProfileEditorPanel" Spacing="15" Margin="10,0,0,0">
-                            <StackPanel>
-                                <TextBlock Text="Profile Name" Opacity="0.7" FontSize="12" Margin="0,0,0,5"/>
-                                <TextBox Name="ProfileNameInput" />
+                <!-- ┌──── Appearance ────┐ -->
+                <TabItem Header="Appearance">
+                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <StackPanel Margin="32,28,32,28" Spacing="0">
+
+                            <StackPanel Margin="0,0,0,24">
+                                <TextBlock Classes="H1" Text="Appearance"/>
+                                <TextBlock Classes="Subtitle" Margin="0,4,0,0" Text="Colors, themes, fonts, and window presentation."/>
                             </StackPanel>
 
-                            <StackPanel>
-                                <TextBlock Text="Executable Path" Opacity="0.7" FontSize="12" Margin="0,0,0,5"/>
-                                <TextBox Name="ProfileCommandInput" PlaceholderText="e.g. cmd.exe, powershell.exe" />
-                            </StackPanel>
+                            <!-- ── Theme section ── -->
+                            <TextBlock Classes="SectionHeader" Text="THEME" Margin="0,0,0,14"/>
 
-                            <StackPanel>
-                                <TextBlock Text="Arguments" Opacity="0.7" FontSize="12" Margin="0,0,0,5"/>
-                                <TextBox Name="ProfileArgsInput" PlaceholderText="Optional arguments..." />
-                            </StackPanel>
-
-                            <StackPanel>
-                                <TextBlock Text="Starting Directory" Opacity="0.7" FontSize="12" Margin="0,0,0,5"/>
-                                <TextBox Name="ProfileCwdInput" PlaceholderText="Optional working directory..." />
-                            </StackPanel>
-
-                            <Separator Opacity="0.2" Margin="0,5"/>
-
-                            <StackPanel>
-                                <TextBlock Text="Connection Type" Opacity="0.7" FontSize="12" Margin="0,0,0,5"/>
-                                <ComboBox Name="ProfileTypeList" HorizontalAlignment="Stretch" IsEnabled="False">
-                                    <ComboBoxItem>Local (CMD, PowerShell, WSL)</ComboBoxItem>
+                            <Grid ColumnDefinitions="*,Auto,Auto,Auto" Margin="0,0,0,12">
+                                <ComboBox Name="ThemeList" Grid.Column="0" HorizontalAlignment="Stretch">
+                                    <ComboBoxItem>Default (Dark)</ComboBoxItem>
                                 </ComboBox>
-                            </StackPanel>
+                                <Button Name="BtnEditTheme"   Grid.Column="1" Classes="Pill" Content="Edit"      Margin="6,0,0,0"/>
+                                <Button Name="BtnImportTheme" Grid.Column="2" Classes="Pill" Content="Import…"   Margin="6,0,0,0"/>
+                                <Button Name="BtnNewTheme"    Grid.Column="3" Classes="Pill" Content="+ New"     Margin="6,0,0,0" ToolTip.Tip="New theme"/>
+                            </Grid>
 
-                            <!-- SSH Specific Settings -->
-                            <StackPanel Name="SshSettingsPanel" Spacing="15" IsVisible="False">
-                                <Grid ColumnDefinitions="*, 80">
-                                    <StackPanel>
-                                        <TextBlock Text="Host" Opacity="0.7" FontSize="12" Margin="0,0,0,5"/>
-                                        <TextBox Name="SshHostInput" PlaceholderText="e.g. 192.168.1.1 or example.com" />
-                                    </StackPanel>
-                                    <StackPanel Grid.Column="1" Margin="10,0,0,0">
-                                        <TextBlock Text="Port" Opacity="0.7" FontSize="12" Margin="0,0,0,5"/>
-                                        <NumericUpDown Name="SshPortInput" Minimum="1" Maximum="65535" Value="22" />
-                                    </StackPanel>
-                                </Grid>
-
-                                <StackPanel>
-                                    <TextBlock Text="Username" Opacity="0.7" FontSize="12" Margin="0,0,0,5"/>
-                                    <TextBox Name="SshUserInput" PlaceholderText="e.g. root or ubuntu" />
-                                </StackPanel>
-
-                                <StackPanel>
-                                    <TextBlock Text="Password / Passphrase (Optional)" Opacity="0.7" FontSize="12" Margin="0,0,0,5"/>
-                                    <TextBox Name="SshPasswordInput" PasswordChar="*" PlaceholderText="Leave empty to prompt in terminal" />
-                                </StackPanel>
-
-                                <StackPanel>
-                                    <TextBlock Text="Authentication" Opacity="0.7" FontSize="12" Margin="0,0,0,5"/>
-                                    <RadioButton Name="RadioAuthAgent" Content="Use SSH Agent (Recommended)" GroupName="AuthMode" IsChecked="True" Margin="0,0,0,5"/>
-                                    <RadioButton Name="RadioAuthKey" Content="Use Identity File" GroupName="AuthMode" Margin="0,0,0,5"/>
-                                    
-                                    <Grid ColumnDefinitions="*, Auto" Margin="20,0,0,0">
-                                        <TextBox Name="SshKeyPathInput" PlaceholderText="Path to private key (id_rsa, .pem)" IsEnabled="False"/>
-                                        <Button Name="BtnBrowseSshKey" Grid.Column="1" Content="..." Margin="5,0,0,0" Width="40" IsEnabled="False"/>
+                            <!-- Theme Editor Panel (toggled by BtnEditTheme / BtnNewTheme) -->
+                            <Border Name="ThemeEditorPanel"
+                                    IsVisible="False"
+                                    Margin="0,0,0,12"
+                                    Padding="14"
+                                    Background="{StaticResource NtPanel}"
+                                    BorderBrush="{StaticResource NtHairline}"
+                                    BorderThickness="1"
+                                    CornerRadius="6">
+                                <StackPanel Spacing="12">
+                                    <Grid ColumnDefinitions="*,Auto">
+                                        <TextBlock Text="Theme editor" FontWeight="SemiBold" VerticalAlignment="Center" Foreground="{StaticResource NtFg}"/>
+                                        <Button Name="BtnCloseEditor" Grid.Column="1" Classes="IconBtn" Content="✕"/>
                                     </Grid>
-                                </StackPanel>
 
-                                <StackPanel>
-                                    <TextBlock Text="Jump Host (Bastion)" Opacity="0.7" FontSize="12" Margin="0,0,0,5"/>
-                                    <ComboBox Name="JumpHostList" HorizontalAlignment="Stretch" PlaceholderText="Direct Connection (None)">
-                                        <!-- Items populated in code -->
-                                    </ComboBox>
-                                </StackPanel>
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Text="Theme name" Classes="RowDesc"/>
+                                        <TextBox Name="EditThemeNameInput"/>
+                                    </StackPanel>
 
-                                <StackPanel Spacing="5">
-                                    <TextBlock Text="Port Forwarding" Opacity="0.7" FontSize="12"/>
-                                    <Border Background="#1A1A1A" TextElement.Foreground="White" BorderBrush="#333" BorderThickness="1" CornerRadius="4" Padding="5">
-                                        <StackPanel Spacing="5">
-                                            <StackPanel Name="ForwardsList" Spacing="2"/>
-                                            <Separator Background="#333"/>
-                                            <TextBlock Text="Add new rule:" Foreground="#666" FontSize="10"/>
-                                            <StackPanel Orientation="Horizontal" Spacing="5">
-                                                <ComboBox Name="RuleInputType" SelectedIndex="0" Width="100">
-                                                    <ComboBoxItem>Local</ComboBoxItem>
-                                                    <ComboBoxItem>Remote</ComboBoxItem>
-                                                    <ComboBoxItem>Dynamic</ComboBoxItem>
-                                                </ComboBox>
-                                                <TextBox Name="RuleInputLocal" PlaceholderText="8080" Width="100"/>
-                                                <TextBox Name="RuleInputRemote" PlaceholderText="127.0.0.1:80" Width="100"/>
-                                                <Button Name="BtnAddRule" Content="+"/>
-                                            </StackPanel>
+                                    <UniformGrid Columns="3">
+                                        <StackPanel Margin="0,0,6,0" Spacing="4">
+                                            <TextBlock Text="Foreground" Classes="RowDesc"/>
+                                            <TextBox Name="EditThemeFgInput" PlaceholderText="#RRGGBB"/>
                                         </StackPanel>
-                                    </Border>
+                                        <StackPanel Margin="3,0,3,0" Spacing="4">
+                                            <TextBlock Text="Background" Classes="RowDesc"/>
+                                            <TextBox Name="EditThemeBgInput" PlaceholderText="#RRGGBB"/>
+                                        </StackPanel>
+                                        <StackPanel Margin="6,0,0,0" Spacing="4">
+                                            <TextBlock Text="Cursor" Classes="RowDesc"/>
+                                            <TextBox Name="EditThemeCursorInput" PlaceholderText="#RRGGBB"/>
+                                        </StackPanel>
+                                    </UniformGrid>
+
+                                    <StackPanel Spacing="6">
+                                        <TextBlock Text="ANSI palette" Classes="RowDesc"/>
+                                        <UniformGrid Rows="2" Columns="8" Name="EditorSwatchGrid">
+                                            <Button Name="EditSwatch0"  Width="28" Height="28" Margin="2" Background="Black" CornerRadius="3"/>
+                                            <Button Name="EditSwatch1"  Width="28" Height="28" Margin="2" Background="Black" CornerRadius="3"/>
+                                            <Button Name="EditSwatch2"  Width="28" Height="28" Margin="2" Background="Black" CornerRadius="3"/>
+                                            <Button Name="EditSwatch3"  Width="28" Height="28" Margin="2" Background="Black" CornerRadius="3"/>
+                                            <Button Name="EditSwatch4"  Width="28" Height="28" Margin="2" Background="Black" CornerRadius="3"/>
+                                            <Button Name="EditSwatch5"  Width="28" Height="28" Margin="2" Background="Black" CornerRadius="3"/>
+                                            <Button Name="EditSwatch6"  Width="28" Height="28" Margin="2" Background="Black" CornerRadius="3"/>
+                                            <Button Name="EditSwatch7"  Width="28" Height="28" Margin="2" Background="Black" CornerRadius="3"/>
+                                            <Button Name="EditSwatch8"  Width="28" Height="28" Margin="2" Background="Black" CornerRadius="3"/>
+                                            <Button Name="EditSwatch9"  Width="28" Height="28" Margin="2" Background="Black" CornerRadius="3"/>
+                                            <Button Name="EditSwatch10" Width="28" Height="28" Margin="2" Background="Black" CornerRadius="3"/>
+                                            <Button Name="EditSwatch11" Width="28" Height="28" Margin="2" Background="Black" CornerRadius="3"/>
+                                            <Button Name="EditSwatch12" Width="28" Height="28" Margin="2" Background="Black" CornerRadius="3"/>
+                                            <Button Name="EditSwatch13" Width="28" Height="28" Margin="2" Background="Black" CornerRadius="3"/>
+                                            <Button Name="EditSwatch14" Width="28" Height="28" Margin="2" Background="Black" CornerRadius="3"/>
+                                            <Button Name="EditSwatch15" Width="28" Height="28" Margin="2" Background="Black" CornerRadius="3"/>
+                                        </UniformGrid>
+                                    </StackPanel>
+
+                                    <StackPanel Orientation="Horizontal" Spacing="8">
+                                        <Button Name="BtnSaveTheme" Classes="Primary" Content="Save theme"/>
+                                        <Button Name="BtnDeleteTheme" Classes="Danger" Content="Delete"/>
+                                        <TextBlock Name="ThemeEditorStatus" VerticalAlignment="Center" FontSize="12" Foreground="{StaticResource NtFg3}"/>
+                                    </StackPanel>
                                 </StackPanel>
+                            </Border>
 
+                            <!-- Theme Preview Area -->
+                            <Border Name="ThemePreviewArea"
+                                    Margin="0,0,0,28"
+                                    Padding="12"
+                                    Background="#111"
+                                    BorderBrush="{StaticResource NtHairline}"
+                                    BorderThickness="1"
+                                    CornerRadius="6">
+                                <StackPanel Spacing="10">
+                                    <TextBlock Text="Preview" Classes="RowDesc" Margin="0,0,0,2"/>
+                                    <Border Name="SampleTextBorder" Padding="10" CornerRadius="4">
+                                        <TextBlock Name="SampleTextBlock"
+                                                   Text="The quick brown fox jumps over the lazy dog."
+                                                   FontFamily="{StaticResource NtMono}"
+                                                   FontSize="12"/>
+                                    </Border>
+                                    <UniformGrid Rows="2" Columns="8" HorizontalAlignment="Left">
+                                        <Border Name="Swatch0"  Width="20" Height="20" Margin="2" CornerRadius="3" ToolTip.Tip="Black"/>
+                                        <Border Name="Swatch1"  Width="20" Height="20" Margin="2" CornerRadius="3" ToolTip.Tip="Red"/>
+                                        <Border Name="Swatch2"  Width="20" Height="20" Margin="2" CornerRadius="3" ToolTip.Tip="Green"/>
+                                        <Border Name="Swatch3"  Width="20" Height="20" Margin="2" CornerRadius="3" ToolTip.Tip="Yellow"/>
+                                        <Border Name="Swatch4"  Width="20" Height="20" Margin="2" CornerRadius="3" ToolTip.Tip="Blue"/>
+                                        <Border Name="Swatch5"  Width="20" Height="20" Margin="2" CornerRadius="3" ToolTip.Tip="Magenta"/>
+                                        <Border Name="Swatch6"  Width="20" Height="20" Margin="2" CornerRadius="3" ToolTip.Tip="Cyan"/>
+                                        <Border Name="Swatch7"  Width="20" Height="20" Margin="2" CornerRadius="3" ToolTip.Tip="White"/>
+                                        <Border Name="Swatch8"  Width="20" Height="20" Margin="2" CornerRadius="3" ToolTip.Tip="Bright Black"/>
+                                        <Border Name="Swatch9"  Width="20" Height="20" Margin="2" CornerRadius="3" ToolTip.Tip="Bright Red"/>
+                                        <Border Name="Swatch10" Width="20" Height="20" Margin="2" CornerRadius="3" ToolTip.Tip="Bright Green"/>
+                                        <Border Name="Swatch11" Width="20" Height="20" Margin="2" CornerRadius="3" ToolTip.Tip="Bright Yellow"/>
+                                        <Border Name="Swatch12" Width="20" Height="20" Margin="2" CornerRadius="3" ToolTip.Tip="Bright Blue"/>
+                                        <Border Name="Swatch13" Width="20" Height="20" Margin="2" CornerRadius="3" ToolTip.Tip="Bright Magenta"/>
+                                        <Border Name="Swatch14" Width="20" Height="20" Margin="2" CornerRadius="3" ToolTip.Tip="Bright Cyan"/>
+                                        <Border Name="Swatch15" Width="20" Height="20" Margin="2" CornerRadius="3" ToolTip.Tip="Bright White"/>
+                                    </UniformGrid>
+                                </StackPanel>
+                            </Border>
 
+                            <!-- ── Window section ── -->
+                            <TextBlock Classes="SectionHeader" Text="WINDOW" Margin="0,0,0,14"/>
 
-                            </StackPanel>
+                            <Grid ColumnDefinitions="*,360" Margin="0,0,0,0">
+                                <StackPanel Grid.Column="0" Spacing="2">
+                                    <TextBlock Classes="RowLabel" Text="Window opacity"/>
+                                    <TextBlock Classes="RowDesc"  Text="Applies when the window is focused."/>
+                                </StackPanel>
+                                <Grid Grid.Column="1" ColumnDefinitions="*,Auto" VerticalAlignment="Center">
+                                    <Slider Name="WindowOpacitySlider"
+                                            Grid.Column="0"
+                                            Minimum="0.2" Maximum="1.0" Value="1.0"
+                                            TickFrequency="0.01" IsSnapToTickEnabled="True"/>
+                                    <TextBlock Name="OpacityValueDisplay"
+                                               Grid.Column="1"
+                                               Text="100%"
+                                               Width="48" TextAlignment="Right"
+                                               VerticalAlignment="Center"
+                                               FontFamily="{StaticResource NtMono}"
+                                               FontSize="12"
+                                               Foreground="{StaticResource NtFg2}"
+                                               Margin="10,0,0,0"/>
+                                </Grid>
+                            </Grid>
+                            <Border BorderBrush="{StaticResource NtHairline}" BorderThickness="0,0,0,1" Margin="0,14,0,14"/>
 
-                            <Separator Background="#333" Margin="0,5"/>
-                            <Button Name="BtnSetDefault" Content="Set as Default" HorizontalAlignment="Left" Padding="10,4"/>
-                            
-                            <Separator Background="#333" Margin="0,5"/>
-                            <TextBlock Text="Organization" FontSize="14" FontWeight="SemiBold" Margin="0,5,0,0" Foreground="#888"/>
-                            
-                            <StackPanel>
-                                <TextBlock Text="Group" Foreground="#AAA" FontSize="12" Margin="0,0,0,5"/>
-                                <TextBox Name="ProfileGroupInput" PlaceholderText="e.g. Work, Personal" />
-                            </StackPanel>
+                            <Grid ColumnDefinitions="*,360">
+                                <StackPanel Grid.Column="0" Spacing="2">
+                                    <TextBlock Classes="RowLabel" Text="Blur effect"/>
+                                    <TextBlock Classes="RowDesc"  Text="Acrylic / Mica where supported by the OS."/>
+                                </StackPanel>
+                                <ComboBox Name="BlurList" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Center">
+                                    <ComboBoxItem>Acrylic</ComboBoxItem>
+                                    <ComboBoxItem>Mica</ComboBoxItem>
+                                    <ComboBoxItem>None</ComboBoxItem>
+                                </ComboBox>
+                            </Grid>
+                            <Border BorderBrush="{StaticResource NtHairline}" BorderThickness="0,0,0,1" Margin="0,14,0,14"/>
 
-                            <StackPanel>
-                                <TextBlock Text="Tags" Foreground="#AAA" FontSize="12" Margin="0,0,0,5"/>
-                                <TextBox Name="ProfileTagsInput" PlaceholderText="comma, separated, tags" />
-                            </StackPanel>
-                            
-                            <TextBlock Text="Visual Overrides (Experimental)" FontSize="14" FontWeight="SemiBold" Margin="0,5,0,0" Foreground="#888"/>
-                            
-                            <StackPanel Orientation="Horizontal" Spacing="10">
-                                <CheckBox Name="CheckOverrideFont" Content="Font" VerticalAlignment="Center"/>
-                                <ComboBox Name="OverrideFontList" Width="200" IsEnabled="{Binding #CheckOverrideFont.IsChecked}">
+                            <Grid ColumnDefinitions="*,360">
+                                <StackPanel Grid.Column="0" Spacing="2">
+                                    <TextBlock Classes="RowLabel" Text="Background image"/>
+                                    <TextBlock Classes="RowDesc"  Text="PNG / JPG / BMP, per-theme."/>
+                                </StackPanel>
+                                <Grid Grid.Column="1" ColumnDefinitions="*,Auto,Auto" VerticalAlignment="Center">
+                                    <TextBox Name="BgImagePathInput" Grid.Column="0" PlaceholderText="Path to image file…"/>
+                                    <Button Name="BtnBrowseImage" Grid.Column="1" Classes="Pill" Content="…" Width="40" Margin="6,0,0,0"/>
+                                    <Button Name="BtnClearImage"  Grid.Column="2" Classes="IconBtn" Content="✕" Margin="4,0,0,0"/>
+                                </Grid>
+                            </Grid>
+                            <Grid ColumnDefinitions="*,360" Margin="0,10,0,0">
+                                <StackPanel Grid.Column="0" Spacing="2">
+                                    <TextBlock Classes="RowLabel" Text="Image opacity"/>
+                                </StackPanel>
+                                <Grid Grid.Column="1" ColumnDefinitions="*,Auto" VerticalAlignment="Center">
+                                    <Slider Name="BgImageOpacitySlider" Grid.Column="0" Minimum="0" Maximum="1"/>
+                                    <TextBlock Name="BgImageOpacityDisplay" Grid.Column="1" Text="50%" Width="48" TextAlignment="Right" VerticalAlignment="Center" FontFamily="{StaticResource NtMono}" FontSize="12" Foreground="{StaticResource NtFg2}" Margin="10,0,0,0"/>
+                                </Grid>
+                            </Grid>
+                            <Grid ColumnDefinitions="*,360" Margin="0,10,0,0">
+                                <StackPanel Grid.Column="0" Spacing="2">
+                                    <TextBlock Classes="RowLabel" Text="Stretch mode"/>
+                                </StackPanel>
+                                <ComboBox Name="BgImageStretchList" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Center">
+                                    <ComboBoxItem>None</ComboBoxItem>
+                                    <ComboBoxItem>Fill</ComboBoxItem>
+                                    <ComboBoxItem>Uniform</ComboBoxItem>
+                                    <ComboBoxItem>UniformToFill</ComboBoxItem>
+                                </ComboBox>
+                            </Grid>
+                            <Border BorderBrush="{StaticResource NtHairline}" BorderThickness="0,0,0,1" Margin="0,18,0,18"/>
+
+                            <!-- ── Fonts & Text rendering ── -->
+                            <TextBlock Classes="SectionHeader" Text="FONTS &amp; TEXT" Margin="0,0,0,14"/>
+
+                            <Grid ColumnDefinitions="*,360">
+                                <StackPanel Grid.Column="0" Spacing="2">
+                                    <TextBlock Classes="RowLabel" Text="Font family"/>
+                                    <TextBlock Classes="RowDesc"  Text="Monospaced font used in the terminal."/>
+                                </StackPanel>
+                                <ComboBox Name="FontList" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Center">
                                     <ComboBoxItem>Cascadia Mono PL</ComboBoxItem>
                                     <ComboBoxItem>JetBrains Mono</ComboBoxItem>
                                 </ComboBox>
-                            </StackPanel>
+                            </Grid>
+                            <Border BorderBrush="{StaticResource NtHairline}" BorderThickness="0,0,0,1" Margin="0,14,0,14"/>
 
-                            <StackPanel Orientation="Horizontal" Spacing="10">
-                                <CheckBox Name="CheckOverrideSize" Content="Size" VerticalAlignment="Center"/>
-                                <NumericUpDown Name="OverrideFontSizeInput" Minimum="6" Maximum="72" Value="14" Width="120" IsEnabled="{Binding #CheckOverrideSize.IsChecked}"/>
-                            </StackPanel>
+                            <Grid ColumnDefinitions="*,360">
+                                <StackPanel Grid.Column="0" Spacing="2">
+                                    <TextBlock Classes="RowLabel" Text="Font size"/>
+                                </StackPanel>
+                                <NumericUpDown Name="FontSizeInput" Grid.Column="1" Minimum="6" Maximum="72" Value="14" VerticalAlignment="Center" HorizontalAlignment="Stretch"/>
+                            </Grid>
+                            <Border BorderBrush="{StaticResource NtHairline}" BorderThickness="0,0,0,1" Margin="0,14,0,14"/>
 
-                            <StackPanel Orientation="Horizontal" Spacing="10">
-                                <CheckBox Name="CheckOverrideTheme" Content="Theme" VerticalAlignment="Center"/>
-                                <ComboBox Name="OverrideThemeList" Width="200" IsEnabled="{Binding #CheckOverrideTheme.IsChecked}">
-                                    <ComboBoxItem>Default (Dark)</ComboBoxItem>
-                                    <ComboBoxItem>Solarized Dark</ComboBoxItem>
-                                    <ComboBoxItem>Dracula</ComboBoxItem>
-                                    <ComboBoxItem>Monokai</ComboBoxItem>
-                                    <ComboBoxItem>One Half Dark</ComboBoxItem>
-                                    <ComboBoxItem>GitHub Dark</ComboBoxItem>
-                                </ComboBox>
-                            </StackPanel>
+                            <Grid ColumnDefinitions="*,360">
+                                <StackPanel Grid.Column="0" Spacing="2">
+                                    <TextBlock Classes="RowLabel" Text="Programming ligatures"/>
+                                    <TextBlock Classes="RowDesc" Text="Render => != >= |> as glyphs."/>
+                                </StackPanel>
+                                <CheckBox Name="LigatureToggle" Grid.Column="1" Classes="Toggle" Content="" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                            </Grid>
+                            <Border BorderBrush="{StaticResource NtHairline}" BorderThickness="0,0,0,1" Margin="0,14,0,14"/>
 
-                            <StackPanel Orientation="Horizontal" Spacing="10">
-                                <CheckBox Name="CheckOverrideLigatures" Content="Ligatures" VerticalAlignment="Center"/>
-                                <CheckBox Name="OverrideLigatureToggle" Content="Enabled" IsEnabled="{Binding #CheckOverrideLigatures.IsChecked}" VerticalAlignment="Center"/>
-                            </StackPanel>
+                            <Grid ColumnDefinitions="*,360">
+                                <StackPanel Grid.Column="0" Spacing="2">
+                                    <TextBlock Classes="RowLabel" Text="Complex shaping (HarfBuzz)"/>
+                                    <TextBlock Classes="RowDesc" Text="Run-level shaping for non-Latin scripts and emoji."/>
+                                </StackPanel>
+                                <CheckBox Name="ComplexShapingToggle" Grid.Column="1" Classes="Toggle" Content="" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                            </Grid>
+                            <Border BorderBrush="{StaticResource NtHairline}" BorderThickness="0,0,0,1" Margin="0,14,0,14"/>
+
+                            <Grid ColumnDefinitions="*,360">
+                                <StackPanel Grid.Column="0" Spacing="2">
+                                    <TextBlock Classes="RowLabel" Text="Command assistant"/>
+                                    <TextBlock Classes="RowDesc" Text="Inline suggestions from shell integration."/>
+                                </StackPanel>
+                                <CheckBox Name="CommandAssistToggle" Grid.Column="1" Classes="Toggle" Content="" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                            </Grid>
+                            <Border BorderBrush="{StaticResource NtHairline}" BorderThickness="0,0,0,1" Margin="0,18,0,18"/>
+
+                            <!-- ── Scrollback ── -->
+                            <TextBlock Classes="SectionHeader" Text="SCROLLBACK" Margin="0,0,0,14"/>
+
+                            <Grid ColumnDefinitions="*,360">
+                                <StackPanel Grid.Column="0" Spacing="2">
+                                    <TextBlock Classes="RowLabel" Text="Scrollback limit"/>
+                                    <TextBlock Classes="RowDesc" Text="Maximum number of lines retained per pane."/>
+                                </StackPanel>
+                                <NumericUpDown Name="ScrollbackInput" Grid.Column="1" Minimum="100" Maximum="100000" Value="10000" Increment="1000" VerticalAlignment="Center" HorizontalAlignment="Stretch"/>
+                            </Grid>
                         </StackPanel>
                     </ScrollViewer>
-                </Grid>
-            </TabItem>
-        </TabControl>
-        
-        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10" Margin="0,15,0,0">
-            <Button Name="BtnCancel" Content="Cancel" Width="90" HorizontalContentAlignment="Center"/>
-            <Button Name="BtnSave" Content="Save" Width="90" HorizontalContentAlignment="Center" Background="#0078d4" Foreground="White"/>
-        </StackPanel>
+                </TabItem>
+
+                <!-- ┌──── Shells & Profiles ────┐ -->
+                <TabItem Header="Profiles">
+                    <Grid ColumnDefinitions="240,*" Margin="0">
+                        <!-- Profile list -->
+                        <Border Grid.Column="0"
+                                Background="{StaticResource NtChromeBg}"
+                                BorderBrush="{StaticResource NtHairline}"
+                                BorderThickness="0,0,1,0">
+                            <Grid RowDefinitions="Auto,*,Auto" Margin="14,16">
+                                <TextBlock Grid.Row="0" Classes="SectionHeader" Text="LOCAL PROFILES" Margin="0,0,0,10"/>
+                                <ListBox Name="ProfilesListBox"
+                                         Grid.Row="1"
+                                         BorderThickness="0"
+                                         Background="Transparent"/>
+                                <StackPanel Grid.Row="2" Spacing="6" Margin="0,10,0,0">
+                                    <StackPanel Orientation="Horizontal" Spacing="6">
+                                        <Button Name="BtnAddProfile" Classes="Pill" Content="+ Add" HorizontalAlignment="Stretch"/>
+                                        <Button Name="BtnDeleteProfile" Classes="Danger" Content="Delete"/>
+                                    </StackPanel>
+                                    <Separator/>
+                                    <TextBlock Text="Import from:" Classes="RowDesc"/>
+                                    <Button Name="BtnImportWT" Classes="Pill" Content="Windows Terminal" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"/>
+                                    <TextBlock Name="ImportStatusText" Text="" Foreground="{StaticResource NtGreen}" FontSize="11" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </Grid>
+                        </Border>
+
+                        <!-- Profile editor -->
+                        <ScrollViewer Grid.Column="1" VerticalScrollBarVisibility="Auto">
+                            <StackPanel Name="ProfileEditorPanel" Margin="32,28,32,28" Spacing="0">
+
+                                <StackPanel Margin="0,0,0,24">
+                                    <TextBlock Classes="H1" Text="Profile"/>
+                                    <TextBlock Classes="Subtitle" Margin="0,4,0,0" Text="Edit the selected profile. Changes apply on Save."/>
+                                </StackPanel>
+
+                                <TextBlock Classes="SectionHeader" Text="BASICS" Margin="0,0,0,14"/>
+
+                                <StackPanel Spacing="14" Margin="0,0,0,20">
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Classes="RowLabel" Text="Profile name"/>
+                                        <TextBox Name="ProfileNameInput"/>
+                                    </StackPanel>
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Classes="RowLabel" Text="Executable path"/>
+                                        <TextBox Name="ProfileCommandInput" PlaceholderText="e.g. cmd.exe, powershell.exe"/>
+                                    </StackPanel>
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Classes="RowLabel" Text="Arguments"/>
+                                        <TextBox Name="ProfileArgsInput" PlaceholderText="Optional arguments…"/>
+                                    </StackPanel>
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Classes="RowLabel" Text="Starting directory"/>
+                                        <TextBox Name="ProfileCwdInput" PlaceholderText="Optional working directory…"/>
+                                    </StackPanel>
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Classes="RowLabel" Text="Connection type"/>
+                                        <ComboBox Name="ProfileTypeList" HorizontalAlignment="Stretch" IsEnabled="False">
+                                            <ComboBoxItem>Local (CMD, PowerShell, WSL)</ComboBoxItem>
+                                        </ComboBox>
+                                    </StackPanel>
+                                </StackPanel>
+
+                                <!-- SSH-only panel (toggled in code-behind) -->
+                                <StackPanel Name="SshSettingsPanel" Spacing="14" Margin="0,0,0,20" IsVisible="False">
+                                    <TextBlock Classes="SectionHeader" Text="SSH"/>
+
+                                    <Grid ColumnDefinitions="*,90">
+                                        <StackPanel Grid.Column="0" Spacing="4" Margin="0,0,8,0">
+                                            <TextBlock Classes="RowLabel" Text="Host"/>
+                                            <TextBox Name="SshHostInput" PlaceholderText="e.g. 192.168.1.1 or example.com"/>
+                                        </StackPanel>
+                                        <StackPanel Grid.Column="1" Spacing="4">
+                                            <TextBlock Classes="RowLabel" Text="Port"/>
+                                            <NumericUpDown Name="SshPortInput" Minimum="1" Maximum="65535" Value="22"/>
+                                        </StackPanel>
+                                    </Grid>
+
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Classes="RowLabel" Text="Username"/>
+                                        <TextBox Name="SshUserInput" PlaceholderText="e.g. root or ubuntu"/>
+                                    </StackPanel>
+
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Classes="RowLabel" Text="Password / passphrase (optional)"/>
+                                        <TextBox Name="SshPasswordInput" PasswordChar="*" PlaceholderText="Leave empty to prompt in terminal"/>
+                                    </StackPanel>
+
+                                    <StackPanel Spacing="6">
+                                        <TextBlock Classes="RowLabel" Text="Authentication"/>
+                                        <RadioButton Name="RadioAuthAgent" Content="Use SSH agent (recommended)" GroupName="AuthMode" IsChecked="True"/>
+                                        <RadioButton Name="RadioAuthKey"   Content="Use identity file" GroupName="AuthMode"/>
+                                        <Grid ColumnDefinitions="*,Auto" Margin="22,4,0,0">
+                                            <TextBox Name="SshKeyPathInput" PlaceholderText="Path to private key (id_rsa, .pem)" IsEnabled="False"/>
+                                            <Button Name="BtnBrowseSshKey" Grid.Column="1" Classes="Pill" Content="…" Width="40" Margin="6,0,0,0" IsEnabled="False"/>
+                                        </Grid>
+                                    </StackPanel>
+
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Classes="RowLabel" Text="Jump host (bastion)"/>
+                                        <ComboBox Name="JumpHostList" HorizontalAlignment="Stretch" PlaceholderText="Direct connection (none)"/>
+                                    </StackPanel>
+
+                                    <StackPanel Spacing="6">
+                                        <TextBlock Classes="RowLabel" Text="Port forwarding"/>
+                                        <Border Background="{StaticResource NtPanelAlt}"
+                                                BorderBrush="{StaticResource NtHairline}"
+                                                BorderThickness="1"
+                                                CornerRadius="5"
+                                                Padding="10">
+                                            <StackPanel Spacing="8">
+                                                <StackPanel Name="ForwardsList" Spacing="4"/>
+                                                <Separator/>
+                                                <TextBlock Text="Add new rule:" Classes="RowDesc"/>
+                                                <Grid ColumnDefinitions="100,100,*,Auto">
+                                                    <ComboBox Name="RuleInputType" Grid.Column="0" SelectedIndex="0">
+                                                        <ComboBoxItem>Local</ComboBoxItem>
+                                                        <ComboBoxItem>Remote</ComboBoxItem>
+                                                        <ComboBoxItem>Dynamic</ComboBoxItem>
+                                                    </ComboBox>
+                                                    <TextBox Name="RuleInputLocal"  Grid.Column="1" PlaceholderText="8080" Margin="6,0,0,0"/>
+                                                    <TextBox Name="RuleInputRemote" Grid.Column="2" PlaceholderText="127.0.0.1:80" Margin="6,0,0,0"/>
+                                                    <Button  Name="BtnAddRule"      Grid.Column="3" Classes="Pill" Content="+" Margin="6,0,0,0" Width="40"/>
+                                                </Grid>
+                                            </StackPanel>
+                                        </Border>
+                                    </StackPanel>
+                                </StackPanel>
+
+                                <Button Name="BtnSetDefault" Classes="Pill" Content="Set as default" HorizontalAlignment="Left" Margin="0,0,0,20"/>
+
+                                <TextBlock Classes="SectionHeader" Text="ORGANIZATION" Margin="0,0,0,14"/>
+                                <StackPanel Spacing="14" Margin="0,0,0,20">
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Classes="RowLabel" Text="Group"/>
+                                        <TextBox Name="ProfileGroupInput" PlaceholderText="e.g. Work, Personal"/>
+                                    </StackPanel>
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Classes="RowLabel" Text="Tags"/>
+                                        <TextBox Name="ProfileTagsInput" PlaceholderText="comma, separated, tags"/>
+                                    </StackPanel>
+                                </StackPanel>
+
+                                <TextBlock Classes="SectionHeader" Text="VISUAL OVERRIDES (EXPERIMENTAL)" Margin="0,0,0,14"/>
+                                <StackPanel Spacing="10">
+                                    <StackPanel Orientation="Horizontal" Spacing="12">
+                                        <CheckBox Name="CheckOverrideFont" Content="Font" VerticalAlignment="Center"/>
+                                        <ComboBox Name="OverrideFontList" Width="220" IsEnabled="{Binding #CheckOverrideFont.IsChecked}">
+                                            <ComboBoxItem>Cascadia Mono PL</ComboBoxItem>
+                                            <ComboBoxItem>JetBrains Mono</ComboBoxItem>
+                                        </ComboBox>
+                                    </StackPanel>
+                                    <StackPanel Orientation="Horizontal" Spacing="12">
+                                        <CheckBox Name="CheckOverrideSize" Content="Size" VerticalAlignment="Center"/>
+                                        <NumericUpDown Name="OverrideFontSizeInput" Minimum="6" Maximum="72" Value="14" Width="140" IsEnabled="{Binding #CheckOverrideSize.IsChecked}"/>
+                                    </StackPanel>
+                                    <StackPanel Orientation="Horizontal" Spacing="12">
+                                        <CheckBox Name="CheckOverrideTheme" Content="Theme" VerticalAlignment="Center"/>
+                                        <ComboBox Name="OverrideThemeList" Width="220" IsEnabled="{Binding #CheckOverrideTheme.IsChecked}">
+                                            <ComboBoxItem>Default (Dark)</ComboBoxItem>
+                                            <ComboBoxItem>Solarized Dark</ComboBoxItem>
+                                            <ComboBoxItem>Dracula</ComboBoxItem>
+                                            <ComboBoxItem>Monokai</ComboBoxItem>
+                                            <ComboBoxItem>One Half Dark</ComboBoxItem>
+                                            <ComboBoxItem>GitHub Dark</ComboBoxItem>
+                                        </ComboBox>
+                                    </StackPanel>
+                                    <StackPanel Orientation="Horizontal" Spacing="12">
+                                        <CheckBox Name="CheckOverrideLigatures" Content="Ligatures" VerticalAlignment="Center"/>
+                                        <CheckBox Name="OverrideLigatureToggle" Content="Enabled" IsEnabled="{Binding #CheckOverrideLigatures.IsChecked}" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </StackPanel>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </Grid>
+                </TabItem>
+            </TabControl>
+        </Grid>
+
+        <!-- ╭───────── Footer ─────────╮ -->
+        <Border Grid.Row="1"
+                Background="{StaticResource NtChromeBg}"
+                BorderBrush="{StaticResource NtHairline}"
+                BorderThickness="0,1,0,0"
+                Padding="16,10">
+            <Grid ColumnDefinitions="*,Auto,Auto">
+                <TextBlock Grid.Column="0"
+                           Text="Changes apply live."
+                           Foreground="{StaticResource NtFg3}"
+                           FontSize="12"
+                           VerticalAlignment="Center"/>
+                <Button Name="BtnCancel" Grid.Column="1" Classes="Pill"    Content="Cancel" Width="100" Margin="0,0,8,0"/>
+                <Button Name="BtnSave"   Grid.Column="2" Classes="Primary" Content="Save"   Width="100"/>
+            </Grid>
+        </Border>
     </Grid>
 </Window>

--- a/src/NovaTerminal.App/SettingsWindow.axaml.cs
+++ b/src/NovaTerminal.App/SettingsWindow.axaml.cs
@@ -1312,6 +1312,7 @@ namespace NovaTerminal
 
             var contrastColor = theme.GetContrastForeground();
             var contrastForeground = new SolidColorBrush(contrastColor.ToAvaloniaColor());
+            UpdatePaletteResources(theme);
 
             this.Background = new Avalonia.Media.SolidColorBrush(theme.Background.ToAvaloniaColor());
             this.Foreground = contrastForeground;
@@ -1326,6 +1327,60 @@ namespace NovaTerminal
                 // Already set Force White in XAML, but good to double check if needed
             }
         }
+
+        private void UpdatePaletteResources(TerminalTheme theme)
+        {
+            var background = theme.Background.ToAvaloniaColor();
+            var foreground = theme.Foreground.ToAvaloniaColor();
+            bool dark = IsDark(background);
+
+            UpdateBrush("NtWindowBg", background);
+            UpdateBrush("NtChromeBg", Shift(background, dark ? 10 : -10));
+            UpdateBrush("NtPanel", Shift(background, dark ? 18 : -18));
+            UpdateBrush("NtPanelAlt", Shift(background, dark ? 6 : -6));
+            UpdateBrush("NtHairline", Shift(background, dark ? 28 : -28));
+            UpdateBrush("NtHairlineStrong", Shift(background, dark ? 40 : -40));
+            UpdateBrush("NtFg", foreground);
+            UpdateBrush("NtFg2", WithAlpha(foreground, 0xC8));
+            UpdateBrush("NtFg3", WithAlpha(foreground, 0x9A));
+            UpdateBrush("NtFg4", WithAlpha(foreground, 0x6E));
+            UpdateBrush("NtBlue", theme.Blue.ToAvaloniaColor());
+            UpdateBrush("NtBlueDim", WithAlpha(theme.Blue.ToAvaloniaColor(), 0x24));
+            UpdateBrush("NtGreen", theme.Green.ToAvaloniaColor());
+            UpdateBrush("NtYellow", theme.Yellow.ToAvaloniaColor());
+            UpdateBrush("NtRed", theme.Red.ToAvaloniaColor());
+        }
+
+        private void UpdateBrush(string key, Color color)
+        {
+            if (Resources[key] is SolidColorBrush brush)
+            {
+                brush.Color = color;
+            }
+            else
+            {
+                Resources[key] = new SolidColorBrush(color);
+            }
+        }
+
+        private static bool IsDark(Color color)
+        {
+            double luminance = ((0.299 * color.R) + (0.587 * color.G) + (0.114 * color.B)) / 255.0;
+            return luminance < 0.5;
+        }
+
+        private static Color Shift(Color color, int delta)
+        {
+            return Color.FromArgb(
+                color.A,
+                Clamp(color.R + delta),
+                Clamp(color.G + delta),
+                Clamp(color.B + delta));
+        }
+
+        private static Color WithAlpha(Color color, byte alpha) => Color.FromArgb(alpha, color.R, color.G, color.B);
+
+        private static byte Clamp(int value) => (byte)Math.Max(0, Math.Min(255, value));
 
         private void SaveAndClose()
         {

--- a/src/NovaTerminal.App/SettingsWindow.axaml.cs
+++ b/src/NovaTerminal.App/SettingsWindow.axaml.cs
@@ -1330,57 +1330,8 @@ namespace NovaTerminal
 
         private void UpdatePaletteResources(TerminalTheme theme)
         {
-            var background = theme.Background.ToAvaloniaColor();
-            var foreground = theme.Foreground.ToAvaloniaColor();
-            bool dark = IsDark(background);
-
-            UpdateBrush("NtWindowBg", background);
-            UpdateBrush("NtChromeBg", Shift(background, dark ? 10 : -10));
-            UpdateBrush("NtPanel", Shift(background, dark ? 18 : -18));
-            UpdateBrush("NtPanelAlt", Shift(background, dark ? 6 : -6));
-            UpdateBrush("NtHairline", Shift(background, dark ? 28 : -28));
-            UpdateBrush("NtHairlineStrong", Shift(background, dark ? 40 : -40));
-            UpdateBrush("NtFg", foreground);
-            UpdateBrush("NtFg2", WithAlpha(foreground, 0xC8));
-            UpdateBrush("NtFg3", WithAlpha(foreground, 0x9A));
-            UpdateBrush("NtFg4", WithAlpha(foreground, 0x6E));
-            UpdateBrush("NtBlue", theme.Blue.ToAvaloniaColor());
-            UpdateBrush("NtBlueDim", WithAlpha(theme.Blue.ToAvaloniaColor(), 0x24));
-            UpdateBrush("NtGreen", theme.Green.ToAvaloniaColor());
-            UpdateBrush("NtYellow", theme.Yellow.ToAvaloniaColor());
-            UpdateBrush("NtRed", theme.Red.ToAvaloniaColor());
+            ThemePaletteResources.Apply(Resources, theme);
         }
-
-        private void UpdateBrush(string key, Color color)
-        {
-            if (Resources[key] is SolidColorBrush brush)
-            {
-                brush.Color = color;
-            }
-            else
-            {
-                Resources[key] = new SolidColorBrush(color);
-            }
-        }
-
-        private static bool IsDark(Color color)
-        {
-            double luminance = ((0.299 * color.R) + (0.587 * color.G) + (0.114 * color.B)) / 255.0;
-            return luminance < 0.5;
-        }
-
-        private static Color Shift(Color color, int delta)
-        {
-            return Color.FromArgb(
-                color.A,
-                Clamp(color.R + delta),
-                Clamp(color.G + delta),
-                Clamp(color.B + delta));
-        }
-
-        private static Color WithAlpha(Color color, byte alpha) => Color.FromArgb(alpha, color.R, color.G, color.B);
-
-        private static byte Clamp(int value) => (byte)Math.Max(0, Math.Min(255, value));
 
         private void SaveAndClose()
         {

--- a/src/NovaTerminal.App/UI/Replay/ReplayWindow.axaml.cs
+++ b/src/NovaTerminal.App/UI/Replay/ReplayWindow.axaml.cs
@@ -27,8 +27,30 @@ namespace NovaTerminal.UI.Replay
         {
             InitializeComponent();
 #if DEBUG
-            Application.Current?.AttachDeveloperTools();
+            TryAttachDeveloperTools(() => Application.Current?.AttachDeveloperTools());
 #endif
+        }
+
+        internal static void TryAttachDeveloperToolsForTest(Action attach)
+        {
+            TryAttachDeveloperTools(attach);
+        }
+
+        private static void TryAttachDeveloperTools(Action? attach)
+        {
+            if (attach == null)
+            {
+                return;
+            }
+
+            try
+            {
+                attach();
+            }
+            catch (InvalidOperationException ex) when (ex.Message.Contains("already been attached", StringComparison.OrdinalIgnoreCase))
+            {
+                // Secondary debug windows can be opened from an app that already attached the dev tools.
+            }
         }
 
         public ReplayWindow(string filePath) : this()

--- a/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
+++ b/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
@@ -24,6 +24,8 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
     private string _userName = string.Empty;
     private int _port = 22;
     private string _accentColor = string.Empty;
+    private string _group = "General";
+    private string _tagsText = string.Empty;
     private bool _isFavorite;
     private string _notes = string.Empty;
     private NewSshAuthMode _authMode = NewSshAuthMode.Agent;
@@ -83,6 +85,18 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
     {
         get => _accentColor;
         set => SetField(ref _accentColor, value);
+    }
+
+    public string Group
+    {
+        get => _group;
+        set => SetField(ref _group, value);
+    }
+
+    public string TagsText
+    {
+        get => _tagsText;
+        set => SetField(ref _tagsText, value);
     }
 
     public bool IsFavorite
@@ -281,9 +295,10 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
             Id = id,
             BackendKind = BackendKind ?? SshBackendKind.OpenSsh,
             Name = name,
+            GroupPath = NormalizeGroup(Group),
             Notes = Notes?.Trim() ?? string.Empty,
             AccentColor = AccentColor?.Trim() ?? string.Empty,
-            Tags = BuildTags(IsFavorite),
+            Tags = BuildTags(TagsText, IsFavorite),
             Host = host,
             User = user,
             Port = port,
@@ -334,6 +349,8 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
             UserName = profile.SshUser,
             Port = profile.SshPort > 0 ? profile.SshPort : 22,
             AccentColor = profile.AccentColor ?? string.Empty,
+            Group = NormalizeGroup(profile.Group),
+            TagsText = FormatTags(profile.Tags),
             IsFavorite = profile.Tags.Any(tag => string.Equals(tag, "favorite", StringComparison.OrdinalIgnoreCase)),
             Notes = profile.Notes ?? string.Empty,
             BackendKind = profile.SshBackendKind,
@@ -369,6 +386,8 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
         HostName = sshProfile.Host;
         UserName = sshProfile.User;
         Port = sshProfile.Port > 0 ? sshProfile.Port : 22;
+        Group = NormalizeGroup(sshProfile.GroupPath);
+        TagsText = FormatTags(sshProfile.Tags);
         Notes = sshProfile.Notes ?? string.Empty;
         AccentColor = sshProfile.AccentColor ?? string.Empty;
         IsFavorite = sshProfile.Tags.Any(tag => string.Equals(tag, "favorite", StringComparison.OrdinalIgnoreCase));
@@ -506,14 +525,39 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
         return !string.IsNullOrWhiteSpace(host) && int.TryParse(trimmed[(colon + 1)..].Trim(), out port);
     }
 
-    private static List<string> BuildTags(bool isFavorite)
+    private static string NormalizeGroup(string? value)
     {
-        if (!isFavorite)
+        string trimmed = value?.Trim() ?? string.Empty;
+        return string.IsNullOrWhiteSpace(trimmed) ? "General" : trimmed;
+    }
+
+    private static string FormatTags(IEnumerable<string>? tags)
+    {
+        return string.Join(", ", NormalizeGeneralTags(tags));
+    }
+
+    private static List<string> BuildTags(string? tagsText, bool isFavorite)
+    {
+        List<string> tags = NormalizeGeneralTags((tagsText ?? string.Empty)
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+
+        if (isFavorite)
         {
-            return new List<string>();
+            tags.Insert(0, "favorite");
         }
 
-        return new List<string> { "favorite" };
+        return tags;
+    }
+
+    private static List<string> NormalizeGeneralTags(IEnumerable<string>? tags)
+    {
+        return (tags ?? Array.Empty<string>())
+            .Where(tag => !string.IsNullOrWhiteSpace(tag))
+            .Select(tag => tag.Trim())
+            .Where(tag => !string.Equals(tag, "favorite", StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(tag => tag, StringComparer.OrdinalIgnoreCase)
+            .ToList();
     }
 
     private bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)

--- a/src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml
+++ b/src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml
@@ -29,7 +29,7 @@
     <Grid RowDefinitions="*,Auto,Auto" Margin="16">
         <TabControl>
             <TabItem Header="Basic">
-                <Grid Margin="0,10,0,0" ColumnDefinitions="170,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" RowSpacing="10">
+                <Grid Margin="0,10,0,0" ColumnDefinitions="170,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" RowSpacing="10">
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="Name" VerticalAlignment="Center" />
                     <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Name}" PlaceholderText="My server" />
 
@@ -51,11 +51,17 @@
                     <TextBlock Grid.Row="6" Grid.Column="0" Text="Remote shell" VerticalAlignment="Center" />
                     <ComboBox Grid.Row="6" Grid.Column="1" Name="RemoteShellKindCombo" SelectedItem="{Binding RemoteShellKind}" />
 
-                    <TextBlock Grid.Row="7" Grid.Column="0" Text="Favorite" VerticalAlignment="Center" />
-                    <CheckBox Grid.Row="7" Grid.Column="1" IsChecked="{Binding IsFavorite}" Content="Pin in Connections list" />
+                    <TextBlock Grid.Row="7" Grid.Column="0" Text="Group" VerticalAlignment="Center" />
+                    <TextBox Grid.Row="7" Grid.Column="1" Text="{Binding Group}" PlaceholderText="General" />
 
-                    <TextBlock Grid.Row="8" Grid.Column="0" Text="Notes" VerticalAlignment="Top" />
-                    <TextBox Grid.Row="8"
+                    <TextBlock Grid.Row="8" Grid.Column="0" Text="Tags" VerticalAlignment="Center" />
+                    <TextBox Grid.Row="8" Grid.Column="1" Text="{Binding TagsText}" PlaceholderText="prod, api, bastion" />
+
+                    <TextBlock Grid.Row="9" Grid.Column="0" Text="Favorite" VerticalAlignment="Center" />
+                    <CheckBox Grid.Row="9" Grid.Column="1" IsChecked="{Binding IsFavorite}" Content="Pin in Connections list" />
+
+                    <TextBlock Grid.Row="10" Grid.Column="0" Text="Notes" VerticalAlignment="Top" />
+                    <TextBox Grid.Row="10"
                              Grid.Column="1"
                              Text="{Binding Notes}"
                              AcceptsReturn="True"

--- a/tests/NovaTerminal.Tests/Core/MainWindowStartupTests.cs
+++ b/tests/NovaTerminal.Tests/Core/MainWindowStartupTests.cs
@@ -1,4 +1,9 @@
 using Avalonia.Headless.XUnit;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Threading;
+using NovaTerminal.Core;
+using System.Reflection;
 
 namespace NovaTerminal.Tests.Core;
 
@@ -10,5 +15,199 @@ public sealed class MainWindowStartupTests
         var window = new NovaTerminal.MainWindow();
 
         Assert.NotNull(window);
+    }
+
+    [AvaloniaFact]
+    public void MainWindow_UsesPaletteForSettingsAndOpenRecording_NotTitleBarButtons()
+    {
+        var window = new NovaTerminal.MainWindow();
+
+        Assert.Null(window.FindControl<Button>("SettingsBtn"));
+        Assert.Null(window.FindControl<Button>("BtnOpenRec"));
+
+        var commands = CommandRegistry.GetCommands();
+        Assert.Contains(commands, command => command.Title == "Settings");
+        Assert.Contains(commands, command => command.Title == "Open Recording...");
+        Assert.Contains(commands, command => command.Title == "Open Recordings Folder");
+    }
+
+    [AvaloniaFact]
+    public async Task ExecuteCommand_DefersActionUntilAfterPaletteCloses()
+    {
+        var window = new NovaTerminal.MainWindow();
+        var toggleMethod = typeof(NovaTerminal.MainWindow).GetMethod("ToggleCommandPalette", BindingFlags.Instance | BindingFlags.NonPublic);
+        var executeMethod = typeof(NovaTerminal.MainWindow).GetMethod("ExecuteCommand", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        toggleMethod!.Invoke(window, null);
+        var overlay = window.FindControl<Grid>("CommandPaletteOverlay");
+        Assert.NotNull(overlay);
+        Assert.True(overlay!.IsVisible);
+
+        bool actionRan = false;
+        bool overlayWasClosedWhenActionRan = false;
+        var command = new TerminalCommand
+        {
+            Title = "Test Deferred Command",
+            Category = "Test",
+            Action = () =>
+            {
+                actionRan = true;
+                overlayWasClosedWhenActionRan = !overlay.IsVisible;
+            }
+        };
+
+        executeMethod!.Invoke(window, new object[] { command });
+
+        Assert.False(actionRan);
+        Assert.False(overlay.IsVisible);
+
+        await Dispatcher.UIThread.InvokeAsync(() => { }, DispatcherPriority.Background);
+
+        Assert.True(actionRan);
+        Assert.True(overlayWasClosedWhenActionRan);
+    }
+
+    [AvaloniaFact]
+    public async Task OpenRecordingPaletteCommand_InvokesAsyncWindowHook()
+    {
+        var window = new RecordingCommandProbeWindow();
+        var executeMethod = typeof(NovaTerminal.MainWindow).GetMethod("ExecuteCommand", BindingFlags.Instance | BindingFlags.NonPublic);
+        var command = CommandRegistry.GetCommands().Single(c => c.Title == "Open Recording...");
+
+        executeMethod!.Invoke(window, new object[] { command });
+        await Dispatcher.UIThread.InvokeAsync(() => { }, DispatcherPriority.Background);
+
+        Assert.True(window.WasOpenRecordingInvoked);
+    }
+
+    [Theory]
+    [InlineData(true, @"C:\Users\behna\AppData\Local\NovaTerminal\recordings\nova.rec", @"C:\Users\behna\AppData\Local\NovaTerminal\recordings", "explorer.exe", "/select,")]
+    [InlineData(true, null, @"C:\Users\behna\AppData\Local\NovaTerminal\recordings", @"C:\Users\behna\AppData\Local\NovaTerminal\recordings", "")]
+    [InlineData(false, "/tmp/nova/recordings/nova.rec", "/tmp/nova/recordings", "/tmp/nova/recordings", "")]
+    public void ResolveRecordingRevealRequest_PrefersExactFileOnWindows(
+        bool isWindows,
+        string? filePath,
+        string recordingsDirectory,
+        string expectedFileName,
+        string expectedArgumentsPrefix)
+    {
+        var request = NovaTerminal.MainWindow.ResolveRecordingRevealRequest(filePath, recordingsDirectory, isWindows);
+
+        Assert.Equal(expectedFileName, request.FileName);
+        if (string.IsNullOrEmpty(expectedArgumentsPrefix))
+        {
+            Assert.True(string.IsNullOrEmpty(request.Arguments));
+        }
+        else
+        {
+            Assert.StartsWith(expectedArgumentsPrefix, request.Arguments, StringComparison.Ordinal);
+            Assert.Contains("nova.rec", request.Arguments, StringComparison.Ordinal);
+        }
+    }
+
+    [AvaloniaFact]
+    public void ApplyThemeToUi_LightTheme_UpdatesTabListAndIdleRecordForeground()
+    {
+        var window = new NovaTerminal.MainWindow();
+        var settingsField = typeof(NovaTerminal.MainWindow).GetField("_settings", BindingFlags.Instance | BindingFlags.NonPublic);
+        var applyThemeMethod = typeof(NovaTerminal.MainWindow).GetMethod("ApplyThemeToUI", BindingFlags.Instance | BindingFlags.NonPublic);
+        var settings = (TerminalSettings)settingsField!.GetValue(window)!;
+
+        settings.ThemeName = "Test Light";
+        settings.ActiveTheme = new TerminalTheme
+        {
+            Name = "Test Light",
+            Background = TermColor.FromRgb(245, 240, 225),
+            Foreground = TermColor.Black
+        };
+
+        applyThemeMethod!.Invoke(window, null);
+
+        var expected = Colors.Black;
+        var btnTabList = window.FindControl<Button>("BtnTabList");
+        var iconTabList = window.FindControl<PathIcon>("IconTabList");
+        var btnRecord = window.FindControl<Button>("BtnRecord");
+        var iconRecord = window.FindControl<PathIcon>("IconRecord");
+
+        Assert.NotNull(btnTabList);
+        Assert.NotNull(iconTabList);
+        Assert.NotNull(btnRecord);
+        Assert.NotNull(iconRecord);
+        Assert.Equal(expected, ((ISolidColorBrush)btnTabList!.Foreground!).Color);
+        Assert.Equal(expected, ((ISolidColorBrush)iconTabList!.Foreground!).Color);
+        Assert.Equal(expected, ((ISolidColorBrush)btnRecord!.Foreground!).Color);
+        Assert.Equal(expected, ((ISolidColorBrush)iconRecord!.Foreground!).Color);
+    }
+
+    [AvaloniaFact]
+    public void ApplyThemeToUi_LightTheme_UpdatesCommandPaletteSearchForeground()
+    {
+        var window = new NovaTerminal.MainWindow();
+        var settingsField = typeof(NovaTerminal.MainWindow).GetField("_settings", BindingFlags.Instance | BindingFlags.NonPublic);
+        var applyThemeMethod = typeof(NovaTerminal.MainWindow).GetMethod("ApplyThemeToUI", BindingFlags.Instance | BindingFlags.NonPublic);
+        var settings = (TerminalSettings)settingsField!.GetValue(window)!;
+
+        settings.ThemeName = "Test Light";
+        settings.ActiveTheme = new TerminalTheme
+        {
+            Name = "Test Light",
+            Background = TermColor.FromRgb(245, 240, 225),
+            Foreground = TermColor.Black
+        };
+
+        applyThemeMethod!.Invoke(window, null);
+
+        var searchBox = window.FindControl<TextBox>("CommandSearchBox");
+
+        Assert.NotNull(searchBox);
+        Assert.Equal(Colors.Black, ((ISolidColorBrush)searchBox!.Foreground!).Color);
+    }
+
+    [AvaloniaFact]
+    public void ApplySplitterVisualState_LightTheme_StrengthensLineOnHoverAndDrag()
+    {
+        var window = new NovaTerminal.MainWindow();
+        var settingsField = typeof(NovaTerminal.MainWindow).GetField("_settings", BindingFlags.Instance | BindingFlags.NonPublic);
+        var applySplitterVisualStateMethod = typeof(NovaTerminal.MainWindow).GetMethod("ApplySplitterVisualState", BindingFlags.Instance | BindingFlags.NonPublic);
+        var settings = (TerminalSettings)settingsField!.GetValue(window)!;
+
+        settings.ThemeName = "Test Light";
+        settings.ActiveTheme = new TerminalTheme
+        {
+            Name = "Test Light",
+            Background = TermColor.FromRgb(245, 240, 225),
+            Foreground = TermColor.Black
+        };
+
+        var splitter = new GridSplitter();
+
+        applySplitterVisualStateMethod!.Invoke(window, new object[] { splitter });
+        var idleColor = ((ISolidColorBrush)splitter.Background!).Color;
+
+        splitter.Classes.Add("splitter-hover");
+        applySplitterVisualStateMethod.Invoke(window, new object[] { splitter });
+        var hoverColor = ((ISolidColorBrush)splitter.Background!).Color;
+
+        splitter.Classes.Remove("splitter-hover");
+        splitter.Classes.Add("splitter-dragging");
+        applySplitterVisualStateMethod.Invoke(window, new object[] { splitter });
+        var draggingColor = ((ISolidColorBrush)splitter.Background!).Color;
+
+        Assert.Equal(Colors.Black.R, idleColor.R);
+        Assert.Equal(Colors.Black.G, idleColor.G);
+        Assert.Equal(Colors.Black.B, idleColor.B);
+        Assert.True(idleColor.A < hoverColor.A);
+        Assert.True(hoverColor.A < draggingColor.A);
+    }
+
+    private sealed class RecordingCommandProbeWindow : NovaTerminal.MainWindow
+    {
+        public bool WasOpenRecordingInvoked { get; private set; }
+
+        protected override Task ExecuteOpenRecordingCommandAsync()
+        {
+            WasOpenRecordingInvoked = true;
+            return Task.CompletedTask;
+        }
     }
 }

--- a/tests/NovaTerminal.Tests/Core/ReplayWindowTests.cs
+++ b/tests/NovaTerminal.Tests/Core/ReplayWindowTests.cs
@@ -1,0 +1,34 @@
+using NovaTerminal.UI.Replay;
+
+namespace NovaTerminal.Tests.Core;
+
+public sealed class ReplayWindowTests
+{
+    [Fact]
+    public void TryAttachDeveloperTools_SwallowsDuplicateAttachmentFailure()
+    {
+        bool invoked = false;
+
+        Exception? error = Record.Exception(() =>
+            ReplayWindow.TryAttachDeveloperToolsForTest(() =>
+            {
+                invoked = true;
+                throw new InvalidOperationException("Developer tools have already been attached. Multiple attachments are not supported.");
+            }));
+
+        Assert.True(invoked);
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void TryAttachDeveloperTools_RethrowsUnexpectedFailures()
+    {
+        Exception ex = Assert.Throws<InvalidOperationException>(() =>
+            ReplayWindow.TryAttachDeveloperToolsForTest(() =>
+            {
+                throw new InvalidOperationException("Some other failure");
+            }));
+
+        Assert.Equal("Some other failure", ex.Message);
+    }
+}

--- a/tests/NovaTerminal.Tests/Core/TabBehaviorTests.cs
+++ b/tests/NovaTerminal.Tests/Core/TabBehaviorTests.cs
@@ -2,6 +2,31 @@ namespace NovaTerminal.Tests.Core;
 
 public sealed class TabBehaviorTests
 {
+    [Theory]
+    [InlineData(false, false, "None")]
+    [InlineData(false, true, "OpenContextMenu")]
+    [InlineData(true, false, "CloseTab")]
+    [InlineData(true, true, "CloseTab")]
+    public void ResolveTabHeaderPointerAction_MapsButtonsToExpectedAction(
+        bool isMiddlePressed,
+        bool isRightPressed,
+        string expected)
+    {
+        var action = NovaTerminal.MainWindow.ResolveTabHeaderPointerAction(isMiddlePressed, isRightPressed);
+        Assert.Equal(expected, action.ToString());
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void ShouldDeferTabContextMenuOpen_DefersOnlyWhenTabWasNotSelected(
+        bool wasSelected,
+        bool expected)
+    {
+        bool shouldDefer = NovaTerminal.MainWindow.ShouldDeferTabContextMenuOpen(wasSelected);
+        Assert.Equal(expected, shouldDefer);
+    }
+
     [Fact]
     public void GetNextMruIndex_Forward_CyclesAcrossAllTabs()
     {
@@ -128,5 +153,37 @@ public sealed class TabBehaviorTests
 
         Assert.EndsWith("~ab12", value);
         Assert.Equal(12, value.Length);
+    }
+
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(true, true, true)]
+    public void ShouldSkipTabWhenClosingOthers_SkipsPinnedOrProtectedTabs(
+        bool isPinned,
+        bool isProtected,
+        bool expected)
+    {
+        bool skip = NovaTerminal.MainWindow.ShouldSkipTabWhenClosingOthers(isPinned, isProtected);
+        Assert.Equal(expected, skip);
+    }
+
+    [Theory]
+    [InlineData(false, "Pin Tab")]
+    [InlineData(true, "Unpin Tab")]
+    public void GetPinTabActionLabel_ReflectsPinnedState(bool isPinned, string expected)
+    {
+        string label = NovaTerminal.MainWindow.GetPinTabActionLabel(isPinned);
+        Assert.Equal(expected, label);
+    }
+
+    [Theory]
+    [InlineData(false, "Protect Tab")]
+    [InlineData(true, "Unprotect Tab")]
+    public void GetProtectTabActionLabel_ReflectsProtectedState(bool isProtected, string expected)
+    {
+        string label = NovaTerminal.MainWindow.GetProtectTabActionLabel(isProtected);
+        Assert.Equal(expected, label);
     }
 }

--- a/tests/NovaTerminal.Tests/Ssh/ConnectionManagerTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/ConnectionManagerTests.cs
@@ -8,6 +8,7 @@ using NovaTerminal.Controls;
 using NovaTerminal.Core;
 using NovaTerminal.Core.Ssh.Launch;
 using NovaTerminal.ViewModels.Ssh;
+using System.Collections.Specialized;
 using System.Linq;
 
 namespace NovaTerminal.Tests.Ssh;
@@ -83,6 +84,28 @@ public sealed class ConnectionManagerTests
     }
 
     [AvaloniaFact]
+    public void DetailPane_ShowsTypedIdentityFileAuthDescription()
+    {
+        var control = CreateMeasuredConnectionManager();
+        control.LoadProfiles(new[]
+        {
+            new TerminalProfile
+            {
+                Type = ConnectionType.SSH,
+                Name = "Prod",
+                SshHost = "prod.internal",
+                SshUser = "ops",
+                UseSshAgent = false,
+                IdentityFilePath = @"C:\keys\prod.pem"
+            }
+        });
+
+        SelectFirstRow(control);
+
+        Assert.Equal("identity file · C:\\keys\\prod.pem", FindControl<TextBlock>(control, "KvAuth").Text);
+    }
+
+    [AvaloniaFact]
     public void FavoriteFilter_RemovesRowImmediately_WhenFavoriteIsCleared()
     {
         var control = CreateMeasuredConnectionManager();
@@ -145,6 +168,32 @@ public sealed class ConnectionManagerTests
         var rows = FindControl<ListBox>(control, "ConnectionsList").ItemsSource!.Cast<SshProfileRowViewModel>().Select(row => row.Name).OrderBy(name => name).ToArray();
         Assert.Equal(new[] { "Alpha", "Beta" }, rows);
         Assert.Equal("2 connections", FindControl<TextBlock>(control, "ResultCountText").Text);
+    }
+
+    [AvaloniaFact]
+    public void SearchFilter_ReplacesVisibleRowsWithSingleResetNotification()
+    {
+        var control = CreateMeasuredConnectionManager();
+        control.LoadProfiles(new[]
+        {
+            CreateSshProfile("Alpha", false),
+            CreateSshProfile("Beta", false),
+            CreateSshProfile("Gamma", false)
+        });
+
+        var list = FindControl<ListBox>(control, "ConnectionsList");
+        var notifications = new List<NotifyCollectionChangedAction>();
+        ((INotifyCollectionChanged)list.ItemsSource!).CollectionChanged += (_, args) => notifications.Add(args.Action);
+
+        control.SearchInput.Text = "Alpha";
+        var viewModelField = typeof(ConnectionManager).GetField("_viewModel", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        var applyFiltersMethod = typeof(ConnectionManager).GetMethod("ApplyFilters", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        var viewModel = (SshManagerViewModel)viewModelField!.GetValue(control)!;
+        viewModel.SearchText = "Alpha";
+        applyFiltersMethod!.Invoke(control, null);
+
+        Assert.Equal(new[] { NotifyCollectionChangedAction.Reset }, notifications);
+        Assert.Equal(1, GetListItemCount(control));
     }
 
     [AvaloniaFact]

--- a/tests/NovaTerminal.Tests/Ssh/ConnectionManagerTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/ConnectionManagerTests.cs
@@ -1,10 +1,13 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Headless.XUnit;
 using Avalonia.Interactivity;
 using Avalonia.VisualTree;
 using NovaTerminal.Controls;
 using NovaTerminal.Core;
+using NovaTerminal.Core.Ssh.Launch;
+using NovaTerminal.ViewModels.Ssh;
 using System.Linq;
 
 namespace NovaTerminal.Tests.Ssh;
@@ -29,28 +32,9 @@ public sealed class ConnectionManagerTests
     [AvaloniaFact]
     public void SecondaryActionButtons_ReserveSquareHitTargets()
     {
-        var control = new ConnectionManager();
-        var window = new Window
-        {
-            Width = 800,
-            Height = 500,
-            Content = control
-        };
-
-        control.LoadProfiles(new[]
-        {
-            new TerminalProfile
-            {
-                Type = ConnectionType.SSH,
-                Name = "Prod",
-                SshHost = "prod.internal",
-                SshUser = "ops",
-                Tags = new() { "favorite" }
-            }
-        });
-
-        window.Measure(new Size(800, 500));
-        window.Arrange(new Rect(0, 0, 800, 500));
+        var control = CreateMeasuredConnectionManager(800, 500);
+        control.LoadProfiles(new[] { CreateSshProfile("Prod", favorite: true) });
+        SelectFirstRow(control);
 
         string[] actionTips =
         {
@@ -68,8 +52,220 @@ public sealed class ConnectionManagerTests
         Assert.Equal(4, actionButtons.Count);
         Assert.All(actionButtons, button =>
         {
-            Assert.True(button.Bounds.Width >= 30, $"Expected '{ToolTip.GetTip(button)}' width >= 30 but was {button.Bounds.Width}.");
-            Assert.True(button.Bounds.Height >= 30, $"Expected '{ToolTip.GetTip(button)}' height >= 30 but was {button.Bounds.Height}.");
+            Assert.True(button.Width >= 30, $"Expected '{ToolTip.GetTip(button)}' width >= 30 but was {button.Width}.");
+            Assert.True(button.Height >= 30, $"Expected '{ToolTip.GetTip(button)}' height >= 30 but was {button.Height}.");
         });
+    }
+
+    [AvaloniaFact]
+    public void DetailsAction_RaisesConnectionDetailsRequested_ForSelectedRow()
+    {
+        var control = CreateMeasuredConnectionManager();
+        control.LoadProfiles(new[] { CreateSshProfile("Prod", favorite: true) });
+        SelectFirstRow(control);
+
+        TerminalProfile? receivedProfile = null;
+        SshDiagnosticsLevel receivedLevel = SshDiagnosticsLevel.None;
+        control.OnConnectionDetailsRequested += (profile, level) =>
+        {
+            receivedProfile = profile;
+            receivedLevel = level;
+        };
+
+        var detailsButton = FindButtonByToolTip(control, "Connection details");
+        Assert.NotNull(detailsButton);
+
+        detailsButton!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+        Assert.NotNull(receivedProfile);
+        Assert.Equal("Prod", receivedProfile!.Name);
+        Assert.Equal(SshDiagnosticsLevel.None, receivedLevel);
+    }
+
+    [AvaloniaFact]
+    public void FavoriteFilter_RemovesRowImmediately_WhenFavoriteIsCleared()
+    {
+        var control = CreateMeasuredConnectionManager();
+        control.LoadProfiles(new[]
+        {
+            CreateSshProfile("Prod", favorite: true),
+            CreateSshProfile("Stage", favorite: false)
+        });
+
+        FindControl<Button>(control, "BtnGroupFav").RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+        Assert.Equal(1, GetListItemCount(control));
+
+        SelectFirstRow(control);
+        FindButtonByToolTip(control, "Toggle favorite")!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+        Assert.Equal(0, GetListItemCount(control));
+        Assert.Equal("0 connections", FindControl<TextBlock>(control, "ResultCountText").Text);
+    }
+
+    [AvaloniaFact]
+    public void TagSection_ShowsNonFavoriteTagsWithAggregatedCounts()
+    {
+        var control = CreateMeasuredConnectionManager();
+        control.LoadProfiles(new[]
+        {
+            CreateSshProfile("Alpha", true, "hetzner", "vw"),
+            CreateSshProfile("Beta", false, "vw"),
+            CreateSshProfile("Gamma", false, "db")
+        });
+        RefreshLayout(control);
+
+        var tagsList = FindControl<ItemsControl>(control, "TagsList");
+        var tags = tagsList.ItemsSource?.Cast<TagNode>().OrderBy(node => node.Name, System.StringComparer.OrdinalIgnoreCase).ToList();
+
+        Assert.NotNull(tags);
+        Assert.Equal(3, tags!.Count);
+        Assert.DoesNotContain(tags, tag => string.Equals(tag.Name, "favorite", System.StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(("db", 1), (tags[0].Name, tags[0].Count));
+        Assert.Equal(("hetzner", 1), (tags[1].Name, tags[1].Count));
+        Assert.Equal(("vw", 2), (tags[2].Name, tags[2].Count));
+    }
+
+    [AvaloniaFact]
+    public void TagFilter_MultiSelectUsesAnyMatching()
+    {
+        var control = CreateMeasuredConnectionManager();
+        control.LoadProfiles(new[]
+        {
+            CreateSshProfile("Alpha", false, "hetzner"),
+            CreateSshProfile("Beta", false, "vw"),
+            CreateSshProfile("Gamma", false, "db")
+        });
+        RefreshLayout(control);
+
+        InvokeTagToggle(control, "hetzner", isChecked: true);
+        Assert.Equal(1, GetListItemCount(control));
+
+        InvokeTagToggle(control, "vw", isChecked: true);
+
+        var rows = FindControl<ListBox>(control, "ConnectionsList").ItemsSource!.Cast<SshProfileRowViewModel>().Select(row => row.Name).OrderBy(name => name).ToArray();
+        Assert.Equal(new[] { "Alpha", "Beta" }, rows);
+        Assert.Equal("2 connections", FindControl<TextBlock>(control, "ResultCountText").Text);
+    }
+
+    [AvaloniaFact]
+    public void LaunchPreview_ReflectsSelectedDiagnosticsLevel()
+    {
+        var control = CreateMeasuredConnectionManager();
+        control.LoadProfiles(new[] { CreateSshProfile("Prod", favorite: false) });
+        SelectFirstRow(control);
+
+        var combo = FindControl<ComboBox>(control, "DiagnosticsCombo");
+        combo.SelectedItem = SshDiagnosticsLevel.VeryVerbose;
+        RefreshLayout(control);
+
+        string preview = FindControl<TextBlock>(control, "LaunchPreviewText").Text ?? string.Empty;
+
+        Assert.Contains("Selected level: Very verbose", preview, System.StringComparison.Ordinal);
+        Assert.Contains("SSH flags added: -vv", preview, System.StringComparison.Ordinal);
+        Assert.Contains("ops@prod.internal:22", preview, System.StringComparison.Ordinal);
+    }
+
+    [AvaloniaFact]
+    public void ConnectionManager_CanArrangeWithinSmallOverlay()
+    {
+        var control = new ConnectionManager();
+        control.Measure(new Size(760, 520));
+        control.Arrange(new Rect(0, 0, 760, 520));
+
+        Assert.True(control.Bounds.Width <= 760, $"Expected width <= 760 but was {control.Bounds.Width}.");
+        Assert.True(control.Bounds.Height <= 520, $"Expected height <= 520 but was {control.Bounds.Height}.");
+    }
+
+    private static ConnectionManager CreateMeasuredConnectionManager(double width = 1080, double height = 720)
+    {
+        var control = new ConnectionManager();
+        var host = new Grid();
+        host.Children.Add(control);
+        var window = new Window
+        {
+            Width = width,
+            Height = height,
+            Content = host
+        };
+
+        window.Measure(new Size(width, height));
+        window.Arrange(new Rect(0, 0, width, height));
+        return control;
+    }
+
+    private static TerminalProfile CreateSshProfile(string name, bool favorite, params string[] tags)
+    {
+        var allTags = tags.ToList();
+        if (favorite)
+        {
+            allTags.Insert(0, "favorite");
+        }
+
+        return new TerminalProfile
+        {
+            Type = ConnectionType.SSH,
+            Name = name,
+            SshHost = $"{name.ToLowerInvariant()}.internal",
+            SshUser = "ops",
+            Tags = allTags
+        };
+    }
+
+    private static T FindControl<T>(ConnectionManager control, string name) where T : Control
+    {
+        return control.FindControl<T>(name)!;
+    }
+
+    private static void SelectFirstRow(ConnectionManager control)
+    {
+        var list = FindControl<ListBox>(control, "ConnectionsList");
+        list.SelectedIndex = 0;
+        if (control.Bounds.Width > 0 && control.Bounds.Height > 0)
+        {
+            RefreshLayout(control);
+        }
+    }
+
+    private static void RefreshLayout(ConnectionManager control)
+    {
+        if (control.Bounds.Width <= 0 || control.Bounds.Height <= 0)
+        {
+            return;
+        }
+
+        control.Measure(control.Bounds.Size);
+        control.Arrange(new Rect(control.Bounds.Size));
+    }
+
+    private static int GetListItemCount(ConnectionManager control)
+    {
+        var list = FindControl<ListBox>(control, "ConnectionsList");
+        return list.ItemsSource?.Cast<object>().Count() ?? 0;
+    }
+
+    private static void InvokeTagToggle(ConnectionManager control, string tag, bool isChecked)
+    {
+        var handler = typeof(ConnectionManager).GetMethod("OnTagClick", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(handler);
+
+        var toggle = new ToggleButton
+        {
+            Tag = tag,
+            IsChecked = isChecked,
+            DataContext = new TagNode
+            {
+                Name = tag,
+                IsSelected = isChecked
+            }
+        };
+
+        handler!.Invoke(control, new object?[] { toggle, new RoutedEventArgs(ToggleButton.ClickEvent) });
+    }
+
+    private static Button? FindButtonByToolTip(ConnectionManager control, string tip)
+    {
+        return control.GetVisualDescendants()
+            .OfType<Button>()
+            .FirstOrDefault(button => string.Equals(ToolTip.GetTip(button) as string, tip, System.StringComparison.Ordinal));
     }
 }

--- a/tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/NewSshConnectionViewModelTests.cs
@@ -114,6 +114,24 @@ public sealed class NewSshConnectionViewModelTests
     }
 
     [Fact]
+    public void ToSshProfile_NormalizesGroupAndTagsAlongsideFavorite()
+    {
+        var vm = new NewSshConnectionViewModel
+        {
+            Name = "Prod",
+            HostName = "prod.internal",
+            Group = "  Prod / API  ",
+            TagsText = " zebra, api, favorite, Api, critical ",
+            IsFavorite = true
+        };
+
+        SshProfile profile = vm.ToSshProfile();
+
+        Assert.Equal("Prod / API", profile.GroupPath);
+        Assert.Equal(new[] { "favorite", "api", "critical", "zebra" }, profile.Tags);
+    }
+
+    [Fact]
     public void ToSshProfile_PreservesZeroControlPersistWhenMuxEnabled()
     {
         var vm = new NewSshConnectionViewModel
@@ -225,6 +243,25 @@ public sealed class NewSshConnectionViewModelTests
         roundTripped.ApplySshProfile(profile);
 
         Assert.Equal(RemoteShellKind.Bash, roundTripped.RemoteShellKind);
+    }
+
+    [Fact]
+    public void ApplySshProfile_ExposesEditableGroupAndNonFavoriteTags()
+    {
+        var vm = new NewSshConnectionViewModel();
+        var profile = new SshProfile
+        {
+            Name = "Prod",
+            Host = "prod.internal",
+            GroupPath = "Prod/API",
+            Tags = new List<string> { "favorite", "api", "critical" }
+        };
+
+        vm.ApplySshProfile(profile);
+
+        Assert.Equal("Prod/API", vm.Group);
+        Assert.Equal("api, critical", vm.TagsText);
+        Assert.True(vm.IsFavorite);
     }
 
     [Fact]

--- a/tests/NovaTerminal.Tests/Ssh/RemotePathAutocompleteServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/RemotePathAutocompleteServiceTests.cs
@@ -213,21 +213,14 @@ public sealed class RemotePathAutocompleteServiceTests
             CreateSshService(profileId),
             _ => null);
 
-        Task<IReadOnlyList<RemotePathSuggestion>>? returnedTask = null;
-        Task invocation = Task.Run(() =>
-        {
-            returnedTask = service.GetSuggestionsAsync(
-                profileId,
-                sessionId,
-                "~/cod",
-                CancellationToken.None);
-        });
+        Task<IReadOnlyList<RemotePathSuggestion>> returnedTask = service.GetSuggestionsAsync(
+            profileId,
+            sessionId,
+            "~/cod",
+            CancellationToken.None);
 
         Assert.True(interop.Started.Wait(TimeSpan.FromSeconds(10)));
-        Task completed = await Task.WhenAny(invocation, Task.Delay(TimeSpan.FromSeconds(10)));
-        Assert.Same(invocation, completed);
-        Assert.NotNull(returnedTask);
-        Assert.False(returnedTask!.IsCompleted);
+        Assert.False(returnedTask.IsCompleted);
 
         interop.Release.Set();
 

--- a/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/SshConnectionServiceTests.cs
@@ -207,6 +207,38 @@ public sealed class SshConnectionServiceTests
     }
 
     [Fact]
+    public void SaveProfile_PersistsEditedGroupAndGeneralTags()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string path = Path.Combine(tempRoot, "profiles.json");
+            var store = new JsonSshProfileStore(path);
+            var service = new SshConnectionService(store);
+
+            var vm = new NewSshConnectionViewModel
+            {
+                Name = "Prod",
+                HostName = "prod.internal",
+                Group = "  Work / Prod  ",
+                TagsText = " db, critical, db ",
+                IsFavorite = true
+            };
+
+            SshProfile saved = service.SaveProfile(vm);
+            SshProfile? persisted = store.GetProfile(saved.Id);
+
+            Assert.NotNull(persisted);
+            Assert.Equal("Work / Prod", persisted!.GroupPath);
+            Assert.Equal(new[] { "critical", "db", "favorite" }, persisted.Tags);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
     public void SaveProfile_DoesNotPersistRememberPasswordPreferenceForNewProfiles()
     {
         string tempRoot = CreateTempDirectory();
@@ -340,6 +372,39 @@ public sealed class SshConnectionServiceTests
             NewSshConnectionViewModel editorVm = service.CreateEditorViewModel(runtimeProfile);
 
             Assert.False(editorVm.RememberPasswordInVault);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CreateEditorViewModel_LoadsStoredGroupAndGeneralTags()
+    {
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string path = Path.Combine(tempRoot, "profiles.json");
+            var store = new JsonSshProfileStore(path);
+            var service = new SshConnectionService(store);
+            var profileId = Guid.Parse("0c4f1473-8b85-4af6-a312-483e0d86a166");
+
+            store.SaveProfile(new SshProfile
+            {
+                Id = profileId,
+                Name = "Prod",
+                Host = "prod.internal",
+                GroupPath = "Prod/API",
+                Tags = new List<string> { "favorite", "api", "critical" }
+            });
+
+            TerminalProfile runtimeProfile = service.GetConnectionProfile(profileId)!;
+            NewSshConnectionViewModel editorVm = service.CreateEditorViewModel(runtimeProfile);
+
+            Assert.Equal("Prod/API", editorVm.Group);
+            Assert.Equal("api, critical", editorVm.TagsText);
+            Assert.True(editorVm.IsFavorite);
         }
         finally
         {

--- a/tests/NovaTerminal.Tests/Ssh/TerminalPaneRecordingTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/TerminalPaneRecordingTests.cs
@@ -1,0 +1,128 @@
+using System.Reflection;
+using Avalonia.Headless.XUnit;
+using NovaTerminal.Controls;
+using NovaTerminal.Core;
+
+namespace NovaTerminal.Tests.Ssh;
+
+public sealed class TerminalPaneRecordingTests
+{
+    [AvaloniaFact]
+    public void ToggleRecording_StartsAndStopsWithoutWritingTerminalText_AndPublishesMetadata()
+    {
+        var pane = new TerminalPane(new TerminalProfile
+        {
+            Name = "PowerShell",
+            Type = ConnectionType.Local,
+            Command = "pwsh.exe"
+        });
+
+        try
+        {
+            var session = new StubTerminalSession();
+            SetSessionForTest(pane, session);
+
+            string before = GetVisiblePlainText(pane.Buffer!);
+            var notifications = new List<RecordingNotificationEventArgs>();
+            pane.RecordingNotification += notifications.Add;
+
+            pane.ToggleRecording();
+            pane.ToggleRecording();
+
+            string after = GetVisiblePlainText(pane.Buffer!);
+
+            Assert.Equal(before, after);
+            Assert.Equal(2, notifications.Count);
+
+            var started = notifications[0];
+            Assert.Equal(RecordingNotificationKind.Started, started.Kind);
+            Assert.True(started.IsRecording);
+            Assert.Equal(session.StartedPath, started.FilePath);
+            Assert.StartsWith(AppPaths.RecordingsDirectory, started.FilePath!, StringComparison.OrdinalIgnoreCase);
+
+            var stopped = notifications[1];
+            Assert.Equal(RecordingNotificationKind.Stopped, stopped.Kind);
+            Assert.False(stopped.IsRecording);
+            Assert.Equal(session.StartedPath, stopped.FilePath);
+            Assert.Equal(AppPaths.RecordingsDirectory, stopped.RecordingsDirectory);
+        }
+        finally
+        {
+            pane.Dispose();
+        }
+    }
+
+    private static void SetSessionForTest(TerminalPane pane, ITerminalSession session)
+    {
+        var property = typeof(TerminalPane).GetProperty("Session", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+        property!.SetValue(pane, session);
+    }
+
+    private static string GetVisiblePlainText(TerminalBuffer buffer)
+    {
+        var field = typeof(TerminalBuffer).GetField("_viewport", BindingFlags.NonPublic | BindingFlags.Instance);
+        var viewport = (TerminalRow[])field!.GetValue(buffer)!;
+        return string.Join("\n", viewport.Select(GetRowText)).TrimEnd();
+    }
+
+    private static string GetRowText(TerminalRow row)
+    {
+        char[] chars = row.Cells.Select(c => c.Character == '\0' ? ' ' : c.Character).ToArray();
+        return new string(chars).TrimEnd();
+    }
+
+    private sealed class StubTerminalSession : ITerminalSession
+    {
+        public Guid Id => Guid.NewGuid();
+        public string ShellCommand => "stub";
+        public string? ShellArguments => null;
+        public bool IsProcessRunning => true;
+        public bool HasActiveChildProcesses => false;
+        public int? ExitCode => null;
+        public bool IsRecording { get; private set; }
+        public string? StartedPath { get; private set; }
+
+        public event Action<string>? OnOutputReceived
+        {
+            add { }
+            remove { }
+        }
+
+        public event Action<int>? OnExit
+        {
+            add { }
+            remove { }
+        }
+
+        public void SendInput(string input)
+        {
+        }
+
+        public void Resize(int cols, int rows)
+        {
+        }
+
+        public void StartRecording(string filePath)
+        {
+            StartedPath = filePath;
+            IsRecording = true;
+        }
+
+        public void StopRecording()
+        {
+            IsRecording = false;
+        }
+
+        public void AttachBuffer(TerminalBuffer buffer)
+        {
+        }
+
+        public void TakeSnapshot()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tests/NovaTerminal.Tests/Ssh/TerminalPaneRecordingTests.cs
+++ b/tests/NovaTerminal.Tests/Ssh/TerminalPaneRecordingTests.cs
@@ -39,6 +39,7 @@ public sealed class TerminalPaneRecordingTests
             Assert.True(started.IsRecording);
             Assert.Equal(session.StartedPath, started.FilePath);
             Assert.StartsWith(AppPaths.RecordingsDirectory, started.FilePath!, StringComparison.OrdinalIgnoreCase);
+            Assert.Matches(@"^nova_rec_\d{8}_\d{6}_[0-9a-f]{6}\.rec$", Path.GetFileName(started.FilePath));
 
             var stopped = notifications[1];
             Assert.Equal(RecordingNotificationKind.Stopped, stopped.Kind);
@@ -50,6 +51,21 @@ public sealed class TerminalPaneRecordingTests
         {
             pane.Dispose();
         }
+    }
+
+    [Fact]
+    public void BuildRecordingFileName_AppendsStableUniqueSuffix()
+    {
+        string first = TerminalPane.BuildRecordingFileName(
+            new DateTime(2026, 5, 22, 10, 30, 45),
+            "a1b2c3d4");
+        string second = TerminalPane.BuildRecordingFileName(
+            new DateTime(2026, 5, 22, 10, 30, 45),
+            "f0e1d2c3");
+
+        Assert.Equal("nova_rec_20260522_103045_a1b2c3.rec", first);
+        Assert.Equal("nova_rec_20260522_103045_f0e1d2.rec", second);
+        Assert.NotEqual(first, second);
     }
 
     private static void SetSessionForTest(TerminalPane pane, ITerminalSession session)


### PR DESCRIPTION
## Summary
- restore and polish the settings and connection manager flows, including live filtering, group/tag editing, tag filters, launch preview, theming, and responsive layout fixes
- improve main window interaction UX with tab context menus, palette/title-bar cleanup, recording toasts and replay fixes, and light-theme consistency fixes
- make pane splitters more readable during hover and resize, and add focused regressions for the new UI behavior

## Test Plan
- dotnet test tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj --filter "FullyQualifiedName~NovaTerminal.Tests.Core.MainWindowStartupTests|FullyQualifiedName~NovaTerminal.Tests.Core.ReplayWindowTests|FullyQualifiedName~NovaTerminal.Tests.Core.MainWindowTransferFlowTests|FullyQualifiedName~NovaTerminal.Tests.Core.TabBehaviorTests|FullyQualifiedName~NovaTerminal.Tests.Ssh.TerminalPaneRecordingTests|FullyQualifiedName~NovaTerminal.Tests.Ssh.TerminalPaneSshDisconnectTests|FullyQualifiedName~NovaTerminal.Tests.Ssh.ConnectionManagerTests|FullyQualifiedName~NovaTerminal.Tests.Ssh.SshManagerViewModelTests|FullyQualifiedName~NovaTerminal.Tests.Ssh.NewSshConnectionViewModelTests|FullyQualifiedName~NovaTerminal.Tests.Ssh.SshConnectionServiceTests" --no-build --artifacts-path D:\projects\nova2\.artifacts-codex