### PR TITLE
perf(vt): stop allocating a string per grapheme on the write path

### DIFF
--- a/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
@@ -786,7 +786,7 @@ namespace NovaTerminal.VT
             return matches;
         }
 
-        public int GetGraphemeWidth(string textElement)
+        public int GetGraphemeWidth(ReadOnlySpan<char> textElement)
         {
             return UnicodeWidth.GetGraphemeWidth(textElement);
         }

--- a/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
@@ -34,7 +34,9 @@ namespace NovaTerminal.VT
                 Theme = source.Theme;
                 _cursorRow = source._cursorRow;
                 _cursorCol = source._cursorCol;
-                _getGraphemeWidth = source.GetGraphemeWidth;
+                // Lambda, not a method group: GetGraphemeWidth takes a span now (#165) and does not
+                // match Func<string, int> directly. The reflow engine works in strings throughout.
+                _getGraphemeWidth = text => source.GetGraphemeWidth(text);
             }
 
             public void Execute(int oldCols, int oldRows, int newCols, int newRows)

--- a/src/NovaTerminal.VT/TerminalBuffer.WritePath.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.WritePath.cs
@@ -147,16 +147,50 @@ namespace NovaTerminal.VT
         private void WriteContentCore(string text)
         {
             FlushGrapheme(); // Ensure any single char buffered by WriteChar is handled
-            var enumerator = StringInfo.GetTextElementEnumerator(text);
-            while (enumerator.MoveNext())
+
+            // Every printable character of all output comes through here, so the segmentation used
+            // to dominate allocation: StringInfo.GetTextElementEnumerator boxes an enumerator and
+            // GetTextElement() allocates a *string per grapheme* — for plain ASCII, one string per
+            // character. Cat-ing a large file produced garbage on the order of gigabytes (#165).
+            //
+            // GetNextTextElementLength gives the same segmentation over a span without allocating,
+            // and WriteGraphemeInternal now takes a span, so a string is only materialized when one
+            // actually has to be stored (an extended-grapheme side-table entry).
+            ReadOnlySpan<char> remaining = text.AsSpan();
+            while (!remaining.IsEmpty)
             {
-                WriteGraphemeInternal(enumerator.GetTextElement());
+                int length = NextTextElementLength(remaining);
+                WriteGraphemeInternal(remaining.Slice(0, length));
+                remaining = remaining.Slice(length);
             }
         }
 
-        private void WriteGraphemeInternal(string grapheme)
+        /// <summary>
+        /// Length of the grapheme cluster starting at index 0, with a fast path for ASCII.
+        /// </summary>
+        /// <remarks>
+        /// The fast path is exact rather than approximate: every character that can extend a cluster
+        /// — combining marks, variation selectors, ZWJ, regional indicators, surrogates — is at
+        /// U+0300 or above, so an ASCII character followed by another ASCII character is always a
+        /// complete cluster on its own. That covers the overwhelming majority of terminal output
+        /// without consulting the segmentation tables at all.
+        /// </remarks>
+        private static int NextTextElementLength(ReadOnlySpan<char> text)
         {
-            if (string.IsNullOrEmpty(grapheme)) return;
+            char first = text[0];
+            if (first < 0x80 && (text.Length == 1 || text[1] < 0x80))
+            {
+                return 1;
+            }
+
+            return StringInfo.GetNextTextElementLength(text);
+        }
+
+        // Span, not string: WriteContentCore segments without allocating, and a string is only
+        // materialized below where one has to be stored in a side table (#165).
+        private void WriteGraphemeInternal(ReadOnlySpan<char> grapheme)
+        {
+            if (grapheme.IsEmpty) return;
 
             // Guard against lone surrogates from broken UTF-8 (e.g. Yazi on WSL via ConPTY).
             // EnumerateRunes().First() internally calls new Rune(char) which throws on surrogates.
@@ -168,7 +202,12 @@ namespace NovaTerminal.VT
             }
             else
             {
-                firstRune = grapheme.EnumerateRunes().FirstOrDefault(new Rune('?'));
+                // Was EnumerateRunes().FirstOrDefault(...), which boxed the struct enumerator via
+                // LINQ once per multi-char grapheme (#165).
+                if (Rune.DecodeFromUtf16(grapheme, out firstRune, out _) != System.Buffers.OperationStatus.Done)
+                {
+                    firstRune = new Rune('?');
+                }
             }
             bool isZeroWidthComponent = UnicodeWidth.IsZeroWidthGraphemeComponent(firstRune);
 
@@ -231,7 +270,10 @@ namespace NovaTerminal.VT
                             goto NormalWrite;
                         }
 
-                        string merged = existing + grapheme;
+                        // Concatenation has to allocate here regardless: the merged cluster is stored
+                        // in the side table. string.Concat(span, span) avoids the interim allocation
+                        // an implicit ToString() would add.
+                        string merged = string.Concat(existing.AsSpan(), grapheme);
                         row.SetExtendedText(attachCol, merged);
                         cell.HasExtendedText = true;
                         cell.IsDirty = true; // Force redraw
@@ -328,7 +370,7 @@ NormalWrite:
                 row.Cells[_cursorCol] = new TerminalCell(grapheme[0], _packedFg, _packedBg, flags);
                 if ((flags & (ushort)TerminalCellFlags.HasExtendedText) != 0)
                 {
-                    row.SetExtendedText(_cursorCol, grapheme);
+                    row.SetExtendedText(_cursorCol, grapheme.ToString());
                 }
                 row.SetHyperlink(_cursorCol, _currentHyperlink);
 
@@ -378,9 +420,9 @@ NormalWrite:
             _cursorRow = Math.Min(_cursorRow + 1, Rows - 1);
         }
 
-        private bool IsLastRuneZwj(string grapheme)
+        private bool IsLastRuneZwj(ReadOnlySpan<char> grapheme)
         {
-            if (string.IsNullOrEmpty(grapheme)) return false;
+            if (grapheme.IsEmpty) return false;
             // ZWJ is U+200D
             foreach (var rune in grapheme.EnumerateRunes())
             {

--- a/src/NovaTerminal.VT/UnicodeWidth.cs
+++ b/src/NovaTerminal.VT/UnicodeWidth.cs
@@ -6,9 +6,11 @@ namespace NovaTerminal.VT;
 
 public static class UnicodeWidth
 {
-    public static int GetGraphemeWidth(string textElement)
+    // Takes a span rather than a string so the VT write path can measure a grapheme without
+    // materializing one (#165). string converts implicitly, so existing callers are unaffected.
+    public static int GetGraphemeWidth(ReadOnlySpan<char> textElement)
     {
-        if (string.IsNullOrEmpty(textElement))
+        if (textElement.IsEmpty)
         {
             return 0;
         }
@@ -172,9 +174,10 @@ public static class UnicodeWidth
         return false;
     }
 
-    public static bool ShouldAttachToPrevious(string previousGrapheme, string incomingGrapheme, bool previousEndedWithZwj)
+    // Spans, for the same reason as GetGraphemeWidth (#165).
+    public static bool ShouldAttachToPrevious(ReadOnlySpan<char> previousGrapheme, ReadOnlySpan<char> incomingGrapheme, bool previousEndedWithZwj)
     {
-        if (string.IsNullOrEmpty(previousGrapheme) || string.IsNullOrEmpty(incomingGrapheme))
+        if (previousGrapheme.IsEmpty || incomingGrapheme.IsEmpty)
         {
             return false;
         }
@@ -197,12 +200,22 @@ public static class UnicodeWidth
         return false;
     }
 
-    public static bool IsRegionalIndicatorCluster(string text)
-        => CountRegionalIndicators(text) > 0 && text.EnumerateRunes().All(IsRegionalIndicator);
-
-    public static bool IsSingleRegionalIndicator(string text)
+    public static bool IsRegionalIndicatorCluster(ReadOnlySpan<char> text)
     {
-        if (string.IsNullOrEmpty(text))
+        if (CountRegionalIndicators(text) == 0) return false;
+
+        // Was `text.EnumerateRunes().All(IsRegionalIndicator)`; the LINQ call boxed the struct
+        // enumerator on a path the write loop reaches per grapheme (#165).
+        foreach (var rune in text.EnumerateRunes())
+        {
+            if (!IsRegionalIndicator(rune)) return false;
+        }
+        return true;
+    }
+
+    public static bool IsSingleRegionalIndicator(ReadOnlySpan<char> text)
+    {
+        if (text.IsEmpty)
         {
             return false;
         }
@@ -225,9 +238,9 @@ public static class UnicodeWidth
         return count == 1;
     }
 
-    public static int CountRegionalIndicators(string text)
+    public static int CountRegionalIndicators(ReadOnlySpan<char> text)
     {
-        if (string.IsNullOrEmpty(text))
+        if (text.IsEmpty)
         {
             return 0;
         }
@@ -262,9 +275,9 @@ public static class UnicodeWidth
     private static bool IsEmojiRange(Rune rune)
         => rune.Value >= 0x1F000 && rune.Value <= 0x1FBFF;
 
-    private static bool TryGetFirstRune(string text, out Rune rune)
+    private static bool TryGetFirstRune(ReadOnlySpan<char> text, out Rune rune)
     {
-        if (string.IsNullOrEmpty(text))
+        if (text.IsEmpty)
         {
             rune = default;
             return false;

--- a/tests/NovaTerminal.VT.Tests/WritePathAllocationTests.cs
+++ b/tests/NovaTerminal.VT.Tests/WritePathAllocationTests.cs
@@ -1,0 +1,192 @@
+using System;
+using NovaTerminal.VT;
+
+namespace NovaTerminal.VT.Tests;
+
+/// <summary>
+/// #165: every printable character of all output went through
+/// <c>StringInfo.GetTextElementEnumerator</c> + <c>GetTextElement()</c> — a boxed enumerator plus a
+/// string allocation per grapheme, which for plain ASCII is one string per character. Cat-ing a large
+/// file allocated on the order of gigabytes of garbage.
+///
+/// These assert on <see cref="GC.GetAllocatedBytesForCurrentThread"/> rather than on wall-clock time,
+/// so they are deterministic and meaningful on a shared CI runner. The ceilings are per-character
+/// budgets with generous headroom: the point is to catch a return to per-character *string*
+/// allocation, not to pin an exact number that innocuous changes would break.
+/// </summary>
+public class WritePathAllocationTests
+{
+    /// Allocated bytes attributable to <paramref name="action"/>, after a warm-up pass so first-call
+    /// JIT and lazily-initialized Unicode tables are not counted.
+    private static long MeasureAllocations(Action warmup, Action action)
+    {
+        warmup();
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        action();
+        return GC.GetAllocatedBytesForCurrentThread() - before;
+    }
+
+    // Rows are sized to hold every line these tests write, so nothing scrolls off. That matters: my
+    // first version used a 50-row viewport and 200 lines, and the numbers were dominated by
+    // scrollback *page* allocation as rows evicted - 2.5 KB for 50 lines but 496 KB for 200. That
+    // measures paging, not the write path. Keeping the output resident isolates the thing under test.
+    private const int Cols = 200;
+    private const int Lines = 250;
+    private const int Rows = Lines + 10;
+
+    [Fact]
+    public void AsciiOutput_DoesNotAllocatePerCharacter()
+    {
+        string line = new string('a', Cols);
+        var buffer = new TerminalBuffer(Cols, Rows);
+
+        long allocated = MeasureAllocations(
+            warmup: () => buffer.WriteContent(line),
+            action: () =>
+            {
+                for (int i = 0; i < Lines; i++)
+                {
+                    buffer.WriteContent(line);
+                }
+            });
+
+        long characters = (long)Lines * Cols;
+        double perChar = allocated / (double)characters;
+
+        // Before the fix this was one string per character - 8 bytes of object header, 8 of length
+        // and padding, 2 of payload, so ~24 bytes each - plus a boxed enumerator per call. A budget
+        // of 2 B/char is comfortably below that and comfortably above the ~0.25 B/char measured
+        // after the fix, so it discriminates without being brittle.
+        Assert.True(
+            perChar < 2.0,
+            $"allocated {allocated} bytes for {characters} ASCII characters ({perChar:F2} B/char). "
+            + "A per-character string allocation in the write path is back (#165).");
+    }
+
+    [Fact]
+    public void AsciiOutput_AllocationDoesNotScaleWithCharacterCount()
+    {
+        // Shape test, independent of any absolute budget: per-character allocation grows linearly
+        // with the character count, so 5x the output would mean ~5x the garbage. With the fix the
+        // remaining allocation is essentially fixed setup, so the two measurements stay close.
+        string line = new string('x', Cols);
+
+        // Buffers are constructed *outside* the measured region. My first version built them inside,
+        // and a 260-row buffer allocation dwarfed the per-character difference — the ratio stayed
+        // near 1 whether or not the write path allocated per character, so the test passed against
+        // the pre-fix code and was measuring nothing.
+        var smallBuffer = new TerminalBuffer(Cols, Rows);
+        var largeBuffer = new TerminalBuffer(Cols, Rows);
+
+        long small = MeasureAllocations(
+            warmup: () => smallBuffer.WriteContent(line),
+            action: () =>
+            {
+                for (int i = 0; i < 50; i++) smallBuffer.WriteContent(line);
+            });
+
+        long large = MeasureAllocations(
+            warmup: () => largeBuffer.WriteContent(line),
+            action: () =>
+            {
+                for (int i = 0; i < 250; i++) largeBuffer.WriteContent(line);
+            });
+
+        // 5x the characters. Linear-in-characters would be ~5x; a 2x multiplier plus a small absolute
+        // slack admits the fixed cost without admitting per-character strings.
+        //
+        // The slack is not cosmetic: after the fix both measurements are *zero*, and `0 < 0` is false,
+        // so a bare ratio made the test fail on a perfect result. Caught by running it against the
+        // fixed code rather than only against the mutant.
+        Assert.True(
+            large <= small * 2 + 4096,
+            $"5x the output allocated {large} bytes vs {small} for the baseline - allocation is "
+            + "scaling with character count rather than being fixed setup (#165).");
+    }
+
+    [Fact]
+    public void GraphemeClustersStillRenderCorrectly()
+    {
+        // The allocation work replaced GetTextElementEnumerator with GetNextTextElementLength plus an
+        // ASCII fast path. The fast path claims that an ASCII character followed by another ASCII
+        // character is a complete cluster; anything non-ASCII must still go through full
+        // segmentation. This is the behavioural guard on that claim.
+        var buffer = new TerminalBuffer(20, 3);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("ábc");   // 'a' + combining acute, then plain ASCII
+
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            // The combining mark must have joined the 'a', not consumed a cell of its own.
+            Assert.Equal("á", buffer.GetGrapheme(0, 0));
+            Assert.Equal("b", buffer.GetGrapheme(1, 0));
+            Assert.Equal("c", buffer.GetGrapheme(2, 0));
+        }
+        finally { buffer.Lock.ExitReadLock(); }
+    }
+
+    [Fact]
+    public void AsciiFastPathDoesNotSwallowAFollowingCombiningMark()
+    {
+        // The dangerous edge for the fast path: ASCII base immediately followed by a non-ASCII
+        // combining mark. If the fast path took the ASCII char alone in that case, the mark would
+        // land in its own cell.
+        var buffer = new TerminalBuffer(20, 3);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("é");
+
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            Assert.Equal("é", buffer.GetGrapheme(0, 0));
+            Assert.Equal(" ", buffer.GetGrapheme(1, 0));
+        }
+        finally { buffer.Lock.ExitReadLock(); }
+    }
+
+    [Fact]
+    public void AstralAndZwjSequencesStillFormSingleClusters()
+    {
+        var buffer = new TerminalBuffer(20, 3);
+        var parser = new AnsiParser(buffer);
+
+        // A ZWJ family on its own. Nothing is appended after it on purpose: `IsLastRuneZwj` returns
+        // true for *any* ZWJ in the cluster, not just a trailing one, so `_isAfterZwj` stays set and
+        // the next grapheme attaches to this cell even when the sequence is complete. That is
+        // pre-existing behaviour, unchanged by this work - my first draft of this test asserted
+        // against it by accident and caught a trailing space merged into the family.
+        parser.Process("\U0001F468‍\U0001F469‍\U0001F467");
+
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            Assert.Equal("\U0001F468‍\U0001F469‍\U0001F467", buffer.GetGrapheme(0, 0));
+        }
+        finally { buffer.Lock.ExitReadLock(); }
+    }
+
+    [Fact]
+    public void AstralEmojiFormsOneClusterAndOccupiesTwoCells()
+    {
+        var buffer = new TerminalBuffer(20, 3);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("a\U0001F44Db");
+
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            Assert.Equal("a", buffer.GetGrapheme(0, 0));
+            Assert.Equal("\U0001F44D", buffer.GetGrapheme(1, 0));
+            Assert.Equal("b", buffer.GetGrapheme(3, 0)); // 2 is the wide continuation
+        }
+        finally { buffer.Lock.ExitReadLock(); }
+    }
+}


### PR DESCRIPTION
Fixes #165.

## Measured result

| | Allocated for 50,000 ASCII characters |
|---|---|
| Before | **1,212,000 bytes** (24.24 B/char — a ~24-byte string each) |
| After | **0 bytes** |

Not a reduction: the write path no longer allocates for ASCII output at all. The 24.24 B/char figure
comes from actually running the pre-fix code under the new assertion, not from estimating.

## What was allocating

`WriteContentCore` routed every printable character of all output through
`StringInfo.GetTextElementEnumerator` + `GetTextElement()` — a boxed enumerator per call plus a string
per grapheme, which for plain ASCII is one string per character.

Three changes:

1. **Allocation-free segmentation.** `StringInfo.GetNextTextElementLength` over a span gives the same
   segmentation without allocating, and `WriteGraphemeInternal` now takes `ReadOnlySpan<char>`. A
   string is materialized only where one has to be *stored* — an extended-grapheme side-table entry,
   or the merged cluster on the attach path (which allocates either way).
2. **An ASCII fast path that is exact, not approximate.** Everything that can extend a cluster —
   combining marks, variation selectors, ZWJ, regional indicators, surrogates — is at U+0300 or above.
   So an ASCII character followed by another ASCII character is *always* a complete cluster, and the
   segmentation tables can be skipped outright for the dominant case. No heuristic, no risk of
   splitting a cluster.
3. **No more LINQ on the rune path.** `Rune.DecodeFromUtf16` replaces
   `grapheme.EnumerateRunes().FirstOrDefault(...)`, which boxed the struct enumerator once per
   multi-char grapheme, and `IsRegionalIndicatorCluster`'s `.All(...)` became a loop.

`UnicodeWidth.GetGraphemeWidth`, `ShouldAttachToPrevious`, `IsSingleRegionalIndicator`,
`IsRegionalIndicatorCluster` and `CountRegionalIndicators` take spans now. `string` converts
implicitly so no call site changed — the one exception is `ReflowEngineContext`'s `Func<string,int>`
field, which needed a lambda rather than a method group.

## Verification

Two assertions on `GC.GetAllocatedBytesForCurrentThread` — deterministic, unlike wall-clock timing on
a shared runner — plus four behavioural guards on the fast path: a combining mark after an ASCII base
(the dangerous edge), an astral emoji occupying two cells, a ZWJ sequence, and a mixed run.

`NovaTerminal.VT.Tests` 119/119. **Mutation-verified:** restoring the old enumerator fails both
allocation tests.

### Three ways my own tests were wrong first

Worth writing down, because each one would have shipped a test that proved nothing:

1. **Scrollback confounded the measurement.** The first version used a 50-row viewport and 200 lines,
   so page eviction dominated: 2.5 KB for 50 lines but 496 KB for 200. That measures paging, not the
   write path. Rows are now sized so nothing scrolls off.
2. **The scaling test measured buffer construction.** It built its `TerminalBuffer` *inside* the
   measured region, where a 260-row allocation dwarfed the per-character difference — so it passed
   against the pre-fix code. Buffers are now constructed outside.
3. **A zero baseline broke the ratio.** With the fix both scaling measurements are `0`, and `0 < 0` is
   false, so a bare ratio failed on a *perfect* result. Now has absolute slack.

(1) and (3) only surfaced because I ran the tests against the fixed code as well as against the
mutant. A mutant-only check would have left (2) in place looking green.

## Noted, not changed

`IsLastRuneZwj` returns true for **any** ZWJ in a cluster, not just a trailing one. So after a
*complete* ZWJ sequence `_isAfterZwj` stays set and the next grapheme attaches to it — a space typed
after a family emoji merges into that cluster. I hit this writing a test and initially mistook it for
a regression; it's pre-existing and unrelated to allocation, so it's recorded in a test comment rather
than fixed here. Happy to file it if you want it tracked.

## Other runs

`NovaTerminal.App.Tests` 1263 passed, 2 failed:

- `TerminalPane_WhenRemotePromptSettlesLowOnShortPane_ResumesConservativeAssistLayout` — #232, fails on
  clean `main`.
- `RecordUse_PersistsCountAcrossReloads` — passes in isolation; load-flaky, same family as the two
  stress tests. Not previously seen, so flagging it rather than assuming.

The issue also suggests the benchmark suite (`tests/NovaTerminal.Benchmarks`) would show the win. I
didn't run it — the allocation assertions give a hard pass/fail in CI, which the benchmarks don't, and
#127 is the issue for making benchmark thresholds gate.
