### PR TITLE
feat(agent-host): A2 long-command completion notifications (default off)

### DIFF
--- a/docs/agent-host/DIRECTION.md
+++ b/docs/agent-host/DIRECTION.md
@@ -148,13 +148,15 @@ Each milestone is independently shippable and announceable. Estimates assume
 ### A2 — Status & notifications
 
 **Deliverables**
-- [ ] Session status model: `running` / `awaiting-input` / `idle` / `exited`
-      (PTY-derived, not scrape-based; exit status + foreground process where
-      the OS allows)
-- [ ] MCP tools: `novaterminal.get_session_status`, long-poll or subscription
-      for completion/stall events
-- [ ] OS notification integration for long-running command completion
-      (absorbs ROADMAP 5.2)
+- [x] Session status model: `running` / `awaitingInput` / `idle` / `exited`
+      with precise/heuristic confidence tiers (PTY-derived, not scrape-based;
+      exit status included; foreground-process reporting deferred) (PR #186)
+- [x] MCP tools: `novaterminal.get_session_status`,
+      `novaterminal.wait_for_events` (cursor long-poll over a bounded event
+      ring) for completion/stall events (PRs #187, #188)
+- [x] In-app notification for long-running command completion, default-off
+      toggle (absorbs ROADMAP 5.2); OS-native notification backends remain a
+      follow-up
 
 **Acceptance criteria**
 - Status transitions covered by replay-driven tests (recorded fixtures per

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -113,11 +113,14 @@ namespace NovaTerminal.Controls
         public event Action<TerminalPane>? CommandStarted;
         public event Action<TerminalPane, int?>? CommandFinished;
         public event Action<TerminalPane, int>? ProcessExited;
+        /// <summary>A command ran at least <see cref="LongCommandNotificationPolicy.ThresholdSeconds"/>: (pane, command, exitCode, duration). Policy (setting, focus) is the window's call.</summary>
+        public event Action<TerminalPane, string?, int?, TimeSpan>? LongCommandCompleted;
 
         private TerminalSettings? _settings;
         private bool _isUpdatingScroll = false;
         private bool _disposed;
         private NovaTerminal.AgentHost.AgentSessionRegistration? _agentRegistration;
+        private DateTimeOffset? _lastCommandStartedAtUtc;
         private Action<int, int>? _onTermViewResize;
         private Action<float, float>? _onTermViewMetricsChanged;
         private DispatcherTimer? _statusTimer;
@@ -1561,6 +1564,7 @@ namespace NovaTerminal.Controls
                 // OnCommandAccepted/OnPromptReady (the UI post below would let a
                 // snapshot briefly see AwaitingInput with CurrentCommand set).
                 _agentRegistration?.StatusMachine.NotifyCommandStarted();
+                _lastCommandStartedAtUtc = DateTimeOffset.UtcNow;
                 Dispatcher.UIThread.Post(() =>
                 {
                     LastExitCode = null;
@@ -1584,6 +1588,19 @@ namespace NovaTerminal.Controls
             Parser.OnCommandFinishedDetailed += (exitCode, durationMs) =>
             {
                 _shellLifecycleTracker?.HandleCommandFinished(exitCode, durationMs);
+
+                // Long-command completion (A2 PR4): the pane only applies the
+                // mechanical threshold; opt-in + focus policy lives in the window.
+                var startedAt = _lastCommandStartedAtUtc;
+                _lastCommandStartedAtUtc = null;
+                TimeSpan? duration = durationMs.HasValue
+                    ? TimeSpan.FromMilliseconds(durationMs.Value)
+                    : startedAt.HasValue ? DateTimeOffset.UtcNow - startedAt.Value : null;
+                if (duration is { } d && LongCommandNotificationPolicy.QualifiesAsLong(d))
+                {
+                    var commandText = _lastRelevantCommandText;
+                    Dispatcher.UIThread.Post(() => LongCommandCompleted?.Invoke(this, commandText, exitCode, d));
+                }
             };
 
             // Sync initial metrics

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -2561,6 +2561,7 @@ namespace NovaTerminal
             pane.CommandStarted -= OnPaneCommandStarted;
             pane.CommandFinished -= OnPaneCommandFinished;
             pane.ProcessExited -= OnPaneProcessExited;
+            pane.LongCommandCompleted -= OnPaneLongCommandCompleted;
 
             pane.RequestRemoteFilesSidebarTransfer += OnPaneRequestRemoteFilesSidebarTransfer;
             pane.WorkingDirectoryChanged += OnPaneWorkingDirectoryChanged;
@@ -2571,6 +2572,7 @@ namespace NovaTerminal
             pane.CommandStarted += OnPaneCommandStarted;
             pane.CommandFinished += OnPaneCommandFinished;
             pane.ProcessExited += OnPaneProcessExited;
+            pane.LongCommandCompleted += OnPaneLongCommandCompleted;
         }
 
         private void UnwirePane(TerminalPane pane)
@@ -2585,6 +2587,7 @@ namespace NovaTerminal
             pane.CommandStarted -= OnPaneCommandStarted;
             pane.CommandFinished -= OnPaneCommandFinished;
             pane.ProcessExited -= OnPaneProcessExited;
+            pane.LongCommandCompleted -= OnPaneLongCommandCompleted;
         }
 
         private void OnPaneRequestRemoteFilesSidebarTransfer(TerminalPane srcPane, SidebarTransferRequest request)
@@ -2664,6 +2667,27 @@ namespace NovaTerminal
             var state = GetOrCreateTabState(tab);
             state.LastExitCode = exitCode.Value;
             QueueTabVisualRefresh(tab);
+        }
+
+        private void OnPaneLongCommandCompleted(TerminalPane pane, string? commandText, int? exitCode, TimeSpan duration)
+        {
+            // Policy: opt-in, and only when the user isn't already looking at
+            // this pane (a different pane is current, or the window is in the
+            // background). The pane already applied the duration threshold.
+            if (!LongCommandNotificationPolicy.ShouldNotify(
+                    _settings.LongCommandNotificationsEnabled,
+                    windowActive: IsActive,
+                    isCurrentPane: ReferenceEquals(pane, _currentPane)))
+            {
+                return;
+            }
+
+            ShowRecordingToast(
+                "Command finished",
+                LongCommandNotificationPolicy.BuildMessage(commandText, exitCode, duration, pane.GetBaseTabTitle()),
+                filePath: null,
+                folderPath: null,
+                autoHide: true);
         }
 
         private void OnPaneProcessExited(TerminalPane pane, int exitCode)

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -5518,6 +5518,16 @@ namespace NovaTerminal
             _recordingToastFolderPath = folderPath;
             titleBlock.Text = title;
             messageBlock.Text = message;
+
+            // The folder button only makes sense for toasts that have one
+            // (recordings). Non-file toasts (long-command completion) would
+            // otherwise offer a button that opens an unrelated folder.
+            var openFolderButton = this.FindControl<Button>("RecordingToastOpenFolder");
+            if (openFolderButton != null)
+            {
+                openFolderButton.IsVisible = folderPath != null || filePath != null;
+            }
+
             toast.IsVisible = true;
 
             _recordingToastTimer.Stop();

--- a/src/NovaTerminal.App/SettingsWindow.axaml
+++ b/src/NovaTerminal.App/SettingsWindow.axaml
@@ -579,6 +579,15 @@
                                 </StackPanel>
                                 <CheckBox Name="AgentAccessObserveToggle" Grid.Column="1" Classes="Toggle" Content="" HorizontalAlignment="Right" VerticalAlignment="Center"/>
                             </Grid>
+                            <Border BorderBrush="{StaticResource NtHairline}" BorderThickness="0,0,0,1" Margin="0,14,0,14"/>
+
+                            <Grid ColumnDefinitions="*,360">
+                                <StackPanel Grid.Column="0" Spacing="2">
+                                    <TextBlock Classes="RowLabel" Text="Long command notifications"/>
+                                    <TextBlock Classes="RowDesc" Text="Show a toast when a command that ran at least 30 seconds finishes in a pane you're not looking at."/>
+                                </StackPanel>
+                                <CheckBox Name="LongCommandNotificationsToggle" Grid.Column="1" Classes="Toggle" Content="" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                            </Grid>
                             <Border BorderBrush="{StaticResource NtHairline}" BorderThickness="0,0,0,1" Margin="0,18,0,18"/>
 
                             <!-- ── Scrollback ── -->

--- a/src/NovaTerminal.App/SettingsWindow.axaml.cs
+++ b/src/NovaTerminal.App/SettingsWindow.axaml.cs
@@ -1402,6 +1402,8 @@ namespace NovaTerminal
             var agentAccessObserveToggle = this.FindControl<CheckBox>("AgentAccessObserveToggle");
 
             if (agentAccessObserveToggle != null) agentAccessObserveToggle.IsChecked = _settings.AgentAccessObserveEnabled;
+            var longCommandNotificationsToggle = this.FindControl<CheckBox>("LongCommandNotificationsToggle");
+            if (longCommandNotificationsToggle != null) longCommandNotificationsToggle.IsChecked = _settings.LongCommandNotificationsEnabled;
             if (fontSizeInput != null) fontSizeInput.Value = (decimal)_settings.FontSize;
             if (scrollbackInput != null) scrollbackInput.Value = (decimal)_settings.MaxHistory;
             if (opacitySlider != null)
@@ -1632,6 +1634,8 @@ namespace NovaTerminal
             if (commandAssistToggle != null) _settings.CommandAssistEnabled = commandAssistToggle.IsChecked == true;
             var agentAccessObserveToggle = this.FindControl<CheckBox>("AgentAccessObserveToggle");
             if (agentAccessObserveToggle != null) _settings.AgentAccessObserveEnabled = agentAccessObserveToggle.IsChecked == true;
+            var longCommandNotificationsToggle = this.FindControl<CheckBox>("LongCommandNotificationsToggle");
+            if (longCommandNotificationsToggle != null) _settings.LongCommandNotificationsEnabled = longCommandNotificationsToggle.IsChecked == true;
 
             if (fontList?.SelectedItem is ComboBoxItem fontItem)
                 _settings.FontFamily = fontItem.Content?.ToString() ?? BundledFontCatalog.DefaultTerminalFontFamily;

--- a/src/NovaTerminal.App/Shell/LongCommandNotificationPolicy.cs
+++ b/src/NovaTerminal.App/Shell/LongCommandNotificationPolicy.cs
@@ -38,10 +38,24 @@ namespace NovaTerminal.Shell
             return string.Create(CultureInfo.InvariantCulture, $"{Math.Max(0, (int)duration.TotalSeconds)}s");
         }
 
+        /// <summary>Toasts must stay one-line; longer commands are elided.</summary>
+        public const int MaxCommandLength = 60;
+
         /// <summary>Toast body, e.g. "cargo build — exit 0 after 3m 5s (Bash)".</summary>
         public static string BuildMessage(string? commandText, int? exitCode, TimeSpan duration, string paneTitle)
         {
-            var command = string.IsNullOrWhiteSpace(commandText) ? "Command" : commandText.Trim();
+            // Flatten multi-line scripts and elide long commands so the toast
+            // stays a compact single line.
+            var command = string.IsNullOrWhiteSpace(commandText)
+                ? "Command"
+                : commandText.Replace("\r", string.Empty, StringComparison.Ordinal)
+                    .Replace('\n', ' ')
+                    .Trim();
+            if (command.Length > MaxCommandLength)
+            {
+                command = command[..(MaxCommandLength - 1)] + "…";
+            }
+
             var exit = exitCode.HasValue
                 ? exitCode.Value.ToString(CultureInfo.InvariantCulture)
                 : "?";

--- a/src/NovaTerminal.App/Shell/LongCommandNotificationPolicy.cs
+++ b/src/NovaTerminal.App/Shell/LongCommandNotificationPolicy.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Globalization;
+
+namespace NovaTerminal.Shell
+{
+    /// <summary>
+    /// Policy for "notify when a long command finishes" (agent-host A2 PR4,
+    /// absorbing ROADMAP §5.2). Pure and stateless so the rules are unit-tested
+    /// while the toast itself stays thin UI code.
+    /// </summary>
+    public static class LongCommandNotificationPolicy
+    {
+        /// <summary>A command must run at least this long to qualify.</summary>
+        public const int ThresholdSeconds = 30;
+
+        /// <summary>The mechanical gate, evaluated by the pane: is this command long enough?</summary>
+        public static bool QualifiesAsLong(TimeSpan duration) => duration >= TimeSpan.FromSeconds(ThresholdSeconds);
+
+        /// <summary>
+        /// The policy gate, evaluated by the window: opt-in setting, and only
+        /// when the user isn't already looking at the pane (different pane, or
+        /// the window itself is in the background).
+        /// </summary>
+        public static bool ShouldNotify(bool enabled, bool windowActive, bool isCurrentPane)
+            => enabled && !(windowActive && isCurrentPane);
+
+        /// <summary>Compact human duration: "42s", "3m 5s", "1h 12m".</summary>
+        public static string FormatDuration(TimeSpan duration)
+        {
+            if (duration.TotalHours >= 1)
+            {
+                return string.Create(CultureInfo.InvariantCulture, $"{(int)duration.TotalHours}h {duration.Minutes}m");
+            }
+            if (duration.TotalMinutes >= 1)
+            {
+                return string.Create(CultureInfo.InvariantCulture, $"{(int)duration.TotalMinutes}m {duration.Seconds}s");
+            }
+            return string.Create(CultureInfo.InvariantCulture, $"{Math.Max(0, (int)duration.TotalSeconds)}s");
+        }
+
+        /// <summary>Toast body, e.g. "cargo build — exit 0 after 3m 5s (Bash)".</summary>
+        public static string BuildMessage(string? commandText, int? exitCode, TimeSpan duration, string paneTitle)
+        {
+            var command = string.IsNullOrWhiteSpace(commandText) ? "Command" : commandText.Trim();
+            var exit = exitCode.HasValue
+                ? exitCode.Value.ToString(CultureInfo.InvariantCulture)
+                : "?";
+            return $"{command} — exit {exit} after {FormatDuration(duration)} ({paneTitle})";
+        }
+    }
+}

--- a/src/NovaTerminal.App/Shell/TerminalSettings.cs
+++ b/src/NovaTerminal.App/Shell/TerminalSettings.cs
@@ -55,6 +55,9 @@ namespace NovaTerminal.Shell
         // agents cannot read any terminal session. Observe-only in v1 — there is
         // no acting capability behind this flag.
         public bool AgentAccessObserveEnabled { get; set; } = false;
+        // In-app toast when a command that ran ≥30s finishes in an unfocused
+        // pane (A2 PR4, absorbs ROADMAP §5.2). Off by default.
+        public bool LongCommandNotificationsEnabled { get; set; } = false;
 
         public System.Collections.Generic.List<TerminalProfile> Profiles { get; set; } = new();
         public Guid DefaultProfileId { get; set; }

--- a/src/NovaTerminal.McpServer/Tools/SettingsTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/SettingsTools.cs
@@ -54,6 +54,7 @@ public static class SettingsTools
         | `GlobalHotkey` | string | Default "Alt+OemTilde". |
         | `ExperimentalNativeSshEnabled` | bool | Default false. |
         | `AgentAccessObserveEnabled` | bool | Default false. Enables the local agent-host observe endpoint (read-only session access for AI agents). |
+        | `LongCommandNotificationsEnabled` | bool | Default false. In-app toast when a command that ran ≥30s finishes in an unfocused pane. |
 
         ## Background
         | Field | Type | Notes |
@@ -117,6 +118,7 @@ public static class SettingsTools
           "CommandAssistPowerShellIntegrationEnabled": true,
           "ExperimentalNativeSshEnabled": false,
           "AgentAccessObserveEnabled": false,
+          "LongCommandNotificationsEnabled": false,
           "Profiles": [
             { "Id": "00000000-0000-0000-0000-000000000001", "Name": "Command Prompt", "Command": "cmd.exe", "Type": 0 }
           ],
@@ -131,7 +133,7 @@ public static class SettingsTools
         "BellVisualEnabled", "SmoothScrolling", "EnableLinkDetection", "QuakeModeEnabled",
         "CommandAssistEnabled", "CommandAssistHistoryEnabled", "CommandAssistAutoHideInAltScreen",
         "CommandAssistShellIntegrationEnabled", "CommandAssistPowerShellIntegrationEnabled",
-        "ExperimentalNativeSshEnabled", "AgentAccessObserveEnabled",
+        "ExperimentalNativeSshEnabled", "AgentAccessObserveEnabled", "LongCommandNotificationsEnabled",
     };
 
     // Plain + enum-like strings; enum-like values are NOT value-validated (type-check only).
@@ -154,7 +156,8 @@ public static class SettingsTools
         "QuakeModeEnabled", "GlobalHotkey", "CommandAssistEnabled", "CommandAssistHistoryEnabled",
         "CommandAssistMaxHistoryEntries", "CommandAssistAutoHideInAltScreen",
         "CommandAssistShellIntegrationEnabled", "CommandAssistPowerShellIntegrationEnabled",
-        "ExperimentalNativeSshEnabled", "AgentAccessObserveEnabled", "Profiles", "DefaultProfileId",
+        "ExperimentalNativeSshEnabled", "AgentAccessObserveEnabled", "LongCommandNotificationsEnabled",
+        "Profiles", "DefaultProfileId",
     };
 
     [McpServerTool(Name = "novaterminal.validate_settings_json"),

--- a/tests/NovaTerminal.App.Tests/AgentHost/LongCommandNotificationPolicyTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/LongCommandNotificationPolicyTests.cs
@@ -49,4 +49,18 @@ public class LongCommandNotificationPolicyTests
         var text = LongCommandNotificationPolicy.BuildMessage(null, null, TimeSpan.FromSeconds(42), "Bash");
         Assert.Equal("Command — exit ? after 42s (Bash)", text);
     }
+
+    [Fact]
+    public void Message_flattens_newlines_and_elides_long_commands()
+    {
+        var multiline = "for f in *.log; do\n  gzip \"$f\"\ndone";
+        var flattened = LongCommandNotificationPolicy.BuildMessage(multiline, 0, TimeSpan.FromSeconds(60), "Bash");
+        Assert.DoesNotContain("\n", flattened, StringComparison.Ordinal);
+        Assert.Contains("for f in *.log; do   gzip \"$f\" done", flattened, StringComparison.Ordinal);
+
+        var longCommand = new string('x', 200);
+        var elided = LongCommandNotificationPolicy.BuildMessage(longCommand, 0, TimeSpan.FromSeconds(60), "Bash");
+        Assert.Contains(new string('x', LongCommandNotificationPolicy.MaxCommandLength - 1) + "…", elided, StringComparison.Ordinal);
+        Assert.DoesNotContain(new string('x', LongCommandNotificationPolicy.MaxCommandLength), elided, StringComparison.Ordinal);
+    }
 }

--- a/tests/NovaTerminal.App.Tests/AgentHost/LongCommandNotificationPolicyTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/LongCommandNotificationPolicyTests.cs
@@ -1,0 +1,52 @@
+using System;
+using NovaTerminal.Shell;
+
+namespace NovaTerminal.AppTests.AgentHost;
+
+/// <summary>Rules for the long-command completion toast (A2 PR4).</summary>
+public class LongCommandNotificationPolicyTests
+{
+    [Theory]
+    [InlineData(29, false)]
+    [InlineData(30, true)]
+    [InlineData(3600, true)]
+    public void Qualifies_exactly_at_the_documented_threshold(int seconds, bool expected)
+    {
+        Assert.Equal(expected, LongCommandNotificationPolicy.QualifiesAsLong(TimeSpan.FromSeconds(seconds)));
+    }
+
+    [Theory]
+    [InlineData(false, true, true, false)]   // disabled: never
+    [InlineData(false, false, false, false)] // disabled: never
+    [InlineData(true, true, true, false)]    // user is looking right at it
+    [InlineData(true, true, false, true)]    // different pane
+    [InlineData(true, false, true, true)]    // window in background
+    [InlineData(true, false, false, true)]   // background + different pane
+    public void Notifies_only_when_enabled_and_not_watching(bool enabled, bool windowActive, bool isCurrentPane, bool expected)
+    {
+        Assert.Equal(expected, LongCommandNotificationPolicy.ShouldNotify(enabled, windowActive, isCurrentPane));
+    }
+
+    [Theory]
+    [InlineData(42, "42s")]
+    [InlineData(185, "3m 5s")]
+    [InlineData(4320, "1h 12m")]
+    public void Durations_format_compactly(int seconds, string expected)
+    {
+        Assert.Equal(expected, LongCommandNotificationPolicy.FormatDuration(TimeSpan.FromSeconds(seconds)));
+    }
+
+    [Fact]
+    public void Message_includes_command_exit_duration_and_pane()
+    {
+        var text = LongCommandNotificationPolicy.BuildMessage("cargo build", 0, TimeSpan.FromSeconds(185), "Bash · repo");
+        Assert.Equal("cargo build — exit 0 after 3m 5s (Bash · repo)", text);
+    }
+
+    [Fact]
+    public void Message_degrades_gracefully_without_command_or_exit_code()
+    {
+        var text = LongCommandNotificationPolicy.BuildMessage(null, null, TimeSpan.FromSeconds(42), "Bash");
+        Assert.Equal("Command — exit ? after 42s (Bash)", text);
+    }
+}


### PR DESCRIPTION
## Summary

PR 4 of milestone **A2 (Status & Notifications)** — the final slice (design: `docs/plans/2026-07-07-agent-host-a2-status-design.md`): a default-off in-app toast when a command that ran ≥ 30 s finishes in a pane the user isn't looking at. UI-only; no protocol involvement. Absorbs ROADMAP §5.2 (automation hooks / notifications). **This completes milestone A2.**

## Design: mechanics in the pane, policy in the window

- **`LongCommandNotificationPolicy`** (`Shell/`) — pure, unit-tested rules: the 30 s qualification threshold, the notify decision (opt-in AND NOT (window active AND pane is current)), compact duration formatting ("3m 5s"), and the toast message builder.
- **`TerminalPane`** applies only the mechanical threshold: duration comes from shell integration's `OnCommandFinishedDetailed` when reported, else from a pane-tracked start timestamp; qualifying completions raise the new `LongCommandCompleted` event (UI-posted) with command text, exit code, and duration.
- **`MainWindow`** applies policy: wired for **all** panes via `WirePane`/`UnwirePane` (unlike the recording toast, this feature exists precisely for non-current panes), checks `LongCommandNotificationsEnabled` + focus state, and reuses the existing toast surface ("cargo build — exit 0 after 3m 5s (Bash)").

## Settings

- `TerminalSettings.LongCommandNotificationsEnabled` (default **false**), settings-window toggle ("Long command notifications"), McpServer `SettingsTools` validator/docs updated.
- OS-native notification backends (Windows toast / macOS / libnotify) remain a follow-up per the design doc; the event plumbing is now in place for them.

## Docs

- `docs/agent-host/DIRECTION.md`: all A2 deliverable checkboxes closed (PRs #186–this).

## Tests (15 new cases in `LongCommandNotificationPolicyTests`)

Threshold boundary (29 s no / 30 s yes), the full notify decision table (disabled never; watching = suppressed; different pane / background window = notify), duration formatting, message building with and without command/exit code.

Suites: AgentHost 64/64, McpServer 129/129.
