### PR TITLE
fix(terminal): render SSH status banners through the ANSI parser

### DIFF
--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -1673,7 +1673,7 @@ namespace NovaTerminal.Controls
                     catch (Exception ex)
                     {
                         System.Diagnostics.Debug.WriteLine($"[TerminalPane] SSH connection failed for '{profile.Name}': {ex.Message}");
-                        Buffer.WriteContent($"\r\n[ERROR] SSH Connection Failed: {ex.Message}\r\n", false);
+                        WriteBanner($"\r\n[ERROR] SSH Connection Failed: {ex.Message}\r\n");
                         
                         // Fail loudly: Do not fall back to RustPtySession with missing arguments.
                         return;
@@ -1715,8 +1715,7 @@ namespace NovaTerminal.Controls
             {
                 // Graceful failure: Log and show in terminal
                 System.Diagnostics.Debug.WriteLine($"[TerminalPane] Failed to spawn session: {ex.Message}");
-                Buffer.WriteContent($"\r\n[ERROR] Failed to spawn process: {effectiveShell}\r\n", false);
-                Buffer.WriteContent($"[DETAILS] {ex.Message}\r\n", false);
+                WriteBanner($"\r\n[ERROR] Failed to spawn process: {effectiveShell}\r\n[DETAILS] {ex.Message}\r\n");
                 return;
             }
 
@@ -2126,10 +2125,7 @@ namespace NovaTerminal.Controls
             }
 
             LastExitCode = null;
-            if (Buffer != null)
-            {
-                Buffer.WriteContent("\r\n\x1b[90m[Reconnecting...]\x1b[0m\r\n", false);
-            }
+            WriteBanner("\r\n\x1b[90m[Reconnecting...]\x1b[0m\r\n");
             InitializeSession(ShellCommand, Profile, TermView.Cols, TermView.Rows, ShellArgs);
         }
 
@@ -2265,17 +2261,29 @@ namespace NovaTerminal.Controls
 
         private void WriteSshDisconnectedBanner(int code)
         {
+            string exitCodeLine = code == 0
+                ? string.Empty
+                : $"[Exit code: {code}]\r\n";
+            WriteBanner(
+                $"\r\n[SSH session disconnected]\r\n{exitCodeLine}[Press Enter to reconnect]\r\n");
+        }
+
+        /// <summary>
+        /// Writes NovaTerminal-generated banner text (connection errors, disconnect/reconnect
+        /// notices) into the terminal. Banners are routed through the ANSI parser rather than
+        /// <see cref="TerminalBuffer.WriteContent"/> — which writes graphemes verbatim — so that
+        /// embedded SGR color codes and CR/LF line breaks are interpreted, instead of leaving
+        /// literal "[90m" garbage collapsed onto a single line. Uses the live session parser when
+        /// present, otherwise a transient parser bound to the same buffer.
+        /// </summary>
+        private void WriteBanner(string text)
+        {
             if (Buffer == null)
             {
                 return;
             }
 
-            string exitCodeLine = code == 0
-                ? string.Empty
-                : $"[Exit code: {code}]\r\n";
-            Buffer.WriteContent(
-                $"\r\n[SSH session disconnected]\r\n{exitCodeLine}[Press Enter to reconnect]\r\n",
-                false);
+            (Parser ?? new AnsiParser(Buffer)).Process(text);
         }
 
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -1673,7 +1673,7 @@ namespace NovaTerminal.Controls
                     catch (Exception ex)
                     {
                         System.Diagnostics.Debug.WriteLine($"[TerminalPane] SSH connection failed for '{profile.Name}': {ex.Message}");
-                        WriteBanner($"\r\n[ERROR] SSH Connection Failed: {ex.Message}\r\n");
+                        WriteBanner($"\r\n[ERROR] SSH Connection Failed: {SanitizeBannerValue(ex.Message)}\r\n");
                         
                         // Fail loudly: Do not fall back to RustPtySession with missing arguments.
                         return;
@@ -1715,7 +1715,7 @@ namespace NovaTerminal.Controls
             {
                 // Graceful failure: Log and show in terminal
                 System.Diagnostics.Debug.WriteLine($"[TerminalPane] Failed to spawn session: {ex.Message}");
-                WriteBanner($"\r\n[ERROR] Failed to spawn process: {effectiveShell}\r\n[DETAILS] {ex.Message}\r\n");
+                WriteBanner($"\r\n[ERROR] Failed to spawn process: {SanitizeBannerValue(effectiveShell)}\r\n[DETAILS] {SanitizeBannerValue(ex.Message)}\r\n");
                 return;
             }
 
@@ -2269,12 +2269,42 @@ namespace NovaTerminal.Controls
         }
 
         /// <summary>
+        /// Strips control characters (C0 incl. ESC, DEL, and C1) from interpolated banner values.
+        /// Banner text is parsed as terminal input, so remote- or profile-derived values such as
+        /// SSH/spawn error messages could otherwise smuggle escape sequences that move the cursor,
+        /// clear the screen, switch modes, or rewrite the title. Only printable content survives.
+        /// </summary>
+        internal static string SanitizeBannerValue(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            var sb = new System.Text.StringBuilder(value.Length);
+            foreach (char c in value)
+            {
+                if (c < 0x20 || c == 0x7F || (c >= 0x80 && c <= 0x9F))
+                {
+                    continue;
+                }
+
+                sb.Append(c);
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
         /// Writes NovaTerminal-generated banner text (connection errors, disconnect/reconnect
         /// notices) into the terminal. Banners are routed through the ANSI parser rather than
         /// <see cref="TerminalBuffer.WriteContent"/> — which writes graphemes verbatim — so that
         /// embedded SGR color codes and CR/LF line breaks are interpreted, instead of leaving
-        /// literal "[90m" garbage collapsed onto a single line. Uses the live session parser when
-        /// present, otherwise a transient parser bound to the same buffer.
+        /// literal "[90m" garbage collapsed onto a single line. A fresh parser is used each time so
+        /// the banner renders with a clean slate: it never inherits a partial escape sequence or
+        /// accumulated SGR state from the (possibly just-disposed) session parser, and never shares
+        /// mutable parser state with the background-thread session output pump.
+        /// Interpolated values must be passed through <see cref="SanitizeBannerValue"/> first.
         /// </summary>
         private void WriteBanner(string text)
         {
@@ -2283,7 +2313,7 @@ namespace NovaTerminal.Controls
                 return;
             }
 
-            (Parser ?? new AnsiParser(Buffer)).Process(text);
+            new AnsiParser(Buffer).Process(text);
         }
 
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)

--- a/tests/NovaTerminal.App.Tests/Ssh/TerminalPaneSshDisconnectTests.cs
+++ b/tests/NovaTerminal.App.Tests/Ssh/TerminalPaneSshDisconnectTests.cs
@@ -105,6 +105,59 @@ public sealed class TerminalPaneSshDisconnectTests
         }
     }
 
+    [AvaloniaFact]
+    public void Reconnect_Banner_RendersAnsiInsteadOfLeavingLiteralEscapeCodes()
+    {
+        // The reconnect banner is styled with SGR ("\x1b[90m...[Reconnecting...]...\x1b[0m").
+        // It must be routed through the ANSI parser so the escape codes are interpreted as
+        // color state — NOT written verbatim into the grid, which leaves visible "[90m"/"[0m"
+        // garbage and (because CR/LF are also uninterpreted) collapses the banner onto one line.
+        var profile = new TerminalProfile
+        {
+            Name = "Native SSH",
+            Type = ConnectionType.SSH,
+            SshHost = "server.example",
+            SshUser = "nova"
+        };
+
+        // No window is shown, so TermView has 0 cols/rows and InitializeSession returns early:
+        // the reconnect path writes its banner but does not attempt a real SSH spawn, keeping the
+        // 80x24 buffer clean and isolating the banner under test.
+        using var pane = new TerminalPane(profile);
+
+        pane.Reconnect();
+
+        string visibleText = GetVisiblePlainText(pane.Buffer!);
+        Assert.Contains("Reconnecting", visibleText, StringComparison.Ordinal);
+        Assert.DoesNotContain("[90m", visibleText, StringComparison.Ordinal);
+        Assert.DoesNotContain("[0m", visibleText, StringComparison.Ordinal);
+        Assert.DoesNotContain("\x1b", visibleText, StringComparison.Ordinal);
+    }
+
+    [AvaloniaFact]
+    public void SshDisconnectedBanner_RendersOnSeparateLines()
+    {
+        // The banner embeds CR/LF between its phrases. Routed through the ANSI parser these must
+        // become real line breaks; written verbatim they would collapse onto a single row.
+        var profile = new TerminalProfile
+        {
+            Name = "Native SSH",
+            Type = ConnectionType.SSH,
+            SshHost = "server.example",
+            SshUser = "nova"
+        };
+        using var pane = new TerminalPane(profile);
+
+        pane.HandleSessionExitForTesting(0);
+
+        string[] lines = GetVisiblePlainText(pane.Buffer!).Split('\n');
+        int disconnectedRow = Array.FindIndex(lines, l => l.Contains("SSH session disconnected", StringComparison.Ordinal));
+        int reconnectRow = Array.FindIndex(lines, l => l.Contains("Press Enter to reconnect", StringComparison.Ordinal));
+
+        Assert.True(disconnectedRow >= 0, "disconnected phrase not found");
+        Assert.True(reconnectRow > disconnectedRow, "reconnect prompt should be on a later row than the disconnect notice");
+    }
+
     private static string GetVisiblePlainText(TerminalBuffer buffer)
     {
         var field = typeof(TerminalBuffer).GetField("_viewport", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);

--- a/tests/NovaTerminal.App.Tests/Ssh/TerminalPaneSshDisconnectTests.cs
+++ b/tests/NovaTerminal.App.Tests/Ssh/TerminalPaneSshDisconnectTests.cs
@@ -158,6 +158,29 @@ public sealed class TerminalPaneSshDisconnectTests
         Assert.True(reconnectRow > disconnectedRow, "reconnect prompt should be on a later row than the disconnect notice");
     }
 
+    [Theory]
+    [InlineData("plain message", "plain message")]
+    [InlineData("café → host", "café → host")] // printable Unicode preserved
+    [InlineData("\x1b[2J\x1b[3Jwiped", "[2J[3Jwiped")]            // ESC stripped, remainder inert text
+    [InlineData("line1\r\nline2\ttab", "line1line2tab")]           // CR/LF/TAB (C0) stripped
+    [InlineData("bell\x07 del\x7f", "bell del")]                   // BEL and DEL stripped
+    public void SanitizeBannerValue_StripsControlCharactersFromInterpolatedText(string input, string expected)
+    {
+        // Interpolated banner values (SSH/spawn error messages, shell paths) may be remote- or
+        // profile-derived. Since banners are parsed as terminal input, any embedded control codes
+        // must be removed so they cannot move the cursor, clear the screen, or change the title.
+        Assert.Equal(expected, TerminalPane.SanitizeBannerValue(input));
+    }
+
+    [Fact]
+    public void SanitizeBannerValue_StripsC1ControlCharacters()
+    {
+        // C1 controls (0x80-0x9F, e.g. 8-bit CSI) are built via a cast to avoid an invisible
+        // control byte or a \u escape in the source literal.
+        string withCsi = (char)0x9B + "CSI c1";
+        Assert.Equal("CSI c1", TerminalPane.SanitizeBannerValue(withCsi));
+    }
+
     private static string GetVisiblePlainText(TerminalBuffer buffer)
     {
         var field = typeof(TerminalBuffer).GetField("_viewport", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);


### PR DESCRIPTION
## Problem

On SSH disconnect/reconnect, NovaTerminal showed garbled output like:

```
root@ChatAI:~/apps/ingest# [SSH session disconnected][Press Enter to reconnect][90m[Reconnecting...][0mroot@ChatAI:~#
```

Two things were wrong, both visible above:
1. **Literal `[90m` / `[0m`** — the reconnect banner's SGR color codes were not interpreted.
2. **No line breaks** — the `\r\n` separators were ignored, collapsing every banner (and the shell prompt) onto one line.

## Root cause

`TerminalPane` injected its status banners via `TerminalBuffer.WriteContent(...)`, which is the buffer's **plain-text fast path**: it writes every grapheme verbatim into the grid and does **not** run text through the ANSI parser or interpret C0 control codes. So `\x1b[90m…\x1b[0m` leaked as literal text (the ESC byte renders invisibly, leaving `[90m`/`[0m`) and `\r\n` never produced line breaks.

Confirmed with a throwaway probe:

```
Input:  "\r\n\x1b[90m[Reconnecting...]\x1b[0m\r\nSECOND"
ROW0 = [[90m[Reconnecting...][0mSECOND ...]   ROW1 = empty   ROW2 = empty
```

## Fix

Added a `WriteBanner` helper that routes banner text through `AnsiParser.Process(...)` — the same path all normal session output already uses. It uses the live session parser, or a transient one bound to the same buffer if none exists yet. All five banner sites (reconnect, disconnect, and the two connection/spawn error banners) now go through it, so SGR codes and `\r\n` are interpreted correctly.

## Testing

TDD in `TerminalPaneSshDisconnectTests`:
- `Reconnect_Banner_RendersAnsiInsteadOfLeavingLiteralEscapeCodes` — verified RED (literal `[90m` present) → GREEN.
- `SshDisconnectedBanner_RendersOnSeparateLines` — locks in the CR/LF line-break fix.
- Full SSH + pane sweep: **208/209 pass**. The single failure (`CommandAssistLayoutTests.TerminalPane_WhenRemotePromptSettlesLowOnShortPane_ResumesConservativeAssistLayout`) is **pre-existing** — it fails identically on unpatched `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
