### PR TITLE
feat(vt): carry OSC 8 hyperlink identity, not just the URI

### DIFF
--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -79,6 +79,12 @@ namespace NovaTerminal.VT
         public Action<int?>? OnCommandFinished { get; set; }
         public Action<int?, long?>? OnCommandFinishedDetailed { get; set; }
 
+        /// <summary>
+        /// Interns OSC 8 hyperlink identities. Per-parser rather than static: two terminals must not share
+        /// a link table, or the same (URI, id) pair written in one pane would group with cells in another.
+        /// </summary>
+        private readonly Links.HyperlinkRegistry _hyperlinks = new();
+
         public AnsiParser(TerminalBuffer buffer, bool? forceConPtyFiltering = null)
         {
             _buffer = buffer;
@@ -1581,13 +1587,23 @@ namespace NovaTerminal.VT
 
             // OSC 8: hyperlinks (open/close)
             // Format: OSC 8 ; params ; URI ST/BEL
+            //
+            // #95 gap 2: the params field used to be discarded — only everything after the second ';' was
+            // read. That field carries `id=`, which is what states that two runs of cells are one anchor,
+            // so hyperlink identity was being thrown away before it reached the buffer. It is parsed here
+            // and resolved into an interned identity; see Links/HyperlinkRegistry.cs.
+            //
+            // A close (`OSC 8 ; ; ST`) has an empty URI and resolves to null, which clears the open link.
+            // Switching straight from one link to another without closing is legal per the spec and needs
+            // no special handling: it is just another assignment.
             if (code == "8")
             {
                 int secondSep = data.IndexOf(';');
                 if (secondSep >= 0)
                 {
+                    string parameters = data.Substring(0, secondSep);
                     string uri = data.Substring(secondSep + 1);
-                    _buffer.CurrentHyperlink = string.IsNullOrWhiteSpace(uri) ? null : uri;
+                    _buffer.CurrentHyperlink = _hyperlinks.Resolve(parameters, uri);
                 }
             }
         }

--- a/src/NovaTerminal.VT/Buffer/ScrollbackPages.cs
+++ b/src/NovaTerminal.VT/Buffer/ScrollbackPages.cs
@@ -109,7 +109,7 @@ namespace NovaTerminal.VT.Storage
             ReadOnlySpan<TerminalCell> row,
             bool isWrapped = false,
             SmallMap<string>? extendedText = null,
-            SmallMap<string>? hyperlinks = null)
+            SmallMap<NovaTerminal.VT.Links.Hyperlink>? hyperlinks = null)
         {
             if (row.Length != _cols)
                 throw new ArgumentException($"Row length {row.Length} must equal Cols {_cols}.", nameof(row));
@@ -219,7 +219,7 @@ namespace NovaTerminal.VT.Storage
         }
 
         /// <summary>Returns the hyperlink SmallMap for the given logical row, or null if none.</summary>
-        public SmallMap<string>? GetHyperlinkMap(int logicalIndex)
+        public SmallMap<NovaTerminal.VT.Links.Hyperlink>? GetHyperlinkMap(int logicalIndex)
         {
             (TerminalPage page, int rowInPage) = FindPage(logicalIndex);
             return page.GetHyperlinkMap(rowInPage);
@@ -269,7 +269,7 @@ namespace NovaTerminal.VT.Storage
             Span<TerminalCell> destination,
             out bool isWrapped,
             out SmallMap<string>? extendedText,
-            out SmallMap<string>? hyperlinks)
+            out SmallMap<NovaTerminal.VT.Links.Hyperlink>? hyperlinks)
         {
             isWrapped = false;
             extendedText = null;

--- a/src/NovaTerminal.VT/Buffer/TerminalPage.cs
+++ b/src/NovaTerminal.VT/Buffer/TerminalPage.cs
@@ -40,7 +40,7 @@ namespace NovaTerminal.VT.Storage
         // Sparse per-row metadata side-channels. null = no extended text/hyperlinks on any row in this page.
         // Indexed by rowIndex (0..RowsInPage-1). Each element is null if that row has no metadata.
         private SmallMap<string>?[]? _extendedText;
-        private SmallMap<string>?[]? _hyperlinks;
+        private SmallMap<NovaTerminal.VT.Links.Hyperlink>?[]? _hyperlinks;
 
         public TerminalPage(int rowsInPage, int cols)
         {
@@ -180,8 +180,8 @@ namespace NovaTerminal.VT.Storage
 
         // ── Hyperlink Metadata ───────────────────────────────────────────────────
 
-        /// <summary>Gets the hyperlink URL for a cell, or null if none.</summary>
-        public string? GetHyperlink(int rowIndex, int col)
+        /// <summary>Gets the hyperlink identity for a cell, or null if none.</summary>
+        public NovaTerminal.VT.Links.Hyperlink? GetHyperlink(int rowIndex, int col)
         {
             if (_hyperlinks == null) return null;
             var map = _hyperlinks[rowIndex];
@@ -190,15 +190,15 @@ namespace NovaTerminal.VT.Storage
         }
 
         /// <summary>Copies all hyperlink entries from an existing SmallMap into the specified row.</summary>
-        public void SetHyperlinkFromMap(int rowIndex, SmallMap<string>? source)
+        public void SetHyperlinkFromMap(int rowIndex, SmallMap<NovaTerminal.VT.Links.Hyperlink>? source)
         {
             if (source == null || source.Count == 0) return;
-            _hyperlinks ??= new SmallMap<string>?[RowsInPage];
+            _hyperlinks ??= new SmallMap<NovaTerminal.VT.Links.Hyperlink>?[RowsInPage];
             _hyperlinks[rowIndex] = source;
         }
 
         /// <summary>Returns the raw SmallMap for the row's hyperlinks (null if none).</summary>
-        public SmallMap<string>? GetHyperlinkMap(int rowIndex) =>
+        public SmallMap<NovaTerminal.VT.Links.Hyperlink>? GetHyperlinkMap(int rowIndex) =>
             _hyperlinks?[rowIndex];
 
         /// <summary>

--- a/src/NovaTerminal.VT/Links/Hyperlink.cs
+++ b/src/NovaTerminal.VT/Links/Hyperlink.cs
@@ -1,0 +1,51 @@
+namespace NovaTerminal.VT.Links
+{
+    /// <summary>
+    /// One OSC 8 hyperlink identity. Cells that belong to the same logical link hold a reference to the
+    /// same instance, so "are these two cells the same link?" is reference equality.
+    /// </summary>
+    /// <remarks>
+    /// #95 gap 2: the side table used to hold a bare URI string per cell, which cannot express identity.
+    /// The OSC 8 spec is explicit that identity is the <em>pair</em>:
+    ///
+    /// <blockquote>Character cells that have the same target URI and the same nonempty <c>id</c> are always
+    /// underlined together on mouseover. The same <c>id</c> is only used for connecting character cells
+    /// whose URIs is also the same.</blockquote>
+    ///
+    /// So neither half alone is sufficient. Two adjacent links to the same URI with different ids are two
+    /// links; the same id against two different URIs is not one link.
+    ///
+    /// For links written <em>without</em> an id, the spec allows either of two heuristics and recommends
+    /// VTE's: assign a fresh identity each time an OSC 8 with a URI but no id is encountered. We do that,
+    /// which means every hyperlink cell has an identity and the ambiguous case simply does not arise. The
+    /// alternative (iTerm2's: join adjacent cells with equal URIs) would silently merge two consecutive
+    /// distinct links that happen to share a URI — the exact case <c>id</c> exists to disambiguate.
+    ///
+    /// Instances are interned by <see cref="HyperlinkRegistry"/>. Reference equality is the identity test;
+    /// value equality is deliberately <em>not</em> implemented, because two separately-written no-id links
+    /// to the same URI are equal by value and must still be distinct links.
+    /// </remarks>
+    public sealed class Hyperlink
+    {
+        internal Hyperlink(string uri, string? id)
+        {
+            Uri = uri;
+            Id = id;
+        }
+
+        /// <summary>The link target, exactly as received (already URI-encoded per the spec).</summary>
+        public string Uri { get; }
+
+        /// <summary>
+        /// The explicit <c>id=</c> parameter, or <c>null</c> when the producer did not supply one.
+        /// </summary>
+        /// <remarks>
+        /// The spec treats an empty id and an absent id as interchangeable, so both arrive here as
+        /// <c>null</c>. This is exposed for diagnostics and tests; identity comparisons should use
+        /// reference equality rather than reading this back out.
+        /// </remarks>
+        public string? Id { get; }
+
+        public override string ToString() => Id is null ? Uri : $"{Uri} (id={Id})";
+    }
+}

--- a/src/NovaTerminal.VT/Links/HyperlinkRegistry.cs
+++ b/src/NovaTerminal.VT/Links/HyperlinkRegistry.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+
+namespace NovaTerminal.VT.Links
+{
+    /// <summary>
+    /// Interns <see cref="Hyperlink"/> instances so that cells belonging to one logical link share a
+    /// reference, per OSC 8's (URI, id) identity rule.
+    /// </summary>
+    /// <remarks>
+    /// #95 gap 2. Two behaviours, both from the spec:
+    ///
+    /// <list type="bullet">
+    /// <item><b>With an explicit id</b> — the same (URI, id) pair returns the <em>same</em> instance, even
+    /// across unrelated writes. That is the whole point of <c>id</c>: it lets a producer state that
+    /// non-contiguous runs, possibly separated by a line break or another pane, are one anchor.</item>
+    /// <item><b>Without an id</b> — every call returns a <em>fresh</em> instance, so cells printed in one
+    /// OSC 8 run are joined and separate runs are not. This is VTE's heuristic, which the spec recommends
+    /// as the easier of the two permitted options.</item>
+    /// </list>
+    ///
+    /// OSC 8 arrives from the remote, so both dimensions are bounded. The interning table only grows for
+    /// links that carry an explicit id, but a hostile stream can emit unlimited distinct ids, so entries
+    /// are capped and the table is cleared wholesale when the cap is hit rather than evicting one entry at
+    /// a time: losing interning degrades hover grouping for old links, it does not corrupt anything, and a
+    /// stream pathological enough to reach the cap has no legitimate grouping to preserve.
+    ///
+    /// No-id links are deliberately not interned, so they cost nothing here — a fresh instance per run is
+    /// garbage-collectable as soon as the rows holding it are evicted.
+    /// </remarks>
+    public sealed class HyperlinkRegistry
+    {
+        /// <summary>
+        /// De facto URI ceiling. The spec records VTE and iTerm2 both capping at 2083 and notes there is no
+        /// de jure limit. Longer targets are refused rather than truncated: a truncated URI is a URI that
+        /// points somewhere else, which is worse than no link at all.
+        /// </summary>
+        public const int MaxUriLength = 2083;
+
+        /// <summary>
+        /// Ceiling on an explicit id. The spec mentions VTE's 250 while explicitly warning not to rely on
+        /// that number, so this is a safety bound, not a compatibility claim. An over-long id is dropped
+        /// and the link is treated as having no id, which downgrades grouping without losing the link.
+        /// </summary>
+        public const int MaxIdLength = 250;
+
+        /// <summary>Cap on distinct explicit-id links held for interning.</summary>
+        public const int MaxInternedLinks = 4096;
+
+        private readonly Dictionary<(string Uri, string Id), Hyperlink> _interned = new();
+
+        /// <summary>
+        /// Resolves an OSC 8 open into a hyperlink identity, or <c>null</c> if the sequence does not name a
+        /// usable target (which is how OSC 8 signals "close the current link").
+        /// </summary>
+        /// <param name="parameters">The raw <c>params</c> field, between the two semicolons.</param>
+        /// <param name="uri">The raw URI field.</param>
+        public Hyperlink? Resolve(string? parameters, string? uri)
+        {
+            if (string.IsNullOrWhiteSpace(uri))
+            {
+                return null;
+            }
+
+            if (uri.Length > MaxUriLength)
+            {
+                return null;
+            }
+
+            string? id = ExtractId(parameters);
+
+            // No id: a fresh identity per OSC 8 open, so this run groups with itself and nothing else.
+            if (id is null)
+            {
+                return new Hyperlink(uri, null);
+            }
+
+            var key = (uri, id);
+            if (_interned.TryGetValue(key, out Hyperlink? existing))
+            {
+                return existing;
+            }
+
+            if (_interned.Count >= MaxInternedLinks)
+            {
+                _interned.Clear();
+            }
+
+            var link = new Hyperlink(uri, id);
+            _interned[key] = link;
+            return link;
+        }
+
+        /// <summary>
+        /// Pulls <c>id</c> out of the OSC 8 params field, or <c>null</c> when absent, empty or unusable.
+        /// </summary>
+        /// <remarks>
+        /// Format is <c>key=value</c> pairs separated by <c>:</c> — e.g. <c>id=xyz123:foo=bar</c>. Only
+        /// <c>id</c> is defined today and the field exists for future extension, so unknown keys are
+        /// skipped rather than treated as an error. The spec states an empty id and an absent id are
+        /// interchangeable, so both yield <c>null</c> here and the caller falls back to a fresh identity.
+        /// </remarks>
+        internal static string? ExtractId(string? parameters)
+        {
+            if (string.IsNullOrEmpty(parameters))
+            {
+                return null;
+            }
+
+            int start = 0;
+            while (start < parameters.Length)
+            {
+                int end = parameters.IndexOf(':', start);
+                if (end < 0)
+                {
+                    end = parameters.Length;
+                }
+
+                int eq = parameters.IndexOf('=', start);
+                if (eq >= 0 && eq < end)
+                {
+                    // Only 'id' is defined; every other key is skipped so the field stays extensible.
+                    if (string.CompareOrdinal(parameters, start, "id", 0, 2) == 0 && eq - start == 2)
+                    {
+                        int valueStart = eq + 1;
+                        int valueLength = end - valueStart;
+                        if (valueLength > 0 && valueLength <= MaxIdLength)
+                        {
+                            string value = parameters.Substring(valueStart, valueLength);
+                            return string.IsNullOrWhiteSpace(value) ? null : value;
+                        }
+
+                        // Present but empty, or absurdly long: treat as no id.
+                        return null;
+                    }
+                }
+
+                start = end + 1;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
@@ -107,7 +107,22 @@ namespace NovaTerminal.VT
             return (cell.HasExtendedText ? row.GetExtendedText(col) : null) ?? cell.Character.ToString();
         }
 
+        /// <summary>
+        /// Returns the URI of the hyperlink on a cell, or <c>null</c> if it has none.
+        /// </summary>
+        /// <remarks>
+        /// For "do these two cells belong to the same anchor?" use
+        /// <see cref="GetHyperlinkIdentityAbsolute"/> instead — equal URIs do not imply one link, which is
+        /// the whole reason OSC 8 has an <c>id</c> parameter.
+        /// </remarks>
         public string? GetHyperlinkAbsolute(int col, int absRow)
+            => GetHyperlinkIdentityAbsolute(col, absRow)?.Uri;
+
+        /// <summary>
+        /// Returns the hyperlink identity on a cell, or <c>null</c> if it has none. Cells in the same
+        /// logical OSC 8 anchor return the same instance, so identity is reference equality.
+        /// </summary>
+        public Links.Hyperlink? GetHyperlinkIdentityAbsolute(int col, int absRow)
         {
             bool lockTaken = EnterReadLockIfNeeded();
             try
@@ -120,8 +135,8 @@ namespace NovaTerminal.VT
                     // into scrollback, but this read path returned null unconditionally, so
                     // an OSC 8 link stopped being a link as soon as it scrolled off screen.
                     var hyperlinks = _scrollback.GetHyperlinkMap(absRow);
-                    return hyperlinks != null && hyperlinks.TryGet(col, out string? uri)
-                        ? uri
+                    return hyperlinks != null && hyperlinks.TryGet(col, out Links.Hyperlink? link)
+                        ? link
                         : null;
                 }
 

--- a/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
@@ -66,7 +66,7 @@ namespace NovaTerminal.VT
                 // (see the GetHyperlinkMap call below) and then silently dropped here - which made
                 // GetHyperlinkMap() on every flowed row unconditionally null, and lost every OSC 8
                 // link on any resize.
-                (TerminalCell Cell, string? ExtendedText, string? Hyperlink)[]? logicalCells = null;
+                (TerminalCell Cell, string? ExtendedText, Links.Hyperlink? Hyperlink)[]? logicalCells = null;
 
                 try
                 {
@@ -112,7 +112,7 @@ namespace NovaTerminal.VT
                     allPhysicalRows = System.Buffers.ArrayPool<TerminalRow>.Shared.Rent(totalPhysRows);
 
                     // 3. Metadata-Aware Logical Reconstruction
-                    var logicalCellsPool = System.Buffers.ArrayPool<(TerminalCell Cell, string? ExtendedText, string? Hyperlink)>.Shared;
+                    var logicalCellsPool = System.Buffers.ArrayPool<(TerminalCell Cell, string? ExtendedText, Links.Hyperlink? Hyperlink)>.Shared;
                     int maxLogicalCells = totalPhysRows * Math.Max(oldCols, newCols) + 1000;
                     logicalCells = logicalCellsPool.Rent(maxLogicalCells);
                     int logicalCellsCount = 0;
@@ -759,7 +759,7 @@ namespace NovaTerminal.VT
                     if (allPhysicalRows is not null)
                         System.Buffers.ArrayPool<TerminalRow>.Shared.Return(allPhysicalRows, clearArray: true);
                     if (logicalCells is not null)
-                        System.Buffers.ArrayPool<(TerminalCell Cell, string? ExtendedText, string? Hyperlink)>.Shared.Return(logicalCells, clearArray: true);
+                        System.Buffers.ArrayPool<(TerminalCell Cell, string? ExtendedText, Links.Hyperlink? Hyperlink)>.Shared.Return(logicalCells, clearArray: true);
                 }
             }
         }

--- a/src/NovaTerminal.VT/TerminalBuffer.State.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.State.cs
@@ -38,7 +38,7 @@ namespace NovaTerminal.VT
         private bool _isBlink { get => _state.IsBlink; set => _state.IsBlink = value; }
         private bool _isStrikethrough { get => _state.IsStrikethrough; set => _state.IsStrikethrough = value; }
         private bool _isHidden { get => _state.IsHidden; set => _state.IsHidden = value; }
-        private string? _currentHyperlink { get => _state.CurrentHyperlink; set => _state.CurrentHyperlink = value; }
+        private Links.Hyperlink? _currentHyperlink { get => _state.CurrentHyperlink; set => _state.CurrentHyperlink = value; }
         private bool _isPendingWrap { get => _state.IsPendingWrap; set => _state.IsPendingWrap = value; }
 
         // Output synchronization state
@@ -76,7 +76,7 @@ namespace NovaTerminal.VT
             public bool IsBlink;
             public bool IsStrikethrough;
             public bool IsHidden;
-            public string? CurrentHyperlink;
+            public Links.Hyperlink? CurrentHyperlink;
             public bool IsPendingWrap;
 
             public bool IsSynchronizedOutput;

--- a/src/NovaTerminal.VT/TerminalBuffer.Style.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.Style.cs
@@ -57,7 +57,11 @@ namespace NovaTerminal.VT
 
         public bool IsHidden { get => _isHidden; set { _isHidden = value; _isStyleDirty = true; } }
 
-        public string? CurrentHyperlink
+        /// <summary>
+        /// The hyperlink identity applied to subsequently written cells, or <c>null</c> when no link is
+        /// open. Set from an OSC 8 open; cleared by an OSC 8 close.
+        /// </summary>
+        public Links.Hyperlink? CurrentHyperlink
         {
             get => _currentHyperlink;
             set => _currentHyperlink = value;

--- a/src/NovaTerminal.VT/TerminalRow.cs
+++ b/src/NovaTerminal.VT/TerminalRow.cs
@@ -16,7 +16,10 @@ namespace NovaTerminal.VT
 
         // M2.2: Side-table for extended graphemes (strings)
         private Storage.SmallMap<string>? _extendedText;
-        private Storage.SmallMap<string>? _hyperlinks;
+
+        // #95 gap 2: holds link identity, not just the URI. Cells in the same logical OSC 8 anchor share
+        // one Hyperlink reference, so grouping is reference equality — see Links/Hyperlink.cs.
+        private Storage.SmallMap<Links.Hyperlink>? _hyperlinks;
 
         public string? GetExtendedText(int col)
         {
@@ -41,22 +44,22 @@ namespace NovaTerminal.VT
             _extendedText = null;
         }
 
-        public string? GetHyperlink(int col)
+        public Links.Hyperlink? GetHyperlink(int col)
         {
             if (_hyperlinks == null) return null;
             return _hyperlinks.TryGet(col, out var link) ? link : null;
         }
 
-        public void SetHyperlink(int col, string? link)
+        public void SetHyperlink(int col, Links.Hyperlink? link)
         {
-            if (string.IsNullOrWhiteSpace(link))
+            if (link is null)
             {
                 _hyperlinks?.Remove(col);
                 if (_hyperlinks?.Count == 0) _hyperlinks = null;
                 return;
             }
 
-            _hyperlinks ??= new Storage.SmallMap<string>();
+            _hyperlinks ??= new Storage.SmallMap<Links.Hyperlink>();
             _hyperlinks.Set(col, link);
         }
 
@@ -75,7 +78,7 @@ namespace NovaTerminal.VT
         /// Returns the raw SmallMap backing hyperlinks for this row.
         /// This is intended for preservation into paged scrollback — do not cache or mutate.
         /// </summary>
-        public Storage.SmallMap<string>? GetHyperlinkMap() => _hyperlinks;
+        public Storage.SmallMap<Links.Hyperlink>? GetHyperlinkMap() => _hyperlinks;
 
         /// <summary>
         /// True when this row carries any side-table entry. Lets callers on the write hot path
@@ -105,8 +108,10 @@ namespace NovaTerminal.VT
             _hyperlinks = ShiftMap(_hyperlinks, startCol, delta, cols);
         }
 
-        private static Storage.SmallMap<string>? ShiftMap(
-            Storage.SmallMap<string>? map, int startCol, int delta, int cols)
+        // Generic over the value type so the extended-text and hyperlink maps share one implementation:
+        // they must shift identically, and two copies of this logic is how they would drift apart.
+        private static Storage.SmallMap<T>? ShiftMap<T>(
+            Storage.SmallMap<T>? map, int startCol, int delta, int cols) where T : class
         {
             if (map is null || map.Count == 0) return null;
 
@@ -114,7 +119,7 @@ namespace NovaTerminal.VT
             // been relocated (and, for a right shift, overwrite ones not yet visited).
             int n = map.Count;
             var keys = new int[n];
-            var values = new string[n];
+            var values = new T[n];
             int i = 0;
             map.ForEach((col, value) =>
             {
@@ -123,7 +128,7 @@ namespace NovaTerminal.VT
                 i++;
             });
 
-            Storage.SmallMap<string>? shifted = null;
+            Storage.SmallMap<T>? shifted = null;
             for (int e = 0; e < n; e++)
             {
                 int col = keys[e];
@@ -138,7 +143,7 @@ namespace NovaTerminal.VT
                     if (dest < startCol || dest >= cols) continue;
                 }
 
-                shifted ??= new Storage.SmallMap<string>();
+                shifted ??= new Storage.SmallMap<T>();
                 shifted.Set(dest, values[e]);
             }
 
@@ -178,7 +183,7 @@ namespace NovaTerminal.VT
         /// extended graphemes and hyperlinks survive the round trip. The row
         /// takes ownership of the maps.
         /// </summary>
-        public void RestoreSideTables(Storage.SmallMap<string>? extendedText, Storage.SmallMap<string>? hyperlinks)
+        public void RestoreSideTables(Storage.SmallMap<string>? extendedText, Storage.SmallMap<Links.Hyperlink>? hyperlinks)
         {
             _extendedText = extendedText is { Count: > 0 } ? extendedText : null;
             _hyperlinks = hyperlinks is { Count: > 0 } ? hyperlinks : null;

--- a/tests/NovaTerminal.App.Tests/BufferTests/ScrollbackMetadataTests.cs
+++ b/tests/NovaTerminal.App.Tests/BufferTests/ScrollbackMetadataTests.cs
@@ -12,6 +12,11 @@ namespace NovaTerminal.Tests.BufferTests
     /// </summary>
     public class ScrollbackMetadataTests
     {
+        // #95 gap 2: hyperlinks carry identity now, not a bare URI. Build them through the registry, the
+        // same way the parser does, rather than reaching for an internal constructor.
+        private static readonly NovaTerminal.VT.Links.HyperlinkRegistry Registry = new();
+        private static NovaTerminal.VT.Links.Hyperlink Link(string uri) => Registry.Resolve(null, uri)!;
+
         [Fact]
         public void AppendRow_WithExtendedText_IsRetained()
         {
@@ -39,8 +44,8 @@ namespace NovaTerminal.Tests.BufferTests
             var pool = new TerminalPagePool();
             var scrollback = new ScrollbackPages(10, pool, maxScrollbackBytes: 16L * 1024 * 1024);
 
-            var links = new SmallMap<string>();
-            links.Set(5, "https://example.com");
+            var links = new SmallMap<NovaTerminal.VT.Links.Hyperlink>();
+            links.Set(5, Link("https://example.com"));
 
             var row = new TerminalCell[10];
             scrollback.AppendRow(row, false, hyperlinks: links);
@@ -49,7 +54,7 @@ namespace NovaTerminal.Tests.BufferTests
             var retrieved = scrollback.GetHyperlinkMap(0);
             Assert.NotNull(retrieved);
             Assert.True(retrieved!.TryGet(5, out var url));
-            Assert.Equal("https://example.com", url);
+            Assert.Equal("https://example.com", url!.Uri);
 
             pool.Clear();
         }
@@ -70,7 +75,7 @@ namespace NovaTerminal.Tests.BufferTests
             scrollback.AppendRow(row);
 
             // Row 2: hyperlink in col 3
-            var links2 = new SmallMap<string>(); links2.Set(3, "https://nova.dev");
+            var links2 = new SmallMap<NovaTerminal.VT.Links.Hyperlink>(); links2.Set(3, Link("https://nova.dev"));
             scrollback.AppendRow(row, false, hyperlinks: links2);
 
             Assert.Equal(3, scrollback.Count);
@@ -86,7 +91,7 @@ namespace NovaTerminal.Tests.BufferTests
             var m2 = scrollback.GetHyperlinkMap(2);
             Assert.NotNull(m2);
             Assert.True(m2!.TryGet(3, out var u2));
-            Assert.Equal("https://nova.dev", u2);
+            Assert.Equal("https://nova.dev", u2!.Uri);
 
             pool.Clear();
         }
@@ -139,12 +144,12 @@ namespace NovaTerminal.Tests.BufferTests
         public void TerminalRow_GetHyperlinkMap_ReturnsMapAfterSet()
         {
             var row = new TerminalRow(10);
-            row.SetHyperlink(7, "https://example.org");
+            row.SetHyperlink(7, Link("https://example.org"));
 
             var map = row.GetHyperlinkMap();
             Assert.NotNull(map);
             Assert.True(map!.TryGet(7, out var link));
-            Assert.Equal("https://example.org", link);
+            Assert.Equal("https://example.org", link!.Uri);
         }
 
         [Fact]
@@ -158,12 +163,12 @@ namespace NovaTerminal.Tests.BufferTests
             page.SetExtendedTextFromMap(0, extMap);
 
             // Row 1: hyperlink — build map separately and attach
-            var linkMap = new SmallMap<string>();
-            linkMap.Set(9, "http://test.io");
+            var linkMap = new SmallMap<NovaTerminal.VT.Links.Hyperlink>();
+            linkMap.Set(9, Link("http://test.io"));
             page.SetHyperlinkFromMap(1, linkMap);
 
             Assert.Equal("ñ", page.GetExtendedText(0, 1));
-            Assert.Equal("http://test.io", page.GetHyperlink(1, 9));
+            Assert.Equal("http://test.io", page.GetHyperlink(1, 9)?.Uri);
 
             // Row 2 has nothing
             Assert.Null(page.GetExtendedTextMap(2));

--- a/tests/NovaTerminal.VT.Tests/Osc8HyperlinkIdentityTests.cs
+++ b/tests/NovaTerminal.VT.Tests/Osc8HyperlinkIdentityTests.cs
@@ -1,0 +1,290 @@
+using NovaTerminal.VT;
+using NovaTerminal.VT.Links;
+
+namespace NovaTerminal.VT.Tests;
+
+/// <summary>
+/// #95 gap 2: OSC 8 hyperlink identity.
+/// </summary>
+/// <remarks>
+/// The parser used to keep only the URI — <c>data.Substring(secondSep + 1)</c> — and throw the params
+/// field away, so the <c>id</c> that states "these runs are one anchor" never reached the buffer.
+///
+/// The spec is what these pin, quoting it directly:
+///
+/// <blockquote>Character cells that have the same target URI and the same nonempty <c>id</c> are always
+/// underlined together on mouseover. The same <c>id</c> is only used for connecting character cells whose
+/// URIs is also the same.</blockquote>
+///
+/// So identity is the pair, and neither half alone decides it. Several tests below therefore assert on
+/// <see cref="Assert.Same"/> / <see cref="Assert.NotSame"/> rather than on URI equality: a URI-equality
+/// implementation passes every "is there a link here" assertion while getting grouping wrong, which is
+/// exactly the bug being fixed.
+/// </remarks>
+public class Osc8HyperlinkIdentityTests
+{
+    private const string Uri = "https://example.com/a";
+    private const string OtherUri = "https://example.com/b";
+
+    private static string Open(string parameters, string uri) => $"\x1b]8;{parameters};{uri}\x1b\\";
+    private static string Close() => "\x1b]8;;\x1b\\";
+
+    private static (TerminalBuffer Buffer, AnsiParser Parser) NewTerminal()
+    {
+        var buffer = new TerminalBuffer(80, 5);
+        return (buffer, new AnsiParser(buffer));
+    }
+
+    private static Hyperlink? LinkAt(TerminalBuffer buffer, int col)
+        => buffer.GetHyperlinkIdentityAbsolute(col, buffer.Scrollback.Count);
+
+    [Fact]
+    public void ExplicitId_ConnectsNonContiguousRuns()
+    {
+        // The spec's motivating case: a single anchor split across two runs, which the producer ties
+        // together with an id. Column 0 and column 2 must be one link despite the gap.
+        var (buffer, parser) = NewTerminal();
+
+        parser.Process(Open("id=xyz", Uri) + "A" + Close());
+        parser.Process(" ");
+        parser.Process(Open("id=xyz", Uri) + "B" + Close());
+
+        Hyperlink? first = LinkAt(buffer, 0);
+        Hyperlink? second = LinkAt(buffer, 2);
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.Same(first, second);
+        Assert.Null(LinkAt(buffer, 1));
+    }
+
+    [Fact]
+    public void SameUriDifferentIds_AreDistinctLinks()
+    {
+        // The discriminating test for this whole change. Two adjacent links to the same target that the
+        // producer has explicitly declared separate. Grouping by URI — the only option before identity
+        // existed — merges them, and would pass every other assertion in this file.
+        var (buffer, parser) = NewTerminal();
+
+        parser.Process(Open("id=one", Uri) + "A" + Close());
+        parser.Process(Open("id=two", Uri) + "B" + Close());
+
+        Hyperlink? a = LinkAt(buffer, 0);
+        Hyperlink? b = LinkAt(buffer, 1);
+
+        Assert.NotNull(a);
+        Assert.NotNull(b);
+        Assert.Equal(a!.Uri, b!.Uri);
+        Assert.NotSame(a, b);
+    }
+
+    [Fact]
+    public void SameIdDifferentUris_AreDistinctLinks()
+    {
+        // "The same id is only used for connecting character cells whose URIs is also the same."
+        // An id is not a global handle; reusing one against a different target must not connect them.
+        var (buffer, parser) = NewTerminal();
+
+        parser.Process(Open("id=shared", Uri) + "A" + Close());
+        parser.Process(Open("id=shared", OtherUri) + "B" + Close());
+
+        Hyperlink? a = LinkAt(buffer, 0);
+        Hyperlink? b = LinkAt(buffer, 1);
+
+        Assert.NotNull(a);
+        Assert.NotNull(b);
+        Assert.NotSame(a, b);
+        Assert.Equal(Uri, a!.Uri);
+        Assert.Equal(OtherUri, b!.Uri);
+    }
+
+    [Fact]
+    public void CellsWrittenInOneRun_ShareIdentity()
+    {
+        var (buffer, parser) = NewTerminal();
+
+        parser.Process(Open(string.Empty, Uri) + "AB" + Close());
+
+        Hyperlink? a = LinkAt(buffer, 0);
+        Hyperlink? b = LinkAt(buffer, 1);
+
+        Assert.NotNull(a);
+        Assert.Same(a, b);
+    }
+
+    [Fact]
+    public void SeparateRunsWithoutAnId_AreDistinctLinks()
+    {
+        // With no id the spec permits two heuristics; we take VTE's, which the spec recommends: a fresh
+        // identity per OSC 8 open. So two runs to the same URI are two links, and the adjacent-and-equal
+        // ambiguity that iTerm2's heuristic has to guess about never arises.
+        var (buffer, parser) = NewTerminal();
+
+        parser.Process(Open(string.Empty, Uri) + "A" + Close());
+        parser.Process(Open(string.Empty, Uri) + "B" + Close());
+
+        Hyperlink? a = LinkAt(buffer, 0);
+        Hyperlink? b = LinkAt(buffer, 1);
+
+        Assert.NotNull(a);
+        Assert.NotNull(b);
+        Assert.Equal(a!.Uri, b!.Uri);
+        Assert.NotSame(a, b);
+    }
+
+    [Fact]
+    public void CloseSequence_EndsTheLink()
+    {
+        var (buffer, parser) = NewTerminal();
+
+        parser.Process(Open("id=xyz", Uri) + "A" + Close() + "B");
+
+        Assert.NotNull(LinkAt(buffer, 0));
+        Assert.Null(LinkAt(buffer, 1));
+    }
+
+    [Fact]
+    public void SwitchingLinkWithoutClosing_IsHonoured()
+    {
+        // Legal per the spec: OSC 8 just reassigns the attribute, like a colour. No close required.
+        var (buffer, parser) = NewTerminal();
+
+        parser.Process(Open("id=one", Uri) + "A" + Open("id=two", OtherUri) + "B");
+
+        Assert.Equal(Uri, LinkAt(buffer, 0)?.Uri);
+        Assert.Equal(OtherUri, LinkAt(buffer, 1)?.Uri);
+    }
+
+    [Theory]
+    // "For hyperlink cells that do not have an id (or have an empty id, these two are interchangeable)".
+    [InlineData("id=")]
+    [InlineData("")]
+    [InlineData("id=:foo=bar")]
+    public void EmptyOrAbsentId_BehavesAsNoId(string parameters)
+    {
+        var (buffer, parser) = NewTerminal();
+
+        parser.Process(Open(parameters, Uri) + "A" + Close());
+        parser.Process(Open(parameters, Uri) + "B" + Close());
+
+        Hyperlink? a = LinkAt(buffer, 0);
+        Hyperlink? b = LinkAt(buffer, 1);
+
+        Assert.NotNull(a);
+        Assert.NotNull(b);
+        Assert.Null(a!.Id);
+        // No id means no cross-run grouping, so these must not be the same link.
+        Assert.NotSame(a, b);
+    }
+
+    [Theory]
+    // The field exists for future extension, so an unrecognised key must be skipped rather than treated
+    // as an error that discards the id sitting next to it.
+    [InlineData("foo=bar:id=keep")]
+    [InlineData("id=keep:foo=bar")]
+    [InlineData("a=1:id=keep:b=2")]
+    public void UnknownParameters_DoNotHideTheId(string parameters)
+    {
+        var (buffer, parser) = NewTerminal();
+
+        parser.Process(Open(parameters, Uri) + "A" + Close());
+        parser.Process(Open("id=keep", Uri) + "B" + Close());
+
+        Hyperlink? a = LinkAt(buffer, 0);
+        Hyperlink? b = LinkAt(buffer, 1);
+
+        Assert.NotNull(a);
+        Assert.Equal("keep", a!.Id);
+        // Same (URI, id) reached by two different param spellings is still one link.
+        Assert.Same(a, b);
+    }
+
+    [Fact]
+    public void OverlongUri_IsRefusedRatherThanTruncated()
+    {
+        // OSC 8 is remote-controlled input. A truncated URI points somewhere other than intended, which
+        // is worse than no link, so an over-long target yields no link at all.
+        var (buffer, parser) = NewTerminal();
+        string huge = "https://example.com/" + new string('x', HyperlinkRegistry.MaxUriLength);
+
+        parser.Process(Open(string.Empty, huge) + "A");
+
+        Assert.Null(LinkAt(buffer, 0));
+    }
+
+    [Fact]
+    public void OverlongId_DowngradesToNoIdButKeepsTheLink()
+    {
+        // Losing an over-long id costs grouping across runs; losing the link would cost the user the
+        // target. Degrade the cheaper one.
+        var (buffer, parser) = NewTerminal();
+        string longId = new string('i', HyperlinkRegistry.MaxIdLength + 1);
+
+        parser.Process(Open($"id={longId}", Uri) + "A" + Close());
+        parser.Process(Open($"id={longId}", Uri) + "B" + Close());
+
+        Hyperlink? a = LinkAt(buffer, 0);
+        Hyperlink? b = LinkAt(buffer, 1);
+
+        Assert.NotNull(a);
+        Assert.Equal(Uri, a!.Uri);
+        Assert.Null(a.Id);
+        Assert.NotSame(a, b);
+    }
+
+    [Fact]
+    public void IdentitySurvivesScrollback()
+    {
+        // The side table already survived into paged scrollback (#164 / gap 1). What matters here is that
+        // the *identity* survives too, not just a URI: a link that scrolls off screen must still group
+        // with its other half on screen.
+        var (buffer, parser) = NewTerminal();
+
+        parser.Process(Open("id=xyz", Uri) + "A" + Close() + "\r\n");
+        for (int i = 0; i < 12; i++)
+        {
+            parser.Process($"filler {i}\r\n");
+        }
+
+        parser.Process(Open("id=xyz", Uri) + "B" + Close());
+
+        // The second half is wherever the cursor ended up after all that scrolling, not viewport row 0 —
+        // reading row 0 lands on a filler line.
+        Hyperlink? scrolled = buffer.GetHyperlinkIdentityAbsolute(0, 0);
+        Hyperlink? onScreen = buffer.GetHyperlinkIdentityAbsolute(0, buffer.Scrollback.Count + buffer.CursorRow);
+
+        Assert.NotNull(scrolled);
+        Assert.NotNull(onScreen);
+        Assert.Same(scrolled, onScreen);
+    }
+
+    [Fact]
+    public void TwoTerminals_DoNotShareLinkIdentities()
+    {
+        // The registry is per-parser on purpose. If it were static, the same (URI, id) written in two
+        // panes would group across them, and hovering one would highlight the other.
+        var (bufferA, parserA) = NewTerminal();
+        var (bufferB, parserB) = NewTerminal();
+
+        parserA.Process(Open("id=xyz", Uri) + "A" + Close());
+        parserB.Process(Open("id=xyz", Uri) + "B" + Close());
+
+        Hyperlink? a = LinkAt(bufferA, 0);
+        Hyperlink? b = LinkAt(bufferB, 0);
+
+        Assert.NotNull(a);
+        Assert.NotNull(b);
+        Assert.NotSame(a, b);
+    }
+
+    [Fact]
+    public void UriOnlyAccessor_StillReturnsTheUri()
+    {
+        // The App layer reads URIs through this shim; the type change must not disturb it.
+        var (buffer, parser) = NewTerminal();
+
+        parser.Process(Open("id=xyz", Uri) + "A" + Close());
+
+        Assert.Equal(Uri, buffer.GetHyperlinkAbsolute(0, buffer.Scrollback.Count));
+    }
+}

--- a/tests/NovaTerminal.VT.Tests/ReflowMetadataTests.cs
+++ b/tests/NovaTerminal.VT.Tests/ReflowMetadataTests.cs
@@ -13,6 +13,10 @@ public class ReflowMetadataTests
 {
     private const string Uri = "https://example.com/reflow";
     private const string OtherUri = "https://example.com/other";
+    // #95 gap 2: hyperlinks are an identity now, not a bare URI. Build them through the registry, the
+    // same way the parser does, rather than reaching for an internal constructor.
+    private static readonly NovaTerminal.VT.Links.HyperlinkRegistry Registry = new();
+    private static NovaTerminal.VT.Links.Hyperlink Link(string uri) => Registry.Resolve(null, uri)!;
     private const string ThumbsUp = "\U0001F44D";
 
     private static string?[] LinksOnRow(TerminalBuffer buffer, int viewRow, int cols)
@@ -23,7 +27,7 @@ public class ReflowMetadataTests
             var row = buffer.GetRowAbsolute(buffer.Scrollback.Count + viewRow);
             Assert.NotNull(row);
             var links = new string?[cols];
-            for (int c = 0; c < cols; c++) links[c] = row!.GetHyperlink(c);
+            for (int c = 0; c < cols; c++) links[c] = row!.GetHyperlink(c)?.Uri;
             return links;
         }
         finally { buffer.Lock.ExitReadLock(); }
@@ -191,15 +195,15 @@ public class ReflowMetadataTests
     {
         var source = new TerminalRow(8);
         source.SetExtendedText(1, ThumbsUp);
-        source.SetHyperlink(1, Uri);
+        source.SetHyperlink(1, Link(Uri));
         source.SetExtendedText(6, ThumbsUp);
-        source.SetHyperlink(6, OtherUri);
+        source.SetHyperlink(6, Link(OtherUri));
 
         var target = new TerminalRow(4);
         target.CopyRowMetadataFrom(source, 4);
 
         Assert.Equal(ThumbsUp, target.GetExtendedText(1));
-        Assert.Equal(Uri, target.GetHyperlink(1));
+        Assert.Equal(Uri, target.GetHyperlink(1)?.Uri);
         // Column 6 is outside the target's width; copying it would key the map past the row.
         Assert.Null(target.GetExtendedText(6));
         Assert.Null(target.GetHyperlink(6));

--- a/tests/NovaTerminal.VT.Tests/RowMetadataShiftTests.cs
+++ b/tests/NovaTerminal.VT.Tests/RowMetadataShiftTests.cs
@@ -12,6 +12,10 @@ public class RowMetadataShiftTests
 {
     private const string ThumbsUp = "\U0001F44D"; // astral, width 2: lead cell + continuation
     private const string Uri = "https://example.com/";
+    // #95 gap 2: hyperlinks are an identity now, not a bare URI. Build them through the registry, the
+    // same way the parser does, rather than reaching for an internal constructor.
+    private static readonly NovaTerminal.VT.Links.HyperlinkRegistry Registry = new();
+    private static NovaTerminal.VT.Links.Hyperlink Link(string uri) => Registry.Resolve(null, uri)!;
 
     private static (TerminalBuffer Buffer, AnsiParser Parser) NewTerminal(int cols = 20, int rows = 3)
     {
@@ -59,7 +63,7 @@ public class RowMetadataShiftTests
             var row = buffer.GetRowAbsolute(0);
             Assert.NotNull(row);
             var links = new string?[cols];
-            for (int c = 0; c < cols; c++) links[c] = row!.GetHyperlink(c);
+            for (int c = 0; c < cols; c++) links[c] = row!.GetHyperlink(c)?.Uri;
             return links;
         }
         finally { buffer.Lock.ExitReadLock(); }
@@ -268,7 +272,7 @@ public class RowMetadataShiftTests
         // not with empty ones - HasRowMetadata is the write path's fast-path guard.
         var row = new TerminalRow(4);
         row.SetExtendedText(3, ThumbsUp);
-        row.SetHyperlink(3, Uri);
+        row.SetHyperlink(3, Link(Uri));
         Assert.True(row.HasRowMetadata);
 
         row.ShiftRowMetadata(0, 4, 4);


### PR DESCRIPTION
Gap 2 of #95. Sets up gap 3, which follows.

## The bug

`HandleOsc` kept only what came after the second `;` and threw the rest away:

```csharp
int secondSep = data.IndexOf(';');
if (secondSep >= 0)
{
    string uri = data.Substring(secondSep + 1);   // params discarded entirely
    _buffer.CurrentHyperlink = string.IsNullOrWhiteSpace(uri) ? null : uri;
}
```

The discarded field is `params`, which is where `id=` lives — the one thing that states which cells form a single anchor. The per-cell side table was `SmallMap<string>`, a bare URI, so even if `id` had been parsed there was nowhere to put it.

## Why identity has to be a pair

Straight from the [OSC 8 spec](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda):

> Character cells that have the same target URI and the same nonempty `id` are always underlined together on mouseover. The same `id` is only used for connecting character cells whose URIs is also the same.

Neither half decides it alone. Two adjacent links to the same URI with different ids are **two** links; one id reused against two URIs is **not** one link.

So `Hyperlink(Uri, Id)` is interned per `(URI, id)` by a `HyperlinkRegistry`, and the side table holds references. "Same link?" becomes reference equality — no per-cell string comparison on a hot path.

## The part that makes gap 3 clean

For links written *without* an id the spec permits two heuristics and recommends VTE's:

> It's probably much easier to implement VTE's approach here: assign a new `id` … whenever an OSC 8 with an URI but no `id` is encountered.

Taking that means **every** hyperlink cell has an identity. Gap 3's full-span hover can then group by identity instead of walking outward while URIs match — which would silently merge two consecutive distinct links that happen to share a URI, the exact case `id` exists to disambiguate. Gap 3 gets to be correct rather than correct-with-a-documented-caveat.

## Scope, and what it deliberately does not touch

Contained to `NovaTerminal.VT`:

- `GetHyperlinkAbsolute` still returns `string?`, so both App-layer call sites compile unchanged. `GetHyperlinkIdentityAbsolute` is the new accessor gap 3 will use.
- Nothing in `Rendering` or `Replay` reads hyperlinks, so there are no golden-image or wire-format implications. I checked rather than assumed.
- Scrollback is never serialised, so reference identity survives paging. That is load-bearing for this design and is asserted by a test.

Registry is **per-parser, not static**: a shared table would group the same `(URI, id)` across panes, so hovering a link in one would highlight another. Pinned by a test.

Bounds, because OSC 8 is remote-controlled input:

| Limit | Behaviour | Why |
|---|---|---|
| URI > 2083 | no link at all | a truncated URI points somewhere *else*, which is worse than no link |
| id > 250 | keeps the link, drops the id | degrades grouping, not the target |
| > 4096 interned | clears the table | losing interning costs grouping for old links; nothing corrupts |

The type change propagated through `TerminalRow`, `ScrollbackPages`, `TerminalPage`, the reflow tuple, `ResizeAndReflow`, `WritePath` and the buffer style state. `ShiftMap` is now generic so the extended-text and hyperlink tables cannot drift apart — two copies of that logic is how they would.

## Tests

14 tests. Several assert `Assert.Same` / `Assert.NotSame` rather than URI equality on purpose: a URI-grouping implementation passes every "is there a link here" assertion while getting grouping wrong, which is the entire bug.

All seven mutations were caught by the intended test, each run restoring the sources byte-identically:

| mutation | caught by |
|---|---|
| group by URI alone, ignoring `id` (**the pre-change behaviour**) | `SameUriDifferentIds_AreDistinctLinks` |
| key on `id` alone, ignoring the URI | `SameIdDifferentUris_AreDistinctLinks` |
| intern no-id links so separate runs merge | `SeparateRunsWithoutAnId_AreDistinctLinks` |
| never intern — always a fresh identity | `ExplicitId_ConnectsNonContiguousRuns` |
| parser discards the params field again | `ExplicitId_ConnectsNonContiguousRuns` |
| `ExtractId` only inspects the first key | `UnknownParameters_DoNotHideTheId` |
| over-long URI accepted instead of refused | `OverlongUri_IsRefusedRatherThanTruncated` |

I added that first mutation only after noticing that `SameUriDifferentIds_AreDistinctLinks` — the test I considered central — was not the *sole* catcher of anything in my original set. A test that never uniquely catches a mutation is not pulling its weight, so the gap was in the sweep, not the test.

## Verification

- Gating suites green: VT 144, Rendering 59, Platform 122, Architecture 24.
- `ScrollbackMetadataTests` (the App.Tests file this change touches) 8/8.
- Full solution builds with no new warnings.

## Follow-up noted, not fixed here

`CsiParamClampTests.cs:14` already feeds `\x1b[888888888b` — REP — and passes. It passes *vacuously*: there is no `case 'b'` in the CSI dispatch at all, and the test only asserts the parser does not hang. Worth flagging on #251 so a contributor does not read it as existing REP coverage.

Refs #95 (gap 2 of 7)
