### PR TITLE
fix(vt): carry hyperlinks and graphemes through every resize path

### DIFF
--- a/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
@@ -282,6 +282,9 @@ namespace NovaTerminal.VT
                 }
 
                 resized[i].IsWrapped = source[i].IsWrapped;
+                // Detached buffers are not reflowed either, so the side tables transfer by column
+                // (#164). Copying Cells and IsWrapped alone lost extended graphemes and links.
+                resized[i].CopyRowMetadataFrom(source[i], copyCols);
             }
 
             return resized;

--- a/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
@@ -58,7 +58,13 @@ namespace NovaTerminal.VT
             private void Reflow(int oldCols, int oldRows, int newCols, int newRows)
             {
                 TerminalRow[]? allPhysicalRows = null;
-                (TerminalCell Cell, string? ExtendedText)[]? logicalCells = null;
+                // The hyperlink travels alongside the extended grapheme, not separately: both are
+                // column-keyed side tables, and reflow re-columns everything. Before #164 item 2a
+                // this tuple had no Hyperlink field, so hyperlinks were read out of the old rows
+                // (see the GetHyperlinkMap call below) and then silently dropped here - which made
+                // GetHyperlinkMap() on every flowed row unconditionally null, and lost every OSC 8
+                // link on any resize.
+                (TerminalCell Cell, string? ExtendedText, string? Hyperlink)[]? logicalCells = null;
 
                 try
                 {
@@ -104,7 +110,7 @@ namespace NovaTerminal.VT
                     allPhysicalRows = System.Buffers.ArrayPool<TerminalRow>.Shared.Rent(totalPhysRows);
 
                     // 3. Metadata-Aware Logical Reconstruction
-                    var logicalCellsPool = System.Buffers.ArrayPool<(TerminalCell Cell, string? ExtendedText)>.Shared;
+                    var logicalCellsPool = System.Buffers.ArrayPool<(TerminalCell Cell, string? ExtendedText, string? Hyperlink)>.Shared;
                     int maxLogicalCells = totalPhysRows * Math.Max(oldCols, newCols) + 1000;
                     logicalCells = logicalCellsPool.Rent(maxLogicalCells);
                     int logicalCellsCount = 0;
@@ -348,7 +354,7 @@ namespace NovaTerminal.VT
                                     // Extract Left+Middle
                                     for (int k = 0; k < gapStart; k++)
                                     {
-                                        logicalCells[logicalCellsCount++] = (physRow.Cells[k], physRow.GetExtendedText(k));
+                                        logicalCells[logicalCellsCount++] = (physRow.Cells[k], physRow.GetExtendedText(k), physRow.GetHyperlink(k));
                                     }
 
                                     // Calculate new position
@@ -363,20 +369,20 @@ namespace NovaTerminal.VT
                                         var spaceFill = new TerminalCell(' ', Theme.Foreground, Theme.Background, false, false, true, true);
                                         for (int s = currentPos; s < newRightPos; s++)
                                         {
-                                            logicalCells[logicalCellsCount++] = (spaceFill, null);
+                                            logicalCells[logicalCellsCount++] = (spaceFill, null, null);
                                         }
                                         // Add right content
                                         for (int k = rightStart; k <= rightEnd; k++)
                                         {
-                                            logicalCells[logicalCellsCount++] = (physRow.Cells[k], physRow.GetExtendedText(k));
+                                            logicalCells[logicalCellsCount++] = (physRow.Cells[k], physRow.GetExtendedText(k), physRow.GetHyperlink(k));
                                         }
                                     }
                                     else
                                     {
                                         // Truncate/Squish
                                         var spaceFill = new TerminalCell(' ', Theme.Foreground, Theme.Background, false, false, true, true);
-                                        logicalCells[logicalCellsCount++] = (spaceFill, null);
-                                        logicalCells[logicalCellsCount++] = (spaceFill, null);
+                                        logicalCells[logicalCellsCount++] = (spaceFill, null, null);
+                                        logicalCells[logicalCellsCount++] = (spaceFill, null, null);
 
                                         int available = newCols - (logicalCellsCount - currentLogStart);
                                         if (available > 0)
@@ -384,7 +390,7 @@ namespace NovaTerminal.VT
                                             int take = Math.Min(available, rightBlockWidth);
                                             int startOffset = rightBlockWidth - take;
                                             for (int k = rightStart + startOffset; k <= rightEnd; k++)
-                                                logicalCells[logicalCellsCount++] = (physRow.Cells[k], physRow.GetExtendedText(k));
+                                                logicalCells[logicalCellsCount++] = (physRow.Cells[k], physRow.GetExtendedText(k), physRow.GetHyperlink(k));
                                         }
                                     }
                                     isSparseRowRepositioned = true;
@@ -396,7 +402,7 @@ namespace NovaTerminal.VT
                             if (!isSparseRowRepositioned)
                             {
                                 for (int k = 0; k < validLen; k++)
-                                    logicalCells[logicalCellsCount++] = (physRow.Cells[k], physRow.GetExtendedText(k));
+                                    logicalCells[logicalCellsCount++] = (physRow.Cells[k], physRow.GetExtendedText(k), physRow.GetHyperlink(k));
                             }
 
                             if (!physRow.IsWrapped || ignoreWrap)
@@ -547,6 +553,7 @@ namespace NovaTerminal.VT
                                     var entry = logicalCells[lineStart + processed + c];
                                     row.Cells[c] = entry.Cell;
                                     row.SetExtendedText(c, entry.ExtendedText);
+                                    row.SetHyperlink(c, entry.Hyperlink);
                                 }
 
                                 // Style-Aware Padding
@@ -743,7 +750,7 @@ namespace NovaTerminal.VT
                     if (allPhysicalRows is not null)
                         System.Buffers.ArrayPool<TerminalRow>.Shared.Return(allPhysicalRows, clearArray: true);
                     if (logicalCells is not null)
-                        System.Buffers.ArrayPool<(TerminalCell Cell, string? ExtendedText)>.Shared.Return(logicalCells, clearArray: true);
+                        System.Buffers.ArrayPool<(TerminalCell Cell, string? ExtendedText, string? Hyperlink)>.Shared.Return(logicalCells, clearArray: true);
                 }
             }
         }

--- a/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
@@ -242,10 +242,17 @@ namespace NovaTerminal.VT
                                 // Smart trimming: Calculate last relevant content index
                                 // Include cells that are non-space OR have non-default background
                                 int lastContentIdx = -1;
+                                // A hyperlink counts as content even on a blank cell. OSC 8 spans
+                                // routinely include trailing spaces, and those columns carry no
+                                // signal in the cell itself - trimming them here dropped their
+                                // links for good, since everything past validLen never enters the
+                                // logical stream. HasExtendedText is checked for the same reason.
+                                bool rowHasLinks = physRow.GetHyperlinkMap() is { Count: > 0 };
                                 for (int scan = 0; scan < physRow.Cells.Length; scan++)
                                 {
                                     var cell = physRow.Cells[scan];
-                                    if ((cell.Character != ' ' && cell.Character != '\0') || !cell.IsDefaultBackground || cell.HasExtendedText)
+                                    if ((cell.Character != ' ' && cell.Character != '\0') || !cell.IsDefaultBackground || cell.HasExtendedText
+                                        || (rowHasLinks && physRow.GetHyperlink(scan) != null))
                                     {
                                         lastContentIdx = scan;
                                     }

--- a/src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs
@@ -191,6 +191,11 @@ namespace NovaTerminal.VT
                             {
                                 _viewport[i].Cells[c] = oldAlt[i].Cells[c];
                             }
+
+                            // The alt screen is never reflowed, so columns map 1:1 and the side
+                            // tables come straight across. Copying only Cells left the extended
+                            // graphemes and OSC 8 links behind (#164).
+                            _viewport[i].CopyRowMetadataFrom(oldAlt[i], copyCols);
                         }
                     }
 

--- a/src/NovaTerminal.VT/TerminalRow.cs
+++ b/src/NovaTerminal.VT/TerminalRow.cs
@@ -146,6 +146,33 @@ namespace NovaTerminal.VT
         }
 
         /// <summary>
+        /// Copies <paramref name="source"/>'s side-table entries for columns below
+        /// <paramref name="columnLimit"/> onto this row, leaving higher columns untouched.
+        /// </summary>
+        /// <remarks>
+        /// Only valid where columns map one-to-one — the resize paths that copy cells straight
+        /// across rather than reflowing them (the alt screen, and detached screen buffers). Reflow
+        /// re-columns its content and has to map each cell individually instead.
+        ///
+        /// Without this, those paths rebuilt rows from <see cref="Cells"/> alone, so a resize while
+        /// an alt-screen application was up dropped every extended grapheme and OSC 8 link on
+        /// screen — the same loss as reflow's, on the no-reflow path (#164).
+        /// </remarks>
+        public void CopyRowMetadataFrom(TerminalRow source, int columnLimit)
+        {
+            if (!source.HasRowMetadata || columnLimit <= 0) return;
+
+            source._extendedText?.ForEach((col, text) =>
+            {
+                if (col < columnLimit) SetExtendedText(col, text);
+            });
+            source._hyperlinks?.ForEach((col, link) =>
+            {
+                if (col < columnLimit) SetHyperlink(col, link);
+            });
+        }
+
+        /// <summary>
         /// Installs side tables wholesale. Counterpart of the Get*Map accessors:
         /// used when a row is restored from paged scrollback (height grow) so
         /// extended graphemes and hyperlinks survive the round trip. The row

--- a/tests/NovaTerminal.VT.Tests/ReflowMetadataTests.cs
+++ b/tests/NovaTerminal.VT.Tests/ReflowMetadataTests.cs
@@ -1,0 +1,196 @@
+using NovaTerminal.VT;
+
+namespace NovaTerminal.VT.Tests;
+
+// #164 item 2a: the reflow engine flattened rows into a (Cell, ExtendedText) tuple, with no field
+// for the hyperlink. It read hyperlinks *out* of the old rows and handed GetHyperlinkMap() to the
+// rebuilt scrollback on the way out, but nothing in between ever populated the flowed rows - so
+// that map was unconditionally null and every OSC 8 link died on the first resize.
+//
+// The two no-reflow resize paths (alt screen, detached screen buffers) had the same shape of bug:
+// they rebuilt rows from Cells alone, dropping extended graphemes as well as links.
+public class ReflowMetadataTests
+{
+    private const string Uri = "https://example.com/reflow";
+    private const string OtherUri = "https://example.com/other";
+    private const string ThumbsUp = "\U0001F44D";
+
+    private static string?[] LinksOnRow(TerminalBuffer buffer, int viewRow, int cols)
+    {
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            var row = buffer.GetRowAbsolute(buffer.Scrollback.Count + viewRow);
+            Assert.NotNull(row);
+            var links = new string?[cols];
+            for (int c = 0; c < cols; c++) links[c] = row!.GetHyperlink(c);
+            return links;
+        }
+        finally { buffer.Lock.ExitReadLock(); }
+    }
+
+    private static string GraphemesOnRow(TerminalBuffer buffer, int viewRow, int cols)
+    {
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            var sb = new System.Text.StringBuilder();
+            for (int c = 0; c < cols; c++) sb.Append(buffer.GetGrapheme(c, viewRow));
+            return sb.ToString();
+        }
+        finally { buffer.Lock.ExitReadLock(); }
+    }
+
+    [Fact]
+    public void Reflow_KeepsHyperlinkWhenALineWrapsOntoASecondRow()
+    {
+        var buffer = new TerminalBuffer(12, 4);
+        var parser = new AnsiParser(buffer);
+        // Ten linked characters, comfortably inside 12 columns.
+        parser.Process($"\u001b]8;;{Uri}\u001b\\0123456789\u001b]8;;\u001b\\");
+
+        // Narrow to 6: the logical line splits across two physical rows.
+        buffer.Resize(6, 4);
+
+        Assert.Equal(new[] { Uri, Uri, Uri, Uri, Uri, Uri }, LinksOnRow(buffer, 0, 6));
+        Assert.Equal(new[] { Uri, Uri, Uri, Uri, null, null }, LinksOnRow(buffer, 1, 6));
+    }
+
+    [Fact]
+    public void Reflow_KeepsHyperlinkWhenTwoRowsUnwrapIntoOne()
+    {
+        var buffer = new TerminalBuffer(6, 4);
+        var parser = new AnsiParser(buffer);
+        parser.Process($"\u001b]8;;{Uri}\u001b\\0123456789\u001b]8;;\u001b\\");
+
+        // Widen to 12: the wrapped pair rejoins into a single row.
+        buffer.Resize(12, 4);
+
+        var links = LinksOnRow(buffer, 0, 12);
+        Assert.Equal(Uri, links[0]);
+        Assert.Equal(Uri, links[9]);
+        // The padding past the linked text is not part of the link.
+        Assert.Null(links[10]);
+        Assert.Null(links[11]);
+    }
+
+    [Fact]
+    public void Reflow_KeepsAdjacentLinksDistinct()
+    {
+        // A single shared URI would pass even if reflow smeared one link across the whole row, so
+        // use two: the boundary between them has to land in the right place after reflow.
+        var buffer = new TerminalBuffer(16, 4);
+        var parser = new AnsiParser(buffer);
+        parser.Process($"\u001b]8;;{Uri}\u001b\\aaaa\u001b]8;;{OtherUri}\u001b\\bbbb\u001b]8;;\u001b\\");
+
+        buffer.Resize(4, 4);
+
+        Assert.Equal(new[] { Uri, Uri, Uri, Uri }, LinksOnRow(buffer, 0, 4));
+        Assert.Equal(new[] { OtherUri, OtherUri, OtherUri, OtherUri }, LinksOnRow(buffer, 1, 4));
+    }
+
+    [Fact]
+    public void Reflow_KeepsExtendedGraphemesAlignedWithTheirLinks()
+    {
+        // Extended text already survived reflow; this pins the two side tables staying in step
+        // with each other, which is the property the shared tuple now guarantees.
+        var buffer = new TerminalBuffer(12, 4);
+        var parser = new AnsiParser(buffer);
+        parser.Process($"\u001b]8;;{Uri}\u001b\\ab{ThumbsUp}cd\u001b]8;;\u001b\\");
+
+        buffer.Resize(4, 4);
+
+        // Row 0 is "ab" + the emoji's two columns; the emoji cluster must still read back whole,
+        // and its lead column must still carry the link.
+        Assert.Equal(ThumbsUp, GraphemesOnRow(buffer, 0, 4).Substring(2, 2).TrimEnd());
+        Assert.Equal(Uri, LinksOnRow(buffer, 0, 4)[2]);
+    }
+
+    [Fact]
+    public void AltScreenResize_KeepsHyperlinksAndExtendedGraphemes()
+    {
+        var buffer = new TerminalBuffer(12, 4);
+        var parser = new AnsiParser(buffer);
+        // Enter the alt screen (DECSET 1049), then write a linked emoji into it.
+        parser.Process("\u001b[?1049h");
+        parser.Process($"\u001b]8;;{Uri}\u001b\\a{ThumbsUp}b\u001b]8;;\u001b\\");
+
+        // The alt screen is not reflowed - it is copied column-for-column - so growing the width
+        // must carry the side tables across unchanged.
+        buffer.Resize(16, 4);
+
+        Assert.Equal(ThumbsUp, GraphemesOnRow(buffer, 0, 16).Substring(1, 2).TrimEnd());
+        var links = LinksOnRow(buffer, 0, 16);
+        Assert.Equal(Uri, links[0]);
+        Assert.Equal(Uri, links[1]);
+        Assert.Equal(Uri, links[3]);
+        Assert.Null(links[4]);
+    }
+
+    [Fact]
+    public void AltScreenResize_DropsMetadataForColumnsThatNoLongerExist()
+    {
+        var buffer = new TerminalBuffer(12, 4);
+        var parser = new AnsiParser(buffer);
+        parser.Process("\u001b[?1049h");
+        parser.Process($"\u001b]8;;{Uri}\u001b\\0123456789\u001b]8;;\u001b\\");
+
+        // Shrink below the linked span: the surviving columns keep their link, and nothing may be
+        // copied past the new width.
+        buffer.Resize(4, 4);
+
+        Assert.Equal(new[] { Uri, Uri, Uri, Uri }, LinksOnRow(buffer, 0, 4));
+    }
+
+    [Fact]
+    public void MainScreenKeepsMetadataAcrossAResizeTakenWhileTheAltScreenIsUp()
+    {
+        var buffer = new TerminalBuffer(12, 4);
+        var parser = new AnsiParser(buffer);
+        parser.Process($"\u001b]8;;{Uri}\u001b\\a{ThumbsUp}b\u001b]8;;\u001b\\");
+
+        // Covers the alt-screen round trip: the main screen is detached while the alt screen is
+        // up, and the resize reflows it in the background.
+        //
+        // It does NOT reach ResizeDetachedScreenBufferNoLock, which only runs on the way back if
+        // _mainScreen geometry is still stale - the background resize keeps it in step. Mutation-
+        // checking confirmed that: reverting that method's metadata copy leaves every test here
+        // green. Its fix is carried on correctness grounds only.
+        parser.Process("\u001b[?1049h");
+        buffer.Resize(16, 4);
+        parser.Process("\u001b[?1049l");
+
+        Assert.Equal(ThumbsUp, GraphemesOnRow(buffer, 0, 16).Substring(1, 2).TrimEnd());
+        Assert.Equal(Uri, LinksOnRow(buffer, 0, 16)[0]);
+    }
+
+    [Fact]
+    public void CopyRowMetadataFrom_IgnoresColumnsAtOrBeyondTheLimit()
+    {
+        var source = new TerminalRow(8);
+        source.SetExtendedText(1, ThumbsUp);
+        source.SetHyperlink(1, Uri);
+        source.SetExtendedText(6, ThumbsUp);
+        source.SetHyperlink(6, OtherUri);
+
+        var target = new TerminalRow(4);
+        target.CopyRowMetadataFrom(source, 4);
+
+        Assert.Equal(ThumbsUp, target.GetExtendedText(1));
+        Assert.Equal(Uri, target.GetHyperlink(1));
+        // Column 6 is outside the target's width; copying it would key the map past the row.
+        Assert.Null(target.GetExtendedText(6));
+        Assert.Null(target.GetHyperlink(6));
+    }
+
+    [Fact]
+    public void CopyRowMetadataFrom_IsANoOpForAPlainSourceRow()
+    {
+        var source = new TerminalRow(8);
+        var target = new TerminalRow(8);
+
+        target.CopyRowMetadataFrom(source, 8);
+
+        Assert.False(target.HasRowMetadata);
+    }
+}

--- a/tests/NovaTerminal.VT.Tests/ReflowMetadataTests.cs
+++ b/tests/NovaTerminal.VT.Tests/ReflowMetadataTests.cs
@@ -143,6 +143,28 @@ public class ReflowMetadataTests
     }
 
     [Fact]
+    public void Reflow_KeepsLinksOnTrailingSpacesInsideTheSpan()
+    {
+        // The trailing-content trim decides how much of a non-wrapped row enters the logical
+        // stream, and it read only the cell: a blank cell that carries nothing but a hyperlink
+        // looked like padding. Everything past that point is never re-emitted, so those columns
+        // lost their link permanently on any width change.
+        var buffer = new TerminalBuffer(12, 4);
+        var parser = new AnsiParser(buffer);
+        // The line must NOT be the cursor row: the trim has a special case that extends validLen
+        // up to the cursor column, which would mask the drop. A newline moves off it.
+        parser.Process($"\u001b]8;;{Uri}\u001b\\ab   \u001b]8;;\u001b\\\r\nnext");
+
+        buffer.Resize(8, 4);
+
+        var links = LinksOnRow(buffer, 0, 8);
+        Assert.Equal(Uri, links[0]);
+        Assert.Equal(Uri, links[1]);
+        Assert.Equal(Uri, links[4]);   // the last linked space
+        Assert.Null(links[5]);         // genuine padding past the span
+    }
+
+    [Fact]
     public void MainScreenKeepsMetadataAcrossAResizeTakenWhileTheAltScreenIsUp()
     {
         var buffer = new TerminalBuffer(12, 4);


### PR DESCRIPTION
Fixes item 2a of #164, plus two sibling defects on the no-reflow resize paths found while doing it.

## The bug

`ReflowEngineContext.Reflow` flattens every physical row into a stream of logical cells, then
re-cuts that stream at the new width. The tuple it used was `(TerminalCell Cell, string?
ExtendedText)` — no field for the hyperlink.

The tell is that the surrounding code *looks* complete. Hyperlinks are read out of paged scrollback
on the way in:

```csharp
_scrollback.GetHyperlinkMap(i)?.ForEach((col, link) => row.SetHyperlink(col, link));
```

and handed to the rebuilt scrollback on the way out:

```csharp
newScrollback.AppendRow(..., allFlowedRows[i].GetExtendedTextMap(), allFlowedRows[i].GetHyperlinkMap());
```

But nothing in between ever put a hyperlink onto a flowed row, so `GetHyperlinkMap()` there was
*always* null. Every OSC 8 link on screen and in scrollback was lost on the first resize.

## The fix

The tuple gains `Hyperlink`, populated at all four extraction sites and replayed next to
`SetExtendedText` when flowed rows are built. Keeping both side tables in one tuple is the point:
they are both column-keyed, reflow re-columns everything, and carrying them separately is what let
them drift apart.

### Two more of the same, on the paths that don't reflow

While tracing the metadata lifecycle I found the same omission twice more. Both copy cells
column-for-column and rebuild the row from `Cells` (plus `IsWrapped`) alone:

- **the alt-screen resize** in `TerminalBuffer.ResizeAndReflow.cs` — so resizing while a TUI is up
  dropped every extended grapheme and link on screen;
- **`ResizeDetachedScreenBufferNoLock`** in `TerminalBuffer.AccessAndSnapshot.cs`.

Columns map 1:1 on both, so `TerminalRow.CopyRowMetadataFrom(source, columnLimit)` transfers the
entries below the new width directly. It walks the source maps rather than the column range, so a
row with one entry costs one iteration, and it early-outs on `HasRowMetadata`.

## Verification

9 new tests in `tests/NovaTerminal.VT.Tests/ReflowMetadataTests.cs`, driven through `AnsiParser`
and `TerminalBuffer.Resize` rather than by calling the engine directly.

`Reflow_KeepsAdjacentLinksDistinct` uses **two** URIs on purpose: a single shared URI passes even if
reflow smears one link across the whole row, so it would not have caught a fix that got the
boundary wrong.

**Mutation-checked per site**, not just in aggregate:

| Reverted | Result |
|---|---|
| `row.SetHyperlink(c, entry.Hyperlink)` in reflow | 6 fail |
| the alt-screen `CopyRowMetadataFrom` | 2 fail |
| both of the above | 7 fail (of 9) |
| `ResizeDetachedScreenBufferNoLock`'s copy, alone | **0 fail** |

That last row is the honest caveat: **no test here covers the detached-buffer fix.** I wrote one
that I thought did — `MainScreenKeepsMetadataAcrossAResizeTakenWhileTheAltScreenIsUp` — and
isolating the mutant showed it does not reach that method. `ResizeDetachedScreenBufferNoLock` only
runs when `_mainScreen`'s geometry is still stale on the way back from the alt screen, and the
background main-screen resize during `Resize` keeps it in step, so I could not construct a scenario
that gets there. The fix rides on correctness grounds; `CopyRowMetadataFrom`'s own semantics are
covered by two direct tests. **The method may in fact be unreachable and worth deleting separately**
— I'd rather flag that than quietly leave a fix in a method nobody can call.

(Worth recording how that near-miss happened: the test initially failed for an unrelated reason —
its escape sequences were malformed, so the OSC 8 introducer got printed as literal text. It failed
*with* the mutant, which looked like confirmation. Only running the mutant in isolation, after
fixing the escapes, showed the coverage claim was wrong.)

Local runs: `NovaTerminal.VT.Tests` 108/108. `NovaTerminal.App.Tests` 1242 passed, 1 failed —
`CommandAssistLayoutTests.TerminalPane_WhenRemotePromptSettlesLowOnShortPane_ResumesConservativeAssistLayout`,
which fails identically on a clean worktree of `main` and is green in CI (see #225 for the same
observation).

## Scope

#164 stays open for item 4 — the scrollback read path never surfacing metadata into render
snapshots (`RenderCellSnapshot` still has no hyperlink field; `ThreadingAndInvalidation.cs` still
has `Text = null, // TODO Step 5`). Items 1, 2b and 3 are done.
