### PR TITLE
feat(agent-host): A2 status protocol - getSessionStatus, waitForEvents event ring, sweep

### DIFF
--- a/src/NovaTerminal.AgentHost.Contracts/AgentHostJsonContext.cs
+++ b/src/NovaTerminal.AgentHost.Contracts/AgentHostJsonContext.cs
@@ -21,6 +21,11 @@ namespace NovaTerminal.AgentHost.Contracts;
 [JsonSerializable(typeof(ScreenSnapshotDto))]
 [JsonSerializable(typeof(ReadScrollbackParams))]
 [JsonSerializable(typeof(ReadScrollbackResult))]
+[JsonSerializable(typeof(GetSessionStatusParams))]
+[JsonSerializable(typeof(SessionStatusDto))]
+[JsonSerializable(typeof(AgentEventDto))]
+[JsonSerializable(typeof(WaitForEventsParams))]
+[JsonSerializable(typeof(WaitForEventsResult))]
 public sealed partial class AgentHostJsonContext : JsonSerializerContext
 {
 }

--- a/src/NovaTerminal.AgentHost.Contracts/AgentHostProtocol.cs
+++ b/src/NovaTerminal.AgentHost.Contracts/AgentHostProtocol.cs
@@ -32,12 +32,50 @@ public static class AgentHostProtocol
     /// <summary>Server-side cap on scrollback lines returned per request.</summary>
     public const int MaxScrollbackLinesPerRequest = 2000;
 
-    /// <summary>Method names for A1 (observe-only). Later milestones append; they never repurpose.</summary>
+    /// <summary>Server-side cap on a waitForEvents long-poll (client read timeouts must exceed this).</summary>
+    public const int MaxWaitForEventsTimeoutMs = 25_000;
+
+    /// <summary>Capacity of the server's event ring; older events are evicted and reported via oldestSeq.</summary>
+    public const int EventRingCapacity = 256;
+
+    /// <summary>Method names. Observe-only; later milestones append, they never repurpose.</summary>
     public static class Methods
     {
         public const string ListSessions = "listSessions";
         public const string ReadScreen = "readScreen";
         public const string ReadScrollback = "readScrollback";
+        public const string GetSessionStatus = "getSessionStatus";
+        public const string WaitForEvents = "waitForEvents";
+    }
+
+    /// <summary>Wire values for session status (A2). See the A2 design doc for exact semantics.</summary>
+    public static class StatusKinds
+    {
+        public const string Running = "running";
+        public const string AwaitingInput = "awaitingInput";
+        public const string Idle = "idle";
+        public const string Exited = "exited";
+    }
+
+    /// <summary>Wire values for status confidence: how the status was derived.</summary>
+    public static class StatusConfidences
+    {
+        /// <summary>Shell-integration events (prompt/command lifecycle) drive the status.</summary>
+        public const string Precise = "precise";
+
+        /// <summary>PTY-level signals only (child processes, alt screen, output activity).</summary>
+        public const string Heuristic = "heuristic";
+    }
+
+    /// <summary>Wire values for event types on the waitForEvents channel.</summary>
+    public static class EventTypes
+    {
+        public const string StatusChanged = "statusChanged";
+        public const string CommandFinished = "commandFinished";
+        public const string Bell = "bell";
+        public const string Stalled = "stalled";
+        public const string SessionOpened = "sessionOpened";
+        public const string SessionClosed = "sessionClosed";
     }
 
     /// <summary>Stable machine-readable error codes carried in <see cref="AgentHostError.Code"/>.</summary>

--- a/src/NovaTerminal.AgentHost.Contracts/SessionContracts.cs
+++ b/src/NovaTerminal.AgentHost.Contracts/SessionContracts.cs
@@ -37,6 +37,18 @@ public sealed record SessionInfo
     /// <summary>True for the active pane of the active tab.</summary>
     [JsonPropertyName("isActive")]
     public required bool IsActive { get; init; }
+
+    /// <summary>
+    /// Current status (<see cref="AgentHostProtocol.StatusKinds"/>), when the
+    /// endpoint computes it (A2+). Null from older endpoints. Not required:
+    /// the wire format omits it when null (WhenWritingNull).
+    /// </summary>
+    [JsonPropertyName("status")]
+    public string? Status { get; init; }
+
+    /// <summary>How the status was derived (<see cref="AgentHostProtocol.StatusConfidences"/>); null when status is null.</summary>
+    [JsonPropertyName("confidence")]
+    public string? Confidence { get; init; }
 }
 
 /// <summary>Result payload for <c>listSessions</c>.</summary>

--- a/src/NovaTerminal.AgentHost.Contracts/StatusContracts.cs
+++ b/src/NovaTerminal.AgentHost.Contracts/StatusContracts.cs
@@ -1,0 +1,112 @@
+using System.Text.Json.Serialization;
+
+namespace NovaTerminal.AgentHost.Contracts;
+
+/// <summary>Params for <c>getSessionStatus</c>.</summary>
+public sealed record GetSessionStatusParams
+{
+    [JsonPropertyName("paneId")]
+    public required Guid PaneId { get; init; }
+}
+
+/// <summary>
+/// Result payload for <c>getSessionStatus</c>. Timestamps are Unix epoch
+/// milliseconds; thresholds are echoed so clients never hard-code them.
+/// </summary>
+public sealed record SessionStatusDto
+{
+    [JsonPropertyName("paneId")]
+    public required Guid PaneId { get; init; }
+
+    /// <summary>One of <see cref="AgentHostProtocol.StatusKinds"/>.</summary>
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    /// <summary>One of <see cref="AgentHostProtocol.StatusConfidences"/>.</summary>
+    [JsonPropertyName("confidence")]
+    public required string Confidence { get; init; }
+
+    [JsonPropertyName("exitCode")]
+    public int? ExitCode { get; init; }
+
+    /// <summary>The command in flight / last accepted, when shell integration reports it.</summary>
+    [JsonPropertyName("currentCommand")]
+    public string? CurrentCommand { get; init; }
+
+    [JsonPropertyName("statusSinceMs")]
+    public required long StatusSinceMs { get; init; }
+
+    [JsonPropertyName("lastOutputAtMs")]
+    public required long LastOutputAtMs { get; init; }
+
+    /// <summary>Running with no output for at least <see cref="StallThresholdSeconds"/>.</summary>
+    [JsonPropertyName("isStalled")]
+    public required bool IsStalled { get; init; }
+
+    [JsonPropertyName("stallThresholdSeconds")]
+    public required int StallThresholdSeconds { get; init; }
+
+    [JsonPropertyName("idleThresholdSeconds")]
+    public required int IdleThresholdSeconds { get; init; }
+}
+
+/// <summary>One event on the <c>waitForEvents</c> channel.</summary>
+public sealed record AgentEventDto
+{
+    /// <summary>Monotonically increasing across the whole endpoint; the long-poll cursor.</summary>
+    [JsonPropertyName("seq")]
+    public required long Seq { get; init; }
+
+    [JsonPropertyName("timestampMs")]
+    public required long TimestampMs { get; init; }
+
+    [JsonPropertyName("paneId")]
+    public required Guid PaneId { get; init; }
+
+    /// <summary>One of <see cref="AgentHostProtocol.EventTypes"/>.</summary>
+    [JsonPropertyName("type")]
+    public required string Type { get; init; }
+
+    /// <summary>Session status at emission time (<see cref="AgentHostProtocol.StatusKinds"/>).</summary>
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    [JsonPropertyName("exitCode")]
+    public int? ExitCode { get; init; }
+
+    /// <summary>Command duration for <c>commandFinished</c> events.</summary>
+    [JsonPropertyName("durationMs")]
+    public long? DurationMs { get; init; }
+}
+
+/// <summary>Params for <c>waitForEvents</c>.</summary>
+public sealed record WaitForEventsParams
+{
+    /// <summary>Deliver events with seq greater than this. Pass 0 on the first call, then the previous nextSeq.</summary>
+    [JsonPropertyName("sinceSeq")]
+    public required long SinceSeq { get; init; }
+
+    /// <summary>How long to park when no events are pending; server-capped at <see cref="AgentHostProtocol.MaxWaitForEventsTimeoutMs"/>.</summary>
+    [JsonPropertyName("timeoutMs")]
+    public required int TimeoutMs { get; init; }
+}
+
+/// <summary>
+/// Result payload for <c>waitForEvents</c>. Empty <see cref="Events"/> means
+/// the timeout elapsed. If <c>sinceSeq + 1 &lt; oldestSeq</c>, events were
+/// evicted before the caller read them — the caller knows exactly that it
+/// missed some and can resynchronize via list/status calls.
+/// </summary>
+public sealed record WaitForEventsResult
+{
+    [JsonPropertyName("events")]
+    public required AgentEventDto[] Events { get; init; }
+
+    /// <summary>Cursor to pass as the next sinceSeq.</summary>
+    [JsonPropertyName("nextSeq")]
+    public required long NextSeq { get; init; }
+
+    /// <summary>Seq of the oldest event still retained (0 when the ring is empty).</summary>
+    [JsonPropertyName("oldestSeq")]
+    public required long OldestSeq { get; init; }
+}

--- a/src/NovaTerminal.App/AgentHost/AgentEventRing.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentEventRing.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NovaTerminal.AgentHost.Contracts;
+
+namespace NovaTerminal.AgentHost
+{
+    /// <summary>
+    /// Bounded, thread-safe event log behind <c>waitForEvents</c>
+    /// (docs/plans/2026-07-07-agent-host-a2-status-design.md). Sequence
+    /// numbers are monotonic across the endpoint's lifetime; when capacity is
+    /// exceeded the oldest events are evicted and readers detect the gap via
+    /// <see cref="WaitForEventsResult.OldestSeq"/>. Long-pollers park on a
+    /// pulse that fires on every append — at-least-once delivery with explicit
+    /// loss reporting, no unbounded memory.
+    /// </summary>
+    public sealed class AgentEventRing
+    {
+        private readonly object _gate = new();
+        private readonly int _capacity;
+        private readonly Queue<AgentEventDto> _events = new();
+        private long _lastSeq; // 0 = nothing ever appended
+        private TaskCompletionSource<bool> _pulse = NewPulse();
+
+        public AgentEventRing(int capacity = AgentHostProtocol.EventRingCapacity)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(capacity);
+            _capacity = capacity;
+        }
+
+        /// <summary>Appends with the next sequence number and wakes any parked long-pollers.</summary>
+        public long Append(Guid paneId, string type, string status, DateTimeOffset timestamp, int? exitCode = null, long? durationMs = null)
+        {
+            TaskCompletionSource<bool> toPulse;
+            long seq;
+            lock (_gate)
+            {
+                seq = ++_lastSeq;
+                _events.Enqueue(new AgentEventDto
+                {
+                    Seq = seq,
+                    TimestampMs = timestamp.ToUnixTimeMilliseconds(),
+                    PaneId = paneId,
+                    Type = type,
+                    Status = status,
+                    ExitCode = exitCode,
+                    DurationMs = durationMs,
+                });
+                while (_events.Count > _capacity)
+                {
+                    _events.Dequeue();
+                }
+
+                toPulse = _pulse;
+                _pulse = NewPulse();
+            }
+
+            toPulse.TrySetResult(true);
+            return seq;
+        }
+
+        /// <summary>Snapshot read of everything past the cursor.</summary>
+        public WaitForEventsResult ReadSince(long sinceSeq)
+        {
+            lock (_gate)
+            {
+                var events = _events.Where(e => e.Seq > sinceSeq).ToArray();
+                return new WaitForEventsResult
+                {
+                    Events = events,
+                    NextSeq = _lastSeq,
+                    OldestSeq = _events.Count == 0 ? 0 : _events.Peek().Seq,
+                };
+            }
+        }
+
+        /// <summary>
+        /// Returns immediately when events exist past the cursor; otherwise
+        /// parks until an append or the timeout (empty result). Cancellation
+        /// (client gone, endpoint stopping) propagates.
+        /// </summary>
+        public async Task<WaitForEventsResult> WaitSinceAsync(long sinceSeq, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            var deadline = DateTimeOffset.UtcNow + timeout;
+            while (true)
+            {
+                // Capture the pulse BEFORE reading: an append that lands after
+                // the read (but before we park) completes this captured pulse,
+                // so the wake-up cannot be lost.
+                Task pulseTask;
+                lock (_gate)
+                {
+                    pulseTask = _pulse.Task;
+                }
+
+                var ready = ReadSince(sinceSeq);
+                if (ready.Events.Length > 0)
+                {
+                    return ready;
+                }
+
+                var remaining = deadline - DateTimeOffset.UtcNow;
+                if (remaining <= TimeSpan.Zero)
+                {
+                    return ready; // empty: timeout elapsed
+                }
+
+                var woke = await Task.WhenAny(pulseTask, Task.Delay(remaining, cancellationToken)).ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested();
+                if (woke != pulseTask)
+                {
+                    return ReadSince(sinceSeq); // timeout; report whatever exists (normally empty)
+                }
+            }
+        }
+
+        private static TaskCompletionSource<bool> NewPulse()
+            => new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+}

--- a/src/NovaTerminal.App/AgentHost/AgentEventRing.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentEventRing.cs
@@ -107,7 +107,13 @@ namespace NovaTerminal.AgentHost
                     return ready; // empty: timeout elapsed
                 }
 
-                var woke = await Task.WhenAny(pulseTask, Task.Delay(remaining, cancellationToken)).ConfigureAwait(false);
+                // The delay gets its own linked cancellation so that when the
+                // pulse wins the race, its timer is released immediately rather
+                // than running out the full remaining window per wake-up.
+                using var delayCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                var delayTask = Task.Delay(remaining, delayCts.Token);
+                var woke = await Task.WhenAny(pulseTask, delayTask).ConfigureAwait(false);
+                delayCts.Cancel();
                 cancellationToken.ThrowIfCancellationRequested();
                 if (woke != pulseTask)
                 {

--- a/src/NovaTerminal.App/AgentHost/AgentHostService.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentHostService.cs
@@ -323,7 +323,7 @@ namespace NovaTerminal.AgentHost
             {
                 try
                 {
-                    registration.StatusMachine.Sweep(registration.HasActiveChildProcesses());
+                    registration.StatusMachine.Sweep(registration.ProbeHasActiveChildProcesses());
                 }
                 catch (Exception ex)
                 {

--- a/src/NovaTerminal.App/AgentHost/AgentHostService.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentHostService.cs
@@ -46,6 +46,12 @@ namespace NovaTerminal.AgentHost
         private string? _discoveryFilePath;
         private readonly System.Collections.Concurrent.ConcurrentDictionary<Stream, byte> _activeClients = new();
 
+        // A2 status plumbing — exists only while the endpoint is running
+        // (off-is-off: no ring, no timer, no subscriptions when disabled).
+        private AgentEventRing? _eventRing;
+        private Timer? _sweepTimer;
+        private readonly Dictionary<AgentSessionRegistration, Action<AgentSessionStatusEvent>> _statusSubscriptions = new();
+
         public AgentHostService(
             AgentSessionRegistry registry,
             string? endpointOverride = null,
@@ -117,6 +123,8 @@ namespace NovaTerminal.AgentHost
                         JsonSerializer.Serialize(descriptor, AgentHostJsonContext.Default.EndpointDescriptor));
                     _discoveryFilePath = discoveryPath;
                     EndpointName = endpoint;
+
+                    StartStatusPlumbingLocked();
                 }
                 catch (Exception ex)
                 {
@@ -141,6 +149,8 @@ namespace NovaTerminal.AgentHost
 
         private void StopLocked()
         {
+            StopStatusPlumbingLocked();
+
             _cts?.Cancel();
             _cts?.Dispose();
             _cts = null;
@@ -210,6 +220,115 @@ namespace NovaTerminal.AgentHost
             {
                 // Missing file, or a foreign instance holds the lock right now:
                 // either way there is nothing of ours left to clean up.
+            }
+        }
+
+        // ── A2 status plumbing ───────────────────────────────────────────────
+
+        private void StartStatusPlumbingLocked()
+        {
+            _eventRing = new AgentEventRing();
+            _registry.SessionRegistered += OnSessionRegistered;
+            _registry.SessionUnregistered += OnSessionUnregistered;
+
+            // Sessions that were already open when the endpoint started get
+            // forwarding but no synthetic sessionOpened: a fresh client learns
+            // about them via listSessions, not via a burst of stale events.
+            foreach (var registration in _registry.GetRegistrations())
+            {
+                AttachStatusForwarding(registration);
+            }
+
+            _sweepTimer = new Timer(_ => SweepStatuses(), null,
+                dueTime: TimeSpan.FromSeconds(1), period: TimeSpan.FromSeconds(1));
+        }
+
+        private void StopStatusPlumbingLocked()
+        {
+            _sweepTimer?.Dispose();
+            _sweepTimer = null;
+
+            _registry.SessionRegistered -= OnSessionRegistered;
+            _registry.SessionUnregistered -= OnSessionUnregistered;
+
+            foreach (var (registration, handler) in _statusSubscriptions)
+            {
+                registration.StatusMachine.EventEmitted -= handler;
+            }
+            _statusSubscriptions.Clear();
+            _eventRing = null;
+        }
+
+        private void OnSessionRegistered(AgentSessionRegistration registration)
+        {
+            AgentEventRing? ring;
+            lock (_gate)
+            {
+                ring = _eventRing;
+                if (ring == null) return;
+                AttachStatusForwardingLocked(registration, ring);
+            }
+
+            var status = registration.StatusMachine.Snapshot();
+            ring.Append(registration.PaneId, AgentHostProtocol.EventTypes.SessionOpened, status.Kind.ToWire(), DateTimeOffset.UtcNow);
+        }
+
+        private void OnSessionUnregistered(AgentSessionRegistration registration)
+        {
+            AgentEventRing? ring;
+            lock (_gate)
+            {
+                ring = _eventRing;
+                if (_statusSubscriptions.Remove(registration, out var handler))
+                {
+                    registration.StatusMachine.EventEmitted -= handler;
+                }
+            }
+
+            var status = registration.StatusMachine.Snapshot();
+            ring?.Append(registration.PaneId, AgentHostProtocol.EventTypes.SessionClosed, status.Kind.ToWire(), DateTimeOffset.UtcNow, status.ExitCode);
+        }
+
+        private void AttachStatusForwarding(AgentSessionRegistration registration)
+        {
+            // Caller holds _gate (Start path).
+            if (_eventRing is { } ring)
+            {
+                AttachStatusForwardingLocked(registration, ring);
+            }
+        }
+
+        private void AttachStatusForwardingLocked(AgentSessionRegistration registration, AgentEventRing ring)
+        {
+            if (_statusSubscriptions.ContainsKey(registration)) return;
+
+            // PaneId is read at event time (it can be re-keyed by session
+            // restore); the ring instance is captured so a stopped endpoint's
+            // orphaned events can never land in a newer ring.
+            void Handler(AgentSessionStatusEvent evt) => ring.Append(
+                registration.PaneId,
+                evt.Type.ToWire(),
+                evt.Status.ToWire(),
+                evt.Timestamp,
+                evt.ExitCode,
+                evt.Duration is { } d ? (long)d.TotalMilliseconds : null);
+
+            _statusSubscriptions[registration] = Handler;
+            registration.StatusMachine.EventEmitted += Handler;
+        }
+
+        private void SweepStatuses()
+        {
+            foreach (var registration in _registry.GetRegistrations())
+            {
+                try
+                {
+                    registration.StatusMachine.Sweep(registration.HasActiveChildProcesses());
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"[AgentHost] status sweep failed for {registration.PaneId}: {ex.Message}");
+                }
             }
         }
 
@@ -374,7 +493,7 @@ namespace NovaTerminal.AgentHost
                     if (line == null) return;
                     if (string.IsNullOrWhiteSpace(line)) continue;
 
-                    var response = HandleRequestLine(line);
+                    var response = await HandleRequestLineAsync(line, token).ConfigureAwait(false);
                     await writer.WriteLineAsync(
                         JsonSerializer.Serialize(response, AgentHostJsonContext.Default.AgentHostResponse))
                         .ConfigureAwait(false);
@@ -396,7 +515,7 @@ namespace NovaTerminal.AgentHost
 
         // ── Request handling ─────────────────────────────────────────────────
 
-        internal AgentHostResponse HandleRequestLine(string line)
+        internal async Task<AgentHostResponse> HandleRequestLineAsync(string line, CancellationToken cancellationToken)
         {
             AgentHostRequest? request;
             try
@@ -428,8 +547,14 @@ namespace NovaTerminal.AgentHost
                     AgentHostProtocol.Methods.ListSessions => HandleListSessions(request),
                     AgentHostProtocol.Methods.ReadScreen => HandleReadScreen(request),
                     AgentHostProtocol.Methods.ReadScrollback => HandleReadScrollback(request),
+                    AgentHostProtocol.Methods.GetSessionStatus => HandleGetSessionStatus(request),
+                    AgentHostProtocol.Methods.WaitForEvents => await HandleWaitForEventsAsync(request, cancellationToken).ConfigureAwait(false),
                     _ => Error(request.Id, AgentHostProtocol.ErrorCodes.UnknownMethod, $"Unknown method '{request.Method}'."),
                 };
+            }
+            catch (OperationCanceledException)
+            {
+                throw; // endpoint stopping / client gone — the connection loop owns this
             }
             catch (JsonException ex)
             {
@@ -439,6 +564,42 @@ namespace NovaTerminal.AgentHost
             {
                 return Error(request.Id, AgentHostProtocol.ErrorCodes.Internal, ex.Message);
             }
+        }
+
+        private AgentHostResponse HandleGetSessionStatus(AgentHostRequest request)
+        {
+            var p = DeserializeParams(request, AgentHostJsonContext.Default.GetSessionStatusParams);
+            if (p == null)
+            {
+                return Error(request.Id, AgentHostProtocol.ErrorCodes.MalformedRequest, "getSessionStatus requires params with a paneId.");
+            }
+            if (!_registry.TryGet(p.PaneId, out var registration))
+            {
+                return Error(request.Id, AgentHostProtocol.ErrorCodes.SessionNotFound, $"No live session with paneId '{p.PaneId}'.");
+            }
+
+            var dto = registration.StatusMachine.Snapshot().ToDto(registration.PaneId);
+            return Ok(request.Id, JsonSerializer.SerializeToElement(dto, AgentHostJsonContext.Default.SessionStatusDto));
+        }
+
+        private async Task<AgentHostResponse> HandleWaitForEventsAsync(AgentHostRequest request, CancellationToken cancellationToken)
+        {
+            var p = DeserializeParams(request, AgentHostJsonContext.Default.WaitForEventsParams);
+            if (p == null)
+            {
+                return Error(request.Id, AgentHostProtocol.ErrorCodes.MalformedRequest, "waitForEvents requires params with sinceSeq and timeoutMs.");
+            }
+
+            var ring = _eventRing;
+            if (ring == null)
+            {
+                return Error(request.Id, AgentHostProtocol.ErrorCodes.Internal, "Event channel is not available.");
+            }
+
+            var sinceSeq = Math.Max(0, p.SinceSeq);
+            var timeout = TimeSpan.FromMilliseconds(Math.Clamp(p.TimeoutMs, 0, AgentHostProtocol.MaxWaitForEventsTimeoutMs));
+            var result = await ring.WaitSinceAsync(sinceSeq, timeout, cancellationToken).ConfigureAwait(false);
+            return Ok(request.Id, JsonSerializer.SerializeToElement(result, AgentHostJsonContext.Default.WaitForEventsResult));
         }
 
         private AgentHostResponse HandleListSessions(AgentHostRequest request)

--- a/src/NovaTerminal.App/AgentHost/AgentSessionRegistration.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentSessionRegistration.cs
@@ -32,7 +32,8 @@ namespace NovaTerminal.AgentHost
             string profileName,
             string kind,
             bool isActive,
-            Func<DateTimeOffset>? nowProvider = null)
+            Func<DateTimeOffset>? nowProvider = null,
+            Func<bool>? hasActiveChildProcessesProvider = null)
         {
             ArgumentNullException.ThrowIfNull(buffer);
             _paneId = paneId;
@@ -42,6 +43,7 @@ namespace NovaTerminal.AgentHost
             _kind = kind;
             _isActive = isActive;
             StatusMachine = new AgentSessionStatusMachine(nowProvider);
+            HasActiveChildProcesses = hasActiveChildProcessesProvider ?? (static () => false);
         }
 
         /// <summary>
@@ -49,6 +51,15 @@ namespace NovaTerminal.AgentHost
         /// pane on the UI thread; snapshots are safe from any thread.
         /// </summary>
         public AgentSessionStatusMachine StatusMachine { get; }
+
+        /// <summary>
+        /// PTY child-process probe for the heuristic status tier, invoked by
+        /// the endpoint's 1 s sweep. Unlike UI state (which is pushed as a
+        /// snapshot), this delegate is deliberately live: it targets the PTY
+        /// layer (<c>ITerminalLifecycle.HasActiveChildProcesses</c>), which is
+        /// thread-safe by contract and never touches Avalonia.
+        /// </summary>
+        public Func<bool> HasActiveChildProcesses { get; }
 
         /// <summary>The pane's VT buffer. Reads must take <see cref="TerminalBuffer.Lock"/> (endpoint milestone A1/PR3).</summary>
         public TerminalBuffer Buffer { get; }

--- a/src/NovaTerminal.App/AgentHost/AgentSessionRegistration.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentSessionRegistration.cs
@@ -33,7 +33,7 @@ namespace NovaTerminal.AgentHost
             string kind,
             bool isActive,
             Func<DateTimeOffset>? nowProvider = null,
-            Func<bool>? hasActiveChildProcessesProvider = null)
+            Func<bool?>? hasActiveChildProcessesProvider = null)
         {
             ArgumentNullException.ThrowIfNull(buffer);
             _paneId = paneId;
@@ -43,7 +43,7 @@ namespace NovaTerminal.AgentHost
             _kind = kind;
             _isActive = isActive;
             StatusMachine = new AgentSessionStatusMachine(nowProvider);
-            HasActiveChildProcesses = hasActiveChildProcessesProvider ?? (static () => false);
+            HasActiveChildProcesses = hasActiveChildProcessesProvider ?? (static () => null);
         }
 
         /// <summary>
@@ -57,9 +57,11 @@ namespace NovaTerminal.AgentHost
         /// the endpoint's 1 s sweep. Unlike UI state (which is pushed as a
         /// snapshot), this delegate is deliberately live: it targets the PTY
         /// layer (<c>ITerminalLifecycle.HasActiveChildProcesses</c>), which is
-        /// thread-safe by contract and never touches Avalonia.
+        /// thread-safe by contract and never touches Avalonia. Null means
+        /// "unknown right now" (session initializing or being swapped); the
+        /// status machine keeps its last known value instead of flapping.
         /// </summary>
-        public Func<bool> HasActiveChildProcesses { get; }
+        public Func<bool?> HasActiveChildProcesses { get; }
 
         /// <summary>The pane's VT buffer. Reads must take <see cref="TerminalBuffer.Lock"/> (endpoint milestone A1/PR3).</summary>
         public TerminalBuffer Buffer { get; }

--- a/src/NovaTerminal.App/AgentHost/AgentSessionRegistration.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentSessionRegistration.cs
@@ -32,8 +32,7 @@ namespace NovaTerminal.AgentHost
             string profileName,
             string kind,
             bool isActive,
-            Func<DateTimeOffset>? nowProvider = null,
-            Func<bool?>? hasActiveChildProcessesProvider = null)
+            Func<DateTimeOffset>? nowProvider = null)
         {
             ArgumentNullException.ThrowIfNull(buffer);
             _paneId = paneId;
@@ -43,7 +42,6 @@ namespace NovaTerminal.AgentHost
             _kind = kind;
             _isActive = isActive;
             StatusMachine = new AgentSessionStatusMachine(nowProvider);
-            HasActiveChildProcesses = hasActiveChildProcessesProvider ?? (static () => null);
         }
 
         /// <summary>
@@ -52,16 +50,38 @@ namespace NovaTerminal.AgentHost
         /// </summary>
         public AgentSessionStatusMachine StatusMachine { get; }
 
+        // The PTY lifecycle behind this session, published by the pane on the
+        // UI thread whenever the session is created, swapped, or torn down —
+        // the same push pattern as the metadata snapshot, so the endpoint's
+        // sweep never dereferences pane state. Volatile: a reference published
+        // here is safely visible to the timer thread.
+        private volatile NovaTerminal.Pty.ITerminalLifecycle? _lifecycle;
+
+        /// <summary>Publishes (or clears) the PTY lifecycle this session runs on. UI thread.</summary>
+        public void SetLifecycle(NovaTerminal.Pty.ITerminalLifecycle? lifecycle) => _lifecycle = lifecycle;
+
         /// <summary>
         /// PTY child-process probe for the heuristic status tier, invoked by
-        /// the endpoint's 1 s sweep. Unlike UI state (which is pushed as a
-        /// snapshot), this delegate is deliberately live: it targets the PTY
-        /// layer (<c>ITerminalLifecycle.HasActiveChildProcesses</c>), which is
-        /// thread-safe by contract and never touches Avalonia. Null means
-        /// "unknown right now" (session initializing or being swapped); the
-        /// status machine keeps its last known value instead of flapping.
+        /// the endpoint's 1 s sweep. Targets only the PTY layer
+        /// (<c>ITerminalLifecycle.HasActiveChildProcesses</c>, thread-safe by
+        /// contract) via the published reference above — never the pane. Null
+        /// means "unknown right now" (no session yet, or the probe raced a
+        /// teardown); the status machine keeps its last known value instead of
+        /// flapping.
         /// </summary>
-        public Func<bool?> HasActiveChildProcesses { get; }
+        public bool? ProbeHasActiveChildProcesses()
+        {
+            var lifecycle = _lifecycle;
+            if (lifecycle == null) return null;
+            try
+            {
+                return lifecycle.HasActiveChildProcesses;
+            }
+            catch
+            {
+                return null; // probe raced a dispose — unknown, not false
+            }
+        }
 
         /// <summary>The pane's VT buffer. Reads must take <see cref="TerminalBuffer.Lock"/> (endpoint milestone A1/PR3).</summary>
         public TerminalBuffer Buffer { get; }

--- a/src/NovaTerminal.App/AgentHost/AgentSessionRegistry.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentSessionRegistry.cs
@@ -25,15 +25,31 @@ namespace NovaTerminal.AgentHost
 
         public int Count => _sessions.Count;
 
+        /// <summary>Raised after a session is added. Used by the endpoint to attach status-event forwarding.</summary>
+        public event Action<AgentSessionRegistration>? SessionRegistered;
+
+        /// <summary>Raised after a session is removed.</summary>
+        public event Action<AgentSessionRegistration>? SessionUnregistered;
+
         /// <summary>Adds a registration. Returns false (and keeps the existing entry) on a duplicate PaneId.</summary>
         public bool Register(AgentSessionRegistration registration)
         {
             ArgumentNullException.ThrowIfNull(registration);
-            return _sessions.TryAdd(registration.PaneId, registration);
+            if (!_sessions.TryAdd(registration.PaneId, registration)) return false;
+            SessionRegistered?.Invoke(registration);
+            return true;
         }
 
         /// <summary>Removes a registration; false when the pane was never registered (or already removed).</summary>
-        public bool Unregister(Guid paneId) => _sessions.TryRemove(paneId, out _);
+        public bool Unregister(Guid paneId)
+        {
+            if (!_sessions.TryRemove(paneId, out var removed)) return false;
+            SessionUnregistered?.Invoke(removed);
+            return true;
+        }
+
+        /// <summary>Point-in-time array of live registrations (for the endpoint's status sweep).</summary>
+        public AgentSessionRegistration[] GetRegistrations() => _sessions.Values.ToArray();
 
         public bool TryGet(Guid paneId, out AgentSessionRegistration registration)
         {
@@ -88,16 +104,22 @@ namespace NovaTerminal.AgentHost
         public SessionInfo[] ListSessions()
         {
             return _sessions.Values
-                .Select(r => new SessionInfo
+                .Select(r =>
                 {
-                    PaneId = r.PaneId,
-                    TabId = r.TabId,
-                    Title = r.Title,
-                    ProfileName = r.ProfileName,
-                    Kind = r.Kind,
-                    Rows = r.Buffer.Rows,
-                    Cols = r.Buffer.Cols,
-                    IsActive = r.IsActive,
+                    var status = r.StatusMachine.Snapshot();
+                    return new SessionInfo
+                    {
+                        PaneId = r.PaneId,
+                        TabId = r.TabId,
+                        Title = r.Title,
+                        ProfileName = r.ProfileName,
+                        Kind = r.Kind,
+                        Rows = r.Buffer.Rows,
+                        Cols = r.Buffer.Cols,
+                        IsActive = r.IsActive,
+                        Status = status.Kind.ToWire(),
+                        Confidence = status.Confidence.ToWire(),
+                    };
                 })
                 .OrderBy(s => s.PaneId)
                 .ToArray();

--- a/src/NovaTerminal.App/AgentHost/AgentSessionStatusMachine.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentSessionStatusMachine.cs
@@ -169,12 +169,18 @@ namespace NovaTerminal.AgentHost
         /// Contributes the time-based transitions and the child-process
         /// heuristic. Idle and stall thresholds only ever fire here, so the
         /// cadence of the caller bounds their latency (1 s in production).
+        /// Null means the probe couldn't answer (session initializing or being
+        /// swapped): the last known value is kept rather than flapping the
+        /// heuristic status through a transient false.
         /// </summary>
-        public void Sweep(bool hasActiveChildProcesses)
+        public void Sweep(bool? hasActiveChildProcesses)
         {
             RunUnderGate(now =>
             {
-                _hasActiveChildren = hasActiveChildProcesses;
+                if (hasActiveChildProcesses.HasValue)
+                {
+                    _hasActiveChildren = hasActiveChildProcesses.Value;
+                }
 
                 if (!_exited
                     && ComputeKind(now) == AgentSessionStatusKind.Running

--- a/src/NovaTerminal.App/AgentHost/AgentStatusWire.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentStatusWire.cs
@@ -1,0 +1,52 @@
+using System;
+using NovaTerminal.AgentHost.Contracts;
+
+namespace NovaTerminal.AgentHost
+{
+    /// <summary>
+    /// Maps the app-internal status types onto the wire strings defined in
+    /// <see cref="AgentHostProtocol"/>. One direction only: the app never
+    /// parses these strings back.
+    /// </summary>
+    public static class AgentStatusWire
+    {
+        public static string ToWire(this AgentSessionStatusKind kind) => kind switch
+        {
+            AgentSessionStatusKind.Running => AgentHostProtocol.StatusKinds.Running,
+            AgentSessionStatusKind.AwaitingInput => AgentHostProtocol.StatusKinds.AwaitingInput,
+            AgentSessionStatusKind.Idle => AgentHostProtocol.StatusKinds.Idle,
+            AgentSessionStatusKind.Exited => AgentHostProtocol.StatusKinds.Exited,
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null),
+        };
+
+        public static string ToWire(this AgentSessionStatusConfidence confidence) => confidence switch
+        {
+            AgentSessionStatusConfidence.Precise => AgentHostProtocol.StatusConfidences.Precise,
+            AgentSessionStatusConfidence.Heuristic => AgentHostProtocol.StatusConfidences.Heuristic,
+            _ => throw new ArgumentOutOfRangeException(nameof(confidence), confidence, null),
+        };
+
+        public static string ToWire(this AgentSessionEventType type) => type switch
+        {
+            AgentSessionEventType.StatusChanged => AgentHostProtocol.EventTypes.StatusChanged,
+            AgentSessionEventType.CommandFinished => AgentHostProtocol.EventTypes.CommandFinished,
+            AgentSessionEventType.Bell => AgentHostProtocol.EventTypes.Bell,
+            AgentSessionEventType.Stalled => AgentHostProtocol.EventTypes.Stalled,
+            _ => throw new ArgumentOutOfRangeException(nameof(type), type, null),
+        };
+
+        public static SessionStatusDto ToDto(this AgentSessionStatusSnapshot snapshot, Guid paneId) => new()
+        {
+            PaneId = paneId,
+            Status = snapshot.Kind.ToWire(),
+            Confidence = snapshot.Confidence.ToWire(),
+            ExitCode = snapshot.ExitCode,
+            CurrentCommand = snapshot.CurrentCommand,
+            StatusSinceMs = snapshot.StatusSince.ToUnixTimeMilliseconds(),
+            LastOutputAtMs = snapshot.LastOutputAt.ToUnixTimeMilliseconds(),
+            IsStalled = snapshot.IsStalled,
+            StallThresholdSeconds = snapshot.StallThresholdSeconds,
+            IdleThresholdSeconds = snapshot.IdleThresholdSeconds,
+        };
+    }
+}

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -1686,6 +1686,13 @@ namespace NovaTerminal.Controls
                 };
                 RegisterActiveSshSession(session, profile);
                 UpdateCommandAssistContext();
+
+                // Seed the status machine's child-process sample the moment the
+                // session exists: without this, the heuristic tier has no first
+                // sample until the endpoint's next 1 s sweep and would report
+                // the machine's default (awaitingInput) for a freshly spawned
+                // command-running session.
+                _agentRegistration?.StatusMachine.Sweep(session.HasActiveChildProcesses);
             }
             catch (Exception ex)
             {

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -401,8 +401,10 @@ namespace NovaTerminal.Controls
                 IsActivePane,
                 nowProvider: null,
                 // PTY-layer probe (thread-safe by contract; no Avalonia state)
-                // for the heuristic status tier's 1 s sweep.
-                hasActiveChildProcessesProvider: () => Session?.HasActiveChildProcesses ?? false);
+                // for the heuristic status tier's 1 s sweep. Null while the
+                // session is initializing or being swapped — the status machine
+                // keeps its last known value instead of flapping through false.
+                hasActiveChildProcessesProvider: () => Session?.HasActiveChildProcesses);
             NovaTerminal.AgentHost.AgentSessionRegistry.Instance.Register(_agentRegistration);
             TitleChanged += (_, _) => UpdateAgentSessionSnapshot();
             WorkingDirectoryChanged += (_, _) => UpdateAgentSessionSnapshot();

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -398,7 +398,11 @@ namespace NovaTerminal.Controls
                 GetBaseTabTitle(),
                 Profile?.Name ?? "Terminal",
                 Profile?.Type == ConnectionType.SSH ? "ssh" : "local",
-                IsActivePane);
+                IsActivePane,
+                nowProvider: null,
+                // PTY-layer probe (thread-safe by contract; no Avalonia state)
+                // for the heuristic status tier's 1 s sweep.
+                hasActiveChildProcessesProvider: () => Session?.HasActiveChildProcesses ?? false);
             NovaTerminal.AgentHost.AgentSessionRegistry.Instance.Register(_agentRegistration);
             TitleChanged += (_, _) => UpdateAgentSessionSnapshot();
             WorkingDirectoryChanged += (_, _) => UpdateAgentSessionSnapshot();

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -398,13 +398,7 @@ namespace NovaTerminal.Controls
                 GetBaseTabTitle(),
                 Profile?.Name ?? "Terminal",
                 Profile?.Type == ConnectionType.SSH ? "ssh" : "local",
-                IsActivePane,
-                nowProvider: null,
-                // PTY-layer probe (thread-safe by contract; no Avalonia state)
-                // for the heuristic status tier's 1 s sweep. Null while the
-                // session is initializing or being swapped — the status machine
-                // keeps its last known value instead of flapping through false.
-                hasActiveChildProcessesProvider: () => Session?.HasActiveChildProcesses);
+                IsActivePane);
             NovaTerminal.AgentHost.AgentSessionRegistry.Instance.Register(_agentRegistration);
             TitleChanged += (_, _) => UpdateAgentSessionSnapshot();
             WorkingDirectoryChanged += (_, _) => UpdateAgentSessionSnapshot();
@@ -1616,6 +1610,7 @@ namespace NovaTerminal.Controls
 
             string startingDir = profile?.StartingDirectory ?? "";
             Session = null;
+            _agentRegistration?.SetLifecycle(null);
             try
             {
                 // If effectiveShell contains a space and is not a direct file, it's likely a combined command.
@@ -1687,12 +1682,15 @@ namespace NovaTerminal.Controls
                 RegisterActiveSshSession(session, profile);
                 UpdateCommandAssistContext();
 
-                // Seed the status machine's child-process sample the moment the
-                // session exists: without this, the heuristic tier has no first
-                // sample until the endpoint's next 1 s sweep and would report
-                // the machine's default (awaitingInput) for a freshly spawned
-                // command-running session.
-                _agentRegistration?.StatusMachine.Sweep(session.HasActiveChildProcesses);
+                // Publish the PTY lifecycle to the registration (the endpoint's
+                // sweep probes only this published reference, never the pane)
+                // and seed the first child-process sample immediately so the
+                // heuristic tier is correct from the moment the session exists.
+                if (_agentRegistration is { } agentReg)
+                {
+                    agentReg.SetLifecycle(session);
+                    agentReg.StatusMachine.Sweep(agentReg.ProbeHasActiveChildProcesses());
+                }
             }
             catch (Exception ex)
             {
@@ -2104,6 +2102,7 @@ namespace NovaTerminal.Controls
                 ITerminalSession session = Session;
                 UnregisterActiveSshSession(session);
                 Session = null;
+                _agentRegistration?.SetLifecycle(null);
                 session.Dispose();
             }
 
@@ -2327,6 +2326,7 @@ namespace NovaTerminal.Controls
                 ITerminalSession session = Session;
                 UnregisterActiveSshSession(session);
                 Session = null;
+                _agentRegistration?.SetLifecycle(null);
                 return session;
             }
             return null;

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentEventRingTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentEventRingTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NovaTerminal.AgentHost;
+using NovaTerminal.AgentHost.Contracts;
+
+namespace NovaTerminal.AppTests.AgentHost;
+
+/// <summary>Cursor, eviction, and long-poll semantics of the A2 event ring.</summary>
+public class AgentEventRingTests
+{
+    private static long Append(AgentEventRing ring, string type = AgentHostProtocol.EventTypes.StatusChanged)
+        => ring.Append(Guid.NewGuid(), type, AgentHostProtocol.StatusKinds.Running, DateTimeOffset.UtcNow);
+
+    [Fact]
+    public void Sequences_are_monotonic_and_cursor_reads_only_newer_events()
+    {
+        var ring = new AgentEventRing();
+        var first = Append(ring);
+        var second = Append(ring);
+        Assert.Equal(first + 1, second);
+
+        var all = ring.ReadSince(0);
+        Assert.Equal(2, all.Events.Length);
+        Assert.Equal(second, all.NextSeq);
+
+        var newer = ring.ReadSince(first);
+        Assert.Equal(second, Assert.Single(newer.Events).Seq);
+
+        var none = ring.ReadSince(second);
+        Assert.Empty(none.Events);
+        Assert.Equal(second, none.NextSeq); // cursor keeps its position
+    }
+
+    [Fact]
+    public void Eviction_is_detectable_via_oldestSeq()
+    {
+        var ring = new AgentEventRing(capacity: 4);
+        for (var i = 0; i < 6; i++) Append(ring);
+
+        var result = ring.ReadSince(0);
+        Assert.Equal(4, result.Events.Length);
+        Assert.Equal(3, result.OldestSeq); // seqs 1–2 evicted
+        Assert.Equal(6, result.NextSeq);
+
+        // A client whose cursor predates oldestSeq-1 knows it missed events.
+        Assert.True(0 + 1 < result.OldestSeq);
+    }
+
+    [Fact]
+    public async Task Long_poll_wakes_on_append()
+    {
+        var ring = new AgentEventRing();
+        var wait = ring.WaitSinceAsync(0, TimeSpan.FromSeconds(20), TestContext.Current.CancellationToken);
+        Assert.False(wait.IsCompleted);
+
+        var seq = Append(ring);
+
+        var result = await wait.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal(seq, Assert.Single(result.Events).Seq);
+    }
+
+    [Fact]
+    public async Task Long_poll_returns_empty_after_timeout()
+    {
+        var ring = new AgentEventRing();
+        var result = await ring.WaitSinceAsync(0, TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken);
+        Assert.Empty(result.Events);
+        Assert.Equal(0, result.NextSeq);
+        Assert.Equal(0, result.OldestSeq);
+    }
+
+    [Fact]
+    public async Task Long_poll_returns_immediately_when_events_already_exist()
+    {
+        var ring = new AgentEventRing();
+        Append(ring);
+
+        var result = await ring.WaitSinceAsync(0, TimeSpan.FromSeconds(20), TestContext.Current.CancellationToken)
+            .WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Single(result.Events);
+    }
+}

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentHostServiceTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentHostServiceTests.cs
@@ -66,6 +66,10 @@ public class AgentHostServiceTests : IDisposable
         return $"{{\"v\":{version},\"id\":{id},\"method\":\"{method}\",\"params\":{paramsJson}}}";
     }
 
+    /// <summary>Sync convenience over the async handler for non-long-poll requests.</summary>
+    private static AgentHostResponse Handle(AgentHostService service, string line)
+        => service.HandleRequestLineAsync(line, TestContext.Current.CancellationToken).GetAwaiter().GetResult();
+
     private static T ResultOf<T>(AgentHostResponse response, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> typeInfo)
     {
         Assert.Null(response.Error);
@@ -81,7 +85,7 @@ public class AgentHostServiceTests : IDisposable
     public void Version_mismatch_is_rejected_with_stable_error_code()
     {
         using var service = NewService(new AgentSessionRegistry());
-        var response = service.HandleRequestLine(RequestLine(AgentHostProtocol.Methods.ListSessions, version: 99));
+        var response = Handle(service,RequestLine(AgentHostProtocol.Methods.ListSessions, version: 99));
         Assert.Equal(AgentHostProtocol.ErrorCodes.VersionMismatch, response.Error?.Code);
     }
 
@@ -89,7 +93,7 @@ public class AgentHostServiceTests : IDisposable
     public void Malformed_frame_is_rejected_not_thrown()
     {
         using var service = NewService(new AgentSessionRegistry());
-        var response = service.HandleRequestLine("this is not json");
+        var response = Handle(service,"this is not json");
         Assert.Equal(AgentHostProtocol.ErrorCodes.MalformedRequest, response.Error?.Code);
     }
 
@@ -97,7 +101,7 @@ public class AgentHostServiceTests : IDisposable
     public void Unknown_method_is_rejected_with_stable_error_code()
     {
         using var service = NewService(new AgentSessionRegistry());
-        var response = service.HandleRequestLine(RequestLine("sendInput"));
+        var response = Handle(service,RequestLine("sendInput"));
         Assert.Equal(AgentHostProtocol.ErrorCodes.UnknownMethod, response.Error?.Code);
     }
 
@@ -105,8 +109,8 @@ public class AgentHostServiceTests : IDisposable
     public void Missing_params_is_a_malformed_request_not_a_missing_session()
     {
         using var service = NewService(new AgentSessionRegistry());
-        var readScreen = service.HandleRequestLine(RequestLine(AgentHostProtocol.Methods.ReadScreen));
-        var readScrollback = service.HandleRequestLine(RequestLine(AgentHostProtocol.Methods.ReadScrollback));
+        var readScreen = Handle(service,RequestLine(AgentHostProtocol.Methods.ReadScreen));
+        var readScrollback = Handle(service,RequestLine(AgentHostProtocol.Methods.ReadScrollback));
         Assert.Equal(AgentHostProtocol.ErrorCodes.MalformedRequest, readScreen.Error?.Code);
         Assert.Equal(AgentHostProtocol.ErrorCodes.MalformedRequest, readScrollback.Error?.Code);
     }
@@ -127,7 +131,7 @@ public class AgentHostServiceTests : IDisposable
         var registration = Register(registry, buffer);
         using var service = NewService(registry);
 
-        var response = service.HandleRequestLine(RequestLine(
+        var response = Handle(service,RequestLine(
             AgentHostProtocol.Methods.ReadScrollback,
             paramsObj: new ReadScrollbackParams { PaneId = registration.PaneId, StartLine = 0, MaxLines = 10 }));
         var result = ResultOf(response, AgentHostJsonContext.Default.ReadScrollbackResult);
@@ -139,7 +143,7 @@ public class AgentHostServiceTests : IDisposable
     public void ReadScreen_for_unknown_pane_reports_session_not_found()
     {
         using var service = NewService(new AgentSessionRegistry());
-        var response = service.HandleRequestLine(RequestLine(
+        var response = Handle(service,RequestLine(
             AgentHostProtocol.Methods.ReadScreen,
             paramsObj: new ReadScreenParams { PaneId = Guid.NewGuid() }));
         Assert.Equal(AgentHostProtocol.ErrorCodes.SessionNotFound, response.Error?.Code);
@@ -157,7 +161,7 @@ public class AgentHostServiceTests : IDisposable
         var registration = Register(registry, buffer);
         using var service = NewService(registry);
 
-        var response = service.HandleRequestLine(RequestLine(
+        var response = Handle(service,RequestLine(
             AgentHostProtocol.Methods.ReadScreen,
             paramsObj: new ReadScreenParams { PaneId = registration.PaneId, IncludeAttributes = true }));
         var dto = ResultOf(response, AgentHostJsonContext.Default.ScreenSnapshotDto);
@@ -185,7 +189,7 @@ public class AgentHostServiceTests : IDisposable
         var registration = Register(registry, buffer);
         using var service = NewService(registry);
 
-        var response = service.HandleRequestLine(RequestLine(
+        var response = Handle(service,RequestLine(
             AgentHostProtocol.Methods.ReadScrollback,
             paramsObj: new ReadScrollbackParams { PaneId = registration.PaneId, StartLine = 1, MaxLines = 3 }));
         var result = ResultOf(response, AgentHostJsonContext.Default.ReadScrollbackResult);

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentHostStatusProtocolTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentHostStatusProtocolTests.cs
@@ -40,11 +40,10 @@ public class AgentHostStatusProtocolTests : IDisposable
         return service;
     }
 
-    private static AgentSessionRegistration Register(AgentSessionRegistry registry, bool hasChildren = false)
+    private static AgentSessionRegistration Register(AgentSessionRegistry registry)
     {
         var registration = new AgentSessionRegistration(
-            Guid.NewGuid(), new TerminalBuffer(80, 24), "title", "Profile", "local", isActive: true,
-            nowProvider: null, hasActiveChildProcessesProvider: () => hasChildren);
+            Guid.NewGuid(), new TerminalBuffer(80, 24), "title", "Profile", "local", isActive: true);
         Assert.True(registry.Register(registration));
         return registration;
     }

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentHostStatusProtocolTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentHostStatusProtocolTests.cs
@@ -1,0 +1,189 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using NovaTerminal.AgentHost;
+using NovaTerminal.AgentHost.Contracts;
+using NovaTerminal.VT;
+
+namespace NovaTerminal.AppTests.AgentHost;
+
+/// <summary>
+/// In-process protocol tests for the A2 additions: getSessionStatus,
+/// waitForEvents (cursor + long-poll), and status in listSessions.
+/// </summary>
+public class AgentHostStatusProtocolTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public AgentHostStatusProtocolTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "nova-agentstatus-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
+        GC.SuppressFinalize(this);
+    }
+
+    private AgentHostService NewRunningService(AgentSessionRegistry registry)
+    {
+        var endpoint = OperatingSystem.IsWindows()
+            ? "novaterminal-agent-status-test-" + Guid.NewGuid().ToString("N")
+            : Path.Combine(_tempDir, Guid.NewGuid().ToString("N")[..8] + ".sock");
+        var service = new AgentHostService(registry, endpoint, _tempDir);
+        service.Start();
+        Assert.True(service.IsRunning);
+        return service;
+    }
+
+    private static AgentSessionRegistration Register(AgentSessionRegistry registry, bool hasChildren = false)
+    {
+        var registration = new AgentSessionRegistration(
+            Guid.NewGuid(), new TerminalBuffer(80, 24), "title", "Profile", "local", isActive: true,
+            nowProvider: null, hasActiveChildProcessesProvider: () => hasChildren);
+        Assert.True(registry.Register(registration));
+        return registration;
+    }
+
+    private static async Task<AgentHostResponse> HandleAsync(AgentHostService service, string method, string paramsJson = "null", long id = 1)
+        => await service.HandleRequestLineAsync(
+            $"{{\"v\":{AgentHostProtocol.Version},\"id\":{id},\"method\":\"{method}\",\"params\":{paramsJson}}}",
+            TestContext.Current.CancellationToken);
+
+    private static T ResultOf<T>(AgentHostResponse response, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> typeInfo)
+    {
+        Assert.Null(response.Error);
+        Assert.NotNull(response.Result);
+        var value = response.Result!.Value.Deserialize(typeInfo);
+        Assert.NotNull(value);
+        return value!;
+    }
+
+    [Fact]
+    public async Task GetSessionStatus_reports_the_machine_snapshot()
+    {
+        var registry = new AgentSessionRegistry();
+        using var service = NewRunningService(registry);
+        var registration = Register(registry);
+        registration.StatusMachine.NotifyCommandAccepted("make -j");
+        registration.StatusMachine.NotifyCommandStarted();
+
+        var response = await HandleAsync(service, AgentHostProtocol.Methods.GetSessionStatus,
+            $"{{\"paneId\":\"{registration.PaneId}\"}}");
+        var dto = ResultOf(response, AgentHostJsonContext.Default.SessionStatusDto);
+
+        Assert.Equal(AgentHostProtocol.StatusKinds.Running, dto.Status);
+        Assert.Equal(AgentHostProtocol.StatusConfidences.Precise, dto.Confidence);
+        Assert.Equal("make -j", dto.CurrentCommand);
+        Assert.False(dto.IsStalled);
+        Assert.Equal(AgentSessionStatusMachine.StallThresholdSeconds, dto.StallThresholdSeconds);
+    }
+
+    [Fact]
+    public async Task GetSessionStatus_maps_missing_params_and_unknown_pane_to_distinct_errors()
+    {
+        using var service = NewRunningService(new AgentSessionRegistry());
+
+        var malformed = await HandleAsync(service, AgentHostProtocol.Methods.GetSessionStatus);
+        Assert.Equal(AgentHostProtocol.ErrorCodes.MalformedRequest, malformed.Error?.Code);
+
+        var notFound = await HandleAsync(service, AgentHostProtocol.Methods.GetSessionStatus,
+            $"{{\"paneId\":\"{Guid.NewGuid()}\"}}");
+        Assert.Equal(AgentHostProtocol.ErrorCodes.SessionNotFound, notFound.Error?.Code);
+    }
+
+    [Fact]
+    public async Task ListSessions_includes_status_and_confidence()
+    {
+        var registry = new AgentSessionRegistry();
+        using var service = NewRunningService(registry);
+        Register(registry);
+
+        var response = await HandleAsync(service, AgentHostProtocol.Methods.ListSessions);
+        var session = Assert.Single(ResultOf(response, AgentHostJsonContext.Default.ListSessionsResult).Sessions);
+
+        Assert.Equal(AgentHostProtocol.StatusKinds.AwaitingInput, session.Status);
+        Assert.Equal(AgentHostProtocol.StatusConfidences.Heuristic, session.Confidence);
+    }
+
+    [Fact]
+    public async Task Registering_a_session_while_running_emits_sessionOpened()
+    {
+        var registry = new AgentSessionRegistry();
+        using var service = NewRunningService(registry);
+        var registration = Register(registry);
+
+        var response = await HandleAsync(service, AgentHostProtocol.Methods.WaitForEvents,
+            "{\"sinceSeq\":0,\"timeoutMs\":5000}");
+        var result = ResultOf(response, AgentHostJsonContext.Default.WaitForEventsResult);
+
+        var opened = Assert.Single(result.Events, e => e.Type == AgentHostProtocol.EventTypes.SessionOpened);
+        Assert.Equal(registration.PaneId, opened.PaneId);
+    }
+
+    [Fact]
+    public async Task WaitForEvents_long_poll_wakes_on_a_status_event()
+    {
+        var registry = new AgentSessionRegistry();
+        using var service = NewRunningService(registry);
+        var registration = Register(registry);
+
+        // Drain the sessionOpened event to get a current cursor.
+        var drained = ResultOf(
+            await HandleAsync(service, AgentHostProtocol.Methods.WaitForEvents, "{\"sinceSeq\":0,\"timeoutMs\":1000}"),
+            AgentHostJsonContext.Default.WaitForEventsResult);
+
+        var wait = HandleAsync(service, AgentHostProtocol.Methods.WaitForEvents,
+            $"{{\"sinceSeq\":{drained.NextSeq},\"timeoutMs\":20000}}");
+        Assert.False(wait.IsCompleted);
+
+        registration.StatusMachine.NotifyCommandStarted(); // → statusChanged(running)
+
+        var result = ResultOf(await wait.WaitAsync(TimeSpan.FromSeconds(10)), AgentHostJsonContext.Default.WaitForEventsResult);
+        var evt = Assert.Single(result.Events, e => e.Type == AgentHostProtocol.EventTypes.StatusChanged);
+        Assert.Equal(AgentHostProtocol.StatusKinds.Running, evt.Status);
+        Assert.Equal(registration.PaneId, evt.PaneId);
+    }
+
+    [Fact]
+    public async Task Unregistering_emits_sessionClosed_and_stops_forwarding()
+    {
+        var registry = new AgentSessionRegistry();
+        using var service = NewRunningService(registry);
+        var registration = Register(registry);
+
+        Assert.True(registry.Unregister(registration.PaneId));
+        registration.StatusMachine.NotifyCommandStarted(); // must NOT be forwarded
+
+        var result = ResultOf(
+            await HandleAsync(service, AgentHostProtocol.Methods.WaitForEvents, "{\"sinceSeq\":0,\"timeoutMs\":1000}"),
+            AgentHostJsonContext.Default.WaitForEventsResult);
+
+        Assert.Contains(result.Events, e => e.Type == AgentHostProtocol.EventTypes.SessionClosed);
+        Assert.DoesNotContain(result.Events, e => e.Type == AgentHostProtocol.EventTypes.StatusChanged);
+    }
+
+    [Fact]
+    public async Task WaitForEvents_times_out_with_an_empty_result()
+    {
+        using var service = NewRunningService(new AgentSessionRegistry());
+
+        var result = ResultOf(
+            await HandleAsync(service, AgentHostProtocol.Methods.WaitForEvents, "{\"sinceSeq\":0,\"timeoutMs\":150}"),
+            AgentHostJsonContext.Default.WaitForEventsResult);
+
+        Assert.Empty(result.Events);
+    }
+
+    [Fact]
+    public async Task WaitForEvents_rejects_missing_params()
+    {
+        using var service = NewRunningService(new AgentSessionRegistry());
+        var response = await HandleAsync(service, AgentHostProtocol.Methods.WaitForEvents);
+        Assert.Equal(AgentHostProtocol.ErrorCodes.MalformedRequest, response.Error?.Code);
+    }
+}

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentSessionStatusMachineTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentSessionStatusMachineTests.cs
@@ -89,6 +89,15 @@ public class AgentSessionStatusMachineTests
     }
 
     [Fact]
+    public void Registration_probe_is_unknown_without_a_published_lifecycle()
+    {
+        // No session yet → the probe answers "unknown", never a hard false.
+        var registration = new AgentSessionRegistration(
+            Guid.NewGuid(), new NovaTerminal.VT.TerminalBuffer(80, 24), "t", "p", "local", isActive: false);
+        Assert.Null(registration.ProbeHasActiveChildProcesses());
+    }
+
+    [Fact]
     public void Sweep_with_unknown_child_state_keeps_the_last_known_value()
     {
         // The probe returns null while the session is initializing or being

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentSessionStatusMachineTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentSessionStatusMachineTests.cs
@@ -89,6 +89,22 @@ public class AgentSessionStatusMachineTests
     }
 
     [Fact]
+    public void Sweep_with_unknown_child_state_keeps_the_last_known_value()
+    {
+        // The probe returns null while the session is initializing or being
+        // swapped; a transient null must not flap Running → AwaitingInput.
+        var (machine, _, _) = Make();
+        machine.Sweep(hasActiveChildProcesses: true);
+        Assert.Equal(AgentSessionStatusKind.Running, machine.Snapshot().Kind);
+
+        machine.Sweep(hasActiveChildProcesses: null);
+        Assert.Equal(AgentSessionStatusKind.Running, machine.Snapshot().Kind);
+
+        machine.Sweep(hasActiveChildProcesses: false);
+        Assert.Equal(AgentSessionStatusKind.AwaitingInput, machine.Snapshot().Kind);
+    }
+
+    [Fact]
     public void Alt_screen_forces_running_in_both_tiers()
     {
         var (machine, _, _) = Make();


### PR DESCRIPTION
## Summary

PR 2 of milestone **A2 (Status & Notifications)** (design: `docs/plans/2026-07-07-agent-host-a2-status-design.md`): the protocol layer. The PR1 status machine is now reachable over the wire — `getSessionStatus`, a cursor-based `waitForEvents` long-poll backed by a bounded event ring, status in `listSessions`, and the 1 s idle/stall sweep, all scoped to the endpoint's lifetime. **Additive only; protocol version stays 1.** MCP tools land in PR 3.

## Protocol additions (contracts)

- Methods `getSessionStatus` / `waitForEvents`; wire-string constants for status kinds, confidence tiers, and event types
- `SessionStatusDto` — status, confidence, exit code, current command, epoch-ms timestamps, and both thresholds echoed so clients never hard-code them
- `AgentEventDto` + `WaitForEventsParams`/`Result` — monotonic `seq` cursor, `nextSeq` to pass back, `oldestSeq` so a lapsed client *knows* it missed events (`sinceSeq + 1 < oldestSeq`)
- `SessionInfo` gains optional `status`/`confidence` (nullable, omitted when null — same pattern as `tabId`)

## App side

- **`AgentEventRing`** — bounded (256), monotonic seqs, thread-safe; long-pollers park on a pulse captured *before* the read so a concurrent append can never be missed; eviction reported, never silent
- **`AgentHostService`** — request path is now async; `waitForEvents` parks up to a server-capped 25 s (client read timeouts stay above it); one poll per connection at a time falls out of the sequential per-connection loop
- **Status plumbing scoped to the endpoint lifecycle** (off-is-off): ring, sweep timer, and per-session event forwarding are created in `Start` and torn down in `Stop`. Registry gains `SessionRegistered`/`SessionUnregistered` events; sessions registered while running emit `sessionOpened`, unregistered ones emit `sessionClosed` and stop forwarding. Pre-existing sessions get forwarding without a synthetic `sessionOpened` burst (a fresh client learns about them via `listSessions`)
- **Forwarding correctness details:** `PaneId` is read at event time (rekey-safe), and each handler captures its ring instance so a stopped endpoint's orphaned events can never land in a newer ring
- **Heuristic tier probe:** `AgentSessionRegistration.HasActiveChildProcesses` is a deliberately live delegate — it targets the PTY layer (`ITerminalLifecycle.HasActiveChildProcesses`, thread-safe by contract), never Avalonia state, and is only invoked by the sweep

## Tests (14 new; AgentHost suite 48/48)

- Ring: monotonic seqs + cursor reads, eviction detectable via `oldestSeq`, long-poll wakes on append, timeout returns empty, immediate return when events exist
- Protocol: `getSessionStatus` snapshot round-trip (running/precise/currentCommand/thresholds), distinct malformed-vs-not-found errors, status+confidence in `listSessions`, `sessionOpened` on register, long-poll woken by a real machine event, `sessionClosed` + forwarding stops on unregister, timeout, malformed params
- Suites: AgentHost 48/48, McpServer 125/125, Architecture 18/18

## Next (A2 PR 3)

MCP tools: `novaterminal.get_session_status` and `novaterminal.wait_for_events` (client long-poll read timeout raised above the server cap), status column in `novaterminal.list_sessions` output.
