### PR TITLE
PTY teardown hardening: pty_cancel_read + PtySafeHandle (#119 #118 #103 #102)

### DIFF
--- a/docs/superpowers/plans/2026-06-10-pty-teardown-hardening.md
+++ b/docs/superpowers/plans/2026-06-10-pty-teardown-hardening.md
@@ -1,0 +1,850 @@
+# PTY Teardown Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add native `pty_cancel_read` + a ref-counting `PtySafeHandle` and an ordered, idempotent teardown so closing a PTY session never blocks on a stuck read and can never use-after-free, plus stop the leaking UI timers.
+
+**Architecture:** A new Rust FFI export breaks the pty so an in-flight blocking read returns; `PtySafeHandle` routes every `pty_*` call through runtime ref-counting so `pty_close` cannot run during any in-flight call; `RustPtySession.Dispose` cancels → joins (bounded) → closes; `TerminalPane`/`TerminalView`/`MainWindow` get idempotent teardown and timer stops.
+
+**Tech Stack:** Rust (`portable-pty`, `windows-sys`, `libc`), C# (.NET 10, `Microsoft.Win32.SafeHandles`), xUnit, Avalonia.
+
+**Spec:** `docs/superpowers/specs/2026-06-10-pty-teardown-hardening-design.md`
+
+**Build/test commands (from repo root):**
+- Rust: `cargo test --manifest-path src/NovaTerminal.App/native/Cargo.toml`
+- C# (targeted, avoids the Mode-B headless flake): `scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter "Category=PtySmoke"`
+- C# build: `scripts/build.ps1 build src/NovaTerminal.App`
+
+> **Spec deviation (flagged):** the spec planned to convert all 9 `Parser.On*` lambdas to named handlers. Implementation review found `InitializeSession` (TerminalPane.axaml.cs:1445) recreates the `Parser` on every (re)start, so those handlers GC with the old parser and do **not** accumulate. The handlers that actually accumulate across restarts are on the **reused `TermView`** (`OnResize`, `MetricsChanged`). Part 3 fixes those instead. Net effect on #102 (no restart-time handler accumulation) is the same, with a smaller, lower-risk diff.
+
+---
+
+## File Structure
+
+| File | Responsibility | Tasks |
+|---|---|---|
+| `src/NovaTerminal.App/native/src/lib.rs` | `pty_cancel_read`; `h_pc`/`h_process` interior mutability | 1–3 |
+| `src/NovaTerminal.Pty/RustPtySession.cs` | `PtySafeHandle`; migrate `Native.*`; ordered idempotent `Dispose` | 4–7 |
+| `tests/NovaTerminal.App.Tests/PtyThreadLifecycleTests.cs` | C# teardown regression guards | 6 |
+| `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs` | idempotent `Dispose`; reused-`TermView` handler idempotency | 8 |
+| `src/NovaTerminal.App/Shell/TerminalView.cs` | stop `_metricsTimer` on detach | 9 |
+| `src/NovaTerminal.App/MainWindow.axaml.cs` | stop `_recordingToastTimer` on close | 10 |
+
+---
+
+## Part 1 — Rust native (`lib.rs`)
+
+### Task 1: Make `h_pc` / `h_process` interior-mutable
+
+**Files:**
+- Modify: `src/NovaTerminal.App/native/src/lib.rs` (struct ~188–197; construction ~344–351, 414–423; readers in `pty_resize` ~504–516, `pty_get_pid` ~545–552, `pty_close` ~573–585)
+
+- [ ] **Step 1: Change the struct fields**
+
+In `pub struct PtyState` change the two Windows handle fields from plain `Option` to `Mutex<Option<…>>`:
+
+```rust
+pub struct PtyState {
+    pub reader: Mutex<Box<dyn Read + Send>>,
+    pub writer: Mutex<Box<dyn Write + Send>>,
+    #[cfg(windows)]
+    pub h_pc: Mutex<Option<windows_sys::Win32::System::Console::HPCON>>,
+    #[cfg(windows)]
+    pub h_process: Mutex<Option<windows_sys::Win32::Foundation::HANDLE>>,
+    pub master: Mutex<Option<Box<dyn portable_pty::MasterPty + Send>>>,
+    pub child: Mutex<Option<Box<dyn portable_pty::Child + Send>>>,
+}
+```
+
+- [ ] **Step 2: Update the two construction sites**
+
+Passthrough branch (was `h_pc: Some(h_pc), h_process: Some(h_process)`):
+
+```rust
+                let state = PtyState {
+                    reader: Mutex::new(reader),
+                    writer: Mutex::new(writer),
+                    h_pc: Mutex::new(Some(h_pc)),
+                    h_process: Mutex::new(Some(h_process)),
+                    master: Mutex::new(None),
+                    child: Mutex::new(None),
+                };
+```
+
+Portable branch (was `h_pc: None, h_process: None`):
+
+```rust
+    let state = PtyState {
+        reader: Mutex::new(reader),
+        writer: Mutex::new(writer),
+        #[cfg(windows)]
+        h_pc: Mutex::new(None),
+        #[cfg(windows)]
+        h_process: Mutex::new(None),
+        master: Mutex::new(Some(pair.master)),
+        child: Mutex::new(Some(child)),
+    };
+```
+
+- [ ] **Step 3: Update the readers in `pty_resize`, `pty_get_pid`, `pty_close`**
+
+`pty_resize` Windows block:
+
+```rust
+        #[cfg(windows)]
+        {
+            if let Ok(h_pc_opt) = state.h_pc.lock() {
+                if let Some(h_pc) = *h_pc_opt {
+                    let size = windows_sys::Win32::System::Console::COORD {
+                        X: cols as i16,
+                        Y: rows as i16,
+                    };
+                    unsafe {
+                        windows_sys::Win32::System::Console::ResizePseudoConsole(h_pc, size);
+                    }
+                    return;
+                }
+            }
+        }
+```
+
+`pty_get_pid` Windows block:
+
+```rust
+        #[cfg(windows)]
+        {
+            if let Ok(h_process_opt) = state.h_process.lock() {
+                if let Some(h_process) = *h_process_opt {
+                    unsafe {
+                        return windows_sys::Win32::System::Threading::GetProcessId(h_process) as c_int;
+                    }
+                }
+            }
+        }
+```
+
+`pty_close` Windows block (take so it is idempotent vs. `pty_cancel_read`):
+
+```rust
+        #[cfg(windows)]
+        {
+            if let Ok(mut h_pc_opt) = state.h_pc.lock() {
+                if let Some(h_pc) = h_pc_opt.take() {
+                    unsafe {
+                        windows_sys::Win32::System::Console::ClosePseudoConsole(h_pc);
+                    }
+                }
+            }
+            if let Ok(mut h_process_opt) = state.h_process.lock() {
+                if let Some(h_process) = h_process_opt.take() {
+                    unsafe {
+                        windows_sys::Win32::Foundation::CloseHandle(h_process);
+                    }
+                }
+            }
+        }
+```
+
+- [ ] **Step 4: Build to verify it compiles**
+
+Run: `cargo build --manifest-path src/NovaTerminal.App/native/Cargo.toml`
+Expected: builds clean (on Linux the `#[cfg(windows)]` blocks are skipped — that is fine).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/native/src/lib.rs
+git commit -m "refactor(pty): make h_pc/h_process interior-mutable for cancel/close split (#118)"
+```
+
+---
+
+### Task 2: Add `pty_cancel_read` with a Rust test
+
+**Files:**
+- Modify: `src/NovaTerminal.App/native/src/lib.rs` (new export after `pty_get_pid`; new test module at end)
+
+- [ ] **Step 1: Write the failing Rust test**
+
+Add at the end of `lib.rs`:
+
+```rust
+#[cfg(test)]
+mod cancel_read_tests {
+    use super::*;
+    use std::ffi::CString;
+    use std::time::Instant;
+
+    // A blocking pty_read on a child with no output must return promptly once
+    // pty_cancel_read is called (kill-to-EOF). Guards #119 / the Dispose join.
+    #[test]
+    fn cancel_read_unblocks_a_pending_read() {
+        // A shell that just sleeps so it produces no output on its own.
+        #[cfg(windows)]
+        let (cmd, args) = ("cmd.exe", "/c timeout /t 30 /nobreak >NUL");
+        #[cfg(not(windows))]
+        let (cmd, args) = ("/bin/sh", "-c 'sleep 30'");
+
+        let c_cmd = CString::new(cmd).unwrap();
+        let c_args = CString::new(args).unwrap();
+        let state = pty_spawn(
+            c_cmd.as_ptr(),
+            c_args.as_ptr(),
+            std::ptr::null(),
+            80,
+            24,
+        );
+        assert!(!state.is_null(), "spawn failed");
+
+        // Reader thread: a single blocking read that should return after cancel.
+        let state_addr = state as usize;
+        let reader = std::thread::spawn(move || {
+            let ptr = state_addr as *mut PtyState;
+            let mut buf = [0u8; 256];
+            pty_read(ptr, buf.as_mut_ptr(), buf.len() as c_int)
+        });
+
+        // Give the read time to block, then cancel.
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        let start = Instant::now();
+        pty_cancel_read(state);
+
+        // The read must return within a couple of seconds, not in ~30s.
+        let rc = reader.join().expect("reader thread panicked");
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(5),
+            "pty_read did not return promptly after cancel"
+        );
+        assert!(rc <= 0, "expected EOF(0) or error(-1) after cancel, got {rc}");
+
+        // close must remain safe (idempotent vs the cancel that already ran).
+        pty_close(state);
+    }
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails to compile**
+
+Run: `cargo test --manifest-path src/NovaTerminal.App/native/Cargo.toml cancel_read`
+Expected: FAIL — `cannot find function pty_cancel_read in this scope`.
+
+- [ ] **Step 3: Implement `pty_cancel_read`**
+
+Add after `pty_get_pid` (before `pty_close`):
+
+```rust
+/// Unblock an in-flight `pty_read` so the caller's read thread can be joined.
+///
+/// The blocked read holds `state.reader`'s lock, so we must NEVER touch `reader`
+/// here. Instead we break the pty from the other side: close the pseudoconsole
+/// (Windows passthrough) and/or kill the child (portable path), which makes the
+/// pending `read()` return EOF/error. Idempotent and safe to call before
+/// `pty_close` (it `take()`s the HPCON so close won't double-free).
+#[unsafe(no_mangle)]
+pub extern "C" fn pty_cancel_read(state_ptr: *mut PtyState) {
+    ffi_guard((), || {
+        if state_ptr.is_null() {
+            return;
+        }
+        // Clone the Arc without consuming the caller's ref (same idiom as pty_read).
+        let state = unsafe {
+            let arc = Arc::from_raw(state_ptr);
+            let cloned = arc.clone();
+            let _ = Arc::into_raw(arc);
+            cloned
+        };
+
+        // Windows passthrough: closing the pseudoconsole breaks the output pipe so
+        // the in-flight ReadFile on h_out_read returns. take() => pty_close won't
+        // double-close.
+        #[cfg(windows)]
+        {
+            if let Ok(mut h_pc_opt) = state.h_pc.lock() {
+                if let Some(h_pc) = h_pc_opt.take() {
+                    unsafe {
+                        windows_sys::Win32::System::Console::ClosePseudoConsole(h_pc);
+                    }
+                }
+            }
+        }
+
+        // Portable path (Unix + Windows non-passthrough): kill the child so the
+        // slave closes and the master read returns EOF.
+        if let Ok(mut child_opt) = state.child.lock() {
+            if let Some(child) = child_opt.as_mut() {
+                let _ = child.kill();
+            }
+        }
+    })
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test --manifest-path src/NovaTerminal.App/native/Cargo.toml cancel_read`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full Rust test suite (no regressions)**
+
+Run: `cargo test --manifest-path src/NovaTerminal.App/native/Cargo.toml`
+Expected: all pass (`ffi_guard_tests`, `passthrough_decision_tests`, `cancel_read_tests`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/NovaTerminal.App/native/src/lib.rs
+git commit -m "feat(pty): add pty_cancel_read to unblock a pending read (#119)"
+```
+
+---
+
+### Task 3: Rebuild the native lib so C# picks it up
+
+**Files:** none (build artifact)
+
+- [ ] **Step 1: Build the native library in release**
+
+Run: `cargo build --release --manifest-path src/NovaTerminal.App/native/Cargo.toml`
+Expected: produces `rusty_pty` (`.dll`/`.so`) in the native `target/release`.
+
+> Note: the `.csproj` copies the native artifact during the app build. If a task below reports a missing `pty_cancel_read` entrypoint at runtime, re-run this step and rebuild the app.
+
+---
+
+## Part 2 — `RustPtySession.cs`
+
+### Task 4: Add `PtySafeHandle`
+
+**Files:**
+- Modify: `src/NovaTerminal.Pty/RustPtySession.cs` (add nested type + `using`)
+
+- [ ] **Step 1: Add the using**
+
+At the top, add:
+
+```csharp
+using Microsoft.Win32.SafeHandles;
+```
+
+- [ ] **Step 2: Add the `PtySafeHandle` nested class**
+
+Inside the `RustPtySession` class (e.g. directly after the `Native` class), add:
+
+```csharp
+        // Owns the *mut PtyState returned by pty_spawn. Passing this to every
+        // pty_* P/Invoke makes the marshaller AddRef before / Release after the
+        // call, so pty_close (ReleaseHandle) can never run while a pty_read (or
+        // any other call) is in flight — closing the #118 use-after-free window.
+        internal sealed class PtySafeHandle : SafeHandleZeroOrMinusOneIsInvalid
+        {
+            public PtySafeHandle() : base(ownsHandle: true) { }
+
+            protected override bool ReleaseHandle()
+            {
+                Native.pty_close(handle);
+                return true;
+            }
+        }
+```
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `scripts/build.ps1 build src/NovaTerminal.Pty`
+Expected: builds (warnings ok). `pty_close(IntPtr)` still exists in `Native`, so `ReleaseHandle` resolves.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/NovaTerminal.Pty/RustPtySession.cs
+git commit -m "feat(pty): add PtySafeHandle wrapping the native PTY pointer (#118)"
+```
+
+---
+
+### Task 5: Migrate `Native.*` signatures and the `_ptyState` field to `PtySafeHandle`
+
+**Files:**
+- Modify: `src/NovaTerminal.Pty/RustPtySession.cs` (`Native` class 39–66; field 14; ctor 233/237/240–243; `IsProcessRunning` 35; `HasActiveChildProcesses` 75–78; `Pid` 86–88; `ReadLoop` 349/351; `SendInput` 431/436; `Resize` 441/445)
+
+- [ ] **Step 1: Update the `Native` P/Invoke signatures**
+
+`pty_spawn`/`pty_spawn_with_envs` return `PtySafeHandle`; `pty_close` keeps an `IntPtr` overload (used by `ReleaseHandle`); all other calls take `PtySafeHandle`; add `pty_cancel_read`:
+
+```csharp
+            [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+            public static extern PtySafeHandle pty_create(string cmd, ushort cols, ushort rows);
+
+            [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+            public static extern PtySafeHandle pty_spawn(string cmd, string? args, string? cwd, ushort cols, ushort rows);
+
+            [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+            public static extern PtySafeHandle pty_spawn_with_envs(string cmd, string? args, string? cwd, ushort cols, ushort rows, string envs);
+
+            [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+            public static extern int pty_read(PtySafeHandle state, byte[] buffer, int len);
+
+            [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+            public static extern int pty_write(PtySafeHandle state, byte[] buffer, int len);
+
+            [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void pty_resize(PtySafeHandle state, ushort cols, ushort rows);
+
+            [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+            public static extern int pty_get_pid(PtySafeHandle state);
+
+            [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void pty_cancel_read(PtySafeHandle state);
+
+            // Raw overload used only by PtySafeHandle.ReleaseHandle().
+            [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void pty_close(IntPtr state);
+```
+
+- [ ] **Step 2: Change the field**
+
+Replace `private IntPtr _ptyState;` (line 14) with:
+
+```csharp
+        private readonly PtySafeHandle _handle;
+```
+
+- [ ] **Step 3: Update the constructor assignment + null check**
+
+Replace the spawn/assignment block (233–243). The two spawns now return `PtySafeHandle`:
+
+```csharp
+                _handle = Native.pty_spawn_with_envs(effectiveShell, combinedArgs.Trim(), cwd, (ushort)cols, (ushort)rows, sb.ToString());
+            }
+            else
+            {
+                _handle = Native.pty_spawn(effectiveShell, combinedArgs.Trim(), cwd, (ushort)cols, (ushort)rows);
+            }
+
+            if (_handle.IsInvalid)
+            {
+                throw new InvalidOperationException("Failed to create Rust PTY session.");
+            }
+```
+
+- [ ] **Step 4: Update the readers of `_ptyState`**
+
+`IsProcessRunning` (35):
+
+```csharp
+        public bool IsProcessRunning => Volatile.Read(ref _isExited) == 0 && !_handle.IsInvalid;
+```
+
+`HasActiveChildProcesses` (75–78):
+
+```csharp
+                if (_handle.IsInvalid) return false;
+                int pid = Native.pty_get_pid(_handle);
+                if (pid <= 0) return false;
+                return HasChildProcesses(pid, ShellCommand);
+```
+
+`Pid` (86–88):
+
+```csharp
+                if (_handle.IsInvalid) return null;
+                int pid = Native.pty_get_pid(_handle);
+                return pid > 0 ? pid : null;
+```
+
+`ReadLoop` (349, 351):
+
+```csharp
+                while (!_cts.Token.IsCancellationRequested && !_handle.IsInvalid)
+                {
+                    int read = Native.pty_read(_handle, buffer, buffer.Length);
+```
+
+`SendInput` (431, 436):
+
+```csharp
+            if (_handle.IsInvalid) return;
+
+            _recorder?.RecordInput(input);
+
+            byte[] data = Encoding.UTF8.GetBytes(input);
+            Native.pty_write(_handle, data, data.Length);
+```
+
+`Resize` (441, 445):
+
+```csharp
+            if (_handle.IsInvalid || cols <= 0 || rows <= 0) return;
+            _cols = cols;
+            _rows = rows;
+            Console.WriteLine($"[RustPtySession] Resizing to {cols}x{rows}");
+            Native.pty_resize(_handle, (ushort)cols, (ushort)rows);
+```
+
+- [ ] **Step 5: Guard `ReadLoop` against a disposed handle race**
+
+A marshalled `pty_read(_handle, …)` throws `ObjectDisposedException` if `Dispose` closed `_handle` between the `IsInvalid` check and the call. Treat it as shutdown. In `ReadLoop`'s outer `catch (Exception ex)` block, add a specific catch *before* it:
+
+```csharp
+            catch (ObjectDisposedException)
+            {
+                // _handle was disposed by Dispose() — normal shutdown.
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[RustPtySession] ReadLoop terminated by unhandled exception: {ex}");
+            }
+```
+
+- [ ] **Step 6: Build to verify it compiles (Dispose still references old `_ptyState` — expected fail)**
+
+Run: `scripts/build.ps1 build src/NovaTerminal.Pty`
+Expected: FAIL — `Dispose()` still uses `_ptyState`/`Native.pty_close(_ptyState)`. Fixed in Task 6. (If you prefer a green build here, do Task 6 Step 3 now.)
+
+---
+
+### Task 6: Ordered, idempotent `Dispose` + C# regression tests
+
+**Files:**
+- Modify: `src/NovaTerminal.Pty/RustPtySession.cs` (`Dispose` 449–474; add fields/const)
+- Test: `tests/NovaTerminal.App.Tests/PtyThreadLifecycleTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these to `PtyThreadLifecycleTests`:
+
+```csharp
+        [Fact]
+        [Trait("Category", "PtySmoke")]
+        public async Task Dispose_WhileReadBlocked_JoinsLoopThreadsPromptly()
+        {
+            string shell = ShellHelper.GetDefaultShell();
+            var session = new RustPtySession(shell, 80, 24);
+
+            await WaitUntilAsync(
+                () => session.ReadLoopThread is not null && session.ProcessLoopThread is not null,
+                TimeSpan.FromSeconds(5));
+
+            Thread read = session.ReadLoopThread!;
+            Thread process = session.ProcessLoopThread!;
+
+            // Let the shell go idle (read parked in native pty_read).
+            await Task.Delay(500);
+
+            var sw = Stopwatch.StartNew();
+            session.Dispose();
+            sw.Stop();
+
+            Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5),
+                $"Dispose took {sw.Elapsed.TotalSeconds:F1}s — cancel/join did not unblock the read");
+            Assert.False(read.IsAlive, "ReadLoop thread should have exited after Dispose");
+            Assert.False(process.IsAlive, "ProcessLoop thread should have exited after Dispose");
+        }
+
+        [Fact]
+        [Trait("Category", "PtySmoke")]
+        public void Dispose_IsIdempotent()
+        {
+            string shell = ShellHelper.GetDefaultShell();
+            var session = new RustPtySession(shell, 80, 24);
+
+            var ex = Record.Exception(() =>
+            {
+                session.Dispose();
+                session.Dispose();
+                session.Dispose();
+            });
+
+            Assert.Null(ex);
+        }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter "Category=PtySmoke"`
+Expected: build FAIL (the old `Dispose` still references `_ptyState`) — or, if Task 5 left it red, that compile error.
+
+- [ ] **Step 3: Add fields/const and rewrite `Dispose`**
+
+Add near the other fields:
+
+```csharp
+        private static readonly TimeSpan DisposeJoinTimeout = TimeSpan.FromSeconds(2);
+        private int _disposed;
+```
+
+Replace `Dispose()` (449–474) with:
+
+```csharp
+        public void Dispose()
+        {
+            // Idempotent: only the first caller runs teardown.
+            if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+
+            if (_recorder != null)
+            {
+                try
+                {
+                    StopRecording();
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"[RustPtySession] StopRecording during dispose failed: {ex.Message}");
+                }
+            }
+
+            // 1. Stop the loops re-entering native calls.
+            _cts.Cancel();
+
+            // 2. Unblock the in-flight native read so the read thread can exit.
+            if (!_handle.IsInvalid)
+            {
+                try { Native.pty_cancel_read(_handle); }
+                catch (ObjectDisposedException) { /* already gone */ }
+            }
+
+            // 3. Let the process loop drain and exit.
+            if (!_outputQueue.IsAddingCompleted)
+            {
+                _outputQueue.CompleteAdding();
+            }
+
+            // 4. Join (bounded) so there are no late callbacks and no thread inside a pty_* call.
+            if (!(_readLoopThread?.Join(DisposeJoinTimeout) ?? true))
+            {
+                Console.WriteLine("[RustPtySession] ReadLoop did not exit within join timeout.");
+            }
+            if (!(_processLoopThread?.Join(DisposeJoinTimeout) ?? true))
+            {
+                Console.WriteLine("[RustPtySession] ProcessLoop did not exit within join timeout.");
+            }
+
+            // 5. Release the handle. SafeHandle guarantees pty_close runs only once
+            //    no pty_* call is in flight, so this is UAF-safe even if a join timed out.
+            _handle.Dispose();
+
+            TryNotifyExit(0);
+        }
+```
+
+- [ ] **Step 4: Build the native lib + app dependency, then run the tests**
+
+Run: `cargo build --release --manifest-path src/NovaTerminal.App/native/Cargo.toml`
+Then: `scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter "Category=PtySmoke"`
+Expected: PASS — all `PtySmoke` tests green (existing thread test + the two new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.Pty/RustPtySession.cs tests/NovaTerminal.App.Tests/PtyThreadLifecycleTests.cs
+git commit -m "feat(pty): ordered idempotent Dispose (cancel->join->close) (#119 #118 #103)"
+```
+
+---
+
+### Task 7: Full app build sanity
+
+**Files:** none
+
+- [ ] **Step 1: Build the app**
+
+Run: `scripts/build.ps1 build src/NovaTerminal.App`
+Expected: builds clean. Fix any remaining `_ptyState` references the compiler flags (there should be none).
+
+- [ ] **Step 2: Commit (only if fixes were needed)**
+
+```bash
+git add -A
+git commit -m "fix(pty): finish PtySafeHandle migration call sites"
+```
+
+---
+
+## Part 3 — `TerminalPane` (#103 pane side + targeted #102)
+
+### Task 8: Idempotent pane `Dispose` + reused-`TermView` handler idempotency
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs` (fields near 96; `InitializeSession` resize/metrics subs 1629–1648; `Dispose` 2183–2201)
+
+- [ ] **Step 1: Add a disposed guard field and named-handler fields**
+
+Near the other private fields (~96):
+
+```csharp
+        private bool _disposed;
+        private Action<int, int>? _onTermViewResize;
+        private Action<float, float>? _onTermViewMetricsChanged;
+```
+
+> Types mirror the event declarations: `TermView.OnResize` is `Action<int, int>` (TerminalView.cs:1212) and `TermView.MetricsChanged` is `Action<float, float>` (TerminalView.cs:49).
+
+- [ ] **Step 2: Make the `TermView` resize/metrics subscriptions idempotent**
+
+Replace the inline lambda subscriptions at 1629–1648 with detach-before-attach using stored delegates (the established codebase idiom, e.g. MainWindow.axaml.cs:2532). First assign the fields once, then detach+attach:
+
+```csharp
+            // Wire up Resize (idempotent across InitializeSession re-runs — TermView is reused).
+            _onTermViewResize ??= (c, r) =>
+            {
+                if (Parser != null)
+                {
+                    float cwResize = TermView.Metrics.CellWidth;
+                    float chResize = TermView.Metrics.CellHeight;
+                    if (cwResize > 0) Parser.CellWidth = cwResize;
+                    if (chResize > 0) Parser.CellHeight = chResize;
+                }
+                Session?.Resize(c, r);
+            };
+            TermView.OnResize -= _onTermViewResize;
+            TermView.OnResize += _onTermViewResize;
+
+            // Metrics changed handling (idempotent — TermView is reused).
+            _onTermViewMetricsChanged ??= (cwMetric, chMetric) =>
+            {
+                if (Parser != null && cwMetric > 0 && chMetric > 0)
+                {
+                    Parser.CellWidth = cwMetric;
+                    Parser.CellHeight = chMetric;
+                }
+            };
+            TermView.MetricsChanged -= _onTermViewMetricsChanged;
+            TermView.MetricsChanged += _onTermViewMetricsChanged;
+```
+
+> The lambdas reference the `Parser`/`Session` fields (not locals), so storing them once and reusing across restarts is correct — they always act on the current parser/session.
+
+- [ ] **Step 3: Make `Dispose` idempotent and detach the reused handlers**
+
+Replace `Dispose` (2183–2201) with:
+
+```csharp
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+
+            CloseRemoteFilesSidebar();
+
+            // Detach handlers on the reused TermView so a disposed pane stops reacting.
+            if (_onTermViewResize != null) TermView.OnResize -= _onTermViewResize;
+            if (_onTermViewMetricsChanged != null) TermView.MetricsChanged -= _onTermViewMetricsChanged;
+
+            if (Buffer != null)
+            {
+                Buffer.OnScreenSwitched -= OnBufferScreenSwitched;
+            }
+            _statusTimer?.Stop();
+            _statusTimer = null;
+            SftpService.Instance.JobUpdated -= Sftp_JobUpdated;
+            if (Session != null)
+            {
+                ITerminalSession session = Session;
+                UnregisterActiveSshSession(session);
+                Session = null;
+                session.Dispose();
+            }
+        }
+```
+
+- [ ] **Step 4: Build to verify it compiles**
+
+Run: `scripts/build.ps1 build src/NovaTerminal.App`
+Expected: builds clean.
+
+- [ ] **Step 5: Manual smoke verification** (headless UI tests hit the Mode-B flake — verify by hand per the project's GUI smoke-test preference)
+
+Run the app (`scripts/build.ps1` run target or launch the built exe), then:
+1. Open a tab, type to confirm output works.
+2. Resize the window several times — confirm no duplicated/janky resize behavior.
+3. Trigger a reconnect/restart (SSH disconnect → Enter, or the reconnect path) a few times — confirm a single bell/title per event and the old session's CPU drops (no lingering process).
+4. Close tabs/panes repeatedly — confirm the app stays responsive and no orphan shells accumulate (Task Manager / `pgrep`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+git commit -m "fix(pane): idempotent Dispose + idempotent TermView handlers across restart (#103 #102)"
+```
+
+---
+
+## Part 4 — Leaking timers (targeted #102)
+
+### Task 9: Stop `_metricsTimer` on detach in `TerminalView`
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Shell/TerminalView.cs` (`OnAttachedToVisualTree` 761–782; `OnDetachedFromVisualTree` 784–796)
+
+- [ ] **Step 1: Stop `_metricsTimer` on detach**
+
+In `OnDetachedFromVisualTree`, after `StopUiTimers();` (789), add:
+
+```csharp
+            _metricsTimer.Stop();
+```
+
+- [ ] **Step 2: Restart `_metricsTimer` on (re)attach so behavior is preserved**
+
+In `OnAttachedToVisualTree`, after `RefreshUiTimerState();` (765), add:
+
+```csharp
+            if (!_metricsTimer.IsEnabled) _metricsTimer.Start();
+```
+
+> Rationale: `_metricsTimer` was started in the ctor and never stopped, so it kept firing every 5s after detach, rooting the view via its `Tick` delegate. Stopping on detach removes the leak; restarting on attach preserves metrics while the view is live.
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `scripts/build.ps1 build src/NovaTerminal.App`
+Expected: builds clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/NovaTerminal.App/Shell/TerminalView.cs
+git commit -m "fix(view): stop _metricsTimer on detach to drop the per-view leak (#102)"
+```
+
+---
+
+### Task 10: Stop `_recordingToastTimer` on close in `MainWindow`
+
+**Files:**
+- Modify: `src/NovaTerminal.App/MainWindow.axaml.cs` (`OnClosing` 5031–5040)
+
+- [ ] **Step 1: Stop the toast timer in `OnClosing`**
+
+In `OnClosing`, before `_globalHotkey?.Dispose();` (5039), add:
+
+```csharp
+            _recordingToastTimer.Stop();
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `scripts/build.ps1 build src/NovaTerminal.App`
+Expected: builds clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/NovaTerminal.App/MainWindow.axaml.cs
+git commit -m "fix(window): stop _recordingToastTimer in OnClosing (#102)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Rust:** `cargo test --manifest-path src/NovaTerminal.App/native/Cargo.toml` → all pass.
+- [ ] **Native rebuilt:** `cargo build --release --manifest-path src/NovaTerminal.App/native/Cargo.toml`.
+- [ ] **C# contract tests:** `scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter "Category=PtySmoke"` → all pass.
+- [ ] **App builds:** `scripts/build.ps1 build src/NovaTerminal.App` → clean.
+- [ ] **Manual smoke** (Task 8 Step 5) performed.
+- [ ] **Issues:** confirm the PR closes #119, #118, #103, and the targeted part of #102. Note in the PR that the `rusty_ssh` SafeHandle mirror and full-`CompositeDisposable` adoption are intentionally out of scope (follow-ups), and that Mode-B re-gating remains tracked in #117.
+
+## Notes for the implementer
+
+- **Do not** run the whole `NovaTerminal.App.Tests` project or full-solution `dotnet test` — the headless Avalonia lane hits the upstream Mode-B deadlock (#81/#117). Always filter to `Category=PtySmoke` for the contract tests, which are non-headless.
+- Always build via `scripts/build.ps1` / `scripts/build.sh`, never raw `dotnet build` (it hangs when stdout is piped — see CLAUDE.md).
+- The native artifact must be rebuilt (Task 3) before the C# side can resolve `pty_cancel_read` at runtime.

--- a/docs/superpowers/plans/2026-06-10-pty-teardown-hardening.md
+++ b/docs/superpowers/plans/2026-06-10-pty-teardown-hardening.md
@@ -660,6 +660,9 @@ Expected: build FAIL (the old `Dispose` still references `_ptyState`) — or, if
 Add near the other fields:
 
 ```csharp
+        // Quick first join: if the shell already exited (EOF), the read loop is
+        // already unwinding and we never need the (potentially ~1s-spinning) cancel.
+        private static readonly TimeSpan QuickJoinTimeout = TimeSpan.FromMilliseconds(250);
         private static readonly TimeSpan DisposeJoinTimeout = TimeSpan.FromSeconds(2);
         private int _disposed;
 ```
@@ -684,27 +687,33 @@ Replace `Dispose()` (449–474) with:
                 }
             }
 
-            // 1. Stop the loops re-entering native calls.
+            // 1. Stop the loops re-entering native calls, and let the process loop drain.
             _cts.Cancel();
-
-            // 2. Unblock the in-flight native read so the read thread can exit.
-            if (!_handle.IsInvalid)
-            {
-                try { Native.pty_cancel_read(_handle); }
-                catch (ObjectDisposedException) { /* already gone */ }
-            }
-
-            // 3. Let the process loop drain and exit.
             if (!_outputQueue.IsAddingCompleted)
             {
                 _outputQueue.CompleteAdding();
             }
 
-            // 4. Join (bounded) so there are no late callbacks and no thread inside a pty_* call.
-            if (!(_readLoopThread?.Join(DisposeJoinTimeout) ?? true))
+            // 2. Quick join. If the shell already exited (EOF), the read loop is
+            //    already unwinding — no cancel needed, and we avoid pty_cancel_read's
+            //    bounded retry spinning when no read is actually blocked.
+            bool readExited = _readLoopThread?.Join(QuickJoinTimeout) ?? true;
+
+            // 3. Only if the read is genuinely still blocked: unblock it, then join hard.
+            if (!readExited)
             {
-                Console.WriteLine("[RustPtySession] ReadLoop did not exit within join timeout.");
+                if (!_handle.IsInvalid)
+                {
+                    try { Native.pty_cancel_read(_handle); }
+                    catch (ObjectDisposedException) { /* already gone */ }
+                }
+                if (!(_readLoopThread?.Join(DisposeJoinTimeout) ?? true))
+                {
+                    Console.WriteLine("[RustPtySession] ReadLoop did not exit within join timeout.");
+                }
             }
+
+            // 4. Join the process loop (it exits once the queue is completed/cancelled).
             if (!(_processLoopThread?.Join(DisposeJoinTimeout) ?? true))
             {
                 Console.WriteLine("[RustPtySession] ProcessLoop did not exit within join timeout.");
@@ -717,6 +726,8 @@ Replace `Dispose()` (449–474) with:
             TryNotifyExit(0);
         }
 ```
+
+> Why quick-join-then-cancel: `pty_cancel_read`'s Windows retry loop can spin up to ~1s when no read is currently blocked (e.g. the shell already exited and the read loop is unwinding). Joining briefly first means the common tab-close path (shell already gone) never pays that cost; the cancel only runs when the read is truly parked on a live, idle child.
 
 - [ ] **Step 4: Build the native lib + app dependency, then run the tests**
 

--- a/docs/superpowers/plans/2026-06-10-pty-teardown-hardening.md
+++ b/docs/superpowers/plans/2026-06-10-pty-teardown-hardening.md
@@ -161,8 +161,10 @@ git commit -m "refactor(pty): make h_pc/h_process interior-mutable for cancel/cl
 
 ### Task 2: Add `pty_cancel_read` with a Rust test
 
+> **Revised mechanism (2026-06-10):** the original kill-to-EOF plan does not unblock the read on the Windows portable-pty path (the GUI app's path) — `reader` is a duplicated pipe handle that only closes at `pty_close`, which `PtySafeHandle` defers until the read returns (a cycle). So the Windows portable path cancels the blocking `ReadFile` directly via `CancelSynchronousIo` against the read thread. Unix still uses `child.kill()`; Windows passthrough still uses `ClosePseudoConsole`. See spec §B.
+
 **Files:**
-- Modify: `src/NovaTerminal.App/native/src/lib.rs` (new export after `pty_get_pid`; new test module at end)
+- Modify: `src/NovaTerminal.App/native/src/lib.rs` (add `read_thread_id` field to `PtyState` + init at both construction sites; record/clear it in `pty_read`; new `pty_cancel_read` export after `pty_get_pid`; new test module at end)
 
 - [ ] **Step 1: Write the failing Rust test**
 
@@ -175,8 +177,11 @@ mod cancel_read_tests {
     use std::ffi::CString;
     use std::time::Instant;
 
-    // A blocking pty_read on a child with no output must return promptly once
-    // pty_cancel_read is called (kill-to-EOF). Guards #119 / the Dispose join.
+    // After pty_cancel_read, a blocked pty_read must return promptly so the read
+    // thread can be joined (guards #119 / the Dispose join). The reader loops and
+    // drains any ConPTY startup chatter (e.g. an ESC[6n DSR query); once the child
+    // is idle the read blocks, and only a working cancel ends the loop. Without a
+    // working cancel the loop blocks forever and join() never completes.
     #[test]
     fn cancel_read_unblocks_a_pending_read() {
         // A shell that just sleeps so it produces no output on its own.
@@ -196,20 +201,26 @@ mod cancel_read_tests {
         );
         assert!(!state.is_null(), "spawn failed");
 
-        // Reader thread: a single blocking read that should return after cancel.
+        // Reader loop: keep reading (draining startup output) until a read returns
+        // <= 0 (EOF, or aborted/errored by the cancel).
         let state_addr = state as usize;
         let reader = std::thread::spawn(move || {
             let ptr = state_addr as *mut PtyState;
             let mut buf = [0u8; 256];
-            pty_read(ptr, buf.as_mut_ptr(), buf.len() as c_int)
+            loop {
+                let rc = pty_read(ptr, buf.as_mut_ptr(), buf.len() as c_int);
+                if rc <= 0 {
+                    return rc;
+                }
+            }
         });
 
-        // Give the read time to block, then cancel.
-        std::thread::sleep(std::time::Duration::from_millis(300));
+        // Let startup output flush; the reader is now blocked on an idle child.
+        std::thread::sleep(std::time::Duration::from_millis(1000));
         let start = Instant::now();
         pty_cancel_read(state);
 
-        // The read must return within a couple of seconds, not in ~30s.
+        // The blocked read must return within a few seconds, not in ~30s.
         let rc = reader.join().expect("reader thread panicked");
         assert!(
             start.elapsed() < std::time::Duration::from_secs(5),
@@ -228,18 +239,68 @@ mod cancel_read_tests {
 Run: `cargo test --manifest-path src/NovaTerminal.App/native/Cargo.toml cancel_read`
 Expected: FAIL — `cannot find function pty_cancel_read in this scope`.
 
-- [ ] **Step 3: Implement `pty_cancel_read`**
+- [ ] **Step 3: Add the read-thread-id field, capture it in `pty_read`, and implement `pty_cancel_read`**
 
-Add after `pty_get_pid` (before `pty_close`):
+**(a) Add a Windows-only atomic field to `PtyState`.** Near the top imports add:
+
+```rust
+#[cfg(windows)]
+use std::sync::atomic::{AtomicU32, Ordering};
+```
+
+In `pub struct PtyState { … }` add:
+
+```rust
+    // OS thread id of the thread currently blocked in pty_read's native ReadFile
+    // (Windows portable path), or 0. pty_cancel_read uses it with
+    // CancelSynchronousIo to unblock the read — killing the child / dropping the
+    // master does NOT close the cloned reader handle on this path.
+    #[cfg(windows)]
+    pub read_thread_id: AtomicU32,
+```
+
+Initialize it at BOTH `PtyState { … }` construction sites (passthrough and portable):
+
+```rust
+        #[cfg(windows)]
+        read_thread_id: AtomicU32::new(0),
+```
+
+**(b) Record/clear the thread id in `pty_read`.** Replace the read body (the `if let Ok(mut reader) = state.reader.lock() { … }` block) with:
+
+```rust
+        let buf = unsafe { std::slice::from_raw_parts_mut(buffer, len as usize) };
+        if let Ok(mut reader) = state.reader.lock() {
+            #[cfg(windows)]
+            state.read_thread_id.store(
+                unsafe { windows_sys::Win32::System::Threading::GetCurrentThreadId() },
+                Ordering::SeqCst,
+            );
+            let result = match reader.read(buf) {
+                Ok(n) => n as c_int,
+                Err(_) => -1,
+            };
+            #[cfg(windows)]
+            state.read_thread_id.store(0, Ordering::SeqCst);
+            result
+        } else {
+            -1
+        }
+```
+
+**(c) Add `pty_cancel_read`** after `pty_get_pid` (before `pty_close`):
 
 ```rust
 /// Unblock an in-flight `pty_read` so the caller's read thread can be joined.
 ///
 /// The blocked read holds `state.reader`'s lock, so we must NEVER touch `reader`
-/// here. Instead we break the pty from the other side: close the pseudoconsole
-/// (Windows passthrough) and/or kill the child (portable path), which makes the
-/// pending `read()` return EOF/error. Idempotent and safe to call before
-/// `pty_close` (it `take()`s the HPCON so close won't double-free).
+/// here. We break the read from the other side, per platform/path:
+///   * Windows passthrough: close the pseudoconsole (breaks the output pipe).
+///   * Windows portable: the cloned reader handle is NOT closed by killing the
+///     child or dropping the master, so cancel the blocking ReadFile directly via
+///     CancelSynchronousIo against the recorded read thread.
+///   * Unix: kill the child so the slave closes and the master read returns EOF.
+/// Idempotent; safe to call before pty_close (it take()s the HPCON).
 #[unsafe(no_mangle)]
 pub extern "C" fn pty_cancel_read(state_ptr: *mut PtyState) {
     ffi_guard((), || {
@@ -254,11 +315,11 @@ pub extern "C" fn pty_cancel_read(state_ptr: *mut PtyState) {
             cloned
         };
 
-        // Windows passthrough: closing the pseudoconsole breaks the output pipe so
-        // the in-flight ReadFile on h_out_read returns. take() => pty_close won't
-        // double-close.
         #[cfg(windows)]
         {
+            // Passthrough: closing the pseudoconsole breaks the output pipe so the
+            // in-flight ReadFile on h_out_read returns. take() => pty_close won't
+            // double-close.
             if let Ok(mut h_pc_opt) = state.h_pc.lock() {
                 if let Some(h_pc) = h_pc_opt.take() {
                     unsafe {
@@ -266,10 +327,39 @@ pub extern "C" fn pty_cancel_read(state_ptr: *mut PtyState) {
                     }
                 }
             }
+
+            // Portable: cancel the blocking ReadFile on the recorded read thread.
+            // Retry within a bounded window to cover the race where the read has
+            // not yet entered ReadFile (CancelSynchronousIo => ERROR_NOT_FOUND).
+            use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, ERROR_NOT_FOUND};
+            use windows_sys::Win32::System::Threading::{OpenThread, THREAD_TERMINATE};
+            use windows_sys::Win32::System::IO::CancelSynchronousIo;
+            for _ in 0..100 {
+                let tid = state.read_thread_id.load(Ordering::SeqCst);
+                if tid == 0 {
+                    // Not currently in a blocking read; brief wait then re-check.
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                    continue;
+                }
+                let h_thread = unsafe { OpenThread(THREAD_TERMINATE, 0, tid) };
+                if h_thread == 0 {
+                    break;
+                }
+                let cancelled = unsafe { CancelSynchronousIo(h_thread) };
+                let last_err = unsafe { GetLastError() };
+                unsafe { CloseHandle(h_thread) };
+                if cancelled != 0 {
+                    break; // an in-flight read was aborted
+                }
+                if last_err != ERROR_NOT_FOUND {
+                    break; // unexpected; stop retrying
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
         }
 
-        // Portable path (Unix + Windows non-passthrough): kill the child so the
-        // slave closes and the master read returns EOF.
+        // Kill the child. On Unix this closes the slave so the master read returns
+        // EOF; on Windows it reaps the child after the read has been cancelled.
         if let Ok(mut child_opt) = state.child.lock() {
             if let Some(child) = child_opt.as_mut() {
                 let _ = child.kill();
@@ -278,6 +368,8 @@ pub extern "C" fn pty_cancel_read(state_ptr: *mut PtyState) {
     })
 }
 ```
+
+> If `windows_sys` does not expose `CancelSynchronousIo` / `OpenThread` / `THREAD_TERMINATE` / `ERROR_NOT_FOUND` under these exact paths, locate the correct module (they live under `Win32::System::IO`, `Win32::System::Threading`, and `Win32::Foundation` respectively) — do not change the mechanism. If a needed feature is missing from the `windows-sys` features in `Cargo.toml`, add the minimal feature and note it in your report.
 
 - [ ] **Step 4: Run the test to verify it passes**
 

--- a/docs/superpowers/specs/2026-06-10-pty-teardown-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-10-pty-teardown-hardening-design.md
@@ -76,15 +76,33 @@ teardown contract.
 Unblocks the read that is parked inside `reader.read()` while holding the
 `state.reader` mutex. The cancel path therefore must **never** touch `reader`.
 
-- **Portable path (Unix + Windows non-passthrough):** lock `state.child`, call
-  `child.kill()`. Child exit closes the slave → master read returns EOF.
-- **Windows passthrough path:** close the `HPCON` and set it to `None`. Closing
-  the pseudoconsole breaks the output pipe → `read()` on `h_out_read` returns.
-  Because `pty_close` also closes the `HPCON`, `h_pc`/`h_process` move from plain
-  `Option<…>` to `Mutex<Option<…>>` and both functions `take()` so neither
-  double-frees. `pty_close` already guards on the `Option`.
-- Wrapped in `ffi_guard`; null-safe; idempotent (second call is a no-op once
-  handles are `None` / child already killed).
+> **Implementation discovery (2026-06-10):** the originally-specified kill-to-EOF
+> mechanism does **not** unblock the read on the Windows **portable-pty path** —
+> which is the path the GUI app always takes (no real console). There, `reader`
+> is a *duplicated* pipe handle from `try_clone_reader()`; killing the child or
+> dropping the master does not close it, and it only closes at `pty_close`. With
+> `PtySafeHandle` deferring `pty_close` until the read returns, that is a cycle.
+> The Windows portable path therefore uses `CancelSynchronousIo` against the
+> read thread (the Win32-canonical cancel for a blocking synchronous read).
+
+Per-platform mechanism:
+
+- **Unix (portable):** lock `state.child`, call `child.kill()`. Child exit closes
+  the slave → master read returns EOF. (Standard pty behavior.)
+- **Windows passthrough path:** `take()` and close the `HPCON`
+  (`ClosePseudoConsole`) → breaks the output pipe → `read()` on `h_out_read`
+  returns. Because `pty_close` also closes the `HPCON`, `h_pc`/`h_process` are
+  `Mutex<Option<…>>` and both functions `take()`, so neither double-frees.
+- **Windows portable path:** `pty_read` records the current OS thread id
+  (`GetCurrentThreadId`) in a `PtyState` field around each blocking read;
+  `pty_cancel_read` opens that thread (`OpenThread(THREAD_TERMINATE, …)`) and
+  calls `CancelSynchronousIo` on it, retrying within a bounded window to cover
+  the race where the read has not yet entered `ReadFile`. The aborted `ReadFile`
+  makes `reader.read()` return an error → `pty_read` returns -1. `child.kill()`
+  still runs to reap the child. Because `Dispose` calls `_cts.Cancel()` *before*
+  `pty_cancel_read`, the C# read loop exits on the next condition check rather
+  than retrying the errored read.
+- Wrapped in `ffi_guard`; null-safe; idempotent.
 
 ### `PtySafeHandle : SafeHandle`
 - `IsInvalid => handle == IntPtr.Zero`.
@@ -163,10 +181,11 @@ the Mode-B headless flake.
 
 ## G. Risks to validate during implementation
 
-- **ConPTY EOF semantics:** whether killing the child alone breaks the
-  passthrough read or `ClosePseudoConsole` is required. The design routes
-  passthrough-cancel through closing the `HPCON`; the Rust test in (F) confirms
-  the read actually returns.
+- **ConPTY EOF semantics** (RESOLVED during implementation): killing the child
+  does **not** unblock the read on the Windows portable-pty path; that path now
+  uses `CancelSynchronousIo` on the read thread (see §B). Passthrough uses
+  `ClosePseudoConsole`; Unix uses `child.kill()`. The Rust test in (F) guards all
+  of this by asserting the read thread returns promptly after cancel.
 - **`Dispose` off the UI thread:** it runs via `Task.Run`. Confirm
   `CloseRemoteFilesSidebar` and any other step touch no UI-thread-only state, or
   marshal them.

--- a/docs/superpowers/specs/2026-06-10-pty-teardown-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-10-pty-teardown-hardening-design.md
@@ -1,0 +1,180 @@
+# PTY Teardown Hardening — Design
+
+**Date:** 2026-06-10
+**Issues:** Closes #119, #118, #103; targeted part of #102. Follow-up to #81 (Mode A).
+**Branch (planned):** `fix/issue-81-teardown`
+
+## Background
+
+#81 ("Unit Tests" testhost teardown hang) was root-caused into two independent
+modes. **Mode A** (in-repo PTY/pane leaks → threadpool starvation) was contained
+on the *test* side in #89 by moving the PTY loops to dedicated `IsBackground`
+threads and disposing test panes. The underlying *production* defects that Mode A
+exposed remain open:
+
+- **#119** — a blocking native `pty_read` has no cancellation path; `pty_close`
+  cannot unblock an in-flight read, so closing a session can leave the C# read
+  thread stuck in native code until the child next produces output or exits
+  (slow-to-close sessions).
+- **#118** — use-after-free window: `pty_close` consumes the handle's `Arc` via
+  `Arc::from_raw` and drops it, while every other export reconstitutes the same
+  raw pointer. A `pty_read` (etc.) that races or follows `pty_close` does
+  `Arc::from_raw` on freed memory (UB). The C# `_ptyState != IntPtr.Zero` guard is
+  an unsynchronized TOCTOU.
+- **#103** — `TerminalPane.Dispose` does not enforce teardown ordering (stop
+  session → drain output → detach parser → release buffer) and is not idempotent
+  against in-flight output.
+- **#102** (targeted subset) — timers and a few cross-lifetime/restart event
+  subscriptions are never cleaned up.
+
+These are not separable: you cannot safely `pty_close` until the read thread has
+been joined, and you cannot join the read thread until the native read has been
+unblocked. #119 + #118 + the native side of #103 therefore collapse into a single
+teardown contract.
+
+## Goals / Non-goals
+
+**Goals**
+- A native `pty_cancel_read` that promptly unblocks an in-flight read.
+- Eliminate the #118 UAF by construction (not by hope-ordering).
+- Ordered, idempotent `RustPtySession.Dispose` and `TerminalPane.Dispose`.
+- Stop the leaking timers (`_metricsTimer`, `_recordingToastTimer`) and the
+  restart-path parser-handler accumulation (duplicate bell/title symptom).
+
+**Non-goals**
+- Re-gating the headless `App.Tests` lane — that is **Mode B**, upstream
+  (AvaloniaUI/Avalonia#21467), tracked in #117. Untouched here.
+- Mirroring `SafeHandle` to `rusty_ssh` handles (#118 notes the same pattern
+  exists there). **Recommended follow-up**, deliberately out of this PR's scope —
+  it widens the diff and the SSH read path differs.
+- A full `CompositeDisposable` refactor of every `+=` site. We fix only what
+  crosses lifetimes or accumulates; purely intra-pane one-shot lambdas GC with the
+  pane and are left alone.
+
+## Approach decisions (locked)
+
+- **Native cancel:** kill-to-EOF (Approach 1) — `pty_cancel_read` breaks the pty
+  so the in-flight `read()` returns, using mutexes the blocked read does *not*
+  hold.
+- **UAF safety:** `PtySafeHandle` (Approach 3) — runtime ref-counting makes
+  `pty_close` impossible during any in-flight `pty_*` call.
+- **#102 depth:** targeted (timers + cross-lifetime/restart subscriptions only).
+
+## Components & files
+
+| File | Change |
+|---|---|
+| `src/NovaTerminal.App/native/src/lib.rs` | New `pty_cancel_read` export; move `h_pc`/`h_process` behind `Mutex<Option<…>>` so cancel and close don't double-free |
+| `src/NovaTerminal.Pty/RustPtySession.cs` | `PtySafeHandle : SafeHandle`; all `Native.*` signatures take the handle; idempotent ordered `Dispose` |
+| `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs` | Idempotent `Dispose` guard; 9 `Parser.On*` lambdas → named handlers detached on restart + `Dispose` |
+| `src/NovaTerminal.App/Shell/TerminalView.cs` | Stop `_metricsTimer` on detach |
+| `src/NovaTerminal.App/MainWindow.axaml.cs` | Stop `_recordingToastTimer` in `OnClosing` |
+
+## B. Native cancel + `PtySafeHandle`
+
+### `pty_cancel_read(state)`
+Unblocks the read that is parked inside `reader.read()` while holding the
+`state.reader` mutex. The cancel path therefore must **never** touch `reader`.
+
+- **Portable path (Unix + Windows non-passthrough):** lock `state.child`, call
+  `child.kill()`. Child exit closes the slave → master read returns EOF.
+- **Windows passthrough path:** close the `HPCON` and set it to `None`. Closing
+  the pseudoconsole breaks the output pipe → `read()` on `h_out_read` returns.
+  Because `pty_close` also closes the `HPCON`, `h_pc`/`h_process` move from plain
+  `Option<…>` to `Mutex<Option<…>>` and both functions `take()` so neither
+  double-frees. `pty_close` already guards on the `Option`.
+- Wrapped in `ffi_guard`; null-safe; idempotent (second call is a no-op once
+  handles are `None` / child already killed).
+
+### `PtySafeHandle : SafeHandle`
+- `IsInvalid => handle == IntPtr.Zero`.
+- `ReleaseHandle()` → `pty_close(handle)`; returns `true`.
+- `pty_spawn` / `pty_spawn_with_envs` return `PtySafeHandle` (marshaler
+  constructs it from the returned pointer).
+- Every other `Native.*` P/Invoke takes `PtySafeHandle` instead of `IntPtr`. The
+  runtime auto-`DangerousAddRef`s before the call and `Release`s after, so
+  `ReleaseHandle` (`pty_close`) cannot run while any `pty_*` call — including a
+  blocked `pty_read` — is in flight. **This is what eliminates #118.**
+
+> Note: with `SafeHandle`, `pty_cancel_read` is still required. Without it, the
+> handle ref stays held by the blocked read and `ReleaseHandle` is deferred until
+> the child happens to output/exit — i.e. the slow-close of #119 persists. Cancel
+> makes the read return promptly so the ref releases and close can proceed.
+
+## C. `RustPtySession.Dispose` — the teardown contract
+
+Idempotent via an `Interlocked` guard (`_disposed`). Safe to call off the UI
+thread (it is invoked through `Task.Run` in `DisposeControlTree`).
+
+```
+Dispose():
+  1. if Interlocked.Exchange(ref _disposed, 1) != 0 → return
+  2. StopRecording() if recording
+  3. _cts.Cancel()                         // read loop won't re-enter pty_read
+  4. Native.pty_cancel_read(_handle)       // unblock in-flight native read
+  5. _outputQueue.CompleteAdding()         // process loop drains + exits
+  6. _readLoopThread.Join(JoinTimeout)     // bounded (~2s); log on timeout
+     _processLoopThread.Join(JoinTimeout)
+  7. _handle.Dispose()                     // SafeHandle → ReleaseHandle → pty_close
+  8. TryNotifyExit(0)
+```
+
+Join is bounded so `Dispose` never hangs; `SafeHandle` keeps the close safe even
+if a join times out, and the `IsBackground` thread cannot block process exit.
+
+## D. `TerminalPane` (#103 pane side + targeted #102)
+
+- **Idempotent** `Dispose` via a guard flag.
+- **Order:** stop/null `_statusTimer` → detach `Parser.On*` handlers → unsubscribe
+  `SftpService.JobUpdated` + `Buffer.OnScreenSwitched` (already present) →
+  `UnregisterActiveSshSession` (already present) → `Session.Dispose()` (runs the
+  contract in C, draining output) → drop references.
+- **Parser handlers:** convert the 9 `Parser.On*` lambdas (`OnBell`,
+  `OnTitleChanged`, `OnWorkingDirectoryChanged`, `OnPromptReady`,
+  `OnCommandAccepted`, `OnCommandStarted`, `OnCommandFinished`,
+  `OnCommandFinishedDetailed`, `OnResponse`) to **named methods** stored once.
+  Detach them both in `Dispose` and on the **session-restart path** that
+  re-creates the `Parser`, fixing the documented duplicate bell/title bug.
+- **Left as-is:** purely intra-pane one-shot lambdas (context-menu items, search
+  box, toast buttons) — they share the pane's lifetime and GC together.
+
+## E. `TerminalView` + `MainWindow` (targeted #102)
+
+- **`TerminalView`:** `_metricsTimer` is started in the ctor but never stopped by
+  `StopUiTimers`; `OnDetachedFromVisualTree` calls `StopUiTimers`. Stop
+  `_metricsTimer` on detach so it stops rooting the view via its `Tick` delegate.
+- **`MainWindow`:** stop `_recordingToastTimer` in `OnClosing`.
+
+## F. Testing strategy (TDD)
+
+All in the **non-headless** lanes (`NovaTerminal.Pty` / lifecycle), unaffected by
+the Mode-B headless flake.
+
+- **Rust unit tests** (`lib.rs`):
+  - spawn a long-running child (no output), call `pty_cancel_read`, assert the
+    next `pty_read` returns within a timeout (EOF/error).
+  - `pty_close` after `pty_cancel_read` is safe; double `pty_close` is safe.
+- **C# `PtyThreadLifecycleTests` extensions:**
+  - start a session whose child produces no output, `Dispose`, assert both loop
+    threads exit within `JoinTimeout`.
+  - `Dispose` is idempotent (call twice; no throw, no double-close).
+  - no `OnOutputReceived` / `OnExit` fires after `Dispose` completes.
+  - threads remain `IsBackground`, non-threadpool (existing guard).
+
+## G. Risks to validate during implementation
+
+- **ConPTY EOF semantics:** whether killing the child alone breaks the
+  passthrough read or `ClosePseudoConsole` is required. The design routes
+  passthrough-cancel through closing the `HPCON`; the Rust test in (F) confirms
+  the read actually returns.
+- **`Dispose` off the UI thread:** it runs via `Task.Run`. Confirm
+  `CloseRemoteFilesSidebar` and any other step touch no UI-thread-only state, or
+  marshal them.
+- **Mass close:** closing many panes at once each does a bounded join on a pool
+  thread. Cancel makes joins fast; bounded timeout caps worst case. Acceptable.
+
+## H. Out of scope (tracked elsewhere)
+
+- Mode B headless re-gate → #117 / AvaloniaUI/Avalonia#21467.
+- `rusty_ssh` `SafeHandle` mirror → recommended #118 follow-up PR.
+- Full `CompositeDisposable` adoption → not pursued (YAGNI).

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -93,6 +93,9 @@ namespace NovaTerminal.Controls
 
         private TerminalSettings? _settings;
         private bool _isUpdatingScroll = false;
+        private bool _disposed;
+        private Action<int, int>? _onTermViewResize;
+        private Action<float, float>? _onTermViewMetricsChanged;
         private DispatcherTimer? _statusTimer;
         private bool _hasUserInteraction;
         private readonly SshDiagnosticsLevel _sshDiagnosticsLevel;
@@ -1625,28 +1628,32 @@ namespace NovaTerminal.Controls
                 Session.SendInput(response);
             };
 
-            // Wire up Resize
-            TermView.OnResize += (c, r) =>
+            // Wire up Resize (idempotent across InitializeSession re-runs — TermView is reused).
+            _onTermViewResize ??= (c, r) =>
             {
                 if (Parser != null)
                 {
-                    float cw = TermView.Metrics.CellWidth;
-                    float ch = TermView.Metrics.CellHeight;
-                    if (cw > 0) Parser.CellWidth = cw;
-                    if (ch > 0) Parser.CellHeight = ch;
+                    float cwResize = TermView.Metrics.CellWidth;
+                    float chResize = TermView.Metrics.CellHeight;
+                    if (cwResize > 0) Parser.CellWidth = cwResize;
+                    if (chResize > 0) Parser.CellHeight = chResize;
                 }
                 Session?.Resize(c, r);
             };
+            TermView.OnResize -= _onTermViewResize;
+            TermView.OnResize += _onTermViewResize;
 
-            // Metrics changed handling
-            TermView.MetricsChanged += (cw, ch) =>
+            // Metrics changed handling (idempotent — TermView is reused).
+            _onTermViewMetricsChanged ??= (cwMetric, chMetric) =>
             {
-                if (Parser != null && cw > 0 && ch > 0)
+                if (Parser != null && cwMetric > 0 && chMetric > 0)
                 {
-                    Parser.CellWidth = cw;
-                    Parser.CellHeight = ch;
+                    Parser.CellWidth = cwMetric;
+                    Parser.CellHeight = chMetric;
                 }
             };
+            TermView.MetricsChanged -= _onTermViewMetricsChanged;
+            TermView.MetricsChanged += _onTermViewMetricsChanged;
         }
 
         private void HandleWorkingDirectoryChanged(string cwd)
@@ -2182,7 +2189,14 @@ namespace NovaTerminal.Controls
 
         public void Dispose()
         {
+            if (_disposed) return;
+            _disposed = true;
+
             CloseRemoteFilesSidebar();
+
+            // Detach handlers on the reused TermView so a disposed pane stops reacting.
+            if (_onTermViewResize != null) TermView.OnResize -= _onTermViewResize;
+            if (_onTermViewMetricsChanged != null) TermView.MetricsChanged -= _onTermViewMetricsChanged;
 
             if (Buffer != null)
             {

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -5036,6 +5036,7 @@ namespace NovaTerminal
             {
                 SessionManager.SaveSession(this, tabs);
             }
+            _recordingToastTimer.Stop();
             _globalHotkey?.Dispose();
         }
 

--- a/src/NovaTerminal.App/Shell/TerminalView.cs
+++ b/src/NovaTerminal.App/Shell/TerminalView.cs
@@ -763,6 +763,7 @@ namespace NovaTerminal.Shell
             base.OnAttachedToVisualTree(e);
             _isAttachedToVisualTree = true;
             RefreshUiTimerState();
+            if (!_metricsTimer.IsEnabled) _metricsTimer.Start();
 
             _cachedTopLevel = TopLevel.GetTopLevel(this);
             if (_cachedTopLevel != null)
@@ -787,6 +788,7 @@ namespace NovaTerminal.Shell
             _isAttachedToVisualTree = false;
             _isUiRenderable = false;
             StopUiTimers();
+            _metricsTimer.Stop();
 
             if (_cachedTopLevel != null)
             {

--- a/src/NovaTerminal.App/native/Cargo.toml
+++ b/src/NovaTerminal.App/native/Cargo.toml
@@ -10,4 +10,4 @@ crate-type = ["cdylib"]
 portable-pty = "0.9"
 libc = "0.2"
 anyhow = "1.0"
-windows-sys = { version = "0.52", features = ["Win32_System_Console", "Win32_System_Threading", "Win32_Foundation", "Win32_Security", "Win32_System_Pipes"] }
+windows-sys = { version = "0.52", features = ["Win32_System_Console", "Win32_System_Threading", "Win32_Foundation", "Win32_Security", "Win32_System_Pipes", "Win32_System_IO"] }

--- a/src/NovaTerminal.App/native/src/lib.rs
+++ b/src/NovaTerminal.App/native/src/lib.rs
@@ -189,9 +189,9 @@ pub struct PtyState {
     pub reader: Mutex<Box<dyn Read + Send>>,
     pub writer: Mutex<Box<dyn Write + Send>>,
     #[cfg(windows)]
-    pub h_pc: Option<windows_sys::Win32::System::Console::HPCON>,
+    pub h_pc: Mutex<Option<windows_sys::Win32::System::Console::HPCON>>,
     #[cfg(windows)]
-    pub h_process: Option<windows_sys::Win32::Foundation::HANDLE>,
+    pub h_process: Mutex<Option<windows_sys::Win32::Foundation::HANDLE>>,
     pub master: Mutex<Option<Box<dyn portable_pty::MasterPty + Send>>>,
     pub child: Mutex<Option<Box<dyn portable_pty::Child + Send>>>,
 }
@@ -344,8 +344,8 @@ fn pty_spawn_impl(
                 let state = PtyState {
                     reader: Mutex::new(reader),
                     writer: Mutex::new(writer),
-                    h_pc: Some(h_pc),
-                    h_process: Some(h_process),
+                    h_pc: Mutex::new(Some(h_pc)),
+                    h_process: Mutex::new(Some(h_process)),
                     master: Mutex::new(None),
                     child: Mutex::new(None),
                 };
@@ -415,9 +415,9 @@ fn pty_spawn_impl(
         reader: Mutex::new(reader),
         writer: Mutex::new(writer),
         #[cfg(windows)]
-        h_pc: None,
+        h_pc: Mutex::new(None),
         #[cfg(windows)]
-        h_process: None,
+        h_process: Mutex::new(None),
         master: Mutex::new(Some(pair.master)),
         child: Mutex::new(Some(child)),
     };
@@ -503,15 +503,17 @@ pub extern "C" fn pty_resize(state_ptr: *mut PtyState, cols: u16, rows: u16) {
 
         #[cfg(windows)]
         {
-            if let Some(h_pc) = state.h_pc {
-                let size = windows_sys::Win32::System::Console::COORD {
-                    X: cols as i16,
-                    Y: rows as i16,
-                };
-                unsafe {
-                    windows_sys::Win32::System::Console::ResizePseudoConsole(h_pc, size);
+            if let Ok(h_pc_opt) = state.h_pc.lock() {
+                if let Some(h_pc) = *h_pc_opt {
+                    let size = windows_sys::Win32::System::Console::COORD {
+                        X: cols as i16,
+                        Y: rows as i16,
+                    };
+                    unsafe {
+                        windows_sys::Win32::System::Console::ResizePseudoConsole(h_pc, size);
+                    }
+                    return;
                 }
-                return;
             }
         }
 
@@ -544,9 +546,11 @@ pub extern "C" fn pty_get_pid(state_ptr: *mut PtyState) -> c_int {
 
         #[cfg(windows)]
         {
-            if let Some(h_process) = state.h_process {
-                unsafe {
-                    return windows_sys::Win32::System::Threading::GetProcessId(h_process) as c_int;
+            if let Ok(h_process_opt) = state.h_process.lock() {
+                if let Some(h_process) = *h_process_opt {
+                    unsafe {
+                        return windows_sys::Win32::System::Threading::GetProcessId(h_process) as c_int;
+                    }
                 }
             }
         }
@@ -572,14 +576,18 @@ pub extern "C" fn pty_close(state_ptr: *mut PtyState) {
 
         #[cfg(windows)]
         {
-            if let Some(h_pc) = state.h_pc {
-                unsafe {
-                    windows_sys::Win32::System::Console::ClosePseudoConsole(h_pc);
+            if let Ok(mut h_pc_opt) = state.h_pc.lock() {
+                if let Some(h_pc) = h_pc_opt.take() {
+                    unsafe {
+                        windows_sys::Win32::System::Console::ClosePseudoConsole(h_pc);
+                    }
                 }
             }
-            if let Some(h_process) = state.h_process {
-                unsafe {
-                    windows_sys::Win32::Foundation::CloseHandle(h_process);
+            if let Ok(mut h_process_opt) = state.h_process.lock() {
+                if let Some(h_process) = h_process_opt.take() {
+                    unsafe {
+                        windows_sys::Win32::Foundation::CloseHandle(h_process);
+                    }
                 }
             }
         }

--- a/src/NovaTerminal.App/native/src/lib.rs
+++ b/src/NovaTerminal.App/native/src/lib.rs
@@ -3,6 +3,8 @@ use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use std::ffi::CStr;
 use std::io::{Read, Write};
 use std::panic::{catch_unwind, AssertUnwindSafe};
+#[cfg(windows)]
+use std::sync::atomic::{AtomicU32, Ordering};
 
 #[cfg(windows)]
 mod win32 {
@@ -194,6 +196,12 @@ pub struct PtyState {
     pub h_process: Mutex<Option<windows_sys::Win32::Foundation::HANDLE>>,
     pub master: Mutex<Option<Box<dyn portable_pty::MasterPty + Send>>>,
     pub child: Mutex<Option<Box<dyn portable_pty::Child + Send>>>,
+    // OS thread id of the thread currently blocked in pty_read's native ReadFile
+    // (Windows portable path), or 0. pty_cancel_read uses it with
+    // CancelSynchronousIo to unblock the read — killing the child / dropping the
+    // master does NOT close the cloned reader handle on this path.
+    #[cfg(windows)]
+    pub read_thread_id: AtomicU32,
 }
 
 // Tokenize an argument string the way a POSIX-ish shell would: split on
@@ -348,6 +356,8 @@ fn pty_spawn_impl(
                     h_process: Mutex::new(Some(h_process)),
                     master: Mutex::new(None),
                     child: Mutex::new(None),
+                    #[cfg(windows)]
+                    read_thread_id: AtomicU32::new(0),
                 };
                 return Arc::into_raw(Arc::new(state)) as *mut PtyState;
             }
@@ -420,6 +430,8 @@ fn pty_spawn_impl(
         h_process: Mutex::new(None),
         master: Mutex::new(Some(pair.master)),
         child: Mutex::new(Some(child)),
+        #[cfg(windows)]
+        read_thread_id: AtomicU32::new(0),
     };
 
     Arc::into_raw(Arc::new(state)) as *mut PtyState
@@ -450,10 +462,18 @@ pub extern "C" fn pty_read(state_ptr: *mut PtyState, buffer: *mut u8, len: c_int
 
         let buf = unsafe { std::slice::from_raw_parts_mut(buffer, len as usize) };
         if let Ok(mut reader) = state.reader.lock() {
-            match reader.read(buf) {
+            #[cfg(windows)]
+            state.read_thread_id.store(
+                unsafe { windows_sys::Win32::System::Threading::GetCurrentThreadId() },
+                Ordering::SeqCst,
+            );
+            let result = match reader.read(buf) {
                 Ok(n) => n as c_int,
                 Err(_) => -1,
-            }
+            };
+            #[cfg(windows)]
+            state.read_thread_id.store(0, Ordering::SeqCst);
+            result
         } else {
             -1
         }
@@ -566,6 +586,83 @@ pub extern "C" fn pty_get_pid(state_ptr: *mut PtyState) -> c_int {
     })
 }
 
+/// Unblock an in-flight `pty_read` so the caller's read thread can be joined.
+///
+/// The blocked read holds `state.reader`'s lock, so we must NEVER touch `reader`
+/// here. We break the read from the other side, per platform/path:
+///   * Windows passthrough: close the pseudoconsole (breaks the output pipe).
+///   * Windows portable: the cloned reader handle is NOT closed by killing the
+///     child or dropping the master, so cancel the blocking ReadFile directly via
+///     CancelSynchronousIo against the recorded read thread.
+///   * Unix: kill the child so the slave closes and the master read returns EOF.
+/// Idempotent; safe to call before pty_close (it take()s the HPCON).
+#[unsafe(no_mangle)]
+pub extern "C" fn pty_cancel_read(state_ptr: *mut PtyState) {
+    ffi_guard((), || {
+        if state_ptr.is_null() {
+            return;
+        }
+        // Clone the Arc without consuming the caller's ref (same idiom as pty_read).
+        let state = unsafe {
+            let arc = Arc::from_raw(state_ptr);
+            let cloned = arc.clone();
+            let _ = Arc::into_raw(arc);
+            cloned
+        };
+
+        #[cfg(windows)]
+        {
+            // Passthrough: closing the pseudoconsole breaks the output pipe so the
+            // in-flight ReadFile on h_out_read returns. take() => pty_close won't
+            // double-close.
+            if let Ok(mut h_pc_opt) = state.h_pc.lock() {
+                if let Some(h_pc) = h_pc_opt.take() {
+                    unsafe {
+                        windows_sys::Win32::System::Console::ClosePseudoConsole(h_pc);
+                    }
+                }
+            }
+
+            // Portable: cancel the blocking ReadFile on the recorded read thread.
+            // Retry within a bounded window to cover the race where the read has
+            // not yet entered ReadFile (CancelSynchronousIo => ERROR_NOT_FOUND).
+            use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, ERROR_NOT_FOUND};
+            use windows_sys::Win32::System::Threading::{OpenThread, THREAD_TERMINATE};
+            use windows_sys::Win32::System::IO::CancelSynchronousIo;
+            for _ in 0..100 {
+                let tid = state.read_thread_id.load(Ordering::SeqCst);
+                if tid == 0 {
+                    // Not currently in a blocking read; brief wait then re-check.
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                    continue;
+                }
+                let h_thread = unsafe { OpenThread(THREAD_TERMINATE, 0, tid) };
+                if h_thread == 0 {
+                    break;
+                }
+                let cancelled = unsafe { CancelSynchronousIo(h_thread) };
+                let last_err = unsafe { GetLastError() };
+                unsafe { CloseHandle(h_thread) };
+                if cancelled != 0 {
+                    break; // an in-flight read was aborted
+                }
+                if last_err != ERROR_NOT_FOUND {
+                    break; // unexpected; stop retrying
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+        }
+
+        // Kill the child. On Unix this closes the slave so the master read returns
+        // EOF; on Windows it reaps the child after the read has been cancelled.
+        if let Ok(mut child_opt) = state.child.lock() {
+            if let Some(child) = child_opt.as_mut() {
+                let _ = child.kill();
+            }
+        }
+    })
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn pty_close(state_ptr: *mut PtyState) {
     ffi_guard((), || {
@@ -630,5 +727,67 @@ mod passthrough_decision_tests {
     fn env_opt_out_always_skips() {
         assert!(should_skip_passthrough(true, true));
         assert!(should_skip_passthrough(true, false));
+    }
+}
+
+#[cfg(test)]
+mod cancel_read_tests {
+    use super::*;
+    use std::ffi::CString;
+    use std::time::Instant;
+
+    // After pty_cancel_read, a blocked pty_read must return promptly so the read
+    // thread can be joined (guards #119 / the Dispose join). The reader loops and
+    // drains any ConPTY startup chatter (e.g. an ESC[6n DSR query); once the child
+    // is idle the read blocks, and only a working cancel ends the loop. Without a
+    // working cancel the loop blocks forever and join() never completes.
+    #[test]
+    fn cancel_read_unblocks_a_pending_read() {
+        // A shell that just sleeps so it produces no output on its own.
+        #[cfg(windows)]
+        let (cmd, args) = ("cmd.exe", "/c timeout /t 30 /nobreak >NUL");
+        #[cfg(not(windows))]
+        let (cmd, args) = ("/bin/sh", "-c 'sleep 30'");
+
+        let c_cmd = CString::new(cmd).unwrap();
+        let c_args = CString::new(args).unwrap();
+        let state = pty_spawn(
+            c_cmd.as_ptr(),
+            c_args.as_ptr(),
+            std::ptr::null(),
+            80,
+            24,
+        );
+        assert!(!state.is_null(), "spawn failed");
+
+        // Reader loop: keep reading (draining startup output) until a read returns
+        // <= 0 (EOF, or aborted/errored by the cancel).
+        let state_addr = state as usize;
+        let reader = std::thread::spawn(move || {
+            let ptr = state_addr as *mut PtyState;
+            let mut buf = [0u8; 256];
+            loop {
+                let rc = pty_read(ptr, buf.as_mut_ptr(), buf.len() as c_int);
+                if rc <= 0 {
+                    return rc;
+                }
+            }
+        });
+
+        // Let startup output flush; the reader is now blocked on an idle child.
+        std::thread::sleep(std::time::Duration::from_millis(1000));
+        let start = Instant::now();
+        pty_cancel_read(state);
+
+        // The blocked read must return within a few seconds, not in ~30s.
+        let rc = reader.join().expect("reader thread panicked");
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(5),
+            "pty_read did not return promptly after cancel"
+        );
+        assert!(rc <= 0, "expected EOF(0) or error(-1) after cancel, got {rc}");
+
+        // close must remain safe (idempotent vs the cancel that already ran).
+        pty_close(state);
     }
 }

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -99,7 +99,9 @@ namespace NovaTerminal.Pty
             get
             {
                 if (_handle.IsClosed || _handle.IsInvalid) return false;
-                int pid = Native.pty_get_pid(_handle);
+                int pid;
+                try { pid = Native.pty_get_pid(_handle); }
+                catch (ObjectDisposedException) { return false; }
                 if (pid <= 0) return false;
                 return HasChildProcesses(pid, ShellCommand);
             }
@@ -110,8 +112,12 @@ namespace NovaTerminal.Pty
             get
             {
                 if (_handle.IsClosed || _handle.IsInvalid) return null;
-                int pid = Native.pty_get_pid(_handle);
-                return pid > 0 ? pid : null;
+                try
+                {
+                    int pid = Native.pty_get_pid(_handle);
+                    return pid > 0 ? pid : null;
+                }
+                catch (ObjectDisposedException) { return null; }
             }
         }
 
@@ -463,7 +469,8 @@ namespace NovaTerminal.Pty
             _recorder?.RecordInput(input);
 
             byte[] data = Encoding.UTF8.GetBytes(input);
-            Native.pty_write(_handle, data, data.Length);
+            try { Native.pty_write(_handle, data, data.Length); }
+            catch (ObjectDisposedException) { /* session disposed mid-call — drop the write */ }
         }
 
         public void Resize(int cols, int rows)
@@ -472,7 +479,8 @@ namespace NovaTerminal.Pty
             _cols = cols;
             _rows = rows;
             Console.WriteLine($"[RustPtySession] Resizing to {cols}x{rows}");
-            Native.pty_resize(_handle, (ushort)cols, (ushort)rows);
+            try { Native.pty_resize(_handle, (ushort)cols, (ushort)rows); }
+            catch (ObjectDisposedException) { /* session disposed mid-call — ignore resize */ }
             _recorder?.RecordResize(cols, rows);
         }
 

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -39,7 +39,7 @@ namespace NovaTerminal.Pty
 
         public event Action<string>? OnOutputReceived;
         public event Action<int>? OnExit;
-        public bool IsProcessRunning => Volatile.Read(ref _isExited) == 0 && !_handle.IsInvalid;
+        public bool IsProcessRunning => Volatile.Read(ref _isExited) == 0 && !_handle.IsClosed && !_handle.IsInvalid;
         public int? ExitCode => _exitCode;
 
         // DllImport definitions
@@ -98,7 +98,7 @@ namespace NovaTerminal.Pty
         {
             get
             {
-                if (_handle.IsInvalid) return false;
+                if (_handle.IsClosed || _handle.IsInvalid) return false;
                 int pid = Native.pty_get_pid(_handle);
                 if (pid <= 0) return false;
                 return HasChildProcesses(pid, ShellCommand);
@@ -109,7 +109,7 @@ namespace NovaTerminal.Pty
         {
             get
             {
-                if (_handle.IsInvalid) return null;
+                if (_handle.IsClosed || _handle.IsInvalid) return null;
                 int pid = Native.pty_get_pid(_handle);
                 return pid > 0 ? pid : null;
             }
@@ -458,7 +458,7 @@ namespace NovaTerminal.Pty
 
         public void SendInput(string input)
         {
-            if (_handle.IsInvalid) return;
+            if (_handle.IsClosed || _handle.IsInvalid) return;
 
             _recorder?.RecordInput(input);
 
@@ -468,7 +468,7 @@ namespace NovaTerminal.Pty
 
         public void Resize(int cols, int rows)
         {
-            if (_handle.IsInvalid || cols <= 0 || rows <= 0) return;
+            if (_handle.IsClosed || _handle.IsInvalid || cols <= 0 || rows <= 0) return;
             _cols = cols;
             _rows = rows;
             Console.WriteLine($"[RustPtySession] Resizing to {cols}x{rows}");

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -12,7 +12,7 @@ namespace NovaTerminal.Pty
     public class RustPtySession : ITerminalSession
     {
         public Guid Id { get; } = Guid.NewGuid();
-        private IntPtr _ptyState;
+        private readonly PtySafeHandle _handle;
         private readonly CancellationTokenSource _cts = new CancellationTokenSource();
         // The read/process loops run on these dedicated threads. Exposed to tests to
         // assert they are background, non-threadpool threads — a leaked session must
@@ -25,6 +25,12 @@ namespace NovaTerminal.Pty
         private int _isExited;
         private int? _exitCode;
 
+        // Quick first join: if the shell already exited (EOF), the read loop is
+        // already unwinding and we never need the (potentially ~1s-spinning) cancel.
+        private static readonly TimeSpan QuickJoinTimeout = TimeSpan.FromMilliseconds(250);
+        private static readonly TimeSpan DisposeJoinTimeout = TimeSpan.FromSeconds(2);
+        private int _disposed;
+
         // Bounded queue for back-pressure - prevents OOM on high-throughput output
         private readonly BlockingCollection<string> _outputQueue = new BlockingCollection<string>(boundedCapacity: 100);
 
@@ -33,7 +39,7 @@ namespace NovaTerminal.Pty
 
         public event Action<string>? OnOutputReceived;
         public event Action<int>? OnExit;
-        public bool IsProcessRunning => Volatile.Read(ref _isExited) == 0 && _ptyState != IntPtr.Zero;
+        public bool IsProcessRunning => Volatile.Read(ref _isExited) == 0 && !_handle.IsInvalid;
         public int? ExitCode => _exitCode;
 
         // DllImport definitions
@@ -42,26 +48,30 @@ namespace NovaTerminal.Pty
             const string LibName = "rusty_pty";
 
             [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr pty_create(string cmd, ushort cols, ushort rows);
+            public static extern PtySafeHandle pty_create(string cmd, ushort cols, ushort rows);
 
             [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr pty_spawn(string cmd, string? args, string? cwd, ushort cols, ushort rows);
+            public static extern PtySafeHandle pty_spawn(string cmd, string? args, string? cwd, ushort cols, ushort rows);
 
             [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr pty_spawn_with_envs(string cmd, string? args, string? cwd, ushort cols, ushort rows, string envs);
+            public static extern PtySafeHandle pty_spawn_with_envs(string cmd, string? args, string? cwd, ushort cols, ushort rows, string envs);
 
             [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-            public static extern int pty_read(IntPtr state, byte[] buffer, int len);
+            public static extern int pty_read(PtySafeHandle state, byte[] buffer, int len);
 
             [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-            public static extern int pty_write(IntPtr state, byte[] buffer, int len);
+            public static extern int pty_write(PtySafeHandle state, byte[] buffer, int len);
 
             [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-            public static extern void pty_resize(IntPtr state, ushort cols, ushort rows);
+            public static extern void pty_resize(PtySafeHandle state, ushort cols, ushort rows);
 
             [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-            public static extern int pty_get_pid(IntPtr state);
+            public static extern int pty_get_pid(PtySafeHandle state);
 
+            [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void pty_cancel_read(PtySafeHandle state);
+
+            // Raw overload used only by PtySafeHandle.ReleaseHandle().
             [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void pty_close(IntPtr state);
         }
@@ -88,8 +98,8 @@ namespace NovaTerminal.Pty
         {
             get
             {
-                if (_ptyState == IntPtr.Zero) return false;
-                int pid = Native.pty_get_pid(_ptyState);
+                if (_handle.IsInvalid) return false;
+                int pid = Native.pty_get_pid(_handle);
                 if (pid <= 0) return false;
                 return HasChildProcesses(pid, ShellCommand);
             }
@@ -99,8 +109,8 @@ namespace NovaTerminal.Pty
         {
             get
             {
-                if (_ptyState == IntPtr.Zero) return null;
-                int pid = Native.pty_get_pid(_ptyState);
+                if (_handle.IsInvalid) return null;
+                int pid = Native.pty_get_pid(_handle);
                 return pid > 0 ? pid : null;
             }
         }
@@ -246,14 +256,14 @@ namespace NovaTerminal.Pty
                     if (sb.Length > 0) sb.Append('\n');
                     sb.Append(kv.Key).Append('=').Append(kv.Value);
                 }
-                _ptyState = Native.pty_spawn_with_envs(effectiveShell, combinedArgs.Trim(), cwd, (ushort)cols, (ushort)rows, sb.ToString());
+                _handle = Native.pty_spawn_with_envs(effectiveShell, combinedArgs.Trim(), cwd, (ushort)cols, (ushort)rows, sb.ToString());
             }
             else
             {
-                _ptyState = Native.pty_spawn(effectiveShell, combinedArgs.Trim(), cwd, (ushort)cols, (ushort)rows);
+                _handle = Native.pty_spawn(effectiveShell, combinedArgs.Trim(), cwd, (ushort)cols, (ushort)rows);
             }
 
-            if (_ptyState == IntPtr.Zero)
+            if (_handle.IsInvalid)
             {
                 throw new InvalidOperationException("Failed to create Rust PTY session.");
             }
@@ -362,9 +372,9 @@ namespace NovaTerminal.Pty
             // swallowed). Contain it so a decode/recorder failure can't take down the host.
             try
             {
-                while (!_cts.Token.IsCancellationRequested && _ptyState != IntPtr.Zero)
+                while (!_cts.Token.IsCancellationRequested && !_handle.IsInvalid)
                 {
-                    int read = Native.pty_read(_ptyState, buffer, buffer.Length);
+                    int read = Native.pty_read(_handle, buffer, buffer.Length);
                     if (read > 0)
                     {
                         // Record raw bytes before any processing
@@ -403,6 +413,10 @@ namespace NovaTerminal.Pty
                         Thread.Sleep(50);
                     }
                 }
+            }
+            catch (ObjectDisposedException)
+            {
+                // _handle was disposed by Dispose() — normal shutdown.
             }
             catch (Exception ex)
             {
@@ -444,26 +458,29 @@ namespace NovaTerminal.Pty
 
         public void SendInput(string input)
         {
-            if (_ptyState == IntPtr.Zero) return;
+            if (_handle.IsInvalid) return;
 
             _recorder?.RecordInput(input);
 
             byte[] data = Encoding.UTF8.GetBytes(input);
-            Native.pty_write(_ptyState, data, data.Length);
+            Native.pty_write(_handle, data, data.Length);
         }
 
         public void Resize(int cols, int rows)
         {
-            if (_ptyState == IntPtr.Zero || cols <= 0 || rows <= 0) return;
+            if (_handle.IsInvalid || cols <= 0 || rows <= 0) return;
             _cols = cols;
             _rows = rows;
             Console.WriteLine($"[RustPtySession] Resizing to {cols}x{rows}");
-            Native.pty_resize(_ptyState, (ushort)cols, (ushort)rows);
+            Native.pty_resize(_handle, (ushort)cols, (ushort)rows);
             _recorder?.RecordResize(cols, rows);
         }
 
         public void Dispose()
         {
+            // Idempotent: only the first caller runs teardown.
+            if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+
             if (_recorder != null)
             {
                 try
@@ -476,17 +493,43 @@ namespace NovaTerminal.Pty
                 }
             }
 
-            if (_ptyState != IntPtr.Zero)
+            // 1. Stop the loops re-entering native calls, and let the process loop drain.
+            _cts.Cancel();
+            if (!_outputQueue.IsAddingCompleted)
             {
-                _cts.Cancel();
-                if (!_outputQueue.IsAddingCompleted)
-                {
-                    _outputQueue.CompleteAdding();
-                }
-                Native.pty_close(_ptyState);
-                _ptyState = IntPtr.Zero;
-                TryNotifyExit(0);
+                _outputQueue.CompleteAdding();
             }
+
+            // 2. Quick join. If the shell already exited (EOF), the read loop is
+            //    already unwinding — no cancel needed, and we avoid pty_cancel_read's
+            //    bounded retry spinning when no read is actually blocked.
+            bool readExited = _readLoopThread?.Join(QuickJoinTimeout) ?? true;
+
+            // 3. Only if the read is genuinely still blocked: unblock it, then join hard.
+            if (!readExited)
+            {
+                if (!_handle.IsInvalid)
+                {
+                    try { Native.pty_cancel_read(_handle); }
+                    catch (ObjectDisposedException) { /* already gone */ }
+                }
+                if (!(_readLoopThread?.Join(DisposeJoinTimeout) ?? true))
+                {
+                    Console.WriteLine("[RustPtySession] ReadLoop did not exit within join timeout.");
+                }
+            }
+
+            // 4. Join the process loop (it exits once the queue is completed/cancelled).
+            if (!(_processLoopThread?.Join(DisposeJoinTimeout) ?? true))
+            {
+                Console.WriteLine("[RustPtySession] ProcessLoop did not exit within join timeout.");
+            }
+
+            // 5. Release the handle. SafeHandle guarantees pty_close runs only once
+            //    no pty_* call is in flight, so this is UAF-safe even if a join timed out.
+            _handle.Dispose();
+
+            TryNotifyExit(0);
         }
 
         private void TryNotifyExit(int code)

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
+using Microsoft.Win32.SafeHandles;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -63,6 +64,21 @@ namespace NovaTerminal.Pty
 
             [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void pty_close(IntPtr state);
+        }
+
+        // Owns the *mut PtyState returned by pty_spawn. Passing this to every
+        // pty_* P/Invoke makes the marshaller AddRef before / Release after the
+        // call, so pty_close (ReleaseHandle) can never run while a pty_read (or
+        // any other call) is in flight — closing the #118 use-after-free window.
+        internal sealed class PtySafeHandle : SafeHandleZeroOrMinusOneIsInvalid
+        {
+            public PtySafeHandle() : base(ownsHandle: true) { }
+
+            protected override bool ReleaseHandle()
+            {
+                Native.pty_close(handle);
+                return true;
+            }
         }
 
         public string ShellCommand { get; }

--- a/tests/NovaTerminal.App.Tests/PtyThreadLifecycleTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtyThreadLifecycleTests.cs
@@ -38,6 +38,50 @@ namespace NovaTerminal.Tests
             Assert.True(process.IsBackground, "ProcessLoop thread must be a background thread");
         }
 
+        [Fact]
+        [Trait("Category", "PtySmoke")]
+        public async Task Dispose_WhileReadBlocked_JoinsLoopThreadsPromptly()
+        {
+            string shell = ShellHelper.GetDefaultShell();
+            var session = new RustPtySession(shell, 80, 24);
+
+            await WaitUntilAsync(
+                () => session.ReadLoopThread is not null && session.ProcessLoopThread is not null,
+                TimeSpan.FromSeconds(5));
+
+            Thread read = session.ReadLoopThread!;
+            Thread process = session.ProcessLoopThread!;
+
+            // Let the shell go idle (read parked in native pty_read).
+            await Task.Delay(500);
+
+            var sw = Stopwatch.StartNew();
+            session.Dispose();
+            sw.Stop();
+
+            Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5),
+                $"Dispose took {sw.Elapsed.TotalSeconds:F1}s — cancel/join did not unblock the read");
+            Assert.False(read.IsAlive, "ReadLoop thread should have exited after Dispose");
+            Assert.False(process.IsAlive, "ProcessLoop thread should have exited after Dispose");
+        }
+
+        [Fact]
+        [Trait("Category", "PtySmoke")]
+        public void Dispose_IsIdempotent()
+        {
+            string shell = ShellHelper.GetDefaultShell();
+            var session = new RustPtySession(shell, 80, 24);
+
+            var ex = Record.Exception(() =>
+            {
+                session.Dispose();
+                session.Dispose();
+                session.Dispose();
+            });
+
+            Assert.Null(ex);
+        }
+
         private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
         {
             var sw = Stopwatch.StartNew();


### PR DESCRIPTION
## Summary

Production-side follow-ups to the #81 Mode-A investigation: make PTY session teardown promptly cancellable and use-after-free–proof, and stop two leaking UI timers. Mode B (the headless `App.Tests` deadlock) is upstream and remains tracked in #117 / AvaloniaUI/Avalonia#21467 — untouched here.

Design & plan: `docs/superpowers/specs/2026-06-10-pty-teardown-hardening-design.md`, `docs/superpowers/plans/2026-06-10-pty-teardown-hardening.md`.

## What changed

**Native (`lib.rs`)**
- New `pty_cancel_read` FFI export that unblocks an in-flight blocking read **without touching the locked `reader`**:
  - Windows passthrough → `ClosePseudoConsole` (breaks the output pipe).
  - Windows portable-pty path → `CancelSynchronousIo` against the recorded read thread. *(Discovery during impl: kill-to-EOF does **not** unblock the read on this path — the cloned reader handle only closes at `pty_close`, which `PtySafeHandle` defers until the read returns, a cycle. CancelSynchronousIo breaks it.)*
  - Unix → `child.kill()` (slave closes → master read returns EOF).
- `h_pc`/`h_process` moved to `Mutex<Option<…>>` so cancel and close `take()` without double-freeing.

**C# (`RustPtySession`)**
- `PtySafeHandle : SafeHandle` wraps the native pointer; every `pty_*` P/Invoke takes it, so the marshaller ref-counts calls vs. release — `pty_close` can't run while any call (incl. a parked read) is in flight. **Closes the #118 UAF by construction.**
- Ordered, idempotent `Dispose`: cancel-token → drain → quick-join → (only if read still blocked) `pty_cancel_read` → bounded hard-join → release. Quick-join-first avoids spinning the cancel retry on the common already-exited path.
- Guards short-circuit on `IsClosed`, and the four off-thread call sites swallow the narrow teardown-race `ObjectDisposedException`.

**UI (targeted #102 / #103)**
- `TerminalPane.Dispose` is now idempotent; the reused-`TermView` `OnResize`/`MetricsChanged` handlers are detach-before-attach so they don't accumulate across session restarts.
- `TerminalView._metricsTimer` is stopped on detach (it was started in the ctor and never stopped → fired every 5s forever, rooting the view); `MainWindow._recordingToastTimer` is stopped in `OnClosing`.

## Closes
- Closes #119, Closes #118, Closes #103
- Addresses the targeted part of #102 (leaking timers + restart-accumulating handlers). The full `CompositeDisposable` adoption and the 9 `Parser.On*` lambdas are intentionally left (the Parser is recreated each restart, so those handlers don't accumulate).

## Out of scope (follow-ups)
- `rusty_ssh` SafeHandle mirror (same #118 pattern) — deliberately deferred.
- Mode-B headless re-gate — #117.

## Test plan
- [x] Rust: `cargo test --manifest-path src/NovaTerminal.App/native/Cargo.toml` → 5/5 (incl. `cancel_read_unblocks_a_pending_read`, which passes on the Windows portable path).
- [x] C#: `scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter "Category=PtySmoke"` → 5/5 (incl. new `Dispose_WhileReadBlocked_JoinsLoopThreadsPromptly`, `Dispose_IsIdempotent`).
- [x] App builds clean (`scripts/build.ps1 build src/NovaTerminal.App`).
- [ ] Manual smoke (UI, headless lane can't cover): type/resize; reconnect 2–3×; close tabs/panes repeatedly (no orphaned shells); close window with a recording toast active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)