### PR TITLE
chore(dev): mirror the MCP server into the sidecar so the repo stays buildable

### DIFF
--- a/docs/mcp-dev-companion.md
+++ b/docs/mcp-dev-companion.md
@@ -41,18 +41,43 @@ hand). The dev-companion tools locate the repository automatically by walking up
 `NovaTerminal.sln`; you can override that with the `NOVATERMINAL_REPO_ROOT` environment variable.
 The live-session tools need the NovaTerminal app running with the opt-ins enabled.
 
-Build once, then run the built DLL (clients should point at the DLL, **not** `dotnet run` —
-`run` emits build/restore output to stdout, which corrupts the JSON-RPC stream):
+Clients should point at the built DLL, **not** `dotnet run` — `run` emits build/restore
+output to stdout, which corrupts the JSON-RPC stream.
+
+**Point the client at the sidecar copy, not at `src/.../bin/`** (#211). The server is a
+long-lived process, so while it runs from the repo tree it holds
+`NovaTerminal.AgentHost.Contracts.dll` open, and *every* full repo build then fails with
+`MSB3027`/`MSB3021` on the McpServer copy step — whether or not the app is running.
+`scripts/run-sidecar.ps1` builds and mirrors the server to a fixed location outside the repo
+and prints the exact path to configure:
+
+```powershell
+scripts/run-sidecar.ps1                     # builds + mirrors app and MCP server, launches the app
+scripts/run-sidecar.ps1 -SkipMcpServer      # app only
+```
+
+The sidecar path is:
+
+```
+%LOCALAPPDATA%\NovaTerminal-sidecar\McpServer\<Configuration>\net10.0\NovaTerminal.McpServer.dll
+~/.local/share/NovaTerminal-sidecar/McpServer/<Configuration>/net10.0/NovaTerminal.McpServer.dll
+```
+
+Because the mirror is refreshed on every `run-sidecar.ps1` invocation, it cannot go silently
+stale the way a hand-made copy does. It does lag while a client holds the server open — the
+script warns when it could not refresh, and restarting the MCP client picks up the new build.
+The repo stays buildable either way, which is the point.
+
+To run it by hand instead (it speaks stdio, so this is mainly a smoke check):
 
 ```bash
-# from the repo root
 dotnet build -c Release src/NovaTerminal.McpServer
 dotnet src/NovaTerminal.McpServer/bin/Release/net10.0/NovaTerminal.McpServer.dll
 ```
 
 ### Client configuration
 
-- Claude Code: `claude mcp add novaterminal -- dotnet "<path-to-repo>/src/NovaTerminal.McpServer/bin/Release/net10.0/NovaTerminal.McpServer.dll"`
+- Claude Code: `claude mcp add novaterminal -- dotnet "%LOCALAPPDATA%\NovaTerminal-sidecar\McpServer\Debug\net10.0\NovaTerminal.McpServer.dll"`
 - Claude Desktop: [examples/mcp/claude_desktop_config.json](../examples/mcp/claude_desktop_config.json)
 - VS Code: [examples/mcp/vscode_mcp_config.json](../examples/mcp/vscode_mcp_config.json)
 

--- a/docs/mcp-dev-companion.md
+++ b/docs/mcp-dev-companion.md
@@ -56,12 +56,18 @@ scripts/run-sidecar.ps1                     # builds + mirrors app and MCP serve
 scripts/run-sidecar.ps1 -SkipMcpServer      # app only
 ```
 
-The sidecar path is:
+The script prints the exact path to configure. It lives at:
 
 ```
 %LOCALAPPDATA%\NovaTerminal-sidecar\McpServer\<Configuration>\net10.0\NovaTerminal.McpServer.dll
 ~/.local/share/NovaTerminal-sidecar/McpServer/<Configuration>/net10.0/NovaTerminal.McpServer.dll
 ```
+
+**Paste the resolved absolute path into client config, not the `%LOCALAPPDATA%` form.** Most
+MCP clients hand their `args` straight to the process with no shell involved, so an
+environment-variable reference is taken literally and the DLL lookup fails. (`%VAR%` also does
+not expand in PowerShell even on a command line.) VS Code is the exception — its `mcp.json`
+performs its own `${env:...}` substitution.
 
 Because the mirror is refreshed on every `run-sidecar.ps1` invocation, it cannot go silently
 stale the way a hand-made copy does. It does lag while a client holds the server open — the
@@ -77,7 +83,8 @@ dotnet src/NovaTerminal.McpServer/bin/Release/net10.0/NovaTerminal.McpServer.dll
 
 ### Client configuration
 
-- Claude Code: `claude mcp add novaterminal -- dotnet "%LOCALAPPDATA%\NovaTerminal-sidecar\McpServer\Debug\net10.0\NovaTerminal.McpServer.dll"`
+- Claude Code (substitute the path `run-sidecar.ps1` printed):
+  `claude mcp add novaterminal -- dotnet "C:\Users\<you>\AppData\Local\NovaTerminal-sidecar\McpServer\Debug\net10.0\NovaTerminal.McpServer.dll"`
 - Claude Desktop: [examples/mcp/claude_desktop_config.json](../examples/mcp/claude_desktop_config.json)
 - VS Code: [examples/mcp/vscode_mcp_config.json](../examples/mcp/vscode_mcp_config.json)
 

--- a/examples/mcp/claude_desktop_config.json
+++ b/examples/mcp/claude_desktop_config.json
@@ -1,16 +1,16 @@
 {
   "//": "Claude Desktop MCP config for the NovaTerminal MCP Dev Companion (read-only, local).",
-  "//build": "Build and mirror first: scripts/run-sidecar.ps1 (it prints the exact path below).",
+  "//build": "Build and mirror first: scripts/run-sidecar.ps1 — it prints the exact absolute path to paste below.",
+  "//paths": "Claude Desktop passes these args straight to the process: there is no shell, so %LOCALAPPDATA% or $HOME would be taken literally and the DLL lookup would fail. Use the absolute path the script prints. Replace C:/Users/YOU and /absolute/path/to/nova2 with your own.",
   "//why-sidecar": "Point at the sidecar copy, NOT src/NovaTerminal.McpServer/bin/. The server is long-lived, so from the repo tree it holds NovaTerminal.AgentHost.Contracts.dll open and every full repo build fails with MSB3027 on the McpServer copy step. See issue #211.",
-  "//paths": "Windows path shown. Elsewhere: ~/.local/share/NovaTerminal-sidecar/McpServer/Debug/net10.0/NovaTerminal.McpServer.dll",
   "//config": "Swap Debug for Release if you launch the sidecar with -Configuration Release.",
-  "//repo-root": "Replace /absolute/path/to/nova2 with your local clone path; the doc-reading tools resolve it from there.",
+  "//non-windows": "Linux/macOS sidecar path: /home/YOU/.local/share/NovaTerminal-sidecar/McpServer/Debug/net10.0/NovaTerminal.McpServer.dll",
   "//why-not-dotnet-run": "Use the built DLL, not 'dotnet run' — run emits build/restore output to stdout, which corrupts the MCP JSON-RPC stream.",
   "mcpServers": {
     "novaterminal-dev": {
       "command": "dotnet",
       "args": [
-        "%LOCALAPPDATA%\\NovaTerminal-sidecar\\McpServer\\Debug\\net10.0\\NovaTerminal.McpServer.dll"
+        "C:/Users/YOU/AppData/Local/NovaTerminal-sidecar/McpServer/Debug/net10.0/NovaTerminal.McpServer.dll"
       ],
       "env": {
         "NOVATERMINAL_REPO_ROOT": "/absolute/path/to/nova2"

--- a/examples/mcp/claude_desktop_config.json
+++ b/examples/mcp/claude_desktop_config.json
@@ -1,13 +1,16 @@
 {
   "//": "Claude Desktop MCP config for the NovaTerminal MCP Dev Companion (read-only, local).",
-  "//build": "Build once first: dotnet build -c Release src/NovaTerminal.McpServer",
-  "//paths": "Replace /absolute/path/to/nova2 with your local clone path.",
+  "//build": "Build and mirror first: scripts/run-sidecar.ps1 (it prints the exact path below).",
+  "//why-sidecar": "Point at the sidecar copy, NOT src/NovaTerminal.McpServer/bin/. The server is long-lived, so from the repo tree it holds NovaTerminal.AgentHost.Contracts.dll open and every full repo build fails with MSB3027 on the McpServer copy step. See issue #211.",
+  "//paths": "Windows path shown. Elsewhere: ~/.local/share/NovaTerminal-sidecar/McpServer/Debug/net10.0/NovaTerminal.McpServer.dll",
+  "//config": "Swap Debug for Release if you launch the sidecar with -Configuration Release.",
+  "//repo-root": "Replace /absolute/path/to/nova2 with your local clone path; the doc-reading tools resolve it from there.",
   "//why-not-dotnet-run": "Use the built DLL, not 'dotnet run' — run emits build/restore output to stdout, which corrupts the MCP JSON-RPC stream.",
   "mcpServers": {
     "novaterminal-dev": {
       "command": "dotnet",
       "args": [
-        "/absolute/path/to/nova2/src/NovaTerminal.McpServer/bin/Release/net10.0/NovaTerminal.McpServer.dll"
+        "%LOCALAPPDATA%\\NovaTerminal-sidecar\\McpServer\\Debug\\net10.0\\NovaTerminal.McpServer.dll"
       ],
       "env": {
         "NOVATERMINAL_REPO_ROOT": "/absolute/path/to/nova2"

--- a/examples/mcp/vscode_mcp_config.json
+++ b/examples/mcp/vscode_mcp_config.json
@@ -1,13 +1,16 @@
 {
   "//": "VS Code MCP config (.vscode/mcp.json) for the NovaTerminal MCP Dev Companion.",
-  "//build": "Build once first: dotnet build -c Release src/NovaTerminal.McpServer",
+  "//build": "Build and mirror first: scripts/run-sidecar.ps1 (it prints the exact path below).",
+  "//why-sidecar": "Point at the sidecar copy, NOT ${workspaceFolder}/src/NovaTerminal.McpServer/bin/. The server is long-lived, so from the repo tree it holds NovaTerminal.AgentHost.Contracts.dll open and every full repo build fails with MSB3027 on the McpServer copy step. See issue #211.",
+  "//paths": "Windows path shown. Elsewhere: ${userHome}/.local/share/NovaTerminal-sidecar/McpServer/Debug/net10.0/NovaTerminal.McpServer.dll",
+  "//config": "Swap Debug for Release if you launch the sidecar with -Configuration Release.",
   "//why-not-dotnet-run": "Use the built DLL, not 'dotnet run' — run emits build/restore output to stdout, which corrupts the MCP JSON-RPC stream.",
   "servers": {
     "novaterminal-dev": {
       "type": "stdio",
       "command": "dotnet",
       "args": [
-        "${workspaceFolder}/src/NovaTerminal.McpServer/bin/Release/net10.0/NovaTerminal.McpServer.dll"
+        "${env:LOCALAPPDATA}\\NovaTerminal-sidecar\\McpServer\\Debug\\net10.0\\NovaTerminal.McpServer.dll"
       ],
       "env": {
         "NOVATERMINAL_REPO_ROOT": "${workspaceFolder}"

--- a/examples/mcp/vscode_mcp_config.json
+++ b/examples/mcp/vscode_mcp_config.json
@@ -2,7 +2,7 @@
   "//": "VS Code MCP config (.vscode/mcp.json) for the NovaTerminal MCP Dev Companion.",
   "//build": "Build and mirror first: scripts/run-sidecar.ps1 (it prints the exact path below).",
   "//why-sidecar": "Point at the sidecar copy, NOT ${workspaceFolder}/src/NovaTerminal.McpServer/bin/. The server is long-lived, so from the repo tree it holds NovaTerminal.AgentHost.Contracts.dll open and every full repo build fails with MSB3027 on the McpServer copy step. See issue #211.",
-  "//paths": "Windows path shown. Elsewhere: ${userHome}/.local/share/NovaTerminal-sidecar/McpServer/Debug/net10.0/NovaTerminal.McpServer.dll",
+  "//paths": "${env:LOCALAPPDATA} is substituted by VS Code itself, not by a shell, so it is safe here — unlike the Claude Desktop example, which needs a literal absolute path. Non-Windows: ${userHome}/.local/share/NovaTerminal-sidecar/McpServer/Debug/net10.0/NovaTerminal.McpServer.dll",
   "//config": "Swap Debug for Release if you launch the sidecar with -Configuration Release.",
   "//why-not-dotnet-run": "Use the built DLL, not 'dotnet run' — run emits build/restore output to stdout, which corrupts the MCP JSON-RPC stream.",
   "servers": {

--- a/scripts/run-sidecar.ps1
+++ b/scripts/run-sidecar.ps1
@@ -1,6 +1,7 @@
 #!/usr/bin/env pwsh
 # Build NovaTerminal, mirror the fresh output to a fixed sidecar directory, and launch it
-# from there.
+# from there. Also mirrors the MCP dev-companion server, which is launched separately by an
+# MCP client rather than by this script.
 #
 # Why this exists: running the app holds a lock on its DLLs, so a `dotnet build` of the main
 # repo fails with "file in use" while an instance is running. The workaround has been to copy
@@ -13,6 +14,12 @@
 # The running build is identifiable in debug.log via the "Build: sha=... built=... path=..."
 # line (the sidecar path makes it obvious you're on the sidecar, not the repo output).
 #
+# NovaTerminal.McpServer gets the same treatment (#211). It is a long-lived process started
+# by whatever MCP client is configured, and while it ran from the repo tree it held
+# NovaTerminal.AgentHost.Contracts.dll open — which made *every* full repo build fail with
+# MSB3027/MSB3021 on the McpServer copy step, whether or not the app was running. Point the
+# MCP client at the sidecar path this script prints and the repo stays buildable.
+#
 # The DLL-lock problem this solves is Windows-specific, but the script runs on Linux/macOS too
 # (rsync/Copy-Item fallback for mirroring, no .exe suffix) so it's usable as a generic
 # always-fresh launcher anywhere.
@@ -21,6 +28,7 @@
 #   scripts/run-sidecar.ps1                 # Debug build, build + mirror + launch
 #   scripts/run-sidecar.ps1 -Configuration Release
 #   scripts/run-sidecar.ps1 -NoBuild        # skip the build; just mirror current output + launch
+#   scripts/run-sidecar.ps1 -SkipMcpServer  # app only; don't build/mirror the MCP server
 #   scripts/run-sidecar.ps1 -SidecarRoot /some/path   # override sidecar location
 
 [CmdletBinding()]
@@ -31,6 +39,10 @@ param(
     [string]$TargetFramework = 'net10.0',
 
     [switch]$NoBuild,
+
+    # The MCP server mirror is opt-out rather than opt-in: leaving it stale is how the repo
+    # ends up locked again, which is the whole point of #211.
+    [switch]$SkipMcpServer,
 
     # Default sidecar lives outside the repo so it never collides with repo bin/obj globbing,
     # IDE file watchers, or `git status`. $env:LOCALAPPDATA is Windows-only; fall back to the
@@ -48,6 +60,44 @@ $repoRoot = Split-Path -Parent $PSScriptRoot
 $appProject = Join-Path $repoRoot 'src' 'NovaTerminal.App'
 $sourceDir = Join-Path $appProject 'bin' $Configuration $TargetFramework
 
+$mcpProject = Join-Path $repoRoot 'src' 'NovaTerminal.McpServer'
+$mcpSourceDir = Join-Path $mcpProject 'bin' $Configuration $TargetFramework
+# Separate destination from the app's: both outputs contain the same shared assemblies (VT,
+# Replay, AgentHost.Contracts...), and robocopy /MIR deletes anything not in its source - so
+# mirroring both into one directory would have each delete the other's private files.
+$mcpDestDir = Join-Path $SidecarRoot 'McpServer' $Configuration $TargetFramework
+
+# Mirrors $from onto $to. Returns $true on success. Never throws: callers decide whether a
+# failed mirror is fatal.
+function Sync-Directory {
+    param([string]$From, [string]$To)
+
+    New-Item -ItemType Directory -Force -Path $To | Out-Null
+
+    if ($IsWindows) {
+        # robocopy /MIR mirrors source to dest (adds new, updates changed, deletes stale). Exit
+        # codes 0-7 are success (8+ are real errors); robocopy uses bit flags, not 0=ok.
+        robocopy $From $To /MIR /NJH /NJS /NDL /NP /R:2 /W:1 | Out-Null
+        return $LASTEXITCODE -lt 8
+    }
+
+    if (Get-Command rsync -ErrorAction SilentlyContinue) {
+        # Trailing slashes => mirror contents of source into dest; --delete removes stale files.
+        rsync -a --delete "$From/" "$To/"
+        return $LASTEXITCODE -eq 0
+    }
+
+    # No rsync: clear dest and recopy. Not incremental, but correct.
+    try {
+        if (Test-Path $To) { Remove-Item -Recurse -Force (Join-Path $To '*') -ErrorAction SilentlyContinue }
+        Copy-Item -Recurse -Force (Join-Path $From '*') $To
+        return $true
+    }
+    catch {
+        return $false
+    }
+}
+
 if (-not $NoBuild) {
     Write-Host "[sidecar] Building NovaTerminal.App ($Configuration)..." -ForegroundColor Cyan
     # Use the build wrapper so MSBuild/dotnet daemons don't outlive the build and hang on
@@ -58,6 +108,20 @@ if (-not $NoBuild) {
         Write-Error "[sidecar] Build failed (exit $LASTEXITCODE). Not launching."
         exit $LASTEXITCODE
     }
+
+    if (-not $SkipMcpServer) {
+        Write-Host "[sidecar] Building NovaTerminal.McpServer ($Configuration)..." -ForegroundColor Cyan
+        & (Join-Path $PSScriptRoot 'build.ps1') build $mcpProject -c $Configuration
+        if ($LASTEXITCODE -ne 0) {
+            # Non-fatal: a stale MCP sidecar must not stop you launching the app. This build
+            # can legitimately fail while an MCP server started from the *repo* path is still
+            # running and holding AgentHost.Contracts.dll - which is the state #211 exists to
+            # get out of.
+            Write-Warning "[sidecar] MCP server build failed (exit $LASTEXITCODE); its sidecar copy may be stale."
+            Write-Warning "[sidecar] If an MCP server is running from the repo tree, stop it (or repoint the client at the sidecar) and re-run."
+            $SkipMcpServer = $true
+        }
+    }
 }
 
 if (-not (Test-Path $sourceDir)) {
@@ -66,31 +130,32 @@ if (-not (Test-Path $sourceDir)) {
 }
 
 $destDir = Join-Path $SidecarRoot $Configuration $TargetFramework
-New-Item -ItemType Directory -Force -Path $destDir | Out-Null
 
 Write-Host "[sidecar] Mirroring fresh output -> $destDir" -ForegroundColor Cyan
-if ($IsWindows) {
-    # robocopy /MIR mirrors source to dest (adds new, updates changed, deletes stale). Exit
-    # codes 0-7 are success (8+ are real errors); robocopy uses bit flags, not 0=ok.
-    robocopy $sourceDir $destDir /MIR /NJH /NJS /NDL /NP /R:2 /W:1 | Out-Null
-    $rc = $LASTEXITCODE
-    if ($rc -ge 8) {
-        Write-Error "[sidecar] robocopy failed (exit $rc)."
-        exit $rc
-    }
+if (-not (Sync-Directory -From $sourceDir -To $destDir)) {
+    Write-Error "[sidecar] Mirror failed for the app output."
+    exit 1
 }
-elseif (Get-Command rsync -ErrorAction SilentlyContinue) {
-    # Trailing slashes => mirror contents of source into dest; --delete removes stale files.
-    rsync -a --delete "$sourceDir/" "$destDir/"
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "[sidecar] rsync failed (exit $LASTEXITCODE)."
-        exit $LASTEXITCODE
+
+if (-not $SkipMcpServer) {
+    if (Test-Path $mcpSourceDir) {
+        Write-Host "[sidecar] Mirroring MCP server -> $mcpDestDir" -ForegroundColor Cyan
+        if (Sync-Directory -From $mcpSourceDir -To $mcpDestDir) {
+            $mcpDll = Join-Path $mcpDestDir 'NovaTerminal.McpServer.dll'
+            Write-Host "[sidecar] MCP client should point at: dotnet `"$mcpDll`"" -ForegroundColor DarkGray
+        }
+        else {
+            # Expected whenever an MCP client already has a server running from this sidecar:
+            # the running process holds its own DLLs. The repo stays buildable either way,
+            # which is the property that matters - the sidecar copy just lags until the client
+            # is restarted.
+            Write-Warning "[sidecar] Could not refresh the MCP sidecar (likely a running server holding its DLLs)."
+            Write-Warning "[sidecar] Restart your MCP client to pick up a fresh build. The repo build is unaffected."
+        }
     }
-}
-else {
-    # No rsync: clear dest and recopy. Not incremental, but correct.
-    if (Test-Path $destDir) { Remove-Item -Recurse -Force (Join-Path $destDir '*') -ErrorAction SilentlyContinue }
-    Copy-Item -Recurse -Force (Join-Path $sourceDir '*') $destDir
+    else {
+        Write-Warning "[sidecar] MCP server output not found: $mcpSourceDir (skipping its mirror)."
+    }
 }
 
 $exeName = if ($IsWindows) { 'NovaTerminal.exe' } else { 'NovaTerminal' }

--- a/scripts/run-sidecar.ps1
+++ b/scripts/run-sidecar.ps1
@@ -88,12 +88,20 @@ function Sync-Directory {
     }
 
     # No rsync: clear dest and recopy. Not incremental, but correct.
+    #
+    # The removal deliberately does NOT suppress errors. It used to (inherited from the
+    # inline version of this code), which was harmless while nothing inspected the outcome -
+    # but now that this function reports success to callers, a failed removal followed by a
+    # successful copy would return $true with stale destination-only files still present.
+    # That is a mirror reported as fresh when it is not, which is the exact failure this
+    # script exists to prevent. Let it throw into the catch below.
     try {
-        if (Test-Path $To) { Remove-Item -Recurse -Force (Join-Path $To '*') -ErrorAction SilentlyContinue }
+        if (Test-Path $To) { Remove-Item -Recurse -Force (Join-Path $To '*') }
         Copy-Item -Recurse -Force (Join-Path $From '*') $To
         return $true
     }
     catch {
+        Write-Warning "[sidecar] Mirror to $To failed: $($_.Exception.Message)"
         return $false
     }
 }


### PR DESCRIPTION
Fixes #211.

## What was wrong

The MCP dev companion is a **long-lived** process, and while it runs from the repo tree it holds `NovaTerminal.AgentHost.Contracts.dll` open. So *every* full repo build fails — whether or not the app is running:

```
error MSB3027: Could not copy ".../AgentHost.Contracts.dll" to "bin/Debug/net10.0/..."
  Exceeded retry count of 10. The file is locked by: ".NET Host (56780)"
  [src/NovaTerminal.McpServer/NovaTerminal.McpServer.csproj]
```

Every full build I ran across this session's ten PRs failed with exactly these two errors, and I worked around them by checking that the *other* 16 projects built. That's a bad steady state: it trains you to ignore build errors.

## The fix is the pattern you already wrote

My original issue proposed inventing a `dotnet publish`-to-stable-path step. That was unnecessary — **`scripts/run-sidecar.ps1` already implements this exact pattern for the app**, and its header describes this exact failure mode:

> running the app holds a lock on its DLLs, so a `dotnet build` of the main repo fails with "file in use"

It just never covered the MCP server. This extends it rather than adding a second mechanism, so the server inherits the freshness guarantee the script exists for — including protection from the stale-copy trap the GlobalHotkey incident in its comments describes, which a hand-rolled publish would happily reopen.

- builds + mirrors `NovaTerminal.McpServer` alongside the app, and prints the path to configure
- `-SkipMcpServer` to opt out
- mirroring factored into `Sync-Directory`, shared by both; **the app's behaviour is unchanged** (same robocopy flags, same `<8` success threshold, same rsync / `Copy-Item` fallbacks)
- `docs/mcp-dev-companion.md` and both `examples/mcp/*.json` updated to the sidecar path, with the reason inline

**Separate destination directories**, deliberately: both outputs contain the same shared assemblies (VT, Replay, AgentHost.Contracts…), and `robocopy /MIR` deletes anything absent from its source — so one shared directory would have each mirror delete the other's private files.

## Two limits I'd rather state than have you discover

**1. The lock is relocated, not eliminated.** Once a client runs the server from the sidecar, that process holds *its* DLLs, so refreshing the mirror fails while it's running. The script warns and continues rather than failing:

```
WARNING: Could not refresh the MCP sidecar (likely a running server holding its DLLs).
WARNING: Restart your MCP client to pick up a fresh build. The repo build is unaffected.
```

That's the right trade: the lock moves from "blocks every repo build" to "the sidecar copy lags until you restart the client". But it is a trade, not a cure.

**2. The first migration needs the old server stopped once.** Verified while writing this — with the repo-path server still running, building `src/NovaTerminal.McpServer` fails with MSB3027, so the very first mirror can't be produced until that process exits. Chicken-and-egg. The build failure is non-fatal in the script and the warning says what to do:

```
WARNING: If an MCP server is running from the repo tree, stop it
         (or repoint the client at the sidecar) and re-run.
```

## Verification

- `run-sidecar.ps1` parses (`Parser::ParseFile`); both example configs are valid JSON.
- `robocopy /MIR` of the app output → `NovaTerminal.exe` present; of the McpServer output → `NovaTerminal.McpServer.dll` present, 41 files. Exit code 1 in both cases, which is "files copied" and passes the script's `<8` check.
- Reproduced the blocking build failure against the live repo-path server (pid 56780), which is what the non-fatal path exists for.

**Not executed:** the full script end-to-end, because its last step launches the app and this machine already has an instance running with four live panes. The launch path is untouched by this change; what I altered is the build/mirror steps above it, and those are exercised above.

## What you need to change locally

Nothing in the repo — your MCP client config points at the repo path, and I haven't touched your machine's config. After this lands, run `scripts/run-sidecar.ps1` once with the current server stopped, then repoint the client at:

```
%LOCALAPPDATA%\NovaTerminal-sidecar\McpServer\Debug\net10.0\NovaTerminal.McpServer.dll
```

Use `Release` in that path if you launch the sidecar with `-Configuration Release`.
