### PR TITLE
fix(render): keep default-equal explicit backgrounds transparent under window opacity

### DIFF
--- a/src/NovaTerminal.App/Shell/TerminalDrawOperation.cs
+++ b/src/NovaTerminal.App/Shell/TerminalDrawOperation.cs
@@ -35,7 +35,6 @@ namespace NovaTerminal.Shell
         private readonly ConcurrentDictionary<string, SKTypeface?> _fallbackCache;
         private readonly SKTypeface[] _fallbackChain;
         private readonly float _opacity;
-        private readonly bool _transparentBackground;
         private readonly bool _hideCursor;
         private readonly double _renderScaling;
         private readonly int _bufferRows;
@@ -171,7 +170,6 @@ namespace NovaTerminal.Shell
             ConcurrentDictionary<string, SKTypeface?> fallbackCache,
             SKTypeface[] fallbackChain,
             double opacity,
-            bool transparentBackground,
             bool hideCursor,
             double renderScaling = 1.0,
             int snapshotRows = 0,
@@ -202,7 +200,6 @@ namespace NovaTerminal.Shell
             _fallbackCache = fallbackCache;
             _fallbackChain = fallbackChain;
             _opacity = (float)Math.Clamp(opacity, 0.0, 1.0);
-            _transparentBackground = transparentBackground;
             _hideCursor = hideCursor;
             _renderScaling = renderScaling;
             _bufferRows = snapshotRows;
@@ -2678,12 +2675,35 @@ namespace NovaTerminal.Shell
         private SKColor ResolveCellBackground(RenderCellSnapshot cell, SKColor themeBg, byte alpha, RenderThemeSnapshot themeSnapshot)
         {
             if (cell.IsDefaultBackground) return themeBg;
+
+            SKColor resolved;
             if (cell.BgIndex >= 0)
             {
                 var c = ResolvePaletteIndex(cell.BgIndex, themeSnapshot);
-                return new SKColor(c.R, c.G, c.B, 255);
+                resolved = new SKColor(c.R, c.G, c.B, 255);
             }
-            return new SKColor(cell.Background.R, cell.Background.G, cell.Background.B, 255);
+            else
+            {
+                resolved = new SKColor(cell.Background.R, cell.Background.G, cell.Background.B, 255);
+            }
+
+            // Under window transparency (alpha < 255), an explicit background whose color is
+            // identical to the theme background must stay just as transparent as a default-background
+            // cell. Remote programs routinely paint the default color explicitly — e.g. SGR 40 on a
+            // dark theme where Background == ANSI black, or an erase-line/-screen issued while a
+            // default-equal background is active. Returning the alpha-baked themeBg here (instead of
+            // an opaque copy) lets the existing `bg != themeBg` draw guard skip the fill, so these
+            // cells show the see-through theme layer rather than an opaque island. This is the
+            // "solid block at the top of a fresh SSH session" bug.
+            if (alpha != 255 &&
+                resolved.Red == themeBg.Red &&
+                resolved.Green == themeBg.Green &&
+                resolved.Blue == themeBg.Blue)
+            {
+                return themeBg;
+            }
+
+            return resolved;
         }
 
         private static TermColor ResolvePaletteIndex(int index, RenderThemeSnapshot themeSnapshot)

--- a/src/NovaTerminal.App/Shell/TerminalView.cs
+++ b/src/NovaTerminal.App/Shell/TerminalView.cs
@@ -1557,7 +1557,6 @@ namespace NovaTerminal.Shell
                 _fallbackCache,
                 FallbackChain.ToArray(),
                 _windowOpacity,
-                _windowOpacity < 1.0,
                 hideCursor,
                 scaling,
                 snapshotRows,

--- a/tests/NovaTerminal.App.Tests/Infra/SnapshotService.cs
+++ b/tests/NovaTerminal.App.Tests/Infra/SnapshotService.cs
@@ -66,7 +66,6 @@ namespace NovaTerminal.Tests.Infra
                 fallbackCache: new ConcurrentDictionary<string, SKTypeface?>(),
                 fallbackChain: Array.Empty<SKTypeface>(),
                 opacity: 1.0,
-                transparentBackground: false,
                 hideCursor: options.HideCursor,
                 renderScaling: options.RenderScaling <= 0 ? 1.0 : options.RenderScaling,
                 snapshotRows: buffer.Rows,

--- a/tests/NovaTerminal.App.Tests/Performance/Infra/RenderPerfSteadyScrollHarness.cs
+++ b/tests/NovaTerminal.App.Tests/Performance/Infra/RenderPerfSteadyScrollHarness.cs
@@ -128,7 +128,6 @@ namespace NovaTerminal.Tests.Performance.Infra
                         fallbackCache: new ConcurrentDictionary<string, SKTypeface?>(),
                         fallbackChain: Array.Empty<SKTypeface>(),
                         opacity: 1.0,
-                        transparentBackground: false,
                         hideCursor: true,
                         renderScaling: 1.0,
                         snapshotRows: buffer.Rows,

--- a/tests/NovaTerminal.App.Tests/RenderTests/BlockSeamRegressionTests.cs
+++ b/tests/NovaTerminal.App.Tests/RenderTests/BlockSeamRegressionTests.cs
@@ -180,7 +180,6 @@ namespace NovaTerminal.Tests.RenderTests
                 fallbackCache: new ConcurrentDictionary<string, SKTypeface?>(),
                 fallbackChain: Array.Empty<SKTypeface>(),
                 opacity: 1.0,
-                transparentBackground: false,
                 hideCursor: true,
                 renderScaling: renderScaling,
                 snapshotRows: buffer.Rows,

--- a/tests/NovaTerminal.App.Tests/RenderTests/TransparentDefaultEqualBackgroundTests.cs
+++ b/tests/NovaTerminal.App.Tests/RenderTests/TransparentDefaultEqualBackgroundTests.cs
@@ -1,0 +1,146 @@
+using NovaTerminal.Shell;
+using Avalonia;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using NovaTerminal.Platform;
+using NovaTerminal.VT;
+using NovaTerminal.Rendering;
+using SkiaSharp;
+using System;
+using System.Collections.Concurrent;
+
+namespace NovaTerminal.Tests.RenderTests
+{
+    // Regression: when window transparency is enabled, an explicit background whose color is
+    // identical to the theme background (e.g. a remote SGR "40" / erased line on a dark theme
+    // where Background == ANSI black) must stay transparent, exactly like a default-background
+    // cell. Otherwise it renders as an opaque island over the see-through theme layer — the
+    // "solid block at the top of a fresh SSH session" bug.
+    public class TransparentDefaultEqualBackgroundTests
+    {
+        private static readonly CellMetrics Metrics = new()
+        {
+            CellWidth = 8.4f,
+            CellHeight = 18.0f,
+            Baseline = 14.0f,
+            Ascent = 14.0f,
+            Descent = 4.0f
+        };
+
+        [AvaloniaFact]
+        public void ExplicitBackgroundEqualToThemeBackground_IsTransparent_UnderWindowOpacity()
+        {
+            const int cols = 40;
+            const int rows = 3;
+            const double opacity = 0.5;
+
+            // Cols 0..7 get an explicit palette-0 (black) background that equals the theme
+            // background; the rest of the row stays at the default background.
+            using var bmp = Render("\x1b[40m        \x1b[49m", cols, rows, opacity);
+
+            int y = (int)Math.Round(Metrics.CellHeight * 0.5);
+            int explicitBgX = XForColCenter(2); // inside the SGR-40 run, over a space (no glyph)
+            int defaultBgX = XForColCenter(20); // never-written default cell
+
+            SKColor explicitBg = bmp.GetPixel(explicitBgX, y);
+            SKColor defaultBg = bmp.GetPixel(defaultBgX, y);
+
+            // The default cell shows the semi-transparent theme layer (~128 alpha).
+            Assert.True(defaultBg.Alpha < 255,
+                $"sanity: default-bg cell should be semi-transparent, got alpha={defaultBg.Alpha}");
+
+            // The explicit default-equal cell must be just as transparent — not an opaque block.
+            Assert.True(Math.Abs(explicitBg.Alpha - defaultBg.Alpha) <= 2,
+                $"explicit bg equal to theme bg rendered opaque under transparency: " +
+                $"explicit alpha={explicitBg.Alpha}, default alpha={defaultBg.Alpha}");
+        }
+
+        [AvaloniaFact]
+        public void ExplicitBackgroundEqualToThemeBackground_StaysOpaque_WhenNotTransparent()
+        {
+            const int cols = 40;
+            const int rows = 3;
+
+            using var bmp = Render("\x1b[40m        \x1b[49m", cols, rows, opacity: 1.0);
+
+            int y = (int)Math.Round(Metrics.CellHeight * 0.5);
+            SKColor explicitBg = bmp.GetPixel(XForColCenter(2), y);
+
+            // No transparency: everything is fully opaque (no behavior change for the common case).
+            Assert.Equal(255, explicitBg.Alpha);
+        }
+
+        private static int XForColCenter(int col)
+        {
+            const double paddingLeft = 4.0;
+            return (int)Math.Round(paddingLeft + ((col + 0.5) * Metrics.CellWidth));
+        }
+
+        private static SKBitmap Render(string text, int cols, int rows, double opacity)
+        {
+            int width = (int)Math.Ceiling((cols * Metrics.CellWidth) + 8);
+            int height = (int)Math.Ceiling(rows * Metrics.CellHeight);
+
+            var buffer = new TerminalBuffer(cols, rows)
+            {
+                Theme = new TerminalTheme
+                {
+                    Foreground = TermColor.White,
+                    Background = TermColor.Black,
+                    CursorColor = TermColor.White
+                }
+            };
+            // Feed through the real ANSI parser so SGR sequences (e.g. "40m") are interpreted,
+            // not written as literal characters.
+            new AnsiParser(buffer).Process(text);
+
+            var bitmap = new SKBitmap(width, height);
+            using var canvas = new SKCanvas(bitmap);
+
+            var typeface = new Typeface("Cascadia Code, Consolas, Monospace");
+            var glyphTypeface = typeface.GlyphTypeface;
+            var skTypeface = new SharedSKTypeface(SKTypeface.FromFamilyName(typeface.FontFamily.Name));
+            var skFont = new SharedSKFont(new SKFont(skTypeface.Typeface, 14));
+
+            var op = new TerminalDrawOperation(
+                new Rect(0, 0, width, height),
+                buffer,
+                scrollOffset: 0,
+                selection: new SelectionState(),
+                searchMatches: null,
+                activeSearchIndex: -1,
+                metrics: Metrics,
+                typeface: typeface,
+                fontSize: 14,
+                glyphTypeface: glyphTypeface,
+                skTypeface: skTypeface,
+                skFont: skFont,
+                enableLigatures: false,
+                fallbackCache: new ConcurrentDictionary<string, SKTypeface?>(),
+                fallbackChain: Array.Empty<SKTypeface>(),
+                opacity: opacity,
+                hideCursor: true,
+                renderScaling: 1.0,
+                snapshotRows: buffer.Rows,
+                snapshotCols: buffer.Cols,
+                totalLines: buffer.TotalLines,
+                cursorRow: buffer.CursorRow,
+                cursorCol: buffer.CursorCol,
+                rowCache: null,
+                enableComplexShaping: true,
+                glyphCache: null);
+
+            try
+            {
+                op.DrawTerminalInternal(canvas);
+                return bitmap;
+            }
+            finally
+            {
+                op.Dispose();
+                skFont.Dispose();
+                skTypeface.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

When window transparency is enabled, the first lines of a fresh SSH session render with a **solid (opaque) background** while the rest of the terminal stays correctly see-through.

## Root cause

Under window opacity the whole window is filled with the theme background at *reduced* alpha; default-background cells then draw nothing and show that see-through layer. But `ResolveCellBackground` hardcoded **alpha 255** for every *explicit*/palette background. So a cell whose background was set explicitly to a color equal to the theme background — exactly what a remote SSH session produces on a dark theme (`\e[40m` / palette-0 black where `Background == ANSI black`, dir-colors, or an erase-line/screen issued while a default-equal background is active) — painted a fully opaque rectangle over the transparent layer.

It only became visible *with* transparency; without it, opaque-default and transparent-default look identical.

## Fix

In `ResolveCellBackground`, when transparency is active (`alpha != 255`) and a resolved explicit background's RGB matches the theme background, return the alpha-baked `themeBg` so the existing `bg != themeBg` draw guard skips the fill. Genuinely colored backgrounds (red, blue, …) are untouched, and there is **no change at all when transparency is off**.

Also removed the dead `transparentBackground` constructor parameter / `_transparentBackground` field (assigned but never read), updating all call sites.

## Verification

- New `TransparentDefaultEqualBackgroundTests` (pixel-level render test): fails without the fix (explicit bg alpha=255 vs default 127), passes with it (both 127); a second case asserts explicit backgrounds stay opaque (255) when transparency is off — no regression.
- Render + theme/alt-screen suites: **46 passed, 3 skipped, 0 failed**.
- Manual visual check on a fresh transparent SSH session: confirmed see-through (no solid band).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
