### PR TITLE
feat(agent-host): A1 observe endpoint behind default-off Agent Access setting

### DIFF
--- a/src/NovaTerminal.AgentHost.Contracts/SessionContracts.cs
+++ b/src/NovaTerminal.AgentHost.Contracts/SessionContracts.cs
@@ -12,10 +12,11 @@ public sealed record SessionInfo
     /// Owning tab, or null when the pane has not yet been associated with a
     /// tab (association happens lazily in the UI layer; freshly created split
     /// or replacement panes may briefly be unassociated). Clients must treat
-    /// null as "unknown", never as an identity.
+    /// null as "unknown", never as an identity. Not <c>required</c>: the wire
+    /// format omits the field entirely when null (WhenWritingNull).
     /// </summary>
     [JsonPropertyName("tabId")]
-    public required Guid? TabId { get; init; }
+    public Guid? TabId { get; init; }
 
     [JsonPropertyName("title")]
     public required string Title { get; init; }

--- a/src/NovaTerminal.App/AgentHost/AgentHostService.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentHostService.cs
@@ -1,0 +1,462 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using NovaTerminal.AgentHost.Contracts;
+using NovaTerminal.Replay;
+using NovaTerminal.VT;
+
+namespace NovaTerminal.AgentHost
+{
+    /// <summary>
+    /// Local IPC endpoint for the agent-host observe surface (milestone A1/PR3,
+    /// docs/plans/2026-07-07-agent-host-a1-observe-design.md).
+    ///
+    /// Off by default: nothing listens until <see cref="Apply"/> is called with
+    /// <c>TerminalSettings.AgentAccessObserveEnabled == true</c>. When enabled it
+    /// serves <c>listSessions</c> / <c>readScreen</c> / <c>readScrollback</c> over a
+    /// per-user local endpoint — a named pipe with <see cref="PipeOptions.CurrentUserOnly"/>
+    /// on Windows, a unix domain socket (mode 0600) elsewhere — and writes an
+    /// <see cref="EndpointDescriptor"/> discovery file next to settings.json.
+    ///
+    /// The protocol is observe-only by construction: no input, spawn, or close
+    /// methods exist in v1. Screen reads go through the deterministic
+    /// <see cref="BufferSnapshot"/> path under the buffer's read lock — the same
+    /// snapshot boundary the replay/parity tests use.
+    /// </summary>
+    public sealed class AgentHostService : IDisposable
+    {
+        /// <summary>Process-wide instance used by the app wiring. Tests construct their own.</summary>
+        public static AgentHostService Instance { get; } = new(AgentSessionRegistry.Instance);
+
+        private readonly AgentSessionRegistry _registry;
+        private readonly string? _endpointOverride;
+        private readonly string? _discoveryDirectoryOverride;
+        private readonly object _gate = new();
+
+        private CancellationTokenSource? _cts;
+        private Task? _acceptLoop;
+        private Socket? _unixListener;
+        private string? _unixSocketPath;
+        private string? _discoveryFilePath;
+
+        public AgentHostService(
+            AgentSessionRegistry registry,
+            string? endpointOverride = null,
+            string? discoveryDirectoryOverride = null)
+        {
+            _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+            _endpointOverride = endpointOverride;
+            _discoveryDirectoryOverride = discoveryDirectoryOverride;
+        }
+
+        public bool IsRunning
+        {
+            get { lock (_gate) { return _cts != null; } }
+        }
+
+        /// <summary>The active endpoint (pipe name or socket path), or null when stopped.</summary>
+        public string? EndpointName { get; private set; }
+
+        /// <summary>Starts or stops the endpoint to match the observe setting. Safe to call repeatedly.</summary>
+        public void Apply(bool enabled)
+        {
+            if (enabled) Start(); else Stop();
+        }
+
+        public void Start()
+        {
+            lock (_gate)
+            {
+                if (_cts != null) return;
+
+                var discoveryDir = _discoveryDirectoryOverride ?? NovaTerminal.Shell.AppPaths.RootDirectory;
+                var discoveryPath = Path.Combine(discoveryDir, AgentHostProtocol.DiscoveryFileName);
+
+                // First instance wins: if another live NovaTerminal already
+                // advertises an endpoint, leave it alone.
+                if (TryReadForeignLiveDescriptor(discoveryPath))
+                {
+                    Debug.WriteLine("[AgentHost] Another live instance owns the endpoint; not starting.");
+                    return;
+                }
+
+                var endpoint = _endpointOverride ?? DefaultEndpointName();
+                _cts = new CancellationTokenSource();
+                var token = _cts.Token;
+
+                try
+                {
+                    if (OperatingSystem.IsWindows())
+                    {
+                        _acceptLoop = Task.Run(() => AcceptNamedPipeLoopAsync(endpoint, token), token);
+                    }
+                    else
+                    {
+                        StartUnixListener(endpoint);
+                        _acceptLoop = Task.Run(() => AcceptUnixLoopAsync(token), token);
+                    }
+
+                    Directory.CreateDirectory(discoveryDir);
+                    var descriptor = new EndpointDescriptor
+                    {
+                        Version = AgentHostProtocol.Version,
+                        Endpoint = endpoint,
+                        Pid = Environment.ProcessId,
+                    };
+                    File.WriteAllText(
+                        discoveryPath,
+                        JsonSerializer.Serialize(descriptor, AgentHostJsonContext.Default.EndpointDescriptor));
+                    _discoveryFilePath = discoveryPath;
+                    EndpointName = endpoint;
+                }
+                catch
+                {
+                    StopLocked();
+                    throw;
+                }
+            }
+        }
+
+        public void Stop()
+        {
+            lock (_gate)
+            {
+                StopLocked();
+            }
+        }
+
+        public void Dispose() => Stop();
+
+        private void StopLocked()
+        {
+            _cts?.Cancel();
+            _cts?.Dispose();
+            _cts = null;
+            _acceptLoop = null;
+            EndpointName = null;
+
+            try { _unixListener?.Dispose(); } catch { /* best effort */ }
+            _unixListener = null;
+            if (_unixSocketPath != null)
+            {
+                try { File.Delete(_unixSocketPath); } catch { /* best effort */ }
+                _unixSocketPath = null;
+            }
+
+            if (_discoveryFilePath != null)
+            {
+                try { File.Delete(_discoveryFilePath); } catch { /* best effort */ }
+                _discoveryFilePath = null;
+            }
+        }
+
+        private static string DefaultEndpointName()
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                // CurrentUserOnly enforces the ACL; the user name only namespaces
+                // the pipe so different users on one machine don't collide.
+                var user = new string(Array.FindAll(
+                    Environment.UserName.ToLowerInvariant().ToCharArray(), char.IsLetterOrDigit));
+                return AgentHostProtocol.WindowsPipeNamePrefix + user;
+            }
+
+            return Path.Combine(NovaTerminal.Shell.AppPaths.RootDirectory, AgentHostProtocol.UnixSocketFileName);
+        }
+
+        private static bool TryReadForeignLiveDescriptor(string discoveryPath)
+        {
+            try
+            {
+                if (!File.Exists(discoveryPath)) return false;
+                var descriptor = JsonSerializer.Deserialize(
+                    File.ReadAllText(discoveryPath), AgentHostJsonContext.Default.EndpointDescriptor);
+                if (descriptor == null || descriptor.Pid == Environment.ProcessId) return false;
+
+                var process = Process.GetProcessById(descriptor.Pid);
+                return !process.HasExited;
+            }
+            catch
+            {
+                // Unreadable descriptor or dead pid: stale, safe to replace.
+                return false;
+            }
+        }
+
+        // ── Transport ────────────────────────────────────────────────────────
+
+        private async Task AcceptNamedPipeLoopAsync(string pipeName, CancellationToken token)
+        {
+            while (!token.IsCancellationRequested)
+            {
+                NamedPipeServerStream? server = null;
+                try
+                {
+                    server = new NamedPipeServerStream(
+                        pipeName,
+                        PipeDirection.InOut,
+                        NamedPipeServerStream.MaxAllowedServerInstances,
+                        PipeTransmissionMode.Byte,
+                        PipeOptions.Asynchronous | PipeOptions.CurrentUserOnly);
+                    await server.WaitForConnectionAsync(token).ConfigureAwait(false);
+                    var connected = server;
+                    server = null;
+                    _ = Task.Run(() => HandleClientAsync(connected, token), token);
+                }
+                catch (OperationCanceledException)
+                {
+                    server?.Dispose();
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    server?.Dispose();
+                    if (token.IsCancellationRequested) return;
+                    Debug.WriteLine($"[AgentHost] pipe accept failed: {ex.Message}");
+                    try { await Task.Delay(250, token).ConfigureAwait(false); }
+                    catch (OperationCanceledException) { return; }
+                }
+            }
+        }
+
+        private void StartUnixListener(string socketPath)
+        {
+            try { File.Delete(socketPath); } catch { /* stale socket from a dead instance */ }
+            Directory.CreateDirectory(Path.GetDirectoryName(socketPath)!);
+
+            var listener = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+            listener.Bind(new UnixDomainSocketEndPoint(socketPath));
+            listener.Listen(backlog: 4);
+            if (!OperatingSystem.IsWindows())
+            {
+                File.SetUnixFileMode(socketPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            }
+
+            _unixListener = listener;
+            _unixSocketPath = socketPath;
+        }
+
+        private async Task AcceptUnixLoopAsync(CancellationToken token)
+        {
+            var listener = _unixListener!;
+            while (!token.IsCancellationRequested)
+            {
+                try
+                {
+                    var client = await listener.AcceptAsync(token).ConfigureAwait(false);
+                    var stream = new NetworkStream(client, ownsSocket: true);
+                    _ = Task.Run(() => HandleClientAsync(stream, token), token);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    if (token.IsCancellationRequested) return;
+                    Debug.WriteLine($"[AgentHost] socket accept failed: {ex.Message}");
+                    return; // listener is likely dead; Stop() owns cleanup
+                }
+            }
+        }
+
+        private async Task HandleClientAsync(Stream stream, CancellationToken token)
+        {
+            try
+            {
+                using var _ = stream;
+                using var reader = new StreamReader(stream, new UTF8Encoding(false), leaveOpen: true);
+                using var writer = new StreamWriter(stream, new UTF8Encoding(false), leaveOpen: true) { AutoFlush = true };
+
+                while (!token.IsCancellationRequested)
+                {
+                    var line = await reader.ReadLineAsync(token).ConfigureAwait(false);
+                    if (line == null) return;
+                    if (string.IsNullOrWhiteSpace(line)) continue;
+
+                    var response = HandleRequestLine(line);
+                    await writer.WriteLineAsync(
+                        JsonSerializer.Serialize(response, AgentHostJsonContext.Default.AgentHostResponse))
+                        .ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // shutdown
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[AgentHost] client connection ended: {ex.Message}");
+            }
+        }
+
+        // ── Request handling ─────────────────────────────────────────────────
+
+        internal AgentHostResponse HandleRequestLine(string line)
+        {
+            AgentHostRequest? request;
+            try
+            {
+                request = JsonSerializer.Deserialize(line, AgentHostJsonContext.Default.AgentHostRequest);
+            }
+            catch (JsonException ex)
+            {
+                return Error(0, AgentHostProtocol.ErrorCodes.MalformedRequest, $"Unparseable frame: {ex.Message}");
+            }
+
+            if (request == null)
+            {
+                return Error(0, AgentHostProtocol.ErrorCodes.MalformedRequest, "Empty frame.");
+            }
+
+            if (request.Version != AgentHostProtocol.Version)
+            {
+                return Error(
+                    request.Id,
+                    AgentHostProtocol.ErrorCodes.VersionMismatch,
+                    $"Protocol version {request.Version} is not supported; this endpoint speaks version {AgentHostProtocol.Version}.");
+            }
+
+            try
+            {
+                return request.Method switch
+                {
+                    AgentHostProtocol.Methods.ListSessions => HandleListSessions(request),
+                    AgentHostProtocol.Methods.ReadScreen => HandleReadScreen(request),
+                    AgentHostProtocol.Methods.ReadScrollback => HandleReadScrollback(request),
+                    _ => Error(request.Id, AgentHostProtocol.ErrorCodes.UnknownMethod, $"Unknown method '{request.Method}'."),
+                };
+            }
+            catch (JsonException ex)
+            {
+                return Error(request.Id, AgentHostProtocol.ErrorCodes.MalformedRequest, $"Bad params: {ex.Message}");
+            }
+            catch (Exception ex)
+            {
+                return Error(request.Id, AgentHostProtocol.ErrorCodes.Internal, ex.Message);
+            }
+        }
+
+        private AgentHostResponse HandleListSessions(AgentHostRequest request)
+        {
+            var result = new ListSessionsResult { Sessions = _registry.ListSessions() };
+            return Ok(request.Id, JsonSerializer.SerializeToElement(result, AgentHostJsonContext.Default.ListSessionsResult));
+        }
+
+        private AgentHostResponse HandleReadScreen(AgentHostRequest request)
+        {
+            var p = DeserializeParams(request, AgentHostJsonContext.Default.ReadScreenParams);
+            if (p == null || !_registry.TryGet(p.PaneId, out var registration))
+            {
+                return Error(request.Id, AgentHostProtocol.ErrorCodes.SessionNotFound, $"No live session with paneId '{p?.PaneId}'.");
+            }
+
+            var buffer = registration.Buffer;
+            BufferSnapshot snapshot;
+            bool cursorVisible;
+            int rows, cols;
+            buffer.Lock.EnterReadLock();
+            try
+            {
+                snapshot = BufferSnapshot.Capture(buffer, p.IncludeAttributes);
+                cursorVisible = buffer.IsCursorVisible;
+                rows = buffer.Rows;
+                cols = buffer.Cols;
+            }
+            finally
+            {
+                buffer.Lock.ExitReadLock();
+            }
+
+            var dto = new ScreenSnapshotDto
+            {
+                Lines = snapshot.Lines,
+                AttributeLines = snapshot.AttributeLines,
+                CursorRow = snapshot.CursorRow,
+                CursorCol = snapshot.CursorCol,
+                CursorVisible = cursorVisible,
+                Rows = rows,
+                Cols = cols,
+            };
+            return Ok(request.Id, JsonSerializer.SerializeToElement(dto, AgentHostJsonContext.Default.ScreenSnapshotDto));
+        }
+
+        private AgentHostResponse HandleReadScrollback(AgentHostRequest request)
+        {
+            var p = DeserializeParams(request, AgentHostJsonContext.Default.ReadScrollbackParams);
+            if (p == null || !_registry.TryGet(p.PaneId, out var registration))
+            {
+                return Error(request.Id, AgentHostProtocol.ErrorCodes.SessionNotFound, $"No live session with paneId '{p?.PaneId}'.");
+            }
+
+            var buffer = registration.Buffer;
+            string[] lines;
+            int effectiveStart;
+            int total;
+            buffer.Lock.EnterReadLock();
+            try
+            {
+                total = buffer.Scrollback.Count;
+                effectiveStart = Math.Clamp(p.StartLine, 0, total);
+                var count = Math.Clamp(p.MaxLines, 0, AgentHostProtocol.MaxScrollbackLinesPerRequest);
+                count = Math.Min(count, total - effectiveStart);
+
+                lines = new string[count];
+                for (var i = 0; i < count; i++)
+                {
+                    lines[i] = RenderScrollbackRow(buffer.Scrollback.GetRow(effectiveStart + i));
+                }
+            }
+            finally
+            {
+                buffer.Lock.ExitReadLock();
+            }
+
+            var result = new ReadScrollbackResult
+            {
+                Lines = lines,
+                StartLine = effectiveStart,
+                TotalLines = total,
+            };
+            return Ok(request.Id, JsonSerializer.SerializeToElement(result, AgentHostJsonContext.Default.ReadScrollbackResult));
+        }
+
+        /// <summary>Same text semantics as <see cref="BufferSnapshot.Capture"/>: skip wide continuations, NUL → space, trim right.</summary>
+        private static string RenderScrollbackRow(ReadOnlySpan<TerminalCell> cells)
+        {
+            var sb = new StringBuilder(cells.Length);
+            foreach (ref readonly var cell in cells)
+            {
+                if (cell.IsWideContinuation) continue;
+                sb.Append(cell.Character == '\0' ? ' ' : cell.Character);
+            }
+            return sb.ToString().TrimEnd();
+        }
+
+        private static T? DeserializeParams<T>(AgentHostRequest request, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> typeInfo)
+            where T : class
+        {
+            return request.Params is { } element ? element.Deserialize(typeInfo) : null;
+        }
+
+        private static AgentHostResponse Ok(long id, JsonElement result) => new()
+        {
+            Version = AgentHostProtocol.Version,
+            Id = id,
+            Result = result,
+        };
+
+        private static AgentHostResponse Error(long id, string code, string message) => new()
+        {
+            Version = AgentHostProtocol.Version,
+            Id = id,
+            Error = new AgentHostError { Code = code, Message = message },
+        };
+    }
+}

--- a/src/NovaTerminal.App/AgentHost/AgentHostService.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentHostService.cs
@@ -164,19 +164,50 @@ namespace NovaTerminal.AgentHost
 
             if (_discoveryFilePath != null)
             {
-                // Only remove the discovery file if it is still ours — another
-                // instance may have legitimately taken over the endpoint.
+                ReleaseDiscoveryFile(_discoveryFilePath);
+                _discoveryFilePath = null;
+            }
+        }
+
+        /// <summary>
+        /// Retires our discovery descriptor without racing other instances.
+        /// The pid check and the release happen under one exclusive file handle
+        /// (FileShare.None), so another instance cannot write its descriptor
+        /// between "it's ours" and the clear. We truncate instead of deleting:
+        /// a delete would have to happen after the handle closes, reopening the
+        /// window — while an empty file is already treated as a stale
+        /// descriptor by <see cref="TryReadForeignLiveDescriptor"/> and by
+        /// clients, and is rewritten in place by the next Start().
+        /// </summary>
+        private static void ReleaseDiscoveryFile(string path)
+        {
+            try
+            {
+                using var fs = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+                EndpointDescriptor? descriptor = null;
                 try
                 {
-                    var descriptor = JsonSerializer.Deserialize(
-                        File.ReadAllText(_discoveryFilePath), AgentHostJsonContext.Default.EndpointDescriptor);
-                    if (descriptor == null || descriptor.Pid == Environment.ProcessId)
-                    {
-                        File.Delete(_discoveryFilePath);
-                    }
+                    using var reader = new StreamReader(fs, leaveOpen: true);
+                    descriptor = JsonSerializer.Deserialize(
+                        reader.ReadToEnd(), AgentHostJsonContext.Default.EndpointDescriptor);
                 }
-                catch { /* best effort */ }
-                _discoveryFilePath = null;
+                catch (JsonException)
+                {
+                    // Unreadable == stale == safe to clear.
+                }
+
+                if (descriptor == null || descriptor.Pid == Environment.ProcessId)
+                {
+                    fs.SetLength(0);
+                    fs.Flush();
+                }
+                // else: another instance took over the endpoint — leave its
+                // descriptor untouched.
+            }
+            catch
+            {
+                // Missing file, or a foreign instance holds the lock right now:
+                // either way there is nothing of ours left to clean up.
             }
         }
 

--- a/src/NovaTerminal.App/AgentHost/AgentHostService.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentHostService.cs
@@ -44,6 +44,7 @@ namespace NovaTerminal.AgentHost
         private Socket? _unixListener;
         private string? _unixSocketPath;
         private string? _discoveryFilePath;
+        private readonly System.Collections.Concurrent.ConcurrentDictionary<Stream, byte> _activeClients = new();
 
         public AgentHostService(
             AgentSessionRegistry registry,
@@ -115,10 +116,13 @@ namespace NovaTerminal.AgentHost
                     _discoveryFilePath = discoveryPath;
                     EndpointName = endpoint;
                 }
-                catch
+                catch (Exception ex)
                 {
+                    // The agent host is an optional surface: a failure to bind
+                    // (permissions, stale endpoint, another listener) must never
+                    // take the terminal down. Leave the app fully functional.
                     StopLocked();
-                    throw;
+                    Debug.WriteLine($"[AgentHost] failed to start observe endpoint: {ex.Message}");
                 }
             }
         }
@@ -141,6 +145,15 @@ namespace NovaTerminal.AgentHost
             _acceptLoop = null;
             EndpointName = null;
 
+            // Disabling Agent Access must revoke access *now*: cancelling the
+            // accept loop is not enough, because already-accepted connections
+            // could otherwise keep reading screens on their open stream.
+            foreach (var client in _activeClients.Keys)
+            {
+                try { client.Dispose(); } catch { /* best effort */ }
+            }
+            _activeClients.Clear();
+
             try { _unixListener?.Dispose(); } catch { /* best effort */ }
             _unixListener = null;
             if (_unixSocketPath != null)
@@ -151,7 +164,18 @@ namespace NovaTerminal.AgentHost
 
             if (_discoveryFilePath != null)
             {
-                try { File.Delete(_discoveryFilePath); } catch { /* best effort */ }
+                // Only remove the discovery file if it is still ours — another
+                // instance may have legitimately taken over the endpoint.
+                try
+                {
+                    var descriptor = JsonSerializer.Deserialize(
+                        File.ReadAllText(_discoveryFilePath), AgentHostJsonContext.Default.EndpointDescriptor);
+                    if (descriptor == null || descriptor.Pid == Environment.ProcessId)
+                    {
+                        File.Delete(_discoveryFilePath);
+                    }
+                }
+                catch { /* best effort */ }
                 _discoveryFilePath = null;
             }
         }
@@ -179,8 +203,12 @@ namespace NovaTerminal.AgentHost
                     File.ReadAllText(discoveryPath), AgentHostJsonContext.Default.EndpointDescriptor);
                 if (descriptor == null || descriptor.Pid == Environment.ProcessId) return false;
 
+                // Guard against PID recycling: the pid must be alive AND be a
+                // NovaTerminal process before we defer to it.
                 var process = Process.GetProcessById(descriptor.Pid);
-                return !process.HasExited;
+                using var current = Process.GetCurrentProcess();
+                return !process.HasExited
+                    && string.Equals(process.ProcessName, current.ProcessName, StringComparison.OrdinalIgnoreCase);
             }
             catch
             {
@@ -227,8 +255,18 @@ namespace NovaTerminal.AgentHost
 
         private void StartUnixListener(string socketPath)
         {
-            try { File.Delete(socketPath); } catch { /* stale socket from a dead instance */ }
             Directory.CreateDirectory(Path.GetDirectoryName(socketPath)!);
+
+            // Never unlink a live socket: if a file is present, probe it first.
+            // Only a socket nobody answers on is stale and safe to remove.
+            if (File.Exists(socketPath))
+            {
+                if (IsUnixSocketAlive(socketPath))
+                {
+                    throw new IOException($"Another live agent-host endpoint is listening on '{socketPath}'.");
+                }
+                File.Delete(socketPath);
+            }
 
             var listener = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
             listener.Bind(new UnixDomainSocketEndPoint(socketPath));
@@ -240,6 +278,20 @@ namespace NovaTerminal.AgentHost
 
             _unixListener = listener;
             _unixSocketPath = socketPath;
+        }
+
+        private static bool IsUnixSocketAlive(string socketPath)
+        {
+            try
+            {
+                using var probe = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+                probe.Connect(new UnixDomainSocketEndPoint(socketPath));
+                return true;
+            }
+            catch (SocketException)
+            {
+                return false;
+            }
         }
 
         private async Task AcceptUnixLoopAsync(CancellationToken token)
@@ -257,17 +309,26 @@ namespace NovaTerminal.AgentHost
                 {
                     return;
                 }
+                catch (ObjectDisposedException)
+                {
+                    return; // Stop() disposed the listener
+                }
                 catch (Exception ex)
                 {
+                    // Transient accept failure: log and retry, mirroring the
+                    // named-pipe loop, so the service never ends up half-running
+                    // (IsRunning true with a dead accept loop).
                     if (token.IsCancellationRequested) return;
                     Debug.WriteLine($"[AgentHost] socket accept failed: {ex.Message}");
-                    return; // listener is likely dead; Stop() owns cleanup
+                    try { await Task.Delay(250, token).ConfigureAwait(false); }
+                    catch (OperationCanceledException) { return; }
                 }
             }
         }
 
         private async Task HandleClientAsync(Stream stream, CancellationToken token)
         {
+            _activeClients.TryAdd(stream, 0);
             try
             {
                 using var _ = stream;
@@ -293,6 +354,10 @@ namespace NovaTerminal.AgentHost
             catch (Exception ex)
             {
                 Debug.WriteLine($"[AgentHost] client connection ended: {ex.Message}");
+            }
+            finally
+            {
+                _activeClients.TryRemove(stream, out _);
             }
         }
 
@@ -352,9 +417,13 @@ namespace NovaTerminal.AgentHost
         private AgentHostResponse HandleReadScreen(AgentHostRequest request)
         {
             var p = DeserializeParams(request, AgentHostJsonContext.Default.ReadScreenParams);
-            if (p == null || !_registry.TryGet(p.PaneId, out var registration))
+            if (p == null)
             {
-                return Error(request.Id, AgentHostProtocol.ErrorCodes.SessionNotFound, $"No live session with paneId '{p?.PaneId}'.");
+                return Error(request.Id, AgentHostProtocol.ErrorCodes.MalformedRequest, "readScreen requires params with a paneId.");
+            }
+            if (!_registry.TryGet(p.PaneId, out var registration))
+            {
+                return Error(request.Id, AgentHostProtocol.ErrorCodes.SessionNotFound, $"No live session with paneId '{p.PaneId}'.");
             }
 
             var buffer = registration.Buffer;
@@ -390,9 +459,13 @@ namespace NovaTerminal.AgentHost
         private AgentHostResponse HandleReadScrollback(AgentHostRequest request)
         {
             var p = DeserializeParams(request, AgentHostJsonContext.Default.ReadScrollbackParams);
-            if (p == null || !_registry.TryGet(p.PaneId, out var registration))
+            if (p == null)
             {
-                return Error(request.Id, AgentHostProtocol.ErrorCodes.SessionNotFound, $"No live session with paneId '{p?.PaneId}'.");
+                return Error(request.Id, AgentHostProtocol.ErrorCodes.MalformedRequest, "readScrollback requires params with paneId, startLine, and maxLines.");
+            }
+            if (!_registry.TryGet(p.PaneId, out var registration))
+            {
+                return Error(request.Id, AgentHostProtocol.ErrorCodes.SessionNotFound, $"No live session with paneId '{p.PaneId}'.");
             }
 
             var buffer = registration.Buffer;
@@ -410,7 +483,10 @@ namespace NovaTerminal.AgentHost
                 lines = new string[count];
                 for (var i = 0; i < count; i++)
                 {
-                    lines[i] = RenderScrollbackRow(buffer.Scrollback.GetRow(effectiveStart + i));
+                    var index = effectiveStart + i;
+                    lines[i] = RenderScrollbackRow(
+                        buffer.Scrollback.GetRow(index),
+                        buffer.Scrollback.GetExtendedTextMap(index));
                 }
             }
             finally
@@ -427,14 +503,27 @@ namespace NovaTerminal.AgentHost
             return Ok(request.Id, JsonSerializer.SerializeToElement(result, AgentHostJsonContext.Default.ReadScrollbackResult));
         }
 
-        /// <summary>Same text semantics as <see cref="BufferSnapshot.Capture"/>: skip wide continuations, NUL → space, trim right.</summary>
-        private static string RenderScrollbackRow(ReadOnlySpan<TerminalCell> cells)
+        /// <summary>
+        /// Same text semantics as <see cref="BufferSnapshot.Capture"/>: skip wide
+        /// continuations, prefer the row's extended text (emoji, multi-codepoint
+        /// graphemes), NUL → space, trim right.
+        /// </summary>
+        private static string RenderScrollbackRow(ReadOnlySpan<TerminalCell> cells, NovaTerminal.VT.Storage.SmallMap<string>? extendedText)
         {
             var sb = new StringBuilder(cells.Length);
-            foreach (ref readonly var cell in cells)
+            for (var col = 0; col < cells.Length; col++)
             {
+                ref readonly var cell = ref cells[col];
                 if (cell.IsWideContinuation) continue;
-                sb.Append(cell.Character == '\0' ? ' ' : cell.Character);
+
+                if (extendedText != null && extendedText.TryGet(col, out var ext) && ext != null)
+                {
+                    sb.Append(ext);
+                }
+                else
+                {
+                    sb.Append(cell.Character == '\0' ? ' ' : cell.Character);
+                }
             }
             return sb.ToString().TrimEnd();
         }

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -1951,6 +1951,10 @@ namespace NovaTerminal
             }
             _startup.Checkpoint("MainWindow.AfterLegacyMigration");
 
+            // Agent-host observe endpoint (docs/agent-host/DIRECTION.md, A1):
+            // strictly no-op unless the user opted in via Settings.
+            AgentHost.AgentHostService.Instance.Apply(_settings.AgentAccessObserveEnabled);
+
             // Ensure visual tree is ready for initial tab border
             this.Loaded += (s, e) =>
             {
@@ -4858,6 +4862,8 @@ namespace NovaTerminal
                 ApplyThemeToUI();
                 ApplySettingsToAllTabs();
                 UpdateTransparencyHints();
+                // Live-apply the agent-host observe endpoint (no restart needed).
+                AgentHost.AgentHostService.Instance.Apply(_settings.AgentAccessObserveEnabled);
 
                 // Refresh Connection Manager if open (or just always update it)
                 _connectionManagerControl?.LoadProfiles(_sshConnectionService.GetConnectionProfiles());
@@ -5234,6 +5240,7 @@ namespace NovaTerminal
             }
             _recordingToastTimer.Stop();
             _globalHotkey?.Dispose();
+            AgentHost.AgentHostService.Instance.Stop();
         }
 
         private void RegisterPaneOwners(TabItem tabItem, Control control)

--- a/src/NovaTerminal.App/SettingsWindow.axaml
+++ b/src/NovaTerminal.App/SettingsWindow.axaml
@@ -570,6 +570,15 @@
                                 </StackPanel>
                                 <CheckBox Name="CommandAssistToggle" Grid.Column="1" Classes="Toggle" Content="" HorizontalAlignment="Right" VerticalAlignment="Center"/>
                             </Grid>
+                            <Border BorderBrush="{StaticResource NtHairline}" BorderThickness="0,0,0,1" Margin="0,14,0,14"/>
+
+                            <Grid ColumnDefinitions="*,360">
+                                <StackPanel Grid.Column="0" Spacing="2">
+                                    <TextBlock Classes="RowLabel" Text="Agent access (observe)"/>
+                                    <TextBlock Classes="RowDesc" Text="Allow AI agents on this machine to read terminal sessions (screen and scrollback). Read-only: agents cannot type or open sessions. Screen content may include sensitive output."/>
+                                </StackPanel>
+                                <CheckBox Name="AgentAccessObserveToggle" Grid.Column="1" Classes="Toggle" Content="" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                            </Grid>
                             <Border BorderBrush="{StaticResource NtHairline}" BorderThickness="0,0,0,1" Margin="0,18,0,18"/>
 
                             <!-- ── Scrollback ── -->

--- a/src/NovaTerminal.App/SettingsWindow.axaml.cs
+++ b/src/NovaTerminal.App/SettingsWindow.axaml.cs
@@ -1399,7 +1399,9 @@ namespace NovaTerminal
             var bgStretchList = this.FindControl<ComboBox>("BgImageStretchList");
             var complexShapingToggle = this.FindControl<CheckBox>("ComplexShapingToggle");
             var commandAssistToggle = this.FindControl<CheckBox>("CommandAssistToggle");
+            var agentAccessObserveToggle = this.FindControl<CheckBox>("AgentAccessObserveToggle");
 
+            if (agentAccessObserveToggle != null) agentAccessObserveToggle.IsChecked = _settings.AgentAccessObserveEnabled;
             if (fontSizeInput != null) fontSizeInput.Value = (decimal)_settings.FontSize;
             if (scrollbackInput != null) scrollbackInput.Value = (decimal)_settings.MaxHistory;
             if (opacitySlider != null)
@@ -1628,6 +1630,8 @@ namespace NovaTerminal
             if (ligatureToggle != null) _settings.EnableLigatures = ligatureToggle.IsChecked == true;
             if (complexShapingToggle != null) _settings.EnableComplexShaping = complexShapingToggle.IsChecked == true;
             if (commandAssistToggle != null) _settings.CommandAssistEnabled = commandAssistToggle.IsChecked == true;
+            var agentAccessObserveToggle = this.FindControl<CheckBox>("AgentAccessObserveToggle");
+            if (agentAccessObserveToggle != null) _settings.AgentAccessObserveEnabled = agentAccessObserveToggle.IsChecked == true;
 
             if (fontList?.SelectedItem is ComboBoxItem fontItem)
                 _settings.FontFamily = fontItem.Content?.ToString() ?? BundledFontCatalog.DefaultTerminalFontFamily;

--- a/src/NovaTerminal.App/Shell/TerminalSettings.cs
+++ b/src/NovaTerminal.App/Shell/TerminalSettings.cs
@@ -50,6 +50,11 @@ namespace NovaTerminal.Shell
         public bool CommandAssistShellIntegrationEnabled { get; set; } = true;
         public bool CommandAssistPowerShellIntegrationEnabled { get; set; } = true;
         public bool ExperimentalNativeSshEnabled { get; set; } = false;
+        // Agent-host observe surface (docs/agent-host/DIRECTION.md, milestone A1).
+        // Off by default: when false, no local IPC endpoint exists at all and AI
+        // agents cannot read any terminal session. Observe-only in v1 — there is
+        // no acting capability behind this flag.
+        public bool AgentAccessObserveEnabled { get; set; } = false;
 
         public System.Collections.Generic.List<TerminalProfile> Profiles { get; set; } = new();
         public Guid DefaultProfileId { get; set; }

--- a/src/NovaTerminal.McpServer/Tools/SettingsTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/SettingsTools.cs
@@ -53,6 +53,7 @@ public static class SettingsTools
         | `QuakeModeEnabled` | bool | Default true. |
         | `GlobalHotkey` | string | Default "Alt+OemTilde". |
         | `ExperimentalNativeSshEnabled` | bool | Default false. |
+        | `AgentAccessObserveEnabled` | bool | Default false. Enables the local agent-host observe endpoint (read-only session access for AI agents). |
 
         ## Background
         | Field | Type | Notes |
@@ -115,6 +116,7 @@ public static class SettingsTools
           "CommandAssistShellIntegrationEnabled": true,
           "CommandAssistPowerShellIntegrationEnabled": true,
           "ExperimentalNativeSshEnabled": false,
+          "AgentAccessObserveEnabled": false,
           "Profiles": [
             { "Id": "00000000-0000-0000-0000-000000000001", "Name": "Command Prompt", "Command": "cmd.exe", "Type": 0 }
           ],
@@ -129,7 +131,7 @@ public static class SettingsTools
         "BellVisualEnabled", "SmoothScrolling", "EnableLinkDetection", "QuakeModeEnabled",
         "CommandAssistEnabled", "CommandAssistHistoryEnabled", "CommandAssistAutoHideInAltScreen",
         "CommandAssistShellIntegrationEnabled", "CommandAssistPowerShellIntegrationEnabled",
-        "ExperimentalNativeSshEnabled",
+        "ExperimentalNativeSshEnabled", "AgentAccessObserveEnabled",
     };
 
     // Plain + enum-like strings; enum-like values are NOT value-validated (type-check only).
@@ -152,7 +154,7 @@ public static class SettingsTools
         "QuakeModeEnabled", "GlobalHotkey", "CommandAssistEnabled", "CommandAssistHistoryEnabled",
         "CommandAssistMaxHistoryEntries", "CommandAssistAutoHideInAltScreen",
         "CommandAssistShellIntegrationEnabled", "CommandAssistPowerShellIntegrationEnabled",
-        "ExperimentalNativeSshEnabled", "Profiles", "DefaultProfileId",
+        "ExperimentalNativeSshEnabled", "AgentAccessObserveEnabled", "Profiles", "DefaultProfileId",
     };
 
     [McpServerTool(Name = "novaterminal.validate_settings_json"),

--- a/src/NovaTerminal.VT/Buffer/ScrollbackPages.cs
+++ b/src/NovaTerminal.VT/Buffer/ScrollbackPages.cs
@@ -256,13 +256,36 @@ namespace NovaTerminal.VT.Storage
         /// Used during vertical resize (height grow) to pull history back into the viewport.
         /// </summary>
         public bool TryPopLastRow(Span<TerminalCell> destination)
+            => TryPopLastRow(destination, out _, out _, out _);
+
+        /// <summary>
+        /// As <see cref="TryPopLastRow(Span{TerminalCell})"/>, but also returns
+        /// the row's wrap flag and side tables (extended text, hyperlinks) so a
+        /// restored viewport row is complete — extended graphemes must survive
+        /// the scrollback round trip. The vacated slot's metadata is cleared so
+        /// a later append into it cannot resurrect stale entries.
+        /// </summary>
+        public bool TryPopLastRow(
+            Span<TerminalCell> destination,
+            out bool isWrapped,
+            out SmallMap<string>? extendedText,
+            out SmallMap<string>? hyperlinks)
         {
+            isWrapped = false;
+            extendedText = null;
+            hyperlinks = null;
+
             if (_pages.Last == null || _pages.Last.Value.UsedRows == 0)
                 return false;
 
             var page = _pages.Last.Value;
-            page.GetRowSpanReadOnly(page.UsedRows - 1).CopyTo(destination);
-            
+            int rowIndex = page.UsedRows - 1;
+            page.GetRowSpanReadOnly(rowIndex).CopyTo(destination);
+            isWrapped = page.IsRowWrapped(rowIndex);
+            extendedText = page.GetExtendedTextMap(rowIndex);
+            hyperlinks = page.GetHyperlinkMap(rowIndex);
+            page.ClearRowMetadata(rowIndex);
+
             page.UsedRows--;
             _totalRowsAppended--;
 

--- a/src/NovaTerminal.VT/Buffer/TerminalPage.cs
+++ b/src/NovaTerminal.VT/Buffer/TerminalPage.cs
@@ -202,6 +202,18 @@ namespace NovaTerminal.VT.Storage
             _hyperlinks?[rowIndex];
 
         /// <summary>
+        /// Clears a row's wrap flag and side tables. Must be called when a row
+        /// slot is vacated (pop) so a later append into the same slot cannot
+        /// resurrect stale metadata.
+        /// </summary>
+        public void ClearRowMetadata(int rowIndex)
+        {
+            SetRowWrapped(rowIndex, false);
+            if (_extendedText != null) _extendedText[rowIndex] = null;
+            if (_hyperlinks != null) _hyperlinks[rowIndex] = null;
+        }
+
+        /// <summary>
         /// Updates cells that rely on default foreground or background colors to a new theme.
         /// This is an O(n) operation over all used cells, invoked rarely during a theme change.
         /// </summary>

--- a/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
@@ -597,7 +597,13 @@ namespace NovaTerminal.VT
 
                     for (int i = 0; i < sbCount; i++)
                     {
-                        newScrollback.AppendRow(allFlowedRows[i].Cells, allFlowedRows[i].IsWrapped);
+                        // Carry each reflowed row's side tables into the rebuilt
+                        // scrollback; extended graphemes must survive reflow.
+                        newScrollback.AppendRow(
+                            allFlowedRows[i].Cells,
+                            allFlowedRows[i].IsWrapped,
+                            allFlowedRows[i].GetExtendedTextMap(),
+                            allFlowedRows[i].GetHyperlinkMap());
                     }
                     
                     int discardedRows = (int)newScrollback.TotalRowsEvicted;

--- a/src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs
@@ -99,7 +99,15 @@ namespace NovaTerminal.VT
 
                             for (int i = 0; i < diff; i++)
                             {
-                                _scrollback.AppendRow(_viewport[i].Cells);
+                                // Preserve wrap flag and side tables (extended text,
+                                // hyperlinks), matching the WritePath eviction; dropping
+                                // them corrupted emoji/multi-codepoint graphemes once a
+                                // resize pushed rows into scrollback.
+                                _scrollback.AppendRow(
+                                    _viewport[i].Cells,
+                                    _viewport[i].IsWrapped,
+                                    _viewport[i].GetExtendedTextMap(),
+                                    _viewport[i].GetHyperlinkMap());
                             }
 
                             var newVp = new TerminalRow[newRows];
@@ -293,7 +301,13 @@ namespace NovaTerminal.VT
 
                 for (int i = 0; i < linesToPush; i++)
                 {
-                    _scrollback.AppendRow(_viewport[i].Cells);
+                    // Same as the height-shrink redistribution path: keep wrap
+                    // flag and side tables so extended graphemes survive.
+                    _scrollback.AppendRow(
+                        _viewport[i].Cells,
+                        _viewport[i].IsWrapped,
+                        _viewport[i].GetExtendedTextMap(),
+                        _viewport[i].GetHyperlinkMap());
                 }
 
                 Array.Copy(_viewport, linesToPush, newViewport, 0, newRows);

--- a/src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs
@@ -271,8 +271,13 @@ namespace NovaTerminal.VT
                 for (int i = linesNeeded - 1; i >= 0; i--)
                 {
                     var row = new TerminalRow(Cols, Theme.Foreground, Theme.Background);
-                    if (_scrollback.TryPopLastRow(row.Cells))
+                    if (_scrollback.TryPopLastRow(row.Cells, out var isWrapped, out var extendedText, out var hyperlinks))
                     {
+                        // Restore the full row, not just cells: wrap flag and side
+                        // tables (extended text, hyperlinks) must survive the
+                        // shrink-then-grow round trip through scrollback.
+                        row.IsWrapped = isWrapped;
+                        row.RestoreSideTables(extendedText, hyperlinks);
                         newViewport[i] = row;
                         pulled++;
                     }

--- a/src/NovaTerminal.VT/TerminalRow.cs
+++ b/src/NovaTerminal.VT/TerminalRow.cs
@@ -77,6 +77,18 @@ namespace NovaTerminal.VT
         /// </summary>
         public Storage.SmallMap<string>? GetHyperlinkMap() => _hyperlinks;
 
+        /// <summary>
+        /// Installs side tables wholesale. Counterpart of the Get*Map accessors:
+        /// used when a row is restored from paged scrollback (height grow) so
+        /// extended graphemes and hyperlinks survive the round trip. The row
+        /// takes ownership of the maps.
+        /// </summary>
+        public void RestoreSideTables(Storage.SmallMap<string>? extendedText, Storage.SmallMap<string>? hyperlinks)
+        {
+            _extendedText = extendedText is { Count: > 0 } ? extendedText : null;
+            _hyperlinks = hyperlinks is { Count: > 0 } ? hyperlinks : null;
+        }
+
         public TerminalRow(int cols)
         {
             Id = System.Threading.Interlocked.Increment(ref _nextId);

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentHostServiceTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentHostServiceTests.cs
@@ -102,6 +102,40 @@ public class AgentHostServiceTests : IDisposable
     }
 
     [Fact]
+    public void Missing_params_is_a_malformed_request_not_a_missing_session()
+    {
+        using var service = NewService(new AgentSessionRegistry());
+        var readScreen = service.HandleRequestLine(RequestLine(AgentHostProtocol.Methods.ReadScreen));
+        var readScrollback = service.HandleRequestLine(RequestLine(AgentHostProtocol.Methods.ReadScrollback));
+        Assert.Equal(AgentHostProtocol.ErrorCodes.MalformedRequest, readScreen.Error?.Code);
+        Assert.Equal(AgentHostProtocol.ErrorCodes.MalformedRequest, readScrollback.Error?.Code);
+    }
+
+    [Fact]
+    public void ReadScrollback_preserves_extended_text_graphemes()
+    {
+        // Emoji / multi-codepoint graphemes are stored as extended text; they
+        // must survive scrolling off screen (parity with readScreen).
+        var registry = new AgentSessionRegistry();
+        var buffer = new TerminalBuffer(20, 3);
+        var parser = new AnsiParser(buffer);
+        parser.Process("ok \U0001F44D done\r\n");
+        for (var i = 0; i < 6; i++)
+        {
+            parser.Process($"filler-{i}\r\n");
+        }
+        var registration = Register(registry, buffer);
+        using var service = NewService(registry);
+
+        var response = service.HandleRequestLine(RequestLine(
+            AgentHostProtocol.Methods.ReadScrollback,
+            paramsObj: new ReadScrollbackParams { PaneId = registration.PaneId, StartLine = 0, MaxLines = 10 }));
+        var result = ResultOf(response, AgentHostJsonContext.Default.ReadScrollbackResult);
+
+        Assert.Contains(result.Lines, line => line.Contains("ok \U0001F44D done", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void ReadScreen_for_unknown_pane_reports_session_not_found()
     {
         using var service = NewService(new AgentSessionRegistry());
@@ -225,6 +259,51 @@ public class AgentHostServiceTests : IDisposable
         Assert.Equal(registration.PaneId, session.PaneId);
         Assert.Equal(24, session.Rows);
         Assert.Equal(80, session.Cols);
+    }
+
+    [Fact]
+    public async Task Disabling_the_service_closes_already_connected_clients()
+    {
+        // Security invariant: turning Agent Access off revokes access for
+        // existing connections, not just future ones.
+        var registry = new AgentSessionRegistry();
+        Register(registry, new TerminalBuffer(80, 24));
+        using var service = NewService(registry);
+        service.Start();
+
+        var descriptor = JsonSerializer.Deserialize(
+            File.ReadAllText(Path.Combine(_tempDir, AgentHostProtocol.DiscoveryFileName)),
+            AgentHostJsonContext.Default.EndpointDescriptor)!;
+        await using var stream = await ConnectAsync(descriptor.Endpoint);
+        using var reader = new StreamReader(stream, new UTF8Encoding(false), leaveOpen: true);
+        // Not await-using: disposal flushes, and flushing into the deliberately
+        // broken pipe after Stop() would throw during teardown.
+        var writer = new StreamWriter(stream, new UTF8Encoding(false), leaveOpen: true) { AutoFlush = true };
+
+        try
+        {
+            // Prove the connection works, so the assertion below is meaningful.
+            await writer.WriteLineAsync(RequestLine(AgentHostProtocol.Methods.ListSessions));
+            Assert.NotNull(await reader.ReadLineAsync().WaitAsync(TimeSpan.FromSeconds(10)));
+
+            service.Stop();
+
+            // The server must have force-closed the stream: the next read observes
+            // end-of-stream or a broken pipe/socket, never fresh data.
+            try
+            {
+                var line = await reader.ReadLineAsync().WaitAsync(TimeSpan.FromSeconds(10));
+                Assert.Null(line);
+            }
+            catch (IOException)
+            {
+                // Also acceptable: the transport surfaces the closed connection as an error.
+            }
+        }
+        finally
+        {
+            try { await writer.DisposeAsync(); } catch (IOException) { /* broken pipe is the expected end state */ }
+        }
     }
 
     private static async Task<Stream> ConnectAsync(string endpoint)

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentHostServiceTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentHostServiceTests.cs
@@ -1,0 +1,243 @@
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using NovaTerminal.AgentHost;
+using NovaTerminal.AgentHost.Contracts;
+using NovaTerminal.Replay;
+using NovaTerminal.VT;
+
+namespace NovaTerminal.AppTests.AgentHost;
+
+/// <summary>
+/// Tests for the agent-host observe endpoint (PR3 of milestone A1,
+/// docs/plans/2026-07-07-agent-host-a1-observe-design.md). Request handling
+/// is covered in-process via HandleRequestLine; the transport (named pipe on
+/// Windows, unix socket elsewhere) is covered by real connect/round-trip
+/// tests using a private endpoint name so parallel test runs don't collide.
+/// </summary>
+public class AgentHostServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public AgentHostServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "nova-agenthost-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
+        GC.SuppressFinalize(this);
+    }
+
+    private string NewEndpointName()
+    {
+        return OperatingSystem.IsWindows()
+            ? "novaterminal-agent-test-" + Guid.NewGuid().ToString("N")
+            : Path.Combine(_tempDir, Guid.NewGuid().ToString("N")[..8] + ".sock");
+    }
+
+    private AgentHostService NewService(AgentSessionRegistry registry)
+        => new(registry, NewEndpointName(), _tempDir);
+
+    private static AgentSessionRegistration Register(AgentSessionRegistry registry, TerminalBuffer buffer, Guid? paneId = null)
+    {
+        var registration = new AgentSessionRegistration(
+            paneId ?? Guid.NewGuid(), buffer, "title", "Profile", "local", isActive: true);
+        Assert.True(registry.Register(registration));
+        return registration;
+    }
+
+    private static string RequestLine(string method, long id = 1, object? paramsObj = null, int version = AgentHostProtocol.Version)
+    {
+        var paramsJson = paramsObj switch
+        {
+            null => "null",
+            ReadScreenParams p => JsonSerializer.Serialize(p, AgentHostJsonContext.Default.ReadScreenParams),
+            ReadScrollbackParams p => JsonSerializer.Serialize(p, AgentHostJsonContext.Default.ReadScrollbackParams),
+            _ => throw new InvalidOperationException("unexpected params type"),
+        };
+        return $"{{\"v\":{version},\"id\":{id},\"method\":\"{method}\",\"params\":{paramsJson}}}";
+    }
+
+    private static T ResultOf<T>(AgentHostResponse response, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> typeInfo)
+    {
+        Assert.Null(response.Error);
+        Assert.NotNull(response.Result);
+        var value = response.Result!.Value.Deserialize(typeInfo);
+        Assert.NotNull(value);
+        return value!;
+    }
+
+    // ── Request handling (in-process) ────────────────────────────────────────
+
+    [Fact]
+    public void Version_mismatch_is_rejected_with_stable_error_code()
+    {
+        using var service = NewService(new AgentSessionRegistry());
+        var response = service.HandleRequestLine(RequestLine(AgentHostProtocol.Methods.ListSessions, version: 99));
+        Assert.Equal(AgentHostProtocol.ErrorCodes.VersionMismatch, response.Error?.Code);
+    }
+
+    [Fact]
+    public void Malformed_frame_is_rejected_not_thrown()
+    {
+        using var service = NewService(new AgentSessionRegistry());
+        var response = service.HandleRequestLine("this is not json");
+        Assert.Equal(AgentHostProtocol.ErrorCodes.MalformedRequest, response.Error?.Code);
+    }
+
+    [Fact]
+    public void Unknown_method_is_rejected_with_stable_error_code()
+    {
+        using var service = NewService(new AgentSessionRegistry());
+        var response = service.HandleRequestLine(RequestLine("sendInput"));
+        Assert.Equal(AgentHostProtocol.ErrorCodes.UnknownMethod, response.Error?.Code);
+    }
+
+    [Fact]
+    public void ReadScreen_for_unknown_pane_reports_session_not_found()
+    {
+        using var service = NewService(new AgentSessionRegistry());
+        var response = service.HandleRequestLine(RequestLine(
+            AgentHostProtocol.Methods.ReadScreen,
+            paramsObj: new ReadScreenParams { PaneId = Guid.NewGuid() }));
+        Assert.Equal(AgentHostProtocol.ErrorCodes.SessionNotFound, response.Error?.Code);
+    }
+
+    [Fact]
+    public void ReadScreen_matches_BufferSnapshot_capture_exactly()
+    {
+        // The A1 parity invariant: what an agent reads over the wire is the
+        // deterministic snapshot, byte for byte.
+        var registry = new AgentSessionRegistry();
+        var buffer = new TerminalBuffer(40, 10);
+        var parser = new AnsiParser(buffer);
+        parser.Process("hello \x1b[1mworld\x1b[0m\r\nsecond line\r\nwide: 你好");
+        var registration = Register(registry, buffer);
+        using var service = NewService(registry);
+
+        var response = service.HandleRequestLine(RequestLine(
+            AgentHostProtocol.Methods.ReadScreen,
+            paramsObj: new ReadScreenParams { PaneId = registration.PaneId, IncludeAttributes = true }));
+        var dto = ResultOf(response, AgentHostJsonContext.Default.ScreenSnapshotDto);
+
+        var expected = BufferSnapshot.Capture(buffer, includeAttributes: true);
+        Assert.Equal(expected.Lines, dto.Lines);
+        Assert.Equal(expected.AttributeLines, dto.AttributeLines);
+        Assert.Equal(expected.CursorRow, dto.CursorRow);
+        Assert.Equal(expected.CursorCol, dto.CursorCol);
+        Assert.Equal(10, dto.Rows);
+        Assert.Equal(40, dto.Cols);
+        Assert.Equal("hello world", dto.Lines[0]);
+    }
+
+    [Fact]
+    public void ReadScrollback_returns_ranged_lines_with_totals()
+    {
+        var registry = new AgentSessionRegistry();
+        var buffer = new TerminalBuffer(20, 4);
+        var parser = new AnsiParser(buffer);
+        for (var i = 0; i < 12; i++)
+        {
+            parser.Process($"line-{i}\r\n");
+        }
+        var registration = Register(registry, buffer);
+        using var service = NewService(registry);
+
+        var response = service.HandleRequestLine(RequestLine(
+            AgentHostProtocol.Methods.ReadScrollback,
+            paramsObj: new ReadScrollbackParams { PaneId = registration.PaneId, StartLine = 1, MaxLines = 3 }));
+        var result = ResultOf(response, AgentHostJsonContext.Default.ReadScrollbackResult);
+
+        Assert.Equal(1, result.StartLine);
+        Assert.Equal(3, result.Lines.Length);
+        Assert.Equal(buffer.Scrollback.Count, result.TotalLines);
+        Assert.Equal("line-1", result.Lines[0]);
+        Assert.Equal("line-3", result.Lines[2]);
+    }
+
+    // ── Endpoint lifecycle & transport ───────────────────────────────────────
+
+    [Fact]
+    public void Disabled_service_creates_no_endpoint_and_no_discovery_file()
+    {
+        var registry = new AgentSessionRegistry();
+        using var service = NewService(registry);
+
+        service.Apply(false);
+
+        Assert.False(service.IsRunning);
+        Assert.False(File.Exists(Path.Combine(_tempDir, AgentHostProtocol.DiscoveryFileName)));
+    }
+
+    [Fact]
+    public void Stop_removes_the_discovery_file()
+    {
+        using var service = NewService(new AgentSessionRegistry());
+        service.Apply(true);
+        var discoveryPath = Path.Combine(_tempDir, AgentHostProtocol.DiscoveryFileName);
+        Assert.True(File.Exists(discoveryPath));
+
+        service.Apply(false);
+
+        Assert.False(service.IsRunning);
+        Assert.False(File.Exists(discoveryPath));
+    }
+
+    [Fact]
+    public async Task ListSessions_round_trips_over_the_real_transport()
+    {
+        var registry = new AgentSessionRegistry();
+        var buffer = new TerminalBuffer(80, 24);
+        var registration = Register(registry, buffer);
+        using var service = NewService(registry);
+        service.Start();
+        Assert.True(service.IsRunning);
+
+        // Discovery file advertises the endpoint, exactly as the MCP client will read it.
+        var descriptor = JsonSerializer.Deserialize(
+            File.ReadAllText(Path.Combine(_tempDir, AgentHostProtocol.DiscoveryFileName)),
+            AgentHostJsonContext.Default.EndpointDescriptor);
+        Assert.NotNull(descriptor);
+        Assert.Equal(AgentHostProtocol.Version, descriptor!.Version);
+        Assert.Equal(Environment.ProcessId, descriptor.Pid);
+
+        await using var stream = await ConnectAsync(descriptor.Endpoint);
+        using var reader = new StreamReader(stream, new UTF8Encoding(false), leaveOpen: true);
+        await using var writer = new StreamWriter(stream, new UTF8Encoding(false), leaveOpen: true) { AutoFlush = true };
+
+        await writer.WriteLineAsync(RequestLine(AgentHostProtocol.Methods.ListSessions, id: 42));
+        var line = await reader.ReadLineAsync().WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.NotNull(line);
+
+        var response = JsonSerializer.Deserialize(line!, AgentHostJsonContext.Default.AgentHostResponse);
+        Assert.NotNull(response);
+        Assert.Equal(42, response!.Id);
+        var sessions = ResultOf(response, AgentHostJsonContext.Default.ListSessionsResult).Sessions;
+        var session = Assert.Single(sessions);
+        Assert.Equal(registration.PaneId, session.PaneId);
+        Assert.Equal(24, session.Rows);
+        Assert.Equal(80, session.Cols);
+    }
+
+    private static async Task<Stream> ConnectAsync(string endpoint)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            var client = new NamedPipeClientStream(".", endpoint, PipeDirection.InOut, PipeOptions.Asynchronous);
+            await client.ConnectAsync(10_000);
+            return client;
+        }
+
+        var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+        await socket.ConnectAsync(new UnixDomainSocketEndPoint(endpoint));
+        return new NetworkStream(socket, ownsSocket: true);
+    }
+}

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentHostServiceTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentHostServiceTests.cs
@@ -212,17 +212,46 @@ public class AgentHostServiceTests : IDisposable
     }
 
     [Fact]
-    public void Stop_removes_the_discovery_file()
+    public void Stop_retires_the_discovery_descriptor()
     {
         using var service = NewService(new AgentSessionRegistry());
         service.Apply(true);
         var discoveryPath = Path.Combine(_tempDir, AgentHostProtocol.DiscoveryFileName);
         Assert.True(File.Exists(discoveryPath));
+        Assert.True(new FileInfo(discoveryPath).Length > 0);
 
         service.Apply(false);
 
+        // The descriptor is truncated under an exclusive handle rather than
+        // deleted (delete-after-close would race a concurrent takeover). An
+        // empty file is a stale descriptor: no live endpoint is advertised.
         Assert.False(service.IsRunning);
-        Assert.False(File.Exists(discoveryPath));
+        Assert.True(!File.Exists(discoveryPath) || new FileInfo(discoveryPath).Length == 0);
+    }
+
+    [Fact]
+    public void Stop_leaves_a_foreign_live_descriptor_untouched()
+    {
+        using var service = NewService(new AgentSessionRegistry());
+        service.Apply(true);
+        var discoveryPath = Path.Combine(_tempDir, AgentHostProtocol.DiscoveryFileName);
+
+        // Simulate another instance taking over the endpoint between our start
+        // and our stop: the descriptor on disk is no longer ours.
+        var foreign = new EndpointDescriptor
+        {
+            Version = AgentHostProtocol.Version,
+            Endpoint = "someone-elses-endpoint",
+            Pid = Environment.ProcessId + 1,
+        };
+        File.WriteAllText(discoveryPath, JsonSerializer.Serialize(foreign, AgentHostJsonContext.Default.EndpointDescriptor));
+
+        service.Apply(false);
+
+        var survivor = JsonSerializer.Deserialize(
+            File.ReadAllText(discoveryPath), AgentHostJsonContext.Default.EndpointDescriptor);
+        Assert.NotNull(survivor);
+        Assert.Equal("someone-elses-endpoint", survivor!.Endpoint);
     }
 
     [Fact]

--- a/tests/NovaTerminal.VT.Tests/ScrollbackSideTableTests.cs
+++ b/tests/NovaTerminal.VT.Tests/ScrollbackSideTableTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using NovaTerminal.VT;
+
+namespace NovaTerminal.VT.Tests;
+
+// Regression coverage for the resize/reflow scrollback paths dropping row side
+// tables (extended text, hyperlinks, wrap flag). The normal write-path eviction
+// always preserved them; the height-shrink redistribution and the reflow
+// rebuild appended bare cell arrays, so emoji / multi-codepoint graphemes came
+// back corrupted from scrollback after any resize. Surfaced by agent-host
+// readScrollback review (PR #184), but affects every scrollback consumer.
+public class ScrollbackSideTableTests
+{
+    private static List<string> AllScrollbackExtendedText(TerminalBuffer buffer)
+    {
+        var values = new List<string>();
+        for (int i = 0; i < buffer.Scrollback.Count; i++)
+        {
+            var map = buffer.Scrollback.GetExtendedTextMap(i);
+            if (map == null) continue;
+            for (int col = 0; col < buffer.Cols; col++)
+            {
+                if (map.TryGet(col, out var text) && text != null)
+                {
+                    values.Add(text);
+                }
+            }
+        }
+        return values;
+    }
+
+    [Fact]
+    public void HeightShrink_PushesRowsToScrollback_WithExtendedTextPreserved()
+    {
+        var buffer = new TerminalBuffer(20, 6);
+        var parser = new AnsiParser(buffer);
+        parser.Process("ok \U0001F44D done\r\n");
+        parser.Process("plain row\r\n");
+
+        // Height-only shrink: the top viewport rows (including the emoji row)
+        // are redistributed into scrollback.
+        buffer.Resize(20, 2);
+
+        Assert.True(buffer.Scrollback.Count > 0);
+        Assert.Contains("\U0001F44D", AllScrollbackExtendedText(buffer));
+    }
+
+    [Fact]
+    public void WidthReflow_RebuildsScrollback_WithExtendedTextPreserved()
+    {
+        var buffer = new TerminalBuffer(20, 4);
+        var parser = new AnsiParser(buffer);
+        parser.Process("ok \U0001F44D done\r\n");
+        for (int i = 0; i < 8; i++)
+        {
+            parser.Process($"filler-{i}\r\n");
+        }
+        // The emoji row has scrolled off via the write path (side tables intact).
+        Assert.Contains("\U0001F44D", AllScrollbackExtendedText(buffer));
+
+        // Width change triggers the reflow engine, which rebuilds scrollback
+        // from reflowed rows; side tables must survive the rebuild.
+        buffer.Resize(24, 4);
+
+        Assert.Contains("\U0001F44D", AllScrollbackExtendedText(buffer));
+    }
+}

--- a/tests/NovaTerminal.VT.Tests/ScrollbackSideTableTests.cs
+++ b/tests/NovaTerminal.VT.Tests/ScrollbackSideTableTests.cs
@@ -47,6 +47,59 @@ public class ScrollbackSideTableTests
     }
 
     [Fact]
+    public void ShrinkThenGrow_RestoresExtendedTextIntoTheViewport()
+    {
+        // The pull-from-scrollback grow path (Reshape) runs on the main screen
+        // while the alternate screen is active — e.g. vim open during a height
+        // shrink + grow. The emoji row must come back from scrollback with its
+        // side table, not as HasExtendedText cells with no map behind them.
+        var buffer = new TerminalBuffer(20, 6);
+        var parser = new AnsiParser(buffer);
+        parser.Process("ok \U0001F44D done\r\n");
+        parser.Process("plain row\r\n");
+
+        parser.Process("\x1b[?1049h");   // enter alt screen (vim et al.)
+        buffer.Resize(20, 2);            // Reshape shrink: emoji row → scrollback
+        Assert.Contains("\U0001F44D", AllScrollbackExtendedText(buffer));
+        buffer.Resize(20, 6);            // Reshape grow: pulled back from scrollback
+        parser.Process("\x1b[?1049l");   // back to the main screen
+
+        var restored = new List<string>();
+        foreach (var row in buffer.ViewportRows)
+        {
+            var map = row.GetExtendedTextMap();
+            if (map == null) continue;
+            for (int col = 0; col < buffer.Cols; col++)
+            {
+                if (map.TryGet(col, out var text) && text != null) restored.Add(text);
+            }
+        }
+        Assert.Contains("\U0001F44D", restored);
+    }
+
+    [Fact]
+    public void PopThenAppend_DoesNotResurrectStaleMetadata()
+    {
+        var pool = new NovaTerminal.VT.Storage.TerminalPagePool();
+        var scrollback = new NovaTerminal.VT.Storage.ScrollbackPages(4, pool);
+        var map = new NovaTerminal.VT.Storage.SmallMap<string>();
+        map.Set(0, "\U0001F44D");
+        scrollback.AppendRow(new TerminalCell[4], isWrapped: true, extendedText: map);
+
+        // Pop returns the metadata with the row and vacates the slot…
+        Assert.True(scrollback.TryPopLastRow(new TerminalCell[4], out var isWrapped, out var extendedText, out _));
+        Assert.True(isWrapped);
+        Assert.NotNull(extendedText);
+
+        // …so a plain row appended into the same slot comes back clean: no
+        // wrap flag, no extended text inherited from the popped row.
+        long abs = scrollback.AppendRow(new TerminalCell[4]);
+        int index = (int)(abs - scrollback.TotalRowsEvicted);
+        Assert.Null(scrollback.GetExtendedTextMap(index));
+        Assert.False(scrollback.IsRowWrapped(index));
+    }
+
+    [Fact]
     public void WidthReflow_RebuildsScrollback_WithExtendedTextPreserved()
     {
         var buffer = new TerminalBuffer(20, 4);


### PR DESCRIPTION
## Summary

PR3 of milestone **A1 (Observe)** (`docs/agent-host/DIRECTION.md`, design in `docs/plans/2026-07-07-agent-host-a1-observe-design.md`): the app-side IPC control endpoint, gated by a new default-off setting. Follows #183 (contracts + registry).

**Off by default, observe-only by construction.** When `AgentAccessObserveEnabled` is false (the default), no listener, socket, pipe, or discovery file exists — verified by test. The protocol has no input/spawn/close methods in v1.

## What's included

### `AgentHostService` (`src/NovaTerminal.App/AgentHost/`)
- Per-user local endpoint: named pipe with `PipeOptions.CurrentUserOnly` on Windows; unix domain socket (mode `0600`, stale socket cleanup) on Linux/macOS. Newline-delimited JSON frames via the source-generated `AgentHostJsonContext` (AOT-safe).
- Serves `listSessions`, `readScreen`, `readScrollback`. Screen reads go through `BufferSnapshot.Capture` **under the buffer's read lock** — the same deterministic snapshot boundary the replay/parity tests use. Scrollback reads are ranged and capped (`MaxScrollbackLinesPerRequest`), with the same text semantics as `BufferSnapshot` (skip wide continuations, NUL→space, trim right).
- `EndpointDescriptor` discovery file next to settings.json while listening; removed on stop. First instance wins (live-pid check); stale descriptors are replaced.
- Stable error codes: `versionMismatch`, `malformedRequest`, `unknownMethod`, `sessionNotFound`, `internal`.

### Settings & UI
- `TerminalSettings.AgentAccessObserveEnabled` (default **false**)
- Settings window toggle: "Agent access (observe)" with explicit read-only + sensitive-content wording
- Live apply: toggling starts/stops the endpoint without restart (`MainWindow.OpenSettings`); started at launch only if enabled; stopped in `OnClosing`
- McpServer `SettingsTools` validator/docs updated with the new key

### Contracts fix
- `SessionInfo.TabId` is no longer `required`: the wire format omits it when null (`WhenWritingNull`), so requiring it broke round-trip deserialization — caught by the new transport test.

## Tests (9 new in `AgentHostServiceTests`)

- **Parity:** `readScreen` result equals a direct `BufferSnapshot.Capture` of the same buffer (lines, attributes, cursor)
- **Off-is-off:** disabled service creates no endpoint and no discovery file; stop removes the discovery file
- **Real transport round-trip:** discovery file → connect (pipe on Windows / unix socket elsewhere) → `listSessions` → typed response
- Protocol: version mismatch, malformed frame, unknown method, session-not-found
- Suites: AgentHost 18/18, Architecture 18/18, McpServer 115/115

## Next (PR4)

MCP-server side: `AgentHostClient` + `novaterminal.list_sessions` / `read_screen` / `read_scrollback` tools — after which Claude Code/Codex can read live NovaTerminal sessions end-to-end.
