### PR TITLE
fix(vt): render extended graphemes from paged scrollback

### DIFF
--- a/src/NovaTerminal.VT/TerminalBuffer.ThreadingAndInvalidation.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ThreadingAndInvalidation.cs
@@ -706,6 +706,14 @@ namespace NovaTerminal.VT
             var sourceCells = _scrollback.GetRow(absRow);
             int copyLen = Math.Min(sourceCells.Length, viewportCols);
 
+            // Paged scrollback carries a per-row extended-text side table; this build path used to
+            // hard-code Text = null, so any grapheme wider than one UTF-16 code unit - emoji, most
+            // CJK with combining marks, flags - was *rendered* as its first code unit the moment
+            // the line scrolled off screen. Selection and copy were fixed earlier (#95 gap 1) by
+            // teaching GetGraphemeAbsolute about the same table; this is the drawing half (#164
+            // item 4). Fetched once per row rather than per cell.
+            var extendedText = _scrollback.GetExtendedTextMap(absRow);
+
             for (int c = 0; c < viewportCols; c++)
             {
                 if (c < copyLen)
@@ -714,7 +722,10 @@ namespace NovaTerminal.VT
                     rebuiltCells[c] = new RenderCellSnapshot
                     {
                         Character = cell.Character,
-                        Text = null, // TODO Step 5: Support extended text in scrollback
+                        Text = cell.HasExtendedText && extendedText != null
+                               && extendedText.TryGet(c, out string? graphemeText)
+                            ? graphemeText
+                            : null,
                         Foreground = cell.Foreground,
                         Background = cell.Background,
                         IsInverse = cell.IsInverse,

--- a/tests/NovaTerminal.VT.Tests/ScrollbackRenderTextTests.cs
+++ b/tests/NovaTerminal.VT.Tests/ScrollbackRenderTextTests.cs
@@ -1,0 +1,89 @@
+using NovaTerminal.VT;
+
+namespace NovaTerminal.VT.Tests;
+
+// #164 item 4: the paged-scrollback branch of the render-snapshot builder hard-coded
+// `Text = null, // TODO Step 5`, so any grapheme wider than one UTF-16 code unit was *drawn* as
+// its first code unit once the line scrolled off screen - an emoji became a lone unpaired
+// surrogate, and a combining sequence lost its marks.
+//
+// The read side was fixed earlier (#95 gap 1) by teaching GetGraphemeAbsolute the same side table,
+// which is why selection and copy were already correct while the screen was visibly wrong. This
+// covers the drawing half. The viewport path (PopulateRenderCellsFromRow_NoLock) was always
+// correct, so the bug appeared only after a line scrolled.
+public class ScrollbackRenderTextTests
+{
+    private const string ThumbsUp = "\U0001F44D";  // astral: 2 UTF-16 code units, width 2
+    private const string EAcute = "é";       // 'e' + combining acute: 2 code units, width 1
+
+    private const int Cols = 20;
+    private const int Rows = 3;
+
+    /// Writes <paramref name="firstLine"/> then enough filler to push it into scrollback, and
+    /// returns the render snapshot's row 0 - which is therefore a *paged scrollback* row.
+    private static RenderCellSnapshot[] ScrolledOffRowCells(string firstLine)
+    {
+        var buffer = new TerminalBuffer(Cols, Rows);
+        var parser = new AnsiParser(buffer);
+        parser.Process(firstLine + "\r\n");
+        for (int i = 0; i < Rows; i++) parser.Process($"filler {i}\r\n");
+
+        Assert.True(buffer.Scrollback.Count > 0, "first row should have scrolled off");
+
+        var request = new RenderSnapshotRequest
+        {
+            ViewportCols = Cols,
+            ViewportRows = Rows,
+            // Scroll back far enough that the scrolled-off line is the top visible row.
+            ScrollOffset = buffer.Scrollback.Count
+        };
+
+        using var snapshot = buffer.CaptureRenderSnapshot(request, out _);
+        Assert.True(snapshot.RowsData.Length > 0);
+        // Copy out: the snapshot's arrays go back to the pool on Dispose.
+        return snapshot.RowsData.Array[0].Cells.ToArray();
+    }
+
+    [Fact]
+    public void ScrollbackRow_RendersAnAstralGraphemeInFull()
+    {
+        // "ok <emoji> done" - the emoji lead cell is column 3.
+        var cells = ScrolledOffRowCells($"ok {ThumbsUp} done");
+
+        Assert.Equal(ThumbsUp, cells[3].Text);
+        // Character alone is the high surrogate, which is exactly what the renderer used to draw.
+        Assert.True(char.IsHighSurrogate(cells[3].Character));
+        Assert.True(cells[3].IsWide);
+        Assert.True(cells[4].IsWideContinuation);
+    }
+
+    [Fact]
+    public void ScrollbackRow_RendersACombiningSequenceInFull()
+    {
+        var cells = ScrolledOffRowCells($"caf{EAcute}");
+
+        Assert.Equal(EAcute, cells[3].Text);
+    }
+
+    [Fact]
+    public void ScrollbackRow_LeavesPlainCellsWithoutText()
+    {
+        // The fallback matters more than the fix: almost every cell is plain, and a non-null Text
+        // on one would send the renderer down its slow shaped-run path for nothing.
+        var cells = ScrolledOffRowCells("plain ascii text");
+
+        Assert.All(cells, cell => Assert.Null(cell.Text));
+    }
+
+    [Fact]
+    public void ScrollbackRow_LeavesNonGraphemeColumnsAlone()
+    {
+        // Only the lead cell of the cluster carries Text; the continuation column and the
+        // surrounding plain cells must not.
+        var cells = ScrolledOffRowCells($"ok {ThumbsUp} done");
+
+        Assert.Null(cells[2].Text);
+        Assert.Null(cells[4].Text);   // wide continuation
+        Assert.Null(cells[5].Text);
+    }
+}


### PR DESCRIPTION
Closes #164 — the last actionable item (item 4).

## The bug

`GetOrBuildCachedPagedRenderRowCells_NoLock` builds render snapshots for rows that live in paged
scrollback. It contained:

```csharp
Text = null, // TODO Step 5: Support extended text in scrollback
```

So every grapheme wider than one UTF-16 code unit was **drawn** as its first code unit the moment
its line scrolled off screen — an emoji became a lone unpaired surrogate, a combining sequence lost
its marks, a flag became half a regional indicator.

Two things made this easy to miss:

1. **The viewport builder was already correct.** `PopulateRenderCellsFromRow_NoLock` does
   `Text = cell.HasExtendedText ? row.GetExtendedText(c) : null`. So the line looked right while it
   was on screen and broke on scroll.
2. **Copy and selection were already fixed.** #95 gap 1 taught `GetGraphemeAbsolute` the same side
   table. So you could select the emoji, paste it, and get the right character — while the screen
   next to you showed the wrong glyph. That divergence is what the TODO was hiding.

## The fix

The data was always there; the builder just never asked for it.

```csharp
var extendedText = _scrollback.GetExtendedTextMap(absRow);
// ...
Text = cell.HasExtendedText && extendedText != null
       && extendedText.TryGet(c, out string? graphemeText)
    ? graphemeText
    : null,
```

- Guarded on `cell.HasExtendedText` first, matching the viewport path exactly, so the two builders
  agree on when a cell has a cluster.
- The map is fetched **once per row**, not per cell.
- Scrollback rows are immutable and the existing cache key is `rowId` + cols, so no cache
  invalidation change is needed.
- `SnapshotAllocationTests.CaptureRenderSnapshot_UnchangedFrames_AllocationsStayLowAfterWarmup`
  still passes — no new allocation on the hot path.

## Verification

4 new tests in `tests/NovaTerminal.VT.Tests/ScrollbackRenderTextTests.cs`. Each writes a line, pushes
it into scrollback with filler, then captures a real render snapshot with
`ScrollOffset = Scrollback.Count` so row 0 of the snapshot is genuinely a paged-scrollback row (not a
viewport row that happens to look similar).

**Mutation-checked.** Restoring `Text = null`:

```
Failed  ScrollbackRow_RendersAnAstralGraphemeInFull
Failed  ScrollbackRow_RendersACombiningSequenceInFull
Passed  ScrollbackRow_LeavesPlainCellsWithoutText
Passed  ScrollbackRow_LeavesNonGraphemeColumnsAlone
```

The two that stay green are the fallback guards, and they earn their place: a spurious non-null
`Text` would push the renderer onto its shaped-run path for ordinary ASCII, which is a performance
regression rather than a visual one and so would not show up in any glyph assertion.

`ScrollbackRow_RendersAnAstralGraphemeInFull` also asserts `char.IsHighSurrogate(cells[3].Character)`
— documenting that `Character` alone is exactly the broken output the renderer used to draw, so the
test states the old behaviour rather than just the new.

Local runs: `NovaTerminal.VT.Tests` 113/113. `NovaTerminal.App.Tests` 1241 passed, 2 failed — both
known and unrelated: `TerminalPane_WhenRemotePromptSettlesLowOnShortPane_ResumesConservativeAssistLayout`
fails identically on clean `main` (see #225, #226), and `DataFlood_Backpressure_StressTest` is flaky
under full-suite load and passes in isolation.

## What this closes

#164's five items land as: 1 (#225), 2a (#226), 2b and 3 (already fixed before triage), 4 (here).

One deliberate non-change: `RenderCellSnapshot` still has **no hyperlink field**, and I don't think it
needs one. Hover and click resolve links live through `GetHyperlinkAbsolute`
(`TerminalView.cs:1937, :2027`), which already reads scrollback correctly. Adding a hyperlink to the
snapshot would only be needed to draw links persistently — a feature the app doesn't have. Worth
reopening as its own issue if that changes.
