### PR TITLE
test(mcp): shorten agent-host socket temp path for macOS sun_path limit

### DIFF
--- a/tests/NovaTerminal.McpServer.Tests/AgentHostClientTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/AgentHostClientTests.cs
@@ -20,7 +20,10 @@ public class AgentHostClientTests : IDisposable
 
     public AgentHostClientTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), "nova-agentclient-tests-" + Guid.NewGuid().ToString("N"));
+        // Short name on purpose: the unix-domain socket built under this dir must keep the
+        // full path under macOS's ~104-char sun_path limit (a long temp dir overflowed it,
+        // failing the live-endpoint tests only on the macOS release runner).
+        _tempDir = Path.Combine(Path.GetTempPath(), "nvac-" + Guid.NewGuid().ToString("N")[..8]);
         Directory.CreateDirectory(_tempDir);
     }
 


### PR DESCRIPTION
The macOS **Release Tests** job failed on `AgentHostClientTests` live-endpoint tests, cancelling the v0.4.0 release and skipping Publish AOT.

Root cause: the test binds a unix-domain socket under `GetTempPath()/nova-agentclient-tests-<32-char-guid>/`, whose full path exceeds macOS's ~104-char `sun_path` limit on the runner, so the fake endpoint can't bind. Passes on Linux (108-char limit, shorter /tmp) and Windows (named pipes). First surfaced now because this is the initial release-test run to include the agent-host IPC tests on macOS.

Fix: shorten the temp-dir name. **Product is unaffected** — the real endpoint is `~/Library/Application Support/NovaTerminal/agent.sock` (~66 chars). Test-only change.