### PR TITLE
feat(shortcuts): keybindings for Connection Manager and Recording

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -65,6 +65,7 @@ Panes allow you to split a single tab into multiple terminal windows.
 NovaTerminal supports high-performance SSH sessions integrated directly into the terminal, with built-in remote file management.
 
 ### 4.1 SSH Profiles and Connection Manager
+- Toggle the **Connection Manager** overlay with `Ctrl+Shift+K` (or the toolbar button).
 - Easily maintain local and SSH profiles in your Settings.
 - **Security:** Credentials use secure platform vault backends. No unexpected password injections triggered by terminal output are allowed for your safety. Fast reconnects and config caching simplify remote work.
 
@@ -136,13 +137,19 @@ Export the current terminal state containing text, colors, and styles.
 - **ANSI:** `Pane: Export Snapshot (ANSI)` (Preserves original styling & colors).
 - **PNG:** `Pane: Export Snapshot (PNG)`
 
-### 6.2 Render Performance HUD
+### 6.2 Session Recording
+Capture the active pane's session to a replayable recording.
+- **Toggle Recording:** `Ctrl+Shift+R` (or the toolbar record button, or `Toggle Recording` in the command palette) starts/stops recording the active pane.
+- **Open a recording:** `Open Recording...` from the command palette.
+- **Browse recordings:** `Open Recordings Folder`.
+
+### 6.3 Render Performance HUD
 - **Toggle Render HUD:** Enables a real-time overlay showing frame time, dirty rows/cells, draw calls, and glyph cache hit rates. Use this when experiencing degraded visual performance.
 
-### 6.3 Debug Screens
+### 6.4 Debug Screens
 - **Box Drawing Test:** Accessible via `Debug: Box Drawing Test Screen` to verify font rendering, gaps, and line alignments.
 
-### 6.4 VT Conformance Report CLI
+### 6.5 VT Conformance Report CLI
 
 NovaTerminal ships a machine-readable VT conformance report derived from its
 coverage matrix. Run the terminal executable with:

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -2127,6 +2127,10 @@ namespace NovaTerminal
             }
             _startup.Checkpoint("MainWindow.AfterInitialTabs");
 
+            // SetupCommandPalette() is lazy (runs on palette open / settings save), so
+            // prime the toolbar shortcut tooltips here for the initial window state.
+            UpdateShortcutTooltips();
+
             // Keyboard Shortcuts
             this.AddHandler(KeyDownEvent, (s, e) =>
             {
@@ -2190,6 +2194,22 @@ namespace NovaTerminal
                 {
                     RecordCommandUsage("settings");
                     _ = OpenSettings(0);
+                    e.Handled = true;
+                    return;
+                }
+
+                if (IsShortcut(e, "connections", "Ctrl+Shift+K"))
+                {
+                    RecordCommandUsage("connections");
+                    ToggleConnections();
+                    e.Handled = true;
+                    return;
+                }
+
+                if (IsShortcut(e, "toggle_recording", "Ctrl+Shift+R"))
+                {
+                    RecordCommandUsage("toggle_recording");
+                    _currentPane?.ToggleRecording();
                     e.Handled = true;
                     return;
                 }
@@ -3992,7 +4012,8 @@ namespace NovaTerminal
             {
                 await OpenSettings(0);
             }, GetEffectiveShortcutBinding("settings", "Ctrl+,"), "settings");
-            CommandRegistry.Register("Connections", "General", () => ToggleConnections(), "", "connections");
+            CommandRegistry.Register("Connections", "General", () => ToggleConnections(), GetEffectiveShortcutBinding("connections", "Ctrl+Shift+K"), "connections");
+            CommandRegistry.Register("Toggle Recording", "General", () => _currentPane?.ToggleRecording(), GetEffectiveShortcutBinding("toggle_recording", "Ctrl+Shift+R"), "toggle_recording");
             CommandRegistry.Register("Open Recording...", "General", () => _ = ExecuteUiCommandAsync(ExecuteOpenRecordingCommandAsync, "Open Recording..."), "");
             CommandRegistry.Register("Open Recordings Folder", "General", () => OpenRecordingsFolder(), "");
 
@@ -4021,6 +4042,22 @@ namespace NovaTerminal
             // Scrolling UX
             CommandRegistry.Register("Scroll: Toggle Smooth", "View", () => { _settings.SmoothScrolling = !_settings.SmoothScrolling; ApplySettingsToAllTabs(); _settings.Save(); }, "");
             CommandRegistry.Register("Debug: Box Drawing Test Screen", "Debug", () => ShowBoxDrawingTestScreen(), "");
+
+            // Keep toolbar tooltips in sync with the (possibly rebound) shortcuts.
+            UpdateShortcutTooltips();
+        }
+
+        private void UpdateShortcutTooltips()
+        {
+            var btnConnections = this.FindControl<Button>("BtnConnections");
+            if (btnConnections != null)
+            {
+                ToolTip.SetTip(btnConnections, $"Connections ({GetEffectiveShortcutBinding("connections", "Ctrl+Shift+K")})");
+            }
+
+            // The record button's tooltip embeds the recording shortcut and is
+            // produced by UpdateRecordButtonUi; re-sync it to pick up rebindings.
+            SyncRecordingButtonState();
         }
 
         private void ShowBoxDrawingTestScreen()
@@ -5291,7 +5328,10 @@ namespace NovaTerminal
             btnRecord.Foreground = isRecording ? activeBrush : inactiveBrush;
             iconRecord.Foreground = isRecording ? activeBrush : inactiveBrush;
             btnRecord.Background = isRecording ? new SolidColorBrush(Color.Parse("#30F1636B")) : Brushes.Transparent;
-            ToolTip.SetTip(btnRecord, isRecording ? "Stop Recording" : "Record Session");
+            var recordingShortcut = GetEffectiveShortcutBinding("toggle_recording", "Ctrl+Shift+R");
+            ToolTip.SetTip(btnRecord, isRecording
+                ? $"Stop Recording ({recordingShortcut})"
+                : $"Record Session ({recordingShortcut})");
         }
     }
 }

--- a/src/NovaTerminal.App/Shell/Shortcuts/ShortcutCatalog.cs
+++ b/src/NovaTerminal.App/Shell/Shortcuts/ShortcutCatalog.cs
@@ -9,6 +9,7 @@ public static class ShortcutCatalog
     [
         new("command_palette", "Command Palette", "General", ShortcutScope.App, "Ctrl+Shift+P"),
         new("settings", "Settings", "General", ShortcutScope.App, "Ctrl+,"),
+        new("connections", "Connection Manager", "General", ShortcutScope.App, "Ctrl+Shift+K"),
         new("new_tab", "New Tab", "General", ShortcutScope.App, "Ctrl+Shift+T"),
         new("close_tab", "Close Tab", "General", ShortcutScope.App, "Ctrl+W"),
         new("next_tab", "Tab: Next (MRU)", "General", ShortcutScope.App, "Ctrl+Tab"),
@@ -23,6 +24,7 @@ public static class ShortcutCatalog
         new("equalize_panes", "Equalize Panes", "View", ShortcutScope.Pane, "Ctrl+Shift+G"),
         new("toggle_pane_zoom", "Pane: Toggle Zoom", "View", ShortcutScope.Pane, "Ctrl+Shift+Z"),
         new("toggle_broadcast_input", "Pane: Toggle Broadcast Input (Tab)", "View", ShortcutScope.Pane, "Ctrl+Shift+B"),
+        new("toggle_recording", "Toggle Recording", "Pane", ShortcutScope.Pane, "Ctrl+Shift+R"),
         new("find", "Find in Terminal", "Edit", ShortcutScope.Pane, "Ctrl+F"),
         new("find_alt", "Find in Terminal (Alt)", "Edit", ShortcutScope.Pane, "Ctrl+Shift+F"),
         new("close_pane", "Close Pane", "General", ShortcutScope.Pane, "Ctrl+Shift+W"),


### PR DESCRIPTION
@
## Summary
Connection Manager and session recording previously had **no keyboard shortcuts**. This adds them, makes them rebindable, and keeps the displayed hints in sync with the live binding.

| Action | Default shortcut | Scope |
|--------|------------------|-------|
| Connection Manager (toggle overlay) | `Ctrl+Shift+K` | App |
| Toggle Recording (active pane) | `Ctrl+Shift+R` | Pane |

## Changes
- **`ShortcutCatalog.cs`** — new `connections` and `toggle_recording` entries. Because the Settings shortcut editor iterates `ShortcutCatalog.GetEntries()`, both automatically get rebindable rows with conflict checking via `ShortcutBindingResolver`.
- **`MainWindow.axaml.cs`**
  - Dispatch blocks in the `KeyDown` handler calling existing `ToggleConnections()` / `_currentPane.ToggleRecording()`, following the `IsShortcut(...)` + `RecordCommandUsage(...)` pattern.
  - Command palette: `Connections` now shows its shortcut; new `Toggle Recording` command registered. Both honor rebinds via `GetEffectiveShortcutBinding`.
  - Toolbar tooltips for the Connections and Record buttons now render the **live** binding (`UpdateShortcutTooltips()` / `UpdateRecordButtonUi`), updating after a rebind with no restart.
  - Fix: `SetupCommandPalette()` is lazy (runs on palette open / settings save, not at startup), so tooltips are also primed once at construction — otherwise the Connection Manager tooltip was blank until the palette/settings were first opened.
- **`docs/USER_MANUAL.md`** — Connection Manager shortcut (§4.1) and a new §6.2 *Session Recording* section.

### Collision check
`Ctrl+Shift+K` / `Ctrl+Shift+R` were both free. Deliberately avoided `Ctrl+Shift+C` (reserved for terminal copy) and `Ctrl+R` (Command Assist history).

## Test plan
- [x] `scripts/build.sh build src/NovaTerminal.App` → 0 errors
- [x] Shortcut test suite (`--filter FullyQualifiedName~Shortcut`) → 34 passed
- [x] App launches and renders; verified first-launch tooltip shows the shortcut, and a Settings rebind updates the tooltip + palette live without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@