### PR TITLE
chore(release): bump version to 0.4.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
-    <Version>0.3.0</Version>
-    <AssemblyVersion>0.3.0.0</AssemblyVersion>
-    <FileVersion>0.3.0.0</FileVersion>
-    <InformationalVersion>0.3.0</InformationalVersion>
+    <Version>0.4.0</Version>
+    <AssemblyVersion>0.4.0.0</AssemblyVersion>
+    <FileVersion>0.4.0.0</FileVersion>
+    <InformationalVersion>0.4.0</InformationalVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Bumps `Directory.Build.props` Version/AssemblyVersion/FileVersion/InformationalVersion from 0.3.0 to 0.4.0 for the 0.4.0 release. Tagging `v0.4.0` after this merges triggers `release.yml` to build and publish the self-contained AOT bundles (now including `--replay` via the app exe, #203).