### PR TITLE
fix(vt): guard CSI s/u/r against prefixed variants

### DIFF
--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -693,6 +693,9 @@ namespace NovaTerminal.VT
                         }
                         break;
                     case 'r': // DECSTBM - Set Scrolling Region
+                              // Ignore leader-prefixed "...r" sequences, e.g. CSI ? Pm r (XTRESTORE -
+                              // restore DEC private mode values). They are NOT DECSTBM.
+                        if (leader == '\0' && intermediates.Length == 0)
                         {
                             int regionTop = (argCount > 0 && validArgs[0] > 0 ? validArgs[0] : 1) - 1;
                             int regionBottom = (argCount > 1 && validArgs[1] > 0 ? validArgs[1] : _buffer.Rows) - 1;
@@ -860,10 +863,22 @@ namespace NovaTerminal.VT
                         _buffer.DeleteLines(linesToDelete);
                         break;
                     case 's': // Save Cursor (ANSI.SYS / SCO)
-                        _buffer.SaveCursor();
+                              // Ignore leader-prefixed "...s" sequences, e.g. CSI ? Pm s (XTSAVE -
+                              // save DEC private mode values). They are NOT SCO save-cursor.
+                        if (leader == '\0' && intermediates.Length == 0)
+                        {
+                            _buffer.SaveCursor();
+                        }
                         break;
                     case 'u': // Restore Cursor (ANSI.SYS / SCO)
-                        _buffer.RestoreCursor();
+                              // Ignore leader-prefixed "...u" sequences, e.g. CSI ? u (kitty keyboard
+                              // protocol query), CSI > Pm u (kitty keyboard push), CSI < Pm u (kitty
+                              // keyboard pop), CSI = Pm u (kitty keyboard set). They are NOT SCO
+                              // restore-cursor. The kitty keyboard protocol itself is issue #266.
+                        if (leader == '\0' && intermediates.Length == 0)
+                        {
+                            _buffer.RestoreCursor();
+                        }
                         break;
                     case 'm': // SGR (Select Graphic Rendition)
                               // Ignore non-standard leader-prefixed "...m" control sequences, e.g.

--- a/tests/NovaTerminal.App.Tests/AnsiParserHardeningTests.cs
+++ b/tests/NovaTerminal.App.Tests/AnsiParserHardeningTests.cs
@@ -128,6 +128,116 @@ public sealed class AnsiParserHardeningTests
         Assert.Equal("X", GetVisiblePlainText(buffer).Trim());
     }
 
+    [Theory]
+    [InlineData("\x1b[?u")]
+    [InlineData("\x1b[>1u")]
+    [InlineData("\x1b[<u")]
+    [InlineData("\x1b[=1u")]
+    public void PrefixedRestoreCursor_IsIgnored_DoesNotMoveCursor(string sequence)
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var parser = new AnsiParser(buffer);
+
+        // Save cursor at (0,0), then move elsewhere before the prefixed "u" under test.
+        // A kitty keyboard query/push/pop/set must NOT be treated as SCO restore-cursor.
+        parser.Process("\x1b[s");
+        parser.Process("\x1b[10;20H");
+
+        parser.Process(sequence);
+
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            Assert.Equal(9, buffer.CursorRow);
+            Assert.Equal(19, buffer.CursorCol);
+        }
+        finally { buffer.Lock.ExitReadLock(); }
+    }
+
+    [Fact]
+    public void PrefixedSaveCursor_XtSave_DoesNotOverwriteSavedCursor()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("\x1b[5;5H"); // move to row 4, col 4 (0-based)
+        parser.Process("\x1b[s");    // SCO save at (4,4)
+
+        parser.Process("\x1b[10;10H"); // move to row 9, col 9
+        parser.Process("\x1b[?1049s");  // XTSAVE - must NOT overwrite the SCO-saved cursor
+
+        parser.Process("\x1b[u"); // SCO restore - should return to (4,4), not (9,9)
+
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            Assert.Equal(4, buffer.CursorRow);
+            Assert.Equal(4, buffer.CursorCol);
+        }
+        finally { buffer.Lock.ExitReadLock(); }
+    }
+
+    [Fact]
+    public void PrefixedRestore_XtRestore_DoesNotChangeScrollRegionOrCursor()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("\x1b[5;20r");   // DECSTBM: scroll region rows 4..19 (0-based)
+        parser.Process("\x1b[10;10H");  // move cursor to row 9, col 9
+
+        parser.Process("\x1b[?1049r");  // XTRESTORE - must NOT be treated as DECSTBM
+
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            Assert.Equal(4, buffer.ScrollTop);
+            Assert.Equal(19, buffer.ScrollBottom);
+            Assert.Equal(9, buffer.CursorRow);
+            Assert.Equal(9, buffer.CursorCol);
+        }
+        finally { buffer.Lock.ExitReadLock(); }
+    }
+
+    [Fact]
+    public void PlainSaveAndRestoreCursor_StillWorks()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("\x1b[3;7H"); // move to row 2, col 6
+        parser.Process("\x1b[s");    // save
+
+        parser.Process("\x1b[1;1H"); // move to origin
+
+        parser.Process("\x1b[u"); // restore
+
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            Assert.Equal(2, buffer.CursorRow);
+            Assert.Equal(6, buffer.CursorCol);
+        }
+        finally { buffer.Lock.ExitReadLock(); }
+    }
+
+    [Fact]
+    public void PlainSetScrollingRegion_StillWorks()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var parser = new AnsiParser(buffer);
+
+        parser.Process("\x1b[5;20r"); // DECSTBM rows 5..20 (1-based) -> 4..19 (0-based)
+
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            Assert.Equal(4, buffer.ScrollTop);
+            Assert.Equal(19, buffer.ScrollBottom);
+        }
+        finally { buffer.Lock.ExitReadLock(); }
+    }
+
     private static string GetVisiblePlainText(TerminalBuffer buffer)
     {
         return string.Join("\n", buffer.ViewportRows.Select(GetRowText)).TrimEnd();


### PR DESCRIPTION
## What

The CSI dispatch switch in `src/NovaTerminal.VT/AnsiParser.cs` handled the
final bytes `s`, `u`, and `r` without checking the CSI leader byte
(`?`, `>`, `<`, `=`). As a result, leader-prefixed sequences that share a
final byte with an SCO/DEC sequence were misinterpreted:

- `CSI ? u` (kitty keyboard protocol query), `CSI > Pm u` (kitty keyboard
  push), `CSI < u` (kitty keyboard pop), and `CSI = Pm u` (kitty keyboard
  set) were all wrongly dispatched as SCO RestoreCursor, silently moving
  the cursor. Codex CLI and OpenCode send `CSI ? u` at startup to probe
  kitty keyboard support, so every session using either tool hit this.
- `CSI ? Pm s` (XTSAVE - save DEC private mode values) was wrongly
  dispatched as SCO SaveCursor.
- `CSI ? Pm r` (XTRESTORE - restore DEC private mode values) was wrongly
  dispatched as DECSTBM, clobbering the scroll region and homing the
  cursor.

## Why

None of the prefixed forms are the sequence the code assumed. Executing
SCO save/restore or DECSTBM in their place corrupts cursor position and
scroll region state for any client that probes or uses these
leader-prefixed sequences.

## Fix

Guard all three `case` blocks (`s`, `u`, `r`) on `leader == '\0' &&
intermediates.Length == 0`, mirroring the existing guard already in place
on `case 'm'` (SGR vs. xterm key-modifier options). Leader-prefixed
variants are now silently ignored, with a comment naming what each one is.

This does NOT implement the kitty keyboard protocol - that is tracked
separately as #266. It only stops the parser from misinterpreting kitty
keyboard control sequences (and XTSAVE/XTRESTORE) as unrelated SCO/DEC
sequences.

## Test evidence

Added 8 new tests to
`tests/NovaTerminal.App.Tests/AnsiParserHardeningTests.cs`:

- `PrefixedRestoreCursor_IsIgnored_DoesNotMoveCursor` (theory, 4 cases):
  `CSI ? u`, `CSI > 1 u`, `CSI < u`, `CSI = 1 u` do not move the cursor.
- `PrefixedSaveCursor_XtSave_DoesNotOverwriteSavedCursor`: `CSI ? 1049 s`
  does not overwrite the SCO-saved cursor.
- `PrefixedRestore_XtRestore_DoesNotChangeScrollRegionOrCursor`:
  `CSI ? 1049 r` does not change the scroll region or cursor position.
- `PlainSaveAndRestoreCursor_StillWorks`: plain `CSI s` / `CSI u` still
  save/restore the cursor.
- `PlainSetScrollingRegion_StillWorks`: plain `CSI 5;20 r` still sets the
  scroll region.

Full run of the hardening test file:

```
scripts/build.ps1 test tests/NovaTerminal.App.Tests/NovaTerminal.App.Tests.csproj --filter FullyQualifiedName~AnsiParserHardeningTests

Passed! - Failed: 0, Passed: 18, Skipped: 0, Total: 18, Duration: 57 ms - NovaTerminal.App.Tests.dll (net10.0)
```

(10 pre-existing tests + 8 new tests, all passing.)

Fixes #264
