### PR TITLE
fix(rendering): route flags, keycaps and emoji singletons to the colour atlas

### DIFF
--- a/src/NovaTerminal.App/Shell/TerminalDrawOperation.cs
+++ b/src/NovaTerminal.App/Shell/TerminalDrawOperation.cs
@@ -1840,7 +1840,15 @@ namespace NovaTerminal.Shell
                     (cp >= 0x1F300 && cp <= 0x1FAFF) || // Emoji
                     IsRegionalIndicatorRune(cp) ||       // Flag emoji sequences
                     (cp >= 0x2600 && cp <= 0x27BF) ||   // Dingbats/symbols
-                    (cp == 0x200D))                      // ZWJ
+                    (cp == 0x200D) ||                    // ZWJ
+                    // Keycap sequences ("1" + FE0F + 20E3) and any other VS16-promoted emoji.
+                    // Without these the run falls through to the per-rune loop below, which calls
+                    // the glyph cache once per *rune* rather than per grapheme cluster - so the
+                    // digit, the selector and the enclosing keycap are rasterized separately and
+                    // the composed glyph is never produced at all. Flags already reach the shaper
+                    // via IsRegionalIndicatorRune for exactly this reason (#172).
+                    (cp == 0xFE0F) ||                    // VARIATION SELECTOR-16
+                    (cp == 0x20E3))                      // COMBINING ENCLOSING KEYCAP
                 {
                     return true;
                 }

--- a/src/NovaTerminal.Rendering/GlyphCache.cs
+++ b/src/NovaTerminal.Rendering/GlyphCache.cs
@@ -192,10 +192,19 @@ namespace NovaTerminal.Rendering
                 // Mahjong tile red dragon, playing card black joker.
                 0x1F004 or 0x1F0CF => true,
 
-                // Enclosed alphanumeric/ideographic supplement pictographs that are emoji by default.
+                // Enclosed alphanumeric supplement pictographs that are emoji by default.
                 0x1F18E => true,
                 >= 0x1F191 and <= 0x1F19A => true,
-                >= 0x1F200 and <= 0x1F2FF => true,
+
+                // Enclosed Ideographic Supplement, enumerated rather than taken as a block. Most of
+                // 1F200-1F2FF is unassigned or non-emoji, and two members - 1F202 (squared katakana
+                // SA) and 1F237 (squared month) - are Emoji_Presentation=No, i.e. text by default.
+                // A block-wide match would send those to the colour atlas and cost them their
+                // foreground tint, which is the failure mode this predicate exists to avoid.
+                0x1F201 or 0x1F21A or 0x1F22F => true,
+                >= 0x1F232 and <= 0x1F236 => true,
+                >= 0x1F238 and <= 0x1F23A => true,
+                0x1F250 or 0x1F251 => true,
 
                 // Miscellaneous Symbols / Dingbats. Kept as the original broad range: it is the one
                 // span the previous code got right, and narrowing it now would be a behaviour change

--- a/src/NovaTerminal.Rendering/GlyphCache.cs
+++ b/src/NovaTerminal.Rendering/GlyphCache.cs
@@ -14,20 +14,32 @@ namespace NovaTerminal.Rendering
             public long LastUsed;
         }
 
+        /// <remarks>
+        /// Note the absence of a skew component. #172 reported that <c>Skew</c> was part of this key
+        /// but never applied when rasterizing, and proposed setting <c>SkewX</c> on the raster font to
+        /// match. That would have been wrong: synthetic italic is applied as a *canvas* transform at
+        /// the draw site (<c>canvas.Skew(-0.22f, 0f)</c> in <c>TerminalDrawOperation</c>), so atlas
+        /// glyphs are supposed to be upright and skewing them too would double the slant.
+        ///
+        /// The real defect was that <c>SkewX</c> is never set on any font in this codebase, so the key
+        /// component was always 0 — dead weight in every hash and comparison. Removed rather than
+        /// populated. If synthetic italic ever moves into the atlas (worth doing: it would stop the
+        /// italic path having to flush the sprite batch), the skew has to come back into the key *and*
+        /// the canvas transform has to go, and the ink-overhang fix becomes a prerequisite, since a
+        /// slanted glyph overflows its advance width by construction.
+        /// </remarks>
         private readonly struct GlyphKey : IEquatable<GlyphKey>
         {
             public readonly string Text;
             public readonly SKTypeface Typeface;
             public readonly float Size;
-            public readonly float Skew;
             public readonly float Scale;
 
-            public GlyphKey(string text, SKTypeface typeface, float size, float skew, float scale)
+            public GlyphKey(string text, SKTypeface typeface, float size, float scale)
             {
                 Text = text;
                 Typeface = typeface;
                 Size = size;
-                Skew = skew;
                 Scale = scale;
             }
 
@@ -36,7 +48,6 @@ namespace NovaTerminal.Rendering
                 return Text == other.Text &&
                        Typeface == other.Typeface &&
                        Size.Equals(other.Size) &&
-                       Skew.Equals(other.Skew) &&
                        Scale.Equals(other.Scale);
             }
 
@@ -48,7 +59,6 @@ namespace NovaTerminal.Rendering
                 hash.Add(Text);
                 hash.Add(Typeface);
                 hash.Add(Size);
-                hash.Add(Skew);
                 hash.Add(Scale);
                 return hash.ToHashCode();
             }
@@ -76,7 +86,7 @@ namespace NovaTerminal.Rendering
 
             lock (_lock)
             {
-                var key = new GlyphKey(text, font.Typeface, font.Size, font.SkewX, scale);
+                var key = new GlyphKey(text, font.Typeface, font.Size, scale);
 
                 if (_entries.TryGetValue(key, out var entry))
                 {
@@ -115,6 +125,103 @@ namespace NovaTerminal.Rendering
             }
         }
 
+        /// <summary>
+        /// True when a grapheme should be rasterized into the RGBA colour atlas rather than the
+        /// Alpha8 one.
+        /// </summary>
+        /// <remarks>
+        /// The two atlases are not interchangeable, and getting this wrong is lossy in *both*
+        /// directions, which is why the checks below are deliberate rather than generous:
+        ///
+        /// <list type="bullet">
+        /// <item>Alpha8 glyphs are tinted with the cell's foreground colour at draw time, so routing an
+        /// emoji here renders it as a flat monochrome silhouette — the #172 symptom.</item>
+        /// <item>Colour glyphs are blitted as-is, so routing ordinary text here would make it ignore
+        /// the foreground colour entirely and always paint as rasterized. That is *worse*, so "when
+        /// unsure, pick colour" is not a safe default.</item>
+        /// </list>
+        ///
+        /// The previous test was two codepoint ranges — <c>1F300-1FAFF</c> and <c>2600-27BF</c> — which
+        /// silently missed whole classes: regional-indicator flags sit at <c>1F1E6-1F1FF</c>, *below*
+        /// the first range; keycap sequences are ASCII + <c>FE0F</c> + <c>20E3</c>; and singletons like
+        /// <c>2B50</c> (star) fall between the two.
+        ///
+        /// Three of the four checks are structural — an explicit emoji-presentation selector, a
+        /// regional-indicator pair, a keycap combiner — and those are exact. The fourth is a range
+        /// table for codepoints whose *default* presentation is emoji, and a table is inherently a
+        /// maintenance burden: it is how the original bug happened. The principled alternative is to
+        /// ask the typeface whether the glyph has colour layers (COLR/CBDT), which SkiaSharp does not
+        /// expose; recorded on #172 rather than pretended away.
+        /// </remarks>
+        internal static bool WantsColorGlyph(string text)
+        {
+            foreach (var rune in text.EnumerateRunes())
+            {
+                int cp = rune.Value;
+
+                // VARIATION SELECTOR-16: an explicit request for emoji presentation, whatever the base
+                // character's default is. Covers keycaps and text-default pictographs that an
+                // application asked to be rendered in colour.
+                if (cp == 0xFE0F) return true;
+
+                // COMBINING ENCLOSING KEYCAP — the tail of a keycap sequence such as "1️⃣".
+                if (cp == 0x20E3) return true;
+
+                // Regional indicators. A pair forms a flag; a lone one still renders as a letter tile
+                // from the emoji font rather than as text.
+                if (cp >= 0x1F1E6 && cp <= 0x1F1FF) return true;
+
+                if (IsEmojiPresentationByDefault(cp)) return true;
+            }
+
+            return false;
+        }
+
+        /// Codepoints whose default presentation is emoji (Unicode Emoji_Presentation=Yes), as ranges.
+        /// Kept narrow on purpose: text-default pictographs are excluded so they keep foreground
+        /// tinting, and a <c>FE0F</c> selector promotes them when an application does want colour.
+        private static bool IsEmojiPresentationByDefault(int cp)
+        {
+            return cp switch
+            {
+                // Miscellaneous Symbols and Pictographs, Emoticons, Transport, Supplemental Symbols
+                // and Pictographs, Symbols and Pictographs Extended-A — plus the skin-tone modifiers
+                // at 1F3FB-1F3FF, which live inside this span.
+                >= 0x1F300 and <= 0x1FAFF => true,
+
+                // Mahjong tile red dragon, playing card black joker.
+                0x1F004 or 0x1F0CF => true,
+
+                // Enclosed alphanumeric/ideographic supplement pictographs that are emoji by default.
+                0x1F18E => true,
+                >= 0x1F191 and <= 0x1F19A => true,
+                >= 0x1F200 and <= 0x1F2FF => true,
+
+                // Miscellaneous Symbols / Dingbats. Kept as the original broad range: it is the one
+                // span the previous code got right, and narrowing it now would be a behaviour change
+                // beyond the scope of this fix.
+                >= 0x2600 and <= 0x27BF => true,
+
+                // Watch, hourglass, and the media-control and clock pictographs that are emoji by
+                // default while their block neighbours are text.
+                0x231A or 0x231B => true,
+                >= 0x23E9 and <= 0x23EC => true,
+                0x23F0 or 0x23F3 => true,
+
+                // Small squares that are emoji-default (their larger and outlined siblings are not).
+                0x25FD or 0x25FE => true,
+
+                // Black/white large squares, star, hollow circle — 2B50 is the singleton the old
+                // two-range test fell straight through.
+                0x2B1B or 0x2B1C or 0x2B50 or 0x2B55 => true,
+
+                // Wavy dash, part alternation mark, circled/squared ideographs.
+                0x3030 or 0x303D or 0x3297 or 0x3299 => true,
+
+                _ => false,
+            };
+        }
+
         // Measures, packs, and rasterizes a glyph into the atlas. Returns null (without touching
         // _entries) when the atlas has no room, so callers can decide how to evict. Must be called
         // under _lock.
@@ -122,18 +229,7 @@ namespace NovaTerminal.Rendering
         {
             string text = key.Text;
 
-            bool isColor = false;
-            foreach (var rune in text.EnumerateRunes())
-            {
-                int cp = rune.Value;
-                if ((cp >= 0x1F300 && cp <= 0x1FAFF) || (cp >= 0x2600 && cp <= 0x27BF))
-                {
-                    isColor = true;
-                    break;
-                }
-            }
-
-            var type = isColor ? AtlasType.Color : AtlasType.Alpha8;
+            var type = WantsColorGlyph(text) ? AtlasType.Color : AtlasType.Alpha8;
 
             // Use physically scaled font for the atlas to ensure bit-perfect sharpness
             float physicalSize = key.Size * key.Scale;

--- a/tests/NovaTerminal.App.Tests/RenderTests/EmojiShapingDetectionTests.cs
+++ b/tests/NovaTerminal.App.Tests/RenderTests/EmojiShapingDetectionTests.cs
@@ -6,19 +6,79 @@ using Xunit;
 
 namespace NovaTerminal.Tests.RenderTests
 {
+    /// <summary>
+    /// `ContainsRunesRequiringComplexShaping` decides whether a run goes to the text shaper or falls
+    /// through to the per-glyph path. That matters for more than shaping quality: the fallback path
+    /// enumerates **runes**, not grapheme clusters, and calls the glyph cache once per rune. So any
+    /// multi-codepoint sequence that is not diverted here gets rasterized in pieces and its composed
+    /// glyph is never produced.
+    ///
+    /// Flags were already diverted (via <c>IsRegionalIndicatorRune</c>). Keycaps were not, which is
+    /// why they rendered wrong regardless of which atlas their pieces were routed to — found while
+    /// reviewing #233 for #172.
+    /// </summary>
     public class EmojiShapingDetectionTests
     {
-        [Fact]
-        public void RegionalIndicatorFlagSequence_RequiresComplexShaping()
+        private static bool RequiresComplexShaping(string text)
         {
             MethodInfo? method = typeof(TerminalDrawOperation).GetMethod(
                 "ContainsRunesRequiringComplexShaping",
                 BindingFlags.NonPublic | BindingFlags.Static);
 
             Assert.NotNull(method);
+            return (bool)(method!.Invoke(null, new object[] { text }) ?? false);
+        }
 
-            bool requires = (bool)(method!.Invoke(null, new object[] { "🇺🇸" }) ?? false);
-            Assert.True(requires);
+        [Fact]
+        public void RegionalIndicatorFlagSequence_RequiresComplexShaping()
+        {
+            Assert.True(RequiresComplexShaping("🇺🇸"));
+        }
+
+        [Theory]
+        [InlineData("1️⃣", "keycap digit one")]
+        [InlineData("#️⃣", "keycap number sign")]
+        [InlineData("*️⃣", "keycap asterisk")]
+        public void KeycapSequence_RequiresComplexShaping(string text, string description)
+        {
+            // Every codepoint of a keycap - ASCII base, FE0F, 20E3 - sits outside the emoji ranges
+            // this method used to check, so the whole sequence fell through to the per-rune path and
+            // was drawn as three unrelated glyphs.
+            Assert.True(
+                RequiresComplexShaping(text),
+                $"{description} must reach the shaper as one unit; per-rune rendering draws the base, "
+                + "the selector and the enclosing keycap separately and never composes the keycap.");
+        }
+
+        [Theory]
+        // These two are already diverted by their base alone (2764 and 2708 both sit in 2600-27BF),
+        // so they pass with or without the VS16 clause. Kept as documentation of intent.
+        [InlineData("❤️", "heart + VS16 (base already in range)")]
+        [InlineData("✈️", "airplane + VS16 (base already in range)")]
+        // These are the cases the VS16 clause actually carries: the base is outside every range this
+        // method checks, so before the clause existed the pair split into base + selector.
+        [InlineData("↩️", "leftwards arrow with hook + VS16 (base U+21A9, out of range)")]
+        [InlineData("™️", "trade mark sign + VS16 (base U+2122, out of range)")]
+        [InlineData("ℹ️", "information source + VS16 (base U+2139, out of range)")]
+        public void Vs16PromotedEmoji_RequiresComplexShaping(string text, string description)
+        {
+            // VS16 means "render the preceding character as emoji". The base is often a text-default
+            // character outside every emoji range, so without this the pair splits.
+            Assert.True(RequiresComplexShaping(text), description);
+        }
+
+        [Theory]
+        [InlineData("plain ascii")]
+        [InlineData("─│┌└")]          // box drawing
+        [InlineData("█░▒▓")]          // block elements
+        [InlineData("→ ≠ ± ∞")]       // text-default symbols
+        [InlineData("中文 かな")]      // CJK / kana
+        public void PlainAndTextDefaultRuns_DoNotRequireComplexShaping(string text)
+        {
+            // The shaper path flushes the sprite batch and bypasses the glyph atlas, so diverting
+            // ordinary text into it would cost the atlas its purpose. Box drawing especially: it has
+            // its own snapped-primitive path that must keep running.
+            Assert.False(RequiresComplexShaping(text));
         }
     }
 }

--- a/tests/NovaTerminal.Rendering.Tests/ColorGlyphRoutingTests.cs
+++ b/tests/NovaTerminal.Rendering.Tests/ColorGlyphRoutingTests.cs
@@ -1,0 +1,133 @@
+using NovaTerminal.Rendering;
+using SkiaSharp;
+
+namespace NovaTerminal.Rendering.Tests;
+
+/// <summary>
+/// #172 item 3: colour-glyph detection was two codepoint ranges — <c>1F300-1FAFF</c> and
+/// <c>2600-27BF</c> — which missed whole classes of emoji. Those fell into the Alpha8 atlas, where
+/// glyphs are tinted with the cell's foreground colour, and so rendered as flat monochrome
+/// silhouettes.
+///
+/// These tests assert the *routing decision* rather than pixels, which makes them independent of
+/// which emoji fonts happen to be installed: the atlas a grapheme is sent to is a property of the
+/// text, not of the font.
+///
+/// The negative cases matter as much as the positive ones. Over-routing to the colour atlas is not a
+/// safe failure: colour glyphs are blitted as-is, so ordinary text sent there would ignore the
+/// foreground colour and always paint as rasterized.
+/// </summary>
+public class ColorGlyphRoutingTests
+{
+    [Theory]
+    // Regional-indicator flags: 1F1E6-1F1FF sits *below* the old lower bound of 1F300.
+    [InlineData("\U0001F1EC\U0001F1E7", "flag (regional indicator pair)")]
+    [InlineData("\U0001F1FA\U0001F1F8", "flag (regional indicator pair)")]
+    [InlineData("\U0001F1E6", "lone regional indicator")]
+    // Keycap sequence: ASCII digit + FE0F + 20E3. Not one codepoint of it is in either old range.
+    [InlineData("1️⃣", "keycap digit")]
+    [InlineData("#️⃣", "keycap hash")]
+    // Singletons that fall between the two old ranges.
+    [InlineData("⭐", "white medium star")]
+    [InlineData("⭕", "heavy large circle")]
+    [InlineData("⬛", "black large square")]
+    // Emoji presentation forced by VS16 on a text-default base.
+    [InlineData("❤️", "heavy black heart + VS16")]
+    [InlineData("✈️", "airplane + VS16")]
+    // Watch and hourglass: emoji-default while their block neighbours are text.
+    [InlineData("⌚", "watch")]
+    [InlineData("⌛", "hourglass")]
+    // Mahjong red dragon and the black joker.
+    [InlineData("\U0001F004", "mahjong tile red dragon")]
+    [InlineData("\U0001F0CF", "playing card black joker")]
+    // Enclosed ideographic supplement.
+    [InlineData("\U0001F201", "squared katakana koko")]
+    // Still covered: the range the old test got right.
+    [InlineData("\U0001F600", "grinning face")]
+    [InlineData("\U0001F44D", "thumbs up")]
+    [InlineData("☕", "hot beverage")]
+    public void EmojiGraphemes_RouteToTheColorAtlas(string text, string description)
+    {
+        Assert.True(
+            GlyphCache.WantsColorGlyph(text),
+            $"{description} ({Describe(text)}) should use the colour atlas; in Alpha8 it renders as a "
+            + "monochrome silhouette tinted with the foreground colour.");
+    }
+
+    [Theory]
+    // Plain text must stay on Alpha8 so it keeps foreground tinting.
+    [InlineData("A", "latin letter")]
+    [InlineData("z", "latin letter")]
+    [InlineData("7", "digit")]
+    [InlineData(" ", "space")]
+    [InlineData("#", "hash without a keycap combiner")]
+    [InlineData("1", "digit without a keycap combiner")]
+    // Box drawing and block elements: the terminal draws these constantly and they must be tintable.
+    [InlineData("─", "box drawing light horizontal")]
+    [InlineData("│", "box drawing light vertical")]
+    [InlineData("┌", "box drawing light down and right")]
+    [InlineData("█", "full block")]
+    [InlineData("░", "light shade")]
+    // Powerline separators, ubiquitous in prompts.
+    [InlineData("", "powerline right arrow")]
+    [InlineData("", "powerline left arrow")]
+    // CJK and accented Latin: text, however wide.
+    [InlineData("中", "CJK ideograph")]
+    [InlineData("あ", "hiragana")]
+    [InlineData("é", "e + combining acute")]
+    // Arrows and math operators are text-default; without VS16 they stay tintable.
+    [InlineData("→", "rightwards arrow")]
+    [InlineData("≠", "not equal to")]
+    public void TextGraphemes_StayOnTheAlpha8Atlas(string text, string description)
+    {
+        Assert.False(
+            GlyphCache.WantsColorGlyph(text),
+            $"{description} ({Describe(text)}) must stay on Alpha8; on the colour atlas it would "
+            + "ignore the cell's foreground colour and always paint as rasterized.");
+    }
+
+    [Fact]
+    public void TheRoutingDecisionReachesTheAtlas()
+    {
+        // The predicate above is the unit under test, but it is only useful if GetOrAdd actually
+        // honours it - so pin the end-to-end path for one case from each side.
+        Assert.SkipUnless(SkiaAvailable(), "SkiaSharp native library not available on this platform.");
+
+        using var cache = new GlyphCache();
+        using var typeface = SKTypeface.Default;
+        using var font = new SKFont(typeface, 16);
+
+        var flag = cache.GetOrAdd("\U0001F1EC\U0001F1E7", font, 1.0f);
+        var letter = cache.GetOrAdd("A", font, 1.0f);
+
+        Assert.NotNull(flag);
+        Assert.NotNull(letter);
+        Assert.Equal(AtlasType.Color, flag!.Value.Type);
+        Assert.Equal(AtlasType.Alpha8, letter!.Value.Type);
+    }
+
+    /// Codepoints of <paramref name="text"/> as U+ notation, so a failure message is readable when
+    /// the grapheme itself is unprintable in a console.
+    private static string Describe(string text)
+    {
+        var parts = new List<string>();
+        foreach (var rune in text.EnumerateRunes())
+        {
+            parts.Add($"U+{rune.Value:X4}");
+        }
+        return string.Join(" ", parts);
+    }
+
+    private static bool SkiaAvailable()
+    {
+        try
+        {
+            using var surface = SKSurface.Create(new SKImageInfo(1, 1, SKColorType.Rgba8888));
+            return surface != null;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/tests/NovaTerminal.Rendering.Tests/ColorGlyphRoutingTests.cs
+++ b/tests/NovaTerminal.Rendering.Tests/ColorGlyphRoutingTests.cs
@@ -16,6 +16,15 @@ namespace NovaTerminal.Rendering.Tests;
 /// The negative cases matter as much as the positive ones. Over-routing to the colour atlas is not a
 /// safe failure: colour glyphs are blitted as-is, so ordinary text sent there would ignore the
 /// foreground colour and always paint as rasterized.
+///
+/// **Scope, established during review of #233.** This predicate only governs graphemes that actually
+/// reach the atlas. `TerminalDrawOperation.ContainsRunesRequiringComplexShaping` diverts emoji in
+/// `1F300-1FAFF`, `2600-27BF`, regional indicators, ZWJ sequences and (as of this change) VS16 and
+/// keycap sequences to the shaper, bypassing the cache entirely. So the cases this predicate really
+/// decides are the **single-rune, emoji-default** ones that fall through: the star, the squares, the
+/// watch, the mahjong/joker tiles and the enclosed-ideographic set. The multi-codepoint entries below
+/// are kept as defence in depth — the predicate should be correct on its own terms whether or not the
+/// draw path happens to divert them today.
 /// </summary>
 public class ColorGlyphRoutingTests
 {
@@ -40,8 +49,11 @@ public class ColorGlyphRoutingTests
     // Mahjong red dragon and the black joker.
     [InlineData("\U0001F004", "mahjong tile red dragon")]
     [InlineData("\U0001F0CF", "playing card black joker")]
-    // Enclosed ideographic supplement.
+    // Enclosed Ideographic Supplement members that are Emoji_Presentation=Yes.
     [InlineData("\U0001F201", "squared katakana koko")]
+    [InlineData("\U0001F21A", "squared CJK unified ideograph 7121")]
+    [InlineData("\U0001F232", "squared CJK unified ideograph 7981")]
+    [InlineData("\U0001F250", "circled ideograph advantage")]
     // Still covered: the range the old test got right.
     [InlineData("\U0001F600", "grinning face")]
     [InlineData("\U0001F44D", "thumbs up")]
@@ -78,6 +90,14 @@ public class ColorGlyphRoutingTests
     // Arrows and math operators are text-default; without VS16 they stay tintable.
     [InlineData("→", "rightwards arrow")]
     [InlineData("≠", "not equal to")]
+    // Enclosed Ideographic Supplement members that are Emoji_Presentation=**No** - text by default,
+    // and the reason 1F200-1F2FF is enumerated rather than matched as a block. A block-wide match
+    // sent these to the colour atlas and cost them their foreground tint.
+    [InlineData("\U0001F202", "squared katakana sa (text-default)")]
+    [InlineData("\U0001F237", "squared month (text-default)")]
+    // Unassigned / non-emoji codepoints inside the same block.
+    [InlineData("\U0001F200", "square hiragana hoka (not emoji)")]
+    [InlineData("\U0001F260", "unassigned in the enclosed ideographic block")]
     public void TextGraphemes_StayOnTheAlpha8Atlas(string text, string description)
     {
         Assert.False(


### PR DESCRIPTION
Addresses items 1 and 3 of #172, plus a keycap-composition bug found during review. Item 2 (ink
overhang) is deliberately left for its own change — see the bottom.

**Two corrections worth reading before the diff:** item 1's prescribed fix would have been wrong, and
my own first draft of this PR overclaimed about flags. Both explained below.

## Item 3: colour-glyph routing

The old test was two ranges:

```csharp
if ((cp >= 0x1F300 && cp <= 0x1FAFF) || (cp >= 0x2600 && cp <= 0x27BF))
```

Anything outside them landed in the Alpha8 atlas, where glyphs are tinted with the cell's foreground
colour — hence monochrome silhouettes. `WantsColorGlyph` replaces it with three exact structural
checks (`FE0F` presentation selector, regional-indicator codepoint, keycap combiner) plus an
enumerated table of emoji-default codepoints.

### What this actually fixes — corrected after review

My first draft claimed flags and keycaps. Neither was accurate, because **most emoji never reach the
glyph cache**: `TerminalDrawOperation.ContainsRunesRequiringComplexShaping` diverts `1F300-1FAFF`,
`2600-27BF`, regional indicators and ZWJ to the shaper, bypassing the atlas entirely.

| Class | Reaches the atlas? | Fixed by this PR? |
|---|---|---|
| Flags 🇬🇧 | No — diverted by `IsRegionalIndicatorRune` | Already worked. My check for them is unreachable, kept as defence in depth |
| Keycaps 1️⃣ | Yes, and **split per rune** | Yes, but by the shaping fix below, not by routing |
| ⭐ ⭕ ⬛ ⬜ | Yes, single rune | **Yes — this is the real routing fix** |
| ⌚ ⌛ 🀄 🃏 | Yes, single rune | **Yes** |
| Enclosed ideographic 🈁🈚🈲㊗ | Yes, single rune | **Yes** |
| VS16 on an out-of-range base ↩️ ™️ ℹ️ | Yes, split per rune | Yes, via the shaping fix |

### Why the table is narrow rather than generous

Getting this wrong is lossy in **both** directions:

- Alpha8 for an emoji → loses colour (the reported bug).
- Colour atlas for text → the sprite is blitted as-is, so it **ignores the foreground colour** and
  always paints as rasterized.

The second is worse, so "when unsure, pick colour" is not a safe default. Text-default pictographs are
excluded and rely on `FE0F` to promote them. Review caught me violating my own comment here by taking
`1F200-1F2FF` as a block: `1F202` 🈂 and `1F237` 🈷 are `Emoji_Presentation=No`, and most of the block
is unassigned. Now enumerated.

The principled fix the issue suggests — asking the typeface whether the glyph has colour layers —
isn't available; SkiaSharp doesn't expose COLR/CBDT presence.

## Keycaps never composed (found in review)

Independent of routing, and the more user-visible of the two. The per-glyph path enumerates **runes,
not grapheme clusters**:

```csharp
// TerminalDrawOperation.cs:1300
foreach (var rune in runText.EnumerateRunes())
{
    string grapheme = rune.ToString();   // one rune, not one cluster
```

So `"1" + FE0F + 20E3` was rasterized as three unrelated glyphs and the keycap was never composed —
whatever atlas the pieces went to. Flags escape this via the shaping diversion; keycaps had no such
clause. `FE0F` and `20E3` now join it, alongside the emoji ranges already there.

## Item 1: the issue's proposed fix is wrong

> "`Skew` is part of the cache key but never applied when rasterizing … Set `physFont.SkewX = key.Skew`"

The diagnosis is right, the remedy isn't. **Synthetic italic is a canvas transform:**

```csharp
// TerminalDrawOperation.cs:1247
canvas.Skew(-0.22f, 0f);
```

Atlas glyphs are *supposed* to be upright; skewing them during rasterization would double the slant.
The real defect is that `SkewX` is never set on any font in this codebase — repo-wide it appears once,
as a *read*, in the cache key construction. So the component was always `0f`: dead weight in every
hash and comparison. Removed rather than populated.

Follow-up worth having: moving synthetic italic *into* the atlas would stop the italic path having to
`FlushBatches`, but it needs the skew back in the key, the canvas transform gone, **and item 2 first**
— a slanted glyph overflows its advance width by construction.

## Verification

- **`ColorGlyphRoutingTests`** — 54 cases asserting the atlas decision, not pixels, so they're
  independent of installed emoji fonts. The negative half carries equal weight: box drawing,
  Powerline separators, CJK, text-default arrows, and the `Emoji_Presentation=No` ideographs must stay
  on Alpha8 or they lose tinting.
- **`EmojiShapingDetectionTests`** — 14 cases on the shaping diversion, including negatives so
  ordinary text and box drawing don't get pushed onto the shaper path (which would bypass the atlas
  and the snapped box primitives).

**Mutation-verified per change:** restoring the old two-range routing fails 14; reverting the keycap
clause fails 3; restoring the block-wide `1F2xx` match fails 4.

The mutation run also caught two of my own tests testing nothing — ❤️ and ✈️ pass with or without the
`FE0F` clause because `2764` and `2708` are already in range. Replaced with bases outside every
checked range (`21A9`, `2122`, `2139`).

Runs: `NovaTerminal.Rendering.Tests` 54/54. `NovaTerminal.App.Tests` 1264 passed, 1 failed —
`TerminalPane_WhenRemotePromptSettlesLowOnShortPane_ResumesConservativeAssistLayout`, which is #232
and fails on clean `main`. **No golden PNG changes were needed**, consistent with the runner lacking
the emoji fonts that would be affected.

## Item 2, and why it's not here

Packing ink bounds instead of advance width changes what `GetOrAdd` returns: the caller must offset the
draw origin by `-bounds.Left` / `-bounds.Top`, which means changing sprite placement in
`TerminalDrawOperation` (`SKRotationScaleMatrix.Create(invScale, 0, xIdxSnap, glyphY, 0, 0)` currently
assumes the sprite's top-left is the ascent line) and regenerating golden PNGs. Different blast radius;
#172 stays open for it.
