### PR TITLE
feat: NovaTerminal MCP Dev Companion (read-only stdio server) (#97)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,7 @@ jobs:
             tests/NovaTerminal.Architecture.Tests/bin/${{ env.CONFIGURATION }}
             tests/NovaTerminal.VT.Tests/bin/${{ env.CONFIGURATION }}
             tests/NovaTerminal.Rendering.Tests/bin/${{ env.CONFIGURATION }}
+            tests/NovaTerminal.McpServer.Tests/bin/${{ env.CONFIGURATION }}
 
   build_and_unit_tests:
     name: Unit Tests (${{ matrix.os }})
@@ -255,7 +256,7 @@ jobs:
         run: |
           set -e
           filter="Category!=Replay&Category!=RenderMetrics&Category!=PtySmoke&Category!=Stress&Category!=GoldenSharedPng"
-          for proj in VT Rendering Architecture Platform; do
+          for proj in VT Rendering Architecture Platform McpServer; do
             echo "::group::NovaTerminal.$proj.Tests"
             dotnet test "tests/NovaTerminal.$proj.Tests" -c "$CONFIGURATION" --no-build --no-restore \
               --filter "$filter" --logger "trx;LogFileName=unit_${proj}.trx"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,5 +37,9 @@
 
     <!-- Architecture testing (added in Phase 2 but reserved here for one-shot CPM) -->
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
+
+    <!-- MCP Dev Companion (NovaTerminal.McpServer) -->
+    <PackageVersion Include="ModelContextProtocol" Version="1.4.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 </Project>

--- a/NovaTerminal.sln
+++ b/NovaTerminal.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
@@ -36,6 +36,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NovaTerminal.VT.Tests", "tests\NovaTerminal.VT.Tests\NovaTerminal.VT.Tests.csproj", "{C480ADFF-F69D-4383-9A87-6300FC525F13}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NovaTerminal.Rendering.Tests", "tests\NovaTerminal.Rendering.Tests\NovaTerminal.Rendering.Tests.csproj", "{39F1F320-2266-487E-98D8-43BE0FECD0A4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NovaTerminal.McpServer", "src\NovaTerminal.McpServer\NovaTerminal.McpServer.csproj", "{4B799A42-DE84-4393-89E9-B7B1EFFFA02D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NovaTerminal.McpServer.Tests", "tests\NovaTerminal.McpServer.Tests\NovaTerminal.McpServer.Tests.csproj", "{254C6074-5012-4A10-BBA4-E14953766E7F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -227,6 +231,30 @@ Global
 		{39F1F320-2266-487E-98D8-43BE0FECD0A4}.Release|x64.Build.0 = Release|Any CPU
 		{39F1F320-2266-487E-98D8-43BE0FECD0A4}.Release|x86.ActiveCfg = Release|Any CPU
 		{39F1F320-2266-487E-98D8-43BE0FECD0A4}.Release|x86.Build.0 = Release|Any CPU
+		{4B799A42-DE84-4393-89E9-B7B1EFFFA02D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4B799A42-DE84-4393-89E9-B7B1EFFFA02D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4B799A42-DE84-4393-89E9-B7B1EFFFA02D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4B799A42-DE84-4393-89E9-B7B1EFFFA02D}.Debug|x64.Build.0 = Debug|Any CPU
+		{4B799A42-DE84-4393-89E9-B7B1EFFFA02D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4B799A42-DE84-4393-89E9-B7B1EFFFA02D}.Debug|x86.Build.0 = Debug|Any CPU
+		{4B799A42-DE84-4393-89E9-B7B1EFFFA02D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4B799A42-DE84-4393-89E9-B7B1EFFFA02D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4B799A42-DE84-4393-89E9-B7B1EFFFA02D}.Release|x64.ActiveCfg = Release|Any CPU
+		{4B799A42-DE84-4393-89E9-B7B1EFFFA02D}.Release|x64.Build.0 = Release|Any CPU
+		{4B799A42-DE84-4393-89E9-B7B1EFFFA02D}.Release|x86.ActiveCfg = Release|Any CPU
+		{4B799A42-DE84-4393-89E9-B7B1EFFFA02D}.Release|x86.Build.0 = Release|Any CPU
+		{254C6074-5012-4A10-BBA4-E14953766E7F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{254C6074-5012-4A10-BBA4-E14953766E7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{254C6074-5012-4A10-BBA4-E14953766E7F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{254C6074-5012-4A10-BBA4-E14953766E7F}.Debug|x64.Build.0 = Debug|Any CPU
+		{254C6074-5012-4A10-BBA4-E14953766E7F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{254C6074-5012-4A10-BBA4-E14953766E7F}.Debug|x86.Build.0 = Debug|Any CPU
+		{254C6074-5012-4A10-BBA4-E14953766E7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{254C6074-5012-4A10-BBA4-E14953766E7F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{254C6074-5012-4A10-BBA4-E14953766E7F}.Release|x64.ActiveCfg = Release|Any CPU
+		{254C6074-5012-4A10-BBA4-E14953766E7F}.Release|x64.Build.0 = Release|Any CPU
+		{254C6074-5012-4A10-BBA4-E14953766E7F}.Release|x86.ActiveCfg = Release|Any CPU
+		{254C6074-5012-4A10-BBA4-E14953766E7F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -247,5 +275,7 @@ Global
 		{B62BD46D-4C93-4406-B598-0A58714F1937} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{C480ADFF-F69D-4383-9A87-6300FC525F13} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{39F1F320-2266-487E-98D8-43BE0FECD0A4} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{4B799A42-DE84-4393-89E9-B7B1EFFFA02D} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{254C6074-5012-4A10-BBA4-E14953766E7F} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/docs/mcp-dev-companion.md
+++ b/docs/mcp-dev-companion.md
@@ -43,12 +43,14 @@ The server speaks MCP over **stdio**, so it is normally launched by an MCP clien
 hand). It locates the repository automatically by walking up to `NovaTerminal.sln`; you can
 override that with the `NOVATERMINAL_REPO_ROOT` environment variable.
 
-To sanity-check it manually:
+Build once, then run the built DLL (clients should point at the DLL, **not** `dotnet run` —
+`run` emits build/restore output to stdout, which corrupts the JSON-RPC stream):
 
 ```bash
 # from the repo root
-dotnet run --project src/NovaTerminal.McpServer
-# then type/pipe newline-delimited JSON-RPC (initialize, notifications/initialized, tools/list)
+dotnet build -c Release src/NovaTerminal.McpServer
+dotnet src/NovaTerminal.McpServer/bin/Release/net10.0/NovaTerminal.McpServer.dll
+# then pipe newline-delimited JSON-RPC (initialize, notifications/initialized, tools/list)
 ```
 
 ### Client configuration

--- a/docs/mcp-dev-companion.md
+++ b/docs/mcp-dev-companion.md
@@ -1,0 +1,65 @@
+# NovaTerminal MCP Dev Companion
+
+An **experimental, local, read-only** [MCP](https://modelcontextprotocol.io) server that exposes
+NovaTerminal's project knowledge (architecture, schemas, VT conformance, dev workflow) to AI coding
+agents in a structured way. It lives in `src/NovaTerminal.McpServer`.
+
+This is a **developer productivity tool**, not a user-facing terminal feature.
+
+## What it is
+
+- A stdio MCP server that AI agents (Claude Desktop, VS Code, etc.) can connect to.
+- Read-only: it reads repository docs and validates JSON against schemas.
+- Self-contained: it has **no project references** to the rest of the solution and pulls in no
+  terminal, SSH, or rendering code.
+
+## What it is NOT (v0.1 non-goals)
+
+It does **not**, and must not:
+
+- execute shell commands
+- open SSH connections
+- read live terminal buffers
+- access saved credentials or private keys
+- modify user profiles
+- control the running NovaTerminal app
+- require network access
+
+See [mcp/security.md](mcp/security.md) for the full security model.
+
+## Tools
+
+See [mcp/tools.md](mcp/tools.md). v0.1 exposes:
+
+`novaterminal.get_project_summary`, `novaterminal.get_architecture_map`,
+`novaterminal.list_docs`, `novaterminal.read_doc`,
+`novaterminal.get_vt_conformance_summary`,
+`novaterminal.get_theme_schema`, `novaterminal.validate_theme_json`,
+`novaterminal.generate_codex_prompt_for_issue`.
+
+## How to run it locally
+
+The server speaks MCP over **stdio**, so it is normally launched by an MCP client (not run by
+hand). It locates the repository automatically by walking up to `NovaTerminal.sln`; you can
+override that with the `NOVATERMINAL_REPO_ROOT` environment variable.
+
+To sanity-check it manually:
+
+```bash
+# from the repo root
+dotnet run --project src/NovaTerminal.McpServer
+# then type/pipe newline-delimited JSON-RPC (initialize, notifications/initialized, tools/list)
+```
+
+### Client configuration
+
+- Claude Desktop: [examples/mcp/claude_desktop_config.json](../examples/mcp/claude_desktop_config.json)
+- VS Code: [examples/mcp/vscode_mcp_config.json](../examples/mcp/vscode_mcp_config.json)
+
+Point `NOVATERMINAL_REPO_ROOT` at your clone so the doc-reading tools resolve.
+
+## Status / roadmap
+
+v0.1 is the read-only dev companion. Future phases (explicitly **out of scope** here) could add
+more VT/profile helpers and, only behind an opt-in bridge, read-only views of a running app. Any
+write/action capability must be opt-in and documented separately.

--- a/docs/mcp/security.md
+++ b/docs/mcp/security.md
@@ -1,0 +1,31 @@
+# NovaTerminal MCP Dev Companion — security model
+
+The v0.1 server is **local-only, read-only, and offline**. It is a development aid; it must never
+become an exfiltration or command-execution surface.
+
+## Guarantees (v0.1)
+
+- **No command execution.** The server contains no process-spawning code paths.
+- **No SSH / network.** It opens no sockets and requires no network access.
+- **No credentials / private keys.** It never reads the vault, profiles, `known_hosts`, or keys.
+- **No live terminal access.** It cannot see terminal buffers, tabs, or selections.
+- **Read-only filesystem access, confined to `docs/`.** File reads go through `RepoContext`, which:
+  - resolves a single repo root (env `NOVATERMINAL_REPO_ROOT`, or by walking up to `NovaTerminal.sln`);
+  - serves only files under `docs/`;
+  - canonicalizes every requested path and **rejects anything that escapes `docs/`** (e.g. `../`,
+    absolute paths). This is covered by tests (`RepoContextTests`).
+
+## Architectural enforcement
+
+- `NovaTerminal.McpServer` has **no `ProjectReference`s** to the rest of the solution, so it cannot
+  call into terminal, PTY, SSH, or rendering code even by accident.
+- It depends only on `ModelContextProtocol` and `Microsoft.Extensions.Hosting`.
+
+## Future capabilities (must stay opt-in)
+
+Any future tool that reads a running app's state (open tabs, active profile metadata, selected
+text) or performs writes/actions is **sensitive**. Such capabilities must:
+
+- be off by default and require explicit user opt-in,
+- be documented separately with their own threat model,
+- never expose credentials, private keys, or raw session contents.

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -1,0 +1,27 @@
+# NovaTerminal MCP Dev Companion — tools (v0.1)
+
+All tools are **read-only**. None execute commands, touch credentials, or access live sessions.
+
+| Tool | Inputs | Description |
+|------|--------|-------------|
+| `novaterminal.get_project_summary` | — | High-level summary: what NovaTerminal is, tech stack, assembly/module layout, key conventions. Orient here first. |
+| `novaterminal.get_architecture_map` | — | The authoritative module-ownership map (`docs/MODULE_OWNERSHIP.md`): per-assembly namespaces, dependencies, owned responsibilities, enforced invariants. |
+| `novaterminal.list_docs` | — | Lists Markdown docs under `docs/` (paths relative to `docs/`). |
+| `novaterminal.read_doc` | `path` | Reads a doc by its path relative to `docs/`. Reads are confined to `docs/`; paths outside it (e.g. `../secret`) are rejected. |
+| `novaterminal.get_vt_conformance_summary` | — | VT/ANSI conformance status and known terminal gaps, gathered from the repo's coverage/gap matrices. |
+| `novaterminal.get_theme_schema` | — | The theme JSON schema: required fields, accepted color formats, and an example. |
+| `novaterminal.validate_theme_json` | `themeJson` | Validates a theme JSON string against the schema; reports missing fields, invalid colors, and unknown fields. |
+| `novaterminal.generate_codex_prompt_for_issue` | `title`, `description?` | Generates a structured implementation prompt (relevant areas, constraints, PR size, steps, tests, acceptance, risks) tailored to NovaTerminal conventions. |
+
+## Notes
+
+- `get_architecture_map`, `list_docs`, `read_doc`, and `get_vt_conformance_summary` read files from
+  the repository; they need the repo root (auto-detected, or set `NOVATERMINAL_REPO_ROOT`).
+- `get_project_summary`, `get_theme_schema`, `validate_theme_json`, and
+  `generate_codex_prompt_for_issue` are fully self-contained (no filesystem access).
+
+## Tools intentionally deferred past v0.1
+
+`explain_escape_sequence`, `generate_vt_test_plan`, connection-profile schema/validation,
+`suggest_relevant_files`, `generate_test_plan_for_change`, and any "running app" bridge tools
+(`list_open_tabs`, `get_selected_text`, …). The latter are sensitive and must remain opt-in.

--- a/examples/mcp/claude_desktop_config.json
+++ b/examples/mcp/claude_desktop_config.json
@@ -1,13 +1,13 @@
 {
   "//": "Claude Desktop MCP config for the NovaTerminal MCP Dev Companion (read-only, local).",
+  "//build": "Build once first: dotnet build -c Release src/NovaTerminal.McpServer",
   "//paths": "Replace /absolute/path/to/nova2 with your local clone path.",
+  "//why-not-dotnet-run": "Use the built DLL, not 'dotnet run' — run emits build/restore output to stdout, which corrupts the MCP JSON-RPC stream.",
   "mcpServers": {
     "novaterminal-dev": {
       "command": "dotnet",
       "args": [
-        "run",
-        "--project",
-        "/absolute/path/to/nova2/src/NovaTerminal.McpServer"
+        "/absolute/path/to/nova2/src/NovaTerminal.McpServer/bin/Release/net10.0/NovaTerminal.McpServer.dll"
       ],
       "env": {
         "NOVATERMINAL_REPO_ROOT": "/absolute/path/to/nova2"

--- a/examples/mcp/claude_desktop_config.json
+++ b/examples/mcp/claude_desktop_config.json
@@ -1,0 +1,17 @@
+{
+  "//": "Claude Desktop MCP config for the NovaTerminal MCP Dev Companion (read-only, local).",
+  "//paths": "Replace /absolute/path/to/nova2 with your local clone path.",
+  "mcpServers": {
+    "novaterminal-dev": {
+      "command": "dotnet",
+      "args": [
+        "run",
+        "--project",
+        "/absolute/path/to/nova2/src/NovaTerminal.McpServer"
+      ],
+      "env": {
+        "NOVATERMINAL_REPO_ROOT": "/absolute/path/to/nova2"
+      }
+    }
+  }
+}

--- a/examples/mcp/vscode_mcp_config.json
+++ b/examples/mcp/vscode_mcp_config.json
@@ -1,0 +1,18 @@
+{
+  "//": "VS Code MCP config (.vscode/mcp.json) for the NovaTerminal MCP Dev Companion.",
+  "//paths": "Uses ${workspaceFolder}; works when the repo is opened as the workspace root.",
+  "servers": {
+    "novaterminal-dev": {
+      "type": "stdio",
+      "command": "dotnet",
+      "args": [
+        "run",
+        "--project",
+        "${workspaceFolder}/src/NovaTerminal.McpServer"
+      ],
+      "env": {
+        "NOVATERMINAL_REPO_ROOT": "${workspaceFolder}"
+      }
+    }
+  }
+}

--- a/examples/mcp/vscode_mcp_config.json
+++ b/examples/mcp/vscode_mcp_config.json
@@ -1,14 +1,13 @@
 {
   "//": "VS Code MCP config (.vscode/mcp.json) for the NovaTerminal MCP Dev Companion.",
-  "//paths": "Uses ${workspaceFolder}; works when the repo is opened as the workspace root.",
+  "//build": "Build once first: dotnet build -c Release src/NovaTerminal.McpServer",
+  "//why-not-dotnet-run": "Use the built DLL, not 'dotnet run' — run emits build/restore output to stdout, which corrupts the MCP JSON-RPC stream.",
   "servers": {
     "novaterminal-dev": {
       "type": "stdio",
       "command": "dotnet",
       "args": [
-        "run",
-        "--project",
-        "${workspaceFolder}/src/NovaTerminal.McpServer"
+        "${workspaceFolder}/src/NovaTerminal.McpServer/bin/Release/net10.0/NovaTerminal.McpServer.dll"
       ],
       "env": {
         "NOVATERMINAL_REPO_ROOT": "${workspaceFolder}"

--- a/src/NovaTerminal.McpServer/NovaTerminal.McpServer.csproj
+++ b/src/NovaTerminal.McpServer/NovaTerminal.McpServer.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    NovaTerminal MCP Dev Companion (#97): a local, read-only stdio MCP server that exposes
+    project knowledge to AI coding agents. Intentionally dependency-free of the rest of the
+    solution (no ProjectReferences) — it reads repo docs and validates JSON against a
+    self-contained schema, and must never touch terminal sessions, SSH, or credentials.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>NovaTerminal.McpServer</RootNamespace>
+    <AssemblyName>NovaTerminal.McpServer</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="NovaTerminal.McpServer.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/NovaTerminal.McpServer/Program.cs
+++ b/src/NovaTerminal.McpServer/Program.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NovaTerminal.McpServer;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+// CRITICAL for stdio transport: all logging must go to stderr. Anything written to stdout
+// corrupts the JSON-RPC stream the MCP client reads.
+builder.Logging.AddConsole(options => options.LogToStandardErrorThreshold = LogLevel.Trace);
+
+// Resolves the repository root once and provides path-safe, read-only access to docs.
+builder.Services.AddSingleton(RepoContext.Discover());
+
+builder.Services
+    .AddMcpServer()
+    .WithStdioServerTransport()
+    .WithToolsFromAssembly();
+
+await builder.Build().RunAsync();

--- a/src/NovaTerminal.McpServer/Program.cs
+++ b/src/NovaTerminal.McpServer/Program.cs
@@ -6,7 +6,10 @@ using NovaTerminal.McpServer;
 var builder = Host.CreateApplicationBuilder(args);
 
 // CRITICAL for stdio transport: all logging must go to stderr. Anything written to stdout
-// corrupts the JSON-RPC stream the MCP client reads.
+// corrupts the JSON-RPC stream the MCP client reads. Host.CreateApplicationBuilder registers a
+// default console logger that writes to stdout, so clear providers first, then add a single
+// console logger pinned to stderr.
+builder.Logging.ClearProviders();
 builder.Logging.AddConsole(options => options.LogToStandardErrorThreshold = LogLevel.Trace);
 
 // Resolves the repository root once and provides path-safe, read-only access to docs.

--- a/src/NovaTerminal.McpServer/RepoContext.cs
+++ b/src/NovaTerminal.McpServer/RepoContext.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace NovaTerminal.McpServer;
+
+/// <summary>
+/// Read-only, path-safe access to the NovaTerminal repository for the MCP Dev Companion.
+/// Resolves the repo root once (env override or by walking up to the solution file) and
+/// constrains all file reads to the <c>docs/</c> subtree — no traversal, no arbitrary FS access,
+/// matching the server's read-only/local-only security model (#97).
+/// </summary>
+public sealed class RepoContext
+{
+    public const string RepoRootEnvVar = "NOVATERMINAL_REPO_ROOT";
+    private const string SolutionFileName = "NovaTerminal.sln";
+
+    /// <summary>Absolute path to the repo root, or null if it could not be located.</summary>
+    public string? RepoRoot { get; }
+
+    internal RepoContext(string? repoRoot) => RepoRoot = repoRoot;
+
+    public static RepoContext Discover()
+    {
+        var fromEnv = System.Environment.GetEnvironmentVariable(RepoRootEnvVar);
+        if (!string.IsNullOrWhiteSpace(fromEnv) && Directory.Exists(fromEnv))
+        {
+            return new RepoContext(Path.GetFullPath(fromEnv));
+        }
+
+        // Walk up from the executable location looking for the solution file.
+        var dir = new DirectoryInfo(System.AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, SolutionFileName)))
+            {
+                return new RepoContext(dir.FullName);
+            }
+            dir = dir.Parent;
+        }
+
+        return new RepoContext(null);
+    }
+
+    public bool TryGetDocsDir(out string docsDir)
+    {
+        docsDir = RepoRoot is null ? string.Empty : Path.Combine(RepoRoot, "docs");
+        return RepoRoot is not null && Directory.Exists(docsDir);
+    }
+
+    /// <summary>Lists doc files (relative to <c>docs/</c>) with the given extensions.</summary>
+    public IReadOnlyList<string> ListDocs()
+    {
+        if (!TryGetDocsDir(out var docsDir)) return System.Array.Empty<string>();
+        return Directory
+            .EnumerateFiles(docsDir, "*.md", SearchOption.AllDirectories)
+            .Select(p => Path.GetRelativePath(docsDir, p).Replace('\\', '/'))
+            .OrderBy(p => p, System.StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Reads a doc by its path relative to <c>docs/</c>. Returns false (and a reason) if the repo
+    /// is unavailable, the path escapes <c>docs/</c>, or the file does not exist.
+    /// </summary>
+    public bool TryReadDoc(string relativePath, out string content, out string error)
+    {
+        content = string.Empty;
+        error = string.Empty;
+
+        if (!TryGetDocsDir(out var docsDir))
+        {
+            error = "Repository docs directory could not be located. " +
+                    $"Set the {RepoRootEnvVar} environment variable to the repo root.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(relativePath))
+        {
+            error = "A document path is required.";
+            return false;
+        }
+
+        // Resolve and confirm the result stays inside docs/ (block ../ traversal, absolute paths).
+        var full = Path.GetFullPath(Path.Combine(docsDir, relativePath));
+        var docsPrefix = docsDir.EndsWith(Path.DirectorySeparatorChar)
+            ? docsDir
+            : docsDir + Path.DirectorySeparatorChar;
+        if (!full.StartsWith(docsPrefix, System.StringComparison.Ordinal))
+        {
+            error = "Path is outside the docs/ directory and was rejected.";
+            return false;
+        }
+
+        if (!File.Exists(full))
+        {
+            error = $"Document '{relativePath}' was not found under docs/.";
+            return false;
+        }
+
+        content = File.ReadAllText(full);
+        return true;
+    }
+}

--- a/src/NovaTerminal.McpServer/RepoContext.cs
+++ b/src/NovaTerminal.McpServer/RepoContext.cs
@@ -82,11 +82,29 @@ public sealed class RepoContext
         }
 
         // Resolve and confirm the result stays inside docs/ (block ../ traversal, absolute paths).
-        var full = Path.GetFullPath(Path.Combine(docsDir, relativePath));
+        // GetFullPath can throw on malformed client input (invalid chars, too long) — treat as a
+        // rejected path rather than crashing the server.
+        string full;
+        try
+        {
+            full = Path.GetFullPath(Path.Combine(docsDir, relativePath));
+        }
+        catch (System.Exception ex) when (ex is System.ArgumentException
+            or System.IO.PathTooLongException or System.NotSupportedException)
+        {
+            error = "The provided path is invalid.";
+            return false;
+        }
+
         var docsPrefix = docsDir.EndsWith(Path.DirectorySeparatorChar)
             ? docsDir
             : docsDir + Path.DirectorySeparatorChar;
-        if (!full.StartsWith(docsPrefix, System.StringComparison.Ordinal))
+        // Windows/macOS file systems are case-insensitive, so use a platform-appropriate comparison
+        // to avoid rejecting valid paths that differ only in casing (e.g. drive letter).
+        var comparison = System.OperatingSystem.IsWindows() || System.OperatingSystem.IsMacOS()
+            ? System.StringComparison.OrdinalIgnoreCase
+            : System.StringComparison.Ordinal;
+        if (!full.StartsWith(docsPrefix, comparison))
         {
             error = "Path is outside the docs/ directory and was rejected.";
             return false;

--- a/src/NovaTerminal.McpServer/RepoContext.cs
+++ b/src/NovaTerminal.McpServer/RepoContext.cs
@@ -116,6 +116,23 @@ public sealed class RepoContext
             return false;
         }
 
+        // A symlink that lives under docs/ can still point outside it, bypassing the prefix check
+        // above. Resolve the final link target and confirm it too stays within docs/.
+        try
+        {
+            var finalTarget = new FileInfo(full).ResolveLinkTarget(returnFinalTarget: true);
+            if (finalTarget is not null &&
+                !Path.GetFullPath(finalTarget.FullName).StartsWith(docsPrefix, comparison))
+            {
+                error = "Path resolves through a symlink to outside the docs/ directory and was rejected.";
+                return false;
+            }
+        }
+        catch (System.IO.IOException)
+        {
+            // Not a link / not resolvable — fall through to a normal read.
+        }
+
         content = File.ReadAllText(full);
         return true;
     }

--- a/src/NovaTerminal.McpServer/Tools/ProjectTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/ProjectTools.cs
@@ -1,0 +1,75 @@
+using System.ComponentModel;
+using System.Linq;
+using ModelContextProtocol.Server;
+
+namespace NovaTerminal.McpServer.Tools;
+
+[McpServerToolType]
+public static class ProjectTools
+{
+    [McpServerTool(Name = "novaterminal.get_project_summary"),
+     Description("Returns a high-level summary of the NovaTerminal project: what it is, its tech stack, and its assembly/module layout. Use this first to orient before working in the codebase.")]
+    public static string GetProjectSummary() =>
+        """
+        # NovaTerminal — project summary
+
+        A cross-platform terminal emulator built on .NET 10 and Avalonia (UI) with SkiaSharp
+        (glyph/atlas rendering). It uses a custom, correctness-first VT/ANSI engine and a Rust
+        native PTY backend.
+
+        ## Tech stack
+        - .NET 10, C#
+        - Avalonia 12 (UI), SkiaSharp 3 (rendering)
+        - Rust native PTY (`librusty_pty`) via P/Invoke
+        - xUnit v3 tests; BenchmarkDotNet + SharpFuzz for perf/fuzzing
+
+        ## Assemblies (leaf → app)
+        - **NovaTerminal.VT** — VT/ANSI state machine, screen buffers, scrollback, lossless
+          reflow, cell/grapheme/Unicode width. Leaf (BCL only).
+        - **NovaTerminal.Replay** — record/replay of byte streams; golden-master harness. (→ VT)
+        - **NovaTerminal.Pty** — PTY session abstraction over the Rust backend.
+        - **NovaTerminal.Rendering** — Skia glyph cache/atlas, render snapshots, statistics.
+        - **NovaTerminal.Platform** — OS/SSH integration (native + external OpenSSH).
+        - **NovaTerminal.App** — Avalonia UI, panes/tabs, command assist, SFTP, theming.
+        - **NovaTerminal.Conformance / .Cli** — VT conformance reporting and CLI tooling.
+        - **NovaTerminal.McpServer** — this read-only MCP Dev Companion.
+
+        ## Key conventions
+        - Build via `scripts/build.{ps1,sh}` (not raw `dotnet`) — see CLAUDE.md.
+        - All `TerminalBuffer` reads require holding `TerminalBuffer.Lock`.
+        - Lossless reflow is a headline invariant — resize never silently drops content.
+        - For authoritative module boundaries/invariants, call `novaterminal.get_architecture_map`.
+        """;
+
+    [McpServerTool(Name = "novaterminal.get_architecture_map"),
+     Description("Returns the authoritative module-ownership / architecture map (docs/MODULE_OWNERSHIP.md): each assembly's namespace, dependencies, owned responsibilities, and enforced invariants.")]
+    public static string GetArchitectureMap(RepoContext repo)
+    {
+        if (repo.TryReadDoc("MODULE_OWNERSHIP.md", out var content, out var error))
+        {
+            return content;
+        }
+        return $"Architecture map unavailable: {error}";
+    }
+
+    [McpServerTool(Name = "novaterminal.list_docs"),
+     Description("Lists the Markdown documents available under the repository's docs/ directory (paths are relative to docs/). Use with novaterminal.read_doc.")]
+    public static string ListDocs(RepoContext repo)
+    {
+        var docs = repo.ListDocs();
+        if (docs.Count == 0)
+        {
+            return "No docs found (repository docs/ directory could not be located — set NOVATERMINAL_REPO_ROOT).";
+        }
+        return string.Join("\n", docs.Select(d => "- " + d));
+    }
+
+    [McpServerTool(Name = "novaterminal.read_doc"),
+     Description("Reads a Markdown document from the repository's docs/ directory by its path relative to docs/ (e.g. 'ThemeSystem.md'). Reads are confined to docs/ — paths outside it are rejected.")]
+    public static string ReadDoc(
+        RepoContext repo,
+        [Description("Path of the document relative to docs/, e.g. 'ThemeSystem.md' or 'plans/foo.md'.")] string path)
+    {
+        return repo.TryReadDoc(path, out var content, out var error) ? content : $"Error: {error}";
+    }
+}

--- a/src/NovaTerminal.McpServer/Tools/ThemeTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/ThemeTools.cs
@@ -1,0 +1,158 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using ModelContextProtocol.Server;
+
+namespace NovaTerminal.McpServer.Tools;
+
+[McpServerToolType]
+public static partial class ThemeTools
+{
+    // The 16 ANSI colors plus the 3 UI colors. All are required in a NovaTerminal theme JSON.
+    private static readonly string[] ColorFields =
+    {
+        "Foreground", "Background", "CursorColor",
+        "Black", "Red", "Green", "Yellow", "Blue", "Magenta", "Cyan", "White",
+        "BrightBlack", "BrightRed", "BrightGreen", "BrightYellow",
+        "BrightBlue", "BrightMagenta", "BrightCyan", "BrightWhite",
+    };
+
+    // Accept "#RGB", "#RRGGBB", "#RRGGBBAA" and the scRGB "sc#r,g,b[,a]" form used by JsonColorConverter.
+    [GeneratedRegex(@"^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$")]
+    private static partial Regex HexColorRegex();
+
+    [McpServerTool(Name = "novaterminal.get_theme_schema"),
+     Description("Returns the schema for a NovaTerminal theme JSON file: required fields (Name + 16 ANSI colors + Foreground/Background/CursorColor), the accepted color string format, and an example. Use before authoring or editing a theme.")]
+    public static string GetThemeSchema() =>
+        """
+        # NovaTerminal theme JSON schema
+
+        A theme is a JSON object. All fields below are required.
+
+        | Field | Type | Notes |
+        |-------|------|-------|
+        | `Name` | string | Display name, e.g. "Dracula". Non-empty. |
+        | `Foreground` | color | Default text color. |
+        | `Background` | color | Terminal background. |
+        | `CursorColor` | color | Cursor color. |
+        | `Black`,`Red`,`Green`,`Yellow`,`Blue`,`Magenta`,`Cyan`,`White` | color | Standard ANSI 0–7. |
+        | `BrightBlack`…`BrightWhite` | color | Bright ANSI 8–15 (same 8 names, `Bright`-prefixed). |
+
+        **Color format:** `#RGB`, `#RRGGBB`, or `#RRGGBBAA` (hex), or the scRGB `sc#r,g,b[,a]` form.
+
+        ## Example
+        ```json
+        {
+          "Name": "Dracula",
+          "Foreground": "#F8F8F2", "Background": "#282A36", "CursorColor": "#F8F8F2",
+          "Black": "#21222C", "Red": "#FF5555", "Green": "#50FA7B", "Yellow": "#F1FA8C",
+          "Blue": "#BD93F9", "Magenta": "#FF79C6", "Cyan": "#8BE9FD", "White": "#F8F8F2",
+          "BrightBlack": "#6272A4", "BrightRed": "#FF6E6E", "BrightGreen": "#69FF94",
+          "BrightYellow": "#FFFFA5", "BrightBlue": "#D6ACFF", "BrightMagenta": "#FF92DF",
+          "BrightCyan": "#A4FFFF", "BrightWhite": "#FFFFFF"
+        }
+        ```
+        """;
+
+    [McpServerTool(Name = "novaterminal.validate_theme_json"),
+     Description("Validates a NovaTerminal theme JSON string against the theme schema. Reports missing required fields, invalid color values, and unknown fields. Returns a structured pass/fail report.")]
+    public static string ValidateThemeJson(
+        [Description("The full theme JSON document to validate.")] string themeJson)
+    {
+        if (string.IsNullOrWhiteSpace(themeJson))
+        {
+            return "INVALID: empty input — expected a theme JSON object.";
+        }
+
+        JsonElement root;
+        try
+        {
+            using var doc = JsonDocument.Parse(themeJson);
+            root = doc.RootElement.Clone();
+        }
+        catch (JsonException ex)
+        {
+            return $"INVALID: not valid JSON — {ex.Message}";
+        }
+
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            return $"INVALID: top-level value must be a JSON object, but was {root.ValueKind}.";
+        }
+
+        var errors = new List<string>();
+        var warnings = new List<string>();
+
+        // Name
+        if (!root.TryGetProperty("Name", out var nameEl))
+        {
+            errors.Add("Missing required field 'Name'.");
+        }
+        else if (nameEl.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(nameEl.GetString()))
+        {
+            errors.Add("Field 'Name' must be a non-empty string.");
+        }
+
+        // Colors
+        foreach (var field in ColorFields)
+        {
+            if (!root.TryGetProperty(field, out var el))
+            {
+                errors.Add($"Missing required color field '{field}'.");
+                continue;
+            }
+            if (el.ValueKind != JsonValueKind.String)
+            {
+                errors.Add($"Field '{field}' must be a color string, but was {el.ValueKind}.");
+                continue;
+            }
+            var value = el.GetString() ?? string.Empty;
+            if (!IsValidColor(value))
+            {
+                errors.Add($"Field '{field}' has an invalid color value '{value}' (expected #RGB/#RRGGBB/#RRGGBBAA or sc#r,g,b).");
+            }
+        }
+
+        // Unknown fields → warnings (forward-compatible, not fatal)
+        var known = new HashSet<string>(ColorFields) { "Name" };
+        foreach (var prop in root.EnumerateObject())
+        {
+            if (!known.Contains(prop.Name))
+            {
+                warnings.Add($"Unknown field '{prop.Name}' (ignored).");
+            }
+        }
+
+        var sb = new StringBuilder();
+        sb.Append(errors.Count == 0 ? "VALID" : "INVALID").Append('\n');
+        if (errors.Count > 0)
+        {
+            sb.Append("\nErrors:\n");
+            foreach (var e in errors) sb.Append("  - ").Append(e).Append('\n');
+        }
+        if (warnings.Count > 0)
+        {
+            sb.Append("\nWarnings:\n");
+            foreach (var w in warnings) sb.Append("  - ").Append(w).Append('\n');
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    private static bool IsValidColor(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return false;
+        if (HexColorRegex().IsMatch(value)) return true;
+        // scRGB form: sc#r,g,b or sc#r,g,b,a with float components.
+        if (value.StartsWith("sc#", System.StringComparison.OrdinalIgnoreCase))
+        {
+            var parts = value[3..].Split(',');
+            return parts.Length is 3 or 4 &&
+                   parts.All(p => float.TryParse(p.Trim(), System.Globalization.NumberStyles.Float,
+                       System.Globalization.CultureInfo.InvariantCulture, out _));
+        }
+        return false;
+    }
+}

--- a/src/NovaTerminal.McpServer/Tools/VtTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/VtTools.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel;
+using System.Text;
+using ModelContextProtocol.Server;
+
+namespace NovaTerminal.McpServer.Tools;
+
+[McpServerToolType]
+public static class VtTools
+{
+    // Docs that describe VT coverage / known gaps, in preference order.
+    private static readonly string[] ConformanceDocs =
+    {
+        "vt_coverage_matrix.md",
+        "vt_ghostty_gap_matrix.md",
+        "TechnicalGapChecklist.md",
+    };
+
+    [McpServerTool(Name = "novaterminal.get_vt_conformance_summary"),
+     Description("Returns NovaTerminal's VT/ANSI conformance status and known terminal gaps, gathered from the repo's coverage/gap matrices (e.g. docs/vt_coverage_matrix.md). Use before changing parser/rendering behavior to understand what is and isn't supported.")]
+    public static string GetVtConformanceSummary(RepoContext repo)
+    {
+        var sb = new StringBuilder();
+        foreach (var doc in ConformanceDocs)
+        {
+            if (repo.TryReadDoc(doc, out var content, out _))
+            {
+                sb.Append("## Source: docs/").Append(doc).Append("\n\n");
+                sb.Append(content.TrimEnd()).Append("\n\n");
+            }
+        }
+
+        if (sb.Length == 0)
+        {
+            return "VT conformance documents could not be located. " +
+                   "Expected one of: docs/" + string.Join(", docs/", ConformanceDocs) +
+                   " (set NOVATERMINAL_REPO_ROOT if running outside the repo).";
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+}

--- a/src/NovaTerminal.McpServer/Tools/WorkflowTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/WorkflowTools.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using ModelContextProtocol.Server;
+
+namespace NovaTerminal.McpServer.Tools;
+
+[McpServerToolType]
+public static class WorkflowTools
+{
+    // Keyword → (relevant area, constraint) hints, used to tailor the generated prompt.
+    private static readonly (string[] Keywords, string Area)[] AreaHints =
+    {
+        (new[] { "ssh", "key", "auth", "connection", "jump host", "known_hosts" },
+            "SSH: NovaTerminal.Platform/Ssh (native + external OpenSSH) and NovaTerminal.App SSH UI/profiles."),
+        (new[] { "theme", "color", "palette" },
+            "Theming: NovaTerminal.App ThemeManager + docs/ThemeSystem.md; colors via TerminalTheme (NovaTerminal.VT). Validate with novaterminal.validate_theme_json."),
+        (new[] { "parser", "escape", "ansi", "csi", "osc", "dcs", "vt", "sequence" },
+            "VT/ANSI: NovaTerminal.VT/AnsiParser.cs. Check novaterminal.get_vt_conformance_summary first."),
+        (new[] { "reflow", "resize", "scrollback", "wrap" },
+            "Reflow/buffers: NovaTerminal.VT TerminalBuffer.*; lossless reflow is a headline invariant."),
+        (new[] { "render", "glyph", "atlas", "draw", "paint", "frame" },
+            "Rendering: NovaTerminal.Rendering (GlyphCache/Atlas) + NovaTerminal.App TerminalView/TerminalDrawOperation."),
+        (new[] { "pty", "shell", "process", "spawn" },
+            "PTY: NovaTerminal.Pty (Rust native backend via P/Invoke)."),
+        (new[] { "sftp", "transfer", "upload", "download" },
+            "SFTP: NovaTerminal.App SftpService (native transfer is in the Rust layer)."),
+        (new[] { "tab", "pane", "window", "layout" },
+            "UI shell: NovaTerminal.App MainWindow / TerminalPane."),
+    };
+
+    [McpServerTool(Name = "novaterminal.generate_codex_prompt_for_issue"),
+     Description("Generates a structured implementation prompt for a NovaTerminal issue/task. Given a title and description, returns relevant code areas, architectural constraints, suggested PR size, implementation steps, tests to update, acceptance criteria, and risks — tailored to NovaTerminal's conventions.")]
+    public static string GenerateCodexPromptForIssue(
+        [Description("Short title of the issue/task, e.g. 'Improve SSH key authentication UX'.")] string title,
+        [Description("Optional fuller description / acceptance notes for the task.")] string description = "")
+    {
+        string haystack = (title + " " + description).ToLowerInvariant();
+        var areas = AreaHints
+            .Where(h => h.Keywords.Any(k => haystack.Contains(k, System.StringComparison.Ordinal)))
+            .Select(h => h.Area)
+            .ToList();
+        if (areas.Count == 0)
+        {
+            areas.Add("Could not auto-map to a subsystem — call novaterminal.get_architecture_map and novaterminal.get_project_summary to locate the relevant module.");
+        }
+
+        var sb = new StringBuilder();
+        sb.Append("# Implementation prompt: ").Append(title.Trim()).Append("\n\n");
+
+        if (!string.IsNullOrWhiteSpace(description))
+        {
+            sb.Append("## Context\n").Append(description.Trim()).Append("\n\n");
+        }
+
+        sb.Append("## Relevant areas\n");
+        foreach (var a in areas) sb.Append("- ").Append(a).Append('\n');
+
+        sb.Append(
+            """
+
+            ## Architectural constraints
+            - Build/test only via `scripts/build.{ps1,sh}` (never raw `dotnet`) — see CLAUDE.md.
+            - Respect module boundaries (novaterminal.get_architecture_map): NovaTerminal.VT is a
+              leaf (BCL only); Pty/Replay/Rendering must not reference UI/App.
+            - All `TerminalBuffer` reads require holding `TerminalBuffer.Lock`.
+            - Lossless reflow must be preserved; alternate-screen isolation must be preserved.
+            - No secrets, private keys, or shell execution introduced into read-only/data paths.
+
+            ## Suggested PR size
+            - Prefer one focused change with tests. If it spans multiple assemblies or changes a
+              public contract, split into reviewable commits.
+
+            ## Implementation steps
+            1. Reproduce / characterize current behavior (add a failing test where applicable).
+            2. Make the minimal change in the owning assembly.
+            3. Add/extend unit tests (prefer NovaTerminal.VT.Tests for VT logic; project-specific
+               test projects otherwise).
+            4. Run the targeted test project, then a broader build, via the wrapper scripts.
+
+            ## Tests to update
+            - Unit tests in the owning assembly's test project.
+            - Replay/regression suites if parser/rendering/reflow behavior changes.
+
+            ## Acceptance criteria
+            - Behavior matches the task description; tests cover the new/changed behavior.
+            - No regressions in the relevant test suites; build is clean.
+
+            ## Risks
+            - Concurrency around `TerminalBuffer.Lock` (re-entrancy: see docs/MODULE_OWNERSHIP.md).
+            - Hostile-input robustness (the VT layer ingests untrusted byte streams).
+            - Cross-platform differences (Windows ConPTY vs Unix PTY; rendering backends).
+            """);
+
+        return sb.ToString().TrimEnd();
+    }
+}

--- a/src/NovaTerminal.McpServer/Tools/WorkflowTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/WorkflowTools.cs
@@ -36,6 +36,9 @@ public static class WorkflowTools
         [Description("Short title of the issue/task, e.g. 'Improve SSH key authentication UX'.")] string title,
         [Description("Optional fuller description / acceptance notes for the task.")] string description = "")
     {
+        // External client input may be null despite the signature — normalize defensively.
+        title ??= string.Empty;
+        description ??= string.Empty;
         string haystack = (title + " " + description).ToLowerInvariant();
         var areas = AreaHints
             .Where(h => h.Keywords.Any(k => haystack.Contains(k, System.StringComparison.Ordinal)))

--- a/tests/NovaTerminal.McpServer.Tests/NovaTerminal.McpServer.Tests.csproj
+++ b/tests/NovaTerminal.McpServer.Tests/NovaTerminal.McpServer.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NovaTerminal.McpServer\NovaTerminal.McpServer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/NovaTerminal.McpServer.Tests/ThemeToolsTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/ThemeToolsTests.cs
@@ -1,0 +1,86 @@
+using NovaTerminal.McpServer.Tools;
+
+namespace NovaTerminal.McpServer.Tests;
+
+public class ThemeToolsTests
+{
+    private const string ValidTheme = """
+        {
+          "Name": "Dracula",
+          "Foreground": "#F8F8F2", "Background": "#282A36", "CursorColor": "#F8F8F2",
+          "Black": "#21222C", "Red": "#FF5555", "Green": "#50FA7B", "Yellow": "#F1FA8C",
+          "Blue": "#BD93F9", "Magenta": "#FF79C6", "Cyan": "#8BE9FD", "White": "#F8F8F2",
+          "BrightBlack": "#6272A4", "BrightRed": "#FF6E6E", "BrightGreen": "#69FF94",
+          "BrightYellow": "#FFFFA5", "BrightBlue": "#D6ACFF", "BrightMagenta": "#FF92DF",
+          "BrightCyan": "#A4FFFF", "BrightWhite": "#FFFFFF"
+        }
+        """;
+
+    [Fact]
+    public void ValidTheme_PassesValidation()
+    {
+        var result = ThemeTools.ValidateThemeJson(ValidTheme);
+        Assert.StartsWith("VALID", result);
+        Assert.DoesNotContain("Errors:", result);
+    }
+
+    [Fact]
+    public void MissingColorField_IsReported()
+    {
+        var missing = ValidTheme.Replace("\"BrightWhite\": \"#FFFFFF\"", "\"BrightWhite\": \"#FFFFFF\"".Replace("\"BrightWhite\"", "\"NotBrightWhite\""));
+        var result = ThemeTools.ValidateThemeJson(missing);
+        Assert.StartsWith("INVALID", result);
+        Assert.Contains("Missing required color field 'BrightWhite'", result);
+        // The renamed field is unknown -> reported as a warning, not fatal on its own.
+        Assert.Contains("Unknown field 'NotBrightWhite'", result);
+    }
+
+    [Fact]
+    public void InvalidColorValue_IsReported()
+    {
+        var bad = ValidTheme.Replace("\"Red\": \"#FF5555\"", "\"Red\": \"not-a-color\"");
+        var result = ThemeTools.ValidateThemeJson(bad);
+        Assert.StartsWith("INVALID", result);
+        Assert.Contains("Field 'Red' has an invalid color value", result);
+    }
+
+    [Theory]
+    [InlineData("#abc")]
+    [InlineData("#AABBCC")]
+    [InlineData("#aabbccdd")]
+    [InlineData("sc#1,0.5,0.25")]
+    [InlineData("sc#1,0.5,0.25,1")]
+    public void AcceptedColorFormats_AreValid(string color)
+    {
+        var theme = ValidTheme.Replace("\"Red\": \"#FF5555\"", $"\"Red\": \"{color}\"");
+        var result = ThemeTools.ValidateThemeJson(theme);
+        Assert.StartsWith("VALID", result);
+    }
+
+    [Fact]
+    public void NonJson_IsRejected()
+    {
+        Assert.StartsWith("INVALID", ThemeTools.ValidateThemeJson("not json {"));
+    }
+
+    [Fact]
+    public void Empty_IsRejected()
+    {
+        Assert.StartsWith("INVALID", ThemeTools.ValidateThemeJson(""));
+    }
+
+    [Fact]
+    public void NonObjectTopLevel_IsRejected()
+    {
+        Assert.StartsWith("INVALID", ThemeTools.ValidateThemeJson("[1,2,3]"));
+    }
+
+    [Fact]
+    public void Schema_DescribesRequiredFields()
+    {
+        var schema = ThemeTools.GetThemeSchema();
+        Assert.Contains("Name", schema);
+        Assert.Contains("BrightWhite", schema);
+        Assert.Contains("#RRGGBB", schema);
+    }
+}

--- a/tests/NovaTerminal.McpServer.Tests/WorkflowAndRepoTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/WorkflowAndRepoTests.cs
@@ -1,0 +1,89 @@
+using System.IO;
+using NovaTerminal.McpServer;
+using NovaTerminal.McpServer.Tools;
+
+namespace NovaTerminal.McpServer.Tests;
+
+public class WorkflowToolsTests
+{
+    [Fact]
+    public void Prompt_IncludesStructuredSections()
+    {
+        var prompt = WorkflowTools.GenerateCodexPromptForIssue("Improve SSH key authentication UX", "Add a key provisioning wizard.");
+        Assert.Contains("## Relevant areas", prompt);
+        Assert.Contains("## Architectural constraints", prompt);
+        Assert.Contains("## Acceptance criteria", prompt);
+        Assert.Contains("## Risks", prompt);
+    }
+
+    [Fact]
+    public void Prompt_MapsKeywordsToSubsystems()
+    {
+        var ssh = WorkflowTools.GenerateCodexPromptForIssue("SSH key auth", "");
+        Assert.Contains("SSH:", ssh);
+
+        var theme = WorkflowTools.GenerateCodexPromptForIssue("New theme palette", "");
+        Assert.Contains("Theming:", theme);
+
+        var parser = WorkflowTools.GenerateCodexPromptForIssue("Handle a new CSI escape sequence", "");
+        Assert.Contains("VT/ANSI:", parser);
+    }
+
+    [Fact]
+    public void Prompt_UnmappedTopic_FallsBackToArchitectureGuidance()
+    {
+        var prompt = WorkflowTools.GenerateCodexPromptForIssue("Refactor the gizmo widget", "");
+        Assert.Contains("get_architecture_map", prompt);
+    }
+
+    [Fact]
+    public void ProjectSummary_IsNonEmpty()
+    {
+        Assert.Contains("NovaTerminal", ProjectTools.GetProjectSummary());
+    }
+}
+
+public class RepoContextTests
+{
+    [Fact]
+    public void ReadDoc_ConfinedToDocs_RejectsTraversal()
+    {
+        string root = Path.Combine(Path.GetTempPath(), "nova-mcp-test-" + System.Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, "docs"));
+            File.WriteAllText(Path.Combine(root, "docs", "Hello.md"), "# hello");
+            File.WriteAllText(Path.Combine(root, "secret.txt"), "top secret");
+
+            var repo = new RepoContext(root);
+
+            // Valid doc reads.
+            Assert.True(repo.TryReadDoc("Hello.md", out var content, out _));
+            Assert.Equal("# hello", content);
+
+            // Traversal out of docs/ is rejected.
+            Assert.False(repo.TryReadDoc("../secret.txt", out _, out var error));
+            Assert.Contains("outside the docs/ directory", error);
+
+            // Missing file reports cleanly.
+            Assert.False(repo.TryReadDoc("Nope.md", out _, out var missingError));
+            Assert.Contains("was not found", missingError);
+
+            // Listing finds the doc.
+            Assert.Contains("Hello.md", repo.ListDocs());
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void NoRepoRoot_ReportsUnavailable()
+    {
+        var repo = new RepoContext(null);
+        Assert.False(repo.TryReadDoc("Hello.md", out _, out var error));
+        Assert.Contains("could not be located", error);
+        Assert.Empty(repo.ListDocs());
+    }
+}

--- a/tests/NovaTerminal.McpServer.Tests/WorkflowAndRepoTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/WorkflowAndRepoTests.cs
@@ -41,6 +41,13 @@ public class WorkflowToolsTests
     {
         Assert.Contains("NovaTerminal", ProjectTools.GetProjectSummary());
     }
+
+    [Fact]
+    public void NullInputs_DoNotThrow()
+    {
+        var prompt = WorkflowTools.GenerateCodexPromptForIssue(null!, null!);
+        Assert.Contains("# Implementation prompt:", prompt);
+    }
 }
 
 public class RepoContextTests
@@ -68,6 +75,10 @@ public class RepoContextTests
             // Missing file reports cleanly.
             Assert.False(repo.TryReadDoc("Nope.md", out _, out var missingError));
             Assert.Contains("was not found", missingError);
+
+            // Malformed path (embedded null) is rejected gracefully, not thrown.
+            Assert.False(repo.TryReadDoc("bad\0name.md", out _, out var badError));
+            Assert.Contains("invalid", badError);
 
             // Listing finds the doc.
             Assert.Contains("Hello.md", repo.ListDocs());


### PR DESCRIPTION
## Summary
Closes #97. Adds **`src/NovaTerminal.McpServer`** — a local, read-only [MCP](https://modelcontextprotocol.io) server that exposes NovaTerminal project knowledge to AI coding agents. Deliberately **isolated**: no `ProjectReference`s to the rest of the solution (depends only on `ModelContextProtocol` + `Microsoft.Extensions.Hosting`), so it cannot reach terminal/SSH/render code even by accident.

## v0.1 tools (all read-only)
`get_project_summary`, `get_architecture_map`, `list_docs`, `read_doc`, `get_vt_conformance_summary`, `get_theme_schema`, `validate_theme_json`, `generate_codex_prompt_for_issue` (the 6 required by the acceptance criteria + `list_docs`/`read_doc`).

- **RepoContext** resolves the repo root (`NOVATERMINAL_REPO_ROOT` env or by walking up to `NovaTerminal.sln`) and **confines all file reads to `docs/`**, rejecting `../` traversal and absolute paths.
- **Theme schema + validation** are self-contained against the documented format (no coupling to App/VT types).
- **Docs**: `docs/mcp-dev-companion.md`, `docs/mcp/tools.md`, `docs/mcp/security.md`. **Example configs**: Claude Desktop + VS Code under `examples/mcp/`.

## Security model (v0.1)
Local-only, read-only, offline: no shell execution, SSH, credential/private-key access, or live terminal access. Enforced by having no solution `ProjectReference`s and by the `docs/`-confined, traversal-rejecting reader. Future app-bridge tools must stay opt-in (documented in `security.md`).

## Verification
- **Build**: McpServer compiles clean; `ModelContextProtocol` 1.4.0 + `Microsoft.Extensions.Hosting` added to central package management.
- **Live stdio handshake**: an `initialize` → `tools/list` run over stdio returns proper capabilities and serves **all 8 tools**.
- **Unit tests** (18, new `NovaTerminal.McpServer.Tests`): theme validation (valid/missing/bad-color/non-JSON/accepted formats), schema content, prompt-generation sections + keyword→subsystem mapping, and `RepoContext` path-traversal rejection / docs confinement.
- Architecture tests are unaffected (both use hardcoded assembly lists; McpServer's namespace doesn't collide).

## Scope notes
v0.1 per the issue's acceptance criteria. Deferred tools (`explain_escape_sequence`, profile schema/validation, `suggest_relevant_files`, any running-app bridge) are listed in `docs/mcp/tools.md` as future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)