### PR TITLE
fix(render): pack glyph ink bounds in the atlas instead of the advance box

### DIFF
--- a/src/NovaTerminal.App/Shell/TerminalDrawOperation.cs
+++ b/src/NovaTerminal.App/Shell/TerminalDrawOperation.cs
@@ -1314,7 +1314,11 @@ namespace NovaTerminal.Shell
 
                         int cellX = c;
                         float yBaselineSnap = baselineYDip;
-                        float glyphY = FromDevicePx(ToDevicePx(yBaselineSnap + font.Metrics.Ascent));
+                        // #172 item 2: the sprite's position now comes from the atlas entry's own ink
+                        // bearing rather than from the font's ascent, so there is no single per-run
+                        // glyph Y any more. Snapping to the device-pixel grid still happens, just per
+                        // glyph and against the baseline.
+                        int baselineDevicePx = ToDevicePx(yBaselineSnap);
                         float invScale = (float)(1.0 / _renderScaling);
                         _blockFillPaint.Color = fg;
                         _blockFillPaint.Style = SKPaintStyle.Fill;
@@ -1474,15 +1478,21 @@ namespace NovaTerminal.Shell
 
                             if (cached != null)
                             {
-                                var (rect, type) = cached.Value;
-                                var xform = SKRotationScaleMatrix.Create(invScale, 0, xIdxSnap, glyphY, 0, 0);
-                                if (type == AtlasType.Alpha8)
+                                var sprite = cached.Value;
+
+                                // Offsets are integer device pixels from the pen origin, and both
+                                // xIdxSnap and the baseline are already on the device-pixel grid, so
+                                // the sprite stays pixel-aligned and therefore sharp.
+                                float spriteX = FromDevicePx(ToDevicePx(xIdxSnap) + sprite.OffsetX);
+                                float spriteY = FromDevicePx(baselineDevicePx + sprite.OffsetY);
+                                var xform = SKRotationScaleMatrix.Create(invScale, 0, spriteX, spriteY, 0, 0);
+                                if (sprite.Type == AtlasType.Alpha8)
                                 {
-                                    AddAlphaBatchEntry(rect, xform, fg);
+                                    AddAlphaBatchEntry(sprite.Rect, xform, fg);
                                 }
                                 else
                                 {
-                                    AddColorBatchEntry(rect, xform);
+                                    AddColorBatchEntry(sprite.Rect, xform);
                                 }
                             }
                             else

--- a/src/NovaTerminal.Rendering/GlyphCache.cs
+++ b/src/NovaTerminal.Rendering/GlyphCache.cs
@@ -5,12 +5,34 @@ using SkiaSharp;
 
 namespace NovaTerminal.Rendering
 {
+    /// <summary>
+    /// A rasterized glyph in the atlas, and where to put it.
+    /// </summary>
+    /// <param name="Rect">The glyph's pixels within its atlas surface.</param>
+    /// <param name="Type">Which surface — see <see cref="GlyphCache.WantsColorGlyph"/>.</param>
+    /// <param name="OffsetX">
+    /// Device-pixel X of the sprite's left edge relative to the pen origin. Usually 0, negative for a
+    /// glyph whose ink starts left of the origin.
+    /// </param>
+    /// <param name="OffsetY">
+    /// Device-pixel Y of the sprite's top edge relative to the baseline, so normally negative.
+    /// </param>
+    /// <remarks>
+    /// #172 item 2: the atlas used to pack every glyph into its <em>advance</em> box — advance width by
+    /// font-wide ascent-to-descent — and the caller placed the sprite at (pen, baseline + ascent),
+    /// which only works while ink stays inside that box. It frequently does not, so the offsets are
+    /// now carried per glyph rather than assumed.
+    /// </remarks>
+    public readonly record struct GlyphSprite(SKRect Rect, AtlasType Type, int OffsetX, int OffsetY);
+
     public class GlyphCache : IDisposable
     {
         private class CacheEntry
         {
             public SKRect Rect;
             public AtlasType Type;
+            public int OffsetX;
+            public int OffsetY;
             public long LastUsed;
         }
 
@@ -80,7 +102,7 @@ namespace NovaTerminal.Rendering
             _atlas = new GlyphAtlas();
         }
 
-        public (SKRect Rect, AtlasType Type)? GetOrAdd(string text, SKFont font, float scale)
+        public GlyphSprite? GetOrAdd(string text, SKFont font, float scale)
         {
             if (string.IsNullOrEmpty(text)) return null;
 
@@ -91,37 +113,45 @@ namespace NovaTerminal.Rendering
                 if (_entries.TryGetValue(key, out var entry))
                 {
                     entry.LastUsed = ++_usageCounter;
-                    return (entry.Rect, entry.Type);
+                    return new GlyphSprite(entry.Rect, entry.Type, entry.OffsetX, entry.OffsetY);
                 }
 
-                var packed = RasterizeAndPack(key);
+                var packed = RasterizeAndPack(key, out bool tooLargeForAtlas);
                 if (packed == null)
                 {
-                    // Atlas overflow. Rather than wiping every cached glyph (the old behaviour,
+                    // A glyph bigger than the whole atlas will never fit, so evicting cannot help.
+                    // Bailing out here matters more since #172 made the packed box the *ink* box,
+                    // which can exceed the advance box: without this, one oversized glyph in the
+                    // visible set would reset the atlas on every single frame, permanently.
+                    if (tooLargeForAtlas) return null;
+
+                    // Genuine overflow. Rather than wiping every cached glyph (the old behaviour,
                     // which forced the whole visible set to be re-rasterized next frame — #125),
                     // rebuild keeping the most-recently-used half so the hot working set stays
                     // warm. Fall back to a full wipe only if even that can't make room.
                     RebuildRetainingHotEntries();
-                    packed = RasterizeAndPack(key);
+                    packed = RasterizeAndPack(key, out _);
                     if (packed == null)
                     {
                         ClearInternal();
                         RendererStatistics.RecordGlyphAtlasReset();
-                        packed = RasterizeAndPack(key);
+                        packed = RasterizeAndPack(key, out _);
                         if (packed == null) return null;
                     }
                 }
 
-                var newEntry = new CacheEntry
+                var sprite = packed.Value;
+                _entries[key] = new CacheEntry
                 {
-                    Rect = packed.Value.Rect,
-                    Type = packed.Value.Type,
+                    Rect = sprite.Rect,
+                    Type = sprite.Type,
+                    OffsetX = sprite.OffsetX,
+                    OffsetY = sprite.OffsetY,
                     LastUsed = ++_usageCounter
                 };
 
-                _entries[key] = newEntry;
                 _needsUpdate = true;
-                return (newEntry.Rect, newEntry.Type);
+                return sprite;
             }
         }
 
@@ -231,11 +261,19 @@ namespace NovaTerminal.Rendering
             };
         }
 
-        // Measures, packs, and rasterizes a glyph into the atlas. Returns null (without touching
-        // _entries) when the atlas has no room, so callers can decide how to evict. Must be called
-        // under _lock.
-        private (SKRect Rect, AtlasType Type)? RasterizeAndPack(GlyphKey key)
+        /// <summary>
+        /// Measures, packs and rasterizes a glyph into the atlas. Returns null without touching
+        /// <c>_entries</c> when it did not fit, so the caller can decide how to evict. Must be called
+        /// under <c>_lock</c>.
+        /// </summary>
+        /// <param name="tooLargeForAtlas">
+        /// True when the glyph is larger than an entire atlas surface and so can never fit, however
+        /// much is evicted. Distinguished from ordinary overflow because the caller's response has to
+        /// differ: evicting is pointless and resetting every frame is worse than not caching it.
+        /// </param>
+        private GlyphSprite? RasterizeAndPack(GlyphKey key, out bool tooLargeForAtlas)
         {
+            tooLargeForAtlas = false;
             string text = key.Text;
 
             var type = WantsColorGlyph(text) ? AtlasType.Color : AtlasType.Alpha8;
@@ -247,13 +285,43 @@ namespace NovaTerminal.Rendering
             physFont.Hinting = SKFontHinting.Full;
             physFont.Subpixel = true;
 
-            // Measure the glyph at physical size
-            float width = physFont.MeasureText(text);
-            var metrics = physFont.Metrics;
-            int h = (int)Math.Ceiling(metrics.Descent - metrics.Ascent);
-            int w = (int)Math.Ceiling(width);
+            // #172 item 2: pack the *ink* bounds, not the advance box. The old box was
+            // ceil(MeasureText) wide by ceil(descent - ascent) tall with the glyph drawn at
+            // y = round(-ascent), which silently cropped anything reaching outside it — measured in
+            // Cascadia Code at 14px, that is Ã Å Ñ Õ Ĩ Ũ losing the top row of their diacritic, ď its
+            // rightmost column and ĥ its leftmost; at 1.5x scaling, 62 glyphs in Latin-1 + Latin
+            // Extended-A. Ink bounds are exact by construction, and usually *smaller* than the advance
+            // box vertically, so the atlas also packs denser.
+            physFont.MeasureText(text, out SKRect bounds);
 
-            if (w == 0) w = 1;
+            int left;
+            int top;
+            int w;
+            int h;
+            if (bounds.IsEmpty)
+            {
+                // No ink at all (a space, or a glyph the typeface draws as nothing). A 1x1
+                // transparent sprite blits to nothing, which is the correct result and far smaller
+                // than the blank advance-width box this used to reserve.
+                left = 0;
+                top = 0;
+                w = 1;
+                h = 1;
+            }
+            else
+            {
+                left = (int)Math.Floor(bounds.Left);
+                top = (int)Math.Floor(bounds.Top);
+                w = Math.Max(1, (int)Math.Ceiling(bounds.Right) - left);
+                h = Math.Max(1, (int)Math.Ceiling(bounds.Bottom) - top);
+            }
+
+            // Pack() adds a 1px gutter, so the usable maximum is one less than the surface.
+            if (w >= GlyphAtlas.AtlasSize || h >= GlyphAtlas.AtlasSize)
+            {
+                tooLargeForAtlas = true;
+                return null;
+            }
 
             var rect = _atlas.Pack(w, h, type);
             if (rect == null) return null;
@@ -265,10 +333,11 @@ namespace NovaTerminal.Rendering
                     IsAntialias = true,
                     Color = SKColors.White,
                 };
-                canvas.DrawText(text, 0, (float)Math.Round(-metrics.Ascent), physFont, paint);
+                // Shift the pen so the ink's top-left lands on the sprite's top-left.
+                canvas.DrawText(text, -left, -top, physFont, paint);
             }, type);
 
-            return (rect.Value, type);
+            return new GlyphSprite(rect.Value, type, left, top);
         }
 
         // Reset the atlas and re-pack only the most-recently-used half of the cached glyphs,
@@ -286,12 +355,21 @@ namespace NovaTerminal.Rendering
 
             foreach (var kv in kept)
             {
-                var packed = RasterizeAndPack(kv.Key);
-                if (packed == null) break; // ran out of room again — drop the rest (coldest first)
+                var packed = RasterizeAndPack(kv.Key, out bool tooLarge);
+                if (packed == null)
+                {
+                    // An oversized glyph can never be re-packed, but the rest of the working set
+                    // still can, so skip it rather than abandoning the rebuild.
+                    if (tooLarge) continue;
+                    break; // ran out of room again — drop the rest (coldest first)
+                }
+
                 _entries[kv.Key] = new CacheEntry
                 {
                     Rect = packed.Value.Rect,
                     Type = packed.Value.Type,
+                    OffsetX = packed.Value.OffsetX,
+                    OffsetY = packed.Value.OffsetY,
                     LastUsed = kv.Value.LastUsed
                 };
             }

--- a/tests/NovaTerminal.App.Tests/RenderTests/AtlasGlyphPlacementTests.cs
+++ b/tests/NovaTerminal.App.Tests/RenderTests/AtlasGlyphPlacementTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using NovaTerminal.Shell;
+using Avalonia.Headless.XUnit;
+using NovaTerminal.Platform;
+using NovaTerminal.Rendering;
+using NovaTerminal.Tests.Infra;
+using NovaTerminal.VT;
+using SkiaSharp;
+using Xunit;
+
+namespace NovaTerminal.Tests.RenderTests
+{
+    /// <summary>
+    /// #172 item 2, end to end: the glyph atlas is a cache, so a frame drawn through it must look like
+    /// the same frame drawn without it. It did not — the atlas packed each glyph into its advance box
+    /// and cropped any ink outside, most visibly the top row of the diacritic on capitals like Ã Å Ñ Õ.
+    ///
+    /// `GlyphInkBoundsTests` pins the packing inside the cache; this pins that the draw path puts the
+    /// sprite where the glyph would have gone. Packing the ink correctly and then blitting it at the
+    /// old anchor is the obvious way to half-fix this, and only a render-level check catches it.
+    /// </summary>
+    [Trait("Category", "RenderMetrics")]
+    public sealed class AtlasGlyphPlacementTests
+    {
+        private static readonly CellMetrics Metrics = new()
+        {
+            CellWidth = 8.4f,
+            CellHeight = 18.0f,
+            Baseline = 14.0f,
+            Ascent = 14.0f,
+            Descent = 4.0f
+        };
+
+        private const int Cols = 24;
+        private const int Rows = 2;
+
+        /// <remarks>
+        /// One glyph per frame, deliberately. Across a multi-glyph run the two paths legitimately
+        /// disagree: without a glyph cache the run is drawn with a single <c>DrawText</c> that
+        /// accumulates the font's own advances, while the cached path places each glyph on the terminal
+        /// cell grid. That is a different (pre-existing) difference, and folding it in would make this
+        /// test measure the wrong thing.
+        /// </remarks>
+        [AvaloniaTheory]
+        [InlineData("A")]
+        [InlineData("W")]
+        [InlineData("j")] // negative left side bearing in many faces
+        [InlineData("g")]
+        [InlineData("_")] // sits below the baseline
+        [InlineData("@")]
+        [InlineData("Ã")] // tall diacritics - the ones actually cropped in Cascadia Code at 14px
+        [InlineData("Å")]
+        [InlineData("Ñ")]
+        [InlineData("Õ")]
+        [InlineData("Ĩ")]
+        [InlineData("Ũ")]
+        [InlineData("ď")] // ink past the advance on the right
+        [InlineData("ĥ")] // ink past the origin on the left
+        [InlineData("Æ")]
+        [InlineData("á")]
+        public void GlyphDrawnThroughTheAtlasLandsWhereTheUncachedGlyphDoes(string glyph)
+        {
+            using var glyphCache = new GlyphCache();
+            using var cached = Render(glyph, glyphCache);
+            using var direct = Render(glyph, glyphCache: null);
+
+            SKRectI a = InkBounds(cached);
+            SKRectI b = InkBounds(direct);
+
+            Assert.False(a.IsEmpty, $"{Describe(glyph)} drew nothing through the atlas");
+            Assert.False(b.IsEmpty, $"{Describe(glyph)} drew nothing without the atlas");
+
+            // Exact, not approximate. Both paths rasterize the same outline at the same size onto the
+            // same pixel grid, and measurement confirms every edge agrees to the pixel - so a
+            // tolerance here would only be hiding something.
+            Assert.True(
+                a == b,
+                $"{Describe(glyph)} ink through the atlas is [{a.Left},{a.Top},{a.Right},{a.Bottom}] "
+                + $"but [{b.Left},{b.Top},{b.Right},{b.Bottom}] without it. The atlas is either cropping "
+                + "the glyph or blitting it in the wrong place (#172 item 2).");
+        }
+
+        /// <summary>Bounding box of everything that differs from the background colour.</summary>
+        private static SKRectI InkBounds(SKBitmap bitmap)
+        {
+            SKColor background = bitmap.GetPixel(bitmap.Width - 1, bitmap.Height - 1);
+            int minX = int.MaxValue, minY = int.MaxValue, maxX = int.MinValue, maxY = int.MinValue;
+
+            for (int y = 0; y < bitmap.Height; y++)
+            {
+                for (int x = 0; x < bitmap.Width; x++)
+                {
+                    if (bitmap.GetPixel(x, y) != background)
+                    {
+                        if (x < minX) minX = x;
+                        if (x > maxX) maxX = x;
+                        if (y < minY) minY = y;
+                        if (y > maxY) maxY = y;
+                    }
+                }
+            }
+
+            return maxX < minX ? SKRectI.Empty : new SKRectI(minX, minY, maxX, maxY);
+        }
+
+        private static SKBitmap Render(string content, GlyphCache? glyphCache)
+        {
+            var buffer = new TerminalBuffer(Cols, Rows);
+            var parser = new AnsiParser(buffer);
+            parser.Process(content);
+
+            return SnapshotService.Capture(
+                buffer,
+                Metrics,
+                (int)(Cols * Metrics.CellWidth),
+                (int)(Rows * Metrics.CellHeight),
+                new SnapshotCaptureOptions { HideCursor = true, GlyphCache = glyphCache });
+        }
+
+        private static string Describe(string s)
+            => string.Join("+", System.Linq.Enumerable.Select(s.EnumerateRunes(), r => "U+" + r.Value.ToString("X4", CultureInfo.InvariantCulture)));
+    }
+}

--- a/tests/NovaTerminal.Rendering.Tests/GlyphInkBoundsTests.cs
+++ b/tests/NovaTerminal.Rendering.Tests/GlyphInkBoundsTests.cs
@@ -1,0 +1,253 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using NovaTerminal.Rendering;
+using SkiaSharp;
+
+namespace NovaTerminal.Rendering.Tests;
+
+/// <summary>
+/// #172 item 2: the atlas packed each glyph into its <em>advance</em> box — <c>ceil(MeasureText)</c>
+/// wide by <c>ceil(descent - ascent)</c> tall, drawn at <c>y = round(-ascent)</c> — and anything whose
+/// ink reached outside that box was cropped by the atlas clip.
+///
+/// The test is written to be font-agnostic, because CI runs on both Windows and Ubuntu and they share
+/// no fonts. Rather than naming glyphs known to overhang, it rasterizes each sample twice: once into a
+/// deliberately oversized bitmap where nothing can possibly be clipped, and once through the cache,
+/// then compares the two ink bounding boxes. Any disagreement is the atlas losing pixels.
+/// </summary>
+public class GlyphInkBoundsTests
+{
+    private static readonly bool SkiaAvailable = CheckSkiaAvailable();
+
+    private static bool CheckSkiaAvailable()
+    {
+        try
+        {
+            using var surface = SKSurface.Create(new SKImageInfo(1, 1, SKColorType.Rgba8888));
+            return surface != null;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    // Latin Extended-A capitals with tall diacritics and a few glyphs with side bearings that reach
+    // past the advance. Whichever of these the runner's default font actually has is enough; the test
+    // asserts that at least one really does overhang, so it cannot pass vacuously.
+    private static readonly string[] Samples =
+    {
+        "A", "j", "f", "W", "g", "@", "_", "|", "/",
+        "Ã", "Å", "Ñ", "Õ", "Æ",
+        "ď", "ĥ", "Ĩ", "Ũ", "ĺ", "ŀ",
+        "á", "Á",
+    };
+
+    [Theory]
+    [InlineData(1.0f)]
+    [InlineData(1.5f)]
+    [InlineData(2.0f)]
+    public void EveryGlyphKeepsAllOfItsInk(float scale)
+    {
+        Assert.SkipUnless(SkiaAvailable, "SkiaSharp native library not available on this platform.");
+
+        using var typeface = SKTypeface.Default;
+        using var font = new SKFont(typeface, 14f);
+        using var cache = new GlyphCache();
+
+        int overhangingSamples = 0;
+        var failures = new List<string>();
+
+        foreach (string text in Samples)
+        {
+            SKSizeI reference = ReferenceInkSize(typeface, 14f * scale, text);
+            if (reference.Width == 0 || reference.Height == 0) continue; // no ink; nothing to lose
+
+            if (ExceedsLegacyAdvanceBox(typeface, 14f * scale, text)) overhangingSamples++;
+
+            var sprite = cache.GetOrAdd(text, font, scale);
+            Assert.NotNull(sprite);
+
+            SKSizeI packed = PackedInkSize(cache, sprite!.Value);
+
+            // One pixel of slack each way: the reference and the atlas rasterize through separate
+            // Skia surfaces, and a faint antialiased edge can land on either side of the alpha
+            // threshold. Cropping loses whole rows or columns, well outside that.
+            if (Math.Abs(packed.Width - reference.Width) > 1 || Math.Abs(packed.Height - reference.Height) > 1)
+            {
+                failures.Add($"{Describe(text)}: atlas ink {packed.Width}x{packed.Height}, "
+                    + $"unclipped ink {reference.Width}x{reference.Height}");
+            }
+        }
+
+        Assert.True(
+            overhangingSamples > 0,
+            "no sampled glyph overhangs the legacy advance box in this font, so this test would pass "
+            + "whether or not the atlas crops. Add a sample that overhangs.");
+
+        Assert.True(
+            failures.Count == 0,
+            $"the atlas cropped {failures.Count} of {Samples.Length} glyphs (#172 item 2):\n  "
+            + string.Join("\n  ", failures));
+    }
+
+    [Fact]
+    public void SpriteOffsetsPlaceTheInkWhereTheGlyphWouldHaveDrawnIt()
+    {
+        Assert.SkipUnless(SkiaAvailable, "SkiaSharp native library not available on this platform.");
+
+        // Packing the ink correctly but blitting it in the old place is the obvious way to get this
+        // wrong, and the size comparison above would not notice. This pins the bearings: the sprite's
+        // offsets must reproduce the ink's position relative to the pen origin.
+        using var typeface = SKTypeface.Default;
+        using var font = new SKFont(typeface, 14f);
+        using var cache = new GlyphCache();
+
+        foreach (string text in Samples)
+        {
+            using var physFont = new SKFont(typeface, 14f)
+            {
+                Edging = SKFontEdging.Antialias,
+                Hinting = SKFontHinting.Full,
+                Subpixel = true
+            };
+            physFont.MeasureText(text, out SKRect bounds);
+            if (bounds.IsEmpty) continue;
+
+            var sprite = cache.GetOrAdd(text, font, 1.0f);
+            Assert.NotNull(sprite);
+
+            Assert.Equal((int)Math.Floor(bounds.Left), sprite!.Value.OffsetX);
+            Assert.Equal((int)Math.Floor(bounds.Top), sprite.Value.OffsetY);
+        }
+    }
+
+    [Fact]
+    public void AGlyphLargerThanTheAtlasIsDeclinedWithoutResettingIt()
+    {
+        Assert.SkipUnless(SkiaAvailable, "SkiaSharp native library not available on this platform.");
+
+        // Ink boxes can exceed advance boxes, so a huge font size can now demand more than a whole
+        // atlas surface. Evicting cannot help, and resetting on every frame forever is much worse
+        // than simply not caching the glyph - so the cache must decline it and leave itself alone.
+        using var typeface = SKTypeface.Default;
+        using var font = new SKFont(typeface, GlyphAtlas.AtlasSize * 4f);
+        using var cache = new GlyphCache();
+
+        // Populate with something ordinary first, so a reset would be observable as a lost entry.
+        using var smallFont = new SKFont(typeface, 14f);
+        Assert.NotNull(cache.GetOrAdd("A", smallFont, 1.0f));
+        long resetsBefore = RendererStatistics.GlyphAtlasResets;
+
+        Assert.Null(cache.GetOrAdd("W", font, 1.0f));
+
+        Assert.Equal(resetsBefore, RendererStatistics.GlyphAtlasResets);
+        Assert.Equal(1, cache.EntryCount);
+        Assert.NotNull(cache.GetOrAdd("A", smallFont, 1.0f));
+    }
+
+    /// <summary>Ink size from a bitmap big enough that clipping is impossible.</summary>
+    private static SKSizeI ReferenceInkSize(SKTypeface typeface, float physicalSize, string text)
+    {
+        SKRectI ink = ReferenceInkRelativeToPen(typeface, physicalSize, text);
+        return ink.IsEmpty ? new SKSizeI(0, 0) : new SKSizeI(ink.Width, ink.Height);
+    }
+
+    /// <summary>
+    /// Rasterized ink bounds relative to the pen origin, from a bitmap big enough that nothing can be
+    /// clipped. Rasterized rather than taken from <c>MeasureText</c> on purpose: hinted glyph bounds
+    /// are rounded outward, so they report up to a pixel of overhang that has no ink in it. Measuring
+    /// pixels keeps the comparison honest in both directions.
+    /// </summary>
+    private static SKRectI ReferenceInkRelativeToPen(SKTypeface typeface, float physicalSize, string text)
+    {
+        int extent = (int)Math.Ceiling(physicalSize * 6) + 16;
+        int penX = extent / 3;
+        int penY = extent / 2;
+
+        using var bitmap = new SKBitmap(extent, extent, SKColorType.Rgba8888, SKAlphaType.Premul);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(SKColors.Transparent);
+
+        using var physFont = new SKFont(typeface, physicalSize)
+        {
+            Edging = SKFontEdging.Antialias,
+            Hinting = SKFontHinting.Full,
+            Subpixel = true
+        };
+        using var paint = new SKPaint { IsAntialias = true, Color = SKColors.White };
+        canvas.DrawText(text, penX, penY, physFont, paint);
+
+        SKRectI ink = InkRect(bitmap, 0, 0, extent, extent);
+        return ink.IsEmpty
+            ? SKRectI.Empty
+            : new SKRectI(ink.Left - penX, ink.Top - penY, ink.Right - penX, ink.Bottom - penY);
+    }
+
+    /// <summary>Ink size within a sprite's rect in the atlas.</summary>
+    private static SKSizeI PackedInkSize(GlyphCache cache, GlyphSprite sprite)
+    {
+        var (alpha, color) = cache.GetAtlasImages();
+        using (alpha)
+        using (color)
+        {
+            using SKBitmap bitmap = SKBitmap.FromImage(sprite.Type == AtlasType.Alpha8 ? alpha : color);
+            return InkSize(
+                bitmap,
+                (int)sprite.Rect.Left,
+                (int)sprite.Rect.Top,
+                (int)sprite.Rect.Width,
+                (int)sprite.Rect.Height);
+        }
+    }
+
+    private static SKSizeI InkSize(SKBitmap bitmap, int x0, int y0, int w, int h)
+    {
+        SKRectI ink = InkRect(bitmap, x0, y0, w, h);
+        return ink.IsEmpty ? new SKSizeI(0, 0) : new SKSizeI(ink.Width, ink.Height);
+    }
+
+    /// <summary>Half-open bounds of the pixels with meaningful alpha in the given region.</summary>
+    private static SKRectI InkRect(SKBitmap bitmap, int x0, int y0, int w, int h)
+    {
+        int minX = int.MaxValue, minY = int.MaxValue, maxX = int.MinValue, maxY = int.MinValue;
+        for (int y = y0; y < y0 + h && y < bitmap.Height; y++)
+        {
+            for (int x = x0; x < x0 + w && x < bitmap.Width; x++)
+            {
+                if (bitmap.GetPixel(x, y).Alpha > 8)
+                {
+                    if (x < minX) minX = x;
+                    if (x > maxX) maxX = x;
+                    if (y < minY) minY = y;
+                    if (y > maxY) maxY = y;
+                }
+            }
+        }
+
+        return maxX < minX ? SKRectI.Empty : new SKRectI(minX, minY, maxX + 1, maxY + 1);
+    }
+
+    /// <summary>Whether this glyph really loses pixels to the box the atlas used to pack it into.</summary>
+    private static bool ExceedsLegacyAdvanceBox(SKTypeface typeface, float physicalSize, string text)
+    {
+        using var physFont = new SKFont(typeface, physicalSize)
+        {
+            Edging = SKFontEdging.Antialias,
+            Hinting = SKFontHinting.Full,
+            Subpixel = true
+        };
+        var metrics = physFont.Metrics;
+        int boxW = Math.Max(1, (int)Math.Ceiling(physFont.MeasureText(text)));
+        int boxH = (int)Math.Ceiling(metrics.Descent - metrics.Ascent);
+        int drawY = (int)Math.Round(-metrics.Ascent);
+
+        SKRectI ink = ReferenceInkRelativeToPen(typeface, physicalSize, text);
+        return !ink.IsEmpty
+            && (ink.Left < 0 || ink.Right > boxW || ink.Top < -drawY || ink.Bottom > boxH - drawY);
+    }
+
+    private static string Describe(string s)
+        => string.Join("+", System.Linq.Enumerable.Select(s.EnumerateRunes(), r => "U+" + r.Value.ToString("X4", CultureInfo.InvariantCulture)));
+}


### PR DESCRIPTION
Closes #172. Item 1 was answered in #229 (the prescription was wrong — recorded in the code), item 3 landed in #233; this is item 2, the last of the three.

## The defect

`RasterizeAndPack` packed every glyph into its **advance** box:

```csharp
int h = (int)Math.Ceiling(metrics.Descent - metrics.Ascent);
int w = (int)Math.Ceiling(physFont.MeasureText(text));
...
canvas.DrawText(text, 0, (float)Math.Round(-metrics.Ascent), physFont, paint);
```

`GlyphAtlas.DrawGlyph` clips to the packed rect, so any ink outside it is simply gone.

In **Cascadia Code at 14px** — the app's own font at its default size — `j` loses two of the five columns of its descender hook, and `Ĩ` loses a column on each side. Ordinary Latin text, not an exotic case. Measured, not inferred:

```
'j' ink through the atlas [4,4,6,16], without it [2,4,6,16]
'Ĩ' ink through the atlas [4,1,7,13], without it [3,1,8,13]
```

## The fix

Measure the ink bounds, pack those, and return the bearing with the rect as a `GlyphSprite`. The draw site positions the sprite from that bearing instead of from `font.Metrics.Ascent`, which also decouples the two: the atlas entry now states where its own content sits rather than the caller assuming a layout.

Offsets are integer device pixels and both the cell x and the baseline are already on the device-pixel grid, so the blit stays pixel-snapped.

## A hazard the change introduces, and the guard for it

Ink boxes are usually *shorter* than ascent-to-descent, so the atlas packs denser. But they can be *wider* than the advance, which makes "glyph bigger than the entire atlas surface" newly reachable. `GetOrAdd`'s overflow path would then evict, retry, reset, retry, and fail — **every frame, forever**, since eviction cannot make room for something larger than the surface. So `RasterizeAndPack` now distinguishes "will never fit" from "no room right now", `GetOrAdd` declines the former without touching the atlas, and `RebuildRetainingHotEntries` skips such an entry rather than abandoning the rebuild. `AGlyphLargerThanTheAtlasIsDeclinedWithoutResettingIt` pins it.

## A correction to the issue's scale

The issue reasons from glyph bounds. Hinted bounds round **outward**, so roughly half the overhang they report contains no ink. My first pass at this counted 10 clipped glyphs in Cascadia at 14px and 62 at 1.5× scaling from bounds arithmetic; measuring actual pixels, most of those "1px overhangs" are empty and the genuinely clipped ones are fewer and larger. Both new suites therefore compare **rasterized pixels**, including the guard that asserts the sample set isn't vacuous — a guard built on the same overstating arithmetic would have been a test that asserts less than it claims.

## Tests — 21, in two layers

**Cache level** (`GlyphInkBoundsTests`, 5): each sprite's ink versus the same glyph rasterized into a bitmap too large to clip, at 1×/1.5×/2× scaling. Font-agnostic, because CI runs Windows and Ubuntu and they share no fonts — rather than naming glyphs known to overhang, it compares the two rasterizations and separately asserts that at least one sample really does overhang on this runner.

**Render level** (`AtlasGlyphPlacementTests`, 16): a frame drawn through the atlas versus the same frame drawn without it. The atlas is a cache, so these must agree — and packing the ink correctly while blitting it at the old anchor would satisfy the cache-level tests entirely. One glyph per frame deliberately: across a multi-glyph run the two paths legitimately differ, because the uncached path draws the run with a single `DrawText` accumulating the font's own advances while the cached path places each glyph on the cell grid. Folding that in would have made the test measure the wrong thing — I found it by probing rather than by assuming, after a whole-string comparison showed a 22px disagreement on `Hello, world`.

Mutation-checked in both directions:

| mutant | fails |
|---|---|
| advance-box packing restored | 4 of 5 cache tests (survivor is the oversized-glyph guard, which targets a different property) |
| ink packed, bearings ignored at the blit | **all 16** placement tests |

## Verification

- `NovaTerminal.Rendering.Tests` 59/59
- `NovaTerminal.App.Tests` 1293 passed, 1 failed — #232 only, unrelated and already known
- `Category=RenderMetrics` 34/34

**On golden PNGs:** they all still pass, but that is not evidence here and I don't want it read as such. `SnapshotService` captures baselines with both caches off by design, so **no golden exercises the glyph atlas at all** — the same shape of gap as the `Render Metrics` job in #127. The render-level tests above are the coverage this path actually has, and they exist because of that gap.
