### PR TITLE
fix(release): app exe serves --replay (headless replay in the AOT bundle)

### DIFF
--- a/docs/agent-host/known-limitations.md
+++ b/docs/agent-host/known-limitations.md
@@ -53,6 +53,6 @@ From `docs/agent-host/DIRECTION.md` and the milestone design docs:
 - **Replay `--replay --at <ms>` / PNG output** — A4 ships headless
   render-to-text of the final screen; frame-stepping and image output are
   out of scope for now (Virtual fast-forward already covers most of it).
-- **CLI not in the release bundle** — `NovaTerminal.Cli` (which hosts
-  `--replay`) is present in local builds but not yet in the published release
-  zip; a pre-0.4.0 packaging fix will include it.
+- **Replay ships in the app executable** — the self-contained AOT release bundle
+  contains no separate `NovaTerminal.Cli`; the app exe serves `--replay <file>`
+  itself (`NovaTerminal --replay …`), the same headless render as the dev CLI.

--- a/docs/agent-host/smoke-test-0.4.0.md
+++ b/docs/agent-host/smoke-test-0.4.0.md
@@ -130,9 +130,9 @@ Have a couple of tabs open; run something interactive (e.g. `vim` or a `ping -t`
 ### Notes
 - If a tool returns "could not be parsed", the app and MCP server are from different
   builds — rebuild both.
-- The CLI (`NovaTerminal.Cli`) is present in a local build but is **not** in the
-  release zip today; the 0.4.0 release must add it for step 4's `--replay` to work
-  for end users (tracked as the pre-release bundle fix).
+- Step 4 uses the dev CLI (`NovaTerminal.Cli`) for convenience. The release bundle
+  ships no separate CLI — the app executable serves `--replay` itself
+  (`NovaTerminal --replay "<.rec>"`), so that is the end-user invocation.
 - These are the surfaces verified by build/logic tests but not visually in this
   cycle: the three toggles, the SSH allowlist checkbox, and the Agent Activity
   window. Steps 2, 5c, and 6 are the highest-value manual confirmations.

--- a/src/NovaTerminal.App/Program.cs
+++ b/src/NovaTerminal.App/Program.cs
@@ -31,6 +31,16 @@ class Program
                 return;
             }
 
+            // Headless replay (A4) — the self-contained AOT bundle ships no separate
+            // NovaTerminal.Cli, so the app executable serves `--replay <file>` itself.
+            // Rooting ReplayCommand here also keeps AOT trimming from dropping it.
+            if (ReplayCommand.IsSupportedCliMode(args))
+            {
+                CliConsoleBindings.Prepare();
+                Environment.ExitCode = ReplayCommand.Execute(args, Console.Out, Console.Error);
+                return;
+            }
+
             // Log startup info
             TerminalLogger.Log("NovaTerminal started with args: " + string.Join(" ", args));
             TerminalLogger.Log("Log file path: " + AppLogger.GetLogFilePath());


### PR DESCRIPTION
The release publishes the App as self-contained AOT with SkipCliShim=true, so NovaTerminal.Cli (host of --replay) wasn't in the bundle — and as a framework-dependent DLL it had no runtime there anyway. Program.Main already handles VtReportCommand/SshAskPassCommand inline before the GUI; this adds the same branch for ReplayCommand, so `NovaTerminal --replay <file>` works from the shipped executable (the replay code is already in the App assembly; rooting it also prevents AOT trimming from dropping it). No `release.yml` change needed.

Verified locally: built the App (Debug) and ran `NovaTerminal.exe --replay <rec>` → renders the final screen, exit 0. Docs (known-limitations, smoke-test) updated to reflect the app-exe replay path.