### PR TITLE
Add shortcut settings and command palette ranking

### DIFF
--- a/docs/plans/2026-05-26-shortcuts-and-command-palette-design.md
+++ b/docs/plans/2026-05-26-shortcuts-and-command-palette-design.md
@@ -1,0 +1,356 @@
+# Shortcut Management And Command Palette Ranking Design
+
+## Goal
+
+Add first-class shortcut management to Settings and make the command palette's initial list reflect persisted most-used commands.
+
+The change must:
+
+- cover app-level commands, pane-local commands, and Command Assist commands
+- block duplicate shortcuts globally across all scopes
+- persist command palette usage across app restarts
+- stay in the app layer and avoid terminal core or VT parsing/rendering changes
+
+## Current State
+
+Today the app has three separate concerns that are only loosely connected:
+
+1. `MainWindow` owns many app-level shortcut checks and also registers command palette commands.
+2. `TerminalPane` owns pane-local and Command Assist key handling.
+3. `SettingsWindow` has no shortcut-management surface.
+
+The current command palette also uses a simple alphabetical list on open. That means:
+
+- `Settings` has no assigned shortcut, so opening it depends on the palette.
+- the initial palette list does not adapt to actual usage.
+- users cannot inspect or change bindings in one place.
+
+## Recommended Approach
+
+Introduce a unified app-layer command catalog for bindable actions, use `TerminalSettings.Keybindings` as the persisted override source, and add a small persisted usage store for command palette ranking.
+
+This keeps the implementation additive:
+
+- no terminal core changes
+- no suggestion rendering inside terminal grid content
+- no refactor of VT parsing/rendering
+- no broad input-system rewrite
+
+## Alternatives Considered
+
+### 1. Minimal patch over scattered hardcoded shortcuts
+
+Add a Settings UI that edits today's existing ids and keep most routing as-is.
+
+Pros:
+
+- smallest upfront code change
+
+Cons:
+
+- preserves duplication between registration, routing, and settings UI
+- makes pane-local and Command Assist bindings harder to keep consistent
+- increases long-term maintenance cost
+
+### 2. Full shortcut-manager refactor
+
+Move all input handling immediately into a new central manager.
+
+Pros:
+
+- cleaner end-state if done fully
+
+Cons:
+
+- too broad for the feature
+- higher regression risk on performance-sensitive and interactive paths
+- unnecessary coupling to current delivery goals
+
+## Architecture
+
+### Unified bindable command catalog
+
+Add an app-layer catalog of bindable actions. Each action should have:
+
+- stable `Id`
+- `Title`
+- `Category`
+- `Scope`
+- `DefaultShortcut`
+- optional availability predicate for commands that are contextual
+
+Suggested scopes:
+
+- `App`
+- `Pane`
+- `CommandAssist`
+
+Examples of actions that should be cataloged in the first pass:
+
+- `settings`
+- `command_palette`
+- `command_assist_toggle`
+- `command_assist_help`
+- `command_assist_history`
+- `find`
+- `new_tab`
+- `close_tab`
+- `close_pane`
+- pane split and pane focus commands
+- palette-visible app commands already registered in `MainWindow`
+
+The catalog becomes the shared source of truth for:
+
+- Settings UI display
+- effective shortcut resolution
+- duplicate validation
+- command palette metadata
+- execution usage tracking
+
+### Shortcut resolution
+
+Use `TerminalSettings.Keybindings` as the persisted override map keyed by command id. Keep default bindings in code and resolve the effective binding at runtime:
+
+1. start from catalog default
+2. apply `Keybindings` override if present
+3. normalize to a canonical shortcut string format
+
+Add an app-layer resolver/service responsible for:
+
+- returning the effective shortcut for a command id
+- enumerating all effective bindings
+- validating that no duplicates exist
+- resetting one binding or all bindings back to defaults
+
+### Shortcut matching
+
+Keep matching in app-layer code. Do not move matching into terminal core logic.
+
+`MainWindow` and `TerminalPane` can continue to own their execution paths, but they should query the shared resolver rather than relying on duplicated fallback strings spread across handlers.
+
+This keeps:
+
+- UI concerns out of terminal core logic
+- pane-local behavior local to `TerminalPane`
+- Command Assist behavior local to the Command Assist subsystem
+
+### Command palette usage store
+
+Add a small persisted usage store separate from `TerminalSettings`.
+
+Store per command id:
+
+- use count
+- last used timestamp
+
+The store should live under the existing app data root as a separate JSON file so settings and behavioral telemetry stay decoupled.
+
+## Settings UI
+
+### New Shortcuts tab
+
+Add a third tab to `SettingsWindow` named `Shortcuts`.
+
+The page should be Avalonia-based and consistent with the existing settings UI. It should show a searchable list of bindable commands grouped by scope and category.
+
+Each row should display:
+
+- action title
+- scope
+- current effective shortcut
+- default shortcut
+- reset action
+
+Optional but useful first-pass affordances:
+
+- search box filtering by title, category, scope, or shortcut text
+- small status text for validation errors
+
+### Editing flow
+
+Editing should be explicit:
+
+1. user activates a shortcut field or edit button
+2. UI enters capture mode for that action
+3. next supported key chord is recorded
+4. chord is normalized and validated
+5. save the override only if valid and unique
+
+Rejected edits should leave the previous binding unchanged.
+
+### Conflict handling
+
+Duplicates are blocked globally across all scopes.
+
+If a captured shortcut is already assigned:
+
+- do not save the new value
+- keep the old value
+- show inline error text identifying the conflicting command
+
+This must apply uniformly to:
+
+- app commands
+- pane-local commands
+- Command Assist commands
+
+### Scope boundaries in UI
+
+The first version should expose one unified surface, but still make scope visible so users understand where a command applies.
+
+Suggested grouping:
+
+- App
+- Pane
+- Command Assist
+
+## Command Palette Ranking
+
+### Empty query behavior
+
+When the command palette opens with an empty query, show the most-used commands first using persisted usage data.
+
+Secondary ordering for ties should be deterministic, for example:
+
+1. higher use count
+2. more recent use
+3. category/title
+
+### Search behavior
+
+When the user types a query, search relevance should remain primary. Usage should act as a secondary tie-breaker among similarly relevant results.
+
+That keeps search predictable while still making familiar commands surface earlier.
+
+### Usage collection
+
+Increment command usage when a command executes successfully from:
+
+- the command palette
+- its keyboard shortcut
+- any shared execution path that maps to a catalog command id
+
+This ensures ranking reflects real user behavior, not just palette clicks.
+
+## Data Model
+
+### Existing settings
+
+Reuse:
+
+- `TerminalSettings.Keybindings`
+
+No breaking migration is needed beyond consistently honoring entries in that map.
+
+### New persisted store
+
+Add a dedicated JSON store for command palette usage, for example:
+
+- `command-palette-usage.json`
+
+This file should be tolerant of:
+
+- missing file
+- unknown command ids
+- removed commands
+- malformed content falling back to empty state
+
+## Execution Model
+
+Execution should stay where it belongs today:
+
+- `MainWindow` executes app-level commands
+- `TerminalPane` executes pane-local commands
+- Command Assist actions remain within the Command Assist subsystem
+
+The catalog should reference these execution paths without collapsing them into terminal core code.
+
+That preserves separation of concerns while still making shortcut management unified.
+
+## Validation Rules
+
+### Supported first-pass bindings
+
+Support the same general single-chord format the app already uses, including combinations such as:
+
+- `Ctrl+Shift+P`
+- `Ctrl+Space`
+- `Alt+Left`
+- `Ctrl+OemPlus`
+
+The first pass should not attempt:
+
+- multi-step chords
+- per-profile bindings
+- imported shortcut schemes
+
+### Duplicate policy
+
+No duplicate effective shortcuts anywhere in the catalog.
+
+This includes duplicates across different scopes. The system should reject them rather than trying to resolve precedence.
+
+## Testing Strategy
+
+Prefer deterministic tests focused on domain and service logic.
+
+Add tests for:
+
+- catalog completeness and stable ids for bindable commands
+- effective binding resolution from defaults plus overrides
+- global duplicate detection across scopes
+- shortcut normalization and parsing for supported chords
+- reset-to-default behavior
+- usage store load/save behavior
+- palette empty-state ranking by persisted usage
+- palette search ordering where usage breaks relevance ties
+- `Settings` having a default binding and being invokable through the shared path
+
+Avoid fragile UI snapshot dependencies unless the repo already relies on them for this area.
+
+## Migration
+
+Migration should be minimal:
+
+- existing users keep current behavior until they edit shortcuts
+- existing `Keybindings` entries remain valid and are honored
+- usage store starts empty if the file does not exist
+
+No data migration should be required for terminal profiles, terminal core state, or Command Assist history.
+
+## First-Pass Scope
+
+### In scope
+
+- add `Shortcuts` tab to Settings
+- define unified bindable command catalog
+- route effective shortcuts through shared resolution
+- assign a default shortcut for `Settings`
+- support app, pane-local, and Command Assist bindings
+- block duplicate shortcuts globally
+- persist command palette usage across restarts
+- rank empty-query palette view by most-used commands
+- use usage as search tie-breaker
+
+### Out of scope
+
+- multi-stroke key chords
+- per-profile shortcut schemes
+- import/export of keymaps
+- fuzzy conflict precedence rules
+- terminal core input refactors
+- rendering suggestions inside the terminal grid
+
+## Recommendation Summary
+
+Implement shortcut management as an additive app-layer capability built on:
+
+- a unified bindable command catalog
+- `TerminalSettings.Keybindings` for overrides
+- a separate persisted command palette usage store
+
+This resolves both reported gaps while preserving the current architectural boundaries:
+
+- shortcut discovery and customization become first-class in Settings
+- `Settings` no longer depends on palette-only access
+- command palette open state reflects real user habits over time

--- a/docs/superpowers/plans/2026-05-26-startup-orchestrator-extraction-plan.md
+++ b/docs/superpowers/plans/2026-05-26-startup-orchestrator-extraction-plan.md
@@ -1,0 +1,1154 @@
+# StartupOrchestrator Extraction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract `StartupOrchestrator` from `MainWindow.axaml.cs`, introduce the `AppServiceBundle` composition-root pattern, and migrate every existing `StartupPerformanceTracker.Current?.TryMark*` call site plus the inline session-restore lifecycle behind the orchestrator. Zero net behavior change; one quiet correctness improvement (collapses a duplicated mark-pair).
+
+**Architecture:** Three new files in `src/NovaTerminal.App/Core/` (`StartupOrchestrator.cs`, `AppServiceBundle.cs`, `AppServices.cs`). MainWindow gains a typed ctor `MainWindow(AppServiceBundle services)` and a parameterless forwarder for the XAML designer + existing tests. The orchestrator wraps the existing `StartupPerformanceTracker` and owns the existing `StartupRestoreCoordinator` instance; neither type is changed.
+
+**Tech Stack:** C# 12, .NET 10, Avalonia 12, xUnit (with `Avalonia.Headless.XUnit` for headless tests), `scripts/build.{ps1,sh}` wrappers (raw `dotnet` hangs Bash pipes — see `CLAUDE.md`).
+
+**Spec:** `docs/superpowers/specs/2026-05-26-startup-orchestrator-extraction-design.md` (committed in `b9bc3fe`).
+
+**Pre-existing in-repo staged changes:** the icon-ico-swap + PowerShell `-File` unquote work is in the staging area when this plan starts; do **NOT** include it in any commit produced by this plan. Use explicit paths in every `git commit` and never run `git add .` / `git add -A`.
+
+---
+
+### Task 1: Create `StartupOrchestrator` with failing tests, then make them pass
+
+**Files:**
+- Create: `src/NovaTerminal.App/Core/StartupOrchestrator.cs`
+- Create: `tests/NovaTerminal.Tests/Core/StartupOrchestratorTests.cs`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `tests/NovaTerminal.Tests/Core/StartupOrchestratorTests.cs` with the full test class:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using NovaTerminal.Core;
+using Xunit;
+
+namespace NovaTerminal.Tests.Core;
+
+public sealed class StartupOrchestratorTests
+{
+    private static (StartupPerformanceTracker tracker, long[] clock) CreateTracker()
+    {
+        var clock = new long[] { 0L };
+        Func<long> ticks = () => clock[0];
+        var tracker = (StartupPerformanceTracker)Activator.CreateInstance(
+            typeof(StartupPerformanceTracker),
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+            null,
+            new object?[] { ticks, 0L, 1000L, null },
+            null)!;
+        return (tracker, clock);
+    }
+
+    private static StartupRestoreCoordinator CreateInlineCoordinator()
+        => new(action => action());
+
+    private static StartupRestoreCoordinator CreateCapturingCoordinator(List<Action> captured)
+        => new(action => captured.Add(action));
+
+    private static NovaSession SessionWith(int tabCount, int activeIndex)
+    {
+        var session = new NovaSession { ActiveTabIndex = activeIndex };
+        for (int i = 0; i < tabCount; i++)
+        {
+            session.Tabs.Add(new TabSession { Title = $"tab-{i}" });
+        }
+        return session;
+    }
+
+    [Fact]
+    public void Mark_DelegatesToTracker()
+    {
+        var (tracker, _) = CreateTracker();
+        var orchestrator = new StartupOrchestrator(tracker, CreateInlineCoordinator());
+
+        orchestrator.Mark(StartupPhase.WindowOpened);
+
+        Assert.True(tracker.TryGetElapsedMilliseconds(StartupPhase.WindowOpened, out _));
+    }
+
+    [Fact]
+    public void Checkpoint_DelegatesToTracker()
+    {
+        var (tracker, _) = CreateTracker();
+        var orchestrator = new StartupOrchestrator(tracker, CreateInlineCoordinator());
+
+        orchestrator.Checkpoint("MainWindow.AfterApplyTheme");
+
+        var snapshot = tracker.CreateSnapshot();
+        Assert.NotNull(snapshot.Checkpoints);
+        Assert.True(snapshot.Checkpoints!.ContainsKey("MainWindow.AfterApplyTheme"));
+    }
+
+    [Fact]
+    public void BeginSessionRestore_WithDeferredTabs_CallsMaterializeImmediateOnce_AndStashesPlan()
+    {
+        var (tracker, _) = CreateTracker();
+        var orchestrator = new StartupOrchestrator(tracker, CreateInlineCoordinator());
+        var session = SessionWith(tabCount: 3, activeIndex: 1);
+        var materialized = new List<int>();
+
+        orchestrator.BeginSessionRestore(session, immediate => materialized.Add(immediate.OriginalIndex));
+
+        Assert.Equal(new[] { 1 }, materialized);
+        Assert.True(orchestrator.HasPendingDeferredRestore);
+        Assert.True(tracker.TryGetElapsedMilliseconds(StartupPhase.SessionRestoreComplete, out _));
+        Assert.False(tracker.TryGetElapsedMilliseconds(StartupPhase.BackgroundRestoreComplete, out _));
+    }
+
+    [Fact]
+    public void BeginSessionRestore_WithSingleTab_MarksBothPhasesAndClearsPending()
+    {
+        var (tracker, _) = CreateTracker();
+        var orchestrator = new StartupOrchestrator(tracker, CreateInlineCoordinator());
+        var session = SessionWith(tabCount: 1, activeIndex: 0);
+        var materialized = new List<int>();
+
+        orchestrator.BeginSessionRestore(session, immediate => materialized.Add(immediate.OriginalIndex));
+
+        Assert.Equal(new[] { 0 }, materialized);
+        Assert.False(orchestrator.HasPendingDeferredRestore);
+        Assert.True(tracker.TryGetElapsedMilliseconds(StartupPhase.SessionRestoreComplete, out _));
+        Assert.True(tracker.TryGetElapsedMilliseconds(StartupPhase.BackgroundRestoreComplete, out _));
+    }
+
+    [Fact]
+    public void Constructor_ThrowsOnNullDependencies()
+    {
+        var (tracker, _) = CreateTracker();
+        var coordinator = CreateInlineCoordinator();
+
+        Assert.Throws<ArgumentNullException>(() => new StartupOrchestrator(null!, coordinator));
+        Assert.Throws<ArgumentNullException>(() => new StartupOrchestrator(tracker, null!));
+    }
+
+    [Fact]
+    public void BeginSessionRestore_ThrowsOnNullArguments()
+    {
+        var (tracker, _) = CreateTracker();
+        var orchestrator = new StartupOrchestrator(tracker, CreateInlineCoordinator());
+        var session = SessionWith(tabCount: 1, activeIndex: 0);
+
+        Assert.Throws<ArgumentNullException>(() => orchestrator.BeginSessionRestore(null!, _ => { }));
+        Assert.Throws<ArgumentNullException>(() => orchestrator.BeginSessionRestore(session, null!));
+    }
+
+    [Fact]
+    public void DrainDeferred_ThrowsOnNullArgument()
+    {
+        var (tracker, _) = CreateTracker();
+        var orchestrator = new StartupOrchestrator(tracker, CreateInlineCoordinator());
+
+        Assert.Throws<ArgumentNullException>(() => orchestrator.DrainDeferred(null!));
+    }
+
+    [Fact]
+    public void BeginSessionRestore_WhenMaterializeThrows_PropagatesAndLeavesStateUnchanged()
+    {
+        var (tracker, _) = CreateTracker();
+        var orchestrator = new StartupOrchestrator(tracker, CreateInlineCoordinator());
+        var session = SessionWith(tabCount: 3, activeIndex: 1);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            orchestrator.BeginSessionRestore(session, _ => throw new InvalidOperationException("boom")));
+
+        Assert.Equal("boom", ex.Message);
+        Assert.False(orchestrator.HasPendingDeferredRestore);
+        Assert.False(tracker.TryGetElapsedMilliseconds(StartupPhase.SessionRestoreComplete, out _));
+        Assert.False(tracker.TryGetElapsedMilliseconds(StartupPhase.BackgroundRestoreComplete, out _));
+    }
+
+    [Fact]
+    public void CompleteWithoutRestore_MarksBothPhases()
+    {
+        var (tracker, _) = CreateTracker();
+        var orchestrator = new StartupOrchestrator(tracker, CreateInlineCoordinator());
+
+        orchestrator.CompleteWithoutRestore();
+
+        Assert.True(tracker.TryGetElapsedMilliseconds(StartupPhase.SessionRestoreComplete, out _));
+        Assert.True(tracker.TryGetElapsedMilliseconds(StartupPhase.BackgroundRestoreComplete, out _));
+    }
+
+    [Fact]
+    public void CompleteWithoutRestore_IsIdempotent()
+    {
+        var (tracker, _) = CreateTracker();
+        var orchestrator = new StartupOrchestrator(tracker, CreateInlineCoordinator());
+
+        orchestrator.CompleteWithoutRestore();
+        orchestrator.CompleteWithoutRestore();
+
+        Assert.True(tracker.TryGetElapsedMilliseconds(StartupPhase.SessionRestoreComplete, out _));
+        Assert.True(tracker.TryGetElapsedMilliseconds(StartupPhase.BackgroundRestoreComplete, out _));
+    }
+
+    [Fact]
+    public void DrainDeferred_WithPendingPlan_RunsAllDeferredTabsInOriginalOrder_AndMarksBackground()
+    {
+        var (tracker, _) = CreateTracker();
+        var orchestrator = new StartupOrchestrator(tracker, CreateInlineCoordinator());
+        var session = SessionWith(tabCount: 4, activeIndex: 1);
+        orchestrator.BeginSessionRestore(session, _ => { });
+        var hydrated = new List<int>();
+
+        orchestrator.DrainDeferred(tab => hydrated.Add(tab.OriginalIndex));
+
+        Assert.Equal(new[] { 0, 2, 3 }, hydrated);
+        Assert.True(tracker.TryGetElapsedMilliseconds(StartupPhase.BackgroundRestoreComplete, out _));
+        Assert.False(orchestrator.HasPendingDeferredRestore);
+    }
+
+    [Fact]
+    public void DrainDeferred_WithoutPendingPlan_IsNoOp()
+    {
+        var (tracker, _) = CreateTracker();
+        var orchestrator = new StartupOrchestrator(tracker, CreateInlineCoordinator());
+        var hydrated = new List<int>();
+
+        orchestrator.DrainDeferred(tab => hydrated.Add(tab.OriginalIndex));
+
+        Assert.Empty(hydrated);
+        Assert.False(tracker.TryGetElapsedMilliseconds(StartupPhase.SessionRestoreComplete, out _));
+        Assert.False(tracker.TryGetElapsedMilliseconds(StartupPhase.BackgroundRestoreComplete, out _));
+    }
+
+    [Fact]
+    public void DrainDeferred_WhenOneTabThrows_StillCompletesAndMarksBackground()
+    {
+        var (tracker, _) = CreateTracker();
+        var orchestrator = new StartupOrchestrator(tracker, CreateInlineCoordinator());
+        var session = SessionWith(tabCount: 4, activeIndex: 1);
+        orchestrator.BeginSessionRestore(session, _ => { });
+        var logged = new List<string>();
+        Action<string>? previous = TerminalLogger.OnLog;
+        TerminalLogger.OnLog = logged.Add;
+        var hydrated = new List<int>();
+
+        try
+        {
+            orchestrator.DrainDeferred(tab =>
+            {
+                if (tab.OriginalIndex == 2)
+                {
+                    throw new InvalidOperationException("bad-tab");
+                }
+                hydrated.Add(tab.OriginalIndex);
+            });
+        }
+        finally
+        {
+            TerminalLogger.OnLog = previous;
+        }
+
+        Assert.Equal(new[] { 0, 3 }, hydrated);
+        Assert.True(tracker.TryGetElapsedMilliseconds(StartupPhase.BackgroundRestoreComplete, out _));
+        Assert.False(orchestrator.HasPendingDeferredRestore);
+        Assert.Contains(logged, line => line.Contains("bad-tab", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(1, 0)]
+    [InlineData(2, 0)]
+    [InlineData(2, 1)]
+    [InlineData(5, 3)]
+    public void Invariant_AfterBeginSessionRestore_BackgroundCompleteImpliesNoPendingPlan(int tabCount, int activeIndex)
+    {
+        var (tracker, _) = CreateTracker();
+        var orchestrator = new StartupOrchestrator(tracker, CreateInlineCoordinator());
+        var session = SessionWith(tabCount, activeIndex);
+
+        orchestrator.BeginSessionRestore(session, _ => { });
+
+        bool backgroundComplete = tracker.TryGetElapsedMilliseconds(StartupPhase.BackgroundRestoreComplete, out _);
+        Assert.Equal(backgroundComplete, !orchestrator.HasPendingDeferredRestore);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail (compile error — `StartupOrchestrator` does not exist)**
+
+Run:
+
+```powershell
+scripts/build.ps1 test -c Release --filter "FullyQualifiedName~StartupOrchestratorTests" --no-restore
+```
+
+Expected: build failure with `error CS0246: The type or namespace name 'StartupOrchestrator' could not be found`.
+
+- [ ] **Step 3: Create the orchestrator class**
+
+Create `src/NovaTerminal.App/Core/StartupOrchestrator.cs`:
+
+```csharp
+using System;
+
+namespace NovaTerminal.Core;
+
+public sealed class StartupOrchestrator
+{
+    private readonly StartupPerformanceTracker _tracker;
+    private readonly StartupRestoreCoordinator _coordinator;
+    private StartupRestorePlan? _pendingPlan;
+
+    public StartupOrchestrator(
+        StartupPerformanceTracker tracker,
+        StartupRestoreCoordinator coordinator)
+    {
+        _tracker = tracker ?? throw new ArgumentNullException(nameof(tracker));
+        _coordinator = coordinator ?? throw new ArgumentNullException(nameof(coordinator));
+    }
+
+    public bool HasPendingDeferredRestore => _pendingPlan is not null;
+
+    public void Mark(StartupPhase phase) => _tracker.TryMark(phase);
+
+    public void Checkpoint(string name) => _tracker.TryMarkCheckpoint(name);
+
+    public void BeginSessionRestore(
+        NovaSession session,
+        Action<StartupRestoreTab> materializeImmediate)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(materializeImmediate);
+
+        var plan = StartupRestorePlan.Create(session);
+        materializeImmediate(plan.ImmediateTab);
+
+        _tracker.TryMark(StartupPhase.SessionRestoreComplete);
+        if (plan.DeferredTabs.Count == 0)
+        {
+            _tracker.TryMark(StartupPhase.BackgroundRestoreComplete);
+        }
+        else
+        {
+            _pendingPlan = plan;
+        }
+    }
+
+    public void DrainDeferred(Action<StartupRestoreTab> materializeTab)
+    {
+        ArgumentNullException.ThrowIfNull(materializeTab);
+
+        var plan = _pendingPlan;
+        if (plan is null)
+        {
+            return;
+        }
+
+        _pendingPlan = null;
+        _coordinator.RunDeferred(
+            plan.DeferredTabs,
+            tab =>
+            {
+                try
+                {
+                    materializeTab(tab);
+                }
+                catch (Exception ex)
+                {
+                    TerminalLogger.Log($"StartupOrchestrator: deferred tab {tab.OriginalIndex} threw: {ex}");
+                }
+            },
+            () => _tracker.TryMark(StartupPhase.BackgroundRestoreComplete));
+    }
+
+    public void CompleteWithoutRestore()
+    {
+        _tracker.TryMark(StartupPhase.SessionRestoreComplete);
+        _tracker.TryMark(StartupPhase.BackgroundRestoreComplete);
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```powershell
+scripts/build.ps1 test -c Release --filter "FullyQualifiedName~StartupOrchestratorTests" --no-restore
+```
+
+Expected: all 15 tests pass (`Mark_DelegatesToTracker`, `Checkpoint_DelegatesToTracker`, `Constructor_ThrowsOnNullDependencies`, `BeginSessionRestore_ThrowsOnNullArguments`, `DrainDeferred_ThrowsOnNullArgument`, `BeginSessionRestore_WithDeferredTabs_...`, `BeginSessionRestore_WithSingleTab_...`, `BeginSessionRestore_WhenMaterializeThrows_...`, `CompleteWithoutRestore_MarksBothPhases`, `CompleteWithoutRestore_IsIdempotent`, `DrainDeferred_WithPendingPlan_...`, `DrainDeferred_WithoutPendingPlan_IsNoOp`, `DrainDeferred_WhenOneTabThrows_...`, 4× `Invariant_...`).
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git commit src/NovaTerminal.App/Core/StartupOrchestrator.cs tests/NovaTerminal.Tests/Core/StartupOrchestratorTests.cs -m "feat: add StartupOrchestrator with phase + restore lifecycle"
+```
+
+---
+
+### Task 2: Create `AppServiceBundle` and `AppServices` with tests
+
+**Files:**
+- Create: `src/NovaTerminal.App/Core/AppServiceBundle.cs`
+- Create: `src/NovaTerminal.App/Core/AppServices.cs`
+- Create: `tests/NovaTerminal.Tests/Core/AppServicesTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/NovaTerminal.Tests/Core/AppServicesTests.cs`:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using NovaTerminal.Core;
+using Xunit;
+
+namespace NovaTerminal.Tests.Core;
+
+public sealed class AppServicesTests
+{
+    [Fact]
+    public void Build_ReturnsBundleWithWiredOrchestrator()
+    {
+        var clock = new long[] { 0L };
+        var tracker = (StartupPerformanceTracker)Activator.CreateInstance(
+            typeof(StartupPerformanceTracker),
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+            null,
+            new object?[] { (Func<long>)(() => clock[0]), 0L, 1000L, null },
+            null)!;
+
+        var bundle = AppServices.Build(tracker, schedule: action => action());
+
+        Assert.NotNull(bundle.Startup);
+        bundle.Startup.Mark(StartupPhase.WindowOpened);
+        Assert.True(tracker.TryGetElapsedMilliseconds(StartupPhase.WindowOpened, out _));
+    }
+
+    [Fact]
+    public void BuildForDesigner_ReturnsBundleWithSynchronousScheduler()
+    {
+        var bundle = AppServices.BuildForDesigner();
+        var session = new NovaSession { ActiveTabIndex = 0 };
+        session.Tabs.Add(new TabSession { Title = "a" });
+        session.Tabs.Add(new TabSession { Title = "b" });
+        bundle.Startup.BeginSessionRestore(session, _ => { });
+        var hydrated = new List<int>();
+
+        bundle.Startup.DrainDeferred(tab => hydrated.Add(tab.OriginalIndex));
+
+        Assert.Equal(new[] { 1 }, hydrated);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail (compile error — `AppServices` does not exist)**
+
+Run:
+
+```powershell
+scripts/build.ps1 test -c Release --filter "FullyQualifiedName~AppServicesTests" --no-restore
+```
+
+Expected: build failure with `error CS0103: The name 'AppServices' does not exist`.
+
+- [ ] **Step 3: Create the bundle record**
+
+Create `src/NovaTerminal.App/Core/AppServiceBundle.cs`:
+
+```csharp
+namespace NovaTerminal.Core;
+
+public sealed record AppServiceBundle(StartupOrchestrator Startup);
+```
+
+- [ ] **Step 4: Create the services factory**
+
+Create `src/NovaTerminal.App/Core/AppServices.cs`:
+
+```csharp
+using System;
+
+namespace NovaTerminal.Core;
+
+public static class AppServices
+{
+    public static AppServiceBundle Build(
+        StartupPerformanceTracker tracker,
+        Action<Action> schedule)
+    {
+        ArgumentNullException.ThrowIfNull(tracker);
+        ArgumentNullException.ThrowIfNull(schedule);
+
+        var coordinator = new StartupRestoreCoordinator(schedule);
+        var orchestrator = new StartupOrchestrator(tracker, coordinator);
+        return new AppServiceBundle(orchestrator);
+    }
+
+    public static AppServiceBundle BuildForDesigner()
+    {
+        var tracker = new StartupPerformanceTracker();
+        var coordinator = new StartupRestoreCoordinator(action => action());
+        var orchestrator = new StartupOrchestrator(tracker, coordinator);
+        return new AppServiceBundle(orchestrator);
+    }
+}
+```
+
+Note: `BuildForDesigner` is `public` (not `internal`) so test fixtures can call it without `InternalsVisibleTo` gymnastics.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run:
+
+```powershell
+scripts/build.ps1 test -c Release --filter "FullyQualifiedName~AppServicesTests" --no-restore
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git commit src/NovaTerminal.App/Core/AppServiceBundle.cs src/NovaTerminal.App/Core/AppServices.cs tests/NovaTerminal.Tests/Core/AppServicesTests.cs -m "feat: add AppServiceBundle composition-root pattern"
+```
+
+---
+
+### Task 3: Wire `MainWindow` to receive `AppServiceBundle`, no call-site migration yet
+
+**Files:**
+- Modify: `src/NovaTerminal.App/MainWindow.axaml.cs` (add typed ctor, forwarder, field)
+- Modify: `src/NovaTerminal.App/App.axaml.cs` (use `AppServices.Build`)
+- Create: `tests/NovaTerminal.Tests/Core/TestMainWindowFactory.cs`
+- Modify: `tests/NovaTerminal.Tests/Core/MainWindowStartupTests.cs` (use factory)
+
+This task adds the wiring but does **not** migrate any `StartupPerformanceTracker.Current?.TryMark*` calls. After this task the orchestrator exists on `MainWindow` but no MainWindow code uses it yet. Everything still compiles and passes.
+
+- [ ] **Step 1: Add the `_startup` field and typed ctor to `MainWindow.axaml.cs`**
+
+Locate the existing field declarations near line 87 in `src/NovaTerminal.App/MainWindow.axaml.cs`:
+
+```csharp
+        private readonly StartupRestoreCoordinator _startupRestoreCoordinator;
+        private StartupRestorePlan? _pendingStartupRestorePlan;
+```
+
+Add a new field directly above them:
+
+```csharp
+        private readonly StartupOrchestrator _startup;
+        private readonly StartupRestoreCoordinator _startupRestoreCoordinator;
+        private StartupRestorePlan? _pendingStartupRestorePlan;
+```
+
+Find the existing parameterless constructor `public MainWindow()`. Convert it into two constructors. The typed one becomes the real ctor; the parameterless one becomes a forwarder kept ONLY for the XAML designer and the existing reflection-driven tests:
+
+```csharp
+        // Designer + legacy-test forwarder. Production callers must use the
+        // typed ctor via App.OnFrameworkInitializationCompleted.
+        public MainWindow() : this(AppServices.BuildForDesigner())
+        {
+        }
+
+        public MainWindow(AppServiceBundle services)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            _startup = services.Startup;
+            // ... rest of the existing ctor body unchanged ...
+        }
+```
+
+Concretely: copy the existing ctor body verbatim into the typed ctor, then leave the parameterless ctor as the one-line forwarder shown above. Do NOT delete or change any existing line of ctor body in this step.
+
+- [ ] **Step 2: Update `App.axaml.cs` to construct services and pass the bundle**
+
+Replace the body of `OnFrameworkInitializationCompleted` in `src/NovaTerminal.App/App.axaml.cs`:
+
+```csharp
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            var tracker = StartupPerformanceTracker.Current
+                ?? throw new InvalidOperationException(
+                    "StartupPerformanceTracker.StartNewCurrent must run before App init.");
+
+            var services = AppServices.Build(
+                tracker,
+                schedule: action => Avalonia.Threading.Dispatcher.UIThread.Post(
+                    action,
+                    Avalonia.Threading.DispatcherPriority.Background));
+
+            desktop.MainWindow = new MainWindow(services);
+            services.Startup.Mark(StartupPhase.MainWindowConstructed);
+
+            // Enable DevTools for debugging - Press F12 to open
+#if DEBUG
+            this.AttachDeveloperTools();
+#endif
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+```
+
+Add the using directive at the top of the file if not already present:
+
+```csharp
+using System;
+```
+
+- [ ] **Step 3: Create the test factory**
+
+Create `tests/NovaTerminal.Tests/Core/TestMainWindowFactory.cs`:
+
+```csharp
+using NovaTerminal.Core;
+
+namespace NovaTerminal.Tests.Core;
+
+internal static class TestMainWindowFactory
+{
+    public static NovaTerminal.MainWindow Create()
+        => new NovaTerminal.MainWindow(AppServices.BuildForDesigner());
+}
+```
+
+- [ ] **Step 4: Switch existing MainWindow fixture call sites to use the factory**
+
+In `tests/NovaTerminal.Tests/Core/MainWindowStartupTests.cs`, replace every occurrence of `new NovaTerminal.MainWindow()` with `TestMainWindowFactory.Create()`. There are 7 occurrences on lines 15, 23, 37, 65, 83, 161, 195, 221. Use the Edit tool with `replace_all: true`:
+
+```
+old_string: new NovaTerminal.MainWindow()
+new_string: TestMainWindowFactory.Create()
+```
+
+Then add the using directive at the top of the test file if not already present:
+
+```csharp
+using NovaTerminal.Core;
+```
+
+(The `NovaTerminal.Core` namespace contains `AppServices` and the orchestrator; the factory file in the same namespace doesn't need a using directive itself.)
+
+The `RecordingCommandProbeWindow` private nested class at the bottom of the file derives from `NovaTerminal.MainWindow` with no explicit ctor — it inherits the parameterless ctor unchanged. Leave that class alone.
+
+- [ ] **Step 5: Build and run the affected tests**
+
+Run:
+
+```powershell
+scripts/build.ps1 test -c Release --filter "FullyQualifiedName~MainWindowStartupTests|FullyQualifiedName~StartupOrchestratorTests|FullyQualifiedName~AppServicesTests" --no-restore
+```
+
+Expected: all tests pass. If any `MainWindowStartupTests` test fails because of a reflection-driven assertion that depended on the parameterless ctor running, investigate — the typed ctor body is supposed to be identical to the old one. Do not "fix" the test by reverting; fix the ctor body.
+
+- [ ] **Step 6: Build the App project to verify App.axaml.cs compiles under AOT-style settings**
+
+Run:
+
+```powershell
+scripts/build.ps1 build src/NovaTerminal.App/NovaTerminal.App.csproj -c Release --no-restore
+```
+
+Expected: build succeeds. The App project's csproj has `<PublishAot>true</PublishAot>` but `dotnet build` (not `publish`) does not enforce AOT trim warnings; we still want a clean build here.
+
+- [ ] **Step 7: Commit**
+
+```powershell
+git commit src/NovaTerminal.App/MainWindow.axaml.cs src/NovaTerminal.App/App.axaml.cs tests/NovaTerminal.Tests/Core/TestMainWindowFactory.cs tests/NovaTerminal.Tests/Core/MainWindowStartupTests.cs -m "refactor: wire MainWindow through AppServiceBundle composition root"
+```
+
+---
+
+### Task 4: Migrate `Mark` and `Checkpoint` call sites in `MainWindow.axaml.cs`
+
+**Files:**
+- Modify: `src/NovaTerminal.App/MainWindow.axaml.cs`
+
+Pure mechanical refactor. Every `StartupPerformanceTracker.Current?.TryMark*(...)` call inside MainWindow becomes `_startup.Mark(...)` or `_startup.Checkpoint(...)`. No behavior change.
+
+Existing call sites (line numbers as of `HEAD` at start of this plan):
+
+| Line | Current | Replace with |
+|---|---|---|
+| 117 | `StartupPerformanceTracker.Current?.TryMark(StartupPhase.WindowOpened);` | `_startup.Mark(StartupPhase.WindowOpened);` |
+| 1217 | `StartupPerformanceTracker.Current?.TryMarkCheckpoint("StartupRestore.AfterSessionLoad");` | `_startup.Checkpoint("StartupRestore.AfterSessionLoad");` |
+| 1234 | `StartupPerformanceTracker.Current?.TryMarkCheckpoint("StartupRestore.AfterTabMaterialization");` | `_startup.Checkpoint("StartupRestore.AfterTabMaterialization");` |
+| 1247 | `StartupPerformanceTracker.Current?.TryMarkCheckpoint("StartupRestore.AfterInitializeRestoredTabs");` | `_startup.Checkpoint("StartupRestore.AfterInitializeRestoredTabs");` |
+| 1248 | `StartupPerformanceTracker.Current?.TryMark(StartupPhase.SessionRestoreComplete);` | `_startup.Mark(StartupPhase.SessionRestoreComplete);` |
+| 1252 | `StartupPerformanceTracker.Current?.TryMark(StartupPhase.BackgroundRestoreComplete);` | `_startup.Mark(StartupPhase.BackgroundRestoreComplete);` |
+| 1293 | `() => StartupPerformanceTracker.Current?.TryMark(StartupPhase.BackgroundRestoreComplete));` | `() => _startup.Mark(StartupPhase.BackgroundRestoreComplete));` |
+| 1967 | `StartupPerformanceTracker.Current?.TryMarkCheckpoint("MainWindow.AfterInitializeComponent");` | `_startup.Checkpoint("MainWindow.AfterInitializeComponent");` |
+| 1969 | `StartupPerformanceTracker.Current?.TryMarkCheckpoint("MainWindow.AfterSettingsLoad");` | `_startup.Checkpoint("MainWindow.AfterSettingsLoad");` |
+| 1979 | `StartupPerformanceTracker.Current?.TryMarkCheckpoint("MainWindow.AfterLegacyMigration");` | `_startup.Checkpoint("MainWindow.AfterLegacyMigration");` |
+| 1987 | `StartupPerformanceTracker.Current?.TryMarkCheckpoint("MainWindow.LoadedPostStart");` | `_startup.Checkpoint("MainWindow.LoadedPostStart");` |
+| 1996 | `StartupPerformanceTracker.Current?.TryMarkCheckpoint("MainWindow.LoadedPostUiReady");` | `_startup.Checkpoint("MainWindow.LoadedPostUiReady");` |
+| 1997 | `StartupPerformanceTracker.Current?.TryMark(StartupPhase.DeferredWorkComplete);` | `_startup.Mark(StartupPhase.DeferredWorkComplete);` |
+| 2100 | `StartupPerformanceTracker.Current?.TryMarkCheckpoint("MainWindow.AfterCoreUiWireup");` | `_startup.Checkpoint("MainWindow.AfterCoreUiWireup");` |
+| 2103 | `StartupPerformanceTracker.Current?.TryMarkCheckpoint("MainWindow.AfterApplyTheme");` | `_startup.Checkpoint("MainWindow.AfterApplyTheme");` |
+| 2153 | `StartupPerformanceTracker.Current?.TryMark(StartupPhase.SessionRestoreComplete);` | `_startup.Mark(StartupPhase.SessionRestoreComplete);` |
+| 2154 | `StartupPerformanceTracker.Current?.TryMark(StartupPhase.BackgroundRestoreComplete);` | `_startup.Mark(StartupPhase.BackgroundRestoreComplete);` |
+| 2160 | `StartupPerformanceTracker.Current?.TryMark(StartupPhase.SessionRestoreComplete);` | `_startup.Mark(StartupPhase.SessionRestoreComplete);` |
+| 2161 | `StartupPerformanceTracker.Current?.TryMark(StartupPhase.BackgroundRestoreComplete);` | `_startup.Mark(StartupPhase.BackgroundRestoreComplete);` |
+| 2168 | `StartupPerformanceTracker.Current?.TryMarkCheckpoint("MainWindow.AfterInitialTabs");` | `_startup.Checkpoint("MainWindow.AfterInitialTabs");` |
+| 2347 | `StartupPerformanceTracker.Current?.TryMarkCheckpoint("MainWindow.CtorComplete");` | `_startup.Checkpoint("MainWindow.CtorComplete");` |
+| 2585 | `StartupPerformanceTracker.Current?.TryMark(StartupPhase.FirstTerminalReady);` (inside `MainWindow.OnPaneOutputReceived` — MainWindow-owned event handler that observes TerminalPane output, NOT TerminalPane's own code) | `_startup.Mark(StartupPhase.FirstTerminalReady);` |
+
+The spec's "TerminalPane keeps the static accessor" rule applies to calls inside `TerminalPane.axaml.cs`. MainWindow's own observer at line 2585 is in scope for migration.
+
+- [ ] **Step 1: Apply the 22 substitutions**
+
+Use the Edit tool with `replace_all: false` for each substitution one-by-one (most call sites have unique surrounding context). For the four duplicated patterns at lines 1248/2153/2160 and 1252/2154/2161, use larger surrounding context (3–4 lines) to disambiguate. The Edit tool will fail with a uniqueness error if the disambiguation is insufficient; if that happens, widen the context.
+
+After every 3–5 edits, re-run a quick compile to fail fast:
+
+```powershell
+scripts/build.ps1 build src/NovaTerminal.App/NovaTerminal.App.csproj -c Release --no-restore
+```
+
+- [ ] **Step 2: Confirm zero remaining `StartupPerformanceTracker.Current?.` references in MainWindow**
+
+Run via the Grep tool (not Bash):
+
+```
+pattern: StartupPerformanceTracker\.Current
+path:    src/NovaTerminal.App/MainWindow.axaml.cs
+output_mode: content
+```
+
+Expected: zero results.
+
+- [ ] **Step 3: Run the regression test set**
+
+Run:
+
+```powershell
+scripts/build.ps1 test -c Release --filter "FullyQualifiedName~MainWindowStartupTests|FullyQualifiedName~StartupOrchestratorTests|FullyQualifiedName~AppServicesTests|FullyQualifiedName~StartupPerformanceTrackerTests|FullyQualifiedName~StartupMetricsWriterTests|FullyQualifiedName~StartupMetricsSummaryTests|FullyQualifiedName~StartupRestoreCoordinatorTests|FullyQualifiedName~StartupRestorePlanTests|FullyQualifiedName~TerminalPaneStartupInstrumentationTests" --no-restore
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```powershell
+git commit src/NovaTerminal.App/MainWindow.axaml.cs -m "refactor: route MainWindow phase + checkpoint marks through StartupOrchestrator"
+```
+
+---
+
+### Task 5: Migrate session restore + deferred path through the orchestrator
+
+**Files:**
+- Modify: `src/NovaTerminal.App/MainWindow.axaml.cs`
+
+This task removes `_startupRestoreCoordinator`, `_pendingStartupRestorePlan`, `RunDeferredStartupRestore()`, replaces the inline plan/mark logic with `_startup.BeginSessionRestore`/`DrainDeferred`, and collapses the duplicated fresh-start path.
+
+- [ ] **Step 1: Delete the now-redundant fields**
+
+In `src/NovaTerminal.App/MainWindow.axaml.cs`, near the field declarations added in Task 3, delete these two lines:
+
+```csharp
+        private readonly StartupRestoreCoordinator _startupRestoreCoordinator;
+        private StartupRestorePlan? _pendingStartupRestorePlan;
+```
+
+Leave the `private readonly StartupOrchestrator _startup;` field in place. The file will not compile until later steps land.
+
+- [ ] **Step 2: Delete the coordinator construction**
+
+Locate line 1973 (approximate; was the only `_startupRestoreCoordinator = new ...` assignment inside the ctor body):
+
+```csharp
+            _startupRestoreCoordinator = new StartupRestoreCoordinator(action => Dispatcher.UIThread.Post(action, DispatcherPriority.Background));
+```
+
+Delete this line entirely. The orchestrator now owns the coordinator (constructed inside `AppServices.Build`).
+
+- [ ] **Step 3: Rewrite the session-restore body in `TryRestoreStartupSession`**
+
+Find the method `TryRestoreStartupSession` (around line 1208). Replace its body between the `if (!SessionManager.TryLoadSavedSession(...) || ...) return false;` guard and the closing brace. The new body:
+
+```csharp
+        private bool TryRestoreStartupSession(TabControl tabs)
+        {
+            if (!SessionManager.TryLoadSavedSession(out NovaSession? session) ||
+                session == null ||
+                session.Tabs.Count == 0)
+            {
+                return false;
+            }
+            _startup.Checkpoint("StartupRestore.AfterSessionLoad");
+
+            _startup.BeginSessionRestore(session, immediate =>
+            {
+                tabs.Items.Clear();
+
+                for (int index = 0; index < session.Tabs.Count; index++)
+                {
+                    TabSession tabSession = session.Tabs[index];
+                    TabItem? tabItem = index == immediate.OriginalIndex
+                        ? SessionManager.CreateRestoredTabItem(tabSession, _settings)
+                        : CreateStartupPlaceholderTab(tabSession);
+
+                    if (tabItem != null)
+                    {
+                        tabs.Items.Add(tabItem);
+                    }
+                }
+
+                if (tabs.Items.Count == 0)
+                {
+                    throw new InvalidOperationException(
+                        "Session restore produced no tab items; aborting restore.");
+                }
+
+                if (immediate.OriginalIndex >= 0 && immediate.OriginalIndex < tabs.Items.Count)
+                {
+                    tabs.SelectedIndex = immediate.OriginalIndex;
+                }
+            });
+
+            _startup.Checkpoint("StartupRestore.AfterTabMaterialization");
+
+            InitializeRestoredTabs(tabs);
+            _startup.Checkpoint("StartupRestore.AfterInitializeRestoredTabs");
+
+            return true;
+        }
+```
+
+Two semantic notes:
+
+- If the callback throws (the empty-tabs guard), `_startup.BeginSessionRestore` propagates the exception. The orchestrator's contract guarantees no phases were marked and no plan was stashed. The caller of `TryRestoreStartupSession` already wraps the call in a `try/catch` flow (the outer `TryRestore...` returns false; see Step 4) — keep that flow.
+- `_startup.Mark(StartupPhase.SessionRestoreComplete)` and the if/else around `_pendingStartupRestorePlan = plan` that previously lived at lines 1248–1258 are gone. The orchestrator handles them.
+
+- [ ] **Step 4: Wrap the `BeginSessionRestore` call site to translate the throw into a clean fall-through**
+
+The current callers of `TryRestoreStartupSession` (around line 2150) treat a `false` return value as "session restore failed; do the fresh-start path". `BeginSessionRestore` now throws when the layout callback rejects the session. Translate the throw into a `false` return inside `TryRestoreStartupSession`:
+
+Replace the body crafted in Step 3 with this wrapped form:
+
+```csharp
+        private bool TryRestoreStartupSession(TabControl tabs)
+        {
+            if (!SessionManager.TryLoadSavedSession(out NovaSession? session) ||
+                session == null ||
+                session.Tabs.Count == 0)
+            {
+                return false;
+            }
+            _startup.Checkpoint("StartupRestore.AfterSessionLoad");
+
+            try
+            {
+                _startup.BeginSessionRestore(session, immediate =>
+                {
+                    tabs.Items.Clear();
+
+                    for (int index = 0; index < session.Tabs.Count; index++)
+                    {
+                        TabSession tabSession = session.Tabs[index];
+                        TabItem? tabItem = index == immediate.OriginalIndex
+                            ? SessionManager.CreateRestoredTabItem(tabSession, _settings)
+                            : CreateStartupPlaceholderTab(tabSession);
+
+                        if (tabItem != null)
+                        {
+                            tabs.Items.Add(tabItem);
+                        }
+                    }
+
+                    if (tabs.Items.Count == 0)
+                    {
+                        throw new InvalidOperationException(
+                            "Session restore produced no tab items; aborting restore.");
+                    }
+
+                    if (immediate.OriginalIndex >= 0 && immediate.OriginalIndex < tabs.Items.Count)
+                    {
+                        tabs.SelectedIndex = immediate.OriginalIndex;
+                    }
+                });
+            }
+            catch (InvalidOperationException ex)
+            {
+                TerminalLogger.Log($"TryRestoreStartupSession: aborted ({ex.Message})");
+                return false;
+            }
+
+            _startup.Checkpoint("StartupRestore.AfterTabMaterialization");
+
+            InitializeRestoredTabs(tabs);
+            _startup.Checkpoint("StartupRestore.AfterInitializeRestoredTabs");
+
+            return true;
+        }
+```
+
+The narrow `InvalidOperationException` catch matches only our intentional throw; any other exception (e.g. from `SessionManager.CreateRestoredTabItem`) keeps propagating as today.
+
+- [ ] **Step 5: Delete `RunDeferredStartupRestore` and `HydrateDeferredStartupTab`-call-from-RunDeferred**
+
+Find and **delete the entire** `RunDeferredStartupRestore` method (around lines 1280–1294):
+
+```csharp
+        private void RunDeferredStartupRestore()
+        {
+            var tabs = this.FindControl<TabControl>("Tabs");
+            var plan = _pendingStartupRestorePlan;
+            if (tabs == null || plan == null)
+            {
+                return;
+            }
+
+            _pendingStartupRestorePlan = null;
+            _startupRestoreCoordinator.RunDeferred(
+                plan.DeferredTabs,
+                deferredTab => HydrateDeferredStartupTab(tabs, deferredTab),
+                () => _startup.Mark(StartupPhase.BackgroundRestoreComplete));
+        }
+```
+
+Leave `HydrateDeferredStartupTab` in place — it's still used by the inline lambda in Step 6.
+
+- [ ] **Step 6: Replace the deferred-restore trigger in `RegisterPaneOwners` / startup-tabs region**
+
+Around line 2164, replace:
+
+```csharp
+            if (_pendingStartupRestorePlan != null)
+            {
+                Dispatcher.UIThread.Post(RunDeferredStartupRestore, DispatcherPriority.Background);
+            }
+```
+
+with:
+
+```csharp
+            if (_startup.HasPendingDeferredRestore)
+            {
+                Dispatcher.UIThread.Post(() =>
+                {
+                    var tabsControl = this.FindControl<TabControl>("Tabs");
+                    if (tabsControl == null)
+                    {
+                        return;
+                    }
+                    _startup.DrainDeferred(deferredTab => HydrateDeferredStartupTab(tabsControl, deferredTab));
+                }, DispatcherPriority.Background);
+            }
+```
+
+This preserves the exact behavior of the old `RunDeferredStartupRestore`: do nothing if the `Tabs` control is missing, otherwise hand each deferred tab to `HydrateDeferredStartupTab`. `BackgroundRestoreComplete` is marked by the orchestrator via its `onCompleted` callback inside `DrainDeferred`.
+
+- [ ] **Step 7: Consolidate the duplicated fresh-start path**
+
+Around lines 2148–2162, the current code is:
+
+```csharp
+            if (tabs != null)
+            {
+                if (!TryRestoreStartupSession(tabs))
+                {
+                    AddTab(defaultProfile);
+                    _startup.Mark(StartupPhase.SessionRestoreComplete);
+                    _startup.Mark(StartupPhase.BackgroundRestoreComplete);
+                }
+            }
+            else
+            {
+                AddTab(defaultProfile);
+                _startup.Mark(StartupPhase.SessionRestoreComplete);
+                _startup.Mark(StartupPhase.BackgroundRestoreComplete);
+            }
+```
+
+(The `_startup.Mark(...)` substitutions were applied in Task 4.) Replace with:
+
+```csharp
+            if (tabs != null)
+            {
+                if (!TryRestoreStartupSession(tabs))
+                {
+                    AddTab(defaultProfile);
+                    _startup.CompleteWithoutRestore();
+                }
+            }
+            else
+            {
+                AddTab(defaultProfile);
+                _startup.CompleteWithoutRestore();
+            }
+```
+
+This is the one quiet correctness improvement the spec promised: collapses the duplicated mark-pair into a single `CompleteWithoutRestore()` call in each branch. Same observable behavior; the orchestrator owns the invariant.
+
+- [ ] **Step 8: Build to confirm there are no dangling references**
+
+Run:
+
+```powershell
+scripts/build.ps1 build src/NovaTerminal.App/NovaTerminal.App.csproj -c Release --no-restore
+```
+
+Expected: clean build. If you get `CS0103: The name '_pendingStartupRestorePlan' does not exist`, you missed a call site — search MainWindow.axaml.cs for `_pendingStartupRestorePlan` and `_startupRestoreCoordinator` and remove or migrate every remaining reference.
+
+Run via Grep tool to verify zero remaining references:
+
+```
+pattern: _pendingStartupRestorePlan|_startupRestoreCoordinator|RunDeferredStartupRestore
+path:    src/NovaTerminal.App/MainWindow.axaml.cs
+output_mode: content
+```
+
+Expected: zero results.
+
+- [ ] **Step 9: Run the regression test set**
+
+Run:
+
+```powershell
+scripts/build.ps1 test -c Release --filter "FullyQualifiedName~MainWindowStartupTests|FullyQualifiedName~StartupOrchestratorTests|FullyQualifiedName~AppServicesTests|FullyQualifiedName~StartupPerformanceTrackerTests|FullyQualifiedName~StartupMetricsWriterTests|FullyQualifiedName~StartupMetricsSummaryTests|FullyQualifiedName~StartupRestoreCoordinatorTests|FullyQualifiedName~StartupRestorePlanTests|FullyQualifiedName~TerminalPaneStartupInstrumentationTests|FullyQualifiedName~SessionManagerTests" --no-restore
+```
+
+Expected: all pass.
+
+- [ ] **Step 10: Commit**
+
+```powershell
+git commit src/NovaTerminal.App/MainWindow.axaml.cs -m "refactor: route MainWindow session restore through StartupOrchestrator"
+```
+
+---
+
+### Task 6: Full-suite regression + measurement-gate documentation
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-26-startup-orchestrator-extraction-design.md` (mark status complete)
+
+- [ ] **Step 1: Run the full test suite using the documented filter**
+
+The README's documented filter excludes Replay, RenderMetrics, and PtySmoke categories:
+
+```powershell
+scripts/build.ps1 test -c Release --filter "Category!=Replay&Category!=RenderMetrics&Category!=PtySmoke" --no-restore
+```
+
+Expected: all pass. If any test outside the touched namespaces fails, investigate — but the suite has pre-existing flakes; verify the failure reproduces on `main` before blaming this PR.
+
+- [ ] **Step 2: Capture a measurement baseline against `main`**
+
+The spec's measurement gate requires before/after numbers. From a fresh terminal:
+
+```powershell
+# Stash any uncommitted work first (icon/PowerShell staging from the session start)
+git stash push --keep-index -m "extraction-plan-baseline-stash"
+git switch -d origin/main
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests\tools\measure_startup.ps1 -Configuration Release -Label pre-orchestrator-extraction -Iterations 10
+git switch -                                                  # back to the working branch
+git stash pop                                                  # restore staging area
+```
+
+If `git stash push --keep-index` is unavailable for any reason (e.g. the staged work was previously stashed and popped), skip the stash step and capture the baseline from a clean checkout of `origin/main` in a separate worktree:
+
+```powershell
+git worktree add ../nova2-baseline origin/main
+cd ../nova2-baseline
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests\tools\measure_startup.ps1 -Configuration Release -Label pre-orchestrator-extraction -Iterations 10
+cd -
+git worktree remove ../nova2-baseline
+```
+
+- [ ] **Step 3: Capture the post-change measurement**
+
+From the working branch with this plan's commits applied:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests\tools\measure_startup.ps1 -Configuration Release -Label post-orchestrator-extraction -Iterations 10
+```
+
+- [ ] **Step 4: Generate the comparison report**
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests\tools\summarize_startup_metrics.ps1 pre-orchestrator-extraction post-orchestrator-extraction
+```
+
+Expected: deltas on `Main Window Constructed`, `Window Opened`, `First Terminal Ready`, `Session Restore Complete` are within ±2%. Save the output text — it goes in the PR description.
+
+If any delta is outside ±2%, investigate. Likely causes (in priority order):
+1. A migrated checkpoint name was typo'd — re-check Task 4's substitution table against the output JSONL.
+2. The orchestrator is being constructed too early or too late — verify the order in `App.OnFrameworkInitializationCompleted` exactly matches the spec.
+3. Genuine background restore drift — if `BackgroundRestoreComplete` regressed >2%, check that the per-tab try/catch wrapper in `DrainDeferred` isn't catching legitimate exceptions that the old code let propagate.
+
+- [ ] **Step 5: Mark the spec as complete**
+
+In `docs/superpowers/specs/2026-05-26-startup-orchestrator-extraction-design.md`, change the second header line from:
+
+```
+**Status:** Spec — awaiting user review before writing implementation plan
+```
+
+to:
+
+```
+**Status:** Implemented (see docs/superpowers/plans/2026-05-26-startup-orchestrator-extraction-plan.md)
+```
+
+- [ ] **Step 6: Commit the doc update**
+
+```powershell
+git commit docs/superpowers/specs/2026-05-26-startup-orchestrator-extraction-design.md -m "docs: mark startup-orchestrator extraction spec as implemented"
+```
+
+- [ ] **Step 7: Open the PR**
+
+```powershell
+gh pr create --title "refactor: extract StartupOrchestrator from MainWindow" --body "$(cat <<'EOF'
+## Summary
+- Extract `StartupOrchestrator` from `MainWindow.axaml.cs` and introduce the `AppServiceBundle` composition-root pattern.
+- Migrate 20+ scattered `StartupPerformanceTracker.Current?.TryMark*` call sites to the orchestrator.
+- Move session-restore lifecycle (`_pendingStartupRestorePlan`, `RunDeferredStartupRestore`, `_startupRestoreCoordinator`) behind the orchestrator.
+- Collapse a duplicated `Mark(SessionRestoreComplete) + Mark(BackgroundRestoreComplete)` pair into a single `CompleteWithoutRestore()` call.
+
+## Why
+PR #67 added the instrumentation building blocks but left the orchestration inline in MainWindow (now 5249 lines). This extraction removes the global-static `StartupPerformanceTracker.Current?.` antipattern from MainWindow, makes the startup state machine independently unit-testable, and establishes the `AppServiceBundle` pattern that future MainWindow-cluster extractions (TabRuntimeRegistry, PaneZoomController, etc.) will follow.
+
+## Out of scope
+- TerminalPane settings threading (P4-#15 from the review doc)
+- Background Restore +5.71% regression recovery from PR #67
+- DI container adoption
+- Any new phases, checkpoints, or measurements
+
+## Measurement
+[Paste the output from `summarize_startup_metrics.ps1 pre-orchestrator-extraction post-orchestrator-extraction` here. All deltas within ±2%.]
+
+## Test plan
+- [x] `scripts/build.ps1 test -c Release --filter "Category!=Replay&Category!=RenderMetrics&Category!=PtySmoke"`
+- [x] `scripts/build.ps1 build src/NovaTerminal.App/NovaTerminal.App.csproj -c Release`
+- [x] Measurement gate within ±2%
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+### Notes for execution
+
+- **Staged-work safety:** the session that produced this plan left the icon-ico-swap + PowerShell `-File` unquote fix in the staging area. Every `git commit` in this plan uses explicit paths, so those changes are never swept into a commit produced by this plan. If a commit step ever lands those files, stop immediately and run `git reset --soft HEAD~1` then re-commit with explicit paths.
+- **Build wrappers are mandatory:** raw `dotnet build` / `dotnet test` hangs the Bash tool's pipe per `CLAUDE.md`. Always use `scripts/build.ps1` / `scripts/build.sh`. If a test step appears stuck, kill it and re-run via the wrapper.
+- **Do NOT touch:** `NovaTerminal.VT`, `NovaTerminal.Rendering`, `NovaTerminal.Replay`, `TerminalPane.axaml.cs`'s `FirstTerminalReady` mark, the `StartupPerformanceTracker.Current` static accessor (it must continue to work for TerminalPane), the `StartupRestoreCoordinator` and `StartupRestorePlan` source files.
+- **Commit granularity:** each task produces exactly one commit. Six commits total. If a task step fails partway, fix forward on the same commit (do not split). If you realize a previous task's commit needs a fix, add a follow-up commit rather than amending.
+- **Existing in-repo stashes** (`stash@{0..5}`): leave them alone. None are related to this work.
+
+### Recommended execution order
+
+1. Task 1 — StartupOrchestrator + tests
+2. Task 2 — AppServiceBundle + AppServices + tests
+3. Task 3 — Wire MainWindow through the bundle (no call-site migration)
+4. Task 4 — Migrate Mark/Checkpoint call sites
+5. Task 5 — Migrate session-restore lifecycle + consolidate fresh-start
+6. Task 6 — Regression + measurement gate + PR

--- a/docs/superpowers/specs/2026-05-26-startup-orchestrator-extraction-design.md
+++ b/docs/superpowers/specs/2026-05-26-startup-orchestrator-extraction-design.md
@@ -1,0 +1,542 @@
+# StartupOrchestrator Extraction Design
+
+**Date:** 2026-05-26
+**Status:** Spec — awaiting user review before writing implementation plan
+**Scope:** App layer only. Pure refactor; sets composition-root pattern for future MainWindow-cluster extractions.
+**Owner:** N/A (single-author repo)
+
+## Context
+
+PR #67 ([codex] Improve startup instrumentation and critical path) added
+`StartupPerformanceTracker`, `StartupRestoreCoordinator`, `StartupRestorePlan`,
+`StartupMetricsWriter`, `StartupMetricsAnalysis` and a measurement harness,
+deferred window icon decoding, and produced 8–12% wins on the four primary
+startup checkpoints (`Main Window Constructed`, `Window Opened`,
+`First Terminal Ready`, `Session Restore Complete`).
+
+The building blocks now exist, but the orchestration sits inline inside
+`MainWindow.axaml.cs` (now 5 249 lines). Specifically:
+
+- 20+ scattered `StartupPerformanceTracker.Current?.TryMark*(...)` call sites
+  (MainWindow lines 117, 1217, 1219, 1234, 1247, 1248, 1252, 1283, 1289, 1293,
+  1967, 1969, 1979, 1987, 1996, 1997, 2100, 2103, 2153, 2154, 2160, 2161, 2168,
+  2347, 2585).
+- `_startupRestoreCoordinator` field constructed in the ctor (line 1973).
+- `_pendingStartupRestorePlan` field (line 88) plus its lifecycle.
+- A duplicated `Mark(SessionRestoreComplete) + Mark(BackgroundRestoreComplete)`
+  pair at lines 2153–2154 and 2160–2161 (the "no restore happened" branches).
+- A private `RunDeferredStartupRestore()` method that talks to the coordinator.
+
+The next ~10% of startup wins (constructor diet, further phase deferral) is
+gated on having an explicit orchestration surface. This design extracts that
+surface and establishes the composition-root pattern (`AppServiceBundle`) that
+all future MainWindow-cluster extractions (`TabRuntimeRegistry`,
+`PaneZoomController`, `RecordingToastController`,
+`TransferOverlayDragController`) will follow.
+
+The companion review document
+(`C:\Users\behna\.claude\plans\review-the-project-deeply-generic-cake.md`)
+ranks this as the top remaining structural item under P0-#1.
+
+## Goal
+
+Extract `StartupOrchestrator` from `MainWindow` and introduce
+`AppServiceBundle` as the composition-root pattern, with:
+
+- zero net behavior change (pure refactor; one quiet correctness improvement
+  noted below)
+- the orchestrator unit-testable without Avalonia bootstrap
+- the wiring pattern (`AppServices.Build(...) → AppServiceBundle → MainWindow`)
+  established so subsequent extractions add one record field, not a ctor
+  parameter
+
+## Non-goals
+
+- No new startup phases, checkpoints, or metrics surfaces. This PR moves
+  existing calls, it does not change what is measured.
+- No `IStartupTracker` interface or `StartupCheckpoints` string-constants
+  module. These were the "Wide" option in brainstorming; both are deferred.
+- No TerminalPane migration. TerminalPane keeps
+  `StartupPerformanceTracker.Current?.TryMark(StartupPhase.FirstTerminalReady)`
+  as-is. The static `Current` accessor remains.
+- No DI container (`Microsoft.Extensions.DependencyInjection`) adoption.
+- No fix to the `TerminalSettings.Load()` per-pane reload (P4-#15) and no
+  attempt to claw back PR #67's +5.71% `Background Restore Complete`
+  regression. Both are separate follow-up PRs.
+- No changes to `NovaTerminal.VT`, `NovaTerminal.Rendering`, or
+  `NovaTerminal.Replay`.
+
+## Constraints
+
+- Native AOT (`PublishAot=true`): no reflection-based DI, no open generics,
+  no assembly scanning.
+- Per `AGENTS.md`: additive changes preferred; keep interfaces small and
+  explicit.
+- The XAML compiler instantiates `MainWindow` via its parameterless ctor at
+  design time. A parameterless ctor must remain on `MainWindow`.
+- All new code must be deterministically unit-testable without spinning up
+  Avalonia.
+
+## Recommended approach
+
+Three decisions, taken in brainstorming:
+
+1. **Wiring pattern** — `static AppServices.Build(...)` returns a
+   `record AppServiceBundle` that `MainWindow`'s ctor accepts as its sole
+   parameter. Future services add a record field; ctor signature does not
+   grow. (Chosen over direct ctor injection and over MS.E.DependencyInjection.)
+2. **Orchestrator scope** — Medium: phases, checkpoints, session-restore
+   lifecycle, pending-plan field, fresh-start path consolidation.
+   (Chosen over Minimal "state holder" and Wide "facade + constants".)
+3. **Primary refactor goal** — Open the door to a bigger refactor (set the
+   pattern). The orchestrator is the prototype that future cluster
+   extractions copy.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Program.cs                                                       │
+│   StartupPerformanceTracker.StartNewCurrent()  // unchanged      │
+│   AppBuilder.Configure<App>()...StartWithClassicDesktop()        │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ App.axaml.cs                                                     │
+│   var tracker  = StartupPerformanceTracker.Current!              │
+│   var services = AppServices.Build(                              │
+│       tracker,                                                   │
+│       schedule: action => Dispatcher.UIThread.Post(              │
+│           action, DispatcherPriority.Background))                │
+│   desktop.MainWindow = new MainWindow(services)                  │
+│   services.Startup.Mark(StartupPhase.MainWindowConstructed)      │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ AppServiceBundle (record)                                        │
+│   StartupOrchestrator Startup                                    │
+│   // future PRs: TabRuntimeRegistry, PaneZoomController, ...     │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ StartupOrchestrator                                              │
+│   wraps  StartupPerformanceTracker     (ctor-injected)           │
+│   owns   StartupRestoreCoordinator     (ctor-injected)           │
+│   owns   StartupRestorePlan? _pendingPlan                        │
+│                                                                  │
+│   Mark / Checkpoint                                              │
+│   BeginSessionRestore(session, materializeImmediate)             │
+│       → returns StartupRestoreOutcome                            │
+│   DrainDeferred(materializeTab)                                  │
+│   CompleteWithoutRestore()                                       │
+│   HasPendingDeferredRestore : bool                               │
+└─────────────────────────────────────────────────────────────────┘
+                                ▲
+                                │ holds reference to
+┌─────────────────────────────────────────────────────────────────┐
+│ MainWindow                                                       │
+│   private readonly StartupOrchestrator _startup;                 │
+│   public MainWindow(AppServiceBundle services) { ... }           │
+│   public MainWindow() : this(AppServices.BuildForDesigner()) {}  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Key boundaries**
+
+- `StartupPerformanceTracker` is unchanged. The orchestrator composes it; it
+  does not replace it. The static `Current` accessor remains for legacy
+  call sites (TerminalPane, the design-time bundle).
+- `StartupRestoreCoordinator` and `StartupRestorePlan` are unchanged. The
+  orchestrator instantiates and owns the coordinator.
+- `App.axaml.cs:20`'s `Mark(MainWindowConstructed)` stays in App (the moment
+  is "ctor returned"). Its target becomes `services.Startup` instead of the
+  static.
+
+## Components
+
+### `StartupOrchestrator` (new — `src/NovaTerminal.App/Core/StartupOrchestrator.cs`)
+
+```csharp
+namespace NovaTerminal.Core;
+
+public sealed class StartupOrchestrator
+{
+    private readonly StartupPerformanceTracker _tracker;
+    private readonly StartupRestoreCoordinator _coordinator;
+    private StartupRestorePlan? _pendingPlan;
+
+    public StartupOrchestrator(
+        StartupPerformanceTracker tracker,
+        StartupRestoreCoordinator coordinator)
+    {
+        _tracker     = tracker     ?? throw new ArgumentNullException(nameof(tracker));
+        _coordinator = coordinator ?? throw new ArgumentNullException(nameof(coordinator));
+    }
+
+    public void Mark(StartupPhase phase) => _tracker.TryMark(phase);
+
+    public void Checkpoint(string name) => _tracker.TryMarkCheckpoint(name);
+
+    public void BeginSessionRestore(
+        NovaSession session,
+        Action<StartupRestoreTab> materializeImmediate);
+
+    public void DrainDeferred(Action<StartupRestoreTab> materializeTab);
+
+    public void CompleteWithoutRestore();
+
+    public bool HasPendingDeferredRestore => _pendingPlan is not null;
+}
+```
+
+Behavior:
+
+- `BeginSessionRestore` calls `StartupRestorePlan.Create(session)`, invokes
+  `materializeImmediate` synchronously with the plan's immediate tab, then
+  marks `SessionRestoreComplete`. If `plan.DeferredTabs.Count == 0`, also
+  marks `BackgroundRestoreComplete` and leaves `_pendingPlan` null. Else
+  stashes `_pendingPlan = plan`. Returns `void` — callers query
+  `HasPendingDeferredRestore` (which is also queried later, after the
+  no-restore branch, so a single property is the source of truth).
+- `DrainDeferred` no-ops if `_pendingPlan` is null. Otherwise clears
+  `_pendingPlan` and calls `_coordinator.RunDeferred(plan.DeferredTabs,
+  perTab, onCompleted: () => _tracker.TryMark(BackgroundRestoreComplete))`,
+  where `perTab` is a local function defined inside `DrainDeferred` that
+  wraps the caller's `materializeTab` in `try { materializeTab(tab); }
+  catch (Exception ex) { TerminalLogger.Log(ex); }`. The coordinator itself
+  is unchanged; the try/catch lives in the orchestrator's lambda, not in
+  `StartupRestoreCoordinator`. This isolates one bad tab from the rest of
+  the loop and from `BackgroundRestoreComplete` firing.
+- `CompleteWithoutRestore` marks both `SessionRestoreComplete` and
+  `BackgroundRestoreComplete`. Idempotent.
+
+### `AppServiceBundle` (new — `src/NovaTerminal.App/Core/AppServiceBundle.cs`)
+
+```csharp
+namespace NovaTerminal.Core;
+
+public sealed record AppServiceBundle(StartupOrchestrator Startup);
+```
+
+Adding a future service is one record field:
+
+```csharp
+public sealed record AppServiceBundle(
+    StartupOrchestrator Startup,
+    TabRuntimeRegistry  Tabs);   // ← future PR adds this line
+```
+
+### `AppServices` (new — `src/NovaTerminal.App/Core/AppServices.cs`)
+
+```csharp
+namespace NovaTerminal.Core;
+
+public static class AppServices
+{
+    public static AppServiceBundle Build(
+        StartupPerformanceTracker tracker,
+        Action<Action> schedule)
+    {
+        var coordinator  = new StartupRestoreCoordinator(schedule);
+        var orchestrator = new StartupOrchestrator(tracker, coordinator);
+        return new AppServiceBundle(orchestrator);
+    }
+
+    internal static AppServiceBundle BuildForDesigner()
+    {
+        var tracker      = new StartupPerformanceTracker();
+        var coordinator  = new StartupRestoreCoordinator(action => action());
+        var orchestrator = new StartupOrchestrator(tracker, coordinator);
+        return new AppServiceBundle(orchestrator);
+    }
+}
+```
+
+`BuildForDesigner` exists solely to satisfy the parameterless `MainWindow`
+ctor that the XAML designer requires. Production code calls `Build`.
+
+### `MainWindow` ctor
+
+```csharp
+private readonly StartupOrchestrator _startup;
+
+public MainWindow(AppServiceBundle services)
+{
+    _startup = services.Startup;
+    // ... existing ctor body, with every
+    //     StartupPerformanceTracker.Current?.TryMark*(...) replaced by
+    //     _startup.Mark(...) / _startup.Checkpoint(...)
+}
+
+public MainWindow() : this(AppServices.BuildForDesigner()) { }
+```
+
+### `App.axaml.cs`
+
+```csharp
+public override void OnFrameworkInitializationCompleted()
+{
+    if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+    {
+        var tracker = StartupPerformanceTracker.Current
+            ?? throw new InvalidOperationException(
+                "StartupPerformanceTracker.StartNewCurrent must run before App init.");
+
+        var services = AppServices.Build(
+            tracker,
+            schedule: action => Dispatcher.UIThread.Post(action, DispatcherPriority.Background));
+
+        var mainWindow = new MainWindow(services);
+        desktop.MainWindow = mainWindow;
+
+        services.Startup.Mark(StartupPhase.MainWindowConstructed);
+    }
+    base.OnFrameworkInitializationCompleted();
+}
+```
+
+## Data flow
+
+### Startup walkthrough (after the extraction)
+
+```
+TIME    LAYER         CALL                                                EFFECT
+────    ─────         ────                                                ──────
+t=0     Program       StartupPerformanceTracker.StartNewCurrent()         tracker.Current set; t0 captured
+        Program       AppBuilder...StartWithClassicDesktop()              Avalonia starts
+
+        App           tracker  = StartupPerformanceTracker.Current!
+                      services = AppServices.Build(tracker, schedule)     orchestrator constructed
+                      w        = new MainWindow(services)                 ctor runs (see below)
+                      services.Startup.Mark(MainWindowConstructed)        phase fires (was App.axaml.cs:20)
+                      desktop.MainWindow = w
+
+══════ MainWindow ctor (synchronous) ═════════════════════════════════════════════════════════════
+        MainWindow    _startup = services.Startup
+                      InitializeComponent()
+                      _startup.Checkpoint("MainWindow.AfterInitializeComponent")
+                      _settings = TerminalSettings.Load()
+                      _startup.Checkpoint("MainWindow.AfterSettingsLoad")
+                      // StartupRestoreCoordinator instantiation REMOVED here —
+                      // owned by orchestrator via AppServices.Build
+                      _startup.Checkpoint("MainWindow.AfterLegacyMigration")
+                      ApplyTheme()
+                      _startup.Checkpoint("MainWindow.AfterApplyTheme")
+
+                      // Session restore branch:
+                      if (session != null && session.Tabs.Count > 0) {
+                          _startup.Checkpoint("StartupRestore.AfterSessionLoad")
+                          _startup.BeginSessionRestore(
+                              session,
+                              immediate => MaterializeTabUi(immediate))
+                          // orchestrator: creates plan; calls callback ONCE
+                          // for immediate; marks SessionRestoreComplete;
+                          // if deferred.Count == 0 also marks
+                          // BackgroundRestoreComplete and leaves _pendingPlan
+                          // null; else stashes _pendingPlan
+                          _startup.Checkpoint("StartupRestore.AfterTabMaterialization")
+                          InitializeRestoredTabsUi()
+                          _startup.Checkpoint("StartupRestore.AfterInitializeRestoredTabs")
+                      } else {
+                          AddTab(defaultProfile)
+                          _startup.CompleteWithoutRestore()
+                          // replaces duplicated pair at MainWindow:2153-2154 and :2160-2161
+                      }
+
+                      if (_startup.HasPendingDeferredRestore) {
+                          Dispatcher.UIThread.Post(
+                              () => _startup.DrainDeferred(t => MaterializeTabUi(t)),
+                              DispatcherPriority.Background)
+                      }
+                      _startup.Checkpoint("MainWindow.AfterInitialTabs")
+                      _startup.Checkpoint("MainWindow.AfterCoreUiWireup")
+                      _startup.Checkpoint("MainWindow.CtorComplete")
+══════════════════════════════════════════════════════════════════════════════════════════════════
+
+t≈X     MainWindow.OnOpened          _startup.Mark(WindowOpened)
+                                                                          (was MainWindow.axaml.cs:117)
+
+t≈Y     TerminalPane (first)         StartupPerformanceTracker.Current?.TryMark(
+                                         FirstTerminalReady)
+                                                                          unchanged — pane keeps the
+                                                                          static accessor
+
+t≈Z     MainWindow Loaded            _startup.Checkpoint("MainWindow.LoadedPostStart")
+                                     // ... wait for UI ready ...
+                                     _startup.Checkpoint("MainWindow.LoadedPostUiReady")
+                                     _startup.Mark(DeferredWorkComplete)
+
+t≈Z+    Dispatcher (Background)      _startup.DrainDeferred(t => MaterializeTabUi(t))
+                                     // orchestrator: if _pendingPlan, calls
+                                     // coordinator.RunDeferred which posts the loop;
+                                     // on completion marks BackgroundRestoreComplete;
+                                     // snapshot writer fires.
+```
+
+### Call-site migration map
+
+| Today (`MainWindow.axaml.cs`) | After |
+|---|---|
+| `_startupRestoreCoordinator = new StartupRestoreCoordinator(...)` (line 1973) | deleted — orchestrator owns it (constructed inside `AppServices.Build`) |
+| `_pendingStartupRestorePlan` field (line 88) | deleted — orchestrator owns it |
+| `StartupPerformanceTracker.Current?.TryMark*(...)` × 20+ sites | `_startup.Mark(...)` or `_startup.Checkpoint(...)` |
+| `var plan = StartupRestorePlan.Create(session)` + immediate materialization + marks (lines 1219–1257) | `_startup.BeginSessionRestore(session, immediate => MaterializeTabUi(immediate))` |
+| Private `RunDeferredStartupRestore()` method (around line 1280) | deleted — replaced by `_startup.DrainDeferred(t => MaterializeTabUi(t))` |
+| Duplicated `TryMark(SessionRestoreComplete) + TryMark(BackgroundRestoreComplete)` at lines 2153–2154 **and** 2160–2161 | single `_startup.CompleteWithoutRestore()` in each branch |
+| `if (_pendingStartupRestorePlan != null) { Post(RunDeferredStartupRestore) }` (line 2164) | `if (_startup.HasPendingDeferredRestore) { Post(() => _startup.DrainDeferred(...)) }` |
+
+### Threading
+
+- `BeginSessionRestore` runs on the UI thread (called from MainWindow ctor).
+  The `materializeImmediate` callback is invoked synchronously on the same
+  thread.
+- `DrainDeferred` is expected on the UI thread. It calls into the coordinator,
+  which uses the injected `schedule` (`Dispatcher.UIThread.Post` in
+  production) to run the deferred loop later — same threading as today.
+- No new locks. `_pendingPlan` is touched only on the UI thread.
+
+### Net observable behavior
+
+Zero, with one quiet correctness improvement: the duplicated
+`Mark(SessionRestoreComplete) + Mark(BackgroundRestoreComplete)` pair at
+MainWindow:2153–2154 and :2160–2161 collapses into a single
+`CompleteWithoutRestore()` call. Same metrics emit, smaller risk surface.
+
+## Error handling
+
+The orchestrator inherits the design doc's error policy: startup must remain
+resilient; instrumentation must not hang the app.
+
+| Failure | Behavior |
+|---|---|
+| `tracker` or `coordinator` null in orchestrator ctor | `ArgumentNullException` — fail fast, wiring bug |
+| `BeginSessionRestore(session: null, ...)` | `ArgumentNullException` |
+| `BeginSessionRestore` with empty `session.Tabs` | propagates `ArgumentException` from `StartupRestorePlan.Create` (existing behavior) — caller is expected to call `CompleteWithoutRestore` instead |
+| `materializeImmediate` callback throws inside `BeginSessionRestore` | exception propagates; orchestrator state unchanged (phases NOT marked, `_pendingPlan` NOT set) so MainWindow's existing try/catch can call `CompleteWithoutRestore` to keep startup metrics complete |
+| `materializeTab` callback throws inside `DrainDeferred` | wrapped in `try/catch` per-tab; failing tab is logged via `TerminalLogger.Log`; remaining tabs still materialize; `BackgroundRestoreComplete` still marked |
+| `Mark` / `Checkpoint` called twice | silently no-op via underlying `TryMark` / `TryMarkCheckpoint` |
+| `DrainDeferred` with no pending plan | no-op |
+| `CompleteWithoutRestore` after `BeginSessionRestore` already marked phases | no-op (idempotent via tracker) |
+| `StartupMetricsWriter` failure | existing tracker behavior (silent retry on next mark) — orchestrator does not intercept |
+| App exits before `DrainDeferred` runs | pending plan dropped, snapshot not written for this launch (acceptable per design doc) |
+
+### Invariant enforced by the orchestrator
+
+> After `BeginSessionRestore` returns, exactly one of:
+> - `HasPendingDeferredRestore == true` and `BackgroundRestoreComplete` is **not** marked, or
+> - `HasPendingDeferredRestore == false` and `BackgroundRestoreComplete` **is** marked.
+
+This is the invariant today's duplicated MainWindow code can violate by
+accident in the "session exists but restore fails" path. Asserted by unit
+test.
+
+## Testing strategy
+
+All new tests in `tests/NovaTerminal.Tests/Core/`. The orchestrator is a pure
+C# class with no Avalonia dependency — tests run in xUnit, no headless
+bootstrap.
+
+### `StartupOrchestratorTests` (new file)
+
+Fixture: real `StartupPerformanceTracker` constructed via the existing
+internal test ctor for controllable time; `StartupRestoreCoordinator` with a
+capturing fake schedule (`Action<Action>` that stores the deferred action so
+the test can run it on demand). A small `IStartupLogProbe` (or
+`TerminalLogger` test seam, whichever is least invasive) captures any logged
+exceptions for assertion.
+
+| Test | Asserts |
+|---|---|
+| `Mark_DelegatesToTracker` | After `Mark(WindowOpened)`, `tracker.TryGetElapsedMilliseconds(WindowOpened, out _) == true` |
+| `Checkpoint_DelegatesToTracker` | After `Checkpoint("X")`, `tracker.CreateSnapshot().Checkpoints["X"]` has a value |
+| `BeginSessionRestore_WithDeferredTabs_CallsMaterializeImmediateOnce_AndStashesPlan` | 3-tab session, active=1 → callback invoked once with `OriginalIndex == 1`; `HasPendingDeferredRestore == true`; `SessionRestoreComplete` marked; `BackgroundRestoreComplete` NOT marked |
+| `BeginSessionRestore_WithSingleTab_MarksBothPhasesAndClearsPending` | 1-tab session → callback invoked once; `HasPendingDeferredRestore == false`; both phases marked |
+| `BeginSessionRestore_WhenMaterializeThrows_DoesNotMarkPhases` | callback throws → exception bubbles; `SessionRestoreCompleteMs == null`; `HasPendingDeferredRestore == false` |
+| `CompleteWithoutRestore_MarksBothPhases` | both `SessionRestoreCompleteMs` and `BackgroundRestoreCompleteMs` populated |
+| `CompleteWithoutRestore_IsIdempotent` | calling twice does not throw; snapshot stable |
+| `DrainDeferred_WithPendingPlan_RunsAllDeferredTabsInOriginalOrder_AndMarksBackground` | 3 deferred tabs at indices [0, 2, 3] → callback invoked 3× in that exact order; `BackgroundRestoreCompleteMs` populated; `HasPendingDeferredRestore == false` after |
+| `DrainDeferred_WithoutPendingPlan_IsNoOp` | fresh orchestrator → call does nothing; no phases marked |
+| `DrainDeferred_WhenOneTabThrows_StillCompletesAndMarksBackground` | middle tab throws → other two still materialize; `BackgroundRestoreComplete` still marked; exception captured by log probe |
+| `Invariant_AfterBeginSessionRestore_BackgroundCompleteImpliesNoPendingPlan` | across {1, 2, 5}-tab sessions, the Section "Invariant" property holds |
+
+### `AppServicesTests` (new file)
+
+| Test | Asserts |
+|---|---|
+| `Build_ReturnsBundleWithWiredOrchestrator` | `bundle.Startup` non-null; its `Mark` call advances the supplied tracker |
+| `BuildForDesigner_ReturnsBundleWithNoOpScheduler` | designer bundle's `DrainDeferred` runs synchronously (verified by callback ordering against a probe list) |
+
+### Existing tests — adjustment only
+
+| File | Change |
+|---|---|
+| `tests/NovaTerminal.Tests/Core/MainWindowStartupTests.cs` | introduce a small test helper `TestMainWindowFactory.Create()` that returns `new MainWindow(AppServices.BuildForDesigner())`; every fixture call site of `new MainWindow()` uses the helper. No assertion changes. The helper lives in `tests/NovaTerminal.Tests/Core/TestMainWindowFactory.cs` so future MainWindow ctor changes touch one file. |
+| `tests/NovaTerminal.Tests/Core/StartupRestoreCoordinatorTests.cs` | unchanged |
+| `tests/NovaTerminal.Tests/Core/StartupRestorePlanTests.cs` | unchanged |
+| `tests/NovaTerminal.Tests/Core/StartupPerformanceTrackerTests.cs` | unchanged |
+| `tests/NovaTerminal.Tests/Core/TerminalPaneStartupInstrumentationTests.cs` | unchanged (TerminalPane still uses the static) |
+| `tests/NovaTerminal.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs` | unchanged (no startup dependency) |
+
+### Verification — measurement gate
+
+Per PR #67's harness, before and after this PR:
+
+```powershell
+pwsh tests\tools\measure_startup.ps1 -Configuration Release -Label pre-orchestrator-extraction  -Iterations 10
+# merge PR
+pwsh tests\tools\measure_startup.ps1 -Configuration Release -Label post-orchestrator-extraction -Iterations 10
+pwsh tests\tools\summarize_startup_metrics.ps1 pre-orchestrator-extraction post-orchestrator-extraction
+```
+
+Acceptance: deltas on `Main Window Constructed`, `Window Opened`,
+`First Terminal Ready`, `Session Restore Complete` within ±2%. This is a
+pure refactor; larger swings either direction warrant investigation.
+
+## Alternatives considered
+
+### B — Direct ctor injection (no bundle)
+
+`MainWindow(StartupOrchestrator startup)`. Smaller today, but every future
+extraction widens the ctor signature and every test fixture pays the cost.
+Defeats the "open the door to a bigger refactor" goal. Rejected.
+
+### C — Microsoft.Extensions.DependencyInjection (manual-registration, AOT-safe)
+
+Industry-standard testability but requires a new NuGet dep (~1 MB to AOT
+bundle), introduces a culture change a single-window desktop app may not need,
+and carries ongoing AOT-corner-case vigilance (open generics, `IOptions<>`,
+scanning). The composition-root record satisfies the same testability needs at
+a fraction of the surface area. Rejected for this PR; revisit only if a
+genuine multi-scope lifetime need appears.
+
+### Wide orchestrator scope (`IStartupTracker` + `StartupCheckpoints`)
+
+Pulls TerminalPane and all magic-string checkpoints into the orchestration
+module. Larger PR, more files touched, no immediate behavior benefit. Deferred
+to a follow-up if/when TerminalPane is refactored to receive services
+explicitly.
+
+### Minimal "state holder" orchestrator
+
+Just exposes the tracker and coordinator as properties; MainWindow still
+drives every detail. Fails to consolidate the duplicated `CompleteWithoutRestore`
+path; barely reduces MainWindow's responsibility surface. Rejected.
+
+## Out of scope (named explicitly to prevent scope creep)
+
+- `IStartupTracker` interface
+- `StartupCheckpoints` string-constants module
+- TerminalPane settings threading (P4-#15)
+- Background Restore +5.71% regression recovery
+- DI container adoption
+- Any change to `NovaTerminal.VT`, `NovaTerminal.Rendering`,
+  `NovaTerminal.Replay`
+- Further MainWindow cluster extractions (`TabRuntimeRegistry`,
+  `PaneZoomController`, etc.) — those follow this pattern in separate PRs
+
+## Open questions
+
+None. All design decisions were resolved during brainstorming.

--- a/src/NovaTerminal.App/Core/AppJsonContext.cs
+++ b/src/NovaTerminal.App/Core/AppJsonContext.cs
@@ -3,6 +3,7 @@ using System;
 using System.Text.Json.Serialization;
 using NovaTerminal.Core;
 using NovaTerminal.CommandAssist.Models;
+using NovaTerminal.Core.Shortcuts;
 
 namespace NovaTerminal.Core
 {
@@ -17,6 +18,7 @@ namespace NovaTerminal.Core
     [JsonSerializable(typeof(List<CommandHistoryEntry>))]
     [JsonSerializable(typeof(List<CommandSnippet>))]
     [JsonSerializable(typeof(Dictionary<string, string>))]
+    [JsonSerializable(typeof(Dictionary<string, CommandPaletteUsageEntry>))]
     [JsonSerializable(typeof(WorkspacePolicyHooks))]
     [JsonSourceGenerationOptions(WriteIndented = true, Converters = new[] { typeof(JsonColorConverter), typeof(TermColorJsonConverter) })]
     public partial class AppJsonContext : JsonSerializerContext

--- a/src/NovaTerminal.App/Core/AppPaths.cs
+++ b/src/NovaTerminal.App/Core/AppPaths.cs
@@ -45,6 +45,7 @@ namespace NovaTerminal.Core
         public static string WorkspacePolicyFilePath => Path.Combine(PolicyDirectory, "workspace_policy.json");
         public static string WorkspaceAuditLogPath => Path.Combine(LogsDirectory, "workspace_audit.log");
         public static string RecordingsDirectory => Path.Combine(RootDirectory, "recordings");
+        public static string CommandPaletteUsageFilePath => Path.Combine(RootDirectory, "command-palette-usage.json");
         public static string CommandAssistDirectory => Path.Combine(RootDirectory, "command-assist");
         public static string CommandHistoryFilePath => Path.Combine(CommandAssistDirectory, "history.json");
         public static string CommandSnippetsFilePath => Path.Combine(CommandAssistDirectory, "snippets.json");

--- a/src/NovaTerminal.App/Core/CommandPaletteOrdering.cs
+++ b/src/NovaTerminal.App/Core/CommandPaletteOrdering.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NovaTerminal.Core.Shortcuts;
+
+namespace NovaTerminal.Core;
+
+public static class CommandPaletteOrdering
+{
+    public static IReadOnlyList<TerminalCommand> OrderForEmptyQuery(
+        IEnumerable<TerminalCommand> commands,
+        IReadOnlyDictionary<string, CommandPaletteUsageEntry> usage)
+    {
+        return OrderCommands(commands, usage);
+    }
+
+    public static IReadOnlyList<TerminalCommand> OrderSearchResults(
+        IEnumerable<TerminalCommand> commands,
+        IReadOnlyDictionary<string, CommandPaletteUsageEntry> usage)
+    {
+        return OrderCommands(commands, usage);
+    }
+
+    private static int GetUseCount(IReadOnlyDictionary<string, CommandPaletteUsageEntry> usage, string commandId)
+    {
+        return usage.TryGetValue(commandId, out CommandPaletteUsageEntry? entry) ? entry.UseCount : 0;
+    }
+
+    private static DateTimeOffset GetLastUsedAt(IReadOnlyDictionary<string, CommandPaletteUsageEntry> usage, string commandId)
+    {
+        return usage.TryGetValue(commandId, out CommandPaletteUsageEntry? entry)
+            ? entry.LastUsedAt
+            : DateTimeOffset.MinValue;
+    }
+
+    private static IReadOnlyList<TerminalCommand> OrderCommands(
+        IEnumerable<TerminalCommand> commands,
+        IReadOnlyDictionary<string, CommandPaletteUsageEntry> usage)
+    {
+        usage ??= new Dictionary<string, CommandPaletteUsageEntry>(StringComparer.OrdinalIgnoreCase);
+
+        return commands
+            .OrderByDescending(command => GetUseCount(usage, command.Id))
+            .ThenByDescending(command => GetLastUsedAt(usage, command.Id))
+            .ThenBy(command => command.Category, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(command => command.Title, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+}

--- a/src/NovaTerminal.App/Core/CommandRegistry.cs
+++ b/src/NovaTerminal.App/Core/CommandRegistry.cs
@@ -6,6 +6,7 @@ namespace NovaTerminal.Core
 {
     public class TerminalCommand
     {
+        public string Id { get; set; } = "";
         public string Title { get; set; } = "";
         public string Category { get; set; } = "General";
         public Action Action { get; set; } = () => { };
@@ -18,10 +19,11 @@ namespace NovaTerminal.Core
     {
         private static List<TerminalCommand> _commands = new();
 
-        public static void Register(string title, string category, Action action, string shortcut = "")
+        public static void Register(string title, string category, Action action, string shortcut = "", string id = "")
         {
             _commands.Add(new TerminalCommand
             {
+                Id = string.IsNullOrWhiteSpace(id) ? title : id,
                 Title = title,
                 Category = category,
                 Action = action,

--- a/src/NovaTerminal.App/Core/Shortcuts/CommandPaletteUsageEntry.cs
+++ b/src/NovaTerminal.App/Core/Shortcuts/CommandPaletteUsageEntry.cs
@@ -1,0 +1,5 @@
+using System;
+
+namespace NovaTerminal.Core.Shortcuts;
+
+public sealed record CommandPaletteUsageEntry(string CommandId, int UseCount, DateTimeOffset LastUsedAt);

--- a/src/NovaTerminal.App/Core/Shortcuts/CommandPaletteUsageStore.cs
+++ b/src/NovaTerminal.App/Core/Shortcuts/CommandPaletteUsageStore.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace NovaTerminal.Core.Shortcuts;
+
+public sealed class CommandPaletteUsageStore
+{
+    private readonly string _path;
+    private Dictionary<string, CommandPaletteUsageEntry>? _entries;
+
+    public CommandPaletteUsageStore(string path)
+    {
+        _path = path;
+    }
+
+    public IReadOnlyDictionary<string, CommandPaletteUsageEntry> Load()
+    {
+        if (_entries is not null)
+        {
+            return _entries;
+        }
+
+        if (!File.Exists(_path))
+        {
+            _entries = new Dictionary<string, CommandPaletteUsageEntry>(StringComparer.OrdinalIgnoreCase);
+            return _entries;
+        }
+
+        try
+        {
+            string json = File.ReadAllText(_path);
+            _entries = JsonSerializer.Deserialize(json, AppJsonContext.Default.DictionaryStringCommandPaletteUsageEntry)
+                ?? new Dictionary<string, CommandPaletteUsageEntry>(StringComparer.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            _entries = new Dictionary<string, CommandPaletteUsageEntry>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        return _entries;
+    }
+
+    public void RecordUse(string commandId, DateTimeOffset usedAt)
+    {
+        if (string.IsNullOrWhiteSpace(commandId))
+        {
+            throw new ArgumentException("Command id cannot be empty.", nameof(commandId));
+        }
+
+        Dictionary<string, CommandPaletteUsageEntry> entries = EnsureEntries();
+        if (entries.TryGetValue(commandId, out CommandPaletteUsageEntry? entry))
+        {
+            entries[commandId] = entry with
+            {
+                UseCount = entry.UseCount + 1,
+                LastUsedAt = usedAt,
+            };
+            return;
+        }
+
+        entries[commandId] = new CommandPaletteUsageEntry(commandId, 1, usedAt);
+    }
+
+    public void Save()
+    {
+        Dictionary<string, CommandPaletteUsageEntry> entries = EnsureEntries();
+        string? directory = Path.GetDirectoryName(_path);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        string json = JsonSerializer.Serialize(entries, AppJsonContext.Default.DictionaryStringCommandPaletteUsageEntry);
+        File.WriteAllText(_path, json);
+    }
+
+    private Dictionary<string, CommandPaletteUsageEntry> EnsureEntries()
+    {
+        if (_entries is null)
+        {
+            _entries = new Dictionary<string, CommandPaletteUsageEntry>(Load(), StringComparer.OrdinalIgnoreCase);
+        }
+
+        return _entries;
+    }
+}

--- a/src/NovaTerminal.App/Core/Shortcuts/CommandPaletteUsageStore.cs
+++ b/src/NovaTerminal.App/Core/Shortcuts/CommandPaletteUsageStore.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace NovaTerminal.Core.Shortcuts;
 
@@ -9,6 +11,7 @@ public sealed class CommandPaletteUsageStore
 {
     private readonly string _path;
     private Dictionary<string, CommandPaletteUsageEntry>? _entries;
+    private int _saveVersion;
 
     public CommandPaletteUsageStore(string path)
     {
@@ -31,8 +34,12 @@ public sealed class CommandPaletteUsageStore
         try
         {
             string json = File.ReadAllText(_path);
-            _entries = JsonSerializer.Deserialize(json, AppJsonContext.Default.DictionaryStringCommandPaletteUsageEntry)
-                ?? new Dictionary<string, CommandPaletteUsageEntry>(StringComparer.OrdinalIgnoreCase);
+            Dictionary<string, CommandPaletteUsageEntry>? deserialized = JsonSerializer.Deserialize(
+                json,
+                AppJsonContext.Default.DictionaryStringCommandPaletteUsageEntry);
+            _entries = deserialized is not null
+                ? new Dictionary<string, CommandPaletteUsageEntry>(deserialized, StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, CommandPaletteUsageEntry>(StringComparer.OrdinalIgnoreCase);
         }
         catch
         {
@@ -66,14 +73,33 @@ public sealed class CommandPaletteUsageStore
     public void Save()
     {
         Dictionary<string, CommandPaletteUsageEntry> entries = EnsureEntries();
+        Dictionary<string, CommandPaletteUsageEntry> snapshot = new(entries, StringComparer.OrdinalIgnoreCase);
+        string json = JsonSerializer.Serialize(snapshot, AppJsonContext.Default.DictionaryStringCommandPaletteUsageEntry);
+        string path = _path;
         string? directory = Path.GetDirectoryName(_path);
-        if (!string.IsNullOrWhiteSpace(directory))
-        {
-            Directory.CreateDirectory(directory);
-        }
+        int version = Interlocked.Increment(ref _saveVersion);
 
-        string json = JsonSerializer.Serialize(entries, AppJsonContext.Default.DictionaryStringCommandPaletteUsageEntry);
-        File.WriteAllText(_path, json);
+        _ = Task.Run(() =>
+        {
+            if (version != Volatile.Read(ref _saveVersion))
+            {
+                return;
+            }
+
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+
+                File.WriteAllText(path, json);
+            }
+            catch
+            {
+                // Keep usage tracking best-effort only.
+            }
+        });
     }
 
     private Dictionary<string, CommandPaletteUsageEntry> EnsureEntries()

--- a/src/NovaTerminal.App/Core/Shortcuts/ShortcutBindingRecord.cs
+++ b/src/NovaTerminal.App/Core/Shortcuts/ShortcutBindingRecord.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace NovaTerminal.Core.Shortcuts;
+
+public sealed record ShortcutBindingRecord
+{
+    public ShortcutBindingRecord(string commandId, ShortcutScope scope, string binding)
+    {
+        if (string.IsNullOrWhiteSpace(commandId))
+        {
+            throw new ArgumentException("Command id cannot be empty.", nameof(commandId));
+        }
+
+        if (string.IsNullOrWhiteSpace(binding))
+        {
+            throw new ArgumentException("Binding cannot be empty.", nameof(binding));
+        }
+
+        CommandId = commandId;
+        Scope = scope;
+        Binding = binding;
+    }
+
+    public string CommandId { get; }
+
+    public ShortcutScope Scope { get; }
+
+    public string Binding { get; }
+}

--- a/src/NovaTerminal.App/Core/Shortcuts/ShortcutBindingResolver.cs
+++ b/src/NovaTerminal.App/Core/Shortcuts/ShortcutBindingResolver.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NovaTerminal.Core.Shortcuts;
+
+public static class ShortcutBindingResolver
+{
+    public static ShortcutBindingResolution Resolve(
+        IReadOnlyCollection<ShortcutDefinition> definitions,
+        IReadOnlyDictionary<string, string>? overrides)
+    {
+        ArgumentNullException.ThrowIfNull(definitions);
+
+        List<ShortcutBindingRecord> bindings = new(definitions.Count);
+        foreach (ShortcutDefinition definition in definitions)
+        {
+            ArgumentNullException.ThrowIfNull(definition);
+
+            string binding = definition.DefaultBinding;
+            if (overrides is not null &&
+                overrides.TryGetValue(definition.CommandId, out string? overrideBinding) &&
+                !string.IsNullOrWhiteSpace(overrideBinding))
+            {
+                binding = overrideBinding;
+            }
+
+            bindings.Add(new ShortcutBindingRecord(
+                definition.CommandId,
+                definition.Scope,
+                ShortcutNormalizer.Normalize(binding)));
+        }
+
+        List<ShortcutBindingConflict> conflicts = bindings
+            .GroupBy(binding => binding.Binding, StringComparer.OrdinalIgnoreCase)
+            .Where(group => group.Count() > 1)
+            .Select(group => new ShortcutBindingConflict(group.Key, group.ToArray()))
+            .ToList();
+
+        return new ShortcutBindingResolution(bindings, conflicts);
+    }
+}
+
+public sealed record ShortcutBindingResolution(
+    IReadOnlyList<ShortcutBindingRecord> Bindings,
+    IReadOnlyList<ShortcutBindingConflict> Conflicts)
+{
+    public bool IsValid => Conflicts.Count == 0;
+}
+
+public sealed record ShortcutBindingConflict(
+    string NormalizedBinding,
+    IReadOnlyList<ShortcutBindingRecord> Bindings);

--- a/src/NovaTerminal.App/Core/Shortcuts/ShortcutBindingResolver.cs
+++ b/src/NovaTerminal.App/Core/Shortcuts/ShortcutBindingResolver.cs
@@ -25,10 +25,20 @@ public static class ShortcutBindingResolver
                 binding = overrideBinding;
             }
 
+            string normalizedBinding;
+            try
+            {
+                normalizedBinding = ShortcutNormalizer.Normalize(binding);
+            }
+            catch (ArgumentException) when (!string.Equals(binding, definition.DefaultBinding, StringComparison.Ordinal))
+            {
+                normalizedBinding = ShortcutNormalizer.Normalize(definition.DefaultBinding);
+            }
+
             bindings.Add(new ShortcutBindingRecord(
                 definition.CommandId,
                 definition.Scope,
-                ShortcutNormalizer.Normalize(binding)));
+                normalizedBinding));
         }
 
         List<ShortcutBindingConflict> conflicts = bindings

--- a/src/NovaTerminal.App/Core/Shortcuts/ShortcutCatalog.cs
+++ b/src/NovaTerminal.App/Core/Shortcuts/ShortcutCatalog.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NovaTerminal.Core.Shortcuts;
+
+public static class ShortcutCatalog
+{
+    private static readonly IReadOnlyList<ShortcutCatalogEntry> Entries =
+    [
+        new("command_palette", "Command Palette", "General", ShortcutScope.App, "Ctrl+Shift+P"),
+        new("settings", "Settings", "General", ShortcutScope.App, "Ctrl+,"),
+        new("new_tab", "New Tab", "General", ShortcutScope.App, "Ctrl+Shift+T"),
+        new("close_tab", "Close Tab", "General", ShortcutScope.App, "Ctrl+W"),
+        new("next_tab", "Tab: Next (MRU)", "General", ShortcutScope.App, "Ctrl+Tab"),
+        new("prev_tab", "Tab: Previous (MRU)", "General", ShortcutScope.App, "Ctrl+Shift+Tab"),
+        new("open_tab_list", "Tab: Open Tab List", "General", ShortcutScope.App, "Ctrl+Shift+O"),
+        new("font_increase", "Font: Increase", "View", ShortcutScope.App, "Ctrl+OemPlus"),
+        new("font_increase_alt", "Font: Increase (Alt)", "View", ShortcutScope.App, "Ctrl+Add"),
+        new("font_decrease", "Font: Decrease", "View", ShortcutScope.App, "Ctrl+OemMinus"),
+        new("font_decrease_alt", "Font: Decrease (Alt)", "View", ShortcutScope.App, "Ctrl+Subtract"),
+        new("split_vertical", "Split Vertical", "View", ShortcutScope.Pane, "Ctrl+Shift+D"),
+        new("split_horizontal", "Split Horizontal", "View", ShortcutScope.Pane, "Ctrl+Shift+E"),
+        new("equalize_panes", "Equalize Panes", "View", ShortcutScope.Pane, "Ctrl+Shift+G"),
+        new("toggle_pane_zoom", "Pane: Toggle Zoom", "View", ShortcutScope.Pane, "Ctrl+Shift+Z"),
+        new("toggle_broadcast_input", "Pane: Toggle Broadcast Input (Tab)", "View", ShortcutScope.Pane, "Ctrl+Shift+B"),
+        new("find", "Find in Terminal", "Edit", ShortcutScope.Pane, "Ctrl+F"),
+        new("find_alt", "Find in Terminal (Alt)", "Edit", ShortcutScope.Pane, "Ctrl+Shift+F"),
+        new("close_pane", "Close Pane", "General", ShortcutScope.Pane, "Ctrl+Shift+W"),
+        new("paste", "Paste", "Edit", ShortcutScope.Pane, "Ctrl+V"),
+        new("command_assist_toggle", "Command Assist Toggle", "Command Assist", ShortcutScope.CommandAssist, "Ctrl+Space"),
+        new("command_assist_help", "Command Assist Help", "Command Assist", ShortcutScope.CommandAssist, "Ctrl+Shift+H"),
+        new("command_assist_history", "Command Assist History", "Command Assist", ShortcutScope.CommandAssist, "Ctrl+R"),
+    ];
+
+    public static IReadOnlyList<ShortcutDefinition> GetDefinitions()
+    {
+        return Entries
+            .Select(entry => new ShortcutDefinition(entry.CommandId, entry.Scope, entry.DefaultBinding))
+            .ToArray();
+    }
+
+    public static IReadOnlyList<ShortcutCatalogEntry> GetEntries()
+    {
+        return Entries;
+    }
+}

--- a/src/NovaTerminal.App/Core/Shortcuts/ShortcutCatalogEntry.cs
+++ b/src/NovaTerminal.App/Core/Shortcuts/ShortcutCatalogEntry.cs
@@ -1,0 +1,8 @@
+namespace NovaTerminal.Core.Shortcuts;
+
+public sealed record ShortcutCatalogEntry(
+    string CommandId,
+    string Title,
+    string Category,
+    ShortcutScope Scope,
+    string DefaultBinding);

--- a/src/NovaTerminal.App/Core/Shortcuts/ShortcutDefinition.cs
+++ b/src/NovaTerminal.App/Core/Shortcuts/ShortcutDefinition.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace NovaTerminal.Core.Shortcuts;
+
+public sealed record ShortcutDefinition
+{
+    public ShortcutDefinition(string commandId, ShortcutScope scope, string defaultBinding)
+    {
+        if (string.IsNullOrWhiteSpace(commandId))
+        {
+            throw new ArgumentException("Command id cannot be empty.", nameof(commandId));
+        }
+
+        if (string.IsNullOrWhiteSpace(defaultBinding))
+        {
+            throw new ArgumentException("Default binding cannot be empty.", nameof(defaultBinding));
+        }
+
+        CommandId = commandId;
+        Scope = scope;
+        DefaultBinding = defaultBinding;
+    }
+
+    public string CommandId { get; }
+
+    public ShortcutScope Scope { get; }
+
+    public string DefaultBinding { get; }
+}

--- a/src/NovaTerminal.App/Core/Shortcuts/ShortcutMatcher.cs
+++ b/src/NovaTerminal.App/Core/Shortcuts/ShortcutMatcher.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Avalonia.Input;
 
@@ -6,6 +7,8 @@ namespace NovaTerminal.Core.Shortcuts;
 
 public static class ShortcutMatcher
 {
+    private static readonly ConcurrentDictionary<string, ParsedShortcut?> ParsedShortcutCache = new(StringComparer.OrdinalIgnoreCase);
+
     public static string Normalize(KeyEventArgs e)
     {
         return NormalizeEvent(e);
@@ -18,16 +21,53 @@ public static class ShortcutMatcher
             return false;
         }
 
+        ParsedShortcut? parsed = ParsedShortcutCache.GetOrAdd(shortcut, ParseShortcut);
+        if (parsed is not ParsedShortcut expected)
+        {
+            return false;
+        }
+
+        KeyModifiers modifiers = e.KeyModifiers & (KeyModifiers.Control | KeyModifiers.Alt | KeyModifiers.Shift);
+        return e.Key == expected.Key && modifiers == expected.Modifiers;
+    }
+
+    private static ParsedShortcut? ParseShortcut(string shortcut)
+    {
         try
         {
-            return string.Equals(
-                ShortcutNormalizer.Normalize(shortcut),
-                NormalizeEvent(e),
-                StringComparison.Ordinal);
+            string normalized = ShortcutNormalizer.Normalize(shortcut);
+            string[] tokens = normalized.Split('+', StringSplitOptions.RemoveEmptyEntries);
+            KeyModifiers modifiers = KeyModifiers.None;
+            Key key = Key.None;
+
+            foreach (string token in tokens)
+            {
+                switch (token)
+                {
+                    case "Ctrl":
+                        modifiers |= KeyModifiers.Control;
+                        break;
+                    case "Alt":
+                        modifiers |= KeyModifiers.Alt;
+                        break;
+                    case "Shift":
+                        modifiers |= KeyModifiers.Shift;
+                        break;
+                    default:
+                        if (!TryParseKey(token, out key))
+                        {
+                            return null;
+                        }
+
+                        break;
+                }
+            }
+
+            return key == Key.None ? null : new ParsedShortcut(modifiers, key);
         }
         catch (ArgumentException)
         {
-            return false;
+            return null;
         }
     }
 
@@ -67,4 +107,36 @@ public static class ShortcutMatcher
             _ => key.ToString(),
         };
     }
+
+    private static bool TryParseKey(string token, out Key key)
+    {
+        switch (token)
+        {
+            case ",":
+                key = Key.OemComma;
+                return true;
+            case "OemPlus":
+                key = Key.OemPlus;
+                return true;
+            case "OemMinus":
+                key = Key.OemMinus;
+                return true;
+            case "Space":
+                key = Key.Space;
+                return true;
+            case "Tab":
+                key = Key.Tab;
+                return true;
+        }
+
+        if (token.Length == 1 && char.IsDigit(token[0]))
+        {
+            key = Key.D0 + (token[0] - '0');
+            return true;
+        }
+
+        return Enum.TryParse(token, out key);
+    }
+
+    private readonly record struct ParsedShortcut(KeyModifiers Modifiers, Key Key);
 }

--- a/src/NovaTerminal.App/Core/Shortcuts/ShortcutMatcher.cs
+++ b/src/NovaTerminal.App/Core/Shortcuts/ShortcutMatcher.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Input;
+
+namespace NovaTerminal.Core.Shortcuts;
+
+public static class ShortcutMatcher
+{
+    public static string Normalize(KeyEventArgs e)
+    {
+        return NormalizeEvent(e);
+    }
+
+    public static bool Matches(KeyEventArgs e, string shortcut)
+    {
+        if (string.IsNullOrWhiteSpace(shortcut))
+        {
+            return false;
+        }
+
+        try
+        {
+            return string.Equals(
+                ShortcutNormalizer.Normalize(shortcut),
+                NormalizeEvent(e),
+                StringComparison.Ordinal);
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    private static string NormalizeEvent(KeyEventArgs e)
+    {
+        List<string> tokens = [];
+        if ((e.KeyModifiers & KeyModifiers.Control) != 0)
+        {
+            tokens.Add("Ctrl");
+        }
+
+        if ((e.KeyModifiers & KeyModifiers.Alt) != 0)
+        {
+            tokens.Add("Alt");
+        }
+
+        if ((e.KeyModifiers & KeyModifiers.Shift) != 0)
+        {
+            tokens.Add("Shift");
+        }
+
+        tokens.Add(NormalizeKey(e.Key));
+        return string.Join("+", tokens);
+    }
+
+    private static string NormalizeKey(Key key)
+    {
+        return key switch
+        {
+            Key.OemComma => ",",
+            Key.OemPlus => "OemPlus",
+            Key.OemMinus => "OemMinus",
+            Key.Space => "Space",
+            Key.Tab => "Tab",
+            >= Key.A and <= Key.Z => key.ToString(),
+            >= Key.D0 and <= Key.D9 => key.ToString()[1..],
+            _ => key.ToString(),
+        };
+    }
+}

--- a/src/NovaTerminal.App/Core/Shortcuts/ShortcutNormalizer.cs
+++ b/src/NovaTerminal.App/Core/Shortcuts/ShortcutNormalizer.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Input;
+
+namespace NovaTerminal.Core.Shortcuts;
+
+public static class ShortcutNormalizer
+{
+    public static string Normalize(string shortcut)
+    {
+        if (string.IsNullOrWhiteSpace(shortcut))
+        {
+            throw new ArgumentException("Shortcut binding cannot be empty.", nameof(shortcut));
+        }
+
+        shortcut = RewriteTrailingSymbolShortcut(shortcut.Trim());
+
+        bool hasCtrl = false;
+        bool hasAlt = false;
+        bool hasShift = false;
+        string? key = null;
+
+        foreach (string rawToken in shortcut.Split('+', StringSplitOptions.TrimEntries))
+        {
+            if (string.IsNullOrWhiteSpace(rawToken))
+            {
+                throw new ArgumentException($"Shortcut '{shortcut}' contains malformed separators.", nameof(shortcut));
+            }
+
+            string token = rawToken.Trim();
+            if (token.Equals("ctrl", StringComparison.OrdinalIgnoreCase) ||
+                token.Equals("control", StringComparison.OrdinalIgnoreCase))
+            {
+                if (hasCtrl)
+                {
+                    throw new ArgumentException($"Shortcut '{shortcut}' repeats the Ctrl modifier.", nameof(shortcut));
+                }
+
+                hasCtrl = true;
+                continue;
+            }
+
+            if (token.Equals("alt", StringComparison.OrdinalIgnoreCase))
+            {
+                if (hasAlt)
+                {
+                    throw new ArgumentException($"Shortcut '{shortcut}' repeats the Alt modifier.", nameof(shortcut));
+                }
+
+                hasAlt = true;
+                continue;
+            }
+
+            if (token.Equals("shift", StringComparison.OrdinalIgnoreCase))
+            {
+                if (hasShift)
+                {
+                    throw new ArgumentException($"Shortcut '{shortcut}' repeats the Shift modifier.", nameof(shortcut));
+                }
+
+                hasShift = true;
+                continue;
+            }
+
+            if (key is not null)
+            {
+                throw new ArgumentException($"Shortcut '{shortcut}' contains more than one key token.", nameof(shortcut));
+            }
+
+            key = NormalizeKeyToken(shortcut, token);
+        }
+
+        if (key is null)
+        {
+            throw new ArgumentException($"Shortcut '{shortcut}' must include a key token.", nameof(shortcut));
+        }
+
+        List<string> normalized = [];
+        if (hasCtrl)
+        {
+            normalized.Add("Ctrl");
+        }
+
+        if (hasAlt)
+        {
+            normalized.Add("Alt");
+        }
+
+        if (hasShift)
+        {
+            normalized.Add("Shift");
+        }
+
+        normalized.Add(key);
+        return string.Join("+", normalized);
+    }
+
+    private static string RewriteTrailingSymbolShortcut(string shortcut)
+    {
+        if (shortcut.EndsWith("++", StringComparison.Ordinal))
+        {
+            return shortcut[..^1] + "Plus";
+        }
+
+        if (shortcut.EndsWith("+-", StringComparison.Ordinal))
+        {
+            return shortcut[..^1] + "Minus";
+        }
+
+        return shortcut;
+    }
+
+    private static string NormalizeKeyToken(string shortcut, string token)
+    {
+        return token.ToLowerInvariant() switch
+        {
+            "comma" => ",",
+            "oemcomma" => ",",
+            "," => ",",
+            "oemplus" => "OemPlus",
+            "plus" => "OemPlus",
+            "-" => "OemMinus",
+            "oemminus" => "OemMinus",
+            "minus" => "OemMinus",
+            "space" => "Space",
+            "tab" => "Tab",
+            _ => NormalizeKnownKeyToken(shortcut, token),
+        };
+    }
+
+    private static string NormalizeKnownKeyToken(string shortcut, string token)
+    {
+        if (token.Length == 1)
+        {
+            char character = token[0];
+            if (char.IsLetter(character))
+            {
+                return char.ToUpperInvariant(character).ToString();
+            }
+
+            if (char.IsDigit(character))
+            {
+                return character.ToString();
+            }
+        }
+
+        if (Enum.TryParse<Key>(token, ignoreCase: true, out Key parsedKey))
+        {
+            return parsedKey.ToString();
+        }
+
+        throw new ArgumentException($"Shortcut '{shortcut}' uses unsupported key token '{token}'.", nameof(shortcut));
+    }
+}

--- a/src/NovaTerminal.App/Core/Shortcuts/ShortcutScope.cs
+++ b/src/NovaTerminal.App/Core/Shortcuts/ShortcutScope.cs
@@ -1,0 +1,8 @@
+namespace NovaTerminal.Core.Shortcuts;
+
+public enum ShortcutScope
+{
+    App,
+    Pane,
+    CommandAssist,
+}

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -217,15 +217,8 @@ namespace NovaTerminal
             return fallback;
         }
 
-        internal static bool TryHandleCommandAssistHelpShortcut(TerminalPane? pane, Key key, KeyModifiers modifiers)
+        internal static bool TryOpenCommandAssistHelp(TerminalPane? pane)
         {
-            bool isCtrl = (modifiers & KeyModifiers.Control) != 0;
-            bool isShift = (modifiers & KeyModifiers.Shift) != 0;
-            if (!isCtrl || !isShift || key != Key.H)
-            {
-                return false;
-            }
-
             return pane?.OpenCommandAssistHelp() == true;
         }
 
@@ -2163,11 +2156,14 @@ namespace NovaTerminal
                     return;
                 }
 
-                if (TryHandleCommandAssistHelpShortcut(_currentPane, e.Key, modifiers))
+                if (IsShortcut(e, "command_assist_help", "Ctrl+Shift+H"))
                 {
-                    RecordCommandUsage("command_assist_help");
-                    e.Handled = true;
-                    return;
+                    if (TryOpenCommandAssistHelp(_currentPane))
+                    {
+                        RecordCommandUsage("command_assist_help");
+                        e.Handled = true;
+                        return;
+                    }
                 }
 
                 if (IsShortcut(e, "command_assist_history", "Ctrl+R"))

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -25,6 +25,7 @@ using SkiaSharp;
 using NovaTerminal.Controls;
 using NovaTerminal.Services.Ssh;
 using NovaTerminal.Core.Ssh.Launch;
+using NovaTerminal.Core.Shortcuts;
 using NovaTerminal.Models;
 using NovaTerminal.ViewModels.Ssh;
 using NovaTerminal.Views.Ssh;
@@ -86,6 +87,8 @@ namespace NovaTerminal
         private TransferCenter? _transferCenterControl;
         private readonly StartupRestoreCoordinator _startupRestoreCoordinator;
         private StartupRestorePlan? _pendingStartupRestorePlan;
+        private readonly CommandPaletteUsageStore _commandPaletteUsageStore;
+        private Dictionary<string, CommandPaletteUsageEntry> _commandPaletteUsage = new(StringComparer.OrdinalIgnoreCase);
 
         private sealed class PaneZoomState
         {
@@ -199,67 +202,19 @@ namespace NovaTerminal
 
         private bool IsShortcut(KeyEventArgs e, string id, string fallback)
         {
-            string binding = fallback;
+            return ShortcutMatcher.Matches(e, GetEffectiveShortcutBinding(id, fallback));
+        }
+
+        private string GetEffectiveShortcutBinding(string id, string fallback)
+        {
             if (_settings.Keybindings != null &&
                 _settings.Keybindings.TryGetValue(id, out var custom) &&
                 !string.IsNullOrWhiteSpace(custom))
             {
-                binding = custom;
+                return custom;
             }
 
-            return ShortcutMatches(e, binding);
-        }
-
-        private static bool ShortcutMatches(KeyEventArgs e, string shortcut)
-        {
-            if (string.IsNullOrWhiteSpace(shortcut)) return false;
-
-            bool wantCtrl = false;
-            bool wantShift = false;
-            bool wantAlt = false;
-            Key? wantKey = null;
-
-            foreach (var raw in shortcut.Split('+', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-            {
-                string token = raw.Trim();
-                if (token.Equals("Ctrl", StringComparison.OrdinalIgnoreCase) || token.Equals("Control", StringComparison.OrdinalIgnoreCase))
-                {
-                    wantCtrl = true;
-                    continue;
-                }
-                if (token.Equals("Shift", StringComparison.OrdinalIgnoreCase))
-                {
-                    wantShift = true;
-                    continue;
-                }
-                if (token.Equals("Alt", StringComparison.OrdinalIgnoreCase))
-                {
-                    wantAlt = true;
-                    continue;
-                }
-
-                wantKey = token.ToLowerInvariant() switch
-                {
-                    "+" => Key.OemPlus,
-                    "-" => Key.OemMinus,
-                    "plus" => Key.OemPlus,
-                    "minus" => Key.OemMinus,
-                    "tab" => Key.Tab,
-                    "space" => Key.Space,
-                    _ => Enum.TryParse<Key>(token, true, out var parsed) ? parsed : null
-                };
-            }
-
-            if (wantKey == null) return false;
-
-            bool hasCtrl = (e.KeyModifiers & KeyModifiers.Control) != 0;
-            bool hasShift = (e.KeyModifiers & KeyModifiers.Shift) != 0;
-            bool hasAlt = (e.KeyModifiers & KeyModifiers.Alt) != 0;
-
-            return hasCtrl == wantCtrl &&
-                   hasShift == wantShift &&
-                   hasAlt == wantAlt &&
-                   e.Key == wantKey.Value;
+            return fallback;
         }
 
         internal static bool TryHandleCommandAssistHelpShortcut(TerminalPane? pane, Key key, KeyModifiers modifiers)
@@ -1967,6 +1922,8 @@ namespace NovaTerminal
             StartupPerformanceTracker.Current?.TryMarkCheckpoint("MainWindow.AfterInitializeComponent");
             _settings = TerminalSettings.Load();
             StartupPerformanceTracker.Current?.TryMarkCheckpoint("MainWindow.AfterSettingsLoad");
+            _commandPaletteUsageStore = new CommandPaletteUsageStore(AppPaths.CommandPaletteUsageFilePath);
+            _commandPaletteUsage = new Dictionary<string, CommandPaletteUsageEntry>(_commandPaletteUsageStore.Load(), StringComparer.OrdinalIgnoreCase);
             _sshConnectionService = new SshConnectionService();
             _sshInteractionService = new SshInteractionService(() => this, ApplyThemeToDialogWindow);
             _sshLegacyMigrationService = new SshLegacyProfileMigrationService();
@@ -2200,6 +2157,7 @@ namespace NovaTerminal
 
                 if (IsShortcut(e, "command_assist_toggle", "Ctrl+Space"))
                 {
+                    RecordCommandUsage("command_assist_toggle");
                     _currentPane?.ToggleCommandAssist();
                     e.Handled = true;
                     return;
@@ -2207,6 +2165,7 @@ namespace NovaTerminal
 
                 if (TryHandleCommandAssistHelpShortcut(_currentPane, e.Key, modifiers))
                 {
+                    RecordCommandUsage("command_assist_help");
                     e.Handled = true;
                     return;
                 }
@@ -2215,13 +2174,23 @@ namespace NovaTerminal
                 {
                     if (_currentPane?.OpenCommandAssistHistorySearch() == true)
                     {
+                        RecordCommandUsage("command_assist_history");
                         e.Handled = true;
                         return;
                     }
                 }
 
+                if (IsShortcut(e, "settings", "Ctrl+,"))
+                {
+                    RecordCommandUsage("settings");
+                    _ = OpenSettings(0);
+                    e.Handled = true;
+                    return;
+                }
+
                 if (IsShortcut(e, "font_increase", "Ctrl+OemPlus") || IsShortcut(e, "font_increase_alt", "Ctrl+Add"))
                 {
+                    RecordCommandUsage("font_increase");
                     _settings.FontSize++;
                     ApplySettingsToAllTabs();
                     _settings.Save();
@@ -2230,6 +2199,7 @@ namespace NovaTerminal
                 }
                 if (IsShortcut(e, "font_decrease", "Ctrl+OemMinus") || IsShortcut(e, "font_decrease_alt", "Ctrl+Subtract"))
                 {
+                    RecordCommandUsage("font_decrease");
                     _settings.FontSize = Math.Max(6, _settings.FontSize - 1);
                     ApplySettingsToAllTabs();
                     _settings.Save();
@@ -2238,30 +2208,35 @@ namespace NovaTerminal
                 }
                 if (IsShortcut(e, "new_tab", "Ctrl+Shift+T"))
                 {
+                    RecordCommandUsage("new_tab");
                     AddTab();
                     e.Handled = true;
                     return;
                 }
                 if (IsShortcut(e, "close_tab", "Ctrl+W"))
                 {
+                    RecordCommandUsage("close_tab");
                     _ = CloseSelectedTabAsync();
                     e.Handled = true;
                     return;
                 }
                 if (IsShortcut(e, "close_pane", "Ctrl+Shift+W"))
                 {
+                    RecordCommandUsage("close_pane");
                     CloseActivePane();
                     e.Handled = true;
                     return;
                 }
                 if (IsShortcut(e, "find", "Ctrl+F") || IsShortcut(e, "find_alt", "Ctrl+Shift+F"))
                 {
+                    RecordCommandUsage("find");
                     _currentPane?.ToggleSearch();
                     e.Handled = true;
                     return;
                 }
                 if (IsShortcut(e, "split_vertical", "Ctrl+Shift+D"))
                 {
+                    RecordCommandUsage("split_vertical");
                     // "Split Vertical" means a vertical divider (side-by-side panes).
                     SplitPane(Avalonia.Layout.Orientation.Horizontal);
                     e.Handled = true;
@@ -2269,6 +2244,7 @@ namespace NovaTerminal
                 }
                 if (IsShortcut(e, "split_horizontal", "Ctrl+Shift+E"))
                 {
+                    RecordCommandUsage("split_horizontal");
                     // "Split Horizontal" means a horizontal divider (stacked panes).
                     SplitPane(Avalonia.Layout.Orientation.Vertical);
                     e.Handled = true;
@@ -2276,18 +2252,21 @@ namespace NovaTerminal
                 }
                 if (IsShortcut(e, "equalize_panes", "Ctrl+Shift+G"))
                 {
+                    RecordCommandUsage("equalize_panes");
                     EqualizeCurrentSplit();
                     e.Handled = true;
                     return;
                 }
                 if (IsShortcut(e, "toggle_pane_zoom", "Ctrl+Shift+Z"))
                 {
+                    RecordCommandUsage("toggle_pane_zoom");
                     TogglePaneZoomForCurrentTab();
                     e.Handled = true;
                     return;
                 }
                 if (IsShortcut(e, "toggle_broadcast_input", "Ctrl+Shift+B"))
                 {
+                    RecordCommandUsage("toggle_broadcast_input");
                     ToggleBroadcastForCurrentTab();
                     e.Handled = true;
                     return;
@@ -2296,6 +2275,7 @@ namespace NovaTerminal
                 bool prevTabShortcut = IsShortcut(e, "prev_tab", "Ctrl+Shift+Tab");
                 if (nextTabShortcut || prevTabShortcut)
                 {
+                    RecordCommandUsage(prevTabShortcut ? "prev_tab" : "next_tab");
                     bool switched = SwitchTabByMru(reverse: prevTabShortcut);
                     if (switched)
                     {
@@ -2305,12 +2285,14 @@ namespace NovaTerminal
                 }
                 if (IsShortcut(e, "open_tab_list", "Ctrl+Shift+O"))
                 {
+                    RecordCommandUsage("open_tab_list");
                     PopulateTabListMenu(showFlyout: true);
                     e.Handled = true;
                     return;
                 }
                 if (IsShortcut(e, "paste", "Ctrl+V"))
                 {
+                    RecordCommandUsage("paste");
                     _ = PasteFromClipboardAsync();
                     e.Handled = true;
                     return;
@@ -3876,7 +3858,7 @@ namespace NovaTerminal
             CommandRegistry.Clear();
 
             // 1. Register Default Commands
-            CommandRegistry.Register("New Tab", "General", () => AddTab(), "Ctrl+Shift+T");
+            CommandRegistry.Register("New Tab", "General", () => AddTab(), GetEffectiveShortcutBinding("new_tab", "Ctrl+Shift+T"), "new_tab");
 
             // Dynamic Profile Tabs
             if (_settings.Profiles != null)
@@ -3940,11 +3922,11 @@ namespace NovaTerminal
                 CommandRegistry.Register($"Workspace Template: Apply {capturedTemplate}", "Workspace", () => ApplyWorkspaceTemplateByName(capturedTemplate), "");
             }
 
-            CommandRegistry.Register("Close Tab", "General", () => CloseActiveTab(), "Ctrl+W");
-            CommandRegistry.Register("Close Pane", "General", () => CloseActivePane(), "Ctrl+Shift+W");
-            CommandRegistry.Register("Tab: Next (MRU)", "General", () => SwitchTabByMru(reverse: false), "Ctrl+Tab");
-            CommandRegistry.Register("Tab: Previous (MRU)", "General", () => SwitchTabByMru(reverse: true), "Ctrl+Shift+Tab");
-            CommandRegistry.Register("Tab: Open Tab List", "General", () => PopulateTabListMenu(showFlyout: true), "Ctrl+Shift+O");
+            CommandRegistry.Register("Close Tab", "General", () => CloseActiveTab(), GetEffectiveShortcutBinding("close_tab", "Ctrl+W"), "close_tab");
+            CommandRegistry.Register("Close Pane", "General", () => CloseActivePane(), GetEffectiveShortcutBinding("close_pane", "Ctrl+Shift+W"), "close_pane");
+            CommandRegistry.Register("Tab: Next (MRU)", "General", () => SwitchTabByMru(reverse: false), GetEffectiveShortcutBinding("next_tab", "Ctrl+Tab"), "next_tab");
+            CommandRegistry.Register("Tab: Previous (MRU)", "General", () => SwitchTabByMru(reverse: true), GetEffectiveShortcutBinding("prev_tab", "Ctrl+Shift+Tab"), "prev_tab");
+            CommandRegistry.Register("Tab: Open Tab List", "General", () => PopulateTabListMenu(showFlyout: true), GetEffectiveShortcutBinding("open_tab_list", "Ctrl+Shift+O"), "open_tab_list");
             CommandRegistry.Register("Tab: Rename Current", "General", () => _ = RenameSelectedTabAsync(), "");
             CommandRegistry.Register("Tab: Copy Current Title", "General", () => _ = CopySelectedTabTitleAsync(), "");
             CommandRegistry.Register("Tab: Close Others", "General", () => _ = CloseOtherTabsAsync(), "");
@@ -3952,29 +3934,29 @@ namespace NovaTerminal
             CommandRegistry.Register("Tab: Toggle Protect", "General", () => ToggleProtectSelectedTab(), "");
             // Keep command naming aligned with common terminal UX:
             // Vertical split => vertical divider => side-by-side panes.
-            CommandRegistry.Register("Split Vertical", "View", () => SplitPane(Avalonia.Layout.Orientation.Horizontal), "Ctrl+Shift+D");
+            CommandRegistry.Register("Split Vertical", "View", () => SplitPane(Avalonia.Layout.Orientation.Horizontal), GetEffectiveShortcutBinding("split_vertical", "Ctrl+Shift+D"), "split_vertical");
             // Horizontal split => horizontal divider => stacked panes.
-            CommandRegistry.Register("Split Horizontal", "View", () => SplitPane(Avalonia.Layout.Orientation.Vertical), "Ctrl+Shift+E");
-            CommandRegistry.Register("Equalize Panes", "View", () => EqualizeCurrentSplit(), "Ctrl+Shift+G");
-            CommandRegistry.Register("Pane: Toggle Zoom", "View", () => TogglePaneZoomForCurrentTab(), "Ctrl+Shift+Z");
-            CommandRegistry.Register("Pane: Toggle Broadcast Input (Tab)", "View", () => ToggleBroadcastForCurrentTab(), "Ctrl+Shift+B");
+            CommandRegistry.Register("Split Horizontal", "View", () => SplitPane(Avalonia.Layout.Orientation.Vertical), GetEffectiveShortcutBinding("split_horizontal", "Ctrl+Shift+E"), "split_horizontal");
+            CommandRegistry.Register("Equalize Panes", "View", () => EqualizeCurrentSplit(), GetEffectiveShortcutBinding("equalize_panes", "Ctrl+Shift+G"), "equalize_panes");
+            CommandRegistry.Register("Pane: Toggle Zoom", "View", () => TogglePaneZoomForCurrentTab(), GetEffectiveShortcutBinding("toggle_pane_zoom", "Ctrl+Shift+Z"), "toggle_pane_zoom");
+            CommandRegistry.Register("Pane: Toggle Broadcast Input (Tab)", "View", () => ToggleBroadcastForCurrentTab(), GetEffectiveShortcutBinding("toggle_broadcast_input", "Ctrl+Shift+B"), "toggle_broadcast_input");
             CommandRegistry.Register("Pane: Reconnect", "View", () => _currentPane?.Reconnect(), "");
             CommandRegistry.Register("Focus Pane Left", "View", () => NavigatePane(MoveDirection.Left), "Alt+Left");
             CommandRegistry.Register("Focus Pane Right", "View", () => NavigatePane(MoveDirection.Right), "Alt+Right");
             CommandRegistry.Register("Focus Pane Up", "View", () => NavigatePane(MoveDirection.Up), "Alt+Up");
             CommandRegistry.Register("Focus Pane Down", "View", () => NavigatePane(MoveDirection.Down), "Alt+Down");
-            CommandRegistry.Register("Find in Terminal", "Edit", () => _currentPane?.ToggleSearch(), "Ctrl+Shift+F");
+            CommandRegistry.Register("Find in Terminal", "Edit", () => _currentPane?.ToggleSearch(), GetEffectiveShortcutBinding("find", "Ctrl+F"), "find");
             CommandRegistry.Register("Pane: Export Snapshot (Plain Text)", "View", () => _currentPane?.ExportSnapshotAsync("txt"), "");
             CommandRegistry.Register("Pane: Export Snapshot (ANSI)", "View", () => _currentPane?.ExportSnapshotAsync("ansi"), "");
             CommandRegistry.Register("Pane: Export Snapshot (PNG)", "View", () => _currentPane?.ExportSnapshotAsync("png"), "");
             CommandRegistry.Register("Pane: Toggle Render HUD", "View", () => _currentPane?.ToggleRenderHud(), "");
-            CommandRegistry.Register("Paste", "Edit", () => _ = PasteFromClipboardAsync(), "Ctrl+V");
-            CommandRegistry.Register("Font: Increase", "View", () => { _settings.FontSize++; ApplySettingsToAllTabs(); _settings.Save(); }, "Ctrl++");
-            CommandRegistry.Register("Font: Decrease", "View", () => { _settings.FontSize = Math.Max(6, _settings.FontSize - 1); ApplySettingsToAllTabs(); _settings.Save(); }, "Ctrl+-");
+            CommandRegistry.Register("Paste", "Edit", () => _ = PasteFromClipboardAsync(), GetEffectiveShortcutBinding("paste", "Ctrl+V"), "paste");
+            CommandRegistry.Register("Font: Increase", "View", () => { _settings.FontSize++; ApplySettingsToAllTabs(); _settings.Save(); }, GetEffectiveShortcutBinding("font_increase", "Ctrl++"), "font_increase");
+            CommandRegistry.Register("Font: Decrease", "View", () => { _settings.FontSize = Math.Max(6, _settings.FontSize - 1); ApplySettingsToAllTabs(); _settings.Save(); }, GetEffectiveShortcutBinding("font_decrease", "Ctrl+-"), "font_decrease");
             CommandRegistry.Register("Settings", "General", async () =>
             {
                 await OpenSettings(0);
-            }, "");
+            }, GetEffectiveShortcutBinding("settings", "Ctrl+,"), "settings");
             CommandRegistry.Register("Open Recording...", "General", () => _ = ExecuteUiCommandAsync(ExecuteOpenRecordingCommandAsync, "Open Recording..."), "");
             CommandRegistry.Register("Open Recordings Folder", "General", () => OpenRecordingsFolder(), "");
 
@@ -4332,7 +4314,7 @@ namespace NovaTerminal
                     }
                     else
                     {
-                        var results = CommandRegistry.Search(box.Text ?? "");
+                        var results = GetPaletteCommands(box.Text ?? "");
                         list.ItemsSource = results;
                         if (results.Count > 0) list.SelectedIndex = 0;
                     }
@@ -4343,7 +4325,7 @@ namespace NovaTerminal
                 {
                     if (e.Property.Name == "Text")
                     {
-                        var results = CommandRegistry.Search(box.Text ?? "");
+                        var results = GetPaletteCommands(box.Text ?? "");
                         list.ItemsSource = results;
                         if (results.Count > 0) list.SelectedIndex = 0;
                     }
@@ -4377,7 +4359,7 @@ namespace NovaTerminal
                 {
                     SetupCommandPalette();
                     box.Text = "";
-                    list.ItemsSource = CommandRegistry.GetCommands().OrderBy(c => c.Category).ThenBy(c => c.Title).ToList();
+                    list.ItemsSource = GetPaletteCommands("");
                     list.SelectedIndex = 0;
                     box.Focus();
                 }
@@ -4917,6 +4899,7 @@ namespace NovaTerminal
         private void ExecuteCommand(TerminalCommand cmd)
         {
             ToggleCommandPalette(); // Close first
+            RecordCommandUsage(cmd.Id);
             Dispatcher.UIThread.Post(() =>
             {
                 try
@@ -4928,6 +4911,35 @@ namespace NovaTerminal
                     Console.WriteLine($"Error executing command {cmd.Title}: {ex.Message}");
                 }
             }, DispatcherPriority.Background);
+        }
+
+        private List<TerminalCommand> GetPaletteCommands(string query)
+        {
+            if (string.IsNullOrWhiteSpace(query))
+            {
+                return CommandPaletteOrdering.OrderForEmptyQuery(CommandRegistry.GetCommands(), _commandPaletteUsage).ToList();
+            }
+
+            return CommandPaletteOrdering.OrderSearchResults(CommandRegistry.Search(query), _commandPaletteUsage).ToList();
+        }
+
+        private void RecordCommandUsage(string commandId)
+        {
+            if (string.IsNullOrWhiteSpace(commandId))
+            {
+                return;
+            }
+
+            try
+            {
+                _commandPaletteUsageStore.RecordUse(commandId, DateTimeOffset.UtcNow);
+                _commandPaletteUsageStore.Save();
+                _commandPaletteUsage = new Dictionary<string, CommandPaletteUsageEntry>(_commandPaletteUsageStore.Load(), StringComparer.OrdinalIgnoreCase);
+            }
+            catch
+            {
+                // Keep command execution resilient if usage persistence is unavailable.
+            }
         }
 
 

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -3957,6 +3957,7 @@ namespace NovaTerminal
             {
                 await OpenSettings(0);
             }, GetEffectiveShortcutBinding("settings", "Ctrl+,"), "settings");
+            CommandRegistry.Register("Connections", "General", () => ToggleConnections(), "", "connections");
             CommandRegistry.Register("Open Recording...", "General", () => _ = ExecuteUiCommandAsync(ExecuteOpenRecordingCommandAsync, "Open Recording..."), "");
             CommandRegistry.Register("Open Recordings Folder", "General", () => OpenRecordingsFolder(), "");
 

--- a/src/NovaTerminal.App/SettingsWindow.axaml
+++ b/src/NovaTerminal.App/SettingsWindow.axaml
@@ -296,6 +296,12 @@
                                     <TextBlock Grid.Column="1" Text="Shells &amp; Profiles" Margin="6,0,0,0" VerticalAlignment="Center"/>
                                 </Grid>
                             </ListBoxItem>
+                            <ListBoxItem>
+                                <Grid ColumnDefinitions="20,*">
+                                    <TextBlock Grid.Column="0" Text="⌘" FontSize="13" Foreground="{StaticResource NtFg3}" VerticalAlignment="Center"/>
+                                    <TextBlock Grid.Column="1" Text="Shortcuts" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                                </Grid>
+                            </ListBoxItem>
                         </ListBox>
 
                         <Border Margin="14,18,14,8"
@@ -755,6 +761,32 @@
                             </StackPanel>
                         </ScrollViewer>
                     </Grid>
+                </TabItem>
+
+                <TabItem Header="Shortcuts">
+                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <StackPanel Margin="32,28,32,28" Spacing="0">
+                            <StackPanel Margin="0,0,0,24">
+                                <TextBlock Classes="H1" Text="Shortcuts"/>
+                                <TextBlock Classes="Subtitle" Margin="0,4,0,0" Text="Manage app, pane, and Command Assist keybindings."/>
+                            </StackPanel>
+
+                            <TextBlock Classes="SectionHeader" Text="KEYBINDINGS" Margin="0,0,0,14"/>
+
+                            <StackPanel Spacing="10" Margin="0,0,0,16">
+                                <TextBox Name="ShortcutSearchInput" PlaceholderText="Search commands, categories, or scopes"/>
+                                <TextBlock Name="ShortcutValidationMessage"
+                                           Foreground="{StaticResource NtRed}"
+                                           FontSize="12"
+                                           IsVisible="False"
+                                           TextWrapping="Wrap"/>
+                                <TextBlock Classes="RowDesc"
+                                           Text="Select a shortcut field and press the new key chord. Reset restores the default binding."/>
+                            </StackPanel>
+
+                            <StackPanel Name="ShortcutBindingsPanel" Spacing="10"/>
+                        </StackPanel>
+                    </ScrollViewer>
                 </TabItem>
             </TabControl>
         </Grid>

--- a/src/NovaTerminal.App/SettingsWindow.axaml.cs
+++ b/src/NovaTerminal.App/SettingsWindow.axaml.cs
@@ -1,8 +1,10 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Layout;
 using NovaTerminal.Core;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.NetworkInformation;
 using Avalonia.Threading;
@@ -10,6 +12,7 @@ using Avalonia.Media;
 using Avalonia.Controls.Shapes;
 using Avalonia.Styling;
 using NovaTerminal.Services.Ssh;
+using NovaTerminal.Core.Shortcuts;
 
 namespace NovaTerminal
 {
@@ -20,6 +23,7 @@ namespace NovaTerminal
 
         private TerminalProfile? _selectedProfile;
         private System.Collections.Generic.List<TerminalProfile> _profilesList = new();
+        private Dictionary<string, string> _shortcutDraftBindings = new(StringComparer.OrdinalIgnoreCase);
 
         public event Action<double>? OnOpacityChanged;
         public event Action<string>? OnBlurChanged;
@@ -50,6 +54,7 @@ namespace NovaTerminal
             // Settings editor is local-profiles only; SSH connections are managed in Connection Manager.
             _profilesList = BuildLocalProfilesForEditor(_settings.Profiles);
             _settings.DefaultProfileId = ResolveDefaultLocalProfileId(_settings.DefaultProfileId, _profilesList);
+            _shortcutDraftBindings = new Dictionary<string, string>(_settings.Keybindings, StringComparer.OrdinalIgnoreCase);
 
             PopulateFonts();
             PopulateThemes();
@@ -300,6 +305,7 @@ namespace NovaTerminal
 
             LoadCurrentSettings();
             PopulateProfilesList();
+            InitializeShortcutEditor();
             ApplyTheme();
 
             _statusTimer = new DispatcherTimer
@@ -1108,6 +1114,270 @@ namespace NovaTerminal
             RefreshForwardsList();
         }
 
+        internal static IReadOnlyList<ShortcutCatalogEntry> FilterShortcutCatalogEntries(string query)
+        {
+            IEnumerable<ShortcutCatalogEntry> entries = ShortcutCatalog.GetEntries();
+            if (!string.IsNullOrWhiteSpace(query))
+            {
+                string trimmedQuery = query.Trim();
+                entries = entries.Where(entry =>
+                    entry.Title.Contains(trimmedQuery, StringComparison.OrdinalIgnoreCase) ||
+                    entry.Category.Contains(trimmedQuery, StringComparison.OrdinalIgnoreCase) ||
+                    FormatScopeLabel(entry.Scope).Contains(trimmedQuery, StringComparison.OrdinalIgnoreCase) ||
+                    entry.CommandId.Contains(trimmedQuery, StringComparison.OrdinalIgnoreCase));
+            }
+
+            return entries
+                .OrderBy(entry => entry.Scope)
+                .ThenBy(entry => entry.Category, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(entry => entry.Title, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        private void InitializeShortcutEditor()
+        {
+            var shortcutSearchInput = this.FindControl<TextBox>("ShortcutSearchInput");
+            if (shortcutSearchInput != null)
+            {
+                shortcutSearchInput.PropertyChanged += (s, e) =>
+                {
+                    if (e.Property.Name == "Text")
+                    {
+                        PopulateShortcutBindingsPanel(shortcutSearchInput.Text ?? "");
+                    }
+                };
+            }
+
+            PopulateShortcutBindingsPanel(shortcutSearchInput?.Text ?? "");
+        }
+
+        private void PopulateShortcutBindingsPanel(string query)
+        {
+            var panel = this.FindControl<StackPanel>("ShortcutBindingsPanel");
+            if (panel == null)
+            {
+                return;
+            }
+
+            panel.Children.Clear();
+            string? activeScope = null;
+            IReadOnlyList<ShortcutCatalogEntry> entries = FilterShortcutCatalogEntries(query);
+            foreach (ShortcutCatalogEntry entry in entries)
+            {
+                string scopeLabel = FormatScopeLabel(entry.Scope);
+                if (!string.Equals(activeScope, scopeLabel, StringComparison.Ordinal))
+                {
+                    panel.Children.Add(new TextBlock
+                    {
+                        Text = scopeLabel.ToUpperInvariant(),
+                        Classes = { "SectionHeader" },
+                        Margin = new Thickness(0, activeScope == null ? 0 : 12, 0, 8),
+                    });
+                    activeScope = scopeLabel;
+                }
+
+                panel.Children.Add(CreateShortcutBindingRow(entry));
+            }
+
+            if (panel.Children.Count == 0)
+            {
+                panel.Children.Add(new TextBlock
+                {
+                    Text = "No shortcuts match the current filter.",
+                    Classes = { "RowDesc" },
+                });
+            }
+        }
+
+        private Control CreateShortcutBindingRow(ShortcutCatalogEntry entry)
+        {
+            string effectiveBinding = GetEffectiveShortcutBinding(entry);
+            var row = new Border
+            {
+                Background = new SolidColorBrush(Color.Parse("#23272f")),
+                BorderBrush = new SolidColorBrush(Color.Parse("#2a2f38")),
+                BorderThickness = new Thickness(1),
+                CornerRadius = new CornerRadius(6),
+                Padding = new Thickness(12),
+                Margin = new Thickness(0, 0, 0, 8),
+            };
+
+            var errorText = new TextBlock
+            {
+                Foreground = Brushes.IndianRed,
+                FontSize = 11,
+                TextWrapping = TextWrapping.Wrap,
+                IsVisible = false,
+            };
+
+            var bindingEditor = new TextBox
+            {
+                Text = effectiveBinding,
+                IsReadOnly = true,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                PlaceholderText = "Press shortcut",
+                MinWidth = 180,
+            };
+
+            bindingEditor.KeyDown += (s, e) => HandleShortcutEditorKeyDown(entry, bindingEditor, errorText, e);
+
+            var resetButton = new Button
+            {
+                Content = "Reset",
+                Classes = { "Pill" },
+                HorizontalAlignment = HorizontalAlignment.Right,
+            };
+            resetButton.Click += (s, e) =>
+            {
+                _shortcutDraftBindings.Remove(entry.CommandId);
+                bindingEditor.Text = entry.DefaultBinding;
+                errorText.IsVisible = false;
+                ClearShortcutValidationMessage();
+            };
+
+            row.Child = new StackPanel
+            {
+                Spacing = 8,
+                Children =
+                {
+                    new Grid
+                    {
+                        ColumnDefinitions = new ColumnDefinitions("*,220,Auto"),
+                        ColumnSpacing = 12,
+                        Children =
+                        {
+                            new StackPanel
+                            {
+                                Spacing = 2,
+                                Children =
+                                {
+                                    new TextBlock
+                                    {
+                                        Text = entry.Title,
+                                        Classes = { "RowLabel" },
+                                    },
+                                    new TextBlock
+                                    {
+                                        Text = $"{entry.Category} · {FormatScopeLabel(entry.Scope)} · Default {entry.DefaultBinding}",
+                                        Classes = { "RowDesc" },
+                                    },
+                                },
+                            },
+                            bindingEditor,
+                            resetButton,
+                        }
+                    },
+                    errorText,
+                }
+            };
+
+            Grid.SetColumn(bindingEditor, 1);
+            Grid.SetColumn(resetButton, 2);
+            return row;
+        }
+
+        private void HandleShortcutEditorKeyDown(
+            ShortcutCatalogEntry entry,
+            TextBox bindingEditor,
+            TextBlock errorText,
+            KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape)
+            {
+                bindingEditor.Text = GetEffectiveShortcutBinding(entry);
+                errorText.IsVisible = false;
+                ClearShortcutValidationMessage();
+                e.Handled = true;
+                return;
+            }
+
+            if (IsModifierKey(e.Key))
+            {
+                e.Handled = true;
+                return;
+            }
+
+            string binding = ShortcutMatcher.Normalize(e);
+            Dictionary<string, string> candidateBindings = new(_shortcutDraftBindings, StringComparer.OrdinalIgnoreCase);
+            if (string.Equals(binding, entry.DefaultBinding, StringComparison.Ordinal))
+            {
+                candidateBindings.Remove(entry.CommandId);
+            }
+            else
+            {
+                candidateBindings[entry.CommandId] = binding;
+            }
+
+            ShortcutBindingResolution resolution = ShortcutBindingResolver.Resolve(ShortcutCatalog.GetDefinitions(), candidateBindings);
+            ShortcutBindingConflict? conflict = resolution.Conflicts.FirstOrDefault(item =>
+                item.Bindings.Any(bindingRecord => string.Equals(bindingRecord.CommandId, entry.CommandId, StringComparison.OrdinalIgnoreCase)));
+
+            if (conflict != null)
+            {
+                string conflictOwner = conflict.Bindings
+                    .Select(bindingRecord => ShortcutCatalog.GetEntries().First(catalogEntry => catalogEntry.CommandId == bindingRecord.CommandId).Title)
+                    .First(title => !string.Equals(title, entry.Title, StringComparison.OrdinalIgnoreCase));
+                errorText.Text = $"{binding} is already assigned to {conflictOwner}.";
+                errorText.IsVisible = true;
+                ShowShortcutValidationMessage("Resolve duplicate shortcuts before saving.");
+                e.Handled = true;
+                return;
+            }
+
+            _shortcutDraftBindings = candidateBindings;
+            bindingEditor.Text = binding;
+            errorText.IsVisible = false;
+            ClearShortcutValidationMessage();
+            e.Handled = true;
+        }
+
+        private static bool IsModifierKey(Key key)
+        {
+            return key is Key.LeftCtrl or Key.RightCtrl or Key.LeftAlt or Key.RightAlt or Key.LeftShift or Key.RightShift;
+        }
+
+        private string GetEffectiveShortcutBinding(ShortcutCatalogEntry entry)
+        {
+            return _shortcutDraftBindings.TryGetValue(entry.CommandId, out string? binding) &&
+                   !string.IsNullOrWhiteSpace(binding)
+                ? binding
+                : entry.DefaultBinding;
+        }
+
+        private static string FormatScopeLabel(ShortcutScope scope)
+        {
+            return scope switch
+            {
+                ShortcutScope.App => "Application",
+                ShortcutScope.Pane => "Pane",
+                ShortcutScope.CommandAssist => "Command Assist",
+                _ => scope.ToString(),
+            };
+        }
+
+        private void ShowShortcutValidationMessage(string message)
+        {
+            var validationMessage = this.FindControl<TextBlock>("ShortcutValidationMessage");
+            if (validationMessage == null)
+            {
+                return;
+            }
+
+            validationMessage.Text = message;
+            validationMessage.IsVisible = true;
+        }
+
+        private void ClearShortcutValidationMessage()
+        {
+            var validationMessage = this.FindControl<TextBlock>("ShortcutValidationMessage");
+            if (validationMessage == null)
+            {
+                return;
+            }
+
+            validationMessage.Text = string.Empty;
+            validationMessage.IsVisible = false;
+        }
 
 
         private void LoadCurrentSettings()
@@ -1370,6 +1640,21 @@ namespace NovaTerminal
             if (bgOpacitySlider != null) _settings.BackgroundImageOpacity = bgOpacitySlider.Value;
             if (bgStretchList?.SelectedItem is ComboBoxItem stretchItem)
                 _settings.BackgroundImageStretch = stretchItem.Content?.ToString() ?? "UniformToFill";
+
+            ShortcutBindingResolution shortcutResolution = ShortcutBindingResolver.Resolve(ShortcutCatalog.GetDefinitions(), _shortcutDraftBindings);
+            if (!shortcutResolution.IsValid)
+            {
+                ShowShortcutValidationMessage("Resolve duplicate shortcuts before saving.");
+                var tabs = this.FindControl<TabControl>("MainTabs");
+                if (tabs != null)
+                {
+                    tabs.SelectedIndex = 2;
+                }
+
+                return;
+            }
+
+            _settings.Keybindings = new Dictionary<string, string>(_shortcutDraftBindings, StringComparer.OrdinalIgnoreCase);
 
             // Sync local profiles list back to settings (SSH connections are store-backed separately).
             _settings.Profiles = NormalizeSettingsProfilesForSave(_profilesList);

--- a/tests/NovaTerminal.Tests/CommandAssist/TerminalPaneCommandAssistShortcutTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/TerminalPaneCommandAssistShortcutTests.cs
@@ -148,30 +148,21 @@ public sealed class TerminalPaneCommandAssistShortcutTests
     }
 
     [AvaloniaFact]
-    public void TryHandleCommandAssistHelpShortcut_WhenPaneOpensHelp_ReturnsTrue()
+    public void TryOpenCommandAssistHelp_WhenPaneOpensHelp_ReturnsTrue()
     {
         var pane = new TerminalPane();
         ConfigureCommandAssist(pane);
         pane.NotifyCommandAssistPaste("git checkout");
 
-        bool handled = NovaTerminal.MainWindow.TryHandleCommandAssistHelpShortcut(
-            pane,
-            Key.H,
-            KeyModifiers.Control | KeyModifiers.Shift);
+        bool handled = NovaTerminal.MainWindow.TryOpenCommandAssistHelp(pane);
 
         Assert.True(handled);
     }
 
     [AvaloniaFact]
-    public void TryHandleCommandAssistHelpShortcut_WhenDifferentShortcut_ReturnsFalse()
+    public void TryOpenCommandAssistHelp_WhenPaneIsMissing_ReturnsFalse()
     {
-        var pane = new TerminalPane();
-        ConfigureCommandAssist(pane);
-
-        bool handled = NovaTerminal.MainWindow.TryHandleCommandAssistHelpShortcut(
-            pane,
-            Key.P,
-            KeyModifiers.Control | KeyModifiers.Shift);
+        bool handled = NovaTerminal.MainWindow.TryOpenCommandAssistHelp(null);
 
         Assert.False(handled);
     }

--- a/tests/NovaTerminal.Tests/Core/CommandPaletteOrderingTests.cs
+++ b/tests/NovaTerminal.Tests/Core/CommandPaletteOrderingTests.cs
@@ -1,0 +1,84 @@
+using NovaTerminal.Core;
+using NovaTerminal.Core.Shortcuts;
+
+namespace NovaTerminal.Tests.Core;
+
+public sealed class CommandPaletteOrderingTests
+{
+    [Fact]
+    public void OrderForEmptyQuery_PrefersMostUsedCommands()
+    {
+        TerminalCommand[] commands =
+        [
+            new TerminalCommand { Id = "settings", Title = "Settings", Category = "General" },
+            new TerminalCommand { Id = "open_recording", Title = "Open Recording...", Category = "General" },
+        ];
+
+        Dictionary<string, CommandPaletteUsageEntry> usage = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["settings"] = new("settings", 8, DateTimeOffset.UtcNow),
+            ["open_recording"] = new("open_recording", 1, DateTimeOffset.UtcNow),
+        };
+
+        IReadOnlyList<TerminalCommand> ordered = CommandPaletteOrdering.OrderForEmptyQuery(commands, usage);
+
+        Assert.Equal("settings", ordered[0].Id);
+    }
+
+    [Fact]
+    public void OrderForEmptyQuery_BreaksUsageTiesByMostRecentUse()
+    {
+        TerminalCommand[] commands =
+        [
+            new() { Id = "settings", Title = "Settings", Category = "General" },
+            new() { Id = "new_tab", Title = "New Tab", Category = "General" },
+        ];
+
+        Dictionary<string, CommandPaletteUsageEntry> usage = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["settings"] = new("settings", 3, new DateTimeOffset(2026, 5, 26, 10, 0, 0, TimeSpan.Zero)),
+            ["new_tab"] = new("new_tab", 3, new DateTimeOffset(2026, 5, 26, 12, 0, 0, TimeSpan.Zero)),
+        };
+
+        IReadOnlyList<TerminalCommand> ordered = CommandPaletteOrdering.OrderForEmptyQuery(commands, usage);
+
+        Assert.Equal("new_tab", ordered[0].Id);
+    }
+
+    [Fact]
+    public void OrderForEmptyQuery_FallsBackToCategoryAndTitleWhenUnused()
+    {
+        TerminalCommand[] commands =
+        [
+            new() { Id = "split_vertical", Title = "Split Vertical", Category = "View" },
+            new() { Id = "settings", Title = "Settings", Category = "General" },
+            new() { Id = "close_tab", Title = "Close Tab", Category = "General" },
+        ];
+
+        IReadOnlyList<TerminalCommand> ordered = CommandPaletteOrdering.OrderForEmptyQuery(
+            commands,
+            new Dictionary<string, CommandPaletteUsageEntry>(StringComparer.OrdinalIgnoreCase));
+
+        Assert.Equal(["close_tab", "settings", "split_vertical"], ordered.Select(command => command.Id).ToArray());
+    }
+
+    [Fact]
+    public void OrderSearchResults_PrefersMostUsedCommandsWhenMatchesTie()
+    {
+        TerminalCommand[] commands =
+        [
+            new() { Id = "settings", Title = "Settings", Category = "General" },
+            new() { Id = "split_settings", Title = "Split Settings", Category = "View" },
+        ];
+
+        Dictionary<string, CommandPaletteUsageEntry> usage = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["split_settings"] = new("split_settings", 5, new DateTimeOffset(2026, 5, 26, 12, 0, 0, TimeSpan.Zero)),
+            ["settings"] = new("settings", 1, new DateTimeOffset(2026, 5, 26, 11, 0, 0, TimeSpan.Zero)),
+        };
+
+        IReadOnlyList<TerminalCommand> ordered = CommandPaletteOrdering.OrderSearchResults(commands, usage);
+
+        Assert.Equal("split_settings", ordered[0].Id);
+    }
+}

--- a/tests/NovaTerminal.Tests/Core/CommandPaletteUsageStoreTests.cs
+++ b/tests/NovaTerminal.Tests/Core/CommandPaletteUsageStoreTests.cs
@@ -15,6 +15,9 @@ public sealed class CommandPaletteUsageStoreTests
             var store = new CommandPaletteUsageStore(path);
             store.RecordUse("settings", new DateTimeOffset(2026, 5, 26, 12, 0, 0, TimeSpan.Zero));
             store.Save();
+            WaitFor(
+                () => File.Exists(path) && File.ReadAllText(path).Contains("settings", StringComparison.Ordinal),
+                TimeSpan.FromSeconds(2));
 
             var reloaded = new CommandPaletteUsageStore(path);
             IReadOnlyDictionary<string, CommandPaletteUsageEntry> snapshot = reloaded.Load();
@@ -27,10 +30,58 @@ public sealed class CommandPaletteUsageStoreTests
         }
     }
 
+    [Fact]
+    public void Load_UsesCaseInsensitiveDictionaryForDeserializedEntries()
+    {
+        string tempRoot = CreateTempDirectory();
+        string path = Path.Combine(tempRoot, "command-palette-usage.json");
+
+        try
+        {
+            File.WriteAllText(
+                path,
+                """
+                {
+                  "Settings": {
+                    "CommandId": "Settings",
+                    "UseCount": 3,
+                    "LastUsedAt": "2026-05-26T12:00:00+00:00"
+                  }
+                }
+                """);
+
+            var store = new CommandPaletteUsageStore(path);
+            IReadOnlyDictionary<string, CommandPaletteUsageEntry> snapshot = store.Load();
+
+            Assert.True(snapshot.TryGetValue("settings", out CommandPaletteUsageEntry? entry));
+            Assert.Equal(3, entry.UseCount);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
     private static string CreateTempDirectory()
     {
         string path = Path.Combine(Path.GetTempPath(), $"nova_usage_test_{Guid.NewGuid():N}");
         Directory.CreateDirectory(path);
         return path;
+    }
+
+    private static void WaitFor(Func<bool> condition, TimeSpan timeout)
+    {
+        DateTime deadline = DateTime.UtcNow.Add(timeout);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            Thread.Sleep(25);
+        }
+
+        Assert.True(condition());
     }
 }

--- a/tests/NovaTerminal.Tests/Core/CommandPaletteUsageStoreTests.cs
+++ b/tests/NovaTerminal.Tests/Core/CommandPaletteUsageStoreTests.cs
@@ -1,0 +1,36 @@
+using NovaTerminal.Core.Shortcuts;
+
+namespace NovaTerminal.Tests.Core;
+
+public sealed class CommandPaletteUsageStoreTests
+{
+    [Fact]
+    public void RecordUse_PersistsCountAcrossReloads()
+    {
+        string tempRoot = CreateTempDirectory();
+        string path = Path.Combine(tempRoot, "command-palette-usage.json");
+
+        try
+        {
+            var store = new CommandPaletteUsageStore(path);
+            store.RecordUse("settings", new DateTimeOffset(2026, 5, 26, 12, 0, 0, TimeSpan.Zero));
+            store.Save();
+
+            var reloaded = new CommandPaletteUsageStore(path);
+            IReadOnlyDictionary<string, CommandPaletteUsageEntry> snapshot = reloaded.Load();
+
+            Assert.Equal(1, snapshot["settings"].UseCount);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    private static string CreateTempDirectory()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"nova_usage_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/tests/NovaTerminal.Tests/Core/MainWindowStartupTests.cs
+++ b/tests/NovaTerminal.Tests/Core/MainWindowStartupTests.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Media;
 using Avalonia.Threading;
 using NovaTerminal.Core;
+using NovaTerminal.Core.Shortcuts;
 using System.Reflection;
 
 namespace NovaTerminal.Tests.Core;
@@ -76,6 +77,44 @@ public sealed class MainWindowStartupTests
         Assert.Contains(commands, command => command.Title == "Settings");
         Assert.Contains(commands, command => command.Title == "Open Recording...");
         Assert.Contains(commands, command => command.Title == "Open Recordings Folder");
+    }
+
+    [AvaloniaFact]
+    public void MainWindow_CommandPaletteShowsSettingsShortcut()
+    {
+        CommandRegistry.Clear();
+        var window = new NovaTerminal.MainWindow();
+        var toggleMethod = typeof(NovaTerminal.MainWindow).GetMethod("ToggleCommandPalette", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        toggleMethod!.Invoke(window, null);
+
+        TerminalCommand settingsCommand = Assert.Single(CommandRegistry.GetCommands().Where(command => command.Title == "Settings"));
+        Assert.Equal("Ctrl+,", settingsCommand.Shortcut);
+    }
+
+    [AvaloniaFact]
+    public void MainWindow_CommandPalettePrefersMostUsedCommandsWhenOpened()
+    {
+        CommandRegistry.Clear();
+        var window = new NovaTerminal.MainWindow();
+        var toggleMethod = typeof(NovaTerminal.MainWindow).GetMethod("ToggleCommandPalette", BindingFlags.Instance | BindingFlags.NonPublic);
+        var usageField = typeof(NovaTerminal.MainWindow).GetField("_commandPaletteUsage", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(usageField);
+
+        usageField!.SetValue(
+            window,
+            new Dictionary<string, CommandPaletteUsageEntry>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["settings"] = new("settings", 8, new DateTimeOffset(2026, 5, 26, 12, 0, 0, TimeSpan.Zero)),
+            });
+
+        toggleMethod!.Invoke(window, null);
+
+        var commandList = window.FindControl<ListBox>("CommandList");
+        IReadOnlyList<TerminalCommand> commands = Assert.IsAssignableFrom<IEnumerable<TerminalCommand>>(commandList!.ItemsSource).ToList();
+
+        Assert.Equal("settings", commands[0].Id);
     }
 
     public async Task ExecuteCommand_DefersActionUntilAfterPaletteCloses()

--- a/tests/NovaTerminal.Tests/Core/MainWindowStartupTests.cs
+++ b/tests/NovaTerminal.Tests/Core/MainWindowStartupTests.cs
@@ -1,7 +1,9 @@
 using Avalonia.Headless.XUnit;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Media;
 using Avalonia.Threading;
+using NovaTerminal.Controls;
 using NovaTerminal.Core;
 using NovaTerminal.Core.Shortcuts;
 using System.Reflection;
@@ -127,6 +129,42 @@ public sealed class MainWindowStartupTests
         IReadOnlyList<TerminalCommand> commands = Assert.IsAssignableFrom<IEnumerable<TerminalCommand>>(commandList!.ItemsSource).ToList();
 
         Assert.Equal("settings", commands[0].Id);
+    }
+
+    [AvaloniaFact]
+    public async Task MainWindow_CustomCommandAssistHelpShortcut_UsesConfiguredBinding()
+    {
+        var window = new NovaTerminal.MainWindow();
+        var settingsField = typeof(NovaTerminal.MainWindow).GetField("_settings", BindingFlags.Instance | BindingFlags.NonPublic);
+        var currentPaneField = typeof(NovaTerminal.MainWindow).GetField("_currentPaneValue", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(settingsField);
+        Assert.NotNull(currentPaneField);
+
+        var settings = (TerminalSettings)settingsField!.GetValue(window)!;
+        settings.CommandAssistEnabled = true;
+        settings.CommandAssistHistoryEnabled = true;
+        settings.Keybindings["command_assist_help"] = "Ctrl+Alt+H";
+
+        var pane = new TerminalPane();
+        pane.ApplySettings(settings);
+        pane.NotifyCommandAssistPaste("git checkout");
+
+        currentPaneField!.SetValue(window, pane);
+
+        var args = new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Key = Key.H,
+            KeyModifiers = KeyModifiers.Control | KeyModifiers.Alt,
+            Source = window,
+        };
+
+        window.RaiseEvent(args);
+        await Dispatcher.UIThread.InvokeAsync(() => { }, DispatcherPriority.Background);
+
+        Assert.True(args.Handled);
+        Assert.True(pane.CommandAssistViewModel?.IsVisible ?? false);
     }
 
     public async Task ExecuteCommand_DefersActionUntilAfterPaletteCloses()

--- a/tests/NovaTerminal.Tests/Core/MainWindowStartupTests.cs
+++ b/tests/NovaTerminal.Tests/Core/MainWindowStartupTests.cs
@@ -93,6 +93,18 @@ public sealed class MainWindowStartupTests
     }
 
     [AvaloniaFact]
+    public void MainWindow_CommandPaletteIncludesConnections()
+    {
+        CommandRegistry.Clear();
+        var window = new NovaTerminal.MainWindow();
+        var toggleMethod = typeof(NovaTerminal.MainWindow).GetMethod("ToggleCommandPalette", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        toggleMethod!.Invoke(window, null);
+
+        Assert.Contains(CommandRegistry.GetCommands(), command => command.Id == "connections" && command.Title == "Connections");
+    }
+
+    [AvaloniaFact]
     public void MainWindow_CommandPalettePrefersMostUsedCommandsWhenOpened()
     {
         CommandRegistry.Clear();

--- a/tests/NovaTerminal.Tests/Core/SettingsWindowShortcutFilteringTests.cs
+++ b/tests/NovaTerminal.Tests/Core/SettingsWindowShortcutFilteringTests.cs
@@ -1,0 +1,15 @@
+using NovaTerminal.Core.Shortcuts;
+
+namespace NovaTerminal.Tests.Core;
+
+public sealed class SettingsWindowShortcutFilteringTests
+{
+    [Fact]
+    public void FilterShortcutCatalogEntries_MatchesTitleCategoryAndScope()
+    {
+        IReadOnlyList<ShortcutCatalogEntry> results = SettingsWindow.FilterShortcutCatalogEntries("assist");
+
+        Assert.Contains(results, entry => entry.CommandId == "command_assist_toggle");
+        Assert.DoesNotContain(results, entry => entry.CommandId == "settings");
+    }
+}

--- a/tests/NovaTerminal.Tests/Core/ShortcutBindingResolverTests.cs
+++ b/tests/NovaTerminal.Tests/Core/ShortcutBindingResolverTests.cs
@@ -1,0 +1,88 @@
+using NovaTerminal.Core.Shortcuts;
+
+namespace NovaTerminal.Tests.Core;
+
+public sealed class ShortcutBindingResolverTests
+{
+    [Fact]
+    public void Resolve_WhenOverridesCreateCrossScopeDuplicate_ReturnsInvalidConflict()
+    {
+        ShortcutDefinition[] definitions =
+        [
+            new("settings", ShortcutScope.App, "Ctrl+,"),
+            new("command_assist_help", ShortcutScope.CommandAssist, "Ctrl+Shift+H"),
+        ];
+
+        Dictionary<string, string> overrides = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["settings"] = "Ctrl+Alt+S",
+            ["command_assist_help"] = "Ctrl+Alt+S",
+        };
+
+        ShortcutBindingResolution resolution = ShortcutBindingResolver.Resolve(definitions, overrides);
+
+        Assert.False(resolution.IsValid);
+
+        ShortcutBindingConflict conflict = Assert.Single(resolution.Conflicts);
+        Assert.Equal("Ctrl+Alt+S", conflict.NormalizedBinding);
+
+        Assert.Equal(
+            ["settings", "command_assist_help"],
+            conflict.Bindings.Select(binding => binding.CommandId).ToArray());
+        Assert.Equal(
+            [ShortcutScope.App, ShortcutScope.CommandAssist],
+            conflict.Bindings.Select(binding => binding.Scope).ToArray());
+        Assert.All(conflict.Bindings, binding => Assert.Equal("Ctrl+Alt+S", binding.Binding));
+    }
+
+    [Fact]
+    public void Normalize_TreatsOemPlusNameAndAliasAsSameBinding()
+    {
+        Assert.Equal(
+            ShortcutNormalizer.Normalize("Ctrl+OemPlus"),
+            ShortcutNormalizer.Normalize("Ctrl+Plus"));
+    }
+
+    [Theory]
+    [InlineData("Ctrl++", "Ctrl+OemPlus")]
+    [InlineData("Ctrl+-", "Ctrl+OemMinus")]
+    public void Normalize_RewritesTrailingSymbolShortcutSyntax(string shortcut, string expected)
+    {
+        Assert.Equal(expected, ShortcutNormalizer.Normalize(shortcut));
+    }
+
+    [Theory]
+    [InlineData("Ctrl++A")]
+    [InlineData("+A")]
+    public void Normalize_WhenSeparatorUsageIsMalformed_ThrowsArgumentException(string shortcut)
+    {
+        Assert.Throws<ArgumentException>(() => ShortcutNormalizer.Normalize(shortcut));
+    }
+
+    [Fact]
+    public void Normalize_WhenKeyTokenIsUnknown_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => ShortcutNormalizer.Normalize("Ctrl+LaunchMissiles"));
+    }
+
+    [Theory]
+    [InlineData("Ctrl+Ctrl+A")]
+    [InlineData("Alt+Alt+S")]
+    [InlineData("Shift+Shift+Tab")]
+    public void Normalize_WhenModifierIsRepeated_ThrowsArgumentException(string shortcut)
+    {
+        Assert.Throws<ArgumentException>(() => ShortcutNormalizer.Normalize(shortcut));
+    }
+
+    [Fact]
+    public void ShortcutDefinition_WhenCommandIdIsEmpty_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => new ShortcutDefinition("", ShortcutScope.App, "Ctrl+,"));
+    }
+
+    [Fact]
+    public void ShortcutBindingRecord_WhenBindingIsEmpty_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => new ShortcutBindingRecord("settings", ShortcutScope.App, ""));
+    }
+}

--- a/tests/NovaTerminal.Tests/Core/ShortcutBindingResolverTests.cs
+++ b/tests/NovaTerminal.Tests/Core/ShortcutBindingResolverTests.cs
@@ -85,4 +85,25 @@ public sealed class ShortcutBindingResolverTests
     {
         Assert.Throws<ArgumentException>(() => new ShortcutBindingRecord("settings", ShortcutScope.App, ""));
     }
+
+    [Fact]
+    public void Resolve_WhenOverrideIsInvalid_FallsBackToDefaultBinding()
+    {
+        ShortcutDefinition[] definitions =
+        [
+            new("settings", ShortcutScope.App, "Ctrl+,"),
+            new("command_assist_help", ShortcutScope.CommandAssist, "Ctrl+Shift+H"),
+        ];
+
+        Dictionary<string, string> overrides = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["settings"] = "Ctrl+LaunchMissiles",
+        };
+
+        ShortcutBindingResolution resolution = ShortcutBindingResolver.Resolve(definitions, overrides);
+
+        Assert.True(resolution.IsValid);
+        ShortcutBindingRecord settings = Assert.Single(resolution.Bindings, binding => binding.CommandId == "settings");
+        Assert.Equal("Ctrl+,", settings.Binding);
+    }
 }

--- a/tests/NovaTerminal.Tests/Core/ShortcutCatalogTests.cs
+++ b/tests/NovaTerminal.Tests/Core/ShortcutCatalogTests.cs
@@ -1,0 +1,28 @@
+using NovaTerminal.Core.Shortcuts;
+
+namespace NovaTerminal.Tests.Core;
+
+public sealed class ShortcutCatalogTests
+{
+    [Fact]
+    public void GetDefinitions_IncludesSettingsPaneAndCommandAssistBindings()
+    {
+        IReadOnlyList<ShortcutDefinition> definitions = ShortcutCatalog.GetDefinitions();
+
+        Assert.Contains(definitions, definition => definition.CommandId == "settings" && definition.Scope == ShortcutScope.App);
+        Assert.Contains(definitions, definition => definition.CommandId == "command_assist_toggle" && definition.Scope == ShortcutScope.CommandAssist);
+        Assert.Contains(definitions, definition => definition.CommandId == "find" && definition.Scope == ShortcutScope.Pane);
+    }
+
+    [Fact]
+    public void GetEntries_ExposesDisplayMetadataForSettingsBinding()
+    {
+        ShortcutCatalogEntry settingsEntry = Assert.Single(
+            ShortcutCatalog.GetEntries(),
+            entry => entry.CommandId == "settings");
+
+        Assert.Equal("Settings", settingsEntry.Title);
+        Assert.Equal("General", settingsEntry.Category);
+        Assert.Equal("Ctrl+,", settingsEntry.DefaultBinding);
+    }
+}

--- a/tests/NovaTerminal.Tests/Core/ShortcutMatcherTests.cs
+++ b/tests/NovaTerminal.Tests/Core/ShortcutMatcherTests.cs
@@ -1,0 +1,31 @@
+using Avalonia.Input;
+using NovaTerminal.Core.Shortcuts;
+
+namespace NovaTerminal.Tests.Core;
+
+public sealed class ShortcutMatcherTests
+{
+    [Fact]
+    public void Matches_AcceptsSettingsShortcutCommaBinding()
+    {
+        var args = new KeyEventArgs
+        {
+            Key = Key.OemComma,
+            KeyModifiers = KeyModifiers.Control,
+        };
+
+        Assert.True(ShortcutMatcher.Matches(args, "Ctrl+,"));
+    }
+
+    [Fact]
+    public void Matches_RejectsExtraModifiers()
+    {
+        var args = new KeyEventArgs
+        {
+            Key = Key.OemComma,
+            KeyModifiers = KeyModifiers.Control | KeyModifiers.Shift,
+        };
+
+        Assert.False(ShortcutMatcher.Matches(args, "Ctrl+,"));
+    }
+}


### PR DESCRIPTION
## Summary
- add a Shortcuts settings tab for app, pane, and Command Assist bindings with global duplicate blocking and reset/search support
- persist command palette usage and rank the empty-state list by most-used commands, with usage also breaking search-result ties
- wire stable command ids and restore the Connections command in the palette with regression coverage

## Test Plan
- [x] dotnet test tests\NovaTerminal.Tests\NovaTerminal.Tests.csproj --filter "FullyQualifiedName~MainWindowStartupTests|FullyQualifiedName~SettingsWindow|FullyQualifiedName~Shortcut|FullyQualifiedName~CommandPalette" -p:SKIP_RUST_NATIVE_BUILD=1 -p:SkipCliShim=true