### PR TITLE
feat(agent-host): A4 slice 3 - headless --replay CLI + docs (completes A4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ acyclic dependency graph.
 - **[`src/NovaTerminal.Pty`](src/NovaTerminal.Pty/)** — Native OS integration and PTY session management.
 - **[`src/NovaTerminal.Replay`](src/NovaTerminal.Replay/)** — Deterministic session recording and playback.
 - **[`src/NovaTerminal.Conformance`](src/NovaTerminal.Conformance/)** — VT conformance matrix tooling and report generation.
-- **[`src/NovaTerminal.Cli`](src/NovaTerminal.Cli/)** — console-subsystem twin of the (WinExe) app for headless tooling: `vt-report` and the SSH askpass helper.
+- **[`src/NovaTerminal.Cli`](src/NovaTerminal.Cli/)** — console-subsystem twin of the (WinExe) app for headless tooling: `vt-report`, headless replay (`--replay <file>`), and the SSH askpass helper.
 - **[`src/NovaTerminal.AgentHost.Contracts`](src/NovaTerminal.AgentHost.Contracts/)** — zero-dependency wire contracts for the agent-host observe channel (shared by App and McpServer).
 - **[`src/NovaTerminal.McpServer`](src/NovaTerminal.McpServer/)** — read-only, stdio-only MCP server exposing project docs, config validators, VT conformance data, and (opt-in, observe-only) live terminal sessions to AI tooling.
 
@@ -165,7 +165,12 @@ Enforced invariants (`NovaTerminal.Architecture.Tests`): `VT` is a leaf with zer
   ([`docs/agent-host/DIRECTION.md`](docs/agent-host/DIRECTION.md)): a
   session-facing MCP surface so AI agents can observe, query status of, and
   (with explicit permission) act inside live terminal sessions, with
-  deterministic replay as the debugging story.
+  deterministic replay as the debugging story. Debug what your agent did,
+  frame by frame: with both opt-in toggles enabled, an agent can call
+  `novaterminal.export_replay` to save a session's recent output (never
+  input — typed keys are not retained) as a standard `.rec` file, and anyone
+  can re-render it deterministically with
+  `NovaTerminal.Cli --replay <file> [--attributes]`.
 - **VT conformance program** — every supported VT/ANSI feature is tracked in a
   matrix; a dedicated CI lane regenerates the report and fails on regressions.
   See [`docs/vt_coverage_matrix.md`](docs/vt_coverage_matrix.md) and

--- a/docs/agent-host/DIRECTION.md
+++ b/docs/agent-host/DIRECTION.md
@@ -179,10 +179,15 @@ Each milestone is independently shippable and announceable. Estimates assume
 ### A4 — Replay for agents (the moat)
 
 **Deliverables**
-- [ ] `novaterminal.export_replay` for a session/time range
-- [ ] CLI: `nova replay <file>` headless render-to-text/PNG for CI and
-      agent-run postmortems
-- [ ] Docs: "Debug what your agent did, frame by frame"
+- [x] `novaterminal.export_replay` for a session/time range (PRs #190–#191:
+      flight-recorder ring bounded by bytes = the retained time range; output +
+      resize only, never input; gated by the default-off `AgentReplayExportEnabled`
+      sub-toggle on top of observe)
+- [x] CLI: `NovaTerminal.Cli --replay <file> [--attributes]` headless
+      render-to-text for CI and agent-run postmortems (PR #192; PNG output and
+      frame-stepping deferred — see the A4 design doc's out-of-scope list)
+- [x] Docs: "Debug what your agent did, frame by frame" (README, agent host
+      program section)
 
 **Acceptance criteria**
 - Exported replays round-trip through the existing replay runner with

--- a/src/NovaTerminal.App/Shell/ReplayCommand.cs
+++ b/src/NovaTerminal.App/Shell/ReplayCommand.cs
@@ -1,0 +1,159 @@
+using System;
+using System.IO;
+using System.Text;
+using NovaTerminal.Replay;
+using NovaTerminal.VT;
+
+namespace NovaTerminal;
+
+/// <summary>
+/// Headless replay for CI and agent-run postmortems (milestone A4,
+/// docs/plans/2026-07-07-agent-host-a4-replay-design.md):
+/// <c>NovaTerminal.Cli --replay &lt;file&gt; [--attributes]</c> runs a replay
+/// file (v2, with v1 compatibility) through the deterministic core in Virtual
+/// mode and prints the final screen as <see cref="BufferSnapshot"/> formatted
+/// text — the same snapshot the golden/parity tests consume.
+///
+/// Exit codes: 0 = success; 1 = unreadable or truncated file (any partial
+/// screen is still printed, with a warning on stderr); 2 = usage error.
+/// </summary>
+internal static class ReplayCommand
+{
+    private const string ReplayFlag = "--replay";
+    private const string AttributesFlag = "--attributes";
+
+    public static bool IsSupportedCliMode(string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+        return Array.Exists(args, arg => string.Equals(arg, ReplayFlag, StringComparison.Ordinal));
+    }
+
+    public static int Execute(string[] args, TextWriter stdout, TextWriter stderr)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(stdout);
+        ArgumentNullException.ThrowIfNull(stderr);
+
+        if (!TryParseArguments(args, stderr, out string filePath, out bool includeAttributes))
+        {
+            return 2;
+        }
+
+        if (!File.Exists(filePath))
+        {
+            stderr.WriteLine($"Replay file not found: '{filePath}'.");
+            return 1;
+        }
+
+        // Header geometry (v2) arrives via the resize callback before any data;
+        // v1 files have no header, so 80x24 is the fallback start geometry.
+        var buffer = new TerminalBuffer(80, 24);
+        var parser = new AnsiParser(buffer);
+        var decoder = Encoding.UTF8.GetDecoder();
+
+        ReplayRunResult result;
+        try
+        {
+            var runner = new ReplayRunner(filePath);
+            // CLI constraint (established by the other commands): no async Main,
+            // bridge with GetAwaiter().GetResult().
+            result = runner.RunWithResultAsync(
+                onDataCallback: data =>
+                {
+                    char[] chars = new char[Encoding.UTF8.GetMaxCharCount(data.Length)];
+                    int charCount = decoder.GetChars(data, 0, data.Length, chars, 0);
+                    if (charCount > 0)
+                    {
+                        parser.Process(new string(chars, 0, charCount));
+                    }
+                    return System.Threading.Tasks.Task.CompletedTask;
+                },
+                onResizeCallback: (cols, rows) =>
+                {
+                    buffer.Resize(cols, rows);
+                    return System.Threading.Tasks.Task.CompletedTask;
+                },
+                onSnapshotCallback: snapshot =>
+                {
+                    buffer.ApplySnapshot(snapshot);
+                    return System.Threading.Tasks.Task.CompletedTask;
+                },
+                options: new ReplayRunOptions { PlaybackMode = ReplayPlaybackMode.Virtual })
+                .GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            // Unreadable from the first line (bad header/JSON) or a mid-file
+            // failure the runner does not classify as tail truncation.
+            stderr.WriteLine($"Failed to replay '{filePath}': {ex.Message}");
+            return 1;
+        }
+
+        BufferSnapshot snapshotOut = BufferSnapshot.Capture(buffer, includeAttributes);
+        stdout.WriteLine(snapshotOut.ToFormattedString());
+
+        if (result.Truncated)
+        {
+            // Partial output was still printed above — flight-recorder exports of
+            // live sessions can legitimately end mid-write.
+            stderr.WriteLine($"Warning: replay file is truncated after {result.EventsProcessed} event(s); the screen above reflects the readable prefix.");
+            return 1;
+        }
+
+        return 0;
+    }
+
+    private static bool TryParseArguments(string[] args, TextWriter stderr, out string filePath, out bool includeAttributes)
+    {
+        filePath = string.Empty;
+        includeAttributes = false;
+        bool seenReplayFlag = false;
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            string arg = args[i];
+            switch (arg)
+            {
+                case ReplayFlag when seenReplayFlag:
+                    stderr.WriteLine("Duplicate argument '--replay'.");
+                    PrintUsage(stderr);
+                    return false;
+                case ReplayFlag:
+                    seenReplayFlag = true;
+                    if (i + 1 >= args.Length || args[i + 1].StartsWith("--", StringComparison.Ordinal))
+                    {
+                        stderr.WriteLine("'--replay' requires a file path.");
+                        PrintUsage(stderr);
+                        return false;
+                    }
+                    filePath = args[++i];
+                    break;
+                case AttributesFlag when includeAttributes:
+                    stderr.WriteLine("Duplicate argument '--attributes'.");
+                    PrintUsage(stderr);
+                    return false;
+                case AttributesFlag:
+                    includeAttributes = true;
+                    break;
+                default:
+                    stderr.WriteLine($"Unknown argument '{arg}' for replay mode.");
+                    PrintUsage(stderr);
+                    return false;
+            }
+        }
+
+        if (!seenReplayFlag || string.IsNullOrWhiteSpace(filePath))
+        {
+            PrintUsage(stderr);
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void PrintUsage(TextWriter stderr)
+    {
+        stderr.WriteLine("Usage: NovaTerminal.Cli --replay <file> [--attributes]");
+        stderr.WriteLine("Replays a NovaTerminal .rec file headlessly and prints the final screen.");
+    }
+}

--- a/src/NovaTerminal.App/Shell/ReplayCommand.cs
+++ b/src/NovaTerminal.App/Shell/ReplayCommand.cs
@@ -60,11 +60,21 @@ internal static class ReplayCommand
             result = runner.RunWithResultAsync(
                 onDataCallback: data =>
                 {
-                    char[] chars = new char[Encoding.UTF8.GetMaxCharCount(data.Length)];
-                    int charCount = decoder.GetChars(data, 0, data.Length, chars, 0);
-                    if (charCount > 0)
+                    // Pooled decode buffer: one rent/return per chunk instead of a
+                    // fresh array — large replays would otherwise churn the GC.
+                    int maxCharCount = Encoding.UTF8.GetMaxCharCount(data.Length);
+                    char[] chars = System.Buffers.ArrayPool<char>.Shared.Rent(maxCharCount);
+                    try
                     {
-                        parser.Process(new string(chars, 0, charCount));
+                        int charCount = decoder.GetChars(data, 0, data.Length, chars, 0);
+                        if (charCount > 0)
+                        {
+                            parser.Process(new string(chars, 0, charCount));
+                        }
+                    }
+                    finally
+                    {
+                        System.Buffers.ArrayPool<char>.Shared.Return(chars);
                     }
                     return System.Threading.Tasks.Task.CompletedTask;
                 },

--- a/src/NovaTerminal.Cli/Program.cs
+++ b/src/NovaTerminal.Cli/Program.cs
@@ -15,6 +15,11 @@ internal static class Program
             return VtReportCommand.Execute(args, Console.Out, Console.Error);
         }
 
+        if (ReplayCommand.IsSupportedCliMode(args))
+        {
+            return ReplayCommand.Execute(args, Console.Out, Console.Error);
+        }
+
         Console.Error.WriteLine("Unsupported CLI mode.");
         return 2;
     }

--- a/src/NovaTerminal.Replay/Replay/PtyRecorder.cs
+++ b/src/NovaTerminal.Replay/Replay/PtyRecorder.cs
@@ -129,6 +129,7 @@ namespace NovaTerminal.Replay
                     IsOriginMode = buffer.Modes.IsOriginMode,
                     IsBracketedPasteMode = buffer.Modes.IsBracketedPasteMode,
                     IsCursorVisible = buffer.Modes.IsCursorVisible,
+                    IsPendingWrap = buffer.IsPendingWrap,
 
                     CurrentForeground = buffer.CurrentForeground.ToUint(),
                     CurrentBackground = buffer.CurrentBackground.ToUint(),

--- a/src/NovaTerminal.VT/ReplayModels.cs
+++ b/src/NovaTerminal.VT/ReplayModels.cs
@@ -67,6 +67,15 @@ namespace NovaTerminal.VT
         [JsonPropertyName("bp")] public bool IsBracketedPasteMode { get; set; }
         [JsonPropertyName("cv")] public bool IsCursorVisible { get; set; }
 
+        /// <summary>
+        /// Deferred autowrap state: the cursor sits on the last column with a
+        /// wrap pending for the next printable character. Absent (false) in
+        /// legacy recordings. Without this, a snapshot taken right after output
+        /// fills the last column replays with the wrap dropped and the next
+        /// character overwrites the row end instead of wrapping.
+        /// </summary>
+        [JsonPropertyName("pw")] public bool IsPendingWrap { get; set; }
+
         [JsonPropertyName("fg")] public uint CurrentForeground { get; set; }
         [JsonPropertyName("bg")] public uint CurrentBackground { get; set; }
         [JsonPropertyName("fgi")] public short CurrentFgIndex { get; set; }

--- a/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
@@ -946,7 +946,11 @@ namespace NovaTerminal.VT
                     }
                 }
 
-                _isPendingWrap = false;
+                // Restore deferred autowrap ("pw", absent=false in legacy files):
+                // a snapshot taken right after output filled the last column must
+                // replay with the wrap still pending, or the next character
+                // overwrites the row end instead of wrapping — divergence from live.
+                _isPendingWrap = snapshot.IsPendingWrap;
             }
             finally
             {

--- a/tests/NovaTerminal.App.Tests/ReplayCommandCliTests.cs
+++ b/tests/NovaTerminal.App.Tests/ReplayCommandCliTests.cs
@@ -1,0 +1,211 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using NovaTerminal.Replay;
+using NovaTerminal.VT;
+
+namespace NovaTerminal.Tests;
+
+/// <summary>
+/// Tests for <c>NovaTerminal.Cli --replay</c> (A4 slice 3,
+/// docs/plans/2026-07-07-agent-host-a4-replay-design.md): headless Virtual-mode
+/// replay of a .rec file printing the deterministic <see cref="BufferSnapshot"/>
+/// formatted screen. Exit codes: 0 success, 1 unreadable/truncated (partial
+/// output still printed), 2 usage.
+/// </summary>
+public sealed class ReplayCommandCliTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public ReplayCommandCliTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "nova-replaycli-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
+        GC.SuppressFinalize(this);
+    }
+
+    private string NewRecPath() => Path.Combine(_tempDir, Guid.NewGuid().ToString("N")[..8] + ".rec");
+
+    private static string WriteRecording(string path, Action<PtyRecorder> record, int cols = 40, int rows = 10)
+    {
+        using (var recorder = new PtyRecorder(path, cols, rows, "test-shell"))
+        {
+            record(recorder);
+        }
+        return path;
+    }
+
+    // ── Flag detection & usage errors ────────────────────────────────────────
+
+    [Fact]
+    public void IsSupportedCliMode_DetectsTheReplayFlag()
+    {
+        Assert.False(ReplayCommand.IsSupportedCliMode(["--help"]));
+        Assert.True(ReplayCommand.IsSupportedCliMode(["--replay", "x.rec"]));
+    }
+
+    [Fact]
+    public void Execute_UsageErrors_Exit2_WithUsageOnStderr()
+    {
+        string[][] badInvocations =
+        {
+            new[] { "--replay" },                                   // missing path
+            new[] { "--replay", "--attributes" },                   // flag where path expected
+            new[] { "--replay", "a.rec", "--bogus" },               // unknown argument
+            new[] { "--replay", "a.rec", "--replay", "b.rec" },     // duplicate --replay
+            new[] { "--replay", "a.rec", "--attributes", "--attributes" }, // duplicate --attributes
+        };
+
+        foreach (string[] args in badInvocations)
+        {
+            using var stdout = new StringWriter();
+            using var stderr = new StringWriter();
+
+            int exitCode = ReplayCommand.Execute(args, stdout, stderr);
+
+            Assert.Equal(2, exitCode);
+            Assert.Contains("Usage: NovaTerminal.Cli --replay", stderr.ToString());
+        }
+    }
+
+    [Fact]
+    public void Execute_MissingFile_Exit1()
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+
+        int exitCode = ReplayCommand.Execute(["--replay", Path.Combine(_tempDir, "nope.rec")], stdout, stderr);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("not found", stderr.ToString());
+    }
+
+    // ── Rendering ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_RendersTheFinalScreen_MatchingADirectlyFedBuffer()
+    {
+        // The headless CLI is the same deterministic pipeline the parity tests
+        // use: replaying the file must print exactly the snapshot of a buffer
+        // fed the same bytes directly (incl. resize and split-emoji chunks).
+        byte[] rocket = Encoding.UTF8.GetBytes("🚀");
+        string recPath = WriteRecording(NewRecPath(), recorder =>
+        {
+            byte[] first = Encoding.UTF8.GetBytes("alpha\r\n\x1b[1mbold\x1b[0m ");
+            recorder.RecordChunk(first, first.Length);
+            recorder.RecordResize(30, 6);
+            recorder.RecordChunkAt(10, rocket.AsSpan(0, 2).ToArray(), 2);
+            recorder.RecordChunkAt(20, rocket.AsSpan(2, 2).ToArray(), 2);
+        });
+
+        var expectedBuffer = new TerminalBuffer(80, 24);
+        var expectedParser = new AnsiParser(expectedBuffer);
+        expectedBuffer.Resize(40, 10); // v2 header geometry, applied before data
+        expectedParser.Process("alpha\r\n\x1b[1mbold\x1b[0m ");
+        expectedBuffer.Resize(30, 6);
+        expectedParser.Process("🚀");
+        string expected = BufferSnapshot.Capture(expectedBuffer, includeAttributes: false).ToFormattedString();
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        int exitCode = ReplayCommand.Execute(["--replay", recPath], stdout, stderr);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(string.Empty, stderr.ToString());
+        Assert.Equal(expected.TrimEnd('\r', '\n'), stdout.ToString().TrimEnd('\r', '\n'));
+        Assert.Contains("🚀", stdout.ToString());
+    }
+
+    [Fact]
+    public void Execute_WithAttributes_PrintsAttributeLines()
+    {
+        string recPath = WriteRecording(NewRecPath(), recorder =>
+        {
+            byte[] data = Encoding.UTF8.GetBytes("\x1b[31mred\x1b[0m plain");
+            recorder.RecordChunk(data, data.Length);
+        });
+
+        using var plainOut = new StringWriter();
+        using var attrOut = new StringWriter();
+        using var stderr = new StringWriter();
+
+        Assert.Equal(0, ReplayCommand.Execute(["--replay", recPath], plainOut, stderr));
+        Assert.Equal(0, ReplayCommand.Execute(["--replay", recPath, "--attributes"], attrOut, stderr));
+
+        var buffer = new TerminalBuffer(40, 10);
+        new AnsiParser(buffer).Process("\x1b[31mred\x1b[0m plain");
+        string expectedAttrs = BufferSnapshot.Capture(buffer, includeAttributes: true).ToFormattedString();
+
+        Assert.Equal(expectedAttrs.TrimEnd('\r', '\n'), attrOut.ToString().TrimEnd('\r', '\n'));
+        Assert.NotEqual(plainOut.ToString(), attrOut.ToString());
+    }
+
+    // ── Truncated / unreadable files ─────────────────────────────────────────
+
+    [Fact]
+    public async Task Execute_TruncatedTail_Exit1_WithPartialScreenAndWarning()
+    {
+        // Flight-recorder exports of live sessions can end mid-write; the CLI
+        // must print the readable prefix and warn instead of failing outright.
+        string recPath = WriteRecording(NewRecPath(), recorder =>
+        {
+            byte[] data = Encoding.UTF8.GetBytes("visible content");
+            recorder.RecordChunk(data, data.Length);
+        });
+        string full = await File.ReadAllTextAsync(recPath, TestContext.Current.CancellationToken);
+        await File.WriteAllTextAsync(
+            recPath,
+            full.TrimEnd('\r', '\n') + "\n{\"t\":99,\"type\":\"data\",\"d\":\"QUJD",
+            TestContext.Current.CancellationToken); // torn final line
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        int exitCode = ReplayCommand.Execute(["--replay", recPath], stdout, stderr);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("visible content", stdout.ToString());
+        Assert.Contains("truncated", stderr.ToString());
+    }
+
+    [Fact]
+    public void Execute_UnreadableFile_Exit1_WithError()
+    {
+        string recPath = Path.Combine(_tempDir, "garbage.rec");
+        File.WriteAllText(recPath, "this is not a replay file\nnot json either\n");
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        int exitCode = ReplayCommand.Execute(["--replay", recPath], stdout, stderr);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Failed to replay", stderr.ToString());
+    }
+
+    // ── End-to-end with the flight recorder (the A4 loop) ────────────────────
+
+    [Fact]
+    public void Execute_RendersAFlightRecorderExport()
+    {
+        // The full A4 story: session bytes → flight ring → exportReplay file →
+        // headless CLI → deterministic screen.
+        var ring = new FlightRecordingBuffer(1024 * 1024, 40, 10, clock: static () => 0);
+        byte[] bytes = Encoding.UTF8.GetBytes("agent did this\r\nline two");
+        ring.RecordChunk(bytes, bytes.Length);
+        string recPath = NewRecPath();
+        ring.ExportTo(recPath, "stub-shell");
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        int exitCode = ReplayCommand.Execute(["--replay", recPath], stdout, stderr);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("agent did this", stdout.ToString());
+        Assert.Contains("line two", stdout.ToString());
+    }
+}

--- a/tests/NovaTerminal.App.Tests/ReplayTests/ReplayV2Tests.cs
+++ b/tests/NovaTerminal.App.Tests/ReplayTests/ReplayV2Tests.cs
@@ -221,6 +221,63 @@ namespace NovaTerminal.Tests.ReplayTests
         }
 
         [Fact]
+        public async Task ReplayV2_Snapshot_RoundTrip_PreservesPendingWrap()
+        {
+            // A snapshot taken right after output fills the last column carries
+            // deferred-autowrap state ("pw"). Replaying snapshot + next chunk must
+            // produce the same screen as feeding the bytes directly: the next
+            // character wraps to the following row instead of overwriting col N-1.
+            string tempFile = Path.GetTempFileName();
+            try
+            {
+                var liveBuffer = new TerminalBuffer(5, 3);
+                var liveParser = new AnsiParser(liveBuffer);
+                liveParser.Process("12345"); // fills row 0 → pending wrap
+                Assert.True(liveBuffer.IsPendingWrap);
+
+                using (var recorder = new PtyRecorder(tempFile, 5, 3))
+                {
+                    recorder.RecordSnapshot(liveBuffer);
+                    byte[] next = Encoding.UTF8.GetBytes("X");
+                    recorder.RecordChunk(next, next.Length);
+                }
+
+                var replayBuffer = new TerminalBuffer(5, 3);
+                var replayParser = new AnsiParser(replayBuffer);
+                var runner = new ReplayRunner(tempFile);
+                await runner.RunAsync(
+                    onDataCallback: data =>
+                    {
+                        replayParser.Process(Encoding.UTF8.GetString(data));
+                        return Task.CompletedTask;
+                    },
+                    onResizeCallback: (cols, rows) =>
+                    {
+                        replayBuffer.Resize(cols, rows);
+                        return Task.CompletedTask;
+                    },
+                    onSnapshotCallback: snapshot =>
+                    {
+                        Assert.True(snapshot.IsPendingWrap); // captured on the wire
+                        replayBuffer.ApplySnapshot(snapshot);
+                        Assert.True(replayBuffer.IsPendingWrap); // restored
+                        return Task.CompletedTask;
+                    });
+
+                liveParser.Process("X"); // what really happens live
+
+                BufferSnapshot expected = BufferSnapshot.Capture(liveBuffer, includeAttributes: true);
+                BufferSnapshot actual = BufferSnapshot.Capture(replayBuffer, includeAttributes: true);
+                Assert.Equal(expected.ToFormattedString(), actual.ToFormattedString());
+                Assert.Equal("X", actual.Lines[1]); // wrapped, not overwritten at row 0 end
+            }
+            finally
+            {
+                if (File.Exists(tempFile)) File.Delete(tempFile);
+            }
+        }
+
+        [Fact]
         public async Task ReplayRunner_V1Compatibility_Works()
         {
             string tempFile = Path.GetTempFileName();


### PR DESCRIPTION
## Summary

Final slice of **milestone A4 (Replay for agents)** per `docs/plans/2026-07-07-agent-host-a4-replay-design.md`, on top of #190 (flight recorder core) and #191 (`exportReplay` protocol + MCP tool): the **headless replay CLI**, README docs, and the DIRECTION A4 checkboxes.

## What's here

**`ReplayCommand` (`NovaTerminal.App/Shell`, dispatched from `NovaTerminal.Cli`)**

`NovaTerminal.Cli --replay <file> [--attributes]` runs a replay file (v2, with v1 compatibility) through the deterministic core in Virtual mode — stateful UTF-8 decode → `AnsiParser.Process`, `buffer.Resize` on resize events, `ApplySnapshot` on snapshot events — and prints the final screen as `BufferSnapshot.ToFormattedString()`, the same snapshot the golden/parity tests consume. Async bridged with `GetAwaiter().GetResult()` (established CLI constraint).

Exit codes: **0** success; **1** unreadable or truncated file — a truncated tail (which a flight-recorder export of a live session can legitimately have) still prints the readable prefix via `RunWithResultAsync` and warns on stderr; **2** usage errors (missing path, unknown/duplicate flags).

**Design deviation, called out:** the design doc sketched a `--fast-forward-ms N` option; it is not implemented. In Virtual mode the entire file is already processed instantly (fast-forward is a Realtime-mode concept in `ReplayRunner`), and rendering the screen *as of* an intermediate time is exactly the frame-stepping/`--at <ms>` feature the design doc lists as out of scope. Adding a flag that silently does nothing would be worse than omitting it.

**Docs**
- README: `--replay` added to the Cli module note; the agent-host program section gains the "debug what your agent did, frame by frame" story (export via `novaterminal.export_replay` — never input — replay via `NovaTerminal.Cli --replay`).
- `DIRECTION.md`: all three A4 deliverable checkboxes closed with PR references. The CLI checkbox notes that PNG output is deferred (out of scope in the approved design); **milestone A4 is complete** with this merge.

## Testing

`ReplayCommandCliTests` (8 tests): flag detection; usage errors exit 2 with usage on stderr (missing path, flag-as-path, unknown arg, duplicates); missing file exits 1; **final screen matches a directly-fed buffer byte-for-byte** (incl. header geometry, mid-stream resize, and an emoji split across chunks); `--attributes` prints the attribute snapshot; truncated tail exits 1 with partial screen + warning; garbage file exits 1; end-to-end `FlightRecordingBuffer → ExportTo → --replay` renders the exported session.

Local: App.Tests (ReplayCommandCli + ReplayTests + AgentHost filter) 143/143.
