### PR TITLE
renderer: enable box-drawing primitives by default

### DIFF
--- a/src/NovaTerminal.App/Shell/TerminalDrawOperation.cs
+++ b/src/NovaTerminal.App/Shell/TerminalDrawOperation.cs
@@ -57,7 +57,11 @@ namespace NovaTerminal.Shell
         private static readonly bool GlyphDiagnosticsEnabled = IsEnvFlagEnabled("NOVATERM_DIAG_GLYPH");
         private static readonly bool GridDiagnosticsEnabled = IsEnvFlagEnabled("NOVATERM_DIAG_GRID");
         private static readonly bool ForceKnownGoodBoxFont = IsEnvFlagEnabled("NOVATERM_FORCE_BOX_FONT");
-        private static readonly bool UseBoxDrawingPrimitives = IsEnvFlagEnabled("NOVATERM_BOX_PRIMITIVES");
+        // On by default: font-supplied box glyphs do not span the full cell height on most
+        // installed fonts, leaving a gap at every row boundary so vertical borders render as
+        // dashed ladders. The primitive path fills cell-edge to cell-edge. Set
+        // NOVATERM_BOX_PRIMITIVES=0 to fall back to font glyphs.
+        private static readonly bool UseBoxDrawingPrimitives = IsEnvFlagEnabled("NOVATERM_BOX_PRIMITIVES", defaultValue: true);
         private static readonly bool UseBlockElementPrimitives = IsEnvFlagEnabled("NOVATERM_BLOCK_PRIMITIVES");
         private static readonly AsyncLocal<TestPrimitiveRenderOverride?> PrimitiveRenderOverrideForTests = new();
         private static readonly ConcurrentDictionary<string, byte> GlyphDiagOnce = new();
@@ -1426,9 +1430,14 @@ namespace NovaTerminal.Shell
                                     continue;
                                 }
 
+                                // Only flush the text batch for code points the primitive path can
+                                // actually draw. The 0x2500-0x257F block is much wider than our
+                                // segment table (dashed variants, mixed-weight joins, diagonals), and
+                                // flushing for those cost a batch break and then fell through to the
+                                // font anyway.
                                 if (IsBoxDrawingPrimitiveRenderingEnabled() &&
                                     TryGetSingleRuneCodePoint(grapheme, out int cpBox) &&
-                                    cpBox >= 0x2500 && cpBox <= 0x257F)
+                                    IsHandledBoxDrawingCodepoint(cpBox))
                                 {
                                     FlushBatches(canvas);
                                     if (TryDrawBoxDrawingGlyph(canvas, grapheme, cellX1, rowTopYDip, cellW, cellH, fg))
@@ -1600,6 +1609,19 @@ namespace NovaTerminal.Shell
             return raw == "1" || string.Equals(raw, "true", StringComparison.OrdinalIgnoreCase);
         }
 
+        /// <summary>
+        /// Reads a flag that is on unless explicitly disabled. Unset keeps <paramref name="defaultValue"/>;
+        /// "0"/"false" turns it off, "1"/"true" turns it on. Unrecognised values keep the default.
+        /// </summary>
+        private static bool IsEnvFlagEnabled(string name, bool defaultValue)
+        {
+            string? raw = Environment.GetEnvironmentVariable(name);
+            if (string.IsNullOrWhiteSpace(raw)) return defaultValue;
+            if (raw == "1" || string.Equals(raw, "true", StringComparison.OrdinalIgnoreCase)) return true;
+            if (raw == "0" || string.Equals(raw, "false", StringComparison.OrdinalIgnoreCase)) return false;
+            return defaultValue;
+        }
+
         private static bool IsBoxDrawingPrimitiveRenderingEnabled()
         {
             TestPrimitiveRenderOverride? overrideFlags = PrimitiveRenderOverrideForTests.Value;
@@ -1611,6 +1633,12 @@ namespace NovaTerminal.Shell
             TestPrimitiveRenderOverride? overrideFlags = PrimitiveRenderOverrideForTests.Value;
             return overrideFlags?.UseBlockElementPrimitives ?? UseBlockElementPrimitives;
         }
+
+        /// <summary>Ambient default, so a test override can pin one primitive path without disturbing the other.</summary>
+        internal static bool DefaultBoxDrawingPrimitivesEnabledForTests => UseBoxDrawingPrimitives;
+
+        /// <inheritdoc cref="DefaultBoxDrawingPrimitivesEnabledForTests"/>
+        internal static bool DefaultBlockElementPrimitivesEnabledForTests => UseBlockElementPrimitives;
 
         internal static IDisposable PushPrimitiveRenderingOverrideForTests(bool useBoxDrawingPrimitives, bool useBlockElementPrimitives)
         {
@@ -2422,19 +2450,26 @@ namespace NovaTerminal.Shell
             if ((mask & 0b1000) != 0 && x2 > xMid && y2 > yMid) canvas.DrawRect(xMid, yMid, x2 - xMid, y2 - yMid, paint); // LR
         }
 
-        private bool TryDrawBoxDrawingGlyph(SKCanvas canvas, string grapheme, float x, float y, float w, float h, SKColor color)
+        private const int SegUp = 1 << 0;
+        private const int SegDown = 1 << 1;
+        private const int SegLeft = 1 << 2;
+        private const int SegRight = 1 << 3;
+
+        /// <summary>
+        /// True when <paramref name="cp"/> is a box-drawing code point the primitive renderer has a
+        /// segment definition for. Callers use this to avoid breaking the text batch for code points
+        /// that would fall through to font rendering anyway.
+        /// </summary>
+        internal static bool IsHandledBoxDrawingCodepoint(int cp)
+            => TryGetBoxDrawingSegments(cp, out _, out _, out _);
+
+        private static bool TryGetBoxDrawingSegments(int cp, out int seg, out bool isDouble, out bool isRoundedArc)
         {
-            if (!TryGetSingleRuneCodePoint(grapheme, out int cp)) return false;
+            seg = 0;
+            isDouble = false;
+            isRoundedArc = false;
+
             if (cp < 0x2500 || cp > 0x257F) return false;
-
-            const int SegUp = 1 << 0;
-            const int SegDown = 1 << 1;
-            const int SegLeft = 1 << 2;
-            const int SegRight = 1 << 3;
-
-            int seg = 0;
-            bool isDouble = false;
-            bool isRoundedArc = false;
 
             switch (cp)
             {
@@ -2486,6 +2521,14 @@ namespace NovaTerminal.Shell
                 default:
                     return false;
             }
+
+            return true;
+        }
+
+        private bool TryDrawBoxDrawingGlyph(SKCanvas canvas, string grapheme, float x, float y, float w, float h, SKColor color)
+        {
+            if (!TryGetSingleRuneCodePoint(grapheme, out int cp)) return false;
+            if (!TryGetBoxDrawingSegments(cp, out int seg, out bool isDouble, out bool isRoundedArc)) return false;
 
             int x1px = ToDevicePx(x);
             int y1px = ToDevicePx(y);

--- a/tests/NovaTerminal.App.Tests/Infra/SnapshotService.cs
+++ b/tests/NovaTerminal.App.Tests/Infra/SnapshotService.cs
@@ -25,8 +25,13 @@ namespace NovaTerminal.Tests.Infra
         public bool HideCursor { get; init; }
         public bool EnableLigatures { get; init; }
         public bool EnableComplexShaping { get; init; } = true;
-        public bool ForceBoxDrawingPrimitives { get; init; }
-        public bool ForceBlockElementPrimitives { get; init; }
+        /// <summary>
+        /// Tri-state primitive overrides. <c>null</c> uses the shipping default, <c>true</c> forces the
+        /// primitive path, <c>false</c> forces font-glyph rendering. Explicit <c>false</c> matters now
+        /// that primitives are the default — it is the only way to keep the font path under test.
+        /// </summary>
+        public bool? ForceBoxDrawingPrimitives { get; init; }
+        public bool? ForceBlockElementPrimitives { get; init; }
         public double RenderScaling { get; init; } = 1.0;
         public string TypefaceFamily { get; init; } = "Cascadia Code PL, CaskaydiaCove Nerd Font, Cascadia Code, Consolas, Monospace";
         public float FontSize { get; init; } = 14f;
@@ -95,11 +100,13 @@ namespace NovaTerminal.Tests.Infra
                 glyphCache: options.GlyphCache);
 
             IDisposable? primitiveOverride = null;
-            if (options.ForceBoxDrawingPrimitives || options.ForceBlockElementPrimitives)
+            if (options.ForceBoxDrawingPrimitives.HasValue || options.ForceBlockElementPrimitives.HasValue)
             {
                 primitiveOverride = TerminalDrawOperation.PushPrimitiveRenderingOverrideForTests(
-                    useBoxDrawingPrimitives: options.ForceBoxDrawingPrimitives,
-                    useBlockElementPrimitives: options.ForceBlockElementPrimitives);
+                    useBoxDrawingPrimitives: options.ForceBoxDrawingPrimitives
+                        ?? TerminalDrawOperation.DefaultBoxDrawingPrimitivesEnabledForTests,
+                    useBlockElementPrimitives: options.ForceBlockElementPrimitives
+                        ?? TerminalDrawOperation.DefaultBlockElementPrimitivesEnabledForTests);
             }
 
             try

--- a/tests/NovaTerminal.App.Tests/RenderTests/BoxDrawingContinuityTests.cs
+++ b/tests/NovaTerminal.App.Tests/RenderTests/BoxDrawingContinuityTests.cs
@@ -1,0 +1,206 @@
+using Avalonia.Headless.XUnit;
+using NovaTerminal.Platform;
+using NovaTerminal.Rendering;
+using NovaTerminal.Shell;
+using NovaTerminal.Tests.Infra;
+using NovaTerminal.VT;
+using SkiaSharp;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace NovaTerminal.Tests.RenderTests
+{
+    /// <summary>
+    /// Font-independent guards for box-drawing rendering.
+    /// </summary>
+    /// <remarks>
+    /// The regression these exist for: font-supplied box glyphs do not span the full cell height on
+    /// most installed fonts, so a stack of U+2502 rendered from the font leaves a gap at every row
+    /// boundary and TUI borders (zellij, mc, lazygit) appear as dashed ladders. The primitive path
+    /// fills cell-edge to cell-edge, so continuity is a structural property we can assert on pixels
+    /// without depending on which fonts the machine has.
+    ///
+    /// Note the <see cref="GlyphCache"/> in every capture below. The box-primitive branch lives inside
+    /// the per-cell loop that <c>DrawRowFromSnapshot</c> only enters when a glyph cache is present; the
+    /// uncached branch is a single <c>canvas.DrawText(runText, ...)</c> with no primitive handling. A
+    /// capture without a cache therefore renders font glyphs no matter what the primitive flag says.
+    /// </remarks>
+    [Collection("GoldenPng")]
+    public sealed class BoxDrawingContinuityTests
+    {
+        private static readonly CellMetrics Metrics = new()
+        {
+            CellWidth = 8.4f,
+            CellHeight = 18.0f,
+            Baseline = 14.0f,
+            Ascent = 14.0f,
+            Descent = 4.0f
+        };
+
+        [AvaloniaFact]
+        public void VerticalBorder_WithPrimitives_HasNoGapAtRowBoundaries()
+        {
+            const int cols = 4;
+            const int rows = 4;
+
+            var buffer = CreateThemedBuffer(cols, rows);
+            var parser = new AnsiParser(buffer);
+            parser.Process("│\r\n│\r\n│\r\n│");
+
+            int width = (int)System.Math.Ceiling(cols * Metrics.CellWidth);
+            int height = (int)System.Math.Ceiling(rows * Metrics.CellHeight);
+
+            using var glyphCache = new GlyphCache();
+            using SKBitmap bitmap = SnapshotService.Capture(buffer, Metrics, width, height, new SnapshotCaptureOptions
+            {
+                ForceBoxDrawingPrimitives = true,
+                GlyphCache = glyphCache,
+                HideCursor = true
+            });
+
+            // Scan the first cell column: each scanline is lit if any pixel in that cell's x range is.
+            int cellRight = (int)System.Math.Ceiling(Metrics.CellWidth);
+            bool[] lit = new bool[height];
+            for (int y = 0; y < height; y++)
+            {
+                for (int x = 0; x < cellRight && x < width; x++)
+                {
+                    if (!IsBackground(bitmap.GetPixel(x, y)))
+                    {
+                        lit[y] = true;
+                        break;
+                    }
+                }
+            }
+
+            AssertContiguous(lit, rows * Metrics.CellHeight, "Vertical border", "scanline");
+        }
+
+        [AvaloniaFact]
+        public void HorizontalBorder_WithPrimitives_HasNoGapBetweenCells()
+        {
+            const int cols = 8;
+            const int rows = 2;
+
+            var buffer = CreateThemedBuffer(cols, rows);
+            var parser = new AnsiParser(buffer);
+            parser.Process(new string('─', cols));
+
+            int width = (int)System.Math.Ceiling(cols * Metrics.CellWidth);
+            int height = (int)System.Math.Ceiling(rows * Metrics.CellHeight);
+
+            using var glyphCache = new GlyphCache();
+            using SKBitmap bitmap = SnapshotService.Capture(buffer, Metrics, width, height, new SnapshotCaptureOptions
+            {
+                ForceBoxDrawingPrimitives = true,
+                GlyphCache = glyphCache,
+                HideCursor = true
+            });
+
+            int firstRowBottom = (int)System.Math.Ceiling(Metrics.CellHeight);
+            bool[] lit = new bool[width];
+            for (int x = 0; x < width; x++)
+            {
+                for (int y = 0; y < firstRowBottom && y < height; y++)
+                {
+                    if (!IsBackground(bitmap.GetPixel(x, y)))
+                    {
+                        lit[x] = true;
+                        break;
+                    }
+                }
+            }
+
+            AssertContiguous(lit, cols * Metrics.CellWidth, "Horizontal border", "column");
+        }
+
+        /// <summary>
+        /// Asserts the lit pixels form one unbroken span covering most of <paramref name="expectedExtent"/>.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately scoped to the interior of the drawn span rather than the whole bitmap: the pixel
+        /// grid insets the cell origin by a few pixels of padding, so leading and trailing blank pixels
+        /// are expected. The regression this guards is a break *between* cells. The extent floor stops
+        /// the test passing trivially on a single lit pixel.
+        /// </remarks>
+        private static void AssertContiguous(bool[] lit, float expectedExtent, string what, string unit)
+        {
+            int first = System.Array.IndexOf(lit, true);
+            Assert.True(first >= 0, $"{what} did not render at all.");
+
+            int last = lit.Length - 1;
+            while (!lit[last]) last--;
+
+            List<int> gaps = Enumerable.Range(first, last - first + 1).Where(i => !lit[i]).ToList();
+            Assert.True(
+                gaps.Count == 0,
+                $"{what} broke at {unit}(s) {string.Join(",", gaps.Take(12))} within span {first}..{last}; " +
+                "expected one unbroken run.");
+
+            int span = last - first + 1;
+            int floor = (int)(expectedExtent * 0.9f);
+            Assert.True(
+                span >= floor,
+                $"{what} spanned only {span} {unit}s; expected at least {floor} of {expectedExtent:F1}.");
+        }
+
+        [Fact]
+        public void HandledCodepoints_CoverTheLightHeavyDoubleAndArcSets()
+        {
+            // Light, heavy, double, rounded arcs.
+            int[] expectHandled =
+            {
+                0x2500, 0x2502, 0x250C, 0x2510, 0x2514, 0x2518, 0x251C, 0x2524, 0x252C, 0x2534, 0x253C,
+                0x2501, 0x2503, 0x250F, 0x2513, 0x2517, 0x251B, 0x2523, 0x252B, 0x2533, 0x253B, 0x254B,
+                0x2550, 0x2551, 0x2554, 0x2557, 0x255A, 0x255D, 0x2560, 0x2563, 0x2566, 0x2569, 0x256C,
+                0x256D, 0x256E, 0x256F, 0x2570
+            };
+
+            foreach (int cp in expectHandled)
+            {
+                Assert.True(
+                    TerminalDrawOperation.IsHandledBoxDrawingCodepoint(cp),
+                    $"U+{cp:X4} should have a segment definition.");
+            }
+        }
+
+        [Theory]
+        // Dashed and dotted variants.
+        [InlineData(0x2504)]
+        [InlineData(0x2508)]
+        [InlineData(0x254C)]
+        // Mixed-weight joins.
+        [InlineData(0x251D)]
+        [InlineData(0x2541)]
+        // Diagonals.
+        [InlineData(0x2571)]
+        [InlineData(0x2573)]
+        // Outside the block entirely.
+        [InlineData(0x2588)]
+        [InlineData('A')]
+        public void UnhandledCodepoints_AreReportedAsUnhandled_SoTheTextBatchIsNotFlushed(int cp)
+        {
+            // These fall through to font rendering. Reporting them as handled would cost a batch
+            // flush per cell for no benefit, which is what the original guard did by testing the
+            // whole 0x2500-0x257F range instead of the segment table.
+            Assert.False(TerminalDrawOperation.IsHandledBoxDrawingCodepoint(cp));
+        }
+
+        private static bool IsBackground(SKColor c)
+            => c.Red < 24 && c.Green < 24 && c.Blue < 24;
+
+        private static TerminalBuffer CreateThemedBuffer(int cols, int rows)
+        {
+            return new TerminalBuffer(cols, rows)
+            {
+                Theme = new TerminalTheme
+                {
+                    Foreground = TermColor.White,
+                    Background = TermColor.Black,
+                    CursorColor = TermColor.White
+                }
+            };
+        }
+    }
+}

--- a/tests/NovaTerminal.App.Tests/RenderTests/GoldenFontPngTests.cs
+++ b/tests/NovaTerminal.App.Tests/RenderTests/GoldenFontPngTests.cs
@@ -85,6 +85,41 @@ namespace NovaTerminal.Tests.RenderTests
             SnapshotService.CompareToBaseline(BaselineScope.OS, "font/ComplexShaping", pngBytes);
         }
 
+        /// <summary>
+        /// Box drawing with primitives explicitly OFF, i.e. rendered from font glyphs.
+        /// </summary>
+        /// <remarks>
+        /// Primitives are the shipping default, so without this the font path has no coverage at all —
+        /// which is how the dashed-vertical-border regression stayed invisible to CI while every
+        /// existing box golden forced primitives on. Font-dependent by nature, hence OS-scoped and
+        /// gated on font availability. Compare against shared/BoxDrawingGridPrimitives, which renders
+        /// the identical buffer through the primitive path.
+        /// </remarks>
+        [FontGoldenFact("Cascadia Code PL", "CaskaydiaCove Nerd Font", "Cascadia Code", "Consolas")]
+        public void GoldenFontPng_BoxDrawingGridFontGlyphs_MatchBaseline()
+        {
+            const int cols = 32;
+            const int rows = 7;
+            var buffer = CreateThemedBuffer(cols, rows);
+            var parser = new AnsiParser(buffer);
+
+            parser.Process("┌────────┬────────┐\r\n");
+            parser.Process("│        │        │\r\n");
+            parser.Process("├────────┼────────┤\r\n");
+            parser.Process("│        │        │\r\n");
+            parser.Process("└────────┴────────┘\r\n");
+            parser.Process("╔══════╦══════╗\r\n");
+            parser.Process("╚══════╩══════╝");
+
+            byte[] pngBytes = SnapshotService.CapturePng(buffer, Metrics, WidthFor(cols), HeightFor(rows), new SnapshotCaptureOptions
+            {
+                ForceBoxDrawingPrimitives = false,
+                HideCursor = true
+            });
+
+            SnapshotService.CompareToBaseline(BaselineScope.OS, "font/BoxDrawingGridFontGlyphs", pngBytes);
+        }
+
         private static TerminalBuffer CreateThemedBuffer(int cols, int rows)
         {
             return new TerminalBuffer(cols, rows)


### PR DESCRIPTION
## Problem

Vertical box-drawing borders render as dashed ladders. Comparing NovaTerminal against Termius on the same TUI (zellij tip popup, mc panels) at the same scale, measured down the popup's left border in capture-resolution pixels:

| | NovaTerminal | Termius |
|---|---|---|
| vertical run pattern | `34 on, 6 off` repeating | `549 on` unbroken |
| gap per row | 6px of a 40px cell (**15%**) | none |
| stem width | 2px | 1px |

The dashes are perfectly x-aligned and horizontal rules are continuous, so this is not a grid-metrics or cell-positioning bug. Font-supplied glyphs for `│` cover only ~85% of the line height — the em box is shorter than the cell and nothing extends it. Horizontal `─` is fine because the glyph advance already matches the cell width.

Worst in mc, where two panel borders sit side by side.

## Fix

The primitive path added in aa7adbf already draws these cell-edge to cell-edge, so joins are seamless by construction. It shipped behind `NOVATERM_BOX_PRIMITIVES`, listed in the README of the time under "Useful diagnostics flags" alongside `NOVATERM_DIAG_GLYPH` and `NOVATERM_FORCE_BOX_FONT`. That section was deleted in the April docs rewrite (a79f548), leaving an undocumented flag that nobody revisited.

This makes primitives the default. `NOVATERM_BOX_PRIMITIVES=0` is now the opt-out, via a new tri-state `IsEnvFlagEnabled(name, defaultValue)`.

The font-substitution alternative was considered and rejected: it depends on which fonts a given machine has, whereas the primitive path is deterministic.

## Also: stop paying for primitives we cannot draw

The old guard tested the whole `0x2500-0x257F` range:

```csharp
if (IsBoxDrawingPrimitiveRenderingEnabled() && TryGetSingleRuneCodePoint(grapheme, out int cpBox) &&
    cpBox >= 0x2500 && cpBox <= 0x257F)
{
    FlushBatches(canvas);              // unconditional
    if (TryDrawBoxDrawingGlyph(...)) { ... }
}
```

Only 37 of those 128 code points have segment definitions. The other 91 — dashed variants (`┄┈╌`), mixed-weight joins (`┝╁`), diagonals (`╱╳`) — broke the text batch and then fell through to font rendering anyway. On a border-heavy screen like mc that is a flush per box cell for no benefit.

The table is extracted into `TryGetBoxDrawingSegments` so the guard and the renderer share one source of truth, and the call site now tests `IsHandledBoxDrawingCodepoint`.

## Test coverage

**`BoxDrawingContinuityTests`** (new) asserts continuity on pixels, independent of installed fonts: a vertical stem and a horizontal rule must each form one unbroken run covering at least 90% of the expected extent. Scoped to the interior of the drawn span, since the pixel grid insets the cell origin by a few pixels of padding. Ten table tests pin handled vs unhandled code points, so filling in the remaining sets has a ratchet.

**`GoldenFontPng_BoxDrawingGridFontGlyphs`** (new) covers the font path with primitives explicitly off — OS-scoped and font-gated, rendering the same grid as `shared/BoxDrawingGridPrimitives` for direct comparison. This required making the `SnapshotCaptureOptions` primitive flags `bool?`: the override was only pushed when one of them was `true`, so "force off" was previously inexpressible.

## Known gap, deliberately not addressed here

**The three existing goldens that set `ForceBoxDrawingPrimitives = true` have never rendered a primitive.** The new continuity test failed on its first run with exactly the dashed signature (~7 lit pixels per 8.4px cell, gaps at every boundary), because the primitive branch lives inside the per-cell loop that `DrawRowFromSnapshot` only enters when a glyph cache is present:

```csharp
if (_glyphCache != null && !runIsItalic)
```

The uncached branch is a bare `canvas.DrawText(runText, ...)` with no primitive handling. And `SnapshotCaptureOptions` documents that golden capture *deliberately* renders with both caches off "so that every baseline is produced by the same deterministic path." So `shared/BoxDrawingGridPrimitives` and `shared/SeamRegressionSurface` are font-glyph baselines wearing primitive names — which is why this regression reached a side-by-side screenshot instead of CI.

The new tests pass a real `GlyphCache` to reach the live path. The existing goldens are untouched: re-baselining them under a behavior change wants to be its own reviewable commit. Worth a follow-up issue — either rename them to reflect what they test, or give them a glyph cache and re-baseline.

## Follow-up

Filling in the dashed, mixed-weight, and diagonal sets is still open. Until then those code points render from the font, which is self-consistent (they no longer mix with primitives in the same run for the same weight class) but still gapped.

## Verification

Full suite green, zero failures:

| Project | Passed | Skipped |
|---|---|---|
| NovaTerminal.App.Tests | 1317 | 11 |
| NovaTerminal.VT.Tests | 144 | 0 |
| NovaTerminal.McpServer.Tests | 134 | 0 |
| NovaTerminal.Platform.Tests | 122 | 18 |
| NovaTerminal.Rendering.Tests | 59 | 0 |
| NovaTerminal.Architecture.Tests | 24 | 0 |

The existing shared goldens still match, which is consistent with the finding above — the uncached path they exercise is unchanged.
