### PR TITLE
fix(pty): local shell tab shows blank/blinking cursor (early-output drop race)

### DIFF
--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -1707,15 +1707,19 @@ namespace NovaTerminal.Controls
                 {
                     agentReg.SetLifecycle(session);
 
-                    // Seed the first child-process sample, but OFF the synchronous
-                    // spawn path: ProbeHasActiveChildProcesses() is a full OS
-                    // process-table scan (CreateToolhelp32Snapshot), and running it
-                    // here delayed first-output wiring and paint on every tab open.
-                    // Background priority runs it after the tab is up; the endpoint's
-                    // 1 s sweep keeps the heuristic tier correct regardless.
-                    Dispatcher.UIThread.Post(
-                        () => agentReg.StatusMachine.Sweep(agentReg.ProbeHasActiveChildProcesses()),
-                        DispatcherPriority.Background);
+                    // Seed the first child-process sample, but OFF the UI thread:
+                    // ProbeHasActiveChildProcesses() is a full OS process-table scan
+                    // (CreateToolhelp32Snapshot on Windows, a pgrep spawn elsewhere) —
+                    // blocking I/O that would jank tab creation. It is thread-safe, so
+                    // run the probe on a background thread and post only the Sweep back
+                    // to the UI thread. The endpoint's 1 s sweep corrects it regardless.
+                    Task.Run(() =>
+                    {
+                        var hasChildren = agentReg.ProbeHasActiveChildProcesses();
+                        Dispatcher.UIThread.Post(
+                            () => agentReg.StatusMachine.Sweep(hasChildren),
+                            DispatcherPriority.Background);
+                    });
                 }
             }
             catch (Exception ex)

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -1702,13 +1702,20 @@ namespace NovaTerminal.Controls
                 UpdateCommandAssistContext();
 
                 // Publish the PTY lifecycle to the registration (the endpoint's
-                // sweep probes only this published reference, never the pane)
-                // and seed the first child-process sample immediately so the
-                // heuristic tier is correct from the moment the session exists.
+                // sweep probes only this published reference, never the pane).
                 if (_agentRegistration is { } agentReg)
                 {
                     agentReg.SetLifecycle(session);
-                    agentReg.StatusMachine.Sweep(agentReg.ProbeHasActiveChildProcesses());
+
+                    // Seed the first child-process sample, but OFF the synchronous
+                    // spawn path: ProbeHasActiveChildProcesses() is a full OS
+                    // process-table scan (CreateToolhelp32Snapshot), and running it
+                    // here delayed first-output wiring and paint on every tab open.
+                    // Background priority runs it after the tab is up; the endpoint's
+                    // 1 s sweep keeps the heuristic tier correct regardless.
+                    Dispatcher.UIThread.Post(
+                        () => agentReg.StatusMachine.Sweep(agentReg.ProbeHasActiveChildProcesses()),
+                        DispatcherPriority.Background);
                 }
             }
             catch (Exception ex)

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -69,26 +69,32 @@ namespace NovaTerminal.Pty
             {
                 if (value == null) return;
 
-                string[]? replay = null;
-                lock (_outputHandlerGate)
+                // The invocation lock is the OUTER lock so that wiring the
+                // subscriber AND replaying the buffer is one atomic step against
+                // EmitOutput. This guarantees (a) the non-thread-safe subscriber
+                // (AnsiParser/TerminalBuffer) is never entered from two threads at
+                // once, and (b) buffered startup output is delivered before any
+                // live output — a ProcessLoop emit cannot slip in ahead of the
+                // replay. Lock order is always invocation -> gate (remove takes
+                // only the gate), so there is no inversion.
+                lock (_outputInvocationLock)
                 {
-                    _onOutputReceived += value;
-                    if (!_hasOutputSubscriberEver)
+                    string[]? replay = null;
+                    lock (_outputHandlerGate)
                     {
-                        _hasOutputSubscriberEver = true;
-                        if (_pendingOutputReplay != null)
+                        if (!_hasOutputSubscriberEver)
                         {
-                            replay = _pendingOutputReplay.ToArray();
-                            _pendingOutputReplay = null;
+                            _hasOutputSubscriberEver = true;
+                            if (_pendingOutputReplay != null)
+                            {
+                                replay = _pendingOutputReplay.ToArray();
+                                _pendingOutputReplay = null;
+                            }
                         }
+                        _onOutputReceived += value;
                     }
-                }
 
-                if (replay != null)
-                {
-                    // Hold the invocation lock for the whole batch so a concurrent
-                    // ProcessLoop emit can't interleave ahead of the replay.
-                    lock (_outputInvocationLock)
+                    if (replay != null)
                     {
                         foreach (var text in replay)
                         {
@@ -108,24 +114,26 @@ namespace NovaTerminal.Pty
         }
 
         // Delivers decoded output to the current subscriber, or buffers it for
-        // replay when none has attached yet. Called only from ProcessLoop.
+        // replay when none has attached yet. Called only from ProcessLoop. The
+        // outer invocation lock makes the whole capture-and-invoke atomic against
+        // the add-replay above and other emits, so it never runs before or during
+        // that replay.
         private void EmitOutput(string text)
         {
-            Action<string>? handler;
-            lock (_outputHandlerGate)
-            {
-                handler = _onOutputReceived;
-                if (!_hasOutputSubscriberEver && handler == null)
-                {
-                    _pendingOutputReplay ??= new List<string>();
-                    _pendingOutputReplay.Add(text);
-                    return;
-                }
-            }
-
-            // Serialized against the replay batch above (and other emits).
             lock (_outputInvocationLock)
             {
+                Action<string>? handler;
+                lock (_outputHandlerGate)
+                {
+                    handler = _onOutputReceived;
+                    if (!_hasOutputSubscriberEver && handler == null)
+                    {
+                        _pendingOutputReplay ??= new List<string>();
+                        _pendingOutputReplay.Add(text);
+                        return;
+                    }
+                }
+
                 handler?.Invoke(text);
             }
         }

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -46,7 +46,71 @@ namespace NovaTerminal.Pty
         // UTF-8 decoder with state - handles partial multi-byte sequences across reads
         private readonly Decoder _utf8Decoder = Encoding.UTF8.GetDecoder();
 
-        public event Action<string>? OnOutputReceived;
+        // Output is buffered until the first subscriber attaches, then replayed.
+        // The read/process threads start in the constructor, so a shell's initial
+        // prompt can arrive before the UI wires OnOutputReceived; without this,
+        // ProcessLoop would dequeue-and-drop that output (blinking cursor, no
+        // prompt). Mirrors NativeSshSession's first-subscriber replay.
+        private readonly object _outputHandlerGate = new();
+        private Action<string>? _onOutputReceived;
+        private List<string>? _pendingOutputReplay;
+        private bool _hasOutputSubscriberEver;
+
+        public event Action<string>? OnOutputReceived
+        {
+            add
+            {
+                if (value == null) return;
+
+                List<string>? replay = null;
+                lock (_outputHandlerGate)
+                {
+                    _onOutputReceived += value;
+                    if (!_hasOutputSubscriberEver)
+                    {
+                        _hasOutputSubscriberEver = true;
+                        replay = _pendingOutputReplay;
+                        _pendingOutputReplay = null;
+                    }
+                }
+
+                if (replay != null)
+                {
+                    foreach (var text in replay)
+                    {
+                        value(text);
+                    }
+                }
+            }
+            remove
+            {
+                if (value == null) return;
+                lock (_outputHandlerGate)
+                {
+                    _onOutputReceived -= value;
+                }
+            }
+        }
+
+        // Delivers decoded output to the current subscriber, or buffers it for
+        // replay when none has attached yet. Called only from ProcessLoop.
+        private void EmitOutput(string text)
+        {
+            Action<string>? handler;
+            lock (_outputHandlerGate)
+            {
+                handler = _onOutputReceived;
+                if (!_hasOutputSubscriberEver && handler == null)
+                {
+                    _pendingOutputReplay ??= new List<string>();
+                    _pendingOutputReplay.Add(text);
+                    return;
+                }
+            }
+
+            handler?.Invoke(text);
+        }
+
         public event Action<int>? OnExit;
         public bool IsProcessRunning => Volatile.Read(ref _isExited) == 0 && !_handle.IsClosed && !_handle.IsInvalid;
         public int? ExitCode => _exitCode;
@@ -524,7 +588,7 @@ namespace NovaTerminal.Pty
             {
                 foreach (var text in _outputQueue.GetConsumingEnumerable(_cts.Token))
                 {
-                    OnOutputReceived?.Invoke(text);
+                    EmitOutput(text);
                 }
             }
             catch (OperationCanceledException)

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -51,7 +51,14 @@ namespace NovaTerminal.Pty
         // prompt can arrive before the UI wires OnOutputReceived; without this,
         // ProcessLoop would dequeue-and-drop that output (blinking cursor, no
         // prompt). Mirrors NativeSshSession's first-subscriber replay.
+        // _outputHandlerGate guards the subscriber field and pending buffer.
+        // _outputInvocationLock separately serializes the actual handler calls so
+        // the first-subscriber replay (subscriber thread) and ProcessLoop
+        // (background thread) never invoke the handler — and thus AnsiParser /
+        // TerminalBuffer, which are not thread-safe — concurrently, and so
+        // replayed output always precedes new output.
         private readonly object _outputHandlerGate = new();
+        private readonly object _outputInvocationLock = new();
         private Action<string>? _onOutputReceived;
         private List<string>? _pendingOutputReplay;
         private bool _hasOutputSubscriberEver;
@@ -62,23 +69,31 @@ namespace NovaTerminal.Pty
             {
                 if (value == null) return;
 
-                List<string>? replay = null;
+                string[]? replay = null;
                 lock (_outputHandlerGate)
                 {
                     _onOutputReceived += value;
                     if (!_hasOutputSubscriberEver)
                     {
                         _hasOutputSubscriberEver = true;
-                        replay = _pendingOutputReplay;
-                        _pendingOutputReplay = null;
+                        if (_pendingOutputReplay != null)
+                        {
+                            replay = _pendingOutputReplay.ToArray();
+                            _pendingOutputReplay = null;
+                        }
                     }
                 }
 
                 if (replay != null)
                 {
-                    foreach (var text in replay)
+                    // Hold the invocation lock for the whole batch so a concurrent
+                    // ProcessLoop emit can't interleave ahead of the replay.
+                    lock (_outputInvocationLock)
                     {
-                        value(text);
+                        foreach (var text in replay)
+                        {
+                            value(text);
+                        }
                     }
                 }
             }
@@ -108,7 +123,11 @@ namespace NovaTerminal.Pty
                 }
             }
 
-            handler?.Invoke(text);
+            // Serialized against the replay batch above (and other emits).
+            lock (_outputInvocationLock)
+            {
+                handler?.Invoke(text);
+            }
         }
 
         public event Action<int>? OnExit;

--- a/tests/NovaTerminal.App.Tests/PtySmokeTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtySmokeTests.cs
@@ -50,13 +50,15 @@ namespace NovaTerminal.Tests
 
             // The buffered startup output replays synchronously on subscribe; give a
             // brief grace window for any straggling chunk, then assert none was lost.
-            for (int i = 0; i < 20 && sb.Length == 0; i++)
+            // Read length under the same lock the subscriber writes under.
+            int len = 0;
+            for (int i = 0; i < 20; i++)
             {
+                lock (sb) { len = sb.Length; }
+                if (len > 0) break;
                 await Task.Delay(100);
             }
 
-            int len;
-            lock (sb) { len = sb.Length; }
             Assert.True(len > 0, "late subscriber received no startup output — early output was dropped");
         }
 

--- a/tests/NovaTerminal.App.Tests/PtySmokeTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtySmokeTests.cs
@@ -2,6 +2,7 @@ using NovaTerminal.Shell;
 using System;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using NovaTerminal.Platform;
 using NovaTerminal.VT;
@@ -24,6 +25,39 @@ namespace NovaTerminal.Tests
             session.Resize(100, 30);
             session.SendInput("\r");
             await Task.Delay(150);
+        }
+
+        [Fact]
+        [Trait("Category", "PtySmoke")]
+        public async Task RustPtySession_LateSubscriber_ReceivesBufferedStartupOutput()
+        {
+            // Regression: the read/process threads start in the constructor, so a
+            // shell's initial prompt/banner can be produced before the UI wires
+            // OnOutputReceived. Before the fix, ProcessLoop dequeued-and-dropped
+            // that output when no subscriber was attached (blinking cursor, no
+            // prompt). Output must now be buffered and replayed to a late subscriber.
+            string shell = ShellHelper.GetDefaultShell();
+            using var session = new RustPtySession(shell, 80, 24);
+
+            // Let the shell start and emit its prompt/banner *before* subscribing.
+            await Task.Delay(1500);
+
+            var sb = new StringBuilder();
+            session.OnOutputReceived += t =>
+            {
+                lock (sb) { sb.Append(t); }
+            };
+
+            // The buffered startup output replays synchronously on subscribe; give a
+            // brief grace window for any straggling chunk, then assert none was lost.
+            for (int i = 0; i < 20 && sb.Length == 0; i++)
+            {
+                await Task.Delay(100);
+            }
+
+            int len;
+            lock (sb) { len = sb.Length; }
+            Assert.True(len > 0, "late subscriber received no startup output — early output was dropped");
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

Fixes an intermittent startup bug where a freshly opened **local** shell tab (PowerShell, WSL, cmd) shows only a blinking cursor with no prompt. Root-cause fix plus removal of the regression that made it surface.

## Root cause

`RustPtySession` starts its read/process threads in its constructor, so a shell's initial prompt can be produced **before** `TerminalPane.InitializeSession` wires `OnOutputReceived`. `ProcessLoop` did `OnOutputReceived?.Invoke(text)` — with no subscriber attached yet, that output was **dequeued and dropped**. Timing-dependent, hence intermittent; local-shell-only because `NativeSshSession` already buffers-and-replays early output to its first subscriber and `RustPtySession` did not.

It started showing up on latest `main` because A3/A4 added a synchronous `ProbeHasActiveChildProcesses()` — a full `CreateToolhelp32Snapshot` process-table scan — on the UI thread between session construction and the `OnOutputReceived` subscription, which widened the drop window (worse on first launch / busy machines).

## Fix

1. **`RustPtySession`: buffer output until the first subscriber, then replay** — the same first-subscriber replay pattern `NativeSshSession` already uses (`_pendingOutputReplay` / `_hasOutputSubscriberEver` under `_outputHandlerGate`, custom `add`/`remove`, and an `EmitOutput` helper called from `ProcessLoop`). This closes the race regardless of subscription timing; no early output can be lost.
2. **`TerminalPane`: defer the child-process probe off the synchronous spawn path** — `ProbeHasActiveChildProcesses()`/`Sweep` now run via `Dispatcher.UIThread.Post(..., Background)` instead of blocking tab creation. Removes the process-table scan I added to every tab open (a jank regression on its own) and stops it delaying first paint. The endpoint's 1 s sweep keeps the status tier correct.

## Testing

New `RustPtySession_LateSubscriber_ReceivesBufferedStartupOutput` (PtySmoke): starts a real shell, waits 1.5 s so the prompt is produced, subscribes **late**, and asserts the buffered startup output is still delivered. Fails on the pre-fix code (output dropped), passes now.

Local: App.Tests (PtySmoke + PtyThreadLifecycle + AgentHost filter) 108/108; full-solution build clean.

## Notes

- The replay buffer makes the exact subscription timing in `InitializeSession` no longer correctness-critical, so I left the `OnOutputReceived += …` where it is (moving it earlier risked a `Parser`-initialization ordering issue).
- SSH sessions were never affected (they already had the replay buffer).
