### PR TITLE
fix(pty): claim the exit code before teardown; serialize real-shell PTY tests

### DIFF
--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -730,11 +730,24 @@ namespace NovaTerminal.Pty
             {
                 if (readFailed)
                 {
-                    // Tear the session down before announcing it. Reporting the exit alone
-                    // would leave the UI recording a terminated session while the child
-                    // process, the writer thread and the native handle all stayed alive —
-                    // nothing else disposes us on our own initiative
-                    // (MainWindow.OnPaneProcessExited only records the exit code).
+                    // Claim the exit code FIRST. TryNotifyExit is first-caller-wins, and
+                    // everything in the teardown below releases ProcessLoop, which then
+                    // reports TryNotifyExit(0) from its own thread:
+                    //   - _cts.Cancel() cancels its GetConsumingEnumerable token
+                    //   - _outputQueue.CompleteAdding() (further down) ends its enumeration
+                    // Notifying after any of those is a race, and it is one this code lost
+                    // on Windows CI while winning it locally - the session reported a clean
+                    // exit 0 after an unrecoverable read failure.
+                    //
+                    // The cost of this ordering is that subscribers observe the exit a few
+                    // microseconds before the handle is released. That is the lesser evil: a
+                    // brief window versus a permanently wrong exit code.
+                    TryNotifyExit(ReadFailureExitCode);
+
+                    // Then tear down. Reporting the exit alone would leave the UI recording
+                    // a terminated session while the child process, the writer thread and
+                    // the native handle all stayed alive — nothing else disposes us on our
+                    // own initiative (MainWindow.OnPaneProcessExited only records the code).
                     //
                     // Deliberately not calling Dispose(): it joins this very thread, and
                     // Thread.Join on the current thread is invalid, which would abort the
@@ -765,13 +778,6 @@ namespace NovaTerminal.Pty
                     {
                         Console.WriteLine($"[RustPtySession] teardown after read failure failed: {ex.Message}");
                     }
-
-                    // Claim the notification BEFORE completing the output queue below.
-                    // Completing it releases ProcessLoop, which unconditionally reports
-                    // TryNotifyExit(0), and the first caller wins (Interlocked guard) — so
-                    // notifying after would usually lose the race and report a read
-                    // failure as a clean exit.
-                    TryNotifyExit(ReadFailureExitCode);
                 }
 
                 // Always signal the consumer so ProcessLoop's GetConsumingEnumerable

--- a/tests/NovaTerminal.App.Tests/PtyReadFailureAndInitCleanupTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtyReadFailureAndInitCleanupTests.cs
@@ -21,6 +21,7 @@ namespace NovaTerminal.Tests
     /// (b) The PowerShell post-launch init wrote <c>nova_init_{guid}.ps1</c> into %TEMP%
     /// and never deleted it, leaking one file per PowerShell session.
     /// </summary>
+    [Collection(PtyRealShellCollection.Name)]
     public class PtyReadFailureAndInitCleanupTests
     {
         [Fact]

--- a/tests/NovaTerminal.App.Tests/PtyReadFailureExitTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtyReadFailureExitTests.cs
@@ -16,6 +16,7 @@ namespace NovaTerminal.Tests
     /// shell — so the teardown runs against a real handle and a real child process rather
     /// than a mock of one.
     /// </summary>
+    [Collection(PtyRealShellCollection.Name)]
     public class PtyReadFailureExitTests
     {
         [Fact]

--- a/tests/NovaTerminal.App.Tests/PtyRealShellCollection.cs
+++ b/tests/NovaTerminal.App.Tests/PtyRealShellCollection.cs
@@ -1,0 +1,26 @@
+using Xunit;
+
+namespace NovaTerminal.Tests
+{
+    /// <summary>
+    /// Serializes every test class that spawns a real shell through a PTY.
+    ///
+    /// xUnit runs test classes in parallel by default, and this assembly configures no
+    /// parallelism limits. That was harmless while only PtySmokeTests and
+    /// PtyThreadLifecycleTests existed, but the read-failure tests added in #215 spawn
+    /// four more concurrent sessions whose output is deliberately never drained. On a
+    /// 2-core Windows runner that was enough to starve
+    /// PtySmokeTests.RustPtySession_FlightRecording_CapturesOutputAndExports, which needs
+    /// a live shell to actually produce output within its timeout — it began failing on
+    /// main the moment those tests landed, while passing in the PR run.
+    ///
+    /// Sharing one collection makes these classes run one at a time. It costs wall-clock
+    /// time in exchange for tests that assert on real subprocess timing being isolated
+    /// from each other, which is the only way they can be meaningful.
+    /// </summary>
+    [CollectionDefinition(Name)]
+    public sealed class PtyRealShellCollection
+    {
+        public const string Name = "PTY real shell";
+    }
+}

--- a/tests/NovaTerminal.App.Tests/PtySmokeTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtySmokeTests.cs
@@ -11,6 +11,7 @@ using NovaTerminal.Pty;
 
 namespace NovaTerminal.Tests
 {
+    [Collection(PtyRealShellCollection.Name)]
     public class PtySmokeTests
     {
         [Fact]
@@ -74,7 +75,14 @@ namespace NovaTerminal.Tests
             string recPath = Path.Combine(Path.GetTempPath(), $"nova_a3_{Guid.NewGuid():N}.rec");
             try
             {
-                using var session = new RustPtySession(shell, 80, 24);
+                // skipPowerShellPostLaunchInit: the init injection calls SendInput on a
+                // 300 ms timer, which is exactly this test's start-up delay, so whether the
+                // injected `& '<script>'` was recorded before the payload below came down to
+                // a coin flip. This test is about agent input fidelity, not the PowerShell
+                // banner, so the injection is pure noise here - and it flipped that coin
+                // twice while PTY timing was being changed elsewhere (#214, #215).
+                using var session = new RustPtySession(
+                    shell, 80, 24, args: null, cwd: null, skipPowerShellPostLaunchInit: true);
                 var registration = new NovaTerminal.AgentHost.AgentSessionRegistration(
                     Guid.NewGuid(), new TerminalBuffer(80, 24), "t", "P", "local", isActive: true);
                 registration.SetLifecycle(session);
@@ -89,11 +97,15 @@ namespace NovaTerminal.Tests
                 session.StopRecording();
 
                 string[] lines = File.ReadAllLines(recPath);
-                // The recording carries an input event with the exact bytes.
-                string? inputLine = lines.FirstOrDefault(l => l.Contains("\"type\":\"input\""));
-                Assert.NotNull(inputLine);
+                // Search every input event rather than only the first. The assertion is
+                // "the payload was recorded byte-faithfully", which says nothing about it
+                // being the only - or first - input in the recording.
                 byte[] expected = System.Text.Encoding.UTF8.GetBytes(payload);
-                Assert.Contains(Convert.ToBase64String(expected), inputLine!);
+                string expectedBase64 = Convert.ToBase64String(expected);
+                string[] inputLines = lines.Where(l => l.Contains("\"type\":\"input\"")).ToArray();
+
+                Assert.NotEmpty(inputLines);
+                Assert.Contains(inputLines, line => line.Contains(expectedBase64));
             }
             finally
             {

--- a/tests/NovaTerminal.App.Tests/PtyThreadLifecycleTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtyThreadLifecycleTests.cs
@@ -15,6 +15,7 @@ namespace NovaTerminal.Tests
     /// The loops must run on dedicated background threads so a leaked session can never
     /// consume the threadpool.
     /// </summary>
+    [Collection(PtyRealShellCollection.Name)]
     public class PtyThreadLifecycleTests
     {
         [Fact]


### PR DESCRIPTION
**`main` has been red since #215.** Both failures are mine. This fixes the cause of each rather than muting them.

```
PtyReadFailureExitTests.RepeatedReadFailures_TearTheSessionDownRatherThanJustReporting
  Expected: -1   Actual: 0
PtySmokeTests.RustPtySession_FlightRecording_CapturesOutputAndExports
  flight ring captured no output from a live shell
```

## 1. Exit-code race — a real bug in the #214 teardown

The read-failure path called `_cts.Cancel()` **before** `TryNotifyExit(ReadFailureExitCode)`. Cancelling releases `ProcessLoop`, which unconditionally reports `TryNotifyExit(0)` from its own thread, and `TryNotifyExit` is first-caller-wins. So an unrecoverable read failure could reach the UI as a **clean exit 0** — precisely the misreporting the exit code was added to prevent.

I had reasoned about this exact race for `_outputQueue.CompleteAdding()` and wrote a comment about it, then missed that `_cts.Cancel()` releases `ProcessLoop` the same way, through the consuming enumerator's cancellation token. The notification is now claimed first, before anything that can release it:

```csharp
TryNotifyExit(ReadFailureExitCode);   // claim first - see comment for why
try { _cts.Cancel(); ... _handle.Dispose(); TryDeleteInitScript(); }
```

The ordering costs a few microseconds in which subscribers observe the exit before the handle is released. That's the lesser evil against a permanently wrong exit code.

**Why the PR run for #215 was green and `main` was not:** it's a race, and the old ordering won locally (3/3) and on the PR runner, then lost on Windows CI. A test that passes because it wins a race is not a passing test — and my own new test is what caught it, one merge too late.

## 2. Test parallelism

xUnit runs test classes in parallel and this assembly configures no limits. Harmless while only `PtySmokeTests` and `PtyThreadLifecycleTests` existed; not harmless once #215 added four more classes that each spawn a real shell **whose output is deliberately never drained**. On a 2-core Windows runner that was enough to starve `RustPtySession_FlightRecording_CapturesOutputAndExports`, which needs a live shell to actually produce output inside its timeout.

The timing is conclusive: that test started failing on `main` at exactly the commit that added those tests, having passed on the four merges before it.

All four real-shell PTY classes now share one collection, so they run one at a time. It costs wall-clock time; tests that assert on real subprocess timing can't be isolated any other way.

## 3. A pre-existing race the above exposed twice

`AgentSentInput_IsByteFaithful_AndReplayRecordedLikeKeystrokes` waits 300 ms before it starts recording. The PowerShell init injection calls `SendInput` on a **300 ms** timer. So whether the injected `& '<script>'` landed in the recording before the test's own payload was a coin flip — and the test read only the **first** input event:

```csharp
string? inputLine = lines.FirstOrDefault(l => l.Contains("\"type\":\"input\""));
```

This is the test that failed in #214 when I briefly used an async write, and again here under serialization. Twice is a pattern, not bad luck. Fixed at the source rather than by nudging timing:

- the session now passes `skipPowerShellPostLaunchInit: true` — this test is about agent input fidelity, not the PowerShell banner, so the injection is pure noise
- the assertion searches **all** input events, since "the payload was recorded byte-faithfully" says nothing about it being first

Windows-only before, because the injection only runs for PowerShell shells.

## Verification

- Pty suites: **47 passed, 0 failed**, 3 consecutive runs.
- Before the fix, `AgentSentInput_IsByteFaithful` failed **2/2** locally once serialization was added — so that fix is locally verified.

**What local runs cannot prove:** the exit-code race. The old ordering also passed locally; Windows CI is the only discriminator I have. If `RepeatedReadFailures_TearTheSessionDownRatherThanJustReporting` is green on Windows here, that's the signal.

## Process note

#215's own tests found this — the value was real, but they found it *after* merge because the PR run happened to win the race. The lesson I'd draw: for a first-of-its-kind concurrency test, a single green CI run isn't evidence. Re-running the job before merging would have caught it.
