### PR TITLE
test(ssh): de-flake port-forward listener test (raise WaitUntilAsync ceiling) (#130)

### DIFF
--- a/tests/NovaTerminal.Platform.Tests/Ssh/NativePortForwardSessionTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/NativePortForwardSessionTests.cs
@@ -467,9 +467,13 @@ public sealed class NativePortForwardSessionTests
         return port;
     }
 
-    private static async Task WaitUntilAsync(Func<bool> predicate)
+    // Generous default ceiling: the predicate flips in milliseconds on an unloaded
+    // box, so a large timeout only affects wall time on a genuine failure. The old
+    // 3s ceiling flaked on loaded CI runners where the accept -> OpenDirectTcpIp
+    // pipeline lagged behind the connect (issue #130).
+    private static async Task WaitUntilAsync(Func<bool> predicate, int timeoutSeconds = 30)
     {
-        DateTime deadline = DateTime.UtcNow.AddSeconds(3);
+        DateTime deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
         while (DateTime.UtcNow < deadline)
         {
             if (predicate())


### PR DESCRIPTION
## Summary
Fixes the flaky `NativePortForwardSessionTests.LocalForwardListenersBindFromConfiguredForwards` tracked in #130.

The test's polling helper `WaitUntilAsync` had a **hardcoded 3-second deadline**. On a loaded GitHub-hosted runner the accept → `OpenDirectTcpIp` pipeline can lag past 3s after the loopback connect, so `OpenRequests.Count == 2` isn't reached in time and the assert fires. (Observed on PR #128's `Unit Tests (windows-latest)`; passed on a job re-run.)

## Change
- `WaitUntilAsync(Func<bool> predicate, int timeoutSeconds = 30)` — default ceiling raised 3s → 30s, now configurable.
- The predicate flips in milliseconds on an unloaded box, so the larger ceiling only affects wall time on a *genuine* failure (and the assert message is unchanged). De-flakes every `WaitUntilAsync` caller in the file in one change.

This is issue #130's option 1 (cheap, minimal surface). Option 2 (a deterministic readiness signal in the fake) was considered but would add a wait primitive across several tests for marginal benefit — the poll predicate itself is fine; only the ceiling was wrong.

## Test plan
- [x] `NativePortForwardSession` tests pass locally (12/12).
- [ ] CI `Unit Tests` (gating) green — the real validation under runner load.

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)