### PR TITLE
feat(agent-host): A1 contracts library + live session registry

### DIFF
--- a/NovaTerminal.sln
+++ b/NovaTerminal.sln
@@ -41,6 +41,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NovaTerminal.McpServer", "s
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NovaTerminal.McpServer.Tests", "tests\NovaTerminal.McpServer.Tests\NovaTerminal.McpServer.Tests.csproj", "{254C6074-5012-4A10-BBA4-E14953766E7F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NovaTerminal.AgentHost.Contracts", "src\NovaTerminal.AgentHost.Contracts\NovaTerminal.AgentHost.Contracts.csproj", "{A7C4E9D1-6B2F-4E8A-9F31-5D8C7B0A2E64}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -255,6 +257,18 @@ Global
 		{254C6074-5012-4A10-BBA4-E14953766E7F}.Release|x64.Build.0 = Release|Any CPU
 		{254C6074-5012-4A10-BBA4-E14953766E7F}.Release|x86.ActiveCfg = Release|Any CPU
 		{254C6074-5012-4A10-BBA4-E14953766E7F}.Release|x86.Build.0 = Release|Any CPU
+		{A7C4E9D1-6B2F-4E8A-9F31-5D8C7B0A2E64}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7C4E9D1-6B2F-4E8A-9F31-5D8C7B0A2E64}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A7C4E9D1-6B2F-4E8A-9F31-5D8C7B0A2E64}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A7C4E9D1-6B2F-4E8A-9F31-5D8C7B0A2E64}.Debug|x64.Build.0 = Debug|Any CPU
+		{A7C4E9D1-6B2F-4E8A-9F31-5D8C7B0A2E64}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A7C4E9D1-6B2F-4E8A-9F31-5D8C7B0A2E64}.Debug|x86.Build.0 = Debug|Any CPU
+		{A7C4E9D1-6B2F-4E8A-9F31-5D8C7B0A2E64}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A7C4E9D1-6B2F-4E8A-9F31-5D8C7B0A2E64}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A7C4E9D1-6B2F-4E8A-9F31-5D8C7B0A2E64}.Release|x64.ActiveCfg = Release|Any CPU
+		{A7C4E9D1-6B2F-4E8A-9F31-5D8C7B0A2E64}.Release|x64.Build.0 = Release|Any CPU
+		{A7C4E9D1-6B2F-4E8A-9F31-5D8C7B0A2E64}.Release|x86.ActiveCfg = Release|Any CPU
+		{A7C4E9D1-6B2F-4E8A-9F31-5D8C7B0A2E64}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -277,5 +291,6 @@ Global
 		{39F1F320-2266-487E-98D8-43BE0FECD0A4} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{4B799A42-DE84-4393-89E9-B7B1EFFFA02D} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{254C6074-5012-4A10-BBA4-E14953766E7F} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{A7C4E9D1-6B2F-4E8A-9F31-5D8C7B0A2E64} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -160,12 +160,18 @@ Enforced invariants (`NovaTerminal.Architecture.Tests`): `VT` is a leaf with zer
 
 #### Active work
 
+- **Agent host program** — the accepted strategic direction
+  ([`docs/agent-host/DIRECTION.md`](docs/agent-host/DIRECTION.md)): a
+  session-facing MCP surface so AI agents can observe, query status of, and
+  (with explicit permission) act inside live terminal sessions, with
+  deterministic replay as the debugging story.
 - **VT conformance program** — every supported VT/ANSI feature is tracked in a
   matrix; a dedicated CI lane regenerates the report and fails on regressions.
   See [`docs/vt_coverage_matrix.md`](docs/vt_coverage_matrix.md) and
   [`docs/ghostty-gaps/vt_conformance_tooling.md`](docs/ghostty-gaps/vt_conformance_tooling.md).
-- **Ghostty gap closure** — systematic comparison against Ghostty's behavior
-  with a roadmap for closing remaining gaps. See
+- **Ghostty gap tracking (regression gate)** — comparison against Ghostty's
+  behavior is maintained as a regression gate; remaining matrix gaps are
+  closed when real TUI or agent workflows hit them. See
   [`docs/ghostty-gaps/`](docs/ghostty-gaps/) and
   [`docs/vt_ghostty_gap_matrix.md`](docs/vt_ghostty_gap_matrix.md).
 - **Native SSH** — cross-platform SSH client (experimental, opt-in) with VT

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,6 +13,9 @@ Related execution plans:
 - `docs/PRODUCTION_EXECUTION_PLAN.md`
 - `docs/MULTI_PANE_EXECUTION_PLAN.md`
 - `docs/TABS_EXECUTION_PLAN.md`
+- `docs/agent-host/DIRECTION.md` — **accepted strategic direction (2026-07-07)**:
+  NovaTerminal as an agent host ("enable, don't embed"). Reframes Phases 4–5
+  and demotes Ghostty gap closure to a regression gate.
 
 ---
 
@@ -325,6 +328,11 @@ in `docs/SSH_ROADMAP.md` and `docs/native-ssh/Native_SSH_Test_Matrix.md`.
 # Phase 4 — Optional AI (Post-v1)
 
 > Must be opt-in and privacy-respecting.
+>
+> **Direction update (2026-07-07):** the accepted strategy is
+> `docs/agent-host/DIRECTION.md` — NovaTerminal enables agents (session-facing
+> MCP surface: observe / status / act / replay) rather than embedding AI.
+> Command Assist remains the only user-facing AI-adjacent surface.
 
 ---
 
@@ -363,6 +371,8 @@ in `docs/SSH_ROADMAP.md` and `docs/native-ssh/Native_SSH_Test_Matrix.md`.
 ---
 
 ## 5.2 Automation Hooks
+
+> Absorbed into milestone **A2** of `docs/agent-host/DIRECTION.md`.
 
 ### Deliverables
 - Notifications for long-running commands

--- a/docs/agent-host/DIRECTION.md
+++ b/docs/agent-host/DIRECTION.md
@@ -1,0 +1,212 @@
+# ADR: NovaTerminal as an Agent Host
+
+_Status: **Accepted** (2026-07-07) · Date: 2026-07-07 · Supersedes the strategic framing of
+`docs/ghostty-gaps/ghostty_gap_roadmap.md`; amends Phases 4–5 of `docs/ROADMAP.md`._
+
+---
+
+## Context
+
+### What changed in the industry
+
+Since this project started, the terminal market has bifurcated:
+
+1. **Pure emulators** competing on speed and correctness. Ghostty won this
+   race: fastest rendering, strong correctness, a full-time famous maintainer,
+   and default-recommendation status in every 2026 comparison.
+2. **Agent-aware terminals** built to host CLI coding agents (Claude Code,
+   Codex CLI, Gemini CLI). Warp rebranded itself an "Agentic Development
+   Environment"; tools like cmux and Agent Deck exist purely to orchestrate
+   agent sessions. CLI agents are now a mainstream developer workflow, and the
+   terminal a developer chooses materially affects their agent workflow.
+
+What agent-aware terminals compete on today: session observability (agents
+reading screen state), session status detection (running / waiting-for-input /
+idle), completion & stall notifications, programmatic session spawning, and
+parallel-session orchestration. Most implementations are tmux-layer inference
+or proprietary. None offer deterministic replay.
+
+### Where NovaTerminal stands
+
+- Chasing Ghostty on its own axis (speed + correctness as the headline) is
+  not winnable for a nights-and-weekends solo project. The gap-closure
+  program produced real quality, but as a *strategy* it is a treadmill.
+- NovaTerminal's unusual investments map directly onto what agents need:
+  - **Cell-based buffer + VT correctness** → structured, trustworthy screen
+    reads ("the agent sees exactly what a human sees").
+  - **Thread-safe PTY ownership** → real process/session status, not
+    heuristics layered on tmux.
+  - **Deterministic replay** → record and replay agent sessions with
+    byte-for-byte buffer parity. No other terminal can do this.
+  - **Existing MCP server** (`src/NovaTerminal.McpServer`) → the transport
+    and packaging already exist; today it is repo-facing (docs, VT
+    explanations, profile validation), not session-facing.
+  - **Native SSH profiles** → agents can be given correct remote sessions,
+    which no agent-aware terminal offers today.
+
+## Decision
+
+**NovaTerminal positions itself as the correct, deterministic terminal that is
+the best host for AI agents — "enable, don't embed."**
+
+Concretely:
+
+1. Extend the MCP surface from *repo-facing* to *session-facing*: agents can
+   observe, query status of, and (with permission) act inside live terminal
+   sessions.
+2. Do **not** build embedded AI (chat sidebars, model integrations, vendor
+   bets). Command Assist remains the only user-facing AI-adjacent surface and
+   keeps its existing opt-in constraints.
+3. Demote Ghostty gap closure from an active program to a regression gate:
+   the VT conformance CI lane stays blocking; new matrix cells are closed
+   only when a real TUI application or agent workflow hits them.
+4. Treat distribution (brew / winget / Flatpak) as a parallel first-class
+   workstream: adoption goals fail on install friction before they fail on
+   features.
+
+## Consequences
+
+- VT correctness stops being a me-too feature and becomes the trust
+  foundation of the agent story.
+- Replay gains a second audience: debugging *agent* behavior, not just
+  terminal bugs.
+- The McpServer grows a live control path and therefore a security model
+  (below). It is no longer "read-only, stdio-only" once Milestone A3 ships;
+  README and docs must be updated at that point.
+- Roadmap Phases 4–5 (`docs/ROADMAP.md`) are effectively reframed by the
+  milestones below; 5.2 Automation Hooks is absorbed into A2.
+
+---
+
+## Architecture
+
+### Control channel
+
+The MCP server is a standalone stdio process; live sessions exist in the
+running App. The design is a **local IPC control endpoint hosted by the App,
+proxied by the MCP server**:
+
+```
+agent (Claude Code / Codex / …)
+   │  stdio MCP
+   ▼
+NovaTerminal.McpServer  ── local IPC (named pipe / unix socket) ──▶  NovaTerminal.App
+                                                                    (session registry,
+                                                                     buffer snapshots,
+                                                                     PTY status, input)
+```
+
+- The stdio MCP server remains the single public surface; the IPC contract is
+  internal and versioned.
+- The App endpoint is loopback-only, per-user, and off by default
+  (`Settings → Agent Access`).
+- Buffer reads go through the existing snapshot boundary — the same
+  deterministic serializer the replay/parity tests use. No new read path.
+
+### Module placement (respects enforced invariants)
+
+- Session-control contracts (DTOs, IPC protocol) live in a new leaf library
+  (working name `NovaTerminal.AgentHost.Contracts`) referenced by both App
+  and McpServer. `VT` stays a leaf; `Pty` still never sees VT types — status
+  events surface via the existing App orchestration layer.
+- No production assembly references test libraries; architecture tests gain
+  assertions for the new edges before the first merge.
+
+### Permission model
+
+| Capability | Default | Gate |
+|---|---|---|
+| list sessions, read screen/scrollback, session status | off | user enables Agent Access (observe) |
+| notifications (completion / stall) | off | same toggle |
+| send input, spawn/close sessions & panes | off | separate explicit opt-in, per-profile allowlist for SSH |
+| replay export | off | observe permission + explicit export action |
+
+Every acting tool call is journaled to a visible activity log in the UI.
+Nothing is silent — same principle as the credential-consent rules.
+
+---
+
+## Roadmap
+
+Each milestone is independently shippable and announceable. Estimates assume
+~5–15 hrs/week.
+
+### A1 — Observe (first public demo)
+
+**Deliverables**
+- [ ] App-side IPC endpoint + session registry exposure
+- [ ] MCP tools: `novaterminal.list_sessions`, `novaterminal.read_screen`
+      (visible grid + cursor), `novaterminal.read_scrollback` (ranged)
+- [ ] `Agent Access (observe)` settings toggle, off by default
+- [ ] Docs + demo recording: Claude Code reading a live `htop`/`vim` session
+
+**Acceptance criteria**
+- Screen reads are snapshots from the deterministic serializer; a replay of
+  the same byte stream yields an identical `read_screen` result (parity test)
+- Zero behavior change when the toggle is off (architecture + integration test)
+
+### A2 — Status & notifications
+
+**Deliverables**
+- [ ] Session status model: `running` / `awaiting-input` / `idle` / `exited`
+      (PTY-derived, not scrape-based; exit status + foreground process where
+      the OS allows)
+- [ ] MCP tools: `novaterminal.get_session_status`, long-poll or subscription
+      for completion/stall events
+- [ ] OS notification integration for long-running command completion
+      (absorbs ROADMAP 5.2)
+
+**Acceptance criteria**
+- Status transitions covered by replay-driven tests (recorded fixtures per
+  state)
+- Stall detection has an explicit, documented definition (no output for N s
+  while `running`) — no heuristics that can't be tested
+
+### A3 — Act (permissioned)
+
+**Deliverables**
+- [ ] MCP tools: `novaterminal.send_input`, `novaterminal.spawn_session`
+      (local profile or SSH profile by name), `novaterminal.close_session`
+- [ ] Separate opt-in + per-profile SSH allowlist + UI activity journal
+- [ ] Threat-model doc for the acting surface
+
+**Acceptance criteria**
+- Acting tools hard-fail when only observe permission is granted (tested)
+- Input injection is byte-faithful and replay-recorded like any PTY input
+
+### A4 — Replay for agents (the moat)
+
+**Deliverables**
+- [ ] `novaterminal.export_replay` for a session/time range
+- [ ] CLI: `nova replay <file>` headless render-to-text/PNG for CI and
+      agent-run postmortems
+- [ ] Docs: "Debug what your agent did, frame by frame"
+
+**Acceptance criteria**
+- Exported replays round-trip through the existing replay runner with
+  byte-identical buffer snapshots on all three OSes
+
+### Parallel track — Distribution
+
+- [ ] Homebrew cask/formula (macOS, Linux)
+- [ ] winget manifest (Windows)
+- [ ] Flatpak (Linux)
+- [ ] Each A-milestone announcement links a one-command install
+
+---
+
+## Non-goals
+
+- Embedded chat UI, model API keys, or any model-vendor dependency
+- Agent orchestration UI (fleets, worktree-per-task) — v1 hosts sessions;
+  orchestrators like cmux can build *on* the MCP surface
+- Remote (network-exposed) control endpoint
+- Weakening any existing invariant: determinism, parity, replayability, and
+  the zero-flicker rule gate this work exactly as they gate everything else
+
+## Final rule (unchanged)
+
+> **If it is not testable, it is not shippable.**
+
+Agent-facing reads and events are only trustworthy because they are built on
+the deterministic core — that is the product.

--- a/docs/plans/2026-07-07-agent-host-a1-observe-design.md
+++ b/docs/plans/2026-07-07-agent-host-a1-observe-design.md
@@ -1,0 +1,213 @@
+# Agent Host A1 (Observe) Design
+
+Milestone **A1** of `docs/agent-host/DIRECTION.md`: agents can list live
+terminal sessions and read their screen/scrollback through the MCP server.
+Observe-only, off by default.
+
+## Goal
+
+Expose three session-facing MCP tools backed by the running app:
+
+- `novaterminal.list_sessions`
+- `novaterminal.read_screen`
+- `novaterminal.read_scrollback`
+
+The change must:
+
+- reuse the deterministic snapshot path (`BufferSnapshot`), not invent a new
+  read path
+- be a strict no-op when the `Agent Access (observe)` setting is off
+- add no new dependencies to `NovaTerminal.VT` (leaf) and none from
+  `NovaTerminal.Pty` to `NovaTerminal.VT`
+- keep the stdio MCP server as the only agent-facing surface
+
+## Current State
+
+- `src/NovaTerminal.McpServer` is a standalone stdio process
+  (`Program.cs`: `Host.CreateApplicationBuilder` → `AddMcpServer()`
+  `.WithStdioServerTransport().WithToolsFromAssembly()`, singleton
+  `RepoContext`). It is repo-facing only; it has no connection to a running
+  app.
+- There is **no IPC of any kind** in `src/` today (no named pipes, unix
+  sockets, or single-instance activation). The control channel is new code.
+- The live session registry is **MainWindow-local**: `_tabIds`,
+  `_activePaneByTab`, `_paneOwnerTab`, `_layoutModelByTab` dictionaries in
+  `src/NovaTerminal.App/MainWindow.axaml.cs`. `TerminalPane`
+  (`Controls/TerminalPane.axaml.cs`) owns `PaneId: Guid` and its
+  `ITerminalSession`. There is no service-level registry to query.
+- Deterministic snapshots exist:
+  `NovaTerminal.Replay.BufferSnapshot.Capture(TerminalBuffer, bool includeAttributes)`
+  (`src/NovaTerminal.Replay/Replay/BufferSnapshot.cs`) produces `Lines` +
+  optional `AttributeLines`; `ReplaySnapshot`
+  (`src/NovaTerminal.VT/ReplayModels.cs`) is the lower-level parity format.
+- Buffer reads are guarded by `TerminalBuffer.Lock`
+  (`ReaderWriterLockSlim`, `NoRecursion`) with
+  `EnterReadLockIfNeeded`/`ExitReadLockIfNeeded` helpers
+  (`TerminalBuffer.ThreadingAndInvalidation.cs`).
+- Settings: `TerminalSettings` (`src/NovaTerminal.App/Shell/TerminalSettings.cs`)
+  already models opt-in experimental flags (`ExperimentalNativeSshEnabled`,
+  `CommandAssistEnabled` default-false) with JSON persistence via
+  `AppJsonContext`.
+
+## Recommended Approach
+
+Three additive pieces:
+
+1. **`NovaTerminal.AgentHost.Contracts`** — new leaf class library: request/
+   response DTOs and the wire protocol version. Referenced by both App and
+   McpServer. Zero project references (enforced).
+2. **App-side endpoint** — an `AgentHostService` in `NovaTerminal.App` that
+   (a) holds a thread-safe session registry populated by existing pane
+   lifecycle code, and (b) when the observe setting is on, listens on a
+   per-user local endpoint and answers contracts requests using
+   `BufferSnapshot.Capture` under the buffer read lock.
+3. **McpServer client + tools** — a lazy IPC client and a new
+   `SessionTools` class exposing the three MCP tools, with a clear error
+   string when the app isn't running or Agent Access is off.
+
+## Alternatives Considered
+
+### 1. App hosts the MCP endpoint directly
+
+Pros: no proxy hop, one process.
+Cons: two MCP surfaces to document (repo-facing stdio + app endpoint);
+agents must discover a socket instead of launching a stdio server (worse
+client compatibility today); harder to keep the public surface stable while
+the IPC contract iterates. **Rejected for A1**; can be revisited once the
+contract is stable.
+
+### 2. Read state out-of-band (replay files / shared memory)
+
+Pros: no live endpoint in the app.
+Cons: stale by construction, no session listing, and it turns the replay
+format into an unversioned IPC contract. Rejected.
+
+### 3. Screen-scraping via OS accessibility APIs (what tmux-layer tools do)
+
+Rejected outright — the entire value proposition is structured, correct,
+deterministic reads from the buffer itself.
+
+## Architecture
+
+```
+agent ── stdio MCP ──▶ NovaTerminal.McpServer
+                          │  AgentHostClient (Contracts DTOs, JSON frames)
+                          ▼
+              per-user local endpoint (named pipe / unix socket)
+                          ▼
+                    NovaTerminal.App
+                    AgentHostService ── registry ◀─ TerminalPane lifecycle
+                          │
+                    BufferSnapshot.Capture(buffer)  [under buffer.Lock read]
+```
+
+### Contracts (`src/NovaTerminal.AgentHost.Contracts`)
+
+- `ProtocolVersion` (int, starts at 1; server rejects unknown majors)
+- `SessionInfo { Guid PaneId, Guid TabId, string Title, string ProfileName,
+  string Kind /* local | ssh */, int Rows, int Cols, bool IsActive }`
+- `ScreenSnapshotDto { string[] Lines, string[]? AttributeLines,
+  int CursorRow, int CursorCol, bool CursorVisible, int Rows, int Cols }`
+  — a 1:1 projection of `BufferSnapshot` output plus cursor state
+- `ScrollbackRequest { Guid PaneId, int StartLine, int MaxLines }` (ranged;
+  server caps `MaxLines`, e.g. 2000/request)
+- Wire format: newline-delimited JSON frames
+  `{ "v": 1, "id": n, "method": "...", "params": {...} }` /
+  `{ "v": 1, "id": n, "result": {...} | "error": {...} }`. Deliberately not
+  MCP or JSON-RPC-the-library — small, versioned, source-generated JSON
+  (AOT-safe, matching the app's `JsonSerializerContext` usage).
+
+### App side (`NovaTerminal.App`)
+
+- `AgentHost/AgentSessionRegistry` — `ConcurrentDictionary<Guid, ...>` of
+  pane registrations `{ PaneId, TabId, title accessor, TerminalBuffer,
+  profile metadata }`. `MainWindow`/`TerminalPane` register on pane
+  creation and unregister on close — the only touch points in existing code,
+  mirroring how `_paneOwnerTab` is maintained today.
+- `AgentHost/AgentHostService` — background listener started only when
+  `TerminalSettings.AgentAccessObserveEnabled` is true (new bool, default
+  `false`, same pattern as `ExperimentalNativeSshEnabled`; added to the
+  McpServer `SettingsTools` known-key lists). Toggling the setting starts/
+  stops the listener without restart.
+- Endpoint: `NamedPipeServerStream` on Windows
+  (`novaterminal-agent-<user-sid>`, `CurrentUserOnly`);
+  `UnixDomainSocketEndPoint` on Linux/macOS at
+  `<AppPaths runtime dir>/agent.sock`, `0600`, unlinked on exit. An
+  `agent-endpoint.json` discovery file next to `settings.json` records
+  `{ version, endpoint, pid }`; first app instance wins, stale files (dead
+  pid) are replaced.
+- Reads: resolve pane → `EnterReadLockIfNeeded(buffer.Lock)` →
+  `BufferSnapshot.Capture(buffer, includeAttributes)` + cursor via existing
+  accessors → release. Never blocks on the UI thread; requests are served on
+  a worker with a per-request timeout so a wedged client cannot hold the
+  read lock indefinitely (read is taken only for the capture itself).
+
+### McpServer side
+
+- `AgentHostClient` (singleton, DI alongside `RepoContext`): reads the
+  discovery file, connects lazily per request batch, reconnects on failure.
+- `Tools/SessionTools.cs`:
+  - `novaterminal.list_sessions` — table of `SessionInfo`
+  - `novaterminal.read_screen` — visible grid as text, cursor position,
+    optional attributes (`includeAttributes` param)
+  - `novaterminal.read_scrollback` — ranged, capped
+- Unavailability is a *normal result*, not an exception: a fixed message
+  explaining that NovaTerminal isn't running or `Agent Access (observe)` is
+  disabled, and where to enable it. Repo-facing tools are unaffected.
+
+### Settings UI
+
+One switch in `SettingsWindow`: **Agent Access — allow AI agents to read
+terminal sessions (observe only)**, with sub-text noting that screen content
+may include sensitive output and that acting permissions do not exist yet.
+
+## Security Notes
+
+- Endpoint is per-user and local-only: pipe ACL `CurrentUserOnly` /
+  socket file mode `0600`. No TCP listener anywhere.
+- Observe-only by design: the protocol has no input/spawn methods in v1, so
+  a compromised client gains nothing beyond reads (A3 adds acting behind a
+  separate opt-in and its own threat-model doc).
+- Screen reads can contain secrets the user has on screen; this is why the
+  toggle is off by default and clearly worded. No content filtering is
+  attempted (out of scope, documented).
+
+## Testing
+
+- **Parity (the headline invariant):** replay a recorded fixture through the
+  core runner and through a live headless session; `read_screen` over IPC
+  must equal `BufferSnapshot.Capture` of the replayed buffer byte-for-byte,
+  on all three OSes. Add to the replay lane.
+- **Off-is-off:** with `AgentAccessObserveEnabled=false` (default), no
+  listener socket/pipe exists (probe fails) and no discovery file is
+  written; MCP tools return the unavailable message. Headless integration
+  test.
+- **Architecture:** new `LayeringTests` fact — `AgentHost.Contracts` has no
+  dependency on App/VT/Avalonia; new `ProjectFileLayeringTests` fact — its
+  csproj has zero `ProjectReference`s; existing invariants (VT leaf, Pty ¬→
+  VT, no prod → test refs) must stay green.
+- **Concurrency:** stress test — continuous `read_screen` while a replay
+  floods the buffer with output; no deadlock (NoRecursion lock policy),
+  no torn snapshots (each capture is internally consistent), renderer
+  metrics lane stays within its ceilings.
+- **Protocol:** version-mismatch and malformed-frame rejection unit tests in
+  a new `tests/NovaTerminal.AgentHost.Contracts.Tests` or folded into
+  `McpServer.Tests`.
+
+## Out of Scope (later milestones)
+
+- Session status model and notifications (A2)
+- `send_input` / `spawn_session` / permissions beyond the observe toggle (A3)
+- Replay export tools (A4)
+- Multiple concurrent app instances beyond first-wins discovery
+
+## Suggested PR Slicing
+
+1. Contracts library + architecture-test assertions (no behavior)
+2. `AgentSessionRegistry` + pane lifecycle registration (no endpoint yet;
+   covered by unit tests)
+3. `AgentHostService` endpoint + settings flag + settings UI
+4. McpServer `AgentHostClient` + `SessionTools` + docs
+   (`README`, `docs/agent-host/`), demo recording
+
+Each step keeps CI green and is independently revertable.

--- a/src/NovaTerminal.AgentHost.Contracts/AgentHostJsonContext.cs
+++ b/src/NovaTerminal.AgentHost.Contracts/AgentHostJsonContext.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Serialization;
+
+namespace NovaTerminal.AgentHost.Contracts;
+
+/// <summary>
+/// Source-generated JSON context for every wire type on the control channel.
+/// Both ends (app endpoint, MCP-server client) must serialize exclusively
+/// through this context: it is reflection-free (Native AOT safe, matching the
+/// release bundles) and keeps the wire shape identical on both sides.
+/// </summary>
+[JsonSourceGenerationOptions(
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = false)]
+[JsonSerializable(typeof(AgentHostRequest))]
+[JsonSerializable(typeof(AgentHostResponse))]
+[JsonSerializable(typeof(AgentHostError))]
+[JsonSerializable(typeof(EndpointDescriptor))]
+[JsonSerializable(typeof(SessionInfo))]
+[JsonSerializable(typeof(ListSessionsResult))]
+[JsonSerializable(typeof(ReadScreenParams))]
+[JsonSerializable(typeof(ScreenSnapshotDto))]
+[JsonSerializable(typeof(ReadScrollbackParams))]
+[JsonSerializable(typeof(ReadScrollbackResult))]
+public sealed partial class AgentHostJsonContext : JsonSerializerContext
+{
+}

--- a/src/NovaTerminal.AgentHost.Contracts/AgentHostProtocol.cs
+++ b/src/NovaTerminal.AgentHost.Contracts/AgentHostProtocol.cs
@@ -1,0 +1,52 @@
+namespace NovaTerminal.AgentHost.Contracts;
+
+/// <summary>
+/// Protocol constants for the agent-host control channel between the running
+/// app (endpoint) and the MCP server (client). See
+/// docs/plans/2026-07-07-agent-host-a1-observe-design.md.
+///
+/// Wire format: newline-delimited JSON frames (<see cref="AgentHostRequest"/> /
+/// <see cref="AgentHostResponse"/>), UTF-8, one frame per line. The transport
+/// is a per-user local endpoint: a named pipe on Windows
+/// (<see cref="WindowsPipeNamePrefix"/> + user SID, CurrentUserOnly), a unix
+/// domain socket (mode 0600) on Linux/macOS. The endpoint is discovered via
+/// <see cref="DiscoveryFileName"/> next to settings.json.
+/// </summary>
+public static class AgentHostProtocol
+{
+    /// <summary>
+    /// Wire protocol version. The server rejects requests whose version does
+    /// not match with <see cref="ErrorCodes.VersionMismatch"/>.
+    /// </summary>
+    public const int Version = 1;
+
+    /// <summary>Discovery file written next to settings.json while the endpoint is up.</summary>
+    public const string DiscoveryFileName = "agent-endpoint.json";
+
+    /// <summary>Windows named-pipe name prefix; the user SID is appended.</summary>
+    public const string WindowsPipeNamePrefix = "novaterminal-agent-";
+
+    /// <summary>Unix domain socket file name (created in the app's runtime directory).</summary>
+    public const string UnixSocketFileName = "agent.sock";
+
+    /// <summary>Server-side cap on scrollback lines returned per request.</summary>
+    public const int MaxScrollbackLinesPerRequest = 2000;
+
+    /// <summary>Method names for A1 (observe-only). Later milestones append; they never repurpose.</summary>
+    public static class Methods
+    {
+        public const string ListSessions = "listSessions";
+        public const string ReadScreen = "readScreen";
+        public const string ReadScrollback = "readScrollback";
+    }
+
+    /// <summary>Stable machine-readable error codes carried in <see cref="AgentHostError.Code"/>.</summary>
+    public static class ErrorCodes
+    {
+        public const string VersionMismatch = "versionMismatch";
+        public const string MalformedRequest = "malformedRequest";
+        public const string UnknownMethod = "unknownMethod";
+        public const string SessionNotFound = "sessionNotFound";
+        public const string Internal = "internal";
+    }
+}

--- a/src/NovaTerminal.AgentHost.Contracts/Frames.cs
+++ b/src/NovaTerminal.AgentHost.Contracts/Frames.cs
@@ -1,0 +1,74 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NovaTerminal.AgentHost.Contracts;
+
+/// <summary>
+/// A single request frame on the control channel. <see cref="Params"/> is a
+/// raw JSON element so the frame envelope stays method-agnostic and
+/// source-generator friendly (no polymorphic serialization); the server
+/// deserializes it into the per-method params type after dispatching on
+/// <see cref="Method"/>.
+/// </summary>
+public sealed record AgentHostRequest
+{
+    [JsonPropertyName("v")]
+    public required int Version { get; init; }
+
+    [JsonPropertyName("id")]
+    public required long Id { get; init; }
+
+    [JsonPropertyName("method")]
+    public required string Method { get; init; }
+
+    [JsonPropertyName("params")]
+    public JsonElement? Params { get; init; }
+}
+
+/// <summary>
+/// A single response frame. Exactly one of <see cref="Result"/> or
+/// <see cref="Error"/> is set. "App not running" is not representable here by
+/// design — that condition surfaces client-side as a failed connection.
+/// </summary>
+public sealed record AgentHostResponse
+{
+    [JsonPropertyName("v")]
+    public required int Version { get; init; }
+
+    [JsonPropertyName("id")]
+    public required long Id { get; init; }
+
+    [JsonPropertyName("result")]
+    public JsonElement? Result { get; init; }
+
+    [JsonPropertyName("error")]
+    public AgentHostError? Error { get; init; }
+}
+
+/// <summary>Error payload; <see cref="Code"/> is one of <see cref="AgentHostProtocol.ErrorCodes"/>.</summary>
+public sealed record AgentHostError
+{
+    [JsonPropertyName("code")]
+    public required string Code { get; init; }
+
+    [JsonPropertyName("message")]
+    public required string Message { get; init; }
+}
+
+/// <summary>
+/// Content of the <see cref="AgentHostProtocol.DiscoveryFileName"/> file the
+/// app writes next to settings.json while the endpoint is listening. A stale
+/// file (dead <see cref="Pid"/>) is replaced by the next app instance.
+/// </summary>
+public sealed record EndpointDescriptor
+{
+    [JsonPropertyName("version")]
+    public required int Version { get; init; }
+
+    /// <summary>Pipe name (Windows) or absolute socket path (Linux/macOS).</summary>
+    [JsonPropertyName("endpoint")]
+    public required string Endpoint { get; init; }
+
+    [JsonPropertyName("pid")]
+    public required int Pid { get; init; }
+}

--- a/src/NovaTerminal.AgentHost.Contracts/NovaTerminal.AgentHost.Contracts.csproj
+++ b/src/NovaTerminal.AgentHost.Contracts/NovaTerminal.AgentHost.Contracts.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Leaf contracts library for the agent-host control channel
+    (docs/agent-host/DIRECTION.md, milestone A1). Shared by NovaTerminal.App
+    (endpoint) and NovaTerminal.McpServer (client). Must have zero project
+    references; enforced by NovaTerminal.Architecture.Tests.
+  -->
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="NovaTerminal.McpServer.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/NovaTerminal.AgentHost.Contracts/SessionContracts.cs
+++ b/src/NovaTerminal.AgentHost.Contracts/SessionContracts.cs
@@ -8,8 +8,14 @@ public sealed record SessionInfo
     [JsonPropertyName("paneId")]
     public required Guid PaneId { get; init; }
 
+    /// <summary>
+    /// Owning tab, or null when the pane has not yet been associated with a
+    /// tab (association happens lazily in the UI layer; freshly created split
+    /// or replacement panes may briefly be unassociated). Clients must treat
+    /// null as "unknown", never as an identity.
+    /// </summary>
     [JsonPropertyName("tabId")]
-    public required Guid TabId { get; init; }
+    public required Guid? TabId { get; init; }
 
     [JsonPropertyName("title")]
     public required string Title { get; init; }

--- a/src/NovaTerminal.AgentHost.Contracts/SessionContracts.cs
+++ b/src/NovaTerminal.AgentHost.Contracts/SessionContracts.cs
@@ -1,0 +1,118 @@
+using System.Text.Json.Serialization;
+
+namespace NovaTerminal.AgentHost.Contracts;
+
+/// <summary>One live terminal session (pane) as reported by <c>listSessions</c>.</summary>
+public sealed record SessionInfo
+{
+    [JsonPropertyName("paneId")]
+    public required Guid PaneId { get; init; }
+
+    [JsonPropertyName("tabId")]
+    public required Guid TabId { get; init; }
+
+    [JsonPropertyName("title")]
+    public required string Title { get; init; }
+
+    [JsonPropertyName("profileName")]
+    public required string ProfileName { get; init; }
+
+    /// <summary>"local" or "ssh".</summary>
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("rows")]
+    public required int Rows { get; init; }
+
+    [JsonPropertyName("cols")]
+    public required int Cols { get; init; }
+
+    /// <summary>True for the active pane of the active tab.</summary>
+    [JsonPropertyName("isActive")]
+    public required bool IsActive { get; init; }
+}
+
+/// <summary>Result payload for <c>listSessions</c>.</summary>
+public sealed record ListSessionsResult
+{
+    [JsonPropertyName("sessions")]
+    public required SessionInfo[] Sessions { get; init; }
+}
+
+/// <summary>Params for <c>readScreen</c>.</summary>
+public sealed record ReadScreenParams
+{
+    [JsonPropertyName("paneId")]
+    public required Guid PaneId { get; init; }
+
+    /// <summary>When true, per-row attribute lines are included (BufferSnapshot format).</summary>
+    [JsonPropertyName("includeAttributes")]
+    public bool IncludeAttributes { get; init; }
+}
+
+/// <summary>
+/// Result payload for <c>readScreen</c>: a 1:1 projection of the deterministic
+/// <c>NovaTerminal.Replay.BufferSnapshot</c> capture plus cursor state. The A1
+/// parity test asserts this equals a direct <c>BufferSnapshot.Capture</c> of
+/// the same buffer.
+/// </summary>
+public sealed record ScreenSnapshotDto
+{
+    /// <summary>Visible viewport, one string per row, top to bottom.</summary>
+    [JsonPropertyName("lines")]
+    public required string[] Lines { get; init; }
+
+    /// <summary>Per-row attribute encoding; present only when requested.</summary>
+    [JsonPropertyName("attributeLines")]
+    public string[]? AttributeLines { get; init; }
+
+    /// <summary>Cursor row in viewport coordinates (0-based).</summary>
+    [JsonPropertyName("cursorRow")]
+    public required int CursorRow { get; init; }
+
+    /// <summary>Cursor column (0-based).</summary>
+    [JsonPropertyName("cursorCol")]
+    public required int CursorCol { get; init; }
+
+    [JsonPropertyName("cursorVisible")]
+    public required bool CursorVisible { get; init; }
+
+    [JsonPropertyName("rows")]
+    public required int Rows { get; init; }
+
+    [JsonPropertyName("cols")]
+    public required int Cols { get; init; }
+}
+
+/// <summary>Params for <c>readScrollback</c> (ranged read, oldest line = 0).</summary>
+public sealed record ReadScrollbackParams
+{
+    [JsonPropertyName("paneId")]
+    public required Guid PaneId { get; init; }
+
+    /// <summary>First scrollback line to return (0-based, oldest first).</summary>
+    [JsonPropertyName("startLine")]
+    public required int StartLine { get; init; }
+
+    /// <summary>
+    /// Maximum lines to return; the server additionally caps this at
+    /// <see cref="AgentHostProtocol.MaxScrollbackLinesPerRequest"/>.
+    /// </summary>
+    [JsonPropertyName("maxLines")]
+    public required int MaxLines { get; init; }
+}
+
+/// <summary>Result payload for <c>readScrollback</c>.</summary>
+public sealed record ReadScrollbackResult
+{
+    [JsonPropertyName("lines")]
+    public required string[] Lines { get; init; }
+
+    /// <summary>Echo of the effective start line after clamping.</summary>
+    [JsonPropertyName("startLine")]
+    public required int StartLine { get; init; }
+
+    /// <summary>Total scrollback lines available at capture time.</summary>
+    [JsonPropertyName("totalLines")]
+    public required int TotalLines { get; init; }
+}

--- a/src/NovaTerminal.App/AgentHost/AgentSessionRegistration.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentSessionRegistration.cs
@@ -6,33 +6,93 @@ namespace NovaTerminal.AgentHost
     /// <summary>
     /// One live pane's entry in <see cref="AgentSessionRegistry"/>.
     ///
-    /// Everything that can change over a pane's lifetime (title, profile,
-    /// active state) is captured as a provider delegate rather than a value,
-    /// so the registry never holds stale copies and never needs update calls
-    /// from the pane. Providers are invoked on whatever thread queries the
-    /// registry and must therefore be cheap and non-throwing for a live pane.
+    /// Holds a lock-protected snapshot of the pane's metadata instead of live
+    /// delegates into the control: the registry is queried from a background
+    /// IPC thread (milestone A1/PR3), and Avalonia controls must not be read
+    /// off the UI thread. The pane pushes updates on the UI thread
+    /// (TerminalPane.UpdateAgentSessionSnapshot) whenever title, working
+    /// directory, profile, or active state changes; readers on any thread get
+    /// a consistent, tear-free view. Guid/bool fields are also read under the
+    /// gate because Guid reads are not atomic.
     /// </summary>
     public sealed class AgentSessionRegistration
     {
-        /// <summary>Stable pane identity; re-keyed via <see cref="AgentSessionRegistry.Rekey"/> on session restore.</summary>
-        public required Guid PaneId { get; set; }
+        private readonly object _gate = new();
+        private Guid _paneId;
+        private Guid? _tabId;
+        private string _title;
+        private string _profileName;
+        private string _kind;
+        private bool _isActive;
 
-        /// <summary>Owning tab; associated lazily by MainWindow via <see cref="AgentSessionRegistry.SetTabAssociation"/>.</summary>
-        public Guid TabId { get; internal set; }
+        public AgentSessionRegistration(
+            Guid paneId,
+            TerminalBuffer buffer,
+            string title,
+            string profileName,
+            string kind,
+            bool isActive)
+        {
+            ArgumentNullException.ThrowIfNull(buffer);
+            _paneId = paneId;
+            Buffer = buffer;
+            _title = title;
+            _profileName = profileName;
+            _kind = kind;
+            _isActive = isActive;
+        }
 
         /// <summary>The pane's VT buffer. Reads must take <see cref="TerminalBuffer.Lock"/> (endpoint milestone A1/PR3).</summary>
-        public required TerminalBuffer Buffer { get; init; }
+        public TerminalBuffer Buffer { get; }
 
-        /// <summary>Current display title (OSC title, or profile + cwd fallback).</summary>
-        public required Func<string> TitleProvider { get; init; }
+        /// <summary>Stable pane identity; re-keyed via <see cref="AgentSessionRegistry.Rekey"/> on session restore.</summary>
+        public Guid PaneId
+        {
+            get { lock (_gate) { return _paneId; } }
+            internal set { lock (_gate) { _paneId = value; } }
+        }
 
-        /// <summary>Current profile name ("Terminal" when the pane has no profile).</summary>
-        public required Func<string> ProfileNameProvider { get; init; }
+        /// <summary>Owning tab; null until MainWindow associates the pane via <see cref="AgentSessionRegistry.SetTabAssociation"/>.</summary>
+        public Guid? TabId
+        {
+            get { lock (_gate) { return _tabId; } }
+            internal set { lock (_gate) { _tabId = value; } }
+        }
+
+        /// <summary>Current display title (OSC title, or profile + cwd fallback) at the last snapshot push.</summary>
+        public string Title
+        {
+            get { lock (_gate) { return _title; } }
+        }
+
+        /// <summary>Current profile name ("Terminal" when the pane has no profile) at the last snapshot push.</summary>
+        public string ProfileName
+        {
+            get { lock (_gate) { return _profileName; } }
+        }
 
         /// <summary>"ssh" or "local".</summary>
-        public required Func<string> KindProvider { get; init; }
+        public string Kind
+        {
+            get { lock (_gate) { return _kind; } }
+        }
 
-        /// <summary>True when this pane is the active pane of its tab.</summary>
-        public required Func<bool> IsActiveProvider { get; init; }
+        /// <summary>True when this pane was the active pane of its tab at the last snapshot push.</summary>
+        public bool IsActive
+        {
+            get { lock (_gate) { return _isActive; } }
+        }
+
+        /// <summary>Atomically replaces the pane-owned metadata. Called on the UI thread by the pane.</summary>
+        public void UpdateSnapshot(string title, string profileName, string kind, bool isActive)
+        {
+            lock (_gate)
+            {
+                _title = title;
+                _profileName = profileName;
+                _kind = kind;
+                _isActive = isActive;
+            }
+        }
     }
 }

--- a/src/NovaTerminal.App/AgentHost/AgentSessionRegistration.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentSessionRegistration.cs
@@ -1,0 +1,38 @@
+using System;
+using NovaTerminal.VT;
+
+namespace NovaTerminal.AgentHost
+{
+    /// <summary>
+    /// One live pane's entry in <see cref="AgentSessionRegistry"/>.
+    ///
+    /// Everything that can change over a pane's lifetime (title, profile,
+    /// active state) is captured as a provider delegate rather than a value,
+    /// so the registry never holds stale copies and never needs update calls
+    /// from the pane. Providers are invoked on whatever thread queries the
+    /// registry and must therefore be cheap and non-throwing for a live pane.
+    /// </summary>
+    public sealed class AgentSessionRegistration
+    {
+        /// <summary>Stable pane identity; re-keyed via <see cref="AgentSessionRegistry.Rekey"/> on session restore.</summary>
+        public required Guid PaneId { get; set; }
+
+        /// <summary>Owning tab; associated lazily by MainWindow via <see cref="AgentSessionRegistry.SetTabAssociation"/>.</summary>
+        public Guid TabId { get; internal set; }
+
+        /// <summary>The pane's VT buffer. Reads must take <see cref="TerminalBuffer.Lock"/> (endpoint milestone A1/PR3).</summary>
+        public required TerminalBuffer Buffer { get; init; }
+
+        /// <summary>Current display title (OSC title, or profile + cwd fallback).</summary>
+        public required Func<string> TitleProvider { get; init; }
+
+        /// <summary>Current profile name ("Terminal" when the pane has no profile).</summary>
+        public required Func<string> ProfileNameProvider { get; init; }
+
+        /// <summary>"ssh" or "local".</summary>
+        public required Func<string> KindProvider { get; init; }
+
+        /// <summary>True when this pane is the active pane of its tab.</summary>
+        public required Func<bool> IsActiveProvider { get; init; }
+    }
+}

--- a/src/NovaTerminal.App/AgentHost/AgentSessionRegistry.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentSessionRegistry.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using NovaTerminal.AgentHost.Contracts;
+
+namespace NovaTerminal.AgentHost
+{
+    /// <summary>
+    /// Thread-safe registry of live terminal sessions for the agent-host
+    /// control channel (docs/agent-host/DIRECTION.md, milestone A1; design in
+    /// docs/plans/2026-07-07-agent-host-a1-observe-design.md).
+    ///
+    /// PR2 scope: pure bookkeeping. Panes register in <c>SetupCommon</c> and
+    /// unregister in <c>DetachFromUiThread</c>; MainWindow associates tabs
+    /// where it maintains <c>_paneOwnerTab</c>. The registry has no behavior
+    /// until the IPC endpoint (PR3) queries it, and it never keeps a pane
+    /// alive: entries are removed on dispose, not finalization.
+    /// </summary>
+    public sealed class AgentSessionRegistry
+    {
+        /// <summary>Process-wide instance used by the app wiring. Tests construct their own.</summary>
+        public static AgentSessionRegistry Instance { get; } = new();
+
+        private readonly ConcurrentDictionary<Guid, AgentSessionRegistration> _sessions = new();
+
+        public int Count => _sessions.Count;
+
+        /// <summary>Adds a registration. Returns false (and keeps the existing entry) on a duplicate PaneId.</summary>
+        public bool Register(AgentSessionRegistration registration)
+        {
+            ArgumentNullException.ThrowIfNull(registration);
+            return _sessions.TryAdd(registration.PaneId, registration);
+        }
+
+        /// <summary>Removes a registration; false when the pane was never registered (or already removed).</summary>
+        public bool Unregister(Guid paneId) => _sessions.TryRemove(paneId, out _);
+
+        public bool TryGet(Guid paneId, out AgentSessionRegistration registration)
+        {
+            var found = _sessions.TryGetValue(paneId, out var value);
+            registration = value!;
+            return found;
+        }
+
+        /// <summary>
+        /// Moves a registration to a new pane id. Session restore assigns a
+        /// persisted PaneId after construction (SessionManager.RestorePaneTree),
+        /// i.e. after the pane has already registered; the PaneId setter calls
+        /// this so the registry key always matches the pane. No-op when the old
+        /// id is unknown; false when the new id is already taken.
+        /// </summary>
+        public bool Rekey(Guid oldPaneId, Guid newPaneId)
+        {
+            if (oldPaneId == newPaneId) return true;
+            if (!_sessions.TryRemove(oldPaneId, out var registration)) return false;
+
+            registration.PaneId = newPaneId;
+            if (_sessions.TryAdd(newPaneId, registration)) return true;
+
+            // New id collided (should not happen — PaneIds are GUIDs). Restore the old entry.
+            registration.PaneId = oldPaneId;
+            _sessions.TryAdd(oldPaneId, registration);
+            return false;
+        }
+
+        /// <summary>Associates a pane with its owning tab. No-op for unknown panes.</summary>
+        public bool SetTabAssociation(Guid paneId, Guid tabId)
+        {
+            if (!_sessions.TryGetValue(paneId, out var registration)) return false;
+            registration.TabId = tabId;
+            return true;
+        }
+
+        /// <summary>
+        /// Point-in-time snapshot as wire DTOs, ordered by PaneId for a
+        /// deterministic listing. Rows/Cols are read from the live buffer;
+        /// they are informational here — actual screen reads (PR3) go through
+        /// the deterministic snapshot path under the buffer lock.
+        /// </summary>
+        public SessionInfo[] ListSessions()
+        {
+            return _sessions.Values
+                .Select(r => new SessionInfo
+                {
+                    PaneId = r.PaneId,
+                    TabId = r.TabId,
+                    Title = r.TitleProvider(),
+                    ProfileName = r.ProfileNameProvider(),
+                    Kind = r.KindProvider(),
+                    Rows = r.Buffer.Rows,
+                    Cols = r.Buffer.Cols,
+                    IsActive = r.IsActiveProvider(),
+                })
+                .OrderBy(s => s.PaneId)
+                .ToArray();
+        }
+    }
+}

--- a/src/NovaTerminal.App/AgentHost/AgentSessionRegistry.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentSessionRegistry.cs
@@ -46,13 +46,18 @@ namespace NovaTerminal.AgentHost
         /// Moves a registration to a new pane id. Session restore assigns a
         /// persisted PaneId after construction (SessionManager.RestorePaneTree),
         /// i.e. after the pane has already registered; the PaneId setter calls
-        /// this so the registry key always matches the pane. No-op when the old
-        /// id is unknown; false when the new id is already taken.
+        /// this so the registry key always matches the pane.
+        ///
+        /// Returns true when the pane is addressable under <paramref name="newPaneId"/>
+        /// afterwards — including the "nothing was registered" case, which is
+        /// not a desync. Returns false only when the entry remains keyed under
+        /// <paramref name="oldPaneId"/> (new id collision, reverted); the caller
+        /// must then keep using the old id.
         /// </summary>
         public bool Rekey(Guid oldPaneId, Guid newPaneId)
         {
             if (oldPaneId == newPaneId) return true;
-            if (!_sessions.TryRemove(oldPaneId, out var registration)) return false;
+            if (!_sessions.TryRemove(oldPaneId, out var registration)) return true;
 
             registration.PaneId = newPaneId;
             if (_sessions.TryAdd(newPaneId, registration)) return true;
@@ -73,9 +78,12 @@ namespace NovaTerminal.AgentHost
 
         /// <summary>
         /// Point-in-time snapshot as wire DTOs, ordered by PaneId for a
-        /// deterministic listing. Rows/Cols are read from the live buffer;
-        /// they are informational here — actual screen reads (PR3) go through
-        /// the deterministic snapshot path under the buffer lock.
+        /// deterministic listing. Safe to call from any thread: metadata comes
+        /// from the registration's lock-protected snapshot (pushed by the pane
+        /// on the UI thread), never from the Avalonia control. Rows/Cols are
+        /// informational int reads from the live buffer — actual screen reads
+        /// (PR3) go through the deterministic snapshot path under the buffer
+        /// lock.
         /// </summary>
         public SessionInfo[] ListSessions()
         {
@@ -84,12 +92,12 @@ namespace NovaTerminal.AgentHost
                 {
                     PaneId = r.PaneId,
                     TabId = r.TabId,
-                    Title = r.TitleProvider(),
-                    ProfileName = r.ProfileNameProvider(),
-                    Kind = r.KindProvider(),
+                    Title = r.Title,
+                    ProfileName = r.ProfileName,
+                    Kind = r.Kind,
                     Rows = r.Buffer.Rows,
                     Cols = r.Buffer.Cols,
-                    IsActive = r.IsActiveProvider(),
+                    IsActive = r.IsActive,
                 })
                 .OrderBy(s => s.PaneId)
                 .ToArray();

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -85,6 +85,8 @@ namespace NovaTerminal.Controls
         /// (SessionManager.RestorePaneTree), i.e. after this pane already
         /// registered with the agent-session registry — so the setter re-keys
         /// the registry entry to keep it addressable under the current id.
+        /// If re-keying fails (the entry stayed under the old id), the pane
+        /// keeps the old id too: pane and registry must never disagree.
         /// </remarks>
         public Guid PaneId
         {
@@ -93,8 +95,10 @@ namespace NovaTerminal.Controls
             {
                 if (_paneId == value) return;
                 var oldId = _paneId;
-                _paneId = value;
-                NovaTerminal.AgentHost.AgentSessionRegistry.Instance.Rekey(oldId, value);
+                if (NovaTerminal.AgentHost.AgentSessionRegistry.Instance.Rekey(oldId, value))
+                {
+                    _paneId = value;
+                }
             }
         }
 
@@ -113,6 +117,7 @@ namespace NovaTerminal.Controls
         private TerminalSettings? _settings;
         private bool _isUpdatingScroll = false;
         private bool _disposed;
+        private NovaTerminal.AgentHost.AgentSessionRegistration? _agentRegistration;
         private Action<int, int>? _onTermViewResize;
         private Action<float, float>? _onTermViewMetricsChanged;
         private DispatcherTimer? _statusTimer;
@@ -170,8 +175,24 @@ namespace NovaTerminal.Controls
                 {
                     _isActivePane = value;
                     UpdateFocusVisuals(IsKeyboardFocusWithin);
+                    UpdateAgentSessionSnapshot();
                 }
             }
+        }
+
+        /// <summary>
+        /// Pushes this pane's current metadata into its agent-session
+        /// registration (UI thread only). Cheap and allocation-light; called
+        /// on title/cwd/profile/active-state changes so background registry
+        /// readers never touch this control.
+        /// </summary>
+        private void UpdateAgentSessionSnapshot()
+        {
+            _agentRegistration?.UpdateSnapshot(
+                GetBaseTabTitle(),
+                Profile?.Name ?? "Terminal",
+                Profile?.Type == ConnectionType.SSH ? "ssh" : "local",
+                IsActivePane);
         }
 
         public string GetBaseTabTitle()
@@ -268,6 +289,7 @@ namespace NovaTerminal.Controls
         public void UpdateProfile(TerminalProfile profile)
         {
             Profile = profile;
+            UpdateAgentSessionSnapshot();
             TermView.ShellOverride = profile.ShellOverride;
             UpdateCommandAssistContext();
             UpdateRemoteFilesSidebarHostIdentity();
@@ -366,19 +388,20 @@ namespace NovaTerminal.Controls
         private void SetupCommon(TerminalSettings? initialSettings)
         {
             // Agent-host observe surface (docs/agent-host/DIRECTION.md, A1):
-            // inert bookkeeping until the IPC endpoint queries it. Providers
-            // keep the entry live across profile/title changes; the entry is
-            // removed in DetachFromUiThread.
-            NovaTerminal.AgentHost.AgentSessionRegistry.Instance.Register(
-                new NovaTerminal.AgentHost.AgentSessionRegistration
-                {
-                    PaneId = PaneId,
-                    Buffer = Buffer!,
-                    TitleProvider = GetBaseTabTitle,
-                    ProfileNameProvider = () => Profile?.Name ?? "Terminal",
-                    KindProvider = () => Profile?.Type == ConnectionType.SSH ? "ssh" : "local",
-                    IsActiveProvider = () => IsActivePane,
-                });
+            // inert bookkeeping until the IPC endpoint queries it. The
+            // registration holds a lock-protected metadata snapshot (never a
+            // live delegate into this control), pushed from the UI thread on
+            // every relevant change; the entry is removed in DetachFromUiThread.
+            _agentRegistration = new NovaTerminal.AgentHost.AgentSessionRegistration(
+                PaneId,
+                Buffer!,
+                GetBaseTabTitle(),
+                Profile?.Name ?? "Terminal",
+                Profile?.Type == ConnectionType.SSH ? "ssh" : "local",
+                IsActivePane);
+            NovaTerminal.AgentHost.AgentSessionRegistry.Instance.Register(_agentRegistration);
+            TitleChanged += (_, _) => UpdateAgentSessionSnapshot();
+            WorkingDirectoryChanged += (_, _) => UpdateAgentSessionSnapshot();
 
             TermView.KeyDownInterceptor = TryHandleCommandAssistKey;
             TermView.TextInput += (_, e) =>

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -78,7 +78,25 @@ namespace NovaTerminal.Controls
         public string ShellCommand { get; private set; } = string.Empty;
         public string ShellArgs { get; private set; } = string.Empty;
         public TerminalProfile? Profile { get; private set; }
-        public Guid PaneId { get; set; } = Guid.NewGuid();
+        private Guid _paneId = Guid.NewGuid();
+
+        /// <remarks>
+        /// Session restore assigns a persisted id after construction
+        /// (SessionManager.RestorePaneTree), i.e. after this pane already
+        /// registered with the agent-session registry — so the setter re-keys
+        /// the registry entry to keep it addressable under the current id.
+        /// </remarks>
+        public Guid PaneId
+        {
+            get => _paneId;
+            set
+            {
+                if (_paneId == value) return;
+                var oldId = _paneId;
+                _paneId = value;
+                NovaTerminal.AgentHost.AgentSessionRegistry.Instance.Rekey(oldId, value);
+            }
+        }
 
         public event Action<TerminalPane, SidebarTransferRequest>? RequestRemoteFilesSidebarTransfer;
         public event Action<bool>? RecordingStateChanged;
@@ -347,6 +365,21 @@ namespace NovaTerminal.Controls
 
         private void SetupCommon(TerminalSettings? initialSettings)
         {
+            // Agent-host observe surface (docs/agent-host/DIRECTION.md, A1):
+            // inert bookkeeping until the IPC endpoint queries it. Providers
+            // keep the entry live across profile/title changes; the entry is
+            // removed in DetachFromUiThread.
+            NovaTerminal.AgentHost.AgentSessionRegistry.Instance.Register(
+                new NovaTerminal.AgentHost.AgentSessionRegistration
+                {
+                    PaneId = PaneId,
+                    Buffer = Buffer!,
+                    TitleProvider = GetBaseTabTitle,
+                    ProfileNameProvider = () => Profile?.Name ?? "Terminal",
+                    KindProvider = () => Profile?.Type == ConnectionType.SSH ? "ssh" : "local",
+                    IsActiveProvider = () => IsActivePane,
+                });
+
             TermView.KeyDownInterceptor = TryHandleCommandAssistKey;
             TermView.TextInput += (_, e) =>
             {
@@ -2219,6 +2252,8 @@ namespace NovaTerminal.Controls
 
             if (_disposed) return null;
             _disposed = true;
+
+            NovaTerminal.AgentHost.AgentSessionRegistry.Instance.Unregister(PaneId);
 
             CloseRemoteFilesSidebar();
 

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -3556,6 +3556,7 @@ namespace NovaTerminal
             if (TryGetSelectedTab(out var selectedTab))
             {
                 _activePaneByTab[selectedTab] = replacementPane;
+                AgentHost.AgentSessionRegistry.Instance.SetTabAssociation(replacementPane.PaneId, GetPersistentTabId(selectedTab));
                 if (FindTabHeaderTextBlock(selectedTab.Header) is TextBlock tabHeader)
                 {
                     tabHeader.Text = resolvedProfile.Name;
@@ -3830,6 +3831,10 @@ namespace NovaTerminal
 
             newPane.ApplySettings(_settings);
             WirePane(newPane);
+            if (TryGetSelectedTab(out var splitOwnerTab))
+            {
+                AgentHost.AgentSessionRegistry.Instance.SetTabAssociation(newPane.PaneId, GetPersistentTabId(splitOwnerTab));
+            }
             newPane.MinWidth = Math.Max(newPane.MinWidth, minPaneWidth);
             newPane.MinHeight = Math.Max(newPane.MinHeight, minPaneHeight);
             originalPane.MinWidth = Math.Max(originalPane.MinWidth, minPaneWidth);

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -3680,6 +3680,7 @@ namespace NovaTerminal
             _currentPane = pane;
             _activePaneByTab[tabItem] = pane;
             _paneOwnerTab[pane] = tabItem;
+            AgentHost.AgentSessionRegistry.Instance.SetTabAssociation(pane.PaneId, GetPersistentTabId(tabItem));
 
             // Defer visual update until layout is complete (ensures template is applied)
             EventHandler? layoutHandler = null;
@@ -5235,6 +5236,7 @@ namespace NovaTerminal
             if (control is TerminalPane pane)
             {
                 _paneOwnerTab[pane] = tabItem;
+                AgentHost.AgentSessionRegistry.Instance.SetTabAssociation(pane.PaneId, GetPersistentTabId(tabItem));
                 return;
             }
 
@@ -5271,6 +5273,7 @@ namespace NovaTerminal
             if (visualTab != null)
             {
                 _paneOwnerTab[pane] = visualTab;
+                AgentHost.AgentSessionRegistry.Instance.SetTabAssociation(pane.PaneId, GetPersistentTabId(visualTab));
                 return visualTab;
             }
 

--- a/src/NovaTerminal.App/NovaTerminal.App.csproj
+++ b/src/NovaTerminal.App/NovaTerminal.App.csproj
@@ -240,6 +240,7 @@
     <ProjectReference Include="..\NovaTerminal.Rendering\NovaTerminal.Rendering.csproj" />
     <ProjectReference Include="..\NovaTerminal.Pty\NovaTerminal.Pty.csproj" />
     <ProjectReference Include="..\NovaTerminal.Replay\NovaTerminal.Replay.csproj" />
+    <ProjectReference Include="..\NovaTerminal.AgentHost.Contracts\NovaTerminal.AgentHost.Contracts.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentSessionRegistryTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentSessionRegistryTests.cs
@@ -21,15 +21,13 @@ public class AgentSessionRegistryTests
         string kind = "local",
         bool isActive = false)
     {
-        return new AgentSessionRegistration
-        {
-            PaneId = paneId ?? Guid.NewGuid(),
-            Buffer = buffer ?? new TerminalBuffer(80, 24),
-            TitleProvider = () => title,
-            ProfileNameProvider = () => profileName,
-            KindProvider = () => kind,
-            IsActiveProvider = () => isActive,
-        };
+        return new AgentSessionRegistration(
+            paneId ?? Guid.NewGuid(),
+            buffer ?? new TerminalBuffer(80, 24),
+            title,
+            profileName,
+            kind,
+            isActive);
     }
 
     [Fact]
@@ -48,6 +46,7 @@ public class AgentSessionRegistryTests
         Assert.Equal(30, session.Rows);
         Assert.Equal(120, session.Cols);
         Assert.True(session.IsActive);
+        Assert.Null(session.TabId); // not yet associated — null, never Guid.Empty
     }
 
     [Fact]
@@ -75,24 +74,14 @@ public class AgentSessionRegistryTests
     }
 
     [Fact]
-    public void Providers_are_read_live_not_captured_at_registration()
+    public void UpdateSnapshot_changes_are_visible_in_the_next_listing()
     {
         var registry = new AgentSessionRegistry();
         var id = Guid.NewGuid();
-        var title = "before";
-        var active = false;
-        registry.Register(new AgentSessionRegistration
-        {
-            PaneId = id,
-            Buffer = new TerminalBuffer(80, 24),
-            TitleProvider = () => title,
-            ProfileNameProvider = () => "Profile",
-            KindProvider = () => "local",
-            IsActiveProvider = () => active,
-        });
+        var registration = MakeRegistration(id, title: "before", isActive: false);
+        registry.Register(registration);
 
-        title = "after";
-        active = true;
+        registration.UpdateSnapshot("after", "Profile", "local", isActive: true);
 
         var session = registry.ListSessions().Single();
         Assert.Equal("after", session.Title);
@@ -118,11 +107,29 @@ public class AgentSessionRegistryTests
     }
 
     [Fact]
-    public void Rekey_of_unknown_id_is_a_noop()
+    public void Rekey_of_unregistered_pane_succeeds_without_creating_an_entry()
+    {
+        // "Nothing registered" is not a desync: the caller may safely adopt
+        // the new id. False is reserved for the entry remaining under the old id.
+        var registry = new AgentSessionRegistry();
+        Assert.True(registry.Rekey(Guid.NewGuid(), Guid.NewGuid()));
+        Assert.Equal(0, registry.Count);
+    }
+
+    [Fact]
+    public void Rekey_collision_keeps_the_entry_under_the_old_id_and_reports_failure()
     {
         var registry = new AgentSessionRegistry();
-        Assert.False(registry.Rekey(Guid.NewGuid(), Guid.NewGuid()));
-        Assert.Equal(0, registry.Count);
+        var oldId = Guid.NewGuid();
+        var takenId = Guid.NewGuid();
+        registry.Register(MakeRegistration(oldId, title: "mover"));
+        registry.Register(MakeRegistration(takenId, title: "occupant"));
+
+        Assert.False(registry.Rekey(oldId, takenId));
+
+        Assert.True(registry.TryGet(oldId, out var mover));
+        Assert.Equal(oldId, mover.PaneId);
+        Assert.Equal("occupant", registry.ListSessions().Single(s => s.PaneId == takenId).Title);
     }
 
     [Fact]

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentSessionRegistryTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentSessionRegistryTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Linq;
+using NovaTerminal.AgentHost;
+using NovaTerminal.VT;
+
+namespace NovaTerminal.AppTests.AgentHost;
+
+/// <summary>
+/// Pure unit tests for the agent-session registry (PR2 of milestone A1,
+/// docs/plans/2026-07-07-agent-host-a1-observe-design.md). No Avalonia
+/// involvement: registrations are built directly against a TerminalBuffer,
+/// exactly as TerminalPane.SetupCommon does.
+/// </summary>
+public class AgentSessionRegistryTests
+{
+    private static AgentSessionRegistration MakeRegistration(
+        Guid? paneId = null,
+        TerminalBuffer? buffer = null,
+        string title = "title",
+        string profileName = "Profile",
+        string kind = "local",
+        bool isActive = false)
+    {
+        return new AgentSessionRegistration
+        {
+            PaneId = paneId ?? Guid.NewGuid(),
+            Buffer = buffer ?? new TerminalBuffer(80, 24),
+            TitleProvider = () => title,
+            ProfileNameProvider = () => profileName,
+            KindProvider = () => kind,
+            IsActiveProvider = () => isActive,
+        };
+    }
+
+    [Fact]
+    public void Register_then_list_exposes_the_session()
+    {
+        var registry = new AgentSessionRegistry();
+        var id = Guid.NewGuid();
+        Assert.True(registry.Register(MakeRegistration(id, new TerminalBuffer(120, 30), title: "vim", kind: "ssh", isActive: true)));
+
+        var sessions = registry.ListSessions();
+
+        var session = Assert.Single(sessions);
+        Assert.Equal(id, session.PaneId);
+        Assert.Equal("vim", session.Title);
+        Assert.Equal("ssh", session.Kind);
+        Assert.Equal(30, session.Rows);
+        Assert.Equal(120, session.Cols);
+        Assert.True(session.IsActive);
+    }
+
+    [Fact]
+    public void Duplicate_pane_id_is_rejected_and_original_kept()
+    {
+        var registry = new AgentSessionRegistry();
+        var id = Guid.NewGuid();
+        Assert.True(registry.Register(MakeRegistration(id, title: "first")));
+        Assert.False(registry.Register(MakeRegistration(id, title: "second")));
+
+        Assert.Equal(1, registry.Count);
+        Assert.Equal("first", registry.ListSessions().Single().Title);
+    }
+
+    [Fact]
+    public void Unregister_removes_the_session_and_is_idempotent()
+    {
+        var registry = new AgentSessionRegistry();
+        var id = Guid.NewGuid();
+        registry.Register(MakeRegistration(id));
+
+        Assert.True(registry.Unregister(id));
+        Assert.False(registry.Unregister(id));
+        Assert.Empty(registry.ListSessions());
+    }
+
+    [Fact]
+    public void Providers_are_read_live_not_captured_at_registration()
+    {
+        var registry = new AgentSessionRegistry();
+        var id = Guid.NewGuid();
+        var title = "before";
+        var active = false;
+        registry.Register(new AgentSessionRegistration
+        {
+            PaneId = id,
+            Buffer = new TerminalBuffer(80, 24),
+            TitleProvider = () => title,
+            ProfileNameProvider = () => "Profile",
+            KindProvider = () => "local",
+            IsActiveProvider = () => active,
+        });
+
+        title = "after";
+        active = true;
+
+        var session = registry.ListSessions().Single();
+        Assert.Equal("after", session.Title);
+        Assert.True(session.IsActive);
+    }
+
+    [Fact]
+    public void Rekey_moves_the_registration_to_the_new_id()
+    {
+        // Session restore assigns persisted PaneIds after construction; the
+        // TerminalPane.PaneId setter re-keys so the entry stays addressable.
+        var registry = new AgentSessionRegistry();
+        var oldId = Guid.NewGuid();
+        var newId = Guid.NewGuid();
+        registry.Register(MakeRegistration(oldId));
+
+        Assert.True(registry.Rekey(oldId, newId));
+
+        Assert.False(registry.TryGet(oldId, out _));
+        Assert.True(registry.TryGet(newId, out var registration));
+        Assert.Equal(newId, registration.PaneId);
+        Assert.Equal(newId, registry.ListSessions().Single().PaneId);
+    }
+
+    [Fact]
+    public void Rekey_of_unknown_id_is_a_noop()
+    {
+        var registry = new AgentSessionRegistry();
+        Assert.False(registry.Rekey(Guid.NewGuid(), Guid.NewGuid()));
+        Assert.Equal(0, registry.Count);
+    }
+
+    [Fact]
+    public void SetTabAssociation_updates_known_panes_only()
+    {
+        var registry = new AgentSessionRegistry();
+        var paneId = Guid.NewGuid();
+        var tabId = Guid.NewGuid();
+        registry.Register(MakeRegistration(paneId));
+
+        Assert.True(registry.SetTabAssociation(paneId, tabId));
+        Assert.False(registry.SetTabAssociation(Guid.NewGuid(), tabId));
+
+        Assert.Equal(tabId, registry.ListSessions().Single().TabId);
+    }
+
+    [Fact]
+    public void ListSessions_is_ordered_by_pane_id_for_determinism()
+    {
+        var registry = new AgentSessionRegistry();
+        for (var i = 0; i < 8; i++)
+        {
+            registry.Register(MakeRegistration());
+        }
+
+        var ids = registry.ListSessions().Select(s => s.PaneId).ToArray();
+        Assert.Equal(ids.OrderBy(g => g).ToArray(), ids);
+    }
+}

--- a/tests/NovaTerminal.Architecture.Tests/LayeringTests.cs
+++ b/tests/NovaTerminal.Architecture.Tests/LayeringTests.cs
@@ -10,6 +10,7 @@ public class LayeringTests
     private static Assembly Rendering => typeof(global::NovaTerminal.Rendering.GlyphAtlas).Assembly;
     private static Assembly Pty       => typeof(global::NovaTerminal.Pty.ITerminalSession).Assembly;
     private static Assembly Platform  => typeof(global::NovaTerminal.Platform.Input.TerminalInputSender).Assembly;
+    private static Assembly AgentHostContracts => typeof(global::NovaTerminal.AgentHost.Contracts.AgentHostProtocol).Assembly;
 
     [Fact]
     public void Vt_must_be_a_leaf_assembly()
@@ -78,9 +79,30 @@ public class LayeringTests
     }
 
     [Fact]
+    public void AgentHostContracts_must_be_a_leaf_assembly()
+    {
+        var result = Types.InAssembly(AgentHostContracts)
+            .Should()
+            .NotHaveDependencyOnAny(
+                "NovaTerminal.VT",
+                "NovaTerminal.Replay",
+                "NovaTerminal.Rendering",
+                "NovaTerminal.Pty",
+                "NovaTerminal.Platform",
+                "NovaTerminal.App",
+                "Avalonia",
+                "SkiaSharp")
+            .GetResult();
+
+        Assert.True(result.IsSuccessful,
+            $"AgentHost.Contracts is a shared wire-contract leaf and must not depend on any " +
+            $"production layer. Offenders: {Join(result.FailingTypeNames)}");
+    }
+
+    [Fact]
     public void No_production_assembly_references_test_assemblies()
     {
-        foreach (var asm in new[] { Vt, Replay, Rendering, Pty, Platform })
+        foreach (var asm in new[] { Vt, Replay, Rendering, Pty, Platform, AgentHostContracts })
         {
             var result = Types.InAssembly(asm)
                 .Should()

--- a/tests/NovaTerminal.Architecture.Tests/NamespaceAlignmentTests.cs
+++ b/tests/NovaTerminal.Architecture.Tests/NamespaceAlignmentTests.cs
@@ -17,7 +17,7 @@ public class NamespaceAlignmentTests
     // Leaf assemblies, each owning exactly "NovaTerminal.<Name>.*".
     private static readonly string[] LeafAssemblies =
         { "NovaTerminal.VT", "NovaTerminal.Replay", "NovaTerminal.Rendering",
-          "NovaTerminal.Pty", "NovaTerminal.Platform" };
+          "NovaTerminal.Pty", "NovaTerminal.Platform", "NovaTerminal.AgentHost.Contracts" };
 
     [Theory]
     [InlineData("NovaTerminal.VT")]
@@ -25,6 +25,7 @@ public class NamespaceAlignmentTests
     [InlineData("NovaTerminal.Rendering")]
     [InlineData("NovaTerminal.Pty")]
     [InlineData("NovaTerminal.Platform")]
+    [InlineData("NovaTerminal.AgentHost.Contracts")]
     public void Leaf_assembly_types_reside_in_its_own_namespace(string asmName)
     {
         var result = Types.InAssembly(LoadByName(asmName))

--- a/tests/NovaTerminal.Architecture.Tests/NovaTerminal.Architecture.Tests.csproj
+++ b/tests/NovaTerminal.Architecture.Tests/NovaTerminal.Architecture.Tests.csproj
@@ -24,5 +24,6 @@
     <ProjectReference Include="..\..\src\NovaTerminal.App\NovaTerminal.App.csproj" />
     <ProjectReference Include="..\..\src\NovaTerminal.Cli\NovaTerminal.Cli.csproj" />
     <ProjectReference Include="..\..\src\NovaTerminal.Conformance\NovaTerminal.Conformance.csproj" />
+    <ProjectReference Include="..\..\src\NovaTerminal.AgentHost.Contracts\NovaTerminal.AgentHost.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/NovaTerminal.Architecture.Tests/ProjectFileLayeringTests.cs
+++ b/tests/NovaTerminal.Architecture.Tests/ProjectFileLayeringTests.cs
@@ -67,4 +67,11 @@ public class ProjectFileLayeringTests
         var refs = ProjectReferences("src/NovaTerminal.VT/NovaTerminal.VT.csproj");
         Assert.Empty(refs);
     }
+
+    [Fact]
+    public void AgentHostContracts_csproj_must_have_no_project_references()
+    {
+        var refs = ProjectReferences("src/NovaTerminal.AgentHost.Contracts/NovaTerminal.AgentHost.Contracts.csproj");
+        Assert.Empty(refs);
+    }
 }


### PR DESCRIPTION
## Summary

First two slices of milestone **A1 (Observe)** of the accepted agent-host direction (`docs/agent-host/DIRECTION.md`, design in `docs/plans/2026-07-07-agent-host-a1-observe-design.md`): the wire-contracts leaf library and the app-side live session registry. **No behavior change** — nothing queries the registry until the IPC endpoint lands (PR3), and no endpoint/listener exists in this PR.

## Docs

- `docs/agent-host/DIRECTION.md` — accepted ADR + A1–A4 roadmap ("enable, don't embed")
- `docs/plans/2026-07-07-agent-host-a1-observe-design.md` — A1 design (control channel, permission model, test plan)
- `docs/ROADMAP.md` / `README.md` — cross-links; Ghostty gap program reframed as a regression gate

## PR1 — `NovaTerminal.AgentHost.Contracts` (new leaf library)

- `AgentHostProtocol` — protocol version, method names, error codes, endpoint discovery constants
- `Frames.cs` — versioned request/response/error envelope + `EndpointDescriptor` discovery-file DTO
- `SessionContracts.cs` — `SessionInfo`, `ScreenSnapshotDto` (1:1 projection of `BufferSnapshot` output + cursor), ranged scrollback params/results
- `AgentHostJsonContext` — source-generated System.Text.Json context (reflection-free, Native-AOT-safe)
- New enforced invariants in `NovaTerminal.Architecture.Tests`: leaf at IL level, zero `ProjectReference`s at csproj level, namespace alignment, included in the no-test-refs sweep

## PR2 — `AgentSessionRegistry` (app side)

- `NovaTerminal.AgentHost.AgentSessionRegistry` — thread-safe registry of live panes; providers (title/profile/kind/active) are read live, never cached
- `TerminalPane.SetupCommon` registers; `DetachFromUiThread` unregisters; the `PaneId` setter re-keys the entry because session restore assigns persisted ids after construction
- `MainWindow` associates tabs at the three existing `_paneOwnerTab` assignment sites
- `ListSessions()` returns contracts `SessionInfo[]`, ordered by PaneId for deterministic listings

## Tests

- `NovaTerminal.Architecture.Tests`: 18/18 passing (4 new invariants)
- `NovaTerminal.App.Tests/AgentHost/AgentSessionRegistryTests`: 8/8 passing (register/list, duplicate rejection, idempotent unregister, live providers, rekey, tab association, deterministic ordering) — pure unit tests, no Avalonia

## Next (PR3)

App-side IPC endpoint (`AgentHostService`) behind a new default-off `Agent Access (observe)` setting, then the MCP `SessionTools` (PR4).
