### PR TITLE
feat(agent-host): send_input 'submit' flag for reliable Enter (CR)

### DIFF
--- a/src/NovaTerminal.AgentHost.Contracts/ActContracts.cs
+++ b/src/NovaTerminal.AgentHost.Contracts/ActContracts.cs
@@ -16,6 +16,19 @@ public sealed record SendInputParams
     /// </summary>
     [JsonPropertyName("text")]
     public required string Text { get; init; }
+
+    /// <summary>
+    /// When true, a single carriage return (U+000D) is appended after
+    /// <see cref="Text"/> — the byte a console treats as "Enter". This is the
+    /// reliable way for an agent to submit a command: many callers cannot emit a
+    /// raw 0x0D through their tool-argument encoding (a literal newline arrives as
+    /// a line feed, which PSReadLine treats as a soft line-continuation, and the
+    /// "\r" escape often arrives as two literal characters). <see cref="Text"/>
+    /// itself is still sent byte-faithfully; this only controls the trailing CR.
+    /// Defaults to false.
+    /// </summary>
+    [JsonPropertyName("submit")]
+    public bool Submit { get; init; }
 }
 
 /// <summary>Result payload for <c>sendInput</c>.</summary>

--- a/src/NovaTerminal.App/AgentHost/AgentHostService.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentHostService.cs
@@ -771,8 +771,14 @@ namespace NovaTerminal.AgentHost
                     Error(request.Id, AgentHostProtocol.ErrorCodes.MalformedRequest, "sendInput requires params with a paneId and text."));
             }
 
+            // Optional trailing CR (0x0D) — the byte a console treats as "Enter".
+            // Text stays byte-faithful; submit only appends the carriage return
+            // that many agent callers cannot emit as a raw 0x0D. See
+            // SendInputParams.Submit.
+            string payload = p.Submit ? p.Text + "\r" : p.Text;
+
             // Size cap before any lookup so a flood is rejected cheaply.
-            int byteCount = Encoding.UTF8.GetByteCount(p.Text);
+            int byteCount = Encoding.UTF8.GetByteCount(payload);
             if (byteCount > AgentHostProtocol.MaxSendInputBytes)
             {
                 return Journaled(request, AgentHostProtocol.Methods.SendInput, p.PaneId, "input",
@@ -806,7 +812,7 @@ namespace NovaTerminal.AgentHost
                 }
             }
 
-            if (!registration.TrySendInput(p.Text))
+            if (!registration.TrySendInput(payload))
             {
                 return Journaled(request, AgentHostProtocol.Methods.SendInput, p.PaneId, registration.ProfileName,
                     Error(request.Id, AgentHostProtocol.ErrorCodes.SessionNotRunning,

--- a/src/NovaTerminal.McpServer/Tools/SessionTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/SessionTools.cs
@@ -163,11 +163,12 @@ public static class SessionTools
     }
 
     [McpServerTool(Name = "novaterminal.send_input"),
-     Description("Types input into a live NovaTerminal session, exactly as a human would at the keyboard — the bytes are queued to the terminal and recorded like any keystroke. Use for driving an interactive program or answering a prompt. 'text' may include control characters (e.g. \\u0003 for Ctrl-C, \\r for Enter). This is an ACTING tool: it requires the user to have enabled BOTH 'Agent access (observe)' and its 'Agent access (act)' sub-toggle in NovaTerminal settings; SSH sessions must also be individually allowlisted. Every call (allowed or denied) is shown in the app's agent activity journal. Get paneId from novaterminal.list_sessions.")]
+     Description("Types input into a live NovaTerminal session, exactly as a human would at the keyboard — the bytes are queued to the terminal and recorded like any keystroke. Use for driving an interactive program or answering a prompt. 'text' is sent byte-for-byte and may include control characters (e.g. \\u0003 for Ctrl-C). To submit a command, set submit=true to append a carriage return (Enter) — do NOT rely on putting a newline in 'text': it arrives as a line feed, which PowerShell/PSReadLine treats as a soft line-continuation rather than the carriage return a console treats as Enter. This is an ACTING tool: it requires the user to have enabled BOTH 'Agent access (observe)' and its 'Agent access (act)' sub-toggle in NovaTerminal settings; SSH sessions must also be individually allowlisted. Every call (allowed or denied) is shown in the app's agent activity journal. Get paneId from novaterminal.list_sessions.")]
     public static async Task<string> SendInput(
         AgentHostClient client,
         [Description("The pane id (GUID) from novaterminal.list_sessions.")] string paneId,
-        [Description("Text to type. Control characters allowed (\\u0003 = Ctrl-C, \\r = Enter). Sent verbatim; no newline is added.")] string text,
+        [Description("Text to type, sent byte-for-byte (control characters allowed, e.g. \\u0003 = Ctrl-C). No newline is added; use submit=true to press Enter.")] string text,
+        [Description("If true, append a carriage return (Enter) after the text to submit it. This is the reliable way to run a command, since most agents cannot emit a raw carriage return in 'text' themselves. Default false.")] bool submit = false,
         CancellationToken cancellationToken = default)
     {
         if (!Guid.TryParse(paneId, out var pane))
@@ -180,7 +181,7 @@ public static class SessionTools
         }
 
         var parameters = JsonSerializer.SerializeToElement(
-            new SendInputParams { PaneId = pane, Text = text },
+            new SendInputParams { PaneId = pane, Text = text, Submit = submit },
             AgentHostJsonContext.Default.SendInputParams);
         var outcome = await client.CallAsync(AgentHostProtocol.Methods.SendInput, parameters, cancellationToken).ConfigureAwait(false);
         if (!TryUnwrap(outcome, out var result, out var error)) return error;

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentHostActProtocolTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentHostActProtocolTests.cs
@@ -169,6 +169,46 @@ public class AgentHostActProtocolTests
     }
 
     [Fact]
+    public void SendInput_with_submit_appends_a_single_carriage_return()
+    {
+        // Agents can rarely emit a raw 0x0D through their tool-argument encoding;
+        // submit=true is the reliable "press Enter". Text stays byte-faithful and
+        // exactly one CR (no LF) is appended.
+        var registry = new AgentSessionRegistry();
+        var session = new InputStubSession();
+        var reg = Register(registry, "local", session);
+        using var service = NewService(registry, new AgentActivityJournal());
+        service.ActEnabled = true;
+
+        var json = JsonSerializer.Serialize(
+            new SendInputParams { PaneId = reg.PaneId, Text = "echo hi", Submit = true },
+            AgentHostJsonContext.Default.SendInputParams);
+        var line = $"{{\"v\":{AgentHostProtocol.Version},\"id\":1,\"method\":\"{AgentHostProtocol.Methods.SendInput}\",\"params\":{json}}}";
+        var response = Handle(service, line);
+
+        Assert.Null(response.Error);
+        Assert.Equal("echo hi\r", Assert.Single(session.Inputs)); // one trailing CR, no LF
+        var result = response.Result!.Value.Deserialize(AgentHostJsonContext.Default.SendInputResult);
+        Assert.Equal(Encoding.UTF8.GetByteCount("echo hi") + 1, result!.BytesSent); // CR counted
+    }
+
+    [Fact]
+    public void SendInput_without_submit_appends_nothing()
+    {
+        var registry = new AgentSessionRegistry();
+        var session = new InputStubSession();
+        var reg = Register(registry, "local", session);
+        using var service = NewService(registry, new AgentActivityJournal());
+        service.ActEnabled = true;
+
+        // Default (submit omitted → false): text reaches the session verbatim.
+        var response = Handle(service, SendInputLine(reg.PaneId, "echo hi"));
+
+        Assert.Null(response.Error);
+        Assert.Equal("echo hi", Assert.Single(session.Inputs)); // no trailing CR
+    }
+
+    [Fact]
     public void SendInput_to_allowlisted_ssh_session_succeeds()
     {
         var registry = new AgentSessionRegistry();

--- a/tests/NovaTerminal.McpServer.Tests/AgentHostClientTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/AgentHostClientTests.cs
@@ -389,7 +389,7 @@ public class SessionToolsFormattingTests
     public async Task SendInput_rejects_a_non_guid_pane_before_any_ipc()
     {
         var client = new AgentHostClient(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "nothing.json"));
-        var text = await SessionTools.SendInput(client, "not-a-guid", "ls\r", TestContext.Current.CancellationToken);
+        var text = await SessionTools.SendInput(client, "not-a-guid", "ls\r", cancellationToken: TestContext.Current.CancellationToken);
         Assert.StartsWith("Error: 'not-a-guid' is not a valid pane id", text, StringComparison.Ordinal);
     }
 
@@ -399,7 +399,7 @@ public class SessionToolsFormattingTests
         // No live endpoint (discovery file absent): the acting call must return
         // the unavailable guidance, not throw.
         var client = new AgentHostClient(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "nothing.json"));
-        var text = await SessionTools.SendInput(client, Guid.NewGuid().ToString(), "ls\r", TestContext.Current.CancellationToken);
+        var text = await SessionTools.SendInput(client, Guid.NewGuid().ToString(), "ls\r", cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(AgentHostClient.UnavailableMessage, text);
     }
 


### PR DESCRIPTION
## Problem

`send_input` is byte-faithful and correct, but agents cannot reliably deliver a raw carriage return (0x0D) — the only byte PowerShell/PSReadLine accepts as "Enter":

- a literal newline in `text` arrives as **LF (0x0A)** → PSReadLine treats it as a soft line-continuation (`>>`), so the command never runs;
- the `\r` escape usually arrives as the **two literal characters** `\` `r`, which get typed as text.

Verified live over the MCP on a pwsh session: LF → continuation; `\r` → literal chars; a genuine 0x0D → submits. So the gap is caller ergonomics, not the handler.

## Change

Add an optional **`submit`** bool to `SendInputParams` and the `send_input` MCP tool. When true, a single CR (0x0D) is appended **after** the still-byte-faithful `text`; `bytesSent` counts it. `text` itself is untouched (the existing byte-faithful acceptance test still holds). Also corrects the misleading `\r = Enter … verbatim` wording in the tool/param descriptions.

Rejected the alternative of decoding C-style escapes inside `text` — it would break the byte-faithful contract and make a literal `\r` unsendable.

## Testing

- `SendInput_with_submit_appends_a_single_carriage_return` — asserts exactly one CR (no LF) reaches `ITerminalSession.SendInput`, and `bytesSent == text+1`.
- `SendInput_without_submit_appends_nothing` — default stays verbatim.
- `NovaTerminal.App.Tests` AgentHost act suite: 25/25 pass (Release).
