### PR TITLE
fix(rendering): decode sixel HLS colors

### DIFF
--- a/src/NovaTerminal.Rendering/SixelDecoder.cs
+++ b/src/NovaTerminal.Rendering/SixelDecoder.cs
@@ -78,7 +78,8 @@ namespace NovaTerminal.Rendering
 
         private static byte ToByte(double channel)
         {
-            return (byte)Math.Clamp((int)(channel * 255), 0, 255);
+            int percentage = Math.Clamp((int)(channel * 100), 0, 100);
+            return (byte)((percentage * 255 + 50) / 100);
         }
 
         public SKBitmap? Decode(string dcs)

--- a/src/NovaTerminal.Rendering/SixelDecoder.cs
+++ b/src/NovaTerminal.Rendering/SixelDecoder.cs
@@ -38,6 +38,49 @@ namespace NovaTerminal.Rendering
             _palette[7] = new SixelColor(255, 255, 255);
         }
 
+        internal static (byte R, byte G, byte B) HlsToRgb(int hue, int lightness, int saturation)
+        {
+            hue = Math.Clamp(hue, 0, 360);
+            lightness = Math.Clamp(lightness, 0, 100);
+            saturation = Math.Clamp(saturation, 0, 100);
+
+            double l = lightness / 100.0;
+            double s = saturation / 100.0;
+
+            if (s == 0)
+            {
+                byte value = ToByte(l);
+                return (value, value, value);
+            }
+
+            double h = ((hue + 240) % 360) / 360.0;
+            double q = l < 0.5
+                ? l * (1 + s)
+                : l + s - (l * s);
+            double p = (2 * l) - q;
+
+            return (
+                ToByte(HueToRgb(p, q, h + (1.0 / 3.0))),
+                ToByte(HueToRgb(p, q, h)),
+                ToByte(HueToRgb(p, q, h - (1.0 / 3.0))));
+        }
+
+        private static double HueToRgb(double p, double q, double hue)
+        {
+            if (hue < 0) hue += 1;
+            if (hue > 1) hue -= 1;
+
+            if (hue < 1.0 / 6.0) return p + ((q - p) * 6 * hue);
+            if (hue < 1.0 / 2.0) return q;
+            if (hue < 2.0 / 3.0) return p + ((q - p) * ((2.0 / 3.0) - hue) * 6);
+            return p;
+        }
+
+        private static byte ToByte(double channel)
+        {
+            return (byte)Math.Clamp((int)(channel * 255), 0, 255);
+        }
+
         public SKBitmap? Decode(string dcs)
         {
             // dcs is everything between 'q' and 'ST'
@@ -96,10 +139,10 @@ namespace NovaTerminal.Rendering
                                         (byte)(p2 * 255 / 100),
                                         (byte)(p3 * 255 / 100));
                                 }
-                                else if (type == 1) // HLS (simplified conversion)
+                                else if (type == 1)
                                 {
-                                    // TODO: Full HLS to RGB conversion if needed
-                                    _palette[idx] = new SixelColor(200, 200, 200);
+                                    var (r, g, b) = HlsToRgb(p1, p2, p3);
+                                    _palette[idx] = new SixelColor(r, g, b);
                                 }
                             }
                         }

--- a/tests/NovaTerminal.Rendering.Tests/SixelDecoderTests.cs
+++ b/tests/NovaTerminal.Rendering.Tests/SixelDecoderTests.cs
@@ -30,9 +30,10 @@ public class SixelDecoderTests
     [InlineData(0, 50, 100, 0, 0, 255)]
     [InlineData(120, 50, 100, 255, 0, 0)]
     [InlineData(240, 50, 100, 0, 255, 0)]
+    [InlineData(121, 50, 100, 255, 3, 0)]
     [InlineData(42, 0, 100, 0, 0, 0)]
     [InlineData(42, 100, 100, 255, 255, 255)]
-    [InlineData(42, 50, 0, 127, 127, 127)]
+    [InlineData(42, 50, 0, 128, 128, 128)]
     public void HlsToRgb_ReturnsExpectedColor(
         int hue,
         int lightness,

--- a/tests/NovaTerminal.Rendering.Tests/SixelDecoderTests.cs
+++ b/tests/NovaTerminal.Rendering.Tests/SixelDecoderTests.cs
@@ -27,6 +27,48 @@ public class SixelDecoderTests
     }
 
     [Theory]
+    [InlineData(0, 50, 100, 0, 0, 255)]
+    [InlineData(120, 50, 100, 255, 0, 0)]
+    [InlineData(240, 50, 100, 0, 255, 0)]
+    [InlineData(42, 0, 100, 0, 0, 0)]
+    [InlineData(42, 100, 100, 255, 255, 255)]
+    [InlineData(42, 50, 0, 127, 127, 127)]
+    public void HlsToRgb_ReturnsExpectedColor(
+        int hue,
+        int lightness,
+        int saturation,
+        byte red,
+        byte green,
+        byte blue)
+    {
+        Assert.Equal((red, green, blue), SixelDecoder.HlsToRgb(hue, lightness, saturation));
+    }
+
+    [Fact]
+    public void HlsToRgb_ClampsOutOfRangeInputs()
+    {
+        Assert.Equal(SixelDecoder.HlsToRgb(0, 50, 100), SixelDecoder.HlsToRgb(-1, 50, 100));
+        Assert.Equal(SixelDecoder.HlsToRgb(360, 50, 100), SixelDecoder.HlsToRgb(361, 50, 100));
+        Assert.Equal((byte.MinValue, byte.MinValue, byte.MinValue), SixelDecoder.HlsToRgb(120, -1, 100));
+        Assert.Equal((byte.MaxValue, byte.MaxValue, byte.MaxValue), SixelDecoder.HlsToRgb(120, 101, 100));
+        Assert.Equal(SixelDecoder.HlsToRgb(120, 50, 0), SixelDecoder.HlsToRgb(120, 50, -1));
+        Assert.Equal(SixelDecoder.HlsToRgb(120, 50, 100), SixelDecoder.HlsToRgb(120, 50, 101));
+    }
+
+    [Fact]
+    public void Decode_HlsRedMatchesRgbRed()
+    {
+        Assert.SkipUnless(SkiaAvailable, "SkiaSharp native library not available on this platform.");
+
+        using var hls = new SixelDecoder().Decode("0;0;0q#1;1;120;50;100#1~");
+        using var rgb = new SixelDecoder().Decode("0;0;0q#1;2;100;0;0#1~");
+
+        Assert.NotNull(hls);
+        Assert.NotNull(rgb);
+        Assert.Equal(rgb.GetPixel(0, 0), hls.GetPixel(0, 0));
+    }
+
+    [Theory]
     [InlineData("0;0;0q#1;;2;3;4~~")]          // empty param via consecutive ';'
     [InlineData("0;0;0q#1;2;;3;~~")]           // multiple empties
     [InlineData("0;0;0q#1;2;99999999999;3;4~")] // overflow int.Parse territory


### PR DESCRIPTION
Fixes #247.

Implements DEC HLS palette conversion for sixel colors, including the DEC hue rotation and input clamping. The conversion stays in `NovaTerminal.Rendering` and does not change VT semantics.

Coverage includes the primary-color anchors, black and white, achromatic colors, clamping, and an HLS/RGB decoder comparison.

Cross-platform behavior is unchanged outside the pure conversion. Renderer metrics are unaffected because this does not change the draw path or caches.

Tests:
- `scripts\build.ps1 test`
- `scripts\build.ps1 test tests\NovaTerminal.Rendering.Tests`
- `dotnet format whitespace --verify-no-changes`
