### PR TITLE
fix(pty): inherit user locale instead of forcing LC_ALL=C

### DIFF
--- a/src/NovaTerminal.App/native/src/lib.rs
+++ b/src/NovaTerminal.App/native/src/lib.rs
@@ -399,8 +399,19 @@ fn pty_spawn_impl(
     cmd_builder.env("TERM", "xterm-256color");
     cmd_builder.env("COLORTERM", "truecolor");
     cmd_builder.env("TERM_PROGRAM", "NovaTerminal");
-    cmd_builder.env("LC_ALL", "C");
-    cmd_builder.env("LANG", "C");
+    // Inherit the user's locale. Forcing LC_ALL/LANG=C put every child shell in the
+    // ASCII locale (mangled non-ASCII filenames, broken multibyte readline input, no
+    // Unicode line drawing), contradicting the UTF-8 pipeline on the managed side.
+    // Only if no locale is present at all, fall back to C.UTF-8 so glibc tools still
+    // get a UTF-8 charmap (#153).
+    if !cfg!(windows) {
+        let has_locale = ["LC_ALL", "LC_CTYPE", "LANG"]
+            .iter()
+            .any(|k| std::env::var_os(k).is_some_and(|v| !v.is_empty()));
+        if !has_locale {
+            cmd_builder.env("LANG", "C.UTF-8");
+        }
+    }
     // Caller-supplied overrides last so shell-integration providers
     // (e.g. zsh's ZDOTDIR) can override the baseline.
     for (k, v) in extra_envs {

--- a/src/NovaTerminal.App/native/src/lib.rs
+++ b/src/NovaTerminal.App/native/src/lib.rs
@@ -402,14 +402,19 @@ fn pty_spawn_impl(
     // Inherit the user's locale. Forcing LC_ALL/LANG=C put every child shell in the
     // ASCII locale (mangled non-ASCII filenames, broken multibyte readline input, no
     // Unicode line drawing), contradicting the UTF-8 pipeline on the managed side.
-    // Only if no locale is present at all, fall back to C.UTF-8 so glibc tools still
-    // get a UTF-8 charmap (#153).
+    // Only if no locale is present at all, fall back to a UTF-8 charmap (#153):
+    // glibc has C.UTF-8; Darwin doesn't, but its BSD locale system accepts the
+    // bare "UTF-8" charmap for LC_CTYPE (bash would warn on LANG=C.UTF-8 there).
     if !cfg!(windows) {
         let has_locale = ["LC_ALL", "LC_CTYPE", "LANG"]
             .iter()
             .any(|k| std::env::var_os(k).is_some_and(|v| !v.is_empty()));
         if !has_locale {
-            cmd_builder.env("LANG", "C.UTF-8");
+            if cfg!(target_os = "macos") {
+                cmd_builder.env("LC_CTYPE", "UTF-8");
+            } else {
+                cmd_builder.env("LANG", "C.UTF-8");
+            }
         }
     }
     // Caller-supplied overrides last so shell-integration providers


### PR DESCRIPTION
Fixes #153.

The portable-pty spawn path forced LC_ALL=C/LANG=C into every child, putting Linux/macOS shells in the ASCII locale (mangled non-ASCII filenames, broken multibyte input, no Unicode line drawing) — contradicting the TERM=xterm-256color/COLORTERM=truecolor setup and the stateful UTF-8 decoder on the C# side. The Windows passthrough path never set these.

Now the child inherits the user's locale; if none of LC_ALL/LC_CTYPE/LANG is set, falls back to LANG=C.UTF-8 so glibc tools still get a UTF-8 charmap. cargo check passes; behavior change is Unix-only (runtime cfg!(windows) guard).