### PR TITLE
feat(input): smooth high-resolution touchpad / precision-wheel scrolling

### DIFF
--- a/src/NovaTerminal.App/Shell/TerminalSettings.cs
+++ b/src/NovaTerminal.App/Shell/TerminalSettings.cs
@@ -24,6 +24,11 @@ namespace NovaTerminal.Shell
         public bool BellAudioEnabled { get; set; } = true;
         public bool BellVisualEnabled { get; set; } = true;
         public bool SmoothScrolling { get; set; } = true;
+        // Scroll units forwarded per wheel notch. For own-buffer scrolling this is lines
+        // per notch; for a mouse-reporting TUI it is wheel clicks per notch. Higher =
+        // smoother/finer (more steps per notch), lower = coarser. Matters most for
+        // high-resolution touchpads, which emit many sub-notch wheel events.
+        public double WheelLinesPerNotch { get; set; } = 3.0;
         public string PaneClosePolicy { get; set; } = "Confirm";
         public System.Collections.Generic.Dictionary<string, string> Keybindings { get; set; } = new();
         public System.Collections.Generic.List<TabTemplateRule> TabTemplateRules { get; set; } = new();

--- a/src/NovaTerminal.App/Shell/TerminalView.cs
+++ b/src/NovaTerminal.App/Shell/TerminalView.cs
@@ -656,7 +656,14 @@ namespace NovaTerminal.Shell
                 _bellAudioEnabled = settings.BellAudioEnabled;
                 _bellVisualEnabled = settings.BellVisualEnabled;
                 _enableSmoothScrolling = settings.SmoothScrolling;
-                _wheelLinesPerNotch = settings.WheelLinesPerNotch > 0 ? settings.WheelLinesPerNotch : 3.0;
+                // Fall back to the default for non-positive/NaN values; clamp the upper
+                // bound so a wild settings value can't drive runaway scroll steps.
+                double wheelLinesPerNotch = settings.WheelLinesPerNotch;
+                if (double.IsNaN(wheelLinesPerNotch) || wheelLinesPerNotch <= 0)
+                {
+                    wheelLinesPerNotch = 3.0;
+                }
+                _wheelLinesPerNotch = Math.Min(wheelLinesPerNotch, 100.0);
                 if (!_cursorBlinkEnabled) _cursorBlinkPhase = true;
                 EnsureFallbackChain();
 
@@ -1554,7 +1561,11 @@ namespace NovaTerminal.Shell
             // (which otherwise floods a TUI with scroll commands -> runaway scrolling).
             if (_buffer.IsMouseReportingActive())
             {
-                int notches = _wheelReportAccumulator.Accumulate(e.Delta.Y, _wheelLinesPerNotch);
+                // Classic stepped wheel (full notch) forwards 1 event per notch so
+                // list/menu TUIs advance one item; only sub-notch precision devices get
+                // the smoothing multiplier.
+                double reportUnitsPerNotch = WheelStepAccumulator.ReportUnitsPerNotch(e.Delta.Y, _wheelLinesPerNotch);
+                int notches = _wheelReportAccumulator.Accumulate(e.Delta.Y, reportUnitsPerNotch);
                 if (notches != 0)
                 {
                     var point = e.GetCurrentPoint(this);

--- a/src/NovaTerminal.App/Shell/TerminalView.cs
+++ b/src/NovaTerminal.App/Shell/TerminalView.cs
@@ -226,6 +226,12 @@ namespace NovaTerminal.Shell
         private bool _isBellFlashActive;
         private bool _enableSmoothScrolling = true;
         private int _targetScrollOffset;
+        // Carry fractional high-resolution wheel deltas so precision touchpads / hi-res
+        // wheels (which emit sub-notch micro-events) produce one step per notch instead
+        // of one per micro-event. Separate accumulators for the two wheel code paths.
+        private readonly WheelStepAccumulator _wheelScrollAccumulator = new();
+        private readonly WheelStepAccumulator _wheelReportAccumulator = new();
+        private double _wheelLinesPerNotch = 3.0;
         private CursorStyle _preferredCursorStyle = CursorStyle.Underline;
         private int _lastCursorRow = -1;
         private int _lastCursorCol = -1;
@@ -650,6 +656,7 @@ namespace NovaTerminal.Shell
                 _bellAudioEnabled = settings.BellAudioEnabled;
                 _bellVisualEnabled = settings.BellVisualEnabled;
                 _enableSmoothScrolling = settings.SmoothScrolling;
+                _wheelLinesPerNotch = settings.WheelLinesPerNotch > 0 ? settings.WheelLinesPerNotch : 3.0;
                 if (!_cursorBlinkEnabled) _cursorBlinkPhase = true;
                 EnsureFallbackChain();
 
@@ -1541,38 +1548,52 @@ namespace NovaTerminal.Shell
             base.OnPointerWheelChanged(e);
             if (_buffer == null) return;
 
-            // If mouse reporting is active, send wheel events to the session
+            // If mouse reporting is active, forward wheel notches to the session.
+            // Accumulate fractional deltas so a high-resolution device emits one
+            // WheelUp/WheelDown per notch rather than one per sub-notch micro-event
+            // (which otherwise floods a TUI with scroll commands -> runaway scrolling).
             if (_buffer.IsMouseReportingActive())
             {
-                var point = e.GetCurrentPoint(this);
-                var (row, col) = ScreenToTerminal(point.Position);
-                var mouseEvent = new TerminalMouseEvent(
-                    TerminalMouseEventKind.Wheel,
-                    e.Delta.Y > 0 ? TerminalMouseButton.WheelUp : TerminalMouseButton.WheelDown,
-                    col + 1,
-                    row + 1,
-                    e.KeyModifiers);
-                SendMouseEvent(mouseEvent);
+                int notches = _wheelReportAccumulator.Accumulate(e.Delta.Y, _wheelLinesPerNotch);
+                if (notches != 0)
+                {
+                    var point = e.GetCurrentPoint(this);
+                    var (row, col) = ScreenToTerminal(point.Position);
+                    var button = notches > 0 ? TerminalMouseButton.WheelUp : TerminalMouseButton.WheelDown;
+                    for (int i = 0; i < Math.Abs(notches); i++)
+                    {
+                        SendMouseEvent(new TerminalMouseEvent(
+                            TerminalMouseEventKind.Wheel,
+                            button,
+                            col + 1,
+                            row + 1,
+                            e.KeyModifiers));
+                    }
+                }
                 e.Handled = true;
                 return;
             }
 
-            // Standard scrolling
-            // Scroll up (positive) -> Increase Offset
-            // Scroll down (negative) -> Decrease Offset
-            int delta = (int)(e.Delta.Y * 3); // 3 lines per notch
-            if (_enableSmoothScrolling)
+            // Standard scrolling. Accumulate fractional deltas (lines per notch) so
+            // sub-notch micro-events are summed line-by-line instead of being truncated
+            // to zero each event.
+            // Scroll up (positive) -> Increase Offset; scroll down (negative) -> Decrease.
+            int delta = _wheelScrollAccumulator.Accumulate(e.Delta.Y, _wheelLinesPerNotch);
+            if (delta != 0)
             {
-                int maxScroll = Math.Max(0, _buffer.TotalLines - _buffer.Rows);
-                _targetScrollOffset = Math.Clamp(_targetScrollOffset + delta, 0, maxScroll);
-                if (!_scrollAnimationTimer.IsEnabled)
+                if (_enableSmoothScrolling)
                 {
-                    _scrollAnimationTimer.Start();
+                    int maxScroll = Math.Max(0, _buffer.TotalLines - _buffer.Rows);
+                    _targetScrollOffset = Math.Clamp(_targetScrollOffset + delta, 0, maxScroll);
+                    if (!_scrollAnimationTimer.IsEnabled)
+                    {
+                        _scrollAnimationTimer.Start();
+                    }
                 }
-            }
-            else
-            {
-                ScrollOffset += delta;
+                else
+                {
+                    ScrollOffset += delta;
+                }
             }
         }
 

--- a/src/NovaTerminal.App/Shell/WheelStepAccumulator.cs
+++ b/src/NovaTerminal.App/Shell/WheelStepAccumulator.cs
@@ -24,14 +24,29 @@ namespace NovaTerminal.Shell
         /// call. Reversing scroll direction discards the stale remainder so the
         /// reversal registers immediately instead of after "climbing back" through it.
         /// </summary>
+        // Largest accumulated magnitude allowed before the int cast. A single wheel
+        // event never legitimately approaches this; it only guards a pathological delta
+        // from casting to int.MinValue (negative overflow saturates there on .NET),
+        // which would make a caller's Math.Abs(steps) throw OverflowException.
+        private const double MaxAccumulation = 10_000.0;
+
         public int Accumulate(double value)
         {
-            if (value != 0 && _remainder != 0 && Math.Sign(value) != Math.Sign(_remainder))
+            // Drop non-finite deltas: Math.Sign(NaN) throws and (int)Infinity is
+            // garbage. A bad device reading must not crash scrolling.
+            if (double.IsNaN(value) || double.IsInfinity(value))
+            {
+                return 0;
+            }
+
+            // Reverse direction -> discard the stale remainder so the reversal
+            // registers immediately. Sign comparison avoids Math.Sign (NaN-safe).
+            if (value != 0 && _remainder != 0 && (value > 0) != (_remainder > 0))
             {
                 _remainder = 0;
             }
 
-            _remainder += value;
+            _remainder = Math.Clamp(_remainder + value, -MaxAccumulation, MaxAccumulation);
             int steps = (int)_remainder; // truncate toward zero; keep the fraction
             _remainder -= steps;
             return steps;
@@ -44,6 +59,17 @@ namespace NovaTerminal.Shell
         /// </summary>
         public int Accumulate(double normalizedDelta, double unitsPerNotch)
             => Accumulate(normalizedDelta * unitsPerNotch);
+
+        /// <summary>
+        /// Per-notch sensitivity for forwarding wheel events to a mouse-reporting TUI.
+        /// A full-notch event (|delta| &gt;= 1.0, i.e. a classic stepped wheel) forwards
+        /// 1:1 so list/menu TUIs advance one item per notch; sub-notch events (precision
+        /// touchpad / hi-res wheel) use the configured multiplier so scrolling stays
+        /// smooth. Non-finite deltas fall through to <paramref name="configuredUnitsPerNotch"/>
+        /// and are dropped later by <see cref="Accumulate(double)"/>.
+        /// </summary>
+        public static double ReportUnitsPerNotch(double normalizedDelta, double configuredUnitsPerNotch)
+            => Math.Abs(normalizedDelta) >= 1.0 ? 1.0 : configuredUnitsPerNotch;
 
         /// <summary>Drops any pending fraction (e.g. when scrolling context changes).</summary>
         public void Reset() => _remainder = 0;

--- a/src/NovaTerminal.App/Shell/WheelStepAccumulator.cs
+++ b/src/NovaTerminal.App/Shell/WheelStepAccumulator.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace NovaTerminal.Shell
+{
+    /// <summary>
+    /// Accumulates fractional, high-resolution mouse-wheel deltas and emits whole
+    /// discrete scroll steps, carrying the unconsumed fraction between events.
+    /// </summary>
+    /// <remarks>
+    /// Avalonia normalizes one classic mouse-wheel notch to a delta of 1.0. Precision
+    /// touchpads and high-resolution wheels instead emit a stream of sub-notch deltas
+    /// (as small as 1/120 per event). Treating each such micro-event as its own scroll
+    /// step turned one notch-worth of swipe into ~120 steps — the "runaway scroll" bug.
+    /// Accumulating the fraction so one notch produces exactly one step matches how
+    /// Windows Terminal behaves with the same devices.
+    /// </remarks>
+    public sealed class WheelStepAccumulator
+    {
+        private double _remainder;
+
+        /// <summary>
+        /// Adds a normalized wheel delta (positive == up) and returns the number of
+        /// whole steps to emit now. The leftover fraction is retained for the next
+        /// call. Reversing scroll direction discards the stale remainder so the
+        /// reversal registers immediately instead of after "climbing back" through it.
+        /// </summary>
+        public int Accumulate(double value)
+        {
+            if (value != 0 && _remainder != 0 && Math.Sign(value) != Math.Sign(_remainder))
+            {
+                _remainder = 0;
+            }
+
+            _remainder += value;
+            int steps = (int)_remainder; // truncate toward zero; keep the fraction
+            _remainder -= steps;
+            return steps;
+        }
+
+        /// <summary>
+        /// Scales a normalized wheel delta by <paramref name="unitsPerNotch"/> (the
+        /// scroll-units-per-notch sensitivity) before accumulating. Higher values yield
+        /// more, finer steps per notch (smoother); lower values are coarser.
+        /// </summary>
+        public int Accumulate(double normalizedDelta, double unitsPerNotch)
+            => Accumulate(normalizedDelta * unitsPerNotch);
+
+        /// <summary>Drops any pending fraction (e.g. when scrolling context changes).</summary>
+        public void Reset() => _remainder = 0;
+    }
+}

--- a/tests/NovaTerminal.App.Tests/Shell/WheelStepAccumulatorTests.cs
+++ b/tests/NovaTerminal.App.Tests/Shell/WheelStepAccumulatorTests.cs
@@ -1,0 +1,97 @@
+using NovaTerminal.Shell;
+
+namespace NovaTerminal.Tests.Shell;
+
+// Regression tests for the touchpad "runaway scroll" bug.
+// Precision touchpads / hi-res wheels emit a flood of sub-notch wheel events
+// (Avalonia normalizes one classic mouse notch to 1.0, but a touchpad emits
+// events worth as little as 1/120 of a notch each). The accumulator must carry
+// the fractional remainder between events and only emit whole steps, so one
+// notch-worth of swipe produces one step rather than ~120.
+public sealed class WheelStepAccumulatorTests
+{
+    [Fact]
+    public void HighResolutionMicroEvents_SummingToOneAndAHalfNotches_EmitOneStep()
+    {
+        var acc = new WheelStepAccumulator();
+
+        int totalSteps = 0;
+        for (int i = 0; i < 180; i++) // 180 * (1/120) == 1.5 notches
+        {
+            totalSteps += acc.Accumulate(1.0 / 120.0);
+        }
+
+        // 180 sub-notch micro-events == 1.5 notches == one whole discrete step
+        // (with half a notch carried). The buggy per-event behaviour emitted ~180
+        // steps (mouse-reporting path) or 0 steps (standard path that truncated
+        // each event to int).
+        Assert.Equal(1, totalSteps);
+    }
+
+    [Fact]
+    public void ClassicMouseNotch_EmitsOneStepImmediately()
+    {
+        var acc = new WheelStepAccumulator();
+
+        Assert.Equal(1, acc.Accumulate(1.0));
+    }
+
+    [Fact]
+    public void Remainder_CarriesBetweenEvents()
+    {
+        var acc = new WheelStepAccumulator();
+
+        Assert.Equal(0, acc.Accumulate(0.6)); // 0.6 accrued, no whole step yet
+        Assert.Equal(1, acc.Accumulate(0.6)); // 1.2 accrued -> one step, 0.2 carried
+        Assert.Equal(0, acc.Accumulate(0.6)); // 0.8 accrued, still short
+        Assert.Equal(1, acc.Accumulate(0.6)); // 1.4 accrued -> one step
+    }
+
+    [Fact]
+    public void NegativeMicroEvents_SummingToOneAndAHalfNotches_EmitOneNegativeStep()
+    {
+        var acc = new WheelStepAccumulator();
+
+        int totalSteps = 0;
+        for (int i = 0; i < 180; i++) // -1.5 notches
+        {
+            totalSteps += acc.Accumulate(-1.0 / 120.0);
+        }
+
+        Assert.Equal(-1, totalSteps);
+    }
+
+    [Theory]
+    [InlineData(1.0, 1)]   // 1 unit per notch  -> 1.5 units over the gesture -> 1 step (chunky)
+    [InlineData(3.0, 4)]   // 3 units per notch  -> 4.5 units -> 4 steps (default)
+    [InlineData(5.0, 7)]   // 5 units per notch  -> 7.5 units -> 7 steps (smoother)
+    public void UnitsPerNotch_ScalesStepsProportionally(double unitsPerNotch, int expectedSteps)
+    {
+        // The caller scales the normalized delta by a "units per notch" sensitivity
+        // before accumulating. A 1.5-notch gesture (180 sub-notch micro-events) must
+        // then yield floor(1.5 * unitsPerNotch) whole steps. This is the knob that
+        // trades chunkiness for smoothness in a TUI. (1.5 * u lands on a .5 midpoint
+        // for these values, so the floor is float-rounding safe.)
+        var acc = new WheelStepAccumulator();
+
+        int totalSteps = 0;
+        for (int i = 0; i < 180; i++) // 1.5 notches
+        {
+            totalSteps += acc.Accumulate(1.0 / 120.0, unitsPerNotch);
+        }
+
+        Assert.Equal(expectedSteps, totalSteps);
+    }
+
+    [Fact]
+    public void DirectionReversal_DiscardsStaleRemainder()
+    {
+        var acc = new WheelStepAccumulator();
+
+        Assert.Equal(0, acc.Accumulate(0.6)); // building toward an up-step
+
+        // User reverses direction. The stale +0.6 must NOT force the user to
+        // "climb back" before a down-step registers; reversal feels immediate.
+        Assert.Equal(-1, acc.Accumulate(-1.0));
+    }
+}

--- a/tests/NovaTerminal.App.Tests/Shell/WheelStepAccumulatorTests.cs
+++ b/tests/NovaTerminal.App.Tests/Shell/WheelStepAccumulatorTests.cs
@@ -94,4 +94,53 @@ public sealed class WheelStepAccumulatorTests
         // "climb back" before a down-step registers; reversal feels immediate.
         Assert.Equal(-1, acc.Accumulate(-1.0));
     }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void NonFiniteInput_IsIgnored_AndDoesNotThrow(double value)
+    {
+        var acc = new WheelStepAccumulator();
+
+        // Math.Sign(NaN) throws ArithmeticException, and (int)Infinity yields a
+        // garbage value; a non-finite delta must be dropped, not crash scrolling.
+        Assert.Equal(0, acc.Accumulate(value));
+        // Accumulator stays healthy afterwards.
+        Assert.Equal(1, acc.Accumulate(1.0));
+    }
+
+    [Theory]
+    // Full-notch events (classic stepped wheel) forward 1:1 so a TUI moves one item
+    // per notch, regardless of the configured smoothing multiplier.
+    [InlineData(1.0, 3.0, 1.0)]
+    [InlineData(-1.0, 3.0, 1.0)]
+    [InlineData(2.0, 3.0, 1.0)]
+    // Sub-notch events (precision touchpad / hi-res wheel) use the multiplier so
+    // scrolling stays smooth.
+    [InlineData(0.0083, 3.0, 3.0)]
+    [InlineData(-0.5, 3.0, 3.0)]
+    [InlineData(0.5, 8.0, 8.0)]
+    public void ReportUnitsPerNotch_FullNotchForwards1to1_SubNotchUsesMultiplier(
+        double delta, double configured, double expected)
+    {
+        Assert.Equal(expected, WheelStepAccumulator.ReportUnitsPerNotch(delta, configured));
+    }
+
+    [Theory]
+    [InlineData(1e18)]
+    [InlineData(-1e18)]
+    public void HugeFiniteValue_DoesNotOverflowIntCast(double value)
+    {
+        var acc = new WheelStepAccumulator();
+
+        // A pathological delta must not produce int.MinValue (negative overflow
+        // saturates there on .NET), which would make the caller's Math.Abs(notches)
+        // throw OverflowException.
+        int steps = acc.Accumulate(value);
+
+        Assert.NotEqual(int.MinValue, steps);
+        // Safe to take the absolute value (as the mouse-reporting path does).
+        Assert.True(Math.Abs(steps) >= 0);
+    }
 }


### PR DESCRIPTION
## Problem

Scrolling with a **laptop touchpad** (or a high-resolution/precision wheel) is unusable in two ways:
- In a mouse-reporting TUI (e.g. Claude Code), scrolling **flies uncontrollably** — impossible to land on a spot.
- For the terminal's own scrollback, scrolling is **near-dead**.

Plain notched mice and Windows Terminal are unaffected.

## Root cause

Avalonia normalizes one classic mouse notch to `Delta.Y == 1.0`, but precision touchpads emit a *flood of sub-notch micro-events* — each as small as `1/120` of a notch. The old handler treated every micro-event as a discrete unit with no fractional carry:

- **Mouse-reporting path:** forwarded one `WheelUp`/`WheelDown` per micro-event → ~120 wheel clicks per notch-of-swipe → runaway.
- **Own-buffer path:** `(int)(0.0167 * 3) == 0` every event, remainder discarded → barely moves.

(Confirmed by instrumenting the handler: the device emits `Delta.Y` values of `0.0083`/`0.0167` at high frequency.)

## Fix

Add `WheelStepAccumulator`: it carries the fractional remainder between events and emits whole steps only once a full unit accrues (resetting on direction reversal), the same way Windows Terminal behaves. Both wheel paths use it. New `WheelLinesPerNotch` setting (default 3) tunes scroll-units-per-notch — raise for smoother/finer, lower for coarser.

## Verification

- 8 unit tests (`WheelStepAccumulatorTests`) — green: sub-notch accumulation, classic-notch behavior, remainder carry, direction-reversal reset, and per-notch sensitivity scaling.
- Manually confirmed in-app on a touchpad: TUI scrolling is controllable and own-buffer scrolling is smooth.
