### PR TITLE
feat(command-assist): emit and parse OSC 133;B command-start marks (V2 Phase 1a)

### DIFF
--- a/docs/agent-host/known-limitations.md
+++ b/docs/agent-host/known-limitations.md
@@ -32,6 +32,15 @@ treat running/idle as a guess.
 - Any session with **shell integration enabled** — it reports at the **precise**
   tier from prompt/command events, which is accurate for WSL and SSH too.
 
+**One exception to the precise tier:** the PowerShell bootstrap emits `OSC 133;C`
+(command accepted) and `OSC 133;D` (command finished) from a wrapped PSReadLine
+`Enter` handler, and skips that wrapping when PSReadLine is absent (minimal hosts,
+server-core, some constrained-language modes). Such a session still reaches the
+**precise** tier from the prompt marks (`OSC 133;A`/`B`) it does emit, but it never
+reports `running` — with no `C`/`D` it looks permanently at a prompt, and it is not
+covered by the child-process heuristic either, because the precise tier suppresses
+it. Installing PSReadLine restores full status.
+
 **Workarounds:**
 - Enable shell integration in the shell (including inside WSL / on the remote)
   to get precise status.

--- a/docs/command-assist/CommandAssist_PowerShell_Integration.md
+++ b/docs/command-assist/CommandAssist_PowerShell_Integration.md
@@ -26,6 +26,13 @@ The PowerShell bootstrap emits the full structured lifecycle:
   - working directory updates
 - `OSC 133;A`
   - prompt ready (emitted from the wrapped `prompt` function)
+- `OSC 133;B`
+  - prompt end / start of user input, appended to the string the wrapped `prompt`
+    function *returns*. Anything the function writes lands before the prompt text
+    (the host prints the return value afterwards), so writing `B` would put the mark
+    at the prompt's start instead of at the first cell of the user's input. The parser
+    reports the cursor position with this mark; Command Assist V2 uses it to read the
+    live command line out of the grid.
 - `OSC 133;C;<base64-utf8>`
   - command accepted; the user-entered buffer is base64-encoded so multiline
     submissions survive transit through the VT byte stream

--- a/docs/command-assist/CommandAssist_ShellIntegration_Gaps.md
+++ b/docs/command-assist/CommandAssist_ShellIntegration_Gaps.md
@@ -5,7 +5,7 @@
 - App-layer launch-plan selection
 - PowerShell bootstrap integration with full structured command capture
   (`OSC 133;A`, `OSC 133;C;<base64>`, `OSC 133;D;<exit>;<duration>`, `OSC 7`)
-  <!-- V2 Phase 1a added `OSC 133;B` to all four bootstraps; see below. -->
+  (V2 Phase 1a added `OSC 133;B` to all four bootstraps — see "Added In V2 Phase 1a" below)
 - Bash provider via `--rcfile` (DEBUG trap preexec, `PROMPT_COMMAND` precmd)
 - Zsh provider via `ZDOTDIR` env-override (native `precmd_functions` /
   `preexec_functions` hooks; user prompt ownership preserved)
@@ -52,6 +52,16 @@
 - fish integration re-defines `fish_prompt` around a copy of the user's function; a config
   that re-defines `fish_prompt` again *after* the bootstrap loads loses the `B` mark
   (`A`/`C`/`D` are unaffected)
+- fish integration works by pointing `XDG_CONFIG_HOME` at our own directory, which also
+  moves `$__fish_config_dir/functions` — so fish's autoloader no longer finds the user's
+  `~/.config/fish/functions/fish_prompt.fish`. We source the user's `config.fish`
+  explicitly, but an autoloaded `fish_prompt` is not part of it: for those users the
+  function we wrap is fish's *default* prompt, not theirs. The marks are correct; the
+  prompt appearance is not
+- `ShellMarkPosition.AbsoluteRow` is stable across scrollback eviction but **not** across a
+  scrollback reset (CSI 3J / RIS / clear-buffer / reflow), which zeroes the buffer's row
+  counters. `ShellMarkPosition.Generation` carries the coordinate-space epoch so a consumer
+  can tell the two apart; a negative derived row only means "aged out" within one generation
 
 ## Deferred Follow-Up Areas
 - richer shell-specific prompt contracts beyond the current wrapper approach

--- a/docs/command-assist/CommandAssist_ShellIntegration_Gaps.md
+++ b/docs/command-assist/CommandAssist_ShellIntegration_Gaps.md
@@ -5,6 +5,7 @@
 - App-layer launch-plan selection
 - PowerShell bootstrap integration with full structured command capture
   (`OSC 133;A`, `OSC 133;C;<base64>`, `OSC 133;D;<exit>;<duration>`, `OSC 7`)
+  <!-- V2 Phase 1a added `OSC 133;B` to all four bootstraps; see below. -->
 - Bash provider via `--rcfile` (DEBUG trap preexec, `PROMPT_COMMAND` precmd)
 - Zsh provider via `ZDOTDIR` env-override (native `precmd_functions` /
   `preexec_functions` hooks; user prompt ownership preserved)
@@ -14,6 +15,25 @@
   `RustPtySession`, and the `pty_spawn_with_envs` Rust FFI (used by Zsh and Fish)
 - structured exit-code and duration enrichment for command history
 - heuristic fallback when structured integration is unavailable or not yet confirmed
+
+## Added In V2 Phase 1a
+- `OSC 133;B` (prompt end / start of user input) is now emitted by all four bootstraps,
+  closing the "no B mark, so `ShellIntegrationEventType.CommandStarted` is dead code" gap.
+  Because bash/zsh/pwsh emit `A` *before* the prompt is printed, `B` cannot come from the
+  same hook — it has to sit at the tail of the prompt itself:
+  - **bash**: `\[\e]133;B\a\]` appended to `PS1`, re-applied from `__nova_arm` (last entry in
+    the `PROMPT_COMMAND` chain, so themes that rewrite `PS1` there cannot drop it)
+  - **zsh**: `%{...%}`-wrapped suffix appended to `PROMPT`, re-applied from `__nova_precmd`
+  - **fish**: `fish_prompt` is copied to `__nova_user_fish_prompt` and re-defined as
+    "original, then `B`" (the `fish_prompt` *event* fires before the prompt renders, so it
+    can only carry `A`)
+  - **PowerShell**: appended to the string the wrapped `prompt` function returns (anything the
+    function writes would land *before* the prompt text)
+- The parser reports the mark with the cursor position at parse time
+  (`AnsiParser.OnCommandStarted` now takes a `ShellIntegrationMark`), which reaches
+  Command Assist as `ShellIntegrationEvent.MarkPosition`. `AbsoluteRow` is the
+  eviction-stable identity; `Row`/`Column` are the immediate buffer coordinates.
+- Nothing consumes the position yet — the grid query reader lands in Phase 1b.
 
 ## Current Limitations
 - shell integration is local-only; SSH launch plans skip provider injection
@@ -26,7 +46,12 @@
   out internal hook calls, but commands run inside `PROMPT_COMMAND` itself can
   still race the guard in pathological user configurations
 - prompt preservation is best-effort and depends on each shell's native prompt
-  ownership conventions
+  ownership conventions; the `OSC 133;B` suffix is *appended* to the user's prompt
+  (never a template assignment), but a prompt framework that rebuilds the prompt after
+  our hook runs would still drop it for that cycle
+- fish integration re-defines `fish_prompt` around a copy of the user's function; a config
+  that re-defines `fish_prompt` again *after* the bootstrap loads loses the `B` mark
+  (`A`/`C`/`D` are unaffected)
 
 ## Deferred Follow-Up Areas
 - richer shell-specific prompt contracts beyond the current wrapper approach

--- a/docs/plans/2026-08-01-command-assist-v2-plan.md
+++ b/docs/plans/2026-08-01-command-assist-v2-plan.md
@@ -35,15 +35,27 @@ segment before it can be claimed as supported.
 
 ## Phase 1 — Truthful query state
 
+**Status: tasks 1 and 2 shipped (Phase 1a).**
+
 Tasks:
-1. Emit `OSC 133;B` from all four bootstrap builders; extend the four `*BootstrapBuilderTests` and the shell-harness integration tests. Preserve bail-out conditions and bash DEBUG-trap guard semantics.
-2. Parser/tracker: wire `133;B` through `AnsiParser` → `ShellLifecycleTracker.HandleCommandStarted` (currently dead) with mark position (row/col).
+1. **[done — Phase 1a]** Emit `OSC 133;B` from all four bootstrap builders; extend the four `*BootstrapBuilderTests` and the shell-harness integration tests. Preserve bail-out conditions and bash DEBUG-trap guard semantics.
+2. **[done — Phase 1a]** Parser/tracker: wire `133;B` through `AnsiParser` → `ShellLifecycleTracker.HandleCommandStarted` (currently dead) with mark position (row/col).
 3. `GridQueryReader` in the new assembly: extract command text between last `B` mark and cursor from the buffer, handling wrapped logical lines and scrolled viewports. Exhaustive buffer-level unit tests first (wrap, resize/reflow, multiline continuation, prompt redraw, cleared screen).
 4. `SuggestionOrchestrator` consumes `GridQueryReader` when marks are live; delete the shadow buffer (`TextInputObserved`/`BackspaceObserved` mirroring). Heuristic Enter-capture stays for history in non-integrated sessions.
 5. Degraded mode: no marks → path suggestions + explicit `Ctrl+R` history search only; prefix-dependent features off.
 6. `CommandAssistInsertionPlanner` computes against grid truth; add tests for post-`Ctrl+U`, post-history-recall, post-Tab-completion insertion (the desync cases that broke V1).
 
 Exit criteria: desync test matrix green on all four shells; shadow buffer code deleted; smoke scenarios 1–8 re-validated.
+
+Phase 1a notes (for the task-3 `GridQueryReader` author):
+- The B mark is carried as `ShellIntegrationEvent.MarkPosition` (`ShellMarkPosition`: `Row`,
+  `Column`, `AbsoluteRow`, `IsAltScreen`). `Row` is the buffer's current row index and goes
+  stale on scrollback eviction; `AbsoluteRow` (`TotalRowsEvicted + Row`) is the stable identity
+  and re-derives the live row as `AbsoluteRow - TotalRowsEvicted`.
+- Neither coordinate survives a reflowing resize — but B rides inside PS1/PROMPT/`fish_prompt`/
+  the pwsh prompt string, so every prompt repaint (including post-resize) re-emits it with
+  fresh coordinates. The reader should treat the newest mark as truth rather than caching one.
+- The controller still ignores `CommandStarted`; nothing consumes the position yet.
 
 ## Phase 2 — Marks-based anchoring + SSH parity
 

--- a/docs/plans/2026-08-01-command-assist-v2-plan.md
+++ b/docs/plans/2026-08-01-command-assist-v2-plan.md
@@ -49,13 +49,26 @@ Exit criteria: desync test matrix green on all four shells; shadow buffer code d
 
 Phase 1a notes (for the task-3 `GridQueryReader` author):
 - The B mark is carried as `ShellIntegrationEvent.MarkPosition` (`ShellMarkPosition`: `Row`,
-  `Column`, `AbsoluteRow`, `IsAltScreen`). `Row` is the buffer's current row index and goes
-  stale on scrollback eviction; `AbsoluteRow` (`TotalRowsEvicted + Row`) is the stable identity
-  and re-derives the live row as `AbsoluteRow - TotalRowsEvicted`.
-- Neither coordinate survives a reflowing resize — but B rides inside PS1/PROMPT/`fish_prompt`/
-  the pwsh prompt string, so every prompt repaint (including post-resize) re-emits it with
-  fresh coordinates. The reader should treat the newest mark as truth rather than caching one.
-- The controller still ignores `CommandStarted`; nothing consumes the position yet.
+  `Column`, `AbsoluteRow`, `IsAltScreen`, `Generation`). `Row` is the buffer's current row index
+  and goes stale on scrollback eviction; `AbsoluteRow` (`TotalRowsEvicted + Row`) is the stable
+  identity and re-derives the live row as `AbsoluteRow - TotalRowsEvicted`.
+- Staleness has **two** cases and only one of them shows up in the row number:
+  - *Eviction* — `TotalRowsEvicted` only grows, so `AbsoluteRow - TotalRowsEvicted` goes
+    negative and the mark is visibly dead.
+  - *Coordinate-space reset* — `ScrollbackPages.Clear()` zeroes **both** counters. It is
+    reached from CSI 3J (what `clear(1)` sends with the `E3` capability — i.e. routinely),
+    RIS, the user's clear-buffer action, and reflow. Afterwards a pre-reset `AbsoluteRow`
+    resolves to a large *positive* row holding unrelated content, with nothing anomalous about
+    it. `Generation` (`ScrollbackPages.Generation`, a process-global monotonic epoch bumped in
+    `Clear()` and on construction) is the detector: **the reader must reject any mark whose
+    `Generation` differs from `buffer.Scrollback.Generation`, and only then treat a negative
+    derived row as "aged out".**
+- B rides inside PS1/PROMPT/`fish_prompt`/the pwsh prompt string, so every prompt repaint
+  (including post-resize and post-clear) re-emits it with fresh coordinates. The reader should
+  treat the newest mark as truth rather than caching one.
+- The controller still ignores `CommandStarted`; nothing consumes the position yet. The pane
+  short-circuits `CommandStarted` before the Command Assist dispatcher for that reason — Phase
+  1b has to remove that early-out (`TerminalPane.OnShellIntegrationEventObserved`).
 
 ## Phase 2 — Marks-based anchoring + SSH parity
 

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -1761,7 +1761,8 @@ namespace NovaTerminal.Controls
                     Row: mark.Row,
                     Column: mark.Column,
                     AbsoluteRow: mark.AbsoluteRow,
-                    IsAltScreen: mark.IsAltScreen));
+                    IsAltScreen: mark.IsAltScreen,
+                    Generation: mark.Generation));
             };
             Parser.OnCommandFinished += exitCode =>
             {
@@ -2949,6 +2950,19 @@ namespace NovaTerminal.Controls
                 !string.IsNullOrWhiteSpace(shellEvent.CommandText))
             {
                 _lastRelevantCommandText = shellEvent.CommandText.Trim();
+            }
+
+            // OSC 133;B (CommandStarted) is dropped unconditionally by
+            // CommandAssistController.HandleShellIntegrationEventAsync, and B fires once per
+            // prompt AND once per prompt repaint -- so forwarding it only queues no-op work
+            // onto the serialized dispatcher, ahead of events that do something. The
+            // "shell integration is live" flag the controller would set from it is already
+            // set by the PromptReady (OSC 133;A) that precedes every B.
+            // Phase 1b, when the mark position starts feeding the grid reader, has to remove
+            // this early-out.
+            if (shellEvent.Type == ShellIntegrationEventType.CommandStarted)
+            {
+                return;
             }
 
             _ = _shellIntegrationEventDispatcher.EnqueueAsync(() => HandleShellIntegrationEventAsync(shellEvent));

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -1735,15 +1735,16 @@ namespace NovaTerminal.Controls
             {
                 _lastRelevantCommandText = commandText?.Trim();
                 _shellLifecycleTracker?.HandleCommandAccepted(commandText);
-                _agentRegistration?.StatusMachine.NotifyCommandAccepted(commandText);
-            };
-            Parser.OnCommandStarted += () =>
-            {
-                _shellLifecycleTracker?.HandleCommandStarted();
+                // OSC 133;C is the execution-start edge: the line editor is closed and the
+                // shell is about to run the command. (OSC 133;B, below, only says the prompt
+                // finished printing -- the shell is idle waiting for input at that point, so
+                // driving "running" off B would report every idle prompt as a busy session.)
+                //
                 // Status machine is notified synchronously on the parser path so
                 // command-lifecycle signals keep their emission order relative to
-                // OnCommandAccepted/OnPromptReady (the UI post below would let a
+                // OnCommandStarted/OnPromptReady (the UI post below would let a
                 // snapshot briefly see AwaitingInput with CurrentCommand set).
+                _agentRegistration?.StatusMachine.NotifyCommandAccepted(commandText);
                 _agentRegistration?.StatusMachine.NotifyCommandStarted();
                 _lastCommandStartedAtUtc = DateTimeOffset.UtcNow;
                 Dispatcher.UIThread.Post(() =>
@@ -1751,6 +1752,16 @@ namespace NovaTerminal.Controls
                     LastExitCode = null;
                     CommandStarted?.Invoke(this);
                 });
+            };
+            Parser.OnCommandStarted += mark =>
+            {
+                // OSC 133;B == prompt end / start of user input. The mark position is the
+                // anchor Command Assist uses to read the live command line out of the grid.
+                _shellLifecycleTracker?.HandleCommandStarted(new ShellMarkPosition(
+                    Row: mark.Row,
+                    Column: mark.Column,
+                    AbsoluteRow: mark.AbsoluteRow,
+                    IsAltScreen: mark.IsAltScreen));
             };
             Parser.OnCommandFinished += exitCode =>
             {

--- a/src/NovaTerminal.CommandAssist/ShellIntegration/Bash/BashBootstrapBuilder.cs
+++ b/src/NovaTerminal.CommandAssist/ShellIntegration/Bash/BashBootstrapBuilder.cs
@@ -67,7 +67,30 @@ public static class BashBootstrapBuilder
         // runs LAST in PROMPT_COMMAND) is responsible for clearing it.
         b.Append("}").Append(nl);
         b.Append(nl);
+        // OSC 133;B marks the END of the prompt, i.e. the cell where the
+        // user's input begins. Bash prints PS1 *after* PROMPT_COMMAND has
+        // run, so unlike A (emitted from __nova_precmd) B cannot be written
+        // from a hook -- it has to ride along at the tail of PS1 itself.
+        // \[ \] wrap it as non-printing so bash's prompt-width arithmetic
+        // (and therefore readline's line wrapping) is unaffected.
+        b.Append("__nova_ps1_mark='\\[\\e]133;B\\a\\]'").Append(nl);
+        // Re-applied every prompt cycle rather than once at startup: themes
+        // like starship/oh-my-posh rewrite PS1 from inside PROMPT_COMMAND,
+        // which would drop a one-shot suffix. The containment check keeps
+        // repeated application idempotent for the ordinary static-PS1 case.
+        b.Append("__nova_apply_ps1_mark() {").Append(nl);
+        b.Append("    case \"$PS1\" in").Append(nl);
+        b.Append("        *\"$__nova_ps1_mark\"*) ;;").Append(nl);
+        b.Append("        *) PS1=\"$PS1$__nova_ps1_mark\" ;;").Append(nl);
+        b.Append("    esac").Append(nl);
+        b.Append("}").Append(nl);
+        b.Append(nl);
         b.Append("__nova_arm() {").Append(nl);
+        // Runs LAST in PROMPT_COMMAND, which is also the only point where the
+        // user's own PROMPT_COMMAND has finished rewriting PS1 -- so the mark
+        // is (re)appended here rather than as a separate chain entry, keeping
+        // the "arm last" invariant and the chain string itself unchanged.
+        b.Append("    __nova_apply_ps1_mark").Append(nl);
         b.Append("    __nova_command_active=0").Append(nl);
         b.Append("}").Append(nl);
         b.Append(nl);
@@ -111,6 +134,10 @@ public static class BashBootstrapBuilder
         b.Append("    PROMPT_COMMAND='__nova_precmd; __nova_arm'").Append(nl);
         b.Append("fi").Append(nl);
         b.Append(nl);
+        // Belt and braces for the very first prompt: PROMPT_COMMAND does run
+        // before it, but if the user's PROMPT_COMMAND aborts early the mark
+        // would otherwise be missing until the next cycle.
+        b.Append("__nova_apply_ps1_mark").Append(nl);
         b.Append("__nova_emit_prompt_ready").Append(nl);
         return b.ToString();
     }

--- a/src/NovaTerminal.CommandAssist/ShellIntegration/Contracts/ShellIntegrationEvent.cs
+++ b/src/NovaTerminal.CommandAssist/ShellIntegration/Contracts/ShellIntegrationEvent.cs
@@ -2,10 +2,17 @@ using System;
 
 namespace NovaTerminal.CommandAssist.ShellIntegration.Contracts;
 
+/// <param name="MarkPosition">
+/// Where the originating OSC 133 mark landed in the terminal buffer. Only
+/// <see cref="ShellIntegrationEventType.CommandStarted"/> (OSC 133;B) carries one today; every
+/// other event type leaves it null. Additive by design — consumers that don't read grid state
+/// ignore it.
+/// </param>
 public sealed record ShellIntegrationEvent(
     ShellIntegrationEventType Type,
     DateTimeOffset Timestamp,
     string? CommandText,
     string? WorkingDirectory,
     int? ExitCode,
-    TimeSpan? Duration);
+    TimeSpan? Duration,
+    ShellMarkPosition? MarkPosition = null);

--- a/src/NovaTerminal.CommandAssist/ShellIntegration/Contracts/ShellMarkPosition.cs
+++ b/src/NovaTerminal.CommandAssist/ShellIntegration/Contracts/ShellMarkPosition.cs
@@ -13,17 +13,29 @@ namespace NovaTerminal.CommandAssist.ShellIntegration.Contracts;
 /// <para>
 /// <see cref="Row"/> is only valid until the next scrollback eviction; <see cref="AbsoluteRow"/>
 /// is the eviction-stable identity (<c>AbsoluteRow - totalRowsEvicted</c> re-derives the current
-/// row, and a negative result means the marked line has scrolled out of history). Neither
-/// survives a reflowing resize, but every shell re-emits its prompt — and therefore its B mark —
-/// after one.
+/// row, and a negative result means the marked line has scrolled out of history).
+/// </para>
+/// <para>
+/// A negative row is <i>not</i> the only staleness case. Clearing the scrollback (CSI 3J — what
+/// <c>clear(1)</c> sends with the <c>E3</c> capability — plus RIS, the user's clear-buffer
+/// action, and reflow) resets the buffer's row counters to zero, after which a pre-reset
+/// <see cref="AbsoluteRow"/> resolves to a perfectly plausible but wrong row.
+/// <see cref="Generation"/> is the epoch that makes this detectable: the mark is only usable
+/// while it still equals the buffer's current scrollback generation. Every shell re-emits its
+/// prompt — and therefore its B mark — after a resize or a clear, so a fresh mark follows.
 /// </para>
 /// </remarks>
 /// <param name="Row">Row index in the buffer's current addressing space at mark time.</param>
 /// <param name="Column">Cursor column at mark time; the first cell of the user's input.</param>
 /// <param name="AbsoluteRow">Eviction-stable row identity for <paramref name="Row"/>.</param>
 /// <param name="IsAltScreen">True when the mark was captured on the alt screen.</param>
+/// <param name="Generation">
+/// Scrollback coordinate-space epoch at mark time; a mark whose generation differs from the
+/// buffer's current one must be discarded rather than resolved.
+/// </param>
 public readonly record struct ShellMarkPosition(
     int Row,
     int Column,
     long AbsoluteRow,
-    bool IsAltScreen);
+    bool IsAltScreen,
+    long Generation);

--- a/src/NovaTerminal.CommandAssist/ShellIntegration/Contracts/ShellMarkPosition.cs
+++ b/src/NovaTerminal.CommandAssist/ShellIntegration/Contracts/ShellMarkPosition.cs
@@ -1,0 +1,29 @@
+namespace NovaTerminal.CommandAssist.ShellIntegration.Contracts;
+
+/// <summary>
+/// Buffer position of an OSC 133 shell-integration mark, in terms this assembly can hold
+/// without referencing the VT core.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This mirrors <c>NovaTerminal.VT.ShellIntegrationMark</c>; the App layer converts at the
+/// boundary, the same way <c>AssistPoint</c>/<c>AssistRect</c> keep Avalonia geometry out of
+/// this assembly.
+/// </para>
+/// <para>
+/// <see cref="Row"/> is only valid until the next scrollback eviction; <see cref="AbsoluteRow"/>
+/// is the eviction-stable identity (<c>AbsoluteRow - totalRowsEvicted</c> re-derives the current
+/// row, and a negative result means the marked line has scrolled out of history). Neither
+/// survives a reflowing resize, but every shell re-emits its prompt — and therefore its B mark —
+/// after one.
+/// </para>
+/// </remarks>
+/// <param name="Row">Row index in the buffer's current addressing space at mark time.</param>
+/// <param name="Column">Cursor column at mark time; the first cell of the user's input.</param>
+/// <param name="AbsoluteRow">Eviction-stable row identity for <paramref name="Row"/>.</param>
+/// <param name="IsAltScreen">True when the mark was captured on the alt screen.</param>
+public readonly record struct ShellMarkPosition(
+    int Row,
+    int Column,
+    long AbsoluteRow,
+    bool IsAltScreen);

--- a/src/NovaTerminal.CommandAssist/ShellIntegration/Fish/FishBootstrapBuilder.cs
+++ b/src/NovaTerminal.CommandAssist/ShellIntegration/Fish/FishBootstrapBuilder.cs
@@ -79,7 +79,17 @@ public static class FishBootstrapBuilder
         // triggers autoloading, so this only fails in a genuinely broken
         // config). Degrading to A-only beats replacing the user's prompt
         // with a synthesized one.
-        b.Append("if functions -q fish_prompt").Append(nl);
+        //
+        // The `not functions -q __nova_user_fish_prompt` half is what makes a
+        // re-source safe. This file IS $__fish_config_dir/config.fish for the
+        // session, so anything that re-runs it (fish's own
+        // `source $__fish_config_dir/config.fish`, `exec fish`, a user alias)
+        // would otherwise copy the CURRENT fish_prompt -- already our wrapper --
+        // over __nova_user_fish_prompt, and the redefinition below would then
+        // call itself forever. With the guard, the second pass finds
+        // __nova_user_fish_prompt already defined and leaves both functions
+        // alone, so the original user prompt stays wrapped exactly once.
+        b.Append("if functions -q fish_prompt; and not functions -q __nova_user_fish_prompt").Append(nl);
         b.Append("    functions --copy fish_prompt __nova_user_fish_prompt").Append(nl);
         b.Append("    function fish_prompt").Append(nl);
         b.Append("        __nova_user_fish_prompt").Append(nl);

--- a/src/NovaTerminal.CommandAssist/ShellIntegration/Fish/FishBootstrapBuilder.cs
+++ b/src/NovaTerminal.CommandAssist/ShellIntegration/Fish/FishBootstrapBuilder.cs
@@ -68,6 +68,25 @@ public static class FishBootstrapBuilder
         b.Append("    __nova_emit_prompt_ready").Append(nl);
         b.Append("end").Append(nl);
         b.Append(nl);
+        // The fish_prompt EVENT fires before the prompt function runs, so it
+        // can only carry A. OSC 133;B has to land after the last prompt cell,
+        // and fish has no post-prompt event -- so we copy the user's
+        // fish_prompt aside and re-define fish_prompt as "original, then B".
+        // The copy keeps the user's prompt output byte-for-byte; we only
+        // append to it.
+        //
+        // Bail out entirely if fish_prompt cannot be resolved (functions -q
+        // triggers autoloading, so this only fails in a genuinely broken
+        // config). Degrading to A-only beats replacing the user's prompt
+        // with a synthesized one.
+        b.Append("if functions -q fish_prompt").Append(nl);
+        b.Append("    functions --copy fish_prompt __nova_user_fish_prompt").Append(nl);
+        b.Append("    function fish_prompt").Append(nl);
+        b.Append("        __nova_user_fish_prompt").Append(nl);
+        b.Append("        printf '\\033]133;B\\a'").Append(nl);
+        b.Append("    end").Append(nl);
+        b.Append("end").Append(nl);
+        b.Append(nl);
         b.Append("__nova_emit_prompt_ready").Append(nl);
         return b.ToString();
     }

--- a/src/NovaTerminal.CommandAssist/ShellIntegration/PowerShell/PowerShellBootstrapBuilder.cs
+++ b/src/NovaTerminal.CommandAssist/ShellIntegration/PowerShell/PowerShellBootstrapBuilder.cs
@@ -60,10 +60,19 @@ public static class PowerShellBootstrapBuilder
         builder.Append("    $lastExit = $global:LASTEXITCODE").Append(nl);
         builder.Append("    Write-NovaCompletion $lastSuccess $lastExit").Append(nl);
         builder.Append("    Write-NovaPromptReady").Append(nl);
-        builder.Append("    if ($script:NovaOriginalPrompt -ne $null) {").Append(nl);
-        builder.Append("        return & $script:NovaOriginalPrompt").Append(nl);
+        // OSC 133;B marks the END of the prompt -- the cell where the user's
+        // input begins. Anything this function *writes* lands before the
+        // prompt text (the host prints the returned string afterwards), so B
+        // must be appended to the returned string instead. -join '' flattens
+        // the rare prompt that emits several objects; a single-string prompt
+        // (the overwhelming case, including oh-my-posh/starship) round-trips
+        // unchanged.
+        builder.Append("    $novaPromptText = if ($script:NovaOriginalPrompt -ne $null) {").Append(nl);
+        builder.Append("        (& $script:NovaOriginalPrompt) -join ''").Append(nl);
+        builder.Append("    } else {").Append(nl);
+        builder.Append("        [string]::Concat('PS ', (Get-Location), '> ')").Append(nl);
         builder.Append("    }").Append(nl);
-        builder.Append("    return [string]::Concat('PS ', (Get-Location), '> ')").Append(nl);
+        builder.Append("    return \"$novaPromptText$([char]27)]133;B$([char]7)\"").Append(nl);
         builder.Append("}").Append(nl);
         builder.Append(nl);
         // Capture the accepted command text at the shell boundary by wrapping

--- a/src/NovaTerminal.CommandAssist/ShellIntegration/PowerShell/PowerShellBootstrapBuilder.cs
+++ b/src/NovaTerminal.CommandAssist/ShellIntegration/PowerShell/PowerShellBootstrapBuilder.cs
@@ -15,10 +15,24 @@ public static class PowerShellBootstrapBuilder
         builder.Append("$bel = [char]7").Append(nl);
         builder.Append("$script:NovaCommandStart = $null").Append(nl);
         builder.Append("$script:NovaAcceptedCommandText = $null").Append(nl);
-        builder.Append("$script:NovaOriginalPrompt = $null").Append(nl);
-        builder.Append("$script:NovaPromptCommand = Get-Command prompt -ErrorAction SilentlyContinue").Append(nl);
-        builder.Append("if ($script:NovaPromptCommand -and $script:NovaPromptCommand.ScriptBlock) {").Append(nl);
-        builder.Append("    $script:NovaOriginalPrompt = $script:NovaPromptCommand.ScriptBlock").Append(nl);
+        // Capture the user's `prompt` exactly once. Re-running the bootstrap in a
+        // session it has already initialized (a second -File pass, a user dot-source,
+        // `exec pwsh` into the same profile) would otherwise capture OUR wrapper as
+        // "the original" and the wrapper would call itself forever. Two guards, because
+        // a second -File pass gets a fresh script scope where the first guard alone
+        // cannot see the earlier capture:
+        //   1. don't overwrite an already-captured original in this scope;
+        //   2. never capture a `prompt` whose body carries our wrapper sentinel.
+        // Worst case (fresh scope + already-wrapped prompt) the bootstrap degrades to
+        // the synthesized default prompt; it never recurses.
+        builder.Append("if (-not (Get-Variable -Name 'NovaOriginalPrompt' -Scope Script -ErrorAction SilentlyContinue)) {").Append(nl);
+        builder.Append("    $script:NovaOriginalPrompt = $null").Append(nl);
+        builder.Append("}").Append(nl);
+        builder.Append("$novaPromptCommand = Get-Command prompt -ErrorAction SilentlyContinue").Append(nl);
+        builder.Append("if ($null -eq $script:NovaOriginalPrompt -and").Append(nl);
+        builder.Append("    $novaPromptCommand -and $novaPromptCommand.ScriptBlock -and").Append(nl);
+        builder.Append("    $novaPromptCommand.ScriptBlock.ToString() -notlike '*__nova_prompt_wrapper*') {").Append(nl);
+        builder.Append("    $script:NovaOriginalPrompt = $novaPromptCommand.ScriptBlock").Append(nl);
         builder.Append("}").Append(nl);
         builder.Append(nl);
         builder.Append("function Write-NovaSequence([string]$sequence) {").Append(nl);
@@ -54,6 +68,9 @@ public static class PowerShellBootstrapBuilder
         builder.Append("}").Append(nl);
         builder.Append(nl);
         builder.Append("function Global:prompt {").Append(nl);
+        // Sentinel the capture guard above greps for. Must stay inside the function
+        // body so it survives into ScriptBlock.ToString().
+        builder.Append("    # __nova_prompt_wrapper").Append(nl);
         // Snapshot $? / $LASTEXITCODE on the first line so subsequent statements
         // don't clobber them before Write-NovaCompletion reads the values.
         builder.Append("    $lastSuccess = $?").Append(nl);
@@ -67,6 +84,14 @@ public static class PowerShellBootstrapBuilder
         // the rare prompt that emits several objects; a single-string prompt
         // (the overwhelming case, including oh-my-posh/starship) round-trips
         // unchanged.
+        //
+        // Deliberate divergence: for a multi-object prompt the host itself
+        // stringifies with the $OFS separator (a space by default), so it would
+        // render "a b c" where we render "abc". Joining with '' is the choice
+        // that keeps the far more common single-string and
+        // array-of-adjacent-fragments prompts byte-identical; the alternative
+        // would insert phantom spaces into every prompt built by emitting
+        // fragments. Prompts that genuinely want separators emit them.
         builder.Append("    $novaPromptText = if ($script:NovaOriginalPrompt -ne $null) {").Append(nl);
         builder.Append("        (& $script:NovaOriginalPrompt) -join ''").Append(nl);
         builder.Append("    } else {").Append(nl);

--- a/src/NovaTerminal.CommandAssist/ShellIntegration/Runtime/ShellLifecycleTracker.cs
+++ b/src/NovaTerminal.CommandAssist/ShellIntegration/Runtime/ShellLifecycleTracker.cs
@@ -43,11 +43,19 @@ public sealed class ShellLifecycleTracker
     /// the first cell of the command line.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Fires once per prompt (and again on every prompt repaint), not once per command.
+    /// </para>
+    /// <para>
+    /// Deliberately does not touch <c>_commandStartedAt</c>. B is the moment the prompt
+    /// finished printing, so a duration measured from it would bill the user's typing time
+    /// to the command. Every path that can reach a D marker passes through
+    /// <see cref="HandleCommandAccepted"/> (OSC 133;C) first, which is the real
+    /// execution-start edge and sets the fallback clock there.
+    /// </para>
     /// </remarks>
     public void HandleCommandStarted(ShellMarkPosition? markPosition = null)
     {
-        _commandStartedAt = _nowProvider();
         Emit(
             ShellIntegrationEventType.CommandStarted,
             commandText: null,

--- a/src/NovaTerminal.CommandAssist/ShellIntegration/Runtime/ShellLifecycleTracker.cs
+++ b/src/NovaTerminal.CommandAssist/ShellIntegration/Runtime/ShellLifecycleTracker.cs
@@ -29,13 +29,31 @@ public sealed class ShellLifecycleTracker
 
     public void HandleCommandAccepted(string? commandText)
     {
+        // OSC 133;C is the real execution-start edge, so it (re)starts the duration clock used
+        // as a fallback when the shell's D marker carries no duration. Without this, the clock
+        // would be left at the 133;B timestamp — the moment the prompt finished printing — and
+        // the fallback would bill the user's typing time to the command.
+        _commandStartedAt = _nowProvider();
         Emit(ShellIntegrationEventType.CommandAccepted, commandText, exitCode: null, duration: null);
     }
 
-    public void HandleCommandStarted()
+    /// <summary>
+    /// OSC 133;B: the prompt has finished printing and the shell handed the line editor to the
+    /// user. <paramref name="markPosition"/> is where that boundary landed in the buffer, i.e.
+    /// the first cell of the command line.
+    /// </summary>
+    /// <remarks>
+    /// Fires once per prompt (and again on every prompt repaint), not once per command.
+    /// </remarks>
+    public void HandleCommandStarted(ShellMarkPosition? markPosition = null)
     {
         _commandStartedAt = _nowProvider();
-        Emit(ShellIntegrationEventType.CommandStarted, commandText: null, exitCode: null, duration: null);
+        Emit(
+            ShellIntegrationEventType.CommandStarted,
+            commandText: null,
+            exitCode: null,
+            duration: null,
+            markPosition: markPosition);
     }
 
     public void HandleCommandFinished(int? exitCode, long? durationMs = null)
@@ -60,7 +78,8 @@ public sealed class ShellLifecycleTracker
         string? commandText,
         int? exitCode,
         TimeSpan? duration,
-        DateTimeOffset? timestamp = null)
+        DateTimeOffset? timestamp = null,
+        ShellMarkPosition? markPosition = null)
     {
         EventObserved?.Invoke(new ShellIntegrationEvent(
             Type: type,
@@ -68,6 +87,7 @@ public sealed class ShellLifecycleTracker
             CommandText: commandText,
             WorkingDirectory: _workingDirectory,
             ExitCode: exitCode,
-            Duration: duration));
+            Duration: duration,
+            MarkPosition: markPosition));
     }
 }

--- a/src/NovaTerminal.CommandAssist/ShellIntegration/Zsh/ZshBootstrapBuilder.cs
+++ b/src/NovaTerminal.CommandAssist/ShellIntegration/Zsh/ZshBootstrapBuilder.cs
@@ -44,6 +44,23 @@ public static class ZshBootstrapBuilder
         b.Append("    printf '\\033]133;A\\a'").Append(nl);
         b.Append("}").Append(nl);
         b.Append(nl);
+        // OSC 133;B marks the END of the prompt -- the cell where the user's
+        // input starts. precmd runs before PROMPT is expanded, so B cannot be
+        // printed from a hook the way A is; it has to be the last thing in
+        // PROMPT itself. %{...%} tells zsh the sequence occupies zero columns,
+        // so prompt-width arithmetic and ZLE redraw stay correct.
+        b.Append("typeset -g __nova_prompt_mark=$'%{\\e]133;B\\a%}'").Append(nl);
+        // Re-applied every precmd rather than once at startup because prompt
+        // frameworks (powerlevel10k, starship, oh-my-zsh themes) reassign
+        // PROMPT from their own precmd hooks; ours is appended to
+        // precmd_functions last, so we get the final word. The containment
+        // check keeps it idempotent for static prompts.
+        b.Append("__nova_apply_prompt_mark() {").Append(nl);
+        b.Append("    if [[ \"$PROMPT\" != *\"$__nova_prompt_mark\"* ]]; then").Append(nl);
+        b.Append("        PROMPT=\"$PROMPT$__nova_prompt_mark\"").Append(nl);
+        b.Append("    fi").Append(nl);
+        b.Append("}").Append(nl);
+        b.Append(nl);
         // zsh has native preexec/precmd hooks via the function-array convention.
         // preexec receives the about-to-run command as $1, so unlike bash we
         // do not need a one-shot guard around the DEBUG trap.
@@ -65,12 +82,17 @@ public static class ZshBootstrapBuilder
         b.Append("        __nova_command_start_ms=\"\"").Append(nl);
         b.Append("    fi").Append(nl);
         b.Append("    __nova_emit_prompt_ready").Append(nl);
+        b.Append("    __nova_apply_prompt_mark").Append(nl);
         b.Append("}").Append(nl);
         b.Append(nl);
         b.Append("typeset -ag precmd_functions preexec_functions").Append(nl);
         b.Append("precmd_functions+=(__nova_precmd)").Append(nl);
         b.Append("preexec_functions+=(__nova_preexec)").Append(nl);
         b.Append(nl);
+        // The first prompt is expanded before any precmd runs in some zsh
+        // configurations, so seed the mark here too; __nova_apply_prompt_mark
+        // is idempotent.
+        b.Append("__nova_apply_prompt_mark").Append(nl);
         b.Append("__nova_emit_prompt_ready").Append(nl);
         return b.ToString();
     }

--- a/src/NovaTerminal.CommandAssist/ShellIntegration/Zsh/ZshBootstrapBuilder.cs
+++ b/src/NovaTerminal.CommandAssist/ShellIntegration/Zsh/ZshBootstrapBuilder.cs
@@ -53,12 +53,16 @@ public static class ZshBootstrapBuilder
         // Re-applied every precmd rather than once at startup because prompt
         // frameworks (powerlevel10k, starship, oh-my-zsh themes) reassign
         // PROMPT from their own precmd hooks; ours is appended to
-        // precmd_functions last, so we get the final word. The containment
-        // check keeps it idempotent for static prompts.
+        // precmd_functions last, so we get the final word.
+        //
+        // Strip-then-append rather than skip-if-present: zsh has no "arm last"
+        // invariant like bash's __nova_arm, so a precmd hook registered after
+        // ours can append to PROMPT and leave our mark buried mid-prompt, where
+        // it would report the input cell several columns early. Removing the
+        // existing suffix (a no-op when absent, since ${var%pattern} only trims
+        // a trailing match) and re-appending is idempotent AND self-correcting.
         b.Append("__nova_apply_prompt_mark() {").Append(nl);
-        b.Append("    if [[ \"$PROMPT\" != *\"$__nova_prompt_mark\"* ]]; then").Append(nl);
-        b.Append("        PROMPT=\"$PROMPT$__nova_prompt_mark\"").Append(nl);
-        b.Append("    fi").Append(nl);
+        b.Append("    PROMPT=\"${PROMPT%$__nova_prompt_mark}$__nova_prompt_mark\"").Append(nl);
         b.Append("}").Append(nl);
         b.Append(nl);
         // zsh has native preexec/precmd hooks via the function-array convention.

--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -1726,7 +1726,11 @@ namespace NovaTerminal.VT
                 Row: row,
                 Column: _buffer.CursorCol,
                 AbsoluteRow: evictedRows + row,
-                IsAltScreen: isAltScreen);
+                IsAltScreen: isAltScreen,
+                // Recorded even for alt-screen marks: the alt screen has no scrollback of its
+                // own, so the main-screen epoch is the only coordinate space that can be reset
+                // underneath a consumer holding this mark.
+                Generation: _buffer.Scrollback.Generation);
         }
 
         private void HandleOsc(string osc)

--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -165,7 +165,17 @@ namespace NovaTerminal.VT
         public Action<string, byte[]>? OnClipboardWrite { get; set; }
         public Action? OnPromptReady { get; set; }
         public Action<string>? OnCommandAccepted { get; set; }
-        public Action? OnCommandStarted { get; set; }
+        /// <summary>
+        /// OSC 133;B — prompt end / start of the user's input line. The argument carries where
+        /// the mark landed in the buffer (see <see cref="ShellIntegrationMark"/>), which is the
+        /// anchor for reading the live command line out of the grid.
+        /// </summary>
+        /// <remarks>
+        /// B is <b>not</b> "the command began executing" — that edge is OSC 133;C
+        /// (<see cref="OnCommandAccepted"/>). B fires once per prompt, including on every
+        /// prompt repaint, and the shell is idle waiting for input when it does.
+        /// </remarks>
+        public Action<ShellIntegrationMark>? OnCommandStarted { get; set; }
         public Action<int?>? OnCommandFinished { get; set; }
         public Action<int?, long?>? OnCommandFinishedDetailed { get; set; }
 
@@ -1696,6 +1706,29 @@ namespace NovaTerminal.VT
             }
         }
 
+        /// <summary>
+        /// Snapshots the cursor as a <see cref="ShellIntegrationMark"/>. Called synchronously
+        /// while the OSC is being dispatched, so the cursor is still exactly where the shell
+        /// left it when it wrote the mark — for OSC 133;B that is the first cell of the user's
+        /// input, immediately after the last prompt cell.
+        /// </summary>
+        private ShellIntegrationMark CaptureCursorMark()
+        {
+            bool isAltScreen = _buffer.IsAltScreenActive;
+
+            // The alt screen has no scrollback: rows are addressed by viewport row alone and
+            // there is no eviction counter to anchor against.
+            int scrollbackRows = isAltScreen ? 0 : _buffer.Scrollback.Count;
+            long evictedRows = isAltScreen ? 0 : _buffer.Scrollback.TotalRowsEvicted;
+
+            int row = scrollbackRows + _buffer.CursorRow;
+            return new ShellIntegrationMark(
+                Row: row,
+                Column: _buffer.CursorCol,
+                AbsoluteRow: evictedRows + row,
+                IsAltScreen: isAltScreen);
+        }
+
         private void HandleOsc(string osc)
         {
             if (string.IsNullOrEmpty(osc)) return;
@@ -1771,10 +1804,15 @@ namespace NovaTerminal.VT
 
             // OSC 133: shell integration markers.
             // Common terminals/shell integrations emit:
-            //   OSC 133;A     -> prompt ready
-            //   OSC 133;B   -> command started
+            //   OSC 133;A     -> prompt start (prompt ready)
+            //   OSC 133;B     -> prompt end / start of user input; reported with the cursor
+            //                    position at parse time, which is where the command line begins
             //   OSC 133;C;X -> command accepted with base64-encoded command X
             //   OSC 133;D;N[;M] -> command finished with exit code N and optional duration M
+            //
+            // Any parameters after the marker letter are tolerated and ignored (FinalTerm
+            // allows key=value attributes on these marks, e.g. "133;B;aid=7"), so a payload
+            // we don't understand still produces the mark rather than being dropped.
             if (code == "133")
             {
                 if (string.IsNullOrWhiteSpace(data)) return;
@@ -1791,7 +1829,7 @@ namespace NovaTerminal.VT
                 }
                 else if (string.Equals(marker, "B", StringComparison.Ordinal))
                 {
-                    OnCommandStarted?.Invoke();
+                    OnCommandStarted?.Invoke(CaptureCursorMark());
                 }
                 else if (string.Equals(marker, "C", StringComparison.Ordinal))
                 {

--- a/src/NovaTerminal.VT/Buffer/ScrollbackPages.cs
+++ b/src/NovaTerminal.VT/Buffer/ScrollbackPages.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace NovaTerminal.VT.Storage
 {
@@ -55,8 +56,21 @@ namespace NovaTerminal.VT.Storage
         private long _currentBytes;
 
         // Absolute row counters (never reset on eviction so indexing stays correct).
+        // They ARE reset by Clear(), which is what the generation epoch below exists
+        // to make detectable.
         private long _totalRowsAppended;
         private long _totalRowsEvicted;
+
+        // Invalidation epoch for the absolute-row coordinate space. Eviction leaves the
+        // space intact (TotalRowsEvicted only grows), but Clear() resets both counters to
+        // zero, so absolute row ids issued before it silently alias rows appended after it.
+        // Clear() is reachable from CSI 3J / RIS / user "clear buffer" / reflow, all of
+        // which are routine, so a holder of an absolute row id needs a way to notice.
+        // The counter is process-global rather than per-instance because reflow can swap in
+        // a brand-new ScrollbackPages (TerminalBuffer.ReflowEngine): a per-instance counter
+        // starting at zero would collide with a pre-reflow id's epoch.
+        private static long s_nextGeneration;
+        private long _generation = Interlocked.Increment(ref s_nextGeneration);
 
         // Cache for O(1) sequential GetRow access during reflow
         private TerminalPage? _lastAccessedPage;
@@ -72,6 +86,15 @@ namespace NovaTerminal.VT.Storage
 
         /// <summary>Total rows that have been evicted from this scrollback due to budget limits.</summary>
         public long TotalRowsEvicted => _totalRowsEvicted;
+
+        /// <summary>
+        /// Monotonic id of the current absolute-row coordinate space. Stable across appends
+        /// and evictions; changes whenever <see cref="Clear"/> resets the row counters (CSI 3J,
+        /// RIS, user clear-buffer, reflow) and whenever a fresh store is constructed. A holder
+        /// of an <c>AbsoluteRow</c> must record this alongside it and treat the row id as
+        /// invalid once the two no longer match.
+        /// </summary>
+        public long Generation => Interlocked.Read(ref _generation);
 
         /// <summary>Approximate byte consumption of retained cell data.</summary>
         public long CurrentBytes => _currentBytes;
@@ -317,6 +340,9 @@ namespace NovaTerminal.VT.Storage
 
         /// <summary>
         /// Removes all scrollback data and returns all pages to the pool.
+        /// Resets the absolute-row counters, and therefore bumps <see cref="Generation"/>:
+        /// every absolute row id issued before this call is now meaningless (it would
+        /// resolve to a plausible-looking but wrong row rather than going negative).
         /// </summary>
         public void Clear()
         {
@@ -327,6 +353,7 @@ namespace NovaTerminal.VT.Storage
             _currentBytes = 0;
             _totalRowsAppended = 0;
             _totalRowsEvicted = 0;
+            Interlocked.Exchange(ref _generation, Interlocked.Increment(ref s_nextGeneration));
 
             _lastAccessedPage = null;
             _lastAccessedPageStartAbsRow = 0;

--- a/src/NovaTerminal.VT/ShellIntegrationMark.cs
+++ b/src/NovaTerminal.VT/ShellIntegrationMark.cs
@@ -23,15 +23,36 @@ namespace NovaTerminal.VT
     /// <see cref="AbsoluteRow"/> is <c>Scrollback.TotalRowsEvicted + Row</c>: a
     /// monotonically increasing, eviction-stable identity for the same physical line.
     /// A later consumer re-derives the current row as
-    /// <c>AbsoluteRow - Scrollback.TotalRowsEvicted</c>; a negative result means the marked
-    /// line has aged out of history. This is the same identity the render path already uses
-    /// for row caching (see <c>TerminalBuffer.ThreadingAndInvalidation</c>).
+    /// <c>AbsoluteRow - Scrollback.TotalRowsEvicted</c>. This is the same identity the
+    /// render path already uses for row caching (see
+    /// <c>TerminalBuffer.ThreadingAndInvalidation</c>).
     /// </description></item>
     /// </list>
     /// </para>
     /// <para>
-    /// Neither coordinate survives a reflowing resize: reflow rebuilds the scrollback store
-    /// and re-wraps logical lines, so ids issued before a resize must be discarded. In
+    /// <b>Staleness contract.</b> Two different things can invalidate
+    /// <see cref="AbsoluteRow"/>, and only one of them is detectable from the row number:
+    /// <list type="bullet">
+    /// <item><description>
+    /// <i>Eviction</i> — the marked line aged out of history. <c>TotalRowsEvicted</c> only
+    /// grows, so <c>AbsoluteRow - TotalRowsEvicted</c> goes negative and the mark is
+    /// self-evidently dead.
+    /// </description></item>
+    /// <item><description>
+    /// <i>Coordinate-space reset</i> — <c>ScrollbackPages.Clear()</c> resets BOTH counters to
+    /// zero. It is reached from CSI 3J ("clear scrollback", what <c>clear(1)</c> sends with
+    /// the <c>E3</c> terminfo capability), RIS, the user's clear-buffer action, and reflow.
+    /// After it, a pre-reset <see cref="AbsoluteRow"/> resolves to a large <i>positive</i>
+    /// row that simply belongs to different content — there is nothing wrong-looking about
+    /// it. That case is why <see cref="Generation"/> exists: compare it against
+    /// <c>Scrollback.Generation</c> and discard the mark when they differ. A negative row is
+    /// a sufficient staleness test only <i>within</i> one generation.
+    /// </description></item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// A reflowing resize both re-wraps logical lines and rebuilds the scrollback store, so
+    /// it bumps <see cref="Generation"/> too and pre-resize ids are correctly rejected. In
     /// practice this is benign, because every shell re-prints its prompt after a resize and
     /// the prompt itself carries the B mark, so a fresh mark arrives with fresh coordinates.
     /// </para>
@@ -45,9 +66,14 @@ namespace NovaTerminal.VT
     /// <param name="Column">Cursor column at the moment the mark was parsed.</param>
     /// <param name="AbsoluteRow">Eviction-stable row identity for <paramref name="Row"/>.</param>
     /// <param name="IsAltScreen">True when the mark was captured while the alt screen was active.</param>
+    /// <param name="Generation">
+    /// <c>Scrollback.Generation</c> at capture time — the epoch <paramref name="AbsoluteRow"/>
+    /// is expressed in. A mark whose generation no longer matches the buffer's is invalid.
+    /// </param>
     public readonly record struct ShellIntegrationMark(
         int Row,
         int Column,
         long AbsoluteRow,
-        bool IsAltScreen);
+        bool IsAltScreen,
+        long Generation);
 }

--- a/src/NovaTerminal.VT/ShellIntegrationMark.cs
+++ b/src/NovaTerminal.VT/ShellIntegrationMark.cs
@@ -1,0 +1,53 @@
+namespace NovaTerminal.VT
+{
+    /// <summary>
+    /// Where an OSC 133 shell-integration mark landed in the buffer, captured at parse time.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Emitted for <c>OSC 133;B</c> (prompt end / start of the user's input), which is the
+    /// anchor a grid reader needs in order to extract the live command line from the buffer
+    /// instead of mirroring keystrokes.
+    /// </para>
+    /// <para>
+    /// Two row coordinates are carried on purpose:
+    /// <list type="bullet">
+    /// <item><description>
+    /// <see cref="Row"/> is the row index in the buffer's <i>current</i> addressing space
+    /// (scrollback row count + cursor row on the main screen; the cursor row itself on the
+    /// alt screen). It is what <c>TerminalBuffer.GetRow</c> / <c>GetCell</c> take, but it
+    /// shifts down by one every time a row is evicted from scrollback, so it is only valid
+    /// for immediate use.
+    /// </description></item>
+    /// <item><description>
+    /// <see cref="AbsoluteRow"/> is <c>Scrollback.TotalRowsEvicted + Row</c>: a
+    /// monotonically increasing, eviction-stable identity for the same physical line.
+    /// A later consumer re-derives the current row as
+    /// <c>AbsoluteRow - Scrollback.TotalRowsEvicted</c>; a negative result means the marked
+    /// line has aged out of history. This is the same identity the render path already uses
+    /// for row caching (see <c>TerminalBuffer.ThreadingAndInvalidation</c>).
+    /// </description></item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// Neither coordinate survives a reflowing resize: reflow rebuilds the scrollback store
+    /// and re-wraps logical lines, so ids issued before a resize must be discarded. In
+    /// practice this is benign, because every shell re-prints its prompt after a resize and
+    /// the prompt itself carries the B mark, so a fresh mark arrives with fresh coordinates.
+    /// </para>
+    /// <para>
+    /// <see cref="IsAltScreen"/> marks are captured against the alt screen, which has no
+    /// scrollback: their <see cref="AbsoluteRow"/> shares no numbering with main-screen
+    /// marks and must not be compared across the two.
+    /// </para>
+    /// </remarks>
+    /// <param name="Row">Row index in the buffer's current addressing space.</param>
+    /// <param name="Column">Cursor column at the moment the mark was parsed.</param>
+    /// <param name="AbsoluteRow">Eviction-stable row identity for <paramref name="Row"/>.</param>
+    /// <param name="IsAltScreen">True when the mark was captured while the alt screen was active.</param>
+    public readonly record struct ShellIntegrationMark(
+        int Row,
+        int Column,
+        long AbsoluteRow,
+        bool IsAltScreen);
+}

--- a/tests/NovaTerminal.App.Tests/AnsiParserHardeningTests.cs
+++ b/tests/NovaTerminal.App.Tests/AnsiParserHardeningTests.cs
@@ -120,7 +120,7 @@ public sealed class AnsiParserHardeningTests
         var buffer = new TerminalBuffer(80, 24);
         var parser = new AnsiParser(buffer);
         int startedCount = 0;
-        parser.OnCommandStarted = () => startedCount++;
+        parser.OnCommandStarted = _ => startedCount++;
 
         parser.Process("\x1b]0;bad-title\x1b]133;B\x07X");
 

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/BashBootstrapBuilderTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/BashBootstrapBuilderTests.cs
@@ -19,8 +19,47 @@ public sealed class BashBootstrapBuilderTests : IDisposable
 
         Assert.Contains("]7;", script);
         Assert.Contains("]133;A", script);
+        Assert.Contains("]133;B", script);
         Assert.Contains("]133;C;", script);
         Assert.Contains("]133;D;", script);
+    }
+
+    [Fact]
+    public void BuildScript_EmitsCommandStartMarkAtTheEndOfPs1()
+    {
+        string script = BashBootstrapBuilder.BuildScript();
+
+        // A is printed from PROMPT_COMMAND, which bash runs *before* it
+        // expands and prints PS1. B marks the opposite edge -- the first cell
+        // of the user's input -- so it can only ride at the tail of PS1, and
+        // must be wrapped in \[ \] so bash does not count it as prompt width.
+        Assert.Contains("__nova_ps1_mark='\\[\\e]133;B\\a\\]'", script);
+        Assert.Contains("PS1=\"$PS1$__nova_ps1_mark\"", script);
+
+        // Appended, never assigned from a template: the only PS1 assignment
+        // in the script is the append form above.
+        Assert.Equal(1, script.Split("PS1=", StringSplitOptions.None).Length - 1);
+    }
+
+    [Fact]
+    public void BuildScript_ReAppliesPs1MarkAfterUserPromptCommandRuns()
+    {
+        string script = BashBootstrapBuilder.BuildScript();
+
+        // Themes like starship/oh-my-posh rewrite PS1 from inside
+        // PROMPT_COMMAND, which would drop a one-shot suffix. __nova_arm is
+        // the last entry in the PROMPT_COMMAND chain, so re-applying from
+        // there gets the final word without changing the chain string (and
+        // therefore without disturbing the DEBUG-trap arm/disarm ordering).
+        int armIndex = script.IndexOf("__nova_arm() {", StringComparison.Ordinal);
+        int applyIndex = script.IndexOf("    __nova_apply_ps1_mark", armIndex, StringComparison.Ordinal);
+        int clearIndex = script.IndexOf("    __nova_command_active=0", armIndex, StringComparison.Ordinal);
+
+        Assert.True(applyIndex > armIndex, "__nova_arm must re-apply the PS1 mark");
+        Assert.True(clearIndex > applyIndex, "the active flag must still be cleared last");
+
+        // Idempotent: a static PS1 must not accumulate one marker per prompt.
+        Assert.Contains("*\"$__nova_ps1_mark\"*) ;;", script);
     }
 
     [Fact]

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/FishBootstrapBuilderTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/FishBootstrapBuilderTests.cs
@@ -56,6 +56,104 @@ public sealed class FishBootstrapBuilderTests : IDisposable
     }
 
     [Fact]
+    public void BuildScript_GuardsThePromptWrapAgainstBeingReSourced()
+    {
+        string script = FishBootstrapBuilder.BuildScript();
+
+        // This file IS $__fish_config_dir/config.fish for the session, so it is
+        // re-entered by anything that re-sources fish's config (fish's own
+        // `source $__fish_config_dir/config.fish`, `exec fish`, a user alias).
+        // Without the second half of this condition the re-run would copy the
+        // CURRENT fish_prompt -- by then our own wrapper -- into
+        // __nova_user_fish_prompt, and the redefinition would call itself
+        // forever.
+        Assert.Contains(
+            "if functions -q fish_prompt; and not functions -q __nova_user_fish_prompt",
+            script);
+    }
+
+    [Fact]
+    public void BuildScript_DoubleSourcing_CannotWrapTheWrapper()
+    {
+        // The structural argument, executed: fish is not runnable on Windows CI,
+        // so model the two statements the guarded block performs against a tiny
+        // function table and run the whole bootstrap body twice, exactly as a
+        // re-source would.
+        var functions = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["fish_prompt"] = "user prompt body",
+        };
+
+        // Mirrors the emitted script: guard, copy, redefine.
+        void RunBootstrapPromptSection()
+        {
+            if (!functions.ContainsKey("fish_prompt")) return;
+            if (functions.ContainsKey("__nova_user_fish_prompt")) return; // the fix
+            functions["__nova_user_fish_prompt"] = functions["fish_prompt"];
+            functions["fish_prompt"] = "call __nova_user_fish_prompt; print 133;B";
+        }
+
+        RunBootstrapPromptSection();
+        RunBootstrapPromptSection();
+        RunBootstrapPromptSection();
+
+        // The copied "original" is still the user's function, never the wrapper --
+        // which is precisely what makes the wrapper's self-call terminate.
+        Assert.Equal("user prompt body", functions["__nova_user_fish_prompt"]);
+        Assert.DoesNotContain("133;B", functions["__nova_user_fish_prompt"]);
+
+        // And the guard is really the thing doing the work: drop it and the same
+        // three passes produce a self-referential copy.
+        var unguarded = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["fish_prompt"] = "user prompt body",
+        };
+        for (int i = 0; i < 2; i++)
+        {
+            unguarded["__nova_user_fish_prompt"] = unguarded["fish_prompt"];
+            unguarded["fish_prompt"] = "call __nova_user_fish_prompt; print 133;B";
+        }
+        Assert.Contains("__nova_user_fish_prompt", unguarded["__nova_user_fish_prompt"]);
+    }
+
+    [Fact]
+    public void BuildScript_DoesNotAccumulatePromptMarks_AcrossPromptCycles()
+    {
+        string script = FishBootstrapBuilder.BuildScript();
+
+        // Builder-level stand-in for bash's real-shell accumulation test (fish is
+        // not installed on Windows CI). fish cannot grow a marker per cycle the way
+        // a PS1/PROMPT string can, because the mark is a `printf` *statement* in a
+        // function body rather than text appended to a variable: the wrap happens
+        // exactly once at bootstrap, guarded against re-entry, and each prompt cycle
+        // simply calls it. Pin both halves of that.
+        Assert.Contains(
+            "if functions -q fish_prompt; and not functions -q __nova_user_fish_prompt",
+            script);
+
+        // Exactly one B emission site, and it is inside the redefined fish_prompt.
+        Assert.Equal(1, CountOccurrences(script, "133;B"));
+        int redefIndex = script.IndexOf("function fish_prompt\n", StringComparison.Ordinal);
+        Assert.True(script.IndexOf("133;B", StringComparison.Ordinal) > redefIndex);
+
+        // The mark is never appended to a variable the way bash/zsh do it, so there
+        // is no accumulating string to guard.
+        Assert.DoesNotContain("fish_prompt=", script);
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0;
+        for (int i = haystack.IndexOf(needle, StringComparison.Ordinal);
+             i >= 0;
+             i = haystack.IndexOf(needle, i + needle.Length, StringComparison.Ordinal))
+        {
+            count++;
+        }
+        return count;
+    }
+
+    [Fact]
     public void BuildScript_UsesNativeFishEventHandlers()
     {
         string script = FishBootstrapBuilder.BuildScript();

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/FishBootstrapBuilderTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/FishBootstrapBuilderTests.cs
@@ -19,8 +19,40 @@ public sealed class FishBootstrapBuilderTests : IDisposable
 
         Assert.Contains("]7;", script);
         Assert.Contains("]133;A", script);
+        Assert.Contains("]133;B", script);
         Assert.Contains("]133;C;", script);
         Assert.Contains("]133;D;", script);
+    }
+
+    [Fact]
+    public void BuildScript_EmitsCommandStartMarkAfterTheUserPromptRenders()
+    {
+        string script = FishBootstrapBuilder.BuildScript();
+
+        // The fish_prompt EVENT fires before the prompt function runs, so it
+        // can only carry A. fish has no post-prompt event, so B is emitted by
+        // re-defining fish_prompt as "copy of the user's prompt, then B" --
+        // the copy keeps the user's prompt output byte-for-byte.
+        Assert.Contains("functions --copy fish_prompt __nova_user_fish_prompt", script);
+
+        int redefIndex = script.IndexOf("function fish_prompt\n", StringComparison.Ordinal);
+        Assert.True(redefIndex > 0, "fish_prompt must be re-defined around the copied original");
+
+        int originalCallIndex = script.IndexOf("    __nova_user_fish_prompt", redefIndex, StringComparison.Ordinal);
+        int markIndex = script.IndexOf("133;B", redefIndex, StringComparison.Ordinal);
+        Assert.True(originalCallIndex > redefIndex, "the copied user prompt must run first");
+        Assert.True(markIndex > originalCallIndex, "B must be emitted after the user's prompt output");
+    }
+
+    [Fact]
+    public void BuildScript_SkipsPromptWrappingWhenFishPromptIsUnavailable()
+    {
+        string script = FishBootstrapBuilder.BuildScript();
+
+        // Degradation guard, mirroring the PSReadLine probe in the PowerShell
+        // bootstrap: if fish_prompt cannot be resolved we emit A only rather
+        // than replacing the user's prompt with a synthesized one.
+        Assert.Contains("if functions -q fish_prompt", script);
     }
 
     [Fact]

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/BashShellIntegrationTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/BashShellIntegrationTests.cs
@@ -73,15 +73,21 @@ public sealed class BashShellIntegrationTests : IDisposable
     [Fact]
     public void Bootstrap_EmitsCommandStartMarkPastThePromptText()
     {
-        // The B mark rides at the tail of PS1, so by the time the parser sees
-        // it the prompt has already been painted: the mark must land at a
-        // non-zero column (i.e. after the prompt cells), not at the start of
-        // the line where A was emitted.
-        HarnessResult result = RunBash("exit 0\n", extraInitLine: "PS1='nova-test$ '");
+        // The B mark rides at the tail of PS1, so by the time the parser sees it the
+        // prompt has already been painted and the cursor sits on the first cell of the
+        // user's input -- i.e. at exactly the prompt's display width.
+        //
+        // The exact column is the assertion that matters. "> 0" would also pass if the
+        // \[ \] non-printing brackets were dropped (readline would then miscount the
+        // prompt width), if the mark were emitted mid-prompt, or if a stray cell were
+        // painted after it -- all of which put the anchor on the wrong cell and would
+        // make a Phase 1b grid read return the wrong command text.
+        const string prompt = "nova-test$ ";
+        HarnessResult result = RunBash("exit 0\n", extraInitLine: $"PS1='{prompt}'");
 
         var marks = result.Events.Where(e => e.Kind == "B").ToList();
         Assert.NotEmpty(marks);
-        Assert.Contains(marks, m => m.MarkPosition is { column: > 0 });
+        Assert.Contains(marks, m => m.MarkPosition is { } p && p.column == prompt.Length);
     }
 
     [Fact]

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/BashShellIntegrationTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/BashShellIntegrationTests.cs
@@ -71,6 +71,37 @@ public sealed class BashShellIntegrationTests : IDisposable
     }
 
     [Fact]
+    public void Bootstrap_EmitsCommandStartMarkPastThePromptText()
+    {
+        // The B mark rides at the tail of PS1, so by the time the parser sees
+        // it the prompt has already been painted: the mark must land at a
+        // non-zero column (i.e. after the prompt cells), not at the start of
+        // the line where A was emitted.
+        HarnessResult result = RunBash("exit 0\n", extraInitLine: "PS1='nova-test$ '");
+
+        var marks = result.Events.Where(e => e.Kind == "B").ToList();
+        Assert.NotEmpty(marks);
+        Assert.Contains(marks, m => m.MarkPosition is { column: > 0 });
+    }
+
+    [Fact]
+    public void Bootstrap_DoesNotAccumulatePromptMarksAcrossPromptCycles()
+    {
+        // __nova_apply_ps1_mark is called once per prompt; without its
+        // containment guard PS1 would grow one marker per cycle and the
+        // parser would see an ever-increasing burst of B marks.
+        HarnessResult result = RunBash("true\ntrue\nexit 0\n", extraInitLine: "PS1='nova-test$ '");
+
+        int prompts = result.Events.Count(e => e.Kind == "A");
+        int marks = result.Events.Count(e => e.Kind == "B");
+
+        // One B per painted prompt, give or take repaints; the failure mode
+        // this guards is quadratic growth, so a generous bound still catches it.
+        Assert.True(marks <= prompts * 2,
+            $"expected at most one B per prompt repaint, got {marks} B for {prompts} A");
+    }
+
+    [Fact]
     public void Bootstrap_ReportsNonZeroExitCode_ForFailingCommand()
     {
         HarnessResult result = RunBash("false\nexit 0\n");

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/FishShellIntegrationTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/FishShellIntegrationTests.cs
@@ -63,6 +63,19 @@ public sealed class FishShellIntegrationTests : IDisposable
     }
 
     [Fact]
+    public void Bootstrap_EmitsCommandStartMarkPastThePromptText()
+    {
+        // fish_prompt is copied aside and re-defined as "original, then B",
+        // so the mark is parsed once the user's prompt has been painted: a
+        // non-zero column proves it landed at the start of the input.
+        HarnessResult result = RunFish("exit 0\n");
+
+        var marks = result.Events.Where(e => e.Kind == "B").ToList();
+        Assert.NotEmpty(marks);
+        Assert.Contains(marks, m => m.MarkPosition is { column: > 0 });
+    }
+
+    [Fact]
     public void Bootstrap_ReportsNonZeroExitCode_ForFailingCommand()
     {
         HarnessResult result = RunFish("false\nexit 0\n");

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/FishShellIntegrationTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/FishShellIntegrationTests.cs
@@ -27,7 +27,7 @@ public sealed class FishShellIntegrationTests : IDisposable
         try { Directory.Delete(_tempRoot, recursive: true); } catch { }
     }
 
-    private HarnessResult RunFish(string stdin)
+    private HarnessResult RunFish(string stdin, string? extraInitLine = null)
     {
         string? fish = ShellHarness.FindFish();
         if (fish is null)
@@ -48,6 +48,17 @@ public sealed class FishShellIntegrationTests : IDisposable
             ["HOME"] = _tempRoot,
         };
 
+        // The bootstrap explicitly sources "$HOME/.config/fish/config.fish" as the
+        // user's config. HOME is redirected above, and XDG_CONFIG_HOME points at
+        // <root> (not <root>/.config), so this file is a distinct, test-owned config
+        // and there is no risk of the bootstrap sourcing itself.
+        if (extraInitLine is not null)
+        {
+            string userConfigDir = Path.Combine(_tempRoot, ".config", "fish");
+            Directory.CreateDirectory(userConfigDir);
+            File.WriteAllText(Path.Combine(userConfigDir, "config.fish"), extraInitLine + "\n");
+        }
+
         // fish -i reads stdin in interactive mode.
         return ShellHarness.Run(fish, "-i", stdin, env, TimeSpan.FromSeconds(20));
     }
@@ -65,14 +76,38 @@ public sealed class FishShellIntegrationTests : IDisposable
     [Fact]
     public void Bootstrap_EmitsCommandStartMarkPastThePromptText()
     {
-        // fish_prompt is copied aside and re-defined as "original, then B",
-        // so the mark is parsed once the user's prompt has been painted: a
-        // non-zero column proves it landed at the start of the input.
-        HarnessResult result = RunFish("exit 0\n");
+        // fish_prompt is copied aside and re-defined as "original, then B", so the mark
+        // is parsed once the user's prompt has been painted and the cursor sits on the
+        // first cell of the user's input -- exactly the prompt's display width. The
+        // exact column is what proves the copy ran *before* the mark and emitted the
+        // user's prompt byte-for-byte; "> 0" would pass even if the wrapper had painted
+        // something of its own.
+        const string prompt = "nova-test$ ";
+        HarnessResult result = RunFish(
+            "exit 0\n",
+            extraInitLine: $"function fish_prompt; printf '{prompt}'; end");
 
         var marks = result.Events.Where(e => e.Kind == "B").ToList();
         Assert.NotEmpty(marks);
-        Assert.Contains(marks, m => m.MarkPosition is { column: > 0 });
+        Assert.Contains(marks, m => m.MarkPosition is { } p && p.column == prompt.Length);
+    }
+
+    [Fact]
+    public void Bootstrap_DoesNotAccumulatePromptMarksAcrossPromptCycles()
+    {
+        // fish wraps fish_prompt exactly once at bootstrap (guarded against a
+        // re-source), so unlike bash/zsh there is no per-cycle string to grow. Pin it
+        // at runtime anyway: the wrap is the one place a recursive or repeated
+        // redefinition would show up, as a burst of B per prompt.
+        HarnessResult result = RunFish(
+            "true\ntrue\nexit 0\n",
+            extraInitLine: "function fish_prompt; printf 'nova-test$ '; end");
+
+        int prompts = result.Events.Count(e => e.Kind == "A");
+        int marks = result.Events.Count(e => e.Kind == "B");
+
+        Assert.True(marks <= prompts * 2,
+            $"expected at most one B per prompt repaint, got {marks} B for {prompts} A");
     }
 
     [Fact]

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/ShellHarness.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/ShellHarness.cs
@@ -24,6 +24,19 @@ internal sealed record OscEvent(string Kind, string? Payload)
         }
     }
 
+    /// <summary>Row/column carried by an OSC 133;B mark, or null for other kinds.</summary>
+    public (int row, int column)? MarkPosition
+    {
+        get
+        {
+            if (Kind != "B" || Payload is null) return null;
+            string[] parts = Payload.Split(',');
+            if (parts.Length != 2) return null;
+            if (!int.TryParse(parts[0], out int row) || !int.TryParse(parts[1], out int column)) return null;
+            return (row, column);
+        }
+    }
+
     public (int? exitCode, long? durationMs) DecodedFinish
     {
         get
@@ -129,6 +142,13 @@ internal static class ShellHarness
         parser.OnPromptReady = () =>
         {
             lock (sync) events.Add(new OscEvent("A", null));
+        };
+        parser.OnCommandStarted = mark =>
+        {
+            // OSC 133;B carries the buffer position of the prompt/input boundary;
+            // record it as "row,col" so tests can assert the mark landed past the
+            // prompt text rather than at column 0.
+            lock (sync) events.Add(new OscEvent("B", $"{mark.Row},{mark.Column}"));
         };
         parser.OnCommandAccepted = text =>
         {

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/ZshShellIntegrationTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/ZshShellIntegrationTests.cs
@@ -71,6 +71,20 @@ public sealed class ZshShellIntegrationTests : IDisposable
     }
 
     [Fact]
+    public void Bootstrap_EmitsCommandStartMarkPastThePromptText()
+    {
+        // The B mark is appended to PROMPT as a %{...%} zero-width sequence,
+        // so it is parsed after the prompt cells are painted: a non-zero
+        // column proves it landed at the start of the input, not at the
+        // prompt-start position where A was emitted.
+        HarnessResult result = RunZsh("exit 0\n");
+
+        var marks = result.Events.Where(e => e.Kind == "B").ToList();
+        Assert.NotEmpty(marks);
+        Assert.Contains(marks, m => m.MarkPosition is { column: > 0 });
+    }
+
+    [Fact]
     public void Bootstrap_ReportsNonZeroExitCode_ForFailingCommand()
     {
         HarnessResult result = RunZsh("false\nexit 0\n");

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/ZshShellIntegrationTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/ZshShellIntegrationTests.cs
@@ -27,7 +27,7 @@ public sealed class ZshShellIntegrationTests : IDisposable
         try { Directory.Delete(_tempRoot, recursive: true); } catch { }
     }
 
-    private HarnessResult RunZsh(string stdin)
+    private HarnessResult RunZsh(string stdin, string? extraInitLine = null)
     {
         string? zsh = ShellHarness.FindZsh();
         if (zsh is null)
@@ -49,6 +49,14 @@ public sealed class ZshShellIntegrationTests : IDisposable
             // pick up the dev machine's actual user config.
             ["HOME"] = _tempRoot,
         };
+
+        // The bootstrap sources $HOME/.zshrc first, so a test-controlled user
+        // rc goes there (HOME is redirected above, so this cannot be the dev
+        // machine's real config).
+        if (extraInitLine is not null)
+        {
+            File.WriteAllText(Path.Combine(_tempRoot, ".zshrc"), extraInitLine + "\n");
+        }
 
         // `--no-global-rcs` skips /etc/zsh/* so the system zshrc doesn't run
         // compinit on us. On a fresh CI runner compinit detects "insecure
@@ -73,15 +81,32 @@ public sealed class ZshShellIntegrationTests : IDisposable
     [Fact]
     public void Bootstrap_EmitsCommandStartMarkPastThePromptText()
     {
-        // The B mark is appended to PROMPT as a %{...%} zero-width sequence,
-        // so it is parsed after the prompt cells are painted: a non-zero
-        // column proves it landed at the start of the input, not at the
-        // prompt-start position where A was emitted.
-        HarnessResult result = RunZsh("exit 0\n");
+        // The B mark is appended to PROMPT as a %{...%} zero-width sequence, so it is
+        // parsed once the prompt cells are painted and the cursor is on the first cell
+        // of the user's input -- exactly the prompt's display width. Asserting the exact
+        // column (not merely "> 0") is what pins the %{...%} zero-width wrapper: without
+        // it zsh counts the escape as printable cells and the anchor drifts.
+        const string prompt = "nova-test$ ";
+        HarnessResult result = RunZsh("exit 0\n", extraInitLine: $"PROMPT='{prompt}'");
 
         var marks = result.Events.Where(e => e.Kind == "B").ToList();
         Assert.NotEmpty(marks);
-        Assert.Contains(marks, m => m.MarkPosition is { column: > 0 });
+        Assert.Contains(marks, m => m.MarkPosition is { } p && p.column == prompt.Length);
+    }
+
+    [Fact]
+    public void Bootstrap_DoesNotAccumulatePromptMarksAcrossPromptCycles()
+    {
+        // __nova_apply_prompt_mark runs once per precmd. It strips any trailing copy of
+        // the mark before re-appending, so PROMPT must not grow a marker per cycle --
+        // the failure mode is quadratic B traffic, which a generous bound still catches.
+        HarnessResult result = RunZsh("true\ntrue\nexit 0\n", extraInitLine: "PROMPT='nova-test$ '");
+
+        int prompts = result.Events.Count(e => e.Kind == "A");
+        int marks = result.Events.Count(e => e.Kind == "B");
+
+        Assert.True(marks <= prompts * 2,
+            $"expected at most one B per prompt repaint, got {marks} B for {prompts} A");
     }
 
     [Fact]

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/PowerShellBootstrapBuilderTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/PowerShellBootstrapBuilderTests.cs
@@ -19,8 +19,37 @@ public sealed class PowerShellBootstrapBuilderTests : IDisposable
 
         Assert.Contains("]7;", script);
         Assert.Contains("]133;A", script);
+        Assert.Contains("]133;B", script);
         Assert.Contains("]133;C;", script);
         Assert.Contains("]133;D;", script);
+    }
+
+    [Fact]
+    public void BuildScript_AppendsCommandStartMarkToTheReturnedPromptString()
+    {
+        string script = PowerShellBootstrapBuilder.BuildScript();
+
+        // Anything the prompt function *writes* lands before the prompt text,
+        // because the host prints the returned string afterwards. A is written
+        // (prompt start); B has to be appended to the returned string so it
+        // lands on the first cell of the user's input.
+        Assert.Contains("return \"$novaPromptText$([char]27)]133;B$([char]7)\"", script);
+
+        int promptReadyIndex = script.IndexOf("    Write-NovaPromptReady", StringComparison.Ordinal);
+        int markIndex = script.IndexOf("]133;B", StringComparison.Ordinal);
+        Assert.True(promptReadyIndex > 0 && markIndex > promptReadyIndex,
+            "the B mark must be produced after the A mark within the prompt function");
+    }
+
+    [Fact]
+    public void BuildScript_KeepsUserPromptOutputWhenAppendingCommandStartMark()
+    {
+        string script = PowerShellBootstrapBuilder.BuildScript();
+
+        // The wrapped original prompt still supplies the prompt text; we only
+        // concatenate the zero-width mark onto whatever it produced.
+        Assert.Contains("$novaPromptText = if ($script:NovaOriginalPrompt -ne $null) {", script);
+        Assert.Contains("(& $script:NovaOriginalPrompt) -join ''", script);
     }
 
     [Fact]

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/PowerShellBootstrapBuilderTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/PowerShellBootstrapBuilderTests.cs
@@ -120,6 +120,71 @@ public sealed class PowerShellBootstrapBuilderTests : IDisposable
     }
 
     [Fact]
+    public void BuildScript_CapturesTheOriginalPromptAtMostOnce()
+    {
+        string script = PowerShellBootstrapBuilder.BuildScript();
+
+        // Running the bootstrap a second time in a session it already initialized
+        // (a second -File pass, a user dot-source, `exec pwsh`) must not capture
+        // OUR wrapper as "the original prompt" -- the wrapper would then invoke
+        // itself forever. Two guards, because a second -File pass gets a fresh
+        // script scope in which the first guard alone cannot see the earlier capture.
+        Assert.Contains(
+            "if (-not (Get-Variable -Name 'NovaOriginalPrompt' -Scope Script -ErrorAction SilentlyContinue)) {",
+            script);
+        Assert.Contains("if ($null -eq $script:NovaOriginalPrompt -and", script);
+        Assert.Contains("-notlike '*__nova_prompt_wrapper*'", script);
+
+        // The sentinel the second guard looks for must actually be inside the
+        // wrapper body, or the check silently never fires.
+        int promptIndex = script.IndexOf("function Global:prompt {", StringComparison.Ordinal);
+        int sentinelIndex = script.IndexOf("    # __nova_prompt_wrapper", StringComparison.Ordinal);
+        Assert.True(promptIndex >= 0 && sentinelIndex > promptIndex,
+            "the wrapper sentinel must live inside the Global:prompt body");
+
+        // The pre-fix shape: an unconditional reset followed by an unconditional
+        // capture. Its presence would re-enable the recursion.
+        Assert.DoesNotContain(
+            "$script:NovaOriginalPrompt = $null\n$script:NovaPromptCommand = Get-Command prompt",
+            script);
+    }
+
+    [Fact]
+    public void BuildScript_DoesNotAccumulatePromptMarks_AcrossPromptCycles()
+    {
+        string script = PowerShellBootstrapBuilder.BuildScript();
+
+        // The pwsh analogue of the bash accumulation test. PowerShell cannot grow a
+        // marker per cycle the way a PS1/PROMPT *string* can: the mark is concatenated
+        // onto the value the wrapper RETURNS, and the wrapper composes that value fresh
+        // from $script:NovaOriginalPrompt on every call. So the invariants to pin are
+        // (a) exactly one place emits B, in the return expression, and (b) the wrapper
+        // never mutates the stored original.
+        Assert.Equal(1, CountOccurrences(script, "]133;B"));
+        Assert.Contains("return \"$novaPromptText$([char]27)]133;B$([char]7)\"", script);
+
+        // The only assignment to the captured original is the guarded capture above --
+        // nothing inside the prompt function writes to it.
+        int promptIndex = script.IndexOf("function Global:prompt {", StringComparison.Ordinal);
+        Assert.True(promptIndex > 0);
+        Assert.DoesNotContain(
+            "$script:NovaOriginalPrompt =",
+            script[promptIndex..]);
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0;
+        for (int i = haystack.IndexOf(needle, StringComparison.Ordinal);
+             i >= 0;
+             i = haystack.IndexOf(needle, i + needle.Length, StringComparison.Ordinal))
+        {
+            count++;
+        }
+        return count;
+    }
+
+    [Fact]
     public void BuildScript_OnlyEmitsCompletionWhenAcceptedCommandIsActive()
     {
         string script = PowerShellBootstrapBuilder.BuildScript();

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/ShellLifecycleTrackerTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/ShellLifecycleTrackerTests.cs
@@ -15,6 +15,7 @@ public sealed class ShellLifecycleTrackerTests
 
         tracker.HandleWorkingDirectoryChanged("/repo");
         tracker.HandleCommandStarted();
+        tracker.HandleCommandAccepted("sleep 2");
         now = now.AddSeconds(2);
         tracker.HandleCommandFinished(17);
 
@@ -34,6 +35,7 @@ public sealed class ShellLifecycleTrackerTests
                 Assert.Null(evt.ExitCode);
                 Assert.Null(evt.Duration);
             },
+            evt => Assert.Equal(ShellIntegrationEventType.CommandAccepted, evt.Type),
             evt =>
             {
                 Assert.Equal(ShellIntegrationEventType.CommandFinished, evt.Type);
@@ -41,6 +43,27 @@ public sealed class ShellLifecycleTrackerTests
                 Assert.Equal(17, evt.ExitCode);
                 Assert.Equal(TimeSpan.FromSeconds(2), evt.Duration);
             });
+    }
+
+    [Fact]
+    public void HandleCommandStarted_DoesNotStartTheDurationFallbackClock()
+    {
+        // OSC 133;B is not an execution edge -- it is "the prompt finished printing".
+        // Anchoring the fallback clock there would bill the user's typing time to the
+        // command, and every path that can produce a D marker goes through C first, so
+        // B must leave the clock alone entirely. Without a C, a D that carries no
+        // duration of its own reports no duration rather than a fabricated one.
+        DateTimeOffset now = new(2026, 8, 1, 12, 0, 0, TimeSpan.Zero);
+        var tracker = new ShellLifecycleTracker(() => now);
+        var events = new List<ShellIntegrationEvent>();
+        tracker.EventObserved += events.Add;
+
+        tracker.HandleCommandStarted(new ShellMarkPosition(0, 5, 0, false, 1));
+        now = now.AddMinutes(5); // user reading, then typing, at the prompt
+        tracker.HandleCommandFinished(exitCode: 0);
+
+        var finished = Assert.Single(events, e => e.Type == ShellIntegrationEventType.CommandFinished);
+        Assert.Null(finished.Duration);
     }
 
     [Fact]
@@ -52,7 +75,7 @@ public sealed class ShellLifecycleTrackerTests
 
         tracker.HandleWorkingDirectoryChanged("/repo");
         tracker.HandleCommandStarted(new ShellMarkPosition(
-            Row: 42, Column: 17, AbsoluteRow: 1042, IsAltScreen: false));
+            Row: 42, Column: 17, AbsoluteRow: 1042, IsAltScreen: false, Generation: 7));
 
         var started = Assert.Single(events, e => e.Type == ShellIntegrationEventType.CommandStarted);
         Assert.NotNull(started.MarkPosition);
@@ -61,6 +84,7 @@ public sealed class ShellLifecycleTrackerTests
         Assert.Equal(17, position.Column);
         Assert.Equal(1042L, position.AbsoluteRow);
         Assert.False(position.IsAltScreen);
+        Assert.Equal(7L, position.Generation);
         Assert.Equal("/repo", started.WorkingDirectory);
     }
 
@@ -91,7 +115,7 @@ public sealed class ShellLifecycleTrackerTests
         var events = new List<ShellIntegrationEvent>();
         tracker.EventObserved += events.Add;
 
-        tracker.HandleCommandStarted(new ShellMarkPosition(0, 5, 0, false));
+        tracker.HandleCommandStarted(new ShellMarkPosition(0, 5, 0, false, 1));
         now = now.AddSeconds(30); // user typing at the prompt
         tracker.HandleCommandAccepted("sleep 1");
         now = now.AddSeconds(1);

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/ShellLifecycleTrackerTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/ShellLifecycleTrackerTests.cs
@@ -44,6 +44,64 @@ public sealed class ShellLifecycleTrackerTests
     }
 
     [Fact]
+    public void HandleCommandStarted_CarriesTheMarkPositionOnTheEmittedEvent()
+    {
+        var tracker = new ShellLifecycleTracker();
+        var events = new List<ShellIntegrationEvent>();
+        tracker.EventObserved += events.Add;
+
+        tracker.HandleWorkingDirectoryChanged("/repo");
+        tracker.HandleCommandStarted(new ShellMarkPosition(
+            Row: 42, Column: 17, AbsoluteRow: 1042, IsAltScreen: false));
+
+        var started = Assert.Single(events, e => e.Type == ShellIntegrationEventType.CommandStarted);
+        Assert.NotNull(started.MarkPosition);
+        ShellMarkPosition position = started.MarkPosition.Value;
+        Assert.Equal(42, position.Row);
+        Assert.Equal(17, position.Column);
+        Assert.Equal(1042L, position.AbsoluteRow);
+        Assert.False(position.IsAltScreen);
+        Assert.Equal("/repo", started.WorkingDirectory);
+    }
+
+    [Fact]
+    public void HandleCommandStarted_WithoutAPosition_EmitsANullMarkPosition()
+    {
+        // Marks from integrations that predate position capture (and every
+        // other event type) simply leave the field null.
+        var tracker = new ShellLifecycleTracker();
+        var events = new List<ShellIntegrationEvent>();
+        tracker.EventObserved += events.Add;
+
+        tracker.HandleCommandStarted();
+        tracker.HandlePromptReady();
+        tracker.HandleCommandAccepted("git status");
+
+        Assert.All(events, e => Assert.Null(e.MarkPosition));
+    }
+
+    [Fact]
+    public void HandleCommandAccepted_RestartsTheDurationFallbackClock()
+    {
+        // OSC 133;B now fires at every prompt, so the clock it starts would
+        // bill the user's typing time to the command. C is the real
+        // execution-start edge and must win.
+        DateTimeOffset now = new(2026, 8, 1, 12, 0, 0, TimeSpan.Zero);
+        var tracker = new ShellLifecycleTracker(() => now);
+        var events = new List<ShellIntegrationEvent>();
+        tracker.EventObserved += events.Add;
+
+        tracker.HandleCommandStarted(new ShellMarkPosition(0, 5, 0, false));
+        now = now.AddSeconds(30); // user typing at the prompt
+        tracker.HandleCommandAccepted("sleep 1");
+        now = now.AddSeconds(1);
+        tracker.HandleCommandFinished(exitCode: 0);
+
+        var finished = Assert.Single(events, e => e.Type == ShellIntegrationEventType.CommandFinished);
+        Assert.Equal(TimeSpan.FromSeconds(1), finished.Duration);
+    }
+
+    [Fact]
     public void HandleCommandFinishedWithoutStart_EmitsFinishedWithoutDuration()
     {
         var tracker = new ShellLifecycleTracker();

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/ZshBootstrapBuilderTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/ZshBootstrapBuilderTests.cs
@@ -19,6 +19,7 @@ public sealed class ZshBootstrapBuilderTests : IDisposable
 
         Assert.Contains("]7;", script);
         Assert.Contains("]133;A", script);
+        Assert.Contains("]133;B", script);
         Assert.Contains("]133;C;", script);
         Assert.Contains("]133;D;", script);
     }
@@ -39,8 +40,41 @@ public sealed class ZshBootstrapBuilderTests : IDisposable
 
         // The bootstrap must not overwrite PROMPT/PS1 with our own template;
         // it can only emit OSC markers around the user's existing prompt.
-        Assert.DoesNotContain("PROMPT=", script);
+        // The single permitted PROMPT assignment is the zero-width OSC 133;B
+        // suffix, which appends to whatever the user's prompt already is.
         Assert.DoesNotContain("PS1=", script);
+        Assert.Equal(
+            1,
+            script.Split("PROMPT=", StringSplitOptions.None).Length - 1);
+        Assert.Contains("PROMPT=\"$PROMPT$__nova_prompt_mark\"", script);
+    }
+
+    [Fact]
+    public void BuildScript_EmitsCommandStartMarkAtTheEndOfThePrompt()
+    {
+        string script = ZshBootstrapBuilder.BuildScript();
+
+        // A is printed from precmd, i.e. before PROMPT is expanded; B has to
+        // land after the last prompt cell, so it rides at the tail of PROMPT
+        // wrapped in %{...%} (zero display width).
+        Assert.Contains("__nova_prompt_mark=$'%{\\e]133;B\\a%}'", script);
+        Assert.Contains("PROMPT=\"$PROMPT$__nova_prompt_mark\"", script);
+
+        // ...and it is (re)applied from precmd so prompt frameworks that
+        // reassign PROMPT every cycle cannot drop it.
+        int precmdIndex = script.IndexOf("__nova_precmd() {", StringComparison.Ordinal);
+        int applyIndex = script.IndexOf("    __nova_apply_prompt_mark", precmdIndex, StringComparison.Ordinal);
+        Assert.True(applyIndex > precmdIndex, "precmd must re-apply the prompt mark");
+    }
+
+    [Fact]
+    public void BuildScript_AppliesPromptMarkIdempotently()
+    {
+        string script = ZshBootstrapBuilder.BuildScript();
+
+        // Called once per prompt: without the containment guard a static
+        // PROMPT would grow one marker per prompt cycle, forever.
+        Assert.Contains("if [[ \"$PROMPT\" != *\"$__nova_prompt_mark\"* ]]; then", script);
     }
 
     [Fact]

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/ZshBootstrapBuilderTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/ZshBootstrapBuilderTests.cs
@@ -46,7 +46,7 @@ public sealed class ZshBootstrapBuilderTests : IDisposable
         Assert.Equal(
             1,
             script.Split("PROMPT=", StringSplitOptions.None).Length - 1);
-        Assert.Contains("PROMPT=\"$PROMPT$__nova_prompt_mark\"", script);
+        Assert.Contains("PROMPT=\"${PROMPT%$__nova_prompt_mark}$__nova_prompt_mark\"", script);
     }
 
     [Fact]
@@ -58,7 +58,7 @@ public sealed class ZshBootstrapBuilderTests : IDisposable
         // land after the last prompt cell, so it rides at the tail of PROMPT
         // wrapped in %{...%} (zero display width).
         Assert.Contains("__nova_prompt_mark=$'%{\\e]133;B\\a%}'", script);
-        Assert.Contains("PROMPT=\"$PROMPT$__nova_prompt_mark\"", script);
+        Assert.Contains("PROMPT=\"${PROMPT%$__nova_prompt_mark}$__nova_prompt_mark\"", script);
 
         // ...and it is (re)applied from precmd so prompt frameworks that
         // reassign PROMPT every cycle cannot drop it.
@@ -72,9 +72,47 @@ public sealed class ZshBootstrapBuilderTests : IDisposable
     {
         string script = ZshBootstrapBuilder.BuildScript();
 
-        // Called once per prompt: without the containment guard a static
-        // PROMPT would grow one marker per prompt cycle, forever.
-        Assert.Contains("if [[ \"$PROMPT\" != *\"$__nova_prompt_mark\"* ]]; then", script);
+        // Called once per prompt, so it must not grow PROMPT by a marker per
+        // cycle. Strip-then-append rather than skip-if-present: a "contains?"
+        // guard is idempotent but not self-correcting -- unlike bash, zsh gives
+        // us no way to be the last precmd hook, so a hook registered after ours
+        // can append to PROMPT and strand our mark mid-prompt, where it would
+        // report the input cell several columns early. ${PROMPT%pattern} trims
+        // only a *trailing* match and is a no-op when absent, so the mark is
+        // re-seated at the true tail every cycle.
+        Assert.Contains("PROMPT=\"${PROMPT%$__nova_prompt_mark}$__nova_prompt_mark\"", script);
+        Assert.DoesNotContain("if [[ \"$PROMPT\" != *\"$__nova_prompt_mark\"* ]]; then", script);
+    }
+
+    [Fact]
+    public void BuildScript_DoesNotAccumulatePromptMarks_AcrossSimulatedPromptCycles()
+    {
+        // Builder-level stand-in for the real-shell accumulation test bash has
+        // (zsh is not installed on Windows CI). Models what
+        // __nova_apply_prompt_mark does to PROMPT over repeated precmd cycles,
+        // including the "a later hook appended something" case that the old
+        // containment guard could not repair.
+        const string mark = "%{]133;B%}";
+        static string Apply(string prompt, string m) =>
+            (prompt.EndsWith(m, StringComparison.Ordinal) ? prompt[..^m.Length] : prompt) + m;
+
+        string prompt = "user@host %# ";
+        for (int i = 0; i < 10; i++)
+        {
+            prompt = Apply(prompt, mark);
+        }
+
+        Assert.Equal("user@host %# " + mark, prompt);
+        Assert.Equal(1, prompt.Split(mark).Length - 1);
+
+        // A prompt framework appends after us. The next cycle must put a mark back
+        // at the true tail; the containment guard would have seen "already present"
+        // and left the only mark buried several columns early. (An orphaned earlier
+        // mark is harmless -- B is re-emitted per prompt and the parser hands the
+        // consumer the newest one.)
+        prompt += "$ ";
+        prompt = Apply(prompt, mark);
+        Assert.EndsWith(mark, prompt, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/NovaTerminal.App.Tests/Controls/PaneParserWiringTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneParserWiringTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
 using NovaTerminal.Controls;
 using NovaTerminal.Shell;
 using NovaTerminal.VT;
@@ -163,6 +164,95 @@ public class PaneParserWiringTests
             Environment.SetEnvironmentVariable("NOVATERM_APPDATA_ROOT", previousRoot);
             Directory.Delete(tempRoot, recursive: true);
         }
+    }
+
+    /// <summary>
+    /// PR #284's one behaviour change: "the command is running" is driven by OSC 133;C
+    /// (command accepted / execution start), not OSC 133;B (prompt end). B fires once per
+    /// painted prompt — including every repaint — while the shell sits idle waiting for
+    /// input, so wiring Running to it would report every idle prompt as a busy session,
+    /// clear <see cref="TerminalPane.LastExitCode"/> under the user's feet, and fire
+    /// <c>CommandStarted</c> as terminal noise.
+    ///
+    /// Driven through the real parser so the assertion covers the pane's wiring, not a
+    /// hand-called notifier.
+    /// </summary>
+    [AvaloniaFact]
+    public void PromptEndMark_DoesNotStartACommand_ButCommandAcceptedDoes()
+    {
+        using var pane = new TerminalPane();
+        pane.CreateAndWireParser();
+        Assert.NotNull(pane.Parser);
+        AnsiParser parser = pane.Parser!;
+
+        Assert.True(
+            NovaTerminal.AgentHost.AgentSessionRegistry.Instance.TryGet(pane.PaneId, out var registration),
+            "the pane registers itself with the agent-session registry in SetupCommon");
+
+        int commandStartedCount = 0;
+        pane.CommandStarted += _ => commandStartedCount++;
+
+        // Seed a finished command so the LastExitCode reset has something to clear.
+        parser.OnCommandFinished?.Invoke(3);
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal(3, pane.LastExitCode);
+
+        // A + prompt text + B: the whole prompt cycle, with the shell now idle at the
+        // input cell.
+        parser.Process("\x1b]133;A\x07");
+        parser.Process("user@host:~$ ");
+        parser.Process("\x1b]133;B\x07");
+        Dispatcher.UIThread.RunJobs();
+
+        var afterPromptEnd = registration.StatusMachine.Snapshot();
+        Assert.Equal(NovaTerminal.AgentHost.AgentSessionStatusKind.AwaitingInput, afterPromptEnd.Kind);
+        // Precise, not merely "heuristic and nothing running": A already put the machine on
+        // the precise tier, so AwaitingInput here is a real statement about the shell.
+        Assert.Equal(NovaTerminal.AgentHost.AgentSessionStatusConfidence.Precise, afterPromptEnd.Confidence);
+        Assert.Null(afterPromptEnd.CurrentCommand);
+        Assert.Equal(3, pane.LastExitCode);
+        Assert.Equal(0, commandStartedCount);
+
+        // C is the execution-start edge.
+        string encoded = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("sleep 5"));
+        parser.Process($"\x1b]133;C;{encoded}\x07");
+        Dispatcher.UIThread.RunJobs();
+
+        var afterAccepted = registration.StatusMachine.Snapshot();
+        Assert.Equal(NovaTerminal.AgentHost.AgentSessionStatusKind.Running, afterAccepted.Kind);
+        Assert.Equal("sleep 5", afterAccepted.CurrentCommand);
+        Assert.Null(pane.LastExitCode);
+        Assert.Equal(1, commandStartedCount);
+    }
+
+    /// <summary>
+    /// The other half of the B contract: a prompt repaint re-emits B, and that must stay a
+    /// no-op for session status even while a command is genuinely running (a prompt-drawing
+    /// TUI, or a shell that repaints after a resize mid-command).
+    /// </summary>
+    [AvaloniaFact]
+    public void RepeatedPromptEndMarks_DoNotDisturbARunningCommand()
+    {
+        using var pane = new TerminalPane();
+        pane.CreateAndWireParser();
+        Assert.True(
+            NovaTerminal.AgentHost.AgentSessionRegistry.Instance.TryGet(pane.PaneId, out var registration));
+
+        AnsiParser parser = pane.Parser!;
+        string encoded = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("sleep 5"));
+        parser.Process("\x1b]133;A\x07$ \x1b]133;B\x07");
+        parser.Process($"\x1b]133;C;{encoded}\x07");
+        Assert.Equal(
+            NovaTerminal.AgentHost.AgentSessionStatusKind.Running,
+            registration.StatusMachine.Snapshot().Kind);
+
+        parser.Process("\x1b]133;B\x07");
+        parser.Process("\x1b]133;B\x07");
+        Dispatcher.UIThread.RunJobs();
+
+        var snapshot = registration.StatusMachine.Snapshot();
+        Assert.Equal(NovaTerminal.AgentHost.AgentSessionStatusKind.Running, snapshot.Kind);
+        Assert.Equal("sleep 5", snapshot.CurrentCommand);
     }
 
     private static string CreateTempAppRoot()

--- a/tests/NovaTerminal.App.Tests/OscShellIntegrationTests.cs
+++ b/tests/NovaTerminal.App.Tests/OscShellIntegrationTests.cs
@@ -13,12 +13,16 @@ public sealed class OscShellIntegrationTests
     {
         var buffer = new TerminalBuffer(80, 24);
         var parser = new AnsiParser(buffer);
-        bool started = false;
+        ShellIntegrationMark? mark = null;
 
-        parser.OnCommandStarted += () => started = true;
+        parser.OnCommandStarted += m => mark = m;
+        parser.Process("$ ");
         parser.Process("\x1b]133;B\x07");
 
-        Assert.True(started);
+        Assert.NotNull(mark);
+        // The mark carries where the user's input starts; see
+        // NovaTerminal.VT.Tests/Osc133CommandStartMarkTests for the full contract.
+        Assert.Equal(2, mark!.Value.Column);
     }
 
     [Fact]

--- a/tests/NovaTerminal.VT.Tests/Osc133CommandStartMarkTests.cs
+++ b/tests/NovaTerminal.VT.Tests/Osc133CommandStartMarkTests.cs
@@ -14,9 +14,17 @@ public class Osc133CommandStartMarkTests
 
     private static (AnsiParser Parser, TerminalBuffer Buffer, List<ShellIntegrationMark> Marks) Make(
         int cols = 40,
-        int rows = 5)
+        int rows = 5,
+        int? maxHistory = null)
     {
         var buffer = new TerminalBuffer(cols, rows);
+        if (maxHistory is int history)
+        {
+            // The byte budget is derived from MaxHistory; eviction works in whole
+            // 64-row pages, so a budget of two pages is the smallest one that both
+            // retains rows and actually evicts.
+            buffer.MaxHistory = history;
+        }
         var parser = new AnsiParser(buffer);
         var marks = new List<ShellIntegrationMark>();
         parser.OnCommandStarted = mark => marks.Add(mark);
@@ -79,11 +87,102 @@ public class Osc133CommandStartMarkTests
             Assert.True(marks[i].AbsoluteRow > marks[i - 1].AbsoluteRow);
         }
 
-        // The last mark still resolves to a live row: current row =
-        // AbsoluteRow - TotalRowsEvicted, which is what a later consumer computes.
-        long evicted = buffer.Scrollback.TotalRowsEvicted;
-        Assert.Equal(marks[^1].Row, (int)(marks[^1].AbsoluteRow - evicted));
+        // Plain scrolling does not disturb the coordinate space, so every mark carries the
+        // same generation and each one still resolves inside the buffer.
+        Assert.All(marks, m => Assert.Equal(buffer.Scrollback.Generation, m.Generation));
         Assert.InRange(marks[^1].Row, 0, buffer.TotalLines - 1);
+    }
+
+    [Fact]
+    public void AbsoluteRow_SurvivesEviction_AndStillResolvesToTheSameContentRow()
+    {
+        // The point of AbsoluteRow: once the scrollback budget starts dropping the oldest
+        // pages, Row is wrong by exactly TotalRowsEvicted, and the stored identity has to
+        // still land on the marked line's own text. MaxHistory sizes the byte budget and
+        // eviction works in whole 64-row pages, so 128 rows is the smallest budget that
+        // both retains history and actually evicts.
+        var (parser, buffer, marks) = Make(cols: 40, rows: 3, maxHistory: 128);
+
+        for (int i = 0; i < 100; i++) parser.Process($"before {i}\r\n");
+        parser.Process("needle-prompt$ ");
+        parser.Process(PromptEnd);
+        parser.Process("\r\n");
+        for (int i = 0; i < 80; i++) parser.Process($"after {i}\r\n");
+
+        long evicted = buffer.Scrollback.TotalRowsEvicted;
+        Assert.True(evicted > 0, $"the budget must actually evict rows; TotalRowsEvicted={evicted}");
+
+        var mark = Assert.Single(marks);
+        // No Clear() happened, so the coordinate space is intact and the id is still usable.
+        Assert.Equal(buffer.Scrollback.Generation, mark.Generation);
+
+        long liveRow = mark.AbsoluteRow - evicted;
+        Assert.True(liveRow >= 0, $"marked line was evicted (abs={mark.AbsoluteRow}, evicted={evicted})");
+        Assert.NotEqual(mark.Row, (int)liveRow); // eviction really did shift the coordinate
+        Assert.StartsWith("needle-prompt$", RowText(buffer, (int)liveRow).TrimEnd());
+    }
+
+    [Fact]
+    public void Generation_ChangesWhenTheScrollbackIsCleared_SoAStaleMarkIsDetectable()
+    {
+        // CSI 3J ("erase saved lines" -- what clear(1) sends when the terminfo E3
+        // capability is present, so a routine event) resets BOTH row counters to zero.
+        // A pre-clear AbsoluteRow therefore resolves to a large *positive* row holding
+        // unrelated content: "negative means aged out" cannot catch it, and Generation
+        // is the only signal that the coordinate space was reset.
+        var (parser, buffer, marks) = Make(cols: 40, rows: 3);
+
+        for (int i = 0; i < 20; i++) parser.Process($"line {i}\r\n");
+        parser.Process("$ ");
+        parser.Process(PromptEnd);
+
+        var mark = Assert.Single(marks);
+        Assert.Equal(buffer.Scrollback.Generation, mark.Generation);
+        Assert.True(mark.AbsoluteRow > 0);
+
+        parser.Process("\x1b[3J");
+
+        Assert.Equal(0L, buffer.Scrollback.TotalRowsEvicted);
+        Assert.NotEqual(mark.Generation, buffer.Scrollback.Generation);
+
+        // The trap the generation exists to close: the naive re-derivation still yields a
+        // plausible in-range row, so a consumer that only checked for a negative result
+        // would happily read the wrong line.
+        long naiveRow = mark.AbsoluteRow - buffer.Scrollback.TotalRowsEvicted;
+        Assert.True(naiveRow >= 0);
+    }
+
+    [Fact]
+    public void Generation_ChangesOnFullReset()
+    {
+        // RIS and the user's clear-buffer action both go through TerminalBuffer.Clear().
+        var (parser, buffer, marks) = Make(cols: 40, rows: 3);
+
+        for (int i = 0; i < 10; i++) parser.Process($"line {i}\r\n");
+        parser.Process("$ ");
+        parser.Process(PromptEnd);
+        var mark = Assert.Single(marks);
+
+        buffer.Clear();
+
+        Assert.NotEqual(mark.Generation, buffer.Scrollback.Generation);
+    }
+
+    [Fact]
+    public void Generation_IsStableAcrossOrdinaryOutput()
+    {
+        // Negative control for the two tests above: nothing but scrolling must ever
+        // invalidate a mark, or a Phase 1b consumer would throw away every anchor.
+        var (parser, buffer, marks) = Make(cols: 40, rows: 3, maxHistory: 128);
+
+        parser.Process("$ ");
+        parser.Process(PromptEnd);
+        long generationAtMark = Assert.Single(marks).Generation;
+
+        for (int i = 0; i < 200; i++) parser.Process($"line {i}\r\n");
+
+        Assert.True(buffer.Scrollback.TotalRowsEvicted > 0);
+        Assert.Equal(generationAtMark, buffer.Scrollback.Generation);
     }
 
     [Fact]

--- a/tests/NovaTerminal.VT.Tests/Osc133CommandStartMarkTests.cs
+++ b/tests/NovaTerminal.VT.Tests/Osc133CommandStartMarkTests.cs
@@ -1,0 +1,211 @@
+using NovaTerminal.VT;
+
+namespace NovaTerminal.VT.Tests;
+
+/// <summary>
+/// OSC 133;B (prompt end / start of user input) and the buffer position captured with it.
+/// The position is the anchor Command Assist V2 uses to read the live command line straight
+/// out of the grid instead of mirroring keystrokes, so "where exactly did the mark land" is
+/// the contract under test here, not merely "did the callback fire".
+/// </summary>
+public class Osc133CommandStartMarkTests
+{
+    private const string PromptEnd = "\x1b]133;B\x07";
+
+    private static (AnsiParser Parser, TerminalBuffer Buffer, List<ShellIntegrationMark> Marks) Make(
+        int cols = 40,
+        int rows = 5)
+    {
+        var buffer = new TerminalBuffer(cols, rows);
+        var parser = new AnsiParser(buffer);
+        var marks = new List<ShellIntegrationMark>();
+        parser.OnCommandStarted = mark => marks.Add(mark);
+        return (parser, buffer, marks);
+    }
+
+    [Fact]
+    public void Mark_IsReportedAtTheCursorCellFollowingThePrompt()
+    {
+        var (parser, _, marks) = Make();
+
+        // The shape every bootstrap produces: A before the prompt text, B at its tail.
+        parser.Process("\x1b]133;A\x07");
+        parser.Process("user@host:~$ ");
+        parser.Process(PromptEnd);
+
+        var mark = Assert.Single(marks);
+        Assert.Equal(0, mark.Row);
+        Assert.Equal("user@host:~$ ".Length, mark.Column);
+        Assert.False(mark.IsAltScreen);
+    }
+
+    [Fact]
+    public void Mark_TracksTheRowAsOutputPushesThePromptDown()
+    {
+        var (parser, _, marks) = Make();
+
+        parser.Process("line one\r\nline two\r\n");
+        parser.Process("$ ");
+        parser.Process(PromptEnd);
+
+        var mark = Assert.Single(marks);
+        Assert.Equal(2, mark.Row);
+        Assert.Equal(2, mark.Column);
+        Assert.Equal(2L, mark.AbsoluteRow);
+    }
+
+    [Fact]
+    public void AbsoluteRow_KeepsCountingWhileRowsScrollIntoScrollback()
+    {
+        // Row is relative to the buffer's current addressing space (scrollback + viewport),
+        // so it keeps growing as long as nothing is evicted; AbsoluteRow adds the eviction
+        // count on top and is the identity a consumer stores.
+        var (parser, buffer, marks) = Make(cols: 40, rows: 3);
+
+        for (int i = 0; i < 6; i++)
+        {
+            parser.Process($"line {i}\r\n");
+            parser.Process("$ ");
+            parser.Process(PromptEnd);
+            parser.Process("\r");
+        }
+
+        Assert.Equal(6, marks.Count);
+        Assert.True(buffer.Scrollback.Count > 0, "rows should have moved into scrollback");
+
+        // Strictly increasing, one row per prompt, and never behind the scrollback floor.
+        for (int i = 1; i < marks.Count; i++)
+        {
+            Assert.True(marks[i].AbsoluteRow > marks[i - 1].AbsoluteRow);
+        }
+
+        // The last mark still resolves to a live row: current row =
+        // AbsoluteRow - TotalRowsEvicted, which is what a later consumer computes.
+        long evicted = buffer.Scrollback.TotalRowsEvicted;
+        Assert.Equal(marks[^1].Row, (int)(marks[^1].AbsoluteRow - evicted));
+        Assert.InRange(marks[^1].Row, 0, buffer.TotalLines - 1);
+    }
+
+    [Fact]
+    public void Mark_ReportsAltScreenCapture()
+    {
+        var (parser, _, marks) = Make();
+
+        parser.Process("\x1b[?1049h"); // enter alt screen
+        parser.Process("\x1b[H");      // home the cursor, as a full-screen app would
+        parser.Process("> ");
+        parser.Process(PromptEnd);
+
+        var mark = Assert.Single(marks);
+        Assert.True(mark.IsAltScreen);
+        // No scrollback on the alt screen: the row is the viewport row and the absolute id
+        // shares no numbering with main-screen marks.
+        Assert.Equal(0, mark.Row);
+        Assert.Equal(0L, mark.AbsoluteRow);
+    }
+
+    [Fact]
+    public void Mark_IsEmittedOncePerPromptRedraw()
+    {
+        // The mark rides in PS1/PROMPT/fish_prompt, so a prompt repaint re-emits it with
+        // fresh coordinates. That is the property that lets a consumer recover after a
+        // resize, so a second B without an intervening C/D must not be swallowed.
+        var (parser, _, marks) = Make();
+
+        parser.Process("\x1b]133;A\x07$ " + PromptEnd);
+        parser.Process("\r\x1b]133;A\x07$ " + PromptEnd);
+
+        Assert.Equal(2, marks.Count);
+    }
+
+    [Fact]
+    public void Mark_IsReportedEvenWithoutAPrecedingPromptStart()
+    {
+        // B before any A (mid-session attach, or an integration that only emits B).
+        var (parser, _, marks) = Make();
+
+        parser.Process("$ " + PromptEnd);
+
+        var mark = Assert.Single(marks);
+        Assert.Equal(2, mark.Column);
+    }
+
+    [Theory]
+    [InlineData("\x1b]133;B;\x07")]                  // trailing separator, empty attribute
+    [InlineData("\x1b]133;B;aid=7\x07")]             // FinalTerm-style key=value attribute
+    [InlineData("\x1b]133;B;;;\x07")]                // repeated empty attributes
+    [InlineData("\x1b]133;B\x1b\\")]                 // ST-terminated instead of BEL
+    public void MalformedOrDecoratedPayloads_StillProduceTheMark(string sequence)
+    {
+        var (parser, _, marks) = Make();
+
+        parser.Process("$ ");
+        parser.Process(sequence);
+
+        var mark = Assert.Single(marks);
+        Assert.Equal(2, mark.Column);
+    }
+
+    [Theory]
+    [InlineData("\x1b]133;\x07")]      // no marker letter
+    [InlineData("\x1b]133;b\x07")]     // lowercase: markers are case-sensitive
+    [InlineData("\x1b]133;BB\x07")]    // not the B marker
+    [InlineData("\x1b]133\x07")]       // no payload at all
+    public void NonBPayloads_DoNotProduceTheMark(string sequence)
+    {
+        var (parser, _, marks) = Make();
+
+        parser.Process(sequence);
+
+        Assert.Empty(marks);
+    }
+
+    [Fact]
+    public void MarkSurvivesSplitProcessCalls()
+    {
+        // PTY reads chop escape sequences at arbitrary offsets; the mark must be reported
+        // once, from the position the cursor holds when the sequence completes.
+        var (parser, _, marks) = Make();
+
+        parser.Process("$ \x1b]133");
+        parser.Process(";B");
+        parser.Process("\x07");
+
+        var mark = Assert.Single(marks);
+        Assert.Equal(2, mark.Column);
+        Assert.Equal(0, mark.Row);
+    }
+
+    [Fact]
+    public void MarkDoesNotDisturbTheBufferContents()
+    {
+        // The mark is zero-width: nothing is written, the cursor does not move.
+        var (parser, buffer, _) = Make();
+
+        parser.Process("$ ");
+        int colBefore = buffer.CursorCol;
+        parser.Process(PromptEnd);
+
+        Assert.Equal(colBefore, buffer.CursorCol);
+        parser.Process("ls");
+        Assert.Equal("$ ls", RowText(buffer, 0).TrimEnd());
+    }
+
+    private static string RowText(TerminalBuffer buffer, int row)
+    {
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            var chars = new char[buffer.Cols];
+            for (int col = 0; col < buffer.Cols; col++)
+            {
+                chars[col] = buffer.GetCellAbsolute(col, row).Character;
+            }
+            return new string(chars).Replace('\0', ' ');
+        }
+        finally
+        {
+            buffer.Lock.ExitReadLock();
+        }
+    }
+}


### PR DESCRIPTION
Implements Phase 1 tasks 1-2 of `docs/plans/2026-08-01-command-assist-v2-plan.md`.

`OSC 133;B` (prompt end / start of the user's input) was never emitted by any Nova
bootstrap, which is why `ShellIntegrationEventType.CommandStarted` and
`ShellLifecycleTracker.HandleCommandStarted` were dead code. This PR emits it from all
four bootstraps and reports it with the buffer position it landed on, which is the anchor
the Phase 1b grid reader needs. Nothing consumes the position yet.

## Per-shell placement of B

Every bootstrap emits `A` *before* the prompt is printed (from `precmd` /
`PROMPT_COMMAND` / the `prompt` function), so `B` cannot come from the same hook. It has
to sit at the tail of the prompt itself, so that the cell position at B-time is the first
cell of the command line.

**bash** - `PS1` gains a non-printing suffix; `\[ \]` keeps bash's prompt-width
arithmetic (and readline's wrapping) correct:

    __nova_ps1_mark='\[\e]133;B\a\]'
    __nova_apply_ps1_mark() {
        case "$PS1" in
            *"$__nova_ps1_mark"*) ;;
            *) PS1="$PS1$__nova_ps1_mark" ;;
        esac
    }

Applied from inside `__nova_arm`, which is the last entry of the `PROMPT_COMMAND` chain:

    __nova_arm() {
        __nova_apply_ps1_mark
        __nova_command_active=0
    }

That is the only point where a theme that rewrites `PS1` from `PROMPT_COMMAND`
(starship, oh-my-posh) has finished, and it keeps the chain string
`__nova_precmd; $PROMPT_COMMAND; __nova_arm` unchanged, so the DEBUG-trap arm/disarm
race guard is untouched (the existing test that pins the chain string still passes
unmodified, and `__nova_command_active=0` still runs last).

**zsh** - `PROMPT` gains a `%{...%}` (zero display width) suffix, re-applied from
`__nova_precmd`, which is appended to `precmd_functions` last:

    typeset -g __nova_prompt_mark=$'%{\e]133;B\a%}'
    __nova_apply_prompt_mark() {
        if [[ "$PROMPT" != *"$__nova_prompt_mark"* ]]; then
            PROMPT="$PROMPT$__nova_prompt_mark"
        fi
    }

**fish** - the `fish_prompt` *event* fires before the prompt function runs, so it can
only carry `A`, and fish has no post-prompt event. The user's prompt is copied aside and
`fish_prompt` re-defined as "original, then B":

    if functions -q fish_prompt
        functions --copy fish_prompt __nova_user_fish_prompt
        function fish_prompt
            __nova_user_fish_prompt
            printf '\033]133;B\a'
        end
    end

The `functions -q` probe mirrors the PSReadLine probe: if `fish_prompt` cannot be
resolved we skip the wrapping entirely and degrade to A-only rather than replacing the
user's prompt with a synthesized one.

**PowerShell** - anything the `prompt` function *writes* lands before the prompt text
(the host prints the return value afterwards), so B is concatenated onto the rendered
prompt instead:

    $novaPromptText = if ($script:NovaOriginalPrompt -ne $null) {
        (& $script:NovaOriginalPrompt) -join ''
    } else {
        [string]::Concat('PS ', (Get-Location), '> ')
    }
    return "$novaPromptText$([char]27)]133;B$([char]7)"

`-join ''` flattens the rare prompt that emits several objects; a single-string prompt
(including oh-my-posh/starship) round-trips unchanged. Verified by hand against
Windows PowerShell: prompt text intact, bytes end `... 62 32 27 93 49 51 51 59 66 7`.
The PSReadLine-absent guard and the "no bare `Write-NovaSequence ']133;B'`" test are
untouched.

All four applications are idempotent, so a static prompt does not accumulate one marker
per prompt cycle.

## Mark coordinates

`AnsiParser.OnCommandStarted` changes from `Action?` to `Action<ShellIntegrationMark>?`
and snapshots the cursor synchronously while dispatching the OSC, so the position is
exactly where the shell left it:

    public readonly record struct ShellIntegrationMark(
        int Row, int Column, long AbsoluteRow, bool IsAltScreen);

- `Row` is the buffer's current row index (`Scrollback.Count + CursorRow`, or the cursor
  row on the alt screen). It is what `GetRow`/`GetCellAbsolute` take, but it shifts down
  on every scrollback eviction, so it is only valid for immediate use.
- `AbsoluteRow` is `Scrollback.TotalRowsEvicted + Row`: monotonic per session and stable
  across eviction. A consumer re-derives the live row as
  `AbsoluteRow - TotalRowsEvicted`, and a negative result means the marked line has aged
  out of history. This is the identity the render path already uses for row caching
  (`TerminalBuffer.ThreadingAndInvalidation`), so it is not a new concept.
- `IsAltScreen` flags marks captured with no scrollback backing; their numbering shares
  nothing with main-screen marks.

Neither coordinate survives a reflowing resize (reflow rebuilds the scrollback store and
re-wraps logical lines). That is deliberate and benign: because B rides inside the prompt
rather than being a one-shot write, every prompt repaint - including the one after a
resize - re-emits it with fresh coordinates. The Phase 1b reader should treat the newest
mark as truth rather than caching one.

It reaches Command Assist as `ShellIntegrationEvent.MarkPosition`, a nullable
`ShellMarkPosition` with the same four fields, converted at the App boundary the way
`AssistPoint`/`AssistRect` keep VT/Avalonia types out of that assembly. The field is
additive; every other event type leaves it null.

## What stays intentionally unconsumed

- `CommandAssistController` is **not touched** (PR #283 owns that file - see below).
  Its `HandleShellIntegrationEventAsync` already lists `CommandStarted` as a
  context-only case that returns without doing anything, and B additionally sets
  `_hasObservedShellIntegrationMarker`, which A already set - so no behaviour change.
- No grid reader, no query extraction, no orchestrator changes. That is Phase 1b.

## Two side effects of B becoming live, fixed here

These are not gold-plating: without them this PR ships regressions.

1. `TerminalPane` drove the agent status machine's "running" transition, the
   `LastExitCode` reset and the `CommandStarted` pane event off B. B fires at every
   prompt while the shell is idle, so that would have reported idle sessions as Running
   over the agent-host protocol and cleared the tab's exit-code badge as soon as the next
   prompt painted. Those side effects move to `OSC 133;C` (command accepted), the only
   execution-start edge Nova's own bootstraps emit. Note this also means Nova-integrated
   sessions now report Running at all - they never did, because B was never emitted.
   Third-party integrations that emit B but no C lose the Running transition; they were
   getting it at the wrong moment (prompt-end) before.
2. `ShellLifecycleTracker`'s duration fallback (used only when a `D` marker carries no
   duration) would have been anchored at prompt-end and billed the user's typing time to
   the command. `HandleCommandAccepted` now restarts that clock.

## Tests

- Four `*BootstrapBuilderTests`: B present; placement relative to A and to the prompt
  text; append-only prompt assignment (exactly one `PS1=` / `PROMPT=` in the script, both
  of the `X="$X$mark"` form); idempotence guard; fish degradation probe. The zsh
  "preserves prompt ownership" test was tightened rather than dropped: it now asserts the
  single permitted `PROMPT=` is the append form.
- New `tests/NovaTerminal.VT.Tests/Osc133CommandStartMarkTests.cs`: position at the cell
  after the prompt, row tracking as output scrolls, `AbsoluteRow` behaviour across
  scrollback, alt-screen capture, B without a preceding A, repeated B per prompt repaint,
  split `Process` calls, zero-width (buffer untouched), plus tolerance theories for
  decorated payloads (`133;B;aid=7`, trailing separators, ST termination) and rejection
  theories for non-B payloads (`133;b`, `133;BB`, `133;`, `133`).
- `ShellLifecycleTrackerTests`: mark position carried on the event, null when absent, and
  the C-restarts-the-duration-clock case.
- Shell harness records B (with `row,col`) as an `OscEvent`; bash/zsh/fish integration
  tests assert a B mark arrives at a non-zero column, i.e. past the prompt cells. The
  bash pair runs for real here (Git Bash) and passes; zsh/fish follow the existing
  runtime-skip pattern and will run on Linux CI. Added a bash test that bounds B count
  against A count, which would catch the PS1 accumulating markers.

## Verification

Clean build. Per-project test runs (solution-level runs can wedge):

| project | result |
| --- | --- |
| NovaTerminal.VT.Tests | 207 passed |
| NovaTerminal.App.Tests | 1491 passed, 13 skipped, 1 flake |
| NovaTerminal.Architecture.Tests | 28 passed |
| NovaTerminal.Platform.Tests | 122 passed, 18 skipped |
| NovaTerminal.Rendering.Tests | 68 passed |
| NovaTerminal.McpServer.Tests | 138 passed |

The one failure was `AgentHostCaptureProtocolTests.Capture_for_unknown_pane_reports_session_not_found`,
a known flake unrelated to this change; it passes in isolation (13/13). The 13 skips are
the zsh/fish shell-integration tests plus the usual platform skips on Windows.

## Conflict-avoidance note

Branched from `main` @ 648933c. The Phase 0c controller split (PR #283) is in flight and
owns `CommandAssistController.cs`; this PR deliberately does not touch that file, so the
two should merge in either order. The overlap surface is
`ShellIntegrationEvent`/`ShellLifecycleTracker` (additive here) and `TerminalPane`'s
parser hookup.

## For the reviewer

- The `OnCommandStarted` signature change (`Action?` -> `Action<ShellIntegrationMark>?`)
  rather than an `OnCommandStartedDetailed` sibling in the style of
  `OnCommandFinishedDetailed`. Only five call sites existed and none needed the
  parameterless form; a parallel callback would have been dead weight for Phase 1b.
- The move of "running"/exit-code-reset semantics from B to C (above). It is the change
  in this PR with real user-visible behaviour.
- zsh and fish placements could not be exercised locally (no zsh/fish on this box) - they
  rest on the builder-level tests plus CI's integration suite. bash and PowerShell were
  verified against real shells.
- Prompt-framework interaction remains best-effort: a framework that rebuilds the prompt
  *after* our hook runs loses the mark for that cycle (documented in the gap doc).
