### PR TITLE
fix(vt): DCS routing (DECRQSS/XTGETTCAP), C0-in-CSI execution, sixel input hardening

### DIFF
--- a/src/NovaTerminal.Rendering/SixelDecoder.cs
+++ b/src/NovaTerminal.Rendering/SixelDecoder.cs
@@ -70,7 +70,10 @@ namespace NovaTerminal.Rendering
                     int start = i;
                     while (i < data.Length && (char.IsDigit(data[i]) || data[i] == ';')) i++;
                     string[] parts = data.Substring(start, i - start).Split(';');
-                    if (parts.Length > 0 && int.TryParse(parts[0], out int idx))
+                    // Cap the palette index: sixel is remote-controlled input, and an
+                    // arbitrary idx would grow the palette dictionary without bound
+                    // (memory DoS). Modern extended implementations top out at 4096.
+                    if (parts.Length > 0 && int.TryParse(parts[0], out int idx) && idx >= 0 && idx < 4096)
                     {
                         if (parts.Length == 5) // Set color: idx; type; p1; p2; p3
                         {

--- a/src/NovaTerminal.Rendering/SixelDecoder.cs
+++ b/src/NovaTerminal.Rendering/SixelDecoder.cs
@@ -74,22 +74,30 @@ namespace NovaTerminal.Rendering
                     {
                         if (parts.Length == 5) // Set color: idx; type; p1; p2; p3
                         {
-                            int type = int.Parse(parts[1]);
-                            int p1 = int.Parse(parts[2]);
-                            int p2 = int.Parse(parts[3]);
-                            int p3 = int.Parse(parts[4]);
-
-                            if (type == 2) // RGB 0-100
+                            // Sixel is remote-controlled input: malformed params (e.g.
+                            // "#1;;2;3;4" — consecutive ';' yields an empty part) must be
+                            // skipped, not thrown out of Decode into the parser loop (#169).
+                            if (int.TryParse(parts[1], out int type) &&
+                                int.TryParse(parts[2], out int p1) &&
+                                int.TryParse(parts[3], out int p2) &&
+                                int.TryParse(parts[4], out int p3))
                             {
-                                _palette[idx] = new SixelColor(
-                                    (byte)(p1 * 255 / 100),
-                                    (byte)(p2 * 255 / 100),
-                                    (byte)(p3 * 255 / 100));
-                            }
-                            else if (type == 1) // HLS (simplified conversion)
-                            {
-                                // TODO: Full HLS to RGB conversion if needed
-                                _palette[idx] = new SixelColor(200, 200, 200);
+                                if (type == 2) // RGB 0-100
+                                {
+                                    // Clamp: values > 100 would otherwise wrap the byte cast.
+                                    p1 = Math.Clamp(p1, 0, 100);
+                                    p2 = Math.Clamp(p2, 0, 100);
+                                    p3 = Math.Clamp(p3, 0, 100);
+                                    _palette[idx] = new SixelColor(
+                                        (byte)(p1 * 255 / 100),
+                                        (byte)(p2 * 255 / 100),
+                                        (byte)(p3 * 255 / 100));
+                                }
+                                else if (type == 1) // HLS (simplified conversion)
+                                {
+                                    // TODO: Full HLS to RGB conversion if needed
+                                    _palette[idx] = new SixelColor(200, 200, 200);
+                                }
                             }
                         }
                         else

--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -89,20 +89,13 @@ namespace NovaTerminal.VT
 
         private static bool DetectConPtyFiltering()
         {
-            if (!OperatingSystem.IsWindows()) return false;
-
-            // Today our Windows backend uses ConPTY, which strips several image control strings.
-            // Keep env checks explicit so future backend changes can loosen this behavior.
-            string? wt = Environment.GetEnvironmentVariable("WT_SESSION");
-            string? termProgram = Environment.GetEnvironmentVariable("TERM_PROGRAM");
-            if (!string.IsNullOrEmpty(wt)) return true;
-            if (!string.IsNullOrEmpty(termProgram) &&
-                termProgram.IndexOf("Windows", StringComparison.OrdinalIgnoreCase) >= 0)
-            {
-                return true;
-            }
-
-            return true;
+            // Windows I/O currently always flows through ConPTY (rusty_pty), which
+            // strips DCS/APC image control strings — filtering is always likely there,
+            // so Kitty graphics must use the tunneled mode. The former WT_SESSION /
+            // TERM_PROGRAM env probes were dead code (the fallthrough returned true
+            // regardless, #169); if a future Windows backend bypasses ConPTY, make
+            // this depend on the backend instead of the OS.
+            return OperatingSystem.IsWindows();
         }
 
         private void FlushText()
@@ -111,6 +104,41 @@ namespace NovaTerminal.VT
             {
                 _buffer.WriteContent(_textBuffer.ToString());
                 _textBuffer.Clear();
+            }
+        }
+
+        /// <summary>
+        /// Executes a C0 control (or DEL). Shared by the Normal state and the CSI state:
+        /// per ECMA-48 §5.4, C0 controls received inside a control sequence are executed
+        /// while the sequence continues (#169). Callers in text-accumulating states must
+        /// FlushText() first.
+        /// </summary>
+        private void ExecuteC0Control(char c)
+        {
+            if (c == '\a')
+            {
+                OnBell?.Invoke();
+            }
+            else if (c == '') // SO — shift GL to G1
+            {
+                _gl = 1;
+            }
+            else if (c == '') // SI — shift GL to G0
+            {
+                _gl = 0;
+            }
+            else
+            {
+                if (_swallowNextNewline)
+                {
+                    if (c == '\r' || c == '\n')
+                    {
+                        if (c == '\n') _swallowNextNewline = false;
+                        return; // swallowed
+                    }
+                    _swallowNextNewline = false;
+                }
+                _buffer.WriteChar(c);
             }
         }
 
@@ -282,31 +310,7 @@ namespace NovaTerminal.VT
                                 else if (c < 0x20 || c == 0x7F) // C0 Controls & DEL
                                 {
                                     FlushText();
-                                    if (c == '\a')
-                                    {
-                                        OnBell?.Invoke();
-                                    }
-                                    else if (c == '') // SO — shift GL to G1
-                                    {
-                                        _gl = 1;
-                                    }
-                                    else if (c == '') // SI — shift GL to G0
-                                    {
-                                        _gl = 0;
-                                    }
-                                    else
-                                    {
-                                        if (_swallowNextNewline)
-                                        {
-                                            if (c == '\r' || c == '\n')
-                                            {
-                                                if (c == '\n') _swallowNextNewline = false;
-                                                continue;
-                                            }
-                                            else _swallowNextNewline = false;
-                                        }
-                                        _buffer.WriteChar(c);
-                                    }
+                                    ExecuteC0Control(c);
                                 }
                                 else
                                 {
@@ -503,6 +507,25 @@ namespace NovaTerminal.VT
                                     HandleCsi(c, _paramBuffer.AsSpan(0, _paramLen));
                                     _paramLen = 0;
                                     _state = State.Normal;
+                                }
+                                else if (c == '\x18' || c == '\x1a')
+                                {
+                                    // CAN/SUB abort the control sequence (ECMA-48).
+                                    _paramLen = 0;
+                                    _state = State.Normal;
+                                }
+                                else if (c < 0x20)
+                                {
+                                    // ECMA-48 §5.4: C0 controls received inside a control
+                                    // sequence are executed and the sequence continues.
+                                    // ConPTY/tmux can split output so CR/LF land mid-CSI;
+                                    // previously both the control AND the sequence were
+                                    // dropped (#169).
+                                    ExecuteC0Control(c);
+                                }
+                                else if (c == '\x7f')
+                                {
+                                    // DEL is ignored inside control sequences (xterm).
                                 }
                                 else
                                 {
@@ -1351,13 +1374,40 @@ namespace NovaTerminal.VT
 
         private void HandleDcs(string dcs)
         {
-
-            // Sixel Support (DCS Ps ; Pi ; Pj q <sixel_data> ST)
-            if (dcs.Contains('q'))
+            // DCS routing (#169). Previously ANY DCS containing 'q' was fed to the Sixel
+            // decoder, which swallowed DECRQSS (DCS $ q …, vim emits it to query SGR /
+            // DECSCUSR) and XTGETTCAP (DCS + q …) without a response — clients blocked
+            // on their reply timeout.
+            if (dcs.StartsWith("$q", StringComparison.Ordinal))
+            {
+                // DECRQSS: setting reports aren't implemented; answer "invalid request"
+                // (DCS 0 $ r ST) so the client gets an immediate, well-formed reply
+                // instead of a timeout.
+                OnResponse?.Invoke("\x1bP0$r\x1b\\");
+            }
+            else if (dcs.StartsWith("+q", StringComparison.Ordinal))
+            {
+                // XTGETTCAP: report failure for the requested capabilities (DCS 0 + r ST).
+                OnResponse?.Invoke("\x1bP0+r\x1b\\");
+            }
+            else if (IsSixel(dcs))
             {
                 HandleSixel(dcs);
             }
             _dcsStringBuffer.Clear();
+        }
+
+        // DECSIXEL is "DCS Ps ; Ps ; Ps q <data> ST": only digits and ';' may precede
+        // the 'q' final byte. Anything else is a different DCS function.
+        private static bool IsSixel(string dcs)
+        {
+            for (int i = 0; i < dcs.Length; i++)
+            {
+                char ch = dcs[i];
+                if (ch == 'q') return true;
+                if (!char.IsAsciiDigit(ch) && ch != ';') return false;
+            }
+            return false;
         }
 
         private void HandleSixel(string dcs)

--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -119,11 +119,11 @@ namespace NovaTerminal.VT
             {
                 OnBell?.Invoke();
             }
-            else if (c == '') // SO — shift GL to G1
+            else if (c == '\x0e') // SO — shift GL to G1
             {
                 _gl = 1;
             }
-            else if (c == '') // SI — shift GL to G0
+            else if (c == '\x0f') // SI — shift GL to G0
             {
                 _gl = 0;
             }

--- a/tests/NovaTerminal.Rendering.Tests/SixelDecoderTests.cs
+++ b/tests/NovaTerminal.Rendering.Tests/SixelDecoderTests.cs
@@ -1,4 +1,5 @@
 using NovaTerminal.Rendering;
+using SkiaSharp;
 using Xunit;
 
 namespace NovaTerminal.Rendering.Tests;
@@ -7,12 +8,32 @@ namespace NovaTerminal.Rendering.Tests;
 // malformed color parameters must be skipped, not thrown into the parser loop.
 public class SixelDecoderTests
 {
+    // SixelDecoder renders through the SkiaSharp native library. Same convention as
+    // GlyphCacheTests: present on Windows CI / dev machines, absent on the Linux
+    // gating runner — skip there rather than fail.
+    private static readonly bool SkiaAvailable = CheckSkiaAvailable();
+
+    private static bool CheckSkiaAvailable()
+    {
+        try
+        {
+            using var surface = SKSurface.Create(new SKImageInfo(1, 1, SKColorType.Rgba8888));
+            return surface != null;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     [Theory]
     [InlineData("0;0;0q#1;;2;3;4~~")]          // empty param via consecutive ';'
     [InlineData("0;0;0q#1;2;;3;~~")]           // multiple empties
     [InlineData("0;0;0q#1;2;99999999999;3;4~")] // overflow int.Parse territory
     public void Decode_MalformedColorParams_DoesNotThrow(string dcs)
     {
+        Assert.SkipUnless(SkiaAvailable, "SkiaSharp native library not available on this platform.");
+
         var decoder = new SixelDecoder();
 
         var ex = Record.Exception(() => decoder.Decode(dcs));
@@ -23,6 +44,8 @@ public class SixelDecoderTests
     [Fact]
     public void Decode_RgbValuesAbove100_AreClampedNotWrapped()
     {
+        Assert.SkipUnless(SkiaAvailable, "SkiaSharp native library not available on this platform.");
+
         var decoder = new SixelDecoder();
 
         // type 2 = RGB percentages; 200% would previously wrap the byte cast.
@@ -34,6 +57,8 @@ public class SixelDecoderTests
     [Fact]
     public void Decode_ValidMinimalSixel_ProducesBitmap()
     {
+        Assert.SkipUnless(SkiaAvailable, "SkiaSharp native library not available on this platform.");
+
         var decoder = new SixelDecoder();
 
         // One 6-pixel column in palette color 1.

--- a/tests/NovaTerminal.Rendering.Tests/SixelDecoderTests.cs
+++ b/tests/NovaTerminal.Rendering.Tests/SixelDecoderTests.cs
@@ -1,0 +1,44 @@
+using NovaTerminal.Rendering;
+using Xunit;
+
+namespace NovaTerminal.Rendering.Tests;
+
+// Regression tests for #169: sixel payloads are remote-controlled input, so
+// malformed color parameters must be skipped, not thrown into the parser loop.
+public class SixelDecoderTests
+{
+    [Theory]
+    [InlineData("0;0;0q#1;;2;3;4~~")]          // empty param via consecutive ';'
+    [InlineData("0;0;0q#1;2;;3;~~")]           // multiple empties
+    [InlineData("0;0;0q#1;2;99999999999;3;4~")] // overflow int.Parse territory
+    public void Decode_MalformedColorParams_DoesNotThrow(string dcs)
+    {
+        var decoder = new SixelDecoder();
+
+        var ex = Record.Exception(() => decoder.Decode(dcs));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Decode_RgbValuesAbove100_AreClampedNotWrapped()
+    {
+        var decoder = new SixelDecoder();
+
+        // type 2 = RGB percentages; 200% would previously wrap the byte cast.
+        var ex = Record.Exception(() => decoder.Decode("0;0;0q#1;2;200;200;200#1~~-"));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Decode_ValidMinimalSixel_ProducesBitmap()
+    {
+        var decoder = new SixelDecoder();
+
+        // One 6-pixel column in palette color 1.
+        var bitmap = decoder.Decode("0;0;0q#1;2;100;0;0#1~");
+
+        Assert.NotNull(bitmap);
+    }
+}

--- a/tests/NovaTerminal.VT.Tests/DcsAndCsiRoutingTests.cs
+++ b/tests/NovaTerminal.VT.Tests/DcsAndCsiRoutingTests.cs
@@ -1,0 +1,109 @@
+using System.Text;
+
+namespace NovaTerminal.VT.Tests;
+
+// Regression tests for #169: DCS routing (DECRQSS/XTGETTCAP vs Sixel) and
+// C0-control handling inside CSI sequences.
+public class DcsAndCsiRoutingTests
+{
+    private static (TerminalBuffer buffer, AnsiParser parser, List<string> responses) CreateTerminal()
+    {
+        var buffer = new TerminalBuffer(cols: 40, rows: 5);
+        var parser = new AnsiParser(buffer);
+        var responses = new List<string>();
+        parser.OnResponse = responses.Add;
+        return (buffer, parser, responses);
+    }
+
+    private static string ReadRow(TerminalBuffer buffer, int viewRow, int cols = 40)
+    {
+        var sb = new StringBuilder();
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            for (int col = 0; col < cols; col++)
+            {
+                sb.Append(buffer.GetGrapheme(col, viewRow));
+            }
+        }
+        finally { buffer.Lock.ExitReadLock(); }
+        return sb.ToString().TrimEnd('\0', ' ');
+    }
+
+    [Fact]
+    public void Decrqss_GetsInvalidRequestResponse_NotSixel()
+    {
+        var (_, parser, responses) = CreateTerminal();
+
+        // vim's SGR query: DCS $ q m ST — previously misrouted to the Sixel decoder
+        // (it contains 'q') and never answered, so vim blocked on its timeout.
+        parser.Process("\x1bP$qm\x1b\\");
+
+        Assert.Single(responses);
+        Assert.Equal("\x1bP0$r\x1b\\", responses[0]);
+    }
+
+    [Fact]
+    public void Xtgettcap_GetsFailureResponse()
+    {
+        var (_, parser, responses) = CreateTerminal();
+
+        // XTGETTCAP for "TN" (hex 544e): DCS + q 544e ST
+        parser.Process("\x1bP+q544e\x1b\\");
+
+        Assert.Single(responses);
+        Assert.Equal("\x1bP0+r\x1b\\", responses[0]);
+    }
+
+    [Fact]
+    public void NonSixelDcs_WithLetterQ_IsNotFedToSixelDecoder()
+    {
+        var (_, parser, _) = CreateTerminal();
+
+        // An unknown DCS whose payload merely contains 'q' — must not throw or
+        // produce sixel artifacts. (No decoder attached; just must not misroute.)
+        var ex = Record.Exception(() => parser.Process("\x1bPzzzqzzz\x1b\\"));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void C0Controls_InsideCsi_AreExecuted_AndSequenceContinues()
+    {
+        var (buffer, parser, _) = CreateTerminal();
+
+        parser.Process("AB");
+        // SGR split by a CR: ESC[3 <CR> 2m — per ECMA-48 the CR executes and the
+        // sequence continues as CSI 32 m. Previously both were dropped.
+        parser.Process("\x1b[3\r2m");
+        parser.Process("X");
+
+        Assert.Equal(0, buffer.CursorRow);
+        // CR executed: cursor returned to col 0, so X overwrote A.
+        Assert.Equal("XB", ReadRow(buffer, 0));
+        // Sequence continued: SGR 32 (green fg) applied to X.
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            var cell = buffer.GetCellAbsolute(0, buffer.Scrollback.Count);
+            Assert.Equal(2, cell.FgIndex); // palette index 2 = green
+        }
+        finally { buffer.Lock.ExitReadLock(); }
+    }
+
+    [Theory]
+    [InlineData('\x18')] // CAN
+    [InlineData('\x1a')] // SUB
+    public void CanAndSub_AbortCsiSequence(char abortChar)
+    {
+        var (buffer, parser, _) = CreateTerminal();
+
+        parser.Process($"\x1b[3{abortChar}1m");
+        parser.Process("X");
+
+        // The aborted SGR must not apply; the trailing "1m" is plain text per xterm
+        // (it was never part of a sequence).
+        Assert.Contains("1mX", ReadRow(buffer, 0));
+    }
+
+}


### PR DESCRIPTION
Fixes #169. Four parser-correctness fixes, batched:

1. **DCS routing.** Any DCS containing 'q' was fed to the Sixel decoder — DECRQSS (DCS \$ q, vim's SGR/DECSCUSR query) and XTGETTCAP (DCS + q) were swallowed with no reply, leaving clients blocked on their timeout. They now get immediate well-formed 'invalid request' replies (DCS 0 \$ r ST / DCS 0 + r ST); Sixel detection requires the DECSIXEL prefix shape (only digits/';' before the 'q' final).
2. **C0 controls mid-CSI** are executed and the sequence continues per ECMA-48 §5.4 (shared ExecuteC0Control helper with the Normal state); CAN/SUB abort the sequence; DEL is ignored. Previously ESC[3 <CR> 2m lost both the CR and the SGR.
3. **DetectConPtyFiltering** had dead env probes before an unconditional 'return true'; now returns OperatingSystem.IsWindows() with the rationale documented (backend-driven, not env-driven).
4. **SixelDecoder** uses TryParse + clamping for color params — remote-controlled '#1;;2;3;4' previously threw FormatException into the parser loop; RGB percentages >100 no longer wrap the byte cast.

Tests: 6 new VT tests (DECRQSS/XTGETTCAP replies, non-sixel 'q' DCS, CR-split SGR continues + executes, CAN/SUB abort) and 5 new SixelDecoder tests. 77 VT + 10 Rendering tests pass.