### PR TITLE
fix(sftp): reject unsafe remote entry names and stop truncating downloads

### DIFF
--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -1875,9 +1875,7 @@ async fn download_file_from_remote(
     // created — before a single byte arrives — so a cancelled or failed re-download
     // used to destroy the previous version and leave a truncated file behind.
     let partial_path = partial_download_path(local_path);
-    let mut local_file = TokioFile::create(&partial_path)
-        .await
-        .map_err(|error| map_local_transfer_error(&partial_path, error))?;
+    let mut local_file = create_partial_download_file(&partial_path).await?;
 
     if let Err(error) = copy_file_with_cancellation(
         &mut remote_file,
@@ -1905,12 +1903,21 @@ async fn download_file_from_remote(
     // has an open handle.
     drop(local_file);
 
+    // Close the remote handle *before* the rename so that the rename is the last
+    // fallible operation, and therefore the single commit point. With the rename first,
+    // a failing shutdown would report the transfer as failed even though the
+    // destination had already been replaced - and in a directory download would abort
+    // the remaining files having already committed this one.
+    if let Err(error) = remote_file.shutdown().await {
+        discard_partial_download(&partial_path).await;
+        return Err(error.into());
+    }
+
     if let Err(error) = tokio::fs::rename(&partial_path, local_path).await {
         discard_partial_download(&partial_path).await;
         return Err(map_local_transfer_error(local_path, error));
     }
 
-    remote_file.shutdown().await?;
     Ok(())
 }
 
@@ -2331,9 +2338,8 @@ fn remote_basename(path: &str) -> anyhow::Result<String> {
         return Err(anyhow::Error::new(NativeSftpTransferError::new(
             NativeSftpTransferErrorKind::InvalidArgument,
             format!(
-                "Remote directory path '{}' resolves to '{}' and cannot be used as a \
-                 download directory name.",
-                path, basename
+                "Remote directory path '{path}' resolves to '{basename}' and cannot be \
+                 used as a download directory name."
             ),
         )));
     }
@@ -2396,10 +2402,7 @@ fn normalize_remote_directory_path(path: &str) -> anyhow::Result<String> {
     if trimmed == "." || trimmed == ".." {
         return Err(anyhow::Error::new(NativeSftpTransferError::new(
             NativeSftpTransferErrorKind::InvalidArgument,
-            format!(
-                "Remote directory path '{}' is not supported for native SFTP transfer.",
-                trimmed
-            ),
+            format!("Remote directory path '{trimmed}' is not supported for native SFTP transfer."),
         )));
     }
 
@@ -2427,9 +2430,8 @@ fn validate_remote_entry_name(file_name: &str) -> anyhow::Result<()> {
         anyhow::Error::new(NativeSftpTransferError::new(
             NativeSftpTransferErrorKind::InvalidArgument,
             format!(
-                "Remote server returned an unsafe directory entry name {:?} ({}). \
-                 Refusing to write outside the download directory.",
-                file_name, reason
+                "Remote server returned an unsafe directory entry name {file_name:?} \
+                 ({reason}). Refusing to write outside the download directory."
             ),
         ))
     };
@@ -2474,16 +2476,48 @@ fn ensure_within_download_root(local_root: &Path, candidate: &Path) -> anyhow::R
     )))
 }
 
-/// Destination for the in-progress copy: the final name plus
-/// [`PARTIAL_DOWNLOAD_SUFFIX`], so the previous good copy at `local_path` survives a
-/// cancelled or failed transfer untouched.
+/// Monotonic discriminator for partial-download file names. Combined with the process
+/// id it keeps concurrent transfers - which `SftpService` runs on independent
+/// `Task.Run` jobs, including two jobs targeting the same destination - from ever
+/// sharing a scratch file.
+static PARTIAL_DOWNLOAD_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Destination for the in-progress copy: the final name plus a per-transfer unique
+/// discriminator and [`PARTIAL_DOWNLOAD_SUFFIX`], so the previous good copy at
+/// `local_path` survives a cancelled or failed transfer untouched.
+///
+/// The name must be unique rather than deterministic: two concurrent downloads to the
+/// same destination would otherwise open and truncate the same scratch file, interleave
+/// their writes, and each rename mismatched content into place while reporting success.
 fn partial_download_path(local_path: &Path) -> PathBuf {
     let mut file_name = local_path
         .file_name()
         .map(OsString::from)
         .unwrap_or_else(|| OsString::from("download"));
-    file_name.push(PARTIAL_DOWNLOAD_SUFFIX);
+    file_name.push(format!(
+        ".{}.{}{}",
+        std::process::id(),
+        PARTIAL_DOWNLOAD_COUNTER.fetch_add(1, Ordering::Relaxed),
+        PARTIAL_DOWNLOAD_SUFFIX
+    ));
     local_path.with_file_name(file_name)
+}
+
+/// Creates the scratch file for an in-progress download.
+///
+/// Uses `create_new` (`O_EXCL` / `CREATE_NEW`) rather than `create`. Beyond catching a
+/// name collision, this is what makes the write safe in a destination directory another
+/// local actor can write to: `create` follows symlinks, so a pre-created
+/// `<destination>.<pid>.<n>.novapart` symlink would redirect the downloaded bytes into
+/// whatever it points at. `O_EXCL` refuses to open an existing path at all, symlink or
+/// not, so a planted link fails the transfer instead of being followed.
+async fn create_partial_download_file(partial_path: &Path) -> anyhow::Result<TokioFile> {
+    tokio::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(partial_path)
+        .await
+        .map_err(|error| map_local_transfer_error(partial_path, error))
 }
 
 /// Best-effort removal of an abandoned partial download. Failures are ignored
@@ -3751,15 +3785,14 @@ mod tests {
 
     fn assert_entry_name_rejected(file_name: &str) {
         let error = validate_remote_entry_name(file_name)
-            .expect_err(&format!("{:?} should be rejected", file_name));
+            .expect_err(&format!("{file_name:?} should be rejected"));
         let native = error
             .downcast_ref::<NativeSftpTransferError>()
             .expect("rejection should be a structured transfer error");
         assert_eq!(
             NativeSftpTransferErrorKind::InvalidArgument,
             native.kind,
-            "{:?} should map to invalid-argument",
-            file_name
+            "{file_name:?} should map to invalid-argument"
         );
     }
 
@@ -3776,7 +3809,7 @@ mod tests {
             "\u{1f600}-emoji",
         ] {
             validate_remote_entry_name(name)
-                .unwrap_or_else(|error| panic!("{:?} should be accepted: {}", name, error));
+                .unwrap_or_else(|error| panic!("{name:?} should be accepted: {error}"));
         }
     }
 
@@ -3848,7 +3881,7 @@ mod tests {
     fn remote_basename_rejects_paths_resolving_to_parent_directory() {
         for path in ["/srv/data/..", "/srv/data/../", "..", "  ..  "] {
             let error = remote_basename(path)
-                .expect_err(&format!("{:?} should not yield a basename", path));
+                .expect_err(&format!("{path:?} should not yield a basename"));
             let native = error
                 .downcast_ref::<NativeSftpTransferError>()
                 .expect("rejection should be a structured transfer error");
@@ -3869,24 +3902,91 @@ mod tests {
 
     #[test]
     fn partial_download_path_appends_suffix_beside_the_destination() {
-        let partial = partial_download_path(Path::new("/home/nova/downloads/archive.tar.gz"));
+        let destination = Path::new("/home/nova/downloads/archive.tar.gz");
+        let partial = partial_download_path(destination);
+        let partial_name = partial
+            .file_name()
+            .and_then(|value| value.to_str())
+            .expect("partial should have a name");
 
-        assert_eq!(
-            Path::new("/home/nova/downloads/archive.tar.gz.novapart"),
-            partial
-        );
+        // Same directory, so the rename is a cheap intra-volume move rather than a copy.
         assert_eq!(
             Path::new("/home/nova/downloads"),
             partial.parent().expect("partial should stay in place")
         );
+        // Prefixed with the full destination name, so a stray file is traceable to it.
+        // This also pins that with_extension is not used - that would turn
+        // "archive.tar.gz" into "archive.tar.novapart" and rename to the wrong path.
+        assert!(
+            partial_name.starts_with("archive.tar.gz."),
+            "unexpected partial name: {partial_name}"
+        );
+        assert!(
+            partial_name.ends_with(PARTIAL_DOWNLOAD_SUFFIX),
+            "unexpected partial name: {partial_name}"
+        );
+        assert_ne!(destination, partial);
     }
 
     #[test]
-    fn partial_download_path_does_not_replace_the_existing_extension() {
-        // with_extension would turn "archive.tar.gz" into "archive.tar.novapart".
-        let partial = partial_download_path(Path::new("archive.tar.gz"));
+    fn partial_download_path_is_unique_per_call() {
+        // Two concurrent downloads to the same destination must not share a scratch
+        // file; a deterministic name let their writes interleave.
+        let destination = Path::new("/home/nova/downloads/archive.tar.gz");
+        let first = partial_download_path(destination);
+        let second = partial_download_path(destination);
 
-        assert_eq!(Path::new("archive.tar.gz.novapart"), partial);
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn create_partial_download_file_refuses_an_existing_path() {
+        // O_EXCL is what stops a planted symlink at the scratch path from redirecting
+        // the downloaded bytes: an existing path fails rather than being followed.
+        let runtime = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime should build");
+
+        runtime.block_on(async {
+            let dir = std::env::temp_dir().join(format!(
+                "nova-exclusive-{}-{}",
+                std::process::id(),
+                PARTIAL_DOWNLOAD_COUNTER.fetch_add(1, Ordering::Relaxed)
+            ));
+            tokio::fs::create_dir_all(&dir)
+                .await
+                .expect("temp dir should be creatable");
+
+            let occupied = dir.join("already-there.novapart");
+            tokio::fs::write(&occupied, b"pre-existing content")
+                .await
+                .expect("pre-existing file should be writable");
+
+            let error = create_partial_download_file(&occupied)
+                .await
+                .expect_err("existing path should be refused");
+            assert!(
+                !error.to_string().is_empty(),
+                "refusal should carry a message"
+            );
+
+            // The pre-existing content must be untouched - not truncated.
+            let preserved = tokio::fs::read(&occupied)
+                .await
+                .expect("pre-existing file should still be readable");
+            assert_eq!(b"pre-existing content".to_vec(), preserved);
+
+            // A fresh path in the same directory still succeeds.
+            let fresh = dir.join("fresh.novapart");
+            let file = create_partial_download_file(&fresh)
+                .await
+                .expect("fresh path should be creatable");
+            drop(file);
+            assert!(fresh.exists());
+
+            let _ = tokio::fs::remove_dir_all(&dir).await;
+        });
     }
 
     #[test]

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -5,11 +5,11 @@ use russh::{ChannelMsg, Disconnect};
 use russh_sftp::client::SftpSession;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
-use std::ffi::{CStr, CString};
+use std::ffi::{CStr, CString, OsStr, OsString};
 use std::future::Future;
 use std::io::Cursor;
 use std::panic::{catch_unwind, AssertUnwindSafe};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::ptr;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, OnceLock, mpsc as std_mpsc};
@@ -1870,10 +1870,16 @@ async fn download_file_from_remote(
         }
     }
 
-    let mut local_file = TokioFile::create(local_path)
+    // Download into a sibling `.novapart` file and rename on success. Writing straight
+    // to `local_path` would truncate an existing good copy the moment the file is
+    // created — before a single byte arrives — so a cancelled or failed re-download
+    // used to destroy the previous version and leave a truncated file behind.
+    let partial_path = partial_download_path(local_path);
+    let mut local_file = TokioFile::create(&partial_path)
         .await
-        .map_err(|error| map_local_transfer_error(local_path, error))?;
-    copy_file_with_cancellation(
+        .map_err(|error| map_local_transfer_error(&partial_path, error))?;
+
+    if let Err(error) = copy_file_with_cancellation(
         &mut remote_file,
         &mut local_file,
         cancellation_marker_path,
@@ -1882,8 +1888,28 @@ async fn download_file_from_remote(
         progress,
         copy_buffer,
     )
-    .await?;
-    local_file.flush().await?;
+    .await
+    {
+        drop(local_file);
+        discard_partial_download(&partial_path).await;
+        return Err(error);
+    }
+
+    if let Err(error) = local_file.flush().await {
+        drop(local_file);
+        discard_partial_download(&partial_path).await;
+        return Err(map_local_transfer_error(&partial_path, error));
+    }
+
+    // Close the handle before renaming: Windows refuses to rename a file that still
+    // has an open handle.
+    drop(local_file);
+
+    if let Err(error) = tokio::fs::rename(&partial_path, local_path).await {
+        discard_partial_download(&partial_path).await;
+        return Err(map_local_transfer_error(local_path, error));
+    }
+
     remote_file.shutdown().await?;
     Ok(())
 }
@@ -1990,8 +2016,10 @@ async fn download_directory_from_remote(
         for entry in entries {
             ensure_transfer_not_canceled(cancellation_marker_path)?;
             let file_name = entry.file_name();
+            validate_remote_entry_name(&file_name)?;
             let remote_child = join_remote_path(&remote_dir, &file_name);
             let local_child = local_dir.join(&file_name);
+            ensure_within_download_root(local_root, &local_child)?;
             let metadata = entry.metadata();
 
             if metadata.is_dir() {
@@ -2286,13 +2314,31 @@ impl std::error::Error for NativeSftpTransferError {}
 
 fn remote_basename(path: &str) -> anyhow::Result<String> {
     let normalized = normalize_remote_directory_path(path)?;
-    normalized
+    let basename = normalized
         .rsplit('/')
         .find(|segment| !segment.is_empty())
         .map(str::to_owned)
         .ok_or_else(|| {
             anyhow::anyhow!("Remote directory name is required for native SFTP transfer.")
-        })
+        })?;
+
+    // A remote path ending in `/..` (or `/.`) would otherwise yield a basename of
+    // ".." and relocate the download root a level above the directory the user
+    // chose. User-supplied rather than server-supplied, so this is hygiene rather
+    // than the vulnerability fixed in validate_remote_entry_name — but the root
+    // still has to land where the user pointed it.
+    if basename == "." || basename == ".." {
+        return Err(anyhow::Error::new(NativeSftpTransferError::new(
+            NativeSftpTransferErrorKind::InvalidArgument,
+            format!(
+                "Remote directory path '{}' resolves to '{}' and cannot be used as a \
+                 download directory name.",
+                path, basename
+            ),
+        )));
+    }
+
+    Ok(basename)
 }
 
 fn resolve_upload_file_destination_path(
@@ -2347,14 +2393,104 @@ fn normalize_remote_directory_path(path: &str) -> anyhow::Result<String> {
         return Ok("/".to_owned());
     }
 
-    if trimmed == "." {
+    if trimmed == "." || trimmed == ".." {
         return Err(anyhow::Error::new(NativeSftpTransferError::new(
             NativeSftpTransferErrorKind::InvalidArgument,
-            "Remote directory path '.' is not supported for native SFTP transfer.",
+            format!(
+                "Remote directory path '{}' is not supported for native SFTP transfer.",
+                trimmed
+            ),
         )));
     }
 
     Ok(trimmed.to_owned())
+}
+
+/// Suffix used for in-progress downloads so a cancelled or failed transfer never
+/// leaves a truncated file at the destination path.
+const PARTIAL_DOWNLOAD_SUFFIX: &str = ".novapart";
+
+/// Validates a **server-supplied** directory entry name before it is joined onto a
+/// local path.
+///
+/// Entry names returned by `read_dir` are attacker-controlled: a malicious or
+/// compromised server chooses them. `Path::join` with an absolute component silently
+/// *replaces* the base rather than nesting under it, so an unchecked join turns a
+/// directory download into an arbitrary file write anywhere the process can reach.
+///
+/// A legitimate entry name is exactly one normal path component. Requiring that (and
+/// that the component round-trips to the original string) rejects every escape shape
+/// at once: `..`, `.`, empty, `/` or `\` separators, absolute and drive-relative
+/// paths (`/etc/cron.d/x`, `C:\Windows\x`, `C:x`), UNC prefixes, and interior NULs.
+fn validate_remote_entry_name(file_name: &str) -> anyhow::Result<()> {
+    let rejected = |reason: &str| {
+        anyhow::Error::new(NativeSftpTransferError::new(
+            NativeSftpTransferErrorKind::InvalidArgument,
+            format!(
+                "Remote server returned an unsafe directory entry name {:?} ({}). \
+                 Refusing to write outside the download directory.",
+                file_name, reason
+            ),
+        ))
+    };
+
+    if file_name.is_empty() {
+        return Err(rejected("empty"));
+    }
+
+    if file_name.contains('\0') {
+        return Err(rejected("contains a NUL byte"));
+    }
+
+    // Reject both separators regardless of host platform: a name containing '\' is
+    // harmless on Unix but escapes on Windows, and the same server may serve both.
+    if file_name.contains('/') || file_name.contains('\\') {
+        return Err(rejected("contains a path separator"));
+    }
+
+    let mut components = Path::new(file_name).components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(value)), None) if value == OsStr::new(file_name) => Ok(()),
+        _ => Err(rejected("is not a single relative path component")),
+    }
+}
+
+/// Defence in depth for [`validate_remote_entry_name`]: confirms a joined child path
+/// is still lexically inside the download root. Purely a guard against a future
+/// refactor reintroducing an unvalidated join — with name validation in place this
+/// never fires.
+fn ensure_within_download_root(local_root: &Path, candidate: &Path) -> anyhow::Result<()> {
+    if candidate.starts_with(local_root) {
+        return Ok(());
+    }
+
+    Err(anyhow::Error::new(NativeSftpTransferError::new(
+        NativeSftpTransferErrorKind::InvalidArgument,
+        format!(
+            "Refusing to write {} outside the download directory {}.",
+            candidate.display(),
+            local_root.display()
+        ),
+    )))
+}
+
+/// Destination for the in-progress copy: the final name plus
+/// [`PARTIAL_DOWNLOAD_SUFFIX`], so the previous good copy at `local_path` survives a
+/// cancelled or failed transfer untouched.
+fn partial_download_path(local_path: &Path) -> PathBuf {
+    let mut file_name = local_path
+        .file_name()
+        .map(OsString::from)
+        .unwrap_or_else(|| OsString::from("download"));
+    file_name.push(PARTIAL_DOWNLOAD_SUFFIX);
+    local_path.with_file_name(file_name)
+}
+
+/// Best-effort removal of an abandoned partial download. Failures are ignored
+/// deliberately: the caller is already returning the original transfer error, and a
+/// leftover `.novapart` file is strictly less harmful than masking that error.
+async fn discard_partial_download(partial_path: &Path) {
+    let _ = tokio::fs::remove_file(partial_path).await;
 }
 
 fn join_remote_path(base: &str, child: &str) -> String {
@@ -3609,6 +3745,181 @@ mod tests {
         assert_eq!(NOVA_SSH_RESULT_CLOSED, result);
         assert_eq!("error", status);
         assert_eq!("Remote path not found: /tmp/missing", message);
+    }
+
+    // ---- #104: server-supplied entry names must not escape the download root ----
+
+    fn assert_entry_name_rejected(file_name: &str) {
+        let error = validate_remote_entry_name(file_name)
+            .expect_err(&format!("{:?} should be rejected", file_name));
+        let native = error
+            .downcast_ref::<NativeSftpTransferError>()
+            .expect("rejection should be a structured transfer error");
+        assert_eq!(
+            NativeSftpTransferErrorKind::InvalidArgument,
+            native.kind,
+            "{:?} should map to invalid-argument",
+            file_name
+        );
+    }
+
+    #[test]
+    fn validate_remote_entry_name_accepts_ordinary_names() {
+        for name in [
+            "file.txt",
+            "nested-dir",
+            "with space.log",
+            "dot.in.middle",
+            "..prefixed",
+            "trailing..",
+            "...",
+            "\u{1f600}-emoji",
+        ] {
+            validate_remote_entry_name(name)
+                .unwrap_or_else(|error| panic!("{:?} should be accepted: {}", name, error));
+        }
+    }
+
+    #[test]
+    fn validate_remote_entry_name_rejects_parent_and_current_directory() {
+        assert_entry_name_rejected("..");
+        assert_entry_name_rejected(".");
+    }
+
+    #[test]
+    fn validate_remote_entry_name_rejects_separators_and_traversal() {
+        assert_entry_name_rejected("../evil");
+        assert_entry_name_rejected("../../evil");
+        assert_entry_name_rejected("nested/child");
+        assert_entry_name_rejected("..\\evil");
+        assert_entry_name_rejected("nested\\child");
+    }
+
+    #[test]
+    fn validate_remote_entry_name_rejects_absolute_and_drive_relative_paths() {
+        // Path::join with any of these silently replaces the download root.
+        assert_entry_name_rejected("/etc/cron.d/payload");
+        assert_entry_name_rejected("/");
+        assert_entry_name_rejected("C:\\Windows\\System32\\payload.dll");
+        assert_entry_name_rejected("\\\\server\\share\\payload");
+    }
+
+    #[test]
+    fn validate_remote_entry_name_rejects_empty_and_nul_names() {
+        assert_entry_name_rejected("");
+        assert_entry_name_rejected("payload\0.txt");
+    }
+
+    #[test]
+    // The absolute join is the whole point of this test: it pins the `Path::join`
+    // replacement behaviour that makes validate_remote_entry_name necessary. Clippy's
+    // join_absolute_paths lint is exactly the bug being demonstrated.
+    #[allow(clippy::join_absolute_paths)]
+    fn path_join_with_absolute_entry_name_would_escape_the_root() {
+        // Documents *why* validation is required rather than relying on join semantics.
+        let root = Path::new("/home/nova/downloads");
+        let escaped = root.join("/etc/cron.d/payload");
+
+        assert_eq!(Path::new("/etc/cron.d/payload"), escaped);
+        assert!(!escaped.starts_with(root));
+        assert!(ensure_within_download_root(root, &escaped).is_err());
+    }
+
+    #[test]
+    fn ensure_within_download_root_accepts_nested_children() {
+        let root = Path::new("/home/nova/downloads");
+
+        ensure_within_download_root(root, &root.join("a"))
+            .expect("direct child should be accepted");
+        ensure_within_download_root(root, &root.join("a").join("b").join("c.txt"))
+            .expect("nested child should be accepted");
+    }
+
+    #[test]
+    fn ensure_within_download_root_rejects_sibling_prefix_collision() {
+        // "downloads-evil" shares a string prefix with "downloads" but is not inside it.
+        let root = Path::new("/home/nova/downloads");
+
+        assert!(ensure_within_download_root(root, Path::new("/home/nova/downloads-evil/x")).is_err());
+        assert!(ensure_within_download_root(root, Path::new("/home/nova/other")).is_err());
+    }
+
+    #[test]
+    fn remote_basename_rejects_paths_resolving_to_parent_directory() {
+        for path in ["/srv/data/..", "/srv/data/../", "..", "  ..  "] {
+            let error = remote_basename(path)
+                .expect_err(&format!("{:?} should not yield a basename", path));
+            let native = error
+                .downcast_ref::<NativeSftpTransferError>()
+                .expect("rejection should be a structured transfer error");
+            assert_eq!(NativeSftpTransferErrorKind::InvalidArgument, native.kind);
+        }
+    }
+
+    #[test]
+    fn remote_basename_still_resolves_ordinary_directories() {
+        assert_eq!("data", remote_basename("/srv/data").expect("should resolve"));
+        assert_eq!(
+            "data",
+            remote_basename("/srv/data/").expect("trailing slash should resolve")
+        );
+    }
+
+    // ---- #144: partial downloads must not clobber the destination ----
+
+    #[test]
+    fn partial_download_path_appends_suffix_beside_the_destination() {
+        let partial = partial_download_path(Path::new("/home/nova/downloads/archive.tar.gz"));
+
+        assert_eq!(
+            Path::new("/home/nova/downloads/archive.tar.gz.novapart"),
+            partial
+        );
+        assert_eq!(
+            Path::new("/home/nova/downloads"),
+            partial.parent().expect("partial should stay in place")
+        );
+    }
+
+    #[test]
+    fn partial_download_path_does_not_replace_the_existing_extension() {
+        // with_extension would turn "archive.tar.gz" into "archive.tar.novapart".
+        let partial = partial_download_path(Path::new("archive.tar.gz"));
+
+        assert_eq!(Path::new("archive.tar.gz.novapart"), partial);
+    }
+
+    #[test]
+    fn discard_partial_download_removes_the_file_and_tolerates_a_missing_one() {
+        let runtime = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime should build");
+
+        runtime.block_on(async {
+            let dir = std::env::temp_dir().join(format!(
+                "nova-partial-{}-{:?}",
+                std::process::id(),
+                std::thread::current().id()
+            ));
+            tokio::fs::create_dir_all(&dir)
+                .await
+                .expect("temp dir should be creatable");
+            let partial = dir.join("download.novapart");
+            tokio::fs::write(&partial, b"partial bytes")
+                .await
+                .expect("partial file should be writable");
+            assert!(partial.exists());
+
+            discard_partial_download(&partial).await;
+            assert!(!partial.exists(), "partial file should be removed");
+
+            // Second call must not panic or error - cleanup runs on paths that may
+            // already be gone.
+            discard_partial_download(&partial).await;
+
+            let _ = tokio::fs::remove_dir_all(&dir).await;
+        });
     }
 }
 


### PR DESCRIPTION
Fixes #104 · Fixes #144

Both defects live in the same `rusty_ssh` download function family, so they share one native rebuild and one security review — per the sequencing in the 2026-07-27 issue triage, which ranked #104 as the only P0 in the backlog.

---

## #104 — remote filename path traversal (Critical)

`download_directory_from_remote` joined **server-supplied** `read_dir` entry names straight onto the local path:

```rust
let file_name = entry.file_name();          // untrusted: chosen by the server
let local_child = local_dir.join(&file_name);
```

There was no `..` rejection, no separator check, no absolute-path check, and no containment test anywhere on the path — verified: the file's only `canonicalize` calls are remote home expansion, and the managed side (`NativeSftpTransferModels.cs`) has no `..`, `GetFullPath`, or `StartsWith` guard either.

`Path::join` with an absolute component **replaces** the base rather than nesting under it, so this was an arbitrary file write anywhere the process could reach:

| Server-supplied name | Result before this PR |
|---|---|
| `/etc/cron.d/payload` | writes to `/etc/cron.d/payload` |
| `C:\Windows\System32\payload.dll` | writes outside the root on Windows |
| `..\..\evil.exe` | escapes relatively |

Aggravating factor: an escaped directory was pushed back onto the `pending` queue, so a whole subtree could be written outside the chosen root, not just one file.

**Fix.** `validate_remote_entry_name` requires each entry name to be exactly one normal path component that round-trips to the original string. That single rule rejects every escape shape at once — `..`, `.`, empty, `/` and `\` separators, absolute and drive-relative paths (`C:x`), UNC prefixes, and interior NULs — rather than blacklisting patterns one at a time.

Two deliberate choices worth reviewing:

- **Both separators are rejected on every platform.** A name containing `\` is harmless on Unix but escapes on Windows, and the same server may serve both; a platform-conditional check would leave the Windows client exposed to a name that a Unix client accepted silently.
- **`ensure_within_download_root` is defence in depth, not the primary control.** With name validation in place it can never fire. It exists so that a future refactor reintroducing an unvalidated join fails loudly instead of silently. Its test covers the sibling-prefix case (`/downloads-evil` must not count as inside `/downloads`) since `Path::starts_with` is component-wise and a naive string prefix check would pass it.

**Also hardened (the secondary, lower-severity half of the issue).** `remote_basename` rejected only `.`, so a user remote path ending in `/..` yielded a basename of `..` and relocated the download root one level above the directory the user picked. Both `remote_basename` and `normalize_remote_directory_path` now reject `.` and `..`. This input is user-supplied rather than server-supplied, so it was hygiene rather than a vulnerability — but the root still has to land where the user pointed it.

## #144 — partial download leaves a truncated file (High)

`download_file_from_remote` wrote straight to the final destination:

```rust
let mut local_file = TokioFile::create(local_path).await?;
```

The issue described this as leaving junk behind. It is worse than that: **`create` truncates an existing file at open time, before a single byte arrives.** A cancelled or failed re-download destroyed the previously good local copy and left a truncated file in its place — silent data loss.

**Fix.** Download to a sibling `.novapart` file; rename into place only after a successful copy and flush. Every error, cancellation, flush-failure, and rename-failure path removes the partial file. The handle is explicitly dropped before the rename because Windows refuses to rename a file that still has an open handle.

`partial_download_path` appends the suffix rather than using `with_extension`, which would turn `archive.tar.gz` into `archive.tar.novapart` and rename to the wrong destination — there's a test pinning that.

Cleanup failures are deliberately ignored: the caller is already returning the original transfer error, and a leftover `.novapart` is strictly less harmful than masking the real failure.

---

## Testing

12 new unit tests in the existing `tests` module:

- accepted ordinary names, including the ones a naive blacklist would over-reject (`..prefixed`, `trailing..`, `...`, emoji)
- rejection of `..` / `.`, separators and traversal, absolute and drive-relative and UNC paths, empty and NUL names
- the `Path::join` replacement behaviour itself, so the reason validation is required is pinned rather than assumed
- containment including the sibling-prefix collision case
- `remote_basename` rejection of `..`, plus a regression test that ordinary directories still resolve
- partial-path construction against compound extensions, and idempotent cleanup

Results:

- `cargo test` (the gate `ci.yml` `rust-ffi-tests` runs): **49 passed, 0 failed**, all 12 new tests confirmed executing by name.
- `cargo clippy --all-targets`: no new lints. Baseline on `main` is 27 pre-existing lints (FFI raw-pointer and format-string); this branch adds none. The one new hit was `join_absolute_paths` on the test that deliberately demonstrates the vulnerable join — annotated with `#[allow]` and a comment explaining why.
- `NovaTerminal.Platform.Tests`: **122 passed, 0 failed**, 18 skipped.

### Two caveats for the reviewer

1. **The 18 skipped Platform tests are the Docker SFTP E2E suite** (`NativeSshDockerE2eTests`), which is exactly the layer that would exercise these paths end-to-end. They skip without a Docker daemon, so the fixes are covered by unit tests and review, not by an integration run. Worth confirming they pass in CI.
2. **The full-solution build could not be verified locally.** `scripts/build.ps1 build` failed with `MSB3027`/`MSB3021` — two running `NovaTerminal.McpServer` processes hold a lock on `NovaTerminal.AgentHost.Contracts.dll`. That is an environment issue unrelated to this change (no managed code is touched), and the projects that matter here compiled and tested cleanly.
