### PR TITLE
fix: kill unbounded error.log writes + add TerminalLogger levels (#109 partial)

### DIFF
--- a/src/NovaTerminal.App/Shell/TerminalDrawOperation.cs
+++ b/src/NovaTerminal.App/Shell/TerminalDrawOperation.cs
@@ -19,6 +19,11 @@ namespace NovaTerminal.Shell
 {
     public sealed class TerminalDrawOperation : ICustomDrawOperation
     {
+        // Throttle render-path error logging: a persistent draw failure fires every frame, so
+        // rate-limit to avoid flooding the log (and previously, unbounded error.log growth).
+        private static long _lastRenderErrorLogTicks;
+        private static readonly long RenderErrorLogIntervalTicks = TimeSpan.FromSeconds(5).Ticks;
+
         private readonly TerminalBuffer _buffer;
         private readonly CellMetrics _metrics;
         private readonly int _scrollOffset;
@@ -794,7 +799,12 @@ namespace NovaTerminal.Shell
             }
             catch (Exception ex)
             {
-                try { System.IO.File.AppendAllText("error.log", "\n--- Exception at " + DateTime.Now + " ---\n" + ex.ToString() + "\n"); } catch { }
+                long now = DateTime.UtcNow.Ticks;
+                if (now - _lastRenderErrorLogTicks >= RenderErrorLogIntervalTicks)
+                {
+                    _lastRenderErrorLogTicks = now;
+                    TerminalLogger.Error("Render frame failed (rate-limited). " + ex);
+                }
                 throw;
             }
             finally

--- a/src/NovaTerminal.App/Shell/TerminalView.cs
+++ b/src/NovaTerminal.App/Shell/TerminalView.cs
@@ -735,7 +735,7 @@ namespace NovaTerminal.Shell
             }
             catch (Exception ex)
             {
-                try { System.IO.File.AppendAllText("error.log", "\n--- ApplySettings Exception at " + DateTime.Now + " ---\n" + ex.ToString() + "\n"); } catch { }
+                TerminalLogger.Error("ApplySettings failed. " + ex);
             }
         }
 
@@ -1393,7 +1393,7 @@ namespace NovaTerminal.Shell
             }
             catch (Exception ex)
             {
-                try { System.IO.File.AppendAllText("error.log", "\n--- OnSizeChanged Exception at " + DateTime.Now + " ---\n" + ex.ToString() + "\n"); } catch { }
+                TerminalLogger.Error("OnSizeChanged failed. " + ex);
             }
         }
 
@@ -1425,7 +1425,7 @@ namespace NovaTerminal.Shell
             }
             catch (Exception ex)
             {
-                try { System.IO.File.AppendAllText("error.log", "\n--- SendThrottledResize Exception at " + DateTime.Now + " ---\n" + ex.ToString() + "\n"); } catch { }
+                TerminalLogger.Error("SendThrottledResize failed. " + ex);
             }
         }
 

--- a/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
@@ -718,7 +718,7 @@ namespace NovaTerminal.VT
                 }
                 catch (Exception ex)
                 {
-                    try { System.IO.File.AppendAllText("error.log", "\n--- Reflow Exception at " + DateTime.Now + " ---\n" + ex.ToString() + "\n"); } catch { }
+                    TerminalLogger.Error("Reflow failed; buffer reset to a clean state. " + ex);
                     // Failsafe: if reflow crashes, we just reset the buffer to a clean state to avoid permanent hang
                     _scrollback = new ScrollbackPages(newCols, _sharedPagePool, _maxScrollbackBytes);
                     _viewport = new TerminalRow[newRows];

--- a/src/NovaTerminal.VT/TerminalLogger.cs
+++ b/src/NovaTerminal.VT/TerminalLogger.cs
@@ -2,13 +2,44 @@ using System;
 
 namespace NovaTerminal.VT
 {
+    public enum LogLevel
+    {
+        Debug,
+        Info,
+        Warning,
+        Error
+    }
+
     public static class TerminalLogger
     {
+        // Existing unstructured hook — kept so current consumers (and Log(string)) are unchanged.
         public static Action<string>? OnLog { get; set; }
 
-        public static void Log(string message)
+        // Optional structured hook. When set, it receives the level; when unset, leveled messages
+        // fall back to OnLog with a "[LEVEL] " prefix (Info passes through verbatim, as before).
+        public static Action<LogLevel, string>? OnLogLevel { get; set; }
+
+        // Messages below this level are dropped before any hook is invoked.
+        public static LogLevel MinimumLevel { get; set; } = LogLevel.Debug;
+
+        public static void Log(string message) => Log(LogLevel.Info, message);
+
+        public static void Log(LogLevel level, string message)
         {
-            OnLog?.Invoke(message);
+            if (level < MinimumLevel) return;
+
+            if (OnLogLevel is { } structured)
+            {
+                structured(level, message);
+                return;
+            }
+
+            OnLog?.Invoke(level == LogLevel.Info ? message : $"[{level}] {message}");
         }
+
+        public static void Debug(string message) => Log(LogLevel.Debug, message);
+        public static void Info(string message) => Log(LogLevel.Info, message);
+        public static void Warning(string message) => Log(LogLevel.Warning, message);
+        public static void Error(string message) => Log(LogLevel.Error, message);
     }
 }

--- a/src/NovaTerminal.VT/TerminalLogger.cs
+++ b/src/NovaTerminal.VT/TerminalLogger.cs
@@ -28,13 +28,23 @@ namespace NovaTerminal.VT
         {
             if (level < MinimumLevel) return;
 
-            if (OnLogLevel is { } structured)
+            // A throwing log hook must never disrupt callers — TerminalLogger is invoked from
+            // critical recovery paths (e.g. Reflow's failsafe catch, the render catch) where an
+            // escaping exception would skip the recovery that follows and could hang the terminal.
+            try
             {
-                structured(level, message);
-                return;
-            }
+                if (OnLogLevel is { } structured)
+                {
+                    structured(level, message);
+                    return;
+                }
 
-            OnLog?.Invoke(level == LogLevel.Info ? message : $"[{level}] {message}");
+                OnLog?.Invoke(level == LogLevel.Info ? message : $"[{level}] {message}");
+            }
+            catch
+            {
+                // Swallow: logging failures must not propagate into error-handling paths.
+            }
         }
 
         public static void Debug(string message) => Log(LogLevel.Debug, message);

--- a/tests/NovaTerminal.VT.Tests/AssemblyInfo.cs
+++ b/tests/NovaTerminal.VT.Tests/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+using Xunit;
+
+// Several tests here exercise process-global static state (e.g. TerminalLogger's hooks and
+// MinimumLevel). Running test classes in parallel races on that shared state, so serialize the
+// whole assembly — it is small and fast, so the cost is negligible.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/NovaTerminal.VT.Tests/TerminalLoggerTests.cs
+++ b/tests/NovaTerminal.VT.Tests/TerminalLoggerTests.cs
@@ -1,0 +1,113 @@
+using System.Collections.Generic;
+using NovaTerminal.VT;
+
+namespace NovaTerminal.VT.Tests;
+
+// Covers the leveled logging added for #109. Tests run sequentially within a class, and each
+// restores the static hooks/level it touches so it doesn't leak into other tests.
+public class TerminalLoggerTests
+{
+    [Fact]
+    public void Log_String_RoutesToOnLog_Verbatim_AsInfo()
+    {
+        var prevOnLog = TerminalLogger.OnLog;
+        var prevOnLevel = TerminalLogger.OnLogLevel;
+        var prevMin = TerminalLogger.MinimumLevel;
+        try
+        {
+            TerminalLogger.OnLogLevel = null;
+            TerminalLogger.MinimumLevel = LogLevel.Debug;
+            string? got = null;
+            TerminalLogger.OnLog = m => got = m;
+
+            TerminalLogger.Log("hello"); // back-compat: Log(string) == Info, no prefix
+
+            Assert.Equal("hello", got);
+        }
+        finally
+        {
+            TerminalLogger.OnLog = prevOnLog;
+            TerminalLogger.OnLogLevel = prevOnLevel;
+            TerminalLogger.MinimumLevel = prevMin;
+        }
+    }
+
+    [Fact]
+    public void LeveledMessages_FallBackToOnLog_WithPrefix()
+    {
+        var prevOnLog = TerminalLogger.OnLog;
+        var prevOnLevel = TerminalLogger.OnLogLevel;
+        var prevMin = TerminalLogger.MinimumLevel;
+        try
+        {
+            TerminalLogger.OnLogLevel = null;
+            TerminalLogger.MinimumLevel = LogLevel.Debug;
+            string? got = null;
+            TerminalLogger.OnLog = m => got = m;
+
+            TerminalLogger.Error("boom");
+
+            Assert.Equal("[Error] boom", got);
+        }
+        finally
+        {
+            TerminalLogger.OnLog = prevOnLog;
+            TerminalLogger.OnLogLevel = prevOnLevel;
+            TerminalLogger.MinimumLevel = prevMin;
+        }
+    }
+
+    [Fact]
+    public void StructuredHook_ReceivesLevel_AndBypassesOnLog()
+    {
+        var prevOnLog = TerminalLogger.OnLog;
+        var prevOnLevel = TerminalLogger.OnLogLevel;
+        var prevMin = TerminalLogger.MinimumLevel;
+        try
+        {
+            TerminalLogger.MinimumLevel = LogLevel.Debug;
+            var captured = new List<(LogLevel, string)>();
+            TerminalLogger.OnLogLevel = (lvl, m) => captured.Add((lvl, m));
+            bool onLogCalled = false;
+            TerminalLogger.OnLog = _ => onLogCalled = true;
+
+            TerminalLogger.Warning("careful");
+
+            Assert.Equal((LogLevel.Warning, "careful"), Assert.Single(captured));
+            Assert.False(onLogCalled);
+        }
+        finally
+        {
+            TerminalLogger.OnLog = prevOnLog;
+            TerminalLogger.OnLogLevel = prevOnLevel;
+            TerminalLogger.MinimumLevel = prevMin;
+        }
+    }
+
+    [Fact]
+    public void MinimumLevel_FiltersBelowThreshold()
+    {
+        var prevOnLog = TerminalLogger.OnLog;
+        var prevOnLevel = TerminalLogger.OnLogLevel;
+        var prevMin = TerminalLogger.MinimumLevel;
+        try
+        {
+            var captured = new List<LogLevel>();
+            TerminalLogger.OnLogLevel = (lvl, _) => captured.Add(lvl);
+            TerminalLogger.MinimumLevel = LogLevel.Warning;
+
+            TerminalLogger.Debug("d");
+            TerminalLogger.Info("i");
+            TerminalLogger.Warning("w");
+            TerminalLogger.Error("e");
+
+            Assert.Equal(new[] { LogLevel.Warning, LogLevel.Error }, captured);
+        }
+        finally
+        {
+            TerminalLogger.OnLog = prevOnLog;
+            TerminalLogger.OnLogLevel = prevOnLevel;
+            TerminalLogger.MinimumLevel = prevMin;
+        }
+    }
+}

--- a/tests/NovaTerminal.VT.Tests/TerminalLoggerTests.cs
+++ b/tests/NovaTerminal.VT.Tests/TerminalLoggerTests.cs
@@ -85,6 +85,31 @@ public class TerminalLoggerTests
     }
 
     [Fact]
+    public void ThrowingHook_DoesNotPropagate()
+    {
+        // TerminalLogger is called from critical recovery paths; a throwing hook must not escape.
+        var prevOnLog = TerminalLogger.OnLog;
+        var prevOnLevel = TerminalLogger.OnLogLevel;
+        var prevMin = TerminalLogger.MinimumLevel;
+        try
+        {
+            TerminalLogger.MinimumLevel = LogLevel.Debug;
+            TerminalLogger.OnLogLevel = (_, _) => throw new System.InvalidOperationException("boom");
+            TerminalLogger.Error("x"); // must not throw
+
+            TerminalLogger.OnLogLevel = null;
+            TerminalLogger.OnLog = _ => throw new System.InvalidOperationException("boom");
+            TerminalLogger.Log("y");   // must not throw
+        }
+        finally
+        {
+            TerminalLogger.OnLog = prevOnLog;
+            TerminalLogger.OnLogLevel = prevOnLevel;
+            TerminalLogger.MinimumLevel = prevMin;
+        }
+    }
+
+    [Fact]
     public void MinimumLevel_FiltersBelowThreshold()
     {
         var prevOnLog = TerminalLogger.OnLog;


### PR DESCRIPTION
## Summary
Addresses the contained, high-value parts of #109 (it does **not** fully close the issue — see "Remaining" below).

### Real bug fixed: unbounded `error.log`
Five `File.AppendAllText("error.log", …)` fallbacks (in `TerminalBuffer.ReflowEngine`, `TerminalView` ×3, `TerminalDrawOperation`) wrote to a **relative path** (lands in the process CWD), and the `TerminalDrawOperation` one sits in the per-frame render catch — a persistent draw error would append **every frame**, growing the file without bound. All five now route to `TerminalLogger`; the render-path site is **rate-limited to once per 5s**.

### TerminalLogger gets levels
Extended with `LogLevel` (Debug/Info/Warning/Error), an optional structured `OnLogLevel` hook, and a `MinimumLevel` filter. **Backward compatible**: `Log(string)` still maps to Info and reaches the existing `OnLog` verbatim.

## Verification
- New `TerminalLoggerTests` (4): back-compat passthrough, level-prefix fallback, structured hook bypasses `OnLog`, `MinimumLevel` filtering.
- Full `NovaTerminal.VT.Tests`: 54 pass. Disabled test parallelization for this (tiny, <1s) assembly — `TerminalLogger` is process-global static, so parallel classes raced on it.
- App builds clean; no `error.log` writes remain in `src/`.

## Remaining for #109 (deliberately out of scope here)
- Replacing the `Console.WriteLine` calls — the bulk are in **Pty**, which **cannot reference `TerminalLogger`** (VT) per the leaf-assembly architecture, so it needs a cross-assembly logging abstraction (a real refactor). Some other `Console.WriteLine`s are legitimate CLI stdout.
- The 26-empty-catch audit (judgment-heavy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)