### PR TITLE
chore(ci): gate dotnet format, and sweep the 674 pre-existing whitespace violations

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,30 @@
+# Line endings are declared here rather than left to each developer's `core.autocrlf` (#216).
+#
+# Why this file exists: `.editorconfig` sets `end_of_line = crlf`, but the repository stores text
+# blobs as LF. On a Windows checkout with `autocrlf=true` the working tree is CRLF and matches
+# `.editorconfig`; on a Linux checkout it is LF and does not. So `dotnet format --verify-no-changes`
+# reached a *different verdict on the same commit* depending on the platform. A format gate whose
+# answer depends on who runs it is worse than no gate, so the rules below make it deterministic.
+#
+# Deliberately narrow: only the extensions the toolchain actually has an opinion about are declared.
+# Everything else stays unspecified, so byte-exact test fixtures (`*.rec` replay recordings, `*.snap`
+# snapshot expectations) and binaries (golden `*.png`) keep exactly the behaviour they have today.
+# Git already auto-detects the images as binary; re-declaring them would change Windows checkout for
+# fixtures that several tests compare as text, which is a risk with no upside here.
+
+# C# and the Avalonia/MSBuild files alongside it: checked out CRLF everywhere, matching
+# `.editorconfig`. These are the rules the format gate depends on.
+*.cs        text eol=crlf
+*.axaml     text eol=crlf
+*.csproj    text eol=crlf
+*.props     text eol=crlf
+*.targets   text eol=crlf
+*.sln       text eol=crlf
+*.runsettings text eol=crlf
+
+# Shell scripts must be LF or they fail to execute on Linux, regardless of authoring platform.
+*.sh        text eol=lf
+
+# Rust sources: LF, matching cargo/rustfmt convention and the crates' own history.
+*.rs        text eol=lf
+*.toml      text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,44 @@ jobs:
   # guards the #124 parser DoS with a 2s ceiling, and measured 2088ms under instrumentation
   # locally. Instrumenting the gate would make the gate's own timing assertions unreliable,
   # so correctness and measurement are kept apart.
+  # Formatting was previously checked only by ci/run.{ps1,sh}, and those were deliberately
+  # report-only because main carried 674 pre-existing whitespace violations. Nothing in
+  # GitHub CI looked at formatting at all, so the count drifted upward unnoticed (649 -> 674
+  # over two weeks with nobody working on it). #216 swept the backlog; this job is the half
+  # that stops it re-accumulating.
+  #
+  # Runs on both OSes on purpose. `.editorconfig` requires CRLF while git stores LF, so
+  # before `.gitattributes` pinned the checkout this check reached a different verdict per
+  # platform. The ubuntu leg is what proves that pinning works.
+  #
+  # Scoped to `whitespace`: a bare `dotnet format` also runs the style and analyzer passes,
+  # whose diagnostics belong to #108. Mixing them would make this gate fail for reasons
+  # unrelated to formatting.
+  format:
+    name: Format (whitespace)
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+          cache: true
+          cache-dependency-path: "**/*.csproj"
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Verify formatting
+        run: dotnet format whitespace --verify-no-changes --no-restore
+
   coverage:
     name: Coverage (NovaTerminal.VT floor)
     runs-on: ubuntu-latest

--- a/ci/run.ps1
+++ b/ci/run.ps1
@@ -47,15 +47,19 @@ Write-Host "=== AOT PUBLISH ==="
     -p:PublishAot=true `
     -p:StripSymbols=true
 
-# Reported, not enforced. `dotnet format --verify-no-changes` currently fails on main
-# with 649 pre-existing whitespace violations across 79 files (~480 of them in
-# TerminalDrawOperation.cs and TerminalBuffer.ReflowEngine.cs alone), so gating on it
-# would make this script permanently red and mask real failures after it. The sweep is
-# tracked in #216; flip this back to a hard failure once it lands.
-Write-Host "=== FORMAT CHECK (report only) ==="
-dotnet format --verify-no-changes
+# Enforced as of #216: the 674 pre-existing whitespace violations that made this
+# report-only have been swept, and `.gitattributes` now pins line endings so the check
+# reaches the same verdict on Windows and Linux (it did not before - `.editorconfig`
+# wants CRLF while git stores LF, so the answer depended on core.autocrlf).
+#
+# Scoped to `whitespace` deliberately. A bare `dotnet format` also runs the style and
+# analyzer passes, whose diagnostics are #108's territory; mixing them in here would
+# make this gate fail for reasons that have nothing to do with formatting.
+Write-Host "=== FORMAT CHECK ==="
+dotnet format whitespace --verify-no-changes
 if ($LASTEXITCODE -ne 0) {
-    Write-Host "FORMAT CHECK: differences found (not failing the run - see comment above)."
+    Write-Host "FORMAT CHECK FAILED: run 'dotnet format whitespace' and commit the result."
+    exit 1
 }
 
 Write-Host "CI SUCCESS"

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -40,14 +40,18 @@ echo "=== TEST ==="
 echo "=== REPLAY TESTS ==="
 "$BUILD" test -c Release --filter Category=Replay
 
-# Reported, not enforced. `dotnet format --verify-no-changes` currently fails on main
-# with 649 pre-existing whitespace violations across 79 files (~480 of them in
-# TerminalDrawOperation.cs and TerminalBuffer.ReflowEngine.cs alone), so gating on it
-# would make this script permanently red and mask real failures after it. The sweep is
-# tracked in #216; flip this back to a hard failure once it lands.
-echo "=== FORMAT CHECK (report only) ==="
-if ! dotnet format --verify-no-changes; then
-    echo "FORMAT CHECK: differences found (not failing the run - see comment above)."
+# Enforced as of #216: the 674 pre-existing whitespace violations that made this
+# report-only have been swept, and `.gitattributes` now pins line endings so the check
+# reaches the same verdict on Windows and Linux (it did not before - `.editorconfig`
+# wants CRLF while git stores LF, so the answer depended on core.autocrlf).
+#
+# Scoped to `whitespace` deliberately. A bare `dotnet format` also runs the style and
+# analyzer passes, whose diagnostics are #108's territory; mixing them in here would
+# make this gate fail for reasons that have nothing to do with formatting.
+echo "=== FORMAT CHECK ==="
+if ! dotnet format whitespace --verify-no-changes; then
+    echo "FORMAT CHECK FAILED: run 'dotnet format whitespace' and commit the result."
+    exit 1
 fi
 
 echo "CI SUCCESS"

--- a/src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs
+++ b/src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs
@@ -378,11 +378,11 @@ namespace NovaTerminal.Controls
 
             SetText("DetailTitle", row.Name);
             SetText("DetailEndpoint", row.Endpoint);
-            SetText("KvHost",  string.IsNullOrWhiteSpace(row.Host)  ? "—" : row.Host);
-            SetText("KvPort",  row.Port.ToString());
-            SetText("KvUser",  string.IsNullOrWhiteSpace(row.User)  ? "—" : row.User);
+            SetText("KvHost", string.IsNullOrWhiteSpace(row.Host) ? "—" : row.Host);
+            SetText("KvPort", row.Port.ToString());
+            SetText("KvUser", string.IsNullOrWhiteSpace(row.User) ? "—" : row.User);
             SetText("KvGroup", string.IsNullOrWhiteSpace(row.GroupPath) ? "Ungrouped" : row.GroupPath);
-            SetText("KvAuth",  DescribeAuth(row.Profile));
+            SetText("KvAuth", DescribeAuth(row.Profile));
 
             var fav = this.FindControl<PathIcon>("DetailFavStar");
             if (fav != null) fav.IsVisible = row.IsFavorite;

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -1736,7 +1736,7 @@ namespace NovaTerminal.Controls
                     {
                         System.Diagnostics.Debug.WriteLine($"[TerminalPane] SSH connection failed for '{profile.Name}': {ex.Message}");
                         WriteBanner($"\r\n[ERROR] SSH Connection Failed: {SanitizeBannerValue(ex.Message)}\r\n");
-                        
+
                         // Fail loudly: Do not fall back to RustPtySession with missing arguments.
                         return;
                     }
@@ -2613,7 +2613,8 @@ namespace NovaTerminal.Controls
             var topLevel = TopLevel.GetTopLevel(this);
             if (topLevel?.StorageProvider == null) return;
 
-            string ext = format.ToLowerInvariant() switch {
+            string ext = format.ToLowerInvariant() switch
+            {
                 "png" => ".png",
                 "ansi" => ".ansi",
                 _ => ".txt"
@@ -2633,12 +2634,12 @@ namespace NovaTerminal.Controls
                 {
                     var dpi = topLevel.RenderScaling;
                     var pixelSize = new PixelSize(
-                        (int)Math.Ceiling(TermView.Bounds.Width * dpi), 
+                        (int)Math.Ceiling(TermView.Bounds.Width * dpi),
                         (int)Math.Ceiling(TermView.Bounds.Height * dpi));
-                    
+
                     var rtb = new Avalonia.Media.Imaging.RenderTargetBitmap(pixelSize, new Vector(96 * dpi, 96 * dpi));
                     rtb.Render(TermView);
-                    
+
                     using var stream = await file.OpenWriteAsync();
                     rtb.Save(stream);
                 }

--- a/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
+++ b/src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs
@@ -20,22 +20,22 @@ public sealed class SshLaunchDetails
     public required string CommandLine { get; init; }
 }
 
-    public sealed class SshConnectionService
+public sealed class SshConnectionService
+{
+    private const string FavoriteTag = "favorite";
+
+    private readonly ISshProfileStore _profileStore;
+
+    public SshConnectionService(ISshProfileStore? profileStore = null)
+        : this(profileStore, null)
     {
-        private const string FavoriteTag = "favorite";
+    }
 
-        private readonly ISshProfileStore _profileStore;
-
-        public SshConnectionService(ISshProfileStore? profileStore = null)
-            : this(profileStore, null)
-        {
-        }
-
-        public SshConnectionService(ISshProfileStore? profileStore, ISshPasswordVault? passwordVault)
-        {
-            _profileStore = profileStore ?? new JsonSshProfileStore();
-            _ = passwordVault;
-        }
+    public SshConnectionService(ISshProfileStore? profileStore, ISshPasswordVault? passwordVault)
+    {
+        _profileStore = profileStore ?? new JsonSshProfileStore();
+        _ = passwordVault;
+    }
 
     public IReadOnlyList<TerminalProfile> GetConnectionProfiles()
     {

--- a/src/NovaTerminal.App/Shell/TerminalDrawOperation.cs
+++ b/src/NovaTerminal.App/Shell/TerminalDrawOperation.cs
@@ -353,7 +353,7 @@ namespace NovaTerminal.Shell
                 frame.ThemeFg = new SKColor(renderSnapshot.Theme.Foreground.R, renderSnapshot.Theme.Foreground.G, renderSnapshot.Theme.Foreground.B, 255);
                 frame.CursorColor = new SKColor(renderSnapshot.Theme.CursorColor.R, renderSnapshot.Theme.CursorColor.G, renderSnapshot.Theme.CursorColor.B, 255);
                 frame.CursorStyle = renderSnapshot.CursorStyle;
-                
+
                 if (renderSnapshot.Images.Length > 0 && renderSnapshot.Images.Array != null)
                 {
                     frame.Images = new List<RenderImageSnapshot>(renderSnapshot.Images.Length);
@@ -367,7 +367,7 @@ namespace NovaTerminal.Shell
                     frame.Images = new List<RenderImageSnapshot>();
                 }
 
-                 // IMPORTANT: Always add exactly one RowRenderItem per visual row
+                // IMPORTANT: Always add exactly one RowRenderItem per visual row
                 // so render loop can safely use r for Y positioning.
                 // Skip row picture cache for AltScreen (mc, vim, htop etc.) — these apps
                 // redraw every row on every focus/resize, giving near-zero cache hit rate.
@@ -808,7 +808,7 @@ namespace NovaTerminal.Shell
                 }
 
                 CompleteFramePerfMetrics(perfWriter, frameSw.Elapsed.TotalMilliseconds, dirtyRowCount, dirtySpanCount);
-                
+
                 return renderSnapshot;
             }
             catch (Exception ex)
@@ -877,7 +877,7 @@ namespace NovaTerminal.Shell
             textY += lineHeight;
             canvas.DrawText($"Draws: {metrics.DrawCallsTotal} (Cache:{metrics.RowPictureCacheHits}/{metrics.RowPictureCacheMisses})", textX, textY, textPaint);
             textY += lineHeight;
-            canvas.DrawText($"Atlas Builds: {metrics.AtlasAlphaGlyphs}/{metrics.AtlasColorGlyphs} | Mem: {metrics.AllocBytesThisFrame/1024.0:F1} kb", textX, textY, textPaint);
+            canvas.DrawText($"Atlas Builds: {metrics.AtlasAlphaGlyphs}/{metrics.AtlasColorGlyphs} | Mem: {metrics.AllocBytesThisFrame / 1024.0:F1} kb", textX, textY, textPaint);
         }
 
         private void FlushBatches(SKCanvas canvas)
@@ -1280,276 +1280,276 @@ namespace NovaTerminal.Shell
                             ? ResolveTypefaceForCodePoint(fallbackChar, primaryTf)
                             : primaryTf;
 
-                    bool useLayer = totalRunWidth > 1;
-                    if (useLayer)
-                    {
-                        canvas.SaveLayer(new SKRect(rx, rowTopYDip, rx + rw, rowTopYDip + (float)_metrics.CellHeight), null);
-                    }
-
-                    var shapingResources = GetOrCreateShapingResources(tfToUse ?? primaryTf);
-                    var shapedFont = shapingResources.Font;
-                    var shaper = shapingResources.Shaper;
-                    LogBoxRunDiagnostics(runText, totalRunWidth, shapedFont, shapedFont.MeasureText(runText));
-                    canvas.DrawShapedText(shaper, runText, rx, baselineYDip, shapedFont, fgPaint);
-                    IncrementShapedTextRun();
-                    IncrementTextDrawCall();
-
-                    if (useLayer) canvas.Restore();
-                    cellsRendered += totalRunWidth;
-                }
-                else
-                {
-                    if (_glyphCache != null && !runIsItalic)
-                    {
-                        if (ShouldDrawRunDirectWhenGlyphCacheEnabled(runText))
+                        bool useLayer = totalRunWidth > 1;
+                        if (useLayer)
                         {
-                            FlushBatches(canvas);
-                            canvas.DrawText(runText, rx, baselineYDip, font, fgPaint);
-                            IncrementTextDrawCall();
-                            IncrementDirectDrawTextCall();
-                            cellsRendered += totalRunWidth;
-                            c = k - 1;
-                            continue;
+                            canvas.SaveLayer(new SKRect(rx, rowTopYDip, rx + rw, rowTopYDip + (float)_metrics.CellHeight), null);
                         }
 
-                        int cellX = c;
-                        float yBaselineSnap = baselineYDip;
-                        // #172 item 2: the sprite's position now comes from the atlas entry's own ink
-                        // bearing rather than from the font's ascent, so there is no single per-run
-                        // glyph Y any more. Snapping to the device-pixel grid still happens, just per
-                        // glyph and against the baseline.
-                        int baselineDevicePx = ToDevicePx(yBaselineSnap);
-                        float invScale = (float)(1.0 / _renderScaling);
-                        _blockFillPaint.Color = fg;
-                        _blockFillPaint.Style = SKPaintStyle.Fill;
-                        _blockFillPaint.IsAntialias = false;
+                        var shapingResources = GetOrCreateShapingResources(tfToUse ?? primaryTf);
+                        var shapedFont = shapingResources.Font;
+                        var shaper = shapingResources.Shaper;
+                        LogBoxRunDiagnostics(runText, totalRunWidth, shapedFont, shapedFont.MeasureText(runText));
+                        canvas.DrawShapedText(shaper, runText, rx, baselineYDip, shapedFont, fgPaint);
+                        IncrementShapedTextRun();
+                        IncrementTextDrawCall();
 
-                        // One iteration per grapheme cluster, not per rune (#234). Everything in this
-                        // body already takes a cluster string and behaves correctly given one; the
-                        // enumerator is what was wrong.
-                        foreach (string grapheme in new RunGraphemeEnumerator(runCellTexts))
-                        {
-                            int graphemeWidth = GetSafeGraphemeWidth(grapheme);
-                            float xIdxSnap = FromDevicePx(_pixelGrid.XForCol(cellX));
-
-                            int fallbackChar = FindFirstMissingGlyphCodePoint(grapheme, primaryTf);
-                            SKFont glyphFont = font;
-                            if (fallbackChar != 0)
-                            {
-                                var glyphTf = ResolveTypefaceForCodePoint(fallbackChar, primaryTf);
-                                if (glyphTf != primaryTf)
-                                {
-                                    glyphFont = GetOrCreateFallbackFont(glyphTf);
-                                }
-                            }
-
-                            if (GlyphDiagnosticsEnabled && IsSingleRuneInRange(grapheme, 0x2500, 0x257F))
-                            {
-                                float measuredGlyphWidth = glyphFont.MeasureText(grapheme);
-                                float expectedGlyphWidth = graphemeWidth * _metrics.CellWidth;
-                                string glyphFamily = glyphFont.Typeface?.FamilyName ?? "unknown";
-                                string diagKey = $"boxglyph:{glyphFamily}:{grapheme}";
-                                string diagMsg = $"[GlyphDiag] box-glyph='{grapheme}' font='{glyphFamily}' measuredDip={measuredGlyphWidth:F4} expectedDip={expectedGlyphWidth:F4} delta={measuredGlyphWidth - expectedGlyphWidth:F4}";
-                                LogDiagOnce(diagKey, diagMsg);
-                            }
-
-                            float cellX1 = xIdxSnap;
-                            float cellX2 = FromDevicePx(_pixelGrid.XForCol(cellX + graphemeWidth));
-                            float cellW = cellX2 - cellX1;
-                            float cellH = snappedCellHeight;
-                            bool hasSingleRune = TryGetSingleRuneCodePoint(grapheme, out int graphemeCodePoint);
-                            bool isBlockShadeOrQuadrant = hasSingleRune && graphemeCodePoint >= 0x2580 && graphemeCodePoint <= 0x259F;
-                            bool isBrailleGlyph = hasSingleRune && graphemeCodePoint >= 0x2800 && graphemeCodePoint <= 0x28FF;
-                            bool isBlackSquareGlyph = hasSingleRune && graphemeCodePoint == 0x25A0;
-                            bool graphGlyphMissing = false;
-                            if ((isBlockShadeOrQuadrant || isBrailleGlyph || isBlackSquareGlyph) &&
-                                (glyphFont.Typeface == null || !glyphFont.Typeface.ContainsGlyph(graphemeCodePoint)))
-                            {
-                                graphGlyphMissing = true;
-                            }
-                            bool usePrimitiveBlockLike = IsBlockElementPrimitiveRenderingEnabled() || isBlockShadeOrQuadrant || isBlackSquareGlyph || graphGlyphMissing;
-                            bool usePrimitiveBraille = IsBlockElementPrimitiveRenderingEnabled() || graphGlyphMissing;
-
-                            // Prefer primitives for block/shade/quadrant bar glyphs to guarantee
-                            // seam-free cell fills. For braille, keep font rendering unless
-                            // primitives are enabled or the current typeface lacks the glyph.
-                            if (usePrimitiveBlockLike &&
-                                TryGetBlockFillRect(grapheme, out int xStartEighths, out int xEndEighths, out int yStartEighths, out int yEndEighths))
-                            {
-                                FlushBatches(canvas);
-
-                                float fillX1 = xStartEighths == 0 ? cellX1 : SnapX(cellX1 + (cellW * (xStartEighths / 8f)));
-                                float fillX2 = xEndEighths == 8 ? cellX2 : SnapX(cellX1 + (cellW * (xEndEighths / 8f)));
-                                float rowBottom = rowTopYDip + cellH;
-                                float fillY1 = yStartEighths == 0 ? rowTopYDip : SnapY(rowTopYDip + (cellH * (yStartEighths / 8f)));
-                                float fillY2 = yEndEighths == 8 ? rowBottom : SnapY(rowTopYDip + (cellH * (yEndEighths / 8f)));
-                                if (fillX2 > fillX1 && fillY2 > fillY1)
-                                {
-                                    canvas.DrawRect(fillX1, fillY1, fillX2 - fillX1, fillY2 - fillY1, _blockFillPaint);
-                                    IncrementRectDrawCall();
-                                }
-
-                                cellX += graphemeWidth;
-                                continue;
-                            }
-
-                            if (usePrimitiveBlockLike && TryGetShadeFillAlpha(grapheme, out float shadeAlpha))
-                            {
-                                FlushBatches(canvas);
-                                byte shadeA = (byte)Math.Clamp((int)Math.Round(fg.Alpha * shadeAlpha), 0, 255);
-                                _shadeFillPaint.Color = new SKColor(fg.Red, fg.Green, fg.Blue, shadeA);
-                                _shadeFillPaint.Style = SKPaintStyle.Fill;
-                                _shadeFillPaint.IsAntialias = false;
-                                if (cellW > 0 && cellH > 0)
-                                {
-                                    canvas.DrawRect(cellX1, rowTopYDip, cellW, cellH, _shadeFillPaint);
-                                    IncrementRectDrawCall();
-                                }
-
-                                cellX += graphemeWidth;
-                                continue;
-                            }
-
-                            if (usePrimitiveBlockLike && TryGetQuadrantFillMask(grapheme, out byte quadrantMask))
-                            {
-                                FlushBatches(canvas);
-                                DrawQuadrantSubcells(canvas, quadrantMask, cellX1, rowTopYDip, cellW, cellH, _blockFillPaint);
-                                cellX += graphemeWidth;
-                                continue;
-                            }
-
-                            if (usePrimitiveBraille && TryGetBraillePattern(grapheme, out byte brailleMask))
-                            {
-                                FlushBatches(canvas);
-                                DrawBrailleSubcells(canvas, brailleMask, cellX1, rowTopYDip, cellW, cellH, _blockFillPaint);
-                                cellX += graphemeWidth;
-                                continue;
-                            }
-
-                            if (IsBoxDrawingPrimitiveRenderingEnabled() &&
-                                TryGetSingleRuneCodePoint(grapheme, out int cpBox) &&
-                                cpBox >= 0x2500 && cpBox <= 0x257F)
-                            {
-                                FlushBatches(canvas);
-                                if (TryDrawBoxDrawingGlyph(canvas, grapheme, cellX1, rowTopYDip, cellW, cellH, fg))
-                                {
-                                    cellX += graphemeWidth;
-                                    continue;
-                                }
-                            }
-
-                            if (ShouldForceDirectTextForGraphGlyph(grapheme))
-                            {
-                                FlushBatches(canvas);
-                                DrawDirectGrapheme(
-                                    canvas,
-                                    grapheme,
-                                    xIdxSnap,
-                                    yBaselineSnap,
-                                    glyphFont,
-                                    fgPaint,
-                                    cellX1,
-                                    rowTopYDip,
-                                    cellW,
-                                    cellH);
-                                cellX += graphemeWidth;
-                                continue;
-                            }
-
-                            if (ShouldBypassGlyphAtlasForGrapheme(grapheme))
-                            {
-                                FlushBatches(canvas);
-                                DrawDirectGrapheme(
-                                    canvas,
-                                    grapheme,
-                                    xIdxSnap,
-                                    yBaselineSnap,
-                                    glyphFont,
-                                    fgPaint,
-                                    cellX1,
-                                    rowTopYDip,
-                                    cellW,
-                                    cellH);
-                                cellX += graphemeWidth;
-                                continue;
-                            }
-
-                            var cached = _glyphCache.GetOrAdd(grapheme, glyphFont, (float)_renderScaling);
-
-                            if (cached != null)
-                            {
-                                var sprite = cached.Value;
-
-                                // Offsets are integer device pixels from the pen origin, and both
-                                // xIdxSnap and the baseline are already on the device-pixel grid, so
-                                // the sprite stays pixel-aligned and therefore sharp.
-                                float spriteX = FromDevicePx(ToDevicePx(xIdxSnap) + sprite.OffsetX);
-                                float spriteY = FromDevicePx(baselineDevicePx + sprite.OffsetY);
-                                var xform = SKRotationScaleMatrix.Create(invScale, 0, spriteX, spriteY, 0, 0);
-                                if (sprite.Type == AtlasType.Alpha8)
-                                {
-                                    AddAlphaBatchEntry(sprite.Rect, xform, fg);
-                                }
-                                else
-                                {
-                                    AddColorBatchEntry(sprite.Rect, xform);
-                                }
-                            }
-                            else
-                            {
-                                FlushBatches(canvas);
-                                canvas.DrawText(grapheme, xIdxSnap, yBaselineSnap, glyphFont, fgPaint);
-                                IncrementTextDrawCall();
-                                IncrementDirectDrawTextCall();
-                            }
-                            cellX += graphemeWidth;
-                        }
-                        LogBoxRunDiagnostics(runText, totalRunWidth, font, font.MeasureText(runText));
+                        if (useLayer) canvas.Restore();
+                        cellsRendered += totalRunWidth;
                     }
                     else
                     {
-                        canvas.DrawText(runText, rx, baselineYDip, font, fgPaint);
-                        IncrementTextDrawCall();
-                        IncrementDirectDrawTextCall();
-                    }
-                    cellsRendered += totalRunWidth;
-                }
-
-                if (appliedItalicTransform)
-                {
-                    canvas.Restore();
-                }
-
-                bool underlineHasVisibleText = runIsUnderline && ContainsNonWhitespace(runText);
-                if (underlineHasVisibleText || runIsStrikethrough)
-                {
-                    _decoStrokePaint.Color = fg;
-                    _decoStrokePaint.IsAntialias = true;
-                    _decoStrokePaint.Style = SKPaintStyle.Stroke;
-                    _decoStrokePaint.StrokeWidth = strokeWidth;
-
-                    if (underlineHasVisibleText)
-                    {
-                        float underlineX1 = rx;
-                        float underlineX2 = rx + rw;
-                        if (TryGetUnderlineBounds(runCellTexts, c, colEdges, paddingLeft, out float trimmedX1, out float trimmedX2))
+                        if (_glyphCache != null && !runIsItalic)
                         {
-                            underlineX1 = trimmedX1;
-                            underlineX2 = trimmedX2;
+                            if (ShouldDrawRunDirectWhenGlyphCacheEnabled(runText))
+                            {
+                                FlushBatches(canvas);
+                                canvas.DrawText(runText, rx, baselineYDip, font, fgPaint);
+                                IncrementTextDrawCall();
+                                IncrementDirectDrawTextCall();
+                                cellsRendered += totalRunWidth;
+                                c = k - 1;
+                                continue;
+                            }
+
+                            int cellX = c;
+                            float yBaselineSnap = baselineYDip;
+                            // #172 item 2: the sprite's position now comes from the atlas entry's own ink
+                            // bearing rather than from the font's ascent, so there is no single per-run
+                            // glyph Y any more. Snapping to the device-pixel grid still happens, just per
+                            // glyph and against the baseline.
+                            int baselineDevicePx = ToDevicePx(yBaselineSnap);
+                            float invScale = (float)(1.0 / _renderScaling);
+                            _blockFillPaint.Color = fg;
+                            _blockFillPaint.Style = SKPaintStyle.Fill;
+                            _blockFillPaint.IsAntialias = false;
+
+                            // One iteration per grapheme cluster, not per rune (#234). Everything in this
+                            // body already takes a cluster string and behaves correctly given one; the
+                            // enumerator is what was wrong.
+                            foreach (string grapheme in new RunGraphemeEnumerator(runCellTexts))
+                            {
+                                int graphemeWidth = GetSafeGraphemeWidth(grapheme);
+                                float xIdxSnap = FromDevicePx(_pixelGrid.XForCol(cellX));
+
+                                int fallbackChar = FindFirstMissingGlyphCodePoint(grapheme, primaryTf);
+                                SKFont glyphFont = font;
+                                if (fallbackChar != 0)
+                                {
+                                    var glyphTf = ResolveTypefaceForCodePoint(fallbackChar, primaryTf);
+                                    if (glyphTf != primaryTf)
+                                    {
+                                        glyphFont = GetOrCreateFallbackFont(glyphTf);
+                                    }
+                                }
+
+                                if (GlyphDiagnosticsEnabled && IsSingleRuneInRange(grapheme, 0x2500, 0x257F))
+                                {
+                                    float measuredGlyphWidth = glyphFont.MeasureText(grapheme);
+                                    float expectedGlyphWidth = graphemeWidth * _metrics.CellWidth;
+                                    string glyphFamily = glyphFont.Typeface?.FamilyName ?? "unknown";
+                                    string diagKey = $"boxglyph:{glyphFamily}:{grapheme}";
+                                    string diagMsg = $"[GlyphDiag] box-glyph='{grapheme}' font='{glyphFamily}' measuredDip={measuredGlyphWidth:F4} expectedDip={expectedGlyphWidth:F4} delta={measuredGlyphWidth - expectedGlyphWidth:F4}";
+                                    LogDiagOnce(diagKey, diagMsg);
+                                }
+
+                                float cellX1 = xIdxSnap;
+                                float cellX2 = FromDevicePx(_pixelGrid.XForCol(cellX + graphemeWidth));
+                                float cellW = cellX2 - cellX1;
+                                float cellH = snappedCellHeight;
+                                bool hasSingleRune = TryGetSingleRuneCodePoint(grapheme, out int graphemeCodePoint);
+                                bool isBlockShadeOrQuadrant = hasSingleRune && graphemeCodePoint >= 0x2580 && graphemeCodePoint <= 0x259F;
+                                bool isBrailleGlyph = hasSingleRune && graphemeCodePoint >= 0x2800 && graphemeCodePoint <= 0x28FF;
+                                bool isBlackSquareGlyph = hasSingleRune && graphemeCodePoint == 0x25A0;
+                                bool graphGlyphMissing = false;
+                                if ((isBlockShadeOrQuadrant || isBrailleGlyph || isBlackSquareGlyph) &&
+                                    (glyphFont.Typeface == null || !glyphFont.Typeface.ContainsGlyph(graphemeCodePoint)))
+                                {
+                                    graphGlyphMissing = true;
+                                }
+                                bool usePrimitiveBlockLike = IsBlockElementPrimitiveRenderingEnabled() || isBlockShadeOrQuadrant || isBlackSquareGlyph || graphGlyphMissing;
+                                bool usePrimitiveBraille = IsBlockElementPrimitiveRenderingEnabled() || graphGlyphMissing;
+
+                                // Prefer primitives for block/shade/quadrant bar glyphs to guarantee
+                                // seam-free cell fills. For braille, keep font rendering unless
+                                // primitives are enabled or the current typeface lacks the glyph.
+                                if (usePrimitiveBlockLike &&
+                                    TryGetBlockFillRect(grapheme, out int xStartEighths, out int xEndEighths, out int yStartEighths, out int yEndEighths))
+                                {
+                                    FlushBatches(canvas);
+
+                                    float fillX1 = xStartEighths == 0 ? cellX1 : SnapX(cellX1 + (cellW * (xStartEighths / 8f)));
+                                    float fillX2 = xEndEighths == 8 ? cellX2 : SnapX(cellX1 + (cellW * (xEndEighths / 8f)));
+                                    float rowBottom = rowTopYDip + cellH;
+                                    float fillY1 = yStartEighths == 0 ? rowTopYDip : SnapY(rowTopYDip + (cellH * (yStartEighths / 8f)));
+                                    float fillY2 = yEndEighths == 8 ? rowBottom : SnapY(rowTopYDip + (cellH * (yEndEighths / 8f)));
+                                    if (fillX2 > fillX1 && fillY2 > fillY1)
+                                    {
+                                        canvas.DrawRect(fillX1, fillY1, fillX2 - fillX1, fillY2 - fillY1, _blockFillPaint);
+                                        IncrementRectDrawCall();
+                                    }
+
+                                    cellX += graphemeWidth;
+                                    continue;
+                                }
+
+                                if (usePrimitiveBlockLike && TryGetShadeFillAlpha(grapheme, out float shadeAlpha))
+                                {
+                                    FlushBatches(canvas);
+                                    byte shadeA = (byte)Math.Clamp((int)Math.Round(fg.Alpha * shadeAlpha), 0, 255);
+                                    _shadeFillPaint.Color = new SKColor(fg.Red, fg.Green, fg.Blue, shadeA);
+                                    _shadeFillPaint.Style = SKPaintStyle.Fill;
+                                    _shadeFillPaint.IsAntialias = false;
+                                    if (cellW > 0 && cellH > 0)
+                                    {
+                                        canvas.DrawRect(cellX1, rowTopYDip, cellW, cellH, _shadeFillPaint);
+                                        IncrementRectDrawCall();
+                                    }
+
+                                    cellX += graphemeWidth;
+                                    continue;
+                                }
+
+                                if (usePrimitiveBlockLike && TryGetQuadrantFillMask(grapheme, out byte quadrantMask))
+                                {
+                                    FlushBatches(canvas);
+                                    DrawQuadrantSubcells(canvas, quadrantMask, cellX1, rowTopYDip, cellW, cellH, _blockFillPaint);
+                                    cellX += graphemeWidth;
+                                    continue;
+                                }
+
+                                if (usePrimitiveBraille && TryGetBraillePattern(grapheme, out byte brailleMask))
+                                {
+                                    FlushBatches(canvas);
+                                    DrawBrailleSubcells(canvas, brailleMask, cellX1, rowTopYDip, cellW, cellH, _blockFillPaint);
+                                    cellX += graphemeWidth;
+                                    continue;
+                                }
+
+                                if (IsBoxDrawingPrimitiveRenderingEnabled() &&
+                                    TryGetSingleRuneCodePoint(grapheme, out int cpBox) &&
+                                    cpBox >= 0x2500 && cpBox <= 0x257F)
+                                {
+                                    FlushBatches(canvas);
+                                    if (TryDrawBoxDrawingGlyph(canvas, grapheme, cellX1, rowTopYDip, cellW, cellH, fg))
+                                    {
+                                        cellX += graphemeWidth;
+                                        continue;
+                                    }
+                                }
+
+                                if (ShouldForceDirectTextForGraphGlyph(grapheme))
+                                {
+                                    FlushBatches(canvas);
+                                    DrawDirectGrapheme(
+                                        canvas,
+                                        grapheme,
+                                        xIdxSnap,
+                                        yBaselineSnap,
+                                        glyphFont,
+                                        fgPaint,
+                                        cellX1,
+                                        rowTopYDip,
+                                        cellW,
+                                        cellH);
+                                    cellX += graphemeWidth;
+                                    continue;
+                                }
+
+                                if (ShouldBypassGlyphAtlasForGrapheme(grapheme))
+                                {
+                                    FlushBatches(canvas);
+                                    DrawDirectGrapheme(
+                                        canvas,
+                                        grapheme,
+                                        xIdxSnap,
+                                        yBaselineSnap,
+                                        glyphFont,
+                                        fgPaint,
+                                        cellX1,
+                                        rowTopYDip,
+                                        cellW,
+                                        cellH);
+                                    cellX += graphemeWidth;
+                                    continue;
+                                }
+
+                                var cached = _glyphCache.GetOrAdd(grapheme, glyphFont, (float)_renderScaling);
+
+                                if (cached != null)
+                                {
+                                    var sprite = cached.Value;
+
+                                    // Offsets are integer device pixels from the pen origin, and both
+                                    // xIdxSnap and the baseline are already on the device-pixel grid, so
+                                    // the sprite stays pixel-aligned and therefore sharp.
+                                    float spriteX = FromDevicePx(ToDevicePx(xIdxSnap) + sprite.OffsetX);
+                                    float spriteY = FromDevicePx(baselineDevicePx + sprite.OffsetY);
+                                    var xform = SKRotationScaleMatrix.Create(invScale, 0, spriteX, spriteY, 0, 0);
+                                    if (sprite.Type == AtlasType.Alpha8)
+                                    {
+                                        AddAlphaBatchEntry(sprite.Rect, xform, fg);
+                                    }
+                                    else
+                                    {
+                                        AddColorBatchEntry(sprite.Rect, xform);
+                                    }
+                                }
+                                else
+                                {
+                                    FlushBatches(canvas);
+                                    canvas.DrawText(grapheme, xIdxSnap, yBaselineSnap, glyphFont, fgPaint);
+                                    IncrementTextDrawCall();
+                                    IncrementDirectDrawTextCall();
+                                }
+                                cellX += graphemeWidth;
+                            }
+                            LogBoxRunDiagnostics(runText, totalRunWidth, font, font.MeasureText(runText));
+                        }
+                        else
+                        {
+                            canvas.DrawText(runText, rx, baselineYDip, font, fgPaint);
+                            IncrementTextDrawCall();
+                            IncrementDirectDrawTextCall();
+                        }
+                        cellsRendered += totalRunWidth;
+                    }
+
+                    if (appliedItalicTransform)
+                    {
+                        canvas.Restore();
+                    }
+
+                    bool underlineHasVisibleText = runIsUnderline && ContainsNonWhitespace(runText);
+                    if (underlineHasVisibleText || runIsStrikethrough)
+                    {
+                        _decoStrokePaint.Color = fg;
+                        _decoStrokePaint.IsAntialias = true;
+                        _decoStrokePaint.Style = SKPaintStyle.Stroke;
+                        _decoStrokePaint.StrokeWidth = strokeWidth;
+
+                        if (underlineHasVisibleText)
+                        {
+                            float underlineX1 = rx;
+                            float underlineX2 = rx + rw;
+                            if (TryGetUnderlineBounds(runCellTexts, c, colEdges, paddingLeft, out float trimmedX1, out float trimmedX2))
+                            {
+                                underlineX1 = trimmedX1;
+                                underlineX2 = trimmedX2;
+                            }
+
+                            float underlineY = FromDevicePx(_pixelGrid.YForUnderline(rowIndex));
+                            canvas.DrawLine(underlineX1, underlineY, underlineX2, underlineY, _decoStrokePaint);
+                            IncrementRectDrawCall();
                         }
 
-                        float underlineY = FromDevicePx(_pixelGrid.YForUnderline(rowIndex));
-                        canvas.DrawLine(underlineX1, underlineY, underlineX2, underlineY, _decoStrokePaint);
-                        IncrementRectDrawCall();
+                        if (runIsStrikethrough)
+                        {
+                            float strikeY = FromDevicePx(_pixelGrid.YForStrike(rowIndex));
+                            canvas.DrawLine(rx, strikeY, rx + rw, strikeY, _decoStrokePaint);
+                            IncrementRectDrawCall();
+                        }
                     }
-
-                    if (runIsStrikethrough)
-                    {
-                        float strikeY = FromDevicePx(_pixelGrid.YForStrike(rowIndex));
-                        canvas.DrawLine(rx, strikeY, rx + rw, strikeY, _decoStrokePaint);
-                        IncrementRectDrawCall();
-                    }
-                }
 
                     c = k - 1;
                 }
@@ -1876,12 +1876,12 @@ namespace NovaTerminal.Shell
                     IsRegionalIndicatorRune(cp) ||       // Flag emoji sequences
                     (cp >= 0x2600 && cp <= 0x27BF) ||   // Dingbats/symbols
                     (cp == 0x200D) ||                    // ZWJ
-                    // Keycap sequences ("1" + FE0F + 20E3) and any other VS16-promoted emoji.
-                    // Without these the run falls through to the per-rune loop below, which calls
-                    // the glyph cache once per *rune* rather than per grapheme cluster - so the
-                    // digit, the selector and the enclosing keycap are rasterized separately and
-                    // the composed glyph is never produced at all. Flags already reach the shaper
-                    // via IsRegionalIndicatorRune for exactly this reason (#172).
+                                                         // Keycap sequences ("1" + FE0F + 20E3) and any other VS16-promoted emoji.
+                                                         // Without these the run falls through to the per-rune loop below, which calls
+                                                         // the glyph cache once per *rune* rather than per grapheme cluster - so the
+                                                         // digit, the selector and the enclosing keycap are rasterized separately and
+                                                         // the composed glyph is never produced at all. Flags already reach the shaper
+                                                         // via IsRegionalIndicatorRune for exactly this reason (#172).
                     (cp == 0xFE0F) ||                    // VARIATION SELECTOR-16
                     (cp == 0x20E3))                      // COMBINING ENCLOSING KEYCAP
                 {

--- a/src/NovaTerminal.App/Shell/TerminalView.cs
+++ b/src/NovaTerminal.App/Shell/TerminalView.cs
@@ -81,10 +81,14 @@ namespace NovaTerminal.Shell
 
             DragDrop.SetAllowDrop(this, true);
             AddHandler(DragDrop.DragOverEvent, OnDragOver);
-            AddHandler(DragDrop.DropEvent, async (s, e) => {
-                try {
+            AddHandler(DragDrop.DropEvent, async (s, e) =>
+            {
+                try
+                {
                     await OnDropAsync(s, e);
-                } catch (Exception ex) {
+                }
+                catch (Exception ex)
+                {
                     System.Diagnostics.Debug.WriteLine($"[TerminalView] OnDropAsync Failed: {ex}");
                 }
             });
@@ -218,7 +222,7 @@ namespace NovaTerminal.Shell
                     }
                     break;
 
-                // Arrows
+                    // Arrows
             }
 
             string? sequence = TerminalInputModeEncoder.EncodeSpecialKey(key, _buffer?.Modes);
@@ -304,7 +308,7 @@ namespace NovaTerminal.Shell
                         _lastCursorRow = cursorRow;
                         _lastCursorCol = cursorCol;
                         CommandAssistAnchorHintChanged?.Invoke();
-                        
+
                         // Reset blink timer on VT cursor movement (like in Vim)
                         // Ensure we don't override the transient cursor suppression (used by AnsiParser for animated text)
                         long now = DateTime.UtcNow.Ticks;
@@ -346,10 +350,10 @@ namespace NovaTerminal.Shell
         private void ResetCursorBlink()
         {
             if (!_cursorBlinkEnabled) return;
-            
+
             // Block transient cursor suppression for 200ms to allow smooth TUI navigation
             _buffer?.BlockCursorSuppression(TimeSpan.FromMilliseconds(200));
-            
+
             _cursorBlinkPhase = true;
             _cursorBlinkTimer.Stop();
             // Restart only if blink should be running at all: an unconditional Start here
@@ -380,7 +384,7 @@ namespace NovaTerminal.Shell
             if (_buffer == null) return;
 
             var m = _buffer.GetMemoryMetrics(_glyphCache.EntryCount, _glyphCache.AtlasByteSize);
-            
+
             // Format for easy log parsing/grep
             TerminalLogger.Log(
                 $"[TerminalMemory] " +
@@ -465,7 +469,7 @@ namespace NovaTerminal.Shell
                 if (paths.Count > 0)
                 {
                     bool isAlt = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
-                    
+
                     bool isWsl = _session.ShellCommand?.Contains("wsl", StringComparison.OrdinalIgnoreCase) ?? false;
                     string? distroName = null;
                     if (isWsl && !string.IsNullOrWhiteSpace(_session.ShellArguments))
@@ -1648,8 +1652,8 @@ namespace NovaTerminal.Shell
             if (cursorBlinkMode && !_cursorBlinkPhase) hideCursor = true;
             if (cursorSuppressedTemporarily)
             {
-                 hideCursor = true;
-                 TerminalLogger.Log($"[TerminalView] Render: Cursor suppressed temporarily.");
+                hideCursor = true;
+                TerminalLogger.Log($"[TerminalView] Render: Cursor suppressed temporarily.");
             }
 
             // Create and dispatch custom draw op

--- a/src/NovaTerminal.Platform/Input/DropRouter.cs
+++ b/src/NovaTerminal.Platform/Input/DropRouter.cs
@@ -14,9 +14,9 @@ namespace NovaTerminal.Platform
     public static class DropRouter
     {
         public static async Task<DropRouterResult> HandleDropAsync(
-            SessionContext context, 
-            IReadOnlyList<string> paths, 
-            bool isAltHeld, 
+            SessionContext context,
+            IReadOnlyList<string> paths,
+            bool isAltHeld,
             IPathMapper? pathMapper = null)
         {
             if (!context.IsEchoEnabled && !isAltHeld)

--- a/src/NovaTerminal.Platform/Input/TextFileDetector.cs
+++ b/src/NovaTerminal.Platform/Input/TextFileDetector.cs
@@ -33,7 +33,7 @@ namespace NovaTerminal.Platform.Input
                         {
                             nulCount++;
                             // A heuristic: if we see even a single NUL byte in the first 8k, it's likely binary.
-                            return false; 
+                            return false;
                         }
                     }
 

--- a/src/NovaTerminal.Platform/Paths/WslPathMapper.cs
+++ b/src/NovaTerminal.Platform/Paths/WslPathMapper.cs
@@ -12,7 +12,7 @@ namespace NovaTerminal.Platform.Paths
     {
         private readonly IProcessRunner _processRunner;
         private readonly string? _distroName;
-        
+
         // LRU Cache: (NormalizedWindowsPath) -> WSLPath
         private static readonly ConcurrentDictionary<(string? Distro, string WinPath), string> _cache = new();
         private static readonly Queue<(string? Distro, string WinPath)> _lruKeys = new();
@@ -45,7 +45,7 @@ namespace NovaTerminal.Platform.Paths
                     : $"-d {_distroName} wslpath -a -u \"{normalizedWinPath}\"";
 
                 var runResult = await _processRunner.RunProcessAsync("wsl.exe", arguments, ct);
-                
+
                 if (runResult.ExitCode == 0 && !string.IsNullOrWhiteSpace(runResult.StdOut))
                 {
                     resultWslPath = runResult.StdOut.Trim();

--- a/src/NovaTerminal.Platform/Ssh/Storage/JsonSshProfileStore.cs
+++ b/src/NovaTerminal.Platform/Ssh/Storage/JsonSshProfileStore.cs
@@ -139,7 +139,7 @@ public sealed class JsonSshProfileStore : ISshProfileStore
                 string directory = Path.GetDirectoryName(_storeFilePath) ?? string.Empty;
                 string timestamp = DateTime.UtcNow.ToString("yyyyMMdd_HHmmss");
                 string backupPath = Path.Combine(directory, $"profiles.json.corrupt.{timestamp}.json");
-                
+
                 File.Move(_storeFilePath, backupPath);
             }
         }
@@ -189,10 +189,10 @@ public sealed class JsonSshProfileStore : ISshProfileStore
         }
 
         string json = JsonSerializer.Serialize(document, SshJsonContext.Default.SshStoreDocument);
-        
+
         string tempPath = Path.Combine(directory ?? string.Empty, $"profiles.json.{Guid.NewGuid():N}.tmp");
         File.WriteAllText(tempPath, json);
-        
+
         try
         {
             if (File.Exists(_storeFilePath))

--- a/src/NovaTerminal.Replay/Replay/ReplayIndex.cs
+++ b/src/NovaTerminal.Replay/Replay/ReplayIndex.cs
@@ -75,7 +75,7 @@ namespace NovaTerminal.Replay
             var entries = new List<ReplayIndexEntry>();
             if (!File.Exists(filePath)) return new ReplayIndex(entries);
 
-            const int bufferSize = 81920; 
+            const int bufferSize = 81920;
             byte[] buffer = new byte[bufferSize];
 
             using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, bufferSize, true);
@@ -90,7 +90,7 @@ namespace NovaTerminal.Replay
                 for (int i = 0; i < bytesRead; i++)
                 {
                     byte b = buffer[i];
-                    
+
                     if (b == '\n')
                     {
                         // Parse line bytes, excluding newline characters
@@ -138,7 +138,7 @@ namespace NovaTerminal.Replay
             {
                 var reader = new Utf8JsonReader(lineBytes);
                 long? foundTime = null;
-                
+
                 while (reader.Read())
                 {
                     if (foundTime == null && reader.TokenType == JsonTokenType.PropertyName && reader.ValueTextEquals("t"u8))
@@ -149,7 +149,7 @@ namespace NovaTerminal.Replay
                         }
                     }
                 }
-                
+
                 return foundTime;
             }
             catch (JsonException)

--- a/src/NovaTerminal.VT/Buffer/ScrollbackPages.cs
+++ b/src/NovaTerminal.VT/Buffer/ScrollbackPages.cs
@@ -173,7 +173,7 @@ namespace NovaTerminal.VT.Storage
                 throw new ArgumentOutOfRangeException(nameof(logicalIndex));
 
             long absRow = _totalRowsEvicted + logicalIndex;
-            
+
             // Fast path: Sequential access cache
             if (_lastAccessedPage != null && !_lastAccessedPage.IsReturned)
             {
@@ -327,7 +327,7 @@ namespace NovaTerminal.VT.Storage
             _currentBytes = 0;
             _totalRowsAppended = 0;
             _totalRowsEvicted = 0;
-            
+
             _lastAccessedPage = null;
             _lastAccessedPageStartAbsRow = 0;
         }

--- a/src/NovaTerminal.VT/Buffer/TerminalPage.cs
+++ b/src/NovaTerminal.VT/Buffer/TerminalPage.cs
@@ -31,10 +31,10 @@ namespace NovaTerminal.VT.Storage
         public int UsedRows;
 
         private bool _returned;
-        
+
         /// <summary>Returns true if this page has been returned to the pool and should not be accessed.</summary>
         public bool IsReturned => _returned;
-        
+
         private ulong _isWrappedMask;
 
         // Sparse per-row metadata side-channels. null = no extended text/hyperlinks on any row in this page.

--- a/src/NovaTerminal.VT/Export/TerminalExporter.cs
+++ b/src/NovaTerminal.VT/Export/TerminalExporter.cs
@@ -20,7 +20,7 @@ namespace NovaTerminal.VT.Export
                     {
                         var cell = buffer.GetCell(c, r);
                         if (cell.IsWideContinuation) continue;
-                        
+
                         string text = buffer.GetGrapheme(c, r);
                         rowSb.Append(text);
                         if (!string.IsNullOrWhiteSpace(text) && text != "\0")
@@ -28,7 +28,7 @@ namespace NovaTerminal.VT.Export
                             lastNonEmpty = rowSb.Length;
                         }
                     }
-                    
+
                     if (lastNonEmpty >= 0)
                     {
                         sb.AppendLine(rowSb.ToString().Substring(0, lastNonEmpty));
@@ -38,7 +38,7 @@ namespace NovaTerminal.VT.Export
                         sb.AppendLine();
                     }
                 }
-                
+
                 return sb.ToString().TrimEnd();
             }
             finally
@@ -84,11 +84,11 @@ namespace NovaTerminal.VT.Export
 
                         sb.Append(buffer.GetGrapheme(c, r));
                     }
-                    
+
                     // Reset at end of line if needed
-                    bool needsEolReset = !lastCell.IsDefaultBackground || !lastCell.IsDefaultForeground || 
-                                       lastCell.IsBold || lastCell.IsItalic || lastCell.IsUnderline || 
-                                       lastCell.IsInverse || lastCell.IsStrikethrough || lastCell.IsFaint || 
+                    bool needsEolReset = !lastCell.IsDefaultBackground || !lastCell.IsDefaultForeground ||
+                                       lastCell.IsBold || lastCell.IsItalic || lastCell.IsUnderline ||
+                                       lastCell.IsInverse || lastCell.IsStrikethrough || lastCell.IsFaint ||
                                        lastCell.IsHidden || lastCell.IsBlink;
 
                     if (!isFirstCell && needsEolReset)
@@ -96,7 +96,7 @@ namespace NovaTerminal.VT.Export
                         sb.Append("\x1b[0m");
                         lastCell = TerminalCell.Default;
                     }
-                    
+
                     sb.AppendLine();
                 }
                 return sb.ToString().TrimEnd();
@@ -156,7 +156,7 @@ namespace NovaTerminal.VT.Export
                 if (cell.IsInverse) codes.Add(7);
                 if (cell.IsHidden) codes.Add(8);
                 if (cell.IsStrikethrough) codes.Add(9);
-                
+
                 // Colors will be added below
             }
             else

--- a/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
@@ -48,7 +48,7 @@ namespace NovaTerminal.VT
 
             // Scrollback rows are now paged, they don't exist as persistent TerminalRow objects.
             if (absRow < _scrollback.Count) return null;
-            
+
             int viewportRow = absRow - _scrollback.Count;
             if (viewportRow < 0 || viewportRow >= Rows) return null;
             return _viewport[viewportRow];
@@ -83,7 +83,7 @@ namespace NovaTerminal.VT
         {
             AssertLockHeld();
             if (absRow < 0 || col < 0 || col >= Cols) return " ";
-            
+
             if (!_isAltScreen && absRow < _scrollback.Count)
             {
                 // The side table has been carried into scrollback since the row-metadata
@@ -113,7 +113,7 @@ namespace NovaTerminal.VT
             try
             {
                 if (absRow < 0 || col < 0 || col >= Cols) return null;
-                
+
                 if (!_isAltScreen && absRow < _scrollback.Count)
                 {
                     // Same gap as GetGraphemeAbsolute: the hyperlink side table survives

--- a/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
@@ -170,261 +170,261 @@ namespace NovaTerminal.VT
                             altSavedInLogicalOffset = (logicalCellsCount - currentLogStart) + _savedCursors.Alt.Col;
                         }
 
-                            int validLen = physRow.Cells.Length;
+                        int validLen = physRow.Cells.Length;
 
-                            // HEURISTIC: TUI Border Protection
-                            // If a line is marked as Wrapped, but it ends with a box-drawing character OR a colored background,
-                            // it is likely a fixed-width TUI element that should NOT flow into the next line on resize.
-                            bool ignoreWrap = false;
-                            if (physRow.IsWrapped)
+                        // HEURISTIC: TUI Border Protection
+                        // If a line is marked as Wrapped, but it ends with a box-drawing character OR a colored background,
+                        // it is likely a fixed-width TUI element that should NOT flow into the next line on resize.
+                        bool ignoreWrap = false;
+                        if (physRow.IsWrapped)
+                        {
+                            // 1. Check for TUI Background Fill (at the very edge)
+                            // TUI apps often fill the background with a specific color (e.g. blue for MC).
+                            // If the last cell has a non-default background AND is a SPACE, it likely hit the edge of a panel.
+                            // We must NOT trigger this for regular text (e.g. "Hint" with black BG), or it won't reflow.
+                            if (physRow.Cells.Length > 0)
                             {
-                                // 1. Check for TUI Background Fill (at the very edge)
-                                // TUI apps often fill the background with a specific color (e.g. blue for MC).
-                                // If the last cell has a non-default background AND is a SPACE, it likely hit the edge of a panel.
-                                // We must NOT trigger this for regular text (e.g. "Hint" with black BG), or it won't reflow.
-                                if (physRow.Cells.Length > 0)
+                                // Scan backwards for the last actual content (skipping newly allocated nulls from resize)
+                                TerminalCell lastCell = default;
+                                bool found = false;
+                                for (int k = physRow.Cells.Length - 1; k >= 0; k--)
                                 {
-                                    // Scan backwards for the last actual content (skipping newly allocated nulls from resize)
-                                    TerminalCell lastCell = default;
-                                    bool found = false;
-                                    for (int k = physRow.Cells.Length - 1; k >= 0; k--)
+                                    if (physRow.Cells[k].Character != '\0')
                                     {
-                                        if (physRow.Cells[k].Character != '\0')
-                                        {
-                                            lastCell = physRow.Cells[k];
-                                            found = true;
-                                            break;
-                                        }
-                                    }
-
-                                    if (found && lastCell.Character == ' ' && !lastCell.IsDefaultBackground)
-                                    {
-                                        ignoreWrap = true;
-                                    }
-                                    else
-                                    {
-                                        // 2. Check for Border Characters (ignoring trailing spaces)
-                                        for (int k = physRow.Cells.Length - 1; k >= 0; k--)
-                                        {
-                                            var c = physRow.Cells[k];
-                                            char ch = c.Character;
-                                            if (ch != ' ' && ch != '\0')
-                                            {
-                                                // Vertical bars, corners, etc.
-                                                // U+2500 to U+257F are Box Drawing. 
-                                                // U+2580 to U+259F are Block Elements (Full Block, Shades, etc.) used for scrollbars/shadows.
-                                                // U+FF00 to U+FFEF are Halfwidth and Fullwidth Forms (includes Fullwidth Pipe U+FF5C).
-                                                // '|' is standard vertical bar (U+007C).
-                                                // '+' and '-' can be ASCII borders.
-                                                // '>' is often used by MC to indicate horizontal scroll overflow.
-                                                if (ch == '|' || ch == '+' || ch == '-' || ch == '>' ||
-                                                   (ch >= '\u2500' && ch <= '\u257F') ||
-                                                   (ch >= '\u2580' && ch <= '\u259F') ||
-                                                   (ch >= '\uFF00' && ch <= '\uFFEF'))
-                                                {
-                                                    ignoreWrap = true;
-                                                }
-                                                // Special Case: MC Headers like ".[^]" often end with ']' or '^'.
-                                                // These are text characters, so we can't protect them globally (would break text wrapping).
-                                                // However, in TUI headers, they typically have a specific background color.
-                                                // Also protect Arrows '↑' (U+2191) and '↓' (U+2193) which are sometimes used as sort indicators.
-                                                else if ((ch == ']' || ch == '[' || ch == '^' || ch == '\u2191' || ch == '\u2193') && !c.IsDefaultBackground)
-                                                {
-                                                    ignoreWrap = true;
-                                                }
-                                                break;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-
-                            if (!physRow.IsWrapped || ignoreWrap)
-                            {
-                                // Smart trimming: Calculate last relevant content index
-                                // Include cells that are non-space OR have non-default background
-                                int lastContentIdx = -1;
-                                // A hyperlink counts as content even on a blank cell. OSC 8 spans
-                                // routinely include trailing spaces, and those columns carry no
-                                // signal in the cell itself - trimming them here dropped their
-                                // links for good, since everything past validLen never enters the
-                                // logical stream. HasExtendedText is checked for the same reason.
-                                bool rowHasLinks = physRow.GetHyperlinkMap() is { Count: > 0 };
-                                for (int scan = 0; scan < physRow.Cells.Length; scan++)
-                                {
-                                    var cell = physRow.Cells[scan];
-                                    if ((cell.Character != ' ' && cell.Character != '\0') || !cell.IsDefaultBackground || cell.HasExtendedText
-                                        || (rowHasLinks && physRow.GetHyperlink(scan) != null))
-                                    {
-                                        lastContentIdx = scan;
-                                    }
-                                }
-
-                                // Determine valid length based on content
-                                if (lastContentIdx >= 0)
-                                {
-                                    validLen = lastContentIdx + 1;
-                                }
-                                else
-                                {
-                                    validLen = 0;
-                                }
-
-                                // Special case: Preserve padding up to the cursor if it's on this row
-                                if (i == absCursorPhysicalIdx && _cursorCol > validLen)
-                                {
-                                    validLen = _cursorCol;
-                                }
-                            }
-
-                            // Improved sparse row detection: Find the LARGEST contiguous gap
-                            // This preserves middle content (e.g. "Left ... Middle ... Right")
-                            bool isSparseRowRepositioned = false;
-                            if (!physRow.IsWrapped && i >= Math.Max(0, absCursorPhysicalIdx - 2) && i <= absCursorPhysicalIdx)
-                            {
-                                // Find largest gap strictly BETWEEN content
-                                // We need to know if the gap is followed by content, otherwise it's just trailing space
-                                // Scan logic:
-                                // 1. Identify all gaps.
-                                // 2. Identify the gap that is:
-                                //    a) Large (> 10)
-                                //    b) Followed by content (not end of line)
-                                //    c) The largest such gap in the row
-
-                                int bestGapStart = -1;
-                                int bestGapLength = 0;
-
-                                int currentScanStart = -1;
-                                int currentScanLength = 0;
-
-                                // First we need to find the "end of row content" to ignore trailing spaces
-                                int lastContentIndex = -1;
-                                for (int scan = physRow.Cells.Length - 1; scan >= 0; scan--)
-                                {
-                                    var cell = physRow.Cells[scan];
-                                    if (cell.Character != ' ' && cell.Character != '\0')
-                                    {
-                                        lastContentIndex = scan;
+                                        lastCell = physRow.Cells[k];
+                                        found = true;
                                         break;
                                     }
                                 }
 
-                                if (lastContentIndex > 0)
+                                if (found && lastCell.Character == ' ' && !lastCell.IsDefaultBackground)
                                 {
-                                    // ONLY Scan up to lastContentIndex
-                                    // This ensures any gap we find implies there is content AFTER it.
-                                    for (int scan = 0; scan <= lastContentIndex; scan++)
-                                    {
-                                        var cell = physRow.Cells[scan];
-                                        bool isSpace = (cell.Character == ' ' || cell.Character == '\0');
-
-                                        if (isSpace)
-                                        {
-                                            if (currentScanStart == -1) currentScanStart = scan;
-                                            currentScanLength++;
-                                        }
-                                        else
-                                        {
-                                            if (currentScanStart != -1)
-                                            {
-                                                if (currentScanLength > bestGapLength)
-                                                {
-                                                    bestGapLength = currentScanLength;
-                                                    bestGapStart = currentScanStart;
-                                                }
-                                                currentScanStart = -1;
-                                                currentScanLength = 0;
-                                            }
-                                        }
-                                    }
-                                    // Check gap if content resumes exactly at lastContentIndex? handled by loop
-                                    // The loop stops AT lastContentIndex. If the character at lastContentIndex is content,
-                                    // the else block triggers and we check the gap before it. Correct.
+                                    ignoreWrap = true;
                                 }
-
-                                // Determine threshold for gap
-                                // Standard: 10 spaces
-                                // Special: 2 spaces IF the content touches the right edge (implies a shrunk right-prompt)
-                                bool isRightPinned = lastContentIndex == physRow.Cells.Length - 1;
-                                int gapThreshold = isRightPinned ? 2 : 10;
-
-                                if (bestGapLength >= gapThreshold)
+                                else
                                 {
-                                    // We found a split!
-                                    // Left+Middle = 0 .. bestGapStart (exclusive)
-                                    // Gap = bestGapStart .. bestGapStart + bestGapLength
-                                    // Right = bestGapStart + bestGapLength .. lastContentIndex (inclusive)
-
-                                    int gapStart = bestGapStart;
-                                    int gapEnd = bestGapStart + bestGapLength;
-                                    int rightStart = gapEnd;
-                                    int rightEnd = lastContentIndex;
-
-                                    // Extract Left+Middle
-                                    for (int k = 0; k < gapStart; k++)
+                                    // 2. Check for Border Characters (ignoring trailing spaces)
+                                    for (int k = physRow.Cells.Length - 1; k >= 0; k--)
                                     {
-                                        logicalCells[logicalCellsCount++] = (physRow.Cells[k], physRow.GetExtendedText(k), physRow.GetHyperlink(k));
+                                        var c = physRow.Cells[k];
+                                        char ch = c.Character;
+                                        if (ch != ' ' && ch != '\0')
+                                        {
+                                            // Vertical bars, corners, etc.
+                                            // U+2500 to U+257F are Box Drawing. 
+                                            // U+2580 to U+259F are Block Elements (Full Block, Shades, etc.) used for scrollbars/shadows.
+                                            // U+FF00 to U+FFEF are Halfwidth and Fullwidth Forms (includes Fullwidth Pipe U+FF5C).
+                                            // '|' is standard vertical bar (U+007C).
+                                            // '+' and '-' can be ASCII borders.
+                                            // '>' is often used by MC to indicate horizontal scroll overflow.
+                                            if (ch == '|' || ch == '+' || ch == '-' || ch == '>' ||
+                                               (ch >= '\u2500' && ch <= '\u257F') ||
+                                               (ch >= '\u2580' && ch <= '\u259F') ||
+                                               (ch >= '\uFF00' && ch <= '\uFFEF'))
+                                            {
+                                                ignoreWrap = true;
+                                            }
+                                            // Special Case: MC Headers like ".[^]" often end with ']' or '^'.
+                                            // These are text characters, so we can't protect them globally (would break text wrapping).
+                                            // However, in TUI headers, they typically have a specific background color.
+                                            // Also protect Arrows '↑' (U+2191) and '↓' (U+2193) which are sometimes used as sort indicators.
+                                            else if ((ch == ']' || ch == '[' || ch == '^' || ch == '\u2191' || ch == '\u2193') && !c.IsDefaultBackground)
+                                            {
+                                                ignoreWrap = true;
+                                            }
+                                            break;
+                                        }
                                     }
+                                }
+                            }
+                        }
 
-                                    // Calculate new position
-                                    int rightBlockWidth = rightEnd - rightStart + 1;
-                                    int newRightPos = newCols - rightBlockWidth;
+                        if (!physRow.IsWrapped || ignoreWrap)
+                        {
+                            // Smart trimming: Calculate last relevant content index
+                            // Include cells that are non-space OR have non-default background
+                            int lastContentIdx = -1;
+                            // A hyperlink counts as content even on a blank cell. OSC 8 spans
+                            // routinely include trailing spaces, and those columns carry no
+                            // signal in the cell itself - trimming them here dropped their
+                            // links for good, since everything past validLen never enters the
+                            // logical stream. HasExtendedText is checked for the same reason.
+                            bool rowHasLinks = physRow.GetHyperlinkMap() is { Count: > 0 };
+                            for (int scan = 0; scan < physRow.Cells.Length; scan++)
+                            {
+                                var cell = physRow.Cells[scan];
+                                if ((cell.Character != ' ' && cell.Character != '\0') || !cell.IsDefaultBackground || cell.HasExtendedText
+                                    || (rowHasLinks && physRow.GetHyperlink(scan) != null))
+                                {
+                                    lastContentIdx = scan;
+                                }
+                            }
 
-                                    int currentPos = logicalCellsCount - currentLogStart; // This is effectively gapStart
+                            // Determine valid length based on content
+                            if (lastContentIdx >= 0)
+                            {
+                                validLen = lastContentIdx + 1;
+                            }
+                            else
+                            {
+                                validLen = 0;
+                            }
 
-                                    if (newRightPos > currentPos + 2 && (newRightPos + rightBlockWidth) <= newCols)
+                            // Special case: Preserve padding up to the cursor if it's on this row
+                            if (i == absCursorPhysicalIdx && _cursorCol > validLen)
+                            {
+                                validLen = _cursorCol;
+                            }
+                        }
+
+                        // Improved sparse row detection: Find the LARGEST contiguous gap
+                        // This preserves middle content (e.g. "Left ... Middle ... Right")
+                        bool isSparseRowRepositioned = false;
+                        if (!physRow.IsWrapped && i >= Math.Max(0, absCursorPhysicalIdx - 2) && i <= absCursorPhysicalIdx)
+                        {
+                            // Find largest gap strictly BETWEEN content
+                            // We need to know if the gap is followed by content, otherwise it's just trailing space
+                            // Scan logic:
+                            // 1. Identify all gaps.
+                            // 2. Identify the gap that is:
+                            //    a) Large (> 10)
+                            //    b) Followed by content (not end of line)
+                            //    c) The largest such gap in the row
+
+                            int bestGapStart = -1;
+                            int bestGapLength = 0;
+
+                            int currentScanStart = -1;
+                            int currentScanLength = 0;
+
+                            // First we need to find the "end of row content" to ignore trailing spaces
+                            int lastContentIndex = -1;
+                            for (int scan = physRow.Cells.Length - 1; scan >= 0; scan--)
+                            {
+                                var cell = physRow.Cells[scan];
+                                if (cell.Character != ' ' && cell.Character != '\0')
+                                {
+                                    lastContentIndex = scan;
+                                    break;
+                                }
+                            }
+
+                            if (lastContentIndex > 0)
+                            {
+                                // ONLY Scan up to lastContentIndex
+                                // This ensures any gap we find implies there is content AFTER it.
+                                for (int scan = 0; scan <= lastContentIndex; scan++)
+                                {
+                                    var cell = physRow.Cells[scan];
+                                    bool isSpace = (cell.Character == ' ' || cell.Character == '\0');
+
+                                    if (isSpace)
                                     {
-                                        // Fill spaces
-                                        var spaceFill = new TerminalCell(' ', Theme.Foreground, Theme.Background, false, false, true, true);
-                                        for (int s = currentPos; s < newRightPos; s++)
-                                        {
-                                            logicalCells[logicalCellsCount++] = (spaceFill, null, null);
-                                        }
-                                        // Add right content
-                                        for (int k = rightStart; k <= rightEnd; k++)
-                                        {
-                                            logicalCells[logicalCellsCount++] = (physRow.Cells[k], physRow.GetExtendedText(k), physRow.GetHyperlink(k));
-                                        }
+                                        if (currentScanStart == -1) currentScanStart = scan;
+                                        currentScanLength++;
                                     }
                                     else
                                     {
-                                        // Truncate/Squish
-                                        var spaceFill = new TerminalCell(' ', Theme.Foreground, Theme.Background, false, false, true, true);
-                                        logicalCells[logicalCellsCount++] = (spaceFill, null, null);
-                                        logicalCells[logicalCellsCount++] = (spaceFill, null, null);
-
-                                        int available = newCols - (logicalCellsCount - currentLogStart);
-                                        if (available > 0)
+                                        if (currentScanStart != -1)
                                         {
-                                            int take = Math.Min(available, rightBlockWidth);
-                                            int startOffset = rightBlockWidth - take;
-                                            for (int k = rightStart + startOffset; k <= rightEnd; k++)
-                                                logicalCells[logicalCellsCount++] = (physRow.Cells[k], physRow.GetExtendedText(k), physRow.GetHyperlink(k));
+                                            if (currentScanLength > bestGapLength)
+                                            {
+                                                bestGapLength = currentScanLength;
+                                                bestGapStart = currentScanStart;
+                                            }
+                                            currentScanStart = -1;
+                                            currentScanLength = 0;
                                         }
                                     }
-                                    isSparseRowRepositioned = true;
+                                }
+                                // Check gap if content resumes exactly at lastContentIndex? handled by loop
+                                // The loop stops AT lastContentIndex. If the character at lastContentIndex is content,
+                                // the else block triggers and we check the gap before it. Correct.
+                            }
+
+                            // Determine threshold for gap
+                            // Standard: 10 spaces
+                            // Special: 2 spaces IF the content touches the right edge (implies a shrunk right-prompt)
+                            bool isRightPinned = lastContentIndex == physRow.Cells.Length - 1;
+                            int gapThreshold = isRightPinned ? 2 : 10;
+
+                            if (bestGapLength >= gapThreshold)
+                            {
+                                // We found a split!
+                                // Left+Middle = 0 .. bestGapStart (exclusive)
+                                // Gap = bestGapStart .. bestGapStart + bestGapLength
+                                // Right = bestGapStart + bestGapLength .. lastContentIndex (inclusive)
+
+                                int gapStart = bestGapStart;
+                                int gapEnd = bestGapStart + bestGapLength;
+                                int rightStart = gapEnd;
+                                int rightEnd = lastContentIndex;
+
+                                // Extract Left+Middle
+                                for (int k = 0; k < gapStart; k++)
+                                {
+                                    logicalCells[logicalCellsCount++] = (physRow.Cells[k], physRow.GetExtendedText(k), physRow.GetHyperlink(k));
                                 }
 
+                                // Calculate new position
+                                int rightBlockWidth = rightEnd - rightStart + 1;
+                                int newRightPos = newCols - rightBlockWidth;
+
+                                int currentPos = logicalCellsCount - currentLogStart; // This is effectively gapStart
+
+                                if (newRightPos > currentPos + 2 && (newRightPos + rightBlockWidth) <= newCols)
+                                {
+                                    // Fill spaces
+                                    var spaceFill = new TerminalCell(' ', Theme.Foreground, Theme.Background, false, false, true, true);
+                                    for (int s = currentPos; s < newRightPos; s++)
+                                    {
+                                        logicalCells[logicalCellsCount++] = (spaceFill, null, null);
+                                    }
+                                    // Add right content
+                                    for (int k = rightStart; k <= rightEnd; k++)
+                                    {
+                                        logicalCells[logicalCellsCount++] = (physRow.Cells[k], physRow.GetExtendedText(k), physRow.GetHyperlink(k));
+                                    }
+                                }
+                                else
+                                {
+                                    // Truncate/Squish
+                                    var spaceFill = new TerminalCell(' ', Theme.Foreground, Theme.Background, false, false, true, true);
+                                    logicalCells[logicalCellsCount++] = (spaceFill, null, null);
+                                    logicalCells[logicalCellsCount++] = (spaceFill, null, null);
+
+                                    int available = newCols - (logicalCellsCount - currentLogStart);
+                                    if (available > 0)
+                                    {
+                                        int take = Math.Min(available, rightBlockWidth);
+                                        int startOffset = rightBlockWidth - take;
+                                        for (int k = rightStart + startOffset; k <= rightEnd; k++)
+                                            logicalCells[logicalCellsCount++] = (physRow.Cells[k], physRow.GetExtendedText(k), physRow.GetHyperlink(k));
+                                    }
+                                }
+                                isSparseRowRepositioned = true;
                             }
 
-                            // Normal processing if not sparse row or repositioning failed
-                            if (!isSparseRowRepositioned)
-                            {
-                                for (int k = 0; k < validLen; k++)
-                                    logicalCells[logicalCellsCount++] = (physRow.Cells[k], physRow.GetExtendedText(k), physRow.GetHyperlink(k));
-                            }
-
-                            if (!physRow.IsWrapped || ignoreWrap)
-                            {
-                                logicalLines.Add((currentLogStart, logicalCellsCount - currentLogStart, false, currentStartPhys));
-                                currentLogStart = -1;
-                            }
                         }
 
-                        if (currentLogStart != -1)
+                        // Normal processing if not sparse row or repositioning failed
+                        if (!isSparseRowRepositioned)
                         {
-                            logicalLines.Add((currentLogStart, logicalCellsCount - currentLogStart, true, currentStartPhys));
+                            for (int k = 0; k < validLen; k++)
+                                logicalCells[logicalCellsCount++] = (physRow.Cells[k], physRow.GetExtendedText(k), physRow.GetHyperlink(k));
                         }
+
+                        if (!physRow.IsWrapped || ignoreWrap)
+                        {
+                            logicalLines.Add((currentLogStart, logicalCellsCount - currentLogStart, false, currentStartPhys));
+                            currentLogStart = -1;
+                        }
+                    }
+
+                    if (currentLogStart != -1)
+                    {
+                        logicalLines.Add((currentLogStart, logicalCellsCount - currentLogStart, true, currentStartPhys));
+                    }
                     // 5. Distribution logic
                     _scrollback.Clear();
                     _viewport = new TerminalRow[newRows];
@@ -621,7 +621,7 @@ namespace NovaTerminal.VT
                             allFlowedRows[i].GetExtendedTextMap(),
                             allFlowedRows[i].GetHyperlinkMap());
                     }
-                    
+
                     int discardedRows = (int)newScrollback.TotalRowsEvicted;
                     _scrollback = newScrollback;
 

--- a/src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs
@@ -52,7 +52,7 @@ namespace NovaTerminal.VT
                     {
                         var oldAlt = _viewport;
                         _viewport = new TerminalRow[newRows];
-                        
+
                         var lastCell = new TerminalCell(' ', Theme.Foreground, Theme.Background, false, false, true, true);
                         if (oldAlt.Length > 0 && oldCols > 0)
                         {
@@ -62,11 +62,11 @@ namespace NovaTerminal.VT
 
                         for (int i = 0; i < newRows; i++)
                         {
-                            if (i < oldAlt.Length) 
+                            if (i < oldAlt.Length)
                             {
                                 _viewport[i] = oldAlt[i];
                             }
-                            else 
+                            else
                             {
                                 _viewport[i] = new TerminalRow(newCols);
                                 for (int cx = 0; cx < newCols; cx++) _viewport[i].Cells[cx] = lastCell;
@@ -90,7 +90,7 @@ namespace NovaTerminal.VT
                     else
                     {
                         // Main screen: Still needs redistribution to maintain scrollback vs viewport split
-                        
+
                         if (newRows < oldRows)
                         {
                             // Shrink height: push top of viewport to scrollback
@@ -164,7 +164,7 @@ namespace NovaTerminal.VT
                     // We preserve what fits top-left to avoid flashing empty if redraw is slow.
                     var oldAlt = _viewport;
                     _viewport = new TerminalRow[newRows];
-                    
+
                     var lastCell = new TerminalCell(' ', Theme.Foreground, Theme.Background, false, false, true, true);
                     if (oldAlt.Length > 0 && oldCols > 0)
                     {
@@ -294,7 +294,7 @@ namespace NovaTerminal.VT
 
                 Array.Copy(_viewport, 0, newViewport, linesNeeded, oldRows);
                 _cursorRow += linesNeeded;
-                
+
                 // Shift MAIN-screen images DOWN (alt coordinates are viewport-relative
                 // and unaffected by the scrollback/viewport redistribution).
                 for (int i = 0; i < _images.Count; i++)

--- a/src/NovaTerminal.VT/TerminalBuffer.ThreadingAndInvalidation.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ThreadingAndInvalidation.cs
@@ -393,16 +393,16 @@ namespace NovaTerminal.VT
             {
                 _cachedAnsiPalette = new TermColor[16];
             }
-            _cachedAnsiPalette[0]  = Theme.Black;
-            _cachedAnsiPalette[1]  = Theme.Red;
-            _cachedAnsiPalette[2]  = Theme.Green;
-            _cachedAnsiPalette[3]  = Theme.Yellow;
-            _cachedAnsiPalette[4]  = Theme.Blue;
-            _cachedAnsiPalette[5]  = Theme.Magenta;
-            _cachedAnsiPalette[6]  = Theme.Cyan;
-            _cachedAnsiPalette[7]  = Theme.White;
-            _cachedAnsiPalette[8]  = Theme.BrightBlack;
-            _cachedAnsiPalette[9]  = Theme.BrightRed;
+            _cachedAnsiPalette[0] = Theme.Black;
+            _cachedAnsiPalette[1] = Theme.Red;
+            _cachedAnsiPalette[2] = Theme.Green;
+            _cachedAnsiPalette[3] = Theme.Yellow;
+            _cachedAnsiPalette[4] = Theme.Blue;
+            _cachedAnsiPalette[5] = Theme.Magenta;
+            _cachedAnsiPalette[6] = Theme.Cyan;
+            _cachedAnsiPalette[7] = Theme.White;
+            _cachedAnsiPalette[8] = Theme.BrightBlack;
+            _cachedAnsiPalette[9] = Theme.BrightRed;
             _cachedAnsiPalette[10] = Theme.BrightGreen;
             _cachedAnsiPalette[11] = Theme.BrightYellow;
             _cachedAnsiPalette[12] = Theme.BrightBlue;

--- a/src/NovaTerminal.VT/TerminalBuffer.WritePath.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.WritePath.cs
@@ -318,7 +318,7 @@ namespace NovaTerminal.VT
             } // End of attachment attempt logic
 
             // NORMAL WRITE LOGIC:
-NormalWrite:
+        NormalWrite:
             int width = GetGraphemeWidth(grapheme);
 
             // Handle Pending Wrap State (M1.3)
@@ -468,7 +468,7 @@ NormalWrite:
             if (isFullScreenScroll && !_isAltScreen)
             {
                 long prevEvicted = _scrollback.TotalRowsEvicted;
-                
+
                 // This copies the cell array into the page-based store;
                 // No TerminalRow object is stored in scrollback anymore.
                 var evictingRow = _viewport[0];

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentHostServiceTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentHostServiceTests.cs
@@ -85,7 +85,7 @@ public class AgentHostServiceTests : IDisposable
     public void Version_mismatch_is_rejected_with_stable_error_code()
     {
         using var service = NewService(new AgentSessionRegistry());
-        var response = Handle(service,RequestLine(AgentHostProtocol.Methods.ListSessions, version: 99));
+        var response = Handle(service, RequestLine(AgentHostProtocol.Methods.ListSessions, version: 99));
         Assert.Equal(AgentHostProtocol.ErrorCodes.VersionMismatch, response.Error?.Code);
     }
 
@@ -93,7 +93,7 @@ public class AgentHostServiceTests : IDisposable
     public void Malformed_frame_is_rejected_not_thrown()
     {
         using var service = NewService(new AgentSessionRegistry());
-        var response = Handle(service,"this is not json");
+        var response = Handle(service, "this is not json");
         Assert.Equal(AgentHostProtocol.ErrorCodes.MalformedRequest, response.Error?.Code);
     }
 
@@ -101,7 +101,7 @@ public class AgentHostServiceTests : IDisposable
     public void Unknown_method_is_rejected_with_stable_error_code()
     {
         using var service = NewService(new AgentSessionRegistry());
-        var response = Handle(service,RequestLine("thisMethodDoesNotExist"));
+        var response = Handle(service, RequestLine("thisMethodDoesNotExist"));
         Assert.Equal(AgentHostProtocol.ErrorCodes.UnknownMethod, response.Error?.Code);
     }
 
@@ -109,8 +109,8 @@ public class AgentHostServiceTests : IDisposable
     public void Missing_params_is_a_malformed_request_not_a_missing_session()
     {
         using var service = NewService(new AgentSessionRegistry());
-        var readScreen = Handle(service,RequestLine(AgentHostProtocol.Methods.ReadScreen));
-        var readScrollback = Handle(service,RequestLine(AgentHostProtocol.Methods.ReadScrollback));
+        var readScreen = Handle(service, RequestLine(AgentHostProtocol.Methods.ReadScreen));
+        var readScrollback = Handle(service, RequestLine(AgentHostProtocol.Methods.ReadScrollback));
         Assert.Equal(AgentHostProtocol.ErrorCodes.MalformedRequest, readScreen.Error?.Code);
         Assert.Equal(AgentHostProtocol.ErrorCodes.MalformedRequest, readScrollback.Error?.Code);
     }
@@ -131,7 +131,7 @@ public class AgentHostServiceTests : IDisposable
         var registration = Register(registry, buffer);
         using var service = NewService(registry);
 
-        var response = Handle(service,RequestLine(
+        var response = Handle(service, RequestLine(
             AgentHostProtocol.Methods.ReadScrollback,
             paramsObj: new ReadScrollbackParams { PaneId = registration.PaneId, StartLine = 0, MaxLines = 10 }));
         var result = ResultOf(response, AgentHostJsonContext.Default.ReadScrollbackResult);
@@ -143,7 +143,7 @@ public class AgentHostServiceTests : IDisposable
     public void ReadScreen_for_unknown_pane_reports_session_not_found()
     {
         using var service = NewService(new AgentSessionRegistry());
-        var response = Handle(service,RequestLine(
+        var response = Handle(service, RequestLine(
             AgentHostProtocol.Methods.ReadScreen,
             paramsObj: new ReadScreenParams { PaneId = Guid.NewGuid() }));
         Assert.Equal(AgentHostProtocol.ErrorCodes.SessionNotFound, response.Error?.Code);
@@ -161,7 +161,7 @@ public class AgentHostServiceTests : IDisposable
         var registration = Register(registry, buffer);
         using var service = NewService(registry);
 
-        var response = Handle(service,RequestLine(
+        var response = Handle(service, RequestLine(
             AgentHostProtocol.Methods.ReadScreen,
             paramsObj: new ReadScreenParams { PaneId = registration.PaneId, IncludeAttributes = true }));
         var dto = ResultOf(response, AgentHostJsonContext.Default.ScreenSnapshotDto);
@@ -189,7 +189,7 @@ public class AgentHostServiceTests : IDisposable
         var registration = Register(registry, buffer);
         using var service = NewService(registry);
 
-        var response = Handle(service,RequestLine(
+        var response = Handle(service, RequestLine(
             AgentHostProtocol.Methods.ReadScrollback,
             paramsObj: new ReadScrollbackParams { PaneId = registration.PaneId, StartLine = 1, MaxLines = 3 }));
         var result = ResultOf(response, AgentHostJsonContext.Default.ReadScrollbackResult);

--- a/tests/NovaTerminal.App.Tests/Buffer/ScrollbackPagesTests.cs
+++ b/tests/NovaTerminal.App.Tests/Buffer/ScrollbackPagesTests.cs
@@ -27,11 +27,11 @@ namespace NovaTerminal.Tests.Buffer
             // Arrange: create a scrollback with 1000 pages (64,000 rows)
             int cols = 80;
             var scrollback = new ScrollbackPages(cols, _pool, maxScrollbackBytes: 256L * 1024 * 1024);
-            
+
             var defCell = TerminalCell.Default;
             var rowArray = new TerminalCell[80];
             for (int i = 0; i < 80; i++) rowArray[i] = defCell;
-            
+
             int totalRows = 64000;
             for (int i = 0; i < totalRows; i++)
             {
@@ -39,7 +39,7 @@ namespace NovaTerminal.Tests.Buffer
                 rowArray[0].Character = (char)('A' + (i % 26));
                 scrollback.AppendRow(rowArray.AsSpan());
             }
-            
+
             // Assert Count matches
             Assert.Equal(totalRows, scrollback.Count);
 

--- a/tests/NovaTerminal.App.Tests/Buffer/TerminalMemoryMetricsTests.cs
+++ b/tests/NovaTerminal.App.Tests/Buffer/TerminalMemoryMetricsTests.cs
@@ -12,7 +12,7 @@ namespace NovaTerminal.Tests.Buffer
         public void GetMemoryMetrics_ReturnsReasonableValues()
         {
             var buffer = new TerminalBuffer(80, 24);
-            
+
             // Add some scrollback
             var row = new TerminalCell[80];
             for (int i = 0; i < 100; i++)

--- a/tests/NovaTerminal.App.Tests/Input/DropRouterTests.cs
+++ b/tests/NovaTerminal.App.Tests/Input/DropRouterTests.cs
@@ -54,18 +54,19 @@ namespace NovaTerminal.Tests.Input
         [Fact]
         public async Task HandleDropAsync_RespectsShellOverride()
         {
-            var context = new SessionContext { 
-                IsEchoEnabled = true, 
+            var context = new SessionContext
+            {
+                IsEchoEnabled = true,
                 DetectedShell = DetectedShell.PosixSh,
                 ShellOverride = ShellOverride.Pwsh
             };
-            
+
             var paths = new List<string> { "a'b.txt" };
 
             var result = await DropRouter.HandleDropAsync(context, paths, isAltHeld: false);
 
             Assert.True(result.Handled);
-            Assert.Equal("'a''b.txt' ", result.TextToSend); 
+            Assert.Equal("'a''b.txt' ", result.TextToSend);
         }
 
         [Fact]

--- a/tests/NovaTerminal.App.Tests/Input/TerminalInputSenderTests.cs
+++ b/tests/NovaTerminal.App.Tests/Input/TerminalInputSenderTests.cs
@@ -18,7 +18,7 @@ namespace NovaTerminal.Tests.Input
             // Arrange
             var mockSession = new Mock<ITerminalSession>();
             string? sentPayload = null;
-            
+
             mockSession.Setup(s => s.SendInput(It.IsAny<string>()))
                        .Callback<string>(s => sentPayload = s);
 
@@ -38,7 +38,7 @@ namespace NovaTerminal.Tests.Input
             // Arrange
             var mockSession = new Mock<ITerminalSession>();
             string? sentPayload = null;
-            
+
             mockSession.Setup(s => s.SendInput(It.IsAny<string>()))
                        .Callback<string>(s => sentPayload = s);
 
@@ -50,7 +50,7 @@ namespace NovaTerminal.Tests.Input
 
             // Assert
             mockSession.Verify(s => s.SendInput(It.IsAny<string>()), Times.Once);
-            
+
             // The interior \x1b[201~ should be stripped out.
             Assert.Equal("\x1b[200~echo 'hijacked'\nrm -rf /\x1b[201~", sentPayload);
         }

--- a/tests/NovaTerminal.App.Tests/ReflowRegressionTests.cs
+++ b/tests/NovaTerminal.App.Tests/ReflowRegressionTests.cs
@@ -36,7 +36,7 @@ namespace NovaTerminal.Tests
             {
                 return GetTextFromSpan(sb.GetRow(absoluteIndex));
             }
-            
+
             int vpIndex = absoluteIndex - sbCount;
             if (vpIndex >= 0 && vpIndex < vp.Length)
             {

--- a/tests/NovaTerminal.App.Tests/Storage/SmallMapTests.cs
+++ b/tests/NovaTerminal.App.Tests/Storage/SmallMapTests.cs
@@ -26,9 +26,9 @@ namespace NovaTerminal.Tests.Storage
         {
             var map = new SmallMap<string>();
             map.Set(10, "Value10");
-            
+
             bool found = map.TryGet(10, out var value);
-            
+
             Assert.True(found);
             Assert.Equal("Value10", value);
         }
@@ -38,9 +38,9 @@ namespace NovaTerminal.Tests.Storage
         {
             var map = new SmallMap<string>();
             map.Set(10, "Value10");
-            
+
             bool found = map.TryGet(20, out var value);
-            
+
             Assert.False(found);
             Assert.Null(value);
         }
@@ -51,7 +51,7 @@ namespace NovaTerminal.Tests.Storage
             var map = new SmallMap<string>();
             map.Set(10, "OldValue");
             map.Set(10, "NewValue");
-            
+
             Assert.Equal(1, map.Count);
             map.TryGet(10, out var value);
             Assert.Equal("NewValue", value);
@@ -65,7 +65,7 @@ namespace NovaTerminal.Tests.Storage
             {
                 map.Set(i, $"Value{i}");
             }
-            
+
             Assert.Equal(8, map.Count);
             for (int i = 0; i < 8; i++)
             {
@@ -82,7 +82,7 @@ namespace NovaTerminal.Tests.Storage
             {
                 map.Set(i, $"Value{i}");
             }
-            
+
             Assert.Equal(9, map.Count);
             for (int i = 0; i < 9; i++)
             {
@@ -98,9 +98,9 @@ namespace NovaTerminal.Tests.Storage
             map.Set(1, "V1");
             map.Set(2, "V2");
             map.Set(3, "V3");
-            
+
             map.Remove(2);
-            
+
             Assert.Equal(2, map.Count);
             Assert.True(map.TryGet(1, out _));
             Assert.False(map.TryGet(2, out _));
@@ -115,9 +115,9 @@ namespace NovaTerminal.Tests.Storage
             {
                 map.Set(i, $"V{i}");
             }
-            
+
             map.Remove(5);
-            
+
             Assert.Equal(9, map.Count);
             Assert.False(map.TryGet(5, out _));
             Assert.True(map.TryGet(4, out _));

--- a/tests/NovaTerminal.App.Tests/TerminalBufferTests.cs
+++ b/tests/NovaTerminal.App.Tests/TerminalBufferTests.cs
@@ -291,7 +291,7 @@ namespace NovaTerminal.Tests
             var contentTexts = new List<string>();
             var sbRows = GetScrollback(buffer);
             for (int i = 0; i < sbRows.Count; i++) contentTexts.Add(GetTextFromSpan(sbRows.GetRow(i)));
-            
+
             var vpRows = GetViewport(buffer);
             foreach (var r in vpRows) contentTexts.Add(GetRowTextContent(r));
 
@@ -408,7 +408,7 @@ namespace NovaTerminal.Tests
             var list = new List<string>();
             var sb = GetScrollback(buffer);
             for (int i = 0; i < sb.Count; i++) list.Add(GetTextFromSpan(sb.GetRow(i)));
-            
+
             var vp = GetViewport(buffer);
             foreach (var r in vp) list.Add(GetRowTextContent(r));
             return list;

--- a/tests/NovaTerminal.Architecture.Tests/LayeringTests.cs
+++ b/tests/NovaTerminal.Architecture.Tests/LayeringTests.cs
@@ -5,11 +5,11 @@ namespace NovaTerminal.Architecture.Tests;
 
 public class LayeringTests
 {
-    private static Assembly Vt        => typeof(global::NovaTerminal.VT.AnsiParser).Assembly;
-    private static Assembly Replay    => typeof(global::NovaTerminal.Replay.ReplayReader).Assembly;
+    private static Assembly Vt => typeof(global::NovaTerminal.VT.AnsiParser).Assembly;
+    private static Assembly Replay => typeof(global::NovaTerminal.Replay.ReplayReader).Assembly;
     private static Assembly Rendering => typeof(global::NovaTerminal.Rendering.GlyphAtlas).Assembly;
-    private static Assembly Pty       => typeof(global::NovaTerminal.Pty.ITerminalSession).Assembly;
-    private static Assembly Platform  => typeof(global::NovaTerminal.Platform.Input.TerminalInputSender).Assembly;
+    private static Assembly Pty => typeof(global::NovaTerminal.Pty.ITerminalSession).Assembly;
+    private static Assembly Platform => typeof(global::NovaTerminal.Platform.Input.TerminalInputSender).Assembly;
     private static Assembly AgentHostContracts => typeof(global::NovaTerminal.AgentHost.Contracts.AgentHostProtocol).Assembly;
 
     [Fact]

--- a/tests/NovaTerminal.McpServer.Tests/AgentHostClientTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/AgentHostClientTests.cs
@@ -380,13 +380,21 @@ public class SessionToolsFormattingTests
     {
         var truncated = SessionTools.FormatExport(new ExportReplayResult
         {
-            FilePath = "/tmp/x.rec", EventCount = 5, FirstEventMs = 0, LastEventMs = 9, TruncatedAtStart = true,
+            FilePath = "/tmp/x.rec",
+            EventCount = 5,
+            FirstEventMs = 0,
+            LastEventMs = 9,
+            TruncatedAtStart = true,
         });
         Assert.Contains("suffix of the session", truncated, StringComparison.Ordinal);
 
         var empty = SessionTools.FormatExport(new ExportReplayResult
         {
-            FilePath = "/tmp/y.rec", EventCount = 0, FirstEventMs = 0, LastEventMs = 0, TruncatedAtStart = false,
+            FilePath = "/tmp/y.rec",
+            EventCount = 0,
+            FirstEventMs = 0,
+            LastEventMs = 0,
+            TruncatedAtStart = false,
         });
         Assert.Contains("no events", empty, StringComparison.OrdinalIgnoreCase);
     }

--- a/tests/NovaTerminal.McpServer.Tests/McpServerStdioE2ETests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/McpServerStdioE2ETests.cs
@@ -113,7 +113,7 @@ public class McpServerStdioE2ETests
         {
             Name = "novaterminal-dev-e2e",
             Command = "dotnet",
-            Arguments = [ ServerDllPath() ],
+            Arguments = [ServerDllPath()],
             EnvironmentVariables = new Dictionary<string, string?>
             {
                 ["NOVATERMINAL_REPO_ROOT"] = RepoRoot(),

--- a/tests/NovaTerminal.Platform.Tests/Export/TerminalExporterTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Export/TerminalExporterTests.cs
@@ -53,11 +53,11 @@ namespace NovaTerminal.Platform.Tests.Export
         public void ExportToAnsi_ShouldEmitDeltaOnPaletteToRgbSwap()
         {
             var buffer = new TerminalBuffer(80, 24);
-            
+
             // Palette Red (Index 1) -> Truecolor Red (rgb 255,0,0) -> same 1 value but different flags
             var paletteRed = new TerminalCell('A', 1, 0, (ushort)TerminalCellFlags.PaletteForeground | (ushort)TerminalCellFlags.DefaultBackground);
             ushort trueColorFlags = (ushort)TerminalCellFlags.DefaultBackground; // NOT PaletteForeground
-            uint trueColorRedInt = new TermColor(255, 0, 0).ToUint(); 
+            uint trueColorRedInt = new TermColor(255, 0, 0).ToUint();
             var truecolorRed = new TerminalCell('B', trueColorRedInt, 0, trueColorFlags);
 
             buffer.ViewportRows[0].Cells[0] = paletteRed;

--- a/tests/NovaTerminal.Platform.Tests/Replay/ReplayIndexTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Replay/ReplayIndexTests.cs
@@ -31,12 +31,12 @@ namespace NovaTerminal.Platform.Tests.Replay
         public async Task BuildAsync_ShouldExtractTimeAndOffsets()
         {
             var index = await ReplayIndex.BuildAsync(_testFile);
-            
+
             Assert.Equal(3, index.Entries.Count);
             Assert.Equal(100, index.Entries[0].TimeMs);
             Assert.Equal(200, index.Entries[1].TimeMs);
             Assert.Equal(350, index.Entries[2].TimeMs);
-            
+
             // Validate limits
             Assert.Equal(100, index.StartTimeMs);
             Assert.Equal(350, index.EndTimeMs);
@@ -45,10 +45,10 @@ namespace NovaTerminal.Platform.Tests.Replay
             // Read using the discovered offset
             using var fs = new FileStream(_testFile, FileMode.Open, FileAccess.Read);
             fs.Seek(index.Entries[1].ByteOffset, SeekOrigin.Begin);
-            
+
             using var reader = new StreamReader(fs);
             string line2 = await reader.ReadLineAsync();
-            
+
             Assert.Contains("\"t\":200", line2);
         }
 
@@ -69,7 +69,7 @@ namespace NovaTerminal.Platform.Tests.Replay
             long afterLast = index.GetClosestOffset(500);
             Assert.Equal(index.Entries[2].ByteOffset, afterLast);
         }
-        
+
         [Fact]
         public async Task ReplayRunner_Seek_ShouldStartFromOffset()
         {
@@ -96,7 +96,7 @@ namespace NovaTerminal.Platform.Tests.Replay
             );
 
             // Excludes t:100 since we sought to t:200
-            Assert.Equal(2, eventCount); 
+            Assert.Equal(2, eventCount);
             Assert.Equal(200, firstInterceptTime);
         }
 

--- a/tests/NovaTerminal.Platform.Tests/Ssh/OpenSshConfigCompilerTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/OpenSshConfigCompilerTests.cs
@@ -267,7 +267,7 @@ public sealed class OpenSshConfigCompilerTests
             string secondHash = File.ReadAllText(hashPath);
 
             Assert.NotEqual(firstHash, secondHash);
-            
+
             string configText = File.ReadAllText(secondResult.ConfigFilePath);
             Assert.Contains("User new_user", configText);
         }


### PR DESCRIPTION
Closes #216.

## Root cause

Formatting was enforced by **nothing**. Not the build, not a hook, not CI:

- `Directory.Build.props` sets `EnforceCodeStyleInBuild=true` and `.editorconfig` (#174) defines the target formatting — but the formatter's `WHITESPACE` rule has no build-time equivalent except `IDE0055`, and `.editorconfig` deliberately keeps style severities at `silent`. Its own header says why: promoting them "would add hundreds of diagnostics to every build and collide head-on with #108".
- Verified: a full `NovaTerminal.VT` build emits **0** `IDExxxx` diagnostics and 166 `CA` warnings, while `ReflowEngine.cs` *in that same project* carried 241 whitespace violations. The build genuinely cannot see them.
- No git hooks installed (`.git/hooks` is all `.sample`).
- **No `dotnet format` anywhere under `.github/`.** The only check lived in `ci/run.{ps1,sh}` and both were deliberately non-failing.

So the single measurement of formatting could not fail — and the count drifted **649 → 674** over two weeks with nobody working on the issue.

## Three commits

### 1. `.gitattributes` — prerequisite, not polish

`.editorconfig` requires CRLF; git stores LF. On Windows with `autocrlf=true` the worktree is CRLF and agrees; on Linux it is LF and does not. **`dotnet format --verify-no-changes` reached a different verdict on the same commit depending on platform.** A gate whose answer depends on who runs it is worse than no gate.

Deliberately narrow — only extensions the toolchain has an opinion about. `*.cs`/`*.axaml`/`*.csproj`/`*.props`/`*.targets`/`*.sln`/`*.runsettings` → CRLF; `*.sh` → LF (or they fail to execute on Linux); `*.rs`/`*.toml` → LF (cargo convention).

Everything else left **unspecified on purpose**: `*.rec` replay recordings are JSONL and `*.snap` snapshots are compared as text, and git already auto-detects the golden `*.png` as binary. Declaring those would change Windows checkout for fixtures that tests read as text — risk, no upside.

`git add --renormalize .` produces no diff, confirming the stored blobs already match; this only pins the checkout side.

### 2. The sweep — 674 violations, 32 files

Nothing but `dotnet format whitespace` output.

**The obvious verification does not work here, and I want to be explicit about that.** `git diff -w --stat` is *not* empty — the formatter inserts line breaks (Allman braces, one property per line in object initializers), which changes line structure, and `-w` only ignores whitespace *within* a line. So I verified three ways instead:

1. Inspected all four files that appear under `git diff -w`. Every change is brace placement or a member moved onto its own line.
2. **Token-stream comparison** — stripping every whitespace character from old and new yields byte-identical text for all 32 files.
3. **String-literal check**, because (2) is blind to indentation inside verbatim and raw literals. Literal boundary counts (`@"`, `"""`) unchanged in all 32 files, and no changed line falls inside one.

A first pass at (3) with a hand-rolled regex flagged `McpServerStdioE2ETests.cs`. That was my regex mis-spanning, not the formatter: the file's single changed line is 116, a collection expression (`[ X() ]` → `[X()]`), and its literals are at lines 67 and 77.

### 3. The gate

`ci/run.ps1` and `ci/run.sh` now exit non-zero, stale 649/79 comments replaced. New `format` job in `ci.yml`, matrixed over **windows-latest and ubuntu-latest**.

Both OSes on purpose — the ubuntu leg is what proves commit 1 works, and it is the leg that would have been silently wrong had this shipped Windows-only.

Scoped to `dotnet format whitespace`, not bare `dotnet format`. The bare form also runs the style and analyzer passes, which on this tree surface **174 additional diagnostics** (`xUnit1051` ×122, `CA1310` ×16, `CA1865` ×14, `CA1866` ×7, `CS0618` ×6, `CS8600` ×3, five singles). Those are #108's territory, not formatting; including them would make this gate red for unrelated reasons.

## Why now

The sequencing caveat that held this issue for two weeks does not currently apply, which is what made a full sweep the right call rather than an exclusion list:

- **#113** (which will rewrite `TerminalDrawOperation.cs`, 263 of the 674) has no branch and no PR.
- The only open PR touches `MainWindow.axaml.cs`, which has **zero** violations.
- **#164 is closed**, so `ReflowEngine.cs` (241) was already free.

## Verification

- `dotnet format whitespace --verify-no-changes` exits **0** on this branch.
- Workflow parses; `format` job present on both platforms.
- Full local suite, zero failures: **App.Tests 1294**, VT 126, Platform 122, Rendering 59, Architecture 24. This is the real behavioural gate — golden PNGs, VT conformance replays and snapshot comparisons would all have caught a token or literal change.
- Worktree clean after the `.gitattributes` rules land — no phantom EOL modifications.

## Deliberately not included

`IDE0055` at build severity. It would catch drift at compile time rather than PR time, but it collides directly with #108's effort to reduce the warning count far enough to re-enable `TreatWarningsAsErrors`, and `.editorconfig`'s own header says so. Worth revisiting after #108, noted on the issue.
