### PR TITLE
ci: pin GITHUB_TOKEN to contents:read in ci, nightly, and vt-conformance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,13 @@ on:
     - cron: "30 3 * * *"
   workflow_dispatch:
 
+# No job here writes to the repository: every step is build/test plus
+# checkout/setup-dotnet/cache/upload-artifact, none of which touch GITHUB_TOKEN
+# beyond reading the source. Grant the minimum and let any future job that needs
+# more opt in with its own job-level `permissions:` block.
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,6 +11,11 @@ on:
         default: false
         type: boolean
 
+# Stress runs only build, run, and upload artifacts — nothing writes back to the
+# repository. See the note in ci.yml.
+permissions:
+  contents: read
+
 concurrency:
   group: nightly-stress-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/vt-conformance.yml
+++ b/.github/workflows/vt-conformance.yml
@@ -22,6 +22,11 @@ on:
       - ".github/workflows/vt-conformance.yml"
   workflow_dispatch:
 
+# The matrix gate only reads the checkout and fails the run; it never comments on
+# the PR or pushes. See the note in ci.yml.
+permissions:
+  contents: read
+
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true


### PR DESCRIPTION
@
Closes all 17 open [code scanning alerts](https://github.com/benyblack/NovaTerminal/security/code-scanning), every one of them `actions/missing-workflow-permissions`.

## What was wrong

`ci.yml`, `nightly.yml`, and `vt-conformance.yml` had no top-level `permissions:` block, so all 17 of their jobs inherited the repository default `GITHUB_TOKEN`, which can be write-all. `release.yml` already declared `contents: write`, which is why none of its jobs were flagged.

## Why `contents: read` is enough

Checked every job in the three files before narrowing the scope:

- No step references `GITHUB_TOKEN`, shells out to `gh`, or uses `actions/github-script`.
- The only actions used are `checkout`, `setup-dotnet`, `cache`, `upload-artifact`, `download-artifact`, `dtolnay/rust-toolchain`, and `Swatinem/rust-cache`.
- All `download-artifact@v4` uses are same-run (no `run-id`, no `github-token`), so they authenticate with the runtime artifact token and are unaffected by token scopes.

Jobs per file: ci 13 + nightly 3 + vt-conformance 1 = 17, matching the alert count exactly.

`release.yml` is left alone — it genuinely publishes releases via `softprops/action-gh-release`. Scoping its `contents: write` down to just the two jobs that need it is a reasonable follow-up, but it is not one of the reported alerts and carries release-breaking risk.

## Testing

YAML parses cleanly for all four workflows. The workflows themselves run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@