### PR TITLE
fix(pty): decoder buffer edge could mute the session; partial writes dropped paste input

### DIFF
--- a/src/NovaTerminal.App/native/src/lib.rs
+++ b/src/NovaTerminal.App/native/src/lib.rs
@@ -514,8 +514,11 @@ pub extern "C" fn pty_write(state_ptr: *mut PtyState, buffer: *const u8, len: c_
 
         let buf = unsafe { std::slice::from_raw_parts(buffer, len as usize) };
         if let Ok(mut writer) = state.writer.lock() {
-            match writer.write(buf) {
-                Ok(n) => n as c_int,
+            // write_all, not write: a single write into a nearly-full PTY pipe can be
+            // partial, and the C# caller has no way to retry the remainder — large
+            // pastes silently lost bytes (#168).
+            match writer.write_all(buf) {
+                Ok(()) => len,
                 Err(_) => -1,
             }
         } else {

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -34,6 +34,15 @@ namespace NovaTerminal.Pty
         // Bounded queue for back-pressure - prevents OOM on high-throughput output
         private readonly BlockingCollection<string> _outputQueue = new BlockingCollection<string>(boundedCapacity: 100);
 
+        // Bounded input queue drained by a dedicated writer thread. The native side does
+        // write_all, which can block indefinitely while the foreground program isn't
+        // draining stdin (paused pager, `sleep`, full-screen app) — and paste/drop
+        // handlers call SendInput from the Avalonia UI thread, so the blocking write must
+        // never run on the caller. The bound applies backpressure to pathological floods
+        // without unbounded memory growth.
+        private readonly BlockingCollection<byte[]> _inputQueue = new BlockingCollection<byte[]>(boundedCapacity: 1024);
+        private Thread? _writeLoopThread;
+
         // UTF-8 decoder with state - handles partial multi-byte sequences across reads
         private readonly Decoder _utf8Decoder = Encoding.UTF8.GetDecoder();
 
@@ -296,8 +305,10 @@ namespace NovaTerminal.Pty
             // IsBackground threads never consume the pool and never block process exit.
             _readLoopThread = new Thread(ReadLoop) { IsBackground = true, Name = $"PtyRead-{Id:N}" };
             _processLoopThread = new Thread(ProcessLoop) { IsBackground = true, Name = $"PtyProcess-{Id:N}" };
+            _writeLoopThread = new Thread(WriteLoop) { IsBackground = true, Name = $"PtyWrite-{Id:N}" };
             _readLoopThread.Start();
             _processLoopThread.Start();
+            _writeLoopThread.Start();
 
             // POST-LAUNCH INJECTION for PowerShell
             if (!skipPowerShellPostLaunchInit &&
@@ -490,15 +501,43 @@ namespace NovaTerminal.Pty
             byte[] data = Encoding.UTF8.GetBytes(input);
             try
             {
-                // Rust side does write_all, so success returns the full length; anything
-                // else means the write failed (#168). Log — input loss must not be silent.
-                int written = Native.pty_write(_handle, data, data.Length);
-                if (written != data.Length)
+                // Queue for the dedicated writer thread — never write on the caller
+                // thread; see _inputQueue. Ordering is preserved (single consumer).
+                _inputQueue.Add(data, _cts.Token);
+            }
+            catch (OperationCanceledException) { /* session disposing — drop the write */ }
+            catch (InvalidOperationException) { /* adding completed — session closing */ }
+        }
+
+        private void WriteLoop()
+        {
+            // Contained like ReadLoop/ProcessLoop: this runs on a dedicated thread, so an
+            // unhandled exception would crash the process.
+            try
+            {
+                foreach (var data in _inputQueue.GetConsumingEnumerable(_cts.Token))
                 {
-                    Console.WriteLine($"[RustPtySession] pty_write failed: {written} of {data.Length} bytes");
+                    try
+                    {
+                        // Rust side does write_all: success returns the full length,
+                        // failure returns -1 (#168). Input loss must not be silent.
+                        int written = Native.pty_write(_handle, data, data.Length);
+                        if (written != data.Length)
+                        {
+                            Console.WriteLine($"[RustPtySession] pty_write returned {written} (expected {data.Length}); input may be lost");
+                        }
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        return; // handle released — session is gone
+                    }
                 }
             }
-            catch (ObjectDisposedException) { /* session disposed mid-call — drop the write */ }
+            catch (OperationCanceledException) { /* dispose */ }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[RustPtySession] WriteLoop terminated by unhandled exception: {ex}");
+            }
         }
 
         public void Resize(int cols, int rows)
@@ -535,6 +574,10 @@ namespace NovaTerminal.Pty
             {
                 _outputQueue.CompleteAdding();
             }
+            if (!_inputQueue.IsAddingCompleted)
+            {
+                _inputQueue.CompleteAdding();
+            }
 
             // 2. Quick join. If the shell already exited (EOF), the read loop is
             //    already unwinding — no cancel needed, and we avoid pty_cancel_read's
@@ -559,6 +602,14 @@ namespace NovaTerminal.Pty
             if (!(_processLoopThread?.Join(DisposeJoinTimeout) ?? true))
             {
                 Console.WriteLine("[RustPtySession] ProcessLoop did not exit within join timeout.");
+            }
+
+            // 4b. Join the writer. A write blocked on a full pipe unblocks when the
+            //     handle below is released (pty_close tears down the pipe); the thread is
+            //     IsBackground, so a timed-out join can never block process exit.
+            if (!(_writeLoopThread?.Join(DisposeJoinTimeout) ?? true))
+            {
+                Console.WriteLine("[RustPtySession] WriteLoop did not exit within join timeout.");
             }
 
             // 5. Release the handle. SafeHandle guarantees pty_close runs only once

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -385,7 +385,12 @@ namespace NovaTerminal.Pty
         private void ReadLoop()
         {
             byte[] buffer = new byte[4096];
-            char[] charBuffer = new char[4096]; // For decoded characters
+            // Sized via GetMaxCharCount, NOT buffer.Length: the stateful decoder can carry
+            // up to 3 pending bytes from the previous read, so a full 4096-byte read can
+            // decode to 4097 chars. With a same-sized buffer GetChars threw
+            // ArgumentException and the catch-all below terminated the loop — the session
+            // went silently mute mid-stream (#168).
+            char[] charBuffer = new char[Encoding.UTF8.GetMaxCharCount(buffer.Length)];
 
             // This runs on a dedicated thread, so an unhandled exception would crash the
             // whole process (unlike the old Task.Run, whose unobserved exceptions were
@@ -483,7 +488,16 @@ namespace NovaTerminal.Pty
             _recorder?.RecordInput(input);
 
             byte[] data = Encoding.UTF8.GetBytes(input);
-            try { Native.pty_write(_handle, data, data.Length); }
+            try
+            {
+                // Rust side does write_all, so success returns the full length; anything
+                // else means the write failed (#168). Log — input loss must not be silent.
+                int written = Native.pty_write(_handle, data, data.Length);
+                if (written != data.Length)
+                {
+                    Console.WriteLine($"[RustPtySession] pty_write failed: {written} of {data.Length} bytes");
+                }
+            }
             catch (ObjectDisposedException) { /* session disposed mid-call — drop the write */ }
         }
 


### PR DESCRIPTION
Fixes #168.

Two silent data-loss bugs in the PTY path:

1. **Read loop could die silently.** The stateful UTF-8 decoder carries up to 3 pending bytes across reads, so a full 4096-byte read can decode to 4097 chars — one more than the same-sized char buffer. GetChars threw ArgumentException, the loop's containment catch logged and returned, and the session went permanently mute mid-stream. Buffer is now sized with Encoding.UTF8.GetMaxCharCount(4096), matching what NativeSshSession.EmitOutput already did.

2. **Paste input could be silently truncated.** rusty_pty's pty_write did a single write() (partial on a nearly-full pipe) and returned the count; SendInput discarded it. Rust now uses write_all() (returns full length or -1), and SendInput logs any mismatch. This also resolves the long-standing CA1806 warning at that call site.

cargo tests pass; Pty project builds clean.