### PR TITLE
fix(build): include native Rust libs in output during execution, not evaluation

### DIFF
--- a/src/NovaTerminal.App/NovaTerminal.App.csproj
+++ b/src/NovaTerminal.App/NovaTerminal.App.csproj
@@ -179,37 +179,56 @@
       Condition="'@(CliShimPublishArtifacts)' != ''" />
   </Target>
 
+  <!-- Native Rust libraries (rusty_pty / rusty_ssh) are produced during the build by
+       BuildRustNative / BuildRustSshNative, or restored from the CI native-binary cache.
+       They must be added to Content during EXECUTION, not evaluation. A static
+       <Content Include Condition="Exists(...)"> is evaluated before those targets run, so on a
+       clean or partial-cache build the file does not exist yet at evaluation time and is
+       silently dropped from the output. That is exactly how rusty_pty.dll went missing from the
+       Windows test artifact and produced DllNotFoundException in CI: a cache hit restored an
+       incomplete target/release, evaluation saw no dll and dropped the item, then BuildRustNative
+       compiled the dll a moment later, too late for the already-evaluated item.
+       DependsOnTargets guarantees the libs are built/restored first; BeforeTargets="AssignTargetPaths"
+       is the last point before Content is collected for copy-to-output, so re-checking Exists()
+       here sees the freshly built files. -->
+  <Target Name="IncludeNativeLibrariesInOutput"
+    DependsOnTargets="BuildRustNative;BuildRustSshNative"
+    BeforeTargets="AssignTargetPaths">
+    <ItemGroup>
+      <Content Include="native\target\release\rusty_pty.dll"
+        Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows))) and Exists('native\target\release\rusty_pty.dll')">
+        <Link>rusty_pty.dll</Link>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+      <Content Include="native\target_linux\release\librusty_pty.so"
+        Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux))) and Exists('native\target_linux\release\librusty_pty.so')">
+        <Link>librusty_pty.so</Link>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+      <Content Include="native\target\release\librusty_pty.dylib"
+        Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX))) and Exists('native\target\release\librusty_pty.dylib')">
+        <Link>librusty_pty.dylib</Link>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+      <Content Include="native\rusty_ssh\target\release\rusty_ssh.dll"
+        Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows))) and Exists('native\rusty_ssh\target\release\rusty_ssh.dll')">
+        <Link>rusty_ssh.dll</Link>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+      <Content Include="native\rusty_ssh\target\release\librusty_ssh.so"
+        Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux))) and Exists('native\rusty_ssh\target\release\librusty_ssh.so')">
+        <Link>librusty_ssh.so</Link>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+      <Content Include="native\rusty_ssh\target\release\librusty_ssh.dylib"
+        Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX))) and Exists('native\rusty_ssh\target\release\librusty_ssh.dylib')">
+        <Link>librusty_ssh.dylib</Link>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+    </ItemGroup>
+  </Target>
+
   <ItemGroup>
-    <Content Include="native\target\release\rusty_pty.dll"
-      Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows))) and Exists('native\target\release\rusty_pty.dll')">
-      <Link>rusty_pty.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="native\target_linux\release\librusty_pty.so"
-      Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux))) and Exists('native\target_linux\release\librusty_pty.so')">
-      <Link>librusty_pty.so</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="native\target\release\librusty_pty.dylib"
-      Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX))) and Exists('native\target\release\librusty_pty.dylib')">
-      <Link>librusty_pty.dylib</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="native\rusty_ssh\target\release\rusty_ssh.dll"
-      Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows))) and Exists('native\rusty_ssh\target\release\rusty_ssh.dll')">
-      <Link>rusty_ssh.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="native\rusty_ssh\target\release\librusty_ssh.so"
-      Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux))) and Exists('native\rusty_ssh\target\release\librusty_ssh.so')">
-      <Link>librusty_ssh.so</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="native\rusty_ssh\target\release\librusty_ssh.dylib"
-      Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX))) and Exists('native\rusty_ssh\target\release\librusty_ssh.dylib')">
-      <Link>librusty_ssh.dylib</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
     <Content Include="themes\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/tests/NovaTerminal.ExternalSuites/NovaTerminal.ExternalSuites.csproj
+++ b/tests/NovaTerminal.ExternalSuites/NovaTerminal.ExternalSuites.csproj
@@ -7,14 +7,27 @@
     <ProjectReference Include="..\..\src\NovaTerminal.Pty\NovaTerminal.Pty.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Include="..\..\src\NovaTerminal.App\native\target\release\rusty_pty.dll" Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))">
-      <Link>rusty_pty.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\src\NovaTerminal.App\native\target_linux\release\librusty_pty.so" Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))">
-      <Link>librusty_pty.so</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+  <!-- The native rusty_pty lib is built by NovaTerminal.App's BuildRustNative target
+       (or restored from the CI native-binary cache). This project only references
+       NovaTerminal.Pty, so it doesn't build the lib itself. The previous static
+       <Content Include> had no Exists() guard, so when the lib wasn't present at copy
+       time (clean/partial-cache build) the Copy task failed the build with MSB3030.
+       Add the items during execution with an Exists() check (re-evaluated after the
+       solution build has had a chance to produce the lib), so the copy happens when
+       the lib is available and is skipped — rather than failing the build — when it
+       isn't. This project is a manual scenario driver, not part of the CI test lanes. -->
+  <Target Name="IncludeNativeLibrariesInOutput" BeforeTargets="AssignTargetPaths">
+    <ItemGroup>
+      <Content Include="..\..\src\NovaTerminal.App\native\target\release\rusty_pty.dll"
+        Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows))) and Exists('..\..\src\NovaTerminal.App\native\target\release\rusty_pty.dll')">
+        <Link>rusty_pty.dll</Link>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+      <Content Include="..\..\src\NovaTerminal.App\native\target_linux\release\librusty_pty.so"
+        Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux))) and Exists('..\..\src\NovaTerminal.App\native\target_linux\release\librusty_pty.so')">
+        <Link>librusty_pty.so</Link>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
## What

The `rusty_pty` / `rusty_ssh` native libraries were added to `Content` via static `<Content Include Condition="Exists(...)">` items. `Exists()` is resolved during MSBuild's **evaluation** phase — *before* `BuildRustNative` / `BuildRustSshNative` run. On a clean or partial-cache build the file doesn't exist yet at evaluation time, so the item is silently dropped and the library never reaches the output directory.

Moved the native-lib `Content` items into a target that:
- `DependsOnTargets="BuildRustNative;BuildRustSshNative"` (guarantees the libs are built/restored first), and
- runs `BeforeTargets="AssignTargetPaths"` (the last point before `Content` is collected for copy-to-output).

`Exists()` is now re-checked during execution, after the libraries exist, so they're reliably copied.

## Why this matters

This is a latent build bug that bites whenever the native lib isn't present at evaluation time. It surfaced concretely in CI: the Windows `Unit Tests` job failed with `System.DllNotFoundException: Unable to load DLL 'rusty_pty'` in the PTY-spawning tests, because the native-binary cache restored an incomplete `target/release`, evaluation dropped the `Content` item, and `BuildRustNative` then compiled the dll a moment later — too late for the already-evaluated item. The artifact shipped without `rusty_pty.dll`. `main` was green only because its prior run happened to have a cache miss that built the dll before evaluation.

## Verification

Reproduced the failure locally on Windows: deleted `native/target/release/rusty_pty.dll` (so it's absent at evaluation), rebuilt, and confirmed:
- `rusty_pty.dll` now lands in `tests/NovaTerminal.App.Tests/bin/Release/net10.0/`, and
- the 7 `BashShellIntegrationTests` that failed in CI with `DllNotFoundException` now pass.

## Context

Discovered while debugging #79's CI. This is an independent build-correctness fix and stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)