### PR TITLE
fix(tests): stop App.Tests PTY/pane leaks driving the #81 teardown hang (Mode A)

### DIFF
--- a/src/NovaTerminal.Pty/NovaTerminal.Pty.csproj
+++ b/src/NovaTerminal.Pty/NovaTerminal.Pty.csproj
@@ -1,6 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <!-- Test hooks: RustPtySession exposes the read/process loop threads as `internal`
+         so tests can assert they run on dedicated background threads (never threadpool
+         threads), guarding the #81 pool-starvation regression. -->
+    <InternalsVisibleTo Include="NovaTerminal.App.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- VT removed in Phase 5: Pty no longer references TerminalBuffer or any VT type.
          Enforced at the IL level by LayeringTests.Pty_must_not_depend_on_Vt and at the
          project-file level by ProjectFileLayeringTests.Pty_csproj_must_not_reference_Vt.

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -341,50 +341,65 @@ namespace NovaTerminal.Pty
             byte[] buffer = new byte[4096];
             char[] charBuffer = new char[4096]; // For decoded characters
 
-            while (!_cts.Token.IsCancellationRequested && _ptyState != IntPtr.Zero)
+            // This runs on a dedicated thread, so an unhandled exception would crash the
+            // whole process (unlike the old Task.Run, whose unobserved exceptions were
+            // swallowed). Contain it so a decode/recorder failure can't take down the host.
+            try
             {
-                int read = Native.pty_read(_ptyState, buffer, buffer.Length);
-                if (read > 0)
+                while (!_cts.Token.IsCancellationRequested && _ptyState != IntPtr.Zero)
                 {
-                    // Record raw bytes before any processing
-                    _recorder?.RecordChunk(buffer, read);
-
-                    // Use the stateful decoder - it will hold incomplete multi-byte sequences
-                    // until more bytes arrive, preventing U+FFFD replacement characters
-                    int charCount = _utf8Decoder.GetChars(buffer, 0, read, charBuffer, 0);
-                    if (charCount > 0)
+                    int read = Native.pty_read(_ptyState, buffer, buffer.Length);
+                    if (read > 0)
                     {
-                        string text = new string(charBuffer, 0, charCount);
-                        try
+                        // Record raw bytes before any processing
+                        _recorder?.RecordChunk(buffer, read);
+
+                        // Use the stateful decoder - it will hold incomplete multi-byte sequences
+                        // until more bytes arrive, preventing U+FFFD replacement characters
+                        int charCount = _utf8Decoder.GetChars(buffer, 0, read, charBuffer, 0);
+                        if (charCount > 0)
                         {
-                            // Block when the queue is full so we apply back-pressure instead of dropping output.
-                            _outputQueue.Add(text, _cts.Token);
-                        }
-                        catch (OperationCanceledException)
-                        {
-                            break;
-                        }
-                        catch (InvalidOperationException)
-                        {
-                            break;
+                            string text = new string(charBuffer, 0, charCount);
+                            try
+                            {
+                                // Block when the queue is full so we apply back-pressure instead of dropping output.
+                                _outputQueue.Add(text, _cts.Token);
+                            }
+                            catch (OperationCanceledException)
+                            {
+                                break;
+                            }
+                            catch (InvalidOperationException)
+                            {
+                                break;
+                            }
                         }
                     }
-                }
-                else if (read == 0) // EOF
-                {
-                    Console.WriteLine("[RustPtySession] EOF received.");
-                    break;
-                }
-                else // Error
-                {
-                    // Reset decoder state on error to prevent corruption
-                    _utf8Decoder.Reset();
-                    Thread.Sleep(50);
+                    else if (read == 0) // EOF
+                    {
+                        Console.WriteLine("[RustPtySession] EOF received.");
+                        break;
+                    }
+                    else // Error
+                    {
+                        // Reset decoder state on error to prevent corruption
+                        _utf8Decoder.Reset();
+                        Thread.Sleep(50);
+                    }
                 }
             }
-            if (!_outputQueue.IsAddingCompleted)
+            catch (Exception ex)
             {
-                _outputQueue.CompleteAdding();
+                Console.WriteLine($"[RustPtySession] ReadLoop terminated by unhandled exception: {ex}");
+            }
+            finally
+            {
+                // Always signal the consumer so ProcessLoop's GetConsumingEnumerable
+                // unblocks and that thread can exit, even if the loop above threw.
+                if (!_outputQueue.IsAddingCompleted)
+                {
+                    _outputQueue.CompleteAdding();
+                }
             }
         }
 
@@ -400,6 +415,13 @@ namespace NovaTerminal.Pty
             catch (OperationCanceledException)
             {
                 // Normal shutdown
+            }
+            catch (Exception ex)
+            {
+                // Dedicated thread: OnOutputReceived runs arbitrary subscriber code, and
+                // an unhandled exception here would crash the process. Contain + log so a
+                // misbehaving subscriber can't take down the host; still notify exit below.
+                Console.WriteLine($"[RustPtySession] ProcessLoop terminated by unhandled exception: {ex}");
             }
             TryNotifyExit(0);
         }

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -13,8 +13,13 @@ namespace NovaTerminal.Pty
         public Guid Id { get; } = Guid.NewGuid();
         private IntPtr _ptyState;
         private readonly CancellationTokenSource _cts = new CancellationTokenSource();
-        private Task? _readTask;
-        private Task? _processTask;
+        // The read/process loops run on these dedicated threads. Exposed to tests to
+        // assert they are background, non-threadpool threads — a leaked session must
+        // not consume the threadpool (#81).
+        private Thread? _readLoopThread;
+        private Thread? _processLoopThread;
+        internal Thread? ReadLoopThread => _readLoopThread;
+        internal Thread? ProcessLoopThread => _processLoopThread;
         private int _exitNotified;
         private int _isExited;
         private int? _exitCode;
@@ -237,9 +242,16 @@ namespace NovaTerminal.Pty
                 throw new InvalidOperationException("Failed to create Rust PTY session.");
             }
 
-            // Start reading and processing in background
-            _readTask = Task.Run(ReadLoop);
-            _processTask = Task.Run(ProcessLoop);
+            // Start reading and processing on DEDICATED background threads, not the
+            // threadpool. These loops make blocking native calls (pty_read) and an
+            // outright-blocking consuming enumerator; on the threadpool a leaked or
+            // slow-to-close session would tie up pool threads and, on low-core CI,
+            // starve the test-run completion -> testhost teardown hang (#81). Dedicated
+            // IsBackground threads never consume the pool and never block process exit.
+            _readLoopThread = new Thread(ReadLoop) { IsBackground = true, Name = $"PtyRead-{Id:N}" };
+            _processLoopThread = new Thread(ProcessLoop) { IsBackground = true, Name = $"PtyProcess-{Id:N}" };
+            _readLoopThread.Start();
+            _processLoopThread.Start();
 
             // POST-LAUNCH INJECTION for PowerShell
             if (!skipPowerShellPostLaunchInit &&

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistLayoutTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistLayoutTests.cs
@@ -52,7 +52,7 @@ public sealed class CommandAssistLayoutTests
     [AvaloniaFact]
     public void TerminalPane_HostsBubbleAndPopupAsOverlayViews()
     {
-        var pane = new TerminalPane();
+        using var pane = new TerminalPane();
         ConfigureCommandAssist(pane);
         var bubbleView = pane.FindControl<CommandAssistBubbleView>("CommandAssistBubble");
         var popupView = pane.FindControl<CommandAssistPopupView>("CommandAssistPopup");
@@ -68,7 +68,7 @@ public sealed class CommandAssistLayoutTests
     [AvaloniaFact]
     public async Task TerminalPane_WhenHelpModeIsOpen_BindsBubbleAndPopupState()
     {
-        var pane = new TerminalPane();
+        using var pane = new TerminalPane();
         ConfigureCommandAssist(pane);
         pane.NotifyCommandAssistPaste("Get-ChildItem");
         pane.OpenCommandAssistHelp();
@@ -97,7 +97,7 @@ public sealed class CommandAssistLayoutTests
     [AvaloniaFact]
     public async Task TerminalPane_WhenHelperModeHasNoSuggestions_ShowsPopupEmptyState()
     {
-        var pane = new TerminalPane();
+        using var pane = new TerminalPane();
         ConfigureCommandAssist(pane);
         pane.NotifyCommandAssistPaste("frobnicate");
         pane.OpenCommandAssistHelp();
@@ -117,7 +117,7 @@ public sealed class CommandAssistLayoutTests
     [AvaloniaFact]
     public async Task TerminalPane_WhenSuggestModeIsCollapsed_KeepsPopupHidden()
     {
-        var pane = new TerminalPane();
+        using var pane = new TerminalPane();
         ConfigureCommandAssist(pane);
         pane.NotifyCommandAssistPaste("git st");
         await Task.Delay(50);
@@ -134,7 +134,7 @@ public sealed class CommandAssistLayoutTests
     [AvaloniaFact]
     public async Task TerminalPane_WhenPaneIsNarrow_HidesBubbleQueryText()
     {
-        var pane = new TerminalPane
+        using var pane = new TerminalPane
         {
             Width = 420,
             Height = 420
@@ -157,7 +157,7 @@ public sealed class CommandAssistLayoutTests
     [AvaloniaFact]
     public void TerminalPane_WhenPaneIsMediumWidth_UsesReducedOverlayWidths()
     {
-        var pane = new TerminalPane
+        using var pane = new TerminalPane
         {
             Width = 700,
             Height = 420
@@ -175,7 +175,7 @@ public sealed class CommandAssistLayoutTests
     [AvaloniaFact]
     public async Task TerminalPane_WhenPaneIsShort_ConstrainsPopupHeight()
     {
-        var pane = new TerminalPane
+        using var pane = new TerminalPane
         {
             Width = 700,
             Height = 220
@@ -198,7 +198,7 @@ public sealed class CommandAssistLayoutTests
     [AvaloniaFact]
     public async Task TerminalPane_WhenBubbleIsVisible_KeepsBubbleAbovePromptAnchor()
     {
-        var pane = new TerminalPane
+        using var pane = new TerminalPane
         {
             Width = 900,
             Height = 500
@@ -225,7 +225,7 @@ public sealed class CommandAssistLayoutTests
     [AvaloniaFact]
     public void TerminalPane_WhenRemoteShellIsNotIntegrated_UsesFallbackAnchorInsteadOfPromptAnchor()
     {
-        var pane = new TerminalPane
+        using var pane = new TerminalPane
         {
             Width = 900,
             Height = 500
@@ -257,7 +257,7 @@ public sealed class CommandAssistLayoutTests
     [AvaloniaFact]
     public void TerminalPane_WhenRemoteShellCursorIsSettledLow_UsesCursorBandFallbackNearInput()
     {
-        var pane = new TerminalPane
+        using var pane = new TerminalPane
         {
             Width = 900,
             Height = 500
@@ -291,7 +291,7 @@ public sealed class CommandAssistLayoutTests
     [AvaloniaFact]
     public void TerminalPane_WhenSshStartupHasTransientTermViewBounds_UsesPaneBoundsForFallbackLayout()
     {
-        var pane = new TerminalPane
+        using var pane = new TerminalPane
         {
             Width = 900,
             Height = 500
@@ -323,7 +323,7 @@ public sealed class CommandAssistLayoutTests
     [AvaloniaFact]
     public void TerminalPane_WhenRemotePromptIsInUpperBandOnShortPane_SuppressesConservativeAssistLayout()
     {
-        var pane = new TerminalPane
+        using var pane = new TerminalPane
         {
             Width = 900,
             Height = 220
@@ -353,7 +353,7 @@ public sealed class CommandAssistLayoutTests
     [AvaloniaFact]
     public void TerminalPane_WhenRemotePromptSettlesLowOnShortPane_ResumesConservativeAssistLayout()
     {
-        var pane = new TerminalPane
+        using var pane = new TerminalPane
         {
             Width = 900,
             Height = 220
@@ -383,7 +383,7 @@ public sealed class CommandAssistLayoutTests
     [AvaloniaFact]
     public void TerminalPane_WhenRemotePromptHintRowsLagPaneHeight_UsesPaneEstimatedRowsForConservativeFallback()
     {
-        var pane = new TerminalPane
+        using var pane = new TerminalPane
         {
             Width = 900,
             Height = 500
@@ -415,7 +415,7 @@ public sealed class CommandAssistLayoutTests
     [AvaloniaFact]
     public async Task TerminalPane_WhenPopupIsVisible_AnchorsPopupTopToCalculatedRect()
     {
-        var pane = new TerminalPane
+        using var pane = new TerminalPane
         {
             Width = 900,
             Height = 500
@@ -438,7 +438,7 @@ public sealed class CommandAssistLayoutTests
     [AvaloniaFact]
     public async Task TerminalPane_WhenPopupIsNarrow_UsesCompactPopupLayout()
     {
-        var pane = new TerminalPane
+        using var pane = new TerminalPane
         {
             Width = 420,
             Height = 420
@@ -463,7 +463,7 @@ public sealed class CommandAssistLayoutTests
     [AvaloniaFact]
     public async Task TerminalPane_WhenAssistBecomesVisible_DoesNotChangeTerminalRowHeight()
     {
-        var pane = new TerminalPane
+        using var pane = new TerminalPane
         {
             Width = 900,
             Height = 500

--- a/tests/NovaTerminal.App.Tests/CommandAssist/TerminalPaneCommandAssistShortcutTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/TerminalPaneCommandAssistShortcutTests.cs
@@ -14,7 +14,7 @@ public sealed class TerminalPaneCommandAssistShortcutTests
     [AvaloniaFact]
     public void ApplySettings_WhenAssistEnabled_DoesNotEagerlyInitializeController()
     {
-        var pane = new TerminalPane();
+        using var pane = new TerminalPane();
         var settings = TerminalSettings.Load();
         settings.CommandAssistEnabled = true;
         settings.CommandAssistHistoryEnabled = true;
@@ -27,7 +27,7 @@ public sealed class TerminalPaneCommandAssistShortcutTests
     [AvaloniaFact]
     public void TryToggleCommandAssistPinShortcut_WhenAssistVisibleWithoutSelection_ReturnsFalse()
     {
-        var pane = new TerminalPane();
+        using var pane = new TerminalPane();
         ConfigureCommandAssist(pane);
         pane.ToggleCommandAssist();
 
@@ -39,7 +39,7 @@ public sealed class TerminalPaneCommandAssistShortcutTests
     [AvaloniaFact]
     public void TryHandleCommandAssistKey_WhenAssistVisible_DoesNotConsumeTab()
     {
-        var pane = new TerminalPane();
+        using var pane = new TerminalPane();
         ConfigureCommandAssist(pane);
         pane.ToggleCommandAssist();
 
@@ -51,7 +51,7 @@ public sealed class TerminalPaneCommandAssistShortcutTests
     [AvaloniaFact]
     public void OpenCommandAssistHelp_WhenDisabledInSettings_ReturnsFalse()
     {
-        var pane = new TerminalPane();
+        using var pane = new TerminalPane();
         var settings = TerminalSettings.Load();
         settings.CommandAssistEnabled = false;
         settings.CommandAssistHistoryEnabled = true;
@@ -66,7 +66,7 @@ public sealed class TerminalPaneCommandAssistShortcutTests
     [AvaloniaFact]
     public async Task OpenCommandAssistHelp_WhenQueryPresent_UsesPaneInfrastructure()
     {
-        var pane = new TerminalPane();
+        using var pane = new TerminalPane();
         ConfigureCommandAssist(pane);
         pane.NotifyCommandAssistPaste("Get-ChildItem");
 
@@ -83,7 +83,7 @@ public sealed class TerminalPaneCommandAssistShortcutTests
     [AvaloniaFact]
     public async Task HandleCommandAssistCompletionAsync_WhenNonZeroExit_OpensFixModeForTrackedCommand()
     {
-        var pane = new TerminalPane();
+        using var pane = new TerminalPane();
         ConfigureCommandAssist(pane);
         pane.NotifyCommandAssistPaste("gti status");
 
@@ -98,7 +98,7 @@ public sealed class TerminalPaneCommandAssistShortcutTests
     [AvaloniaFact]
     public async Task HandleCommandAssistCompletionAsync_WhenZeroExit_DoesNotOpenFixMode()
     {
-        var pane = new TerminalPane();
+        using var pane = new TerminalPane();
         ConfigureCommandAssist(pane);
         pane.NotifyCommandAssistPaste("gti status");
 
@@ -112,7 +112,7 @@ public sealed class TerminalPaneCommandAssistShortcutTests
     [AvaloniaFact]
     public async Task HandleCommandAssistCompletionAsync_WhenKnownCommandFails_DoesNotOpenTypoFixMode()
     {
-        var pane = new TerminalPane();
+        using var pane = new TerminalPane();
         ConfigureCommandAssist(pane);
         pane.NotifyCommandAssistPaste("git commit");
 
@@ -127,7 +127,7 @@ public sealed class TerminalPaneCommandAssistShortcutTests
     [AvaloniaFact]
     public void CanExplainSelection_WhenSelectionIsEmpty_ReturnsFalse()
     {
-        var pane = new TerminalPane();
+        using var pane = new TerminalPane();
         ConfigureCommandAssist(pane);
 
         Assert.False(pane.CanExplainSelection());
@@ -136,7 +136,7 @@ public sealed class TerminalPaneCommandAssistShortcutTests
     [AvaloniaFact]
     public async Task ExplainSelectionAsync_WhenSelectionTextProvided_OpensHelp()
     {
-        var pane = new TerminalPane();
+        using var pane = new TerminalPane();
         ConfigureCommandAssist(pane);
 
         bool canExplain = pane.CanExplainSelection("fatal: not a git repository");
@@ -152,7 +152,7 @@ public sealed class TerminalPaneCommandAssistShortcutTests
     [AvaloniaFact]
     public void TryOpenCommandAssistHelp_WhenPaneOpensHelp_ReturnsTrue()
     {
-        var pane = new TerminalPane();
+        using var pane = new TerminalPane();
         ConfigureCommandAssist(pane);
         pane.NotifyCommandAssistPaste("git checkout");
 

--- a/tests/NovaTerminal.App.Tests/CommandAssist/TerminalViewKeyHandlingTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/TerminalViewKeyHandlingTests.cs
@@ -166,7 +166,7 @@ public sealed class TerminalViewKeyHandlingTests
     [AvaloniaFact]
     public void PromptHintAndPaneAnchorLayout_WhenCursorRowOrMetricsChange_UpdateWithoutBufferMutation()
     {
-        var pane = new TerminalPane
+        using var pane = new TerminalPane
         {
             Width = 900,
             Height = 500

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowStartupTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowStartupTests.cs
@@ -148,7 +148,7 @@ public sealed class MainWindowStartupTests
         settings.CommandAssistHistoryEnabled = true;
         settings.Keybindings["command_assist_help"] = "Ctrl+Alt+H";
 
-        var pane = new TerminalPane();
+        using var pane = new TerminalPane();
         pane.ApplySettings(settings);
         pane.NotifyCommandAssistPaste("git checkout");
 

--- a/tests/NovaTerminal.App.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/TerminalPaneRemoteFilesSidebarTests.cs
@@ -15,7 +15,7 @@ public sealed class TerminalPaneRemoteFilesSidebarTests
     [AvaloniaFact]
     public void RemoteFilesSidebarHost_IsCreatedOnlyWhenOpened()
     {
-        var pane = new TerminalPane(new TerminalProfile
+        using var pane = new TerminalPane(new TerminalProfile
         {
             Name = "Native SSH",
             Type = ConnectionType.SSH,
@@ -37,7 +37,7 @@ public sealed class TerminalPaneRemoteFilesSidebarTests
     [AvaloniaFact]
     public void NativeSshPane_ContextMenu_KeepsOnlyRemoteFilesEntry()
     {
-        var pane = new TerminalPane(new TerminalProfile
+        using var pane = new TerminalPane(new TerminalProfile
         {
             Name = "Native SSH",
             Type = ConnectionType.SSH,
@@ -54,7 +54,7 @@ public sealed class TerminalPaneRemoteFilesSidebarTests
     [AvaloniaFact]
     public void Sidebar_HidesImmediately_WhenAltScreenBecomesActive()
     {
-        var pane = new TerminalPane();
+        using var pane = new TerminalPane();
 
         pane.ShowRemoteFilesSidebarForTest();
         pane.HandleAltScreenChangedForTest(true);
@@ -65,7 +65,7 @@ public sealed class TerminalPaneRemoteFilesSidebarTests
     [AvaloniaFact]
     public void SidebarEntryPoint_IsUnavailable_ForLocalPane()
     {
-        var pane = new TerminalPane(new TerminalProfile
+        using var pane = new TerminalPane(new TerminalProfile
         {
             Name = "PowerShell",
             Type = ConnectionType.Local,
@@ -78,7 +78,7 @@ public sealed class TerminalPaneRemoteFilesSidebarTests
     [AvaloniaFact]
     public void SidebarEntryPoint_IsUnavailable_ForOpenSshPane()
     {
-        var pane = new TerminalPane(new TerminalProfile
+        using var pane = new TerminalPane(new TerminalProfile
         {
             Name = "OpenSSH",
             Type = ConnectionType.SSH,
@@ -95,7 +95,7 @@ public sealed class TerminalPaneRemoteFilesSidebarTests
     {
         var service = new RecordingRemoteDirectoryBrowserService(
             RemoteSidebarListingResult.Success("/srv/app", Array.Empty<RemoteSidebarEntry>()));
-        var pane = new TerminalPane(new TerminalProfile
+        using var pane = new TerminalPane(new TerminalProfile
         {
             Name = "Native SSH",
             Type = ConnectionType.SSH,
@@ -119,7 +119,7 @@ public sealed class TerminalPaneRemoteFilesSidebarTests
     {
         var service = new RecordingRemoteDirectoryBrowserService(
             RemoteSidebarListingResult.Success("~/downloads", Array.Empty<RemoteSidebarEntry>()));
-        var pane = new TerminalPane(new TerminalProfile
+        using var pane = new TerminalPane(new TerminalProfile
         {
             Name = "Native SSH",
             Type = ConnectionType.SSH,
@@ -142,7 +142,7 @@ public sealed class TerminalPaneRemoteFilesSidebarTests
     {
         var service = new RecordingRemoteDirectoryBrowserService(
             RemoteSidebarListingResult.Success("~/downloads", Array.Empty<RemoteSidebarEntry>()));
-        var pane = new TerminalPane(new TerminalProfile
+        using var pane = new TerminalPane(new TerminalProfile
         {
             Name = "Native SSH",
             Type = ConnectionType.SSH,
@@ -165,7 +165,7 @@ public sealed class TerminalPaneRemoteFilesSidebarTests
     [AvaloniaFact]
     public void SessionExit_KeepsSidebarVisibleInDisconnectedState()
     {
-        var pane = new TerminalPane(new TerminalProfile
+        using var pane = new TerminalPane(new TerminalProfile
         {
             Name = "Native SSH",
             Type = ConnectionType.SSH,

--- a/tests/NovaTerminal.App.Tests/Core/TerminalPaneStartupInstrumentationTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/TerminalPaneStartupInstrumentationTests.cs
@@ -21,7 +21,7 @@ public sealed class TerminalPaneStartupInstrumentationTests
         StartupPerformanceTracker.SetCurrentForTests(tracker);
         try
         {
-            var pane = new TerminalPane("pwsh.exe");
+            using var pane = new TerminalPane("pwsh.exe");
             StartupMetricsSnapshot snapshot = tracker.CreateSnapshot();
 
             Assert.NotNull(pane);

--- a/tests/NovaTerminal.App.Tests/PaneLayoutModelTests.cs
+++ b/tests/NovaTerminal.App.Tests/PaneLayoutModelTests.cs
@@ -15,8 +15,8 @@ namespace NovaTerminal.Tests
         [AvaloniaFact]
         public void FromControl_BuildsSplitTree_WithPaneIds()
         {
-            var left = new TerminalPane { PaneId = Guid.NewGuid() };
-            var right = new TerminalPane { PaneId = Guid.NewGuid() };
+            using var left = new TerminalPane { PaneId = Guid.NewGuid() };
+            using var right = new TerminalPane { PaneId = Guid.NewGuid() };
             var grid = new Grid();
             grid.ColumnDefinitions.Add(new ColumnDefinition(1, GridUnitType.Star));
             grid.ColumnDefinitions.Add(new ColumnDefinition(3, GridUnitType.Pixel));
@@ -40,8 +40,8 @@ namespace NovaTerminal.Tests
         [AvaloniaFact]
         public void FromControl_NormalizesRatios_ForStarColumns()
         {
-            var first = new TerminalPane { PaneId = Guid.NewGuid() };
-            var second = new TerminalPane { PaneId = Guid.NewGuid() };
+            using var first = new TerminalPane { PaneId = Guid.NewGuid() };
+            using var second = new TerminalPane { PaneId = Guid.NewGuid() };
             var grid = new Grid();
             grid.ColumnDefinitions.Add(new ColumnDefinition(3, GridUnitType.Star));
             grid.ColumnDefinitions.Add(new ColumnDefinition(3, GridUnitType.Pixel));

--- a/tests/NovaTerminal.App.Tests/PtyThreadLifecycleTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtyThreadLifecycleTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using NovaTerminal.Pty;
+using NovaTerminal.Shell;
+using Xunit;
+
+namespace NovaTerminal.Tests
+{
+    /// <summary>
+    /// Regression guard for #81: ~16 leaked RustPtySession read/process loops on
+    /// threadpool threads saturated the 17-worker pool (0 idle) on 2-vCPU CI runners,
+    /// starving the xUnit run-completion continuation and hanging the testhost teardown.
+    /// The loops must run on dedicated background threads so a leaked session can never
+    /// consume the threadpool.
+    /// </summary>
+    public class PtyThreadLifecycleTests
+    {
+        [Fact]
+        [Trait("Category", "PtySmoke")]
+        public async Task BackgroundLoops_RunOnDedicatedBackgroundThreads_NotThreadPool()
+        {
+            string shell = ShellHelper.GetDefaultShell();
+            using var session = new RustPtySession(shell, 80, 24);
+
+            await WaitUntilAsync(
+                () => session.ReadLoopThread is not null && session.ProcessLoopThread is not null,
+                TimeSpan.FromSeconds(5));
+
+            Thread read = session.ReadLoopThread!;
+            Thread process = session.ProcessLoopThread!;
+
+            Assert.False(read.IsThreadPoolThread, "ReadLoop must not run on a threadpool thread");
+            Assert.False(process.IsThreadPoolThread, "ProcessLoop must not run on a threadpool thread");
+
+            Assert.True(read.IsBackground, "ReadLoop thread must be a background thread");
+            Assert.True(process.IsBackground, "ProcessLoop thread must be a background thread");
+        }
+
+        private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+        {
+            var sw = Stopwatch.StartNew();
+            while (!condition())
+            {
+                if (sw.Elapsed > timeout)
+                    throw new TimeoutException("PTY loop threads did not start within the timeout.");
+                await Task.Delay(25);
+            }
+        }
+    }
+}

--- a/tests/NovaTerminal.App.Tests/Ssh/TerminalPaneSshDisconnectTests.cs
+++ b/tests/NovaTerminal.App.Tests/Ssh/TerminalPaneSshDisconnectTests.cs
@@ -31,7 +31,7 @@ public sealed class TerminalPaneSshDisconnectTests
             SshHost = "server.example",
             SshUser = "nova"
         };
-        var pane = new TerminalPane(profile);
+        using var pane = new TerminalPane(profile);
 
         pane.HandleSessionExitForTesting(17);
 
@@ -50,7 +50,7 @@ public sealed class TerminalPaneSshDisconnectTests
             Type = ConnectionType.Local,
             Command = "pwsh.exe"
         };
-        var pane = new TerminalPane(profile);
+        using var pane = new TerminalPane(profile);
 
         pane.HandleSessionExitForTesting(5);
 

--- a/tests/NovaTerminal.App.Tests/TestHostThreadPoolConfig.cs
+++ b/tests/NovaTerminal.App.Tests/TestHostThreadPoolConfig.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace NovaTerminal.Tests
+{
+    /// <summary>
+    /// #81 (part 2): Avalonia.Headless.XUnit's <c>AvaloniaTestCase.Run</c> synchronously
+    /// blocks a worker thread per parallel test (<c>TaskAwaiter&lt;RunSummary&gt;.GetResult()</c>),
+    /// while the single shared <c>HeadlessUnitTestSession</c> dispatcher worker — which
+    /// actually runs those tests — is itself a <c>Task.Run</c> that needs a threadpool
+    /// thread. On a 2-vCPU CI runner the default min worker count (= core count) lets the
+    /// parallel blockers consume every pool thread, so the dispatcher worker can never be
+    /// scheduled, the dispatched test Tasks never complete, and the testhost hangs in
+    /// teardown until --blame-hang aborts it.
+    ///
+    /// Part 1 of the fix (RustPtySession loops moved off the threadpool onto dedicated
+    /// background threads) removed an unbounded second consumer that previously masked
+    /// AND amplified this (and is why an earlier SetMinThreads attempt didn't stick).
+    /// This gives the pool guaranteed headroom so the dispatcher worker is always
+    /// schedulable alongside the bounded set of parallel AvaloniaTestCase.Run blockers.
+    /// </summary>
+    internal static class TestHostThreadPoolConfig
+    {
+        [ModuleInitializer]
+        internal static void Init()
+        {
+            ThreadPool.GetMinThreads(out _, out int completionPortThreads);
+            int target = Math.Max(Environment.ProcessorCount * 4, 32);
+            ThreadPool.SetMinThreads(target, completionPortThreads);
+        }
+    }
+}


### PR DESCRIPTION
## What

Fixes the **in-repo half** of the `NovaTerminal.App.Tests` CI teardown hang (#81). Dump analysis (full hang dumps captured under 2-core pinning) showed #81 is **two independent failure modes**:

- **Mode A — in-repo resource leaks → thread-pool starvation.** Fixed here.
- **Mode B — `Avalonia.Headless.XUnit` dispatcher deadlock** (`AvaloniaTestCase.Run` sync-blocks; dispatched test never completes). Upstream, survives all in-repo fixes — tracked at [AvaloniaUI/Avalonia#21467](https://github.com/AvaloniaUI/Avalonia/issues/21467). **Not** addressed here; the #84 non-gating mitigation stays until it's fixed upstream.

## Mode A changes

- **`RustPtySession`**: run `ReadLoop`/`ProcessLoop` on dedicated `IsBackground` threads instead of `Task.Run`. A blocking native `pty_read` + a blocking consuming enumerator on thread-pool threads let leaked sessions saturate the pool (dump: 17/17 workers, 0 idle) and starve the xUnit run-completion on 2-vCPU CI. Dedicated background threads never consume the pool or block process exit.
- **Tests**: dispose the **37 `TerminalPane`** instances created across 8 test files (`using var`). `TerminalPane`'s ctor starts a 2s `DispatcherTimer` and subscribes to the `SftpService` singleton; undisposed panes leaked timers, subscriptions, and PTY sessions (gcroot-confirmed). `TerminalPane.Dispose()` already cleans all of these — the tests just weren't disposing.
- **`TestHostThreadPoolConfig`** (`[ModuleInitializer]` `SetMinThreads`): headroom so the shared headless dispatcher worker stays schedulable alongside parallel `AvaloniaTestCase.Run` blockers (defense-in-depth).
- **`PtyThreadLifecycleTests`** + `InternalsVisibleTo`: regression guard asserting the PTY loops run on dedicated, non-thread-pool background threads.

## Verification

Reproduced the original hang within 1–6 iterations of the real suite pinned to 2 cores; with these fixes the Mode-A pool-starvation hang no longer appears in that signature (PTY loops off the pool, leaks released). Mode B still reproduces independently (separate, upstream).

## Notes / not in scope

- Does **not** make `App.Tests` safe to re-gate on a 2-vCPU runner on its own — Mode B is upstream. Keep #84 (`continue-on-error`) until `Avalonia.Headless.XUnit` ships a fix, then bump past 12.0.4 and revert the one-line `ci.yml` gate change.
- The suite still has pre-existing **flaky assertion failures** (e.g. some Windows shell-integration tests) that are unrelated to the teardown hang.

Closes none — #81 stays open to track the upstream Mode-B fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
