### PR TITLE
Native SSH FFI handle-safety: fail-closed registry + NovaSshSafeHandle (#121 items 2/4/3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,28 @@ env:
   MSBUILDDISABLENODEREUSE: '1'
 
 jobs:
+  # Native FFI unit/integration tests (handle registry, abuse suite, alloc balance).
+  # The per-OS build job only `cargo build`s the crates; the cargo test suites
+  # (rusty_ssh fail-closed handle tests + rusty_pty cancel tests) run here.
+  rust-ffi-tests:
+    name: Rust FFI Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Rust incremental build cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            src/NovaTerminal.App/native
+            src/NovaTerminal.App/native/rusty_ssh
+      - name: rusty_ssh FFI tests (registry, abuse suite, alloc balance)
+        run: cargo test --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml
+      - name: rusty_pty FFI tests
+        run: cargo test --manifest-path src/NovaTerminal.App/native/Cargo.toml
+
   # Single build job per OS: Rust native + .NET in one step.
   # Eliminates the artifact round-trip that the old build_native → build_dotnet split required.
   build:

--- a/docs/superpowers/plans/2026-06-10-ssh-ffi-handle-safety.md
+++ b/docs/superpowers/plans/2026-06-10-ssh-ffi-handle-safety.md
@@ -1,0 +1,953 @@
+# Native SSH FFI Handle-Safety Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the native SSH FFI fail closed on stale/closed/double-closed session handles (Rust monotonic-id registry) and ref-counted on the managed side (`NovaSshSafeHandle`), eliminating the poll-vs-close use-after-free, with an FFI abuse-test suite and an error-string allocation audit.
+
+**Architecture:** Replace the raw `*mut NovaSshSession` FFI handle with an opaque `u64` id into a process-global `Mutex<HashMap<u64, Arc<NovaSshSession>>>`; every session export validates the id (absent ⇒ `INVALID_ARGUMENT`) and operates through a cloned `Arc` so an in-flight call can't be freed by a concurrent close. On the C# side, a `NovaSshSafeHandle : SafeHandleZeroOrMinusOneIsInvalid` carries the id and gives the marshaller AddRef/Release around every call.
+
+**Tech Stack:** Rust (`russh`, `std::sync`), C# (.NET 10, `Microsoft.Win32.SafeHandles`), xUnit, `cargo test`.
+
+**Spec:** `docs/superpowers/specs/2026-06-10-ssh-ffi-handle-safety-design.md`
+**Issue:** #121 items 2/4/3 (item 1 = separate sub-project B).
+
+**Build/test commands (from repo root):**
+- Rust SSH: `cargo test --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml`
+- Rust SSH build (release, for C# to load): `cargo build --release --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml`
+- C# build: `scripts/build.ps1 build src/NovaTerminal.Platform`
+- C# tests (targeted): `scripts/build.ps1 test tests/NovaTerminal.Platform.Tests --filter "FullyQualifiedName~NativeSshSafeHandle"`
+- ALWAYS use `scripts/build.ps1` / `scripts/build.sh`, never raw `dotnet build` (hangs on piped stdout — see CLAUDE.md).
+
+---
+
+## File Structure
+
+| File | Responsibility | Tasks |
+|---|---|---|
+| `rusty_ssh/src/lib.rs` | Handle registry + interior mutability + export migration + error-string counter + lifecycle abuse unit tests | 1, 2, 4 |
+| `rusty_ssh/tests/ffi_contract.rs` | Updated null tests + JSON-malformed abuse tests + counter balance | 3 |
+| `Ssh/Native/NativeSshSafeHandle.cs` (new) | `SafeHandle` subclass owning the session id | 5 |
+| `Ssh/Native/NativeSshInterop.cs` + `INativeSshInterop.cs` | P/Invoke + interface migrated to `NovaSshSafeHandle` | 5, 6 |
+| `Ssh/Sessions/NativeSshSession.cs` | `_sessionHandle` → `NovaSshSafeHandle`; Dispose | 6 |
+| `Ssh/Native/NativePortForwardSession.cs` | hold the shared `NovaSshSafeHandle` | 6 |
+| `tests/NovaTerminal.Platform.Tests/Ssh/NativeSshSafeHandleTests.cs` (new) | disposed-handle safety | 7 |
+| `.github/workflows/ci.yml` | ensure `rusty_ssh` `cargo test` runs | 8 |
+
+---
+
+## Part 1 — Rust handle registry (item 2)
+
+### Task 1: Registry + interior mutability + migrate all session exports
+
+**Files:**
+- Modify: `src/NovaTerminal.App/native/rusty_ssh/src/lib.rs` (struct 117-121; constructions ~594, ~2817, ~2978; exports 602-844; close 846-867; connect ~555-600)
+- Modify: `src/NovaTerminal.App/native/rusty_ssh/tests/ffi_contract.rs` (null-handle test signatures)
+
+This is a cohesive refactor; the existing tests (`ffi_contract.rs`, the `ffi_guard` unit tests) are the regression guard. End state: `cargo test` green.
+
+- [ ] **Step 1: Add registry statics + helpers**
+
+Near the top of `lib.rs` (after the `use` block; add any missing imports: `std::collections::HashMap`, `std::sync::{Arc, Mutex, OnceLock}`, `std::sync::atomic::{AtomicU64, Ordering}` — `Arc`/`Mutex` may already be imported):
+
+```rust
+static SESSION_REGISTRY: OnceLock<Mutex<HashMap<u64, Arc<NovaSshSession>>>> = OnceLock::new();
+static NEXT_SESSION_ID: AtomicU64 = AtomicU64::new(1);
+
+fn session_registry() -> &'static Mutex<HashMap<u64, Arc<NovaSshSession>>> {
+    SESSION_REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+// Lock the registry, recovering from poisoning (the lock is held only for brief
+// map ops with no user code, so a poisoned guard is still structurally valid).
+fn lock_registry() -> std::sync::MutexGuard<'static, HashMap<u64, Arc<NovaSshSession>>> {
+    session_registry().lock().unwrap_or_else(|p| p.into_inner())
+}
+
+/// Insert a session, returning a fresh non-zero handle id (id 0 is never issued,
+/// so the C# SafeHandleZeroOrMinusOneIsInvalid treats 0 as invalid).
+fn registry_insert(session: NovaSshSession) -> u64 {
+    let id = NEXT_SESSION_ID.fetch_add(1, Ordering::SeqCst);
+    lock_registry().insert(id, Arc::new(session));
+    id
+}
+
+/// Look up a live session by handle token. None ⇒ unknown/closed/stale handle.
+fn registry_get(handle: usize) -> Option<Arc<NovaSshSession>> {
+    let id = handle as u64;
+    if id == 0 {
+        return None;
+    }
+    lock_registry().get(&id).cloned()
+}
+
+/// Remove (close) a session, returning it if it was present. A second call for
+/// the same id returns None (covers double-close).
+fn registry_remove(handle: usize) -> Option<Arc<NovaSshSession>> {
+    let id = handle as u64;
+    if id == 0 {
+        return None;
+    }
+    lock_registry().remove(&id)
+}
+```
+
+- [ ] **Step 2: Move `command_tx`/`worker` behind interior mutability**
+
+Change the struct (117-121):
+
+```rust
+pub struct NovaSshSession {
+    shared: Arc<SharedState>,
+    command_tx: Mutex<Option<mpsc::UnboundedSender<WorkerCommand>>>,
+    worker: Mutex<Option<thread::JoinHandle<()>>>,
+}
+```
+
+Update the three construction sites — `nova_ssh_connect` (~594), and the two others (~2817, ~2978). Wrap the values:
+- where it currently sets `command_tx: Some(command_tx)` → `command_tx: Mutex::new(Some(command_tx))`
+- `command_tx: None` → `command_tx: Mutex::new(None)`
+- `worker: Some(worker)` → `worker: Mutex::new(Some(worker))`
+- `worker: None` → `worker: Mutex::new(None)`
+
+Add a small helper for the repeated command-send pattern (used by write/resize/channel_*):
+
+```rust
+// Send a worker command through the session's command channel, mapping the
+// channel state to an FFI result. Returns CLOSED if the worker is gone.
+fn send_command(session: &NovaSshSession, command: WorkerCommand) -> c_int {
+    let guard = session.command_tx.lock().unwrap_or_else(|p| p.into_inner());
+    match guard.as_ref() {
+        Some(tx) => tx
+            .send(command)
+            .map(|_| NOVA_SSH_RESULT_OK)
+            .unwrap_or(NOVA_SSH_RESULT_CLOSED),
+        None => NOVA_SSH_RESULT_CLOSED,
+    }
+}
+```
+
+- [ ] **Step 3: Migrate `nova_ssh_connect` to return a handle id**
+
+In `nova_ssh_connect` (~555-600), it currently ends `Box::into_raw(Box::new(session))` returning `*mut NovaSshSession`. Change the return type to `usize` and the tail to register. The signature becomes:
+
+```rust
+pub extern "C" fn nova_ssh_connect(args: *const NovaSshConnectArgs) -> usize {
+```
+
+Wrap the body in `ffi_guard(0, || { ... })` (return `0` on panic), and replace the final `Box::into_raw(Box::new(session))` with:
+
+```rust
+        registry_insert(session) as usize
+```
+
+(Every early `return std::ptr::null_mut();` / error path in `connect` becomes `return 0;`.)
+
+- [ ] **Step 4: Migrate the session exports to the handle token + registry lookup**
+
+Rewrite each export. Signatures change `session: *mut NovaSshSession` → `handle: usize`; the null check + `&mut *session` become a registry lookup.
+
+`nova_ssh_poll_event`:
+
+```rust
+pub extern "C" fn nova_ssh_poll_event(
+    handle: usize,
+    event: *mut NovaSshEvent,
+    payload: *mut u8,
+    payload_capacity: usize,
+) -> c_int {
+    ffi_guard(NOVA_SSH_RESULT_PANIC, || {
+        if event.is_null() {
+            return NOVA_SSH_RESULT_INVALID_ARGUMENT;
+        }
+        let session = match registry_get(handle) {
+            Some(s) => s,
+            None => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
+        };
+        let queued = match session.shared.peek_event() {
+            Some(event_value) => event_value,
+            None => return NOVA_SSH_RESULT_OK,
+        };
+        unsafe {
+            (*event).kind = queued.kind as u32;
+            (*event).payload_len = queued.payload.len() as u32;
+            (*event).status_code = queued.status_code;
+            (*event).flags = queued.flags;
+        }
+        if queued.payload.len() > payload_capacity {
+            return NOVA_SSH_RESULT_BUFFER_TOO_SMALL;
+        }
+        if !payload.is_null() && !queued.payload.is_empty() {
+            unsafe {
+                ptr::copy_nonoverlapping(queued.payload.as_ptr(), payload, queued.payload.len());
+            }
+        }
+        session.shared.pop_event();
+        NOVA_SSH_RESULT_EVENT_READY
+    })
+}
+```
+
+`nova_ssh_write`:
+
+```rust
+pub extern "C" fn nova_ssh_write(handle: usize, data: *const u8, data_len: usize) -> c_int {
+    ffi_guard(NOVA_SSH_RESULT_PANIC, || {
+        if data.is_null() && data_len != 0 {
+            return NOVA_SSH_RESULT_INVALID_ARGUMENT;
+        }
+        let session = match registry_get(handle) {
+            Some(s) => s,
+            None => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
+        };
+        let bytes = if data_len == 0 {
+            Vec::new()
+        } else {
+            unsafe { std::slice::from_raw_parts(data, data_len) }.to_vec()
+        };
+        send_command(&session, WorkerCommand::Write(bytes))
+    })
+}
+```
+
+`nova_ssh_resize`:
+
+```rust
+pub extern "C" fn nova_ssh_resize(handle: usize, cols: u16, rows: u16) -> c_int {
+    ffi_guard(NOVA_SSH_RESULT_PANIC, || {
+        if cols == 0 || rows == 0 {
+            return NOVA_SSH_RESULT_INVALID_ARGUMENT;
+        }
+        let session = match registry_get(handle) {
+            Some(s) => s,
+            None => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
+        };
+        send_command(&session, WorkerCommand::Resize { cols, rows })
+    })
+}
+```
+
+`nova_ssh_open_direct_tcpip` (keeps its reply-channel logic; only handle + lookup + command-send change):
+
+```rust
+pub extern "C" fn nova_ssh_open_direct_tcpip(
+    handle: usize,
+    args: *const NovaSshDirectTcpIpArgs,
+) -> c_int {
+    ffi_guard(NOVA_SSH_RESULT_PANIC, || {
+        if args.is_null() {
+            return NOVA_SSH_RESULT_INVALID_ARGUMENT;
+        }
+        let args = unsafe { args.as_ref() }.expect("validated non-null args");
+        let host_to_connect = match read_c_string(args.host_to_connect) {
+            Some(value) => value,
+            None => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
+        };
+        let originator_address =
+            read_c_string(args.originator_address).unwrap_or_else(|| "127.0.0.1".to_owned());
+        let session = match registry_get(handle) {
+            Some(s) => s,
+            None => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
+        };
+        let (reply_tx, reply_rx) = std_mpsc::channel();
+        let command = WorkerCommand::OpenDirectTcpIp {
+            host_to_connect,
+            port_to_connect: if args.port_to_connect == 0 { 0 } else { args.port_to_connect as u32 },
+            originator_address,
+            originator_port: args.originator_port as u32,
+            reply: reply_tx,
+        };
+        {
+            let guard = session.command_tx.lock().unwrap_or_else(|p| p.into_inner());
+            match guard.as_ref() {
+                Some(tx) => {
+                    if tx.send(command).is_err() {
+                        return NOVA_SSH_RESULT_CLOSED;
+                    }
+                }
+                None => return NOVA_SSH_RESULT_CLOSED,
+            }
+        }
+        match reply_rx.recv() {
+            Ok(Ok(channel_id)) => channel_id as c_int,
+            Ok(Err(_)) => NOVA_SSH_RESULT_CHANNEL_OPEN_FAILED,
+            Err(_) => NOVA_SSH_RESULT_CLOSED,
+        }
+    })
+}
+```
+
+`nova_ssh_channel_write`:
+
+```rust
+pub extern "C" fn nova_ssh_channel_write(
+    handle: usize,
+    channel_id: u32,
+    data: *const u8,
+    data_len: usize,
+) -> c_int {
+    ffi_guard(NOVA_SSH_RESULT_PANIC, || {
+        if data.is_null() && data_len != 0 {
+            return NOVA_SSH_RESULT_INVALID_ARGUMENT;
+        }
+        let session = match registry_get(handle) {
+            Some(s) => s,
+            None => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
+        };
+        let bytes = if data_len == 0 {
+            Vec::new()
+        } else {
+            unsafe { std::slice::from_raw_parts(data, data_len) }.to_vec()
+        };
+        send_command(&session, WorkerCommand::WriteForwardChannel { channel_id, data: bytes })
+    })
+}
+```
+
+`nova_ssh_channel_eof`:
+
+```rust
+pub extern "C" fn nova_ssh_channel_eof(handle: usize, channel_id: u32) -> c_int {
+    ffi_guard(NOVA_SSH_RESULT_PANIC, || {
+        let session = match registry_get(handle) {
+            Some(s) => s,
+            None => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
+        };
+        send_command(&session, WorkerCommand::ForwardChannelEof { channel_id })
+    })
+}
+```
+
+`nova_ssh_channel_close`:
+
+```rust
+pub extern "C" fn nova_ssh_channel_close(handle: usize, channel_id: u32) -> c_int {
+    ffi_guard(NOVA_SSH_RESULT_PANIC, || {
+        let session = match registry_get(handle) {
+            Some(s) => s,
+            None => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
+        };
+        send_command(&session, WorkerCommand::CloseForwardChannel { channel_id })
+    })
+}
+```
+
+`nova_ssh_submit_response`:
+
+```rust
+pub extern "C" fn nova_ssh_submit_response(
+    handle: usize,
+    response_kind: u32,
+    data: *const u8,
+    data_len: usize,
+) -> c_int {
+    ffi_guard(NOVA_SSH_RESULT_PANIC, || {
+        if data.is_null() && data_len != 0 {
+            return NOVA_SSH_RESULT_INVALID_ARGUMENT;
+        }
+        let kind = match response_kind {
+            1 => NovaSshResponseKind::HostKeyDecision,
+            2 => NovaSshResponseKind::Password,
+            3 => NovaSshResponseKind::Passphrase,
+            4 => NovaSshResponseKind::KeyboardInteractive,
+            _ => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
+        };
+        let session = match registry_get(handle) {
+            Some(s) => s,
+            None => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
+        };
+        let payload = if data_len == 0 {
+            Vec::new()
+        } else {
+            unsafe { std::slice::from_raw_parts(data, data_len) }.to_vec()
+        };
+        session.shared.queue_response(QueuedResponse { kind, payload });
+        NOVA_SSH_RESULT_OK
+    })
+}
+```
+
+- [ ] **Step 5: Migrate `nova_ssh_close` to remove from the registry**
+
+```rust
+pub extern "C" fn nova_ssh_close(handle: usize) -> c_int {
+    ffi_guard(NOVA_SSH_RESULT_PANIC, || {
+        let session = match registry_remove(handle) {
+            Some(s) => s,
+            None => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
+        };
+        if let Some(tx) = session.command_tx.lock().unwrap_or_else(|p| p.into_inner()).take() {
+            let _ = tx.send(WorkerCommand::Close);
+        }
+        session.shared.mark_closed();
+        if let Some(worker) = session.worker.lock().unwrap_or_else(|p| p.into_inner()).take() {
+            let _ = worker.join();
+        }
+        NOVA_SSH_RESULT_OK
+    })
+}
+```
+
+(Note: `session` is now `Arc<NovaSshSession>`; the `Box` is freed when the last `Arc` — registry's plus any in-flight call's clone — drops. The worker join happens on the removed Arc.)
+
+- [ ] **Step 6: Update the existing `ffi_contract.rs` null tests to the new signatures**
+
+In `invalid_handles_are_rejected_cleanly`, the calls now pass a handle `0usize` instead of `std::ptr::null_mut()`:
+
+```rust
+    assert_eq!(
+        NOVA_SSH_RESULT_INVALID_ARGUMENT,
+        nova_ssh_poll_event(0, &mut event, std::ptr::null_mut(), 0)
+    );
+    assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, nova_ssh_resize(0, 120, 30));
+    assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, nova_ssh_write(0, [1u8].as_ptr(), 1));
+    assert_eq!(
+        NOVA_SSH_RESULT_INVALID_ARGUMENT,
+        nova_ssh_submit_response(0, 1, br#"{}"#.as_ptr(), 2)
+    );
+    assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, nova_ssh_close(0));
+```
+
+- [ ] **Step 7: Build + run the Rust suite**
+
+Run: `cargo test --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml`
+Expected: builds; all existing tests pass (`ffi_struct_layout_stays_stable`, `invalid_handles_are_rejected_cleanly`, `ffi_guard_*`). Fix any compile errors from missed `command_tx`/`worker` access sites (search the file for `.command_tx` and `.worker` to confirm every read goes through `.lock()`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/NovaTerminal.App/native/rusty_ssh/src/lib.rs src/NovaTerminal.App/native/rusty_ssh/tests/ffi_contract.rs
+git commit -m "refactor(ssh-ffi): registry-backed handle ids, fail-closed on stale (#121 #118)"
+```
+End the commit body with a blank line then:
+`Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+
+---
+
+### Task 2: Handle-lifecycle abuse unit tests (item 4)
+
+**Files:**
+- Modify: `src/NovaTerminal.App/native/rusty_ssh/src/lib.rs` (add a `#[cfg(test)] mod handle_abuse_tests` at end)
+
+These run inside the crate so they can build a stub session (no live server) and use `registry_insert`.
+
+- [ ] **Step 1: Add a test-only stub constructor**
+
+Add (inside the crate, gated for tests):
+
+```rust
+#[cfg(test)]
+fn stub_session() -> NovaSshSession {
+    NovaSshSession {
+        shared: Arc::new(SharedState::new()),
+        command_tx: Mutex::new(None),
+        worker: Mutex::new(None),
+    }
+}
+```
+
+- [ ] **Step 2: Write the abuse tests**
+
+```rust
+#[cfg(test)]
+mod handle_abuse_tests {
+    use super::*;
+
+    #[test]
+    fn calls_after_close_fail_closed() {
+        let handle = registry_insert(stub_session()) as usize;
+        assert_eq!(NOVA_SSH_RESULT_OK, nova_ssh_close(handle));
+
+        let mut event = NovaSshEvent::default();
+        assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, nova_ssh_poll_event(handle, &mut event, std::ptr::null_mut(), 0));
+        assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, nova_ssh_write(handle, [1u8].as_ptr(), 1));
+        assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, nova_ssh_resize(handle, 80, 24));
+        assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, nova_ssh_channel_eof(handle, 0));
+        assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, nova_ssh_submit_response(handle, 2, br#"{}"#.as_ptr(), 2));
+    }
+
+    #[test]
+    fn double_close_is_rejected() {
+        let handle = registry_insert(stub_session()) as usize;
+        assert_eq!(NOVA_SSH_RESULT_OK, nova_ssh_close(handle));
+        assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, nova_ssh_close(handle));
+    }
+
+    #[test]
+    fn concurrent_poll_and_close_never_crashes() {
+        for _ in 0..200 {
+            let handle = registry_insert(stub_session()) as usize;
+            let poller = std::thread::spawn(move || {
+                let mut event = NovaSshEvent::default();
+                for _ in 0..50 {
+                    let rc = nova_ssh_poll_event(handle, &mut event, std::ptr::null_mut(), 0);
+                    // OK / no-event / EVENT_READY / closed are all acceptable; never UB.
+                    assert!(matches!(
+                        rc,
+                        NOVA_SSH_RESULT_OK | NOVA_SSH_RESULT_EVENT_READY | NOVA_SSH_RESULT_INVALID_ARGUMENT
+                    ));
+                }
+            });
+            let closer = std::thread::spawn(move || nova_ssh_close(handle));
+            poller.join().unwrap();
+            let _ = closer.join().unwrap();
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run**
+
+Run: `cargo test --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml handle_abuse`
+Expected: PASS (all three). The concurrent test repeats 200× to shake out the race.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+git commit -m "test(ssh-ffi): handle-lifecycle abuse tests (call-after-close, double-close, race) (#121)"
+```
+(+ Co-Authored-By trailer.)
+
+---
+
+### Task 3: JSON-malformed abuse tests (item 4)
+
+**Files:**
+- Modify: `src/NovaTerminal.App/native/rusty_ssh/tests/ffi_contract.rs`
+
+- [ ] **Step 1: Add malformed/oversized JSON tests**
+
+The `nova_ssh_sftp_transfer` / `nova_ssh_sftp_list_directory` exports parse JSON before connecting, so they reject bad input without a server. Add `nova_ssh_sftp_list_directory` and `nova_ssh_string_free` to the `use` imports, then:
+
+```rust
+use std::ffi::CString;
+use rusty_ssh::{nova_ssh_sftp_list_directory, nova_ssh_string_free};
+
+#[test]
+fn malformed_json_is_rejected_without_panic() {
+    let bad = CString::new("{ this is not valid json ").unwrap();
+    let mut response: *mut std::os::raw::c_char = std::ptr::null_mut();
+    let rc = nova_ssh_sftp_list_directory(bad.as_ptr(), &mut response);
+    assert_ne!(rc, 0, "malformed JSON must not report success");
+    if !response.is_null() {
+        unsafe { nova_ssh_string_free(response) };
+    }
+}
+
+#[test]
+fn oversized_json_is_rejected_without_panic() {
+    // A syntactically-valid but semantically-bogus, very large payload.
+    let big = format!(r#"{{"junk":"{}"}}"#, "A".repeat(2_000_000));
+    let payload = CString::new(big).unwrap();
+    let mut response: *mut std::os::raw::c_char = std::ptr::null_mut();
+    let rc = nova_ssh_sftp_list_directory(payload.as_ptr(), &mut response);
+    assert_ne!(rc, 0, "bogus oversized JSON must not report success");
+    if !response.is_null() {
+        unsafe { nova_ssh_string_free(response) };
+    }
+}
+```
+
+> The exact P/Invoke signature of `nova_ssh_sftp_list_directory` is `(*const c_char, *mut *mut c_char) -> c_int`. Confirm the parameter/return types against `lib.rs` and adjust the `use`/types if the response out-param differs; do not change the export.
+
+- [ ] **Step 2: Run**
+
+Run: `cargo test --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml`
+Expected: all pass, including the two new JSON tests and the (now id-`0`) null tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/NovaTerminal.App/native/rusty_ssh/tests/ffi_contract.rs
+git commit -m "test(ssh-ffi): malformed/oversized JSON abuse tests (#121)"
+```
+(+ Co-Authored-By trailer.)
+
+---
+
+## Part 2 — Error-string allocation audit (item 3)
+
+### Task 4: Debug allocation counter + balance test
+
+**Files:**
+- Modify: `src/NovaTerminal.App/native/rusty_ssh/src/lib.rs`
+
+- [ ] **Step 1: Add the debug counter and hook it into the string alloc/free boundary**
+
+Add near the registry statics:
+
+```rust
+#[cfg(debug_assertions)]
+static OUTSTANDING_FFI_STRINGS: AtomicI64 = AtomicI64::new(0);
+
+// Convert an owned String into a freshly-allocated C string handed to the caller.
+// In debug builds, tracks the outstanding count so tests can assert alloc/free balance.
+fn ffi_string_into_raw(value: String) -> *mut c_char {
+    match CString::new(value) {
+        Ok(c) => {
+            #[cfg(debug_assertions)]
+            OUTSTANDING_FFI_STRINGS.fetch_add(1, Ordering::SeqCst);
+            c.into_raw()
+        }
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+```
+
+Add the `AtomicI64` import (`std::sync::atomic::AtomicI64`). Then route every existing `CString::new(...).into_raw()` / `CString::into_raw(...)` that returns a payload to C# (the `sftp_transfer` and `list_directory` response builders) through `ffi_string_into_raw(...)`. (Search `lib.rs` for `into_raw` to find them; the SFTP/list response paths are the ones returning `*mut c_char` to C#.)
+
+Update `nova_ssh_string_free` to decrement:
+
+```rust
+pub extern "C" fn nova_ssh_string_free(value: *mut c_char) {
+    ffi_guard((), || {
+        if !value.is_null() {
+            #[cfg(debug_assertions)]
+            OUTSTANDING_FFI_STRINGS.fetch_sub(1, Ordering::SeqCst);
+            drop(unsafe { CString::from_raw(value) });
+        }
+    });
+}
+```
+
+> If `nova_ssh_string_free` isn't already `ffi_guard`-wrapped, wrap it as shown (the existing body is the `if !value.is_null() { drop(CString::from_raw(value)) }` line).
+
+- [ ] **Step 2: Write the balance test**
+
+Add to the `#[cfg(test)] mod handle_abuse_tests` (or a new `#[cfg(test)] mod alloc_balance_tests`):
+
+```rust
+#[cfg(all(test, debug_assertions))]
+mod alloc_balance_tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn malformed_list_request_frees_its_response_string() {
+        let before = OUTSTANDING_FFI_STRINGS.load(Ordering::SeqCst);
+        let bad = CString::new("{ not json").unwrap();
+        let mut response: *mut c_char = std::ptr::null_mut();
+        let _ = nova_ssh_sftp_list_directory(bad.as_ptr(), &mut response);
+        if !response.is_null() {
+            nova_ssh_string_free(response);
+        }
+        let after = OUTSTANDING_FFI_STRINGS.load(Ordering::SeqCst);
+        assert_eq!(before, after, "every FFI-allocated string must be freed");
+    }
+}
+```
+
+> Tests run single-threaded for this module if other tests also allocate FFI strings concurrently; if flakiness appears, gate with a serial guard or compare a local delta around the call rather than absolute counts. Prefer the before/after delta as written.
+
+- [ ] **Step 3: Run**
+
+Run: `cargo test --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml alloc_balance`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+git commit -m "feat(ssh-ffi): debug FFI-string alloc counter + balance test (#121)"
+```
+(+ Co-Authored-By trailer.)
+
+---
+
+## Part 3 — C# `NovaSshSafeHandle` + migration (item 2)
+
+### Task 5: `NovaSshSafeHandle` + NativeMethods signature changes
+
+**Files:**
+- Create: `src/NovaTerminal.Platform/Ssh/Native/NativeSshSafeHandle.cs`
+- Modify: `src/NovaTerminal.Platform/Ssh/Native/NativeSshInterop.cs` (the nested `NativeMethods` class, 915-959)
+
+- [ ] **Step 1: Create `NovaSshSafeHandle`**
+
+```csharp
+using System;
+using Microsoft.Win32.SafeHandles;
+
+namespace NovaTerminal.Platform.Ssh.Native;
+
+// Owns a native SSH session registry id (returned by nova_ssh_connect). Passing
+// this to every session P/Invoke makes the marshaller AddRef before / Release
+// after each call, so nova_ssh_close (ReleaseHandle) cannot run while a poll or
+// write is in flight — closing the poll-vs-close use-after-free (#121/#118).
+public sealed class NovaSshSafeHandle : SafeHandleZeroOrMinusOneIsInvalid
+{
+    public NovaSshSafeHandle() : base(ownsHandle: true) { }
+
+    protected override bool ReleaseHandle()
+    {
+        NativeSshInterop.NativeMethods.nova_ssh_close_raw(handle);
+        return true;
+    }
+}
+```
+
+- [ ] **Step 2: Update `NativeMethods` signatures**
+
+In `NativeSshInterop.NativeMethods`, change the persistent-session imports to take `NovaSshSafeHandle`, make `nova_ssh_connect` return it, and add a raw close for `ReleaseHandle`. Also make `NativeMethods` `internal` (it's `private static class` today — promote to `internal static class` so `NovaSshSafeHandle` can call it; keep it nested in `NativeSshInterop`).
+
+```csharp
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_connect")]
+        public static extern NovaSshSafeHandle nova_ssh_connect(in NativeConnectArgs args);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_poll_event")]
+        public static extern int nova_ssh_poll_event(NovaSshSafeHandle session, out NativeEventHeader @event, byte[] payload, nuint payloadCapacity);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_write")]
+        public static extern int nova_ssh_write(NovaSshSafeHandle session, byte[] data, nuint dataLength);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_resize")]
+        public static extern int nova_ssh_resize(NovaSshSafeHandle session, ushort cols, ushort rows);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_open_direct_tcpip")]
+        public static extern int nova_ssh_open_direct_tcpip(NovaSshSafeHandle session, in NativeDirectTcpIpOpenArgs args);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_channel_write")]
+        public static extern int nova_ssh_channel_write(NovaSshSafeHandle session, uint channelId, byte[] data, nuint dataLength);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_channel_eof")]
+        public static extern int nova_ssh_channel_eof(NovaSshSafeHandle session, uint channelId);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_channel_close")]
+        public static extern int nova_ssh_channel_close(NovaSshSafeHandle session, uint channelId);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_submit_response")]
+        public static extern int nova_ssh_submit_response(NovaSshSafeHandle session, uint responseKind, byte[] data, nuint dataLength);
+
+        // Raw close used only by NovaSshSafeHandle.ReleaseHandle().
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_close")]
+        public static extern int nova_ssh_close_raw(IntPtr session);
+```
+
+(Leave `nova_ssh_sftp_transfer`, `nova_ssh_sftp_list_directory`, `nova_ssh_string_free` unchanged — they don't take a session handle.)
+
+- [ ] **Step 3: Build (expect interface/impl errors — fixed in Task 6)**
+
+Run: `scripts/build.ps1 build src/NovaTerminal.Platform`
+Expected: FAIL — `INativeSshInterop`/`NativeSshInterop`/`NativeSshSession` still use `IntPtr`. Resolved in Task 6. (Proceed to Task 6 to reach green.)
+
+---
+
+### Task 6: Migrate interface, interop bodies, session, and port-forward
+
+**Files:**
+- Modify: `src/NovaTerminal.Platform/Ssh/Native/INativeSshInterop.cs`
+- Modify: `src/NovaTerminal.Platform/Ssh/Native/NativeSshInterop.cs` (`Connect` + session methods)
+- Modify: `src/NovaTerminal.Platform/Ssh/Sessions/NativeSshSession.cs`
+- Modify: `src/NovaTerminal.Platform/Ssh/Native/NativePortForwardSession.cs`
+
+- [ ] **Step 1: Migrate the interface**
+
+In `INativeSshInterop.cs`, change `IntPtr` → `NovaSshSafeHandle` for the session methods and `Connect`'s return:
+
+```csharp
+    NovaSshSafeHandle Connect(NativeSshConnectionOptions options);
+    NativeSshEvent? PollEvent(NovaSshSafeHandle sessionHandle);
+    void Write(NovaSshSafeHandle sessionHandle, ReadOnlySpan<byte> data);
+    void Resize(NovaSshSafeHandle sessionHandle, int cols, int rows);
+    int OpenDirectTcpIp(NovaSshSafeHandle sessionHandle, NativePortForwardOpenOptions options);
+    void WriteChannel(NovaSshSafeHandle sessionHandle, int channelId, ReadOnlySpan<byte> data);
+    void SendChannelEof(NovaSshSafeHandle sessionHandle, int channelId);
+    void CloseChannel(NovaSshSafeHandle sessionHandle, int channelId);
+    void SubmitResponse(NovaSshSafeHandle sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data);
+    void Close(NovaSshSafeHandle sessionHandle);
+```
+
+(`ListRemoteDirectory` and `RunSftpTransfer` are unchanged.)
+
+- [ ] **Step 2: Migrate `NativeSshInterop` method bodies**
+
+`Connect` (23-122): change the return type to `NovaSshSafeHandle`; replace the handle check + return:
+
+```csharp
+                NovaSshSafeHandle handle = NativeMethods.nova_ssh_connect(in args);
+                if (handle.IsInvalid)
+                {
+                    handle.Dispose();
+                    throw new InvalidOperationException("Failed to create native SSH session.");
+                }
+
+                return handle;
+```
+
+For each session method, change the parameter type to `NovaSshSafeHandle` and the guard from `== IntPtr.Zero` to `is null or { IsInvalid: true } or { IsClosed: true }`, then pass `sessionHandle` straight to the (now SafeHandle-typed) `NativeMethods` call. Example — `PollEvent`:
+
+```csharp
+    public NativeSshEvent? PollEvent(NovaSshSafeHandle sessionHandle)
+    {
+        if (sessionHandle is null || sessionHandle.IsInvalid || sessionHandle.IsClosed)
+        {
+            return null;
+        }
+        // ... unchanged loop, but the nova_ssh_poll_event call now takes sessionHandle directly ...
+    }
+```
+
+Apply the same parameter-type + guard change to `Write`, `Resize`, `OpenDirectTcpIp`, `WriteChannel`, `SendChannelEof`, `CloseChannel`, `SubmitResponse`, `Close`. For `Close`:
+
+```csharp
+    public void Close(NovaSshSafeHandle sessionHandle)
+    {
+        // Disposing the SafeHandle runs ReleaseHandle -> nova_ssh_close exactly once,
+        // after any in-flight call's AddRef has been released.
+        sessionHandle?.Dispose();
+    }
+```
+
+(The old `Close` returned-code handling is no longer needed; `ReleaseHandle` ignores the return per SafeHandle contract.) Wrap each native call's marshalling concern is handled by the SafeHandle; no try/catch needed beyond the existing result-code checks. Note: a method racing a dispose can throw `ObjectDisposedException` from the marshaller — guard the bodies that loop/poll (`PollEvent`) with a `try { } catch (ObjectDisposedException) { return null; }` and the void methods with `catch (ObjectDisposedException) { }`.
+
+- [ ] **Step 3: Migrate `NativeSshSession`**
+
+- Change `private IntPtr _sessionHandle;` → `private NovaSshSafeHandle? _sessionHandle;`.
+- `_sessionHandle = _interop.Connect(connectionOptions);` is unchanged (now returns the SafeHandle).
+- Guards `_sessionHandle == IntPtr.Zero` → `_sessionHandle is null or { IsInvalid: true } or { IsClosed: true }`.
+- The teardown (527-530): replace
+  ```csharp
+  IntPtr handle = Interlocked.Exchange(ref _sessionHandle, IntPtr.Zero);
+  if (handle != IntPtr.Zero) { _interop.Close(handle); }
+  ```
+  with
+  ```csharp
+  NovaSshSafeHandle? handle = Interlocked.Exchange(ref _sessionHandle, null);
+  handle?.Dispose();
+  ```
+- Pass `_sessionHandle` to `NativePortForwardSession` (83) — now a `NovaSshSafeHandle`.
+
+- [ ] **Step 4: Migrate `NativePortForwardSession`**
+
+Change its stored handle field and constructor parameter from `IntPtr` to `NovaSshSafeHandle`, and pass it through to `_interop.OpenDirectTcpIp/WriteChannel/SendChannelEof/CloseChannel`. It does **not** own/dispose the handle (the `NativeSshSession` does); it only borrows the reference for the session's lifetime.
+
+- [ ] **Step 5: Build the native lib + the platform assembly**
+
+Run: `cargo build --release --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml`
+Then: `scripts/build.ps1 build src/NovaTerminal.Platform`
+Expected: Build succeeded. Fix any remaining `IntPtr`-typed call sites the compiler flags.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/NovaTerminal.Platform/Ssh/Native/NativeSshSafeHandle.cs src/NovaTerminal.Platform/Ssh/Native/NativeSshInterop.cs src/NovaTerminal.Platform/Ssh/Native/INativeSshInterop.cs src/NovaTerminal.Platform/Ssh/Sessions/NativeSshSession.cs src/NovaTerminal.Platform/Ssh/Native/NativePortForwardSession.cs
+git commit -m "feat(ssh): NovaSshSafeHandle ref-counts native SSH session FFI (#121 #118)"
+```
+(+ Co-Authored-By trailer.)
+
+---
+
+### Task 7: C# disposed-handle safety test
+
+**Files:**
+- Create: `tests/NovaTerminal.Platform.Tests/Ssh/NativeSshSafeHandleTests.cs`
+
+- [ ] **Step 1: Write the test**
+
+```csharp
+using NovaTerminal.Platform.Ssh.Native;
+using Xunit;
+
+namespace NovaTerminal.Platform.Tests.Ssh;
+
+public class NativeSshSafeHandleTests
+{
+    [Fact]
+    public void Dispose_IsIdempotent_AndDoesNotThrow()
+    {
+        // A default (invalid) handle should dispose safely and repeatedly.
+        var handle = new NovaSshSafeHandle();
+        Assert.True(handle.IsInvalid);
+
+        var ex = Record.Exception(() =>
+        {
+            handle.Dispose();
+            handle.Dispose();
+        });
+
+        Assert.Null(ex);
+        Assert.True(handle.IsClosed);
+    }
+
+    [Fact]
+    public void Interop_SessionMethods_NoOp_OnDisposedHandle()
+    {
+        var interop = new NativeSshInterop();
+        var handle = new NovaSshSafeHandle();
+        handle.Dispose();
+
+        // Calling through a disposed/invalid handle must be a safe no-op, not a crash.
+        var ex = Record.Exception(() =>
+        {
+            _ = interop.PollEvent(handle);
+            interop.Write(handle, new byte[] { 1 });
+            interop.Resize(handle, 80, 24);
+            interop.Close(handle);
+        });
+
+        Assert.Null(ex);
+    }
+}
+```
+
+> A default `NovaSshSafeHandle` has handle value 0 (invalid), so `ReleaseHandle` is not invoked on dispose (SafeHandle skips release for invalid handles) — no native call occurs, making this test server-free and safe.
+
+- [ ] **Step 2: Run**
+
+Run: `scripts/build.ps1 test tests/NovaTerminal.Platform.Tests --filter "FullyQualifiedName~NativeSshSafeHandle"`
+Expected: PASS (2 tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/NovaTerminal.Platform.Tests/Ssh/NativeSshSafeHandleTests.cs
+git commit -m "test(ssh): NovaSshSafeHandle dispose idempotency + disposed-handle safety (#121)"
+```
+(+ Co-Authored-By trailer.)
+
+---
+
+## Part 4 — CI + final verification
+
+### Task 8: Ensure `rusty_ssh` tests run in CI; final verification
+
+**Files:**
+- Modify (if needed): `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Check whether CI runs `rusty_ssh` cargo tests**
+
+Search `ci.yml` for `rusty_ssh` and `cargo test`. The repo already has an `Analyze (rust)` job and builds the native crates. If there is no `cargo test` step for `rusty_ssh`, add one to the Rust job:
+
+```yaml
+      - name: Rust SSH FFI tests
+        run: cargo test --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml
+```
+
+If a `cargo test` already covers the workspace/crate, leave it; just confirm `ffi_contract` and the new unit tests are included.
+
+- [ ] **Step 2: Commit (only if ci.yml changed)**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: run rusty_ssh cargo tests (FFI contract + abuse suite) (#121)"
+```
+(+ Co-Authored-By trailer.)
+
+- [ ] **Step 3: Final consolidated verification**
+
+Run, expecting all green:
+- `cargo test --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml` → all pass (layout, null, handle-abuse, JSON-abuse, alloc-balance).
+- `cargo build --release --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml`
+- `scripts/build.ps1 build src/NovaTerminal.App` (full app builds with the migrated platform assembly).
+- `scripts/build.ps1 test tests/NovaTerminal.Platform.Tests --filter "FullyQualifiedName~NativeSshSafeHandle"` → pass.
+
+- [ ] **Step 4: Confirm the issue scope**
+
+This PR closes #121 items 2, 4, 3. Note in the PR that item 1 (credential zeroization) is sub-project B (separate PR), and that `NativeSshDockerE2eTests` (Docker-gated, `[SKIP]` off-CI) remain unaffected.
+
+## Notes for the implementer
+
+- Do NOT run the whole `NovaTerminal.Platform.Tests` project broadly if it pulls in slow/Docker-gated SSH E2E tests; use the `--filter` shown. The native SSH E2E tests are `[SKIP]` without Docker.
+- The native `rusty_ssh` artifact must be rebuilt (`cargo build --release …`) before the C# side resolves the changed exports at runtime.
+- Build only via `scripts/build.ps1` / `scripts/build.sh`.
+- Keep all exports `ffi_guard`-wrapped; never let a `.lock().unwrap()` panic escape (use `unwrap_or_else(|p| p.into_inner())` as shown).

--- a/docs/superpowers/specs/2026-06-10-ssh-ffi-handle-safety-design.md
+++ b/docs/superpowers/specs/2026-06-10-ssh-ffi-handle-safety-design.md
@@ -1,0 +1,98 @@
+# Native SSH FFI Handle-Safety Hardening — Design
+
+**Date:** 2026-06-10
+**Issue:** #121 (items 2, 4, 3 — "sub-project A"). Item 1 (credential zeroization) is **sub-project B**, a separate spec/plan/PR.
+**Branch (planned):** `fix/issue-121-ssh-ffi-handle-safety`
+**Lineage:** Continues the FFI-safety work from #118/#119 (PTY `PtySafeHandle`), applying the same managed-side ref-counting to the native SSH stack and adding a Rust-side fail-closed handle model.
+
+## Background
+
+`#121` collects hardening items for the native SSH stack (`rusty_ssh` + `NativeSshInterop`). This spec covers three of the four; the fourth (secret zeroization) is split out because it spans a different axis (vault/options/serialization) and is larger.
+
+Current state (verified):
+- `nova_ssh_connect` returns a raw `*mut NovaSshSession` (`Box::into_raw`). Every session export (`poll_event`, `write`, `resize`, `open_direct_tcpip`, `channel_write`/`eof`/`close`, `submit_response`) does `let session = unsafe { &mut *session };`. `nova_ssh_close` does `Box::from_raw` + drop immediately — **there is no internal refcount**.
+- C# `NativeSshSession` holds `IntPtr _sessionHandle`, polls on a background thread (`PollEvent`) while `Close` runs on `Dispose`, guarded only by `Interlocked.Exchange(ref _sessionHandle, IntPtr.Zero)`. That stops *new* calls but not one already past the null-check — so a `poll_event` in flight while `nova_ssh_close` frees → dangling `&mut` → **use-after-free** (the #118 race, on the SSH side).
+- `NativePortForwardSession` shares the same handle.
+- All exports are wrapped in `ffi_guard(NOVA_SSH_RESULT_PANIC, …)` (panic → `-7`, no unwind across FFI). Good; preserved.
+- `ffi_contract.rs` (41 LOC) tests only struct layout + null-handle rejection.
+
+## Goals / Non-goals
+
+**Goals**
+- Eliminate the poll-vs-close UAF on the SSH session handle (item 2).
+- Make the Rust FFI **fail closed** on stale/closed/double-closed handles (return `INVALID_ARGUMENT`) instead of invoking UB, so abuse is safely testable (items 2 + 4).
+- Add the FFI abuse-test suite to `ffi_contract.rs` and confirm it runs in CI (item 4).
+- Audit + guard error-string ownership across the FFI with a debug allocation counter (item 3).
+
+**Non-goals**
+- Secret zeroization / credential `char[]` rework — **sub-project B** (#121 item 1).
+- Changing SSH auth, host-key verification (reviewed, correct), or the worker/event protocol.
+- The one-shot SFTP paths' handle model — `RunSftpTransfer`/`ListRemoteDirectory` take JSON and return a response with no persistent handle; they get only the error-string audit (item 3) and JSON abuse tests (item 4), not the SafeHandle migration.
+
+## Approach decisions (locked)
+
+- **Handle model:** C# `NovaSshSafeHandle` (managed ref-counting) **AND** a Rust generation-registry (fail-closed). Both, not either.
+- **Registry mechanism:** a process-global `Mutex<HashMap<u64, Arc<NovaSshSession>>>` keyed by a **monotonic `u64` id**. Monotonic ids are never reused, so a freed id is simply absent — functionally the generation/slab scheme with less machinery and the same fail-closed property.
+- **Abuse tests live in Rust** (`ffi_contract.rs`), enabled by the fail-closed registry, plus one C# disposed-handle safety test.
+
+## B. Rust handle registry (item 2 core)
+
+`rusty_ssh/src/lib.rs`:
+
+- Global: `static REGISTRY: OnceLock<Mutex<HashMap<u64, Arc<NovaSshSession>>>>` + `static NEXT_ID: AtomicU64` (starts at 1). Id `0` is never issued (so the C# `SafeHandleZeroOrMinusOneIsInvalid` sees `0` ⇒ invalid).
+- Session-export signatures change from `session: *mut NovaSshSession` to a pointer-sized handle token (`handle: usize`, carrying the `u64` id on the 64-bit targets we ship).
+- `nova_ssh_connect`: build the session, `let id = NEXT_ID.fetch_add(1, SeqCst)`, `registry.lock().insert(id, Arc::new(session))`, return `id as usize`. On failure return `0`.
+- Each session export: `lookup(handle)` → `registry.lock().get(&id).cloned()` (clone the `Arc`, release the lock immediately) → `None` ⇒ `INVALID_ARGUMENT`; `Some(arc)` ⇒ operate via `&arc`. The `Arc` clone keeps the session alive for the call's duration even if `close` races (no UAF); the absent-id check makes stale/double-close calls fail closed.
+- `nova_ssh_close`: `registry.lock().remove(&id)` → `None` ⇒ `INVALID_ARGUMENT` (covers double-close); `Some(arc)` ⇒ on it: `command_tx` send `Close`, `shared.mark_closed()`, `worker` join. The `Box` is freed when the last `Arc` (registry's + any in-flight) drops.
+- **Interior mutability:** because non-close exports now hold `&NovaSshSession` (via `Arc`) rather than `&mut`, the fields `close` mutates — `command_tx: Option<Sender>` and `worker: Option<JoinHandle>` — move behind `Mutex<Option<…>>`. `shared` is already shared/thread-safe; `command_tx` sends need only `&self`.
+
+This keeps FFI calls short (enqueue a command / peek the event queue) and non-serialized across sessions; per-session work that was `&mut` is now `&self` through thread-safe fields.
+
+## C. C# `NovaSshSafeHandle` + migration (item 2)
+
+- New `internal sealed class NovaSshSafeHandle : SafeHandleZeroOrMinusOneIsInvalid` in the `Native` namespace; `ReleaseHandle()` → `NativeMethods.nova_ssh_close(handle)`; returns `true`.
+- `NativeMethods`: keep a raw `nova_ssh_close(IntPtr)` (used by `ReleaseHandle`); change the persistent-session P/Invokes (`nova_ssh_poll_event`/`write`/`resize`/`open_direct_tcpip`/`channel_write`/`channel_eof`/`channel_close`/`submit_response`) to take `NovaSshSafeHandle`; `nova_ssh_connect` returns `NovaSshSafeHandle`.
+- `INativeSshInterop`: `Connect` returns `NovaSshSafeHandle`; the session methods take `NovaSshSafeHandle` instead of `IntPtr`. The one-shot `ListRemoteDirectory`/`RunSftpTransfer` signatures are unchanged.
+- `NativeSshInterop`: `Connect` returns the SafeHandle (throw if `IsInvalid`); session methods short-circuit on `handle.IsClosed || handle.IsInvalid` then call through. The marshaller's automatic `DangerousAddRef`/`Release` around each P/Invoke prevents `nova_ssh_close` (`ReleaseHandle`) from running during an in-flight `PollEvent`/`Write` — closing the poll-vs-close race.
+- `NativeSshSession`: `_sessionHandle: IntPtr` → `NovaSshSafeHandle`; the `Interlocked.Exchange`/`Close(handle)` teardown becomes `_sessionHandle.Dispose()` (SafeHandle is itself thread-safe + idempotent). `NativePortForwardSession` receives and holds the same `NovaSshSafeHandle` instance (shared ownership; the runtime ref-counts).
+
+## D. FFI abuse tests (item 4)
+
+The abuse tests target the **handle lifecycle**, not real SSH I/O — so they must not need a live server (none exists in CI; the Docker E2E suite is `[SKIP]` off-CI). They split by what they need:
+
+**Handle-lifecycle tests — `#[cfg(test)] mod` unit tests inside `lib.rs`** (so they can build a *stub* `NovaSshSession` — `command_tx: None`, `worker: None`, fresh `shared` — and insert it into the registry to obtain a real id without connecting):
+- **call-after-close**: register a stub → `close` → `poll_event`/`write`/`resize`/`submit_response` on the same id ⇒ all `INVALID_ARGUMENT`.
+- **double-close**: second `nova_ssh_close` on the id ⇒ `INVALID_ARGUMENT`.
+- **concurrent poll+close**: register a stub, spawn threads hammering `poll_event` on the id while another thread `close`s ⇒ no UB; each call returns OK / `EVENT_READY` / `INVALID_ARGUMENT`, never crashes. (Run under repetition to shake out the race.)
+
+**JSON-input tests — `rusty_ssh/tests/ffi_contract.rs` integration tests** (no session needed; these parse before connecting):
+- **malformed + oversized JSON** into `nova_ssh_sftp_transfer` / `nova_ssh_sftp_list_directory` ⇒ clean error result, no panic/UB.
+- Keep the existing struct-layout + null-handle tests; add the alloc-counter balance assertion (§E).
+
+This requires the registry insert/lookup/remove helpers and a stub-session constructor to be `pub(crate)` / test-visible. Confirm `cargo test` for `rusty_ssh` (unit + integration) runs in CI (the workflow builds the crate; add/verify the test step).
+
+One C# test: calling a session method on a disposed `NovaSshSafeHandle` is a safe no-op / throws `ObjectDisposedException` rather than crashing.
+
+## E. Error-string ownership audit + debug counter (item 3)
+
+- Rust: a `#[cfg(debug_assertions)]` `static OUTSTANDING_STRINGS: AtomicI64`. Increment wherever a `CString::into_raw` is handed to C# (the `sftp_transfer`/`list_directory` response paths); decrement in `nova_ssh_string_free`. A Rust test runs representative transfer/list calls (against malformed input so no network needed) and asserts the counter returns to 0.
+- C# audit: confirm every Rust-allocated payload is freed — `TakeNativeUtf8AndFree` + the `finally` blocks in `RunSftpTransfer`/`ListRemoteDirectory` already do this; add a one-line ownership-contract comment at `nova_ssh_string_free`'s C# call sites. No behavior change expected; if the audit finds a leak path, fix it.
+
+## F. Testing strategy
+
+- **Rust** (`cargo test --manifest-path src/NovaTerminal.App/native/rusty_ssh/Cargo.toml`): registry validation, the abuse suite, the alloc-counter balance test. Wired into CI.
+- **C#** (targeted, non-headless): `NovaSshSafeHandle` dispose idempotency + post-dispose safety; build of `NovaTerminal.Platform` green via `scripts/build.ps1`.
+- Existing native SSH E2E tests (`NativeSshDockerE2eTests`, currently `[SKIP]` off-CI) remain unaffected; the migration must keep them compiling.
+
+## G. Risks to validate during implementation
+
+- **`NovaSshSession` interior-mutability refactor**: `command_tx`/`worker` → `Mutex<Option<…>>`; verify no other `&mut self` path breaks, and that `close`'s `worker.join()` (now under a lock-then-take) doesn't deadlock against a worker that calls back into the session.
+- **`worker.join()` in `ReleaseHandle`** can block; runs in the Dispose/finalizer context. Confirm it terminates promptly once `Close` is signalled; bound/log if not.
+- **Token vs pointer**: handle is a `u64` id carried in an `IntPtr`; assumes 64-bit (the shipped app is x64 .NET 10). Assert the registry never issues `0`.
+- **Registry lock contention**: lookups clone-and-release immediately, so contention is minimal; confirm no export holds the registry lock across blocking work.
+- **`NativePortForwardSession` sharing**: ensure both it and `NativeSshSession` reference the *same* `NovaSshSafeHandle` (one owner Disposes; the other must not double-dispose — SafeHandle tolerates it, but ownership should be explicit).
+
+## H. Out of scope (tracked elsewhere)
+
+- #121 item 1 — credential `char[]`/`byte[]` zeroization rework + Rust `zeroize` → **sub-project B** (next spec/plan/PR).
+- Re-running the Docker-gated SSH E2E suite in CI — unchanged.

--- a/src/NovaTerminal.App/native/rusty_ssh/examples/smoke.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/examples/smoke.rs
@@ -55,7 +55,7 @@ fn main() {
     };
 
     let session = nova_ssh_connect(&connect_args);
-    if session.is_null() {
+    if session == 0 {
         eprintln!("Failed to create SSH session");
         std::process::exit(1);
     }

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -11,7 +11,8 @@ use std::io::Cursor;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 use std::ptr;
-use std::sync::{Arc, Condvar, Mutex, mpsc as std_mpsc};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex, OnceLock, mpsc as std_mpsc};
 use std::thread;
 use std::time::Duration;
 use tokio::fs::File as TokioFile;
@@ -116,8 +117,56 @@ const NOVA_SSH_EVENT_FLAG_BINARY: u32 = 2;
 
 pub struct NovaSshSession {
     shared: Arc<SharedState>,
-    command_tx: Option<mpsc::UnboundedSender<WorkerCommand>>,
-    worker: Option<thread::JoinHandle<()>>,
+    command_tx: Mutex<Option<mpsc::UnboundedSender<WorkerCommand>>>,
+    worker: Mutex<Option<thread::JoinHandle<()>>>,
+}
+
+static SESSION_REGISTRY: OnceLock<Mutex<HashMap<u64, Arc<NovaSshSession>>>> = OnceLock::new();
+static NEXT_SESSION_ID: AtomicU64 = AtomicU64::new(1);
+
+fn session_registry() -> &'static Mutex<HashMap<u64, Arc<NovaSshSession>>> {
+    SESSION_REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn lock_registry() -> std::sync::MutexGuard<'static, HashMap<u64, Arc<NovaSshSession>>> {
+    session_registry().lock().unwrap_or_else(|p| p.into_inner())
+}
+
+/// Insert a session, returning a fresh non-zero handle id (0 is never issued).
+fn registry_insert(session: NovaSshSession) -> u64 {
+    let id = NEXT_SESSION_ID.fetch_add(1, Ordering::SeqCst);
+    lock_registry().insert(id, Arc::new(session));
+    id
+}
+
+/// Look up a live session by handle token. None ⇒ unknown/closed/stale handle.
+fn registry_get(handle: usize) -> Option<Arc<NovaSshSession>> {
+    let id = handle as u64;
+    if id == 0 {
+        return None;
+    }
+    lock_registry().get(&id).cloned()
+}
+
+/// Remove (close) a session, returning it if present. Second call ⇒ None (double-close).
+fn registry_remove(handle: usize) -> Option<Arc<NovaSshSession>> {
+    let id = handle as u64;
+    if id == 0 {
+        return None;
+    }
+    lock_registry().remove(&id)
+}
+
+/// Sends a command to the session's worker, returning OK or CLOSED.
+fn send_command(session: &NovaSshSession, command: WorkerCommand) -> c_int {
+    let guard = session.command_tx.lock().unwrap_or_else(|p| p.into_inner());
+    match guard.as_ref() {
+        Some(tx) => tx
+            .send(command)
+            .map(|_| NOVA_SSH_RESULT_OK)
+            .unwrap_or(NOVA_SSH_RESULT_CLOSED),
+        None => NOVA_SSH_RESULT_CLOSED,
+    }
 }
 
 struct SharedState {
@@ -553,11 +602,11 @@ impl client::Handler for TransferClientHandler {
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn nova_ssh_connect(args: *const NovaSshConnectArgs) -> *mut NovaSshSession {
-    ffi_guard(std::ptr::null_mut(), || {
+pub extern "C" fn nova_ssh_connect(args: *const NovaSshConnectArgs) -> usize {
+    ffi_guard(0, || {
         let config = match ConnectConfig::from_args(args) {
             Some(config) => config,
-            None => return ptr::null_mut(),
+            None => return 0,
         };
 
         let shared = Arc::new(SharedState::new());
@@ -591,27 +640,30 @@ pub extern "C" fn nova_ssh_connect(args: *const NovaSshConnectArgs) -> *mut Nova
 
         let session = NovaSshSession {
             shared,
-            command_tx: Some(command_tx),
-            worker: Some(worker),
+            command_tx: Mutex::new(Some(command_tx)),
+            worker: Mutex::new(Some(worker)),
         };
 
-        Box::into_raw(Box::new(session))
+        registry_insert(session) as usize
     })
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn nova_ssh_poll_event(
-    session: *mut NovaSshSession,
+    handle: usize,
     event: *mut NovaSshEvent,
     payload: *mut u8,
     payload_capacity: usize,
 ) -> c_int {
     ffi_guard(NOVA_SSH_RESULT_PANIC, || {
-        if session.is_null() || event.is_null() {
+        if event.is_null() {
             return NOVA_SSH_RESULT_INVALID_ARGUMENT;
         }
 
-        let session = unsafe { &mut *session };
+        let session = match registry_get(handle) {
+            Some(s) => s,
+            None => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
+        };
         let queued = match session.shared.peek_event() {
             Some(event_value) => event_value,
             None => return NOVA_SSH_RESULT_OK,
@@ -641,19 +693,18 @@ pub extern "C" fn nova_ssh_poll_event(
 
 #[unsafe(no_mangle)]
 pub extern "C" fn nova_ssh_write(
-    session: *mut NovaSshSession,
+    handle: usize,
     data: *const u8,
     data_len: usize,
 ) -> c_int {
     ffi_guard(NOVA_SSH_RESULT_PANIC, || {
-        if session.is_null() || (data.is_null() && data_len != 0) {
+        if data.is_null() && data_len != 0 {
             return NOVA_SSH_RESULT_INVALID_ARGUMENT;
         }
 
-        let session = unsafe { &mut *session };
-        let tx = match &session.command_tx {
-            Some(sender) => sender,
-            None => return NOVA_SSH_RESULT_CLOSED,
+        let session = match registry_get(handle) {
+            Some(s) => s,
+            None => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
         };
 
         let bytes = if data_len == 0 {
@@ -662,38 +713,33 @@ pub extern "C" fn nova_ssh_write(
             unsafe { std::slice::from_raw_parts(data, data_len) }.to_vec()
         };
 
-        tx.send(WorkerCommand::Write(bytes))
-            .map(|_| NOVA_SSH_RESULT_OK)
-            .unwrap_or(NOVA_SSH_RESULT_CLOSED)
+        send_command(&session, WorkerCommand::Write(bytes))
     })
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn nova_ssh_resize(session: *mut NovaSshSession, cols: u16, rows: u16) -> c_int {
+pub extern "C" fn nova_ssh_resize(handle: usize, cols: u16, rows: u16) -> c_int {
     ffi_guard(NOVA_SSH_RESULT_PANIC, || {
-        if session.is_null() || cols == 0 || rows == 0 {
+        if cols == 0 || rows == 0 {
             return NOVA_SSH_RESULT_INVALID_ARGUMENT;
         }
 
-        let session = unsafe { &mut *session };
-        let tx = match &session.command_tx {
-            Some(sender) => sender,
-            None => return NOVA_SSH_RESULT_CLOSED,
+        let session = match registry_get(handle) {
+            Some(s) => s,
+            None => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
         };
 
-        tx.send(WorkerCommand::Resize { cols, rows })
-            .map(|_| NOVA_SSH_RESULT_OK)
-            .unwrap_or(NOVA_SSH_RESULT_CLOSED)
+        send_command(&session, WorkerCommand::Resize { cols, rows })
     })
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn nova_ssh_open_direct_tcpip(
-    session: *mut NovaSshSession,
+    handle: usize,
     args: *const NovaSshDirectTcpIpArgs,
 ) -> c_int {
     ffi_guard(NOVA_SSH_RESULT_PANIC, || {
-        if session.is_null() || args.is_null() {
+        if args.is_null() {
             return NOVA_SSH_RESULT_INVALID_ARGUMENT;
         }
 
@@ -705,10 +751,9 @@ pub extern "C" fn nova_ssh_open_direct_tcpip(
         let originator_address =
             read_c_string(args.originator_address).unwrap_or_else(|| "127.0.0.1".to_owned());
 
-        let session = unsafe { &mut *session };
-        let tx = match &session.command_tx {
-            Some(sender) => sender,
-            None => return NOVA_SSH_RESULT_CLOSED,
+        let session = match registry_get(handle) {
+            Some(s) => s,
+            None => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
         };
 
         let (reply_tx, reply_rx) = std_mpsc::channel();
@@ -724,8 +769,16 @@ pub extern "C" fn nova_ssh_open_direct_tcpip(
             reply: reply_tx,
         };
 
-        if tx.send(command).is_err() {
-            return NOVA_SSH_RESULT_CLOSED;
+        {
+            let guard = session.command_tx.lock().unwrap_or_else(|p| p.into_inner());
+            match guard.as_ref() {
+                Some(tx) => {
+                    if tx.send(command).is_err() {
+                        return NOVA_SSH_RESULT_CLOSED;
+                    }
+                }
+                None => return NOVA_SSH_RESULT_CLOSED,
+            }
         }
 
         match reply_rx.recv() {
@@ -738,20 +791,19 @@ pub extern "C" fn nova_ssh_open_direct_tcpip(
 
 #[unsafe(no_mangle)]
 pub extern "C" fn nova_ssh_channel_write(
-    session: *mut NovaSshSession,
+    handle: usize,
     channel_id: u32,
     data: *const u8,
     data_len: usize,
 ) -> c_int {
     ffi_guard(NOVA_SSH_RESULT_PANIC, || {
-        if session.is_null() || (data.is_null() && data_len != 0) {
+        if data.is_null() && data_len != 0 {
             return NOVA_SSH_RESULT_INVALID_ARGUMENT;
         }
 
-        let session = unsafe { &mut *session };
-        let tx = match &session.command_tx {
-            Some(sender) => sender,
-            None => return NOVA_SSH_RESULT_CLOSED,
+        let session = match registry_get(handle) {
+            Some(s) => s,
+            None => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
         };
 
         let bytes = if data_len == 0 {
@@ -760,62 +812,49 @@ pub extern "C" fn nova_ssh_channel_write(
             unsafe { std::slice::from_raw_parts(data, data_len) }.to_vec()
         };
 
-        tx.send(WorkerCommand::WriteForwardChannel {
-            channel_id,
-            data: bytes,
-        })
-        .map(|_| NOVA_SSH_RESULT_OK)
-        .unwrap_or(NOVA_SSH_RESULT_CLOSED)
+        send_command(
+            &session,
+            WorkerCommand::WriteForwardChannel {
+                channel_id,
+                data: bytes,
+            },
+        )
     })
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn nova_ssh_channel_eof(session: *mut NovaSshSession, channel_id: u32) -> c_int {
+pub extern "C" fn nova_ssh_channel_eof(handle: usize, channel_id: u32) -> c_int {
     ffi_guard(NOVA_SSH_RESULT_PANIC, || {
-        if session.is_null() {
-            return NOVA_SSH_RESULT_INVALID_ARGUMENT;
-        }
-
-        let session = unsafe { &mut *session };
-        let tx = match &session.command_tx {
-            Some(sender) => sender,
-            None => return NOVA_SSH_RESULT_CLOSED,
+        let session = match registry_get(handle) {
+            Some(s) => s,
+            None => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
         };
 
-        tx.send(WorkerCommand::ForwardChannelEof { channel_id })
-            .map(|_| NOVA_SSH_RESULT_OK)
-            .unwrap_or(NOVA_SSH_RESULT_CLOSED)
+        send_command(&session, WorkerCommand::ForwardChannelEof { channel_id })
     })
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn nova_ssh_channel_close(session: *mut NovaSshSession, channel_id: u32) -> c_int {
+pub extern "C" fn nova_ssh_channel_close(handle: usize, channel_id: u32) -> c_int {
     ffi_guard(NOVA_SSH_RESULT_PANIC, || {
-        if session.is_null() {
-            return NOVA_SSH_RESULT_INVALID_ARGUMENT;
-        }
-
-        let session = unsafe { &mut *session };
-        let tx = match &session.command_tx {
-            Some(sender) => sender,
-            None => return NOVA_SSH_RESULT_CLOSED,
+        let session = match registry_get(handle) {
+            Some(s) => s,
+            None => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
         };
 
-        tx.send(WorkerCommand::CloseForwardChannel { channel_id })
-            .map(|_| NOVA_SSH_RESULT_OK)
-            .unwrap_or(NOVA_SSH_RESULT_CLOSED)
+        send_command(&session, WorkerCommand::CloseForwardChannel { channel_id })
     })
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn nova_ssh_submit_response(
-    session: *mut NovaSshSession,
+    handle: usize,
     response_kind: u32,
     data: *const u8,
     data_len: usize,
 ) -> c_int {
     ffi_guard(NOVA_SSH_RESULT_PANIC, || {
-        if session.is_null() || (data.is_null() && data_len != 0) {
+        if data.is_null() && data_len != 0 {
             return NOVA_SSH_RESULT_INVALID_ARGUMENT;
         }
 
@@ -827,7 +866,10 @@ pub extern "C" fn nova_ssh_submit_response(
             _ => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
         };
 
-        let session = unsafe { &mut *session };
+        let session = match registry_get(handle) {
+            Some(s) => s,
+            None => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
+        };
         let payload = if data_len == 0 {
             Vec::new()
         } else {
@@ -844,21 +886,30 @@ pub extern "C" fn nova_ssh_submit_response(
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn nova_ssh_close(session: *mut NovaSshSession) -> c_int {
+pub extern "C" fn nova_ssh_close(handle: usize) -> c_int {
     ffi_guard(NOVA_SSH_RESULT_PANIC, || {
-        if session.is_null() {
-            return NOVA_SSH_RESULT_INVALID_ARGUMENT;
-        }
+        let session = match registry_remove(handle) {
+            Some(s) => s,
+            None => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
+        };
 
-        let mut session = unsafe { Box::from_raw(session) };
-
-        if let Some(tx) = session.command_tx.take() {
+        if let Some(tx) = session
+            .command_tx
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .take()
+        {
             let _ = tx.send(WorkerCommand::Close);
         }
 
         session.shared.mark_closed();
 
-        if let Some(worker) = session.worker.take() {
+        if let Some(worker) = session
+            .worker
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .take()
+        {
             let _ = worker.join();
         }
 
@@ -2803,7 +2854,7 @@ fn wait_keyboard_responses(shared: &Arc<SharedState>) -> anyhow::Result<Vec<Stri
 }
 
 #[cfg(test)]
-fn create_test_session_with_event(kind: NovaSshEventKind, payload: &[u8]) -> *mut NovaSshSession {
+fn create_test_session_with_event(kind: NovaSshEventKind, payload: &[u8]) -> usize {
     let shared = Arc::new(SharedState::new());
     shared.queue_event(QueuedEvent {
         kind,
@@ -2812,11 +2863,11 @@ fn create_test_session_with_event(kind: NovaSshEventKind, payload: &[u8]) -> *mu
         flags: NOVA_SSH_EVENT_FLAG_JSON,
     });
 
-    Box::into_raw(Box::new(NovaSshSession {
+    registry_insert(NovaSshSession {
         shared,
-        command_tx: None,
-        worker: None,
-    }))
+        command_tx: Mutex::new(None),
+        worker: Mutex::new(None),
+    }) as usize
 }
 
 #[cfg(test)]
@@ -2825,22 +2876,22 @@ mod tests {
 
     #[test]
     fn null_handle_operations_return_invalid_argument() {
-        let resize = nova_ssh_resize(ptr::null_mut(), 120, 30);
-        let write = nova_ssh_write(ptr::null_mut(), [1u8, 2, 3].as_ptr(), 3);
+        let resize = nova_ssh_resize(0, 120, 30);
+        let write = nova_ssh_write(0, [1u8, 2, 3].as_ptr(), 3);
         let forward_args = NovaSshDirectTcpIpArgs {
             host_to_connect: ptr::null(),
             port_to_connect: 80,
             originator_address: ptr::null(),
             originator_port: 1000,
         };
-        let open = nova_ssh_open_direct_tcpip(ptr::null_mut(), &forward_args);
-        let channel_write = nova_ssh_channel_write(ptr::null_mut(), 1, [1u8, 2, 3].as_ptr(), 3);
-        let channel_eof = nova_ssh_channel_eof(ptr::null_mut(), 1);
-        let channel_close = nova_ssh_channel_close(ptr::null_mut(), 1);
-        let respond = nova_ssh_submit_response(ptr::null_mut(), 1, br#"{}"#.as_ptr(), 2);
+        let open = nova_ssh_open_direct_tcpip(0, &forward_args);
+        let channel_write = nova_ssh_channel_write(0, 1, [1u8, 2, 3].as_ptr(), 3);
+        let channel_eof = nova_ssh_channel_eof(0, 1);
+        let channel_close = nova_ssh_channel_close(0, 1);
+        let respond = nova_ssh_submit_response(0, 1, br#"{}"#.as_ptr(), 2);
         let mut sftp_response = ptr::null_mut();
         let sftp = nova_ssh_sftp_transfer(ptr::null(), None, ptr::null_mut(), &mut sftp_response);
-        let close = nova_ssh_close(ptr::null_mut());
+        let close = nova_ssh_close(0);
 
         assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, resize);
         assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, write);
@@ -2936,7 +2987,7 @@ mod tests {
     fn poll_reports_required_payload_length_before_copying() {
         let payload = br#"{"host":"example.internal","fingerprint":"SHA256:test"}"#;
         let session = create_test_session_with_event(NovaSshEventKind::HostKeyPrompt, payload);
-        assert!(!session.is_null());
+        assert_ne!(0, session);
 
         let mut event = NovaSshEvent::default();
         let mut tiny = [0u8; 8];
@@ -2954,7 +3005,7 @@ mod tests {
     fn poll_copies_payload_when_buffer_is_large_enough() {
         let payload = b"hello from ssh";
         let session = create_test_session_with_event(NovaSshEventKind::Data, payload);
-        assert!(!session.is_null());
+        assert_ne!(0, session);
 
         let mut event = NovaSshEvent::default();
         let mut buffer = [0u8; 64];
@@ -2973,11 +3024,11 @@ mod tests {
     fn submit_response_queues_prompt_data_even_before_worker_loop_runs() {
         let shared = Arc::new(SharedState::new());
         let (command_tx, _command_rx) = mpsc::unbounded_channel();
-        let session = Box::into_raw(Box::new(NovaSshSession {
+        let session = registry_insert(NovaSshSession {
             shared: shared.clone(),
-            command_tx: Some(command_tx),
-            worker: None,
-        }));
+            command_tx: Mutex::new(Some(command_tx)),
+            worker: Mutex::new(None),
+        }) as usize;
 
         let payload = br#"{"accept":true}"#;
         let rc = nova_ssh_submit_response(
@@ -3440,7 +3491,7 @@ mod ffi_guard_tests {
 
     #[test]
     fn poll_event_rejects_null_without_panic() {
-        let rc = nova_ssh_poll_event(std::ptr::null_mut(), std::ptr::null_mut(), std::ptr::null_mut(), 0);
+        let rc = nova_ssh_poll_event(0, std::ptr::null_mut(), std::ptr::null_mut(), 0);
         assert_eq!(rc, NOVA_SSH_RESULT_INVALID_ARGUMENT);
     }
 }

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -11,7 +11,7 @@ use std::io::Cursor;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 use std::ptr;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, OnceLock, mpsc as std_mpsc};
 use std::thread;
 use std::time::Duration;
@@ -123,6 +123,22 @@ pub struct NovaSshSession {
 
 static SESSION_REGISTRY: OnceLock<Mutex<HashMap<u64, Arc<NovaSshSession>>>> = OnceLock::new();
 static NEXT_SESSION_ID: AtomicU64 = AtomicU64::new(1);
+
+#[cfg(debug_assertions)]
+static OUTSTANDING_FFI_STRINGS: AtomicI64 = AtomicI64::new(0);
+
+// Convert an owned String into a C string handed to the caller. In debug builds,
+// tracks the outstanding count so tests can assert alloc/free balance.
+fn ffi_string_into_raw(value: String) -> *mut c_char {
+    match CString::new(value) {
+        Ok(c) => {
+            #[cfg(debug_assertions)]
+            OUTSTANDING_FFI_STRINGS.fetch_add(1, Ordering::SeqCst);
+            c.into_raw()
+        }
+        Err(_) => std::ptr::null_mut(),
+    }
+}
 
 fn session_registry() -> &'static Mutex<HashMap<u64, Arc<NovaSshSession>>> {
     SESSION_REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
@@ -1058,12 +1074,10 @@ pub extern "C" fn nova_ssh_sftp_list_directory(
 #[unsafe(no_mangle)]
 pub extern "C" fn nova_ssh_string_free(value: *mut c_char) {
     ffi_guard((), || {
-        if value.is_null() {
-            return;
-        }
-
-        unsafe {
-            drop(CString::from_raw(value));
+        if !value.is_null() {
+            #[cfg(debug_assertions)]
+            OUTSTANDING_FFI_STRINGS.fetch_sub(1, Ordering::SeqCst);
+            drop(unsafe { CString::from_raw(value) });
         }
     })
 }
@@ -1286,13 +1300,14 @@ fn write_sftp_response_json(
         Err(_) => return result,
     };
 
-    match CString::new(json) {
-        Ok(value) => unsafe {
-            *response_json = value.into_raw();
-            result
-        },
-        Err(_) => result,
+    let raw = ffi_string_into_raw(json);
+    if raw.is_null() {
+        return result;
     }
+    unsafe {
+        *response_json = raw;
+    }
+    result
 }
 
 fn write_remote_path_list_response_json(
@@ -1312,13 +1327,14 @@ fn write_remote_path_list_response_json(
         Err(_) => return result,
     };
 
-    match CString::new(json) {
-        Ok(value) => unsafe {
-            *response_json = value.into_raw();
-            result
-        },
-        Err(_) => result,
+    let raw = ffi_string_into_raw(json);
+    if raw.is_null() {
+        return result;
     }
+    unsafe {
+        *response_json = raw;
+    }
+    result
 }
 
 fn sftp_request_has_blank_fields(request: &SftpTransferRequest) -> bool {
@@ -3493,5 +3509,95 @@ mod ffi_guard_tests {
     fn poll_event_rejects_null_without_panic() {
         let rc = nova_ssh_poll_event(0, std::ptr::null_mut(), std::ptr::null_mut(), 0);
         assert_eq!(rc, NOVA_SSH_RESULT_INVALID_ARGUMENT);
+    }
+}
+
+#[cfg(test)]
+fn stub_session() -> NovaSshSession {
+    NovaSshSession {
+        shared: Arc::new(SharedState::new()),
+        command_tx: Mutex::new(None),
+        worker: Mutex::new(None),
+    }
+}
+
+#[cfg(test)]
+mod handle_abuse_tests {
+    use super::*;
+
+    #[test]
+    fn calls_after_close_fail_closed() {
+        let handle = registry_insert(stub_session()) as usize;
+        assert_eq!(NOVA_SSH_RESULT_OK, nova_ssh_close(handle));
+
+        let mut event = NovaSshEvent::default();
+        assert_eq!(
+            NOVA_SSH_RESULT_INVALID_ARGUMENT,
+            nova_ssh_poll_event(handle, &mut event, std::ptr::null_mut(), 0)
+        );
+        assert_eq!(
+            NOVA_SSH_RESULT_INVALID_ARGUMENT,
+            nova_ssh_write(handle, [1u8].as_ptr(), 1)
+        );
+        assert_eq!(
+            NOVA_SSH_RESULT_INVALID_ARGUMENT,
+            nova_ssh_resize(handle, 80, 24)
+        );
+        assert_eq!(
+            NOVA_SSH_RESULT_INVALID_ARGUMENT,
+            nova_ssh_channel_eof(handle, 0)
+        );
+        assert_eq!(
+            NOVA_SSH_RESULT_INVALID_ARGUMENT,
+            nova_ssh_submit_response(handle, 2, br#"{}"#.as_ptr(), 2)
+        );
+    }
+
+    #[test]
+    fn double_close_is_rejected() {
+        let handle = registry_insert(stub_session()) as usize;
+        assert_eq!(NOVA_SSH_RESULT_OK, nova_ssh_close(handle));
+        assert_eq!(NOVA_SSH_RESULT_INVALID_ARGUMENT, nova_ssh_close(handle));
+    }
+
+    #[test]
+    fn concurrent_poll_and_close_never_crashes() {
+        for _ in 0..200 {
+            let handle = registry_insert(stub_session()) as usize;
+            let poller = std::thread::spawn(move || {
+                let mut event = NovaSshEvent::default();
+                for _ in 0..50 {
+                    let rc = nova_ssh_poll_event(handle, &mut event, std::ptr::null_mut(), 0);
+                    assert!(matches!(
+                        rc,
+                        NOVA_SSH_RESULT_OK
+                            | NOVA_SSH_RESULT_EVENT_READY
+                            | NOVA_SSH_RESULT_INVALID_ARGUMENT
+                    ));
+                }
+            });
+            let closer = std::thread::spawn(move || nova_ssh_close(handle));
+            poller.join().unwrap();
+            let _ = closer.join().unwrap();
+        }
+    }
+}
+
+#[cfg(all(test, debug_assertions))]
+mod alloc_balance_tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn malformed_list_request_frees_its_response_string() {
+        let before = OUTSTANDING_FFI_STRINGS.load(Ordering::SeqCst);
+        let bad = CString::new("{ not json").unwrap();
+        let mut response: *mut c_char = std::ptr::null_mut();
+        let _ = nova_ssh_sftp_list_directory(bad.as_ptr(), &mut response);
+        if !response.is_null() {
+            nova_ssh_string_free(response);
+        }
+        let after = OUTSTANDING_FFI_STRINGS.load(Ordering::SeqCst);
+        assert_eq!(before, after, "every FFI-allocated string must be freed");
     }
 }

--- a/src/NovaTerminal.App/native/rusty_ssh/tests/ffi_contract.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/tests/ffi_contract.rs
@@ -1,8 +1,10 @@
+use std::ffi::CString;
 use std::mem::{align_of, size_of};
 
 use rusty_ssh::{
-    nova_ssh_close, nova_ssh_poll_event, nova_ssh_resize, nova_ssh_submit_response,
-    nova_ssh_write, NovaSshConnectArgs, NovaSshEvent, NOVA_SSH_RESULT_INVALID_ARGUMENT,
+    nova_ssh_close, nova_ssh_poll_event, nova_ssh_resize, nova_ssh_sftp_list_directory,
+    nova_ssh_string_free, nova_ssh_submit_response, nova_ssh_write, NovaSshConnectArgs,
+    NovaSshEvent, NOVA_SSH_RESULT_INVALID_ARGUMENT,
 };
 
 #[test]
@@ -38,4 +40,28 @@ fn invalid_handles_are_rejected_cleanly() {
         NOVA_SSH_RESULT_INVALID_ARGUMENT,
         nova_ssh_close(0)
     );
+}
+
+#[test]
+fn malformed_json_is_rejected_without_panic() {
+    let bad = CString::new("{ this is not valid json ").unwrap();
+    let mut response: *mut std::os::raw::c_char = std::ptr::null_mut();
+    let rc = nova_ssh_sftp_list_directory(bad.as_ptr(), &mut response);
+    assert_ne!(rc, 0, "malformed JSON must not report success");
+    if !response.is_null() {
+        nova_ssh_string_free(response);
+    }
+}
+
+#[test]
+fn oversized_json_is_rejected_without_panic() {
+    // Syntactically-valid but semantically-bogus, very large payload.
+    let big = format!(r#"{{"junk":"{}"}}"#, "A".repeat(2_000_000));
+    let payload = CString::new(big).unwrap();
+    let mut response: *mut std::os::raw::c_char = std::ptr::null_mut();
+    let rc = nova_ssh_sftp_list_directory(payload.as_ptr(), &mut response);
+    assert_ne!(rc, 0, "bogus oversized JSON must not report success");
+    if !response.is_null() {
+        nova_ssh_string_free(response);
+    }
 }

--- a/src/NovaTerminal.App/native/rusty_ssh/tests/ffi_contract.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/tests/ffi_contract.rs
@@ -20,22 +20,22 @@ fn invalid_handles_are_rejected_cleanly() {
 
     assert_eq!(
         NOVA_SSH_RESULT_INVALID_ARGUMENT,
-        nova_ssh_poll_event(std::ptr::null_mut(), &mut event, std::ptr::null_mut(), 0)
+        nova_ssh_poll_event(0, &mut event, std::ptr::null_mut(), 0)
     );
     assert_eq!(
         NOVA_SSH_RESULT_INVALID_ARGUMENT,
-        nova_ssh_resize(std::ptr::null_mut(), 120, 30)
+        nova_ssh_resize(0, 120, 30)
     );
     assert_eq!(
         NOVA_SSH_RESULT_INVALID_ARGUMENT,
-        nova_ssh_write(std::ptr::null_mut(), [1u8].as_ptr(), 1)
+        nova_ssh_write(0, [1u8].as_ptr(), 1)
     );
     assert_eq!(
         NOVA_SSH_RESULT_INVALID_ARGUMENT,
-        nova_ssh_submit_response(std::ptr::null_mut(), 1, br#"{}"#.as_ptr(), 2)
+        nova_ssh_submit_response(0, 1, br#"{}"#.as_ptr(), 2)
     );
     assert_eq!(
         NOVA_SSH_RESULT_INVALID_ARGUMENT,
-        nova_ssh_close(std::ptr::null_mut())
+        nova_ssh_close(0)
     );
 }

--- a/src/NovaTerminal.Platform/Ssh/Native/INativeSshInterop.cs
+++ b/src/NovaTerminal.Platform/Ssh/Native/INativeSshInterop.cs
@@ -2,7 +2,7 @@ namespace NovaTerminal.Platform.Ssh.Native;
 
 public interface INativeSshInterop
 {
-    IntPtr Connect(NativeSshConnectionOptions options);
+    NovaSshSafeHandle Connect(NativeSshConnectionOptions options);
 
     // Blocking FFI/network call. App/UI-facing services must offload this work before awaiting it.
     IReadOnlyList<NativeRemotePathEntry> ListRemoteDirectory(
@@ -14,13 +14,13 @@ public interface INativeSshInterop
         NativeSftpTransferOptions transferOptions,
         Action<NativeSftpTransferProgress>? progress,
         CancellationToken cancellationToken);
-    NativeSshEvent? PollEvent(IntPtr sessionHandle);
-    void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data);
-    void Resize(IntPtr sessionHandle, int cols, int rows);
-    int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options);
-    void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data);
-    void SendChannelEof(IntPtr sessionHandle, int channelId);
-    void CloseChannel(IntPtr sessionHandle, int channelId);
-    void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data);
-    void Close(IntPtr sessionHandle);
+    NativeSshEvent? PollEvent(NovaSshSafeHandle sessionHandle);
+    void Write(NovaSshSafeHandle sessionHandle, ReadOnlySpan<byte> data);
+    void Resize(NovaSshSafeHandle sessionHandle, int cols, int rows);
+    int OpenDirectTcpIp(NovaSshSafeHandle sessionHandle, NativePortForwardOpenOptions options);
+    void WriteChannel(NovaSshSafeHandle sessionHandle, int channelId, ReadOnlySpan<byte> data);
+    void SendChannelEof(NovaSshSafeHandle sessionHandle, int channelId);
+    void CloseChannel(NovaSshSafeHandle sessionHandle, int channelId);
+    void SubmitResponse(NovaSshSafeHandle sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data);
+    void Close(NovaSshSafeHandle sessionHandle);
 }

--- a/src/NovaTerminal.Platform/Ssh/Native/NativePortForwardSession.cs
+++ b/src/NovaTerminal.Platform/Ssh/Native/NativePortForwardSession.cs
@@ -20,7 +20,7 @@ public sealed class NativePortForwardSession : IDisposable
     private const byte SocksReplyCommandNotSupported = 0x07;
     private const byte SocksReplyAddressTypeNotSupported = 0x08;
 
-    private readonly IntPtr _sessionHandle;
+    private readonly NovaSshSafeHandle _sessionHandle;
     private readonly INativeSshInterop _interop;
     private readonly Action<string> _log;
     private readonly Func<NetworkStream, byte[], CancellationToken, Task> _socksReplyWriter;
@@ -30,7 +30,7 @@ public sealed class NativePortForwardSession : IDisposable
     private int _disposed;
 
     public NativePortForwardSession(
-        IntPtr sessionHandle,
+        NovaSshSafeHandle sessionHandle,
         IReadOnlyList<PortForward> forwards,
         INativeSshInterop interop,
         Action<string>? log = null)
@@ -39,13 +39,13 @@ public sealed class NativePortForwardSession : IDisposable
     }
 
     private NativePortForwardSession(
-        IntPtr sessionHandle,
+        NovaSshSafeHandle sessionHandle,
         IReadOnlyList<PortForward> forwards,
         INativeSshInterop interop,
         Action<string>? log,
         Func<NetworkStream, byte[], CancellationToken, Task> socksReplyWriter)
     {
-        if (sessionHandle == IntPtr.Zero)
+        if (sessionHandle is null || sessionHandle.IsInvalid || sessionHandle.IsClosed)
         {
             throw new ArgumentException("Native port forwarding requires a valid SSH session handle.", nameof(sessionHandle));
         }

--- a/src/NovaTerminal.Platform/Ssh/Native/NativeSshInterop.cs
+++ b/src/NovaTerminal.Platform/Ssh/Native/NativeSshInterop.cs
@@ -20,7 +20,7 @@ public sealed partial class NativeSshInterop : INativeSshInterop
     private static readonly IntPtr SftpTransferProgressCallbackPointer =
         Marshal.GetFunctionPointerForDelegate(SftpTransferProgressCallback);
 
-    public IntPtr Connect(NativeSshConnectionOptions options)
+    public NovaSshSafeHandle Connect(NativeSshConnectionOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
 
@@ -94,9 +94,10 @@ public sealed partial class NativeSshInterop : INativeSshInterop
                     FishCwdBootstrap = fishCwdBootstrapPtr
                 };
 
-                IntPtr handle = NativeMethods.nova_ssh_connect(in args);
-                if (handle == IntPtr.Zero)
+                NovaSshSafeHandle handle = NativeMethods.nova_ssh_connect(in args);
+                if (handle.IsInvalid)
                 {
+                    handle.Dispose();
                     throw new InvalidOperationException("Failed to create native SSH session.");
                 }
 
@@ -291,9 +292,9 @@ public sealed partial class NativeSshInterop : INativeSshInterop
         }
     }
 
-    public NativeSshEvent? PollEvent(IntPtr sessionHandle)
+    public NativeSshEvent? PollEvent(NovaSshSafeHandle sessionHandle)
     {
-        if (sessionHandle == IntPtr.Zero)
+        if (sessionHandle is null || sessionHandle.IsInvalid || sessionHandle.IsClosed)
         {
             return null;
         }
@@ -301,71 +302,90 @@ public sealed partial class NativeSshInterop : INativeSshInterop
         byte[] buffer = Array.Empty<byte>();
         NativeEventHeader header = default;
 
-        while (true)
+        try
         {
-            int rc = NativeMethods.nova_ssh_poll_event(sessionHandle, out header, buffer, (nuint)buffer.Length);
-            if (rc == ResultOk)
+            while (true)
             {
-                return null;
-            }
+                int rc = NativeMethods.nova_ssh_poll_event(sessionHandle, out header, buffer, (nuint)buffer.Length);
+                if (rc == ResultOk)
+                {
+                    return null;
+                }
 
-            if (rc == ResultBufferTooSmall)
-            {
-                buffer = new byte[header.PayloadLength];
-                continue;
-            }
+                if (rc == ResultBufferTooSmall)
+                {
+                    buffer = new byte[header.PayloadLength];
+                    continue;
+                }
 
-            if (rc == ResultEventReady)
-            {
-                int payloadLength = checked((int)header.PayloadLength);
-                byte[] payload = payloadLength == 0
-                    ? Array.Empty<byte>()
-                    : buffer[..payloadLength];
-                return new NativeSshEvent((NativeSshEventKind)header.Kind, payload, header.StatusCode, (NativeSshEventFlags)header.Flags);
-            }
+                if (rc == ResultEventReady)
+                {
+                    int payloadLength = checked((int)header.PayloadLength);
+                    byte[] payload = payloadLength == 0
+                        ? Array.Empty<byte>()
+                        : buffer[..payloadLength];
+                    return new NativeSshEvent((NativeSshEventKind)header.Kind, payload, header.StatusCode, (NativeSshEventFlags)header.Flags);
+                }
 
-            throw new InvalidOperationException($"Native SSH poll failed with result {rc}.");
+                throw new InvalidOperationException($"Native SSH poll failed with result {rc}.");
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            return null;
         }
     }
 
-    public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data)
+    public void Write(NovaSshSafeHandle sessionHandle, ReadOnlySpan<byte> data)
     {
-        if (sessionHandle == IntPtr.Zero)
+        if (sessionHandle is null || sessionHandle.IsInvalid || sessionHandle.IsClosed)
         {
             return;
         }
 
         byte[] payload = data.ToArray();
-        int rc = NativeMethods.nova_ssh_write(sessionHandle, payload, (nuint)payload.Length);
-        if (rc is ResultOk or ResultInvalidArgument)
+        try
         {
-            return;
-        }
+            int rc = NativeMethods.nova_ssh_write(sessionHandle, payload, (nuint)payload.Length);
+            if (rc is ResultOk or ResultInvalidArgument)
+            {
+                return;
+            }
 
-        throw new InvalidOperationException($"Native SSH write failed with result {rc}.");
+            throw new InvalidOperationException($"Native SSH write failed with result {rc}.");
+        }
+        catch (ObjectDisposedException)
+        {
+        }
     }
 
-    public void Resize(IntPtr sessionHandle, int cols, int rows)
+    public void Resize(NovaSshSafeHandle sessionHandle, int cols, int rows)
     {
-        if (sessionHandle == IntPtr.Zero || cols <= 0 || rows <= 0)
+        if (sessionHandle is null || sessionHandle.IsInvalid || sessionHandle.IsClosed || cols <= 0 || rows <= 0)
         {
             return;
         }
 
-        int rc = NativeMethods.nova_ssh_resize(sessionHandle, checked((ushort)cols), checked((ushort)rows));
-        if (rc is ResultOk or ResultInvalidArgument)
+        try
         {
-            return;
-        }
+            int rc = NativeMethods.nova_ssh_resize(sessionHandle, checked((ushort)cols), checked((ushort)rows));
+            if (rc is ResultOk or ResultInvalidArgument)
+            {
+                return;
+            }
 
-        throw new InvalidOperationException($"Native SSH resize failed with result {rc}.");
+            throw new InvalidOperationException($"Native SSH resize failed with result {rc}.");
+        }
+        catch (ObjectDisposedException)
+        {
+        }
     }
 
-    public int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options)
+    public int OpenDirectTcpIp(NovaSshSafeHandle sessionHandle, NativePortForwardOpenOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
 
-        if (sessionHandle == IntPtr.Zero)
+        if (sessionHandle is null || sessionHandle.IsInvalid || sessionHandle.IsClosed)
         {
             throw new InvalidOperationException("Cannot open a native port-forward channel without a session handle.");
         }
@@ -394,6 +414,10 @@ public sealed partial class NativeSshInterop : INativeSshInterop
 
             throw new InvalidOperationException($"Native SSH direct-tcpip open failed with result {channelId}.");
         }
+        catch (ObjectDisposedException)
+        {
+            return -1;
+        }
         finally
         {
             FreeUtf8(hostPtr);
@@ -401,86 +425,101 @@ public sealed partial class NativeSshInterop : INativeSshInterop
         }
     }
 
-    public void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data)
+    public void WriteChannel(NovaSshSafeHandle sessionHandle, int channelId, ReadOnlySpan<byte> data)
     {
-        if (sessionHandle == IntPtr.Zero || channelId < 0)
+        if (sessionHandle is null || sessionHandle.IsInvalid || sessionHandle.IsClosed || channelId < 0)
         {
             return;
         }
 
         byte[] payload = data.ToArray();
-        int rc = NativeMethods.nova_ssh_channel_write(sessionHandle, checked((uint)channelId), payload, (nuint)payload.Length);
-        if (rc is ResultOk or ResultInvalidArgument or ResultClosed)
+        try
         {
-            return;
-        }
+            int rc = NativeMethods.nova_ssh_channel_write(sessionHandle, checked((uint)channelId), payload, (nuint)payload.Length);
+            if (rc is ResultOk or ResultInvalidArgument or ResultClosed)
+            {
+                return;
+            }
 
-        throw new InvalidOperationException($"Native SSH channel write failed with result {rc}.");
+            throw new InvalidOperationException($"Native SSH channel write failed with result {rc}.");
+        }
+        catch (ObjectDisposedException)
+        {
+        }
     }
 
-    public void SendChannelEof(IntPtr sessionHandle, int channelId)
+    public void SendChannelEof(NovaSshSafeHandle sessionHandle, int channelId)
     {
-        if (sessionHandle == IntPtr.Zero || channelId < 0)
+        if (sessionHandle is null || sessionHandle.IsInvalid || sessionHandle.IsClosed || channelId < 0)
         {
             return;
         }
 
-        int rc = NativeMethods.nova_ssh_channel_eof(sessionHandle, checked((uint)channelId));
-        if (rc is ResultOk or ResultInvalidArgument or ResultClosed)
+        try
         {
-            return;
-        }
+            int rc = NativeMethods.nova_ssh_channel_eof(sessionHandle, checked((uint)channelId));
+            if (rc is ResultOk or ResultInvalidArgument or ResultClosed)
+            {
+                return;
+            }
 
-        throw new InvalidOperationException($"Native SSH channel EOF failed with result {rc}.");
+            throw new InvalidOperationException($"Native SSH channel EOF failed with result {rc}.");
+        }
+        catch (ObjectDisposedException)
+        {
+        }
     }
 
-    public void CloseChannel(IntPtr sessionHandle, int channelId)
+    public void CloseChannel(NovaSshSafeHandle sessionHandle, int channelId)
     {
-        if (sessionHandle == IntPtr.Zero || channelId < 0)
+        if (sessionHandle is null || sessionHandle.IsInvalid || sessionHandle.IsClosed || channelId < 0)
         {
             return;
         }
 
-        int rc = NativeMethods.nova_ssh_channel_close(sessionHandle, checked((uint)channelId));
-        if (rc is ResultOk or ResultInvalidArgument or ResultClosed)
+        try
         {
-            return;
-        }
+            int rc = NativeMethods.nova_ssh_channel_close(sessionHandle, checked((uint)channelId));
+            if (rc is ResultOk or ResultInvalidArgument or ResultClosed)
+            {
+                return;
+            }
 
-        throw new InvalidOperationException($"Native SSH channel close failed with result {rc}.");
+            throw new InvalidOperationException($"Native SSH channel close failed with result {rc}.");
+        }
+        catch (ObjectDisposedException)
+        {
+        }
     }
 
-    public void Close(IntPtr sessionHandle)
+    public void Close(NovaSshSafeHandle sessionHandle)
     {
-        if (sessionHandle == IntPtr.Zero)
-        {
-            return;
-        }
-
-        int rc = NativeMethods.nova_ssh_close(sessionHandle);
-        if (rc is ResultOk or ResultInvalidArgument)
-        {
-            return;
-        }
-
-        throw new InvalidOperationException($"Native SSH close failed with result {rc}.");
+        // Disposing the SafeHandle runs ReleaseHandle -> nova_ssh_close exactly once,
+        // after any in-flight call's AddRef has been released.
+        sessionHandle?.Dispose();
     }
 
-    public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data)
+    public void SubmitResponse(NovaSshSafeHandle sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data)
     {
-        if (sessionHandle == IntPtr.Zero)
+        if (sessionHandle is null || sessionHandle.IsInvalid || sessionHandle.IsClosed)
         {
             return;
         }
 
         byte[] payload = data.ToArray();
-        int rc = NativeMethods.nova_ssh_submit_response(sessionHandle, (uint)responseKind, payload, (nuint)payload.Length);
-        if (rc is ResultOk or ResultInvalidArgument)
+        try
         {
-            return;
-        }
+            int rc = NativeMethods.nova_ssh_submit_response(sessionHandle, (uint)responseKind, payload, (nuint)payload.Length);
+            if (rc is ResultOk or ResultInvalidArgument)
+            {
+                return;
+            }
 
-        throw new InvalidOperationException($"Native SSH submit response failed with result {rc}.");
+            throw new InvalidOperationException($"Native SSH submit response failed with result {rc}.");
+        }
+        catch (ObjectDisposedException)
+        {
+        }
     }
 
     internal static void InvokeManagedProgressCallbackForTest(
@@ -753,7 +792,7 @@ public sealed partial class NativeSshInterop : INativeSshInterop
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    private struct NativeConnectArgs
+    internal struct NativeConnectArgs
     {
         public IntPtr Host;
         public IntPtr User;
@@ -775,7 +814,7 @@ public sealed partial class NativeSshInterop : INativeSshInterop
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    private struct NativeEventHeader
+    internal struct NativeEventHeader
     {
         public uint Kind;
         public uint PayloadLength;
@@ -784,7 +823,7 @@ public sealed partial class NativeSshInterop : INativeSshInterop
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    private struct NativeDirectTcpIpOpenArgs
+    internal struct NativeDirectTcpIpOpenArgs
     {
         public IntPtr HostToConnect;
         public ushort PortToConnect;
@@ -912,40 +951,41 @@ public sealed partial class NativeSshInterop : INativeSshInterop
         public Action<NativeSftpTransferProgress> Progress { get; }
     }
 
-    private static class NativeMethods
+    internal static class NativeMethods
     {
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_connect")]
-        public static extern IntPtr nova_ssh_connect(in NativeConnectArgs args);
+        public static extern NovaSshSafeHandle nova_ssh_connect(in NativeConnectArgs args);
 
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_poll_event")]
-        public static extern int nova_ssh_poll_event(IntPtr session, out NativeEventHeader @event, byte[] payload, nuint payloadCapacity);
+        public static extern int nova_ssh_poll_event(NovaSshSafeHandle session, out NativeEventHeader @event, byte[] payload, nuint payloadCapacity);
 
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_write")]
-        public static extern int nova_ssh_write(IntPtr session, byte[] data, nuint dataLength);
+        public static extern int nova_ssh_write(NovaSshSafeHandle session, byte[] data, nuint dataLength);
 
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_resize")]
-        public static extern int nova_ssh_resize(IntPtr session, ushort cols, ushort rows);
+        public static extern int nova_ssh_resize(NovaSshSafeHandle session, ushort cols, ushort rows);
 
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_sftp_list_directory")]
         public static extern int nova_ssh_sftp_list_directory(IntPtr requestJson, out IntPtr responseJson);
 
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_open_direct_tcpip")]
-        public static extern int nova_ssh_open_direct_tcpip(IntPtr session, in NativeDirectTcpIpOpenArgs args);
+        public static extern int nova_ssh_open_direct_tcpip(NovaSshSafeHandle session, in NativeDirectTcpIpOpenArgs args);
 
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_channel_write")]
-        public static extern int nova_ssh_channel_write(IntPtr session, uint channelId, byte[] data, nuint dataLength);
+        public static extern int nova_ssh_channel_write(NovaSshSafeHandle session, uint channelId, byte[] data, nuint dataLength);
 
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_channel_eof")]
-        public static extern int nova_ssh_channel_eof(IntPtr session, uint channelId);
+        public static extern int nova_ssh_channel_eof(NovaSshSafeHandle session, uint channelId);
 
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_channel_close")]
-        public static extern int nova_ssh_channel_close(IntPtr session, uint channelId);
+        public static extern int nova_ssh_channel_close(NovaSshSafeHandle session, uint channelId);
 
+        // Raw close used only by NovaSshSafeHandle.ReleaseHandle().
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_close")]
-        public static extern int nova_ssh_close(IntPtr session);
+        public static extern int nova_ssh_close_raw(IntPtr session);
 
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_submit_response")]
-        public static extern int nova_ssh_submit_response(IntPtr session, uint responseKind, byte[] data, nuint dataLength);
+        public static extern int nova_ssh_submit_response(NovaSshSafeHandle session, uint responseKind, byte[] data, nuint dataLength);
 
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_sftp_transfer")]
         public static extern int nova_ssh_sftp_transfer(

--- a/src/NovaTerminal.Platform/Ssh/Native/NativeSshSafeHandle.cs
+++ b/src/NovaTerminal.Platform/Ssh/Native/NativeSshSafeHandle.cs
@@ -1,0 +1,19 @@
+using System;
+using Microsoft.Win32.SafeHandles;
+
+namespace NovaTerminal.Platform.Ssh.Native;
+
+// Owns a native SSH session registry id (returned by nova_ssh_connect). Passing
+// this to every session P/Invoke makes the marshaller AddRef before / Release
+// after each call, so nova_ssh_close (ReleaseHandle) cannot run while a poll or
+// write is in flight — closing the poll-vs-close use-after-free (#121/#118).
+public sealed class NovaSshSafeHandle : SafeHandleZeroOrMinusOneIsInvalid
+{
+    public NovaSshSafeHandle() : base(ownsHandle: true) { }
+
+    protected override bool ReleaseHandle()
+    {
+        NativeSshInterop.NativeMethods.nova_ssh_close_raw(handle);
+        return true;
+    }
+}

--- a/src/NovaTerminal.Platform/Ssh/Native/NativeSshSafeHandle.cs
+++ b/src/NovaTerminal.Platform/Ssh/Native/NativeSshSafeHandle.cs
@@ -11,6 +11,13 @@ public sealed class NovaSshSafeHandle : SafeHandleZeroOrMinusOneIsInvalid
 {
     public NovaSshSafeHandle() : base(ownsHandle: true) { }
 
+    // Test-only: wrap a fabricated, non-owned handle value so fakes can return a
+    // non-invalid handle whose disposal does NOT call the native ReleaseHandle.
+    internal NovaSshSafeHandle(nint value, bool ownsHandle) : base(ownsHandle)
+    {
+        SetHandle(value);
+    }
+
     protected override bool ReleaseHandle()
     {
         NativeSshInterop.NativeMethods.nova_ssh_close_raw(handle);

--- a/src/NovaTerminal.Platform/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Platform/Ssh/Sessions/NativeSshSession.cs
@@ -31,7 +31,7 @@ public sealed class NativeSshSession : ITerminalSession
 
     private ReplayWriter? _recorder;
     private NativePortForwardSession? _portForwardSession;
-    private IntPtr _sessionHandle;
+    private NovaSshSafeHandle? _sessionHandle;
     private int _cols;
     private int _rows;
     private int _isRunning;
@@ -192,7 +192,7 @@ public sealed class NativeSshSession : ITerminalSession
 
     public void SendInput(string input)
     {
-        if (_sessionHandle == IntPtr.Zero || string.IsNullOrEmpty(input))
+        if (_sessionHandle is null || _sessionHandle.IsInvalid || _sessionHandle.IsClosed || string.IsNullOrEmpty(input))
         {
             return;
         }
@@ -203,7 +203,7 @@ public sealed class NativeSshSession : ITerminalSession
 
     public void Resize(int cols, int rows)
     {
-        if (_sessionHandle == IntPtr.Zero || cols <= 0 || rows <= 0)
+        if (_sessionHandle is null || _sessionHandle.IsInvalid || _sessionHandle.IsClosed || cols <= 0 || rows <= 0)
         {
             return;
         }
@@ -524,11 +524,8 @@ public sealed class NativeSshSession : ITerminalSession
 
     private void CloseNativeHandle()
     {
-        IntPtr handle = Interlocked.Exchange(ref _sessionHandle, IntPtr.Zero);
-        if (handle != IntPtr.Zero)
-        {
-            _interop.Close(handle);
-        }
+        NovaSshSafeHandle? handle = Interlocked.Exchange(ref _sessionHandle, null);
+        handle?.Dispose();
     }
 
     private static bool IsCriticalException(Exception ex)

--- a/src/NovaTerminal.Platform/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Platform/Ssh/Sessions/NativeSshSession.cs
@@ -525,7 +525,10 @@ public sealed class NativeSshSession : ITerminalSession
     private void CloseNativeHandle()
     {
         NovaSshSafeHandle? handle = Interlocked.Exchange(ref _sessionHandle, null);
-        handle?.Dispose();
+        if (handle != null)
+        {
+            _interop.Close(handle);
+        }
     }
 
     private static bool IsCriticalException(Exception ex)

--- a/tests/NovaTerminal.App.Tests/Core/SftpServiceTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/SftpServiceTests.cs
@@ -756,7 +756,7 @@ public sealed class SftpServiceTests
         public string? ListedRemotePath { get; private set; }
         public CancellationToken CancellationToken { get; private set; }
 
-        public IntPtr Connect(NativeSshConnectionOptions options) => throw new NotSupportedException();
+        public NovaSshSafeHandle Connect(NativeSshConnectionOptions options) => throw new NotSupportedException();
 
         public void RunSftpTransfer(
             NativeSshConnectionOptions connectionOptions,
@@ -780,15 +780,15 @@ public sealed class SftpServiceTests
             return [];
         }
 
-        public NativeSshEvent? PollEvent(IntPtr sessionHandle) => throw new NotSupportedException();
-        public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data) => throw new NotSupportedException();
-        public void Resize(IntPtr sessionHandle, int cols, int rows) => throw new NotSupportedException();
-        public int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options) => throw new NotSupportedException();
-        public void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data) => throw new NotSupportedException();
-        public void SendChannelEof(IntPtr sessionHandle, int channelId) => throw new NotSupportedException();
-        public void CloseChannel(IntPtr sessionHandle, int channelId) => throw new NotSupportedException();
-        public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data) => throw new NotSupportedException();
-        public void Close(IntPtr sessionHandle) => throw new NotSupportedException();
+        public NativeSshEvent? PollEvent(NovaSshSafeHandle sessionHandle) => throw new NotSupportedException();
+        public void Write(NovaSshSafeHandle sessionHandle, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void Resize(NovaSshSafeHandle sessionHandle, int cols, int rows) => throw new NotSupportedException();
+        public int OpenDirectTcpIp(NovaSshSafeHandle sessionHandle, NativePortForwardOpenOptions options) => throw new NotSupportedException();
+        public void WriteChannel(NovaSshSafeHandle sessionHandle, int channelId, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void SendChannelEof(NovaSshSafeHandle sessionHandle, int channelId) => throw new NotSupportedException();
+        public void CloseChannel(NovaSshSafeHandle sessionHandle, int channelId) => throw new NotSupportedException();
+        public void SubmitResponse(NovaSshSafeHandle sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void Close(NovaSshSafeHandle sessionHandle) => throw new NotSupportedException();
     }
 
     private sealed class BlockingNativeSshInterop : INativeSshInterop
@@ -796,7 +796,7 @@ public sealed class SftpServiceTests
         public ManualResetEventSlim Started { get; } = new(false);
         public ManualResetEventSlim Release { get; } = new(false);
 
-        public IntPtr Connect(NativeSshConnectionOptions options) => throw new NotSupportedException();
+        public NovaSshSafeHandle Connect(NativeSshConnectionOptions options) => throw new NotSupportedException();
 
         public void RunSftpTransfer(
             NativeSshConnectionOptions connectionOptions,
@@ -813,14 +813,14 @@ public sealed class SftpServiceTests
             string remotePath,
             CancellationToken cancellationToken) => throw new NotSupportedException();
 
-        public NativeSshEvent? PollEvent(IntPtr sessionHandle) => throw new NotSupportedException();
-        public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data) => throw new NotSupportedException();
-        public void Resize(IntPtr sessionHandle, int cols, int rows) => throw new NotSupportedException();
-        public int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options) => throw new NotSupportedException();
-        public void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data) => throw new NotSupportedException();
-        public void SendChannelEof(IntPtr sessionHandle, int channelId) => throw new NotSupportedException();
-        public void CloseChannel(IntPtr sessionHandle, int channelId) => throw new NotSupportedException();
-        public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data) => throw new NotSupportedException();
-        public void Close(IntPtr sessionHandle) => throw new NotSupportedException();
+        public NativeSshEvent? PollEvent(NovaSshSafeHandle sessionHandle) => throw new NotSupportedException();
+        public void Write(NovaSshSafeHandle sessionHandle, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void Resize(NovaSshSafeHandle sessionHandle, int cols, int rows) => throw new NotSupportedException();
+        public int OpenDirectTcpIp(NovaSshSafeHandle sessionHandle, NativePortForwardOpenOptions options) => throw new NotSupportedException();
+        public void WriteChannel(NovaSshSafeHandle sessionHandle, int channelId, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void SendChannelEof(NovaSshSafeHandle sessionHandle, int channelId) => throw new NotSupportedException();
+        public void CloseChannel(NovaSshSafeHandle sessionHandle, int channelId) => throw new NotSupportedException();
+        public void SubmitResponse(NovaSshSafeHandle sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void Close(NovaSshSafeHandle sessionHandle) => throw new NotSupportedException();
     }
 }

--- a/tests/NovaTerminal.App.Tests/Ssh/RemoteDirectoryBrowserServiceTests.cs
+++ b/tests/NovaTerminal.App.Tests/Ssh/RemoteDirectoryBrowserServiceTests.cs
@@ -250,7 +250,7 @@ public sealed class RemoteDirectoryBrowserServiceTests
         public string? LastRemotePath { get; private set; }
         public NativeSshConnectionOptions? LastConnectionOptions { get; private set; }
 
-        public IntPtr Connect(NativeSshConnectionOptions options) => throw new NotSupportedException();
+        public NovaSshSafeHandle Connect(NativeSshConnectionOptions options) => throw new NotSupportedException();
 
         public IReadOnlyList<NativeRemotePathEntry> ListRemoteDirectory(
             NativeSshConnectionOptions connectionOptions,
@@ -263,15 +263,15 @@ public sealed class RemoteDirectoryBrowserServiceTests
         }
 
         public void RunSftpTransfer(NativeSshConnectionOptions connectionOptions, NativeSftpTransferOptions transferOptions, Action<NativeSftpTransferProgress>? progress, CancellationToken cancellationToken) => throw new NotSupportedException();
-        public NativeSshEvent? PollEvent(IntPtr sessionHandle) => throw new NotSupportedException();
-        public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data) => throw new NotSupportedException();
-        public void Resize(IntPtr sessionHandle, int cols, int rows) => throw new NotSupportedException();
-        public int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options) => throw new NotSupportedException();
-        public void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data) => throw new NotSupportedException();
-        public void SendChannelEof(IntPtr sessionHandle, int channelId) => throw new NotSupportedException();
-        public void CloseChannel(IntPtr sessionHandle, int channelId) => throw new NotSupportedException();
-        public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data) => throw new NotSupportedException();
-        public void Close(IntPtr sessionHandle) => throw new NotSupportedException();
+        public NativeSshEvent? PollEvent(NovaSshSafeHandle sessionHandle) => throw new NotSupportedException();
+        public void Write(NovaSshSafeHandle sessionHandle, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void Resize(NovaSshSafeHandle sessionHandle, int cols, int rows) => throw new NotSupportedException();
+        public int OpenDirectTcpIp(NovaSshSafeHandle sessionHandle, NativePortForwardOpenOptions options) => throw new NotSupportedException();
+        public void WriteChannel(NovaSshSafeHandle sessionHandle, int channelId, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void SendChannelEof(NovaSshSafeHandle sessionHandle, int channelId) => throw new NotSupportedException();
+        public void CloseChannel(NovaSshSafeHandle sessionHandle, int channelId) => throw new NotSupportedException();
+        public void SubmitResponse(NovaSshSafeHandle sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void Close(NovaSshSafeHandle sessionHandle) => throw new NotSupportedException();
     }
 
     private sealed class ThrowingNativeSshInterop : INativeSshInterop
@@ -283,7 +283,7 @@ public sealed class RemoteDirectoryBrowserServiceTests
             _exception = exception;
         }
 
-        public IntPtr Connect(NativeSshConnectionOptions options) => throw new NotSupportedException();
+        public NovaSshSafeHandle Connect(NativeSshConnectionOptions options) => throw new NotSupportedException();
 
         public IReadOnlyList<NativeRemotePathEntry> ListRemoteDirectory(
             NativeSshConnectionOptions connectionOptions,
@@ -294,14 +294,14 @@ public sealed class RemoteDirectoryBrowserServiceTests
         }
 
         public void RunSftpTransfer(NativeSshConnectionOptions connectionOptions, NativeSftpTransferOptions transferOptions, Action<NativeSftpTransferProgress>? progress, CancellationToken cancellationToken) => throw new NotSupportedException();
-        public NativeSshEvent? PollEvent(IntPtr sessionHandle) => throw new NotSupportedException();
-        public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data) => throw new NotSupportedException();
-        public void Resize(IntPtr sessionHandle, int cols, int rows) => throw new NotSupportedException();
-        public int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options) => throw new NotSupportedException();
-        public void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data) => throw new NotSupportedException();
-        public void SendChannelEof(IntPtr sessionHandle, int channelId) => throw new NotSupportedException();
-        public void CloseChannel(IntPtr sessionHandle, int channelId) => throw new NotSupportedException();
-        public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data) => throw new NotSupportedException();
-        public void Close(IntPtr sessionHandle) => throw new NotSupportedException();
+        public NativeSshEvent? PollEvent(NovaSshSafeHandle sessionHandle) => throw new NotSupportedException();
+        public void Write(NovaSshSafeHandle sessionHandle, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void Resize(NovaSshSafeHandle sessionHandle, int cols, int rows) => throw new NotSupportedException();
+        public int OpenDirectTcpIp(NovaSshSafeHandle sessionHandle, NativePortForwardOpenOptions options) => throw new NotSupportedException();
+        public void WriteChannel(NovaSshSafeHandle sessionHandle, int channelId, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void SendChannelEof(NovaSshSafeHandle sessionHandle, int channelId) => throw new NotSupportedException();
+        public void CloseChannel(NovaSshSafeHandle sessionHandle, int channelId) => throw new NotSupportedException();
+        public void SubmitResponse(NovaSshSafeHandle sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void Close(NovaSshSafeHandle sessionHandle) => throw new NotSupportedException();
     }
 }

--- a/tests/NovaTerminal.App.Tests/Ssh/RemotePathAutocompleteServiceTests.cs
+++ b/tests/NovaTerminal.App.Tests/Ssh/RemotePathAutocompleteServiceTests.cs
@@ -298,7 +298,7 @@ public sealed class RemotePathAutocompleteServiceTests
         public string? LastRemotePath { get; private set; }
         public NativeSshConnectionOptions? LastConnectionOptions { get; private set; }
 
-        public IntPtr Connect(NativeSshConnectionOptions options) => throw new NotSupportedException();
+        public NovaSshSafeHandle Connect(NativeSshConnectionOptions options) => throw new NotSupportedException();
 
         public IReadOnlyList<NativeRemotePathEntry> ListRemoteDirectory(
             NativeSshConnectionOptions connectionOptions,
@@ -311,15 +311,15 @@ public sealed class RemotePathAutocompleteServiceTests
         }
 
         public void RunSftpTransfer(NativeSshConnectionOptions connectionOptions, NativeSftpTransferOptions transferOptions, Action<NativeSftpTransferProgress>? progress, CancellationToken cancellationToken) => throw new NotSupportedException();
-        public NativeSshEvent? PollEvent(IntPtr sessionHandle) => throw new NotSupportedException();
-        public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data) => throw new NotSupportedException();
-        public void Resize(IntPtr sessionHandle, int cols, int rows) => throw new NotSupportedException();
-        public int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options) => throw new NotSupportedException();
-        public void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data) => throw new NotSupportedException();
-        public void SendChannelEof(IntPtr sessionHandle, int channelId) => throw new NotSupportedException();
-        public void CloseChannel(IntPtr sessionHandle, int channelId) => throw new NotSupportedException();
-        public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data) => throw new NotSupportedException();
-        public void Close(IntPtr sessionHandle) => throw new NotSupportedException();
+        public NativeSshEvent? PollEvent(NovaSshSafeHandle sessionHandle) => throw new NotSupportedException();
+        public void Write(NovaSshSafeHandle sessionHandle, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void Resize(NovaSshSafeHandle sessionHandle, int cols, int rows) => throw new NotSupportedException();
+        public int OpenDirectTcpIp(NovaSshSafeHandle sessionHandle, NativePortForwardOpenOptions options) => throw new NotSupportedException();
+        public void WriteChannel(NovaSshSafeHandle sessionHandle, int channelId, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void SendChannelEof(NovaSshSafeHandle sessionHandle, int channelId) => throw new NotSupportedException();
+        public void CloseChannel(NovaSshSafeHandle sessionHandle, int channelId) => throw new NotSupportedException();
+        public void SubmitResponse(NovaSshSafeHandle sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void Close(NovaSshSafeHandle sessionHandle) => throw new NotSupportedException();
     }
 
     private sealed class BlockingNativeSshInterop : INativeSshInterop
@@ -334,7 +334,7 @@ public sealed class RemotePathAutocompleteServiceTests
         public ManualResetEventSlim Started { get; } = new(false);
         public ManualResetEventSlim Release { get; } = new(false);
 
-        public IntPtr Connect(NativeSshConnectionOptions options) => throw new NotSupportedException();
+        public NovaSshSafeHandle Connect(NativeSshConnectionOptions options) => throw new NotSupportedException();
 
         public IReadOnlyList<NativeRemotePathEntry> ListRemoteDirectory(
             NativeSshConnectionOptions connectionOptions,
@@ -347,14 +347,14 @@ public sealed class RemotePathAutocompleteServiceTests
         }
 
         public void RunSftpTransfer(NativeSshConnectionOptions connectionOptions, NativeSftpTransferOptions transferOptions, Action<NativeSftpTransferProgress>? progress, CancellationToken cancellationToken) => throw new NotSupportedException();
-        public NativeSshEvent? PollEvent(IntPtr sessionHandle) => throw new NotSupportedException();
-        public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data) => throw new NotSupportedException();
-        public void Resize(IntPtr sessionHandle, int cols, int rows) => throw new NotSupportedException();
-        public int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options) => throw new NotSupportedException();
-        public void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data) => throw new NotSupportedException();
-        public void SendChannelEof(IntPtr sessionHandle, int channelId) => throw new NotSupportedException();
-        public void CloseChannel(IntPtr sessionHandle, int channelId) => throw new NotSupportedException();
-        public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data) => throw new NotSupportedException();
-        public void Close(IntPtr sessionHandle) => throw new NotSupportedException();
+        public NativeSshEvent? PollEvent(NovaSshSafeHandle sessionHandle) => throw new NotSupportedException();
+        public void Write(NovaSshSafeHandle sessionHandle, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void Resize(NovaSshSafeHandle sessionHandle, int cols, int rows) => throw new NotSupportedException();
+        public int OpenDirectTcpIp(NovaSshSafeHandle sessionHandle, NativePortForwardOpenOptions options) => throw new NotSupportedException();
+        public void WriteChannel(NovaSshSafeHandle sessionHandle, int channelId, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void SendChannelEof(NovaSshSafeHandle sessionHandle, int channelId) => throw new NotSupportedException();
+        public void CloseChannel(NovaSshSafeHandle sessionHandle, int channelId) => throw new NotSupportedException();
+        public void SubmitResponse(NovaSshSafeHandle sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data) => throw new NotSupportedException();
+        public void Close(NovaSshSafeHandle sessionHandle) => throw new NotSupportedException();
     }
 }

--- a/tests/NovaTerminal.Platform.Tests/Ssh/JumpHostConnectPlanTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/JumpHostConnectPlanTests.cs
@@ -122,10 +122,10 @@ public sealed class JumpHostConnectPlanTests
     {
         public NativeSshConnectionOptions? LastConnectOptions { get; private set; }
 
-        public IntPtr Connect(NativeSshConnectionOptions options)
+        public NovaSshSafeHandle Connect(NativeSshConnectionOptions options)
         {
             LastConnectOptions = options;
-            return new IntPtr(1);
+            return new NovaSshSafeHandle(new IntPtr(1), ownsHandle: false);
         }
 
         public void RunSftpTransfer(NativeSshConnectionOptions connectionOptions, NativeSftpTransferOptions transferOptions, Action<NativeSftpTransferProgress>? progress, CancellationToken cancellationToken)
@@ -138,35 +138,35 @@ public sealed class JumpHostConnectPlanTests
             throw new NotSupportedException();
         }
 
-        public NativeSshEvent? PollEvent(IntPtr sessionHandle) => NativeSshEvent.Closed();
+        public NativeSshEvent? PollEvent(NovaSshSafeHandle sessionHandle) => NativeSshEvent.Closed();
 
-        public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data)
+        public void Write(NovaSshSafeHandle sessionHandle, ReadOnlySpan<byte> data)
         {
         }
 
-        public void Resize(IntPtr sessionHandle, int cols, int rows)
+        public void Resize(NovaSshSafeHandle sessionHandle, int cols, int rows)
         {
         }
 
-        public int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options) => 1;
+        public int OpenDirectTcpIp(NovaSshSafeHandle sessionHandle, NativePortForwardOpenOptions options) => 1;
 
-        public void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data)
+        public void WriteChannel(NovaSshSafeHandle sessionHandle, int channelId, ReadOnlySpan<byte> data)
         {
         }
 
-        public void SendChannelEof(IntPtr sessionHandle, int channelId)
+        public void SendChannelEof(NovaSshSafeHandle sessionHandle, int channelId)
         {
         }
 
-        public void CloseChannel(IntPtr sessionHandle, int channelId)
+        public void CloseChannel(NovaSshSafeHandle sessionHandle, int channelId)
         {
         }
 
-        public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data)
+        public void SubmitResponse(NovaSshSafeHandle sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data)
         {
         }
 
-        public void Close(IntPtr sessionHandle)
+        public void Close(NovaSshSafeHandle sessionHandle)
         {
         }
     }

--- a/tests/NovaTerminal.Platform.Tests/Ssh/NativePortForwardSessionTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/NativePortForwardSessionTests.cs
@@ -19,7 +19,7 @@ public sealed class NativePortForwardSessionTests
         int secondPort = GetFreePort();
 
         using var session = new NativePortForwardSession(
-            new IntPtr(7),
+            FakeHandle(7),
             [
                 CreateForward(firstPort, "svc-one.internal", 8080),
                 CreateForward(secondPort, "svc-two.internal", 9090)
@@ -50,7 +50,7 @@ public sealed class NativePortForwardSessionTests
         int listenPort = GetFreePort();
 
         using var session = new NativePortForwardSession(
-            new IntPtr(9),
+            FakeHandle(9),
             [CreateForward(listenPort, "svc.internal", 7000)],
             interop);
 
@@ -68,7 +68,7 @@ public sealed class NativePortForwardSessionTests
         int listenPort = GetFreePort();
 
         var session = new NativePortForwardSession(
-            new IntPtr(11),
+            FakeHandle(11),
             [CreateForward(listenPort, "svc.internal", 5432)],
             interop);
 
@@ -94,7 +94,7 @@ public sealed class NativePortForwardSessionTests
 
         InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() =>
             new NativePortForwardSession(
-                new IntPtr(13),
+                FakeHandle(13),
                 [
                     CreateForward(firstPort, "svc-one.internal", 80),
                     CreateForward(occupiedPort, "svc-two.internal", 81)
@@ -114,7 +114,7 @@ public sealed class NativePortForwardSessionTests
         int listenPort = GetFreePort();
 
         using var session = new NativePortForwardSession(
-            new IntPtr(15),
+            FakeHandle(15),
             [CreateDynamicForward(listenPort)],
             interop);
 
@@ -142,7 +142,7 @@ public sealed class NativePortForwardSessionTests
         int listenPort = GetFreePort();
 
         using var session = new NativePortForwardSession(
-            new IntPtr(16),
+            FakeHandle(16),
             [CreateDynamicForward(listenPort)],
             interop);
 
@@ -169,7 +169,7 @@ public sealed class NativePortForwardSessionTests
         int listenPort = GetFreePort();
 
         using var session = new NativePortForwardSession(
-            new IntPtr(18),
+            FakeHandle(18),
             [CreateDynamicForward(listenPort)],
             interop);
 
@@ -195,7 +195,7 @@ public sealed class NativePortForwardSessionTests
         int listenPort = GetFreePort();
 
         using var session = new NativePortForwardSession(
-            new IntPtr(19),
+            FakeHandle(19),
             [CreateDynamicForward(listenPort)],
             interop);
 
@@ -220,7 +220,7 @@ public sealed class NativePortForwardSessionTests
         int dynamicPort = GetFreePort();
 
         var session = new NativePortForwardSession(
-            new IntPtr(20),
+            FakeHandle(20),
             [CreateDynamicForward(dynamicPort)],
             interop);
 
@@ -248,7 +248,7 @@ public sealed class NativePortForwardSessionTests
         int dynamicPort = GetFreePort();
 
         using var session = CreateSessionWithReplyWriter(
-            new IntPtr(21),
+            FakeHandle(21),
             [CreateDynamicForward(dynamicPort)],
             interop,
             (_, _, _) => throw new IOException("Injected reply write failure."));
@@ -275,7 +275,7 @@ public sealed class NativePortForwardSessionTests
         int dynamicPort = GetFreePort();
 
         using var session = new NativePortForwardSession(
-            new IntPtr(22),
+            FakeHandle(22),
             [
                 CreateForward(localPort, "svc-local.internal", 8080),
                 CreateDynamicForward(dynamicPort)
@@ -326,7 +326,7 @@ public sealed class NativePortForwardSessionTests
         int dynamicPort = GetFreePort();
 
         using var session = new NativePortForwardSession(
-            new IntPtr(17),
+            FakeHandle(17),
             [
                 CreateForward(localPort, "svc-one.internal", 8080),
                 CreateDynamicForward(dynamicPort)
@@ -491,7 +491,7 @@ public sealed class NativePortForwardSessionTests
         public List<NativePortForwardOpenOptions> OpenRequests { get; } = [];
         public List<int> ClosedChannelIds { get; } = [];
 
-        public IntPtr Connect(NativeSshConnectionOptions options) => new(1);
+        public NovaSshSafeHandle Connect(NativeSshConnectionOptions options) => new(new IntPtr(1), ownsHandle: false);
 
         public void RunSftpTransfer(NativeSshConnectionOptions connectionOptions, NativeSftpTransferOptions transferOptions, Action<NativeSftpTransferProgress>? progress, CancellationToken cancellationToken)
         {
@@ -503,51 +503,54 @@ public sealed class NativePortForwardSessionTests
             throw new NotSupportedException();
         }
 
-        public NativeSshEvent? PollEvent(IntPtr sessionHandle)
+        public NativeSshEvent? PollEvent(NovaSshSafeHandle sessionHandle)
         {
             return _events.TryDequeue(out NativeSshEvent? nextEvent)
                 ? nextEvent
                 : null;
         }
 
-        public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data)
+        public void Write(NovaSshSafeHandle sessionHandle, ReadOnlySpan<byte> data)
         {
         }
 
-        public void Resize(IntPtr sessionHandle, int cols, int rows)
+        public void Resize(NovaSshSafeHandle sessionHandle, int cols, int rows)
         {
         }
 
-        public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data)
+        public void SubmitResponse(NovaSshSafeHandle sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data)
         {
         }
 
-        public int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options)
+        public int OpenDirectTcpIp(NovaSshSafeHandle sessionHandle, NativePortForwardOpenOptions options)
         {
             OpenRequests.Add(options);
             return Interlocked.Increment(ref _nextChannelId);
         }
 
-        public void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data)
+        public void WriteChannel(NovaSshSafeHandle sessionHandle, int channelId, ReadOnlySpan<byte> data)
         {
         }
 
-        public void SendChannelEof(IntPtr sessionHandle, int channelId)
+        public void SendChannelEof(NovaSshSafeHandle sessionHandle, int channelId)
         {
         }
 
-        public void CloseChannel(IntPtr sessionHandle, int channelId)
+        public void CloseChannel(NovaSshSafeHandle sessionHandle, int channelId)
         {
             ClosedChannelIds.Add(channelId);
         }
 
-        public void Close(IntPtr sessionHandle)
+        public void Close(NovaSshSafeHandle sessionHandle)
         {
         }
     }
 
+    private static NovaSshSafeHandle FakeHandle(int value) =>
+        new(new IntPtr(value), ownsHandle: false);
+
     private static NativePortForwardSession CreateSessionWithReplyWriter(
-        IntPtr sessionHandle,
+        NovaSshSafeHandle sessionHandle,
         IReadOnlyList<PortForward> forwards,
         INativeSshInterop interop,
         Func<NetworkStream, byte[], CancellationToken, Task> replyWriter)
@@ -556,7 +559,7 @@ public sealed class NativePortForwardSessionTests
             BindingFlags.Instance | BindingFlags.NonPublic,
             binder: null,
             [
-                typeof(IntPtr),
+                typeof(NovaSshSafeHandle),
                 typeof(IReadOnlyList<PortForward>),
                 typeof(INativeSshInterop),
                 typeof(Action<string>),

--- a/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshSafeHandleTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshSafeHandleTests.cs
@@ -1,0 +1,41 @@
+using NovaTerminal.Platform.Ssh.Native;
+using Xunit;
+
+namespace NovaTerminal.Platform.Tests.Ssh;
+
+public class NativeSshSafeHandleTests
+{
+    [Fact]
+    public void Dispose_IsIdempotent_AndDoesNotThrow()
+    {
+        var handle = new NovaSshSafeHandle();
+        Assert.True(handle.IsInvalid);
+
+        var ex = Record.Exception(() =>
+        {
+            handle.Dispose();
+            handle.Dispose();
+        });
+
+        Assert.Null(ex);
+        Assert.True(handle.IsClosed);
+    }
+
+    [Fact]
+    public void Interop_SessionMethods_NoOp_OnDisposedHandle()
+    {
+        var interop = new NativeSshInterop();
+        var handle = new NovaSshSafeHandle();
+        handle.Dispose();
+
+        var ex = Record.Exception(() =>
+        {
+            _ = interop.PollEvent(handle);
+            interop.Write(handle, new byte[] { 1 });
+            interop.Resize(handle, 80, 24);
+            interop.Close(handle);
+        });
+
+        Assert.Null(ex);
+    }
+}

--- a/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshSessionInteractionTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshSessionInteractionTests.cs
@@ -170,7 +170,7 @@ public sealed class NativeSshSessionInteractionTests
         public int PollCallCount { get; private set; }
         public List<(NativeSshResponseKind Kind, string PayloadJson)> Submissions { get; } = new();
 
-        public IntPtr Connect(NativeSshConnectionOptions options) => new(1);
+        public NovaSshSafeHandle Connect(NativeSshConnectionOptions options) => new(new IntPtr(1), ownsHandle: false);
 
         public void RunSftpTransfer(NativeSshConnectionOptions connectionOptions, NativeSftpTransferOptions transferOptions, Action<NativeSftpTransferProgress>? progress, CancellationToken cancellationToken)
         {
@@ -182,7 +182,7 @@ public sealed class NativeSshSessionInteractionTests
             throw new NotSupportedException();
         }
 
-        public NativeSshEvent? PollEvent(IntPtr sessionHandle)
+        public NativeSshEvent? PollEvent(NovaSshSafeHandle sessionHandle)
         {
             PollCallCount++;
             return _events.TryDequeue(out NativeSshEvent? nextEvent)
@@ -190,34 +190,34 @@ public sealed class NativeSshSessionInteractionTests
                 : null;
         }
 
-        public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data)
+        public void Write(NovaSshSafeHandle sessionHandle, ReadOnlySpan<byte> data)
         {
         }
 
-        public void Resize(IntPtr sessionHandle, int cols, int rows)
+        public void Resize(NovaSshSafeHandle sessionHandle, int cols, int rows)
         {
         }
 
-        public int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options) => 1;
+        public int OpenDirectTcpIp(NovaSshSafeHandle sessionHandle, NativePortForwardOpenOptions options) => 1;
 
-        public void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data)
+        public void WriteChannel(NovaSshSafeHandle sessionHandle, int channelId, ReadOnlySpan<byte> data)
         {
         }
 
-        public void SendChannelEof(IntPtr sessionHandle, int channelId)
+        public void SendChannelEof(NovaSshSafeHandle sessionHandle, int channelId)
         {
         }
 
-        public void CloseChannel(IntPtr sessionHandle, int channelId)
+        public void CloseChannel(NovaSshSafeHandle sessionHandle, int channelId)
         {
         }
 
-        public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data)
+        public void SubmitResponse(NovaSshSafeHandle sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data)
         {
             Submissions.Add((responseKind, Encoding.UTF8.GetString(data)));
         }
 
-        public void Close(IntPtr sessionHandle)
+        public void Close(NovaSshSafeHandle sessionHandle)
         {
         }
 

--- a/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshSessionTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshSessionTests.cs
@@ -243,11 +243,11 @@ public sealed class NativeSshSessionTests
         public NativeSshConnectionOptions? LastConnectOptions { get; private set; }
         public Exception? ResizeException { get; set; }
 
-        public IntPtr Connect(NativeSshConnectionOptions options)
+        public NovaSshSafeHandle Connect(NativeSshConnectionOptions options)
         {
             ArgumentNullException.ThrowIfNull(options);
             LastConnectOptions = options;
-            return new IntPtr(_nextHandle++);
+            return new NovaSshSafeHandle(new IntPtr(_nextHandle++), ownsHandle: false);
         }
 
         public void RunSftpTransfer(NativeSshConnectionOptions connectionOptions, NativeSftpTransferOptions transferOptions, Action<NativeSftpTransferProgress>? progress, CancellationToken cancellationToken)
@@ -260,9 +260,9 @@ public sealed class NativeSshSessionTests
             throw new NotSupportedException();
         }
 
-        public NativeSshEvent? PollEvent(IntPtr sessionHandle)
+        public NativeSshEvent? PollEvent(NovaSshSafeHandle sessionHandle)
         {
-            if (sessionHandle == IntPtr.Zero)
+            if (sessionHandle is null || sessionHandle.IsInvalid)
             {
                 throw new InvalidOperationException("Unexpected null handle.");
             }
@@ -272,12 +272,12 @@ public sealed class NativeSshSessionTests
                 : null;
         }
 
-        public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data)
+        public void Write(NovaSshSafeHandle sessionHandle, ReadOnlySpan<byte> data)
         {
             Writes.Add(data.ToArray());
         }
 
-        public void Resize(IntPtr sessionHandle, int cols, int rows)
+        public void Resize(NovaSshSafeHandle sessionHandle, int cols, int rows)
         {
             if (ResizeException != null)
             {
@@ -287,29 +287,29 @@ public sealed class NativeSshSessionTests
             Resizes.Add((cols, rows));
         }
 
-        public int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options)
+        public int OpenDirectTcpIp(NovaSshSafeHandle sessionHandle, NativePortForwardOpenOptions options)
         {
             return 1;
         }
 
-        public void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data)
+        public void WriteChannel(NovaSshSafeHandle sessionHandle, int channelId, ReadOnlySpan<byte> data)
         {
         }
 
-        public void SendChannelEof(IntPtr sessionHandle, int channelId)
+        public void SendChannelEof(NovaSshSafeHandle sessionHandle, int channelId)
         {
         }
 
-        public void CloseChannel(IntPtr sessionHandle, int channelId)
+        public void CloseChannel(NovaSshSafeHandle sessionHandle, int channelId)
         {
         }
 
-        public void Close(IntPtr sessionHandle)
+        public void Close(NovaSshSafeHandle sessionHandle)
         {
             CloseCallCount++;
         }
 
-        public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data)
+        public void SubmitResponse(NovaSshSafeHandle sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data)
         {
         }
 

--- a/tests/NovaTerminal.Platform.Tests/Ssh/SshSessionFactoryTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/SshSessionFactoryTests.cs
@@ -95,37 +95,37 @@ public sealed class SshSessionFactoryTests
 
     private sealed class StubNativeSshInterop : INativeSshInterop
     {
-        public IntPtr Connect(NativeSshConnectionOptions options) => new(1);
+        public NovaSshSafeHandle Connect(NativeSshConnectionOptions options) => new(new IntPtr(1), ownsHandle: false);
         public IReadOnlyList<NativeRemotePathEntry> ListRemoteDirectory(NativeSshConnectionOptions connectionOptions, string remotePath, CancellationToken cancellationToken) => throw new NotSupportedException();
         public void RunSftpTransfer(NativeSshConnectionOptions connectionOptions, NativeSftpTransferOptions transferOptions, Action<NativeSftpTransferProgress>? progress, CancellationToken cancellationToken) => throw new NotSupportedException();
-        public NativeSshEvent? PollEvent(IntPtr sessionHandle) => null;
-        public void Write(IntPtr sessionHandle, ReadOnlySpan<byte> data)
+        public NativeSshEvent? PollEvent(NovaSshSafeHandle sessionHandle) => null;
+        public void Write(NovaSshSafeHandle sessionHandle, ReadOnlySpan<byte> data)
         {
         }
 
-        public void Resize(IntPtr sessionHandle, int cols, int rows)
+        public void Resize(NovaSshSafeHandle sessionHandle, int cols, int rows)
         {
         }
 
-        public int OpenDirectTcpIp(IntPtr sessionHandle, NativePortForwardOpenOptions options) => 1;
+        public int OpenDirectTcpIp(NovaSshSafeHandle sessionHandle, NativePortForwardOpenOptions options) => 1;
 
-        public void WriteChannel(IntPtr sessionHandle, int channelId, ReadOnlySpan<byte> data)
+        public void WriteChannel(NovaSshSafeHandle sessionHandle, int channelId, ReadOnlySpan<byte> data)
         {
         }
 
-        public void SendChannelEof(IntPtr sessionHandle, int channelId)
+        public void SendChannelEof(NovaSshSafeHandle sessionHandle, int channelId)
         {
         }
 
-        public void CloseChannel(IntPtr sessionHandle, int channelId)
+        public void CloseChannel(NovaSshSafeHandle sessionHandle, int channelId)
         {
         }
 
-        public void Close(IntPtr sessionHandle)
+        public void Close(NovaSshSafeHandle sessionHandle)
         {
         }
 
-        public void SubmitResponse(IntPtr sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data)
+        public void SubmitResponse(NovaSshSafeHandle sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data)
         {
         }
     }


### PR DESCRIPTION
## Summary

Sub-project **A** of #121 — hardens the native SSH FFI handle lifecycle. Eliminates the poll-vs-close use-after-free on the SSH side (the #118 race, now applied to `rusty_ssh`) and makes the FFI fail closed on stale/closed/double-closed handles, with an abuse-test suite and an error-string allocation audit.

Continues the FFI-safety pattern from #118/#119 (PTY `PtySafeHandle`), adding a Rust-side fail-closed registry since the SSH side had no internal refcount (`nova_ssh_close` did `Box::from_raw`+drop immediately).

Spec: `docs/superpowers/specs/2026-06-10-ssh-ffi-handle-safety-design.md` · Plan: `docs/superpowers/plans/2026-06-10-ssh-ffi-handle-safety.md`

## What changed

**Rust (`rusty_ssh/src/lib.rs`)**
- Handle is now an opaque monotonic `u64` id into a process-global `Mutex<HashMap<u64, Arc<NovaSshSession>>>`. `nova_ssh_connect` returns the id; every session export validates it (`registry_get`) and operates on a cloned `Arc` (so an in-flight call can't be freed by a concurrent close); `nova_ssh_close` removes-then-operates. Unknown/stale/double-closed id ⇒ `INVALID_ARGUMENT`, never UB. Ids never reused; id 0 never issued.
- `command_tx`/`worker` moved behind `Mutex<Option<…>>` (exports operate via `&session`). All locks poison-safe; all exports stay `ffi_guard`-wrapped.

**C# (`NovaTerminal.Platform/Ssh`)**
- `NovaSshSafeHandle : SafeHandleZeroOrMinusOneIsInvalid` carries the id; every session P/Invoke takes it, so the marshaller AddRef/Releases around each call — `nova_ssh_close` can't run during an in-flight poll/write. **Closes #118 on the SSH side.**
- Migrated `INativeSshInterop` / `NativeSshInterop` / `NativeSshSession` / `NativePortForwardSession` off raw `IntPtr`. `NativeSshSession` owns/disposes the handle once; `NativePortForwardSession` borrows it. Session methods guard `IsClosed`/`IsInvalid` and swallow the narrow teardown-race `ObjectDisposedException`.

**Tests + CI (items 4 + 3)**
- Rust abuse suite: handle-lifecycle (call-after-close, double-close, 200× concurrent poll+close) as in-crate unit tests via a stub session; malformed/oversized JSON as integration tests.
- Debug FFI-string allocation counter + balance test (item 3 audit).
- C# `NovaSshSafeHandleTests` (dispose idempotency + disposed-handle no-op).
- New `rust-ffi-tests` CI job runs `cargo test` for `rusty_ssh` (+ `rusty_pty`) — previously the build job only `cargo build`'d the crates.

## Closes
- Closes #118 (SSH-side use-after-free), and addresses #121 items 2 (SafeHandle), 4 (abuse tests), 3 (error-string audit).

## Out of scope (follow-up)
- #121 **item 1** — credential `char[]`/`byte[]` zeroization + Rust `zeroize` — is **sub-project B**, a separate spec/plan/PR.
- Pre-existing (not a regression): a registry entry persists until explicit `nova_ssh_close` (the prior `Box` design had the same explicit-free requirement; our C# always disposes the SafeHandle). Self-eviction on worker exit is feasible later if wanted.

## Test plan
- [x] `cargo test` (rusty_ssh): 29 unit + 4 integration (incl. registry/abuse/alloc-balance/JSON) pass.
- [x] App builds clean (`scripts/build.ps1 build src/NovaTerminal.App`).
- [x] `Platform.Tests` SSH tests (27) + `App.Tests` SFTP/browser/autocomplete (50) + `NovaSshSafeHandleTests` (2) pass.
- [ ] CI `rust-ffi-tests` job green on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)