### PR TITLE
chore(devloop): sidecar runner + build-provenance startup log

### DIFF
--- a/scripts/run-sidecar.ps1
+++ b/scripts/run-sidecar.ps1
@@ -1,0 +1,81 @@
+#!/usr/bin/env pwsh
+# Build NovaTerminal, mirror the fresh output to a fixed sidecar directory, and launch it
+# from there.
+#
+# Why this exists: running the app holds a lock on its DLLs, so a `dotnet build` of the main
+# repo fails with "file in use" while an instance is running. The workaround has been to copy
+# bin/ by hand and run the copy side-by-side — but a hand copy goes stale silently, and you
+# end up chasing bugs that were already fixed (see the GlobalHotkey crash incident: a stale
+# "net10.0 - Copy" binary still had the pre-fix WndProc bug).
+#
+# This script removes the manual step: every launch rebuilds and re-mirrors, so the sidecar
+# is always current, while the main repo bin stays unlocked for `dotnet build`/`dotnet test`.
+# The running build is identifiable in debug.log via the "Build: sha=... built=... path=..."
+# line (the sidecar path makes it obvious you're on the sidecar, not the repo output).
+#
+# Usage:
+#   scripts/run-sidecar.ps1                 # Debug build, build + mirror + launch
+#   scripts/run-sidecar.ps1 -Configuration Release
+#   scripts/run-sidecar.ps1 -NoBuild        # skip the build; just mirror current output + launch
+#   scripts/run-sidecar.ps1 -SidecarRoot D:\nova-sidecar   # override sidecar location
+
+[CmdletBinding()]
+param(
+    [ValidateSet('Debug', 'Release')]
+    [string]$Configuration = 'Debug',
+
+    [string]$TargetFramework = 'net10.0',
+
+    [switch]$NoBuild,
+
+    # Default sidecar lives outside the repo so it never collides with repo bin/obj globbing,
+    # IDE file watchers, or `git status`.
+    [string]$SidecarRoot = (Join-Path $env:LOCALAPPDATA 'NovaTerminal-sidecar')
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$appProject = Join-Path $repoRoot 'src\NovaTerminal.App'
+$sourceDir = Join-Path $appProject "bin\$Configuration\$TargetFramework"
+
+if (-not $NoBuild) {
+    Write-Host "[sidecar] Building NovaTerminal.App ($Configuration)..." -ForegroundColor Cyan
+    # Use the build wrapper so MSBuild/dotnet daemons don't outlive the build and hang on
+    # captured stdout (see CLAUDE.md). The main repo bin is free to build because the
+    # currently-running instance is the sidecar copy, not this output.
+    & (Join-Path $PSScriptRoot 'build.ps1') build $appProject -c $Configuration
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "[sidecar] Build failed (exit $LASTEXITCODE). Not launching."
+        exit $LASTEXITCODE
+    }
+}
+
+if (-not (Test-Path $sourceDir)) {
+    Write-Error "[sidecar] Build output not found: $sourceDir. Run without -NoBuild first."
+    exit 1
+}
+
+$destDir = Join-Path $SidecarRoot "$Configuration\$TargetFramework"
+New-Item -ItemType Directory -Force -Path $destDir | Out-Null
+
+Write-Host "[sidecar] Mirroring fresh output -> $destDir" -ForegroundColor Cyan
+# robocopy /MIR mirrors source to dest (adds new, updates changed, deletes stale). Exit codes
+# 0-7 are success (8+ are real errors); robocopy uses bit flags, not the usual 0=ok convention.
+robocopy $sourceDir $destDir /MIR /NJH /NJS /NDL /NP /R:2 /W:1 | Out-Null
+$rc = $LASTEXITCODE
+if ($rc -ge 8) {
+    Write-Error "[sidecar] robocopy failed (exit $rc)."
+    exit $rc
+}
+
+$exe = Join-Path $destDir 'NovaTerminal.exe'
+if (-not (Test-Path $exe)) {
+    Write-Error "[sidecar] Expected executable not found after mirror: $exe"
+    exit 1
+}
+
+$builtAt = (Get-Item $exe).LastWriteTime.ToString('yyyy-MM-dd HH:mm:ss')
+Write-Host "[sidecar] Launching $exe (built $builtAt)" -ForegroundColor Green
+# Launch detached so this shell returns immediately and the repo stays free to build/test.
+Start-Process -FilePath $exe -WorkingDirectory $destDir

--- a/scripts/run-sidecar.ps1
+++ b/scripts/run-sidecar.ps1
@@ -13,11 +13,15 @@
 # The running build is identifiable in debug.log via the "Build: sha=... built=... path=..."
 # line (the sidecar path makes it obvious you're on the sidecar, not the repo output).
 #
+# The DLL-lock problem this solves is Windows-specific, but the script runs on Linux/macOS too
+# (rsync/Copy-Item fallback for mirroring, no .exe suffix) so it's usable as a generic
+# always-fresh launcher anywhere.
+#
 # Usage:
 #   scripts/run-sidecar.ps1                 # Debug build, build + mirror + launch
 #   scripts/run-sidecar.ps1 -Configuration Release
 #   scripts/run-sidecar.ps1 -NoBuild        # skip the build; just mirror current output + launch
-#   scripts/run-sidecar.ps1 -SidecarRoot D:\nova-sidecar   # override sidecar location
+#   scripts/run-sidecar.ps1 -SidecarRoot /some/path   # override sidecar location
 
 [CmdletBinding()]
 param(
@@ -29,15 +33,20 @@ param(
     [switch]$NoBuild,
 
     # Default sidecar lives outside the repo so it never collides with repo bin/obj globbing,
-    # IDE file watchers, or `git status`.
-    [string]$SidecarRoot = (Join-Path $env:LOCALAPPDATA 'NovaTerminal-sidecar')
+    # IDE file watchers, or `git status`. $env:LOCALAPPDATA is Windows-only; fall back to the
+    # XDG-ish data dir elsewhere so the script doesn't throw on a null Join-Path argument.
+    [string]$SidecarRoot = $(
+        if ($env:LOCALAPPDATA) { Join-Path $env:LOCALAPPDATA 'NovaTerminal-sidecar' }
+        else { Join-Path $HOME '.local/share/NovaTerminal-sidecar' }
+    )
 )
 
 $ErrorActionPreference = 'Stop'
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
-$appProject = Join-Path $repoRoot 'src\NovaTerminal.App'
-$sourceDir = Join-Path $appProject "bin\$Configuration\$TargetFramework"
+# Build path segments with Join-Path (no embedded separators) so they're correct on every OS.
+$appProject = Join-Path $repoRoot 'src' 'NovaTerminal.App'
+$sourceDir = Join-Path $appProject 'bin' $Configuration $TargetFramework
 
 if (-not $NoBuild) {
     Write-Host "[sidecar] Building NovaTerminal.App ($Configuration)..." -ForegroundColor Cyan
@@ -56,23 +65,44 @@ if (-not (Test-Path $sourceDir)) {
     exit 1
 }
 
-$destDir = Join-Path $SidecarRoot "$Configuration\$TargetFramework"
+$destDir = Join-Path $SidecarRoot $Configuration $TargetFramework
 New-Item -ItemType Directory -Force -Path $destDir | Out-Null
 
 Write-Host "[sidecar] Mirroring fresh output -> $destDir" -ForegroundColor Cyan
-# robocopy /MIR mirrors source to dest (adds new, updates changed, deletes stale). Exit codes
-# 0-7 are success (8+ are real errors); robocopy uses bit flags, not the usual 0=ok convention.
-robocopy $sourceDir $destDir /MIR /NJH /NJS /NDL /NP /R:2 /W:1 | Out-Null
-$rc = $LASTEXITCODE
-if ($rc -ge 8) {
-    Write-Error "[sidecar] robocopy failed (exit $rc)."
-    exit $rc
+if ($IsWindows) {
+    # robocopy /MIR mirrors source to dest (adds new, updates changed, deletes stale). Exit
+    # codes 0-7 are success (8+ are real errors); robocopy uses bit flags, not 0=ok.
+    robocopy $sourceDir $destDir /MIR /NJH /NJS /NDL /NP /R:2 /W:1 | Out-Null
+    $rc = $LASTEXITCODE
+    if ($rc -ge 8) {
+        Write-Error "[sidecar] robocopy failed (exit $rc)."
+        exit $rc
+    }
+}
+elseif (Get-Command rsync -ErrorAction SilentlyContinue) {
+    # Trailing slashes => mirror contents of source into dest; --delete removes stale files.
+    rsync -a --delete "$sourceDir/" "$destDir/"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "[sidecar] rsync failed (exit $LASTEXITCODE)."
+        exit $LASTEXITCODE
+    }
+}
+else {
+    # No rsync: clear dest and recopy. Not incremental, but correct.
+    if (Test-Path $destDir) { Remove-Item -Recurse -Force (Join-Path $destDir '*') -ErrorAction SilentlyContinue }
+    Copy-Item -Recurse -Force (Join-Path $sourceDir '*') $destDir
 }
 
-$exe = Join-Path $destDir 'NovaTerminal.exe'
+$exeName = if ($IsWindows) { 'NovaTerminal.exe' } else { 'NovaTerminal' }
+$exe = Join-Path $destDir $exeName
 if (-not (Test-Path $exe)) {
     Write-Error "[sidecar] Expected executable not found after mirror: $exe"
     exit 1
+}
+
+# Zip/copy doesn't always preserve the execute bit on Unix; ensure the host is runnable.
+if (-not $IsWindows) {
+    chmod +x $exe 2>$null
 }
 
 $builtAt = (Get-Item $exe).LastWriteTime.ToString('yyyy-MM-dd HH:mm:ss')

--- a/src/NovaTerminal.App/NovaTerminal.App.csproj
+++ b/src/NovaTerminal.App/NovaTerminal.App.csproj
@@ -227,4 +227,31 @@
     <InternalsVisibleTo Include="NovaTerminal.App.Tests" />
     <InternalsVisibleTo Include="NovaTerminal.Cli" />
   </ItemGroup>
+
+  <!-- Stamp the git short-SHA (with a +dirty marker for uncommitted changes) into an
+       assembly metadata attribute so the running binary can report exactly which commit
+       it was built from. Surfaced at startup in Program.Main (see "Build:" log line).
+       Resilient: if git is absent or this isn't a repo, the SHA falls back to "unknown"
+       and the build still succeeds. No build timestamp is embedded (that would break
+       deterministic builds and force rebuilds); Program.Main reads the exe's file
+       last-write-time at runtime instead. -->
+  <Target Name="StampGitInfo" BeforeTargets="GetAssemblyAttributes" Condition="'$(DesignTimeBuild)' != 'true'">
+    <Exec Command="git rev-parse --short HEAD"
+          ConsoleToMSBuild="true" ContinueOnError="true" StandardOutputImportance="low" StandardErrorImportance="low">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_GitShaRaw" />
+      <Output TaskParameter="ExitCode" PropertyName="_GitShaExit" />
+    </Exec>
+    <Exec Command="git status --porcelain --untracked-files=no"
+          ConsoleToMSBuild="true" ContinueOnError="true" StandardOutputImportance="low" StandardErrorImportance="low">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_GitDirtyRaw" />
+    </Exec>
+    <PropertyGroup>
+      <_GitSha Condition="'$(_GitShaExit)' == '0' and '$(_GitShaRaw)' != ''">$(_GitShaRaw)</_GitSha>
+      <_GitSha Condition="'$(_GitSha)' == ''">unknown</_GitSha>
+      <_GitDirtySuffix Condition="'$(_GitDirtyRaw)' != ''">+dirty</_GitDirtySuffix>
+    </PropertyGroup>
+    <ItemGroup>
+      <AssemblyMetadata Include="GitSha" Value="$(_GitSha)$(_GitDirtySuffix)" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/NovaTerminal.App/Program.cs
+++ b/src/NovaTerminal.App/Program.cs
@@ -33,6 +33,7 @@ class Program
             // Log startup info
             TerminalLogger.Log("NovaTerminal started with args: " + string.Join(" ", args));
             TerminalLogger.Log("Log file path: " + AppLogger.GetLogFilePath());
+            TerminalLogger.Log("Build: " + DescribeBuild());
             StartupPerformanceTracker.StartNewCurrent();
 
             BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
@@ -44,6 +45,43 @@ class Program
             System.IO.File.WriteAllText(AppPaths.StartupErrorFilePath, ex.ToString());
             throw;
         }
+    }
+
+    // Identifies exactly which build is running, so a stale side-by-side copy is obvious
+    // in debug.log. Reports git SHA (stamped at compile via the StampGitInfo MSBuild target),
+    // the binary path, and its on-disk build time. This is the line that would have
+    // immediately flagged the "net10.0 - Copy" stale-binary crash incident.
+    private static string DescribeBuild()
+    {
+        var asm = System.Reflection.Assembly.GetExecutingAssembly();
+
+        string sha = "unknown";
+        foreach (var meta in asm.GetCustomAttributes(typeof(System.Reflection.AssemblyMetadataAttribute), false))
+        {
+            if (meta is System.Reflection.AssemblyMetadataAttribute m && m.Key == "GitSha")
+            {
+                sha = string.IsNullOrEmpty(m.Value) ? "unknown" : m.Value;
+                break;
+            }
+        }
+
+        // Environment.ProcessPath is correct under both normal and single-file/AOT hosting,
+        // whereas Assembly.Location is empty for single-file/AOT.
+        string path = Environment.ProcessPath ?? asm.Location;
+        string builtAt = "?";
+        try
+        {
+            if (!string.IsNullOrEmpty(path) && System.IO.File.Exists(path))
+            {
+                builtAt = System.IO.File.GetLastWriteTime(path).ToString("yyyy-MM-dd HH:mm:ss");
+            }
+        }
+        catch
+        {
+            // Best-effort diagnostics only — never let build-info logging break startup.
+        }
+
+        return $"sha={sha} built={builtAt} path={path}";
     }
 
     // Avalonia configuration, don't remove; also used by visual designer.


### PR DESCRIPTION
## Why

A crash was re-reported that PR #74 had already fixed. Investigation: the crashing process was a **hand-copied stale binary** (`src\NovaTerminal.App\bin\Debug\net10.0 - Copy\NovaTerminal.exe`, built ~6h *before* the fix merged). The copy is a deliberate workflow — running a side-by-side instance so the repo bin isn't locked during `dotnet build`/`test` — but a manual copy goes stale silently, and you end up chasing already-fixed bugs.

This adds two small, independent dev-loop improvements so that can't happen quietly again.

## What

**1. `scripts/run-sidecar.ps1`** — build → mirror fresh output to a fixed sidecar dir → launch from there.
- Default sidecar: `%LOCALAPPDATA%\NovaTerminal-sidecar` (outside the repo, so no bin/obj glob or `git status` noise).
- Every launch rebuilds + re-mirrors → the sidecar is always current; the repo bin stays unlocked so the main checkout can build/test while the instance runs.
- Uses `scripts/build.ps1` (daemon-pipe-hang-safe), `robocopy /MIR`, `Start-Process` (detached).
- Flags: `-Configuration Debug|Release`, `-NoBuild`, `-SidecarRoot <path>`.

**2. Build-provenance stamp, logged at startup (no UI change).**
- `StampGitInfo` MSBuild target stamps the git short-SHA (`+dirty` marker for uncommitted changes) into `[AssemblyMetadata("GitSha", ...)]`. Falls back to `unknown` if git is unavailable; **no embedded build timestamp** (keeps deterministic builds intact — the exe's on-disk mtime is read at runtime instead).
- `Program.Main` logs one line: `Build: sha=<sha> built=<exe mtime> path=<exe>`. This is exactly the signal that would have flagged the incident at a glance (`path` shows `- Copy`, `built` shows the old time). Uses `Environment.ProcessPath` so it's correct under single-file/AOT too.

## Verification
- Build clean.
- Generated AssemblyInfo contains `[assembly: AssemblyMetadata("GitSha","c3dc2e5+dirty")]` (dirty because the commit was in-flight; a clean build shows the bare SHA).

## Notes
- Independent of the in-flight #76 (Core→Platform rename); branched off `main`. Once merged it flows into future branches; #76 picks it up on its next merge from main.
- AOT caveat: `AssemblyMetadata` could be trimmed under aggressive AOT trimming, in which case `sha` reads `unknown` — but the path + build-time still identify the binary, which is the part that mattered for the incident. The primary use is the JIT Debug/Release dev sidecar.

## Test plan
- [ ] `scripts/run-sidecar.ps1` builds, mirrors, and launches a window
- [ ] `debug.log` shows the new `Build: sha=... built=... path=...` line at startup
- [ ] Run the sidecar while `scripts/build.ps1 build` runs against the repo — build is not blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)