### PR TITLE
fix(vt): stop swallowing the character after a completed ZWJ emoji

### DIFF
--- a/src/NovaTerminal.VT/TerminalBuffer.WritePath.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.WritePath.cs
@@ -311,7 +311,7 @@ namespace NovaTerminal.VT
                     }
 
 
-                    _isAfterZwj = IsLastRuneZwj(grapheme);
+                    _isAfterZwj = EndsWithZwj(grapheme);
                     Invalidate();
                     return; // CRITICAL: Stop here, don't write again to current cursor
                 }
@@ -405,7 +405,7 @@ NormalWrite:
             if (_cursorCol > _maxColThisRow) _maxColThisRow = _cursorCol;
             _prevCursorCol = _cursorCol;
             _prevCursorRow = _cursorRow;
-            this._isAfterZwj = IsLastRuneZwj(grapheme);
+            this._isAfterZwj = EndsWithZwj(grapheme);
         }
 
         private void AdvanceCursorRowForLineFeed()
@@ -420,15 +420,27 @@ NormalWrite:
             _cursorRow = Math.Min(_cursorRow + 1, Rows - 1);
         }
 
-        private bool IsLastRuneZwj(ReadOnlySpan<char> grapheme)
+        /// <summary>
+        /// Whether <paramref name="grapheme"/> ends on a ZWJ (U+200D), and so ended <em>expecting a
+        /// continuation</em> — the question <c>_isAfterZwj</c> is asked to answer.
+        /// </summary>
+        /// <remarks>
+        /// #236: this used to return true for a ZWJ <em>anywhere</em> in the cluster, and the comment
+        /// claimed that as deliberate. But a *completed* ZWJ sequence contains ZWJ without ending on
+        /// one, so the flag stayed set and the next grapheme — any grapheme — attached to it. Printing
+        /// a family emoji followed by a space merged the space into the family.
+        ///
+        /// The flag has to stay true for an incomplete sequence: grapheme segmentation keeps a
+        /// trailing ZWJ attached to its base (GB9), so a PTY read that ends mid-join hands the write
+        /// path a cluster like "man + ZWJ" and the emoji completing it arrives in the next read.
+        ///
+        /// Testing the last <c>char</c> is exact rather than a shortcut: U+200D is in the BMP and is
+        /// not a surrogate, so it can only ever be a whole trailing rune, never the tail half of an
+        /// astral one.
+        /// </remarks>
+        private static bool EndsWithZwj(ReadOnlySpan<char> grapheme)
         {
-            if (grapheme.IsEmpty) return false;
-            // ZWJ is U+200D
-            foreach (var rune in grapheme.EnumerateRunes())
-            {
-                if (rune.Value == 0x200D) return true; // Any ZWJ in the grapheme makes it "joining"
-            }
-            return false;
+            return !grapheme.IsEmpty && grapheme[^1] == '\u200D';
         }
 
         /// <summary>

--- a/tests/NovaTerminal.VT.Tests/WritePathAllocationTests.cs
+++ b/tests/NovaTerminal.VT.Tests/WritePathAllocationTests.cs
@@ -157,17 +157,17 @@ public class WritePathAllocationTests
         var buffer = new TerminalBuffer(20, 3);
         var parser = new AnsiParser(buffer);
 
-        // A ZWJ family on its own. Nothing is appended after it on purpose: `IsLastRuneZwj` returns
-        // true for *any* ZWJ in the cluster, not just a trailing one, so `_isAfterZwj` stays set and
-        // the next grapheme attaches to this cell even when the sequence is complete. That is
-        // pre-existing behaviour, unchanged by this work - my first draft of this test asserted
-        // against it by accident and caught a trailing space merged into the family.
-        parser.Process("\U0001F468‍\U0001F469‍\U0001F467");
+        // A ZWJ family, then a following character. This originally wrote the family on its own,
+        // because `IsLastRuneZwj` returned true for *any* ZWJ in the cluster and the trailing space
+        // got merged into the family - a real bug the test tripped over, filed as #236 and fixed
+        // since. Appending `z` again now that the flag means what its name says.
+        parser.Process("\U0001F468‍\U0001F469‍\U0001F467z");
 
         buffer.Lock.EnterReadLock();
         try
         {
             Assert.Equal("\U0001F468‍\U0001F469‍\U0001F467", buffer.GetGrapheme(0, 0));
+            Assert.Equal("z", buffer.GetGrapheme(2, 0));
         }
         finally { buffer.Lock.ExitReadLock(); }
     }

--- a/tests/NovaTerminal.VT.Tests/ZwjContinuationTests.cs
+++ b/tests/NovaTerminal.VT.Tests/ZwjContinuationTests.cs
@@ -1,0 +1,163 @@
+using NovaTerminal.VT;
+
+namespace NovaTerminal.VT.Tests;
+
+/// <summary>
+/// #236: <c>_isAfterZwj</c> means "the cluster just written ended expecting a continuation", and the
+/// write path uses it to attach whatever arrives next to the previous cell. It was computed by
+/// scanning the cluster for a ZWJ *anywhere*, so a *completed* ZWJ sequence — which contains ZWJ but
+/// does not end with one — left the flag set and swallowed the following character.
+///
+/// The flag exists for split reads: a ZWJ can arrive at the tail of one PTY read with the emoji that
+/// completes the join in the next. Both directions are asserted here, because narrowing the check is
+/// only correct if the incomplete case still joins.
+/// </summary>
+public class ZwjContinuationTests
+{
+    private const string Zwj = "\u200D";
+    private const string Man = "\U0001F468";
+    private const string Woman = "\U0001F469";
+    private const string Girl = "\U0001F467";
+    private const string ThumbsUp = "\U0001F44D";
+    private const string Family = Man + Zwj + Woman + Zwj + Girl;
+
+    [Fact]
+    public void SpaceAfterCompletedZwjSequenceLandsInItsOwnCell()
+    {
+        var buffer = new TerminalBuffer(20, 3);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process(Family + " x");
+
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            // The family is one cluster in cell 0 and occupies two columns, so cell 1 is its
+            // continuation and the space is the first thing to get a cell of its own.
+            Assert.Equal(Family, buffer.GetGrapheme(0, 0));
+            Assert.Equal(" ", buffer.GetGrapheme(2, 0));
+            Assert.Equal("x", buffer.GetGrapheme(3, 0));
+        }
+        finally { buffer.Lock.ExitReadLock(); }
+    }
+
+    [Fact]
+    public void LetterImmediatelyAfterCompletedZwjSequenceLandsInItsOwnCell()
+    {
+        // The space in the repro is not special; nothing at all should attach.
+        var buffer = new TerminalBuffer(20, 3);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process(Family + "ab");
+
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            Assert.Equal(Family, buffer.GetGrapheme(0, 0));
+            Assert.Equal("a", buffer.GetGrapheme(2, 0));
+            Assert.Equal("b", buffer.GetGrapheme(3, 0));
+        }
+        finally { buffer.Lock.ExitReadLock(); }
+    }
+
+    [Fact]
+    public void EmojiAfterCompletedZwjSequenceStartsANewCluster()
+    {
+        // The worst case for the old behaviour: the following grapheme is itself joinable, so it
+        // merged into a family that was already complete and produced one enormous cluster.
+        var buffer = new TerminalBuffer(20, 3);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process(Family + ThumbsUp);
+
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            Assert.Equal(Family, buffer.GetGrapheme(0, 0));
+            Assert.Equal(ThumbsUp, buffer.GetGrapheme(2, 0));
+        }
+        finally { buffer.Lock.ExitReadLock(); }
+    }
+
+    [Fact]
+    public void TrailingZwjSplitAcrossReadsStillJoins()
+    {
+        // The case the flag is for. Grapheme segmentation keeps a trailing ZWJ attached to its base
+        // (GB9), so the first read produces the single cluster "man + ZWJ" — which really does end
+        // expecting a continuation — and the second read must merge into it rather than take a cell.
+        var buffer = new TerminalBuffer(20, 3);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process(Man + Zwj);
+        parser.Process(Woman);
+
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            Assert.Equal(Man + Zwj + Woman, buffer.GetGrapheme(0, 0));
+        }
+        finally { buffer.Lock.ExitReadLock(); }
+    }
+
+    [Fact]
+    public void ZwjArrivingAloneBetweenReadsStillJoins()
+    {
+        // Three-way split: the ZWJ is its own read, so it is its own single-rune cluster.
+        var buffer = new TerminalBuffer(20, 3);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process(Man);
+        parser.Process(Zwj);
+        parser.Process(Woman);
+
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            Assert.Equal(Man + Zwj + Woman, buffer.GetGrapheme(0, 0));
+        }
+        finally { buffer.Lock.ExitReadLock(); }
+    }
+
+    [Fact]
+    public void ThreeWayJoinAssembledAcrossReadsProducesOneCluster()
+    {
+        // Each read ends on a ZWJ, so the flag has to survive two consecutive attachments. The
+        // attach path recomputes the flag from the *incoming* piece, not the merged result, which is
+        // what makes this work.
+        var buffer = new TerminalBuffer(20, 3);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process(Man + Zwj);
+        parser.Process(Woman + Zwj);
+        parser.Process(Girl);
+
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            Assert.Equal(Family, buffer.GetGrapheme(0, 0));
+        }
+        finally { buffer.Lock.ExitReadLock(); }
+    }
+
+    [Fact]
+    public void CharacterAfterASequenceCompletedAcrossReadsLandsInItsOwnCell()
+    {
+        // Combines both halves: the join is assembled from split reads, and once it is complete the
+        // next character must stop attaching. A fix that simply cleared the flag after one
+        // attachment would pass the split-read tests above and fail this one.
+        var buffer = new TerminalBuffer(20, 3);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process(Man + Zwj);
+        parser.Process(Woman);
+        parser.Process("x");
+
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            Assert.Equal(Man + Zwj + Woman, buffer.GetGrapheme(0, 0));
+            Assert.Equal("x", buffer.GetGrapheme(2, 0));
+        }
+        finally { buffer.Lock.ExitReadLock(); }
+    }
+}


### PR DESCRIPTION
Closes #236.

## The bug

`_isAfterZwj` means "the cluster just written ended expecting a continuation". `WriteGraphemeInternal` reads it as permission to attach whatever arrives next to the previous cell. It was computed by scanning the cluster for a ZWJ **anywhere**:

```csharp
foreach (var rune in grapheme.EnumerateRunes())
    if (rune.Value == 0x200D) return true; // Any ZWJ in the grapheme makes it "joining"
```

A *completed* ZWJ sequence contains ZWJ but does not end on one, so the flag stayed set and the next grapheme — any grapheme — merged into it.

```
printf '\xF0\x9F\x91\xA8\xE2\x80\x8D\xF0\x9F\x91\xA9\xE2\x80\x8D\xF0\x9F\x91\xA7 x'
```

The space landed inside the family's cluster, and everything after it on the line sat one column left of where it belonged. Not just cosmetic drift either: the same flag suppresses pending-wrap (`if (_isPendingWrap && !isZeroWidthComponent && !_isAfterZwj)`), so a family emoji at the right margin also deferred the line break for one character.

## The fix

Renamed to `EndsWithZwj` and made it test the last `char` — which is what the old name already claimed. Exact rather than a shortcut: U+200D is in the BMP and is not a surrogate, so it can only ever be a whole trailing rune, never the tail half of an astral one. Also `static` now, which drops a CA1822.

## Why not just "clear the flag after one attachment"

Because the flag has to survive a chain. Grapheme segmentation keeps a trailing ZWJ attached to its base (GB9), so a PTY read that ends mid-join hands the write path the cluster `man + ZWJ`, and a three-part family can arrive as three reads each ending on a ZWJ. `ThreeWayJoinAssembledAcrossReadsProducesOneCluster` covers that, and `CharacterAfterASequenceCompletedAcrossReadsLandsInItsOwnCell` is there specifically to fail the clear-after-one shortcut, which would pass every other split-read test.

## Tests

Seven, in a new `ZwjContinuationTests`, deliberately split across both directions — and **mutation-checked in both**, since narrowing the check is only correct if the incomplete case still joins:

| mutant | fails |
|---|---|
| original "any ZWJ in cluster" | exactly the 3 completed-sequence tests |
| `return false` (never continue) | exactly the 4 split-read join tests |

No overlap, no gap: every test discriminates, and neither direction is unguarded. The four join tests pass on unfixed `main`, which is the point — they are the regression guard on behaviour that already worked.

Also un-neutered `WritePathAllocationTests.AstralAndZwjSequencesStillFormSingleClusters`. When I wrote it for #235 it appended a character after the family, hit this bug, and I removed the append with a comment recording the behaviour as pre-existing. The append is back and the comment now points at the fix.

## Verification

- `NovaTerminal.VT.Tests` 126/126
- `NovaTerminal.Rendering.Tests` 54/54
- `NovaTerminal.App.Tests` 1268 passed, 1 failed — #232 only, unrelated and already known
