### PR TITLE
fix(palette): list every installed theme instead of two hardcoded entries

### DIFF
--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -4366,9 +4366,25 @@ namespace NovaTerminal
             CommandRegistry.Register("SFTP: Download Folder...", "Remote", () => _ = InitiateSftpTransfer(null, TransferDirection.Download, TransferKind.Folder), "");
             CommandRegistry.Register("SFTP: Show Transfers", "Remote", () => ToggleTransferCenter(), "");
 
-            // Themes
-            CommandRegistry.Register("Theme: Solarized Dark", "Theme", () => { _settings.ThemeName = "Solarized Dark"; ApplyThemeToUI(); ApplySettingsToAllTabs(); _settings.Save(); }, "");
-            CommandRegistry.Register("Theme: Default Dark", "Theme", () => { _settings.ThemeName = "Default (Dark)"; ApplyThemeToUI(); ApplySettingsToAllTabs(); _settings.Save(); }, "");
+            // Themes: one entry per installed theme (built-in + imported), so the
+            // palette never drifts from what the Settings theme list offers.
+            foreach (var themeName in _settings.ThemeManager.GetAvailableThemes()
+                         .OrderBy(t => t, StringComparer.OrdinalIgnoreCase))
+            {
+                CommandRegistry.Register(
+                    $"Theme: {themeName}",
+                    "Theme",
+                    () =>
+                    {
+                        _settings.ThemeName = themeName;
+                        _settings.RefreshActiveTheme();
+                        ApplyThemeToUI();
+                        ApplySettingsToAllTabs();
+                        _settings.Save();
+                    },
+                    "",
+                    $"theme:{themeName}");
+            }
 
             // Cursor UX
             CommandRegistry.Register("Cursor: Block", "View", () => { _settings.CursorStyle = "Block"; ApplySettingsToAllTabs(); _settings.Save(); }, "");


### PR DESCRIPTION
## Problem

The command palette's Theme section registered exactly two commands:

```csharp
CommandRegistry.Register("Theme: Solarized Dark", ...);
CommandRegistry.Register("Theme: Default Dark", ...);
```

The app ships five theme files (`src/NovaTerminal.App/themes/`) plus the built-in
`Default`, so **Dracula, GitHub Dark, Monokai and One Half Dark were unreachable
from the palette**, and any theme the user imported never showed up.

Secondary issue: `Theme: Default Dark` assigned the legacy alias `"Default (Dark)"`
to `ThemeName`. `ThemeManager.GetTheme` rewrites that alias to `"Default"`, so the
`TerminalSettings.ActiveTheme` cache check (`_activeTheme.Name != ThemeName`) never
matched and re-resolved the theme on every access.

## Fix

Register one command per installed theme, enumerated from
`_settings.ThemeManager.GetAvailableThemes()` — the same source
`SettingsWindow.PopulateThemes` uses, so the palette and the Settings theme list
cannot drift apart again. `SetupCommandPalette()` already re-runs each time the
palette opens, so a newly imported theme appears without a restart.

Each command now sets the theme's real name (no alias) and refreshes the cache
before applying.

Palette now lists: Default, Dracula, GitHub Dark, Monokai, One Half Dark,
Solarized Dark.

## Note

Command ids are `theme:<name>` rather than the display title, so frecency ordering
stays stable if titles change. The side effect is that the two old entries lose
their accumulated usage counts.

## Testing

- `scripts/build.ps1 build src/NovaTerminal.App` — 0 errors
- `scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~CommandPalette|FullyQualifiedName~Theme"` — 21 passed

No test added: the new code is a straight enumeration with no branching, and
covering it would require constructing a `MainWindow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
