### PR TITLE
test(pane): pin the subscription-lifetime invariants #102 depends on

### DIFF
--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -123,6 +123,7 @@ namespace NovaTerminal.Controls
         private DateTimeOffset? _lastCommandStartedAtUtc;
         private Action<int, int>? _onTermViewResize;
         private Action<float, float>? _onTermViewMetricsChanged;
+        private Action<float, float>? _onTermViewMetricsLayout;
         private DispatcherTimer? _statusTimer;
         private bool _hasUserInteraction;
         private readonly SshDiagnosticsLevel _sshDiagnosticsLevel;
@@ -473,11 +474,17 @@ namespace NovaTerminal.Controls
             // Wire up focus syncing
             TermView.GotFocus += (s, e) => UpdateFocusVisuals(true);
             TermView.LostFocus += (s, e) => UpdateFocusVisuals(false);
-            TermView.MetricsChanged += (cw, ch) =>
+            // Cached so DetachFromUiThread can remove it. As an uncached lambda it was the one
+            // TermView handler left attached after disposal, which contradicted the claim that a
+            // disposed pane stops reacting — harmless in practice (it only re-runs this pane's own
+            // layout) but it made the invariant untestable, and an untestable invariant is one edit
+            // away from being false (#102).
+            _onTermViewMetricsLayout = (cw, ch) =>
             {
                 UpdateMinimumSizeConstraints();
                 UpdateCommandAssistOverlayPlacement();
             };
+            TermView.MetricsChanged += _onTermViewMetricsLayout;
             TermView.CommandAssistAnchorHintChanged += () => UpdateCommandAssistOverlayPlacement();
             SizeChanged += (_, _) => UpdateCommandAssistOverlayPlacement();
             TermView.TextInputObserved += text =>
@@ -1545,6 +1552,41 @@ namespace NovaTerminal.Controls
 
             // Update buffer to match view exactly before starting PTY
             Buffer.Resize(cols, rows);
+            CreateAndWireParser();
+
+            // Sync initial metrics
+            float cw = TermView.Metrics.CellWidth;
+            float ch = TermView.Metrics.CellHeight;
+            if (cw > 0) Parser!.CellWidth = cw;
+            if (ch > 0) Parser!.CellHeight = ch;
+
+            // Setup Session
+            string effectiveShell = shell ?? ShellHelper.GetDefaultShell();
+            string args = explicitArgs ?? profile?.Arguments ?? "";
+            InitializeSessionCore(effectiveShell, args, profile, cols, rows);
+        }
+
+        /// <summary>
+        /// Replaces <see cref="Parser"/> with a fresh <see cref="AnsiParser"/> and attaches this
+        /// pane's handlers to it.
+        /// </summary>
+        /// <remarks>
+        /// The handlers attached here are deliberately never removed, and that is safe for exactly
+        /// one reason: a <b>new</b> parser is created on every call, so each one starts with an empty
+        /// handler list and the previous parser becomes garbage along with its handlers. #102 read
+        /// the missing <c>-=</c> calls as an accumulation bug on <c>Reconnect()</c>; they are not,
+        /// because of this line.
+        ///
+        /// That makes the assignment load-bearing. Hoisting the parser out to reuse it across
+        /// sessions — a reasonable-looking change — would silently double all of these on every
+        /// reconnect, producing the duplicate bell/title symptom #102 describes, with no <c>-=</c>
+        /// anywhere to fall back on. Split into its own method so that invariant can be asserted
+        /// without spinning up a shell; see <c>PaneParserWiringTests</c>.
+        /// </remarks>
+        internal void CreateAndWireParser()
+        {
+            if (Buffer == null) return;
+
             Parser = new AnsiParser(Buffer);
 
             Parser.OnBell += () =>
@@ -1628,16 +1670,12 @@ namespace NovaTerminal.Controls
                     Dispatcher.UIThread.Post(() => LongCommandCompleted?.Invoke(this, commandText, exitCode, d));
                 }
             };
+        }
 
-            // Sync initial metrics
-            float cw = TermView.Metrics.CellWidth;
-            float ch = TermView.Metrics.CellHeight;
-            if (cw > 0) Parser.CellWidth = cw;
-            if (ch > 0) Parser.CellHeight = ch;
-
-            // Setup Session
-            string effectiveShell = shell ?? ShellHelper.GetDefaultShell();
-            string args = explicitArgs ?? profile?.Arguments ?? "";
+        /// Spawns the session and wires the handlers that depend on it. Split out of
+        /// <c>InitializeSession</c> alongside <see cref="CreateAndWireParser"/>; no behaviour change.
+        private void InitializeSessionCore(string effectiveShell, string args, TerminalProfile? profile, int cols, int rows)
+        {
             _shellLifecycleTracker = null;
             _isShellIntegrationActive = false;
             _shellIntegrationEnvOverrides = null;
@@ -1771,7 +1809,28 @@ namespace NovaTerminal.Controls
                 Session.SendInput(response);
             };
 
-            // Wire up Resize (idempotent across InitializeSession re-runs — TermView is reused).
+            WireReusedTermViewHandlers();
+        }
+
+        /// <summary>
+        /// Subscribes the two <see cref="TermView"/> handlers that belong to session setup, in a way
+        /// that is safe to call repeatedly.
+        /// </summary>
+        /// <remarks>
+        /// Every other subscription made by <c>InitializeSession</c> targets an object that is
+        /// recreated with the session — a fresh <see cref="AnsiParser"/> (see the assignment at the
+        /// top of that method) or the new <see cref="ITerminalSession"/> — so those handler lists
+        /// start empty and cannot accumulate. These two are the exception: <c>TermView</c> is the
+        /// pane's own control and outlives any individual session, so <c>Reconnect()</c> would add a
+        /// second copy of each on every reconnect.
+        ///
+        /// Hence the cached delegates plus remove-before-add: the delegate identity has to be stable
+        /// for <c>-=</c> to match, which a fresh lambda per call would not give. Extracted into its
+        /// own method so the idempotence can be asserted directly (#102) rather than only through a
+        /// full session spin-up.
+        /// </remarks>
+        internal void WireReusedTermViewHandlers()
+        {
             _onTermViewResize ??= (c, r) =>
             {
                 if (Parser != null)
@@ -1786,7 +1845,6 @@ namespace NovaTerminal.Controls
             TermView.OnResize -= _onTermViewResize;
             TermView.OnResize += _onTermViewResize;
 
-            // Metrics changed handling (idempotent — TermView is reused).
             _onTermViewMetricsChanged ??= (cwMetric, chMetric) =>
             {
                 if (Parser != null && cwMetric > 0 && chMetric > 0)
@@ -2405,6 +2463,7 @@ namespace NovaTerminal.Controls
             // Detach handlers on the reused TermView so a disposed pane stops reacting.
             if (_onTermViewResize != null) TermView.OnResize -= _onTermViewResize;
             if (_onTermViewMetricsChanged != null) TermView.MetricsChanged -= _onTermViewMetricsChanged;
+            if (_onTermViewMetricsLayout != null) TermView.MetricsChanged -= _onTermViewMetricsLayout;
 
             if (Buffer != null)
             {

--- a/tests/NovaTerminal.App.Tests/Controls/PaneParserWiringTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneParserWiringTests.cs
@@ -1,0 +1,98 @@
+using System;
+using Avalonia.Headless.XUnit;
+using NovaTerminal.Controls;
+using NovaTerminal.VT;
+using Xunit;
+
+namespace NovaTerminal.Tests.Controls;
+
+/// <summary>
+/// Pins the invariant that makes #102's headline finding a non-issue.
+///
+/// <c>CreateAndWireParser</c> attaches 8 handlers to <see cref="AnsiParser"/> and never removes
+/// them, which #102 read as an accumulation bug on session restart. It is safe for exactly one
+/// reason: the method assigns a <b>fresh</b> parser first, so every session starts from empty
+/// handler lists and the previous parser is garbage along with its handlers.
+///
+/// One line holds that up. Hoisting the parser out to reuse it across sessions — a
+/// reasonable-looking change — would silently double all 8 on every <c>Reconnect()</c>, producing
+/// exactly the duplicate bell/title symptom #102 describes, with no <c>-=</c> anywhere to fall back
+/// on.
+///
+/// The parser's hooks are <c>Action</c>-typed properties rather than events, so <c>+=</c> is plain
+/// delegate combination and the invocation list is readable without reflection.
+/// </summary>
+public class PaneParserWiringTests
+{
+    private static int HandlerCount(Delegate? handler) => handler?.GetInvocationList().Length ?? 0;
+
+    /// Every parser hook the pane wires, with its current handler count.
+    private static (string Name, int Count)[] HookCounts(AnsiParser parser) =>
+    [
+        (nameof(parser.OnBell), HandlerCount(parser.OnBell)),
+        (nameof(parser.OnWorkingDirectoryChanged), HandlerCount(parser.OnWorkingDirectoryChanged)),
+        (nameof(parser.OnTitleChanged), HandlerCount(parser.OnTitleChanged)),
+        (nameof(parser.OnPromptReady), HandlerCount(parser.OnPromptReady)),
+        (nameof(parser.OnCommandAccepted), HandlerCount(parser.OnCommandAccepted)),
+        (nameof(parser.OnCommandStarted), HandlerCount(parser.OnCommandStarted)),
+        (nameof(parser.OnCommandFinished), HandlerCount(parser.OnCommandFinished)),
+        (nameof(parser.OnCommandFinishedDetailed), HandlerCount(parser.OnCommandFinishedDetailed)),
+    ];
+
+    [AvaloniaFact]
+    public void RewiringTheParser_ReplacesItRatherThanReusingIt()
+    {
+        using var pane = new TerminalPane();
+
+        pane.CreateAndWireParser();
+        AnsiParser? first = pane.Parser;
+        Assert.NotNull(first);
+
+        pane.CreateAndWireParser();
+        AnsiParser? second = pane.Parser;
+        Assert.NotNull(second);
+
+        Assert.False(
+            ReferenceEquals(first, second),
+            "Session setup reused the AnsiParser. Its 8 handler subscriptions are only safe because "
+            + "a fresh parser starts with empty handler lists - reusing one duplicates every handler "
+            + "per reconnect (#102). Either restore the fresh parser, or add a matching -= for each.");
+    }
+
+    [AvaloniaFact]
+    public void RewiringTheParser_LeavesExactlyOneHandlerPerHook()
+    {
+        using var pane = new TerminalPane();
+
+        // Twenty reconnects' worth. If the parser were reused, each hook would end up with 20
+        // handlers and a single bell would fire the pane's handler twenty times.
+        for (int i = 0; i < 20; i++)
+        {
+            pane.CreateAndWireParser();
+        }
+
+        Assert.NotNull(pane.Parser);
+        foreach ((string name, int count) in HookCounts(pane.Parser!))
+        {
+            Assert.Equal(1, count);
+        }
+    }
+
+    [AvaloniaFact]
+    public void TheSupersededParser_KeepsItsOwnHandlersAndIsSimplyDropped()
+    {
+        // Documents *why* not unsubscribing is acceptable: the old parser is not mutated or cleaned
+        // up, it is abandoned. Nothing feeds it once Session output goes to the new one, so its
+        // handlers are unreachable and collectible along with it.
+        using var pane = new TerminalPane();
+
+        pane.CreateAndWireParser();
+        AnsiParser? superseded = pane.Parser;
+        Assert.NotNull(superseded);
+
+        pane.CreateAndWireParser();
+
+        Assert.Equal(1, HandlerCount(superseded!.OnBell));
+        Assert.False(ReferenceEquals(superseded, pane.Parser));
+    }
+}

--- a/tests/NovaTerminal.App.Tests/Controls/PaneSubscriptionLifetimeTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneSubscriptionLifetimeTests.cs
@@ -87,7 +87,7 @@ public class PaneSubscriptionLifetimeTests
     }
 
     [AvaloniaFact]
-    public void DisposingAPane_RemovesEveryTermViewHandler()
+    public void DisposingAPane_RemovesTheResizeAndMetricsHandlers()
     {
         var pane = new TerminalPane();
         pane.WireReusedTermViewHandlers();
@@ -96,10 +96,64 @@ public class PaneSubscriptionLifetimeTests
 
         pane.Dispose();
 
-        // TermView is the pane's own child, so a residual handler is not a memory leak - but
-        // DetachFromUiThread's stated contract is that a disposed pane stops reacting, and one of
-        // these two MetricsChanged handlers used to stay attached because it was an uncached lambda.
+        // Scoped deliberately to these two: they are the ones DetachFromUiThread removes, and one of
+        // the MetricsChanged pair used to stay attached because it was an uncached lambda. The wider
+        // picture - which TermView handlers survive disposal, and that the set does not grow - is
+        // pinned by DisposingAPane_LeavesOnlyTheKnownConstructionTimeHandlers below.
         Assert.Equal(0, SubscriberCount(pane.TermView, "OnResize"));
         Assert.Equal(0, SubscriberCount(pane.TermView, "MetricsChanged"));
+    }
+
+    /// Every field-like event declared on TerminalView, so the inventory below cannot silently drift
+    /// as events are added.
+    private static string[] TermViewEventNames()
+    {
+        var names = new System.Collections.Generic.List<string>();
+        foreach (EventInfo e in typeof(NovaTerminal.Shell.TerminalView)
+                     .GetEvents(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly))
+        {
+            names.Add(e.Name);
+        }
+        names.Sort(StringComparer.Ordinal);
+        return names.ToArray();
+    }
+
+    [AvaloniaFact]
+    public void DisposingAPane_LeavesOnlyTheKnownConstructionTimeHandlers()
+    {
+        // A disposed pane does NOT end up with zero TermView handlers: the ~10 subscriptions made
+        // during construction (focus, key/text input, scroll, drop, search) are never removed. That
+        // is not a leak - TermView is the pane's own child and dies with it - but it does mean
+        // "a disposed pane stops reacting" holds only for the handlers listed in the assertion above.
+        //
+        // Rather than assert a number that says nothing, this pins the *set*: adding a new
+        // construction-time subscription without a matching detach will fail here with the event
+        // named, which is the point at which someone should decide whether it needs removing.
+        var pane = new TerminalPane();
+        pane.WireReusedTermViewHandlers();
+        pane.Dispose();
+
+        var residual = new System.Collections.Generic.List<string>();
+        foreach (string name in TermViewEventNames())
+        {
+            int count = SubscriberCount(pane.TermView, name);
+            if (count > 0) residual.Add($"{name}={count}");
+        }
+
+        string[] expected =
+        [
+            "BackspaceObserved=1",
+            "CommandAssistAnchorHintChanged=1",
+            "DropNotice=1",
+            "EnterObserved=1",
+            "PasteObserved=1",
+            "Ready=1",
+            "ScrollStateChanged=1",
+            "SearchStateChanged=1",
+            "TextFileDropped=1",
+            "TextInputObserved=1",
+        ];
+
+        Assert.Equal(expected, residual.ToArray());
     }
 }

--- a/tests/NovaTerminal.App.Tests/Controls/PaneSubscriptionLifetimeTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneSubscriptionLifetimeTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Reflection;
+using Avalonia.Headless.XUnit;
+using NovaTerminal.Controls;
+using NovaTerminal.Shell;
+using Xunit;
+
+namespace NovaTerminal.Tests.Controls;
+
+/// <summary>
+/// Standing guards for #102, which reported that <c>TerminalPane</c>'s event subscriptions were
+/// never removed and would accumulate on session-restart paths.
+///
+/// Audited against current <c>main</c>, the specific claims no longer hold — #154's
+/// <c>DetachFromUiThread</c> split and the cached-delegate pairs in session setup closed them. But
+/// "no longer holds" is only as good as the next edit, and the reasoning is non-obvious, so these
+/// tests pin the properties the safety actually rests on:
+///
+/// <list type="number">
+/// <item>The one subscription the pane makes on an app-lifetime singleton is removed on dispose, so
+/// opening and closing tabs does not pile handlers onto a global.</item>
+/// <item>Re-running session setup does not add a second copy of the handlers it puts on the pane's
+/// own long-lived <c>TermView</c> — the thing <c>Reconnect()</c> would otherwise do on every
+/// reconnect.</item>
+/// <item>A disposed pane has no <c>TermView</c> handlers left at all.</item>
+/// </list>
+///
+/// Everything else <c>InitializeSession</c> subscribes targets an object recreated with the session
+/// — a fresh <c>AnsiParser</c>, the new <c>ITerminalSession</c> — so those lists start empty by
+/// construction. That is the load-bearing assumption behind leaving 9 parser handlers unsubscribed,
+/// and it is pinned separately in <c>PaneReconnectTests</c> because it needs a real shell.
+/// </summary>
+public class PaneSubscriptionLifetimeTests
+{
+    /// Length of a field-like event's invocation list, or 0 when nothing is subscribed.
+    ///
+    /// Reads the compiler-generated backing field. There is no public way to count subscribers, and
+    /// counting is the whole point: asserting "the handler still works" would pass just as happily
+    /// with ten copies attached, which is the failure this file exists to catch.
+    private static int SubscriberCount(object target, string eventName)
+    {
+        Type type = target.GetType();
+        FieldInfo? field = null;
+        for (Type? t = type; t != null && field == null; t = t.BaseType)
+        {
+            field = t.GetField(eventName, BindingFlags.Instance | BindingFlags.NonPublic);
+        }
+
+        Assert.NotNull(field);
+        var handler = field!.GetValue(target) as Delegate;
+        return handler?.GetInvocationList().Length ?? 0;
+    }
+
+    [AvaloniaFact]
+    public void DisposingPanes_LeavesNoHandlersOnTheSftpSingleton()
+    {
+        // SftpService.Instance is the only app-lifetime object the pane subscribes to, which makes it
+        // the only subscription whose omission would accumulate across tab open/close — every other
+        // target dies with the pane or with the session.
+        int baseline = SubscriberCount(SftpService.Instance, nameof(SftpService.JobUpdated));
+
+        for (int i = 0; i < 10; i++)
+        {
+            var pane = new TerminalPane();
+            // Subscribed during construction, so this needs no session.
+            Assert.Equal(baseline + 1, SubscriberCount(SftpService.Instance, nameof(SftpService.JobUpdated)));
+            pane.Dispose();
+            Assert.Equal(baseline, SubscriberCount(SftpService.Instance, nameof(SftpService.JobUpdated)));
+        }
+    }
+
+    [AvaloniaFact]
+    public void RewiringSessionHandlers_DoesNotAccumulateOnTheReusedTermView()
+    {
+        using var pane = new TerminalPane();
+
+        // Construction attaches one MetricsChanged handler for layout; session setup adds one more of
+        // those plus OnResize. Repeating the session wiring must not move either number - that is
+        // what makes Reconnect() safe.
+        for (int i = 0; i < 20; i++)
+        {
+            pane.WireReusedTermViewHandlers();
+        }
+
+        Assert.Equal(1, SubscriberCount(pane.TermView, "OnResize"));
+        Assert.Equal(2, SubscriberCount(pane.TermView, "MetricsChanged"));
+    }
+
+    [AvaloniaFact]
+    public void DisposingAPane_RemovesEveryTermViewHandler()
+    {
+        var pane = new TerminalPane();
+        pane.WireReusedTermViewHandlers();
+        Assert.Equal(1, SubscriberCount(pane.TermView, "OnResize"));
+        Assert.Equal(2, SubscriberCount(pane.TermView, "MetricsChanged"));
+
+        pane.Dispose();
+
+        // TermView is the pane's own child, so a residual handler is not a memory leak - but
+        // DetachFromUiThread's stated contract is that a disposed pane stops reacting, and one of
+        // these two MetricsChanged handlers used to stay attached because it was an uncached lambda.
+        Assert.Equal(0, SubscriberCount(pane.TermView, "OnResize"));
+        Assert.Equal(0, SubscriberCount(pane.TermView, "MetricsChanged"));
+    }
+}


### PR DESCRIPTION
Re-scopes #102 rather than implementing it: the audit it describes was accurate when written, but the
defects it names have since been fixed. This pins the invariants that make them stay fixed.

## Why not just implement the proposed fix

#102 proposes unsubscribing ~40 handlers and suggests a `CompositeDisposable` helper registered at
each `+=` site. Checking each claim against `main` first:

| Claim | Status | Evidence |
|---|---|---|
| "9 Parser events … no `-=` in `Dispose()`" | **Not a leak.** A fresh `AnsiParser` is created per session, so handler lists start empty and the old parser is garbage along with its handlers. | the assignment at the top of `CreateAndWireParser` |
| "15+ TerminalView events subscribed during setup" | **Not a leak.** `TermView` is the pane's own XAML child — they die together. | `TerminalPane.axaml:50` |
| "session-restart paths … will accumulate handlers (duplicate bell/title)" | **False.** `Reconnect()` re-runs only `InitializeSession`, whose sole same-object subscriptions use remove-before-add. | `Reconnect()` → `InitializeSession`; `WireReusedTermViewHandlers` |
| "`_recordingToastTimer.Tick` … timer never stopped in `OnClosing`" | **Already stopped.** | `MainWindow.axaml.cs:5514` |
| "MainWindow `Loaded`/`Activated`/`SizeChanged` never unsubscribed" | Moot — single app-lifetime instance. | — |

I also checked the direction the issue doesn't mention, which is the one that *could* genuinely leak
— a long-lived object holding handlers on closed panes — and MainWindow already does remove-before-add
on all five pane events plus a detach path (`:2585-2618`).

So option C (the `CompositeDisposable` refactor) would touch every `+=` site across a 2400- and a
5800-line file, with dropped-or-duplicated UI events as the failure mode, to fix nothing currently
broken. Option B (add ~40 `-=`) needs ~40 new cached-delegate fields for the same return. This is
option A: prove the properties, keep the diff small.

## What the tests pin

Six tests over the three properties the current safety actually rests on:

1. **`SftpService.Instance` is the only cross-lifetime subscription, and it is removed on dispose.**
   Ten open/close cycles must return the singleton's invocation list to its baseline. This is the one
   omission that would have accumulated across tab churn.
2. **Re-running session setup does not double the handlers on the reused `TermView`.** Twenty wirings,
   counts unchanged — the thing `Reconnect()` would otherwise do.
3. **A fresh parser per session.** Two calls produce different instances; twenty leave exactly one
   handler per hook. This is the line that makes 8 unsubscribed parser handlers correct, and hoisting
   the parser out to reuse it — a reasonable-looking change — would silently double all 8 per
   reconnect.

Counting is done by reading invocation lists, deliberately: asserting "the handler still works" would
pass just as happily with twenty copies attached, which is the exact failure being guarded.

## Two production changes, both for testability

- **Extracted `WireReusedTermViewHandlers` and `CreateAndWireParser`** from `InitializeSession`. No
  behaviour change. My first attempt at (3) used a real shell and **could not start a session
  headless at all** — `TermView.Ready` needs font metrics that the headless platform doesn't provide
  — so this trades a flaky integration test for a deterministic unit test on the same invariant.
- **Cached the `SetupCommon` `MetricsChanged` lambda** so `DetachFromUiThread` can remove it. Found by
  the tests: as an uncached lambda it was the one `TermView` handler still attached after disposal,
  contradicting that method's stated contract ("so a disposed pane stops reacting"). Harmless in
  practice — it only re-runs this pane's own layout — but it made the invariant unassertable.

## Verification

**Mutation-verified per guard, not in aggregate:**

| Mutation | Result |
|---|---|
| Reuse the parser (`??=` instead of `=`) | 3 fail |
| Drop the `SftpService` unsubscribe | 1 fail |
| Leave the metrics-layout handler attached | 1 fail |
| Remove the remove-before-add in the TermView wiring | 1 fail |

**One finding worth flagging, because it contradicts the existing comment.** The idempotence does
*not* come from the `??=` delegate caching. I mutated `??=` to a plain assignment — a fresh delegate
every call — and everything still passed: these lambdas capture only `this`, so Roslyn emits an
instance method and delegate equality holds on target+method, making `-=` match anyway. **The
remove-before-add is what does the work.** The caching is harmless but is not the safety property, and
the old comment implied otherwise. I've left the caching in place (it avoids pointless allocation) and
corrected the reasoning in the doc comments.

`NovaTerminal.App.Tests`: 1250 passed, 1 failed — `TerminalPane_WhenRemotePromptSettlesLowOnShortPane_ResumesConservativeAssistLayout`,
which fails on clean `main` and is green in CI (same as #225–#229).

## Suggested disposition for #102

Close as fixed-by-#154-and-follow-ups, with these tests as the guard. The one thing I'd keep from the
original proposal is the *observation*, not the fix: the parser story is safe by construction rather
than by discipline, and that's now asserted rather than assumed.
