### PR TITLE
fix: return reflow ArrayPool rentals in finally (#122)

### DIFF
--- a/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
@@ -726,6 +726,15 @@ namespace NovaTerminal.VT
                     _cursorRow = 0;
                     _cursorCol = 0;
                 }
+                finally
+                {
+                    // Return the pooled arrays. clearArray: true because the rows hold cell
+                    // structs with string references; not clearing would pin them in the pool.
+                    if (allPhysicalRows is not null)
+                        System.Buffers.ArrayPool<TerminalRow>.Shared.Return(allPhysicalRows, clearArray: true);
+                    if (logicalCells is not null)
+                        System.Buffers.ArrayPool<(TerminalCell Cell, string? ExtendedText)>.Shared.Return(logicalCells, clearArray: true);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
Fixes #122. Width-change reflow rented a `TerminalRow[]` and a `(TerminalCell, string?)[]` from `ArrayPool<T>.Shared` but **never returned them** — no `.Return()` calls, no `finally`. Every reflow abandoned both arrays, so the pool could never reuse them and large arrays kept hitting the GC/LOH on each resize. The optimization defeated itself, and exception paths cleaned up nothing.

## Fix
Added a `finally` block to `Reflow()` that returns both rentals with `clearArray: true` (the slots hold cell structs with string references, so clearing matters to avoid pinning them in the pool). Both rentals were already hoisted to nullable locals declared before the `try`, so the `finally` covers every exit path: the early `return` on degenerate sizes, the success path, and the failsafe `catch`.

`Return(clearArray: true)` only nulls the rented array's own slots — it does not mutate the `TerminalRow` objects, some of which are live viewport rows — so there is no aliasing risk.

## Verification
- `NovaTerminal.VT` builds with 0 errors.
- 35 reflow tests pass (`ReflowRegressionTests`, `ReflowScenariosTests`, `BufferTests/ReflowTests`), 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)