### PR TITLE
fix(hotkey): restore WndProc on teardown to stop ExecutionEngineException crash

### DIFF
--- a/src/NovaTerminal.App/Core/GlobalHotkey.cs
+++ b/src/NovaTerminal.App/Core/GlobalHotkey.cs
@@ -20,6 +20,7 @@ namespace NovaTerminal.Core
 
         private IntPtr _handle;
         private bool _registered;
+        private bool _disposed;
 
         public event Action? OnHotkeyPressed;
 
@@ -60,10 +61,39 @@ namespace NovaTerminal.Core
         public void SetupHook()
         {
             if (_handle == IntPtr.Zero || !OperatingSystem.IsWindows()) return;
+            if (_oldWndProc != IntPtr.Zero) return; // already hooked
 
-            _wndProcDelegate = WndProc; // Keep reference to prevent GC
+            // _wndProcDelegate must stay rooted for as long as the window's WNDPROC slot
+            // points at its thunk. It is a field, so it lives as long as this instance does.
+            // RemoveHook() restores the original WNDPROC *before* this instance (and the
+            // delegate) can be collected — see the comment there for why that ordering is
+            // load-bearing.
+            _wndProcDelegate = WndProc;
             IntPtr newWndProcPtr = Marshal.GetFunctionPointerForDelegate(_wndProcDelegate);
             _oldWndProc = SetWindowLongPtr(_handle, GWLP_WNDPROC, newWndProcPtr);
+        }
+
+        private void RemoveHook()
+        {
+            // Restore the original window procedure BEFORE dropping the managed delegate.
+            //
+            // Skipping this was a confirmed crash (ExecutionEngineException on the
+            // GlobalHotkey.WndProc -> CallWindowProc frame, captured in a WER dump): on
+            // window teardown the WNDPROC slot still pointed at our managed thunk, and once
+            // this instance became collectable the GC freed _wndProcDelegate. The next window
+            // message Win32 dispatched (WM_DESTROY / WM_NCDESTROY, or a stray WM_HOTKEY) then
+            // called into freed memory and aborted the process with no managed exception.
+            // Heavy terminal output (e.g. an agent streaming) supplies the GC pressure that
+            // collects the delegate, which is why it surfaced as a random
+            // "window vanishes instantly".
+            if (_handle == IntPtr.Zero || _oldWndProc == IntPtr.Zero || !OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
+            SetWindowLongPtr(_handle, GWLP_WNDPROC, _oldWndProc);
+            _oldWndProc = IntPtr.Zero;
+            _wndProcDelegate = null;
         }
 
         private IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
@@ -71,7 +101,19 @@ namespace NovaTerminal.Core
             const int WM_HOTKEY = 0x0312;
             if (msg == WM_HOTKEY && wParam.ToInt32() == HOTKEY_ID)
             {
-                OnHotkeyPressed?.Invoke();
+                // An exception escaping a reverse-P/Invoke WndProc unwinds into native Win32
+                // (DispatchMessage), which is undefined behavior and crashes the process.
+                // Swallow handler exceptions at this boundary; toggling visibility is
+                // best-effort and must never take the app down.
+                try
+                {
+                    OnHotkeyPressed?.Invoke();
+                }
+                catch
+                {
+                    // Intentionally ignored — see comment above.
+                }
+
                 return IntPtr.Zero; // Handled
             }
 
@@ -93,7 +135,11 @@ namespace NovaTerminal.Core
 
         public void Dispose()
         {
+            if (_disposed) return;
+            _disposed = true;
+
             Unregister();
+            RemoveHook();
         }
     }
 }

--- a/src/NovaTerminal.App/Core/GlobalHotkey.cs
+++ b/src/NovaTerminal.App/Core/GlobalHotkey.cs
@@ -71,6 +71,16 @@ namespace NovaTerminal.Core
             _wndProcDelegate = WndProc;
             IntPtr newWndProcPtr = Marshal.GetFunctionPointerForDelegate(_wndProcDelegate);
             _oldWndProc = SetWindowLongPtr(_handle, GWLP_WNDPROC, newWndProcPtr);
+
+            // GWLP_WNDPROC always has a non-null previous value on a real window, so a zero
+            // return means SetWindowLongPtr failed: the WNDPROC slot was NOT replaced. Drop
+            // the delegate we just rooted — there is no installed thunk backing it, and
+            // RemoveHook (guarded on _oldWndProc != Zero) would otherwise never release it.
+            if (_oldWndProc == IntPtr.Zero)
+            {
+                _wndProcDelegate = null;
+                AppLogger.Log("[GlobalHotkey] SetWindowLongPtr(GWLP_WNDPROC) failed; hotkey hook not installed.");
+            }
         }
 
         private void RemoveHook()
@@ -103,15 +113,16 @@ namespace NovaTerminal.Core
             {
                 // An exception escaping a reverse-P/Invoke WndProc unwinds into native Win32
                 // (DispatchMessage), which is undefined behavior and crashes the process.
-                // Swallow handler exceptions at this boundary; toggling visibility is
-                // best-effort and must never take the app down.
+                // Catch at this boundary so a misbehaving handler can never take the app down;
+                // toggling visibility is best-effort. Log (don't silently swallow) so the
+                // failure is diagnosable in debug.log.
                 try
                 {
                     OnHotkeyPressed?.Invoke();
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // Intentionally ignored — see comment above.
+                    AppLogger.Log($"[GlobalHotkey] hotkey handler threw: {ex}");
                 }
 
                 return IntPtr.Zero; // Handled


### PR DESCRIPTION
## Summary

Fixes an intermittent hard crash where the NovaTerminal window **vanishes instantly** with no error dialog, no managed exception, and no NovaTerminal log entry. Root cause confirmed from a WER crash dump (not a guess).

## Root cause

`GlobalHotkey` (quake-mode toggle, `Alt+\``) subclasses the main window's `WNDPROC` via `SetWindowLongPtr` to catch `WM_HOTKEY`. Teardown only called `UnregisterHotKey` — it **never restored the original `WNDPROC`**. So on window teardown the `WNDPROC` slot still pointed at our managed delegate thunk; once the `GlobalHotkey` instance became collectable, the GC freed `_wndProcDelegate`, and the next dispatched window message (`WM_DESTROY` / `WM_NCDESTROY`, or a stray `WM_HOTKEY`) called into freed memory.

Dump evidence — faulting thread carried `System.ExecutionEngineException` with:

```
GlobalHotkey.CallWindowProc        (P/Invoke out)
IL_STUB_PInvoke
GlobalHotkey.WndProc
IL_STUB_ReversePInvoke
Avalonia.Win32 ... DispatchMessage
```

It surfaced while running a coding agent in a session because heavy terminal output supplies the GC pressure that collects the delegate. Only reproduces when **QuakeModeEnabled** is set (the sole caller of `GlobalHotkey`).

## Fix

- `RemoveHook()` restores the saved `_oldWndProc` via `SetWindowLongPtr` **before** nulling the delegate; `Dispose()` calls it (idempotent via a `_disposed` guard).
- `WndProc` wraps `OnHotkeyPressed` in try/catch so a handler exception can't unwind from the reverse-P/Invoke callback into native Win32 (also UB / a process-killer — a second latent crash path).
- `SetupHook()` guards against double-hooking.

## Scope

Pre-existing bug (dump predates the architecture-foundation work). Landing on its own branch off `main` so it can ship independently of PR #73.

## Test plan
- [ ] Build clean (`scripts/build.ps1 build src/NovaTerminal.App`) — verified locally, 0 errors
- [ ] Enable Quake mode, run a long agent session, close/reopen the window repeatedly — should no longer crash
- [ ] WER local-dump capture for `NovaTerminal.exe` is armed locally; a clean run produces no new `.dmp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)