### PR TITLE
feat(mcp): connection-profile schema & validation tools + server README (v0.3)

### DIFF
--- a/docs/mcp-dev-companion.md
+++ b/docs/mcp-dev-companion.md
@@ -29,13 +29,10 @@ See [mcp/security.md](mcp/security.md) for the full security model.
 
 ## Tools
 
-See [mcp/tools.md](mcp/tools.md). v0.1 exposes:
+See [mcp/tools.md](mcp/tools.md) for the authoritative list. As of v0.3 this includes the
+connection-profile tools:
 
-`novaterminal.get_project_summary`, `novaterminal.get_architecture_map`,
-`novaterminal.list_docs`, `novaterminal.read_doc`,
-`novaterminal.get_vt_conformance_summary`,
-`novaterminal.get_theme_schema`, `novaterminal.validate_theme_json`,
-`novaterminal.generate_codex_prompt_for_issue`.
+`novaterminal.get_connection_profile_schema`, `novaterminal.validate_connection_profile_json`.
 
 ## How to run it locally
 

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -1,4 +1,4 @@
-# NovaTerminal MCP Dev Companion — tools (v0.1)
+# NovaTerminal MCP Dev Companion — tools (v0.3)
 
 All tools are **read-only**. None execute commands, touch credentials, or access live sessions.
 
@@ -13,6 +13,8 @@ All tools are **read-only**. None execute commands, touch credentials, or access
 | `novaterminal.generate_vt_test_plan` | `feature` | Generates a structured VT/ANSI test plan (cases, where tests live, verification) for a parser/rendering feature. |
 | `novaterminal.get_theme_schema` | — | The theme JSON schema: required fields, accepted color formats, and an example. |
 | `novaterminal.validate_theme_json` | `themeJson` | Validates a theme JSON string against the schema; reports missing fields, invalid colors, and unknown fields. |
+| `novaterminal.get_connection_profile_schema` | — | The SSH connection-profile JSON schema: PascalCase fields by area, integer enum mappings, defaults, and an example. Accepts a single profile or a full `profiles.json` document. |
+| `novaterminal.validate_connection_profile_json` | `profileJson` | Validates a connection-profile JSON (single profile or full document; auto-detected); reports wrong types, out-of-range integer enums/ports, missing `Name`/`Host`, and warns on unknown fields and any stray `Password`. |
 | `novaterminal.generate_codex_prompt_for_issue` | `title`, `description?` | Generates a structured implementation prompt (relevant areas, constraints, PR size, steps, tests, acceptance, risks) tailored to NovaTerminal conventions. |
 | `novaterminal.suggest_relevant_files` | `topic` | Suggests the concrete source/test files most relevant to a topic/task (e.g. `reflow`, `glyph atlas`, `ssh key auth`). |
 
@@ -25,10 +27,6 @@ All tools are **read-only**. None execute commands, touch credentials, or access
 
 ## Still deferred
 
-- **Connection-profile schema/validation** (`get_connection_profile_schema`,
-  `validate_connection_profile_json`): unlike themes, the profile format has no stable documented
-  schema, is large (~37 fields incl. enums/nested rules), and contains a sensitive `Password`
-  field — deferred until a documented profile schema exists, to avoid drift and over-coupling.
 - **`generate_test_plan_for_change`**: largely covered by `generate_codex_prompt_for_issue`
   (its "tests to update" section) and `generate_vt_test_plan`.
 - **Running-app bridge tools** (`list_open_tabs`, `get_active_profile_metadata`,

--- a/docs/superpowers/plans/2026-06-28-mcp-connection-profile-tools.md
+++ b/docs/superpowers/plans/2026-06-28-mcp-connection-profile-tools.md
@@ -1,0 +1,1064 @@
+# MCP Connection-Profile Schema & Validation Tools — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two read-only MCP tools — `novaterminal.get_connection_profile_schema` and `novaterminal.validate_connection_profile_json` — to the NovaTerminal MCP Dev Companion, targeting the real on-disk SSH connection-profile format.
+
+**Architecture:** A new static tool class `ConnectionProfileTools` in `src/NovaTerminal.McpServer`, mirroring the existing `ThemeTools` pattern (`[McpServerToolType]` / `[McpServerTool]`, `string` return, `System.Text.Json` parsing). The server keeps its no-`ProjectReference` isolation, so field/enum knowledge is hand-mirrored from `SshProfile`; a reflection-based drift-guard test in the *test* project (which gains a test-only `ProjectReference` to `NovaTerminal.Platform`) fails if `SshProfile` changes.
+
+**Tech Stack:** C# / .NET 10, `ModelContextProtocol` SDK, `System.Text.Json`, xUnit v3.
+
+## Global Constraints
+
+- **Build/test only via wrappers:** `scripts/build.ps1 <args>` (PowerShell) or `scripts/build.sh <args>` (bash). Never raw `dotnet build`/`dotnet test` (it hangs when stdout is captured).
+- **Server isolation:** `src/NovaTerminal.McpServer` must NOT gain any `ProjectReference`. Field/enum knowledge is hand-written. (The *test* project may reference `NovaTerminal.Platform` — that is the only new cross-project edge allowed.)
+- **Wire format is verified fact:** on-disk profile JSON uses **PascalCase keys** and **integer-valued enums** (`SshJsonContext` sets only `WriteIndented`; no naming policy, no string-enum converter). Do not use camelCase or string enums anywhere.
+- **Report format matches `ThemeTools`:** output starts with `VALID` or `INVALID`; an `Errors:` block and/or `Warnings:` block follow, each line `  - <message>`; trailing whitespace trimmed. Validity = zero errors (warnings never fail).
+- **Tool names exactly:** `novaterminal.get_connection_profile_schema`, `novaterminal.validate_connection_profile_json`.
+- **TargetFramework** is centralized in `Directory.Build.props` (`net10.0`); do not add it to csproj files.
+- Commit after each task.
+
+**Reference — exact source-of-truth types** (`src/NovaTerminal.Platform/Ssh/Models/`):
+- `SshProfile` props (21): `Id, BackendKind, Name, GroupPath, Notes, AccentColor, Tags, Host, User, Port, AuthMode, IdentityFilePath, RememberPasswordInVault, JumpHops, Forwards, MuxOptions, ServerAliveIntervalSeconds, ServerAliveCountMax, ExtraSshArgs, WorkingDirectory, RemoteShellKind`
+- `SshJumpHop` props (3): `Host, User, Port`
+- `PortForward` props (5): `Kind, BindAddress, SourcePort, DestinationHost, DestinationPort`
+- `SshMuxOptions` props (4): `Enabled, ControlMasterAuto, ControlPath, ControlPersistSeconds`
+- `SshProfileStoreSnapshot` props (2, public, namespace `NovaTerminal.Platform.Ssh.Storage`): `SchemaVersion, Profiles`
+- Enums: `SshBackendKind {OpenSsh=0, Native=1}` (ns `NovaTerminal.Platform.Ssh.Models`); `SshAuthMode {Default=0, Agent=1, IdentityFile=2}` (ns `…Ssh.Models`); `PortForwardKind {Local=0, Remote=1, Dynamic=2}` (ns `…Ssh.Models`); `RemoteShellKind {Auto=0, Bash=1, Zsh=2, Fish=3, Pwsh=4}` (ns `NovaTerminal.Platform`)
+
+---
+
+### Task 1: Schema tool (`get_connection_profile_schema`)
+
+**Files:**
+- Create: `src/NovaTerminal.McpServer/Tools/ConnectionProfileTools.cs`
+- Test: `tests/NovaTerminal.McpServer.Tests/ConnectionProfileToolsTests.cs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `public static string ConnectionProfileTools.GetConnectionProfileSchema()` — returns the descriptive schema text including a fenced ` ```json ` example. The class is `public static` and annotated `[McpServerToolType]`. (Task 2 adds `ValidateConnectionProfileJson` to the same class; Task 3's drift guard reads `internal` arrays added in Task 2.)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/NovaTerminal.McpServer.Tests/ConnectionProfileToolsTests.cs`:
+
+```csharp
+using NovaTerminal.McpServer.Tools;
+
+namespace NovaTerminal.McpServer.Tests;
+
+public class ConnectionProfileToolsTests
+{
+    [Fact]
+    public void Schema_DescribesFieldGroupsAndEnumMappings()
+    {
+        var schema = ConnectionProfileTools.GetConnectionProfileSchema();
+
+        // Field-group headings.
+        Assert.Contains("Identity", schema);
+        Assert.Contains("Connection", schema);
+        Assert.Contains("Auth", schema);
+        Assert.Contains("Jump hosts", schema);
+        Assert.Contains("Port forwarding", schema);
+        Assert.Contains("Multiplexing", schema);
+        Assert.Contains("Document wrapper", schema);
+
+        // Integer enum mappings must be spelled out (enums are ints on the wire).
+        Assert.Contains("0=OpenSsh", schema);
+        Assert.Contains("1=Native", schema);
+        Assert.Contains("2=IdentityFile", schema);
+        Assert.Contains("2=Dynamic", schema);
+        Assert.Contains("4=Pwsh", schema);
+
+        // Required fields and an example are present.
+        Assert.Contains("`Name`", schema);
+        Assert.Contains("`Host`", schema);
+        Assert.Contains("```json", schema);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `scripts/build.ps1 test tests/NovaTerminal.McpServer.Tests --filter "FullyQualifiedName~ConnectionProfileToolsTests"`
+Expected: FAIL — build error, `ConnectionProfileTools` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/NovaTerminal.McpServer/Tools/ConnectionProfileTools.cs`:
+
+```csharp
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+
+namespace NovaTerminal.McpServer.Tools;
+
+// Source of truth for field names / enum values:
+//   src/NovaTerminal.Platform/Ssh/Models/SshProfile.cs (+ SshJumpHop, PortForward,
+//   SshMuxOptions) and SshProfileStoreSnapshot in Ssh/Storage/ISshProfileStore.cs.
+// This server has NO ProjectReference to NovaTerminal.Platform by design, so that
+// knowledge is hand-mirrored below. A reflection drift-guard test in
+// NovaTerminal.McpServer.Tests fails if those types change. Keep both in sync.
+[McpServerToolType]
+public static class ConnectionProfileTools
+{
+    [McpServerTool(Name = "novaterminal.get_connection_profile_schema"),
+     Description("Returns the schema for a NovaTerminal SSH connection-profile JSON: PascalCase fields grouped by area, integer enum mappings, defaults, and a complete example. The on-disk format uses integer-valued enums; passwords are vault-managed and never stored in profile JSON. Use before authoring or editing a profile.")]
+    public static string GetConnectionProfileSchema() =>
+        """
+        # NovaTerminal connection-profile (SSH) JSON schema
+
+        Profiles are stored at `%LOCALAPPDATA%\NovaTerminal\ssh\profiles.json`. The on-disk
+        format uses **PascalCase** field names and **integer-valued enums**. Passwords are
+        never stored here — they live in the OS credential vault.
+
+        A single profile is a JSON object. The full file wraps profiles in a document:
+        `{ "SchemaVersion": 1, "Profiles": [ <profile>, ... ] }`. The validator accepts
+        either shape.
+
+        ## Identity / organization
+        | Field | Type | Notes |
+        |-------|------|-------|
+        | `Id` | string (GUID) | Optional; the store assigns one if absent/invalid. |
+        | `Name` | string | **Required**, non-empty. |
+        | `GroupPath` | string | Tree path, e.g. "Prod/DB". Default "General". |
+        | `Notes` | string | Free text. |
+        | `AccentColor` | string | e.g. "#3399EE". |
+        | `Tags` | string[] | Labels. |
+
+        ## Connection
+        | Field | Type | Notes |
+        |-------|------|-------|
+        | `Host` | string | **Required**, non-empty. |
+        | `User` | string | SSH user. |
+        | `Port` | int | 1–65535. Default 22. |
+        | `BackendKind` | int enum | 0=OpenSsh, 1=Native. |
+
+        ## Auth
+        | Field | Type | Notes |
+        |-------|------|-------|
+        | `AuthMode` | int enum | 0=Default, 1=Agent, 2=IdentityFile. |
+        | `IdentityFilePath` | string | Key path; expected when AuthMode is 2 (IdentityFile). |
+        | `RememberPasswordInVault` | bool | Whether to keep the password in the vault. |
+
+        ## Jump hosts
+        `JumpHops` is an array of `{ "Host": string, "User": string, "Port": int (1–65535) }`.
+
+        ## Port forwarding
+        `Forwards` is an array of objects:
+        | Field | Type | Notes |
+        |-------|------|-------|
+        | `Kind` | int enum | 0=Local, 1=Remote, 2=Dynamic. |
+        | `BindAddress` | string | e.g. "127.0.0.1". |
+        | `SourcePort` | int | 0–65535. |
+        | `DestinationHost` | string | Forward target host. |
+        | `DestinationPort` | int | 0–65535. |
+
+        ## Multiplexing
+        `MuxOptions` is `{ "Enabled": bool, "ControlMasterAuto": bool, "ControlPath": string, "ControlPersistSeconds": int (>= 0) }`.
+
+        ## Session / shell
+        | Field | Type | Notes |
+        |-------|------|-------|
+        | `ServerAliveIntervalSeconds` | int | >= 1. Default 30. |
+        | `ServerAliveCountMax` | int | >= 1. Default 3. |
+        | `ExtraSshArgs` | string | Extra ssh CLI args. |
+        | `WorkingDirectory` | string | Remote working directory. |
+        | `RemoteShellKind` | int enum | 0=Auto, 1=Bash, 2=Zsh, 3=Fish, 4=Pwsh. |
+
+        ## Document wrapper
+        | Field | Type | Notes |
+        |-------|------|-------|
+        | `SchemaVersion` | int | Current = 1. |
+        | `Profiles` | object[] | Array of profile objects. |
+
+        ## Example (full document)
+        ```json
+        {
+          "SchemaVersion": 1,
+          "Profiles": [
+            {
+              "Id": "aeb456e4-8dd2-4b33-a74d-cb473de0323b",
+              "BackendKind": 0,
+              "Name": "prod-db",
+              "GroupPath": "Prod/DB",
+              "Notes": "primary database jump",
+              "AccentColor": "#3399EE",
+              "Tags": ["prod", "db"],
+              "Host": "prod.internal",
+              "User": "svc",
+              "Port": 2222,
+              "AuthMode": 2,
+              "IdentityFilePath": "/home/svc/.ssh/prod_ed25519",
+              "RememberPasswordInVault": false,
+              "JumpHops": [
+                { "Host": "jump-1.internal", "User": "ops", "Port": 22 }
+              ],
+              "Forwards": [
+                { "Kind": 0, "BindAddress": "127.0.0.1", "SourcePort": 5432, "DestinationHost": "db.internal", "DestinationPort": 5432 }
+              ],
+              "MuxOptions": { "Enabled": false, "ControlMasterAuto": true, "ControlPath": "", "ControlPersistSeconds": 0 },
+              "ServerAliveIntervalSeconds": 30,
+              "ServerAliveCountMax": 3,
+              "ExtraSshArgs": "",
+              "WorkingDirectory": "",
+              "RemoteShellKind": 0
+            }
+          ]
+        }
+        ```
+        """;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `scripts/build.ps1 test tests/NovaTerminal.McpServer.Tests --filter "FullyQualifiedName~ConnectionProfileToolsTests"`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.McpServer/Tools/ConnectionProfileTools.cs tests/NovaTerminal.McpServer.Tests/ConnectionProfileToolsTests.cs
+git commit -m "feat(mcp): add get_connection_profile_schema tool"
+```
+
+---
+
+### Task 2: Validator tool (`validate_connection_profile_json`)
+
+**Files:**
+- Modify: `src/NovaTerminal.McpServer/Tools/ConnectionProfileTools.cs`
+- Test: `tests/NovaTerminal.McpServer.Tests/ConnectionProfileToolsTests.cs`
+
+**Interfaces:**
+- Consumes: `GetConnectionProfileSchema()` (for the self-consistency test).
+- Produces:
+  - `public static string ConnectionProfileTools.ValidateConnectionProfileJson(string profileJson)` — `VALID`/`INVALID` report.
+  - `internal static readonly string[] ProfileFields, JumpHopFields, PortForwardFields, MuxFields, DocumentFields` — known PascalCase field-name sets (read by Task 3's drift guard).
+  - `internal static readonly string[] BackendKindNames, AuthModeNames, PortForwardKindNames, RemoteShellKindNames` — enum names indexed by integer value (read by Task 3's drift guard).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/NovaTerminal.McpServer.Tests/ConnectionProfileToolsTests.cs` (inside the class):
+
+```csharp
+    private const string ValidProfile = """
+        { "Name": "box", "Host": "box.internal", "Port": 22 }
+        """;
+
+    private const string ValidDocument = """
+        {
+          "SchemaVersion": 1,
+          "Profiles": [
+            {
+              "Name": "prod-db", "Host": "prod.internal", "User": "svc", "Port": 2222,
+              "BackendKind": 0, "AuthMode": 2, "IdentityFilePath": "/k/id_ed25519",
+              "Tags": ["prod"], "RememberPasswordInVault": false,
+              "JumpHops": [ { "Host": "j1", "User": "ops", "Port": 22 } ],
+              "Forwards": [ { "Kind": 0, "BindAddress": "127.0.0.1", "SourcePort": 5432, "DestinationHost": "db", "DestinationPort": 5432 } ],
+              "MuxOptions": { "Enabled": false, "ControlMasterAuto": true, "ControlPath": "", "ControlPersistSeconds": 0 },
+              "RemoteShellKind": 1
+            }
+          ]
+        }
+        """;
+
+    [Fact]
+    public void MinimalProfile_IsValid()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson(ValidProfile);
+        Assert.StartsWith("VALID", result);
+        Assert.DoesNotContain("Errors:", result);
+    }
+
+    [Fact]
+    public void FullDocument_IsValid()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson(ValidDocument);
+        Assert.StartsWith("VALID", result);
+        Assert.DoesNotContain("Errors:", result);
+    }
+
+    [Fact]
+    public void SchemaExample_PassesItsOwnValidator()
+    {
+        var schema = ConnectionProfileTools.GetConnectionProfileSchema();
+        int fence = schema.IndexOf("```json", StringComparison.Ordinal);
+        Assert.True(fence >= 0, "schema must contain a ```json example");
+        int bodyStart = schema.IndexOf('\n', fence) + 1;
+        int bodyEnd = schema.IndexOf("```", bodyStart, StringComparison.Ordinal);
+        string exampleJson = schema[bodyStart..bodyEnd];
+
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson(exampleJson);
+        Assert.StartsWith("VALID", result);
+    }
+
+    [Fact]
+    public void Empty_IsRejected() =>
+        Assert.StartsWith("INVALID", ConnectionProfileTools.ValidateConnectionProfileJson(""));
+
+    [Fact]
+    public void NonJson_IsRejected() =>
+        Assert.StartsWith("INVALID", ConnectionProfileTools.ValidateConnectionProfileJson("not json {"));
+
+    [Fact]
+    public void NonObjectRoot_IsRejected() =>
+        Assert.StartsWith("INVALID", ConnectionProfileTools.ValidateConnectionProfileJson("[1,2,3]"));
+
+    [Fact]
+    public void MissingName_IsError()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Host": "h" }""");
+        Assert.StartsWith("INVALID", result);
+        Assert.Contains("Missing required field 'Name'", result);
+    }
+
+    [Fact]
+    public void MissingHost_IsError()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Name": "n" }""");
+        Assert.StartsWith("INVALID", result);
+        Assert.Contains("Missing required field 'Host'", result);
+    }
+
+    [Fact]
+    public void EnumOutOfRange_IsError()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Name": "n", "Host": "h", "AuthMode": 9 }""");
+        Assert.StartsWith("INVALID", result);
+        Assert.Contains("'AuthMode'", result);
+        Assert.Contains("0=Default", result); // mapping hint
+    }
+
+    [Fact]
+    public void EnumNotInteger_IsError()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Name": "n", "Host": "h", "BackendKind": "OpenSsh" }""");
+        Assert.StartsWith("INVALID", result);
+        Assert.Contains("'BackendKind'", result);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(70000)]
+    public void PortOutOfRange_IsError(int port)
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson($$"""{ "Name": "n", "Host": "h", "Port": {{port}} }""");
+        Assert.StartsWith("INVALID", result);
+        Assert.Contains("'Port'", result);
+    }
+
+    [Fact]
+    public void WrongType_IsError()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Name": "n", "Host": "h", "Port": "22" }""");
+        Assert.StartsWith("INVALID", result);
+        Assert.Contains("'Port'", result);
+    }
+
+    [Fact]
+    public void ServerAliveCountMaxZero_IsError()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Name": "n", "Host": "h", "ServerAliveCountMax": 0 }""");
+        Assert.StartsWith("INVALID", result);
+        Assert.Contains("'ServerAliveCountMax'", result);
+    }
+
+    [Fact]
+    public void ProfilesNotArray_IsError()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "SchemaVersion": 1, "Profiles": 5 }""");
+        Assert.StartsWith("INVALID", result);
+        Assert.Contains("'Profiles'", result);
+    }
+
+    [Fact]
+    public void UnknownField_IsWarningButValid()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Name": "n", "Host": "h", "Bogus": 1 }""");
+        Assert.StartsWith("VALID", result);
+        Assert.Contains("Warnings:", result);
+        Assert.Contains("Unknown field 'Bogus'", result);
+    }
+
+    [Fact]
+    public void PasswordField_IsSecurityWarning()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Name": "n", "Host": "h", "Password": "secret" }""");
+        Assert.StartsWith("VALID", result);
+        Assert.Contains("Password", result);
+        Assert.Contains("vault", result);
+    }
+
+    [Fact]
+    public void MalformedId_IsWarning()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Name": "n", "Host": "h", "Id": "not-a-guid" }""");
+        Assert.StartsWith("VALID", result);
+        Assert.Contains("'Id'", result);
+    }
+
+    [Fact]
+    public void IdentityFileModeWithBlankPath_IsWarning()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Name": "n", "Host": "h", "AuthMode": 2, "IdentityFilePath": "" }""");
+        Assert.StartsWith("VALID", result);
+        Assert.Contains("IdentityFilePath", result);
+    }
+
+    [Fact]
+    public void MissingSchemaVersionInDocument_IsWarning()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Profiles": [ { "Name": "n", "Host": "h" } ] }""");
+        Assert.StartsWith("VALID", result);
+        Assert.Contains("SchemaVersion", result);
+    }
+
+    [Fact]
+    public void NewerSchemaVersion_IsWarning()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "SchemaVersion": 2, "Profiles": [ { "Name": "n", "Host": "h" } ] }""");
+        Assert.StartsWith("VALID", result);
+        Assert.Contains("SchemaVersion", result);
+    }
+
+    [Fact]
+    public void Null_IsRejected() =>
+        Assert.StartsWith("INVALID", ConnectionProfileTools.ValidateConnectionProfileJson(null!));
+
+    [Fact]
+    public void AutoDetect_SingleVsDocument_UsesCorrectPaths()
+    {
+        var single = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Host": "h" }""");
+        Assert.Contains("Missing required field 'Name'", single);
+        Assert.DoesNotContain("Profiles[", single);
+
+        var doc = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Profiles": [ { "Host": "h" } ] }""");
+        Assert.Contains("Profiles[0].Missing required field 'Name'", doc);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `scripts/build.ps1 test tests/NovaTerminal.McpServer.Tests --filter "FullyQualifiedName~ConnectionProfileToolsTests"`
+Expected: FAIL — build error, `ValidateConnectionProfileJson` does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+Add `using` directives at the top of `ConnectionProfileTools.cs` (alongside the existing two):
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+```
+
+Then add the following members inside the `ConnectionProfileTools` class (after `GetConnectionProfileSchema`):
+
+```csharp
+    private const int CurrentSchemaVersion = 1;
+
+    // Known PascalCase field names (mirror SshProfile etc.; guarded by drift-guard test).
+    internal static readonly string[] ProfileFields =
+    {
+        "Id", "BackendKind", "Name", "GroupPath", "Notes", "AccentColor", "Tags", "Host",
+        "User", "Port", "AuthMode", "IdentityFilePath", "RememberPasswordInVault",
+        "JumpHops", "Forwards", "MuxOptions", "ServerAliveIntervalSeconds",
+        "ServerAliveCountMax", "ExtraSshArgs", "WorkingDirectory", "RemoteShellKind",
+    };
+    internal static readonly string[] JumpHopFields = { "Host", "User", "Port" };
+    internal static readonly string[] PortForwardFields =
+        { "Kind", "BindAddress", "SourcePort", "DestinationHost", "DestinationPort" };
+    internal static readonly string[] MuxFields =
+        { "Enabled", "ControlMasterAuto", "ControlPath", "ControlPersistSeconds" };
+    internal static readonly string[] DocumentFields = { "SchemaVersion", "Profiles" };
+
+    // Enum names indexed by integer value (mirror the enums; guarded by drift-guard test).
+    internal static readonly string[] BackendKindNames = { "OpenSsh", "Native" };
+    internal static readonly string[] AuthModeNames = { "Default", "Agent", "IdentityFile" };
+    internal static readonly string[] PortForwardKindNames = { "Local", "Remote", "Dynamic" };
+    internal static readonly string[] RemoteShellKindNames = { "Auto", "Bash", "Zsh", "Fish", "Pwsh" };
+
+    [McpServerTool(Name = "novaterminal.validate_connection_profile_json"),
+     Description("Validates a NovaTerminal SSH connection-profile JSON string. Accepts either a single profile object or a full profiles.json document ({ \"SchemaVersion\", \"Profiles\": [...] }); auto-detects which. Reports errors (wrong types, out-of-range integer enums/ports, missing required Name/Host) and warnings (unknown fields, a stray Password field, malformed Id, etc.). Passwords are vault-managed and must never appear in profile JSON.")]
+    public static string ValidateConnectionProfileJson(
+        [Description("The connection-profile JSON to validate: a single SshProfile object or a full profiles.json document.")] string profileJson)
+    {
+        if (string.IsNullOrWhiteSpace(profileJson))
+        {
+            return "INVALID: empty input — expected a connection-profile JSON object.";
+        }
+
+        JsonElement root;
+        try
+        {
+            using var doc = JsonDocument.Parse(profileJson);
+            root = doc.RootElement.Clone();
+        }
+        catch (JsonException ex)
+        {
+            return $"INVALID: not valid JSON — {ex.Message}";
+        }
+
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            return $"INVALID: top-level value must be a JSON object, but was {root.ValueKind}.";
+        }
+
+        var errors = new List<string>();
+        var warnings = new List<string>();
+
+        if (root.TryGetProperty("Profiles", out var profilesEl))
+        {
+            ValidateDocument(root, profilesEl, errors, warnings);
+        }
+        else
+        {
+            ValidateProfile(root, string.Empty, errors, warnings);
+        }
+
+        return Report(errors, warnings);
+    }
+
+    private static void ValidateDocument(
+        JsonElement root, JsonElement profilesEl, List<string> errors, List<string> warnings)
+    {
+        if (!root.TryGetProperty("SchemaVersion", out var verEl))
+        {
+            warnings.Add("'SchemaVersion' is missing; the store defaults it to 1.");
+        }
+        else if (verEl.ValueKind != JsonValueKind.Number || !verEl.TryGetInt32(out var ver))
+        {
+            errors.Add($"Field 'SchemaVersion' must be an integer, but was {verEl.ValueKind}.");
+        }
+        else if (ver <= 0)
+        {
+            warnings.Add($"'SchemaVersion' is {ver}; the store defaults non-positive versions to 1.");
+        }
+        else if (ver > CurrentSchemaVersion)
+        {
+            warnings.Add($"'SchemaVersion' is {ver}, newer than the current version {CurrentSchemaVersion}; some fields may be unrecognized.");
+        }
+
+        if (profilesEl.ValueKind != JsonValueKind.Array)
+        {
+            errors.Add($"Field 'Profiles' must be a JSON array, but was {profilesEl.ValueKind}.");
+        }
+        else
+        {
+            int i = 0;
+            foreach (var profile in profilesEl.EnumerateArray())
+            {
+                if (profile.ValueKind != JsonValueKind.Object)
+                {
+                    errors.Add($"'Profiles[{i}]' must be a JSON object, but was {profile.ValueKind}.");
+                }
+                else
+                {
+                    ValidateProfile(profile, $"Profiles[{i}].", errors, warnings);
+                }
+                i++;
+            }
+        }
+
+        foreach (var prop in root.EnumerateObject())
+        {
+            if (prop.Name is not ("SchemaVersion" or "Profiles"))
+            {
+                warnings.Add($"Unknown field '{prop.Name}' (ignored).");
+            }
+        }
+    }
+
+    private static void ValidateProfile(
+        JsonElement p, string path, List<string> errors, List<string> warnings)
+    {
+        RequireNonEmptyString(p, path, "Name", errors);
+        RequireNonEmptyString(p, path, "Host", errors);
+
+        foreach (var f in new[]
+                 {
+                     "GroupPath", "Notes", "AccentColor", "User",
+                     "IdentityFilePath", "ExtraSshArgs", "WorkingDirectory",
+                 })
+        {
+            RequireStringType(p, path, f, errors);
+        }
+
+        if (p.TryGetProperty("Id", out var idEl))
+        {
+            if (idEl.ValueKind != JsonValueKind.String)
+            {
+                errors.Add($"{path}Field 'Id' must be a string GUID, but was {idEl.ValueKind}.");
+            }
+            else if (!Guid.TryParse(idEl.GetString(), out _))
+            {
+                warnings.Add($"{path}Field 'Id' is not a valid GUID; the store will assign one.");
+            }
+        }
+
+        if (p.TryGetProperty("Tags", out var tagsEl))
+        {
+            if (tagsEl.ValueKind != JsonValueKind.Array)
+            {
+                errors.Add($"{path}Field 'Tags' must be an array of strings, but was {tagsEl.ValueKind}.");
+            }
+            else
+            {
+                int ti = 0;
+                foreach (var tag in tagsEl.EnumerateArray())
+                {
+                    if (tag.ValueKind != JsonValueKind.String)
+                    {
+                        errors.Add($"{path}Field 'Tags[{ti}]' must be a string, but was {tag.ValueKind}.");
+                    }
+                    ti++;
+                }
+            }
+        }
+
+        RequireBoolType(p, path, "RememberPasswordInVault", errors);
+
+        CheckEnum(p, path, "BackendKind", BackendKindNames, errors);
+        CheckEnum(p, path, "AuthMode", AuthModeNames, errors);
+        CheckEnum(p, path, "RemoteShellKind", RemoteShellKindNames, errors);
+
+        CheckIntRange(p, path, "Port", 1, 65535, errors);
+        CheckIntRange(p, path, "ServerAliveIntervalSeconds", 1, int.MaxValue, errors);
+        CheckIntRange(p, path, "ServerAliveCountMax", 1, int.MaxValue, errors);
+
+        if (p.TryGetProperty("AuthMode", out var amEl)
+            && amEl.ValueKind == JsonValueKind.Number
+            && amEl.TryGetInt32(out var am) && am == 2)
+        {
+            bool blank = !p.TryGetProperty("IdentityFilePath", out var ipEl)
+                         || ipEl.ValueKind != JsonValueKind.String
+                         || string.IsNullOrWhiteSpace(ipEl.GetString());
+            if (blank)
+            {
+                warnings.Add($"{path}AuthMode is IdentityFile (2) but 'IdentityFilePath' is blank.");
+            }
+        }
+
+        if (p.TryGetProperty("JumpHops", out var hopsEl))
+        {
+            ValidateArrayOfObjects(hopsEl, path, "JumpHops", errors, warnings, ValidateJumpHop);
+        }
+
+        if (p.TryGetProperty("Forwards", out var fwdEl))
+        {
+            ValidateArrayOfObjects(fwdEl, path, "Forwards", errors, warnings, ValidateForward);
+        }
+
+        if (p.TryGetProperty("MuxOptions", out var muxEl))
+        {
+            if (muxEl.ValueKind != JsonValueKind.Object)
+            {
+                errors.Add($"{path}Field 'MuxOptions' must be a JSON object, but was {muxEl.ValueKind}.");
+            }
+            else
+            {
+                ValidateMux(muxEl, $"{path}MuxOptions.", errors, warnings);
+            }
+        }
+
+        CheckUnknownAndPassword(p, path, ProfileFields, errors, warnings);
+    }
+
+    private static void ValidateJumpHop(
+        JsonElement h, string path, List<string> errors, List<string> warnings)
+    {
+        RequireStringType(h, path, "Host", errors);
+        RequireStringType(h, path, "User", errors);
+        CheckIntRange(h, path, "Port", 1, 65535, errors);
+        CheckUnknownAndPassword(h, path, JumpHopFields, errors, warnings);
+    }
+
+    private static void ValidateForward(
+        JsonElement f, string path, List<string> errors, List<string> warnings)
+    {
+        CheckEnum(f, path, "Kind", PortForwardKindNames, errors);
+        RequireStringType(f, path, "BindAddress", errors);
+        RequireStringType(f, path, "DestinationHost", errors);
+        CheckIntRange(f, path, "SourcePort", 0, 65535, errors);
+        CheckIntRange(f, path, "DestinationPort", 0, 65535, errors);
+
+        if (f.TryGetProperty("Kind", out var kEl)
+            && kEl.ValueKind == JsonValueKind.Number
+            && kEl.TryGetInt32(out var kind) && (kind == 0 || kind == 1))
+        {
+            WarnZeroPort(f, path, "SourcePort", warnings);
+            WarnZeroPort(f, path, "DestinationPort", warnings);
+        }
+
+        CheckUnknownAndPassword(f, path, PortForwardFields, errors, warnings);
+    }
+
+    private static void ValidateMux(
+        JsonElement m, string path, List<string> errors, List<string> warnings)
+    {
+        RequireBoolType(m, path, "Enabled", errors);
+        RequireBoolType(m, path, "ControlMasterAuto", errors);
+        RequireStringType(m, path, "ControlPath", errors);
+        CheckIntRange(m, path, "ControlPersistSeconds", 0, int.MaxValue, errors);
+        CheckUnknownAndPassword(m, path, MuxFields, errors, warnings);
+    }
+
+    private static void RequireNonEmptyString(
+        JsonElement obj, string path, string field, List<string> errors)
+    {
+        if (!obj.TryGetProperty(field, out var el))
+        {
+            errors.Add($"{path}Missing required field '{field}'.");
+        }
+        else if (el.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(el.GetString()))
+        {
+            errors.Add($"{path}Field '{field}' must be a non-empty string.");
+        }
+    }
+
+    private static void RequireStringType(
+        JsonElement obj, string path, string field, List<string> errors)
+    {
+        if (obj.TryGetProperty(field, out var el) && el.ValueKind != JsonValueKind.String)
+        {
+            errors.Add($"{path}Field '{field}' must be a string, but was {el.ValueKind}.");
+        }
+    }
+
+    private static void RequireBoolType(
+        JsonElement obj, string path, string field, List<string> errors)
+    {
+        if (obj.TryGetProperty(field, out var el)
+            && el.ValueKind is not (JsonValueKind.True or JsonValueKind.False))
+        {
+            errors.Add($"{path}Field '{field}' must be a boolean, but was {el.ValueKind}.");
+        }
+    }
+
+    private static void CheckEnum(
+        JsonElement obj, string path, string field, string[] names, List<string> errors)
+    {
+        if (!obj.TryGetProperty(field, out var el))
+        {
+            return;
+        }
+
+        string mapping = string.Join(", ", names.Select((n, i) => $"{i}={n}"));
+        if (el.ValueKind != JsonValueKind.Number || !el.TryGetInt32(out var v))
+        {
+            errors.Add($"{path}Field '{field}' must be an integer enum value ({mapping}), but was {el.ValueKind}.");
+            return;
+        }
+
+        if (v < 0 || v >= names.Length)
+        {
+            errors.Add($"{path}Field '{field}' value {v} is out of range ({mapping}).");
+        }
+    }
+
+    private static void CheckIntRange(
+        JsonElement obj, string path, string field, int min, int max, List<string> errors)
+    {
+        if (!obj.TryGetProperty(field, out var el))
+        {
+            return;
+        }
+
+        if (el.ValueKind != JsonValueKind.Number || !el.TryGetInt32(out var v))
+        {
+            errors.Add($"{path}Field '{field}' must be an integer, but was {el.ValueKind}.");
+            return;
+        }
+
+        if (v < min || v > max)
+        {
+            string range = max == int.MaxValue ? $">= {min}" : $"[{min}..{max}]";
+            errors.Add($"{path}Field '{field}' value {v} is out of range ({range}).");
+        }
+    }
+
+    private static void WarnZeroPort(
+        JsonElement obj, string path, string field, List<string> warnings)
+    {
+        if (obj.TryGetProperty(field, out var el)
+            && el.ValueKind == JsonValueKind.Number
+            && el.TryGetInt32(out var v) && v == 0)
+        {
+            warnings.Add($"{path}Field '{field}' is 0 for a Local/Remote forward; expected a real port.");
+        }
+    }
+
+    private static void CheckUnknownAndPassword(
+        JsonElement obj, string path, string[] known, List<string> errors, List<string> warnings)
+    {
+        var set = new HashSet<string>(known, StringComparer.Ordinal);
+        foreach (var prop in obj.EnumerateObject())
+        {
+            if (string.Equals(prop.Name, "Password", StringComparison.OrdinalIgnoreCase))
+            {
+                warnings.Add($"{path}Field '{prop.Name}' must not appear in profile JSON — passwords are stored in the credential vault, not in profiles.");
+                continue;
+            }
+
+            if (!set.Contains(prop.Name))
+            {
+                warnings.Add($"{path}Unknown field '{prop.Name}' (ignored).");
+            }
+        }
+    }
+
+    private static void ValidateArrayOfObjects(
+        JsonElement arr, string parentPath, string field,
+        List<string> errors, List<string> warnings,
+        Action<JsonElement, string, List<string>, List<string>> validateItem)
+    {
+        if (arr.ValueKind != JsonValueKind.Array)
+        {
+            errors.Add($"{parentPath}Field '{field}' must be a JSON array, but was {arr.ValueKind}.");
+            return;
+        }
+
+        int i = 0;
+        foreach (var item in arr.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Object)
+            {
+                errors.Add($"{parentPath}{field}[{i}] must be a JSON object, but was {item.ValueKind}.");
+            }
+            else
+            {
+                validateItem(item, $"{parentPath}{field}[{i}].", errors, warnings);
+            }
+            i++;
+        }
+    }
+
+    private static string Report(List<string> errors, List<string> warnings)
+    {
+        var sb = new StringBuilder();
+        sb.Append(errors.Count == 0 ? "VALID" : "INVALID").Append('\n');
+        if (errors.Count > 0)
+        {
+            sb.Append("\nErrors:\n");
+            foreach (var e in errors)
+            {
+                sb.Append("  - ").Append(e).Append('\n');
+            }
+        }
+        if (warnings.Count > 0)
+        {
+            sb.Append("\nWarnings:\n");
+            foreach (var w in warnings)
+            {
+                sb.Append("  - ").Append(w).Append('\n');
+            }
+        }
+        return sb.ToString().TrimEnd();
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `scripts/build.ps1 test tests/NovaTerminal.McpServer.Tests --filter "FullyQualifiedName~ConnectionProfileToolsTests"`
+Expected: PASS (all `ConnectionProfileToolsTests`, ~24 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.McpServer/Tools/ConnectionProfileTools.cs tests/NovaTerminal.McpServer.Tests/ConnectionProfileToolsTests.cs
+git commit -m "feat(mcp): add validate_connection_profile_json tool"
+```
+
+---
+
+### Task 3: Drift-guard test (reflection vs `NovaTerminal.Platform`)
+
+**Files:**
+- Modify: `tests/NovaTerminal.McpServer.Tests/NovaTerminal.McpServer.Tests.csproj`
+- Create: `tests/NovaTerminal.McpServer.Tests/ConnectionProfileDriftGuardTests.cs`
+
+**Interfaces:**
+- Consumes: `ConnectionProfileTools.ProfileFields/JumpHopFields/PortForwardFields/MuxFields/DocumentFields` and `…BackendKindNames/AuthModeNames/PortForwardKindNames/RemoteShellKindNames` (internal, visible via the existing `InternalsVisibleTo`); the real types from `NovaTerminal.Platform`.
+- Produces: nothing (test-only).
+
+- [ ] **Step 1: Add the test-only ProjectReference**
+
+Edit `tests/NovaTerminal.McpServer.Tests/NovaTerminal.McpServer.Tests.csproj` — add `NovaTerminal.Platform` to the existing `ProjectReference` ItemGroup so it reads:
+
+```xml
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NovaTerminal.McpServer\NovaTerminal.McpServer.csproj" />
+    <!-- Test-only: the drift guard reflects over the real profile types. The MCP server
+         itself must never reference NovaTerminal.Platform. -->
+    <ProjectReference Include="..\..\src\NovaTerminal.Platform\NovaTerminal.Platform.csproj" />
+  </ItemGroup>
+```
+
+- [ ] **Step 2: Write the failing drift-guard tests**
+
+Create `tests/NovaTerminal.McpServer.Tests/ConnectionProfileDriftGuardTests.cs`:
+
+```csharp
+using System;
+using System.Linq;
+using NovaTerminal.McpServer.Tools;
+using NovaTerminal.Platform;                 // RemoteShellKind
+using NovaTerminal.Platform.Ssh.Models;      // SshProfile, SshJumpHop, PortForward, SshMuxOptions, enums
+using NovaTerminal.Platform.Ssh.Storage;     // SshProfileStoreSnapshot
+
+namespace NovaTerminal.McpServer.Tests;
+
+// Guards against drift between the hand-mirrored field/enum knowledge in
+// ConnectionProfileTools and the real types in NovaTerminal.Platform. If these fail,
+// a profile type changed — update ConnectionProfileTools (fields, enums, schema, rules).
+public class ConnectionProfileDriftGuardTests
+{
+    private static string[] PropNames(Type t) =>
+        t.GetProperties().Select(p => p.Name).OrderBy(n => n, StringComparer.Ordinal).ToArray();
+
+    private static string[] Sorted(string[] values) =>
+        values.OrderBy(n => n, StringComparer.Ordinal).ToArray();
+
+    [Fact]
+    public void ProfileFields_MatchSshProfile() =>
+        Assert.Equal(PropNames(typeof(SshProfile)), Sorted(ConnectionProfileTools.ProfileFields));
+
+    [Fact]
+    public void JumpHopFields_MatchSshJumpHop() =>
+        Assert.Equal(PropNames(typeof(SshJumpHop)), Sorted(ConnectionProfileTools.JumpHopFields));
+
+    [Fact]
+    public void PortForwardFields_MatchPortForward() =>
+        Assert.Equal(PropNames(typeof(PortForward)), Sorted(ConnectionProfileTools.PortForwardFields));
+
+    [Fact]
+    public void MuxFields_MatchSshMuxOptions() =>
+        Assert.Equal(PropNames(typeof(SshMuxOptions)), Sorted(ConnectionProfileTools.MuxFields));
+
+    [Fact]
+    public void DocumentFields_MatchSnapshot() =>
+        Assert.Equal(PropNames(typeof(SshProfileStoreSnapshot)), Sorted(ConnectionProfileTools.DocumentFields));
+
+    // Enum name arrays are indexed by integer value; compare to Enum.GetNames (value order).
+    [Fact]
+    public void BackendKindNames_MatchEnum() =>
+        Assert.Equal(Enum.GetNames<SshBackendKind>(), ConnectionProfileTools.BackendKindNames);
+
+    [Fact]
+    public void AuthModeNames_MatchEnum() =>
+        Assert.Equal(Enum.GetNames<SshAuthMode>(), ConnectionProfileTools.AuthModeNames);
+
+    [Fact]
+    public void PortForwardKindNames_MatchEnum() =>
+        Assert.Equal(Enum.GetNames<PortForwardKind>(), ConnectionProfileTools.PortForwardKindNames);
+
+    [Fact]
+    public void RemoteShellKindNames_MatchEnum() =>
+        Assert.Equal(Enum.GetNames<RemoteShellKind>(), ConnectionProfileTools.RemoteShellKindNames);
+}
+```
+
+- [ ] **Step 3: Run drift-guard tests to verify they pass**
+
+(The arrays and types already exist from Task 2, so these should pass once the reference is added.)
+
+Run: `scripts/build.ps1 test tests/NovaTerminal.McpServer.Tests --filter "FullyQualifiedName~ConnectionProfileDriftGuardTests"`
+Expected: PASS (9 tests). If any fail, the hand-mirrored array in `ConnectionProfileTools` disagrees with the real type — fix the array (and the schema text / validation rules) to match.
+
+- [ ] **Step 4: Run the whole MCP test project to confirm nothing regressed**
+
+Run: `scripts/build.ps1 test tests/NovaTerminal.McpServer.Tests`
+Expected: PASS (all existing tests plus the new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/NovaTerminal.McpServer.Tests/NovaTerminal.McpServer.Tests.csproj tests/NovaTerminal.McpServer.Tests/ConnectionProfileDriftGuardTests.cs
+git commit -m "test(mcp): add SshProfile drift-guard for connection-profile tools"
+```
+
+---
+
+### Task 4: Documentation updates
+
+**Files:**
+- Modify: `docs/mcp/tools.md`
+- Modify: `docs/mcp-dev-companion.md`
+
+**Interfaces:** none (docs only).
+
+- [ ] **Step 1: Add the two tools to the tools table and bump the version title**
+
+In `docs/mcp/tools.md`, change the title line:
+
+```markdown
+# NovaTerminal MCP Dev Companion — tools (v0.1)
+```
+
+to:
+
+```markdown
+# NovaTerminal MCP Dev Companion — tools (v0.3)
+```
+
+Then add these two rows to the tools table, immediately after the `novaterminal.validate_theme_json` row:
+
+```markdown
+| `novaterminal.get_connection_profile_schema` | — | The SSH connection-profile JSON schema: PascalCase fields by area, integer enum mappings, defaults, and an example. Accepts a single profile or a full `profiles.json` document. |
+| `novaterminal.validate_connection_profile_json` | `profileJson` | Validates a connection-profile JSON (single profile or full document; auto-detected); reports wrong types, out-of-range integer enums/ports, missing `Name`/`Host`, and warns on unknown fields and any stray `Password`. |
+```
+
+- [ ] **Step 2: Remove the now-shipped deferred entry**
+
+In `docs/mcp/tools.md`, delete this bullet from the `## Still deferred` section (leave the other two bullets intact):
+
+```markdown
+- **Connection-profile schema/validation** (`get_connection_profile_schema`,
+  `validate_connection_profile_json`): unlike themes, the profile format has no stable documented
+  schema, is large (~37 fields incl. enums/nested rules), and contains a sensitive `Password`
+  field — deferred until a documented profile schema exists, to avoid drift and over-coupling.
+```
+
+- [ ] **Step 3: List the new tools in the companion overview**
+
+In `docs/mcp-dev-companion.md`, replace the tools paragraph:
+
+```markdown
+See [mcp/tools.md](mcp/tools.md). v0.1 exposes:
+
+`novaterminal.get_project_summary`, `novaterminal.get_architecture_map`,
+`novaterminal.list_docs`, `novaterminal.read_doc`,
+`novaterminal.get_vt_conformance_summary`,
+`novaterminal.get_theme_schema`, `novaterminal.validate_theme_json`,
+`novaterminal.generate_codex_prompt_for_issue`.
+```
+
+with (adds the connection-profile tools and points at the authoritative list):
+
+```markdown
+See [mcp/tools.md](mcp/tools.md) for the authoritative list. As of v0.3 this includes the
+connection-profile tools:
+
+`novaterminal.get_connection_profile_schema`, `novaterminal.validate_connection_profile_json`.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/mcp/tools.md docs/mcp-dev-companion.md
+git commit -m "docs(mcp): document connection-profile schema & validation tools"
+```
+
+---
+
+## Notes for the implementer
+
+- **Raw string literals:** `GetConnectionProfileSchema` uses a `"""` raw string. Preserve the closing `"""` indentation exactly as shown (it determines leading-whitespace stripping), matching the existing `ThemeTools.GetThemeSchema`.
+- **`VALID` vs `INVALID` assertions:** `"INVALID".StartsWith("VALID")` is `false`, so `Assert.StartsWith("VALID", result)` correctly distinguishes them — do not change to `Contains`.
+- **Pre-existing doc drift (out of scope):** `docs/mcp-dev-companion.md`'s old list omitted the v0.2 tools (`explain_escape_sequence`, `generate_vt_test_plan`, `suggest_relevant_files`). Task 4 redirects that section to `tools.md` as the source of truth rather than re-listing everything, so this plan does not separately backfill those names.
+- **CI:** `NovaTerminal.McpServer.Tests` is already in the unit-test loop; no `ci.yml` change is needed for the new test files. The new test-only `ProjectReference` to `NovaTerminal.Platform` builds in the test job (other test projects already depend on it).
+```

--- a/docs/superpowers/specs/2026-06-27-mcp-connection-profile-tools-design.md
+++ b/docs/superpowers/specs/2026-06-27-mcp-connection-profile-tools-design.md
@@ -24,10 +24,19 @@ There are two profile types in the codebase, and only one is persisted:
 
 - **`SshProfile`** (`src/NovaTerminal.Platform/Ssh/Models/SshProfile.cs`) is the model
   actually serialized to disk at `%LOCALAPPDATA%\NovaTerminal\ssh\profiles.json`. It has
-  a **stable, source-generated JSON contract** (`SshJsonContext`): camelCase property
-  names, enums-as-strings, `WriteIndented`, wrapped in an `SshStoreDocument` carrying a
-  `schemaVersion` field (current value `1`). It has **no `Password` field** — passwords
-  live in the credential vault keyed by `ProfileId` (`VaultService`).
+  a **stable, source-generated JSON contract** (`SshJsonContext`), wrapped in an
+  `SshStoreDocument` carrying a `SchemaVersion` field (current value `1`). It has **no
+  `Password` field** — passwords live in the credential vault keyed by `ProfileId`
+  (`VaultService`).
+
+  **Wire format (verified against `SshJsonContext` + `JsonSshProfileStoreTests`):**
+  `SshJsonContext` sets only `WriteIndented = true` — **no** `PropertyNamingPolicy` and
+  **no** `JsonStringEnumConverter`. Therefore the on-disk JSON uses **PascalCase keys**
+  (verbatim CLR property names, e.g. `"Profiles"`, `"Host"`, `"BackendKind"`) and
+  serializes **enums as integers**, not strings. (The `JsonSshProfileStoreTests` corrupt-file
+  test writes `{ "Profiles": [ ... ] }` and the password test asserts `DoesNotContain("\"Password\":")`,
+  both confirming PascalCase.) Any camelCase / string-enum examples seen elsewhere in the
+  codebase come from unrelated JSON contexts and do not apply here.
 - **`TerminalProfile`** (`src/NovaTerminal.App/Shell/TerminalProfile.cs`) is the app-layer
   model that *does* declare a `Password` property, but it is `[JsonIgnore]` and never
   serialized.
@@ -50,7 +59,8 @@ developer would author or inspect in `profiles.json`.
 ## Non-goals
 
 - No formal JSON Schema (draft 2020-12) document — descriptive prose + an annotated
-  example only, matching the existing `get_theme_schema` pattern.
+  example only, matching the existing `get_theme_schema` pattern. Because enums are
+  integers on the wire, the descriptive schema must spell out each int→name mapping.
 - No separate hand-written schema markdown file — the tool *is* the canonical schema doc.
 - No reading or writing of the user's real `profiles.json` — the validator operates only
   on JSON passed in as a string argument.
@@ -74,33 +84,35 @@ It is mitigated by a reflection-based **drift-guard test** (see Testing) that li
   default, followed by a complete annotated example covering both the single-profile and
   full-document shapes.
 
-Field groups (from `SshProfile`):
+Field groups (from `SshProfile`) — **PascalCase keys, integer-valued enums**:
 
-- **Identity / org:** `id` (GUID), `name`, `groupPath`, `notes`, `accentColor`, `tags[]`
-- **Connection:** `host`, `user`, `port` (default 22), `backendKind` (`OpenSsh` | `Native`)
-- **Auth:** `authMode` (`Default` | `Agent` | `IdentityFile`), `identityFilePath`,
-  `rememberPasswordInVault`
-- **Jump hosts:** `jumpHops[]` → `{ host, user, port }`
-- **Port forwarding:** `forwards[]` →
-  `{ kind: Local | Remote | Dynamic, bindAddress, sourcePort, destinationHost, destinationPort }`
-- **Multiplexing:** `muxOptions` →
-  `{ enabled, controlMasterAuto, controlPath, controlPersistSeconds }`
-- **Session / shell:** `serverAliveIntervalSeconds` (default 30),
-  `serverAliveCountMax` (default 3), `extraSshArgs`, `workingDirectory`,
-  `remoteShellKind` (`Auto` | `Bash` | `Zsh` | `Fish` | `Pwsh`)
-- **Document wrapper:** `schemaVersion` (int, current = 1), `profiles[]`
+- **Identity / org:** `Id` (GUID string), `Name`, `GroupPath`, `Notes`, `AccentColor`, `Tags[]`
+- **Connection:** `Host`, `User`, `Port` (int, default 22),
+  `BackendKind` (int: `0`=OpenSsh, `1`=Native)
+- **Auth:** `AuthMode` (int: `0`=Default, `1`=Agent, `2`=IdentityFile), `IdentityFilePath`,
+  `RememberPasswordInVault` (bool)
+- **Jump hosts:** `JumpHops[]` → `{ Host, User, Port }`
+- **Port forwarding:** `Forwards[]` →
+  `{ Kind (int: 0=Local, 1=Remote, 2=Dynamic), BindAddress, SourcePort, DestinationHost, DestinationPort }`
+- **Multiplexing:** `MuxOptions` →
+  `{ Enabled (bool), ControlMasterAuto (bool), ControlPath, ControlPersistSeconds (int) }`
+- **Session / shell:** `ServerAliveIntervalSeconds` (int, default 30),
+  `ServerAliveCountMax` (int, default 3), `ExtraSshArgs`, `WorkingDirectory`,
+  `RemoteShellKind` (int: `0`=Auto, `1`=Bash, `2`=Zsh, `3`=Fish, `4`=Pwsh)
+- **Document wrapper:** `SchemaVersion` (int, current = 1), `Profiles[]`
 
 ## Tool 2 — `validate_connection_profile_json`
 
 - **Input:** `profileJson` (string).
 - **Output:** a `VALID` / `INVALID` report mirroring `validate_theme_json`: a header line,
   then grouped error and warning lines, each with a field path
-  (e.g. `profiles[2].forwards[0].kind`).
+  (e.g. `Profiles[2].Forwards[0].Kind`).
 
 ### Auto-detection
 
-If the parsed root object has a `profiles` array → treat as `SshStoreDocument` and
-validate each entry. Otherwise → treat as a single `SshProfile`.
+If the parsed root object has a `Profiles` property → treat as `SshStoreDocument` and
+validate each entry under the path `Profiles[i].`. Otherwise → treat as a single
+`SshProfile`.
 
 ### Tiered validation rules
 
@@ -108,29 +120,32 @@ validate each entry. Otherwise → treat as a single `SshProfile`.
 
 - JSON parse failure.
 - Root is not a JSON object.
-- Wrong JSON type for a known field (e.g. `port: "22"`, `tags` not an array).
-- Unknown enum value for `backendKind`, `authMode`, `remoteShellKind`, or
-  `forwards[].kind`.
-- `port` or `jumpHops[].port` outside 1–65535.
-- `sourcePort` or `destinationPort` outside 0–65535.
-- `serverAliveIntervalSeconds` or `serverAliveCountMax` < 1.
-- `controlPersistSeconds` < 0.
-- Missing or blank required `host`.
-- Missing required `name`.
-- (Document shape) missing `schemaVersion`, or `profiles` is not an array.
+- Wrong JSON type for a known field (e.g. `Port: "22"`, `Tags` not an array).
+- Enum field (`BackendKind`, `AuthMode`, `RemoteShellKind`, `Forwards[].Kind`) that is not
+  a JSON integer, or is an integer outside its defined range. The message includes the
+  int→name mapping as a hint.
+- `Port` or `JumpHops[].Port` outside 1–65535.
+- `SourcePort` or `DestinationPort` outside 0–65535.
+- `ServerAliveIntervalSeconds` or `ServerAliveCountMax` < 1.
+- `ControlPersistSeconds` < 0.
+- Missing or blank required `Host`.
+- Missing required `Name`.
+- (Document shape) `Profiles` present but not a JSON array.
 
 **Warnings (still `VALID`):**
 
 - Unknown / extra field (top-level or nested).
-- Malformed `id` GUID.
-- Unknown `schemaVersion` value (≠ 1) — forward-compatibility note.
-- `authMode: IdentityFile` with a blank `identityFilePath`.
-- A `Local` or `Remote` forward with `sourcePort` or `destinationPort` = 0.
-- A `password` field present anywhere — **security flag**; passwords are vault-managed and
-  must never appear in profile JSON.
+- Malformed `Id` GUID.
+- Missing, zero, or negative `SchemaVersion` (the store auto-defaults it to 1).
+- `SchemaVersion` > 1 — forward-compatibility note.
+- `AuthMode` = 2 (IdentityFile) with a blank `IdentityFilePath`.
+- A `Local` (Kind 0) or `Remote` (Kind 1) forward with `SourcePort` or `DestinationPort` = 0.
+- A `Password` field present anywhere (case-insensitive) — **security flag**; passwords are
+  vault-managed and must never appear in profile JSON.
 
-**Required fields:** `name` + `host` for a single profile; `schemaVersion` + `profiles[]`
-for a document. Every other field is optional (has a default).
+**Required fields:** `Name` + `Host` for a single profile; a `Profiles` array for a
+document (`SchemaVersion` is recommended but warned, not required). Every other field is
+optional (has a default).
 
 Validity rule: zero errors → `VALID` (warnings do not fail validation); any error →
 `INVALID`.
@@ -150,18 +165,23 @@ Validity rule: zero errors → `VALID` (warnings do not fail validation); any er
 New file: `tests/NovaTerminal.McpServer.Tests/ConnectionProfileToolsTests.cs`
 (xUnit v3, matching `ThemeToolsTests` style).
 
-- **Schema tool:** non-empty output; contains each field-group heading; the embedded
-  example parses as JSON and passes its own validator (self-consistency).
-- **Validator happy paths:** minimal valid single profile; full profile with
-  `jumpHops` / `forwards` / `muxOptions`; full `SshStoreDocument` with multiple profiles.
-- **Validator errors:** parse failure; non-object root; bad enum (`authMode: "Foo"`);
-  `port: 0` and `port: 70000`; `serverAliveCountMax: 0`; missing `host`; missing `name`;
-  document missing `schemaVersion`; `profiles` not an array; wrong type (`port: "22"`).
-- **Validator warnings (still VALID):** unknown field; `password` present (security flag);
-  malformed `id`; `authMode: IdentityFile` with blank path; unknown `schemaVersion`.
+- **Schema tool:** non-empty output; contains each field-group heading and each enum
+  int→name mapping; the embedded example parses as JSON and passes its own validator
+  (self-consistency).
+- **Validator happy paths:** minimal valid single profile (`Name` + `Host`); full profile
+  with `JumpHops` / `Forwards` / `MuxOptions` and integer enums; full `SshStoreDocument`
+  (`SchemaVersion` + `Profiles[]`) with multiple profiles.
+- **Validator errors:** parse failure; non-object root; enum out of range (`AuthMode: 9`);
+  enum non-integer (`BackendKind: "OpenSsh"`); `Port: 0` and `Port: 70000`;
+  `ServerAliveCountMax: 0`; missing `Host`; missing `Name`; `Profiles` not an array;
+  wrong type (`Port: "22"`).
+- **Validator warnings (still VALID):** unknown field; `Password` present (security flag);
+  malformed `Id`; `AuthMode: 2` with blank `IdentityFilePath`; missing `SchemaVersion`;
+  `SchemaVersion: 2`.
 - **Robustness:** null / empty input; nested path reporting
-  (`profiles[2].forwards[0].kind`).
-- **Auto-detect:** the same payload recognized correctly as single vs document.
+  (`Profiles[2].Forwards[0].Kind`).
+- **Auto-detect:** a single-profile payload vs a `{ "Profiles": [...] }` document
+  recognized correctly.
 
 **Drift guard:** add a **test-only** `ProjectReference` from
 `tests/NovaTerminal.McpServer.Tests` (not the server) to `NovaTerminal.Platform`, plus a

--- a/docs/superpowers/specs/2026-06-27-mcp-connection-profile-tools-design.md
+++ b/docs/superpowers/specs/2026-06-27-mcp-connection-profile-tools-design.md
@@ -125,21 +125,26 @@ validate each entry under the path `Profiles[i].`. Otherwise → treat as a sing
   a JSON integer, or is an integer outside its defined range. The message includes the
   int→name mapping as a hint.
 - `Port` or `JumpHops[].Port` outside 1–65535.
-- `SourcePort` or `DestinationPort` outside 0–65535.
+- Missing or out-of-range `SourcePort` (1–65535) on any forward — the OpenSSH config compiler
+  drops forwards with `SourcePort <= 0`, so anything else would validate yet be silently omitted.
+- A `Local` (Kind 0) or `Remote` (Kind 1) forward missing a non-empty `DestinationHost` or a
+  `DestinationPort` in 1–65535 — those forwards are likewise dropped by the compiler. (Dynamic /
+  Kind 2 forwards have no fixed destination; their destination fields are only range-checked if
+  present.) An omitted `Kind` deserializes to `0` (Local), so it is held to the Local requirements.
 - `ServerAliveIntervalSeconds` or `ServerAliveCountMax` < 1.
 - `ControlPersistSeconds` < 0.
-- Missing or blank required `Host`.
+- Missing or blank required `Host`; on a jump hop, a missing or blank `Host` is likewise an error.
 - Missing required `Name`.
+- Malformed `Id` GUID — unrecoverable: the store deserializes `Id` straight into a `Guid`, and the
+  parse failure quarantines the entire `profiles.json` on load.
 - (Document shape) `Profiles` present but not a JSON array.
 
 **Warnings (still `VALID`):**
 
 - Unknown / extra field (top-level or nested).
-- Malformed `Id` GUID.
 - Missing, zero, or negative `SchemaVersion` (the store auto-defaults it to 1).
 - `SchemaVersion` > 1 — forward-compatibility note.
 - `AuthMode` = 2 (IdentityFile) with a blank `IdentityFilePath`.
-- A `Local` (Kind 0) or `Remote` (Kind 1) forward with `SourcePort` or `DestinationPort` = 0.
 - A `Password` field present anywhere (case-insensitive) — **security flag**; passwords are
   vault-managed and must never appear in profile JSON.
 

--- a/docs/superpowers/specs/2026-06-27-mcp-connection-profile-tools-design.md
+++ b/docs/superpowers/specs/2026-06-27-mcp-connection-profile-tools-design.md
@@ -1,0 +1,196 @@
+# MCP Dev Companion — Connection-Profile Schema & Validation Tools (v0.3)
+
+**Date:** 2026-06-27
+**Status:** Design approved, ready for implementation plan
+**Component:** `src/NovaTerminal.McpServer`
+
+## Summary
+
+Add two read-only MCP tools to the NovaTerminal MCP Dev Companion that let a
+developer or AI client discover and validate the connection-profile JSON format:
+
+- `novaterminal.get_connection_profile_schema`
+- `novaterminal.validate_connection_profile_json`
+
+These were previously deferred (see `docs/mcp/tools.md` → "Still deferred") on the
+grounds that the profile format had "no stable documented schema" and "contains a
+sensitive `Password` field." Investigation of the codebase shows both concerns are
+already resolved by the existing design, so the work is lower-risk than the roadmap
+note implied (see Background). This brings the server's tool count from **11 → 13**.
+
+## Background — the two profile models
+
+There are two profile types in the codebase, and only one is persisted:
+
+- **`SshProfile`** (`src/NovaTerminal.Platform/Ssh/Models/SshProfile.cs`) is the model
+  actually serialized to disk at `%LOCALAPPDATA%\NovaTerminal\ssh\profiles.json`. It has
+  a **stable, source-generated JSON contract** (`SshJsonContext`): camelCase property
+  names, enums-as-strings, `WriteIndented`, wrapped in an `SshStoreDocument` carrying a
+  `schemaVersion` field (current value `1`). It has **no `Password` field** — passwords
+  live in the credential vault keyed by `ProfileId` (`VaultService`).
+- **`TerminalProfile`** (`src/NovaTerminal.App/Shell/TerminalProfile.cs`) is the app-layer
+  model that *does* declare a `Password` property, but it is `[JsonIgnore]` and never
+  serialized.
+
+Therefore:
+- A "stable documented schema" effectively already exists (the source generator).
+- The "sensitive `Password` field" is already excluded from JSON.
+
+The tools target the **`SshProfile` / `SshStoreDocument` on-disk format** — the JSON a
+developer would author or inspect in `profiles.json`.
+
+## Goals
+
+- Let a client retrieve a human-readable description of the profile JSON format.
+- Let a client validate a pasted profile JSON (single profile *or* full document) and
+  receive actionable, tiered feedback.
+- Keep the server's existing security posture: read-only, no `ProjectReference` to the
+  rest of the solution, no process/network/credential access.
+
+## Non-goals
+
+- No formal JSON Schema (draft 2020-12) document — descriptive prose + an annotated
+  example only, matching the existing `get_theme_schema` pattern.
+- No separate hand-written schema markdown file — the tool *is* the canonical schema doc.
+- No reading or writing of the user's real `profiles.json` — the validator operates only
+  on JSON passed in as a string argument.
+- No validation of vault/password storage — out of scope and intentionally so.
+
+## Architectural constraint
+
+The MCP server deliberately has **no `ProjectReference`** to the rest of the solution
+(security isolation). The tools therefore **cannot import `SshProfile`**; they parse with
+`System.Text.Json` (`JsonDocument` / `JsonNode`) against hand-written knowledge of the
+field names, types, and enum values — exactly like the existing `validate_theme_json`.
+
+This reintroduces a drift risk (a new `SshProfile` field would be unknown to the tool).
+It is mitigated by a reflection-based **drift-guard test** (see Testing) that lives in the
+*test* project, not the server.
+
+## Tool 1 — `get_connection_profile_schema`
+
+- **Input:** none.
+- **Output:** descriptive text, fields grouped by area, each with type / enum values /
+  default, followed by a complete annotated example covering both the single-profile and
+  full-document shapes.
+
+Field groups (from `SshProfile`):
+
+- **Identity / org:** `id` (GUID), `name`, `groupPath`, `notes`, `accentColor`, `tags[]`
+- **Connection:** `host`, `user`, `port` (default 22), `backendKind` (`OpenSsh` | `Native`)
+- **Auth:** `authMode` (`Default` | `Agent` | `IdentityFile`), `identityFilePath`,
+  `rememberPasswordInVault`
+- **Jump hosts:** `jumpHops[]` → `{ host, user, port }`
+- **Port forwarding:** `forwards[]` →
+  `{ kind: Local | Remote | Dynamic, bindAddress, sourcePort, destinationHost, destinationPort }`
+- **Multiplexing:** `muxOptions` →
+  `{ enabled, controlMasterAuto, controlPath, controlPersistSeconds }`
+- **Session / shell:** `serverAliveIntervalSeconds` (default 30),
+  `serverAliveCountMax` (default 3), `extraSshArgs`, `workingDirectory`,
+  `remoteShellKind` (`Auto` | `Bash` | `Zsh` | `Fish` | `Pwsh`)
+- **Document wrapper:** `schemaVersion` (int, current = 1), `profiles[]`
+
+## Tool 2 — `validate_connection_profile_json`
+
+- **Input:** `profileJson` (string).
+- **Output:** a `VALID` / `INVALID` report mirroring `validate_theme_json`: a header line,
+  then grouped error and warning lines, each with a field path
+  (e.g. `profiles[2].forwards[0].kind`).
+
+### Auto-detection
+
+If the parsed root object has a `profiles` array → treat as `SshStoreDocument` and
+validate each entry. Otherwise → treat as a single `SshProfile`.
+
+### Tiered validation rules
+
+**Errors (→ `INVALID`):**
+
+- JSON parse failure.
+- Root is not a JSON object.
+- Wrong JSON type for a known field (e.g. `port: "22"`, `tags` not an array).
+- Unknown enum value for `backendKind`, `authMode`, `remoteShellKind`, or
+  `forwards[].kind`.
+- `port` or `jumpHops[].port` outside 1–65535.
+- `sourcePort` or `destinationPort` outside 0–65535.
+- `serverAliveIntervalSeconds` or `serverAliveCountMax` < 1.
+- `controlPersistSeconds` < 0.
+- Missing or blank required `host`.
+- Missing required `name`.
+- (Document shape) missing `schemaVersion`, or `profiles` is not an array.
+
+**Warnings (still `VALID`):**
+
+- Unknown / extra field (top-level or nested).
+- Malformed `id` GUID.
+- Unknown `schemaVersion` value (≠ 1) — forward-compatibility note.
+- `authMode: IdentityFile` with a blank `identityFilePath`.
+- A `Local` or `Remote` forward with `sourcePort` or `destinationPort` = 0.
+- A `password` field present anywhere — **security flag**; passwords are vault-managed and
+  must never appear in profile JSON.
+
+**Required fields:** `name` + `host` for a single profile; `schemaVersion` + `profiles[]`
+for a document. Every other field is optional (has a default).
+
+Validity rule: zero errors → `VALID` (warnings do not fail validation); any error →
+`INVALID`.
+
+## Placement & implementation notes
+
+- New tool class alongside the existing static tool classes in
+  `src/NovaTerminal.McpServer`, following the same `[McpServerTool]` static-method pattern
+  as the theme tools.
+- A code comment in the new tool class points at
+  `src/NovaTerminal.Platform/Ssh/Models/SshProfile.cs` as the source of truth, noting the
+  drift-guard test.
+- Logging stays on stderr (stdio transport requirement); no new dependencies.
+
+## Testing
+
+New file: `tests/NovaTerminal.McpServer.Tests/ConnectionProfileToolsTests.cs`
+(xUnit v3, matching `ThemeToolsTests` style).
+
+- **Schema tool:** non-empty output; contains each field-group heading; the embedded
+  example parses as JSON and passes its own validator (self-consistency).
+- **Validator happy paths:** minimal valid single profile; full profile with
+  `jumpHops` / `forwards` / `muxOptions`; full `SshStoreDocument` with multiple profiles.
+- **Validator errors:** parse failure; non-object root; bad enum (`authMode: "Foo"`);
+  `port: 0` and `port: 70000`; `serverAliveCountMax: 0`; missing `host`; missing `name`;
+  document missing `schemaVersion`; `profiles` not an array; wrong type (`port: "22"`).
+- **Validator warnings (still VALID):** unknown field; `password` present (security flag);
+  malformed `id`; `authMode: IdentityFile` with blank path; unknown `schemaVersion`.
+- **Robustness:** null / empty input; nested path reporting
+  (`profiles[2].forwards[0].kind`).
+- **Auto-detect:** the same payload recognized correctly as single vs document.
+
+**Drift guard:** add a **test-only** `ProjectReference` from
+`tests/NovaTerminal.McpServer.Tests` (not the server) to `NovaTerminal.Platform`, plus a
+reflection test asserting:
+
+- the documented field set matches `SshProfile`'s public properties (and nested types'
+  properties), and
+- the enum value lists used by the tools match the actual enums
+  (`SshBackendKind`, `SshAuthMode`, `RemoteShellKind`, `PortForwardKind`).
+
+If someone adds or renames an `SshProfile` field, this test fails in CI and points at the
+MCP tool to update.
+
+## Documentation updates
+
+- `docs/mcp/tools.md`: add the two tools to the tools table; **remove** the
+  connection-profile entry from the "Still deferred" section.
+- `docs/mcp-dev-companion.md`: bump tool count 11 → 13; note as the v0.3 increment.
+
+## CI
+
+The `NovaTerminal.McpServer.Tests` project is already registered in the unit-test loop, so
+no new project registration is needed. Verify `ci.yml` needs no path changes for the new
+test file (it should not, since the project is already listed). The new test-only
+`ProjectReference` to `NovaTerminal.Platform` must build cleanly in the CI test job.
+
+## Out of scope / future
+
+- Running-app read-only bridge tools (`list_open_tabs`, `get_active_profile_metadata`, …)
+  remain deferred — sensitive, opt-in, require a separate threat model.
+- A formal machine-readable JSON Schema document could be added later if a consuming
+  linter needs it.

--- a/src/NovaTerminal.McpServer/README.md
+++ b/src/NovaTerminal.McpServer/README.md
@@ -1,0 +1,150 @@
+# NovaTerminal MCP Dev Companion
+
+A local, **read-only** [Model Context Protocol](https://modelcontextprotocol.io) server that
+exposes NovaTerminal's project knowledge to AI coding agents (Claude Desktop, Claude Code, VS
+Code, etc.). It helps you explore the architecture, understand VT/ANSI behavior, and author or
+validate theme and SSH connection-profile JSON — without leaving your editor.
+
+This is a **developer tool**, not a user-facing NovaTerminal feature.
+
+## Safety posture
+
+The server is deliberately constrained and isolated:
+
+- **Read-only.** It never executes shell commands, opens SSH connections, reads live terminal
+  buffers, accesses saved credentials or private keys, modifies profiles, or controls the running
+  app.
+- **No network access.**
+- **No coupling to the rest of the solution.** The project has **no `ProjectReference`** to any
+  other NovaTerminal assembly — it only reads repo docs and validates JSON against self-contained
+  schemas. (Where it mirrors a real type — e.g. the SSH profile schema — a drift-guard test in
+  `tests/NovaTerminal.McpServer.Tests` keeps the copy honest.)
+- **Filesystem access is confined to `docs/`.** Doc reads reject path traversal (`..`), absolute
+  paths, and symlink escapes.
+
+## Tech stack
+
+- .NET 10 (`net10.0`), C#
+- [`ModelContextProtocol`](https://www.nuget.org/packages/ModelContextProtocol) SDK
+- `Microsoft.Extensions.Hosting`
+- Transport: **stdio** (JSON-RPC over stdin/stdout)
+
+## Build
+
+Use the repo's build wrapper (raw `dotnet build` can hang when stdout is captured — see the root
+`CLAUDE.md`):
+
+```bash
+# Windows / PowerShell
+scripts/build.ps1 build -c Release src/NovaTerminal.McpServer
+
+# Linux / macOS / Git Bash
+scripts/build.sh build -c Release src/NovaTerminal.McpServer
+```
+
+This produces `src/NovaTerminal.McpServer/bin/Release/net10.0/NovaTerminal.McpServer.dll`.
+
+## Run
+
+Run the **built DLL** directly:
+
+```bash
+dotnet src/NovaTerminal.McpServer/bin/Release/net10.0/NovaTerminal.McpServer.dll
+```
+
+> ⚠️ **Do not use `dotnet run`.** It emits build/restore output to stdout, which corrupts the MCP
+> JSON-RPC stream the client reads. Always launch the compiled DLL. (All logging in the server is
+> pinned to stderr for the same reason.)
+
+The server speaks stdio and is meant to be launched **by an MCP client**, not run interactively —
+on its own it will simply wait for JSON-RPC input.
+
+### Repository root discovery
+
+Tools that read repo docs need to know where the repository is. The server resolves the root by:
+
+1. The `NOVATERMINAL_REPO_ROOT` environment variable, if set; otherwise
+2. Walking up from the current directory until it finds `NovaTerminal.sln`.
+
+When a client launches the server from an arbitrary working directory, set
+`NOVATERMINAL_REPO_ROOT` explicitly (see the example configs below).
+
+## Client setup
+
+Ready-to-edit example configs live in [`examples/mcp/`](../../examples/mcp/):
+
+- **Claude Desktop** — [`examples/mcp/claude_desktop_config.json`](../../examples/mcp/claude_desktop_config.json)
+- **VS Code** (`.vscode/mcp.json`) — [`examples/mcp/vscode_mcp_config.json`](../../examples/mcp/vscode_mcp_config.json)
+
+Both follow the same shape: launch `dotnet` with the path to the built DLL and set
+`NOVATERMINAL_REPO_ROOT`. Build the project once first, then point the config at the DLL. For
+Claude Desktop, replace `/absolute/path/to/nova2` with your local clone path; the VS Code config
+uses `${workspaceFolder}`.
+
+Example (Claude Desktop):
+
+```json
+{
+  "mcpServers": {
+    "novaterminal-dev": {
+      "command": "dotnet",
+      "args": [
+        "/absolute/path/to/nova2/src/NovaTerminal.McpServer/bin/Release/net10.0/NovaTerminal.McpServer.dll"
+      ],
+      "env": {
+        "NOVATERMINAL_REPO_ROOT": "/absolute/path/to/nova2"
+      }
+    }
+  }
+}
+```
+
+After editing the config, restart the client; the `novaterminal-dev` tools should appear in its
+tool list.
+
+## Tools
+
+All tools are read-only. See [`docs/mcp/tools.md`](../../docs/mcp/tools.md) for the authoritative
+list and notes; the current set:
+
+| Tool | Inputs | What it does |
+|------|--------|-------------|
+| `novaterminal.get_project_summary` | — | What NovaTerminal is, tech stack, assembly/module layout, key conventions. Start here. |
+| `novaterminal.get_architecture_map` | — | The module-ownership map: per-assembly namespaces, dependencies, responsibilities, invariants. |
+| `novaterminal.list_docs` | — | Lists Markdown docs under `docs/`. |
+| `novaterminal.read_doc` | `path` | Reads a doc by path relative to `docs/` (traversal rejected). |
+| `novaterminal.get_vt_conformance_summary` | — | VT/ANSI conformance status and known gaps. |
+| `novaterminal.explain_escape_sequence` | `sequence` | Explains a VT/ANSI escape sequence (e.g. `ESC[2J`, `CSI ?25h`, `OSC 8`). |
+| `novaterminal.generate_vt_test_plan` | `feature` | A structured VT test plan (cases, where tests live, verification). |
+| `novaterminal.get_theme_schema` | — | Theme JSON schema: required fields, color formats, example. |
+| `novaterminal.validate_theme_json` | `themeJson` | Validates a theme JSON; reports missing fields, invalid colors, unknown fields. |
+| `novaterminal.get_connection_profile_schema` | — | SSH connection-profile JSON schema: PascalCase fields by area, integer enum mappings, defaults, example. Covers a single profile or a full `profiles.json` document. |
+| `novaterminal.validate_connection_profile_json` | `profileJson` | Validates a connection-profile JSON (single profile or full document, auto-detected); reports wrong types, out-of-range integer enums/ports, missing `Name`/`Host`, and warns on unknown fields and any stray `Password`. |
+| `novaterminal.generate_codex_prompt_for_issue` | `title`, `description?` | A structured implementation prompt (relevant areas, constraints, PR size, steps, tests, acceptance, risks). |
+| `novaterminal.suggest_relevant_files` | `topic` | The concrete source/test files most relevant to a topic (e.g. `reflow`, `glyph atlas`, `ssh key auth`). |
+
+Self-contained tools (no filesystem access): `get_project_summary`, `get_theme_schema`,
+`validate_theme_json`, `get_connection_profile_schema`, `validate_connection_profile_json`,
+`generate_codex_prompt_for_issue`. The rest read files under `docs/` and need the repo root.
+
+### Example: validate a profile
+
+Ask your agent: *"Validate this connection profile."* The agent calls
+`validate_connection_profile_json` with your JSON. Note the on-disk format uses **PascalCase**
+keys and **integer-valued enums** (call `get_connection_profile_schema` for the mappings).
+Passwords are stored in the OS credential vault and must never appear in profile JSON — a stray
+`Password` field is flagged.
+
+## Development
+
+Run the test project (targeted — the full solution test suite is slow):
+
+```bash
+scripts/build.ps1 test tests/NovaTerminal.McpServer.Tests
+```
+
+## Further reading
+
+- [`docs/mcp-dev-companion.md`](../../docs/mcp-dev-companion.md) — overview, goals, and non-goals
+- [`docs/mcp/tools.md`](../../docs/mcp/tools.md) — authoritative tool list
+- [`docs/mcp/security.md`](../../docs/mcp/security.md) — security model

--- a/src/NovaTerminal.McpServer/Tools/ConnectionProfileTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/ConnectionProfileTools.cs
@@ -229,13 +229,7 @@ public static class ConnectionProfileTools
             }
         }
 
-        foreach (var prop in root.EnumerateObject())
-        {
-            if (prop.Name is not ("SchemaVersion" or "Profiles"))
-            {
-                warnings.Add($"Unknown field '{prop.Name}' (ignored).");
-            }
-        }
+        CheckUnknownAndPassword(root, string.Empty, DocumentFields, errors, warnings);
     }
 
     private static void ValidateProfile(

--- a/src/NovaTerminal.McpServer/Tools/ConnectionProfileTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/ConnectionProfileTools.cs
@@ -60,14 +60,17 @@ public static class ConnectionProfileTools
         `JumpHops` is an array of `{ "Host": string, "User": string, "Port": int (1–65535) }`.
 
         ## Port forwarding
-        `Forwards` is an array of objects:
+        `Forwards` is an array of objects. `SourcePort` is required (1–65535) on every forward.
+        Local/Remote forwards also require a non-empty `DestinationHost` and `DestinationPort`
+        (1–65535); Dynamic forwards (SOCKS) have no fixed destination. An omitted `Kind` means
+        Local (0).
         | Field | Type | Notes |
         |-------|------|-------|
-        | `Kind` | int enum | 0=Local, 1=Remote, 2=Dynamic. |
+        | `Kind` | int enum | 0=Local, 1=Remote, 2=Dynamic. Omitted = 0 (Local). |
         | `BindAddress` | string | e.g. "127.0.0.1". |
-        | `SourcePort` | int | 0–65535. |
-        | `DestinationHost` | string | Forward target host. |
-        | `DestinationPort` | int | 0–65535. |
+        | `SourcePort` | int | Required, 1–65535. |
+        | `DestinationHost` | string | Required for Local/Remote; unused for Dynamic. |
+        | `DestinationPort` | int | Required 1–65535 for Local/Remote; unused for Dynamic. |
 
         ## Multiplexing
         `MuxOptions` is `{ "Enabled": bool, "ControlMasterAuto": bool, "ControlPath": string, "ControlPersistSeconds": int (>= 0) }`.
@@ -255,7 +258,9 @@ public static class ConnectionProfileTools
             }
             else if (!Guid.TryParse(idEl.GetString(), out _))
             {
-                warnings.Add($"{path}Field 'Id' is not a valid GUID; the store will assign one.");
+                // A non-GUID Id is unrecoverable: the store deserializes Id straight into a Guid,
+                // and the resulting parse failure quarantines the entire profiles.json on load.
+                errors.Add($"{path}Field 'Id' must be a valid GUID; an unparseable Id makes the store quarantine the whole profiles.json on load.");
             }
         }
 
@@ -330,7 +335,8 @@ public static class ConnectionProfileTools
     private static void ValidateJumpHop(
         JsonElement h, string path, List<string> errors, List<string> warnings)
     {
-        RequireStringType(h, path, "Host", errors);
+        // A jump hop is meaningless without a host to connect to — require it, like profile Host.
+        RequireNonEmptyString(h, path, "Host", errors);
         RequireStringType(h, path, "User", errors);
         CheckIntRange(h, path, "Port", 1, 65535, errors);
         CheckUnknownAndPassword(h, path, JumpHopFields, errors, warnings);
@@ -341,16 +347,29 @@ public static class ConnectionProfileTools
     {
         CheckEnum(f, path, "Kind", PortForwardKindNames, errors);
         RequireStringType(f, path, "BindAddress", errors);
-        RequireStringType(f, path, "DestinationHost", errors);
-        CheckIntRange(f, path, "SourcePort", 0, 65535, errors);
-        CheckIntRange(f, path, "DestinationPort", 0, 65535, errors);
 
-        if (f.TryGetProperty("Kind", out var kEl)
-            && kEl.ValueKind == JsonValueKind.Number
-            && kEl.TryGetInt32(out var kind) && (kind == 0 || kind == 1))
+        // A missing Kind deserializes to 0 (Local).
+        int kind = 0;
+        if (f.TryGetProperty("Kind", out var kEl) && kEl.ValueKind == JsonValueKind.Number)
         {
-            WarnZeroPort(f, path, "SourcePort", warnings);
-            WarnZeroPort(f, path, "DestinationPort", warnings);
+            kEl.TryGetInt32(out kind);
+        }
+
+        // Every forward needs a usable source port: OpenSshConfigCompiler.AppendForward drops
+        // forwards with SourcePort <= 0, so anything else would validate yet be silently omitted.
+        RequireIntRange(f, path, "SourcePort", 1, 65535, errors);
+
+        if (kind == 0 || kind == 1)
+        {
+            // Local/Remote forwards are dropped without a destination host + positive port.
+            RequireNonEmptyString(f, path, "DestinationHost", errors);
+            RequireIntRange(f, path, "DestinationPort", 1, 65535, errors);
+        }
+        else
+        {
+            // Dynamic forwards have no fixed destination; only range-check destination fields if present.
+            RequireStringType(f, path, "DestinationHost", errors);
+            CheckIntRange(f, path, "DestinationPort", 0, 65535, errors);
         }
 
         CheckUnknownAndPassword(f, path, PortForwardFields, errors, warnings);
@@ -440,15 +459,17 @@ public static class ConnectionProfileTools
         }
     }
 
-    private static void WarnZeroPort(
-        JsonElement obj, string path, string field, List<string> warnings)
+    // Like CheckIntRange, but the field is mandatory: a missing value is an error too.
+    private static void RequireIntRange(
+        JsonElement obj, string path, string field, int min, int max, List<string> errors)
     {
-        if (obj.TryGetProperty(field, out var el)
-            && el.ValueKind == JsonValueKind.Number
-            && el.TryGetInt32(out var v) && v == 0)
+        if (!obj.TryGetProperty(field, out _))
         {
-            warnings.Add($"{path}Field '{field}' is 0 for a Local/Remote forward; expected a real port.");
+            errors.Add($"{path}Missing required field '{field}'.");
+            return;
         }
+
+        CheckIntRange(obj, path, field, min, max, errors);
     }
 
     private static void CheckUnknownAndPassword(

--- a/src/NovaTerminal.McpServer/Tools/ConnectionProfileTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/ConnectionProfileTools.cs
@@ -1,0 +1,121 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+
+namespace NovaTerminal.McpServer.Tools;
+
+// Source of truth for field names / enum values:
+//   src/NovaTerminal.Platform/Ssh/Models/SshProfile.cs (+ SshJumpHop, PortForward,
+//   SshMuxOptions) and SshProfileStoreSnapshot in Ssh/Storage/ISshProfileStore.cs.
+// This server has NO ProjectReference to NovaTerminal.Platform by design, so that
+// knowledge is hand-mirrored below. A reflection drift-guard test in
+// NovaTerminal.McpServer.Tests fails if those types change. Keep both in sync.
+[McpServerToolType]
+public static class ConnectionProfileTools
+{
+    [McpServerTool(Name = "novaterminal.get_connection_profile_schema"),
+     Description("Returns the schema for a NovaTerminal SSH connection-profile JSON: PascalCase fields grouped by area, integer enum mappings, defaults, and a complete example. The on-disk format uses integer-valued enums; passwords are vault-managed and never stored in profile JSON. Use before authoring or editing a profile.")]
+    public static string GetConnectionProfileSchema() =>
+        """
+        # NovaTerminal connection-profile (SSH) JSON schema
+
+        Profiles are stored at `%LOCALAPPDATA%\NovaTerminal\ssh\profiles.json`. The on-disk
+        format uses **PascalCase** field names and **integer-valued enums**. Passwords are
+        never stored here — they live in the OS credential vault.
+
+        A single profile is a JSON object. The full file wraps profiles in a document:
+        `{ "SchemaVersion": 1, "Profiles": [ <profile>, ... ] }`. The validator accepts
+        either shape.
+
+        ## Identity / organization
+        | Field | Type | Notes |
+        |-------|------|-------|
+        | `Id` | string (GUID) | Optional; the store assigns one if absent/invalid. |
+        | `Name` | string | **Required**, non-empty. |
+        | `GroupPath` | string | Tree path, e.g. "Prod/DB". Default "General". |
+        | `Notes` | string | Free text. |
+        | `AccentColor` | string | e.g. "#3399EE". |
+        | `Tags` | string[] | Labels. |
+
+        ## Connection
+        | Field | Type | Notes |
+        |-------|------|-------|
+        | `Host` | string | **Required**, non-empty. |
+        | `User` | string | SSH user. |
+        | `Port` | int | 1–65535. Default 22. |
+        | `BackendKind` | int enum | 0=OpenSsh, 1=Native. |
+
+        ## Auth
+        | Field | Type | Notes |
+        |-------|------|-------|
+        | `AuthMode` | int enum | 0=Default, 1=Agent, 2=IdentityFile. |
+        | `IdentityFilePath` | string | Key path; expected when AuthMode is 2 (IdentityFile). |
+        | `RememberPasswordInVault` | bool | Whether to keep the password in the vault. |
+
+        ## Jump hosts
+        `JumpHops` is an array of `{ "Host": string, "User": string, "Port": int (1–65535) }`.
+
+        ## Port forwarding
+        `Forwards` is an array of objects:
+        | Field | Type | Notes |
+        |-------|------|-------|
+        | `Kind` | int enum | 0=Local, 1=Remote, 2=Dynamic. |
+        | `BindAddress` | string | e.g. "127.0.0.1". |
+        | `SourcePort` | int | 0–65535. |
+        | `DestinationHost` | string | Forward target host. |
+        | `DestinationPort` | int | 0–65535. |
+
+        ## Multiplexing
+        `MuxOptions` is `{ "Enabled": bool, "ControlMasterAuto": bool, "ControlPath": string, "ControlPersistSeconds": int (>= 0) }`.
+
+        ## Session / shell
+        | Field | Type | Notes |
+        |-------|------|-------|
+        | `ServerAliveIntervalSeconds` | int | >= 1. Default 30. |
+        | `ServerAliveCountMax` | int | >= 1. Default 3. |
+        | `ExtraSshArgs` | string | Extra ssh CLI args. |
+        | `WorkingDirectory` | string | Remote working directory. |
+        | `RemoteShellKind` | int enum | 0=Auto, 1=Bash, 2=Zsh, 3=Fish, 4=Pwsh. |
+
+        ## Document wrapper
+        | Field | Type | Notes |
+        |-------|------|-------|
+        | `SchemaVersion` | int | Current = 1. |
+        | `Profiles` | object[] | Array of profile objects. |
+
+        ## Example (full document)
+        ```json
+        {
+          "SchemaVersion": 1,
+          "Profiles": [
+            {
+              "Id": "aeb456e4-8dd2-4b33-a74d-cb473de0323b",
+              "BackendKind": 0,
+              "Name": "prod-db",
+              "GroupPath": "Prod/DB",
+              "Notes": "primary database jump",
+              "AccentColor": "#3399EE",
+              "Tags": ["prod", "db"],
+              "Host": "prod.internal",
+              "User": "svc",
+              "Port": 2222,
+              "AuthMode": 2,
+              "IdentityFilePath": "/home/svc/.ssh/prod_ed25519",
+              "RememberPasswordInVault": false,
+              "JumpHops": [
+                { "Host": "jump-1.internal", "User": "ops", "Port": 22 }
+              ],
+              "Forwards": [
+                { "Kind": 0, "BindAddress": "127.0.0.1", "SourcePort": 5432, "DestinationHost": "db.internal", "DestinationPort": 5432 }
+              ],
+              "MuxOptions": { "Enabled": false, "ControlMasterAuto": true, "ControlPath": "", "ControlPersistSeconds": 0 },
+              "ServerAliveIntervalSeconds": 30,
+              "ServerAliveCountMax": 3,
+              "ExtraSshArgs": "",
+              "WorkingDirectory": "",
+              "RemoteShellKind": 0
+            }
+          ]
+        }
+        ```
+        """;
+}

--- a/src/NovaTerminal.McpServer/Tools/ConnectionProfileTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/ConnectionProfileTools.cs
@@ -1,4 +1,9 @@
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
 using ModelContextProtocol.Server;
 
 namespace NovaTerminal.McpServer.Tools;
@@ -118,4 +123,405 @@ public static class ConnectionProfileTools
         }
         ```
         """;
+
+    private const int CurrentSchemaVersion = 1;
+
+    // Known PascalCase field names (mirror SshProfile etc.; guarded by drift-guard test).
+    internal static readonly string[] ProfileFields =
+    {
+        "Id", "BackendKind", "Name", "GroupPath", "Notes", "AccentColor", "Tags", "Host",
+        "User", "Port", "AuthMode", "IdentityFilePath", "RememberPasswordInVault",
+        "JumpHops", "Forwards", "MuxOptions", "ServerAliveIntervalSeconds",
+        "ServerAliveCountMax", "ExtraSshArgs", "WorkingDirectory", "RemoteShellKind",
+    };
+    internal static readonly string[] JumpHopFields = { "Host", "User", "Port" };
+    internal static readonly string[] PortForwardFields =
+        { "Kind", "BindAddress", "SourcePort", "DestinationHost", "DestinationPort" };
+    internal static readonly string[] MuxFields =
+        { "Enabled", "ControlMasterAuto", "ControlPath", "ControlPersistSeconds" };
+    internal static readonly string[] DocumentFields = { "SchemaVersion", "Profiles" };
+
+    // Enum names indexed by integer value (mirror the enums; guarded by drift-guard test).
+    internal static readonly string[] BackendKindNames = { "OpenSsh", "Native" };
+    internal static readonly string[] AuthModeNames = { "Default", "Agent", "IdentityFile" };
+    internal static readonly string[] PortForwardKindNames = { "Local", "Remote", "Dynamic" };
+    internal static readonly string[] RemoteShellKindNames = { "Auto", "Bash", "Zsh", "Fish", "Pwsh" };
+
+    [McpServerTool(Name = "novaterminal.validate_connection_profile_json"),
+     Description("Validates a NovaTerminal SSH connection-profile JSON string. Accepts either a single profile object or a full profiles.json document ({ \"SchemaVersion\", \"Profiles\": [...] }); auto-detects which. Reports errors (wrong types, out-of-range integer enums/ports, missing required Name/Host) and warnings (unknown fields, a stray Password field, malformed Id, etc.). Passwords are vault-managed and must never appear in profile JSON.")]
+    public static string ValidateConnectionProfileJson(
+        [Description("The connection-profile JSON to validate: a single SshProfile object or a full profiles.json document.")] string profileJson)
+    {
+        if (string.IsNullOrWhiteSpace(profileJson))
+        {
+            return "INVALID: empty input — expected a connection-profile JSON object.";
+        }
+
+        JsonElement root;
+        try
+        {
+            using var doc = JsonDocument.Parse(profileJson);
+            root = doc.RootElement.Clone();
+        }
+        catch (JsonException ex)
+        {
+            return $"INVALID: not valid JSON — {ex.Message}";
+        }
+
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            return $"INVALID: top-level value must be a JSON object, but was {root.ValueKind}.";
+        }
+
+        var errors = new List<string>();
+        var warnings = new List<string>();
+
+        if (root.TryGetProperty("Profiles", out var profilesEl))
+        {
+            ValidateDocument(root, profilesEl, errors, warnings);
+        }
+        else
+        {
+            ValidateProfile(root, string.Empty, errors, warnings);
+        }
+
+        return Report(errors, warnings);
+    }
+
+    private static void ValidateDocument(
+        JsonElement root, JsonElement profilesEl, List<string> errors, List<string> warnings)
+    {
+        if (!root.TryGetProperty("SchemaVersion", out var verEl))
+        {
+            warnings.Add("'SchemaVersion' is missing; the store defaults it to 1.");
+        }
+        else if (verEl.ValueKind != JsonValueKind.Number || !verEl.TryGetInt32(out var ver))
+        {
+            errors.Add($"Field 'SchemaVersion' must be an integer, but was {verEl.ValueKind}.");
+        }
+        else if (ver <= 0)
+        {
+            warnings.Add($"'SchemaVersion' is {ver}; the store defaults non-positive versions to 1.");
+        }
+        else if (ver > CurrentSchemaVersion)
+        {
+            warnings.Add($"'SchemaVersion' is {ver}, newer than the current version {CurrentSchemaVersion}; some fields may be unrecognized.");
+        }
+
+        if (profilesEl.ValueKind != JsonValueKind.Array)
+        {
+            errors.Add($"Field 'Profiles' must be a JSON array, but was {profilesEl.ValueKind}.");
+        }
+        else
+        {
+            int i = 0;
+            foreach (var profile in profilesEl.EnumerateArray())
+            {
+                if (profile.ValueKind != JsonValueKind.Object)
+                {
+                    errors.Add($"'Profiles[{i}]' must be a JSON object, but was {profile.ValueKind}.");
+                }
+                else
+                {
+                    ValidateProfile(profile, $"Profiles[{i}].", errors, warnings);
+                }
+                i++;
+            }
+        }
+
+        foreach (var prop in root.EnumerateObject())
+        {
+            if (prop.Name is not ("SchemaVersion" or "Profiles"))
+            {
+                warnings.Add($"Unknown field '{prop.Name}' (ignored).");
+            }
+        }
+    }
+
+    private static void ValidateProfile(
+        JsonElement p, string path, List<string> errors, List<string> warnings)
+    {
+        RequireNonEmptyString(p, path, "Name", errors);
+        RequireNonEmptyString(p, path, "Host", errors);
+
+        foreach (var f in new[]
+                 {
+                     "GroupPath", "Notes", "AccentColor", "User",
+                     "IdentityFilePath", "ExtraSshArgs", "WorkingDirectory",
+                 })
+        {
+            RequireStringType(p, path, f, errors);
+        }
+
+        if (p.TryGetProperty("Id", out var idEl))
+        {
+            if (idEl.ValueKind != JsonValueKind.String)
+            {
+                errors.Add($"{path}Field 'Id' must be a string GUID, but was {idEl.ValueKind}.");
+            }
+            else if (!Guid.TryParse(idEl.GetString(), out _))
+            {
+                warnings.Add($"{path}Field 'Id' is not a valid GUID; the store will assign one.");
+            }
+        }
+
+        if (p.TryGetProperty("Tags", out var tagsEl))
+        {
+            if (tagsEl.ValueKind != JsonValueKind.Array)
+            {
+                errors.Add($"{path}Field 'Tags' must be an array of strings, but was {tagsEl.ValueKind}.");
+            }
+            else
+            {
+                int ti = 0;
+                foreach (var tag in tagsEl.EnumerateArray())
+                {
+                    if (tag.ValueKind != JsonValueKind.String)
+                    {
+                        errors.Add($"{path}Field 'Tags[{ti}]' must be a string, but was {tag.ValueKind}.");
+                    }
+                    ti++;
+                }
+            }
+        }
+
+        RequireBoolType(p, path, "RememberPasswordInVault", errors);
+
+        CheckEnum(p, path, "BackendKind", BackendKindNames, errors);
+        CheckEnum(p, path, "AuthMode", AuthModeNames, errors);
+        CheckEnum(p, path, "RemoteShellKind", RemoteShellKindNames, errors);
+
+        CheckIntRange(p, path, "Port", 1, 65535, errors);
+        CheckIntRange(p, path, "ServerAliveIntervalSeconds", 1, int.MaxValue, errors);
+        CheckIntRange(p, path, "ServerAliveCountMax", 1, int.MaxValue, errors);
+
+        if (p.TryGetProperty("AuthMode", out var amEl)
+            && amEl.ValueKind == JsonValueKind.Number
+            && amEl.TryGetInt32(out var am) && am == 2)
+        {
+            bool blank = !p.TryGetProperty("IdentityFilePath", out var ipEl)
+                         || ipEl.ValueKind != JsonValueKind.String
+                         || string.IsNullOrWhiteSpace(ipEl.GetString());
+            if (blank)
+            {
+                warnings.Add($"{path}AuthMode is IdentityFile (2) but 'IdentityFilePath' is blank.");
+            }
+        }
+
+        if (p.TryGetProperty("JumpHops", out var hopsEl))
+        {
+            ValidateArrayOfObjects(hopsEl, path, "JumpHops", errors, warnings, ValidateJumpHop);
+        }
+
+        if (p.TryGetProperty("Forwards", out var fwdEl))
+        {
+            ValidateArrayOfObjects(fwdEl, path, "Forwards", errors, warnings, ValidateForward);
+        }
+
+        if (p.TryGetProperty("MuxOptions", out var muxEl))
+        {
+            if (muxEl.ValueKind != JsonValueKind.Object)
+            {
+                errors.Add($"{path}Field 'MuxOptions' must be a JSON object, but was {muxEl.ValueKind}.");
+            }
+            else
+            {
+                ValidateMux(muxEl, $"{path}MuxOptions.", errors, warnings);
+            }
+        }
+
+        CheckUnknownAndPassword(p, path, ProfileFields, errors, warnings);
+    }
+
+    private static void ValidateJumpHop(
+        JsonElement h, string path, List<string> errors, List<string> warnings)
+    {
+        RequireStringType(h, path, "Host", errors);
+        RequireStringType(h, path, "User", errors);
+        CheckIntRange(h, path, "Port", 1, 65535, errors);
+        CheckUnknownAndPassword(h, path, JumpHopFields, errors, warnings);
+    }
+
+    private static void ValidateForward(
+        JsonElement f, string path, List<string> errors, List<string> warnings)
+    {
+        CheckEnum(f, path, "Kind", PortForwardKindNames, errors);
+        RequireStringType(f, path, "BindAddress", errors);
+        RequireStringType(f, path, "DestinationHost", errors);
+        CheckIntRange(f, path, "SourcePort", 0, 65535, errors);
+        CheckIntRange(f, path, "DestinationPort", 0, 65535, errors);
+
+        if (f.TryGetProperty("Kind", out var kEl)
+            && kEl.ValueKind == JsonValueKind.Number
+            && kEl.TryGetInt32(out var kind) && (kind == 0 || kind == 1))
+        {
+            WarnZeroPort(f, path, "SourcePort", warnings);
+            WarnZeroPort(f, path, "DestinationPort", warnings);
+        }
+
+        CheckUnknownAndPassword(f, path, PortForwardFields, errors, warnings);
+    }
+
+    private static void ValidateMux(
+        JsonElement m, string path, List<string> errors, List<string> warnings)
+    {
+        RequireBoolType(m, path, "Enabled", errors);
+        RequireBoolType(m, path, "ControlMasterAuto", errors);
+        RequireStringType(m, path, "ControlPath", errors);
+        CheckIntRange(m, path, "ControlPersistSeconds", 0, int.MaxValue, errors);
+        CheckUnknownAndPassword(m, path, MuxFields, errors, warnings);
+    }
+
+    private static void RequireNonEmptyString(
+        JsonElement obj, string path, string field, List<string> errors)
+    {
+        if (!obj.TryGetProperty(field, out var el))
+        {
+            errors.Add($"{path}Missing required field '{field}'.");
+        }
+        else if (el.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(el.GetString()))
+        {
+            errors.Add($"{path}Field '{field}' must be a non-empty string.");
+        }
+    }
+
+    private static void RequireStringType(
+        JsonElement obj, string path, string field, List<string> errors)
+    {
+        if (obj.TryGetProperty(field, out var el) && el.ValueKind != JsonValueKind.String)
+        {
+            errors.Add($"{path}Field '{field}' must be a string, but was {el.ValueKind}.");
+        }
+    }
+
+    private static void RequireBoolType(
+        JsonElement obj, string path, string field, List<string> errors)
+    {
+        if (obj.TryGetProperty(field, out var el)
+            && el.ValueKind is not (JsonValueKind.True or JsonValueKind.False))
+        {
+            errors.Add($"{path}Field '{field}' must be a boolean, but was {el.ValueKind}.");
+        }
+    }
+
+    private static void CheckEnum(
+        JsonElement obj, string path, string field, string[] names, List<string> errors)
+    {
+        if (!obj.TryGetProperty(field, out var el))
+        {
+            return;
+        }
+
+        string mapping = string.Join(", ", names.Select((n, i) => $"{i}={n}"));
+        if (el.ValueKind != JsonValueKind.Number || !el.TryGetInt32(out var v))
+        {
+            errors.Add($"{path}Field '{field}' must be an integer enum value ({mapping}), but was {el.ValueKind}.");
+            return;
+        }
+
+        if (v < 0 || v >= names.Length)
+        {
+            errors.Add($"{path}Field '{field}' value {v} is out of range ({mapping}).");
+        }
+    }
+
+    private static void CheckIntRange(
+        JsonElement obj, string path, string field, int min, int max, List<string> errors)
+    {
+        if (!obj.TryGetProperty(field, out var el))
+        {
+            return;
+        }
+
+        if (el.ValueKind != JsonValueKind.Number || !el.TryGetInt32(out var v))
+        {
+            errors.Add($"{path}Field '{field}' must be an integer, but was {el.ValueKind}.");
+            return;
+        }
+
+        if (v < min || v > max)
+        {
+            string range = max == int.MaxValue ? $">= {min}" : $"[{min}..{max}]";
+            errors.Add($"{path}Field '{field}' value {v} is out of range ({range}).");
+        }
+    }
+
+    private static void WarnZeroPort(
+        JsonElement obj, string path, string field, List<string> warnings)
+    {
+        if (obj.TryGetProperty(field, out var el)
+            && el.ValueKind == JsonValueKind.Number
+            && el.TryGetInt32(out var v) && v == 0)
+        {
+            warnings.Add($"{path}Field '{field}' is 0 for a Local/Remote forward; expected a real port.");
+        }
+    }
+
+    private static void CheckUnknownAndPassword(
+        JsonElement obj, string path, string[] known, List<string> errors, List<string> warnings)
+    {
+        var set = new HashSet<string>(known, StringComparer.Ordinal);
+        foreach (var prop in obj.EnumerateObject())
+        {
+            if (string.Equals(prop.Name, "Password", StringComparison.OrdinalIgnoreCase))
+            {
+                warnings.Add($"{path}Field '{prop.Name}' must not appear in profile JSON — passwords are stored in the credential vault, not in profiles.");
+                continue;
+            }
+
+            if (!set.Contains(prop.Name))
+            {
+                warnings.Add($"{path}Unknown field '{prop.Name}' (ignored).");
+            }
+        }
+    }
+
+    private static void ValidateArrayOfObjects(
+        JsonElement arr, string parentPath, string field,
+        List<string> errors, List<string> warnings,
+        Action<JsonElement, string, List<string>, List<string>> validateItem)
+    {
+        if (arr.ValueKind != JsonValueKind.Array)
+        {
+            errors.Add($"{parentPath}Field '{field}' must be a JSON array, but was {arr.ValueKind}.");
+            return;
+        }
+
+        int i = 0;
+        foreach (var item in arr.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Object)
+            {
+                errors.Add($"{parentPath}{field}[{i}] must be a JSON object, but was {item.ValueKind}.");
+            }
+            else
+            {
+                validateItem(item, $"{parentPath}{field}[{i}].", errors, warnings);
+            }
+            i++;
+        }
+    }
+
+    private static string Report(List<string> errors, List<string> warnings)
+    {
+        var sb = new StringBuilder();
+        sb.Append(errors.Count == 0 ? "VALID" : "INVALID").Append('\n');
+        if (errors.Count > 0)
+        {
+            sb.Append("\nErrors:\n");
+            foreach (var e in errors)
+            {
+                sb.Append("  - ").Append(e).Append('\n');
+            }
+        }
+        if (warnings.Count > 0)
+        {
+            sb.Append("\nWarnings:\n");
+            foreach (var w in warnings)
+            {
+                sb.Append("  - ").Append(w).Append('\n');
+            }
+        }
+        return sb.ToString().TrimEnd();
+    }
 }

--- a/tests/NovaTerminal.McpServer.Tests/ConnectionProfileDriftGuardTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/ConnectionProfileDriftGuardTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Linq;
+using NovaTerminal.McpServer.Tools;
+using NovaTerminal.Platform;                 // RemoteShellKind
+using NovaTerminal.Platform.Ssh.Models;      // SshProfile, SshJumpHop, PortForward, SshMuxOptions, enums
+using NovaTerminal.Platform.Ssh.Storage;     // SshProfileStoreSnapshot
+
+namespace NovaTerminal.McpServer.Tests;
+
+// Guards against drift between the hand-mirrored field/enum knowledge in
+// ConnectionProfileTools and the real types in NovaTerminal.Platform. If these fail,
+// a profile type changed — update ConnectionProfileTools (fields, enums, schema, rules).
+public class ConnectionProfileDriftGuardTests
+{
+    private static string[] PropNames(Type t) =>
+        t.GetProperties().Select(p => p.Name).OrderBy(n => n, StringComparer.Ordinal).ToArray();
+
+    private static string[] Sorted(string[] values) =>
+        values.OrderBy(n => n, StringComparer.Ordinal).ToArray();
+
+    [Fact]
+    public void ProfileFields_MatchSshProfile() =>
+        Assert.Equal(PropNames(typeof(SshProfile)), Sorted(ConnectionProfileTools.ProfileFields));
+
+    [Fact]
+    public void JumpHopFields_MatchSshJumpHop() =>
+        Assert.Equal(PropNames(typeof(SshJumpHop)), Sorted(ConnectionProfileTools.JumpHopFields));
+
+    [Fact]
+    public void PortForwardFields_MatchPortForward() =>
+        Assert.Equal(PropNames(typeof(PortForward)), Sorted(ConnectionProfileTools.PortForwardFields));
+
+    [Fact]
+    public void MuxFields_MatchSshMuxOptions() =>
+        Assert.Equal(PropNames(typeof(SshMuxOptions)), Sorted(ConnectionProfileTools.MuxFields));
+
+    [Fact]
+    public void DocumentFields_MatchSnapshot() =>
+        Assert.Equal(PropNames(typeof(SshProfileStoreSnapshot)), Sorted(ConnectionProfileTools.DocumentFields));
+
+    // Enum name arrays are indexed by integer value; compare to Enum.GetNames (value order).
+    [Fact]
+    public void BackendKindNames_MatchEnum() =>
+        Assert.Equal(Enum.GetNames<SshBackendKind>(), ConnectionProfileTools.BackendKindNames);
+
+    [Fact]
+    public void AuthModeNames_MatchEnum() =>
+        Assert.Equal(Enum.GetNames<SshAuthMode>(), ConnectionProfileTools.AuthModeNames);
+
+    [Fact]
+    public void PortForwardKindNames_MatchEnum() =>
+        Assert.Equal(Enum.GetNames<PortForwardKind>(), ConnectionProfileTools.PortForwardKindNames);
+
+    [Fact]
+    public void RemoteShellKindNames_MatchEnum() =>
+        Assert.Equal(Enum.GetNames<RemoteShellKind>(), ConnectionProfileTools.RemoteShellKindNames);
+}

--- a/tests/NovaTerminal.McpServer.Tests/ConnectionProfileDriftGuardTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/ConnectionProfileDriftGuardTests.cs
@@ -34,6 +34,11 @@ public class ConnectionProfileDriftGuardTests
     public void MuxFields_MatchSshMuxOptions() =>
         Assert.Equal(PropNames(typeof(SshMuxOptions)), Sorted(ConnectionProfileTools.MuxFields));
 
+    // SshProfileStoreSnapshot is a public proxy for the actually-serialized (internal)
+    // SshStoreDocument; both must stay structurally identical ({ SchemaVersion, Profiles }).
+    // SshStoreDocument is internal to NovaTerminal.Platform and unreachable here, so we guard
+    // DocumentFields against the snapshot. If you add a field to SshStoreDocument, mirror it on
+    // SshProfileStoreSnapshot (and in ConnectionProfileTools.DocumentFields) or this guard goes stale.
     [Fact]
     public void DocumentFields_MatchSnapshot() =>
         Assert.Equal(PropNames(typeof(SshProfileStoreSnapshot)), Sorted(ConnectionProfileTools.DocumentFields));

--- a/tests/NovaTerminal.McpServer.Tests/ConnectionProfileToolsTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/ConnectionProfileToolsTests.cs
@@ -180,10 +180,11 @@ public class ConnectionProfileToolsTests
     }
 
     [Fact]
-    public void MalformedId_IsWarning()
+    public void MalformedId_IsError()
     {
+        // A non-GUID Id makes the store quarantine the whole profiles.json on load, so it's fatal.
         var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Name": "n", "Host": "h", "Id": "not-a-guid" }""");
-        Assert.StartsWith("VALID", result);
+        Assert.StartsWith("INVALID", result);
         Assert.Contains("'Id'", result);
     }
 
@@ -224,5 +225,45 @@ public class ConnectionProfileToolsTests
 
         var doc = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Profiles": [ { "Host": "h" } ] }""");
         Assert.Contains("Profiles[0].Missing required field 'Name'", doc);
+    }
+
+    [Fact]
+    public void JumpHopMissingHost_IsError()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson(
+            """{ "Name": "n", "Host": "h", "JumpHops": [ { "User": "ops" } ] }""");
+        Assert.StartsWith("INVALID", result);
+        Assert.Contains("JumpHops[0].Missing required field 'Host'", result);
+    }
+
+    [Fact]
+    public void ForwardWithZeroSourcePort_IsError()
+    {
+        // The OpenSSH config compiler drops forwards with SourcePort <= 0, so zero is fatal.
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson(
+            """{ "Name": "n", "Host": "h", "Forwards": [ { "Kind": 0, "SourcePort": 0, "DestinationHost": "db", "DestinationPort": 5432 } ] }""");
+        Assert.StartsWith("INVALID", result);
+        Assert.Contains("Forwards[0].Field 'SourcePort'", result);
+    }
+
+    [Fact]
+    public void LocalForwardMissingDestination_IsError()
+    {
+        // Omitted Kind deserializes to Local (0); Local/Remote forwards need a destination host + port.
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson(
+            """{ "Name": "n", "Host": "h", "Forwards": [ { "SourcePort": 5432 } ] }""");
+        Assert.StartsWith("INVALID", result);
+        Assert.Contains("Forwards[0].Missing required field 'DestinationHost'", result);
+        Assert.Contains("Forwards[0].Missing required field 'DestinationPort'", result);
+    }
+
+    [Fact]
+    public void DynamicForwardWithSourcePortOnly_IsValid()
+    {
+        // Dynamic (SOCKS) forwards have no fixed destination, so only SourcePort is required.
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson(
+            """{ "Name": "n", "Host": "h", "Forwards": [ { "Kind": 2, "SourcePort": 1080 } ] }""");
+        Assert.StartsWith("VALID", result);
+        Assert.DoesNotContain("Errors:", result);
     }
 }

--- a/tests/NovaTerminal.McpServer.Tests/ConnectionProfileToolsTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/ConnectionProfileToolsTests.cs
@@ -30,4 +30,199 @@ public class ConnectionProfileToolsTests
         Assert.Contains("`Host`", schema);
         Assert.Contains("```json", schema);
     }
+
+    private const string ValidProfile = """
+        { "Name": "box", "Host": "box.internal", "Port": 22 }
+        """;
+
+    private const string ValidDocument = """
+        {
+          "SchemaVersion": 1,
+          "Profiles": [
+            {
+              "Name": "prod-db", "Host": "prod.internal", "User": "svc", "Port": 2222,
+              "BackendKind": 0, "AuthMode": 2, "IdentityFilePath": "/k/id_ed25519",
+              "Tags": ["prod"], "RememberPasswordInVault": false,
+              "JumpHops": [ { "Host": "j1", "User": "ops", "Port": 22 } ],
+              "Forwards": [ { "Kind": 0, "BindAddress": "127.0.0.1", "SourcePort": 5432, "DestinationHost": "db", "DestinationPort": 5432 } ],
+              "MuxOptions": { "Enabled": false, "ControlMasterAuto": true, "ControlPath": "", "ControlPersistSeconds": 0 },
+              "RemoteShellKind": 1
+            }
+          ]
+        }
+        """;
+
+    [Fact]
+    public void MinimalProfile_IsValid()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson(ValidProfile);
+        Assert.StartsWith("VALID", result);
+        Assert.DoesNotContain("Errors:", result);
+    }
+
+    [Fact]
+    public void FullDocument_IsValid()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson(ValidDocument);
+        Assert.StartsWith("VALID", result);
+        Assert.DoesNotContain("Errors:", result);
+    }
+
+    [Fact]
+    public void SchemaExample_PassesItsOwnValidator()
+    {
+        var schema = ConnectionProfileTools.GetConnectionProfileSchema();
+        int fence = schema.IndexOf("```json", StringComparison.Ordinal);
+        Assert.True(fence >= 0, "schema must contain a ```json example");
+        int bodyStart = schema.IndexOf('\n', fence) + 1;
+        int bodyEnd = schema.IndexOf("```", bodyStart, StringComparison.Ordinal);
+        string exampleJson = schema[bodyStart..bodyEnd];
+
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson(exampleJson);
+        Assert.StartsWith("VALID", result);
+    }
+
+    [Fact]
+    public void Empty_IsRejected() =>
+        Assert.StartsWith("INVALID", ConnectionProfileTools.ValidateConnectionProfileJson(""));
+
+    [Fact]
+    public void NonJson_IsRejected() =>
+        Assert.StartsWith("INVALID", ConnectionProfileTools.ValidateConnectionProfileJson("not json {"));
+
+    [Fact]
+    public void NonObjectRoot_IsRejected() =>
+        Assert.StartsWith("INVALID", ConnectionProfileTools.ValidateConnectionProfileJson("[1,2,3]"));
+
+    [Fact]
+    public void MissingName_IsError()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Host": "h" }""");
+        Assert.StartsWith("INVALID", result);
+        Assert.Contains("Missing required field 'Name'", result);
+    }
+
+    [Fact]
+    public void MissingHost_IsError()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Name": "n" }""");
+        Assert.StartsWith("INVALID", result);
+        Assert.Contains("Missing required field 'Host'", result);
+    }
+
+    [Fact]
+    public void EnumOutOfRange_IsError()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Name": "n", "Host": "h", "AuthMode": 9 }""");
+        Assert.StartsWith("INVALID", result);
+        Assert.Contains("'AuthMode'", result);
+        Assert.Contains("0=Default", result); // mapping hint
+    }
+
+    [Fact]
+    public void EnumNotInteger_IsError()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Name": "n", "Host": "h", "BackendKind": "OpenSsh" }""");
+        Assert.StartsWith("INVALID", result);
+        Assert.Contains("'BackendKind'", result);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(70000)]
+    public void PortOutOfRange_IsError(int port)
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson($$"""{ "Name": "n", "Host": "h", "Port": {{port}} }""");
+        Assert.StartsWith("INVALID", result);
+        Assert.Contains("'Port'", result);
+    }
+
+    [Fact]
+    public void WrongType_IsError()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Name": "n", "Host": "h", "Port": "22" }""");
+        Assert.StartsWith("INVALID", result);
+        Assert.Contains("'Port'", result);
+    }
+
+    [Fact]
+    public void ServerAliveCountMaxZero_IsError()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Name": "n", "Host": "h", "ServerAliveCountMax": 0 }""");
+        Assert.StartsWith("INVALID", result);
+        Assert.Contains("'ServerAliveCountMax'", result);
+    }
+
+    [Fact]
+    public void ProfilesNotArray_IsError()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "SchemaVersion": 1, "Profiles": 5 }""");
+        Assert.StartsWith("INVALID", result);
+        Assert.Contains("'Profiles'", result);
+    }
+
+    [Fact]
+    public void UnknownField_IsWarningButValid()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Name": "n", "Host": "h", "Bogus": 1 }""");
+        Assert.StartsWith("VALID", result);
+        Assert.Contains("Warnings:", result);
+        Assert.Contains("Unknown field 'Bogus'", result);
+    }
+
+    [Fact]
+    public void PasswordField_IsSecurityWarning()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Name": "n", "Host": "h", "Password": "secret" }""");
+        Assert.StartsWith("VALID", result);
+        Assert.Contains("Password", result);
+        Assert.Contains("vault", result);
+    }
+
+    [Fact]
+    public void MalformedId_IsWarning()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Name": "n", "Host": "h", "Id": "not-a-guid" }""");
+        Assert.StartsWith("VALID", result);
+        Assert.Contains("'Id'", result);
+    }
+
+    [Fact]
+    public void IdentityFileModeWithBlankPath_IsWarning()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Name": "n", "Host": "h", "AuthMode": 2, "IdentityFilePath": "" }""");
+        Assert.StartsWith("VALID", result);
+        Assert.Contains("IdentityFilePath", result);
+    }
+
+    [Fact]
+    public void MissingSchemaVersionInDocument_IsWarning()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Profiles": [ { "Name": "n", "Host": "h" } ] }""");
+        Assert.StartsWith("VALID", result);
+        Assert.Contains("SchemaVersion", result);
+    }
+
+    [Fact]
+    public void NewerSchemaVersion_IsWarning()
+    {
+        var result = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "SchemaVersion": 2, "Profiles": [ { "Name": "n", "Host": "h" } ] }""");
+        Assert.StartsWith("VALID", result);
+        Assert.Contains("SchemaVersion", result);
+    }
+
+    [Fact]
+    public void Null_IsRejected() =>
+        Assert.StartsWith("INVALID", ConnectionProfileTools.ValidateConnectionProfileJson(null!));
+
+    [Fact]
+    public void AutoDetect_SingleVsDocument_UsesCorrectPaths()
+    {
+        var single = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Host": "h" }""");
+        Assert.Contains("Missing required field 'Name'", single);
+        Assert.DoesNotContain("Profiles[", single);
+
+        var doc = ConnectionProfileTools.ValidateConnectionProfileJson("""{ "Profiles": [ { "Host": "h" } ] }""");
+        Assert.Contains("Profiles[0].Missing required field 'Name'", doc);
+    }
 }

--- a/tests/NovaTerminal.McpServer.Tests/ConnectionProfileToolsTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/ConnectionProfileToolsTests.cs
@@ -1,0 +1,33 @@
+using NovaTerminal.McpServer.Tools;
+
+namespace NovaTerminal.McpServer.Tests;
+
+public class ConnectionProfileToolsTests
+{
+    [Fact]
+    public void Schema_DescribesFieldGroupsAndEnumMappings()
+    {
+        var schema = ConnectionProfileTools.GetConnectionProfileSchema();
+
+        // Field-group headings.
+        Assert.Contains("Identity", schema);
+        Assert.Contains("Connection", schema);
+        Assert.Contains("Auth", schema);
+        Assert.Contains("Jump hosts", schema);
+        Assert.Contains("Port forwarding", schema);
+        Assert.Contains("Multiplexing", schema);
+        Assert.Contains("Document wrapper", schema);
+
+        // Integer enum mappings must be spelled out (enums are ints on the wire).
+        Assert.Contains("0=OpenSsh", schema);
+        Assert.Contains("1=Native", schema);
+        Assert.Contains("2=IdentityFile", schema);
+        Assert.Contains("2=Dynamic", schema);
+        Assert.Contains("4=Pwsh", schema);
+
+        // Required fields and an example are present.
+        Assert.Contains("`Name`", schema);
+        Assert.Contains("`Host`", schema);
+        Assert.Contains("```json", schema);
+    }
+}

--- a/tests/NovaTerminal.McpServer.Tests/NovaTerminal.McpServer.Tests.csproj
+++ b/tests/NovaTerminal.McpServer.Tests/NovaTerminal.McpServer.Tests.csproj
@@ -17,6 +17,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\NovaTerminal.McpServer\NovaTerminal.McpServer.csproj" />
+    <!-- Test-only: the drift guard reflects over the real profile types. The MCP server
+         itself must never reference NovaTerminal.Platform. -->
+    <ProjectReference Include="..\..\src\NovaTerminal.Platform\NovaTerminal.Platform.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Adds two read-only MCP Dev Companion tools for the SSH connection-profile JSON format, plus a proper README for the server. Brings the tool count 11 → 13 (v0.3).

- **`novaterminal.get_connection_profile_schema`** — descriptive schema (PascalCase fields grouped by area, integer enum mappings, defaults) + an annotated example; covers a single profile or a full `profiles.json` document.
- **`novaterminal.validate_connection_profile_json`** — validates a single `SshProfile` object *or* a full `SshStoreDocument` (auto-detected). Tiered output: errors → `INVALID`, warnings never fail. Flags a stray `Password` key (passwords are vault-managed, never in profile JSON).

## Why this was lower-risk than the deferral note implied

The roadmap deferred this citing "no stable documented schema" + "sensitive `Password` field." Investigation showed both are already handled: the persisted `SshProfile`/`SshStoreDocument` format is stable (source-generated `SshJsonContext`) and carries no password. One correction landed during design: the real wire format is **PascalCase keys + integer-valued enums** (the context sets no naming policy and no string-enum converter), not the camelCase/string-enum form earlier notes assumed.

## Design & safety

- Server keeps its **no-`ProjectReference`** isolation. Field/enum knowledge is hand-mirrored from `SshProfile`; a **reflection drift-guard test** (test-only reference to `NovaTerminal.Platform`) fails CI if the real types change.
- Descriptive schema (no formal JSON Schema doc to drift), consistent with the existing `get_theme_schema`/`validate_theme_json` pattern.

## Docs

- New **`src/NovaTerminal.McpServer/README.md`**: safety posture, build via wrapper, running the built DLL (not `dotnet run`), repo-root discovery, Claude Desktop / VS Code setup, full tool list, testing.
- `docs/mcp/tools.md` (→ v0.3, two rows added, deferred entry removed) and `docs/mcp-dev-companion.md` updated.

## Tests

- `validate_connection_profile_json`: 24 focused tests (happy/error/warning/robustness/auto-detect + schema self-consistency).
- Drift guard: 9 tests (field-name & enum-name arrays vs reflected real types).
- Full `NovaTerminal.McpServer.Tests` project: **85/85 passing.**

## Review trail

Built task-by-task with per-task spec+quality review and a final whole-branch review (verdict: ready to merge). Spec: `docs/superpowers/specs/2026-06-27-mcp-connection-profile-tools-design.md`; plan: `docs/superpowers/plans/2026-06-28-mcp-connection-profile-tools.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)