### PR TITLE
test(assist): stop the layout tests reading the developer settings file

### DIFF
--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistLayoutTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistLayoutTests.cs
@@ -242,9 +242,12 @@ public sealed class CommandAssistLayoutTests
 
         TerminalView termView = Assert.IsType<TerminalView>(pane.FindControl<TerminalView>("TermView"));
         Assert.NotNull(pane.Buffer);
+        // Metrics before layout, not after (#232): arranging TermView resizes the buffer to
+        // Bounds.Height / CellHeight, so pinning afterwards leaves the row count - and therefore any
+        // cursor row this test sets - derived from the ambient font instead of from these numbers.
+        termView.SetMetricsForTest(10, 18);
         termView.Measure(new Size(900, 500));
         termView.Arrange(new Rect(0, 0, 900, 500));
-        termView.SetMetricsForTest(10, 18);
         pane.Buffer.SetCursorPosition(0, 1);
 
         CommandAssistAnchorLayout layout = Assert.IsType<CommandAssistAnchorLayout>(pane.CalculateCommandAssistAnchorLayoutForTest());
@@ -274,9 +277,11 @@ public sealed class CommandAssistLayoutTests
 
         TerminalView termView = Assert.IsType<TerminalView>(pane.FindControl<TerminalView>("TermView"));
         Assert.NotNull(pane.Buffer);
+        // See the note on metric ordering above (#232). Here it mattered doubly: at the ambient cell
+        // height this machine produces, the buffer was 17 rows and row 18 was silently clamped to 16.
+        termView.SetMetricsForTest(10, 18);
         termView.Measure(new Size(900, 500));
         termView.Arrange(new Rect(0, 0, 900, 500));
-        termView.SetMetricsForTest(10, 18);
         pane.Buffer.SetCursorPosition(0, 18);
 
         CommandAssistAnchorLayout layout = Assert.IsType<CommandAssistAnchorLayout>(pane.CalculateCommandAssistAnchorLayoutForTest());
@@ -340,10 +345,16 @@ public sealed class CommandAssistLayoutTests
 
         TerminalView termView = Assert.IsType<TerminalView>(pane.FindControl<TerminalView>("TermView"));
         Assert.NotNull(pane.Buffer);
+        // See the note on metric ordering above (#232).
+        termView.SetMetricsForTest(10, 18);
         termView.Measure(new Size(900, 220));
         termView.Arrange(new Rect(0, 0, 900, 220));
-        termView.SetMetricsForTest(10, 18);
         pane.Buffer.SetCursorPosition(0, 1);
+
+        // The suppression decision is `cursorRow / (visibleRows - 1) < 0.55`, so it turns entirely on
+        // these two numbers. Asserting them makes an environment that produces different ones fail
+        // here, with the numbers, instead of further down as a confusing null layout.
+        AssertPromptHint(termView, expectedCursorRow: 1, expectedVisibleRows: 12);
 
         CommandAssistAnchorLayout? layout = pane.CalculateCommandAssistAnchorLayoutForTest();
 
@@ -370,10 +381,19 @@ public sealed class CommandAssistLayoutTests
 
         TerminalView termView = Assert.IsType<TerminalView>(pane.FindControl<TerminalView>("TermView"));
         Assert.NotNull(pane.Buffer);
+        // #232: this is the test that was red locally and green in CI. Arranging TermView resizes the
+        // buffer to Bounds.Height / CellHeight, so with metrics pinned *after* the arrange the row
+        // count came from the ambient font. On this machine that gave 7 rows, row 7 was clamped to 6,
+        // and 6/11 = 0.545 falls just under the 0.55 band-start ratio - suppressed, layout null. On CI
+        // the row count was larger, row 7 survived, 7/11 = 0.636 cleared the ratio. A margin of 0.005
+        // between passing and failing, decided by a font.
+        termView.SetMetricsForTest(10, 18);
         termView.Measure(new Size(900, 220));
         termView.Arrange(new Rect(0, 0, 900, 220));
-        termView.SetMetricsForTest(10, 18);
         pane.Buffer.SetCursorPosition(0, 7);
+
+        // 220 / 18 = 12 rows, cursor row 7, so 7/11 = 0.636 - above the ratio, hence not suppressed.
+        AssertPromptHint(termView, expectedCursorRow: 7, expectedVisibleRows: 12);
 
         CommandAssistAnchorLayout layout = Assert.IsType<CommandAssistAnchorLayout>(pane.CalculateCommandAssistAnchorLayoutForTest());
 
@@ -605,11 +625,34 @@ public sealed class CommandAssistLayoutTests
         Assert.Equal("No local help found.", emptyState.Text);
     }
 
+    /// <summary>
+    /// Asserts the prompt hint the anchor calculation will actually read.
+    /// </summary>
+    /// <remarks>
+    /// #232: the suppression rule is <c>cursorRow / (visibleRows - 1) &lt; 0.55</c>, and both numbers
+    /// come from TermView's arranged height divided by its cell height. Pinning the metrics keeps them
+    /// deterministic; asserting them here means a future change to how rows are derived fails with the
+    /// numbers rather than as an unexplained null layout twenty lines later.
+    /// </remarks>
+    private static void AssertPromptHint(TerminalView termView, int expectedCursorRow, int expectedVisibleRows)
+    {
+        CommandAssistPromptHint? hint = termView.GetCommandAssistPromptHint();
+        Assert.NotNull(hint);
+        Assert.Equal(expectedVisibleRows, hint!.Value.VisibleRows);
+        Assert.Equal(expectedCursorRow, hint.Value.VisibleCursorVisualRow);
+    }
+
     private static void ConfigureCommandAssist(TerminalPane pane)
     {
-        var settings = TerminalSettings.Load();
-        settings.CommandAssistEnabled = true;
-        settings.CommandAssistHistoryEnabled = true;
+        // Constructed, not TerminalSettings.Load() (#232). Load() reads the *developer's* settings
+        // file, so the font family and size a test runs against were whatever this machine happened to
+        // have configured - 18pt here, 14pt on a CI runner with no settings file at all. That is the
+        // mechanism behind "fails locally, green in CI", and it applied to every test in this file.
+        var settings = new TerminalSettings
+        {
+            CommandAssistEnabled = true,
+            CommandAssistHistoryEnabled = true
+        };
         pane.ApplySettings(settings);
     }
 }

--- a/tests/NovaTerminal.App.Tests/CommandAssist/TerminalPaneCommandAssistShortcutTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/TerminalPaneCommandAssistShortcutTests.cs
@@ -15,7 +15,7 @@ public sealed class TerminalPaneCommandAssistShortcutTests
     public void ApplySettings_WhenAssistEnabled_DoesNotEagerlyInitializeController()
     {
         using var pane = new TerminalPane();
-        var settings = TerminalSettings.Load();
+        var settings = new TerminalSettings(); // constructed, not Load() - see #232
         settings.CommandAssistEnabled = true;
         settings.CommandAssistHistoryEnabled = true;
 
@@ -52,7 +52,7 @@ public sealed class TerminalPaneCommandAssistShortcutTests
     public void OpenCommandAssistHelp_WhenDisabledInSettings_ReturnsFalse()
     {
         using var pane = new TerminalPane();
-        var settings = TerminalSettings.Load();
+        var settings = new TerminalSettings(); // constructed, not Load() - see #232
         settings.CommandAssistEnabled = false;
         settings.CommandAssistHistoryEnabled = true;
         pane.ApplySettings(settings);
@@ -176,7 +176,7 @@ public sealed class TerminalPaneCommandAssistShortcutTests
 
     private static void ConfigureCommandAssist(TerminalPane pane)
     {
-        var settings = TerminalSettings.Load();
+        var settings = new TerminalSettings(); // constructed, not Load() - see #232
         settings.CommandAssistEnabled = true;
         settings.CommandAssistHistoryEnabled = true;
         pane.ApplySettings(settings);

--- a/tests/NovaTerminal.App.Tests/CommandAssist/TerminalViewKeyHandlingTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/TerminalViewKeyHandlingTests.cs
@@ -220,7 +220,7 @@ public sealed class TerminalViewKeyHandlingTests
             Width = 900,
             Height = 500
         };
-        var settings = TerminalSettings.Load();
+        var settings = new TerminalSettings(); // constructed, not Load() - see #232
         settings.CommandAssistEnabled = true;
         settings.CommandAssistHistoryEnabled = true;
         pane.ApplySettings(settings);


### PR DESCRIPTION
Closes #232.

## Root cause — and it was never one test

`ConfigureCommandAssist` called `TerminalSettings.Load()`, which reads the **developer's settings file**. So the font family and size every test in this file ran against were whatever that machine happened to have configured. Here: `MesloLGLDZ Nerd Font Mono` at 18pt. On a CI runner with no settings file: the defaults, 14pt. That is the entire "fails locally, green in CI" mechanism, and it applied to the whole file — only one test happened to sit close enough to a threshold to notice.

## The path from a font to a null layout

Measured, not reasoned:

```
settings:        font='MesloLGLDZ Nerd Font Mono' size=18
after paneArr:   term=0.0x0.0    cellH=28.00 rows=0
after termArr:   term=900.0x220.0 cellH=28.00 rows=7     <-- buffer resized to 7 rows here
after setMetric: term=900.0x220.0 cellH=18.00 rows=12    <-- too late; buffer is still 7
bufferRows=7 visualCursorRow=6                            <-- SetCursorPosition(0, 7) clamped to 6
hint: row=6 rows=12
layout: NULL (suppressed)
```

1. `ApplySettings` at 18pt gives a 28px cell.
2. `termView.Arrange` resizes the buffer to `Bounds.Height / CellHeight` = 220/28 = **7 rows**.
3. `SetCursorPosition(0, 7)` is silently clamped to **6**.
4. `SetMetricsForTest(10, 18)` runs *after* the arrange, so `Rows` recomputes to 12 but the buffer keeps 7 and the cursor keeps 6.
5. Suppression is `cursorRow / (visibleRows - 1) < 0.55`. Locally **6/11 = 0.545** — under. In CI, more rows meant row 7 survived: **7/11 = 0.636** — over.

**A margin of 0.005 between pass and fail, decided by a font.**

## Two fixes, and why the obvious one alone would have been wrong

The issue warned that the numbers would tempt someone into moving the threshold. They would have — and it would have been wrong. The production threshold is fine; the test was feeding it inputs it never intended. The clamp is also correct behaviour: placing a cursor past the end of a buffer should clamp.

1. **Construct `TerminalSettings` instead of loading it** — here and in the three other test files that did the same (4 more call sites). No test should read the user's config; that it changes results is only the most visible consequence.
2. **Pin the cell metrics *before* `Measure`/`Arrange`**, so the buffer's row count derives from the pinned numbers rather than the ambient font. Four tests in this file had the ordering backwards; two already had it right, which is what made the correct pattern easy to confirm. One of the four was also setting cursor row 18 in a buffer that had 17 rows.

Fix 1 removes the machine-specific input; fix 2 removes the font-measurement dependence that would remain even with default settings, since default-font cell height still differs between Windows and Linux. Both are needed.

## Making the next one loud instead of confusing

Added `AssertPromptHint` to the two tests whose outcome turns on the normalized cursor row. The failure this issue describes presented as `Assert.IsType() Failure: Value is null` — twenty lines downstream of the actual problem, with no numbers. Now the inputs are asserted where they are established:

```csharp
AssertPromptHint(termView, expectedCursorRow: 7, expectedVisibleRows: 12);
```

## Verification

Local `NovaTerminal.App.Tests`: **1294 passed, 0 failed.** That is the point of the issue — the suite has reported `1 failed` on every local run for days, which meant a genuine new failure had to be spotted by diffing against a remembered baseline instead of by the suite going red.

`CommandAssistLayoutTests` 23/23 on its own.
