### PR TITLE
feat(command-assist): capture straight-through-typed commands in markless sessions (V2 Phase 1, task 7)

### DIFF
--- a/docs/command-assist/CommandAssist_ShellIntegration_Gaps.md
+++ b/docs/command-assist/CommandAssist_ShellIntegration_Gaps.md
@@ -190,8 +190,9 @@ boundary as a nullable snapshot rather than a string.
 A session with no OSC 133 marks — a non-integrated local shell, a shell whose bootstrap bailed out,
 an un-instrumented SSH host — has no query at all. Not an empty query it might act on: no query.
 The shadow keystroke buffer is deleted, not kept as a fallback, because a fallback that desyncs is
-worse than no fallback (it was the fallback that made V1's history and insertions wrong). What that
-costs, concretely:
+worse than no fallback (it was the fallback that made V1's history and insertions wrong). History
+capture got a replacement in Phase 1d, but a capture-only one that refuses rather than guesses; it
+is never consulted as a query. What degraded mode costs, concretely:
 
 - **no passive suggestions.** With no query the path provider has no command token and no
   path-shaped fragment to work from, so it returns nothing. Degraded passive suggestions are empty
@@ -201,28 +202,44 @@ costs, concretely:
   for, and Fix still works, because it analyses the command that failed rather than the one being
   typed.
 - **no insertion.** Rows can be browsed; nothing may be spliced into a command line nobody can see.
-- **no Enter-time history capture.** This is the one that is worth arguing about. V1's heuristic
-  capture read the shadow buffer, so for any line the user had edited with keys the mirror could
-  not observe — `Ctrl+U`, arrows, history recall, tab completion — it wrote a command the user
-  never ran into persistent history. Recording nothing is recoverable; recording something false is
-  not. Instrumented sessions are unaffected: the first command is captured from the grid at Enter
-  (which is strictly better than the mirror ever was, since the grid survives all of those edits),
-  and every command after it comes from the `133;C` payload.
+- **Enter-time history capture, but only for a straight-through-typed line.** This is the one that
+  was worth arguing about. V1's heuristic capture read the shadow buffer, so for any line the user
+  had edited with keys the mirror could not observe — `Ctrl+U`, arrows, history recall, tab
+  completion — it wrote a command the user never ran into persistent history. Recording nothing is
+  recoverable; recording something false is not. Instrumented sessions were never affected: the
+  first command is captured from the grid at Enter (which is strictly better than the mirror ever
+  was, since the grid survives all of those edits), and every command after it comes from the
+  `133;C` payload.
 
-  **This is a hole, not a resting state, and it is tracked as Phase 1 task 7 in
-  `docs/plans/2026-08-01-command-assist-v2-plan.md` — required before the flag flip.** The affected
-  population is not marginal: `cmd.exe`, every shell whose bootstrap bailed out, and *every* SSH
-  session, since SSH launch plans skip provider injection. For those, history never fills, so
-  `Ctrl+R` is an empty box rather than a browse-only one. The replacement is deliberately not the
-  mirror: it is a **poisoned** capture-only accumulator confined to `TerminalPane`
-  (`TextInputObserved` appends, `BackspaceObserved` chops, any key the pane does not model — arrows,
-  `Home`/`End`, `Delete`, `Tab`, page keys, F-keys, unowned chords — poisons it, paste poisons it,
-  `Enter` and `Ctrl+C` reset it), consulted at Enter only when the grid has nothing, and never used
-  as the query. The distinction from V1 is the whole argument: V1's mirror answered "what is on the
-  line" with a guess and failed *silently and wrongly*; a poisoned accumulator turns itself off the
-  moment it stops knowing, so its outcomes are "exactly what was typed" or "nothing". That is the
-  same bar the grid reader is held to, reached by a different mechanism, and it is deletable once
-  Phase 2 gives instrumented remotes real marks.
+  Phase 1c shipped with markless sessions capturing nothing at all, which was a hole rather than a
+  resting state — `cmd.exe`, every shell whose bootstrap bailed out, and *every* SSH session, since
+  SSH launch plans skip provider injection. **Shipped in Phase 1d (ii-strict), Phase 1 task 7.**
+  The contract in one line: **in a session with no marks, a command typed straight through with no
+  editing is captured verbatim; anything else is captured not at all.**
+
+  The mechanism is deliberately not the mirror. `MarklessSubmissionAccumulator` is **poisoned** by
+  everything it cannot model, and it is consulted at Enter *only* when the grid has nothing — never
+  as the query. `TextInputObserved` appends, `BackspaceObserved` chops one character. The key
+  classification is an allow-list, so an unrecognised key poisons: only modifier keys, `Enter`,
+  `Backspace` (both without `Alt`), `Ctrl+C` (which resets), keys Command Assist consumed, and
+  printable keys with no `Ctrl`/`Alt`/`Meta` leave it alone. Arrows, `Home`, `End`, `Delete`, `Tab`,
+  page keys, `Insert`, `Escape`, F-keys and every unowned chord poison it, as does any text that
+  reaches the PTY without going through key handling: both paste paths, `Ctrl+Enter` insertion, the
+  drop toast, sibling-pane broadcast, the clipboard-image path, the agent host's act surface. It
+  resets on `Enter` (after the capture read), `Ctrl+C`, any alt-screen transition, and session
+  start / restart / profile switch.
+
+  Its outcomes are therefore "exactly the characters the user typed, in order" or "nothing" — the
+  same bar the grid reader is held to, reached by a different mechanism — and it is deletable in one
+  commit once Phase 2 gives instrumented remotes real marks.
+
+  **It composes with suppression rather than replacing it.** Poison is an accumulator fact ("I
+  cannot describe this line"); `AssistSessionStateMachine.IsCurrentSubmissionSuppressed` is a
+  provenance fact ("this text was not composed here") that `CapturePipeline` applies to both capture
+  sources. A paste in a markless session is stopped twice over; a paste in an *instrumented* session,
+  where the grid reads it perfectly well, is stopped only by suppression. And grid truth always wins
+  where it exists, including when it reads the line as empty: "observed empty" and "unknown" are
+  different answers and only the second falls through to the accumulator.
 
 **`Ctrl+R` in a degraded session** still opens and still helps, because history is per user rather
 than per session: with no query to filter on, Search shows the recency list, which includes
@@ -237,7 +254,8 @@ first time a keystroke fails to narrow it.
 - providers bail out (`IsIntegrated: false`) when the user forces an
   incompatible startup mode (PowerShell `-File`; bash `-c`/`--rcfile`/`--init-file`;
   zsh `-c`/`--no-rcs`/`-f`; fish `-c`/`--no-config`/`-N`); those sessions fall
-  back to heuristic capture
+  back to the markless capture-only accumulator, which records a
+  straight-through-typed command and nothing else
 - `BashBootstrapBuilder` uses a one-shot guard around the DEBUG trap to filter
   out internal hook calls, but commands run inside `PROMPT_COMMAND` itself can
   still race the guard in pathological user configurations

--- a/docs/command-assist/CommandAssist_ShellIntegration_Gaps.md
+++ b/docs/command-assist/CommandAssist_ShellIntegration_Gaps.md
@@ -220,18 +220,58 @@ is never consulted as a query. What degraded mode costs, concretely:
   The mechanism is deliberately not the mirror. `MarklessSubmissionAccumulator` is **poisoned** by
   everything it cannot model, and it is consulted at Enter *only* when the grid has nothing — never
   as the query. `TextInputObserved` appends, `BackspaceObserved` chops one character. The key
-  classification is an allow-list, so an unrecognised key poisons: only modifier keys, `Enter`,
-  `Backspace` (both without `Alt`), `Ctrl+C` (which resets), keys Command Assist consumed, and
-  printable keys with no `Ctrl`/`Alt`/`Meta` leave it alone. Arrows, `Home`, `End`, `Delete`, `Tab`,
-  page keys, `Insert`, `Escape`, F-keys and every unowned chord poison it, as does any text that
-  reaches the PTY without going through key handling: both paste paths, `Ctrl+Enter` insertion, the
-  drop toast, sibling-pane broadcast, the clipboard-image path, the agent host's act surface. It
-  resets on `Enter` (after the capture read), `Ctrl+C`, any alt-screen transition, and session
-  start / restart / profile switch.
+  classification is an allow-list, so an unrecognised key poisons. What leaves it alone:
 
-  Its outcomes are therefore "exactly the characters the user typed, in order" or "nothing" — the
-  same bar the grid reader is held to, reached by a different mechanism — and it is deletable in one
-  commit once Phase 2 gives instrumented remotes real marks.
+  - modifier keys on their own;
+  - `Enter` and `Backspace` **with no modifiers at all**. Not merely "without `Alt`": with the kitty
+    keyboard protocol's disambiguate tier active, `TerminalView` encodes a *modified* Enter or
+    Backspace as CSI u (`Ctrl+Backspace` → `CSI 127;5u`, `Shift+Enter` → `CSI 13;2u`) and returns
+    early, so `EnterObserved` / `BackspaceObserved` never fire — the accumulator would keep every
+    character while a kitty-aware editor deleted a word. The modifier is not visible downstream, so
+    the classifier refuses it up front. Cost: one lost capture per `Ctrl+Backspace`;
+  - `Ctrl+C`, which resets rather than poisons;
+  - keys Command Assist consumed (see the `Ctrl+Shift+P` note below);
+  - printable keys with no `Ctrl`/`Alt`/`Meta` — **and the `AltGr` exception**: on Windows, Avalonia
+    reports `AltGr` as `Control|Alt`, so a literal reading of that rule poisons every `@`, `{`, `[`,
+    `\`, `|` and `~` typed on a German, French, Nordic, Turkish or Polish layout, i.e. captures
+    nothing at all for those users. `Ctrl`+`Alt` plus a *text-producing* key is therefore allowed.
+    That stays fail-closed because `TerminalView` sends **nothing** to the PTY for that combination
+    — `EncodeKittyKey` returns null on the `Control|Alt` pair, `EncodeAltKey` returns null for it,
+    and the legacy `Ctrl` branch requires `!Alt` — so the only route to the shell is the composed
+    `WM_CHAR`, which arrives as `OnTextInput` and is appended. `Ctrl`+`Alt` plus a *non*-text key
+    (`Enter`, `Backspace`, `Tab`, `Escape`, arrows) still poisons: those do reach the shell.
+
+  Arrows, `Home`, `End`, `Delete`, `Tab`, page keys, `Insert`, `Escape`, F-keys and every other
+  unowned chord poison it, as does any text that reaches the PTY without going through key handling:
+  both paste paths, `Ctrl+Enter` insertion, the drop toast, sibling-pane broadcast, the
+  clipboard-image path, the agent host's act surface, and parser device replies (`OnResponse`: DA1,
+  DSR, answerback). It resets on `Enter` (after the capture read), `Ctrl+C`, any alt-screen
+  transition, and session start / restart / profile switch.
+
+  `Ctrl+Shift+P` is only *conditionally* assist-consumed: the window's shortcut handler calls
+  `TerminalPane.TryToggleCommandAssistPinShortcut`, which routes without observing, and if no
+  selection can be pinned the route returns false and the key continues on to `TerminalView`, where
+  the accumulator sees it as an unowned `Ctrl` chord and poisons. That is the safe direction — a
+  keypress that may or may not have reached the shell is treated as if it did — and it costs at most
+  one capture.
+
+  **The echo gate.** The accumulator alone is not enough, for a reason that is a security bug rather
+  than a correctness one. `TerminalView.OnTextInput` fires per keystroke unconditionally: it does not
+  know whether the shell is echoing. So `ssh host` / Enter / `hunter2` / Enter, all inside one
+  markless session, leaves a clean unpoisoned `hunter2` in the accumulator at the hidden `password:`
+  prompt with no grid snapshot to outrank it — and `SecretsFilter` is pattern-based, so a bare secret
+  sails through it into `history.jsonl`. Before the accumulator's answer is used, the pane therefore
+  requires that exact text to be **visible on the grid, ending at the cursor**
+  (`GridQueryReader.TryReadTextEndingAtCursor`, reading the cursor row and its soft-wrapped
+  predecessors under the buffer read lock, comparing text rather than columns so wide characters
+  count once). In any visible markless prompt the typed command *is* on screen — only the `B` mark is
+  missing — so a correct capture pays nothing; at a no-echo prompt the strings do not match and
+  nothing is captured. Every doubt resolves the same way: no buffer, an alt screen, an unresolvable
+  cursor, an echo that has not landed, a partially echoed line — no capture.
+
+  Its outcomes are therefore "exactly the characters the user typed, in order, and visibly on
+  screen" or "nothing" — the same bar the grid reader is held to, reached by a different mechanism —
+  and it is deletable in one commit once Phase 2 gives instrumented remotes real marks.
 
   **It composes with suppression rather than replacing it.** Poison is an accumulator fact ("I
   cannot describe this line"); `AssistSessionStateMachine.IsCurrentSubmissionSuppressed` is a

--- a/docs/plans/2026-08-01-command-assist-v2-plan.md
+++ b/docs/plans/2026-08-01-command-assist-v2-plan.md
@@ -35,10 +35,10 @@ segment before it can be claimed as supported.
 
 ## Phase 1 — Truthful query state
 
-**Status: tasks 1–6 complete; one task added and open.** Tasks 1 and 2 shipped in Phase 1a; task 3
-in Phase 1b; tasks 4, 5 and 6 in Phase 1c. Task 7 below was raised by the Phase 1c review and is
-**required before the Phase 6 flag flip**, on the same footing as the deferred smoke-scenario
-re-validation in the exit criteria: the phase's mechanism is done, its user-visible coverage is not.
+**Status: complete.** Tasks 1 and 2 shipped in Phase 1a; task 3 in Phase 1b; tasks 4, 5 and 6 in
+Phase 1c; task 7 — raised by the Phase 1c review as a pre-flag-flip requirement — in Phase 1d. The
+one item the phase still carries to Phase 6 is the deferred smoke-scenario re-validation in the exit
+criteria, which waits on the flag flip because the feature is still default-off.
 
 Tasks:
 1. **[done — Phase 1a]** Emit `OSC 133;B` from all four bootstrap builders; extend the four `*BootstrapBuilderTests` and the shell-harness integration tests. Preserve bail-out conditions and bash DEBUG-trap guard semantics.
@@ -47,9 +47,9 @@ Tasks:
 4. **[done — Phase 1c]** `SuggestionOrchestrator` consumes `GridQueryReader` when marks are live; delete the shadow buffer (`TextInputObserved`/`BackspaceObserved` mirroring). Heuristic Enter-capture stays for history in non-integrated sessions. *Amended:* the pass resolves its own query (callers no longer hand one in) and reads on its worker rather than on the keystroke, per the PR #285 review's settled-boundary point. Enter-capture stays but its source is now the grid, so it works for an instrumented session's first command and captures **nothing** in a markless one — see the Phase 1c notes below.
 5. **[done — Phase 1c]** Degraded mode: no marks → path suggestions + explicit `Ctrl+R` history search only; prefix-dependent features off. *Amended:* with no query the path provider returns nothing, so degraded passive suggestions are empty in practice; `Ctrl+R` shows the recency list and is browse-only.
 6. **[done — Phase 1c]** `CommandAssistInsertionPlanner` computes against grid truth; add tests for post-`Ctrl+U`, post-history-recall, post-Tab-completion insertion (the desync cases that broke V1). *Amended:* the planner also gained four refusal rules (no snapshot, cursor off the end, multiline, right prompt trimmed).
-7. **[open — required before the flag flip]** **Markless capture-only accumulator (ii-strict).** Restore Enter-time history capture for sessions with no `OSC 133` marks, as a *poisoned* line accumulator that lives entirely in `TerminalPane`. See "Phase 1c follow-up" below for the design and the reasoning.
+7. **[done — Phase 1d]** **Markless capture-only accumulator (ii-strict).** Restore Enter-time history capture for sessions with no `OSC 133` marks, as a *poisoned* line accumulator that lives entirely in `TerminalPane`. See "Phase 1c follow-up" below for the design and the reasoning, and the Phase 1d notes for what shipped.
 
-Exit criteria: desync test matrix green on all four shells; shadow buffer code deleted; smoke scenarios 1–8 re-validated. *Status: the desync matrix is green at three levels (reader, controller seam, real pane driven by escape sequences) and the shadow buffer is deleted. Smoke scenarios 1–8 are re-validated at the flag-flip phase, since the feature is still default-off and the M4.2 scenario doc still describes V1 behavior. Task 7 (markless capture) is carried to the same gate for the same reason, and Phase 6 step 1 must check both.*
+Exit criteria: desync test matrix green on all four shells; shadow buffer code deleted; smoke scenarios 1–8 re-validated. *Status: the desync matrix is green at three levels (reader, controller seam, real pane driven by escape sequences), the shadow buffer is deleted, and task 7 landed in Phase 1d. Smoke scenarios 1–8 are re-validated at the flag-flip phase, since the feature is still default-off and the M4.2 scenario doc still describes V1 behavior; that is the only Phase 1 item Phase 6 step 1 still has to check.*
 
 Phase 1a notes (for the task-3 `GridQueryReader` author):
 - The B mark is carried as `ShellIntegrationEvent.MarkPosition` (`ShellMarkPosition`: `Row`,
@@ -166,6 +166,40 @@ bar Phase 1c set for the grid reader, met by a different mechanism.
 population it serves (instrumented remotes stop needing it) without emptying it (`cmd.exe` and
 bailed-out bootstraps remain).
 
+### Phase 1d notes — what task 7 actually shipped
+
+`MarklessSubmissionAccumulator` (`src/NovaTerminal.App/Controls/`) plus wiring in `TerminalPane`.
+Zero changes inside `NovaTerminal.CommandAssist`, as designed: the assist assembly still sees one
+`HandleEnterAsync(string?)` and cannot tell the two sources apart.
+
+- **The poison classification is an allow-list, not the deny-list the design sketched.** The
+  interceptor is handed `(Key, KeyModifiers)`, and a deny-list of "arrows, Home, End, Delete, Tab,
+  page keys, F-keys, unowned chords" fails *open* on anything nobody thought of. Inverted, it fails
+  closed: a key press leaves the buffer alone only if it is a modifier key, `Enter`, `Backspace`
+  (both without `Alt`), `Ctrl+C` (which resets), a key Command Assist consumed, or a printable key
+  with no `Ctrl`/`Alt`/`Meta`. Everything else poisons. An allow-list missing a harmless key costs
+  one capture; a deny-list missing a line-editing key writes a false command to history.
+- **`TryHandleCommandAssistKey` was split** into the routing decision (`TryRouteCommandAssistKey`,
+  unchanged behavior) and the observation, which runs after it and returns nothing. "Command Assist
+  consumed this key" and "the shell never saw it" are the same fact, so the routing result is the
+  input to the classification.
+- **Text that reaches the PTY without going through key handling poisons at its own call site**:
+  `Ctrl+Enter` insertion (the one key Command Assist owns that *sends*), both paste paths, the
+  drag-and-drop path toast, sibling-pane broadcast, the clipboard-image path, and the agent host's
+  A3 act surface (`AgentSessionRegistration.InputInjected`, added for this).
+- **Resets**: `Enter` (after the capture read), `Ctrl+C`, any alt-screen transition in either
+  direction, and session start / restart / profile switch (`InitializeSessionCore`).
+- **Backspace refuses rather than guesses** when the last character is a surrogate or a combining
+  mark, because "one character" is then not the same thing to the accumulator and to the shell's
+  line editor. On an empty buffer it is a no-op, not a poison. There is an 8 KB cap.
+- **Composition with suppression.** They are distinct and both survive. Poison is an accumulator
+  fact ("I cannot describe this line"); `IsCurrentSubmissionSuppressed` is a provenance fact ("this
+  text was not composed here") that `CapturePipeline` applies to *both* sources, which is why a
+  paste is still not captured in an instrumented session where the grid reads it perfectly.
+- Tests: `PaneMarklessCaptureTests` (pane level, 26) and `MarklessSubmissionAccumulatorTests` (unit,
+  27). Mutation-checked: un-poisoning arrows fails the poison theory; letting the accumulator win
+  over the grid fails the grid-wins test.
+
 ## Phase 2 — Marks-based anchoring + SSH parity
 
 Tasks:
@@ -210,9 +244,9 @@ Exit criteria: local providers run through the seam with zero behavior change; a
 
 ## Phase 6 — Flag flip
 
-1. Verify all six re-enable criteria from the design doc, plus the two items Phase 1 carried here:
-   smoke scenarios 1–8 re-validated, and Phase 1 task 7 (markless capture-only accumulator) landed
-   or explicitly re-adjudicated.
+1. Verify all six re-enable criteria from the design doc, plus the one item Phase 1 carried here:
+   smoke scenarios 1–8 re-validated. (Phase 1's other carried item, task 7's markless capture-only
+   accumulator, landed in Phase 1d.)
 2. Update `CommandAssistDefaultDisabledTests` → `CommandAssistDefaultEnabledTests`; flip `TerminalSettings.CommandAssistEnabled = true`; changelog + docs refresh (`CommandAssist.md` rewritten to match V2 reality, §14 keyboard table fixed).
 3. New smoke checklist executed on Windows + Unix-over-SSH; record results in `docs/command-assist/`.
 

--- a/docs/plans/2026-08-01-command-assist-v2-plan.md
+++ b/docs/plans/2026-08-01-command-assist-v2-plan.md
@@ -175,18 +175,51 @@ Zero changes inside `NovaTerminal.CommandAssist`, as designed: the assist assemb
 - **The poison classification is an allow-list, not the deny-list the design sketched.** The
   interceptor is handed `(Key, KeyModifiers)`, and a deny-list of "arrows, Home, End, Delete, Tab,
   page keys, F-keys, unowned chords" fails *open* on anything nobody thought of. Inverted, it fails
-  closed: a key press leaves the buffer alone only if it is a modifier key, `Enter`, `Backspace`
-  (both without `Alt`), `Ctrl+C` (which resets), a key Command Assist consumed, or a printable key
-  with no `Ctrl`/`Alt`/`Meta`. Everything else poisons. An allow-list missing a harmless key costs
-  one capture; a deny-list missing a line-editing key writes a false command to history.
+  closed: a key press leaves the buffer alone only if it is a modifier key, `Enter` or `Backspace`
+  **with no modifiers at all**, `Ctrl+C` (which resets), a key Command Assist consumed, or a
+  printable key with no `Ctrl`/`Alt`/`Meta` **or with `Ctrl+Alt`, which on Windows is how Avalonia
+  reports `AltGr`**. Everything else poisons. An allow-list missing a harmless key costs one
+  capture; a deny-list missing a line-editing key writes a false command to history.
+- **Two modifier rules changed in review, both for reasons that live outside this class.**
+  - *`Enter`/`Backspace` require `KeyModifiers.None`, not merely "no `Alt`".* With the kitty
+    keyboard protocol's disambiguate tier active, `TerminalView` encodes a modified Enter or
+    Backspace as CSI u (`Ctrl+Backspace` → `CSI 127;5u`, `Shift+Enter` → `CSI 13;2u`) and returns
+    early, so `EnterObserved` / `BackspaceObserved` never fire: the accumulator would keep every
+    character while a kitty-aware editor deleted a word. Fail-closed at the cost of one capture per
+    `Ctrl+Backspace`; gating on live kitty state instead would make the classification depend on
+    terminal state that can change mid-line.
+  - *`Ctrl+Alt` plus a **text-producing** key does not poison.* Avalonia reports `AltGr` as
+    `Control|Alt`, so the literal rule cost German, French, Nordic, Turkish and Polish users every
+    `@`, `{`, `[`, `\`, `|` and `~` — i.e. essentially every capture. It stays fail-closed because
+    `TerminalView` sends *nothing* to the PTY for that combination (`EncodeKittyKey` and
+    `EncodeAltKey` both return null on the `Control|Alt` pair; the legacy `Ctrl` branch requires
+    `!Alt`), so the only route to the shell is the composed `WM_CHAR`, which arrives as
+    `OnTextInput` and is appended. `Ctrl+Alt` plus a non-text key still poisons.
+- **The echo gate (review blocker).** `TerminalView.OnTextInput` fires per keystroke
+  unconditionally, so at a hidden `password:` prompt inside a markless session the accumulator ends
+  up clean and holding the password, with no grid snapshot to outrank it — and `SecretsFilter` is
+  pattern-based, so a bare secret would reach `history.jsonl`. `TerminalPane` therefore requires the
+  accumulated text to be **painted on the grid ending at the cursor** before it is used
+  (`GridQueryReader.TryReadTextEndingAtCursor`: cursor row plus soft-wrapped predecessors, under the
+  buffer read lock, compared as text so wide characters count once). A visible markless prompt
+  always satisfies this — only the `B` mark is missing, not the text — so correct captures pay
+  nothing, and every doubt (no buffer, alt screen, unresolved cursor, unlanded or partial echo)
+  resolves to no capture.
+- **`Ctrl+Shift+P` is only conditionally assist-consumed.** The window's shortcut handler calls
+  `TryToggleCommandAssistPinShortcut`, which routes without observing; when nothing can be pinned
+  the route returns false and the key travels on to `TerminalView`, where the accumulator sees an
+  unowned `Ctrl` chord and poisons. Safe direction, one capture.
 - **`TryHandleCommandAssistKey` was split** into the routing decision (`TryRouteCommandAssistKey`,
   unchanged behavior) and the observation, which runs after it and returns nothing. "Command Assist
   consumed this key" and "the shell never saw it" are the same fact, so the routing result is the
   input to the classification.
 - **Text that reaches the PTY without going through key handling poisons at its own call site**:
   `Ctrl+Enter` insertion (the one key Command Assist owns that *sends*), both paste paths, the
-  drag-and-drop path toast, sibling-pane broadcast, the clipboard-image path, and the agent host's
-  A3 act surface (`AgentSessionRegistration.InputInjected`, added for this).
+  drag-and-drop path toast, sibling-pane broadcast, the clipboard-image path, the agent host's
+  A3 act surface (`AgentSessionRegistration.InputInjected`, added for this), and parser device
+  replies (`AnsiParser.OnResponse` — DA1, DSR, answerback; a reply that lands in a line editor is
+  literal input the same way a paste is). The accumulator's poison flag is `volatile`, because
+  `InputInjected` fires on whatever thread the agent-host IPC endpoint is serving.
 - **Resets**: `Enter` (after the capture read), `Ctrl+C`, any alt-screen transition in either
   direction, and session start / restart / profile switch (`InitializeSessionCore`).
 - **Backspace refuses rather than guesses** when the last character is a surrogate or a combining
@@ -196,9 +229,13 @@ Zero changes inside `NovaTerminal.CommandAssist`, as designed: the assist assemb
   fact ("I cannot describe this line"); `IsCurrentSubmissionSuppressed` is a provenance fact ("this
   text was not composed here") that `CapturePipeline` applies to *both* sources, which is why a
   paste is still not captured in an instrumented session where the grid reads it perfectly.
-- Tests: `PaneMarklessCaptureTests` (pane level, 26) and `MarklessSubmissionAccumulatorTests` (unit,
-  27). Mutation-checked: un-poisoning arrows fails the poison theory; letting the accumulator win
-  over the grid fails the grid-wins test.
+- Tests: `PaneMarklessCaptureTests` (pane level, 40), `MarklessSubmissionAccumulatorTests` (unit,
+  42) and the `TryReadTextEndingAtCursor` block in `GridQueryReaderTests` (VT, 10).
+  Mutation-checked: un-poisoning arrows fails the poison theory; letting the accumulator win over
+  the grid fails the grid-wins test; **removing the echo gate fails the password test** (plus the
+  partial-echo and echoed-elsewhere tests); loosening `Enter`/`Backspace` back to "no `Alt`" fails
+  the modified-Enter/Backspace tests; dropping the `AltGr` carve-out fails the AltGr theory and the
+  end-to-end AltGr capture.
 
 ## Phase 2 — Marks-based anchoring + SSH parity
 

--- a/src/NovaTerminal.App/AgentHost/AgentSessionRegistration.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentSessionRegistration.cs
@@ -262,6 +262,13 @@ namespace NovaTerminal.AgentHost
         }
 
         /// <summary>
+        /// Raised after <see cref="TrySendInput"/> has put bytes on the wire. The owning pane uses
+        /// it to invalidate anything that models the command line from keystrokes alone: an agent
+        /// typing for the user is text the keyboard path never saw.
+        /// </summary>
+        public Action? InputInjected { get; set; }
+
+        /// <summary>
         /// Injects <paramref name="text"/> into the live session (A3). Returns
         /// false when no session is published or its process has already exited.
         /// Goes through <see cref="NovaTerminal.Pty.ITerminalIO.SendInput"/> —
@@ -275,6 +282,7 @@ namespace NovaTerminal.AgentHost
             {
                 if (!session.IsProcessRunning) return false;
                 session.SendInput(text);
+                InputInjected?.Invoke();
                 return true;
             }
             catch

--- a/src/NovaTerminal.App/Controls/MarklessSubmissionAccumulator.cs
+++ b/src/NovaTerminal.App/Controls/MarklessSubmissionAccumulator.cs
@@ -1,0 +1,266 @@
+using System.Globalization;
+using System.Text;
+using Avalonia.Input;
+
+namespace NovaTerminal.Controls
+{
+    /// <summary>
+    /// What the user typed on the current command line, for the sessions where nobody can read it
+    /// off the grid: `cmd.exe`, any shell whose integration bootstrap bailed out, and every SSH
+    /// host the user has not instrumented. Used <em>only</em> as the Enter-time submission text for
+    /// history capture, never as the Command Assist query.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>This is not V1's shadow buffer.</b> The mirror that Phase 1c deleted answered "what is on
+    /// the command line?" with a guess, and its failure mode was silent wrongness: `Ctrl+U` left it
+    /// holding text that was no longer on screen, Tab completions were truncated to what the user
+    /// had typed, and all of it was written to permanent history as commands the user had run.
+    /// </para>
+    /// <para>
+    /// This one is <b>poisoned</b> by every edit it cannot model. It knows exactly two operations —
+    /// append the characters the user typed, and remove the last one on Backspace — and anything
+    /// else at all (an arrow key, `Home`, `Delete`, `Tab`, a page key, an F-key, any unowned
+    /// `Ctrl`/`Alt` chord, a paste, an assist insertion) turns it off until the line is reset. Its
+    /// only two outcomes are therefore "exactly the characters the user typed, in order" and
+    /// "nothing", which is the same bar the grid reader is held to, reached by a different
+    /// mechanism. Recording nothing is recoverable; recording a command the user never ran is not.
+    /// </para>
+    /// <para>
+    /// Deletable in one commit once every session has real `OSC 133` marks.
+    /// </para>
+    /// </remarks>
+    internal sealed class MarklessSubmissionAccumulator
+    {
+        /// <summary>
+        /// Beyond this many characters the line stops being a command anyone typed by hand, and
+        /// the accumulator stops paying to hold it. Poisoning rather than truncating, because a
+        /// truncated command line is exactly the "something false" this class exists to avoid.
+        /// </summary>
+        internal const int MaxTrackedLength = 8192;
+
+        private readonly StringBuilder _buffer = new();
+        private bool _poisoned;
+
+        internal bool IsPoisoned => _poisoned;
+
+        /// <summary>The user typed printable text and the pane sent it to the PTY.</summary>
+        internal void AppendTypedText(string? text)
+        {
+            if (_poisoned || string.IsNullOrEmpty(text))
+            {
+                return;
+            }
+
+            // A newline arriving as text input rather than as an Enter key press is not a keystroke
+            // this class models: it submits (possibly several) lines without going through the
+            // Enter path that reads and resets. CapturePipeline rejects multi-line submissions too,
+            // but the accumulator must not carry stale text into the next line either.
+            if (text.Contains('\n') || text.Contains('\r') || _buffer.Length + text.Length > MaxTrackedLength)
+            {
+                Poison();
+                return;
+            }
+
+            _buffer.Append(text);
+        }
+
+        /// <summary>
+        /// Backspace: the shell's line editor removed the last character, so remove ours.
+        /// </summary>
+        /// <remarks>
+        /// On an empty buffer this is a no-op rather than a poison: the buffer is empty exactly
+        /// when the line is, and backspace at an empty prompt does nothing in every shell.
+        /// It <em>does</em> poison when "the last character" is ambiguous — a surrogate pair or a
+        /// combining sequence, where what the shell deletes and what one UTF-16 unit is are not
+        /// reliably the same thing.
+        /// </remarks>
+        internal void ObserveBackspace()
+        {
+            if (_poisoned)
+            {
+                return;
+            }
+
+            if (_buffer.Length == 0)
+            {
+                return;
+            }
+
+            char last = _buffer[_buffer.Length - 1];
+            if (char.IsSurrogate(last) || IsCombining(last))
+            {
+                Poison();
+                return;
+            }
+
+            _buffer.Length--;
+        }
+
+        /// <summary>Something happened to the command line that this class cannot model.</summary>
+        internal void Poison() => _poisoned = true;
+
+        /// <summary>New command line: forget the text and clear the poison.</summary>
+        internal void Reset()
+        {
+            _buffer.Clear();
+            _poisoned = false;
+        }
+
+        /// <summary>
+        /// What the user submitted, or <see langword="null"/> when the accumulator stopped being
+        /// able to say. Does not reset — the caller resets after the read, because Enter is both
+        /// the read point and the reset point and the order matters.
+        /// </summary>
+        internal string? TryReadSubmission() => _poisoned ? null : _buffer.ToString();
+
+        /// <summary>
+        /// How a key press observed at <c>TerminalPane.TryHandleCommandAssistKey</c> affects the
+        /// accumulator.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <param name="modifiers">Its modifiers.</param>
+        /// <param name="wasHandledByAssist">
+        /// Whether Command Assist consumed the key. When it did, the key never reached
+        /// <c>TerminalView</c>'s input encoder and so never reached the shell, and the command line
+        /// is untouched. (`Ctrl+Enter` is the exception, because accepting a suggestion *sends*
+        /// text; the pane poisons at that call site rather than here.)
+        /// </param>
+        /// <remarks>
+        /// The classification is an <b>allow-list</b>, and that direction is deliberate: a key this
+        /// method has never heard of poisons. An allow-list that is missing a harmless key costs a
+        /// capture; a deny-list that is missing a line-editing key writes a wrong command to
+        /// history, and those two mistakes are not the same size.
+        /// </remarks>
+        internal static AccumulatorKeyEffect ClassifyKey(Key key, KeyModifiers modifiers, bool wasHandledByAssist)
+        {
+            if (wasHandledByAssist)
+            {
+                return AccumulatorKeyEffect.None;
+            }
+
+            bool isCtrl = (modifiers & KeyModifiers.Control) != 0;
+            bool isAlt = (modifiers & KeyModifiers.Alt) != 0;
+            bool isMeta = (modifiers & KeyModifiers.Meta) != 0;
+
+            if (IsModifierOnly(key))
+            {
+                return AccumulatorKeyEffect.None;
+            }
+
+            // Ctrl+C abandons the line. TerminalView routes it to copy-to-clipboard when there is a
+            // selection, which leaves the line intact, but resetting on a copy loses a capture and
+            // resetting on the interrupt is required: the cheap uniform rule errs the safe way.
+            if (isCtrl && !isAlt && key == Key.C)
+            {
+                return AccumulatorKeyEffect.Reset;
+            }
+
+            // Enter submits. The reset happens on the Enter path (after the capture read), not
+            // here, so this is only saying "do not poison". Alt+Enter is not a submit: TerminalView's
+            // Alt-sends-ESC branch runs first and it becomes an escape-prefixed chord.
+            if (key == Key.Enter && !isAlt)
+            {
+                return AccumulatorKeyEffect.None;
+            }
+
+            // Backspace is modeled; BackspaceObserved does the chop. TerminalView ignores Ctrl on
+            // Key.Back (it sends a plain DEL either way), so Ctrl+Backspace is modeled too. Alt is
+            // again intercepted upstream and is a chord.
+            if (key == Key.Back && !isAlt)
+            {
+                return AccumulatorKeyEffect.None;
+            }
+
+            // Printable keys with no chord modifier become an Avalonia TextInput event, and the
+            // append happens there with the actual text. Meta is included as a chord modifier:
+            // Cmd+key on macOS is an application shortcut, not a character.
+            if (!isCtrl && !isAlt && !isMeta && IsTextProducing(key))
+            {
+                return AccumulatorKeyEffect.None;
+            }
+
+            return AccumulatorKeyEffect.Poison;
+        }
+
+        internal void ApplyKey(Key key, KeyModifiers modifiers, bool wasHandledByAssist)
+        {
+            switch (ClassifyKey(key, modifiers, wasHandledByAssist))
+            {
+                case AccumulatorKeyEffect.Poison:
+                    Poison();
+                    break;
+                case AccumulatorKeyEffect.Reset:
+                    Reset();
+                    break;
+            }
+        }
+
+        private static bool IsModifierOnly(Key key) => key switch
+        {
+            Key.None or
+            Key.LeftShift or Key.RightShift or
+            Key.LeftCtrl or Key.RightCtrl or
+            Key.LeftAlt or Key.RightAlt or
+            Key.LWin or Key.RWin => true,
+            _ => false,
+        };
+
+        /// <summary>
+        /// Keys that produce a character rather than a control sequence. Everything that is not on
+        /// this list poisons, so it is written to be over- rather than under-inclusive of the
+        /// harmless: `Key.ImeProcessed` and `Key.DeadCharProcessed` are here because composition
+        /// ends in a TextInput event carrying the composed character (or in nothing at all, which
+        /// leaves the buffer correct either way).
+        /// </summary>
+        private static bool IsTextProducing(Key key)
+        {
+            if (key >= Key.A && key <= Key.Z)
+            {
+                return true;
+            }
+
+            if (key >= Key.D0 && key <= Key.D9)
+            {
+                return true;
+            }
+
+            if (key >= Key.NumPad0 && key <= Key.Divide)
+            {
+                // NumPad0..NumPad9, Multiply, Add, Separator, Subtract, Decimal, Divide.
+                return true;
+            }
+
+            return key switch
+            {
+                Key.Space or
+                Key.OemPlus or Key.OemComma or Key.OemMinus or Key.OemPeriod or
+                Key.Oem1 or Key.Oem2 or Key.Oem3 or Key.Oem4 or
+                Key.Oem5 or Key.Oem6 or Key.Oem7 or Key.Oem8 or
+                Key.Oem102 or
+                Key.AbntC1 or Key.AbntC2 or
+                Key.ImeProcessed or Key.DeadCharProcessed => true,
+                _ => false,
+            };
+        }
+
+        private static bool IsCombining(char value) =>
+            CharUnicodeInfo.GetUnicodeCategory(value) is
+                UnicodeCategory.NonSpacingMark or
+                UnicodeCategory.SpacingCombiningMark or
+                UnicodeCategory.EnclosingMark;
+    }
+
+    /// <summary>What a key press does to <see cref="MarklessSubmissionAccumulator"/>.</summary>
+    internal enum AccumulatorKeyEffect
+    {
+        /// <summary>The key is modeled elsewhere, or never reached the shell. Leave state alone.</summary>
+        None,
+
+        /// <summary>The command line changed in a way the accumulator cannot follow.</summary>
+        Poison,
+
+        /// <summary>The line was abandoned; start a fresh one.</summary>
+        Reset,
+    }
+}

--- a/src/NovaTerminal.App/Controls/MarklessSubmissionAccumulator.cs
+++ b/src/NovaTerminal.App/Controls/MarklessSubmissionAccumulator.cs
@@ -27,6 +27,12 @@ namespace NovaTerminal.Controls
     /// mechanism. Recording nothing is recoverable; recording a command the user never ran is not.
     /// </para>
     /// <para>
+    /// <b>It is not the last gate either.</b> Knowing what the user typed is not the same as knowing
+    /// the shell was listening: at a no-echo prompt (`ssh` asking for a password) every keystroke
+    /// still arrives here. <c>TerminalPane.ReadEchoedMarklessSubmission</c> therefore requires this
+    /// class's answer to be painted on the grid at the cursor before it is used.
+    /// </para>
+    /// <para>
     /// Deletable in one commit once every session has real `OSC 133` marks.
     /// </para>
     /// </remarks>
@@ -40,7 +46,17 @@ namespace NovaTerminal.Controls
         internal const int MaxTrackedLength = 8192;
 
         private readonly StringBuilder _buffer = new();
-        private bool _poisoned;
+
+        /// <remarks>
+        /// <c>volatile</c> because <see cref="Poison"/> is reachable off the UI thread:
+        /// <c>AgentSessionRegistration.InputInjected</c> fires on whatever thread the agent-host
+        /// IPC endpoint is serving, and <c>TerminalPane.NotifyExternalInputSent</c> calls straight
+        /// through. Every other member runs on the UI thread, so this one write is the whole of the
+        /// cross-thread surface — and a poison that the UI thread never observes is a command the
+        /// user never typed written to permanent history. Same reasoning, and the same fix, as the
+        /// pane's <c>_hasUnechoedInput</c>.
+        /// </remarks>
+        private volatile bool _poisoned;
 
         internal bool IsPoisoned => _poisoned;
 
@@ -156,18 +172,41 @@ namespace NovaTerminal.Controls
                 return AccumulatorKeyEffect.Reset;
             }
 
-            // Enter submits. The reset happens on the Enter path (after the capture read), not
-            // here, so this is only saying "do not poison". Alt+Enter is not a submit: TerminalView's
-            // Alt-sends-ESC branch runs first and it becomes an escape-prefixed chord.
-            if (key == Key.Enter && !isAlt)
+            // Enter submits and Backspace chops, and both are modeled — but only completely
+            // unmodified. Any modifier at all poisons, for a reason that is not obvious from the
+            // legacy encoder: with the kitty keyboard protocol's disambiguate tier active,
+            // TerminalView encodes a *modified* Enter or Backspace as a CSI u sequence
+            // (`Ctrl+Backspace` -> `CSI 127;5u`, `Shift+Enter` -> `CSI 13;2u`) and takes the early
+            // return, so `EnterObserved` / `BackspaceObserved` never fire. The accumulator would
+            // then keep every character while a kitty-aware line editor deleted a whole word, or
+            // keep collecting on a line the shell has already broken. The modifier is not visible
+            // in the events this class is fed, so the classifier has to refuse it up front.
+            //
+            // Cost: one lost capture per `Ctrl+Backspace` or `Shift+Enter`. That is the fail-closed
+            // direction, and gating on "is kitty active right now" instead would make the
+            // classification depend on mutable terminal state that can change mid-line.
+            if ((key == Key.Enter || key == Key.Back) && modifiers == KeyModifiers.None)
             {
                 return AccumulatorKeyEffect.None;
             }
 
-            // Backspace is modeled; BackspaceObserved does the chop. TerminalView ignores Ctrl on
-            // Key.Back (it sends a plain DEL either way), so Ctrl+Backspace is modeled too. Alt is
-            // again intercepted upstream and is a chord.
-            if (key == Key.Back && !isAlt)
+            // AltGr. On Windows, Avalonia reports it as Control|Alt — there is no separate
+            // KeyModifiers.AltGr — so without this carve-out every accented or symbol character
+            // that needs AltGr on a German, French, Nordic, Turkish or Polish layout would poison
+            // the line it appears in. That is `@`, `{`, `[`, `\`, `|`, `~` and more: on those
+            // layouts the accumulator would capture essentially nothing.
+            //
+            // This is fail-closed, not a hole, and the proof is in TerminalView: for Ctrl+Alt plus
+            // a text-producing key it sends *nothing* to the PTY. `EncodeKittyKey` returns null on
+            // the Control|Alt pair (TerminalInputModeEncoder.cs), `EncodeAltKey` returns null for
+            // the same pair, and the legacy Ctrl branch requires `!Alt`. So the only way those
+            // bytes reach the shell is the composed WM_CHAR that arrives as `OnTextInput` — which
+            // is exactly the event this class observes and appends. The keypress changes the line
+            // only through a path the accumulator can see.
+            //
+            // Non-text-producing Ctrl+Alt chords (Enter, Backspace, Tab, Escape, arrows) fall
+            // through to the poison below, because those *do* reach the shell as control bytes.
+            if (isCtrl && isAlt && !isMeta && IsTextProducing(key))
             {
                 return AccumulatorKeyEffect.None;
             }

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -147,6 +147,11 @@ namespace NovaTerminal.Controls
         // us bytes we have parsed into the grid". See NoteInputAwaitingEcho for why insertion
         // refuses while it is set. Written from the UI thread, cleared from the PTY read thread.
         private volatile bool _hasUnechoedInput;
+
+        // Enter-time history capture for sessions with no OSC 133 marks (V2 Phase 1, task 7).
+        // Never the query - see MarklessSubmissionAccumulator for why this is not the shadow
+        // buffer coming back, and OnCommandAssistEnterObserved for how it composes with grid truth.
+        private readonly MarklessSubmissionAccumulator _marklessSubmission = new();
         private string? _lastRelevantCommandText;
         private CommandAssistBarViewModel? _boundCommandAssistViewModel;
         private string? _lastCommandAssistAnchorDiagnosticSignature;
@@ -457,6 +462,8 @@ namespace NovaTerminal.Controls
                 Profile?.Type == ConnectionType.SSH ? "ssh" : "local",
                 IsActivePane,
                 profileId: Profile?.Id);
+            // A3 act: an agent typing into this pane is text the keyboard path never saw.
+            _agentRegistration.InputInjected = NotifyExternalInputSent;
             NovaTerminal.AgentHost.AgentSessionRegistry.Instance.Register(_agentRegistration);
             TitleChanged += (_, _) => UpdateAgentSessionSnapshot();
             WorkingDirectoryChanged += (_, _) => UpdateAgentSessionSnapshot();
@@ -539,36 +546,18 @@ namespace NovaTerminal.Controls
             TermView.MetricsChanged += _onTermViewMetricsLayout;
             TermView.CommandAssistAnchorHintChanged += () => UpdateCommandAssistOverlayPlacement();
             SizeChanged += (_, _) => UpdateCommandAssistOverlayPlacement();
-            // Keystrokes are triggers, not content (V2 Phase 1c). The text and the fact that a
-            // character was deleted are both discarded here: Command Assist re-reads the command
-            // line out of the grid on the refresh these queue, which is the only source that also
-            // knows about the arrow keys, Ctrl+U, history recall and shell-side Tab completion.
-            // The TermView events themselves stay - they are the cheapest available signal that
-            // the prompt is being edited.
-            TermView.TextInputObserved += _ =>
-            {
-                NoteInputAwaitingEcho();
-                if (EnsureCommandAssistInitialized())
-                {
-                    _commandAssistController?.NotifyInputActivity();
-                }
-            };
-            TermView.BackspaceObserved += () =>
-            {
-                NoteInputAwaitingEcho();
-                if (EnsureCommandAssistInitialized())
-                {
-                    _commandAssistController?.NotifyInputActivity();
-                }
-            };
+            // Keystrokes are triggers, not content, for the *query* (V2 Phase 1c): Command Assist
+            // re-reads the command line out of the grid on the refresh these queue, which is the
+            // only source that also knows about the arrow keys, Ctrl+U, history recall and
+            // shell-side Tab completion.
+            //
+            // They are content for one narrow purpose, added in V2 Phase 1 task 7: the markless
+            // submission accumulator, which supplies Enter-time history capture for the sessions
+            // the grid cannot serve. See NotifyTypedTextObserved and friends.
+            TermView.TextInputObserved += NotifyTypedTextObserved;
+            TermView.BackspaceObserved += NotifyBackspaceObserved;
             TermView.EnterObserved += OnCommandAssistEnterObserved;
-            TermView.PasteObserved += _ =>
-            {
-                if (EnsureCommandAssistInitialized())
-                {
-                    _commandAssistController?.NotifyPastedInput();
-                }
-            };
+            TermView.PasteObserved += NotifyPasteObserved;
 
             if (Buffer != null)
             {
@@ -626,6 +615,7 @@ namespace NovaTerminal.Controls
                 ToastPanel.IsVisible = false;
                 if (!string.IsNullOrEmpty(_pendingEscapedPath) && Session != null)
                 {
+                    NotifyExternalInputSent();
                     Session.SendInput(_pendingEscapedPath);
                     _pendingPasteFilePath = null;
                     _pendingEscapedPath = null;
@@ -640,6 +630,7 @@ namespace NovaTerminal.Controls
                     try
                     {
                         string content = await System.IO.File.ReadAllTextAsync(_pendingPasteFilePath);
+                        NotifyExternalInputSent();
                         NovaTerminal.Platform.Input.TerminalInputSender.SendBracketedPaste(Session, content);
                     }
                     catch (Exception ex)
@@ -1431,6 +1422,12 @@ namespace NovaTerminal.Controls
 
         private void HandleAltScreenChanged(bool isAltScreen)
         {
+            // A full-screen app owns the keyboard, and the keys it eats are not line edits. Drop
+            // whatever half-line was pending on the way in so a TUI session cannot leave text
+            // behind that a later Enter captures, and drop it again on the way out because the
+            // prompt underneath was redrawn by something the accumulator never saw.
+            _marklessSubmission.Reset();
+
             _agentRegistration?.StatusMachine.NotifyAltScreenChanged(isAltScreen);
             _commandAssistController?.HandleAltScreenChanged(isAltScreen);
             UpdateRemoteFilesSidebarVisibility();
@@ -1444,16 +1441,92 @@ namespace NovaTerminal.Controls
         /// widens the window in which the shell has begun repainting over it. This is as close to
         /// the keypress as the pane can get.
         /// </remarks>
-        private void OnCommandAssistEnterObserved()
+        internal void OnCommandAssistEnterObserved()
         {
+            // The reset is owed even when Command Assist is off or uninitialized: the accumulator
+            // is fed from TermView events that fire regardless, and a line left in it would be
+            // carried into the next one.
             if (!EnsureCommandAssistInitialized())
             {
+                _marklessSubmission.Reset();
                 return;
             }
 
-            AssistQuerySnapshot? submitted = _commandAssistController.TryReadQuerySnapshot();
-            _ = HandleCommandAssistEnterObservedAsync(submitted?.Text);
+            AssistQuerySnapshot? snapshot = _commandAssistController.TryReadQuerySnapshot();
+
+            // Grid truth always wins where it exists, including when it says the line was empty:
+            // "observed empty" and "unknown" are different answers, and only the second one falls
+            // through to the accumulator. A poisoned accumulator answers null, which
+            // CapturePipeline reads as "nothing to persist".
+            string? submitted = snapshot is { } grid
+                ? grid.Text
+                : _marklessSubmission.TryReadSubmission();
+
+            // After the read, before the await: Enter is both the capture point and the start of
+            // the next line.
+            _marklessSubmission.Reset();
+
+            _ = HandleCommandAssistEnterObservedAsync(submitted);
         }
+
+        /// <summary>
+        /// The user typed printable text into the terminal. Feeds the markless accumulator and
+        /// triggers a suggestion refresh; the text itself is content only for the accumulator.
+        /// </summary>
+        internal void NotifyTypedTextObserved(string text)
+        {
+            _marklessSubmission.AppendTypedText(text);
+            NoteInputAwaitingEcho();
+            if (EnsureCommandAssistInitialized())
+            {
+                _commandAssistController?.NotifyInputActivity();
+            }
+        }
+
+        /// <summary>The user pressed Backspace; the accumulator drops its last character.</summary>
+        internal void NotifyBackspaceObserved()
+        {
+            _marklessSubmission.ObserveBackspace();
+            NoteInputAwaitingEcho();
+            if (EnsureCommandAssistInitialized())
+            {
+                _commandAssistController?.NotifyInputActivity();
+            }
+        }
+
+        /// <summary>
+        /// Text arrived on the command line from somewhere other than the keyboard (a drag-and-drop
+        /// or a clipboard paste).
+        /// </summary>
+        /// <remarks>
+        /// Two mechanisms fire here and they are not the same one. The accumulator is
+        /// <em>poisoned</em>, because it did not see the characters and can no longer describe the
+        /// line. Command Assist is told the submission is <em>suppressed</em>, which is a
+        /// provenance claim — the text on the line was not composed here — and that one applies to
+        /// the grid path as well, where the line is perfectly readable and still should not be
+        /// written to history as something the user typed. Either alone stops the paste being
+        /// captured in a markless session; only suppression stops it in an instrumented one.
+        /// </remarks>
+        internal void NotifyPasteObserved(string text)
+        {
+            _marklessSubmission.Poison();
+            if (EnsureCommandAssistInitialized())
+            {
+                _commandAssistController?.NotifyPastedInput();
+            }
+        }
+
+        /// <summary>
+        /// Bytes reached this pane's PTY from somewhere other than its own keyboard handling: a
+        /// broadcast from a sibling pane, the drag-and-drop path toast, a clipboard image path, the
+        /// agent host's act surface. The accumulator can no longer describe the command line.
+        /// </summary>
+        /// <remarks>
+        /// A poison rather than a reset, because none of these callers can say whether what they
+        /// sent ended in a newline: unlike Enter, they leave the line in a state only the shell
+        /// knows. Poison recovers at the next Enter, which costs at most one capture.
+        /// </remarks>
+        internal void NotifyExternalInputSent() => _marklessSubmission.Poison();
 
         private async Task HandleCommandAssistEnterObservedAsync(string? submittedText)
         {
@@ -1507,7 +1580,24 @@ namespace NovaTerminal.Controls
             }
         }
 
+        /// <summary>
+        /// <c>TerminalView.KeyDownInterceptor</c>. Routes the key to Command Assist if it owns it,
+        /// and observes every key either way for the markless submission accumulator.
+        /// </summary>
+        /// <remarks>
+        /// The observation is strictly a side effect: this returns exactly what
+        /// <see cref="TryRouteCommandAssistKey"/> returns, so input routing is unchanged. It has to
+        /// run <em>after</em> the routing decision, because "Command Assist consumed this key" is
+        /// the same fact as "the shell never saw it".
+        /// </remarks>
         internal bool TryHandleCommandAssistKey(Key key, KeyModifiers modifiers)
+        {
+            bool handledByAssist = TryRouteCommandAssistKey(key, modifiers);
+            _marklessSubmission.ApplyKey(key, modifiers, handledByAssist);
+            return handledByAssist;
+        }
+
+        private bool TryRouteCommandAssistKey(Key key, KeyModifiers modifiers)
         {
             if (!IsCommandAssistFeatureEnabled())
             {
@@ -1568,7 +1658,10 @@ namespace NovaTerminal.Controls
 
         public bool TryToggleCommandAssistPinShortcut()
         {
-            return TryHandleCommandAssistKey(Key.P, KeyModifiers.Control | KeyModifiers.Shift);
+            // Routes without observing: this arrives from the window's shortcut handler, which sees
+            // the key before TerminalView does, so nothing was ever sent to the shell whether the
+            // pin toggles or not.
+            return TryRouteCommandAssistKey(Key.P, KeyModifiers.Control | KeyModifiers.Shift);
         }
 
         /// <summary>
@@ -1651,6 +1744,12 @@ namespace NovaTerminal.Controls
             }
 
             _lastRelevantCommandText = insertionText;
+
+            // Text on the command line the user did not type. Insertion is only reachable when the
+            // grid can be read, so the accumulator is not the capture source here anyway - but it
+            // is still holding a line it can no longer describe, and Ctrl+Enter is the one key the
+            // interceptor deliberately does not poison on (Command Assist owns it).
+            _marklessSubmission.Poison();
             Session.SendInput(textToSend);
             return true;
         }
@@ -1925,6 +2024,9 @@ namespace NovaTerminal.Controls
             _shellLifecycleTracker = null;
             _isShellIntegrationActive = false;
             _shellIntegrationEnvOverrides = null;
+            // A restart or a profile switch reaches here; the pending line belonged to the shell
+            // that is going away.
+            _marklessSubmission.Reset();
             lock (_commandStartMarkGate)
             {
                 _latestCommandStartMark = null;
@@ -2356,6 +2458,11 @@ namespace NovaTerminal.Controls
 
         public void NotifyCommandAssistPaste(string text)
         {
+            // Poisons before the feature gate: the accumulator is fed unconditionally, so it must
+            // be invalidated unconditionally. See NotifyPasteObserved for how poison and
+            // suppression divide the work.
+            _marklessSubmission.Poison();
+
             if (!EnsureCommandAssistInitialized())
             {
                 return;

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -1460,13 +1460,68 @@ namespace NovaTerminal.Controls
             // CapturePipeline reads as "nothing to persist".
             string? submitted = snapshot is { } grid
                 ? grid.Text
-                : _marklessSubmission.TryReadSubmission();
+                : ReadEchoedMarklessSubmission();
 
             // After the read, before the await: Enter is both the capture point and the start of
             // the next line.
             _marklessSubmission.Reset();
 
             _ = HandleCommandAssistEnterObservedAsync(submitted);
+        }
+
+        /// <summary>
+        /// The accumulator's answer, but only when the screen agrees with it.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>This gate exists to keep passwords out of history.</b> The accumulator is fed from
+        /// <c>TerminalView.OnTextInput</c>, which fires for every keystroke unconditionally — it
+        /// has no idea whether the shell is echoing. So in a markless session (`cmd.exe`, an
+        /// un-instrumented SSH host), the sequence `ssh host` / Enter / `hunter2` / Enter leaves the
+        /// accumulator holding a clean, unpoisoned `hunter2` at the hidden `password:` prompt, with
+        /// no grid snapshot to override it — and it would be written to `history.jsonl` verbatim.
+        /// <c>SecretsFilter</c> cannot save us there: it is pattern-based and a bare secret has no
+        /// pattern.
+        /// </para>
+        /// <para>
+        /// The check is the one thing that distinguishes the two cases. In any <em>visible</em>
+        /// markless prompt the typed command is on the screen — only the <c>OSC 133;B</c> mark is
+        /// missing, not the text — so requiring the accumulated string to be painted on the grid
+        /// ending at the cursor costs a correct capture nothing. At a no-echo prompt the grid holds
+        /// the prompt and nothing else, and the strings do not match.
+        /// </para>
+        /// <para>
+        /// Conservative in every direction: no buffer, an alt screen, a cursor the reader will not
+        /// resolve, an echo that has not landed yet, a shell that reprinted the line differently —
+        /// all of them fall out as "no capture". Comparison is on text rather than columns, so a
+        /// double-width character counts once (see
+        /// <see cref="GridQueryReader.TryReadTextEndingAtCursor"/>).
+        /// </para>
+        /// </remarks>
+        private string? ReadEchoedMarklessSubmission()
+        {
+            string? typed = _marklessSubmission.TryReadSubmission();
+            if (string.IsNullOrEmpty(typed))
+            {
+                // Poisoned, or an empty line: either way there is nothing to prove.
+                return typed;
+            }
+
+            TerminalBuffer? buffer = Buffer;
+            if (buffer == null)
+            {
+                return null;
+            }
+
+            if (!GridQueryReader.TryReadTextEndingAtCursor(buffer, typed.Length, out string onScreen))
+            {
+                return null;
+            }
+
+            // Exactly typed.Length characters were requested, so equality is "the accumulated text
+            // is painted on the grid and ends at the cursor". A short read (the row does not hold
+            // that much) fails the same way a wrong read does.
+            return string.Equals(onScreen, typed, StringComparison.Ordinal) ? typed : null;
         }
 
         /// <summary>
@@ -1507,8 +1562,16 @@ namespace NovaTerminal.Controls
         /// written to history as something the user typed. Either alone stops the paste being
         /// captured in a markless session; only suppression stops it in an instrumented one.
         /// </remarks>
+        /// <param name="text">
+        /// Ignored. The pasted text is deliberately not read: neither mechanism below wants it —
+        /// the accumulator's answer to "what is on the line now" is "I cannot say", not "the line
+        /// plus this", and suppression is a provenance flag with no payload. The parameter stays
+        /// because it is the <c>TerminalView.PasteObserved</c> signature and a future consumer
+        /// (length-based heuristics, say) would want it.
+        /// </param>
         internal void NotifyPasteObserved(string text)
         {
+            _ = text;
             _marklessSubmission.Poison();
             if (EnsureCommandAssistInitialized())
             {
@@ -1842,6 +1905,16 @@ namespace NovaTerminal.Controls
 
             Parser = new AnsiParser(Buffer);
 
+            // A device reply is text on the PTY that the keyboard path never produced: DA1, a DSR
+            // cursor report, an answerback. Nothing here can promise the shell's line editor was
+            // not reading when the query arrived, and a reply that lands in a line editor is
+            // literal input in exactly the way a paste is - so the accumulator can no longer
+            // describe the line. Poison rather than reset, for the same reason
+            // NotifyExternalInputSent poisons: the writer cannot say whether what it sent ended the
+            // line. Subscribed here rather than beside the SendInput handler in
+            // InitializeSessionCore so it exists whenever a parser does, session or not.
+            Parser.OnResponse += _ => _marklessSubmission.Poison();
+
             // OSC 10/11 (fg/bg color query) answers come from the active theme; without this,
             // a freshly-created parser would fall back to AnsiParser's hardcoded defaults until
             // the next ApplySettings call (#265). Must use the same profile-merged theme
@@ -2159,7 +2232,8 @@ namespace NovaTerminal.Controls
                 });
             };
 
-            // Wire up Parser responses (e.g. DA1)
+            // Wire up Parser responses (e.g. DA1). The accumulator invalidation for these lives in
+            // CreateAndWireParser, next to the parser's other observers.
             Parser.OnResponse += response =>
             {
                 Session.SendInput(response);

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -1894,6 +1894,9 @@ namespace NovaTerminal
             foreach (var pane in EnumeratePanes(tabItem.Content as Control))
             {
                 if (pane == _currentPane) continue;
+                // Broadcast bytes never went through the receiving pane's key handling, so its
+                // markless submission accumulator cannot model them.
+                pane.NotifyExternalInputSent();
                 pane.Session?.SendInput(sequence);
             }
         }
@@ -1909,6 +1912,7 @@ namespace NovaTerminal
             foreach (var pane in EnumeratePanes(tabItem.Content as Control))
             {
                 if (pane == _currentPane) continue;
+                pane.NotifyExternalInputSent();
                 pane.Session?.SendInput(text);
             }
         }
@@ -4177,6 +4181,7 @@ namespace NovaTerminal
                         string sendPath = isWsl
                             ? NovaTerminal.Platform.Input.ClipboardImage.ToWslMountPath(path)
                             : path;
+                        _currentPane.NotifyExternalInputSent();
                         _currentPane.Session.SendInput(NovaTerminal.Platform.Input.ClipboardImage.QuotePathForInput(sendPath));
                     }
                     finally

--- a/src/NovaTerminal.CommandAssist/Application/CapturePipeline.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CapturePipeline.cs
@@ -16,10 +16,15 @@ namespace NovaTerminal.CommandAssist.Application;
 /// There are two capture paths because there are two moments a command becomes known. The
 /// structured path is the shell telling us, through <c>OSC 133;C</c>, the text it accepted; that is
 /// authoritative and survives multi-line input, history recall and line editing. The Enter-time
-/// path is the host telling us what it could see on the command line when the user pressed Enter -
-/// since Phase 1c that is the terminal grid read between the newest <c>OSC 133;B</c> mark and the
-/// cursor, and nothing else. There is no keystroke mirror behind it any more, so in a session with
-/// no marks the host has nothing to pass and this path captures nothing at all.
+/// path is the host telling us what it could see on the command line when the user pressed Enter.
+/// Since Phase 1c its first source is the terminal grid, read between the newest <c>OSC 133;B</c>
+/// mark and the cursor. Since Phase 1d it has a second, strictly narrower source for the sessions
+/// that have no marks at all (`cmd.exe`, a bailed-out bootstrap, an un-instrumented SSH host): the
+/// host's <c>MarklessSubmissionAccumulator</c>, which offers a line only when the user typed it
+/// straight through with no editing <em>and</em> that exact text is painted on the grid at the
+/// cursor. It is not the V1 keystroke mirror returning - the mirror guessed, and its wrong guesses
+/// went to permanent history; this one answers "nothing" for everything it cannot model, so what
+/// reaches here is either the typed line verbatim or an empty string.
 /// </para>
 /// <para>
 /// The paths overlap for exactly one command. Structured capture only stands down the heuristic once
@@ -58,11 +63,14 @@ internal sealed class CapturePipeline
     /// went to the shell.
     /// </summary>
     /// <param name="submission">
-    /// The command line as the host read it out of the terminal grid at the instant Enter was
-    /// observed. An empty string means the host had nothing truthful to offer - a markless session,
-    /// a closed lifecycle gate, an unreadable mark - and nothing is persisted, which is the whole
-    /// point: the alternative source (a keystroke mirror) was deleted in Phase 1c because it wrote
-    /// commands the user never ran into permanent history.
+    /// The command line as the host could see it at the instant Enter was observed: read out of the
+    /// terminal grid where there is a live <c>OSC 133;B</c> mark, and otherwise the markless
+    /// accumulator's straight-through-typed line, gated on that text being echoed on screen. An
+    /// empty string means the host had nothing truthful to offer - a closed lifecycle gate, an
+    /// unreadable mark, an accumulator poisoned by an edit it could not model, or a prompt that did
+    /// not echo - and nothing is persisted. That asymmetry is the whole point: the source deleted in
+    /// Phase 1c (a keystroke mirror with no such gates) wrote commands the user never ran into
+    /// permanent history.
     /// </param>
     /// <param name="isSubmissionSuppressed">
     /// Whether the session marked this submission untrustworthy (pasted rather than typed).

--- a/src/NovaTerminal.VT/GridQueryReader.cs
+++ b/src/NovaTerminal.VT/GridQueryReader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text;
 
 namespace NovaTerminal.VT
@@ -303,6 +304,175 @@ namespace NovaTerminal.VT
                 StartRow: startRow,
                 EndRow: endRow);
             return true;
+        }
+
+        /// <summary>
+        /// Reads the last <paramref name="maxChars"/> characters of grid text that sit immediately
+        /// behind the cursor, following soft-wrapped predecessor rows backwards as far as needed.
+        /// </summary>
+        /// <param name="buffer">The buffer to read.</param>
+        /// <param name="maxChars">How many characters to read back from the cursor.</param>
+        /// <param name="text">
+        /// The text ending at the cursor. Shorter than <paramref name="maxChars"/> when the grid
+        /// does not hold that much behind the cursor, which is itself an answer.
+        /// </param>
+        /// <returns>
+        /// <c>false</c> when there is no readable grid at all (no buffer, an active alt screen, a
+        /// cursor outside the buffer). Never throws.
+        /// </returns>
+        /// <remarks>
+        /// <para>
+        /// This exists for one caller and one question: <b>did the shell echo what the user
+        /// typed?</b> In a markless session the host has no <c>OSC 133;B</c> mark to read from, so
+        /// it cannot say where the command line starts — but it can still ask whether a candidate
+        /// string is painted on the screen ending at the cursor, which is what an echoing line
+        /// editor produces and what a hidden password prompt does not. See
+        /// <c>TerminalPane.WasAccumulatedTextEchoedAtCursor</c>.
+        /// </para>
+        /// <para>
+        /// It deliberately does <i>not</i> try to identify the command line. It reads a fixed
+        /// number of characters backwards and hands them over; deciding whether they match is the
+        /// caller's job, and a mismatch means "do not capture" rather than "capture something
+        /// else".
+        /// </para>
+        /// <para>
+        /// Wide characters are compared as text, not columns: the trailing half of a double-width
+        /// cell is skipped exactly as <see cref="TryReadCommandLine"/> skips it, so one CJK
+        /// character is one character here too. Lock discipline matches
+        /// <see cref="TryReadCommandLine"/>.
+        /// </para>
+        /// </remarks>
+        public static bool TryReadTextEndingAtCursor(
+            TerminalBuffer buffer,
+            int maxChars,
+            out string text)
+        {
+            text = string.Empty;
+            if (buffer is null || maxChars < 0)
+            {
+                return false;
+            }
+
+            bool lockTaken = false;
+            if (!buffer.Lock.IsReadLockHeld &&
+                !buffer.Lock.IsWriteLockHeld &&
+                !buffer.Lock.IsUpgradeableReadLockHeld)
+            {
+                buffer.Lock.EnterReadLock();
+                lockTaken = true;
+            }
+
+            try
+            {
+                return TryReadTextEndingAtCursorLocked(buffer, maxChars, out text);
+            }
+            finally
+            {
+                if (lockTaken)
+                {
+                    buffer.Lock.ExitReadLock();
+                }
+            }
+        }
+
+        private static bool TryReadTextEndingAtCursorLocked(
+            TerminalBuffer buffer,
+            int maxChars,
+            out string text)
+        {
+            text = string.Empty;
+
+            // A full-screen application owns the grid; there is no echoing line editor to check.
+            if (buffer.IsAltScreenActive)
+            {
+                return false;
+            }
+
+            int cols = buffer.Cols;
+            if (cols <= 0)
+            {
+                return false;
+            }
+
+            int totalRows = buffer.InternalTotalLines;
+            int cursorRow = buffer.Scrollback.Count + buffer.InternalCursorRow;
+            if (cursorRow < 0 || cursorRow >= totalRows)
+            {
+                return false;
+            }
+
+            // Deferred autowrap: after a character lands on the last column the cursor stays
+            // parked there with the wrap pending, so its *text* position is one past it.
+            int cursorTextCol = buffer.IsPendingWrap
+                ? Math.Min(buffer.InternalCursorCol + 1, cols)
+                : buffer.InternalCursorCol;
+            if (cursorTextCol < 0)
+            {
+                return false;
+            }
+
+            cursorTextCol = Math.Min(cursorTextCol, cols);
+
+            if (maxChars == 0)
+            {
+                return true;
+            }
+
+            var rows = new List<string>();
+            int collected = 0;
+            int row = cursorRow;
+            int rowsRead = 0;
+
+            while (true)
+            {
+                int endCol = row == cursorRow
+                    ? cursorTextCol
+                    : SoftWrappedRowEnd(buffer, row, cols);
+
+                string rowText = ReadRowText(buffer, row, endCol);
+                rows.Add(rowText);
+                collected += rowText.Length;
+                rowsRead++;
+
+                if (collected >= maxChars ||
+                    row <= 0 ||
+                    rowsRead >= MaxSpanRows ||
+                    !buffer.IsRowWrappedAbsolute(row - 1))
+                {
+                    break;
+                }
+
+                row--;
+            }
+
+            rows.Reverse();
+            string joined = string.Concat(rows);
+            text = joined.Length > maxChars
+                ? joined.Substring(joined.Length - maxChars)
+                : joined;
+            return true;
+        }
+
+        /// <summary>
+        /// The text of one row's cells in <c>[0, endCol)</c>, with the same cell-to-character
+        /// rules <see cref="TryReadCommandLineLocked"/> uses: wide continuations are skipped,
+        /// and an unset cell reads as a space.
+        /// </summary>
+        private static string ReadRowText(TerminalBuffer buffer, int row, int endCol)
+        {
+            var text = new StringBuilder();
+            for (int col = 0; col < endCol; col++)
+            {
+                if (buffer.GetCellAbsolute(col, row).IsWideContinuation)
+                {
+                    continue;
+                }
+
+                string grapheme = buffer.GetGraphemeAbsolute(col, row);
+                text.Append(string.IsNullOrEmpty(grapheme) || grapheme == "\0" ? " " : grapheme);
+            }
+
+            return text.ToString();
         }
 
         /// <summary>

--- a/tests/NovaTerminal.App.Tests/Controls/MarklessSubmissionAccumulatorTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/MarklessSubmissionAccumulatorTests.cs
@@ -1,0 +1,159 @@
+using Avalonia.Input;
+using NovaTerminal.Controls;
+using Xunit;
+
+namespace NovaTerminal.Tests.Controls;
+
+/// <summary>
+/// The accumulator's own rules, away from the pane. <c>PaneMarklessCaptureTests</c> covers the
+/// wiring; this covers the edges that are hard to reach through a terminal.
+/// </summary>
+public class MarklessSubmissionAccumulatorTests
+{
+    [Fact]
+    public void TypingThenReading_ReturnsExactlyWhatWasTyped()
+    {
+        var accumulator = new MarklessSubmissionAccumulator();
+
+        accumulator.AppendTypedText("git");
+        accumulator.AppendTypedText(" ");
+        accumulator.AppendTypedText("status");
+
+        Assert.Equal("git status", accumulator.TryReadSubmission());
+    }
+
+    /// <summary>
+    /// Backspace at an empty prompt does nothing in every shell, so it must not poison: otherwise
+    /// one stray keypress before the user starts typing costs the whole command.
+    /// </summary>
+    [Fact]
+    public void BackspaceOnAnEmptyBuffer_IsANoOpRatherThanAPoison()
+    {
+        var accumulator = new MarklessSubmissionAccumulator();
+
+        accumulator.ObserveBackspace();
+        accumulator.AppendTypedText("ls");
+
+        Assert.Equal("ls", accumulator.TryReadSubmission());
+    }
+
+    /// <summary>
+    /// "The last character" is not a well-defined thing to remove when the buffer ends in a
+    /// surrogate pair or a combining sequence: what the shell's line editor deletes and what one
+    /// UTF-16 unit is are not reliably the same. Refuse rather than guess.
+    /// </summary>
+    [Theory]
+    // An astral-plane emoji (two UTF-16 units), then "e" plus a combining acute (two code points
+    // that render as one character).
+    [InlineData("cd \U0001F600")]
+    [InlineData("echo é")]
+    public void BackspaceOverAnAmbiguousCharacter_Poisons(string typed)
+    {
+        var accumulator = new MarklessSubmissionAccumulator();
+
+        accumulator.AppendTypedText(typed);
+        accumulator.ObserveBackspace();
+
+        Assert.True(accumulator.IsPoisoned);
+        Assert.Null(accumulator.TryReadSubmission());
+    }
+
+    /// <summary>
+    /// Text input carrying a newline submits without going through the Enter path that reads and
+    /// resets, so the accumulator would otherwise carry the line into the next command.
+    /// </summary>
+    [Fact]
+    public void TextInputContainingANewline_Poisons()
+    {
+        var accumulator = new MarklessSubmissionAccumulator();
+
+        accumulator.AppendTypedText("echo one\necho two");
+
+        Assert.Null(accumulator.TryReadSubmission());
+    }
+
+    [Fact]
+    public void BeyondTheLengthCap_Poisons()
+    {
+        var accumulator = new MarklessSubmissionAccumulator();
+
+        accumulator.AppendTypedText(new string('x', MarklessSubmissionAccumulator.MaxTrackedLength));
+        Assert.NotNull(accumulator.TryReadSubmission());
+
+        accumulator.AppendTypedText("x");
+        Assert.Null(accumulator.TryReadSubmission());
+    }
+
+    [Fact]
+    public void Reset_ClearsBothTheTextAndThePoison()
+    {
+        var accumulator = new MarklessSubmissionAccumulator();
+
+        accumulator.AppendTypedText("git sta");
+        accumulator.Poison();
+        accumulator.Reset();
+        accumulator.AppendTypedText("ls");
+
+        Assert.Equal("ls", accumulator.TryReadSubmission());
+    }
+
+    /// <summary>
+    /// The classification is an allow-list. A key nobody thought about poisons, because an
+    /// allow-list that is missing a harmless key costs a capture and a deny-list that is missing a
+    /// line-editing key writes a command the user never ran into permanent history.
+    /// </summary>
+    [Theory]
+    [InlineData(Key.MediaNextTrack, KeyModifiers.None)]
+    [InlineData(Key.BrowserBack, KeyModifiers.None)]
+    [InlineData(Key.A, KeyModifiers.Control)]
+    [InlineData(Key.A, KeyModifiers.Alt)]
+    [InlineData(Key.A, KeyModifiers.Meta)]
+    [InlineData(Key.Enter, KeyModifiers.Alt)]
+    [InlineData(Key.Back, KeyModifiers.Alt)]
+    public void UnknownAndChordedKeys_Poison(Key key, KeyModifiers modifiers)
+    {
+        Assert.Equal(
+            AccumulatorKeyEffect.Poison,
+            MarklessSubmissionAccumulator.ClassifyKey(key, modifiers, wasHandledByAssist: false));
+    }
+
+    [Theory]
+    [InlineData(Key.A, KeyModifiers.None)]
+    [InlineData(Key.A, KeyModifiers.Shift)]
+    [InlineData(Key.D4, KeyModifiers.Shift)]
+    [InlineData(Key.Space, KeyModifiers.None)]
+    [InlineData(Key.OemMinus, KeyModifiers.None)]
+    [InlineData(Key.NumPad7, KeyModifiers.None)]
+    [InlineData(Key.Divide, KeyModifiers.None)]
+    [InlineData(Key.Enter, KeyModifiers.None)]
+    [InlineData(Key.Back, KeyModifiers.None)]
+    [InlineData(Key.Back, KeyModifiers.Control)]
+    [InlineData(Key.LeftShift, KeyModifiers.None)]
+    public void ModeledAndPrintableKeys_LeaveTheBufferAlone(Key key, KeyModifiers modifiers)
+    {
+        Assert.Equal(
+            AccumulatorKeyEffect.None,
+            MarklessSubmissionAccumulator.ClassifyKey(key, modifiers, wasHandledByAssist: false));
+    }
+
+    /// <summary>
+    /// A key Command Assist consumed never reached <c>TerminalView</c>'s encoder, so it never
+    /// reached the shell and the command line is untouched. (`Ctrl+Enter` is the exception and the
+    /// pane poisons at that call site, because accepting a suggestion sends text.)
+    /// </summary>
+    [Fact]
+    public void AKeyCommandAssistConsumed_DoesNotPoison()
+    {
+        Assert.Equal(
+            AccumulatorKeyEffect.None,
+            MarklessSubmissionAccumulator.ClassifyKey(Key.Up, KeyModifiers.None, wasHandledByAssist: true));
+    }
+
+    [Fact]
+    public void CtrlC_Resets()
+    {
+        Assert.Equal(
+            AccumulatorKeyEffect.Reset,
+            MarklessSubmissionAccumulator.ClassifyKey(Key.C, KeyModifiers.Control, wasHandledByAssist: false));
+    }
+}

--- a/tests/NovaTerminal.App.Tests/Controls/MarklessSubmissionAccumulatorTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/MarklessSubmissionAccumulatorTests.cs
@@ -117,6 +117,91 @@ public class MarklessSubmissionAccumulatorTests
             MarklessSubmissionAccumulator.ClassifyKey(key, modifiers, wasHandledByAssist: false));
     }
 
+    /// <summary>
+    /// `Enter` and `Backspace` are modeled only completely unmodified, and the reason is the kitty
+    /// keyboard protocol rather than the legacy encoder. With the disambiguate tier active,
+    /// `TerminalView` encodes a modified Enter or Backspace as CSI u — `Ctrl+Backspace` becomes
+    /// `CSI 127;5u`, `Shift+Enter` becomes `CSI 13;2u` — and takes the early return, so
+    /// `BackspaceObserved` / `EnterObserved` never fire. A kitty-aware line editor deletes a whole
+    /// word on that sequence while the accumulator, having been told nothing, keeps every
+    /// character. The modifier is invisible by the time the observation events arrive, so the
+    /// refusal has to happen here.
+    /// </summary>
+    [Theory]
+    [InlineData(Key.Back, KeyModifiers.Control)]
+    [InlineData(Key.Back, KeyModifiers.Shift)]
+    [InlineData(Key.Enter, KeyModifiers.Control)]
+    [InlineData(Key.Enter, KeyModifiers.Shift)]
+    public void ModifiedEnterAndBackspace_Poison(Key key, KeyModifiers modifiers)
+    {
+        Assert.Equal(
+            AccumulatorKeyEffect.Poison,
+            MarklessSubmissionAccumulator.ClassifyKey(key, modifiers, wasHandledByAssist: false));
+    }
+
+    /// <summary>
+    /// The <c>AltGr</c> carve-out. Windows Avalonia reports <c>AltGr</c> as <c>Control|Alt</c>, so
+    /// without this a German, French, Nordic, Turkish or Polish user poisons the line on every
+    /// <c>@</c>, <c>{</c>, <c>[</c>, <c>\</c>, <c>|</c> and <c>~</c> — which is to say, captures
+    /// nothing.
+    /// </summary>
+    /// <remarks>
+    /// It stays fail-closed because <c>TerminalView</c> sends nothing to the PTY for
+    /// <c>Ctrl+Alt</c> plus a text-producing key: <c>EncodeKittyKey</c> returns null on the
+    /// <c>Control|Alt</c> pair, <c>EncodeAltKey</c> returns null for it, and the legacy <c>Ctrl</c>
+    /// branch requires <c>!Alt</c>. The only path to the shell is the composed <c>WM_CHAR</c>,
+    /// which arrives as <c>OnTextInput</c> and is appended — so the accumulator sees every change
+    /// this keypress makes to the line.
+    /// </remarks>
+    [Theory]
+    [InlineData(Key.Q)]        // AltGr+Q -> '@' on a German layout
+    [InlineData(Key.D2)]       // AltGr+2 -> '@' on many layouts
+    [InlineData(Key.Oem5)]     // AltGr+<key> -> '\' or '|' depending on layout
+    [InlineData(Key.Oem102)]
+    [InlineData(Key.NumPad7)]
+    public void AltGrPlusATextProducingKey_LeavesTheBufferAlone(Key key)
+    {
+        Assert.Equal(
+            AccumulatorKeyEffect.None,
+            MarklessSubmissionAccumulator.ClassifyKey(
+                key, KeyModifiers.Control | KeyModifiers.Alt, wasHandledByAssist: false));
+    }
+
+    /// <summary>
+    /// The other half of the carve-out: <c>Ctrl+Alt</c> plus a key that does <em>not</em> produce
+    /// text still poisons, because those <em>do</em> reach the shell as control bytes and the
+    /// accumulator never learns what the line editor did with them.
+    /// </summary>
+    [Theory]
+    [InlineData(Key.Enter)]
+    [InlineData(Key.Back)]
+    [InlineData(Key.Tab)]
+    [InlineData(Key.Escape)]
+    [InlineData(Key.Left)]
+    [InlineData(Key.Delete)]
+    public void AltGrPlusANonTextKey_StillPoisons(Key key)
+    {
+        Assert.Equal(
+            AccumulatorKeyEffect.Poison,
+            MarklessSubmissionAccumulator.ClassifyKey(
+                key, KeyModifiers.Control | KeyModifiers.Alt, wasHandledByAssist: false));
+    }
+
+    /// <summary>
+    /// The carve-out is for <c>AltGr</c>, not for "any pile of modifiers". Adding <c>Meta</c> makes
+    /// it an application chord again on every platform that has one.
+    /// </summary>
+    [Fact]
+    public void CtrlAltMetaPlusATextProducingKey_Poisons()
+    {
+        Assert.Equal(
+            AccumulatorKeyEffect.Poison,
+            MarklessSubmissionAccumulator.ClassifyKey(
+                Key.Q,
+                KeyModifiers.Control | KeyModifiers.Alt | KeyModifiers.Meta,
+                wasHandledByAssist: false));
+    }
+
     [Theory]
     [InlineData(Key.A, KeyModifiers.None)]
     [InlineData(Key.A, KeyModifiers.Shift)]
@@ -127,7 +212,6 @@ public class MarklessSubmissionAccumulatorTests
     [InlineData(Key.Divide, KeyModifiers.None)]
     [InlineData(Key.Enter, KeyModifiers.None)]
     [InlineData(Key.Back, KeyModifiers.None)]
-    [InlineData(Key.Back, KeyModifiers.Control)]
     [InlineData(Key.LeftShift, KeyModifiers.None)]
     public void ModeledAndPrintableKeys_LeaveTheBufferAlone(Key key, KeyModifiers modifiers)
     {

--- a/tests/NovaTerminal.App.Tests/Controls/PaneMarklessCaptureTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneMarklessCaptureTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
+using NovaTerminal.AgentHost;
 using NovaTerminal.CommandAssist.Domain;
 using NovaTerminal.CommandAssist.Models;
 using NovaTerminal.Controls;
@@ -176,8 +177,10 @@ public class PaneMarklessCaptureTests
     {
         using var fixture = await Fixture.IntegratedAsync("git status --short");
 
-        // Everything the accumulator would have said is wrong or absent.
-        fixture.Type("nonsense");
+        // Everything the accumulator would have said is wrong or absent. Deliberately unechoed:
+        // the point is that the grid's answer is taken without the accumulator being consulted at
+        // all, so what is painted must stay exactly what IntegratedAsync painted.
+        fixture.Type("nonsense", echo: false);
         fixture.PressKey(Key.Left);
 
         fixture.PressEnter();
@@ -234,6 +237,204 @@ public class PaneMarklessCaptureTests
         Assert.True(await fixture.NothingWasCapturedAsync());
     }
 
+    /// <summary>
+    /// The security case, and the reason the echo gate exists at all.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>TerminalView.OnTextInput</c> fires for every keystroke unconditionally — it cannot know
+    /// whether the shell is echoing. So inside one markless session, `ssh host` submits and resets
+    /// the accumulator, and then at the hidden `password:` prompt every character of the password
+    /// is appended to a perfectly clean, unpoisoned accumulator, with no grid snapshot to outrank
+    /// it. Without the gate, the password is written to `history.jsonl` verbatim:
+    /// <c>SecretsFilter</c> is pattern-based, and a bare secret has no pattern.
+    /// </para>
+    /// <para>
+    /// The distinguishing fact is on the screen. A visible markless prompt has the typed command
+    /// painted on it — only the <c>OSC 133;B</c> mark is missing — and a no-echo prompt does not.
+    /// </para>
+    /// </remarks>
+    [AvaloniaFact]
+    public async Task InAMarklessSession_TextTheShellNeverEchoedIsNotCaptured()
+    {
+        using var fixture = await Fixture.MarklessAsync();
+
+        // The command that opens the no-echo prompt is an ordinary, echoed, captured line.
+        fixture.Type("ssh host");
+        fixture.PressEnter();
+        CommandHistoryEntry entry = await fixture.WaitForSingleEntryAsync();
+        Assert.Equal("ssh host", entry.CommandText);
+
+        // Then the prompt itself, and a password that never appears on the grid.
+        fixture.Echo("\r\nhost's password: ");
+        fixture.Type("hunter2", echo: false);
+        fixture.PressEnter();
+
+        Assert.True(await fixture.OnlyTheFirstEntryWasCapturedAsync("ssh host"));
+    }
+
+    /// <summary>
+    /// Half an echo is not an echo. A shell that painted some of what was typed — a slow remote, a
+    /// prompt that reprinted, a line the accumulator and the screen simply disagree about — is a
+    /// case where the honest answer is "I do not know what was submitted".
+    /// </summary>
+    [AvaloniaFact]
+    public async Task InAMarklessSession_APartiallyEchoedLineIsNotCaptured()
+    {
+        using var fixture = await Fixture.MarklessAsync();
+
+        fixture.Type("git checkout ma", echo: false);
+        fixture.Echo("git checkout m");
+        fixture.PressEnter();
+
+        Assert.True(await fixture.NothingWasCapturedAsync());
+    }
+
+    /// <summary>
+    /// The gate compares against what is at the <em>cursor</em>, not anywhere on the row: text that
+    /// happens to be on screen because it scrolled past earlier is not evidence that this line was
+    /// echoed.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task InAMarklessSession_TextEchoedSomewhereElseOnTheRowIsNotCaptured()
+    {
+        using var fixture = await Fixture.MarklessAsync();
+
+        fixture.Echo("whoami and then some");
+        fixture.Type("whoami", echo: false);
+        fixture.PressEnter();
+
+        Assert.True(await fixture.NothingWasCapturedAsync());
+    }
+
+    /// <summary>
+    /// `AltGr` on a non-US layout. Windows Avalonia reports it as `Control|Alt`, and the composed
+    /// character arrives afterwards as an ordinary text-input event; treating the key press as an
+    /// unowned `Ctrl` chord would poison the line, which on a German, French, Nordic, Turkish or
+    /// Polish layout means losing the capture of any command containing `@`, `{`, `[`, `\`, `|` or
+    /// `~` — i.e. most of them.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task InAMarklessSession_AnAltGrComposedCharacterIsCaptured()
+    {
+        using var fixture = await Fixture.MarklessAsync();
+
+        fixture.Type("ssh user");
+
+        // AltGr+Q on a German layout: the key press, then the WM_CHAR it composes.
+        fixture.PressKey(Key.Q, KeyModifiers.Control | KeyModifiers.Alt);
+        fixture.Pane.NotifyTypedTextObserved("@");
+        fixture.Echo("@");
+
+        fixture.Type("example.com");
+        fixture.PressEnter();
+
+        CommandHistoryEntry entry = await fixture.WaitForSingleEntryAsync();
+        Assert.Equal("ssh user@example.com", entry.CommandText);
+    }
+
+    /// <summary>
+    /// The other half of the `AltGr` carve-out: `Ctrl+Alt` plus a key that produces no text does
+    /// reach the shell as a control byte, so it still poisons.
+    /// </summary>
+    [AvaloniaTheory]
+    [InlineData(Key.Back)]
+    [InlineData(Key.Enter)]
+    [InlineData(Key.Tab)]
+    [InlineData(Key.Escape)]
+    public async Task InAMarklessSession_CtrlAltPlusANonTextKeyStopsTheLineBeingCaptured(Key key)
+    {
+        using var fixture = await Fixture.MarklessAsync();
+
+        fixture.Type("git status");
+        fixture.PressKey(key, KeyModifiers.Control | KeyModifiers.Alt);
+        fixture.PressEnter();
+
+        Assert.True(await fixture.NothingWasCapturedAsync());
+    }
+
+    /// <summary>
+    /// `Ctrl+Backspace` and `Shift+Enter` are not the plain keys with a harmless modifier riding
+    /// along. Under the kitty keyboard protocol's disambiguate tier `TerminalView` encodes them as
+    /// CSI u and returns early, so `BackspaceObserved` / `EnterObserved` never fire and the
+    /// accumulator keeps characters a kitty-aware editor has already deleted. The classifier
+    /// refuses the modifier instead, at the cost of one capture.
+    /// </summary>
+    [AvaloniaTheory]
+    [InlineData(Key.Back, KeyModifiers.Control)]
+    [InlineData(Key.Back, KeyModifiers.Shift)]
+    [InlineData(Key.Enter, KeyModifiers.Shift)]
+    public async Task InAMarklessSession_AModifiedEnterOrBackspaceStopsTheLineBeingCaptured(
+        Key key, KeyModifiers modifiers)
+    {
+        using var fixture = await Fixture.MarklessAsync();
+
+        fixture.Type("git status");
+        fixture.PressKey(key, modifiers);
+        fixture.PressEnter();
+
+        Assert.True(await fixture.NothingWasCapturedAsync());
+    }
+
+    /// <summary>
+    /// A device reply — DA1 here, but a DSR cursor report or an answerback the same way — is text
+    /// on the PTY that the keyboard never produced. If it arrives while a line editor is reading,
+    /// it lands in the line exactly as a paste would.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task InAMarklessSession_AParserDeviceReplyStopsTheLineBeingCaptured()
+    {
+        using var fixture = await Fixture.MarklessAsync();
+
+        fixture.Type("echo hi");
+        fixture.Echo("\x1b[c"); // a primary device attributes query; the parser answers it
+        fixture.PressEnter();
+
+        Assert.True(await fixture.NothingWasCapturedAsync());
+    }
+
+    /// <summary>
+    /// The agent host's act surface reaches the pane through
+    /// <c>AgentSessionRegistration.InputInjected</c>, which is set in <c>SetupCommon</c>. Driven
+    /// through the registry rather than by calling the pane method directly, so the wiring itself
+    /// is what is asserted: an agent typing for the user is text the keyboard path never saw.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task InAMarklessSession_AgentInjectedInputStopsTheLineBeingCaptured()
+    {
+        using var fixture = await Fixture.MarklessAsync();
+
+        Assert.True(AgentSessionRegistry.Instance.TryGet(fixture.Pane.PaneId, out AgentSessionRegistration registration));
+
+        fixture.Type("echo ");
+        Assert.NotNull(registration.InputInjected);
+        registration.InputInjected!.Invoke();
+        fixture.PressEnter();
+
+        Assert.True(await fixture.NothingWasCapturedAsync());
+    }
+
+    /// <summary>
+    /// Grid truth wins even when it is empty. "The line is empty" and "I cannot read the line" are
+    /// different answers, and only the second falls through to the accumulator — otherwise an
+    /// instrumented session with a stale accumulator would capture the accumulator's leftovers
+    /// every time the user pressed Enter at a bare prompt.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task InAnIntegratedSession_AnEmptyGridBeatsACleanAccumulator()
+    {
+        // The dangerous shape, built deliberately: the text is painted *before* the B mark, so the
+        // grid reads the command line as empty while the echo gate — which only asks whether the
+        // accumulated text is on screen at the cursor — would happily wave it through. Only the
+        // "grid truth wins, including when it is empty" rule stops this capture.
+        using var fixture = await Fixture.IntegratedAsync(string.Empty, prompt: "$ rm -rf /");
+
+        fixture.Type("rm -rf /", echo: false);
+        fixture.PressEnter();
+
+        Assert.True(await fixture.NothingWasCapturedAsync());
+    }
+
     private sealed class Fixture : IDisposable
     {
         private readonly string _directory;
@@ -256,13 +457,17 @@ public class PaneMarklessCaptureTests
             return fixture;
         }
 
-        /// <summary>An instrumented prompt with <paramref name="commandLine"/> painted at it.</summary>
-        public static async Task<Fixture> IntegratedAsync(string commandLine)
+        /// <summary>
+        /// An instrumented prompt with <paramref name="commandLine"/> painted at it.
+        /// <paramref name="prompt"/> is what is painted <em>before</em> the <c>B</c> mark, so a
+        /// caller can place text on the row that the mark deliberately excludes.
+        /// </summary>
+        public static async Task<Fixture> IntegratedAsync(string commandLine, string prompt = "$ ")
         {
             Fixture fixture = await CreateAsync();
             fixture.Pane.ArmShellIntegrationTracker();
             fixture.Pane.CreateAndWireParser();
-            fixture.Pane.Parser!.Process(PromptStart + "$ " + PromptEnd + commandLine);
+            fixture.Pane.Parser!.Process(PromptStart + prompt + PromptEnd + commandLine);
 
             // The shell-integration dispatcher is serialized and asynchronous; B opens the
             // lifecycle gate on the far side of it.
@@ -270,23 +475,45 @@ public class PaneMarklessCaptureTests
             return fixture;
         }
 
-        public void Type(string text)
+        /// <summary>
+        /// Types <paramref name="text"/> and, unless <paramref name="echo"/> says otherwise, has
+        /// the shell paint it back.
+        /// </summary>
+        /// <remarks>
+        /// The echo is not decoration. Since the echo gate landed, the pane will not use the
+        /// accumulator's answer unless that text is on the grid at the cursor — which is what an
+        /// ordinary visible prompt produces and what a password prompt does not. Passing
+        /// <c>echo: false</c> is how these tests spell "the shell did not show this".
+        /// </remarks>
+        public void Type(string text, bool echo = true)
         {
             foreach (char c in text)
             {
                 // One key press then one text-input event, in the order Avalonia raises them.
                 PressKey(KeyForCharacter(c));
                 Pane.NotifyTypedTextObserved(c.ToString());
+                if (echo)
+                {
+                    Echo(c.ToString());
+                }
             }
         }
+
+        /// <summary>Bytes arriving from the shell, painted into the grid.</summary>
+        public void Echo(string text) => Pane.Parser!.Process(text);
 
         public void PressKey(Key key, KeyModifiers modifiers = KeyModifiers.None) =>
             Pane.TryHandleCommandAssistKey(key, modifiers);
 
-        public void PressBackspace()
+        public void PressBackspace(bool echo = true)
         {
             PressKey(Key.Back);
             Pane.NotifyBackspaceObserved();
+            if (echo)
+            {
+                // What every line editor sends to rub out one character.
+                Echo("\b \b");
+            }
         }
 
         public void PressEnter()
@@ -338,6 +565,18 @@ public class PaneMarklessCaptureTests
             await Task.Delay(150);
             IReadOnlyList<CommandHistoryEntry> entries = await _historyStore.GetRecentAsync(10);
             return entries.Count == 0;
+        }
+
+        /// <summary>
+        /// The store holds exactly one entry and it is <paramref name="expected"/> — for the tests
+        /// where an earlier command legitimately was captured and the claim is that a later one
+        /// was not.
+        /// </summary>
+        public async Task<bool> OnlyTheFirstEntryWasCapturedAsync(string expected)
+        {
+            await Task.Delay(150);
+            IReadOnlyList<CommandHistoryEntry> entries = await _historyStore.GetRecentAsync(10);
+            return entries.Count == 1 && entries[0].CommandText == expected;
         }
 
         public void Dispose()

--- a/tests/NovaTerminal.App.Tests/Controls/PaneMarklessCaptureTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneMarklessCaptureTests.cs
@@ -1,0 +1,411 @@
+using System.Reflection;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using NovaTerminal.CommandAssist.Domain;
+using NovaTerminal.CommandAssist.Models;
+using NovaTerminal.Controls;
+using NovaTerminal.Shell;
+using Xunit;
+
+namespace NovaTerminal.Tests.Controls;
+
+/// <summary>
+/// Enter-time history capture in sessions the grid cannot serve (V2 Phase 1, task 7): `cmd.exe`,
+/// shells whose integration bootstrap bailed out, and every un-instrumented SSH host.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The property under test is not "the accumulator captures the line". It is the pair: it captures
+/// <em>exactly</em> the typed line, or it captures <em>nothing</em>. Phase 1c deleted V1's shadow
+/// buffer precisely because its third outcome — capturing something plausible and wrong — put
+/// commands the user never ran into permanent history. Most of the cases below are therefore
+/// "and nothing was written".
+/// </para>
+/// <para>
+/// Sibling coverage: <c>PaneGridTruthDesyncTests</c> covers the instrumented path this one falls
+/// back from, and <c>CapturePipelineTests</c> covers what the assist assembly does with the string
+/// once it has one. This file is about which string the pane hands over.
+/// </para>
+/// </remarks>
+public class PaneMarklessCaptureTests
+{
+    private const string PromptStart = "\x1b]133;A\x07";
+    private const string PromptEnd = "\x1b]133;B\x07";
+
+    /// <summary>
+    /// The whole point of the task: a straight-through-typed line in a session with no marks reaches
+    /// history, verbatim and redacted. The secret is here rather than in its own test because the
+    /// interesting claim is that the accumulator feeds the <em>normal</em> capture pipeline, redaction
+    /// and all, rather than a side door into the store.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task InAMarklessSession_ATypedLineIsCapturedVerbatimAndRedacted()
+    {
+        using var fixture = await Fixture.MarklessAsync();
+
+        fixture.Type("mysql -u root --password hunter2");
+        fixture.PressEnter();
+
+        CommandHistoryEntry entry = await fixture.WaitForSingleEntryAsync();
+        Assert.Equal("mysql -u root --password [REDACTED]", entry.CommandText);
+        Assert.True(entry.IsRedacted);
+        Assert.Equal(CommandCaptureSource.Heuristic, entry.Source);
+    }
+
+    /// <summary>
+    /// Every key the accumulator cannot model turns it off. These are the edits that made V1 wrong:
+    /// an arrow moves the insertion point so later characters do not land where the buffer thinks;
+    /// `Home` does the same wholesale; `Tab` invites the shell to rewrite the word; `Delete` removes
+    /// a character the buffer never sees go; `Ctrl+W` deletes a word; `Up` replaces the entire line
+    /// with one the user typed no character of.
+    /// </summary>
+    [AvaloniaTheory]
+    [InlineData(Key.Left, KeyModifiers.None)]
+    [InlineData(Key.Right, KeyModifiers.None)]
+    [InlineData(Key.Up, KeyModifiers.None)]
+    [InlineData(Key.Down, KeyModifiers.None)]
+    [InlineData(Key.Home, KeyModifiers.None)]
+    [InlineData(Key.End, KeyModifiers.None)]
+    [InlineData(Key.Delete, KeyModifiers.None)]
+    [InlineData(Key.Tab, KeyModifiers.None)]
+    [InlineData(Key.PageUp, KeyModifiers.None)]
+    [InlineData(Key.PageDown, KeyModifiers.None)]
+    [InlineData(Key.Insert, KeyModifiers.None)]
+    [InlineData(Key.Escape, KeyModifiers.None)]
+    [InlineData(Key.F7, KeyModifiers.None)]
+    [InlineData(Key.W, KeyModifiers.Control)]
+    [InlineData(Key.U, KeyModifiers.Control)]
+    [InlineData(Key.A, KeyModifiers.Control)]
+    [InlineData(Key.B, KeyModifiers.Alt)]
+    public async Task InAMarklessSession_AnUnmodeledKeyStopsTheLineBeingCaptured(Key key, KeyModifiers modifiers)
+    {
+        using var fixture = await Fixture.MarklessAsync();
+
+        fixture.Type("git stauts");
+        fixture.PressKey(key, modifiers);
+        fixture.Type("x");
+        fixture.PressEnter();
+
+        Assert.True(await fixture.NothingWasCapturedAsync());
+    }
+
+    /// <summary>Backspace is the one edit besides typing that the accumulator does model.</summary>
+    [AvaloniaFact]
+    public async Task InAMarklessSession_BackspaceRemovesTheLastCharacter()
+    {
+        using var fixture = await Fixture.MarklessAsync();
+
+        fixture.Type("gitt");
+        fixture.PressBackspace();
+        fixture.PressEnter();
+
+        CommandHistoryEntry entry = await fixture.WaitForSingleEntryAsync();
+        Assert.Equal("git", entry.CommandText);
+    }
+
+    /// <summary>
+    /// Paste poisons, and the poison outlives the keystrokes that follow it: the pasted characters
+    /// are still on the line and the accumulator still cannot describe them.
+    /// </summary>
+    /// <remarks>
+    /// Paste is covered twice over, by two mechanisms that are worth keeping distinct. The
+    /// accumulator is <em>poisoned</em> — it did not see the characters. The session is separately
+    /// marked <em>suppressed</em> (<c>AssistSessionStateMachine.IsCurrentSubmissionSuppressed</c>),
+    /// which is a provenance claim that also applies to instrumented sessions, where the grid reads
+    /// the pasted line perfectly well and it should still not be recorded as something the user
+    /// typed. Here only the first is load-bearing; <c>CapturePipelineTests</c> owns the second.
+    /// </remarks>
+    [AvaloniaFact]
+    public async Task InAMarklessSession_APasteStopsTheLineBeingCaptured()
+    {
+        using var fixture = await Fixture.MarklessAsync();
+
+        fixture.Pane.NotifyPasteObserved("curl https://example.com");
+        fixture.PressEnter();
+
+        Assert.True(await fixture.NothingWasCapturedAsync());
+
+        // ... and typing after the paste does not wash it out.
+        fixture.Pane.NotifyPasteObserved("curl https://example.com");
+        fixture.Type(" | jq");
+        fixture.PressEnter();
+
+        Assert.True(await fixture.NothingWasCapturedAsync());
+    }
+
+    /// <summary>The clipboard paste path is a different call site and poisons the same way.</summary>
+    [AvaloniaFact]
+    public async Task InAMarklessSession_AClipboardPasteStopsTheLineBeingCaptured()
+    {
+        using var fixture = await Fixture.MarklessAsync();
+
+        fixture.Type("echo ");
+        fixture.Pane.NotifyCommandAssistPaste("secret-value");
+        fixture.PressEnter();
+
+        Assert.True(await fixture.NothingWasCapturedAsync());
+    }
+
+    /// <summary>
+    /// `Ctrl+C` abandons the line, so the next one starts clean. Without this the first unmodeled
+    /// key would silently cost every subsequent command in the session, not just its own.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task InAMarklessSession_CtrlCClearsThePoisonForTheNextLine()
+    {
+        using var fixture = await Fixture.MarklessAsync();
+
+        fixture.Type("git sta");
+        fixture.PressKey(Key.Left);
+        fixture.PressKey(Key.C, KeyModifiers.Control);
+
+        fixture.Type("git status");
+        fixture.PressEnter();
+
+        CommandHistoryEntry entry = await fixture.WaitForSingleEntryAsync();
+        Assert.Equal("git status", entry.CommandText);
+    }
+
+    /// <summary>
+    /// Grid truth wins wherever it exists, and it does not consult the accumulator to decide. The
+    /// line here is one the accumulator has given up on — the user arrowed around in it — and the
+    /// capture is still exactly what is painted on screen.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task InAnIntegratedSession_TheGridWinsEvenWhenTheAccumulatorIsPoisoned()
+    {
+        using var fixture = await Fixture.IntegratedAsync("git status --short");
+
+        // Everything the accumulator would have said is wrong or absent.
+        fixture.Type("nonsense");
+        fixture.PressKey(Key.Left);
+
+        fixture.PressEnter();
+
+        CommandHistoryEntry entry = await fixture.WaitForSingleEntryAsync();
+        Assert.Equal("git status --short", entry.CommandText);
+    }
+
+    /// <summary>
+    /// A full-screen app owns the keyboard and its keys are not line edits. The half-line pending
+    /// when it started must not survive it — asserted after the TUI exits, so that what is being
+    /// tested is the reset rather than <c>CapturePipeline</c>'s separate alt-screen gate.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task InAMarklessSession_AltScreenDiscardsThePendingLine()
+    {
+        using var fixture = await Fixture.MarklessAsync();
+
+        fixture.Type("vim notes.txt");
+        await fixture.EnterAltScreenAsync();
+        await fixture.LeaveAltScreenAsync();
+
+        fixture.PressEnter();
+
+        Assert.True(await fixture.NothingWasCapturedAsync());
+    }
+
+    /// <summary>The control for the test above: without the TUI, the same line is captured.</summary>
+    [AvaloniaFact]
+    public async Task InAMarklessSession_TheSameLineWithoutAltScreenIsCaptured()
+    {
+        using var fixture = await Fixture.MarklessAsync();
+
+        fixture.Type("vim notes.txt");
+        fixture.PressEnter();
+
+        CommandHistoryEntry entry = await fixture.WaitForSingleEntryAsync();
+        Assert.Equal("vim notes.txt", entry.CommandText);
+    }
+
+    /// <summary>
+    /// Bytes this pane's keyboard handling never produced — a broadcast from a sibling pane, the
+    /// drop toast, the agent host's act surface — all land on <c>NotifyExternalInputSent</c>.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task InAMarklessSession_ExternallySentInputStopsTheLineBeingCaptured()
+    {
+        using var fixture = await Fixture.MarklessAsync();
+
+        fixture.Type("echo ");
+        fixture.Pane.NotifyExternalInputSent();
+        fixture.PressEnter();
+
+        Assert.True(await fixture.NothingWasCapturedAsync());
+    }
+
+    private sealed class Fixture : IDisposable
+    {
+        private readonly string _directory;
+        private readonly IHistoryStore _historyStore;
+
+        private Fixture(TerminalPane pane, IHistoryStore historyStore, string directory)
+        {
+            Pane = pane;
+            _historyStore = historyStore;
+            _directory = directory;
+        }
+
+        public TerminalPane Pane { get; }
+
+        /// <summary>A shell that emits no <c>OSC 133</c> at all.</summary>
+        public static async Task<Fixture> MarklessAsync()
+        {
+            Fixture fixture = await CreateAsync();
+            fixture.Pane.CreateAndWireParser();
+            return fixture;
+        }
+
+        /// <summary>An instrumented prompt with <paramref name="commandLine"/> painted at it.</summary>
+        public static async Task<Fixture> IntegratedAsync(string commandLine)
+        {
+            Fixture fixture = await CreateAsync();
+            fixture.Pane.ArmShellIntegrationTracker();
+            fixture.Pane.CreateAndWireParser();
+            fixture.Pane.Parser!.Process(PromptStart + "$ " + PromptEnd + commandLine);
+
+            // The shell-integration dispatcher is serialized and asynchronous; B opens the
+            // lifecycle gate on the far side of it.
+            await Task.Delay(50);
+            return fixture;
+        }
+
+        public void Type(string text)
+        {
+            foreach (char c in text)
+            {
+                // One key press then one text-input event, in the order Avalonia raises them.
+                PressKey(KeyForCharacter(c));
+                Pane.NotifyTypedTextObserved(c.ToString());
+            }
+        }
+
+        public void PressKey(Key key, KeyModifiers modifiers = KeyModifiers.None) =>
+            Pane.TryHandleCommandAssistKey(key, modifiers);
+
+        public void PressBackspace()
+        {
+            PressKey(Key.Back);
+            Pane.NotifyBackspaceObserved();
+        }
+
+        public void PressEnter()
+        {
+            PressKey(Key.Enter);
+            Pane.OnCommandAssistEnterObserved();
+        }
+
+        public async Task EnterAltScreenAsync()
+        {
+            Pane.Parser!.Process("\x1b[?1049h");
+            await Task.Delay(50);
+        }
+
+        public async Task LeaveAltScreenAsync()
+        {
+            Pane.Parser!.Process("\x1b[?1049l");
+            await Task.Delay(50);
+        }
+
+        /// <summary>The one entry that should have been written, waiting for the async capture.</summary>
+        public async Task<CommandHistoryEntry> WaitForSingleEntryAsync(int timeoutMs = 2000)
+        {
+            int elapsed = 0;
+            while (true)
+            {
+                IReadOnlyList<CommandHistoryEntry> entries = await _historyStore.GetRecentAsync(10);
+                if (entries.Count > 0)
+                {
+                    return Assert.Single(entries);
+                }
+
+                if (elapsed >= timeoutMs)
+                {
+                    throw new TimeoutException("No history entry was captured.");
+                }
+
+                await Task.Delay(10);
+                elapsed += 10;
+            }
+        }
+
+        /// <summary>
+        /// Nothing reached the store. Waits first, because the assertion is about an asynchronous
+        /// write that did not happen: checking immediately would pass even if it were about to.
+        /// </summary>
+        public async Task<bool> NothingWasCapturedAsync()
+        {
+            await Task.Delay(150);
+            IReadOnlyList<CommandHistoryEntry> entries = await _historyStore.GetRecentAsync(10);
+            return entries.Count == 0;
+        }
+
+        public void Dispose()
+        {
+            Pane.Dispose();
+            try
+            {
+                Directory.Delete(_directory, recursive: true);
+            }
+            catch
+            {
+                // Best effort; the temp root is per-test anyway.
+            }
+        }
+
+        private static async Task<Fixture> CreateAsync()
+        {
+            // A private services graph rather than the shared TestCommandAssistServices instance:
+            // these tests assert that the store is *empty*, so they cannot share a history file
+            // with whatever else is running.
+            string directory = Path.Combine(
+                Path.GetTempPath(),
+                $"nova_markless_capture_{Environment.ProcessId}_{Guid.NewGuid():N}");
+            Directory.CreateDirectory(directory);
+
+            var services = new CommandAssistServices(
+                Path.Combine(directory, "history.jsonl"),
+                legacyHistoryFilePath: null,
+                Path.Combine(directory, "snippets.json"),
+                () => directory);
+
+            // Force the store open before the pane runs, so the first read is not racing creation.
+            await services.HistoryStore.GetRecentAsync(1);
+
+            var pane = new TerminalPane();
+            pane.CommandAssistServices = services;
+            var settings = new TerminalSettings(); // constructed, not Load() - see #232
+            settings.CommandAssistEnabled = true;
+            settings.CommandAssistHistoryEnabled = true;
+            pane.ApplySettings(settings);
+
+            var session = new PaneAssistInsertionTests.RecordingSession();
+            typeof(TerminalPane)
+                .GetProperty("Session", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)!
+                .SetValue(pane, session);
+
+            return new Fixture(pane, services.HistoryStore, directory);
+        }
+
+        /// <summary>
+        /// The key press that accompanies <paramref name="c"/>. Only has to be right about the
+        /// classification (printable, no chord modifier), which is all the accumulator reads.
+        /// </summary>
+        private static Key KeyForCharacter(char c) => c switch
+        {
+            >= 'a' and <= 'z' => Key.A + (c - 'a'),
+            >= 'A' and <= 'Z' => Key.A + (c - 'A'),
+            >= '0' and <= '9' => Key.D0 + (c - '0'),
+            ' ' => Key.Space,
+            '-' => Key.OemMinus,
+            '.' => Key.OemPeriod,
+            ',' => Key.OemComma,
+            '/' => Key.Oem2,
+            '\\' => Key.Oem5,
+            ':' or ';' => Key.Oem1,
+            '\'' or '"' => Key.Oem7,
+            '|' => Key.Oem5,
+            _ => Key.Oem8,
+        };
+    }
+}

--- a/tests/NovaTerminal.VT.Tests/GridQueryReaderTests.cs
+++ b/tests/NovaTerminal.VT.Tests/GridQueryReaderTests.cs
@@ -894,4 +894,140 @@ public class GridQueryReaderTests
         Assert.False(s.TryRead(out _));
         Assert.False(s.Buffer.Lock.IsReadLockHeld);
     }
+
+    // ------------------------------------------------- text ending at the cursor (echo check)
+
+    /// <remarks>
+    /// <c>TryReadTextEndingAtCursor</c> answers a different question from the rest of this file:
+    /// not "where does the command line start" — it has no mark to work from — but "is this exact
+    /// string painted on the screen behind the cursor". Its one caller is the markless capture
+    /// path's echo gate, which uses it to refuse to write a password nobody echoed into history.
+    /// </remarks>
+    private static string ReadBack(Session s, int count)
+    {
+        Assert.True(GridQueryReader.TryReadTextEndingAtCursor(s.Buffer, count, out string text));
+        return text;
+    }
+
+    [Fact]
+    public void TextEndingAtTheCursor_IsTheTailOfWhatWasPainted()
+    {
+        var s = new Session().Write("$ git status");
+
+        Assert.Equal("git status", ReadBack(s, 10));
+        Assert.Equal("$ git status", ReadBack(s, 12));
+    }
+
+    /// <summary>
+    /// A short read is an answer, not a failure: the caller compares for equality, so "the grid
+    /// does not hold that many characters" comes back as a shorter string and fails the match.
+    /// </summary>
+    [Fact]
+    public void AskingForMoreThanTheRowHolds_ReturnsWhatThereIs()
+    {
+        var s = new Session().Write("ls");
+
+        Assert.Equal("ls", ReadBack(s, 50));
+    }
+
+    /// <summary>
+    /// Nothing after the cursor is readable, which is the property the echo gate rests on: text
+    /// that is on screen somewhere else is not evidence that this line was echoed.
+    /// </summary>
+    [Fact]
+    public void TextAfterTheCursor_IsNotRead()
+    {
+        var s = new Session().Write("whoami and more").Write("\x1b[1;7H"); // cursor back to col 6
+
+        Assert.Equal("whoami", ReadBack(s, 6));
+        Assert.Equal("whoami", ReadBack(s, 15));
+    }
+
+    [Fact]
+    public void ASoftWrappedLine_IsFollowedBackwardsThroughItsPredecessorRows()
+    {
+        var s = new Session(cols: 10).Write("abcdefghijklmno");
+
+        Assert.Equal("abcdefghijklmno", ReadBack(s, 15));
+        Assert.Equal("klmno", ReadBack(s, 5));
+    }
+
+    /// <summary>
+    /// The walk stops at a row that is not soft-wrapped into the cursor's: an earlier command's
+    /// output is not part of what was typed here.
+    /// </summary>
+    [Fact]
+    public void AHardLineBreakStopsTheWalk()
+    {
+        var s = new Session().Write("older output\r\n$ ls");
+
+        Assert.Equal("$ ls", ReadBack(s, 20));
+    }
+
+    /// <summary>
+    /// Wide characters are one character each, so a caller comparing against typed text does not
+    /// have to know anything about columns.
+    /// </summary>
+    [Fact]
+    public void WideCharacters_CountAsOneCharacterEach()
+    {
+        var s = new Session().Write("echo " + Cjk);
+
+        Assert.Equal(Cjk, ReadBack(s, 2));
+        Assert.Equal("echo " + Cjk, ReadBack(s, 7));
+    }
+
+    /// <summary>Deferred autowrap: the cursor parks on the last column with the wrap pending.</summary>
+    [Fact]
+    public void WithAPendingWrap_TheLastCharacterIsIncluded()
+    {
+        var s = new Session(cols: 5).Write("abcde");
+
+        Assert.True(s.Buffer.IsPendingWrap);
+        Assert.Equal("abcde", ReadBack(s, 5));
+    }
+
+    /// <summary>
+    /// A full-screen application owns the grid; there is no echoing line editor to check against,
+    /// so the honest answer is "cannot read" rather than whatever the TUI happens to have painted.
+    /// </summary>
+    [Fact]
+    public void OnTheAltScreen_TheReadFails()
+    {
+        var s = new Session().Write("\x1b[?1049h").Write("tui content");
+
+        Assert.False(GridQueryReader.TryReadTextEndingAtCursor(s.Buffer, 5, out string text));
+        Assert.Equal(string.Empty, text);
+    }
+
+    [Fact]
+    public void AZeroLengthReadSucceedsAndIsEmpty()
+    {
+        var s = new Session().Write("$ ls");
+
+        Assert.True(GridQueryReader.TryReadTextEndingAtCursor(s.Buffer, 0, out string text));
+        Assert.Equal(string.Empty, text);
+    }
+
+    [Fact]
+    public void TheEchoReadObeysTheSameLockDiscipline()
+    {
+        var s = new Session().Write("$ ls");
+
+        s.Buffer.Lock.EnterReadLock();
+        try
+        {
+            Assert.True(GridQueryReader.TryReadTextEndingAtCursor(s.Buffer, 2, out string text));
+            Assert.Equal("ls", text);
+        }
+        finally
+        {
+            s.Buffer.Lock.ExitReadLock();
+        }
+
+        Assert.False(s.Buffer.Lock.IsReadLockHeld);
+
+        Assert.True(GridQueryReader.TryReadTextEndingAtCursor(s.Buffer, 2, out _));
+        Assert.False(s.Buffer.Lock.IsReadLockHeld);
+    }
 }


### PR DESCRIPTION
Implements Phase 1 task 7 of `docs/plans/2026-08-01-command-assist-v2-plan.md`; pre-flag-flip requirement from PR #286 review.

## The hole

Phase 1c (#286) deleted V1's shadow buffer and, with it, Enter-time history capture. That is correct for instrumented sessions - the grid is strictly better than the mirror ever was - but a session with no `OSC 133` marks then captures **nothing, ever**. That is not a corner: it is `cmd.exe`, every shell whose bootstrap bailed out (`pwsh -File`, `bash -c`, `zsh -f`, `fish -N`), and **every SSH session**, because SSH launch plans skip provider injection and Phase 2 task 3 only lifts that for hosts the user has instrumented. For all of those, history never fills, so `Ctrl+R` is an empty box, Fix has no prior command to reason about, and ranking has no corpus.

## The contract

**In a session with no marks, a command typed straight through with no editing is captured verbatim; anything else is captured not at all.**

`MarklessSubmissionAccumulator` (`src/NovaTerminal.App/Controls/`) is a `StringBuilder` plus a poison flag, used *only* as the Enter-time submission text and never as the query. `TextInputObserved` appends, `BackspaceObserved` chops one character, and everything it cannot model poisons it. Its only two outcomes are "exactly the characters the user typed, in order" and "nothing".

That is the whole distinction from the mirror this does not restore. V1's mirror answered "what is on the line?" with a guess and failed *silently and wrongly*: the Fix-mode caption was concatenated into it, Tab completions were truncated to what the user had typed, `Ctrl+U` left it holding text no longer on screen - and all of it was written to permanent history as commands the user had run. A poisoned accumulator turns itself off the moment it stops knowing. Recording nothing is recoverable; recording a command the user never ran is not.

Zero changes inside `NovaTerminal.CommandAssist`. It feeds the existing `HandleEnterAsync(string?)` seam, the assist assembly cannot tell the two sources apart, and the whole thing is deletable in one commit once Phase 2 gives instrumented remotes real marks.

## The poison set

The classification is an **allow-list**, not the deny-list the plan sketched. The interceptor is handed `(Key, KeyModifiers)`, and a deny-list of "arrows, Home, End, Delete, Tab, page keys, F-keys, unowned chords" fails *open* on anything nobody thought of - which is the wrong direction for a mechanism whose entire justification is that it never captures something false. Inverted, it fails closed. An allow-list missing a harmless key costs one capture; a deny-list missing a line-editing key writes a false command to history.

A key press leaves the buffer alone only when it is one of:

- a modifier key alone (`LeftShift`/`RightShift`, `LeftCtrl`/`RightCtrl`, `LeftAlt`/`RightAlt`, `LWin`/`RWin`, `None`);
- `Enter` without `Alt` (the Enter path resets after the capture read);
- `Backspace` without `Alt` (`BackspaceObserved` does the chop; `TerminalView` ignores `Ctrl` on `Key.Back`, so `Ctrl+Backspace` is modeled too);
- `Ctrl+C` - which **resets** rather than leaving state alone;
- a key Command Assist consumed (`Escape`, `Up`, `Down`, `Ctrl+Shift+P` while the surface is up) - it never reached `TerminalView`'s encoder, so it never reached the shell;
- a printable key with no `Ctrl`/`Alt`/`Meta`: `A`-`Z`, `D0`-`D9`, the numpad block (`NumPad0`-`Divide`), `Space`, the OEM punctuation keys (`OemPlus`, `OemComma`, `OemMinus`, `OemPeriod`, `Oem1`-`Oem8`, `Oem102`, `AbntC1`/`AbntC2`), and `ImeProcessed`/`DeadCharProcessed`.

**Everything else poisons.** Concretely that includes `Left`, `Right`, `Up`, `Down`, `Home`, `End`, `Delete`, `Insert`, `Tab`, `PageUp`, `PageDown`, `Escape`, every F-key, every `Ctrl` chord Command Assist does not own (`Ctrl+W`, `Ctrl+U`, `Ctrl+A`, ...), every `Alt` chord including `Alt+Enter` and `Alt+Backspace`, every `Meta` chord, and every key not in the list above.

`TryHandleCommandAssistKey` is split into `TryRouteCommandAssistKey` (the routing decision, behaviour unchanged) and the observation, which runs after it and returns nothing - "Command Assist consumed this key" and "the shell never saw it" are the same fact, so the routing result is an input to the classification. `TryToggleCommandAssistPinShortcut` calls the router directly, since it arrives from the window's shortcut handler and nothing was sent to the shell either way.

Text that reaches the PTY without going through key handling poisons at its own call site: both paste paths (`TermView.PasteObserved` for drag-and-drop, `NotifyCommandAssistPaste` for the clipboard), `Ctrl+Enter` insertion (the one key Command Assist owns that *sends*), the drop-path toast, sibling-pane broadcast, the clipboard-image path, and the agent host's A3 act surface (`AgentSessionRegistration.InputInjected`, added here).

Backspace refuses rather than guesses when the last character is a surrogate or a combining mark, because "one character" is then not the same thing to the accumulator and to the shell's line editor. On an empty buffer it is a no-op, not a poison - backspace at an empty prompt does nothing in every shell. There is an 8 KB cap, and text input containing a newline poisons.

## Reset points

- `Enter`, **after** the capture read - it is both the capture point and the start of the next line. Owed even when Command Assist is off, since the accumulator is fed from `TermView` events that fire regardless.
- `Ctrl+C`. Without this the first unmodeled key would cost every subsequent command in the session, not just its own. `TerminalView` routes `Ctrl+C`-with-a-selection to copy, which leaves the line intact; resetting there loses one capture, which is the safe direction.
- Any alt-screen transition, in **both** directions. On the way in so a TUI eating keys cannot leave a half-line behind; on the way out because the prompt underneath was redrawn by something the accumulator never saw.
- Session start / restart / profile switch (`InitializeSessionCore`).

Focus loss is deliberately **not** a reset or a poison: keys cannot be typed while unfocused, and anything that does reach the PTY comes through one of the external-input sites above.

## How grid truth, the accumulator and suppression compose

**Grid vs accumulator - at the Enter call site.** `submitted = snapshot is { } grid ? grid.Text : accumulator.TryReadSubmission()`. Grid truth always wins where it exists, *including when it reads the line as empty*: "observed empty" and "unknown" are different answers and only the second falls through. A poisoned accumulator answers `null`, which `CapturePipeline` reads as nothing to persist.

**Poison vs suppression - distinct mechanisms, both survive.** Poison is an accumulator fact ("I cannot describe this line"). `AssistSessionStateMachine.IsCurrentSubmissionSuppressed` is a provenance fact ("this text was not composed here") that `CapturePipeline` applies to *both* capture sources. A paste in a markless session is stopped twice over; a paste in an instrumented session - where the grid reads it perfectly well - is stopped only by suppression. Neither subsumes the other, and the paste call sites set both.

**Multi-line.** `CapturePipeline` already rejects submissions containing `\n` or `\r`, so the accumulator needs no predicate of its own; it poisons on a newline arriving as text input only because such a submission bypasses the Enter path that reads and resets, and the buffer must not carry into the next line.

## Tests

`tests/NovaTerminal.App.Tests/Controls/PaneMarklessCaptureTests.cs` (26 cases) - the real pane, a private services graph so it can assert the store is *empty*:

1. typed line in a markless session is captured verbatim **and redacted** (`mysql -u root --password hunter2`), proving it feeds the normal pipeline rather than a side door into the store;
2. 17 poisoning keys parameterised (`Left`, `Right`, `Up`, `Down`, `Home`, `End`, `Delete`, `Tab`, `PageUp`, `PageDown`, `Insert`, `Escape`, `F7`, `Ctrl+W`, `Ctrl+U`, `Ctrl+A`, `Alt+B`) - nothing captured;
3. backspace modeled (`gitt`, backspace, Enter, `git`);
4. paste then Enter captures nothing, and paste then typing still captures nothing; clipboard paste covered separately;
5. `Ctrl+C` clears the poison so the next line is captured;
6. instrumented session: the grid wins even with the accumulator poisoned;
7. alt-screen discards the pending line - asserted after the TUI exits, so it tests the reset rather than `CapturePipeline`'s separate alt-screen gate - with a control test proving the same line is otherwise captured;
8. externally sent input stops the capture.

`tests/NovaTerminal.App.Tests/Controls/MarklessSubmissionAccumulatorTests.cs` (27 cases) - the edges awkward to reach through a terminal: backspace on empty as a no-op, backspace over a surrogate pair or a combining sequence as a poison, the newline and length guards, and the key classification directly (unknown keys and chords poison; modeled and printable keys do not).

**Mutation checks.** Adding the arrow keys to the printable allow-list fails four cases of the poison theory (`Left`, `Right`, `Up`, `Down`). Making the accumulator win over the grid fails `InAnIntegratedSession_TheGridWinsEvenWhenTheAccumulatorIsPoisoned`. Both mutants reverted.

## Verification

Clean solution build (`scripts/build.ps1 build`, 0 errors). Per-project suites:

- `NovaTerminal.VT.Tests` - 270/270 passed
- `NovaTerminal.Architecture.Tests` - 28/28 passed
- `NovaTerminal.App.Tests` - 1624/1625 passed; the single failure is `AgentHostCaptureProtocolTests.Capture_with_an_unparseable_paneId_is_malformed_and_journaled`, a known headless-Avalonia init flake unrelated to this change

53 of those App tests are new.

## Docs

Phase 1 task 7 ticked and the "tasks 1-6 complete; one task open" qualifier dropped; Phase 1d notes added covering what shipped and where it departs from the sketch. Phase 6 step 1 now carries only the smoke-scenario re-validation. The gaps doc's markless-capture note moves from "tracked, required before the flag flip" to shipped, with the contract and the composition rules above.
