### PR TITLE
test(sftp): pin that rename replaces an existing download destination

### DIFF
--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -4066,6 +4066,61 @@ mod tests {
     }
 
     #[test]
+    fn rename_replaces_an_existing_destination() {
+        // download_file_from_remote commits by renaming the `.novapart` scratch file
+        // over `local_path`, which assumes rename REPLACES an existing destination
+        // rather than failing. That holds on all three target platforms today
+        // (on Windows via SetFileInformationByHandle + FileRenameInfo.ReplaceIfExists),
+        // but it is a platform guarantee this crate silently depends on rather than one
+        // it controls: if it ever stopped holding, every re-download over an existing
+        // file would fail and directory re-downloads would abort at the first such file.
+        // Raised as a concern on PR #210; pinned here so a regression is caught by
+        // `cargo test` instead of by users.
+        let runtime = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime should build");
+
+        runtime.block_on(async {
+            let dir = std::env::temp_dir().join(format!(
+                "nova-rename-{}-{}",
+                std::process::id(),
+                PARTIAL_DOWNLOAD_COUNTER.fetch_add(1, Ordering::Relaxed)
+            ));
+            tokio::fs::create_dir_all(&dir)
+                .await
+                .expect("temp dir should be creatable");
+
+            let destination = dir.join("archive.tar.gz");
+            let partial = partial_download_path(&destination);
+            tokio::fs::write(&destination, b"stale previous download")
+                .await
+                .expect("destination should be writable");
+            tokio::fs::write(&partial, b"freshly downloaded bytes")
+                .await
+                .expect("partial should be writable");
+
+            tokio::fs::rename(&partial, &destination)
+                .await
+                .expect("rename must replace an existing destination");
+
+            assert_eq!(
+                b"freshly downloaded bytes".to_vec(),
+                tokio::fs::read(&destination)
+                    .await
+                    .expect("destination should be readable"),
+                "destination should hold the newly downloaded bytes"
+            );
+            assert!(
+                !partial.exists(),
+                "the scratch file should be consumed by the rename"
+            );
+
+            let _ = tokio::fs::remove_dir_all(&dir).await;
+        });
+    }
+
+    #[test]
     fn discard_partial_download_removes_the_file_and_tolerates_a_missing_one() {
         let runtime = Builder::new_current_thread()
             .enable_all()


### PR DESCRIPTION
Follow-up to review feedback on #210. Test only — no production code changes.

## Why

`download_file_from_remote` commits a download by renaming the `.novapart` scratch file over the final destination. That makes correctness depend on **rename replacing an existing destination rather than failing** — a platform guarantee this crate relies on but does not control, and which nothing in the suite pinned.

Review of #210 flagged this as a suspected Windows defect: the concern was that `tokio::fs::rename` cannot replace an existing file on Windows, which would make every re-download over an existing file fail and abort directory re-downloads at the first such file.

**The defect doesn't reproduce** — `std::fs::rename` does replace on Windows (via `SetFileInformationByHandle` with `FileRenameInfo { ReplaceIfExists: true }`; formerly `MoveFileEx` + `MOVEFILE_REPLACE_EXISTING`). Probed on Windows 10.0.26200 / rustc 1.88.0:

```
CASE1 replace-existing:    OK      dest_now="FRESH-NEW-CONTENT"  partial_gone=true
CASE2 readonly-dest:       FAILED  kind=PermissionDenied  (os error 5)
CASE3 dest-open-for-read:  OK      (replaced)
CASE4 dest-is-directory:   FAILED  kind=PermissionDenied  (os error 5)
```

CASE2 and CASE4 do fail, but both failed identically before #210 — `TokioFile::create(local_path)` also returned `PermissionDenied` on a read-only file or a directory path — so neither is a regression, and in both cases the existing file is left intact.

So no fix is needed. But the exchange surfaced something worth keeping: this is a load-bearing platform assumption with no test behind it. If it ever stopped holding, the failure would reach users rather than CI.

## What this adds

One test, `rename_replaces_an_existing_destination`, which writes a stale destination plus a fresh scratch file, renames, and asserts the destination ends up with the new bytes and the scratch file is consumed. It runs on every platform in CI, so the guarantee is checked on Windows, Linux, and macOS rather than assumed from one developer machine.

## Verification

- `cargo test`: 51 passed, 0 failed (47 unit + 4 FFI contract).
- `cargo clippy --all-targets`: 27 lints, exactly the `main` baseline.
