### PR TITLE
feat(agent-host): A3 slice 2 - spawn_session + close_session

### DIFF
--- a/src/NovaTerminal.AgentHost.Contracts/ActContracts.cs
+++ b/src/NovaTerminal.AgentHost.Contracts/ActContracts.cs
@@ -25,3 +25,46 @@ public sealed record SendInputResult
     [JsonPropertyName("bytesSent")]
     public required int BytesSent { get; init; }
 }
+
+/// <summary>Params for <c>spawnSession</c> (A3).</summary>
+public sealed record SpawnSessionParams
+{
+    /// <summary>
+    /// Profile name to open (case-insensitive; local settings profiles resolve
+    /// before SSH store profiles on a collision). Null or empty opens the
+    /// default local profile.
+    /// </summary>
+    [JsonPropertyName("profile")]
+    public string? Profile { get; init; }
+}
+
+/// <summary>Result payload for <c>spawnSession</c>: identity of the newly opened pane.</summary>
+public sealed record SpawnSessionResult
+{
+    [JsonPropertyName("paneId")]
+    public required Guid PaneId { get; init; }
+
+    [JsonPropertyName("tabId")]
+    public Guid? TabId { get; init; }
+
+    [JsonPropertyName("profileName")]
+    public required string ProfileName { get; init; }
+
+    /// <summary>"local" or "ssh".</summary>
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+}
+
+/// <summary>Params for <c>closeSession</c> (A3).</summary>
+public sealed record CloseSessionParams
+{
+    [JsonPropertyName("paneId")]
+    public required Guid PaneId { get; init; }
+}
+
+/// <summary>Result payload for <c>closeSession</c>.</summary>
+public sealed record CloseSessionResult
+{
+    [JsonPropertyName("closed")]
+    public required bool Closed { get; init; }
+}

--- a/src/NovaTerminal.AgentHost.Contracts/AgentHostJsonContext.cs
+++ b/src/NovaTerminal.AgentHost.Contracts/AgentHostJsonContext.cs
@@ -30,6 +30,10 @@ namespace NovaTerminal.AgentHost.Contracts;
 [JsonSerializable(typeof(ExportReplayResult))]
 [JsonSerializable(typeof(SendInputParams))]
 [JsonSerializable(typeof(SendInputResult))]
+[JsonSerializable(typeof(SpawnSessionParams))]
+[JsonSerializable(typeof(SpawnSessionResult))]
+[JsonSerializable(typeof(CloseSessionParams))]
+[JsonSerializable(typeof(CloseSessionResult))]
 public sealed partial class AgentHostJsonContext : JsonSerializerContext
 {
 }

--- a/src/NovaTerminal.AgentHost.Contracts/AgentHostProtocol.cs
+++ b/src/NovaTerminal.AgentHost.Contracts/AgentHostProtocol.cs
@@ -73,6 +73,12 @@ public static class AgentHostProtocol
         /// plus per-profile allowlisting for SSH sessions.
         /// </summary>
         public const string SendInput = "sendInput";
+
+        /// <summary>A3: opens a new tab running a local or allowlisted-SSH profile by name. Returns the new paneId.</summary>
+        public const string SpawnSession = "spawnSession";
+
+        /// <summary>A3: closes a live pane by id.</summary>
+        public const string CloseSession = "closeSession";
     }
 
     /// <summary>Server-side cap on a single <c>sendInput</c> payload, in bytes (A3).</summary>

--- a/src/NovaTerminal.App/AgentHost/AgentHostService.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentHostService.cs
@@ -112,6 +112,14 @@ namespace NovaTerminal.AgentHost
         /// <summary>Publishes (or clears) the per-profile SSH allowlist probe. UI thread.</summary>
         public void SetSshProfileAllowlist(Func<Guid, bool>? probe) => _sshProfileAllowlist = probe;
 
+        // UI-thread bridge for spawn/close (A3 PR2), published by MainWindow.
+        // Closes over the window, so it is cleared on Stop like the allowlist
+        // probe. Volatile: published from UI, read on IPC.
+        private volatile IAgentActionExecutor? _actionExecutor;
+
+        /// <summary>Publishes (or clears) the spawn/close UI executor. UI thread.</summary>
+        public void SetActionExecutor(IAgentActionExecutor? executor) => _actionExecutor = executor;
+
         private bool AllowsAgentActOnProfile(Guid profileId)
         {
             var probe = _sshProfileAllowlist;
@@ -251,6 +259,7 @@ namespace NovaTerminal.AgentHost
             // each Apply, so clearing here is safe. Bool gates are value types and
             // do not leak, so they are left as-is.
             _sshProfileAllowlist = null;
+            _actionExecutor = null; // closes over the window too — same pinning reason
         }
 
         /// <summary>
@@ -634,6 +643,8 @@ namespace NovaTerminal.AgentHost
                     AgentHostProtocol.Methods.WaitForEvents => await HandleWaitForEventsAsync(request, cancellationToken).ConfigureAwait(false),
                     AgentHostProtocol.Methods.ExportReplay => HandleExportReplay(request),
                     AgentHostProtocol.Methods.SendInput => HandleSendInput(request),
+                    AgentHostProtocol.Methods.SpawnSession => await HandleSpawnSessionAsync(request).ConfigureAwait(false),
+                    AgentHostProtocol.Methods.CloseSession => await HandleCloseSessionAsync(request).ConfigureAwait(false),
                     _ => Error(request.Id, AgentHostProtocol.ErrorCodes.UnknownMethod, $"Unknown method '{request.Method}'."),
                 };
             }
@@ -805,6 +816,114 @@ namespace NovaTerminal.AgentHost
             var result = new SendInputResult { BytesSent = byteCount };
             return Journaled(request, AgentHostProtocol.Methods.SendInput, p.PaneId, registration.ProfileName,
                 Ok(request.Id, JsonSerializer.SerializeToElement(result, AgentHostJsonContext.Default.SendInputResult)));
+        }
+
+        private async Task<AgentHostResponse> HandleSpawnSessionAsync(AgentHostRequest request)
+        {
+            SpawnSessionParams? p;
+            try
+            {
+                p = DeserializeParams(request, AgentHostJsonContext.Default.SpawnSessionParams);
+            }
+            catch (JsonException)
+            {
+                p = null;
+            }
+            // Missing/empty profile = default local profile, so params may be null;
+            // only a present-but-unparseable params object is malformed.
+            p ??= new SpawnSessionParams();
+            string target = string.IsNullOrWhiteSpace(p.Profile) ? "(default)" : p.Profile!;
+
+            if (!_actEnabled)
+            {
+                return Journaled(request, AgentHostProtocol.Methods.SpawnSession, null, target,
+                    Error(request.Id, AgentHostProtocol.ErrorCodes.ActDisabled,
+                        "Acting is disabled. Enable Settings → Agent access (observe) → Agent access (act), then retry."));
+            }
+
+            var executor = _actionExecutor;
+            if (executor == null)
+            {
+                return Journaled(request, AgentHostProtocol.Methods.SpawnSession, null, target,
+                    Error(request.Id, AgentHostProtocol.ErrorCodes.ActUnavailable,
+                        "The app cannot spawn sessions right now (starting up or shutting down). Retry shortly."));
+            }
+
+            (AgentSpawnResult? result, AgentSpawnError? error) = await executor.SpawnAsync(p.Profile).ConfigureAwait(false);
+            if (result is not { } spawn)
+            {
+                var (code, message) = error switch
+                {
+                    AgentSpawnError.ProfileNotFound => (AgentHostProtocol.ErrorCodes.ProfileNotFound, $"No local or SSH profile named '{target}'."),
+                    AgentSpawnError.ProfileNotAllowed => (AgentHostProtocol.ErrorCodes.ProfileNotAllowed, $"The SSH profile '{target}' is not allowlisted for agent access."),
+                    _ => (AgentHostProtocol.ErrorCodes.SpawnFailed, $"Failed to open a session for '{target}'."),
+                };
+                return Journaled(request, AgentHostProtocol.Methods.SpawnSession, null, target,
+                    Error(request.Id, code, message));
+            }
+
+            var dto = new SpawnSessionResult
+            {
+                PaneId = spawn.PaneId,
+                TabId = spawn.TabId,
+                ProfileName = spawn.ProfileName,
+                Kind = spawn.Kind,
+            };
+            return Journaled(request, AgentHostProtocol.Methods.SpawnSession, spawn.PaneId, spawn.ProfileName,
+                Ok(request.Id, JsonSerializer.SerializeToElement(dto, AgentHostJsonContext.Default.SpawnSessionResult)));
+        }
+
+        private async Task<AgentHostResponse> HandleCloseSessionAsync(AgentHostRequest request)
+        {
+            CloseSessionParams? p;
+            try
+            {
+                p = DeserializeParams(request, AgentHostJsonContext.Default.CloseSessionParams);
+            }
+            catch (JsonException)
+            {
+                p = null;
+            }
+            if (p == null)
+            {
+                return Journaled(request, AgentHostProtocol.Methods.CloseSession, null, "session",
+                    Error(request.Id, AgentHostProtocol.ErrorCodes.MalformedRequest, "closeSession requires params with a paneId."));
+            }
+
+            if (!_actEnabled)
+            {
+                return Journaled(request, AgentHostProtocol.Methods.CloseSession, p.PaneId, "session",
+                    Error(request.Id, AgentHostProtocol.ErrorCodes.ActDisabled,
+                        "Acting is disabled. Enable Settings → Agent access (observe) → Agent access (act), then retry."));
+            }
+
+            // Close is deliberately not SSH-allowlist-gated: it ends a session the
+            // user can see disappear and is journaled; it cannot exfiltrate or run
+            // anything. It still requires a live registration, so unknown panes 404.
+            if (!_registry.TryGet(p.PaneId, out _))
+            {
+                return Journaled(request, AgentHostProtocol.Methods.CloseSession, p.PaneId, "session",
+                    Error(request.Id, AgentHostProtocol.ErrorCodes.SessionNotFound, $"No live session with paneId '{p.PaneId}'."));
+            }
+
+            var executor = _actionExecutor;
+            if (executor == null)
+            {
+                return Journaled(request, AgentHostProtocol.Methods.CloseSession, p.PaneId, "session",
+                    Error(request.Id, AgentHostProtocol.ErrorCodes.ActUnavailable,
+                        "The app cannot close sessions right now (starting up or shutting down). Retry shortly."));
+            }
+
+            bool closed = await executor.ClosePaneAsync(p.PaneId).ConfigureAwait(false);
+            if (!closed)
+            {
+                return Journaled(request, AgentHostProtocol.Methods.CloseSession, p.PaneId, "session",
+                    Error(request.Id, AgentHostProtocol.ErrorCodes.SessionNotFound, $"No live pane with paneId '{p.PaneId}' to close."));
+            }
+
+            var dto = new CloseSessionResult { Closed = true };
+            return Journaled(request, AgentHostProtocol.Methods.CloseSession, p.PaneId, "session",
+                Ok(request.Id, JsonSerializer.SerializeToElement(dto, AgentHostJsonContext.Default.CloseSessionResult)));
         }
 
         /// <summary>

--- a/src/NovaTerminal.App/AgentHost/AgentHostService.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentHostService.cs
@@ -823,15 +823,17 @@ namespace NovaTerminal.AgentHost
             SpawnSessionParams? p;
             try
             {
-                p = DeserializeParams(request, AgentHostJsonContext.Default.SpawnSessionParams);
+                // Missing params entirely (null) is legitimate — it means "default
+                // local profile". A *present but unparseable* params object is
+                // malformed and must NOT silently fall back to a default spawn
+                // (that would turn bad input into an acting side effect).
+                p = DeserializeParams(request, AgentHostJsonContext.Default.SpawnSessionParams) ?? new SpawnSessionParams();
             }
             catch (JsonException)
             {
-                p = null;
+                return Journaled(request, AgentHostProtocol.Methods.SpawnSession, null, "(malformed)",
+                    Error(request.Id, AgentHostProtocol.ErrorCodes.MalformedRequest, "The spawnSession parameters are malformed."));
             }
-            // Missing/empty profile = default local profile, so params may be null;
-            // only a present-but-unparseable params object is malformed.
-            p ??= new SpawnSessionParams();
             string target = string.IsNullOrWhiteSpace(p.Profile) ? "(default)" : p.Profile!;
 
             if (!_actEnabled)

--- a/src/NovaTerminal.App/AgentHost/IAgentActionExecutor.cs
+++ b/src/NovaTerminal.App/AgentHost/IAgentActionExecutor.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Threading.Tasks;
+
+namespace NovaTerminal.AgentHost
+{
+    /// <summary>Outcome of an agent-requested spawn (A3).</summary>
+    public readonly struct AgentSpawnResult
+    {
+        public AgentSpawnResult(Guid paneId, Guid? tabId, string profileName, string kind)
+        {
+            PaneId = paneId;
+            TabId = tabId;
+            ProfileName = profileName;
+            Kind = kind;
+        }
+
+        public Guid PaneId { get; }
+        public Guid? TabId { get; }
+        public string ProfileName { get; }
+
+        /// <summary>"local" or "ssh".</summary>
+        public string Kind { get; }
+    }
+
+    /// <summary>
+    /// Reason a spawn could not be satisfied, mapped to a protocol error code by
+    /// the endpoint. Keeps Avalonia/UI concerns out of the service.
+    /// </summary>
+    public enum AgentSpawnError
+    {
+        /// <summary>No local or SSH profile matched the requested name.</summary>
+        ProfileNotFound,
+
+        /// <summary>An SSH profile matched but is not allowlisted for agent access.</summary>
+        ProfileNotAllowed,
+
+        /// <summary>The profile resolved but the tab failed to open.</summary>
+        SpawnFailed,
+    }
+
+    /// <summary>
+    /// UI-thread bridge the agent-host endpoint uses to open and close sessions
+    /// (A3 spawn/close). Implemented by MainWindow and published on the service
+    /// while the window lives; the service never touches Avalonia directly.
+    /// Implementations marshal to the UI thread themselves.
+    /// </summary>
+    public interface IAgentActionExecutor
+    {
+        /// <summary>
+        /// Opens a new tab for <paramref name="profileName"/> (null/empty = default
+        /// local profile). Returns the spawned pane's identity, or an error reason.
+        /// The allowlist check for SSH profiles happens inside the implementation
+        /// (it owns profile resolution).
+        /// </summary>
+        Task<(AgentSpawnResult? Result, AgentSpawnError? Error)> SpawnAsync(string? profileName);
+
+        /// <summary>Closes the pane with <paramref name="paneId"/>. False if no such live pane.</summary>
+        Task<bool> ClosePaneAsync(Guid paneId);
+    }
+}

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -3207,8 +3207,11 @@ namespace NovaTerminal
                 }
                 _currentPane = target;
 
+                // CloseActivePaneAsync can no-op if a close is already in flight
+                // (_closePaneInProgress); report the real outcome by checking the
+                // pane is actually gone, so closeSession never claims a false success.
                 await CloseActivePaneAsync(skipConfirm: true);
-                return true;
+                return !_paneOwnerTab.ContainsKey(target);
             });
         }
 

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -37,7 +37,7 @@ using NovaTerminal.Pty;
 
 namespace NovaTerminal
 {
-    public partial class MainWindow : Window
+    public partial class MainWindow : Window, AgentHost.IAgentActionExecutor
     {
         internal readonly record struct ShellOpenRequest(string FileName, string? Arguments);
         private const string SplitterHoverClass = "splitter-hover";
@@ -1959,6 +1959,7 @@ namespace NovaTerminal
             AgentHost.AgentHostService.Instance.ReplayExportEnabled = _settings.AgentReplayExportEnabled;
             AgentHost.AgentHostService.Instance.ActEnabled = _settings.AgentAccessActEnabled;
             AgentHost.AgentHostService.Instance.SetSshProfileAllowlist(IsSshProfileAgentAllowed);
+            AgentHost.AgentHostService.Instance.SetActionExecutor(this);
             AgentHost.AgentHostService.Instance.Apply(_settings.AgentAccessObserveEnabled);
 
             // Ensure visual tree is ready for initial tab border
@@ -3111,6 +3112,106 @@ namespace NovaTerminal
             }
         }
 
+        // ── A3 agent act executor (spawn/close) ──────────────────────────────
+        // Implemented on MainWindow because spawning/closing is inherently UI-thread
+        // tab work. Published to the agent-host endpoint via SetActionExecutor; the
+        // endpoint calls these from its IPC thread, so every body marshals to the UI
+        // thread. Gating (act toggle) is enforced by the endpoint before we get here;
+        // the SSH allowlist is enforced here since we own profile resolution.
+
+        async Task<(AgentHost.AgentSpawnResult? Result, AgentHost.AgentSpawnError? Error)> AgentHost.IAgentActionExecutor.SpawnAsync(string? profileName)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                TerminalProfile? profile;
+                bool isSsh;
+
+                if (string.IsNullOrWhiteSpace(profileName))
+                {
+                    profile = _settings.Profiles.Find(p => p.Id == _settings.DefaultProfileId)
+                              ?? (_settings.Profiles.Count > 0 ? _settings.Profiles[0] : null);
+                    isSsh = false;
+                }
+                else
+                {
+                    // Local settings profiles resolve before SSH store profiles on
+                    // a name collision (documented in the A3 design).
+                    profile = _settings.Profiles.Find(
+                        p => p.Type == ConnectionType.Local &&
+                             string.Equals(p.Name, profileName, StringComparison.OrdinalIgnoreCase));
+                    isSsh = false;
+
+                    if (profile == null)
+                    {
+                        TerminalProfile? sshProfile = _sshConnectionService.GetConnectionProfiles()
+                            .FirstOrDefault(p => string.Equals(p.Name, profileName, StringComparison.OrdinalIgnoreCase));
+                        if (sshProfile != null)
+                        {
+                            // SSH targets must be allowlisted per profile.
+                            if (!IsSshProfileAgentAllowed(sshProfile.Id))
+                            {
+                                return ((AgentHost.AgentSpawnResult?)null, (AgentHost.AgentSpawnError?)AgentHost.AgentSpawnError.ProfileNotAllowed);
+                            }
+                            profile = sshProfile;
+                            isSsh = true;
+                        }
+                    }
+                }
+
+                if (profile == null)
+                {
+                    return (null, AgentHost.AgentSpawnError.ProfileNotFound);
+                }
+
+                try
+                {
+                    AddTab(profile);
+                    var pane = _currentPane;
+                    if (pane == null)
+                    {
+                        return (null, AgentHost.AgentSpawnError.SpawnFailed);
+                    }
+
+                    Guid? tabId = _paneOwnerTab.TryGetValue(pane, out var tab)
+                        ? GetPersistentTabId(tab)
+                        : (Guid?)null;
+                    string kind = isSsh || profile.Type == ConnectionType.SSH ? "ssh" : "local";
+                    var result = new AgentHost.AgentSpawnResult(pane.PaneId, tabId, profile.Name, kind);
+                    return ((AgentHost.AgentSpawnResult?)result, (AgentHost.AgentSpawnError?)null);
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"[MainWindow] Agent spawn failed: {ex.Message}");
+                    return (null, AgentHost.AgentSpawnError.SpawnFailed);
+                }
+            });
+        }
+
+        async Task<bool> AgentHost.IAgentActionExecutor.ClosePaneAsync(Guid paneId)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(async () =>
+            {
+                TerminalPane? target = _paneOwnerTab.Keys.FirstOrDefault(p => p.PaneId == paneId);
+                if (target == null)
+                {
+                    return false;
+                }
+
+                // Make the target the active pane of its (selected) tab, then reuse
+                // the split-aware close path with the confirm dialog bypassed.
+                if (_paneOwnerTab.TryGetValue(target, out var tab))
+                {
+                    var tabs = this.FindControl<TabControl>("Tabs");
+                    if (tabs != null) tabs.SelectedItem = tab;
+                    _activePaneByTab[tab] = target;
+                }
+                _currentPane = target;
+
+                await CloseActivePaneAsync(skipConfirm: true);
+                return true;
+            });
+        }
+
         private void CloseTab(TabItem ti)
         {
             if (_paneZoomStateByTab.ContainsKey(ti))
@@ -3154,7 +3255,7 @@ namespace NovaTerminal
             _ = CloseActivePaneAsync();
         }
 
-        private async Task CloseActivePaneAsync()
+        private async Task CloseActivePaneAsync(bool skipConfirm = false)
         {
             if (_closePaneInProgress || _currentPane == null) return;
             _closePaneInProgress = true;
@@ -3169,7 +3270,10 @@ namespace NovaTerminal
                     paneToClose = _currentPane;
                     if (paneToClose == null) return;
                 }
-                if (!await ShouldClosePaneAsync(paneToClose))
+                // Agent-initiated close bypasses the confirmation dialog: an agent
+                // can't answer a modal, and the act opt-in + journal entry are the
+                // consent surface (A3 threat model).
+                if (!skipConfirm && !await ShouldClosePaneAsync(paneToClose))
                 {
                     FocusPaneTerminal(paneToClose, defer: true);
                     return;
@@ -4913,6 +5017,7 @@ namespace NovaTerminal
                 AgentHost.AgentHostService.Instance.ReplayExportEnabled = _settings.AgentReplayExportEnabled;
                 AgentHost.AgentHostService.Instance.ActEnabled = _settings.AgentAccessActEnabled;
                 AgentHost.AgentHostService.Instance.SetSshProfileAllowlist(IsSshProfileAgentAllowed);
+                AgentHost.AgentHostService.Instance.SetActionExecutor(this);
                 AgentHost.AgentHostService.Instance.Apply(_settings.AgentAccessObserveEnabled);
 
                 // Refresh Connection Manager if open (or just always update it)

--- a/src/NovaTerminal.McpServer/Tools/SessionTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/SessionTools.cs
@@ -190,6 +190,47 @@ public static class SessionTools
             : AgentHostClient.ProtocolErrorMessage;
     }
 
+    [McpServerTool(Name = "novaterminal.spawn_session"),
+     Description("Opens a new terminal tab in the running NovaTerminal app and returns its paneId (use that id with the other session tools). 'profile' is a profile NAME (case-insensitive); omit it for the default local profile. Local profiles resolve before SSH profiles on a name clash. This is an ACTING tool requiring 'Agent access (observe)' + 'Agent access (act)'; spawning an SSH profile additionally requires that profile to be allowlisted. Every call is shown in the agent activity journal.")]
+    public static async Task<string> SpawnSession(
+        AgentHostClient client,
+        [Description("Profile name to open. Omit or leave empty for the default local profile.")] string? profile = null,
+        CancellationToken cancellationToken = default)
+    {
+        var parameters = JsonSerializer.SerializeToElement(
+            new SpawnSessionParams { Profile = profile },
+            AgentHostJsonContext.Default.SpawnSessionParams);
+        var outcome = await client.CallAsync(AgentHostProtocol.Methods.SpawnSession, parameters, cancellationToken).ConfigureAwait(false);
+        if (!TryUnwrap(outcome, out var result, out var error)) return error;
+
+        return TryDeserializeResult(result, AgentHostJsonContext.Default.SpawnSessionResult, out var dto)
+            ? $"Opened {dto!.Kind} session '{dto.ProfileName}' — paneId {dto.PaneId}{(dto.TabId is { } t ? $" (tab {t})" : "")}."
+            : AgentHostClient.ProtocolErrorMessage;
+    }
+
+    [McpServerTool(Name = "novaterminal.close_session"),
+     Description("Closes a live terminal session (pane) in the running NovaTerminal app. This is an ACTING tool requiring 'Agent access (observe)' + 'Agent access (act)'. The close is not blocked by a confirmation dialog, so use it deliberately; it is recorded in the agent activity journal. Get paneId from novaterminal.list_sessions.")]
+    public static async Task<string> CloseSession(
+        AgentHostClient client,
+        [Description("The pane id (GUID) from novaterminal.list_sessions.")] string paneId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Guid.TryParse(paneId, out var pane))
+        {
+            return $"Error: '{paneId}' is not a valid pane id (GUID). Use novaterminal.list_sessions to find live pane ids.";
+        }
+
+        var parameters = JsonSerializer.SerializeToElement(
+            new CloseSessionParams { PaneId = pane },
+            AgentHostJsonContext.Default.CloseSessionParams);
+        var outcome = await client.CallAsync(AgentHostProtocol.Methods.CloseSession, parameters, cancellationToken).ConfigureAwait(false);
+        if (!TryUnwrap(outcome, out var result, out var error)) return error;
+
+        return TryDeserializeResult(result, AgentHostJsonContext.Default.CloseSessionResult, out var dto) && dto!.Closed
+            ? $"Closed session {pane}."
+            : AgentHostClient.ProtocolErrorMessage;
+    }
+
     // ── Shared plumbing ─────────────────────────────────────────────────────
 
     /// <summary>

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentHostActProtocolTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentHostActProtocolTests.cs
@@ -278,6 +278,179 @@ public class AgentHostActProtocolTests
         Assert.Equal("ls\r", Assert.Single(session.Inputs));
     }
 
+    // ── spawnSession / closeSession ──────────────────────────────────────────
+
+    private sealed class StubExecutor : IAgentActionExecutor
+    {
+        public Func<string?, (AgentSpawnResult?, AgentSpawnError?)>? OnSpawn;
+        public Func<Guid, bool>? OnClose;
+        public string? LastSpawnProfile;
+        public Guid? LastClosePane;
+
+        public Task<(AgentSpawnResult? Result, AgentSpawnError? Error)> SpawnAsync(string? profileName)
+        {
+            LastSpawnProfile = profileName;
+            var r = OnSpawn?.Invoke(profileName) ?? (null, AgentSpawnError.SpawnFailed);
+            return Task.FromResult(r);
+        }
+
+        public Task<bool> ClosePaneAsync(Guid paneId)
+        {
+            LastClosePane = paneId;
+            return Task.FromResult(OnClose?.Invoke(paneId) ?? false);
+        }
+    }
+
+    private static string SpawnLine(string? profile, long id = 1)
+    {
+        var json = JsonSerializer.Serialize(
+            new SpawnSessionParams { Profile = profile }, AgentHostJsonContext.Default.SpawnSessionParams);
+        return $"{{\"v\":{AgentHostProtocol.Version},\"id\":{id},\"method\":\"{AgentHostProtocol.Methods.SpawnSession}\",\"params\":{json}}}";
+    }
+
+    private static string CloseLine(Guid paneId, long id = 1)
+    {
+        var json = JsonSerializer.Serialize(
+            new CloseSessionParams { PaneId = paneId }, AgentHostJsonContext.Default.CloseSessionParams);
+        return $"{{\"v\":{AgentHostProtocol.Version},\"id\":{id},\"method\":\"{AgentHostProtocol.Methods.CloseSession}\",\"params\":{json}}}";
+    }
+
+    [Fact]
+    public void SpawnSession_is_actDisabled_when_only_observe_is_enabled()
+    {
+        var journal = new AgentActivityJournal();
+        using var service = NewService(new AgentSessionRegistry(), journal);
+        service.SetActionExecutor(new StubExecutor());
+        // act disabled
+
+        var response = Handle(service, SpawnLine("Bash"));
+
+        Assert.Equal(AgentHostProtocol.ErrorCodes.ActDisabled, response.Error?.Code);
+        Assert.Equal(AgentHostProtocol.ErrorCodes.ActDisabled, Assert.Single(journal.Snapshot()).Outcome);
+    }
+
+    [Fact]
+    public void SpawnSession_without_executor_is_actUnavailable()
+    {
+        using var service = NewService(new AgentSessionRegistry(), new AgentActivityJournal());
+        service.ActEnabled = true;
+        // no executor published
+
+        var response = Handle(service, SpawnLine("Bash"));
+
+        Assert.Equal(AgentHostProtocol.ErrorCodes.ActUnavailable, response.Error?.Code);
+    }
+
+    [Fact]
+    public void SpawnSession_maps_executor_errors_to_stable_codes()
+    {
+        using var service = NewService(new AgentSessionRegistry(), new AgentActivityJournal());
+        service.ActEnabled = true;
+
+        var notFound = new StubExecutor { OnSpawn = _ => (null, AgentSpawnError.ProfileNotFound) };
+        service.SetActionExecutor(notFound);
+        Assert.Equal(AgentHostProtocol.ErrorCodes.ProfileNotFound, Handle(service, SpawnLine("nope")).Error?.Code);
+
+        var notAllowed = new StubExecutor { OnSpawn = _ => (null, AgentSpawnError.ProfileNotAllowed) };
+        service.SetActionExecutor(notAllowed);
+        Assert.Equal(AgentHostProtocol.ErrorCodes.ProfileNotAllowed, Handle(service, SpawnLine("prod-ssh")).Error?.Code);
+    }
+
+    [Fact]
+    public void SpawnSession_success_returns_pane_identity_and_journals()
+    {
+        using var service = NewService(new AgentSessionRegistry(), new AgentActivityJournal());
+        service.ActEnabled = true;
+        var paneId = Guid.NewGuid();
+        var tabId = Guid.NewGuid();
+        var exec = new StubExecutor { OnSpawn = _ => (new AgentSpawnResult(paneId, tabId, "Bash", "local"), null) };
+        service.SetActionExecutor(exec);
+
+        var response = Handle(service, SpawnLine(null));
+
+        Assert.Null(response.Error);
+        var result = response.Result!.Value.Deserialize(AgentHostJsonContext.Default.SpawnSessionResult);
+        Assert.Equal(paneId, result!.PaneId);
+        Assert.Equal(tabId, result.TabId);
+        Assert.Equal("Bash", result.ProfileName);
+        Assert.Equal("local", result.Kind);
+        Assert.Null(exec.LastSpawnProfile); // null profile passed through as default
+    }
+
+    [Fact]
+    public void CloseSession_is_actDisabled_when_only_observe_is_enabled()
+    {
+        var registry = new AgentSessionRegistry();
+        var reg = Register(registry, "local", new InputStubSession());
+        var journal = new AgentActivityJournal();
+        using var service = NewService(registry, journal);
+        service.SetActionExecutor(new StubExecutor());
+
+        var response = Handle(service, CloseLine(reg.PaneId));
+
+        Assert.Equal(AgentHostProtocol.ErrorCodes.ActDisabled, response.Error?.Code);
+    }
+
+    [Fact]
+    public void CloseSession_for_unknown_pane_is_sessionNotFound()
+    {
+        using var service = NewService(new AgentSessionRegistry(), new AgentActivityJournal());
+        service.ActEnabled = true;
+        service.SetActionExecutor(new StubExecutor { OnClose = _ => true });
+
+        var response = Handle(service, CloseLine(Guid.NewGuid()));
+
+        Assert.Equal(AgentHostProtocol.ErrorCodes.SessionNotFound, response.Error?.Code);
+    }
+
+    [Fact]
+    public void CloseSession_closes_a_live_registered_pane_and_journals()
+    {
+        var registry = new AgentSessionRegistry();
+        var reg = Register(registry, "local", new InputStubSession());
+        var journal = new AgentActivityJournal();
+        using var service = NewService(registry, journal);
+        service.ActEnabled = true;
+        var exec = new StubExecutor { OnClose = _ => true };
+        service.SetActionExecutor(exec);
+
+        var response = Handle(service, CloseLine(reg.PaneId));
+
+        Assert.Null(response.Error);
+        var result = response.Result!.Value.Deserialize(AgentHostJsonContext.Default.CloseSessionResult);
+        Assert.True(result!.Closed);
+        Assert.Equal(reg.PaneId, exec.LastClosePane);
+        Assert.Equal("ok", Assert.Single(journal.Snapshot()).Outcome);
+    }
+
+    [Fact]
+    public void CloseSession_when_executor_reports_no_pane_is_sessionNotFound()
+    {
+        var registry = new AgentSessionRegistry();
+        var reg = Register(registry, "local", new InputStubSession());
+        using var service = NewService(registry, new AgentActivityJournal());
+        service.ActEnabled = true;
+        service.SetActionExecutor(new StubExecutor { OnClose = _ => false }); // registry knows it, UI raced it away
+
+        var response = Handle(service, CloseLine(reg.PaneId));
+
+        Assert.Equal(AgentHostProtocol.ErrorCodes.SessionNotFound, response.Error?.Code);
+    }
+
+    [Fact]
+    public void Stop_clears_the_action_executor()
+    {
+        var registry = new AgentSessionRegistry();
+        var reg = Register(registry, "local", new InputStubSession());
+        using var service = NewService(registry, new AgentActivityJournal());
+        service.ActEnabled = true;
+        service.SetActionExecutor(new StubExecutor { OnClose = _ => true });
+
+        service.Stop(); // window closing → executor released (no window pinning)
+
+        Assert.Equal(AgentHostProtocol.ErrorCodes.ActUnavailable, Handle(service, CloseLine(reg.PaneId)).Error?.Code);
+    }
+
     // ── Journal ──────────────────────────────────────────────────────────────
 
     [Fact]

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentHostActProtocolTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentHostActProtocolTests.cs
@@ -286,9 +286,11 @@ public class AgentHostActProtocolTests
         public Func<Guid, bool>? OnClose;
         public string? LastSpawnProfile;
         public Guid? LastClosePane;
+        public int SpawnCalls;
 
         public Task<(AgentSpawnResult? Result, AgentSpawnError? Error)> SpawnAsync(string? profileName)
         {
+            SpawnCalls++;
             LastSpawnProfile = profileName;
             var r = OnSpawn?.Invoke(profileName) ?? (null, AgentSpawnError.SpawnFailed);
             return Task.FromResult(r);
@@ -354,6 +356,22 @@ public class AgentHostActProtocolTests
         var notAllowed = new StubExecutor { OnSpawn = _ => (null, AgentSpawnError.ProfileNotAllowed) };
         service.SetActionExecutor(notAllowed);
         Assert.Equal(AgentHostProtocol.ErrorCodes.ProfileNotAllowed, Handle(service, SpawnLine("prod-ssh")).Error?.Code);
+    }
+
+    [Fact]
+    public void SpawnSession_with_malformed_params_is_malformedRequest_not_a_default_spawn()
+    {
+        using var service = NewService(new AgentSessionRegistry(), new AgentActivityJournal());
+        service.ActEnabled = true;
+        var exec = new StubExecutor { OnSpawn = _ => (new AgentSpawnResult(Guid.NewGuid(), null, "Bash", "local"), null) };
+        service.SetActionExecutor(exec);
+
+        // "profile" present but the wrong JSON type → deserialization throws.
+        var line = $"{{\"v\":{AgentHostProtocol.Version},\"id\":1,\"method\":\"{AgentHostProtocol.Methods.SpawnSession}\",\"params\":{{\"profile\":123}}}}";
+        var response = Handle(service, line);
+
+        Assert.Equal(AgentHostProtocol.ErrorCodes.MalformedRequest, response.Error?.Code);
+        Assert.Equal(0, exec.SpawnCalls); // executor never invoked — no default spawn side effect
     }
 
     [Fact]

--- a/tests/NovaTerminal.McpServer.Tests/McpServerStdioE2ETests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/McpServerStdioE2ETests.cs
@@ -43,6 +43,8 @@ public class McpServerStdioE2ETests
         "novaterminal.wait_for_events",
         "novaterminal.export_replay",
         "novaterminal.send_input",
+        "novaterminal.spawn_session",
+        "novaterminal.close_session",
     };
 
     [Fact]


### PR DESCRIPTION
## Summary

Second slice of **milestone A3 (Act, permissioned)** per `docs/plans/2026-07-12-agent-host-a3-act-design.md`, on top of #193 (act gate + `send_input`): **`spawn_session` and `close_session`**. Same permission model and journal; protocol stays additive on version 1. Slice 3 (journal UI + connection-editor allowlist checkbox + threat model + docs + DIRECTION checkboxes) follows.

## What's here

**UI executor bridge (`IAgentActionExecutor`)**
- `AgentHostService` never touches Avalonia. MainWindow implements `IAgentActionExecutor` (`SpawnAsync`, `ClosePaneAsync`) and publishes itself via `SetActionExecutor(this)` at both settings-apply sites; each body marshals to the UI thread with `Dispatcher.UIThread.InvokeAsync`. The delegate closes over the window, so it's **cleared in `StopLocked` alongside the SSH allowlist probe** (window-pinning fix from #193 extended) — verified by a test.
- Null executor → `actUnavailable` (distinct from `actDisabled`: opted in, just can't act this instant — retryable).

**spawnSession**
- `spawnSession { profile? }` → `{ paneId, tabId, profileName, kind }`. Missing/empty profile = default local profile. Name resolution (in MainWindow, which owns profiles): local settings profiles first, then the SSH store, case-insensitive. `profileNotFound` if neither; **SSH profiles require `AllowAgentAccess`** (`profileNotAllowed`) — the allowlist check lives with resolution. Opens via the existing `AddTab` path and returns the new pane's identity.

**closeSession**
- `closeSession { paneId }` → `{ closed: true }`. Requires a live registration (`sessionNotFound` otherwise). Reuses the split-aware close path with a new `skipConfirm` flag on `CloseActivePaneAsync` — an **agent close bypasses the confirmation dialog** (an agent can't answer a modal; the act opt-in + journal entry are the consent surface, per the threat model). Deliberately *not* SSH-allowlist-gated: closing ends a visible session and can't exfiltrate or execute — rationale in the design doc.

**Gating & journal** — both methods require the separate `AgentAccessActEnabled` opt-in (`actDisabled` otherwise) and journal every attempt, allowed or denied, exactly like `send_input`.

**MCP tools** — `novaterminal.spawn_session(profile?)` and `novaterminal.close_session(paneId)`; descriptions flag them as acting tools needing both toggles (+ SSH allowlisting for spawn) and note that close bypasses confirmation. E2E tool list = 24.

## Testing

Protocol tests with a stub executor: `actDisabled` when only observe is on (both methods, journaled); `actUnavailable` with no executor; spawn maps executor `ProfileNotFound`/`ProfileNotAllowed` to the right codes and returns pane identity on success (default-profile null passthrough asserted); close → `sessionNotFound` for unknown pane, closes a live registered pane (executor receives the id, journaled `ok`), and maps executor-reports-no-pane to `sessionNotFound`; `Stop` clears the executor (→ `actUnavailable`).

Local: App.Tests AgentHostActProtocol 22/22, McpServer.Tests 134/134, build clean.

## Scope note

The design listed the connection-editor allowlist checkbox in this slice; I moved it to slice 3 to group it with the other UI work (journal window) and keep this PR focused on the protocol/executor. The allowlist is already settable via JSON / the MCP connection-profile tools and is fully honored here.

## Reviewer note

`MainWindow.axaml.cs` changes here are all A3 executor code. A parallel local change to `TerminalPane.axaml.cs` / `TerminalPaneSshDisconnectTests.cs` (SSH reconnect-banner refactor) is deliberately excluded from this commit.
