### PR TITLE
feat(agent-host): A2 session status state machine with confidence tiers

### DIFF
--- a/docs/plans/2026-07-07-agent-host-a2-status-design.md
+++ b/docs/plans/2026-07-07-agent-host-a2-status-design.md
@@ -1,0 +1,170 @@
+# Agent Host A2 (Status & Notifications) Design
+
+Milestone **A2** of `docs/agent-host/DIRECTION.md`: agents can ask what a
+session is *doing* — running, waiting for input, idle, exited — and wait for
+completion/stall events instead of polling screens. Also absorbs ROADMAP §5.2
+(automation hooks / OS notifications). Builds directly on the A1 surface
+(#183, #184, #185).
+
+## Goal
+
+Expose per-session status and an event channel:
+
+- `novaterminal.get_session_status` — current status with confidence tier
+- `novaterminal.wait_for_events` — long-poll for status changes, command
+  completion, bells, and stalls
+- status summary included in `novaterminal.list_sessions`
+- optional user-facing notification when a long-running command finishes
+
+The change must:
+
+- derive status from **owned signals** (PTY process state, shell-integration
+  events, alt-screen state) — never from screen scraping
+- be explicit about precision: a `confidence` field distinguishes
+  shell-integration-backed status from PTY-only heuristics
+- keep every stall/idle definition explicit and testable (fixed thresholds,
+  injectable clock) — no untestable heuristics
+- stay observe-only and behind the existing `Agent Access (observe)` toggle;
+  protocol changes are strictly additive (version stays 1)
+
+## Current State
+
+Signals that already exist, per pane:
+
+- **PTY truth (always available)** — `ITerminalLifecycle`
+  (`src/NovaTerminal.Pty/ITerminalSession.cs`): `IsProcessRunning`,
+  `HasActiveChildProcesses`, `ExitCode`, `OnExit`; `ITerminalIO.OnOutputReceived`.
+- **Shell integration (precise, opt-in)** — `ShellLifecycleTracker`
+  (`src/NovaTerminal.App/CommandAssist/ShellIntegration/Runtime/`):
+  `PromptReady`, `CommandAccepted`, `CommandStarted`,
+  `CommandFinished(exitCode, duration)`, `WorkingDirectoryChanged`, already
+  surfaced as `TerminalPane` events (`CommandStarted`, `CommandFinished`,
+  `ProcessExited`, `OutputReceived`, `BellReceived`).
+- **VT state** — `TerminalBuffer.IsAltScreenActive` (a TUI owns the screen).
+- The agent-host registry (`AgentSessionRegistration`) already holds a
+  lock-protected metadata snapshot pushed from the UI thread; status extends
+  the same pattern.
+
+Nothing about "status" crosses the IPC boundary today.
+
+## Status Model
+
+One enum, two confidence tiers.
+
+| Status | Precise (shell integration active) | Heuristic (PTY-only) |
+|---|---|---|
+| `running` | between `CommandStarted` and `CommandFinished`, or alt-screen active | `HasActiveChildProcesses`, or alt-screen active |
+| `awaitingInput` | `PromptReady` seen since last command | process alive, no active children, not alt-screen |
+| `idle` | `awaitingInput` with no output/input for `IdleThresholdSeconds` (default 60) | same, from heuristic `awaitingInput` |
+| `exited` | `OnExit` fired / `!IsProcessRunning`; carries `ExitCode` | same (PTY truth in both tiers) |
+
+Stall is an **event**, not a status: `running` with no output for
+`StallThresholdSeconds` (default 30) emits `stalled`; output resumption emits
+`statusChanged(running)`. Definitions live in contracts constants; both
+thresholds are server-side and reported in the status DTO so clients never
+hard-code them.
+
+`confidence` is `precise` when the pane's shell integration is active,
+`heuristic` otherwise. Agents (and Warp-style comparisons) get honesty for
+free: NovaTerminal reports *how* it knows, which tmux-layer scrapers cannot.
+
+## Architecture
+
+### App side
+
+- `AgentHost/AgentSessionStatus.cs` — immutable status snapshot:
+  `{ Status, Confidence, ExitCode?, CurrentCommand?, StatusSinceMs,
+  LastOutputAtMs, StallThresholdSeconds, IdleThresholdSeconds }`.
+- `AgentSessionRegistration` gains a lock-protected `Status` slot plus an
+  `ApplySignal(...)` reducer — a pure state machine with an injectable clock,
+  mirroring `ShellLifecycleTracker`'s testability pattern.
+- `TerminalPane` wiring (all UI-thread, same touch points as the A1 snapshot
+  pushes): `OutputReceived`, `CommandStarted`, `CommandFinished`,
+  `ProcessExited`, `BellReceived`, shell-integration prompt events, and
+  `Buffer.OnScreenSwitched` for alt-screen transitions.
+- **Timers:** one shared 1 s tick in `AgentHostService` (running only while
+  the endpoint is up) sweeps registrations for idle/stall transitions. No
+  per-session timers; cost is O(open panes) per second, only when the user
+  opted in.
+- **Event ring:** a bounded per-service ring buffer (256 entries, monotonically
+  increasing `seq`, oldest evicted) of
+  `{ seq, timestampMs, paneId, type, exitCode?, durationMs? }` where `type` ∈
+  `statusChanged | commandFinished | bell | stalled | sessionOpened |
+  sessionClosed`. Long-pollers read from a cursor; eviction is reported via
+  the response's `oldestSeq` so a lapsed client knows it missed events.
+
+### Protocol (additive; version stays 1)
+
+- `getSessionStatus { paneId }` → status DTO
+- `waitForEvents { sinceSeq, timeoutMs }` → `{ events[], nextSeq, oldestSeq }`
+  — returns immediately if events exist past the cursor, otherwise parks up to
+  `timeoutMs` (server-capped at 25 s, under the client's 30 s guard) and
+  returns empty on timeout. One long-poll per connection at a time.
+- `SessionInfo` gains optional `status` + `confidence` fields (omitted when
+  unknown, same nullable-field pattern as `tabId`).
+
+### MCP tools
+
+- `novaterminal.get_session_status` — one session's status, human-readable
+- `novaterminal.wait_for_events` — long-poll wrapper; the tool description
+  teaches the cursor protocol ("pass nextSeq from the previous call")
+- `novaterminal.list_sessions` — status column added
+
+### Notifications (ROADMAP §5.2 absorbed)
+
+App-side and independent of agents: when `CommandFinished` arrives with
+`duration >= NotifyAfterSeconds` (default 30) for an unfocused pane, raise the
+existing in-app toast; OS-native notifications (Windows toast / macOS
+UNUserNotification / libnotify) ride the same event behind
+`LongCommandNotificationsEnabled` (default off, settings toggle). This ships
+last and is UI-only — no protocol involvement.
+
+## Alternatives Considered
+
+**Push events over a persistent stream instead of long-poll** — a second frame
+type and connection lifecycle complexity for no A2 benefit; MCP tools are
+request/response anyway. The ring + cursor gives at-least-once delivery with
+explicit loss reporting, which is enough for "tell me when it finishes".
+
+**Foreground-process inspection for better heuristics** (read the PTY's
+foreground process name à la tmux) — platform-specific, racy, and the payoff
+is small next to shell integration, which we already ship. Deferred; the
+`confidence` field leaves room for it.
+
+**Status computed on demand instead of event-driven** — polling
+`HasActiveChildProcesses` per request would miss transitions between polls
+(no events possible) and does process-tree walks on the request path.
+Event-driven with a 1 s sweep is deterministic and testable.
+
+## Testing
+
+- **State machine (pure):** signal sequences × both confidence tiers →
+  expected status transitions, with a fake clock driving idle/stall
+  thresholds. Exhaustive table tests, no UI.
+- **Replay-driven:** the shell-integration events originate in the parser, so
+  recorded fixtures (existing Command Assist lanes) drive
+  `running → awaitingInput` transitions deterministically — per the
+  DIRECTION acceptance criterion.
+- **Event ring:** cursor semantics, eviction reporting (`oldestSeq`),
+  long-poll wake-on-event and timeout-returns-empty, one-poller-per-connection.
+- **IPC/tools:** `wait_for_events` round trip over the real transport;
+  status field appears in `list_sessions`; unknown pane → `sessionNotFound`.
+- **Off-is-off:** no timer runs and no ring exists while Agent Access is
+  disabled (the sweep lives inside `AgentHostService`'s lifecycle).
+
+## Out of Scope
+
+- Acting on sessions (A3), replay export (A4)
+- Foreground-process name reporting (future heuristic upgrade)
+- Notification actions/deep-links ("click to focus pane") — UI follow-up
+
+## Suggested PR Slicing
+
+1. Status model + reducer + pane wiring + state-machine tests (no protocol
+   change; registry-internal)
+2. Protocol additions: `getSessionStatus`, `waitForEvents`, event ring,
+   `SessionInfo.status` + endpoint tests
+3. MCP tools + client long-poll support + tests
+4. Long-command notifications (toast + settings toggle) + docs
+
+Each step keeps CI green and is independently shippable.

--- a/src/NovaTerminal.App/AgentHost/AgentSessionRegistration.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentSessionRegistration.cs
@@ -31,7 +31,8 @@ namespace NovaTerminal.AgentHost
             string title,
             string profileName,
             string kind,
-            bool isActive)
+            bool isActive,
+            Func<DateTimeOffset>? nowProvider = null)
         {
             ArgumentNullException.ThrowIfNull(buffer);
             _paneId = paneId;
@@ -40,7 +41,14 @@ namespace NovaTerminal.AgentHost
             _profileName = profileName;
             _kind = kind;
             _isActive = isActive;
+            StatusMachine = new AgentSessionStatusMachine(nowProvider);
         }
+
+        /// <summary>
+        /// Per-session status state machine (A2). Signals are pushed by the
+        /// pane on the UI thread; snapshots are safe from any thread.
+        /// </summary>
+        public AgentSessionStatusMachine StatusMachine { get; }
 
         /// <summary>The pane's VT buffer. Reads must take <see cref="TerminalBuffer.Lock"/> (endpoint milestone A1/PR3).</summary>
         public TerminalBuffer Buffer { get; }

--- a/src/NovaTerminal.App/AgentHost/AgentSessionStatus.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentSessionStatus.cs
@@ -1,0 +1,67 @@
+using System;
+
+namespace NovaTerminal.AgentHost
+{
+    /// <summary>What a session is doing right now (agent-host A2 status model).</summary>
+    public enum AgentSessionStatusKind
+    {
+        /// <summary>A command or full-screen TUI is executing.</summary>
+        Running,
+
+        /// <summary>The shell is at a prompt waiting for input.</summary>
+        AwaitingInput,
+
+        /// <summary>At a prompt with no activity for <see cref="AgentSessionStatusMachine.IdleThresholdSeconds"/>.</summary>
+        Idle,
+
+        /// <summary>The session's process has exited.</summary>
+        Exited,
+    }
+
+    /// <summary>
+    /// How the status was derived. Precise means shell-integration events
+    /// (prompt/command lifecycle) are driving the machine; heuristic means
+    /// PTY-level signals only (child processes, alt screen, output activity).
+    /// </summary>
+    public enum AgentSessionStatusConfidence
+    {
+        Heuristic,
+        Precise,
+    }
+
+    public enum AgentSessionEventType
+    {
+        StatusChanged,
+        CommandFinished,
+        Bell,
+        Stalled,
+    }
+
+    /// <summary>Point-in-time status, safe to read from any thread via <see cref="AgentSessionStatusMachine.Snapshot"/>.</summary>
+    public sealed record AgentSessionStatusSnapshot
+    {
+        public required AgentSessionStatusKind Kind { get; init; }
+        public required AgentSessionStatusConfidence Confidence { get; init; }
+        public int? ExitCode { get; init; }
+        public string? CurrentCommand { get; init; }
+        public required DateTimeOffset StatusSince { get; init; }
+        public required DateTimeOffset LastOutputAt { get; init; }
+        public required bool IsStalled { get; init; }
+        public int StallThresholdSeconds { get; init; } = AgentSessionStatusMachine.StallThresholdSeconds;
+        public int IdleThresholdSeconds { get; init; } = AgentSessionStatusMachine.IdleThresholdSeconds;
+    }
+
+    /// <summary>
+    /// A transition emitted by the status machine. PR2 of the A2 design feeds
+    /// these into the event ring behind <c>waitForEvents</c>; until then they
+    /// exist for tests and future consumers.
+    /// </summary>
+    public sealed record AgentSessionStatusEvent
+    {
+        public required AgentSessionEventType Type { get; init; }
+        public required AgentSessionStatusKind Status { get; init; }
+        public required DateTimeOffset Timestamp { get; init; }
+        public int? ExitCode { get; init; }
+        public TimeSpan? Duration { get; init; }
+    }
+}

--- a/src/NovaTerminal.App/AgentHost/AgentSessionStatusMachine.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentSessionStatusMachine.cs
@@ -108,6 +108,11 @@ namespace NovaTerminal.AgentHost
                 _promptSeen = true;
                 _commandInFlight = true;
                 _commandStartedAt = now;
+                // A new command starts a fresh silence episode: without this, a
+                // stall from the previous command would leak into this one (an
+                // immediate IsStalled=true and no fresh stalled event later).
+                _lastOutputAt = now;
+                _stalled = false;
                 return null;
             });
         }
@@ -208,19 +213,34 @@ namespace NovaTerminal.AgentHost
 
         // ── Internals ───────────────────────────────────────────────────────
 
+        // Pending events plus a single-drainer flag: signals arrive from the UI
+        // thread while Sweep runs on the endpoint's timer thread, so releasing
+        // the gate before invoking handlers could deliver events out of the
+        // order they were generated. Events are enqueued under the gate and
+        // drained by exactly one thread at a time, preserving global order
+        // without ever invoking handlers while holding the gate.
+        private readonly Queue<AgentSessionStatusEvent> _pendingEvents = new();
+        private bool _draining;
+
         /// <summary>
         /// Mutates under the lock, recomputes the derived status, and raises
         /// any events (mutation-specific ones plus StatusChanged) outside the
-        /// lock, preserving order.
+        /// lock, in generation order.
         /// </summary>
         private void RunUnderGate(Func<DateTimeOffset, List<AgentSessionStatusEvent>?> mutate)
         {
-            List<AgentSessionStatusEvent>? toRaise;
             lock (_gate)
             {
                 var now = _now();
                 var before = _kind;
-                toRaise = mutate(now);
+                var produced = mutate(now);
+                if (produced != null)
+                {
+                    foreach (var evt in produced)
+                    {
+                        _pendingEvents.Enqueue(evt);
+                    }
+                }
 
                 var after = ComputeKind(now);
                 if (after != before)
@@ -231,16 +251,43 @@ namespace NovaTerminal.AgentHost
                     {
                         _stalled = false; // stall is a running-only condition
                     }
-                    (toRaise ??= new List<AgentSessionStatusEvent>()).Add(
+                    _pendingEvents.Enqueue(
                         MakeEvent(AgentSessionEventType.StatusChanged, after, now, _exited ? _exitCode : null));
                 }
+
+                if (_draining || _pendingEvents.Count == 0)
+                {
+                    return; // another thread is already delivering, or nothing to deliver
+                }
+                _draining = true;
             }
 
-            if (toRaise != null)
+            DrainPendingEvents();
+        }
+
+        private void DrainPendingEvents()
+        {
+            while (true)
             {
-                foreach (var evt in toRaise)
+                AgentSessionStatusEvent next;
+                lock (_gate)
                 {
-                    EventEmitted?.Invoke(evt);
+                    if (_pendingEvents.Count == 0)
+                    {
+                        _draining = false;
+                        return;
+                    }
+                    next = _pendingEvents.Dequeue();
+                }
+
+                try
+                {
+                    EventEmitted?.Invoke(next);
+                }
+                catch
+                {
+                    lock (_gate) { _draining = false; }
+                    throw;
                 }
             }
         }

--- a/src/NovaTerminal.App/AgentHost/AgentSessionStatusMachine.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentSessionStatusMachine.cs
@@ -1,0 +1,276 @@
+using System;
+using System.Collections.Generic;
+
+namespace NovaTerminal.AgentHost
+{
+    /// <summary>
+    /// Per-session status state machine for the agent-host A2 milestone
+    /// (docs/plans/2026-07-07-agent-host-a2-status-design.md).
+    ///
+    /// Signals arrive from the pane on the UI thread (PTY lifecycle, shell
+    /// integration, alt-screen switches); the periodic <see cref="Sweep"/>
+    /// contributes time-based transitions (idle, stall) and the PTY
+    /// child-process heuristic. All state is guarded by one lock;
+    /// <see cref="Snapshot"/> is safe from any thread. Events are collected
+    /// under the lock but raised outside it.
+    ///
+    /// The clock is injectable (same pattern as ShellLifecycleTracker) so
+    /// every threshold is deterministic in tests: stall = no output for
+    /// <see cref="StallThresholdSeconds"/> while running; idle = at a prompt
+    /// with no output for <see cref="IdleThresholdSeconds"/>.
+    /// </summary>
+    public sealed class AgentSessionStatusMachine
+    {
+        public const int StallThresholdSeconds = 30;
+        public const int IdleThresholdSeconds = 60;
+
+        private readonly object _gate = new();
+        private readonly Func<DateTimeOffset> _now;
+
+        // Signal state
+        private bool _precise;            // shell integration observed
+        private bool _commandInFlight;    // precise tier: between started/finished
+        private bool _promptSeen;         // precise tier: a prompt has appeared
+        private bool _altScreenActive;
+        private bool _hasActiveChildren;  // heuristic tier: from last sweep
+        private bool _exited;
+        private int? _exitCode;
+        private string? _currentCommand;
+        private DateTimeOffset? _commandStartedAt;
+
+        // Derived state
+        private AgentSessionStatusKind _kind;
+        private DateTimeOffset _statusSince;
+        private DateTimeOffset _lastOutputAt;
+        private bool _stalled;
+
+        /// <summary>Raised outside the lock, in emission order.</summary>
+        public event Action<AgentSessionStatusEvent>? EventEmitted;
+
+        public AgentSessionStatusMachine(Func<DateTimeOffset>? nowProvider = null)
+        {
+            _now = nowProvider ?? (() => DateTimeOffset.UtcNow);
+            var now = _now();
+            _statusSince = now;
+            _lastOutputAt = now;
+            // A fresh session has a live process and no known children yet.
+            _kind = AgentSessionStatusKind.AwaitingInput;
+        }
+
+        // ── Signals (UI thread) ─────────────────────────────────────────────
+
+        public void NotifyOutput()
+        {
+            RunUnderGate(now =>
+            {
+                _lastOutputAt = now;
+                if (_stalled)
+                {
+                    // Output resumed: the stall is over. Re-announce the current
+                    // status so event consumers see the recovery explicitly.
+                    _stalled = false;
+                    return new List<AgentSessionStatusEvent>
+                    {
+                        MakeEvent(AgentSessionEventType.StatusChanged, ComputeKind(now), now),
+                    };
+                }
+                return null;
+            });
+        }
+
+        public void NotifyPromptReady()
+        {
+            RunUnderGate(_ =>
+            {
+                _precise = true;
+                _promptSeen = true;
+                _commandInFlight = false;
+                _currentCommand = null;
+                return null;
+            });
+        }
+
+        public void NotifyCommandAccepted(string? commandText)
+        {
+            RunUnderGate(_ =>
+            {
+                _precise = true;
+                _currentCommand = string.IsNullOrWhiteSpace(commandText) ? null : commandText.Trim();
+                return null;
+            });
+        }
+
+        public void NotifyCommandStarted()
+        {
+            RunUnderGate(now =>
+            {
+                _precise = true;
+                _promptSeen = true;
+                _commandInFlight = true;
+                _commandStartedAt = now;
+                return null;
+            });
+        }
+
+        public void NotifyCommandFinished(int? exitCode)
+        {
+            RunUnderGate(now =>
+            {
+                _precise = true;
+                _commandInFlight = false;
+                var duration = _commandStartedAt.HasValue ? now - _commandStartedAt.Value : (TimeSpan?)null;
+                _commandStartedAt = null;
+                var events = new List<AgentSessionStatusEvent>
+                {
+                    MakeEvent(AgentSessionEventType.CommandFinished, ComputeKind(now), now, exitCode, duration),
+                };
+                _currentCommand = null;
+                return events;
+            });
+        }
+
+        public void NotifyBell()
+        {
+            RunUnderGate(now => new List<AgentSessionStatusEvent>
+            {
+                MakeEvent(AgentSessionEventType.Bell, ComputeKind(now), now),
+            });
+        }
+
+        public void NotifyAltScreenChanged(bool isAltScreenActive)
+        {
+            RunUnderGate(_ =>
+            {
+                _altScreenActive = isAltScreenActive;
+                return null;
+            });
+        }
+
+        public void NotifyExited(int exitCode)
+        {
+            RunUnderGate(_ =>
+            {
+                _exited = true;
+                _exitCode = exitCode;
+                _commandInFlight = false;
+                _currentCommand = null;
+                return null;
+            });
+        }
+
+        // ── Sweep (periodic; endpoint-owned in PR2) ─────────────────────────
+
+        /// <summary>
+        /// Contributes the time-based transitions and the child-process
+        /// heuristic. Idle and stall thresholds only ever fire here, so the
+        /// cadence of the caller bounds their latency (1 s in production).
+        /// </summary>
+        public void Sweep(bool hasActiveChildProcesses)
+        {
+            RunUnderGate(now =>
+            {
+                _hasActiveChildren = hasActiveChildProcesses;
+
+                if (!_exited
+                    && ComputeKind(now) == AgentSessionStatusKind.Running
+                    && !_stalled
+                    && now - _lastOutputAt >= TimeSpan.FromSeconds(StallThresholdSeconds))
+                {
+                    _stalled = true;
+                    return new List<AgentSessionStatusEvent>
+                    {
+                        MakeEvent(AgentSessionEventType.Stalled, AgentSessionStatusKind.Running, now),
+                    };
+                }
+                return null;
+            });
+        }
+
+        // ── Reads ───────────────────────────────────────────────────────────
+
+        public AgentSessionStatusSnapshot Snapshot()
+        {
+            lock (_gate)
+            {
+                var now = _now();
+                return new AgentSessionStatusSnapshot
+                {
+                    Kind = ComputeKind(now),
+                    Confidence = _precise ? AgentSessionStatusConfidence.Precise : AgentSessionStatusConfidence.Heuristic,
+                    ExitCode = _exitCode,
+                    CurrentCommand = _currentCommand,
+                    StatusSince = _statusSince,
+                    LastOutputAt = _lastOutputAt,
+                    IsStalled = _stalled,
+                };
+            }
+        }
+
+        // ── Internals ───────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Mutates under the lock, recomputes the derived status, and raises
+        /// any events (mutation-specific ones plus StatusChanged) outside the
+        /// lock, preserving order.
+        /// </summary>
+        private void RunUnderGate(Func<DateTimeOffset, List<AgentSessionStatusEvent>?> mutate)
+        {
+            List<AgentSessionStatusEvent>? toRaise;
+            lock (_gate)
+            {
+                var now = _now();
+                var before = _kind;
+                toRaise = mutate(now);
+
+                var after = ComputeKind(now);
+                if (after != before)
+                {
+                    _kind = after;
+                    _statusSince = now;
+                    if (after != AgentSessionStatusKind.Running)
+                    {
+                        _stalled = false; // stall is a running-only condition
+                    }
+                    (toRaise ??= new List<AgentSessionStatusEvent>()).Add(
+                        MakeEvent(AgentSessionEventType.StatusChanged, after, now, _exited ? _exitCode : null));
+                }
+            }
+
+            if (toRaise != null)
+            {
+                foreach (var evt in toRaise)
+                {
+                    EventEmitted?.Invoke(evt);
+                }
+            }
+        }
+
+        private AgentSessionStatusKind ComputeKind(DateTimeOffset now)
+        {
+            if (_exited) return AgentSessionStatusKind.Exited;
+            if (_altScreenActive) return AgentSessionStatusKind.Running;
+
+            bool running = _precise ? _commandInFlight : _hasActiveChildren;
+            if (running) return AgentSessionStatusKind.Running;
+
+            // At a prompt (precise) or no busy children (heuristic).
+            return now - _lastOutputAt >= TimeSpan.FromSeconds(IdleThresholdSeconds)
+                ? AgentSessionStatusKind.Idle
+                : AgentSessionStatusKind.AwaitingInput;
+        }
+
+        private static AgentSessionStatusEvent MakeEvent(
+            AgentSessionEventType type,
+            AgentSessionStatusKind status,
+            DateTimeOffset timestamp,
+            int? exitCode = null,
+            TimeSpan? duration = null) => new()
+            {
+                Type = type,
+                Status = status,
+                Timestamp = timestamp,
+                ExitCode = exitCode,
+                Duration = duration,
+            };
+    }
+}

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -403,6 +403,16 @@ namespace NovaTerminal.Controls
             TitleChanged += (_, _) => UpdateAgentSessionSnapshot();
             WorkingDirectoryChanged += (_, _) => UpdateAgentSessionSnapshot();
 
+            // A2 status signals (docs/plans/2026-07-07-agent-host-a2-status-design.md):
+            // PTY/shell lifecycle events feed the per-session status machine.
+            // Prompt/command-accepted signals are wired where the parser hooks
+            // are installed (InitializeSession); alt-screen in HandleAltScreenChanged.
+            OutputReceived += _ => _agentRegistration?.StatusMachine.NotifyOutput();
+            BellReceived += _ => _agentRegistration?.StatusMachine.NotifyBell();
+            CommandStarted += _ => _agentRegistration?.StatusMachine.NotifyCommandStarted();
+            CommandFinished += (_, exitCode) => _agentRegistration?.StatusMachine.NotifyCommandFinished(exitCode);
+            ProcessExited += (_, exitCode) => _agentRegistration?.StatusMachine.NotifyExited(exitCode);
+
             TermView.KeyDownInterceptor = TryHandleCommandAssistKey;
             TermView.TextInput += (_, e) =>
             {
@@ -1307,6 +1317,7 @@ namespace NovaTerminal.Controls
 
         private void HandleAltScreenChanged(bool isAltScreen)
         {
+            _agentRegistration?.StatusMachine.NotifyAltScreenChanged(isAltScreen);
             _commandAssistController?.HandleAltScreenChanged(isAltScreen);
             UpdateRemoteFilesSidebarVisibility();
             UpdateRemoteFilesSidebarEntryPointState();
@@ -1535,11 +1546,13 @@ namespace NovaTerminal.Controls
             Parser.OnPromptReady += () =>
             {
                 _shellLifecycleTracker?.HandlePromptReady();
+                _agentRegistration?.StatusMachine.NotifyPromptReady();
             };
             Parser.OnCommandAccepted += commandText =>
             {
                 _lastRelevantCommandText = commandText?.Trim();
                 _shellLifecycleTracker?.HandleCommandAccepted(commandText);
+                _agentRegistration?.StatusMachine.NotifyCommandAccepted(commandText);
             };
             Parser.OnCommandStarted += () =>
             {

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -404,13 +404,12 @@ namespace NovaTerminal.Controls
             WorkingDirectoryChanged += (_, _) => UpdateAgentSessionSnapshot();
 
             // A2 status signals (docs/plans/2026-07-07-agent-host-a2-status-design.md):
-            // PTY/shell lifecycle events feed the per-session status machine.
-            // Prompt/command-accepted signals are wired where the parser hooks
-            // are installed (InitializeSession); alt-screen in HandleAltScreenChanged.
+            // PTY lifecycle events feed the per-session status machine. Command
+            // lifecycle (started/finished) and prompt/accepted signals are wired
+            // synchronously at the parser hooks in InitializeSession so their
+            // relative order is preserved; alt-screen in HandleAltScreenChanged.
             OutputReceived += _ => _agentRegistration?.StatusMachine.NotifyOutput();
             BellReceived += _ => _agentRegistration?.StatusMachine.NotifyBell();
-            CommandStarted += _ => _agentRegistration?.StatusMachine.NotifyCommandStarted();
-            CommandFinished += (_, exitCode) => _agentRegistration?.StatusMachine.NotifyCommandFinished(exitCode);
             ProcessExited += (_, exitCode) => _agentRegistration?.StatusMachine.NotifyExited(exitCode);
 
             TermView.KeyDownInterceptor = TryHandleCommandAssistKey;
@@ -1557,6 +1556,11 @@ namespace NovaTerminal.Controls
             Parser.OnCommandStarted += () =>
             {
                 _shellLifecycleTracker?.HandleCommandStarted();
+                // Status machine is notified synchronously on the parser path so
+                // command-lifecycle signals keep their emission order relative to
+                // OnCommandAccepted/OnPromptReady (the UI post below would let a
+                // snapshot briefly see AwaitingInput with CurrentCommand set).
+                _agentRegistration?.StatusMachine.NotifyCommandStarted();
                 Dispatcher.UIThread.Post(() =>
                 {
                     LastExitCode = null;
@@ -1565,6 +1569,7 @@ namespace NovaTerminal.Controls
             };
             Parser.OnCommandFinished += exitCode =>
             {
+                _agentRegistration?.StatusMachine.NotifyCommandFinished(exitCode);
                 Dispatcher.UIThread.Post(() =>
                 {
                     if (exitCode.HasValue)

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentSessionStatusMachineTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentSessionStatusMachineTests.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NovaTerminal.AgentHost;
+
+namespace NovaTerminal.AppTests.AgentHost;
+
+/// <summary>
+/// Deterministic tests for the A2 status state machine
+/// (docs/plans/2026-07-07-agent-host-a2-status-design.md). A fake clock
+/// drives every time-based threshold; no UI, no timers, no PTY.
+/// </summary>
+public class AgentSessionStatusMachineTests
+{
+    private sealed class FakeClock
+    {
+        public DateTimeOffset Now { get; private set; } = new(2026, 7, 7, 12, 0, 0, TimeSpan.Zero);
+        public void Advance(TimeSpan by) => Now += by;
+        public Func<DateTimeOffset> Provider => () => Now;
+    }
+
+    private static (AgentSessionStatusMachine Machine, FakeClock Clock, List<AgentSessionStatusEvent> Events) Make()
+    {
+        var clock = new FakeClock();
+        var machine = new AgentSessionStatusMachine(clock.Provider);
+        var events = new List<AgentSessionStatusEvent>();
+        machine.EventEmitted += events.Add;
+        return (machine, clock, events);
+    }
+
+    [Fact]
+    public void Fresh_session_is_awaiting_input_with_heuristic_confidence()
+    {
+        var (machine, _, _) = Make();
+        var snapshot = machine.Snapshot();
+
+        Assert.Equal(AgentSessionStatusKind.AwaitingInput, snapshot.Kind);
+        Assert.Equal(AgentSessionStatusConfidence.Heuristic, snapshot.Confidence);
+        Assert.False(snapshot.IsStalled);
+    }
+
+    [Fact]
+    public void Precise_command_lifecycle_drives_running_then_awaiting_input()
+    {
+        var (machine, _, events) = Make();
+
+        machine.NotifyPromptReady();
+        Assert.Equal(AgentSessionStatusKind.AwaitingInput, machine.Snapshot().Kind);
+        Assert.Equal(AgentSessionStatusConfidence.Precise, machine.Snapshot().Confidence);
+
+        machine.NotifyCommandAccepted("cargo build");
+        machine.NotifyCommandStarted();
+        var running = machine.Snapshot();
+        Assert.Equal(AgentSessionStatusKind.Running, running.Kind);
+        Assert.Equal("cargo build", running.CurrentCommand);
+
+        machine.NotifyCommandFinished(exitCode: 0);
+        Assert.Equal(AgentSessionStatusKind.AwaitingInput, machine.Snapshot().Kind);
+        Assert.Null(machine.Snapshot().CurrentCommand);
+
+        Assert.Contains(events, e => e.Type == AgentSessionEventType.StatusChanged && e.Status == AgentSessionStatusKind.Running);
+        Assert.Contains(events, e => e.Type == AgentSessionEventType.CommandFinished && e.ExitCode == 0);
+    }
+
+    [Fact]
+    public void CommandFinished_reports_duration_from_the_injected_clock()
+    {
+        var (machine, clock, events) = Make();
+        machine.NotifyCommandStarted();
+        clock.Advance(TimeSpan.FromSeconds(42));
+        machine.NotifyCommandFinished(exitCode: 1);
+
+        var finished = Assert.Single(events, e => e.Type == AgentSessionEventType.CommandFinished);
+        Assert.Equal(TimeSpan.FromSeconds(42), finished.Duration);
+        Assert.Equal(1, finished.ExitCode);
+    }
+
+    [Fact]
+    public void Heuristic_tier_uses_child_processes_from_the_sweep()
+    {
+        var (machine, _, _) = Make();
+
+        machine.Sweep(hasActiveChildProcesses: true);
+        Assert.Equal(AgentSessionStatusKind.Running, machine.Snapshot().Kind);
+        Assert.Equal(AgentSessionStatusConfidence.Heuristic, machine.Snapshot().Confidence);
+
+        machine.Sweep(hasActiveChildProcesses: false);
+        Assert.Equal(AgentSessionStatusKind.AwaitingInput, machine.Snapshot().Kind);
+    }
+
+    [Fact]
+    public void Alt_screen_forces_running_in_both_tiers()
+    {
+        var (machine, _, _) = Make();
+        machine.NotifyAltScreenChanged(true);
+        Assert.Equal(AgentSessionStatusKind.Running, machine.Snapshot().Kind);
+
+        // Even precise "at prompt" state is overridden while a TUI owns the screen.
+        machine.NotifyPromptReady();
+        Assert.Equal(AgentSessionStatusKind.Running, machine.Snapshot().Kind);
+
+        machine.NotifyAltScreenChanged(false);
+        Assert.Equal(AgentSessionStatusKind.AwaitingInput, machine.Snapshot().Kind);
+    }
+
+    [Fact]
+    public void Idle_requires_the_documented_threshold_without_output()
+    {
+        var (machine, clock, events) = Make();
+        machine.NotifyPromptReady();
+
+        clock.Advance(TimeSpan.FromSeconds(AgentSessionStatusMachine.IdleThresholdSeconds - 1));
+        machine.Sweep(hasActiveChildProcesses: false);
+        Assert.Equal(AgentSessionStatusKind.AwaitingInput, machine.Snapshot().Kind);
+
+        clock.Advance(TimeSpan.FromSeconds(2));
+        machine.Sweep(hasActiveChildProcesses: false);
+        Assert.Equal(AgentSessionStatusKind.Idle, machine.Snapshot().Kind);
+        Assert.Contains(events, e => e.Type == AgentSessionEventType.StatusChanged && e.Status == AgentSessionStatusKind.Idle);
+
+        // Output wakes it back up.
+        machine.NotifyOutput();
+        Assert.Equal(AgentSessionStatusKind.AwaitingInput, machine.Snapshot().Kind);
+    }
+
+    [Fact]
+    public void Stall_fires_once_while_running_and_recovers_on_output()
+    {
+        var (machine, clock, events) = Make();
+        machine.NotifyCommandStarted();
+
+        clock.Advance(TimeSpan.FromSeconds(AgentSessionStatusMachine.StallThresholdSeconds));
+        machine.Sweep(hasActiveChildProcesses: true);
+        machine.Sweep(hasActiveChildProcesses: true); // second sweep must not re-emit
+
+        Assert.Single(events, e => e.Type == AgentSessionEventType.Stalled);
+        Assert.True(machine.Snapshot().IsStalled);
+        Assert.Equal(AgentSessionStatusKind.Running, machine.Snapshot().Kind);
+
+        machine.NotifyOutput();
+        Assert.False(machine.Snapshot().IsStalled);
+        Assert.Contains(events, e => e.Type == AgentSessionEventType.StatusChanged && e.Status == AgentSessionStatusKind.Running);
+
+        // A fresh silence stalls again — it's a per-episode event, not one-shot.
+        clock.Advance(TimeSpan.FromSeconds(AgentSessionStatusMachine.StallThresholdSeconds));
+        machine.Sweep(hasActiveChildProcesses: true);
+        Assert.Equal(2, events.Count(e => e.Type == AgentSessionEventType.Stalled));
+    }
+
+    [Fact]
+    public void Stall_does_not_fire_at_a_prompt()
+    {
+        var (machine, clock, events) = Make();
+        machine.NotifyPromptReady();
+
+        clock.Advance(TimeSpan.FromSeconds(AgentSessionStatusMachine.StallThresholdSeconds + 5));
+        machine.Sweep(hasActiveChildProcesses: false);
+
+        Assert.DoesNotContain(events, e => e.Type == AgentSessionEventType.Stalled);
+        Assert.False(machine.Snapshot().IsStalled);
+    }
+
+    [Fact]
+    public void Exit_is_terminal_and_carries_the_exit_code()
+    {
+        var (machine, _, events) = Make();
+        machine.NotifyCommandStarted();
+        machine.NotifyExited(137);
+
+        var snapshot = machine.Snapshot();
+        Assert.Equal(AgentSessionStatusKind.Exited, snapshot.Kind);
+        Assert.Equal(137, snapshot.ExitCode);
+
+        // Nothing moves it off Exited.
+        machine.NotifyOutput();
+        machine.Sweep(hasActiveChildProcesses: true);
+        machine.NotifyPromptReady();
+        Assert.Equal(AgentSessionStatusKind.Exited, machine.Snapshot().Kind);
+
+        var exitEvent = Assert.Single(events, e => e.Type == AgentSessionEventType.StatusChanged && e.Status == AgentSessionStatusKind.Exited);
+        Assert.Equal(137, exitEvent.ExitCode);
+    }
+
+    [Fact]
+    public void Bell_emits_an_event_without_changing_status()
+    {
+        var (machine, _, events) = Make();
+        machine.NotifyBell();
+
+        Assert.Single(events, e => e.Type == AgentSessionEventType.Bell);
+        Assert.Equal(AgentSessionStatusKind.AwaitingInput, machine.Snapshot().Kind);
+    }
+
+    [Fact]
+    public void StatusSince_tracks_the_last_transition_not_the_last_signal()
+    {
+        var (machine, clock, _) = Make();
+        machine.NotifyCommandStarted();
+        var since = machine.Snapshot().StatusSince;
+
+        clock.Advance(TimeSpan.FromSeconds(5));
+        machine.NotifyOutput(); // no transition
+        Assert.Equal(since, machine.Snapshot().StatusSince);
+
+        clock.Advance(TimeSpan.FromSeconds(5));
+        machine.NotifyCommandFinished(0); // Running → AwaitingInput
+        Assert.NotEqual(since, machine.Snapshot().StatusSince);
+    }
+
+    [Fact]
+    public void Registration_exposes_a_status_machine()
+    {
+        var registration = new AgentSessionRegistration(
+            Guid.NewGuid(), new NovaTerminal.VT.TerminalBuffer(80, 24), "t", "p", "local", isActive: false);
+        Assert.NotNull(registration.StatusMachine);
+        Assert.Equal(AgentSessionStatusKind.AwaitingInput, registration.StatusMachine.Snapshot().Kind);
+    }
+}

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentSessionStatusMachineTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentSessionStatusMachineTests.cs
@@ -148,6 +148,27 @@ public class AgentSessionStatusMachineTests
     }
 
     [Fact]
+    public void Stall_state_does_not_leak_into_the_next_command()
+    {
+        var (machine, clock, events) = Make();
+        machine.NotifyCommandStarted();
+        clock.Advance(TimeSpan.FromSeconds(AgentSessionStatusMachine.StallThresholdSeconds));
+        machine.Sweep(hasActiveChildProcesses: true);
+        Assert.True(machine.Snapshot().IsStalled);
+
+        // Next command begins before any output arrives (e.g. re-run from
+        // history): it starts a fresh silence episode, not pre-stalled.
+        machine.NotifyCommandFinished(exitCode: 124);
+        machine.NotifyCommandStarted();
+        Assert.False(machine.Snapshot().IsStalled);
+
+        // And the new command can stall again with its own event.
+        clock.Advance(TimeSpan.FromSeconds(AgentSessionStatusMachine.StallThresholdSeconds));
+        machine.Sweep(hasActiveChildProcesses: true);
+        Assert.Equal(2, events.Count(e => e.Type == AgentSessionEventType.Stalled));
+    }
+
+    [Fact]
     public void Stall_does_not_fire_at_a_prompt()
     {
         var (machine, clock, events) = Make();


### PR DESCRIPTION
## Summary

PR 1 of milestone **A2 (Status & Notifications)** (design: `docs/plans/2026-07-07-agent-host-a2-status-design.md`): the per-session status state machine and its pane wiring. **Registry-internal — no protocol change, nothing reads this over IPC yet** (that's PR 2). Follows the A1 series (#183/#184/#185).

## Status model

One enum — `running` / `awaitingInput` / `idle` / `exited` — with a **confidence tier**: `precise` when shell-integration events (prompt ready, command started/finished) drive the machine, `heuristic` when only PTY signals (child processes, alt screen, output activity) are available. Stall is an **event**, not a status: `running` with no output for 30 s emits `stalled` once per silence episode; output resumption re-announces the status. Idle = at a prompt with no output for 60 s. Both thresholds are named constants reported in the snapshot, and only ever fire from the periodic `Sweep` — no hidden timers, no heuristics that can't be tested.

## What's included

- `AgentHost/AgentSessionStatusMachine` — lock-guarded reducer with an injectable clock (same testability pattern as `ShellLifecycleTracker`); signals mutate, `Sweep(hasActiveChildProcesses)` contributes time-based transitions and the child-process heuristic, `Snapshot()` is safe from any thread, events are collected under the lock and raised outside it in order.
- `AgentHost/AgentSessionStatus.cs` — status/confidence/event types + immutable snapshot record.
- `AgentSessionRegistration.StatusMachine` — one machine per registered session.
- `TerminalPane` wiring (all UI-thread, additive): `OutputReceived`, `BellReceived`, `CommandStarted`, `CommandFinished`, `ProcessExited` in `SetupCommon`; `Parser.OnPromptReady` / `OnCommandAccepted` at the existing parser hooks; alt-screen via `HandleAltScreenChanged`.

## Tests (12 new, all deterministic via fake clock)

Fresh-session default, precise command lifecycle (running → awaitingInput with `CurrentCommand` tracking), command duration from the injected clock, heuristic tier via sweep, alt-screen forcing `running` in both tiers, idle exactly at threshold + wake on output, stall fires once per episode / recovers on output / re-arms, stall never fires at a prompt, exit terminal with exit code, bell without status change, `StatusSince` tracking transitions not signals, registration exposure.

Suites: AgentHost 34/34.

## Next (A2 PR 2)

Protocol additions: `getSessionStatus`, `waitForEvents` (event ring + cursor long-poll), status field in `SessionInfo`, sweep timer inside `AgentHostService`'s lifecycle.
