### PR TITLE
refactor(command-assist): split the controller into state machine, capture pipeline and suggestion orchestrator (V2 Phase 0c)

### DIFF
--- a/docs/MODULE_OWNERSHIP.md
+++ b/docs/MODULE_OWNERSHIP.md
@@ -168,7 +168,7 @@ invariant changes.
 
 **Namespace:** `NovaTerminal.CommandAssist` (+ `.Application`, `.Domain`, `.Models`, `.Storage`, `.ShellIntegration`, `.ViewModels`)
 **Depends on:** *(leaf — only BCL)*
-**Public surface:** `CommandAssistController`, `CommandAssistAnchorCalculator` (+ `AssistRect`/`AssistPoint`/`AssistSize`), `AssistKey`/`AssistModifiers`, `CommandAssistModeRouter`, `CommandAssistKeyRouter`, `CommandAssistInsertionPlanner`, `CommandAssistResultBuilder`, `RecognizedCommandParser`, the `I*Store` / `I*Provider` / `ISuggestionEngine` / `ISecretsFilter` domain contracts and their local implementations, `IShellIntegrationProvider` + the four shell providers and bootstrap builders, `ShellIntegrationRegistry`, `ShellLifecycleTracker`, `JsonlHistoryStore`, `JsonSnippetStore`, `CommandAssistJsonContext` / `CommandAssistJsonLinesContext`, and the assist view-models
+**Public surface:** `CommandAssistController` and its three collaborators (`AssistSessionStateMachine` + `AssistSessionState`, `AssistSessionContext`, `CapturePipeline`, `SuggestionOrchestrator` + `SuggestionRefreshOutcome`), `CommandAssistAnchorCalculator` (+ `AssistRect`/`AssistPoint`/`AssistSize`), `AssistKey`/`AssistModifiers`, `CommandAssistModeRouter`, `CommandAssistKeyRouter`, `CommandAssistInsertionPlanner`, `CommandAssistResultBuilder`, `RecognizedCommandParser`, the `I*Store` / `I*Provider` / `ISuggestionEngine` / `ISecretsFilter` domain contracts and their local implementations, `IShellIntegrationProvider` + the four shell providers and bootstrap builders, `ShellIntegrationRegistry`, `ShellLifecycleTracker`, `JsonlHistoryStore`, `JsonSnippetStore`, `CommandAssistJsonContext` / `CommandAssistJsonLinesContext`, and the assist view-models
 **Internals exposed to:** `NovaTerminal.App.Tests` only. The App is deliberately not granted
 `InternalsVisibleTo`: the two helpers `TerminalPane` needs (`CommandAssistKeyRouter`,
 `CommandAssistInsertionPlanner`) are public pure-static functions over public types, so the App
@@ -182,7 +182,9 @@ consumes this assembly through its published surface.
   plus their source-generated JSON contexts
 - Shell integration: the `OSC 133` contract, the bash/zsh/fish/PowerShell bootstrap builders and providers, provider registry, lifecycle tracking, ordered async event dispatch
 - Assist view-models (`INotifyPropertyChanged` only — no toolkit types)
-- Application core: controller, mode router, insertion planner, result builder, key router, anchor calculator
+- Application core: controller (a facade over the session state machine, the capture pipeline and
+  the suggestion orchestrator, with `AssistSessionContext` carrying the environment they share),
+  mode router, insertion planner, result builder, key router, anchor calculator
 
 **Non-responsibilities**
 - Rendering the assist surfaces. The Avalonia `UserControl`s stay in the App at
@@ -213,9 +215,9 @@ consumes this assembly through its published surface.
 > **Note:** extracted from the App in #114 as Phase 0 of the Command Assist V2 rebuild
 > (`docs/plans/2026-08-01-command-assist-v2-plan.md`). Phase 0b then replaced the static
 > `CommandAssistInfrastructure` locator with the injected `CommandAssistServices`, unified ranking on
-> `CommandAssistSuggestionEngine`, and swapped the history store for JSONL. The remaining Phase 0
-> item — splitting `CommandAssistController` into a state machine, capture pipeline, and suggestion
-> orchestrator (plan task 4) — lands in a follow-up.
+> `CommandAssistSuggestionEngine`, and swapped the history store for JSONL. Phase 0c split
+> `CommandAssistController` into `AssistSessionStateMachine`, `CapturePipeline` and
+> `SuggestionOrchestrator` (plan task 4), completing Phase 0.
 
 ---
 

--- a/docs/plans/2026-08-01-command-assist-v2-plan.md
+++ b/docs/plans/2026-08-01-command-assist-v2-plan.md
@@ -14,14 +14,14 @@ Design: `2026-08-01-command-assist-v2-design.md`
 
 Closes #114. Pure restructuring; every existing test must pass unmodified (namespace updates aside).
 
-**Status: task 4 outstanding; everything else has shipped.** Tasks 1, 2 and 7 landed in PR #276
-(Phase 0a); tasks 3, 5 and 6 in PR #279 (Phase 0b).
+**Status: complete.** Tasks 1, 2 and 7 landed in PR #276 (Phase 0a); tasks 3, 5 and 6 in PR #279
+(Phase 0b); task 4 in Phase 0c.
 
 Tasks:
 1. **[done — #276]** Create `src/NovaTerminal.CommandAssist/` project (Avalonia-free). Move Domain, Models, Storage, ShellIntegration, ViewModels, Application core.
 2. **[done — #276]** Introduce `AssistKey`/`AssistModifiers` abstraction for `CommandAssistKeyRouter`; map from `Avalonia.Input` in `TerminalPane`. Introduce plain geometry records (`AssistPoint/AssistRect/AssistSize`) for `CommandAssistAnchorCalculator`; convert at the App boundary.
 3. **[done — #279]** Replace static `CommandAssistInfrastructure` with `CommandAssistServices` composed at the App root and injected into `TerminalPane`. (Injected at the single `MainWindow.WirePane` funnel, so session-restored panes get it too.)
-4. Split `CommandAssistController` (854 L): `AssistSessionStateMachine` (enum state: Hidden / PassiveBubble / PopupBrowse / Search / Help / Fix — replaces the 7 bools), `CapturePipeline`, `SuggestionOrchestrator` (debounce + `CancellationToken` refresh, replacing `_refreshVersion`).
+4. **[done — Phase 0c]** Split `CommandAssistController`: `AssistSessionStateMachine` (enum state: Hidden / PassiveBubble / PassivePopup / ExplicitBubble / ExplicitPopup / HistorySearch / Help / FixHint / FixPopup — the sketched six split further because explicitness has to survive a popup round trip and Fix has two popup variants), `AssistSessionContext` (the environment facts that are not session state), `CapturePipeline`, `SuggestionOrchestrator` (`CancellationToken` refresh replacing `_refreshVersion`; the debounce is deliberately deferred to Phase 3, where it is a policy decision rather than a mechanism swap).
 5. **[done — #279]** Single ranking: delete `JsonHistoryStore.Score` (stores return candidates), delete dead `HistorySuggestionEngine`, `CommandAssistBarView`, unused ctors, `TryUpdateExitCodeAsync`, `CanExecuteDirectly`.
 6. **[done — #279]** Storage: JSONL append + in-memory index + compaction; one-time `history.json` migration; keep `AppJsonContext` source-gen. (One store instance per process: the cap is mutable, never an instance swap.)
 7. **[done — #276]** Update `NamespaceAlignmentTests` / architecture tests and `docs/MODULE_OWNERSHIP.md` for the new assembly.

--- a/src/NovaTerminal.CommandAssist/Application/AssistSessionContext.cs
+++ b/src/NovaTerminal.CommandAssist/Application/AssistSessionContext.cs
@@ -1,0 +1,139 @@
+using NovaTerminal.CommandAssist.Models;
+
+namespace NovaTerminal.CommandAssist.Application;
+
+/// <summary>
+/// The environment an assist session runs in: which shell, where, whether the connection is remote,
+/// whether the alt screen is up, and how much of the OSC 133 contract the shell has actually proved
+/// it speaks.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the other half of the split described on <see cref="AssistSessionStateMachine"/>. None of
+/// these values say anything about what the assist surface is doing - they describe the terminal
+/// underneath it. They change on their own schedule (a directory change, an alt-screen switch, a
+/// marker arriving) rather than in response to the user driving the assist UI, which is exactly why
+/// they are not states of <see cref="AssistSessionState"/>.
+/// </para>
+/// <para>
+/// Mutable and shared: the controller, the <see cref="CapturePipeline"/> and the
+/// <see cref="SuggestionOrchestrator"/> all read the same instance, so a directory change observed
+/// by a shell-integration event is immediately visible to the next ranking pass. All mutation goes
+/// through named methods.
+/// </para>
+/// </remarks>
+public sealed class AssistSessionContext
+{
+    /// <summary>Shell kind reported by the host ("pwsh", "bash", ...), or null when unknown.</summary>
+    public string? ShellKind { get; private set; }
+
+    /// <summary>Working directory as last reported by the host or by an OSC 133 event.</summary>
+    public string? WorkingDirectory { get; private set; }
+
+    /// <summary>Connection profile id, recorded on captured history entries.</summary>
+    public string? ProfileId { get; private set; }
+
+    /// <summary>Terminal session id, recorded on captured history entries.</summary>
+    public string? SessionId { get; private set; }
+
+    /// <summary>Remote host id for SSH sessions, recorded on captured history entries.</summary>
+    public string? HostId { get; private set; }
+
+    /// <summary>Whether this session runs over SSH.</summary>
+    public bool IsRemote { get; private set; }
+
+    /// <summary>
+    /// Whether the terminal is showing an alternate screen (a full-screen TUI). Every assist surface
+    /// stays down while this is true.
+    /// </summary>
+    public bool IsAltScreenActive { get; private set; }
+
+    /// <summary>Whether shell integration is configured for this session.</summary>
+    public bool IsShellIntegrationEnabled { get; private set; }
+
+    /// <summary>
+    /// Whether any OSC 133 marker has been seen on this session. Reserved for the Phase 2 work that
+    /// lifts the SSH restrictions once a remote shell proves it is instrumented; nothing reads it
+    /// yet, and it is kept only so that the observation is not lost.
+    /// </summary>
+    public bool HasObservedShellIntegrationMarker { get; private set; }
+
+    /// <summary>
+    /// Whether a <c>CommandAccepted</c> (OSC 133;C) marker has been seen. This is the one that
+    /// matters for capture: until the shell proves it reports command text, the heuristic Enter-time
+    /// capture has to stand in for it.
+    /// </summary>
+    public bool HasObservedStructuredCommandCaptureMarker { get; private set; }
+
+    /// <summary>
+    /// True when structured capture can be trusted to record this session's commands, which is what
+    /// tells the heuristic Enter-time path to stand down.
+    /// </summary>
+    public bool IsStructuredCaptureActive =>
+        IsShellIntegrationEnabled && HasObservedStructuredCommandCaptureMarker;
+
+    /// <summary>Replaces the host-reported session facts.</summary>
+    /// <remarks>
+    /// Observed markers survive only while shell integration stays configured: a session that
+    /// switched integration off has to prove itself again.
+    /// </remarks>
+    public void UpdateSession(
+        string? shellKind,
+        string? workingDirectory,
+        string? profileId,
+        string? sessionId,
+        string? hostId,
+        bool isRemote,
+        bool isShellIntegrated)
+    {
+        ShellKind = shellKind;
+        WorkingDirectory = workingDirectory;
+        ProfileId = profileId;
+        SessionId = sessionId;
+        HostId = hostId;
+        IsRemote = isRemote;
+        IsShellIntegrationEnabled = isShellIntegrated;
+        HasObservedShellIntegrationMarker = HasObservedShellIntegrationMarker && isShellIntegrated;
+        HasObservedStructuredCommandCaptureMarker = HasObservedStructuredCommandCaptureMarker && isShellIntegrated;
+    }
+
+    /// <summary>Turns shell integration on or off, forgetting observed markers when it goes off.</summary>
+    public void SetShellIntegrationEnabled(bool isEnabled)
+    {
+        IsShellIntegrationEnabled = isEnabled;
+        if (!isEnabled)
+        {
+            HasObservedShellIntegrationMarker = false;
+            HasObservedStructuredCommandCaptureMarker = false;
+        }
+    }
+
+    /// <summary>Records an alt-screen switch.</summary>
+    public void SetAltScreenActive(bool isActive) => IsAltScreenActive = isActive;
+
+    /// <summary>Records a working-directory change reported by a shell-integration event.</summary>
+    public void SetWorkingDirectory(string workingDirectory) => WorkingDirectory = workingDirectory;
+
+    /// <summary>Records that the shell emitted some OSC 133 marker.</summary>
+    public void ObserveShellIntegrationMarker() => HasObservedShellIntegrationMarker = true;
+
+    /// <summary>Records that the shell emitted a command-accepted marker carrying command text.</summary>
+    public void ObserveStructuredCommandCaptureMarker() => HasObservedStructuredCommandCaptureMarker = true;
+
+    /// <summary>Builds the immutable snapshot the help/fix providers are queried with.</summary>
+    public CommandAssistContextSnapshot CreateSnapshot(string queryText, string? selectedText)
+    {
+        string recognizedSource = string.IsNullOrWhiteSpace(queryText) ? selectedText ?? string.Empty : queryText;
+
+        return new CommandAssistContextSnapshot(
+            QueryText: queryText,
+            RecognizedCommand: RecognizedCommandParser.ParsePrimaryCommand(recognizedSource),
+            ShellKind: ShellKind,
+            WorkingDirectory: WorkingDirectory,
+            ProfileId: ProfileId,
+            SessionId: SessionId,
+            HostId: HostId,
+            IsRemote: IsRemote,
+            SelectedText: selectedText);
+    }
+}

--- a/src/NovaTerminal.CommandAssist/Application/AssistSessionState.cs
+++ b/src/NovaTerminal.CommandAssist/Application/AssistSessionState.cs
@@ -1,0 +1,65 @@
+namespace NovaTerminal.CommandAssist.Application;
+
+/// <summary>
+/// What the assist session is doing right now - the single value that replaces the mode and
+/// visibility bools <see cref="CommandAssistController"/> used to carry side by side.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two axes are folded into this enum because the code has always treated them as one thing:
+/// the <see cref="Models.CommandAssistMode"/> the session is in, and whether the popup is open on
+/// top of the bubble. A third axis - whether the user asked for the session explicitly - is folded
+/// in as well: it survives a round trip through the popup and through
+/// <see cref="AssistSessionStateMachine.ObserveTypedInput"/>, so it cannot be a transient flag.
+/// </para>
+/// <para>
+/// Environment facts are deliberately <em>not</em> here. Alt-screen, remoteness, whether shell
+/// integration is configured and whether its markers have been seen describe the terminal the
+/// session runs in, not what the session is doing; they live in
+/// <see cref="AssistSessionContext"/> and gate transitions from the outside.
+/// </para>
+/// </remarks>
+public enum AssistSessionState
+{
+    /// <summary>No assist surface on screen. The resting state, and where every dismissal lands.</summary>
+    Hidden,
+
+    /// <summary>
+    /// Suggest mode the user did not ask for: the bubble shows itself only while the last refresh
+    /// produced rows. Path suggestions only - history and snippets stay out of an unasked-for hint.
+    /// </summary>
+    PassiveBubble,
+
+    /// <summary>
+    /// <see cref="PassiveBubble"/> with the popup opened by arrow-key navigation. Collapses back to
+    /// <see cref="PassiveBubble"/> on the next Suggest-mode refresh, which closes the popup.
+    /// </summary>
+    PassivePopup,
+
+    /// <summary>
+    /// A session the user opened deliberately (assist toggle, or typing on after a history search).
+    /// The bubble stays up even with no rows, and the suggestion scope widens to history + snippets.
+    /// </summary>
+    ExplicitBubble,
+
+    /// <summary><see cref="ExplicitBubble"/> with the popup opened by arrow-key navigation.</summary>
+    ExplicitPopup,
+
+    /// <summary>
+    /// Explicit history search (Ctrl+R): popup open, history-only scope, and the explicitness
+    /// survives if the user keeps typing.
+    /// </summary>
+    HistorySearch,
+
+    /// <summary>Help mode: popup open over docs and recipe rows. Not a suggestion-refreshing state.</summary>
+    Help,
+
+    /// <summary>
+    /// Fix mode entered from a low-confidence failure analysis: bubble-only affordance, popup closed
+    /// until the user navigates into it.
+    /// </summary>
+    FixHint,
+
+    /// <summary>Fix mode entered from a high-confidence failure analysis: popup opened immediately.</summary>
+    FixPopup
+}

--- a/src/NovaTerminal.CommandAssist/Application/AssistSessionStateMachine.cs
+++ b/src/NovaTerminal.CommandAssist/Application/AssistSessionStateMachine.cs
@@ -1,0 +1,207 @@
+using System;
+using NovaTerminal.CommandAssist.Models;
+
+namespace NovaTerminal.CommandAssist.Application;
+
+/// <summary>
+/// Owns what the assist session is doing. Every change of state is a named transition; there is no
+/// settable state property, so the set of ways the session can move is the set of methods here.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This replaces the mode field and the visibility/explicit-session bools that
+/// <see cref="CommandAssistController"/> used to keep in sync by hand. The controller still writes
+/// the view-model (visibility, popup, labels) itself; the state machine is the authority for the
+/// three things behavior actually branches on: the current <see cref="Mode"/>, whether this is an
+/// <see cref="IsExplicitSession"/>, and whether the current submission is suppressed.
+/// </para>
+/// <para>
+/// <strong>Session state vs environment.</strong> A fact belongs here when it describes what the
+/// assist surface is doing and changes as the user drives it. A fact belongs in
+/// <see cref="AssistSessionContext"/> when it describes the terminal or shell the session happens
+/// to be running in - alt-screen, remoteness, shell-integration configuration, observed OSC 133
+/// markers, cwd, shell kind, ids. Those gate transitions from the outside (the controller refuses to
+/// open anything while the alt screen is up) but they are not states of the session, and putting
+/// them in the enum would multiply it by every combination of terminal condition.
+/// </para>
+/// </remarks>
+public sealed class AssistSessionStateMachine
+{
+    /// <summary>The current session state. Only the transitions below can change it.</summary>
+    public AssistSessionState State { get; private set; } = AssistSessionState.Hidden;
+
+    /// <summary>
+    /// True when the text sitting in the shell's input line did not come from the user typing it
+    /// here - today that means it was pasted - so neither history capture nor suggestion insertion
+    /// may act on it.
+    /// </summary>
+    /// <remarks>
+    /// Kept beside the enum rather than inside it on purpose: a paste can land in any state, so
+    /// folding it in would double the state count while carrying no information about what the
+    /// surface is showing. It is still only reachable through named transitions
+    /// (<see cref="ObservePastedText"/> sets it; <see cref="ObserveTypedInput"/> and
+    /// <see cref="CompleteSubmission"/> clear it), never through a setter. Phase 1 deletes the
+    /// shadow query buffer this exists to protect, and should delete this with it.
+    /// </remarks>
+    public bool IsCurrentSubmissionSuppressed { get; private set; }
+
+    /// <summary>The assist mode implied by the current state.</summary>
+    public CommandAssistMode Mode => State switch
+    {
+        AssistSessionState.HistorySearch => CommandAssistMode.Search,
+        AssistSessionState.Help => CommandAssistMode.Help,
+        AssistSessionState.FixHint or AssistSessionState.FixPopup => CommandAssistMode.Fix,
+        _ => CommandAssistMode.Suggest
+    };
+
+    /// <summary>
+    /// True when the user opened this session deliberately. Widens the Suggest-mode scope to history
+    /// and snippets, and keeps the bubble up even when a refresh returns nothing.
+    /// </summary>
+    public bool IsExplicitSession => State is
+        AssistSessionState.ExplicitBubble or
+        AssistSessionState.ExplicitPopup or
+        AssistSessionState.HistorySearch;
+
+    /// <summary>Whether the session intends the popup to be open over the bubble.</summary>
+    public bool IsPopupOpen => State is
+        AssistSessionState.PassivePopup or
+        AssistSessionState.ExplicitPopup or
+        AssistSessionState.HistorySearch or
+        AssistSessionState.Help or
+        AssistSessionState.FixPopup;
+
+    /// <summary>
+    /// Whether the state ranks suggestions at all. Help and Fix render content produced elsewhere,
+    /// so a refresh queued while they are up is dropped rather than allowed to overwrite them.
+    /// </summary>
+    public bool AllowsSuggestionRefresh => Mode is CommandAssistMode.Suggest or CommandAssistMode.Search;
+
+    /// <summary>
+    /// Toggles the explicit assist session (the assist shortcut).
+    /// </summary>
+    /// <param name="isSurfaceVisible">
+    /// Whether an assist surface is currently on screen. Passed in rather than derived because in
+    /// the passive states visibility depends on whether the last refresh produced rows, which the
+    /// view-model owns; the toggle has always keyed off what the user can see.
+    /// </param>
+    /// <returns>The state after the toggle.</returns>
+    public AssistSessionState ToggleSession(bool isSurfaceVisible)
+    {
+        State = isSurfaceVisible ? AssistSessionState.Hidden : AssistSessionState.ExplicitBubble;
+        return State;
+    }
+
+    /// <summary>Opens explicit history search (Ctrl+R).</summary>
+    public void OpenSearch() => State = AssistSessionState.HistorySearch;
+
+    /// <summary>Shows help content with the popup open.</summary>
+    public void OpenHelp() => State = AssistSessionState.Help;
+
+    /// <summary>
+    /// Shows fix content: popup open for a confident diagnosis, bubble-only affordance otherwise.
+    /// </summary>
+    public void ShowFix(bool openPopup) =>
+        State = openPopup ? AssistSessionState.FixPopup : AssistSessionState.FixHint;
+
+    /// <summary>
+    /// Enters one of the helper modes that render externally produced content.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown for <see cref="CommandAssistMode.Suggest"/> and <see cref="CommandAssistMode.Search"/>:
+    /// those are reached by user intent through their own transitions, never by publishing content.
+    /// </exception>
+    public void EnterHelperMode(CommandAssistMode mode, bool openPopup)
+    {
+        switch (mode)
+        {
+            case CommandAssistMode.Help:
+                OpenHelp();
+                return;
+            case CommandAssistMode.Fix:
+                ShowFix(openPopup);
+                return;
+            default:
+                throw new ArgumentOutOfRangeException(
+                    nameof(mode),
+                    mode,
+                    "Only Help and Fix publish helper content; Suggest and Search are entered by user intent.");
+        }
+    }
+
+    /// <summary>
+    /// The user typed into the shell. Returns to Suggest mode with the popup closed, preserving
+    /// whether this is an explicit session - typing on after a history search stays explicit.
+    /// </summary>
+    public void ObserveTypedInput()
+    {
+        IsCurrentSubmissionSuppressed = false;
+        State = IsExplicitSession ? AssistSessionState.ExplicitBubble : AssistSessionState.PassiveBubble;
+    }
+
+    /// <summary>
+    /// The user pasted text. Drops back to a passive Suggest bubble and suppresses the current
+    /// submission: the pasted text is not something the user composed here.
+    /// </summary>
+    public void ObservePastedText()
+    {
+        IsCurrentSubmissionSuppressed = true;
+        State = AssistSessionState.PassiveBubble;
+    }
+
+    /// <summary>
+    /// The user moved the selection, which opens the popup over whichever surface is up.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="AssistSessionState.Hidden"/> is a deliberate no-op: rows left over from a session
+    /// that was toggled off can still be navigated, but there is no visible surface to browse, so
+    /// the session does not re-open.
+    /// </remarks>
+    public void OpenPopupForSelection()
+    {
+        State = State switch
+        {
+            AssistSessionState.PassiveBubble => AssistSessionState.PassivePopup,
+            AssistSessionState.ExplicitBubble => AssistSessionState.ExplicitPopup,
+            AssistSessionState.FixHint => AssistSessionState.FixPopup,
+            _ => State
+        };
+    }
+
+    /// <summary>
+    /// A Suggest-mode refresh landed, which closes the popup. Search, Help and Fix are untouched:
+    /// their popups are not owned by the ranking pass.
+    /// </summary>
+    public void ClosePopupAfterRefresh()
+    {
+        State = State switch
+        {
+            AssistSessionState.PassivePopup => AssistSessionState.PassiveBubble,
+            AssistSessionState.ExplicitPopup => AssistSessionState.ExplicitBubble,
+            _ => State
+        };
+    }
+
+    /// <summary>Dismisses the surface (Escape, or the host tearing the session down).</summary>
+    public void Dismiss() => State = AssistSessionState.Hidden;
+
+    /// <summary>The alt screen came up; the surface hides and the session ends.</summary>
+    /// <remarks>
+    /// Submission suppression deliberately survives: the alt screen says nothing about whether the
+    /// text on the input line was typed or pasted.
+    /// </remarks>
+    public void HideForAltScreen() => State = AssistSessionState.Hidden;
+
+    /// <summary>The user accepted a suggestion; the surface closes.</summary>
+    public void AcceptSelection() => State = AssistSessionState.Hidden;
+
+    /// <summary>
+    /// The command line was submitted. Ends the session and clears submission suppression - the next
+    /// line starts clean.
+    /// </summary>
+    public void CompleteSubmission()
+    {
+        IsCurrentSubmissionSuppressed = false;
+        State = AssistSessionState.Hidden;
+    }
+}

--- a/src/NovaTerminal.CommandAssist/Application/CapturePipeline.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CapturePipeline.cs
@@ -1,0 +1,247 @@
+using System;
+using System.Threading.Tasks;
+using NovaTerminal.CommandAssist.Domain;
+using NovaTerminal.CommandAssist.Models;
+using NovaTerminal.CommandAssist.ShellIntegration.Contracts;
+
+namespace NovaTerminal.CommandAssist.Application;
+
+/// <summary>
+/// Everything that turns a command the user ran into a history entry: the heuristic Enter-time
+/// capture, the structured OSC 133 capture, the dedup between the two, secret redaction, and the
+/// exit-code / duration patch that lands when the command finishes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// There are two capture paths because there are two kinds of session. When the shell is
+/// instrumented it tells us the command text it accepted, and that text is authoritative - it
+/// survives multi-line input, history recall and line editing. When it is not, all we have is the
+/// keystrokes we watched go by, so the Enter key is the trigger and the shadow query buffer is the
+/// source.
+/// </para>
+/// <para>
+/// The paths overlap for exactly one command. Structured capture only stands down the heuristic once
+/// <see cref="AssistSessionContext.HasObservedStructuredCommandCaptureMarker"/> is set, and that only
+/// becomes true when the first <c>CommandAccepted</c> arrives - which is after the first Enter. So
+/// the first command of an instrumented session is captured twice unless something notices, and the
+/// something is the pending-entry dedup below: an accepted command whose text matches the entry the
+/// heuristic path just wrote is dropped, and the finish event patches the heuristic entry instead.
+/// </para>
+/// <para>
+/// Capture is best-effort throughout. Every store call is wrapped: a history write must never take
+/// down the keystroke that triggered it.
+/// </para>
+/// </remarks>
+public sealed class CapturePipeline
+{
+    private readonly IHistoryStore _historyStore;
+    private readonly ISecretsFilter _secretsFilter;
+    private readonly AssistSessionContext _context;
+
+    private string? _pendingEntryId;
+    private string? _pendingCommandText;
+
+    public CapturePipeline(
+        IHistoryStore historyStore,
+        ISecretsFilter secretsFilter,
+        AssistSessionContext context)
+    {
+        _historyStore = historyStore;
+        _secretsFilter = secretsFilter;
+        _context = context;
+    }
+
+    /// <summary>The entry awaiting an exit code, if a capture is currently in flight.</summary>
+    internal string? PendingEntryId => _pendingEntryId;
+
+    /// <summary>
+    /// Heuristic capture: the user pressed Enter and we believe <paramref name="submission"/> is what
+    /// went to the shell.
+    /// </summary>
+    /// <param name="submission">The shadow query buffer contents.</param>
+    /// <param name="isSubmissionSuppressed">
+    /// Whether the session marked this submission untrustworthy (pasted rather than typed).
+    /// </param>
+    public async Task CaptureSubmissionAsync(string submission, bool isSubmissionSuppressed)
+    {
+        try
+        {
+            string trimmed = submission.Trim();
+            bool shouldPersist = !_context.IsAltScreenActive &&
+                                 !_context.IsStructuredCaptureActive &&
+                                 !isSubmissionSuppressed &&
+                                 !string.IsNullOrWhiteSpace(trimmed) &&
+                                 !trimmed.Contains('\n') &&
+                                 !trimmed.Contains('\r');
+
+            if (!shouldPersist)
+            {
+                return;
+            }
+
+            RedactionResult redaction = _secretsFilter.Redact(trimmed);
+            var entry = new CommandHistoryEntry(
+                Id: Guid.NewGuid().ToString("N"),
+                CommandText: redaction.RedactedText,
+                ExecutedAt: DateTimeOffset.UtcNow,
+                ShellKind: _context.ShellKind ?? "unknown",
+                WorkingDirectory: _context.WorkingDirectory,
+                ProfileId: _context.ProfileId,
+                SessionId: _context.SessionId,
+                HostId: _context.HostId,
+                ExitCode: null,
+                IsRemote: _context.IsRemote,
+                IsRedacted: redaction.WasRedacted,
+                Source: CommandCaptureSource.Heuristic,
+                DurationMs: null);
+
+            await _historyStore.AppendAsync(entry);
+            _pendingEntryId = entry.Id;
+            _pendingCommandText = NormalizeCommandText(trimmed);
+        }
+        catch
+        {
+            // Assist capture is best-effort; Enter should still reach the shell path even if persistence fails.
+        }
+    }
+
+    /// <summary>
+    /// Patches the pending entry with an exit code observed outside shell integration (the host's own
+    /// command-finished signal).
+    /// </summary>
+    public async Task CompleteSubmissionAsync(int? exitCode)
+    {
+        string? pendingEntryId = _pendingEntryId;
+        _pendingEntryId = null;
+        if (string.IsNullOrWhiteSpace(pendingEntryId))
+        {
+            return;
+        }
+
+        try
+        {
+            await _historyStore.TryUpdateExecutionResultAsync(pendingEntryId, exitCode, durationMs: null);
+        }
+        catch
+        {
+            // History metadata enrichment is best-effort only.
+        }
+    }
+
+    /// <summary>
+    /// Consumes a shell-integration event: records what it proves about the session, then runs the
+    /// structured capture or the completion patch it implies.
+    /// </summary>
+    public async Task HandleShellIntegrationEventAsync(ShellIntegrationEvent shellEvent)
+    {
+        if (shellEvent.WorkingDirectory != null)
+        {
+            _context.SetWorkingDirectory(shellEvent.WorkingDirectory);
+        }
+
+        if (shellEvent.Type is ShellIntegrationEventType.PromptReady or
+            ShellIntegrationEventType.CommandAccepted or
+            ShellIntegrationEventType.CommandStarted or
+            ShellIntegrationEventType.CommandFinished)
+        {
+            _context.ObserveShellIntegrationMarker();
+        }
+
+        if (shellEvent.Type is ShellIntegrationEventType.CommandAccepted)
+        {
+            _context.ObserveStructuredCommandCaptureMarker();
+        }
+
+        switch (shellEvent.Type)
+        {
+            case ShellIntegrationEventType.WorkingDirectoryChanged:
+            case ShellIntegrationEventType.PromptReady:
+            case ShellIntegrationEventType.CommandStarted:
+                return;
+
+            case ShellIntegrationEventType.CommandAccepted:
+                await CaptureAcceptedCommandAsync(shellEvent);
+                return;
+
+            case ShellIntegrationEventType.CommandFinished:
+                await CompleteAcceptedCommandAsync(shellEvent);
+                return;
+        }
+    }
+
+    private async Task CaptureAcceptedCommandAsync(ShellIntegrationEvent shellEvent)
+    {
+        if (!_context.IsShellIntegrationEnabled || _context.IsAltScreenActive)
+        {
+            return;
+        }
+
+        string commandText = shellEvent.CommandText?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(commandText))
+        {
+            return;
+        }
+
+        // The first-command double-capture guard: the heuristic path already wrote this exact command
+        // moments ago, so let its entry stand and let CommandFinished patch that one.
+        string normalizedCommandText = NormalizeCommandText(commandText);
+        if (!string.IsNullOrWhiteSpace(_pendingEntryId) &&
+            string.Equals(_pendingCommandText, normalizedCommandText, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        try
+        {
+            RedactionResult redaction = _secretsFilter.Redact(commandText);
+            var entry = new CommandHistoryEntry(
+                Id: Guid.NewGuid().ToString("N"),
+                CommandText: redaction.RedactedText,
+                ExecutedAt: shellEvent.Timestamp,
+                ShellKind: _context.ShellKind ?? "unknown",
+                WorkingDirectory: shellEvent.WorkingDirectory ?? _context.WorkingDirectory,
+                ProfileId: _context.ProfileId,
+                SessionId: _context.SessionId,
+                HostId: _context.HostId,
+                ExitCode: null,
+                IsRemote: _context.IsRemote,
+                IsRedacted: redaction.WasRedacted,
+                Source: CommandCaptureSource.ShellIntegration,
+                DurationMs: null);
+
+            await _historyStore.AppendAsync(entry);
+            _pendingEntryId = entry.Id;
+            _pendingCommandText = normalizedCommandText;
+        }
+        catch
+        {
+            // Structured capture is best-effort and must not affect shell execution.
+        }
+    }
+
+    private async Task CompleteAcceptedCommandAsync(ShellIntegrationEvent shellEvent)
+    {
+        string? pendingEntryId = _pendingEntryId;
+        if (string.IsNullOrWhiteSpace(pendingEntryId))
+        {
+            return;
+        }
+
+        long? durationMs = shellEvent.Duration.HasValue
+            ? (long)Math.Round(shellEvent.Duration.Value.TotalMilliseconds)
+            : null;
+
+        try
+        {
+            await _historyStore.TryUpdateExecutionResultAsync(pendingEntryId, shellEvent.ExitCode, durationMs);
+            _pendingEntryId = null;
+            _pendingCommandText = null;
+        }
+        catch
+        {
+            // Structured metadata updates are best-effort only.
+        }
+    }
+
+    private static string NormalizeCommandText(string commandText) => commandText.Trim();
+}

--- a/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
@@ -10,41 +10,25 @@ using NovaTerminal.CommandAssist.ViewModels;
 
 namespace NovaTerminal.CommandAssist.Application;
 
+/// <summary>
+/// The facade the terminal pane talks to. It owns the assist view-model and the selected-row list,
+/// and delegates everything else to three collaborators:
+/// <see cref="AssistSessionStateMachine"/> (what the session is doing),
+/// <see cref="CapturePipeline"/> (turning commands into history) and
+/// <see cref="SuggestionOrchestrator"/> (producing ranked rows).
+/// </summary>
+/// <remarks>
+/// <see cref="AssistSessionContext"/> carries the environment all three share. The controller keeps
+/// the view-model writes because presentation is the facade's job: the state machine says the
+/// session is in an explicit Suggest session, the controller decides that means the bubble is up and
+/// the popup is not.
+/// </remarks>
 public sealed class CommandAssistController
 {
-    /// <summary>Rows the popup/bubble shows. M4.2's hard-coded cap; Phase 3 replaces it with scrolling.</summary>
-    private const int MaxDisplayedSuggestions = 5;
-
-    /// <summary>
-    /// How many history candidates the ranking engine gets to choose from for a text query.
-    /// </summary>
-    /// <remarks>
-    /// Wider than <see cref="MaxDisplayedSuggestions"/> on purpose. The store used to pre-rank with
-    /// its own scoring function and hand back its own top five, so the engine only ever re-ordered
-    /// a set the store had already picked. Now the store is a recall gate that truncates by
-    /// recency, so it has to hand over enough rows for the engine's cwd / shell / profile / exit-code
-    /// signals to matter - otherwise a relevant-but-older command could never reach the list.
-    /// Empty-query recall stays at the display cap: with no text to score, "most recent five" is
-    /// already the answer, and widening it would let the frequency signal outrank recency.
-    /// </remarks>
-    private const int HistoryCandidatePoolSize = 50;
-
-    private bool _isAltScreenActive;
-    private string? _workingDirectory;
-    private string? _shellKind;
-    private string? _profileId;
-    private string? _sessionId;
-    private string? _hostId;
-    private bool _isRemote;
-    private bool _isShellIntegrationEnabled;
-    private bool _hasObservedShellIntegrationMarker;
-    private bool _hasObservedStructuredCommandCaptureMarker;
-    private bool _ignoreCurrentSubmission;
-    private bool _isExplicitAssistSession;
-    private int _refreshVersion;
-    private string? _pendingHistoryEntryId;
-    private string? _pendingHistoryCommandText;
-    private CommandAssistMode _currentMode = CommandAssistMode.Suggest;
+    private readonly AssistSessionStateMachine _state = new();
+    private readonly AssistSessionContext _context = new();
+    private readonly CapturePipeline _capturePipeline;
+    private readonly SuggestionOrchestrator _suggestionOrchestrator;
     private readonly List<AssistSuggestion> _suggestions = new();
     private readonly Action<Action> _dispatch;
     private readonly ICommandDocsProvider _commandDocsProvider;
@@ -76,6 +60,14 @@ public sealed class CommandAssistController
         _resultBuilder = resultBuilder ?? new CommandAssistResultBuilder();
         ViewModel = new CommandAssistBarViewModel();
         _dispatch = dispatch ?? (action => action());
+        _capturePipeline = new CapturePipeline(historyStore, secretsFilter, _context);
+        _suggestionOrchestrator = new SuggestionOrchestrator(
+            historyStore,
+            snippetStore,
+            suggestionEngine,
+            _context,
+            _dispatch,
+            ApplyRefreshOutcome);
     }
 
     public IHistoryStore HistoryStore { get; }
@@ -85,19 +77,20 @@ public sealed class CommandAssistController
     public CommandAssistBarViewModel ViewModel { get; }
     public IReadOnlyList<AssistSuggestion> Suggestions => _suggestions;
 
+    /// <summary>What the session is doing right now. Exposed for diagnostics and tests.</summary>
+    public AssistSessionState SessionState => _state.State;
+
     public void ToggleAssist()
     {
-        if (_isAltScreenActive)
+        if (_context.IsAltScreenActive)
         {
             ViewModel.IsVisible = false;
             return;
         }
 
-        _currentMode = CommandAssistMode.Suggest;
+        bool nextVisible = _state.ToggleSession(ViewModel.IsVisible) != AssistSessionState.Hidden;
         ViewModel.ModeLabel = "Suggest";
         ViewModel.IsPopupOpen = false;
-        bool nextVisible = !ViewModel.IsVisible;
-        _isExplicitAssistSession = nextVisible;
         ViewModel.IsVisible = nextVisible;
         if (nextVisible)
         {
@@ -107,14 +100,13 @@ public sealed class CommandAssistController
 
     public bool OpenHistorySearch()
     {
-        if (_isAltScreenActive)
+        if (_context.IsAltScreenActive)
         {
             ViewModel.IsVisible = false;
             return false;
         }
 
-        _isExplicitAssistSession = true;
-        _currentMode = CommandAssistMode.Search;
+        _state.OpenSearch();
         ViewModel.ModeLabel = "History";
         ViewModel.IsPopupOpen = true;
         ViewModel.IsVisible = true;
@@ -124,7 +116,7 @@ public sealed class CommandAssistController
 
     public bool OpenHelp()
     {
-        if (_isAltScreenActive)
+        if (_context.IsAltScreenActive)
         {
             ViewModel.IsVisible = false;
             return false;
@@ -136,13 +128,12 @@ public sealed class CommandAssistController
 
     public void HandleTextInput(string text)
     {
-        if (_isAltScreenActive || string.IsNullOrEmpty(text))
+        if (_context.IsAltScreenActive || string.IsNullOrEmpty(text))
         {
             return;
         }
 
-        _ignoreCurrentSubmission = false;
-        _currentMode = CommandAssistMode.Suggest;
+        _state.ObserveTypedInput();
         ViewModel.QueryText += text;
         ViewModel.ModeLabel = "Suggest";
         ViewModel.IsPopupOpen = false;
@@ -152,7 +143,7 @@ public sealed class CommandAssistController
 
     public void HandleBackspace()
     {
-        if (_isAltScreenActive || string.IsNullOrEmpty(ViewModel.QueryText))
+        if (_context.IsAltScreenActive || string.IsNullOrEmpty(ViewModel.QueryText))
         {
             return;
         }
@@ -163,13 +154,11 @@ public sealed class CommandAssistController
 
     public void HandlePastedText(string text)
     {
-        _ignoreCurrentSubmission = true;
-        _isExplicitAssistSession = false;
-        _currentMode = CommandAssistMode.Suggest;
+        _state.ObservePastedText();
         ViewModel.QueryText = text ?? string.Empty;
         ViewModel.ModeLabel = "Suggest";
         ViewModel.IsPopupOpen = false;
-        ViewModel.IsVisible = !_isAltScreenActive && ViewModel.HasSuggestions;
+        ViewModel.IsVisible = !_context.IsAltScreenActive && ViewModel.HasSuggestions;
         QueueRefreshSuggestions();
     }
 
@@ -177,40 +166,9 @@ public sealed class CommandAssistController
     {
         try
         {
-            string submission = ViewModel.QueryText.Trim();
-            bool shouldPersist = !_isAltScreenActive &&
-                                 !IsStructuredShellIntegrationActive() &&
-                                 !_ignoreCurrentSubmission &&
-                                 !string.IsNullOrWhiteSpace(submission) &&
-                                 !submission.Contains('\n') &&
-                                 !submission.Contains('\r');
-
-            if (shouldPersist)
-            {
-                RedactionResult redaction = SecretsFilter.Redact(submission);
-                var entry = new CommandHistoryEntry(
-                    Id: Guid.NewGuid().ToString("N"),
-                    CommandText: redaction.RedactedText,
-                    ExecutedAt: DateTimeOffset.UtcNow,
-                    ShellKind: _shellKind ?? "unknown",
-                    WorkingDirectory: _workingDirectory,
-                    ProfileId: _profileId,
-                    SessionId: _sessionId,
-                    HostId: _hostId,
-                    ExitCode: null,
-                    IsRemote: _isRemote,
-                    IsRedacted: redaction.WasRedacted,
-                    Source: CommandCaptureSource.Heuristic,
-                    DurationMs: null);
-
-                await HistoryStore.AppendAsync(entry);
-                _pendingHistoryEntryId = entry.Id;
-                _pendingHistoryCommandText = NormalizeCommandText(submission);
-            }
-        }
-        catch
-        {
-            // Assist capture is best-effort; Enter should still reach the shell path even if persistence fails.
+            await _capturePipeline.CaptureSubmissionAsync(
+                ViewModel.QueryText,
+                _state.IsCurrentSubmissionSuppressed);
         }
         finally
         {
@@ -227,44 +185,28 @@ public sealed class CommandAssistController
         bool isRemote,
         bool isShellIntegrated = false)
     {
-        _shellKind = shellKind;
-        _workingDirectory = workingDirectory;
-        _profileId = profileId;
-        _sessionId = sessionId;
-        _hostId = hostId;
-        _isRemote = isRemote;
-        _isShellIntegrationEnabled = isShellIntegrated;
-        _hasObservedShellIntegrationMarker = _hasObservedShellIntegrationMarker && isShellIntegrated;
-        _hasObservedStructuredCommandCaptureMarker = _hasObservedStructuredCommandCaptureMarker && isShellIntegrated;
+        _context.UpdateSession(
+            shellKind,
+            workingDirectory,
+            profileId,
+            sessionId,
+            hostId,
+            isRemote,
+            isShellIntegrated);
     }
 
     public void SetShellIntegrationEnabled(bool isEnabled)
     {
-        _isShellIntegrationEnabled = isEnabled;
-        if (!isEnabled)
-        {
-            _hasObservedShellIntegrationMarker = false;
-            _hasObservedStructuredCommandCaptureMarker = false;
-        }
+        _context.SetShellIntegrationEnabled(isEnabled);
     }
 
     public void Dismiss()
     {
-        CancelPendingRefreshes();
-        _isExplicitAssistSession = false;
-        _currentMode = CommandAssistMode.Suggest;
+        _suggestionOrchestrator.CancelPending();
+        _state.Dismiss();
         ViewModel.IsVisible = false;
         ViewModel.IsPopupOpen = false;
-        ViewModel.TopSuggestionText = string.Empty;
-        ViewModel.SelectedIndex = -1;
-        ViewModel.SelectedBadgesText = string.Empty;
-        ViewModel.SelectedMetadataText = string.Empty;
-        ViewModel.SelectedDescriptionText = string.Empty;
-        ViewModel.EmptyStateText = string.Empty;
-        ViewModel.ShowEmptyState = false;
-        ViewModel.HasSuggestions = false;
-        ViewModel.Suggestions.Clear();
-        _suggestions.Clear();
+        ClearSuggestionSurface();
     }
 
     public bool HandleEscape()
@@ -309,7 +251,7 @@ public sealed class CommandAssistController
     public bool TryGetInsertionText(out string? insertionText)
     {
         AssistSuggestion? selected = GetSelectedSuggestion();
-        if (selected == null || _ignoreCurrentSubmission || _isAltScreenActive)
+        if (selected == null || _state.IsCurrentSubmissionSuppressed || _context.IsAltScreenActive)
         {
             insertionText = null;
             return false;
@@ -327,8 +269,7 @@ public sealed class CommandAssistController
         }
 
         ViewModel.QueryText = insertionText;
-        _isExplicitAssistSession = false;
-        _currentMode = CommandAssistMode.Suggest;
+        _state.AcceptSelection();
         ViewModel.ModeLabel = "Suggest";
         ViewModel.IsPopupOpen = false;
         Dismiss();
@@ -345,32 +286,20 @@ public sealed class CommandAssistController
 
     public async Task HandleCommandFinishedAsync(int? exitCode)
     {
-        string? pendingEntryId = _pendingHistoryEntryId;
-        _pendingHistoryEntryId = null;
-        if (string.IsNullOrWhiteSpace(pendingEntryId))
-        {
-            return;
-        }
-
-        try
-        {
-            await HistoryStore.TryUpdateExecutionResultAsync(pendingEntryId, exitCode, durationMs: null);
-        }
-        catch
-        {
-            // History metadata enrichment is best-effort only.
-        }
+        await _capturePipeline.CompleteSubmissionAsync(exitCode);
     }
 
     public async Task<bool> OpenHelpAsync(string? queryText = null, string? selectedText = null)
     {
-        if (_isAltScreenActive)
+        if (_context.IsAltScreenActive)
         {
             ViewModel.IsVisible = false;
             return false;
         }
 
-        CommandAssistContextSnapshot snapshot = CreateContextSnapshot(queryText, selectedText);
+        CommandAssistContextSnapshot snapshot = _context.CreateSnapshot(
+            queryText ?? ViewModel.QueryText,
+            selectedText);
         var helpQuery = new CommandHelpQuery(
             RawInput: snapshot.QueryText,
             CommandToken: snapshot.RecognizedCommand,
@@ -409,7 +338,7 @@ public sealed class CommandAssistController
 
     public async Task<bool> HandleCommandFailureAsync(CommandFailureContext context)
     {
-        if (_isAltScreenActive)
+        if (_context.IsAltScreenActive)
         {
             ViewModel.IsVisible = false;
             return false;
@@ -447,39 +376,7 @@ public sealed class CommandAssistController
 
     public async Task HandleShellIntegrationEventAsync(ShellIntegrationEvent shellEvent)
     {
-        if (shellEvent.WorkingDirectory != null)
-        {
-            _workingDirectory = shellEvent.WorkingDirectory;
-        }
-
-        if (shellEvent.Type is ShellIntegrationEventType.PromptReady or
-            ShellIntegrationEventType.CommandAccepted or
-            ShellIntegrationEventType.CommandStarted or
-            ShellIntegrationEventType.CommandFinished)
-        {
-            _hasObservedShellIntegrationMarker = true;
-        }
-
-        if (shellEvent.Type is ShellIntegrationEventType.CommandAccepted)
-        {
-            _hasObservedStructuredCommandCaptureMarker = true;
-        }
-
-        switch (shellEvent.Type)
-        {
-            case ShellIntegrationEventType.WorkingDirectoryChanged:
-            case ShellIntegrationEventType.PromptReady:
-            case ShellIntegrationEventType.CommandStarted:
-                return;
-
-            case ShellIntegrationEventType.CommandAccepted:
-                await HandleShellIntegratedCommandAcceptedAsync(shellEvent);
-                return;
-
-            case ShellIntegrationEventType.CommandFinished:
-                await HandleShellIntegratedCommandFinishedAsync(shellEvent);
-                return;
-        }
+        await _capturePipeline.HandleShellIntegrationEventAsync(shellEvent);
     }
 
     public async Task<bool> TogglePinSelectionAsync()
@@ -502,7 +399,7 @@ public sealed class CommandAssistController
             CommandSnippet? existing = snippets.FirstOrDefault(x => x.Id == selected.Id) ??
                                        snippets.FirstOrDefault(x =>
                                            string.Equals(x.CommandText, selected.InsertText, StringComparison.OrdinalIgnoreCase) &&
-                                           string.Equals(x.ShellKind ?? string.Empty, _shellKind ?? string.Empty, StringComparison.OrdinalIgnoreCase));
+                                           string.Equals(x.ShellKind ?? string.Empty, _context.ShellKind ?? string.Empty, StringComparison.OrdinalIgnoreCase));
 
             if (existing != null)
             {
@@ -519,8 +416,8 @@ public sealed class CommandAssistController
                     Name: selected.DisplayText,
                     CommandText: selected.InsertText,
                     Description: selected.Description,
-                    ShellKind: _shellKind,
-                    WorkingDirectory: _workingDirectory,
+                    ShellKind: _context.ShellKind,
+                    WorkingDirectory: _context.WorkingDirectory,
                     IsPinned: true,
                     CreatedAt: DateTimeOffset.UtcNow,
                     LastUsedAt: selected.LastUsedAt);
@@ -539,137 +436,78 @@ public sealed class CommandAssistController
 
     public void HandleAltScreenChanged(bool isAltScreenActive)
     {
-        _isAltScreenActive = isAltScreenActive;
-        if (isAltScreenActive)
-        {
-            CancelPendingRefreshes();
-            _isExplicitAssistSession = false;
-            _currentMode = CommandAssistMode.Suggest;
-            ViewModel.IsVisible = false;
-            ViewModel.IsPopupOpen = false;
-            ViewModel.TopSuggestionText = string.Empty;
-            ViewModel.SelectedIndex = -1;
-            ViewModel.SelectedBadgesText = string.Empty;
-            ViewModel.SelectedMetadataText = string.Empty;
-            ViewModel.SelectedDescriptionText = string.Empty;
-            ViewModel.EmptyStateText = string.Empty;
-            ViewModel.ShowEmptyState = false;
-            ViewModel.HasSuggestions = false;
-            ViewModel.Suggestions.Clear();
-            _suggestions.Clear();
-        }
-    }
-
-    private void QueueRefreshSuggestions()
-    {
-        if (_currentMode is not (CommandAssistMode.Suggest or CommandAssistMode.Search))
+        _context.SetAltScreenActive(isAltScreenActive);
+        if (!isAltScreenActive)
         {
             return;
         }
 
-        int refreshVersion = Interlocked.Increment(ref _refreshVersion);
-        CommandAssistMode requestedMode = _currentMode;
-        string query = ViewModel.QueryText;
-        SuggestionScope scope = ResolveSuggestionScope(requestedMode);
-        var context = new CommandAssistQueryContext(
-            query,
-            _workingDirectory,
-            _shellKind,
-            _profileId,
-            _isRemote,
-            IncludeHistorySuggestions: scope.IncludeHistory,
-            IncludeSnippetSuggestions: scope.IncludeSnippets,
-            IncludePathSuggestions: scope.IncludePaths);
-        _ = RefreshSuggestionsAsync(query, context, refreshVersion, requestedMode);
+        _suggestionOrchestrator.CancelPending();
+        _state.HideForAltScreen();
+        ViewModel.IsVisible = false;
+        ViewModel.IsPopupOpen = false;
+        ClearSuggestionSurface();
     }
 
-    private async Task RefreshSuggestionsAsync(
-        string query,
-        CommandAssistQueryContext context,
-        int refreshVersion,
-        CommandAssistMode requestedMode)
+    private void QueueRefreshSuggestions()
     {
-        try
+        if (!_state.AllowsSuggestionRefresh)
         {
-            IReadOnlyList<AssistSuggestion> suggestions = await Task.Run(async () =>
-            {
-                IReadOnlyList<CommandHistoryEntry> history = Array.Empty<CommandHistoryEntry>();
-                if (context.IncludeHistorySuggestions)
-                {
-                    history = string.IsNullOrWhiteSpace(query)
-                        ? await HistoryStore.GetRecentAsync(MaxDisplayedSuggestions).ConfigureAwait(false)
-                        : await HistoryStore.SearchAsync(query, HistoryCandidatePoolSize).ConfigureAwait(false);
-                }
-
-                IReadOnlyList<CommandSnippet> snippets = Array.Empty<CommandSnippet>();
-                if (context.IncludeSnippetSuggestions && SnippetStore != null)
-                {
-                    snippets = await SnippetStore.GetAllAsync().ConfigureAwait(false);
-                }
-
-                return SuggestionEngine.GetSuggestions(history, snippets, context, MaxDisplayedSuggestions);
-            }).ConfigureAwait(false);
-
-            _dispatch(() =>
-            {
-                if (refreshVersion != _refreshVersion || _currentMode != requestedMode)
-                {
-                    return;
-                }
-
-                _suggestions.Clear();
-                _suggestions.AddRange(suggestions);
-                ViewModel.SelectedIndex = suggestions.Count > 0 ? 0 : -1;
-                ViewModel.EmptyStateText = string.Empty;
-                ViewModel.ShowEmptyState = false;
-                SyncSuggestionViewModel();
-                if (requestedMode == CommandAssistMode.Suggest)
-                {
-                    ViewModel.IsPopupOpen = false;
-                    ViewModel.IsVisible = _isExplicitAssistSession || suggestions.Count > 0;
-                }
-            });
+            return;
         }
-        catch
-        {
-            _dispatch(() =>
-            {
-                if (refreshVersion != _refreshVersion || _currentMode != requestedMode)
-                {
-                    return;
-                }
 
-                _suggestions.Clear();
-                ViewModel.TopSuggestionText = string.Empty;
-                ViewModel.SelectedIndex = -1;
-                ViewModel.SelectedBadgesText = string.Empty;
-                ViewModel.SelectedMetadataText = string.Empty;
-                ViewModel.SelectedDescriptionText = string.Empty;
-                ViewModel.EmptyStateText = string.Empty;
-                ViewModel.ShowEmptyState = false;
-                ViewModel.HasSuggestions = false;
-                ViewModel.Suggestions.Clear();
-                if (requestedMode == CommandAssistMode.Suggest)
-                {
-                    ViewModel.IsPopupOpen = false;
-                    ViewModel.IsVisible = _isExplicitAssistSession;
-                }
-            });
-        }
+        _suggestionOrchestrator.Refresh(_state.Mode, _state.IsExplicitSession, ViewModel.QueryText);
     }
 
-    private void CancelPendingRefreshes()
+    /// <summary>
+    /// Applies a ranking pass on the dispatcher thread. Outcomes for a mode the session has already
+    /// left are dropped: the orchestrator's cancellation covers superseded queries, this covers a
+    /// pass that was in flight when Help or Fix took the surface over.
+    /// </summary>
+    private void ApplyRefreshOutcome(SuggestionRefreshOutcome outcome)
     {
-        Interlocked.Increment(ref _refreshVersion);
+        if (_state.Mode != outcome.RequestedMode)
+        {
+            return;
+        }
+
+        if (outcome.Faulted)
+        {
+            ClearSuggestionSurface();
+        }
+        else
+        {
+            _suggestions.Clear();
+            _suggestions.AddRange(outcome.Suggestions);
+            ViewModel.SelectedIndex = _suggestions.Count > 0 ? 0 : -1;
+            ViewModel.EmptyStateText = string.Empty;
+            ViewModel.ShowEmptyState = false;
+            SyncSuggestionViewModel();
+        }
+
+        if (outcome.RequestedMode != CommandAssistMode.Suggest)
+        {
+            return;
+        }
+
+        _state.ClosePopupAfterRefresh();
+        ViewModel.IsPopupOpen = false;
+        ViewModel.IsVisible = _state.IsExplicitSession || _suggestions.Count > 0;
     }
 
     private void ResetSubmissionState()
     {
-        CancelPendingRefreshes();
-        _ignoreCurrentSubmission = false;
-        _isExplicitAssistSession = false;
+        _suggestionOrchestrator.CancelPending();
+        _state.CompleteSubmission();
         ViewModel.QueryText = string.Empty;
         ViewModel.IsPopupOpen = false;
+        ClearSuggestionSurface();
+        ViewModel.IsVisible = false;
+    }
+
+    /// <summary>Empties every row-derived view-model field and the backing suggestion list.</summary>
+    private void ClearSuggestionSurface()
+    {
         ViewModel.TopSuggestionText = string.Empty;
         ViewModel.SelectedIndex = -1;
         ViewModel.SelectedBadgesText = string.Empty;
@@ -679,7 +517,6 @@ public sealed class CommandAssistController
         ViewModel.ShowEmptyState = false;
         ViewModel.HasSuggestions = false;
         ViewModel.Suggestions.Clear();
-        ViewModel.IsVisible = false;
         _suggestions.Clear();
     }
 
@@ -693,6 +530,7 @@ public sealed class CommandAssistController
         ViewModel.SelectedIndex = index;
         if (!ViewModel.IsPopupOpen)
         {
+            _state.OpenPopupForSelection();
             ViewModel.IsPopupOpen = true;
         }
 
@@ -752,23 +590,6 @@ public sealed class CommandAssistController
         return string.Join("  |  ", parts);
     }
 
-    private CommandAssistContextSnapshot CreateContextSnapshot(string? queryText, string? selectedText)
-    {
-        string effectiveQuery = queryText ?? ViewModel.QueryText;
-        string recognizedSource = string.IsNullOrWhiteSpace(effectiveQuery) ? selectedText ?? string.Empty : effectiveQuery;
-
-        return new CommandAssistContextSnapshot(
-            QueryText: effectiveQuery,
-            RecognizedCommand: RecognizedCommandParser.ParsePrimaryCommand(recognizedSource),
-            ShellKind: _shellKind,
-            WorkingDirectory: _workingDirectory,
-            ProfileId: _profileId,
-            SessionId: _sessionId,
-            HostId: _hostId,
-            IsRemote: _isRemote,
-            SelectedText: selectedText);
-    }
-
     private void ApplyHelperSuggestions(
         CommandAssistMode mode,
         string? queryText,
@@ -776,9 +597,8 @@ public sealed class CommandAssistController
         string emptyStateText,
         bool openPopup)
     {
-        CancelPendingRefreshes();
-        _isExplicitAssistSession = false;
-        _currentMode = mode;
+        _suggestionOrchestrator.CancelPending();
+        _state.EnterHelperMode(mode, openPopup);
         ViewModel.ModeLabel = mode.ToString();
         ViewModel.QueryText = queryText ?? string.Empty;
         ViewModel.IsPopupOpen = openPopup;
@@ -791,125 +611,6 @@ public sealed class CommandAssistController
         ViewModel.SelectedIndex = suggestions.Count > 0 ? 0 : -1;
         SyncSuggestionViewModel();
     }
-
-    private async Task HandleShellIntegratedCommandAcceptedAsync(ShellIntegrationEvent shellEvent)
-    {
-        if (!_isShellIntegrationEnabled || _isAltScreenActive)
-        {
-            return;
-        }
-
-        string commandText = shellEvent.CommandText?.Trim() ?? string.Empty;
-        if (string.IsNullOrWhiteSpace(commandText))
-        {
-            return;
-        }
-
-        string normalizedCommandText = NormalizeCommandText(commandText);
-        if (!string.IsNullOrWhiteSpace(_pendingHistoryEntryId) &&
-            string.Equals(_pendingHistoryCommandText, normalizedCommandText, StringComparison.Ordinal))
-        {
-            return;
-        }
-
-        try
-        {
-            RedactionResult redaction = SecretsFilter.Redact(commandText);
-            var entry = new CommandHistoryEntry(
-                Id: Guid.NewGuid().ToString("N"),
-                CommandText: redaction.RedactedText,
-                ExecutedAt: shellEvent.Timestamp,
-                ShellKind: _shellKind ?? "unknown",
-                WorkingDirectory: shellEvent.WorkingDirectory ?? _workingDirectory,
-                ProfileId: _profileId,
-                SessionId: _sessionId,
-                HostId: _hostId,
-                ExitCode: null,
-                IsRemote: _isRemote,
-                IsRedacted: redaction.WasRedacted,
-                Source: CommandCaptureSource.ShellIntegration,
-                DurationMs: null);
-
-            await HistoryStore.AppendAsync(entry);
-            _pendingHistoryEntryId = entry.Id;
-            _pendingHistoryCommandText = normalizedCommandText;
-        }
-        catch
-        {
-            // Structured capture is best-effort and must not affect shell execution.
-        }
-    }
-
-    private async Task HandleShellIntegratedCommandFinishedAsync(ShellIntegrationEvent shellEvent)
-    {
-        string? pendingEntryId = _pendingHistoryEntryId;
-        if (string.IsNullOrWhiteSpace(pendingEntryId))
-        {
-            return;
-        }
-
-        long? durationMs = shellEvent.Duration.HasValue
-            ? (long)Math.Round(shellEvent.Duration.Value.TotalMilliseconds)
-            : null;
-
-        try
-        {
-            await HistoryStore.TryUpdateExecutionResultAsync(pendingEntryId, shellEvent.ExitCode, durationMs);
-            _pendingHistoryEntryId = null;
-            _pendingHistoryCommandText = null;
-        }
-        catch
-        {
-            // Structured metadata updates are best-effort only.
-        }
-    }
-
-    private bool IsStructuredShellIntegrationActive()
-    {
-        return _isShellIntegrationEnabled && _hasObservedStructuredCommandCaptureMarker;
-    }
-
-    private SuggestionScope ResolveSuggestionScope(CommandAssistMode requestedMode)
-    {
-        if (requestedMode == CommandAssistMode.Search)
-        {
-            return new SuggestionScope(
-                IncludeHistory: true,
-                IncludeSnippets: false,
-                IncludePaths: false);
-        }
-
-        if (requestedMode == CommandAssistMode.Suggest && _isExplicitAssistSession)
-        {
-            return new SuggestionScope(
-                IncludeHistory: true,
-                IncludeSnippets: true,
-                IncludePaths: true);
-        }
-
-        if (requestedMode == CommandAssistMode.Suggest)
-        {
-            return new SuggestionScope(
-                IncludeHistory: false,
-                IncludeSnippets: false,
-                IncludePaths: true);
-        }
-
-        return new SuggestionScope(
-            IncludeHistory: false,
-            IncludeSnippets: false,
-            IncludePaths: false);
-    }
-
-    private static string NormalizeCommandText(string commandText)
-    {
-        return commandText.Trim();
-    }
-
-    private readonly record struct SuggestionScope(
-        bool IncludeHistory,
-        bool IncludeSnippets,
-        bool IncludePaths);
 
     private sealed class EmptyCommandDocsProvider : ICommandDocsProvider
     {

--- a/src/NovaTerminal.CommandAssist/Application/SuggestionOrchestrator.cs
+++ b/src/NovaTerminal.CommandAssist/Application/SuggestionOrchestrator.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NovaTerminal.CommandAssist.Domain;
+using NovaTerminal.CommandAssist.Models;
+
+namespace NovaTerminal.CommandAssist.Application;
+
+/// <summary>
+/// Turns "the query changed" into a ranked list: resolves which sources are in scope for the current
+/// session, fetches candidates off the UI thread, ranks them with the one suggestion engine, and
+/// hands the result back through the dispatcher - unless a newer pass has superseded it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Staleness is handled with a <see cref="CancellationTokenSource"/> per pass: queueing a refresh
+/// cancels the one before it, and an outcome whose token is cancelled is dropped instead of applied.
+/// This replaces the interlocked <c>_refreshVersion</c> counter that used to serve the same purpose;
+/// the behavior is identical, but the mechanism is one Phase 3 can hang a debounce off and Phase 1
+/// can thread into the stores. Note that the token is deliberately <em>not</em> passed to the store
+/// or engine calls yet: cancelling work already in flight is a behavior change, and this pass is a
+/// mechanism swap only.
+/// </para>
+/// <para>
+/// There is no debounce here. Phase 3 owns that policy decision.
+/// </para>
+/// </remarks>
+public sealed class SuggestionOrchestrator
+{
+    /// <summary>Rows the popup/bubble shows. M4.2's hard-coded cap; Phase 3 replaces it with scrolling.</summary>
+    public const int MaxDisplayedSuggestions = 5;
+
+    /// <summary>
+    /// How many history candidates the ranking engine gets to choose from for a text query.
+    /// </summary>
+    /// <remarks>
+    /// Wider than <see cref="MaxDisplayedSuggestions"/> on purpose. The store used to pre-rank with
+    /// its own scoring function and hand back its own top five, so the engine only ever re-ordered
+    /// a set the store had already picked. Now the store is a recall gate that truncates by
+    /// recency, so it has to hand over enough rows for the engine's cwd / shell / profile / exit-code
+    /// signals to matter - otherwise a relevant-but-older command could never reach the list.
+    /// Empty-query recall stays at the display cap: with no text to score, "most recent five" is
+    /// already the answer, and widening it would let the frequency signal outrank recency.
+    /// </remarks>
+    private const int HistoryCandidatePoolSize = 50;
+
+    private readonly IHistoryStore _historyStore;
+    private readonly ISnippetStore? _snippetStore;
+    private readonly ISuggestionEngine _suggestionEngine;
+    private readonly AssistSessionContext _context;
+    private readonly Action<Action> _dispatch;
+    private readonly Action<SuggestionRefreshOutcome> _applyOutcome;
+
+    private CancellationTokenSource? _refreshCts;
+
+    public SuggestionOrchestrator(
+        IHistoryStore historyStore,
+        ISnippetStore? snippetStore,
+        ISuggestionEngine suggestionEngine,
+        AssistSessionContext context,
+        Action<Action> dispatch,
+        Action<SuggestionRefreshOutcome> applyOutcome)
+    {
+        _historyStore = historyStore;
+        _snippetStore = snippetStore;
+        _suggestionEngine = suggestionEngine;
+        _context = context;
+        _dispatch = dispatch;
+        _applyOutcome = applyOutcome;
+    }
+
+    /// <summary>
+    /// Queues a ranking pass for <paramref name="query"/>, superseding any pass still in flight.
+    /// Returns immediately; the outcome arrives through the dispatcher.
+    /// </summary>
+    public void Refresh(CommandAssistMode requestedMode, bool isExplicitSession, string query)
+    {
+        CancellationToken token = BeginPass();
+        SuggestionScope scope = ResolveScope(requestedMode, isExplicitSession);
+        var queryContext = new CommandAssistQueryContext(
+            query,
+            _context.WorkingDirectory,
+            _context.ShellKind,
+            _context.ProfileId,
+            _context.IsRemote,
+            IncludeHistorySuggestions: scope.IncludeHistory,
+            IncludeSnippetSuggestions: scope.IncludeSnippets,
+            IncludePathSuggestions: scope.IncludePaths);
+
+        _ = RunPassAsync(query, queryContext, requestedMode, token);
+    }
+
+    /// <summary>
+    /// Cancels the pass in flight, if any, so its result is never applied. Used wherever the surface
+    /// is torn down or replaced by content the ranking pass must not overwrite.
+    /// </summary>
+    public void CancelPending()
+    {
+        CancellationTokenSource? previous = Interlocked.Exchange(ref _refreshCts, null);
+        Cancel(previous);
+    }
+
+    private CancellationToken BeginPass()
+    {
+        var next = new CancellationTokenSource();
+        CancellationTokenSource? previous = Interlocked.Exchange(ref _refreshCts, next);
+        Cancel(previous);
+        return next.Token;
+    }
+
+    private static void Cancel(CancellationTokenSource? source)
+    {
+        if (source == null)
+        {
+            return;
+        }
+
+        source.Cancel();
+
+        // Safe to dispose while an in-flight pass still holds the token: reading
+        // CancellationToken.IsCancellationRequested does not throw after the source is disposed, and
+        // nothing here registers callbacks or touches the wait handle.
+        source.Dispose();
+    }
+
+    private async Task RunPassAsync(
+        string query,
+        CommandAssistQueryContext queryContext,
+        CommandAssistMode requestedMode,
+        CancellationToken token)
+    {
+        try
+        {
+            IReadOnlyList<AssistSuggestion> suggestions = await Task.Run(async () =>
+            {
+                IReadOnlyList<CommandHistoryEntry> history = Array.Empty<CommandHistoryEntry>();
+                if (queryContext.IncludeHistorySuggestions)
+                {
+                    history = string.IsNullOrWhiteSpace(query)
+                        ? await _historyStore.GetRecentAsync(MaxDisplayedSuggestions).ConfigureAwait(false)
+                        : await _historyStore.SearchAsync(query, HistoryCandidatePoolSize).ConfigureAwait(false);
+                }
+
+                IReadOnlyList<CommandSnippet> snippets = Array.Empty<CommandSnippet>();
+                if (queryContext.IncludeSnippetSuggestions && _snippetStore != null)
+                {
+                    snippets = await _snippetStore.GetAllAsync().ConfigureAwait(false);
+                }
+
+                return _suggestionEngine.GetSuggestions(history, snippets, queryContext, MaxDisplayedSuggestions);
+            }).ConfigureAwait(false);
+
+            Publish(new SuggestionRefreshOutcome(requestedMode, suggestions, Faulted: false), token);
+        }
+        catch
+        {
+            Publish(
+                new SuggestionRefreshOutcome(requestedMode, Array.Empty<AssistSuggestion>(), Faulted: true),
+                token);
+        }
+    }
+
+    private void Publish(SuggestionRefreshOutcome outcome, CancellationToken token)
+    {
+        _dispatch(() =>
+        {
+            if (token.IsCancellationRequested)
+            {
+                return;
+            }
+
+            _applyOutcome(outcome);
+        });
+    }
+
+    /// <summary>
+    /// Which suggestion sources the current session is allowed to draw on.
+    /// </summary>
+    /// <remarks>
+    /// History search is history-only. An explicit Suggest session gets everything. A passive Suggest
+    /// bubble - one the user never asked for - gets paths only: unasked-for history rows were the
+    /// noisiest part of V1. Help and Fix rank nothing.
+    /// </remarks>
+    private static SuggestionScope ResolveScope(CommandAssistMode requestedMode, bool isExplicitSession)
+    {
+        if (requestedMode == CommandAssistMode.Search)
+        {
+            return new SuggestionScope(
+                IncludeHistory: true,
+                IncludeSnippets: false,
+                IncludePaths: false);
+        }
+
+        if (requestedMode == CommandAssistMode.Suggest && isExplicitSession)
+        {
+            return new SuggestionScope(
+                IncludeHistory: true,
+                IncludeSnippets: true,
+                IncludePaths: true);
+        }
+
+        if (requestedMode == CommandAssistMode.Suggest)
+        {
+            return new SuggestionScope(
+                IncludeHistory: false,
+                IncludeSnippets: false,
+                IncludePaths: true);
+        }
+
+        return new SuggestionScope(
+            IncludeHistory: false,
+            IncludeSnippets: false,
+            IncludePaths: false);
+    }
+
+    private readonly record struct SuggestionScope(
+        bool IncludeHistory,
+        bool IncludeSnippets,
+        bool IncludePaths);
+}

--- a/src/NovaTerminal.CommandAssist/Application/SuggestionRefreshOutcome.cs
+++ b/src/NovaTerminal.CommandAssist/Application/SuggestionRefreshOutcome.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using NovaTerminal.CommandAssist.Models;
+
+namespace NovaTerminal.CommandAssist.Application;
+
+/// <summary>
+/// The result of one ranking pass, handed back to the controller on the dispatcher thread.
+/// </summary>
+/// <param name="RequestedMode">
+/// The mode the pass was queued for. The controller drops the outcome if the session has moved on to
+/// a different mode since - a Help popup must not be overwritten by a Suggest pass that was already
+/// in flight when it opened.
+/// </param>
+/// <param name="Suggestions">The ranked rows; empty when the pass failed.</param>
+/// <param name="Faulted">
+/// True when the candidate fetch or the ranking threw. The surface is cleared rather than left
+/// showing rows from a previous query.
+/// </param>
+public readonly record struct SuggestionRefreshOutcome(
+    CommandAssistMode RequestedMode,
+    IReadOnlyList<AssistSuggestion> Suggestions,
+    bool Faulted);

--- a/tests/NovaTerminal.App.Tests/CommandAssist/AssistSessionStateMachineTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/AssistSessionStateMachineTests.cs
@@ -1,0 +1,484 @@
+using NovaTerminal.CommandAssist.Application;
+using NovaTerminal.CommandAssist.Models;
+
+namespace NovaTerminal.Tests.CommandAssist;
+
+/// <summary>
+/// The full transition table. Every state gets every event, so a new state or a new transition
+/// cannot be added without deciding - here, in one place - what it does from everywhere else.
+/// </summary>
+public sealed class AssistSessionStateMachineTests
+{
+    [Fact]
+    public void NewMachine_StartsHiddenWithNothingSuppressed()
+    {
+        var machine = new AssistSessionStateMachine();
+
+        Assert.Equal(AssistSessionState.Hidden, machine.State);
+        Assert.False(machine.IsCurrentSubmissionSuppressed);
+        Assert.False(machine.IsExplicitSession);
+        Assert.False(machine.IsPopupOpen);
+        Assert.Equal(CommandAssistMode.Suggest, machine.Mode);
+    }
+
+    /// <summary>Guards the table below: every state must be reachable by the documented route.</summary>
+    [Theory]
+    [InlineData(AssistSessionState.Hidden)]
+    [InlineData(AssistSessionState.PassiveBubble)]
+    [InlineData(AssistSessionState.PassivePopup)]
+    [InlineData(AssistSessionState.ExplicitBubble)]
+    [InlineData(AssistSessionState.ExplicitPopup)]
+    [InlineData(AssistSessionState.HistorySearch)]
+    [InlineData(AssistSessionState.Help)]
+    [InlineData(AssistSessionState.FixHint)]
+    [InlineData(AssistSessionState.FixPopup)]
+    public void CreateInState_ReachesTheRequestedState(AssistSessionState state)
+    {
+        Assert.Equal(state, CreateInState(state).State);
+    }
+
+    [Theory]
+    [InlineData(AssistSessionState.Hidden, CommandAssistMode.Suggest)]
+    [InlineData(AssistSessionState.PassiveBubble, CommandAssistMode.Suggest)]
+    [InlineData(AssistSessionState.PassivePopup, CommandAssistMode.Suggest)]
+    [InlineData(AssistSessionState.ExplicitBubble, CommandAssistMode.Suggest)]
+    [InlineData(AssistSessionState.ExplicitPopup, CommandAssistMode.Suggest)]
+    [InlineData(AssistSessionState.HistorySearch, CommandAssistMode.Search)]
+    [InlineData(AssistSessionState.Help, CommandAssistMode.Help)]
+    [InlineData(AssistSessionState.FixHint, CommandAssistMode.Fix)]
+    [InlineData(AssistSessionState.FixPopup, CommandAssistMode.Fix)]
+    public void Mode_IsDerivedFromState(AssistSessionState state, CommandAssistMode expected)
+    {
+        Assert.Equal(expected, CreateInState(state).Mode);
+    }
+
+    [Theory]
+    [InlineData(AssistSessionState.Hidden, false)]
+    [InlineData(AssistSessionState.PassiveBubble, false)]
+    [InlineData(AssistSessionState.PassivePopup, false)]
+    [InlineData(AssistSessionState.ExplicitBubble, true)]
+    [InlineData(AssistSessionState.ExplicitPopup, true)]
+    [InlineData(AssistSessionState.HistorySearch, true)]
+    [InlineData(AssistSessionState.Help, false)]
+    [InlineData(AssistSessionState.FixHint, false)]
+    [InlineData(AssistSessionState.FixPopup, false)]
+    public void IsExplicitSession_IsDerivedFromState(AssistSessionState state, bool expected)
+    {
+        Assert.Equal(expected, CreateInState(state).IsExplicitSession);
+    }
+
+    [Theory]
+    [InlineData(AssistSessionState.Hidden, false)]
+    [InlineData(AssistSessionState.PassiveBubble, false)]
+    [InlineData(AssistSessionState.PassivePopup, true)]
+    [InlineData(AssistSessionState.ExplicitBubble, false)]
+    [InlineData(AssistSessionState.ExplicitPopup, true)]
+    [InlineData(AssistSessionState.HistorySearch, true)]
+    [InlineData(AssistSessionState.Help, true)]
+    [InlineData(AssistSessionState.FixHint, false)]
+    [InlineData(AssistSessionState.FixPopup, true)]
+    public void IsPopupOpen_IsDerivedFromState(AssistSessionState state, bool expected)
+    {
+        Assert.Equal(expected, CreateInState(state).IsPopupOpen);
+    }
+
+    [Theory]
+    [InlineData(AssistSessionState.Hidden, true)]
+    [InlineData(AssistSessionState.PassiveBubble, true)]
+    [InlineData(AssistSessionState.PassivePopup, true)]
+    [InlineData(AssistSessionState.ExplicitBubble, true)]
+    [InlineData(AssistSessionState.ExplicitPopup, true)]
+    [InlineData(AssistSessionState.HistorySearch, true)]
+    [InlineData(AssistSessionState.Help, false)]
+    [InlineData(AssistSessionState.FixHint, false)]
+    [InlineData(AssistSessionState.FixPopup, false)]
+    public void AllowsSuggestionRefresh_IsFalseForContentModes(AssistSessionState state, bool expected)
+    {
+        Assert.Equal(expected, CreateInState(state).AllowsSuggestionRefresh);
+    }
+
+    [Theory]
+    [InlineData(AssistSessionState.Hidden)]
+    [InlineData(AssistSessionState.PassiveBubble)]
+    [InlineData(AssistSessionState.PassivePopup)]
+    [InlineData(AssistSessionState.ExplicitBubble)]
+    [InlineData(AssistSessionState.ExplicitPopup)]
+    [InlineData(AssistSessionState.HistorySearch)]
+    [InlineData(AssistSessionState.Help)]
+    [InlineData(AssistSessionState.FixHint)]
+    [InlineData(AssistSessionState.FixPopup)]
+    public void ToggleSession_WhenSurfaceIsVisible_AlwaysHides(AssistSessionState state)
+    {
+        AssistSessionStateMachine machine = CreateInState(state);
+
+        Assert.Equal(AssistSessionState.Hidden, machine.ToggleSession(isSurfaceVisible: true));
+        Assert.Equal(AssistSessionState.Hidden, machine.State);
+    }
+
+    [Theory]
+    [InlineData(AssistSessionState.Hidden)]
+    [InlineData(AssistSessionState.PassiveBubble)]
+    [InlineData(AssistSessionState.PassivePopup)]
+    [InlineData(AssistSessionState.ExplicitBubble)]
+    [InlineData(AssistSessionState.ExplicitPopup)]
+    [InlineData(AssistSessionState.HistorySearch)]
+    [InlineData(AssistSessionState.Help)]
+    [InlineData(AssistSessionState.FixHint)]
+    [InlineData(AssistSessionState.FixPopup)]
+    public void ToggleSession_WhenNoSurfaceIsVisible_OpensAnExplicitSession(AssistSessionState state)
+    {
+        AssistSessionStateMachine machine = CreateInState(state);
+
+        Assert.Equal(AssistSessionState.ExplicitBubble, machine.ToggleSession(isSurfaceVisible: false));
+        Assert.True(machine.IsExplicitSession);
+    }
+
+    [Theory]
+    [InlineData(AssistSessionState.Hidden)]
+    [InlineData(AssistSessionState.PassiveBubble)]
+    [InlineData(AssistSessionState.PassivePopup)]
+    [InlineData(AssistSessionState.ExplicitBubble)]
+    [InlineData(AssistSessionState.ExplicitPopup)]
+    [InlineData(AssistSessionState.HistorySearch)]
+    [InlineData(AssistSessionState.Help)]
+    [InlineData(AssistSessionState.FixHint)]
+    [InlineData(AssistSessionState.FixPopup)]
+    public void OpenSearch_FromAnyState_EntersHistorySearch(AssistSessionState state)
+    {
+        AssistSessionStateMachine machine = CreateInState(state);
+
+        machine.OpenSearch();
+
+        Assert.Equal(AssistSessionState.HistorySearch, machine.State);
+        Assert.True(machine.IsExplicitSession);
+        Assert.True(machine.IsPopupOpen);
+    }
+
+    [Theory]
+    [InlineData(AssistSessionState.Hidden)]
+    [InlineData(AssistSessionState.PassiveBubble)]
+    [InlineData(AssistSessionState.PassivePopup)]
+    [InlineData(AssistSessionState.ExplicitBubble)]
+    [InlineData(AssistSessionState.ExplicitPopup)]
+    [InlineData(AssistSessionState.HistorySearch)]
+    [InlineData(AssistSessionState.Help)]
+    [InlineData(AssistSessionState.FixHint)]
+    [InlineData(AssistSessionState.FixPopup)]
+    public void OpenHelp_FromAnyState_EntersHelp(AssistSessionState state)
+    {
+        AssistSessionStateMachine machine = CreateInState(state);
+
+        machine.OpenHelp();
+
+        Assert.Equal(AssistSessionState.Help, machine.State);
+        Assert.False(machine.IsExplicitSession);
+    }
+
+    [Theory]
+    [InlineData(AssistSessionState.Hidden)]
+    [InlineData(AssistSessionState.PassiveBubble)]
+    [InlineData(AssistSessionState.PassivePopup)]
+    [InlineData(AssistSessionState.ExplicitBubble)]
+    [InlineData(AssistSessionState.ExplicitPopup)]
+    [InlineData(AssistSessionState.HistorySearch)]
+    [InlineData(AssistSessionState.Help)]
+    [InlineData(AssistSessionState.FixHint)]
+    [InlineData(AssistSessionState.FixPopup)]
+    public void ShowFix_FromAnyState_EntersFixWithTheRequestedPopupState(AssistSessionState state)
+    {
+        AssistSessionStateMachine confident = CreateInState(state);
+        AssistSessionStateMachine tentative = CreateInState(state);
+
+        confident.ShowFix(openPopup: true);
+        tentative.ShowFix(openPopup: false);
+
+        Assert.Equal(AssistSessionState.FixPopup, confident.State);
+        Assert.Equal(AssistSessionState.FixHint, tentative.State);
+    }
+
+    [Theory]
+    [InlineData(AssistSessionState.Hidden, AssistSessionState.PassiveBubble)]
+    [InlineData(AssistSessionState.PassiveBubble, AssistSessionState.PassiveBubble)]
+    [InlineData(AssistSessionState.PassivePopup, AssistSessionState.PassiveBubble)]
+    [InlineData(AssistSessionState.ExplicitBubble, AssistSessionState.ExplicitBubble)]
+    [InlineData(AssistSessionState.ExplicitPopup, AssistSessionState.ExplicitBubble)]
+    [InlineData(AssistSessionState.HistorySearch, AssistSessionState.ExplicitBubble)]
+    [InlineData(AssistSessionState.Help, AssistSessionState.PassiveBubble)]
+    [InlineData(AssistSessionState.FixHint, AssistSessionState.PassiveBubble)]
+    [InlineData(AssistSessionState.FixPopup, AssistSessionState.PassiveBubble)]
+    public void ObserveTypedInput_ReturnsToSuggestPreservingExplicitness(
+        AssistSessionState state,
+        AssistSessionState expected)
+    {
+        AssistSessionStateMachine machine = CreateInState(state);
+
+        machine.ObserveTypedInput();
+
+        Assert.Equal(expected, machine.State);
+    }
+
+    [Theory]
+    [InlineData(AssistSessionState.Hidden)]
+    [InlineData(AssistSessionState.PassiveBubble)]
+    [InlineData(AssistSessionState.PassivePopup)]
+    [InlineData(AssistSessionState.ExplicitBubble)]
+    [InlineData(AssistSessionState.ExplicitPopup)]
+    [InlineData(AssistSessionState.HistorySearch)]
+    [InlineData(AssistSessionState.Help)]
+    [InlineData(AssistSessionState.FixHint)]
+    [InlineData(AssistSessionState.FixPopup)]
+    public void ObservePastedText_DropsToAPassiveBubbleAndSuppressesTheSubmission(AssistSessionState state)
+    {
+        AssistSessionStateMachine machine = CreateInState(state);
+
+        machine.ObservePastedText();
+
+        Assert.Equal(AssistSessionState.PassiveBubble, machine.State);
+        Assert.True(machine.IsCurrentSubmissionSuppressed);
+    }
+
+    [Theory]
+    [InlineData(AssistSessionState.Hidden, AssistSessionState.Hidden)]
+    [InlineData(AssistSessionState.PassiveBubble, AssistSessionState.PassivePopup)]
+    [InlineData(AssistSessionState.PassivePopup, AssistSessionState.PassivePopup)]
+    [InlineData(AssistSessionState.ExplicitBubble, AssistSessionState.ExplicitPopup)]
+    [InlineData(AssistSessionState.ExplicitPopup, AssistSessionState.ExplicitPopup)]
+    [InlineData(AssistSessionState.HistorySearch, AssistSessionState.HistorySearch)]
+    [InlineData(AssistSessionState.Help, AssistSessionState.Help)]
+    [InlineData(AssistSessionState.FixHint, AssistSessionState.FixPopup)]
+    [InlineData(AssistSessionState.FixPopup, AssistSessionState.FixPopup)]
+    public void OpenPopupForSelection_OpensThePopupOverWhateverIsUp(
+        AssistSessionState state,
+        AssistSessionState expected)
+    {
+        AssistSessionStateMachine machine = CreateInState(state);
+
+        machine.OpenPopupForSelection();
+
+        Assert.Equal(expected, machine.State);
+    }
+
+    [Theory]
+    [InlineData(AssistSessionState.Hidden, AssistSessionState.Hidden)]
+    [InlineData(AssistSessionState.PassiveBubble, AssistSessionState.PassiveBubble)]
+    [InlineData(AssistSessionState.PassivePopup, AssistSessionState.PassiveBubble)]
+    [InlineData(AssistSessionState.ExplicitBubble, AssistSessionState.ExplicitBubble)]
+    [InlineData(AssistSessionState.ExplicitPopup, AssistSessionState.ExplicitBubble)]
+    [InlineData(AssistSessionState.HistorySearch, AssistSessionState.HistorySearch)]
+    [InlineData(AssistSessionState.Help, AssistSessionState.Help)]
+    [InlineData(AssistSessionState.FixHint, AssistSessionState.FixHint)]
+    [InlineData(AssistSessionState.FixPopup, AssistSessionState.FixPopup)]
+    public void ClosePopupAfterRefresh_OnlyCollapsesSuggestPopups(
+        AssistSessionState state,
+        AssistSessionState expected)
+    {
+        AssistSessionStateMachine machine = CreateInState(state);
+
+        machine.ClosePopupAfterRefresh();
+
+        Assert.Equal(expected, machine.State);
+    }
+
+    [Theory]
+    [InlineData(AssistSessionState.Hidden)]
+    [InlineData(AssistSessionState.PassiveBubble)]
+    [InlineData(AssistSessionState.PassivePopup)]
+    [InlineData(AssistSessionState.ExplicitBubble)]
+    [InlineData(AssistSessionState.ExplicitPopup)]
+    [InlineData(AssistSessionState.HistorySearch)]
+    [InlineData(AssistSessionState.Help)]
+    [InlineData(AssistSessionState.FixHint)]
+    [InlineData(AssistSessionState.FixPopup)]
+    public void Dismiss_FromAnyState_Hides(AssistSessionState state)
+    {
+        AssistSessionStateMachine machine = CreateInState(state);
+
+        machine.Dismiss();
+
+        Assert.Equal(AssistSessionState.Hidden, machine.State);
+    }
+
+    [Theory]
+    [InlineData(AssistSessionState.Hidden)]
+    [InlineData(AssistSessionState.PassiveBubble)]
+    [InlineData(AssistSessionState.PassivePopup)]
+    [InlineData(AssistSessionState.ExplicitBubble)]
+    [InlineData(AssistSessionState.ExplicitPopup)]
+    [InlineData(AssistSessionState.HistorySearch)]
+    [InlineData(AssistSessionState.Help)]
+    [InlineData(AssistSessionState.FixHint)]
+    [InlineData(AssistSessionState.FixPopup)]
+    public void HideForAltScreen_FromAnyState_Hides(AssistSessionState state)
+    {
+        AssistSessionStateMachine machine = CreateInState(state);
+
+        machine.HideForAltScreen();
+
+        Assert.Equal(AssistSessionState.Hidden, machine.State);
+    }
+
+    [Theory]
+    [InlineData(AssistSessionState.Hidden)]
+    [InlineData(AssistSessionState.PassiveBubble)]
+    [InlineData(AssistSessionState.PassivePopup)]
+    [InlineData(AssistSessionState.ExplicitBubble)]
+    [InlineData(AssistSessionState.ExplicitPopup)]
+    [InlineData(AssistSessionState.HistorySearch)]
+    [InlineData(AssistSessionState.Help)]
+    [InlineData(AssistSessionState.FixHint)]
+    [InlineData(AssistSessionState.FixPopup)]
+    public void AcceptSelection_FromAnyState_Hides(AssistSessionState state)
+    {
+        AssistSessionStateMachine machine = CreateInState(state);
+
+        machine.AcceptSelection();
+
+        Assert.Equal(AssistSessionState.Hidden, machine.State);
+    }
+
+    [Theory]
+    [InlineData(AssistSessionState.Hidden)]
+    [InlineData(AssistSessionState.PassiveBubble)]
+    [InlineData(AssistSessionState.PassivePopup)]
+    [InlineData(AssistSessionState.ExplicitBubble)]
+    [InlineData(AssistSessionState.ExplicitPopup)]
+    [InlineData(AssistSessionState.HistorySearch)]
+    [InlineData(AssistSessionState.Help)]
+    [InlineData(AssistSessionState.FixHint)]
+    [InlineData(AssistSessionState.FixPopup)]
+    public void CompleteSubmission_FromAnyState_HidesAndClearsSuppression(AssistSessionState state)
+    {
+        AssistSessionStateMachine machine = CreateInState(state);
+        machine.ObservePastedText();
+
+        machine.CompleteSubmission();
+
+        Assert.Equal(AssistSessionState.Hidden, machine.State);
+        Assert.False(machine.IsCurrentSubmissionSuppressed);
+    }
+
+    [Theory]
+    [InlineData(CommandAssistMode.Suggest)]
+    [InlineData(CommandAssistMode.Search)]
+    public void EnterHelperMode_ForANonContentMode_IsRejected(CommandAssistMode mode)
+    {
+        var machine = new AssistSessionStateMachine();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => machine.EnterHelperMode(mode, openPopup: true));
+        Assert.Equal(AssistSessionState.Hidden, machine.State);
+    }
+
+    [Theory]
+    [InlineData(CommandAssistMode.Help, true, AssistSessionState.Help)]
+    [InlineData(CommandAssistMode.Help, false, AssistSessionState.Help)]
+    [InlineData(CommandAssistMode.Fix, true, AssistSessionState.FixPopup)]
+    [InlineData(CommandAssistMode.Fix, false, AssistSessionState.FixHint)]
+    public void EnterHelperMode_ForAContentMode_EntersIt(
+        CommandAssistMode mode,
+        bool openPopup,
+        AssistSessionState expected)
+    {
+        var machine = new AssistSessionStateMachine();
+
+        machine.EnterHelperMode(mode, openPopup);
+
+        Assert.Equal(expected, machine.State);
+    }
+
+    [Fact]
+    public void ObserveTypedInput_ClearsSubmissionSuppression()
+    {
+        var machine = new AssistSessionStateMachine();
+        machine.ObservePastedText();
+
+        machine.ObserveTypedInput();
+
+        Assert.False(machine.IsCurrentSubmissionSuppressed);
+    }
+
+    [Theory]
+    [InlineData(AssistSessionState.Hidden)]
+    [InlineData(AssistSessionState.Help)]
+    [InlineData(AssistSessionState.FixPopup)]
+    [InlineData(AssistSessionState.HistorySearch)]
+    public void SubmissionSuppression_SurvivesEverythingExceptTypingAndSubmitting(AssistSessionState state)
+    {
+        var machine = new AssistSessionStateMachine();
+        machine.ObservePastedText();
+
+        MoveTo(machine, state);
+        machine.Dismiss();
+        machine.HideForAltScreen();
+        machine.AcceptSelection();
+        machine.OpenPopupForSelection();
+        machine.ClosePopupAfterRefresh();
+
+        Assert.True(machine.IsCurrentSubmissionSuppressed);
+    }
+
+    /// <summary>
+    /// The one path that has to survive the split: Ctrl+R, then keep typing. The session stays
+    /// explicit, which is what widens the suggestion scope back out to history and snippets.
+    /// </summary>
+    [Fact]
+    public void HistorySearch_ThenTyping_StaysAnExplicitSession()
+    {
+        var machine = new AssistSessionStateMachine();
+
+        machine.OpenSearch();
+        machine.ObserveTypedInput();
+
+        Assert.Equal(AssistSessionState.ExplicitBubble, machine.State);
+        Assert.True(machine.IsExplicitSession);
+        Assert.Equal(CommandAssistMode.Suggest, machine.Mode);
+    }
+
+    private static AssistSessionStateMachine CreateInState(AssistSessionState state)
+    {
+        var machine = new AssistSessionStateMachine();
+        MoveTo(machine, state);
+        return machine;
+    }
+
+    private static void MoveTo(AssistSessionStateMachine machine, AssistSessionState state)
+    {
+        switch (state)
+        {
+            case AssistSessionState.Hidden:
+                machine.Dismiss();
+                return;
+            case AssistSessionState.PassiveBubble:
+                machine.Dismiss();
+                machine.ObserveTypedInput();
+                return;
+            case AssistSessionState.PassivePopup:
+                machine.Dismiss();
+                machine.ObserveTypedInput();
+                machine.OpenPopupForSelection();
+                return;
+            case AssistSessionState.ExplicitBubble:
+                machine.Dismiss();
+                machine.ToggleSession(isSurfaceVisible: false);
+                return;
+            case AssistSessionState.ExplicitPopup:
+                machine.Dismiss();
+                machine.ToggleSession(isSurfaceVisible: false);
+                machine.OpenPopupForSelection();
+                return;
+            case AssistSessionState.HistorySearch:
+                machine.OpenSearch();
+                return;
+            case AssistSessionState.Help:
+                machine.OpenHelp();
+                return;
+            case AssistSessionState.FixHint:
+                machine.ShowFix(openPopup: false);
+                return;
+            case AssistSessionState.FixPopup:
+                machine.ShowFix(openPopup: true);
+                return;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(state), state, "Unhandled state in the test table.");
+        }
+    }
+}

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CapturePipelineTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CapturePipelineTests.cs
@@ -1,0 +1,419 @@
+using NovaTerminal.CommandAssist.Application;
+using NovaTerminal.CommandAssist.Domain;
+using NovaTerminal.CommandAssist.Models;
+using NovaTerminal.CommandAssist.ShellIntegration.Contracts;
+
+namespace NovaTerminal.Tests.CommandAssist;
+
+/// <summary>
+/// Capture rules in isolation: which submissions become history entries, how the heuristic and
+/// structured paths avoid writing the same command twice, and how the exit code lands afterwards.
+/// </summary>
+public sealed class CapturePipelineTests
+{
+    private static readonly DateTimeOffset EventTime = DateTimeOffset.Parse("2026-03-09T12:00:00+00:00");
+
+    [Fact]
+    public async Task CaptureSubmissionAsync_PersistsARedactedHeuristicEntry()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, AssistSessionContext context) = CreatePipeline();
+        context.UpdateSession("pwsh", @"C:\repo", "profile-1", "session-1", "host-1", isRemote: true, isShellIntegrated: false);
+
+        await pipeline.CaptureSubmissionAsync("  gh auth login --password hunter2  ", isSubmissionSuppressed: false);
+
+        CommandHistoryEntry entry = Assert.Single(store.Entries);
+        Assert.Equal("gh auth login --password [REDACTED]", entry.CommandText);
+        Assert.True(entry.IsRedacted);
+        Assert.Equal(CommandCaptureSource.Heuristic, entry.Source);
+        Assert.Equal("pwsh", entry.ShellKind);
+        Assert.Equal(@"C:\repo", entry.WorkingDirectory);
+        Assert.Equal("profile-1", entry.ProfileId);
+        Assert.Equal("session-1", entry.SessionId);
+        Assert.Equal("host-1", entry.HostId);
+        Assert.True(entry.IsRemote);
+        Assert.Null(entry.ExitCode);
+    }
+
+    [Fact]
+    public async Task CaptureSubmissionAsync_WhenShellKindIsUnknown_TagsTheEntryUnknown()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, _) = CreatePipeline();
+
+        await pipeline.CaptureSubmissionAsync("git status", isSubmissionSuppressed: false);
+
+        Assert.Equal("unknown", Assert.Single(store.Entries).ShellKind);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("echo one\necho two")]
+    [InlineData("echo one\r\necho two")]
+    public async Task CaptureSubmissionAsync_RejectsEmptyAndMultiLineSubmissions(string submission)
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, _) = CreatePipeline();
+
+        await pipeline.CaptureSubmissionAsync(submission, isSubmissionSuppressed: false);
+
+        Assert.Empty(store.Entries);
+    }
+
+    [Fact]
+    public async Task CaptureSubmissionAsync_WhenTheSubmissionIsSuppressed_CapturesNothing()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, _) = CreatePipeline();
+
+        await pipeline.CaptureSubmissionAsync("git status", isSubmissionSuppressed: true);
+
+        Assert.Empty(store.Entries);
+    }
+
+    [Fact]
+    public async Task CaptureSubmissionAsync_WhileTheAltScreenIsUp_CapturesNothing()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, AssistSessionContext context) = CreatePipeline();
+        context.SetAltScreenActive(true);
+
+        await pipeline.CaptureSubmissionAsync("git status", isSubmissionSuppressed: false);
+
+        Assert.Empty(store.Entries);
+    }
+
+    [Fact]
+    public async Task CaptureSubmissionAsync_OnceStructuredCaptureIsProven_StandsDown()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, AssistSessionContext context) = CreatePipeline();
+        context.SetShellIntegrationEnabled(true);
+        context.ObserveStructuredCommandCaptureMarker();
+
+        await pipeline.CaptureSubmissionAsync("git status", isSubmissionSuppressed: false);
+
+        Assert.Empty(store.Entries);
+    }
+
+    [Fact]
+    public async Task CaptureSubmissionAsync_WhenTheStoreThrows_DoesNotPropagate()
+    {
+        var pipeline = new CapturePipeline(new ThrowingHistoryStore(), new SecretsFilter(), new AssistSessionContext());
+
+        await pipeline.CaptureSubmissionAsync("git status", isSubmissionSuppressed: false);
+    }
+
+    [Fact]
+    public async Task CompleteSubmissionAsync_PatchesTheExitCodeOfThePendingEntry()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, _) = CreatePipeline();
+        await pipeline.CaptureSubmissionAsync("git status", isSubmissionSuppressed: false);
+
+        await pipeline.CompleteSubmissionAsync(23);
+
+        Assert.Equal(23, Assert.Single(store.Entries).ExitCode);
+    }
+
+    [Fact]
+    public async Task CompleteSubmissionAsync_WithNothingPending_PatchesNothing()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, _) = CreatePipeline();
+
+        await pipeline.CompleteSubmissionAsync(1);
+
+        Assert.Empty(store.PatchedEntryIds);
+    }
+
+    [Fact]
+    public async Task CompleteSubmissionAsync_ConsumesThePendingEntry()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, _) = CreatePipeline();
+        await pipeline.CaptureSubmissionAsync("git status", isSubmissionSuppressed: false);
+
+        await pipeline.CompleteSubmissionAsync(0);
+        await pipeline.CompleteSubmissionAsync(1);
+
+        Assert.Single(store.PatchedEntryIds);
+        Assert.Equal(0, Assert.Single(store.Entries).ExitCode);
+    }
+
+    [Fact]
+    public async Task CommandAccepted_PersistsARedactedStructuredEntry()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, AssistSessionContext context) = CreatePipeline();
+        context.SetShellIntegrationEnabled(true);
+
+        await pipeline.HandleShellIntegrationEventAsync(Accepted("gh auth login --password hunter2", @"C:\from-event"));
+
+        CommandHistoryEntry entry = Assert.Single(store.Entries);
+        Assert.Equal("gh auth login --password [REDACTED]", entry.CommandText);
+        Assert.Equal(CommandCaptureSource.ShellIntegration, entry.Source);
+        Assert.Equal(EventTime, entry.ExecutedAt);
+        Assert.Equal(@"C:\from-event", entry.WorkingDirectory);
+    }
+
+    [Fact]
+    public async Task CommandAccepted_WhenShellIntegrationIsDisabled_CapturesNothing()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, _) = CreatePipeline();
+
+        await pipeline.HandleShellIntegrationEventAsync(Accepted("git status"));
+
+        Assert.Empty(store.Entries);
+    }
+
+    [Fact]
+    public async Task CommandAccepted_WhileTheAltScreenIsUp_CapturesNothing()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, AssistSessionContext context) = CreatePipeline();
+        context.SetShellIntegrationEnabled(true);
+        context.SetAltScreenActive(true);
+
+        await pipeline.HandleShellIntegrationEventAsync(Accepted("git status"));
+
+        Assert.Empty(store.Entries);
+    }
+
+    [Fact]
+    public async Task CommandAccepted_WithNoCommandText_CapturesNothing()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, AssistSessionContext context) = CreatePipeline();
+        context.SetShellIntegrationEnabled(true);
+
+        await pipeline.HandleShellIntegrationEventAsync(Accepted("   "));
+
+        Assert.Empty(store.Entries);
+    }
+
+    /// <summary>
+    /// The first command of an instrumented session goes down both paths: the heuristic fires on
+    /// Enter, and only then does the shell prove it reports command text. One entry must survive.
+    /// </summary>
+    [Fact]
+    public async Task FirstCommandOfAnInstrumentedSession_IsCapturedOnceAndPatchedOnce()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, AssistSessionContext context) = CreatePipeline();
+        context.SetShellIntegrationEnabled(true);
+
+        await pipeline.CaptureSubmissionAsync("git status", isSubmissionSuppressed: false);
+        await pipeline.HandleShellIntegrationEventAsync(Accepted("git status"));
+        await pipeline.HandleShellIntegrationEventAsync(Finished(exitCode: 0, duration: TimeSpan.FromSeconds(1)));
+
+        CommandHistoryEntry entry = Assert.Single(store.Entries);
+        Assert.Equal(CommandCaptureSource.Heuristic, entry.Source);
+        Assert.Equal(0, entry.ExitCode);
+        Assert.Equal(1000, entry.DurationMs);
+    }
+
+    [Fact]
+    public async Task SecondCommandOfAnInstrumentedSession_IsCapturedByTheStructuredPathOnly()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, AssistSessionContext context) = CreatePipeline();
+        context.SetShellIntegrationEnabled(true);
+        await pipeline.CaptureSubmissionAsync("git status", isSubmissionSuppressed: false);
+        await pipeline.HandleShellIntegrationEventAsync(Accepted("git status"));
+        await pipeline.HandleShellIntegrationEventAsync(Finished(0, TimeSpan.FromSeconds(1)));
+
+        // The marker is now proven, so the heuristic stands down for everything that follows.
+        await pipeline.CaptureSubmissionAsync("dotnet test", isSubmissionSuppressed: false);
+        await pipeline.HandleShellIntegrationEventAsync(Accepted("dotnet test"));
+
+        Assert.Equal(2, store.Entries.Count);
+        Assert.Equal(CommandCaptureSource.ShellIntegration, store.Entries[1].Source);
+    }
+
+    [Fact]
+    public async Task CommandAccepted_WhenTextDiffersFromThePendingHeuristicEntry_CapturesBoth()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, AssistSessionContext context) = CreatePipeline();
+        context.SetShellIntegrationEnabled(true);
+        await pipeline.CaptureSubmissionAsync("git stat", isSubmissionSuppressed: false);
+
+        await pipeline.HandleShellIntegrationEventAsync(Accepted("git status"));
+
+        Assert.Equal(2, store.Entries.Count);
+        Assert.Equal(CommandCaptureSource.Heuristic, store.Entries[0].Source);
+        Assert.Equal(CommandCaptureSource.ShellIntegration, store.Entries[1].Source);
+    }
+
+    [Fact]
+    public async Task CommandAccepted_DedupIgnoresSurroundingWhitespace()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, AssistSessionContext context) = CreatePipeline();
+        context.SetShellIntegrationEnabled(true);
+        await pipeline.CaptureSubmissionAsync("  git status  ", isSubmissionSuppressed: false);
+
+        await pipeline.HandleShellIntegrationEventAsync(Accepted("git status  "));
+
+        Assert.Single(store.Entries);
+    }
+
+    [Fact]
+    public async Task CommandFinished_PatchesExitCodeAndRoundedDuration()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, AssistSessionContext context) = CreatePipeline();
+        context.SetShellIntegrationEnabled(true);
+        await pipeline.HandleShellIntegrationEventAsync(Accepted("git status"));
+
+        await pipeline.HandleShellIntegrationEventAsync(Finished(7, TimeSpan.FromMilliseconds(2500.6)));
+
+        CommandHistoryEntry entry = Assert.Single(store.Entries);
+        Assert.Equal(7, entry.ExitCode);
+        Assert.Equal(2501, entry.DurationMs);
+    }
+
+    [Fact]
+    public async Task CommandFinished_WithoutAnAcceptedCommand_PatchesNothing()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, AssistSessionContext context) = CreatePipeline();
+        context.SetShellIntegrationEnabled(true);
+
+        await pipeline.HandleShellIntegrationEventAsync(Finished(1, TimeSpan.FromMilliseconds(500)));
+
+        Assert.Empty(store.Entries);
+        Assert.Empty(store.PatchedEntryIds);
+    }
+
+    [Fact]
+    public async Task CommandFinished_ConsumesThePendingEntry()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, AssistSessionContext context) = CreatePipeline();
+        context.SetShellIntegrationEnabled(true);
+        await pipeline.HandleShellIntegrationEventAsync(Accepted("git status"));
+
+        await pipeline.HandleShellIntegrationEventAsync(Finished(0, TimeSpan.FromSeconds(1)));
+        await pipeline.HandleShellIntegrationEventAsync(Finished(9, TimeSpan.FromSeconds(2)));
+
+        Assert.Single(store.PatchedEntryIds);
+        Assert.Equal(0, Assert.Single(store.Entries).ExitCode);
+    }
+
+    [Theory]
+    [InlineData(ShellIntegrationEventType.PromptReady, false)]
+    [InlineData(ShellIntegrationEventType.CommandStarted, false)]
+    [InlineData(ShellIntegrationEventType.CommandFinished, false)]
+    [InlineData(ShellIntegrationEventType.CommandAccepted, true)]
+    public async Task ObservedMarkers_OnlyCommandAcceptedProvesStructuredCapture(
+        ShellIntegrationEventType type,
+        bool expectsStructuredCapture)
+    {
+        (CapturePipeline pipeline, _, AssistSessionContext context) = CreatePipeline();
+        context.SetShellIntegrationEnabled(true);
+
+        await pipeline.HandleShellIntegrationEventAsync(new ShellIntegrationEvent(
+            Type: type,
+            Timestamp: EventTime,
+            CommandText: "git status",
+            WorkingDirectory: null,
+            ExitCode: null,
+            Duration: null));
+
+        Assert.True(context.HasObservedShellIntegrationMarker);
+        Assert.Equal(expectsStructuredCapture, context.HasObservedStructuredCommandCaptureMarker);
+        Assert.Equal(expectsStructuredCapture, context.IsStructuredCaptureActive);
+    }
+
+    [Fact]
+    public async Task WorkingDirectoryChanged_UpdatesTheContextWithoutClaimingAMarker()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, AssistSessionContext context) = CreatePipeline();
+
+        await pipeline.HandleShellIntegrationEventAsync(new ShellIntegrationEvent(
+            Type: ShellIntegrationEventType.WorkingDirectoryChanged,
+            Timestamp: EventTime,
+            CommandText: null,
+            WorkingDirectory: "/new/place",
+            ExitCode: null,
+            Duration: null));
+
+        Assert.Equal("/new/place", context.WorkingDirectory);
+        Assert.False(context.HasObservedShellIntegrationMarker);
+        Assert.Empty(store.Entries);
+    }
+
+    private static (CapturePipeline Pipeline, InMemoryHistoryStore Store, AssistSessionContext Context) CreatePipeline()
+    {
+        var store = new InMemoryHistoryStore();
+        var context = new AssistSessionContext();
+        return (new CapturePipeline(store, new SecretsFilter(), context), store, context);
+    }
+
+    private static ShellIntegrationEvent Accepted(string? commandText, string? workingDirectory = null)
+    {
+        return new ShellIntegrationEvent(
+            Type: ShellIntegrationEventType.CommandAccepted,
+            Timestamp: EventTime,
+            CommandText: commandText,
+            WorkingDirectory: workingDirectory,
+            ExitCode: null,
+            Duration: null);
+    }
+
+    private static ShellIntegrationEvent Finished(int? exitCode, TimeSpan? duration)
+    {
+        return new ShellIntegrationEvent(
+            Type: ShellIntegrationEventType.CommandFinished,
+            Timestamp: EventTime.AddSeconds(1),
+            CommandText: null,
+            WorkingDirectory: null,
+            ExitCode: exitCode,
+            Duration: duration);
+    }
+
+    private sealed class InMemoryHistoryStore : IHistoryStore
+    {
+        private readonly List<CommandHistoryEntry> _entries = new();
+        private readonly List<string> _patchedEntryIds = new();
+
+        public IReadOnlyList<CommandHistoryEntry> Entries => _entries;
+        public IReadOnlyList<string> PatchedEntryIds => _patchedEntryIds;
+
+        public Task AppendAsync(CommandHistoryEntry entry, CancellationToken cancellationToken = default)
+        {
+            _entries.Add(entry);
+            return Task.CompletedTask;
+        }
+
+        public Task ClearAsync(CancellationToken cancellationToken = default)
+        {
+            _entries.Clear();
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<CommandHistoryEntry>> GetRecentAsync(int maxResults, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<CommandHistoryEntry>>(_entries.Take(maxResults).ToList());
+
+        public Task<IReadOnlyList<CommandHistoryEntry>> SearchAsync(string query, int maxCandidates, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<CommandHistoryEntry>>(_entries.Take(maxCandidates).ToList());
+
+        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default)
+        {
+            int index = _entries.FindIndex(x => x.Id == entryId);
+            if (index < 0)
+            {
+                return Task.FromResult(false);
+            }
+
+            _patchedEntryIds.Add(entryId);
+            _entries[index] = _entries[index] with
+            {
+                ExitCode = exitCode,
+                DurationMs = durationMs ?? _entries[index].DurationMs
+            };
+            return Task.FromResult(true);
+        }
+    }
+
+    private sealed class ThrowingHistoryStore : IHistoryStore
+    {
+        public Task AppendAsync(CommandHistoryEntry entry, CancellationToken cancellationToken = default)
+            => Task.FromException(new InvalidOperationException("simulated write failure"));
+
+        public Task ClearAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task<IReadOnlyList<CommandHistoryEntry>> GetRecentAsync(int maxResults, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<CommandHistoryEntry>>(Array.Empty<CommandHistoryEntry>());
+
+        public Task<IReadOnlyList<CommandHistoryEntry>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<CommandHistoryEntry>>(Array.Empty<CommandHistoryEntry>());
+
+        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default)
+            => Task.FromException<bool>(new InvalidOperationException("simulated write failure"));
+    }
+}


### PR DESCRIPTION
Completes #114. Implements Phase 0 task 4 of `docs/plans/2026-08-01-command-assist-v2-plan.md`,
the last outstanding Phase 0 item. Stacked on #279 (base
`command-assist/v2-phase0b-di-ranking-storage`).

Pure restructuring: no behavior change, no new policy, no deletions beyond moving code. The
existing `CommandAssistControllerTests` pass with **zero** edits - not even mechanical construction
updates, because the controller's constructor and public surface are unchanged. `TerminalPane` is
untouched (`git diff c361e3f -- src/NovaTerminal.App` is empty).

## The three collaborators

`CommandAssistController` stays the facade `TerminalPane` and the view-models talk to. It keeps the
view-model writes - presentation is the facade's job - and delegates the rest.

**`AssistSessionStateMachine`** owns what the session is doing. One enum, reached only through named
transitions; there is no settable state property, so the set of ways the session can move is the set
of methods on the class.

**`AssistSessionContext`** holds the environment the other three share: shell kind, cwd, profile /
session / host ids, remoteness, alt screen, whether shell integration is configured, and which OSC
133 markers have been observed. Mutable and shared, so a directory change observed by a shell
integration event is visible to the next ranking pass.

**`CapturePipeline`** owns history capture end to end: heuristic Enter-time capture, structured
`CommandAccepted` / `CommandFinished` capture, the dedup between them, secret redaction, the
exit-code and duration patch, and the pending-entry lifecycle. Its doc comment explains why the
first command of an instrumented session goes down both paths and how one entry survives.

**`SuggestionOrchestrator`** owns scope resolution (search vs explicit vs passive), the candidate
fetch, the single ranking pass, and the refresh lifecycle. `MaxDisplayedSuggestions` and
`HistoryCandidatePoolSize` moved here with their rationale comments.

## State enum and transitions

    Hidden
    PassiveBubble    Suggest, not explicit, popup closed
    PassivePopup     Suggest, not explicit, popup open
    ExplicitBubble   Suggest, explicit, popup closed
    ExplicitPopup    Suggest, explicit, popup open
    HistorySearch    Search, explicit, popup open
    Help             Help, popup open
    FixHint          Fix, popup closed (low-confidence affordance)
    FixPopup         Fix, popup open (confident diagnosis)

The plan sketched six states (Hidden / PassiveBubble / PopupBrowse / Search / Help / Fix). Reality
needed nine:

- Explicitness has to survive a popup round trip and a return to typing. `Ctrl+R` then typing on
  stays an explicit session, and that is what keeps history and snippets in scope - one existing
  test depends on it. A single `PopupBrowse` would forget it.
- Fix has two visual variants that the failure-confidence router already distinguishes: popup open
  for a confident diagnosis, bubble-only affordance otherwise.

Transitions, all named methods: `ToggleSession(isSurfaceVisible)`, `OpenSearch`, `OpenHelp`,
`ShowFix(openPopup)`, `EnterHelperMode(mode, openPopup)`, `ObserveTypedInput`, `ObservePastedText`,
`OpenPopupForSelection`, `ClosePopupAfterRefresh`, `Dismiss`, `HideForAltScreen`, `AcceptSelection`,
`CompleteSubmission`. `Mode`, `IsExplicitSession`, `IsPopupOpen` and `AllowsSuggestionRefresh` are
derived, never stored. `EnterHelperMode` throws for Suggest and Search: those are entered by user
intent, never by publishing content.

`ToggleSession` takes surface visibility as an argument rather than deriving it. In the passive
states the bubble is on screen only while the last refresh produced rows, and that is the
view-model's fact; the toggle has always keyed off what the user can see.

## Bools: eliminated vs relocated

Seven bools plus the mode field:

| Field | Disposition |
| --- | --- |
| `_currentMode` | Folded into `AssistSessionState`; `Mode` is derived |
| `_isExplicitAssistSession` | Folded into the enum (`Explicit*` and `HistorySearch` states) |
| `_ignoreCurrentSubmission` | Kept as `AssistSessionStateMachine.IsCurrentSubmissionSuppressed` |
| `_isAltScreenActive` | Moved to `AssistSessionContext` |
| `_isRemote` | Moved to `AssistSessionContext` |
| `_isShellIntegrationEnabled` | Moved to `AssistSessionContext` |
| `_hasObservedShellIntegrationMarker` | Moved to `AssistSessionContext` |
| `_hasObservedStructuredCommandCaptureMarker` | Moved to `AssistSessionContext` |
| `_pendingHistoryEntryId` / `_pendingHistoryCommandText` | Moved to `CapturePipeline` |
| `_refreshVersion` | Replaced by a `CancellationTokenSource` in `SuggestionOrchestrator` |

The boundary, documented on both types: a fact is session state when it describes what the assist
surface is doing and changes because the user drove it. It is environment when it describes the
terminal or shell underneath - those change on their own schedule and gate transitions from the
outside, and folding them into the enum would multiply it by every combination of terminal
condition.

`IsCurrentSubmissionSuppressed` is the one bool kept as a bool. A paste can land in any state, so
folding it in would double the state count while saying nothing about what the surface shows. It is
still only reachable through named transitions (`ObservePastedText` sets it, `ObserveTypedInput` and
`CompleteSubmission` clear it), never a setter. Phase 1 deletes the shadow query buffer it exists to
protect and should delete it too.

## CancellationToken swap

`_refreshVersion` was an interlocked counter compared at apply time to drop stale results. It is now
a `CancellationTokenSource` per pass: queueing cancels the previous one, and an outcome whose token
is cancelled is dropped. Behaviorally identical.

Two deliberate limits:

- **No debounce.** That is a Phase 3 policy change (plan Phase 3 task 1, ~75 ms). This PR swaps the
  mechanism only.
- **The token is not passed into the store or engine calls.** Cancelling work already in flight
  would be a behavior change - and would surface immediately in the tests that await a delayed
  store's last search. Threading it through is Phase 1 work.

## Tests

New: `AssistSessionStateMachineTests` (175 cases) walks the full transition table - every state gets
every event, plus the derived projections and the illegal `EnterHelperMode` calls.
`CapturePipelineTests` (29 cases) covers capture directly: what the heuristic path rejects
(empty, multi-line, suppressed, alt screen, structured capture proven), the first-command
double-capture dedup and its whitespace insensitivity, the second-command path, exit code and
rounded duration patching, pending-entry consumption, marker observation, and the store-throws path.

Unchanged: `CommandAssistControllerTests`, byte for byte.

Test count delta: **+204**. Full per-project run on this branch: App.Tests 1681 passed / 11 skipped,
Architecture 28, McpServer 138, Platform 122 / 18 skipped, Rendering 68, VT 191 - 2228 passed, 29
skipped. Two failures in the parallel App.Tests run
(`AgentHostCaptureProtocolTests.Capture_file_names_are_unique_within_the_same_second` and
`VtReportCliTests.CliShim_PrintsHumanReadableSummary`) are known pre-existing flakes; both pass in
isolation.

## Latent bugs found, not fixed

None of these block the split, so none were touched. Follow-up candidates:

1. **Toggling assist off does not cancel an in-flight refresh.** Every other teardown path
   (`Dismiss`, alt screen, submission, helper content) cancels; `ToggleAssist` does not. A pass
   queued by the toggle-on can land afterwards and set `IsVisible` from the row count, re-showing a
   bubble the user just dismissed. Preserved exactly.
2. **`HandleCommandFinishedAsync` clears the pending entry id but not the pending command text.**
   The dedup key outlives its entry. Harmless today because the dedup also requires a non-empty
   pending id, but it is an asymmetry waiting to bite.
3. **`HasObservedShellIntegrationMarker` is written and reset but never read.** Design doc Phase 2
   reserves it for lifting the SSH restrictions once a remote shell proves it is instrumented. Kept,
   with a comment saying so.
4. **Selection can open the popup while the surface is hidden.** Rows left behind by a toggled-off
   session are still navigable, and `SetSelectedIndex` sets the view-model's popup flag. Unobservable
   (the popup renders on `IsVisible && IsPopupOpen`), but it means the view-model flag and the
   session state can disagree; `OpenPopupForSelection` documents the no-op.
5. **`HandleTextInput` sets visibility from the previous query's `HasSuggestions`** before the new
   refresh lands, so an explicit session can blink the bubble off and back on. M4.2 behavior,
   preserved.
6. **Dead public surface.** `CommandAssistController.HistoryStore`, `SecretsFilter` and
   `SuggestionEngine` have had no callers since Phase 0b unified the composition root. Deleting them
   is a one-line change but it is surface removal, which this PR is not.

## What to scrutinize

- The nine-state enum: is the Passive/Explicit duplication worth it, or should explicitness be a
  separate readonly projection? I argued above that it must survive `ObserveTypedInput`.
- The exact view-model write order in `Dismiss` / `HandleAltScreenChanged` / `ResetSubmissionState`.
  The shared `ClearSuggestionSurface` helper emits the same `PropertyChanged` sequence as the three
  inline blocks it replaces (the only reordering is around `_suggestions.Clear()`, which raises
  nothing).
- `ApplyRefreshOutcome`'s mode guard: it now compares `_state.Mode` where the old code compared
  `_currentMode`. Same value, but it is the one place the split could have changed which passes get
  dropped.
- `CommandAssistController.SessionState` is new public surface (diagnostics and tests only). Say the
  word and it goes internal.
