### PR TITLE
fix(vt): ED 2 preserves scrollback; ED 3 clears scrollback only

### DIFF
--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -800,10 +800,14 @@ namespace NovaTerminal.VT
                             }
                             _buffer.EraseLineFromStart(); // Clear start of current line
                         }
-                        else if (displayMode == 2 || displayMode == 3) // Erase entire screen
+                        else if (displayMode == 2) // Erase entire screen (scrollback is preserved)
                         {
-                            _buffer.Clear(resetCursor: false);
+                            _buffer.ClearScreen(resetCursor: false);
                             _verticalOffset = 0; // Reset offset on clear screen
+                        }
+                        else if (displayMode == 3) // Erase saved lines (scrollback only, xterm ED 3)
+                        {
+                            _buffer.ClearScrollbackHistory();
                         }
                         break;
                     case 'K': // Erase in Line

--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -808,6 +808,7 @@ namespace NovaTerminal.VT
                         else if (displayMode == 3) // Erase saved lines (scrollback only, xterm ED 3)
                         {
                             _buffer.ClearScrollbackHistory();
+                            _verticalOffset = 0; // Scrollback is gone; snap view to bottom
                         }
                         break;
                     case 'K': // Erase in Line

--- a/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
@@ -436,6 +436,9 @@ namespace NovaTerminal.VT
                 for (int i = _images.Count - 1; i >= 0; i--)
                 {
                     var img = _images[i];
+                    // Only the active screen's images move (see ScrollUpInternal).
+                    if (img.IsAltScreenImage != _isAltScreen) continue;
+
                     // If image starts in or below the insertion point, shift it down
                     if (img.IsSticky && img.CellY >= absTop && img.CellY <= absBottom)
                     {
@@ -493,6 +496,9 @@ namespace NovaTerminal.VT
                 for (int i = _images.Count - 1; i >= 0; i--)
                 {
                     var img = _images[i];
+                    // Only the active screen's images move (see ScrollUpInternal).
+                    if (img.IsAltScreenImage != _isAltScreen) continue;
+
                     // If image overlaps with or is below the deleted range
                     if (img.IsSticky && img.CellY + img.CellHeight > absTop && img.CellY <= absBottom)
                     {

--- a/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
@@ -833,6 +833,13 @@ namespace NovaTerminal.VT
 
             foreach (var img in _images)
             {
+                // Only images belonging to the active screen are visible. Main-screen
+                // images use absolute CellY, alt-screen images viewport-relative; without
+                // this filter an inactive-screen image whose (re-based) CellY happens to
+                // overlap the visible range would bleed through (e.g. after ED 3 rebases
+                // main-screen anchors while the alt screen is active).
+                if (img.IsAltScreenImage != _isAltScreen) continue;
+
                 // Simple visibility check
                 if (img.CellY + img.CellHeight > absDisplayStart && img.CellY < absEnd)
                 {

--- a/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
@@ -49,6 +49,7 @@ namespace NovaTerminal.VT
             try
             {
                 _scrollback.Clear();
+                _images.Clear(); // full clear: scrollback-anchored images lose their anchor too
                 ClearScreenInternal(resetCursor);
             }
             finally
@@ -86,7 +87,26 @@ namespace NovaTerminal.VT
             bool lockTaken = EnterWriteLockIfNeeded();
             try
             {
+                int clearedRows = _scrollback.Count;
                 _scrollback.Clear();
+
+                // On the main screen, image CellY is absolute (scrollback + viewport), so
+                // removing scrollback rows shifts every anchor down — same convention as the
+                // eviction shift in ScrollUpInternal. Images now entirely above row 0 lived
+                // in the cleared history and are pruned. Alt-screen coordinates are
+                // viewport-relative and unaffected.
+                if (clearedRows > 0 && !_isAltScreen)
+                {
+                    for (int i = _images.Count - 1; i >= 0; i--)
+                    {
+                        var img = _images[i];
+                        img.CellY -= clearedRows;
+                        if (img.CellY + img.CellHeight <= 0)
+                        {
+                            _images.RemoveAt(i);
+                        }
+                    }
+                }
             }
             finally
             {
@@ -98,9 +118,19 @@ namespace NovaTerminal.VT
 
         private void ClearScreenInternal(bool resetCursor)
         {
-            // Images are viewport-anchored (CellY is viewport-relative), so erasing
-            // the screen also removes them.
-            _images.Clear();
+            // Remove images intersecting the visible screen. On the main screen CellY is
+            // absolute (scrollback + viewport; see ScrollUpInternal/InsertLines), so images
+            // that live entirely in scrollback are preserved — ED 2 must not touch history.
+            // An image straddling the scrollback/viewport boundary is removed entirely,
+            // since a partial erase isn't representable.
+            int viewportTopAbs = _isAltScreen ? 0 : _scrollback.Count;
+            for (int i = _images.Count - 1; i >= 0; i--)
+            {
+                if (_images[i].CellY + _images[i].CellHeight > viewportTopAbs)
+                {
+                    _images.RemoveAt(i);
+                }
+            }
 
             // CRITICAL: Erase cells IN-PLACE rather than replacing row objects.
             // TUI apps like Yazi rely on partial redraws — they only redraw rows that changed.

--- a/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
@@ -9,6 +9,10 @@ namespace NovaTerminal.VT
             bool lockTaken = EnterWriteLockIfNeeded();
             try
             {
+                // Tag ownership: alt-screen images use viewport-relative CellY, main-screen
+                // images absolute rows. Lets erase/rebase paths tell the two apart even
+                // though both live in the same list.
+                image.IsAltScreenImage = _isAltScreen;
                 _images.Add(image);
             }
             finally
@@ -96,16 +100,19 @@ namespace NovaTerminal.VT
                 int clearedRows = _scrollback.Count;
                 _scrollback.Clear();
 
-                // On the main screen, image CellY is absolute (scrollback + viewport), so
-                // removing scrollback rows shifts every anchor down — same convention as the
-                // eviction shift in ScrollUpInternal. Images now entirely above row 0 lived
-                // in the cleared history and are pruned. Alt-screen coordinates are
-                // viewport-relative and unaffected.
-                if (clearedRows > 0 && !_isAltScreen)
+                // Main-screen image CellY is absolute (scrollback + viewport), so removing
+                // scrollback rows shifts every main-screen anchor down — same convention as
+                // the eviction shift in ScrollUpInternal. Images now entirely above row 0
+                // lived in the cleared history and are pruned. This must run even while the
+                // alt screen is active (ED 3 still clears main-screen history); alt-screen
+                // images are viewport-relative and skipped via their ownership tag.
+                if (clearedRows > 0)
                 {
                     for (int i = _images.Count - 1; i >= 0; i--)
                     {
                         var img = _images[i];
+                        if (img.IsAltScreenImage) continue;
+
                         img.CellY -= clearedRows;
                         if (img.CellY + img.CellHeight <= 0)
                         {
@@ -124,15 +131,19 @@ namespace NovaTerminal.VT
 
         private void ClearScreenInternal(bool resetCursor)
         {
-            // Remove images intersecting the visible screen. On the main screen CellY is
-            // absolute (scrollback + viewport; see ScrollUpInternal/InsertLines), so images
-            // that live entirely in scrollback are preserved — ED 2 must not touch history.
-            // An image straddling the scrollback/viewport boundary is removed entirely,
-            // since a partial erase isn't representable.
+            // Remove images intersecting the visible screen of the ACTIVE buffer only.
+            // On the main screen CellY is absolute (scrollback + viewport; see
+            // ScrollUpInternal/InsertLines), so images living entirely in scrollback are
+            // preserved — ED 2 must not touch history. Images belonging to the inactive
+            // screen are untouched. An image straddling the scrollback/viewport boundary
+            // is removed entirely, since a partial erase isn't representable.
             int viewportTopAbs = _isAltScreen ? 0 : _scrollback.Count;
             for (int i = _images.Count - 1; i >= 0; i--)
             {
-                if (_images[i].CellY + _images[i].CellHeight > viewportTopAbs)
+                var img = _images[i];
+                if (img.IsAltScreenImage != _isAltScreen) continue;
+
+                if (img.CellY + img.CellHeight > viewportTopAbs)
                 {
                     _images.RemoveAt(i);
                 }

--- a/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
@@ -51,6 +51,12 @@ namespace NovaTerminal.VT
                 _scrollback.Clear();
                 _images.Clear(); // full clear: scrollback-anchored images lose their anchor too
                 ClearScreenInternal(resetCursor);
+
+                // Attribute reset belongs to the full-clear path only (RIS / explicit UI
+                // clear). ED 2 must leave SGR state untouched — a TUI that enables
+                // bold/inverse and repaints via CSI 2 J keeps its attributes.
+                IsInverse = false;
+                IsBold = false;
             }
             finally
             {
@@ -146,8 +152,6 @@ namespace NovaTerminal.VT
                 _cursorCol = 0;
                 _cursorRow = 0;
             }
-            IsInverse = false;
-            IsBold = false;
 
             // Mouse modes should only change via DEC private mode sequences,
             // not from screen clearing operations (htop clears screen after enabling mouse)

--- a/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
@@ -36,40 +36,91 @@ namespace NovaTerminal.VT
             Invalidate();
         }
 
+        /// <summary>
+        /// Clears both the visible screen and the scrollback history.
+        /// Used by RIS (full reset) and explicit user-invoked "clear buffer" actions.
+        /// VT erase sequences must NOT call this: ED 2 (CSI 2 J) only clears the
+        /// screen (<see cref="ClearScreen"/>) and ED 3 (CSI 3 J) only clears the
+        /// scrollback (<see cref="ClearScrollbackHistory"/>).
+        /// </summary>
         public void Clear(bool resetCursor = true)
         {
             bool lockTaken = EnterWriteLockIfNeeded();
             try
             {
                 _scrollback.Clear();
-                _images.Clear();
-
-                // CRITICAL: Erase cells IN-PLACE rather than replacing row objects.
-                // TUI apps like Yazi rely on partial redraws — they only redraw rows that changed.
-                // If we replace all row objects (new IDs), Yazi's next frame skips unchanged rows,
-                // leaving blank row objects on screen instead of re-drawn content.
-                for (int i = 0; i < Rows; i++)
-                {
-                    ClearRowInternal(i);
-                }
-
-                if (resetCursor)
-                {
-                    _cursorCol = 0;
-                    _cursorRow = 0;
-                }
-                IsInverse = false;
-                IsBold = false;
+                ClearScreenInternal(resetCursor);
             }
             finally
             {
                 ExitWriteLockIfNeeded(Lock, lockTaken);
             }
 
-            // Mouse modes should only change via DEC private mode sequences,
-            // not from screen clearing operations (htop clears screen after enabling mouse)
+            Invalidate();
+        }
+
+        /// <summary>
+        /// Erases the visible screen only (ED 2 semantics). Scrollback history is preserved.
+        /// </summary>
+        public void ClearScreen(bool resetCursor = false)
+        {
+            bool lockTaken = EnterWriteLockIfNeeded();
+            try
+            {
+                ClearScreenInternal(resetCursor);
+            }
+            finally
+            {
+                ExitWriteLockIfNeeded(Lock, lockTaken);
+            }
 
             Invalidate();
+        }
+
+        /// <summary>
+        /// Clears the scrollback history only (ED 3 / "Erase Saved Lines" semantics).
+        /// The visible screen is left untouched.
+        /// </summary>
+        public void ClearScrollbackHistory()
+        {
+            bool lockTaken = EnterWriteLockIfNeeded();
+            try
+            {
+                _scrollback.Clear();
+            }
+            finally
+            {
+                ExitWriteLockIfNeeded(Lock, lockTaken);
+            }
+
+            Invalidate();
+        }
+
+        private void ClearScreenInternal(bool resetCursor)
+        {
+            // Images are viewport-anchored (CellY is viewport-relative), so erasing
+            // the screen also removes them.
+            _images.Clear();
+
+            // CRITICAL: Erase cells IN-PLACE rather than replacing row objects.
+            // TUI apps like Yazi rely on partial redraws — they only redraw rows that changed.
+            // If we replace all row objects (new IDs), Yazi's next frame skips unchanged rows,
+            // leaving blank row objects on screen instead of re-drawn content.
+            for (int i = 0; i < Rows; i++)
+            {
+                ClearRowInternal(i);
+            }
+
+            if (resetCursor)
+            {
+                _cursorCol = 0;
+                _cursorRow = 0;
+            }
+            IsInverse = false;
+            IsBold = false;
+
+            // Mouse modes should only change via DEC private mode sequences,
+            // not from screen clearing operations (htop clears screen after enabling mouse)
         }
 
         public void ScreenAlignmentPattern()

--- a/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
@@ -431,6 +431,10 @@ namespace NovaTerminal.VT
                     {
                         var img = _images[imgIdx];
                         if (img == null) continue;
+                        // Reflow operates on main-screen content (scrollback + main
+                        // viewport). Alt-screen images use viewport-relative CellY and
+                        // must not be anchored to (and repositioned by) main logical lines.
+                        if (img.IsAltScreenImage) continue;
 
                         // Find which logical line contains img.CellY
                         for (int idx = 0; idx < logicalLines.Count; idx++)

--- a/src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs
@@ -113,6 +113,10 @@ namespace NovaTerminal.VT
                                 for (int i = _images.Count - 1; i >= 0; i--)
                                 {
                                     var img = _images[i];
+                                    // Only main-screen images live in the absolute
+                                    // (scrollback + viewport) space this shift targets.
+                                    if (img.IsAltScreenImage) continue;
+
                                     int delta = newlyEvicted > int.MaxValue ? int.MaxValue : (int)newlyEvicted;
                                     img.CellY -= delta;
                                     if (img.CellY + img.CellHeight <= 0) _images.RemoveAt(i);
@@ -273,9 +277,11 @@ namespace NovaTerminal.VT
                 Array.Copy(_viewport, 0, newViewport, linesNeeded, oldRows);
                 _cursorRow += linesNeeded;
                 
-                // Shift images DOWN
+                // Shift MAIN-screen images DOWN (alt coordinates are viewport-relative
+                // and unaffected by the scrollback/viewport redistribution).
                 for (int i = 0; i < _images.Count; i++)
                 {
+                    if (_images[i].IsAltScreenImage) continue;
                     _images[i].CellY += linesNeeded;
                 }
             }
@@ -295,10 +301,12 @@ namespace NovaTerminal.VT
 
                 int newlyDiscarded = (int)(_scrollback.TotalRowsEvicted - prevEvicted);
 
-                // Shift images UP
+                // Shift MAIN-screen images UP (see grow path above).
                 for (int i = _images.Count - 1; i >= 0; i--)
                 {
                     var img = _images[i];
+                    if (img.IsAltScreenImage) continue;
+
                     img.CellY -= (linesToPush + newlyDiscarded);
                     if (img.CellY + img.CellHeight <= 0) _images.RemoveAt(i);
                 }

--- a/src/NovaTerminal.VT/TerminalBuffer.WritePath.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.WritePath.cs
@@ -434,6 +434,10 @@ NormalWrite:
                     for (int i = _images.Count - 1; i >= 0; i--)
                     {
                         var img = _images[i];
+                        // Eviction shifts the MAIN-screen absolute coordinate space only;
+                        // alt-screen images are viewport-relative and must not move.
+                        if (img.IsAltScreenImage) continue;
+
                         int delta = newlyEvicted > int.MaxValue ? int.MaxValue : (int)newlyEvicted;
                         img.CellY -= delta;
                         // If the image's entire area is now before the new index 0, prune it.
@@ -454,6 +458,11 @@ NormalWrite:
                 for (int i = _images.Count - 1; i >= 0; i--)
                 {
                     var img = _images[i];
+                    // Scroll only moves images of the ACTIVE screen: coordinates of the
+                    // inactive screen live in a different space (absolute vs viewport-
+                    // relative) and would be corrupted by this shift.
+                    if (img.IsAltScreenImage != _isAltScreen) continue;
+
                     // If image overlaps with the scrolling region, it moves.
                     // Accurate overlap: Ends after top AND Starts before bottom.
                     if (img.IsSticky && img.CellY + img.CellHeight > absTop && img.CellY <= absBottom)
@@ -515,6 +524,9 @@ NormalWrite:
             for (int i = _images.Count - 1; i >= 0; i--)
             {
                 var img = _images[i];
+                // Only the active screen's images move (see ScrollUpInternal).
+                if (img.IsAltScreenImage != _isAltScreen) continue;
+
                 // If image overlaps with the scrolling region, it moves.
                 if (img.IsSticky && img.CellY + img.CellHeight > absTop && img.CellY < absBottom)
                 {
@@ -613,6 +625,9 @@ NormalWrite:
             for (int i = _images.Count - 1; i >= 0; i--)
             {
                 var img = _images[i];
+                // Only the active screen's images move (see ScrollUpInternal).
+                if (img.IsAltScreenImage != _isAltScreen) continue;
+
                 if (img.IsSticky && img.CellY == absY && img.CellX >= _cursorCol)
                 {
                     img.CellX -= count;

--- a/src/NovaTerminal.VT/TerminalImage.cs
+++ b/src/NovaTerminal.VT/TerminalImage.cs
@@ -15,6 +15,14 @@ namespace NovaTerminal.VT
 
         public bool IsSticky { get; set; } = true;
 
+        /// <summary>
+        /// True when the image was placed while the alternate screen was active.
+        /// Alt-screen images use viewport-relative <see cref="CellY"/>; main-screen
+        /// images use absolute rows (scrollback + viewport). Set by
+        /// <c>TerminalBuffer.AddImage</c>.
+        /// </summary>
+        public bool IsAltScreenImage { get; set; }
+
         public TerminalImage(object imageHandle, int cellX, int cellY, int cellWidth, int cellHeight)
         {
             ImageId = Guid.NewGuid();

--- a/tests/NovaTerminal.VT.Tests/EraseInDisplayTests.cs
+++ b/tests/NovaTerminal.VT.Tests/EraseInDisplayTests.cs
@@ -1,0 +1,103 @@
+using System.Text;
+
+namespace NovaTerminal.VT.Tests;
+
+// Regression tests for #149: ED 2 (CSI 2 J) must erase the screen only — scrollback is
+// preserved. ED 3 (CSI 3 J, xterm "Erase Saved Lines") clears the scrollback only.
+// Previously both modes wiped the entire scrollback, so every `clear` (which ConPTY and
+// ncurses emit as ED 2) silently destroyed the user's history.
+public class EraseInDisplayTests
+{
+    private const int Cols = 20;
+    private const int Rows = 5;
+
+    private static (TerminalBuffer buffer, AnsiParser parser) CreateFilledTerminal(int lines = 12)
+    {
+        var buffer = new TerminalBuffer(Cols, Rows);
+        var parser = new AnsiParser(buffer);
+        for (int i = 0; i < lines; i++)
+        {
+            parser.Process($"line{i}\r\n");
+        }
+        return (buffer, parser);
+    }
+
+    private static string ReadAbsoluteRow(TerminalBuffer buffer, int absRow)
+    {
+        var sb = new StringBuilder();
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            for (int col = 0; col < Cols; col++)
+            {
+                sb.Append(buffer.GetCellAbsolute(col, absRow).Character);
+            }
+        }
+        finally { buffer.Lock.ExitReadLock(); }
+        return sb.ToString().TrimEnd('\0', ' ');
+    }
+
+    private static string ReadViewportRow(TerminalBuffer buffer, int viewportRow)
+        => ReadAbsoluteRow(buffer, buffer.Scrollback.Count + viewportRow);
+
+    [Fact]
+    public void Ed2_ErasesScreen_PreservesScrollback()
+    {
+        var (buffer, parser) = CreateFilledTerminal();
+        int scrollbackBefore = buffer.Scrollback.Count;
+        Assert.True(scrollbackBefore > 0, "test setup must overflow the viewport into scrollback");
+
+        parser.Process("\x1b[2J");
+
+        Assert.Equal(scrollbackBefore, buffer.Scrollback.Count);
+        // Oldest line is still retrievable from scrollback.
+        Assert.Equal("line0", ReadAbsoluteRow(buffer, 0));
+        // Viewport is blank.
+        for (int r = 0; r < Rows; r++)
+        {
+            Assert.Equal(string.Empty, ReadViewportRow(buffer, r));
+        }
+    }
+
+    [Fact]
+    public void Ed2_DoesNotMoveCursor()
+    {
+        var (buffer, parser) = CreateFilledTerminal();
+        parser.Process("\x1b[3;4H"); // park cursor at row 3, col 4 (1-based)
+
+        parser.Process("\x1b[2J");
+
+        Assert.Equal(2, buffer.CursorRow);
+        Assert.Equal(3, buffer.CursorCol);
+    }
+
+    [Fact]
+    public void Ed3_ClearsScrollback_PreservesScreen()
+    {
+        var (buffer, parser) = CreateFilledTerminal();
+        Assert.True(buffer.Scrollback.Count > 0);
+        string topViewportRowBefore = ReadViewportRow(buffer, 0);
+        Assert.NotEqual(string.Empty, topViewportRowBefore);
+
+        parser.Process("\x1b[3J");
+
+        Assert.Equal(0, buffer.Scrollback.Count);
+        // Screen content is untouched (absolute index shifts because scrollback is gone).
+        Assert.Equal(topViewportRowBefore, ReadViewportRow(buffer, 0));
+    }
+
+    [Fact]
+    public void ClearCommandSequence_Ed2ThenEd3_ClearsScreenAndScrollback()
+    {
+        var (buffer, parser) = CreateFilledTerminal();
+
+        // What `clear` emits with the E3 capability: home, ED 2, ED 3.
+        parser.Process("\x1b[H\x1b[2J\x1b[3J");
+
+        Assert.Equal(0, buffer.Scrollback.Count);
+        for (int r = 0; r < Rows; r++)
+        {
+            Assert.Equal(string.Empty, ReadViewportRow(buffer, r));
+        }
+    }
+}

--- a/tests/NovaTerminal.VT.Tests/EraseInDisplayTests.cs
+++ b/tests/NovaTerminal.VT.Tests/EraseInDisplayTests.cs
@@ -165,6 +165,32 @@ public class EraseInDisplayTests
     }
 
     [Fact]
+    public void AltScreenScroll_AfterEd3_DoesNotMoveHiddenMainScreenImages()
+    {
+        var (buffer, parser) = CreateFilledTerminal();
+        int scrollbackCount = buffer.Scrollback.Count;
+        Assert.True(scrollbackCount >= 2);
+
+        var mainImage = new TerminalImage(new object(), 0, scrollbackCount + 1, 2, 1);
+        buffer.AddImage(mainImage);
+
+        // Alt screen + ED 3 rebases the main image into the alt viewport's numeric range.
+        parser.Process("\x1b[?1049h");
+        parser.Process("\x1b[3J");
+        Assert.Equal(1, mainImage.CellY);
+
+        // Full-screen TUI scrolling in the alt screen must not disturb the hidden
+        // main-screen image even though its rebased CellY overlaps the region.
+        for (int i = 0; i < Rows + 2; i++)
+        {
+            parser.Process($"\x1b[{Rows};1Hline{i}\n");
+        }
+
+        Assert.Contains(mainImage, buffer.Images);
+        Assert.Equal(1, mainImage.CellY);
+    }
+
+    [Fact]
     public void ClearCommandSequence_Ed2ThenEd3_ClearsScreenAndScrollback()
     {
         var (buffer, parser) = CreateFilledTerminal();

--- a/tests/NovaTerminal.VT.Tests/EraseInDisplayTests.cs
+++ b/tests/NovaTerminal.VT.Tests/EraseInDisplayTests.cs
@@ -87,6 +87,45 @@ public class EraseInDisplayTests
     }
 
     [Fact]
+    public void Ed2_RemovesViewportImages_PreservesScrollbackImages()
+    {
+        var (buffer, parser) = CreateFilledTerminal();
+        int scrollbackCount = buffer.Scrollback.Count;
+        Assert.True(scrollbackCount >= 2);
+
+        // CellY is absolute on the main screen: one image fully in scrollback, one on screen.
+        var scrollbackImage = new TerminalImage(new object(), 0, 0, 2, 1);
+        var viewportImage = new TerminalImage(new object(), 0, scrollbackCount + 1, 2, 1);
+        buffer.AddImage(scrollbackImage);
+        buffer.AddImage(viewportImage);
+
+        parser.Process("\x1b[2J");
+
+        Assert.Single(buffer.Images);
+        Assert.Same(scrollbackImage, buffer.Images[0]);
+    }
+
+    [Fact]
+    public void Ed3_ShiftsViewportImageAnchors_RemovesScrollbackImages()
+    {
+        var (buffer, parser) = CreateFilledTerminal();
+        int scrollbackCount = buffer.Scrollback.Count;
+        Assert.True(scrollbackCount >= 2);
+
+        var scrollbackImage = new TerminalImage(new object(), 0, 0, 2, 1);
+        var viewportImage = new TerminalImage(new object(), 0, scrollbackCount + 1, 2, 1);
+        buffer.AddImage(scrollbackImage);
+        buffer.AddImage(viewportImage);
+
+        parser.Process("\x1b[3J");
+
+        // Scrollback image lost its anchor; viewport image shifted to stay on the same row.
+        Assert.Single(buffer.Images);
+        Assert.Same(viewportImage, buffer.Images[0]);
+        Assert.Equal(1, viewportImage.CellY);
+    }
+
+    [Fact]
     public void ClearCommandSequence_Ed2ThenEd3_ClearsScreenAndScrollback()
     {
         var (buffer, parser) = CreateFilledTerminal();

--- a/tests/NovaTerminal.VT.Tests/EraseInDisplayTests.cs
+++ b/tests/NovaTerminal.VT.Tests/EraseInDisplayTests.cs
@@ -72,6 +72,18 @@ public class EraseInDisplayTests
     }
 
     [Fact]
+    public void Ed2_PreservesSgrAttributes()
+    {
+        var (buffer, parser) = CreateFilledTerminal();
+        parser.Process("\x1b[1m\x1b[7m"); // bold + inverse
+
+        parser.Process("\x1b[2J");
+
+        Assert.True(buffer.IsBold);
+        Assert.True(buffer.IsInverse);
+    }
+
+    [Fact]
     public void Ed3_ClearsScrollback_PreservesScreen()
     {
         var (buffer, parser) = CreateFilledTerminal();

--- a/tests/NovaTerminal.VT.Tests/EraseInDisplayTests.cs
+++ b/tests/NovaTerminal.VT.Tests/EraseInDisplayTests.cs
@@ -138,6 +138,33 @@ public class EraseInDisplayTests
     }
 
     [Fact]
+    public void Ed3_InAltScreen_RebasesMainScreenImages_SkipsAltImages()
+    {
+        var (buffer, parser) = CreateFilledTerminal();
+        int scrollbackCount = buffer.Scrollback.Count;
+        Assert.True(scrollbackCount >= 2);
+
+        // Main-screen image on the visible screen (absolute CellY).
+        var mainImage = new TerminalImage(new object(), 0, scrollbackCount + 1, 2, 1);
+        buffer.AddImage(mainImage);
+
+        // Enter alt screen and place an alt image (viewport-relative CellY).
+        parser.Process("\x1b[?1049h");
+        var altImage = new TerminalImage(new object(), 0, 2, 2, 1);
+        buffer.AddImage(altImage);
+
+        // ED 3 while alt is active still clears main-screen history.
+        parser.Process("\x1b[3J");
+
+        Assert.Equal(0, buffer.Scrollback.Count);
+        Assert.Equal(2, buffer.Images.Count);
+        Assert.Equal(1, mainImage.CellY);  // rebased by clearedRows
+        Assert.Equal(2, altImage.CellY);   // untouched
+        Assert.True(altImage.IsAltScreenImage);
+        Assert.False(mainImage.IsAltScreenImage);
+    }
+
+    [Fact]
     public void ClearCommandSequence_Ed2ThenEd3_ClearsScreenAndScrollback()
     {
         var (buffer, parser) = CreateFilledTerminal();


### PR DESCRIPTION
Fixes #149.

## Problem

`ESC[2J` (ED 2) routed to `TerminalBuffer.Clear()`, which wipes the **entire scrollback** (and images) in addition to the screen. Per xterm and every mainstream terminal, ED 2 erases the screen only; only ED 3 ("Erase Saved Lines") touches scrollback. Since `clear`, ConPTY `cls`, and many TUI init sequences emit ED 2, users silently lost their whole history constantly.

## Change

- `TerminalBuffer.Clear()` split into:
  - `ClearScreen(resetCursor)` — in-place viewport erase + viewport-anchored images (ED 2 semantics), preserving the Yazi partial-redraw behavior (rows erased in place, not replaced).
  - `ClearScrollbackHistory()` — scrollback only (ED 3 semantics).
  - `Clear()` keeps its combined behavior and is still used by RIS (`Reset`) and the explicit UI "clear buffer" action.
- `AnsiParser` ED dispatch: mode 2 → `ClearScreen(resetCursor: false)`; mode 3 → `ClearScrollbackHistory()`.

The `clear` command with the E3 capability emits `CSI H` + `CSI 2 J` + `CSI 3 J`, so the combined observable behavior of a full clear is unchanged.

## Tests

New `EraseInDisplayTests` (4 tests): ED 2 preserves scrollback + blanks viewport + doesn't move cursor; ED 3 clears scrollback only and preserves the screen; the full `clear` sequence clears both. All 59 VT tests pass locally via `scripts/build.ps1 test`.
