### PR TITLE
test(render): gate the row and glyph caches in CI

### DIFF
--- a/tests/NovaTerminal.App.Tests/Infra/SnapshotService.cs
+++ b/tests/NovaTerminal.App.Tests/Infra/SnapshotService.cs
@@ -30,6 +30,23 @@ namespace NovaTerminal.Tests.Infra
         public double RenderScaling { get; init; } = 1.0;
         public string TypefaceFamily { get; init; } = "Cascadia Code PL, CaskaydiaCove Nerd Font, Cascadia Code, Consolas, Monospace";
         public float FontSize { get; init; } = 14f;
+
+        /// <summary>
+        /// Row-picture cache to render with, or <c>null</c> to render uncached.
+        /// </summary>
+        /// <remarks>
+        /// Golden-PNG capture deliberately renders with both caches off, so that every baseline is
+        /// produced by the same deterministic path. That also meant nothing in CI ever exercised the
+        /// caches — the gap #127 describes. Supplying one here lets a caller render the *same* buffer
+        /// twice and assert the second frame hit the cache, which is what detects a regression that
+        /// silently invalidates rows every frame.
+        ///
+        /// Callers own the instance and its disposal; leave it null for baseline captures.
+        /// </remarks>
+        public RowImageCache? RowCache { get; init; }
+
+        /// <summary>Glyph atlas to render with, or <c>null</c> to render uncached. See <see cref="RowCache"/>.</summary>
+        public GlyphCache? GlyphCache { get; init; }
     }
 
     public static class SnapshotService
@@ -73,9 +90,9 @@ namespace NovaTerminal.Tests.Infra
                 totalLines: buffer.TotalLines,
                 cursorRow: buffer.CursorRow,
                 cursorCol: buffer.CursorCol,
-                rowCache: null,
+                rowCache: options.RowCache,
                 enableComplexShaping: options.EnableComplexShaping,
-                glyphCache: null);
+                glyphCache: options.GlyphCache);
 
             IDisposable? primitiveOverride = null;
             if (options.ForceBoxDrawingPrimitives || options.ForceBlockElementPrimitives)

--- a/tests/NovaTerminal.App.Tests/RenderTests/RenderCacheEffectivenessTests.cs
+++ b/tests/NovaTerminal.App.Tests/RenderTests/RenderCacheEffectivenessTests.cs
@@ -1,0 +1,184 @@
+using System;
+using NovaTerminal.Shell;
+using Avalonia.Headless.XUnit;
+using NovaTerminal.Platform;
+using NovaTerminal.Rendering;
+using NovaTerminal.Tests.Infra;
+using NovaTerminal.VT;
+using Xunit;
+
+namespace NovaTerminal.Tests.RenderTests
+{
+    /// <summary>
+    /// #127: the rendering pipeline's caches were not protected by CI. A regression that silently
+    /// defeated the row cache — say an accidental per-frame invalidation — would have passed cleanly.
+    ///
+    /// The `Render Metrics` CI job already existed and looked like protection, but the tests behind it
+    /// only called <c>RendererStatistics.RecordFrame(...)</c> by hand and asserted the counter moved.
+    /// They never rendered anything. `RendererMetricsTests` says as much in a closing comment. A job
+    /// that tests the bookkeeping class rather than the renderer is worse than no job: it reads as
+    /// coverage.
+    ///
+    /// These tests render for real, through <c>TerminalDrawOperation</c> to an offscreen surface, and
+    /// assert on counters rather than on frame *times* — deterministic on a shared CI runner, where a
+    /// millisecond threshold would flake. #127 defers timing thresholds to nightly for that reason;
+    /// this is the part that can gate a PR today.
+    ///
+    /// Tagged `RenderMetrics` so the existing job picks them up with no workflow change.
+    /// </summary>
+    [Trait("Category", "RenderMetrics")]
+    [Collection("RendererStatistics")]
+    public sealed class RenderCacheEffectivenessTests
+    {
+        private static readonly CellMetrics Metrics = new()
+        {
+            CellWidth = 8.4f,
+            CellHeight = 18.0f,
+            Baseline = 14.0f,
+            Ascent = 14.0f,
+            Descent = 4.0f
+        };
+
+        private const int Cols = 40;
+        private const int Rows = 10;
+
+        private static TerminalBuffer BufferWithContent()
+        {
+            var buffer = new TerminalBuffer(Cols, Rows);
+            var parser = new AnsiParser(buffer);
+            for (int i = 0; i < Rows - 1; i++)
+            {
+                parser.Process($"line {i} with some content\r\n");
+            }
+            return buffer;
+        }
+
+        private static void Render(TerminalBuffer buffer, RowImageCache? rowCache, GlyphCache? glyphCache)
+        {
+            using var bitmap = SnapshotService.Capture(
+                buffer,
+                Metrics,
+                (int)(Cols * Metrics.CellWidth),
+                (int)(Rows * Metrics.CellHeight),
+                new SnapshotCaptureOptions
+                {
+                    HideCursor = true,
+                    RowCache = rowCache,
+                    GlyphCache = glyphCache
+                });
+        }
+
+        [AvaloniaFact]
+        public void SecondFrameOfUnchangedContent_IsServedFromTheRowCache()
+        {
+            var buffer = BufferWithContent();
+            using var rowCache = new RowImageCache();
+
+            // Frame 1 populates the cache: every renderable row is a miss.
+            RendererStatistics.Reset();
+            Render(buffer, rowCache, glyphCache: null);
+            long firstHits = RendererStatistics.RowCacheHits;
+            long firstMisses = RendererStatistics.RowCacheMisses;
+
+            Assert.True(firstMisses > 0, "first frame should have populated the row cache");
+            Assert.Equal(0, firstHits);
+
+            // Frame 2 renders the same unchanged buffer. Row identity and revision are unchanged, so
+            // every row that was cached must come back as a hit. This is the assertion that fails if
+            // something starts invalidating rows every frame.
+            RendererStatistics.Reset();
+            Render(buffer, rowCache, glyphCache: null);
+            long secondHits = RendererStatistics.RowCacheHits;
+            long secondMisses = RendererStatistics.RowCacheMisses;
+
+            Assert.True(
+                secondHits > 0,
+                $"second frame of identical content produced {secondHits} row-cache hits and "
+                + $"{secondMisses} misses - the row cache is not being consulted or is being "
+                + "invalidated every frame (#127).");
+
+            Assert.True(
+                secondHits >= secondMisses,
+                $"second frame of identical content was mostly misses ({secondMisses} misses vs "
+                + $"{secondHits} hits) - row caching has regressed (#127).");
+        }
+
+        [AvaloniaFact]
+        public void MutatingOneRow_InvalidatesOnlyThatRow()
+        {
+            // The complement of the test above, and the reason it isn't enough on its own: a cache
+            // that never invalidates would also pass "second frame is all hits". Touching one row must
+            // cost exactly one miss, not a full redraw.
+            var buffer = BufferWithContent();
+            using var rowCache = new RowImageCache();
+
+            Render(buffer, rowCache, glyphCache: null);   // populate
+
+            // Rewrite the top row in place. Its revision changes; every other row's does not.
+            var parser = new AnsiParser(buffer);
+            parser.Process("\u001b[1;1H");
+            parser.Process("CHANGED");
+
+            RendererStatistics.Reset();
+            Render(buffer, rowCache, glyphCache: null);
+
+            long hits = RendererStatistics.RowCacheHits;
+            long misses = RendererStatistics.RowCacheMisses;
+
+            Assert.True(hits > 0, $"expected untouched rows to stay cached; got {hits} hits");
+
+            // Both bounds are load-bearing, and the lower one is easy to forget: without it a cache
+            // that ignored the revision entirely - always hitting, never noticing the edit - would
+            // pass this test while rendering stale pixels. Verified by mutating Key.Equals to compare
+            // only RowId, which makes this assertion the one that fires.
+            Assert.True(
+                misses >= 1,
+                $"editing a row produced {misses} row-cache misses - the edited row was served from "
+                + "cache, so the revision is not part of the key and the frame renders stale (#127).");
+
+            Assert.True(
+                misses <= 2,
+                $"editing one row caused {misses} row-cache misses (with {hits} hits) - the "
+                + "invalidation is wider than the change (#127). Two are allowed: the edited row, and "
+                + "the cursor row if it differs.");
+        }
+
+        [AvaloniaFact]
+        public void GlyphAtlasIsReusedAcrossFrames_WithoutResetting()
+        {
+            var buffer = BufferWithContent();
+            using var glyphCache = new GlyphCache();
+
+            long resetsBefore = RendererStatistics.GlyphAtlasResets;
+
+            Render(buffer, rowCache: null, glyphCache: glyphCache);
+            int entriesAfterFirstFrame = glyphCache.EntryCount;
+            Assert.True(entriesAfterFirstFrame > 0, "first frame should have populated the glyph atlas");
+
+            // Same content again: the atlas should be reused, not rebuilt. Entry count must not grow,
+            // because every glyph is already resident, and the atlas must not have been reset.
+            for (int i = 0; i < 5; i++)
+            {
+                Render(buffer, rowCache: null, glyphCache: glyphCache);
+            }
+
+            Assert.Equal(entriesAfterFirstFrame, glyphCache.EntryCount);
+            Assert.Equal(resetsBefore, RendererStatistics.GlyphAtlasResets);
+        }
+
+        [AvaloniaFact]
+        public void RenderingWithoutARowCache_ReportsNoHits()
+        {
+            // Guards the guard: if `RowCache = null` still produced hits, the tests above would be
+            // measuring something other than the cache they think they are.
+            var buffer = BufferWithContent();
+
+            RendererStatistics.Reset();
+            Render(buffer, rowCache: null, glyphCache: null);
+            Render(buffer, rowCache: null, glyphCache: null);
+
+            Assert.Equal(0, RendererStatistics.RowCacheHits);
+            Assert.True(RendererStatistics.RowCacheMisses > 0);
+        }
+    }
+}


### PR DESCRIPTION
Addresses the PR-gateable half of #127. Timing thresholds and the sustained-output stress case stay
open — see the bottom.

## The gap is real, but it isn't a missing job

#127 says the rendering caches aren't protected by CI. True. What's worth stating precisely, because
it's a trap:

**A `Render Metrics (os)` job already exists** and runs `dotnet test --filter Category=RenderMetrics`.
It looks like protection. The tests behind that filter do this:

```csharp
RendererStatistics.Reset();
RendererStatistics.RecordFrame(true, 100);
Assert.Equal(1, RendererStatistics.TotalFrames);
```

They call the recorder by hand and assert the counter moved. **They never render anything.**
`RendererMetricsTests` says so itself in a closing comment ("We cannot easily unit test the actual
TerminalView rendering loop here…").

A job that tests the bookkeeping class instead of the renderer is worse than no job, because it reads
as coverage — the same shape as the stale `Render Metrics` name suggesting the pipeline was gated.

So this PR adds **no workflow changes**. It adds tests with substance behind the filter that already
exists.

## Why the golden-PNG harness couldn't be reused as-is

`SnapshotService.Capture` renders the real pipeline to an offscreen surface — exactly what item 1 asks
for — but passes:

```csharp
rowCache: null,
glyphCache: null,
```

Deliberately: every golden baseline should come from one deterministic uncached path. So the harness
that *could* exercise the caches was explicitly configured not to.

`SnapshotCaptureOptions` now takes optional `RowCache` / `GlyphCache`. Baseline captures keep passing
nothing and are byte-for-byte unaffected.

## The four gates

Counters, not frame times. Deterministic on a shared runner, where a millisecond threshold would
flake — #127 defers timing to nightly for that reason, and this is the part that can gate a PR today.

1. **A second frame of unchanged content is served from the row cache.** The direct guard on "an
   accidental per-frame invalidation", which is #127's own example.
2. **Editing one row invalidates that row and only that row.**
3. **The glyph atlas is reused across frames** without resetting or growing its entry count.
4. **Rendering with no row cache reports no hits** — guards the guard. If `null` still produced hits,
   the other tests would be measuring something other than the cache they name.

## Mutation-verified in both directions

| Mutation | Result |
|---|---|
| `item.CachedPicture = null` every frame (#127's stated regression) | 2 fail: *"0 row-cache hits and 10 misses — the row cache is not being consulted or is being invalidated every frame"* |
| `RowCache.Key.Equals` ignores `Revision`, so a changed row still hits | 1 fail: *"the edited row was served from cache … the frame renders stale"* |

**The second mutation caught a hole in my own test.** `MutatingOneRow` asserted only an *upper* bound
on misses (`misses <= 2`), so a cache that never invalidated would have sailed through it while
rendering stale pixels — even though the comment claimed it covered that case. It now asserts both
bounds, and the lower one has its own mutation behind it.

That's three PRs in a row where mutation-checking the *opposite* direction found a test asserting less
than it claimed. I've started treating "what would a broken-the-other-way implementation do?" as a
required question rather than a nice-to-have.

## Verification

`RenderCacheEffectivenessTests` 4/4. `NovaTerminal.App.Tests` 1268 passed, 1 failed —
`TerminalPane_WhenRemotePromptSettlesLowOnShortPane_ResumesConservativeAssistLayout`, which is #232 and
fails on clean `main`. `NovaTerminal.Rendering.Tests` 54/54.

No golden PNG changes, as expected: baseline captures still pass `null` for both caches.

## Left open on #127

- **Frame-time thresholds** (the timing half of item 1). Wants nightly, and wants a stable baseline
  first — a threshold picked from one runner's numbers is a flake generator.
- **The sustained-output stress case** (item 3), asserting render stays decoupled from parse rate.
  Also nightly-shaped.
- **Draw-path allocation-per-frame.** I looked at this and left it: the only capture entry point
  encodes a PNG, and `SKImage.Encode` allocation swamps anything the draw path does. Doing it properly
  means a capture-to-surface path that skips encoding. Worth its own change; the cache hit rates cover
  the regression #127 actually names.
