### PR TITLE
docs: tell contributors about the format gate that #253 turned on

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,11 +45,29 @@ and retry through the wrapper.
 
 To rehearse CI locally before pushing: `ci/run.sh` or `ci/run.ps1`. That does a
 clean Release build, runs the whole test suite unfiltered, re-runs the replay
-category on its own, and does an AOT publish. It does **not** reproduce the
-three-OS matrix or the per-category job split, so a green local run is strong
-evidence but not a guarantee.
+category on its own, checks formatting, and does an AOT publish. It does **not**
+reproduce the three-OS matrix or the per-category job split, so a green local run
+is strong evidence but not a guarantee.
 
-### 3. Pick something small
+### 3. Formatting
+
+Formatting is a **blocking** CI check. Before pushing:
+
+```bash
+dotnet format whitespace          # fixes it
+dotnet format whitespace --verify-no-changes   # what CI runs
+```
+
+Only the whitespace pass is gated — indentation, alignment, brace placement, line
+breaks. The style and analyzer passes are **not** enforced yet (tracked in #108),
+so do not run a bare `dotnet format`: it will also rewrite things this project has
+not agreed on, and your diff becomes unreviewable.
+
+`.editorconfig` defines the rules and `.gitattributes` pins line endings, so the
+check gives the same answer on Windows and Linux. If your editor fights it, trust
+`dotnet format` — that is what CI runs.
+
+### 4. Pick something small
 
 Issues labelled [`good first issue`][gfi] are scoped to be landable in an
 evening and are deliberately kept away from the load-bearing parts of the VT
@@ -61,7 +79,7 @@ theme/recipe additions are always welcome and always reviewed.
 [gfi]: https://github.com/benyblack/NovaTerminal/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
 [hw]: https://github.com/benyblack/NovaTerminal/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22
 
-### 4. Ask
+### 5. Ask
 
 If you are unsure whether an approach fits, comment on the issue before writing
 much code. That costs you a day of waiting and saves you a week of rework. We
@@ -366,6 +384,9 @@ providing it up front just gets you a faster first response.
 
 All PRs are automatically checked by CI:
 
+- formatting (`dotnet format whitespace`, Windows + Linux — blocking). The
+  cheapest check to fail and the cheapest to fix: run `dotnet format whitespace`
+  and commit the result.
 - unit tests (VT, Rendering, Architecture, Platform, McpServer — blocking)
 - headless App.Tests (currently non-blocking due to an upstream
   Avalonia.Headless teardown deadlock, tracked in #81). Note: this is a
@@ -397,6 +418,10 @@ Maintainers may request:
 - Avoid premature optimization
 - Keep methods small and explicit
 - Comment *why*, not *what*
+
+Mechanical formatting is not a matter of taste here — `.editorconfig` decides it
+and CI enforces it. Run `dotnet format whitespace` and move on; there is nothing
+to argue about and no reviewer will ask you to hand-align anything.
 
 ---
 


### PR DESCRIPTION
Follow-up to #253. Docs only.

#253 made `dotnet format whitespace` a **blocking** CI check on both Windows and Linux. `CONTRIBUTING.md` did not mention formatting anywhere — so a first-time contributor would open their first PR, hit a red check, and find nothing about it in the document whose entire job is getting them to a merged PR.

That lands on precisely the people the new `good first issue` set (#247–#252) is meant to attract, and it is my omission from #253 rather than a pre-existing gap.

## Three additions

**A `Formatting` step in Start Here** (now step 3 of 5) with the fix command and the verify command CI runs. It says explicitly *not* to run a bare `dotnet format`:

> Only the whitespace pass is gated […] The style and analyzer passes are **not** enforced yet (tracked in #108), so do not run a bare `dotnet format`: it will also rewrite things this project has not agreed on, and your diff becomes unreviewable.

Worth being explicit about, because the obvious command is the wrong one — a bare `dotnet format` surfaces 174 analyzer diagnostics on the current tree that belong to #108.

**Formatting added to the blocking-checks list** under CI & Review Process, flagged as the cheapest check to fail and the cheapest to fix.

**A line under Coding Style** stating that mechanical formatting is not a matter of taste, so nobody hand-aligns anything or argues about it in review.

It also notes that `.gitattributes` is why the check agrees across platforms — the non-obvious part if someone's editor disagrees with the tool.

## Verified

- `dotnet format whitespace --verify-no-changes` exits 0 on this branch, so the document's own advice is true.
- Start Here renumbers cleanly 1–5.
