### PR TITLE
fix(vt): read row side tables back out of scrollback (#95 gap 1)

### DIFF
--- a/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
@@ -86,7 +86,18 @@ namespace NovaTerminal.VT
             
             if (!_isAltScreen && absRow < _scrollback.Count)
             {
-                // Scrollback doesn't support extended text yet (Step 5)
+                // The side table has been carried into scrollback since the row-metadata
+                // work landed; this read path was the missing half (#95 gap 1). Without it
+                // an emoji or CJK grapheme degraded to its first UTF-16 char the moment the
+                // line scrolled off - visible in copied text and in link detection, both of
+                // which read through here.
+                var extendedText = _scrollback.GetExtendedTextMap(absRow);
+                if (extendedText != null && extendedText.TryGet(col, out string? scrollbackText)
+                    && scrollbackText != null)
+                {
+                    return scrollbackText;
+                }
+
                 return _scrollback.GetRow(absRow)[col].Character.ToString();
             }
 
@@ -105,8 +116,13 @@ namespace NovaTerminal.VT
                 
                 if (!_isAltScreen && absRow < _scrollback.Count)
                 {
-                    // Scrollback doesn't support hyperlinks yet (Step 5)
-                    return null;
+                    // Same gap as GetGraphemeAbsolute: the hyperlink side table survives
+                    // into scrollback, but this read path returned null unconditionally, so
+                    // an OSC 8 link stopped being a link as soon as it scrolled off screen.
+                    var hyperlinks = _scrollback.GetHyperlinkMap(absRow);
+                    return hyperlinks != null && hyperlinks.TryGet(col, out string? uri)
+                        ? uri
+                        : null;
                 }
 
                 var row = GetRowAbsolute(absRow);

--- a/tests/NovaTerminal.VT.Tests/ScrollbackReadPathTests.cs
+++ b/tests/NovaTerminal.VT.Tests/ScrollbackReadPathTests.cs
@@ -1,0 +1,91 @@
+using NovaTerminal.VT;
+
+namespace NovaTerminal.VT.Tests;
+
+// #95 gap 1: the scrollback *storage* already carried row side tables (see
+// ScrollbackSideTableTests), but the read accessors did not consult them -
+// GetGraphemeAbsolute returned cell.Character.ToString() and GetHyperlinkAbsolute
+// returned null unconditionally for any row in scrollback. So a multi-codepoint
+// grapheme silently degraded to its first UTF-16 char, and an OSC 8 link stopped being a
+// link, the moment the line scrolled off screen. Both accessors feed selection/copy and
+// link detection, so the loss was user-visible in both.
+public class ScrollbackReadPathTests
+{
+    /// Writes enough lines to push the first one into scrollback, and returns the buffer.
+    private static TerminalBuffer BufferWithFirstRowScrolledOff(string firstLine, int rows = 3)
+    {
+        var buffer = new TerminalBuffer(20, rows);
+        var parser = new AnsiParser(buffer);
+        parser.Process(firstLine + "\r\n");
+        for (int i = 0; i < rows; i++)
+        {
+            parser.Process($"filler {i}\r\n");
+        }
+        return buffer;
+    }
+
+    [Fact]
+    public void GetGraphemeAbsolute_ReturnsTheFullGraphemeFromScrollback()
+    {
+        // Astral-plane emoji: two UTF-16 code units, so the old path returned a lone
+        // unpaired surrogate rather than the character.
+        var buffer = BufferWithFirstRowScrolledOff("ok \U0001F44D done");
+
+        Assert.True(buffer.Scrollback.Count > 0, "first row should have scrolled off");
+
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            string grapheme = buffer.GetGraphemeAbsolute(3, 0);
+            Assert.Equal("\U0001F44D", grapheme);
+        }
+        finally
+        {
+            buffer.Lock.ExitReadLock();
+        }
+    }
+
+    [Fact]
+    public void GetGraphemeAbsolute_StillReturnsPlainCharactersFromScrollback()
+    {
+        // The fallback must survive: rows with no side table are the common case.
+        var buffer = BufferWithFirstRowScrolledOff("plain text");
+
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            Assert.Equal("p", buffer.GetGraphemeAbsolute(0, 0));
+            Assert.Equal("l", buffer.GetGraphemeAbsolute(1, 0));
+        }
+        finally
+        {
+            buffer.Lock.ExitReadLock();
+        }
+    }
+
+    [Fact]
+    public void GetHyperlinkAbsolute_ReturnsTheUriFromScrollback()
+    {
+        const string uri = "https://example.com/scrolled-off";
+        var buffer = new TerminalBuffer(20, 3);
+        var parser = new AnsiParser(buffer);
+
+        // OSC 8 open, text, OSC 8 close.
+        parser.Process($"\x1b]8;;{uri}\x1b\\linked\x1b]8;;\x1b\\\r\n");
+        for (int i = 0; i < 3; i++)
+        {
+            parser.Process($"filler {i}\r\n");
+        }
+
+        Assert.True(buffer.Scrollback.Count > 0, "linked row should have scrolled off");
+        Assert.Equal(uri, buffer.GetHyperlinkAbsolute(0, 0));
+    }
+
+    [Fact]
+    public void GetHyperlinkAbsolute_ReturnsNullForUnlinkedScrollbackCells()
+    {
+        var buffer = BufferWithFirstRowScrolledOff("no links here");
+
+        Assert.Null(buffer.GetHyperlinkAbsolute(0, 0));
+    }
+}


### PR DESCRIPTION
Addresses **gap 1 of #95**. Deliberately does not close the issue — gaps 2–6 remain.

## The gap

Scrollback *storage* has carried row side tables since the row-metadata work landed — `ScrollbackPages.GetExtendedTextMap` / `GetHyperlinkMap`, guarded by `ScrollbackSideTableTests`. The read accessors never consulted them:

```csharp
// GetGraphemeAbsolute
// Scrollback doesn't support extended text yet (Step 5)
return _scrollback.GetRow(absRow)[col].Character.ToString();

// GetHyperlinkAbsolute
// Scrollback doesn't support hyperlinks yet (Step 5)
return null;
```

So the moment a line scrolled off screen:

- a multi-codepoint grapheme degraded to its **first UTF-16 code unit** — for an astral-plane emoji that's a lone unpaired surrogate, not a character
- an OSC 8 hyperlink stopped being a hyperlink

Both accessors feed selection/copy (`SelectionState`) and link detection (`Links/RowTextExtractor`), so the loss was user-visible on both paths — copy an emoji from scrollback and you got mojibake.

## The fix

Both accessors consult the side table and fall back to the cell character, so rows with no side table — the common case — behave exactly as before. The issue labelled this "good first issue" and that's fair: the storage and the accessors already existed, only the wiring was missing.

## Tests

4 cases in `NovaTerminal.VT.Tests`:

| Test | Guards |
|---|---|
| `GetGraphemeAbsolute_ReturnsTheFullGraphemeFromScrollback` | astral-plane emoji survives scrolling off |
| `GetHyperlinkAbsolute_ReturnsTheUriFromScrollback` | OSC 8 URI survives scrolling off |
| `GetGraphemeAbsolute_StillReturnsPlainCharactersFromScrollback` | the fallback still works |
| `GetHyperlinkAbsolute_ReturnsNullForUnlinkedScrollbackCells` | unlinked cells stay null |

The last two exist so the fix can't regress into always consulting a map.

**Mutation-checked** against the original stubs: exactly the two retrieval tests fail, both fallback tests still pass. That also confirms the tests aren't passing for the wrong reason — the rows really are reaching scrollback rather than being served from the viewport (two of the tests assert `Scrollback.Count > 0` explicitly).

Full VT suite: **85 passed, 0 failed.**

## Scope note

Gap 1 only. Per the triage's dependency note, gap 2 (`id=` parameter) and #164 item 2a both change the side-table *value type*, so they should be done together to avoid touching `ReflowEngine` twice — this change doesn't touch that shape, so it doesn't get in their way.
