### PR TITLE
fix: emit back-tab (ESC [ Z) for Shift+Tab

### DIFF
--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -1823,7 +1823,7 @@ namespace NovaTerminal
             {
                 case Key.Enter: sequence = "\r"; return true;
                 case Key.Back: sequence = "\x7f"; return true;
-                case Key.Tab: sequence = "\t"; return true;
+                case Key.Tab: sequence = isShift ? "\x1b[Z" : "\t"; return true;
                 case Key.Escape: sequence = "\x1b"; return true;
             }
 

--- a/src/NovaTerminal.App/Shell/TerminalView.cs
+++ b/src/NovaTerminal.App/Shell/TerminalView.cs
@@ -164,7 +164,10 @@ namespace NovaTerminal.Shell
                     BackspaceObserved?.Invoke();
                     return true;
                 case Key.Tab:
-                    _session.SendInput("\t");
+                    // Shift+Tab must emit the back-tab (CBT) sequence ESC [ Z, exactly as
+                    // xterm does. TUIs like Claude Code rely on it for reverse navigation
+                    // (e.g. cycling permission modes backward); a literal tab breaks that.
+                    _session.SendInput((keyModifiers & KeyModifiers.Shift) != 0 ? "\x1b[Z" : "\t");
                     return true;
                 case Key.Escape:
                     _session.SendInput("\x1b");

--- a/tests/NovaTerminal.App.Tests/CommandAssist/TerminalViewKeyHandlingTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/TerminalViewKeyHandlingTests.cs
@@ -55,6 +55,23 @@ public sealed class TerminalViewKeyHandlingTests
     }
 
     [AvaloniaFact]
+    public void HandleKeyDownCore_WhenShiftTabPressed_SendsBackTabSequenceNotLiteralTab()
+    {
+        // Regression: Shift+Tab must emit the back-tab (CBT) sequence ESC [ Z, matching
+        // xterm. The unconditional Key.Tab case used to swallow the Shift modifier and send
+        // a literal tab, which broke Claude Code's reverse permission-mode cycling.
+        var session = new Mock<ITerminalSession>();
+        var view = new TerminalView();
+        view.SetSession(session.Object);
+
+        bool handled = view.HandleKeyDownCore(Key.Tab, KeyModifiers.Shift);
+
+        Assert.True(handled);
+        session.Verify(x => x.SendInput("\x1b[Z"), Times.Once);
+        session.Verify(x => x.SendInput("\t"), Times.Never);
+    }
+
+    [AvaloniaFact]
     public void HandleKeyDownCore_WhenSessionNotRunning_DoesNotConsumeEnter_SoPaneCanReconnect()
     {
         // Regression: after an SSH disconnect the dead session object is kept around so the


### PR DESCRIPTION
@
## Problem

Shift+Tab does not work in TUIs like Claude Code when run inside NovaTerminal — e.g. it fails to cycle permission modes backward.

## Root cause

`TerminalView.HandleKeyDownCore` handled `Key.Tab` by sending a literal tab `"\t"` **unconditionally**, silently dropping the Shift modifier. xterm emits the back-tab / CBT sequence `ESC [ Z` (`\x1b[Z`) for Shift+Tab, and Claude Code (among other TUIs) listens for exactly that to navigate in reverse. Since NovaTerminal never produced it, Shift+Tab just inserted a tab character.

The same bug existed in `MainWindow.TryMapBroadcastKey`, the path used when broadcasting input to sibling panes.

## Fix

Both paths now check the Shift modifier:
- Shift+Tab → `\x1b[Z` (back-tab)
- Tab → `\t` (unchanged)

## Tests

- Added regression test `HandleKeyDownCore_WhenShiftTabPressed_SendsBackTabSequenceNotLiteralTab` asserting `\x1b[Z` is sent and `\t` is not.
- Existing plain-Tab test still passes (normal Tab path unchanged).
- `TerminalViewKeyHandlingTests`: 12/12 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@