### PR TITLE
fix(ux): surface DropRouter messages instead of discarding them

### DIFF
--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -520,6 +520,24 @@ namespace NovaTerminal.Controls
                 _pendingPasteFilePath = args.FilePath;
                 _pendingEscapedPath = args.EscapedPath;
                 ToastMessageText.Text = System.IO.Path.GetFileName(args.FilePath);
+                // Restore the action buttons: an informational drop notice (below) hides
+                // them, and the panel is shared between both uses.
+                ToastPastePathBtn.IsVisible = true;
+                ToastActionBtn.IsVisible = true;
+                ToastPanel.IsVisible = true;
+            };
+
+            // Drop refused, or accepted with a caveat. Reuses the same panel - the message
+            // belongs in the pane the drop landed on, not in a window-level toast - but with
+            // the action buttons hidden, because there is nothing to act on: the text was
+            // either never sent, or already sent.
+            TermView.DropNotice += message =>
+            {
+                _pendingPasteFilePath = null;
+                _pendingEscapedPath = null;
+                ToastMessageText.Text = message;
+                ToastPastePathBtn.IsVisible = false;
+                ToastActionBtn.IsVisible = false;
                 ToastPanel.IsVisible = true;
             };
 

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -519,7 +519,13 @@ namespace NovaTerminal.Controls
             {
                 _pendingPasteFilePath = args.FilePath;
                 _pendingEscapedPath = args.EscapedPath;
-                ToastMessageText.Text = System.IO.Path.GetFileName(args.FilePath);
+                string fileName = System.IO.Path.GetFileName(args.FilePath);
+                // A notice riding along with the drop (currently only the WSL mapping
+                // fallback) is appended rather than shown separately, because it would
+                // otherwise overwrite this actionable prompt in the shared panel.
+                ToastMessageText.Text = string.IsNullOrEmpty(args.Notice)
+                    ? fileName
+                    : $"{fileName} — {args.Notice}";
                 // Restore the action buttons: an informational drop notice (below) hides
                 // them, and the panel is shared between both uses.
                 ToastPastePathBtn.IsVisible = true;

--- a/src/NovaTerminal.App/Shell/TerminalView.cs
+++ b/src/NovaTerminal.App/Shell/TerminalView.cs
@@ -392,6 +392,16 @@ namespace NovaTerminal.Shell
         {
             public string FilePath { get; set; } = string.Empty;
             public string EscapedPath { get; set; } = string.Empty;
+
+            /// A DropRouter message that applies to this same drop, or null.
+            ///
+            /// Carried here rather than raised as a separate DropNotice because both render
+            /// into the pane's single toast panel: raising both would mean one immediately
+            /// overwrites the other, and whichever won, information would be lost. The
+            /// reachable case is a single text file dropped on a WSL session where path
+            /// mapping fell back to the Windows path - the smart-paste prompt is actionable
+            /// and must survive, so the warning rides along with it.
+            public string? Notice { get; set; }
         }
 
         public event EventHandler<TextFileDroppedEventArgs>? TextFileDropped;
@@ -498,7 +508,13 @@ namespace NovaTerminal.Shell
                             var args = new TextFileDroppedEventArgs
                             {
                                 FilePath = paths[0],
-                                EscapedPath = result.TextToSend ?? string.Empty
+                                EscapedPath = result.TextToSend ?? string.Empty,
+                                // This branch returns, so a DropNotice raised below would
+                                // never fire for a single text file - the WSL mapping-failure
+                                // warning was still being lost here.
+                                Notice = ShouldRaiseDropNotice(result.ToastMessage)
+                                    ? result.ToastMessage
+                                    : null
                             };
                             TextFileDropped?.Invoke(this, args);
                             return; // Do NOT insert path automatically, wait for user to click Toast

--- a/src/NovaTerminal.App/Shell/TerminalView.cs
+++ b/src/NovaTerminal.App/Shell/TerminalView.cs
@@ -395,6 +395,28 @@ namespace NovaTerminal.Shell
         }
 
         public event EventHandler<TextFileDroppedEventArgs>? TextFileDropped;
+
+        /// Raised with a human-readable explanation when a file drop is refused, or is
+        /// accepted with a caveat. DropRouter has always produced these messages
+        /// (ToastMessage) but nothing consumed them, so all three - secure-input block,
+        /// shell-metacharacter block, and WSL-mapping fallback - were discarded and the drop
+        /// appeared to do nothing at all (#182).
+        ///
+        /// Deliberately a plain message rather than a typed severity: two of the three are
+        /// refusals and one is a warning about a successful drop, and the pane presents both
+        /// the same way. Splitting them would add a distinction the UI does not make.
+        public event Action<string>? DropNotice;
+
+        /// Whether a DropRouter outcome carries a message the user must see.
+        ///
+        /// Extracted so the contract can be tested against real DropRouter results without
+        /// simulating a drag-and-drop gesture. The subtlety worth pinning is that it depends
+        /// only on the message: the original code surfaced nothing when a message arrived
+        /// *alongside* TextToSend, which is exactly the WSL-mapping-fallback shape, so that
+        /// third message was lost even though the other two were at least reachable via the
+        /// block branch.
+        internal static bool ShouldRaiseDropNotice(string? toastMessage) =>
+            !string.IsNullOrEmpty(toastMessage);
         public event Action<string>? TextInputObserved;
         public event Action? BackspaceObserved;
         public event Action? EnterObserved;
@@ -459,10 +481,14 @@ namespace NovaTerminal.Shell
                     if (result.Handled)
                     {
                         // 1) First check if DropRouter explicitly blocked the input for security
-                        if (!string.IsNullOrEmpty(result.ToastMessage) && string.IsNullOrEmpty(result.TextToSend))
+                        if (ShouldRaiseDropNotice(result.ToastMessage) && string.IsNullOrEmpty(result.TextToSend))
                         {
-                            // Terminal session echo is disabled and Alt was not held
-                            // Do not show the Smart Paste toast. It's unsafe.
+                            // Terminal session echo is disabled and Alt was not held.
+                            // Do not send anything - but do tell the user why nothing
+                            // happened. This used to be a bare `return`, so a blocked drop
+                            // was indistinguishable from a drop that silently did nothing
+                            // (#182).
+                            DropNotice?.Invoke(result.ToastMessage!);
                             return;
                         }
 
@@ -483,7 +509,17 @@ namespace NovaTerminal.Shell
                             _session.SendInput(result.TextToSend);
                             PasteObserved?.Invoke(result.TextToSend);
                         }
-                        
+
+                        // A message can accompany a *successful* drop too: DropRouter sets
+                        // one alongside TextToSend when WSL path mapping failed and it fell
+                        // back to the Windows path. The path is inserted either way, so this
+                        // is a warning rather than a block - and it was the third message
+                        // being dropped on the floor here, not just the two blocks above.
+                        if (ShouldRaiseDropNotice(result.ToastMessage))
+                        {
+                            DropNotice?.Invoke(result.ToastMessage!);
+                        }
+
                         return;
                     }
                 }

--- a/tests/NovaTerminal.App.Tests/Input/DropNoticeSurfacingTests.cs
+++ b/tests/NovaTerminal.App.Tests/Input/DropNoticeSurfacingTests.cs
@@ -82,6 +82,34 @@ namespace NovaTerminal.Tests.Input
         }
 
         [Fact]
+        public async Task SingleTextFileWithMappingFallback_StillHasAMessageToCarry()
+        {
+            // Review of this PR caught that the single-text-file branch returns before the
+            // DropNotice call, so the mapping-failure warning was still lost for the one
+            // shape where the smart-paste prompt also applies. The message now rides on
+            // TextFileDroppedEventArgs.Notice instead of being raised separately - both
+            // render into the same toast panel, so raising both would lose one.
+            var context = new SessionContext
+            {
+                IsEchoEnabled = true,
+                IsWslSession = true,
+                DetectedShell = DetectedShell.PosixSh
+            };
+
+            var mapper = new Mock<IPathMapper>();
+            mapper.Setup(m => m.MapAsync(@"C:\notes.txt", It.IsAny<CancellationToken>()))
+                  .ReturnsAsync(@"C:\notes.txt");
+
+            var result = await DropRouter.HandleDropAsync(
+                context, new List<string> { @"C:\notes.txt" }, isAltHeld: false, mapper.Object);
+
+            // A single .txt takes the TextFileDropped branch, and this outcome carries both
+            // a path to insert and a warning about it.
+            Assert.False(string.IsNullOrEmpty(result.TextToSend));
+            Assert.True(TerminalView.ShouldRaiseDropNotice(result.ToastMessage));
+        }
+
+        [Fact]
         public async Task AnOrdinaryDrop_SurfacesNothing()
         {
             // Guards the other direction: no gratuitous toast on the common path.

--- a/tests/NovaTerminal.App.Tests/Input/DropNoticeSurfacingTests.cs
+++ b/tests/NovaTerminal.App.Tests/Input/DropNoticeSurfacingTests.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NovaTerminal.Platform;
+using NovaTerminal.Platform.Paths;
+using NovaTerminal.Shell;
+using NovaTerminal.VT;
+using Xunit;
+
+namespace NovaTerminal.Tests.Input
+{
+    /// <summary>
+    /// #182: DropRouter produced user-facing messages that nothing consumed.
+    ///
+    /// DropRouterTests already covers that the messages are *produced*. These tests cover
+    /// the half that was missing - that every produced message is one TerminalView will
+    /// surface - by feeding real DropRouter outcomes into the decision TerminalView makes.
+    ///
+    /// The remaining untested link is the UI plumbing itself (event to toast panel), which
+    /// would need a simulated drag-and-drop gesture; see the PR.
+    /// </summary>
+    public class DropNoticeSurfacingTests
+    {
+        [Fact]
+        public async Task SecureInputBlock_ProducesAMessageThatGetsSurfaced()
+        {
+            var context = new SessionContext { IsEchoEnabled = false };
+            var result = await DropRouter.HandleDropAsync(
+                context, new List<string> { @"C:\test.txt" }, isAltHeld: false);
+
+            Assert.True(TerminalView.ShouldRaiseDropNotice(result.ToastMessage));
+        }
+
+        [Fact]
+        public async Task MetacharacterBlock_ProducesAMessageThatGetsSurfaced()
+        {
+            // Cmd specifically: only CmdQuoter implements HasUnsafeMetacharacters (the
+            // IShellQuoter default returns false), because % and ! expansion cannot be
+            // neutralised in an interactive cmd session. My first attempt used PosixSh and
+            // the drop was allowed - correctly - so the test was asserting nothing.
+            var context = new SessionContext
+            {
+                IsEchoEnabled = true,
+                DetectedShell = DetectedShell.Cmd
+            };
+
+            // "%APPDATA%.txt" is the injection case the rule exists for.
+            var result = await DropRouter.HandleDropAsync(
+                context, new List<string> { @"C:\%APPDATA%.txt" }, isAltHeld: false);
+
+            Assert.True(
+                TerminalView.ShouldRaiseDropNotice(result.ToastMessage),
+                $"expected a surfaced message, got {result.ToastMessage ?? "<null>"}");
+        }
+
+        [Fact]
+        public async Task WslMappingFallback_SurfacesItsMessageEvenThoughTextWasSent()
+        {
+            // The regression that motivated #182's third message. The path *is* inserted, so
+            // the old code took the "send text" branch and returned without ever looking at
+            // ToastMessage. A notice must fire even when text was sent.
+            var context = new SessionContext
+            {
+                IsEchoEnabled = true,
+                IsWslSession = true,
+                DetectedShell = DetectedShell.PosixSh
+            };
+
+            var mapper = new Mock<IPathMapper>();
+            // Returning the input unchanged is how a mapping failure presents.
+            mapper.Setup(m => m.MapAsync(@"C:\test.txt", It.IsAny<CancellationToken>()))
+                  .ReturnsAsync(@"C:\test.txt");
+
+            var result = await DropRouter.HandleDropAsync(
+                context, new List<string> { @"C:\test.txt" }, isAltHeld: false, mapper.Object);
+
+            Assert.False(string.IsNullOrEmpty(result.TextToSend));
+            Assert.True(
+                TerminalView.ShouldRaiseDropNotice(result.ToastMessage),
+                "a message accompanying a successful drop must still be surfaced");
+        }
+
+        [Fact]
+        public async Task AnOrdinaryDrop_SurfacesNothing()
+        {
+            // Guards the other direction: no gratuitous toast on the common path.
+            var context = new SessionContext
+            {
+                IsEchoEnabled = true,
+                DetectedShell = DetectedShell.Pwsh
+            };
+
+            var result = await DropRouter.HandleDropAsync(
+                context, new List<string> { @"C:\test.txt" }, isAltHeld: false);
+
+            Assert.False(string.IsNullOrEmpty(result.TextToSend));
+            Assert.False(TerminalView.ShouldRaiseDropNotice(result.ToastMessage));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #182.

`DropRouter` has always produced user-facing explanations (`DropRouterResult.ToastMessage`) and nothing consumed them — so a refused drop looked identical to a drop that silently did nothing.

## Three messages were discarded, not two

| # | Source | Why it was lost |
|---|---|---|
| 1 | `DropRouter.cs:27` secure-input block | `TextToSend` empty → hit the bare `return` |
| 2 | `:67` shell-metacharacter block | same |
| 3 | `:84` WSL mapping fallback | sets `ToastMessage` **alongside** `TextToSend`, so it fell through to the send branch — which never looked at the message |

The third is the interesting one and confirms the triage's count over the issue's. The path **is** inserted (the unmapped Windows path), so it's a warning about a *successful* drop, not a refusal.

That shaped two decisions:

- the event is **`DropNotice`**, not `DropBlocked` — naming it for refusal would be wrong for a third of its uses
- it carries a plain message with **no severity** — two are refusals, one isn't, and the pane presents both identically. Adding a severity would encode a distinction the UI doesn't make.

## Where it surfaces

`TerminalPane` already owns a toast panel for the smart-paste flow, and the message belongs in the pane the drop landed on rather than a window-level toast — so it reuses that panel, with the two action buttons hidden because there's nothing to act on (the text was either never sent, or already sent).

The smart-paste handler now re-shows those buttons explicitly, since the panel is shared between both uses — otherwise a notice would permanently strip the buttons off the next smart-paste toast.

## Tests

`DropRouterTests` already covered that the messages are *produced* — including, usefully, that the WSL case sets text and message together. So the missing half was that every produced message is one the view will surface.

Four tests drive **real `DropRouter` outcomes** through the decision `TerminalView` makes, rather than asserting on hand-built results:

- each of the three message cases surfaces
- an ordinary drop stays silent (guards against a gratuitous toast on the common path)

**Mutation-checked:** forcing the decision to `false` fails exactly the three message cases and leaves the silent one passing.

### Two things worth flagging from writing them

**My metacharacter test initially passed while asserting nothing.** I used `PosixSh`, and only `CmdQuoter` implements `HasUnsafeMetacharacters` — the `IShellQuoter` default returns `false`. So the drop was correctly *allowed* and my "expected a block" assertion was vacuous. It now uses `Cmd` with `"%APPDATA%.txt"`, the injection the rule exists for. I only caught it because the assertion had a failure message attached.

**The production branches call the same helper the tests exercise**, rather than repeating `!string.IsNullOrEmpty(...)` inline. I wrote it inline first, which would have let the tested rule and the real branch drift apart silently.

### Not covered

The UI plumbing itself — event → visible toast panel. That needs a simulated drag-and-drop gesture with a `DataTransfer`, which I don't think is worth building for this; the handler is four assignments. Worth a reviewer's eye on the button visibility restore, since that's the part with state.
