### PR TITLE
feat(agent-host): A3 slice 3 - activity journal UI + allowlist checkbox + threat model + docs (completes A3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ acyclic dependency graph.
 - **[`src/NovaTerminal.Conformance`](src/NovaTerminal.Conformance/)** — VT conformance matrix tooling and report generation.
 - **[`src/NovaTerminal.Cli`](src/NovaTerminal.Cli/)** — console-subsystem twin of the (WinExe) app for headless tooling: `vt-report`, headless replay (`--replay <file>`), and the SSH askpass helper.
 - **[`src/NovaTerminal.AgentHost.Contracts`](src/NovaTerminal.AgentHost.Contracts/)** — zero-dependency wire contracts for the agent-host observe channel (shared by App and McpServer).
-- **[`src/NovaTerminal.McpServer`](src/NovaTerminal.McpServer/)** — read-only, stdio-only MCP server exposing project docs, config validators, VT conformance data, and (opt-in, observe-only) live terminal sessions to AI tooling.
+- **[`src/NovaTerminal.McpServer`](src/NovaTerminal.McpServer/)** — stdio-only MCP server exposing project docs, config validators, VT conformance data, and (opt-in) live terminal sessions to AI tooling: observe by default, and — behind a separate explicit opt-in — act (type into / open / close sessions).
 
 Validation:
 
@@ -164,8 +164,12 @@ Enforced invariants (`NovaTerminal.Architecture.Tests`): `VT` is a leaf with zer
 - **Agent host program** — the accepted strategic direction
   ([`docs/agent-host/DIRECTION.md`](docs/agent-host/DIRECTION.md)): a
   session-facing MCP surface so AI agents can observe, query status of, and
-  (with explicit permission) act inside live terminal sessions, with
-  deterministic replay as the debugging story. Debug what your agent did,
+  — with explicit, separate permission — act inside live terminal sessions
+  (`send_input` / `spawn_session` / `close_session`, gated by an "Agent access
+  (act)" opt-in on top of observe, a per-profile SSH allowlist, and a visible
+  activity journal; threat model in
+  [`docs/agent-host/2026-07-12-acting-threat-model.md`](docs/agent-host/2026-07-12-acting-threat-model.md)),
+  with deterministic replay as the debugging story. Debug what your agent did,
   frame by frame: with both opt-in toggles enabled, an agent can call
   `novaterminal.export_replay` to save a session's recent output (never
   input — typed keys are not retained) as a standard `.rec` file, and anyone

--- a/docs/agent-host/2026-07-12-acting-threat-model.md
+++ b/docs/agent-host/2026-07-12-acting-threat-model.md
@@ -1,0 +1,99 @@
+# Agent Host Acting Surface — Threat Model (A3)
+
+_Status: current as of milestone A3 (2026-07-12). Scope: the permissioned
+acting surface — `sendInput`, `spawnSession`, `closeSession` — added on top of
+the observe (A1/A2) and replay-export (A4) surfaces. Read alongside
+`docs/agent-host/DIRECTION.md` and `docs/plans/2026-07-12-agent-host-a3-act-design.md`._
+
+## What the acting surface exposes
+
+With permission, a local AI agent (via the stdio MCP server, proxied to the
+running app over the per-user local IPC endpoint) can:
+
+- **`sendInput`** — inject arbitrary bytes into a live session, exactly as if
+  typed at the keyboard.
+- **`spawnSession`** — open a new tab running a local profile, or an
+  allowlisted SSH profile, by name.
+- **`closeSession`** — close a live pane.
+
+This is a meaningful escalation from observe: the agent can now run commands as
+the user, on local shells and (when allowlisted) on remote hosts the user has
+credentials for.
+
+## Trust boundaries
+
+```
+AI agent ──stdio──▶ NovaTerminal.McpServer ──per-user local IPC──▶ NovaTerminal.App
+ (untrusted intent)   (thin proxy, no policy)                      (all policy + gating here)
+```
+
+- The **MCP server is not a policy boundary** — it forwards calls. All gating
+  is enforced in the App endpoint (`AgentHostService`).
+- The **IPC endpoint is loopback/per-user only**: a Windows named pipe with
+  `PipeOptions.CurrentUserOnly`, or a unix domain socket at mode 0600. It is
+  never network-exposed (an unchanged DIRECTION non-goal). The threat actor is
+  therefore a process already running as the user, or the agent the user has
+  themselves connected.
+- The user is trusted; the agent's *intent* is not. The design assumes the
+  agent may be confused, jailbroken, or prompt-injected by hostile terminal
+  content it read via observe.
+
+## Controls
+
+1. **Two-key gating, fail-closed.** Nothing acts unless (a) the observe
+   endpoint is running (`AgentAccessObserveEnabled`) **and** (b) the separate
+   `AgentAccessActEnabled` opt-in is on. Both default off; acting never rides
+   the observe toggle. Denied → `actDisabled`.
+2. **Per-profile SSH allowlist.** Acting on an SSH session (input, or spawning
+   an SSH profile) additionally requires that profile's `AllowAgentAccess`
+   flag (default off). The probe **fails closed**: if it is unavailable, or
+   the profile is unknown, SSH acting is denied (`profileNotAllowed`). Local
+   sessions are governed by the act toggle alone — a local shell is already
+   reachable by any process running as the user, so a local allowlist would be
+   security theater; remote sessions reach *other* machines with the user's
+   credentials and so are gated per profile.
+3. **Visible activity journal.** Every acting attempt — allowed **and denied**,
+   including malformed requests — is recorded to an in-app activity journal
+   ("nothing is silent", mirroring the credential-consent principle). The
+   journal is the consent/visibility surface, especially for `closeSession`,
+   which bypasses the interactive close-confirmation dialog (an agent cannot
+   answer a modal).
+4. **Input size cap.** `sendInput` is capped at 32 KiB per call to bound a
+   flood; the endpoint is per-user local so this is a robustness bound, not a
+   defense against a remote attacker.
+5. **Instant revocation.** Turning the act toggle off is read on the next
+   request (volatile flag); turning observe off tears the endpoint down and
+   force-closes live connections. Closing the window clears the UI executor and
+   allowlist probe.
+
+## Residual risks (accepted)
+
+- **A connected agent acting on hostile content.** If the user enables acting
+  and an agent is prompt-injected by terminal output, it can run commands as
+  the user within the granted scope. Mitigation is the default-off gating, the
+  per-profile SSH allowlist, and the visible journal — not prevention. Users
+  should enable acting only for agents they trust, and allowlist only the SSH
+  profiles they intend agents to drive.
+- **`closeSession` bypasses the confirm dialog.** Deliberate: closing is
+  bounded (ends a visible session, cannot exfiltrate or execute) and the act
+  opt-in plus journal entry are the consent surface. A confused agent could
+  close a pane with unsaved in-terminal state; this is the same risk as a
+  mis-click and is journaled.
+- **The journal is in-memory and bounded (200 entries).** It is a *visibility*
+  surface, not a tamper-evident audit log — the agent's own MCP transcript is
+  the authoritative record. A high-volume attacker could roll older entries
+  out of the ring.
+- **Byte-faithful input includes control characters.** By design (Ctrl-C,
+  Enter, etc. must work). The cap and gating bound abuse; there is no content
+  filtering of injected input (it would be trivially bypassable and break
+  legitimate use).
+
+## Explicit non-goals
+
+- No network-exposed control endpoint.
+- No per-agent identity, authentication, or rate limiting beyond the size cap
+  (the endpoint is single-user local).
+- No sandboxing of what a spawned/driven shell can do — it runs with the
+  user's own privileges, exactly as a terminal the user opened.
+- Not a defense against a local process already running as the user (such a
+  process can drive the terminal directly regardless).

--- a/docs/agent-host/DIRECTION.md
+++ b/docs/agent-host/DIRECTION.md
@@ -167,14 +167,23 @@ Each milestone is independently shippable and announceable. Estimates assume
 ### A3 — Act (permissioned)
 
 **Deliverables**
-- [ ] MCP tools: `novaterminal.send_input`, `novaterminal.spawn_session`
-      (local profile or SSH profile by name), `novaterminal.close_session`
-- [ ] Separate opt-in + per-profile SSH allowlist + UI activity journal
-- [ ] Threat-model doc for the acting surface
+- [x] MCP tools: `novaterminal.send_input` (PR #193), `novaterminal.spawn_session`
+      (local profile or SSH profile by name) + `novaterminal.close_session` (PR #194)
+- [x] Separate opt-in (`AgentAccessActEnabled`, default off) + per-profile SSH
+      allowlist (`SshProfile.AllowAgentAccess`, fail-closed) + UI activity journal
+      (`AgentActivityJournal` + "Agent Activity…" window; every attempt, allowed or
+      denied, is recorded) (PRs #193–#195)
+- [x] Threat-model doc for the acting surface
+      (`docs/agent-host/2026-07-12-acting-threat-model.md`, PR #195)
 
 **Acceptance criteria**
-- Acting tools hard-fail when only observe permission is granted (tested)
-- Input injection is byte-faithful and replay-recorded like any PTY input
+- [x] Acting tools hard-fail when only observe permission is granted (tested:
+      `actDisabled`; SSH also `profileNotAllowed`)
+- [x] Input injection is byte-faithful and replay-recorded like any PTY input
+      (goes through the session's normal `SendInput`; PtySmoke asserts the recorded
+      input event)
+
+**Milestone A3 complete.** Design: `docs/plans/2026-07-12-agent-host-a3-act-design.md`.
 
 ### A4 — Replay for agents (the moat)
 

--- a/src/NovaTerminal.App/MainWindow.axaml
+++ b/src/NovaTerminal.App/MainWindow.axaml
@@ -129,6 +129,7 @@
                             <Separator />
                             <MenuItem Header="New SSH Connection..." Name="MenuNewSshConnection" />
                             <MenuItem Header="Manage Profiles..." Name="MenuManageProfiles" />
+                            <MenuItem Header="Agent Activity..." Name="MenuAgentActivity" />
                         </MenuFlyout>
                     </Button.Flyout>
                 </Button>

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -2098,6 +2098,12 @@ namespace NovaTerminal
                 await ShowNewSshConnectionDialogAsync(null);
             };
 
+            var menuAgentActivity = this.FindControl<MenuItem>("MenuAgentActivity");
+            if (menuAgentActivity != null) menuAgentActivity.Click += async (s, e) =>
+            {
+                await ShowAgentActivityJournalAsync();
+            };
+
             var btnRecord = this.FindControl<Button>("BtnRecord");
             if (btnRecord != null)
             {
@@ -5120,6 +5126,94 @@ namespace NovaTerminal
                 System.Diagnostics.Debug.WriteLine($"[MainWindow] Failed to show SSH connection details: {ex.Message}");
                 await ShowSimpleMessageDialogAsync("Connection details", ex.Message);
             }
+        }
+
+        // A3: visible agent activity journal ("nothing is silent"). Read-only
+        // snapshot of recent acting attempts (allowed and denied), newest first,
+        // with a Refresh button. The journal data layer lives in
+        // AgentActivityJournal; this is its window.
+        private async Task ShowAgentActivityJournalAsync()
+        {
+            var dialog = CreateThemedDialogWindow("Agent activity", 720, 460, canResize: true);
+
+            var list = new ItemsControl();
+            var scroll = new ScrollViewer
+            {
+                Content = list,
+                VerticalScrollBarVisibility = Avalonia.Controls.Primitives.ScrollBarVisibility.Auto,
+            };
+
+            var empty = new TextBlock
+            {
+                Text = "No agent activity recorded yet. Actions taken by AI agents (typing, opening or closing sessions) appear here — including attempts that were denied.",
+                TextWrapping = TextWrapping.Wrap,
+                Opacity = 0.7,
+            };
+
+            void Refresh()
+            {
+                var entries = AgentHost.AgentActivityJournal.Instance.Snapshot();
+                if (entries.Count == 0)
+                {
+                    list.ItemsSource = null;
+                    scroll.IsVisible = false;
+                    empty.IsVisible = true;
+                    return;
+                }
+
+                empty.IsVisible = false;
+                scroll.IsVisible = true;
+                list.ItemsSource = entries.Select(e =>
+                {
+                    string when = e.TimestampUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss");
+                    string outcome = e.Outcome == "ok" ? "ok" : $"denied: {e.Outcome}";
+                    string pane = e.PaneId is { } id ? $" · pane {id}" : string.Empty;
+                    return new TextBlock
+                    {
+                        Text = $"{when}  {e.Method}  [{outcome}]  {e.Target}{pane}",
+                        TextWrapping = TextWrapping.Wrap,
+                        Margin = new Thickness(0, 2, 0, 2),
+                    };
+                }).ToList();
+            }
+
+            var refreshButton = new Button { Content = "Refresh", Width = 92 };
+            refreshButton.Click += (_, __) => Refresh();
+            var closeButton = new Button { Content = "Close", Width = 92 };
+            closeButton.Click += (_, __) => dialog.Close();
+
+            Refresh();
+
+            dialog.Content = new Border
+            {
+                Padding = new Thickness(16),
+                Child = new DockPanel
+                {
+                    LastChildFill = true,
+                    Children =
+                    {
+                        new TextBlock
+                        {
+                            Text = "Recent actions taken (or attempted) by AI agents with 'Agent access (act)' enabled. Newest first; the list is in-memory and bounded.",
+                            TextWrapping = TextWrapping.Wrap,
+                            Margin = new Thickness(0, 0, 0, 12),
+                            [DockPanel.DockProperty] = Dock.Top,
+                        },
+                        new StackPanel
+                        {
+                            Orientation = Avalonia.Layout.Orientation.Horizontal,
+                            HorizontalAlignment = HorizontalAlignment.Right,
+                            Spacing = 8,
+                            Margin = new Thickness(0, 12, 0, 0),
+                            [DockPanel.DockProperty] = Dock.Bottom,
+                            Children = { refreshButton, closeButton },
+                        },
+                        new Panel { Children = { scroll, empty } },
+                    }
+                }
+            };
+
+            await dialog.ShowDialog(this);
         }
 
         private async Task ShowSimpleMessageDialogAsync(string title, string message)

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -5136,7 +5136,23 @@ namespace NovaTerminal
         {
             var dialog = CreateThemedDialogWindow("Agent activity", 720, 460, canResize: true);
 
-            var list = new ItemsControl();
+            var list = new ItemsControl
+            {
+                // Bind to the data snapshot with a template; don't materialize
+                // controls as items (bypasses recycling, leaks on refresh).
+                ItemTemplate = new Avalonia.Controls.Templates.FuncDataTemplate<AgentHost.AgentActivityEntry>((e, _) =>
+                {
+                    string when = e.TimestampUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss");
+                    string outcome = e.Outcome == "ok" ? "ok" : $"denied: {e.Outcome}";
+                    string pane = e.PaneId is { } id ? $" · pane {id}" : string.Empty;
+                    return new TextBlock
+                    {
+                        Text = $"{when}  {e.Method}  [{outcome}]  {e.Target}{pane}",
+                        TextWrapping = TextWrapping.Wrap,
+                        Margin = new Thickness(0, 2, 0, 2),
+                    };
+                }),
+            };
             var scroll = new ScrollViewer
             {
                 Content = list,
@@ -5163,18 +5179,7 @@ namespace NovaTerminal
 
                 empty.IsVisible = false;
                 scroll.IsVisible = true;
-                list.ItemsSource = entries.Select(e =>
-                {
-                    string when = e.TimestampUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss");
-                    string outcome = e.Outcome == "ok" ? "ok" : $"denied: {e.Outcome}";
-                    string pane = e.PaneId is { } id ? $" · pane {id}" : string.Empty;
-                    return new TextBlock
-                    {
-                        Text = $"{when}  {e.Method}  [{outcome}]  {e.Target}{pane}",
-                        TextWrapping = TextWrapping.Wrap,
-                        Margin = new Thickness(0, 2, 0, 2),
-                    };
-                }).ToList();
+                list.ItemsSource = entries; // data snapshot; the ItemTemplate renders each row
             }
 
             var refreshButton = new Button { Content = "Refresh", Width = 92 };

--- a/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
@@ -91,11 +91,10 @@ public sealed class SshLaunchDetails
         if (existing != null)
         {
             incoming.RememberPasswordInVault = existing.RememberPasswordInVault;
-            // The connection editor has no agent-allowlist control yet (A3 PR2),
-            // so the view-model can't carry it — preserve the stored value across
-            // an edit, or editing any other field would silently revoke the
-            // allowlist and break SSH sendInput.
-            incoming.AllowAgentAccess = existing.AllowAgentAccess;
+            // AllowAgentAccess is carried by the view-model (loaded via
+            // ApplySshProfile, edited by the connection editor's checkbox, A3
+            // PR3), so it is authoritative here — no force-preserve, which would
+            // ignore the user unchecking the box.
 
             if (viewModel.BackendKind is null)
             {

--- a/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
+++ b/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
@@ -36,6 +36,7 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
     private string _validationWarning = string.Empty;
     private SshBackendKind? _backendKind;
     private bool _rememberPasswordInVault;
+    private bool _allowAgentAccess;
     private int _keepAliveIntervalSeconds = 30;
     private int _keepAliveCountMax = 3;
     private bool _enableMux;
@@ -167,6 +168,17 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
     }
 
     public bool IsRememberPasswordVisible => BackendKind == SshBackendKind.Native;
+
+    /// <summary>
+    /// A3: allowlists this SSH profile for the agent-host act surface (letting
+    /// agents type into / spawn it, when the global "Agent access (act)" toggle
+    /// is on). Default false.
+    /// </summary>
+    public bool AllowAgentAccess
+    {
+        get => _allowAgentAccess;
+        set => SetField(ref _allowAgentAccess, value);
+    }
 
     public int KeepAliveIntervalSeconds
     {
@@ -329,7 +341,8 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
             ServerAliveIntervalSeconds = keepAliveInterval,
             ServerAliveCountMax = keepAliveCountMax,
             ExtraSshArgs = ExtraSshArgs?.Trim() ?? string.Empty,
-            RemoteShellKind = RemoteShellKind
+            RemoteShellKind = RemoteShellKind,
+            AllowAgentAccess = AllowAgentAccess
         };
     }
 
@@ -395,6 +408,7 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
         IsFavorite = sshProfile.Tags.Any(tag => string.Equals(tag, "favorite", StringComparison.OrdinalIgnoreCase));
         AuthMode = sshProfile.AuthMode == SshAuthMode.IdentityFile ? NewSshAuthMode.IdentityFile : NewSshAuthMode.Agent;
         IdentityFilePath = sshProfile.IdentityFilePath ?? string.Empty;
+        AllowAgentAccess = sshProfile.AllowAgentAccess;
 
         JumpHops.Clear();
         foreach (SshJumpHop hop in sshProfile.JumpHops)

--- a/src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml
+++ b/src/NovaTerminal.App/Views/Ssh/NewSshConnectionView.axaml
@@ -152,7 +152,7 @@
             </TabItem>
 
             <TabItem Header="Advanced">
-                <Grid Margin="0,10,0,0" RowDefinitions="Auto,*" RowSpacing="8">
+                <Grid Margin="0,10,0,0" RowDefinitions="Auto,*,Auto" RowSpacing="8">
                     <TextBlock Grid.Row="0" Text="Extra ssh args (appended after alias)" Opacity="0.8" />
                     <TextBox Grid.Row="1"
                              Text="{Binding ExtraSshArgs}"
@@ -161,6 +161,12 @@
                              VerticalContentAlignment="Top"
                              Height="150"
                              PlaceholderText="-o StrictHostKeyChecking=no" />
+                    <StackPanel Grid.Row="2" Spacing="2">
+                        <CheckBox IsChecked="{Binding AllowAgentAccess}"
+                                  Content="Allow AI agent access to this connection" />
+                        <TextBlock Text="Lets AI agents type into and open this SSH connection, when 'Agent access (act)' is enabled in Settings. Every action is shown in the agent activity journal. Off by default."
+                                   Opacity="0.7" TextWrapping="Wrap" />
+                    </StackPanel>
                 </Grid>
             </TabItem>
         </TabControl>

--- a/src/NovaTerminal.McpServer/README.md
+++ b/src/NovaTerminal.McpServer/README.md
@@ -1,26 +1,37 @@
 # NovaTerminal MCP Dev Companion
 
-A local, **read-only** [Model Context Protocol](https://modelcontextprotocol.io) server that
-exposes NovaTerminal's project knowledge to AI coding agents (Claude Desktop, Claude Code, VS
-Code, etc.). It helps you explore the architecture, understand VT/ANSI behavior, and author or
-validate theme and SSH connection-profile JSON — without leaving your editor.
-
-This is a **developer tool**, not a user-facing NovaTerminal feature.
+A local [Model Context Protocol](https://modelcontextprotocol.io) server that exposes
+NovaTerminal's project knowledge — and, opt-in, its live terminal sessions — to AI coding agents
+(Claude Desktop, Claude Code, VS Code, etc.). It helps you explore the architecture, understand
+VT/ANSI behavior, author or validate theme and SSH connection-profile JSON, and (when you enable
+it) observe and drive running sessions — without leaving your editor.
 
 ## Safety posture
 
-The server is deliberately constrained and isolated:
+The server has two tool families with different postures:
 
-- **Read-only.** It never executes shell commands, opens SSH connections, reads live terminal
-  buffers, accesses saved credentials or private keys, modifies profiles, or controls the running
-  app.
-- **No network access.**
-- **No coupling to the rest of the solution.** The project has **no `ProjectReference`** to any
-  other NovaTerminal assembly — it only reads repo docs and validates JSON against self-contained
-  schemas. (Where it mirrors a real type — e.g. the SSH profile schema — a drift-guard test in
-  `tests/NovaTerminal.McpServer.Tests` keeps the copy honest.)
-- **Filesystem access is confined to `docs/`.** Doc reads reject path traversal (`..`), absolute
-  paths, and symlink escapes.
+**Repo / dev-companion tools** (docs, config validators, VT conformance) are deliberately
+constrained and isolated:
+
+- **Read-only and offline.** They never execute shell commands, open SSH connections, access
+  saved credentials or private keys, or reach the network. Filesystem access is confined to
+  `docs/` (reads reject path traversal, absolute paths, and symlink escapes).
+
+**Live-session tools** proxy the running NovaTerminal app over a per-user local IPC endpoint and
+are gated by explicit, default-off user opt-ins:
+
+- **Observe** (`list_sessions`, `read_screen`, `read_scrollback`, `get_session_status`,
+  `wait_for_events`, `export_replay`) requires "Agent access (observe)". Read-only.
+- **Act** (`send_input`, `spawn_session`, `close_session`) requires a *separate* "Agent access
+  (act)" opt-in on top of observe; SSH sessions additionally require a per-profile allowlist. Every
+  acting call — allowed or denied — is recorded in an in-app activity journal. See the threat model
+  at [`docs/agent-host/2026-07-12-acting-threat-model.md`](../../docs/agent-host/2026-07-12-acting-threat-model.md).
+- When neither toggle is on, no live-session endpoint exists and these tools return guidance
+  instead of data.
+
+The only cross-assembly dependency is the zero-reference `NovaTerminal.AgentHost.Contracts` leaf
+(the IPC wire types); dev-companion schemas that mirror real types are kept honest by drift-guard
+tests in `tests/NovaTerminal.McpServer.Tests`.
 
 ## Tech stack
 
@@ -104,8 +115,12 @@ tool list.
 
 ## Tools
 
-All tools are read-only. See [`docs/mcp/tools.md`](../../docs/mcp/tools.md) for the authoritative
-list and notes; the current set:
+The repo / dev-companion tools below are read-only and offline. The live-session tools
+(`list_sessions`, `read_screen`, `read_scrollback`, `get_session_status`, `wait_for_events`,
+`export_replay`, `send_input`, `spawn_session`, `close_session`) proxy the running app and require
+the opt-in toggles described under **Safety posture** — the last three *act* on sessions. See
+[`docs/mcp/tools.md`](../../docs/mcp/tools.md) for the authoritative list and notes; the
+dev-companion set:
 
 | Tool | Inputs | What it does |
 |------|--------|-------------|

--- a/tests/NovaTerminal.App.Tests/Ssh/SshConnectionServiceTests.cs
+++ b/tests/NovaTerminal.App.Tests/Ssh/SshConnectionServiceTests.cs
@@ -271,11 +271,11 @@ public sealed class SshConnectionServiceTests
     }
 
     [Fact]
-    public void SaveProfile_PreservesAgentAllowlistWhenEditingAnotherField()
+    public void EditorRoundTrip_LoadsAndPreservesAgentAllowlist()
     {
-        // A3: the connection editor has no allowlist control yet, so editing any
-        // other field must not silently revoke an allowlist set via JSON/MCP —
-        // else SSH sendInput would start being rejected.
+        // A3 PR3: the editor loads the allowlist flag into the view-model
+        // (CreateEditorViewModel → ApplySshProfile), so editing another field
+        // and saving preserves it — the view-model is authoritative.
         string tempRoot = CreateTempDirectory();
         try
         {
@@ -292,19 +292,50 @@ public sealed class SshConnectionServiceTests
                 AllowAgentAccess = true
             });
 
-            var vm = new NewSshConnectionViewModel
-            {
-                ProfileId = existingId,
-                Name = "Allowed Renamed",
-                HostName = "renamed.internal",
-                UserName = "ops"
-            };
+            // Load through the real editor path and confirm the checkbox reflects state.
+            var runtime = SshConnectionService.ToRuntimeProfile(store.GetProfile(existingId)!);
+            var vm = service.CreateEditorViewModel(runtime);
+            Assert.True(vm.AllowAgentAccess);
 
+            // Edit an unrelated field; the flag rides along on the view-model.
+            vm.HostName = "renamed.internal";
             SshProfile saved = service.SaveProfile(vm);
 
             Assert.True(saved.AllowAgentAccess);
-            Assert.True(store.GetProfile(saved.Id)!.AllowAgentAccess);
             Assert.True(new JsonSshProfileStore(path).GetProfile(saved.Id)!.AllowAgentAccess);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void EditorRoundTrip_CanRevokeAgentAllowlist()
+    {
+        // Unchecking the box must win — the view-model is authoritative, not a
+        // force-preserved stored value.
+        string tempRoot = CreateTempDirectory();
+        try
+        {
+            string path = Path.Combine(tempRoot, "profiles.json");
+            var store = new JsonSshProfileStore(path);
+            var service = new SshConnectionService(store);
+            var existingId = Guid.Parse("d5e6f7a8-b9c0-4d1e-8f2a-3b4c5d6e7f80");
+
+            store.SaveProfile(new SshProfile
+            {
+                Id = existingId,
+                Name = "Allowed",
+                Host = "allowed.internal",
+                AllowAgentAccess = true
+            });
+
+            var vm = service.CreateEditorViewModel(SshConnectionService.ToRuntimeProfile(store.GetProfile(existingId)!));
+            vm.AllowAgentAccess = false; // user unchecks
+            service.SaveProfile(vm);
+
+            Assert.False(new JsonSshProfileStore(path).GetProfile(existingId)!.AllowAgentAccess);
         }
         finally
         {


### PR DESCRIPTION
## Summary

Final slice of **milestone A3 (Act, permissioned)**, on top of #193 (act gate + `send_input`) and #194 (spawn/close): the **visible activity journal, the connection-editor allowlist checkbox, the threat model, and docs**. Completes A3.

## What's here

**Activity journal UI** — an "Agent Activity…" item in the new-tab menu opens a themed window listing recent acting attempts newest-first (timestamp, method, outcome, target, pane), with a Refresh button. Denied attempts appear too, so the user can see everything an agent tried — the "nothing is silent" surface the acting model relies on. Built on the `AgentActivityJournal` data layer from #193 (already tested); the window reuses the existing `CreateThemedDialogWindow` helper (no new AXAML file).

**Connection-editor allowlist checkbox** — the SSH connection editor's Advanced tab gains "Allow AI agent access to this connection", bound to a new `AllowAgentAccess` view-model property. Full round-trip: `ApplySshProfile` loads the stored flag into the editor, `ToSshProfile` writes it back, and `SaveProfile` no longer force-preserves it (the view-model is now authoritative, so **unchecking actually revokes** — the PR1 force-preserve was a stopgap while the control didn't exist). The flag reaches the endpoint's allowlist probe via the store, unchanged.

**Threat model** — `docs/agent-host/2026-07-12-acting-threat-model.md`: trust boundaries, the two-key + per-profile-allowlist + journal controls, accepted residual risks (agent acting on hostile content, confirm-dialog bypass, in-memory journal, byte-faithful control chars), and explicit non-goals.

**Docs** — root README and the McpServer README drop the now-inaccurate "read-only" framing and document the observe-vs-act split, the permission model, and the journal (the DIRECTION consequence note flagged this update as required once A3 shipped). DIRECTION A3 deliverables + acceptance criteria checked off with PR references; **milestone A3 marked complete**.

## Testing

`SshConnectionServiceTests`: `EditorRoundTrip_LoadsAndPreservesAgentAllowlist` (editor loads the flag, editing another field preserves it) and `EditorRoundTrip_CanRevokeAgentAllowlist` (unchecking wins). The journal data layer and acting gating remain covered by #193/#194 suites.

Local: App.Tests (SshConnectionService + AgentHost) 120/120, McpServer.Tests 134/134, full-solution build clean.

## Reviewer note

`MainWindow.axaml.cs` / `MainWindow.axaml` changes here are the journal window + menu entry. A parallel local change to `TerminalPane.axaml.cs` / `TerminalPaneSshDisconnectTests.cs` (SSH reconnect-banner refactor) is again excluded from this commit.
