### PR TITLE
fix: clear leaked mouse/focus reporting on shell prompt-ready

### DIFF
--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -1445,6 +1445,10 @@ namespace NovaTerminal.VT
                 string marker = parts[0];
                 if (string.Equals(marker, "A", StringComparison.Ordinal))
                 {
+                    // We're back at a shell prompt: clear any mouse/focus reporting a TUI
+                    // left enabled after an unclean exit, so pointer moves don't flood the
+                    // prompt with leaked ESC[<..M reports.
+                    _buffer.Modes.ResetTransientInputReporting();
                     OnPromptReady?.Invoke();
                 }
                 else if (string.Equals(marker, "B", StringComparison.Ordinal))

--- a/src/NovaTerminal.VT/ModeState.cs
+++ b/src/NovaTerminal.VT/ModeState.cs
@@ -24,6 +24,23 @@ namespace NovaTerminal.VT
         public bool IsLineFeedNewLineMode { get; set; }   // 20 - LNM (Line Feed New Line Mode)
         public bool IsEchoEnabled { get; set; } = true;   // 12 - SRM (Send/Receive Mode)
 
+        /// <summary>
+        /// Clears the input-reporting modes a full-screen application turns on for itself
+        /// (mouse tracking and focus reporting). Called when the shell signals a fresh prompt
+        /// so a TUI that exited uncleanly — Ctrl+C, crash, or output dropped during PTY
+        /// teardown — can't leave mouse reporting on and flood the prompt with ESC[&lt;..M
+        /// reports on every pointer move. Shell-owned modes (bracketed paste, application
+        /// cursor keys, auto-wrap) are intentionally left untouched.
+        /// </summary>
+        public void ResetTransientInputReporting()
+        {
+            MouseModeX10 = false;
+            MouseModeButtonEvent = false;
+            MouseModeAnyEvent = false;
+            MouseModeSGR = false;
+            IsFocusEventReporting = false;
+        }
+
         public ModeState Clone()
         {
             return new ModeState

--- a/tests/NovaTerminal.App.Tests/OscShellIntegrationTests.cs
+++ b/tests/NovaTerminal.App.Tests/OscShellIntegrationTests.cs
@@ -137,6 +137,62 @@ public sealed class OscShellIntegrationTests
     }
 
     [Fact]
+    public void Osc133A_PromptReady_ClearsLeakedMouseTrackingModes()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var parser = new AnsiParser(buffer);
+
+        // A TUI (e.g. Claude Code) turns on mouse tracking, then exits uncleanly
+        // (Ctrl+C / crash) without sending the disable sequences.
+        parser.Process("\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h");
+        Assert.True(buffer.Modes.MouseModeAnyEvent);
+        Assert.True(buffer.Modes.MouseModeSGR);
+
+        // The shell draws its next prompt. That is proof no TUI is holding mouse
+        // capture, so the leaked mouse modes must be cleared (otherwise every mouse
+        // move floods the prompt with ESC[<..M reports).
+        parser.Process("\x1b]133;A\x07");
+
+        Assert.False(buffer.Modes.MouseModeX10);
+        Assert.False(buffer.Modes.MouseModeButtonEvent);
+        Assert.False(buffer.Modes.MouseModeAnyEvent);
+        Assert.False(buffer.Modes.MouseModeSGR);
+    }
+
+    [Fact]
+    public void Osc133A_PromptReady_ClearsLeakedFocusEventReporting()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("\x1b[?1004h");
+        Assert.True(buffer.Modes.IsFocusEventReporting);
+
+        parser.Process("\x1b]133;A\x07");
+
+        Assert.False(buffer.Modes.IsFocusEventReporting);
+    }
+
+    [Fact]
+    public void Osc133A_PromptReady_PreservesShellOwnedModes()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var parser = new AnsiParser(buffer);
+
+        // PSReadLine owns bracketed paste and application cursor keys at the prompt;
+        // clearing these on every prompt would break paste and arrow keys.
+        parser.Process("\x1b[?2004h\x1b[?1h");
+        Assert.True(buffer.Modes.IsBracketedPasteMode);
+        Assert.True(buffer.Modes.IsApplicationCursorKeys);
+
+        parser.Process("\x1b]133;A\x07");
+
+        Assert.True(buffer.Modes.IsBracketedPasteMode);
+        Assert.True(buffer.Modes.IsApplicationCursorKeys);
+        Assert.True(buffer.Modes.IsAutoWrapMode);
+    }
+
+    [Fact]
     public void Osc133D_WithExitCodeAndDuration_RaisesDetailedCommandFinished()
     {
         var buffer = new TerminalBuffer(80, 24);


### PR DESCRIPTION
## Problem

Intermittently, after a TUI like Claude Code exits, the PowerShell prompt gets flooded with literal `[<..;..;..M` text on every mouse move:

```
PS D:\projects\...> [<35;27;15M[<35;32;14M[<35;36;14M...
```

Those are **SGR mouse-tracking reports** (`ESC[<button;x;yM`) with the invisible `ESC` stripped by PSReadLine.

## Root cause

A full-screen app enables mouse tracking (`?1000/1002/1003/1006`) and focus reporting (`?1004`) for itself. On a **clean** exit it sends the disable sequences and `ModeState` clears. On an **unclean** exit — Ctrl+C/SIGINT, crash, or output dropped during ConPTY teardown — those disables never reach the parser, so the flags stay set. Back at the bare prompt, `TerminalView` keeps emitting mouse reports on every pointer move (the encoder is correct — it just sees the mode flag still on). This is why it's intermittent: only the unclean exits leak.

## Fix

Clear the self-enabled input-reporting modes (mouse `1000/1002/1003/1006` + focus `1004`) when the shell signals a fresh prompt via `OSC 133;A`. A prompt-ready mark is proof no TUI is holding mouse capture, so it's a safe, reliable reset point.

Shell-owned modes — bracketed paste (`2004`), application cursor keys (`1`), auto-wrap — are **deliberately left untouched** so paste and arrow keys keep working.

- `ModeState.ResetTransientInputReporting()` — the targeted reset
- `AnsiParser` calls it at the `OSC 133;A` handler before firing `OnPromptReady`

## Limitation

The reset keys off the `OSC 133;A` mark, so it fires only when shell integration is active for the session. Plain sessions without it would still leak; recovery there is opening a new pane (fresh `ModeState`). A manual reset-input keybinding is a reasonable follow-up to cover that case.

It's also worth filing upstream that Claude Code should reset mouse modes on SIGINT — but a terminal shouldn't rely on apps cleaning up, so this mitigation stands regardless.

## Tests

Added to `OscShellIntegrationTests` (TDD — watched the first two fail before implementing):
- `Osc133A_PromptReady_ClearsLeakedMouseTrackingModes`
- `Osc133A_PromptReady_ClearsLeakedFocusEventReporting`
- `Osc133A_PromptReady_PreservesShellOwnedModes`

28 passed across the OSC 133 / DEC mode / mouse-reporting suites, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
