### PR TITLE
test(app-tests): fix headless-dispatcher threadpool starvation (#81, #79)

### DIFF
--- a/tests/NovaTerminal.App.Tests/TestThreadPoolConfig.cs
+++ b/tests/NovaTerminal.App.Tests/TestThreadPoolConfig.cs
@@ -1,0 +1,37 @@
+using System.Runtime.CompilerServices;
+
+namespace NovaTerminal.Tests;
+
+/// <summary>
+/// Raises the worker-thread floor for the test host before any test runs.
+/// </summary>
+/// <remarks>
+/// Dump-confirmed root cause of the CI flakes #79 (TaskCanceledException) and #81
+/// (8-minute testhost teardown/inactivity hang): <c>Avalonia.Headless.XUnit</c>'s
+/// <c>AvaloniaTestCase.Run</c> executes each <c>[AvaloniaFact]</c> by synchronously
+/// blocking a thread-pool thread (<c>Task.GetResult()</c> -> <c>SpinThenBlockingWait</c>)
+/// while the test body runs on the single shared headless dispatcher. Under xUnit's
+/// parallel collection execution on a low-core CI runner, every available pool thread
+/// ends up blocked this way, so the dispatcher's own async continuations cannot get a
+/// worker thread -> classic sync-over-async thread-pool starvation. The run then either
+/// deadlocks (host never exits, blame-hang aborts at 8 min -> #81) or a dispatcher
+/// operation is cancelled under the contention (-> #79).
+///
+/// Raising the minimum worker-thread count guarantees the pool hands out spare threads
+/// immediately instead of throttling, so the dispatcher always makes progress. This
+/// fixes the root cause for both flakes without disabling test parallelism. It runs in
+/// the test host only and does not affect production.
+/// </remarks>
+internal static class TestThreadPoolConfig
+{
+    [ModuleInitializer]
+    internal static void RaiseWorkerThreadFloor()
+    {
+        int floor = Math.Max(Environment.ProcessorCount * 4, 32);
+        ThreadPool.GetMinThreads(out int workerMin, out int completionPortMin);
+        if (workerMin < floor)
+        {
+            ThreadPool.SetMinThreads(floor, completionPortMin);
+        }
+    }
+}


### PR DESCRIPTION
## What

Fixes the root cause — **dump-confirmed** — of both CI flakes: #81 (8-minute testhost teardown/inactivity hang) and #79 (`TaskCanceledException` under parallel load).

A hang dump captured from a failing Ubuntu `Unit Tests` run (via #84's instrumentation) showed the testhost deadlocked: the main thread blocked in `Main` → `Task.GetResult()`, and **4 threadpool workers all stuck in `Avalonia.Headless.XUnit.AvaloniaTestCase.Run` → `GetResult()` → `SpinThenBlockingWait`**.

`AvaloniaTestCase.Run` runs each `[AvaloniaFact]` by **synchronously blocking a threadpool thread** while the test body executes on the single shared headless dispatcher. Under xUnit's parallel collection execution on a **low-core CI runner** (2 cores), every available pool thread ends up blocked this way, so the dispatcher's own async continuations can't get a worker → **sync-over-async threadpool starvation**. That either deadlocks the host (→ #81's 8-min abort) or cancels a dispatcher op under the contention (→ #79's `TaskCanceledException`). This is why both are CI-only and load-dependent, and why #79's full-serialization made it *worse* (removed the activity masking the stall).

## Fix

A `[ModuleInitializer]` in the test assembly raises the worker min-thread floor to `max(ProcessorCount × 4, 32)` before any test runs, so the pool hands out spare workers immediately and the dispatcher always makes progress. Targets the starvation root directly — **fixes both #79 and #81 without disabling test parallelism**. Test-host only; no production impact.

## Validation

- Local build green.
- Controlled WSL repro under a 2-core `taskset` pin with oversubscribed parallelism — the same harness that previously produced the failures ~3/8 runs — re-run with the fix (results in PR thread).
- CI: the `Unit Tests` job (which reproduced the hang ~every run recently) should now pass reliably.

Once this lands, #84 (hang-dump capture) can merge cleanly, and #79's parked serialization PR can be closed as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)