### PR TITLE
chore(command-assist): disable by default for 0.3 (feature not production-ready)

### DIFF
--- a/src/NovaTerminal.App/Shell/TerminalSettings.cs
+++ b/src/NovaTerminal.App/Shell/TerminalSettings.cs
@@ -40,7 +40,9 @@ namespace NovaTerminal.Shell
 
         public bool QuakeModeEnabled { get; set; } = true;
         public string GlobalHotkey { get; set; } = "Alt+OemTilde";
-        public bool CommandAssistEnabled { get; set; } = true;
+        // Disabled by default as of 0.3: the Command Assist feature isn't production-ready
+        // yet. This master flag gates the whole feature; users can opt in via Settings.
+        public bool CommandAssistEnabled { get; set; } = false;
         public bool CommandAssistHistoryEnabled { get; set; } = true;
         public int CommandAssistMaxHistoryEntries { get; set; } = 5000;
         public bool CommandAssistAutoHideInAltScreen { get; set; } = true;

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistDefaultDisabledTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistDefaultDisabledTests.cs
@@ -1,0 +1,19 @@
+using NovaTerminal.Shell;
+using Xunit;
+
+namespace NovaTerminal.Tests.CommandAssist;
+
+public sealed class CommandAssistDefaultDisabledTests
+{
+    // Command Assist ships disabled by default for 0.3 — the feature isn't ready yet.
+    // The master CommandAssistEnabled flag gates IsCommandAssistFeatureEnabled(); users
+    // can still opt in via Settings. Sub-feature defaults are intentionally left on so
+    // that opting in gives the full experience.
+    [Fact]
+    public void CommandAssist_IsDisabledByDefault()
+    {
+        var settings = new TerminalSettings();
+
+        Assert.False(settings.CommandAssistEnabled);
+    }
+}


### PR DESCRIPTION
Disables Command Assist by default ahead of the 0.3 release — the feature isn't in good shape yet.

## Change
- `TerminalSettings.CommandAssistEnabled` default `true` → `false`. This master flag gates `IsCommandAssistFeatureEnabled()` (`CommandAssistEnabled && CommandAssistHistoryEnabled`), so the whole feature is off by default.
- Users can still opt in via **Settings** (the existing `commandAssistToggle` binds to this flag).
- Sub-feature defaults (history, shell/PowerShell integration) intentionally left `true` so opting in gives the full experience.

## Tests
- New `CommandAssistDefaultDisabledTests` asserts the default is `false` (TDD: red→green).
- Existing Command Assist tests are unaffected — they all set `CommandAssistEnabled` explicitly. Full CommandAssist suite: 276 passed, 0 failed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)