### PR TITLE
feat(agent-host): A4 slice 1 - flight recorder core (bounded output ring, inert)

### DIFF
--- a/docs/plans/2026-07-07-agent-host-a4-replay-design.md
+++ b/docs/plans/2026-07-07-agent-host-a4-replay-design.md
@@ -1,0 +1,176 @@
+# Agent Host A4 (Replay for Agents) Design
+
+Milestone **A4** of `docs/agent-host/DIRECTION.md` — the moat: "debug what your
+agent did in the terminal, frame by frame." An agent (or its human) can export
+a session's recent activity as a standard NovaTerminal replay file and re-run
+it headlessly with pixel/byte determinism. A3 (acting) is intentionally
+skipped for now; A4 is still observe-only.
+
+## Goal
+
+- **Flight recorder:** while Agent Access is enabled, each session retains a
+  bounded in-memory ring of its recent raw PTY output (+ resizes) — no disk
+  writes until asked.
+- **`novaterminal.export_replay`** — MCP tool that writes the ring to a
+  standard v2 `.rec` file under a dedicated agent-exports folder and returns
+  the path.
+- **`NovaTerminal.Cli --replay <file>`** — headless: replay the file through
+  the deterministic core and print the final screen (`BufferSnapshot`
+  formatted text), for CI and agent postmortems.
+
+The change must:
+
+- reuse the existing replay format v2 and `PtyRecorder`/`ReplayRunner`
+  machinery — no second format, no second code path for correctness
+- preserve original inter-chunk timing (the format's `t` field), which
+  requires explicit-timestamp write overloads on `PtyRecorder`
+- respect layering: raw bytes exist only in `NovaTerminal.Pty`; Pty may
+  reference Replay (it already does) but never VT
+- stay observe-only and default-off: the flight ring only exists while the
+  observe endpoint is running, and export is additionally gated by its own
+  default-off setting per the DIRECTION permission table ("off; observe
+  permission + explicit export action")
+
+## Current State (verified)
+
+- Recording taps **raw bytes** in `RustPtySession.ReadLoop`
+  (`_recorder?.RecordChunk(buffer, read)`) before UTF-8 decoding; input and
+  resize are also recorded. `PtyRecorder` (NovaTerminal.Replay) writes v2
+  JSON-Lines but only to a file path and only with enqueue-time timestamps —
+  no explicit-timestamp API.
+- The App layer only ever sees decoded strings; **no rolling raw-byte history
+  exists anywhere** today.
+- `ReplayRunner.RunAsync(...)` in Virtual mode + `BufferSnapshot.Capture` +
+  `ToFormattedString()` is exactly the headless-replay primitive; golden
+  tests already consume it.
+- CLI commands are static classes in `NovaTerminal.App/Shell`
+  (`IsSupportedCliMode` / `Execute(args, stdout, stderr)`) dispatched from
+  `NovaTerminal.Cli/Program.cs`.
+- Manual recordings: `AppPaths.RecordingsDirectory`,
+  `nova_rec_{yyyyMMdd_HHmmss}_{suffix}.rec`.
+
+## Design
+
+### Privacy stance (explicit)
+
+Agent exports contain **output and resize events only — never input events**.
+Manual user-initiated recordings keep recording keystrokes as today, but an
+agent-triggered export must not exfiltrate typed secrets (passwords at
+prompts). Replay rendering correctness needs only output + resize; input
+events are ignored by the render path anyway. Documented in the tool
+description and the settings toggle text.
+
+### Flight recorder (NovaTerminal.Replay + Pty integration)
+
+- **`FlightRecordingBuffer`** (new, `NovaTerminal.Replay`): thread-safe
+  bounded ring of `(tMs, kind: chunk|resize, payload)` entries, bounded by
+  total payload bytes (default 2 MiB per session, constant in contracts).
+  Tracks the **geometry at the start of the retained window**: when trimming
+  evicts a resize event, the window-start geometry advances — so an export is
+  always self-consistent (header geometry = geometry at first retained
+  event). Exposes `WriteTo(PtyRecorder recorder)` which rebases timestamps to
+  the first retained event.
+  - Lives in Replay (not Pty) so it can be unit-tested in isolation and
+    reused; Pty already references Replay, and VT types are not needed.
+- **`ITerminalFlightRecorder`** (new members on the Pty session surface):
+  `EnableFlightRecording(long maxBytes)`, `DisableFlightRecording()`,
+  `TryExportFlightRecording(string filePath, out FlightExportInfo info)`.
+  Folded into `ITerminalSession` alongside `ITerminalRecorder`.
+  `RustPtySession` feeds the ring at the existing byte-level tap points
+  (`ReadLoop` chunk, `Resize`) — same places as `_recorder`, one extra
+  null-check per chunk when disabled.
+- **Lifecycle** (off-is-off, same pattern as the status sweep):
+  `AgentHostService` enables flight recording on every registered session at
+  `Start` and on `SessionRegistered`; disables at `Stop` and ignores
+  unregistered sessions. The registration already publishes the session
+  reference (the volatile lifecycle slot from A2 PR2 — widened to carry the
+  session so the service can reach the flight-recorder surface without
+  touching the pane).
+
+### Protocol + MCP tool
+
+- New method `exportReplay { paneId }` →
+  `{ filePath, eventCount, firstEventMs, lastEventMs, truncatedAtStart }`
+  (`truncatedAtStart` = ring had already evicted older data). Additive;
+  protocol version stays 1.
+- Server handler: requires the new setting (below) — otherwise a dedicated
+  `exportDisabled` error code with guidance; resolves the registration,
+  calls `TryExportFlightRecording` targeting
+  `AppPaths.RecordingsDirectory/agent-exports/nova_rec_{stamp}_{suffix}.rec`
+  (existing naming convention, dedicated subfolder so agent artifacts are
+  visually separate from manual recordings).
+- **Setting:** `AgentReplayExportEnabled` (default **false**), settings-window
+  sub-toggle under Agent access; validator lists updated. Both toggles must
+  be on for export to work — this is the "explicit export action" tier from
+  the DIRECTION permission table.
+- MCP tool `novaterminal.export_replay(paneId)` — returns the file path, the
+  time range, the truncation flag, and a hint to replay it with
+  `NovaTerminal.Cli --replay <path>`.
+
+### Headless CLI
+
+- **`ReplayCommand`** (`NovaTerminal.App/Shell`, dispatched from
+  `NovaTerminal.Cli/Program.cs` after the existing two commands):
+  `--replay <file> [--attributes] [--fast-forward-ms N]`.
+  Virtual-mode `ReplayRunner.RunAsync` → UTF-8 decode → `AnsiParser.Process`
+  → `buffer.Resize` on resize events → `BufferSnapshot.Capture(buffer,
+  includeAttributes).ToFormattedString()` to stdout. Async bridged with
+  `GetAwaiter().GetResult()` (established CLI constraint). Exit codes:
+  0 success, 1 unreadable/truncated file (partial output still printed with a
+  stderr warning, using `RunWithResultAsync`), 2 usage.
+
+## Alternatives Considered
+
+- **Export only when the user manually records** — no memory cost, but the
+  moment an agent needs a postmortem is precisely when nobody was recording.
+  The flight recorder is the feature.
+- **Ring in the App layer from `OnOutputReceived` strings** — bytes are
+  already decoded there; re-encoding loses invalid-UTF-8 sequences and splits
+  differ from the wire. Rejected: determinism demands the byte-level tap.
+- **Synthetic timestamps on export** (avoid touching `PtyRecorder`) — Virtual
+  replay ignores timing, but Realtime playback in ReplayWindow and future
+  frame-stepping would be garbage. Two small explicit-timestamp overloads are
+  cheap and keep the format honest.
+- **Including input events with a redaction pass** — redaction of terminal
+  input is not reliably possible (no structure). Omit input entirely.
+
+## Testing
+
+- **Ring unit tests** (App.Tests/ReplayTests or AgentHost): byte-budget
+  trimming, geometry tracking across evicted resizes, timestamp rebasing,
+  `truncatedAtStart` reporting, thread-safety smoke (writer + exporter).
+- **Round-trip (the acceptance criterion):** feed a byte script (incl. a
+  resize and an emoji) into a `FlightRecordingBuffer`, export via
+  `PtyRecorder`, replay the file through `ReplayRunner` into a fresh
+  buffer — `BufferSnapshot` must equal the snapshot of a buffer fed the same
+  bytes directly. Runs on all three OSes via the normal unit lanes.
+- **Recorder overloads:** explicit-timestamp events serialize with the given
+  `t` values, monotonicity preserved.
+- **Protocol:** export with both toggles on → file exists, valid v2 header,
+  no `input` events present (privacy assertion); export with
+  `AgentReplayExportEnabled=false` → `exportDisabled`; unknown pane →
+  `sessionNotFound`.
+- **CLI:** `--replay` on a fixture prints the golden-matching formatted
+  snapshot; bad path/usage exit codes; truncated file exits 1 with partial
+  output.
+- **Off-is-off:** with Agent Access disabled, sessions have no ring
+  (enable/disable verified via the session surface).
+
+## Out of Scope
+
+- Frame-stepping / `--at <ms>` rendering and PNG output (extension of
+  ReplayCommand later; Virtual fast-forward already gives most of it)
+- Exporting manual recordings via MCP (users can already share those files)
+- A3 acting surface (unchanged; separate milestone)
+
+## Suggested PR Slicing
+
+1. **Flight recorder core:** `FlightRecordingBuffer`, `PtyRecorder`
+   explicit-timestamp overloads, `ITerminalFlightRecorder` +
+   `RustPtySession` integration, ring + round-trip + recorder tests. No
+   behavior change (nothing enables it yet).
+2. **Protocol + tool:** service lifecycle wiring, `exportReplay` method +
+   `exportDisabled` error code, `AgentReplayExportEnabled` setting + toggle,
+   MCP `novaterminal.export_replay`, protocol/privacy tests.
+3. **CLI + docs:** `ReplayCommand` + tests, README (`--replay` usage, module
+   notes), DIRECTION A4 checkboxes.

--- a/src/NovaTerminal.Platform/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Platform/Ssh/Sessions/NativeSshSession.cs
@@ -119,7 +119,12 @@ public sealed class NativeSshSession : ITerminalSession
             return; // Already enabled
         }
 
-        _flightRecorder = new FlightRecordingBuffer(maxTotalBytes, _cols, _rows);
+        // Defensive fallback: geometry should always be positive here, but the
+        // ring constructor rejects non-positive dimensions and enabling must
+        // never throw at the agent-host lifecycle call site.
+        int cols = _cols > 0 ? _cols : 80;
+        int rows = _rows > 0 ? _rows : 24;
+        _flightRecorder = new FlightRecordingBuffer(maxTotalBytes, cols, rows);
     }
 
     public void DisableFlightRecording()
@@ -136,8 +141,19 @@ public sealed class NativeSshSession : ITerminalSession
             return false;
         }
 
-        info = ring.ExportTo(filePath, ShellCommand);
-        return true;
+        try
+        {
+            info = ring.ExportTo(filePath, ShellCommand);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+        {
+            // Try-pattern: expected I/O failures (bad path, permissions, full
+            // disk) must not crash the host on an agent-triggered export.
+            _log($"[NativeSshSession] Flight recording export failed: {ex.Message}");
+            info = default;
+            return false;
+        }
     }
 
     public event Action<string>? OnOutputReceived

--- a/src/NovaTerminal.Platform/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Platform/Ssh/Sessions/NativeSshSession.cs
@@ -30,6 +30,10 @@ public sealed class NativeSshSession : ITerminalSession
     private readonly object _outputHandlerGate = new();
 
     private ReplayWriter? _recorder;
+
+    // Flight recorder ring (agent replay export) — same byte-level tap as _recorder,
+    // never records input. See ITerminalFlightRecorder.
+    private FlightRecordingBuffer? _flightRecorder;
     private NativePortForwardSession? _portForwardSession;
     private NovaSshSafeHandle? _sessionHandle;
     private int _cols;
@@ -106,6 +110,35 @@ public sealed class NativeSshSession : ITerminalSession
     public bool HasActiveChildProcesses => false;
     public int? ExitCode => _exitCode;
     public bool IsRecording => _recorder != null;
+    public bool IsFlightRecording => _flightRecorder != null;
+
+    public void EnableFlightRecording(long maxTotalBytes)
+    {
+        if (_flightRecorder != null)
+        {
+            return; // Already enabled
+        }
+
+        _flightRecorder = new FlightRecordingBuffer(maxTotalBytes, _cols, _rows);
+    }
+
+    public void DisableFlightRecording()
+    {
+        _flightRecorder = null;
+    }
+
+    public bool TryExportFlightRecording(string filePath, out FlightExportInfo info)
+    {
+        FlightRecordingBuffer? ring = _flightRecorder;
+        if (ring == null)
+        {
+            info = default;
+            return false;
+        }
+
+        info = ring.ExportTo(filePath, ShellCommand);
+        return true;
+    }
 
     public event Action<string>? OnOutputReceived
     {
@@ -214,6 +247,7 @@ public sealed class NativeSshSession : ITerminalSession
             _cols = cols;
             _rows = rows;
             _recorder?.RecordResize(cols, rows);
+            _flightRecorder?.RecordResize(cols, rows);
         }
         catch (Exception ex) when (!IsCriticalException(ex))
         {
@@ -303,6 +337,7 @@ public sealed class NativeSshSession : ITerminalSession
     public void Dispose()
     {
         StopRecording();
+        DisableFlightRecording();
         _pollCts.Cancel();
         _metrics.MarkDisconnected("Disposed");
         _portForwardSession?.Dispose();
@@ -391,6 +426,7 @@ public sealed class NativeSshSession : ITerminalSession
     {
         _metrics.MarkFirstOutput();
         _recorder?.RecordChunk(payload, payload.Length);
+        _flightRecorder?.RecordChunk(payload, payload.Length);
 
         char[] chars = new char[Encoding.UTF8.GetMaxCharCount(payload.Length)];
         int charCount = _utf8Decoder.GetChars(payload, 0, payload.Length, chars, 0, flush: false);

--- a/src/NovaTerminal.Platform/Ssh/Sessions/OpenSshSession.cs
+++ b/src/NovaTerminal.Platform/Ssh/Sessions/OpenSshSession.cs
@@ -75,6 +75,10 @@ public sealed class OpenSshSession : ITerminalSession
     public void Resize(int cols, int rows) => _inner.Resize(cols, rows);
     public void StartRecording(string filePath) => _inner.StartRecording(filePath);
     public void StopRecording() => _inner.StopRecording();
+    public bool IsFlightRecording => _inner.IsFlightRecording;
+    public void EnableFlightRecording(long maxTotalBytes) => _inner.EnableFlightRecording(maxTotalBytes);
+    public void DisableFlightRecording() => _inner.DisableFlightRecording();
+    public bool TryExportFlightRecording(string filePath, out NovaTerminal.Replay.FlightExportInfo info) => _inner.TryExportFlightRecording(filePath, out info);
     public void Dispose() => _inner.Dispose();
 
     private static ITerminalSession CreateInnerSession(

--- a/src/NovaTerminal.Platform/Ssh/Sessions/SshSession.cs
+++ b/src/NovaTerminal.Platform/Ssh/Sessions/SshSession.cs
@@ -83,5 +83,9 @@ public sealed class SshSession : ITerminalSession
     public void Resize(int cols, int rows) => _inner.Resize(cols, rows);
     public void StartRecording(string filePath) => _inner.StartRecording(filePath);
     public void StopRecording() => _inner.StopRecording();
+    public bool IsFlightRecording => _inner.IsFlightRecording;
+    public void EnableFlightRecording(long maxTotalBytes) => _inner.EnableFlightRecording(maxTotalBytes);
+    public void DisableFlightRecording() => _inner.DisableFlightRecording();
+    public bool TryExportFlightRecording(string filePath, out NovaTerminal.Replay.FlightExportInfo info) => _inner.TryExportFlightRecording(filePath, out info);
     public void Dispose() => _inner.Dispose();
 }

--- a/src/NovaTerminal.Pty/ITerminalSession.cs
+++ b/src/NovaTerminal.Pty/ITerminalSession.cs
@@ -1,4 +1,5 @@
 using System;
+using NovaTerminal.Replay;
 
 namespace NovaTerminal.Pty
 {
@@ -36,6 +37,36 @@ namespace NovaTerminal.Pty
     }
 
     /// <summary>
+    /// Bounded in-memory "flight recorder" of a session's recent raw output and
+    /// resizes, exportable on demand as a standard replay v2 file. Unlike
+    /// <see cref="ITerminalRecorder"/>, nothing touches disk until an export is
+    /// requested, and the retained window never includes input events — exports can
+    /// be triggered by agents and must not exfiltrate typed secrets (see
+    /// docs/plans/2026-07-07-agent-host-a4-replay-design.md).
+    /// </summary>
+    public interface ITerminalFlightRecorder
+    {
+        bool IsFlightRecording { get; }
+
+        /// <summary>
+        /// Starts retaining recent output/resize events, bounded by
+        /// <paramref name="maxTotalBytes"/> (payload bytes plus a fixed per-event
+        /// overhead). Idempotent while already enabled.
+        /// </summary>
+        void EnableFlightRecording(long maxTotalBytes);
+
+        /// <summary>Stops retaining events and discards the current window. Idempotent.</summary>
+        void DisableFlightRecording();
+
+        /// <summary>
+        /// Writes the retained window to <paramref name="filePath"/> as a replay v2
+        /// file. Returns false (without touching disk) when flight recording is not
+        /// enabled.
+        /// </summary>
+        bool TryExportFlightRecording(string filePath, out FlightExportInfo info);
+    }
+
+    /// <summary>
     /// Composite contract preserved for backward compatibility. New code should depend on
     /// the narrowest sub-interface it actually needs.
     ///
@@ -46,7 +77,7 @@ namespace NovaTerminal.Pty
     /// See arch test Pty_must_not_depend_on_Vt and Phase 5 of the architecture-foundation plan.
     /// </summary>
     public interface ITerminalSession
-        : ITerminalIO, ITerminalLifecycle, ITerminalShellMetadata, ITerminalRecorder
+        : ITerminalIO, ITerminalLifecycle, ITerminalShellMetadata, ITerminalRecorder, ITerminalFlightRecorder
     {
     }
 }

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -360,7 +360,12 @@ namespace NovaTerminal.Pty
         public void EnableFlightRecording(long maxTotalBytes)
         {
             if (_flightRecorder != null) return; // Already enabled
-            _flightRecorder = new NovaTerminal.Replay.FlightRecordingBuffer(maxTotalBytes, _cols, _rows);
+            // Defensive fallback: geometry should always be positive here, but the
+            // ring constructor rejects non-positive dimensions and enabling must
+            // never throw at the agent-host lifecycle call site.
+            int cols = _cols > 0 ? _cols : 80;
+            int rows = _rows > 0 ? _rows : 24;
+            _flightRecorder = new NovaTerminal.Replay.FlightRecordingBuffer(maxTotalBytes, cols, rows);
         }
 
         public void DisableFlightRecording()
@@ -377,8 +382,19 @@ namespace NovaTerminal.Pty
                 return false;
             }
 
-            info = ring.ExportTo(filePath, ShellCommand);
-            return true;
+            try
+            {
+                info = ring.ExportTo(filePath, ShellCommand);
+                return true;
+            }
+            catch (Exception ex) when (ex is System.IO.IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+            {
+                // Try-pattern: expected I/O failures (bad path, permissions, full
+                // disk) must not crash the host on an agent-triggered export.
+                Console.WriteLine($"[RustPtySession] Flight recording export failed: {ex.Message}");
+                info = default;
+                return false;
+            }
         }
 
         public void StartRecording(string filePath)

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -347,7 +347,39 @@ namespace NovaTerminal.Pty
 
         private NovaTerminal.Replay.ReplayWriter? _recorder;
 
+        // Flight recorder ring (agent replay export). Written from the read loop and
+        // Resize; enabled/disabled from the App's agent-host lifecycle. Reference
+        // swap is atomic; loops observe it with the same null-conditional pattern as
+        // _recorder. Never records input — see ITerminalFlightRecorder.
+        private NovaTerminal.Replay.FlightRecordingBuffer? _flightRecorder;
+
         public bool IsRecording => _recorder != null;
+
+        public bool IsFlightRecording => _flightRecorder != null;
+
+        public void EnableFlightRecording(long maxTotalBytes)
+        {
+            if (_flightRecorder != null) return; // Already enabled
+            _flightRecorder = new NovaTerminal.Replay.FlightRecordingBuffer(maxTotalBytes, _cols, _rows);
+        }
+
+        public void DisableFlightRecording()
+        {
+            _flightRecorder = null;
+        }
+
+        public bool TryExportFlightRecording(string filePath, out NovaTerminal.Replay.FlightExportInfo info)
+        {
+            var ring = _flightRecorder;
+            if (ring == null)
+            {
+                info = default;
+                return false;
+            }
+
+            info = ring.ExportTo(filePath, ShellCommand);
+            return true;
+        }
 
         public void StartRecording(string filePath)
         {
@@ -415,6 +447,7 @@ namespace NovaTerminal.Pty
                     {
                         // Record raw bytes before any processing
                         _recorder?.RecordChunk(buffer, read);
+                        _flightRecorder?.RecordChunk(buffer, read);
 
                         // Use the stateful decoder - it will hold incomplete multi-byte sequences
                         // until more bytes arrive, preventing U+FFFD replacement characters
@@ -549,6 +582,7 @@ namespace NovaTerminal.Pty
             try { Native.pty_resize(_handle, (ushort)cols, (ushort)rows); }
             catch (ObjectDisposedException) { /* session disposed mid-call — ignore resize */ }
             _recorder?.RecordResize(cols, rows);
+            _flightRecorder?.RecordResize(cols, rows);
         }
 
         public void Dispose()
@@ -567,6 +601,8 @@ namespace NovaTerminal.Pty
                     Console.WriteLine($"[RustPtySession] StopRecording during dispose failed: {ex.Message}");
                 }
             }
+
+            DisableFlightRecording();
 
             // 1. Stop the loops re-entering native calls, and let the process loop drain.
             _cts.Cancel();

--- a/src/NovaTerminal.Replay/Replay/FlightRecordingBuffer.cs
+++ b/src/NovaTerminal.Replay/Replay/FlightRecordingBuffer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace NovaTerminal.Replay
 {
@@ -124,10 +125,20 @@ namespace NovaTerminal.Replay
         /// replay v2 file via <see cref="PtyRecorder"/>. Event timestamps are rebased
         /// so the first retained event is at t=0. Concurrent writers keep recording;
         /// the export is a consistent point-in-time snapshot of the ring.
+        /// Throws (IOException, UnauthorizedAccessException, …) when the target path
+        /// is not writable.
         /// </summary>
         public FlightExportInfo ExportTo(string filePath, string shell)
         {
             ArgumentNullException.ThrowIfNull(filePath);
+
+            // Surface path errors synchronously. PtyRecorder's writer task swallows
+            // I/O failures (best-effort semantics for live recording), so without
+            // this probe an export to an unwritable path would "succeed" while
+            // writing nothing — the Try* session surface could never report false.
+            using (File.Create(filePath))
+            {
+            }
 
             Entry[] entries;
             int cols;

--- a/src/NovaTerminal.Replay/Replay/FlightRecordingBuffer.cs
+++ b/src/NovaTerminal.Replay/Replay/FlightRecordingBuffer.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Collections.Generic;
+
+namespace NovaTerminal.Replay
+{
+    /// <summary>Summary of a completed flight-recording export.</summary>
+    public readonly struct FlightExportInfo
+    {
+        public FlightExportInfo(int eventCount, long firstEventMs, long lastEventMs, bool truncatedAtStart)
+        {
+            EventCount = eventCount;
+            FirstEventMs = firstEventMs;
+            LastEventMs = lastEventMs;
+            TruncatedAtStart = truncatedAtStart;
+        }
+
+        /// <summary>Number of events written to the export file (output chunks + resizes).</summary>
+        public int EventCount { get; }
+
+        /// <summary>
+        /// Timestamp of the first exported event, in milliseconds since flight recording
+        /// was enabled. Timestamps inside the exported file are rebased so the first
+        /// event is at t=0; this value locates the exported window on the session's
+        /// recording timeline.
+        /// </summary>
+        public long FirstEventMs { get; }
+
+        /// <summary>Timestamp of the last exported event, same timeline as <see cref="FirstEventMs"/>.</summary>
+        public long LastEventMs { get; }
+
+        /// <summary>True when the ring had already evicted older events; the export shows a suffix of the session.</summary>
+        public bool TruncatedAtStart { get; }
+    }
+
+    /// <summary>
+    /// Thread-safe bounded ring of recent raw PTY output and resize events — the
+    /// "flight recorder" behind agent replay export. Retention is bounded by total
+    /// payload bytes; when the budget is exceeded the oldest events are evicted.
+    ///
+    /// Privacy: this type has no input-event API by design. Agent-triggered exports
+    /// must never contain typed input (passwords at prompts); replay rendering needs
+    /// only output + resize. See docs/plans/2026-07-07-agent-host-a4-replay-design.md.
+    ///
+    /// The ring tracks the terminal geometry at the start of the retained window:
+    /// when trimming evicts a resize event, the window-start geometry advances to that
+    /// resize's dimensions, so an export is always self-consistent (the v2 header
+    /// geometry equals the geometry in effect at the first retained event).
+    /// </summary>
+    public sealed class FlightRecordingBuffer
+    {
+        /// <summary>
+        /// Fixed per-event bookkeeping charge against the byte budget, so payload-free
+        /// events (resizes) cannot grow the ring without bound.
+        /// </summary>
+        public const int EntryOverheadBytes = 32;
+
+        private readonly object _gate = new object();
+        private readonly Queue<Entry> _entries = new Queue<Entry>();
+        private readonly long _maxTotalBytes;
+        private readonly Func<long> _clock;
+        private readonly long _enabledAtMs;
+
+        private long _retainedBytes;
+        private int _windowStartCols;
+        private int _windowStartRows;
+        private bool _truncatedAtStart;
+
+        /// <param name="maxTotalBytes">
+        /// Retention budget: sum of payload bytes plus <see cref="EntryOverheadBytes"/>
+        /// per event. Must be positive. The most recent event is always retained, even
+        /// if it alone exceeds the budget.
+        /// </param>
+        /// <param name="initialCols">Terminal columns when recording starts.</param>
+        /// <param name="initialRows">Terminal rows when recording starts.</param>
+        /// <param name="clock">
+        /// Monotonic millisecond clock (tests inject a fake). Defaults to
+        /// <see cref="Environment.TickCount64"/>.
+        /// </param>
+        public FlightRecordingBuffer(long maxTotalBytes, int initialCols, int initialRows, Func<long>? clock = null)
+        {
+            if (maxTotalBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maxTotalBytes), maxTotalBytes, "Retention budget must be positive.");
+            if (initialCols <= 0) throw new ArgumentOutOfRangeException(nameof(initialCols), initialCols, "Columns must be positive.");
+            if (initialRows <= 0) throw new ArgumentOutOfRangeException(nameof(initialRows), initialRows, "Rows must be positive.");
+
+            _maxTotalBytes = maxTotalBytes;
+            _windowStartCols = initialCols;
+            _windowStartRows = initialRows;
+            _clock = clock ?? (static () => Environment.TickCount64);
+            _enabledAtMs = _clock();
+        }
+
+        /// <summary>Records a raw output chunk. Safe to call from the PTY read loop.</summary>
+        public void RecordChunk(byte[] data, int length)
+        {
+            ArgumentNullException.ThrowIfNull(data);
+            if (length <= 0 || length > data.Length) return;
+
+            byte[] copy = new byte[length];
+            Array.Copy(data, copy, length);
+
+            lock (_gate)
+            {
+                _entries.Enqueue(Entry.Chunk(NowMs(), copy));
+                _retainedBytes += copy.Length + EntryOverheadBytes;
+                TrimLocked();
+            }
+        }
+
+        /// <summary>Records a terminal resize.</summary>
+        public void RecordResize(int cols, int rows)
+        {
+            if (cols <= 0 || rows <= 0) return;
+
+            lock (_gate)
+            {
+                _entries.Enqueue(Entry.Resize(NowMs(), cols, rows));
+                _retainedBytes += EntryOverheadBytes;
+                TrimLocked();
+            }
+        }
+
+        /// <summary>
+        /// Writes the retained window to <paramref name="filePath"/> as a standard
+        /// replay v2 file via <see cref="PtyRecorder"/>. Event timestamps are rebased
+        /// so the first retained event is at t=0. Concurrent writers keep recording;
+        /// the export is a consistent point-in-time snapshot of the ring.
+        /// </summary>
+        public FlightExportInfo ExportTo(string filePath, string shell)
+        {
+            ArgumentNullException.ThrowIfNull(filePath);
+
+            Entry[] entries;
+            int cols;
+            int rows;
+            bool truncated;
+            lock (_gate)
+            {
+                entries = _entries.ToArray();
+                cols = _windowStartCols;
+                rows = _windowStartRows;
+                truncated = _truncatedAtStart;
+            }
+
+            using var recorder = new PtyRecorder(filePath, cols, rows, shell ?? string.Empty);
+
+            if (entries.Length == 0)
+            {
+                return new FlightExportInfo(eventCount: 0, firstEventMs: 0, lastEventMs: 0, truncatedAtStart: truncated);
+            }
+
+            long baseMs = entries[0].TimeMs;
+            foreach (Entry entry in entries)
+            {
+                long rebased = entry.TimeMs - baseMs;
+                if (entry.Payload != null)
+                {
+                    recorder.RecordChunkAt(rebased, entry.Payload, entry.Payload.Length);
+                }
+                else
+                {
+                    recorder.RecordResizeAt(rebased, entry.Cols, entry.Rows);
+                }
+            }
+
+            return new FlightExportInfo(
+                eventCount: entries.Length,
+                firstEventMs: entries[0].TimeMs,
+                lastEventMs: entries[^1].TimeMs,
+                truncatedAtStart: truncated);
+        }
+
+        /// <summary>Point-in-time view of the ring for tests and diagnostics.</summary>
+        public FlightRecordingStats GetStats()
+        {
+            lock (_gate)
+            {
+                return new FlightRecordingStats(
+                    eventCount: _entries.Count,
+                    retainedBytes: _retainedBytes,
+                    windowStartCols: _windowStartCols,
+                    windowStartRows: _windowStartRows,
+                    truncatedAtStart: _truncatedAtStart);
+            }
+        }
+
+        private long NowMs()
+        {
+            long elapsed = _clock() - _enabledAtMs;
+            return elapsed >= 0 ? elapsed : 0;
+        }
+
+        private void TrimLocked()
+        {
+            // Always retain the most recent event, even when it alone exceeds the
+            // budget — an oversized final chunk must not silently empty the export.
+            while (_entries.Count > 1 && _retainedBytes > _maxTotalBytes)
+            {
+                Entry evicted = _entries.Dequeue();
+                _retainedBytes -= (evicted.Payload?.Length ?? 0) + EntryOverheadBytes;
+                _truncatedAtStart = true;
+
+                if (evicted.Payload == null)
+                {
+                    // Evicting a resize advances the geometry at the window start.
+                    _windowStartCols = evicted.Cols;
+                    _windowStartRows = evicted.Rows;
+                }
+            }
+        }
+
+        private readonly struct Entry
+        {
+            private Entry(long timeMs, byte[]? payload, int cols, int rows)
+            {
+                TimeMs = timeMs;
+                Payload = payload;
+                Cols = cols;
+                Rows = rows;
+            }
+
+            public static Entry Chunk(long timeMs, byte[] payload) => new Entry(timeMs, payload, 0, 0);
+
+            public static Entry Resize(long timeMs, int cols, int rows) => new Entry(timeMs, null, cols, rows);
+
+            public long TimeMs { get; }
+
+            /// <summary>Raw output bytes; null for resize entries.</summary>
+            public byte[]? Payload { get; }
+
+            public int Cols { get; }
+
+            public int Rows { get; }
+        }
+    }
+
+    /// <summary>Snapshot of <see cref="FlightRecordingBuffer"/> internals for tests and diagnostics.</summary>
+    public readonly struct FlightRecordingStats
+    {
+        public FlightRecordingStats(int eventCount, long retainedBytes, int windowStartCols, int windowStartRows, bool truncatedAtStart)
+        {
+            EventCount = eventCount;
+            RetainedBytes = retainedBytes;
+            WindowStartCols = windowStartCols;
+            WindowStartRows = windowStartRows;
+            TruncatedAtStart = truncatedAtStart;
+        }
+
+        public int EventCount { get; }
+        public long RetainedBytes { get; }
+        public int WindowStartCols { get; }
+        public int WindowStartRows { get; }
+        public bool TruncatedAtStart { get; }
+    }
+}

--- a/src/NovaTerminal.Replay/Replay/PtyRecorder.cs
+++ b/src/NovaTerminal.Replay/Replay/PtyRecorder.cs
@@ -38,6 +38,18 @@ namespace NovaTerminal.Replay
 
         public void RecordChunk(byte[] data, int length)
         {
+            RecordChunkAt(GetTimestamp(), data, length);
+        }
+
+        /// <summary>
+        /// Records an output chunk with an explicit time offset instead of the
+        /// enqueue-time clock. Used when re-emitting previously captured events
+        /// (e.g. flight-recorder export) so the file preserves original inter-chunk
+        /// timing. Callers are responsible for supplying non-decreasing offsets.
+        /// </summary>
+        public void RecordChunkAt(long timeOffsetMs, byte[] data, int length)
+        {
+            if (timeOffsetMs < 0) throw new ArgumentOutOfRangeException(nameof(timeOffsetMs), timeOffsetMs, "Time offset must be non-negative.");
             if (_cts.IsCancellationRequested || _queue.IsAddingCompleted) return;
 
             byte[] copy = new byte[length];
@@ -45,7 +57,7 @@ namespace NovaTerminal.Replay
 
             TryEnqueue(new ReplayEvent
             {
-                TimeOffsetMs = GetTimestamp(),
+                TimeOffsetMs = timeOffsetMs,
                 Type = "data",
                 Data = Convert.ToBase64String(copy)
             });
@@ -53,11 +65,20 @@ namespace NovaTerminal.Replay
 
         public void RecordResize(int cols, int rows)
         {
+            RecordResizeAt(GetTimestamp(), cols, rows);
+        }
+
+        /// <summary>
+        /// Records a resize with an explicit time offset. See <see cref="RecordChunkAt"/>.
+        /// </summary>
+        public void RecordResizeAt(long timeOffsetMs, int cols, int rows)
+        {
+            if (timeOffsetMs < 0) throw new ArgumentOutOfRangeException(nameof(timeOffsetMs), timeOffsetMs, "Time offset must be non-negative.");
             if (_cts.IsCancellationRequested || _queue.IsAddingCompleted) return;
 
             TryEnqueue(new ReplayEvent
             {
-                TimeOffsetMs = GetTimestamp(),
+                TimeOffsetMs = timeOffsetMs,
                 Type = "resize",
                 Cols = cols,
                 Rows = rows

--- a/src/NovaTerminal.Replay/Replay/PtyRecorder.cs
+++ b/src/NovaTerminal.Replay/Replay/PtyRecorder.cs
@@ -49,7 +49,9 @@ namespace NovaTerminal.Replay
         /// </summary>
         public void RecordChunkAt(long timeOffsetMs, byte[] data, int length)
         {
+            ArgumentNullException.ThrowIfNull(data);
             if (timeOffsetMs < 0) throw new ArgumentOutOfRangeException(nameof(timeOffsetMs), timeOffsetMs, "Time offset must be non-negative.");
+            if (length <= 0 || length > data.Length) return;
             if (_cts.IsCancellationRequested || _queue.IsAddingCompleted) return;
 
             byte[] copy = new byte[length];
@@ -74,6 +76,7 @@ namespace NovaTerminal.Replay
         public void RecordResizeAt(long timeOffsetMs, int cols, int rows)
         {
             if (timeOffsetMs < 0) throw new ArgumentOutOfRangeException(nameof(timeOffsetMs), timeOffsetMs, "Time offset must be non-negative.");
+            if (cols <= 0 || rows <= 0) return;
             if (_cts.IsCancellationRequested || _queue.IsAddingCompleted) return;
 
             TryEnqueue(new ReplayEvent

--- a/tests/NovaTerminal.App.Tests/PtySmokeTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtySmokeTests.cs
@@ -58,6 +58,11 @@ namespace NovaTerminal.Tests
                 Assert.True(info.EventCount > 0, "flight ring captured no output from a live shell");
                 Assert.True(File.Exists(tempFile));
 
+                // Try-pattern: an unwritable path is reported as false, not thrown.
+                string badPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "nested", "export.rec");
+                Assert.False(session.TryExportFlightRecording(badPath, out _));
+                Assert.True(session.IsFlightRecording); // failure does not disturb the ring
+
                 // Disable drops the ring.
                 session.DisableFlightRecording();
                 Assert.False(session.IsFlightRecording);

--- a/tests/NovaTerminal.App.Tests/PtySmokeTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtySmokeTests.cs
@@ -27,6 +27,50 @@ namespace NovaTerminal.Tests
 
         [Fact]
         [Trait("Category", "PtySmoke")]
+        public async Task RustPtySession_FlightRecording_CapturesOutputAndExports()
+        {
+            string shell = ShellHelper.GetDefaultShell();
+            string tempFile = Path.GetTempFileName();
+            try
+            {
+                using var session = new RustPtySession(shell, 80, 24);
+
+                // Off by default: no ring, export refuses without touching the file.
+                Assert.False(session.IsFlightRecording);
+                Assert.False(session.TryExportFlightRecording(tempFile, out _));
+
+                session.EnableFlightRecording(2 * 1024 * 1024);
+                Assert.True(session.IsFlightRecording);
+
+                // The shell banner/prompt guarantees some output; poll until the
+                // ring has captured at least one chunk.
+                NovaTerminal.Replay.FlightExportInfo info = default;
+                bool exported = false;
+                for (int i = 0; i < 40; i++)
+                {
+                    await Task.Delay(250);
+                    exported = session.TryExportFlightRecording(tempFile, out info);
+                    Assert.True(exported);
+                    if (info.EventCount > 0) break;
+                }
+
+                Assert.True(exported);
+                Assert.True(info.EventCount > 0, "flight ring captured no output from a live shell");
+                Assert.True(File.Exists(tempFile));
+
+                // Disable drops the ring.
+                session.DisableFlightRecording();
+                Assert.False(session.IsFlightRecording);
+                Assert.False(session.TryExportFlightRecording(tempFile, out _));
+            }
+            finally
+            {
+                if (File.Exists(tempFile)) File.Delete(tempFile);
+            }
+        }
+
+        [Fact]
+        [Trait("Category", "PtySmoke")]
         public async Task RustPtySession_CanSpawnExecutableWithSpacesInPath()
         {
             // Regression: CreateProcessW with lpApplicationName=NULL and an

--- a/tests/NovaTerminal.App.Tests/ReplayTests/FlightRecordingBufferTests.cs
+++ b/tests/NovaTerminal.App.Tests/ReplayTests/FlightRecordingBufferTests.cs
@@ -383,6 +383,51 @@ namespace NovaTerminal.Tests.ReplayTests
         }
 
         [Fact]
+        public void PtyRecorder_ExplicitTimestampOverloads_ValidateArguments()
+        {
+            string tempFile = Path.GetTempFileName();
+            try
+            {
+                using (var recorder = new PtyRecorder(tempFile, 80, 24, "pwsh.exe"))
+                {
+                    Assert.Throws<ArgumentNullException>(() => recorder.RecordChunkAt(0, null!, 1));
+
+                    byte[] data = Utf8("xyz");
+                    recorder.RecordChunkAt(0, data, 0);               // empty — ignored
+                    recorder.RecordChunkAt(0, data, -1);              // negative — ignored
+                    recorder.RecordChunkAt(0, data, data.Length + 1); // oversized — ignored
+                    recorder.RecordResizeAt(0, 0, 24);                // non-positive — ignored
+                    recorder.RecordResizeAt(0, 80, -1);               // non-positive — ignored
+
+                    recorder.RecordChunkAt(5, data, data.Length);     // valid
+                }
+
+                ReplayEvent[] events = ReadEventLines(tempFile).ToArray();
+                ReplayEvent ev = Assert.Single(events);
+                Assert.Equal("data", ev.Type);
+                Assert.Equal(5, ev.TimeOffsetMs);
+            }
+            finally
+            {
+                if (File.Exists(tempFile)) File.Delete(tempFile);
+            }
+        }
+
+        [Fact]
+        public void ExportTo_UnwritablePath_ThrowsSynchronously()
+        {
+            // PtyRecorder's writer task swallows I/O failures (best-effort live
+            // recording); ExportTo must surface path errors synchronously so the
+            // session-level Try* surface can report false instead of "succeeding"
+            // with no file.
+            var ring = new FlightRecordingBuffer(1024, 80, 24, clock: static () => 0);
+            RecordChunk(ring, "data");
+
+            string missingDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "nested", "export.rec");
+            Assert.ThrowsAny<IOException>(() => ring.ExportTo(missingDir, "pwsh.exe"));
+        }
+
+        [Fact]
         public void PtyRecorder_ExplicitTimestampOverloads_RejectNegativeOffsets()
         {
             string tempFile = Path.GetTempFileName();

--- a/tests/NovaTerminal.App.Tests/ReplayTests/FlightRecordingBufferTests.cs
+++ b/tests/NovaTerminal.App.Tests/ReplayTests/FlightRecordingBufferTests.cs
@@ -1,0 +1,464 @@
+using NovaTerminal.VT;
+using NovaTerminal.Replay;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NovaTerminal.Tests.ReplayTests
+{
+    /// <summary>
+    /// Flight recorder core (agent-host A4 slice 1): bounded ring semantics,
+    /// explicit-timestamp recorder overloads, and the export round-trip
+    /// acceptance criterion from docs/plans/2026-07-07-agent-host-a4-replay-design.md.
+    /// </summary>
+    public class FlightRecordingBufferTests
+    {
+        private sealed class FakeClock
+        {
+            public long NowMs;
+            public long Read() => NowMs;
+        }
+
+        private static byte[] Utf8(string s) => Encoding.UTF8.GetBytes(s);
+
+        private static void RecordChunk(FlightRecordingBuffer ring, string text)
+        {
+            byte[] bytes = Utf8(text);
+            ring.RecordChunk(bytes, bytes.Length);
+        }
+
+        // ---------------------------------------------------------------
+        // Ring semantics
+        // ---------------------------------------------------------------
+
+        [Fact]
+        public void RecordChunk_OverBudget_EvictsOldestAndReportsTruncation()
+        {
+            // Budget fits two 100-byte chunks (plus overhead) but not three.
+            long budget = 2 * (100 + FlightRecordingBuffer.EntryOverheadBytes) + 10;
+            var ring = new FlightRecordingBuffer(budget, 80, 24, clock: static () => 0);
+
+            ring.RecordChunk(new byte[100], 100);
+            ring.RecordChunk(new byte[100], 100);
+            Assert.False(ring.GetStats().TruncatedAtStart);
+            Assert.Equal(2, ring.GetStats().EventCount);
+
+            ring.RecordChunk(new byte[100], 100);
+
+            FlightRecordingStats stats = ring.GetStats();
+            Assert.Equal(2, stats.EventCount);
+            Assert.True(stats.TruncatedAtStart);
+            Assert.True(stats.RetainedBytes <= budget);
+        }
+
+        [Fact]
+        public void RecordChunk_SingleChunkLargerThanBudget_IsRetained()
+        {
+            var ring = new FlightRecordingBuffer(maxTotalBytes: 64, 80, 24, clock: static () => 0);
+
+            ring.RecordChunk(new byte[10], 10);
+            ring.RecordChunk(new byte[4096], 4096); // alone exceeds the budget
+
+            FlightRecordingStats stats = ring.GetStats();
+            Assert.Equal(1, stats.EventCount); // newest survives, older evicted
+            Assert.True(stats.TruncatedAtStart);
+        }
+
+        [Fact]
+        public void RecordResize_FloodOverBudget_IsBoundedByEntryOverhead()
+        {
+            long budget = 10 * FlightRecordingBuffer.EntryOverheadBytes;
+            var ring = new FlightRecordingBuffer(budget, 80, 24, clock: static () => 0);
+
+            for (int i = 0; i < 1000; i++)
+            {
+                ring.RecordResize(81 + (i % 40), 25 + (i % 20));
+            }
+
+            FlightRecordingStats stats = ring.GetStats();
+            Assert.True(stats.EventCount <= 10);
+            Assert.True(stats.TruncatedAtStart);
+        }
+
+        [Fact]
+        public void Trim_EvictingResize_AdvancesWindowStartGeometry()
+        {
+            // Budget fits exactly one 100-byte chunk entry; recording
+            // chunk(100) → resize(132x43) → chunk(100) must evict both the first
+            // chunk and the resize, leaving the window-start geometry at 132x43.
+            long budget = 100 + FlightRecordingBuffer.EntryOverheadBytes;
+            var ring = new FlightRecordingBuffer(budget, 80, 24, clock: static () => 0);
+
+            ring.RecordChunk(new byte[100], 100);
+            ring.RecordResize(132, 43);
+            ring.RecordChunk(new byte[100], 100);
+
+            FlightRecordingStats stats = ring.GetStats();
+            Assert.Equal(132, stats.WindowStartCols);
+            Assert.Equal(43, stats.WindowStartRows);
+            Assert.True(stats.TruncatedAtStart);
+        }
+
+        [Fact]
+        public void Trim_EvictingOnlyChunks_KeepsInitialGeometry()
+        {
+            long budget = 100 + FlightRecordingBuffer.EntryOverheadBytes;
+            var ring = new FlightRecordingBuffer(budget, 80, 24, clock: static () => 0);
+
+            ring.RecordChunk(new byte[100], 100);
+            ring.RecordChunk(new byte[100], 100);
+
+            FlightRecordingStats stats = ring.GetStats();
+            Assert.Equal(80, stats.WindowStartCols);
+            Assert.Equal(24, stats.WindowStartRows);
+        }
+
+        [Fact]
+        public void Constructor_RejectsNonPositiveArguments()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new FlightRecordingBuffer(0, 80, 24));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new FlightRecordingBuffer(1024, 0, 24));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new FlightRecordingBuffer(1024, 80, -1));
+        }
+
+        // ---------------------------------------------------------------
+        // Export: header geometry, timestamp rebasing, truncation flag
+        // ---------------------------------------------------------------
+
+        [Fact]
+        public void ExportTo_RebasesTimestampsToFirstRetainedEvent()
+        {
+            string tempFile = Path.GetTempFileName();
+            try
+            {
+                var clock = new FakeClock();
+                var ring = new FlightRecordingBuffer(1024 * 1024, 80, 24, clock.Read);
+
+                clock.NowMs = 1000;
+                RecordChunk(ring, "one");
+                clock.NowMs = 1500;
+                ring.RecordResize(100, 30);
+                clock.NowMs = 2400;
+                RecordChunk(ring, "two");
+
+                FlightExportInfo info = ring.ExportTo(tempFile, "pwsh.exe");
+
+                Assert.Equal(3, info.EventCount);
+                Assert.Equal(1000, info.FirstEventMs);
+                Assert.Equal(2400, info.LastEventMs);
+                Assert.False(info.TruncatedAtStart);
+
+                long[] offsets = ReadEventLines(tempFile)
+                    .Select(ev => ev.TimeOffsetMs)
+                    .ToArray();
+                Assert.Equal(new long[] { 0, 500, 1400 }, offsets);
+            }
+            finally
+            {
+                if (File.Exists(tempFile)) File.Delete(tempFile);
+            }
+        }
+
+        [Fact]
+        public void ExportTo_HeaderCarriesWindowStartGeometry_AfterResizeEviction()
+        {
+            string tempFile = Path.GetTempFileName();
+            try
+            {
+                long budget = 100 + FlightRecordingBuffer.EntryOverheadBytes;
+                var ring = new FlightRecordingBuffer(budget, 80, 24, clock: static () => 0);
+
+                ring.RecordChunk(new byte[100], 100);
+                ring.RecordResize(132, 43);
+                ring.RecordChunk(new byte[100], 100);
+
+                FlightExportInfo info = ring.ExportTo(tempFile, "pwsh.exe");
+                Assert.True(info.TruncatedAtStart);
+
+                ReplayHeader header = ReadHeader(tempFile);
+                Assert.Equal("novarec", header.Type);
+                Assert.Equal(2, header.Version);
+                Assert.Equal(132, header.Cols);
+                Assert.Equal(43, header.Rows);
+            }
+            finally
+            {
+                if (File.Exists(tempFile)) File.Delete(tempFile);
+            }
+        }
+
+        [Fact]
+        public void ExportTo_EmptyRing_WritesHeaderOnlyFile()
+        {
+            string tempFile = Path.GetTempFileName();
+            try
+            {
+                var ring = new FlightRecordingBuffer(1024, 80, 24, clock: static () => 0);
+
+                FlightExportInfo info = ring.ExportTo(tempFile, "pwsh.exe");
+
+                Assert.Equal(0, info.EventCount);
+                Assert.False(info.TruncatedAtStart);
+
+                string[] lines = File.ReadAllLines(tempFile).Where(l => !string.IsNullOrWhiteSpace(l)).ToArray();
+                Assert.Single(lines);
+                ReplayHeader header = ReadHeader(tempFile);
+                Assert.Equal(80, header.Cols);
+                Assert.Equal(24, header.Rows);
+            }
+            finally
+            {
+                if (File.Exists(tempFile)) File.Delete(tempFile);
+            }
+        }
+
+        [Fact]
+        public void ExportTo_ContainsOnlyDataAndResizeEvents()
+        {
+            // Privacy invariant: the ring has no input API, so an export can never
+            // contain input events. Assert at the file level anyway.
+            string tempFile = Path.GetTempFileName();
+            try
+            {
+                var ring = new FlightRecordingBuffer(1024 * 1024, 80, 24, clock: static () => 0);
+                RecordChunk(ring, "password prompt: ");
+                ring.RecordResize(100, 30);
+                RecordChunk(ring, "ok\r\n");
+
+                ring.ExportTo(tempFile, "pwsh.exe");
+
+                string[] types = ReadEventLines(tempFile).Select(ev => ev.Type).ToArray();
+                Assert.Equal(3, types.Length);
+                Assert.All(types, t => Assert.True(t == "data" || t == "resize", $"unexpected event type '{t}'"));
+            }
+            finally
+            {
+                if (File.Exists(tempFile)) File.Delete(tempFile);
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // Thread-safety smoke: concurrent writer + exporter
+        // ---------------------------------------------------------------
+
+        [Fact]
+        public async Task ExportTo_WhileWriterIsRecording_ProducesValidFile()
+        {
+            var ring = new FlightRecordingBuffer(64 * 1024, 80, 24);
+            using var stop = new CancellationTokenSource();
+
+            Task writer = Task.Run(() =>
+            {
+                byte[] chunk = Utf8("chunk-of-output\r\n");
+                int i = 0;
+                while (!stop.Token.IsCancellationRequested)
+                {
+                    ring.RecordChunk(chunk, chunk.Length);
+                    if (++i % 50 == 0) ring.RecordResize(80 + (i % 5), 24);
+                }
+            });
+
+            try
+            {
+                for (int round = 0; round < 5; round++)
+                {
+                    string tempFile = Path.GetTempFileName();
+                    try
+                    {
+                        FlightExportInfo info = ring.ExportTo(tempFile, "pwsh.exe");
+
+                        // Every export must be a well-formed v2 file with monotonic timestamps.
+                        ReplayHeader header = ReadHeader(tempFile);
+                        Assert.Equal("novarec", header.Type);
+
+                        long previous = -1;
+                        int count = 0;
+                        foreach (ReplayEvent ev in ReadEventLines(tempFile))
+                        {
+                            Assert.True(ev.TimeOffsetMs >= previous, "timestamps must be non-decreasing");
+                            previous = ev.TimeOffsetMs;
+                            count++;
+                        }
+                        Assert.Equal(info.EventCount, count);
+                    }
+                    finally
+                    {
+                        if (File.Exists(tempFile)) File.Delete(tempFile);
+                    }
+                }
+            }
+            finally
+            {
+                stop.Cancel();
+                await writer;
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // PtyRecorder explicit-timestamp overloads
+        // ---------------------------------------------------------------
+
+        [Fact]
+        public void PtyRecorder_ExplicitTimestampOverloads_SerializeGivenOffsets()
+        {
+            string tempFile = Path.GetTempFileName();
+            try
+            {
+                using (var recorder = new PtyRecorder(tempFile, 80, 24, "pwsh.exe"))
+                {
+                    byte[] data = Utf8("hello");
+                    recorder.RecordChunkAt(0, data, data.Length);
+                    recorder.RecordResizeAt(250, 100, 30);
+                    recorder.RecordChunkAt(1300, data, data.Length);
+                }
+
+                ReplayEvent[] events = ReadEventLines(tempFile).ToArray();
+                Assert.Equal(3, events.Length);
+                Assert.Equal(0, events[0].TimeOffsetMs);
+                Assert.Equal("data", events[0].Type);
+                Assert.Equal(250, events[1].TimeOffsetMs);
+                Assert.Equal("resize", events[1].Type);
+                Assert.Equal(100, events[1].Cols);
+                Assert.Equal(30, events[1].Rows);
+                Assert.Equal(1300, events[2].TimeOffsetMs);
+            }
+            finally
+            {
+                if (File.Exists(tempFile)) File.Delete(tempFile);
+            }
+        }
+
+        [Fact]
+        public void PtyRecorder_ExplicitTimestampOverloads_RejectNegativeOffsets()
+        {
+            string tempFile = Path.GetTempFileName();
+            try
+            {
+                using var recorder = new PtyRecorder(tempFile, 80, 24, "pwsh.exe");
+                byte[] data = Utf8("x");
+                Assert.Throws<ArgumentOutOfRangeException>(() => recorder.RecordChunkAt(-1, data, data.Length));
+                Assert.Throws<ArgumentOutOfRangeException>(() => recorder.RecordResizeAt(-1, 80, 24));
+            }
+            finally
+            {
+                if (File.Exists(tempFile)) File.Delete(tempFile);
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // Round-trip acceptance criterion (DIRECTION A4): export → ReplayRunner
+        // yields the same buffer as feeding the bytes directly.
+        // ---------------------------------------------------------------
+
+        [Fact]
+        public async Task ExportedFlightRecording_RoundTripsThroughReplayRunner_WithBufferParity()
+        {
+            string tempFile = Path.GetTempFileName();
+            try
+            {
+                // Byte script: text, a resize, colored text, and an emoji whose UTF-8
+                // bytes are deliberately split across two chunks — export must
+                // preserve wire-exact chunk boundaries, not re-encoded strings.
+                byte[] rocket = Utf8("🚀"); // 4 bytes
+                var script = new (byte[]? Chunk, (int Cols, int Rows)? Resize)[]
+                {
+                    (Utf8("alpha\r\nbeta"), null),
+                    (null, (100, 30)),
+                    (Utf8("\x1b[31mred "), null),
+                    (rocket.AsSpan(0, 2).ToArray(), null),
+                    (rocket.AsSpan(2, 2).ToArray(), null),
+                    (Utf8(" done\x1b[0m"), null),
+                };
+
+                // 1. Feed the ring (as the PTY read loop would) and export.
+                var clock = new FakeClock();
+                var ring = new FlightRecordingBuffer(1024 * 1024, 80, 24, clock.Read);
+                foreach (var step in script)
+                {
+                    clock.NowMs += 10;
+                    if (step.Chunk != null) ring.RecordChunk(step.Chunk, step.Chunk.Length);
+                    else ring.RecordResize(step.Resize!.Value.Cols, step.Resize.Value.Rows);
+                }
+                FlightExportInfo info = ring.ExportTo(tempFile, "pwsh.exe");
+                Assert.Equal(script.Length, info.EventCount);
+
+                // 2. Expected: the same bytes fed directly into a buffer.
+                var expectedBuffer = new TerminalBuffer(80, 24);
+                var expectedParser = new AnsiParser(expectedBuffer);
+                var expectedDecoder = Encoding.UTF8.GetDecoder();
+                foreach (var step in script)
+                {
+                    if (step.Chunk != null)
+                    {
+                        char[] chars = new char[Encoding.UTF8.GetMaxCharCount(step.Chunk.Length)];
+                        int n = expectedDecoder.GetChars(step.Chunk, 0, step.Chunk.Length, chars, 0);
+                        if (n > 0) expectedParser.Process(new string(chars, 0, n));
+                    }
+                    else
+                    {
+                        expectedBuffer.Resize(step.Resize!.Value.Cols, step.Resize.Value.Rows);
+                    }
+                }
+
+                // 3. Actual: replay the exported file through the deterministic core.
+                var actualBuffer = new TerminalBuffer(80, 24);
+                var actualParser = new AnsiParser(actualBuffer);
+                var actualDecoder = Encoding.UTF8.GetDecoder();
+                var runner = new ReplayRunner(tempFile);
+                ReplayRunResult result = await runner.RunWithResultAsync(
+                    onDataCallback: data =>
+                    {
+                        char[] chars = new char[Encoding.UTF8.GetMaxCharCount(data.Length)];
+                        int n = actualDecoder.GetChars(data, 0, data.Length, chars, 0);
+                        if (n > 0) actualParser.Process(new string(chars, 0, n));
+                        return Task.CompletedTask;
+                    },
+                    onResizeCallback: (cols, rows) =>
+                    {
+                        actualBuffer.Resize(cols, rows);
+                        return Task.CompletedTask;
+                    },
+                    options: new ReplayRunOptions { PlaybackMode = ReplayPlaybackMode.Virtual });
+
+                Assert.False(result.Truncated);
+
+                // 4. Byte-identical buffer snapshots.
+                BufferSnapshot expected = BufferSnapshot.Capture(expectedBuffer, includeAttributes: true);
+                BufferSnapshot actual = BufferSnapshot.Capture(actualBuffer, includeAttributes: true);
+                Assert.Equal(expected.ToFormattedString(), actual.ToFormattedString());
+            }
+            finally
+            {
+                if (File.Exists(tempFile)) File.Delete(tempFile);
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // Helpers
+        // ---------------------------------------------------------------
+
+        private static ReplayHeader ReadHeader(string filePath)
+        {
+            string first = File.ReadLines(filePath).First();
+            ReplayHeader? header = JsonSerializer.Deserialize(first, ReplayJsonContext.Default.ReplayHeader);
+            Assert.NotNull(header);
+            return header!;
+        }
+
+        private static System.Collections.Generic.IEnumerable<ReplayEvent> ReadEventLines(string filePath)
+        {
+            foreach (string line in File.ReadAllLines(filePath).Skip(1))
+            {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+                ReplayEvent? ev = JsonSerializer.Deserialize(line, ReplayJsonContext.Default.ReplayEvent);
+                Assert.NotNull(ev);
+                yield return ev!;
+            }
+        }
+    }
+}

--- a/tests/NovaTerminal.App.Tests/ReplayTests/FlightRecordingBufferTests.cs
+++ b/tests/NovaTerminal.App.Tests/ReplayTests/FlightRecordingBufferTests.cs
@@ -193,6 +193,55 @@ namespace NovaTerminal.Tests.ReplayTests
         }
 
         [Fact]
+        public async Task ExportTo_AfterResizeEviction_ReplayerAppliesPostResizeGeometryBeforeData()
+        {
+            // The retained window may start with a chunk that was emitted *after* a
+            // resize that has since been evicted. ReplayRunner applies the header
+            // geometry before replaying data, so the header must carry the
+            // post-resize dimensions — otherwise that chunk would render at the old
+            // width (wrong wrapping/cursor).
+            string tempFile = Path.GetTempFileName();
+            try
+            {
+                long budget = 100 + FlightRecordingBuffer.EntryOverheadBytes;
+                var ring = new FlightRecordingBuffer(budget, 80, 24, clock: static () => 0);
+
+                ring.RecordChunk(new byte[100], 100);   // 80x24 era — evicted
+                ring.RecordResize(132, 43);             // evicted
+                ring.RecordChunk(new byte[100], 100);   // retained; emitted at 132x43
+
+                ring.ExportTo(tempFile, "pwsh.exe");
+
+                var geometryCallbacks = new System.Collections.Generic.List<(int Cols, int Rows)>();
+                int dataChunksBeforeFirstGeometry = 0;
+                var runner = new ReplayRunner(tempFile);
+                await runner.RunWithResultAsync(
+                    onDataCallback: _ =>
+                    {
+                        if (geometryCallbacks.Count == 0) dataChunksBeforeFirstGeometry++;
+                        return Task.CompletedTask;
+                    },
+                    onResizeCallback: (cols, rows) =>
+                    {
+                        geometryCallbacks.Add((cols, rows));
+                        return Task.CompletedTask;
+                    },
+                    options: new ReplayRunOptions { PlaybackMode = ReplayPlaybackMode.Virtual });
+
+                // Geometry arrives from the header before any data, and it is the
+                // post-resize geometry — never the stale 80x24.
+                Assert.Equal(0, dataChunksBeforeFirstGeometry);
+                Assert.NotEmpty(geometryCallbacks);
+                Assert.Equal((132, 43), geometryCallbacks[0]);
+                Assert.DoesNotContain((80, 24), geometryCallbacks);
+            }
+            finally
+            {
+                if (File.Exists(tempFile)) File.Delete(tempFile);
+            }
+        }
+
+        [Fact]
         public void ExportTo_EmptyRing_WritesHeaderOnlyFile()
         {
             string tempFile = Path.GetTempFileName();

--- a/tests/NovaTerminal.App.Tests/Ssh/TerminalPaneRecordingTests.cs
+++ b/tests/NovaTerminal.App.Tests/Ssh/TerminalPaneRecordingTests.cs
@@ -132,6 +132,22 @@ public sealed class TerminalPaneRecordingTests
             IsRecording = false;
         }
 
+        public bool IsFlightRecording => false;
+
+        public void EnableFlightRecording(long maxTotalBytes)
+        {
+        }
+
+        public void DisableFlightRecording()
+        {
+        }
+
+        public bool TryExportFlightRecording(string filePath, out NovaTerminal.Replay.FlightExportInfo info)
+        {
+            info = default;
+            return false;
+        }
+
         public void AttachBuffer(TerminalBuffer buffer)
         {
         }

--- a/tests/NovaTerminal.App.Tests/Ssh/TerminalPaneSshDisconnectTests.cs
+++ b/tests/NovaTerminal.App.Tests/Ssh/TerminalPaneSshDisconnectTests.cs
@@ -159,6 +159,22 @@ public sealed class TerminalPaneSshDisconnectTests
         {
         }
 
+        public bool IsFlightRecording => false;
+
+        public void EnableFlightRecording(long maxTotalBytes)
+        {
+        }
+
+        public void DisableFlightRecording()
+        {
+        }
+
+        public bool TryExportFlightRecording(string filePath, out NovaTerminal.Replay.FlightExportInfo info)
+        {
+            info = default;
+            return false;
+        }
+
         public void AttachBuffer(TerminalBuffer buffer)
         {
         }

--- a/tests/NovaTerminal.ExternalSuites/Vttest/VttestCapture.cs
+++ b/tests/NovaTerminal.ExternalSuites/Vttest/VttestCapture.cs
@@ -123,6 +123,14 @@ namespace NovaTerminal.ExternalSuites.Vttest
         public void Resize(int cols, int rows) { }
         public void StartRecording(string filePath) { }
         public void StopRecording() { }
+        public bool IsFlightRecording => false;
+        public void EnableFlightRecording(long maxTotalBytes) { }
+        public void DisableFlightRecording() { }
+        public bool TryExportFlightRecording(string filePath, out NovaTerminal.Replay.FlightExportInfo info)
+        {
+            info = default;
+            return false;
+        }
         public void AttachBuffer(TerminalBuffer buffer) { }
         public void TakeSnapshot() { }
 


### PR DESCRIPTION
## Summary

First of three PR slices for **milestone A4 (Replay for agents)** per the approved design in `docs/plans/2026-07-07-agent-host-a4-replay-design.md` (included in this PR): the **flight recorder core**. This slice is inert — nothing enables the ring yet; the agent-host lifecycle wiring, `exportReplay` protocol method, and settings gate land in slice 2, the `--replay` CLI in slice 3.

## What's here

**`FlightRecordingBuffer` (NovaTerminal.Replay, new)**
- Thread-safe bounded ring of `(tMs, chunk|resize, payload)` entries; retention bounded by total payload bytes plus a fixed 32-byte per-event overhead (so payload-free resize floods can't grow the ring without bound).
- Tracks the **geometry at the start of the retained window**: evicting a resize advances the window-start geometry, so an export is always self-consistent (v2 header geometry = geometry in effect at the first retained event).
- The most recent event is always retained, even if it alone exceeds the budget — an oversized final chunk must not silently empty the export.
- `ExportTo(filePath, shell)` snapshots the ring under lock, then writes a standard replay **v2** file via `PtyRecorder` with timestamps **rebased to the first retained event**. Injectable monotonic clock for tests.
- **Privacy invariant:** the type has *no input-event API by design*. Agent-triggered exports must never contain typed input (passwords at prompts); replay rendering needs only output + resize.

**`PtyRecorder` explicit-timestamp overloads**
- `RecordChunkAt(long tMs, …)` / `RecordResizeAt(long tMs, …)`; the existing `RecordChunk`/`RecordResize` now delegate with the enqueue-time clock. Needed so exports preserve original inter-chunk timing (the format's `t` field) — Virtual replay ignores timing, but Realtime playback and future frame-stepping must not see garbage.

**`ITerminalFlightRecorder` (NovaTerminal.Pty)**
- `IsFlightRecording` / `EnableFlightRecording(maxTotalBytes)` / `DisableFlightRecording()` / `TryExportFlightRecording(path, out FlightExportInfo)`, folded into `ITerminalSession` alongside `ITerminalRecorder`.
- `RustPtySession`: ring fed at the existing byte-level tap points (`ReadLoop` chunk before UTF-8 decode, `Resize`) — same places as `_recorder`, one extra null-check per chunk when disabled. Ring dropped on dispose.
- `NativeSshSession`: same integration at its byte tap (`EmitOutput`, `Resize`) — native SSH sessions are first-class for agent replay export.
- `SshSession` / `OpenSshSession`: delegate to the inner session. Test stubs (`TerminalPaneRecordingTests`, `TerminalPaneSshDisconnectTests`, `VttestCapture`) implement no-ops.

## Layering

Raw bytes stay in Pty; the ring lives in Replay (unit-testable in isolation, Pty already references Replay); **Pty still never references VT**; contracts untouched. Architecture suite passes unchanged (18/18).

## Testing

- **Ring unit tests:** byte-budget trimming + truncation flag, oversized-chunk retention, resize-flood bounding, window-start geometry across evicted resizes (and not across evicted chunks), constructor validation.
- **Export tests:** timestamp rebasing (fake clock → exact `t` values in file), header geometry after resize eviction, empty-ring header-only file, file-level assertion that exports contain **only `data`/`resize` events**.
- **Thread-safety smoke:** concurrent writer + repeated exports; every export is a well-formed v2 file with non-decreasing timestamps.
- **Recorder overloads:** explicit `t` values serialized verbatim; negative offsets rejected.
- **Round-trip (A4 acceptance criterion):** byte script incl. a resize and an emoji whose UTF-8 bytes are split across two chunks → ring → export → `ReplayRunner` (Virtual) → `BufferSnapshot` byte-identical to a buffer fed the same bytes directly.
- **Session surface smoke (`PtySmoke`):** live `RustPtySession` — off by default, enable → captures real shell output → export produces a file, disable drops the ring.

Local results: App.Tests (ReplayTests+PtySmoke+TerminalPaneRecording+AgentHost filter) 127/127, Architecture 18/18, Platform 120/120.

## Slicing plan (from the design doc)

1. **This PR** — flight recorder core, inert.
2. Protocol + tool: `AgentHostService` lifecycle wiring, `exportReplay` + `exportDisabled` error code, `AgentReplayExportEnabled` setting (default off), MCP `novaterminal.export_replay`, protocol/privacy tests.
3. CLI + docs: `--replay` headless render-to-text, README, DIRECTION A4 checkboxes.
