### PR TITLE
feat(command-assist): consume grid-truth query state and delete the shadow buffer (V2 Phase 1c)

### DIFF
--- a/docs/command-assist/CommandAssist_ShellIntegration_Gaps.md
+++ b/docs/command-assist/CommandAssist_ShellIntegration_Gaps.md
@@ -148,8 +148,23 @@ refresh pass, on the worker the pass already runs on, not on the keystroke that 
 keystroke is a trigger carrying no text; the pass resolves its own query. Passes supersede each
 other through the existing per-pass `CancellationTokenSource`, so a burst of keystrokes applies one
 read, the last one. That is coalescing by supersession, not by timing: there is no debounce, which
-is a Phase 3 policy decision. The window that remains is a pass whose read beats the shell's echo
-of the final character, which ranks a one-character-stale query until the next trigger.
+is a Phase 3 policy decision.
+
+The window that remains is a read that beats the shell's echo of the character just typed, and it is
+worth restating because an earlier revision of this document understated it as "ranks a
+one-character-stale query". For *ranking*, that is the whole of it. For *insertion* it was a
+corruption bug. The stale read is internally perfect — `git st` with the cursor at offset 6, every
+planner guard satisfied — while the PTY already holds `git sta`; and because the stale text is always
+a strict **prefix** of the true line, no `StartsWith`-style check can ever catch it. `Ctrl+Enter` on a
+row ranked from `git st` would append `atus` to a line that already reads `git sta`, and the line
+becomes `git staatus`. Guarded now: `TerminalPane` tracks `_hasUnechoedInput` — set by
+`TextInputObserved` / `BackspaceObserved`, cleared once session bytes have been parsed into the
+grid — and `TryInsertSelectedCommandAssistSuggestion` refuses while it is set, which is the same
+refusal-on-doubt rule the planner's four conditions follow. Ranking is deliberately left unguarded: a
+marginally worse row for one keystroke does not justify going quiet, and the next trigger corrects it.
+The clear is approximate in one direction only — unrelated session output can clear the flag early,
+leaving the original window open — but never the other, because output that has been parsed is
+output that is in the grid.
 
 **3. Insertion refuses rather than guesses.** `CommandAssistInsertionPlanner` keeps the V1 rule that
 insertion is additive — send only the characters the suggestion adds, never delete, never move the
@@ -194,9 +209,27 @@ costs, concretely:
   (which is strictly better than the mirror ever was, since the grid survives all of those edits),
   and every command after it comes from the `133;C` payload.
 
+  **This is a hole, not a resting state, and it is tracked as Phase 1 task 7 in
+  `docs/plans/2026-08-01-command-assist-v2-plan.md` — required before the flag flip.** The affected
+  population is not marginal: `cmd.exe`, every shell whose bootstrap bailed out, and *every* SSH
+  session, since SSH launch plans skip provider injection. For those, history never fills, so
+  `Ctrl+R` is an empty box rather than a browse-only one. The replacement is deliberately not the
+  mirror: it is a **poisoned** capture-only accumulator confined to `TerminalPane`
+  (`TextInputObserved` appends, `BackspaceObserved` chops, any key the pane does not model — arrows,
+  `Home`/`End`, `Delete`, `Tab`, page keys, F-keys, unowned chords — poisons it, paste poisons it,
+  `Enter` and `Ctrl+C` reset it), consulted at Enter only when the grid has nothing, and never used
+  as the query. The distinction from V1 is the whole argument: V1's mirror answered "what is on the
+  line" with a guess and failed *silently and wrongly*; a poisoned accumulator turns itself off the
+  moment it stops knowing, so its outcomes are "exactly what was typed" or "nothing". That is the
+  same bar the grid reader is held to, reached by a different mechanism, and it is deletable once
+  Phase 2 gives instrumented remotes real marks.
+
 **`Ctrl+R` in a degraded session** still opens and still helps, because history is per user rather
 than per session: with no query to filter on, Search shows the recency list, which includes
-everything captured in instrumented sessions. It is browse-only — see the insertion rule above.
+everything captured in instrumented sessions. It is browse-only — see the insertion rule above. It
+also says so: the bubble is labelled **`History - recent`** rather than `History` when no query can
+be read, because an identical-looking filter box that silently cannot filter reads as a bug the
+first time a keystroke fails to narrow it.
 
 ## Current Limitations
 - shell integration is local-only; SSH launch plans skip provider injection

--- a/docs/command-assist/CommandAssist_ShellIntegration_Gaps.md
+++ b/docs/command-assist/CommandAssist_ShellIntegration_Gaps.md
@@ -109,6 +109,95 @@ still exactly what the mark describes, and Phase 1c reads the final command text
 `GridQueryReader.MaxSpanRows` stays as a backstop for shells that emit `B` without a matching `D`,
 rather than being the only guard.
 
+## Added In V2 Phase 1c — the consumption contract
+
+Phase 1b made the reader trustworthy. Phase 1c is what consumes it, and the reader's contract is
+only half of the story: a caller that reads whenever it likes, and acts on whatever comes back,
+gets wrong answers from a correct reader. Three rules, all enforced on the Command Assist side.
+
+**1. Lifecycle gate — read only between `B` and `C`.** The reader cannot self-gate: the cells
+between the mark and the cursor look identical whether the user is editing a command line or the
+command has run and those are the first lines of its output. Only the OSC 133 stream distinguishes
+them, so consumption is gated on `AssistSessionContext.IsAcceptingCommandInput` — opened by
+`CommandStarted` (`133;B`), closed by `CommandAccepted` (`133;C`), by `CommandFinished` (`133;D`)
+and by an alt-screen switch. Nothing else opens it; a prompt repaint re-emits `B`, so the gate
+reopens on evidence rather than on assumption.
+
+The gate is deliberately *not* conditioned on `IsShellIntegrationEnabled`, which records only
+whether we injected the bootstrap. A shell that emits `B` is instrumented whether we did it or the
+user did, and Phase 2's instrumented-remote work depends on believing the marks. (Today that is
+theory rather than practice: `ShellLifecycleTracker` is armed only by
+`TerminalPane.ApplyShellIntegrationLaunchPlan`, so a session we did not instrument delivers no
+events at all and stays fully degraded. Arming it on observed marks is Phase 2 task 3.)
+
+The gate and the mark are two independent facts and both are required. The gate can be open while
+the mark has aged out of scrollback or its coordinate generation has been reset; the mark can be
+live while the command it anchors is halfway through printing its output.
+
+*Known edge, currently unreachable:* the parser raises `OnCommandAccepted` only for a `133;C`
+carrying a decodable base64 payload, so a bare `133;C` does not close the gate — `133;D` then has
+to. All four bootstraps emit `133;C;<base64>`, and a session we did not instrument has no tracker
+armed, so no reachable configuration hits this. It becomes real the moment Phase 2 arms the tracker
+for third-party integrations, and should be closed there.
+
+**2. Settled-boundary reads, not per-keystroke reads.** The buffer takes its write lock per written
+character, so a read racing a prompt repaint (`\r`, erase-to-end-of-line, reprint) can legitimately
+observe a half-erased line — and acting on that produces suggestion flicker on every `Ctrl+U`,
+history recall and tab completion. The read therefore happens inside `SuggestionOrchestrator`'s
+refresh pass, on the worker the pass already runs on, not on the keystroke that triggered it. A
+keystroke is a trigger carrying no text; the pass resolves its own query. Passes supersede each
+other through the existing per-pass `CancellationTokenSource`, so a burst of keystrokes applies one
+read, the last one. That is coalescing by supersession, not by timing: there is no debounce, which
+is a Phase 3 policy decision. The window that remains is a pass whose read beats the shell's echo
+of the final character, which ranks a one-character-stale query until the next trigger.
+
+**3. Insertion refuses rather than guesses.** `CommandAssistInsertionPlanner` keeps the V1 rule that
+insertion is additive — send only the characters the suggestion adds, never delete, never move the
+cursor — but it now computes against `AssistQuerySnapshot` and refuses outright when the append
+assumption does not hold:
+
+- **no snapshot** (markless session, or gate closed): the command line cannot be seen, so appending
+  a whole command to an unknown prefix is how `git sgit status` happens;
+- **cursor not at the end of the text**: sent text lands at the cursor, so the "suffix" would be
+  spliced into the middle of the command;
+- **`IsMultiline`**: the text contains continuation-prompt cells (`PS2`, `PROMPT2`, fish's `> `)
+  that the user never typed, so it is not a prefix even when it starts one;
+- **`RightPromptTrimmed`**: the reader's RPROMPT trim is conservative, but conservative means "over-
+  returns rather than deletes"; when it did fire, the *tail* of the line is an inference, and the
+  tail is exactly what an append attaches to.
+
+An observed-empty line is not a refusal: the grid was read and the line is empty, so the whole
+command is sent. That distinction — "empty" versus "unknown" — is why the query crosses the
+boundary as a nullable snapshot rather than a string.
+
+### Degraded mode after Phase 1c
+
+A session with no OSC 133 marks — a non-integrated local shell, a shell whose bootstrap bailed out,
+an un-instrumented SSH host — has no query at all. Not an empty query it might act on: no query.
+The shadow keystroke buffer is deleted, not kept as a fallback, because a fallback that desyncs is
+worse than no fallback (it was the fallback that made V1's history and insertions wrong). What that
+costs, concretely:
+
+- **no passive suggestions.** With no query the path provider has no command token and no
+  path-shaped fragment to work from, so it returns nothing. Degraded passive suggestions are empty
+  by construction rather than by a special case.
+- **no help token from the command line.** `Ctrl+Alt+H` with nothing selected finds nothing.
+  Explain-selection still works, because a selection is an explicit input the grid is not needed
+  for, and Fix still works, because it analyses the command that failed rather than the one being
+  typed.
+- **no insertion.** Rows can be browsed; nothing may be spliced into a command line nobody can see.
+- **no Enter-time history capture.** This is the one that is worth arguing about. V1's heuristic
+  capture read the shadow buffer, so for any line the user had edited with keys the mirror could
+  not observe — `Ctrl+U`, arrows, history recall, tab completion — it wrote a command the user
+  never ran into persistent history. Recording nothing is recoverable; recording something false is
+  not. Instrumented sessions are unaffected: the first command is captured from the grid at Enter
+  (which is strictly better than the mirror ever was, since the grid survives all of those edits),
+  and every command after it comes from the `133;C` payload.
+
+**`Ctrl+R` in a degraded session** still opens and still helps, because history is per user rather
+than per session: with no query to filter on, Search shows the recency list, which includes
+everything captured in instrumented sessions. It is browse-only — see the insertion rule above.
+
 ## Current Limitations
 - shell integration is local-only; SSH launch plans skip provider injection
   because env-var overrides do not propagate across SSH

--- a/docs/plans/2026-08-01-command-assist-v2-plan.md
+++ b/docs/plans/2026-08-01-command-assist-v2-plan.md
@@ -35,17 +35,18 @@ segment before it can be claimed as supported.
 
 ## Phase 1 — Truthful query state
 
-**Status: tasks 1 and 2 shipped (Phase 1a); task 3 shipped (Phase 1b).**
+**Status: complete.** Tasks 1 and 2 shipped in Phase 1a; task 3 in Phase 1b; tasks 4, 5 and 6 in
+Phase 1c.
 
 Tasks:
 1. **[done — Phase 1a]** Emit `OSC 133;B` from all four bootstrap builders; extend the four `*BootstrapBuilderTests` and the shell-harness integration tests. Preserve bail-out conditions and bash DEBUG-trap guard semantics.
 2. **[done — Phase 1a]** Parser/tracker: wire `133;B` through `AnsiParser` → `ShellLifecycleTracker.HandleCommandStarted` (currently dead) with mark position (row/col).
 3. **[done — Phase 1b]** `GridQueryReader`: extract command text between last `B` mark and cursor from the buffer, handling wrapped logical lines and scrolled viewports. Exhaustive buffer-level unit tests first (wrap, resize/reflow, multiline continuation, prompt redraw, cleared screen). *Landed in `NovaTerminal.VT`, not the CommandAssist assembly as sketched here* — the extraction is pure buffer walking and `LayeringTests` forbids CommandAssist from referencing VT; Command Assist consumes it at the App boundary via `TerminalPane.TryGetGridCommandLine`.
-4. `SuggestionOrchestrator` consumes `GridQueryReader` when marks are live; delete the shadow buffer (`TextInputObserved`/`BackspaceObserved` mirroring). Heuristic Enter-capture stays for history in non-integrated sessions.
-5. Degraded mode: no marks → path suggestions + explicit `Ctrl+R` history search only; prefix-dependent features off.
-6. `CommandAssistInsertionPlanner` computes against grid truth; add tests for post-`Ctrl+U`, post-history-recall, post-Tab-completion insertion (the desync cases that broke V1).
+4. **[done — Phase 1c]** `SuggestionOrchestrator` consumes `GridQueryReader` when marks are live; delete the shadow buffer (`TextInputObserved`/`BackspaceObserved` mirroring). Heuristic Enter-capture stays for history in non-integrated sessions. *Amended:* the pass resolves its own query (callers no longer hand one in) and reads on its worker rather than on the keystroke, per the PR #285 review's settled-boundary point. Enter-capture stays but its source is now the grid, so it works for an instrumented session's first command and captures **nothing** in a markless one — see the Phase 1c notes below.
+5. **[done — Phase 1c]** Degraded mode: no marks → path suggestions + explicit `Ctrl+R` history search only; prefix-dependent features off. *Amended:* with no query the path provider returns nothing, so degraded passive suggestions are empty in practice; `Ctrl+R` shows the recency list and is browse-only.
+6. **[done — Phase 1c]** `CommandAssistInsertionPlanner` computes against grid truth; add tests for post-`Ctrl+U`, post-history-recall, post-Tab-completion insertion (the desync cases that broke V1). *Amended:* the planner also gained four refusal rules (no snapshot, cursor off the end, multiline, right prompt trimmed).
 
-Exit criteria: desync test matrix green on all four shells; shadow buffer code deleted; smoke scenarios 1–8 re-validated.
+Exit criteria: desync test matrix green on all four shells; shadow buffer code deleted; smoke scenarios 1–8 re-validated. *Status: the desync matrix is green at three levels (reader, controller seam, real pane driven by escape sequences) and the shadow buffer is deleted. Smoke scenarios 1–8 are re-validated at the flag-flip phase, since the feature is still default-off and the M4.2 scenario doc still describes V1 behavior.*
 
 Phase 1a notes (for the task-3 `GridQueryReader` author):
 - The B mark is carried as `ShellIntegrationEvent.MarkPosition` (`ShellMarkPosition`: `Row`,
@@ -98,6 +99,27 @@ Phase 1b notes (for the task-4 orchestrator author):
   last two are what stop a double space inside typed input that reaches the right edge from
   eating the tail of the line when the cursor is at Home. Unrecognised right prompts are returned
   as extra text; that direction is recoverable, deleting typed input is not.
+
+Phase 1c notes (for the Phase 2 author, and for anyone reading the deleted surface later):
+- The consumption contract — lifecycle gate, settled reads, insertion refusals — is written up in
+  `docs/command-assist/CommandAssist_ShellIntegration_Gaps.md` under "Added In V2 Phase 1c".
+- The query crosses into the CommandAssist assembly as `AssistQuerySnapshot?` through a
+  `Func<AssistQuerySnapshot?>` the controller is constructed with. `TerminalPane` supplies it and
+  maps `GridCommandLine` to it, because `LayeringTests` forbids CommandAssist from referencing VT.
+  Null means "unknown", not "empty", and that distinction is load-bearing in the planner.
+- **Deleted:** `CommandAssistController.HandleTextInput(string)`, `HandleBackspace()`,
+  `HandlePastedText(string)`; the `ViewModel.QueryText` writes in `TryAcceptSelection` and in the
+  typing/paste handlers; the `query` parameter on `SuggestionOrchestrator.Refresh`; the
+  `CommandStarted` early-out in `TerminalPane.OnShellIntegrationEventObserved`. **Kept:**
+  `AssistSessionStateMachine.IsCurrentSubmissionSuppressed`, because paste suppression is a
+  provenance fact the grid cannot reconstruct, not a query fact.
+- `TerminalPane.ArmShellIntegrationTracker()` was extracted out of `ApplyShellIntegrationLaunchPlan`
+  and is the hook Phase 2 task 3 needs: arming the tracker on *observed* marks (rather than only on
+  a launch plan we created) is what makes a user-instrumented remote deliver events at all. Doing
+  that also makes the bare-`133;C` edge in the gaps doc reachable, so close it in the same change.
+- The `CommandStarted` event now costs one dispatcher hop per prompt repaint. If that ever shows up
+  in the Phase 3 benchmark, the fix is to make the gate idempotent at the pane rather than to
+  restore the early-out.
 
 ## Phase 2 — Marks-based anchoring + SSH parity
 

--- a/docs/plans/2026-08-01-command-assist-v2-plan.md
+++ b/docs/plans/2026-08-01-command-assist-v2-plan.md
@@ -35,8 +35,10 @@ segment before it can be claimed as supported.
 
 ## Phase 1 — Truthful query state
 
-**Status: complete.** Tasks 1 and 2 shipped in Phase 1a; task 3 in Phase 1b; tasks 4, 5 and 6 in
-Phase 1c.
+**Status: tasks 1–6 complete; one task added and open.** Tasks 1 and 2 shipped in Phase 1a; task 3
+in Phase 1b; tasks 4, 5 and 6 in Phase 1c. Task 7 below was raised by the Phase 1c review and is
+**required before the Phase 6 flag flip**, on the same footing as the deferred smoke-scenario
+re-validation in the exit criteria: the phase's mechanism is done, its user-visible coverage is not.
 
 Tasks:
 1. **[done — Phase 1a]** Emit `OSC 133;B` from all four bootstrap builders; extend the four `*BootstrapBuilderTests` and the shell-harness integration tests. Preserve bail-out conditions and bash DEBUG-trap guard semantics.
@@ -45,8 +47,9 @@ Tasks:
 4. **[done — Phase 1c]** `SuggestionOrchestrator` consumes `GridQueryReader` when marks are live; delete the shadow buffer (`TextInputObserved`/`BackspaceObserved` mirroring). Heuristic Enter-capture stays for history in non-integrated sessions. *Amended:* the pass resolves its own query (callers no longer hand one in) and reads on its worker rather than on the keystroke, per the PR #285 review's settled-boundary point. Enter-capture stays but its source is now the grid, so it works for an instrumented session's first command and captures **nothing** in a markless one — see the Phase 1c notes below.
 5. **[done — Phase 1c]** Degraded mode: no marks → path suggestions + explicit `Ctrl+R` history search only; prefix-dependent features off. *Amended:* with no query the path provider returns nothing, so degraded passive suggestions are empty in practice; `Ctrl+R` shows the recency list and is browse-only.
 6. **[done — Phase 1c]** `CommandAssistInsertionPlanner` computes against grid truth; add tests for post-`Ctrl+U`, post-history-recall, post-Tab-completion insertion (the desync cases that broke V1). *Amended:* the planner also gained four refusal rules (no snapshot, cursor off the end, multiline, right prompt trimmed).
+7. **[open — required before the flag flip]** **Markless capture-only accumulator (ii-strict).** Restore Enter-time history capture for sessions with no `OSC 133` marks, as a *poisoned* line accumulator that lives entirely in `TerminalPane`. See "Phase 1c follow-up" below for the design and the reasoning.
 
-Exit criteria: desync test matrix green on all four shells; shadow buffer code deleted; smoke scenarios 1–8 re-validated. *Status: the desync matrix is green at three levels (reader, controller seam, real pane driven by escape sequences) and the shadow buffer is deleted. Smoke scenarios 1–8 are re-validated at the flag-flip phase, since the feature is still default-off and the M4.2 scenario doc still describes V1 behavior.*
+Exit criteria: desync test matrix green on all four shells; shadow buffer code deleted; smoke scenarios 1–8 re-validated. *Status: the desync matrix is green at three levels (reader, controller seam, real pane driven by escape sequences) and the shadow buffer is deleted. Smoke scenarios 1–8 are re-validated at the flag-flip phase, since the feature is still default-off and the M4.2 scenario doc still describes V1 behavior. Task 7 (markless capture) is carried to the same gate for the same reason, and Phase 6 step 1 must check both.*
 
 Phase 1a notes (for the task-3 `GridQueryReader` author):
 - The B mark is carried as `ShellIntegrationEvent.MarkPosition` (`ShellMarkPosition`: `Row`,
@@ -121,6 +124,48 @@ Phase 1c notes (for the Phase 2 author, and for anyone reading the deleted surfa
   in the Phase 3 benchmark, the fix is to make the gate idempotent at the pane rather than to
   restore the early-out.
 
+### Phase 1c follow-up — task 7: markless capture-only accumulator (ii-strict)
+
+**The hole.** Phase 1c deleted V1's Enter-time history capture along with the shadow buffer, and put
+nothing in its place. That is correct for instrumented sessions — the grid is strictly better than
+the mirror ever was — but a session with no `OSC 133` marks now captures **nothing**, ever. That is
+not a corner: it is `cmd.exe`, every shell whose bootstrap bailed out (`pwsh -File`, `bash -c`,
+`zsh -f`, `fish -N`), and **every SSH session**, because SSH launch plans skip provider injection
+entirely and Phase 2 task 3 only lifts that for hosts the *user* has instrumented. For all of those,
+history stays empty forever, which means `Ctrl+R` is an empty box, Fix has no prior command to
+reason about, and ranking has no corpus. Shipping the flag flip in that state would present a
+feature that does nothing for a large share of real sessions.
+
+**The design (ii-strict).** A line accumulator in `TerminalPane`, used *only* as the Enter-time
+submission text, never as the query:
+
+- `TextInputObserved` appends the text; `BackspaceObserved` chops one character.
+- **Any unmodeled key poisons the buffer.** `KeyDownInterceptor` already sees every key the pane
+  does not own; arrows, `Home`, `End`, `Delete`, `Tab`, `PgUp`/`PgDn`, F-keys and any `Ctrl`/`Alt`
+  chord Command Assist does not own all set the poison flag. Paste poisons.
+- `Enter` and `Ctrl+C` reset it (text and flag).
+- At `Enter`: `submitted = grid text if available else (poisoned ? null : accumulator)`. Grid truth
+  always wins where it exists; the accumulator is consulted only where there is none.
+
+It feeds the existing `HandleEnterAsync(string?)` seam and requires **zero** changes inside
+`NovaTerminal.CommandAssist` — the assist assembly keeps its "the host tells me, or nothing" contract
+and cannot tell the two sources apart. It is deletable in one commit once Phase 2 gives SSH real
+marks.
+
+**Why this is not the desync class coming back.** The PR body's counterargument against restoring
+the mirror is sound, and it is an argument about the *unpoisoned* variant. V1's mirror answered
+"what is on the line?" with a guess, and its failure mode was **silent wrongness**: the Fix-mode
+caption was concatenated into it, Tab completions were truncated to what the user had typed, and
+`Ctrl+U` left it holding text that was no longer on screen — all of which were written to permanent
+history as commands the user had run. A poisoned accumulator cannot do that. Every edit it cannot
+model turns it off, so its only two outcomes are "exactly the characters the user typed, in order"
+and "nothing". Failure mode "captures nothing", never "captures something false" — which is the same
+bar Phase 1c set for the grid reader, met by a different mechanism.
+
+**Ordering.** Anywhere before the flag flip. It does not block Phase 2, and Phase 2 shrinks the
+population it serves (instrumented remotes stop needing it) without emptying it (`cmd.exe` and
+bailed-out bootstraps remain).
+
 ## Phase 2 — Marks-based anchoring + SSH parity
 
 Tasks:
@@ -165,7 +210,9 @@ Exit criteria: local providers run through the seam with zero behavior change; a
 
 ## Phase 6 — Flag flip
 
-1. Verify all six re-enable criteria from the design doc.
+1. Verify all six re-enable criteria from the design doc, plus the two items Phase 1 carried here:
+   smoke scenarios 1–8 re-validated, and Phase 1 task 7 (markless capture-only accumulator) landed
+   or explicitly re-adjudicated.
 2. Update `CommandAssistDefaultDisabledTests` → `CommandAssistDefaultEnabledTests`; flip `TerminalSettings.CommandAssistEnabled = true`; changelog + docs refresh (`CommandAssist.md` rewritten to match V2 reality, §14 keyboard table fixed).
 3. New smoke checklist executed on Windows + Unix-over-SSH; record results in `docs/command-assist/`.
 

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -534,26 +534,32 @@ namespace NovaTerminal.Controls
             TermView.MetricsChanged += _onTermViewMetricsLayout;
             TermView.CommandAssistAnchorHintChanged += () => UpdateCommandAssistOverlayPlacement();
             SizeChanged += (_, _) => UpdateCommandAssistOverlayPlacement();
-            TermView.TextInputObserved += text =>
+            // Keystrokes are triggers, not content (V2 Phase 1c). The text and the fact that a
+            // character was deleted are both discarded here: Command Assist re-reads the command
+            // line out of the grid on the refresh these queue, which is the only source that also
+            // knows about the arrow keys, Ctrl+U, history recall and shell-side Tab completion.
+            // The TermView events themselves stay - they are the cheapest available signal that
+            // the prompt is being edited.
+            TermView.TextInputObserved += _ =>
             {
                 if (EnsureCommandAssistInitialized())
                 {
-                    _commandAssistController?.HandleTextInput(text);
+                    _commandAssistController?.NotifyInputActivity();
                 }
             };
             TermView.BackspaceObserved += () =>
             {
                 if (EnsureCommandAssistInitialized())
                 {
-                    _commandAssistController?.HandleBackspace();
+                    _commandAssistController?.NotifyInputActivity();
                 }
             };
             TermView.EnterObserved += OnCommandAssistEnterObserved;
-            TermView.PasteObserved += text =>
+            TermView.PasteObserved += _ =>
             {
                 if (EnsureCommandAssistInitialized())
                 {
-                    _commandAssistController?.HandlePastedText(text);
+                    _commandAssistController?.NotifyPastedInput();
                 }
             };
 
@@ -975,7 +981,12 @@ namespace NovaTerminal.Controls
                 services.ErrorInsightService,
                 modeRouter: null,
                 resultBuilder: null,
-                action =>
+                // The grid-truth seam. Command Assist may not reference NovaTerminal.VT (see
+                // ProjectFileLayeringTests), so the reader's GridCommandLine is mapped to the
+                // assist assembly's own AssistQuerySnapshot right here, at the one boundary that
+                // can see both types. Everything downstream sees plain data.
+                queryProvider: TryReadAssistQuerySnapshot,
+                dispatch: action =>
                 {
                     if (Dispatcher.UIThread.CheckAccess())
                     {
@@ -1419,12 +1430,25 @@ namespace NovaTerminal.Controls
             UpdateRemoteFilesSidebarEntryPointState();
         }
 
+        /// <remarks>
+        /// The grid read happens here, synchronously, rather than inside the async continuation.
+        /// <c>TerminalView</c> sends the carriage return to the PTY before raising this, so the
+        /// input line is already condemned: every scheduling hop between the keypress and the read
+        /// widens the window in which the shell has begun repainting over it. This is as close to
+        /// the keypress as the pane can get.
+        /// </remarks>
         private void OnCommandAssistEnterObserved()
         {
-            _ = HandleCommandAssistEnterObservedAsync();
+            if (!EnsureCommandAssistInitialized())
+            {
+                return;
+            }
+
+            AssistQuerySnapshot? submitted = _commandAssistController.TryReadQuerySnapshot();
+            _ = HandleCommandAssistEnterObservedAsync(submitted?.Text);
         }
 
-        private async Task HandleCommandAssistEnterObservedAsync()
+        private async Task HandleCommandAssistEnterObservedAsync(string? submittedText)
         {
             if (!EnsureCommandAssistInitialized())
             {
@@ -1433,13 +1457,12 @@ namespace NovaTerminal.Controls
 
             try
             {
-                string currentQuery = _commandAssistController.ViewModel.QueryText;
-                if (!string.IsNullOrWhiteSpace(currentQuery))
+                if (!string.IsNullOrWhiteSpace(submittedText))
                 {
-                    _lastRelevantCommandText = currentQuery.Trim();
+                    _lastRelevantCommandText = submittedText.Trim();
                 }
 
-                await _commandAssistController.HandleEnterAsync();
+                await _commandAssistController.HandleEnterAsync(submittedText);
             }
             catch (Exception ex)
             {
@@ -1548,7 +1571,12 @@ namespace NovaTerminal.Controls
                 return false;
             }
 
-            string existingQuery = _commandAssistController.ViewModel.QueryText;
+            // Read the line before accepting: accepting dismisses the surface, and the planner needs
+            // to know what is on the command line *now* rather than what the last ranking pass saw.
+            // A markless session yields null here, and the planner refuses -- insertion is
+            // prefix-dependent and degraded mode does not offer prefix-dependent features.
+            AssistQuerySnapshot? existingQuery = _commandAssistController.TryReadQuerySnapshot();
+
             if (!_commandAssistController.TryAcceptSelection(out string? insertionText) || insertionText == null)
             {
                 return false;
@@ -2267,12 +2295,16 @@ namespace NovaTerminal.Controls
                 return;
             }
 
+            // The text is kept for the failure-analysis path (Fix mode needs a command to analyse
+            // and a paste is often the whole of one), but it is no longer handed to Command Assist
+            // as query state: NotifyPastedInput carries provenance only. See
+            // CommandAssistController.NotifyPastedInput.
             if (!string.IsNullOrWhiteSpace(text))
             {
                 _lastRelevantCommandText = text.Trim();
             }
 
-            _commandAssistController?.HandlePastedText(text);
+            _commandAssistController?.NotifyPastedInput();
         }
 
         internal bool CanExplainSelection(string? selectedTextOverride = null)
@@ -2975,6 +3007,23 @@ namespace NovaTerminal.Controls
             args = plan.ShellArguments ?? string.Empty;
             _isShellIntegrationActive = true;
             _shellIntegrationEnvOverrides = plan.EnvironmentOverrides;
+            ArmShellIntegrationTracker();
+        }
+
+        /// <summary>
+        /// Arms the translator that turns raw OSC 133 parser callbacks into the ordered
+        /// <see cref="ShellIntegrationEvent"/> stream Command Assist consumes.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately separate from <c>_isShellIntegrationActive</c>, which the caller above sets
+        /// and which means something narrower: that <em>we</em> injected a bootstrap into this
+        /// shell. Arming the translator only says the events will be delivered if they arrive.
+        /// (Phase 2's remote-integration work is where a session we did not instrument gets to arm
+        /// it too.) Internal so a headless test can drive the real parser to tracker to dispatcher
+        /// to controller path without spawning a shell.
+        /// </remarks>
+        internal void ArmShellIntegrationTracker()
+        {
             _shellLifecycleTracker = new ShellLifecycleTracker();
             _shellLifecycleTracker.EventObserved += OnShellIntegrationEventObserved;
         }
@@ -2987,20 +3036,16 @@ namespace NovaTerminal.Controls
                 _lastRelevantCommandText = shellEvent.CommandText.Trim();
             }
 
-            // OSC 133;B (CommandStarted) is dropped unconditionally by
-            // CommandAssistController.HandleShellIntegrationEventAsync, and B fires once per
-            // prompt AND once per prompt repaint -- so forwarding it only queues no-op work
-            // onto the serialized dispatcher, ahead of events that do something. The
-            // "shell integration is live" flag the controller would set from it is already
-            // set by the PromptReady (OSC 133;A) that precedes every B.
-            // The grid reader (Phase 1b) does not need this path either: it takes the mark
-            // straight off the parser callback via _latestCommandStartMark. Phase 1c, when the
-            // orchestrator starts pulling grid truth on the event, has to remove this early-out.
-            if (shellEvent.Type == ShellIntegrationEventType.CommandStarted)
-            {
-                return;
-            }
-
+            // OSC 133;B (CommandStarted) used to be dropped here as a no-op: nothing consumed it,
+            // and B fires once per prompt AND once per prompt repaint, so forwarding it only
+            // queued dead work onto the serialized dispatcher ahead of events that did something.
+            //
+            // Phase 1c gave it a job. B is what opens Command Assist's command-input window
+            // (AssistSessionContext.IsAcceptingCommandInput), and that window is the lifecycle gate
+            // on reading the command line out of the grid: with the event dropped, the gate would
+            // never open and grid-truth query state would be dead on arrival. The early-out is
+            // therefore gone, and the repaint cost -- one dispatcher hop per prompt paint, doing an
+            // idempotent bool set and a marker observation -- is the price of the gate.
             _ = _shellIntegrationEventDispatcher.EnqueueAsync(() => HandleShellIntegrationEventAsync(shellEvent));
         }
 
@@ -3024,8 +3069,13 @@ namespace NovaTerminal.Controls
         /// <c>B</c> without a matching <c>D</c>.
         /// </para>
         /// <para>
-        /// <b>Nothing consumes this yet.</b> Phase 1c wires it into the suggestion orchestrator
-        /// and deletes the keystroke shadow buffer.
+        /// <b>The mark is only half the gate.</b> Whether the cells between it and the cursor are a
+        /// command line the user is editing or the output of a command that already ran is a
+        /// lifecycle fact, and Command Assist holds it
+        /// (<c>AssistSessionContext.IsAcceptingCommandInput</c>, opened by <c>133;B</c> and closed
+        /// by <c>133;C</c>). This seam answers only "can the grid be read from the newest mark";
+        /// <see cref="TryReadAssistQuerySnapshot"/> is what the orchestrator calls, and the
+        /// orchestrator applies the gate before calling it.
         /// </para>
         /// </remarks>
         /// <returns><c>false</c> when there is no live mark or the grid cannot be read.</returns>
@@ -3047,6 +3097,36 @@ namespace NovaTerminal.Controls
 
             return mark is ShellIntegrationMark live
                 && GridQueryReader.TryReadCommandLine(buffer, live, out line);
+        }
+
+        /// <summary>
+        /// The App-boundary mapping: <see cref="GridCommandLine"/> (VT) to
+        /// <see cref="AssistQuerySnapshot"/> (Command Assist). This is the provider handed to the
+        /// controller, and the only place the two type systems meet.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Callable from any thread, and it is: the suggestion orchestrator invokes it from the
+        /// worker its refresh pass runs on, deliberately, so the read lands behind the queue hop
+        /// rather than on the keystroke that triggered it. Both things it touches are safe for
+        /// that - the mark is read under <c>_commandStartMarkGate</c> and
+        /// <see cref="GridQueryReader"/> takes the buffer's own read lock.
+        /// </para>
+        /// <para>
+        /// The span's <c>StartRow</c>/<c>EndRow</c> are dropped rather than carried across. Nothing
+        /// on the far side has a use for buffer coordinates, and Phase 2's anchoring work will take
+        /// the <c>133;A</c> row through the anchor calculator instead.
+        /// </para>
+        /// </remarks>
+        internal AssistQuerySnapshot? TryReadAssistQuerySnapshot()
+        {
+            return TryGetGridCommandLine(out GridCommandLine line)
+                ? new AssistQuerySnapshot(
+                    Text: line.Text,
+                    CursorOffset: line.CursorOffset,
+                    IsMultiline: line.IsMultiline,
+                    RightPromptTrimmed: line.RightPromptTrimmed)
+                : null;
         }
 
         internal async Task HandleCommandAssistCompletionAsync(int? exitCode)

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -142,6 +142,11 @@ namespace NovaTerminal.Controls
         // across the two; the gate costs one uncontended lock per prompt.
         private readonly object _commandStartMarkGate = new();
         private ShellIntegrationMark? _latestCommandStartMark;
+
+        // True between "the user pressed a key that edits the command line" and "the session sent
+        // us bytes we have parsed into the grid". See NoteInputAwaitingEcho for why insertion
+        // refuses while it is set. Written from the UI thread, cleared from the PTY read thread.
+        private volatile bool _hasUnechoedInput;
         private string? _lastRelevantCommandText;
         private CommandAssistBarViewModel? _boundCommandAssistViewModel;
         private string? _lastCommandAssistAnchorDiagnosticSignature;
@@ -542,6 +547,7 @@ namespace NovaTerminal.Controls
             // the prompt is being edited.
             TermView.TextInputObserved += _ =>
             {
+                NoteInputAwaitingEcho();
                 if (EnsureCommandAssistInitialized())
                 {
                     _commandAssistController?.NotifyInputActivity();
@@ -549,6 +555,7 @@ namespace NovaTerminal.Controls
             };
             TermView.BackspaceObserved += () =>
             {
+                NoteInputAwaitingEcho();
                 if (EnsureCommandAssistInitialized())
                 {
                     _commandAssistController?.NotifyInputActivity();
@@ -1564,9 +1571,52 @@ namespace NovaTerminal.Controls
             return TryHandleCommandAssistKey(Key.P, KeyModifiers.Control | KeyModifiers.Shift);
         }
 
+        /// <summary>
+        /// The user pressed a key that edits the command line, and the PTY has been sent the bytes
+        /// for it. Until the shell echoes them back and the parser paints them, the grid is a
+        /// prefix of the real command line.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This is the one desync the grid cannot self-report. Every other stale read looks wrong -
+        /// a half-erased line, a mark that went dark - but an unechoed keystroke leaves a read that
+        /// is internally perfect: <c>"git st"</c> with the cursor at offset 6, every planner guard
+        /// satisfied, while the shell already holds <c>"git sta"</c>. Because the stale text is
+        /// always a strict <em>prefix</em> of the true line, no prefix check can detect it: the
+        /// planner would compute <c>"atus"</c> against <c>"git st"</c> and the line would become
+        /// <c>"git staatus"</c>.
+        /// </para>
+        /// <para>
+        /// So insertion refuses while this is set, consistent with the planner's other rules -
+        /// refusal on doubt, never a guess. Ranking is deliberately left alone: a one-character-
+        /// stale query ranks slightly worse rows and the next trigger fixes it, which is a cost
+        /// worth paying to keep suggestions live while typing.
+        /// </para>
+        /// <para>
+        /// The clear is approximate in one direction only. Any session output clears the flag, so
+        /// unrelated output (a background job printing) can clear it before the echo lands, leaving
+        /// the original window open. It cannot go the other way: output that has been parsed is
+        /// output that is in the grid.
+        /// </para>
+        /// </remarks>
+        internal void NoteInputAwaitingEcho() => _hasUnechoedInput = true;
+
+        /// <summary>Session bytes have been parsed into the grid, so the grid has caught up.</summary>
+        internal void NoteSessionOutputApplied() => _hasUnechoedInput = false;
+
+        /// <summary>Whether an edit keystroke is still waiting for the shell's echo.</summary>
+        internal bool HasUnechoedInput => _hasUnechoedInput;
+
         private bool TryInsertSelectedCommandAssistSuggestion()
         {
             if (_commandAssistController == null || Session == null)
+            {
+                return false;
+            }
+
+            // The echo race: a fresh read taken now can be a self-consistent snapshot of a command
+            // line the shell has already moved past. See NoteInputAwaitingEcho.
+            if (_hasUnechoedInput)
             {
                 return false;
             }
@@ -1577,13 +1627,25 @@ namespace NovaTerminal.Controls
             // prefix-dependent and degraded mode does not offer prefix-dependent features.
             AssistQuerySnapshot? existingQuery = _commandAssistController.TryReadQuerySnapshot();
 
-            if (!_commandAssistController.TryAcceptSelection(out string? insertionText) || insertionText == null)
+            // Everything above and below this line is non-mutating, and that ordering is the point.
+            // TryAcceptSelection accepts *and* dismisses; calling it first meant that every refusal
+            // after it - a degraded session, a cursor mid-line, a multiline entry - tore the list
+            // down and sent nothing, so Ctrl+Enter read as "the feature is broken" rather than as
+            // "not here". The plan is computed first and the surface is only touched once there is
+            // text to send.
+            if (!_commandAssistController.TryGetInsertionText(out string? insertionText) ||
+                string.IsNullOrWhiteSpace(insertionText))
             {
                 return false;
             }
 
             if (!CommandAssistInsertionPlanner.TryCreateInsertion(existingQuery, insertionText, out string? textToSend) ||
                 string.IsNullOrEmpty(textToSend))
+            {
+                return false;
+            }
+
+            if (!_commandAssistController.TryAcceptSelection(out _))
             {
                 return false;
             }
@@ -1984,6 +2046,10 @@ namespace NovaTerminal.Controls
             Session.OnOutputReceived += text =>
             {
                 Parser.Process(text);
+
+                // After Parse, not before: the flag's contract is "the grid may be behind the
+                // keyboard", so it may only be cleared once these bytes are actually painted.
+                NoteSessionOutputApplied();
                 Dispatcher.UIThread.Post(() =>
                 {
                     UpdateScrollUI();

--- a/src/NovaTerminal.CommandAssist/Application/AssistQuerySnapshot.cs
+++ b/src/NovaTerminal.CommandAssist/Application/AssistQuerySnapshot.cs
@@ -1,0 +1,65 @@
+namespace NovaTerminal.CommandAssist.Application;
+
+/// <summary>
+/// What the shell's line editor currently holds, as read out of the terminal grid: the V2 query.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is Command Assist's own shape for <c>NovaTerminal.VT.GridCommandLine</c>. The two records
+/// carry the same facts, but this assembly may not reference VT (the layering tests forbid it), so
+/// the App maps one to the other at its boundary and the grid crosses into Command Assist as plain
+/// data. The fields are deliberately the ones a consumer has to branch on, not the ones the reader
+/// found convenient: the span's row numbers stay behind in VT because nothing here has a use for
+/// them.
+/// </para>
+/// <para>
+/// A snapshot only exists while the shell is between <c>OSC 133;B</c> and the <c>OSC 133;C</c> that
+/// closes the line editor. Outside that window - and in a session with no shell integration at all -
+/// there is no snapshot, and the honest query is "unknown", not "empty". Callers get
+/// <see langword="null"/> and are expected to drop prefix-dependent behavior rather than guess.
+/// </para>
+/// </remarks>
+/// <param name="Text">
+/// The command line exactly as it is painted, with hard line breaks as <c>'\n'</c>. Never null.
+/// </param>
+/// <param name="CursorOffset">
+/// Where the cursor sits within <paramref name="Text"/>; always a valid index into it. Routinely
+/// less than the length, because arrow keys are normal.
+/// </param>
+/// <param name="IsMultiline">
+/// The entry spans a hard line break, so <paramref name="Text"/> contains whatever the shell painted
+/// as a continuation prompt (<c>PS2</c>, <c>PROMPT2</c>, fish's <c>&gt; </c>). Nothing marks those
+/// cells as prompt rather than input, so the text is usable for history and display but is not a
+/// typed prefix.
+/// </param>
+/// <param name="RightPromptTrimmed">
+/// A right-aligned prompt (zsh <c>RPROMPT</c>, fish <c>fish_right_prompt</c>, starship's right
+/// prompt) was recognised on the final row and excluded. The reader's trim is deliberately
+/// conservative, but "conservative" is not "certain": the tail of the line is the one part of it
+/// that may not be what the user typed.
+/// </param>
+public readonly record struct AssistQuerySnapshot(
+    string Text,
+    int CursorOffset,
+    bool IsMultiline,
+    bool RightPromptTrimmed)
+{
+    /// <summary>
+    /// Whether <see cref="Text"/> may be treated as a prefix the user typed and left the cursor at
+    /// the end of - the assumption every suffix-append insertion rests on.
+    /// </summary>
+    /// <remarks>
+    /// Three ways it fails, and all three are ordinary rather than exotic:
+    /// <list type="bullet">
+    /// <item>the cursor is not at the end, so appending would land text in the middle of the line;</item>
+    /// <item>the entry is multiline, so the text contains continuation-prompt cells that were never
+    /// typed;</item>
+    /// <item>a right prompt was trimmed, so the tail of the line is the reader's judgement rather
+    /// than an observation.</item>
+    /// </list>
+    /// Ranking and help still run on an untrustworthy snapshot - a bad ranking shows the wrong rows,
+    /// which the user ignores. A bad insertion edits the user's command line.
+    /// </remarks>
+    public bool IsUsableAsTypedPrefix =>
+        !IsMultiline && !RightPromptTrimmed && CursorOffset == Text.Length;
+}

--- a/src/NovaTerminal.CommandAssist/Application/AssistSessionContext.cs
+++ b/src/NovaTerminal.CommandAssist/Application/AssistSessionContext.cs
@@ -72,6 +72,37 @@ internal sealed class AssistSessionContext
     public bool IsStructuredCaptureActive =>
         IsShellIntegrationEnabled && HasObservedStructuredCommandCaptureMarker;
 
+    /// <summary>
+    /// Whether the shell is currently sitting in its line editor waiting for the user: opened by
+    /// <c>OSC 133;B</c> (prompt end), closed again by <c>OSC 133;C</c> (the line was submitted).
+    /// This is the lifecycle gate on grid-truth query reading.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The grid reader cannot gate itself. Between the mark and the cursor there are cells; whether
+    /// those cells are a command line the user is editing or the first lines of that command's
+    /// output is a fact about the shell's lifecycle, not about the buffer, and only the OSC 133
+    /// stream carries it. So the gate lives here, on the consumer side, and the reader's answer is
+    /// consulted only while it is open.
+    /// </para>
+    /// <para>
+    /// It is deliberately <em>not</em> conditioned on <see cref="IsShellIntegrationEnabled"/>. That
+    /// flag records whether <em>we</em> injected a bootstrap; a shell that emits <c>B</c> is
+    /// instrumented whether we did it or the user did, and Phase 2's instrumented-remote story
+    /// depends on believing the marks rather than the injection. What closes the gate is evidence
+    /// that the window ended - <c>C</c>, <c>D</c>, an alt-screen switch - never the absence of
+    /// configuration.
+    /// </para>
+    /// <para>
+    /// <c>D</c> closes it as well as <c>C</c> because a shell can reach <c>D</c> without an
+    /// intervening <c>C</c>, and leaving the gate open for a command's whole run is exactly the
+    /// failure it exists to prevent. The pane drops its mark on <c>D</c> too, so that case is
+    /// double-covered on purpose: two independent facts have to be wrong before output can be
+    /// served as a command line.
+    /// </para>
+    /// </remarks>
+    public bool IsAcceptingCommandInput { get; private set; }
+
     /// <summary>Replaces the host-reported session facts.</summary>
     /// <remarks>
     /// Observed markers survive only while shell integration stays configured: a session that
@@ -108,8 +139,30 @@ internal sealed class AssistSessionContext
         }
     }
 
-    /// <summary>Records an alt-screen switch.</summary>
-    public void SetAltScreenActive(bool isActive) => IsAltScreenActive = isActive;
+    /// <summary>
+    /// Records an alt-screen switch. Going into the alt screen closes the command-input window:
+    /// the prompt that emitted <c>B</c> is not on the screen the user is looking at any more, and
+    /// leaving it open would let a refresh read the TUI's own grid as a command line.
+    /// </summary>
+    /// <remarks>
+    /// Coming back out does not reopen it. The shell repaints its prompt when the alt screen is
+    /// torn down, and that repaint re-emits <c>B</c>, so the gate reopens on evidence rather than
+    /// on assumption.
+    /// </remarks>
+    public void SetAltScreenActive(bool isActive)
+    {
+        IsAltScreenActive = isActive;
+        if (isActive)
+        {
+            IsAcceptingCommandInput = false;
+        }
+    }
+
+    /// <summary><c>OSC 133;B</c>: the prompt finished printing and the line editor is the user's.</summary>
+    public void OpenCommandInputWindow() => IsAcceptingCommandInput = true;
+
+    /// <summary><c>OSC 133;C</c> / <c>OSC 133;D</c>: the line editor is closed.</summary>
+    public void CloseCommandInputWindow() => IsAcceptingCommandInput = false;
 
     /// <summary>Records a working-directory change reported by a shell-integration event.</summary>
     public void SetWorkingDirectory(string workingDirectory) => WorkingDirectory = workingDirectory;

--- a/src/NovaTerminal.CommandAssist/Application/AssistSessionContext.cs
+++ b/src/NovaTerminal.CommandAssist/Application/AssistSessionContext.cs
@@ -21,9 +21,43 @@ namespace NovaTerminal.CommandAssist.Application;
 /// by a shell-integration event is immediately visible to the next ranking pass. All mutation goes
 /// through named methods.
 /// </para>
+/// <para>
+/// <strong>Threading contract.</strong> Every mutator here is called on the dispatcher thread - the
+/// controller marshals shell-integration events and host callbacks there before touching this
+/// object - but the readers are not all on it: <see cref="SuggestionOrchestrator"/> reads
+/// <see cref="IsAcceptingCommandInput"/>, <see cref="IsAltScreenActive"/>,
+/// <see cref="WorkingDirectory"/>, <see cref="ShellKind"/>, <see cref="ProfileId"/> and
+/// <see cref="IsRemote"/> from the worker its refresh pass runs on. There is no lock, and the
+/// contract that makes that safe has two halves.
+/// </para>
+/// <para>
+/// First, <em>every field must stay reference-sized or bool-sized</em>. Those are written
+/// atomically by the CLR, so a worker either sees the old value or the new one and never a torn
+/// one. A future multi-field fact - a struct carrying a mark, a tuple of directory plus generation -
+/// cannot simply be added here; it needs a lock or an immutable snapshot object swapped in as a
+/// single reference (which is what <c>TerminalPane</c> does with its mark gate).
+/// </para>
+/// <para>
+/// Second, <em>a stale read is tolerated rather than prevented</em>. A pass that reads the gate
+/// microseconds before <c>133;C</c> closes it produces an outcome for a command line that has since
+/// been submitted - and that outcome is dropped anyway, because the transition that closed the gate
+/// came with a refresh that superseded the pass through
+/// <c>SuggestionOrchestrator.CancelPending</c>. The window is real and the correctness argument is
+/// supersession, not synchronization; anything that starts acting on these values <em>without</em>
+/// going through a cancellable pass has to re-establish it.
+/// </para>
 /// </remarks>
 internal sealed class AssistSessionContext
 {
+    /// <summary>
+    /// Backing field for <see cref="IsAcceptingCommandInput"/>. Explicitly <c>volatile</c> - unlike
+    /// its neighbours - because it is the one flag a worker thread polls in a tight decision rather
+    /// than reads once as context: <see cref="SuggestionOrchestrator.TryReadQuery"/> consults it to
+    /// decide whether it is legal to touch the terminal grid at all. The others are already
+    /// atomic-by-width and would only gain ordering guarantees nothing depends on.
+    /// </summary>
+    private volatile bool _isAcceptingCommandInput;
+
     /// <summary>Shell kind reported by the host ("pwsh", "bash", ...), or null when unknown.</summary>
     public string? ShellKind { get; private set; }
 
@@ -101,7 +135,7 @@ internal sealed class AssistSessionContext
     /// served as a command line.
     /// </para>
     /// </remarks>
-    public bool IsAcceptingCommandInput { get; private set; }
+    public bool IsAcceptingCommandInput => _isAcceptingCommandInput;
 
     /// <summary>Replaces the host-reported session facts.</summary>
     /// <remarks>
@@ -154,15 +188,39 @@ internal sealed class AssistSessionContext
         IsAltScreenActive = isActive;
         if (isActive)
         {
-            IsAcceptingCommandInput = false;
+            _isAcceptingCommandInput = false;
         }
     }
 
     /// <summary><c>OSC 133;B</c>: the prompt finished printing and the line editor is the user's.</summary>
-    public void OpenCommandInputWindow() => IsAcceptingCommandInput = true;
+    /// <remarks>
+    /// <para>
+    /// Refused while the alt screen is up, so that the invariant "the gate is never open during an
+    /// alt screen" holds no matter which order the two facts arrive in.
+    /// <see cref="SetAltScreenActive"/> closes the gate on the way in, but a full-screen TUI is free
+    /// to emit <c>133;B</c> of its own afterwards - it is a perfectly legal thing for a program that
+    /// draws its own prompt to do - and that would reopen a window onto the TUI's grid. Consumers
+    /// already check alt-screen separately, so this is belt and braces; without it the two flags can
+    /// disagree, and a self-contradicting invariant is one refactor away from being load-bearing.
+    /// </para>
+    /// <para>
+    /// Re-emitting <c>B</c> while the gate is already open is idempotent by construction. Prompt
+    /// frameworks repaint constantly and each repaint carries the mark; the pane keeps the newest
+    /// mark and this keeps the gate open, which is exactly the intent.
+    /// </para>
+    /// </remarks>
+    public void OpenCommandInputWindow()
+    {
+        if (IsAltScreenActive)
+        {
+            return;
+        }
+
+        _isAcceptingCommandInput = true;
+    }
 
     /// <summary><c>OSC 133;C</c> / <c>OSC 133;D</c>: the line editor is closed.</summary>
-    public void CloseCommandInputWindow() => IsAcceptingCommandInput = false;
+    public void CloseCommandInputWindow() => _isAcceptingCommandInput = false;
 
     /// <summary>Records a working-directory change reported by a shell-integration event.</summary>
     public void SetWorkingDirectory(string workingDirectory) => WorkingDirectory = workingDirectory;

--- a/src/NovaTerminal.CommandAssist/Application/AssistSessionStateMachine.cs
+++ b/src/NovaTerminal.CommandAssist/Application/AssistSessionStateMachine.cs
@@ -134,6 +134,28 @@ internal sealed class AssistSessionStateMachine
     /// The user typed into the shell. Returns to Suggest mode with the popup closed, preserving
     /// whether this is an explicit session - typing on after a history search stays explicit.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Known weakness, accepted rather than fixed:</strong> one keystroke after a paste
+    /// clears <see cref="IsCurrentSubmissionSuppressed"/>, so "paste a command, add a character,
+    /// press Enter" writes the pasted text to history as though the user had composed it. That was
+    /// harmless in V1 because the shadow buffer only held the characters it had watched go by; it is
+    /// not harmless now, because the grid reproduces pasted text perfectly and this flag is the only
+    /// thing standing between a paste and the history file.
+    /// </para>
+    /// <para>
+    /// The tightening - suppression survives until the submission resets it - was considered and
+    /// deliberately not taken here. It is a behavior change, not a bug fix: paste-then-edit-then-run
+    /// capturing is V1 behavior that
+    /// <c>AssistSessionStateMachineTests.ObserveTypedInput_ClearsSubmissionSuppression</c> and
+    /// <c>SubmissionSuppression_SurvivesEverythingExceptTypingAndSubmitting</c> both pin by name, and
+    /// flipping it silently inside a phase whose subject is query truth would bury a policy decision
+    /// about what belongs in history inside a refactor. It belongs with the Phase 3 capture-policy
+    /// work, where the "paste a snippet and tweak it" case can be weighed against the "paste a
+    /// credential-bearing one-liner" case in the open. Until then the loss is bounded by
+    /// <c>ISecretsFilter</c> redaction and stated here rather than left to be rediscovered.
+    /// </para>
+    /// </remarks>
     public void ObserveTypedInput()
     {
         IsCurrentSubmissionSuppressed = false;

--- a/src/NovaTerminal.CommandAssist/Application/AssistSessionStateMachine.cs
+++ b/src/NovaTerminal.CommandAssist/Application/AssistSessionStateMachine.cs
@@ -36,12 +36,21 @@ internal sealed class AssistSessionStateMachine
     /// may act on it.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Kept beside the enum rather than inside it on purpose: a paste can land in any state, so
     /// folding it in would double the state count while carrying no information about what the
     /// surface is showing. It is still only reachable through named transitions
     /// (<see cref="ObservePastedText"/> sets it; <see cref="ObserveTypedInput"/> and
-    /// <see cref="CompleteSubmission"/> clear it), never through a setter. Phase 1 deletes the
-    /// shadow query buffer this exists to protect, and should delete this with it.
+    /// <see cref="CompleteSubmission"/> clear it), never through a setter.
+    /// </para>
+    /// <para>
+    /// Phase 1c deleted the shadow query buffer and an earlier draft of this comment expected this
+    /// flag to go with it. It does not, and the reason is worth stating: this is not a query fact.
+    /// The grid reads pasted text as faithfully as typed text - what it cannot see is provenance,
+    /// and provenance is the whole question. A pasted line must not be written to history as though
+    /// the user composed it here, and must not have a suggestion spliced into it. Both of those
+    /// survive the deletion, so this does too.
+    /// </para>
     /// </remarks>
     public bool IsCurrentSubmissionSuppressed { get; private set; }
 

--- a/src/NovaTerminal.CommandAssist/Application/CapturePipeline.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CapturePipeline.cs
@@ -13,11 +13,13 @@ namespace NovaTerminal.CommandAssist.Application;
 /// </summary>
 /// <remarks>
 /// <para>
-/// There are two capture paths because there are two kinds of session. When the shell is
-/// instrumented it tells us the command text it accepted, and that text is authoritative - it
-/// survives multi-line input, history recall and line editing. When it is not, all we have is the
-/// keystrokes we watched go by, so the Enter key is the trigger and the shadow query buffer is the
-/// source.
+/// There are two capture paths because there are two moments a command becomes known. The
+/// structured path is the shell telling us, through <c>OSC 133;C</c>, the text it accepted; that is
+/// authoritative and survives multi-line input, history recall and line editing. The Enter-time
+/// path is the host telling us what it could see on the command line when the user pressed Enter -
+/// since Phase 1c that is the terminal grid read between the newest <c>OSC 133;B</c> mark and the
+/// cursor, and nothing else. There is no keystroke mirror behind it any more, so in a session with
+/// no marks the host has nothing to pass and this path captures nothing at all.
 /// </para>
 /// <para>
 /// The paths overlap for exactly one command. Structured capture only stands down the heuristic once
@@ -55,7 +57,13 @@ internal sealed class CapturePipeline
     /// Heuristic capture: the user pressed Enter and we believe <paramref name="submission"/> is what
     /// went to the shell.
     /// </summary>
-    /// <param name="submission">The shadow query buffer contents.</param>
+    /// <param name="submission">
+    /// The command line as the host read it out of the terminal grid at the instant Enter was
+    /// observed. An empty string means the host had nothing truthful to offer - a markless session,
+    /// a closed lifecycle gate, an unreadable mark - and nothing is persisted, which is the whole
+    /// point: the alternative source (a keystroke mirror) was deleted in Phase 1c because it wrote
+    /// commands the user never ran into permanent history.
+    /// </param>
     /// <param name="isSubmissionSuppressed">
     /// Whether the session marked this submission untrustworthy (pasted rather than typed).
     /// </param>

--- a/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
@@ -121,6 +121,17 @@ public sealed class CommandAssistController
         }
     }
 
+    /// <summary>
+    /// Opens explicit history search (<c>Ctrl+R</c>).
+    /// </summary>
+    /// <remarks>
+    /// The label distinguishes the two things this surface can be. With a readable command line the
+    /// rows are filtered by it, and "History" says so. Without one - a markless session, a closed
+    /// lifecycle gate - there is no query and there will never be one, so the rows are the recency
+    /// list and typing will not narrow them. Calling that "History" too presents a filter box that
+    /// cannot filter, and the user reads the first keystroke that changes nothing as a bug rather
+    /// than as the documented degraded behavior.
+    /// </remarks>
     public bool OpenHistorySearch()
     {
         if (_context.IsAltScreenActive)
@@ -130,7 +141,7 @@ public sealed class CommandAssistController
         }
 
         _state.OpenSearch();
-        ViewModel.ModeLabel = "History";
+        ViewModel.ModeLabel = TryReadQuerySnapshot() == null ? "History - recent" : "History";
         ViewModel.IsPopupOpen = true;
         ViewModel.IsVisible = true;
         QueueRefreshSuggestions();

--- a/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
@@ -18,10 +18,28 @@ namespace NovaTerminal.CommandAssist.Application;
 /// <see cref="SuggestionOrchestrator"/> (producing ranked rows).
 /// </summary>
 /// <remarks>
+/// <para>
 /// <see cref="AssistSessionContext"/> carries the environment all three share. The controller keeps
 /// the view-model writes because presentation is the facade's job: the state machine says the
 /// session is in an explicit Suggest session, the controller decides that means the bubble is up and
 /// the popup is not.
+/// </para>
+/// <para>
+/// <strong>Query state (Phase 1c).</strong> The controller does not hold a query. It has no
+/// <c>HandleTextInput(text)</c>, no backspace mirror and no paste mirror, because it has no buffer
+/// for them to write into. The question "what is on the command line" is answered by reading the
+/// terminal grid between the newest <c>OSC 133;B</c> mark and the cursor - see
+/// <see cref="AssistQuerySnapshot"/> - and every consumer of the query (ranking, the help token, the
+/// insertion planner, the view-model's <c>QueryText</c>) goes to that one source. Keystrokes remain
+/// as <em>triggers</em>: <see cref="NotifyInputActivity"/> says "the line probably changed, look
+/// again", and the looking is the orchestrator's job.
+/// </para>
+/// <para>
+/// What survives from the old shadow buffer is exactly one bit:
+/// <see cref="AssistSessionStateMachine.IsCurrentSubmissionSuppressed"/>. Paste suppression is a
+/// statement about provenance ("the user did not compose this here"), which the grid cannot
+/// reconstruct from pixels, and it gates history capture and insertion rather than the query.
+/// </para>
 /// </remarks>
 public sealed class CommandAssistController
 {
@@ -47,6 +65,7 @@ public sealed class CommandAssistController
         IErrorInsightService? errorInsightService,
         CommandAssistModeRouter? modeRouter,
         CommandAssistResultBuilder? resultBuilder,
+        Func<AssistQuerySnapshot?>? queryProvider = null,
         Action<Action>? dispatch = null)
     {
         HistoryStore = historyStore;
@@ -66,6 +85,10 @@ public sealed class CommandAssistController
             snippetStore,
             suggestionEngine,
             _context,
+            // No provider means no grid, which is the same situation as a shell that emits no
+            // marks: the session runs in degraded mode. Defaulting to "no truth available" rather
+            // than throwing keeps every non-App host (tests, the MCP surface) on the honest path.
+            queryProvider ?? (() => null),
             _dispatch,
             ApplyRefreshOutcome);
     }
@@ -126,48 +149,89 @@ public sealed class CommandAssistController
         return true;
     }
 
-    public void HandleTextInput(string text)
+    /// <summary>
+    /// The user did something at the prompt that probably changed the command line - typed a
+    /// character, pressed Backspace. Triggers a refresh; carries no text.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the whole of what a keystroke means to Command Assist now. The character itself is
+    /// not interesting: it is already on the screen, and so is everything the shell did that no
+    /// keystroke describes - the <c>Ctrl+U</c> that emptied the line, the Up-arrow that recalled a
+    /// command, the Tab the shell completed. V1 mirrored the four events it could see and was wrong
+    /// about the line the moment any of the others happened.
+    /// </para>
+    /// <para>
+    /// Backspace deliberately has no separate entry point and no "is there anything to delete"
+    /// guard. Whether the line got shorter is the grid's business.
+    /// </para>
+    /// </remarks>
+    public void NotifyInputActivity()
     {
-        if (_context.IsAltScreenActive || string.IsNullOrEmpty(text))
+        if (_context.IsAltScreenActive)
         {
             return;
         }
 
         _state.ObserveTypedInput();
-        ViewModel.QueryText += text;
         ViewModel.ModeLabel = "Suggest";
         ViewModel.IsPopupOpen = false;
+
+        // Visibility follows the rows that are already up, not the rows this refresh will produce.
+        // Setting it true here and false when the pass lands is the flash that #232's predecessor
+        // shipped; the pass sets it for real in ApplyRefreshOutcome.
         ViewModel.IsVisible = ViewModel.HasSuggestions;
         QueueRefreshSuggestions();
     }
 
-    public void HandleBackspace()
-    {
-        if (_context.IsAltScreenActive || string.IsNullOrEmpty(ViewModel.QueryText))
-        {
-            return;
-        }
-
-        ViewModel.QueryText = ViewModel.QueryText[..^1];
-        QueueRefreshSuggestions();
-    }
-
-    public void HandlePastedText(string text)
+    /// <summary>
+    /// The user pasted into the terminal. Suppresses the current submission and triggers a refresh;
+    /// like <see cref="NotifyInputActivity"/> it carries no text.
+    /// </summary>
+    /// <remarks>
+    /// Suppression is the one piece of the old paste handling that had to survive the shadow
+    /// buffer's deletion, and it is not a query fact: it says the text on the line was not composed
+    /// here, which stops it being written to history as though it were and stops a suggestion being
+    /// spliced into it. The grid can read pasted text perfectly well; what it cannot see is where
+    /// the text came from.
+    /// </remarks>
+    public void NotifyPastedInput()
     {
         _state.ObservePastedText();
-        ViewModel.QueryText = text ?? string.Empty;
         ViewModel.ModeLabel = "Suggest";
         ViewModel.IsPopupOpen = false;
         ViewModel.IsVisible = !_context.IsAltScreenActive && ViewModel.HasSuggestions;
         QueueRefreshSuggestions();
     }
 
-    public async Task HandleEnterAsync()
+    /// <summary>
+    /// The user pressed Enter. Runs heuristic history capture over <paramref name="submittedText"/>
+    /// and resets the session for the next command line.
+    /// </summary>
+    /// <param name="submittedText">
+    /// What the host believes was submitted, read from the grid at the moment Enter was observed, or
+    /// <see langword="null"/> when there was nothing truthful to read. Passed in rather than pulled
+    /// from a snapshot here because the host owns the timing: Enter reaches the PTY before this runs,
+    /// and the closer the read sits to the keypress the smaller the window in which the shell has
+    /// already begun repainting.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// A markless session passes <see langword="null"/> and captures nothing. That is a deliberate
+    /// loss and the alternative was worse: V1's Enter-time capture read the shadow buffer, so any
+    /// line the user had edited with the keys the mirror could not see was written to persistent
+    /// history <em>wrong</em>. Recording no command is recoverable; recording a command the user
+    /// never ran is not. Instrumented sessions are unaffected - the first command is captured from
+    /// the grid here, and every command after it from the <c>OSC 133;C</c> payload, which is what
+    /// <see cref="AssistSessionContext.IsStructuredCaptureActive"/> stands the heuristic down for.
+    /// </para>
+    /// </remarks>
+    public async Task HandleEnterAsync(string? submittedText = null)
     {
         try
         {
             await _capturePipeline.CaptureSubmissionAsync(
-                ViewModel.QueryText,
+                submittedText ?? string.Empty,
                 _state.IsCurrentSubmissionSuppressed);
         }
         catch
@@ -180,6 +244,17 @@ public sealed class CommandAssistController
             ResetSubmissionState();
         }
     }
+
+    /// <summary>
+    /// The live command line, or <see langword="null"/> when the session is markless, the shell is
+    /// not in its line editor, or the grid cannot be read.
+    /// </summary>
+    /// <remarks>
+    /// Read fresh on every call rather than cached from the last refresh. Callers use it to decide
+    /// what to send to a live terminal, and the line may have moved since the rows on screen were
+    /// ranked.
+    /// </remarks>
+    public AssistQuerySnapshot? TryReadQuerySnapshot() => _suggestionOrchestrator.TryReadQuery();
 
     public void UpdateSessionContext(
         string? shellKind,
@@ -273,7 +348,10 @@ public sealed class CommandAssistController
             return false;
         }
 
-        ViewModel.QueryText = insertionText;
+        // No query write here. Accepting a row asks the host to send a delta to the terminal; the
+        // line's new contents are then whatever the shell paints, and the next refresh reads that.
+        // Writing the accepted text into QueryText was V1 predicting the outcome of an edit it did
+        // not perform, and it was wrong whenever the send failed or the shell transformed the input.
         _state.AcceptSelection();
         ViewModel.ModeLabel = "Suggest";
         ViewModel.IsPopupOpen = false;
@@ -302,8 +380,13 @@ public sealed class CommandAssistController
             return false;
         }
 
+        // Falls back to grid truth, not to the view-model. The view-model holds whatever the last
+        // ranking pass wrote, which is a frame behind at best and stale help-token extraction at
+        // worst; in a markless session there is no query and the recognized command comes from the
+        // selection alone, which is the degraded-mode contract.
+        string effectiveQuery = queryText ?? TryReadQuerySnapshot()?.Text ?? string.Empty;
         CommandAssistContextSnapshot snapshot = _context.CreateSnapshot(
-            queryText ?? ViewModel.QueryText,
+            effectiveQuery,
             selectedText);
         var helpQuery = new CommandHelpQuery(
             RawInput: snapshot.QueryText,
@@ -323,7 +406,7 @@ public sealed class CommandAssistController
 
         _dispatch(() => ApplyHelperSuggestions(
             _modeRouter.ChooseModeForHelpRequest(),
-            queryText ?? ViewModel.QueryText,
+            effectiveQuery,
             suggestions,
             "No local help found.",
             openPopup: true));
@@ -379,8 +462,30 @@ public sealed class CommandAssistController
         return false;
     }
 
+    /// <summary>
+    /// Consumes an OSC 133 event: moves the command-input lifecycle gate, then lets the capture
+    /// pipeline do whatever the event means for history.
+    /// </summary>
+    /// <remarks>
+    /// The gate moves here rather than inside <see cref="CapturePipeline"/> because it is not a
+    /// capture concern - it is what makes grid-truth reading legal, and the pipeline would be the
+    /// wrong place to look for it. <c>B</c> opens the window, <c>C</c> and <c>D</c> close it; see
+    /// <see cref="AssistSessionContext.IsAcceptingCommandInput"/> for why both closers are needed
+    /// and why nothing else opens it.
+    /// </remarks>
     public async Task HandleShellIntegrationEventAsync(ShellIntegrationEvent shellEvent)
     {
+        switch (shellEvent.Type)
+        {
+            case ShellIntegrationEventType.CommandStarted:
+                _context.OpenCommandInputWindow();
+                break;
+            case ShellIntegrationEventType.CommandAccepted:
+            case ShellIntegrationEventType.CommandFinished:
+                _context.CloseCommandInputWindow();
+                break;
+        }
+
         await _capturePipeline.HandleShellIntegrationEventAsync(shellEvent);
     }
 
@@ -461,7 +566,7 @@ public sealed class CommandAssistController
             return;
         }
 
-        _suggestionOrchestrator.Refresh(_state.Mode, _state.IsExplicitSession, ViewModel.QueryText);
+        _suggestionOrchestrator.Refresh(_state.Mode, _state.IsExplicitSession);
     }
 
     /// <summary>
@@ -475,6 +580,10 @@ public sealed class CommandAssistController
         {
             return;
         }
+
+        // The one place a Suggest/Search query reaches the view-model. The pass read it off the
+        // grid, so this is also where the surface catches up with edits no keystroke reported.
+        ViewModel.QueryText = outcome.Query;
 
         if (outcome.Faulted)
         {
@@ -605,6 +714,11 @@ public sealed class CommandAssistController
         _suggestionOrchestrator.CancelPending();
         _state.EnterHelperMode(mode, openPopup);
         ViewModel.ModeLabel = mode.ToString();
+
+        // Help and Fix put their subject in the query field: the command Help was asked about, the
+        // command that failed. That is a caption for content the user asked for, not a claim about
+        // what is on the command line - and Fix in particular is shown *after* the line was
+        // submitted, when there is no command line to be truthful about.
         ViewModel.QueryText = queryText ?? string.Empty;
         ViewModel.IsPopupOpen = openPopup;
         ViewModel.IsVisible = true;

--- a/src/NovaTerminal.CommandAssist/Application/CommandAssistInsertionPlanner.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CommandAssistInsertionPlanner.cs
@@ -1,17 +1,49 @@
 namespace NovaTerminal.CommandAssist.Application;
 
 /// <summary>
-/// Works out the delta the terminal must be sent to turn the text already typed at the prompt into
-/// the selected suggestion.
+/// Works out the delta the terminal must be sent to turn what is already on the command line into
+/// the selected suggestion - or refuses, when the line is not one a suffix can safely be appended
+/// to.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Public for the same reason as <see cref="CommandAssistKeyRouter"/>: the App's
 /// <c>TerminalPane</c> calls it when accepting a suggestion, and it is a pure static function over
-/// strings, so exposing it lets this assembly avoid granting the App <c>InternalsVisibleTo</c>.
+/// values, so exposing it lets this assembly avoid granting the App <c>InternalsVisibleTo</c>.
+/// </para>
+/// <para>
+/// <strong>Insertion stays additive (Phase 1c).</strong> The rule has always been "send only the
+/// characters the suggestion adds" - Command Assist never deletes what the user typed, never moves
+/// the cursor, never rewrites the line. What changed is what the rule is computed against: V1 used
+/// the keystroke mirror, so every edit it could not see produced a delta against a line that did not
+/// exist. Now the input is an <see cref="AssistQuerySnapshot"/> read out of the grid, and the cases
+/// the mirror got wrong are the cases this refuses.
+/// </para>
+/// <para>
+/// <strong>Refusal is a feature.</strong> A refused insertion costs the user one keystroke of
+/// convenience. A wrong one edits their command line - the thing they are about to run. Every
+/// condition below resolves that asymmetry the same way.
+/// </para>
 /// </remarks>
 public static class CommandAssistInsertionPlanner
 {
-    public static bool TryCreateInsertion(string? existingQuery, string? selectedCommand, out string? textToSend)
+    /// <summary>
+    /// Computes the text to send so that the command line becomes <paramref name="selectedCommand"/>,
+    /// or returns <see langword="false"/> if that cannot be done by appending.
+    /// </summary>
+    /// <param name="query">
+    /// The live command line, or <see langword="null"/> when the session is markless or the shell is
+    /// not in its line editor. <see langword="null"/> always refuses: without grid truth there is no
+    /// way to know what is already on the line, and appending a whole command to an unknown prefix
+    /// produces <c>git sgit status</c>. Insertion is a prefix-dependent feature, and degraded mode
+    /// does not offer those.
+    /// </param>
+    /// <param name="selectedCommand">The suggestion the user accepted.</param>
+    /// <param name="textToSend">The suffix to send; <see langword="null"/> on refusal.</param>
+    public static bool TryCreateInsertion(
+        AssistQuerySnapshot? query,
+        string? selectedCommand,
+        out string? textToSend)
     {
         textToSend = null;
 
@@ -20,24 +52,41 @@ public static class CommandAssistInsertionPlanner
             return false;
         }
 
-        string query = existingQuery ?? string.Empty;
-        if (query.Length == 0)
+        if (query is not AssistQuerySnapshot line)
         {
+            return false;
+        }
+
+        // The three ways a snapshot fails to be a typed prefix - cursor mid-line, multiline entry,
+        // trimmed right prompt - are spelled out on AssistQuerySnapshot.IsUsableAsTypedPrefix. Each
+        // one breaks the append in its own way: the cursor decides where sent text lands, a
+        // continuation prompt is text in the snapshot the user never typed, and a trimmed right
+        // prompt means the tail of the line is the reader's inference rather than an observation.
+        if (!line.IsUsableAsTypedPrefix)
+        {
+            return false;
+        }
+
+        string text = line.Text;
+        if (text.Length == 0)
+        {
+            // An empty line is a fact here, not an absence of one: the grid was read and the line
+            // is empty. Sending the whole command is exactly right.
             textToSend = selectedCommand;
             return true;
         }
 
-        if (!selectedCommand.StartsWith(query, System.StringComparison.Ordinal))
+        if (!selectedCommand.StartsWith(text, System.StringComparison.Ordinal))
         {
             return false;
         }
 
-        if (selectedCommand.Length == query.Length)
+        if (selectedCommand.Length == text.Length)
         {
             return false;
         }
 
-        textToSend = selectedCommand[query.Length..];
+        textToSend = selectedCommand[text.Length..];
         return true;
     }
 }

--- a/src/NovaTerminal.CommandAssist/Application/SuggestionOrchestrator.cs
+++ b/src/NovaTerminal.CommandAssist/Application/SuggestionOrchestrator.cs
@@ -8,22 +8,39 @@ using NovaTerminal.CommandAssist.Models;
 namespace NovaTerminal.CommandAssist.Application;
 
 /// <summary>
-/// Turns "the query changed" into a ranked list: resolves which sources are in scope for the current
-/// session, fetches candidates off the UI thread, ranks them with the one suggestion engine, and
-/// hands the result back through the dispatcher - unless a newer pass has superseded it.
+/// Turns "something happened at the prompt" into a ranked list: reads the query out of the terminal
+/// grid, resolves which sources are in scope for the current session, fetches candidates off the UI
+/// thread, ranks them with the one suggestion engine, and hands the result back through the
+/// dispatcher - unless a newer pass has superseded it.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Staleness is handled with a <see cref="CancellationTokenSource"/> per pass: queueing a refresh
-/// cancels the one before it, and an outcome whose token is cancelled is dropped instead of applied.
-/// This replaces the interlocked <c>_refreshVersion</c> counter that used to serve the same purpose;
-/// the behavior is identical, but the mechanism is one Phase 3 can hang a debounce off and Phase 1
-/// can thread into the stores. Note that the token is deliberately <em>not</em> passed to the store
-/// or engine calls yet: cancelling work already in flight is a behavior change, and this pass is a
-/// mechanism swap only.
+/// <strong>The pass owns the query (Phase 1c).</strong> Callers no longer hand one in; they say
+/// "refresh" and the pass resolves the query itself, from
+/// <see cref="AssistSessionContext.IsAcceptingCommandInput"/> plus the grid provider. A keystroke is
+/// a <em>trigger</em>, not a source: what the user typed is already on screen, and the screen also
+/// knows about the arrow keys, the <c>Ctrl+U</c>, the history recall and the Tab completion that no
+/// keystroke mirror ever saw.
 /// </para>
 /// <para>
-/// There is no debounce here. Phase 3 owns that policy decision.
+/// <strong>Why the read happens here and not at the keystroke.</strong> The buffer's write lock is
+/// taken per written character, so a read racing a prompt repaint (<c>\r</c>, erase-to-end, reprint)
+/// can legitimately observe a half-erased line. Reading inside the pass puts the read behind the
+/// queue hop the refresh already makes, and the per-pass cancellation below means that when several
+/// keystrokes arrive together only the last pass's read is applied. That is coalescing by
+/// supersession, not by timing: there is deliberately no debounce here, because a debounce is a
+/// policy decision and Phase 3 owns it.
+/// </para>
+/// <para>
+/// The remaining window is honest and small: a pass whose read beats the shell's echo of the last
+/// character ranks a one-character-stale query until the next trigger. Phase 3's debounce closes it.
+/// </para>
+/// <para>
+/// Staleness is handled with a <see cref="CancellationTokenSource"/> per pass: queueing a refresh
+/// cancels the one before it, and an outcome whose token is cancelled is dropped instead of applied.
+/// This replaces the interlocked <c>_refreshVersion</c> counter that used to serve the same purpose.
+/// Note that the token is deliberately <em>not</em> passed to the store or engine calls yet:
+/// cancelling work already in flight is a behavior change Phase 0c did not want to make.
 /// </para>
 /// </remarks>
 internal sealed class SuggestionOrchestrator
@@ -49,6 +66,7 @@ internal sealed class SuggestionOrchestrator
     private readonly ISnippetStore? _snippetStore;
     private readonly ISuggestionEngine _suggestionEngine;
     private readonly AssistSessionContext _context;
+    private readonly Func<AssistQuerySnapshot?> _queryProvider;
     private readonly Action<Action> _dispatch;
     private readonly Action<SuggestionRefreshOutcome> _applyOutcome;
 
@@ -59,6 +77,7 @@ internal sealed class SuggestionOrchestrator
         ISnippetStore? snippetStore,
         ISuggestionEngine suggestionEngine,
         AssistSessionContext context,
+        Func<AssistQuerySnapshot?> queryProvider,
         Action<Action> dispatch,
         Action<SuggestionRefreshOutcome> applyOutcome)
     {
@@ -66,29 +85,50 @@ internal sealed class SuggestionOrchestrator
         _snippetStore = snippetStore;
         _suggestionEngine = suggestionEngine;
         _context = context;
+        _queryProvider = queryProvider;
         _dispatch = dispatch;
         _applyOutcome = applyOutcome;
     }
 
     /// <summary>
-    /// Queues a ranking pass for <paramref name="query"/>, superseding any pass still in flight.
-    /// Returns immediately; the outcome arrives through the dispatcher.
+    /// Queues a ranking pass, superseding any pass still in flight. Returns immediately; the pass
+    /// resolves its own query and the outcome arrives through the dispatcher.
     /// </summary>
-    public void Refresh(CommandAssistMode requestedMode, bool isExplicitSession, string query)
+    public void Refresh(CommandAssistMode requestedMode, bool isExplicitSession)
     {
         CancellationToken token = BeginPass();
         SuggestionScope scope = ResolveScope(requestedMode, isExplicitSession);
-        var queryContext = new CommandAssistQueryContext(
-            query,
-            _context.WorkingDirectory,
-            _context.ShellKind,
-            _context.ProfileId,
-            _context.IsRemote,
-            IncludeHistorySuggestions: scope.IncludeHistory,
-            IncludeSnippetSuggestions: scope.IncludeSnippets,
-            IncludePathSuggestions: scope.IncludePaths);
+        _ = RunPassAsync(scope, requestedMode, token);
+    }
 
-        _ = RunPassAsync(query, queryContext, requestedMode, token);
+    /// <summary>
+    /// Reads the live command line, or returns <see langword="null"/> when there is nothing
+    /// truthful to read.
+    /// </summary>
+    /// <remarks>
+    /// Two conditions, and both are necessary. The lifecycle gate says the shell is in its line
+    /// editor; the provider says the grid can actually be walked from the mark to the cursor. Either
+    /// one alone is insufficient - the gate can be open while the mark has aged out of scrollback,
+    /// and the provider is happy to walk a mark that describes a command that finished running two
+    /// minutes ago.
+    /// </remarks>
+    public AssistQuerySnapshot? TryReadQuery()
+    {
+        if (!_context.IsAcceptingCommandInput || _context.IsAltScreenActive)
+        {
+            return null;
+        }
+
+        try
+        {
+            return _queryProvider();
+        }
+        catch
+        {
+            // The provider reaches across into the terminal buffer. A read that throws is a read
+            // that produced no truth, which is the same answer as no mark at all.
+            return null;
+        }
     }
 
     /// <summary>
@@ -119,15 +159,35 @@ internal sealed class SuggestionOrchestrator
     }
 
     private async Task RunPassAsync(
-        string query,
-        CommandAssistQueryContext queryContext,
+        SuggestionScope scope,
         CommandAssistMode requestedMode,
         CancellationToken token)
     {
+        // The query is resolved *inside* the worker, not here. Refresh() is called straight off the
+        // keystroke, so anything before the Task.Run boundary still runs on the caller's thread -
+        // which is exactly the mid-repaint read this design exists to avoid. Recorded outside the
+        // lambda so the catch below and the outcome can both see whatever the pass managed to read.
+        string query = string.Empty;
+
         try
         {
             IReadOnlyList<AssistSuggestion> suggestions = await Task.Run(async () =>
             {
+                // In a markless session this stays empty: degraded mode has no query, so an
+                // explicit Search falls back to the recency list and everything prefix-dependent
+                // finds nothing to work with. That is the intent, not a gap.
+                query = TryReadQuery()?.Text ?? string.Empty;
+
+                var queryContext = new CommandAssistQueryContext(
+                    query,
+                    _context.WorkingDirectory,
+                    _context.ShellKind,
+                    _context.ProfileId,
+                    _context.IsRemote,
+                    IncludeHistorySuggestions: scope.IncludeHistory,
+                    IncludeSnippetSuggestions: scope.IncludeSnippets,
+                    IncludePathSuggestions: scope.IncludePaths);
+
                 IReadOnlyList<CommandHistoryEntry> history = Array.Empty<CommandHistoryEntry>();
                 if (queryContext.IncludeHistorySuggestions)
                 {
@@ -145,12 +205,12 @@ internal sealed class SuggestionOrchestrator
                 return _suggestionEngine.GetSuggestions(history, snippets, queryContext, MaxDisplayedSuggestions);
             }).ConfigureAwait(false);
 
-            Publish(new SuggestionRefreshOutcome(requestedMode, suggestions, Faulted: false), token);
+            Publish(new SuggestionRefreshOutcome(requestedMode, query, suggestions, Faulted: false), token);
         }
         catch
         {
             Publish(
-                new SuggestionRefreshOutcome(requestedMode, Array.Empty<AssistSuggestion>(), Faulted: true),
+                new SuggestionRefreshOutcome(requestedMode, query, Array.Empty<AssistSuggestion>(), Faulted: true),
                 token);
         }
     }
@@ -175,6 +235,14 @@ internal sealed class SuggestionOrchestrator
     /// History search is history-only. An explicit Suggest session gets everything. A passive Suggest
     /// bubble - one the user never asked for - gets paths only: unasked-for history rows were the
     /// noisiest part of V1. Help and Fix rank nothing.
+    /// <para>
+    /// Scope is a question about the session, not about the query, so a markless session resolves the
+    /// same scopes as an instrumented one. What differs is what the sources do with an empty query:
+    /// history returns the recency list (which is what makes explicit <c>Ctrl+R</c> still worth
+    /// opening in a degraded session) and the path provider returns nothing, because it needs a
+    /// command token and a path-shaped fragment to work from. Degraded passive suggestions are
+    /// therefore empty by construction rather than by a special case.
+    /// </para>
     /// </remarks>
     private static SuggestionScope ResolveScope(CommandAssistMode requestedMode, bool isExplicitSession)
     {

--- a/src/NovaTerminal.CommandAssist/Application/SuggestionRefreshOutcome.cs
+++ b/src/NovaTerminal.CommandAssist/Application/SuggestionRefreshOutcome.cs
@@ -11,6 +11,12 @@ namespace NovaTerminal.CommandAssist.Application;
 /// a different mode since - a Help popup must not be overwritten by a Suggest pass that was already
 /// in flight when it opened.
 /// </param>
+/// <param name="Query">
+/// The query the pass actually ranked. Carried back rather than read from the view-model because as
+/// of Phase 1c the pass resolves its own query - it reads the grid when the pass runs, not when the
+/// keystroke that triggered it arrived - so the controller has no other way to know what the rows on
+/// screen are rows *for*. This is what the view-model's <c>QueryText</c> is set from.
+/// </param>
 /// <param name="Suggestions">The ranked rows; empty when the pass failed.</param>
 /// <param name="Faulted">
 /// True when the candidate fetch or the ranking threw. The surface is cleared rather than left
@@ -18,5 +24,6 @@ namespace NovaTerminal.CommandAssist.Application;
 /// </param>
 internal readonly record struct SuggestionRefreshOutcome(
     CommandAssistMode RequestedMode,
+    string Query,
     IReadOnlyList<AssistSuggestion> Suggestions,
     bool Faulted);

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistControllerTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistControllerTests.cs
@@ -82,11 +82,13 @@ public sealed class CommandAssistControllerTests
             [new CommandHelpItem("git checkout", "git checkout <branch>", "Switch branches.", "bash", ["Doc"])]);
         var recipeProvider = new RecordingRecipeProvider(
             [new CommandHelpItem("git recipe", "git status --short", "Show concise status.", "bash", ["Recipe"])]);
+        var grid = new FakeGrid();
         var controller = CreateController(
             suggestionEngine: new CommandAssistSuggestionEngine(),
             commandDocsProvider: docsProvider,
-            recipeProvider: recipeProvider);
-        controller.HandleTextInput("git checkout");
+            recipeProvider: recipeProvider,
+            grid: grid);
+        grid.SetLine("git checkout");
 
         bool opened = await controller.OpenHelpAsync();
 
@@ -236,28 +238,31 @@ public sealed class CommandAssistControllerTests
     }
 
     [Fact]
-    public void HandleTextInput_WhenHistoryExistsAndAssistNotExplicit_DoesNotShowHistorySuggestions()
+    public async Task Typing_WhenHistoryExistsAndAssistNotExplicit_DoesNotShowHistorySuggestions()
     {
         var historyStore = new InMemoryHistoryStore();
         historyStore.Seed(
             CreateEntry("git status"),
             CreateEntry("dotnet test"));
 
+        var grid = new FakeGrid();
         var controller = CreateController(
             historyStore: historyStore,
             snippetStore: null,
-            suggestionEngine: new CommandAssistSuggestionEngine());
+            suggestionEngine: new CommandAssistSuggestionEngine(),
+            grid: grid);
 
-        controller.HandleTextInput("git ");
+        grid.SetLine("git ");
+        controller.NotifyInputActivity();
+        await WaitForConditionAsync(() => controller.ViewModel.QueryText == "git ");
 
-        Assert.Equal("git ", controller.ViewModel.QueryText);
         Assert.False(controller.ViewModel.HasSuggestions);
         Assert.Equal(string.Empty, controller.ViewModel.TopSuggestionText);
         Assert.Empty(controller.Suggestions);
     }
 
     [Fact]
-    public void HandleTextInput_WhenSnippetExistsAndAssistNotExplicit_DoesNotShowSnippetSuggestions()
+    public async Task Typing_WhenSnippetExistsAndAssistNotExplicit_DoesNotShowSnippetSuggestions()
     {
         var snippetStore = new InMemorySnippetStore();
         snippetStore.Seed(new CommandSnippet(
@@ -271,12 +276,16 @@ public sealed class CommandAssistControllerTests
             CreatedAt: DateTimeOffset.Parse("2026-03-01T09:00:00+00:00"),
             LastUsedAt: DateTimeOffset.Parse("2026-03-01T09:30:00+00:00")));
 
+        var grid = new FakeGrid();
         var controller = CreateController(
             historyStore: new InMemoryHistoryStore(),
             snippetStore: snippetStore,
-            suggestionEngine: new CommandAssistSuggestionEngine());
+            suggestionEngine: new CommandAssistSuggestionEngine(),
+            grid: grid);
 
-        controller.HandleTextInput("git st");
+        grid.SetLine("git st");
+        controller.NotifyInputActivity();
+        await WaitForConditionAsync(() => controller.ViewModel.QueryText == "git st");
 
         Assert.False(controller.ViewModel.HasSuggestions);
         Assert.Equal(string.Empty, controller.ViewModel.TopSuggestionText);
@@ -284,17 +293,19 @@ public sealed class CommandAssistControllerTests
     }
 
     [Fact]
-    public async Task HandleTextInput_WhenAssistIsExplicit_UpdatesQueryAndTopSuggestion()
+    public async Task Typing_WhenAssistIsExplicit_UpdatesQueryAndTopSuggestion()
     {
         var historyStore = new InMemoryHistoryStore();
         historyStore.Seed(
             CreateEntry("git status"),
             CreateEntry("dotnet test"));
 
-        var controller = CreateController(historyStore);
+        var grid = new FakeGrid();
+        var controller = CreateController(historyStore, grid: grid);
         controller.ToggleAssist();
 
-        controller.HandleTextInput("git ");
+        grid.SetLine("git ");
+        controller.NotifyInputActivity();
         await historyStore.WaitForSearchSettledAsync();
         await WaitForConditionAsync(() => controller.ViewModel.TopSuggestionText == "git status");
 
@@ -305,13 +316,15 @@ public sealed class CommandAssistControllerTests
     }
 
     [Fact]
-    public void HandleTextInput_WhenNoSuggestionsExist_HidesSuggestBubble()
+    public async Task Typing_WhenNoSuggestionsExist_HidesSuggestBubble()
     {
-        var controller = CreateController(new InMemoryHistoryStore());
+        var grid = new FakeGrid();
+        var controller = CreateController(new InMemoryHistoryStore(), grid: grid);
 
-        controller.HandleTextInput("zzzz");
+        grid.SetLine("zzzz");
+        controller.NotifyInputActivity();
+        await WaitForConditionAsync(() => controller.ViewModel.QueryText == "zzzz");
 
-        Assert.Equal("zzzz", controller.ViewModel.QueryText);
         Assert.False(controller.ViewModel.HasSuggestions);
         Assert.False(controller.ViewModel.IsVisible);
         Assert.False(controller.ViewModel.Bubble.IsVisible);
@@ -319,12 +332,14 @@ public sealed class CommandAssistControllerTests
     }
 
     [Fact]
-    public async Task HandleTextInput_WhenNoSuggestionsExist_DoesNotFlashVisibleBeforeRefreshCompletes()
+    public async Task Typing_WhenNoSuggestionsExist_DoesNotFlashVisibleBeforeRefreshCompletes()
     {
         var historyStore = new DelayedHistoryStore(TimeSpan.FromMilliseconds(250));
-        var controller = CreateController(historyStore);
+        var grid = new FakeGrid();
+        var controller = CreateController(historyStore, grid: grid);
 
-        controller.HandleTextInput("zzzz");
+        grid.SetLine("zzzz");
+        controller.NotifyInputActivity();
 
         Assert.False(controller.ViewModel.IsVisible);
         Assert.False(controller.ViewModel.Bubble.IsVisible);
@@ -339,9 +354,8 @@ public sealed class CommandAssistControllerTests
     {
         var historyStore = new InMemoryHistoryStore();
         var controller = CreateController(historyStore);
-        controller.HandleTextInput("gh auth login --password hunter2");
 
-        await controller.HandleEnterAsync();
+        await controller.HandleEnterAsync("gh auth login --password hunter2");
 
         Assert.Single(historyStore.Entries);
         Assert.Equal("gh auth login --password [REDACTED]", historyStore.Entries[0].CommandText);
@@ -349,15 +363,36 @@ public sealed class CommandAssistControllerTests
         Assert.Equal(string.Empty, controller.ViewModel.QueryText);
     }
 
+    /// <summary>
+    /// The submission the host read off the grid can legitimately be multiline - a continuation
+    /// entry is one command line - and capture still refuses it. Phase 1c did not relax this: a
+    /// multiline grid read contains continuation-prompt cells the user never typed, so persisting
+    /// it would put the shell's own decoration into history.
+    /// </summary>
     [Fact]
     public async Task HandleEnterAsync_DoesNotPersistMultiLineScriptLikeInput()
     {
         var historyStore = new InMemoryHistoryStore();
         var controller = CreateController(historyStore);
-        controller.HandleTextInput("echo one");
-        controller.HandlePastedText("echo one\necho two");
 
-        await controller.HandleEnterAsync();
+        await controller.HandleEnterAsync("echo one\necho two");
+
+        Assert.Empty(historyStore.Entries);
+    }
+
+    /// <summary>
+    /// A markless session has no grid to read at Enter, so it captures nothing. This is the
+    /// deliberate cost of deleting the shadow buffer: V1 captured whatever its keystroke mirror
+    /// held, which for any line the user had edited with keys the mirror could not see was a
+    /// command they never ran. Nothing is recoverable; wrong is not.
+    /// </summary>
+    [Fact]
+    public async Task HandleEnterAsync_InADegradedSession_CapturesNothing()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        var controller = CreateController(historyStore);
+
+        await controller.HandleEnterAsync(submittedText: null);
 
         Assert.Empty(historyStore.Entries);
     }
@@ -371,9 +406,11 @@ public sealed class CommandAssistControllerTests
     {
         var historyStore = new InMemoryHistoryStore();
         var controller = CreateController(historyStore);
-        controller.HandlePastedText("git status");
+        controller.NotifyPastedInput();
 
-        await controller.HandleEnterAsync();
+        // The grid can read pasted text perfectly well, so the submission text here is real; what
+        // rejects it is provenance, which is the only thing paste handling still carries.
+        await controller.HandleEnterAsync("git status");
 
         Assert.Empty(historyStore.Entries);
     }
@@ -401,11 +438,14 @@ public sealed class CommandAssistControllerTests
                     LastUsedAt: null,
                     ExitCode: 0)
             });
+        var grid = new FakeGrid();
         var controller = CreateController(
             historyStore: new InMemoryHistoryStore(),
-            suggestionEngine: suggestionEngine);
+            suggestionEngine: suggestionEngine,
+            grid: grid);
 
-        controller.HandlePastedText("git stat");
+        grid.SetLine("git stat");
+        controller.NotifyPastedInput();
         await WaitForConditionAsync(() => controller.Suggestions.Count > 0);
 
         // A row is selected, so a false return can only come from the suppression flag.
@@ -427,19 +467,22 @@ public sealed class CommandAssistControllerTests
     {
         var historyStore = new InMemoryHistoryStore();
         historyStore.Seed(CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")));
-        var controller = CreateController(historyStore);
+        var grid = new FakeGrid();
+        var controller = CreateController(historyStore, grid: grid);
 
         controller.OpenHistorySearch();
         await historyStore.WaitForSearchSettledAsync();
 
-        await controller.HandleEnterAsync();
+        await controller.HandleEnterAsync("git status");
         int searchesAfterSubmission = historyStore.SearchCount;
 
-        // Follow-up interactions that refresh with a non-empty buffer. Search or explicit-Suggest
-        // scope would reach for history; the passive path-only scope this submission normalized
-        // back to must not.
-        controller.HandleTextInput("git st");
-        controller.HandleBackspace();
+        // Follow-up interactions that refresh with a non-empty command line. Search or
+        // explicit-Suggest scope would reach for history; the passive path-only scope this
+        // submission normalized back to must not.
+        grid.SetLine("git st");
+        controller.NotifyInputActivity();
+        grid.SetLine("git s");
+        controller.NotifyInputActivity();
         await historyStore.WaitForSearchSettledAsync();
 
         Assert.Equal(searchesAfterSubmission, historyStore.SearchCount);
@@ -451,34 +494,35 @@ public sealed class CommandAssistControllerTests
     public async Task HandleEnterAsync_WhenHistoryStoreThrows_DoesNotPropagate()
     {
         var controller = CreateController(new ThrowingHistoryStore());
-        controller.HandleTextInput("git status");
 
-        await controller.HandleEnterAsync();
+        await controller.HandleEnterAsync("git status");
 
         Assert.Equal(string.Empty, controller.ViewModel.QueryText);
         Assert.False(controller.ViewModel.IsVisible);
     }
 
     [Fact]
-    public async Task HandleTextInput_DoesNotBlockWhileHistorySearchIsPending()
+    public async Task Typing_DoesNotBlockWhileHistorySearchIsPending()
     {
         var historyStore = new DelayedHistoryStore(TimeSpan.FromMilliseconds(250), CreateEntry("git status"));
-        var controller = CreateController(historyStore);
-        var stopwatch = Stopwatch.StartNew();
+        var grid = new FakeGrid();
+        var controller = CreateController(historyStore, grid: grid);
         controller.ToggleAssist();
+        grid.SetLine("git");
+        var stopwatch = Stopwatch.StartNew();
 
-        controller.HandleTextInput("git");
+        controller.NotifyInputActivity();
 
         stopwatch.Stop();
 
-        Assert.True(stopwatch.ElapsedMilliseconds < 100, $"HandleTextInput blocked for {stopwatch.ElapsedMilliseconds}ms");
-        Assert.Equal("git", controller.ViewModel.QueryText);
+        Assert.True(stopwatch.ElapsedMilliseconds < 100, $"NotifyInputActivity blocked for {stopwatch.ElapsedMilliseconds}ms");
 
         await historyStore.WaitForLastSearchAsync();
+        await WaitForConditionAsync(() => controller.ViewModel.QueryText == "git");
     }
 
     [Fact]
-    public async Task HandleTextInput_DoesNotBlockWhileSuggestionEngineIsSlow()
+    public async Task Typing_DoesNotBlockWhileSuggestionEngineIsSlow()
     {
         var suggestionEngine = new DelayedSuggestionEngine(
             delay: TimeSpan.FromMilliseconds(250),
@@ -496,19 +540,21 @@ public sealed class CommandAssistControllerTests
                     LastUsedAt: null,
                     ExitCode: null)
             });
+        var grid = new FakeGrid();
         var controller = CreateController(
             historyStore: new InMemoryHistoryStore(),
-            suggestionEngine: suggestionEngine);
+            suggestionEngine: suggestionEngine,
+            grid: grid);
+        grid.SetLine("cd ./d");
         var stopwatch = Stopwatch.StartNew();
 
-        controller.HandleTextInput("cd ./d");
+        controller.NotifyInputActivity();
 
         stopwatch.Stop();
 
-        Assert.True(stopwatch.ElapsedMilliseconds < 100, $"HandleTextInput blocked for {stopwatch.ElapsedMilliseconds}ms");
-        Assert.Equal("cd ./d", controller.ViewModel.QueryText);
+        Assert.True(stopwatch.ElapsedMilliseconds < 100, $"NotifyInputActivity blocked for {stopwatch.ElapsedMilliseconds}ms");
 
-        await Task.Delay(350);
+        await WaitForConditionAsync(() => controller.ViewModel.QueryText == "cd ./d", timeoutMs: 2000);
     }
 
     [Fact]
@@ -519,9 +565,11 @@ public sealed class CommandAssistControllerTests
             CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")),
             CreateEntry("git stash", DateTimeOffset.Parse("2026-03-01T09:59:00+00:00")));
 
-        var controller = CreateController(historyStore);
+        var grid = new FakeGrid();
+        var controller = CreateController(historyStore, grid: grid);
         controller.OpenHistorySearch();
-        controller.HandleTextInput("git st");
+        grid.SetLine("git st");
+        controller.NotifyInputActivity();
         await historyStore.WaitForSearchSettledAsync();
         await WaitForConditionAsync(() => controller.Suggestions.Count > 1 &&
                                           controller.ViewModel.TopSuggestionText == "git status");
@@ -554,9 +602,11 @@ public sealed class CommandAssistControllerTests
             CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")),
             CreateEntry("git stash", DateTimeOffset.Parse("2026-03-01T09:59:00+00:00")));
 
-        var controller = CreateController(historyStore);
+        var grid = new FakeGrid();
+        var controller = CreateController(historyStore, grid: grid);
         controller.ToggleAssist();
-        controller.HandleTextInput("git st");
+        grid.SetLine("git st");
+        controller.NotifyInputActivity();
         await historyStore.WaitForSearchSettledAsync();
         await WaitForConditionAsync(() => controller.Suggestions.Count > 1 &&
                                           controller.ViewModel.TopSuggestionText == "git status");
@@ -573,9 +623,8 @@ public sealed class CommandAssistControllerTests
     {
         var historyStore = new InMemoryHistoryStore();
         var controller = CreateController(historyStore);
-        controller.HandleTextInput("git status");
 
-        await controller.HandleEnterAsync();
+        await controller.HandleEnterAsync("git status");
         await controller.HandleCommandFinishedAsync(23);
 
         Assert.Single(historyStore.Entries);
@@ -616,9 +665,8 @@ public sealed class CommandAssistControllerTests
             WorkingDirectory: @"C:\repo",
             ExitCode: null,
             Duration: null));
-        controller.HandleTextInput("git status");
 
-        await controller.HandleEnterAsync();
+        await controller.HandleEnterAsync("git status");
 
         Assert.Single(historyStore.Entries);
         Assert.Equal(CommandCaptureSource.ShellIntegration, historyStore.Entries[0].Source);
@@ -637,9 +685,8 @@ public sealed class CommandAssistControllerTests
             WorkingDirectory: @"C:\repo",
             ExitCode: null,
             Duration: null));
-        controller.HandleTextInput("git status");
 
-        await controller.HandleEnterAsync();
+        await controller.HandleEnterAsync("git status");
 
         Assert.Single(historyStore.Entries);
         Assert.Equal(CommandCaptureSource.Heuristic, historyStore.Entries[0].Source);
@@ -724,9 +771,8 @@ public sealed class CommandAssistControllerTests
         var historyStore = new InMemoryHistoryStore();
         var controller = CreateController(historyStore);
         controller.SetShellIntegrationEnabled(true);
-        controller.HandleTextInput("git status");
 
-        await controller.HandleEnterAsync();
+        await controller.HandleEnterAsync("git status");
         await controller.HandleShellIntegrationEventAsync(new ShellIntegrationEvent(
             Type: ShellIntegrationEventType.CommandAccepted,
             Timestamp: DateTimeOffset.Parse("2026-03-09T12:00:00+00:00"),
@@ -835,16 +881,15 @@ public sealed class CommandAssistControllerTests
             hostId: null,
             isRemote: false,
             isShellIntegrated: true);
-        controller.HandleTextInput("git status");
 
-        await controller.HandleEnterAsync();
+        await controller.HandleEnterAsync("git status");
 
         Assert.Single(historyStore.Entries);
         Assert.Equal(CommandCaptureSource.ShellIntegration, historyStore.Entries[0].Source);
     }
 
     [Fact]
-    public async Task HandleTextInput_WhenPinnedSnippetMatches_ShowsSnippetAsTopSuggestion()
+    public async Task Typing_WhenPinnedSnippetMatches_ShowsSnippetAsTopSuggestion()
     {
         var historyStore = new InMemoryHistoryStore();
         historyStore.Seed(CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")));
@@ -860,9 +905,11 @@ public sealed class CommandAssistControllerTests
             CreatedAt: DateTimeOffset.Parse("2026-03-01T09:00:00+00:00"),
             LastUsedAt: DateTimeOffset.Parse("2026-03-01T09:30:00+00:00")));
 
-        var controller = CreateController(historyStore, snippetStore, new CommandAssistSuggestionEngine());
+        var grid = new FakeGrid();
+        var controller = CreateController(historyStore, snippetStore, new CommandAssistSuggestionEngine(), grid: grid);
         controller.ToggleAssist();
-        controller.HandleTextInput("git st");
+        grid.SetLine("git st");
+        controller.NotifyInputActivity();
 
         await historyStore.WaitForSearchSettledAsync();
         await snippetStore.WaitForReadAsync();
@@ -880,9 +927,11 @@ public sealed class CommandAssistControllerTests
         var historyStore = new InMemoryHistoryStore();
         historyStore.Seed(CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")));
         var snippetStore = new InMemorySnippetStore();
-        var controller = CreateController(historyStore, snippetStore, new CommandAssistSuggestionEngine());
+        var grid = new FakeGrid();
+        var controller = CreateController(historyStore, snippetStore, new CommandAssistSuggestionEngine(), grid: grid);
         controller.ToggleAssist();
-        controller.HandleTextInput("git st");
+        grid.SetLine("git st");
+        controller.NotifyInputActivity();
 
         await historyStore.WaitForSearchSettledAsync();
         await snippetStore.WaitForReadAsync();
@@ -932,9 +981,11 @@ public sealed class CommandAssistControllerTests
             CreatedAt: DateTimeOffset.Parse("2026-03-01T09:00:00+00:00"),
             LastUsedAt: DateTimeOffset.Parse("2026-03-01T09:30:00+00:00")));
 
-        var controller = CreateController(historyStore, snippetStore, new CommandAssistSuggestionEngine());
+        var grid = new FakeGrid();
+        var controller = CreateController(historyStore, snippetStore, new CommandAssistSuggestionEngine(), grid: grid);
         controller.ToggleAssist();
-        controller.HandleTextInput("git st");
+        grid.SetLine("git st");
+        controller.NotifyInputActivity();
         await historyStore.WaitForSearchSettledAsync();
         await snippetStore.WaitForReadAsync();
         await WaitForConditionAsync(() => controller.ViewModel.TopSuggestionText == "Git Status" &&
@@ -954,7 +1005,8 @@ public sealed class CommandAssistControllerTests
         ISuggestionEngine? suggestionEngine = null,
         ICommandDocsProvider? commandDocsProvider = null,
         IRecipeProvider? recipeProvider = null,
-        IErrorInsightService? errorInsightService = null)
+        IErrorInsightService? errorInsightService = null,
+        FakeGrid? grid = null)
     {
         historyStore ??= new InMemoryHistoryStore();
         var filter = new SecretsFilter();
@@ -965,7 +1017,7 @@ public sealed class CommandAssistControllerTests
         // still pass a real CommandAssistSuggestionEngine explicitly.
         var engine = suggestionEngine ?? new CommandAssistSuggestionEngine(new NoPathSuggestionProvider());
 
-        return new CommandAssistController(
+        var controller = new CommandAssistController(
             historyStore,
             filter,
             engine,
@@ -974,7 +1026,78 @@ public sealed class CommandAssistControllerTests
             recipeProvider,
             errorInsightService,
             modeRouter: null,
-            resultBuilder: null);
+            resultBuilder: null,
+            queryProvider: grid == null ? null : grid.Read);
+
+        if (grid != null)
+        {
+            // A controller handed a grid is standing in for an instrumented session sitting at its
+            // prompt, so open the lifecycle gate once here rather than in twenty tests. The gate's
+            // own behavior - that it opens on B, closes on C and D, and that a closed gate means no
+            // query no matter what the grid says - is what CommandAssistGridTruthTests is for.
+            grid.OpenPrompt(controller);
+        }
+
+        return controller;
+    }
+
+    /// <summary>
+    /// Stands in for the terminal grid behind the App's provider seam.
+    /// </summary>
+    /// <remarks>
+    /// Tests set the whole line rather than appending to it, which is the point of the Phase 1c
+    /// model: the grid does not know or care whether the line got there by typing, by
+    /// <c>Ctrl+U</c> then retyping, by an Up-arrow history recall or by the shell's own Tab
+    /// completion. Every one of those is "the line is now this".
+    /// </remarks>
+    private sealed class FakeGrid
+    {
+        // Locked rather than volatile because the real provider is read from the refresh pass's
+        // worker thread, not from the thread that set the line.
+        private readonly object _gate = new();
+        private AssistQuerySnapshot? _snapshot;
+
+        public AssistQuerySnapshot? Read()
+        {
+            lock (_gate)
+            {
+                return _snapshot;
+            }
+        }
+
+        public void SetLine(
+            string text,
+            int? cursorOffset = null,
+            bool isMultiline = false,
+            bool rightPromptTrimmed = false)
+        {
+            lock (_gate)
+            {
+                _snapshot = new AssistQuerySnapshot(text, cursorOffset ?? text.Length, isMultiline, rightPromptTrimmed);
+            }
+        }
+
+        /// <summary>The mark went away: scrollback reset, aged out, or the session ended.</summary>
+        public void GoDark()
+        {
+            lock (_gate)
+            {
+                _snapshot = null;
+            }
+        }
+
+        /// <summary><c>OSC 133;B</c> - the prompt finished printing and the line editor is live.</summary>
+        public void OpenPrompt(CommandAssistController controller)
+        {
+            SetLine(string.Empty);
+            controller.HandleShellIntegrationEventAsync(new ShellIntegrationEvent(
+                Type: ShellIntegrationEventType.CommandStarted,
+                Timestamp: DateTimeOffset.UtcNow,
+                CommandText: null,
+                WorkingDirectory: null,
+                ExitCode: null,
+                Duration: null)).GetAwaiter().GetResult();
+        }
     }
 
     private static CommandFailureContext CreateFailureContext(string commandText, int? exitCode, string? errorOutput)

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistControllerTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistControllerTests.cs
@@ -222,7 +222,10 @@ public sealed class CommandAssistControllerTests
 
         Assert.True(opened);
         Assert.True(controller.ViewModel.IsVisible);
-        Assert.Equal("History", controller.ViewModel.ModeLabel);
+
+        // No grid provider on the default harness, so this is a degraded session and the label says
+        // so - see CommandAssistGridTruthTests for the pair of cases side by side.
+        Assert.Equal("History - recent", controller.ViewModel.ModeLabel);
     }
 
     [Fact]

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistGridTruthTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistGridTruthTests.cs
@@ -1,0 +1,538 @@
+using NovaTerminal.CommandAssist.Application;
+using NovaTerminal.CommandAssist.Domain;
+using NovaTerminal.CommandAssist.Models;
+using NovaTerminal.CommandAssist.ShellIntegration.Contracts;
+
+namespace NovaTerminal.Tests.CommandAssist;
+
+/// <summary>
+/// Phase 1c: the query is read out of the terminal grid, and the shadow keystroke buffer is gone.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Three things are pinned here, and they are the three the design rests on.
+/// </para>
+/// <para>
+/// <strong>The lifecycle gate.</strong> The grid reader cannot tell "the user is typing" from
+/// "this is the command's output"; only the OSC 133 stream can. So consumption is gated on the
+/// window between <c>B</c> and <c>C</c>, and a grid that is perfectly readable outside that window
+/// is still not a query.
+/// </para>
+/// <para>
+/// <strong>Desync immunity.</strong> The V1 shadow buffer mirrored TextInput, Backspace, Enter and
+/// Paste. Arrow keys, <c>Ctrl+U</c>, <c>Ctrl+W</c>, shell history recall and shell-side Tab
+/// completion all edit the line without producing any of those four, so V1's query drifted from
+/// reality and never came back. Here the shell rewrites the line behind the controller's back and
+/// the next refresh simply agrees with it.
+/// </para>
+/// <para>
+/// <strong>Degraded mode.</strong> No marks means no query - not an empty query it might act on,
+/// and not a keystroke mirror kept as a fallback. Prefix-dependent features go quiet; explicit
+/// history search still opens and shows recency.
+/// </para>
+/// </remarks>
+public sealed class CommandAssistGridTruthTests
+{
+    // ---- lifecycle gate ------------------------------------------------------------------
+
+    [Fact]
+    public async Task BeforeAnyPromptMark_TheGridIsNotConsulted()
+    {
+        var harness = Harness.Create();
+        harness.Grid.SetLine("git status");
+
+        harness.Controller.NotifyInputActivity();
+        await harness.SettleAsync();
+
+        Assert.Null(harness.Controller.TryReadQuerySnapshot());
+        Assert.Equal(string.Empty, harness.Controller.ViewModel.QueryText);
+    }
+
+    [Fact]
+    public async Task AfterThePromptMark_TheGridIsTheQuery()
+    {
+        var harness = Harness.Create();
+        await harness.PromptReadyAsync();
+        harness.Grid.SetLine("git status");
+
+        harness.Controller.NotifyInputActivity();
+        await harness.SettleAsync();
+
+        Assert.Equal("git status", harness.Controller.TryReadQuerySnapshot()?.Text);
+        Assert.Equal("git status", harness.Controller.ViewModel.QueryText);
+    }
+
+    /// <summary>
+    /// The gate's whole reason for existing. After <c>OSC 133;C</c> the command is running and the
+    /// cells below the mark are its output - but the mark is deliberately kept across C (the input
+    /// line is still on screen at that instant), so the reader would happily return something. Only
+    /// the lifecycle gate stops it.
+    /// </summary>
+    [Fact]
+    public async Task BetweenCommands_AReadableGridIsStillNotAQuery()
+    {
+        var harness = Harness.Create();
+        await harness.PromptReadyAsync();
+        harness.Grid.SetLine("git status");
+
+        await harness.CommandAcceptedAsync("git status");
+
+        // The provider is still perfectly happy to answer - nothing about the buffer changed.
+        Assert.Equal("git status", harness.Grid.Read()?.Text);
+
+        harness.Controller.NotifyInputActivity();
+        await harness.SettleAsync();
+
+        Assert.Null(harness.Controller.TryReadQuerySnapshot());
+        Assert.Equal(string.Empty, harness.Controller.ViewModel.QueryText);
+    }
+
+    [Fact]
+    public async Task AfterCommandFinished_TheGateIsClosed()
+    {
+        var harness = Harness.Create();
+        await harness.PromptReadyAsync();
+        harness.Grid.SetLine("on branch main");
+
+        await harness.CommandFinishedAsync(exitCode: 0);
+
+        Assert.Null(harness.Controller.TryReadQuerySnapshot());
+    }
+
+    /// <summary>
+    /// A prompt repaint re-emits <c>B</c>, so the window reopens on evidence. This is the path back
+    /// from every closer: next command, alt screen teardown, resize.
+    /// </summary>
+    [Fact]
+    public async Task TheNextPromptReopensTheGate()
+    {
+        var harness = Harness.Create();
+        await harness.PromptReadyAsync();
+        await harness.CommandAcceptedAsync("git status");
+        await harness.CommandFinishedAsync(exitCode: 0);
+
+        await harness.PromptReadyAsync();
+        harness.Grid.SetLine("ls");
+
+        Assert.Equal("ls", harness.Controller.TryReadQuerySnapshot()?.Text);
+    }
+
+    [Fact]
+    public async Task WhileTheAltScreenIsUp_TheGridIsNotConsulted()
+    {
+        var harness = Harness.Create();
+        await harness.PromptReadyAsync();
+        harness.Grid.SetLine("vim notes.txt");
+
+        harness.Controller.HandleAltScreenChanged(true);
+
+        Assert.Null(harness.Controller.TryReadQuerySnapshot());
+    }
+
+    /// <summary>
+    /// Both halves are necessary. The gate can be open while the mark has aged out of scrollback or
+    /// its coordinate generation has been reset, and then there is no truth to read either.
+    /// </summary>
+    [Fact]
+    public async Task WhenTheMarkGoesDarkWithTheGateOpen_ThereIsNoQuery()
+    {
+        var harness = Harness.Create();
+        await harness.PromptReadyAsync();
+        harness.Grid.SetLine("git status");
+        Assert.NotNull(harness.Controller.TryReadQuerySnapshot());
+
+        harness.Grid.GoDark();
+
+        Assert.Null(harness.Controller.TryReadQuerySnapshot());
+    }
+
+    // ---- desync immunity (the V1 failure matrix) -----------------------------------------
+
+    /// <summary>
+    /// <c>Ctrl+U</c> clears the line. V1's mirror never saw it, so its query stayed at whatever had
+    /// been typed and every subsequent ranking and insertion was computed against text that was no
+    /// longer on screen.
+    /// </summary>
+    [Fact]
+    public async Task AfterCtrlU_TheQueryFollowsTheEmptiedLine()
+    {
+        var harness = Harness.Create();
+        await harness.PromptReadyAsync();
+
+        harness.Grid.SetLine("git st");
+        harness.Controller.NotifyInputActivity();
+        await harness.WaitForQueryAsync("git st");
+
+        // Ctrl+U reaches the shell, the shell erases the line, and nothing tells Command Assist.
+        // The next trigger - any trigger - reads the truth.
+        harness.Grid.SetLine(string.Empty);
+        harness.Controller.NotifyInputActivity();
+        await harness.WaitForQueryAsync(string.Empty);
+
+        Assert.Equal(string.Empty, harness.Controller.ViewModel.QueryText);
+    }
+
+    /// <summary>
+    /// Up-arrow history recall replaces the line with a command the user typed no character of.
+    /// V1 ranked against the empty mirror and offered nothing; the grid ranks against the recalled
+    /// command.
+    /// </summary>
+    [Fact]
+    public async Task AfterHistoryRecall_TheQueryIsTheRecalledCommand()
+    {
+        var harness = Harness.Create(seed: new[] { "git status --short", "dotnet test" });
+        await harness.PromptReadyAsync();
+        harness.Controller.ToggleAssist();
+
+        harness.Grid.SetLine("git status");
+        harness.Controller.NotifyInputActivity();
+
+        await harness.WaitForQueryAsync("git status");
+        await harness.WaitForConditionAsync(() => harness.Controller.ViewModel.TopSuggestionText == "git status --short");
+
+        Assert.Equal("git status --short", harness.Controller.ViewModel.TopSuggestionText);
+    }
+
+    /// <summary>
+    /// Shell-side Tab completion. Command Assist deliberately does not own Tab (the shell does), so
+    /// the completion arrives as a line rewrite with no key event attached - the purest form of the
+    /// V1 desync.
+    /// </summary>
+    [Fact]
+    public async Task AfterShellTabCompletion_TheQueryIsTheCompletedWord()
+    {
+        var harness = Harness.Create();
+        await harness.PromptReadyAsync();
+
+        harness.Grid.SetLine("cd src/NovaTerm");
+        harness.Controller.NotifyInputActivity();
+        await harness.WaitForQueryAsync("cd src/NovaTerm");
+
+        harness.Grid.SetLine("cd src/NovaTerminal.CommandAssist/");
+        harness.Controller.NotifyInputActivity();
+        await harness.WaitForQueryAsync("cd src/NovaTerminal.CommandAssist/");
+    }
+
+    /// <summary>
+    /// The whole point, in one assertion: a trigger with no text argument still moves the query,
+    /// because the text was never the trigger's to carry.
+    /// </summary>
+    [Fact]
+    public async Task ATriggerCarriesNoText_AndTheQueryStillFollowsTheGrid()
+    {
+        var harness = Harness.Create();
+        await harness.PromptReadyAsync();
+
+        harness.Grid.SetLine("kubectl get pods");
+        harness.Controller.NotifyInputActivity();
+        await harness.WaitForQueryAsync("kubectl get pods");
+
+        // A backspace, as far as Command Assist is concerned, is the same event as a keypress.
+        harness.Grid.SetLine("kubectl get pod");
+        harness.Controller.NotifyInputActivity();
+        await harness.WaitForQueryAsync("kubectl get pod");
+    }
+
+    // ---- degraded mode -------------------------------------------------------------------
+
+    /// <summary>
+    /// No marks at all: a non-integrated local shell, or an un-instrumented SSH session. Typing
+    /// produces no query, so passive suggestions have nothing to rank.
+    /// </summary>
+    [Fact]
+    public async Task Degraded_TypingProducesNoQueryAndNoPassiveSuggestions()
+    {
+        var harness = Harness.CreateDegraded(seed: new[] { "git status" });
+
+        harness.Controller.NotifyInputActivity();
+        await harness.SettleAsync();
+
+        Assert.Equal(string.Empty, harness.Controller.ViewModel.QueryText);
+        Assert.Empty(harness.Controller.Suggestions);
+        Assert.False(harness.Controller.ViewModel.IsVisible);
+    }
+
+    /// <summary>
+    /// The degraded-mode Search decision: <c>Ctrl+R</c> still opens, and with no query to filter on
+    /// it lists what was run most recently. History is per user, not per session, so a degraded
+    /// session can still browse commands captured in instrumented ones.
+    /// </summary>
+    [Fact]
+    public async Task Degraded_ExplicitHistorySearchShowsTheRecencyList()
+    {
+        var harness = Harness.CreateDegraded(seed: new[] { "dotnet build", "git status" });
+
+        bool opened = harness.Controller.OpenHistorySearch();
+        await harness.WaitForConditionAsync(() => harness.Controller.Suggestions.Count > 0);
+
+        Assert.True(opened);
+        Assert.Equal("History", harness.Controller.ViewModel.ModeLabel);
+        Assert.Equal(string.Empty, harness.Controller.ViewModel.QueryText);
+        Assert.Contains(harness.Controller.Suggestions, s => s.InsertText == "git status");
+        Assert.Contains(harness.Controller.Suggestions, s => s.InsertText == "dotnet build");
+    }
+
+    /// <summary>
+    /// The other half of the degraded-Search decision: you can browse the rows, but nothing may be
+    /// spliced into a command line nobody can see. The planner is what refuses; this pins that the
+    /// controller hands it a null snapshot rather than an empty-string stand-in.
+    /// </summary>
+    [Fact]
+    public async Task Degraded_SelectingAHistoryRowYieldsNoInsertionPlan()
+    {
+        var harness = Harness.CreateDegraded(seed: new[] { "git status" });
+
+        harness.Controller.OpenHistorySearch();
+        await harness.WaitForConditionAsync(() => harness.Controller.Suggestions.Count > 0);
+
+        Assert.True(harness.Controller.TryGetInsertionText(out string? selected));
+        Assert.Equal("git status", selected);
+
+        Assert.Null(harness.Controller.TryReadQuerySnapshot());
+        Assert.False(CommandAssistInsertionPlanner.TryCreateInsertion(
+            harness.Controller.TryReadQuerySnapshot(),
+            selected,
+            out string? textToSend));
+        Assert.Null(textToSend);
+    }
+
+    /// <summary>
+    /// Help in a degraded session gets no command token from a query it does not have - but an
+    /// explicit selection still works, which is the escape hatch that keeps Explain useful there.
+    /// </summary>
+    [Fact]
+    public async Task Degraded_HelpTakesNoTokenFromTheQueryButStillHonoursASelection()
+    {
+        var docsProvider = new RecordingDocsProvider();
+        var harness = Harness.CreateDegraded(docsProvider: docsProvider);
+
+        await harness.Controller.OpenHelpAsync();
+        Assert.Equal(string.Empty, docsProvider.LastQuery?.RawInput);
+        Assert.Null(docsProvider.LastQuery?.CommandToken);
+
+        await harness.Controller.ExplainSelectionAsync("fatal: not a git repository");
+        Assert.Equal("fatal: not a git repository", docsProvider.LastQuery?.SelectedText);
+    }
+
+    /// <summary>
+    /// An instrumented session gets its help token from the grid, not from a view-model field that
+    /// the last ranking pass happened to write.
+    /// </summary>
+    [Fact]
+    public async Task Integrated_HelpTakesItsTokenFromTheGrid()
+    {
+        var docsProvider = new RecordingDocsProvider();
+        var harness = Harness.Create(docsProvider: docsProvider);
+        await harness.PromptReadyAsync();
+        harness.Grid.SetLine("docker compose up");
+
+        await harness.Controller.OpenHelpAsync();
+
+        Assert.Equal("docker compose up", docsProvider.LastQuery?.RawInput);
+        Assert.Equal("docker", docsProvider.LastQuery?.CommandToken);
+    }
+
+    // ---- harness -------------------------------------------------------------------------
+
+    private sealed class Harness
+    {
+        private Harness(CommandAssistController controller, FakeGrid grid, InMemoryHistoryStore history)
+        {
+            Controller = controller;
+            Grid = grid;
+            History = history;
+        }
+
+        public CommandAssistController Controller { get; }
+
+        public FakeGrid Grid { get; }
+
+        public InMemoryHistoryStore History { get; }
+
+        public static Harness Create(string[]? seed = null, ICommandDocsProvider? docsProvider = null)
+            => Build(new FakeGrid(), seed, docsProvider);
+
+        /// <summary>A session with no OSC 133 marks: the provider never returns anything.</summary>
+        public static Harness CreateDegraded(string[]? seed = null, ICommandDocsProvider? docsProvider = null)
+            => Build(grid: null, seed, docsProvider);
+
+        private static Harness Build(FakeGrid? grid, string[]? seed, ICommandDocsProvider? docsProvider)
+        {
+            var history = new InMemoryHistoryStore();
+            if (seed != null)
+            {
+                history.Seed(seed);
+            }
+
+            var controller = new CommandAssistController(
+                history,
+                new SecretsFilter(),
+                new CommandAssistSuggestionEngine(new NoPathSuggestionProvider()),
+                snippetStore: null,
+                commandDocsProvider: docsProvider,
+                recipeProvider: null,
+                errorInsightService: null,
+                modeRouter: null,
+                resultBuilder: null,
+                queryProvider: grid == null ? null : grid.Read);
+
+            return new Harness(controller, grid ?? new FakeGrid(), history);
+        }
+
+        public Task PromptReadyAsync() => EmitAsync(ShellIntegrationEventType.CommandStarted, null, null);
+
+        public Task CommandAcceptedAsync(string commandText)
+            => EmitAsync(ShellIntegrationEventType.CommandAccepted, commandText, null);
+
+        public Task CommandFinishedAsync(int exitCode)
+            => EmitAsync(ShellIntegrationEventType.CommandFinished, null, exitCode);
+
+        private Task EmitAsync(ShellIntegrationEventType type, string? commandText, int? exitCode)
+        {
+            return Controller.HandleShellIntegrationEventAsync(new ShellIntegrationEvent(
+                Type: type,
+                Timestamp: DateTimeOffset.UtcNow,
+                CommandText: commandText,
+                WorkingDirectory: null,
+                ExitCode: exitCode,
+                Duration: null));
+        }
+
+        public Task SettleAsync() => Task.Delay(60);
+
+        public Task WaitForQueryAsync(string expected)
+            => WaitForConditionAsync(() => Controller.ViewModel.QueryText == expected);
+
+        public async Task WaitForConditionAsync(Func<bool> predicate, int timeoutMs = 2000)
+        {
+            int elapsed = 0;
+            while (!predicate())
+            {
+                if (elapsed >= timeoutMs)
+                {
+                    throw new TimeoutException(
+                        $"Timed out waiting for test condition. QueryText='{Controller.ViewModel.QueryText}', " +
+                        $"rows={Controller.Suggestions.Count}, top='{Controller.ViewModel.TopSuggestionText}'.");
+                }
+
+                await Task.Delay(10);
+                elapsed += 10;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The provider seam's stand-in. Locked rather than volatile because the real provider is read
+    /// from the refresh pass's worker thread, not from the thread that set the line.
+    /// </summary>
+    private sealed class FakeGrid
+    {
+        private readonly object _gate = new();
+        private AssistQuerySnapshot? _snapshot;
+
+        public AssistQuerySnapshot? Read()
+        {
+            lock (_gate)
+            {
+                return _snapshot;
+            }
+        }
+
+        public void SetLine(string text, int? cursorOffset = null)
+        {
+            lock (_gate)
+            {
+                _snapshot = new AssistQuerySnapshot(text, cursorOffset ?? text.Length, false, false);
+            }
+        }
+
+        public void GoDark()
+        {
+            lock (_gate)
+            {
+                _snapshot = null;
+            }
+        }
+    }
+
+    private sealed class NoPathSuggestionProvider : IPathSuggestionProvider
+    {
+        public IReadOnlyList<AssistSuggestion> GetSuggestions(CommandAssistQueryContext context, int maxResults)
+            => Array.Empty<AssistSuggestion>();
+    }
+
+    private sealed class RecordingDocsProvider : ICommandDocsProvider
+    {
+        public CommandHelpQuery? LastQuery { get; private set; }
+
+        public Task<IReadOnlyList<CommandHelpItem>> GetHelpAsync(
+            CommandHelpQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            LastQuery = query;
+            return Task.FromResult<IReadOnlyList<CommandHelpItem>>(Array.Empty<CommandHelpItem>());
+        }
+    }
+
+    private sealed class InMemoryHistoryStore : IHistoryStore
+    {
+        private readonly List<CommandHistoryEntry> _entries = new();
+
+        public Task AppendAsync(CommandHistoryEntry entry, CancellationToken cancellationToken = default)
+        {
+            _entries.Add(entry);
+            return Task.CompletedTask;
+        }
+
+        public Task ClearAsync(CancellationToken cancellationToken = default)
+        {
+            _entries.Clear();
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<CommandHistoryEntry>> GetRecentAsync(int maxResults, CancellationToken cancellationToken = default)
+        {
+            IReadOnlyList<CommandHistoryEntry> results = _entries
+                .OrderByDescending(x => x.ExecutedAt)
+                .Take(maxResults)
+                .ToList();
+            return Task.FromResult(results);
+        }
+
+        public Task<IReadOnlyList<CommandHistoryEntry>> SearchAsync(string query, int maxCandidates, CancellationToken cancellationToken = default)
+        {
+            IReadOnlyList<CommandHistoryEntry> results = _entries
+                .Where(x => x.CommandText.Contains(query, StringComparison.OrdinalIgnoreCase))
+                .OrderByDescending(x => x.ExecutedAt)
+                .Take(Math.Max(0, maxCandidates))
+                .ToList();
+            return Task.FromResult(results);
+        }
+
+        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+
+        public void Seed(params string[] commandTexts)
+        {
+            DateTimeOffset at = DateTimeOffset.Parse("2026-03-01T10:00:00+00:00");
+            foreach (string commandText in commandTexts)
+            {
+                _entries.Add(new CommandHistoryEntry(
+                    Id: Guid.NewGuid().ToString("N"),
+                    CommandText: commandText,
+                    ExecutedAt: at,
+                    ShellKind: "pwsh",
+                    WorkingDirectory: @"C:\repo",
+                    ProfileId: "profile-1",
+                    SessionId: "session-1",
+                    HostId: null,
+                    ExitCode: 0,
+                    IsRemote: false,
+                    IsRedacted: false,
+                    Source: CommandCaptureSource.Heuristic,
+                    DurationMs: null));
+                at = at.AddSeconds(-1);
+            }
+        }
+    }
+}

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistGridTruthTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistGridTruthTests.cs
@@ -146,6 +146,69 @@ public sealed class CommandAssistGridTruthTests
         Assert.Null(harness.Controller.TryReadQuerySnapshot());
     }
 
+    /// <summary>
+    /// <c>B</c> rides inside the prompt string, so a prompt framework that repaints mid-edit
+    /// re-emits it with the window already open. That has to be a no-op: treating a second
+    /// <c>B</c> as a toggle, or as evidence that a new command line started, would blank the query
+    /// under the user's hands. The newest mark wins and nothing else changes.
+    /// </summary>
+    [Fact]
+    public async Task ASecondPromptMarkInsideTheWindow_ChangesNothing()
+    {
+        var harness = Harness.Create();
+        await harness.PromptReadyAsync();
+        harness.Grid.SetLine("git st");
+        Assert.Equal("git st", harness.Controller.TryReadQuerySnapshot()?.Text);
+
+        await harness.PromptReadyAsync();
+
+        Assert.Equal("git st", harness.Controller.TryReadQuerySnapshot()?.Text);
+    }
+
+    /// <summary>
+    /// <c>Ctrl+C</c> at a prompt. Nothing ran, so the shell emits no <c>C</c> and no <c>D</c> - it
+    /// prints <c>^C</c> and a fresh prompt, which re-emits <c>B</c>. The gate legitimately stays
+    /// open across the whole thing; the only state that moves is which mark is newest. This is the
+    /// one common interrupt path that reaches neither closer, so it is pinned rather than inferred.
+    /// </summary>
+    [Fact]
+    public async Task CtrlCAtAPrompt_LeavesTheGateOpenAndTheNextMarkTakesOver()
+    {
+        var harness = Harness.Create();
+        await harness.PromptReadyAsync();
+        harness.Grid.SetLine("git stat");
+
+        // The interrupt, then the shell's new prompt. No submission event of any kind.
+        await harness.PromptReadyAsync();
+        harness.Grid.SetLine(string.Empty);
+
+        AssistQuerySnapshot? snapshot = harness.Controller.TryReadQuerySnapshot();
+        Assert.True(snapshot.HasValue);
+        Assert.Equal(string.Empty, snapshot!.Value.Text);
+    }
+
+    /// <summary>
+    /// A full-screen TUI may emit its own <c>OSC 133;B</c> - a program that draws a prompt is
+    /// entitled to. The gate must refuse to open, so that "never open while the alt screen is up"
+    /// is a property of the flag itself and not just of every consumer remembering to check both.
+    /// </summary>
+    [Fact]
+    public async Task WhileTheAltScreenIsUp_APromptMarkDoesNotOpenTheGate()
+    {
+        var harness = Harness.Create();
+        harness.Controller.HandleAltScreenChanged(true);
+
+        await harness.PromptReadyAsync();
+        harness.Grid.SetLine("git status");
+
+        Assert.Null(harness.Controller.TryReadQuerySnapshot());
+
+        // Leaving the alt screen does not reopen it either: the shell's own prompt repaint does.
+        harness.Controller.HandleAltScreenChanged(false);
+
+        Assert.Null(harness.Controller.TryReadQuerySnapshot());
+    }
+
     // ---- desync immunity (the V1 failure matrix) -----------------------------------------
 
     /// <summary>
@@ -266,10 +329,28 @@ public sealed class CommandAssistGridTruthTests
         await harness.WaitForConditionAsync(() => harness.Controller.Suggestions.Count > 0);
 
         Assert.True(opened);
-        Assert.Equal("History", harness.Controller.ViewModel.ModeLabel);
+
+        // The label is the honest one: there is no query, there will not be one, and typing will
+        // not narrow these rows. "History" on its own presents a filter box that cannot filter.
+        Assert.Equal("History - recent", harness.Controller.ViewModel.ModeLabel);
         Assert.Equal(string.Empty, harness.Controller.ViewModel.QueryText);
         Assert.Contains(harness.Controller.Suggestions, s => s.InsertText == "git status");
         Assert.Contains(harness.Controller.Suggestions, s => s.InsertText == "dotnet build");
+    }
+
+    /// <summary>The other side of the label decision: a readable command line does filter.</summary>
+    [Fact]
+    public async Task Integrated_ExplicitHistorySearchIsLabelledAsAFilter()
+    {
+        var harness = Harness.Create(seed: new[] { "dotnet build", "git status" });
+        await harness.PromptReadyAsync();
+        harness.Grid.SetLine("git");
+
+        harness.Controller.OpenHistorySearch();
+        await harness.WaitForConditionAsync(() => harness.Controller.Suggestions.Count > 0);
+
+        Assert.Equal("History", harness.Controller.ViewModel.ModeLabel);
+        Assert.Equal("git", harness.Controller.ViewModel.QueryText);
     }
 
     /// <summary>

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistInsertionPlannerTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistInsertionPlannerTests.cs
@@ -2,13 +2,28 @@ using NovaTerminal.CommandAssist.Application;
 
 namespace NovaTerminal.Tests.CommandAssist;
 
+/// <summary>
+/// The planner's contract in two halves: the suffix arithmetic (unchanged since V1) and the
+/// refusals (new in Phase 1c, and the reason the arithmetic can now be trusted). Every refusal here
+/// is a line V1 would have happily computed a delta against, using a keystroke mirror that had no
+/// idea the line had moved.
+/// </summary>
 public sealed class CommandAssistInsertionPlannerTests
 {
+    private static AssistQuerySnapshot Line(
+        string text,
+        int? cursorOffset = null,
+        bool isMultiline = false,
+        bool rightPromptTrimmed = false)
+    {
+        return new AssistQuerySnapshot(text, cursorOffset ?? text.Length, isMultiline, rightPromptTrimmed);
+    }
+
     [Fact]
-    public void TryCreateInsertion_WhenQueryIsPrefix_ReturnsOnlySuffix()
+    public void TryCreateInsertion_WhenLineIsPrefix_ReturnsOnlySuffix()
     {
         bool created = CommandAssistInsertionPlanner.TryCreateInsertion(
-            existingQuery: "git st",
+            Line("git st"),
             selectedCommand: "git status",
             out string? textToSend);
 
@@ -17,10 +32,10 @@ public sealed class CommandAssistInsertionPlannerTests
     }
 
     [Fact]
-    public void TryCreateInsertion_WhenQueryMatchesExactly_ReturnsFalse()
+    public void TryCreateInsertion_WhenLineMatchesExactly_ReturnsFalse()
     {
         bool created = CommandAssistInsertionPlanner.TryCreateInsertion(
-            existingQuery: "git status",
+            Line("git status"),
             selectedCommand: "git status",
             out string? textToSend);
 
@@ -28,11 +43,16 @@ public sealed class CommandAssistInsertionPlannerTests
         Assert.Null(textToSend);
     }
 
+    /// <summary>
+    /// An empty line is a fact the grid reported, not a missing one, so the whole command is safe
+    /// to send. The distinction between this and the markless case below is the entire point of
+    /// modelling the query as a nullable snapshot rather than a string.
+    /// </summary>
     [Fact]
-    public void TryCreateInsertion_WhenQueryIsEmpty_ReturnsFullSuggestion()
+    public void TryCreateInsertion_WhenTheLineIsObservedEmpty_ReturnsTheFullSuggestion()
     {
         bool created = CommandAssistInsertionPlanner.TryCreateInsertion(
-            existingQuery: string.Empty,
+            Line(string.Empty),
             selectedCommand: "git status",
             out string? textToSend);
 
@@ -41,14 +61,122 @@ public sealed class CommandAssistInsertionPlannerTests
     }
 
     [Fact]
-    public void TryCreateInsertion_WhenSuggestionDoesNotStartWithQuery_ReturnsFalse()
+    public void TryCreateInsertion_WhenSuggestionDoesNotStartWithTheLine_ReturnsFalse()
     {
         bool created = CommandAssistInsertionPlanner.TryCreateInsertion(
-            existingQuery: "kubectl",
+            Line("kubectl"),
             selectedCommand: "git status",
             out string? textToSend);
 
         Assert.False(created);
         Assert.Null(textToSend);
+    }
+
+    [Fact]
+    public void TryCreateInsertion_WhenSelectedCommandIsEmpty_ReturnsFalse()
+    {
+        bool created = CommandAssistInsertionPlanner.TryCreateInsertion(
+            Line("git st"),
+            selectedCommand: string.Empty,
+            out string? textToSend);
+
+        Assert.False(created);
+        Assert.Null(textToSend);
+    }
+
+    /// <summary>
+    /// Refusal 1 - no grid truth. A markless session cannot see the command line, so it cannot know
+    /// that sending "git status" onto a line already reading "git s" produces "git sgit status".
+    /// Insertion is a prefix-dependent feature and degraded mode does not offer those.
+    /// </summary>
+    [Fact]
+    public void TryCreateInsertion_WithoutGridTruth_Refuses()
+    {
+        bool created = CommandAssistInsertionPlanner.TryCreateInsertion(
+            query: null,
+            selectedCommand: "git status",
+            out string? textToSend);
+
+        Assert.False(created);
+        Assert.Null(textToSend);
+    }
+
+    /// <summary>
+    /// Refusal 2 - the cursor is not at the end. The user pressed Home or Left; sent text lands at
+    /// the cursor, so the "suffix" would be spliced into the middle of the command.
+    /// </summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(3)]
+    [InlineData(5)]
+    public void TryCreateInsertion_WhenTheCursorIsNotAtTheEnd_Refuses(int cursorOffset)
+    {
+        bool created = CommandAssistInsertionPlanner.TryCreateInsertion(
+            Line("git st", cursorOffset),
+            selectedCommand: "git status",
+            out string? textToSend);
+
+        Assert.False(created);
+        Assert.Null(textToSend);
+    }
+
+    /// <summary>
+    /// Refusal 3 - multiline. The snapshot contains whatever the shell painted as a continuation
+    /// prompt, so the text is not a prefix the user typed even when it happens to start one.
+    /// </summary>
+    [Fact]
+    public void TryCreateInsertion_WhenTheEntryIsMultiline_Refuses()
+    {
+        bool created = CommandAssistInsertionPlanner.TryCreateInsertion(
+            Line("for i in 1 2 3\n> do echo", isMultiline: true),
+            selectedCommand: "for i in 1 2 3\n> do echo $i; done",
+            out string? textToSend);
+
+        Assert.False(created);
+        Assert.Null(textToSend);
+    }
+
+    /// <summary>
+    /// Refusal 4 - a right prompt was trimmed. The reader's RPROMPT heuristic is deliberately
+    /// conservative, but conservative means "over-returns rather than deletes"; when it did fire,
+    /// the tail of the line is an inference and the tail is exactly what a suffix append attaches
+    /// to.
+    /// </summary>
+    [Fact]
+    public void TryCreateInsertion_WhenARightPromptWasTrimmed_Refuses()
+    {
+        bool created = CommandAssistInsertionPlanner.TryCreateInsertion(
+            Line("git st", rightPromptTrimmed: true),
+            selectedCommand: "git status",
+            out string? textToSend);
+
+        Assert.False(created);
+        Assert.Null(textToSend);
+    }
+
+    /// <summary>
+    /// The V1 desync cases, stated as the planner sees them. Each is a line the shell rewrote
+    /// without emitting anything a keystroke mirror could observe; each now produces the delta the
+    /// grid implies rather than the delta a stale mirror implied.
+    /// </summary>
+    [Theory]
+    // Ctrl+U: the mirror still held "git st"; V1 would have sent "atus" onto an empty line.
+    [InlineData("", "git status", "git status")]
+    // Up-arrow history recall: the line is now a full command the user never typed a character of.
+    [InlineData("git status", "git status --short", " --short")]
+    // Shell-side Tab completion: the shell finished the word for the user.
+    [InlineData("git status", "git status --porcelain", " --porcelain")]
+    public void TryCreateInsertion_AfterTheShellRewroteTheLine_FollowsTheGrid(
+        string lineAfterShellEdit,
+        string selectedCommand,
+        string expected)
+    {
+        bool created = CommandAssistInsertionPlanner.TryCreateInsertion(
+            Line(lineAfterShellEdit),
+            selectedCommand,
+            out string? textToSend);
+
+        Assert.True(created);
+        Assert.Equal(expected, textToSend);
     }
 }

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistLayoutTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistLayoutTests.cs
@@ -77,7 +77,7 @@ public sealed class CommandAssistLayoutTests
     {
         using var pane = new TerminalPane();
         ConfigureCommandAssist(pane);
-        pane.NotifyCommandAssistPaste("Get-ChildItem");
+        await AtAnIntegratedPromptAsync(pane, "Get-ChildItem");
         pane.OpenCommandAssistHelp();
         await Task.Delay(50);
 
@@ -106,7 +106,7 @@ public sealed class CommandAssistLayoutTests
     {
         using var pane = new TerminalPane();
         ConfigureCommandAssist(pane);
-        pane.NotifyCommandAssistPaste("frobnicate");
+        await AtAnIntegratedPromptAsync(pane, "frobnicate");
         pane.OpenCommandAssistHelp();
         await Task.Delay(50);
 
@@ -126,7 +126,7 @@ public sealed class CommandAssistLayoutTests
     {
         using var pane = new TerminalPane();
         ConfigureCommandAssist(pane);
-        pane.NotifyCommandAssistPaste("git st");
+        await AtAnIntegratedPromptAsync(pane, "git st");
         await Task.Delay(50);
 
         CommandAssistBubbleView bubbleView = Assert.IsType<CommandAssistBubbleView>(pane.FindControl<CommandAssistBubbleView>("CommandAssistBubble"));
@@ -149,7 +149,7 @@ public sealed class CommandAssistLayoutTests
         ConfigureCommandAssist(pane);
         pane.Measure(new Size(420, 420));
         pane.Arrange(new Rect(0, 0, 420, 420));
-        pane.NotifyCommandAssistPaste("git status --short");
+        await AtAnIntegratedPromptAsync(pane, "git status --short");
         await Task.Delay(50);
         pane.Measure(new Size(420, 420));
         pane.Arrange(new Rect(0, 0, 420, 420));
@@ -190,7 +190,7 @@ public sealed class CommandAssistLayoutTests
         ConfigureCommandAssist(pane);
         pane.Measure(new Size(700, 220));
         pane.Arrange(new Rect(0, 0, 700, 220));
-        pane.NotifyCommandAssistPaste("Get-ChildItem");
+        await AtAnIntegratedPromptAsync(pane, "Get-ChildItem");
         pane.OpenCommandAssistHelp();
         await Task.Delay(50);
         pane.Measure(new Size(700, 220));
@@ -213,7 +213,7 @@ public sealed class CommandAssistLayoutTests
         ConfigureCommandAssist(pane);
         pane.Measure(new Size(900, 500));
         pane.Arrange(new Rect(0, 0, 900, 500));
-        pane.NotifyCommandAssistPaste("git st");
+        await AtAnIntegratedPromptAsync(pane, "git st");
         await Task.Delay(50);
         pane.Measure(new Size(900, 500));
         pane.Arrange(new Rect(0, 0, 900, 500));
@@ -450,7 +450,7 @@ public sealed class CommandAssistLayoutTests
         ConfigureCommandAssist(pane);
         pane.Measure(new Size(900, 500));
         pane.Arrange(new Rect(0, 0, 900, 500));
-        pane.NotifyCommandAssistPaste("Get-ChildItem");
+        await AtAnIntegratedPromptAsync(pane, "Get-ChildItem");
         pane.OpenCommandAssistHelp();
         await Task.Delay(50);
         pane.Measure(new Size(900, 500));
@@ -473,7 +473,7 @@ public sealed class CommandAssistLayoutTests
         ConfigureCommandAssist(pane);
         pane.Measure(new Size(420, 420));
         pane.Arrange(new Rect(0, 0, 420, 420));
-        pane.NotifyCommandAssistPaste("Get-ChildItem");
+        await AtAnIntegratedPromptAsync(pane, "Get-ChildItem");
         pane.OpenCommandAssistHelp();
         await Task.Delay(50);
         pane.Measure(new Size(420, 420));
@@ -503,7 +503,7 @@ public sealed class CommandAssistLayoutTests
         Assert.NotNull(terminalView);
         double baselineHeight = terminalView.Bounds.Height;
 
-        pane.NotifyCommandAssistPaste("Get-ChildItem");
+        await AtAnIntegratedPromptAsync(pane, "Get-ChildItem");
         pane.OpenCommandAssistHelp();
         await Task.Delay(50);
         pane.Measure(new Size(900, 500));
@@ -647,6 +647,27 @@ public sealed class CommandAssistLayoutTests
         Assert.NotNull(hint);
         Assert.Equal(expectedVisibleRows, hint!.Value.VisibleRows);
         Assert.Equal(expectedCursorRow, hint.Value.VisibleCursorVisualRow);
+    }
+
+    /// <summary>
+    /// Puts <paramref name="commandLine"/> on the pane's command line the way a shell does: an
+    /// integrated prompt, the <c>OSC 133;B</c> mark, then the text.
+    /// </summary>
+    /// <remarks>
+    /// Phase 1c deleted the shadow keystroke buffer, so <c>NotifyCommandAssistPaste</c> - which
+    /// these tests used to seed a query with - no longer writes query state, and a paste-seeded
+    /// help lookup would silently find nothing. The grid is the only source now, so the setup says
+    /// so.
+    /// </remarks>
+    private static async Task AtAnIntegratedPromptAsync(TerminalPane pane, string commandLine)
+    {
+        pane.ArmShellIntegrationTracker();
+        pane.CreateAndWireParser();
+        pane.Parser!.Process("\x1b]133;A\x07PS C:\\> \x1b]133;B\x07" + commandLine);
+
+        // The shell-integration event dispatcher is serialized and asynchronous; the controller's
+        // lifecycle gate opens when B reaches it through that queue.
+        await Task.Delay(50);
     }
 
     private static void ConfigureCommandAssist(TerminalPane pane)

--- a/tests/NovaTerminal.App.Tests/CommandAssist/TerminalPaneCommandAssistShortcutTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/TerminalPaneCommandAssistShortcutTests.cs
@@ -64,12 +64,20 @@ public sealed class TerminalPaneCommandAssistShortcutTests
         Assert.False(pane.CommandAssistViewModel?.IsVisible ?? false);
     }
 
+    /// <summary>
+    /// Phase 1c: the pane's query comes off the grid, so this drives the whole real seam - the
+    /// parser sees <c>OSC 133;B</c>, the pane keeps the mark, the controller's lifecycle gate opens,
+    /// and Help resolves its command token by reading the cells between the mark and the cursor.
+    /// The paste that used to seed a shadow buffer here no longer has anything to seed.
+    /// </summary>
     [AvaloniaFact]
-    public async Task OpenCommandAssistHelp_WhenQueryPresent_UsesPaneInfrastructure()
+    public async Task OpenCommandAssistHelp_WhenTheGridHoldsACommand_UsesPaneInfrastructure()
     {
         using var pane = new TerminalPane();
         ConfigureCommandAssist(pane);
-        pane.NotifyCommandAssistPaste("Get-ChildItem");
+        pane.ArmShellIntegrationTracker();
+        pane.CreateAndWireParser();
+        await TypeAtAnIntegratedPromptAsync(pane, "Get-ChildItem");
 
         bool handled = pane.OpenCommandAssistHelp();
         await Task.Delay(50);
@@ -79,6 +87,53 @@ public sealed class TerminalPaneCommandAssistShortcutTests
         Assert.True(vm.IsVisible);
         Assert.Equal("Help", vm.ModeLabel);
         Assert.True(vm.HasSuggestions);
+    }
+
+    /// <summary>
+    /// The gate at pane level: outside the <c>B</c>..<c>C</c> window the grid still holds the text,
+    /// and Help still gets nothing from it. Without the gate the same bytes would produce a help
+    /// lookup for whatever the command printed.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task OpenCommandAssistHelp_AfterTheCommandWasSubmitted_TakesNoTokenFromTheGrid()
+    {
+        using var pane = new TerminalPane();
+        ConfigureCommandAssist(pane);
+        pane.ArmShellIntegrationTracker();
+        pane.CreateAndWireParser();
+        await TypeAtAnIntegratedPromptAsync(pane, "Get-ChildItem");
+
+        await SubmitAsync(pane, "Get-ChildItem");
+
+        pane.OpenCommandAssistHelp();
+        await Task.Delay(50);
+
+        CommandAssistBarViewModel vm = AssertViewModel(pane);
+        Assert.Equal(string.Empty, vm.QueryText);
+        Assert.False(vm.HasSuggestions);
+    }
+
+    /// <summary>
+    /// Drives a real integrated prompt: <c>OSC 133;A</c>, prompt text, <c>OSC 133;B</c>, then the
+    /// command line itself. The delay lets the pane's serialized shell-integration dispatcher
+    /// deliver <c>B</c> to the controller, which is what opens the lifecycle gate.
+    /// </summary>
+    private static async Task TypeAtAnIntegratedPromptAsync(TerminalPane pane, string commandLine)
+    {
+        pane.Parser!.Process("\x1b]133;A\x07PS C:\\> \x1b]133;B\x07" + commandLine);
+        await Task.Delay(50);
+    }
+
+    /// <summary>
+    /// <c>OSC 133;C;&lt;base64&gt;</c>, the way all four bootstraps emit it. The payload matters:
+    /// the parser only raises <c>OnCommandAccepted</c> for a C that decodes to something, so a
+    /// bare <c>133;C</c> would not close the lifecycle gate here.
+    /// </summary>
+    private static async Task SubmitAsync(TerminalPane pane, string commandLine)
+    {
+        string encoded = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(commandLine));
+        pane.Parser!.Process($"\x1b]133;C;{encoded}\x07");
+        await Task.Delay(50);
     }
 
     [AvaloniaFact]

--- a/tests/NovaTerminal.App.Tests/Controls/PaneAssistInsertionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneAssistInsertionTests.cs
@@ -1,0 +1,278 @@
+using System.Reflection;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using NovaTerminal.CommandAssist.Models;
+using NovaTerminal.CommandAssist.ViewModels;
+using NovaTerminal.Controls;
+using NovaTerminal.Pty;
+using NovaTerminal.Replay;
+using NovaTerminal.Shell;
+using NovaTerminal.VT;
+using Xunit;
+
+namespace NovaTerminal.Tests.Controls;
+
+/// <summary>
+/// What <c>Ctrl+Enter</c> is allowed to send, driven through the real pane: parser, mark, grid
+/// reader, controller gate, insertion planner and the session it would send to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two failures found in the Phase 1c review live here, and they are the two ends of the same
+/// method. One is about sending the <em>wrong</em> text (the echo race); the other is about
+/// destroying the surface while sending <em>no</em> text (accept-before-plan).
+/// </para>
+/// <para>
+/// Sibling coverage: <c>CommandAssistInsertionPlannerTests</c> pins the planner's own refusal rules
+/// against snapshots, and <c>PaneGridTruthDesyncTests</c> pins the query the planner is fed. This
+/// file is about the order the pane does things in and what it refuses to do.
+/// </para>
+/// </remarks>
+public class PaneAssistInsertionTests
+{
+    private const string PromptStart = "\x1b]133;A\x07";
+    private const string PromptEnd = "\x1b]133;B\x07";
+
+    /// <summary>
+    /// The echo race. Rows were ranked from <c>"git st"</c>; the user typed <c>'a'</c>, so the PTY
+    /// holds <c>"git sta"</c>, and pressed <c>Ctrl+Enter</c> before the shell echoed it. A fresh
+    /// read still says <c>"git st"</c> - and it is a perfectly self-consistent read: the cursor is
+    /// at the end, the line is single-line, no right prompt was trimmed, so every planner guard
+    /// passes. The planner would send <c>"atus"</c> and the line would become <c>git staatus</c>.
+    /// No prefix check can catch this, because stale text is always a prefix of the true line; the
+    /// only signal is "we have sent bytes the grid has not seen come back yet".
+    /// </summary>
+    [AvaloniaFact]
+    public async Task WhenTypedInputHasNotBeenEchoedYet_CtrlEnterRefusesUntilItIs()
+    {
+        using var fixture = await Fixture.AtAnIntegratedPromptAsync("git st", history: "git status");
+
+        // The keystroke has reached the PTY; the echo has not come back.
+        fixture.Pane.NoteInputAwaitingEcho();
+
+        fixture.PressCtrlEnter();
+
+        Assert.Empty(fixture.Session.Sent);
+        Assert.True(fixture.ViewModel.IsVisible);
+
+        // The echo lands and the grid catches up. (The pane clears the flag after Parser.Process,
+        // which is what the production output hook does.)
+        fixture.Pane.NoteSessionOutputApplied();
+
+        fixture.PressCtrlEnter();
+
+        Assert.Equal("atus", Assert.Single(fixture.Session.Sent));
+    }
+
+    /// <summary>
+    /// The baseline the test above is measured against: with the grid up to date, the same setup
+    /// sends the delta. Without this, "refused" would be indistinguishable from "never worked".
+    /// </summary>
+    [AvaloniaFact]
+    public async Task WhenTheGridIsCurrent_CtrlEnterSendsOnlyTheSuffix()
+    {
+        using var fixture = await Fixture.AtAnIntegratedPromptAsync("git st", history: "git status");
+
+        fixture.PressCtrlEnter();
+
+        Assert.Equal("atus", Assert.Single(fixture.Session.Sent));
+        Assert.False(fixture.ViewModel.IsVisible);
+    }
+
+    /// <summary>
+    /// Destructive refusal. In a degraded session there is no snapshot, so the planner refuses -
+    /// but the pane used to call <c>TryAcceptSelection</c> (which accepts <em>and</em> dismisses)
+    /// before asking it, so the refusal arrived after the list was already gone. From the user's
+    /// side that is <c>Ctrl+Enter</c> silently deleting the thing they were browsing and sending
+    /// nothing: indistinguishable from a broken feature. The plan is computed from the
+    /// non-mutating read first; the surface is only touched once there is text to send.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task InADegradedSession_CtrlEnterRefusesWithoutTearingTheListDown()
+    {
+        using var fixture = await Fixture.DegradedAtAHistorySearchAsync(history: "git status");
+
+        Assert.True(fixture.ViewModel.IsVisible);
+        Assert.True(fixture.ViewModel.HasSuggestions);
+
+        fixture.PressCtrlEnter();
+
+        Assert.Empty(fixture.Session.Sent);
+        Assert.True(fixture.ViewModel.IsVisible);
+        Assert.True(fixture.ViewModel.HasSuggestions);
+    }
+
+    private sealed class Fixture : IDisposable
+    {
+        private readonly string _directory;
+
+        private Fixture(TerminalPane pane, RecordingSession session, string directory)
+        {
+            Pane = pane;
+            Session = session;
+            _directory = directory;
+        }
+
+        public TerminalPane Pane { get; }
+
+        public RecordingSession Session { get; }
+
+        public CommandAssistBarViewModel ViewModel =>
+            Assert.IsType<CommandAssistBarViewModel>(Pane.CommandAssistViewModel);
+
+        /// <summary>An instrumented prompt with <paramref name="commandLine"/> typed at it.</summary>
+        public static async Task<Fixture> AtAnIntegratedPromptAsync(string commandLine, string history)
+        {
+            Fixture fixture = await CreateAsync(history);
+            fixture.Pane.ArmShellIntegrationTracker();
+            fixture.Pane.CreateAndWireParser();
+            fixture.Pane.Parser!.Process(PromptStart + "$ " + PromptEnd + commandLine);
+
+            // The shell-integration dispatcher is serialized and asynchronous; B opens the
+            // lifecycle gate on the far side of it.
+            await Task.Delay(50);
+
+            // An explicit session is what widens the suggestion scope back out to history.
+            fixture.Pane.ToggleCommandAssist();
+            await fixture.WaitForAsync(() => fixture.ViewModel.TopSuggestionText == history);
+            return fixture;
+        }
+
+        /// <summary>No marks at all, with the recency list up from <c>Ctrl+R</c>.</summary>
+        public static async Task<Fixture> DegradedAtAHistorySearchAsync(string history)
+        {
+            Fixture fixture = await CreateAsync(history);
+            fixture.Pane.CreateAndWireParser();
+
+            fixture.Pane.OpenCommandAssistHistorySearch();
+            await fixture.WaitForAsync(() => fixture.ViewModel.HasSuggestions);
+            return fixture;
+        }
+
+        public void PressCtrlEnter() =>
+            Pane.TryHandleCommandAssistKey(Key.Enter, KeyModifiers.Control);
+
+        public void Dispose()
+        {
+            Pane.Dispose();
+            try
+            {
+                Directory.Delete(_directory, recursive: true);
+            }
+            catch
+            {
+                // Best effort; the temp root is per-test anyway.
+            }
+        }
+
+        private static async Task<Fixture> CreateAsync(string history)
+        {
+            // A private services graph rather than the shared TestCommandAssistServices instance:
+            // these tests assert on which row is selected, so they must not race whatever other
+            // pane-level tests have written into the shared history file.
+            string directory = Path.Combine(
+                Path.GetTempPath(),
+                $"nova_assist_insertion_{Environment.ProcessId}_{Guid.NewGuid():N}");
+            Directory.CreateDirectory(directory);
+
+            var services = new CommandAssistServices(
+                Path.Combine(directory, "history.jsonl"),
+                legacyHistoryFilePath: null,
+                Path.Combine(directory, "snippets.json"),
+                () => directory);
+
+            // Awaited, never blocked on: these tests run on Avalonia's headless dispatcher thread,
+            // and a GetAwaiter().GetResult() here deadlocks the store's continuation against it.
+            await services.HistoryStore.AppendAsync(new CommandHistoryEntry(
+                Id: Guid.NewGuid().ToString("N"),
+                CommandText: history,
+                ExecutedAt: DateTimeOffset.UtcNow,
+                ShellKind: "pwsh",
+                WorkingDirectory: null,
+                ProfileId: null,
+                SessionId: null,
+                HostId: null,
+                ExitCode: 0,
+                IsRemote: false,
+                IsRedacted: false,
+                Source: CommandCaptureSource.Heuristic,
+                DurationMs: null));
+
+            var pane = new TerminalPane();
+            pane.CommandAssistServices = services;
+            var settings = new TerminalSettings(); // constructed, not Load() - see #232
+            settings.CommandAssistEnabled = true;
+            settings.CommandAssistHistoryEnabled = true;
+            pane.ApplySettings(settings);
+
+            var session = new RecordingSession();
+            typeof(TerminalPane)
+                .GetProperty("Session", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)!
+                .SetValue(pane, session);
+
+            return new Fixture(pane, session, directory);
+        }
+
+        private async Task WaitForAsync(Func<bool> predicate, int timeoutMs = 2000)
+        {
+            int elapsed = 0;
+            while (!predicate())
+            {
+                if (elapsed >= timeoutMs)
+                {
+                    throw new TimeoutException(
+                        $"Timed out. query='{ViewModel.QueryText}', top='{ViewModel.TopSuggestionText}', " +
+                        $"visible={ViewModel.IsVisible}, rows={ViewModel.Suggestions.Count}.");
+                }
+
+                await Task.Delay(10);
+                elapsed += 10;
+            }
+        }
+    }
+
+    /// <summary>A session that records what the pane sends and does nothing else.</summary>
+    internal sealed class RecordingSession : ITerminalSession
+    {
+        private readonly List<string> _sent = new();
+
+        public IReadOnlyList<string> Sent => _sent;
+
+        public Guid Id { get; } = Guid.NewGuid();
+        public string ShellCommand => "pwsh.exe";
+        public string? ShellArguments => null;
+        public bool IsProcessRunning => true;
+        public bool HasActiveChildProcesses => false;
+        public int? ExitCode => null;
+        public bool IsRecording => false;
+        public bool IsFlightRecording => false;
+
+        public event Action<string>? OnOutputReceived { add { } remove { } }
+
+        public event Action<int>? OnExit { add { } remove { } }
+
+        public void SendInput(string input) => _sent.Add(input);
+
+        public void Resize(int cols, int rows) { }
+
+        public void StartRecording(string filePath) { }
+
+        public void StopRecording() { }
+
+        public void EnableFlightRecording(long maxTotalBytes) { }
+
+        public void DisableFlightRecording() { }
+
+        public bool TryExportFlightRecording(string filePath, out FlightExportInfo info)
+        {
+            info = default;
+            return false;
+        }
+
+        public void AttachBuffer(TerminalBuffer buffer) { }
+
+        public void TakeSnapshot() { }
+
+        public void Dispose() { }
+    }
+}

--- a/tests/NovaTerminal.App.Tests/Controls/PaneGridTruthDesyncTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneGridTruthDesyncTests.cs
@@ -1,0 +1,161 @@
+using Avalonia.Headless.XUnit;
+using NovaTerminal.CommandAssist.Application;
+using NovaTerminal.Controls;
+using NovaTerminal.Shell;
+using Xunit;
+
+namespace NovaTerminal.Tests.Controls;
+
+/// <summary>
+/// The V1 desync matrix, driven through the real stack: escape sequences into
+/// <c>TerminalPane.Parser</c>, out through the grid reader, the App-boundary snapshot mapping and
+/// the controller's lifecycle gate.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every scenario here is a case where the shell rewrites the command line and emits nothing that a
+/// keystroke mirror could observe. V1 mirrored TextInput, Backspace, Enter and Paste; <c>Ctrl+U</c>,
+/// history recall and shell-side Tab completion produce none of those, so its query drifted and
+/// stayed drifted for the rest of the command. What is asserted is that the pane's view of the
+/// command line is whatever is painted, with no reference to how it got there.
+/// </para>
+/// <para>
+/// Sibling coverage: <c>PaneGridCommandLineTests</c> pins the mark plumbing,
+/// <c>NovaTerminal.VT.Tests.GridQueryReaderTests</c> pins extraction, and
+/// <c>CommandAssistGridTruthTests</c> pins the same scenarios against the controller seam without a
+/// terminal. This file is the one that proves the pieces are actually connected.
+/// </para>
+/// </remarks>
+public class PaneGridTruthDesyncTests
+{
+    private const string PromptStart = "\x1b]133;A\x07";
+    private const string PromptEnd = "\x1b]133;B\x07";
+    private const string CommandExecuted = "\x1b]133;C\x07";
+    private const string CommandFinished = "\x1b]133;D;0\x07";
+    private const string EraseLine = "\r\x1b[K";
+
+    /// <summary>
+    /// <c>Ctrl+U</c>: the shell erases the line and reprints the prompt. Nothing reaches the App as
+    /// a key event Command Assist watches, so V1's query kept the erased text forever.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task AfterCtrlU_TheQueryIsTheEmptiedLine()
+    {
+        using var pane = CreatePane();
+        await AtAPromptAsync(pane, "git st");
+
+        Assert.Equal("git st", ReadQuery(pane)?.Text);
+
+        // What Ctrl+U actually looks like on the wire: carriage return, erase to end of line,
+        // prompt reprinted (which re-emits B), nothing after it.
+        pane.Parser!.Process(EraseLine + PromptStart + "$ " + PromptEnd);
+
+        Assert.Equal(string.Empty, ReadQuery(pane)?.Text);
+    }
+
+    /// <summary>
+    /// Up-arrow history recall. The line becomes a command the user typed no character of, and it
+    /// is longer than anything they typed - the case where V1 would compute an insertion delta
+    /// against a prefix that was not on the line.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task AfterHistoryRecall_TheQueryIsTheRecalledCommand()
+    {
+        using var pane = CreatePane();
+        await AtAPromptAsync(pane, "git");
+
+        pane.Parser!.Process(EraseLine + PromptStart + "$ " + PromptEnd + "git status --short");
+
+        AssistQuerySnapshot? line = ReadQuery(pane);
+        Assert.Equal("git status --short", line?.Text);
+
+        // And the planner now computes against that, not against "git".
+        Assert.True(CommandAssistInsertionPlanner.TryCreateInsertion(
+            line,
+            "git status --short --branch",
+            out string? textToSend));
+        Assert.Equal(" --branch", textToSend);
+    }
+
+    /// <summary>
+    /// Shell-side Tab completion. Command Assist deliberately does not own Tab, so the completed
+    /// text arrives as painted cells with no key event at all.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task AfterShellTabCompletion_TheQueryIsTheCompletedWord()
+    {
+        using var pane = CreatePane();
+        await AtAPromptAsync(pane, "cd Nova");
+
+        // The shell finishes the word in place.
+        pane.Parser!.Process("Terminal.CommandAssist/");
+
+        Assert.Equal("cd NovaTerminal.CommandAssist/", ReadQuery(pane)?.Text);
+    }
+
+    /// <summary>
+    /// A left-arrow moves the cursor without changing the text. The text is still the query - it is
+    /// what the user will run - but it is no longer a prefix an append can extend, and the snapshot
+    /// says so.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task AfterAnArrowKey_TheTextIsUnchangedButItIsNoLongerAnAppendableParent()
+    {
+        using var pane = CreatePane();
+        await AtAPromptAsync(pane, "git status");
+
+        pane.Parser!.Process("\x1b[D\x1b[D\x1b[D");
+
+        AssistQuerySnapshot? line = ReadQuery(pane);
+        Assert.Equal("git status", line?.Text);
+        Assert.Equal(7, line?.CursorOffset);
+        Assert.False(line?.IsUsableAsTypedPrefix);
+        Assert.False(CommandAssistInsertionPlanner.TryCreateInsertion(line, "git status --short", out _));
+    }
+
+    /// <summary>
+    /// The lifecycle gate at the pane level. After <c>D</c> the pane drops the mark, so even the
+    /// raw seam goes dark rather than serving the command's output as a command line.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task AfterTheCommandFinishes_ThereIsNoQuery()
+    {
+        using var pane = CreatePane();
+        await AtAPromptAsync(pane, "git status");
+
+        pane.Parser!.Process(CommandExecuted + "\r\nOn branch main\r\n" + CommandFinished);
+
+        Assert.Null(ReadQuery(pane));
+    }
+
+    /// <summary>
+    /// The provider the controller is constructed with - reader, mark lifecycle and App-boundary
+    /// mapping, exactly as production wires them. The controller's own lifecycle gate sits above
+    /// this and is covered by <c>CommandAssistGridTruthTests</c> and the pane-level Help tests in
+    /// <c>TerminalPaneCommandAssistShortcutTests</c>; what this file is for is the layer below it.
+    /// </summary>
+    private static AssistQuerySnapshot? ReadQuery(TerminalPane pane) => pane.TryReadAssistQuerySnapshot();
+
+    /// <summary>Paints an integrated prompt and types <paramref name="commandLine"/> at it.</summary>
+    private static async Task AtAPromptAsync(TerminalPane pane, string commandLine)
+    {
+        pane.Parser!.Process(PromptStart + "$ " + PromptEnd + commandLine);
+
+        // The shell-integration event dispatcher is serialized and asynchronous; the lifecycle gate
+        // opens when B reaches the controller through it.
+        await Task.Delay(50);
+    }
+
+    private static TerminalPane CreatePane()
+    {
+        var pane = new TerminalPane();
+        pane.CommandAssistServices = TestCommandAssistServices.Instance;
+        var settings = new TerminalSettings(); // constructed, not Load() - see #232
+        settings.CommandAssistEnabled = true;
+        settings.CommandAssistHistoryEnabled = true;
+        pane.ApplySettings(settings);
+        pane.ArmShellIntegrationTracker();
+        pane.CreateAndWireParser();
+        return pane;
+    }
+}


### PR DESCRIPTION
# Command Assist V2 Phase 1c: grid-truth query state

Implements Phase 1 tasks 4-6 of `docs/plans/2026-08-01-command-assist-v2-plan.md`.

Phase 1a made the shells emit `OSC 133;B`. Phase 1b built a reader that turns a `B` mark plus a
cursor into the live command line. This is the phase that consumes it and deletes the shadow
keystroke buffer -- design pillar 1, and re-enable criterion 1.

The shadow buffer was V1's deepest correctness flaw. It mirrored four events (TextInput, Backspace,
Enter, Paste) and every other way a command line can change -- arrow keys, `Ctrl+U`, `Ctrl+W`, shell
history recall, the shell's own Tab completion -- desynced it silently and permanently. Ranking,
help-token extraction and insertion planning were all built on it.

## The seam

The query crosses into `NovaTerminal.CommandAssist` as plain data, because `LayeringTests` forbids
that assembly from referencing `NovaTerminal.VT`:

```
TerminalPane._latestCommandStartMark + Buffer
  -> GridQueryReader.TryReadCommandLine          (VT, Phase 1b)
  -> TerminalPane.TryReadAssistQuerySnapshot()   (App boundary: the only place both types exist)
  -> Func<AssistQuerySnapshot?>                  (handed to CommandAssistController's ctor)
  -> SuggestionOrchestrator.TryReadQuery()       (applies the lifecycle gate)
```

`AssistQuerySnapshot(Text, CursorOffset, IsMultiline, RightPromptTrimmed)` is CommandAssist's own
shape for `GridCommandLine`. The span's row numbers are dropped: nothing on that side has a use for
buffer coordinates.

**Null means "unknown", not "empty".** That distinction is load-bearing. An observed-empty line is
safe to send a whole command to; a line nobody can see is not.

## The three consumption rules (from the PR #285 review)

**1. Lifecycle gate.** The reader cannot self-gate. The cells between the mark and the cursor look
identical whether the user is editing a command line or the command has run and those are its first
output lines; only the OSC 133 stream distinguishes them.
`AssistSessionContext.IsAcceptingCommandInput` opens on `CommandStarted` (`133;B`) and closes on
`CommandAccepted` (`133;C`), `CommandFinished` (`133;D`) and an alt-screen switch. The gate and the
mark are independent facts and both are required: the gate can be open while the mark has aged out
of scrollback, and the mark is deliberately kept across `C` while the input line is still painted.

The gate is not conditioned on `IsShellIntegrationEnabled` -- that records only whether *we*
injected the bootstrap, and a shell emitting `B` is instrumented either way. (Today that is theory:
`ShellLifecycleTracker` is only armed by `ApplyShellIntegrationLaunchPlan`, so a session we did not
instrument delivers no events at all. Arming it on observed marks is Phase 2 task 3.)

This is why `TerminalPane`'s `CommandStarted` early-out is gone -- the Phase 1a note said Phase 1c
had to remove it if the event acquired a consumer, and it has: without `B` reaching the controller
the gate never opens and grid truth is dead on arrival. The cost is one dispatcher hop per prompt
repaint, doing an idempotent bool set.

**2. Settled-boundary reads.** The buffer takes its write lock per written character, so a read
racing a prompt repaint (`\r`, erase-to-EOL, reprint) can observe a half-erased line -- suggestion
flicker on every `Ctrl+U` and history recall. The refresh pass now resolves its own query, on the
worker it already runs on, rather than at the keystroke: `SuggestionOrchestrator.Refresh` lost its
`query` parameter, and the read happens inside the pass's `Task.Run`. Bursts coalesce through the
per-pass `CancellationTokenSource` that already existed, so N keystrokes apply one read -- the last.

No debounce. That is a Phase 3 policy decision. The window that remains is honest: a pass whose read
beats the shell's echo of the final character ranks a one-character-stale query until the next
trigger.

**3. Insertion refuses rather than guesses.** `CommandAssistInsertionPlanner` keeps the additive rule
(send only what the suggestion adds; never delete, never move the cursor) and now takes a snapshot.
It returns nothing when:

| refusal | why an append would be wrong |
|---|---|
| no snapshot (markless, or gate closed) | the line cannot be seen; appending a whole command to an unknown prefix is how `git sgit status` happens |
| `CursorOffset != Text.Length` | sent text lands at the cursor, so the "suffix" would be spliced mid-command |
| `IsMultiline` | the text contains continuation-prompt cells (`PS2`, `PROMPT2`, fish `> `) the user never typed |
| `RightPromptTrimmed` | the reader's RPROMPT trim is conservative, but the *tail* is then an inference -- and the tail is what an append attaches to |

## Degraded-mode decisions

A session with no marks has **no query**, not an empty one. The shadow buffer is deleted, not kept
as a fallback: a fallback that desyncs is worse than none, because it writes wrong commands into
persistent history and computes edits against lines that do not exist.

- **Search (`Ctrl+R`) query source.** There isn't one, and that is the answer. With no query, Search
  shows the recency list. This still helps, because history is per user rather than per session, so
  a degraded session browses everything captured in instrumented ones. It is **browse-only**:
  selecting a row yields no insertion plan, per refusal rule 1.
- **Passive path suggestions: off.** Not by a special case -- `FileSystemPathSuggestionProvider`
  needs a command token and a path-shaped fragment, and an empty query has neither.
- **Help token from the command line: none.** Explain-selection still works (a selection is explicit
  input the grid is not needed for) and Fix still works (it analyses the command that failed).
- **Enter-time heuristic history capture: nothing is captured.** This is the decision most worth
  arguing with, so: V1's capture read the shadow buffer, which means for any line the user had
  edited with keys the mirror could not see, it wrote a command they never ran into persistent
  history. Recording nothing is recoverable; recording something false is not. Instrumented sessions
  are unaffected and in fact improved -- the first command is now captured from the grid at Enter
  (which survives `Ctrl+U`, recall and Tab, as the mirror never did), and everything after it comes
  from the `133;C` payload, exactly as before.

## Deleted surface

| deleted | replaced by |
|---|---|
| `CommandAssistController.HandleTextInput(string)` | `NotifyInputActivity()` -- a trigger with no text |
| `CommandAssistController.HandleBackspace()` | `NotifyInputActivity()` (whether the line got shorter is the grid's business) |
| `CommandAssistController.HandlePastedText(string)` | `NotifyPastedInput()` -- provenance only |
| `ViewModel.QueryText +=` / `=` in the typing and paste handlers | one write, in `ApplyRefreshOutcome`, from the pass's grid read |
| `ViewModel.QueryText = insertionText` in `TryAcceptSelection` | nothing; the shell paints the result and the next refresh reads it |
| `OpenHelpAsync`'s `?? ViewModel.QueryText` fallback | `?? TryReadQuerySnapshot()?.Text` |
| `SuggestionOrchestrator.Refresh(mode, explicit, query)` | `Refresh(mode, explicit)` |
| `CommandAssistInsertionPlanner.TryCreateInsertion(string?, ...)` | `TryCreateInsertion(AssistQuerySnapshot?, ...)` |
| the `CommandStarted` early-out in `TerminalPane.OnShellIntegrationEventObserved` | the event now opens the gate |

**Kept deliberately:** `AssistSessionStateMachine.IsCurrentSubmissionSuppressed`. An earlier comment
predicted it would die with the shadow buffer; it does not, because it is not a query fact. The grid
reads pasted text as faithfully as typed text -- what it cannot see is *provenance*, and provenance
is what gates history capture and insertion. `TermView.TextInputObserved` / `BackspaceObserved` also
stay subscribed: they are the cheapest available signal that the prompt is being edited.

**Added:** `TerminalPane.ArmShellIntegrationTracker()`, extracted out of
`ApplyShellIntegrationLaunchPlan`. Deliberately separate from `_isShellIntegrationActive` (which
means the narrower "we injected a bootstrap"), and the hook Phase 2 task 3 needs.

## Test delta

Per-project, before -> after:

| suite | before | after | delta |
|---|---|---|---|
| `NovaTerminal.App.Tests` | 1703 passed / 15 skipped / 1718 | 1736 / 15 / 1751 | +33 |
| `NovaTerminal.VT.Tests` | 270 | 270 | 0 |
| `NovaTerminal.Architecture.Tests` | 28 | 28 | 0 |
| `NovaTerminal.McpServer.Tests` | 138 | 138 | 0 |

The +33 accounts exactly:

- `CommandAssistGridTruthTests` (new, 16): the lifecycle gate opening and closing on each edge; a
  readable grid between commands still not being a query; both halves of the gate being required;
  the `Ctrl+U` / history-recall / Tab-completion matrix at the controller seam; and five
  degraded-mode tests.
- `PaneGridTruthDesyncTests` (new, 5): the same matrix through the real stack -- escape sequences
  into `TerminalPane.Parser`, out through the reader, the mark lifecycle and the boundary mapping.
- `CommandAssistInsertionPlannerTests` (4 -> 14, +10): the four original cases restated against
  snapshots, plus every refusal rule and the three V1 desync deltas.
- `CommandAssistControllerTests` (+1): a degraded session captures nothing at Enter.
- `TerminalPaneCommandAssistShortcutTests` (+1): after `133;C`, Help takes no token from the grid.

Rewritten in place, intent preserved, mechanics changed: ~20 controller tests now drive a `FakeGrid`
behind the provider seam and set the line *whole* rather than appending to it (which is the point --
the grid does not know how the text got there); capture tests hand `HandleEnterAsync` the submitted
text directly. The pane-level tests that seeded a query with `NotifyCommandAssistPaste` now paint a
real integrated prompt through the parser; that was not cosmetic, since after this change a paste
seeds nothing and two of them would have gone on passing while asserting against an empty lookup.

## Mutation checks

| mutant | result |
|---|---|
| drop `!_context.IsAcceptingCommandInput` from `SuggestionOrchestrator.TryReadQuery` | **caught**, 4 failures, incl. `BetweenCommands_AReadableGridIsStillNotAQuery` and the pane-level `OpenCommandAssistHelp_AfterTheCommandWasSubmitted_TakesNoTokenFromTheGrid` |
| drop `CursorOffset == Text.Length` from `AssistQuerySnapshot.IsUsableAsTypedPrefix` | **caught**, 4 failures: all three `WhenTheCursorIsNotAtTheEnd_Refuses` cases and the pane-level `AfterAnArrowKey_...` |

## What to scrutinise

1. **The Enter-time capture loss in markless sessions.** The plan text says "heuristic Enter-capture
   stays for history in non-integrated sessions", and strictly it does not -- the mechanism stays,
   its source is now the grid, and a markless session has no grid. The reasoning is above; if you
   disagree the alternative is a capture-only keystroke accumulator, which reintroduces the exact
   desync class into persistent data.
2. **The bare-`133;C` edge.** The parser raises `OnCommandAccepted` only for a `C` with a decodable
   base64 payload, so a bare `133;C` does not close the gate and `133;D` has to. All four bootstraps
   emit `133;C;<base64>`, and an uninstrumented session has no tracker armed, so nothing reachable
   hits this today. It becomes real when Phase 2 arms the tracker for third-party integrations;
   flagged in the gaps doc and the plan notes.
3. **Reading the grid from the refresh worker.** `TryReadAssistQuerySnapshot` is now called off the
   UI thread by design. Both things it touches are guarded (`_commandStartMarkGate`, and
   `GridQueryReader` takes the buffer's read lock), but it is a new threading edge.
4. **The remaining echo race.** A pass whose read beats the shell's echo ranks a one-character-stale
   query. Deliberate -- closing it means a debounce, which is Phase 3.
5. **`ArmShellIntegrationTracker` as internal test surface.** It let the pane tests drive the real
   parser-to-tracker-to-dispatcher-to-controller path instead of faking the event, which felt worth
   the exposure. Push back if not.
6. **Smoke scenarios 1-8** are not re-validated here. The feature is still default-off and the M4.2
   scenario doc still describes V1 behavior; the plan's exit criterion is noted as deferred to the
   flag-flip phase rather than silently ticked.
