### PR TITLE
fix(render): draw one glyph per grapheme cluster, not per rune

### DIFF
--- a/src/NovaTerminal.App/Shell/TerminalDrawOperation.cs
+++ b/src/NovaTerminal.App/Shell/TerminalDrawOperation.cs
@@ -9,6 +9,7 @@ using System;
 using System.Buffers;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
@@ -90,6 +91,19 @@ namespace NovaTerminal.Shell
         private const int RunBuilderInitialCapacity = 256;
         private const int RunBuilderMaxCapacity = 4096;
         private readonly StringBuilder _runBuilder = new(capacity: RunBuilderInitialCapacity);
+
+        /// <summary>
+        /// The per-cell text of the run being built, parallel to <see cref="_runBuilder"/>.
+        /// </summary>
+        /// <remarks>
+        /// #234: the per-glyph draw path used to re-split <c>runText</c> by *rune*, so every
+        /// multi-codepoint cluster was rasterized in pieces and its composed glyph never produced.
+        /// Re-segmenting the concatenated run is not the fix either — cluster boundaries do not have
+        /// to line up with cell boundaries, and segmenting across a boundary would merge two cells
+        /// into one glyph. Keeping the cell texts is exact: each entry is the cell's own text, and
+        /// each cell's width was already measured from that same string when the run was built.
+        /// </remarks>
+        private readonly List<string> _runCellTexts = new(capacity: 64);
         private float[]? _colEdges;
         private float[]? _rowEdges;
         private int _colEdgesCount;
@@ -1121,7 +1135,14 @@ namespace NovaTerminal.Shell
                     _runBuilder.Capacity = RunBuilderInitialCapacity;
                 }
 
+                if (_runCellTexts.Capacity > RunBuilderMaxCapacity)
+                {
+                    _runCellTexts.Clear();
+                    _runCellTexts.Capacity = 64;
+                }
+
                 var runBuilder = _runBuilder;
+                var runCellTexts = _runCellTexts;
 
                 for (int c = 0; c < snapshot.Cols; c++)
                 {
@@ -1142,6 +1163,7 @@ namespace NovaTerminal.Shell
                     }
 
                     runBuilder.Clear();
+                    runCellTexts.Clear();
                     int totalRunWidth = 0;
                     bool runNeedsComplexShaping = false;
                     bool runHasBoxDrawing = false;
@@ -1203,6 +1225,7 @@ namespace NovaTerminal.Shell
                         runNeedsComplexShaping = runHasComplexShapingGlyph && !runHasBoxDrawing;
 
                         runBuilder.Append(cellText);
+                        runCellTexts.Add(cellText);
                         int w = GetSafeGraphemeWidth(cellText); // GetGraphemeWidth is thread-safe
                         totalRunWidth += w;
                         k++;
@@ -1297,9 +1320,11 @@ namespace NovaTerminal.Shell
                         _blockFillPaint.Style = SKPaintStyle.Fill;
                         _blockFillPaint.IsAntialias = false;
 
-                        foreach (var rune in runText.EnumerateRunes())
+                        // One iteration per grapheme cluster, not per rune (#234). Everything in this
+                        // body already takes a cluster string and behaves correctly given one; the
+                        // enumerator is what was wrong.
+                        foreach (string grapheme in new RunGraphemeEnumerator(runCellTexts))
                         {
-                            string grapheme = rune.ToString();
                             int graphemeWidth = GetSafeGraphemeWidth(grapheme);
                             float xIdxSnap = FromDevicePx(_pixelGrid.XForCol(cellX));
 
@@ -1497,7 +1522,7 @@ namespace NovaTerminal.Shell
                     {
                         float underlineX1 = rx;
                         float underlineX2 = rx + rw;
-                        if (TryGetUnderlineBounds(runText, c, colEdges, paddingLeft, out float trimmedX1, out float trimmedX2))
+                        if (TryGetUnderlineBounds(runCellTexts, c, colEdges, paddingLeft, out float trimmedX1, out float trimmedX2))
                         {
                             underlineX1 = trimmedX1;
                             underlineX2 = trimmedX2;
@@ -2210,6 +2235,71 @@ namespace NovaTerminal.Shell
             return false;
         }
 
+        /// <summary>
+        /// Walks the grapheme clusters of a run, cell by cell.
+        /// </summary>
+        /// <remarks>
+        /// A struct with its own <c>GetEnumerator</c> so <c>foreach</c> binds to it directly: this runs
+        /// once per run per frame, and an iterator method would allocate a state machine each time.
+        ///
+        /// Segmentation is restricted to a single cell's text on purpose. Cluster boundaries are not
+        /// guaranteed to coincide with cell boundaries — a cell can hold a cluster ending in a ZWJ if a
+        /// PTY read split mid-join — and segmenting the concatenated run would then fuse two cells into
+        /// one glyph while the column arithmetic still advanced by two.
+        ///
+        /// Conversely, a cell's text is *usually* exactly one cluster but not always: the VT write
+        /// path's ZWJ attachment can leave two clusters in one cell (a trailing ZWJ followed by a
+        /// non-pictographic character does not join under GB11). So each cell is still segmented rather
+        /// than assumed to be a single cluster — but the common single-cluster and single-char cases
+        /// return the cell's own string, allocating nothing where the old code allocated per rune.
+        /// </remarks>
+        private struct RunGraphemeEnumerator
+        {
+            private readonly List<string> _cellTexts;
+            private int _cellIndex;
+            private int _offset;
+
+            public RunGraphemeEnumerator(List<string> cellTexts)
+            {
+                _cellTexts = cellTexts;
+                _cellIndex = 0;
+                _offset = 0;
+                Current = string.Empty;
+            }
+
+            public string Current { get; private set; }
+
+            public RunGraphemeEnumerator GetEnumerator() => this;
+
+            public bool MoveNext()
+            {
+                while (_cellIndex < _cellTexts.Count)
+                {
+                    string cell = _cellTexts[_cellIndex];
+                    if (_offset >= cell.Length)
+                    {
+                        _cellIndex++;
+                        _offset = 0;
+                        continue;
+                    }
+
+                    int remaining = cell.Length - _offset;
+                    int length = remaining == 1
+                        ? 1 // A single char is a whole cluster; skip the segmentation tables.
+                        : StringInfo.GetNextTextElementLength(cell, _offset);
+
+                    Current = _offset == 0 && length == cell.Length
+                        ? cell // The common case: the cell is one cluster, so reuse its string.
+                        : cell.Substring(_offset, length);
+                    _offset += length;
+                    return true;
+                }
+
+                Current = string.Empty;
+                return false;
+            }
+        }
+
         private static bool IsSingleRuneInRange(string grapheme, int minCodePointInclusive, int maxCodePointInclusive)
         {
             if (!TryGetSingleRuneCodePoint(grapheme, out int cp)) return false;
@@ -2621,7 +2711,14 @@ namespace NovaTerminal.Shell
                 => RuntimeHelpers.GetHashCode(obj);
         }
 
-        private bool TryGetUnderlineBounds(string runText, int runStartCol, float[] colEdges, float paddingLeft, out float x1, out float x2)
+        /// <remarks>
+        /// #234: this took the concatenated run text and enumerated it by rune, so its column
+        /// arithmetic could disagree with <c>totalRunWidth</c> — which the caller sums from each
+        /// *cell's* cluster width. A keycap cell measures 2 columns as a cluster but 1 as runes (the
+        /// selector and the enclosing keycap are zero-width), so the underline came up short. Driving
+        /// both from the same per-cell strings makes the two agree by construction.
+        /// </remarks>
+        private bool TryGetUnderlineBounds(List<string> runCellTexts, int runStartCol, float[] colEdges, float paddingLeft, out float x1, out float x2)
         {
             x1 = 0f;
             x2 = 0f;
@@ -2630,9 +2727,8 @@ namespace NovaTerminal.Shell
             int startCellOffset = -1;
             int endCellOffsetExclusive = -1;
 
-            foreach (var rune in runText.EnumerateRunes())
+            foreach (string grapheme in new RunGraphemeEnumerator(runCellTexts))
             {
-                string grapheme = rune.ToString();
                 int w = GetSafeGraphemeWidth(grapheme);
                 if (w <= 0) continue;
 

--- a/tests/NovaTerminal.App.Tests/RenderTests/GraphemeClusterDrawPathTests.cs
+++ b/tests/NovaTerminal.App.Tests/RenderTests/GraphemeClusterDrawPathTests.cs
@@ -1,0 +1,183 @@
+using System;
+using NovaTerminal.Shell;
+using Avalonia.Headless.XUnit;
+using NovaTerminal.Platform;
+using NovaTerminal.Rendering;
+using NovaTerminal.Tests.Infra;
+using NovaTerminal.VT;
+using SkiaSharp;
+using Xunit;
+
+namespace NovaTerminal.Tests.RenderTests
+{
+    /// <summary>
+    /// #234: the per-glyph draw path enumerated <em>runes</em> while calling the result "grapheme", so
+    /// every multi-codepoint sequence was rasterized in pieces and its composed glyph never produced —
+    /// a keycap as digit + selector + enclosing mark, a flag as two letter tiles, a ZWJ family as
+    /// separate people.
+    ///
+    /// The observable used here is the glyph atlas entry count, because it is exactly what the loop
+    /// drives and it does not depend on the CI runner having any particular emoji font: a cluster asked
+    /// for once produces one entry whether or not the typeface can draw it, while a cluster split into
+    /// three runes asks three times.
+    /// </summary>
+    [Trait("Category", "RenderMetrics")]
+    public sealed class GraphemeClusterDrawPathTests
+    {
+        private static readonly CellMetrics Metrics = new()
+        {
+            CellWidth = 8.4f,
+            CellHeight = 18.0f,
+            Baseline = 14.0f,
+            Ascent = 14.0f,
+            Descent = 4.0f
+        };
+
+        private const int Cols = 12;
+        private const int Rows = 2;
+
+        /// <summary>
+        /// Atlas entries produced by rendering <paramref name="content"/> into one row.
+        /// </summary>
+        /// <remarks>
+        /// A blank buffer yields zero: whitespace-only runs are drawn directly and never reach the
+        /// atlas. So a single-cell payload plus the trailing blanks yields one entry for the payload's
+        /// cluster and one for the space that shares its run — two in total, whatever the payload is.
+        /// </remarks>
+        private static int AtlasEntriesFor(string content, bool enableComplexShaping)
+        {
+            var buffer = new TerminalBuffer(Cols, Rows);
+            var parser = new AnsiParser(buffer);
+            parser.Process(content);
+
+            using var glyphCache = new GlyphCache();
+            using var bitmap = SnapshotService.Capture(
+                buffer,
+                Metrics,
+                (int)(Cols * Metrics.CellWidth),
+                (int)(Rows * Metrics.CellHeight),
+                new SnapshotCaptureOptions
+                {
+                    HideCursor = true,
+                    EnableComplexShaping = enableComplexShaping,
+                    GlyphCache = glyphCache
+                });
+
+            return glyphCache.EntryCount;
+        }
+
+        [AvaloniaTheory]
+        // Keycap: "1" + VS16 + COMBINING ENCLOSING KEYCAP.
+        [InlineData("1️⃣", "keycap")]
+        // Flag: two regional indicators.
+        [InlineData("\U0001F1FA\U0001F1F8", "regional indicator pair")]
+        // ZWJ family: three people joined by ZWJ.
+        [InlineData("\U0001F468‍\U0001F469‍\U0001F467", "ZWJ sequence")]
+        // Skin-tone modifier.
+        [InlineData("\U0001F44D\U0001F3FF", "emoji modifier sequence")]
+        // VS16-promoted emoji.
+        [InlineData("❤️", "VS16 sequence")]
+        public void MultiCodepointSequence_CostsOneGlyph_WhenComplexShapingIsDisabled(string sequence, string description)
+        {
+            // `EnableComplexShaping` is a user-facing toggle. With it on, all of these are diverted to
+            // the shaper and never reach the per-glyph loop, which is why the bug stayed hidden; with it
+            // off, this loop is the only thing drawing them.
+            int baseline = AtlasEntriesFor("A", enableComplexShaping: false);
+            int actual = AtlasEntriesFor(sequence, enableComplexShaping: false);
+
+            Assert.Equal(2, baseline); // 'A' and the space beside it - sanity on the measurement itself.
+            Assert.Equal(baseline, actual);
+        }
+
+        [AvaloniaFact]
+        public void CombiningMark_CostsOneGlyph_EvenInTheDefaultConfiguration()
+        {
+            // #234 claimed the default configuration was unaffected because emoji reach the shaper.
+            // That is not true for combining marks: `ContainsRunesRequiringComplexShaping` covers
+            // U+0590-U+0FFF and the emoji ranges but not U+0300-U+036F, so "a + combining acute" fell
+            // through to the per-rune loop with shaping *on* as well, and was drawn as two glyphs
+            // stacked at one origin. Measured, not assumed - this asserts the default path.
+            int baseline = AtlasEntriesFor("A", enableComplexShaping: true);
+            int actual = AtlasEntriesFor("á", enableComplexShaping: true);
+
+            Assert.Equal(2, baseline);
+            Assert.Equal(baseline, actual);
+        }
+
+        [AvaloniaFact]
+        public void PlainAsciiRun_IsUnaffected()
+        {
+            // Guards against the enumerator change altering the ordinary case: two distinct letters
+            // plus the space is three entries, exactly as before.
+            Assert.Equal(3, AtlasEntriesFor("AB", enableComplexShaping: false));
+        }
+
+        [AvaloniaTheory]
+        // A ZWJ family is 2 columns as a cluster but 6 as runes (three 2-wide people, the ZWJs
+        // zero-width), so the old arithmetic overshot by four columns.
+        [InlineData("\U0001F468‍\U0001F469‍\U0001F467")]
+        // A VS16 sequence is 2 columns as a cluster but 1 as runes (U+2764 is narrow on its own and
+        // the selector is zero-width), so the old arithmetic undershot. Both directions matter: a fix
+        // that merely widened something would pass one of these and fail the other.
+        [InlineData("❤️")]
+        public void UnderlineSpansTheClusterWidth_NotTheSumOfRuneWidths(string sequence)
+        {
+            // The half of the defect that is not about glyph composition. The run's total width is
+            // summed from each cell's *cluster* width, but `TryGetUnderlineBounds` walked runes, so the
+            // two disagreed for any cluster whose rune widths do not add up to its cluster width.
+            //
+            // Measured by diffing the same content with and without SGR 4, which isolates the underline
+            // exactly and depends on no glyph metrics at all.
+            float span = MeasureUnderlineSpan(sequence);
+            float letterSpan = MeasureUnderlineSpan("A");
+
+            // The control: a 1-column cell must land in the 1-column band, otherwise the assertion
+            // below would be measuring something other than what it claims.
+            Assert.InRange(letterSpan, Metrics.CellWidth * 0.5f, Metrics.CellWidth * 1.5f);
+
+            Assert.InRange(span, Metrics.CellWidth * 1.5f, Metrics.CellWidth * 2.5f);
+        }
+
+        /// <summary>Width in pixels of the underline drawn beneath <paramref name="content"/>.</summary>
+        private static float MeasureUnderlineSpan(string content)
+        {
+            using var withRule = Render("\u001b[4m" + content);
+            using var without = Render(content);
+
+            int minX = int.MaxValue;
+            int maxX = int.MinValue;
+            for (int y = 0; y < withRule.Height; y++)
+            {
+                for (int x = 0; x < withRule.Width; x++)
+                {
+                    if (withRule.GetPixel(x, y) != without.GetPixel(x, y))
+                    {
+                        if (x < minX) minX = x;
+                        if (x > maxX) maxX = x;
+                    }
+                }
+            }
+
+            Assert.True(maxX >= minX, $"no underline pixels found for '{content}'");
+            return maxX - minX + 1;
+        }
+
+        private static SKBitmap Render(string content)
+        {
+            var buffer = new TerminalBuffer(Cols, Rows);
+            var parser = new AnsiParser(buffer);
+            parser.Process(content);
+
+            return SnapshotService.Capture(
+                buffer,
+                Metrics,
+                (int)(Cols * Metrics.CellWidth),
+                (int)(Rows * Metrics.CellHeight),
+                new SnapshotCaptureOptions
+                {
+                    HideCursor = true,
+                    EnableComplexShaping = false
+                });
+        }
+    }
+}


### PR DESCRIPTION
Closes #234.

## The defect

```csharp
foreach (var rune in runText.EnumerateRunes())
{
    string grapheme = rune.ToString();   // one rune, not one cluster
```

The variable was named `grapheme`; a rune is not a cluster. So every multi-codepoint sequence reaching this loop was rasterized in pieces and its composed glyph never produced — a keycap as digit + selector + enclosing mark, a flag as two letter tiles, a ZWJ family as separate people. Reachable whenever `EnableComplexShaping` is off, which is a user-facing toggle.

## Why re-segmenting `runText` would have been wrong

The obvious fix — swap `EnumerateRunes` for a text-element enumerator over `runText` — introduces a subtler bug. `runText` is the concatenation of the run's cells, and cluster boundaries are not obliged to coincide with cell boundaries: a cell can hold a cluster ending in a ZWJ when a PTY read splits mid-join, and segmenting across the boundary would then fuse two cells into one glyph while `cellX += graphemeWidth` still advanced by two.

So the run's per-cell texts are kept alongside it (`_runCellTexts`, parallel to `_runBuilder`) and segmentation is bounded to a single cell. Each cell is still segmented rather than assumed to be one cluster, because the write path's ZWJ attachment can leave two in one cell — a trailing ZWJ followed by a non-pictographic character does not join under GB11.

`RunGraphemeEnumerator` is a struct with its own `GetEnumerator` so `foreach` binds to it directly; an iterator method would allocate a state machine per run per frame. The single-cluster and single-char cases return the cell's own string, so nothing is allocated where the old code allocated per rune.

## Second site: the underline

`TryGetUnderlineBounds` had the same rune loop, and its column arithmetic could therefore disagree with `totalRunWidth`, which the caller sums from each cell's *cluster* width:

| sequence | cluster width | sum of rune widths |
|---|---|---|
| ZWJ family | 2 | 6 (three 2-wide people, ZWJs zero-width) |
| VS16 heart | 2 | 1 (U+2764 narrow alone, selector zero-width) |

Both now derive from the same per-cell strings, so they agree by construction.

## Two corrections to the issue, both measured

**The default configuration was not fine.** The issue reasons that emoji reach the shaper so only the toggled-off path is affected. But `ContainsRunesRequiringComplexShaping` covers U+0590–U+0FFF and the emoji ranges and *not* U+0300–U+036F, so `a` + combining acute fell through to the per-rune loop with shaping **on** as well, and was drawn as two glyphs stacked at one origin. `CombiningMark_CostsOneGlyph_EvenInTheDefaultConfiguration` asserts the default path.

**The drift goes both ways.** The issue suggests width totals "may or may not already agree". They disagree in both directions, which is why the underline test is a `Theory` over one overshooting and one undershooting sequence — a fix that merely widened something would pass one and fail the other.

## Tests

Nine, on two observables that do not depend on the runner having an emoji font:

- **Glyph-atlas entry count.** A cluster asked for once produces one entry whether or not the typeface can compose it; split into three runes it asks three times. Measured before the fix: keycap 4, flag 3, family 5, skin tone 3, VS16 3 (each including the space beside it). After: 2 across the board, equal to a plain `A`.
- **Underline extent**, obtained by diffing the same content rendered with and without SGR 4, which isolates the rule exactly and involves no glyph metrics.

Both include a control assertion — `Assert.Equal(2, baseline)` on `A`, and a 1-column band on the letter's underline — so a broken measurement fails rather than passing vacuously.

Mutation-checked with a per-rune enumerator: **8 of 9 fail**, the survivor being `PlainAsciiRun_IsUnaffected`, which must pass in both directions since it exists to pin that the ordinary case did not change.

## Verification

- `NovaTerminal.App.Tests` 1277 passed, 1 failed — #232 only, unrelated and already known.
- **Every existing golden PNG still matches byte for byte.** No baseline was regenerated, and none needed to be.
- `Category=RenderMetrics` 18/18.
- Allocation measured on an 80×25 frame with a warm glyph cache: **43.39 B/cell before and after, unchanged.** `Substring` returns the receiver when the range is the whole string, so the old per-rune path was not allocating for ASCII either.

## Adjacent finding, for #127 not here

That 43 B/cell is worth a number on the record. Substituting a cached table of single-char strings for `next.Character.ToString()` at the run-build site drops it to **17.75 B/cell** — so ~59% of the draw path's per-cell allocation is one `ToString` per cell per frame. At 80×25 and 60 fps that is roughly 4 MB/s of garbage. Out of scope here; I'll note it on #127, which owns draw-path allocation.
