### PR TITLE
feat(pty): add pty_last_error, and kill the child in pty_close

### DIFF
--- a/src/NovaTerminal.App/native/src/lib.rs
+++ b/src/NovaTerminal.App/native/src/lib.rs
@@ -431,6 +431,77 @@ mod win32 {
 
 use std::sync::{Arc, Mutex};
 
+// Last-failure channel (#120 item 3).
+//
+// Every failure exit in pty_spawn_impl returned a bare null pointer, so the managed side could
+// only ever say "Failed to create Rust PTY session." — "shell binary not found", "cwd does not
+// exist" and "openpty failed" were indistinguishable, which is the single most common thing a
+// user actually needs to know when a tab won't open.
+//
+// Thread-local rather than global, for the same reason errno is: two tabs can be spawning
+// concurrently, and a global would let one overwrite the other's message. The managed caller
+// reads it on the same thread that made the failing call, which is how RustPtySession works.
+std::thread_local! {
+    static LAST_ERROR: std::cell::RefCell<Option<String>> = const { std::cell::RefCell::new(None) };
+}
+
+fn set_last_error(message: impl Into<String>) {
+    LAST_ERROR.with(|slot| *slot.borrow_mut() = Some(message.into()));
+}
+
+fn clear_last_error() {
+    LAST_ERROR.with(|slot| *slot.borrow_mut() = None);
+}
+
+/// Copies the calling thread's most recent failure message into `buffer` as NUL-terminated UTF-8
+/// and returns the number of bytes written, excluding the NUL. Returns 0 when there is nothing to
+/// report, and -1 on invalid arguments.
+///
+/// The message is left in place, so it can be read more than once; the next `pty_spawn*` call on
+/// this thread clears it.
+///
+/// # Safety
+///
+/// `buffer` must be null or point to at least `len` writable bytes. Null and non-positive `len`
+/// are rejected rather than dereferenced.
+// Suppressed rather than inherited: every other export in this file trips the same lint (it is
+// inherent to a C ABI that takes pointers), but that is a pre-existing baseline of 8 and this
+// annotation keeps a new export from growing it. Cleaning up the other 8 is its own change.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[unsafe(no_mangle)]
+pub extern "C" fn pty_last_error(buffer: *mut c_char, len: c_int) -> c_int {
+    ffi_guard(-1, || {
+        if buffer.is_null() || len <= 1 {
+            // len == 1 leaves room for the NUL only, which cannot convey anything.
+            return -1;
+        }
+
+        LAST_ERROR.with(|slot| {
+            let borrowed = slot.borrow();
+            let Some(message) = borrowed.as_deref() else {
+                unsafe { *buffer = 0 };
+                return 0;
+            };
+
+            let capacity = (len - 1) as usize;
+            let bytes = message.as_bytes();
+            // Truncate on a char boundary: a half-written multi-byte sequence would decode to
+            // U+FFFD on the managed side, and the path/command names in these messages are
+            // exactly the sort of thing that contains non-ASCII.
+            let mut take = bytes.len().min(capacity);
+            while take > 0 && !message.is_char_boundary(take) {
+                take -= 1;
+            }
+
+            unsafe {
+                std::ptr::copy_nonoverlapping(bytes.as_ptr(), buffer as *mut u8, take);
+                *buffer.add(take) = 0;
+            }
+            take as c_int
+        })
+    })
+}
+
 /// Runs an FFI body, converting any panic into `on_panic` instead of unwinding
 /// across the C boundary (undefined behavior). Asserted unwind-safe: FFI bodies
 /// operate on raw pointers owned by the caller.
@@ -536,7 +607,7 @@ pub extern "C" fn pty_spawn(
     rows: u16,
 ) -> *mut PtyState {
     ffi_guard(std::ptr::null_mut(), || {
-        pty_spawn_impl(cmd, args, cwd, cols, rows, &[])
+        pty_spawn_impl(cmd, args, cwd, cols, rows, &[], false)
     })
 }
 
@@ -551,10 +622,16 @@ pub extern "C" fn pty_spawn_with_envs(
 ) -> *mut PtyState {
     ffi_guard(std::ptr::null_mut(), || {
         let overrides = parse_env_overrides(envs);
-        pty_spawn_impl(cmd, args, cwd, cols, rows, &overrides)
+        pty_spawn_impl(cmd, args, cwd, cols, rows, &overrides, false)
     })
 }
 
+/// `force_portable` is a test seam. Only the portable-pty path owns a `portable_pty::Child`, and
+/// that is the path whose teardown #120 item 2 is about; the ConPTY passthrough path instead ends
+/// its child as a side effect of ClosePseudoConsole. Whether a test run takes the passthrough path
+/// depends on whether the runner has a real console, which is not something a test should depend
+/// on - and steering it through NOVA_PTY_NO_PASSTHROUGH would mutate process-wide env while other
+/// spawn tests run in parallel.
 fn pty_spawn_impl(
     cmd: *const c_char,
     args: *const c_char,
@@ -562,9 +639,14 @@ fn pty_spawn_impl(
     cols: u16,
     rows: u16,
     extra_envs: &[(String, String)],
+    force_portable: bool,
 ) -> *mut PtyState {
+    // Any message from a previous attempt on this thread is stale from here on.
+    clear_last_error();
+
     let cmd_str = unsafe {
         if cmd.is_null() {
+            set_last_error("cmd was null");
             return std::ptr::null_mut();
         }
         CStr::from_ptr(cmd).to_string_lossy()
@@ -594,16 +676,25 @@ fn pty_spawn_impl(
         let env_opt_out = std::env::var("NOVA_PTY_NO_PASSTHROUGH")
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
-        let skip_passthrough = should_skip_passthrough(env_opt_out, win32::host_has_real_console());
+        let skip_passthrough = force_portable
+            || should_skip_passthrough(env_opt_out, win32::host_has_real_console());
         if !skip_passthrough {
-            if let Ok((reader, writer, h_pc, h_process)) = win32::spawn_with_passthrough(
+            let attempt = win32::spawn_with_passthrough(
                 cmd_str.as_ref(),
                 args_str.as_ref().map(|s| s.as_ref()),
                 cwd_str.as_ref().map(|s| s.as_ref()),
                 cols,
                 rows,
                 extra_envs,
-            ) {
+            );
+            // A passthrough failure is not fatal - we fall through to portable-pty below - so
+            // record it as context rather than as the error. If the fallback also fails its
+            // message replaces this one, which is the more useful of the two.
+            if let Err(ref err) = attempt {
+                set_last_error(format!("ConPTY passthrough spawn failed: {err}"));
+            }
+            if let Ok((reader, writer, h_pc, h_process)) = attempt {
+                clear_last_error();
                 let state = PtyState {
                     reader: Mutex::new(reader),
                     writer: Mutex::new(writer),
@@ -630,7 +721,10 @@ fn pty_spawn_impl(
 
     let pair = match system.openpty(size) {
         Ok(p) => p,
-        Err(_) => return std::ptr::null_mut(),
+        Err(e) => {
+            set_last_error(format!("openpty failed: {e}"));
+            return std::ptr::null_mut();
+        }
     };
 
     let mut cmd_builder = CommandBuilder::new(cmd_str.as_ref());
@@ -646,7 +740,8 @@ fn pty_spawn_impl(
             }
         }
     }
-    if let Some(c) = cwd_str {
+    // Borrowed, not moved: the spawn failure message below names the cwd.
+    if let Some(c) = cwd_str.as_ref() {
         if !c.is_empty() {
             cmd_builder.cwd(c.as_ref());
         }
@@ -680,16 +775,35 @@ fn pty_spawn_impl(
 
     let child = match pair.slave.spawn_command(cmd_builder) {
         Ok(c) => c,
-        Err(_) => return std::ptr::null_mut(),
+        Err(e) => {
+            // The overwhelmingly common real failure: a shell path that does not exist, or a cwd
+            // that does not. Naming the command and cwd is the whole point of this channel.
+            set_last_error(format!(
+                "failed to spawn '{}'{}: {e}",
+                cmd_str,
+                cwd_str
+                    .as_deref()
+                    .filter(|c| !c.is_empty())
+                    .map(|c| format!(" in '{c}'"))
+                    .unwrap_or_default()
+            ));
+            return std::ptr::null_mut();
+        }
     };
 
     let reader = match pair.master.try_clone_reader() {
         Ok(r) => r,
-        Err(_) => return std::ptr::null_mut(),
+        Err(e) => {
+            set_last_error(format!("failed to clone PTY reader: {e}"));
+            return std::ptr::null_mut();
+        }
     };
     let writer = match pair.master.take_writer() {
         Ok(w) => w,
-        Err(_) => return std::ptr::null_mut(),
+        Err(e) => {
+            set_last_error(format!("failed to take PTY writer: {e}"));
+            return std::ptr::null_mut();
+        }
     };
 
     let state = PtyState {
@@ -740,12 +854,21 @@ pub extern "C" fn pty_read(state_ptr: *mut PtyState, buffer: *mut u8, len: c_int
             );
             let result = match reader.read(buf) {
                 Ok(n) => n as c_int,
-                Err(_) => -1,
+                Err(e) => {
+                    // pty_read still collapses every failure to -1, because the managed read loop
+                    // treats the code as opaque and retries a bounded number of times either way.
+                    // Recording *why* is what was missing: a permanently failing handle used to
+                    // report nothing at all, so a frozen tab had no explanation anywhere (#107
+                    // recorded this as blocked on #120's error channel).
+                    set_last_error(format!("pty read failed: {e}"));
+                    -1
+                }
             };
             #[cfg(windows)]
             state.read_thread_id.store(0, Ordering::SeqCst);
             result
         } else {
+            set_last_error("pty read failed: reader lock poisoned");
             -1
         }
     })
@@ -774,9 +897,13 @@ pub extern "C" fn pty_write(state_ptr: *mut PtyState, buffer: *const u8, len: c_
             // pastes silently lost bytes (#168).
             match writer.write_all(buf) {
                 Ok(()) => len,
-                Err(_) => -1,
+                Err(e) => {
+                    set_last_error(format!("pty write failed: {e}"));
+                    -1
+                }
             }
         } else {
+            set_last_error("pty write failed: writer lock poisoned");
             -1
         }
     })
@@ -962,8 +1089,250 @@ pub extern "C" fn pty_close(state_ptr: *mut PtyState) {
                 }
             }
         }
-        // Drop logic handles the rest (reader, writer, master, child)
+
+        // Kill the child here too, not only in pty_cancel_read (#120 item 2).
+        //
+        // portable_pty::Child follows std::process::Child: dropping it does *not* kill the
+        // process, it just stops observing it. So the comment that "drop logic handles the rest"
+        // was true for the reader, writer and master and false for the child. The normal teardown
+        // path is safe because RustPtySession.Dispose calls pty_cancel_read first, but its
+        // exception-unwind branch deliberately skips the cancel - and any other caller that
+        // reaches pty_close directly orphans the shell.
+        //
+        // Idempotent: kill() on an already-reaped child returns Err, which we ignore, and
+        // pty_cancel_read having already killed it makes this a no-op.
+        if let Ok(mut child_opt) = state.child.lock() {
+            if let Some(child) = child_opt.as_mut() {
+                let _ = child.kill();
+            }
+        }
+
+        // Drop logic handles the rest (reader, writer, master)
     })
+}
+
+#[cfg(test)]
+mod last_error_tests {
+    use super::*;
+    use std::ffi::CString;
+
+    /// Calls pty_last_error into a buffer of `capacity` and returns (rc, decoded string).
+    fn read_last_error(capacity: usize) -> (c_int, String) {
+        let mut buf = vec![0i8; capacity];
+        let rc = pty_last_error(buf.as_mut_ptr() as *mut c_char, capacity as c_int);
+        let bytes: Vec<u8> = buf.iter().take_while(|b| **b != 0).map(|b| *b as u8).collect();
+        (rc, String::from_utf8_lossy(&bytes).into_owned())
+    }
+
+    #[test]
+    fn reports_nothing_when_there_is_no_error() {
+        clear_last_error();
+        let (rc, message) = read_last_error(64);
+        assert_eq!(rc, 0);
+        assert!(message.is_empty());
+    }
+
+    #[test]
+    fn rejects_invalid_arguments() {
+        assert_eq!(pty_last_error(std::ptr::null_mut(), 64), -1);
+
+        let mut buf = [0i8; 4];
+        // A one-byte buffer holds the NUL and nothing else, so it cannot convey a message.
+        assert_eq!(pty_last_error(buf.as_mut_ptr() as *mut c_char, 1), -1);
+        assert_eq!(pty_last_error(buf.as_mut_ptr() as *mut c_char, 0), -1);
+    }
+
+    #[test]
+    fn returns_the_message_and_leaves_it_readable() {
+        set_last_error("boom");
+
+        let (rc, message) = read_last_error(64);
+        assert_eq!(rc, 4);
+        assert_eq!(message, "boom");
+
+        // Readable more than once: the managed side logs and rethrows off the same value.
+        let (rc2, again) = read_last_error(64);
+        assert_eq!(rc2, 4);
+        assert_eq!(again, "boom");
+    }
+
+    #[test]
+    fn truncates_on_a_char_boundary() {
+        // Three 4-byte emoji. A buffer with room for 6 payload bytes must stop after the first
+        // one rather than splitting the second, which would decode to U+FFFD managed-side.
+        set_last_error("\u{1F44D}\u{1F44D}\u{1F44D}");
+
+        let (rc, message) = read_last_error(7);
+
+        assert_eq!(rc, 4, "should have emitted exactly one whole emoji");
+        assert_eq!(message, "\u{1F44D}");
+    }
+
+    #[test]
+    fn truncation_can_emit_nothing_rather_than_a_partial_char() {
+        set_last_error("\u{1F44D}");
+        // Room for 2 payload bytes, but the only char needs 4.
+        let (rc, message) = read_last_error(3);
+        assert_eq!(rc, 0);
+        assert!(message.is_empty());
+    }
+
+    // The point of the whole channel: a failed spawn must say *why*.
+    #[test]
+    fn failed_spawn_names_the_command() {
+        let bogus = "novaterminal-no-such-shell-91b7fe";
+        let c_cmd = CString::new(bogus).unwrap();
+        let state = pty_spawn(
+            c_cmd.as_ptr(),
+            std::ptr::null(),
+            std::ptr::null(),
+            80,
+            24,
+        );
+        assert!(state.is_null(), "spawning {bogus} should fail");
+
+        let (rc, message) = read_last_error(512);
+        assert!(rc > 0, "expected a message, got rc={rc}");
+        assert!(
+            message.contains(bogus),
+            "message should name the command; got: {message}"
+        );
+    }
+
+    #[test]
+    fn null_cmd_is_reported_rather_than_silently_null() {
+        let state = pty_spawn(
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            80,
+            24,
+        );
+        assert!(state.is_null());
+
+        let (rc, message) = read_last_error(128);
+        assert!(rc > 0);
+        assert_eq!(message, "cmd was null");
+    }
+
+    #[test]
+    fn a_successful_spawn_clears_a_previous_failure() {
+        set_last_error("stale message from an earlier attempt");
+
+        #[cfg(windows)]
+        let (cmd, args) = ("cmd.exe", "/c exit");
+        #[cfg(not(windows))]
+        let (cmd, args) = ("/bin/sh", "-c 'exit 0'");
+
+        let c_cmd = CString::new(cmd).unwrap();
+        let c_args = CString::new(args).unwrap();
+        let state = pty_spawn(
+            c_cmd.as_ptr(),
+            c_args.as_ptr(),
+            std::ptr::null(),
+            80,
+            24,
+        );
+        assert!(!state.is_null(), "spawning {cmd} should succeed");
+
+        let (rc, message) = read_last_error(128);
+        assert_eq!(rc, 0, "stale message survived a successful spawn: {message}");
+
+        pty_close(state);
+    }
+}
+
+#[cfg(test)]
+mod close_kills_child_tests {
+    use super::*;
+    use std::ffi::CString;
+
+    // #120 item 2: portable_pty::Child follows std::process::Child - dropping it does not kill the
+    // process. pty_close only closed handles and let the child drop, so any caller reaching
+    // pty_close without first calling pty_cancel_read (notably RustPtySession.Dispose's
+    // exception-unwind branch) orphaned the shell.
+    //
+    // Platform note, because it changes what this test proves. I mutation-checked it on Windows by
+    // removing the new child.kill() from pty_close, and it still passed: on Windows dropping the
+    // PtyState drops the ConPTY master, which closes the pseudoconsole, which ends the child as a
+    // side effect. So on Windows the orphan does not reproduce and this test is only a guard.
+    //
+    // On Unix closing the master fd does *not* end a child that holds the slave, which is where the
+    // orphan is real and where this test is load-bearing. It runs on Linux via the ubuntu leg of
+    // the Rust FFI Tests job.
+    #[test]
+    fn close_without_cancel_terminates_the_child() {
+        // A child that would outlive the test by a wide margin if it were not killed.
+        #[cfg(windows)]
+        let (cmd, args) = ("cmd.exe", "/c timeout /t 120 /nobreak >NUL");
+        #[cfg(not(windows))]
+        let (cmd, args) = ("/bin/sh", "-c 'sleep 120'");
+
+        let c_cmd = CString::new(cmd).unwrap();
+        let c_args = CString::new(args).unwrap();
+        // force_portable: only the portable-pty path owns a `child`, and it is the one whose
+        // teardown this test is about.
+        let state = pty_spawn_impl(
+            c_cmd.as_ptr(),
+            c_args.as_ptr(),
+            std::ptr::null(),
+            80,
+            24,
+            &[],
+            true,
+        );
+        assert!(!state.is_null(), "spawn failed");
+
+        let pid = pty_get_pid(state);
+        assert!(pid > 0, "expected a real pid, got {pid}");
+
+        // Deliberately no pty_cancel_read: that is the path under test.
+        pty_close(state);
+
+        assert!(
+            wait_for_process_exit(pid, std::time::Duration::from_secs(10)),
+            "child pid {pid} survived pty_close - it has been orphaned"
+        );
+    }
+
+    /// True once the process is gone, polling until `timeout`.
+    fn wait_for_process_exit(pid: c_int, timeout: std::time::Duration) -> bool {
+        let deadline = std::time::Instant::now() + timeout;
+        while std::time::Instant::now() < deadline {
+            if !process_is_alive(pid) {
+                return true;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        !process_is_alive(pid)
+    }
+
+    #[cfg(windows)]
+    fn process_is_alive(pid: c_int) -> bool {
+        use windows_sys::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
+        use windows_sys::Win32::System::Threading::{
+            GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+        };
+
+        unsafe {
+            let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid as u32);
+            if handle == 0 {
+                // Cannot open it at all: already reaped.
+                return false;
+            }
+            let mut code: u32 = 0;
+            let ok = GetExitCodeProcess(handle, &mut code);
+            CloseHandle(handle);
+            ok != 0 && code == STILL_ACTIVE as u32
+        }
+    }
+
+    #[cfg(not(windows))]
+    fn process_is_alive(pid: c_int) -> bool {
+        // Signal 0 checks for existence without delivering anything. A zombie still counts as
+        // alive here, but the child is reaped by portable-pty's own bookkeeping on kill.
+        unsafe { libc::kill(pid, 0) == 0 }
+    }
 }
 
 #[cfg(test)]

--- a/src/NovaTerminal.App/native/src/lib.rs
+++ b/src/NovaTerminal.App/native/src/lib.rs
@@ -833,6 +833,14 @@ pub extern "C" fn pty_create(cmd: *const c_char, cols: u16, rows: u16) -> *mut P
 pub extern "C" fn pty_read(state_ptr: *mut PtyState, buffer: *mut u8, len: c_int) -> c_int {
     ffi_guard(-1, || {
         if state_ptr.is_null() || buffer.is_null() || len < 0 {
+            // Every -1 must leave a matching message. Returning without touching the channel
+            // would leave whatever an earlier failure wrote in place, so a caller reading it
+            // after this -1 would be told about an unrelated, older problem.
+            set_last_error(format!(
+                "pty_read called with invalid arguments: state={}, buffer={}, len={len}",
+                if state_ptr.is_null() { "null" } else { "ok" },
+                if buffer.is_null() { "null" } else { "ok" },
+            ));
             return -1;
         }
         if len == 0 {
@@ -878,6 +886,12 @@ pub extern "C" fn pty_read(state_ptr: *mut PtyState, buffer: *mut u8, len: c_int
 pub extern "C" fn pty_write(state_ptr: *mut PtyState, buffer: *const u8, len: c_int) -> c_int {
     ffi_guard(-1, || {
         if state_ptr.is_null() || buffer.is_null() || len < 0 {
+            // Same contract as pty_read: a -1 never leaves a stale message behind.
+            set_last_error(format!(
+                "pty_write called with invalid arguments: state={}, buffer={}, len={len}",
+                if state_ptr.is_null() { "null" } else { "ok" },
+                if buffer.is_null() { "null" } else { "ok" },
+            ));
             return -1;
         }
         if len == 0 {
@@ -1197,6 +1211,41 @@ mod last_error_tests {
             message.contains(bogus),
             "message should name the command; got: {message}"
         );
+    }
+
+    // The channel's contract: a -1 always describes *that* call. Without this, an invalid-argument
+    // rejection returned -1 while leaving an older, unrelated message in place, so the caller was
+    // told about the wrong failure - worse than being told nothing.
+    #[test]
+    fn invalid_read_arguments_replace_a_stale_message() {
+        set_last_error("stale message from an unrelated earlier failure");
+
+        let mut buf = [0u8; 16];
+        assert_eq!(pty_read(std::ptr::null_mut(), buf.as_mut_ptr(), 16), -1);
+
+        let (rc, message) = read_last_error(256);
+        assert!(rc > 0);
+        assert!(
+            message.contains("pty_read called with invalid arguments"),
+            "expected the read rejection, got: {message}"
+        );
+        assert!(!message.contains("stale"), "stale message survived: {message}");
+    }
+
+    #[test]
+    fn invalid_write_arguments_replace_a_stale_message() {
+        set_last_error("stale message from an unrelated earlier failure");
+
+        let buf = [0u8; 16];
+        assert_eq!(pty_write(std::ptr::null_mut(), buf.as_ptr(), 16), -1);
+
+        let (rc, message) = read_last_error(256);
+        assert!(rc > 0);
+        assert!(
+            message.contains("pty_write called with invalid arguments"),
+            "expected the write rejection, got: {message}"
+        );
+        assert!(!message.contains("stale"), "stale message survived: {message}");
     }
 
     #[test]

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -38,12 +38,16 @@ namespace NovaTerminal.Pty
         // the process (#107). 20 attempts x 50 ms tolerates roughly a second of
         // transient failure before giving up.
         //
-        // The retry exists only because the cause cannot be identified: pty_read
-        // collapses every failure to -1 (null args, read error with errno discarded,
-        // poisoned lock, and a panic caught by ffi_guard all return the same value), so
-        // a transient condition is indistinguishable from an unrecoverable one here.
-        // Classifying them needs the pty_last_error channel tracked in #120; until then
-        // "retry a bounded number of times, then fail" is the safe reading.
+        // The retry exists because the *return code* still cannot classify the failure:
+        // pty_read collapses every error to -1 (null args, read error, poisoned lock, and a
+        // panic caught by ffi_guard all return the same value), so a transient condition is
+        // indistinguishable from an unrecoverable one from the code alone, and "retry a
+        // bounded number of times, then fail" remains the safe reading.
+        //
+        // What #120 item 3 added is the *reason*: pty_last_error now carries a message, which
+        // this loop logs when it gives up, so a frozen tab is no longer unexplained. Turning
+        // that message into a retry/no-retry decision would mean matching on error text, which
+        // is worse than the bound.
         internal const int MaxConsecutiveReadErrors = 20;
         private static readonly TimeSpan ReadErrorRetryDelay = TimeSpan.FromMilliseconds(50);
 
@@ -221,6 +225,48 @@ namespace NovaTerminal.Pty
             // Raw overload used only by PtySafeHandle.ReleaseHandle().
             [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void pty_close(IntPtr state);
+
+            // Thread-local last-failure message (#120 item 3). Must be read on the same thread
+            // that made the failing call. Writes NUL-terminated UTF-8 and returns the byte count
+            // excluding the NUL; 0 when there is nothing to report, -1 on bad arguments.
+            [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+            public static extern int pty_last_error(byte[] buffer, int len);
+        }
+
+        /// <summary>
+        /// The native layer's message for the most recent failure on this thread, or null if it
+        /// had nothing to say.
+        /// </summary>
+        /// <remarks>
+        /// Before this existed, every spawn failure surfaced as the same
+        /// "Failed to create Rust PTY session." — a missing shell binary, a deleted working
+        /// directory and an openpty failure were indistinguishable, which is exactly the
+        /// information a user needs when a tab refuses to open.
+        /// </remarks>
+        private static string? TryGetNativeLastError()
+        {
+            try
+            {
+                // 1 KiB is comfortably more than any message the native side produces; it
+                // truncates on a char boundary rather than overflowing, so a long path costs
+                // detail, not correctness.
+                var buffer = new byte[1024];
+                int written = Native.pty_last_error(buffer, buffer.Length);
+                if (written <= 0) return null;
+                return Encoding.UTF8.GetString(buffer, 0, written);
+            }
+            catch (EntryPointNotFoundException)
+            {
+                // A native library predating this export. This helper exists only to *improve* an
+                // error message, so it must never replace one with something worse — without this
+                // catch, a stale rusty_pty turned "failed to spawn <shell>" into an unrelated
+                // EntryPointNotFoundException from inside the failure path.
+                return null;
+            }
+            catch (DllNotFoundException)
+            {
+                return null;
+            }
         }
 
         // Owns the *mut PtyState returned by pty_spawn. Passing this to every
@@ -452,7 +498,13 @@ namespace NovaTerminal.Pty
 
             if (_handle.IsInvalid)
             {
-                throw new InvalidOperationException("Failed to create Rust PTY session.");
+                // Read the native reason immediately: it is thread-local and the next spawn on
+                // this thread clears it.
+                string? reason = TryGetNativeLastError();
+                throw new InvalidOperationException(
+                    reason is null
+                        ? $"Failed to create Rust PTY session for '{effectiveShell}'."
+                        : $"Failed to create Rust PTY session for '{effectiveShell}': {reason}");
             }
 
             // Start reading and processing on DEDICATED background threads, not the
@@ -706,10 +758,13 @@ namespace NovaTerminal.Pty
 
                         if (++consecutiveReadErrors >= MaxConsecutiveReadErrors)
                         {
-                            // Fail the session instead of spinning forever. See
-                            // MaxConsecutiveReadErrors for why the cause is unknown here.
+                            // Fail the session instead of spinning forever. The native reason is
+                            // read on this thread, which is the same thread that made the failing
+                            // pty_read - the channel is thread-local (#120 item 3).
+                            string? reason = TryGetNativeLastError();
                             Console.WriteLine(
-                                $"[RustPtySession] pty_read failed {consecutiveReadErrors} times consecutively; ending session.");
+                                $"[RustPtySession] pty_read failed {consecutiveReadErrors} times consecutively; ending session."
+                                + (reason is null ? string.Empty : $" Last native error: {reason}"));
                             readFailed = true;
                             break;
                         }

--- a/tests/NovaTerminal.App.Tests/PtySpawnFailureTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtySpawnFailureTests.cs
@@ -1,0 +1,48 @@
+using System;
+using NovaTerminal.Pty;
+using Xunit;
+
+namespace NovaTerminal.Tests
+{
+    /// <summary>
+    /// #120 item 3: a failed spawn used to throw a bare "Failed to create Rust PTY session." — the
+    /// native layer returned a null pointer and nothing else, so a missing shell binary, a deleted
+    /// working directory and an openpty failure were indistinguishable. That is the single most
+    /// useful thing to know when a tab refuses to open.
+    ///
+    /// In this collection because it spawns through the real native library.
+    /// </summary>
+    [Collection(PtyRealShellCollection.Name)]
+    public class PtySpawnFailureTests
+    {
+        private const string MissingShell = "novaterminal-no-such-shell-3d81ac.exe";
+
+        [Fact]
+        public void Spawning_a_missing_shell_reports_the_command_in_the_exception()
+        {
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => new RustPtySession(MissingShell, cols: 80, rows: 24));
+
+            // Naming the shell is the point: the old message named nothing at all.
+            Assert.Contains(MissingShell, ex.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void Spawning_a_missing_shell_reports_the_native_reason()
+        {
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => new RustPtySession(MissingShell, cols: 80, rows: 24));
+
+            // The native message is appended after a colon. Assert that *something* came across
+            // the pty_last_error channel rather than matching OS-specific wording: the underlying
+            // text differs between Windows ("The system cannot find the file specified") and Unix
+            // ("No such file or directory"), and pinning either would make this a Windows-only
+            // test in disguise.
+            int separator = ex.Message.IndexOf("': ", StringComparison.Ordinal);
+            Assert.True(
+                separator > 0,
+                $"expected a native reason appended to the message, got: {ex.Message}");
+            Assert.NotEmpty(ex.Message.Substring(separator + 3).Trim());
+        }
+    }
+}


### PR DESCRIPTION
Addresses items 2 and 3 of #120. With item 4 (#228) and item 1 (already fixed by #153), this closes
out the issue.

## Item 3: no way to say *why* a spawn failed

`pty_spawn_impl` had five failure exits and every one of them did the same thing:

```rust
Err(_) => return std::ptr::null_mut(),
```

So `RustPtySession` could only ever throw `"Failed to create Rust PTY session."` — a shell binary
that doesn't exist, a working directory that was deleted, and an `openpty` failure all produced the
identical message. That is precisely the information a user needs when a tab refuses to open, and
none of it was reachable.

`pty_last_error(buffer, len)` exposes it:

- **Thread-local, for the reason errno is.** Two tabs can be spawning concurrently; a global would
  let one overwrite the other's message.
- **NUL-terminated UTF-8, truncated on a char boundary.** These messages carry paths and command
  names, so splitting a multi-byte sequence would hand the managed side a U+FFFD. When the buffer is
  too small for even one char it returns 0 rather than a partial one.
- **Readable more than once.** The managed caller logs and rethrows off the same value. The next
  `pty_spawn*` on that thread clears it.
- Populated on every spawn exit, naming the command and cwd on the common one:
  `failed to spawn 'C:\nope\pwsh.exe' in 'D:\gone': ...`

**Also wired into `pty_read`/`pty_write`.** This is what #107 recorded as blocked on #120: `pty_read`
still collapses every failure to `-1`, and the managed loop still retries a bounded number of times
because the *code* can't classify the failure — but it now logs the *reason* when it gives up, so a
frozen tab is no longer completely unexplained. Turning the message into a retry/no-retry decision
would mean matching on error text, which is worse than the bound; I left the bound alone and updated
the comment that pointed at this issue.

### One thing worth flagging in the managed helper

`TryGetNativeLastError` swallows `EntryPointNotFoundException`:

```csharp
catch (EntryPointNotFoundException)
{
    // A native library predating this export. This helper exists only to *improve* an
    // error message, so it must never replace one with something worse.
    return null;
}
```

That isn't hypothetical defensiveness — I hit it. My first test run had a stale `rusty_pty` in the
test output directory, and the result was that a clean `InvalidOperationException` became an
`EntryPointNotFoundException` thrown *from inside the failure path*, hiding the actual problem. A
helper whose only job is to enrich an error message must never be able to replace it.

## Item 2: `pty_close` left the child running

`portable_pty::Child` follows `std::process::Child` — dropping it does **not** kill the process. So
the comment saying "drop logic handles the rest (reader, writer, master, child)" was true for the
first three and false for the fourth. `pty_close` now kills the child too (idempotently: `kill()` on
an already-reaped child returns `Err`, ignored, and `pty_cancel_read` having already killed it makes
this a no-op).

`RustPtySession.Dispose` is safe today because it calls `pty_cancel_read` first — but its
exception-unwind branch deliberately skips the cancel, and any other caller reaching `pty_close`
directly orphans the shell.

### What the test for this actually proves — and doesn't

I mutation-checked it by removing the new `kill()`, and **it still passed on Windows.** Diagnosis:
dropping the `PtyState` drops the ConPTY master, which closes the pseudoconsole, which ends the
child as a side effect. I confirmed the child *was* alive immediately before `pty_close` and gone
within 50 ms after, with the fix removed. So on Windows the orphan does not reproduce and this test
is a guard, not a demonstration.

On Unix, closing the master fd does not end a child holding the slave — that is where the orphan is
real and where the test is load-bearing. It runs on Linux through the `ubuntu-latest` leg of the
`Rust FFI Tests` job (added in #228 for exactly this class of gap). I could not run it on Linux
locally, so CI is the verification; I'll confirm the result on this PR before merging.

Stating this rather than letting "mutation-verified" stand unqualified — the earlier version of that
claim on #226 turned out to be wrong for a similar reason.

## `force_portable`: a new test seam

`pty_spawn_impl` takes a `force_portable: bool` (false at both public entry points). Only the
portable-pty path owns a `Child` at all, and whether a test run takes the ConPTY passthrough path
depends on whether the runner has a real console — not something a test should depend on. The
alternative, steering it with `NOVA_PTY_NO_PASSTHROUGH`, would mutate process-wide environment while
other spawn tests run in parallel (and is `unsafe` under the 2024 edition anyway).

## Verification

**8 Rust tests** for the channel: empty state returns 0; null buffer and `len <= 1` return -1;
message readable twice; char-boundary truncation in both directions (one whole emoji from a 7-byte
buffer, *nothing* from a 3-byte one rather than half a char); failed spawn names the command; null
`cmd` reports `"cmd was null"` instead of silently returning null; a successful spawn clears a stale
message.

**1 Rust test** for `pty_close` killing the child, with the caveat above.

**2 C# tests** asserting the exception carries both the command and a native reason. The reason test
fails when the lookup is stubbed to `null`; the command test passes either way, because the command
name comes from managed code — noting that so the pair isn't read as two independent proofs.

The reason test deliberately does not match the OS wording ("The system cannot find the file
specified" vs "No such file or directory") — pinning either would make it a Windows-only test in
disguise.

Runs: `cargo test` 19/19 on Windows. `NovaTerminal.App.Tests` 1244 passed / 1 failed —
`TerminalPane_WhenRemotePromptSettlesLowOnShortPane_ResumesConservativeAssistLayout`, which fails on
clean `main` and is green in CI (same as #225/#226/#227). `NovaTerminal.Platform.Tests` 122 / 0.

Clippy, measured against a clean `main` worktree: **errors unchanged at the pre-existing 8.** The new
export would have made it 10, so it carries a targeted `#[allow(clippy::not_unsafe_ptr_arg_deref)]`
with the reasoning inline rather than quietly growing the baseline. The other 8 are worth clearing in
their own change — every export in that file trips it, which is inherent to a C ABI taking pointers.
