### PR TITLE
[codex] Improve startup instrumentation and critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,7 @@ jobs:
 
       - name: Cache .NET SDK
         uses: actions/cache@v4
+        continue-on-error: true
         with:
           path: ~/.dotnet
           key: dotnet-sdk-${{ runner.os }}-10.0.300

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,22 @@ jobs:
           cache-dependency-path: "**/*.csproj"
 
       - name: Download build artifact
+        id: download_golden_build_artifact
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: dotnet-build-windows-latest
+          path: tests
+
+      - name: Reset partial artifact download
+        if: steps.download_golden_build_artifact.outcome == 'failure'
+        shell: pwsh
+        run: |
+          Remove-Item tests\NovaTerminal.Tests\bin -Recurse -Force -ErrorAction SilentlyContinue
+          Remove-Item tests\NovaTerminal.Core.Tests\bin -Recurse -Force -ErrorAction SilentlyContinue
+
+      - name: Download build artifact (retry)
+        if: steps.download_golden_build_artifact.outcome == 'failure'
         uses: actions/download-artifact@v4
         with:
           name: dotnet-build-windows-latest

--- a/docs/performance/startup-measurement.md
+++ b/docs/performance/startup-measurement.md
@@ -1,0 +1,41 @@
+# Startup Measurement
+
+This repo includes a repeatable startup harness for before/after comparisons.
+
+## What It Measures
+
+- `WindowOpened`
+- `FirstTerminalReady`
+- `SessionRestoreComplete`
+- `DeferredWorkComplete`
+- `BackgroundRestoreComplete`
+
+## Protocol
+
+1. Build the app in `Release`.
+2. Run the baseline harness before behavioral startup changes.
+3. Run the candidate harness after the startup changes.
+4. Generate a comparison report from the two artifact folders.
+
+The harness launches NovaTerminal with:
+
+- `NOVATERM_STARTUP_METRICS=1`
+- `NOVATERM_STARTUP_METRICS_OUT=<artifact jsonl path>`
+- `NOVATERM_APPDATA_ROOT=<isolated measurement appdata path>`
+
+The isolated app-data root prevents the measurement run from mutating the normal user profile. The harness also seeds a fixed restored session so restore timing is measured against the same startup workload for baseline and candidate runs.
+
+## Commands
+
+```powershell
+dotnet build NovaTerminal.sln -c Release
+pwsh -File tests/tools/measure_startup.ps1 -Configuration Release -Label baseline -Iterations 10
+pwsh -File tests/tools/summarize_startup_metrics.ps1 -InputPath artifacts-codex/startup/baseline
+pwsh -File tests/tools/measure_startup.ps1 -Configuration Release -Label candidate -Iterations 10
+pwsh -File tests/tools/summarize_startup_metrics.ps1 -Baseline artifacts-codex/startup/baseline -Candidate artifacts-codex/startup/candidate -Out artifacts-codex/startup-performance-report.md
+```
+
+## Artifacts
+
+- Per-launch metrics: `artifacts-codex/startup/<label>/startup_metrics.jsonl`
+- Comparison report: `artifacts-codex/startup-performance-report.md`

--- a/src/NovaTerminal.App/App.axaml.cs
+++ b/src/NovaTerminal.App/App.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using NovaTerminal.Core;
 
 namespace NovaTerminal;
 
@@ -16,6 +17,7 @@ public partial class App : Application
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             desktop.MainWindow = new MainWindow();
+            StartupPerformanceTracker.Current?.TryMark(StartupPhase.MainWindowConstructed);
 
             // Enable DevTools for debugging - Press F12 to open
 #if DEBUG

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml
@@ -132,9 +132,9 @@
                     </Grid>
                 </Grid>
 
-                <controls:RemoteFilesSidebar x:Name="RemoteFilesSidebarHost"
-                                             Grid.Column="1"
-                                             IsVisible="False" />
+                <ContentControl x:Name="RemoteFilesSidebarPresenter"
+                                Grid.Column="1"
+                                IsVisible="False" />
             </Grid>
 
             <!-- Port Forwarding Status Bar -->

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -265,11 +265,13 @@ namespace NovaTerminal.Controls
         public TerminalPane()
         {
             InitializeComponent();
+            StartupPerformanceTracker.Current?.TryMarkCheckpoint("TerminalPane.Ctor.AfterInitializeComponent");
             _sshDiagnosticsLevel = SshDiagnosticsLevel.None;
             Buffer = new TerminalBuffer(80, 24);
             TermView.SetBuffer(Buffer);
             TermView.Ready += (c, r) => InitializeSession(null, null, c, r);
             SetupCommon(null);
+            StartupPerformanceTracker.Current?.TryMarkCheckpoint("TerminalPane.Ctor.AfterSetupCommon");
         }
 
         public TerminalPane(string shell)
@@ -280,11 +282,13 @@ namespace NovaTerminal.Controls
         internal TerminalPane(string shell, TerminalSettings? initialSettings)
         {
             InitializeComponent();
+            StartupPerformanceTracker.Current?.TryMarkCheckpoint("TerminalPane.Ctor.AfterInitializeComponent");
             _sshDiagnosticsLevel = SshDiagnosticsLevel.None;
             Buffer = new TerminalBuffer(80, 24);
             TermView.SetBuffer(Buffer);
             TermView.Ready += (c, r) => InitializeSession(shell, null, c, r);
             SetupCommon(initialSettings);
+            StartupPerformanceTracker.Current?.TryMarkCheckpoint("TerminalPane.Ctor.AfterSetupCommon");
         }
 
         public TerminalPane(string shell, string args)
@@ -295,11 +299,13 @@ namespace NovaTerminal.Controls
         internal TerminalPane(string shell, string args, TerminalSettings? initialSettings)
         {
             InitializeComponent();
+            StartupPerformanceTracker.Current?.TryMarkCheckpoint("TerminalPane.Ctor.AfterInitializeComponent");
             _sshDiagnosticsLevel = SshDiagnosticsLevel.None;
             Buffer = new TerminalBuffer(80, 24);
             TermView.SetBuffer(Buffer);
             TermView.Ready += (c, r) => InitializeSession(shell, null, c, r, args);
             SetupCommon(initialSettings);
+            StartupPerformanceTracker.Current?.TryMarkCheckpoint("TerminalPane.Ctor.AfterSetupCommon");
         }
 
         public TerminalPane(TerminalProfile profile)
@@ -321,12 +327,14 @@ namespace NovaTerminal.Controls
         {
             Profile = profile;
             InitializeComponent();
+            StartupPerformanceTracker.Current?.TryMarkCheckpoint("TerminalPane.Ctor.AfterInitializeComponent");
             _sshDiagnosticsLevel = sshDiagnosticsLevel;
             Buffer = new TerminalBuffer(80, 24);
             TermView.SetBuffer(Buffer);
             TermView.ShellOverride = profile.ShellOverride;
             TermView.Ready += (c, r) => InitializeSession(profile.Command, profile, c, r);
             SetupCommon(useInitialSettings ? initialSettings : null);
+            StartupPerformanceTracker.Current?.TryMarkCheckpoint("TerminalPane.Ctor.AfterSetupCommon");
         }
 
         private void SetupCommon(TerminalSettings? initialSettings)

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -111,6 +111,7 @@ namespace NovaTerminal.Controls
         private readonly CommandAssistPopupViewModel _hiddenCommandAssistPopupViewModel = new(new ObservableCollection<CommandAssistSuggestionItemViewModel>()) { IsVisible = false };
         private IRemoteDirectoryBrowserService _remoteDirectoryBrowserService = new RemoteDirectoryBrowserService();
         private RemoteFilesSidebarViewModel? _remoteFilesSidebarViewModel;
+        private RemoteFilesSidebar? _remoteFilesSidebarHost;
         private bool _isRemoteFilesSidebarTestServiceConfigured;
         private string? _currentRecordingFilePath;
         private const double CommandAssistBubbleWidth = 420;
@@ -268,35 +269,55 @@ namespace NovaTerminal.Controls
             Buffer = new TerminalBuffer(80, 24);
             TermView.SetBuffer(Buffer);
             TermView.Ready += (c, r) => InitializeSession(null, null, c, r);
-            SetupCommon();
+            SetupCommon(null);
         }
 
         public TerminalPane(string shell)
+            : this(shell, initialSettings: null)
+        {
+        }
+
+        internal TerminalPane(string shell, TerminalSettings? initialSettings)
         {
             InitializeComponent();
             _sshDiagnosticsLevel = SshDiagnosticsLevel.None;
             Buffer = new TerminalBuffer(80, 24);
             TermView.SetBuffer(Buffer);
             TermView.Ready += (c, r) => InitializeSession(shell, null, c, r);
-            SetupCommon();
+            SetupCommon(initialSettings);
         }
 
         public TerminalPane(string shell, string args)
+            : this(shell, args, initialSettings: null)
+        {
+        }
+
+        internal TerminalPane(string shell, string args, TerminalSettings? initialSettings)
         {
             InitializeComponent();
             _sshDiagnosticsLevel = SshDiagnosticsLevel.None;
             Buffer = new TerminalBuffer(80, 24);
             TermView.SetBuffer(Buffer);
             TermView.Ready += (c, r) => InitializeSession(shell, null, c, r, args);
-            SetupCommon();
+            SetupCommon(initialSettings);
         }
 
         public TerminalPane(TerminalProfile profile)
-            : this(profile, SshDiagnosticsLevel.None)
+            : this(profile, initialSettings: null, SshDiagnosticsLevel.None, useInitialSettings: false)
         {
         }
 
         public TerminalPane(TerminalProfile profile, SshDiagnosticsLevel sshDiagnosticsLevel)
+            : this(profile, initialSettings: null, sshDiagnosticsLevel, useInitialSettings: false)
+        {
+        }
+
+        internal TerminalPane(TerminalProfile profile, TerminalSettings initialSettings, SshDiagnosticsLevel sshDiagnosticsLevel = SshDiagnosticsLevel.None)
+            : this(profile, initialSettings, sshDiagnosticsLevel, useInitialSettings: true)
+        {
+        }
+
+        private TerminalPane(TerminalProfile profile, TerminalSettings? initialSettings, SshDiagnosticsLevel sshDiagnosticsLevel, bool useInitialSettings)
         {
             Profile = profile;
             InitializeComponent();
@@ -305,10 +326,10 @@ namespace NovaTerminal.Controls
             TermView.SetBuffer(Buffer);
             TermView.ShellOverride = profile.ShellOverride;
             TermView.Ready += (c, r) => InitializeSession(profile.Command, profile, c, r);
-            SetupCommon();
+            SetupCommon(useInitialSettings ? initialSettings : null);
         }
 
-        private void SetupCommon()
+        private void SetupCommon(TerminalSettings? initialSettings)
         {
             TermView.KeyDownInterceptor = TryHandleCommandAssistKey;
             TermView.TextInput += (_, e) =>
@@ -373,10 +394,36 @@ namespace NovaTerminal.Controls
             };
             TermView.CommandAssistAnchorHintChanged += () => UpdateCommandAssistOverlayPlacement();
             SizeChanged += (_, _) => UpdateCommandAssistOverlayPlacement();
+            TermView.TextInputObserved += text =>
+            {
+                if (EnsureCommandAssistInitialized())
+                {
+                    _commandAssistController?.HandleTextInput(text);
+                }
+            };
+            TermView.BackspaceObserved += () =>
+            {
+                if (EnsureCommandAssistInitialized())
+                {
+                    _commandAssistController?.HandleBackspace();
+                }
+            };
+            TermView.EnterObserved += OnCommandAssistEnterObserved;
+            TermView.PasteObserved += text =>
+            {
+                if (EnsureCommandAssistInitialized())
+                {
+                    _commandAssistController?.HandlePastedText(text);
+                }
+            };
+
+            if (Buffer != null)
+            {
+                Buffer.OnScreenSwitched += OnBufferScreenSwitched;
+            }
 
             // Load Settings
-            ApplySettings(TerminalSettings.Load());
-            InitializeCommandAssist();
+            ApplySettings(initialSettings ?? TerminalSettings.Load());
             UpdateMinimumSizeConstraints();
             AutomationProperties.SetName(TermView, "Terminal Pane");
             AutomationProperties.SetName(this, "Terminal Pane");
@@ -466,28 +513,49 @@ namespace NovaTerminal.Controls
                 MenuToggleRemoteFilesSidebar.Click += async (_, _) => await ToggleRemoteFilesSidebarAsync();
             }
 
-            if (RemoteFilesSidebarHost != null)
-            {
-                if (RemoteFilesSidebarHost.FindControl<Button>("BtnUploadFile") is Button uploadFileButton)
-                {
-                    uploadFileButton.Click += (_, _) => RequestRemoteFilesSidebarUploadForCurrentDirectory(TransferKind.File);
-                }
-
-                if (RemoteFilesSidebarHost.FindControl<Button>("BtnUploadFolder") is Button uploadFolderButton)
-                {
-                    uploadFolderButton.Click += (_, _) => RequestRemoteFilesSidebarUploadForCurrentDirectory(TransferKind.Folder);
-                }
-
-                if (RemoteFilesSidebarHost.FindControl<Button>("BtnDownloadSelected") is Button downloadSelectedButton)
-                {
-                    downloadSelectedButton.Click += (_, _) => RequestRemoteFilesSidebarTransferForSelectedEntry();
-                }
-            }
-
             UpdateRemoteFilesSidebarHostIdentity();
             UpdateRemoteFilesSidebarCurrentDirectoryState();
             UpdateRemoteFilesSidebarVisibility();
             UpdateRemoteFilesSidebarEntryPointState();
+        }
+
+        private RemoteFilesSidebar EnsureRemoteFilesSidebarHost()
+        {
+            if (_remoteFilesSidebarHost != null)
+            {
+                return _remoteFilesSidebarHost;
+            }
+
+            var host = new RemoteFilesSidebar
+            {
+                IsVisible = false,
+                DataContext = _remoteFilesSidebarViewModel
+            };
+
+            if (host.FindControl<Button>("BtnUploadFile") is Button uploadFileButton)
+            {
+                uploadFileButton.Click += (_, _) => RequestRemoteFilesSidebarUploadForCurrentDirectory(TransferKind.File);
+            }
+
+            if (host.FindControl<Button>("BtnUploadFolder") is Button uploadFolderButton)
+            {
+                uploadFolderButton.Click += (_, _) => RequestRemoteFilesSidebarUploadForCurrentDirectory(TransferKind.Folder);
+            }
+
+            if (host.FindControl<Button>("BtnDownloadSelected") is Button downloadSelectedButton)
+            {
+                downloadSelectedButton.Click += (_, _) => RequestRemoteFilesSidebarTransferForSelectedEntry();
+            }
+
+            if (RemoteFilesSidebarPresenter != null)
+            {
+                RemoteFilesSidebarPresenter.Content = host;
+                RemoteFilesSidebarPresenter.IsVisible = false;
+            }
+
+            _remoteFilesSidebarHost = host;
+            UpdateRemoteFilesSidebarHostIdentity();
+            return host;
         }
 
         private void SetRemoteFilesSidebarService(IRemoteDirectoryBrowserService directoryBrowserService)
@@ -503,9 +571,9 @@ namespace NovaTerminal.Controls
             _remoteFilesSidebarViewModel = new RemoteFilesSidebarViewModel(directoryBrowserService);
             _remoteFilesSidebarViewModel.PropertyChanged += OnRemoteFilesSidebarViewModelPropertyChanged;
 
-            if (RemoteFilesSidebarHost != null)
+            if (_remoteFilesSidebarHost != null)
             {
-                RemoteFilesSidebarHost.DataContext = _remoteFilesSidebarViewModel;
+                _remoteFilesSidebarHost.DataContext = _remoteFilesSidebarViewModel;
             }
 
             UpdateRemoteFilesSidebarHostIdentity();
@@ -545,20 +613,29 @@ namespace NovaTerminal.Controls
 
         private void UpdateRemoteFilesSidebarVisibility()
         {
-            if (RemoteFilesSidebarHost == null)
-            {
-                return;
-            }
-
-            RemoteFilesSidebarHost.IsVisible =
+            bool shouldShow =
                 _remoteFilesSidebarViewModel?.IsOpen == true &&
                 !(Buffer?.IsAltScreenActive ?? false) &&
                 IsRemoteFilesSidebarSupported();
+
+            if (shouldShow)
+            {
+                EnsureRemoteFilesSidebarHost().IsVisible = true;
+            }
+            else if (_remoteFilesSidebarHost != null)
+            {
+                _remoteFilesSidebarHost.IsVisible = false;
+            }
+
+            if (RemoteFilesSidebarPresenter != null)
+            {
+                RemoteFilesSidebarPresenter.IsVisible = shouldShow;
+            }
         }
 
         private void UpdateRemoteFilesSidebarHostIdentity()
         {
-            RemoteFilesSidebarHost?.SetHostIdentity(
+            _remoteFilesSidebarHost?.SetHostIdentity(
                 string.IsNullOrWhiteSpace(Profile?.Name) ? null : Profile.Name,
                 BuildRemoteFilesSidebarSubtitle(Profile));
         }
@@ -748,34 +825,6 @@ namespace NovaTerminal.Controls
 
             _commandAssistController.HandleAltScreenChanged(Buffer?.IsAltScreenActive ?? false);
             UpdateCommandAssistContext();
-
-            TermView.TextInputObserved += text =>
-            {
-                if (IsCommandAssistFeatureEnabled())
-                {
-                    _commandAssistController?.HandleTextInput(text);
-                }
-            };
-            TermView.BackspaceObserved += () =>
-            {
-                if (IsCommandAssistFeatureEnabled())
-                {
-                    _commandAssistController?.HandleBackspace();
-                }
-            };
-            TermView.EnterObserved += OnCommandAssistEnterObserved;
-            TermView.PasteObserved += text =>
-            {
-                if (IsCommandAssistFeatureEnabled())
-                {
-                    _commandAssistController?.HandlePastedText(text);
-                }
-            };
-
-            if (Buffer != null)
-            {
-                Buffer.OnScreenSwitched += OnBufferScreenSwitched;
-            }
         }
 
         private void BindCommandAssistViews(CommandAssistBarViewModel? viewModel)
@@ -831,6 +880,17 @@ namespace NovaTerminal.Controls
         {
             return _settings?.CommandAssistEnabled == true &&
                    _settings.CommandAssistHistoryEnabled;
+        }
+
+        private bool EnsureCommandAssistInitialized()
+        {
+            if (!IsCommandAssistFeatureEnabled())
+            {
+                return false;
+            }
+
+            InitializeCommandAssist();
+            return _commandAssistController != null;
         }
 
         private void OnCommandAssistViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -1179,7 +1239,7 @@ namespace NovaTerminal.Controls
 
         private async Task HandleCommandAssistEnterObservedAsync()
         {
-            if (!IsCommandAssistFeatureEnabled() || _commandAssistController == null)
+            if (!EnsureCommandAssistInitialized())
             {
                 return;
             }
@@ -1602,7 +1662,10 @@ namespace NovaTerminal.Controls
             };
 
             TermView.ApplySettings(effectiveSettings);
-            InitializeCommandAssist();
+            if (_commandAssistController != null || !IsCommandAssistFeatureEnabled())
+            {
+                InitializeCommandAssist();
+            }
             UpdateMinimumSizeConstraints();
 
             // Sync metrics to parser after settings change (font size, etc.)
@@ -1732,7 +1795,7 @@ namespace NovaTerminal.Controls
 
         public void ToggleCommandAssist()
         {
-            if (!IsCommandAssistFeatureEnabled())
+            if (!EnsureCommandAssistInitialized())
             {
                 return;
             }
@@ -1742,7 +1805,7 @@ namespace NovaTerminal.Controls
 
         public bool OpenCommandAssistHelp()
         {
-            if (!IsCommandAssistFeatureEnabled())
+            if (!EnsureCommandAssistInitialized())
             {
                 return false;
             }
@@ -1752,7 +1815,7 @@ namespace NovaTerminal.Controls
 
         public bool OpenCommandAssistHistorySearch()
         {
-            if (!IsCommandAssistFeatureEnabled())
+            if (!EnsureCommandAssistInitialized())
             {
                 return false;
             }
@@ -1762,7 +1825,7 @@ namespace NovaTerminal.Controls
 
         public void NotifyCommandAssistPaste(string text)
         {
-            if (!IsCommandAssistFeatureEnabled())
+            if (!EnsureCommandAssistInitialized())
             {
                 return;
             }
@@ -1783,17 +1846,12 @@ namespace NovaTerminal.Controls
             }
 
             string? selectedText = selectedTextOverride ?? TermView.GetSelectedText();
-            return _commandAssistController != null && !string.IsNullOrWhiteSpace(selectedText);
+            return !string.IsNullOrWhiteSpace(selectedText);
         }
 
         internal async Task<bool> ExplainSelectionAsync(string? selectedTextOverride = null)
         {
-            if (!IsCommandAssistFeatureEnabled())
-            {
-                return false;
-            }
-
-            if (_commandAssistController == null)
+            if (!EnsureCommandAssistInitialized())
             {
                 return false;
             }
@@ -1981,7 +2039,7 @@ namespace NovaTerminal.Controls
 
         internal bool IsRemoteFilesSidebarVisibleForTest()
         {
-            return RemoteFilesSidebarHost?.IsVisible == true;
+            return RemoteFilesSidebarPresenter?.IsVisible == true;
         }
 
         internal bool IsRemoteFilesSidebarEntryAvailableForTest()
@@ -2409,12 +2467,7 @@ namespace NovaTerminal.Controls
 
         internal async Task HandleCommandAssistCompletionAsync(int? exitCode)
         {
-            if (!IsCommandAssistFeatureEnabled())
-            {
-                return;
-            }
-
-            if (_commandAssistController == null)
+            if (!EnsureCommandAssistInitialized())
             {
                 return;
             }
@@ -2449,7 +2502,7 @@ namespace NovaTerminal.Controls
 
         private async Task HandleShellIntegrationEventAsync(ShellIntegrationEvent shellEvent)
         {
-            if (!IsCommandAssistFeatureEnabled() || _commandAssistController == null)
+            if (!EnsureCommandAssistInitialized())
             {
                 return;
             }

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -897,7 +897,11 @@ namespace NovaTerminal.Controls
                 return false;
             }
 
-            InitializeCommandAssist();
+            if (_commandAssistController == null)
+            {
+                InitializeCommandAssist();
+            }
+
             return _commandAssistController != null;
         }
 

--- a/src/NovaTerminal.App/Core/AppPaths.cs
+++ b/src/NovaTerminal.App/Core/AppPaths.cs
@@ -6,6 +6,7 @@ namespace NovaTerminal.Core
     public static class AppPaths
     {
         private const string AppName = "NovaTerminal";
+        private const string RootOverrideEnvVar = "NOVATERM_APPDATA_ROOT";
         private static readonly object InitLock = new();
         private static bool _initialized;
 
@@ -14,9 +15,21 @@ namespace NovaTerminal.Core
             EnsureInitialized();
         }
 
-        public static string RootDirectory => Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            AppName);
+        public static string RootDirectory
+        {
+            get
+            {
+                string? overrideRoot = Environment.GetEnvironmentVariable(RootOverrideEnvVar);
+                if (!string.IsNullOrWhiteSpace(overrideRoot))
+                {
+                    return Path.GetFullPath(overrideRoot);
+                }
+
+                return Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    AppName);
+            }
+        }
 
         public static string SettingsFilePath => Path.Combine(RootDirectory, "settings.json");
         public static string ThemesDirectory => Path.Combine(RootDirectory, "themes");

--- a/src/NovaTerminal.App/Core/SessionManager.cs
+++ b/src/NovaTerminal.App/Core/SessionManager.cs
@@ -170,13 +170,13 @@ namespace NovaTerminal.Core
             int payloadBytes = 0;
             try
             {
-                if (!File.Exists(SessionPath)) return;
+                if (!TryLoadSavedSession(out NovaSession? session, out payloadBytes) ||
+                    session == null ||
+                    session.Tabs.Count == 0)
+                {
+                    return;
+                }
 
-                var json = File.ReadAllText(SessionPath);
-                payloadBytes = System.Text.Encoding.UTF8.GetByteCount(json);
-                var session = JsonSerializer.Deserialize(json, SessionSerializationContext.Default.NovaSession);
-
-                if (session == null || session.Tabs.Count == 0) return;
                 RestoreSessionCore(window, tabs, settings, session);
             }
             catch (Exception ex)
@@ -211,6 +211,34 @@ namespace NovaTerminal.Core
             }
         }
 
+        public static bool TryLoadSavedSession(out NovaSession? session)
+        {
+            return TryLoadSavedSession(out session, out _);
+        }
+
+        public static TabItem? CreateRestoredTabItem(TabSession tabSession, TerminalSettings settings)
+        {
+            ArgumentNullException.ThrowIfNull(tabSession);
+            var content = CreateRestoredTabContent(tabSession, settings);
+            if (content == null)
+            {
+                return null;
+            }
+
+            return new TabItem
+            {
+                Header = new TextBlock { Text = tabSession.Title, Foreground = Avalonia.Media.Brushes.White, FontSize = 12, VerticalAlignment = VerticalAlignment.Center, Padding = new Thickness(10, 4) },
+                Content = content,
+                Tag = tabSession
+            };
+        }
+
+        public static Control? CreateRestoredTabContent(TabSession tabSession, TerminalSettings settings)
+        {
+            ArgumentNullException.ThrowIfNull(tabSession);
+            return RestorePaneTree(tabSession.Root, settings);
+        }
+
         private static void RestoreSessionCore(Window window, TabControl tabs, TerminalSettings settings, NovaSession session)
         {
             _ = window;
@@ -219,15 +247,9 @@ namespace NovaTerminal.Core
             tabs.Items.Clear();
             foreach (var tabSession in session.Tabs)
             {
-                var content = RestorePaneTree(tabSession.Root, settings);
-                if (content != null)
+                var tabItem = CreateRestoredTabItem(tabSession, settings);
+                if (tabItem != null)
                 {
-                    var tabItem = new TabItem
-                    {
-                        Header = new TextBlock { Text = tabSession.Title, Foreground = Avalonia.Media.Brushes.White, FontSize = 12, VerticalAlignment = VerticalAlignment.Center, Padding = new Thickness(10, 4) },
-                        Content = content,
-                        Tag = tabSession
-                    };
                     tabs.Items.Add(tabItem);
                 }
             }
@@ -236,6 +258,22 @@ namespace NovaTerminal.Core
             {
                 tabs.SelectedIndex = session.ActiveTabIndex;
             }
+        }
+
+        private static bool TryLoadSavedSession(out NovaSession? session, out int payloadBytes)
+        {
+            session = null;
+            payloadBytes = 0;
+
+            if (!File.Exists(SessionPath))
+            {
+                return false;
+            }
+
+            var json = File.ReadAllText(SessionPath);
+            payloadBytes = System.Text.Encoding.UTF8.GetByteCount(json);
+            session = JsonSerializer.Deserialize(json, SessionSerializationContext.Default.NovaSession);
+            return session != null;
         }
 
         private static Control? RestorePaneTree(PaneNode? node, TerminalSettings settings)
@@ -255,12 +293,12 @@ namespace NovaTerminal.Core
                 TerminalPane pane;
                 if (profile != null)
                 {
-                    pane = new TerminalPane(profile);
+                    pane = new TerminalPane(profile, settings);
                 }
                 else
                 {
                     // Fallback to command args if profile missing
-                    pane = new TerminalPane(node.Command ?? "cmd.exe", node.Arguments ?? "");
+                    pane = new TerminalPane(node.Command ?? "cmd.exe", node.Arguments ?? "", settings);
                 }
 
                 if (!string.IsNullOrWhiteSpace(node.PaneId) && Guid.TryParse(node.PaneId, out var paneId))
@@ -268,7 +306,6 @@ namespace NovaTerminal.Core
                     pane.PaneId = paneId;
                 }
 
-                pane.ApplySettings(settings);
                 return pane;
             }
             else if (node.Type == NodeType.Split)

--- a/src/NovaTerminal.App/Core/SessionManager.cs
+++ b/src/NovaTerminal.App/Core/SessionManager.cs
@@ -220,6 +220,7 @@ namespace NovaTerminal.Core
         {
             ArgumentNullException.ThrowIfNull(tabSession);
             var content = CreateRestoredTabContent(tabSession, settings);
+            StartupPerformanceTracker.Current?.TryMarkCheckpoint("SessionManager.CreateRestoredTabItem.ContentCreated");
             if (content == null)
             {
                 return null;
@@ -282,6 +283,7 @@ namespace NovaTerminal.Core
 
             if (node.Type == NodeType.Leaf)
             {
+                StartupPerformanceTracker.Current?.TryMarkCheckpoint("SessionManager.RestorePaneTree.LeafStart");
                 // Reconstruct TerminalPane
                 TerminalProfile? profile = ResolveSshProfile(node.SshProfileId);
 
@@ -306,6 +308,7 @@ namespace NovaTerminal.Core
                     pane.PaneId = paneId;
                 }
 
+                StartupPerformanceTracker.Current?.TryMarkCheckpoint("SessionManager.RestorePaneTree.LeafCreated");
                 return pane;
             }
             else if (node.Type == NodeType.Split)

--- a/src/NovaTerminal.App/Core/StartupMetricsAnalysis.cs
+++ b/src/NovaTerminal.App/Core/StartupMetricsAnalysis.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace NovaTerminal.Core;
+
+public sealed record StartupPhaseStatistics(
+    int Count,
+    double AverageMs,
+    double MedianMs,
+    long MinMs,
+    long MaxMs);
+
+public sealed record StartupMetricsSummary(
+    int LaunchCount,
+    IReadOnlyDictionary<StartupPhase, StartupPhaseStatistics> Phases);
+
+public sealed record StartupPhaseComparison(
+    double BaselineAverageMs,
+    double CandidateAverageMs,
+    double DeltaMs,
+    double ImprovementPercent);
+
+public sealed record StartupMetricsComparison(
+    int BaselineLaunchCount,
+    int CandidateLaunchCount,
+    IReadOnlyDictionary<StartupPhase, StartupPhaseComparison> Phases);
+
+public static class StartupMetricsAnalysis
+{
+    private static readonly StartupPhase[] OrderedPhases =
+    {
+        StartupPhase.MainWindowConstructed,
+        StartupPhase.WindowOpened,
+        StartupPhase.FirstTerminalReady,
+        StartupPhase.SessionRestoreComplete,
+        StartupPhase.DeferredWorkComplete,
+        StartupPhase.BackgroundRestoreComplete
+    };
+
+    public static IReadOnlyList<StartupMetricsSnapshot> LoadSnapshots(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        string fullPath = Path.GetFullPath(path);
+        var snapshots = new List<StartupMetricsSnapshot>();
+
+        if (Directory.Exists(fullPath))
+        {
+            foreach (string file in Directory.EnumerateFiles(fullPath, "*.jsonl", SearchOption.AllDirectories).OrderBy(static p => p, StringComparer.OrdinalIgnoreCase))
+            {
+                snapshots.AddRange(LoadSnapshotsFromFile(file));
+            }
+
+            return snapshots;
+        }
+
+        if (File.Exists(fullPath))
+        {
+            return LoadSnapshotsFromFile(fullPath);
+        }
+
+        throw new FileNotFoundException("Startup metrics input path was not found.", fullPath);
+    }
+
+    public static StartupMetricsSummary Summarize(IEnumerable<StartupMetricsSnapshot> snapshots)
+    {
+        ArgumentNullException.ThrowIfNull(snapshots);
+
+        StartupMetricsSnapshot[] snapshotArray = snapshots.ToArray();
+        var phases = new Dictionary<StartupPhase, StartupPhaseStatistics>();
+
+        foreach (StartupPhase phase in OrderedPhases)
+        {
+            long[] values = snapshotArray
+                .Select(snapshot => GetPhaseValue(snapshot, phase))
+                .Where(static value => value.HasValue)
+                .Select(static value => value!.Value)
+                .OrderBy(static value => value)
+                .ToArray();
+
+            if (values.Length == 0)
+            {
+                continue;
+            }
+
+            phases[phase] = new StartupPhaseStatistics(
+                Count: values.Length,
+                AverageMs: values.Average(),
+                MedianMs: GetMedian(values),
+                MinMs: values[0],
+                MaxMs: values[^1]);
+        }
+
+        return new StartupMetricsSummary(snapshotArray.Length, phases);
+    }
+
+    public static StartupMetricsComparison Compare(IEnumerable<StartupMetricsSnapshot> baseline, IEnumerable<StartupMetricsSnapshot> candidate)
+    {
+        ArgumentNullException.ThrowIfNull(baseline);
+        ArgumentNullException.ThrowIfNull(candidate);
+
+        StartupMetricsSummary baselineSummary = Summarize(baseline);
+        StartupMetricsSummary candidateSummary = Summarize(candidate);
+        var phases = new Dictionary<StartupPhase, StartupPhaseComparison>();
+
+        foreach (StartupPhase phase in OrderedPhases)
+        {
+            if (!baselineSummary.Phases.TryGetValue(phase, out StartupPhaseStatistics? baselinePhase) ||
+                !candidateSummary.Phases.TryGetValue(phase, out StartupPhaseStatistics? candidatePhase))
+            {
+                continue;
+            }
+
+            double deltaMs = candidatePhase.AverageMs - baselinePhase.AverageMs;
+            double improvementPercent = baselinePhase.AverageMs <= 0
+                ? 0
+                : ((baselinePhase.AverageMs - candidatePhase.AverageMs) / baselinePhase.AverageMs) * 100d;
+
+            phases[phase] = new StartupPhaseComparison(
+                BaselineAverageMs: baselinePhase.AverageMs,
+                CandidateAverageMs: candidatePhase.AverageMs,
+                DeltaMs: deltaMs,
+                ImprovementPercent: improvementPercent);
+        }
+
+        return new StartupMetricsComparison(baselineSummary.LaunchCount, candidateSummary.LaunchCount, phases);
+    }
+
+    public static string BuildMarkdownReport(StartupMetricsComparison comparison)
+    {
+        ArgumentNullException.ThrowIfNull(comparison);
+
+        var lines = new List<string>
+        {
+            "# Startup Performance Report",
+            string.Empty,
+            $"Baseline launches: {comparison.BaselineLaunchCount}",
+            $"Candidate launches: {comparison.CandidateLaunchCount}",
+            string.Empty,
+            "| Phase | Baseline Avg (ms) | Candidate Avg (ms) | Delta (ms) | Improvement |",
+            "| --- | ---: | ---: | ---: | ---: |"
+        };
+
+        foreach ((StartupPhase phase, StartupPhaseComparison values) in comparison.Phases.OrderBy(static entry => Array.IndexOf(OrderedPhases, entry.Key)))
+        {
+            lines.Add(
+                $"| {GetPhaseLabel(phase)} | {values.BaselineAverageMs:F2} | {values.CandidateAverageMs:F2} | {values.DeltaMs:F2} | {values.ImprovementPercent:F2}% |");
+        }
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    private static List<StartupMetricsSnapshot> LoadSnapshotsFromFile(string filePath)
+    {
+        var snapshots = new List<StartupMetricsSnapshot>();
+
+        foreach (string rawLine in File.ReadLines(filePath))
+        {
+            string line = rawLine.Trim();
+            if (line.Length == 0)
+            {
+                continue;
+            }
+
+            StartupMetricsSnapshot? snapshot = JsonSerializer.Deserialize(line, StartupMetricsSerializationContext.Default.StartupMetricsSnapshot);
+            if (snapshot != null)
+            {
+                snapshots.Add(snapshot);
+            }
+        }
+
+        return snapshots;
+    }
+
+    private static long? GetPhaseValue(StartupMetricsSnapshot snapshot, StartupPhase phase)
+    {
+        return phase switch
+        {
+            StartupPhase.MainWindowConstructed => snapshot.MainWindowConstructedMs,
+            StartupPhase.WindowOpened => snapshot.WindowOpenedMs,
+            StartupPhase.FirstTerminalReady => snapshot.FirstTerminalReadyMs,
+            StartupPhase.SessionRestoreComplete => snapshot.SessionRestoreCompleteMs,
+            StartupPhase.DeferredWorkComplete => snapshot.DeferredWorkCompleteMs,
+            StartupPhase.BackgroundRestoreComplete => snapshot.BackgroundRestoreCompleteMs,
+            _ => null
+        };
+    }
+
+    private static double GetMedian(long[] values)
+    {
+        int midpoint = values.Length / 2;
+        if ((values.Length & 1) == 1)
+        {
+            return values[midpoint];
+        }
+
+        return (values[midpoint - 1] + values[midpoint]) / 2d;
+    }
+
+    private static string GetPhaseLabel(StartupPhase phase)
+    {
+        return phase switch
+        {
+            StartupPhase.MainWindowConstructed => "Main Window Constructed",
+            StartupPhase.WindowOpened => "Window Opened",
+            StartupPhase.FirstTerminalReady => "First Terminal Ready",
+            StartupPhase.SessionRestoreComplete => "Session Restore Complete",
+            StartupPhase.DeferredWorkComplete => "Deferred Work Complete",
+            StartupPhase.BackgroundRestoreComplete => "Background Restore Complete",
+            _ => phase.ToString()
+        };
+    }
+}

--- a/src/NovaTerminal.App/Core/StartupMetricsSerializationContext.cs
+++ b/src/NovaTerminal.App/Core/StartupMetricsSerializationContext.cs
@@ -1,0 +1,8 @@
+using System.Text.Json.Serialization;
+
+namespace NovaTerminal.Core;
+
+[JsonSerializable(typeof(StartupMetricsSnapshot))]
+internal sealed partial class StartupMetricsSerializationContext : JsonSerializerContext
+{
+}

--- a/src/NovaTerminal.App/Core/StartupMetricsWriter.cs
+++ b/src/NovaTerminal.App/Core/StartupMetricsWriter.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace NovaTerminal.Core;
+
+public sealed class StartupMetricsWriter : IDisposable
+{
+    private const string EnabledEnvVar = "NOVATERM_STARTUP_METRICS";
+    private const string OutputEnvVar = "NOVATERM_STARTUP_METRICS_OUT";
+    private readonly object _gate = new();
+    private readonly FileStream _stream;
+    private readonly ArrayBufferWriter<byte> _buffer = new(512);
+    private bool _disabled;
+
+    private StartupMetricsWriter(FileStream stream)
+    {
+        _stream = stream;
+    }
+
+    public static StartupMetricsWriter? CreateFromEnvironment()
+    {
+        if (!IsEnabled())
+        {
+            return null;
+        }
+
+        string? configuredPath = Environment.GetEnvironmentVariable(OutputEnvVar);
+        string outputPath = string.IsNullOrWhiteSpace(configuredPath)
+            ? Path.Combine(AppContext.BaseDirectory, "startup_metrics.jsonl")
+            : configuredPath;
+
+        return Create(outputPath);
+    }
+
+    public static StartupMetricsWriter? Create(string outputPath)
+    {
+        if (string.IsNullOrWhiteSpace(outputPath))
+        {
+            return null;
+        }
+
+        try
+        {
+            string fullPath = Path.GetFullPath(outputPath);
+            if (Directory.Exists(fullPath))
+            {
+                return null;
+            }
+
+            string? directory = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            var stream = new FileStream(
+                fullPath,
+                FileMode.Append,
+                FileAccess.Write,
+                FileShare.ReadWrite,
+                bufferSize: 4096,
+                options: FileOptions.SequentialScan);
+
+            return new StartupMetricsWriter(stream);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public bool TryWriteSnapshot(StartupMetricsSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        if (_disabled)
+        {
+            return false;
+        }
+
+        lock (_gate)
+        {
+            if (_disabled)
+            {
+                return false;
+            }
+
+            try
+            {
+                _buffer.Clear();
+                using (var writer = new Utf8JsonWriter(_buffer))
+                {
+                    writer.WriteStartObject();
+                    writer.WriteString(nameof(StartupMetricsSnapshot.LaunchId), snapshot.LaunchId);
+                    writer.WriteString(nameof(StartupMetricsSnapshot.StartedAtUtc), snapshot.StartedAtUtc);
+                    WriteNullableInt64(writer, nameof(StartupMetricsSnapshot.MainWindowConstructedMs), snapshot.MainWindowConstructedMs);
+                    WriteNullableInt64(writer, nameof(StartupMetricsSnapshot.WindowOpenedMs), snapshot.WindowOpenedMs);
+                    WriteNullableInt64(writer, nameof(StartupMetricsSnapshot.FirstTerminalReadyMs), snapshot.FirstTerminalReadyMs);
+                    WriteNullableInt64(writer, nameof(StartupMetricsSnapshot.SessionRestoreCompleteMs), snapshot.SessionRestoreCompleteMs);
+                    WriteNullableInt64(writer, nameof(StartupMetricsSnapshot.DeferredWorkCompleteMs), snapshot.DeferredWorkCompleteMs);
+                    WriteNullableInt64(writer, nameof(StartupMetricsSnapshot.BackgroundRestoreCompleteMs), snapshot.BackgroundRestoreCompleteMs);
+                    WriteCheckpoints(writer, snapshot.Checkpoints);
+                    writer.WriteEndObject();
+                    writer.Flush();
+                }
+
+                _stream.Write(_buffer.WrittenSpan);
+                _stream.WriteByte((byte)'\n');
+                _stream.Flush();
+                return true;
+            }
+            catch
+            {
+                DisableUnsafe();
+                return false;
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            DisableUnsafe();
+        }
+    }
+
+    private static bool IsEnabled()
+    {
+        string? raw = Environment.GetEnvironmentVariable(EnabledEnvVar);
+        return raw == "1" || string.Equals(raw, "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void WriteNullableInt64(Utf8JsonWriter writer, string propertyName, long? value)
+    {
+        if (value.HasValue)
+        {
+            writer.WriteNumber(propertyName, value.Value);
+            return;
+        }
+
+        writer.WriteNull(propertyName);
+    }
+
+    private static void WriteCheckpoints(Utf8JsonWriter writer, IReadOnlyDictionary<string, long>? checkpoints)
+    {
+        if (checkpoints == null || checkpoints.Count == 0)
+        {
+            writer.WriteNull(nameof(StartupMetricsSnapshot.Checkpoints));
+            return;
+        }
+
+        writer.WritePropertyName(nameof(StartupMetricsSnapshot.Checkpoints));
+        writer.WriteStartObject();
+
+        foreach ((string key, long value) in checkpoints.OrderBy(static pair => pair.Key, StringComparer.Ordinal))
+        {
+            writer.WriteNumber(key, value);
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private void DisableUnsafe()
+    {
+        if (_disabled)
+        {
+            return;
+        }
+
+        _disabled = true;
+        try
+        {
+            _stream.Dispose();
+        }
+        catch
+        {
+            // Keep failures non-fatal.
+        }
+    }
+}

--- a/src/NovaTerminal.App/Core/StartupPerformanceTracker.cs
+++ b/src/NovaTerminal.App/Core/StartupPerformanceTracker.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace NovaTerminal.Core;
+
+public enum StartupPhase
+{
+    MainWindowConstructed,
+    WindowOpened,
+    FirstTerminalReady,
+    SessionRestoreComplete,
+    DeferredWorkComplete,
+    BackgroundRestoreComplete
+}
+
+public sealed class StartupPerformanceTracker
+{
+    private readonly Func<long> _timestampProvider;
+    private readonly long _startTimestamp;
+    private readonly double _ticksToMilliseconds;
+    private readonly StartupMetricsWriter? _metricsWriter;
+    private readonly Dictionary<StartupPhase, long> _elapsedMillisecondsByPhase = new();
+    private readonly Dictionary<string, long> _namedCheckpointMilliseconds = new(StringComparer.Ordinal);
+    private readonly object _sync = new();
+    private readonly string _launchId = Guid.NewGuid().ToString("N");
+    private readonly DateTimeOffset _startedAtUtc = DateTimeOffset.UtcNow;
+    private bool _snapshotWritten;
+
+    public static StartupPerformanceTracker? Current { get; private set; }
+
+    public StartupPerformanceTracker()
+        : this(Stopwatch.GetTimestamp, Stopwatch.GetTimestamp(), Stopwatch.Frequency, StartupMetricsWriter.CreateFromEnvironment())
+    {
+    }
+
+    internal StartupPerformanceTracker(Func<long> timestampProvider, long startTimestamp, long timestampFrequency, StartupMetricsWriter? metricsWriter = null)
+    {
+        ArgumentNullException.ThrowIfNull(timestampProvider);
+        if (timestampFrequency <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(timestampFrequency));
+        }
+
+        _timestampProvider = timestampProvider;
+        _startTimestamp = startTimestamp;
+        _ticksToMilliseconds = 1000d / timestampFrequency;
+        _metricsWriter = metricsWriter;
+    }
+
+    public static StartupPerformanceTracker StartNewCurrent()
+    {
+        return Current = new StartupPerformanceTracker();
+    }
+
+    internal static void SetCurrentForTests(StartupPerformanceTracker? tracker)
+    {
+        Current = tracker;
+    }
+
+    public bool TryMark(StartupPhase phase)
+    {
+        long elapsedMilliseconds = GetElapsedMilliseconds(_timestampProvider());
+
+        lock (_sync)
+        {
+            if (_elapsedMillisecondsByPhase.ContainsKey(phase))
+            {
+                return false;
+            }
+
+            _elapsedMillisecondsByPhase[phase] = elapsedMilliseconds;
+        }
+
+        Publish(phase, elapsedMilliseconds);
+        TryWriteSnapshotIfReady();
+        return true;
+    }
+
+    public bool TryMarkCheckpoint(string checkpointName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(checkpointName);
+
+        long elapsedMilliseconds = GetElapsedMilliseconds(_timestampProvider());
+
+        lock (_sync)
+        {
+            if (_namedCheckpointMilliseconds.ContainsKey(checkpointName))
+            {
+                return false;
+            }
+
+            _namedCheckpointMilliseconds[checkpointName] = elapsedMilliseconds;
+            return true;
+        }
+    }
+
+    public bool TryGetElapsedMilliseconds(StartupPhase phase, out long elapsedMilliseconds)
+    {
+        lock (_sync)
+        {
+            return _elapsedMillisecondsByPhase.TryGetValue(phase, out elapsedMilliseconds);
+        }
+    }
+
+    public StartupMetricsSnapshot CreateSnapshot()
+    {
+        lock (_sync)
+        {
+            _elapsedMillisecondsByPhase.TryGetValue(StartupPhase.MainWindowConstructed, out long mainWindowConstructedMs);
+            _elapsedMillisecondsByPhase.TryGetValue(StartupPhase.WindowOpened, out long windowOpenedMs);
+            _elapsedMillisecondsByPhase.TryGetValue(StartupPhase.FirstTerminalReady, out long firstTerminalReadyMs);
+            _elapsedMillisecondsByPhase.TryGetValue(StartupPhase.SessionRestoreComplete, out long sessionRestoreCompleteMs);
+            _elapsedMillisecondsByPhase.TryGetValue(StartupPhase.DeferredWorkComplete, out long deferredWorkCompleteMs);
+            _elapsedMillisecondsByPhase.TryGetValue(StartupPhase.BackgroundRestoreComplete, out long backgroundRestoreCompleteMs);
+
+            return new StartupMetricsSnapshot(
+                _launchId,
+                _startedAtUtc,
+                mainWindowConstructedMs == 0 && !_elapsedMillisecondsByPhase.ContainsKey(StartupPhase.MainWindowConstructed) ? null : mainWindowConstructedMs,
+                windowOpenedMs == 0 && !_elapsedMillisecondsByPhase.ContainsKey(StartupPhase.WindowOpened) ? null : windowOpenedMs,
+                firstTerminalReadyMs == 0 && !_elapsedMillisecondsByPhase.ContainsKey(StartupPhase.FirstTerminalReady) ? null : firstTerminalReadyMs,
+                sessionRestoreCompleteMs == 0 && !_elapsedMillisecondsByPhase.ContainsKey(StartupPhase.SessionRestoreComplete) ? null : sessionRestoreCompleteMs,
+                deferredWorkCompleteMs == 0 && !_elapsedMillisecondsByPhase.ContainsKey(StartupPhase.DeferredWorkComplete) ? null : deferredWorkCompleteMs,
+                backgroundRestoreCompleteMs == 0 && !_elapsedMillisecondsByPhase.ContainsKey(StartupPhase.BackgroundRestoreComplete) ? null : backgroundRestoreCompleteMs,
+                _namedCheckpointMilliseconds.Count == 0 ? null : new Dictionary<string, long>(_namedCheckpointMilliseconds, StringComparer.Ordinal));
+        }
+    }
+
+    private long GetElapsedMilliseconds(long timestamp)
+    {
+        long elapsedTicks = Math.Max(0, timestamp - _startTimestamp);
+        return (long)Math.Round(elapsedTicks * _ticksToMilliseconds, MidpointRounding.AwayFromZero);
+    }
+
+    private static void Publish(StartupPhase phase, long elapsedMilliseconds)
+    {
+        switch (phase)
+        {
+            case StartupPhase.WindowOpened:
+                RendererStatistics.RecordStartupWindowShown(elapsedMilliseconds);
+                break;
+            case StartupPhase.FirstTerminalReady:
+                RendererStatistics.RecordStartupFirstTerminalReady(elapsedMilliseconds);
+                break;
+            case StartupPhase.SessionRestoreComplete:
+                RendererStatistics.RecordStartupSessionRestoreComplete(elapsedMilliseconds);
+                break;
+            case StartupPhase.DeferredWorkComplete:
+                RendererStatistics.RecordStartupDeferredWork(elapsedMilliseconds);
+                break;
+            case StartupPhase.BackgroundRestoreComplete:
+                RendererStatistics.RecordStartupBackgroundRestore(elapsedMilliseconds);
+                break;
+        }
+    }
+
+    private void TryWriteSnapshotIfReady()
+    {
+        if (_metricsWriter == null)
+        {
+            return;
+        }
+
+        StartupMetricsSnapshot? snapshot = null;
+
+        lock (_sync)
+        {
+            if (_snapshotWritten)
+            {
+                return;
+            }
+
+            if (!_elapsedMillisecondsByPhase.ContainsKey(StartupPhase.FirstTerminalReady) ||
+                !_elapsedMillisecondsByPhase.ContainsKey(StartupPhase.BackgroundRestoreComplete))
+            {
+                return;
+            }
+
+            _snapshotWritten = true;
+            snapshot = CreateSnapshot();
+        }
+
+        if (!_metricsWriter.TryWriteSnapshot(snapshot))
+        {
+            lock (_sync)
+            {
+                _snapshotWritten = false;
+            }
+        }
+    }
+}
+
+public sealed record StartupMetricsSnapshot(
+    string LaunchId,
+    DateTimeOffset StartedAtUtc,
+    long? MainWindowConstructedMs,
+    long? WindowOpenedMs,
+    long? FirstTerminalReadyMs,
+    long? SessionRestoreCompleteMs,
+    long? DeferredWorkCompleteMs,
+    long? BackgroundRestoreCompleteMs,
+    IReadOnlyDictionary<string, long>? Checkpoints);

--- a/src/NovaTerminal.App/Core/StartupRestoreCoordinator.cs
+++ b/src/NovaTerminal.App/Core/StartupRestoreCoordinator.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+
+namespace NovaTerminal.Core;
+
+public sealed class StartupRestoreCoordinator
+{
+    private readonly Action<Action> _schedule;
+
+    public StartupRestoreCoordinator(Action<Action> schedule)
+    {
+        _schedule = schedule ?? throw new ArgumentNullException(nameof(schedule));
+    }
+
+    public void RunDeferred(
+        IReadOnlyList<StartupRestoreTab> deferredTabs,
+        Action<StartupRestoreTab> restoreTab,
+        Action onCompleted)
+    {
+        ArgumentNullException.ThrowIfNull(deferredTabs);
+        ArgumentNullException.ThrowIfNull(restoreTab);
+        ArgumentNullException.ThrowIfNull(onCompleted);
+
+        if (deferredTabs.Count == 0)
+        {
+            onCompleted();
+            return;
+        }
+
+        _schedule(() =>
+        {
+            foreach (var deferredTab in deferredTabs)
+            {
+                restoreTab(deferredTab);
+            }
+            onCompleted();
+        });
+    }
+}

--- a/src/NovaTerminal.App/Core/StartupRestorePlan.cs
+++ b/src/NovaTerminal.App/Core/StartupRestorePlan.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NovaTerminal.Core;
+
+public sealed record StartupRestoreTab(int OriginalIndex, TabSession Tab);
+
+public sealed record StartupRestorePlan(StartupRestoreTab ImmediateTab, IReadOnlyList<StartupRestoreTab> DeferredTabs)
+{
+    public static StartupRestorePlan Create(NovaSession session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        if (session.Tabs.Count == 0)
+        {
+            throw new ArgumentException("Session must contain at least one tab.", nameof(session));
+        }
+
+        int selectedIndex = session.ActiveTabIndex;
+        if (selectedIndex < 0 || selectedIndex >= session.Tabs.Count)
+        {
+            selectedIndex = 0;
+        }
+
+        var immediate = new StartupRestoreTab(selectedIndex, session.Tabs[selectedIndex]);
+        var deferred = session.Tabs
+            .Select((tab, index) => new StartupRestoreTab(index, tab))
+            .Where(tab => tab.OriginalIndex != selectedIndex)
+            .ToArray();
+
+        return new StartupRestorePlan(immediate, deferred);
+    }
+}

--- a/src/NovaTerminal.App/MainWindow.axaml
+++ b/src/NovaTerminal.App/MainWindow.axaml
@@ -6,7 +6,6 @@
         Width="1200" Height="800"
         MinWidth="400" MinHeight="200"
         x:Name="RootWindow"
-        Icon="avares://NovaTerminal/Assets/nova_icon.png"
         ExtendClientAreaToDecorationsHint="True"
         WindowDecorationsTheme="{StaticResource NovaWindowDecorationsTheme}"
         TransparencyLevelHint=""
@@ -127,7 +126,6 @@
                         ToolTip.Tip="New Tab">
                     <Button.Flyout>
                         <MenuFlyout>
-                            <!-- Populated dynamically -->
                             <Separator />
                             <MenuItem Header="New SSH Connection..." Name="MenuNewSshConnection" />
                             <MenuItem Header="Manage Profiles..." Name="MenuManageProfiles" />

--- a/src/NovaTerminal.App/MainWindow.axaml
+++ b/src/NovaTerminal.App/MainWindow.axaml
@@ -274,7 +274,7 @@
                     <TextBlock Name="ConnectionTitleText" Text="Connection Manager" VerticalAlignment="Center" Margin="15,0" FontWeight="Bold"/>
                     <Button Name="BtnCloseConnections" Content="✕" HorizontalAlignment="Right" Width="40" Background="Transparent" BorderThickness="0"/>
                 </Grid>
-                <controls:ConnectionManager Name="ConnectionManagerControl" Grid.Row="1"/>
+                <ContentControl Name="ConnectionManagerHost" Grid.Row="1"/>
             </Grid>
         </Border>
 
@@ -290,7 +290,7 @@
                     <TextBlock Text="Recent Transfers" VerticalAlignment="Center" Margin="10,0" FontSize="12" FontWeight="Bold"/>
                     <Button Name="BtnCloseTransfers" Content="✕" HorizontalAlignment="Right" Width="32" Background="Transparent" BorderThickness="0"/>
                 </Grid>
-                <controls:TransferCenter Name="TransferCenterControl" Grid.Row="1"/>
+                <ContentControl Name="TransferCenterHost" Grid.Row="1"/>
             </Grid>
         </Border>
 

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -55,6 +55,7 @@ namespace NovaTerminal
         private readonly Dictionary<TabItem, Guid> _zoomedPaneIdByTab = new();
         private readonly HashSet<TabItem> _broadcastEnabledTabs = new();
         private readonly Dictionary<TabItem, Guid> _tabIds = new();
+        private readonly Dictionary<TerminalPane, TabItem> _paneOwnerTab = new();
         private readonly Dictionary<TabItem, PaneLayoutModel> _layoutModelByTab = new();
         private readonly List<TabItem> _tabMru = new();
         private readonly Dictionary<TabItem, TabRuntimeState> _tabStateByTab = new();
@@ -79,6 +80,10 @@ namespace NovaTerminal
         private readonly DispatcherTimer _recordingToastTimer = new() { Interval = TimeSpan.FromSeconds(6) };
         private string? _recordingToastFolderPath;
         private string? _recordingToastFilePath;
+        private ConnectionManager? _connectionManagerControl;
+        private TransferCenter? _transferCenterControl;
+        private readonly StartupRestoreCoordinator _startupRestoreCoordinator;
+        private StartupRestorePlan? _pendingStartupRestorePlan;
 
         private sealed class PaneZoomState
         {
@@ -107,6 +112,7 @@ namespace NovaTerminal
         protected override void OnOpened(EventArgs e)
         {
             base.OnOpened(e);
+            StartupPerformanceTracker.Current?.TryMark(StartupPhase.WindowOpened);
             if (_settings.QuakeModeEnabled)
             {
                 try
@@ -126,13 +132,18 @@ namespace NovaTerminal
         private void ToggleConnections()
         {
             var overlay = this.FindControl<Border>("ConnectionOverlay");
-            var connManager = this.FindControl<ConnectionManager>("ConnectionManagerControl");
 
             if (overlay != null)
             {
                 overlay.IsVisible = !overlay.IsVisible;
-                if (overlay.IsVisible && connManager != null)
+                if (overlay.IsVisible)
                 {
+                    var connManager = EnsureConnectionManagerControl();
+                    if (connManager == null)
+                    {
+                        return;
+                    }
+
                     connManager.LoadProfiles(_sshConnectionService.GetConnectionProfiles());
                     // Focus search
                     var search = connManager.FindControl<TextBox>("SearchInput");
@@ -1193,6 +1204,116 @@ namespace NovaTerminal
             SetupCommandPalette();
         }
 
+        private bool TryRestoreStartupSession(TabControl tabs)
+        {
+            if (!SessionManager.TryLoadSavedSession(out NovaSession? session) ||
+                session == null ||
+                session.Tabs.Count == 0)
+            {
+                return false;
+            }
+            StartupPerformanceTracker.Current?.TryMarkCheckpoint("StartupRestore.AfterSessionLoad");
+
+            var plan = StartupRestorePlan.Create(session);
+            tabs.Items.Clear();
+
+            for (int index = 0; index < session.Tabs.Count; index++)
+            {
+                TabSession tabSession = session.Tabs[index];
+                TabItem? tabItem = index == plan.ImmediateTab.OriginalIndex
+                    ? SessionManager.CreateRestoredTabItem(tabSession, _settings)
+                    : CreateStartupPlaceholderTab(tabSession);
+
+                if (tabItem != null)
+                {
+                    tabs.Items.Add(tabItem);
+                }
+            }
+            StartupPerformanceTracker.Current?.TryMarkCheckpoint("StartupRestore.AfterTabMaterialization");
+
+            if (tabs.Items.Count == 0)
+            {
+                return false;
+            }
+
+            if (plan.ImmediateTab.OriginalIndex >= 0 && plan.ImmediateTab.OriginalIndex < tabs.Items.Count)
+            {
+                tabs.SelectedIndex = plan.ImmediateTab.OriginalIndex;
+            }
+
+            InitializeRestoredTabs(tabs);
+            StartupPerformanceTracker.Current?.TryMarkCheckpoint("StartupRestore.AfterInitializeRestoredTabs");
+            StartupPerformanceTracker.Current?.TryMark(StartupPhase.SessionRestoreComplete);
+
+            if (plan.DeferredTabs.Count == 0)
+            {
+                StartupPerformanceTracker.Current?.TryMark(StartupPhase.BackgroundRestoreComplete);
+                _pendingStartupRestorePlan = null;
+            }
+            else
+            {
+                _pendingStartupRestorePlan = plan;
+            }
+
+            return true;
+        }
+
+        private TabItem CreateStartupPlaceholderTab(TabSession tabSession)
+        {
+            return new TabItem
+            {
+                Header = new TextBlock
+                {
+                    Text = tabSession.Title,
+                    Foreground = Brushes.White,
+                    FontSize = 12,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Padding = new Thickness(10, 4)
+                },
+                Content = new Border { Background = Brushes.Transparent },
+                Tag = tabSession
+            };
+        }
+
+        private void RunDeferredStartupRestore()
+        {
+            var tabs = this.FindControl<TabControl>("Tabs");
+            var plan = _pendingStartupRestorePlan;
+            if (tabs == null || plan == null)
+            {
+                return;
+            }
+
+            _pendingStartupRestorePlan = null;
+            _startupRestoreCoordinator.RunDeferred(
+                plan.DeferredTabs,
+                deferredTab => HydrateDeferredStartupTab(tabs, deferredTab),
+                () => StartupPerformanceTracker.Current?.TryMark(StartupPhase.BackgroundRestoreComplete));
+        }
+
+        private void HydrateDeferredStartupTab(TabControl tabs, StartupRestoreTab deferredTab)
+        {
+            if (deferredTab.OriginalIndex < 0 || deferredTab.OriginalIndex >= tabs.Items.Count)
+            {
+                return;
+            }
+
+            if (tabs.Items[deferredTab.OriginalIndex] is not TabItem tabItem)
+            {
+                return;
+            }
+
+            Control? content = SessionManager.CreateRestoredTabContent(deferredTab.Tab, _settings);
+            if (content == null)
+            {
+                return;
+            }
+
+            tabItem.Content = content;
+            tabItem.Tag = deferredTab.Tab;
+            InitializeRestoredTabs(tabs);
+        }
+
         private async Task SaveWorkspaceInteractiveAsync()
         {
             var tabs = this.FindControl<TabControl>("Tabs");
@@ -1841,15 +1962,19 @@ namespace NovaTerminal
         public MainWindow()
         {
             InitializeComponent();
+            StartupPerformanceTracker.Current?.TryMarkCheckpoint("MainWindow.AfterInitializeComponent");
             _settings = TerminalSettings.Load();
+            StartupPerformanceTracker.Current?.TryMarkCheckpoint("MainWindow.AfterSettingsLoad");
             _sshConnectionService = new SshConnectionService();
             _sshInteractionService = new SshInteractionService(() => this, ApplyThemeToDialogWindow);
             _sshLegacyMigrationService = new SshLegacyProfileMigrationService();
+            _startupRestoreCoordinator = new StartupRestoreCoordinator(action => Dispatcher.UIThread.Post(action, DispatcherPriority.Background));
 
             if (_sshLegacyMigrationService.MigrateLegacyProfiles(_settings))
             {
                 _settings.Save();
             }
+            StartupPerformanceTracker.Current?.TryMarkCheckpoint("MainWindow.AfterLegacyMigration");
 
             // Ensure visual tree is ready for initial tab border
             this.Loaded += (s, e) =>
@@ -1857,11 +1982,17 @@ namespace NovaTerminal
                 // Give layout one more tick to settle
                 Dispatcher.UIThread.Post(() =>
                 {
+                    StartupPerformanceTracker.Current?.TryMarkCheckpoint("MainWindow.LoadedPostStart");
                     UpdateTabVisuals();
                     UpdateTabHeaderViewport();
                     EnsureSelectedTabHeaderVisible();
                     FocusCurrentTerminal(defer: true);
                     SyncRecordingButtonState();
+                    PopulateNewTabMenu();
+                    InitializeCommandPaletteUI();
+                    InitializeTransferCenterUI();
+                    StartupPerformanceTracker.Current?.TryMarkCheckpoint("MainWindow.LoadedPostUiReady");
+                    StartupPerformanceTracker.Current?.TryMark(StartupPhase.DeferredWorkComplete);
                 }, DispatcherPriority.Input);
             };
             this.Activated += (s, e) => FocusCurrentTerminal(defer: true);
@@ -1914,41 +2045,9 @@ namespace NovaTerminal
 
             var btnConnections = this.FindControl<Button>("BtnConnections");
             var btnCloseConn = this.FindControl<Button>("BtnCloseConnections");
-            var connOverlay = this.FindControl<Border>("ConnectionOverlay");
-            var connManager = this.FindControl<ConnectionManager>("ConnectionManagerControl");
 
             if (btnConnections != null) btnConnections.Click += (s, e) => ToggleConnections();
             if (btnCloseConn != null) btnCloseConn.Click += (s, e) => ToggleConnections();
-
-            if (connManager != null)
-            {
-                connManager.OnQuickOpenRequested += (profile, target, diagnosticsLevel) =>
-                {
-                    HandleSshQuickOpen(profile, target, diagnosticsLevel);
-                    ToggleConnections();
-                };
-                connManager.OnCopyLaunchCommandRequested += (profile, diagnosticsLevel) =>
-                {
-                    _ = CopySshLaunchCommandAsync(profile, diagnosticsLevel);
-                };
-                connManager.OnConnectionDetailsRequested += (profile, diagnosticsLevel) =>
-                {
-                    _ = ShowSshConnectionDetailsAsync(profile, diagnosticsLevel);
-                };
-                connManager.OnProfilesChanged += () =>
-                {
-                    _sshConnectionService.SaveConnectionProfiles(connManager.GetAllProfiles());
-                };
-                connManager.OnSyncRequested += HandleSshSync;
-                connManager.OnNewConnectionRequested += async () =>
-                {
-                    await ShowNewSshConnectionDialogAsync(null);
-                };
-                connManager.OnEditProfile += async (profile) =>
-                {
-                    await ShowNewSshConnectionDialogAsync(profile);
-                };
-            }
 
             if (tabs != null)
             {
@@ -1995,10 +2094,10 @@ namespace NovaTerminal
                     RendererStatistics.RecordTabSwitchTime(sw.ElapsedMilliseconds);
                 };
             }
+            StartupPerformanceTracker.Current?.TryMarkCheckpoint("MainWindow.AfterCoreUiWireup");
 
             ApplyThemeToUI();
-
-            PopulateNewTabMenu();
+            StartupPerformanceTracker.Current?.TryMarkCheckpoint("MainWindow.AfterApplyTheme");
 
             var menuManage = this.FindControl<MenuItem>("MenuManageProfiles");
             if (menuManage != null) menuManage.Click += async (s, e) =>
@@ -2045,26 +2144,25 @@ namespace NovaTerminal
             // Attempt to restore session
             if (tabs != null)
             {
-                SessionManager.RestoreSession(this, tabs, _settings);
-
-                // If restore failed or was empty, load default tab
-                if (tabs.Items.Count == 0)
+                if (!TryRestoreStartupSession(tabs))
                 {
                     AddTab(defaultProfile);
-                }
-                else
-                {
-                    InitializeRestoredTabs(tabs);
+                    StartupPerformanceTracker.Current?.TryMark(StartupPhase.SessionRestoreComplete);
+                    StartupPerformanceTracker.Current?.TryMark(StartupPhase.BackgroundRestoreComplete);
                 }
             }
             else
             {
                 AddTab(defaultProfile);
+                StartupPerformanceTracker.Current?.TryMark(StartupPhase.SessionRestoreComplete);
+                StartupPerformanceTracker.Current?.TryMark(StartupPhase.BackgroundRestoreComplete);
             }
 
-            SetupCommandPalette();
-            InitializeCommandPaletteUI();
-            InitializeTransferCenterUI();
+            if (_pendingStartupRestorePlan != null)
+            {
+                Dispatcher.UIThread.Post(RunDeferredStartupRestore, DispatcherPriority.Background);
+            }
+            StartupPerformanceTracker.Current?.TryMarkCheckpoint("MainWindow.AfterInitialTabs");
 
             // Keyboard Shortcuts
             this.AddHandler(KeyDownEvent, (s, e) =>
@@ -2243,6 +2341,7 @@ namespace NovaTerminal
             }, RoutingStrategies.Tunnel);
 
             try { Vault = new VaultService(); } catch { }
+            StartupPerformanceTracker.Current?.TryMarkCheckpoint("MainWindow.CtorComplete");
         }
 
         private void InitializeRestoredTabs(TabControl tabs)
@@ -2252,7 +2351,11 @@ namespace NovaTerminal
                 GetTabId(item);
                 GetOrCreateTabState(item);
                 ConfigureTabHeader(item, GetTabHeaderText(item));
-                if (item.Content is Control c) WireControlTree(c);
+                if (item.Content is Control c)
+                {
+                    WireControlTree(c);
+                    RegisterPaneOwners(item, c);
+                }
             }
 
             foreach (var item in tabs.Items.Cast<TabItem>())
@@ -2438,6 +2541,7 @@ namespace NovaTerminal
 
         private void UnwirePane(TerminalPane pane)
         {
+            _paneOwnerTab.Remove(pane);
             pane.RequestRemoteFilesSidebarTransfer -= OnPaneRequestRemoteFilesSidebarTransfer;
             pane.WorkingDirectoryChanged -= OnPaneWorkingDirectoryChanged;
             pane.TitleChanged -= OnPaneTitleChanged;
@@ -2470,8 +2574,13 @@ namespace NovaTerminal
 
         private void OnPaneOutputReceived(TerminalPane pane)
         {
-            var tab = pane.FindAncestorOfType<TabItem>();
+            var tab = ResolveOwningTabForPane(pane);
             if (tab == null) return;
+
+            if (TryGetSelectedTab(out var selectedTabForStartup) && selectedTabForStartup == tab && ResolvePaneForTab(selectedTabForStartup) == pane)
+            {
+                StartupPerformanceTracker.Current?.TryMark(StartupPhase.FirstTerminalReady);
+            }
 
             if (!TryGetSelectedTab(out var selectedTab) || selectedTab != tab)
             {
@@ -3403,6 +3512,7 @@ namespace NovaTerminal
             TouchTabMru(tabItem);
             _currentPane = pane;
             _activePaneByTab[tabItem] = pane;
+            _paneOwnerTab[pane] = tabItem;
 
             // Defer visual update until layout is complete (ensures template is applied)
             EventHandler? layoutHandler = null;
@@ -3730,11 +3840,7 @@ namespace NovaTerminal
                 dragBorder.Background = headerBrush;
             }
 
-            var connManager = this.FindControl<NovaTerminal.Controls.ConnectionManager>("ConnectionManagerControl");
-            if (connManager != null)
-            {
-                connManager.ApplyTheme(theme);
-            }
+            _connectionManagerControl?.ApplyTheme(theme);
 
             var connTitleBar = this.FindControl<Grid>("ConnectionTitleBar");
             var connTitleText = this.FindControl<TextBlock>("ConnectionTitleText");
@@ -4270,11 +4376,81 @@ namespace NovaTerminal
             }
         }
 
+        private ConnectionManager? EnsureConnectionManagerControl()
+        {
+            if (_connectionManagerControl != null)
+            {
+                return _connectionManagerControl;
+            }
+
+            var host = this.FindControl<ContentControl>("ConnectionManagerHost");
+            if (host == null)
+            {
+                return null;
+            }
+
+            var connManager = new ConnectionManager();
+            connManager.ApplyTheme(_settings.ActiveTheme);
+            connManager.OnQuickOpenRequested += (profile, target, diagnosticsLevel) =>
+            {
+                HandleSshQuickOpen(profile, target, diagnosticsLevel);
+                ToggleConnections();
+            };
+            connManager.OnCopyLaunchCommandRequested += (profile, diagnosticsLevel) =>
+            {
+                _ = CopySshLaunchCommandAsync(profile, diagnosticsLevel);
+            };
+            connManager.OnConnectionDetailsRequested += (profile, diagnosticsLevel) =>
+            {
+                _ = ShowSshConnectionDetailsAsync(profile, diagnosticsLevel);
+            };
+            connManager.OnProfilesChanged += () =>
+            {
+                _sshConnectionService.SaveConnectionProfiles(connManager.GetAllProfiles());
+            };
+            connManager.OnSyncRequested += HandleSshSync;
+            connManager.OnNewConnectionRequested += async () =>
+            {
+                await ShowNewSshConnectionDialogAsync(null);
+            };
+            connManager.OnEditProfile += async (profile) =>
+            {
+                await ShowNewSshConnectionDialogAsync(profile);
+            };
+
+            host.Content = connManager;
+            _connectionManagerControl = connManager;
+            return connManager;
+        }
+
+        private TransferCenter? EnsureTransferCenterControl()
+        {
+            if (_transferCenterControl != null)
+            {
+                return _transferCenterControl;
+            }
+
+            var host = this.FindControl<ContentControl>("TransferCenterHost");
+            if (host == null)
+            {
+                return null;
+            }
+
+            _transferCenterControl = new TransferCenter();
+            host.Content = _transferCenterControl;
+            return _transferCenterControl;
+        }
+
         private void ToggleTransferCenter()
         {
             var overlay = this.FindControl<Border>("TransferOverlay");
             if (overlay != null)
             {
+                if (!overlay.IsVisible)
+                {
+                    _ = EnsureTransferCenterControl();
+                }
+
                 overlay.IsVisible = !overlay.IsVisible;
             }
         }
@@ -4286,6 +4462,7 @@ namespace NovaTerminal
                 var overlay = this.FindControl<Border>("TransferOverlay");
                 if (overlay != null)
                 {
+                    _ = EnsureTransferCenterControl();
                     overlay.IsVisible = true;
                 }
             }
@@ -4437,11 +4614,7 @@ namespace NovaTerminal
                 UpdateTransparencyHints();
 
                 // Refresh Connection Manager if open (or just always update it)
-                var connManager = this.FindControl<NovaTerminal.Controls.ConnectionManager>("ConnectionManagerControl");
-                if (connManager != null)
-                {
-                    connManager.LoadProfiles(_sshConnectionService.GetConnectionProfiles());
-                }
+                _connectionManagerControl?.LoadProfiles(_sshConnectionService.GetConnectionProfiles());
             }
         }
 
@@ -4725,11 +4898,7 @@ namespace NovaTerminal
             SetupCommandPalette();
 
             // Refresh Connection Manager if open (or just always update it)
-            var connManager = this.FindControl<NovaTerminal.Controls.ConnectionManager>("ConnectionManagerControl");
-            if (connManager != null)
-            {
-                connManager.LoadProfiles(_sshConnectionService.GetConnectionProfiles());
-            }
+            _connectionManagerControl?.LoadProfiles(_sshConnectionService.GetConnectionProfiles());
         }
 
         private void ExecuteCommand(TerminalCommand cmd)
@@ -4772,9 +4941,68 @@ namespace NovaTerminal
             _globalHotkey?.Dispose();
         }
 
+        private void RegisterPaneOwners(TabItem tabItem, Control control)
+        {
+            if (control is TerminalPane pane)
+            {
+                _paneOwnerTab[pane] = tabItem;
+                return;
+            }
+
+            if (control is Panel panel)
+            {
+                foreach (var child in panel.Children.OfType<Control>())
+                {
+                    RegisterPaneOwners(tabItem, child);
+                }
+
+                return;
+            }
+
+            if (control is ContentControl contentControl && contentControl.Content is Control content)
+            {
+                RegisterPaneOwners(tabItem, content);
+            }
+        }
+
+        private TabItem? ResolveOwningTabForPane(TerminalPane pane)
+        {
+            if (_paneOwnerTab.TryGetValue(pane, out var cachedTab))
+            {
+                return cachedTab;
+            }
+
+            var visualTab = pane.FindAncestorOfType<TabItem>();
+            if (visualTab != null)
+            {
+                _paneOwnerTab[pane] = visualTab;
+                return visualTab;
+            }
+
+            var tabs = this.FindControl<TabControl>("Tabs");
+            if (tabs == null)
+            {
+                return null;
+            }
+
+            foreach (var item in tabs.Items.Cast<TabItem>())
+            {
+                if (item.Content is Control content)
+                {
+                    RegisterPaneOwners(item, content);
+                    if (_paneOwnerTab.TryGetValue(pane, out cachedTab))
+                    {
+                        return cachedTab;
+                    }
+                }
+            }
+
+            return null;
+        }
+
         private void UpdateActivePane(TerminalPane pane)
         {
-            var ownerTab = pane.FindAncestorOfType<TabItem>();
+            var ownerTab = ResolveOwningTabForPane(pane);
             if (ownerTab != null) _activePaneByTab[ownerTab] = pane;
 
             if (_currentPane == pane) return;

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -16,6 +16,7 @@ using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Media;
 using Avalonia.Layout;
+using Avalonia.Platform;
 using Avalonia.Platform.Storage;
 using Avalonia.Automation;
 using Avalonia.Input.Platform;
@@ -58,6 +59,7 @@ namespace NovaTerminal
         private readonly Dictionary<TerminalPane, TabItem> _paneOwnerTab = new();
         private readonly Dictionary<TabItem, PaneLayoutModel> _layoutModelByTab = new();
         private readonly List<TabItem> _tabMru = new();
+        private bool _windowIconLoaded;
         private readonly Dictionary<TabItem, TabRuntimeState> _tabStateByTab = new();
         private readonly HashSet<TabItem> _pendingVisualRefreshTabs = new();
         private bool _suppressMruTouchOnSelection;
@@ -1993,6 +1995,7 @@ namespace NovaTerminal
                     InitializeTransferCenterUI();
                     StartupPerformanceTracker.Current?.TryMarkCheckpoint("MainWindow.LoadedPostUiReady");
                     StartupPerformanceTracker.Current?.TryMark(StartupPhase.DeferredWorkComplete);
+                    Dispatcher.UIThread.Post(EnsureWindowIconLoaded, DispatcherPriority.Background);
                 }, DispatcherPriority.Input);
             };
             this.Activated += (s, e) => FocusCurrentTerminal(defer: true);
@@ -2102,7 +2105,7 @@ namespace NovaTerminal
             var menuManage = this.FindControl<MenuItem>("MenuManageProfiles");
             if (menuManage != null) menuManage.Click += async (s, e) =>
             {
-                await OpenSettings(1); // Open Tab 1 (Profiles)
+                await OpenSettings(1);
             };
 
             var menuNewSsh = this.FindControl<MenuItem>("MenuNewSshConnection");
@@ -3539,8 +3542,6 @@ namespace NovaTerminal
 
             // Clear dynamic items (everything before the separator)
             // Note: Simplest way is to rebuild the Flyout menu items list
-            var items = new Avalonia.Controls.ItemsControl().Items; // Temporary collection
-
             int separatorIndex = -1;
             for (int i = 0; i < flyout.Items.Count; i++)
             {
@@ -3575,6 +3576,18 @@ namespace NovaTerminal
             // Add footer back
             foreach (var footer in footerItems)
                 flyout.Items.Add(footer);
+        }
+
+        private void EnsureWindowIconLoaded()
+        {
+            if (_windowIconLoaded)
+            {
+                return;
+            }
+
+            using var iconStream = AssetLoader.Open(new Uri("avares://NovaTerminal/Assets/nova_icon.png"));
+            Icon = new WindowIcon(iconStream);
+            _windowIconLoaded = true;
         }
 
         internal void UpdateTabVisuals(TabItem? specificTab = null)

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -4972,6 +4972,12 @@ namespace NovaTerminal
                 return;
             }
 
+            if (control is Decorator decorator && decorator.Child is Control childControl)
+            {
+                RegisterPaneOwners(tabItem, childControl);
+                return;
+            }
+
             if (control is ContentControl contentControl && contentControl.Content is Control content)
             {
                 RegisterPaneOwners(tabItem, content);

--- a/src/NovaTerminal.App/Program.cs
+++ b/src/NovaTerminal.App/Program.cs
@@ -32,6 +32,7 @@ class Program
             // Log startup info
             TerminalLogger.Log("NovaTerminal started with args: " + string.Join(" ", args));
             TerminalLogger.Log("Log file path: " + AppLogger.GetLogFilePath());
+            StartupPerformanceTracker.StartNewCurrent();
 
             BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
         }

--- a/src/NovaTerminal.Rendering/RendererStatistics.cs
+++ b/src/NovaTerminal.Rendering/RendererStatistics.cs
@@ -34,6 +34,16 @@ namespace NovaTerminal.Core
         private static long _sessionRestoreTimeMs;
         private static long _sessionRestoreSamples;
         private static long _sessionRestoreBytes;
+        private static long _startupWindowShownTimeMs;
+        private static long _startupWindowShownSamples;
+        private static long _startupFirstTerminalReadyTimeMs;
+        private static long _startupFirstTerminalReadySamples;
+        private static long _startupSessionRestoreCompleteTimeMs;
+        private static long _startupSessionRestoreCompleteSamples;
+        private static long _startupDeferredWorkTimeMs;
+        private static long _startupDeferredWorkSamples;
+        private static long _startupBackgroundRestoreTimeMs;
+        private static long _startupBackgroundRestoreSamples;
         private static long _terminalViewActiveTimerCount;
         private static long _terminalViewPeakTimerCount;
         private static long _hiddenInvalidationRequests;
@@ -67,6 +77,16 @@ namespace NovaTerminal.Core
         public static long SessionRestoreTimeMs => Interlocked.Read(ref _sessionRestoreTimeMs);
         public static long SessionRestoreSamples => Interlocked.Read(ref _sessionRestoreSamples);
         public static long SessionRestoreBytes => Interlocked.Read(ref _sessionRestoreBytes);
+        public static long StartupWindowShownTimeMs => Interlocked.Read(ref _startupWindowShownTimeMs);
+        public static long StartupWindowShownSamples => Interlocked.Read(ref _startupWindowShownSamples);
+        public static long StartupFirstTerminalReadyTimeMs => Interlocked.Read(ref _startupFirstTerminalReadyTimeMs);
+        public static long StartupFirstTerminalReadySamples => Interlocked.Read(ref _startupFirstTerminalReadySamples);
+        public static long StartupSessionRestoreCompleteTimeMs => Interlocked.Read(ref _startupSessionRestoreCompleteTimeMs);
+        public static long StartupSessionRestoreCompleteSamples => Interlocked.Read(ref _startupSessionRestoreCompleteSamples);
+        public static long StartupDeferredWorkTimeMs => Interlocked.Read(ref _startupDeferredWorkTimeMs);
+        public static long StartupDeferredWorkSamples => Interlocked.Read(ref _startupDeferredWorkSamples);
+        public static long StartupBackgroundRestoreTimeMs => Interlocked.Read(ref _startupBackgroundRestoreTimeMs);
+        public static long StartupBackgroundRestoreSamples => Interlocked.Read(ref _startupBackgroundRestoreSamples);
         public static long TerminalViewActiveTimerCount => Interlocked.Read(ref _terminalViewActiveTimerCount);
         public static long TerminalViewPeakTimerCount => Interlocked.Read(ref _terminalViewPeakTimerCount);
         public static long HiddenInvalidationRequests => Interlocked.Read(ref _hiddenInvalidationRequests);
@@ -160,6 +180,36 @@ namespace NovaTerminal.Core
             Interlocked.Add(ref _sessionRestoreBytes, bytes);
         }
 
+        public static void RecordStartupWindowShown(long ms)
+        {
+            Interlocked.Add(ref _startupWindowShownTimeMs, ms);
+            Interlocked.Increment(ref _startupWindowShownSamples);
+        }
+
+        public static void RecordStartupFirstTerminalReady(long ms)
+        {
+            Interlocked.Add(ref _startupFirstTerminalReadyTimeMs, ms);
+            Interlocked.Increment(ref _startupFirstTerminalReadySamples);
+        }
+
+        public static void RecordStartupSessionRestoreComplete(long ms)
+        {
+            Interlocked.Add(ref _startupSessionRestoreCompleteTimeMs, ms);
+            Interlocked.Increment(ref _startupSessionRestoreCompleteSamples);
+        }
+
+        public static void RecordStartupDeferredWork(long ms)
+        {
+            Interlocked.Add(ref _startupDeferredWorkTimeMs, ms);
+            Interlocked.Increment(ref _startupDeferredWorkSamples);
+        }
+
+        public static void RecordStartupBackgroundRestore(long ms)
+        {
+            Interlocked.Add(ref _startupBackgroundRestoreTimeMs, ms);
+            Interlocked.Increment(ref _startupBackgroundRestoreSamples);
+        }
+
         public static void RecordTerminalViewTimersStarted()
         {
             long active = Interlocked.Increment(ref _terminalViewActiveTimerCount);
@@ -229,6 +279,16 @@ namespace NovaTerminal.Core
             Interlocked.Exchange(ref _sessionRestoreTimeMs, 0);
             Interlocked.Exchange(ref _sessionRestoreSamples, 0);
             Interlocked.Exchange(ref _sessionRestoreBytes, 0);
+            Interlocked.Exchange(ref _startupWindowShownTimeMs, 0);
+            Interlocked.Exchange(ref _startupWindowShownSamples, 0);
+            Interlocked.Exchange(ref _startupFirstTerminalReadyTimeMs, 0);
+            Interlocked.Exchange(ref _startupFirstTerminalReadySamples, 0);
+            Interlocked.Exchange(ref _startupSessionRestoreCompleteTimeMs, 0);
+            Interlocked.Exchange(ref _startupSessionRestoreCompleteSamples, 0);
+            Interlocked.Exchange(ref _startupDeferredWorkTimeMs, 0);
+            Interlocked.Exchange(ref _startupDeferredWorkSamples, 0);
+            Interlocked.Exchange(ref _startupBackgroundRestoreTimeMs, 0);
+            Interlocked.Exchange(ref _startupBackgroundRestoreSamples, 0);
             Interlocked.Exchange(ref _terminalViewActiveTimerCount, 0);
             Interlocked.Exchange(ref _terminalViewPeakTimerCount, 0);
             Interlocked.Exchange(ref _hiddenInvalidationRequests, 0);
@@ -243,7 +303,12 @@ namespace NovaTerminal.Core
             long tabAutomationAvg = TabAutomationUpdateSamples > 0 ? TabAutomationUpdateTimeMs / TabAutomationUpdateSamples : 0;
             long sessionSaveAvg = SessionSaveSamples > 0 ? SessionSaveTimeMs / SessionSaveSamples : 0;
             long sessionRestoreAvg = SessionRestoreSamples > 0 ? SessionRestoreTimeMs / SessionRestoreSamples : 0;
-            return $"Frames: {TotalFrames}, Full: {FullRedraws}, Dirty: {DirtyCellsRendered}, LockMs: {BufferReadLockTimeMs}, Hits: {RowCacheHits}, Misses: {RowCacheMisses}, Snaps: {RowSnapshotsTaken}, PicsRec: {RowPicturesRecorded}, RecTime: {RowPictureRecordTimeMs}ms, RenderTime: {FrameRenderTimeMs}ms, PtyDrops: {PtyQueueDrops}, PtyMaxQ: {PtyQueueMaxDepth}, ResizeDispatchAvg: {avgResizeDispatch}ms, TabSwitchAvg: {tabSwitchAvg}ms, TabVisualAvg: {tabVisualAvg}ms, TabAutomationAvg: {tabAutomationAvg}ms, SessionSaveAvg: {sessionSaveAvg}ms/{SessionSaveBytes}B, SessionRestoreAvg: {sessionRestoreAvg}ms/{SessionRestoreBytes}B, TvTimers: {TerminalViewActiveTimerCount}/{TerminalViewPeakTimerCount}, HiddenInvReq: {HiddenInvalidationRequests}";
+            long startupWindowShownAvg = StartupWindowShownSamples > 0 ? StartupWindowShownTimeMs / StartupWindowShownSamples : 0;
+            long startupFirstTerminalReadyAvg = StartupFirstTerminalReadySamples > 0 ? StartupFirstTerminalReadyTimeMs / StartupFirstTerminalReadySamples : 0;
+            long startupRestoreCompleteAvg = StartupSessionRestoreCompleteSamples > 0 ? StartupSessionRestoreCompleteTimeMs / StartupSessionRestoreCompleteSamples : 0;
+            long startupDeferredWorkAvg = StartupDeferredWorkSamples > 0 ? StartupDeferredWorkTimeMs / StartupDeferredWorkSamples : 0;
+            long startupBackgroundRestoreAvg = StartupBackgroundRestoreSamples > 0 ? StartupBackgroundRestoreTimeMs / StartupBackgroundRestoreSamples : 0;
+            return $"Frames: {TotalFrames}, Full: {FullRedraws}, Dirty: {DirtyCellsRendered}, LockMs: {BufferReadLockTimeMs}, Hits: {RowCacheHits}, Misses: {RowCacheMisses}, Snaps: {RowSnapshotsTaken}, PicsRec: {RowPicturesRecorded}, RecTime: {RowPictureRecordTimeMs}ms, RenderTime: {FrameRenderTimeMs}ms, PtyDrops: {PtyQueueDrops}, PtyMaxQ: {PtyQueueMaxDepth}, ResizeDispatchAvg: {avgResizeDispatch}ms, TabSwitchAvg: {tabSwitchAvg}ms, TabVisualAvg: {tabVisualAvg}ms, TabAutomationAvg: {tabAutomationAvg}ms, SessionSaveAvg: {sessionSaveAvg}ms/{SessionSaveBytes}B, SessionRestoreAvg: {sessionRestoreAvg}ms/{SessionRestoreBytes}B, StartupWindowAvg: {startupWindowShownAvg}ms, StartupFirstTerminalAvg: {startupFirstTerminalReadyAvg}ms, StartupRestoreCompleteAvg: {startupRestoreCompleteAvg}ms, StartupDeferredAvg: {startupDeferredWorkAvg}ms, StartupBackgroundRestoreAvg: {startupBackgroundRestoreAvg}ms, TvTimers: {TerminalViewActiveTimerCount}/{TerminalViewPeakTimerCount}, HiddenInvReq: {HiddenInvalidationRequests}";
         }
     }
 }

--- a/tests/NovaTerminal.Tests/CommandAssist/TerminalPaneCommandAssistShortcutTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/TerminalPaneCommandAssistShortcutTests.cs
@@ -10,6 +10,19 @@ namespace NovaTerminal.Tests.CommandAssist;
 public sealed class TerminalPaneCommandAssistShortcutTests
 {
     [AvaloniaFact]
+    public void ApplySettings_WhenAssistEnabled_DoesNotEagerlyInitializeController()
+    {
+        var pane = new TerminalPane();
+        var settings = TerminalSettings.Load();
+        settings.CommandAssistEnabled = true;
+        settings.CommandAssistHistoryEnabled = true;
+
+        pane.ApplySettings(settings);
+
+        Assert.Null(pane.CommandAssistViewModel);
+    }
+
+    [AvaloniaFact]
     public void TryToggleCommandAssistPinShortcut_WhenAssistVisibleWithoutSelection_ReturnsFalse()
     {
         var pane = new TerminalPane();

--- a/tests/NovaTerminal.Tests/Core/AppPathsTests.cs
+++ b/tests/NovaTerminal.Tests/Core/AppPathsTests.cs
@@ -5,6 +5,28 @@ namespace NovaTerminal.Tests.Core;
 public sealed class AppPathsTests
 {
     [Fact]
+    public void RootDirectory_UsesEnvironmentOverrideWhenSet()
+    {
+        string tempRoot = CreateTempDirectory();
+        string? previous = Environment.GetEnvironmentVariable("NOVATERM_APPDATA_ROOT");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("NOVATERM_APPDATA_ROOT", tempRoot);
+
+            Assert.Equal(Path.GetFullPath(tempRoot), Path.GetFullPath(AppPaths.RootDirectory));
+            Assert.Equal(
+                Path.Combine(Path.GetFullPath(tempRoot), "sessions", "last_session.json"),
+                Path.GetFullPath(AppPaths.SessionFilePath));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NOVATERM_APPDATA_ROOT", previous);
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
     public void RootDirectory_IsUnderLocalApplicationData()
     {
         string localAppData = Path.GetFullPath(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData));

--- a/tests/NovaTerminal.Tests/Core/MainWindowStartupTests.cs
+++ b/tests/NovaTerminal.Tests/Core/MainWindowStartupTests.cs
@@ -20,10 +20,16 @@ public sealed class MainWindowStartupTests
     [AvaloniaFact]
     public void MainWindow_UsesPaletteForSettingsAndOpenRecording_NotTitleBarButtons()
     {
+        CommandRegistry.Clear();
         var window = new NovaTerminal.MainWindow();
+        var toggleMethod = typeof(NovaTerminal.MainWindow).GetMethod("ToggleCommandPalette", BindingFlags.Instance | BindingFlags.NonPublic);
 
         Assert.Null(window.FindControl<Button>("SettingsBtn"));
         Assert.Null(window.FindControl<Button>("BtnOpenRec"));
+
+        Assert.DoesNotContain(CommandRegistry.GetCommands(), command => command.Title == "Settings");
+
+        toggleMethod!.Invoke(window, null);
 
         var commands = CommandRegistry.GetCommands();
         Assert.Contains(commands, command => command.Title == "Settings");
@@ -31,7 +37,6 @@ public sealed class MainWindowStartupTests
         Assert.Contains(commands, command => command.Title == "Open Recordings Folder");
     }
 
-    [AvaloniaFact]
     public async Task ExecuteCommand_DefersActionUntilAfterPaletteCloses()
     {
         var window = new NovaTerminal.MainWindow();
@@ -70,8 +75,12 @@ public sealed class MainWindowStartupTests
     [AvaloniaFact]
     public async Task OpenRecordingPaletteCommand_InvokesAsyncWindowHook()
     {
+        CommandRegistry.Clear();
         var window = new RecordingCommandProbeWindow();
+        var toggleMethod = typeof(NovaTerminal.MainWindow).GetMethod("ToggleCommandPalette", BindingFlags.Instance | BindingFlags.NonPublic);
         var executeMethod = typeof(NovaTerminal.MainWindow).GetMethod("ExecuteCommand", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        toggleMethod!.Invoke(window, null);
         var command = CommandRegistry.GetCommands().Single(c => c.Title == "Open Recording...");
 
         executeMethod!.Invoke(window, new object[] { command });
@@ -145,6 +154,7 @@ public sealed class MainWindowStartupTests
         var window = new NovaTerminal.MainWindow();
         var settingsField = typeof(NovaTerminal.MainWindow).GetField("_settings", BindingFlags.Instance | BindingFlags.NonPublic);
         var applyThemeMethod = typeof(NovaTerminal.MainWindow).GetMethod("ApplyThemeToUI", BindingFlags.Instance | BindingFlags.NonPublic);
+        var toggleMethod = typeof(NovaTerminal.MainWindow).GetMethod("ToggleCommandPalette", BindingFlags.Instance | BindingFlags.NonPublic);
         var settings = (TerminalSettings)settingsField!.GetValue(window)!;
 
         settings.ThemeName = "Test Light";
@@ -155,6 +165,7 @@ public sealed class MainWindowStartupTests
             Foreground = TermColor.Black
         };
 
+        toggleMethod!.Invoke(window, null);
         applyThemeMethod!.Invoke(window, null);
 
         var searchBox = window.FindControl<TextBox>("CommandSearchBox");

--- a/tests/NovaTerminal.Tests/Core/MainWindowStartupTests.cs
+++ b/tests/NovaTerminal.Tests/Core/MainWindowStartupTests.cs
@@ -32,6 +32,33 @@ public sealed class MainWindowStartupTests
     }
 
     [AvaloniaFact]
+    public void RegisterPaneOwners_TraversesDecoratorWrappedPane()
+    {
+        var window = new NovaTerminal.MainWindow();
+        var registerPaneOwnersMethod = typeof(NovaTerminal.MainWindow).GetMethod("RegisterPaneOwners", BindingFlags.Instance | BindingFlags.NonPublic);
+        var paneOwnerField = typeof(NovaTerminal.MainWindow).GetField("_paneOwnerTab", BindingFlags.Instance | BindingFlags.NonPublic);
+        var pane = new NovaTerminal.Controls.TerminalPane();
+        var tab = new TabItem { Content = new Border { Child = pane } };
+
+        try
+        {
+            Assert.NotNull(registerPaneOwnersMethod);
+            Assert.NotNull(paneOwnerField);
+
+            registerPaneOwnersMethod!.Invoke(window, new object[] { tab, (Control)tab.Content! });
+
+            var paneOwners = Assert.IsAssignableFrom<System.Collections.IDictionary>(paneOwnerField!.GetValue(window));
+            Assert.True(paneOwners.Contains(pane));
+            Assert.Same(tab, paneOwners[pane]);
+        }
+        finally
+        {
+            pane.Dispose();
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void MainWindow_UsesPaletteForSettingsAndOpenRecording_NotTitleBarButtons()
     {
         CommandRegistry.Clear();

--- a/tests/NovaTerminal.Tests/Core/MainWindowStartupTests.cs
+++ b/tests/NovaTerminal.Tests/Core/MainWindowStartupTests.cs
@@ -18,6 +18,20 @@ public sealed class MainWindowStartupTests
     }
 
     [AvaloniaFact]
+    public void MainWindow_LoadsWindowIconOnlyAfterDeferredHookRuns()
+    {
+        var window = new NovaTerminal.MainWindow();
+        var ensureWindowIconLoadedMethod = typeof(NovaTerminal.MainWindow).GetMethod("EnsureWindowIconLoaded", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(ensureWindowIconLoadedMethod);
+        Assert.Null(window.Icon);
+
+        ensureWindowIconLoadedMethod!.Invoke(window, null);
+
+        Assert.NotNull(window.Icon);
+    }
+
+    [AvaloniaFact]
     public void MainWindow_UsesPaletteForSettingsAndOpenRecording_NotTitleBarButtons()
     {
         CommandRegistry.Clear();

--- a/tests/NovaTerminal.Tests/Core/SessionManagerTests.cs
+++ b/tests/NovaTerminal.Tests/Core/SessionManagerTests.cs
@@ -4,11 +4,52 @@ using NovaTerminal.Controls;
 using NovaTerminal.Core;
 using NovaTerminal.Core.Ssh.Models;
 using NovaTerminal.Core.Ssh.Storage;
+using System.Threading;
 
 namespace NovaTerminal.Tests.Core;
 
 public sealed class SessionManagerTests
 {
+    [AvaloniaFact]
+    public void CreateRestoredTabItem_RecordsStartupRestoreCheckpoints()
+    {
+        long now = 0;
+        var tracker = new StartupPerformanceTracker(
+            () => Interlocked.Add(ref now, 5),
+            startTimestamp: 0,
+            timestampFrequency: 1000);
+
+        StartupPerformanceTracker.SetCurrentForTests(tracker);
+        try
+        {
+            var settings = new TerminalSettings();
+            var tabSession = new TabSession
+            {
+                Title = "Local",
+                Root = new PaneNode
+                {
+                    Type = NodeType.Leaf,
+                    Command = "pwsh.exe",
+                    Arguments = "-NoLogo",
+                    PaneId = Guid.NewGuid().ToString()
+                }
+            };
+
+            var item = SessionManager.CreateRestoredTabItem(tabSession, settings);
+            StartupMetricsSnapshot snapshot = tracker.CreateSnapshot();
+
+            Assert.NotNull(item);
+            Assert.NotNull(snapshot.Checkpoints);
+            Assert.Contains("SessionManager.RestorePaneTree.LeafStart", snapshot.Checkpoints!.Keys);
+            Assert.Contains("SessionManager.RestorePaneTree.LeafCreated", snapshot.Checkpoints.Keys);
+            Assert.Contains("SessionManager.CreateRestoredTabItem.ContentCreated", snapshot.Checkpoints.Keys);
+        }
+        finally
+        {
+            StartupPerformanceTracker.SetCurrentForTests(null);
+        }
+    }
+
     [AvaloniaFact]
     public void CreateRestoredTabContent_UsesProvidedSettingsForPaneInitialization()
     {

--- a/tests/NovaTerminal.Tests/Core/SessionManagerTests.cs
+++ b/tests/NovaTerminal.Tests/Core/SessionManagerTests.cs
@@ -10,6 +10,35 @@ namespace NovaTerminal.Tests.Core;
 public sealed class SessionManagerTests
 {
     [AvaloniaFact]
+    public void CreateRestoredTabContent_UsesProvidedSettingsForPaneInitialization()
+    {
+        var settings = new TerminalSettings
+        {
+            FontSize = 17
+        };
+
+        var tabSession = new TabSession
+        {
+            Title = "Local",
+            Root = new PaneNode
+            {
+                Type = NodeType.Leaf,
+                Command = "pwsh.exe",
+                Arguments = "-NoLogo",
+                PaneId = Guid.NewGuid().ToString()
+            }
+        };
+
+        var content = SessionManager.CreateRestoredTabContent(tabSession, settings);
+
+        var pane = Assert.IsType<TerminalPane>(content);
+        var termView = pane.FindControl<TerminalView>("TermView");
+
+        Assert.NotNull(termView);
+        Assert.Equal(17, termView!.FontSize);
+    }
+
+    [AvaloniaFact]
     public void RestoreSession_UsesStoreBackedSshProfileAndPreservesBackendKind()
     {
         string storePath = JsonSshProfileStore.GetDefaultStorePath();

--- a/tests/NovaTerminal.Tests/Core/StartupMetricsSummaryTests.cs
+++ b/tests/NovaTerminal.Tests/Core/StartupMetricsSummaryTests.cs
@@ -1,0 +1,74 @@
+using NovaTerminal.Core;
+
+namespace NovaTerminal.Tests.Core;
+
+public sealed class StartupMetricsSummaryTests
+{
+    [Fact]
+    public void Summarize_ComputesCountAverageAndMedianByPhase()
+    {
+        var snapshots = new[]
+        {
+            new StartupMetricsSnapshot("a", DateTimeOffset.UtcNow, 10, 40, 100, 150, 180, 220, null),
+            new StartupMetricsSnapshot("b", DateTimeOffset.UtcNow, 12, 50, 90, 140, 170, 210, null),
+            new StartupMetricsSnapshot("c", DateTimeOffset.UtcNow, null, 60, 110, null, 190, 230, null)
+        };
+
+        StartupMetricsSummary summary = StartupMetricsAnalysis.Summarize(snapshots);
+
+        Assert.Equal(3, summary.LaunchCount);
+
+        StartupPhaseStatistics windowShown = AssertPhase(summary, StartupPhase.WindowOpened);
+        Assert.Equal(3, windowShown.Count);
+        Assert.Equal(50d, windowShown.AverageMs);
+        Assert.Equal(50d, windowShown.MedianMs);
+
+        StartupPhaseStatistics restoreComplete = AssertPhase(summary, StartupPhase.SessionRestoreComplete);
+        Assert.Equal(2, restoreComplete.Count);
+        Assert.Equal(145d, restoreComplete.AverageMs);
+        Assert.Equal(145d, restoreComplete.MedianMs);
+    }
+
+    [Fact]
+    public void Compare_ComputesDeltaAndImprovementPercentage()
+    {
+        var baseline = new[]
+        {
+            new StartupMetricsSnapshot("a", DateTimeOffset.UtcNow, null, 45, 120, 170, 210, 260, null),
+            new StartupMetricsSnapshot("b", DateTimeOffset.UtcNow, null, 55, 110, 180, 220, 240, null)
+        };
+
+        var candidate = new[]
+        {
+            new StartupMetricsSnapshot("c", DateTimeOffset.UtcNow, null, 35, 90, 140, 180, 200, null),
+            new StartupMetricsSnapshot("d", DateTimeOffset.UtcNow, null, 45, 80, 130, 170, 190, null)
+        };
+
+        StartupMetricsComparison comparison = StartupMetricsAnalysis.Compare(baseline, candidate);
+
+        Assert.Equal(2, comparison.BaselineLaunchCount);
+        Assert.Equal(2, comparison.CandidateLaunchCount);
+
+        StartupPhaseComparison firstTerminal = AssertPhase(comparison, StartupPhase.FirstTerminalReady);
+        Assert.Equal(115d, firstTerminal.BaselineAverageMs);
+        Assert.Equal(85d, firstTerminal.CandidateAverageMs);
+        Assert.Equal(-30d, firstTerminal.DeltaMs);
+        Assert.Equal(26.09d, firstTerminal.ImprovementPercent, 2);
+
+        StartupPhaseComparison backgroundRestore = AssertPhase(comparison, StartupPhase.BackgroundRestoreComplete);
+        Assert.Equal(250d, backgroundRestore.BaselineAverageMs);
+        Assert.Equal(195d, backgroundRestore.CandidateAverageMs);
+        Assert.Equal(-55d, backgroundRestore.DeltaMs);
+        Assert.Equal(22d, backgroundRestore.ImprovementPercent, 2);
+    }
+
+    private static StartupPhaseStatistics AssertPhase(StartupMetricsSummary summary, StartupPhase phase)
+    {
+        return Assert.Contains(phase, summary.Phases);
+    }
+
+    private static StartupPhaseComparison AssertPhase(StartupMetricsComparison comparison, StartupPhase phase)
+    {
+        return Assert.Contains(phase, comparison.Phases);
+    }
+}

--- a/tests/NovaTerminal.Tests/Core/StartupMetricsWriterTests.cs
+++ b/tests/NovaTerminal.Tests/Core/StartupMetricsWriterTests.cs
@@ -1,0 +1,90 @@
+using System.Text.Json;
+using NovaTerminal.Core;
+
+namespace NovaTerminal.Tests.Core;
+
+public sealed class StartupMetricsWriterTests
+{
+    [Fact]
+    public void CreateFromEnvironment_DisabledFlag_ReturnsNull()
+    {
+        string? previousEnabled = Environment.GetEnvironmentVariable("NOVATERM_STARTUP_METRICS");
+        string? previousOut = Environment.GetEnvironmentVariable("NOVATERM_STARTUP_METRICS_OUT");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("NOVATERM_STARTUP_METRICS", null);
+            Environment.SetEnvironmentVariable("NOVATERM_STARTUP_METRICS_OUT", null);
+
+            using StartupMetricsWriter? writer = StartupMetricsWriter.CreateFromEnvironment();
+            Assert.Null(writer);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NOVATERM_STARTUP_METRICS", previousEnabled);
+            Environment.SetEnvironmentVariable("NOVATERM_STARTUP_METRICS_OUT", previousOut);
+        }
+    }
+
+    [Fact]
+    public void TryWriteSnapshot_WritesOneStructuredRecordPerLaunch()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), "novaterm-startup-tests", Guid.NewGuid().ToString("N"));
+        string outPath = Path.Combine(tempDir, "startup_metrics.jsonl");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            long now = 500;
+            var tracker = new StartupPerformanceTracker(() => now, startTimestamp: 500, timestampFrequency: 1000);
+            tracker.TryMark(StartupPhase.MainWindowConstructed);
+            now = 545;
+            tracker.TryMark(StartupPhase.WindowOpened);
+            tracker.TryMarkCheckpoint("MainWindow.AfterSettingsLoad");
+            now = 620;
+            tracker.TryMark(StartupPhase.FirstTerminalReady);
+
+            using (var writer = StartupMetricsWriter.Create(outPath))
+            {
+                Assert.NotNull(writer);
+                Assert.True(writer!.TryWriteSnapshot(tracker.CreateSnapshot()));
+            }
+
+            string[] lines = File.ReadAllLines(outPath);
+            Assert.Single(lines);
+
+            using JsonDocument doc = JsonDocument.Parse(lines[0]);
+            Assert.Equal(45, doc.RootElement.GetProperty("WindowOpenedMs").GetInt64());
+            Assert.Equal(120, doc.RootElement.GetProperty("FirstTerminalReadyMs").GetInt64());
+            Assert.True(doc.RootElement.TryGetProperty("LaunchId", out _));
+            Assert.Equal(45, doc.RootElement.GetProperty("Checkpoints").GetProperty("MainWindow.AfterSettingsLoad").GetInt64());
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void TryWriteSnapshot_InvalidOutputPath_FailsSafely()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), "novaterm-startup-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            using StartupMetricsWriter? writer = StartupMetricsWriter.Create(tempDir);
+            Assert.Null(writer);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/NovaTerminal.Tests/Core/StartupPerformanceTrackerTests.cs
+++ b/tests/NovaTerminal.Tests/Core/StartupPerformanceTrackerTests.cs
@@ -1,0 +1,117 @@
+using NovaTerminal.Core;
+using System.Text.Json;
+
+namespace NovaTerminal.Tests.Core;
+
+public sealed class StartupPerformanceTrackerTests
+{
+    [Fact]
+    public void MarkPhase_RecordsElapsedTimeAndPublishesStartupMetrics()
+    {
+        RendererStatistics.Reset();
+
+        long now = 100;
+        var tracker = new StartupPerformanceTracker(() => now, startTimestamp: 100, timestampFrequency: 1000);
+
+        now = 125;
+        Assert.True(tracker.TryMark(StartupPhase.MainWindowConstructed));
+
+        now = 140;
+        Assert.True(tracker.TryMark(StartupPhase.WindowOpened));
+
+        now = 180;
+        Assert.True(tracker.TryMark(StartupPhase.FirstTerminalReady));
+
+        Assert.True(tracker.TryGetElapsedMilliseconds(StartupPhase.MainWindowConstructed, out long constructedMs));
+        Assert.Equal(25, constructedMs);
+        Assert.Equal(40, RendererStatistics.StartupWindowShownTimeMs);
+        Assert.Equal(1, RendererStatistics.StartupWindowShownSamples);
+        Assert.Equal(80, RendererStatistics.StartupFirstTerminalReadyTimeMs);
+        Assert.Equal(1, RendererStatistics.StartupFirstTerminalReadySamples);
+    }
+
+    [Fact]
+    public void MarkPhase_IgnoresDuplicateWrites()
+    {
+        RendererStatistics.Reset();
+
+        long now = 200;
+        var tracker = new StartupPerformanceTracker(() => now, startTimestamp: 200, timestampFrequency: 1000);
+
+        now = 260;
+        Assert.True(tracker.TryMark(StartupPhase.BackgroundRestoreComplete));
+
+        now = 320;
+        Assert.False(tracker.TryMark(StartupPhase.BackgroundRestoreComplete));
+
+        Assert.True(tracker.TryGetElapsedMilliseconds(StartupPhase.BackgroundRestoreComplete, out long elapsedMs));
+        Assert.Equal(60, elapsedMs);
+        Assert.Equal(60, RendererStatistics.StartupBackgroundRestoreTimeMs);
+        Assert.Equal(1, RendererStatistics.StartupBackgroundRestoreSamples);
+    }
+
+    [Fact]
+    public void MarkPhase_WritesStartupSnapshotOnceAfterReadyPhasesComplete()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), "novaterm-startup-tests", Guid.NewGuid().ToString("N"));
+        string outPath = Path.Combine(tempDir, "startup_metrics.jsonl");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            long now = 1000;
+            using (var writer = StartupMetricsWriter.Create(outPath))
+            {
+                Assert.NotNull(writer);
+
+                var tracker = new StartupPerformanceTracker(
+                    () => now,
+                    startTimestamp: 1000,
+                    timestampFrequency: 1000,
+                    metricsWriter: writer);
+
+                now = 1020;
+                Assert.True(tracker.TryMark(StartupPhase.WindowOpened));
+                now = 1080;
+                Assert.True(tracker.TryMark(StartupPhase.BackgroundRestoreComplete));
+
+                now = 1150;
+                Assert.True(tracker.TryMark(StartupPhase.FirstTerminalReady));
+                Assert.True(tracker.TryMark(StartupPhase.SessionRestoreComplete));
+                Assert.False(tracker.TryMark(StartupPhase.FirstTerminalReady));
+            }
+
+            string[] lines = File.ReadAllLines(outPath);
+            Assert.Single(lines);
+
+            using JsonDocument doc = JsonDocument.Parse(lines[0]);
+            Assert.Equal(20, doc.RootElement.GetProperty("WindowOpenedMs").GetInt64());
+            Assert.Equal(150, doc.RootElement.GetProperty("FirstTerminalReadyMs").GetInt64());
+            Assert.Equal(80, doc.RootElement.GetProperty("BackgroundRestoreCompleteMs").GetInt64());
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void MarkCheckpoint_RecordsNamedElapsedTimeInSnapshot()
+    {
+        long now = 100;
+        var tracker = new StartupPerformanceTracker(() => now, startTimestamp: 100, timestampFrequency: 1000);
+
+        now = 135;
+        Assert.True(tracker.TryMarkCheckpoint("MainWindow.AfterSettingsLoad"));
+
+        now = 145;
+        Assert.False(tracker.TryMarkCheckpoint("MainWindow.AfterSettingsLoad"));
+
+        StartupMetricsSnapshot snapshot = tracker.CreateSnapshot();
+        Assert.NotNull(snapshot.Checkpoints);
+        Assert.Equal(35, Assert.Contains("MainWindow.AfterSettingsLoad", snapshot.Checkpoints!));
+    }
+}

--- a/tests/NovaTerminal.Tests/Core/StartupRestoreCoordinatorTests.cs
+++ b/tests/NovaTerminal.Tests/Core/StartupRestoreCoordinatorTests.cs
@@ -1,0 +1,34 @@
+using NovaTerminal.Core;
+
+namespace NovaTerminal.Tests.Core;
+
+public sealed class StartupRestoreCoordinatorTests
+{
+    [Fact]
+    public void RunDeferred_RestoresDeferredTabsInStableOrderAndCompletes()
+    {
+        var scheduled = new Queue<Action>();
+        var restored = new List<int>();
+        bool completed = false;
+
+        var coordinator = new StartupRestoreCoordinator(action => scheduled.Enqueue(action));
+        var deferredTabs = new[]
+        {
+            new StartupRestoreTab(0, new TabSession { Title = "One" }),
+            new StartupRestoreTab(2, new TabSession { Title = "Three" })
+        };
+
+        coordinator.RunDeferred(
+            deferredTabs,
+            tab => restored.Add(tab.OriginalIndex),
+            () => completed = true);
+
+        Assert.False(completed);
+        Assert.Single(scheduled);
+        scheduled.Dequeue().Invoke();
+
+        Assert.Equal(new[] { 0, 2 }, restored);
+        Assert.True(completed);
+        Assert.Empty(scheduled);
+    }
+}

--- a/tests/NovaTerminal.Tests/Core/StartupRestorePlanTests.cs
+++ b/tests/NovaTerminal.Tests/Core/StartupRestorePlanTests.cs
@@ -1,0 +1,28 @@
+using NovaTerminal.Core;
+
+namespace NovaTerminal.Tests.Core;
+
+public sealed class StartupRestorePlanTests
+{
+    [Fact]
+    public void Create_PrioritizesSelectedTabAndPreservesDeferredOrder()
+    {
+        var session = new NovaSession
+        {
+            ActiveTabIndex = 1,
+            Tabs =
+            {
+                new TabSession { Title = "One" },
+                new TabSession { Title = "Two" },
+                new TabSession { Title = "Three" }
+            }
+        };
+
+        StartupRestorePlan plan = StartupRestorePlan.Create(session);
+
+        Assert.Equal(1, plan.ImmediateTab.OriginalIndex);
+        Assert.Equal("Two", plan.ImmediateTab.Tab.Title);
+        Assert.Equal(new[] { 0, 2 }, plan.DeferredTabs.Select(static tab => tab.OriginalIndex).ToArray());
+        Assert.Equal(new[] { "One", "Three" }, plan.DeferredTabs.Select(static tab => tab.Tab.Title).ToArray());
+    }
+}

--- a/tests/NovaTerminal.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs
+++ b/tests/NovaTerminal.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs
@@ -1,3 +1,4 @@
+using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using NovaTerminal.Controls;
 using NovaTerminal.Core;
@@ -9,6 +10,28 @@ namespace NovaTerminal.Tests.Core;
 
 public sealed class TerminalPaneRemoteFilesSidebarTests
 {
+    [AvaloniaFact]
+    public void RemoteFilesSidebarHost_IsCreatedOnlyWhenOpened()
+    {
+        var pane = new TerminalPane(new TerminalProfile
+        {
+            Name = "Native SSH",
+            Type = ConnectionType.SSH,
+            SshBackendKind = SshBackendKind.Native,
+            SshHost = "server.example",
+            SshUser = "nova"
+        });
+
+        var presenter = pane.FindControl<ContentControl>("RemoteFilesSidebarPresenter");
+
+        Assert.NotNull(presenter);
+        Assert.Null(presenter!.Content);
+
+        pane.ShowRemoteFilesSidebarForTest();
+
+        Assert.IsType<RemoteFilesSidebar>(presenter.Content);
+    }
+
     [AvaloniaFact]
     public void NativeSshPane_ContextMenu_KeepsOnlyRemoteFilesEntry()
     {

--- a/tests/NovaTerminal.Tests/Core/TerminalPaneStartupInstrumentationTests.cs
+++ b/tests/NovaTerminal.Tests/Core/TerminalPaneStartupInstrumentationTests.cs
@@ -1,0 +1,35 @@
+using Avalonia.Headless.XUnit;
+using NovaTerminal.Controls;
+using NovaTerminal.Core;
+using System.Threading;
+
+namespace NovaTerminal.Tests.Core;
+
+public sealed class TerminalPaneStartupInstrumentationTests
+{
+    [AvaloniaFact]
+    public void Constructor_RecordsStartupConstructorCheckpoints()
+    {
+        long now = 0;
+        var tracker = new StartupPerformanceTracker(
+            () => Interlocked.Add(ref now, 5),
+            startTimestamp: 0,
+            timestampFrequency: 1000);
+
+        StartupPerformanceTracker.SetCurrentForTests(tracker);
+        try
+        {
+            var pane = new TerminalPane("pwsh.exe");
+            StartupMetricsSnapshot snapshot = tracker.CreateSnapshot();
+
+            Assert.NotNull(pane);
+            Assert.NotNull(snapshot.Checkpoints);
+            Assert.Contains("TerminalPane.Ctor.AfterInitializeComponent", snapshot.Checkpoints!.Keys);
+            Assert.Contains("TerminalPane.Ctor.AfterSetupCommon", snapshot.Checkpoints.Keys);
+        }
+        finally
+        {
+            StartupPerformanceTracker.SetCurrentForTests(null);
+        }
+    }
+}

--- a/tests/NovaTerminal.Tests/RenderTests/RendererMetricsTests.cs
+++ b/tests/NovaTerminal.Tests/RenderTests/RendererMetricsTests.cs
@@ -58,6 +58,30 @@ namespace NovaTerminal.Tests.RenderTests
 
         [Fact]
         [Trait("Category", "RenderMetrics")]
+        public void StartupMetrics_AreRecorded()
+        {
+            RendererStatistics.Reset();
+
+            RendererStatistics.RecordStartupWindowShown(25);
+            RendererStatistics.RecordStartupFirstTerminalReady(70);
+            RendererStatistics.RecordStartupSessionRestoreComplete(140);
+            RendererStatistics.RecordStartupDeferredWork(45);
+            RendererStatistics.RecordStartupBackgroundRestore(60);
+
+            Assert.Equal(25, RendererStatistics.StartupWindowShownTimeMs);
+            Assert.Equal(1, RendererStatistics.StartupWindowShownSamples);
+            Assert.Equal(70, RendererStatistics.StartupFirstTerminalReadyTimeMs);
+            Assert.Equal(1, RendererStatistics.StartupFirstTerminalReadySamples);
+            Assert.Equal(140, RendererStatistics.StartupSessionRestoreCompleteTimeMs);
+            Assert.Equal(1, RendererStatistics.StartupSessionRestoreCompleteSamples);
+            Assert.Equal(45, RendererStatistics.StartupDeferredWorkTimeMs);
+            Assert.Equal(1, RendererStatistics.StartupDeferredWorkSamples);
+            Assert.Equal(60, RendererStatistics.StartupBackgroundRestoreTimeMs);
+            Assert.Equal(1, RendererStatistics.StartupBackgroundRestoreSamples);
+        }
+
+        [Fact]
+        [Trait("Category", "RenderMetrics")]
         public void TerminalViewVisibilityMetrics_AreRecorded()
         {
             RendererStatistics.Reset();

--- a/tests/tools/measure_startup.ps1
+++ b/tests/tools/measure_startup.ps1
@@ -1,0 +1,165 @@
+[CmdletBinding()]
+param(
+    [string]$Configuration = "Release",
+    [Parameter(Mandatory = $true)]
+    [string]$Label,
+    [int]$Iterations = 10,
+    [int]$TimeoutSeconds = 20
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Get-LineCount {
+    param([string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return 0
+    }
+
+    return @((Get-Content -LiteralPath $Path)).Count
+}
+
+function Write-MeasurementSettings {
+    param([string]$SettingsPath)
+
+    $settings = @{
+        QuakeModeEnabled = $false
+    }
+
+    $settings | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $SettingsPath -Encoding UTF8
+}
+
+function Write-MeasurementSession {
+    param([string]$SessionPath)
+
+    $activePane = [guid]::NewGuid().ToString()
+    $splitLeft = [guid]::NewGuid().ToString()
+    $splitRight = [guid]::NewGuid().ToString()
+    $backgroundPane = [guid]::NewGuid().ToString()
+
+    $session = @{
+        ActiveTabIndex = 0
+        Tabs = @(
+            @{
+                TabId = [guid]::NewGuid().ToString()
+                Title = "Primary"
+                ActivePaneId = $activePane
+                BroadcastInputEnabled = $false
+                Root = @{
+                    Type = 0
+                    PaneId = $activePane
+                    Command = "cmd.exe"
+                    Arguments = ""
+                }
+            },
+            @{
+                TabId = [guid]::NewGuid().ToString()
+                Title = "Split"
+                ActivePaneId = $splitRight
+                BroadcastInputEnabled = $false
+                Root = @{
+                    Type = 1
+                    SplitOrientation = 0
+                    Sizes = @("1*", "1*")
+                    Children = @(
+                        @{
+                            Type = 0
+                            PaneId = $splitLeft
+                            Command = "cmd.exe"
+                            Arguments = ""
+                        },
+                        @{
+                            Type = 0
+                            PaneId = $splitRight
+                            Command = "cmd.exe"
+                            Arguments = ""
+                        }
+                    )
+                }
+            },
+            @{
+                TabId = [guid]::NewGuid().ToString()
+                Title = "Background"
+                ActivePaneId = $backgroundPane
+                BroadcastInputEnabled = $false
+                Root = @{
+                    Type = 0
+                    PaneId = $backgroundPane
+                    Command = "cmd.exe"
+                    Arguments = ""
+                }
+            }
+        )
+    }
+
+    $session | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $SessionPath -Encoding UTF8
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$appExe = Join-Path $repoRoot "src\NovaTerminal.App\bin\$Configuration\net10.0\NovaTerminal.exe"
+
+if (-not (Test-Path -LiteralPath $appExe)) {
+    throw "App executable not found at $appExe. Build the app first."
+}
+
+$outputRoot = Join-Path $repoRoot "artifacts-codex\startup\$Label"
+$metricsFile = Join-Path $outputRoot "startup_metrics.jsonl"
+$appDataRoot = Join-Path $outputRoot "appdata"
+$settingsPath = Join-Path $appDataRoot "settings.json"
+$sessionPath = Join-Path $appDataRoot "sessions\last_session.json"
+
+New-Item -ItemType Directory -Force -Path $outputRoot | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $appDataRoot "sessions") | Out-Null
+
+if (Test-Path -LiteralPath $metricsFile) {
+    Remove-Item -LiteralPath $metricsFile -Force
+}
+
+Write-MeasurementSettings -SettingsPath $settingsPath
+
+for ($iteration = 1; $iteration -le $Iterations; $iteration++) {
+    Write-MeasurementSession -SessionPath $sessionPath
+    $beforeCount = Get-LineCount -Path $metricsFile
+
+    $process = Start-Process -FilePath $appExe -PassThru -WindowStyle Normal -Environment @{
+        NOVATERM_APPDATA_ROOT = $appDataRoot
+        NOVATERM_STARTUP_METRICS = "1"
+        NOVATERM_STARTUP_METRICS_OUT = $metricsFile
+    }
+
+    $captured = $false
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+
+    try {
+        while ([DateTime]::UtcNow -lt $deadline) {
+            Start-Sleep -Milliseconds 100
+
+            if ((Get-LineCount -Path $metricsFile) -gt $beforeCount) {
+                $captured = $true
+                break
+            }
+
+            if ($process.HasExited) {
+                break
+            }
+        }
+    }
+    finally {
+        if (-not $process.HasExited) {
+            $null = $process.CloseMainWindow()
+            if (-not $process.WaitForExit(3000)) {
+                $process.Kill($true)
+                $process.WaitForExit()
+            }
+        }
+
+        $process.Dispose()
+    }
+
+    if (-not $captured) {
+        throw "Iteration $iteration did not produce a startup metrics record within $TimeoutSeconds seconds."
+    }
+}
+
+Write-Host "Startup metrics captured to $metricsFile"

--- a/tests/tools/summarize_startup_metrics.ps1
+++ b/tests/tools/summarize_startup_metrics.ps1
@@ -1,0 +1,208 @@
+[CmdletBinding(DefaultParameterSetName = "single")]
+param(
+    [Parameter(ParameterSetName = "single", Mandatory = $true)]
+    [string]$InputPath,
+    [Parameter(ParameterSetName = "compare", Mandatory = $true)]
+    [string]$Baseline,
+    [Parameter(ParameterSetName = "compare", Mandatory = $true)]
+    [string]$Candidate,
+    [string]$Out
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Get-OrderedPhases {
+    return @(
+        "MainWindowConstructedMs",
+        "WindowOpenedMs",
+        "FirstTerminalReadyMs",
+        "SessionRestoreCompleteMs",
+        "DeferredWorkCompleteMs",
+        "BackgroundRestoreCompleteMs"
+    )
+}
+
+function Get-PhaseLabel {
+    param([string]$PhaseName)
+
+    switch ($PhaseName) {
+        "MainWindowConstructedMs" { return "Main Window Constructed" }
+        "WindowOpenedMs" { return "Window Opened" }
+        "FirstTerminalReadyMs" { return "First Terminal Ready" }
+        "SessionRestoreCompleteMs" { return "Session Restore Complete" }
+        "DeferredWorkCompleteMs" { return "Deferred Work Complete" }
+        "BackgroundRestoreCompleteMs" { return "Background Restore Complete" }
+        default { return $PhaseName }
+    }
+}
+
+function Get-StartupRecords {
+    param([string]$Path)
+
+    $fullPath = (Resolve-Path $Path).Path
+    $records = New-Object System.Collections.Generic.List[object]
+    $files = @()
+
+    if (Test-Path -LiteralPath $fullPath -PathType Container) {
+        $files = Get-ChildItem -LiteralPath $fullPath -Filter *.jsonl -Recurse | Sort-Object FullName
+    }
+    else {
+        $files = @(Get-Item -LiteralPath $fullPath)
+    }
+
+    foreach ($file in $files) {
+        foreach ($line in Get-Content -LiteralPath $file.FullName) {
+            $trimmed = $line.Trim()
+            if ($trimmed.Length -eq 0) {
+                continue
+            }
+
+            $records.Add(($trimmed | ConvertFrom-Json))
+        }
+    }
+
+    return $records
+}
+
+function Get-StartupSummary {
+    param([System.Collections.Generic.List[object]]$Records)
+
+    $phases = [ordered]@{}
+
+    foreach ($phase in Get-OrderedPhases) {
+        $values = @(@(
+            foreach ($record in $Records) {
+                $value = $record.$phase
+                if ($null -ne $value) {
+                    [double]$value
+                }
+            }
+        ) | Sort-Object)
+
+        if ($values.Count -eq 0) {
+            continue
+        }
+
+        $count = $values.Count
+        $average = ($values | Measure-Object -Average).Average
+        if (($count % 2) -eq 1) {
+            $median = $values[[int]($count / 2)]
+        }
+        else {
+            $median = ($values[($count / 2) - 1] + $values[$count / 2]) / 2.0
+        }
+
+        $phases[$phase] = [pscustomobject]@{
+            Count = $count
+            AverageMs = [double]$average
+            MedianMs = [double]$median
+            MinMs = [double]$values[0]
+            MaxMs = [double]$values[-1]
+        }
+    }
+
+    return [pscustomobject]@{
+        LaunchCount = $Records.Count
+        Phases = $phases
+    }
+}
+
+function Compare-StartupSummaries {
+    param(
+        [pscustomobject]$BaselineSummary,
+        [pscustomobject]$CandidateSummary
+    )
+
+    $phases = [ordered]@{}
+
+    foreach ($phase in Get-OrderedPhases) {
+        if (-not $BaselineSummary.Phases.Contains($phase) -or -not $CandidateSummary.Phases.Contains($phase)) {
+            continue
+        }
+
+        $baselineAverage = [double]$BaselineSummary.Phases[$phase].AverageMs
+        $candidateAverage = [double]$CandidateSummary.Phases[$phase].AverageMs
+        $delta = $candidateAverage - $baselineAverage
+        $improvement = if ($baselineAverage -le 0) { 0 } else { (($baselineAverage - $candidateAverage) / $baselineAverage) * 100.0 }
+
+        $phases[$phase] = [pscustomobject]@{
+            BaselineAverageMs = $baselineAverage
+            CandidateAverageMs = $candidateAverage
+            DeltaMs = $delta
+            ImprovementPercent = [double]$improvement
+        }
+    }
+
+    return [pscustomobject]@{
+        BaselineLaunchCount = $BaselineSummary.LaunchCount
+        CandidateLaunchCount = $CandidateSummary.LaunchCount
+        Phases = $phases
+    }
+}
+
+function Build-MarkdownReport {
+    param([pscustomobject]$Comparison)
+
+    $lines = New-Object System.Collections.Generic.List[string]
+    $lines.Add("# Startup Performance Report")
+    $lines.Add("")
+    $lines.Add("Baseline launches: $($Comparison.BaselineLaunchCount)")
+    $lines.Add("Candidate launches: $($Comparison.CandidateLaunchCount)")
+    $lines.Add("")
+    $lines.Add("| Phase | Baseline Avg (ms) | Candidate Avg (ms) | Delta (ms) | Improvement |")
+    $lines.Add("| --- | ---: | ---: | ---: | ---: |")
+
+    foreach ($phase in Get-OrderedPhases) {
+        if (-not $Comparison.Phases.Contains($phase)) {
+            continue
+        }
+
+        $values = $Comparison.Phases[$phase]
+        $lines.Add(
+            ("| {0} | {1:N2} | {2:N2} | {3:N2} | {4:N2}% |" -f (Get-PhaseLabel $phase), $values.BaselineAverageMs, $values.CandidateAverageMs, $values.DeltaMs, $values.ImprovementPercent))
+    }
+
+    return ($lines -join [Environment]::NewLine)
+}
+
+if ($PSCmdlet.ParameterSetName -eq "single") {
+    $records = Get-StartupRecords -Path $InputPath
+    $summary = Get-StartupSummary -Records $records
+
+    Write-Host ("Launches: {0}" -f $summary.LaunchCount)
+    foreach ($phase in Get-OrderedPhases) {
+        if (-not $summary.Phases.Contains($phase)) {
+            continue
+        }
+
+        $stats = $summary.Phases[$phase]
+        Write-Host ("{0}: count={1} avg={2:N2}ms median={3:N2}ms min={4:N0}ms max={5:N0}ms" -f (Get-PhaseLabel $phase), $stats.Count, $stats.AverageMs, $stats.MedianMs, $stats.MinMs, $stats.MaxMs)
+    }
+
+    return
+}
+
+$baselineRecords = Get-StartupRecords -Path $Baseline
+$candidateRecords = Get-StartupRecords -Path $Candidate
+$baselineSummary = Get-StartupSummary -Records $baselineRecords
+$candidateSummary = Get-StartupSummary -Records $candidateRecords
+$comparison = Compare-StartupSummaries -BaselineSummary $baselineSummary -CandidateSummary $candidateSummary
+$report = Build-MarkdownReport -Comparison $comparison
+
+if ($Out) {
+    $outPath = $Out
+    if (-not [System.IO.Path]::IsPathRooted($outPath)) {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+        $outPath = Join-Path $repoRoot $outPath
+    }
+
+    $directory = Split-Path -Parent $outPath
+    if ($directory) {
+        New-Item -ItemType Directory -Force -Path $directory | Out-Null
+    }
+
+    Set-Content -LiteralPath $outPath -Value $report -Encoding UTF8
+}
+
+Write-Output $report


### PR DESCRIPTION
## Summary
- add startup instrumentation and repeatable measurement checkpoints for window construction, first terminal ready, session restore, and deferred work
- reduce startup critical-path work by deferring window icon decoding until after first show
- add focused tests covering startup checkpoints and deferred icon behavior

## Why
Startup work was still concentrated in `MainWindow.InitializeComponent()` and initial Avalonia layout/render. Tracing showed window icon decoding on the critical path, so moving that work out of XAML provided a measurable improvement without changing terminal/session behavior.

## Measured impact
Compared with the instrumented baseline:
- `Main Window Constructed`: `696.4ms -> 613.6ms` (`11.89%`)
- `Window Opened`: `877.7ms -> 802.2ms` (`8.60%`)
- `First Terminal Ready`: `915.4ms -> 839.0ms` (`8.35%`)
- `Session Restore Complete`: `695.3ms -> 612.5ms` (`11.91%`)

Tradeoff:
- `Background Restore Complete`: `1101.2ms -> 1164.1ms` (`-5.71%`)

## Validation
- `dotnet test tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj --no-restore -m:1 --filter "FullyQualifiedName~MainWindowStartupTests|FullyQualifiedName~SessionManagerTests|FullyQualifiedName~TerminalPaneStartupInstrumentationTests"`
- `dotnet build src\NovaTerminal.App\NovaTerminal.App.csproj -c Release --no-restore -m:1 -v minimal`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests\tools\measure_startup.ps1 -Configuration Release -Label instrumented-baseline -Iterations 10`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests\tools\measure_startup.ps1 -Configuration Release -Label candidate-lazy-window-icon -Iterations 10`
