### PR TITLE
feat(agent-host): A2 MCP tools - get_session_status, wait_for_events, status in list_sessions

### DIFF
--- a/src/NovaTerminal.McpServer/AgentHostClient.cs
+++ b/src/NovaTerminal.McpServer/AgentHostClient.cs
@@ -46,7 +46,11 @@ public sealed class AgentHostClient
         public bool Available => Response != null;
     }
 
-    public async Task<CallOutcome> CallAsync(string method, JsonElement? parameters, CancellationToken cancellationToken)
+    public async Task<CallOutcome> CallAsync(
+        string method,
+        JsonElement? parameters,
+        CancellationToken cancellationToken,
+        TimeSpan? roundTripTimeout = null)
     {
         var descriptor = TryReadLiveDescriptor();
         if (descriptor == null)
@@ -57,7 +61,9 @@ public sealed class AgentHostClient
         try
         {
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            timeoutCts.CancelAfter(RoundTripTimeout);
+            // Long-poll calls (waitForEvents) pass a timeout above the server's
+            // 25 s park cap; everything else keeps the tight default.
+            timeoutCts.CancelAfter(roundTripTimeout ?? RoundTripTimeout);
 
             await using var stream = await ConnectAsync(descriptor.Endpoint, timeoutCts.Token).ConfigureAwait(false);
             using var reader = new StreamReader(stream, new UTF8Encoding(false), leaveOpen: true);

--- a/src/NovaTerminal.McpServer/Tools/SessionTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/SessionTools.cs
@@ -87,6 +87,58 @@ public static class SessionTools
             : AgentHostClient.ProtocolErrorMessage;
     }
 
+    [McpServerTool(Name = "novaterminal.get_session_status"),
+     Description("Reports what a live NovaTerminal session is doing right now: running / awaitingInput / idle / exited, with a confidence tier (precise = shell-integration events; heuristic = PTY signals), the in-flight command when known, exit code, and stall state. Read-only. Get paneId from novaterminal.list_sessions.")]
+    public static async Task<string> GetSessionStatus(
+        AgentHostClient client,
+        [Description("The pane id (GUID) from novaterminal.list_sessions.")] string paneId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Guid.TryParse(paneId, out var pane))
+        {
+            return $"Error: '{paneId}' is not a valid pane id (GUID). Use novaterminal.list_sessions to find live pane ids.";
+        }
+
+        var parameters = JsonSerializer.SerializeToElement(
+            new GetSessionStatusParams { PaneId = pane },
+            AgentHostJsonContext.Default.GetSessionStatusParams);
+        var outcome = await client.CallAsync(AgentHostProtocol.Methods.GetSessionStatus, parameters, cancellationToken).ConfigureAwait(false);
+        if (!TryUnwrap(outcome, out var result, out var error)) return error;
+
+        return TryDeserializeResult(result, AgentHostJsonContext.Default.SessionStatusDto, out var dto)
+            ? FormatStatus(dto!)
+            : AgentHostClient.ProtocolErrorMessage;
+    }
+
+    [McpServerTool(Name = "novaterminal.wait_for_events"),
+     Description("Waits for session events from the running NovaTerminal app: status changes, command completions (with exit code and duration), bells, stalls, and sessions opening/closing. Long-poll with a cursor: pass sinceSeq=0 on the first call, then the nextSeq from each result. Returns immediately when events are pending, otherwise parks up to timeoutMs (server-capped at 25000). An empty result means the timeout elapsed — call again with the same cursor. Read-only.")]
+    public static async Task<string> WaitForEvents(
+        AgentHostClient client,
+        [Description("Cursor: deliver events newer than this sequence number. 0 on the first call, then the previous result's nextSeq.")] long sinceSeq = 0,
+        [Description("How long to wait when no events are pending, in milliseconds (0–25000). Default 20000.")] int timeoutMs = 20_000,
+        CancellationToken cancellationToken = default)
+    {
+        if (sinceSeq < 0)
+        {
+            return "Error: sinceSeq must be 0 or greater (0 = from the oldest retained event).";
+        }
+
+        var clampedTimeout = Math.Clamp(timeoutMs, 0, AgentHostProtocol.MaxWaitForEventsTimeoutMs);
+        var parameters = JsonSerializer.SerializeToElement(
+            new WaitForEventsParams { SinceSeq = sinceSeq, TimeoutMs = clampedTimeout },
+            AgentHostJsonContext.Default.WaitForEventsParams);
+        var outcome = await client.CallAsync(
+            AgentHostProtocol.Methods.WaitForEvents,
+            parameters,
+            cancellationToken,
+            roundTripTimeout: TimeSpan.FromMilliseconds(clampedTimeout + 5_000)).ConfigureAwait(false);
+        if (!TryUnwrap(outcome, out var result, out var error)) return error;
+
+        return TryDeserializeResult(result, AgentHostJsonContext.Default.WaitForEventsResult, out var dto)
+            ? FormatEvents(dto!, sinceSeq)
+            : AgentHostClient.ProtocolErrorMessage;
+    }
+
     // ── Shared plumbing ─────────────────────────────────────────────────────
 
     /// <summary>
@@ -153,15 +205,59 @@ public static class SessionTools
         var sb = new StringBuilder();
         sb.AppendLine($"{sessions.Length} live session(s):");
         sb.AppendLine();
-        sb.AppendLine("| paneId | title | profile | kind | size | active | tabId |");
-        sb.AppendLine("|---|---|---|---|---|---|---|");
+        sb.AppendLine("| paneId | title | profile | kind | size | active | status | tabId |");
+        sb.AppendLine("|---|---|---|---|---|---|---|---|");
         foreach (var s in sessions)
         {
+            var status = s.Status == null ? "-" : $"{s.Status} ({s.Confidence})";
             sb.AppendLine(
-                $"| {s.PaneId} | {s.Title} | {s.ProfileName} | {s.Kind} | {s.Cols}x{s.Rows} | {(s.IsActive ? "yes" : "no")} | {(s.TabId?.ToString() ?? "-")} |");
+                $"| {s.PaneId} | {s.Title} | {s.ProfileName} | {s.Kind} | {s.Cols}x{s.Rows} | {(s.IsActive ? "yes" : "no")} | {status} | {(s.TabId?.ToString() ?? "-")} |");
         }
         return sb.ToString().TrimEnd();
     }
+
+    internal static string FormatStatus(SessionStatusDto dto)
+    {
+        var sb = new StringBuilder();
+        sb.Append($"Session {dto.PaneId}: {dto.Status} ({dto.Confidence} confidence)");
+        if (dto.CurrentCommand != null) sb.Append($", command: {dto.CurrentCommand}");
+        if (dto.ExitCode is { } exit) sb.Append($", exit code {exit}");
+        if (dto.IsStalled) sb.Append($" — STALLED (no output for at least {dto.StallThresholdSeconds}s)");
+        sb.AppendLine();
+        sb.AppendLine($"Status since: {FormatUtc(dto.StatusSinceMs)}; last output: {FormatUtc(dto.LastOutputAtMs)}.");
+        sb.Append($"Thresholds: stall after {dto.StallThresholdSeconds}s of silence while running, idle after {dto.IdleThresholdSeconds}s at a prompt.");
+        return sb.ToString();
+    }
+
+    internal static string FormatEvents(WaitForEventsResult dto, long sinceSeq)
+    {
+        var sb = new StringBuilder();
+        if (dto.Events.Length == 0)
+        {
+            sb.Append($"No events within the wait window. Call again with sinceSeq={dto.NextSeq}.");
+            return sb.ToString();
+        }
+
+        sb.AppendLine($"{dto.Events.Length} event(s). Next call: sinceSeq={dto.NextSeq}.");
+        if (sinceSeq > 0 && sinceSeq + 1 < dto.OldestSeq)
+        {
+            sb.AppendLine($"Warning: events {sinceSeq + 1}–{dto.OldestSeq - 1} were evicted before this read — some events were missed. Resynchronize with novaterminal.list_sessions / get_session_status.");
+        }
+        sb.AppendLine();
+        sb.AppendLine("| seq | time (UTC) | paneId | type | status | details |");
+        sb.AppendLine("|---|---|---|---|---|---|");
+        foreach (var e in dto.Events)
+        {
+            var details = e.Type == AgentHostProtocol.EventTypes.CommandFinished
+                ? $"exit {(e.ExitCode?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "?")}{(e.DurationMs is { } d ? $", {d} ms" : "")}"
+                : e.ExitCode is { } code ? $"exit {code}" : "-";
+            sb.AppendLine($"| {e.Seq} | {FormatUtc(e.TimestampMs)} | {e.PaneId} | {e.Type} | {e.Status} | {details} |");
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string FormatUtc(long unixMs)
+        => DateTimeOffset.FromUnixTimeMilliseconds(unixMs).ToString("yyyy-MM-dd HH:mm:ss'Z'", System.Globalization.CultureInfo.InvariantCulture);
 
     internal static string FormatScreen(ScreenSnapshotDto dto)
     {

--- a/tests/NovaTerminal.McpServer.Tests/AgentHostClientTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/AgentHostClientTests.cs
@@ -268,6 +268,89 @@ public class SessionToolsFormattingTests
     }
 
     [Fact]
+    public void FormatSessionList_includes_the_status_column()
+    {
+        var text = SessionTools.FormatSessionList(new[]
+        {
+            new SessionInfo
+            {
+                PaneId = Guid.NewGuid(), Title = "build", ProfileName = "Bash", Kind = "local",
+                Rows = 24, Cols = 80, IsActive = true,
+                Status = AgentHostProtocol.StatusKinds.Running,
+                Confidence = AgentHostProtocol.StatusConfidences.Precise,
+            },
+        });
+
+        Assert.Contains("| running (precise) |", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatStatus_renders_command_stall_and_thresholds()
+    {
+        var text = SessionTools.FormatStatus(new SessionStatusDto
+        {
+            PaneId = Guid.NewGuid(),
+            Status = AgentHostProtocol.StatusKinds.Running,
+            Confidence = AgentHostProtocol.StatusConfidences.Precise,
+            CurrentCommand = "cargo build",
+            StatusSinceMs = 1_800_000_000_000,
+            LastOutputAtMs = 1_800_000_030_000,
+            IsStalled = true,
+            StallThresholdSeconds = 30,
+            IdleThresholdSeconds = 60,
+        });
+
+        Assert.Contains("running (precise confidence)", text, StringComparison.Ordinal);
+        Assert.Contains("command: cargo build", text, StringComparison.Ordinal);
+        Assert.Contains("STALLED", text, StringComparison.Ordinal);
+        Assert.Contains("idle after 60s", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatEvents_teaches_the_cursor_and_reports_eviction_gaps()
+    {
+        var paneId = Guid.NewGuid();
+        var result = new WaitForEventsResult
+        {
+            Events = new[]
+            {
+                new AgentEventDto
+                {
+                    Seq = 12, TimestampMs = 1_800_000_000_000, PaneId = paneId,
+                    Type = AgentHostProtocol.EventTypes.CommandFinished,
+                    Status = AgentHostProtocol.StatusKinds.AwaitingInput,
+                    ExitCode = 0, DurationMs = 4200,
+                },
+            },
+            NextSeq = 12,
+            OldestSeq = 10,
+        };
+
+        // Cursor 3 predates oldestSeq 10 → events 4–9 were evicted.
+        var text = SessionTools.FormatEvents(result, sinceSeq: 3);
+        Assert.Contains("sinceSeq=12", text, StringComparison.Ordinal);
+        Assert.Contains("Warning: events 4–9 were evicted", text, StringComparison.Ordinal);
+        Assert.Contains("commandFinished", text, StringComparison.Ordinal);
+        Assert.Contains("exit 0, 4200 ms", text, StringComparison.Ordinal);
+
+        // A current cursor produces no warning.
+        var clean = SessionTools.FormatEvents(result, sinceSeq: 11);
+        Assert.DoesNotContain("Warning", clean, StringComparison.Ordinal);
+
+        // Empty result teaches the retry cursor.
+        var empty = SessionTools.FormatEvents(new WaitForEventsResult { Events = Array.Empty<AgentEventDto>(), NextSeq = 12, OldestSeq = 10 }, sinceSeq: 12);
+        Assert.Contains("No events within the wait window. Call again with sinceSeq=12.", empty, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WaitForEvents_rejects_a_negative_cursor_before_any_ipc()
+    {
+        var client = new AgentHostClient(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "nothing.json"));
+        var text = await SessionTools.WaitForEvents(client, sinceSeq: -1, timeoutMs: 100, TestContext.Current.CancellationToken);
+        Assert.StartsWith("Error: sinceSeq must be 0 or greater", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void FormatScrollback_reports_range_and_paging_hint()
     {
         var text = SessionTools.FormatScrollback(new ReadScrollbackResult

--- a/tests/NovaTerminal.McpServer.Tests/McpServerStdioE2ETests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/McpServerStdioE2ETests.cs
@@ -39,6 +39,8 @@ public class McpServerStdioE2ETests
         "novaterminal.list_sessions",
         "novaterminal.read_screen",
         "novaterminal.read_scrollback",
+        "novaterminal.get_session_status",
+        "novaterminal.wait_for_events",
     };
 
     [Fact]


### PR DESCRIPTION
## Summary

PR 3 of milestone **A2 (Status & Notifications)** (design: `docs/plans/2026-07-07-agent-host-a2-status-design.md`): the MCP tools. With this, an agent can ask what a session is doing and **wait for it to finish** instead of polling screens — "tell me when the build completes, with the exit code and duration" now works end-to-end from Claude Code / any MCP client. Follows #186 (state machine) and #187 (protocol).

## New MCP tools

- **`novaterminal.get_session_status`** — status + confidence tier, in-flight command, exit code, stall state, and both thresholds, with human-readable timestamps
- **`novaterminal.wait_for_events`** — cursor long-poll over the endpoint's event ring. The tool description and every result teach the cursor protocol ("next call: sinceSeq=N"); an empty result explicitly says the timeout elapsed and repeats the cursor; a cursor that predates `oldestSeq` produces a "events X–Y were evicted" warning with resync guidance, so missed events are never silent
- **`novaterminal.list_sessions`** — now renders a `status` column (`running (precise)`), dash for pre-A2 endpoints

## Client

- `AgentHostClient.CallAsync` accepts a per-call round-trip timeout; `wait_for_events` passes its wait window + 5 s so long-polls survive the client's default 10 s guard (server park cap stays 25 s, below both)
- `timeoutMs` is clamped client-side to [0, 25000]; `sinceSeq < 0` is rejected before any IPC

## Tests (4 new; McpServer suite 129/129)

- Status column rendering; status formatting (command, STALLED, thresholds); event formatting (cursor teaching, eviction-gap warning present/absent, commandFinished details, empty-result retry hint); negative-cursor guard runs before the availability check
- E2E stdio handshake updated: tool list is now exactly 20

## Next (A2 PR 4, final)

Long-command completion notifications (in-app toast + settings toggle) — UI-only, rides the same `CommandFinished` event.
