### PR TITLE
feat(vt): read the live command line from the grid between the OSC 133;B mark and the cursor (V2 Phase 1b)

### DIFF
--- a/docs/command-assist/CommandAssist_ShellIntegration_Gaps.md
+++ b/docs/command-assist/CommandAssist_ShellIntegration_Gaps.md
@@ -35,6 +35,53 @@
   eviction-stable identity; `Row`/`Column` are the immediate buffer coordinates.
 - Nothing consumes the position yet — the grid query reader lands in Phase 1b.
 
+## Added In V2 Phase 1b
+
+`NovaTerminal.VT.GridQueryReader.TryReadCommandLine(buffer, mark, out GridCommandLine)` reads the
+live command line straight out of the grid: the cells from the newest `OSC 133;B` mark to the
+cursor. It lives in `NovaTerminal.VT` rather than the CommandAssist assembly the plan first
+sketched, because the work is pure buffer walking (wrap flags, paged scrollback, wide-cell
+continuations, deferred autowrap) and the layering tests forbid CommandAssist from referencing
+VT; the App-side seam is the internal `TerminalPane.TryGetGridCommandLine`, which pairs the
+reader with the newest mark and the buffer's read lock. Nothing consumes the seam yet —
+Phase 1c does that and deletes the keystroke shadow buffer.
+
+**Contract.** The reader never throws and never guesses: it returns `false` for a mark from a
+dead coordinate generation, a marked line that aged out of scrollback, an alt-screen mark or an
+active alt screen, a cursor above or left of the mark, a mark position outside the buffer, and a
+span larger than 512 rows. `GridCommandLine` carries `Text`, `CursorOffset` (always a valid index
+into `Text`; the cursor is routinely mid-line after arrow keys), `IsMultiline`,
+`RightPromptTrimmed`, and the span's `StartRow`/`EndRow`. Soft-wrapped rows are joined with no
+separator and are followed *past* the cursor row, so a logical line wrapped over three physical
+rows comes back whole no matter which row the cursor is on. The result is only meaningful between
+`OSC 133;B` and the following `OSC 133;C` — the reader cannot distinguish "still typing" from
+"the command ran and this is its output", so lifecycle gating is the consumer's job.
+
+**Multiline decision (b), raw plus flag.** A hard line break inside the span becomes a single
+`'\n'` and sets `IsMultiline`. The text is returned raw, which means it still contains whatever
+the shell painted as a continuation prompt (`PS2`, `PROMPT2`, fish's `> `): nothing marks those
+cells as prompt rather than input, so the reader cannot strip them and instead flags the text as
+untrustworthy-as-prefix. Consumers may use multiline text for history and display but must never
+treat it as a typed prefix. The alternative — returning only the first logical line — was
+rejected because it silently loses text and makes `CursorOffset` ambiguous, and downstream
+refuses prefix-dependent features on multiline input anyway. Documented gap: if the cursor sits
+on an *earlier* logical line of a continuation entry, the span stops at the end of that line and
+`IsMultiline` stays clear. Extending across hard breaks whenever the row below has content would
+close that gap but misfire on every zsh tab completion, which prints its listing directly below
+the input line.
+
+**Right-prompt (RPROMPT) decision.** zsh's `RPROMPT`, fish's `fish_right_prompt` and starship's
+right prompt all paint right-aligned text on the input's own row, and a naive "mark column to
+last non-blank cell" read swallows it. Stopping at the cursor is not an option because the cursor
+is mid-line whenever the user has pressed an arrow key. Trailing cells are excluded only on the
+final row of the span, only when the cursor is on that row, and only when all three of the
+following hold: the trailing content ends within 2 columns of the right edge (right-aligned text
+does; typed input generally does not, and `ZLE_RPROMPT_INDENT` defaults to 1), it is separated
+from the rest of the row by a run of at least 2 blank cells, and that run starts at or after the
+cursor. The third condition means nothing left of the cursor is ever discarded, so a double space
+inside typed input cannot be mistaken for the separator. The rule is deliberately conservative:
+a gap followed by content that stops well short of the right edge is kept.
+
 ## Current Limitations
 - shell integration is local-only; SSH launch plans skip provider injection
   because env-var overrides do not propagate across SSH
@@ -62,6 +109,10 @@
   scrollback reset (CSI 3J / RIS / clear-buffer / reflow), which zeroes the buffer's row
   counters. `ShellMarkPosition.Generation` carries the coordinate-space epoch so a consumer
   can tell the two apart; a negative derived row only means "aged out" within one generation
+- the mark records the cursor's column but not the deferred-autowrap bit, so a prompt that ends
+  exactly on the last column leaves `GridQueryReader` starting one cell early and picking up the
+  prompt's final character. Recording pending-wrap on the mark would fix it; not worth the
+  cross-layer churn for a prompt that exactly fills the terminal width
 
 ## Deferred Follow-Up Areas
 - richer shell-specific prompt contracts beyond the current wrapper approach

--- a/docs/command-assist/CommandAssist_ShellIntegration_Gaps.md
+++ b/docs/command-assist/CommandAssist_ShellIntegration_Gaps.md
@@ -74,13 +74,40 @@ the input line.
 right prompt all paint right-aligned text on the input's own row, and a naive "mark column to
 last non-blank cell" read swallows it. Stopping at the cursor is not an option because the cursor
 is mid-line whenever the user has pressed an arrow key. Trailing cells are excluded only on the
-final row of the span, only when the cursor is on that row, and only when all three of the
-following hold: the trailing content ends within 2 columns of the right edge (right-aligned text
-does; typed input generally does not, and `ZLE_RPROMPT_INDENT` defaults to 1), it is separated
-from the rest of the row by a run of at least 2 blank cells, and that run starts at or after the
-cursor. The third condition means nothing left of the cursor is ever discarded, so a double space
-inside typed input cannot be mistaken for the separator. The rule is deliberately conservative:
-a gap followed by content that stops well short of the right edge is kept.
+final row of the span, only when the cursor is on that row, and only when all five of the
+following hold. The row is read as `[input][gap][badge]`:
+
+1. the trailing content ends within 2 columns of the right edge (right-aligned text does; typed
+   input generally does not, and `ZLE_RPROMPT_INDENT` defaults to 1);
+2. the gap starts at or after the cursor, so nothing left of the cursor is ever discarded;
+3. the gap is the *widest* run of blank cells in that region — the row's dominant slack, which is
+   what a right-aligned paint produces;
+4. the gap is at least 2 cells wide **and strictly wider than the badge it separates**;
+5. the badge is at most `Cols / 3` columns wide.
+
+Conditions 4 and 5 are load-bearing, and an earlier revision of this document was wrong about
+why. Condition 2 does *not* on its own make a double space inside typed input safe: it protects
+only what is left of the cursor. With the cursor at the start of the line (Home) and input that
+happens to reach the right edge — `echo aaaa...aa  bbbb` — every interior gap is at or after the
+cursor, and the `bbbb` was silently deleted. Condition 4 is what stops that: two blanks in front
+of four characters is a typo, not a right prompt.
+
+Condition 3 also fixes multi-segment right prompts. Taking the rightmost qualifying run cut
+`12:34  ok` at its own internal gap, keeping the wide blank run and `12:34` — worse than not
+trimming at all. Taking the widest run trims the whole right-aligned group.
+
+The failure mode is deliberately asymmetric. An unrecognised right prompt comes back as extra
+text, which a consumer can survive; a mis-recognised one deletes what the user typed. So a gap
+followed by content that stops well short of the right edge is kept, a badge wider than the gap
+in front of it is kept, and a badge wider than a third of the row is kept.
+
+**Mark lifecycle at the App seam.** `TerminalPane` drops `_latestCommandStartMark` on `OSC 133;D`
+(command finished), so between one command's end and the next prompt's `B` the seam returns
+`false` instead of serving command output as a command line. It is deliberately *not* dropped on
+`OSC 133;C`: C fires the instant the user submits, while the input line is still on screen and
+still exactly what the mark describes, and Phase 1c reads the final command text on that edge.
+`GridQueryReader.MaxSpanRows` stays as a backstop for shells that emit `B` without a matching `D`,
+rather than being the only guard.
 
 ## Current Limitations
 - shell integration is local-only; SSH launch plans skip provider injection

--- a/docs/plans/2026-08-01-command-assist-v2-plan.md
+++ b/docs/plans/2026-08-01-command-assist-v2-plan.md
@@ -81,15 +81,23 @@ Phase 1b notes (for the task-4 orchestrator author):
   cursor is routinely mid-line), `IsMultiline`, `RightPromptTrimmed`, `StartRow`, `EndRow`.
 - **The result is only meaningful between `B` and the following `C`.** The reader cannot tell
   "still typing" from "the command ran and this is its output"; lifecycle gating is the
-  consumer's job. A `MaxSpanRows` cap (512) bounds the damage if that gate is missed.
+  consumer's job. Two backstops: the pane drops `_latestCommandStartMark` on `133;D`, so the seam
+  goes dark between a command finishing and the next prompt (it is deliberately *kept* across
+  `133;C`, when the input line is still on screen and still what the mark describes), and a
+  `MaxSpanRows` cap (512) bounds the damage for shells that emit `B` without a matching `D`.
 - **Multiline is decision (b): raw text, hard breaks as `'\n'`, `IsMultiline` set.** Nothing
   identifies continuation-prompt cells (`PS2`/`PROMPT2`) as prompt rather than input, so they
   are *in* the text. Treat multiline text as opaque — history/display only, never a typed
   prefix. One documented gap: if the cursor sits on an earlier logical line of a continuation
   entry, the span stops at the end of that line and `IsMultiline` stays clear.
-- **RPROMPT** is excluded from the final row only, and only when all three hold: content ends
-  within 2 columns of the right edge, a ≥2-blank gap precedes it, and that gap starts at or
-  after the cursor. Nothing left of the cursor is ever discarded.
+- **RPROMPT** is excluded from the final row only, and only when all five hold: content ends
+  within 2 columns of the right edge; the gap starts at or after the cursor (nothing left of the
+  cursor is ever discarded); the gap is the *widest* blank run in that region, so a multi-segment
+  right prompt is trimmed whole rather than cut at its own internal gap; the gap is >= 2 cells
+  and strictly wider than the badge it separates; and the badge is at most `Cols / 3` wide. The
+  last two are what stop a double space inside typed input that reaches the right edge from
+  eating the tail of the line when the cursor is at Home. Unrecognised right prompts are returned
+  as extra text; that direction is recoverable, deleting typed input is not.
 
 ## Phase 2 — Marks-based anchoring + SSH parity
 
@@ -104,7 +112,7 @@ Exit criteria: SSH + instrumented remote passes smoke scenarios with zero `[Corr
 ## Phase 3 — Visible usefulness
 
 Tasks:
-1. Auto-open policy v2: passive bubble with top-1 merged suggestion after ≥2 chars, ~75 ms debounce; Escape suppresses for current command; popup still intent-only. Policy behind `CommandAssistPassiveBubbleEnabled` (default true when master flag on); M4.3-quiet behavior as fallback.
+1. Auto-open policy v2: passive bubble with top-1 merged suggestion after >=2 chars, ~75 ms debounce; Escape suppresses for current command; popup still intent-only. Policy behind `CommandAssistPassiveBubbleEnabled` (default true when master flag on); M4.3-quiet behavior as fallback.
 2. Bind `ShortcutHintText` in `CommandAssistBubbleView`; verify content reflects rebound shortcuts.
 3. Popup interactivity: rows become selectable (mouse hover + click-to-accept), `ScrollViewer` + scroll-into-view, remove hard-coded `maxResults: 5` in favor of scrolling cap.
 4. Shortcuts: move pin off `Ctrl+Shift+P` to a new catalogued binding; add `Esc`/`Up`/`Down`/`Ctrl+Enter` to catalog under `ShortcutScope.CommandAssist`; migration for existing shortcut config.
@@ -119,7 +127,7 @@ Exit criteria: type-two-chars-see-value demo works on all four shells; benchmark
 Tasks:
 1. Stderr capture: buffer the `133;C`→`133;D` output region (bounded: last 40 lines / 8 KB), redact via `SecretsFilter`, populate `CommandFailureContext.ErrorOutput` (removes the hard-coded `null` at the TerminalPane call site).
 2. Expand `HeuristicErrorInsightService`: per-shell command-not-found patterns, permission-denied, `./` hint (now reachable), git/docker/npm/dotnet failure signatures. Target: useful suggestion for top-10 failure classes.
-3. `CommandKnowledgeService` with ordered sources: (a) build-time tldr-pages-derived catalogue (≥200 commands, <2 MB, CC-BY attribution in About), (b) local probing (`man -w`, `Get-Help`, `--help`) for "open full help" actions. Replaces `LocalCommandDocsProvider` + `SeedRecipeProvider`; closes #250.
+3. `CommandKnowledgeService` with ordered sources: (a) build-time tldr-pages-derived catalogue (>=200 commands, <2 MB, CC-BY attribution in About), (b) local probing (`man -w`, `Get-Help`, `--help`) for "open full help" actions. Replaces `LocalCommandDocsProvider` + `SeedRecipeProvider`; closes #250.
 4. Snippet management UI in Settings (list/edit/delete; `ISnippetStore.RemoveAsync` gets a caller).
 
 Exit criteria: Fix mode demo across failure classes; Help useful for arbitrary common commands; catalogue size + attribution verified.

--- a/docs/plans/2026-08-01-command-assist-v2-plan.md
+++ b/docs/plans/2026-08-01-command-assist-v2-plan.md
@@ -35,12 +35,12 @@ segment before it can be claimed as supported.
 
 ## Phase 1 — Truthful query state
 
-**Status: tasks 1 and 2 shipped (Phase 1a).**
+**Status: tasks 1 and 2 shipped (Phase 1a); task 3 shipped (Phase 1b).**
 
 Tasks:
 1. **[done — Phase 1a]** Emit `OSC 133;B` from all four bootstrap builders; extend the four `*BootstrapBuilderTests` and the shell-harness integration tests. Preserve bail-out conditions and bash DEBUG-trap guard semantics.
 2. **[done — Phase 1a]** Parser/tracker: wire `133;B` through `AnsiParser` → `ShellLifecycleTracker.HandleCommandStarted` (currently dead) with mark position (row/col).
-3. `GridQueryReader` in the new assembly: extract command text between last `B` mark and cursor from the buffer, handling wrapped logical lines and scrolled viewports. Exhaustive buffer-level unit tests first (wrap, resize/reflow, multiline continuation, prompt redraw, cleared screen).
+3. **[done — Phase 1b]** `GridQueryReader`: extract command text between last `B` mark and cursor from the buffer, handling wrapped logical lines and scrolled viewports. Exhaustive buffer-level unit tests first (wrap, resize/reflow, multiline continuation, prompt redraw, cleared screen). *Landed in `NovaTerminal.VT`, not the CommandAssist assembly as sketched here* — the extraction is pure buffer walking and `LayeringTests` forbids CommandAssist from referencing VT; Command Assist consumes it at the App boundary via `TerminalPane.TryGetGridCommandLine`.
 4. `SuggestionOrchestrator` consumes `GridQueryReader` when marks are live; delete the shadow buffer (`TextInputObserved`/`BackspaceObserved` mirroring). Heuristic Enter-capture stays for history in non-integrated sessions.
 5. Degraded mode: no marks → path suggestions + explicit `Ctrl+R` history search only; prefix-dependent features off.
 6. `CommandAssistInsertionPlanner` computes against grid truth; add tests for post-`Ctrl+U`, post-history-recall, post-Tab-completion insertion (the desync cases that broke V1).
@@ -67,8 +67,29 @@ Phase 1a notes (for the task-3 `GridQueryReader` author):
   (including post-resize and post-clear) re-emits it with fresh coordinates. The reader should
   treat the newest mark as truth rather than caching one.
 - The controller still ignores `CommandStarted`; nothing consumes the position yet. The pane
-  short-circuits `CommandStarted` before the Command Assist dispatcher for that reason — Phase
-  1b has to remove that early-out (`TerminalPane.OnShellIntegrationEventObserved`).
+  short-circuits `CommandStarted` before the Command Assist dispatcher for that reason. That
+  early-out survived Phase 1b (the reader takes the mark straight off the parser callback, not
+  off the dispatcher); **Phase 1c has to remove it** when the orchestrator starts pulling grid
+  truth on the event (`TerminalPane.OnShellIntegrationEventObserved`).
+
+Phase 1b notes (for the task-4 orchestrator author):
+- `GridQueryReader.TryReadCommandLine(buffer, mark, out GridCommandLine)` lives in
+  `NovaTerminal.VT`; the App-side seam is `TerminalPane.TryGetGridCommandLine(out …)`, which
+  pairs it with the newest mark (`_latestCommandStartMark`, kept under a gate because the
+  parser callback runs on the PTY read thread). Nothing calls the seam yet.
+- `GridCommandLine` carries `Text`, `CursorOffset` (always a valid index into `Text` — the
+  cursor is routinely mid-line), `IsMultiline`, `RightPromptTrimmed`, `StartRow`, `EndRow`.
+- **The result is only meaningful between `B` and the following `C`.** The reader cannot tell
+  "still typing" from "the command ran and this is its output"; lifecycle gating is the
+  consumer's job. A `MaxSpanRows` cap (512) bounds the damage if that gate is missed.
+- **Multiline is decision (b): raw text, hard breaks as `'\n'`, `IsMultiline` set.** Nothing
+  identifies continuation-prompt cells (`PS2`/`PROMPT2`) as prompt rather than input, so they
+  are *in* the text. Treat multiline text as opaque — history/display only, never a typed
+  prefix. One documented gap: if the cursor sits on an earlier logical line of a continuation
+  entry, the span stops at the end of that line and `IsMultiline` stays clear.
+- **RPROMPT** is excluded from the final row only, and only when all three hold: content ends
+  within 2 columns of the right edge, a ≥2-blank gap precedes it, and that gap starts at or
+  after the cursor. Nothing left of the cursor is ever discarded.
 
 ## Phase 2 — Marks-based anchoring + SSH parity
 

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -1794,6 +1794,23 @@ namespace NovaTerminal.Controls
             };
             Parser.OnCommandFinishedDetailed += (exitCode, durationMs) =>
             {
+                // OSC 133;D == the command finished, so the B mark that anchored its input line
+                // no longer points at an input line: everything from it down is command output.
+                // Dropping it here closes the window in which the grid reader would happily
+                // return output as "the live command line" -- until the next prompt re-emits B,
+                // there is nothing truthful to read, and "no mark" is the honest answer.
+                //
+                // D rather than C (CommandExecuted) deliberately: in one B -> C -> D cycle, C
+                // fires the instant the user submits, while the input line is still on screen and
+                // still exactly what the mark describes. Clearing on C would blind the reader for
+                // the whole run of the command, including the submission edge that Phase 1c reads
+                // the final command text on. GridQueryReader.MaxSpanRows stays as a backstop for
+                // shells that emit B without a matching D, but it is no longer the only guard.
+                lock (_commandStartMarkGate)
+                {
+                    _latestCommandStartMark = null;
+                }
+
                 _shellLifecycleTracker?.HandleCommandFinished(exitCode, durationMs);
 
                 // Long-command completion (A2 PR4): the pane only applies the
@@ -2998,11 +3015,17 @@ namespace NovaTerminal.Controls
         /// (taken by <see cref="GridQueryReader"/> itself).
         /// </para>
         /// <para>
+        /// <b>Lifecycle.</b> The mark is dropped on <c>OSC 133;D</c> (command finished), so
+        /// between one command's end and the next prompt's <c>B</c> this returns <c>false</c>
+        /// rather than serving that command's output as a command line. It is deliberately kept
+        /// across <c>OSC 133;C</c>: C fires the instant the user submits, while the input line is
+        /// still on screen and still exactly what the mark describes.
+        /// <see cref="GridQueryReader.MaxSpanRows"/> remains as a backstop for shells that emit
+        /// <c>B</c> without a matching <c>D</c>.
+        /// </para>
+        /// <para>
         /// <b>Nothing consumes this yet.</b> Phase 1c wires it into the suggestion orchestrator
-        /// and deletes the keystroke shadow buffer. Note the reader's own contract: the result
-        /// is only meaningful between <c>OSC 133;B</c> and the following <c>OSC 133;C</c> — past
-        /// that the "command line" is really command output, and gating on the lifecycle is the
-        /// caller's job.
+        /// and deletes the keystroke shadow buffer.
         /// </para>
         /// </remarks>
         /// <returns><c>false</c> when there is no live mark or the grid cannot be read.</returns>

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -136,6 +136,12 @@ namespace NovaTerminal.Controls
         private IReadOnlyDictionary<string, string>? _shellIntegrationEnvOverrides;
         private readonly OrderedAsyncEventDispatcher _shellIntegrationEventDispatcher = new();
         private readonly CommandAssistAnchorCalculator _commandAssistAnchorCalculator = new();
+
+        // Newest OSC 133;B mark, written from the PTY read thread and read from the UI thread.
+        // A ShellIntegrationMark is five fields wide, so a plain nullable field could be torn
+        // across the two; the gate costs one uncontended lock per prompt.
+        private readonly object _commandStartMarkGate = new();
+        private ShellIntegrationMark? _latestCommandStartMark;
         private string? _lastRelevantCommandText;
         private CommandAssistBarViewModel? _boundCommandAssistViewModel;
         private string? _lastCommandAssistAnchorDiagnosticSignature;
@@ -1757,6 +1763,14 @@ namespace NovaTerminal.Controls
             {
                 // OSC 133;B == prompt end / start of user input. The mark position is the
                 // anchor Command Assist uses to read the live command line out of the grid.
+                // B rides inside the prompt string, so it is re-emitted on every repaint
+                // (resize, clear, zle reset-prompt) with fresh coordinates: keep the newest
+                // one rather than the first.
+                lock (_commandStartMarkGate)
+                {
+                    _latestCommandStartMark = mark;
+                }
+
                 _shellLifecycleTracker?.HandleCommandStarted(new ShellMarkPosition(
                     Row: mark.Row,
                     Column: mark.Column,
@@ -1804,6 +1818,10 @@ namespace NovaTerminal.Controls
             _shellLifecycleTracker = null;
             _isShellIntegrationActive = false;
             _shellIntegrationEnvOverrides = null;
+            lock (_commandStartMarkGate)
+            {
+                _latestCommandStartMark = null;
+            }
 
             // Update SFTP Menu Visibility
             // If it's not an SSH session, detach the context menu entirely to avoid "tiny empty box" artifacts
@@ -2958,14 +2976,54 @@ namespace NovaTerminal.Controls
             // onto the serialized dispatcher, ahead of events that do something. The
             // "shell integration is live" flag the controller would set from it is already
             // set by the PromptReady (OSC 133;A) that precedes every B.
-            // Phase 1b, when the mark position starts feeding the grid reader, has to remove
-            // this early-out.
+            // The grid reader (Phase 1b) does not need this path either: it takes the mark
+            // straight off the parser callback via _latestCommandStartMark. Phase 1c, when the
+            // orchestrator starts pulling grid truth on the event, has to remove this early-out.
             if (shellEvent.Type == ShellIntegrationEventType.CommandStarted)
             {
                 return;
             }
 
             _ = _shellIntegrationEventDispatcher.EnqueueAsync(() => HandleShellIntegrationEventAsync(shellEvent));
+        }
+
+        /// <summary>
+        /// Reads the live command line out of the terminal grid: the cells between the newest
+        /// <c>OSC 133;B</c> mark and the cursor.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The Phase 1b seam. Combines the three things the reader needs and the pane is the
+        /// only place that has all of: the newest mark, the buffer, and the buffer's read lock
+        /// (taken by <see cref="GridQueryReader"/> itself).
+        /// </para>
+        /// <para>
+        /// <b>Nothing consumes this yet.</b> Phase 1c wires it into the suggestion orchestrator
+        /// and deletes the keystroke shadow buffer. Note the reader's own contract: the result
+        /// is only meaningful between <c>OSC 133;B</c> and the following <c>OSC 133;C</c> — past
+        /// that the "command line" is really command output, and gating on the lifecycle is the
+        /// caller's job.
+        /// </para>
+        /// </remarks>
+        /// <returns><c>false</c> when there is no live mark or the grid cannot be read.</returns>
+        internal bool TryGetGridCommandLine(out GridCommandLine line)
+        {
+            line = default;
+
+            var buffer = Buffer;
+            if (buffer == null)
+            {
+                return false;
+            }
+
+            ShellIntegrationMark? mark;
+            lock (_commandStartMarkGate)
+            {
+                mark = _latestCommandStartMark;
+            }
+
+            return mark is ShellIntegrationMark live
+                && GridQueryReader.TryReadCommandLine(buffer, live, out line);
         }
 
         internal async Task HandleCommandAssistCompletionAsync(int? exitCode)

--- a/src/NovaTerminal.VT/GridCommandLine.cs
+++ b/src/NovaTerminal.VT/GridCommandLine.cs
@@ -1,0 +1,59 @@
+namespace NovaTerminal.VT
+{
+    /// <summary>
+    /// The live command line as read out of the terminal grid by
+    /// <see cref="GridQueryReader.TryReadCommandLine"/>: the cells between an
+    /// <c>OSC 133;B</c> mark and the cursor, in reading order.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is grid truth, not a keystroke mirror. It stays correct across history recall,
+    /// <c>Ctrl+U</c>, tab completion, bracketed paste and any other edit the shell's line
+    /// editor performs without telling the terminal what it did — the V1 shadow buffer could
+    /// not, which is why it desynced.
+    /// </para>
+    /// <para>
+    /// <b>Only valid between <c>OSC 133;B</c> and the following <c>OSC 133;C</c>.</b> The reader
+    /// cannot tell "the user is still typing" from "the command already ran and this is its
+    /// output": both look like cells between the mark and the cursor. Gating on the command
+    /// lifecycle is the caller's job.
+    /// </para>
+    /// </remarks>
+    /// <param name="Text">
+    /// The extracted text. Soft-wrapped (auto-wrapped) rows are joined with no separator, so a
+    /// logical line that spans several physical rows comes back as one line. A hard line break
+    /// inside the span — shell continuation input — becomes a single <c>'\n'</c>; see
+    /// <paramref name="IsMultiline"/>.
+    /// </param>
+    /// <param name="CursorOffset">
+    /// The cursor's index within <paramref name="Text"/>. Always in <c>[0, Text.Length]</c>: the
+    /// cursor is frequently mid-line (arrow keys, <c>Ctrl+A</c>), so this is not simply the
+    /// length. When the cursor sits on the trailing cell of a double-width character the offset
+    /// lands after that character.
+    /// </param>
+    /// <param name="IsMultiline">
+    /// True when <paramref name="Text"/> contains a hard line break — a shell continuation
+    /// entry, or a bracketed paste of several lines. <paramref name="Text"/> is then
+    /// <i>raw</i>: it still contains whatever the shell painted as a
+    /// continuation prompt (<c>PS2</c>, <c>PROMPT2</c>, <c>&gt;&nbsp;</c>), because nothing marks
+    /// those cells as prompt rather than input. Consumers must treat multiline text as opaque —
+    /// fine for history and display, never a typed prefix to complete against.
+    /// </param>
+    /// <param name="RightPromptTrimmed">
+    /// True when trailing cells were excluded as a right-aligned prompt (zsh <c>RPROMPT</c>,
+    /// fish <c>fish_right_prompt</c>, starship's right prompt). Diagnostic only; the exclusion
+    /// rule is documented on <see cref="GridQueryReader"/>.
+    /// </param>
+    /// <param name="StartRow">
+    /// First row of the span in the buffer's current addressing space (scrollback rows +
+    /// viewport row). Shifts under scrollback eviction like any other current-space row index.
+    /// </param>
+    /// <param name="EndRow">Last row of the span, same addressing space as <paramref name="StartRow"/>.</param>
+    public readonly record struct GridCommandLine(
+        string Text,
+        int CursorOffset,
+        bool IsMultiline,
+        bool RightPromptTrimmed,
+        int StartRow,
+        int EndRow);
+}

--- a/src/NovaTerminal.VT/GridQueryReader.cs
+++ b/src/NovaTerminal.VT/GridQueryReader.cs
@@ -1,0 +1,388 @@
+using System;
+using System.Text;
+
+namespace NovaTerminal.VT
+{
+    /// <summary>
+    /// Reads the live command line out of the terminal grid: the cells from an
+    /// <c>OSC 133;B</c> mark (prompt end / first cell of user input) to the cursor.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Placement.</b> This lives in <c>NovaTerminal.VT</c> rather than in
+    /// <c>NovaTerminal.CommandAssist</c> (where the V2 plan first sketched it) because the
+    /// extraction is pure buffer walking — wrap flags, paged scrollback, wide-cell
+    /// continuations, the deferred-autowrap cursor — and the layering tests forbid
+    /// <c>NovaTerminal.CommandAssist</c> from referencing <c>NovaTerminal.VT</c>. Command
+    /// Assist consumes the result through the App boundary.
+    /// </para>
+    /// <para>
+    /// <b>Lock discipline.</b> <see cref="TryReadCommandLine"/> takes the buffer read lock
+    /// itself unless the calling thread already holds a read or write lock —
+    /// <see cref="TerminalBuffer.Lock"/> is non-recursive, so blind re-entry would throw. The
+    /// underlying cell accessors assert the lock is held.
+    /// </para>
+    /// <para>
+    /// <b>It never throws and never guesses.</b> Every ambiguity resolves to <c>false</c>:
+    /// a mark from a dead coordinate generation, a mark whose line has aged out of scrollback,
+    /// an alt-screen mark or an active alt screen, a cursor above the mark, a mark position
+    /// outside the buffer, or an implausibly large span (see <see cref="MaxSpanRows"/>).
+    /// </para>
+    /// <para>
+    /// <b>Right-prompt (RPROMPT) exclusion.</b> zsh's <c>RPROMPT</c> — and fish's
+    /// <c>fish_right_prompt</c>, and starship's right prompt — paints right-aligned text on the
+    /// same physical row as the input. Naively reading "mark column to last non-blank cell"
+    /// swallows it. Stopping at the cursor instead is wrong, because the cursor is often
+    /// mid-line. The rule used here, applied <i>only</i> to the final row of the span and
+    /// <i>only</i> when the cursor is on that row:
+    /// <list type="number">
+    /// <item><description>the trailing content must end within
+    /// <see cref="MaxRightPromptIndent"/> columns of the right edge (right-aligned text does;
+    /// typed input generally does not, and <c>ZLE_RPROMPT_INDENT</c> defaults to 1);</description></item>
+    /// <item><description>it must be separated from the rest of the row by a run of at least
+    /// <see cref="MinRightPromptGap"/> blank cells;</description></item>
+    /// <item><description>that run must start at or after the cursor. Nothing left of the
+    /// cursor is ever discarded, so a double space inside typed input cannot be mistaken for
+    /// the separator.</description></item>
+    /// </list>
+    /// All three must hold. Shells drop the right prompt as soon as input grows into it, which
+    /// is why rows other than the cursor's are exempt: a soft-wrapped row is full of input by
+    /// definition.
+    /// </para>
+    /// <para>
+    /// <b>Multiline.</b> The span always runs to the end of the logical line the cursor is on
+    /// (soft-wrapped continuations are followed <i>past</i> the cursor row — the cursor may be
+    /// on the first of three wrapped rows). Hard line breaks inside the span are emitted as
+    /// <c>'\n'</c> and raise <see cref="GridCommandLine.IsMultiline"/>; the text is returned
+    /// raw, continuation-prompt paint included. See <see cref="GridCommandLine.IsMultiline"/>
+    /// for why, and for what consumers may do with it.
+    /// </para>
+    /// <para>
+    /// <b>Known limitation: multiline entries read from an earlier line.</b> The span stops at
+    /// the end of the cursor's logical line, so if the user arrows <i>up</i> inside a
+    /// continuation entry the reader returns that line alone with
+    /// <see cref="GridCommandLine.IsMultiline"/> clear — truthful for the region read, but not
+    /// the whole entry. The alternative, extending across hard breaks while the row below has
+    /// content, was rejected: zsh prints its completion listing directly below the input line,
+    /// so that rule would misfire on every tab completion, which is precisely the case Command
+    /// Assist most needs to get right.
+    /// </para>
+    /// <para>
+    /// <b>Known limitation.</b> A prompt that ends exactly on the last column leaves the cursor
+    /// parked on that column with the wrap deferred, and the mark records only the column — not
+    /// the deferred-wrap bit. The reader then starts one cell early and the text picks up the
+    /// prompt's final character. Recording pending-wrap on the mark would fix it; it is not
+    /// worth the cross-layer churn for a prompt that exactly fills the terminal width.
+    /// </para>
+    /// </remarks>
+    public static class GridQueryReader
+    {
+        /// <summary>
+        /// Upper bound on the number of physical rows a single command line may span. A span
+        /// larger than this means the mark is being used outside its <c>B</c>-to-<c>C</c>
+        /// window (so the "command line" is really command output), and building the string
+        /// would be both wrong and expensive.
+        /// </summary>
+        public const int MaxSpanRows = 512;
+
+        /// <summary>Blank cells required before a right-aligned prompt is recognised as one.</summary>
+        public const int MinRightPromptGap = 2;
+
+        /// <summary>
+        /// How far from the right edge a right-aligned prompt may stop. zsh's
+        /// <c>ZLE_RPROMPT_INDENT</c> defaults to 1; 2 leaves a little slack.
+        /// </summary>
+        public const int MaxRightPromptIndent = 2;
+
+        /// <summary>
+        /// Extracts the command line between <paramref name="mark"/> and the cursor.
+        /// </summary>
+        /// <returns>
+        /// <c>true</c> and a populated <paramref name="result"/> when the mark is live and
+        /// resolves to a readable span; <c>false</c> otherwise. Never throws.
+        /// </returns>
+        public static bool TryReadCommandLine(
+            TerminalBuffer buffer,
+            ShellIntegrationMark mark,
+            out GridCommandLine result)
+        {
+            result = default;
+            if (buffer is null)
+            {
+                return false;
+            }
+
+            // Non-recursive lock: only acquire if this thread is not already inside one.
+            bool lockTaken = false;
+            if (!buffer.Lock.IsReadLockHeld && !buffer.Lock.IsWriteLockHeld)
+            {
+                buffer.Lock.EnterReadLock();
+                lockTaken = true;
+            }
+
+            try
+            {
+                return TryReadCommandLineLocked(buffer, mark, out result);
+            }
+            finally
+            {
+                if (lockTaken)
+                {
+                    buffer.Lock.ExitReadLock();
+                }
+            }
+        }
+
+        private static bool TryReadCommandLineLocked(
+            TerminalBuffer buffer,
+            ShellIntegrationMark mark,
+            out GridCommandLine result)
+        {
+            result = default;
+
+            // Coordinate-space epoch first: after a scrollback reset a stale AbsoluteRow
+            // resolves to a perfectly plausible row holding unrelated content, so no
+            // arithmetic check downstream can catch it.
+            if (mark.Generation != buffer.Scrollback.Generation)
+            {
+                return false;
+            }
+
+            // The alt screen has no scrollback and no shared row numbering; a full-screen
+            // application owns the grid and there is no shell line editor to read.
+            if (mark.IsAltScreen || buffer.IsAltScreenActive)
+            {
+                return false;
+            }
+
+            int cols = buffer.Cols;
+            if (cols <= 0 || mark.Column < 0 || mark.Column >= cols)
+            {
+                return false;
+            }
+
+            long derivedRow = mark.AbsoluteRow - buffer.Scrollback.TotalRowsEvicted;
+            if (derivedRow < 0)
+            {
+                return false; // the marked line aged out of history
+            }
+
+            int totalRows = buffer.InternalTotalLines;
+            int startRow = (int)derivedRow;
+            if (startRow >= totalRows)
+            {
+                return false;
+            }
+
+            int cursorRow = buffer.Scrollback.Count + buffer.InternalCursorRow;
+
+            // Deferred autowrap: after a character lands on the last column the cursor stays
+            // parked there with the wrap pending, so its *text* position is one past it.
+            int cursorTextCol = buffer.IsPendingWrap
+                ? Math.Min(buffer.InternalCursorCol + 1, cols)
+                : buffer.InternalCursorCol;
+
+            if (cursorRow < startRow)
+            {
+                return false; // cursor above the mark: the mark is stale
+            }
+
+            if (cursorRow == startRow && cursorTextCol < mark.Column)
+            {
+                return false; // cursor left of the mark on the mark's own row
+            }
+
+            // Follow soft wraps past the cursor: the cursor may be on the first of several
+            // physical rows that make up one logical line.
+            int endRow = cursorRow;
+            while (endRow < totalRows - 1 && buffer.IsRowWrappedAbsolute(endRow))
+            {
+                endRow++;
+                if (endRow - startRow + 1 > MaxSpanRows)
+                {
+                    return false;
+                }
+            }
+
+            if (endRow - startRow + 1 > MaxSpanRows)
+            {
+                return false;
+            }
+
+            var text = new StringBuilder();
+            int cursorOffset = -1;
+            bool isMultiline = false;
+            bool rightPromptTrimmed = false;
+
+            for (int row = startRow; row <= endRow; row++)
+            {
+                int firstCol = row == startRow ? mark.Column : 0;
+                bool isCursorRow = row == cursorRow;
+                bool isLastRow = row == endRow;
+                bool wrapped = !isLastRow && buffer.IsRowWrappedAbsolute(row);
+
+                int endCol = wrapped
+                    ? SoftWrappedRowEnd(buffer, row, cols)
+                    : ContentRowEnd(
+                        buffer,
+                        row,
+                        firstCol,
+                        cols,
+                        isCursorRow && isLastRow ? cursorTextCol : (int?)null,
+                        ref rightPromptTrimmed);
+
+                for (int col = firstCol; col < endCol; col++)
+                {
+                    if (isCursorRow && col == cursorTextCol)
+                    {
+                        cursorOffset = text.Length;
+                    }
+
+                    if (buffer.GetCellAbsolute(col, row).IsWideContinuation)
+                    {
+                        continue; // trailing half of a double-width cell
+                    }
+
+                    string grapheme = buffer.GetGraphemeAbsolute(col, row);
+                    text.Append(string.IsNullOrEmpty(grapheme) || grapheme == "\0" ? " " : grapheme);
+                }
+
+                if (isCursorRow && cursorOffset < 0)
+                {
+                    // Cursor at (or past) the end of the row's content.
+                    cursorOffset = text.Length;
+                }
+
+                if (!isLastRow && !wrapped)
+                {
+                    text.Append('\n');
+                    isMultiline = true;
+                }
+            }
+
+            if (cursorOffset < 0)
+            {
+                cursorOffset = text.Length;
+            }
+
+            result = new GridCommandLine(
+                Text: text.ToString(),
+                CursorOffset: cursorOffset,
+                IsMultiline: isMultiline,
+                RightPromptTrimmed: rightPromptTrimmed,
+                StartRow: startRow,
+                EndRow: endRow);
+            return true;
+        }
+
+        /// <summary>
+        /// Exclusive end column for a soft-wrapped row. Such a row is full of input by
+        /// definition, except for the one-cell hole a double-width character leaves when it
+        /// does not fit in the last column and wraps early.
+        /// </summary>
+        private static int SoftWrappedRowEnd(TerminalBuffer buffer, int row, int cols)
+        {
+            if (cols >= 2 &&
+                IsBlank(buffer.GetCellAbsolute(cols - 1, row)) &&
+                buffer.GetCellAbsolute(0, row + 1).IsWide)
+            {
+                return cols - 1;
+            }
+
+            return cols;
+        }
+
+        /// <summary>
+        /// Exclusive end column for a row that is not soft-wrapped: trailing blanks are
+        /// dropped, but the cursor always stays inside the text (the user may have typed
+        /// trailing spaces and parked the cursor after them), and a right-aligned prompt is
+        /// excluded when <paramref name="cursorTextCol"/> is supplied.
+        /// </summary>
+        private static int ContentRowEnd(
+            TerminalBuffer buffer,
+            int row,
+            int firstCol,
+            int cols,
+            int? cursorTextCol,
+            ref bool rightPromptTrimmed)
+        {
+            int lastNonBlank = LastNonBlankColumn(buffer, row, firstCol, cols);
+            int contentEnd = Math.Max(firstCol, lastNonBlank + 1);
+
+            if (cursorTextCol is int cursorCol)
+            {
+                if (contentEnd > cursorCol && lastNonBlank >= cols - 1 - MaxRightPromptIndent)
+                {
+                    int gapStart = FindRightPromptGapStart(
+                        buffer, row, Math.Max(firstCol, cursorCol), lastNonBlank);
+                    if (gapStart >= 0)
+                    {
+                        rightPromptTrimmed = true;
+                        contentEnd = gapStart;
+                    }
+                }
+
+                return Math.Max(cursorCol, Math.Max(contentEnd, firstCol));
+            }
+
+            return contentEnd;
+        }
+
+        /// <summary>
+        /// Start column of the rightmost run of at least <see cref="MinRightPromptGap"/> blanks
+        /// that lies at or after <paramref name="floor"/> and left of
+        /// <paramref name="lastNonBlank"/>, or <c>-1</c> when there is none.
+        /// </summary>
+        private static int FindRightPromptGapStart(
+            TerminalBuffer buffer, int row, int floor, int lastNonBlank)
+        {
+            int col = lastNonBlank - 1;
+            while (col >= floor)
+            {
+                if (!IsBlank(buffer.GetCellAbsolute(col, row)))
+                {
+                    col--;
+                    continue;
+                }
+
+                int runStart = col;
+                while (runStart - 1 >= floor && IsBlank(buffer.GetCellAbsolute(runStart - 1, row)))
+                {
+                    runStart--;
+                }
+
+                if (col - runStart + 1 >= MinRightPromptGap)
+                {
+                    return runStart;
+                }
+
+                col = runStart - 1;
+            }
+
+            return -1;
+        }
+
+        private static int LastNonBlankColumn(TerminalBuffer buffer, int row, int firstCol, int cols)
+        {
+            for (int col = cols - 1; col >= firstCol; col--)
+            {
+                if (!IsBlank(buffer.GetCellAbsolute(col, row)))
+                {
+                    return col;
+                }
+            }
+
+            return firstCol - 1;
+        }
+
+        /// <summary>
+        /// A cell holding nothing. The trailing half of a double-width character stores a space
+        /// but is <i>not</i> blank — it sits inside content, and treating it as a gap would let
+        /// two adjacent CJK characters look like a right-prompt separator.
+        /// </summary>
+        private static bool IsBlank(in TerminalCell cell)
+            => !cell.IsWideContinuation
+               && !cell.HasExtendedText
+               && (cell.Character == ' ' || cell.Character == '\0');
+    }
+}

--- a/src/NovaTerminal.VT/GridQueryReader.cs
+++ b/src/NovaTerminal.VT/GridQueryReader.cs
@@ -34,20 +34,36 @@ namespace NovaTerminal.VT
     /// same physical row as the input. Naively reading "mark column to last non-blank cell"
     /// swallows it. Stopping at the cursor instead is wrong, because the cursor is often
     /// mid-line. The rule used here, applied <i>only</i> to the final row of the span and
-    /// <i>only</i> when the cursor is on that row:
+    /// <i>only</i> when the cursor is on that row, reads the row as
+    /// <c>[input][gap][badge]</c> and requires all of:
     /// <list type="number">
     /// <item><description>the trailing content must end within
     /// <see cref="MaxRightPromptIndent"/> columns of the right edge (right-aligned text does;
     /// typed input generally does not, and <c>ZLE_RPROMPT_INDENT</c> defaults to 1);</description></item>
-    /// <item><description>it must be separated from the rest of the row by a run of at least
-    /// <see cref="MinRightPromptGap"/> blank cells;</description></item>
-    /// <item><description>that run must start at or after the cursor. Nothing left of the
-    /// cursor is ever discarded, so a double space inside typed input cannot be mistaken for
-    /// the separator.</description></item>
+    /// <item><description>the gap must start at or after the cursor. Nothing left of the
+    /// cursor is ever discarded;</description></item>
+    /// <item><description>the gap is the <i>widest</i> run of blank cells in that region, so a
+    /// multi-segment right prompt such as <c>12:34  ok</c> is trimmed whole instead of being cut
+    /// at its own internal gap (which would keep the wide run and the left segment — worse than
+    /// not trimming at all);</description></item>
+    /// <item><description>the gap must be at least <see cref="MinRightPromptGap"/> cells wide
+    /// <i>and strictly wider than the badge it separates</i>. A right prompt is a small label
+    /// pushed to the edge by the row's slack; a stray double space inside typed input is
+    /// not;</description></item>
+    /// <item><description>the badge must be no wider than
+    /// <c>Cols / </c><see cref="MaxRightPromptWidthDivisor"/> columns. Right prompts are badges,
+    /// not sentences.</description></item>
     /// </list>
-    /// All three must hold. Shells drop the right prompt as soon as input grows into it, which
-    /// is why rows other than the cursor's are exempt: a soft-wrapped row is full of input by
-    /// definition.
+    /// All five must hold. Conditions 4 and 5 are what stop the reader deleting typed input:
+    /// without them a row such as <c>echo aaaa...aa  bbbb</c> that happens to reach the right
+    /// edge, with the cursor parked at the start of the line (Home), silently loses its
+    /// <c>bbbb</c> — condition 2 does not protect content to the <i>right</i> of a mid-line
+    /// cursor. The failure mode is deliberately asymmetric: an unrecognised right prompt comes
+    /// back as extra text, which a consumer can survive, while a mis-recognised one deletes what
+    /// the user typed. A badge wider than the gap in front of it, or wider than a third of the
+    /// row, is therefore kept.
+    /// Shells drop the right prompt as soon as input grows into it, which is why rows other than
+    /// the cursor's are exempt: a soft-wrapped row is full of input by definition.
     /// </para>
     /// <para>
     /// <b>Multiline.</b> The span always runs to the end of the logical line the cursor is on
@@ -85,7 +101,10 @@ namespace NovaTerminal.VT
         /// </summary>
         public const int MaxSpanRows = 512;
 
-        /// <summary>Blank cells required before a right-aligned prompt is recognised as one.</summary>
+        /// <summary>
+        /// Blank cells required before a right-aligned prompt is recognised as one. A floor, not
+        /// the whole test: the gap must also be strictly wider than the badge it separates.
+        /// </summary>
         public const int MinRightPromptGap = 2;
 
         /// <summary>
@@ -93,6 +112,13 @@ namespace NovaTerminal.VT
         /// <c>ZLE_RPROMPT_INDENT</c> defaults to 1; 2 leaves a little slack.
         /// </summary>
         public const int MaxRightPromptIndent = 2;
+
+        /// <summary>
+        /// The widest a right prompt may be, as a fraction of the terminal width: a badge may
+        /// occupy at most <c>Cols / MaxRightPromptWidthDivisor</c> columns. Anything larger is
+        /// far more likely to be typed input that happens to reach the right edge, and is kept.
+        /// </summary>
+        public const int MaxRightPromptWidthDivisor = 3;
 
         /// <summary>
         /// Extracts the command line between <paramref name="mark"/> and the cursor.
@@ -112,9 +138,13 @@ namespace NovaTerminal.VT
                 return false;
             }
 
-            // Non-recursive lock: only acquire if this thread is not already inside one.
+            // Non-recursive lock: only acquire if this thread is not already inside one. The
+            // upgradeable-read case cannot arise on today's call paths, but re-entering from
+            // inside one would throw, and this method's contract is that it never does.
             bool lockTaken = false;
-            if (!buffer.Lock.IsReadLockHeld && !buffer.Lock.IsWriteLockHeld)
+            if (!buffer.Lock.IsReadLockHeld &&
+                !buffer.Lock.IsWriteLockHeld &&
+                !buffer.Lock.IsUpgradeableReadLockHeld)
             {
                 buffer.Lock.EnterReadLock();
                 lockTaken = true;
@@ -280,6 +310,15 @@ namespace NovaTerminal.VT
         /// definition, except for the one-cell hole a double-width character leaves when it
         /// does not fit in the last column and wraps early.
         /// </summary>
+        /// <remarks>
+        /// The hole is not distinguishable from content. A typed space in the last column of a
+        /// row whose next row begins with a wide character produces a byte-identical grid to the
+        /// early-wrap hole, because nothing records <i>why</i> the cell is blank. The reader
+        /// drops it either way, so that one case loses a typed space. The alternative — keeping
+        /// it — inserts a phantom space into the middle of every command line that wraps before
+        /// a CJK or emoji character, which is both far more common and harder for a consumer to
+        /// undo.
+        /// </remarks>
         private static int SoftWrappedRowEnd(TerminalBuffer buffer, int row, int cols)
         {
             if (cols >= 2 &&
@@ -314,7 +353,7 @@ namespace NovaTerminal.VT
                 if (contentEnd > cursorCol && lastNonBlank >= cols - 1 - MaxRightPromptIndent)
                 {
                     int gapStart = FindRightPromptGapStart(
-                        buffer, row, Math.Max(firstCol, cursorCol), lastNonBlank);
+                        buffer, row, Math.Max(firstCol, cursorCol), lastNonBlank, cols);
                     if (gapStart >= 0)
                     {
                         rightPromptTrimmed = true;
@@ -329,13 +368,35 @@ namespace NovaTerminal.VT
         }
 
         /// <summary>
-        /// Start column of the rightmost run of at least <see cref="MinRightPromptGap"/> blanks
-        /// that lies at or after <paramref name="floor"/> and left of
-        /// <paramref name="lastNonBlank"/>, or <c>-1</c> when there is none.
+        /// Start column of the blank run that separates a right-aligned prompt from the rest of
+        /// the row, or <c>-1</c> when the row does not look like one.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The candidate is the <i>widest</i> blank run at or after <paramref name="floor"/> and
+        /// left of <paramref name="lastNonBlank"/> — the row's dominant slack, which is what a
+        /// right-aligned paint produces. Taking the rightmost qualifying run instead (the
+        /// previous rule) cuts a multi-segment right prompt such as <c>12:34  ok</c> at its own
+        /// internal gap, keeping the wide run and the left segment: worse than not trimming.
+        /// Ties resolve to the leftmost run, which yields the larger badge and so the more
+        /// conservative answer below.
+        /// </para>
+        /// <para>
+        /// The run then has to look like a separator rather than a typo: at least
+        /// <see cref="MinRightPromptGap"/> cells wide, strictly wider than the badge it
+        /// separates, and that badge no wider than
+        /// <paramref name="cols"/><c> / </c><see cref="MaxRightPromptWidthDivisor"/> columns.
+        /// Failing any of these keeps the whole row — over-returning is recoverable, deleting
+        /// typed input is not.
+        /// </para>
+        /// </remarks>
         private static int FindRightPromptGapStart(
-            TerminalBuffer buffer, int row, int floor, int lastNonBlank)
+            TerminalBuffer buffer, int row, int floor, int lastNonBlank, int cols)
         {
+            int bestStart = -1;
+            int bestEnd = -1;
+            int bestWidth = 0;
+
             int col = lastNonBlank - 1;
             while (col >= floor)
             {
@@ -351,15 +412,35 @@ namespace NovaTerminal.VT
                     runStart--;
                 }
 
-                if (col - runStart + 1 >= MinRightPromptGap)
+                // Scanning right to left, ">=" keeps the leftmost of equally wide runs.
+                int width = col - runStart + 1;
+                if (width >= bestWidth)
                 {
-                    return runStart;
+                    bestWidth = width;
+                    bestStart = runStart;
+                    bestEnd = col;
                 }
 
                 col = runStart - 1;
             }
 
-            return -1;
+            if (bestStart < 0 || bestWidth < MinRightPromptGap)
+            {
+                return -1;
+            }
+
+            int badgeWidth = lastNonBlank - bestEnd;
+            if (badgeWidth >= bestWidth)
+            {
+                return -1; // the gap does not dominate: this is spacing inside typed input
+            }
+
+            if (badgeWidth > cols / MaxRightPromptWidthDivisor)
+            {
+                return -1; // too big to be a badge
+            }
+
+            return bestStart;
         }
 
         private static int LastNonBlankColumn(TerminalBuffer buffer, int row, int firstCol, int cols)

--- a/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
@@ -54,6 +54,35 @@ namespace NovaTerminal.VT
             return _viewport[viewportRow];
         }
 
+        /// <summary>
+        /// True when the row at an absolute index ends because it auto-wrapped rather than
+        /// because of an explicit newline — i.e. the next row continues the same logical line.
+        /// Requires the read lock.
+        /// </summary>
+        /// <remarks>
+        /// Unlike <see cref="GetRowAbsolute"/> this answers for scrollback rows too, reading the
+        /// per-row wrap bit the pages carry. Out-of-range indices answer <c>false</c> rather
+        /// than throwing, so callers walking a span can stop at the buffer edge naturally.
+        /// </remarks>
+        public bool IsRowWrappedAbsolute(int absRow)
+        {
+            AssertLockHeld();
+            if (absRow < 0) return false;
+
+            if (_isAltScreen)
+            {
+                return absRow < Rows && _viewport[absRow].IsWrapped;
+            }
+
+            if (absRow < _scrollback.Count)
+            {
+                return _scrollback.IsRowWrapped(absRow);
+            }
+
+            int viewportRow = absRow - _scrollback.Count;
+            return viewportRow >= 0 && viewportRow < Rows && _viewport[viewportRow].IsWrapped;
+        }
+
         public TerminalCell GetCellAbsolute(int col, int absRow)
         {
             AssertLockHeld();

--- a/tests/NovaTerminal.App.Tests/Controls/PaneGridCommandLineTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneGridCommandLineTests.cs
@@ -15,6 +15,8 @@ namespace NovaTerminal.Tests.Controls;
 public class PaneGridCommandLineTests
 {
     private const string PromptEnd = "\x1b]133;B\x07";
+    private const string CommandExecuted = "\x1b]133;C\x07";
+    private const string CommandFinished = "\x1b]133;D;0\x07";
 
     [AvaloniaFact]
     public void WithoutAMark_ThereIsNoGridCommandLine()
@@ -56,5 +58,32 @@ public class PaneGridCommandLineTests
 
         Assert.True(pane.TryGetGridCommandLine(out GridCommandLine line));
         Assert.Equal("ls -la", line.Text);
+    }
+
+    [AvaloniaFact]
+    public void TheMarkSurvivesCommandExecutionButNotCommandCompletion()
+    {
+        // C (executed) must not drop the mark: it fires the instant the user submits, while the
+        // input line is still on screen and still exactly what the mark describes. D (finished)
+        // must, or the span from the mark to the cursor is the command's *output* -- and it
+        // stays dropped until the next prompt re-emits B.
+        using var pane = new TerminalPane();
+        pane.CreateAndWireParser();
+
+        pane.Parser!.Process("\x1b]133;A\x07$ " + PromptEnd + "git status");
+
+        pane.Parser!.Process(CommandExecuted);
+        Assert.True(pane.TryGetGridCommandLine(out GridCommandLine submitted));
+        Assert.Equal("git status", submitted.Text);
+
+        pane.Parser!.Process("\r\n On branch main\r\n");
+        pane.Parser!.Process(CommandFinished);
+
+        Assert.False(pane.TryGetGridCommandLine(out _));
+
+        pane.Parser!.Process("\x1b]133;A\x07$ " + PromptEnd + "ls");
+
+        Assert.True(pane.TryGetGridCommandLine(out GridCommandLine next));
+        Assert.Equal("ls", next.Text);
     }
 }

--- a/tests/NovaTerminal.App.Tests/Controls/PaneGridCommandLineTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneGridCommandLineTests.cs
@@ -1,0 +1,60 @@
+using Avalonia.Headless.XUnit;
+using NovaTerminal.Controls;
+using NovaTerminal.VT;
+using Xunit;
+
+namespace NovaTerminal.Tests.Controls;
+
+/// <summary>
+/// The Phase 1b seam: <c>TerminalPane.TryGetGridCommandLine</c> combines the newest
+/// <c>OSC 133;B</c> mark with the pane's buffer and hands both to
+/// <see cref="GridQueryReader"/>. Extraction semantics are covered exhaustively in
+/// <c>NovaTerminal.VT.Tests.GridQueryReaderTests</c>; what is pinned here is the wiring —
+/// that the pane keeps the mark at all, and keeps the <i>newest</i> one.
+/// </summary>
+public class PaneGridCommandLineTests
+{
+    private const string PromptEnd = "\x1b]133;B\x07";
+
+    [AvaloniaFact]
+    public void WithoutAMark_ThereIsNoGridCommandLine()
+    {
+        using var pane = new TerminalPane();
+        pane.CreateAndWireParser();
+
+        pane.Parser!.Process("$ git status");
+
+        Assert.False(pane.TryGetGridCommandLine(out _));
+    }
+
+    [AvaloniaFact]
+    public void AfterAPromptMark_TheLiveCommandLineIsReadFromTheGrid()
+    {
+        using var pane = new TerminalPane();
+        pane.CreateAndWireParser();
+
+        pane.Parser!.Process("\x1b]133;A\x07user@host:~$ ");
+        pane.Parser!.Process(PromptEnd);
+        pane.Parser!.Process("git status");
+
+        Assert.True(pane.TryGetGridCommandLine(out GridCommandLine line));
+        Assert.Equal("git status", line.Text);
+        Assert.Equal(10, line.CursorOffset);
+    }
+
+    [AvaloniaFact]
+    public void APromptRepaintReplacesTheMark()
+    {
+        // B rides inside the prompt string, so every repaint re-emits it. Holding the first
+        // mark would leave the reader anchored to a prompt that is no longer on screen.
+        using var pane = new TerminalPane();
+        pane.CreateAndWireParser();
+
+        pane.Parser!.Process("\x1b]133;A\x07$ " + PromptEnd + "stale");
+        pane.Parser!.Process("\r\x1b[K");
+        pane.Parser!.Process("\x1b]133;A\x07nova> " + PromptEnd + "ls -la");
+
+        Assert.True(pane.TryGetGridCommandLine(out GridCommandLine line));
+        Assert.Equal("ls -la", line.Text);
+    }
+}

--- a/tests/NovaTerminal.VT.Tests/GridQueryReaderTests.cs
+++ b/tests/NovaTerminal.VT.Tests/GridQueryReaderTests.cs
@@ -104,6 +104,24 @@ public class GridQueryReaderTests
     }
 
     [Fact]
+    public void MarkAtColumnZeroOfAnEmptyPromptRow_Reads()
+    {
+        // A zero-width prompt (PROMPT='' or a prompt that ends with a newline) puts the mark on
+        // column 0. Nothing left of the mark, and firstCol == 0 for both the mark row and every
+        // continuation row: the one place those two cases coincide.
+        var s = new Session().Prompt(string.Empty);
+
+        Assert.Equal(0, s.Mark.Column);
+        Assert.Equal(string.Empty, s.Read().Text);
+
+        s.Write("ls -la");
+
+        var line = s.Read();
+        Assert.Equal("ls -la", line.Text);
+        Assert.Equal(6, line.CursorOffset);
+    }
+
+    [Fact]
     public void PromptTextItselfIsNeverIncluded()
     {
         var s = new Session().Prompt("user@host ~/src (main) $ ").Write("ls");
@@ -349,6 +367,55 @@ public class GridQueryReaderTests
     }
 
     [Fact]
+    public void SoftWrappedRowPagedIntoScrollback_IsStillFollowedAsOneLogicalLine()
+    {
+        // The reason IsRowWrappedAbsolute exists: a soft-wrapped logical line whose *first*
+        // physical row has already paged out of the viewport. That row has no TerminalRow object
+        // at all, so the wrap bit has to come from the scrollback page -- and the sibling
+        // scrollback test above uses hard line breaks, which leaves that bit false and the
+        // branch never exercised in its interesting state.
+        string input = new string('a', 14) + new string('b', 16) + new string('c', 16) + new string('d', 14);
+        var s = new Session(cols: 16, rows: 3).Prompt().Write(input);
+
+        Assert.True(s.Buffer.Scrollback.Count > 0, "the first physical row must have paged out");
+
+        s.Buffer.Lock.EnterReadLock();
+        try
+        {
+            Assert.Null(s.Buffer.GetRowAbsolute(0));          // genuinely paged, not a viewport row
+            Assert.True(s.Buffer.IsRowWrappedAbsolute(0));    // ...with the wrap bit set
+        }
+        finally
+        {
+            s.Buffer.Lock.ExitReadLock();
+        }
+
+        var line = s.Read();
+
+        Assert.Equal(input, line.Text);
+        Assert.DoesNotContain("\n", line.Text);
+        Assert.False(line.IsMultiline);
+        Assert.Equal(0, line.StartRow);
+    }
+
+    [Fact]
+    public void ExtendedGraphemeOnAScrollbackRow_SurvivesThePaging()
+    {
+        // The side table that holds multi-char clusters is per-row; a paged row has to carry it
+        // through GetGraphemeAbsolute or the emoji comes back as a lone replacement char.
+        var s = new Session(cols: 40, rows: 3)
+            .Prompt()
+            .Write("echo " + Emoji)
+            .Write("\r\n> def")
+            .Write("\r\n> ghi")
+            .Write("\r\n> jkl");
+
+        Assert.True(s.Buffer.Scrollback.Count > 0, "the mark's row must have scrolled off");
+
+        Assert.Equal("echo " + Emoji + "\n> def\n> ghi\n> jkl", s.Read().Text);
+    }
+
+    [Fact]
     public void MarkAgedOutOfScrollback_Fails()
     {
         var s = new Session(cols: 40, rows: 3, maxHistory: 128).Prompt().Write("ls");
@@ -434,6 +501,23 @@ public class GridQueryReaderTests
         s.Prompt().Write("git status");
 
         s.Buffer.Resize(40, 3);
+
+        Assert.Equal("git status", s.Read().Text);
+    }
+
+    [Fact]
+    public void HeightGrowingResize_KeepsTheMarkUsable()
+    {
+        // The other half of the height-only case: growing the viewport pulls rows back out of
+        // scrollback, so Scrollback.Count falls while absolute row identity must not move.
+        var s = new Session(cols: 40, rows: 3);
+        for (int i = 0; i < 6; i++) s.Write($"line {i}\r\n");
+        s.Prompt().Write("git status");
+
+        int scrollbackBefore = s.Buffer.Scrollback.Count;
+        Assert.True(scrollbackBefore > 0, "there must be scrollback for the grow to reclaim");
+
+        s.Buffer.Resize(40, 8);
 
         Assert.Equal("git status", s.Read().Text);
     }
@@ -589,7 +673,63 @@ public class GridQueryReaderTests
 
         var line = s.Read();
 
-        Assert.EndsWith("[main]", line.Text);
+        // Pinned exactly, not just EndsWith: the interior cells were never written, so this also
+        // pins that untouched '\0' cells inside the span come back as spaces.
+        Assert.Equal("ls" + new string(' ', 15) + "[main]", line.Text);
+        Assert.False(line.RightPromptTrimmed);
+    }
+
+    [Fact]
+    public void TypedInputReachingTheRightEdgeWithAnInteriorDoubleSpace_KeepsItsTail()
+    {
+        // The case the "gap starts at or after the cursor" condition does *not* cover: the
+        // cursor is at the start of the line (Home) but the input runs to the right edge, so
+        // every interior gap is at or after the cursor. A rule built on the gap alone deletes
+        // the "bbbb". The gap must also dominate the badge it separates: two blanks in front of
+        // four characters is a typo, not a right prompt.
+        string input = "echo " + new string('a', 26) + "  bbbb"; // 37 cells: columns 2..38
+        var s = new Session(cols: 40, rows: 6).Prompt().Write(input).Write("\x1b[3G");
+
+        var line = s.Read();
+
+        Assert.Equal(input, line.Text);
+        Assert.Equal(0, line.CursorOffset);
+        Assert.False(line.RightPromptTrimmed);
+    }
+
+    [Fact]
+    public void MultiSegmentRightPrompt_IsTrimmedWholeRatherThanAtItsInternalGap()
+    {
+        // "12:34  ok" is one right-aligned group with its own internal gap. Cutting at the
+        // rightmost qualifying run would keep "ls" plus 26 blanks plus "12:34" -- worse than not
+        // trimming. The gap is therefore the *widest* run, which is the row's real slack.
+        var s = new Session(cols: 40, rows: 6)
+            .Prompt()
+            .Write("ls")
+            .Write("\x1b[31G12:34  ok") // columns 30..38
+            .Write("\x1b[5G");
+
+        var line = s.Read();
+
+        Assert.Equal("ls", line.Text);
+        Assert.True(line.RightPromptTrimmed);
+    }
+
+    [Fact]
+    public void RightAlignedContentTooWideToBeABadge_IsKept()
+    {
+        // A right prompt is a small label. Sixteen columns of a forty-column row is not one, so
+        // the reader refuses the trim and returns the row -- over-returning is recoverable,
+        // deleting typed input is not.
+        var s = new Session(cols: 40, rows: 6)
+            .Prompt()
+            .Write("ls")
+            .Write("\x1b[24Gabcdefghijklmnop") // columns 23..38, gap of 19
+            .Write("\x1b[5G");
+
+        var line = s.Read();
+
+        Assert.Equal("ls" + new string(' ', 19) + "abcdefghijklmnop", line.Text);
         Assert.False(line.RightPromptTrimmed);
     }
 
@@ -662,6 +802,46 @@ public class GridQueryReaderTests
 
         Assert.Equal(ascii + CjkOne, line.Text);
         Assert.DoesNotContain(" ", line.Text);
+        Assert.Equal(1, line.EndRow);
+    }
+
+    [Fact]
+    public void CombiningMarkAttachedByTheWritePath_IsOneGrapheme()
+    {
+        // The mark arrives as a separate write and the write path merges it into the base cell's
+        // extended text. The reader must read the merged cluster, not the bare base character.
+        var s = new Session().Prompt().Write("echo e").Write("\u0301");
+
+        var line = s.Read();
+
+        Assert.Equal("echo e\u0301", line.Text);
+        Assert.Equal(line.Text.Length, line.CursorOffset);
+    }
+
+    [Fact]
+    public void ZwjClusterAttachedByTheWritePath_IsOneGrapheme()
+    {
+        // U+1F468 ZWJ U+1F4BB: two emoji joined into a single cluster by the attachment path.
+        const string Zwj = "\U0001F468\u200D\U0001F4BB";
+        var s = new Session().Prompt().Write("echo " + Zwj);
+
+        Assert.Equal("echo " + Zwj, s.Read().Text);
+    }
+
+    [Fact]
+    public void CursorParkedOnTheWideCharacterWrapHole_MapsToTheCharacterBoundary()
+    {
+        // The blank cell a double-width character leaves behind when it wraps early is layout,
+        // not text. Parking the cursor on it must not emit it, and the offset must land on the
+        // boundary between the last character that fitted and the wide one that did not.
+        string ascii = new string('a', 16) + "x";
+        var s = new Session(cols: 20, rows: 6).Prompt().Write(ascii + CjkOne);
+        s.Write("\x1b[1;20H"); // row 0, column 19: the hole
+
+        var line = s.Read();
+
+        Assert.Equal(ascii + CjkOne, line.Text);
+        Assert.Equal(ascii.Length, line.CursorOffset);
         Assert.Equal(1, line.EndRow);
     }
 

--- a/tests/NovaTerminal.VT.Tests/GridQueryReaderTests.cs
+++ b/tests/NovaTerminal.VT.Tests/GridQueryReaderTests.cs
@@ -1,0 +1,717 @@
+using System.Collections.Generic;
+using System.Linq;
+using NovaTerminal.VT;
+
+namespace NovaTerminal.VT.Tests;
+
+/// <summary>
+/// The grid-truth query reader: the text between the last <c>OSC 133;B</c> mark and the cursor.
+/// </summary>
+/// <remarks>
+/// Command Assist V2 deletes its keystroke shadow buffer on the strength of these tests, so the
+/// bar is "what does the grid actually contain", not "what did we type". Everything is driven
+/// through the real parser and write path rather than by poking cells, because the properties
+/// under test — wrap flags, wide-cell continuations, deferred autowrap, scrollback paging — are
+/// produced by that path and nowhere else.
+/// </remarks>
+public class GridQueryReaderTests
+{
+    private const string PromptEnd = "\x1b]133;B\x07";
+    private const string PromptStart = "\x1b]133;A\x07";
+
+    // Written as escapes rather than literals so the assertions cannot depend on the source
+    // file's encoding. U+4F60 U+597D = two double-width CJK ideographs; U+1F44D = an emoji
+    // (surrogate pair, double width, stored in the row's extended-text side table).
+    private const string CjkOne = "你";
+    private const string Cjk = "你好";
+    private const string Emoji = "👍";
+
+    private sealed class Session
+    {
+        private readonly List<ShellIntegrationMark> _marks = new();
+
+        public Session(int cols = 40, int rows = 6, int? maxHistory = null)
+        {
+            Buffer = new TerminalBuffer(cols, rows);
+            if (maxHistory is int history)
+            {
+                // The byte budget is derived from MaxHistory and eviction works in whole
+                // 64-row pages, so 128 is the smallest budget that both retains history and
+                // actually evicts.
+                Buffer.MaxHistory = history;
+            }
+
+            Parser = new AnsiParser(Buffer);
+            Parser.OnCommandStarted = mark => _marks.Add(mark);
+        }
+
+        public TerminalBuffer Buffer { get; }
+
+        public AnsiParser Parser { get; }
+
+        public List<ShellIntegrationMark> Marks => _marks;
+
+        /// <summary>The newest mark — a prompt repaint re-emits B, and the newest one is truth.</summary>
+        public ShellIntegrationMark Mark => _marks[^1];
+
+        public Session Write(string data)
+        {
+            Parser.Process(data);
+            return this;
+        }
+
+        /// <summary>Prompt as every bootstrap paints it: A, the prompt text, then B.</summary>
+        public Session Prompt(string text = "$ ") => Write(PromptStart + text + PromptEnd);
+
+        public bool TryRead(out GridCommandLine line)
+            => GridQueryReader.TryReadCommandLine(Buffer, Mark, out line);
+
+        public GridCommandLine Read()
+        {
+            Assert.True(TryRead(out var line), "the mark should have resolved to a readable span");
+            return line;
+        }
+    }
+
+    // ---------------------------------------------------------------- simple reads
+
+    [Fact]
+    public void SimpleLine_IsReadFromTheMarkToTheCursor()
+    {
+        var s = new Session().Prompt().Write("git status");
+
+        var line = s.Read();
+
+        Assert.Equal("git status", line.Text);
+        Assert.Equal(10, line.CursorOffset);
+        Assert.False(line.IsMultiline);
+        Assert.False(line.RightPromptTrimmed);
+        Assert.Equal(0, line.StartRow);
+        Assert.Equal(0, line.EndRow);
+    }
+
+    [Fact]
+    public void EmptyInput_ReadsAnEmptyLineRatherThanFailing()
+    {
+        // The mark lands on the cursor cell, so "nothing typed yet" is a *successful* read of
+        // the empty string. Command Assist needs to tell that apart from "no usable mark".
+        var s = new Session().Prompt();
+
+        var line = s.Read();
+
+        Assert.Equal(string.Empty, line.Text);
+        Assert.Equal(0, line.CursorOffset);
+    }
+
+    [Fact]
+    public void PromptTextItselfIsNeverIncluded()
+    {
+        var s = new Session().Prompt("user@host ~/src (main) $ ").Write("ls");
+
+        Assert.Equal("ls", s.Read().Text);
+    }
+
+    [Fact]
+    public void CursorMidLine_AfterLeftArrows_KeepsTheWholeTextAndMovesTheOffset()
+    {
+        var s = new Session().Prompt().Write("git status").Write("\x1b[6D");
+
+        var line = s.Read();
+
+        Assert.Equal("git status", line.Text);
+        Assert.Equal(4, line.CursorOffset);
+    }
+
+    [Fact]
+    public void CursorAtStartOfInput_AfterCtrlA_ReadsOffsetZero()
+    {
+        // Ctrl+A reaches the terminal as an absolute column move to the first input cell.
+        var s = new Session().Prompt().Write("git status").Write("\x1b[3G");
+
+        var line = s.Read();
+
+        Assert.Equal("git status", line.Text);
+        Assert.Equal(0, line.CursorOffset);
+    }
+
+    [Fact]
+    public void TrailingSpacesLeftOfTheCursorAreKept()
+    {
+        // "git " with the cursor parked after the space: the space is typed input, and
+        // dropping it would make every "complete the next argument" suggestion wrong.
+        var s = new Session().Prompt().Write("git ");
+
+        var line = s.Read();
+
+        Assert.Equal("git ", line.Text);
+        Assert.Equal(4, line.CursorOffset);
+    }
+
+    [Fact]
+    public void BlankCellsBeyondBothTheCursorAndTheContentAreDropped()
+    {
+        var s = new Session().Prompt().Write("ls").Write("\x1b[4G");
+
+        var line = s.Read();
+
+        Assert.Equal("ls", line.Text); // not "ls" plus 37 columns of blanks
+        Assert.Equal(1, line.CursorOffset);
+    }
+
+    [Fact]
+    public void HistoryRecall_IsReadFromTheGridEvenThoughNoKeystrokesProducedIt()
+    {
+        // The desync class that killed V1: the shell repaints the line wholesale (Up arrow,
+        // Ctrl+U, tab completion) and the terminal only ever sees the redraw.
+        var s = new Session().Prompt().Write("gi");
+        s.Write("\r\x1b[K").Write("$ git log --oneline -20"); // shell redraws prompt + recalled line
+
+        Assert.Equal("git log --oneline -20", s.Read().Text);
+    }
+
+    // ---------------------------------------------------------------- soft wrap
+
+    [Fact]
+    public void SoftWrapAcrossTwoRows_IsOneLogicalLineWithNoInjectedNewline()
+    {
+        string input = new string('a', 18) + new string('b', 12);
+        var s = new Session(cols: 20, rows: 6).Prompt().Write(input);
+
+        var line = s.Read();
+
+        Assert.Equal(input, line.Text);
+        Assert.DoesNotContain("\n", line.Text);
+        Assert.False(line.IsMultiline);
+        Assert.Equal(30, line.CursorOffset);
+        Assert.Equal(0, line.StartRow);
+        Assert.Equal(1, line.EndRow);
+    }
+
+    [Fact]
+    public void SoftWrapAcrossThreeRows_IsStillOneLogicalLine()
+    {
+        string input = new string('a', 14) + new string('b', 16) + new string('c', 10);
+        var s = new Session(cols: 16, rows: 6).Prompt().Write(input);
+
+        var line = s.Read();
+
+        Assert.Equal(input, line.Text);
+        Assert.Equal(40, line.CursorOffset);
+        Assert.Equal(2, line.EndRow);
+    }
+
+    [Theory]
+    // Cursor parked on each physical row of a three-row wrapped line. The span must still be
+    // the whole logical line: soft-wrapped continuations are followed *past* the cursor row.
+    [InlineData(1, 5, 2)]   // row 0, column 4 -> two cells into the input
+    [InlineData(2, 3, 16)]  // row 1
+    [InlineData(3, 7, 36)]  // row 2
+    public void WrappedLine_CursorOnAnyRow_KeepsTheWholeLineAndMapsTheOffset(
+        int cupRow, int cupCol, int expectedOffset)
+    {
+        string input = new string('a', 14) + new string('b', 16) + new string('c', 10);
+        var s = new Session(cols: 16, rows: 6).Prompt().Write(input);
+        s.Write($"\x1b[{cupRow};{cupCol}H");
+
+        var line = s.Read();
+
+        Assert.Equal(input, line.Text);
+        Assert.Equal(expectedOffset, line.CursorOffset);
+        Assert.Equal(2, line.EndRow);
+    }
+
+    [Fact]
+    public void InputEndingExactlyAtTheRightEdge_IsWholeDespiteTheDeferredWrap()
+    {
+        // Deferred autowrap: the cursor is parked on the last column with the wrap pending, so
+        // its text position is one *past* it. Reading the raw cursor column would lose the
+        // final character and put the offset in the wrong place.
+        string input = new string('a', 17) + "z";
+        var s = new Session(cols: 20, rows: 6).Prompt().Write(input);
+
+        Assert.True(s.Buffer.IsPendingWrap);
+
+        var line = s.Read();
+
+        Assert.Equal(input, line.Text);
+        Assert.Equal(18, line.CursorOffset);
+        Assert.Equal(0, line.EndRow);
+    }
+
+    [Fact]
+    public void OneCharacterPastTheRightEdge_WrapsOntoTheNextRow()
+    {
+        string input = new string('a', 17) + "zy";
+        var s = new Session(cols: 20, rows: 6).Prompt().Write(input);
+
+        var line = s.Read();
+
+        Assert.Equal(input, line.Text);
+        Assert.Equal(19, line.CursorOffset);
+        Assert.Equal(1, line.EndRow);
+    }
+
+    // ---------------------------------------------------------------- multiline
+
+    [Fact]
+    public void MultilineContinuation_IsRawTextWithNewlinesAndTheMultilineFlag()
+    {
+        // Decision (b): the span is returned raw, including whatever the shell painted as a
+        // continuation prompt. Nothing marks PS2 cells as prompt rather than input, so the
+        // reader cannot strip them and must instead flag the text as untrustworthy-as-prefix.
+        var s = new Session()
+            .Prompt()
+            .Write("for i in 1 2 3")
+            .Write("\r\n> do echo $i");
+
+        var line = s.Read();
+
+        Assert.Equal("for i in 1 2 3\n> do echo $i", line.Text);
+        Assert.True(line.IsMultiline);
+        Assert.Equal(line.Text.Length, line.CursorOffset);
+        Assert.Equal(1, line.EndRow);
+    }
+
+    [Fact]
+    public void MultilineContinuation_CursorOnAnEarlierLine_ReadsThatLineAloneAndFlagsNothing()
+    {
+        // Documented limitation, pinned here so a change to it is deliberate: the span stops at
+        // the end of the cursor's logical line. Extending across hard breaks whenever the row
+        // below has content was rejected because zsh prints its completion listing right there,
+        // which would misfire on every tab completion.
+        var s = new Session()
+            .Prompt()
+            .Write("for i in 1 2 3")
+            .Write("\r\n> do echo $i")
+            .Write("\x1b[1;6H"); // arrow up into the first line
+
+        var line = s.Read();
+
+        Assert.Equal("for i in 1 2 3", line.Text);
+        Assert.False(line.IsMultiline);
+        Assert.Equal(3, line.CursorOffset);
+    }
+
+    [Fact]
+    public void MultilineSpanCombinesHardBreaksAndSoftWraps()
+    {
+        var s = new Session(cols: 16, rows: 6)
+            .Prompt()
+            .Write(new string('a', 14) + new string('b', 6)) // wraps onto a second row
+            .Write("\r\n> tail");
+
+        var line = s.Read();
+
+        Assert.Equal(new string('a', 14) + new string('b', 6) + "\n> tail", line.Text);
+        Assert.True(line.IsMultiline);
+    }
+
+    // ---------------------------------------------------------------- prompt redraw
+
+    [Fact]
+    public void PromptRedraw_TheNewestMarkIsTheOneThatCounts()
+    {
+        var s = new Session();
+        s.Prompt().Write("stale text");
+        s.Write("\r\x1b[K").Prompt("nova> ").Write("ls -la");
+
+        Assert.Equal(2, s.Marks.Count);
+        Assert.Equal("ls -la", s.Read().Text);
+
+        // The first mark is still *live* (same generation, same row) but it starts two columns
+        // earlier, inside the repainted prompt — which is exactly why the reader must be handed
+        // the newest mark rather than caching one.
+        Assert.True(GridQueryReader.TryReadCommandLine(s.Buffer, s.Marks[0], out var stale));
+        Assert.NotEqual("ls -la", stale.Text);
+    }
+
+    // ---------------------------------------------------------------- scrollback and eviction
+
+    [Fact]
+    public void MarkRowInScrollback_StillReadsThroughThePagedRows()
+    {
+        // A multiline entry tall enough to push its own first row off the viewport. The mark
+        // row now lives in paged scrollback, which has no TerminalRow object at all.
+        var s = new Session(cols: 40, rows: 3)
+            .Prompt()
+            .Write("abc")
+            .Write("\r\n> def")
+            .Write("\r\n> ghi")
+            .Write("\r\n> jkl");
+
+        Assert.True(s.Buffer.Scrollback.Count > 0, "the first row must have scrolled off");
+
+        var line = s.Read();
+
+        Assert.Equal("abc\n> def\n> ghi\n> jkl", line.Text);
+        Assert.Equal(0, line.StartRow);
+        Assert.Equal(3, line.EndRow);
+    }
+
+    [Fact]
+    public void MarkAgedOutOfScrollback_Fails()
+    {
+        var s = new Session(cols: 40, rows: 3, maxHistory: 128).Prompt().Write("ls");
+        for (int i = 0; i < 200; i++) s.Write($"line {i}\r\n");
+
+        Assert.True(s.Buffer.Scrollback.TotalRowsEvicted > 0, "the budget must actually evict");
+        Assert.Equal(s.Buffer.Scrollback.Generation, s.Mark.Generation); // not a generation reset
+        Assert.True(s.Mark.AbsoluteRow - s.Buffer.Scrollback.TotalRowsEvicted < 0);
+
+        Assert.False(s.TryRead(out _));
+    }
+
+    [Fact]
+    public void ScrollingAloneNeverInvalidatesAMark()
+    {
+        // Negative control for the eviction test: ordinary scrolling shifts row numbers but the
+        // mark must keep resolving, or the reader would give up on every long command.
+        var s = new Session(cols: 40, rows: 3, maxHistory: 128);
+        for (int i = 0; i < 100; i++) s.Write($"line {i}\r\n");
+        s.Prompt().Write("ls -la");
+
+        var line = s.Read();
+
+        Assert.Equal("ls -la", line.Text);
+        Assert.True(s.Buffer.Scrollback.Count > 0);
+    }
+
+    // ---------------------------------------------------------------- invalidation
+
+    [Fact]
+    public void ClearedScrollback_BumpsTheGenerationAndTheMarkIsRefused()
+    {
+        // CSI 3J is what clear(1) sends with the E3 capability, so this is routine. It zeroes
+        // both row counters, so the stale AbsoluteRow resolves to a plausible, in-range row
+        // holding unrelated content: "a negative row means aged out" cannot catch it and only
+        // the generation can. The mark is taken while it is still a viewport row, then pushed
+        // into scrollback, so dropping the scrollback really does re-point it.
+        var s = new Session(cols: 40, rows: 10);
+        for (int i = 0; i < 5; i++) s.Write($"out {i}\r\n");
+        s.Prompt().Write("ls");
+
+        Assert.True(s.TryRead(out _));
+
+        for (int i = 0; i < 20; i++) s.Write($"more {i}\r\n");
+        s.Write("\x1b[3J");
+
+        Assert.Equal(0L, s.Buffer.Scrollback.TotalRowsEvicted);
+        Assert.InRange(s.Mark.AbsoluteRow, 0, s.Buffer.TotalLines - 1); // the trap
+        Assert.NotEqual(s.Mark.Generation, s.Buffer.Scrollback.Generation);
+        Assert.False(s.TryRead(out _));
+    }
+
+    [Fact]
+    public void FullReset_IsRefused()
+    {
+        var s = new Session().Prompt().Write("ls");
+
+        s.Buffer.Clear();
+
+        Assert.False(s.TryRead(out _));
+    }
+
+    [Fact]
+    public void ReflowingResize_IsRefused()
+    {
+        // A width change re-wraps every logical line and rebuilds the scrollback store, so the
+        // mark's coordinates describe a layout that no longer exists. Benign in practice: every
+        // shell repaints its prompt after a resize, and the repaint carries a fresh B.
+        var s = new Session(cols: 40, rows: 6).Prompt().Write("git status");
+
+        s.Buffer.Resize(24, 6);
+
+        Assert.False(s.TryRead(out _));
+    }
+
+    [Fact]
+    public void HeightOnlyResize_KeepsTheMarkUsable()
+    {
+        // Counterpart to the reflow case: no re-wrap, no coordinate-space reset. Rows pushed
+        // from the viewport into scrollback keep their absolute identity.
+        var s = new Session(cols: 40, rows: 6);
+        for (int i = 0; i < 4; i++) s.Write($"line {i}\r\n");
+        s.Prompt().Write("git status");
+
+        s.Buffer.Resize(40, 3);
+
+        Assert.Equal("git status", s.Read().Text);
+    }
+
+    [Fact]
+    public void AltScreenMark_IsRefused()
+    {
+        var s = new Session();
+        s.Write("\x1b[?1049h").Write("\x1b[H").Prompt("> ").Write("q");
+
+        Assert.True(s.Mark.IsAltScreen);
+        Assert.False(s.TryRead(out _));
+    }
+
+    [Fact]
+    public void MainScreenMark_IsRefusedWhileTheAltScreenIsActive()
+    {
+        var s = new Session().Prompt().Write("vim");
+
+        s.Write("\x1b[?1049h");
+
+        Assert.False(s.TryRead(out _));
+    }
+
+    [Fact]
+    public void CursorAboveTheMark_IsRefused()
+    {
+        var s = new Session().Write("out\r\nput\r\n").Prompt().Write("ls");
+
+        s.Write("\x1b[1;1H");
+
+        Assert.False(s.TryRead(out _));
+    }
+
+    [Fact]
+    public void CursorLeftOfTheMarkOnTheMarkRow_IsRefused()
+    {
+        // The line editor moved the cursor into the prompt itself: the mark no longer describes
+        // where input begins, so there is nothing truthful to return.
+        var s = new Session().Prompt().Write("ls").Write("\x1b[1G");
+
+        Assert.False(s.TryRead(out _));
+    }
+
+    [Fact]
+    public void ImplausiblySpanningMark_IsRefused()
+    {
+        // The mark is only meaningful between B and the following C. Used past that window the
+        // "command line" is really command output; the span cap stops the reader building a
+        // multi-megabyte string out of it.
+        var s = new Session(cols: 40, rows: 3).Prompt().Write("ls");
+        s.Write(string.Concat(Enumerable.Repeat("\r\n", GridQueryReader.MaxSpanRows + 64)));
+
+        Assert.Equal(s.Buffer.Scrollback.Generation, s.Mark.Generation);
+        Assert.Equal(0L, s.Buffer.Scrollback.TotalRowsEvicted);
+        Assert.False(s.TryRead(out _));
+    }
+
+    [Fact]
+    public void NullBuffer_IsRefused()
+    {
+        Assert.False(GridQueryReader.TryReadCommandLine(null!, default, out _));
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(40)]
+    [InlineData(4000)]
+    public void MarkColumnOutOfRange_IsRefused(int column)
+    {
+        var buffer = new TerminalBuffer(40, 6);
+        var mark = new ShellIntegrationMark(
+            Row: 0, Column: column, AbsoluteRow: 0, IsAltScreen: false,
+            Generation: buffer.Scrollback.Generation);
+
+        Assert.False(GridQueryReader.TryReadCommandLine(buffer, mark, out _));
+    }
+
+    [Fact]
+    public void MarkRowPastTheEndOfTheBuffer_IsRefused()
+    {
+        var buffer = new TerminalBuffer(40, 6);
+        var mark = new ShellIntegrationMark(
+            Row: 0, Column: 0, AbsoluteRow: 500, IsAltScreen: false,
+            Generation: buffer.Scrollback.Generation);
+
+        Assert.False(GridQueryReader.TryReadCommandLine(buffer, mark, out _));
+    }
+
+    // ---------------------------------------------------------------- right prompt
+
+    [Fact]
+    public void RightPrompt_IsExcluded()
+    {
+        // zsh RPROMPT / fish fish_right_prompt / starship's right prompt all paint right-aligned
+        // text on the input's own row. The shape: a wide blank gap, then content flush against
+        // the right edge (ZLE_RPROMPT_INDENT defaults to 1).
+        var s = new Session(cols: 40, rows: 6)
+            .Prompt()
+            .Write("ls")
+            .Write("\x1b[34G[main]") // right-aligned, ending one column short of the edge
+            .Write("\x1b[5G");       // shell puts the cursor back at the end of the input
+
+        var line = s.Read();
+
+        Assert.Equal("ls", line.Text);
+        Assert.Equal(2, line.CursorOffset);
+        Assert.True(line.RightPromptTrimmed);
+    }
+
+    [Fact]
+    public void RightPrompt_IsExcludedEvenWithTheCursorAtTheStartOfTheInput()
+    {
+        // Stopping at the cursor would be the easy rule and it is wrong: the cursor is mid-line
+        // whenever the user has used an arrow key.
+        var s = new Session(cols: 40, rows: 6)
+            .Prompt()
+            .Write("ls -la")
+            .Write("\x1b[34G[main]")
+            .Write("\x1b[3G");
+
+        var line = s.Read();
+
+        Assert.Equal("ls -la", line.Text);
+        Assert.Equal(0, line.CursorOffset);
+        Assert.True(line.RightPromptTrimmed);
+    }
+
+    [Fact]
+    public void DoubleSpaceInsideTypedInput_IsNotMistakenForARightPrompt()
+    {
+        // The gap rule alone would cut "echo" off here. Two further conditions save it: the
+        // trailing content must reach the right edge, and the gap must start at or after the
+        // cursor.
+        var s = new Session(cols: 40, rows: 6).Prompt().Write("echo  hi").Write("\x1b[3G");
+
+        var line = s.Read();
+
+        Assert.Equal("echo  hi", line.Text);
+        Assert.False(line.RightPromptTrimmed);
+    }
+
+    [Fact]
+    public void TrailingContentNotAtTheRightEdge_IsNotTreatedAsARightPrompt()
+    {
+        // Deliberately conservative boundary: a gap plus content that stops well short of the
+        // edge is far more likely to be typed input than a right-aligned prompt, so it is kept.
+        var s = new Session(cols: 40, rows: 6)
+            .Prompt()
+            .Write("ls")
+            .Write("\x1b[20G[main]")
+            .Write("\x1b[5G");
+
+        var line = s.Read();
+
+        Assert.EndsWith("[main]", line.Text);
+        Assert.False(line.RightPromptTrimmed);
+    }
+
+    [Fact]
+    public void SingleSpaceBeforeRightEdgeContent_IsNotTreatedAsARightPrompt()
+    {
+        // One space is a word separator, not a prompt gap.
+        var s = new Session(cols: 12, rows: 6).Prompt().Write("ls abcdefgh");
+
+        var line = s.Read();
+
+        Assert.Equal("ls abcdefgh", line.Text);
+        Assert.False(line.RightPromptTrimmed);
+    }
+
+    // ---------------------------------------------------------------- wide characters
+
+    [Fact]
+    public void DoubleWidthPromptCells_DoNotShiftTheStartOfInput()
+    {
+        var s = new Session().Prompt(Cjk + "$ ").Write("ls");
+
+        Assert.Equal(6, s.Mark.Column); // two double-width cells, then "$ "
+        Assert.Equal("ls", s.Read().Text);
+    }
+
+    [Fact]
+    public void DoubleWidthInput_IsNotDoubleCountedAndItsContinuationIsNotEmitted()
+    {
+        var s = new Session().Prompt().Write("echo " + Cjk);
+
+        var line = s.Read();
+
+        Assert.Equal("echo " + Cjk, line.Text);
+        Assert.Equal(7, line.CursorOffset); // characters, not columns
+    }
+
+    [Fact]
+    public void EmojiInInput_SurvivesAsAWholeGrapheme()
+    {
+        var s = new Session().Prompt().Write("echo " + Emoji);
+
+        var line = s.Read();
+
+        Assert.Equal("echo " + Emoji, line.Text);
+        Assert.Equal(7, line.CursorOffset); // 5 + the surrogate pair
+    }
+
+    [Fact]
+    public void CursorBetweenDoubleWidthCharacters_MapsToACharacterBoundary()
+    {
+        var s = new Session().Prompt().Write(Cjk + "ls").Write("\x1b[7G"); // column 6 = the 'l'
+
+        var line = s.Read();
+
+        Assert.Equal(Cjk + "ls", line.Text);
+        Assert.Equal(2, line.CursorOffset);
+    }
+
+    [Fact]
+    public void WideCharacterThatDoesNotFitLeavesNoPhantomSpaceAtTheWrap()
+    {
+        // A double-width character with only one column left wraps early, leaving the last cell
+        // of the row blank. That hole is layout, not input: emitting it would insert a space
+        // into the middle of the command line.
+        string ascii = new string('a', 16) + "x";
+        var s = new Session(cols: 20, rows: 6).Prompt().Write(ascii + CjkOne);
+
+        var line = s.Read();
+
+        Assert.Equal(ascii + CjkOne, line.Text);
+        Assert.DoesNotContain(" ", line.Text);
+        Assert.Equal(1, line.EndRow);
+    }
+
+    [Fact]
+    public void AdjacentWideCharactersAreNotReadAsARightPromptGap()
+    {
+        // The trailing half of a wide cell stores a space. Counting it as blank would let two
+        // adjacent CJK characters look like the separator before a right-aligned prompt.
+        var s = new Session(cols: 12, rows: 6).Prompt().Write(Cjk + Cjk);
+
+        var line = s.Read();
+
+        Assert.Equal(Cjk + Cjk, line.Text);
+        Assert.False(line.RightPromptTrimmed);
+    }
+
+    // ---------------------------------------------------------------- lock discipline
+
+    [Fact]
+    public void ReadingWhileTheCallerAlreadyHoldsTheReadLock_DoesNotDeadlockOrThrow()
+    {
+        // The buffer lock is non-recursive, so the reader must notice an outer lock rather than
+        // blindly re-entering. The render path holds one across whole frames.
+        var s = new Session().Prompt().Write("ls");
+
+        s.Buffer.Lock.EnterReadLock();
+        try
+        {
+            Assert.True(GridQueryReader.TryReadCommandLine(s.Buffer, s.Mark, out var line));
+            Assert.Equal("ls", line.Text);
+        }
+        finally
+        {
+            s.Buffer.Lock.ExitReadLock();
+        }
+
+        Assert.False(s.Buffer.Lock.IsReadLockHeld);
+    }
+
+    [Fact]
+    public void TheReadLockIsReleasedOnBothOutcomes()
+    {
+        var s = new Session().Prompt().Write("ls");
+
+        Assert.True(s.TryRead(out _));
+        Assert.False(s.Buffer.Lock.IsReadLockHeld);
+
+        s.Buffer.Clear();
+
+        Assert.False(s.TryRead(out _));
+        Assert.False(s.Buffer.Lock.IsReadLockHeld);
+    }
+}


### PR DESCRIPTION
Implements Phase 1 task 3 of `docs/plans/2026-08-01-command-assist-v2-plan.md`.

Phase 1a gave us `OSC 133;B` marks. This turns a mark into text: the cells between the mark and the cursor, read straight out of the grid. That is the thing V1's keystroke shadow buffer could never be - correct after history recall, `Ctrl+U`, tab completion and bracketed paste, because the grid is what the shell actually drew.

## API

```csharp
// NovaTerminal.VT
public static bool GridQueryReader.TryReadCommandLine(
    TerminalBuffer buffer, ShellIntegrationMark mark, out GridCommandLine result);

public readonly record struct GridCommandLine(
    string Text,               // soft wraps joined, hard breaks as '\n'
    int CursorOffset,          // always a valid index into Text
    bool IsMultiline,
    bool RightPromptTrimmed,   // diagnostic
    int StartRow, int EndRow); // buffer's current addressing space
```

App-side seam: `internal bool TerminalPane.TryGetGridCommandLine(out GridCommandLine)`.

`CursorOffset` is not simply `Text.Length` - the cursor is mid-line whenever the user has pressed an arrow key, and the insertion planner in task 6 computes against it.

### Why NovaTerminal.VT and not NovaTerminal.CommandAssist

The plan sketched this in the CommandAssist assembly. It cannot live there: the extraction is pure buffer walking - wrap flags, paged scrollback, wide-cell continuations, deferred autowrap - and `LayeringTests` forbids `NovaTerminal.CommandAssist` from referencing `NovaTerminal.VT`. So the reader is VT-side and Command Assist consumes it at the App boundary. Zero changes to the CommandAssist assembly in this PR. The plan doc is updated to say so.

### Refusals

Returns `false`, never throws, for: a mark from a dead coordinate generation; a marked line that aged out of scrollback; an alt-screen mark or an active alt screen; a cursor above the mark, or left of it on the mark's own row; a mark position outside the buffer; a span over `MaxSpanRows` (512).

**The result is only meaningful between `OSC 133;B` and the following `OSC 133;C`.** The reader cannot tell "the user is still typing" from "the command ran and this is its output" - both are cells between the mark and the cursor. Lifecycle gating is the consumer's job; the span cap only bounds the damage if that gate is missed.

## Multiline decision: (b), raw text plus a flag

A hard line break inside the span becomes a single `'\n'` and sets `IsMultiline`. Text is returned raw, which means it still contains whatever the shell painted as a continuation prompt (`PS2`, `PROMPT2`, fish's `> `).

Rationale:

- Nothing marks continuation-prompt cells as prompt rather than input - only the main prompt carries a B mark - so the reader *cannot* strip them. `IsMultiline` therefore has to be a hard "do not treat this as a typed prefix" signal rather than a hint, and it is documented as such: history and display are fine, completion is not.
- Option (a) - return only the first logical line when the cursor is on it - silently loses text and makes `CursorOffset` ambiguous (an offset into a truncated string while more input exists below). One rule that always holds beats a rule whose shape depends on where the cursor happens to be.
- Downstream refuses prefix-dependent features on multiline anyway, so the extra text costs nothing and keeps information.

Known gap, tested and documented: if the cursor sits on an *earlier* logical line of a continuation entry, the span stops at the end of that line and `IsMultiline` stays clear. The obvious fix - extend across hard breaks whenever the row below has content - was rejected because zsh prints its completion listing directly below the input line, so it would misfire on every tab completion, which is exactly the case Command Assist most needs to get right.

Soft wraps are followed *past* the cursor row, so a logical line wrapped over three physical rows comes back whole no matter which row the cursor is parked on. That case is not optional: `CUP` into row 1 of a 3-row wrapped line is what every arrow key does.

## RPROMPT decision

zsh's `RPROMPT`, fish's `fish_right_prompt` and starship's right prompt all paint right-aligned text on the input's own row. "Mark column to last non-blank cell" swallows it; "stop at the cursor" is wrong because the cursor is mid-line whenever an arrow key has been used.

Cells are excluded only on the final row of the span, only when the cursor is on that row, and only when **all three** hold:

1. the trailing content ends within 2 columns of the right edge (right-aligned text does; typed input generally does not, and `ZLE_RPROMPT_INDENT` defaults to 1);
2. it is separated from the rest of the row by a run of at least 2 blank cells;
3. that run starts at or after the cursor.

Condition 3 means nothing left of the cursor is ever discarded, so a double space inside typed input cannot be mistaken for the separator - there is a test for exactly that (`echo  hi` with the cursor at home). Condition 1 makes the rule deliberately conservative: a gap followed by content that stops short of the right edge is kept, contamination and all, rather than risk eating real input. Rows other than the cursor's are exempt because shells drop the right prompt as soon as input grows into them, and a soft-wrapped row is full of input by definition.

Wide characters: the trailing half of a double-width cell stores a space but is *not* treated as blank, or two adjacent CJK characters would look like a right-prompt separator.

## Lock discipline

`TryReadCommandLine` takes the buffer read lock itself unless the calling thread already holds a read or write lock - `TerminalBuffer.Lock` is non-recursive, so blind re-entry throws, and the render path holds a read lock across whole frames. Same shape as `RowTextExtractor`. Tested both ways, including that the lock is released on the failure path.

On the pane, the mark is written from the PTY read thread and read from the UI thread; a `ShellIntegrationMark` is five fields wide, so it sits behind a gate rather than in a plain nullable field that could be torn across the two.

## Deliberately not consumed yet

The controller is untouched. Nothing calls `TryGetGridCommandLine`. Phase 1c wires it into `SuggestionOrchestrator`, deletes the `TextInputObserved`/`BackspaceObserved` shadow buffer, and removes the `CommandStarted` early-out in `OnShellIntegrationEventObserved` (which survives here because the reader takes the mark straight off the parser callback, not off the dispatcher). No CommandAssist assembly changes.

## New API surface in VT

- `GridQueryReader`, `GridCommandLine`
- `TerminalBuffer.IsRowWrappedAbsolute(int absRow)` - answers the wrap question for paged scrollback rows too, which `GetRowAbsolute` cannot (it returns `null` for them).

## Tests

49 new cases in `tests/NovaTerminal.VT.Tests/GridQueryReaderTests.cs`, driven through the real parser and write path rather than by poking cells, because the properties under test are produced by that path and nowhere else:

- simple line, empty input (mark == cursor), prompt text never included, trailing spaces left of the cursor kept, blanks beyond both cursor and content dropped, history recall read from the grid
- soft wrap over 2 and 3 rows; cursor parked on each of the three rows; input ending exactly at the right edge (deferred autowrap) and one character past it
- multiline continuation with the raw PS2 paint; the documented earlier-line gap; a span mixing hard breaks and soft wraps
- prompt redraw: the newest mark wins, and the superseded mark demonstrably reads something else
- mark row moved into paged scrollback; mark aged out by eviction, with ordinary scrolling as the negative control
- CSI 3J (constructed so the stale row resolves *in range* - the trap the generation exists to catch), `Clear()`, reflowing resize; height-only resize as the negative control
- alt-screen mark, and a main-screen mark while the alt screen is active
- cursor above the mark, cursor left of the mark, span cap, null buffer, out-of-range mark column and row
- RPROMPT excluded with the cursor at the end and at the start; three negative controls (double space in input, content not at the right edge, single-space gap)
- CJK in the prompt and in the input, emoji as a whole grapheme, cursor between double-width characters, the phantom-space hole a wide character leaves when it wraps early, adjacent wide characters not read as a gap
- reading while the caller already holds the read lock; lock released on both outcomes

3 App-level cases in `tests/NovaTerminal.App.Tests/Controls/PaneGridCommandLineTests.cs` pin the pane wiring (no mark, mark, prompt repaint replaces the mark).

## Verification

Clean solution build. `NovaTerminal.VT.Tests` 260/260 (was 211). `NovaTerminal.Architecture.Tests` 28/28 - the layering constraint holds. `NovaTerminal.App.Tests` 1701 passed / 15 skipped / 1 failed: `VtReportCliTests.CliShim_PrintsHumanReadableSummary`, which shells out to a Release-configuration CLI binary that a Debug run does not produce. Environmental and pre-existing, unrelated to this change.
