### PR TITLE
docs(agent-host): known-limitations, smoke-test, keychain runbook + get_session_status caveat

### DIFF
--- a/docs/agent-host/known-limitations.md
+++ b/docs/agent-host/known-limitations.md
@@ -1,0 +1,58 @@
+# Agent host — known limitations
+
+Current limitations of the agent-host surface (A1–A4). None are correctness bugs
+in the deterministic core; they are boundaries of what the current signals can
+observe. Tracked against the DIRECTION follow-ups.
+
+## Heuristic session status can't see inside WSL or remote SSH
+
+`novaterminal.get_session_status` (and the status column in `list_sessions`) has
+two confidence tiers:
+
+- **precise** — driven by shell-integration events (prompt / command lifecycle).
+  Accurate regardless of where the process runs.
+- **heuristic** — inferred from PTY signals, primarily "does the shell have an
+  active child process?" via the OS process tree.
+
+The heuristic child-process probe only sees processes in the **host OS** process
+tree. It therefore **cannot see**:
+
+- processes running inside a **WSL** distribution (they live in the WSL VM's
+  Linux namespace, not as Windows children of the launched `wsl.exe`), or
+- processes running on a **remote SSH** host.
+
+Consequence: a genuinely-running command in a WSL or SSH session may report
+`awaitingInput` / `idle` at **heuristic** confidence, even though it is busy.
+The reported tier always says `heuristic` in that case, which is the signal to
+treat running/idle as a guess.
+
+**Accurate today:**
+- Native local shells (`cmd`, PowerShell) — a running command is a real host-OS
+  child process, so status is correct even at the heuristic tier.
+- Any session with **shell integration enabled** — it reports at the **precise**
+  tier from prompt/command events, which is accurate for WSL and SSH too.
+
+**Workarounds:**
+- Enable shell integration in the shell (including inside WSL / on the remote)
+  to get precise status.
+- Use `wait_for_events` / `read_screen` to corroborate rather than relying on the
+  heuristic running/idle alone.
+
+**Planned fix:** foreground-process reporting for the heuristic tier
+(DIRECTION A2 follow-up) — query the foreground process inside the WSL distro /
+over the SSH channel so the heuristic tier is accurate there too.
+
+## Other parked follow-ups
+
+From `docs/agent-host/DIRECTION.md` and the milestone design docs:
+
+- **OS-native completion notifications** — A2 currently shows an in-app toast
+  only; native OS notification backends are a follow-up.
+- **`Idle` transitions surface only via the 1 s sweep** — an idle transition is
+  observed on the next sweep tick, not instantaneously.
+- **Replay `--replay --at <ms>` / PNG output** — A4 ships headless
+  render-to-text of the final screen; frame-stepping and image output are
+  out of scope for now (Virtual fast-forward already covers most of it).
+- **CLI not in the release bundle** — `NovaTerminal.Cli` (which hosts
+  `--replay`) is present in local builds but not yet in the published release
+  zip; a pre-0.4.0 packaging fix will include it.

--- a/docs/agent-host/smoke-test-0.4.0.md
+++ b/docs/agent-host/smoke-test-0.4.0.md
@@ -1,0 +1,138 @@
+# Agent-host smoke test (pre-0.4.0)
+
+Manual verification of A1–A4 on a real build before tagging 0.4.0. Layered — stop
+after any layer. Each check lists the action, the expected result, and the red flag.
+
+Paths assume the repo at its current location; adjust as needed. Config/state lives
+under `%LOCALAPPDATA%\NovaTerminal` (settings.json, agent-endpoint.json, recordings\).
+
+## 0. Build & launch
+
+- [ ] Build everything:
+  ```
+  scripts/build.ps1 build NovaTerminal.sln
+  ```
+  Expected: 0 errors. Red flag: any error (a warning flood is normal).
+
+- [ ] Launch the app (run the built exe directly — the wrapper doesn't do `run`):
+  ```
+  src\NovaTerminal.App\bin\Debug\net10.0\NovaTerminal.exe
+  ```
+  Expected: window opens, a shell tab is live. Red flag: crash → check
+  `%LOCALAPPDATA%\NovaTerminal\logs\startup_error.txt`.
+
+- [ ] Build the MCP server (Release) and wire it to Claude Code:
+  ```
+  scripts/build.ps1 build -c Release src/NovaTerminal.McpServer
+  claude mcp add novaterminal -- dotnet "<REPO>\src\NovaTerminal.McpServer\bin\Release\net10.0\NovaTerminal.McpServer.dll"
+  ```
+  (Any MCP client works; do NOT use `dotnet run` — it corrupts stdio.) In a Claude
+  Code session, confirm the `novaterminal.*` tools appear.
+
+## 1. Off-is-off (default state)
+
+With **all** agent toggles off (fresh settings):
+
+- [ ] Ask the agent: run `novaterminal.list_sessions`.
+  Expected: the "unavailable / enable Agent access (observe)" guidance, not data.
+- [ ] Confirm there is **no** `%LOCALAPPDATA%\NovaTerminal\agent-endpoint.json` (or it is
+  empty). Red flag: an endpoint file exists while observe is off.
+
+## 2. Settings toggles persist (UI)
+
+Settings → the Agent access rows:
+
+- [ ] Verify three toggles exist: **Agent access (observe)**, **Agent replay
+  export** (indented), **Agent access (act)** (indented). Toggle observe on, others
+  off; Save.
+- [ ] Reopen Settings — observe still on. Check `%LOCALAPPDATA%\NovaTerminal\settings.json`:
+  `AgentAccessObserveEnabled: true`, `AgentReplayExportEnabled: false`,
+  `AgentAccessActEnabled: false`. Red flag: values don't round-trip.
+- [ ] With observe now on, `agent-endpoint.json` appears next to settings.json.
+
+## 3. Observe + status (A1/A2) — observe ON only
+
+Have a couple of tabs open; run something interactive (e.g. `vim` or a `ping -t`).
+
+- [ ] `novaterminal.list_sessions` → lists panes with paneId, title, kind, size,
+  status. Red flag: empty while tabs are open, or wrong kind.
+- [ ] `novaterminal.read_screen <paneId>` → the visible grid matches what you see,
+  including cursor position. Red flag: stale/garbled content, wrong wrapping.
+- [ ] `novaterminal.read_scrollback <paneId>` → history lines, oldest first.
+- [ ] Start a long command (`ping -n 20 localhost`), then
+  `novaterminal.get_session_status <paneId>` → `running`; after it finishes →
+  `idle`/`awaitingInput`. Red flag: status stuck on the wrong state.
+- [ ] `novaterminal.wait_for_events` with the long command running → returns a
+  `commandFinished` (or status) event when it completes, rather than timing out
+  every call. Red flag: never delivers the completion event.
+
+## 4. Replay export (A4) — enable "Agent replay export"
+
+- [ ] With observe + replay-export on, produce some output in a pane, then
+  `novaterminal.export_replay <paneId>`.
+  Expected: returns a path under `%LOCALAPPDATA%\NovaTerminal\recordings\agent-exports\`
+  and an event count. Red flag: `exportDisabled` (toggle didn't apply) or a path
+  that doesn't exist.
+- [ ] Confirm the file exists and, opening it, that it contains `data`/`resize`
+  lines but **no `input` lines** (privacy). Red flag: any `"type":"input"`.
+- [ ] Replay it headlessly through the CLI:
+  ```
+  dotnet src\NovaTerminal.Cli\bin\Debug\net10.0\NovaTerminal.Cli.dll --replay "<exported .rec path>"
+  ```
+  Expected: prints the final screen; exit code 0. Red flag: crash, or an empty
+  screen for a session that clearly had output.
+- [ ] Turn "Agent replay export" **off**, retry `export_replay` → `exportDisabled`.
+
+## 5. Act gating (A3) — the security-critical checks
+
+**5a. Act still OFF (observe on):**
+- [ ] `novaterminal.send_input` (any paneId, text `"echo hi\r"`) → **`actDisabled`**;
+  nothing is typed into the terminal. Red flag: the text actually runs.
+- [ ] `novaterminal.spawn_session` and `novaterminal.close_session` likewise →
+  `actDisabled`.
+
+**5b. Turn "Agent access (act)" ON:**
+- [ ] `send_input <local paneId>` `"echo agent-was-here\r"` → the command runs in
+  that pane; result reports bytes sent. Red flag: nothing typed, or wrong pane.
+- [ ] `spawn_session` (no profile) → a new tab opens; returns a paneId. `spawn_session`
+  with a **local profile name** → tab for that profile.
+- [ ] `close_session <paneId>` → that pane/tab closes **without** a confirmation
+  dialog. Red flag: a modal blocks it, or it reports success but the pane stays.
+
+**5c. SSH allowlist (no live host needed):**
+- [ ] Create an SSH connection profile (host can be anything). Leave "Allow AI agent
+  access to this connection" (Advanced tab) **unchecked**.
+- [ ] `spawn_session "<that SSH profile name>"` → **`profileNotAllowed`**; no tab
+  opens. Red flag: it opens/connects anyway.
+- [ ] Check the box, Save, retry → the spawn is permitted (the tab opens even if the
+  host is unreachable; a connect error in the pane is fine — the gate passed).
+- [ ] Uncheck it again, Save, edit any other field, Save, reopen → the box is still
+  unchecked (revoke sticks; the allowlist round-trips).
+
+## 6. Activity journal (A3) — "nothing is silent"
+
+- [ ] New-tab menu (`+`) → **Agent Activity…** opens a window.
+- [ ] It lists the recent actions from steps 5a/5b — including the **denied**
+  `actDisabled` / `profileNotAllowed` attempts, newest first, each with method,
+  outcome, and target. Red flag: denied attempts missing, or the window empty after
+  you've acted.
+- [ ] Refresh picks up new entries after another `send_input`.
+
+## 7. Revocation
+
+- [ ] Turn **Agent access (observe)** off (Save). `agent-endpoint.json` is emptied,
+  and any `novaterminal.*` tool now returns the unavailable guidance — including the
+  act tools (act rides on observe being up). Red flag: tools still work after observe
+  is off.
+
+---
+
+### Notes
+- If a tool returns "could not be parsed", the app and MCP server are from different
+  builds — rebuild both.
+- The CLI (`NovaTerminal.Cli`) is present in a local build but is **not** in the
+  release zip today; the 0.4.0 release must add it for step 4's `--replay` to work
+  for end users (tracked as the pre-release bundle fix).
+- These are the surfaces verified by build/logic tests but not visually in this
+  cycle: the three toggles, the SSH allowlist checkbox, and the Agent Activity
+  window. Steps 2, 5c, and 6 are the highest-value manual confirmations.

--- a/docs/announcements/2026-07-13-agent-host-launch.md
+++ b/docs/announcements/2026-07-13-agent-host-launch.md
@@ -1,0 +1,119 @@
+<!--
+DRAFT — publish alongside the release that actually ships the agent-host surface.
+
+Before publishing, verify:
+  1. A release (0.4.0) is cut whose binaries contain milestones A1–A4. The
+     features described here are on `main` but were NOT in v0.3.0.
+  2. `winget install benyblack.NovaTerminal` works (first-time winget-pkgs
+     submission merged — see packaging/winget/submit-first-time.ps1). If not,
+     drop the winget line from "Install" and keep the direct download.
+  3. Update every version string / URL below to the released tag.
+  4. Record the short demo referenced in "See it" (Claude Code reading a live
+     session + waiting on a build), or remove that callout.
+
+Targets: GitHub release notes (long form), a blog post, and a shortened
+Show HN / Reddit r/commandline post. Keep the security framing first.
+-->
+
+# NovaTerminal: the terminal your AI agent can see
+
+CLI coding agents — Claude Code, Codex, Gemini CLI — now live in the terminal.
+But the terminal itself has stayed a black box to them: an agent kicks off a
+build or a migration and then squints at scraped text, guessing whether it's
+done, stuck, or waiting for input. NovaTerminal closes that gap. It's a fast,
+correct, cross-platform terminal that also exposes a **structured, permissioned
+interface to the agent running inside it** — over the Model Context Protocol,
+so any MCP-capable agent can use it today.
+
+The bet is simple: don't embed a chatbot in the terminal. Make the terminal the
+best *host* for the agents people already use.
+
+## Safety first, because this can act
+
+The agent surface is **off by default and opt-in in two independent steps**:
+
+- **Observe** (read the screen, scrollback, and live status) is one toggle.
+- **Act** (type into, open, and close sessions) is a *separate* toggle on top of
+  observe — turning on observe never grants acting.
+- Driving a **remote SSH** session requires allowlisting that connection
+  specifically; the check fails closed.
+- Every action an agent takes — and every one it's denied — is recorded in a
+  visible in-app **activity journal**. Nothing happens silently.
+
+There's a written [threat model](../agent-host/2026-07-12-acting-threat-model.md)
+covering the trust boundaries, the controls, and the risks we explicitly accept.
+The endpoint is local and per-user; there is no network-exposed control surface.
+When everything is off, the agent interface doesn't exist.
+
+## What an agent can do
+
+**Observe** — read exactly what a human sees. Screen and scrollback come from
+the same deterministic snapshot the terminal renders from, so the agent isn't
+parsing a lossy scrape; it's reading the real cell grid, cursor, and styling.
+
+**Know the state** — ask whether a session is running, waiting for input, idle,
+or exited (with exit code), and long-poll for events: command finished, stalled,
+bell. An agent can start a build and *wait* for it instead of polling `ps`.
+
+**Act, with permission** — type input (byte-faithful, including control keys),
+open a new tab from a named profile, or close a pane. Injected input flows
+through the same path as human keystrokes, so it records and replays identically.
+
+**Replay — debug what your agent did, frame by frame.** This is the part no
+other terminal does. NovaTerminal keeps a bounded flight recording of recent
+session output; an agent (or you) can export it as a deterministic `.rec` file
+and re-render it headlessly:
+
+```
+NovaTerminal.Cli --replay session.rec
+```
+
+Byte-for-byte reproducible on Windows, macOS, and Linux — a real postmortem for
+an agent run, not a scrollback screenshot. (Exports contain output only, never
+anything typed.)
+
+## Why this terminal
+
+The agent features are only trustworthy because of what's underneath:
+
+- **A cell-based VT engine with strong VT/ANSI conformance** — the structured
+  read is accurate because the buffer is accurate.
+- **Deterministic recording and replay** — the same core that powers agent
+  replay has gated the project's correctness from day one.
+- **Native SSH** — profiles, jump hosts, port forwarding — so agents can be
+  handed correct remote sessions, not a fragile `ssh` wrapper.
+- **Cross-platform, self-contained, AOT-compiled** — one download, no runtime.
+
+## Install
+
+```
+# Windows
+winget install benyblack.NovaTerminal
+
+# Or download a self-contained build for your platform:
+# https://github.com/benyblack/NovaTerminal/releases/latest
+```
+
+Point your agent at it by adding the MCP server (stdio). With Claude Code:
+
+```
+claude mcp add novaterminal -- <path-to>/NovaTerminal.McpServer
+```
+
+Then enable **Settings → Agent access (observe)** — and, only if you want the
+agent to act, **Agent access (act)** — and watch the activity journal.
+
+## See it
+
+<!-- Embed the demo GIF/video: Claude Code reading a live vim/htop session, then
+     waiting on a build via wait_for_events, then replaying the run. -->
+
+## Where it's going
+
+NovaTerminal is a nights-and-weekends project with a clear thesis. Next up:
+broader distribution (Flathub, AUR, Homebrew), OS-native completion
+notifications, and richer replay (frame stepping, image output). Issues and
+ideas welcome at https://github.com/benyblack/NovaTerminal.
+
+It's the correct, deterministic terminal — and now, the one your agent can
+actually see.

--- a/docs/superpowers/2026-07-16-issue100-keychain-manual-validation.md
+++ b/docs/superpowers/2026-07-16-issue100-keychain-manual-validation.md
@@ -1,0 +1,186 @@
+# PR #132 (#100) — macOS/Linux keychain manual validation runbook
+
+The merge gate for PR #132 is **native keychain behavior on macOS and Linux** — the weak
+file crypto it replaces was Linux/macOS-only; Windows already used Credential Manager.
+Windows was regression-checked separately (see the appendix) and shows no regression, but
+that does **not** cover the gate. Run the checks below on real hardware before merging.
+
+Target/attribute scheme (for verification commands):
+- Service/label: `NovaTerminal`
+- Key per credential: `SSH:PROFILE:<profile-guid>` or `SSH:<user@host>`
+- App-data dir (where `settings.json` lives): `~/.local/share/NovaTerminal` on Linux;
+  **`~/Library/Application Support/NovaTerminal` on macOS** (confirmed 2026-07-16).
+  Overridable via `NOVATERM_APPDATA_ROOT`.
+
+## Fastest keychain-store check (recommended, no SSH needed)
+
+The SSH connect UI on this branch is 50 commits stale and its OpenSSH/Native path is
+unreliable, so don't gate on a live connection. Instead run the shipped integration test,
+which does a real `MacKeychainStore` / `LinuxSecretStore` write→update→read→delete round-trip:
+
+```sh
+scripts/build.sh test tests/NovaTerminal.App.Tests/NovaTerminal.App.Tests.csproj \
+  --filter "FullyQualifiedName~KeychainSecretStoreIntegrationTests"
+```
+
+It **self-skips silently (counts as passed) when no keyring is present**, so for a real
+verdict temporarily change the skip guard's `return;` to
+`throw new System.InvalidOperationException("keychain unavailable");` — then a pass proves
+it actually ran. **macOS: verified 2026-07-16 (passes with the throw-guard).**
+
+## Linux — fresh-VM setup, then run (Ubuntu/Debian; adjust apt→dnf for Fedora)
+
+```sh
+# 1) System deps: build tools, Secret Service (libsecret), keyring, GUI runtime libs
+sudo apt update
+sudo apt install -y git curl build-essential pkg-config \
+    libsecret-1-0 libsecret-1-dev libsecret-tools gnome-keyring dbus-x11 \
+    libx11-6 libice6 libsm6 libfontconfig1 libgl1 libglib2.0-0
+
+# 2) Rust toolchain (native PTY/SSH libs)
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+. "$HOME/.cargo/env"
+
+# 3) .NET SDK — preview channel (must satisfy repo global.json; check after install)
+curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
+bash /tmp/dotnet-install.sh --channel 10.0 --quality preview
+export PATH="$HOME/.dotnet:$PATH"
+dotnet --version    # compare against global.json's pinned SDK
+
+# 4) Source + branch
+git clone https://github.com/benyblack/NovaTerminal.git
+cd NovaTerminal
+git checkout fix/issue-100-vault-keychain-security
+```
+
+### Linux keychain-store round-trip (the key check)
+
+`LinuxSecretStore` needs a live, **unlocked** Secret Service — so run this **inside the
+graphical desktop session** (a terminal in the GNOME/KDE session), where `gnome-keyring`
+provides the D-Bus secrets service and the login keyring is unlocked. Apply the same
+throw-guard tweak (skip-guard `return;` → `throw new System.InvalidOperationException(...)`)
+so a skip can't masquerade as a pass, then:
+
+```sh
+scripts/build.sh test tests/NovaTerminal.App.Tests/NovaTerminal.App.Tests.csproj \
+  --filter "FullyQualifiedName~KeychainSecretStoreIntegrationTests"
+```
+
+- **Pass** → `LinuxSecretStore` write/update/read/delete works against Secret Service. ✔
+- **Fails with "keychain unavailable"** → the Secret Service isn't reachable/unlocked; make
+  sure you're in the desktop session (not a bare SSH/tty) with the login keyring unlocked.
+
+Independently confirm an entry is visible (from the same session):
+`secret-tool search service NovaTerminal` (after a save).
+
+### Linux GUI checks (run the app)
+
+```sh
+dotnet src/NovaTerminal.App/bin/Debug/net10.0/NovaTerminal.dll
+```
+
+- **§3 startup probe:** with the keyring **unlocked**, launch — window appears promptly, no
+  hang, no unexpected keyring-unlock dialog on startup (the `LinuxSecretStore` ctor does a
+  synchronous Secret Service lookup on the UI thread).
+- **§4 disabled-mode/locked-keyring:** launch with no secrets provider —
+  `dbus-run-session -- dotnet src/NovaTerminal.App/bin/Debug/net10.0/NovaTerminal.dll` —
+  expect the app to launch, show the one-time "Credential storage unavailable" toast, and
+  still let SSH connect (password just isn't persisted). No crash, no silent swallow.
+- **§6 legacy `vault.dat`:** `printf x > ~/.local/share/NovaTerminal/vault.dat`, launch,
+  then confirm it's gone (`ls -l ~/.local/share/NovaTerminal/vault.dat` → No such file).
+
+## 0. Build & run the PR branch
+
+```sh
+git fetch origin fix/issue-100-vault-keychain-security
+git checkout fix/issue-100-vault-keychain-security
+scripts/build.sh build src/NovaTerminal.App        # wrapper; or: dotnet build -nodeReuse:false
+# run the built app (adjust net10.0 path if needed):
+dotnet src/NovaTerminal.App/bin/Debug/net10.0/NovaTerminal.dll
+```
+
+Use a **password-based** SSH profile (not agent/key) — only password auth exercises the
+keychain. Create a throwaway profile against any host that accepts password auth.
+
+---
+
+## 1. macOS — keychain round-trip
+
+1. Connect the password profile; enter the password with **remember** on.
+2. **Verify it was written:** Keychain Access → search `NovaTerminal` → an item whose
+   service is `NovaTerminal` and account/key is `SSH:PROFILE:<guid>` exists.
+   CLI equivalent: `security find-generic-password -s "NovaTerminal" -a "SSH:PROFILE:<guid>"`
+3. Quit the app fully, relaunch, reconnect the same profile.
+
+**Pass:** step 3 connects with **no** password prompt (read from Keychain); step 2 item present.
+**Red flag:** re-prompts every time, or no Keychain item created.
+
+## 2. Linux (GNOME Keyring / KWallet) — keychain round-trip
+
+1. Same connect-with-remember as above.
+2. **Verify write:** `secret-tool search key "SSH:PROFILE:<guid>"`
+   (or `secret-tool search service NovaTerminal`) returns the item.
+3. Quit fully, relaunch, reconnect.
+
+**Pass:** step 3 no re-prompt; `secret-tool` shows the entry.
+**Red flag:** nothing stored, or re-prompt on reconnect.
+
+## 3. Linux — startup probe doesn't block or pop an unlock prompt
+
+`LinuxSecretStore` does a **synchronous** Secret Service lookup on the UI thread in its
+ctor. With an **unlocked** keyring, launch the app and watch startup.
+
+**Pass:** window appears promptly; no hang; no unexpected keyring-unlock dialog at launch.
+**Red flag:** app hangs on the splash/first window, or an unlock prompt appears just from
+launching (before any connect).
+
+## 4. Linux — headless / locked-keyring (disabled mode)
+
+Simulate no usable keychain, e.g. run without a Secret Service provider:
+
+```sh
+# a session with no keyring daemon / D-Bus secrets service, or lock the keyring first
+dbus-run-session -- dotnet src/NovaTerminal.App/bin/Debug/net10.0/NovaTerminal.dll
+```
+
+**Pass:** app launches; shows the one-time **"Credential storage unavailable"** toast;
+SSH still **connects** (you enter the password each time; it just isn't persisted);
+`VaultService.PersistenceAvailable` is false (reads null, writes no-op).
+**Red flag:** crash on launch, silent swallow (no toast), or SSH broken entirely.
+
+## 5. Cross-process — app-saved password read by `ssh-askpass`
+
+With a password saved (from #1/#2), trigger a flow that invokes the `ssh-askpass` helper
+(separate process) — e.g. a git/ssh op or reconnect path that shells out to askpass.
+
+**Pass:** the helper reads the same keychain entry and authenticates without a manual prompt.
+**Red flag:** askpass can't find the secret (prompts) although the app has it saved.
+
+## 6. Legacy `vault.dat` deletion (Linux/macOS)
+
+```sh
+# with the app closed, plant a dummy in the app-data dir:
+printf 'legacy junk' > ~/.local/share/NovaTerminal/vault.dat
+ls -l ~/.local/share/NovaTerminal/vault.dat   # exists
+# launch the app, then re-check:
+ls -l ~/.local/share/NovaTerminal/vault.dat   # should be GONE
+```
+
+**Pass:** `vault.dat` is deleted on launch **without being read/migrated**.
+**Red flag:** file still present, or its contents were parsed.
+
+---
+
+## Appendix — Windows results (2026-07-16, informational, not the gate)
+
+Validated on a #132 worktree build (`ba4bea8`), Debug, Windows 11:
+- Builds clean; launches with no crash (no new `startup_error.txt`).
+- "Credentials stored in OS keychain" UI text renders (new store wired in).
+- **Write:** creating profile `vw2` with a saved password created a fresh
+  `NovaTerminal:SSH:PROFILE:<guid>` entry in Credential Manager, stamped that day
+  (verified via `CredEnumerate` `LastWritten`).
+- **Read across restart:** after a full app restart, `vw2` reconnected with no password
+  prompt — password read back from Credential Manager.
+
+Conclusion: the `ISecretStore` refactor did not regress the Windows Credential Manager
+read/write path. macOS/Linux (sections 1–6) remain to be validated on real hardware.

--- a/packaging/winget/submit-first-time.ps1
+++ b/packaging/winget/submit-first-time.ps1
@@ -1,0 +1,77 @@
+<#
+.SYNOPSIS
+    One-time bootstrap submission of NovaTerminal to the winget community repo.
+
+.DESCRIPTION
+    The first winget-pkgs submission must be done by hand (the release.yml
+    'submit_winget' job uses `wingetcreate update`, which only works once the
+    package already exists upstream). This script does that first submission
+    from the in-repo manifest set.
+
+    It:
+      1. verifies winget + wingetcreate are available (installs wingetcreate if not),
+      2. validates the manifest set locally,
+      3. submits it to microsoft/winget-pkgs, opening a PR from your fork.
+
+    You must supply a GitHub Personal Access Token (classic) with 'public_repo'
+    scope — wingetcreate uses it to fork winget-pkgs and open the PR. Create one
+    at https://github.com/settings/tokens. This script never stores it.
+
+.PARAMETER Version
+    The manifest version folder to submit. Default: 0.3.0.
+
+.PARAMETER Token
+    GitHub PAT. If omitted, the WINGET_PAT environment variable is used.
+
+.EXAMPLE
+    ./submit-first-time.ps1 -Token ghp_xxx
+
+.EXAMPLE
+    $env:WINGET_PAT = 'ghp_xxx'; ./submit-first-time.ps1 -Version 0.3.0
+#>
+[CmdletBinding()]
+param(
+    [string]$Version = "0.3.0",
+    [string]$Token = $env:WINGET_PAT
+)
+
+$ErrorActionPreference = "Stop"
+
+# Resolve the manifest directory relative to this script (packaging/winget/<version>).
+$manifestDir = Join-Path $PSScriptRoot $Version
+if (-not (Test-Path $manifestDir)) {
+    throw "Manifest directory not found: $manifestDir. Cut the manifest for $Version first (see README.md)."
+}
+
+if ([string]::IsNullOrWhiteSpace($Token)) {
+    throw "No GitHub token. Pass -Token <PAT> or set `$env:WINGET_PAT. Needs 'public_repo' scope to fork winget-pkgs and open the PR."
+}
+
+# 1. winget client (ships with App Installer on Windows 10/11).
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+    throw "winget not found. Install 'App Installer' from the Microsoft Store, then re-run."
+}
+
+# 2. wingetcreate (Windows Package Manager Manifest Creator).
+if (-not (Get-Command wingetcreate -ErrorAction SilentlyContinue)) {
+    Write-Host "wingetcreate not found; installing via winget..."
+    winget install --id Microsoft.WingetCreate --exact --accept-source-agreements --accept-package-agreements
+    if (-not (Get-Command wingetcreate -ErrorAction SilentlyContinue)) {
+        throw "wingetcreate still not on PATH after install. Open a new shell and re-run, or install manually: winget install Microsoft.WingetCreate"
+    }
+}
+
+# 3. Validate locally first (schema + required fields; offline).
+Write-Host "Validating manifest set in $manifestDir ..."
+winget validate --manifest $manifestDir
+
+# 4. Submit. wingetcreate re-validates, downloads the installer URL, verifies the
+#    SHA256, forks microsoft/winget-pkgs, commits under
+#    manifests/b/benyblack/NovaTerminal/<version>/, and opens the PR.
+Write-Host "Submitting to microsoft/winget-pkgs (this forks the repo and opens a PR)..."
+wingetcreate submit --token $Token $manifestDir
+
+Write-Host ""
+Write-Host "Done. Track the PR at https://github.com/microsoft/winget-pkgs/pulls (author: your GitHub account)."
+Write-Host "After it merges, 'winget install benyblack.NovaTerminal' works, and future releases"
+Write-Host "auto-submit via the release.yml 'submit_winget' job (set the WINGET_PAT repo secret)."

--- a/src/NovaTerminal.McpServer/Tools/SessionTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/SessionTools.cs
@@ -88,7 +88,7 @@ public static class SessionTools
     }
 
     [McpServerTool(Name = "novaterminal.get_session_status"),
-     Description("Reports what a live NovaTerminal session is doing right now: running / awaitingInput / idle / exited, with a confidence tier (precise = shell-integration events; heuristic = PTY signals), the in-flight command when known, exit code, and stall state. Read-only. Get paneId from novaterminal.list_sessions.")]
+     Description("Reports what a live NovaTerminal session is doing right now: running / awaitingInput / idle / exited, with a confidence tier (precise = shell-integration events; heuristic = PTY signals), the in-flight command when known, exit code, and stall state. Read-only. Get paneId from novaterminal.list_sessions. Limitation: the heuristic tier detects a running command via the OS process tree, which cannot see processes running inside a WSL distribution or on a remote SSH host — so a genuinely-running command in a WSL or SSH session may report awaitingInput/idle. Native local shells (cmd/PowerShell) are accurate; enabling shell integration upgrades a session to the precise tier, which is accurate regardless.")]
     public static async Task<string> GetSessionStatus(
         AgentHostClient client,
         [Description("The pane id (GUID) from novaterminal.list_sessions.")] string paneId,


### PR DESCRIPTION
## Docs & release-prep batch (agent-host 0.4.0)

Documentation and helper files accumulated during the A1–A4 work and #100/#132 validation, plus one tool-description caveat. No behavior changes beyond the MCP tool description string.

- **`docs/agent-host/known-limitations.md`** — WSL/SSH heuristic session-status limits (the process-tree probe can't see inside a WSL distro or a remote SSH host) and parked follow-ups (OS-native notifications, idle-via-sweep, replay `--at`/PNG, CLI-not-in-bundle).
- **`docs/agent-host/smoke-test-0.4.0.md`** — layered manual smoke test for A1–A4 on a real build before tagging 0.4.0.
- **`docs/superpowers/2026-07-16-issue100-keychain-manual-validation.md`** — cross-platform keychain validation runbook for #100/#132 (Windows CM + macOS Keychain + Linux Secret Service), incl. the integration-test method and the results already gathered.
- **`docs/announcements/2026-07-13-agent-host-launch.md`** — agent-host launch announcement draft.
- **`packaging/winget/submit-first-time.ps1`** — helper for the first-time winget-pkgs submission.
- **`SessionTools.cs`** — appends the WSL/SSH heuristic-tier caveat to the `get_session_status` MCP tool description (one line), so agents know a WSL/SSH "idle" at heuristic confidence may be a busy command.
