### PR TITLE
feat: MCP Dev Companion v0.2 — explain_escape_sequence, generate_vt_test_plan, suggest_relevant_files

### DIFF
--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -9,9 +9,12 @@ All tools are **read-only**. None execute commands, touch credentials, or access
 | `novaterminal.list_docs` | — | Lists Markdown docs under `docs/` (paths relative to `docs/`). |
 | `novaterminal.read_doc` | `path` | Reads a doc by its path relative to `docs/`. Reads are confined to `docs/`; paths outside it (e.g. `../secret`) are rejected. |
 | `novaterminal.get_vt_conformance_summary` | — | VT/ANSI conformance status and known terminal gaps, gathered from the repo's coverage/gap matrices. |
+| `novaterminal.explain_escape_sequence` | `sequence` | Explains a VT/ANSI escape sequence (e.g. `ESC[2J`, `CSI ?25h`, `OSC 8`, `ESC c`) — name and what it does in NovaTerminal. |
+| `novaterminal.generate_vt_test_plan` | `feature` | Generates a structured VT/ANSI test plan (cases, where tests live, verification) for a parser/rendering feature. |
 | `novaterminal.get_theme_schema` | — | The theme JSON schema: required fields, accepted color formats, and an example. |
 | `novaterminal.validate_theme_json` | `themeJson` | Validates a theme JSON string against the schema; reports missing fields, invalid colors, and unknown fields. |
 | `novaterminal.generate_codex_prompt_for_issue` | `title`, `description?` | Generates a structured implementation prompt (relevant areas, constraints, PR size, steps, tests, acceptance, risks) tailored to NovaTerminal conventions. |
+| `novaterminal.suggest_relevant_files` | `topic` | Suggests the concrete source/test files most relevant to a topic/task (e.g. `reflow`, `glyph atlas`, `ssh key auth`). |
 
 ## Notes
 
@@ -20,8 +23,13 @@ All tools are **read-only**. None execute commands, touch credentials, or access
 - `get_project_summary`, `get_theme_schema`, `validate_theme_json`, and
   `generate_codex_prompt_for_issue` are fully self-contained (no filesystem access).
 
-## Tools intentionally deferred past v0.1
+## Still deferred
 
-`explain_escape_sequence`, `generate_vt_test_plan`, connection-profile schema/validation,
-`suggest_relevant_files`, `generate_test_plan_for_change`, and any "running app" bridge tools
-(`list_open_tabs`, `get_selected_text`, …). The latter are sensitive and must remain opt-in.
+- **Connection-profile schema/validation** (`get_connection_profile_schema`,
+  `validate_connection_profile_json`): unlike themes, the profile format has no stable documented
+  schema, is large (~37 fields incl. enums/nested rules), and contains a sensitive `Password`
+  field — deferred until a documented profile schema exists, to avoid drift and over-coupling.
+- **`generate_test_plan_for_change`**: largely covered by `generate_codex_prompt_for_issue`
+  (its "tests to update" section) and `generate_vt_test_plan`.
+- **Running-app bridge tools** (`list_open_tabs`, `get_active_profile_metadata`,
+  `get_selected_text`, …): sensitive; must remain opt-in and documented separately.

--- a/src/NovaTerminal.McpServer/Tools/VtTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/VtTools.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text;
 using ModelContextProtocol.Server;
@@ -37,5 +38,151 @@ public static class VtTools
         }
 
         return sb.ToString().TrimEnd();
+    }
+
+    // Curated explanations for the most common control sequences, keyed by a normalized token.
+    // CSI entries are keyed by final byte ("CSI:J"); OSC by numeric code ("OSC:0"); a few ESC/DCS.
+    private static readonly Dictionary<string, string> SequenceTable = new()
+    {
+        ["CSI:A"] = "CUU — Cursor Up Ps times.",
+        ["CSI:B"] = "CUD — Cursor Down Ps times.",
+        ["CSI:C"] = "CUF — Cursor Forward Ps times.",
+        ["CSI:D"] = "CUB — Cursor Back Ps times.",
+        ["CSI:E"] = "CNL — Cursor Next Line Ps times (column 1).",
+        ["CSI:F"] = "CPL — Cursor Previous Line Ps times (column 1).",
+        ["CSI:G"] = "CHA — Cursor Horizontal Absolute to column Ps.",
+        ["CSI:H"] = "CUP — Cursor Position to row;col (1-based).",
+        ["CSI:J"] = "ED — Erase in Display (0=below, 1=above, 2=all, 3=all+scrollback).",
+        ["CSI:K"] = "EL — Erase in Line (0=right, 1=left, 2=whole line).",
+        ["CSI:L"] = "IL — Insert Ps blank lines.",
+        ["CSI:M"] = "DL — Delete Ps lines.",
+        ["CSI:P"] = "DCH — Delete Ps characters (count clamped to the line width).",
+        ["CSI:S"] = "SU — Scroll Up Ps lines (count clamped, see #124).",
+        ["CSI:T"] = "SD — Scroll Down Ps lines.",
+        ["CSI:X"] = "ECH — Erase Ps characters.",
+        ["CSI:@"] = "ICH — Insert Ps blank characters.",
+        ["CSI:b"] = "REP — Repeat the preceding character Ps times (count clamped).",
+        ["CSI:d"] = "VPA — Line Position Absolute (row Ps).",
+        ["CSI:m"] = "SGR — Select Graphic Rendition (colors/bold/underline/etc.).",
+        ["CSI:r"] = "DECSTBM — Set Top/Bottom margins (scroll region).",
+        ["CSI:h"] = "SM / DECSET — Set (mode/private mode), e.g. ?1049h = alt screen, ?25h = show cursor, ?2004h = bracketed paste.",
+        ["CSI:l"] = "RM / DECRST — Reset (mode/private mode), e.g. ?1049l = leave alt screen, ?25l = hide cursor.",
+        ["CSI:n"] = "DSR — Device Status Report (e.g. 6n = cursor position report).",
+        ["CSI:c"] = "DA — Device Attributes (primary/secondary).",
+        ["CSI:q"] = "DECSCUSR (with space intermediate) — set cursor style.",
+        ["OSC:0"] = "Set icon name and window title.",
+        ["OSC:2"] = "Set window title.",
+        ["OSC:7"] = "Report current working directory (file:// URI).",
+        ["OSC:8"] = "Hyperlink (OSC 8 ; params ; URI ST … ST).",
+        ["OSC:52"] = "Clipboard get/set (base64).",
+        ["OSC:133"] = "Shell integration markers (A=prompt, B=cmd start, C=cmd accepted, D=cmd finished).",
+        ["OSC:1337"] = "iTerm2 proprietary (incl. inline images: 1337;File=…).",
+        ["OSC:1339"] = "Tunneled Sixel/Kitty image payload.",
+        ["ESC:c"] = "RIS — Reset to Initial State (full terminal reset).",
+        ["ESC:7"] = "DECSC — Save cursor.",
+        ["ESC:8"] = "DECRC — Restore cursor.",
+        ["ESC:M"] = "RI — Reverse Index (scroll down if at top).",
+        ["DCS"] = "Device Control String — used by NovaTerminal for Sixel images (… q … ST).",
+        ["APC"] = "Application Program Command — used by NovaTerminal for Kitty graphics (ESC _ G … ST).",
+    };
+
+    [McpServerTool(Name = "novaterminal.explain_escape_sequence"),
+     Description("Explains a VT/ANSI escape sequence. Accepts forms like 'ESC[2J', '\\x1b[2J', 'CSI 2 J', 'CSI ?25h', 'OSC 7', or 'ESC c'. Returns the sequence name and what it does in NovaTerminal.")]
+    public static string ExplainEscapeSequence(
+        [Description("The escape sequence to explain, e.g. 'ESC[2J', 'CSI ?1049h', 'OSC 8', 'ESC c'.")] string sequence)
+    {
+        if (string.IsNullOrWhiteSpace(sequence))
+        {
+            return "Provide a sequence, e.g. 'ESC[2J', 'CSI ?25h', 'OSC 7', or 'ESC c'.";
+        }
+
+        // Normalize common notations to a canonical introducer + body.
+        string s = sequence.Trim()
+            .Replace("", "ESC", System.StringComparison.Ordinal)
+            .Replace("\\x1b", "ESC", System.StringComparison.OrdinalIgnoreCase)
+            .Replace("\\e", "ESC", System.StringComparison.OrdinalIgnoreCase);
+
+        string upper = s.ToUpperInvariant();
+
+        // CSI: "ESC[" or "CSI"
+        string? csiBody = null;
+        if (upper.StartsWith("ESC[", System.StringComparison.Ordinal)) csiBody = s.Substring(4);
+        else if (upper.StartsWith("CSI", System.StringComparison.Ordinal)) csiBody = s.Substring(3);
+        if (csiBody is not null)
+        {
+            // Final byte is the last non-space char in the body.
+            string body = csiBody.Trim();
+            if (body.Length == 0) return "Incomplete CSI sequence (no final byte).";
+            char finalByte = body[^1];
+            string key = "CSI:" + finalByte;
+            return SequenceTable.TryGetValue(key, out var desc)
+                ? $"CSI sequence, final byte '{finalByte}': {desc}"
+                : $"CSI sequence with final byte '{finalByte}': not in the curated table. Params: '{body[..^1]}'.";
+        }
+
+        // OSC: "ESC]" or "OSC"
+        string? oscBody = null;
+        if (upper.StartsWith("ESC]", System.StringComparison.Ordinal)) oscBody = s.Substring(4);
+        else if (upper.StartsWith("OSC", System.StringComparison.Ordinal)) oscBody = s.Substring(3);
+        if (oscBody is not null)
+        {
+            string body = oscBody.Trim().TrimStart(' ');
+            // Leading numeric code up to ';' or space.
+            int i = 0;
+            while (i < body.Length && char.IsDigit(body[i])) i++;
+            string code = body[..i];
+            string key = "OSC:" + code;
+            return SequenceTable.TryGetValue(key, out var desc)
+                ? $"OSC {code}: {desc}"
+                : $"OSC sequence (code '{code}'): not in the curated table.";
+        }
+
+        // ESC Fe / simple ESC sequences: "ESC c", "ESC 7", "ESC M"
+        if (upper.StartsWith("ESC", System.StringComparison.Ordinal))
+        {
+            string rest = s.Substring(3).Trim();
+            if (rest.Length > 0)
+            {
+                string key = "ESC:" + rest[0];
+                if (SequenceTable.TryGetValue(key, out var desc))
+                    return $"ESC {rest[0]}: {desc}";
+            }
+        }
+
+        if (upper.StartsWith("DCS", System.StringComparison.Ordinal)) return "DCS: " + SequenceTable["DCS"];
+        if (upper.StartsWith("APC", System.StringComparison.Ordinal)) return "APC: " + SequenceTable["APC"];
+
+        return $"Unrecognized sequence '{sequence}'. Use forms like 'ESC[2J', 'CSI ?25h', 'OSC 7', 'ESC c', 'DCS', or 'APC'.";
+    }
+
+    [McpServerTool(Name = "novaterminal.generate_vt_test_plan"),
+     Description("Generates a structured VT/ANSI test plan for a parser/rendering feature or sequence: cases to cover (parsing, state, reflow, edge cases), where tests live, and how to verify against conformance.")]
+    public static string GenerateVtTestPlan(
+        [Description("The VT feature or sequence under test, e.g. 'OSC 8 hyperlinks' or 'DECSTBM scroll region'.")] string feature)
+    {
+        feature ??= string.Empty;
+        return $$"""
+        # VT test plan: {{feature.Trim()}}
+
+        ## Cases to cover
+        - Happy path: well-formed sequence(s) produce the expected buffer/cursor state.
+        - Parameter handling: default (omitted) params, multiple params, and clamped/oversized
+          params (CSI numeric params are capped — see #124).
+        - Split across writes: the sequence arrives in fragments across multiple Process() calls.
+        - Malformed/partial: truncated or invalid sequences must not throw and must recover so
+          following text renders (see AnsiParserHardeningTests).
+        - Interaction with reflow: behavior survives a resize (lossless reflow invariant, #123).
+        - Alt screen vs main screen, and scrollback, where relevant.
+
+        ## Where tests live
+        - Pure parser/buffer behavior → tests/NovaTerminal.VT.Tests/.
+        - Replay/regression (real byte streams) → tests/NovaTerminal.App.Tests/ReplayTests/.
+        - Reflow scenarios → tests/NovaTerminal.App.Tests/ReflowScenariosTests.cs and BufferTests/.
+
+        ## Verification
+        - Drive input via AnsiParser.Process and assert on TerminalBuffer state under the read lock.
+        - Cross-check against novaterminal.get_vt_conformance_summary for known gaps/expectations.
+        - For hostile-input robustness, consider a case in the SharpFuzz harness (#124).
+        """;
     }
 }

--- a/src/NovaTerminal.McpServer/Tools/VtTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/VtTools.cs
@@ -74,7 +74,7 @@ public static class VtTools
         ["OSC:2"] = "Set window title.",
         ["OSC:7"] = "Report current working directory (file:// URI).",
         ["OSC:8"] = "Hyperlink (OSC 8 ; params ; URI ST … ST).",
-        ["OSC:52"] = "Clipboard get/set (base64).",
+        ["OSC:52"] = "Clipboard get/set (base64). NOT currently supported by NovaTerminal — HandleOsc ignores OSC 52 (see docs/vt_coverage_matrix.md).",
         ["OSC:133"] = "Shell integration markers (A=prompt, B=cmd start, C=cmd accepted, D=cmd finished).",
         ["OSC:1337"] = "iTerm2 proprietary (incl. inline images: 1337;File=…).",
         ["OSC:1339"] = "Tunneled Sixel/Kitty image payload.",

--- a/src/NovaTerminal.McpServer/Tools/VtTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/VtTools.cs
@@ -104,9 +104,10 @@ public static class VtTools
 
         string upper = s.ToUpperInvariant();
 
-        // CSI: "ESC[" or "CSI"
+        // CSI: "ESC[", "ESC [" or "CSI"
         string? csiBody = null;
         if (upper.StartsWith("ESC[", System.StringComparison.Ordinal)) csiBody = s.Substring(4);
+        else if (upper.StartsWith("ESC [", System.StringComparison.Ordinal)) csiBody = s.Substring(5);
         else if (upper.StartsWith("CSI", System.StringComparison.Ordinal)) csiBody = s.Substring(3);
         if (csiBody is not null)
         {
@@ -120,9 +121,10 @@ public static class VtTools
                 : $"CSI sequence with final byte '{finalByte}': not in the curated table. Params: '{body[..^1]}'.";
         }
 
-        // OSC: "ESC]" or "OSC"
+        // OSC: "ESC]", "ESC ]" or "OSC"
         string? oscBody = null;
         if (upper.StartsWith("ESC]", System.StringComparison.Ordinal)) oscBody = s.Substring(4);
+        else if (upper.StartsWith("ESC ]", System.StringComparison.Ordinal)) oscBody = s.Substring(5);
         else if (upper.StartsWith("OSC", System.StringComparison.Ordinal)) oscBody = s.Substring(3);
         if (oscBody is not null)
         {
@@ -137,7 +139,20 @@ public static class VtTools
                 : $"OSC sequence (code '{code}'): not in the curated table.";
         }
 
-        // ESC Fe / simple ESC sequences: "ESC c", "ESC 7", "ESC M"
+        // DCS: literal "DCS" or the 7-bit introducer ESC P ("ESCP" / "ESC P"). Check before the
+        // generic ESC handling so the 'P' isn't misread as a simple ESC sequence.
+        if (upper.StartsWith("DCS", System.StringComparison.Ordinal)
+            || upper.StartsWith("ESCP", System.StringComparison.Ordinal)
+            || upper.StartsWith("ESC P", System.StringComparison.Ordinal))
+            return "DCS: " + SequenceTable["DCS"];
+
+        // APC: literal "APC" or the 7-bit introducer ESC _ ("ESC_" / "ESC _").
+        if (upper.StartsWith("APC", System.StringComparison.Ordinal)
+            || upper.StartsWith("ESC_", System.StringComparison.Ordinal)
+            || upper.StartsWith("ESC _", System.StringComparison.Ordinal))
+            return "APC: " + SequenceTable["APC"];
+
+        // Other ESC Fe / simple ESC sequences: "ESC c", "ESC 7", "ESC M".
         if (upper.StartsWith("ESC", System.StringComparison.Ordinal))
         {
             string rest = s.Substring(3).Trim();
@@ -148,9 +163,6 @@ public static class VtTools
                     return $"ESC {rest[0]}: {desc}";
             }
         }
-
-        if (upper.StartsWith("DCS", System.StringComparison.Ordinal)) return "DCS: " + SequenceTable["DCS"];
-        if (upper.StartsWith("APC", System.StringComparison.Ordinal)) return "APC: " + SequenceTable["APC"];
 
         return $"Unrecognized sequence '{sequence}'. Use forms like 'ESC[2J', 'CSI ?25h', 'OSC 7', 'ESC c', 'DCS', or 'APC'.";
     }

--- a/src/NovaTerminal.McpServer/Tools/VtTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/VtTools.cs
@@ -48,8 +48,8 @@ public static class VtTools
         ["CSI:B"] = "CUD — Cursor Down Ps times.",
         ["CSI:C"] = "CUF — Cursor Forward Ps times.",
         ["CSI:D"] = "CUB — Cursor Back Ps times.",
-        ["CSI:E"] = "CNL — Cursor Next Line Ps times (column 1).",
-        ["CSI:F"] = "CPL — Cursor Previous Line Ps times (column 1).",
+        ["CSI:E"] = "CNL — Cursor Next Line Ps times (column 1). NOT currently handled by NovaTerminal's parser.",
+        ["CSI:F"] = "CPL — Cursor Previous Line Ps times (column 1). NOT currently handled by NovaTerminal's parser.",
         ["CSI:G"] = "CHA — Cursor Horizontal Absolute to column Ps.",
         ["CSI:H"] = "CUP — Cursor Position to row;col (1-based).",
         ["CSI:J"] = "ED — Erase in Display (0=below, 1=above, 2=all, 3=all+scrollback).",
@@ -61,7 +61,7 @@ public static class VtTools
         ["CSI:T"] = "SD — Scroll Down Ps lines.",
         ["CSI:X"] = "ECH — Erase Ps characters.",
         ["CSI:@"] = "ICH — Insert Ps blank characters.",
-        ["CSI:b"] = "REP — Repeat the preceding character Ps times (count clamped).",
+        ["CSI:b"] = "REP — Repeat the preceding character Ps times. NOT currently handled by NovaTerminal's parser (it has no REP handler; CSI params are clamped generically but the sequence is a no-op).",
         ["CSI:d"] = "VPA — Line Position Absolute (row Ps).",
         ["CSI:m"] = "SGR — Select Graphic Rendition (colors/bold/underline/etc.).",
         ["CSI:r"] = "DECSTBM — Set Top/Bottom margins (scroll region).",
@@ -87,7 +87,7 @@ public static class VtTools
     };
 
     [McpServerTool(Name = "novaterminal.explain_escape_sequence"),
-     Description("Explains a VT/ANSI escape sequence. Accepts forms like 'ESC[2J', '\\x1b[2J', 'CSI 2 J', 'CSI ?25h', 'OSC 7', or 'ESC c'. Returns the sequence name and what it does in NovaTerminal.")]
+     Description("Explains a VT/ANSI escape sequence (standard meaning). Accepts forms like 'ESC[2J', '\\x1b[2J', 'CSI 2 J', 'CSI ?25h', 'OSC 7', or 'ESC c'. Entries note where NovaTerminal does NOT handle a sequence; for the authoritative support matrix use novaterminal.get_vt_conformance_summary.")]
     public static string ExplainEscapeSequence(
         [Description("The escape sequence to explain, e.g. 'ESC[2J', 'CSI ?1049h', 'OSC 8', 'ESC c'.")] string sequence)
     {

--- a/src/NovaTerminal.McpServer/Tools/VtTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/VtTools.cs
@@ -111,14 +111,23 @@ public static class VtTools
         else if (upper.StartsWith("CSI", System.StringComparison.Ordinal)) csiBody = s.Substring(3);
         if (csiBody is not null)
         {
-            // Final byte is the last non-space char in the body.
-            string body = csiBody.Trim();
+            // Strip whitespace the user added for readability ("CSI 2 J") so it isn't mistaken for
+            // an intermediate byte. Real intermediates are punctuation (0x21–0x2F) and survive.
+            string body = new string(csiBody.Where(c => !char.IsWhiteSpace(c)).ToArray());
             if (body.Length == 0) return "Incomplete CSI sequence (no final byte).";
             char finalByte = body[^1];
-            string key = "CSI:" + finalByte;
-            return SequenceTable.TryGetValue(key, out var desc)
-                ? $"CSI sequence, final byte '{finalByte}': {desc}"
-                : $"CSI sequence with final byte '{finalByte}': not in the curated table. Params: '{body[..^1]}'.";
+            string prefix = body[..^1]; // leader/params + any intermediate bytes
+
+            // The curated table is keyed by final byte only, but intermediate bytes can select a
+            // different function (e.g. DECSCUSR is `CSI Ps SP q`), so surface them explicitly.
+            string intermediates = new string(prefix.Where(c => c >= '\x21' && c <= '\x2F').ToArray());
+            string note = intermediates.Length > 0
+                ? $" [intermediate byte(s) '{intermediates}' present — may select a different function than the bare final byte]"
+                : string.Empty;
+
+            return SequenceTable.TryGetValue("CSI:" + finalByte, out var desc)
+                ? $"CSI sequence, final byte '{finalByte}'{note}: {desc}"
+                : $"CSI sequence with final byte '{finalByte}'{note}: not in the curated table. Params/intermediates: '{prefix}'.";
         }
 
         // OSC: "ESC]", "ESC ]" or "OSC"

--- a/src/NovaTerminal.McpServer/Tools/WorkflowTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/WorkflowTools.cs
@@ -98,4 +98,72 @@ public static class WorkflowTools
 
         return sb.ToString().TrimEnd();
     }
+
+    // Topic keyword → concrete files worth opening for that area.
+    private static readonly (string[] Keywords, string[] Files)[] FileHints =
+    {
+        (new[] { "reflow", "resize", "wrap" }, new[] {
+            "src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs",
+            "src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs",
+            "tests/NovaTerminal.App.Tests/ReflowScenariosTests.cs",
+            "tests/NovaTerminal.VT.Tests/ReflowEdgeCaseTests.cs" }),
+        (new[] { "scrollback" }, new[] {
+            "src/NovaTerminal.VT/Buffer/ScrollbackPages.cs",
+            "src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs" }),
+        (new[] { "parser", "escape", "ansi", "csi", "osc", "dcs", "apc", "sequence" }, new[] {
+            "src/NovaTerminal.VT/AnsiParser.cs",
+            "tests/NovaTerminal.App.Tests/AnsiParserHardeningTests.cs",
+            "tests/NovaTerminal.VT.Tests/CsiParamClampTests.cs" }),
+        (new[] { "theme", "color", "palette" }, new[] {
+            "src/NovaTerminal.VT/TerminalTheme.cs",
+            "src/NovaTerminal.App/Core/ThemeManager.cs",
+            "docs/ThemeSystem.md" }),
+        (new[] { "glyph", "atlas", "render", "draw", "paint" }, new[] {
+            "src/NovaTerminal.Rendering/GlyphCache.cs",
+            "src/NovaTerminal.Rendering/GlyphAtlas.cs",
+            "src/NovaTerminal.App/Shell/TerminalDrawOperation.cs",
+            "src/NovaTerminal.App/Shell/TerminalView.cs" }),
+        (new[] { "pty", "spawn", "process" }, new[] {
+            "src/NovaTerminal.Pty/RustPtySession.cs" }),
+        (new[] { "ssh", "key", "auth", "connection", "jump" }, new[] {
+            "src/NovaTerminal.App/Shell/TerminalProfile.cs",
+            "src/NovaTerminal.Platform/Ssh/",
+            "docs/SSH_ROADMAP.md" }),
+        (new[] { "sftp", "transfer", "upload", "download" }, new[] {
+            "src/NovaTerminal.App/Shell/SftpService.cs" }),
+        (new[] { "log", "logging", "logger" }, new[] {
+            "src/NovaTerminal.VT/TerminalLogger.cs" }),
+        (new[] { "tab", "pane", "window", "layout" }, new[] {
+            "src/NovaTerminal.App/MainWindow.axaml.cs",
+            "src/NovaTerminal.App/Controls/TerminalPane.axaml.cs" }),
+        (new[] { "fuzz", "robustness" }, new[] {
+            "tests/NovaTerminal.Benchmarks/FuzzTarget.cs",
+            "tests/NovaTerminal.VT.Tests/FuzzSmokeTests.cs" }),
+    };
+
+    [McpServerTool(Name = "novaterminal.suggest_relevant_files"),
+     Description("Given a topic or task description, suggests the concrete NovaTerminal source/test files most relevant to it (e.g. 'reflow', 'OSC 8 hyperlinks', 'theme validation'). Start here to find where to work.")]
+    public static string SuggestRelevantFiles(
+        [Description("The topic or task, e.g. 'reflow edge cases', 'glyph atlas', 'ssh key auth'.")] string topic)
+    {
+        topic ??= string.Empty;
+        string haystack = topic.ToLowerInvariant();
+
+        var files = FileHints
+            .Where(h => h.Keywords.Any(k => haystack.Contains(k, System.StringComparison.Ordinal)))
+            .SelectMany(h => h.Files)
+            .Distinct()
+            .ToList();
+
+        if (files.Count == 0)
+        {
+            return "No direct file mapping for that topic. Call novaterminal.get_architecture_map " +
+                   "to find the owning assembly, then novaterminal.list_docs / read_doc.";
+        }
+
+        var sb = new StringBuilder();
+        sb.Append("Relevant files for \"").Append(topic.Trim()).Append("\":\n");
+        foreach (var f in files) sb.Append("- ").Append(f).Append('\n');
+        return sb.ToString().TrimEnd();
+    }
 }

--- a/src/NovaTerminal.McpServer/Tools/WorkflowTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/WorkflowTools.cs
@@ -116,7 +116,7 @@ public static class WorkflowTools
             "tests/NovaTerminal.VT.Tests/CsiParamClampTests.cs" }),
         (new[] { "theme", "color", "palette" }, new[] {
             "src/NovaTerminal.VT/TerminalTheme.cs",
-            "src/NovaTerminal.App/Core/ThemeManager.cs",
+            "src/NovaTerminal.App/Shell/ThemeManager.cs",
             "docs/ThemeSystem.md" }),
         (new[] { "glyph", "atlas", "render", "draw", "paint" }, new[] {
             "src/NovaTerminal.Rendering/GlyphCache.cs",

--- a/tests/NovaTerminal.McpServer.Tests/V2ToolsTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/V2ToolsTests.cs
@@ -43,6 +43,24 @@ public class ExplainEscapeSequenceTests
     }
 
     [Fact]
+    public void CsiIntermediateBytes_AreSurfaced()
+    {
+        // A real (punctuation) intermediate byte must be surfaced, e.g. DECSTR `CSI ! p`.
+        var result = VtTools.ExplainEscapeSequence("CSI ! p");
+        Assert.Contains("intermediate", result, System.StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("!", result, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormattingSpaces_AreNotTreatedAsIntermediates()
+    {
+        // "CSI 2 J" has only a formatting space; it must resolve to ED with no intermediate note.
+        var result = VtTools.ExplainEscapeSequence("CSI 2 J");
+        Assert.Contains("ED", result, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("intermediate byte", result, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void UnknownCsiFinalByte_IsReportedGracefully()
     {
         var result = VtTools.ExplainEscapeSequence("CSI 1 ~");

--- a/tests/NovaTerminal.McpServer.Tests/V2ToolsTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/V2ToolsTests.cs
@@ -26,6 +26,14 @@ public class ExplainEscapeSequenceTests
     }
 
     [Fact]
+    public void Osc52_IsMarkedUnsupported()
+    {
+        // NovaTerminal's AnsiParser does not handle OSC 52; the explainer must not imply it does.
+        var result = VtTools.ExplainEscapeSequence("OSC 52");
+        Assert.Contains("NOT currently supported", result, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void UnknownCsiFinalByte_IsReportedGracefully()
     {
         var result = VtTools.ExplainEscapeSequence("CSI 1 ~");

--- a/tests/NovaTerminal.McpServer.Tests/V2ToolsTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/V2ToolsTests.cs
@@ -33,6 +33,15 @@ public class ExplainEscapeSequenceTests
         Assert.Contains("NOT currently supported", result, System.StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData("CSI E")] // CNL — not in HandleCsi
+    [InlineData("CSI F")] // CPL — not in HandleCsi
+    [InlineData("CSI b")] // REP — no handler
+    public void UnhandledCsiSequences_AreMarkedUnsupported(string seq)
+    {
+        Assert.Contains("NOT currently handled", VtTools.ExplainEscapeSequence(seq), System.StringComparison.Ordinal);
+    }
+
     [Fact]
     public void UnknownCsiFinalByte_IsReportedGracefully()
     {

--- a/tests/NovaTerminal.McpServer.Tests/V2ToolsTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/V2ToolsTests.cs
@@ -1,0 +1,85 @@
+using NovaTerminal.McpServer.Tools;
+
+namespace NovaTerminal.McpServer.Tests;
+
+public class ExplainEscapeSequenceTests
+{
+    [Theory]
+    [InlineData("ESC[2J", "ED")]
+    [InlineData("\\x1b[2J", "ED")]
+    [InlineData("CSI 2 J", "ED")]
+    [InlineData("CSI H", "CUP")]
+    [InlineData("CSI ?25h", "DECSET")]      // final byte 'h'
+    [InlineData("CSI m", "SGR")]
+    [InlineData("OSC 7", "working directory")]
+    [InlineData("OSC 8", "Hyperlink")]
+    [InlineData("ESC c", "RIS")]
+    public void RecognizesCommonSequences(string seq, string expectedSubstring)
+    {
+        Assert.Contains(expectedSubstring, VtTools.ExplainEscapeSequence(seq), System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void UnknownCsiFinalByte_IsReportedGracefully()
+    {
+        var result = VtTools.ExplainEscapeSequence("CSI 1 ~");
+        Assert.Contains("final byte", result, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Empty_PromptsForInput()
+    {
+        Assert.Contains("Provide a sequence", VtTools.ExplainEscapeSequence(""));
+    }
+
+    [Fact]
+    public void Garbage_IsRejectedGracefully()
+    {
+        Assert.Contains("Unrecognized", VtTools.ExplainEscapeSequence("hello world"));
+    }
+}
+
+public class VtTestPlanTests
+{
+    [Fact]
+    public void TestPlan_IncludesKeySectionsAndFeature()
+    {
+        var plan = VtTools.GenerateVtTestPlan("OSC 8 hyperlinks");
+        Assert.Contains("OSC 8 hyperlinks", plan, System.StringComparison.Ordinal);
+        Assert.Contains("## Cases to cover", plan, System.StringComparison.Ordinal);
+        Assert.Contains("## Where tests live", plan, System.StringComparison.Ordinal);
+        Assert.Contains("## Verification", plan, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TestPlan_NullFeature_DoesNotThrow()
+    {
+        Assert.Contains("VT test plan", VtTools.GenerateVtTestPlan(null!));
+    }
+}
+
+public class SuggestRelevantFilesTests
+{
+    [Theory]
+    [InlineData("reflow edge cases", "TerminalBuffer.ReflowEngine.cs")]
+    [InlineData("glyph atlas overflow", "GlyphAtlas.cs")]
+    [InlineData("ssh key auth", "TerminalProfile.cs")]
+    [InlineData("OSC parser sequence", "AnsiParser.cs")]
+    public void MapsTopicToFiles(string topic, string expectedFile)
+    {
+        Assert.Contains(expectedFile, WorkflowTools.SuggestRelevantFiles(topic), System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UnmappedTopic_FallsBackToArchitectureGuidance()
+    {
+        Assert.Contains("get_architecture_map", WorkflowTools.SuggestRelevantFiles("the gizmo widget"));
+    }
+
+    [Fact]
+    public void NullTopic_DoesNotThrow()
+    {
+        // No keyword match → fallback guidance; must not throw.
+        Assert.Contains("architecture", WorkflowTools.SuggestRelevantFiles(null!), System.StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/NovaTerminal.McpServer.Tests/V2ToolsTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/V2ToolsTests.cs
@@ -14,6 +14,12 @@ public class ExplainEscapeSequenceTests
     [InlineData("OSC 7", "working directory")]
     [InlineData("OSC 8", "Hyperlink")]
     [InlineData("ESC c", "RIS")]
+    [InlineData("ESC [ 2 J", "ED")]          // space form
+    [InlineData("ESC ] 7", "working directory")]
+    [InlineData("ESC P q", "DCS")]           // 7-bit DCS introducer
+    [InlineData("ESCP", "DCS")]              // no-space DCS introducer
+    [InlineData("ESC _ G", "APC")]           // 7-bit APC introducer
+    [InlineData("ESC_Ga=T", "APC")]          // no-space APC (Kitty)
     public void RecognizesCommonSequences(string seq, string expectedSubstring)
     {
         Assert.Contains(expectedSubstring, VtTools.ExplainEscapeSequence(seq), System.StringComparison.OrdinalIgnoreCase);
@@ -65,6 +71,7 @@ public class SuggestRelevantFilesTests
     [InlineData("glyph atlas overflow", "GlyphAtlas.cs")]
     [InlineData("ssh key auth", "TerminalProfile.cs")]
     [InlineData("OSC parser sequence", "AnsiParser.cs")]
+    [InlineData("theme validation", "src/NovaTerminal.App/Shell/ThemeManager.cs")] // correct path
     public void MapsTopicToFiles(string topic, string expectedFile)
     {
         Assert.Contains(expectedFile, WorkflowTools.SuggestRelevantFiles(topic), System.StringComparison.Ordinal);


### PR DESCRIPTION
## Summary
Follow-up to #97 (now merged). Adds three more **read-only, self-contained** tools to `NovaTerminal.McpServer`, drawing down the issue''s deferred-tool list:

- **`novaterminal.explain_escape_sequence`** — accepts `ESC[2J`, `\x1b[2J`, `CSI ?25h`, `OSC 8`, `ESC c`, `DCS`, `APC`, etc.; identifies the introducer + final byte / OSC code and explains it from a curated table, with NovaTerminal-specific notes (e.g. CSI param clamping from #124).
- **`novaterminal.generate_vt_test_plan`** — a structured VT/ANSI test plan (cases to cover, where tests live, how to verify against conformance) for a given feature/sequence.
- **`novaterminal.suggest_relevant_files`** — maps a topic (`reflow`, `glyph atlas`, `ssh key auth`, …) to the concrete source/test files to open.

The server now serves **11 tools**.

## Deliberately still deferred
- **Connection-profile schema/validation**: unlike themes (stable, documented in `ThemeSystem.md`), `TerminalProfile` has ~37 fields incl. enums, nested `ForwardingRule`, and a sensitive `Password` — a self-contained validator would drift and over-reach. Deferred until a documented profile schema exists (noted in `docs/mcp/tools.md`).
- `generate_test_plan_for_change` — already covered by `generate_codex_prompt_for_issue` + `generate_vt_test_plan`.
- Running-app bridge tools — sensitive, opt-in only.

## Verification
- **stdio handshake** serves all 11 tools (verified).
- **39 unit tests pass** (20 new): escape-sequence recognition across CSI/OSC/ESC forms + graceful handling of unknown/empty/garbage; VT test-plan sections; topic→file mapping + fallback; null-input safety.
- All tools remain read-only/self-contained; no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)