### PR TITLE
docs(mcp): refresh tools/security/dev-companion for the agent-host observe/act surface

### DIFF
--- a/docs/mcp-dev-companion.md
+++ b/docs/mcp-dev-companion.md
@@ -1,45 +1,45 @@
-# NovaTerminal MCP Dev Companion
+# NovaTerminal MCP server
 
-An **experimental, local, read-only** [MCP](https://modelcontextprotocol.io) server that exposes
-NovaTerminal's project knowledge (architecture, schemas, VT conformance, dev workflow) to AI coding
-agents in a structured way. It lives in `src/NovaTerminal.McpServer`.
+A local, stdio [MCP](https://modelcontextprotocol.io) server (`src/NovaTerminal.McpServer`) that
+exposes NovaTerminal to AI coding agents (Claude Code, Claude Desktop, VS Code, …). It began as a
+read-only "dev companion" and now also fronts the **agent host** — opt-in access to live terminal
+sessions. Two tool families:
 
-This is a **developer productivity tool**, not a user-facing terminal feature.
+1. **Repo / dev-companion tools** — read-only and offline: project knowledge (architecture,
+   schemas, VT conformance, dev workflow). A developer-productivity aid; always available.
+2. **Live-session tools (agent host)** — observe, and behind a separate opt-in, act on the running
+   app's terminal sessions. A user-facing feature, **off by default**.
 
-## What it is
+## Repo / dev-companion tools
 
-- A stdio MCP server that AI agents (Claude Desktop, VS Code, etc.) can connect to.
-- Read-only: it reads repository docs and validates JSON against schemas.
-- Self-contained: it has **no project references** to the rest of the solution and pulls in no
-  terminal, SSH, or rendering code.
+- **Read-only.** Read repository docs and validate theme / SSH-profile / settings JSON against schemas.
+- **Offline and sandboxed.** No command execution, no SSH/network, no credentials, no live-session
+  access; filesystem reads are confined to `docs/`.
 
-## What it is NOT (v0.1 non-goals)
+## Live-session tools (agent host)
 
-It does **not**, and must not:
+Proxy the **running** NovaTerminal app over a per-user local IPC endpoint, gated by explicit,
+default-off opt-ins in the app's settings:
 
-- execute shell commands
-- open SSH connections
-- read live terminal buffers
-- access saved credentials or private keys
-- modify user profiles
-- control the running NovaTerminal app
-- require network access
+- **Observe** (opt-in) — read live sessions: `list_sessions`, `read_screen`, `read_scrollback`,
+  `get_session_status`, `wait_for_events`, `export_replay`.
+- **Act** (a *separate* opt-in, on top of observe) — `send_input`, `spawn_session`,
+  `close_session`. SSH targets require a per-profile allowlist, and every acting call — allowed or
+  denied — is recorded in an in-app activity journal.
 
-See [mcp/security.md](mcp/security.md) for the full security model.
+With both toggles off there is no live endpoint at all. See [mcp/security.md](mcp/security.md) and
+the [acting threat model](agent-host/2026-07-12-acting-threat-model.md).
 
 ## Tools
 
-See [mcp/tools.md](mcp/tools.md) for the authoritative list. As of v0.4 this includes the
-connection-profile and settings tools:
-
-`novaterminal.get_connection_profile_schema`, `novaterminal.validate_connection_profile_json`,
-`novaterminal.get_settings_schema`, `novaterminal.validate_settings_json`.
+See [mcp/tools.md](mcp/tools.md) for the authoritative list of both families.
 
 ## How to run it locally
 
 The server speaks MCP over **stdio**, so it is normally launched by an MCP client (not run by
-hand). It locates the repository automatically by walking up to `NovaTerminal.sln`; you can
-override that with the `NOVATERMINAL_REPO_ROOT` environment variable.
+hand). The dev-companion tools locate the repository automatically by walking up to
+`NovaTerminal.sln`; you can override that with the `NOVATERMINAL_REPO_ROOT` environment variable.
+The live-session tools need the NovaTerminal app running with the opt-ins enabled.
 
 Build once, then run the built DLL (clients should point at the DLL, **not** `dotnet run` —
 `run` emits build/restore output to stdout, which corrupts the JSON-RPC stream):
@@ -48,18 +48,21 @@ Build once, then run the built DLL (clients should point at the DLL, **not** `do
 # from the repo root
 dotnet build -c Release src/NovaTerminal.McpServer
 dotnet src/NovaTerminal.McpServer/bin/Release/net10.0/NovaTerminal.McpServer.dll
-# then pipe newline-delimited JSON-RPC (initialize, notifications/initialized, tools/list)
 ```
 
 ### Client configuration
 
+- Claude Code: `claude mcp add novaterminal -- dotnet "<path-to-repo>/src/NovaTerminal.McpServer/bin/Release/net10.0/NovaTerminal.McpServer.dll"`
 - Claude Desktop: [examples/mcp/claude_desktop_config.json](../examples/mcp/claude_desktop_config.json)
 - VS Code: [examples/mcp/vscode_mcp_config.json](../examples/mcp/vscode_mcp_config.json)
 
-Point `NOVATERMINAL_REPO_ROOT` at your clone so the doc-reading tools resolve.
+Point `NOVATERMINAL_REPO_ROOT` at your clone so the doc-reading tools resolve. To use the
+live-session tools, enable **Settings → Agent access (observe)** in NovaTerminal (and the
+**Agent access (act)** sub-toggle to allow typing/spawning/closing).
 
-## Status / roadmap
+## Status
 
-v0.1 is the read-only dev companion. Future phases (explicitly **out of scope** here) could add
-more VT/profile helpers and, only behind an opt-in bridge, read-only views of a running app. Any
-write/action capability must be opt-in and documented separately.
+Both the read-only dev companion and the agent-host observe/act surface (milestones A1–A4) ship as
+of 0.4.0. Remaining follow-ups are tracked in
+[agent-host/known-limitations.md](agent-host/known-limitations.md) and
+[agent-host/DIRECTION.md](agent-host/DIRECTION.md).

--- a/docs/mcp/security.md
+++ b/docs/mcp/security.md
@@ -1,31 +1,43 @@
-# NovaTerminal MCP Dev Companion — security model
+# NovaTerminal MCP — security model
 
-The v0.1 server is **local-only, read-only, and offline**. It is a development aid; it must never
-become an exfiltration or command-execution surface.
+The server has **two tool families** with different security postures.
 
-## Guarantees (v0.1)
+## Repo / dev-companion tools — local-only, read-only, offline
 
-- **No command execution.** The server contains no process-spawning code paths.
-- **No SSH / network.** It opens no sockets and requires no network access.
-- **No credentials / private keys.** It never reads the vault, profiles, `known_hosts`, or keys.
-- **No live terminal access.** It cannot see terminal buffers, tabs, or selections.
-- **Read-only filesystem access, confined to `docs/`.** File reads go through `RepoContext`, which:
+These are a development aid and must never become an exfiltration or command-execution surface:
+
+- **No command execution.** The server contains no process-spawning code paths for these tools.
+- **No SSH / network.** They open no sockets and require no network access.
+- **No credentials / private keys.** They never read the vault, profiles, `known_hosts`, or keys.
+- **Read-only filesystem access, confined to `docs/`.** Reads go through `RepoContext`, which:
   - resolves a single repo root (env `NOVATERMINAL_REPO_ROOT`, or by walking up to `NovaTerminal.sln`);
   - serves only files under `docs/`;
-  - canonicalizes every requested path and **rejects anything that escapes `docs/`** (e.g. `../`,
-    absolute paths). This is covered by tests (`RepoContextTests`).
+  - canonicalizes every requested path and **rejects anything that escapes `docs/`** (`../`,
+    absolute paths). Covered by `RepoContextTests`.
+
+## Live-session tools (agent host) — explicit, default-off opt-ins
+
+The observe/act tools proxy the **running** NovaTerminal app over a **per-user local IPC endpoint**
+(a `CurrentUserOnly` named pipe on Windows; a `0600` unix-domain socket under the app-data dir on
+macOS/Linux). They are gated by opt-ins in the app's settings:
+
+- **Observe** (`list_sessions`, `read_screen`, `read_scrollback`, `get_session_status`,
+  `wait_for_events`, `export_replay`) requires **Agent access (observe)**. Read-only. Replay export
+  additionally requires the **Agent replay export** sub-toggle and **never records typed input**.
+- **Act** (`send_input`, `spawn_session`, `close_session`) requires a **separate** **Agent access
+  (act)** opt-in *on top of* observe. SSH targets additionally require a **per-profile allowlist**.
+  Every acting call — allowed or denied — is recorded in an in-app **activity journal**.
+- With both toggles off, **no endpoint exists** and the live-session tools return guidance, not data.
+
+Full analysis of the acting surface: the
+[acting threat model](../agent-host/2026-07-12-acting-threat-model.md).
 
 ## Architectural enforcement
 
-- `NovaTerminal.McpServer` has **no `ProjectReference`s** to the rest of the solution, so it cannot
-  call into terminal, PTY, SSH, or rendering code even by accident.
-- It depends only on `ModelContextProtocol` and `Microsoft.Extensions.Hosting`.
-
-## Future capabilities (must stay opt-in)
-
-Any future tool that reads a running app's state (open tabs, active profile metadata, selected
-text) or performs writes/actions is **sensitive**. Such capabilities must:
-
-- be off by default and require explicit user opt-in,
-- be documented separately with their own threat model,
-- never expose credentials, private keys, or raw session contents.
+- `NovaTerminal.McpServer`'s only cross-assembly dependency is the zero-reference
+  `NovaTerminal.AgentHost.Contracts` leaf (the IPC wire types). It links **no** terminal, PTY, SSH,
+  or rendering code — the live-session tools reach the app purely over that IPC contract, never by
+  calling into it in-process.
+- Otherwise it depends only on `ModelContextProtocol` and `Microsoft.Extensions.Hosting`.
+- Dev-companion schemas that mirror real types are kept honest by drift-guard tests in
+  `tests/NovaTerminal.McpServer.Tests`.

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -1,6 +1,16 @@
-# NovaTerminal MCP Dev Companion — tools (v0.4)
+# NovaTerminal MCP — tools (v0.4)
 
-All tools are **read-only**. None execute commands, touch credentials, or access live sessions.
+The server exposes **two tool families**:
+
+- **Repo / dev-companion tools** — read-only and offline: no command execution, no network, no
+  credentials; filesystem access is confined to `docs/`. Available whenever the server runs.
+- **Live-session tools (agent host)** — proxy the *running* NovaTerminal app over a per-user local
+  IPC endpoint and are gated by explicit, **default-off** user opt-ins (see
+  [security.md](security.md) and the
+  [acting threat model](../agent-host/2026-07-12-acting-threat-model.md)). With the opt-ins off,
+  no live endpoint exists and these tools return guidance instead of data.
+
+## Repo / dev-companion tools (read-only, offline)
 
 | Tool | Inputs | Description |
 |------|--------|-------------|
@@ -20,6 +30,33 @@ All tools are **read-only**. None execute commands, touch credentials, or access
 | `novaterminal.generate_codex_prompt_for_issue` | `title`, `description?` | Generates a structured implementation prompt (relevant areas, constraints, PR size, steps, tests, acceptance, risks) tailored to NovaTerminal conventions. |
 | `novaterminal.suggest_relevant_files` | `topic` | Suggests the concrete source/test files most relevant to a topic/task (e.g. `reflow`, `glyph atlas`, `ssh key auth`). |
 
+## Live-session tools (agent host)
+
+These require NovaTerminal to be **running** with the relevant opt-in enabled. Get a `paneId` from
+`list_sessions`.
+
+### Observe — requires **Agent access (observe)** (read-only)
+
+| Tool | Inputs | Description |
+|------|--------|-------------|
+| `novaterminal.list_sessions` | — | Lists live sessions: `paneId`, title, profile, kind (local/ssh), size, active flag, and status. |
+| `novaterminal.read_screen` | `paneId`, `includeAttributes?` | The visible screen as deterministic text (viewport lines, cursor position/visibility, size); optional per-row attribute encodings. |
+| `novaterminal.read_scrollback` | `paneId` | Scrollback history lines, oldest first. |
+| `novaterminal.get_session_status` | `paneId` | What the session is doing now — running / awaitingInput / idle / exited — with a confidence tier (precise = shell-integration events; heuristic = PTY signals), in-flight command, and exit code when known. |
+| `novaterminal.wait_for_events` | `sinceSeq?`, `timeoutMs?` | Long-polls the per-session event ring for status/command events after a cursor, so an agent can await completion instead of polling. |
+| `novaterminal.export_replay` | `paneId` | Exports the session's recent output + resizes as a deterministic `.rec` file (replay with `NovaTerminal --replay <file>`). **Never records input.** Requires the additional **Agent replay export** sub-toggle. |
+
+### Act — requires the separate **Agent access (act)** opt-in *on top of* observe
+
+Every acting call — allowed or denied — is recorded in the in-app **activity journal**. SSH
+targets additionally require a per-profile allowlist.
+
+| Tool | Inputs | Description |
+|------|--------|-------------|
+| `novaterminal.send_input` | `paneId`, `text`, `submit?` | Types `text` into a session byte-for-byte (control characters allowed, e.g. `` = Ctrl-C). Set `submit=true` to append a carriage return (Enter) — a bare newline arrives as LF, which PowerShell/PSReadLine treats as a soft continuation rather than submit. |
+| `novaterminal.spawn_session` | `profile?` | Opens a new tab running the default local profile, a named local profile, or an *allowlisted* SSH profile; returns the new `paneId`. |
+| `novaterminal.close_session` | `paneId` | Closes a live pane (no confirmation dialog — the act opt-in plus the journal entry is the consent surface). |
+
 ## Notes
 
 - `get_architecture_map`, `list_docs`, `read_doc`, and `get_vt_conformance_summary` read files from
@@ -28,10 +65,13 @@ All tools are **read-only**. None execute commands, touch credentials, or access
   `generate_codex_prompt_for_issue` are fully self-contained (no filesystem access).
 - `validate_settings_json` validates the top-level settings shape and the structure of its
   collections; it does not deep-validate embedded `Profiles`/`TabTemplateRules` entries.
+- The live-session tools reach the app only through the zero-reference
+  `NovaTerminal.AgentHost.Contracts` wire types over a per-user local IPC endpoint — the server
+  still links no terminal, PTY, SSH, or rendering code.
 
 ## Still deferred
 
 - **`generate_test_plan_for_change`**: largely covered by `generate_codex_prompt_for_issue`
   (its "tests to update" section) and `generate_vt_test_plan`.
-- **Running-app bridge tools** (`list_open_tabs`, `get_active_profile_metadata`,
-  `get_selected_text`, …): sensitive; must remain opt-in and documented separately.
+- **Replay frame-stepping / image output** (`--replay --at <ms>`, PNG): `export_replay` + the
+  headless renderer cover final-screen text today; frame-by-frame and images are future work.


### PR DESCRIPTION
The three MCP docs still described the v0.1 read-only *dev companion* and explicitly denied live-session access — stale since the agent host (A1–A4) shipped and now contradicting the README/McpServer README.

Reframed each around the **two tool families**:

- **docs/mcp/tools.md** — adds the live-session tools (observe: list_sessions/read_screen/read_scrollback/get_session_status/wait_for_events/export_replay; act: send_input/spawn_session/close_session) with the opt-in / SSH-allowlist / activity-journal notes; corrects the 'all read-only, no live sessions' intro.
- **docs/mcp/security.md** — documents the acting surface (default-off opt-ins, allowlist, journal, per-user local IPC) and fixes the stale 'no ProjectReferences / no live terminal access' claims (now links the zero-ref \AgentHost.Contracts\ leaf).
- **docs/mcp-dev-companion.md** — drops 'read-only / not a user-facing feature'; two-family overview + updated run/config + 0.4.0 status.

Docs-only.