### PR TITLE
chore(build): start the warnings-as-errors ratchet on six clean projects

### DIFF
--- a/src/NovaTerminal.AgentHost.Contracts/NovaTerminal.AgentHost.Contracts.csproj
+++ b/src/NovaTerminal.AgentHost.Contracts/NovaTerminal.AgentHost.Contracts.csproj
@@ -7,6 +7,12 @@
     references; enforced by NovaTerminal.Architecture.Tests.
   -->
 
+  <PropertyGroup>
+    <!-- Ratchet (#108): warning-free today, so lock it in. See the repo-wide default in
+         Directory.Build.props, which stays false until the noisy projects are cleaned. -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="NovaTerminal.McpServer.Tests" />
   </ItemGroup>

--- a/src/NovaTerminal.Cli/NovaTerminal.Cli.csproj
+++ b/src/NovaTerminal.Cli/NovaTerminal.Cli.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <AssemblyName>NovaTerminal.Cli</AssemblyName>
     <OutputType>Exe</OutputType>
+    <!-- Ratchet (#108): warning-free today, so lock it in. See the repo-wide default in
+         Directory.Build.props, which stays false until the noisy projects are cleaned. -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/NovaTerminal.Architecture.Tests/NovaTerminal.Architecture.Tests.csproj
+++ b/tests/NovaTerminal.Architecture.Tests/NovaTerminal.Architecture.Tests.csproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <!-- Ratchet (#108): reached zero by hoisting two constant array arguments (CA1861) in
+         ProjectFileLayeringTests. See the repo-wide default in Directory.Build.props. -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/NovaTerminal.Architecture.Tests/ProjectFileLayeringTests.cs
+++ b/tests/NovaTerminal.Architecture.Tests/ProjectFileLayeringTests.cs
@@ -16,6 +16,12 @@ namespace NovaTerminal.Architecture.Tests;
 /// </summary>
 public class ProjectFileLayeringTests
 {
+    // Hoisted out of the two Assert.Equal calls below to satisfy CA1861 (constant array
+    // arguments are re-allocated on every call). Both assertions expect the same single
+    // reference, so one field serves both - and this project is now built with
+    // TreatWarningsAsErrors, so the analyzer is enforced rather than advisory (#108).
+    private static readonly string[] VtOnly = ["NovaTerminal.VT"];
+
     private static string RepoRoot()
     {
         DirectoryInfo? dir = new(AppContext.BaseDirectory);
@@ -51,14 +57,14 @@ public class ProjectFileLayeringTests
     public void Replay_csproj_only_references_Vt()
     {
         var refs = ProjectReferences("src/NovaTerminal.Replay/NovaTerminal.Replay.csproj");
-        Assert.Equal(new[] { "NovaTerminal.VT" }, refs);
+        Assert.Equal(VtOnly, refs);
     }
 
     [Fact]
     public void Rendering_csproj_only_references_Vt()
     {
         var refs = ProjectReferences("src/NovaTerminal.Rendering/NovaTerminal.Rendering.csproj");
-        Assert.Equal(new[] { "NovaTerminal.VT" }, refs);
+        Assert.Equal(VtOnly, refs);
     }
 
     [Fact]

--- a/tests/NovaTerminal.McpServer.Tests/AgentHostClientTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/AgentHostClientTests.cs
@@ -16,6 +16,7 @@ namespace NovaTerminal.McpServer.Tests;
 /// </summary>
 public class AgentHostClientTests : IDisposable
 {
+
     private readonly string _tempDir;
 
     public AgentHostClientTests()
@@ -117,7 +118,9 @@ public class AgentHostClientTests : IDisposable
         var roundTripped = outcome.Response.Result!.Value.Deserialize(AgentHostJsonContext.Default.ListSessionsResult);
         Assert.Equal("vim", Assert.Single(roundTripped!.Sessions).Title);
 
-        await serverTask.WaitAsync(TimeSpan.FromSeconds(10));
+        // TestContext token per xUnit1051, so a cancelled test run stops waiting promptly
+        // instead of holding the full 10s ceiling.
+        await serverTask.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -148,7 +151,9 @@ public class AgentHostClientTests : IDisposable
 
         Assert.False(outcome.Available);
         Assert.Equal(AgentHostClient.ProtocolErrorMessage, outcome.UnavailableReason);
-        await serverTask.WaitAsync(TimeSpan.FromSeconds(10));
+        // TestContext token per xUnit1051, so a cancelled test run stops waiting promptly
+        // instead of holding the full 10s ceiling.
+        await serverTask.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
     }
 
     /// <summary>Accepts one connection, reads one line, replies with a raw string, then exits.</summary>
@@ -217,6 +222,12 @@ public class AgentHostClientTests : IDisposable
 /// <summary>Formatter tests: the shapes agents actually read.</summary>
 public class SessionToolsFormattingTests
 {
+    // Hoisted out of the object initialisers below to satisfy CA1861: a constant array
+    // argument is re-allocated on every call. This project is now built with
+    // TreatWarningsAsErrors (#108), so these analyzers are enforced rather than advisory.
+    private static readonly string[] HelloWorldLines = ["hello", "world"];
+    private static readonly string[] AbLines = ["a", "b"];
+
     [Fact]
     public async Task ReadScrollback_rejects_non_positive_maxLines_before_any_ipc()
     {
@@ -257,7 +268,7 @@ public class SessionToolsFormattingTests
     {
         var text = SessionTools.FormatScreen(new ScreenSnapshotDto
         {
-            Lines = new[] { "hello", "world" },
+            Lines = HelloWorldLines,
             CursorRow = 1,
             CursorCol = 5,
             CursorVisible = true,
@@ -419,7 +430,7 @@ public class SessionToolsFormattingTests
     {
         var text = SessionTools.FormatScrollback(new ReadScrollbackResult
         {
-            Lines = new[] { "a", "b" },
+            Lines = AbLines,
             StartLine = 10,
             TotalLines = 100,
         });

--- a/tests/NovaTerminal.McpServer.Tests/NovaTerminal.McpServer.Tests.csproj
+++ b/tests/NovaTerminal.McpServer.Tests/NovaTerminal.McpServer.Tests.csproj
@@ -2,6 +2,12 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <!-- Ratchet (#108): warning-free today, so lock it in. See the repo-wide default in
+         Directory.Build.props, which stays false until the noisy projects are cleaned.
+         Verified on a clean full rebuild after clearing the McpServer file lock (#211) -
+         the lock had been masking this project entirely, since it cannot build until
+         NovaTerminal.McpServer does. -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/NovaTerminal.Rendering.Tests/NovaTerminal.Rendering.Tests.csproj
+++ b/tests/NovaTerminal.Rendering.Tests/NovaTerminal.Rendering.Tests.csproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <!-- Ratchet (#108): warning-free today, so lock it in. See the repo-wide default in
+         Directory.Build.props, which stays false until the noisy projects are cleaned. -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/NovaTerminal.VT.Tests/NovaTerminal.VT.Tests.csproj
+++ b/tests/NovaTerminal.VT.Tests/NovaTerminal.VT.Tests.csproj
@@ -1,6 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <!-- Ratchet (#108): this project builds warning-free today, so lock that in. The
+         repo-wide default in Directory.Build.props stays false until the remaining
+         projects are cleaned up; opting in per project keeps a clean project from
+         silently regressing while the noisy ones are still being worked through. -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Addresses #108. **Leaves the issue open** — 12 of 18 projects still carry diagnostics.

## Approach: ratchet, not big bang

Flipping `TreatWarningsAsErrors` repo-wide means fixing ~1800 diagnostics in one unreviewable change. Instead this enables it **per project on the ones already clean**, so a clean project can't silently regress while the noisy ones are worked through. Each subsequent PR takes one or two more projects and stays reviewable.

Six projects enabled:

| Project | Work needed |
|---|---|
| `NovaTerminal.AgentHost.Contracts` | none — already clean |
| `NovaTerminal.Cli` | none — already clean |
| `NovaTerminal.Rendering.Tests` | none — already clean |
| `NovaTerminal.VT.Tests` | none — already clean |
| `NovaTerminal.Architecture.Tests` | 2 × CA1861 |
| `NovaTerminal.McpServer.Tests` | 4 diagnostics |

Fixes are mechanical: constant array arguments hoisted to `static readonly` fields (CA1861), and two `WaitAsync` calls now pass `TestContext.Current.CancellationToken` (xUnit1051) so a cancelled run stops waiting instead of holding the full 10s ceiling.

## Measured rather than assumed

`Directory.Build.props` documents ~350 diagnostics, but that inventory predates a lot of code. A forced full rebuild on current `main` gives **1822 unique diagnostics across 13 projects**:

```
484  CA1834      256  CA1305      238  xUnit1051
178  CA1822      112  CA1051      100  CA1805
 88  CA1861       52  CA1859       28  CA1310
```

The remaining ladder, smallest first — this is the suggested order for follow-ups:

```
Benchmarks 16    Conformance 20    ExternalSuites 22
Pty 26           Replay 28         Rendering 40
McpServer 44     Platform 74       Platform.Tests 80
VT 164           App.Tests 532     App 772
```

`App` alone is 42% of the total, and CA1834 (484 hits) is the single biggest rule — `Directory.Build.props` already notes "the bulk comes from a single file", so that one is likely a concentrated fix rather than 484 scattered ones.

## The finding worth more than the change

**`McpServer.Tests` initially measured zero warnings, and that was false.** The #211 file lock stopped it building at all, so it reported nothing — and I read that as "clean".

You picked clearing the lock over ratcheting it unverified, and that's what caught it: with the lock gone it built and surfaced 4 real diagnostics. Had I taken the unverified route, this PR would have been red on arrival.

The general lesson: **a project that can't build reads as clean.** Any warning count taken from a red build understates reality, silently, in proportion to how much failed. Worth remembering the next time someone measures diagnostics on a build that wasn't fully green.

## Verification

- Forced full rebuild (`--no-incremental`): **18/18 projects, 0 errors, 0 warnings** in the ratcheted set. This is the first fully clean local build this session — previously the #211 lock always left 2 errors.
- Tests for the four touched test projects: **18, 134, 85, 10 passed; 0 failed.**

The ratchet is self-enforcing: if anyone adds a warning to one of these six, their build fails locally and in CI rather than adding to a pile nobody is counting.
