### PR TITLE
fix(ssh): let Enter reconnect after a disconnect instead of being swallowed

### DIFF
--- a/src/NovaTerminal.App/Shell/TerminalView.cs
+++ b/src/NovaTerminal.App/Shell/TerminalView.cs
@@ -148,6 +148,14 @@ namespace NovaTerminal.Shell
             switch (key)
             {
                 case Key.Enter:
+                    if (!_session.IsProcessRunning)
+                    {
+                        // The session has exited (e.g. SSH disconnected) but the dead session
+                        // object is kept around so the "[Press Enter to reconnect]" banner works.
+                        // Don't swallow Enter into the dead PTY — let it bubble up to
+                        // TerminalPane.OnKeyDown, which owns the reconnect-on-Enter logic.
+                        return false;
+                    }
                     _session.SendInput("\r");
                     EnterObserved?.Invoke();
                     return true;

--- a/tests/NovaTerminal.App.Tests/CommandAssist/TerminalViewKeyHandlingTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/TerminalViewKeyHandlingTests.cs
@@ -55,6 +55,38 @@ public sealed class TerminalViewKeyHandlingTests
     }
 
     [AvaloniaFact]
+    public void HandleKeyDownCore_WhenSessionNotRunning_DoesNotConsumeEnter_SoPaneCanReconnect()
+    {
+        // Regression: after an SSH disconnect the dead session object is kept around so the
+        // "[Press Enter to reconnect]" banner works. TerminalView (the focused child) must not
+        // swallow Enter into the dead PTY — it has to bubble up to TerminalPane.OnKeyDown, which
+        // owns the reconnect-on-Enter logic. Consuming it here is what made reconnect impossible.
+        var session = new Mock<ITerminalSession>();
+        session.SetupGet(x => x.IsProcessRunning).Returns(false);
+        var view = new TerminalView();
+        view.SetSession(session.Object);
+
+        bool handled = view.HandleKeyDownCore(Key.Enter, KeyModifiers.None);
+
+        Assert.False(handled);
+        session.Verify(x => x.SendInput(It.IsAny<string>()), Times.Never);
+    }
+
+    [AvaloniaFact]
+    public void HandleKeyDownCore_WhenSessionRunning_ForwardsEnterToSession()
+    {
+        var session = new Mock<ITerminalSession>();
+        session.SetupGet(x => x.IsProcessRunning).Returns(true);
+        var view = new TerminalView();
+        view.SetSession(session.Object);
+
+        bool handled = view.HandleKeyDownCore(Key.Enter, KeyModifiers.None);
+
+        Assert.True(handled);
+        session.Verify(x => x.SendInput("\r"), Times.Once);
+    }
+
+    [AvaloniaFact]
     public void HandleKeyDownCore_WhenAltLetterPressed_SendsEscapePrefixedSequence()
     {
         var session = new Mock<ITerminalSession>();

--- a/tests/NovaTerminal.App.Tests/Ssh/TerminalPaneSshDisconnectTests.cs
+++ b/tests/NovaTerminal.App.Tests/Ssh/TerminalPaneSshDisconnectTests.cs
@@ -86,16 +86,23 @@ public sealed class TerminalPaneSshDisconnectTests
         view!.SetSession(deadSession.Object);
 
         var window = new Window { Content = pane, Width = 600, Height = 400 };
-        window.Show();
-        view.Focus();
-        Assert.True(pane.IsKeyboardFocusWithin);
+        try
+        {
+            window.Show();
+            view.Focus();
+            Assert.True(pane.IsKeyboardFocusWithin);
 
-        window.KeyPress(Key.Enter, RawInputModifiers.None, PhysicalKey.Enter, "\r");
+            window.KeyPress(Key.Enter, RawInputModifiers.None, PhysicalKey.Enter, "\r");
 
-        // Enter was not forwarded to the dead session...
-        deadSession.Verify(x => x.SendInput(It.IsAny<string>()), Times.Never);
-        // ...and the pane's reconnect path ran.
-        Assert.Contains("Reconnecting", GetVisiblePlainText(pane.Buffer!), StringComparison.Ordinal);
+            // Enter was not forwarded to the dead session...
+            deadSession.Verify(x => x.SendInput(It.IsAny<string>()), Times.Never);
+            // ...and the pane's reconnect path ran.
+            Assert.Contains("Reconnecting", GetVisiblePlainText(pane.Buffer!), StringComparison.Ordinal);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     private static string GetVisiblePlainText(TerminalBuffer buffer)

--- a/tests/NovaTerminal.App.Tests/Ssh/TerminalPaneSshDisconnectTests.cs
+++ b/tests/NovaTerminal.App.Tests/Ssh/TerminalPaneSshDisconnectTests.cs
@@ -1,5 +1,9 @@
 using NovaTerminal.Shell;
+using Avalonia.Controls;
+using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Moq;
 using NovaTerminal.Controls;
 using NovaTerminal.Platform;
 using NovaTerminal.VT;
@@ -57,6 +61,41 @@ public sealed class TerminalPaneSshDisconnectTests
         string visibleText = GetVisiblePlainText(pane.Buffer!);
         Assert.Equal(5, pane.LastExitCode);
         Assert.DoesNotContain("SSH session disconnected", visibleText, StringComparison.Ordinal);
+    }
+
+    [AvaloniaFact]
+    public void RealEnterKeyPress_AfterDisconnect_BubblesToPaneAndTriggersReconnect()
+    {
+        // End-to-end through Avalonia's real input pipeline: a dead session is left attached to
+        // the focused TerminalView (as happens after an SSH disconnect). Pressing Enter must NOT
+        // be swallowed into the dead PTY — it has to bubble TerminalView -> TerminalPane.OnKeyDown,
+        // whose reconnect handler runs Reconnect(), which writes a "[Reconnecting...]" marker.
+        var profile = new TerminalProfile
+        {
+            Name = "Native SSH",
+            Type = ConnectionType.SSH,
+            SshHost = "server.example",
+            SshUser = "nova"
+        };
+        var deadSession = new Mock<ITerminalSession>();
+        deadSession.SetupGet(x => x.IsProcessRunning).Returns(false);
+
+        using var pane = new TerminalPane(profile);
+        var view = pane.FindControl<TerminalView>("TermView");
+        Assert.NotNull(view);
+        view!.SetSession(deadSession.Object);
+
+        var window = new Window { Content = pane, Width = 600, Height = 400 };
+        window.Show();
+        view.Focus();
+        Assert.True(pane.IsKeyboardFocusWithin);
+
+        window.KeyPress(Key.Enter, RawInputModifiers.None, PhysicalKey.Enter, "\r");
+
+        // Enter was not forwarded to the dead session...
+        deadSession.Verify(x => x.SendInput(It.IsAny<string>()), Times.Never);
+        // ...and the pane's reconnect path ran.
+        Assert.Contains("Reconnecting", GetVisiblePlainText(pane.Buffer!), StringComparison.Ordinal);
     }
 
     private static string GetVisiblePlainText(TerminalBuffer buffer)


### PR DESCRIPTION
## Problem

When an SSH session disconnects, the terminal shows `[SSH session disconnected]` / `[Press Enter to reconnect]`, but pressing **Enter does nothing** — the session never recovers.

## Root cause

After a disconnect, `TerminalPane.HandleSessionExit` writes the banner but deliberately keeps the dead session object attached (it's only cleared on actual reconnect/dispose). The reconnect-on-Enter logic lives in **`TerminalPane.OnKeyDown`** (`TerminalPane.axaml.cs:1984`).

But the focused control is the inner **`TerminalView`**, a *child* of the pane. In Avalonia's bubbling phase the child runs first, and `TerminalView.HandleKeyDownCore` consumed Enter unconditionally:

```csharp
case Key.Enter:
    _session.SendInput("\r");   // no-op into the dead PTY
    EnterObserved?.Invoke();
    return true;                // -> e.Handled = true
```

It never checked `_session.IsProcessRunning`. So `TerminalView` marked the event handled and it **never bubbled up to `TerminalPane.OnKeyDown`**, where the reconnect would fire. Enter just disappeared into a dead PTY.

The session layers were fine — both `RustPtySession` and `NativeSshSession` flip their exited flag *before* firing `OnExit`, so `IsProcessRunning` is already `false` when the banner shows; the key event just never reached the reconnect handler.

## Fix

In `TerminalView`, when the session isn't running, don't consume Enter — return `false` so it bubbles to `TerminalPane.OnKeyDown`, where `ShouldReconnectOnEnter(Session)` is true and `Reconnect()` fires. Scoped to the `Key.Enter` case only, so no other key behavior changes.

## Tests

- Unit tests on `HandleKeyDownCore` for the dead-session (Enter not consumed) and live-session (Enter still forwarded) cases.
- A real-input-pipeline test — real `Window` + `KeyPress` through Avalonia's actual `TerminalView -> TerminalPane` bubbling — proving Enter now reaches the pane and runs `Reconnect()`. Verified to **fail without the fix** (the dead session received `SendInput` and no reconnect occurred), so it guards against regression.

All 16 disconnect + key-handling tests pass. Also smoke-tested by launching the real GUI build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
