### PR TITLE
feat(agent-host): A4 slice 2 - exportReplay protocol + MCP tool behind default-off sub-gate

### DIFF
--- a/src/NovaTerminal.AgentHost.Contracts/AgentHostJsonContext.cs
+++ b/src/NovaTerminal.AgentHost.Contracts/AgentHostJsonContext.cs
@@ -26,6 +26,8 @@ namespace NovaTerminal.AgentHost.Contracts;
 [JsonSerializable(typeof(AgentEventDto))]
 [JsonSerializable(typeof(WaitForEventsParams))]
 [JsonSerializable(typeof(WaitForEventsResult))]
+[JsonSerializable(typeof(ExportReplayParams))]
+[JsonSerializable(typeof(ExportReplayResult))]
 public sealed partial class AgentHostJsonContext : JsonSerializerContext
 {
 }

--- a/src/NovaTerminal.AgentHost.Contracts/AgentHostProtocol.cs
+++ b/src/NovaTerminal.AgentHost.Contracts/AgentHostProtocol.cs
@@ -38,6 +38,17 @@ public static class AgentHostProtocol
     /// <summary>Capacity of the server's event ring; older events are evicted and reported via oldestSeq.</summary>
     public const int EventRingCapacity = 256;
 
+    /// <summary>
+    /// Per-session retention budget for the flight recorder ring behind
+    /// <c>exportReplay</c> (A4): total payload bytes plus a fixed per-event
+    /// overhead of recent raw output/resize events kept in memory while the
+    /// observe endpoint is running.
+    /// </summary>
+    public const long FlightRecorderMaxBytesPerSession = 2 * 1024 * 1024;
+
+    /// <summary>Subfolder of the recordings directory where agent-triggered exports land (A4).</summary>
+    public const string AgentExportsSubdirectory = "agent-exports";
+
     /// <summary>Method names. Observe-only; later milestones append, they never repurpose.</summary>
     public static class Methods
     {
@@ -46,6 +57,14 @@ public static class AgentHostProtocol
         public const string ReadScrollback = "readScrollback";
         public const string GetSessionStatus = "getSessionStatus";
         public const string WaitForEvents = "waitForEvents";
+
+        /// <summary>
+        /// A4: writes a session's flight recording (recent output + resizes,
+        /// never input) to a replay v2 file and returns its path. Additive in
+        /// protocol version 1; requires the replay-export setting on top of
+        /// the observe toggle.
+        /// </summary>
+        public const string ExportReplay = "exportReplay";
     }
 
     /// <summary>Wire values for session status (A2). See the A2 design doc for exact semantics.</summary>
@@ -86,5 +105,19 @@ public static class AgentHostProtocol
         public const string UnknownMethod = "unknownMethod";
         public const string SessionNotFound = "sessionNotFound";
         public const string Internal = "internal";
+
+        /// <summary>
+        /// A4: <c>exportReplay</c> was called but the user has not enabled
+        /// "Agent replay export" in settings (a second default-off gate on top
+        /// of the observe toggle, per the DIRECTION permission table).
+        /// </summary>
+        public const string ExportDisabled = "exportDisabled";
+
+        /// <summary>
+        /// A4: the session exists but no flight recording is available to
+        /// export right now (its PTY session is not yet published, was torn
+        /// down, or the export failed to write).
+        /// </summary>
+        public const string ExportUnavailable = "exportUnavailable";
     }
 }

--- a/src/NovaTerminal.AgentHost.Contracts/ReplayContracts.cs
+++ b/src/NovaTerminal.AgentHost.Contracts/ReplayContracts.cs
@@ -1,0 +1,43 @@
+using System.Text.Json.Serialization;
+
+namespace NovaTerminal.AgentHost.Contracts;
+
+/// <summary>Params for <c>exportReplay</c> (A4).</summary>
+public sealed record ExportReplayParams
+{
+    [JsonPropertyName("paneId")]
+    public required Guid PaneId { get; init; }
+}
+
+/// <summary>
+/// Result payload for <c>exportReplay</c>: where the replay v2 file landed and
+/// what window it covers. Privacy invariant: the file contains output and
+/// resize events only — never input (typed keys are not retained by the flight
+/// recorder at all; see docs/plans/2026-07-07-agent-host-a4-replay-design.md).
+/// </summary>
+public sealed record ExportReplayResult
+{
+    /// <summary>Absolute path of the written replay file.</summary>
+    [JsonPropertyName("filePath")]
+    public required string FilePath { get; init; }
+
+    /// <summary>Events written (output chunks + resizes).</summary>
+    [JsonPropertyName("eventCount")]
+    public required int EventCount { get; init; }
+
+    /// <summary>
+    /// First exported event, in milliseconds since flight recording started
+    /// for this session. Timestamps inside the file are rebased so the first
+    /// event is t=0; this locates the window on the session's timeline.
+    /// </summary>
+    [JsonPropertyName("firstEventMs")]
+    public required long FirstEventMs { get; init; }
+
+    /// <summary>Last exported event, same timeline as <see cref="FirstEventMs"/>.</summary>
+    [JsonPropertyName("lastEventMs")]
+    public required long LastEventMs { get; init; }
+
+    /// <summary>True when older events had already been evicted from the bounded ring.</summary>
+    [JsonPropertyName("truncatedAtStart")]
+    public required bool TruncatedAtStart { get; init; }
+}

--- a/src/NovaTerminal.App/AgentHost/AgentHostService.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentHostService.cs
@@ -37,6 +37,7 @@ namespace NovaTerminal.AgentHost
         private readonly AgentSessionRegistry _registry;
         private readonly string? _endpointOverride;
         private readonly string? _discoveryDirectoryOverride;
+        private readonly string? _exportDirectoryOverride;
         private readonly object _gate = new();
 
         private CancellationTokenSource? _cts;
@@ -55,12 +56,24 @@ namespace NovaTerminal.AgentHost
         public AgentHostService(
             AgentSessionRegistry registry,
             string? endpointOverride = null,
-            string? discoveryDirectoryOverride = null)
+            string? discoveryDirectoryOverride = null,
+            string? exportDirectoryOverride = null)
         {
             _registry = registry ?? throw new ArgumentNullException(nameof(registry));
             _endpointOverride = endpointOverride;
             _discoveryDirectoryOverride = discoveryDirectoryOverride;
+            _exportDirectoryOverride = exportDirectoryOverride;
         }
+
+        /// <summary>
+        /// Second default-off gate for <c>exportReplay</c> (A4): mirrors
+        /// <c>TerminalSettings.AgentReplayExportEnabled</c>, pushed by
+        /// MainWindow alongside <see cref="Apply"/>. Both the observe toggle
+        /// (endpoint running) and this flag must be on for an export to
+        /// succeed — the "explicit export action" tier of the DIRECTION
+        /// permission table. Read on the IPC thread; bool reads are atomic.
+        /// </summary>
+        public bool ReplayExportEnabled { get; set; }
 
         public bool IsRunning
         {
@@ -234,9 +247,12 @@ namespace NovaTerminal.AgentHost
             // Sessions that were already open when the endpoint started get
             // forwarding but no synthetic sessionOpened: a fresh client learns
             // about them via listSessions, not via a burst of stale events.
+            // They also start flight recording (A4): the ring exists exactly
+            // while the observe endpoint runs — off-is-off.
             foreach (var registration in _registry.GetRegistrations())
             {
                 AttachStatusForwarding(registration);
+                registration.EnableFlightRecording(AgentHostProtocol.FlightRecorderMaxBytesPerSession);
             }
 
             _sweepTimer = new Timer(_ => SweepStatuses(), null,
@@ -250,6 +266,13 @@ namespace NovaTerminal.AgentHost
 
             _registry.SessionRegistered -= OnSessionRegistered;
             _registry.SessionUnregistered -= OnSessionUnregistered;
+
+            // Off-is-off: disabling Agent Access drops every flight ring now —
+            // no in-memory retention survives the toggle.
+            foreach (var registration in _registry.GetRegistrations())
+            {
+                registration.DisableFlightRecording();
+            }
 
             foreach (var (registration, handler) in _statusSubscriptions)
             {
@@ -267,6 +290,7 @@ namespace NovaTerminal.AgentHost
                 ring = _eventRing;
                 if (ring == null) return;
                 AttachStatusForwardingLocked(registration, ring);
+                registration.EnableFlightRecording(AgentHostProtocol.FlightRecorderMaxBytesPerSession);
             }
 
             var status = registration.StatusMachine.Snapshot();
@@ -549,6 +573,7 @@ namespace NovaTerminal.AgentHost
                     AgentHostProtocol.Methods.ReadScrollback => HandleReadScrollback(request),
                     AgentHostProtocol.Methods.GetSessionStatus => HandleGetSessionStatus(request),
                     AgentHostProtocol.Methods.WaitForEvents => await HandleWaitForEventsAsync(request, cancellationToken).ConfigureAwait(false),
+                    AgentHostProtocol.Methods.ExportReplay => HandleExportReplay(request),
                     _ => Error(request.Id, AgentHostProtocol.ErrorCodes.UnknownMethod, $"Unknown method '{request.Method}'."),
                 };
             }
@@ -600,6 +625,55 @@ namespace NovaTerminal.AgentHost
             var timeout = TimeSpan.FromMilliseconds(Math.Clamp(p.TimeoutMs, 0, AgentHostProtocol.MaxWaitForEventsTimeoutMs));
             var result = await ring.WaitSinceAsync(sinceSeq, timeout, cancellationToken).ConfigureAwait(false);
             return Ok(request.Id, JsonSerializer.SerializeToElement(result, AgentHostJsonContext.Default.WaitForEventsResult));
+        }
+
+        private AgentHostResponse HandleExportReplay(AgentHostRequest request)
+        {
+            var p = DeserializeParams(request, AgentHostJsonContext.Default.ExportReplayParams);
+            if (p == null)
+            {
+                return Error(request.Id, AgentHostProtocol.ErrorCodes.MalformedRequest, "exportReplay requires params with a paneId.");
+            }
+
+            // Second default-off gate (DIRECTION permission table: "observe
+            // permission + explicit export action"). The observe toggle got the
+            // caller this far; replay export needs its own opt-in.
+            if (!ReplayExportEnabled)
+            {
+                return Error(
+                    request.Id,
+                    AgentHostProtocol.ErrorCodes.ExportDisabled,
+                    "Replay export is disabled. Enable Settings → Agent access (observe) → Agent replay export in NovaTerminal, then retry. Exports contain terminal output and resizes only — never typed input.");
+            }
+
+            if (!_registry.TryGet(p.PaneId, out var registration))
+            {
+                return Error(request.Id, AgentHostProtocol.ErrorCodes.SessionNotFound, $"No live session with paneId '{p.PaneId}'.");
+            }
+
+            var exportDir = _exportDirectoryOverride
+                ?? Path.Combine(NovaTerminal.Shell.AppPaths.RecordingsDirectory, AgentHostProtocol.AgentExportsSubdirectory);
+            Directory.CreateDirectory(exportDir);
+            var fileName = Controls.TerminalPane.BuildRecordingFileName(DateTime.Now, p.PaneId.ToString("N"));
+            var filePath = Path.Combine(exportDir, fileName);
+
+            if (!registration.TryExportFlightRecording(filePath, out var info))
+            {
+                return Error(
+                    request.Id,
+                    AgentHostProtocol.ErrorCodes.ExportUnavailable,
+                    "No flight recording is available for this session right now (the session may still be starting, already closed, or the file could not be written).");
+            }
+
+            var result = new ExportReplayResult
+            {
+                FilePath = Path.GetFullPath(filePath),
+                EventCount = info.EventCount,
+                FirstEventMs = info.FirstEventMs,
+                LastEventMs = info.LastEventMs,
+                TruncatedAtStart = info.TruncatedAtStart,
+            };
+            return Ok(request.Id, JsonSerializer.SerializeToElement(result, AgentHostJsonContext.Default.ExportReplayResult));
         }
 
         private AgentHostResponse HandleListSessions(AgentHostRequest request)

--- a/src/NovaTerminal.App/AgentHost/AgentHostService.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentHostService.cs
@@ -65,15 +65,24 @@ namespace NovaTerminal.AgentHost
             _exportDirectoryOverride = exportDirectoryOverride;
         }
 
+        // Volatile: written by the UI thread (settings apply), read by the IPC
+        // thread per exportReplay request — the store/load barrier makes a
+        // toggle visible to in-flight connections immediately.
+        private volatile bool _replayExportEnabled;
+
         /// <summary>
         /// Second default-off gate for <c>exportReplay</c> (A4): mirrors
         /// <c>TerminalSettings.AgentReplayExportEnabled</c>, pushed by
         /// MainWindow alongside <see cref="Apply"/>. Both the observe toggle
         /// (endpoint running) and this flag must be on for an export to
         /// succeed — the "explicit export action" tier of the DIRECTION
-        /// permission table. Read on the IPC thread; bool reads are atomic.
+        /// permission table.
         /// </summary>
-        public bool ReplayExportEnabled { get; set; }
+        public bool ReplayExportEnabled
+        {
+            get => _replayExportEnabled;
+            set => _replayExportEnabled = value;
+        }
 
         public bool IsRunning
         {
@@ -654,7 +663,11 @@ namespace NovaTerminal.AgentHost
             var exportDir = _exportDirectoryOverride
                 ?? Path.Combine(NovaTerminal.Shell.AppPaths.RecordingsDirectory, AgentHostProtocol.AgentExportsSubdirectory);
             Directory.CreateDirectory(exportDir);
-            var fileName = Controls.TerminalPane.BuildRecordingFileName(DateTime.Now, p.PaneId.ToString("N"));
+            // Fresh random suffix per export (same scheme as manual recordings):
+            // the timestamp alone has one-second resolution, so repeated exports
+            // for one pane within a second must not compute the same path — the
+            // writer truncates, which would silently destroy the earlier file.
+            var fileName = Controls.TerminalPane.BuildRecordingFileName(DateTime.Now, Guid.NewGuid().ToString("N"));
             var filePath = Path.Combine(exportDir, fileName);
 
             if (!registration.TryExportFlightRecording(filePath, out var info))

--- a/src/NovaTerminal.App/AgentHost/AgentSessionRegistration.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentSessionRegistration.cs
@@ -70,7 +70,25 @@ namespace NovaTerminal.AgentHost
         /// <summary>Publishes (or clears) the PTY session this registration runs on. UI thread.</summary>
         public void SetLifecycle(NovaTerminal.Pty.ITerminalSession? session)
         {
+            var previous = _session;
             _session = session;
+
+            // The flight ring follows the observe lifecycle of *this*
+            // registration: a session this registration no longer owns
+            // (reconnect swap, detach) must not keep retaining output until
+            // its eventual disposal.
+            if (previous != null && !ReferenceEquals(previous, session))
+            {
+                try
+                {
+                    previous.DisableFlightRecording();
+                }
+                catch
+                {
+                    // raced a dispose — the ring died with the session
+                }
+            }
+
             if (session != null)
             {
                 var maxBytes = System.Threading.Interlocked.Read(ref _flightRecordingMaxBytes);

--- a/src/NovaTerminal.App/AgentHost/AgentSessionRegistration.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentSessionRegistration.cs
@@ -50,15 +50,103 @@ namespace NovaTerminal.AgentHost
         /// </summary>
         public AgentSessionStatusMachine StatusMachine { get; }
 
-        // The PTY lifecycle behind this session, published by the pane on the
+        // The PTY session behind this registration, published by the pane on the
         // UI thread whenever the session is created, swapped, or torn down —
         // the same push pattern as the metadata snapshot, so the endpoint's
         // sweep never dereferences pane state. Volatile: a reference published
-        // here is safely visible to the timer thread.
-        private volatile NovaTerminal.Pty.ITerminalLifecycle? _lifecycle;
+        // here is safely visible to the timer thread. Widened from
+        // ITerminalLifecycle in A4 so the endpoint can also reach the
+        // flight-recorder surface (ITerminalFlightRecorder) without touching
+        // the pane; the sweep still uses only the lifecycle members.
+        private volatile NovaTerminal.Pty.ITerminalSession? _session;
 
-        /// <summary>Publishes (or clears) the PTY lifecycle this session runs on. UI thread.</summary>
-        public void SetLifecycle(NovaTerminal.Pty.ITerminalLifecycle? lifecycle) => _lifecycle = lifecycle;
+        // Desired flight-recording state pushed by the endpoint (A4). Kept on
+        // the registration because the pane may publish the session *after*
+        // the endpoint enabled recording (registration happens before spawn),
+        // and reconnects swap sessions: every newly published session must
+        // inherit the endpoint's decision. 0 = disabled.
+        private long _flightRecordingMaxBytes;
+
+        /// <summary>Publishes (or clears) the PTY session this registration runs on. UI thread.</summary>
+        public void SetLifecycle(NovaTerminal.Pty.ITerminalSession? session)
+        {
+            _session = session;
+            if (session != null)
+            {
+                var maxBytes = System.Threading.Interlocked.Read(ref _flightRecordingMaxBytes);
+                if (maxBytes > 0)
+                {
+                    TryApplyFlightRecording(session, maxBytes);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Endpoint lifecycle (A4): start retaining recent output on the
+        /// current session and every session published later, bounded by
+        /// <paramref name="maxBytes"/>. Idempotent.
+        /// </summary>
+        public void EnableFlightRecording(long maxBytes)
+        {
+            System.Threading.Interlocked.Exchange(ref _flightRecordingMaxBytes, maxBytes);
+            if (_session is { } session)
+            {
+                TryApplyFlightRecording(session, maxBytes);
+            }
+        }
+
+        /// <summary>Endpoint lifecycle (A4): stop retaining and drop the ring. Idempotent.</summary>
+        public void DisableFlightRecording()
+        {
+            System.Threading.Interlocked.Exchange(ref _flightRecordingMaxBytes, 0);
+            var session = _session;
+            if (session == null) return;
+            try
+            {
+                session.DisableFlightRecording();
+            }
+            catch
+            {
+                // raced a dispose — the ring died with the session
+            }
+        }
+
+        /// <summary>
+        /// Exports the session's flight recording to <paramref name="filePath"/>.
+        /// False when no session is published, recording is not enabled, or the
+        /// write failed (the session logs the reason).
+        /// </summary>
+        public bool TryExportFlightRecording(string filePath, out NovaTerminal.Replay.FlightExportInfo info)
+        {
+            var session = _session;
+            if (session == null)
+            {
+                info = default;
+                return false;
+            }
+
+            try
+            {
+                return session.TryExportFlightRecording(filePath, out info);
+            }
+            catch
+            {
+                info = default;
+                return false; // raced a dispose — treat as unavailable
+            }
+        }
+
+        private static void TryApplyFlightRecording(NovaTerminal.Pty.ITerminalSession session, long maxBytes)
+        {
+            try
+            {
+                session.EnableFlightRecording(maxBytes);
+            }
+            catch
+            {
+                // raced a dispose — the next published session will inherit the state
+            }
+        }
 
         /// <summary>
         /// PTY child-process probe for the heuristic status tier, invoked by
@@ -71,7 +159,7 @@ namespace NovaTerminal.AgentHost
         /// </summary>
         public bool? ProbeHasActiveChildProcesses()
         {
-            var lifecycle = _lifecycle;
+            var lifecycle = _session;
             if (lifecycle == null) return null;
             try
             {

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -1952,7 +1952,10 @@ namespace NovaTerminal
             _startup.Checkpoint("MainWindow.AfterLegacyMigration");
 
             // Agent-host observe endpoint (docs/agent-host/DIRECTION.md, A1):
-            // strictly no-op unless the user opted in via Settings.
+            // strictly no-op unless the user opted in via Settings. The replay
+            // export sub-gate (A4) is pushed alongside so the endpoint checks
+            // the current setting on every exportReplay request.
+            AgentHost.AgentHostService.Instance.ReplayExportEnabled = _settings.AgentReplayExportEnabled;
             AgentHost.AgentHostService.Instance.Apply(_settings.AgentAccessObserveEnabled);
 
             // Ensure visual tree is ready for initial tab border
@@ -4886,7 +4889,9 @@ namespace NovaTerminal
                 ApplyThemeToUI();
                 ApplySettingsToAllTabs();
                 UpdateTransparencyHints();
-                // Live-apply the agent-host observe endpoint (no restart needed).
+                // Live-apply the agent-host observe endpoint (no restart needed),
+                // including the A4 replay-export sub-gate.
+                AgentHost.AgentHostService.Instance.ReplayExportEnabled = _settings.AgentReplayExportEnabled;
                 AgentHost.AgentHostService.Instance.Apply(_settings.AgentAccessObserveEnabled);
 
                 // Refresh Connection Manager if open (or just always update it)

--- a/src/NovaTerminal.App/SettingsWindow.axaml
+++ b/src/NovaTerminal.App/SettingsWindow.axaml
@@ -581,6 +581,15 @@
                             </Grid>
                             <Border BorderBrush="{StaticResource NtHairline}" BorderThickness="0,0,0,1" Margin="0,14,0,14"/>
 
+                            <Grid ColumnDefinitions="*,360" Margin="24,0,0,0">
+                                <StackPanel Grid.Column="0" Spacing="2">
+                                    <TextBlock Classes="RowLabel" Text="Agent replay export"/>
+                                    <TextBlock Classes="RowDesc" Text="Additionally allow agents to export a session's recent output as a replay file. Exports contain output and window resizes only — never anything you type. Requires Agent access (observe)."/>
+                                </StackPanel>
+                                <CheckBox Name="AgentReplayExportToggle" Grid.Column="1" Classes="Toggle" Content="" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                            </Grid>
+                            <Border BorderBrush="{StaticResource NtHairline}" BorderThickness="0,0,0,1" Margin="0,14,0,14"/>
+
                             <Grid ColumnDefinitions="*,360">
                                 <StackPanel Grid.Column="0" Spacing="2">
                                     <TextBlock Classes="RowLabel" Text="Long command notifications"/>

--- a/src/NovaTerminal.App/SettingsWindow.axaml.cs
+++ b/src/NovaTerminal.App/SettingsWindow.axaml.cs
@@ -1402,6 +1402,8 @@ namespace NovaTerminal
             var agentAccessObserveToggle = this.FindControl<CheckBox>("AgentAccessObserveToggle");
 
             if (agentAccessObserveToggle != null) agentAccessObserveToggle.IsChecked = _settings.AgentAccessObserveEnabled;
+            var agentReplayExportToggle = this.FindControl<CheckBox>("AgentReplayExportToggle");
+            if (agentReplayExportToggle != null) agentReplayExportToggle.IsChecked = _settings.AgentReplayExportEnabled;
             var longCommandNotificationsToggle = this.FindControl<CheckBox>("LongCommandNotificationsToggle");
             if (longCommandNotificationsToggle != null) longCommandNotificationsToggle.IsChecked = _settings.LongCommandNotificationsEnabled;
             if (fontSizeInput != null) fontSizeInput.Value = (decimal)_settings.FontSize;
@@ -1634,6 +1636,8 @@ namespace NovaTerminal
             if (commandAssistToggle != null) _settings.CommandAssistEnabled = commandAssistToggle.IsChecked == true;
             var agentAccessObserveToggle = this.FindControl<CheckBox>("AgentAccessObserveToggle");
             if (agentAccessObserveToggle != null) _settings.AgentAccessObserveEnabled = agentAccessObserveToggle.IsChecked == true;
+            var agentReplayExportToggle = this.FindControl<CheckBox>("AgentReplayExportToggle");
+            if (agentReplayExportToggle != null) _settings.AgentReplayExportEnabled = agentReplayExportToggle.IsChecked == true;
             var longCommandNotificationsToggle = this.FindControl<CheckBox>("LongCommandNotificationsToggle");
             if (longCommandNotificationsToggle != null) _settings.LongCommandNotificationsEnabled = longCommandNotificationsToggle.IsChecked == true;
 

--- a/src/NovaTerminal.App/Shell/TerminalSettings.cs
+++ b/src/NovaTerminal.App/Shell/TerminalSettings.cs
@@ -55,6 +55,12 @@ namespace NovaTerminal.Shell
         // agents cannot read any terminal session. Observe-only in v1 — there is
         // no acting capability behind this flag.
         public bool AgentAccessObserveEnabled { get; set; } = false;
+        // A4 sub-gate on top of the observe toggle: allows agents to export a
+        // session's recent output as a replay file (novaterminal.export_replay).
+        // Exports contain output and resize events only — never typed input
+        // (privacy decision in docs/plans/2026-07-07-agent-host-a4-replay-design.md).
+        // Off by default; both toggles must be on for an export to succeed.
+        public bool AgentReplayExportEnabled { get; set; } = false;
         // In-app toast when a command that ran ≥30s finishes in an unfocused
         // pane (A2 PR4, absorbs ROADMAP §5.2). Off by default.
         public bool LongCommandNotificationsEnabled { get; set; } = false;

--- a/src/NovaTerminal.McpServer/Tools/SessionTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/SessionTools.cs
@@ -139,6 +139,29 @@ public static class SessionTools
             : AgentHostClient.ProtocolErrorMessage;
     }
 
+    [McpServerTool(Name = "novaterminal.export_replay"),
+     Description("Exports a live NovaTerminal session's recent terminal output as a deterministic replay (.rec) file and returns its path — use it for postmortems of what happened in a session ('debug what your agent did, frame by frame'). The file contains output and window resizes only, NEVER anything the user typed. Requires BOTH 'Agent access (observe)' and its 'Agent replay export' sub-toggle in NovaTerminal settings. The recording window is bounded, so long sessions export only the most recent activity (the result says when it was truncated). Replay the file headlessly with: NovaTerminal.Cli --replay <path>. Get paneId from novaterminal.list_sessions.")]
+    public static async Task<string> ExportReplay(
+        AgentHostClient client,
+        [Description("The pane id (GUID) from novaterminal.list_sessions.")] string paneId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Guid.TryParse(paneId, out var pane))
+        {
+            return $"Error: '{paneId}' is not a valid pane id (GUID). Use novaterminal.list_sessions to find live pane ids.";
+        }
+
+        var parameters = JsonSerializer.SerializeToElement(
+            new ExportReplayParams { PaneId = pane },
+            AgentHostJsonContext.Default.ExportReplayParams);
+        var outcome = await client.CallAsync(AgentHostProtocol.Methods.ExportReplay, parameters, cancellationToken).ConfigureAwait(false);
+        if (!TryUnwrap(outcome, out var result, out var error)) return error;
+
+        return TryDeserializeResult(result, AgentHostJsonContext.Default.ExportReplayResult, out var dto)
+            ? FormatExport(dto!)
+            : AgentHostClient.ProtocolErrorMessage;
+    }
+
     // ── Shared plumbing ─────────────────────────────────────────────────────
 
     /// <summary>
@@ -254,6 +277,27 @@ public static class SessionTools
             sb.AppendLine($"| {e.Seq} | {FormatUtc(e.TimestampMs)} | {e.PaneId} | {e.Type} | {e.Status} | {details} |");
         }
         return sb.ToString().TrimEnd();
+    }
+
+    internal static string FormatExport(ExportReplayResult dto)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Replay exported: {dto.FilePath}");
+        if (dto.EventCount == 0)
+        {
+            sb.AppendLine("The recording window contained no events yet (the session produced no output since recording started); the file has a valid header and nothing else.");
+        }
+        else
+        {
+            var durationMs = Math.Max(0, dto.LastEventMs - dto.FirstEventMs);
+            sb.AppendLine($"{dto.EventCount} event(s) covering {durationMs} ms of activity (output and resizes only — input is never recorded).");
+        }
+        if (dto.TruncatedAtStart)
+        {
+            sb.AppendLine("Note: older activity had already been evicted from the bounded recording window — this export is a suffix of the session, not its full history.");
+        }
+        sb.Append("Replay it headlessly with: NovaTerminal.Cli --replay <path> (renders the final screen deterministically).");
+        return sb.ToString();
     }
 
     private static string FormatUtc(long unixMs)

--- a/src/NovaTerminal.McpServer/Tools/SettingsTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/SettingsTools.cs
@@ -54,6 +54,7 @@ public static class SettingsTools
         | `GlobalHotkey` | string | Default "Alt+OemTilde". |
         | `ExperimentalNativeSshEnabled` | bool | Default false. |
         | `AgentAccessObserveEnabled` | bool | Default false. Enables the local agent-host observe endpoint (read-only session access for AI agents). |
+        | `AgentReplayExportEnabled` | bool | Default false. Sub-gate on top of the observe toggle: allows agents to export a session's recent output as a replay file (output + resizes only, never input). |
         | `LongCommandNotificationsEnabled` | bool | Default false. In-app toast when a command that ran ≥30s finishes in an unfocused pane. |
 
         ## Background
@@ -118,6 +119,7 @@ public static class SettingsTools
           "CommandAssistPowerShellIntegrationEnabled": true,
           "ExperimentalNativeSshEnabled": false,
           "AgentAccessObserveEnabled": false,
+          "AgentReplayExportEnabled": false,
           "LongCommandNotificationsEnabled": false,
           "Profiles": [
             { "Id": "00000000-0000-0000-0000-000000000001", "Name": "Command Prompt", "Command": "cmd.exe", "Type": 0 }
@@ -133,7 +135,8 @@ public static class SettingsTools
         "BellVisualEnabled", "SmoothScrolling", "EnableLinkDetection", "QuakeModeEnabled",
         "CommandAssistEnabled", "CommandAssistHistoryEnabled", "CommandAssistAutoHideInAltScreen",
         "CommandAssistShellIntegrationEnabled", "CommandAssistPowerShellIntegrationEnabled",
-        "ExperimentalNativeSshEnabled", "AgentAccessObserveEnabled", "LongCommandNotificationsEnabled",
+        "ExperimentalNativeSshEnabled", "AgentAccessObserveEnabled", "AgentReplayExportEnabled",
+        "LongCommandNotificationsEnabled",
     };
 
     // Plain + enum-like strings; enum-like values are NOT value-validated (type-check only).
@@ -156,8 +159,8 @@ public static class SettingsTools
         "QuakeModeEnabled", "GlobalHotkey", "CommandAssistEnabled", "CommandAssistHistoryEnabled",
         "CommandAssistMaxHistoryEntries", "CommandAssistAutoHideInAltScreen",
         "CommandAssistShellIntegrationEnabled", "CommandAssistPowerShellIntegrationEnabled",
-        "ExperimentalNativeSshEnabled", "AgentAccessObserveEnabled", "LongCommandNotificationsEnabled",
-        "Profiles", "DefaultProfileId",
+        "ExperimentalNativeSshEnabled", "AgentAccessObserveEnabled", "AgentReplayExportEnabled",
+        "LongCommandNotificationsEnabled", "Profiles", "DefaultProfileId",
     };
 
     [McpServerTool(Name = "novaterminal.validate_settings_json"),

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentHostReplayProtocolTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentHostReplayProtocolTests.cs
@@ -152,6 +152,55 @@ public class AgentHostReplayProtocolTests : IDisposable
     }
 
     [Fact]
+    public void Swapping_or_clearing_the_published_session_disables_the_old_ring()
+    {
+        // A session this registration no longer owns must not keep retaining
+        // output until its eventual disposal (observe-lifecycle invariant).
+        var registration = new AgentSessionRegistration(
+            Guid.NewGuid(), new TerminalBuffer(80, 24), "t", "P", "local", isActive: true);
+        registration.EnableFlightRecording(1024);
+
+        var first = new FlightStubSession();
+        registration.SetLifecycle(first);
+        Assert.True(first.IsFlightRecording);
+
+        var second = new FlightStubSession();
+        registration.SetLifecycle(second);
+        Assert.False(first.IsFlightRecording);  // swapped out → ring dropped
+        Assert.True(second.IsFlightRecording);
+
+        registration.SetLifecycle(null);
+        Assert.False(second.IsFlightRecording); // cleared → ring dropped
+    }
+
+    [Fact]
+    public void Repeated_exports_for_the_same_pane_produce_distinct_files()
+    {
+        var registry = new AgentSessionRegistry();
+        var registration = Register(registry);
+        var session = new FlightStubSession();
+        registration.SetLifecycle(session);
+        registration.EnableFlightRecording(AgentHostProtocol.FlightRecorderMaxBytesPerSession);
+        session.FeedOutput("some output");
+
+        using var service = NewService(registry);
+        service.ReplayExportEnabled = true;
+
+        // Two exports within the same second (the timestamp component has
+        // one-second resolution) must not overwrite each other.
+        var first = Handle(service, ExportRequestLine(registration.PaneId, id: 1));
+        var second = Handle(service, ExportRequestLine(registration.PaneId, id: 2));
+
+        Assert.Null(first.Error);
+        Assert.Null(second.Error);
+        var firstResult = first.Result!.Value.Deserialize(AgentHostJsonContext.Default.ExportReplayResult)!;
+        var secondResult = second.Result!.Value.Deserialize(AgentHostJsonContext.Default.ExportReplayResult)!;
+        Assert.NotEqual(firstResult.FilePath, secondResult.FilePath);
+        Assert.True(File.Exists(firstResult.FilePath));
+        Assert.True(File.Exists(secondResult.FilePath));
+    }
+
+    [Fact]
     public void Session_published_after_enable_inherits_the_pending_recording_state()
     {
         // Registration happens before the pane spawns its PTY session; a session

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentHostReplayProtocolTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentHostReplayProtocolTests.cs
@@ -1,0 +1,281 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using NovaTerminal.AgentHost;
+using NovaTerminal.AgentHost.Contracts;
+using NovaTerminal.Replay;
+using NovaTerminal.VT;
+
+namespace NovaTerminal.AppTests.AgentHost;
+
+/// <summary>
+/// Tests for the A4 <c>exportReplay</c> protocol surface and its flight-recorder
+/// lifecycle wiring (docs/plans/2026-07-07-agent-host-a4-replay-design.md, PR2).
+/// Two independent gates: the observe endpoint must be running (ring exists) and
+/// <see cref="AgentHostService.ReplayExportEnabled"/> must be on. Exports must
+/// never contain input events.
+/// </summary>
+public class AgentHostReplayProtocolTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _exportDir;
+
+    public AgentHostReplayProtocolTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "nova-agentreplay-tests-" + Guid.NewGuid().ToString("N"));
+        _exportDir = Path.Combine(_tempDir, "agent-exports");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
+        GC.SuppressFinalize(this);
+    }
+
+    private AgentHostService NewService(AgentSessionRegistry registry)
+    {
+        var endpoint = OperatingSystem.IsWindows()
+            ? "novaterminal-agent-test-" + Guid.NewGuid().ToString("N")
+            : Path.Combine(_tempDir, Guid.NewGuid().ToString("N")[..8] + ".sock");
+        return new AgentHostService(registry, endpoint, _tempDir, _exportDir);
+    }
+
+    private static AgentSessionRegistration Register(AgentSessionRegistry registry, Guid? paneId = null)
+    {
+        var registration = new AgentSessionRegistration(
+            paneId ?? Guid.NewGuid(), new TerminalBuffer(80, 24), "title", "Profile", "local", isActive: true);
+        Assert.True(registry.Register(registration));
+        return registration;
+    }
+
+    private static string ExportRequestLine(Guid paneId, long id = 1)
+    {
+        var paramsJson = JsonSerializer.Serialize(
+            new ExportReplayParams { PaneId = paneId }, AgentHostJsonContext.Default.ExportReplayParams);
+        return $"{{\"v\":{AgentHostProtocol.Version},\"id\":{id},\"method\":\"{AgentHostProtocol.Methods.ExportReplay}\",\"params\":{paramsJson}}}";
+    }
+
+    private static AgentHostResponse Handle(AgentHostService service, string line)
+        => service.HandleRequestLineAsync(line, TestContext.Current.CancellationToken).GetAwaiter().GetResult();
+
+    // ── Stub session with a real ring ────────────────────────────────────────
+
+    private sealed class FlightStubSession : NovaTerminal.Pty.ITerminalSession
+    {
+        private FlightRecordingBuffer? _ring;
+
+        public long? LastEnabledMaxBytes { get; private set; }
+
+        public void FeedOutput(string text)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(text);
+            _ring?.RecordChunk(bytes, bytes.Length);
+        }
+
+        public void FeedResize(int cols, int rows) => _ring?.RecordResize(cols, rows);
+
+        public bool IsFlightRecording => _ring != null;
+
+        public void EnableFlightRecording(long maxTotalBytes)
+        {
+            if (_ring != null) return;
+            LastEnabledMaxBytes = maxTotalBytes;
+            _ring = new FlightRecordingBuffer(maxTotalBytes, 80, 24, clock: static () => 0);
+        }
+
+        public void DisableFlightRecording() => _ring = null;
+
+        public bool TryExportFlightRecording(string filePath, out FlightExportInfo info)
+        {
+            var ring = _ring;
+            if (ring == null)
+            {
+                info = default;
+                return false;
+            }
+            info = ring.ExportTo(filePath, "stub-shell");
+            return true;
+        }
+
+        // Inert ITerminalSession surface
+        public Guid Id { get; } = Guid.NewGuid();
+        public string ShellCommand => "stub-shell";
+        public string? ShellArguments => null;
+        public bool IsProcessRunning => true;
+        public bool HasActiveChildProcesses => false;
+        public int? ExitCode => null;
+        public bool IsRecording => false;
+        public event Action<string>? OnOutputReceived { add { } remove { } }
+        public event Action<int>? OnExit { add { } remove { } }
+        public void SendInput(string input) { }
+        public void Resize(int cols, int rows) { }
+        public void StartRecording(string filePath) { }
+        public void StopRecording() { }
+        public void Dispose() { }
+    }
+
+    // ── Lifecycle: the ring exists exactly while the endpoint runs ──────────
+
+    [Fact]
+    public void Start_enables_flight_recording_on_already_registered_sessions_and_stop_disables_it()
+    {
+        var registry = new AgentSessionRegistry();
+        var registration = Register(registry);
+        var session = new FlightStubSession();
+        registration.SetLifecycle(session);
+        Assert.False(session.IsFlightRecording); // off-is-off before Start
+
+        using var service = NewService(registry);
+        service.Start();
+        Assert.True(session.IsFlightRecording);
+        Assert.Equal(AgentHostProtocol.FlightRecorderMaxBytesPerSession, session.LastEnabledMaxBytes);
+
+        service.Stop();
+        Assert.False(session.IsFlightRecording);
+    }
+
+    [Fact]
+    public void Sessions_registered_while_running_get_flight_recording()
+    {
+        var registry = new AgentSessionRegistry();
+        using var service = NewService(registry);
+        service.Start();
+
+        var registration = Register(registry);
+        var session = new FlightStubSession();
+        registration.SetLifecycle(session);
+
+        Assert.True(session.IsFlightRecording);
+    }
+
+    [Fact]
+    public void Session_published_after_enable_inherits_the_pending_recording_state()
+    {
+        // Registration happens before the pane spawns its PTY session; a session
+        // published later (or swapped on reconnect) must inherit the endpoint's
+        // decision without any further service involvement.
+        var registration = new AgentSessionRegistration(
+            Guid.NewGuid(), new TerminalBuffer(80, 24), "t", "P", "local", isActive: true);
+        registration.EnableFlightRecording(1024);
+
+        var late = new FlightStubSession();
+        registration.SetLifecycle(late);
+        Assert.True(late.IsFlightRecording);
+
+        var swapped = new FlightStubSession();
+        registration.SetLifecycle(swapped);
+        Assert.True(swapped.IsFlightRecording);
+
+        registration.DisableFlightRecording();
+        Assert.False(swapped.IsFlightRecording);
+
+        var afterDisable = new FlightStubSession();
+        registration.SetLifecycle(afterDisable);
+        Assert.False(afterDisable.IsFlightRecording);
+    }
+
+    // ── exportReplay handler ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Export_with_both_gates_on_writes_a_v2_file_with_no_input_events()
+    {
+        var registry = new AgentSessionRegistry();
+        var registration = Register(registry);
+        var session = new FlightStubSession();
+        registration.SetLifecycle(session);
+        registration.EnableFlightRecording(AgentHostProtocol.FlightRecorderMaxBytesPerSession);
+
+        session.FeedOutput("hello from the session\r\n");
+        session.FeedResize(100, 30);
+        session.FeedOutput("after resize");
+
+        using var service = NewService(registry);
+        service.ReplayExportEnabled = true;
+
+        var response = Handle(service, ExportRequestLine(registration.PaneId));
+
+        Assert.Null(response.Error);
+        Assert.NotNull(response.Result);
+        var result = response.Result!.Value.Deserialize(AgentHostJsonContext.Default.ExportReplayResult);
+        Assert.NotNull(result);
+        Assert.Equal(3, result!.EventCount);
+        Assert.False(result.TruncatedAtStart);
+        Assert.True(File.Exists(result.FilePath));
+        Assert.StartsWith(Path.GetFullPath(_exportDir), Path.GetFullPath(result.FilePath), StringComparison.Ordinal);
+        Assert.StartsWith("nova_rec_", Path.GetFileName(result.FilePath), StringComparison.Ordinal);
+        Assert.EndsWith(".rec", result.FilePath, StringComparison.Ordinal);
+
+        string[] lines = File.ReadAllLines(result.FilePath).Where(l => !string.IsNullOrWhiteSpace(l)).ToArray();
+        var header = JsonSerializer.Deserialize(lines[0], ReplayJsonContext.Default.ReplayHeader);
+        Assert.NotNull(header);
+        Assert.Equal("novarec", header!.Type);
+        Assert.Equal(2, header.Version);
+
+        // Privacy invariant: output + resize only, never input.
+        var eventTypes = lines.Skip(1)
+            .Select(l => JsonSerializer.Deserialize(l, ReplayJsonContext.Default.ReplayEvent)!.Type)
+            .ToArray();
+        Assert.Equal(3, eventTypes.Length);
+        Assert.All(eventTypes, t => Assert.True(t == "data" || t == "resize", $"unexpected event type '{t}'"));
+        Assert.DoesNotContain("input", eventTypes);
+    }
+
+    [Fact]
+    public void Export_without_the_export_setting_fails_with_exportDisabled_and_writes_nothing()
+    {
+        var registry = new AgentSessionRegistry();
+        var registration = Register(registry);
+        var session = new FlightStubSession();
+        registration.SetLifecycle(session);
+        registration.EnableFlightRecording(AgentHostProtocol.FlightRecorderMaxBytesPerSession);
+        session.FeedOutput("secret output");
+
+        using var service = NewService(registry);
+        service.ReplayExportEnabled = false; // observe on, export sub-gate off
+
+        var response = Handle(service, ExportRequestLine(registration.PaneId));
+
+        Assert.Equal(AgentHostProtocol.ErrorCodes.ExportDisabled, response.Error?.Code);
+        Assert.False(Directory.Exists(_exportDir) && Directory.EnumerateFiles(_exportDir).Any());
+    }
+
+    [Fact]
+    public void Export_for_unknown_pane_reports_session_not_found()
+    {
+        using var service = NewService(new AgentSessionRegistry());
+        service.ReplayExportEnabled = true;
+
+        var response = Handle(service, ExportRequestLine(Guid.NewGuid()));
+
+        Assert.Equal(AgentHostProtocol.ErrorCodes.SessionNotFound, response.Error?.Code);
+    }
+
+    [Fact]
+    public void Export_without_params_is_a_malformed_request()
+    {
+        using var service = NewService(new AgentSessionRegistry());
+        service.ReplayExportEnabled = true;
+
+        var line = $"{{\"v\":{AgentHostProtocol.Version},\"id\":7,\"method\":\"{AgentHostProtocol.Methods.ExportReplay}\",\"params\":null}}";
+        var response = Handle(service, line);
+
+        Assert.Equal(AgentHostProtocol.ErrorCodes.MalformedRequest, response.Error?.Code);
+    }
+
+    [Fact]
+    public void Export_for_session_without_a_published_pty_reports_exportUnavailable()
+    {
+        var registry = new AgentSessionRegistry();
+        var registration = Register(registry); // no SetLifecycle: pane hasn't spawned yet
+
+        using var service = NewService(registry);
+        service.ReplayExportEnabled = true;
+
+        var response = Handle(service, ExportRequestLine(registration.PaneId));
+
+        Assert.Equal(AgentHostProtocol.ErrorCodes.ExportUnavailable, response.Error?.Code);
+    }
+}

--- a/tests/NovaTerminal.McpServer.Tests/AgentHostClientTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/AgentHostClientTests.cs
@@ -343,6 +343,49 @@ public class SessionToolsFormattingTests
     }
 
     [Fact]
+    public void FormatExport_reports_path_window_and_replay_hint()
+    {
+        var text = SessionTools.FormatExport(new ExportReplayResult
+        {
+            FilePath = @"C:\rec\agent-exports\nova_rec_20260707_120000_abc123.rec",
+            EventCount = 42,
+            FirstEventMs = 10_000,
+            LastEventMs = 25_500,
+            TruncatedAtStart = false,
+        });
+
+        Assert.Contains("nova_rec_20260707_120000_abc123.rec", text, StringComparison.Ordinal);
+        Assert.Contains("42 event(s) covering 15500 ms", text, StringComparison.Ordinal);
+        Assert.Contains("input is never recorded", text, StringComparison.Ordinal);
+        Assert.Contains("--replay", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("truncated", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void FormatExport_flags_truncation_and_empty_windows()
+    {
+        var truncated = SessionTools.FormatExport(new ExportReplayResult
+        {
+            FilePath = "/tmp/x.rec", EventCount = 5, FirstEventMs = 0, LastEventMs = 9, TruncatedAtStart = true,
+        });
+        Assert.Contains("suffix of the session", truncated, StringComparison.Ordinal);
+
+        var empty = SessionTools.FormatExport(new ExportReplayResult
+        {
+            FilePath = "/tmp/y.rec", EventCount = 0, FirstEventMs = 0, LastEventMs = 0, TruncatedAtStart = false,
+        });
+        Assert.Contains("no events", empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExportReplay_rejects_a_non_guid_pane_before_any_ipc()
+    {
+        var client = new AgentHostClient(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "nothing.json"));
+        var text = await SessionTools.ExportReplay(client, "not-a-guid", TestContext.Current.CancellationToken);
+        Assert.StartsWith("Error: 'not-a-guid' is not a valid pane id", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task WaitForEvents_rejects_a_negative_cursor_before_any_ipc()
     {
         var client = new AgentHostClient(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "nothing.json"));

--- a/tests/NovaTerminal.McpServer.Tests/McpServerStdioE2ETests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/McpServerStdioE2ETests.cs
@@ -41,6 +41,7 @@ public class McpServerStdioE2ETests
         "novaterminal.read_scrollback",
         "novaterminal.get_session_status",
         "novaterminal.wait_for_events",
+        "novaterminal.export_replay",
     };
 
     [Fact]


### PR DESCRIPTION
## Summary

Slice 2 of 3 for **milestone A4 (Replay for agents)** per `docs/plans/2026-07-07-agent-host-a4-replay-design.md`: the **`exportReplay` protocol method and `novaterminal.export_replay` MCP tool**, on top of the flight recorder core from #190. Slice 3 (`--replay` CLI + docs + DIRECTION checkboxes) follows.

## Permission model (two independent default-off gates)

Per the DIRECTION permission table ("off; observe permission + explicit export action"):

1. **Observe toggle** (`AgentAccessObserveEnabled`, existing): the flight ring exists exactly while the observe endpoint runs — enabled on every registered session at `Start` and on `SessionRegistered`, dropped for all sessions at `Stop`. Off-is-off: no endpoint → no in-memory retention at all.
2. **New `AgentReplayExportEnabled` setting** (default **false**): settings-window sub-toggle under Agent access; without it `exportReplay` fails with the new stable `exportDisabled` error code and guidance. Pushed to the service by MainWindow at both settings-apply sites, checked per request.

**Privacy invariant (from the design doc):** exports contain output and resize events only — **never input**. The ring has no input API by construction (slice 1); this PR asserts it again at the protocol level and states it in the tool description, the settings toggle text, and the setting's doc comment.

## What's here

**Contracts (additive, protocol stays v1)**
- `Methods.ExportReplay`, error codes `exportDisabled` (setting off) and `exportUnavailable` (session exists but no ring/PTY published, or the write failed) — distinct codes so agents can tell "ask the user to opt in" from "retry later".
- `ExportReplayParams { paneId }` → `ExportReplayResult { filePath, eventCount, firstEventMs, lastEventMs, truncatedAtStart }`; registered in the source-gen JSON context.
- `FlightRecorderMaxBytesPerSession` (2 MiB) and `AgentExportsSubdirectory` constants.

**App**
- `AgentSessionRegistration`: the volatile lifecycle slot from A2 is **widened to carry the session** (`ITerminalSession`), so the endpoint reaches the flight-recorder surface without touching the pane; the sweep still uses only lifecycle members. New `EnableFlightRecording` / `DisableFlightRecording` / `TryExportFlightRecording` with **pending-state semantics**: registration happens before the pane spawns its PTY, and reconnects swap sessions — every session published via `SetLifecycle` inherits the endpoint's current decision.
- `AgentHostService`: lifecycle wiring in start/stop/on-registered; `ReplayExportEnabled` property; `exportReplay` handler writing to `RecordingsDirectory/agent-exports/nova_rec_{stamp}_{suffix}.rec` (existing naming convention via `TerminalPane.BuildRecordingFileName`, dedicated subfolder so agent artifacts are visually separate); test-only export-directory override.
- Settings: `AgentReplayExportEnabled` + indented sub-toggle in the settings window (copy states the never-input guarantee), load/save wiring.

**McpServer**
- `novaterminal.export_replay(paneId)` tool: returns the path, the covered window, a truncation note when the bounded ring already evicted older data, and the `NovaTerminal.Cli --replay <path>` hint (CLI lands in slice 3). GUID validated before any IPC, mirroring the other session tools.
- `SettingsTools`: `AgentReplayExportEnabled` added to the schema doc, example, and both validator lists.
- E2E expected-tool list: 21 tools.

## Testing

- **Protocol** (`AgentHostReplayProtocolTests`): export with both gates on → file exists in the export dir, valid v2 header, **only `data`/`resize` events** (privacy assertion); `exportDisabled` with the sub-gate off (and nothing written); `sessionNotFound`; `malformedRequest`; `exportUnavailable` when no PTY session is published.
- **Lifecycle**: Start enables the ring on already-registered sessions (with the contract budget) and Stop disables it; sessions registered while running get recording; a session published or swapped **after** enable inherits the pending state, and not after disable.
- **MCP formatting/plumbing**: `FormatExport` (path, window, never-input note, replay hint, truncation flag, empty-window case); non-GUID pane rejected before IPC; stdio E2E tool list.

Local: App.Tests (AgentHost+ReplayTests+PtySmoke) 136/136, McpServer.Tests 132/132, Architecture 18/18.
