### PR TITLE
ci: test-gate releases, conformance on VT changes, truthful CONTRIBUTING

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,11 @@ env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   CONFIGURATION: Release
+  # Same daemon hygiene as ci.yml / scripts/build.* — see CLAUDE.md: without these,
+  # MSBuild worker nodes and the build server outlive the step and hang the runner
+  # when stdout is captured.
+  DOTNET_CLI_USE_MSBUILD_SERVER: 0
+  MSBUILDDISABLENODEREUSE: 1
 
 jobs:
   release_metadata:
@@ -116,11 +121,72 @@ jobs:
             src/NovaTerminal.App/native/target*/**/release/*pty.*
             src/NovaTerminal.App/native/rusty_ssh/target*/**/release/*ssh.*
 
+  # Release gate (#156): releases used to publish AOT bundles without running a
+  # single test. Run the same deterministic unit lane that gates PRs in ci.yml —
+  # on all three release OSes, which also gives macOS its only automated test
+  # coverage — before any bundle is published.
+  release_tests:
+    name: Release Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    needs: [release_metadata, build_native]
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release_metadata.outputs.checkout_ref }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Download Native Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: native-${{ matrix.os }}
+          path: src/NovaTerminal.App/native
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        env:
+          SKIP_RUST_NATIVE_BUILD: "1"
+        run: dotnet build -c ${{ env.CONFIGURATION }} --no-restore
+
+      # Mirrors the gating unit lane in ci.yml (same projects, same filter).
+      - name: Test (unit — gating, non-headless projects)
+        env:
+          SKIP_RUST_NATIVE_BUILD: "1"
+        shell: bash
+        run: |
+          set -e
+          filter="Category!=Replay&Category!=RenderMetrics&Category!=PtySmoke&Category!=Stress&Category!=GoldenSharedPng"
+          for proj in VT Rendering Architecture Platform McpServer; do
+            echo "::group::NovaTerminal.$proj.Tests"
+            dotnet test "tests/NovaTerminal.$proj.Tests" -c "$CONFIGURATION" --no-build --no-restore \
+              --filter "$filter" --logger "trx;LogFileName=release_${proj}.trx"
+            echo "::endgroup::"
+          done
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-tests-${{ matrix.os }}
+          retention-days: 5
+          path: "**/*.trx"
+
   publish_aot:
     name: Publish AOT (${{ matrix.rid }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
-    needs: [release_metadata, create_release, build_native]
+    needs: [release_metadata, create_release, build_native, release_tests]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/vt-conformance.yml
+++ b/.github/workflows/vt-conformance.yml
@@ -7,6 +7,9 @@ on:
       - "docs/ghostty-gaps/vt_conformance_tooling.md"
       - "src/NovaTerminal.App/Resources/vt-conformance-report.json"
       - "src/NovaTerminal.Conformance/**"
+      # Parser/buffer changes can invalidate matrix claims even when the matrix
+      # itself is untouched, so run the gate for them too (#156).
+      - "src/NovaTerminal.VT/**"
       - ".github/workflows/vt-conformance.yml"
   push:
     branches: [main]
@@ -15,6 +18,7 @@ on:
       - "docs/ghostty-gaps/vt_conformance_tooling.md"
       - "src/NovaTerminal.App/Resources/vt-conformance-report.json"
       - "src/NovaTerminal.Conformance/**"
+      - "src/NovaTerminal.VT/**"
       - ".github/workflows/vt-conformance.yml"
   workflow_dispatch:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,8 +176,10 @@ All PRs are automatically checked by CI:
 
 - unit tests (VT, Rendering, Architecture, Platform, McpServer — blocking)
 - headless App.Tests (currently non-blocking due to an upstream
-  Avalonia.Headless teardown deadlock, tracked in #81 — regressions still
-  surface as a red check and must be explained in review)
+  Avalonia.Headless teardown deadlock, tracked in #81). Note: this is a
+  step-level `continue-on-error`, so a failure does NOT turn the check red —
+  it is only visible in the step log and uploaded artifacts. Reviewers must
+  open the Unit Tests job and check the App.Tests step explicitly.
 - renderer metric thresholds (`tab_perf_smoke`)
 - golden shared PNG tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,12 +174,21 @@ PRs missing this information will be blocked.
 
 All PRs are automatically checked by CI:
 
-- unit tests
-- replay tests
-- parity checks
-- renderer metric thresholds
+- unit tests (VT, Rendering, Architecture, Platform, McpServer — blocking)
+- headless App.Tests (currently non-blocking due to an upstream
+  Avalonia.Headless teardown deadlock, tracked in #81 — regressions still
+  surface as a red check and must be explained in review)
+- renderer metric thresholds (`tab_perf_smoke`)
+- golden shared PNG tests
 
-Failing CI blocks merge.
+Replay and cross-platform parity suites run on every push to `main` and on
+the daily scheduled run (see `docs/plans/2026-04-22-ci-rebalance-and-release-publishing.md`);
+a parity or replay break detected there must be fixed or reverted before the
+next release. Release tags additionally run the gating unit lane on all three
+OSes before any bundle is published.
+
+Failing blocking CI blocks merge. Do not rely on the non-blocking lanes to
+catch regressions for you — run the relevant categories locally.
 
 Maintainers may request:
 - additional replay fixtures


### PR DESCRIPTION
Fixes #156.

Three gaps from the CI review:

1. **Releases ran zero tests.** release.yml now has a release_tests job — the same deterministic unit lane that gates PRs (VT/Rendering/Architecture/Platform/McpServer, same category filter) — on windows/ubuntu/macos, gating publish_aot. This also gives macOS (a shipped release target) its first automated test coverage. Daemon-hygiene env (DOTNET_CLI_USE_MSBUILD_SERVER=0, MSBUILDDISABLENODEREUSE=1) added to match ci.yml.

2. **vt-conformance.yml never triggered on parser changes** — only on matrix/tooling paths. Added src/NovaTerminal.VT/** to both triggers.

3. **CONTRIBUTING.md claimed replay/parity gate PRs — they don't** (moved to push-to-main + schedule in the 2026-04-22 rebalance) and App.Tests is continue-on-error (#81). The CI section now describes reality and points at the rebalance doc.

Deliberately NOT changed here (bigger calls for maintainers): re-enabling replay/parity on PRs, and making App.Tests blocking again (needs the #81 fixture quarantine work first).