### PR TITLE
chore(logging): route lost Console diagnostics to the debug log

### DIFF
--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -5309,7 +5309,7 @@ namespace NovaTerminal
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error executing command {commandTitle}: {ex.Message}");
+                TerminalLogger.Error($"Error executing command {commandTitle}: {ex.Message}");
                 await ShowSimpleMessageDialogAsync(commandTitle, ex.Message);
             }
         }
@@ -5456,7 +5456,7 @@ namespace NovaTerminal
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"Error executing command {cmd.Title}: {ex.Message}");
+                    TerminalLogger.Error($"Error executing command {cmd.Title}: {ex.Message}");
                 }
             }, DispatcherPriority.Background);
         }

--- a/src/NovaTerminal.App/Program.cs
+++ b/src/NovaTerminal.App/Program.cs
@@ -3,6 +3,7 @@ using Avalonia;
 using Avalonia.Media;
 using System;
 using NovaTerminal.Platform;
+using NovaTerminal.Pty;
 using NovaTerminal.VT;
 
 namespace NovaTerminal;
@@ -41,6 +42,11 @@ class Program
                 return;
             }
 
+            // The PTY layer cannot reference VT (Pty_must_not_depend_on_Vt), so it reports through its
+            // own sink; bridge it here so its diagnostics reach the same debug log as everything else.
+            // Before #109 they went to Console.WriteLine, i.e. nowhere in a GUI process.
+            PtyLogger.Sink = static (level, message) => TerminalLogger.Log(ToLogLevel(level), message);
+
             // Log startup info
             TerminalLogger.Log("NovaTerminal started with args: " + string.Join(" ", args));
             TerminalLogger.Log("Log file path: " + AppLogger.GetLogFilePath());
@@ -57,6 +63,24 @@ class Program
             throw;
         }
     }
+
+    /// <summary>
+    /// Maps the PTY layer's severity onto the app's.
+    /// </summary>
+    /// <remarks>
+    /// Written out rather than cast. The two enums happen to agree member-for-member today, so
+    /// <c>(LogLevel)level</c> would work and would keep working right up until someone inserted a member
+    /// into one of them, at which point every PTY message would be silently mislevelled.
+    /// <c>PtyLogLevelsMatchAppLogLevels</c> in the architecture tests pins the correspondence.
+    /// </remarks>
+    internal static LogLevel ToLogLevel(PtyLogLevel level) => level switch
+    {
+        PtyLogLevel.Debug => LogLevel.Debug,
+        PtyLogLevel.Info => LogLevel.Info,
+        PtyLogLevel.Warning => LogLevel.Warning,
+        PtyLogLevel.Error => LogLevel.Error,
+        _ => LogLevel.Info,
+    };
 
     // Identifies exactly which build is running, so a stale side-by-side copy is obvious
     // in debug.log. Reports git SHA (stamped at compile via the StampGitInfo MSBuild target),

--- a/src/NovaTerminal.App/Shell/ThemeManager.cs
+++ b/src/NovaTerminal.App/Shell/ThemeManager.cs
@@ -62,7 +62,7 @@ namespace NovaTerminal.Shell
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ThemeManager] Error loading theme from {file}: {ex.Message}");
+                    TerminalLogger.Warning($"[ThemeManager] Error loading theme from {file}: {ex.Message}");
                 }
             }
             _isLoaded = true;
@@ -144,7 +144,7 @@ namespace NovaTerminal.Shell
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[ThemeManager] Error saving theme {theme.Name}: {ex.Message}");
+                TerminalLogger.Error($"[ThemeManager] Error saving theme {theme.Name}: {ex.Message}");
             }
         }
 
@@ -167,7 +167,7 @@ namespace NovaTerminal.Shell
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ThemeManager] Error deleting theme {name}: {ex.Message}");
+                    TerminalLogger.Error($"[ThemeManager] Error deleting theme {name}: {ex.Message}");
                 }
             }
         }

--- a/src/NovaTerminal.App/UI/Replay/ReplayViewModel.cs
+++ b/src/NovaTerminal.App/UI/Replay/ReplayViewModel.cs
@@ -97,7 +97,7 @@ namespace NovaTerminal.UI.Replay
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[ReplayViewModel] Init Error: {ex.Message}");
+                TerminalLogger.Error($"[ReplayViewModel] Init Error: {ex.Message}");
             }
         }
 

--- a/src/NovaTerminal.App/UI/Replay/ReplayWindow.axaml.cs
+++ b/src/NovaTerminal.App/UI/Replay/ReplayWindow.axaml.cs
@@ -267,7 +267,7 @@ namespace NovaTerminal.UI.Replay
             catch (OperationCanceledException) { }
             catch (Exception ex)
             {
-                Console.WriteLine($"[ReplayWindow] Playback Error: {ex.Message}");
+                TerminalLogger.Error($"[ReplayWindow] Playback Error: {ex.Message}");
             }
             finally
             {

--- a/src/NovaTerminal.Platform/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Platform/Ssh/Sessions/NativeSshSession.cs
@@ -72,7 +72,7 @@ public sealed class NativeSshSession : ITerminalSession
         _ = extraArgs;
         _cols = cols;
         _rows = rows;
-        _log = log ?? Console.WriteLine;
+        _log = log ?? TerminalLogger.Log;
         _interop = interop ?? new NativeSshInterop();
         _interactionHandler = interactionHandler;
         _profileId = profile.Id;

--- a/src/NovaTerminal.Platform/Ssh/Sessions/OpenSshSession.cs
+++ b/src/NovaTerminal.Platform/Ssh/Sessions/OpenSshSession.cs
@@ -106,7 +106,7 @@ public sealed class OpenSshSession : ITerminalSession
         string args = SshArgBuilder.BuildCommandLine(launchPlan.Arguments);
         string safeArgs = SshArgBuilder.SanitizeForLog(args);
 
-        Action<string> logger = log ?? Console.WriteLine;
+        Action<string> logger = log ?? TerminalLogger.Log;
         logger($"[OpenSshSession] Using OpenSSH executable: {launchPlan.SshExecutablePath}");
         logger($"[OpenSshSession] Arguments: {safeArgs}");
         logger($"[OpenSshSession] Generated config: {launchPlan.ConfigFilePath}");

--- a/src/NovaTerminal.Pty/PtyLogger.cs
+++ b/src/NovaTerminal.Pty/PtyLogger.cs
@@ -33,8 +33,23 @@ namespace NovaTerminal.Pty
     /// </remarks>
     public static class PtyLogger
     {
-        /// <summary>Receives every message at or above <see cref="MinimumLevel"/>. Null discards.</summary>
-        public static Action<PtyLogLevel, string>? Sink { get; set; }
+        /// <summary>
+        /// Receives every message at or above <see cref="MinimumLevel"/>. Never null by default.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to the console rather than to nothing, which review of #244 caught: a null default
+        /// would have fixed the GUI (which replaces this) while making every *other* consumer worse than
+        /// before — PTY diagnostics in the test host and in any library use previously reached a real
+        /// console and would have started disappearing instead.
+        ///
+        /// The console is the right default precisely because it is only wrong when no console exists,
+        /// and the one host in that position sets its own sink at startup before any session is created.
+        /// This is also the only place in the PTY layer allowed to name <c>Console</c>: the guard in
+        /// <c>DiagnosticSinkTests</c> exists to stop *call sites* choosing a destination, and funnelling
+        /// that choice into a single documented default is what it is funnelling them towards.
+        /// </remarks>
+        public static Action<PtyLogLevel, string>? Sink { get; set; } =
+            static (level, message) => Console.Error.WriteLine(level == PtyLogLevel.Info ? message : $"[{level}] {message}");
 
         public static PtyLogLevel MinimumLevel { get; set; } = PtyLogLevel.Debug;
 

--- a/src/NovaTerminal.Pty/PtyLogger.cs
+++ b/src/NovaTerminal.Pty/PtyLogger.cs
@@ -1,0 +1,63 @@
+using System;
+
+namespace NovaTerminal.Pty
+{
+    /// <summary>Severity of a <see cref="PtyLogger"/> message. Mirrors the app's log levels.</summary>
+    public enum PtyLogLevel
+    {
+        Debug,
+        Info,
+        Warning,
+        Error
+    }
+
+    /// <summary>
+    /// Diagnostic sink for the PTY layer.
+    /// </summary>
+    /// <remarks>
+    /// #109: this layer's diagnostics used to go to <c>Console.WriteLine</c>. In a Windows GUI process
+    /// there is no console attached, so every one of those messages — spawn parameters, read-loop
+    /// failures, join timeouts, lost input on a short write — was written to nothing. They looked like
+    /// logging and were closer to comments.
+    ///
+    /// This is deliberately not <c>NovaTerminal.VT.TerminalLogger</c>, even though it duplicates a
+    /// little of its shape. <c>Pty_must_not_depend_on_Vt</c> in the architecture tests forbids it at IL
+    /// level (VT is reachable transitively through Replay, so it would have compiled), and the PTY layer
+    /// genuinely should not need the terminal emulator to report that a pipe read failed. The App wires
+    /// <see cref="Sink"/> to <c>TerminalLogger</c> at startup, so messages land in the same debug log as
+    /// everything else.
+    ///
+    /// The honest longer-term fix is to move the logging facility out of VT into a leaf both layers can
+    /// reference; recorded on #109 rather than done here, because relocating a public type used
+    /// repo-wide does not belong in the change that stops dropping messages.
+    /// </remarks>
+    public static class PtyLogger
+    {
+        /// <summary>Receives every message at or above <see cref="MinimumLevel"/>. Null discards.</summary>
+        public static Action<PtyLogLevel, string>? Sink { get; set; }
+
+        public static PtyLogLevel MinimumLevel { get; set; } = PtyLogLevel.Debug;
+
+        public static void Log(PtyLogLevel level, string message)
+        {
+            if (level < MinimumLevel) return;
+
+            // A throwing sink must never disrupt the caller: these calls sit inside teardown paths and
+            // catch blocks, where an escaping exception would skip the recovery that follows. Same
+            // reasoning as TerminalLogger.Log.
+            try
+            {
+                Sink?.Invoke(level, message);
+            }
+            catch
+            {
+                // Swallow: logging failures must not propagate into error-handling paths.
+            }
+        }
+
+        public static void Debug(string message) => Log(PtyLogLevel.Debug, message);
+        public static void Info(string message) => Log(PtyLogLevel.Info, message);
+        public static void Warning(string message) => Log(PtyLogLevel.Warning, message);
+        public static void Error(string message) => Log(PtyLogLevel.Error, message);
+    }
+}

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -478,7 +478,7 @@ namespace NovaTerminal.Pty
                 }
             }
 
-            Console.WriteLine($"[RustPtySession] Spawning '{effectiveShell}' args='{combinedArgs}' cwd='{cwd}' at {cols}x{rows}");
+            PtyLogger.Info($"[RustPtySession] Spawning '{effectiveShell}' args='{combinedArgs}' cwd='{cwd}' at {cols}x{rows}");
             if (environmentOverrides != null && environmentOverrides.Count > 0)
             {
                 // Pack overrides as newline-separated KEY=VALUE pairs. The
@@ -576,7 +576,7 @@ namespace NovaTerminal.Pty
                     }
                     catch (Exception ex)
                     {
-                        Console.WriteLine($"[RustPtySession] PS Injection Failed: {ex.Message}");
+                        PtyLogger.Warning($"[RustPtySession] PS Injection Failed: {ex.Message}");
                     }
                     finally
                     {
@@ -644,7 +644,7 @@ namespace NovaTerminal.Pty
             {
                 // Try-pattern: expected I/O failures (bad path, permissions, full
                 // disk) must not crash the host on an agent-triggered export.
-                Console.WriteLine($"[RustPtySession] Flight recording export failed: {ex.Message}");
+                PtyLogger.Warning($"[RustPtySession] Flight recording export failed: {ex.Message}");
                 info = default;
                 return false;
             }
@@ -660,11 +660,11 @@ namespace NovaTerminal.Pty
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[RustPtySession] Recording start marker failed: {ex.Message}");
+                PtyLogger.Warning($"[RustPtySession] Recording start marker failed: {ex.Message}");
             }
 
             _recorder = recorder;
-            Console.WriteLine($"[RustPtySession] Recording started to: {filePath}");
+            PtyLogger.Info($"[RustPtySession] Recording started to: {filePath}");
         }
 
         public void StopRecording()
@@ -679,7 +679,7 @@ namespace NovaTerminal.Pty
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[RustPtySession] Recording stop marker failed: {ex.Message}");
+                PtyLogger.Warning($"[RustPtySession] Recording stop marker failed: {ex.Message}");
             }
 
             try
@@ -688,10 +688,10 @@ namespace NovaTerminal.Pty
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[RustPtySession] Recorder dispose failed: {ex.Message}");
+                PtyLogger.Warning($"[RustPtySession] Recorder dispose failed: {ex.Message}");
             }
 
-            Console.WriteLine("[RustPtySession] Recording stopped.");
+            PtyLogger.Info("[RustPtySession] Recording stopped.");
         }
 
         private void ReadLoop()
@@ -748,7 +748,7 @@ namespace NovaTerminal.Pty
                     }
                     else if (read == 0) // EOF
                     {
-                        Console.WriteLine("[RustPtySession] EOF received.");
+                        PtyLogger.Info("[RustPtySession] EOF received.");
                         break;
                     }
                     else // read < 0: error
@@ -762,7 +762,7 @@ namespace NovaTerminal.Pty
                             // read on this thread, which is the same thread that made the failing
                             // pty_read - the channel is thread-local (#120 item 3).
                             string? reason = TryGetNativeLastError();
-                            Console.WriteLine(
+                            PtyLogger.Error(
                                 $"[RustPtySession] pty_read failed {consecutiveReadErrors} times consecutively; ending session."
                                 + (reason is null ? string.Empty : $" Last native error: {reason}"));
                             readFailed = true;
@@ -779,7 +779,7 @@ namespace NovaTerminal.Pty
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[RustPtySession] ReadLoop terminated by unhandled exception: {ex}");
+                PtyLogger.Error($"[RustPtySession] ReadLoop terminated by unhandled exception: {ex}");
             }
             finally
             {
@@ -831,7 +831,7 @@ namespace NovaTerminal.Pty
                     }
                     catch (Exception ex)
                     {
-                        Console.WriteLine($"[RustPtySession] teardown after read failure failed: {ex.Message}");
+                        PtyLogger.Error($"[RustPtySession] teardown after read failure failed: {ex.Message}");
                     }
                 }
 
@@ -862,7 +862,7 @@ namespace NovaTerminal.Pty
                 // Dedicated thread: OnOutputReceived runs arbitrary subscriber code, and
                 // an unhandled exception here would crash the process. Contain + log so a
                 // misbehaving subscriber can't take down the host; still notify exit below.
-                Console.WriteLine($"[RustPtySession] ProcessLoop terminated by unhandled exception: {ex}");
+                PtyLogger.Error($"[RustPtySession] ProcessLoop terminated by unhandled exception: {ex}");
             }
             TryNotifyExit(0);
         }
@@ -899,7 +899,7 @@ namespace NovaTerminal.Pty
                         int written = Native.pty_write(_handle, data, data.Length);
                         if (written != data.Length)
                         {
-                            Console.WriteLine($"[RustPtySession] pty_write returned {written} (expected {data.Length}); input may be lost");
+                            PtyLogger.Warning($"[RustPtySession] pty_write returned {written} (expected {data.Length}); input may be lost");
                         }
                     }
                     catch (ObjectDisposedException)
@@ -911,7 +911,7 @@ namespace NovaTerminal.Pty
             catch (OperationCanceledException) { /* dispose */ }
             catch (Exception ex)
             {
-                Console.WriteLine($"[RustPtySession] WriteLoop terminated by unhandled exception: {ex}");
+                PtyLogger.Error($"[RustPtySession] WriteLoop terminated by unhandled exception: {ex}");
             }
         }
 
@@ -920,7 +920,7 @@ namespace NovaTerminal.Pty
             if (_handle.IsClosed || _handle.IsInvalid || cols <= 0 || rows <= 0) return;
             _cols = cols;
             _rows = rows;
-            Console.WriteLine($"[RustPtySession] Resizing to {cols}x{rows}");
+            PtyLogger.Debug($"[RustPtySession] Resizing to {cols}x{rows}");
             try { Native.pty_resize(_handle, (ushort)cols, (ushort)rows); }
             catch (ObjectDisposedException) { /* session disposed mid-call — ignore resize */ }
             _recorder?.RecordResize(cols, rows);
@@ -940,7 +940,7 @@ namespace NovaTerminal.Pty
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[RustPtySession] StopRecording during dispose failed: {ex.Message}");
+                    PtyLogger.Warning($"[RustPtySession] StopRecording during dispose failed: {ex.Message}");
                 }
             }
 
@@ -973,14 +973,14 @@ namespace NovaTerminal.Pty
                 }
                 if (!(_readLoopThread?.Join(DisposeJoinTimeout) ?? true))
                 {
-                    Console.WriteLine("[RustPtySession] ReadLoop did not exit within join timeout.");
+                    PtyLogger.Warning("[RustPtySession] ReadLoop did not exit within join timeout.");
                 }
             }
 
             // 4. Join the process loop (it exits once the queue is completed/cancelled).
             if (!(_processLoopThread?.Join(DisposeJoinTimeout) ?? true))
             {
-                Console.WriteLine("[RustPtySession] ProcessLoop did not exit within join timeout.");
+                PtyLogger.Warning("[RustPtySession] ProcessLoop did not exit within join timeout.");
             }
 
             // 4b. Join the writer. A write blocked on a full pipe unblocks when the
@@ -988,7 +988,7 @@ namespace NovaTerminal.Pty
             //     IsBackground, so a timed-out join can never block process exit.
             if (!(_writeLoopThread?.Join(DisposeJoinTimeout) ?? true))
             {
-                Console.WriteLine("[RustPtySession] WriteLoop did not exit within join timeout.");
+                PtyLogger.Warning("[RustPtySession] WriteLoop did not exit within join timeout.");
             }
 
             // 5. Release the handle. SafeHandle guarantees pty_close runs only once
@@ -1033,7 +1033,7 @@ namespace NovaTerminal.Pty
                 {
                     // The whole point of tracking the task: a failure here used to be
                     // swallowed as an unobserved exception.
-                    Console.WriteLine($"[RustPtySession] PS injection task faulted: {ex.Message}");
+                    PtyLogger.Warning($"[RustPtySession] PS injection task faulted: {ex.Message}");
                 }
             }
 
@@ -1058,7 +1058,7 @@ namespace NovaTerminal.Pty
             catch (Exception ex)
             {
                 // Best effort: a leftover temp script must never fail a disposal.
-                Console.WriteLine($"[RustPtySession] PS init script cleanup failed: {ex.Message}");
+                PtyLogger.Warning($"[RustPtySession] PS init script cleanup failed: {ex.Message}");
             }
         }
 

--- a/src/NovaTerminal.Replay/Replay/PtyRecorder.cs
+++ b/src/NovaTerminal.Replay/Replay/PtyRecorder.cs
@@ -249,7 +249,7 @@ namespace NovaTerminal.Replay
             catch (OperationCanceledException) { }
             catch (Exception ex)
             {
-                Console.WriteLine($"[PtyRecorder] Write failed: {ex.Message}");
+                TerminalLogger.Warning($"[PtyRecorder] Write failed: {ex.Message}");
             }
         }
 

--- a/tests/NovaTerminal.Architecture.Tests/DiagnosticSinkTests.cs
+++ b/tests/NovaTerminal.Architecture.Tests/DiagnosticSinkTests.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NovaTerminal.Pty;
+using NovaTerminal.VT;
+
+namespace NovaTerminal.Architecture.Tests;
+
+/// <summary>
+/// #109: diagnostics in the GUI and library layers used to go to <c>Console.WriteLine</c>. A Windows GUI
+/// process has no console attached, so those messages — spawn parameters, read-loop failures, join
+/// timeouts, lost input on a short write, theme load errors — were written to nothing. They read as
+/// logging and behaved like comments.
+///
+/// A source scan rather than an IL check, because <c>Console.WriteLine</c> resolves to a BCL call that
+/// carries no marker distinguishing "console tool printing its output" from "GUI code losing a
+/// diagnostic". The distinction is which project it lives in, which only the source tells us.
+/// </summary>
+public class DiagnosticSinkTests
+{
+    /// <summary>
+    /// Projects whose product *is* stdout. Console writes here are correct and must not be "fixed".
+    /// </summary>
+    private static readonly string[] ConsoleToolProjects =
+    [
+        "NovaTerminal.Cli",
+        "NovaTerminal.Conformance",
+    ];
+
+    private static string RepoRoot()
+    {
+        DirectoryInfo? dir = new(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "NovaTerminal.sln")))
+            {
+                return dir.FullName;
+            }
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException("Could not locate repository root from test output path.");
+    }
+
+    [Fact]
+    public void Gui_and_library_code_must_not_write_diagnostics_to_the_console()
+    {
+        string src = Path.Combine(RepoRoot(), "src");
+        var offenders = new List<string>();
+
+        foreach (string file in Directory.EnumerateFiles(src, "*.cs", SearchOption.AllDirectories))
+        {
+            if (file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal) ||
+                file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (ConsoleToolProjects.Any(p =>
+                    file.Contains($"{Path.DirectorySeparatorChar}{p}{Path.DirectorySeparatorChar}", StringComparison.Ordinal)))
+            {
+                continue;
+            }
+
+            string text = File.ReadAllText(file);
+
+            // Console.Out / Console.Error *as values* are fine: Program.cs hands them to the CLI
+            // commands, which is how a GUI executable serves `--replay` and friends. What must not
+            // appear is a write performed by GUI or library code itself.
+            foreach (Match match in Regex.Matches(text, @"Console\s*\.\s*(WriteLine|Write)\s*\(", RegexOptions.None, TimeSpan.FromSeconds(5)))
+            {
+                int line = text.Take(match.Index).Count(c => c == '\n') + 1;
+                offenders.Add($"{Path.GetRelativePath(RepoRoot(), file)}:{line}");
+            }
+
+            foreach (Match match in Regex.Matches(text, @"Console\s*\.\s*Error\s*\.\s*(WriteLine|Write)\s*\(", RegexOptions.None, TimeSpan.FromSeconds(5)))
+            {
+                int line = text.Take(match.Index).Count(c => c == '\n') + 1;
+                offenders.Add($"{Path.GetRelativePath(RepoRoot(), file)}:{line}");
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "Diagnostics written to the console are lost in a GUI process (#109). Use TerminalLogger, "
+            + "or PtyLogger in NovaTerminal.Pty which may not reference VT. Offenders:\n  "
+            + string.Join("\n  ", offenders.Distinct()));
+    }
+
+    [Fact]
+    public void Console_tool_projects_are_still_allowed_to_print()
+    {
+        // Guards the guard: if the exclusion above stopped matching - a project rename, a path-separator
+        // slip - the test would silently police nothing in those projects while appearing to pass.
+        // NovaTerminal.Conformance prints its report to stdout, so it must contain console writes.
+        string conformance = Path.Combine(RepoRoot(), "src", "NovaTerminal.Conformance");
+        int writes = Directory.EnumerateFiles(conformance, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Sum(f => Regex.Count(File.ReadAllText(f), @"Console\s*\.", RegexOptions.None, TimeSpan.FromSeconds(5)));
+
+        Assert.True(writes > 0, "expected the conformance tool to print to stdout; the exclusion list may be stale");
+    }
+
+    [Fact]
+    public void PtyLogLevels_match_app_log_levels()
+    {
+        // Program.ToLogLevel maps between these by name rather than by cast, but the mapping is only
+        // meaningful while the two enums agree. If a member is inserted into one, this fails here rather
+        // than silently mislevelling every PTY message.
+        Assert.Equal(
+            Enum.GetNames<LogLevel>(),
+            Enum.GetNames<PtyLogLevel>());
+    }
+}

--- a/tests/NovaTerminal.Architecture.Tests/DiagnosticSinkTests.cs
+++ b/tests/NovaTerminal.Architecture.Tests/DiagnosticSinkTests.cs
@@ -29,6 +29,21 @@ public class DiagnosticSinkTests
         "NovaTerminal.Conformance",
     ];
 
+    /// <summary>
+    /// The single file allowed to name <c>Console</c> outside the console tools.
+    /// </summary>
+    /// <remarks>
+    /// <c>PtyLogger</c> *is* the destination decision. The rule this test enforces is that call sites do
+    /// not each pick a destination; a logging sink's documented default is where that choice belongs, and
+    /// its default has to be the console so that hosts which have one keep seeing PTY diagnostics.
+    /// Deliberately a one-element list, and <see cref="Only_PtyLogger_is_exempt_from_the_console_rule"/>
+    /// keeps it that way.
+    /// </remarks>
+    private static readonly string[] SinkImplementationFiles =
+    [
+        "PtyLogger.cs",
+    ];
+
     private static string RepoRoot()
     {
         DirectoryInfo? dir = new(AppContext.BaseDirectory);
@@ -59,6 +74,11 @@ public class DiagnosticSinkTests
 
             if (ConsoleToolProjects.Any(p =>
                     file.Contains($"{Path.DirectorySeparatorChar}{p}{Path.DirectorySeparatorChar}", StringComparison.Ordinal)))
+            {
+                continue;
+            }
+
+            if (SinkImplementationFiles.Contains(Path.GetFileName(file), StringComparer.Ordinal))
             {
                 continue;
             }
@@ -100,6 +120,22 @@ public class DiagnosticSinkTests
             .Sum(f => Regex.Count(File.ReadAllText(f), @"Console\s*\.", RegexOptions.None, TimeSpan.FromSeconds(5)));
 
         Assert.True(writes > 0, "expected the conformance tool to print to stdout; the exclusion list may be stale");
+    }
+
+    [Fact]
+    public void Only_PtyLogger_is_exempt_from_the_console_rule()
+    {
+        // An exemption list is how a guard like this rots. One entry, asserted.
+        Assert.Equal(["PtyLogger.cs"], SinkImplementationFiles);
+    }
+
+    [Fact]
+    public void PtyLogger_has_a_sink_by_default()
+    {
+        // Review of #244: a null default would have fixed the GUI while making every other consumer
+        // worse, since PTY diagnostics in the test host previously reached a real console. The GUI
+        // replaces this before creating any session.
+        Assert.NotNull(PtyLogger.Sink);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #109 items 1 and 2. Item 3 stays open with a corrected count.

## Two of the three items were already done

Worth stating plainly, because the issue still described them as broken:

- **Item 1** asks to "extend TerminalLogger with levels" and calls it "a 6-line `Action<string>` hook — no levels, no structure". It already has `LogLevel`, a structured `OnLogLevel` hook, a `MinimumLevel` filter and throw-safety.
- **Item 2's `error.log` half** is gone. The only remaining mention in the tree is a comment in `TerminalDrawOperation` recording that it used to exist, and the draw-path rate limiting the issue asks for is already there.

## What was still real, and it's sharper than "inconsistent logging"

A Windows GUI process has no console attached. So all ~30 `Console.WriteLine` calls in the GUI and library layers were **written to nothing** — not merely unstructured. Spawn parameters, read-loop failures, thread join timeouts, `pty_write returned N (expected M); input may be lost`, theme load and save errors. Diagnostics that read as logging and behaved like comments.

Levels assigned by what the message means, not mechanically:

| level | examples |
|---|---|
| `Error` | unhandled exceptions in the read/process/write loops, failed teardown after read failure, repeated `pty_read` failure ending the session, theme save/delete failures |
| `Warning` | thread join timeouts, short writes losing input, recorder and PS-injection failures, theme load failure for one file |
| `Info` | spawn, EOF, recording started/stopped |
| `Debug` | per-resize chatter |

The two SSH sessions' `log ?? Console.WriteLine` defaults now fall back to the logger.

**Left alone deliberately:** `NovaTerminal.Cli` and `NovaTerminal.Conformance`, whose product *is* stdout, and `Program.cs` handing `Console.Out`/`Console.Error` to the CLI commands. The issue's "28 `Console.WriteLine` calls in src" count sweeps those in; converting them would have broken the conformance tool's output.

## Why NovaTerminal.Pty gets its own logger

My first attempt added `using NovaTerminal.VT;` to `RustPtySession` and called `TerminalLogger`. It compiled — VT is reachable transitively through Replay — and **`Pty_must_not_depend_on_Vt` in the architecture tests is what caught it**. That rule is right: the PTY layer should not need the terminal emulator to report that a pipe read failed.

So `PtyLogger` is a small sink in `NovaTerminal.Pty`, bridged from `Program` at startup. It duplicates a little of `TerminalLogger`'s shape, which is a real cost; the honest fix is to move the logging facility out of VT into a leaf both layers can reference, and that does not belong in the change that stops dropping messages. Noted on the issue as follow-up.

The level mapping is written out rather than cast:

```csharp
internal static LogLevel ToLogLevel(PtyLogLevel level) => level switch { ... };
```

`(LogLevel)level` would work today and would keep working right up until someone inserted a member into one enum, at which point every PTY message would be silently mislevelled.

## Guard

A source scan in the architecture tests, not an IL check — `Console.WriteLine` compiles to a BCL call carrying no marker that distinguishes "console tool printing its output" from "GUI code losing a diagnostic". Only the containing project tells you that.

Three tests:

1. GUI and library code may not write to the console. Reports every offender as `path:line`.
2. **The exclusion list is itself asserted to still match something.** If a project rename or a path-separator slip broke the console-tool exclusion, test 1 would silently police nothing in those projects while appearing to pass.
3. The two level enums are pinned member-for-member.

Verified by reintroducing a `Console.WriteLine` in `ThemeManager` — the scan failed and named `src\NovaTerminal.App\Shell\ThemeManager.cs:65`.

## Item 3 remains, and the count in the issue is low

The issue says 26 empty catch blocks. Counting catches whose body is *entirely* bare — no statement and no comment — gives **43**. Many of this repo's silent catches do carry an explanatory comment and are fine; the 43 are the undocumented ones. That audit is a separate change: each site needs a judgement about whether swallowing is correct, and batching 43 of those into a logging PR would bury the ones that are real bugs.

## Verification

All suites green locally, zero failures: App.Tests 1294, VT 126, Platform 122, Rendering 59, Architecture 21.
