### PR TITLE
feat(agent-host): A3 slice 1 - act gate + send_input (permissioned, journaled)

### DIFF
--- a/docs/plans/2026-07-12-agent-host-a3-act-design.md
+++ b/docs/plans/2026-07-12-agent-host-a3-act-design.md
@@ -1,0 +1,169 @@
+# Agent Host A3 (Act, Permissioned) Design
+
+Milestone **A3** of `docs/agent-host/DIRECTION.md`: agents can — with explicit,
+separate permission — type into, spawn, and close terminal sessions. Follows
+A1 (observe), A2 (status), A4 (replay export); the protocol stays additive on
+version 1.
+
+## Goal
+
+- **`novaterminal.send_input`** — inject input into a live session, byte-faithful
+  and replay-recorded exactly like human keystrokes.
+- **`novaterminal.spawn_session`** — open a new tab running a local profile or
+  an *allowlisted* SSH profile, by name; returns the new paneId.
+- **`novaterminal.close_session`** — close a live pane.
+- **Permission model** (DIRECTION table: "off; separate explicit opt-in,
+  per-profile allowlist for SSH"): a new default-off `AgentAccessActEnabled`
+  settings toggle, plus a per-SSH-profile `AllowAgentAccess` flag (default
+  off). Acting on an SSH session (input, spawn) requires both.
+- **Activity journal**: every acting call — including denied ones — is recorded
+  to a visible in-app journal. Nothing is silent.
+- **Threat-model doc** for the acting surface.
+
+## Current State (verified)
+
+- The observe endpoint (`AgentHostService`) already gates everything on
+  `AgentAccessObserveEnabled` and carries a second volatile gate
+  (`ReplayExportEnabled`, A4) pushed by MainWindow on settings apply — the
+  same pattern extends to the act gate.
+- `AgentSessionRegistration` publishes the pane's `ITerminalSession` (volatile
+  slot, A4). `ITerminalSession.SendInput(string)` is thread-safe (bounded
+  input queue, dedicated writer thread) and already records input to any
+  active manual recording (`_recorder?.RecordInput`) — the "replay-recorded
+  like any PTY input" acceptance criterion falls out of reusing this path.
+  The A4 flight ring records output only; agent input never lands in agent
+  exports (privacy invariant upheld).
+- Registrations carry `Title`/`ProfileName`/`Kind` ("local"/"ssh") but not the
+  profile id; the allowlist check needs identity, so the pane will also push
+  `ProfileId`.
+- `MainWindow.AddTab(TerminalProfile?)` opens a tab from a local settings
+  profile or a store-backed SSH profile (`_sshConnectionService`);
+  `CloseActivePaneAsync()` implements the split-aware close path. Both are
+  UI-thread-only, so acting requests need a UI executor bridge.
+- `SshProfile` (Platform, JSON store with schema versioning) has no
+  agent-related field; adding a bool defaulting to false needs no migration.
+
+## Design
+
+### Permission model
+
+| Check | sendInput | spawnSession | closeSession |
+|---|---|---|---|
+| Observe endpoint running | ✓ (transport exists at all) | ✓ | ✓ |
+| `AgentAccessActEnabled` (new, default off) | ✓ | ✓ | ✓ |
+| SSH profile `AllowAgentAccess` (new, default off) | ✓ when the target pane is an SSH session | ✓ when the named profile is SSH | — |
+
+- `AgentAccessActEnabled` is a settings-window sub-toggle under Agent access
+  (sibling of the A4 replay-export toggle) with copy that states exactly what
+  it allows. MainWindow pushes it into `AgentHostService.ActEnabled`
+  (volatile) at both settings-apply sites.
+- `AllowAgentAccess` on `SshProfile` (persisted, default false), surfaced as a
+  checkbox in the connection profile editor. The endpoint checks it through an
+  injectable probe (`Func<Guid, bool>` published by MainWindow, reading the
+  profile store) so tests can stub it and the service never touches UI state.
+- `closeSession` deliberately has no SSH-allowlist requirement: closing is
+  destructive-but-bounded (ends a session the user can see disappearing, and
+  is journaled); it cannot exfiltrate or execute anything remotely.
+
+Denied calls return distinct stable error codes so agents can tell "ask the
+user to opt in" from "pick a different profile": `actDisabled`,
+`profileNotAllowed`, `profileNotFound`, `sessionNotRunning`, `actUnavailable`
+(endpoint running but no UI executor — e.g. teardown race), `spawnFailed`.
+
+### Protocol (additive, version stays 1)
+
+- `sendInput { paneId, text }` → `{ bytesSent }`. `text` is a JSON string and
+  may contain control characters (`\x03` = Ctrl-C, `\r` = Enter …); it is
+  UTF-8 encoded and queued through the session's normal `SendInput` path —
+  byte-faithful at the boundary we own (injecting invalid-UTF-8 byte
+  sequences is out of scope; the session API is string-typed end to end).
+  Capped at 32 KiB per call (`malformedRequest` beyond).
+- `spawnSession { profile? }` → `{ paneId, tabId, profileName, kind }`.
+  Missing/empty `profile` = the default local profile. Otherwise the name is
+  resolved case-insensitively against local settings profiles first, then the
+  SSH store (`profileNotFound` if neither; `profileNotAllowed` for an SSH
+  profile without `AllowAgentAccess`).
+- `closeSession { paneId }` → `{ closed: true }`.
+
+### UI executor bridge (spawn/close)
+
+`AgentHostService` never touches Avalonia. MainWindow publishes a volatile
+executor object (`IAgentActionExecutor`: `Task<SpawnResult> SpawnAsync(...)`,
+`Task<bool> ClosePaneAsync(Guid paneId)`) on startup and clears it on close;
+its implementation marshals to the UI thread (`Dispatcher.UIThread.InvokeAsync`)
+and reuses `AddTab` / the existing split-aware close path. Null executor →
+`actUnavailable`. Agent-triggered closes bypass the close-confirmation dialog
+(a modal question the agent cannot answer); the act opt-in plus the journal
+entry is the consent surface — called out in the threat model.
+
+`sendInput` needs no executor: it goes through the registration's published
+session, which is thread-safe by contract.
+
+### Activity journal
+
+`AgentActivityJournal` (App/AgentHost): thread-safe bounded ring (last 200
+entries) of `{ timestampUtc, method, paneId?, target, outcome }` where outcome
+is `ok` or the error code — **denied attempts are journaled too**. The
+endpoint appends on every acting request; an `EntryAdded` event feeds the UI.
+PR3 adds the visible surface (menu-accessible journal window listing entries,
+newest first, with a live indicator while entries arrive). The journal is
+in-memory: it is a visibility surface, not an audit log — stated in the
+threat model.
+
+## Alternatives considered
+
+- **Reusing the observe toggle for acting** — rejected outright by DIRECTION's
+  permission table; observing must never quietly escalate.
+- **Allowlist on local profiles too** — local shells are already fully
+  reachable by any local process running as the user; the allowlist exists
+  because SSH profiles reach *other* machines with the user's credentials.
+  A local allowlist would be security theater; the single act toggle governs
+  local sessions.
+- **Blocking close on the confirm dialog** — turns every agent close into a
+  25 s protocol timeout with a surprise modal; rejected in favor of
+  bypass + journal.
+- **Persisting the journal to disk** — an append-only file invites being
+  treated as an audit log, which it is not (the agent's own MCP transcript is
+  the audit trail); in-memory keeps the privacy footprint zero.
+
+## Testing
+
+- **Hard-fail acceptance (DIRECTION):** all three methods return `actDisabled`
+  when only observe is enabled; sendInput/spawn return `profileNotAllowed` for
+  non-allowlisted SSH targets; everything still works for local sessions with
+  the act toggle on.
+- **Byte-faithful acceptance:** handler test asserts the exact wire string
+  (including `\x03` and `\r`) reaches `ITerminalSession.SendInput`;
+  PtySmoke-level test proves an agent-injected command executes in a live
+  shell and that a manual recording of that session contains the injected
+  input event (replay-recorded like any PTY input).
+- **Protocol:** unknown pane → `sessionNotFound`; exited session →
+  `sessionNotRunning`; missing params → `malformedRequest`; oversized input →
+  `malformedRequest`; no executor → `actUnavailable`; spawn resolves local
+  before SSH on name collision.
+- **Journal:** every call (allowed and denied) appends exactly one entry with
+  the right outcome; ring is bounded.
+- **Off-is-off:** with the act toggle off nothing about observe behavior
+  changes (existing suites stay green).
+
+## Out of scope
+
+- Raw non-UTF-8 byte injection, per-key events, or paste-bracketing controls.
+- Split-pane spawning (`spawnSession` opens tabs; panes/splits can follow).
+- Persisted audit logging, per-agent identity, or rate limiting beyond the
+  input size cap (the endpoint is per-user local; see threat model).
+- Any network-exposed control surface (unchanged non-goal).
+
+## Suggested PR slicing
+
+1. **Act gate + sendInput:** contracts (method, error codes, DTOs), settings
+   toggle + `ActEnabled` plumbing, `SshProfile.AllowAgentAccess` + allowlist
+   probe, registration `ProfileId` + `TrySendInput`, journal core (no UI),
+   `sendInput` handler, MCP `novaterminal.send_input`, acceptance + protocol +
+   journal tests.
+2. **spawnSession/closeSession:** executor bridge published by MainWindow,
+   both handlers + MCP tools, connection-editor allowlist checkbox, tests.
+3. **Journal UI + docs:** journal window, threat-model doc
+   (`docs/agent-host/2026-07-12-acting-threat-model.md`), README + McpServer
+   README updated (the MCP surface is no longer read-only), DIRECTION A3
+   checkboxes.

--- a/src/NovaTerminal.AgentHost.Contracts/ActContracts.cs
+++ b/src/NovaTerminal.AgentHost.Contracts/ActContracts.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace NovaTerminal.AgentHost.Contracts;
+
+/// <summary>Params for <c>sendInput</c> (A3, act surface).</summary>
+public sealed record SendInputParams
+{
+    [JsonPropertyName("paneId")]
+    public required Guid PaneId { get; init; }
+
+    /// <summary>
+    /// Text to inject, exactly as a human would type it. May contain control
+    /// characters (e.g. "" = Ctrl-C, "\r" = Enter). UTF-8 encoded and
+    /// queued through the session's normal input path. Capped server-side at
+    /// <see cref="AgentHostProtocol.MaxSendInputBytes"/>.
+    /// </summary>
+    [JsonPropertyName("text")]
+    public required string Text { get; init; }
+}
+
+/// <summary>Result payload for <c>sendInput</c>.</summary>
+public sealed record SendInputResult
+{
+    /// <summary>Number of UTF-8 bytes queued to the session.</summary>
+    [JsonPropertyName("bytesSent")]
+    public required int BytesSent { get; init; }
+}

--- a/src/NovaTerminal.AgentHost.Contracts/AgentHostJsonContext.cs
+++ b/src/NovaTerminal.AgentHost.Contracts/AgentHostJsonContext.cs
@@ -28,6 +28,8 @@ namespace NovaTerminal.AgentHost.Contracts;
 [JsonSerializable(typeof(WaitForEventsResult))]
 [JsonSerializable(typeof(ExportReplayParams))]
 [JsonSerializable(typeof(ExportReplayResult))]
+[JsonSerializable(typeof(SendInputParams))]
+[JsonSerializable(typeof(SendInputResult))]
 public sealed partial class AgentHostJsonContext : JsonSerializerContext
 {
 }

--- a/src/NovaTerminal.AgentHost.Contracts/AgentHostProtocol.cs
+++ b/src/NovaTerminal.AgentHost.Contracts/AgentHostProtocol.cs
@@ -65,7 +65,18 @@ public static class AgentHostProtocol
         /// the observe toggle.
         /// </summary>
         public const string ExportReplay = "exportReplay";
+
+        /// <summary>
+        /// A3 (act, permissioned): injects input into a live session,
+        /// byte-faithful and replay-recorded like human keystrokes. Requires
+        /// the separate <c>AgentAccessActEnabled</c> opt-in on top of observe,
+        /// plus per-profile allowlisting for SSH sessions.
+        /// </summary>
+        public const string SendInput = "sendInput";
     }
+
+    /// <summary>Server-side cap on a single <c>sendInput</c> payload, in bytes (A3).</summary>
+    public const int MaxSendInputBytes = 32 * 1024;
 
     /// <summary>Wire values for session status (A2). See the A2 design doc for exact semantics.</summary>
     public static class StatusKinds
@@ -119,5 +130,36 @@ public static class AgentHostProtocol
         /// down, or the export failed to write).
         /// </summary>
         public const string ExportUnavailable = "exportUnavailable";
+
+        /// <summary>
+        /// A3: an acting method (<c>sendInput</c> and later spawn/close) was
+        /// called but the user has not enabled "Agent access (act)" — the
+        /// separate default-off opt-in that gates all acting, on top of observe.
+        /// </summary>
+        public const string ActDisabled = "actDisabled";
+
+        /// <summary>
+        /// A3: the target (or named) SSH profile has not been allowlisted for
+        /// agent access (<c>AllowAgentAccess</c> is off). Local sessions are
+        /// governed by the act toggle alone and never hit this.
+        /// </summary>
+        public const string ProfileNotAllowed = "profileNotAllowed";
+
+        /// <summary>A3: <c>spawnSession</c> named a profile that matched no local or SSH profile.</summary>
+        public const string ProfileNotFound = "profileNotFound";
+
+        /// <summary>A3: the target session exists but its process has already exited — input goes nowhere.</summary>
+        public const string SessionNotRunning = "sessionNotRunning";
+
+        /// <summary>
+        /// A3: the endpoint is running but the UI action executor is not
+        /// published (startup/teardown race). Distinct from
+        /// <see cref="ActDisabled"/>: the user opted in, the app just can't act
+        /// this instant — safe to retry.
+        /// </summary>
+        public const string ActUnavailable = "actUnavailable";
+
+        /// <summary>A3: <c>spawnSession</c> resolved a profile but the tab failed to open.</summary>
+        public const string SpawnFailed = "spawnFailed";
     }
 }

--- a/src/NovaTerminal.App/AgentHost/AgentActivityJournal.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentActivityJournal.cs
@@ -73,7 +73,18 @@ namespace NovaTerminal.AgentHost
                 }
             }
 
-            EntryAdded?.Invoke(entry);
+            // Isolate subscriber faults: Record runs on the acting path *after*
+            // input has already been delivered, so a throwing UI subscriber must
+            // not propagate out and turn a successful sendInput into an error the
+            // caller would retry (double-submitting the input).
+            try
+            {
+                EntryAdded?.Invoke(entry);
+            }
+            catch
+            {
+                // best effort — the journal is a visibility surface, not critical path
+            }
             return entry;
         }
 

--- a/src/NovaTerminal.App/AgentHost/AgentActivityJournal.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentActivityJournal.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NovaTerminal.AgentHost
+{
+    /// <summary>
+    /// One recorded agent acting attempt (A3). Denied attempts are recorded too:
+    /// the journal is a visibility surface, so the user can see everything an
+    /// agent tried, not only what succeeded.
+    /// </summary>
+    public sealed record AgentActivityEntry
+    {
+        public required DateTimeOffset TimestampUtc { get; init; }
+
+        /// <summary>Protocol method (<see cref="Contracts.AgentHostProtocol.Methods"/>), e.g. "sendInput".</summary>
+        public required string Method { get; init; }
+
+        /// <summary>Target pane, when the call addressed one.</summary>
+        public Guid? PaneId { get; init; }
+
+        /// <summary>Human-readable target (profile name, pane title, or a short summary of the payload).</summary>
+        public required string Target { get; init; }
+
+        /// <summary>"ok" for a successful call, otherwise the stable error code that was returned.</summary>
+        public required string Outcome { get; init; }
+    }
+
+    /// <summary>
+    /// Thread-safe bounded ring of recent agent acting attempts (A3). In-memory
+    /// only — a visibility surface, not an audit log (the agent's own MCP
+    /// transcript is the audit trail). The acting endpoint appends on every
+    /// acting request; the UI subscribes to <see cref="EntryAdded"/>.
+    /// </summary>
+    public sealed class AgentActivityJournal
+    {
+        /// <summary>Process-wide instance used by the app wiring. Tests construct their own.</summary>
+        public static AgentActivityJournal Instance { get; } = new();
+
+        /// <summary>Maximum retained entries; older ones are evicted.</summary>
+        public const int Capacity = 200;
+
+        private readonly object _gate = new();
+        private readonly Queue<AgentActivityEntry> _entries = new();
+        private readonly Func<DateTimeOffset> _now;
+
+        public AgentActivityJournal(Func<DateTimeOffset>? nowProvider = null)
+        {
+            _now = nowProvider ?? (static () => DateTimeOffset.UtcNow);
+        }
+
+        /// <summary>Raised after an entry is appended (may fire on a background/IPC thread).</summary>
+        public event Action<AgentActivityEntry>? EntryAdded;
+
+        /// <summary>Records an acting attempt and its outcome. Returns the stored entry.</summary>
+        public AgentActivityEntry Record(string method, Guid? paneId, string target, string outcome)
+        {
+            var entry = new AgentActivityEntry
+            {
+                TimestampUtc = _now(),
+                Method = method,
+                PaneId = paneId,
+                Target = target ?? string.Empty,
+                Outcome = outcome,
+            };
+
+            lock (_gate)
+            {
+                _entries.Enqueue(entry);
+                while (_entries.Count > Capacity)
+                {
+                    _entries.Dequeue();
+                }
+            }
+
+            EntryAdded?.Invoke(entry);
+            return entry;
+        }
+
+        /// <summary>Point-in-time snapshot, newest first.</summary>
+        public IReadOnlyList<AgentActivityEntry> Snapshot()
+        {
+            lock (_gate)
+            {
+                return _entries.Reverse().ToArray();
+            }
+        }
+
+        public int Count
+        {
+            get { lock (_gate) { return _entries.Count; } }
+        }
+    }
+}

--- a/src/NovaTerminal.App/AgentHost/AgentHostService.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentHostService.cs
@@ -734,10 +734,22 @@ namespace NovaTerminal.AgentHost
 
         private AgentHostResponse HandleSendInput(AgentHostRequest request)
         {
-            var p = DeserializeParams(request, AgentHostJsonContext.Default.SendInputParams);
+            SendInputParams? p;
+            try
+            {
+                p = DeserializeParams(request, AgentHostJsonContext.Default.SendInputParams);
+            }
+            catch (JsonException)
+            {
+                // Missing required fields / bad shapes throw here rather than
+                // returning null. Journal it: a malformed acting attempt is still
+                // an externally reachable acting attempt the user should see.
+                p = null;
+            }
             if (p == null || p.Text == null)
             {
-                return Error(request.Id, AgentHostProtocol.ErrorCodes.MalformedRequest, "sendInput requires params with a paneId and text.");
+                return Journaled(request, AgentHostProtocol.Methods.SendInput, p?.PaneId, "input",
+                    Error(request.Id, AgentHostProtocol.ErrorCodes.MalformedRequest, "sendInput requires params with a paneId and text."));
             }
 
             // Size cap before any lookup so a flood is rejected cheaply.

--- a/src/NovaTerminal.App/AgentHost/AgentHostService.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentHostService.cs
@@ -243,6 +243,14 @@ namespace NovaTerminal.AgentHost
                 ReleaseDiscoveryFile(_discoveryFilePath);
                 _discoveryFilePath = null;
             }
+
+            // Release the SSH allowlist probe. It closes over MainWindow (via the
+            // instance method it points at); this static singleton outlives the
+            // window, so holding the delegate would pin the closed window (and its
+            // tabs, PTYs, controls) in memory. MainWindow re-publishes it before
+            // each Apply, so clearing here is safe. Bool gates are value types and
+            // do not leak, so they are left as-is.
+            _sshProfileAllowlist = null;
         }
 
         /// <summary>

--- a/src/NovaTerminal.App/AgentHost/AgentHostService.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentHostService.cs
@@ -38,6 +38,7 @@ namespace NovaTerminal.AgentHost
         private readonly string? _endpointOverride;
         private readonly string? _discoveryDirectoryOverride;
         private readonly string? _exportDirectoryOverride;
+        private readonly AgentActivityJournal _journal;
         private readonly object _gate = new();
 
         private CancellationTokenSource? _cts;
@@ -57,12 +58,14 @@ namespace NovaTerminal.AgentHost
             AgentSessionRegistry registry,
             string? endpointOverride = null,
             string? discoveryDirectoryOverride = null,
-            string? exportDirectoryOverride = null)
+            string? exportDirectoryOverride = null,
+            AgentActivityJournal? journal = null)
         {
             _registry = registry ?? throw new ArgumentNullException(nameof(registry));
             _endpointOverride = endpointOverride;
             _discoveryDirectoryOverride = discoveryDirectoryOverride;
             _exportDirectoryOverride = exportDirectoryOverride;
+            _journal = journal ?? AgentActivityJournal.Instance;
         }
 
         // Volatile: written by the UI thread (settings apply), read by the IPC
@@ -82,6 +85,45 @@ namespace NovaTerminal.AgentHost
         {
             get => _replayExportEnabled;
             set => _replayExportEnabled = value;
+        }
+
+        // A3 act gate. Volatile for the same UI-writes/IPC-reads reason as the
+        // export gate above.
+        private volatile bool _actEnabled;
+
+        /// <summary>
+        /// Separate default-off opt-in for the acting surface (A3):
+        /// <c>sendInput</c> and later spawn/close. Mirrors
+        /// <c>TerminalSettings.AgentAccessActEnabled</c>, pushed by MainWindow
+        /// alongside <see cref="Apply"/>. On top of observe; SSH targets need
+        /// per-profile allowlisting as well (see <see cref="AllowsAgentActOnProfile"/>).
+        /// </summary>
+        public bool ActEnabled
+        {
+            get => _actEnabled;
+            set => _actEnabled = value;
+        }
+
+        // Per-profile SSH allowlist probe, published by MainWindow (reads the
+        // SSH profile store). Null (no probe wired) denies every SSH profile —
+        // fail closed. Volatile: published from the UI thread, read on IPC.
+        private volatile Func<Guid, bool>? _sshProfileAllowlist;
+
+        /// <summary>Publishes (or clears) the per-profile SSH allowlist probe. UI thread.</summary>
+        public void SetSshProfileAllowlist(Func<Guid, bool>? probe) => _sshProfileAllowlist = probe;
+
+        private bool AllowsAgentActOnProfile(Guid profileId)
+        {
+            var probe = _sshProfileAllowlist;
+            if (probe == null) return false; // fail closed
+            try
+            {
+                return probe(profileId);
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         public bool IsRunning
@@ -583,6 +625,7 @@ namespace NovaTerminal.AgentHost
                     AgentHostProtocol.Methods.GetSessionStatus => HandleGetSessionStatus(request),
                     AgentHostProtocol.Methods.WaitForEvents => await HandleWaitForEventsAsync(request, cancellationToken).ConfigureAwait(false),
                     AgentHostProtocol.Methods.ExportReplay => HandleExportReplay(request),
+                    AgentHostProtocol.Methods.SendInput => HandleSendInput(request),
                     _ => Error(request.Id, AgentHostProtocol.ErrorCodes.UnknownMethod, $"Unknown method '{request.Method}'."),
                 };
             }
@@ -687,6 +730,72 @@ namespace NovaTerminal.AgentHost
                 TruncatedAtStart = info.TruncatedAtStart,
             };
             return Ok(request.Id, JsonSerializer.SerializeToElement(result, AgentHostJsonContext.Default.ExportReplayResult));
+        }
+
+        private AgentHostResponse HandleSendInput(AgentHostRequest request)
+        {
+            var p = DeserializeParams(request, AgentHostJsonContext.Default.SendInputParams);
+            if (p == null || p.Text == null)
+            {
+                return Error(request.Id, AgentHostProtocol.ErrorCodes.MalformedRequest, "sendInput requires params with a paneId and text.");
+            }
+
+            // Size cap before any lookup so a flood is rejected cheaply.
+            int byteCount = Encoding.UTF8.GetByteCount(p.Text);
+            if (byteCount > AgentHostProtocol.MaxSendInputBytes)
+            {
+                return Journaled(request, AgentHostProtocol.Methods.SendInput, p.PaneId, "input",
+                    Error(request.Id, AgentHostProtocol.ErrorCodes.MalformedRequest,
+                        $"Input exceeds the {AgentHostProtocol.MaxSendInputBytes}-byte per-call limit."));
+            }
+
+            // Separate act opt-in (DIRECTION: acting never rides the observe toggle).
+            if (!_actEnabled)
+            {
+                return Journaled(request, AgentHostProtocol.Methods.SendInput, p.PaneId, "input",
+                    Error(request.Id, AgentHostProtocol.ErrorCodes.ActDisabled,
+                        "Acting is disabled. Enable Settings → Agent access (observe) → Agent access (act) in NovaTerminal, then retry."));
+            }
+
+            if (!_registry.TryGet(p.PaneId, out var registration))
+            {
+                return Journaled(request, AgentHostProtocol.Methods.SendInput, p.PaneId, "input",
+                    Error(request.Id, AgentHostProtocol.ErrorCodes.SessionNotFound, $"No live session with paneId '{p.PaneId}'."));
+            }
+
+            // Per-profile SSH allowlist: acting on a remote reaches another
+            // machine with the user's credentials, so it is opt-in per profile.
+            if (string.Equals(registration.Kind, "ssh", StringComparison.Ordinal))
+            {
+                if (registration.ProfileId is not { } profileId || !AllowsAgentActOnProfile(profileId))
+                {
+                    return Journaled(request, AgentHostProtocol.Methods.SendInput, p.PaneId, registration.ProfileName,
+                        Error(request.Id, AgentHostProtocol.ErrorCodes.ProfileNotAllowed,
+                            $"The SSH profile '{registration.ProfileName}' is not allowlisted for agent access. Enable it in the connection's settings, then retry."));
+                }
+            }
+
+            if (!registration.TrySendInput(p.Text))
+            {
+                return Journaled(request, AgentHostProtocol.Methods.SendInput, p.PaneId, registration.ProfileName,
+                    Error(request.Id, AgentHostProtocol.ErrorCodes.SessionNotRunning,
+                        "The session is not accepting input (its process has exited or is being torn down)."));
+            }
+
+            var result = new SendInputResult { BytesSent = byteCount };
+            return Journaled(request, AgentHostProtocol.Methods.SendInput, p.PaneId, registration.ProfileName,
+                Ok(request.Id, JsonSerializer.SerializeToElement(result, AgentHostJsonContext.Default.SendInputResult)));
+        }
+
+        /// <summary>
+        /// Records an acting attempt to the journal (allowed or denied) and
+        /// returns the response unchanged. Outcome = "ok" or the error code, so
+        /// the user sees everything an agent tried.
+        /// </summary>
+        private AgentHostResponse Journaled(AgentHostRequest request, string method, Guid? paneId, string target, AgentHostResponse response)
+        {
+            _journal.Record(method, paneId, target, response.Error?.Code ?? "ok");
+            return response;
         }
 
         private AgentHostResponse HandleListSessions(AgentHostRequest request)

--- a/src/NovaTerminal.App/AgentHost/AgentSessionRegistration.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentSessionRegistration.cs
@@ -24,6 +24,7 @@ namespace NovaTerminal.AgentHost
         private string _profileName;
         private string _kind;
         private bool _isActive;
+        private Guid? _profileId;
 
         public AgentSessionRegistration(
             Guid paneId,
@@ -32,7 +33,8 @@ namespace NovaTerminal.AgentHost
             string profileName,
             string kind,
             bool isActive,
-            Func<DateTimeOffset>? nowProvider = null)
+            Func<DateTimeOffset>? nowProvider = null,
+            Guid? profileId = null)
         {
             ArgumentNullException.ThrowIfNull(buffer);
             _paneId = paneId;
@@ -41,6 +43,7 @@ namespace NovaTerminal.AgentHost
             _profileName = profileName;
             _kind = kind;
             _isActive = isActive;
+            _profileId = profileId;
             StatusMachine = new AgentSessionStatusMachine(nowProvider);
         }
 
@@ -224,6 +227,39 @@ namespace NovaTerminal.AgentHost
             get { lock (_gate) { return _kind; } }
         }
 
+        /// <summary>
+        /// Backing profile id (local settings profile or SSH store profile), or
+        /// null for a profile-less pane. Used by the A3 act surface to check the
+        /// per-profile SSH allowlist; null or a local session is governed by the
+        /// global act toggle alone.
+        /// </summary>
+        public Guid? ProfileId
+        {
+            get { lock (_gate) { return _profileId; } }
+        }
+
+        /// <summary>
+        /// Injects <paramref name="text"/> into the live session (A3). Returns
+        /// false when no session is published or its process has already exited.
+        /// Goes through <see cref="NovaTerminal.Pty.ITerminalIO.SendInput"/> —
+        /// the same thread-safe, replay-recorded path human keystrokes take.
+        /// </summary>
+        public bool TrySendInput(string text)
+        {
+            var session = _session;
+            if (session == null) return false;
+            try
+            {
+                if (!session.IsProcessRunning) return false;
+                session.SendInput(text);
+                return true;
+            }
+            catch
+            {
+                return false; // raced a dispose
+            }
+        }
+
         /// <summary>True when this pane was the active pane of its tab at the last snapshot push.</summary>
         public bool IsActive
         {
@@ -231,7 +267,7 @@ namespace NovaTerminal.AgentHost
         }
 
         /// <summary>Atomically replaces the pane-owned metadata. Called on the UI thread by the pane.</summary>
-        public void UpdateSnapshot(string title, string profileName, string kind, bool isActive)
+        public void UpdateSnapshot(string title, string profileName, string kind, bool isActive, Guid? profileId = null)
         {
             lock (_gate)
             {
@@ -239,6 +275,7 @@ namespace NovaTerminal.AgentHost
                 _profileName = profileName;
                 _kind = kind;
                 _isActive = isActive;
+                _profileId = profileId;
             }
         }
     }

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -195,7 +195,8 @@ namespace NovaTerminal.Controls
                 GetBaseTabTitle(),
                 Profile?.Name ?? "Terminal",
                 Profile?.Type == ConnectionType.SSH ? "ssh" : "local",
-                IsActivePane);
+                IsActivePane,
+                Profile?.Id);
         }
 
         public string GetBaseTabTitle()
@@ -401,7 +402,8 @@ namespace NovaTerminal.Controls
                 GetBaseTabTitle(),
                 Profile?.Name ?? "Terminal",
                 Profile?.Type == ConnectionType.SSH ? "ssh" : "local",
-                IsActivePane);
+                IsActivePane,
+                profileId: Profile?.Id);
             NovaTerminal.AgentHost.AgentSessionRegistry.Instance.Register(_agentRegistration);
             TitleChanged += (_, _) => UpdateAgentSessionSnapshot();
             WorkingDirectoryChanged += (_, _) => UpdateAgentSessionSnapshot();

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -1953,9 +1953,12 @@ namespace NovaTerminal
 
             // Agent-host observe endpoint (docs/agent-host/DIRECTION.md, A1):
             // strictly no-op unless the user opted in via Settings. The replay
-            // export sub-gate (A4) is pushed alongside so the endpoint checks
-            // the current setting on every exportReplay request.
+            // export sub-gate (A4) and the act gate + SSH allowlist (A3) are
+            // pushed alongside so the endpoint checks the current settings on
+            // every request.
             AgentHost.AgentHostService.Instance.ReplayExportEnabled = _settings.AgentReplayExportEnabled;
+            AgentHost.AgentHostService.Instance.ActEnabled = _settings.AgentAccessActEnabled;
+            AgentHost.AgentHostService.Instance.SetSshProfileAllowlist(IsSshProfileAgentAllowed);
             AgentHost.AgentHostService.Instance.Apply(_settings.AgentAccessObserveEnabled);
 
             // Ensure visual tree is ready for initial tab border
@@ -3089,6 +3092,22 @@ namespace NovaTerminal
             finally
             {
                 _closeTabInProgress = false;
+            }
+        }
+
+        // A3 per-profile SSH allowlist probe, handed to the agent-host endpoint.
+        // Reads the SSH profile store (off the UI thread on an IPC call), so it
+        // must not touch Avalonia state — the store is thread-safe. Unknown or
+        // non-SSH profile ids return false (fail closed).
+        private bool IsSshProfileAgentAllowed(Guid profileId)
+        {
+            try
+            {
+                return _sshConnectionService?.GetStoredProfile(profileId)?.AllowAgentAccess == true;
+            }
+            catch
+            {
+                return false;
             }
         }
 
@@ -4890,8 +4909,10 @@ namespace NovaTerminal
                 ApplySettingsToAllTabs();
                 UpdateTransparencyHints();
                 // Live-apply the agent-host observe endpoint (no restart needed),
-                // including the A4 replay-export sub-gate.
+                // including the A4 replay-export sub-gate and the A3 act gate.
                 AgentHost.AgentHostService.Instance.ReplayExportEnabled = _settings.AgentReplayExportEnabled;
+                AgentHost.AgentHostService.Instance.ActEnabled = _settings.AgentAccessActEnabled;
+                AgentHost.AgentHostService.Instance.SetSshProfileAllowlist(IsSshProfileAgentAllowed);
                 AgentHost.AgentHostService.Instance.Apply(_settings.AgentAccessObserveEnabled);
 
                 // Refresh Connection Manager if open (or just always update it)

--- a/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
@@ -91,6 +91,11 @@ public sealed class SshLaunchDetails
         if (existing != null)
         {
             incoming.RememberPasswordInVault = existing.RememberPasswordInVault;
+            // The connection editor has no agent-allowlist control yet (A3 PR2),
+            // so the view-model can't carry it — preserve the stored value across
+            // an edit, or editing any other field would silently revoke the
+            // allowlist and break SSH sendInput.
+            incoming.AllowAgentAccess = existing.AllowAgentAccess;
 
             if (viewModel.BackendKind is null)
             {
@@ -289,6 +294,7 @@ public sealed class SshLaunchDetails
         merged.AuthMode = incoming.AuthMode;
         merged.IdentityFilePath = incoming.IdentityFilePath;
         merged.RememberPasswordInVault = incoming.RememberPasswordInVault;
+        merged.AllowAgentAccess = incoming.AllowAgentAccess;
         merged.JumpHops = incoming.JumpHops.Select(CloneJumpHop).ToList();
         merged.Forwards = incoming.Forwards.Select(CloneForward).ToList();
         merged.MuxOptions = CloneMuxOptions(incoming.MuxOptions);
@@ -592,7 +598,8 @@ public sealed class SshLaunchDetails
             ServerAliveCountMax = profile.ServerAliveCountMax,
             ExtraSshArgs = profile.ExtraSshArgs,
             WorkingDirectory = profile.WorkingDirectory,
-            RemoteShellKind = profile.RemoteShellKind
+            RemoteShellKind = profile.RemoteShellKind,
+            AllowAgentAccess = profile.AllowAgentAccess
         };
     }
 

--- a/src/NovaTerminal.App/SettingsWindow.axaml
+++ b/src/NovaTerminal.App/SettingsWindow.axaml
@@ -590,6 +590,15 @@
                             </Grid>
                             <Border BorderBrush="{StaticResource NtHairline}" BorderThickness="0,0,0,1" Margin="0,14,0,14"/>
 
+                            <Grid ColumnDefinitions="*,360" Margin="24,0,0,0">
+                                <StackPanel Grid.Column="0" Spacing="2">
+                                    <TextBlock Classes="RowLabel" Text="Agent access (act)"/>
+                                    <TextBlock Classes="RowDesc" Text="Additionally allow agents to type into, open, and close terminal sessions. SSH connections must also be allowlisted individually. Every action is shown in the agent activity journal. Requires Agent access (observe)."/>
+                                </StackPanel>
+                                <CheckBox Name="AgentAccessActToggle" Grid.Column="1" Classes="Toggle" Content="" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                            </Grid>
+                            <Border BorderBrush="{StaticResource NtHairline}" BorderThickness="0,0,0,1" Margin="0,14,0,14"/>
+
                             <Grid ColumnDefinitions="*,360">
                                 <StackPanel Grid.Column="0" Spacing="2">
                                     <TextBlock Classes="RowLabel" Text="Long command notifications"/>

--- a/src/NovaTerminal.App/SettingsWindow.axaml.cs
+++ b/src/NovaTerminal.App/SettingsWindow.axaml.cs
@@ -1404,6 +1404,8 @@ namespace NovaTerminal
             if (agentAccessObserveToggle != null) agentAccessObserveToggle.IsChecked = _settings.AgentAccessObserveEnabled;
             var agentReplayExportToggle = this.FindControl<CheckBox>("AgentReplayExportToggle");
             if (agentReplayExportToggle != null) agentReplayExportToggle.IsChecked = _settings.AgentReplayExportEnabled;
+            var agentAccessActToggle = this.FindControl<CheckBox>("AgentAccessActToggle");
+            if (agentAccessActToggle != null) agentAccessActToggle.IsChecked = _settings.AgentAccessActEnabled;
             var longCommandNotificationsToggle = this.FindControl<CheckBox>("LongCommandNotificationsToggle");
             if (longCommandNotificationsToggle != null) longCommandNotificationsToggle.IsChecked = _settings.LongCommandNotificationsEnabled;
             if (fontSizeInput != null) fontSizeInput.Value = (decimal)_settings.FontSize;
@@ -1638,6 +1640,8 @@ namespace NovaTerminal
             if (agentAccessObserveToggle != null) _settings.AgentAccessObserveEnabled = agentAccessObserveToggle.IsChecked == true;
             var agentReplayExportToggle = this.FindControl<CheckBox>("AgentReplayExportToggle");
             if (agentReplayExportToggle != null) _settings.AgentReplayExportEnabled = agentReplayExportToggle.IsChecked == true;
+            var agentAccessActToggle = this.FindControl<CheckBox>("AgentAccessActToggle");
+            if (agentAccessActToggle != null) _settings.AgentAccessActEnabled = agentAccessActToggle.IsChecked == true;
             var longCommandNotificationsToggle = this.FindControl<CheckBox>("LongCommandNotificationsToggle");
             if (longCommandNotificationsToggle != null) _settings.LongCommandNotificationsEnabled = longCommandNotificationsToggle.IsChecked == true;
 

--- a/src/NovaTerminal.App/Shell/TerminalSettings.cs
+++ b/src/NovaTerminal.App/Shell/TerminalSettings.cs
@@ -61,6 +61,12 @@ namespace NovaTerminal.Shell
         // (privacy decision in docs/plans/2026-07-07-agent-host-a4-replay-design.md).
         // Off by default; both toggles must be on for an export to succeed.
         public bool AgentReplayExportEnabled { get; set; } = false;
+        // A3 act surface: separate default-off opt-in letting agents type into,
+        // spawn, and close sessions (novaterminal.send_input / spawn_session /
+        // close_session). On top of observe; SSH sessions additionally require
+        // per-profile allowlisting. Every acting call is shown in the agent
+        // activity journal. Off by default.
+        public bool AgentAccessActEnabled { get; set; } = false;
         // In-app toast when a command that ran ≥30s finishes in an unfocused
         // pane (A2 PR4, absorbs ROADMAP §5.2). Off by default.
         public bool LongCommandNotificationsEnabled { get; set; } = false;

--- a/src/NovaTerminal.McpServer/Tools/ConnectionProfileTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/ConnectionProfileTools.cs
@@ -55,6 +55,7 @@ public static class ConnectionProfileTools
         | `AuthMode` | int enum | 0=Default, 1=Agent, 2=IdentityFile. |
         | `IdentityFilePath` | string | Key path; expected when AuthMode is 2 (IdentityFile). |
         | `RememberPasswordInVault` | bool | Whether to keep the password in the vault. |
+        | `AllowAgentAccess` | bool | Default false. Allowlists this SSH profile for the agent-host act surface (typing/spawning); requires the global "Agent access (act)" setting too. |
 
         ## Jump hosts
         `JumpHops` is an array of `{ "Host": string, "User": string, "Port": int (1–65535) }`.
@@ -120,7 +121,8 @@ public static class ConnectionProfileTools
               "ServerAliveCountMax": 3,
               "ExtraSshArgs": "",
               "WorkingDirectory": "",
-              "RemoteShellKind": 0
+              "RemoteShellKind": 0,
+              "AllowAgentAccess": false
             }
           ]
         }
@@ -136,6 +138,7 @@ public static class ConnectionProfileTools
         "User", "Port", "AuthMode", "IdentityFilePath", "RememberPasswordInVault",
         "JumpHops", "Forwards", "MuxOptions", "ServerAliveIntervalSeconds",
         "ServerAliveCountMax", "ExtraSshArgs", "WorkingDirectory", "RemoteShellKind",
+        "AllowAgentAccess",
     };
     internal static readonly string[] JumpHopFields = { "Host", "User", "Port" };
     internal static readonly string[] PortForwardFields =
@@ -285,6 +288,7 @@ public static class ConnectionProfileTools
         }
 
         RequireBoolType(p, path, "RememberPasswordInVault", errors);
+        RequireBoolType(p, path, "AllowAgentAccess", errors);
 
         CheckEnum(p, path, "BackendKind", BackendKindNames, errors);
         CheckEnum(p, path, "AuthMode", AuthModeNames, errors);

--- a/src/NovaTerminal.McpServer/Tools/SessionTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/SessionTools.cs
@@ -162,6 +162,34 @@ public static class SessionTools
             : AgentHostClient.ProtocolErrorMessage;
     }
 
+    [McpServerTool(Name = "novaterminal.send_input"),
+     Description("Types input into a live NovaTerminal session, exactly as a human would at the keyboard — the bytes are queued to the terminal and recorded like any keystroke. Use for driving an interactive program or answering a prompt. 'text' may include control characters (e.g. \\u0003 for Ctrl-C, \\r for Enter). This is an ACTING tool: it requires the user to have enabled BOTH 'Agent access (observe)' and its 'Agent access (act)' sub-toggle in NovaTerminal settings; SSH sessions must also be individually allowlisted. Every call (allowed or denied) is shown in the app's agent activity journal. Get paneId from novaterminal.list_sessions.")]
+    public static async Task<string> SendInput(
+        AgentHostClient client,
+        [Description("The pane id (GUID) from novaterminal.list_sessions.")] string paneId,
+        [Description("Text to type. Control characters allowed (\\u0003 = Ctrl-C, \\r = Enter). Sent verbatim; no newline is added.")] string text,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Guid.TryParse(paneId, out var pane))
+        {
+            return $"Error: '{paneId}' is not a valid pane id (GUID). Use novaterminal.list_sessions to find live pane ids.";
+        }
+        if (text == null)
+        {
+            return "Error: text is required (use an empty string to send nothing, though that is a no-op).";
+        }
+
+        var parameters = JsonSerializer.SerializeToElement(
+            new SendInputParams { PaneId = pane, Text = text },
+            AgentHostJsonContext.Default.SendInputParams);
+        var outcome = await client.CallAsync(AgentHostProtocol.Methods.SendInput, parameters, cancellationToken).ConfigureAwait(false);
+        if (!TryUnwrap(outcome, out var result, out var error)) return error;
+
+        return TryDeserializeResult(result, AgentHostJsonContext.Default.SendInputResult, out var dto)
+            ? $"Sent {dto!.BytesSent} byte(s) to session {pane}."
+            : AgentHostClient.ProtocolErrorMessage;
+    }
+
     // ── Shared plumbing ─────────────────────────────────────────────────────
 
     /// <summary>

--- a/src/NovaTerminal.McpServer/Tools/SettingsTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/SettingsTools.cs
@@ -55,6 +55,7 @@ public static class SettingsTools
         | `ExperimentalNativeSshEnabled` | bool | Default false. |
         | `AgentAccessObserveEnabled` | bool | Default false. Enables the local agent-host observe endpoint (read-only session access for AI agents). |
         | `AgentReplayExportEnabled` | bool | Default false. Sub-gate on top of the observe toggle: allows agents to export a session's recent output as a replay file (output + resizes only, never input). |
+        | `AgentAccessActEnabled` | bool | Default false. Separate opt-in on top of observe: allows agents to type into, spawn, and close sessions. SSH sessions additionally require per-profile allowlisting. |
         | `LongCommandNotificationsEnabled` | bool | Default false. In-app toast when a command that ran ≥30s finishes in an unfocused pane. |
 
         ## Background
@@ -120,6 +121,7 @@ public static class SettingsTools
           "ExperimentalNativeSshEnabled": false,
           "AgentAccessObserveEnabled": false,
           "AgentReplayExportEnabled": false,
+          "AgentAccessActEnabled": false,
           "LongCommandNotificationsEnabled": false,
           "Profiles": [
             { "Id": "00000000-0000-0000-0000-000000000001", "Name": "Command Prompt", "Command": "cmd.exe", "Type": 0 }
@@ -136,7 +138,7 @@ public static class SettingsTools
         "CommandAssistEnabled", "CommandAssistHistoryEnabled", "CommandAssistAutoHideInAltScreen",
         "CommandAssistShellIntegrationEnabled", "CommandAssistPowerShellIntegrationEnabled",
         "ExperimentalNativeSshEnabled", "AgentAccessObserveEnabled", "AgentReplayExportEnabled",
-        "LongCommandNotificationsEnabled",
+        "AgentAccessActEnabled", "LongCommandNotificationsEnabled",
     };
 
     // Plain + enum-like strings; enum-like values are NOT value-validated (type-check only).
@@ -160,7 +162,7 @@ public static class SettingsTools
         "CommandAssistMaxHistoryEntries", "CommandAssistAutoHideInAltScreen",
         "CommandAssistShellIntegrationEnabled", "CommandAssistPowerShellIntegrationEnabled",
         "ExperimentalNativeSshEnabled", "AgentAccessObserveEnabled", "AgentReplayExportEnabled",
-        "LongCommandNotificationsEnabled", "Profiles", "DefaultProfileId",
+        "AgentAccessActEnabled", "LongCommandNotificationsEnabled", "Profiles", "DefaultProfileId",
     };
 
     [McpServerTool(Name = "novaterminal.validate_settings_json"),

--- a/src/NovaTerminal.Platform/Ssh/Models/SshProfile.cs
+++ b/src/NovaTerminal.Platform/Ssh/Models/SshProfile.cs
@@ -32,4 +32,11 @@ public sealed class SshProfile
     public string ExtraSshArgs { get; set; } = string.Empty;
     public string WorkingDirectory { get; set; } = string.Empty;
     public RemoteShellKind RemoteShellKind { get; set; } = RemoteShellKind.Auto;
+
+    // A3 (agent host act surface): when true, AI agents granted "Agent access
+    // (act)" may type into and spawn sessions for this remote profile. Default
+    // false — acting on a remote reaches another machine with the user's
+    // credentials, so it is opt-in per profile on top of the global act toggle.
+    // New field; absent in older stores deserializes to false (no migration).
+    public bool AllowAgentAccess { get; set; }
 }

--- a/src/NovaTerminal.Platform/Ssh/Storage/JsonSshProfileStore.cs
+++ b/src/NovaTerminal.Platform/Ssh/Storage/JsonSshProfileStore.cs
@@ -336,7 +336,8 @@ public sealed class JsonSshProfileStore : ISshProfileStore
             ServerAliveCountMax = profile.ServerAliveCountMax,
             ExtraSshArgs = profile.ExtraSshArgs,
             WorkingDirectory = profile.WorkingDirectory,
-            RemoteShellKind = profile.RemoteShellKind
+            RemoteShellKind = profile.RemoteShellKind,
+            AllowAgentAccess = profile.AllowAgentAccess
         };
     }
 

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentActivityJournalTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentActivityJournalTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Linq;
+using NovaTerminal.AgentHost;
+
+namespace NovaTerminal.AppTests.AgentHost;
+
+public class AgentActivityJournalTests
+{
+    [Fact]
+    public void Record_appends_newest_first_and_raises_event()
+    {
+        var clock = new DateTimeOffset(2026, 7, 12, 0, 0, 0, TimeSpan.Zero);
+        var journal = new AgentActivityJournal(() => clock);
+        int raised = 0;
+        journal.EntryAdded += _ => raised++;
+
+        var pane = Guid.NewGuid();
+        journal.Record("sendInput", pane, "Profile", "ok");
+        journal.Record("sendInput", pane, "Profile", "actDisabled");
+
+        Assert.Equal(2, raised);
+        var entries = journal.Snapshot();
+        Assert.Equal("actDisabled", entries[0].Outcome); // newest first
+        Assert.Equal("ok", entries[1].Outcome);
+        Assert.Equal(pane, entries[0].PaneId);
+        Assert.Equal(clock, entries[0].TimestampUtc);
+    }
+
+    [Fact]
+    public void Ring_is_bounded_to_capacity()
+    {
+        var journal = new AgentActivityJournal();
+        for (int i = 0; i < AgentActivityJournal.Capacity + 50; i++)
+        {
+            journal.Record("sendInput", null, i.ToString(), "ok");
+        }
+
+        Assert.Equal(AgentActivityJournal.Capacity, journal.Count);
+        var entries = journal.Snapshot();
+        Assert.Equal(AgentActivityJournal.Capacity, entries.Count);
+        // Newest entry is the last recorded; oldest survivor is entry #50.
+        Assert.Equal((AgentActivityJournal.Capacity + 49).ToString(), entries[0].Target);
+        Assert.Equal("50", entries[^1].Target);
+    }
+}

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentHostActProtocolTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentHostActProtocolTests.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using NovaTerminal.AgentHost;
+using NovaTerminal.AgentHost.Contracts;
+
+namespace NovaTerminal.AppTests.AgentHost;
+
+/// <summary>
+/// Tests for the A3 act surface — <c>sendInput</c> gating and journaling
+/// (docs/plans/2026-07-12-agent-host-a3-act-design.md, PR1). Acting requires
+/// the separate act opt-in on top of observe; SSH targets additionally require
+/// per-profile allowlisting; every attempt (allowed or denied) is journaled.
+/// </summary>
+public class AgentHostActProtocolTests
+{
+    private sealed class InputStubSession : NovaTerminal.Pty.ITerminalSession
+    {
+        private readonly bool _running;
+        public InputStubSession(bool running = true) => _running = running;
+
+        public readonly List<string> Inputs = new();
+
+        public void SendInput(string input) => Inputs.Add(input);
+        public bool IsProcessRunning => _running;
+
+        public Guid Id { get; } = Guid.NewGuid();
+        public string ShellCommand => "stub";
+        public string? ShellArguments => null;
+        public bool HasActiveChildProcesses => false;
+        public int? ExitCode => null;
+        public bool IsRecording => false;
+        public event Action<string>? OnOutputReceived { add { } remove { } }
+        public event Action<int>? OnExit { add { } remove { } }
+        public void Resize(int cols, int rows) { }
+        public void StartRecording(string filePath) { }
+        public void StopRecording() { }
+        public bool IsFlightRecording => false;
+        public void EnableFlightRecording(long maxTotalBytes) { }
+        public void DisableFlightRecording() { }
+        public bool TryExportFlightRecording(string filePath, out NovaTerminal.Replay.FlightExportInfo info) { info = default; return false; }
+        public void Dispose() { }
+    }
+
+    private static AgentSessionRegistration Register(
+        AgentSessionRegistry registry, string kind, InputStubSession session, Guid? profileId = null)
+    {
+        var reg = new AgentSessionRegistration(
+            Guid.NewGuid(), new NovaTerminal.VT.TerminalBuffer(80, 24),
+            "title", "Profile", kind, isActive: true, profileId: profileId);
+        reg.SetLifecycle(session);
+        registry.Register(reg);
+        return reg;
+    }
+
+    private static AgentHostService NewService(AgentSessionRegistry registry, AgentActivityJournal journal)
+    {
+        var endpoint = OperatingSystem.IsWindows()
+            ? "novaterminal-agent-test-" + Guid.NewGuid().ToString("N")
+            : System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString("N")[..8] + ".sock");
+        return new AgentHostService(registry, endpoint, System.IO.Path.GetTempPath(), null, journal);
+    }
+
+    private static string SendInputLine(Guid paneId, string text, long id = 1)
+    {
+        var json = JsonSerializer.Serialize(
+            new SendInputParams { PaneId = paneId, Text = text }, AgentHostJsonContext.Default.SendInputParams);
+        return $"{{\"v\":{AgentHostProtocol.Version},\"id\":{id},\"method\":\"{AgentHostProtocol.Methods.SendInput}\",\"params\":{json}}}";
+    }
+
+    private static AgentHostResponse Handle(AgentHostService service, string line)
+        => service.HandleRequestLineAsync(line, TestContext.Current.CancellationToken).GetAwaiter().GetResult();
+
+    // ── Hard-fail acceptance (DIRECTION) ─────────────────────────────────────
+
+    [Fact]
+    public void SendInput_is_rejected_with_actDisabled_when_only_observe_is_enabled()
+    {
+        var registry = new AgentSessionRegistry();
+        var session = new InputStubSession();
+        var reg = Register(registry, "local", session);
+        var journal = new AgentActivityJournal();
+        using var service = NewService(registry, journal);
+        service.ActEnabled = false; // observe only
+
+        var response = Handle(service, SendInputLine(reg.PaneId, "ls\r"));
+
+        Assert.Equal(AgentHostProtocol.ErrorCodes.ActDisabled, response.Error?.Code);
+        Assert.Empty(session.Inputs); // nothing reached the session
+        var entry = Assert.Single(journal.Snapshot());
+        Assert.Equal(AgentHostProtocol.ErrorCodes.ActDisabled, entry.Outcome);
+    }
+
+    [Fact]
+    public void SendInput_to_non_allowlisted_ssh_session_is_profileNotAllowed()
+    {
+        var registry = new AgentSessionRegistry();
+        var session = new InputStubSession();
+        var profileId = Guid.NewGuid();
+        var reg = Register(registry, "ssh", session, profileId);
+        var journal = new AgentActivityJournal();
+        using var service = NewService(registry, journal);
+        service.ActEnabled = true;
+        service.SetSshProfileAllowlist(_ => false); // not allowlisted
+
+        var response = Handle(service, SendInputLine(reg.PaneId, "whoami\r"));
+
+        Assert.Equal(AgentHostProtocol.ErrorCodes.ProfileNotAllowed, response.Error?.Code);
+        Assert.Empty(session.Inputs);
+    }
+
+    [Fact]
+    public void SendInput_to_ssh_session_with_no_allowlist_probe_fails_closed()
+    {
+        var registry = new AgentSessionRegistry();
+        var session = new InputStubSession();
+        var reg = Register(registry, "ssh", session, Guid.NewGuid());
+        var journal = new AgentActivityJournal();
+        using var service = NewService(registry, journal);
+        service.ActEnabled = true;
+        // No SetSshProfileAllowlist call → probe is null → deny.
+
+        var response = Handle(service, SendInputLine(reg.PaneId, "x\r"));
+
+        Assert.Equal(AgentHostProtocol.ErrorCodes.ProfileNotAllowed, response.Error?.Code);
+    }
+
+    // ── Success paths ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SendInput_to_local_session_with_act_enabled_delivers_bytes_faithfully()
+    {
+        var registry = new AgentSessionRegistry();
+        var session = new InputStubSession();
+        var reg = Register(registry, "local", session);
+        var journal = new AgentActivityJournal();
+        using var service = NewService(registry, journal);
+        service.ActEnabled = true;
+
+        // Control characters must survive verbatim: Ctrl-C then "exit\r".
+        string payload = "exit\r";
+        var response = Handle(service, SendInputLine(reg.PaneId, payload));
+
+        Assert.Null(response.Error);
+        var result = response.Result!.Value.Deserialize(AgentHostJsonContext.Default.SendInputResult);
+        Assert.Equal(Encoding.UTF8.GetByteCount(payload), result!.BytesSent);
+        Assert.Equal(payload, Assert.Single(session.Inputs)); // byte-faithful at the API boundary
+        Assert.Equal("ok", Assert.Single(journal.Snapshot()).Outcome);
+    }
+
+    [Fact]
+    public void SendInput_to_allowlisted_ssh_session_succeeds()
+    {
+        var registry = new AgentSessionRegistry();
+        var session = new InputStubSession();
+        var profileId = Guid.NewGuid();
+        var reg = Register(registry, "ssh", session, profileId);
+        using var service = NewService(registry, new AgentActivityJournal());
+        service.ActEnabled = true;
+        service.SetSshProfileAllowlist(id => id == profileId);
+
+        var response = Handle(service, SendInputLine(reg.PaneId, "uptime\r"));
+
+        Assert.Null(response.Error);
+        Assert.Equal("uptime\r", Assert.Single(session.Inputs));
+    }
+
+    // ── Protocol errors ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void SendInput_for_unknown_pane_is_sessionNotFound()
+    {
+        using var service = NewService(new AgentSessionRegistry(), new AgentActivityJournal());
+        service.ActEnabled = true;
+
+        var response = Handle(service, SendInputLine(Guid.NewGuid(), "x"));
+
+        Assert.Equal(AgentHostProtocol.ErrorCodes.SessionNotFound, response.Error?.Code);
+    }
+
+    [Fact]
+    public void SendInput_to_exited_session_is_sessionNotRunning()
+    {
+        var registry = new AgentSessionRegistry();
+        var session = new InputStubSession(running: false);
+        var reg = Register(registry, "local", session);
+        using var service = NewService(registry, new AgentActivityJournal());
+        service.ActEnabled = true;
+
+        var response = Handle(service, SendInputLine(reg.PaneId, "x"));
+
+        Assert.Equal(AgentHostProtocol.ErrorCodes.SessionNotRunning, response.Error?.Code);
+        Assert.Empty(session.Inputs);
+    }
+
+    [Fact]
+    public void SendInput_over_the_size_cap_is_malformedRequest()
+    {
+        var registry = new AgentSessionRegistry();
+        var session = new InputStubSession();
+        var reg = Register(registry, "local", session);
+        using var service = NewService(registry, new AgentActivityJournal());
+        service.ActEnabled = true;
+
+        string huge = new string('a', AgentHostProtocol.MaxSendInputBytes + 1);
+        var response = Handle(service, SendInputLine(reg.PaneId, huge));
+
+        Assert.Equal(AgentHostProtocol.ErrorCodes.MalformedRequest, response.Error?.Code);
+        Assert.Empty(session.Inputs);
+    }
+
+    [Fact]
+    public void SendInput_without_params_is_malformedRequest()
+    {
+        using var service = NewService(new AgentSessionRegistry(), new AgentActivityJournal());
+        service.ActEnabled = true;
+
+        var line = $"{{\"v\":{AgentHostProtocol.Version},\"id\":1,\"method\":\"{AgentHostProtocol.Methods.SendInput}\",\"params\":null}}";
+        var response = Handle(service, line);
+
+        Assert.Equal(AgentHostProtocol.ErrorCodes.MalformedRequest, response.Error?.Code);
+    }
+
+    // ── Journal ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Every_attempt_allowed_or_denied_is_journaled_once()
+    {
+        var registry = new AgentSessionRegistry();
+        var session = new InputStubSession();
+        var reg = Register(registry, "local", session);
+        var journal = new AgentActivityJournal();
+        using var service = NewService(registry, journal);
+
+        service.ActEnabled = false;
+        Handle(service, SendInputLine(reg.PaneId, "a"));   // denied: actDisabled
+        service.ActEnabled = true;
+        Handle(service, SendInputLine(reg.PaneId, "b"));   // ok
+        Handle(service, SendInputLine(Guid.NewGuid(), "c")); // denied: sessionNotFound
+
+        var entries = journal.Snapshot(); // newest first
+        Assert.Equal(3, entries.Count);
+        Assert.Equal(AgentHostProtocol.ErrorCodes.SessionNotFound, entries[0].Outcome);
+        Assert.Equal("ok", entries[1].Outcome);
+        Assert.Equal(AgentHostProtocol.ErrorCodes.ActDisabled, entries[2].Outcome);
+        Assert.All(entries, e => Assert.Equal(AgentHostProtocol.Methods.SendInput, e.Method));
+    }
+}

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentHostActProtocolTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentHostActProtocolTests.cs
@@ -111,6 +111,25 @@ public class AgentHostActProtocolTests
     }
 
     [Fact]
+    public void Stop_clears_the_ssh_allowlist_probe_so_it_cannot_pin_the_window()
+    {
+        // The static service singleton outlives MainWindow; the probe closes over
+        // it. Stop must release the delegate (fail-closed afterwards) so a closed
+        // window can be collected.
+        var registry = new AgentSessionRegistry();
+        var session = new InputStubSession();
+        var reg = Register(registry, "ssh", session, Guid.NewGuid());
+        using var service = NewService(registry, new AgentActivityJournal());
+        service.ActEnabled = true;
+        service.SetSshProfileAllowlist(_ => true);
+
+        service.Stop(); // window closing
+
+        var response = Handle(service, SendInputLine(reg.PaneId, "x\r"));
+        Assert.Equal(AgentHostProtocol.ErrorCodes.ProfileNotAllowed, response.Error?.Code);
+    }
+
+    [Fact]
     public void SendInput_to_ssh_session_with_no_allowlist_probe_fails_closed()
     {
         var registry = new AgentSessionRegistry();

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentHostActProtocolTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentHostActProtocolTests.cs
@@ -211,15 +211,52 @@ public class AgentHostActProtocolTests
     }
 
     [Fact]
-    public void SendInput_without_params_is_malformedRequest()
+    public void SendInput_without_params_is_malformedRequest_and_is_journaled()
     {
-        using var service = NewService(new AgentSessionRegistry(), new AgentActivityJournal());
+        var journal = new AgentActivityJournal();
+        using var service = NewService(new AgentSessionRegistry(), journal);
         service.ActEnabled = true;
 
         var line = $"{{\"v\":{AgentHostProtocol.Version},\"id\":1,\"method\":\"{AgentHostProtocol.Methods.SendInput}\",\"params\":null}}";
         var response = Handle(service, line);
 
         Assert.Equal(AgentHostProtocol.ErrorCodes.MalformedRequest, response.Error?.Code);
+        // Malformed acting attempts are externally reachable — they must be visible.
+        Assert.Equal(AgentHostProtocol.ErrorCodes.MalformedRequest, Assert.Single(journal.Snapshot()).Outcome);
+    }
+
+    [Fact]
+    public void SendInput_with_missing_required_field_is_malformedRequest_and_is_journaled()
+    {
+        var journal = new AgentActivityJournal();
+        using var service = NewService(new AgentSessionRegistry(), journal);
+        service.ActEnabled = true;
+
+        // params present but missing the required "text" field → deserialization throws.
+        var line = $"{{\"v\":{AgentHostProtocol.Version},\"id\":1,\"method\":\"{AgentHostProtocol.Methods.SendInput}\",\"params\":{{\"paneId\":\"{Guid.NewGuid()}\"}}}}";
+        var response = Handle(service, line);
+
+        Assert.Equal(AgentHostProtocol.ErrorCodes.MalformedRequest, response.Error?.Code);
+        Assert.Equal(AgentHostProtocol.ErrorCodes.MalformedRequest, Assert.Single(journal.Snapshot()).Outcome);
+    }
+
+    [Fact]
+    public void SendInput_succeeds_even_if_a_journal_subscriber_throws()
+    {
+        // A throwing UI subscriber must not reverse a delivered sendInput —
+        // otherwise a retry double-submits the input.
+        var registry = new AgentSessionRegistry();
+        var session = new InputStubSession();
+        var reg = Register(registry, "local", session);
+        var journal = new AgentActivityJournal();
+        journal.EntryAdded += _ => throw new InvalidOperationException("boom");
+        using var service = NewService(registry, journal);
+        service.ActEnabled = true;
+
+        var response = Handle(service, SendInputLine(reg.PaneId, "ls\r"));
+
+        Assert.Null(response.Error);
+        Assert.Equal("ls\r", Assert.Single(session.Inputs));
     }
 
     // ── Journal ──────────────────────────────────────────────────────────────

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentHostServiceTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentHostServiceTests.cs
@@ -101,7 +101,7 @@ public class AgentHostServiceTests : IDisposable
     public void Unknown_method_is_rejected_with_stable_error_code()
     {
         using var service = NewService(new AgentSessionRegistry());
-        var response = Handle(service,RequestLine("sendInput"));
+        var response = Handle(service,RequestLine("thisMethodDoesNotExist"));
         Assert.Equal(AgentHostProtocol.ErrorCodes.UnknownMethod, response.Error?.Code);
     }
 

--- a/tests/NovaTerminal.App.Tests/PtySmokeTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtySmokeTests.cs
@@ -1,6 +1,7 @@
 using NovaTerminal.Shell;
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using NovaTerminal.Platform;
 using NovaTerminal.VT;
@@ -23,6 +24,45 @@ namespace NovaTerminal.Tests
             session.Resize(100, 30);
             session.SendInput("\r");
             await Task.Delay(150);
+        }
+
+        [Fact]
+        [Trait("Category", "PtySmoke")]
+        public async Task AgentSentInput_IsByteFaithful_AndReplayRecordedLikeKeystrokes()
+        {
+            // A3 acceptance: input an agent injects through the registration is
+            // (a) byte-faithful and (b) recorded to a manual replay exactly like
+            // a human keystroke — the session records it via the same
+            // _recorder.RecordInput path SendInput always uses.
+            string shell = ShellHelper.GetDefaultShell();
+            string recPath = Path.Combine(Path.GetTempPath(), $"nova_a3_{Guid.NewGuid():N}.rec");
+            try
+            {
+                using var session = new RustPtySession(shell, 80, 24);
+                var registration = new NovaTerminal.AgentHost.AgentSessionRegistration(
+                    Guid.NewGuid(), new TerminalBuffer(80, 24), "t", "P", "local", isActive: true);
+                registration.SetLifecycle(session);
+
+                await Task.Delay(300); // let the shell come up
+                session.StartRecording(recPath);
+
+                const string payload = "echo nova-a3-marker\r";
+                Assert.True(registration.TrySendInput(payload));
+
+                await Task.Delay(400);
+                session.StopRecording();
+
+                string[] lines = File.ReadAllLines(recPath);
+                // The recording carries an input event with the exact bytes.
+                string? inputLine = lines.FirstOrDefault(l => l.Contains("\"type\":\"input\""));
+                Assert.NotNull(inputLine);
+                byte[] expected = System.Text.Encoding.UTF8.GetBytes(payload);
+                Assert.Contains(Convert.ToBase64String(expected), inputLine!);
+            }
+            finally
+            {
+                if (File.Exists(recPath)) File.Delete(recPath);
+            }
         }
 
         [Fact]

--- a/tests/NovaTerminal.App.Tests/Ssh/SshConnectionServiceTests.cs
+++ b/tests/NovaTerminal.App.Tests/Ssh/SshConnectionServiceTests.cs
@@ -271,6 +271,48 @@ public sealed class SshConnectionServiceTests
     }
 
     [Fact]
+    public void SaveProfile_PreservesAgentAllowlistWhenEditingAnotherField()
+    {
+        // A3: the connection editor has no allowlist control yet, so editing any
+        // other field must not silently revoke an allowlist set via JSON/MCP —
+        // else SSH sendInput would start being rejected.
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string path = Path.Combine(tempRoot, "profiles.json");
+            var store = new JsonSshProfileStore(path);
+            var service = new SshConnectionService(store);
+            var existingId = Guid.Parse("c4d5e6f7-a8b9-4c1d-8e2f-3a4b5c6d7e8f");
+
+            store.SaveProfile(new SshProfile
+            {
+                Id = existingId,
+                Name = "Allowed",
+                Host = "allowed.internal",
+                AllowAgentAccess = true
+            });
+
+            var vm = new NewSshConnectionViewModel
+            {
+                ProfileId = existingId,
+                Name = "Allowed Renamed",
+                HostName = "renamed.internal",
+                UserName = "ops"
+            };
+
+            SshProfile saved = service.SaveProfile(vm);
+
+            Assert.True(saved.AllowAgentAccess);
+            Assert.True(store.GetProfile(saved.Id)!.AllowAgentAccess);
+            Assert.True(new JsonSshProfileStore(path).GetProfile(saved.Id)!.AllowAgentAccess);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
     public void SaveProfile_PreservesLegacyRememberPasswordPreferenceForExistingProfiles()
     {
         string tempRoot = CreateTempDirectory();

--- a/tests/NovaTerminal.McpServer.Tests/AgentHostClientTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/AgentHostClientTests.cs
@@ -386,6 +386,24 @@ public class SessionToolsFormattingTests
     }
 
     [Fact]
+    public async Task SendInput_rejects_a_non_guid_pane_before_any_ipc()
+    {
+        var client = new AgentHostClient(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "nothing.json"));
+        var text = await SessionTools.SendInput(client, "not-a-guid", "ls\r", TestContext.Current.CancellationToken);
+        Assert.StartsWith("Error: 'not-a-guid' is not a valid pane id", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SendInput_when_endpoint_unavailable_surfaces_guidance_verbatim()
+    {
+        // No live endpoint (discovery file absent): the acting call must return
+        // the unavailable guidance, not throw.
+        var client = new AgentHostClient(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "nothing.json"));
+        var text = await SessionTools.SendInput(client, Guid.NewGuid().ToString(), "ls\r", TestContext.Current.CancellationToken);
+        Assert.Equal(AgentHostClient.UnavailableMessage, text);
+    }
+
+    [Fact]
     public async Task WaitForEvents_rejects_a_negative_cursor_before_any_ipc()
     {
         var client = new AgentHostClient(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "nothing.json"));

--- a/tests/NovaTerminal.McpServer.Tests/McpServerStdioE2ETests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/McpServerStdioE2ETests.cs
@@ -42,6 +42,7 @@ public class McpServerStdioE2ETests
         "novaterminal.get_session_status",
         "novaterminal.wait_for_events",
         "novaterminal.export_replay",
+        "novaterminal.send_input",
     };
 
     [Fact]

--- a/tests/NovaTerminal.Platform.Tests/Ssh/JsonSshProfileStoreTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/JsonSshProfileStoreTests.cs
@@ -152,6 +152,39 @@ public sealed class JsonSshProfileStoreTests
     }
 
     [Fact]
+    public void SaveAndLoad_RoundTripsAllowAgentAccess()
+    {
+        // Regression: the A3 agent-act allowlist flag must survive the store's
+        // clone path (GetProfile clones), or SSH sendInput is always denied.
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string storePath = Path.Combine(tempRoot, "profiles.json");
+            var store = new JsonSshProfileStore(storePath);
+            var profile = new SshProfile
+            {
+                Id = Guid.Parse("b1c2d3e4-f5a6-4708-9192-a3b4c5d6e7f8"),
+                Name = "allowed",
+                Host = "allowed.internal",
+                AllowAgentAccess = true
+            };
+
+            store.SaveProfile(profile);
+
+            // Fresh store instance forces a load from disk, not a cached object.
+            var reopened = new JsonSshProfileStore(storePath);
+            SshProfile? loaded = reopened.GetProfile(profile.Id);
+
+            Assert.NotNull(loaded);
+            Assert.True(loaded!.AllowAgentAccess);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
     public void SaveAndLoad_RoundTripsRemoteShellKind()
     {
         string tempRoot = CreateTempDirectory();


### PR DESCRIPTION
## Summary

First slice of **milestone A3 (Act, permissioned)** per the approved design in `docs/plans/2026-07-12-agent-host-a3-act-design.md` (included): the **act permission model + `novaterminal.send_input`**. This is the first agent-host surface that can change a session rather than observe it, so it lands behind its own gates and a visibility journal. `spawn_session`/`close_session` (slice 2) and the journal UI + threat model (slice 3) follow. Protocol stays additive on version 1.

## Permission model (DIRECTION table: "off; separate explicit opt-in, per-profile allowlist for SSH")

Three independent checks, all fail-closed:

1. **Observe endpoint running** — the transport only exists when Agent Access (observe) is on.
2. **`AgentAccessActEnabled`** (new setting, default off) — a *separate* opt-in from observe; acting never rides the observe toggle. Settings-window sub-toggle under Agent access; MainWindow pushes it into `AgentHostService.ActEnabled` (volatile) at both apply sites. Denied → `actDisabled`.
3. **Per-profile SSH allowlist** — new `SshProfile.AllowAgentAccess` (default false, no store migration). Acting on an SSH session reaches another machine with the user's credentials, so it's opt-in per profile *on top of* the act toggle. Checked via an injectable probe MainWindow publishes (`SetSshProfileAllowlist`, reads the SSH store off-thread); **null probe denies everything**. Denied → `profileNotAllowed`. Local sessions are governed by the act toggle alone (a local shell is already reachable by any process running as the user — a local allowlist would be theater; documented in the design's alternatives).

Distinct stable error codes so an agent can tell "ask the user to opt in" (`actDisabled`, `profileNotAllowed`) from retryable/terminal states (`sessionNotRunning`, `sessionNotFound`, `actUnavailable`, `spawnFailed`).

## Activity journal

`AgentActivityJournal` — thread-safe bounded ring (200 entries) of `{ timestampUtc, method, paneId?, target, outcome }`. **Every acting attempt is journaled, allowed or denied** (outcome = `ok` or the error code), so the user can see everything an agent tried. In-memory by design — a visibility surface, not an audit log (the agent's MCP transcript is the audit trail; rationale in the design doc). This slice wires the journal into the endpoint; the visible UI is slice 3.

## send_input

- `sendInput { paneId, text }` → `{ bytesSent }`. `text` is sent verbatim through the registration's published `ITerminalSession.SendInput` — **the same thread-safe, replay-recorded path human keystrokes take**, which satisfies the DIRECTION acceptance criterion "input injection is byte-faithful and replay-recorded like any PTY input" for free. Control characters (Ctrl-C, `\r`) pass through unchanged. Capped at 32 KiB/call (`malformedRequest` beyond, checked before any lookup).
- MCP `novaterminal.send_input(paneId, text)` — GUID-validated before IPC; description spells out that it's an acting tool needing both toggles (and SSH allowlisting) and that every call is journaled.
- `AgentSessionRegistration` gains `ProfileId` (pushed by the pane, needed for the allowlist check) and `TrySendInput` (guards `IsProcessRunning`, dispose-safe).

## Testing

- **Hard-fail acceptance (DIRECTION):** `send_input` → `actDisabled` when only observe is on (nothing reaches the session); non-allowlisted SSH → `profileNotAllowed`; SSH with no probe wired → fail-closed `profileNotAllowed`; local + act-on works; allowlisted SSH works.
- **Byte-faithful acceptance:** handler asserts the exact wire string (including `\r`) reaches `ITerminalSession.SendInput`; a `PtySmoke` test injects a command into a live shell and asserts the manual recording contains the input event with the exact base64 bytes — replay-recorded like any keystroke.
- **Protocol:** unknown pane → `sessionNotFound`; exited session → `sessionNotRunning`; over-cap → `malformedRequest`; missing params → `malformedRequest`.
- **Journal:** allowed and denied calls each append exactly one entry with the right outcome; ring bounded; newest-first snapshot; `EntryAdded` fires.
- **Drift guards updated:** `SshProfile.AllowAgentAccess` mirrored in ConnectionProfileTools (fields, schema doc, example, bool validator); the "unknown method" endpoint test no longer uses `sendInput` as its fake (it's real now). Settings schema/validators list `AgentAccessActEnabled`; e2e tool list = 22 tools.

Local: App.Tests (AgentHost + journal + PtySmoke) 91/91, McpServer.Tests 134/134, Architecture 18/18.

## Note for reviewers

This branch touches `TerminalPane.axaml.cs` with **only** the two `ProfileId` argument additions to the agent-session registration. A parallel local change to that file (an SSH reconnect-banner refactor) and to `TerminalPaneSshDisconnectTests.cs` was deliberately left out of this commit.
