### PR TITLE
fix: cap OSC/DCS/APC string accumulation in AnsiParser (#106)

### DIFF
--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -29,6 +29,15 @@ namespace NovaTerminal.VT
         private int _paramLen = 0;
         private const int MaxCsiParamChars = 65536;
 
+        // Hard safety cap on string-type control sequences (OSC/DCS/APC) to bound memory
+        // against a hostile or runaway stream that never sends a terminator. Unlike CSI
+        // params, these legitimately carry large payloads — iTerm2 (OSC 1337) and tunneled
+        // (OSC 1339) inline images, Sixel images (DCS), and Kitty graphics (APC) — so the
+        // cap is generous rather than the 64 KiB used for CSI. Past the cap we stop
+        // accumulating and let the sequence terminate (a truncated image simply fails to
+        // decode), mirroring how CSI params stop growing at MaxCsiParamChars.
+        internal const int MaxStringSequenceChars = 16 * 1024 * 1024; // 16 Mi chars (~32 MB UTF-16)
+
         // ConPTY Sync Fix: Track vertical offset caused by inline images that ConPTY doesn't see.
         // This effectively "scrolls" the PTY's logical cursor to match our visual cursor.
         private int _verticalOffset = 0;
@@ -384,7 +393,8 @@ namespace NovaTerminal.VT
                                 }
                                 else
                                 {
-                                    _oscStringBuffer.Add(c);
+                                    if (_oscStringBuffer.Count < MaxStringSequenceChars)
+                                        _oscStringBuffer.Add(c);
                                 }
                                 break;
 
@@ -415,7 +425,8 @@ namespace NovaTerminal.VT
                                 }
                                 else
                                 {
-                                    _dcsStringBuffer.Add(c);
+                                    if (_dcsStringBuffer.Count < MaxStringSequenceChars)
+                                        _dcsStringBuffer.Add(c);
                                 }
                                 break;
 
@@ -444,7 +455,8 @@ namespace NovaTerminal.VT
                                 }
                                 else
                                 {
-                                    _apcStringBuffer.Add(c);
+                                    if (_apcStringBuffer.Count < MaxStringSequenceChars)
+                                        _apcStringBuffer.Add(c);
                                 }
                                 break;
 
@@ -1563,8 +1575,14 @@ namespace NovaTerminal.VT
                 }
             }
 
-            // Accumulate payload
-            _kittyPayloadBuffer.Append(payload);
+            // Accumulate payload. Bounded so a hostile stream that keeps sending m=1
+            // continuation chunks (and never the final m=0) cannot grow this unboundedly;
+            // per-sequence APC accumulation is already capped, but the cross-chunk total
+            // needs its own guard. Over the cap we stop appending (the image fails to decode).
+            if (_kittyPayloadBuffer.Length + payload.Length <= MaxStringSequenceChars)
+            {
+                _kittyPayloadBuffer.Append(payload);
+            }
 
             // Check if more chunks are coming (m=1)
             bool more = false;

--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -36,7 +36,9 @@ namespace NovaTerminal.VT
         // cap is generous rather than the 64 KiB used for CSI. Past the cap we stop
         // accumulating and let the sequence terminate (a truncated image simply fails to
         // decode), mirroring how CSI params stop growing at MaxCsiParamChars.
-        internal const int MaxStringSequenceChars = 16 * 1024 * 1024; // 16 Mi chars (~32 MB UTF-16)
+        // Settable so tests can drive the cap with small payloads instead of allocating
+        // tens of MB; the default is the production value.
+        public int MaxStringSequenceChars { get; set; } = 16 * 1024 * 1024; // 16 Mi chars (~32 MB UTF-16)
 
         // ConPTY Sync Fix: Track vertical offset caused by inline images that ConPTY doesn't see.
         // This effectively "scrolls" the PTY's logical cursor to match our visual cursor.
@@ -46,6 +48,7 @@ namespace NovaTerminal.VT
         private List<char> _apcStringBuffer = new List<char>();
         private List<char> _dcsStringBuffer = new List<char>();
         private System.Text.StringBuilder _kittyPayloadBuffer = new System.Text.StringBuilder();
+        private bool _kittyPayloadOverflow; // set once a chunked Kitty payload exceeds the cap
         private Dictionary<string, string> _kittyPendingParams = new();
         private readonly bool _isConPtyFilteringLikely;
 
@@ -1578,10 +1581,19 @@ namespace NovaTerminal.VT
             // Accumulate payload. Bounded so a hostile stream that keeps sending m=1
             // continuation chunks (and never the final m=0) cannot grow this unboundedly;
             // per-sequence APC accumulation is already capped, but the cross-chunk total
-            // needs its own guard. Over the cap we stop appending (the image fails to decode).
-            if (_kittyPayloadBuffer.Length + payload.Length <= MaxStringSequenceChars)
+            // needs its own guard.
+            if (!_kittyPayloadOverflow && _kittyPayloadBuffer.Length + payload.Length <= MaxStringSequenceChars)
             {
                 _kittyPayloadBuffer.Append(payload);
+            }
+            else if (!_kittyPayloadOverflow)
+            {
+                // Payload exceeded the cap mid-stream: abort this image. Free the buffer now
+                // rather than holding up to the cap across further continuation chunks, and
+                // remember to skip the (truncated, undecodable) payload at the terminator
+                // instead of spending CPU base64-decoding garbage.
+                _kittyPayloadOverflow = true;
+                _kittyPayloadBuffer.Clear();
             }
 
             // Check if more chunks are coming (m=1)
@@ -1599,6 +1611,14 @@ namespace NovaTerminal.VT
             // Process finalized image
             try
             {
+                if (_kittyPayloadOverflow)
+                {
+                    // The payload blew past the cap mid-stream; discard it rather than
+                    // decoding a truncated buffer. The finally below resets state.
+                    TerminalLogger.Log("[ANSI_PARSER] Kitty image discarded: payload exceeded size cap.");
+                    return;
+                }
+
                 string action = _kittyPendingParams.TryGetValue("a", out var aVal) ? aVal : "t";
                 TerminalLogger.Log($"[ANSI_PARSER] Kitty finalizing image. Action={action}, TotalPayload={_kittyPayloadBuffer.Length}");
 
@@ -1756,6 +1776,7 @@ namespace NovaTerminal.VT
         {
             _kittyPayloadBuffer.Clear();
             _kittyPendingParams.Clear();
+            _kittyPayloadOverflow = false;
         }
 
         private void HandleITerm2Image(string osc)

--- a/tests/NovaTerminal.VT.Tests/StringSequenceCapTests.cs
+++ b/tests/NovaTerminal.VT.Tests/StringSequenceCapTests.cs
@@ -3,23 +3,25 @@ using NovaTerminal.VT;
 namespace NovaTerminal.VT.Tests;
 
 // Regression tests for #106: OSC/DCS/APC string accumulation must be bounded so a hostile
-// or runaway stream cannot grow parser buffers without limit. The cap is generous (it must
-// not truncate legitimate inline images carried over these sequences), so these tests drive
-// payloads just past the cap to prove accumulation stops and the parser stays usable.
+// or runaway stream cannot grow parser buffers without limit. The production cap is generous
+// (it must not truncate legitimate inline images carried over these sequences); these tests
+// lower MaxStringSequenceChars so they exercise the cap with tiny payloads.
 public class StringSequenceCapTests
 {
+    private const int TestCap = 1000;
+
     [Fact]
     public void Osc_string_accumulation_is_capped_and_parser_recovers()
     {
         var buffer = new TerminalBuffer(cols: 10, rows: 1);
-        var parser = new AnsiParser(buffer);
+        var parser = new AnsiParser(buffer) { MaxStringSequenceChars = TestCap };
 
         string? title = null;
         parser.OnTitleChanged = t => title = t;
 
         // An OSC 0 (window title) whose payload exceeds the cap. Without the guard the
         // parser would accumulate every byte; with it, accumulation stops at the cap.
-        int overCap = AnsiParser.MaxStringSequenceChars + 100;
+        int overCap = TestCap + 100;
         string input = "\x1b]0;" + new string('A', overCap) + "\x07Z";
 
         parser.Process(input);
@@ -27,7 +29,7 @@ public class StringSequenceCapTests
         Assert.NotNull(title);
         // Truncated: far fewer chars than were sent, and never above the cap.
         Assert.True(title!.Length < overCap, "title should be truncated below the payload length");
-        Assert.True(title.Length <= AnsiParser.MaxStringSequenceChars, "title must not exceed the cap");
+        Assert.True(title.Length <= TestCap, "title must not exceed the cap");
 
         // The parser must terminate the over-long sequence cleanly and resume normal
         // rendering — the trailing 'Z' lands at the home cell rather than being lost or
@@ -44,24 +46,48 @@ public class StringSequenceCapTests
     public void Dcs_sixel_payload_is_capped()
     {
         var buffer = new TerminalBuffer(cols: 10, rows: 1);
-        var parser = new AnsiParser(buffer);
+        var parser = new AnsiParser(buffer) { MaxStringSequenceChars = TestCap };
         var decoder = new RecordingImageDecoder();
         parser.ImageDecoder = decoder;
 
         // DCS Sixel payload (begins with 'q') exceeding the cap.
-        int overCap = AnsiParser.MaxStringSequenceChars + 100;
+        int overCap = TestCap + 100;
         parser.Process("\x1bPq" + new string('~', overCap) + "\x07");
 
         Assert.NotNull(decoder.LastSixelPayload);
         Assert.True(decoder.LastSixelPayload!.Length < overCap, "sixel payload should be truncated");
-        Assert.True(decoder.LastSixelPayload.Length <= AnsiParser.MaxStringSequenceChars, "sixel payload must not exceed the cap");
+        Assert.True(decoder.LastSixelPayload.Length <= TestCap, "sixel payload must not exceed the cap");
+    }
+
+    [Fact]
+    public void Kitty_payload_exceeding_cap_across_chunks_is_discarded_not_decoded()
+    {
+        var buffer = new TerminalBuffer(cols: 80, rows: 24);
+        var parser = new AnsiParser(buffer, forceConPtyFiltering: false) { MaxStringSequenceChars = TestCap };
+        var decoder = new RecordingImageDecoder();
+        parser.ImageDecoder = decoder;
+
+        // Chunked Kitty transfer (m=1 continuations) whose accumulated payload blows past
+        // the cap before the final m=0 chunk arrives.
+        string chunk = new string('Q', 600);
+        parser.Process("\x1b_Ga=T,f=100,m=1;" + chunk + "\x07"); // 600 -> under cap
+        parser.Process("\x1b_Gm=1;" + chunk + "\x07");           // 1200 -> trips overflow
+        parser.Process("\x1b_Gm=0;QUJD\x07");                    // terminator
+
+        // The truncated image must be discarded outright — the decoder is never invoked
+        // (no CPU spent base64-decoding a corrupt multi-chunk payload).
+        Assert.Equal(0, decoder.DecodeImageBytesCallCount);
+
+        // State is reset, so a subsequent well-formed image decodes normally.
+        parser.Process("\x1b_Ga=T,f=100,m=0;QUJD\x07");
+        Assert.Equal(1, decoder.DecodeImageBytesCallCount);
     }
 
     [Fact]
     public void Normal_sized_sequences_are_unaffected_by_cap()
     {
         var buffer = new TerminalBuffer(cols: 10, rows: 1);
-        var parser = new AnsiParser(buffer);
+        var parser = new AnsiParser(buffer) { MaxStringSequenceChars = TestCap };
         var decoder = new RecordingImageDecoder();
         parser.ImageDecoder = decoder;
 
@@ -78,12 +104,14 @@ public class StringSequenceCapTests
     private sealed class RecordingImageDecoder : IImageDecoder
     {
         public string? LastSixelPayload { get; private set; }
+        public int DecodeImageBytesCallCount { get; private set; }
 
         public object? DecodeImageBytes(byte[] imageData, out int pixelWidth, out int pixelHeight)
         {
-            pixelWidth = 0;
-            pixelHeight = 0;
-            return null;
+            DecodeImageBytesCallCount++;
+            pixelWidth = 1;
+            pixelHeight = 1;
+            return new object();
         }
 
         public object? DecodeSixel(string sixelData, out int pixelWidth, out int pixelHeight)

--- a/tests/NovaTerminal.VT.Tests/StringSequenceCapTests.cs
+++ b/tests/NovaTerminal.VT.Tests/StringSequenceCapTests.cs
@@ -1,0 +1,97 @@
+using NovaTerminal.VT;
+
+namespace NovaTerminal.VT.Tests;
+
+// Regression tests for #106: OSC/DCS/APC string accumulation must be bounded so a hostile
+// or runaway stream cannot grow parser buffers without limit. The cap is generous (it must
+// not truncate legitimate inline images carried over these sequences), so these tests drive
+// payloads just past the cap to prove accumulation stops and the parser stays usable.
+public class StringSequenceCapTests
+{
+    [Fact]
+    public void Osc_string_accumulation_is_capped_and_parser_recovers()
+    {
+        var buffer = new TerminalBuffer(cols: 10, rows: 1);
+        var parser = new AnsiParser(buffer);
+
+        string? title = null;
+        parser.OnTitleChanged = t => title = t;
+
+        // An OSC 0 (window title) whose payload exceeds the cap. Without the guard the
+        // parser would accumulate every byte; with it, accumulation stops at the cap.
+        int overCap = AnsiParser.MaxStringSequenceChars + 100;
+        string input = "\x1b]0;" + new string('A', overCap) + "\x07Z";
+
+        parser.Process(input);
+
+        Assert.NotNull(title);
+        // Truncated: far fewer chars than were sent, and never above the cap.
+        Assert.True(title!.Length < overCap, "title should be truncated below the payload length");
+        Assert.True(title.Length <= AnsiParser.MaxStringSequenceChars, "title must not exceed the cap");
+
+        // The parser must terminate the over-long sequence cleanly and resume normal
+        // rendering — the trailing 'Z' lands at the home cell rather than being lost or
+        // treated as part of the OSC string.
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            Assert.Equal("Z", buffer.GetGrapheme(col: 0, viewRow: 0));
+        }
+        finally { buffer.Lock.ExitReadLock(); }
+    }
+
+    [Fact]
+    public void Dcs_sixel_payload_is_capped()
+    {
+        var buffer = new TerminalBuffer(cols: 10, rows: 1);
+        var parser = new AnsiParser(buffer);
+        var decoder = new RecordingImageDecoder();
+        parser.ImageDecoder = decoder;
+
+        // DCS Sixel payload (begins with 'q') exceeding the cap.
+        int overCap = AnsiParser.MaxStringSequenceChars + 100;
+        parser.Process("\x1bPq" + new string('~', overCap) + "\x07");
+
+        Assert.NotNull(decoder.LastSixelPayload);
+        Assert.True(decoder.LastSixelPayload!.Length < overCap, "sixel payload should be truncated");
+        Assert.True(decoder.LastSixelPayload.Length <= AnsiParser.MaxStringSequenceChars, "sixel payload must not exceed the cap");
+    }
+
+    [Fact]
+    public void Normal_sized_sequences_are_unaffected_by_cap()
+    {
+        var buffer = new TerminalBuffer(cols: 10, rows: 1);
+        var parser = new AnsiParser(buffer);
+        var decoder = new RecordingImageDecoder();
+        parser.ImageDecoder = decoder;
+
+        string? title = null;
+        parser.OnTitleChanged = t => title = t;
+
+        parser.Process("\x1b]0;hello\x07");
+        parser.Process("\x1bPq#0!1~\x07");
+
+        Assert.Equal("hello", title);
+        Assert.Equal("q#0!1~", decoder.LastSixelPayload);
+    }
+
+    private sealed class RecordingImageDecoder : IImageDecoder
+    {
+        public string? LastSixelPayload { get; private set; }
+
+        public object? DecodeImageBytes(byte[] imageData, out int pixelWidth, out int pixelHeight)
+        {
+            pixelWidth = 0;
+            pixelHeight = 0;
+            return null;
+        }
+
+        public object? DecodeSixel(string sixelData, out int pixelWidth, out int pixelHeight)
+        {
+            LastSixelPayload = sixelData;
+            pixelWidth = 0;
+            pixelHeight = 0;
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #106. OSC, DCS, and APC string sequences were accumulated into **unbounded** `List<char>` buffers, and Kitty graphics into an unbounded `StringBuilder` across `m=1` continuation chunks. A hostile or runaway stream (e.g. `cat`-ing a crafted file, or output from a compromised SSH host) that never sends a terminator could grow these buffers without limit → memory abuse. CSI params already had a cap (`MaxCsiParamChars`); string-type sequences did not.

## Fix
Added `MaxStringSequenceChars` and stop accumulating past it on all four buffers (`_oscStringBuffer`, `_dcsStringBuffer`, `_apcStringBuffer`, and the cross-chunk `_kittyPayloadBuffer`). This mirrors the existing CSI convention: cap the buffer, keep consuming bytes to the terminator, then handle what was captured.

### Note on the cap value (divergence from the issue)
The issue suggested "same 64 KiB" as CSI. I deliberately used **16 Mi chars** instead, because — unlike CSI params — these sequences legitimately carry **inline image payloads**:
- **OSC** — iTerm2 images (`OSC 1337;File=`) and tunneled Sixel/Kitty (`OSC 1339`)
- **DCS** — Sixel images (entire image in one sequence)
- **APC** — Kitty graphics chunks

A flat 64 KiB cap would silently corrupt legitimate images. 16 Mi chars still bounds memory hard (steady-state per buffer is cleared after each sequence) while leaving image transfers intact. The constant is `internal` and easy to tune.

The Kitty cross-chunk accumulator (`_kittyPayloadBuffer`) is line 39 — just outside the issue's cited 36–38 range — but it's the same vulnerability class (the per-APC-sequence cap alone wouldn't stop an attacker sending infinite `m=1` chunks), so I capped it too.

## Verification
- New `StringSequenceCapTests` (3): over-cap OSC title is truncated and the parser recovers (trailing text still renders); over-cap DCS Sixel payload is truncated; normal-sized OSC/Sixel are unaffected.
- Existing `AnsiParserHardeningTests` + `GraphicsTests` (19) still pass — no image regression.
- Full `NovaTerminal.VT.Tests` suite (29) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)