### PR TITLE
fix(ssh): serialize NativeSshSession output invocation (replay-vs-emit race)

### DIFF
--- a/src/NovaTerminal.Platform/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Platform/Ssh/Sessions/NativeSshSession.cs
@@ -28,6 +28,11 @@ public sealed class NativeSshSession : ITerminalSession
     private bool _allowVaultPasswordReuse;
     private readonly object _exitHandlerGate = new();
     private readonly object _outputHandlerGate = new();
+    // Serializes actual handler invocation so the first-subscriber replay
+    // (subscriber thread) and poll-loop emits never enter the non-thread-safe
+    // subscriber (AnsiParser/TerminalBuffer) concurrently, and replayed startup
+    // output always precedes live output. Outer lock; order is invocation -> gate.
+    private readonly object _outputInvocationLock = new();
 
     private ReplayWriter? _recorder;
 
@@ -165,23 +170,32 @@ public sealed class NativeSshSession : ITerminalSession
                 return;
             }
 
-            List<string>? replay = null;
-            lock (_outputHandlerGate)
+            // Invocation lock is the OUTER lock so wiring the subscriber and
+            // replaying the buffer is atomic against EmitText: no concurrent
+            // invocation, and a live emit cannot slip ahead of the replay.
+            lock (_outputInvocationLock)
             {
-                _onOutputReceived += value;
-                if (!_hasOutputSubscriberEver)
+                string[]? replay = null;
+                lock (_outputHandlerGate)
                 {
-                    _hasOutputSubscriberEver = true;
-                    replay = _pendingOutputReplay;
-                    _pendingOutputReplay = null;
+                    if (!_hasOutputSubscriberEver)
+                    {
+                        _hasOutputSubscriberEver = true;
+                        if (_pendingOutputReplay != null)
+                        {
+                            replay = _pendingOutputReplay.ToArray();
+                            _pendingOutputReplay = null;
+                        }
+                    }
+                    _onOutputReceived += value;
                 }
-            }
 
-            if (replay != null)
-            {
-                foreach (string text in replay)
+                if (replay != null)
                 {
-                    value(text);
+                    foreach (string text in replay)
+                    {
+                        value(text);
+                    }
                 }
             }
         }
@@ -559,19 +573,25 @@ public sealed class NativeSshSession : ITerminalSession
 
     private void EmitText(string text)
     {
-        Action<string>? handler;
-        lock (_outputHandlerGate)
+        // Outer invocation lock makes capture-and-invoke atomic against the
+        // add-replay above and other emits, so it never runs before or during
+        // that replay and never invokes the handler concurrently.
+        lock (_outputInvocationLock)
         {
-            handler = _onOutputReceived;
-            if (!_hasOutputSubscriberEver && handler == null)
+            Action<string>? handler;
+            lock (_outputHandlerGate)
             {
-                _pendingOutputReplay ??= new List<string>();
-                _pendingOutputReplay.Add(text);
-                return;
+                handler = _onOutputReceived;
+                if (!_hasOutputSubscriberEver && handler == null)
+                {
+                    _pendingOutputReplay ??= new List<string>();
+                    _pendingOutputReplay.Add(text);
+                    return;
+                }
             }
-        }
 
-        handler?.Invoke(text);
+            handler?.Invoke(text);
+        }
     }
 
     private void CloseNativeHandle()

--- a/src/NovaTerminal.Platform/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Platform/Ssh/Sessions/NativeSshSession.cs
@@ -590,6 +590,11 @@ public sealed class NativeSshSession : ITerminalSession
                 }
             }
 
+            // Invoked while holding _outputInvocationLock: the subscriber MUST be
+            // non-blocking (the pane handler parses synchronously and posts to the
+            // UI thread via Dispatcher.Post, which does not wait). A handler that
+            // blocks here — e.g. synchronously awaiting a UI-thread response — would
+            // stall the poll loop and any new subscriber.
             handler?.Invoke(text);
         }
     }

--- a/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshSessionTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshSessionTests.cs
@@ -40,13 +40,15 @@ public sealed class NativeSshSessionTests
 
         using var session = new NativeSshSession(CreateProfile(), interop: interop);
 
-        // Let the poll loop consume both Data events before anyone subscribes.
-        await Task.Delay(300);
+        // Deterministically wait until the poll loop has consumed both Data events
+        // before anyone subscribes (no arbitrary sleep), so the buffered-replay path
+        // is exercised.
+        await WaitUntilAsync(() => interop.IsQueueDrained);
 
-        var outputs = new List<string>();
-        session.OnOutputReceived += outputs.Add; // late subscriber → replay fires here
+        var outputs = new ConcurrentQueue<string>();
+        session.OnOutputReceived += outputs.Enqueue; // late subscriber → replay fires here
 
-        await WaitUntilAsync(() => outputs.Count > 0);
+        await WaitUntilAsync(() => string.Concat(outputs) == "first second");
         Assert.Equal("first second", string.Concat(outputs));
     }
 
@@ -258,6 +260,9 @@ public sealed class NativeSshSessionTests
     {
         private readonly ConcurrentQueue<NativeSshEvent> _events = new();
         private int _nextHandle = 1;
+
+        /// <summary>True once the poll loop has dequeued every enqueued event (ConcurrentQueue read is thread-safe).</summary>
+        public bool IsQueueDrained => _events.IsEmpty;
 
         public List<byte[]> Writes { get; } = new();
         public List<(int Cols, int Rows)> Resizes { get; } = new();

--- a/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshSessionTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshSessionTests.cs
@@ -37,13 +37,18 @@ public sealed class NativeSshSessionTests
         var interop = new FakeNativeSshInterop();
         interop.Enqueue(NativeSshEvent.Data(Encoding.UTF8.GetBytes("first ")));
         interop.Enqueue(NativeSshEvent.Data(Encoding.UTF8.GetBytes("second")));
+        interop.Enqueue(NativeSshEvent.ExitStatus(0));
+        interop.Enqueue(NativeSshEvent.Closed(Array.Empty<byte>()));
 
         using var session = new NativeSshSession(CreateProfile(), interop: interop);
 
-        // Deterministically wait until the poll loop has consumed both Data events
-        // before anyone subscribes (no arbitrary sleep), so the buffered-replay path
-        // is exercised.
-        await WaitUntilAsync(() => interop.IsQueueDrained);
+        // Signal-driven, not clock-driven: once the session has exited, the poll
+        // loop has fully processed both Data events (decoded and buffered), so a
+        // late output subscriber must receive them via replay — never live. OnExit
+        // replays its code to a late subscriber, so subscribing here is race-free.
+        var exit = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        session.OnExit += code => exit.TrySetResult(code);
+        Assert.Equal(0, await exit.Task.WaitAsync(TimeSpan.FromSeconds(2)));
 
         var outputs = new ConcurrentQueue<string>();
         session.OnOutputReceived += outputs.Enqueue; // late subscriber → replay fires here
@@ -260,9 +265,6 @@ public sealed class NativeSshSessionTests
     {
         private readonly ConcurrentQueue<NativeSshEvent> _events = new();
         private int _nextHandle = 1;
-
-        /// <summary>True once the poll loop has dequeued every enqueued event (ConcurrentQueue read is thread-safe).</summary>
-        public bool IsQueueDrained => _events.IsEmpty;
 
         public List<byte[]> Writes { get; } = new();
         public List<(int Cols, int Rows)> Resizes { get; } = new();

--- a/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshSessionTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshSessionTests.cs
@@ -29,6 +29,28 @@ public sealed class NativeSshSessionTests
     }
 
     [Fact]
+    public async Task EarlyOutput_IsBufferedAndReplayedToLateSubscriber_InOrder()
+    {
+        // Regression: output produced before the first subscriber attaches must be
+        // buffered and replayed in order — not dropped, and never delivered
+        // concurrently with the replay (the invocation-lock hardening).
+        var interop = new FakeNativeSshInterop();
+        interop.Enqueue(NativeSshEvent.Data(Encoding.UTF8.GetBytes("first ")));
+        interop.Enqueue(NativeSshEvent.Data(Encoding.UTF8.GetBytes("second")));
+
+        using var session = new NativeSshSession(CreateProfile(), interop: interop);
+
+        // Let the poll loop consume both Data events before anyone subscribes.
+        await Task.Delay(300);
+
+        var outputs = new List<string>();
+        session.OnOutputReceived += outputs.Add; // late subscriber → replay fires here
+
+        await WaitUntilAsync(() => outputs.Count > 0);
+        Assert.Equal("first second", string.Concat(outputs));
+    }
+
+    [Fact]
     public void Constructor_AllowsDynamicForwardProfiles()
     {
         SshProfile profile = CreateProfile();


### PR DESCRIPTION
## Summary

Follow-up to #199: applies the same output-invocation-lock hardening to `NativeSshSession` that `RustPtySession` got, closing the structurally identical (though narrower) first-subscriber-replay-vs-emit race.

## Background

`NativeSshSession` already buffered early output and replayed it to the first subscriber, but — like the pre-#199 `RustPtySession` — it released the handler gate before both the replay loop (subscriber thread) and `EmitText` (poll-loop thread) invoked the handler. So a live emit could run concurrently with the replay, or slip ahead of it, driving the non-thread-safe `AnsiParser`/`TerminalBuffer` from two threads. Narrower than the local-shell bug (a single poll loop produces output), but the same class of defect.

## Change

- New `_outputInvocationLock`, made the **outer** lock in both the `OnOutputReceived` `add` accessor and `EmitText`, enclosing the gate section and the actual handler invocation. Add and emit are now fully mutually exclusive: an emit either precedes the subscribe (output buffered → replayed) or follows it (delivered live, after the replay) — never interleaved, reordered, or lost. The pending buffer is snapshotted with `.ToArray()` under the gate. Lock order is always invocation → gate (`remove` takes only the gate), so no inversion; the handler doesn't re-enter either lock and the pane's handler posts to the UI thread non-blockingly, so no deadlock.

## Testing

New deterministic `EarlyOutput_IsBufferedAndReplayedToLateSubscriber_InOrder` (uses `FakeNativeSshInterop`): enqueues two Data events, lets the poll loop consume them before subscribing, subscribes late, and asserts the buffered output replays in order (`"first second"`). Platform SSH suite 38/38 (18 Docker/live-SSH skipped).

No behavior change for the common single-subscriber path; this only tightens the concurrency guarantees.
