### PR TITLE
chore(release): bump version to 0.3.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
-    <Version>0.2.0</Version>
-    <AssemblyVersion>0.2.0.0</AssemblyVersion>
-    <FileVersion>0.2.0.0</FileVersion>
-    <InformationalVersion>0.2.0</InformationalVersion>
+    <Version>0.3.0</Version>
+    <AssemblyVersion>0.3.0.0</AssemblyVersion>
+    <FileVersion>0.3.0.0</FileVersion>
+    <InformationalVersion>0.3.0</InformationalVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Bumps `Directory.Build.props` 0.2.0 → 0.3.0 (Version / AssemblyVersion / FileVersion / InformationalVersion) ahead of the `v0.3.0` tag.

Merge this, then tag `v0.3.0` on `main` to trigger `release.yml` (GitHub release + native libs + AOT zips for win-x64 / linux-x64 / osx-arm64).

Prereqs already landed: Command Assist disabled by default (#90), #81 Mode-A leak fixes (#89). Windows installer/auto-update/signing deferred to #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)