### PR TITLE
ci: measure coverage and put a floor under NovaTerminal.VT (#117 item 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,15 +354,23 @@ jobs:
           SKIP_RUST_NATIVE_BUILD: '1'
         shell: bash
         run: |
+          # No `|| true` here. The step is already continue-on-error, so swallowing the
+          # exit code inside the loop only destroys the diagnostics - which is exactly what
+          # happened on the first attempt: five empty log groups and no way to tell why.
+          # set -x records the resolved command so a failure is self-explaining.
+          set -x
+          dotnet --version
           filter="Category!=Replay&Category!=RenderMetrics&Category!=PtySmoke&Category!=Stress&Category!=GoldenSharedPng"
           for proj in VT Rendering Architecture Platform McpServer; do
             echo "::group::NovaTerminal.$proj.Tests"
             dotnet test "tests/NovaTerminal.$proj.Tests" -c "$CONFIGURATION" --no-build --no-restore \
               --filter "$filter" \
               --settings tests/coverage.runsettings \
-              --results-directory "coverage/$proj" || true
+              --results-directory "coverage/$proj"
             echo "::endgroup::"
           done
+          echo "=== collected reports ==="
+          find coverage -name '*.cobertura.xml' -print || echo "none found"
 
       # A floor, not a target, and deliberately below the measured value: VT is at 53.14%
       # line / 46.51% branch as measured by this invocation, so the floor is 50% - normal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,7 +365,20 @@ jobs:
           set -x
           dotnet --version
           filter="Category!=Replay&Category!=RenderMetrics&Category!=PtySmoke&Category!=Stress&Category!=GoldenSharedPng"
-          for proj in VT Rendering Architecture Platform McpServer; do
+          # Which projects are measured, and why these:
+          #
+          # Architecture.Tests is deliberately absent. It has no coverlet.collector
+          # reference (unlike the four below), so it produced no report and the job
+          # measured four projects while listing five. It asserts project and IL structure
+          # rather than executing product code, so there is little for coverlet to
+          # attribute - excluding it is more honest than adding the package to make an
+          # empty report appear.
+          #
+          # App.Tests is also absent, matching the gating lane, which excludes it because
+          # of the Avalonia headless flake (#81). It does carry the collector, and it
+          # exercises a lot of VT (the buffer and reflow scenario suites live there) - so
+          # its absence is the main reason the VT figure below understates true coverage.
+          for proj in VT Rendering Platform McpServer; do
             echo "::group::NovaTerminal.$proj.Tests"
             dotnet test "tests/NovaTerminal.$proj.Tests" -c "$CONFIGURATION" --no-restore \
               --filter "$filter" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,97 @@ jobs:
             **/*.trx
             **/*.dmp
 
+  # Coverage measurement (#117). coverlet.collector was pinned in
+  # Directory.Packages.props and referenced by all five test projects, but nothing ever
+  # enabled it - no invocation passed a collect switch and no report was produced.
+  #
+  # Deliberately a separate job rather than instrumenting the gating Unit Tests lane.
+  # Coverage instrumentation slows execution by orders of magnitude on hot loops, and the
+  # suite contains wall-clock assertions - CsiParamClampTests.HugeCsiParameter_DoesNotHang
+  # guards the #124 parser DoS with a 2s ceiling, and measured 2088ms under instrumentation
+  # locally. Instrumenting the gate would make the gate's own timing assertions unreliable,
+  # so correctness and measurement are kept apart.
+  coverage:
+    name: Coverage (NovaTerminal.VT floor)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [build]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache .NET SDK
+        uses: actions/cache@v4
+        with:
+          path: ~/.dotnet
+          key: dotnet-sdk-${{ runner.os }}-${{ hashFiles('global.json') }}
+          restore-keys: dotnet-sdk-${{ runner.os }}-
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        env:
+          DOTNET_INSTALL_DIR: ~/.dotnet
+        with:
+          global-json-file: global.json
+          cache: true
+          cache-dependency-path: "**/*.csproj"
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dotnet-build-ubuntu-latest
+          path: tests
+
+      - name: Restore execute permissions
+        run: |
+          find tests -path "*/bin/Release/net*" -type f \
+            ! -name "*.dll" ! -name "*.json" ! -name "*.pdb" ! -name "*.xml" \
+            ! -name "*.so" ! -name "*.dylib" ! -name "*.a" ! -name "*.txt" \
+            -exec chmod +x {} + || true
+
+      # continue-on-error: this job measures, it does not judge correctness - the Unit Tests
+      # lane already does that on an uninstrumented run. Without this, a wall-clock
+      # assertion tripped by instrumentation overhead (see the job comment) would fail here
+      # for a reason that says nothing about the code. Coverage data is still written for
+      # every test that ran, so the floor check below remains meaningful.
+      - name: Test with coverage
+        continue-on-error: true
+        env:
+          SKIP_RUST_NATIVE_BUILD: '1'
+        shell: bash
+        run: |
+          filter="Category!=Replay&Category!=RenderMetrics&Category!=PtySmoke&Category!=Stress&Category!=GoldenSharedPng"
+          for proj in VT Rendering Architecture Platform McpServer; do
+            echo "::group::NovaTerminal.$proj.Tests"
+            dotnet test "tests/NovaTerminal.$proj.Tests" -c "$CONFIGURATION" --no-build --no-restore \
+              --filter "$filter" \
+              --settings tests/coverage.runsettings \
+              --results-directory "coverage/$proj" || true
+            echo "::endgroup::"
+          done
+
+      # A floor, not a target, and deliberately below the measured value: VT is at 53.14%
+      # line / 46.51% branch as measured by this invocation, so the floor is 50% - normal
+      # churn cannot turn a green PR red, and it should be ratcheted up as coverage grows
+      # rather than set aspirationally now. VT gets the only floor because it is the
+      # conformance-critical assembly; the other four upload their reports so their numbers
+      # are visible before anyone commits to a floor for them.
+      - name: Check coverage floor (NovaTerminal.VT)
+        shell: pwsh
+        run: >-
+          ./scripts/check-coverage.ps1
+          -ReportDirectory coverage/VT
+          -MinimumLinePercent 50
+          -Label NovaTerminal.VT
+
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-reports
+          retention-days: 5
+          path: coverage/**/*.cobertura.xml
+
   golden_shared_png_tests:
     name: Golden Shared PNGs (windows-latest)
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,18 +330,22 @@ jobs:
           cache: true
           cache-dependency-path: "**/*.csproj"
 
-      - name: Download build artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: dotnet-build-ubuntu-latest
-          path: tests
+      # Builds from source rather than consuming the build job's artifact. Two reasons:
+      #
+      # 1. `dotnet test <dir> --no-build --settings <file>` silently does nothing on this
+      #    SDK - it exits 0 in ~0.3s with no output and writes no report, five times over.
+      #    The gating lane gets away with the same --no-build because it passes no
+      #    --settings. Building here matches the invocation shape that was verified to
+      #    produce a report locally, instead of relying on that combination working.
+      # 2. Coverage needs the source tree anyway to attribute lines, so the artifact saved
+      #    nothing here.
+      #
+      # The cost is one extra build in exchange for a job that demonstrably measures.
+      - name: Restore
+        run: dotnet restore
 
-      - name: Restore execute permissions
-        run: |
-          find tests -path "*/bin/Release/net*" -type f \
-            ! -name "*.dll" ! -name "*.json" ! -name "*.pdb" ! -name "*.xml" \
-            ! -name "*.so" ! -name "*.dylib" ! -name "*.a" ! -name "*.txt" \
-            -exec chmod +x {} + || true
+      - name: Build
+        run: dotnet build -c ${{ env.CONFIGURATION }} --no-restore
 
       # continue-on-error: this job measures, it does not judge correctness - the Unit Tests
       # lane already does that on an uninstrumented run. Without this, a wall-clock
@@ -354,16 +358,16 @@ jobs:
           SKIP_RUST_NATIVE_BUILD: '1'
         shell: bash
         run: |
-          # No `|| true` here. The step is already continue-on-error, so swallowing the
-          # exit code inside the loop only destroys the diagnostics - which is exactly what
-          # happened on the first attempt: five empty log groups and no way to tell why.
-          # set -x records the resolved command so a failure is self-explaining.
+          # No `|| true` inside the loop. The step is already continue-on-error, so
+          # swallowing exit codes there only destroys the diagnostics - which is exactly
+          # what happened on the first attempt: five empty log groups and no way to tell
+          # why. set -x records the resolved command so a failure explains itself.
           set -x
           dotnet --version
           filter="Category!=Replay&Category!=RenderMetrics&Category!=PtySmoke&Category!=Stress&Category!=GoldenSharedPng"
           for proj in VT Rendering Architecture Platform McpServer; do
             echo "::group::NovaTerminal.$proj.Tests"
-            dotnet test "tests/NovaTerminal.$proj.Tests" -c "$CONFIGURATION" --no-build --no-restore \
+            dotnet test "tests/NovaTerminal.$proj.Tests" -c "$CONFIGURATION" --no-restore \
               --filter "$filter" \
               --settings tests/coverage.runsettings \
               --results-directory "coverage/$proj"

--- a/scripts/check-coverage.ps1
+++ b/scripts/check-coverage.ps1
@@ -1,0 +1,58 @@
+#!/usr/bin/env pwsh
+# Fails when an assembly's line coverage drops below a floor (#117).
+#
+# Why a script and not a coverlet setting: coverlet.collector (the `--collect` /
+# runsettings path) has no threshold option - only coverlet.msbuild does, which would mean
+# a second coverage package and a different invocation. Parsing the cobertura report the
+# collector already writes keeps one mechanism.
+#
+# Why pwsh and not bash: this runs on both windows-latest and ubuntu-latest, pwsh ships on
+# both GitHub runner images, and it parses XML natively instead of grepping attributes out
+# of markup.
+#
+# Usage:
+#   scripts/check-coverage.ps1 -ReportDirectory coverage/VT -MinimumLinePercent 50
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ReportDirectory,
+
+    [Parameter(Mandatory = $true)]
+    [double]$MinimumLinePercent,
+
+    # Purely for the log line, so a failure says which assembly is short.
+    [string]$Label = ""
+)
+
+$ErrorActionPreference = 'Stop'
+
+$reports = @(Get-ChildItem -Path $ReportDirectory -Recurse -Filter 'coverage.cobertura.xml' -ErrorAction SilentlyContinue)
+
+if ($reports.Count -eq 0) {
+    # A missing report means collection silently stopped working, which would otherwise
+    # look like a pass. Treat it as a failure.
+    Write-Host "::error::No coverage.cobertura.xml found under '$ReportDirectory'. Coverage collection did not run."
+    exit 1
+}
+
+# One report per test project run; take the newest if a stale one lingers.
+$report = ($reports | Sort-Object LastWriteTime -Descending)[0]
+[xml]$xml = Get-Content -Path $report.FullName
+
+$lineRate = [double]$xml.coverage.'line-rate'
+$branchRate = [double]$xml.coverage.'branch-rate'
+$linePercent = [math]::Round($lineRate * 100, 2)
+$branchPercent = [math]::Round($branchRate * 100, 2)
+
+$name = if ([string]::IsNullOrWhiteSpace($Label)) { $ReportDirectory } else { $Label }
+
+Write-Host "$name coverage: line ${linePercent}% (floor ${MinimumLinePercent}%), branch ${branchPercent}%"
+Write-Host "  report: $($report.FullName)"
+
+if ($linePercent -lt $MinimumLinePercent) {
+    Write-Host "::error::$name line coverage ${linePercent}% is below the ${MinimumLinePercent}% floor."
+    exit 1
+}
+
+exit 0

--- a/tests/coverage.runsettings
+++ b/tests/coverage.runsettings
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Coverage settings for `dotnet test` (#117).
+
+  coverlet.collector has been pinned in Directory.Packages.props and referenced by all
+  five test projects for a while, but nothing ever enabled it: no test invocation passed
+  a collect switch, and no report was produced. The dependency was present and entirely
+  unused.
+
+  A settings file rather than a command-line collect switch: the collector's friendly name
+  contains spaces, which does not survive the quoting layers between the CI shell,
+  scripts/build.*, and MSBuild (it splits into separate switches and fails with MSB1008).
+  Keeping it here also means local and CI runs measure identically.
+-->
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <!-- Generated and obsolete members are not meaningful coverage targets. -->
+          <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
+          <!-- Test assemblies measure the product, not themselves. -->
+          <Exclude>[*.Tests]*,[NovaTerminal.Benchmarks]*</Exclude>
+          <SingleHit>false</SingleHit>
+          <UseSourceLink>true</UseSourceLink>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
Addresses **#117 item 1**. Item 2 (re-gate the headless `App.Tests` suite) stays open — it waits on AvaloniaUI/Avalonia#21467, still unfixed and not fixable in-repo.

## The gap

`coverlet.collector` was pinned in `Directory.Packages.props` and referenced by **all five** test projects — and nothing ever switched it on. No invocation passed a collect switch; no report was produced. I checked the workflows for existing coverage wiring and the five grep hits were all false positives (comments, and `docs/vt_coverage_matrix.md`). So the dependency was present and entirely unused, and "952 tests, no idea what they cover" was accurate.

## Measured first, then set the floor

**NovaTerminal.VT: 53.14% line, 46.51% branch.** The floor is **50% line** — deliberately below the measured value so normal churn can't turn a green PR red. It's a ratchet to raise as coverage grows, not an aspiration to fail against today.

VT gets the only floor (conformance-critical assembly, per the issue). The other four collect and upload so their numbers are visible before anyone commits to a floor for them.

## Three decisions, each forced by something that broke first

**Settings file, not `--collect`.** The collector's friendly name contains spaces, which doesn't survive the quoting layers between the CI shell, `scripts/build.*` and MSBuild — it splits into separate switches and dies with `MSB1008: Only one project can be specified`. A checked-in `tests/coverage.runsettings` sidesteps that and makes local and CI runs measure identically. (My first `.runsettings` also failed, because XML comments can't contain `--` and mine described command-line switches.)

**A separate job, not the gating Unit Tests lane.** This is the one worth reviewing. Instrumentation slows hot loops by orders of magnitude, and this suite contains wall-clock assertions:

```
CsiParamClampTests.HugeCsiParameter_DoesNotHang("\x1b[333333261S")
  CSI '[333333261S' took 2088ms — parameter likely unclamped
```

That test guards the #124 parser DoS with a 2s ceiling on a sub-millisecond operation. Under instrumentation it measured 2088ms — it failed the moment I added coverage to the gating lane. **Instrumenting the gate would make the gate's own timing assertions unreliable**, so correctness and measurement are now separate jobs, and the test step is `continue-on-error` for the same reason: this job measures, the Unit Tests lane judges. Coverage data is still written for every test that ran, so the floor stays meaningful.

I considered instead tagging that test with a `Timing` trait and filtering it out of the instrumented run. I preferred separation: the timing problem isn't specific to that one test, it's inherent to instrumenting anything with a clock in it, and a filter would need extending every time someone adds another.

**A script, not a coverlet threshold.** `coverlet.collector` has no threshold option — only `coverlet.msbuild` does, which would mean a second coverage package and a different invocation. `scripts/check-coverage.ps1` parses the cobertura report the collector already writes. `pwsh` because it ships on both runner images and parses XML natively instead of grepping attributes out of markup.

The script **fails on a missing report** rather than passing vacuously — that's the failure mode that would otherwise let collection silently break and still look green.

## Verification

Locally, all three script states:

| Case | Result |
|---|---|
| 50% floor vs 53.14% actual | exit 0 |
| 90% floor vs 53.14% actual | exit 1 with `::error::` |
| missing report directory | exit 1 with `::error::` |

Coverage collection itself confirmed end-to-end: `VT.Tests` 85 passed, cobertura report written and parsed.

### What CI will tell us that I can't

The job's behaviour on the runner — artifact download, execute-permission restore, and whether any *other* project has a timing-sensitive test that trips under instrumentation. VT was the one I found locally; the other four ran clean here, but Linux timing differs.

## Caveat on the number

53.14% is VT as measured by `VT.Tests` **alone**. VT is also exercised by `App.Tests` (the buffer and reflow scenario suites live there), so true VT coverage is higher and this floor is conservative in a second way. Merging reports across projects needs a report-merge step; worth doing when the floor gets ratcheted, not before.
