### PR TITLE
fix(ssh): stop retaining session passwords as unclearable managed strings

### DIFF
--- a/src/NovaTerminal.App/Services/Ssh/ActiveSshSessionRegistry.cs
+++ b/src/NovaTerminal.App/Services/Ssh/ActiveSshSessionRegistry.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
 using NovaTerminal.Platform.Ssh.Models;
 
 namespace NovaTerminal.Services.Ssh;
@@ -8,7 +11,42 @@ public sealed class ActiveSshSessionRegistry
 {
     private static readonly Lazy<ActiveSshSessionRegistry> Shared = new(() => new ActiveSshSessionRegistry());
     private readonly ConcurrentDictionary<Guid, ActiveSshSessionDescriptor> _sessions = new();
-    private readonly ConcurrentDictionary<Guid, string> _runtimePasswords = new();
+
+    /// <summary>
+    /// Session passwords, held as UTF-8 in pinned buffers rather than as <see cref="string"/>.
+    /// </summary>
+    /// <remarks>
+    /// #121: this used to be a <c>ConcurrentDictionary&lt;Guid, string&gt;</c>, which meant plaintext
+    /// credentials sat on the managed heap for the whole lifetime of a session — hours — in a process
+    /// that also renders untrusted terminal output. A <see cref="string"/> cannot be cleared, and the
+    /// GC is free to copy it while compacting, so the old copy could not even be reliably
+    /// *over*written.
+    ///
+    /// Two properties change here, and both are about the long-lived copy specifically:
+    ///
+    /// <list type="bullet">
+    /// <item><b>Clearable.</b> Bytes are zeroed on overwrite and on <see cref="Unregister"/>, so the
+    /// window shrinks from "process lifetime" to "session lifetime".</item>
+    /// <item><b>Not relocatable.</b> The buffer is allocated pinned, so compaction cannot leave a stale
+    /// copy elsewhere in the heap that nothing has a reference to and nothing can clear.</item>
+    /// </list>
+    ///
+    /// What this does <em>not</em> do, stated plainly so nobody reads more into it: transient
+    /// <see cref="string"/> copies still exist. <see cref="TryGetRuntimePassword"/> has to return one
+    /// because every consumer needs one — <c>NativeSshConnectionOptions.Password</c> is a string and the
+    /// interop marshals it as <c>LPUTF8Str</c>. Those copies are short-lived and eligible for collection
+    /// immediately, which is a materially different exposure from one that persists for the session.
+    /// Removing them means changing the FFI signature to take a buffer; that is tracked on #121 and is
+    /// deliberately not bundled here.
+    ///
+    /// A plain dictionary under an explicit lock, not a <see cref="ConcurrentDictionary{TKey,TValue}"/>:
+    /// zeroing a buffer that a concurrent reader is mid-decode would hand that reader a half-zeroed
+    /// password and fail its auth for no visible reason. Reads, writes and clears all happen inside the
+    /// lock so the bytes are never observed while being wiped. Contention is irrelevant — this is touched
+    /// on auth and on teardown, not per keystroke.
+    /// </remarks>
+    private readonly Dictionary<Guid, byte[]> _runtimePasswords = new();
+    private readonly object _runtimePasswordGate = new();
 
     public static ActiveSshSessionRegistry Instance => Shared.Value;
 
@@ -42,7 +80,7 @@ public sealed class ActiveSshSessionRegistry
     public void Unregister(Guid sessionId)
     {
         _sessions.TryRemove(sessionId, out _);
-        _runtimePasswords.TryRemove(sessionId, out _);
+        ClearRuntimePassword(sessionId);
     }
 
     public void SetRuntimePassword(Guid sessionId, string? password)
@@ -54,18 +92,60 @@ public sealed class ActiveSshSessionRegistry
 
         if (string.IsNullOrEmpty(password))
         {
-            _runtimePasswords.TryRemove(sessionId, out _);
+            ClearRuntimePassword(sessionId);
             return;
         }
 
-        _runtimePasswords[sessionId] = password;
+        // Pinned so the GC cannot relocate it: a moved buffer leaves plaintext behind at the old
+        // address with no reference to it, which is the one thing zeroing cannot fix afterwards.
+        int byteCount = Encoding.UTF8.GetByteCount(password);
+        byte[] buffer = GC.AllocateArray<byte>(byteCount, pinned: true);
+        Encoding.UTF8.GetBytes(password, buffer);
+
+        lock (_runtimePasswordGate)
+        {
+            if (_runtimePasswords.TryGetValue(sessionId, out byte[]? existing))
+            {
+                CryptographicOperations.ZeroMemory(existing);
+            }
+
+            _runtimePasswords[sessionId] = buffer;
+        }
     }
 
+    /// <summary>
+    /// Returns the session's password, or <c>null</c> when none is held.
+    /// </summary>
+    /// <remarks>
+    /// The returned string is a transient copy — see the note on <c>_runtimePasswords</c>. Callers should
+    /// use it and let it go rather than storing it anywhere with a longer life than the operation.
+    /// </remarks>
     public bool TryGetRuntimePassword(Guid sessionId, out string? password)
     {
-        bool found = _runtimePasswords.TryGetValue(sessionId, out string? stored);
-        password = found ? stored : null;
-        return found;
+        lock (_runtimePasswordGate)
+        {
+            if (!_runtimePasswords.TryGetValue(sessionId, out byte[]? stored))
+            {
+                password = null;
+                return false;
+            }
+
+            // Decoded under the lock so a concurrent Unregister cannot zero the bytes mid-decode and
+            // hand back a truncated password that would fail auth for no discoverable reason.
+            password = Encoding.UTF8.GetString(stored);
+            return true;
+        }
+    }
+
+    private void ClearRuntimePassword(Guid sessionId)
+    {
+        lock (_runtimePasswordGate)
+        {
+            if (_runtimePasswords.Remove(sessionId, out byte[]? removed))
+            {
+                CryptographicOperations.ZeroMemory(removed);
+            }
+        }
     }
 }
 

--- a/src/NovaTerminal.App/native/rusty_ssh/tests/ffi_contract.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/tests/ffi_contract.rs
@@ -54,6 +54,54 @@ fn malformed_json_is_rejected_without_panic() {
 }
 
 #[test]
+fn invalid_utf8_bytes_are_rejected_without_panic() {
+    // #121: the abuse suite covered null pointers, double-close, use-after-free and malformed JSON, but
+    // never invalid *encoding*. That is the one gap with history behind it: #152 was a real bug where
+    // the DllImport ANSI default silently mangled non-ASCII cmd/cwd/args into U+FFFD, which is why every
+    // string parameter now carries [MarshalAs(UnmanagedType.LPUTF8Str)] and why CA2101 is suppressed
+    // there rather than "fixed".
+    //
+    // A managed caller cannot easily produce these bytes, but a caller in any other language can, and
+    // the boundary is public. The contract to pin is that `CStr::to_str` failing is handled as a
+    // rejection rather than an unwrap across the FFI boundary.
+    //
+    // 0x80 is a UTF-8 continuation byte with no leader; 0xC3 0x28 is a two-byte sequence whose
+    // continuation byte is invalid; 0xED 0xA0 0x80 is a surrogate half, which is well-formed CESU-8 and
+    // illegal UTF-8 — the case a naive length-only validator lets through.
+    for bad in [
+        &b"\x80"[..],
+        &b"\xC3\x28"[..],
+        &b"\xED\xA0\x80"[..],
+        &b"{\"path\":\"/\xFF\xFE\"}"[..],
+        &b"\xF4\x90\x80\x80"[..], // beyond U+10FFFF
+    ] {
+        let payload = CString::new(bad).expect("test bytes must not contain an interior NUL");
+        let mut response: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let rc = nova_ssh_sftp_list_directory(payload.as_ptr(), &mut response);
+
+        assert_eq!(
+            NOVA_SSH_RESULT_INVALID_ARGUMENT, rc,
+            "invalid UTF-8 must be rejected as invalid-argument: {bad:?}"
+        );
+
+        // The return code alone does not prove *why* it was rejected: malformed JSON returns the same
+        // code, so `assert_ne!(rc, 0)` would still pass if `to_str()` were swapped for
+        // `to_string_lossy()` — the mangled U+FFFD text would simply fail to parse as JSON instead.
+        // The message is what distinguishes the two paths, so assert on that.
+        assert!(!response.is_null(), "a rejection must still produce a response body");
+        let message = unsafe { std::ffi::CStr::from_ptr(response) }
+            .to_string_lossy()
+            .into_owned();
+        nova_ssh_string_free(response);
+
+        assert!(
+            message.contains("non-UTF8"),
+            "expected the encoding-rejection path, got: {message}"
+        );
+    }
+}
+
+#[test]
 fn oversized_json_is_rejected_without_panic() {
     // Syntactically-valid but semantically-bogus, very large payload.
     let big = format!(r#"{{"junk":"{}"}}"#, "A".repeat(2_000_000));

--- a/tests/NovaTerminal.App.Tests/Ssh/ActiveSshSessionSecretHygieneTests.cs
+++ b/tests/NovaTerminal.App.Tests/Ssh/ActiveSshSessionSecretHygieneTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using NovaTerminal.Platform.Ssh.Models;
+using NovaTerminal.Services.Ssh;
+using Xunit;
+
+namespace NovaTerminal.Tests.Ssh;
+
+/// <summary>
+/// #121: <c>ActiveSshSessionRegistry</c> retains the session password so the remote file browser and
+/// path autocomplete can open their own SFTP connections without re-prompting. It used to retain it as a
+/// <see cref="string"/>, which cannot be cleared and which the GC may relocate — so plaintext sat on the
+/// managed heap for the whole session with no way to wipe it.
+///
+/// These assert the two properties that changed. They reach into the private buffer by reflection on
+/// purpose: the observable API cannot distinguish "forgotten" from "wiped", and *wiped* is the whole
+/// point. A test that only checked <c>TryGetRuntimePassword</c> returns false would have passed against
+/// the old code.
+/// </summary>
+public sealed class ActiveSshSessionSecretHygieneTests
+{
+    private const string Secret = "correct horse battery staple";
+
+    private static Dictionary<Guid, byte[]> PasswordBuffers(ActiveSshSessionRegistry registry)
+    {
+        FieldInfo field = typeof(ActiveSshSessionRegistry).GetField(
+            "_runtimePasswords",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException(
+                "ActiveSshSessionRegistry._runtimePasswords is gone. If the storage was reshaped, these "
+                + "tests need reshaping with it — do not delete them, they are the only check that the "
+                + "retained secret is actually wiped rather than merely dropped.");
+
+        return (Dictionary<Guid, byte[]>)field.GetValue(registry)!;
+    }
+
+    private static ActiveSshSessionRegistry RegistryWithSession(Guid sessionId)
+    {
+        var registry = new ActiveSshSessionRegistry();
+        registry.Register(new ActiveSshSessionDescriptor(sessionId, Guid.NewGuid(), SshBackendKind.Native));
+        return registry;
+    }
+
+    [Fact]
+    public void Unregister_WipesTheRetainedBytes_NotJustTheReference()
+    {
+        Guid sessionId = Guid.NewGuid();
+        ActiveSshSessionRegistry registry = RegistryWithSession(sessionId);
+        registry.SetRuntimePassword(sessionId, Secret);
+
+        // Hold the array itself, so dropping it from the dictionary cannot hide whether it was wiped.
+        byte[] retained = PasswordBuffers(registry)[sessionId];
+        Assert.Contains(retained, b => b != 0);
+
+        registry.Unregister(sessionId);
+
+        Assert.All(retained, b => Assert.Equal(0, b));
+        Assert.False(registry.TryGetRuntimePassword(sessionId, out _));
+    }
+
+    [Fact]
+    public void OverwritingThePassword_WipesThePreviousBytes()
+    {
+        // The re-auth path: a second prompt in the same session replaces the stored secret. Without an
+        // explicit wipe the first one is simply abandoned, still legible, for the rest of the process.
+        Guid sessionId = Guid.NewGuid();
+        ActiveSshSessionRegistry registry = RegistryWithSession(sessionId);
+
+        registry.SetRuntimePassword(sessionId, Secret);
+        byte[] first = PasswordBuffers(registry)[sessionId];
+
+        registry.SetRuntimePassword(sessionId, "a different secret entirely");
+
+        Assert.All(first, b => Assert.Equal(0, b));
+        Assert.True(registry.TryGetRuntimePassword(sessionId, out string? current));
+        Assert.Equal("a different secret entirely", current);
+    }
+
+    [Fact]
+    public void ClearingWithAnEmptyPassword_WipesTheRetainedBytes()
+    {
+        Guid sessionId = Guid.NewGuid();
+        ActiveSshSessionRegistry registry = RegistryWithSession(sessionId);
+        registry.SetRuntimePassword(sessionId, Secret);
+        byte[] retained = PasswordBuffers(registry)[sessionId];
+
+        registry.SetRuntimePassword(sessionId, null);
+
+        Assert.All(retained, b => Assert.Equal(0, b));
+        Assert.False(registry.TryGetRuntimePassword(sessionId, out _));
+    }
+
+    [Theory]
+    // The regression risk this change introduces: storage moved from a verbatim string to UTF-8 bytes,
+    // so anything that does not survive an encode/decode round trip is a new bug. A user whose password
+    // contains a non-ASCII character would silently fail to authenticate.
+    [InlineData("plain-ascii-123")]
+    [InlineData("café-münchen")]
+    [InlineData("пароль")]
+    [InlineData("密碼")]
+    [InlineData("emoji-\U0001F511-key")]
+    [InlineData("trailing space ")]
+    [InlineData(" leading space")]
+    [InlineData("tab\tand\nnewline")]
+    public void RetainedPasswordSurvivesTheUtf8RoundTrip(string password)
+    {
+        Guid sessionId = Guid.NewGuid();
+        ActiveSshSessionRegistry registry = RegistryWithSession(sessionId);
+
+        registry.SetRuntimePassword(sessionId, password);
+
+        Assert.True(registry.TryGetRuntimePassword(sessionId, out string? roundTripped));
+        Assert.Equal(password, roundTripped);
+    }
+
+    // NOT TESTED, deliberately: that the lock prevents a torn read.
+    //
+    // I wrote that test and then deleted it. It hammered concurrent reads against concurrent
+    // Unregisters and asserted every observation was the whole secret or nothing — and it passed
+    // just as happily with the lock removed, verified by mutation. The window between taking the
+    // array out of the dictionary and decoding it is a few nanoseconds, so a probabilistic test
+    // cannot close it, and forcing it would mean a pause seam in production code purely for the
+    // test.
+    //
+    // A test that passes with and without the thing it claims to guard is worse than no test: it
+    // reads as coverage. So the lock's justification is stated in the code and left as reasoning,
+    // not dressed up as a verified property.
+}


### PR DESCRIPTION
Addresses #121's remaining half — the managed side of item 1. The Rust half zeroizes; the managed side was handing it a `string` that cannot be cleared. #121 stays open for the rest (see the end).

## The exposure

`ActiveSshSessionRegistry.cs:11` held session passwords as:

```csharp
private readonly ConcurrentDictionary<Guid, string> _runtimePasswords = new();
```

On a **process-wide singleton**, for the **entire lifetime of a session** — hours — in a process that also renders untrusted terminal output. A `string` cannot be wiped, and the GC may relocate it while compacting, so the old copy could not even reliably be *over*written.

## Retention itself is load-bearing and stays

Worth stating, because "just don't keep it" was my first instinct and it's wrong. Three consumers depend on it:

- `SshInteractionService.cs:104` — reuses it for a later auth prompt in the same session
- `RemoteDirectoryBrowserService.cs:134` — opens its own SFTP connection for the remote file browser
- the path-autocomplete path, via the same helper

Dropping the retention would re-prompt for a password on autocomplete. So what changed is *what* is retained.

## What changed

UTF-8 bytes in a buffer allocated with `GC.AllocateArray<byte>(n, pinned: true)`, zeroed via `CryptographicOperations.ZeroMemory` on overwrite and on `Unregister`.

Two properties move, and both are about the long-lived copy specifically:

| | Before | After |
|---|---|---|
| Clearable | No — a `string` can only be dereferenced | Yes — window shrinks from process lifetime to session lifetime |
| Relocatable | Yes — compaction can leave a stale copy nothing references and nothing can clear | No — pinned |

Storage is a plain `Dictionary` under an explicit lock rather than a `ConcurrentDictionary`: wiping a buffer that a reader is mid-decode would hand back a half-zeroed password and fail its auth for no discoverable reason. Reads, writes and clears all happen inside the lock. Contention is irrelevant — this is touched on auth and on teardown, not per keystroke.

## What this does not do

Stated in the code so nobody reads more into it. **Transient `string` copies still exist**, because every consumer needs one: `NativeSshConnectionOptions.Password` is a `string` and the interop marshals it as `LPUTF8Str`. Those are short-lived and immediately collectable — a materially different exposure from one that persists for the session, which is why this slice is worth shipping on its own. Removing them means changing the FFI signature to take a buffer; left on #121.

## Also: the bad-UTF-8 abuse test

The suite covered null pointers, double-close, use-after-free and malformed JSON but never invalid *encoding* — the one gap with history, since #152 was a real bug where the DllImport ANSI default silently mangled non-ASCII into U+FFFD.

**The obvious assertion was too weak.** My first version asserted `rc != 0`, which passes even with `to_str()` swapped for `to_string_lossy()` — the mangled text simply fails to parse as JSON instead, and malformed JSON returns the *same* `NOVA_SSH_RESULT_INVALID_ARGUMENT`. It now asserts on the rejection message, and the mutant fails with `"…rejected invalid remote path list request JSON."` instead of the non-UTF8 message.

## Tests — all mutation-checked

| mutant | fails |
|---|---|
| drop the reference without wiping (the old behaviour) | both wipe tests |
| overwrite without wiping the displaced buffer | the overwrite test |
| UTF-8 → Latin1 | 3 of the 8 round-trip cases |
| `to_str()` → `to_string_lossy()` in the FFI | the new encoding test |

The round-trip theory exists because this change introduces a genuine regression risk: storage moved from a verbatim `string` to UTF-8 bytes, so a password containing a non-ASCII character that failed to survive would **silently fail to authenticate**. Eight cases including Cyrillic, CJK, an emoji, and leading/trailing whitespace.

The wipe tests reach into the private buffer by reflection deliberately — the observable API cannot distinguish "forgotten" from "wiped", and wiped is the whole point. A test that only checked `TryGetRuntimePassword` returns false would have passed against the old code.

## One test I wrote and deleted

A concurrent read/`Unregister` hammer asserting no torn read. **It passed just as happily with the lock removed** — verified by mutation with `locks=0` confirmed in the file before running. The race window is nanoseconds and forcing it would need a pause seam in production code purely for the test.

A test that passes with and without the thing it claims to guard is worse than no test, so the lock's justification is left as reasoning in the code rather than dressed up as a verified property. The deletion is recorded in the test file with the reasoning.

## A finding I am reporting rather than fixing

`read_c_string` (`rusty_ssh/src/lib.rs:1377`) uses `to_string_lossy()`, and it is used for **every connect argument** — `host`, `user`, `term`, `identity_file`, `jump_host`, `jump_user`, `shell_detection_command` and the three cwd bootstrap commands (:1185-1224, :860).

So invalid UTF-8 there is silently replaced with U+FFFD rather than rejected — the same class as #152, and inconsistent with the SFTP entry points which reject it explicitly. The app itself cannot trigger it (managed marshals as `LPUTF8Str`), but the boundary is `pub extern "C"`, and silently substituting U+FFFD into `bash_cwd_bootstrap` — a shell command sent to the remote — is worse than rejecting it.

Not fixed here because a naive fix changes semantics in several places at once: `host`/`user` would correctly become `INVALID_ARGUMENT`, but `term` and `originator_address` fall back to defaults via `unwrap_or_else` and the cwd bootstraps would silently skip the feature. That deserves its own change with its own reasoning. Reported on #121.

## Verification

- Full suite green: **App.Tests 1305**, VT 126, Platform 122, Rendering 59, Architecture 24, `rusty_ssh` 56 + 5 FFI contract.
- Clippy at parity with `main` — **14 errors / 13 warnings**, measured the same way on both, since the new test dereferences a raw pointer and that is what grew the baseline in #239.
- Format gate passes.

One note on that last point, since it is the first PR under the new gate: it initially failed locally on `ENDOFLINE` because the files were authored with LF while `.editorconfig` requires CRLF. `git diff HEAD` showed **no content difference** — the committed blob was already correct, and a fresh checkout (which is what CI does) produces CRLF. Worth knowing as the shape of a false alarm rather than a real one.
