### PR TITLE
fix(vt): shift row side tables with ICH/DCH/insert-mode cell shifts

### DIFF
--- a/src/NovaTerminal.VT/TerminalBuffer.WritePath.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.WritePath.cs
@@ -580,6 +580,12 @@ NormalWrite:
                 row.Cells[c] = row.Cells[c - count];
             }
 
+            // The extended-grapheme and hyperlink side tables are keyed by column, so they have to
+            // move with the cells they describe — otherwise a cell keeps HasExtendedText while its
+            // string stays behind at the old column (#164). Insert mode reaches this per printable
+            // character, hence the HasRowMetadata guard.
+            if (row.HasRowMetadata) row.ShiftRowMetadata(_cursorCol, count, Cols);
+
             // Fill gap with default empty cells
             var empty = new TerminalCell(' ', CurrentForeground, CurrentBackground, false, false, IsDefaultForeground, IsDefaultBackground, false, CurrentFgIndex, CurrentBgIndex, false, false, false, false, false, false);
             for (int c = _cursorCol; c < endCol; c++)
@@ -619,6 +625,10 @@ NormalWrite:
             {
                 row.Cells[c] = row.Cells[c + count];
             }
+
+            // Side tables follow the cells (#164). Entries in the deleted range are dropped; the
+            // blanked tail columns end up with no entries, matching the empty cells written below.
+            if (row.HasRowMetadata) row.ShiftRowMetadata(_cursorCol, -count, Cols);
 
             // Update images on this row: shift those to the right of cursor left
             int absY = _isAltScreen ? _cursorRow : (_scrollback.Count + _cursorRow);

--- a/src/NovaTerminal.VT/TerminalRow.cs
+++ b/src/NovaTerminal.VT/TerminalRow.cs
@@ -78,6 +78,74 @@ namespace NovaTerminal.VT
         public Storage.SmallMap<string>? GetHyperlinkMap() => _hyperlinks;
 
         /// <summary>
+        /// True when this row carries any side-table entry. Lets callers on the write hot path
+        /// (insert mode runs per printable character) skip metadata maintenance entirely for
+        /// the overwhelmingly common plain-ASCII, no-hyperlink row.
+        /// </summary>
+        public bool HasRowMetadata => _extendedText != null || _hyperlinks != null;
+
+        /// <summary>
+        /// Moves side-table entries to follow a horizontal cell shift, so extended graphemes and
+        /// hyperlinks stay attached to the cells they describe.
+        /// </summary>
+        /// <param name="startCol">First column affected — the cursor column for ICH/DCH.</param>
+        /// <param name="delta">
+        /// Positive to shift right (ICH / insert mode), negative to shift left (DCH).
+        /// </param>
+        /// <param name="cols">Row width; entries pushed past it are dropped.</param>
+        /// <remarks>
+        /// Without this, <c>CSI @</c> / <c>CSI P</c> moved <see cref="Cells"/> but left the maps
+        /// keyed to pre-shift columns: cells kept <c>HasExtendedText</c> while their strings —
+        /// and their hyperlinks — pointed at the wrong columns (issue #164, item 1).
+        /// </remarks>
+        public void ShiftRowMetadata(int startCol, int delta, int cols)
+        {
+            if (delta == 0) return;
+            _extendedText = ShiftMap(_extendedText, startCol, delta, cols);
+            _hyperlinks = ShiftMap(_hyperlinks, startCol, delta, cols);
+        }
+
+        private static Storage.SmallMap<string>? ShiftMap(
+            Storage.SmallMap<string>? map, int startCol, int delta, int cols)
+        {
+            if (map is null || map.Count == 0) return null;
+
+            // Snapshot before rebuilding: shifting in place would revisit entries that had already
+            // been relocated (and, for a right shift, overwrite ones not yet visited).
+            int n = map.Count;
+            var keys = new int[n];
+            var values = new string[n];
+            int i = 0;
+            map.ForEach((col, value) =>
+            {
+                keys[i] = col;
+                values[i] = value;
+                i++;
+            });
+
+            Storage.SmallMap<string>? shifted = null;
+            for (int e = 0; e < n; e++)
+            {
+                int col = keys[e];
+                int dest = col;
+                if (col >= startCol)
+                {
+                    dest = col + delta;
+
+                    // Dropped: pushed off the end of the row (ICH), or consumed by the deletion
+                    // itself (DCH moves the deleted columns to below startCol). Columns left of
+                    // startCol are untouched and must not be range-checked against startCol.
+                    if (dest < startCol || dest >= cols) continue;
+                }
+
+                shifted ??= new Storage.SmallMap<string>();
+                shifted.Set(dest, values[e]);
+            }
+
+            return shifted;
+        }
+
+        /// <summary>
         /// Installs side tables wholesale. Counterpart of the Get*Map accessors:
         /// used when a row is restored from paged scrollback (height grow) so
         /// extended graphemes and hyperlinks survive the round trip. The row

--- a/tests/NovaTerminal.VT.Tests/RowMetadataShiftTests.cs
+++ b/tests/NovaTerminal.VT.Tests/RowMetadataShiftTests.cs
@@ -1,0 +1,278 @@
+using NovaTerminal.VT;
+
+namespace NovaTerminal.VT.Tests;
+
+// #164 item 1: ICH (CSI @), DCH (CSI P) and insert mode (IRM) shifted TerminalRow.Cells but left
+// the per-row side tables - extended graphemes and OSC 8 hyperlinks - keyed to their pre-shift
+// columns. The result was visibly wrong output: a cell kept its HasExtendedText flag while the
+// string describing it stayed behind at the old column, so an emoji/CJK cluster rendered (and
+// copied) as its first UTF-16 code unit while a neighbouring plain cell rendered the cluster.
+// Hyperlinks drifted the same way, so the clickable region no longer matched the visible text.
+public class RowMetadataShiftTests
+{
+    private const string ThumbsUp = "\U0001F44D"; // astral, width 2: lead cell + continuation
+    private const string Uri = "https://example.com/";
+
+    private static (TerminalBuffer Buffer, AnsiParser Parser) NewTerminal(int cols = 20, int rows = 3)
+    {
+        var buffer = new TerminalBuffer(cols, rows);
+        return (buffer, new AnsiParser(buffer));
+    }
+
+    /// GetGrapheme requires the read lock; every assertion here goes through this.
+    private static string GraphemeAt(TerminalBuffer buffer, int col)
+    {
+        buffer.Lock.EnterReadLock();
+        try { return buffer.GetGrapheme(col, 0); }
+        finally { buffer.Lock.ExitReadLock(); }
+    }
+
+    /// Every extended-text entry still held by row 0's side table, keyed by column.
+    ///
+    /// The drop cases have to assert against the map itself, not against GetGrapheme: a stale
+    /// entry is invisible through the rendered view whenever the cell that lands on the column
+    /// carries no HasExtendedText flag. It becomes visible - as the wrong glyph - as soon as some
+    /// later write does set that flag, which is exactly the corruption #164 describes.
+    private static (int Col, string Text)[] SideTableTexts(TerminalBuffer buffer, int cols)
+    {
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            var row = buffer.GetRowAbsolute(0);
+            Assert.NotNull(row);
+            var found = new List<(int, string)>();
+            for (int c = 0; c < cols; c++)
+            {
+                string? text = row!.GetExtendedText(c);
+                if (text != null) found.Add((c, text));
+            }
+            return found.ToArray();
+        }
+        finally { buffer.Lock.ExitReadLock(); }
+    }
+
+    private static string?[] SideTableLinks(TerminalBuffer buffer, int cols)
+    {
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            var row = buffer.GetRowAbsolute(0);
+            Assert.NotNull(row);
+            var links = new string?[cols];
+            for (int c = 0; c < cols; c++) links[c] = row!.GetHyperlink(c);
+            return links;
+        }
+        finally { buffer.Lock.ExitReadLock(); }
+    }
+
+    [Fact]
+    public void Ich_MovesExtendedGraphemeWithItsCell()
+    {
+        var (buffer, parser) = NewTerminal();
+        // Columns: 0 'a', 1-2 emoji (lead + continuation), 3 'b'.
+        parser.Process($"a{ThumbsUp}b");
+        Assert.Equal(ThumbsUp, GraphemeAt(buffer, 1));
+
+        // Home, then insert two blanks: everything shifts right by two.
+        parser.Process("\u001b[1G\u001b[2@");
+
+        Assert.Equal(ThumbsUp, GraphemeAt(buffer, 3));
+        // The stale key is the bug's signature: before the fix the string stayed at column 1.
+        Assert.NotEqual(ThumbsUp, GraphemeAt(buffer, 1));
+        Assert.Equal("a", GraphemeAt(buffer, 2));
+        Assert.Equal("b", GraphemeAt(buffer, 5));
+    }
+
+    [Fact]
+    public void Dch_MovesExtendedGraphemeWithItsCell()
+    {
+        var (buffer, parser) = NewTerminal();
+        // Columns: 0 'a', 1 'b', 2-3 emoji, 4 'c'.
+        parser.Process($"ab{ThumbsUp}c");
+
+        // Home, delete one character: everything shifts left by one.
+        parser.Process("\u001b[1G\u001b[1P");
+
+        Assert.Equal("b", GraphemeAt(buffer, 0));
+        Assert.Equal(ThumbsUp, GraphemeAt(buffer, 1));
+        Assert.NotEqual(ThumbsUp, GraphemeAt(buffer, 2));
+        Assert.Equal("c", GraphemeAt(buffer, 3));
+    }
+
+    [Fact]
+    public void Dch_DropsMetadataForTheDeletedColumns()
+    {
+        var (buffer, parser) = NewTerminal(cols: 10);
+        parser.Process($"a{ThumbsUp}b");
+
+        // Cursor onto the emoji lead cell, then delete both of its columns.
+        parser.Process("\u001b[2G\u001b[2P");
+
+        // The cluster is gone from the side table entirely - not relocated, and not left behind
+        // at column 1 where the pre-shift key pointed.
+        Assert.Empty(SideTableTexts(buffer, 10));
+        Assert.Equal("b", GraphemeAt(buffer, 1));
+    }
+
+    [Fact]
+    public void Ich_DropsMetadataPushedPastTheEndOfTheRow()
+    {
+        var (buffer, parser) = NewTerminal(cols: 6);
+        // Emoji at columns 4-5, hard against the right edge.
+        parser.Process($"abcd{ThumbsUp}");
+        Assert.Equal(ThumbsUp, GraphemeAt(buffer, 4));
+
+        // Insert three blanks at home: the emoji is pushed off the row.
+        parser.Process("\u001b[1G\u001b[3@");
+
+        // Column 4 now holds a plain 'b', so a stale entry would not show through GetGrapheme -
+        // it has to be gone from the map itself.
+        Assert.Empty(SideTableTexts(buffer, 6));
+    }
+
+    // The next two are regression guards on the shift's range check rather than on the original
+    // bug: they pass both before and after the fix, but fail against the obvious wrong
+    // implementation that range-checks unshifted columns (below startCol) against startCol and so
+    // discards every entry to the left of the cursor.
+    [Fact]
+    public void Ich_LeavesColumnsBeforeTheCursorAlone()
+    {
+        var (buffer, parser) = NewTerminal();
+        // Emoji at columns 0-1; the cursor sits to its right, so it must not move.
+        parser.Process($"{ThumbsUp}xy");
+        parser.Process("\u001b[4G\u001b[2@");
+
+        Assert.Equal(ThumbsUp, GraphemeAt(buffer, 0));
+        Assert.Equal(new[] { (0, ThumbsUp) }, SideTableTexts(buffer, 20));
+    }
+
+    [Fact]
+    public void Dch_LeavesColumnsBeforeTheCursorAlone()
+    {
+        var (buffer, parser) = NewTerminal();
+        parser.Process($"{ThumbsUp}xy");
+        parser.Process("\u001b[4G\u001b[1P");
+
+        Assert.Equal(ThumbsUp, GraphemeAt(buffer, 0));
+        Assert.Equal(new[] { (0, ThumbsUp) }, SideTableTexts(buffer, 20));
+    }
+
+    [Fact]
+    public void Ich_MovesHyperlinkWithItsCell()
+    {
+        var (buffer, parser) = NewTerminal();
+        parser.Process($"\u001b]8;;{Uri}\u001b\\ab\u001b]8;;\u001b\\");
+        Assert.Equal(Uri, buffer.GetHyperlinkAbsolute(0, 0));
+
+        parser.Process("\u001b[1G\u001b[3@");
+
+        Assert.Equal(Uri, buffer.GetHyperlinkAbsolute(3, 0));
+        Assert.Equal(Uri, buffer.GetHyperlinkAbsolute(4, 0));
+        // The inserted blanks are not part of the link.
+        Assert.Null(buffer.GetHyperlinkAbsolute(0, 0));
+        Assert.Null(buffer.GetHyperlinkAbsolute(2, 0));
+    }
+
+    [Fact]
+    public void Dch_MovesHyperlinkWithItsCell()
+    {
+        var (buffer, parser) = NewTerminal();
+        parser.Process($"xx\u001b]8;;{Uri}\u001b\\ab\u001b]8;;\u001b\\");
+        Assert.Equal(Uri, buffer.GetHyperlinkAbsolute(2, 0));
+
+        parser.Process("\u001b[1G\u001b[2P");
+
+        Assert.Equal(Uri, buffer.GetHyperlinkAbsolute(0, 0));
+        Assert.Equal(Uri, buffer.GetHyperlinkAbsolute(1, 0));
+        Assert.Null(buffer.GetHyperlinkAbsolute(2, 0));
+    }
+
+    [Fact]
+    public void InsertMode_MovesExtendedGraphemeWithItsCell()
+    {
+        var (buffer, parser) = NewTerminal();
+        parser.Process($"a{ThumbsUp}b");
+
+        // IRM on, home, type one character: the printable itself shifts the row right by one.
+        // This is the per-character path, hence the hot-path guard in InsertCharactersInternal.
+        parser.Process("\u001b[4h\u001b[1GZ");
+
+        Assert.Equal("Z", GraphemeAt(buffer, 0));
+        Assert.Equal("a", GraphemeAt(buffer, 1));
+        Assert.Equal(ThumbsUp, GraphemeAt(buffer, 2));
+        Assert.NotEqual(ThumbsUp, GraphemeAt(buffer, 1));
+    }
+
+    [Fact]
+    public void InsertMode_MovesHyperlinkWithItsCell()
+    {
+        var (buffer, parser) = NewTerminal();
+        parser.Process($"\u001b]8;;{Uri}\u001b\\ab\u001b]8;;\u001b\\");
+
+        parser.Process("\u001b[4h\u001b[1GZ");
+
+        // 'Z' is typed outside any OSC 8 span, so it must not inherit the link.
+        Assert.Null(buffer.GetHyperlinkAbsolute(0, 0));
+        Assert.Equal(Uri, buffer.GetHyperlinkAbsolute(1, 0));
+        Assert.Equal(Uri, buffer.GetHyperlinkAbsolute(2, 0));
+    }
+
+    [Fact]
+    public void Ich_WithCountBeyondTheRowClearsEverythingFromTheCursor()
+    {
+        var (buffer, parser) = NewTerminal(cols: 8);
+        parser.Process($"a{ThumbsUp}b");
+
+        // A count larger than the remaining width blanks the tail; no metadata may survive it.
+        parser.Process("\u001b[2G\u001b[9999@");
+
+        // Only the emoji ever had an extended-text entry ('a' is plain ASCII), and it was pushed
+        // out, so nothing may remain.
+        Assert.Empty(SideTableTexts(buffer, 8));
+        Assert.Equal("a", GraphemeAt(buffer, 0));
+    }
+
+    [Fact]
+    public void Dch_ClearsLinksFromTheBlankedTailColumns()
+    {
+        var (buffer, parser) = NewTerminal(cols: 6);
+        parser.Process($"\u001b]8;;{Uri}\u001b\\abcdef\u001b]8;;\u001b\\");
+        Assert.All(SideTableLinks(buffer, 6), link => Assert.Equal(Uri, link));
+
+        // Delete two columns at home: the two vacated tail columns are blank cells, so they must
+        // not still be part of the link.
+        parser.Process("\u001b[1G\u001b[2P");
+
+        Assert.Equal(new[] { Uri, Uri, Uri, Uri, null, null }, SideTableLinks(buffer, 6));
+    }
+
+    [Fact]
+    public void ShiftRowMetadata_IsANoOpForRowsWithoutSideTables()
+    {
+        // The guard in the write path skips the shift entirely for plain rows; make sure the
+        // method itself is also safe if called directly on one.
+        var row = new TerminalRow(10);
+        Assert.False(row.HasRowMetadata);
+
+        row.ShiftRowMetadata(0, 3, 10);
+
+        Assert.False(row.HasRowMetadata);
+        Assert.Null(row.GetExtendedText(0));
+        Assert.Null(row.GetHyperlink(0));
+    }
+
+    [Fact]
+    public void ShiftRowMetadata_DropsTheMapOnceEveryEntryIsShiftedOut()
+    {
+        // A row that shifts all of its entries off the end must end up with no maps at all,
+        // not with empty ones - HasRowMetadata is the write path's fast-path guard.
+        var row = new TerminalRow(4);
+        row.SetExtendedText(3, ThumbsUp);
+        row.SetHyperlink(3, Uri);
+        Assert.True(row.HasRowMetadata);
+
+        row.ShiftRowMetadata(0, 4, 4);
+
+        Assert.False(row.HasRowMetadata);
+    }
+}


### PR DESCRIPTION
Fixes item 1 of #164.

## The bug

`ICH` (`CSI @`), `DCH` (`CSI P`) and insert mode shifted `TerminalRow.Cells` but left the per-row
side tables — extended graphemes (`_extendedText`) and OSC 8 hyperlinks (`_hyperlinks`) — keyed to
their **pre-shift** columns.

The cells carry `HasExtendedText`, and that flag travels with the cell. The string it points at did
not. So after `CSI @` / `CSI P` on a line containing emoji, CJK, or an OSC 8 link:

- the cell that now holds the cluster looks up an empty column and renders (and copies) as its first
  UTF-16 code unit;
- the column the cluster used to occupy still has the string, and shows it if whatever landed there
  happens to carry the flag;
- hyperlink spans slide out of step with the text, so the clickable region no longer matches what
  the user sees.

Insert mode reaches `InsertCharactersInternal` once per printable character, so an editor in IRM hit
this constantly.

## The fix

`TerminalRow.ShiftRowMetadata(startCol, delta, cols)` moves both maps to match a horizontal cell
shift:

- entries left of `startCol` are untouched;
- entries at or right of it move by `delta`;
- entries pushed past the row edge (ICH) or consumed by the deletion itself (DCH, where they map
  below `startCol`) are dropped.

Two details worth flagging for review:

- **Rebuild from a snapshot, not in place.** `SmallMap` has no reorder primitive, and mutating while
  walking would revisit entries that had already been relocated — and for a right shift, overwrite
  ones not yet visited.
- **Maps go back to `null` once empty.** `HasRowMetadata` is the write path's fast-path guard;
  leaving an empty map behind would keep the guard permanently true for that row and reintroduce
  the per-character cost this avoids.

The call sites are guarded by `if (row.HasRowMetadata)`, so a plain-ASCII row with no links — the
overwhelmingly common case, and the one insert mode churns through — pays two null checks and
allocates nothing.

## Verification

14 new tests in `tests/NovaTerminal.VT.Tests/RowMetadataShiftTests.cs`, driven through `AnsiParser`
with real escape sequences rather than direct buffer calls.

**Mutation-checked.** Commenting out the two `ShiftRowMetadata` calls fails **10 of the 14**:

```
Failed  Ich_MovesExtendedGraphemeWithItsCell
Failed  Dch_MovesExtendedGraphemeWithItsCell
Failed  Ich_MovesHyperlinkWithItsCell
Failed  Dch_MovesHyperlinkWithItsCell
Failed  InsertMode_MovesExtendedGraphemeWithItsCell
Failed  InsertMode_MovesHyperlinkWithItsCell
Failed  Dch_DropsMetadataForTheDeletedColumns
Failed  Dch_ClearsLinksFromTheBlankedTailColumns
Failed  Ich_DropsMetadataPushedPastTheEndOfTheRow
Failed  Ich_WithCountBeyondTheRowClearsEverythingFromTheCursor
Passed  Ich_LeavesColumnsBeforeTheCursorAlone
Passed  Dch_LeavesColumnsBeforeTheCursorAlone
Passed  ShiftRowMetadata_IsANoOpForRowsWithoutSideTables
Passed  ShiftRowMetadata_DropsTheMapOnceEveryEntryIsShiftedOut
```

The four that pass either way are deliberate: the two `LeavesColumnsBeforeTheCursorAlone` tests
guard the range check against the obvious wrong implementation (range-checking *unshifted* columns
against `startCol`, which discards everything left of the cursor — a mistake I made and caught while
writing this), and the two direct `ShiftRowMetadata` tests cover the null-out contract behind
`HasRowMetadata`.

The drop cases assert against the side table via `GetRowAbsolute(0).GetExtendedText(col)` rather
than `GetGrapheme`. That matters: a stale entry is *invisible* through the rendered view whenever
the cell that lands on the column carries no `HasExtendedText` flag. Asserting through `GetGrapheme`
made four of those tests pass against the unfixed code — they were checking nothing.

Local runs: `NovaTerminal.VT.Tests` 99/99, `NovaTerminal.App.Tests` 1241 passed.

## Pre-existing failures, not from this change

Two App.Tests failures showed up in the full local run:

- `StressTests.DataFlood_Backpressure_StressTest` — passes on retry in isolation; flaky under
  full-suite load.
- `CommandAssistLayoutTests.TerminalPane_WhenRemotePromptSettlesLowOnShortPane_ResumesConservativeAssistLayout`
  — fails **identically on a clean worktree of `main`** (`ef02e93`), so it predates this branch. It
  is green in CI, which points at something environment-dependent in the local headless setup.
  Flagging rather than fixing here; worth its own issue if it reproduces for anyone else.

## Scope

Item 1 only. #164 stays open for item 2a (`ReflowEngine`'s 2-field tuple drops hyperlinks on
reflow) and item 4 (the scrollback read path never surfaces metadata). Items 2b and 3 were already
fixed before this branch — see the triage notes.
