### PR TITLE
build(dist): winget package (portable, cert-free) + release auto-submit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,3 +237,32 @@ jobs:
         with:
           tag_name: ${{ needs.release_metadata.outputs.release_tag }}
           files: artifacts/release/NovaTerminal-${{ matrix.rid }}-${{ needs.release_metadata.outputs.release_tag }}.zip
+
+  # Opens a submission PR to microsoft/winget-pkgs for the just-published Windows
+  # zip (portable package; see packaging/winget/). Optional and self-skipping:
+  # runs only on real tag pushes and only when the WINGET_PAT secret is set.
+  #
+  # wingetcreate re-downloads the asset, recomputes the SHA256, and updates the
+  # latest manifest from winget-pkgs — so it requires benyblack.NovaTerminal to
+  # ALREADY exist there. Bootstrap the first version manually (see
+  # packaging/winget/README.md); subsequent releases flow through this job.
+  submit_winget:
+    name: Submit to winget-pkgs
+    runs-on: windows-latest
+    needs: [release_metadata, publish_aot]
+    if: github.event_name == 'push'
+    steps:
+      - name: Submit manifest via wingetcreate
+        shell: pwsh
+        env:
+          WINGET_PAT: ${{ secrets.WINGET_PAT }}
+        run: |
+          if (-not $env:WINGET_PAT) {
+            Write-Host "WINGET_PAT not set; skipping winget-pkgs submission."
+            exit 0
+          }
+          $tag = "${{ needs.release_metadata.outputs.release_tag }}"
+          $ver = $tag.TrimStart('v')
+          $url = "https://github.com/benyblack/NovaTerminal/releases/download/$tag/NovaTerminal-win-x64-$tag.zip"
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          ./wingetcreate.exe update benyblack.NovaTerminal --version $ver --urls "$url" --submit --token $env:WINGET_PAT

--- a/packaging/winget/0.3.0/benyblack.NovaTerminal.installer.yaml
+++ b/packaging/winget/0.3.0/benyblack.NovaTerminal.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: benyblack.NovaTerminal
+PackageVersion: 0.3.0
+
+# NovaTerminal releases ship as self-contained AOT bundles zipped per platform
+# (see .github/workflows/release.yml). There is no signed installer, so the
+# Windows package is delivered as a portable app extracted from the release zip
+# — no code-signing certificate required for winget onboarding.
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: NovaTerminal.exe
+    PortableCommandAlias: nova
+
+# Portable packages install per-user and need no elevation.
+UpgradeBehavior: uninstallPrevious
+
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/benyblack/NovaTerminal/releases/download/v0.3.0/NovaTerminal-win-x64-v0.3.0.zip
+    InstallerSha256: 277F23A78BBD4AD011D344E5577803BD0C3DF276D278671F1C2BD1980A718563
+
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/packaging/winget/0.3.0/benyblack.NovaTerminal.locale.en-US.yaml
+++ b/packaging/winget/0.3.0/benyblack.NovaTerminal.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: benyblack.NovaTerminal
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: Behnam Yousefi
+PublisherUrl: https://github.com/benyblack
+PublisherSupportUrl: https://github.com/benyblack/NovaTerminal/issues
+Author: Behnam Yousefi
+PackageName: NovaTerminal
+PackageUrl: https://github.com/benyblack/NovaTerminal
+License: MIT
+LicenseUrl: https://github.com/benyblack/NovaTerminal/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Behnam Yousefi
+CopyrightUrl: https://github.com/benyblack/NovaTerminal/blob/main/LICENSE
+ShortDescription: A correct, deterministic, cross-platform terminal emulator with a cell-based VT engine, deterministic session replay, and native SSH.
+Description: |-
+  NovaTerminal is a cross-platform terminal emulator built on a cell-based virtual-terminal
+  engine with strong VT/ANSI conformance, deterministic session recording and replay, and a
+  native SSH client (profiles, jump hosts, port forwarding). It is self-contained: this package
+  is a portable build extracted from the official release archive and runs without an installer.
+Moniker: novaterminal
+Tags:
+  - terminal
+  - terminal-emulator
+  - console
+  - ssh
+  - vt
+  - ansi
+  - developer-tools
+  - avalonia
+ReleaseNotesUrl: https://github.com/benyblack/NovaTerminal/releases/tag/v0.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/packaging/winget/0.3.0/benyblack.NovaTerminal.yaml
+++ b/packaging/winget/0.3.0/benyblack.NovaTerminal.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: benyblack.NovaTerminal
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -1,0 +1,85 @@
+# winget packaging
+
+Source-of-truth [winget](https://learn.microsoft.com/windows/package-manager/) manifests for
+NovaTerminal, kept in-repo so each release can regenerate and submit them.
+
+The Windows release ships as a self-contained, AOT-compiled **zip** (see
+`.github/workflows/release.yml`) — there is no signed installer. The manifest therefore packages
+NovaTerminal as a **portable** app extracted from the release zip (`InstallerType: zip`,
+`NestedInstallerType: portable`), which needs **no code-signing certificate**. Once accepted into
+the community repo it installs with:
+
+```
+winget install benyblack.NovaTerminal
+```
+
+## Layout
+
+```
+packaging/winget/<version>/
+  benyblack.NovaTerminal.yaml               # version manifest
+  benyblack.NovaTerminal.installer.yaml     # installer (zip → portable NovaTerminal.exe, alias: nova)
+  benyblack.NovaTerminal.locale.en-US.yaml  # default-locale metadata
+```
+
+`PackageIdentifier` is `benyblack.NovaTerminal`; the portable command alias is `nova`.
+
+## Validate a manifest set locally
+
+On a Windows machine with the winget client:
+
+```powershell
+winget validate --manifest packaging\winget\0.3.0
+# Optional end-to-end install test in a throwaway context:
+winget install --manifest packaging\winget\0.3.0
+```
+
+`winget validate` checks schema and required fields offline. `winget install --manifest` downloads
+the real zip, verifies the SHA256, and installs the portable app — the same checks the community
+repo's CI runs.
+
+## Cutting a manifest for a new release
+
+The only per-release changes are the version, the installer URL, and the SHA256. After the GitHub
+release for `vX.Y.Z` has published its assets:
+
+```powershell
+# From the repo root, with the GitHub CLI authenticated.
+$ver = "X.Y.Z"
+$asset = "NovaTerminal-win-x64-v$ver.zip"
+$url = "https://github.com/benyblack/NovaTerminal/releases/download/v$ver/$asset"
+
+# 1. Download the published asset and compute its hash.
+gh release download "v$ver" --pattern $asset --dir "$env:TEMP\nova-winget" --clobber
+$sha = (Get-FileHash "$env:TEMP\nova-winget\$asset" -Algorithm SHA256).Hash
+
+# 2. Copy the previous version folder and update the three files.
+Copy-Item -Recurse packaging\winget\0.3.0 packaging\winget\$ver
+# In each file: set PackageVersion: X.Y.Z
+# In the installer file: set the new InstallerUrl and InstallerSha256 ($url / $sha)
+# In the locale file: update ReleaseNotesUrl to the vX.Y.Z tag and refresh the description
+#   ONLY once the release actually contains the described features.
+```
+
+`wingetcreate update benyblack.NovaTerminal --version X.Y.Z --urls $url` automates steps 1–2
+(it re-downloads and re-hashes), if you prefer that tool.
+
+## Submitting to the community repo
+
+Fork [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs) and copy the version
+folder to `manifests/b/benyblack/NovaTerminal/<version>/`, or run
+`wingetcreate submit packaging\winget\<version>`. The repo's automation validates the schema,
+downloads the zip, verifies the hash, and installs the portable package in a sandbox. Because the
+package is portable and per-user, it needs no elevation and no signature — but SmartScreen may warn
+on first launch of the unsigned exe; that resolves when code-signing lands (a separate workstream).
+
+## Notes / caveats
+
+- **Version vs. feature drift.** The `0.3.0` manifest describes NovaTerminal *as of that release*.
+  The agent-host surface (observe / status / act / replay export, milestones A1–A4) landed after
+  v0.3.0 and is unreleased at the time of writing; do not advertise those capabilities in a manifest
+  until the release actually contains them (cut a new `vX.Y.Z` first, then a matching manifest).
+- **x64 only.** Releases currently publish `win-x64`. Add an `arm64` installer entry when the
+  release workflow starts producing a `win-arm64` bundle.
+- **Auto-submission (optional follow-up).** A release-workflow step using `wingetcreate` with a
+  PAT can open the winget-pkgs PR automatically on each tag; kept manual for now.

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -53,8 +53,11 @@ $url = "https://github.com/benyblack/NovaTerminal/releases/download/v$ver/$asset
 gh release download "v$ver" --pattern $asset --dir "$env:TEMP\nova-winget" --clobber
 $sha = (Get-FileHash "$env:TEMP\nova-winget\$asset" -Algorithm SHA256).Hash
 
-# 2. Copy the previous version folder and update the three files.
-Copy-Item -Recurse packaging\winget\0.3.0 packaging\winget\$ver
+# 2. Copy the previous version's files into a new folder and update them.
+#    (Create the dir first and copy contents with a wildcard — `Copy-Item -Recurse`
+#    onto an existing dir nests the source folder instead of copying its contents.)
+New-Item -ItemType Directory -Force -Path packaging\winget\$ver | Out-Null
+Copy-Item packaging\winget\0.3.0\* packaging\winget\$ver
 # In each file: set PackageVersion: X.Y.Z
 # In the installer file: set the new InstallerUrl and InstallerSha256 ($url / $sha)
 # In the locale file: update ReleaseNotesUrl to the vX.Y.Z tag and refresh the description


### PR DESCRIPTION
## Summary

First step of the **Distribution** workstream (`docs/agent-host/DIRECTION.md`): a cert-free **winget** package so Windows users can `winget install benyblack.NovaTerminal`. Adds the in-repo manifest set for the current release (v0.3.0) plus an optional, self-skipping release-workflow job to auto-submit future versions.

## Why portable/zip (no installer, no signing)

`release.yml` publishes self-contained AOT bundles as per-platform **zips** — there is no installer, and code-signing is still blocked. So the manifest packages NovaTerminal as a **portable app extracted from the release zip** (`InstallerType: zip` + `NestedInstallerType: portable` → `NovaTerminal.exe`, alias `nova`). Portable packages install per-user, need no elevation, and need no certificate — exactly the cert-free path the roadmap calls viable.

## Contents

- `packaging/winget/0.3.0/` — the three-file manifest set (version / installer / en-US locale), schema **1.6.0**:
  - `PackageIdentifier: benyblack.NovaTerminal`, publisher **Behnam Yousefi**, **MIT**.
  - `InstallerUrl` → the real v0.3.0 asset; `InstallerSha256` computed from the published `NovaTerminal-win-x64-v0.3.0.zip` (verified to match the live download).
  - `winget validate --manifest packaging/winget/0.3.0` → **succeeded** (clean, no warnings).
- `packaging/winget/README.md` — local validation, the mechanical per-release bump (new version + URL + SHA, or `wingetcreate update`), and community-repo submission steps.
- `.github/workflows/release.yml` — new `submit_winget` job (needs `publish_aot`, `if: github.event_name == 'push'`). It runs `wingetcreate update … --submit` to open a winget-pkgs PR for the just-published Windows zip. **Self-skips when `WINGET_PAT` is unset**, so it's inert until you add the secret.

## Accuracy / caveats (called out in the README)

- **Version-vs-feature honesty:** the 0.3.0 manifest describes NovaTerminal *as of v0.3.0*. The agent-host surface (A1–A4) landed after that release and is unreleased, so it is deliberately **not** advertised here — that framing belongs to a future 0.4.0 release + manifest.
- **Bootstrap:** `wingetcreate update` requires the package to already exist in winget-pkgs, so the **first** submission is manual (`wingetcreate submit packaging/winget/0.3.0`, or a fork PR); the workflow job handles every release after that.
- **x64 only** (all the release produces today); add an arm64 installer entry when the workflow emits a `win-arm64` bundle.
- The unsigned exe may trip **SmartScreen** on first launch until code-signing lands (separate workstream).

## Testing

`winget validate` clean against the installed client; `release.yml` re-parses as valid YAML with the new job wired to `publish_aot`. No code changes — nothing else to test.
