### PR TITLE
perf(render): stop the cursor blink timer while the pane is unfocused

### DIFF
--- a/src/NovaTerminal.App/Shell/TerminalView.cs
+++ b/src/NovaTerminal.App/Shell/TerminalView.cs
@@ -352,7 +352,12 @@ namespace NovaTerminal.Shell
             
             _cursorBlinkPhase = true;
             _cursorBlinkTimer.Stop();
-            _cursorBlinkTimer.Start();
+            // Restart only if blink should be running at all: an unconditional Start here
+            // would resurrect the timer on an unfocused pane and undo the #126 gating.
+            if (ShouldRunCursorBlinkTimer())
+            {
+                _cursorBlinkTimer.Start();
+            }
             _isDirty = true;
             InvalidateVisual();
         }
@@ -690,6 +695,10 @@ namespace NovaTerminal.Shell
                 }
                 _wheelLinesPerNotch = Math.Min(wheelLinesPerNotch, 100.0);
                 if (!_cursorBlinkEnabled) _cursorBlinkPhase = true;
+                // _cursorBlinkEnabled was just reassigned from settings, and it is half of
+                // ShouldRunCursorBlinkTimer - so the timer has to be re-evaluated here or
+                // toggling the setting would not take effect until the next focus change.
+                RefreshCursorBlinkTimerState();
                 EnsureFallbackChain();
 
                 if (_buffer != null)
@@ -812,6 +821,14 @@ namespace NovaTerminal.Shell
             if (change.Property == IsVisibleProperty || change.Property == BoundsProperty)
             {
                 RefreshUiTimerState();
+            }
+            else if (change.Property == IsKeyboardFocusWithinProperty)
+            {
+                // Tracked on IsKeyboardFocusWithin rather than in OnGotFocus/OnLostFocus so
+                // the timer follows exactly the same condition Render() uses to decide
+                // whether to draw the cursor - including focus landing on a descendant,
+                // which the OnGotFocus/OnLostFocus pair does not observe.
+                RefreshCursorBlinkTimerState();
             }
         }
 
@@ -1443,9 +1460,55 @@ namespace NovaTerminal.Shell
         {
             if (_uiTimersRunning) return;
             _renderTimer.Start();
-            _cursorBlinkTimer.Start();
+            // Blink is gated separately from the render timer: output still arrives on an
+            // unfocused pane and must render, but its cursor is not drawn at all.
+            RefreshCursorBlinkTimerState();
             _uiTimersRunning = true;
             RendererStatistics.RecordTerminalViewTimersStarted();
+        }
+
+        /// The blink timer only earns its keep while the cursor is actually drawn.
+        ///
+        /// Render() already does `bool hideCursor = !IsKeyboardFocusWithin;`, so on an
+        /// unfocused pane every blink tick set _isDirty, the render timer turned that into
+        /// an InvalidateVisual, and the resulting frame was pixel-identical - a full render
+        /// pass every 530 ms per unfocused pane, forever, for nothing (#126). With several
+        /// panes open that is the dominant source of idle wakeups.
+        ///
+        /// Deliberately not folded into ShouldRunUiTimers(): that gates the render timer
+        /// too, and stopping *that* on focus loss would freeze output from a background
+        /// shell - a correctness bug, not a saving.
+        private bool ShouldRunCursorBlinkTimer() =>
+            ShouldRunCursorBlinkTimer(_cursorBlinkEnabled, IsKeyboardFocusWithin);
+
+        /// The rule itself, as a pure function so it can be tested without a visual tree or
+        /// a focus manager. `focused` is the caller's IsKeyboardFocusWithin - the same input
+        /// Render() uses for `hideCursor`, so the two cannot drift apart.
+        internal static bool ShouldRunCursorBlinkTimer(bool blinkEnabled, bool focused) =>
+            blinkEnabled && focused;
+
+        private void RefreshCursorBlinkTimerState()
+        {
+            bool shouldBlink = ShouldRunCursorBlinkTimer();
+            if (shouldBlink == _cursorBlinkTimer.IsEnabled)
+            {
+                return;
+            }
+
+            if (shouldBlink)
+            {
+                // Start solid so the cursor is immediately visible on focus, rather than
+                // possibly resuming mid-blink in the hidden phase.
+                _cursorBlinkPhase = true;
+                _cursorBlinkTimer.Start();
+            }
+            else
+            {
+                _cursorBlinkTimer.Stop();
+                // Leave the phase solid so a later focus gain cannot briefly show a hidden
+                // cursor before the first tick.
+                _cursorBlinkPhase = true;
+            }
         }
 
         private void StopUiTimers()

--- a/tests/NovaTerminal.App.Tests/CursorBlinkGatingTests.cs
+++ b/tests/NovaTerminal.App.Tests/CursorBlinkGatingTests.cs
@@ -1,0 +1,43 @@
+using NovaTerminal.Shell;
+using Xunit;
+
+namespace NovaTerminal.Tests
+{
+    /// <summary>
+    /// Guards the #126 gating rule: the cursor-blink timer must only run when the cursor is
+    /// actually drawn. Render() hides the cursor whenever the view lacks keyboard focus, so
+    /// a blink tick on an unfocused pane produced a pixel-identical frame - a full render
+    /// pass every 530 ms, per pane, indefinitely.
+    ///
+    /// The rule is tested as a pure function rather than by driving a real control: the
+    /// timer only starts once the view is attached, visible and sized, and
+    /// IsKeyboardFocusWithin is set by Avalonia's focus manager rather than by a test. A
+    /// headless test would therefore pass without the visual tree ever being in the state
+    /// the assertion claims to cover - see the PR for what is consequently not covered.
+    /// </summary>
+    public class CursorBlinkGatingTests
+    {
+        [Theory]
+        // blink setting on, focused: the only combination that should tick.
+        [InlineData(true, true, true)]
+        // Focused but the user turned blinking off.
+        [InlineData(true, false, false)]
+        // The #126 case: blink enabled, pane unfocused - cursor is not drawn, so no ticks.
+        [InlineData(false, true, false)]
+        // Neither.
+        [InlineData(false, false, false)]
+        public void BlinkTimerRunsOnlyWhenFocusedAndEnabled(bool focused, bool blinkEnabled, bool expected)
+        {
+            Assert.Equal(expected, TerminalView.ShouldRunCursorBlinkTimer(blinkEnabled, focused));
+        }
+
+        [Fact]
+        public void LosingFocusStopsBlinkingEvenWithTheSettingEnabled()
+        {
+            // Stated separately from the table because it is the actual regression: before
+            // #126 the setting alone decided, so this returned true and cost a render pass.
+            Assert.True(TerminalView.ShouldRunCursorBlinkTimer(blinkEnabled: true, focused: true));
+            Assert.False(TerminalView.ShouldRunCursorBlinkTimer(blinkEnabled: true, focused: false));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #126.

## The waste

`Render()` already contains:

```csharp
bool hideCursor = !IsKeyboardFocusWithin;
```

So on an **unfocused** pane, every 530 ms blink tick set `_isDirty`, the render timer turned that into an `InvalidateVisual()`, and the resulting frame was pixel-identical. A full render pass per unfocused pane, indefinitely, producing nothing. With several panes open that's the dominant source of idle wakeups.

Worth noting the issue understated it slightly: `ShouldRunUiTimers()` checks attachment, visibility and bounds — but never focus, which is the condition that actually determines whether the cursor is drawn.

## The gate

`_cursorBlinkEnabled && IsKeyboardFocusWithin`, re-evaluated from the three places that can change either input. All three mattered:

| Site | Why it's needed |
|---|---|
| `OnPropertyChanged` / `IsKeyboardFocusWithinProperty` | the focus transition itself |
| `ApplySettings` | reassigns `_cursorBlinkEnabled`; without this, toggling the setting wouldn't take effect until the next focus change |
| `ResetCursorBlink` | did an unconditional `Stop()/Start()` and would have **resurrected** the timer on an unfocused pane, silently undoing the fix |

I tracked `IsKeyboardFocusWithinProperty` rather than using the existing `OnGotFocus`/`OnLostFocus` overrides on purpose: those don't observe focus landing on a *descendant*, whereas `IsKeyboardFocusWithin` is precisely the input `Render()` uses. Tracking the same property is what stops the timer and the drawing decision from drifting apart later.

**The render timer is deliberately untouched.** Folding focus into `ShouldRunUiTimers()` would stop it too and freeze output from a background shell — a correctness bug, not a saving.

Phase handling: the timer both starts and stops with `_cursorBlinkPhase` forced solid, so a pane regaining focus can't briefly render a *hidden* cursor before the first tick.

## Tests

The rule is extracted as a pure static, tested across the enabled × focused matrix (5 cases). **Mutation-checked:** dropping the focus term fails 2 of the 5.

### Why a pure function and not a headless control test

I tried to reach this through a real `TerminalView` and concluded the test would have been vacuous. The blink timer only starts once the view is attached, visible and sized, and `IsKeyboardFocusWithin` is set by Avalonia's focus manager, not by a test. A headless test would pass without the visual tree ever entering the state the assertion claims to cover — which is worse than no test, because it looks like coverage.

**So what is not covered:** that the timer object actually stops on a real focus change in a real window, and that this measurably reduces render passes. The former is three small call sites I've read carefully; the latter would need a render-count assertion via `RendererStatistics`, which counts timer start/stop rather than frames. If you want that guarantee pinned, adding a frame counter to `RendererStatistics` would be the way — happy to file it.

No reduced-motion setting exists in the repo, so nothing here interacts with one; the all-or-nothing `settings.CursorBlink` remains the only user control.
