### PR TITLE
test: de-flake three nightly-CI tests

### DIFF
--- a/tests/NovaTerminal.App.Tests/Performance/PerformanceTests.cs
+++ b/tests/NovaTerminal.App.Tests/Performance/PerformanceTests.cs
@@ -77,6 +77,21 @@ namespace NovaTerminal.Tests.Performance
         [Trait("Category", "Performance")]
         public void ReflowStress_Benchmark()
         {
+            // Warm the reflow path on a throwaway buffer before timing, mirroring
+            // LargeThroughput_Benchmark above. Reflow is JIT-heavy and rents from
+            // ArrayPool; without a warmup the cold first several Resize calls
+            // dominated the 100-iteration average and tipped the 15ms threshold on
+            // shared CI runners (observed 18.06ms in the nightly flake).
+            var warmupBuffer = new TerminalBuffer(80, 1000);
+            for (int i = 0; i < 1000; i++)
+            {
+                warmupBuffer.WriteContent($"Line {i:D4} XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\r\n", false);
+            }
+            for (int i = 0; i < 20; i++)
+            {
+                warmupBuffer.Resize(40 + (i % 40), 24);
+            }
+
             var buffer = new TerminalBuffer(80, 1000); // 1000 lines of history
             for (int i = 0; i < 1000; i++)
             {

--- a/tests/NovaTerminal.App.Tests/PtySmokeTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtySmokeTests.cs
@@ -83,10 +83,14 @@ namespace NovaTerminal.Tests
                 Assert.True(session.IsFlightRecording);
 
                 // The shell banner/prompt guarantees some output; poll until the
-                // ring has captured at least one chunk.
+                // ring has captured at least one chunk. The loop breaks as soon as
+                // output arrives, so the ceiling only affects wall time on a genuine
+                // failure — keep it generous because a loaded Windows CI runner
+                // (Defender realtime scan + process-pool saturation) can take well
+                // over 10s to emit the shell's first bytes.
                 NovaTerminal.Replay.FlightExportInfo info = default;
                 bool exported = false;
-                for (int i = 0; i < 40; i++)
+                for (int i = 0; i < 120; i++)
                 {
                     await Task.Delay(250);
                     exported = session.TryExportFlightRecording(tempFile, out info);

--- a/tests/NovaTerminal.Platform.Tests/Ssh/NativePortForwardSessionTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/NativePortForwardSessionTests.cs
@@ -492,6 +492,15 @@ public sealed class NativePortForwardSessionTests
         private readonly ConcurrentQueue<NativeSshEvent> _events = new();
         private int _nextChannelId = 100;
 
+        // OpenDirectTcpIp/CloseChannel are invoked from the per-listener accept
+        // loops (Task.Run in NativePortForwardSession.StartListener), so with two
+        // forwards two threads mutate these lists concurrently. List<T> is not
+        // thread-safe: racing Add calls can clobber the size field, dropping an
+        // entry so OpenRequests.Count never reaches 2 and the WaitUntilAsync
+        // predicate hangs to its full ceiling. Serialize the writes. (Reads in
+        // the assertions run after the predicate quiesces, so they need no lock.)
+        private readonly object _collectionsLock = new();
+
         public List<NativePortForwardOpenOptions> OpenRequests { get; } = [];
         public List<int> ClosedChannelIds { get; } = [];
 
@@ -528,7 +537,10 @@ public sealed class NativePortForwardSessionTests
 
         public int OpenDirectTcpIp(NovaSshSafeHandle sessionHandle, NativePortForwardOpenOptions options)
         {
-            OpenRequests.Add(options);
+            lock (_collectionsLock)
+            {
+                OpenRequests.Add(options);
+            }
             return Interlocked.Increment(ref _nextChannelId);
         }
 
@@ -542,7 +554,10 @@ public sealed class NativePortForwardSessionTests
 
         public void CloseChannel(NovaSshSafeHandle sessionHandle, int channelId)
         {
-            ClosedChannelIds.Add(channelId);
+            lock (_collectionsLock)
+            {
+                ClosedChannelIds.Add(channelId);
+            }
         }
 
         public void Close(NovaSshSafeHandle sessionHandle)

--- a/tests/NovaTerminal.Platform.Tests/Ssh/NativePortForwardSessionTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/NativePortForwardSessionTests.cs
@@ -497,12 +497,23 @@ public sealed class NativePortForwardSessionTests
         // forwards two threads mutate these lists concurrently. List<T> is not
         // thread-safe: racing Add calls can clobber the size field, dropping an
         // entry so OpenRequests.Count never reaches 2 and the WaitUntilAsync
-        // predicate hangs to its full ceiling. Serialize the writes. (Reads in
-        // the assertions run after the predicate quiesces, so they need no lock.)
+        // predicate hangs to its full ceiling. Serialize the writes, and expose
+        // reads as locked snapshots — WaitUntilAsync polls these while the accept
+        // loops are still adding, so a live List<T> would risk stale counts or a
+        // "collection modified during enumeration" throw in predicates like .Any.
         private readonly object _collectionsLock = new();
+        private readonly List<NativePortForwardOpenOptions> _openRequests = [];
+        private readonly List<int> _closedChannelIds = [];
 
-        public List<NativePortForwardOpenOptions> OpenRequests { get; } = [];
-        public List<int> ClosedChannelIds { get; } = [];
+        public IReadOnlyList<NativePortForwardOpenOptions> OpenRequests
+        {
+            get { lock (_collectionsLock) { return _openRequests.ToArray(); } }
+        }
+
+        public IReadOnlyList<int> ClosedChannelIds
+        {
+            get { lock (_collectionsLock) { return _closedChannelIds.ToArray(); } }
+        }
 
         public NovaSshSafeHandle Connect(NativeSshConnectionOptions options) => new(new IntPtr(1), ownsHandle: false);
 
@@ -539,7 +550,7 @@ public sealed class NativePortForwardSessionTests
         {
             lock (_collectionsLock)
             {
-                OpenRequests.Add(options);
+                _openRequests.Add(options);
             }
             return Interlocked.Increment(ref _nextChannelId);
         }
@@ -556,7 +567,7 @@ public sealed class NativePortForwardSessionTests
         {
             lock (_collectionsLock)
             {
-                ClosedChannelIds.Add(channelId);
+                _closedChannelIds.Add(channelId);
             }
         }
 


### PR DESCRIPTION
## Why

The scheduled CI run (`cron: 30 3 * * *`) trips a *different* timing-sensitive test most nights and emails a failure — even though every `push`/merge run on `main` is green. Investigation traced the recurring emails to three distinct causes plus one non-bug.

## Fixes (all test-only, no production code changed)

### 1. SSH `LocalForwardListenersBindFromConfiguredForwards` — real data race
`FakeNativeSshInterop.OpenRequests` / `ClosedChannelIds` are plain `List<T>`, but the two per-listener accept loops (`Task.Run` in `NativePortForwardSession.StartListener`) call `Add` **concurrently**. `List<T>` is not thread-safe — a lost `Add` pins `Count` at 1, so the `WaitUntilAsync` predicate never flips and hangs to its **full 30s ceiling** (exactly the observed failure). The earlier `3s → 30s` bump (9f038f8) only masked this. **Fix:** serialize the writes under a lock. Only this test races; the single-listener tests don't.

### 2. `ReflowStress_Benchmark` — cold-JIT, no warmup
Unlike its sibling `LargeThroughput_Benchmark`, this test had no warmup, so cold-JIT on the first `Resize` calls dominated the 100-iteration average and tipped the 15 ms threshold (observed 18.06 ms). **Fix:** add a warmup pass. Steady-state avg is ~2.3 ms.

### 3. `RustPtySession_FlightRecording_CapturesOutputAndExports` — poll window too tight
Brand-new test; the 10 s poll window is too short for a shell's first bytes on a loaded Windows runner (Defender scan + process-pool saturation). **Fix:** widen the ceiling 10 s → 30 s. The loop breaks the instant output arrives, so there's no happy-path cost.

### Not a bug: Cross-Platform Parity Compare (07-09)
`concurrency: cancel-in-progress` cancelled the in-flight scheduled run when a new push landed. No change needed.

## Verification
- SSH test: **25/25** runs green; full port-forward class **12/12**
- Reflow: **5/5** runs; avg **18 ms → 2.34 ms**
- PTY: **3/3** runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)