### PR TITLE
fix(vt): zero-length regex matches no longer crash terminal search

### DIFF
--- a/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
@@ -732,7 +732,7 @@ namespace NovaTerminal.VT
                             // Zero-length matches (patterns like "a*", "()" or "\b") have no
                             // cells to highlight, and would index colMapping at -1 (or past the
                             // end for a match at end-of-line). See #150.
-                            if (!m.Success || m.Length == 0) continue;
+                            if (m.Length == 0) continue;
 
                             int startCol = colMapping[m.Index];
                             int endCol = colMapping[m.Index + m.Length - 1];

--- a/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
@@ -729,12 +729,14 @@ namespace NovaTerminal.VT
                         // Regex Search
                         foreach (System.Text.RegularExpressions.Match m in regex.Matches(lineText))
                         {
-                            if (m.Success)
-                            {
-                                int startCol = colMapping[m.Index];
-                                int endCol = colMapping[m.Index + m.Length - 1];
-                                matches.Add(new SearchMatch(r, startCol, endCol));
-                            }
+                            // Zero-length matches (patterns like "a*", "()" or "\b") have no
+                            // cells to highlight, and would index colMapping at -1 (or past the
+                            // end for a match at end-of-line). See #150.
+                            if (!m.Success || m.Length == 0) continue;
+
+                            int startCol = colMapping[m.Index];
+                            int endCol = colMapping[m.Index + m.Length - 1];
+                            matches.Add(new SearchMatch(r, startCol, endCol));
                         }
                     }
                     else

--- a/tests/NovaTerminal.VT.Tests/FindMatchesTests.cs
+++ b/tests/NovaTerminal.VT.Tests/FindMatchesTests.cs
@@ -1,0 +1,56 @@
+namespace NovaTerminal.VT.Tests;
+
+// Regression tests for #150: regex patterns that produce zero-length matches (e.g. "a*",
+// "()", "\b") crashed FindMatches with ArgumentOutOfRangeException — thrown while holding
+// the buffer read lock — because colMapping was indexed at m.Index + m.Length - 1 == -1.
+public class FindMatchesTests
+{
+    private static (TerminalBuffer buffer, AnsiParser parser) CreateTerminal(string content = "foo bar foo")
+    {
+        var buffer = new TerminalBuffer(cols: 40, rows: 5);
+        var parser = new AnsiParser(buffer);
+        parser.Process(content);
+        return (buffer, parser);
+    }
+
+    [Theory]
+    [InlineData("x*")]      // zero-length match at every position
+    [InlineData("()")]      // empty group, zero-length everywhere
+    [InlineData("\\b")]     // word boundary, zero-length
+    [InlineData("(?=foo)")] // lookahead, zero-length
+    [InlineData("$")]       // end anchor, zero-length at end-of-line
+    public void ZeroLengthRegexMatches_DoNotThrow(string pattern)
+    {
+        var (buffer, _) = CreateTerminal();
+
+        var ex = Record.Exception(() => buffer.FindMatches(pattern, useRegex: true, caseSensitive: false));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void ZeroLengthMatches_AreSkipped_ButRealMatchesStillFound()
+    {
+        var (buffer, _) = CreateTerminal("foo bar foo");
+
+        // "o*" matches zero-length everywhere but also "oo" twice.
+        var matches = buffer.FindMatches("o*", useRegex: true, caseSensitive: false);
+
+        Assert.Equal(2, matches.Count);
+        Assert.All(matches, m => Assert.True(m.EndCol >= m.StartCol));
+    }
+
+    [Fact]
+    public void PlainRegexSearch_StillWorks()
+    {
+        var (buffer, _) = CreateTerminal("foo bar foo");
+
+        var matches = buffer.FindMatches("foo", useRegex: true, caseSensitive: true);
+
+        Assert.Equal(2, matches.Count);
+        Assert.Equal(0, matches[0].StartCol);
+        Assert.Equal(2, matches[0].EndCol);
+        Assert.Equal(8, matches[1].StartCol);
+        Assert.Equal(10, matches[1].EndCol);
+    }
+}


### PR DESCRIPTION
Fixes #150.

Regex patterns producing zero-length matches ('a*', '()', '\b', lookaheads, '\$') indexed colMapping at m.Index + m.Length - 1 == -1 and threw ArgumentOutOfRangeException inside the buffer read lock. Zero-length matches are now skipped (nothing to highlight); real matches from the same pattern are still returned.

New FindMatchesTests: 5 zero-length patterns don't throw; 'o*' still finds both 'oo' runs; plain regex column mapping unchanged. All 62 VT tests pass via scripts/build.ps1 test.