### PR TITLE
Re-enable shell-integration tests on CI via PTY-backed harness (#71)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,12 +212,13 @@ jobs:
         run: dotnet restore
 
       # The shell-integration tests under tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration
-      # spawn real bash/zsh/fish via the production PTY path. bash and zsh are
-      # preinstalled on ubuntu-latest; fish is not, so install it here so
-      # FishShellIntegrationTests actually runs instead of skipping.
-      - name: Install fish (Linux)
+      # spawn real bash/zsh/fish via the production PTY path. bash is
+      # preinstalled on ubuntu-latest; zsh and fish are not on ubuntu-24.04,
+      # so install them here -- otherwise ZshShellIntegrationTests and
+      # FishShellIntegrationTests skip instead of running.
+      - name: Install zsh and fish (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y fish
+        run: sudo apt-get update && sudo apt-get install -y zsh fish
 
       - name: Test (unit)
         # Keep the unit lane focused on deterministic tests; stress tests run in nightly,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,14 @@ jobs:
       - name: Restore
         run: dotnet restore
 
+      # The shell-integration tests under tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration
+      # spawn real bash/zsh/fish via the production PTY path. bash and zsh are
+      # preinstalled on ubuntu-latest; fish is not, so install it here so
+      # FishShellIntegrationTests actually runs instead of skipping.
+      - name: Install fish (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y fish
+
       - name: Test (unit)
         # Keep the unit lane focused on deterministic tests; stress tests run in nightly,
         # and shared golden PNGs are currently only stable against the checked-in baselines on Windows.

--- a/src/NovaTerminal.App/native/src/lib.rs
+++ b/src/NovaTerminal.App/native/src/lib.rs
@@ -177,6 +177,44 @@ pub struct PtyState {
     pub child: Mutex<Option<Box<dyn portable_pty::Child + Send>>>,
 }
 
+// Tokenize an argument string the way a POSIX-ish shell would: split on
+// whitespace, but keep a double-quoted region as a single token and drop
+// the surrounding quotes. Backslash escapes inside quotes are passed
+// through (Windows paths use backslashes that should remain literal).
+// Good enough for CommandBuilder's argv-style consumption -- we are not
+// running a real shell here, just rebuilding argv from the test caller's
+// pre-formatted argument string.
+fn split_args(input: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    let mut started = false;
+    for ch in input.chars() {
+        if in_quotes {
+            if ch == '"' {
+                in_quotes = false;
+            } else {
+                current.push(ch);
+            }
+        } else if ch == '"' {
+            in_quotes = true;
+            started = true;
+        } else if ch.is_whitespace() {
+            if started {
+                out.push(std::mem::take(&mut current));
+                started = false;
+            }
+        } else {
+            current.push(ch);
+            started = true;
+        }
+    }
+    if started {
+        out.push(current);
+    }
+    out
+}
+
 fn parse_env_overrides(envs: *const c_char) -> Vec<(String, String)> {
     if envs.is_null() {
         return Vec::new();
@@ -251,23 +289,33 @@ fn pty_spawn_impl(
 
     #[cfg(windows)]
     {
-        if let Ok((reader, writer, h_pc, h_process)) = win32::spawn_with_passthrough(
-            cmd_str.as_ref(),
-            args_str.as_ref().map(|s| s.as_ref()),
-            cwd_str.as_ref().map(|s| s.as_ref()),
-            cols,
-            rows,
-            extra_envs,
-        ) {
-            let state = PtyState {
-                reader: Mutex::new(reader),
-                writer: Mutex::new(writer),
-                h_pc: Some(h_pc),
-                h_process: Some(h_process),
-                master: Mutex::new(None),
-                child: Mutex::new(None),
-            };
-            return Arc::into_raw(Arc::new(state)) as *mut PtyState;
+        // Allow callers (notably the xunit test runner, where the
+        // PSEUDOCONSOLE_PASSTHROUGH path silently swallows the child's
+        // stdout when the host has no real console) to force the
+        // portable-pty ConPTY path via env var. Production never sets
+        // this so behavior is unchanged for the app.
+        let skip_passthrough = std::env::var("NOVA_PTY_NO_PASSTHROUGH")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        if !skip_passthrough {
+            if let Ok((reader, writer, h_pc, h_process)) = win32::spawn_with_passthrough(
+                cmd_str.as_ref(),
+                args_str.as_ref().map(|s| s.as_ref()),
+                cwd_str.as_ref().map(|s| s.as_ref()),
+                cols,
+                rows,
+                extra_envs,
+            ) {
+                let state = PtyState {
+                    reader: Mutex::new(reader),
+                    writer: Mutex::new(writer),
+                    h_pc: Some(h_pc),
+                    h_process: Some(h_process),
+                    master: Mutex::new(None),
+                    child: Mutex::new(None),
+                };
+                return Arc::into_raw(Arc::new(state)) as *mut PtyState;
+            }
         }
     }
 
@@ -287,7 +335,12 @@ fn pty_spawn_impl(
 
     let mut cmd_builder = CommandBuilder::new(cmd_str.as_ref());
     if let Some(a) = args_str {
-        for arg in a.split_whitespace() {
+        // Plain split_whitespace would keep the surrounding " on a quoted
+        // path like `--rcfile "C:\path with space\foo"`, which then breaks
+        // the child (it tries to open a literal `"C:\path…` file). Parse
+        // the argument string respecting double quotes so the child sees
+        // the same argv it would from a shell.
+        for arg in split_args(a.as_ref()) {
             if !arg.is_empty() {
                 cmd_builder.arg(arg);
             }

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -74,6 +74,16 @@ namespace NovaTerminal.Core
             }
         }
 
+        public int? Pid
+        {
+            get
+            {
+                if (_ptyState == IntPtr.Zero) return null;
+                int pid = Native.pty_get_pid(_ptyState);
+                return pid > 0 ? pid : null;
+            }
+        }
+
         [StructLayout(LayoutKind.Sequential)]
         private struct PROCESSENTRY32
         {

--- a/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/BashShellIntegrationTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/BashShellIntegrationTests.cs
@@ -14,6 +14,7 @@ namespace NovaTerminal.Tests.CommandAssist.ShellIntegration.Integration;
 /// real ~/.bashrc is not sourced.
 /// </summary>
 [Trait("Category", "ShellIntegration")]
+[Collection(nameof(ShellIntegrationCollection))]
 public sealed class BashShellIntegrationTests : IDisposable
 {
     private readonly string _tempRoot;

--- a/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/BashShellIntegrationTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/BashShellIntegrationTests.cs
@@ -33,11 +33,6 @@ public sealed class BashShellIntegrationTests : IDisposable
 
     private HarnessResult RunBash(string stdin, string? extraInitLine = null)
     {
-        if (!ShellHarness.IsEnabled())
-        {
-            Assert.Skip("shell integration tests gated off on this runner (set NOVA_RUN_SHELL_INTEGRATION_TESTS=1 to enable)");
-        }
-
         string? bash = ShellHarness.FindBash();
         if (bash is null)
         {

--- a/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/FishShellIntegrationTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/FishShellIntegrationTests.cs
@@ -28,11 +28,6 @@ public sealed class FishShellIntegrationTests : IDisposable
 
     private HarnessResult RunFish(string stdin)
     {
-        if (!ShellHarness.IsEnabled())
-        {
-            Assert.Skip("shell integration tests gated off on this runner (set NOVA_RUN_SHELL_INTEGRATION_TESTS=1 to enable)");
-        }
-
         string? fish = ShellHarness.FindFish();
         if (fish is null)
         {

--- a/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/FishShellIntegrationTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/FishShellIntegrationTests.cs
@@ -9,6 +9,7 @@ namespace NovaTerminal.Tests.CommandAssist.ShellIntegration.Integration;
 /// generated <root>/fish/config.fish is the one loaded.
 /// </summary>
 [Trait("Category", "ShellIntegration")]
+[Collection(nameof(ShellIntegrationCollection))]
 public sealed class FishShellIntegrationTests : IDisposable
 {
     private readonly string _tempRoot;

--- a/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/ShellHarness.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/ShellHarness.cs
@@ -122,10 +122,12 @@ internal static class ShellHarness
         var capture = new StringBuilder();
         object sync = new();
         long lastOutputTicks = Environment.TickCount64;
+        using var firstPromptReady = new ManualResetEventSlim(false);
 
         parser.OnPromptReady = () =>
         {
             lock (sync) events.Add(new OscEvent("A", null));
+            firstPromptReady.Set();
         };
         parser.OnCommandAccepted = text =>
         {
@@ -223,11 +225,16 @@ internal static class ShellHarness
             }
         }, watcherCts.Token);
 
-        // Give the PTY a moment to settle and the bootstrap to start sourcing
-        // before we feed scripted input -- the read pipeline subscribes
-        // synchronously above, but the shell needs a few ms after spawn
-        // before it's ready to consume keystrokes deterministically.
-        Thread.Sleep(100);
+        // Wait for the bootstrap to fire its first OSC 133;A (prompt
+        // ready) before we feed scripted input. Without this, anything
+        // the system shell config does on the way in -- e.g. Ubuntu's
+        // /etc/zsh/zshrc running compinit and prompting "Ignore insecure
+        // directories? [y/n]" -- will consume our scripted stdin as the
+        // answer to its own prompt, leaving the shell wedged on an empty
+        // input buffer. Cap the wait at half the overall timeout so we
+        // still produce a useful diagnostic if the bootstrap never
+        // signals readiness.
+        firstPromptReady.Wait(TimeSpan.FromMilliseconds(timeoutSpan.TotalMilliseconds / 2));
 
         // Interactive shells (bash -i, zsh -i, fish -i) put the TTY into
         // readline-style raw mode where the Enter key is CR (\r), not LF

--- a/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/ShellHarness.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/ShellHarness.cs
@@ -122,12 +122,10 @@ internal static class ShellHarness
         var capture = new StringBuilder();
         object sync = new();
         long lastOutputTicks = Environment.TickCount64;
-        using var firstPromptReady = new ManualResetEventSlim(false);
 
         parser.OnPromptReady = () =>
         {
             lock (sync) events.Add(new OscEvent("A", null));
-            firstPromptReady.Set();
         };
         parser.OnCommandAccepted = text =>
         {
@@ -225,16 +223,12 @@ internal static class ShellHarness
             }
         }, watcherCts.Token);
 
-        // Wait for the bootstrap to fire its first OSC 133;A (prompt
-        // ready) before we feed scripted input. Without this, anything
-        // the system shell config does on the way in -- e.g. Ubuntu's
-        // /etc/zsh/zshrc running compinit and prompting "Ignore insecure
-        // directories? [y/n]" -- will consume our scripted stdin as the
-        // answer to its own prompt, leaving the shell wedged on an empty
-        // input buffer. Cap the wait short (2s) since under contention
-        // the PTY ProcessLoop can be slow to fire the callback; if we
-        // miss it we just proceed and let the PTY queue the input.
-        firstPromptReady.Wait(TimeSpan.FromSeconds(2));
+        // Brief settle period before we feed scripted input. Zsh's
+        // compinit-prompting issue on Ubuntu is already neutralized by
+        // ZshShellIntegrationTests passing --no-global-rcs, so we don't
+        // need a synchronous wait-for-prompt-ready here -- which adds
+        // its own thread-scheduling sensitivity under CI parallelism.
+        Thread.Sleep(200);
 
         // Interactive shells (bash -i, zsh -i, fish -i) put the TTY into
         // readline-style raw mode where the Enter key is CR (\r), not LF

--- a/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/ShellHarness.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/ShellHarness.cs
@@ -121,6 +121,7 @@ internal static class ShellHarness
         var events = new List<OscEvent>();
         var capture = new StringBuilder();
         object sync = new();
+        long lastOutputTicks = Environment.TickCount64;
 
         parser.OnPromptReady = () =>
         {
@@ -162,6 +163,7 @@ internal static class ShellHarness
         {
             lock (sync) capture.Append(text);
             parser.Process(text);
+            Volatile.Write(ref lastOutputTicks, Environment.TickCount64);
         };
         session.OnExit += code => exitSignal.TrySetResult(code);
 
@@ -177,7 +179,7 @@ internal static class ShellHarness
         // keeps retrying forever and OnExit never fires. Watch the actual
         // OS process by PID and signal exit ourselves once it's gone.
         var watcherCts = new CancellationTokenSource();
-        _ = Task.Run(() =>
+        _ = Task.Run(async () =>
         {
             int? trackedPid = null;
             for (int i = 0; i < 30 && trackedPid is null; i++)
@@ -186,31 +188,38 @@ internal static class ShellHarness
                 trackedPid = session.Pid;
                 if (trackedPid is null)
                 {
-                    try { Task.Delay(100, watcherCts.Token).Wait(); }
-                    catch { return; }
+                    try { await Task.Delay(100, watcherCts.Token).ConfigureAwait(false); }
+                    catch (OperationCanceledException) { return; }
                 }
             }
             if (trackedPid is null) return;
-            while (!watcherCts.Token.IsCancellationRequested)
+
+            System.Diagnostics.Process p;
+            try { p = System.Diagnostics.Process.GetProcessById(trackedPid.Value); }
+            catch (ArgumentException) { exitSignal.TrySetResult(0); return; }
+            using (p)
             {
-                try
+                while (!watcherCts.Token.IsCancellationRequested)
                 {
-                    using var p = System.Diagnostics.Process.GetProcessById(trackedPid.Value);
-                    if (p.HasExited)
+                    try
                     {
-                        exitSignal.TrySetResult(p.ExitCode);
+                        p.Refresh();
+                        if (p.HasExited)
+                        {
+                            exitSignal.TrySetResult(p.ExitCode);
+                            return;
+                        }
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        // Process handle is gone -- treat as a clean exit.
+                        exitSignal.TrySetResult(0);
                         return;
                     }
+                    catch { /* transient query failure; retry next tick */ }
+                    try { await Task.Delay(100, watcherCts.Token).ConfigureAwait(false); }
+                    catch (OperationCanceledException) { return; }
                 }
-                catch (ArgumentException)
-                {
-                    // Process is gone -- treat as a clean exit.
-                    exitSignal.TrySetResult(0);
-                    return;
-                }
-                catch { /* transient query failure; retry next tick */ }
-                try { Task.Delay(100, watcherCts.Token).Wait(); }
-                catch { return; }
             }
         }, watcherCts.Token);
 
@@ -238,11 +247,25 @@ internal static class ShellHarness
                 $"Shell {shellPath} did not exit within {timeoutSpan.TotalSeconds:F1}s");
         }
 
-        // Final flush window: ProcessLoop drains the output queue serially,
-        // so by the time OnExit fires every chunk has been delivered to the
-        // parser. A tiny sleep papers over the residual scheduling gap
-        // between the last OnOutputReceived call and our snapshot read.
-        Thread.Sleep(25);
+        // Drain window: the exit signal can fire from the PID watcher
+        // before the PTY ReadLoop -> ProcessLoop -> parser pipeline has
+        // delivered the last few bytes (which may contain the final OSC
+        // 133;C / D markers). Sleeping a fixed N ms is a race on a loaded
+        // CI runner; instead wait until OnOutputReceived has been quiet
+        // for `drainIdleMs` consecutive ms, capped by `drainCapMs` overall
+        // so we don't hang forever if the shell decides to keep printing
+        // after the child reaps.
+        const long drainIdleMs = 200;
+        const long drainCapMs = 2000;
+        long drainStart = Environment.TickCount64;
+        while (true)
+        {
+            long now = Environment.TickCount64;
+            long sinceOutput = now - Volatile.Read(ref lastOutputTicks);
+            long sinceDrainStart = now - drainStart;
+            if (sinceOutput >= drainIdleMs || sinceDrainStart >= drainCapMs) break;
+            Thread.Sleep(25);
+        }
 
         string captured;
         OscEvent[] eventsSnapshot;

--- a/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/ShellHarness.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/ShellHarness.cs
@@ -231,10 +231,10 @@ internal static class ShellHarness
         // /etc/zsh/zshrc running compinit and prompting "Ignore insecure
         // directories? [y/n]" -- will consume our scripted stdin as the
         // answer to its own prompt, leaving the shell wedged on an empty
-        // input buffer. Cap the wait at half the overall timeout so we
-        // still produce a useful diagnostic if the bootstrap never
-        // signals readiness.
-        firstPromptReady.Wait(TimeSpan.FromMilliseconds(timeoutSpan.TotalMilliseconds / 2));
+        // input buffer. Cap the wait short (2s) since under contention
+        // the PTY ProcessLoop can be slow to fire the callback; if we
+        // miss it we just proceed and let the PTY queue the input.
+        firstPromptReady.Wait(TimeSpan.FromSeconds(2));
 
         // Interactive shells (bash -i, zsh -i, fish -i) put the TTY into
         // readline-style raw mode where the Enter key is CR (\r), not LF

--- a/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/ShellHarness.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/ShellHarness.cs
@@ -150,7 +150,7 @@ internal static class ShellHarness
         var exitSignal = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
         TimeSpan timeoutSpan = timeout ?? TimeSpan.FromSeconds(15);
 
-        using var session = new RustPtySession(
+        var session = new RustPtySession(
             shellPath,
             cols: 120,
             rows: 30,
@@ -237,14 +237,61 @@ internal static class ShellHarness
         string ttyInput = scriptedStdin.Replace("\n", "\r");
         session.SendInput(ttyInput);
 
-        bool exited = exitSignal.Task.Wait(timeoutSpan);
-        watcherCts.Cancel();
+        bool exited;
+        try
+        {
+            exited = exitSignal.Task.Wait(timeoutSpan);
+            watcherCts.Cancel();
+
+            // Belt-and-suspenders: if the shell hasn't terminated on its
+            // own (timeout, or assertion-failure path where exitSignal
+            // fires because we observed exit but the OS process is somehow
+            // still around), kill it explicitly. On Linux, closing the
+            // master fd in pty_close() does NOT unblock RustPtySession's
+            // ReadLoop thread that's already blocked in pty_read on that
+            // same fd; only the child closing its slave end produces the
+            // EOF that lets ReadLoop terminate. Without this, a single
+            // hung zsh `-i` cascades into the xunit host being unable to
+            // shut down, which we observed as a 14-minute silent stall.
+            try
+            {
+                int? pid = session.Pid;
+                if (pid is int p)
+                {
+                    using var proc = System.Diagnostics.Process.GetProcessById(p);
+                    if (!proc.HasExited) proc.Kill(entireProcessTree: true);
+                }
+            }
+            catch { /* process already gone or unkillable -- nothing more we can do */ }
+        }
+        catch
+        {
+            session.Dispose();
+            throw;
+        }
+
         if (!exited)
         {
-            // Dispose() (via using) will kill the child on scope exit;
-            // throw so the test sees a clear failure.
+            string partial;
+            int eventCount;
+            lock (sync)
+            {
+                partial = capture.ToString();
+                eventCount = events.Count;
+            }
+            session.Dispose();
+            var dump = new StringBuilder(partial.Length * 2);
+            foreach (char c in partial)
+            {
+                if (c >= 0x20 && c < 0x7F) dump.Append(c);
+                else if (c == '\n') dump.Append("\\n");
+                else if (c == '\r') dump.Append("\\r");
+                else if (c == '\t') dump.Append("\\t");
+                else dump.Append("\\x").Append(((int)c).ToString("X2"));
+            }
             throw new TimeoutException(
-                $"Shell {shellPath} did not exit within {timeoutSpan.TotalSeconds:F1}s");
+                $"Shell {shellPath} did not exit within {timeoutSpan.TotalSeconds:F1}s. " +
+                $"events={eventCount}, captured ({partial.Length} chars): {dump}");
         }
 
         // Drain window: the exit signal can fire from the PID watcher
@@ -274,6 +321,7 @@ internal static class ShellHarness
             captured = capture.ToString();
             eventsSnapshot = events.ToArray();
         }
+        session.Dispose();
 
         // PTY merges stdout and stderr onto the same master fd, so there is
         // no way to separate the two streams here. Expose the combined

--- a/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/ShellHarness.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/ShellHarness.cs
@@ -1,5 +1,5 @@
-using System.Diagnostics;
 using System.Text;
+using NovaTerminal.Core;
 
 namespace NovaTerminal.Tests.CommandAssist.ShellIntegration.Integration;
 
@@ -35,45 +35,16 @@ internal sealed record OscEvent(string Kind, string? Payload)
 }
 
 /// <summary>
-/// Spawns a real shell with our generated bootstrap and captures the OSC
-/// lifecycle the shell emits. Intended for integration coverage that
-/// the substring-based bootstrap-builder tests cannot reach.
+/// Spawns a real shell with our generated bootstrap through the production
+/// PTY path (<see cref="RustPtySession"/> + <see cref="AnsiParser"/>) and
+/// captures the OSC lifecycle the shell emits via parser callbacks. This
+/// exercises ConPTY/portable-pty end-to-end so the shell sees a real TTY
+/// and bash -i / zsh -i / fish -i behave identically to a user terminal --
+/// unlike the previous Process.Start + piped-stdin scheme, which hung
+/// headless CI runners by leaving job-control-confused bash children alive.
 /// </summary>
 internal static class ShellHarness
 {
-    /// <summary>
-    /// Gate for the real-shell integration tests. They reliably pass on
-    /// developer machines (Git Bash on Windows, native bash on Linux/macOS
-    /// with a real terminal context) but on headless CI runners bash -i
-    /// with piped stdin can leak shell processes that never exit, hanging
-    /// the entire job until the 15-minute global timeout fires. We default
-    /// to "skip on CI, run elsewhere" so the tests still catch regressions
-    /// on dev boxes but never block CI; an explicit opt-in
-    /// (NOVA_RUN_SHELL_INTEGRATION_TESTS=1) lets us re-enable them once a
-    /// proper CI-side fix lands.
-    ///
-    /// TODO(#71): Replace the underlying Process.Start + piped-stdin
-    /// harness with a RustPtySession-backed implementation so bash sees a
-    /// real PTY on CI. When that lands, this gate can be deleted.
-    /// </summary>
-    public static bool IsEnabled()
-    {
-        string? explicitOptIn = Environment.GetEnvironmentVariable("NOVA_RUN_SHELL_INTEGRATION_TESTS");
-        if (explicitOptIn == "1" ||
-            string.Equals(explicitOptIn, "true", StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        string? ci = Environment.GetEnvironmentVariable("CI");
-        if (string.Equals(ci, "true", StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return true;
-    }
-
     public static string? FindBash()
     {
         // Prefer Git Bash on Windows so we get a real GNU bash, not WSL's
@@ -119,101 +90,173 @@ internal static class ShellHarness
         IReadOnlyDictionary<string, string>? environmentOverrides = null,
         TimeSpan? timeout = null)
     {
-        var psi = new ProcessStartInfo
-        {
-            FileName = shellPath,
-            Arguments = arguments,
-            RedirectStandardInput = true,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-        };
+        // On Windows, the rusty_pty default path uses ConPTY with the
+        // PSEUDOCONSOLE_PASSTHROUGH flag set. That mode silently drops the
+        // child's stdout when the calling process has no real attached
+        // console -- exactly the case for xunit test hosts -- so we opt the
+        // native side over to the portable-pty fallback (a plain ConPTY
+        // without the passthrough flag) for the duration of this call.
+        // Production (Avalonia app with a real GUI process) does not set
+        // this and continues to use the original passthrough path.
+        Environment.SetEnvironmentVariable("NOVA_PTY_NO_PASSTHROUGH", "1");
 
+        // Force a predictable locale so OSC output isn't disturbed by
+        // user-locale variations on test runners.
+        var env = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["LC_ALL"] = "C",
+            ["LANG"] = "C",
+        };
         if (environmentOverrides is not null)
         {
             foreach (var kv in environmentOverrides)
             {
-                psi.Environment[kv.Key] = kv.Value;
+                env[kv.Key] = kv.Value;
             }
         }
 
-        // Force a predictable locale so OSC output isn't disturbed by
-        // user-locale variations on test runners.
-        psi.Environment["LC_ALL"] = "C";
-        psi.Environment["LANG"] = "C";
+        var buffer = new TerminalBuffer(120, 30);
+        var parser = new AnsiParser(buffer, forceConPtyFiltering: false);
 
-        using var proc = Process.Start(psi) ?? throw new InvalidOperationException($"Failed to start {shellPath}");
-        proc.StandardInput.Write(scriptedStdin);
-        proc.StandardInput.Close();
-
-        var stdoutTask = proc.StandardOutput.ReadToEndAsync();
-        var stderrTask = proc.StandardError.ReadToEndAsync();
-
-        if (!proc.WaitForExit((int)(timeout ?? TimeSpan.FromSeconds(15)).TotalMilliseconds))
-        {
-            try { proc.Kill(entireProcessTree: true); } catch { }
-            throw new TimeoutException($"Shell {shellPath} did not exit within timeout");
-        }
-
-        string stdout = stdoutTask.GetAwaiter().GetResult();
-        string stderr = stderrTask.GetAwaiter().GetResult();
-        var events = ParseOsc(stdout);
-        return new HarnessResult(stdout, stderr, proc.ExitCode, events);
-    }
-
-    /// <summary>
-    /// Minimal OSC parser for test consumption. Recognizes ESC ] ... BEL
-    /// and ESC ] ... ESC \ terminators. Only emits events for OSC 7 and
-    /// OSC 133;{A,B,C,D}; ignores other OSC traffic.
-    /// </summary>
-    public static IReadOnlyList<OscEvent> ParseOsc(string stdout)
-    {
         var events = new List<OscEvent>();
-        int i = 0;
-        while (i < stdout.Length)
+        var capture = new StringBuilder();
+        object sync = new();
+
+        parser.OnPromptReady = () =>
         {
-            if (stdout[i] != '\x1b' || i + 1 >= stdout.Length || stdout[i + 1] != ']')
+            lock (sync) events.Add(new OscEvent("A", null));
+        };
+        parser.OnCommandAccepted = text =>
+        {
+            // Re-encode to base64 so OscEvent.DecodedCommand round-trips
+            // back to the same text -- matches the on-the-wire format the
+            // bootstrap emits and keeps the OscEvent contract uniform.
+            string b64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(text));
+            lock (sync) events.Add(new OscEvent("C", b64));
+        };
+        parser.OnCommandFinishedDetailed = (exit, dur) =>
+        {
+            string payload = $"{exit?.ToString() ?? string.Empty};{dur?.ToString() ?? string.Empty}";
+            lock (sync) events.Add(new OscEvent("D", payload));
+        };
+        parser.OnWorkingDirectoryChanged = cwd =>
+        {
+            // AnsiParser hands us the decoded path; re-prepend the scheme so
+            // tests that look for Payload.StartsWith("file://") still match.
+            lock (sync) events.Add(new OscEvent("7", "file://" + cwd));
+        };
+
+        var exitSignal = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        TimeSpan timeoutSpan = timeout ?? TimeSpan.FromSeconds(15);
+
+        using var session = new RustPtySession(
+            shellPath,
+            cols: 120,
+            rows: 30,
+            args: arguments,
+            cwd: null,
+            skipPowerShellPostLaunchInit: true,
+            environmentOverrides: env);
+
+        session.OnOutputReceived += text =>
+        {
+            lock (sync) capture.Append(text);
+            parser.Process(text);
+        };
+        session.OnExit += code => exitSignal.TrySetResult(code);
+
+        // Production TerminalPane wires parser responses (cursor-position
+        // DSR replies, device-attribute replies, etc.) back to the session.
+        // Without this, ConPTY can hang waiting on \x1B[6n at startup and
+        // the child never gets to write anything.
+        parser.OnResponse = resp => session.SendInput(resp);
+
+        // RustPtySession.ReadLoop breaks out only when pty_read returns 0
+        // (clean EOF). On Windows ConPTY the master read often errors out
+        // (-1) after the child exits instead of returning 0, so ReadLoop
+        // keeps retrying forever and OnExit never fires. Watch the actual
+        // OS process by PID and signal exit ourselves once it's gone.
+        var watcherCts = new CancellationTokenSource();
+        _ = Task.Run(() =>
+        {
+            int? trackedPid = null;
+            for (int i = 0; i < 30 && trackedPid is null; i++)
             {
-                i++;
-                continue;
-            }
-
-            int start = i + 2;
-            int end = start;
-            while (end < stdout.Length)
-            {
-                char c = stdout[end];
-                if (c == '\x07') break;
-                if (c == '\x1b' && end + 1 < stdout.Length && stdout[end + 1] == '\\') break;
-                end++;
-            }
-
-            if (end >= stdout.Length) break;
-
-            string body = stdout[start..end];
-            i = end + (stdout[end] == '\x1b' ? 2 : 1);
-
-            // OSC 7: cwd notification, e.g. "7;file://host/path"
-            if (body.StartsWith("7;"))
-            {
-                events.Add(new OscEvent("7", body[2..]));
-                continue;
-            }
-
-            // OSC 133 lifecycle: "133;A", "133;B", "133;C[;payload]", "133;D[;exit[;dur]]"
-            if (body.StartsWith("133;"))
-            {
-                string rest = body[4..];
-                if (rest.Length == 0) continue;
-                char kind = rest[0];
-                if (kind is 'A' or 'B' or 'C' or 'D')
+                if (watcherCts.Token.IsCancellationRequested) return;
+                trackedPid = session.Pid;
+                if (trackedPid is null)
                 {
-                    string? payload = rest.Length > 2 && rest[1] == ';' ? rest[2..] : null;
-                    events.Add(new OscEvent(kind.ToString(), payload));
+                    try { Task.Delay(100, watcherCts.Token).Wait(); }
+                    catch { return; }
                 }
             }
+            if (trackedPid is null) return;
+            while (!watcherCts.Token.IsCancellationRequested)
+            {
+                try
+                {
+                    using var p = System.Diagnostics.Process.GetProcessById(trackedPid.Value);
+                    if (p.HasExited)
+                    {
+                        exitSignal.TrySetResult(p.ExitCode);
+                        return;
+                    }
+                }
+                catch (ArgumentException)
+                {
+                    // Process is gone -- treat as a clean exit.
+                    exitSignal.TrySetResult(0);
+                    return;
+                }
+                catch { /* transient query failure; retry next tick */ }
+                try { Task.Delay(100, watcherCts.Token).Wait(); }
+                catch { return; }
+            }
+        }, watcherCts.Token);
+
+        // Give the PTY a moment to settle and the bootstrap to start sourcing
+        // before we feed scripted input -- the read pipeline subscribes
+        // synchronously above, but the shell needs a few ms after spawn
+        // before it's ready to consume keystrokes deterministically.
+        Thread.Sleep(100);
+
+        // Interactive shells (bash -i, zsh -i, fish -i) put the TTY into
+        // readline-style raw mode where the Enter key is CR (\r), not LF
+        // (\n). Tests author scripted input as "echo hello\nexit 0\n" for
+        // readability; translate LF -> CR here so each line is actually
+        // submitted instead of sitting in the readline buffer forever.
+        string ttyInput = scriptedStdin.Replace("\n", "\r");
+        session.SendInput(ttyInput);
+
+        bool exited = exitSignal.Task.Wait(timeoutSpan);
+        watcherCts.Cancel();
+        if (!exited)
+        {
+            // Dispose() (via using) will kill the child on scope exit;
+            // throw so the test sees a clear failure.
+            throw new TimeoutException(
+                $"Shell {shellPath} did not exit within {timeoutSpan.TotalSeconds:F1}s");
         }
-        return events;
+
+        // Final flush window: ProcessLoop drains the output queue serially,
+        // so by the time OnExit fires every chunk has been delivered to the
+        // parser. A tiny sleep papers over the residual scheduling gap
+        // between the last OnOutputReceived call and our snapshot read.
+        Thread.Sleep(25);
+
+        string captured;
+        OscEvent[] eventsSnapshot;
+        lock (sync)
+        {
+            captured = capture.ToString();
+            eventsSnapshot = events.ToArray();
+        }
+
+        // PTY merges stdout and stderr onto the same master fd, so there is
+        // no way to separate the two streams here. Expose the combined
+        // capture under both fields: the existing error-pattern tests look
+        // for specific words ("command not found", "syntax error", "%N",
+        // etc.) which don't false-positive against normal PS1/echo traffic.
+        return new HarnessResult(captured, captured, exitSignal.Task.Result, eventsSnapshot);
     }
 }

--- a/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/ShellIntegrationCollection.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/ShellIntegrationCollection.cs
@@ -1,0 +1,13 @@
+namespace NovaTerminal.Tests.CommandAssist.ShellIntegration.Integration;
+
+/// <summary>
+/// All shell-integration test classes share this collection so xunit
+/// runs them sequentially. Each PTY session pins a ReadLoop + ProcessLoop
+/// thread; running multiple classes in parallel on a 2-core CI runner
+/// starves the ThreadPool and the AnsiParser callback that signals
+/// prompt-ready cannot be scheduled in time, causing cascading hangs.
+/// </summary>
+[CollectionDefinition(nameof(ShellIntegrationCollection), DisableParallelization = true)]
+public sealed class ShellIntegrationCollection
+{
+}

--- a/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/ZshShellIntegrationTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/ZshShellIntegrationTests.cs
@@ -9,6 +9,7 @@ namespace NovaTerminal.Tests.CommandAssist.ShellIntegration.Integration;
 /// .zshrc is the one loaded, mirroring the production launch plan.
 /// </summary>
 [Trait("Category", "ShellIntegration")]
+[Collection(nameof(ShellIntegrationCollection))]
 public sealed class ZshShellIntegrationTests : IDisposable
 {
     private readonly string _tempRoot;

--- a/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/ZshShellIntegrationTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/ZshShellIntegrationTests.cs
@@ -28,11 +28,6 @@ public sealed class ZshShellIntegrationTests : IDisposable
 
     private HarnessResult RunZsh(string stdin)
     {
-        if (!ShellHarness.IsEnabled())
-        {
-            Assert.Skip("shell integration tests gated off on this runner (set NOVA_RUN_SHELL_INTEGRATION_TESTS=1 to enable)");
-        }
-
         string? zsh = ShellHarness.FindZsh();
         if (zsh is null)
         {

--- a/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/ZshShellIntegrationTests.cs
+++ b/tests/NovaTerminal.Tests/CommandAssist/ShellIntegration/Integration/ZshShellIntegrationTests.cs
@@ -49,7 +49,14 @@ public sealed class ZshShellIntegrationTests : IDisposable
             ["HOME"] = _tempRoot,
         };
 
-        return ShellHarness.Run(zsh, "-i", stdin, env, TimeSpan.FromSeconds(20));
+        // `--no-global-rcs` skips /etc/zsh/* so the system zshrc doesn't run
+        // compinit on us. On a fresh CI runner compinit detects "insecure
+        // directories" and prompts `Ignore? [y/n]` BEFORE our bootstrap
+        // loads -- which then eats the first line of scripted stdin and
+        // leaves zsh wedged on an empty input buffer. With this flag only
+        // $ZDOTDIR/.zshrc (our bootstrap) is sourced, matching how the
+        // bash test isolates via --rcfile.
+        return ShellHarness.Run(zsh, "--no-global-rcs -i", stdin, env, TimeSpan.FromSeconds(20));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Replaces the `Process.Start` + piped-stdin harness in `ShellHarness.Run` with a `RustPtySession` + `AnsiParser` implementation. The shell sees a real TTY (ConPTY on Windows, portable-pty on Linux/macOS) so `bash -i` / `zsh -i` / `fish -i` no longer leave job-control-confused children behind that hung both ubuntu-latest and windows-latest CI jobs.
- OSC lifecycle is captured via parser callbacks (`OnPromptReady`, `OnCommandAccepted`, `OnCommandFinishedDetailed`, `OnWorkingDirectoryChanged`) instead of regex-scraping stdout.
- Drops the `ShellHarness.IsEnabled` / `NOVA_RUN_SHELL_INTEGRATION_TESTS` CI gate. Adds `apt install fish` to the ubuntu-latest unit job so `FishShellIntegrationTests` runs.

## Incidental native fixes the PTY harness exposed

- `portable-pty` fallback: previously split args on whitespace alone, so a quoted path (`--rcfile "C:\path\foo"`) arrived at the child with literal `"` chars. Now respects double-quoted regions.
- New `NOVA_PTY_NO_PASSTHROUGH=1` env opt-out for the Windows `PSEUDOCONSOLE_PASSTHROUGH` path -- that mode silently drops the child's stdout when the host has no real console (xunit). Production never sets it.
- `RustPtySession.Pid` accessor added; the test harness uses it to detect child exit directly, since ConPTY masters don't always EOF cleanly when the child exits.

Closes #71.

## Test plan

- [x] All 7 `BashShellIntegrationTests` pass locally on Windows (~4s)
- [x] `PtySmokeTests` and bootstrap-builder substring tests unaffected
- [ ] `BashShellIntegrationTests` pass on ubuntu-latest + windows-latest
- [ ] `ZshShellIntegrationTests` runs (not skipped) on ubuntu-latest
- [ ] `FishShellIntegrationTests` runs on ubuntu-latest after the new \`apt install fish\` step
- [ ] No orphan shell PIDs after the unit-tests job finishes on either OS

🤖 Generated with [Claude Code](https://claude.com/claude-code)