### PR TITLE
feat(agent-host): A1 MCP session tools - list_sessions, read_screen, read_scrollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ acyclic dependency graph.
 - **[`src/NovaTerminal.Replay`](src/NovaTerminal.Replay/)** — Deterministic session recording and playback.
 - **[`src/NovaTerminal.Conformance`](src/NovaTerminal.Conformance/)** — VT conformance matrix tooling and report generation.
 - **[`src/NovaTerminal.Cli`](src/NovaTerminal.Cli/)** — console-subsystem twin of the (WinExe) app for headless tooling: `vt-report` and the SSH askpass helper.
-- **[`src/NovaTerminal.McpServer`](src/NovaTerminal.McpServer/)** — read-only, stdio-only MCP server exposing project docs, config validators, and VT conformance data to AI tooling.
+- **[`src/NovaTerminal.AgentHost.Contracts`](src/NovaTerminal.AgentHost.Contracts/)** — zero-dependency wire contracts for the agent-host observe channel (shared by App and McpServer).
+- **[`src/NovaTerminal.McpServer`](src/NovaTerminal.McpServer/)** — read-only, stdio-only MCP server exposing project docs, config validators, VT conformance data, and (opt-in, observe-only) live terminal sessions to AI tooling.
 
 Validation:
 

--- a/docs/agent-host/DIRECTION.md
+++ b/docs/agent-host/DIRECTION.md
@@ -134,10 +134,10 @@ Each milestone is independently shippable and announceable. Estimates assume
 ### A1 — Observe (first public demo)
 
 **Deliverables**
-- [ ] App-side IPC endpoint + session registry exposure
-- [ ] MCP tools: `novaterminal.list_sessions`, `novaterminal.read_screen`
+- [x] App-side IPC endpoint + session registry exposure (PRs #183, #184)
+- [x] MCP tools: `novaterminal.list_sessions`, `novaterminal.read_screen`
       (visible grid + cursor), `novaterminal.read_scrollback` (ranged)
-- [ ] `Agent Access (observe)` settings toggle, off by default
+- [x] `Agent Access (observe)` settings toggle, off by default (PR #184)
 - [ ] Docs + demo recording: Claude Code reading a live `htop`/`vim` session
 
 **Acceptance criteria**

--- a/src/NovaTerminal.AgentHost.Contracts/AgentHostDiscovery.cs
+++ b/src/NovaTerminal.AgentHost.Contracts/AgentHostDiscovery.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+
+namespace NovaTerminal.AgentHost.Contracts;
+
+/// <summary>
+/// Resolves where the endpoint discovery file lives. Lives in the contracts
+/// leaf so both ends of the channel — the app (writer) and the MCP server
+/// (reader), which share no other assemblies — agree on one path by
+/// construction. Mirrors the app's AppPaths.RootDirectory resolution,
+/// including the NOVATERM_APPDATA_ROOT override used by tests and portable
+/// installs.
+/// </summary>
+public static class AgentHostDiscovery
+{
+    private const string AppName = "NovaTerminal";
+    public const string RootOverrideEnvVar = "NOVATERM_APPDATA_ROOT";
+
+    /// <summary>The app-data directory the discovery file is written into.</summary>
+    public static string GetDefaultDirectory()
+    {
+        var overrideRoot = Environment.GetEnvironmentVariable(RootOverrideEnvVar);
+        if (!string.IsNullOrWhiteSpace(overrideRoot))
+        {
+            return Path.GetFullPath(overrideRoot);
+        }
+
+        return Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            AppName);
+    }
+
+    /// <summary>Full path of the discovery file (<see cref="AgentHostProtocol.DiscoveryFileName"/>).</summary>
+    public static string GetDefaultDiscoveryFilePath()
+        => Path.Combine(GetDefaultDirectory(), AgentHostProtocol.DiscoveryFileName);
+}

--- a/src/NovaTerminal.App/AgentHost/AgentHostService.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentHostService.cs
@@ -76,7 +76,9 @@ namespace NovaTerminal.AgentHost
             {
                 if (_cts != null) return;
 
-                var discoveryDir = _discoveryDirectoryOverride ?? NovaTerminal.Shell.AppPaths.RootDirectory;
+                // AgentHostDiscovery mirrors AppPaths.RootDirectory; using it here
+                // keeps writer (app) and reader (MCP server) on one path by construction.
+                var discoveryDir = _discoveryDirectoryOverride ?? AgentHostDiscovery.GetDefaultDirectory();
                 var discoveryPath = Path.Combine(discoveryDir, AgentHostProtocol.DiscoveryFileName);
 
                 // First instance wins: if another live NovaTerminal already

--- a/src/NovaTerminal.McpServer/AgentHostClient.cs
+++ b/src/NovaTerminal.McpServer/AgentHostClient.cs
@@ -1,0 +1,160 @@
+using System.IO.Pipes;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using NovaTerminal.AgentHost.Contracts;
+
+namespace NovaTerminal.McpServer;
+
+/// <summary>
+/// Client side of the agent-host observe channel
+/// (docs/agent-host/DIRECTION.md, milestone A1). Discovers the running app's
+/// endpoint via the descriptor file next to settings.json and speaks the
+/// newline-delimited JSON frame protocol from NovaTerminal.AgentHost.Contracts.
+///
+/// Unavailability is a normal state, not an exception: when NovaTerminal isn't
+/// running or the user has not enabled "Agent access (observe)", callers get a
+/// human-readable reason to surface verbatim to the agent.
+/// </summary>
+public sealed class AgentHostClient
+{
+    /// <summary>Fixed guidance surfaced when no live endpoint is reachable.</summary>
+    public const string UnavailableMessage =
+        "Live session access is unavailable: NovaTerminal is not running with Agent Access enabled. " +
+        "Start NovaTerminal and enable Settings → Agent access (observe), then retry. " +
+        "This surface is observe-only: agents can read sessions but cannot type or open them.";
+
+    private static readonly TimeSpan ConnectTimeout = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan RoundTripTimeout = TimeSpan.FromSeconds(10);
+
+    private readonly string _discoveryFilePath;
+    private long _nextId;
+
+    public AgentHostClient(string? discoveryFilePathOverride = null)
+    {
+        _discoveryFilePath = discoveryFilePathOverride ?? AgentHostDiscovery.GetDefaultDiscoveryFilePath();
+    }
+
+    /// <summary>Outcome of a call: either a protocol response, or a reason the endpoint is unreachable.</summary>
+    public sealed record CallOutcome(AgentHostResponse? Response, string? UnavailableReason)
+    {
+        public bool Available => Response != null;
+    }
+
+    public async Task<CallOutcome> CallAsync(string method, JsonElement? parameters, CancellationToken cancellationToken)
+    {
+        var descriptor = TryReadLiveDescriptor();
+        if (descriptor == null)
+        {
+            return new CallOutcome(null, UnavailableMessage);
+        }
+
+        try
+        {
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(RoundTripTimeout);
+
+            await using var stream = await ConnectAsync(descriptor.Endpoint, timeoutCts.Token).ConfigureAwait(false);
+            using var reader = new StreamReader(stream, new UTF8Encoding(false), leaveOpen: true);
+            await using var writer = new StreamWriter(stream, new UTF8Encoding(false), leaveOpen: true) { AutoFlush = true };
+
+            var request = new AgentHostRequest
+            {
+                Version = AgentHostProtocol.Version,
+                Id = Interlocked.Increment(ref _nextId),
+                Method = method,
+                Params = parameters,
+            };
+            await writer.WriteLineAsync(
+                JsonSerializer.Serialize(request, AgentHostJsonContext.Default.AgentHostRequest)
+                    .AsMemory(),
+                timeoutCts.Token).ConfigureAwait(false);
+
+            var line = await reader.ReadLineAsync(timeoutCts.Token).ConfigureAwait(false);
+            if (line == null)
+            {
+                return new CallOutcome(null, UnavailableMessage);
+            }
+
+            var response = JsonSerializer.Deserialize(line, AgentHostJsonContext.Default.AgentHostResponse);
+            return response == null
+                ? new CallOutcome(null, UnavailableMessage)
+                : new CallOutcome(response, null);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return new CallOutcome(null, "Live session access timed out talking to NovaTerminal. The app may be busy; retry.");
+        }
+        catch (Exception)
+        {
+            // Connection refused / broken pipe: the endpoint died between the
+            // descriptor read and the connect — same user remedy as unavailable.
+            return new CallOutcome(null, UnavailableMessage);
+        }
+    }
+
+    private EndpointDescriptor? TryReadLiveDescriptor()
+    {
+        try
+        {
+            if (!File.Exists(_discoveryFilePath)) return null;
+            var text = File.ReadAllText(_discoveryFilePath);
+            if (string.IsNullOrWhiteSpace(text)) return null; // truncated == retired
+
+            var descriptor = JsonSerializer.Deserialize(text, AgentHostJsonContext.Default.EndpointDescriptor);
+            if (descriptor == null || descriptor.Version != AgentHostProtocol.Version) return null;
+
+            // Stale-descriptor guard, mirroring the app side: the advertised
+            // pid must still be alive.
+            try
+            {
+                using var process = System.Diagnostics.Process.GetProcessById(descriptor.Pid);
+                if (process.HasExited) return null;
+            }
+            catch (ArgumentException)
+            {
+                return null;
+            }
+
+            return descriptor;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static async Task<Stream> ConnectAsync(string endpoint, CancellationToken cancellationToken)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            var pipe = new NamedPipeClientStream(".", endpoint, PipeDirection.InOut, PipeOptions.Asynchronous);
+            try
+            {
+                using var connectCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                connectCts.CancelAfter(ConnectTimeout);
+                await pipe.ConnectAsync(connectCts.Token).ConfigureAwait(false);
+                return pipe;
+            }
+            catch
+            {
+                await pipe.DisposeAsync().ConfigureAwait(false);
+                throw;
+            }
+        }
+
+        var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+        try
+        {
+            using var connectCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            connectCts.CancelAfter(ConnectTimeout);
+            await socket.ConnectAsync(new UnixDomainSocketEndPoint(endpoint), connectCts.Token).ConfigureAwait(false);
+            return new NetworkStream(socket, ownsSocket: true);
+        }
+        catch
+        {
+            socket.Dispose();
+            throw;
+        }
+    }
+}

--- a/src/NovaTerminal.McpServer/AgentHostClient.cs
+++ b/src/NovaTerminal.McpServer/AgentHostClient.cs
@@ -18,6 +18,11 @@ namespace NovaTerminal.McpServer;
 /// </summary>
 public sealed class AgentHostClient
 {
+    /// <summary>Surfaced when the endpoint answered with something the client cannot parse.</summary>
+    public const string ProtocolErrorMessage =
+        "NovaTerminal answered, but the response could not be parsed. This usually means the app and " +
+        "the MCP server are from different versions — update them together and retry.";
+
     /// <summary>Fixed guidance surfaced when no live endpoint is reachable.</summary>
     public const string UnavailableMessage =
         "Live session access is unavailable: NovaTerminal is not running with Agent Access enabled. " +
@@ -73,15 +78,33 @@ public sealed class AgentHostClient
             var line = await reader.ReadLineAsync(timeoutCts.Token).ConfigureAwait(false);
             if (line == null)
             {
-                return new CallOutcome(null, UnavailableMessage);
+                // Connected, then EOF before a response: that's a live app
+                // dropping us (e.g. Agent Access toggled off mid-call), not
+                // "app isn't running".
+                return new CallOutcome(null, "NovaTerminal closed the connection before responding. Agent Access may have just been disabled; check Settings → Agent access (observe) and retry.");
             }
 
-            var response = JsonSerializer.Deserialize(line, AgentHostJsonContext.Default.AgentHostResponse);
-            return response == null
-                ? new CallOutcome(null, UnavailableMessage)
-                : new CallOutcome(response, null);
+            try
+            {
+                var response = JsonSerializer.Deserialize(line, AgentHostJsonContext.Default.AgentHostResponse);
+                return response == null
+                    ? new CallOutcome(null, ProtocolErrorMessage)
+                    : new CallOutcome(response, null);
+            }
+            catch (JsonException)
+            {
+                // Connected and answered, but not in a shape we understand:
+                // a protocol problem, not an availability problem.
+                return new CallOutcome(null, ProtocolErrorMessage);
+            }
         }
-        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Cooperative cancellation from the MCP host must propagate, not
+            // masquerade as an unavailable endpoint.
+            throw;
+        }
+        catch (OperationCanceledException)
         {
             return new CallOutcome(null, "Live session access timed out talking to NovaTerminal. The app may be busy; retry.");
         }
@@ -109,7 +132,20 @@ public sealed class AgentHostClient
             try
             {
                 using var process = System.Diagnostics.Process.GetProcessById(descriptor.Pid);
-                if (process.HasExited) return null;
+                try
+                {
+                    if (process.HasExited) return null;
+                }
+                catch (System.ComponentModel.Win32Exception)
+                {
+                    // Access denied querying exit state (elevated app, different
+                    // integrity level): we *did* get a process object, so assume
+                    // it is alive rather than falsely reporting unavailable.
+                }
+                catch (InvalidOperationException)
+                {
+                    return null; // no process handle — treat as exited
+                }
             }
             catch (ArgumentException)
             {

--- a/src/NovaTerminal.McpServer/NovaTerminal.McpServer.csproj
+++ b/src/NovaTerminal.McpServer/NovaTerminal.McpServer.csproj
@@ -1,10 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <!--
-    NovaTerminal MCP Dev Companion (#97): a local, read-only stdio MCP server that exposes
-    project knowledge to AI coding agents. Intentionally dependency-free of the rest of the
-    solution (no ProjectReferences) — it reads repo docs and validates JSON against a
-    self-contained schema, and must never touch terminal sessions, SSH, or credentials.
+    NovaTerminal MCP server: a local stdio MCP server that exposes project knowledge to AI
+    coding agents, plus — per the agent-host direction (docs/agent-host/DIRECTION.md, A1) —
+    opt-in, observe-only access to live terminal sessions, proxied over the app's local IPC
+    endpoint. The only solution dependency is the zero-reference contracts leaf
+    (NovaTerminal.AgentHost.Contracts); this server must never reference App/VT/Platform,
+    and must never touch SSH or credentials. Session access is read-only and exists only
+    while the user has "Agent access (observe)" enabled in the running app.
   -->
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -17,6 +20,10 @@
   <ItemGroup>
     <PackageReference Include="ModelContextProtocol" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NovaTerminal.AgentHost.Contracts\NovaTerminal.AgentHost.Contracts.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NovaTerminal.McpServer/Program.cs
+++ b/src/NovaTerminal.McpServer/Program.cs
@@ -15,6 +15,10 @@ builder.Logging.AddConsole(options => options.LogToStandardErrorThreshold = LogL
 // Resolves the repository root once and provides path-safe, read-only access to docs.
 builder.Services.AddSingleton(RepoContext.Discover());
 
+// Client for the app's opt-in, observe-only live-session endpoint (agent-host A1).
+// Constructing it does not touch the endpoint; availability is checked per call.
+builder.Services.AddSingleton(new AgentHostClient());
+
 builder.Services
     .AddMcpServer()
     .WithStdioServerTransport()

--- a/src/NovaTerminal.McpServer/Tools/SessionTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/SessionTools.cs
@@ -22,8 +22,9 @@ public static class SessionTools
         var outcome = await client.CallAsync(AgentHostProtocol.Methods.ListSessions, null, cancellationToken).ConfigureAwait(false);
         if (!TryUnwrap(outcome, out var result, out var error)) return error;
 
-        var sessions = result.Deserialize(AgentHostJsonContext.Default.ListSessionsResult)?.Sessions;
-        return FormatSessionList(sessions ?? Array.Empty<SessionInfo>());
+        return TryDeserializeResult(result, AgentHostJsonContext.Default.ListSessionsResult, out var dto)
+            ? FormatSessionList(dto!.Sessions)
+            : AgentHostClient.ProtocolErrorMessage;
     }
 
     [McpServerTool(Name = "novaterminal.read_screen"),
@@ -45,8 +46,9 @@ public static class SessionTools
         var outcome = await client.CallAsync(AgentHostProtocol.Methods.ReadScreen, parameters, cancellationToken).ConfigureAwait(false);
         if (!TryUnwrap(outcome, out var result, out var error)) return error;
 
-        var dto = result.Deserialize(AgentHostJsonContext.Default.ScreenSnapshotDto);
-        return dto == null ? AgentHostClient.UnavailableMessage : FormatScreen(dto);
+        return TryDeserializeResult(result, AgentHostJsonContext.Default.ScreenSnapshotDto, out var dto)
+            ? FormatScreen(dto!)
+            : AgentHostClient.ProtocolErrorMessage;
     }
 
     [McpServerTool(Name = "novaterminal.read_scrollback"),
@@ -62,6 +64,17 @@ public static class SessionTools
         {
             return $"Error: '{paneId}' is not a valid pane id (GUID). Use novaterminal.list_sessions to find live pane ids.";
         }
+        if (maxLines <= 0)
+        {
+            // Guarded here, before any IPC: the server clamps this to an empty
+            // page whose paging hint would point at the same startLine — an
+            // agent following the documented paging flow would loop forever.
+            return "Error: maxLines must be greater than 0.";
+        }
+        if (startLine < 0)
+        {
+            return "Error: startLine must be 0 or greater (0 = oldest retained line).";
+        }
 
         var parameters = JsonSerializer.SerializeToElement(
             new ReadScrollbackParams { PaneId = pane, StartLine = startLine, MaxLines = maxLines },
@@ -69,11 +82,37 @@ public static class SessionTools
         var outcome = await client.CallAsync(AgentHostProtocol.Methods.ReadScrollback, parameters, cancellationToken).ConfigureAwait(false);
         if (!TryUnwrap(outcome, out var result, out var error)) return error;
 
-        var dto = result.Deserialize(AgentHostJsonContext.Default.ReadScrollbackResult);
-        return dto == null ? AgentHostClient.UnavailableMessage : FormatScrollback(dto);
+        return TryDeserializeResult(result, AgentHostJsonContext.Default.ReadScrollbackResult, out var dto)
+            ? FormatScrollback(dto!)
+            : AgentHostClient.ProtocolErrorMessage;
     }
 
     // ── Shared plumbing ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Deserializes a result payload, treating malformed/empty payloads as a
+    /// protocol error rather than throwing out of the tool. Contract note: the
+    /// DTOs' array/string members are declared <c>required</c> and non-nullable,
+    /// so a successful deserialization here cannot yield null members — a
+    /// missing required field lands in the JsonException path instead.
+    /// </summary>
+    private static bool TryDeserializeResult<T>(
+        JsonElement result,
+        System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> typeInfo,
+        out T? value)
+        where T : class
+    {
+        try
+        {
+            value = result.Deserialize(typeInfo);
+            return value != null;
+        }
+        catch (JsonException)
+        {
+            value = null;
+            return false;
+        }
+    }
 
     private static bool TryUnwrap(AgentHostClient.CallOutcome outcome, out JsonElement result, out string error)
     {

--- a/src/NovaTerminal.McpServer/Tools/SessionTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/SessionTools.cs
@@ -1,0 +1,165 @@
+using System.ComponentModel;
+using System.Text;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using NovaTerminal.AgentHost.Contracts;
+
+namespace NovaTerminal.McpServer.Tools;
+
+/// <summary>
+/// Live-session observe tools (docs/agent-host/DIRECTION.md, milestone A1).
+/// These proxy the running app's local IPC endpoint via <see cref="AgentHostClient"/>;
+/// they are read-only by protocol design and only work while the user has
+/// enabled "Agent access (observe)" in NovaTerminal's settings.
+/// </summary>
+[McpServerToolType]
+public static class SessionTools
+{
+    [McpServerTool(Name = "novaterminal.list_sessions"),
+     Description("Lists the live terminal sessions in the running NovaTerminal app: pane id, title, profile, kind (local/ssh), size, and active state. Requires NovaTerminal to be running with 'Agent access (observe)' enabled; returns instructions if it isn't. Use the paneId with novaterminal.read_screen / novaterminal.read_scrollback.")]
+    public static async Task<string> ListSessions(AgentHostClient client, CancellationToken cancellationToken)
+    {
+        var outcome = await client.CallAsync(AgentHostProtocol.Methods.ListSessions, null, cancellationToken).ConfigureAwait(false);
+        if (!TryUnwrap(outcome, out var result, out var error)) return error;
+
+        var sessions = result.Deserialize(AgentHostJsonContext.Default.ListSessionsResult)?.Sessions;
+        return FormatSessionList(sessions ?? Array.Empty<SessionInfo>());
+    }
+
+    [McpServerTool(Name = "novaterminal.read_screen"),
+     Description("Reads the visible screen of a live NovaTerminal session as text: the exact deterministic snapshot a human sees (viewport lines, cursor position/visibility, size). Optionally includes per-row attribute encodings. Read-only. Get paneId from novaterminal.list_sessions.")]
+    public static async Task<string> ReadScreen(
+        AgentHostClient client,
+        [Description("The pane id (GUID) from novaterminal.list_sessions.")] string paneId,
+        [Description("Include per-row attribute lines (flags:fg/bg per cell). Default false.")] bool includeAttributes = false,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Guid.TryParse(paneId, out var pane))
+        {
+            return $"Error: '{paneId}' is not a valid pane id (GUID). Use novaterminal.list_sessions to find live pane ids.";
+        }
+
+        var parameters = JsonSerializer.SerializeToElement(
+            new ReadScreenParams { PaneId = pane, IncludeAttributes = includeAttributes },
+            AgentHostJsonContext.Default.ReadScreenParams);
+        var outcome = await client.CallAsync(AgentHostProtocol.Methods.ReadScreen, parameters, cancellationToken).ConfigureAwait(false);
+        if (!TryUnwrap(outcome, out var result, out var error)) return error;
+
+        var dto = result.Deserialize(AgentHostJsonContext.Default.ScreenSnapshotDto);
+        return dto == null ? AgentHostClient.UnavailableMessage : FormatScreen(dto);
+    }
+
+    [McpServerTool(Name = "novaterminal.read_scrollback"),
+     Description("Reads a range of scrollback (history) lines from a live NovaTerminal session, oldest first. Ranged and capped per request; the result reports the effective start line and the total lines available so you can page. Read-only. Get paneId from novaterminal.list_sessions.")]
+    public static async Task<string> ReadScrollback(
+        AgentHostClient client,
+        [Description("The pane id (GUID) from novaterminal.list_sessions.")] string paneId,
+        [Description("First scrollback line to return (0 = oldest retained line). Default 0.")] int startLine = 0,
+        [Description("Maximum lines to return (server-capped). Default 200.")] int maxLines = 200,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Guid.TryParse(paneId, out var pane))
+        {
+            return $"Error: '{paneId}' is not a valid pane id (GUID). Use novaterminal.list_sessions to find live pane ids.";
+        }
+
+        var parameters = JsonSerializer.SerializeToElement(
+            new ReadScrollbackParams { PaneId = pane, StartLine = startLine, MaxLines = maxLines },
+            AgentHostJsonContext.Default.ReadScrollbackParams);
+        var outcome = await client.CallAsync(AgentHostProtocol.Methods.ReadScrollback, parameters, cancellationToken).ConfigureAwait(false);
+        if (!TryUnwrap(outcome, out var result, out var error)) return error;
+
+        var dto = result.Deserialize(AgentHostJsonContext.Default.ReadScrollbackResult);
+        return dto == null ? AgentHostClient.UnavailableMessage : FormatScrollback(dto);
+    }
+
+    // ── Shared plumbing ─────────────────────────────────────────────────────
+
+    private static bool TryUnwrap(AgentHostClient.CallOutcome outcome, out JsonElement result, out string error)
+    {
+        result = default;
+        if (!outcome.Available)
+        {
+            error = outcome.UnavailableReason ?? AgentHostClient.UnavailableMessage;
+            return false;
+        }
+
+        var response = outcome.Response!;
+        if (response.Error != null)
+        {
+            error = $"Error ({response.Error.Code}): {response.Error.Message}";
+            return false;
+        }
+
+        if (response.Result == null)
+        {
+            error = AgentHostClient.UnavailableMessage;
+            return false;
+        }
+
+        result = response.Result.Value;
+        error = string.Empty;
+        return true;
+    }
+
+    // ── Formatting (internal for tests) ─────────────────────────────────────
+
+    internal static string FormatSessionList(SessionInfo[] sessions)
+    {
+        if (sessions.Length == 0)
+        {
+            return "No live sessions. NovaTerminal is running with Agent Access enabled, but no terminal panes are open.";
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"{sessions.Length} live session(s):");
+        sb.AppendLine();
+        sb.AppendLine("| paneId | title | profile | kind | size | active | tabId |");
+        sb.AppendLine("|---|---|---|---|---|---|---|");
+        foreach (var s in sessions)
+        {
+            sb.AppendLine(
+                $"| {s.PaneId} | {s.Title} | {s.ProfileName} | {s.Kind} | {s.Cols}x{s.Rows} | {(s.IsActive ? "yes" : "no")} | {(s.TabId?.ToString() ?? "-")} |");
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    internal static string FormatScreen(ScreenSnapshotDto dto)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Screen {dto.Cols}x{dto.Rows}, cursor at row {dto.CursorRow}, col {dto.CursorCol} ({(dto.CursorVisible ? "visible" : "hidden")}). Lines are numbered from 0; trailing whitespace is trimmed.");
+        sb.AppendLine();
+        for (var i = 0; i < dto.Lines.Length; i++)
+        {
+            sb.AppendLine($"{i,3}| {dto.Lines[i]}");
+        }
+
+        if (dto.AttributeLines is { Length: > 0 })
+        {
+            sb.AppendLine();
+            sb.AppendLine("Attributes (per row: flagsHex:fgIndex/bgIndex per cell, '|' separated):");
+            for (var i = 0; i < dto.AttributeLines.Length; i++)
+            {
+                sb.AppendLine($"{i,3}| {dto.AttributeLines[i]}");
+            }
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    internal static string FormatScrollback(ReadScrollbackResult dto)
+    {
+        var sb = new StringBuilder();
+        var end = dto.StartLine + dto.Lines.Length;
+        sb.AppendLine($"Scrollback lines {dto.StartLine}–{Math.Max(dto.StartLine, end - 1)} of {dto.TotalLines} total (oldest first).");
+        if (end < dto.TotalLines)
+        {
+            sb.AppendLine($"More available: call again with startLine={end}.");
+        }
+        sb.AppendLine();
+        for (var i = 0; i < dto.Lines.Length; i++)
+        {
+            sb.AppendLine($"{dto.StartLine + i,5}| {dto.Lines[i]}");
+        }
+        return sb.ToString().TrimEnd();
+    }
+}

--- a/tests/NovaTerminal.McpServer.Tests/AgentHostClientTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/AgentHostClientTests.cs
@@ -117,6 +117,63 @@ public class AgentHostClientTests : IDisposable
         await serverTask.WaitAsync(TimeSpan.FromSeconds(10));
     }
 
+    [Fact]
+    public async Task Caller_cancellation_propagates_instead_of_reporting_unavailable()
+    {
+        WriteDescriptor("some-endpoint-nobody-listens-on");
+        var client = new AgentHostClient(DiscoveryPath);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => client.CallAsync(AgentHostProtocol.Methods.ListSessions, null, cts.Token));
+    }
+
+    [Fact]
+    public async Task Malformed_server_response_is_a_protocol_error_not_unavailable()
+    {
+        var endpoint = OperatingSystem.IsWindows()
+            ? "novaterminal-agent-client-test-" + Guid.NewGuid().ToString("N")
+            : Path.Combine(_tempDir, "m.sock");
+
+        using var serverCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var serverTask = RunRawReplyEndpointOnceAsync(endpoint, "this is not a frame", serverCts.Token);
+        WriteDescriptor(endpoint);
+
+        var client = new AgentHostClient(DiscoveryPath);
+        var outcome = await client.CallAsync(AgentHostProtocol.Methods.ListSessions, null, TestContext.Current.CancellationToken);
+
+        Assert.False(outcome.Available);
+        Assert.Equal(AgentHostClient.ProtocolErrorMessage, outcome.UnavailableReason);
+        await serverTask.WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
+    /// <summary>Accepts one connection, reads one line, replies with a raw string, then exits.</summary>
+    private static async Task RunRawReplyEndpointOnceAsync(string endpoint, string rawReply, CancellationToken token)
+    {
+        await using var stream = await AcceptOneAsync(endpoint, token);
+        using var reader = new StreamReader(stream, new UTF8Encoding(false), leaveOpen: true);
+        await using var writer = new StreamWriter(stream, new UTF8Encoding(false), leaveOpen: true) { AutoFlush = true };
+        _ = await reader.ReadLineAsync(token);
+        await writer.WriteLineAsync(rawReply.AsMemory(), token);
+    }
+
+    private static async Task<Stream> AcceptOneAsync(string endpoint, CancellationToken token)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            var pipe = new NamedPipeServerStream(endpoint, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+            await pipe.WaitForConnectionAsync(token);
+            return pipe;
+        }
+
+        using var listener = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+        listener.Bind(new UnixDomainSocketEndPoint(endpoint));
+        listener.Listen(1);
+        var socket = await listener.AcceptAsync(token);
+        return new NetworkStream(socket, ownsSocket: true);
+    }
+
     /// <summary>Serves exactly one connection and one request, then exits.</summary>
     private static async Task RunFakeEndpointOnceAsync(string endpoint, ListSessionsResult reply, CancellationToken token)
     {
@@ -157,6 +214,24 @@ public class AgentHostClientTests : IDisposable
 /// <summary>Formatter tests: the shapes agents actually read.</summary>
 public class SessionToolsFormattingTests
 {
+    [Fact]
+    public async Task ReadScrollback_rejects_non_positive_maxLines_before_any_ipc()
+    {
+        // maxLines <= 0 would produce an empty page whose paging hint repeats
+        // the same startLine — an agent following the hint would loop forever.
+        // The guard runs before the IPC call: a client with no discovery file
+        // would otherwise return the unavailable message instead.
+        var client = new AgentHostClient(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "nothing.json"));
+
+        var zero = await SessionTools.ReadScrollback(client, Guid.NewGuid().ToString(), startLine: 0, maxLines: 0, TestContext.Current.CancellationToken);
+        var negative = await SessionTools.ReadScrollback(client, Guid.NewGuid().ToString(), startLine: 0, maxLines: -5, TestContext.Current.CancellationToken);
+        var negativeStart = await SessionTools.ReadScrollback(client, Guid.NewGuid().ToString(), startLine: -1, maxLines: 10, TestContext.Current.CancellationToken);
+
+        Assert.Equal("Error: maxLines must be greater than 0.", zero);
+        Assert.Equal("Error: maxLines must be greater than 0.", negative);
+        Assert.StartsWith("Error: startLine must be 0 or greater", negativeStart, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void FormatSessionList_renders_a_row_per_session_and_handles_null_tab()
     {

--- a/tests/NovaTerminal.McpServer.Tests/AgentHostClientTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/AgentHostClientTests.cs
@@ -1,0 +1,209 @@
+using System.IO.Pipes;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using NovaTerminal.AgentHost.Contracts;
+using NovaTerminal.McpServer;
+using NovaTerminal.McpServer.Tools;
+
+namespace NovaTerminal.McpServer.Tests;
+
+/// <summary>
+/// Client-side tests for the agent-host observe channel (milestone A1, PR4).
+/// The endpoint here is a minimal in-test fake speaking the contracts frame
+/// protocol — the real server lives in the app and is tested there; these
+/// tests pin the client's discovery, unavailability, and round-trip behavior.
+/// </summary>
+public class AgentHostClientTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public AgentHostClientTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "nova-agentclient-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
+        GC.SuppressFinalize(this);
+    }
+
+    private string DiscoveryPath => Path.Combine(_tempDir, AgentHostProtocol.DiscoveryFileName);
+
+    private void WriteDescriptor(string endpoint, int? pid = null)
+    {
+        var descriptor = new EndpointDescriptor
+        {
+            Version = AgentHostProtocol.Version,
+            Endpoint = endpoint,
+            Pid = pid ?? Environment.ProcessId,
+        };
+        File.WriteAllText(DiscoveryPath, JsonSerializer.Serialize(descriptor, AgentHostJsonContext.Default.EndpointDescriptor));
+    }
+
+    [Fact]
+    public async Task Missing_discovery_file_reports_unavailable_with_guidance()
+    {
+        var client = new AgentHostClient(DiscoveryPath);
+        var outcome = await client.CallAsync(AgentHostProtocol.Methods.ListSessions, null, TestContext.Current.CancellationToken);
+
+        Assert.False(outcome.Available);
+        Assert.Equal(AgentHostClient.UnavailableMessage, outcome.UnavailableReason);
+    }
+
+    [Fact]
+    public async Task Truncated_descriptor_is_treated_as_retired()
+    {
+        // The app truncates (never deletes) the descriptor on stop.
+        File.WriteAllText(DiscoveryPath, string.Empty);
+        var client = new AgentHostClient(DiscoveryPath);
+
+        var outcome = await client.CallAsync(AgentHostProtocol.Methods.ListSessions, null, TestContext.Current.CancellationToken);
+
+        Assert.False(outcome.Available);
+    }
+
+    [Fact]
+    public async Task Dead_pid_descriptor_is_treated_as_stale()
+    {
+        // Pid 4_000_000 is above the Windows/Linux practical pid ranges used in
+        // CI; GetProcessById throws → stale.
+        WriteDescriptor("nonexistent-endpoint", pid: 4_000_000);
+        var client = new AgentHostClient(DiscoveryPath);
+
+        var outcome = await client.CallAsync(AgentHostProtocol.Methods.ListSessions, null, TestContext.Current.CancellationToken);
+
+        Assert.False(outcome.Available);
+    }
+
+    [Fact]
+    public async Task Round_trips_a_list_sessions_call_against_a_live_endpoint()
+    {
+        var endpoint = OperatingSystem.IsWindows()
+            ? "novaterminal-agent-client-test-" + Guid.NewGuid().ToString("N")
+            : Path.Combine(_tempDir, "t.sock");
+
+        var sessions = new ListSessionsResult
+        {
+            Sessions = new[]
+            {
+                new SessionInfo
+                {
+                    PaneId = Guid.NewGuid(),
+                    Title = "vim",
+                    ProfileName = "Bash",
+                    Kind = "local",
+                    Rows = 24,
+                    Cols = 80,
+                    IsActive = true,
+                },
+            },
+        };
+
+        using var serverCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var serverTask = RunFakeEndpointOnceAsync(endpoint, sessions, serverCts.Token);
+        WriteDescriptor(endpoint);
+
+        var client = new AgentHostClient(DiscoveryPath);
+        var outcome = await client.CallAsync(AgentHostProtocol.Methods.ListSessions, null, TestContext.Current.CancellationToken);
+
+        Assert.True(outcome.Available, outcome.UnavailableReason);
+        Assert.Null(outcome.Response!.Error);
+        var roundTripped = outcome.Response.Result!.Value.Deserialize(AgentHostJsonContext.Default.ListSessionsResult);
+        Assert.Equal("vim", Assert.Single(roundTripped!.Sessions).Title);
+
+        await serverTask.WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
+    /// <summary>Serves exactly one connection and one request, then exits.</summary>
+    private static async Task RunFakeEndpointOnceAsync(string endpoint, ListSessionsResult reply, CancellationToken token)
+    {
+        Stream stream;
+        if (OperatingSystem.IsWindows())
+        {
+            var pipe = new NamedPipeServerStream(endpoint, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+            await pipe.WaitForConnectionAsync(token);
+            stream = pipe;
+        }
+        else
+        {
+            using var listener = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+            listener.Bind(new UnixDomainSocketEndPoint(endpoint));
+            listener.Listen(1);
+            var socket = await listener.AcceptAsync(token);
+            stream = new NetworkStream(socket, ownsSocket: true);
+        }
+
+        await using (stream)
+        {
+            using var reader = new StreamReader(stream, new UTF8Encoding(false), leaveOpen: true);
+            await using var writer = new StreamWriter(stream, new UTF8Encoding(false), leaveOpen: true) { AutoFlush = true };
+
+            var line = await reader.ReadLineAsync(token);
+            var request = JsonSerializer.Deserialize(line!, AgentHostJsonContext.Default.AgentHostRequest)!;
+            var response = new AgentHostResponse
+            {
+                Version = AgentHostProtocol.Version,
+                Id = request.Id,
+                Result = JsonSerializer.SerializeToElement(reply, AgentHostJsonContext.Default.ListSessionsResult),
+            };
+            await writer.WriteLineAsync(JsonSerializer.Serialize(response, AgentHostJsonContext.Default.AgentHostResponse).AsMemory(), token);
+        }
+    }
+}
+
+/// <summary>Formatter tests: the shapes agents actually read.</summary>
+public class SessionToolsFormattingTests
+{
+    [Fact]
+    public void FormatSessionList_renders_a_row_per_session_and_handles_null_tab()
+    {
+        var paneId = Guid.NewGuid();
+        var text = SessionTools.FormatSessionList(new[]
+        {
+            new SessionInfo
+            {
+                PaneId = paneId, Title = "htop", ProfileName = "Zsh", Kind = "ssh",
+                Rows = 40, Cols = 120, IsActive = false, TabId = null,
+            },
+        });
+
+        Assert.Contains(paneId.ToString(), text, StringComparison.Ordinal);
+        Assert.Contains("| htop | Zsh | ssh | 120x40 | no | - |", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatScreen_numbers_lines_and_reports_cursor()
+    {
+        var text = SessionTools.FormatScreen(new ScreenSnapshotDto
+        {
+            Lines = new[] { "hello", "world" },
+            CursorRow = 1,
+            CursorCol = 5,
+            CursorVisible = true,
+            Rows = 24,
+            Cols = 80,
+        });
+
+        Assert.Contains("cursor at row 1, col 5", text, StringComparison.Ordinal);
+        Assert.Contains("  0| hello", text, StringComparison.Ordinal);
+        Assert.Contains("  1| world", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatScrollback_reports_range_and_paging_hint()
+    {
+        var text = SessionTools.FormatScrollback(new ReadScrollbackResult
+        {
+            Lines = new[] { "a", "b" },
+            StartLine = 10,
+            TotalLines = 100,
+        });
+
+        Assert.Contains("lines 10–11 of 100", text, StringComparison.Ordinal);
+        Assert.Contains("startLine=12", text, StringComparison.Ordinal);
+        Assert.Contains("   10| a", text, StringComparison.Ordinal);
+    }
+}

--- a/tests/NovaTerminal.McpServer.Tests/McpServerStdioE2ETests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/McpServerStdioE2ETests.cs
@@ -36,6 +36,9 @@ public class McpServerStdioE2ETests
         "novaterminal.validate_settings_json",
         "novaterminal.generate_codex_prompt_for_issue",
         "novaterminal.suggest_relevant_files",
+        "novaterminal.list_sessions",
+        "novaterminal.read_screen",
+        "novaterminal.read_scrollback",
     };
 
     [Fact]


### PR DESCRIPTION
## Summary

PR4 — the final slice of milestone **A1 (Observe)** (`docs/agent-host/DIRECTION.md`): the MCP server can now read live terminal sessions from the running app. With this merged, any MCP-capable agent (Claude Code, Codex CLI, …) can `list_sessions` → `read_screen` / `read_scrollback` end-to-end — observe-only, and only while the user has **Settings → Agent access (observe)** enabled. Follows #183 (contracts + registry) and #184 (endpoint + toggle).

## What's included

### `AgentHostClient` (`src/NovaTerminal.McpServer/AgentHostClient.cs`)
- Discovers the endpoint via the descriptor file; treats missing / truncated (retired) / version-mismatched / dead-pid descriptors as **unavailable** — a normal result with fixed guidance text, never an exception.
- Connects per call (named pipe on Windows, unix socket elsewhere) with connect/round-trip timeouts; speaks the contracts frame protocol via the source-generated JSON context.

### New MCP tools (`Tools/SessionTools.cs`)
- `novaterminal.list_sessions` — pane id, title, profile, kind, size, active state, tab
- `novaterminal.read_screen` — numbered viewport lines + cursor position/visibility; optional per-row attribute encodings
- `novaterminal.read_scrollback` — ranged + capped, oldest first, with a paging hint (`startLine=<next>`) and totals

### Shared discovery path (`AgentHostDiscovery` in the contracts leaf)
App (writer) and MCP server (reader) share no assemblies except the contracts leaf, so the discovery-path resolution now lives there — mirroring `AppPaths.RootDirectory` including the `NOVATERM_APPDATA_ROOT` override — and the app's `AgentHostService` uses it too. One path by construction, no drift.

### Policy note
`NovaTerminal.McpServer.csproj` previously documented "no ProjectReferences, must never touch terminal sessions". Per the accepted direction this changes deliberately: the **only** allowed solution dependency is the zero-reference contracts leaf, and session access is observe-only behind the user's opt-in. The csproj comment now states the new rule; App/VT/Platform remain forbidden.

## Tests

- `AgentHostClientTests`: unavailable on missing discovery file (with guidance text), truncated descriptor treated as retired, dead-pid descriptor treated as stale, and a full round trip against an in-test fake endpoint speaking the frame protocol (pipe on Windows / unix socket on Linux & macOS)
- `SessionToolsFormattingTests`: session table (incl. null tab), screen rendering with cursor report, scrollback range + paging hint
- E2E stdio handshake updated: tool list is now exactly 18
- Suites: McpServer 122/122 (7 new), Architecture 18/18

## Docs

- README: contracts library added to the module list; McpServer description now includes opt-in observe access
- `docs/agent-host/DIRECTION.md`: A1 deliverables checked off (demo recording remains)
