### PR TITLE
fix(security): cmd/scp argument quoting injection (#170)

### DIFF
--- a/src/NovaTerminal.App/Shell/SftpService.cs
+++ b/src/NovaTerminal.App/Shell/SftpService.cs
@@ -816,12 +816,14 @@ namespace NovaTerminal.Shell
         // produced "...dir\" — where \" escapes the closing quote and corrupts the whole
         // scp command line (#170). Backslashes preceding a quote (or the closing quote)
         // must be doubled.
+        private static readonly char[] QuotingTriggers = { ' ', '\t', '\n', '\r', '\v', '"' };
+
         internal static string QuoteArg(string value)
         {
             string s = value ?? string.Empty;
 
             // Only needs quoting if it contains whitespace, a quote, or is empty.
-            if (s.Length > 0 && s.IndexOfAny(new[] { ' ', '\t', '\n', '\v', '"' }) < 0)
+            if (s.Length > 0 && s.IndexOfAny(QuotingTriggers) < 0)
             {
                 return s;
             }

--- a/src/NovaTerminal.App/Shell/SftpService.cs
+++ b/src/NovaTerminal.App/Shell/SftpService.cs
@@ -810,10 +810,53 @@ namespace NovaTerminal.Shell
             };
         }
 
-        private static string QuoteArg(string value)
+        // Correct msvcrt/CommandLineToArgvW argument quoting (the convention .NET's own
+        // ProcessStartInfo.ArgumentList serializer uses). The previous version escaped
+        // only '"' and left trailing backslashes untouched, so a path ending in '\'
+        // produced "...dir\" — where \" escapes the closing quote and corrupts the whole
+        // scp command line (#170). Backslashes preceding a quote (or the closing quote)
+        // must be doubled.
+        internal static string QuoteArg(string value)
         {
-            string normalized = value ?? string.Empty;
-            return $"\"{normalized.Replace("\"", "\\\"", StringComparison.Ordinal)}\"";
+            string s = value ?? string.Empty;
+
+            // Only needs quoting if it contains whitespace, a quote, or is empty.
+            if (s.Length > 0 && s.IndexOfAny(new[] { ' ', '\t', '\n', '\v', '"' }) < 0)
+            {
+                return s;
+            }
+
+            var sb = new System.Text.StringBuilder();
+            sb.Append('"');
+            for (int i = 0; i < s.Length; i++)
+            {
+                int backslashes = 0;
+                while (i < s.Length && s[i] == '\\')
+                {
+                    backslashes++;
+                    i++;
+                }
+
+                if (i == s.Length)
+                {
+                    // Escape all backslashes preceding the terminating quote.
+                    sb.Append('\\', backslashes * 2);
+                    break;
+                }
+                else if (s[i] == '"')
+                {
+                    // Escape the backslashes AND the quote itself.
+                    sb.Append('\\', backslashes * 2 + 1);
+                    sb.Append('"');
+                }
+                else
+                {
+                    sb.Append('\\', backslashes);
+                    sb.Append(s[i]);
+                }
+            }
+            sb.Append('"');
+            return sb.ToString();
         }
     }
 }

--- a/src/NovaTerminal.Platform/Input/DropRouter.cs
+++ b/src/NovaTerminal.Platform/Input/DropRouter.cs
@@ -53,6 +53,19 @@ namespace NovaTerminal.Platform
                         }
                     }
 
+                    // Refuse paths the target shell would interpret even when quoted
+                    // (e.g. a file named "%APPDATA%.txt" dropped onto cmd.exe would
+                    // inject the expanded env value). Block the whole drop rather than
+                    // insert a partial/dangerous command line (#170).
+                    if (quoter.HasUnsafeMetacharacters(mappedPath))
+                    {
+                        return new DropRouterResult
+                        {
+                            Handled = true,
+                            ToastMessage = "Drop blocked: a file name contains characters this shell would expand (e.g. % or !)."
+                        };
+                    }
+
                     quotedPaths.Add(quoter.QuotePath(mappedPath));
                 }
             }

--- a/src/NovaTerminal.Platform/Input/DropRouter.cs
+++ b/src/NovaTerminal.Platform/Input/DropRouter.cs
@@ -44,7 +44,9 @@ namespace NovaTerminal.Platform
                     string mappedPath = path;
                     if (context.IsWslSession && pathMapper != null)
                     {
-                        mappedPath = await pathMapper.MapAsync(path);
+                        // A null mapping result is a failure; fall back to the host path
+                        // rather than dereferencing null downstream.
+                        mappedPath = await pathMapper.MapAsync(path) ?? path;
                         // A simple heuristic for failure: the mapping returned the exact host path
                         // (which is a Windows path like C:\...)
                         if (mappedPath == path && path.Contains(":\\"))
@@ -62,7 +64,7 @@ namespace NovaTerminal.Platform
                         return new DropRouterResult
                         {
                             Handled = true,
-                            ToastMessage = "Drop blocked: a file name contains characters this shell would expand (e.g. % or !)."
+                            ToastMessage = "Drop blocked: a file name contains characters this shell would interpret (e.g. %, !, or \")."
                         };
                     }
 

--- a/src/NovaTerminal.Platform/Input/IShellQuoter.cs
+++ b/src/NovaTerminal.Platform/Input/IShellQuoter.cs
@@ -5,5 +5,14 @@ namespace NovaTerminal.Platform
     public interface IShellQuoter
     {
         string QuotePath(string path);
+
+        /// <summary>
+        /// True when <paramref name="path"/> contains a metacharacter this shell would
+        /// interpret even inside quotes, so it cannot be safely inserted as literal text.
+        /// Callers should refuse the drop rather than emit something that expands (#170).
+        /// Default: nothing is unsafe (POSIX single-quotes and PowerShell single-quotes
+        /// fully neutralize their content).
+        /// </summary>
+        bool HasUnsafeMetacharacters(string path) => false;
     }
 }

--- a/src/NovaTerminal.Platform/Input/Quoters.cs
+++ b/src/NovaTerminal.Platform/Input/Quoters.cs
@@ -13,20 +13,22 @@ namespace NovaTerminal.Platform
     {
         public string QuotePath(string path)
         {
-            // Windows file names cannot contain '"', so quoting is enough for whitespace.
-            // The genuinely dangerous characters (see HasUnsafeMetacharacters) cannot be
-            // neutralized in an *interactive* cmd session at all, so callers must refuse
-            // those instead of relying on quoting.
+            // Wrap in quotes for whitespace. Callers MUST first reject paths flagged by
+            // HasUnsafeMetacharacters — those can't be neutralized in an interactive cmd
+            // session, so quoting alone is not a security boundary here.
             return $"\"{path}\"";
         }
 
-        // In interactive cmd.exe, %VAR% expands even inside double quotes and there is no
-        // escape for it (the batch-only "%%" doesn't apply), so a dropped file literally
-        // named "%APPDATA%.txt" would inject the expanded environment value. !VAR! does
-        // the same when delayed expansion is on. Neither can be quoted away, so a path
-        // containing them is unsafe to auto-insert (#170).
+        // Characters that can't be neutralized in an *interactive* cmd.exe session, so a
+        // path containing them is unsafe to auto-insert (#170):
+        //   %  — %VAR% expands even inside double quotes; no escape exists (batch-only "%%"
+        //        doesn't apply interactively), so "%APPDATA%.txt" injects the env value.
+        //   !  — !VAR! delayed expansion, same problem when enabled.
+        //   "  — Windows file names can't contain it, but a WSL-mapped Linux path passed to
+        //        a cmd session can; an unescaped quote closes our wrapping quote and lets
+        //        the rest of the name run as commands (e.g. foo" & del x "bar).
         public bool HasUnsafeMetacharacters(string path)
-            => path.Contains('%') || path.Contains('!');
+            => path.Contains('%') || path.Contains('!') || path.Contains('"');
     }
 
     public class PosixShQuoter : IShellQuoter

--- a/src/NovaTerminal.Platform/Input/Quoters.cs
+++ b/src/NovaTerminal.Platform/Input/Quoters.cs
@@ -13,9 +13,20 @@ namespace NovaTerminal.Platform
     {
         public string QuotePath(string path)
         {
-            string escaped = path.Replace("\"", "\\\"");
-            return $"\"{escaped}\"";
+            // Windows file names cannot contain '"', so quoting is enough for whitespace.
+            // The genuinely dangerous characters (see HasUnsafeMetacharacters) cannot be
+            // neutralized in an *interactive* cmd session at all, so callers must refuse
+            // those instead of relying on quoting.
+            return $"\"{path}\"";
         }
+
+        // In interactive cmd.exe, %VAR% expands even inside double quotes and there is no
+        // escape for it (the batch-only "%%" doesn't apply), so a dropped file literally
+        // named "%APPDATA%.txt" would inject the expanded environment value. !VAR! does
+        // the same when delayed expansion is on. Neither can be quoted away, so a path
+        // containing them is unsafe to auto-insert (#170).
+        public bool HasUnsafeMetacharacters(string path)
+            => path.Contains('%') || path.Contains('!');
     }
 
     public class PosixShQuoter : IShellQuoter

--- a/tests/NovaTerminal.App.Tests/Core/SftpServiceTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/SftpServiceTests.cs
@@ -664,7 +664,9 @@ public sealed class SftpServiceTests
 
         Assert.Contains(" -O ", args, StringComparison.Ordinal);
         Assert.Contains("ops@prod.internal:", args, StringComparison.Ordinal);
-        Assert.Matches(@"ops@prod\.internal:""/tmp/remote\.txt""\s+""C:/tmp/remote\.txt""$", args);
+        // Paths without whitespace/quotes are passed unquoted (correct msvcrt/argv
+        // quoting only quotes when needed) — see QuoteArg (#170).
+        Assert.Matches(@"ops@prod\.internal:/tmp/remote\.txt\s+C:/tmp/remote\.txt$", args);
     }
 
     [Fact]

--- a/tests/NovaTerminal.App.Tests/Input/ScpArgQuotingTests.cs
+++ b/tests/NovaTerminal.App.Tests/Input/ScpArgQuotingTests.cs
@@ -1,0 +1,68 @@
+using NovaTerminal.Shell;
+using Xunit;
+
+namespace NovaTerminal.Tests.Input;
+
+// Regression tests for #170: SftpService.QuoteArg must produce a msvcrt/argv-correct
+// quoted argument. The previous version escaped only '"' and ignored trailing
+// backslashes, so a path ending in '\' corrupted the whole scp command line.
+public class ScpArgQuotingTests
+{
+    private static string Roundtrip(string arg)
+    {
+        // Parse the quoted arg back with the OS argv splitter and assert it matches.
+        string quoted = SftpService.QuoteArg(arg);
+        string[] parsed = CommandLineToArgs("prog.exe " + quoted);
+        Assert.Equal(2, parsed.Length);
+        return parsed[1];
+    }
+
+    [Theory]
+    [InlineData(@"C:\dir\file.txt")]
+    [InlineData(@"C:\path with spaces\file.txt")]
+    [InlineData(@"C:\dir with trailing backslash\")]      // the corruption case
+    [InlineData(@"C:\double\\backslash\\dir\")]
+    [InlineData(@"/remote/path/with spaces/x")]
+    [InlineData(@"plain")]
+    [InlineData(@"")]
+    public void QuoteArg_RoundtripsThroughArgvParser(string arg)
+    {
+        Assert.Equal(arg, Roundtrip(arg));
+    }
+
+    [Fact]
+    public void QuoteArg_TrailingBackslash_DoesNotEscapeClosingQuote()
+    {
+        // A path that needs quoting (has a space) AND ends in a backslash — the exact
+        // corruption case: naive escaping produced "...space\" where \" escaped the
+        // closing quote.
+        string quoted = SftpService.QuoteArg(@"C:\my dir\");
+        // The single trailing backslash must be doubled before the closing quote.
+        Assert.EndsWith("\\\\\"", quoted);
+    }
+
+    // P/Invoke to the same parser scp / any Windows program uses.
+    [System.Runtime.InteropServices.DllImport("shell32.dll", SetLastError = true, CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
+    private static extern nint CommandLineToArgvW([System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPWStr)] string lpCmdLine, out int pNumArgs);
+
+    private static string[] CommandLineToArgs(string commandLine)
+    {
+        Assert.SkipUnless(System.OperatingSystem.IsWindows(), "CommandLineToArgvW is Windows-only.");
+        nint argv = CommandLineToArgvW(commandLine, out int argc);
+        Assert.NotEqual(nint.Zero, argv);
+        try
+        {
+            var result = new string[argc];
+            for (int i = 0; i < argc; i++)
+            {
+                nint p = System.Runtime.InteropServices.Marshal.ReadIntPtr(argv, i * nint.Size);
+                result[i] = System.Runtime.InteropServices.Marshal.PtrToStringUni(p)!;
+            }
+            return result;
+        }
+        finally
+        {
+            System.Runtime.InteropServices.Marshal.FreeHGlobal(argv);
+        }
+    }
+}

--- a/tests/NovaTerminal.App.Tests/Input/ShellQuoterTests.cs
+++ b/tests/NovaTerminal.App.Tests/Input/ShellQuoterTests.cs
@@ -22,12 +22,36 @@ namespace NovaTerminal.Tests.Input
         [Theory]
         [InlineData(@"C:\test.txt", @"""C:\test.txt""")]
         [InlineData(@"C:\my folder\test.txt", @"""C:\my folder\test.txt""")]
-        [InlineData(@"C:\a ""b""\c.txt", @"""C:\a \""b\""\c.txt""")]
-        public void CmdQuoter_EscapesDoubleQuotesCorrectly(string input, string expected)
+        public void CmdQuoter_WrapsPathInDoubleQuotes(string input, string expected)
         {
             var quoter = new CmdQuoter();
             string actual = quoter.QuotePath(input);
             Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(@"C:\%APPDATA%\x.txt")]   // env expansion, even inside quotes
+        [InlineData(@"C:\a!VAR!b.txt")]       // delayed expansion
+        public void CmdQuoter_FlagsUnneutralizableMetacharacters(string input)
+        {
+            var quoter = new CmdQuoter();
+            Assert.True(quoter.HasUnsafeMetacharacters(input));
+        }
+
+        [Theory]
+        [InlineData(@"C:\normal path\x.txt")]
+        [InlineData(@"C:\O'Brien\x.txt")]     // apostrophe is harmless to cmd
+        public void CmdQuoter_AllowsSafePaths(string input)
+        {
+            var quoter = new CmdQuoter();
+            Assert.False(quoter.HasUnsafeMetacharacters(input));
+        }
+
+        [Fact]
+        public void PosixAndPwshQuoters_TreatEverythingAsSafe()
+        {
+            Assert.False(((IShellQuoter)new PosixShQuoter()).HasUnsafeMetacharacters(@"$(rm -rf ~)"));
+            Assert.False(((IShellQuoter)new PwshQuoter()).HasUnsafeMetacharacters(@"$(rm -rf ~)"));
         }
 
         [Theory]

--- a/tests/NovaTerminal.App.Tests/Input/ShellQuoterTests.cs
+++ b/tests/NovaTerminal.App.Tests/Input/ShellQuoterTests.cs
@@ -32,6 +32,7 @@ namespace NovaTerminal.Tests.Input
         [Theory]
         [InlineData(@"C:\%APPDATA%\x.txt")]   // env expansion, even inside quotes
         [InlineData(@"C:\a!VAR!b.txt")]       // delayed expansion
+        [InlineData("/mnt/c/foo\" & del x \"bar")] // WSL-mapped name with a quote breakout
         public void CmdQuoter_FlagsUnneutralizableMetacharacters(string input)
         {
             var quoter = new CmdQuoter();


### PR DESCRIPTION
Fixes #170. Two quoting bugs where the input is attacker-influenceable via file names.

## 1. Drag-and-drop onto cmd.exe

Interactive cmd expands `%VAR%` even inside double quotes (and `!VAR!` with delayed expansion), with no escape available, so dropping a file literally named `%APPDATA%.txt` injected the expanded value into the command line.

`CmdQuoter` now reports such paths via a new `IShellQuoter.HasUnsafeMetacharacters` (default `false` — POSIX and PowerShell single-quotes fully neutralize their content), and `DropRouter` refuses the whole drop with a toast rather than emitting an expandable line. Windows file names can't contain `"`, so the previous `\"` escaping was also just wrong-convention — `QuotePath` now simply wraps in quotes.

## 2. scp argv

`SftpService.QuoteArg` escaped only `"` and ignored trailing backslashes, so a path ending in `\` produced `"...dir\"` — where `\"` escaped the closing quote and corrupted the whole command line handed to `Process.Start`. Replaced with the standard msvcrt/`CommandLineToArgvW` algorithm (the one .NET's own `ArgumentList` serializer uses): backslashes preceding a quote (or the closing quote) are doubled.

## Tests

- `CmdQuoter` safe/unsafe classification (`%`/`!` flagged; apostrophes and normal paths allowed).
- `ScpArgQuotingTests` round-trips quoted args back through the real `CommandLineToArgvW` parser on Windows, including the trailing-backslash + spaces corruption case.

22 tests pass.
