### PR TITLE
fix(app): two-phase pane teardown — session disposal always runs

### DIFF
--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -2194,7 +2194,24 @@ namespace NovaTerminal.Controls
 
         public void Dispose()
         {
-            if (_disposed) return;
+            // Synchronous teardown for UI-thread callers. MainWindow.DisposeControlTree
+            // splits the two phases instead, so the (potentially blocking) session
+            // teardown runs off the UI thread while the UI-affine detach stays on it.
+            DetachFromUiThread()?.Dispose();
+        }
+
+        /// <summary>
+        /// Detaches UI-affine state (control visibility, DispatcherTimer, event handlers)
+        /// and transfers ownership of the underlying session to the caller for disposal.
+        /// MUST be called on the UI thread. Returns <c>null</c> when already disposed or
+        /// when the pane has no session. See #154: previously the whole Dispose ran on a
+        /// worker thread with a swallowed catch, so a VerifyAccess throw in the UI-affine
+        /// part aborted teardown before the session was disposed, leaking the PTY and its
+        /// child shell.
+        /// </summary>
+        public ITerminalSession? DetachFromUiThread()
+        {
+            if (_disposed) return null;
             _disposed = true;
 
             CloseRemoteFilesSidebar();
@@ -2215,8 +2232,9 @@ namespace NovaTerminal.Controls
                 ITerminalSession session = Session;
                 UnregisterActiveSshSession(session);
                 Session = null;
-                session.Dispose();
+                return session;
             }
+            return null;
         }
 
         private static void RegisterActiveSshSession(ITerminalSession session, TerminalProfile? profile)

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -2211,6 +2211,12 @@ namespace NovaTerminal.Controls
         /// </summary>
         public ITerminalSession? DetachFromUiThread()
         {
+            // Enforce the UI-thread contract BEFORE flipping _disposed: if this threw
+            // mid-teardown after _disposed was set, every later Dispose() would return
+            // early and the session would leak permanently — the exact bug this method
+            // exists to prevent.
+            Dispatcher.UIThread.VerifyAccess();
+
             if (_disposed) return null;
             _disposed = true;
 

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -3330,10 +3330,35 @@ namespace NovaTerminal
 
         private void DisposeControlTree(Control control)
         {
+            // All call sites are UI event paths, but marshal defensively: the UI-affine
+            // detach below throws VerifyAccess off the UI thread.
+            if (!Dispatcher.UIThread.CheckAccess())
+            {
+                Dispatcher.UIThread.Post(() => DisposeControlTree(control));
+                return;
+            }
+
             if (control is TerminalPane pane)
             {
                 UnwirePane(pane);
-                Task.Run(() => { try { pane.Dispose(); } catch { } });
+
+                // Two-phase teardown (#154): UI-affine detach runs here on the UI thread;
+                // only the potentially blocking session teardown moves to the pool.
+                // Previously the whole pane.Dispose() ran in Task.Run with a swallowed
+                // catch, so a VerifyAccess throw aborted teardown before the session was
+                // disposed, leaking the PTY and its child shell.
+                var session = pane.DetachFromUiThread();
+                if (session != null)
+                {
+                    Task.Run(() =>
+                    {
+                        try { session.Dispose(); }
+                        catch (Exception ex)
+                        {
+                            System.Diagnostics.Debug.WriteLine($"[MainWindow] Session dispose failed: {ex.Message}");
+                        }
+                    });
+                }
             }
             else if (control is Panel panel) { foreach (var child in panel.Children) if (child is Control c) DisposeControlTree(c); }
             else if (control is ContentPresenter cp && cp.Content is Control childContent) DisposeControlTree(childContent);

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -3355,7 +3355,9 @@ namespace NovaTerminal
                         try { session.Dispose(); }
                         catch (Exception ex)
                         {
-                            System.Diagnostics.Debug.WriteLine($"[MainWindow] Session dispose failed: {ex.Message}");
+                            // Debug.WriteLine is compiled out of Release builds; use the
+                            // logger so production dispose failures leave a trace.
+                            TerminalLogger.Log($"[MainWindow] Session dispose failed: {ex.Message}");
                         }
                     });
                 }


### PR DESCRIPTION
Fixes #154.

Tab close disposed panes via Task.Run(() => { try { pane.Dispose(); } catch { } }). TerminalPane.Dispose does UI-affine work (CloseRemoteFilesSidebar → control IsVisible, DispatcherTimer.Stop, event detach) before session.Dispose(), so a VerifyAccess throw off the UI thread silently aborted teardown and orphaned the PTY + child shell.

Changes: TerminalPane.DetachFromUiThread() performs the UI-affine detach on the UI thread and transfers session ownership; DisposeControlTree runs it inline (with a defensive dispatcher marshal) and disposes only the session on the pool, logging failures instead of swallowing them. TerminalPane.Dispose() remains for synchronous UI-thread callers.

Build clean via scripts/build.ps1 (App + native).