### PR TITLE
fix(app): crash-safe settings/session/vault persistence; Cancel reverts preview

### DIFF
--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -4660,6 +4660,22 @@ namespace NovaTerminal
         {
             var sw = new SettingsWindow(tabIndex, profileId);
 
+            // Snapshot the live-previewed values so Cancel can restore them (#167).
+            // The preview handlers below mutate _settings directly; without this,
+            // closing the dialog without saving left the preview values live, and any
+            // later unrelated Save() persisted them to disk.
+            var previewSnapshot = new
+            {
+                _settings.WindowOpacity,
+                _settings.BlurEffect,
+                _settings.BackgroundImagePath,
+                _settings.BackgroundImageOpacity,
+                _settings.BackgroundImageStretch,
+                _settings.FontFamily,
+                _settings.FontSize,
+                _settings.ThemeName
+            };
+
             // Wire up live preview events
             sw.OnOpacityChanged += (val) => { _settings.WindowOpacity = val; ApplyThemeToUI(); ApplySettingsToAllTabs(); };
             sw.OnBlurChanged += (val) => { _settings.BlurEffect = val; UpdateTransparencyHints(); };
@@ -4710,6 +4726,24 @@ namespace NovaTerminal
 
                 // Refresh Connection Manager if open (or just always update it)
                 _connectionManagerControl?.LoadProfiles(_sshConnectionService.GetConnectionProfiles());
+            }
+            else
+            {
+                // Cancel: revert the live preview (#167).
+                _settings.WindowOpacity = previewSnapshot.WindowOpacity;
+                _settings.BlurEffect = previewSnapshot.BlurEffect;
+                _settings.BackgroundImagePath = previewSnapshot.BackgroundImagePath;
+                _settings.BackgroundImageOpacity = previewSnapshot.BackgroundImageOpacity;
+                _settings.BackgroundImageStretch = previewSnapshot.BackgroundImageStretch;
+                _settings.FontFamily = previewSnapshot.FontFamily;
+                _settings.FontSize = previewSnapshot.FontSize;
+                _settings.ThemeName = previewSnapshot.ThemeName;
+                _settings.RefreshActiveTheme();
+
+                ApplyThemeToUI();
+                ApplySettingsToAllTabs();
+                UpdateTransparencyHints();
+                UpdateTabVisuals();
             }
         }
 

--- a/src/NovaTerminal.App/Shell/AtomicFile.cs
+++ b/src/NovaTerminal.App/Shell/AtomicFile.cs
@@ -1,0 +1,42 @@
+using System;
+using System.IO;
+
+namespace NovaTerminal.Shell
+{
+    /// <summary>
+    /// Crash-safe file persistence: write to a temp sibling, then atomically move it
+    /// over the destination, keeping the previous content as <c>&lt;path&gt;.bak</c>.
+    /// A crash mid-write can no longer corrupt the destination (#167). Same pattern
+    /// as <c>JsonSshProfileStore</c> / <c>OpenSshConfigCompiler</c> in Platform.
+    /// </summary>
+    internal static class AtomicFile
+    {
+        public static void WriteAllText(string path, string contents)
+        {
+            string tmp = path + ".tmp";
+            File.WriteAllText(tmp, contents);
+            ReplaceWithBackup(tmp, path);
+        }
+
+        public static void WriteAllBytes(string path, byte[] bytes)
+        {
+            string tmp = path + ".tmp";
+            File.WriteAllBytes(tmp, bytes);
+            ReplaceWithBackup(tmp, path);
+        }
+
+        private static void ReplaceWithBackup(string tmp, string path)
+        {
+            if (File.Exists(path))
+            {
+                // Best-effort backup of the previous good content; the atomic move
+                // below must not be blocked by a backup failure.
+                try { File.Copy(path, path + ".bak", overwrite: true); }
+                catch (IOException) { }
+                catch (UnauthorizedAccessException) { }
+            }
+
+            File.Move(tmp, path, overwrite: true);
+        }
+    }
+}

--- a/src/NovaTerminal.App/Shell/AtomicFile.cs
+++ b/src/NovaTerminal.App/Shell/AtomicFile.cs
@@ -12,31 +12,37 @@ namespace NovaTerminal.Shell
     internal static class AtomicFile
     {
         public static void WriteAllText(string path, string contents)
-        {
-            string tmp = path + ".tmp";
-            File.WriteAllText(tmp, contents);
-            ReplaceWithBackup(tmp, path);
-        }
+            => Write(path, tmp => File.WriteAllText(tmp, contents));
 
         public static void WriteAllBytes(string path, byte[] bytes)
-        {
-            string tmp = path + ".tmp";
-            File.WriteAllBytes(tmp, bytes);
-            ReplaceWithBackup(tmp, path);
-        }
+            => Write(path, tmp => File.WriteAllBytes(tmp, bytes));
 
-        private static void ReplaceWithBackup(string tmp, string path)
+        private static void Write(string path, Action<string> writeTemp)
         {
-            if (File.Exists(path))
+            // Unique temp sibling: concurrent savers of the same destination (e.g. two
+            // VaultService instances over the same vault.dat) must not collide on a
+            // shared ".tmp" name — last atomic move wins, nobody sees a torn file.
+            string tmp = path + "." + Guid.NewGuid().ToString("N") + ".tmp";
+            try
             {
-                // Best-effort backup of the previous good content; the atomic move
-                // below must not be blocked by a backup failure.
-                try { File.Copy(path, path + ".bak", overwrite: true); }
-                catch (IOException) { }
-                catch (UnauthorizedAccessException) { }
-            }
+                writeTemp(tmp);
 
-            File.Move(tmp, path, overwrite: true);
+                if (File.Exists(path))
+                {
+                    // Best-effort backup of the previous good content; the atomic move
+                    // below must not be blocked by a backup failure of any kind.
+                    try { File.Copy(path, path + ".bak", overwrite: true); }
+                    catch { }
+                }
+
+                File.Move(tmp, path, overwrite: true);
+            }
+            catch
+            {
+                // Don't leave orphaned temp files behind on failure.
+                try { if (File.Exists(tmp)) File.Delete(tmp); } catch { }
+                throw;
+            }
         }
     }
 }

--- a/src/NovaTerminal.App/Shell/SessionManager.cs
+++ b/src/NovaTerminal.App/Shell/SessionManager.cs
@@ -29,7 +29,9 @@ namespace NovaTerminal.Shell
                 var json = JsonSerializer.Serialize(session, SessionSerializationContext.Default.NovaSession);
                 payloadBytes = System.Text.Encoding.UTF8.GetByteCount(json);
                 Directory.CreateDirectory(Path.GetDirectoryName(SessionPath)!);
-                File.WriteAllText(SessionPath, json);
+                // Atomic write with .bak (#167): SaveSession runs on shutdown — a crash
+                // mid-write previously corrupted the session and lost the restore state.
+                AtomicFile.WriteAllText(SessionPath, json);
             }
             catch (Exception ex)
             {

--- a/src/NovaTerminal.App/Shell/TerminalSettings.cs
+++ b/src/NovaTerminal.App/Shell/TerminalSettings.cs
@@ -133,7 +133,28 @@ namespace NovaTerminal.Shell
                     try { File.Copy(settingsPath, settingsPath + ".corrupt", overwrite: true); }
                     catch { /* best effort */ }
 
-                    settings = TryLoadOrNull(settingsPath + ".bak") ?? new TerminalSettings();
+                    var fromBackup = TryLoadOrNull(settingsPath + ".bak");
+                    if (fromBackup != null)
+                    {
+                        settings = fromBackup;
+                        // Repair the primary immediately so subsequent launches don't
+                        // repeatedly quarantine + fall back (review feedback on #178).
+                        try
+                        {
+                            AtomicFile.WriteAllText(settingsPath,
+                                JsonSerializer.Serialize(fromBackup, AppJsonContext.Default.TerminalSettings));
+                        }
+                        catch (Exception repairEx)
+                        {
+                            System.Diagnostics.Debug.WriteLine($"[Settings] Failed to repair '{settingsPath}' from backup: {repairEx.Message}");
+                        }
+                    }
+                    else
+                    {
+                        // The reset to defaults must leave a diagnosable trace.
+                        System.Diagnostics.Debug.WriteLine($"[Settings] Backup '{settingsPath}.bak' is also unreadable; falling back to defaults.");
+                        settings = new TerminalSettings();
+                    }
                 }
             }
             else

--- a/src/NovaTerminal.App/Shell/TerminalSettings.cs
+++ b/src/NovaTerminal.App/Shell/TerminalSettings.cs
@@ -124,9 +124,16 @@ namespace NovaTerminal.Shell
                     string json = File.ReadAllText(settingsPath);
                     settings = JsonSerializer.Deserialize(json, AppJsonContext.Default.TerminalSettings) ?? new TerminalSettings();
                 }
-                catch
+                catch (Exception ex)
                 {
-                    settings = new TerminalSettings();
+                    // Corrupt settings must not be silently replaced with defaults (#167):
+                    // quarantine the evidence, then fall back to the .bak written by
+                    // AtomicFile before resorting to defaults.
+                    System.Diagnostics.Debug.WriteLine($"[Settings] '{settingsPath}' is unreadable ({ex.Message}); trying backup.");
+                    try { File.Copy(settingsPath, settingsPath + ".corrupt", overwrite: true); }
+                    catch { /* best effort */ }
+
+                    settings = TryLoadOrNull(settingsPath + ".bak") ?? new TerminalSettings();
                 }
             }
             else
@@ -195,15 +202,34 @@ namespace NovaTerminal.Shell
             return settings;
         }
 
+        private static TerminalSettings? TryLoadOrNull(string path)
+        {
+            try
+            {
+                if (!File.Exists(path)) return null;
+                string json = File.ReadAllText(path);
+                return JsonSerializer.Deserialize(json, AppJsonContext.Default.TerminalSettings);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
         public void Save()
         {
             try
             {
                 AppPaths.EnsureInitialized();
                 string json = JsonSerializer.Serialize(this, AppJsonContext.Default.TerminalSettings);
-                File.WriteAllText(SettingsPath, json);
+                // Atomic write with .bak (#167): a crash mid-write previously corrupted
+                // settings.json, and the next start silently reset all configuration.
+                AtomicFile.WriteAllText(SettingsPath, json);
             }
-            catch { }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[Settings] Save failed: {ex.Message}");
+            }
         }
     }
 }

--- a/src/NovaTerminal.App/Shell/VaultService.cs
+++ b/src/NovaTerminal.App/Shell/VaultService.cs
@@ -357,7 +357,9 @@ namespace NovaTerminal.Shell
                     encrypted = EncryptFallback(data);
                 }
 
-                File.WriteAllBytes(_vaultPath, encrypted);
+                // Atomic write with .bak (#167): a crash mid-write previously corrupted
+                // vault.dat, silently losing all stored secrets.
+                AtomicFile.WriteAllBytes(_vaultPath, encrypted);
             }
             catch (Exception ex)
             {

--- a/src/NovaTerminal.App/Shell/VaultService.cs
+++ b/src/NovaTerminal.App/Shell/VaultService.cs
@@ -382,9 +382,40 @@ namespace NovaTerminal.Shell
                 return true;
             }
 
+            if (TryLoadSecretsFrom(_vaultPath, out secrets))
+            {
+                return true;
+            }
+
+            // Primary is unreadable/undecryptable. Do NOT silently continue with an
+            // empty vault — the next Save() would overwrite vault.dat (and eventually
+            // its .bak) and permanently destroy every stored secret (#167 review).
+            // Quarantine the evidence and try the backup written by AtomicFile.
+            System.Diagnostics.Debug.WriteLine($"[Vault] '{_vaultPath}' is unreadable; trying backup.");
+            try { File.Copy(_vaultPath, _vaultPath + ".corrupt", overwrite: true); }
+            catch { /* best effort */ }
+
+            if (TryLoadSecretsFrom(_vaultPath + ".bak", out secrets))
+            {
+                return true;
+            }
+
+            System.Diagnostics.Debug.WriteLine("[Vault] Backup is also unreadable; starting with an empty vault.");
+            secrets = new Dictionary<string, string>();
+            return false;
+        }
+
+        private bool TryLoadSecretsFrom(string path, out Dictionary<string, string> secrets)
+        {
+            secrets = new Dictionary<string, string>();
+            if (!File.Exists(path))
+            {
+                return false;
+            }
+
             try
             {
-                byte[] encrypted = File.ReadAllBytes(_vaultPath);
+                byte[] encrypted = File.ReadAllBytes(path);
                 byte[] data;
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -394,7 +425,7 @@ namespace NovaTerminal.Shell
                 }
                 else
                 {
-                    // Cross-platform fallback: AES-256-GCM
+                    // Cross-platform fallback (see EncryptFallback)
                     data = DecryptFallback(encrypted);
                 }
 
@@ -409,7 +440,7 @@ namespace NovaTerminal.Shell
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"[Vault] Load failed: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"[Vault] Load from '{path}' failed: {ex.Message}");
                 return false;
             }
         }

--- a/tests/NovaTerminal.App.Tests/Core/TerminalSettingsPersistenceTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/TerminalSettingsPersistenceTests.cs
@@ -1,0 +1,97 @@
+using NovaTerminal.Shell;
+using System.Text.Json;
+
+namespace NovaTerminal.Tests.Core;
+
+// Regression tests for #167: settings persistence must be crash-safe (atomic write
+// + .bak) and corrupt files must fall back to the backup instead of silently
+// resetting all configuration to defaults.
+public sealed class TerminalSettingsPersistenceTests
+{
+    [Fact]
+    public void LoadFromPath_CorruptFile_FallsBackToBackup()
+    {
+        string root = Directory.CreateTempSubdirectory("nova-settings-tests-").FullName;
+        try
+        {
+            string path = Path.Combine(root, "settings.json");
+
+            // A valid backup with a recognizable marker...
+            var good = new TerminalSettings { FontFamily = "BackupMarkerFont" };
+            File.WriteAllText(path + ".bak", JsonSerializer.Serialize(good, AppJsonContext.Default.TerminalSettings));
+
+            // ...and a corrupt primary (truncated JSON, as a crash mid-write produces).
+            File.WriteAllText(path, "{\"FontFamily\":\"Trunc");
+
+            TerminalSettings loaded = TerminalSettings.LoadFromPath(path);
+
+            Assert.Equal("BackupMarkerFont", loaded.FontFamily);
+            // The corrupt file is quarantined for diagnosis, not destroyed.
+            Assert.True(File.Exists(path + ".corrupt"));
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void LoadFromPath_CorruptFile_NoBackup_FallsBackToDefaults()
+    {
+        string root = Directory.CreateTempSubdirectory("nova-settings-tests-").FullName;
+        try
+        {
+            string path = Path.Combine(root, "settings.json");
+            File.WriteAllText(path, "not json at all");
+
+            TerminalSettings loaded = TerminalSettings.LoadFromPath(path);
+
+            Assert.NotNull(loaded);
+            Assert.NotEmpty(loaded.Profiles);
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void AtomicFile_WriteAllText_KeepsBackupOfPreviousContent()
+    {
+        string root = Directory.CreateTempSubdirectory("nova-atomic-tests-").FullName;
+        try
+        {
+            string path = Path.Combine(root, "file.json");
+
+            AtomicFile.WriteAllText(path, "v1");
+            AtomicFile.WriteAllText(path, "v2");
+
+            Assert.Equal("v2", File.ReadAllText(path));
+            Assert.Equal("v1", File.ReadAllText(path + ".bak"));
+            Assert.False(File.Exists(path + ".tmp"), "temp file must not linger");
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void AtomicFile_WriteAllBytes_RoundTrips()
+    {
+        string root = Directory.CreateTempSubdirectory("nova-atomic-tests-").FullName;
+        try
+        {
+            string path = Path.Combine(root, "vault.dat");
+            byte[] payload = { 1, 2, 3, 250, 251, 252 };
+
+            AtomicFile.WriteAllBytes(path, payload);
+
+            Assert.Equal(payload, File.ReadAllBytes(path));
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+}

--- a/tests/NovaTerminal.App.Tests/Core/TerminalSettingsPersistenceTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/TerminalSettingsPersistenceTests.cs
@@ -28,6 +28,12 @@ public sealed class TerminalSettingsPersistenceTests
             Assert.Equal("BackupMarkerFont", loaded.FontFamily);
             // The corrupt file is quarantined for diagnosis, not destroyed.
             Assert.True(File.Exists(path + ".corrupt"));
+
+            // The primary is repaired from the backup, so the next launch loads
+            // cleanly instead of repeating the quarantine/fallback cycle.
+            TerminalSettings reloaded = TerminalSettings.LoadFromPath(path);
+            Assert.Equal("BackupMarkerFont", reloaded.FontFamily);
+            Assert.Contains("BackupMarkerFont", File.ReadAllText(path));
         }
         finally
         {
@@ -68,7 +74,7 @@ public sealed class TerminalSettingsPersistenceTests
 
             Assert.Equal("v2", File.ReadAllText(path));
             Assert.Equal("v1", File.ReadAllText(path + ".bak"));
-            Assert.False(File.Exists(path + ".tmp"), "temp file must not linger");
+            Assert.Empty(Directory.GetFiles(root, "*.tmp")); // no lingering temp files
         }
         finally
         {


### PR DESCRIPTION
Fixes #167.

1. **Atomic persistence.** New internal AtomicFile helper (write temp sibling -> best-effort .bak of previous content -> atomic File.Move overwrite), used by TerminalSettings.Save, SessionManager.SaveSession (runs on shutdown!), and VaultService.Save. Same pattern JsonSshProfileStore/OpenSshConfigCompiler already use in Platform.
2. **Corrupt-file handling.** A corrupt settings.json is quarantined as .corrupt and the loader falls back to .bak before resorting to defaults; failures are logged instead of silently swallowed.
3. **Cancel reverts live preview.** OpenSettings snapshots the eight live-previewed values (opacity, blur, bg image x3, font, font size, theme) before wiring the preview handlers, and restores + re-applies them when the dialog closes without saving — previously any later unrelated Save() persisted the canceled preview.

4 new tests (backup fallback, defaults fallback, .bak retention, byte round-trip) pass; the existing LoadFromPath tests are unaffected.