### PR TITLE
fix(pty): bound the read-error retry and stop leaking PowerShell init scripts

### DIFF
--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -492,6 +492,22 @@ namespace NovaTerminal.Pty
                     {
                         Console.WriteLine($"[RustPtySession] PS Injection Failed: {ex.Message}");
                     }
+                    finally
+                    {
+                        // Close the window where Dispose finished before this task did.
+                        // Dispose waits only briefly for us; if the write ran long, its
+                        // single delete attempt could hit a file still open here, or run
+                        // before the file existed at all. Whichever of the two finishes
+                        // last performs the delete, so neither ordering leaks.
+                        //
+                        // Guarded on teardown: on the happy path the shell sources the
+                        // script and it deletes itself, and deleting it here would race
+                        // that read.
+                        if (_cts.IsCancellationRequested || Volatile.Read(ref _disposed) != 0)
+                        {
+                            TryDeleteInitScript();
+                        }
+                    }
                 });
             }
         }
@@ -678,13 +694,42 @@ namespace NovaTerminal.Pty
             }
             finally
             {
-                // Claim the exit notification BEFORE completing the queue. Completing it
-                // releases ProcessLoop, which unconditionally reports TryNotifyExit(0),
-                // and the first caller wins (Interlocked guard) — so notifying after
-                // CompleteAdding would race and usually lose, reporting a read failure
-                // as a clean exit.
                 if (readFailed)
                 {
+                    // Tear the session down before announcing it. Reporting the exit alone
+                    // would leave the UI recording a terminated session while the child
+                    // process, the writer thread and the native handle all stayed alive —
+                    // nothing else disposes us on our own initiative
+                    // (MainWindow.OnPaneProcessExited only records the exit code).
+                    //
+                    // Deliberately not calling Dispose(): it joins this very thread, and
+                    // Thread.Join on the current thread is invalid, which would abort the
+                    // rest of the teardown. This does the subset that is safe from here.
+                    try
+                    {
+                        _cts.Cancel();
+
+                        if (!_inputQueue.IsAddingCompleted)
+                        {
+                            _inputQueue.CompleteAdding();
+                        }
+
+                        // Releases the PTY, which ends the child and unblocks a writer
+                        // parked in pty_write. Safe from this thread: the SafeHandle
+                        // refcount makes pty_close wait for any in-flight pty_* call, and
+                        // Dispose() is idempotent so a later disposal still works.
+                        _handle.Dispose();
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"[RustPtySession] teardown after read failure failed: {ex.Message}");
+                    }
+
+                    // Claim the notification BEFORE completing the output queue below.
+                    // Completing it releases ProcessLoop, which unconditionally reports
+                    // TryNotifyExit(0), and the first caller wins (Interlocked guard) — so
+                    // notifying after would usually lose the race and report a read
+                    // failure as a clean exit.
                     TryNotifyExit(ReadFailureExitCode);
                 }
 
@@ -890,6 +935,14 @@ namespace NovaTerminal.Pty
                 }
             }
 
+            TryDeleteInitScript();
+        }
+
+        /// Removes the init script if one was written. Idempotent and never throws, so it
+        /// is safe to call from both Dispose and the injection task's finally - whichever
+        /// runs last wins, which is what makes the two orderings equivalent.
+        private void TryDeleteInitScript()
+        {
             string? scriptPath = _powerShellInitScriptPath;
             if (scriptPath == null) return;
 

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -719,6 +719,13 @@ namespace NovaTerminal.Pty
                         // refcount makes pty_close wait for any in-flight pty_* call, and
                         // Dispose() is idempotent so a later disposal still works.
                         _handle.Dispose();
+
+                        // Make the emergency path self-contained rather than deferring to
+                        // the owner's eventual Dispose. If the shell died without sourcing
+                        // the init script, the script would otherwise survive for as long
+                        // as the dead pane stayed open. Safe here: the handle is already
+                        // released, so no shell can be mid-source.
+                        TryDeleteInitScript();
                     }
                     catch (Exception ex)
                     {

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Win32.SafeHandles;
@@ -30,6 +31,38 @@ namespace NovaTerminal.Pty
         private static readonly TimeSpan QuickJoinTimeout = TimeSpan.FromMilliseconds(250);
         private static readonly TimeSpan DisposeJoinTimeout = TimeSpan.FromSeconds(2);
         private int _disposed;
+
+        // A negative pty_read is retried a bounded number of times, then treated as
+        // terminal. Previously it retried forever at 20 Hz, so a permanently failing
+        // handle left the tab frozen with no error and the loop spinning for the life of
+        // the process (#107). 20 attempts x 50 ms tolerates roughly a second of
+        // transient failure before giving up.
+        //
+        // The retry exists only because the cause cannot be identified: pty_read
+        // collapses every failure to -1 (null args, read error with errno discarded,
+        // poisoned lock, and a panic caught by ffi_guard all return the same value), so
+        // a transient condition is indistinguishable from an unrecoverable one here.
+        // Classifying them needs the pty_last_error channel tracked in #120; until then
+        // "retry a bounded number of times, then fail" is the safe reading.
+        internal const int MaxConsecutiveReadErrors = 20;
+        private static readonly TimeSpan ReadErrorRetryDelay = TimeSpan.FromMilliseconds(50);
+
+        /// Exit code reported when the read loop gives up after repeated failures, to
+        /// distinguish it from a clean shell exit (0). Not an OS exit status - the
+        /// process may still be alive; the *session* is what has failed.
+        internal const int ReadFailureExitCode = -1;
+
+        // PowerShell post-launch init injection. Held so Dispose can observe the task's
+        // failures instead of dropping them, and delete the script if the shell never
+        // sourced it (the script deletes itself on the happy path). Both are written from
+        // the injection task and read by Dispose, hence the volatile access.
+        private Task? _powerShellInitTask;
+        private volatile string? _powerShellInitScriptPath;
+
+        // Test hook: lets the #107 cleanup guard assert on the exact file this session
+        // created, rather than inferring it by diffing %TEMP% (which cannot tell "never
+        // created" apart from "created and cleaned up").
+        internal string? PowerShellInitScriptPath => _powerShellInitScriptPath;
 
         // Bounded queue for back-pressure - prevents OOM on high-throughput output
         private readonly BlockingCollection<string> _outputQueue = new BlockingCollection<string>(boundedCapacity: 100);
@@ -405,10 +438,20 @@ namespace NovaTerminal.Pty
             if (!skipPowerShellPostLaunchInit &&
                 (shellLower.Contains("powershell") || shellLower.Contains("pwsh")))
             {
-                Task.Delay(300).ContinueWith(_ =>
+                // Tracked (not discarded) so Dispose can observe failures, and cancelled
+                // with the session so closing a tab inside the delay window doesn't
+                // inject into a dead handle.
+                _powerShellInitTask = Task.Run(async () =>
                 {
                     try
                     {
+                        await Task.Delay(300, _cts.Token).ConfigureAwait(false);
+
+                        string tempScript = System.IO.Path.Combine(
+                            System.IO.Path.GetTempPath(),
+                            $"nova_init_{Guid.NewGuid()}.ps1");
+                        string cleanPath = tempScript.Replace("'", "''");
+
                         var sb = new StringBuilder();
                         // 1. Set Encoding cleanly
                         sb.AppendLine("$OutputEncoding = [System.Console]::OutputEncoding = [System.Text.Encoding]::UTF8;");
@@ -420,13 +463,30 @@ namespace NovaTerminal.Pty
                         sb.AppendLine("Write-Host ''");
                         sb.AppendLine("Write-Host 'Install the latest PowerShell for new features and improvements! https://aka.ms/PSWindows';");
                         sb.AppendLine("Write-Host ''");
+                        // 4. Delete this script. Self-deletion is what actually fixes the
+                        //    %TEMP% leak (#107): the file is removed the moment the shell
+                        //    has finished sourcing it, with no timer to guess at. The
+                        //    Dispose-time cleanup below is only a backstop for the case
+                        //    where the shell never runs it at all.
+                        sb.AppendLine($"Remove-Item -LiteralPath '{cleanPath}' -Force -ErrorAction SilentlyContinue;");
 
-                        string tempScript = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"nova_init_{Guid.NewGuid()}.ps1");
+                        // Record the path before writing, so a failure between write and
+                        // injection still leaves something for Dispose to clean up.
+                        _powerShellInitScriptPath = tempScript;
+
+                        // Deliberately the synchronous write, matching the original code.
+                        // An awaited WriteAllTextAsync adds a scheduling hop between the
+                        // delay and SendInput, which moved the injected keystrokes later
+                        // and made PtySmokeTests.AgentSentInput_IsByteFaithful flaky - the
+                        // injection landed inside that test's recording window. Injection
+                        // timing is observable behaviour, so it is kept as it was.
                         System.IO.File.WriteAllText(tempScript, sb.ToString());
 
-                        // Inject the execution command
-                        string cleanPath = tempScript.Replace("'", "''");
                         SendInput($"& '{cleanPath}'\r");
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // Session closed inside the delay window — nothing to inject.
                     }
                     catch (Exception ex)
                     {
@@ -545,6 +605,11 @@ namespace NovaTerminal.Pty
             // This runs on a dedicated thread, so an unhandled exception would crash the
             // whole process (unlike the old Task.Run, whose unobserved exceptions were
             // swallowed). Contain it so a decode/recorder failure can't take down the host.
+            // Set when the loop gives up after repeated read failures, so the exit is
+            // reported as a failure rather than the clean 0 ProcessLoop would send.
+            bool readFailed = false;
+            int consecutiveReadErrors = 0;
+
             try
             {
                 while (!_cts.Token.IsCancellationRequested && !_handle.IsInvalid)
@@ -552,6 +617,8 @@ namespace NovaTerminal.Pty
                     int read = Native.pty_read(_handle, buffer, buffer.Length);
                     if (read > 0)
                     {
+                        consecutiveReadErrors = 0;
+
                         // Record raw bytes before any processing
                         _recorder?.RecordChunk(buffer, read);
                         _flightRecorder?.RecordChunk(buffer, read);
@@ -582,11 +649,22 @@ namespace NovaTerminal.Pty
                         Console.WriteLine("[RustPtySession] EOF received.");
                         break;
                     }
-                    else // Error
+                    else // read < 0: error
                     {
                         // Reset decoder state on error to prevent corruption
                         _utf8Decoder.Reset();
-                        Thread.Sleep(50);
+
+                        if (++consecutiveReadErrors >= MaxConsecutiveReadErrors)
+                        {
+                            // Fail the session instead of spinning forever. See
+                            // MaxConsecutiveReadErrors for why the cause is unknown here.
+                            Console.WriteLine(
+                                $"[RustPtySession] pty_read failed {consecutiveReadErrors} times consecutively; ending session.");
+                            readFailed = true;
+                            break;
+                        }
+
+                        Thread.Sleep(ReadErrorRetryDelay);
                     }
                 }
             }
@@ -600,6 +678,16 @@ namespace NovaTerminal.Pty
             }
             finally
             {
+                // Claim the exit notification BEFORE completing the queue. Completing it
+                // releases ProcessLoop, which unconditionally reports TryNotifyExit(0),
+                // and the first caller wins (Interlocked guard) — so notifying after
+                // CompleteAdding would race and usually lose, reporting a read failure
+                // as a clean exit.
+                if (readFailed)
+                {
+                    TryNotifyExit(ReadFailureExitCode);
+                }
+
                 // Always signal the consumer so ProcessLoop's GetConsumingEnumerable
                 // unblocks and that thread can exit, even if the loop above threw.
                 if (!_outputQueue.IsAddingCompleted)
@@ -713,6 +801,7 @@ namespace NovaTerminal.Pty
 
             // 1. Stop the loops re-entering native calls, and let the process loop drain.
             _cts.Cancel();
+
             if (!_outputQueue.IsAddingCompleted)
             {
                 _outputQueue.CompleteAdding();
@@ -759,7 +848,63 @@ namespace NovaTerminal.Pty
             //    no pty_* call is in flight, so this is UAF-safe even if a join timed out.
             _handle.Dispose();
 
+            // 6. Observe the PowerShell injection task and remove its script. Previously
+            //    the task was discarded and the file never deleted, leaking one
+            //    nova_init_{guid}.ps1 per PowerShell session (#107).
+            //
+            //    Ordered last on purpose: by here the shell is gone, so it cannot be
+            //    holding the script open (Windows refuses to delete a file whose open
+            //    handle lacks FILE_SHARE_DELETE). That hazard is reasoned, not observed -
+            //    on the happy path the script deletes itself the moment it is sourced, so
+            //    this call is usually a no-op and the placement is untestable. Last is
+            //    simply the position with no failure mode.
+            CleanUpPowerShellInit();
+
             TryNotifyExit(0);
+        }
+
+        /// Observes the injection task's outcome and removes its script if the shell
+        /// never sourced it. Bounded and fully guarded: dispose must not block on, or be
+        /// derailed by, best-effort cleanup.
+        private void CleanUpPowerShellInit()
+        {
+            Task? initTask = _powerShellInitTask;
+            if (initTask != null)
+            {
+                try
+                {
+                    // Bounded: the task is either already cancelled by _cts or mid-write.
+                    // A timeout is not an error - the file cleanup below still runs.
+                    initTask.Wait(TimeSpan.FromMilliseconds(250));
+                }
+                catch (AggregateException ex)
+                    when (ex.InnerExceptions.All(inner => inner is OperationCanceledException))
+                {
+                    // Expected: cancelled by _cts.Cancel() above.
+                }
+                catch (Exception ex)
+                {
+                    // The whole point of tracking the task: a failure here used to be
+                    // swallowed as an unobserved exception.
+                    Console.WriteLine($"[RustPtySession] PS injection task faulted: {ex.Message}");
+                }
+            }
+
+            string? scriptPath = _powerShellInitScriptPath;
+            if (scriptPath == null) return;
+
+            try
+            {
+                // Normally already gone - the script's last line deletes itself once the
+                // shell sources it, so this is the backstop for the case where the shell
+                // never ran it (spawn failed, session closed first, injection faulted).
+                System.IO.File.Delete(scriptPath);
+            }
+            catch (Exception ex)
+            {
+                // Best effort: a leftover temp script must never fail a disposal.
+                Console.WriteLine($"[RustPtySession] PS init script cleanup failed: {ex.Message}");
+            }
         }
 
         private void TryNotifyExit(int code)

--- a/tests/NovaTerminal.App.Tests/PtyReadFailureAndInitCleanupTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtyReadFailureAndInitCleanupTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using NovaTerminal.Pty;
+using NovaTerminal.Shell;
+using Xunit;
+
+namespace NovaTerminal.Tests
+{
+    /// <summary>
+    /// Regression guards for #107.
+    ///
+    /// (a) A negative <c>pty_read</c> used to reset the decoder and sleep 50 ms forever,
+    /// so a permanently failing handle span at 20 Hz for the life of the process while the
+    /// tab sat frozen with no error. It is now bounded and reports a distinct exit code.
+    ///
+    /// (b) The PowerShell post-launch init wrote <c>nova_init_{guid}.ps1</c> into %TEMP%
+    /// and never deleted it, leaking one file per PowerShell session.
+    /// </summary>
+    public class PtyReadFailureAndInitCleanupTests
+    {
+        [Fact]
+        public void ReadFailureExitCode_IsDistinguishableFromACleanExit()
+        {
+            // The whole point of the code is to tell "the shell exited" apart from "we
+            // gave up reading". If this ever became 0 the distinction would vanish
+            // silently, with no test failing anywhere else.
+            Assert.NotEqual(0, RustPtySession.ReadFailureExitCode);
+        }
+
+        [Fact]
+        public void MaxConsecutiveReadErrors_IsBoundedAndAllowsForTransientFailures()
+        {
+            // Bounded at all: an unbounded value would restore the infinite spin.
+            Assert.InRange(RustPtySession.MaxConsecutiveReadErrors, 1, 1000);
+
+            // And not so small that a brief transient blip kills a healthy session.
+            Assert.True(
+                RustPtySession.MaxConsecutiveReadErrors >= 5,
+                "too few retries would tear down a session over a momentary read failure");
+        }
+
+        // NOTE: an "EOF still reports exit code 0" test was written and then removed here.
+        // Driving a real shell to exit by sending "exit\r" did not reliably produce an
+        // OnExit within 15s on Windows — the shell can still be busy with the post-launch
+        // init injection when the input lands, so the test was timing-dependent rather
+        // than assertion-dependent. A flaky guard is worse than an honest gap.
+        //
+        // Neither side of the exit-code change (EOF => 0, repeated read failure =>
+        // ReadFailureExitCode) is directly covered as a result: forcing a negative
+        // pty_read needs a seam that does not exist, since Native.pty_read is a static
+        // P/Invoke. Making the read callable injectable would give both cases real
+        // coverage and is worth doing, but it is a refactor beyond this fix.
+
+        [Fact]
+        [Trait("Category", "PtySmoke")]
+        public async Task PowerShellInit_LeavesNoTempScriptBehind()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // The init injection is PowerShell-only, so there is nothing to leak.
+                return;
+            }
+
+            var session = new RustPtySession("powershell.exe", 80, 24);
+            string? scriptPath;
+            try
+            {
+                // The injection fires on a 300 ms delay; wait past it so the script is
+                // actually written and sourced rather than skipped by cancellation.
+                await Task.Delay(2500);
+                scriptPath = session.PowerShellInitScriptPath;
+
+                Assert.NotNull(scriptPath);
+            }
+            finally
+            {
+                session.Dispose();
+            }
+
+            // The script deletes itself once sourced, and Dispose removes it if the shell
+            // never ran it. Either way, the file this session created must not survive.
+            Assert.False(
+                File.Exists(scriptPath),
+                $"PowerShell init script survived disposal: {scriptPath}");
+        }
+
+        [Fact]
+        [Trait("Category", "PtySmoke")]
+        public async Task DisposeDuringInitDelay_LeavesNoTempScriptAndDoesNotHang()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
+            var session = new RustPtySession("powershell.exe", 80, 24);
+
+            // Dispose *inside* the 300 ms injection window: the task must observe
+            // cancellation rather than inject into a dead handle, and Dispose must not
+            // block waiting for it.
+            await Task.Delay(50);
+
+            var sw = Stopwatch.StartNew();
+            session.Dispose();
+            sw.Stop();
+
+            Assert.True(
+                sw.Elapsed < TimeSpan.FromSeconds(5),
+                $"Dispose took {sw.Elapsed.TotalSeconds:F1}s — it should not block on the init task");
+
+            // Cancelled before the write, so no script should ever have been created; if
+            // one was, it must not have survived.
+            await Task.Delay(750);
+            string? scriptPath = session.PowerShellInitScriptPath;
+
+            Assert.False(
+                scriptPath != null && File.Exists(scriptPath),
+                $"cancelled init left a script behind: {scriptPath}");
+        }
+    }
+}


### PR DESCRIPTION
Addresses #107 items 1 and 2. **Item 3 is deliberately not included** — see "Why the logging stays" below.

## Item 1 — read error vs EOF

`RustPtySession.ReadLoop` treated a negative `pty_read` as transient, forever:

```csharp
else // Error
{
    _utf8Decoder.Reset();
    Thread.Sleep(50);
}
```

A permanently failing handle therefore spun at 20 Hz for the life of the process, with the tab frozen, nothing logged, and no exit reported — while the `read == 0` EOF branch immediately beside it correctly breaks.

The retry is now bounded: 20 consecutive failures (~1s) then log, terminate the loop, and report a distinct exit code instead of the hardcoded `0`.

**Why bound rather than classify.** The issue proposes treating distinct negative codes as terminal, and that isn't currently possible — `pty_read` collapses *every* failure to `-1`:

```rust
pub extern "C" fn pty_read(state_ptr: *mut PtyState, buffer: *mut u8, len: c_int) -> c_int {
    ffi_guard(-1, || {
        if state_ptr.is_null() || buffer.is_null() || len < 0 { return -1; }
        ...
        Err(_) => -1,          // errno discarded
        ...
        } else { -1 }          // poisoned lock
    })
}
```

Null arguments, a read error with errno thrown away, a poisoned lock, and a panic caught by `ffi_guard` are indistinguishable at the boundary. Telling them apart needs a `pty_last_error` export — which is **#120 item 3**, not this issue. Rather than quietly expand into #120's scope, this PR takes the strongest conclusion available from a `-1`: retry a bounded number of times, then fail.

**Ordering detail worth reviewing.** The failure notification is claimed *before* `CompleteAdding`, because completing the queue releases `ProcessLoop`, which unconditionally calls `TryNotifyExit(0)`. `TryNotifyExit` is first-caller-wins, so notifying after would usually lose the race and report a read failure as a clean exit.

## Item 2 — leaked `nova_init_{guid}.ps1`

The PowerShell post-launch injection was a discarded `ContinueWith`: exceptions went to `Console`, nothing observed the task, and the temp script was never deleted — one leaked file per PowerShell session.

Now: the task is tracked so `Dispose` observes its failures; it is cancelled with `_cts` so closing a tab inside the 300 ms window no longer injects into a dead handle; and **the script deletes itself as its own last statement**, which is what actually fixes the leak — the file goes away the moment the shell finishes sourcing it, with no timer to guess at. `Dispose` deletes it as a backstop for the case where the shell never ran it.

## Two things the tests changed about the implementation

Both are cases where a test caught me, and I think they're the most useful part of this PR to review:

**1. The write must stay synchronous.** I first used `await File.WriteAllTextAsync(...)`. That added a scheduling hop between the delay and `SendInput`, moving the injected keystrokes later — and `PtySmokeTests.AgentSentInput_IsByteFaithful_AndReplayRecordedLikeKeystrokes` started failing, because the injection landed inside that test's recording window:

```
String:    "{"t":0,"type":"input","d":"JiAnQzpcVXNlcnNcYmVobmF...   // & 'C:\Users\behn...
Not found: "ZWNobyBub3ZhLWEzLW1hcmtlcg0="                          // echo nova-a3-marker\r
```

Injection timing is observable behaviour, so it is kept exactly as it was. Flagging this because it means **PTY injection timing is load-bearing for an unrelated replay test** — a sharp edge for anyone touching this code later.

**2. My first cleanup test was wrong, and briefly sent me fixing a non-bug.** It diffed `nova_init_*.ps1` in `%TEMP%` before and after. It reported a leak — so I moved the cleanup later in `Dispose` and added a retry loop, reasoning about Windows file locks. Then I checked the premise: `ShellHelper.GetDefaultShell()` returns `pwsh.exe`/`powershell.exe` on Windows, so **every** PTY smoke test triggers this same injection, and their in-flight scripts were being attributed to my session. The leak report was cross-test interference, not a defect.

The test now asserts on the exact path the session created, via an `internal` test hook (the project already has `InternalsVisibleTo` for this purpose). The retry loop is gone. I kept the late placement in `Dispose` — the shell is dead by then, so it cannot hold the script open — but the comment says plainly that this hazard is *reasoned, not observed*, since on the happy path the call is a no-op and the placement is untestable.

## Why the logging stays (item 3)

`NovaTerminal.Pty` **must not reference** `NovaTerminal.VT`, enforced by `LayeringTests.Pty_must_not_depend_on_Vt` and `ProjectFileLayeringTests.Pty_csproj_must_not_reference_Vt`. `TerminalLogger` lives in VT, so routing this file's 18 (now 19) `Console.WriteLine` calls through it is impossible without either breaking that boundary or inventing a new logging abstraction for this assembly. That decision belongs to #109, which owns the logging consolidation and already covers `RustPtySession` specifically. Adding one more call for #109 to sweep is better than shipping a competing abstraction here.

## Verification

- Pty suites: **43 passed, 0 failed** — run 4 consecutive times, since these spawn real shells and I'd already been bitten by one intermittent failure.
- `scripts/build.ps1 build src/NovaTerminal.Pty`: 0 errors.
- Full-solution build still blocked locally by the McpServer file lock (filed as #211). Affected projects built and tested cleanly; CI covers the rest.

### Not covered

Neither exit-code path has a direct test. Forcing a negative `pty_read` needs a seam that doesn't exist — `Native.pty_read` is a static P/Invoke. A test driving a real shell to exit was written and then removed: it depended on the shell exiting within a timeout rather than on the assertion, and a flaky guard is worse than an honest gap. Making the read callable injectable would give both cases real coverage and is worth doing as a follow-up.
