### PR TITLE
fix: resolve 5 CS8602 null-deref warnings in TerminalPane (#105)

### DIFF
--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -20,6 +20,7 @@ using Avalonia.Controls.Shapes;
 using Avalonia.Automation;
 using Avalonia.Platform.Storage;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using NovaTerminal.CommandAssist.Application;
 using NovaTerminal.CommandAssist.Models;
@@ -897,6 +898,10 @@ namespace NovaTerminal.Controls
                    _settings.CommandAssistHistoryEnabled;
         }
 
+        // When this returns true the controller is guaranteed non-null; the attribute lets
+        // the compiler's null-flow analysis see that, so callers can dereference
+        // _commandAssistController directly after the guard without CS8602.
+        [MemberNotNullWhen(true, nameof(_commandAssistController))]
         private bool EnsureCommandAssistInitialized()
         {
             if (!IsCommandAssistFeatureEnabled())


### PR DESCRIPTION
## Summary
Fixes #105. The 5 CS8602 (possible null dereference) warnings in `TerminalPane.axaml.cs` (lines ~1268, 1905, 2525, 2548, 2560) all dereference `_commandAssistController` immediately after an `EnsureCommandAssistInitialized()` guard:

```csharp
if (!EnsureCommandAssistInitialized()) return;
... _commandAssistController.SomeMethod() ... // CS8602
```

The guard already returns `true` only when the field is non-null (`return _commandAssistController != null;`), but the compiler could not propagate that fact across the call boundary.

## Fix
Annotated `EnsureCommandAssistInitialized()` with `[MemberNotNullWhen(true, nameof(_commandAssistController))]`. Null-flow analysis now understands that a `true` return implies `_commandAssistController != null`, clearing all five warnings **at the root** — no null-forgiving (`!`) operators, no redundant re-checks scattered at each call site, and **no runtime behavior change** (the attribute is compile-time metadata; the guards already bailed correctly).

Unblocks #108 (re-enable `TreatWarningsAsErrors`).

## Verification
- `src/NovaTerminal.App` builds with **0 errors** and **0 CS8602** in `TerminalPane.axaml.cs` (was 5).
- No IL/behavior change — `MemberNotNullWhen` and the added `using` are compile-time only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)