### PR TITLE
test(pty): make pty_read injectable and cover the read-failure exit paths

### DIFF
--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -363,6 +363,13 @@ namespace NovaTerminal.Pty
         private int _cols;
         private int _rows;
 
+        /// The PTY read call, injectable so tests can drive the read loop's failure
+        /// handling. `pty_read` returns the byte count, 0 for EOF, or a negative value for
+        /// any error - see MaxConsecutiveReadErrors.
+        internal delegate int PtyReadDelegate(PtySafeHandle handle, byte[] buffer, int length);
+
+        private readonly PtyReadDelegate _readFromPty;
+
         public RustPtySession(
             string shellCommand,
             int cols = 120,
@@ -371,7 +378,34 @@ namespace NovaTerminal.Pty
             string? cwd = null,
             bool skipPowerShellPostLaunchInit = false,
             IReadOnlyDictionary<string, string>? environmentOverrides = null)
+            : this(
+                shellCommand,
+                cols,
+                rows,
+                args,
+                cwd,
+                skipPowerShellPostLaunchInit,
+                environmentOverrides,
+                readFromPty: null)
         {
+        }
+
+        /// Test-facing constructor. Identical to the public one except that the PTY read
+        /// call can be substituted: `Native.pty_read` is a static P/Invoke, so without a
+        /// seam here the read loop's error handling (bounded retry, teardown, failure exit
+        /// code) is unreachable from a test. The session still spawns a real shell, so the
+        /// teardown path is exercised against a real handle and a real child process.
+        internal RustPtySession(
+            string shellCommand,
+            int cols,
+            int rows,
+            string? args,
+            string? cwd,
+            bool skipPowerShellPostLaunchInit,
+            IReadOnlyDictionary<string, string>? environmentOverrides,
+            PtyReadDelegate? readFromPty)
+        {
+            _readFromPty = readFromPty ?? Native.pty_read;
             ShellCommand = shellCommand;
             ShellArguments = args;
             _cols = cols;
@@ -630,7 +664,7 @@ namespace NovaTerminal.Pty
             {
                 while (!_cts.Token.IsCancellationRequested && !_handle.IsInvalid)
                 {
-                    int read = Native.pty_read(_handle, buffer, buffer.Length);
+                    int read = _readFromPty(_handle, buffer, buffer.Length);
                     if (read > 0)
                     {
                         consecutiveReadErrors = 0;

--- a/tests/NovaTerminal.App.Tests/PtyReadFailureExitTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtyReadFailureExitTests.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NovaTerminal.Pty;
+using NovaTerminal.Shell;
+using Xunit;
+
+namespace NovaTerminal.Tests
+{
+    /// <summary>
+    /// Covers the read-loop exit paths added for #107, which were unreachable when that
+    /// fix shipped: <c>Native.pty_read</c> is a static P/Invoke, so nothing could force a
+    /// failure. The read call is now injectable, while the session still spawns a real
+    /// shell — so the teardown runs against a real handle and a real child process rather
+    /// than a mock of one.
+    /// </summary>
+    public class PtyReadFailureExitTests
+    {
+        [Fact]
+        [Trait("Category", "PtySmoke")]
+        public async Task RepeatedReadFailures_GiveUpAndReportTheFailureExitCode()
+        {
+            int reads = 0;
+            using var session = NewSession((handle, buffer, length) =>
+            {
+                Interlocked.Increment(ref reads);
+                return -1;
+            });
+
+            int? code = await WaitForExitAsync(session, TimeSpan.FromSeconds(20));
+
+            Assert.Equal(RustPtySession.ReadFailureExitCode, code);
+
+            // Bounded, not endless: the loop must stop at the limit rather than keep
+            // calling. A couple of extra reads are tolerated for the racing final pass.
+            Assert.InRange(
+                Volatile.Read(ref reads),
+                RustPtySession.MaxConsecutiveReadErrors,
+                RustPtySession.MaxConsecutiveReadErrors + 2);
+        }
+
+        [Fact]
+        [Trait("Category", "PtySmoke")]
+        public async Task RepeatedReadFailures_TearTheSessionDownRatherThanJustReporting()
+        {
+            // The defect caught in review of #214: reporting the exit while leaving the
+            // child process, writer thread and native handle alive left the UI showing a
+            // terminated session that was still running.
+            using var session = NewSession((handle, buffer, length) => -1);
+
+            int? code = await WaitForExitAsync(session, TimeSpan.FromSeconds(20));
+            Assert.Equal(RustPtySession.ReadFailureExitCode, code);
+
+            Assert.False(
+                session.IsProcessRunning,
+                "a session that gave up reading must not still report itself as running");
+            Assert.Equal(RustPtySession.ReadFailureExitCode, session.ExitCode);
+        }
+
+        [Fact]
+        [Trait("Category", "PtySmoke")]
+        public async Task Eof_StillReportsACleanExit()
+        {
+            // The other side of the change: introducing a failure code must not reclassify
+            // a normal end-of-stream. This is the assertion the removed timing-dependent
+            // test was reaching for, now deterministic.
+            using var session = NewSession((handle, buffer, length) => 0);
+
+            int? code = await WaitForExitAsync(session, TimeSpan.FromSeconds(20));
+
+            Assert.Equal(0, code);
+        }
+
+        [Fact]
+        [Trait("Category", "PtySmoke")]
+        public async Task ASuccessfulReadResetsTheFailureCounter()
+        {
+            // Transient failures must not accumulate across healthy reads, or a session
+            // that hiccups once every MaxConsecutiveReadErrors reads would eventually be
+            // torn down despite working fine.
+            int calls = 0;
+            using var session = NewSession((handle, buffer, length) =>
+            {
+                int call = Interlocked.Increment(ref calls);
+
+                // Fail one short of the limit, succeed, then repeat - several times over.
+                // If the counter did not reset, this would trip the limit and exit.
+                if (call % RustPtySession.MaxConsecutiveReadErrors != 0)
+                {
+                    return -1;
+                }
+
+                byte[] payload = Encoding.UTF8.GetBytes("x");
+                payload.CopyTo(buffer, 0);
+                return payload.Length;
+            });
+
+            int? code = await WaitForExitAsync(session, TimeSpan.FromSeconds(6));
+
+            Assert.Null(code);
+            Assert.True(
+                session.IsProcessRunning,
+                "the session should still be running: no failure run ever reached the limit");
+        }
+
+        private static RustPtySession NewSession(RustPtySession.PtyReadDelegate readFromPty)
+        {
+            // A real shell is still spawned so the teardown acts on a real handle; only
+            // the read call is substituted.
+            return new RustPtySession(
+                ShellHelper.GetDefaultShell(),
+                80,
+                24,
+                args: null,
+                cwd: null,
+                // Keep the PowerShell init injection out of the way: it is irrelevant here
+                // and its SendInput would race the substituted read loop.
+                skipPowerShellPostLaunchInit: true,
+                environmentOverrides: null,
+                readFromPty: readFromPty);
+        }
+
+        /// Returns the reported exit code, or null if none arrived within the timeout.
+        ///
+        /// Falls back to <see cref="RustPtySession.ExitCode"/> rather than relying solely
+        /// on the event: the read loop starts inside the constructor, so with a read
+        /// substitute that returns immediately (EOF) the exit can be reported before this
+        /// method has a chance to subscribe. TryNotifyExit assigns ExitCode before raising
+        /// OnExit, so the recorded value is authoritative either way. Without this the test
+        /// passes or fails on scheduling luck.
+        private static async Task<int?> WaitForExitAsync(RustPtySession session, TimeSpan timeout)
+        {
+            int? observed = null;
+            var exited = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            session.OnExit += code =>
+            {
+                observed = code;
+                exited.TrySetResult(true);
+            };
+
+            if (session.ExitCode.HasValue)
+            {
+                return session.ExitCode;
+            }
+
+            await Task.WhenAny(exited.Task, Task.Delay(timeout));
+            return observed ?? session.ExitCode;
+        }
+    }
+}


### PR DESCRIPTION
Closes the coverage gap I flagged when #107 shipped in #214. Test-only in effect — the one production change is a constructor seam.

## The gap

`Native.pty_read` is a static P/Invoke, so nothing could force a read failure. That left **every** exit path added in #214 untested:

- the bounded retry (does the loop actually stop?)
- the failure exit code (is it distinguishable from a clean exit?)
- the teardown that review of #214 had to add (does the child actually die?)

The last one is the uncomfortable part: a reviewer found that defect by reading, not by a failing test, and nothing would have caught a regression of it.

## The seam

The public constructor now delegates to an internal one taking a `PtyReadDelegate`, defaulting to `Native.pty_read`:

```csharp
internal delegate int PtyReadDelegate(PtySafeHandle handle, byte[] buffer, int length);
```

Only the read call is substituted. **The session still spawns a real shell**, so the failure teardown is exercised against a real handle and a real child process — not a mock of one. That matters here, because the thing under test is precisely whether `_handle.Dispose()` from the read thread really ends the child.

## Tests

| Test | Guards |
|---|---|
| `RepeatedReadFailures_GiveUpAndReportTheFailureExitCode` | the loop stops at the bound and reports `ReadFailureExitCode`. Asserts the call count *in range*, so an unbounded loop fails rather than merely being slow. |
| `RepeatedReadFailures_TearTheSessionDownRatherThanJustReporting` | `IsProcessRunning` is false afterwards — the defect from #214's review |
| `Eof_StillReportsACleanExit` | introducing a failure code didn't reclassify normal termination |
| `ASuccessfulReadResetsTheFailureCounter` | transient blips can't accumulate into a teardown across healthy reads |

### Mutation-verified

I didn't want to trust four tests that passed first try, so I disabled the bound (`if (false && ...)`) and re-ran. Result: **exactly the two bound-dependent tests fail, and the other two still pass.** Correctly targeted, and they have teeth.

That check also caught a bug in my own test helper, which is the reason it was worth doing. On the first mutation run `Eof_StillReportsACleanExit` *also* failed — not because of the mutation, but because the read loop starts **inside the constructor**, so a substitute returning EOF immediately can report the exit before the test subscribes to `OnExit`. It had been passing on scheduling luck. The helper now also consults `ExitCode`, which `TryNotifyExit` assigns before raising the event:

```csharp
session.OnExit += code => { observed = code; exited.TrySetResult(true); };
if (session.ExitCode.HasValue) return session.ExitCode;   // already exited
await Task.WhenAny(exited.Task, Task.Delay(timeout));
return observed ?? session.ExitCode;
```

Worth knowing generally for this class: **anything observing a `RustPtySession` event has this race**, because the loops are started by the constructor before any caller can subscribe. The existing buffered-output replay exists for the same reason on the output path.

## Verification

- Pty suites: **47 passed, 0 failed** (43 existing + 4 new) — the new file run 3 consecutive times, plus a full-suite run, since these spawn real shells.
- Mutation run as described above.

## Note

The tests pass `skipPowerShellPostLaunchInit: true`. The init injection is irrelevant to these paths and its `SendInput` would race the substituted read loop — the same interaction that made `AgentSentInput_IsByteFaithful` fail in #214.
