### PR TITLE
feat(vt): respond to OSC 10/11 color queries

### DIFF
--- a/docs/vt_coverage_matrix.md
+++ b/docs/vt_coverage_matrix.md
@@ -142,6 +142,7 @@ It is designed to be:
 |---|---|---:|---|---|---|
 | OSC 0/2 | Set title | ⚠ Partial | Manual/Unit | App/UI | |
 | OSC 7 | CWD reporting | ✅ Supported | Unit: `tests/NovaTerminal.App.Tests/OscUxTests.cs` | Parser+App | |
+| OSC 10/11 | Foreground/background color query | ✅ Supported | Unit: `tests/NovaTerminal.App.Tests/OscUxTests.cs` | Parser+App | Query form (`?`) only; set form is ignored safely, no runtime palette change. Colors sourced from `AnsiParser.DefaultForeground`/`DefaultBackground`, wired from the active theme at parser creation and on `TerminalPane.ApplySettings`; falls back to fg C0C0C0 / bg 000000 when unset |
 | OSC 52 | Clipboard | ❌ Not supported | — | App/UI | |
 | OSC 8 | Hyperlinks | ✅ Supported | Unit: `tests/NovaTerminal.App.Tests/OscUxTests.cs` | Parser+Renderer+UI | Ctrl-click open path is app-level |
 | OSC 133 | Shell integration lifecycle | ⚠ Partial | Unit: `tests/NovaTerminal.App.Tests/OscShellIntegrationTests.cs` | Parser+Command Assist | Supports A/B/C/D markers; broader semantic prompt extensions not audited |

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -1607,6 +1607,15 @@ namespace NovaTerminal.Controls
 
             Parser = new AnsiParser(Buffer);
 
+            // OSC 10/11 (fg/bg color query) answers come from the active theme; without this,
+            // a freshly-created parser would fall back to AnsiParser's hardcoded defaults until
+            // the next ApplySettings call (#265).
+            if (_settings != null)
+            {
+                Parser.DefaultForeground = _settings.ActiveTheme.Foreground;
+                Parser.DefaultBackground = _settings.ActiveTheme.Background;
+            }
+
             Parser.OnBell += () =>
             {
                 Dispatcher.UIThread.Post(() =>
@@ -1943,6 +1952,11 @@ namespace NovaTerminal.Controls
                 float ch = TermView.Metrics.CellHeight;
                 if (cw > 0) Parser.CellWidth = cw;
                 if (ch > 0) Parser.CellHeight = ch;
+
+                // Keep OSC 10/11 (fg/bg color query) responses in sync with the active theme,
+                // including profile-specific theme overrides (see effectiveSettings above).
+                Parser.DefaultForeground = effectiveSettings.ActiveTheme.Foreground;
+                Parser.DefaultBackground = effectiveSettings.ActiveTheme.Background;
             }
 
             // Font family/size and shaping toggles just moved with the settings.

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -1609,11 +1609,16 @@ namespace NovaTerminal.Controls
 
             // OSC 10/11 (fg/bg color query) answers come from the active theme; without this,
             // a freshly-created parser would fall back to AnsiParser's hardcoded defaults until
-            // the next ApplySettings call (#265).
+            // the next ApplySettings call (#265). Must use the same profile-merged theme
+            // resolution as ApplySettings (via BuildEffectiveSettings) — using the global
+            // _settings.ActiveTheme directly would clobber a per-profile theme override,
+            // since this method runs after ApplySettings on pane init and on every
+            // Reconnect().
             if (_settings != null)
             {
-                Parser.DefaultForeground = _settings.ActiveTheme.Foreground;
-                Parser.DefaultBackground = _settings.ActiveTheme.Background;
+                var effectiveTheme = BuildEffectiveSettings(_settings).ActiveTheme;
+                Parser.DefaultForeground = effectiveTheme.Foreground;
+                Parser.DefaultBackground = effectiveTheme.Background;
             }
 
             Parser.OnBell += () =>
@@ -1903,13 +1908,18 @@ namespace NovaTerminal.Controls
 
 
 
-        public void ApplySettings(TerminalSettings settings)
+        /// <summary>
+        /// Merges global settings with this pane's profile overrides (font, theme, cursor).
+        /// Shared by <see cref="ApplySettings"/> (which needs every merged field for
+        /// <see cref="TermView"/>) and <see cref="CreateAndWireParser"/> (which only needs
+        /// the resulting <see cref="TerminalSettings.ActiveTheme"/> colors for OSC 10/11
+        /// answers), so the two call sites can never resolve the profile-effective theme
+        /// differently — see the #265 wiring-bug follow-up.
+        /// </summary>
+        private TerminalSettings BuildEffectiveSettings(TerminalSettings settings)
         {
-            _settings = settings;
-
-            // Merge global settings with profile overrides
             // We create a "copy" for the view to use, but we only override specific visual fields
-            var effectiveSettings = new TerminalSettings
+            return new TerminalSettings
             {
                 FontSize = Profile?.FontSize ?? settings.FontSize,
                 FontFamily = Profile?.FontFamily ?? settings.FontFamily,
@@ -1937,6 +1947,14 @@ namespace NovaTerminal.Controls
                 Profiles = settings.Profiles,
                 DefaultProfileId = settings.DefaultProfileId
             };
+        }
+
+        public void ApplySettings(TerminalSettings settings)
+        {
+            _settings = settings;
+
+            // Merge global settings with profile overrides
+            var effectiveSettings = BuildEffectiveSettings(settings);
 
             TermView.ApplySettings(effectiveSettings);
             if (_commandAssistController != null || !IsCommandAssistFeatureEnabled())

--- a/src/NovaTerminal.App/Resources/vt-conformance-report.json
+++ b/src/NovaTerminal.App/Resources/vt-conformance-report.json
@@ -1,16 +1,16 @@
 {
   "schemaVersion": 1,
   "matrixPath": "docs/vt_coverage_matrix.md",
-  "matrixSha256": "bbfc633258d80584c48d47b42ea5d05ff76a1547a7efab8f7dd19fedb86d6de6",
+  "matrixSha256": "b273bce43d24b7746cd76f06be25e0273abfee40e75df163c72bc2281af0ce67",
   "summary": {
-    "totalRows": 55,
-    "supportedCount": 16,
+    "totalRows": 56,
+    "supportedCount": 17,
     "partialCount": 32,
     "experimentalCount": 1,
     "notSupportedCount": 5,
     "wontSupportCount": 1,
-    "rowsWithLinkedEvidence": 29,
-    "supportedRowsWithLinkedEvidence": 16,
+    "rowsWithLinkedEvidence": 30,
+    "supportedRowsWithLinkedEvidence": 17,
     "errorCount": 0,
     "warningCount": 0
   },
@@ -68,35 +68,35 @@
       "order": 7,
       "title": "8) OSC sequences",
       "startLine": 141,
-      "endLine": 149,
-      "rowCount": 7
+      "endLine": 150,
+      "rowCount": 8
     },
     {
       "order": 8,
       "title": "9) Kitty graphics / APC",
-      "startLine": 155,
-      "endLine": 158,
+      "startLine": 156,
+      "endLine": 159,
       "rowCount": 2
     },
     {
       "order": 9,
       "title": "10) SIXEL",
-      "startLine": 164,
-      "endLine": 167,
+      "startLine": 165,
+      "endLine": 168,
       "rowCount": 2
     },
     {
       "order": 10,
       "title": "11) Clipboard, selection, and hyperlinking",
-      "startLine": 173,
-      "endLine": 177,
+      "startLine": 174,
+      "endLine": 178,
       "rowCount": 3
     },
     {
       "order": 11,
       "title": "12) Unicode width, graphemes, and font behavior",
-      "startLine": 183,
-      "endLine": 187,
+      "startLine": 184,
+      "endLine": 188,
       "rowCount": 3
     }
   ],
@@ -882,6 +882,27 @@
     },
     {
       "section": "8) OSC sequences",
+      "feature": "OSC 10/11",
+      "status": "\u2705 Supported",
+      "specOrNotes": "",
+      "evidenceText": "Unit: \u0060tests/NovaTerminal.App.Tests/OscUxTests.cs\u0060",
+      "evidenceKinds": [
+        "unit"
+      ],
+      "evidenceLinks": [
+        {
+          "path": "tests/NovaTerminal.App.Tests/OscUxTests.cs",
+          "exists": true
+        }
+      ],
+      "hasAutomatedEvidenceSignal": true,
+      "hasLinkedEvidence": true,
+      "ownership": "Parser\u002BApp",
+      "knownDeviations": "Query form (\u0060?\u0060) only; set form is ignored safely, no runtime palette change. Colors sourced from \u0060AnsiParser.DefaultForeground\u0060/\u0060DefaultBackground\u0060, wired from the active theme at parser creation and on \u0060TerminalPane.ApplySettings\u0060; falls back to fg C0C0C0 / bg 000000 when unset",
+      "sourceLine": 145
+    },
+    {
+      "section": "8) OSC sequences",
       "feature": "OSC 52",
       "status": "\u274C Not supported",
       "specOrNotes": "",
@@ -892,7 +913,7 @@
       "hasLinkedEvidence": false,
       "ownership": "App/UI",
       "knownDeviations": "",
-      "sourceLine": 145
+      "sourceLine": 146
     },
     {
       "section": "8) OSC sequences",
@@ -913,7 +934,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BRenderer\u002BUI",
       "knownDeviations": "Ctrl-click open path is app-level",
-      "sourceLine": 146
+      "sourceLine": 147
     },
     {
       "section": "8) OSC sequences",
@@ -934,7 +955,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BCommand Assist",
       "knownDeviations": "Supports A/B/C/D markers; broader semantic prompt extensions not audited",
-      "sourceLine": 147
+      "sourceLine": 148
     },
     {
       "section": "8) OSC sequences",
@@ -955,7 +976,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BRenderer",
       "knownDeviations": "Parser support exists, but targeted automated replay/unit coverage for OSC 1337 is still missing",
-      "sourceLine": 148
+      "sourceLine": 149
     },
     {
       "section": "8) OSC sequences",
@@ -971,7 +992,7 @@
       "hasLinkedEvidence": false,
       "ownership": "Parser\u002BWin",
       "knownDeviations": "",
-      "sourceLine": 149
+      "sourceLine": 150
     },
     {
       "section": "9) Kitty graphics / APC",
@@ -996,7 +1017,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BRenderer",
       "knownDeviations": "",
-      "sourceLine": 157
+      "sourceLine": 158
     },
     {
       "section": "9) Kitty graphics / APC",
@@ -1012,7 +1033,7 @@
       "hasLinkedEvidence": false,
       "ownership": "Buffer\u002BRenderer",
       "knownDeviations": "",
-      "sourceLine": 158
+      "sourceLine": 159
     },
     {
       "section": "10) SIXEL",
@@ -1028,7 +1049,7 @@
       "hasLinkedEvidence": false,
       "ownership": "Decoder\u002BRenderer",
       "knownDeviations": "",
-      "sourceLine": 166
+      "sourceLine": 167
     },
     {
       "section": "10) SIXEL",
@@ -1042,7 +1063,7 @@
       "hasLinkedEvidence": false,
       "ownership": "Buffer\u002BRenderer",
       "knownDeviations": "",
-      "sourceLine": 167
+      "sourceLine": 168
     },
     {
       "section": "11) Clipboard, selection, and hyperlinking",
@@ -1058,7 +1079,7 @@
       "hasLinkedEvidence": false,
       "ownership": "UI",
       "knownDeviations": "",
-      "sourceLine": 175
+      "sourceLine": 176
     },
     {
       "section": "11) Clipboard, selection, and hyperlinking",
@@ -1072,7 +1093,7 @@
       "hasLinkedEvidence": false,
       "ownership": "UI",
       "knownDeviations": "",
-      "sourceLine": 176
+      "sourceLine": 177
     },
     {
       "section": "11) Clipboard, selection, and hyperlinking",
@@ -1093,7 +1114,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BUI",
       "knownDeviations": "Ctrl-click open path is app-level",
-      "sourceLine": 177
+      "sourceLine": 178
     },
     {
       "section": "12) Unicode width, graphemes, and font behavior",
@@ -1123,7 +1144,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Buffer\u002BRenderer",
       "knownDeviations": "Deterministic 0/1/2-cell model for combining marks, emoji modifiers, ZWJ emoji, variation selectors, and regional-indicator flags. No Unicode-version pin or full UAX #11 conformance table is documented yet.",
-      "sourceLine": 185
+      "sourceLine": 186
     },
     {
       "section": "12) Unicode width, graphemes, and font behavior",
@@ -1156,7 +1177,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Buffer\u002BRenderer",
       "knownDeviations": "Combining/variation attachment is covered for common terminal cases, including pending-wrap boundaries. Full extended-grapheme-cluster conformance is not claimed.",
-      "sourceLine": 186
+      "sourceLine": 187
     },
     {
       "section": "12) Unicode width, graphemes, and font behavior",
@@ -1185,7 +1206,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Buffer\u002BRenderer",
       "knownDeviations": "Chunked ZWJ families, emoji modifiers, VS15/VS16, and chunked regional-indicator flag pairs are covered. Remaining gaps: cursor-addressing CSI remains cell-oriented, and width-changing selectors that arrive after a base glyph already placed at the last column are not guaranteed to retroactively reflow.",
-      "sourceLine": 187
+      "sourceLine": 188
     }
   ],
   "errors": [],

--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -1554,16 +1554,7 @@ namespace NovaTerminal.VT
             // instead of staying silent.
             if (code == "10" || code == "11")
             {
-                if (data == "?")
-                {
-                    TermColor color = code == "10"
-                        ? (DefaultForeground ?? TermColor.FromRgb(0xC0, 0xC0, 0xC0))
-                        : (DefaultBackground ?? TermColor.FromRgb(0x00, 0x00, 0x00));
-                    OnResponse?.Invoke(FormatOscColorResponse(code, color));
-                }
-                // Non-query forms (e.g. "OSC 10;#ff0000" / "OSC 11;rgb:1234/5678/9abc" to
-                // *set* the color) are not supported for runtime palette changes; ignore
-                // them safely rather than attempting to parse/apply an unsupported request.
+                HandleOscColorQuery(int.Parse(code, System.Globalization.CultureInfo.InvariantCulture), data);
                 return;
             }
 
@@ -1658,6 +1649,43 @@ namespace NovaTerminal.VT
 
         // xterm's "rgb:RRRR/GGGG/BBBB" dynamic-color-response format: each 8-bit channel is
         // widened to 16 bits by replicating the byte (0xRR -> 0xRRRR, i.e. value * 0x101).
+        // xterm's dynamic-color OSC accepts multiple values chained in one sequence, each
+        // advancing to the next color slot: "OSC 10;?;?" queries fg (slot 10) then bg
+        // (slot 11), and xterm sends two separate replies for it. A trailing ';' is also
+        // legal (e.g. "OSC 11;?;") and simply yields one extra, ignored slot. Treating the
+        // whole payload as a single "is it exactly \"?\"" check — as the original code did —
+        // means either of those legal, in-the-wild spellings produces silence: the same
+        // stall #265 fixed, just for a different query shape. Splitting on ';' and walking
+        // an incrementing slot code answers every "?" we understand (10, 11) and silently
+        // skips slots we don't (e.g. 12, the cursor color) instead of dropping the request.
+        private void HandleOscColorQuery(int startCode, string data)
+        {
+            string[] slots = data.Split(';');
+            int slotCode = startCode;
+            foreach (string slot in slots)
+            {
+                if (slot == "?")
+                {
+                    TermColor? color = slotCode switch
+                    {
+                        10 => DefaultForeground ?? TermColor.FromRgb(0xC0, 0xC0, 0xC0),
+                        11 => DefaultBackground ?? TermColor.FromRgb(0x00, 0x00, 0x00),
+                        _ => null
+                    };
+
+                    if (color != null)
+                    {
+                        OnResponse?.Invoke(FormatOscColorResponse(slotCode.ToString(System.Globalization.CultureInfo.InvariantCulture), color.Value));
+                    }
+                }
+                // Non-"?" slots (e.g. "#ff0000" to *set* a color, or an empty slot from a
+                // trailing ';') are not supported for runtime palette changes; ignore them
+                // safely rather than attempting to parse/apply an unsupported request.
+
+                slotCode++;
+            }
+        }
+
         private static string FormatOscColorResponse(string code, TermColor color)
         {
             int r = color.R * 0x101;

--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -69,6 +69,16 @@ namespace NovaTerminal.VT
 
         public float CellWidth { get; set; } = 10.0f;  // Default fallback
         public float CellHeight { get; set; } = 20.0f; // Default fallback
+
+        /// <summary>
+        /// Colors reported in response to OSC 10/11 (foreground/background) queries. The host
+        /// (NovaTerminal.App) sets these from the active theme; when unset, <see cref="HandleOsc"/>
+        /// falls back to a sane default rather than staying silent (#265: silence made OpenCode and
+        /// vim/nvim's startup theme probes stall for their ~1s timeout on every launch).
+        /// </summary>
+        public TermColor? DefaultForeground { get; set; }
+        public TermColor? DefaultBackground { get; set; }
+
         public Action<string>? OnResponse { get; set; }
         public Action? OnBell { get; set; }
         public Action<string>? OnWorkingDirectoryChanged { get; set; }
@@ -1534,6 +1544,29 @@ namespace NovaTerminal.VT
                 return;
             }
 
+            // OSC 10/11: dynamic foreground/background color queries.
+            // Query form is "10;?" / "11;?" (BEL and ST termination are both already
+            // normalized away by the caller before HandleOsc ever sees this string).
+            // xterm answers with "OSC 1x ; rgb:RRRR/GGGG/BBBB ST", 16 bits per channel
+            // (8-bit channel replicated: value * 0x101). OpenCode and vim/nvim send this
+            // at startup with a ~1s timeout to detect a dark/light theme; never responding
+            // was the bug (#265), so an unset provider still answers with a sane default
+            // instead of staying silent.
+            if (code == "10" || code == "11")
+            {
+                if (data == "?")
+                {
+                    TermColor color = code == "10"
+                        ? (DefaultForeground ?? TermColor.FromRgb(0xC0, 0xC0, 0xC0))
+                        : (DefaultBackground ?? TermColor.FromRgb(0x00, 0x00, 0x00));
+                    OnResponse?.Invoke(FormatOscColorResponse(code, color));
+                }
+                // Non-query forms (e.g. "OSC 10;#ff0000" / "OSC 11;rgb:1234/5678/9abc" to
+                // *set* the color) are not supported for runtime palette changes; ignore
+                // them safely rather than attempting to parse/apply an unsupported request.
+                return;
+            }
+
             // OSC 133: shell integration markers.
             // Common terminals/shell integrations emit:
             //   OSC 133;A     -> prompt ready
@@ -1621,6 +1654,16 @@ namespace NovaTerminal.VT
                     _buffer.CurrentHyperlink = _hyperlinks.Resolve(parameters, uri);
                 }
             }
+        }
+
+        // xterm's "rgb:RRRR/GGGG/BBBB" dynamic-color-response format: each 8-bit channel is
+        // widened to 16 bits by replicating the byte (0xRR -> 0xRRRR, i.e. value * 0x101).
+        private static string FormatOscColorResponse(string code, TermColor color)
+        {
+            int r = color.R * 0x101;
+            int g = color.G * 0x101;
+            int b = color.B * 0x101;
+            return $"\x1b]{code};rgb:{r:x4}/{g:x4}/{b:x4}\x1b\\";
         }
 
         private static bool TryExtractPathFromOsc7(string data, out string path)

--- a/tests/NovaTerminal.App.Tests/Controls/PaneParserWiringTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneParserWiringTests.cs
@@ -1,6 +1,8 @@
 using System;
+using System.IO;
 using Avalonia.Headless.XUnit;
 using NovaTerminal.Controls;
+using NovaTerminal.Shell;
 using NovaTerminal.VT;
 using Xunit;
 
@@ -94,5 +96,78 @@ public class PaneParserWiringTests
 
         Assert.Equal(1, HandlerCount(superseded!.OnBell));
         Assert.False(ReferenceEquals(superseded, pane.Parser));
+    }
+
+    /// <summary>
+    /// Regression test for the PR #275 review finding: <c>CreateAndWireParser</c> used to seed
+    /// the parser's OSC 10/11 answer colors from the global <c>_settings.ActiveTheme</c> instead
+    /// of the profile-merged theme that <see cref="TerminalPane.ApplySettings"/> resolves (via
+    /// <c>Profile?.ThemeName ?? settings.ThemeName</c>). Because <c>CreateAndWireParser</c> runs
+    /// after <c>ApplySettings</c> on pane construction, and again on every session
+    /// (re)initialization, a pane whose profile overrides the theme would silently answer color
+    /// queries with the global theme's colors until the next settings apply.
+    /// </summary>
+    [AvaloniaFact]
+    public void CreateAndWireParser_UsesProfileThemeOverride_NotGlobalTheme()
+    {
+        string tempRoot = CreateTempAppRoot();
+        string? previousRoot = Environment.GetEnvironmentVariable("NOVATERM_APPDATA_ROOT");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("NOVATERM_APPDATA_ROOT", tempRoot);
+
+            var globalTheme = new TerminalTheme
+            {
+                Name = "PaneWiringGlobalTheme",
+                Foreground = TermColor.FromRgb(10, 20, 30),
+                Background = TermColor.FromRgb(40, 50, 60),
+            };
+            var profileTheme = new TerminalTheme
+            {
+                Name = "PaneWiringProfileTheme",
+                Foreground = TermColor.FromRgb(200, 210, 220),
+                Background = TermColor.FromRgb(5, 6, 7),
+            };
+
+            var themeManager = new ThemeManager();
+            themeManager.SaveTheme(globalTheme);
+            themeManager.SaveTheme(profileTheme);
+
+            var settings = new TerminalSettings { ThemeName = globalTheme.Name };
+            var profile = new TerminalProfile { ThemeName = profileTheme.Name };
+
+            // The constructor's SetupCommon path already called ApplySettings(settings) with
+            // this profile attached, exactly like MainWindow does before a pane is attached
+            // and its session starts.
+            using var pane = new TerminalPane(profile, settings);
+
+            // Simulates session init (InitializeSession -> CreateAndWireParser). This is the
+            // call that used to clobber the profile override with _settings.ActiveTheme.
+            pane.CreateAndWireParser();
+
+            Assert.NotNull(pane.Parser);
+            Assert.Equal(profileTheme.Foreground, pane.Parser!.DefaultForeground);
+            Assert.Equal(profileTheme.Background, pane.Parser!.DefaultBackground);
+
+            // Simulate a Reconnect(), which calls CreateAndWireParser again with no
+            // intervening ApplySettings. The profile override must still win every time.
+            pane.CreateAndWireParser();
+
+            Assert.Equal(profileTheme.Foreground, pane.Parser!.DefaultForeground);
+            Assert.Equal(profileTheme.Background, pane.Parser!.DefaultBackground);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NOVATERM_APPDATA_ROOT", previousRoot);
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    private static string CreateTempAppRoot()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"nova_pane_wiring_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
     }
 }

--- a/tests/NovaTerminal.App.Tests/OscUxTests.cs
+++ b/tests/NovaTerminal.App.Tests/OscUxTests.cs
@@ -77,10 +77,10 @@ namespace NovaTerminal.Tests
             var responses = new List<string>();
             parser.OnResponse = r => responses.Add(r);
 
-            parser.Process("]11;?");
+            parser.Process("\u001b]11;?\u0007");
 
             var response = Assert.Single(responses);
-            Assert.Equal("]11;rgb:1111/2222/3333\\", response);
+            Assert.Equal("\u001b]11;rgb:1111/2222/3333\u001b\\", response);
         }
 
         [Fact]
@@ -95,10 +95,10 @@ namespace NovaTerminal.Tests
             parser.OnResponse = r => responses.Add(r);
 
             // ST-terminated (ESC backslash) form instead of BEL.
-            parser.Process("]10;?\\");
+            parser.Process("\u001b]10;?\u001b\\");
 
             var response = Assert.Single(responses);
-            Assert.Equal("]10;rgb:1111/2222/3333\\", response);
+            Assert.Equal("\u001b]10;rgb:1111/2222/3333\u001b\\", response);
         }
 
         [Fact]
@@ -109,12 +109,12 @@ namespace NovaTerminal.Tests
             var responses = new List<string>();
             parser.OnResponse = r => responses.Add(r);
 
-            parser.Process("]10;?");
-            parser.Process("]11;?");
+            parser.Process("\u001b]10;?\u0007");
+            parser.Process("\u001b]11;?\u0007");
 
             Assert.Equal(2, responses.Count);
-            Assert.Equal("]10;rgb:c0c0/c0c0/c0c0\\", responses[0]);
-            Assert.Equal("]11;rgb:0000/0000/0000\\", responses[1]);
+            Assert.Equal("\u001b]10;rgb:c0c0/c0c0/c0c0\u001b\\", responses[0]);
+            Assert.Equal("\u001b]11;rgb:0000/0000/0000\u001b\\", responses[1]);
         }
 
         [Fact]
@@ -129,14 +129,53 @@ namespace NovaTerminal.Tests
             parser.OnResponse = r => responses.Add(r);
 
             // Set form (not a query): must not crash and must not emit a response.
-            parser.Process("]11;#ff0000");
+            parser.Process("\u001b]11;#ff0000\u0007");
 
             Assert.Empty(responses);
 
             // Parser state must not be corrupted: a subsequent query still works.
-            parser.Process("]11;?");
+            parser.Process("\u001b]11;?\u0007");
             var response2 = Assert.Single(responses);
-            Assert.Equal("]11;rgb:1111/2222/3333\\", response2);
+            Assert.Equal("\u001b]11;rgb:1111/2222/3333\u001b\\", response2);
+        }
+
+        [Fact]
+        public void Osc10_ChainedQuery_RespondsForForegroundThenBackground()
+        {
+            var buffer = new TerminalBuffer(80, 24);
+            var parser = new AnsiParser(buffer)
+            {
+                DefaultForeground = new TermColor(0x11, 0x22, 0x33),
+                DefaultBackground = new TermColor(0x44, 0x55, 0x66)
+            };
+            var responses = new List<string>();
+            parser.OnResponse = r => responses.Add(r);
+
+            // xterm advances to the next color slot per chained value: "OSC 10;?;?"
+            // queries fg (slot 10) then bg (slot 11) and expects two replies.
+            parser.Process("\u001b]10;?;?\u0007");
+
+            Assert.Equal(2, responses.Count);
+            Assert.Equal("\u001b]10;rgb:1111/2222/3333\u001b\\", responses[0]);
+            Assert.Equal("\u001b]11;rgb:4444/5555/6666\u001b\\", responses[1]);
+        }
+
+        [Fact]
+        public void Osc11_TrailingSemicolon_StillAnswersTheQuery()
+        {
+            var buffer = new TerminalBuffer(80, 24);
+            var parser = new AnsiParser(buffer)
+            {
+                DefaultBackground = new TermColor(0x11, 0x22, 0x33)
+            };
+            var responses = new List<string>();
+            parser.OnResponse = r => responses.Add(r);
+
+            // A trailing ';' is legal and must not swallow the query into silence (#265 follow-up).
+            parser.Process("\u001b]11;?;\u0007");
+
+            var response = Assert.Single(responses);
+            Assert.Equal("\u001b]11;rgb:1111/2222/3333\u001b\\", response);
         }
     }
 }

--- a/tests/NovaTerminal.App.Tests/OscUxTests.cs
+++ b/tests/NovaTerminal.App.Tests/OscUxTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using NovaTerminal.Shell;
 using NovaTerminal.Platform;
 using NovaTerminal.VT;
@@ -58,6 +59,84 @@ namespace NovaTerminal.Tests
 
             Assert.Equal(CursorStyle.Beam, buffer.Modes.CursorStyle);
             Assert.False(buffer.Modes.IsCursorBlinkEnabled);
+        }
+
+        // #265: OpenCode (and vim/nvim) probe OSC 10/11 at startup with a ~1s timeout to
+        // detect a dark/light theme. Silence stalled every launch and misdetected the theme;
+        // the parser must always answer, using the host-supplied theme colors when set and a
+        // sane default otherwise.
+
+        [Fact]
+        public void Osc11_QueryWithProvider_ReturnsBackgroundColor_BelTerminated()
+        {
+            var buffer = new TerminalBuffer(80, 24);
+            var parser = new AnsiParser(buffer)
+            {
+                DefaultBackground = new TermColor(0x11, 0x22, 0x33)
+            };
+            var responses = new List<string>();
+            parser.OnResponse = r => responses.Add(r);
+
+            parser.Process("]11;?");
+
+            var response = Assert.Single(responses);
+            Assert.Equal("]11;rgb:1111/2222/3333\\", response);
+        }
+
+        [Fact]
+        public void Osc10_QueryWithProvider_ReturnsForegroundColor_StTerminated()
+        {
+            var buffer = new TerminalBuffer(80, 24);
+            var parser = new AnsiParser(buffer)
+            {
+                DefaultForeground = new TermColor(0x11, 0x22, 0x33)
+            };
+            var responses = new List<string>();
+            parser.OnResponse = r => responses.Add(r);
+
+            // ST-terminated (ESC backslash) form instead of BEL.
+            parser.Process("]10;?\\");
+
+            var response = Assert.Single(responses);
+            Assert.Equal("]10;rgb:1111/2222/3333\\", response);
+        }
+
+        [Fact]
+        public void Osc10And11_QueryWithoutProvider_StillRespondsWithDefaults()
+        {
+            var buffer = new TerminalBuffer(80, 24);
+            var parser = new AnsiParser(buffer);
+            var responses = new List<string>();
+            parser.OnResponse = r => responses.Add(r);
+
+            parser.Process("]10;?");
+            parser.Process("]11;?");
+
+            Assert.Equal(2, responses.Count);
+            Assert.Equal("]10;rgb:c0c0/c0c0/c0c0\\", responses[0]);
+            Assert.Equal("]11;rgb:0000/0000/0000\\", responses[1]);
+        }
+
+        [Fact]
+        public void Osc11_SetForm_IsIgnoredSafely()
+        {
+            var buffer = new TerminalBuffer(80, 24);
+            var parser = new AnsiParser(buffer)
+            {
+                DefaultBackground = new TermColor(0x11, 0x22, 0x33)
+            };
+            var responses = new List<string>();
+            parser.OnResponse = r => responses.Add(r);
+
+            // Set form (not a query): must not crash and must not emit a response.
+            parser.Process("]11;#ff0000");
+
+            Assert.Empty(responses);
+
+            // Parser state must not be corrupted: a subsequent query still works.
+            parser.Process("]11;?");
+            var response2 = Assert.Single(responses);
+            Assert.Equal("]11;rgb:1111/2222/3333\\", response2);
         }
     }
 }


### PR DESCRIPTION
## What

`AnsiParser.HandleOsc` now answers OSC 10 (foreground) and OSC 11 (background) dynamic color queries instead of staying silent.

## Why

OpenCode queries `ESC ] 11 ; ? BEL` at startup (with a ~1s timeout) to detect a dark/light theme. vim/nvim do the same for background detection. NovaTerminal's parser only handled OSC 0/2, 7, 8, 133, 1337, 1339 - OSC 10/11 fell through unanswered, so every launch of these tools stalled for the full timeout and then guessed the theme wrong.

Fixes #265.

## Design

- `AnsiParser` gains two nullable properties, `DefaultForeground` and `DefaultBackground` (type `NovaTerminal.VT.TermColor?`), following the same host-supplies-a-value pattern already used by `OnResponse` / `OnTitleChanged`. `TermColor` already lives in `NovaTerminal.VT` (used by `TerminalTheme`), so this needed no new leaf-assembly dependency.
- `HandleOsc` responds to a query form (`10;?` / `11;?`) via the existing `OnResponse` callback with xterm's `ESC ] 1x ; rgb:RRRR/GGGG/BBBB ESC \` format (each 8-bit channel widened to 16 bits by `value * 0x101`). BEL- and ST-terminated queries both work, since OSC termination is already normalized to a single call to `HandleOsc` before code/data get parsed.
- If no provider is set, the parser still answers with a hardcoded default (fg C0C0C0 / bg 000000) - never silent.
- Non-query "set" forms (e.g. `OSC 11;#ff0000`) are recognized and ignored safely; NovaTerminal does not support runtime palette changes via OSC, so these are a no-op rather than a crash or state corruption.

## App wiring

`TerminalPane.axaml.cs`:
- `CreateAndWireParser()` sets `Parser.DefaultForeground`/`DefaultBackground` from `_settings.ActiveTheme` right after constructing the parser, so a freshly spawned session answers with the right colors immediately.
- `ApplySettings()` also updates both properties from `effectiveSettings.ActiveTheme` (which already accounts for profile-specific theme overrides), so a theme change while a session is running keeps OSC 10/11 answers in sync - this reuses the settings pipeline that already exists for theme application, no new refactor needed.

## Tests

Added to `tests/NovaTerminal.App.Tests/OscUxTests.cs`:
- `Osc11_QueryWithProvider_ReturnsBackgroundColor_BelTerminated` - byte-exact response for BEL-terminated query.
- `Osc10_QueryWithProvider_ReturnsForegroundColor_StTerminated` - byte-exact response for ST-terminated query.
- `Osc10And11_QueryWithoutProvider_StillRespondsWithDefaults` - confirms the fallback defaults (no silence).
- `Osc11_SetForm_IsIgnoredSafely` - confirms the set form (`OSC 11;#ff0000`) does not crash, does not emit a response, and does not corrupt parser state (a following query still works).

Full `OscUxTests` class result after rebasing onto latest main (including #273):

```
Passed!  - Failed: 0, Passed: 8, Skipped: 0, Total: 8
```

Full solution build (`scripts/build.ps1 build`) also succeeds with 0 errors.

## Docs

`docs/vt_coverage_matrix.md`: added an OSC 10/11 row (Supported), evidence pointing at `OscUxTests.cs`, with a note about the query-only scope and the default fallback colors.
