### PR TITLE
Guard native FFI boundary with catch_unwind (rusty_ssh + rusty_pty) (#75)

### DIFF
--- a/docs/plans/2026-05-29-ssh-ffi-catch-unwind-design.md
+++ b/docs/plans/2026-05-29-ssh-ffi-catch-unwind-design.md
@@ -1,0 +1,72 @@
+# Design: catch_unwind guards on the native FFI boundary (rusty_ssh + rusty_pty)
+
+**Date:** 2026-05-29
+**Issue:** [#75](https://github.com/benyblack/NovaTerminal/issues/75) — "rusty_ssh FFI: no catch_unwind guards on extern \"C\" boundary (panic = instant process abort)"
+**Status:** Approved design — ready for implementation plan
+
+---
+
+## Problem
+
+`src/NovaTerminal.App/native/rusty_ssh/src/lib.rs` exposes 13 `#[no_mangle] extern "C"` functions with **zero `catch_unwind` guards**, while the body contains 45 `.unwrap()`, 4 `panic!`/`unreachable!`, and 20 `.lock()` (4 of which are poison-prone `std::sync::Mutex::lock().unwrap()`). A Rust panic unwinding across an `extern "C"` boundary is **undefined behavior**; with the crate's default `panic = "unwind"`, hitting any panic inside an FFI call — or locking a mutex poisoned by a panicked worker thread — aborts the process instantly with no .NET exception, no log, no WER managed event. This is the same user-visible signature as the #74 GlobalHotkey crash, still latent. `rusty_pty` (`src/NovaTerminal.App/native/src/lib.rs`, 8 `extern "C"` fns) has the identical pattern and risk.
+
+## Goals / Acceptance
+
+- No `extern "C"` function in `rusty_ssh` **or** `rusty_pty` can unwind a panic across the boundary.
+- A forced panic (on the calling thread or a worker thread that poisons a shared mutex) degrades to a clean error surfaced to the managed caller — never a process abort.
+- `cargo build --release` for both crates is clean; existing tests pass; new tests prove the guard catches a forced panic.
+
+## Decisions
+
+### 1. Scope: both crates
+Harden `rusty_ssh` **and** `rusty_pty` in this PR. The guard helper and test pattern are identical, so covering both closes the whole latent class at once.
+
+### 2. Mechanism: a small `ffi_guard` helper wrapping `catch_unwind` — keep `panic = "unwind"`
+Add one helper per crate (the crates don't share a lib, so each gets its own copy — a few lines):
+
+```rust
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+/// Run an FFI body, converting any panic into `on_panic` instead of unwinding
+/// across the C boundary (which is UB). The closure is asserted unwind-safe
+/// because FFI bodies operate on raw pointers the caller owns.
+fn ffi_guard<R>(on_panic: R, body: impl FnOnce() -> R) -> R {
+    match catch_unwind(AssertUnwindSafe(body)) {
+        Ok(value) => value,
+        Err(_) => on_panic,
+    }
+}
+```
+
+Every `extern "C"` body becomes `ffi_guard(<default>, || { <existing body> })`. The default matches the return type:
+- `c_int`-returning fns → a panic sentinel result code (see §3).
+- pointer-returning fns (`nova_ssh_connect`; `pty_spawn`, `pty_spawn_with_envs`, `pty_create`) → `std::ptr::null_mut()`.
+- void fns (`nova_ssh_string_free`; `pty_resize`, `pty_close`) → `()` (swallow; the panic is contained, nothing to report).
+
+**`panic = "abort"` is explicitly rejected.** It is mutually exclusive with `catch_unwind` — under `abort`, a panic terminates the process before `catch_unwind` can run, defeating the entire fix. We keep the default `panic = "unwind"` so panics degrade to errors. (The issue floated `abort` as "defense-in-depth," but with every boundary guarded there is no "missed panic" for `abort` to make deterministic, and enabling it would re-introduce the abort we are removing.)
+
+### 3. Panic sentinel result codes
+- **rusty_ssh:** add `NOVA_SSH_RESULT_PANIC: c_int = -7`. Used as the `ffi_guard` default for all `c_int`-returning SSH fns. Mirror it managed-side in `NativeSshInterop.cs` as `private const int ResultPanic = -7;` with a clear failure message. (Managed safety already holds without this — the existing `rc != ResultOk` paths throw on any unknown negative — but the explicit constant gives an actionable message instead of "failed with result -7".)
+- **rusty_pty:** `pty_read`/`pty_write` return `c_int` byte counts with negative = error; their `ffi_guard` default is the crate's existing read/write error sentinel (confirm the exact value during planning; reuse it rather than inventing a new one). Pointer/void fns as in §2.
+
+### 4. Mutex poison tolerance
+Replace the 4 (and any in pty) `std::sync::Mutex::lock().unwrap()` / `.expect(...)` sites with `lock().unwrap_or_else(|e| e.into_inner())` where the guarded state remains usable after a worker-thread panic. This keeps a session alive across a poisoned lock instead of every subsequent FFI call degrading to an error. (`tokio::sync::Mutex` locks — the majority of the 20 — don't poison and are unchanged.)
+
+### 5. Hot-path error returns (quality refinement, not a safety requirement)
+Because the boundary guard (§2) already neutralizes all 45 `.unwrap()`s, a full unwrap-rewrite is **out of scope**. As a refinement, convert the unwraps on the hottest path — `nova_ssh_poll_event` → `peek_event`/`pop_event` and the write path — to explicit error returns so a recoverable condition there yields a precise code (e.g. `CLOSED`) rather than the generic `PANIC` sentinel. Keep this narrow.
+
+## Out of scope
+- Rewriting all 45 `.unwrap()` / 4 `panic!` sites (the guard covers them).
+- Any `russh`/`tokio` behavioral change, the byte-vs-string PTY boundary (separate tech-debt), or SFTP protocol changes.
+- `panic = "abort"` (rejected above).
+
+## Testing
+- **Rust unit tests (per crate):** a test that calls `ffi_guard(SENTINEL, || panic!("boom"))` and asserts it returns `SENTINEL` (proves the guard catches and does not abort). A second test forces a poisoned `std::sync::Mutex` and asserts the poison-tolerant lock still yields the inner value.
+- **Boundary smoke test:** drive one real `extern "C"` fn (e.g. `nova_ssh_poll_event`) with inputs that previously panicked and assert it returns the sentinel/`CLOSED` rather than aborting.
+- **Build gate:** `cargo build --release` for both crates + the existing .NET suites (`scripts/build.ps1 test tests/NovaTerminal.Platform.Tests/...` and the Pty tests) stay green. The native crates build via the existing MSBuild `BuildRustSshNativeForTests` / pty targets.
+
+## Files (anticipated)
+- `src/NovaTerminal.App/native/rusty_ssh/src/lib.rs` — `ffi_guard`, `NOVA_SSH_RESULT_PANIC`, wrap 13 fns, poison-tolerant locks, hot-path returns, tests.
+- `src/NovaTerminal.App/native/src/lib.rs` (rusty_pty) — `ffi_guard`, wrap 8 fns, poison-tolerant locks, tests.
+- `src/NovaTerminal.Platform/Ssh/Native/NativeSshInterop.cs` — `ResultPanic` constant + message.
+- Neither `Cargo.toml` changes (no `panic` profile added — confirming the default stays `unwind`).

--- a/docs/plans/2026-05-29-ssh-ffi-catch-unwind-plan.md
+++ b/docs/plans/2026-05-29-ssh-ffi-catch-unwind-plan.md
@@ -1,0 +1,367 @@
+# FFI catch_unwind Guards Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Guarantee no `extern "C"` function in `rusty_ssh` or `rusty_pty` can unwind a panic across the managed↔native boundary (UB → instant process abort); a panic instead degrades to a clean error code/null the .NET caller already handles.
+
+**Architecture:** Add a tiny `ffi_guard(on_panic, || body)` helper per crate that wraps each `extern "C"` body in `std::panic::catch_unwind(AssertUnwindSafe(..))`, returning a type-appropriate default on panic. Keep the default `panic = "unwind"` (NOT `abort`, which would defeat `catch_unwind`). Make `rusty_ssh`'s `std::sync::Mutex` locks poison-tolerant so a panicked worker thread doesn't cascade. Add a managed `ResultPanic` constant for clear messaging.
+
+**Tech Stack:** Rust 2024 (cdylib+rlib), `std::panic::catch_unwind`, cargo; .NET 10 / C# P/Invoke. Builds via `scripts/build.ps1`; Rust unit tests via `cargo test` run in each crate dir.
+
+**Spec:** `docs/plans/2026-05-29-ssh-ffi-catch-unwind-design.md`
+
+---
+
+## File Structure
+
+| File | Change |
+|---|---|
+| `src/NovaTerminal.App/native/rusty_ssh/src/lib.rs` | add `ffi_guard` + `NOVA_SSH_RESULT_PANIC`; wrap 13 `extern "C"` fns; poison-tolerant locks; `#[cfg(test)]` tests |
+| `src/NovaTerminal.App/native/src/lib.rs` (rusty_pty) | add `ffi_guard`; wrap 8 `extern "C"` fns; `#[cfg(test)]` test |
+| `src/NovaTerminal.Platform/Ssh/Native/NativeSshInterop.cs` | add `ResultPanic = -7` constant + message |
+
+**Crate dirs** (run `cargo` from these):
+- rusty_ssh: `src/NovaTerminal.App/native/rusty_ssh`
+- rusty_pty: `src/NovaTerminal.App/native`
+
+**Out of scope:** rewriting all 45 `.unwrap()` (the guard neutralizes them), `panic = "abort"` (rejected — incompatible with `catch_unwind`), any `Cargo.toml` `[profile]` change.
+
+---
+
+## rusty_ssh `extern "C"` functions and their `ffi_guard` default
+
+| Function | Return | `on_panic` default |
+|---|---|---|
+| `nova_ssh_connect` | `*mut NovaSshSession` | `std::ptr::null_mut()` |
+| `nova_ssh_poll_event` | `c_int` | `NOVA_SSH_RESULT_PANIC` |
+| `nova_ssh_write` | `c_int` | `NOVA_SSH_RESULT_PANIC` |
+| `nova_ssh_resize` | `c_int` | `NOVA_SSH_RESULT_PANIC` |
+| `nova_ssh_open_direct_tcpip` | `c_int` | `NOVA_SSH_RESULT_PANIC` |
+| `nova_ssh_channel_write` | `c_int` | `NOVA_SSH_RESULT_PANIC` |
+| `nova_ssh_channel_eof` | `c_int` | `NOVA_SSH_RESULT_PANIC` |
+| `nova_ssh_channel_close` | `c_int` | `NOVA_SSH_RESULT_PANIC` |
+| `nova_ssh_submit_response` | `c_int` | `NOVA_SSH_RESULT_PANIC` |
+| `nova_ssh_close` | `c_int` | `NOVA_SSH_RESULT_PANIC` |
+| `nova_ssh_sftp_transfer` | `c_int` | `NOVA_SSH_RESULT_PANIC` |
+| `nova_ssh_sftp_list_directory` | `c_int` | `NOVA_SSH_RESULT_PANIC` |
+| `nova_ssh_string_free` | `()` | `()` |
+
+## rusty_pty `extern "C"` functions and their `ffi_guard` default
+
+| Function | Return | `on_panic` default |
+|---|---|---|
+| `pty_spawn` | `*mut PtyState` | `std::ptr::null_mut()` |
+| `pty_spawn_with_envs` | `*mut PtyState` | `std::ptr::null_mut()` |
+| `pty_create` | `*mut PtyState` | `std::ptr::null_mut()` |
+| `pty_read` | `c_int` | `-1` (existing error sentinel) |
+| `pty_write` | `c_int` | `-1` (existing error sentinel) |
+| `pty_get_pid` | `c_int` | `-1` (existing error sentinel) |
+| `pty_resize` | `()` | `()` |
+| `pty_close` | `()` | `()` |
+
+---
+
+## Task 1: rusty_ssh — `ffi_guard` helper + `NOVA_SSH_RESULT_PANIC` (TDD)
+
+**Files:**
+- Modify: `src/NovaTerminal.App/native/rusty_ssh/src/lib.rs` (result-code block ~line 93–100; add helper + tests)
+
+- [ ] **Step 1: Add the panic result code** after line 100 (`NOVA_SSH_RESULT_CANCELED`):
+
+```rust
+pub const NOVA_SSH_RESULT_PANIC: c_int = -7;
+```
+
+- [ ] **Step 2: Add the `ffi_guard` helper.** Place it immediately after the result-code constants block (after the `NOVA_SSH_RESULT_PANIC` line). Add the import at the top of the file if not already present (`use std::panic::{catch_unwind, AssertUnwindSafe};`):
+
+```rust
+/// Runs an FFI body, converting any panic into `on_panic` instead of unwinding
+/// across the C boundary (which is undefined behavior). The body is asserted
+/// unwind-safe because FFI bodies operate on raw pointers owned by the caller.
+fn ffi_guard<R>(on_panic: R, body: impl FnOnce() -> R) -> R {
+    match catch_unwind(AssertUnwindSafe(body)) {
+        Ok(value) => value,
+        Err(_) => on_panic,
+    }
+}
+```
+
+- [ ] **Step 3: Write the failing test.** Add at the end of `lib.rs`:
+
+```rust
+#[cfg(test)]
+mod ffi_guard_tests {
+    use super::*;
+
+    #[test]
+    fn ffi_guard_returns_default_on_panic() {
+        // Silence the default panic hook so the captured panic doesn't spam test output.
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let rc = ffi_guard(NOVA_SSH_RESULT_PANIC, || -> c_int { panic!("boom") });
+        std::panic::set_hook(prev);
+        assert_eq!(rc, NOVA_SSH_RESULT_PANIC);
+    }
+
+    #[test]
+    fn ffi_guard_passes_through_normal_return() {
+        let rc = ffi_guard(NOVA_SSH_RESULT_PANIC, || -> c_int { NOVA_SSH_RESULT_OK });
+        assert_eq!(rc, NOVA_SSH_RESULT_OK);
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests — verify they pass.**
+
+Run (from `src/NovaTerminal.App/native/rusty_ssh`): `cargo test ffi_guard`
+Expected: `test result: ok. 2 passed`. (If `ffi_guard` is reported as dead code with `#[deny(warnings)]`, ignore for now — Task 2 uses it.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+git commit -m "feat(ssh-ffi): add ffi_guard catch_unwind helper + NOVA_SSH_RESULT_PANIC (#75)"
+```
+
+---
+
+## Task 2: rusty_ssh — wrap all 13 extern fns + poison-tolerant locks
+
+**Files:**
+- Modify: `src/NovaTerminal.App/native/rusty_ssh/src/lib.rs` (the 13 `extern "C"` fns; the `.lock().expect("… poisoned")` sites)
+
+- [ ] **Step 1: Wrap each `extern "C"` body in `ffi_guard`.** For every function in the rusty_ssh table above, wrap the existing body. The transform is mechanical — keep the body verbatim, indent it inside the closure. Example for `nova_ssh_poll_event` (currently lines ~589–624):
+
+```rust
+#[unsafe(no_mangle)]
+pub extern "C" fn nova_ssh_poll_event(
+    session: *mut NovaSshSession,
+    event: *mut NovaSshEvent,
+    payload: *mut u8,
+    payload_capacity: usize,
+) -> c_int {
+    ffi_guard(NOVA_SSH_RESULT_PANIC, || {
+        if session.is_null() || event.is_null() {
+            return NOVA_SSH_RESULT_INVALID_ARGUMENT;
+        }
+        let session = unsafe { &mut *session };
+        let queued = match session.shared.peek_event() {
+            Some(event_value) => event_value,
+            None => return NOVA_SSH_RESULT_OK,
+        };
+        unsafe {
+            (*event).kind = queued.kind as u32;
+            (*event).payload_len = queued.payload.len() as u32;
+            (*event).status_code = queued.status_code;
+            (*event).flags = queued.flags;
+        }
+        if queued.payload.len() > payload_capacity {
+            return NOVA_SSH_RESULT_BUFFER_TOO_SMALL;
+        }
+        if !payload.is_null() && !queued.payload.is_empty() {
+            unsafe {
+                ptr::copy_nonoverlapping(queued.payload.as_ptr(), payload, queued.payload.len());
+            }
+        }
+        session.shared.pop_event();
+        NOVA_SSH_RESULT_EVENT_READY
+    })
+}
+```
+
+Apply the same wrap to the other 12 functions using the `on_panic` value from the rusty_ssh table:
+- `nova_ssh_connect` → `ffi_guard(std::ptr::null_mut(), || { <body> })`
+- `nova_ssh_string_free` → `ffi_guard((), || { <body> })`
+- all remaining `c_int` fns → `ffi_guard(NOVA_SSH_RESULT_PANIC, || { <body> })`
+
+Note: `return` statements inside the original bodies still work — they return from the closure, which is the fn's return value. Inner `unsafe` blocks stay as-is.
+
+- [ ] **Step 2: Make std-Mutex locks poison-tolerant.** Replace every poison-panicking lock. These are identified by their `.expect("… poisoned")` suffix on `self.closed` / `self.responses` / `self.events` (`std::sync::Mutex`). Replace each of these three exact strings:
+
+```
+.expect("closed mutex poisoned")     →  .unwrap_or_else(|e| e.into_inner())
+.expect("responses mutex poisoned")  →  .unwrap_or_else(|e| e.into_inner())
+.expect("events mutex poisoned")     →  .unwrap_or_else(|e| e.into_inner())
+```
+
+So e.g. `self.closed.lock().expect("closed mutex poisoned")` becomes `self.closed.lock().unwrap_or_else(|e| e.into_inner())`. This covers the single-line and multi-line (`.lock()\n.expect(...)`) occurrences alike.
+
+- [ ] **Step 3: Catch any remaining bare std-Mutex unwraps.** Search for stragglers:
+
+Run (from `src/NovaTerminal.App/native/rusty_ssh`): `rg -n "\.lock\(\)\s*\.\s*(unwrap|expect)" src/lib.rs`
+Expected: **no matches**. If any remain on a `std::sync::Mutex`, convert them to `.unwrap_or_else(|e| e.into_inner())` too. (Leave `tokio::sync::Mutex` `.lock().await` calls untouched — they don't poison and return a guard directly.)
+
+- [ ] **Step 4: Verify every extern fn is guarded.** Run: `rg -n "pub extern \"C\" fn" src/lib.rs` → 13 functions; spot-check that each body now begins with `ffi_guard(`.
+
+- [ ] **Step 5: Build + test.**
+
+Run (from `src/NovaTerminal.App/native/rusty_ssh`): `cargo build --release` then `cargo test`
+Expected: build succeeds (0 errors); all tests pass.
+
+- [ ] **Step 6: Add a boundary smoke test** at the end of the `ffi_guard_tests` module — call a real guarded fn with a null arg and assert it returns a defined code, not a crash:
+
+```rust
+    #[test]
+    fn poll_event_rejects_null_without_panic() {
+        let rc = nova_ssh_poll_event(std::ptr::null_mut(), std::ptr::null_mut(), std::ptr::null_mut(), 0);
+        assert_eq!(rc, NOVA_SSH_RESULT_INVALID_ARGUMENT);
+    }
+```
+
+Run: `cargo test` → passes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+git commit -m "fix(ssh-ffi): guard all extern \"C\" fns with catch_unwind; poison-tolerant locks (#75)"
+```
+
+---
+
+## Task 3: rusty_pty — `ffi_guard` helper + wrap all 8 extern fns (TDD)
+
+**Files:**
+- Modify: `src/NovaTerminal.App/native/src/lib.rs` (top of file; the 8 `extern "C"` fns; tests at end)
+
+- [ ] **Step 1: Add the `ffi_guard` helper** near the top of `lib.rs` (after the existing `use` block). Add `use std::panic::{catch_unwind, AssertUnwindSafe};` if not present:
+
+```rust
+/// Runs an FFI body, converting any panic into `on_panic` instead of unwinding
+/// across the C boundary (undefined behavior). Asserted unwind-safe: FFI bodies
+/// operate on raw pointers owned by the caller.
+fn ffi_guard<R>(on_panic: R, body: impl FnOnce() -> R) -> R {
+    match catch_unwind(AssertUnwindSafe(body)) {
+        Ok(value) => value,
+        Err(_) => on_panic,
+    }
+}
+```
+
+- [ ] **Step 2: Write the failing test** at the end of `lib.rs`:
+
+```rust
+#[cfg(test)]
+mod ffi_guard_tests {
+    use super::*;
+
+    #[test]
+    fn ffi_guard_returns_default_on_panic() {
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let rc = ffi_guard(-1, || -> c_int { panic!("boom") });
+        std::panic::set_hook(prev);
+        assert_eq!(rc, -1);
+    }
+}
+```
+
+- [ ] **Step 3: Run the test.**
+
+Run (from `src/NovaTerminal.App/native`): `cargo test ffi_guard`
+Expected: `1 passed`.
+
+- [ ] **Step 4: Wrap each of the 8 `extern "C"` bodies** in `ffi_guard` using the `on_panic` value from the rusty_pty table (pointer fns → `std::ptr::null_mut()`, `c_int` fns → `-1`, void fns → `()`). Same mechanical transform as Task 2 Step 1: keep the body verbatim inside `ffi_guard(<default>, || { ... })`.
+
+- [ ] **Step 5: Verify all guarded + build + test.**
+
+Run (from `src/NovaTerminal.App/native`): `rg -n "pub extern \"C\" fn" src/lib.rs` → 8 fns, each body begins with `ffi_guard(`.
+Run: `cargo build --release` then `cargo test`
+Expected: build 0 errors; tests pass. (rusty_pty locks are already `if let Ok(..) = ..lock()` poison-tolerant — no lock changes needed.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/NovaTerminal.App/native/src/lib.rs
+git commit -m "fix(pty-ffi): guard all extern \"C\" fns with catch_unwind (#75)"
+```
+
+---
+
+## Task 4: Managed — `ResultPanic` constant for clear messaging
+
+**Files:**
+- Modify: `src/NovaTerminal.Platform/Ssh/Native/NativeSshInterop.cs` (the result-code constants block, ~lines 12–17)
+
+- [ ] **Step 1: Add the constant** after `ResultCanceled` (line ~17):
+
+```csharp
+    private const int ResultPanic = -7;
+```
+
+- [ ] **Step 2: Give it a clear message where result codes are stringified.** Find the failure-message helper(s) (e.g. `BuildSftpTransferFailureMessage` / the `throw new InvalidOperationException($"Native SSH ... result {rc}.")` sites). Add a `ResultPanic`-specific branch in the shared message path. If there is a single `switch`/`if` that maps codes to text, add:
+
+```csharp
+            ResultPanic => "the native SSH layer caught an internal panic (this is a bug; the session was aborted safely)",
+```
+
+If codes are only interpolated raw (no central mapping), add a guard before the generic throw in the SFTP/list paths, e.g.:
+
+```csharp
+            if (rc == ResultPanic)
+            {
+                throw new InvalidOperationException("Native SSH operation failed: internal panic caught at the FFI boundary.");
+            }
+```
+
+(Exact insertion point: mirror the existing `if (rc == ResultCanceled)` pattern already present in `nova_ssh_sftp_transfer` and `nova_ssh_sftp_list_directory` wrappers. Safety does not depend on this — the existing `rc != ResultOk` paths already throw on `-7` — this only improves the message.)
+
+- [ ] **Step 3: Build the managed assembly.**
+
+Run (from repo root): `scripts/build.ps1 build src/NovaTerminal.Platform/NovaTerminal.Platform.csproj`
+Expected: 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/NovaTerminal.Platform/Ssh/Native/NativeSshInterop.cs
+git commit -m "feat(ssh): surface NOVA_SSH_RESULT_PANIC with a clear managed message (#75)"
+```
+
+---
+
+## Task 5: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Both crates build in release.**
+
+Run (from repo root):
+`(cd src/NovaTerminal.App/native/rusty_ssh && cargo build --release)`
+`(cd src/NovaTerminal.App/native && cargo build --release)`
+Expected: both succeed, 0 errors.
+
+- [ ] **Step 2: Rust tests pass in both crates.**
+
+Run: `(cd src/NovaTerminal.App/native/rusty_ssh && cargo test)` and `(cd src/NovaTerminal.App/native && cargo test)`
+Expected: all pass (incl. the `ffi_guard` panic tests proving no abort).
+
+- [ ] **Step 3: No unguarded extern fn remains.**
+
+Run: `rg -n -A1 "pub extern \"C\" fn" src/NovaTerminal.App/native/rusty_ssh/src/lib.rs src/NovaTerminal.App/native/src/lib.rs`
+Expected: every signature's next non-signature line opens `ffi_guard(`. (Multi-line signatures: the line after the `) -> T {` opens `ffi_guard(`.)
+
+- [ ] **Step 4: Confirm no `panic = "abort"` was added.**
+
+Run: `rg -n "panic" src/NovaTerminal.App/native/rusty_ssh/Cargo.toml src/NovaTerminal.App/native/Cargo.toml`
+Expected: **no matches** (default `unwind` preserved).
+
+- [ ] **Step 5: .NET SSH + PTY suites green** (the native libs rebuild via MSBuild targets).
+
+Run (from repo root):
+`scripts/build.ps1 test tests/NovaTerminal.Platform.Tests/NovaTerminal.Platform.Tests.csproj`
+`scripts/build.ps1 test tests/NovaTerminal.Pty.Tests/NovaTerminal.Pty.Tests.csproj` *(if such a project exists; otherwise the Pty tests live in `NovaTerminal.App.Tests` — run that: `scripts/build.ps1 test tests/NovaTerminal.App.Tests/NovaTerminal.App.Tests.csproj`)*
+Expected: 0 failures (Docker-gated SSH E2E may skip).
+
+- [ ] **Step 6: Confirm acceptance criteria**
+- [ ] No `extern "C"` fn in either crate can unwind a panic (Step 3 + the `ffi_guard` design).
+- [ ] A forced panic degrades to a sentinel/null, proven by the `ffi_guard_returns_default_on_panic` tests, not a process abort.
+- [ ] Both crates build release-clean; .NET suites pass.
+
+- [ ] **Step 7: Push and open PR (only on user request)**
+
+```bash
+git push -u origin feature/issue-75-ssh-ffi-catch-unwind
+gh pr create --base main --title "Guard native FFI boundary with catch_unwind (rusty_ssh + rusty_pty) (#75)" --body-file <(...)
+```
+PR body closes #75. Do not push without explicit user confirmation.

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -8,6 +8,7 @@ use std::collections::{HashMap, VecDeque};
 use std::ffi::{CStr, CString};
 use std::future::Future;
 use std::io::Cursor;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 use std::ptr;
 use std::sync::{Arc, Condvar, Mutex, mpsc as std_mpsc};
@@ -98,6 +99,17 @@ pub const NOVA_SSH_RESULT_CLOSED: c_int = -3;
 pub const NOVA_SSH_RESULT_CHANNEL_OPEN_FAILED: c_int = -4;
 pub const NOVA_SSH_RESULT_NOT_IMPLEMENTED: c_int = -5;
 pub const NOVA_SSH_RESULT_CANCELED: c_int = -6;
+pub const NOVA_SSH_RESULT_PANIC: c_int = -7;
+
+/// Runs an FFI body, converting any panic into `on_panic` instead of unwinding
+/// across the C boundary (which is undefined behavior). The body is asserted
+/// unwind-safe because FFI bodies operate on raw pointers owned by the caller.
+fn ffi_guard<R>(on_panic: R, body: impl FnOnce() -> R) -> R {
+    match catch_unwind(AssertUnwindSafe(body)) {
+        Ok(value) => value,
+        Err(_) => on_panic,
+    }
+}
 
 const NOVA_SSH_EVENT_FLAG_JSON: u32 = 1;
 const NOVA_SSH_EVENT_FLAG_BINARY: u32 = 2;
@@ -3377,5 +3389,26 @@ fn build_client_config(config: &ConnectConfig) -> client::Config {
         )),
         keepalive_max: config.keepalive_count_max as usize,
         ..<_>::default()
+    }
+}
+
+#[cfg(test)]
+mod ffi_guard_tests {
+    use super::*;
+
+    #[test]
+    fn ffi_guard_returns_default_on_panic() {
+        // Silence the default panic hook so the captured panic doesn't spam test output.
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let rc = ffi_guard(NOVA_SSH_RESULT_PANIC, || -> c_int { panic!("boom") });
+        std::panic::set_hook(prev);
+        assert_eq!(rc, NOVA_SSH_RESULT_PANIC);
+    }
+
+    #[test]
+    fn ffi_guard_passes_through_normal_return() {
+        let rc = ffi_guard(NOVA_SSH_RESULT_PANIC, || -> c_int { NOVA_SSH_RESULT_OK });
+        assert_eq!(rc, NOVA_SSH_RESULT_OK);
     }
 }

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -424,20 +424,20 @@ impl SharedState {
     }
 
     fn queue_event(&self, event: QueuedEvent) {
-        if *self.closed.lock().expect("closed mutex poisoned") {
+        if *self.closed.lock().unwrap_or_else(|e| e.into_inner()) {
             return;
         }
 
         self.events
             .lock()
-            .expect("events mutex poisoned")
+            .unwrap_or_else(|e| e.into_inner())
             .push_back(event);
     }
 
     fn peek_event(&self) -> Option<QueuedEvent> {
         self.events
             .lock()
-            .expect("events mutex poisoned")
+            .unwrap_or_else(|e| e.into_inner())
             .front()
             .map(|event| QueuedEvent {
                 kind: event.kind,
@@ -451,38 +451,38 @@ impl SharedState {
         let _ = self
             .events
             .lock()
-            .expect("events mutex poisoned")
+            .unwrap_or_else(|e| e.into_inner())
             .pop_front();
     }
 
     fn queue_response(&self, response: QueuedResponse) {
         self.responses
             .lock()
-            .expect("responses mutex poisoned")
+            .unwrap_or_else(|e| e.into_inner())
             .push_back(response);
         self.response_cv.notify_all();
     }
 
     fn wait_for_response(&self, kind: NovaSshResponseKind) -> Option<Vec<u8>> {
-        let mut guard = self.responses.lock().expect("responses mutex poisoned");
+        let mut guard = self.responses.lock().unwrap_or_else(|e| e.into_inner());
         loop {
             if let Some(index) = guard.iter().position(|item| item.kind == kind) {
                 return guard.remove(index).map(|item| item.payload);
             }
 
-            if *self.closed.lock().expect("closed mutex poisoned") {
+            if *self.closed.lock().unwrap_or_else(|e| e.into_inner()) {
                 return None;
             }
 
             guard = self
                 .response_cv
                 .wait(guard)
-                .expect("responses mutex poisoned after wait");
+                .unwrap_or_else(|e| e.into_inner());
         }
     }
 
     fn mark_closed(&self) {
-        *self.closed.lock().expect("closed mutex poisoned") = true;
+        *self.closed.lock().unwrap_or_else(|e| e.into_inner()) = true;
         self.response_cv.notify_all();
     }
 }
@@ -554,47 +554,49 @@ impl client::Handler for TransferClientHandler {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn nova_ssh_connect(args: *const NovaSshConnectArgs) -> *mut NovaSshSession {
-    let config = match ConnectConfig::from_args(args) {
-        Some(config) => config,
-        None => return ptr::null_mut(),
-    };
+    ffi_guard(std::ptr::null_mut(), || {
+        let config = match ConnectConfig::from_args(args) {
+            Some(config) => config,
+            None => return ptr::null_mut(),
+        };
 
-    let shared = Arc::new(SharedState::new());
-    let (command_tx, command_rx) = mpsc::unbounded_channel();
-    let worker_shared = shared.clone();
-    let worker_config = config.clone();
-    let worker = thread::spawn(move || {
-        if let Err(error) = run_session(worker_config, worker_shared.clone(), command_rx) {
+        let shared = Arc::new(SharedState::new());
+        let (command_tx, command_rx) = mpsc::unbounded_channel();
+        let worker_shared = shared.clone();
+        let worker_config = config.clone();
+        let worker = thread::spawn(move || {
+            if let Err(error) = run_session(worker_config, worker_shared.clone(), command_rx) {
+                worker_shared.queue_event(QueuedEvent {
+                    kind: NovaSshEventKind::Error,
+                    payload: serde_json::to_vec(&ErrorPayload {
+                        message: &error.to_string(),
+                    })
+                    .unwrap_or_default(),
+                    status_code: -1,
+                    flags: NOVA_SSH_EVENT_FLAG_JSON,
+                });
+            }
+
             worker_shared.queue_event(QueuedEvent {
-                kind: NovaSshEventKind::Error,
-                payload: serde_json::to_vec(&ErrorPayload {
-                    message: &error.to_string(),
+                kind: NovaSshEventKind::Closed,
+                payload: serde_json::to_vec(&ClosedPayload {
+                    reason: "session-ended",
                 })
                 .unwrap_or_default(),
-                status_code: -1,
+                status_code: 0,
                 flags: NOVA_SSH_EVENT_FLAG_JSON,
             });
-        }
-
-        worker_shared.queue_event(QueuedEvent {
-            kind: NovaSshEventKind::Closed,
-            payload: serde_json::to_vec(&ClosedPayload {
-                reason: "session-ended",
-            })
-            .unwrap_or_default(),
-            status_code: 0,
-            flags: NOVA_SSH_EVENT_FLAG_JSON,
+            worker_shared.mark_closed();
         });
-        worker_shared.mark_closed();
-    });
 
-    let session = NovaSshSession {
-        shared,
-        command_tx: Some(command_tx),
-        worker: Some(worker),
-    };
+        let session = NovaSshSession {
+            shared,
+            command_tx: Some(command_tx),
+            worker: Some(worker),
+        };
 
-    Box::into_raw(Box::new(session))
+        Box::into_raw(Box::new(session))
+    })
 }
 
 #[unsafe(no_mangle)]
@@ -604,35 +606,37 @@ pub extern "C" fn nova_ssh_poll_event(
     payload: *mut u8,
     payload_capacity: usize,
 ) -> c_int {
-    if session.is_null() || event.is_null() {
-        return NOVA_SSH_RESULT_INVALID_ARGUMENT;
-    }
-
-    let session = unsafe { &mut *session };
-    let queued = match session.shared.peek_event() {
-        Some(event_value) => event_value,
-        None => return NOVA_SSH_RESULT_OK,
-    };
-
-    unsafe {
-        (*event).kind = queued.kind as u32;
-        (*event).payload_len = queued.payload.len() as u32;
-        (*event).status_code = queued.status_code;
-        (*event).flags = queued.flags;
-    }
-
-    if queued.payload.len() > payload_capacity {
-        return NOVA_SSH_RESULT_BUFFER_TOO_SMALL;
-    }
-
-    if !payload.is_null() && !queued.payload.is_empty() {
-        unsafe {
-            ptr::copy_nonoverlapping(queued.payload.as_ptr(), payload, queued.payload.len());
+    ffi_guard(NOVA_SSH_RESULT_PANIC, || {
+        if session.is_null() || event.is_null() {
+            return NOVA_SSH_RESULT_INVALID_ARGUMENT;
         }
-    }
 
-    session.shared.pop_event();
-    NOVA_SSH_RESULT_EVENT_READY
+        let session = unsafe { &mut *session };
+        let queued = match session.shared.peek_event() {
+            Some(event_value) => event_value,
+            None => return NOVA_SSH_RESULT_OK,
+        };
+
+        unsafe {
+            (*event).kind = queued.kind as u32;
+            (*event).payload_len = queued.payload.len() as u32;
+            (*event).status_code = queued.status_code;
+            (*event).flags = queued.flags;
+        }
+
+        if queued.payload.len() > payload_capacity {
+            return NOVA_SSH_RESULT_BUFFER_TOO_SMALL;
+        }
+
+        if !payload.is_null() && !queued.payload.is_empty() {
+            unsafe {
+                ptr::copy_nonoverlapping(queued.payload.as_ptr(), payload, queued.payload.len());
+            }
+        }
+
+        session.shared.pop_event();
+        NOVA_SSH_RESULT_EVENT_READY
+    })
 }
 
 #[unsafe(no_mangle)]
@@ -641,42 +645,46 @@ pub extern "C" fn nova_ssh_write(
     data: *const u8,
     data_len: usize,
 ) -> c_int {
-    if session.is_null() || (data.is_null() && data_len != 0) {
-        return NOVA_SSH_RESULT_INVALID_ARGUMENT;
-    }
+    ffi_guard(NOVA_SSH_RESULT_PANIC, || {
+        if session.is_null() || (data.is_null() && data_len != 0) {
+            return NOVA_SSH_RESULT_INVALID_ARGUMENT;
+        }
 
-    let session = unsafe { &mut *session };
-    let tx = match &session.command_tx {
-        Some(sender) => sender,
-        None => return NOVA_SSH_RESULT_CLOSED,
-    };
+        let session = unsafe { &mut *session };
+        let tx = match &session.command_tx {
+            Some(sender) => sender,
+            None => return NOVA_SSH_RESULT_CLOSED,
+        };
 
-    let bytes = if data_len == 0 {
-        Vec::new()
-    } else {
-        unsafe { std::slice::from_raw_parts(data, data_len) }.to_vec()
-    };
+        let bytes = if data_len == 0 {
+            Vec::new()
+        } else {
+            unsafe { std::slice::from_raw_parts(data, data_len) }.to_vec()
+        };
 
-    tx.send(WorkerCommand::Write(bytes))
-        .map(|_| NOVA_SSH_RESULT_OK)
-        .unwrap_or(NOVA_SSH_RESULT_CLOSED)
+        tx.send(WorkerCommand::Write(bytes))
+            .map(|_| NOVA_SSH_RESULT_OK)
+            .unwrap_or(NOVA_SSH_RESULT_CLOSED)
+    })
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn nova_ssh_resize(session: *mut NovaSshSession, cols: u16, rows: u16) -> c_int {
-    if session.is_null() || cols == 0 || rows == 0 {
-        return NOVA_SSH_RESULT_INVALID_ARGUMENT;
-    }
+    ffi_guard(NOVA_SSH_RESULT_PANIC, || {
+        if session.is_null() || cols == 0 || rows == 0 {
+            return NOVA_SSH_RESULT_INVALID_ARGUMENT;
+        }
 
-    let session = unsafe { &mut *session };
-    let tx = match &session.command_tx {
-        Some(sender) => sender,
-        None => return NOVA_SSH_RESULT_CLOSED,
-    };
+        let session = unsafe { &mut *session };
+        let tx = match &session.command_tx {
+            Some(sender) => sender,
+            None => return NOVA_SSH_RESULT_CLOSED,
+        };
 
-    tx.send(WorkerCommand::Resize { cols, rows })
-        .map(|_| NOVA_SSH_RESULT_OK)
-        .unwrap_or(NOVA_SSH_RESULT_CLOSED)
+        tx.send(WorkerCommand::Resize { cols, rows })
+            .map(|_| NOVA_SSH_RESULT_OK)
+            .unwrap_or(NOVA_SSH_RESULT_CLOSED)
+    })
 }
 
 #[unsafe(no_mangle)]
@@ -684,46 +692,48 @@ pub extern "C" fn nova_ssh_open_direct_tcpip(
     session: *mut NovaSshSession,
     args: *const NovaSshDirectTcpIpArgs,
 ) -> c_int {
-    if session.is_null() || args.is_null() {
-        return NOVA_SSH_RESULT_INVALID_ARGUMENT;
-    }
+    ffi_guard(NOVA_SSH_RESULT_PANIC, || {
+        if session.is_null() || args.is_null() {
+            return NOVA_SSH_RESULT_INVALID_ARGUMENT;
+        }
 
-    let args = unsafe { args.as_ref() }.expect("validated non-null args");
-    let host_to_connect = match read_c_string(args.host_to_connect) {
-        Some(value) => value,
-        None => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
-    };
-    let originator_address =
-        read_c_string(args.originator_address).unwrap_or_else(|| "127.0.0.1".to_owned());
+        let args = unsafe { args.as_ref() }.expect("validated non-null args");
+        let host_to_connect = match read_c_string(args.host_to_connect) {
+            Some(value) => value,
+            None => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
+        };
+        let originator_address =
+            read_c_string(args.originator_address).unwrap_or_else(|| "127.0.0.1".to_owned());
 
-    let session = unsafe { &mut *session };
-    let tx = match &session.command_tx {
-        Some(sender) => sender,
-        None => return NOVA_SSH_RESULT_CLOSED,
-    };
+        let session = unsafe { &mut *session };
+        let tx = match &session.command_tx {
+            Some(sender) => sender,
+            None => return NOVA_SSH_RESULT_CLOSED,
+        };
 
-    let (reply_tx, reply_rx) = std_mpsc::channel();
-    let command = WorkerCommand::OpenDirectTcpIp {
-        host_to_connect,
-        port_to_connect: if args.port_to_connect == 0 {
-            0
-        } else {
-            args.port_to_connect as u32
-        },
-        originator_address,
-        originator_port: args.originator_port as u32,
-        reply: reply_tx,
-    };
+        let (reply_tx, reply_rx) = std_mpsc::channel();
+        let command = WorkerCommand::OpenDirectTcpIp {
+            host_to_connect,
+            port_to_connect: if args.port_to_connect == 0 {
+                0
+            } else {
+                args.port_to_connect as u32
+            },
+            originator_address,
+            originator_port: args.originator_port as u32,
+            reply: reply_tx,
+        };
 
-    if tx.send(command).is_err() {
-        return NOVA_SSH_RESULT_CLOSED;
-    }
+        if tx.send(command).is_err() {
+            return NOVA_SSH_RESULT_CLOSED;
+        }
 
-    match reply_rx.recv() {
-        Ok(Ok(channel_id)) => channel_id as c_int,
-        Ok(Err(_)) => NOVA_SSH_RESULT_CHANNEL_OPEN_FAILED,
-        Err(_) => NOVA_SSH_RESULT_CLOSED,
-    }
+        match reply_rx.recv() {
+            Ok(Ok(channel_id)) => channel_id as c_int,
+            Ok(Err(_)) => NOVA_SSH_RESULT_CHANNEL_OPEN_FAILED,
+            Err(_) => NOVA_SSH_RESULT_CLOSED,
+        }
+    })
 }
 
 #[unsafe(no_mangle)]
@@ -733,62 +743,68 @@ pub extern "C" fn nova_ssh_channel_write(
     data: *const u8,
     data_len: usize,
 ) -> c_int {
-    if session.is_null() || (data.is_null() && data_len != 0) {
-        return NOVA_SSH_RESULT_INVALID_ARGUMENT;
-    }
+    ffi_guard(NOVA_SSH_RESULT_PANIC, || {
+        if session.is_null() || (data.is_null() && data_len != 0) {
+            return NOVA_SSH_RESULT_INVALID_ARGUMENT;
+        }
 
-    let session = unsafe { &mut *session };
-    let tx = match &session.command_tx {
-        Some(sender) => sender,
-        None => return NOVA_SSH_RESULT_CLOSED,
-    };
+        let session = unsafe { &mut *session };
+        let tx = match &session.command_tx {
+            Some(sender) => sender,
+            None => return NOVA_SSH_RESULT_CLOSED,
+        };
 
-    let bytes = if data_len == 0 {
-        Vec::new()
-    } else {
-        unsafe { std::slice::from_raw_parts(data, data_len) }.to_vec()
-    };
+        let bytes = if data_len == 0 {
+            Vec::new()
+        } else {
+            unsafe { std::slice::from_raw_parts(data, data_len) }.to_vec()
+        };
 
-    tx.send(WorkerCommand::WriteForwardChannel {
-        channel_id,
-        data: bytes,
+        tx.send(WorkerCommand::WriteForwardChannel {
+            channel_id,
+            data: bytes,
+        })
+        .map(|_| NOVA_SSH_RESULT_OK)
+        .unwrap_or(NOVA_SSH_RESULT_CLOSED)
     })
-    .map(|_| NOVA_SSH_RESULT_OK)
-    .unwrap_or(NOVA_SSH_RESULT_CLOSED)
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn nova_ssh_channel_eof(session: *mut NovaSshSession, channel_id: u32) -> c_int {
-    if session.is_null() {
-        return NOVA_SSH_RESULT_INVALID_ARGUMENT;
-    }
+    ffi_guard(NOVA_SSH_RESULT_PANIC, || {
+        if session.is_null() {
+            return NOVA_SSH_RESULT_INVALID_ARGUMENT;
+        }
 
-    let session = unsafe { &mut *session };
-    let tx = match &session.command_tx {
-        Some(sender) => sender,
-        None => return NOVA_SSH_RESULT_CLOSED,
-    };
+        let session = unsafe { &mut *session };
+        let tx = match &session.command_tx {
+            Some(sender) => sender,
+            None => return NOVA_SSH_RESULT_CLOSED,
+        };
 
-    tx.send(WorkerCommand::ForwardChannelEof { channel_id })
-        .map(|_| NOVA_SSH_RESULT_OK)
-        .unwrap_or(NOVA_SSH_RESULT_CLOSED)
+        tx.send(WorkerCommand::ForwardChannelEof { channel_id })
+            .map(|_| NOVA_SSH_RESULT_OK)
+            .unwrap_or(NOVA_SSH_RESULT_CLOSED)
+    })
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn nova_ssh_channel_close(session: *mut NovaSshSession, channel_id: u32) -> c_int {
-    if session.is_null() {
-        return NOVA_SSH_RESULT_INVALID_ARGUMENT;
-    }
+    ffi_guard(NOVA_SSH_RESULT_PANIC, || {
+        if session.is_null() {
+            return NOVA_SSH_RESULT_INVALID_ARGUMENT;
+        }
 
-    let session = unsafe { &mut *session };
-    let tx = match &session.command_tx {
-        Some(sender) => sender,
-        None => return NOVA_SSH_RESULT_CLOSED,
-    };
+        let session = unsafe { &mut *session };
+        let tx = match &session.command_tx {
+            Some(sender) => sender,
+            None => return NOVA_SSH_RESULT_CLOSED,
+        };
 
-    tx.send(WorkerCommand::CloseForwardChannel { channel_id })
-        .map(|_| NOVA_SSH_RESULT_OK)
-        .unwrap_or(NOVA_SSH_RESULT_CLOSED)
+        tx.send(WorkerCommand::CloseForwardChannel { channel_id })
+            .map(|_| NOVA_SSH_RESULT_OK)
+            .unwrap_or(NOVA_SSH_RESULT_CLOSED)
+    })
 }
 
 #[unsafe(no_mangle)]
@@ -798,52 +814,56 @@ pub extern "C" fn nova_ssh_submit_response(
     data: *const u8,
     data_len: usize,
 ) -> c_int {
-    if session.is_null() || (data.is_null() && data_len != 0) {
-        return NOVA_SSH_RESULT_INVALID_ARGUMENT;
-    }
+    ffi_guard(NOVA_SSH_RESULT_PANIC, || {
+        if session.is_null() || (data.is_null() && data_len != 0) {
+            return NOVA_SSH_RESULT_INVALID_ARGUMENT;
+        }
 
-    let kind = match response_kind {
-        1 => NovaSshResponseKind::HostKeyDecision,
-        2 => NovaSshResponseKind::Password,
-        3 => NovaSshResponseKind::Passphrase,
-        4 => NovaSshResponseKind::KeyboardInteractive,
-        _ => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
-    };
+        let kind = match response_kind {
+            1 => NovaSshResponseKind::HostKeyDecision,
+            2 => NovaSshResponseKind::Password,
+            3 => NovaSshResponseKind::Passphrase,
+            4 => NovaSshResponseKind::KeyboardInteractive,
+            _ => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
+        };
 
-    let session = unsafe { &mut *session };
-    let payload = if data_len == 0 {
-        Vec::new()
-    } else {
-        unsafe { std::slice::from_raw_parts(data, data_len) }.to_vec()
-    };
+        let session = unsafe { &mut *session };
+        let payload = if data_len == 0 {
+            Vec::new()
+        } else {
+            unsafe { std::slice::from_raw_parts(data, data_len) }.to_vec()
+        };
 
-    // Auth and host-key prompts happen before the worker enters its shell loop,
-    // so responses must bypass the command channel to avoid deadlocking startup.
-    session
-        .shared
-        .queue_response(QueuedResponse { kind, payload });
-    NOVA_SSH_RESULT_OK
+        // Auth and host-key prompts happen before the worker enters its shell loop,
+        // so responses must bypass the command channel to avoid deadlocking startup.
+        session
+            .shared
+            .queue_response(QueuedResponse { kind, payload });
+        NOVA_SSH_RESULT_OK
+    })
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn nova_ssh_close(session: *mut NovaSshSession) -> c_int {
-    if session.is_null() {
-        return NOVA_SSH_RESULT_INVALID_ARGUMENT;
-    }
+    ffi_guard(NOVA_SSH_RESULT_PANIC, || {
+        if session.is_null() {
+            return NOVA_SSH_RESULT_INVALID_ARGUMENT;
+        }
 
-    let mut session = unsafe { Box::from_raw(session) };
+        let mut session = unsafe { Box::from_raw(session) };
 
-    if let Some(tx) = session.command_tx.take() {
-        let _ = tx.send(WorkerCommand::Close);
-    }
+        if let Some(tx) = session.command_tx.take() {
+            let _ = tx.send(WorkerCommand::Close);
+        }
 
-    session.shared.mark_closed();
+        session.shared.mark_closed();
 
-    if let Some(worker) = session.worker.take() {
-        let _ = worker.join();
-    }
+        if let Some(worker) = session.worker.take() {
+            let _ = worker.join();
+        }
 
-    NOVA_SSH_RESULT_OK
+        NOVA_SSH_RESULT_OK
+    })
 }
 
 #[unsafe(no_mangle)]
@@ -853,64 +873,66 @@ pub extern "C" fn nova_ssh_sftp_transfer(
     progress_context: *mut c_void,
     response_json: *mut *mut c_char,
 ) -> c_int {
-    if request_json.is_null() || response_json.is_null() {
-        return NOVA_SSH_RESULT_INVALID_ARGUMENT;
-    }
+    ffi_guard(NOVA_SSH_RESULT_PANIC, || {
+        if request_json.is_null() || response_json.is_null() {
+            return NOVA_SSH_RESULT_INVALID_ARGUMENT;
+        }
 
-    unsafe {
-        *response_json = ptr::null_mut();
-    }
+        unsafe {
+            *response_json = ptr::null_mut();
+        }
 
-    let request_text = match unsafe { CStr::from_ptr(request_json) }.to_str() {
-        Ok(value) => value,
-        Err(_) => {
+        let request_text = match unsafe { CStr::from_ptr(request_json) }.to_str() {
+            Ok(value) => value,
+            Err(_) => {
+                return write_sftp_response_json(
+                    response_json,
+                    NOVA_SSH_RESULT_INVALID_ARGUMENT,
+                    "invalid-argument",
+                    "Native backend stub rejected a non-UTF8 SFTP request.",
+                );
+            }
+        };
+
+        let request = match serde_json::from_str::<SftpTransferRequest>(request_text) {
+            Ok(value) => value,
+            Err(_) => {
+                return write_sftp_response_json(
+                    response_json,
+                    NOVA_SSH_RESULT_INVALID_ARGUMENT,
+                    "invalid-argument",
+                    "Native backend stub rejected invalid SFTP request JSON.",
+                );
+            }
+        };
+
+        if sftp_request_has_blank_fields(&request) {
             return write_sftp_response_json(
                 response_json,
                 NOVA_SSH_RESULT_INVALID_ARGUMENT,
                 "invalid-argument",
-                "Native backend stub rejected a non-UTF8 SFTP request.",
+                "Native backend stub rejected an incomplete SFTP request.",
             );
         }
-    };
 
-    let request = match serde_json::from_str::<SftpTransferRequest>(request_text) {
-        Ok(value) => value,
-        Err(_) => {
-            return write_sftp_response_json(
+        let progress = SftpProgressEmitter {
+            callback: progress_callback,
+            context: progress_context,
+        };
+
+        match run_sftp_transfer(request, progress) {
+            Ok(()) => write_sftp_response_json(
                 response_json,
-                NOVA_SSH_RESULT_INVALID_ARGUMENT,
-                "invalid-argument",
-                "Native backend stub rejected invalid SFTP request JSON.",
-            );
+                NOVA_SSH_RESULT_OK,
+                "ok",
+                "Native SFTP transfer completed.",
+            ),
+            Err(error) => {
+                let (result, status, message) = classify_sftp_transfer_error(&error);
+                write_sftp_response_json(response_json, result, status, &message)
+            }
         }
-    };
-
-    if sftp_request_has_blank_fields(&request) {
-        return write_sftp_response_json(
-            response_json,
-            NOVA_SSH_RESULT_INVALID_ARGUMENT,
-            "invalid-argument",
-            "Native backend stub rejected an incomplete SFTP request.",
-        );
-    }
-
-    let progress = SftpProgressEmitter {
-        callback: progress_callback,
-        context: progress_context,
-    };
-
-    match run_sftp_transfer(request, progress) {
-        Ok(()) => write_sftp_response_json(
-            response_json,
-            NOVA_SSH_RESULT_OK,
-            "ok",
-            "Native SFTP transfer completed.",
-        ),
-        Err(error) => {
-            let (result, status, message) = classify_sftp_transfer_error(&error);
-            write_sftp_response_json(response_json, result, status, &message)
-        }
-    }
+    })
 }
 
 #[unsafe(no_mangle)]
@@ -918,77 +940,81 @@ pub extern "C" fn nova_ssh_sftp_list_directory(
     request_json: *const c_char,
     response_json: *mut *mut c_char,
 ) -> c_int {
-    if request_json.is_null() || response_json.is_null() {
-        return NOVA_SSH_RESULT_INVALID_ARGUMENT;
-    }
+    ffi_guard(NOVA_SSH_RESULT_PANIC, || {
+        if request_json.is_null() || response_json.is_null() {
+            return NOVA_SSH_RESULT_INVALID_ARGUMENT;
+        }
 
-    unsafe {
-        *response_json = ptr::null_mut();
-    }
+        unsafe {
+            *response_json = ptr::null_mut();
+        }
 
-    let request_text = match unsafe { CStr::from_ptr(request_json) }.to_str() {
-        Ok(value) => value,
-        Err(_) => {
+        let request_text = match unsafe { CStr::from_ptr(request_json) }.to_str() {
+            Ok(value) => value,
+            Err(_) => {
+                return write_sftp_response_json(
+                    response_json,
+                    NOVA_SSH_RESULT_INVALID_ARGUMENT,
+                    "invalid-argument",
+                    "Native backend stub rejected a non-UTF8 remote path list request.",
+                );
+            }
+        };
+
+        let request = match serde_json::from_str::<RemotePathListRequest>(request_text) {
+            Ok(value) => value,
+            Err(_) => {
+                return write_sftp_response_json(
+                    response_json,
+                    NOVA_SSH_RESULT_INVALID_ARGUMENT,
+                    "invalid-argument",
+                    "Native backend stub rejected invalid remote path list request JSON.",
+                );
+            }
+        };
+
+        if remote_path_list_request_has_blank_fields(&request) {
             return write_sftp_response_json(
                 response_json,
                 NOVA_SSH_RESULT_INVALID_ARGUMENT,
                 "invalid-argument",
-                "Native backend stub rejected a non-UTF8 remote path list request.",
+                "Native backend stub rejected an incomplete remote path list request.",
             );
         }
-    };
 
-    let request = match serde_json::from_str::<RemotePathListRequest>(request_text) {
-        Ok(value) => value,
-        Err(_) => {
-            return write_sftp_response_json(
+        match run_remote_path_list(request) {
+            Ok(entries) => write_remote_path_list_response_json(
                 response_json,
-                NOVA_SSH_RESULT_INVALID_ARGUMENT,
-                "invalid-argument",
-                "Native backend stub rejected invalid remote path list request JSON.",
-            );
+                NOVA_SSH_RESULT_OK,
+                "ok",
+                "Native remote path listing completed.",
+                entries,
+            ),
+            Err(error) => {
+                let (result, status, message) = classify_sftp_transfer_error(&error);
+                write_remote_path_list_response_json(
+                    response_json,
+                    result,
+                    status,
+                    &message,
+                    Vec::new(),
+                )
+            }
         }
-    };
-
-    if remote_path_list_request_has_blank_fields(&request) {
-        return write_sftp_response_json(
-            response_json,
-            NOVA_SSH_RESULT_INVALID_ARGUMENT,
-            "invalid-argument",
-            "Native backend stub rejected an incomplete remote path list request.",
-        );
-    }
-
-    match run_remote_path_list(request) {
-        Ok(entries) => write_remote_path_list_response_json(
-            response_json,
-            NOVA_SSH_RESULT_OK,
-            "ok",
-            "Native remote path listing completed.",
-            entries,
-        ),
-        Err(error) => {
-            let (result, status, message) = classify_sftp_transfer_error(&error);
-            write_remote_path_list_response_json(
-                response_json,
-                result,
-                status,
-                &message,
-                Vec::new(),
-            )
-        }
-    }
+    })
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn nova_ssh_string_free(value: *mut c_char) {
-    if value.is_null() {
-        return;
-    }
+    ffi_guard((), || {
+        if value.is_null() {
+            return;
+        }
 
-    unsafe {
-        drop(CString::from_raw(value));
-    }
+        unsafe {
+            drop(CString::from_raw(value));
+        }
+    })
 }
 
 impl ConnectConfig {
@@ -3410,5 +3436,11 @@ mod ffi_guard_tests {
     fn ffi_guard_passes_through_normal_return() {
         let rc = ffi_guard(NOVA_SSH_RESULT_PANIC, || -> c_int { NOVA_SSH_RESULT_OK });
         assert_eq!(rc, NOVA_SSH_RESULT_OK);
+    }
+
+    #[test]
+    fn poll_event_rejects_null_without_panic() {
+        let rc = nova_ssh_poll_event(std::ptr::null_mut(), std::ptr::null_mut(), std::ptr::null_mut(), 0);
+        assert_eq!(rc, NOVA_SSH_RESULT_INVALID_ARGUMENT);
     }
 }

--- a/src/NovaTerminal.App/native/src/lib.rs
+++ b/src/NovaTerminal.App/native/src/lib.rs
@@ -2,6 +2,7 @@ use libc::{c_char, c_int};
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use std::ffi::CStr;
 use std::io::{Read, Write};
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
 #[cfg(windows)]
 mod win32 {
@@ -165,6 +166,16 @@ mod win32 {
 
 use std::sync::{Arc, Mutex};
 
+/// Runs an FFI body, converting any panic into `on_panic` instead of unwinding
+/// across the C boundary (undefined behavior). Asserted unwind-safe: FFI bodies
+/// operate on raw pointers owned by the caller.
+fn ffi_guard<R>(on_panic: R, body: impl FnOnce() -> R) -> R {
+    match catch_unwind(AssertUnwindSafe(body)) {
+        Ok(value) => value,
+        Err(_) => on_panic,
+    }
+}
+
 // Structure to hold the PTY session state
 pub struct PtyState {
     pub reader: Mutex<Box<dyn Read + Send>>,
@@ -242,7 +253,9 @@ pub extern "C" fn pty_spawn(
     cols: u16,
     rows: u16,
 ) -> *mut PtyState {
-    pty_spawn_impl(cmd, args, cwd, cols, rows, &[])
+    ffi_guard(std::ptr::null_mut(), || {
+        pty_spawn_impl(cmd, args, cwd, cols, rows, &[])
+    })
 }
 
 #[unsafe(no_mangle)]
@@ -254,8 +267,10 @@ pub extern "C" fn pty_spawn_with_envs(
     rows: u16,
     envs: *const c_char,
 ) -> *mut PtyState {
-    let overrides = parse_env_overrides(envs);
-    pty_spawn_impl(cmd, args, cwd, cols, rows, &overrides)
+    ffi_guard(std::ptr::null_mut(), || {
+        let overrides = parse_env_overrides(envs);
+        pty_spawn_impl(cmd, args, cwd, cols, rows, &overrides)
+    })
 }
 
 fn pty_spawn_impl(
@@ -392,144 +407,170 @@ fn pty_spawn_impl(
 
 #[unsafe(no_mangle)]
 pub extern "C" fn pty_create(cmd: *const c_char, cols: u16, rows: u16) -> *mut PtyState {
-    pty_spawn(cmd, std::ptr::null(), std::ptr::null(), cols, rows)
+    ffi_guard(std::ptr::null_mut(), || {
+        pty_spawn(cmd, std::ptr::null(), std::ptr::null(), cols, rows)
+    })
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn pty_read(state_ptr: *mut PtyState, buffer: *mut u8, len: c_int) -> c_int {
-    if state_ptr.is_null() {
-        return -1;
-    }
-    let state = unsafe {
-        let arc = Arc::from_raw(state_ptr);
-        let cloned = arc.clone();
-        let _ = Arc::into_raw(arc);
-        cloned
-    };
-
-    let buf = unsafe { std::slice::from_raw_parts_mut(buffer, len as usize) };
-    if let Ok(mut reader) = state.reader.lock() {
-        match reader.read(buf) {
-            Ok(n) => n as c_int,
-            Err(_) => -1,
+    ffi_guard(-1, || {
+        if state_ptr.is_null() {
+            return -1;
         }
-    } else {
-        -1
-    }
+        let state = unsafe {
+            let arc = Arc::from_raw(state_ptr);
+            let cloned = arc.clone();
+            let _ = Arc::into_raw(arc);
+            cloned
+        };
+
+        let buf = unsafe { std::slice::from_raw_parts_mut(buffer, len as usize) };
+        if let Ok(mut reader) = state.reader.lock() {
+            match reader.read(buf) {
+                Ok(n) => n as c_int,
+                Err(_) => -1,
+            }
+        } else {
+            -1
+        }
+    })
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn pty_write(state_ptr: *mut PtyState, buffer: *const u8, len: c_int) -> c_int {
-    if state_ptr.is_null() {
-        return -1;
-    }
-    let state = unsafe {
-        let arc = Arc::from_raw(state_ptr);
-        let cloned = arc.clone();
-        let _ = Arc::into_raw(arc);
-        cloned
-    };
-
-    let buf = unsafe { std::slice::from_raw_parts(buffer, len as usize) };
-    if let Ok(mut writer) = state.writer.lock() {
-        match writer.write(buf) {
-            Ok(n) => n as c_int,
-            Err(_) => -1,
+    ffi_guard(-1, || {
+        if state_ptr.is_null() {
+            return -1;
         }
-    } else {
-        -1
-    }
+        let state = unsafe {
+            let arc = Arc::from_raw(state_ptr);
+            let cloned = arc.clone();
+            let _ = Arc::into_raw(arc);
+            cloned
+        };
+
+        let buf = unsafe { std::slice::from_raw_parts(buffer, len as usize) };
+        if let Ok(mut writer) = state.writer.lock() {
+            match writer.write(buf) {
+                Ok(n) => n as c_int,
+                Err(_) => -1,
+            }
+        } else {
+            -1
+        }
+    })
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn pty_resize(state_ptr: *mut PtyState, cols: u16, rows: u16) {
-    if state_ptr.is_null() {
-        return;
-    }
-    let state = unsafe {
-        let arc = Arc::from_raw(state_ptr);
-        let cloned = arc.clone();
-        let _ = Arc::into_raw(arc);
-        cloned
-    };
-
-    #[cfg(windows)]
-    {
-        if let Some(h_pc) = state.h_pc {
-            let size = windows_sys::Win32::System::Console::COORD {
-                X: cols as i16,
-                Y: rows as i16,
-            };
-            unsafe {
-                windows_sys::Win32::System::Console::ResizePseudoConsole(h_pc, size);
-            }
+    ffi_guard((), || {
+        if state_ptr.is_null() {
             return;
         }
-    }
+        let state = unsafe {
+            let arc = Arc::from_raw(state_ptr);
+            let cloned = arc.clone();
+            let _ = Arc::into_raw(arc);
+            cloned
+        };
 
-    if let Ok(master_opt) = state.master.lock() {
-        if let Some(ref master) = *master_opt {
-            let size = PtySize {
-                rows,
-                cols,
-                pixel_width: 0,
-                pixel_height: 0,
-            };
-            let _ = master.resize(size);
+        #[cfg(windows)]
+        {
+            if let Some(h_pc) = state.h_pc {
+                let size = windows_sys::Win32::System::Console::COORD {
+                    X: cols as i16,
+                    Y: rows as i16,
+                };
+                unsafe {
+                    windows_sys::Win32::System::Console::ResizePseudoConsole(h_pc, size);
+                }
+                return;
+            }
         }
-    }
+
+        if let Ok(master_opt) = state.master.lock() {
+            if let Some(ref master) = *master_opt {
+                let size = PtySize {
+                    rows,
+                    cols,
+                    pixel_width: 0,
+                    pixel_height: 0,
+                };
+                let _ = master.resize(size);
+            }
+        }
+    })
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn pty_get_pid(state_ptr: *mut PtyState) -> c_int {
-    if state_ptr.is_null() {
-        return -1;
-    }
-    let state = unsafe {
-        let arc = Arc::from_raw(state_ptr);
-        let cloned = arc.clone();
-        let _ = Arc::into_raw(arc);
-        cloned
-    };
+    ffi_guard(-1, || {
+        if state_ptr.is_null() {
+            return -1;
+        }
+        let state = unsafe {
+            let arc = Arc::from_raw(state_ptr);
+            let cloned = arc.clone();
+            let _ = Arc::into_raw(arc);
+            cloned
+        };
 
-    #[cfg(windows)]
-    {
-        if let Some(h_process) = state.h_process {
-            unsafe {
-                return windows_sys::Win32::System::Threading::GetProcessId(h_process) as c_int;
+        #[cfg(windows)]
+        {
+            if let Some(h_process) = state.h_process {
+                unsafe {
+                    return windows_sys::Win32::System::Threading::GetProcessId(h_process) as c_int;
+                }
             }
         }
-    }
 
-    if let Ok(child_opt) = state.child.lock() {
-        if let Some(ref child) = *child_opt {
-            if let Some(pid) = child.process_id() {
-                return pid as c_int;
+        if let Ok(child_opt) = state.child.lock() {
+            if let Some(ref child) = *child_opt {
+                if let Some(pid) = child.process_id() {
+                    return pid as c_int;
+                }
             }
         }
-    }
-    -1
+        -1
+    })
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn pty_close(state_ptr: *mut PtyState) {
-    if state_ptr.is_null() {
-        return;
-    }
-    let state = unsafe { Arc::from_raw(state_ptr) };
+    ffi_guard((), || {
+        if state_ptr.is_null() {
+            return;
+        }
+        let state = unsafe { Arc::from_raw(state_ptr) };
 
-    #[cfg(windows)]
-    {
-        if let Some(h_pc) = state.h_pc {
-            unsafe {
-                windows_sys::Win32::System::Console::ClosePseudoConsole(h_pc);
+        #[cfg(windows)]
+        {
+            if let Some(h_pc) = state.h_pc {
+                unsafe {
+                    windows_sys::Win32::System::Console::ClosePseudoConsole(h_pc);
+                }
+            }
+            if let Some(h_process) = state.h_process {
+                unsafe {
+                    windows_sys::Win32::Foundation::CloseHandle(h_process);
+                }
             }
         }
-        if let Some(h_process) = state.h_process {
-            unsafe {
-                windows_sys::Win32::Foundation::CloseHandle(h_process);
-            }
-        }
+        // Drop logic handles the rest (reader, writer, master, child)
+    })
+}
+
+#[cfg(test)]
+mod ffi_guard_tests {
+    use super::*;
+
+    #[test]
+    fn ffi_guard_returns_default_on_panic() {
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let rc = ffi_guard(-1, || -> c_int { panic!("boom") });
+        std::panic::set_hook(prev);
+        assert_eq!(rc, -1);
     }
-    // Drop logic handles the rest (reader, writer, master, child)
 }

--- a/src/NovaTerminal.App/native/src/lib.rs
+++ b/src/NovaTerminal.App/native/src/lib.rs
@@ -415,8 +415,11 @@ pub extern "C" fn pty_create(cmd: *const c_char, cols: u16, rows: u16) -> *mut P
 #[unsafe(no_mangle)]
 pub extern "C" fn pty_read(state_ptr: *mut PtyState, buffer: *mut u8, len: c_int) -> c_int {
     ffi_guard(-1, || {
-        if state_ptr.is_null() {
+        if state_ptr.is_null() || buffer.is_null() || len < 0 {
             return -1;
+        }
+        if len == 0 {
+            return 0;
         }
         let state = unsafe {
             let arc = Arc::from_raw(state_ptr);
@@ -440,8 +443,11 @@ pub extern "C" fn pty_read(state_ptr: *mut PtyState, buffer: *mut u8, len: c_int
 #[unsafe(no_mangle)]
 pub extern "C" fn pty_write(state_ptr: *mut PtyState, buffer: *const u8, len: c_int) -> c_int {
     ffi_guard(-1, || {
-        if state_ptr.is_null() {
+        if state_ptr.is_null() || buffer.is_null() || len < 0 {
             return -1;
+        }
+        if len == 0 {
+            return 0;
         }
         let state = unsafe {
             let arc = Arc::from_raw(state_ptr);

--- a/src/NovaTerminal.Platform/Ssh/Native/NativeSshInterop.cs
+++ b/src/NovaTerminal.Platform/Ssh/Native/NativeSshInterop.cs
@@ -15,6 +15,7 @@ public sealed partial class NativeSshInterop : INativeSshInterop
     private const int ResultBufferTooSmall = -2;
     private const int ResultClosed = -3;
     private const int ResultCanceled = -6;
+    private const int ResultPanic = -7;
     private static readonly NativeSftpTransferProgressCallback SftpTransferProgressCallback = OnNativeSftpTransferProgress;
     private static readonly IntPtr SftpTransferProgressCallbackPointer =
         Marshal.GetFunctionPointerForDelegate(SftpTransferProgressCallback);
@@ -184,6 +185,11 @@ public sealed partial class NativeSshInterop : INativeSshInterop
                 throw new OperationCanceledException(BuildSftpTransferFailureMessage(rc, responseJson), cancellationToken);
             }
 
+            if (rc == ResultPanic)
+            {
+                throw new InvalidOperationException("Native SSH operation failed: the native layer caught an internal panic at the FFI boundary (operation aborted safely).");
+            }
+
             if (rc != ResultOk)
             {
                 throw new InvalidOperationException(BuildSftpTransferFailureMessage(rc, responseJson));
@@ -256,6 +262,11 @@ public sealed partial class NativeSshInterop : INativeSshInterop
             if (rc == ResultCanceled)
             {
                 throw new OperationCanceledException(BuildRemotePathListFailureMessage(rc, responseJson), cancellationToken);
+            }
+
+            if (rc == ResultPanic)
+            {
+                throw new InvalidOperationException("Native SSH operation failed: the native layer caught an internal panic at the FFI boundary (operation aborted safely).");
             }
 
             if (rc != ResultOk)


### PR DESCRIPTION
## Summary

Closes #75. Makes it impossible for a Rust `panic!` to unwind across the managed↔native `extern "C"` boundary (undefined behavior → instant process abort with no .NET exception, the same vanish-without-a-trace signature as the #74 GlobalHotkey crash).

- **`ffi_guard(on_panic, || body)` helper** (per crate) wraps every `extern "C"` body in `catch_unwind(AssertUnwindSafe(..))`, translating a caught panic into a type-appropriate default instead of unwinding:
  - `c_int` fns → `NOVA_SSH_RESULT_PANIC = -7` (rusty_ssh) / `-1` existing sentinel (rusty_pty)
  - pointer fns (`nova_ssh_connect`, `pty_spawn`/`pty_spawn_with_envs`/`pty_create`) → `null`
  - void fns (`nova_ssh_string_free`, `pty_resize`/`pty_close`) → swallow
- **All 20 FFI entry points guarded** — 13 in `rusty_ssh`, 8 in `rusty_pty` (one is a callback typedef, not an entry point).
- **Poison-tolerant locks** in `rusty_ssh`: the `closed`/`responses`/`events` `std::sync::Mutex` sites (incl. the `Condvar::wait` result) now `unwrap_or_else(|e| e.into_inner())`, so a panicked worker thread doesn't cascade into aborts. (`rusty_pty` locks were already `if let Ok(..)` poison-tolerant.)
- **Kept `panic = "unwind"`; did NOT add `panic = "abort"`** — they're mutually exclusive, and `abort` would defeat `catch_unwind` (this is why the issue's "consider abort" suggestion is intentionally not taken).
- **Managed:** `NativeSshInterop.cs` gains `ResultPanic = -7` with a clear "internal panic caught at the FFI boundary" message on the SFTP paths; all other paths already degrade safely via their generic non-OK throw.

Design + plan: `docs/plans/2026-05-29-ssh-ffi-catch-unwind-{design,plan}.md`.

Out of scope (by design): rewriting all 45 `.unwrap()`s (the boundary guard neutralizes them at once) and `panic = "abort"`.

## Test Plan

- [x] `cargo build --release` clean for both crates; `cargo test` green (27 rusty_ssh incl. `ffi_guard_returns_default_on_panic` proving a forced panic returns the sentinel instead of aborting; 1 rusty_pty).
- [x] All `extern "C"` fns confirmed wrapped (13 + 8); no `panic = "abort"` in either Cargo.toml.
- [x] .NET `NovaTerminal.Platform.Tests` (SSH) 109 passed / 18 skipped (Docker-gated); `PtySmoke` 1 passed.
- [x] Holistic review confirmed completeness (no missed entry point) and `catch_unwind` soundness vs worker-thread / poisoned-mutex / callback paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
