### PR TITLE
feat(command-assist): accept on Enter/click, explicit-intent visibility, context-scoped history (V2 Phase 3a)

### DIFF
--- a/docs/command-assist/CommandAssist.md
+++ b/docs/command-assist/CommandAssist.md
@@ -243,6 +243,45 @@ score =
 
 Do not overfit early. Keep ranking explainable.
 
+### Shipped: context scoping and the empty-query bands (V2 Phase 3a, revised in the PR #290 review)
+
+`CommandAssistSuggestionEngine` has two paths, and the difference matters more than any individual
+weight.
+
+With **a text query** the context terms are nudges: same-context is worth 30, same-profile 20, same cwd
+12, against text-match tiers of prefix 120 / token prefix 70 / contains 25 / subsequence 12. What the
+user typed decides the order; affinity breaks ties. A partition here would rank a same-host subsequence
+match above a local prefix match, which reads as the list ignoring the query.
+
+With **no query** (`Ctrl+R`, or an explicit bubble at an empty prompt) there is nothing to match on, so
+the same terms partition instead. In descending order:
+
+| Band | Boost | What is in it |
+| --- | --- | --- |
+| This context, this profile | 1000 + 200 | History from this host (or local history on a local pane) run under this profile. |
+| This context | 1000 | History from this host, other profiles. Pinned snippets ride here too: pinning means "in scope everywhere", and a snippet has no host to compare. |
+| Snippets and same profile | 200 | **Unpinned snippets**, and history from this profile that ran somewhere else. |
+| Everything else | ~1–6 | Frequency and recency only: other hosts, other machines. |
+
+Nothing is filtered out — a command you remember running elsewhere is still in the list, below the fold,
+because that is why a shared history exists.
+
+**Why unpinned snippets sit in the same-profile band.** They are user-authored text somebody chose to
+save, which is worth more than another machine's recency; they are not evidence about *this* host, which
+is what the top band is for. The trade-off is stated rather than hidden: with more same-context history
+rows than the popup shows, an unpinned snippet is below the fold, and pinning (`Ctrl+Shift+P`) is the
+one-keystroke answer. The alternative — hoisting every snippet above this host's own history — makes the
+list say "snippets first" for users who never asked for that.
+
+**What "this context" means, and the one spelling trap in it.** On a remote pane it is the host id; on a
+local pane it is "not on somebody else's machine" (there is no local host id to compare). The host id is
+**the configured `Profile.SshHost` string, verbatim** — not a resolved address, not a canonical name. So
+two profiles pointing at the same box as `10.0.0.5` and `build.example` do not share a band, and neither
+do `build` and `build.example`. That is a deliberate consequence of using configuration rather than
+resolution (resolution is a network call on a ranking path, and it changes under DHCP), and it fails in
+the safe direction: an unrecognised context is not a context, so the list falls back to recency, which
+is unhelpful rather than wrong.
+
 ---
 
 ## 7. Data model
@@ -484,28 +523,54 @@ still refers to it.
 | --- | --- | --- |
 | `Ctrl+Space` | app | Toggle the explicit assist session for the focused pane. |
 | `Ctrl+R` | app | Open history search (popup, recency list scoped to this pane's context). |
-| `Ctrl+Alt+H` | app | Help for the command on the line, or for the selection. |
-| `Up` / `Down` | assist, while a surface is visible | Move the selection; opens the popup on the first move. |
-| `Enter` | **assist, while the popup is open with a row selected**; otherwise the shell | Insert the selected suggestion. See below. |
+| `Ctrl+Shift+H` | app | Help for the command on the line, or for the selection. |
+| `Down` | assist, while a surface is visible | Move the selection down; opens the popup on the first move. |
+| `Up` | assist while the popup is open, or on a surface the user summoned; **otherwise the shell** | Move the selection up. See below. |
+| `Enter` | **assist, while the popup is open with a row selected and the overlay is actually rendered**; otherwise the shell | Insert the selected suggestion. See below. |
 | `Ctrl+Enter` | assist, while a surface is visible | Insert the selected suggestion. Works in every state, including Help and Fix. |
 | `Esc` | assist, while a surface is visible | Dismiss. |
 | `Tab` | **always the shell** | Shell completion. Command Assist never takes it. |
 | `Ctrl+Shift+P` | assist when a row can be pinned, otherwise falls through | Pin/unpin the selected row. (Collides with the command palette; Phase 3b moves it.) |
 
 Mouse, in the popup: hover highlights, a single click selects, and a double click — or a click on the
-row that is already selected — inserts. The row list scrolls.
+row that is already selected — inserts. The row list scrolls. Right-click and middle-click are
+swallowed by the popup: neither means anything to the list, and left to bubble they would open the pane
+context menu over it or paste into the shell underneath.
+
+**`Down` browses suggestions while typing; `Up` remains shell history.** The entry into the row list is
+one-directional in the passive states — the typing bubble and the bubble-only Fix hint, the two surfaces
+the user did not ask for. `Down` has no meaning at a shell prompt, so taking it costs nothing; `Up` is
+history recall in every shell there is, and taking it cost a great deal: the assist consumed the key,
+opened its popup as a side effect of clamping the selection to row 0, and the `Enter` that followed
+inserted a suggestion instead of submitting the command. This matches fish and PSReadLine, where
+history recall is `Up`'s and nothing takes it.
+
+Once the popup is open, `Up` and `Down` both navigate it, in every mode — the user is demonstrably in
+the list. `Up` at the top row is a no-op that opens nothing and arms nothing. And on a surface the user
+summoned by name (`Ctrl+Space`, `Ctrl+R`, Help, a confident Fix popup) both arrows are assist-owned from
+the first keypress, because there the list *is* what was asked for.
 
 **The `Enter` rule, precisely.** `Enter` is Command Assist's only when *all* of: a surface is visible,
-the popup is open, a row is selected, and the mode is Suggest or Search. In Suggest mode that state is
-only reachable by the user having moved the selection, and in Search mode only because they pressed
-`Ctrl+R`; typing closes the popup, so the ordinary type-a-command-and-press-`Enter` flow never reaches
-it. Help and Fix are excluded — their rows are documentation and diagnoses rather than a command line
-being composed, and a Fix popup is on screen right after a submission, where the next `Enter` is most
-likely aimed at the shell.
+the popup is open, a row is selected, the mode is Suggest or Search, and the pane's overlay host is
+genuinely rendered (visible, non-zero opacity). In Suggest mode that state is only reachable by the user
+having moved the selection, and in Search mode only because they pressed `Ctrl+R`; typing closes the
+popup, so the ordinary type-a-command-and-press-`Enter` flow never reaches it. Help and Fix are
+excluded — their rows are documentation and diagnoses rather than a command line being composed, and a
+Fix popup is on screen right after a submission, where the next `Enter` is most likely aimed at the
+shell.
+
+The rendered-overlay term is not redundant with visibility. `TerminalPane` hides the overlay host on its
+own authority when the conservative anchor check produces no layout, and dims it to zero opacity while a
+placement correction settles; both bypasses are waived only for a *user-requested* surface, and a
+passive popup is not one. Without the term, a passive popup on a short markless-SSH pane could own
+`Enter` at zero pixels — nothing on screen, and the command line silently not submitting. The hint strip
+reads the same predicate, so it stops promising `Enter` at the same moment.
 
 Only a *completely unmodified* `Enter` is taken. `Shift+Enter` is a newline in several line editors,
 and under the kitty keyboard protocol's disambiguate tier every modified `Enter` is a distinct `CSI u`
-sequence the shell may act on.
+sequence the shell may act on. "Unmodified" includes `Meta` (Windows/Super/Cmd): it is mapped across the
+App boundary for no other reason than this rule, since a dropped modifier makes `Win+Enter` look
+unmodified to the router while the pane sees it for what it is.
 
 If the insertion is refused (the line cannot be read, a keystroke is still unechoed, the cursor is
 mid-line, the text was pasted), `Enter` is *not* consumed and reaches the shell, which submits as it

--- a/docs/command-assist/CommandAssist.md
+++ b/docs/command-assist/CommandAssist.md
@@ -473,9 +473,49 @@ This feature must feel immediate.
 
 ---
 
-## 14. Suggested keyboard model
+## 14. Keyboard model
 
-### Defaults
+### Shipped (V2 Phase 3a)
+
+This is what the product does. The original speculative table follows it, kept because the roadmap
+still refers to it.
+
+| Key | Owner | Effect |
+| --- | --- | --- |
+| `Ctrl+Space` | app | Toggle the explicit assist session for the focused pane. |
+| `Ctrl+R` | app | Open history search (popup, recency list scoped to this pane's context). |
+| `Ctrl+Alt+H` | app | Help for the command on the line, or for the selection. |
+| `Up` / `Down` | assist, while a surface is visible | Move the selection; opens the popup on the first move. |
+| `Enter` | **assist, while the popup is open with a row selected**; otherwise the shell | Insert the selected suggestion. See below. |
+| `Ctrl+Enter` | assist, while a surface is visible | Insert the selected suggestion. Works in every state, including Help and Fix. |
+| `Esc` | assist, while a surface is visible | Dismiss. |
+| `Tab` | **always the shell** | Shell completion. Command Assist never takes it. |
+| `Ctrl+Shift+P` | assist when a row can be pinned, otherwise falls through | Pin/unpin the selected row. (Collides with the command palette; Phase 3b moves it.) |
+
+Mouse, in the popup: hover highlights, a single click selects, and a double click — or a click on the
+row that is already selected — inserts. The row list scrolls.
+
+**The `Enter` rule, precisely.** `Enter` is Command Assist's only when *all* of: a surface is visible,
+the popup is open, a row is selected, and the mode is Suggest or Search. In Suggest mode that state is
+only reachable by the user having moved the selection, and in Search mode only because they pressed
+`Ctrl+R`; typing closes the popup, so the ordinary type-a-command-and-press-`Enter` flow never reaches
+it. Help and Fix are excluded — their rows are documentation and diagnoses rather than a command line
+being composed, and a Fix popup is on screen right after a submission, where the next `Enter` is most
+likely aimed at the shell.
+
+Only a *completely unmodified* `Enter` is taken. `Shift+Enter` is a newline in several line editors,
+and under the kitty keyboard protocol's disambiguate tier every modified `Enter` is a distinct `CSI u`
+sequence the shell may act on.
+
+If the insertion is refused (the line cannot be read, a keystroke is still unechoed, the cursor is
+mid-line, the text was pasted), `Enter` is *not* consumed and reaches the shell, which submits as it
+always did. A refusal must not turn `Enter` into a dead key.
+
+There is still no execute-from-assist action: insertion sends text to the shell's line editor and
+stops, and the user presses `Enter` themselves. Insert and execute stay separate.
+
+### Original proposal (historical)
+
 - `Ctrl+Space` → open/toggle assist for current pane
 - `Ctrl+R` → history search mode
 - `Ctrl+Shift+P` → command palette
@@ -487,6 +527,12 @@ This feature must feel immediate.
 - `Alt+Enter` → insert without execution
 
 Keep insert and execute clearly separate.
+
+Differences from what shipped, and why: `Tab` stays shell-owned (taking the completion key from the
+shell is a bigger loss than the convenience is worth); `Enter` inserts rather than executes, and the
+"user explicitly navigated there" condition became a state-machine predicate rather than a focus
+question, because the assist surface never takes keyboard focus from the terminal; `Ctrl+Enter` is
+insert, not execute; `Alt+Enter` is unassigned.
 
 ---
 

--- a/docs/command-assist/CommandAssist_ShellIntegration_Gaps.md
+++ b/docs/command-assist/CommandAssist_ShellIntegration_Gaps.md
@@ -201,7 +201,41 @@ is never consulted as a query. What degraded mode costs, concretely:
   Explain-selection still works, because a selection is an explicit input the grid is not needed
   for, and Fix still works, because it analyses the command that failed rather than the one being
   typed.
-- **no insertion.** Rows can be browsed; nothing may be spliced into a command line nobody can see.
+- **no insertion into a line that has been touched.** **Narrowed in V2 Phase 3a; the original rule was
+  "no insertion at all".** The rule was written against "there is no snapshot, so the prefix is
+  unknown", and that conflated two situations. In the one the owner actually hit — open a markless SSH
+  pane, press `Ctrl+R`, pick a row — the prefix is not unknown, it is *empty*, and the pane can prove
+  it. `MarklessSubmissionAccumulator` was reset by the last `Enter` (or `Ctrl+C`) and has observed
+  nothing since, and it poisons on every edit it cannot model. So `TerminalPane` supplies the planner
+  an `AssistQuerySnapshot("", 0, false, false)` — the "observed empty" value the planner already treats
+  as a fact rather than an absence — and the whole command is sent.
+
+  Four conditions, each failing closed, and all four must hold:
+
+  1. **there is no grid snapshot.** Grid truth still wins wherever it exists; this path is only for
+     sessions that have none.
+  2. **the accumulator is not poisoned.** No arrow key, `Home`, `Delete`, `Tab`, paste, prior
+     insertion, agent injection or unrecognised chord since the reset. The key classification is an
+     allow-list, so a key it has never heard of poisons.
+  3. **the accumulator is empty.** Nothing typed since the reset, so there is no prefix for an
+     appended command to corrupt. An empty *buffer* is not enough on its own — condition 2 is what
+     makes "empty" mean "the line is empty" rather than "I stopped watching".
+  4. **`TerminalPane._hasUnechoedInput` is clear.** No keystrokes in flight that the grid has not seen
+     come back; the same gate the echo race uses.
+
+  Paste suppression (`IsCurrentSubmissionSuppressed`) and the alt-screen check still refuse upstream of
+  all of this.
+
+  The safety argument rests on the shape of the failure, not only on the gate: insertion sends text to
+  the shell's line editor and stops. The user sees the command sitting on their prompt and presses
+  `Enter` themselves, so the worst case is a visible, editable, deletable line — never a command that
+  ran. Compare the case the original rule was written for (`git sgit status`), which is also visible,
+  but is produced by *appending to text the user typed* — which conditions 2–4 exclude.
+
+  One honest residual cost: "the accumulator is clean and empty" is not the same as "the shell is at a
+  prompt". A markless pane running a program that reads stdin (`cat`, a REPL) satisfies every
+  condition, so an accepted row is typed into that program instead. Typing the command by hand would
+  have done the same thing, and it is equally visible.
 - **Enter-time history capture, but only for a straight-through-typed line.** This is the one that
   was worth arguing about. V1's heuristic capture read the shadow buffer, so for any line the user
   had edited with keys the mirror could not observe — `Ctrl+U`, arrows, history recall, tab
@@ -283,10 +317,20 @@ is never consulted as a query. What degraded mode costs, concretely:
 
 **`Ctrl+R` in a degraded session** still opens and still helps, because history is per user rather
 than per session: with no query to filter on, Search shows the recency list, which includes
-everything captured in instrumented sessions. It is browse-only — see the insertion rule above. It
-also says so: the bubble is labelled **`History - recent`** rather than `History` when no query can
-be read, because an identical-looking filter box that silently cannot filter reads as a bug the
-first time a keystroke fails to narrow it.
+everything captured in instrumented sessions. It also says so: the bubble is labelled
+**`History - recent`** rather than `History` when no query can be read, because an identical-looking
+filter box that silently cannot filter reads as a bug the first time a keystroke fails to narrow it.
+
+Since V2 Phase 3a it is no longer browse-only: at an untouched prompt the selected row can be inserted
+with `Enter` or `Ctrl+Enter` under the four conditions above. Once anything has been typed on the line,
+it is browse-only again.
+
+**The recency list is context-ordered since V2 Phase 3a.** Entries from this pane's host (or local
+entries, on a local pane) rank above the rest, with profile as a secondary term. Nothing is filtered
+out — a command run on another host is still in the list, below the fold — and the ranking lives in
+`CommandAssistSuggestionEngine` like every other ranking rule. The recall pool was widened from 5 to
+200 candidates at the same time, because a store that hands over five rows, all from whichever pane ran
+a command last, gives the engine nothing to reorder.
 
 ### Overlay anchoring after Phase 2a
 

--- a/docs/command-assist/CommandAssist_ShellIntegration_Gaps.md
+++ b/docs/command-assist/CommandAssist_ShellIntegration_Gaps.md
@@ -197,7 +197,7 @@ is never consulted as a query. What degraded mode costs, concretely:
 - **no passive suggestions.** With no query the path provider has no command token and no
   path-shaped fragment to work from, so it returns nothing. Degraded passive suggestions are empty
   by construction rather than by a special case.
-- **no help token from the command line.** `Ctrl+Alt+H` with nothing selected finds nothing.
+- **no help token from the command line.** `Ctrl+Shift+H` with nothing selected finds nothing.
   Explain-selection still works, because a selection is an explicit input the grid is not needed
   for, and Fix still works, because it analyses the command that failed rather than the one being
   typed.
@@ -331,6 +331,31 @@ out — a command run on another host is still in the list, below the fold — a
 `CommandAssistSuggestionEngine` like every other ranking rule. The recall pool was widened from 5 to
 200 candidates at the same time, because a store that hands over five rows, all from whichever pane ran
 a command last, gives the engine nothing to reorder.
+
+Three honest edges in that scoping, all found in the PR #290 review:
+
+- **the host id is the configured `Profile.SshHost` spelling, verbatim.** Not resolved, not canonicalised
+  — so the same machine reached as `10.0.0.5` and as `build.example` occupies two contexts and the two
+  panes do not share a band. Resolution would be a network call on a ranking path and would move under
+  DHCP; the fallback (an unknown context is not a context, so pure recency) is unhelpful rather than
+  wrong. Full band table in `CommandAssist.md` §6.
+- **pinning a snippet is worth +50 on the text-query path too**, not only on the empty-query one. A
+  pinned snippet satisfies both affinity terms by definition (it has no host and no profile of its own to
+  compare), so it collects the same-context 30 and same-profile 20 on top of its own pin boost of 40.
+  Deliberate, and bounded by the text-match tiers still dominating.
+- **an unpinned snippet sits in the same-profile band (+200)**: above cross-context history, below this
+  host's own. With more same-context rows than the popup shows it is below the fold, and pinning is the
+  answer. Chosen over "snippets always first" in the review; the dead `+8` nudge it replaced put snippets
+  below every command the user had ever run once.
+
+**One caveat about the popup and the mouse.** The popup surface is opaque to hit testing, and since the
+PR #290 review it also swallows right- and middle-clicks (they would otherwise open the pane context menu
+over the list, or paste into the shell beneath it). The cost is that an application on the *primary*
+screen which has enabled mouse reporting does not see clicks that land on the popup rectangle — the
+overlay is not a terminal surface and cannot forward them. Alt-screen apps are unaffected because the
+assist surface is hidden there outright; the exposure is a primary-screen program doing its own mouse
+tracking (`less`, a full-screen-less TUI) while an assist popup happens to be open over it. `Esc`
+dismisses.
 
 ### Overlay anchoring after Phase 2a
 

--- a/docs/plans/2026-08-01-command-assist-v2-plan.md
+++ b/docs/plans/2026-08-01-command-assist-v2-plan.md
@@ -255,16 +255,48 @@ Exit criteria: SSH + instrumented remote passes smoke scenarios with zero `[Corr
 
 ## Phase 3 — Visible usefulness
 
-Tasks:
-1. Auto-open policy v2: passive bubble with top-1 merged suggestion after >=2 chars, ~75 ms debounce; Escape suppresses for current command; popup still intent-only. Policy behind `CommandAssistPassiveBubbleEnabled` (default true when master flag on); M4.3-quiet behavior as fallback.
-2. Bind `ShortcutHintText` in `CommandAssistBubbleView`; verify content reflects rebound shortcuts.
-3. Popup interactivity: rows become selectable (mouse hover + click-to-accept), `ScrollViewer` + scroll-into-view, remove hard-coded `maxResults: 5` in favor of scrolling cap.
-4. Shortcuts: move pin off `Ctrl+Shift+P` to a new catalogued binding; add `Esc`/`Up`/`Down`/`Ctrl+Enter` to catalog under `ShortcutScope.CommandAssist`; migration for existing shortcut config.
-5. Gating decoupled: master flag alone gates the feature; history flag gates capture only. Wire `CommandAssistAutoHideInAltScreen` for real or delete it (decide at phase kickoff).
-6. Settings UI group: master, history + Clear history button (`IHistoryStore.ClearAsync` finally called), shell integration, passive bubble.
-7. Perf benchmark (new, spec §12 targets): first-paint <16 ms, incremental <30 ms, no typing jank; wire into CI as a regression guard.
+**Split into 3a and 3b after owner dogfooding.** Phases 0–2 were merged and tested by the product
+owner, who reported three things that no task in this phase covered: `Ctrl+R` listed history but
+"does no action when I select" (local *and* SSH); the list mixed every session's and tab's commands
+together; and in a tab split into two SSH panes the assist did not appear on one of them at all.
+Those are the whole of what a user sees, so they were pulled forward into **Phase 3a** together with
+the two tasks below that they touch (2, and 3 in full). Everything else is **Phase 3b**.
 
-Exit criteria: type-two-chars-see-value demo works on all four shells; benchmark in CI; updated smoke checklist passes.
+Tasks:
+1. Auto-open policy v2: passive bubble with top-1 merged suggestion after >=2 chars, ~75 ms debounce; Escape suppresses for current command; popup still intent-only. Policy behind `CommandAssistPassiveBubbleEnabled` (default true when master flag on); M4.3-quiet behavior as fallback. **Phase 3b.**
+2. ~~Bind `ShortcutHintText` in `CommandAssistBubbleView`; verify content reflects rebound shortcuts.~~ **Done (Phase 3a).** Bound in the bubble *and* repeated in the popup footer. Content is state-dependent rather than a constant, which the task line did not anticipate: after the accept-model change below, a fixed strip would advertise `Enter` in states where the shell owns it. `CommandAssistBarViewModel` computes it from one predicate (`AssistSessionStateMachine.AllowsAcceptOnEnter`) that the key router also consults, via a probe the controller installs — so the hint and the routing cannot disagree. "Reflects rebound shortcuts" is **not** done, because the bindings are not in the shortcut catalogue yet; that is task 4.
+3. ~~Popup interactivity: rows become selectable (mouse hover + click-to-accept), `ScrollViewer` + scroll-into-view, remove hard-coded `maxResults: 5` in favor of scrolling cap.~~ **Done (Phase 3a).** Hover via `:pointerover`, single click selects, double click (or a click on the already-selected row) accepts through the same gate `Ctrl+Enter` uses. `ScrollViewer` + `ContainerFromIndex(...).BringIntoView()` on selection change; cap 5 → 50 with the history recall pool widened to 200. Two things the task line missed: the rows had to stop being immutable records (a rebuild per selection move destroys the containers under the pointer), and `CommandAssistOverlayHost` had `IsHitTestVisible="False"`, which excludes the whole subtree — no click could ever have reached a row. Deliberately *not* a `ListBox`: it would take keyboard focus off `TerminalView` on the first click.
+4. Shortcuts: move pin off `Ctrl+Shift+P` to a new catalogued binding; add `Esc`/`Up`/`Down`/`Ctrl+Enter` to catalog under `ShortcutScope.CommandAssist`; migration for existing shortcut config. **Phase 3b** — and it now has one more entry to catalogue: plain `Enter`.
+5. Gating decoupled: master flag alone gates the feature; history flag gates capture only. Wire `CommandAssistAutoHideInAltScreen` for real or delete it (decide at phase kickoff). **Phase 3b.**
+6. Settings UI group: master, history + Clear history button (`IHistoryStore.ClearAsync` finally called), shell integration, passive bubble. **Phase 3b.**
+7. Perf benchmark (new, spec §12 targets): first-paint <16 ms, incremental <30 ms, no typing jank; wire into CI as a regression guard. **Phase 3b.**
+
+Phase 3a also shipped three things that were not tasks here at all, because they are the reports:
+
+- **`Enter` accepts while browsing.** Accept was `Ctrl+Enter`-only, so `Ctrl+R` → arrow → `Enter`
+  submitted the (empty) line and the submission reset dismissed the popup: nothing inserted, surface
+  gone. `Enter` is now assist-owned in exactly one state — popup open, row selected, mode Suggest or
+  Search — and falls through to the shell when the insertion is refused, so a refusal is never a dead
+  key. Documented in `CommandAssist.md` §14, which was rewritten to describe shipped reality (the
+  Phase 6 task line asking for that is correspondingly smaller now).
+- **Explicit intent is never hidden.** `ShouldSuppressConservativeRemoteAssist` hid the overlay
+  outright on short markless-SSH panes whose prompt sat high in the pane — and a split makes both
+  panes short. It applied to `Ctrl+R` as readily as to a passive bubble, which is the "does not show
+  up on one of them" report. A user-requested surface (`AssistSessionState`:
+  ExplicitBubble/ExplicitPopup/HistorySearch/Help/FixPopup) now bypasses it, and worst-case placement
+  is the safe lower band. The correction stack still *runs* for those surfaces; what it may not do is
+  drop them to zero opacity while it settles.
+- **Context-scoped history.** The `Ctrl+R` path was `GetRecentAsync` — pure recency, no context, and
+  truncated to 5 candidates so no ranking rule could have helped. Entries matching the pane's context
+  (host id for SSH, localness for local; profile as a secondary term) now rank first, and the rest
+  follow rather than being hidden. Ranking stays in `CommandAssistSuggestionEngine`; the stores remain
+  recall gates.
+- **Degraded-session insertion, narrowed rather than dropped.** #286's browse-only rule refused all
+  insertion without a grid snapshot. It now allows it when the pane can *prove* the line is empty:
+  the #287 markless accumulator is unpoisoned and empty, and no keystroke is awaiting echo. This is a
+  documented contract change — see the gaps doc.
+
+Exit criteria: type-two-chars-see-value demo works on all four shells; benchmark in CI; updated smoke checklist passes. **(Phase 3b; Phase 3a's own bar was the three owner reports plus green per-project suites.)**
 
 ## Phase 4 — Real content
 

--- a/docs/plans/2026-08-01-command-assist-v2-plan.md
+++ b/docs/plans/2026-08-01-command-assist-v2-plan.md
@@ -271,14 +271,19 @@ Tasks:
 6. Settings UI group: master, history + Clear history button (`IHistoryStore.ClearAsync` finally called), shell integration, passive bubble. **Phase 3b.**
 7. Perf benchmark (new, spec §12 targets): first-paint <16 ms, incremental <30 ms, no typing jank; wire into CI as a regression guard. **Phase 3b.**
 
-Phase 3a also shipped three things that were not tasks here at all, because they are the reports:
+Phase 3a also shipped four things that were not tasks here at all — the three owner reports, plus the
+insertion narrowing they forced:
 
 - **`Enter` accepts while browsing.** Accept was `Ctrl+Enter`-only, so `Ctrl+R` → arrow → `Enter`
   submitted the (empty) line and the submission reset dismissed the popup: nothing inserted, surface
   gone. `Enter` is now assist-owned in exactly one state — popup open, row selected, mode Suggest or
-  Search — and falls through to the shell when the insertion is refused, so a refusal is never a dead
-  key. Documented in `CommandAssist.md` §14, which was rewritten to describe shipped reality (the
-  Phase 6 task line asking for that is correspondingly smaller now).
+  Search, overlay actually rendered — and falls through to the shell when the insertion is refused, so a
+  refusal is never a dead key. Documented in `CommandAssist.md` §14, which was rewritten to describe
+  shipped reality (the Phase 6 task line asking for that is correspondingly smaller now).
+  The PR #290 review added two conditions to this: the rendered-overlay term (a passive popup the pane had
+  hidden or dimmed could otherwise own `Enter` at zero pixels) and the arrow asymmetry — `Down` browses
+  suggestions while typing, `Up` stays the shell's history recall, and both arrows are owned only in an
+  open list or on a surface the user summoned.
 - **Explicit intent is never hidden.** `ShouldSuppressConservativeRemoteAssist` hid the overlay
   outright on short markless-SSH panes whose prompt sat high in the pane — and a split makes both
   panes short. It applied to `Ctrl+R` as readily as to a passive bubble, which is the "does not show

--- a/src/NovaTerminal.App/CommandAssist/Views/CommandAssistBubbleView.axaml
+++ b/src/NovaTerminal.App/CommandAssist/Views/CommandAssistBubbleView.axaml
@@ -36,10 +36,17 @@
                 which is why the shortcuts were unlearnable in-product: the one surface that could have
                 taught them rendered everything except them. Content is state-dependent (see
                 CommandAssistBarViewModel), so it never advertises a key the surface does not own.
+
+                It is also the lowest-priority content in the bubble, and the layout has to say so: this
+                is an Auto column next to the summary's *, so without a cap it wins every width argument
+                (PR #290 review). Collapsed outright in compact layout - the 280 px floor a split SSH
+                pane lands on - and capped otherwise so the summary keeps the remainder.
             -->
             <TextBlock x:Name="BubbleShortcutHintText"
                        Grid.Column="3"
                        Text="{Binding ShortcutHintText}"
+                       IsVisible="{Binding ShowShortcutHint}"
+                       MaxWidth="240"
                        Foreground="#8B96A5"
                        FontSize="11"
                        VerticalAlignment="Center"

--- a/src/NovaTerminal.App/CommandAssist/Views/CommandAssistBubbleView.axaml
+++ b/src/NovaTerminal.App/CommandAssist/Views/CommandAssistBubbleView.axaml
@@ -10,7 +10,7 @@
             BorderThickness="1"
             CornerRadius="8"
             Padding="10,6">
-        <Grid ColumnDefinitions="Auto,Auto,*" ColumnSpacing="10">
+        <Grid ColumnDefinitions="Auto,Auto,*,Auto" ColumnSpacing="10">
             <TextBlock x:Name="BubbleModeLabelText"
                        Text="{Binding ModeLabel}"
                        Foreground="#8EC5FF"
@@ -28,6 +28,20 @@
                        Grid.Column="2"
                        Text="{Binding SummaryText}"
                        Foreground="#D7E8FF"
+                       VerticalAlignment="Center"
+                       TextTrimming="CharacterEllipsis"/>
+
+            <!--
+                The hint strip. Present on the view-model since M4.2 and never bound until V2 Phase 3a,
+                which is why the shortcuts were unlearnable in-product: the one surface that could have
+                taught them rendered everything except them. Content is state-dependent (see
+                CommandAssistBarViewModel), so it never advertises a key the surface does not own.
+            -->
+            <TextBlock x:Name="BubbleShortcutHintText"
+                       Grid.Column="3"
+                       Text="{Binding ShortcutHintText}"
+                       Foreground="#8B96A5"
+                       FontSize="11"
                        VerticalAlignment="Center"
                        TextTrimming="CharacterEllipsis"/>
         </Grid>

--- a/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml
+++ b/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml
@@ -26,11 +26,20 @@
             <Setter Property="Background" Value="#332F6FEB"/>
         </Style>
     </UserControl.Styles>
+    <!--
+        Right- and middle-clicks anywhere on the popup are swallowed here rather than allowed to bubble
+        (PR #290 review): the popup floats over a live terminal inside a pane whose root grid owns a
+        context menu, so a right-click on a suggestion row opened the pane menu on top of the list, and a
+        middle-click was an X11-style paste into the shell underneath. Neither gesture means anything to
+        the popup, so neither may mean anything to what is behind it.
+    -->
     <Border Background="#F01B1B1B"
             BorderBrush="#404040"
             BorderThickness="1"
             CornerRadius="10"
-            Padding="12">
+            Padding="12"
+            PointerPressed="OnPopupSurfacePointerPressed"
+            ContextRequested="OnPopupSurfaceContextRequested">
         <Grid RowDefinitions="Auto,*,Auto" ColumnDefinitions="*"
               RowSpacing="10">
             <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">

--- a/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml
+++ b/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml
@@ -5,12 +5,33 @@
              x:DataType="viewModels:CommandAssistPopupViewModel"
              x:Class="NovaTerminal.CommandAssist.Views.CommandAssistPopupView"
              IsVisible="{Binding IsVisible}">
+    <UserControl.Styles>
+        <!--
+            Row visuals. Hover is pure CSS-style state, so pointer feedback costs no code: the
+            :pointerover pseudo-class already tracks what the mouse is over, and `Classes.selected` is
+            bound to the row view-model's mutable IsSelected. Selection wins over hover because the
+            selected row is the one Enter acts on and that has to stay legible while the pointer is
+            elsewhere in the list.
+        -->
+        <Style Selector="Border.assistRow">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="CornerRadius" Value="4"/>
+            <Setter Property="Padding" Value="4,2"/>
+            <Setter Property="Cursor" Value="Hand"/>
+        </Style>
+        <Style Selector="Border.assistRow:pointerover">
+            <Setter Property="Background" Value="#22FFFFFF"/>
+        </Style>
+        <Style Selector="Border.assistRow.selected">
+            <Setter Property="Background" Value="#332F6FEB"/>
+        </Style>
+    </UserControl.Styles>
     <Border Background="#F01B1B1B"
             BorderBrush="#404040"
             BorderThickness="1"
             CornerRadius="10"
             Padding="12">
-        <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*"
+        <Grid RowDefinitions="Auto,*,Auto" ColumnDefinitions="*"
               RowSpacing="10">
             <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
                 <TextBlock x:Name="PopupModeLabelText"
@@ -34,43 +55,51 @@
                         CornerRadius="6"
                         Padding="8">
                     <Grid>
-                        <ItemsControl x:Name="PopupSuggestionsList"
-                                      ItemsSource="{Binding Suggestions}"
+                        <ScrollViewer x:Name="PopupSuggestionsScroller"
+                                      HorizontalScrollBarVisibility="Disabled"
+                                      VerticalScrollBarVisibility="Auto"
                                       IsVisible="{Binding HasSuggestions}">
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate x:DataType="viewModels:CommandAssistSuggestionItemViewModel">
-                                    <Grid ColumnDefinitions="Auto,*,Auto"
-                                          Margin="0,2">
-                                        <TextBlock Text="{Binding SelectionGlyph}"
-                                                   Foreground="#8EC5FF"
-                                                   Width="12"
-                                                   VerticalAlignment="Top"/>
-                                        <StackPanel Grid.Column="1"
-                                                    Spacing="1">
-                                            <TextBlock Text="{Binding DisplayText}"
-                                                       Foreground="White"
-                                                       FontFamily="Consolas"
-                                                       TextTrimming="CharacterEllipsis"/>
-                                            <TextBlock Text="{Binding DescriptionText}"
-                                                       Foreground="#C8E1FF"
-                                                       FontSize="11"
-                                                       TextWrapping="Wrap"/>
-                                            <TextBlock Text="{Binding MetadataText}"
-                                                       Foreground="#9CA3AF"
-                                                       FontSize="11"
-                                                       TextTrimming="CharacterEllipsis"/>
-                                        </StackPanel>
-                                        <TextBlock Grid.Column="2"
-                                                   Text="{Binding BadgesText}"
-                                                   Foreground="#C8E1FF"
-                                                   FontSize="11"
-                                                   HorizontalAlignment="Right"
-                                                   Margin="8,0,0,0"
-                                                   TextWrapping="Wrap"/>
-                                    </Grid>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
+                            <ItemsControl x:Name="PopupSuggestionsList"
+                                          ItemsSource="{Binding Suggestions}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="viewModels:CommandAssistSuggestionItemViewModel">
+                                        <Border Classes="assistRow"
+                                                Classes.selected="{Binding IsSelected}"
+                                                Margin="0,1"
+                                                PointerPressed="OnSuggestionRowPointerPressed">
+                                            <Grid ColumnDefinitions="Auto,*,Auto">
+                                                <TextBlock Text="{Binding SelectionGlyph}"
+                                                           Foreground="#8EC5FF"
+                                                           Width="12"
+                                                           VerticalAlignment="Top"/>
+                                                <StackPanel Grid.Column="1"
+                                                            Spacing="1">
+                                                    <TextBlock Text="{Binding DisplayText}"
+                                                               Foreground="White"
+                                                               FontFamily="Consolas"
+                                                               TextTrimming="CharacterEllipsis"/>
+                                                    <TextBlock Text="{Binding DescriptionText}"
+                                                               Foreground="#C8E1FF"
+                                                               FontSize="11"
+                                                               TextWrapping="Wrap"/>
+                                                    <TextBlock Text="{Binding MetadataText}"
+                                                               Foreground="#9CA3AF"
+                                                               FontSize="11"
+                                                               TextTrimming="CharacterEllipsis"/>
+                                                </StackPanel>
+                                                <TextBlock Grid.Column="2"
+                                                           Text="{Binding BadgesText}"
+                                                           Foreground="#C8E1FF"
+                                                           FontSize="11"
+                                                           HorizontalAlignment="Right"
+                                                           Margin="8,0,0,0"
+                                                           TextWrapping="Wrap"/>
+                                            </Grid>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </ScrollViewer>
 
                         <TextBlock x:Name="PopupEmptyStateTextBlock"
                                    Text="{Binding EmptyStateText}"
@@ -116,7 +145,7 @@
                     CornerRadius="6"
                     Padding="8"
                     IsVisible="{Binding UseCompactLayout}">
-                <Grid RowDefinitions="Auto,Auto"
+                <Grid RowDefinitions="Auto,*"
                       RowSpacing="8">
                     <StackPanel Spacing="4"
                                 IsVisible="{Binding HasSuggestions}">
@@ -139,42 +168,51 @@
                     </StackPanel>
 
                     <Grid Grid.Row="1">
-                        <ItemsControl ItemsSource="{Binding Suggestions}"
+                        <ScrollViewer x:Name="PopupCompactSuggestionsScroller"
+                                      HorizontalScrollBarVisibility="Disabled"
+                                      VerticalScrollBarVisibility="Auto"
                                       IsVisible="{Binding HasSuggestions}">
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate x:DataType="viewModels:CommandAssistSuggestionItemViewModel">
-                                    <Grid ColumnDefinitions="Auto,*,Auto"
-                                          Margin="0,2">
-                                        <TextBlock Text="{Binding SelectionGlyph}"
-                                                   Foreground="#8EC5FF"
-                                                   Width="12"
-                                                   VerticalAlignment="Top"/>
-                                        <StackPanel Grid.Column="1"
-                                                    Spacing="1">
-                                            <TextBlock Text="{Binding DisplayText}"
-                                                       Foreground="White"
-                                                       FontFamily="Consolas"
-                                                       TextTrimming="CharacterEllipsis"/>
-                                            <TextBlock Text="{Binding DescriptionText}"
-                                                       Foreground="#C8E1FF"
-                                                       FontSize="11"
-                                                       TextWrapping="Wrap"/>
-                                            <TextBlock Text="{Binding MetadataText}"
-                                                       Foreground="#9CA3AF"
-                                                       FontSize="11"
-                                                       TextTrimming="CharacterEllipsis"/>
-                                        </StackPanel>
-                                        <TextBlock Grid.Column="2"
-                                                   Text="{Binding BadgesText}"
-                                                   Foreground="#C8E1FF"
-                                                   FontSize="11"
-                                                   HorizontalAlignment="Right"
-                                                   Margin="8,0,0,0"
-                                                   TextWrapping="Wrap"/>
-                                    </Grid>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
+                            <ItemsControl x:Name="PopupCompactSuggestionsList"
+                                          ItemsSource="{Binding Suggestions}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="viewModels:CommandAssistSuggestionItemViewModel">
+                                        <Border Classes="assistRow"
+                                                Classes.selected="{Binding IsSelected}"
+                                                Margin="0,1"
+                                                PointerPressed="OnSuggestionRowPointerPressed">
+                                            <Grid ColumnDefinitions="Auto,*,Auto">
+                                                <TextBlock Text="{Binding SelectionGlyph}"
+                                                           Foreground="#8EC5FF"
+                                                           Width="12"
+                                                           VerticalAlignment="Top"/>
+                                                <StackPanel Grid.Column="1"
+                                                            Spacing="1">
+                                                    <TextBlock Text="{Binding DisplayText}"
+                                                               Foreground="White"
+                                                               FontFamily="Consolas"
+                                                               TextTrimming="CharacterEllipsis"/>
+                                                    <TextBlock Text="{Binding DescriptionText}"
+                                                               Foreground="#C8E1FF"
+                                                               FontSize="11"
+                                                               TextWrapping="Wrap"/>
+                                                    <TextBlock Text="{Binding MetadataText}"
+                                                               Foreground="#9CA3AF"
+                                                               FontSize="11"
+                                                               TextTrimming="CharacterEllipsis"/>
+                                                </StackPanel>
+                                                <TextBlock Grid.Column="2"
+                                                           Text="{Binding BadgesText}"
+                                                           Foreground="#C8E1FF"
+                                                           FontSize="11"
+                                                           HorizontalAlignment="Right"
+                                                           Margin="8,0,0,0"
+                                                           TextWrapping="Wrap"/>
+                                            </Grid>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </ScrollViewer>
 
                         <TextBlock Text="{Binding EmptyStateText}"
                                    Foreground="#9CA3AF"
@@ -185,6 +223,13 @@
                     </Grid>
                 </Grid>
             </Border>
+
+            <TextBlock Grid.Row="2"
+                       x:Name="PopupShortcutHintText"
+                       Text="{Binding ShortcutHintText}"
+                       Foreground="#8B96A5"
+                       FontSize="11"
+                       TextTrimming="CharacterEllipsis"/>
         </Grid>
     </Border>
 </UserControl>

--- a/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml.cs
+++ b/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml.cs
@@ -1,11 +1,145 @@
+using System;
+using System.ComponentModel;
 using Avalonia.Controls;
+using Avalonia.Input;
+using NovaTerminal.CommandAssist.ViewModels;
 
 namespace NovaTerminal.CommandAssist.Views;
 
+/// <summary>
+/// The suggestion popup. Renders rows, and turns pointer gestures on them into the two requests the
+/// pane knows how to answer: select this row, accept this row.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why events rather than commands.</strong> Accepting a row sends text to a PTY and needs the
+/// grid read, the echo flag and the markless accumulator that only <c>TerminalPane</c> has - the same
+/// path <c>Ctrl+Enter</c> takes. A command on the view-model would either duplicate that gate or
+/// bypass it, and this assembly cannot see the session anyway. So the view reports the gesture and the
+/// pane decides, which keeps exactly one insertion gate in the product.
+/// </para>
+/// <para>
+/// <strong>Why not a <c>ListBox</c>.</strong> A ListBox would supply hover, selection and
+/// scroll-into-view for free, and would also take keyboard focus off <c>TerminalView</c> on the first
+/// click - after which the user's next keystroke goes to the list instead of the shell. The popup
+/// overlays a live terminal that must keep focus at all times, so the rows are deliberately
+/// non-focusable <c>Border</c>s and the three behaviors are wired by hand.
+/// </para>
+/// </remarks>
 public partial class CommandAssistPopupView : UserControl
 {
+    private CommandAssistPopupViewModel? _observedViewModel;
+
     public CommandAssistPopupView()
     {
         InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    /// <summary>A row was clicked once. The argument is its index in <c>Suggestions</c>.</summary>
+    public event Action<int>? SuggestionPointerSelected;
+
+    /// <summary>
+    /// A row was double-clicked, or clicked while already selected. The argument is its index.
+    /// </summary>
+    public event Action<int>? SuggestionPointerAccepted;
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        if (_observedViewModel != null)
+        {
+            _observedViewModel.PropertyChanged -= OnViewModelPropertyChanged;
+        }
+
+        _observedViewModel = DataContext as CommandAssistPopupViewModel;
+
+        if (_observedViewModel != null)
+        {
+            _observedViewModel.PropertyChanged += OnViewModelPropertyChanged;
+        }
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(CommandAssistPopupViewModel.SelectedIndex))
+        {
+            BringSelectedRowIntoView();
+        }
+    }
+
+    /// <summary>
+    /// Scrolls the selected row into view after a keyboard move.
+    /// </summary>
+    /// <remarks>
+    /// Needed because the row list is an <c>ItemsControl</c> rather than a selecting control: nothing
+    /// else knows that one of its children is special. Both list instances are asked, because the
+    /// compact and expanded layouts are separate subtrees and only one of them is realized at a time -
+    /// the unrealized one has no container for the index and answers null, which is the no-op.
+    /// </remarks>
+    private void BringSelectedRowIntoView()
+    {
+        int index = _observedViewModel?.SelectedIndex ?? -1;
+        if (index < 0)
+        {
+            return;
+        }
+
+        BringIntoView(PopupSuggestionsList, index);
+        BringIntoView(PopupCompactSuggestionsList, index);
+    }
+
+    private static void BringIntoView(ItemsControl? list, int index)
+    {
+        if (list == null || index >= list.ItemCount)
+        {
+            return;
+        }
+
+        list.ContainerFromIndex(index)?.BringIntoView();
+    }
+
+    /// <summary>
+    /// Single click selects; double click - or a click on the row that is already selected - accepts.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The "already selected" case is what makes the mouse usable without a double click: browse to a
+    /// row with the arrow keys or a first click, then click it to run the insertion. Both gestures are
+    /// deliberate second acts, which is the bar an action that edits the user's command line has to
+    /// clear.
+    /// </para>
+    /// <para>
+    /// Left button only, and always marked handled. The popup floats over a terminal that treats a
+    /// pointer press as the start of a text selection, so an unhandled press would begin selecting the
+    /// grid underneath the list.
+    /// </para>
+    /// </remarks>
+    private void OnSuggestionRowPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+
+        if (sender is not Control { DataContext: CommandAssistSuggestionItemViewModel row })
+        {
+            return;
+        }
+
+        int index = _observedViewModel?.Suggestions.IndexOf(row) ?? -1;
+        if (index < 0)
+        {
+            return;
+        }
+
+        e.Handled = true;
+
+        if (e.ClickCount >= 2 || row.IsSelected)
+        {
+            SuggestionPointerAccepted?.Invoke(index);
+            return;
+        }
+
+        SuggestionPointerSelected?.Invoke(index);
     }
 }

--- a/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml.cs
+++ b/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml.cs
@@ -99,6 +99,49 @@ public partial class CommandAssistPopupView : UserControl
     }
 
     /// <summary>
+    /// Whether a pointer button pressed on the popup must be swallowed rather than allowed to reach
+    /// whatever is behind it.
+    /// </summary>
+    /// <remarks>
+    /// A predicate rather than an inline condition so the rule is assertable without synthesizing
+    /// pointer input: the two buttons named here are the two that do something destructive to the
+    /// terminal underneath (pane context menu, X11-style middle-click paste), and neither does anything
+    /// at all to the popup.
+    /// </remarks>
+    internal static bool IsSwallowedPointerButton(bool isRightButtonPressed, bool isMiddleButtonPressed) =>
+        isRightButtonPressed || isMiddleButtonPressed;
+
+    /// <summary>
+    /// Swallows right- and middle-clicks landing anywhere on the popup surface.
+    /// </summary>
+    /// <remarks>
+    /// Left-clicks are deliberately left alone here: the row handler below is the one that decides what
+    /// a left-click means, and marking the press handled at this level first would not stop it (the row
+    /// handler runs first, on the inner control) but would obscure where the decision lives.
+    /// </remarks>
+    private void OnPopupSurfacePointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        PointerPointProperties properties = e.GetCurrentPoint(this).Properties;
+        if (IsSwallowedPointerButton(properties.IsRightButtonPressed, properties.IsMiddleButtonPressed))
+        {
+            e.Handled = true;
+        }
+    }
+
+    /// <summary>
+    /// Stops a context-menu request raised over the popup from reaching the pane.
+    /// </summary>
+    /// <remarks>
+    /// Separate from the pointer handler because it is a separate event: Avalonia raises
+    /// <c>ContextRequested</c> from the pointer <em>release</em> (and from the menu key), so handling the
+    /// press alone leaves <c>TerminalPane.RootGrid</c>'s <c>ContextMenu</c> free to open over the list.
+    /// </remarks>
+    private void OnPopupSurfaceContextRequested(object? sender, ContextRequestedEventArgs e)
+    {
+        e.Handled = true;
+    }
+
+    /// <summary>
     /// Single click selects; double click - or a click on the row that is already selected - accepts.
     /// </summary>
     /// <remarks>

--- a/src/NovaTerminal.App/Controls/AssistKeyMapper.cs
+++ b/src/NovaTerminal.App/Controls/AssistKeyMapper.cs
@@ -42,6 +42,16 @@ namespace NovaTerminal.Controls
                 result |= AssistModifiers.Shift;
             }
 
+            // Meta is mapped even though nothing in Command Assist binds it. The accept-on-Enter rule
+            // is "no modifiers at all", so a dropped modifier is not a harmless omission: it made
+            // Win+Enter read as unmodified in the router while TerminalPane's own
+            // `modifiers == KeyModifiers.None` guard read it correctly, so the two disagreed about who
+            // owned the key and the hint strip could promise an accept that never happened.
+            if ((modifiers & KeyModifiers.Meta) != 0)
+            {
+                result |= AssistModifiers.Meta;
+            }
+
             return result;
         }
     }

--- a/src/NovaTerminal.App/Controls/MarklessSubmissionAccumulator.cs
+++ b/src/NovaTerminal.App/Controls/MarklessSubmissionAccumulator.cs
@@ -60,6 +60,20 @@ namespace NovaTerminal.Controls
 
         internal bool IsPoisoned => _poisoned;
 
+        /// <summary>
+        /// The accumulator can describe the current line <em>and</em> that description is "empty".
+        /// </summary>
+        /// <remarks>
+        /// The one thing this class knows that is useful outside history capture. In a markless session
+        /// there is no grid snapshot, so V2 Phase 3a asks this before allowing a suggestion to be
+        /// inserted: unpoisoned means nothing the accumulator cannot model has happened since the line
+        /// was reset, and empty means nothing has been typed - between them, the line is empty and a
+        /// whole command may be sent to it. See
+        /// <c>TerminalPane.TryReadInsertionQuerySnapshot</c> for the rest of the gate (the echo flag,
+        /// paste suppression, the alt screen).
+        /// </remarks>
+        internal bool IsCleanAndEmpty => !_poisoned && _buffer.Length == 0;
+
         /// <summary>The user typed printable text and the pane sent it to the PTY.</summary>
         internal void AppendTypedText(string? text)
         {

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml
@@ -116,11 +116,19 @@
                         </Grid>
                     </Border>
 
+                    <!--
+                        The host itself has no Background, so it is transparent to hit testing and a
+                        click anywhere except on a child still reaches the terminal underneath. It used
+                        to set IsHitTestVisible="False", which excludes the whole subtree and is why the
+                        popup rows could not be clicked at all (V2 Phase 3a): a child cannot opt back
+                        into hit testing its parent has switched off. The bubble opts out individually
+                        instead - it is a status readout with nothing to click, and it sits directly over
+                        the prompt row the user selects text on.
+                    -->
                     <Grid x:Name="CommandAssistOverlayHost"
                           Grid.Row="0"
                           ZIndex="150"
-                          IsVisible="False"
-                          IsHitTestVisible="False">
+                          IsVisible="False">
                         <assist:CommandAssistPopupView x:Name="CommandAssistPopup"
                                                        HorizontalAlignment="Left"
                                                        VerticalAlignment="Top"
@@ -128,6 +136,7 @@
                         <assist:CommandAssistBubbleView x:Name="CommandAssistBubble"
                                                         HorizontalAlignment="Left"
                                                         VerticalAlignment="Top"
+                                                        IsHitTestVisible="False"
                                                         Margin="16,16,16,24" />
                     </Grid>
                 </Grid>

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -179,6 +179,10 @@ namespace NovaTerminal.Controls
         private string? _lastCommandAssistAnchorAppliedSignature;
         private string? _lastCommandAssistAnchorCorrectionSignature;
         private bool _suppressSshAssistOverlayUntilSettled;
+
+        // Last value of IsCommandAssistOverlayRendered the controller was told about. Starts false, which
+        // matches the overlay host's IsVisible="False" in the XAML.
+        private bool _wasCommandAssistOverlayRendered;
         private int _sshAssistCorrectionPassCount;
         private int _commandAssistPlacementCorrectionPasses;
         private readonly CommandAssistBubbleViewModel _hiddenCommandAssistBubbleViewModel = new() { IsVisible = false };
@@ -1017,6 +1021,12 @@ namespace NovaTerminal.Controls
                 // assist assembly's own AssistQuerySnapshot right here, at the one boundary that
                 // can see both types. Everything downstream sees plain data.
                 queryProvider: TryReadAssistQuerySnapshot,
+
+                // The other seam the controller cannot see for itself: whether the overlay it believes
+                // is up is actually on screen. This pane hides it (no layout) and dims it (placement
+                // correction) on its own authority, and an armed Enter on a zero-pixel surface is the
+                // PR #290 review's first blocker.
+                renderedSurfaceProbe: () => IsCommandAssistOverlayRendered,
                 dispatch: action =>
                 {
                     if (Dispatcher.UIThread.CheckAccess())
@@ -1407,6 +1417,7 @@ namespace NovaTerminal.Controls
                 bool keepOverlayOpaque = !_suppressSshAssistOverlayUntilSettled || IsCommandAssistSurfaceUserRequested;
                 CommandAssistOverlayHost.IsVisible = shouldShowOverlayHost;
                 CommandAssistOverlayHost.Opacity = shouldShowOverlayHost && keepOverlayOpaque ? 1.0 : 0.0;
+                NotifyCommandAssistOverlayRenderedChanged();
             }
 
             if (layout == null)
@@ -1419,6 +1430,12 @@ namespace NovaTerminal.Controls
                 if (_boundCommandAssistViewModel != null)
                 {
                     _boundCommandAssistViewModel.Bubble.ShowQueryText = !layout.UseCompactBubbleLayout;
+
+                    // Same rule, same reason, one more casualty of a 280 px bubble: the hint strip's Auto
+                    // column beat the summary's * column at the width a split SSH pane produces, so the
+                    // one thing the bubble exists to show was squeezed out by a legend for it
+                    // (PR #290 review). The popup footer still carries the shortcuts.
+                    _boundCommandAssistViewModel.Bubble.ShowShortcutHint = !layout.UseCompactBubbleLayout;
                 }
 
                 CommandAssistBubble.Width = layout.BubbleRect.Width;
@@ -1527,6 +1544,48 @@ namespace NovaTerminal.Controls
         private bool IsCommandAssistSurfaceUserRequested =>
             _commandAssistController?.IsUserRequestedSurface == true;
 
+        /// <summary>
+        /// Whether the assist overlay this pane hosts is actually on screen right now.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The pane-side half of the PR #290 review's first blocker. Assist visibility has two
+        /// authorities and they disagree: the session says "a surface is up" through
+        /// <c>CommandAssistBarViewModel.IsVisible</c>, and this pane independently hides the overlay host
+        /// when the conservative anchor check yields no layout, or drops it to zero opacity while a
+        /// placement correction settles. Both of those bypasses are waived for a surface the user asked
+        /// for by name - and a <c>PassivePopup</c> is not one, so a passive popup could hold an armed
+        /// <c>Enter</c> at zero pixels while the user's command line silently failed to submit.
+        /// </para>
+        /// <para>
+        /// Read live rather than cached: it is asked on the key path and during
+        /// <c>SyncPresentationState</c>, and both want the current frame's answer.
+        /// </para>
+        /// </remarks>
+        internal bool IsCommandAssistOverlayRendered =>
+            CommandAssistOverlayHost is { IsVisible: true } host && host.Opacity > 0;
+
+        /// <summary>
+        /// Tells the controller the answer to <see cref="IsCommandAssistOverlayRendered"/> moved, so the
+        /// hint strip can catch up with the routing decision.
+        /// </summary>
+        /// <remarks>
+        /// Gated on an actual change, and not only to save work: republishing presentation state can
+        /// raise <c>IsAcceptOnEnterArmed</c>, which this pane listens to, which runs another placement
+        /// pass. The change check is what makes that converge on the second pass instead of recursing.
+        /// </remarks>
+        private void NotifyCommandAssistOverlayRenderedChanged()
+        {
+            bool isRendered = IsCommandAssistOverlayRendered;
+            if (isRendered == _wasCommandAssistOverlayRendered)
+            {
+                return;
+            }
+
+            _wasCommandAssistOverlayRendered = isRendered;
+            _commandAssistController?.NotifyRenderedSurfaceVisibilityChanged();
+        }
+
         internal bool ShouldCorrectCommandAssistPlacementForTest(CommandAssistAnchorLayout layout, bool assistIsVisible)
         {
             return ShouldCorrectCommandAssistPlacement(layout, assistIsVisible);
@@ -1614,6 +1673,7 @@ namespace NovaTerminal.Controls
                 {
                     _suppressSshAssistOverlayUntilSettled = true;
                     CommandAssistOverlayHost.Opacity = 0.0;
+                    NotifyCommandAssistOverlayRenderedChanged();
                 }
 
                 // Re-apply anchored margins if the rendered position drifted from expected.
@@ -1635,6 +1695,7 @@ namespace NovaTerminal.Controls
                     _suppressSshAssistOverlayUntilSettled = false;
                     _sshAssistCorrectionPassCount = 0;
                     CommandAssistOverlayHost.Opacity = 1.0;
+                    NotifyCommandAssistOverlayRenderedChanged();
                     TerminalLogger.Log("[AssistAnchor][SSH][Corrected] max-pass reached; showing overlay with best-known anchor.");
                     return;
                 }
@@ -1669,6 +1730,7 @@ namespace NovaTerminal.Controls
             if (CommandAssistOverlayHost != null)
             {
                 CommandAssistOverlayHost.Opacity = 1.0;
+                NotifyCommandAssistOverlayRenderedChanged();
             }
         }
 
@@ -1979,9 +2041,14 @@ namespace NovaTerminal.Controls
             }
 
             CommandAssistController? controller = _commandAssistController;
+            // Every fact here is asked of the controller rather than computed locally, including the two
+            // that depend on this pane: IsAcceptOnEnterArmed folds in IsCommandAssistOverlayRendered
+            // through the probe installed in InitializeCommandAssist, so the router, the hint strip and
+            // this pane cannot hold three different opinions about who owns Enter.
             var keyState = new AssistKeyState(
                 IsSurfaceVisible: controller?.ViewModel.IsVisible == true,
-                IsAcceptOnEnterArmed: controller?.IsAcceptOnEnterArmed == true);
+                IsAcceptOnEnterArmed: controller?.IsAcceptOnEnterArmed == true,
+                IsSelectionUpOwned: controller?.IsSelectionUpOwned == true);
             if (!CommandAssistKeyRouter.IsAssistOwnedKey(
                     keyState,
                     AssistKeyMapper.ToAssistKey(key),
@@ -2001,7 +2068,8 @@ namespace NovaTerminal.Controls
             }
 
             // Accept-on-Enter (V2 Phase 3a). The router only says yes here while the popup is open with
-            // a row selected, so the typing flow never reaches this branch.
+            // a row selected *and the overlay is rendered*, so neither the typing flow nor a surface this
+            // pane has hidden or dimmed reaches this branch.
             //
             // The return value is the insertion's, not `true`, and that is the important part: when
             // insertion refuses - a poisoned markless line, an unechoed keystroke, a cursor mid-line -
@@ -2019,6 +2087,9 @@ namespace NovaTerminal.Controls
                 return true;
             }
 
+            // Only reached when the router granted Up to the assist - an open popup, or a surface the user
+            // summoned. In the passive states Up is never routed here at all, so the shell keeps its
+            // history recall (PR #290 review).
             if (key == Key.Up)
             {
                 controller?.MoveSelectionUp();

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -500,6 +500,17 @@ namespace NovaTerminal.Controls
             ProcessExited += (_, exitCode) => _agentRegistration?.StatusMachine.NotifyExited(exitCode);
 
             TermView.KeyDownInterceptor = TryHandleCommandAssistKey;
+
+            // Mouse support for the popup rows (V2 Phase 3a). Wired here rather than in
+            // BindCommandAssistViews because the view is a fixed part of the pane's XAML tree while the
+            // view-model comes and goes with the feature flag: subscribing on every bind would add a
+            // second handler per rebind.
+            if (CommandAssistPopup != null)
+            {
+                CommandAssistPopup.SuggestionPointerSelected += OnCommandAssistSuggestionPointerSelected;
+                CommandAssistPopup.SuggestionPointerAccepted += OnCommandAssistSuggestionPointerAccepted;
+            }
+
             TermView.TextInput += (_, e) =>
             {
                 if (!string.IsNullOrEmpty(e.Text))
@@ -1264,11 +1275,28 @@ namespace NovaTerminal.Controls
         /// the "it might be a login banner" case.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// V2 Phase 2a: this is a hedge against not knowing where the prompt is, so a mark-anchored
         /// pane never reaches it. The <paramref name="hasMarkAnchor"/> early-out is redundant with
         /// <paramref name="hasReliablePromptAnchor"/> (a mark makes the anchor reliable by
         /// definition) and deliberately so: the property under test is "marks bypass suppression",
         /// and it should not depend on a second flag staying in sync.
+        /// </para>
+        /// <para>
+        /// V2 Phase 3a adds the second bypass, and it is the fix for the owner's third report: in a tab
+        /// split into two SSH panes, the assist did not appear on one of them at all. A split halves the
+        /// pane height, which puts both panes under
+        /// <see cref="ConservativeRemoteShortPaneHeightThreshold"/>, and on the pane whose prompt was
+        /// still in the upper band this returned true — for <c>Ctrl+R</c> as readily as for a passive
+        /// bubble. Suppressing a surface the user summoned is not conservative behavior; it is the
+        /// feature not working. So an explicitly requested surface is never hidden here, and the worst
+        /// case becomes what the anchor calculator already does without a reliable anchor: the safe
+        /// lower band.
+        /// </para>
+        /// <para>
+        /// The suppression stays exactly as it was for uninvited surfaces on markless SSH, which is the
+        /// case it was written for.
+        /// </para>
         /// </remarks>
         private bool ShouldSuppressConservativeRemoteAssist(
             CommandAssistPromptHint? promptHint,
@@ -1276,7 +1304,7 @@ namespace NovaTerminal.Controls
             bool hasMarkAnchor,
             double paneHeight)
         {
-            if (hasMarkAnchor)
+            if (hasMarkAnchor || IsCommandAssistSurfaceUserRequested)
             {
                 return false;
             }
@@ -1354,6 +1382,13 @@ namespace NovaTerminal.Controls
                 // Mark-anchored placement never hides the overlay while it settles: there is nothing
                 // to settle. Clearing here also unwinds any suppression left over from a markless
                 // frame earlier in the same session.
+                //
+                // A user-requested surface deliberately does *not* clear the counters here, even though
+                // it is also never hidden (V2 Phase 3a). Resetting _sshAssistCorrectionPassCount on
+                // every placement pass would stop MaxSshAssistCorrectionPasses from ever being reached,
+                // and since a correction pass posts another placement pass, that is an unbounded render
+                // loop. The bypass therefore lives on the opacity write below, which is the only thing
+                // the user can see anyway.
                 _suppressSshAssistOverlayUntilSettled = false;
                 _sshAssistCorrectionPassCount = 0;
 
@@ -1366,8 +1401,12 @@ namespace NovaTerminal.Controls
 
             if (CommandAssistOverlayHost != null)
             {
+                // The settle-suppression never applies to a surface the user asked for (V2 Phase 3a):
+                // an invisible answer to Ctrl+R is indistinguishable from no answer, which is how the
+                // owner experienced it on one pane of an SSH split.
+                bool keepOverlayOpaque = !_suppressSshAssistOverlayUntilSettled || IsCommandAssistSurfaceUserRequested;
                 CommandAssistOverlayHost.IsVisible = shouldShowOverlayHost;
-                CommandAssistOverlayHost.Opacity = shouldShowOverlayHost && !_suppressSshAssistOverlayUntilSettled ? 1.0 : 0.0;
+                CommandAssistOverlayHost.Opacity = shouldShowOverlayHost && keepOverlayOpaque ? 1.0 : 0.0;
             }
 
             if (layout == null)
@@ -1466,8 +1505,27 @@ namespace NovaTerminal.Controls
                 return false;
             }
 
+            // Deliberately *not* gated on IsCommandAssistSurfaceUserRequested. V2 Phase 3a's rule is
+            // that a summoned surface is never hidden, not that it is never corrected: correcting the
+            // placement is the useful half of this stack and costs the user nothing. What it must not do
+            // is drop the overlay to zero opacity while it settles, which for up to six render passes
+            // reads as "Ctrl+R did nothing" — so the hiding is what carries the bypass, at the two
+            // places that apply it (see the opacity write in UpdateCommandAssistOverlayPlacement and
+            // the suppression write inside CorrectPlacement).
             return Profile?.Type == ConnectionType.SSH && assistIsVisible;
         }
+
+        /// <summary>
+        /// Whether the assist surface currently on screen is one the user asked for by name —
+        /// <c>Ctrl+Space</c>, <c>Ctrl+R</c>, Help, a confident Fix popup.
+        /// </summary>
+        /// <remarks>
+        /// The single question every overlay-hiding heuristic in this file now asks first. The
+        /// authority is <c>AssistSessionStateMachine.IsUserRequestedSurface</c>; this is only the
+        /// null-safe pane-side spelling of it.
+        /// </remarks>
+        private bool IsCommandAssistSurfaceUserRequested =>
+            _commandAssistController?.IsUserRequestedSurface == true;
 
         internal bool ShouldCorrectCommandAssistPlacementForTest(CommandAssistAnchorLayout layout, bool assistIsVisible)
         {
@@ -1551,8 +1609,12 @@ namespace NovaTerminal.Controls
                     return;
                 }
 
-                _suppressSshAssistOverlayUntilSettled = true;
-                CommandAssistOverlayHost.Opacity = 0.0;
+                // Correct the placement either way; hide only what the user did not ask for.
+                if (!IsCommandAssistSurfaceUserRequested)
+                {
+                    _suppressSshAssistOverlayUntilSettled = true;
+                    CommandAssistOverlayHost.Opacity = 0.0;
+                }
 
                 // Re-apply anchored margins if the rendered position drifted from expected.
                 CommandAssistBubble.Margin = new Thickness(layout.BubbleRect.X, layout.BubbleRect.Y, 0, 0);
@@ -1917,9 +1979,11 @@ namespace NovaTerminal.Controls
             }
 
             CommandAssistController? controller = _commandAssistController;
-            bool isAssistVisible = controller?.ViewModel.IsVisible == true;
+            var keyState = new AssistKeyState(
+                IsSurfaceVisible: controller?.ViewModel.IsVisible == true,
+                IsAcceptOnEnterArmed: controller?.IsAcceptOnEnterArmed == true);
             if (!CommandAssistKeyRouter.IsAssistOwnedKey(
-                    isAssistVisible,
+                    keyState,
                     AssistKeyMapper.ToAssistKey(key),
                     AssistKeyMapper.ToAssistModifiers(modifiers)))
             {
@@ -1934,6 +1998,19 @@ namespace NovaTerminal.Controls
             {
                 controller?.HandleEscape();
                 return true;
+            }
+
+            // Accept-on-Enter (V2 Phase 3a). The router only says yes here while the popup is open with
+            // a row selected, so the typing flow never reaches this branch.
+            //
+            // The return value is the insertion's, not `true`, and that is the important part: when
+            // insertion refuses - a poisoned markless line, an unechoed keystroke, a cursor mid-line -
+            // Enter falls through to the shell and submits, exactly as it did before this branch
+            // existed. Consuming it instead would turn a refusal into a dead key, which is a strictly
+            // worse answer than the pre-Phase-3a behavior the user is used to.
+            if (key == Key.Enter && modifiers == KeyModifiers.None)
+            {
+                return TryInsertSelectedCommandAssistSuggestion();
             }
 
             if (key == Key.Down)
@@ -2012,6 +2089,40 @@ namespace NovaTerminal.Controls
         /// <summary>Whether an edit keystroke is still waiting for the shell's echo.</summary>
         internal bool HasUnechoedInput => _hasUnechoedInput;
 
+        /// <summary>
+        /// A popup row was clicked once: select it, exactly as <c>Up</c>/<c>Down</c> would.
+        /// </summary>
+        /// <remarks>
+        /// Selecting rather than accepting is deliberate. A single click that ran an insertion would
+        /// make the list unbrowsable by mouse — there would be no way to look at a row's detail panel
+        /// without committing to it — and it would put a destructive action one stray click away on a
+        /// surface that overlays the terminal. Accept needs a second, deliberate act: a double click, or
+        /// a click on the row that is already selected.
+        /// </remarks>
+        internal void OnCommandAssistSuggestionPointerSelected(int index)
+        {
+            _commandAssistController?.TrySelectSuggestionAt(index);
+        }
+
+        /// <summary>A popup row was double-clicked, or clicked while already selected: accept it.</summary>
+        internal void OnCommandAssistSuggestionPointerAccepted(int index)
+        {
+            CommandAssistController? controller = _commandAssistController;
+            if (controller == null)
+            {
+                return;
+            }
+
+            // Select first even on the accept path: a double click on an unselected row must insert the
+            // row that was clicked, not whatever the keyboard had highlighted.
+            if (!controller.TrySelectSuggestionAt(index))
+            {
+                return;
+            }
+
+            TryInsertSelectedCommandAssistSuggestion();
+        }
+
         private bool TryInsertSelectedCommandAssistSuggestion()
         {
             if (_commandAssistController == null || Session == null)
@@ -2028,9 +2139,7 @@ namespace NovaTerminal.Controls
 
             // Read the line before accepting: accepting dismisses the surface, and the planner needs
             // to know what is on the command line *now* rather than what the last ranking pass saw.
-            // A markless session yields null here, and the planner refuses -- insertion is
-            // prefix-dependent and degraded mode does not offer prefix-dependent features.
-            AssistQuerySnapshot? existingQuery = _commandAssistController.TryReadQuerySnapshot();
+            AssistQuerySnapshot? existingQuery = TryReadInsertionQuerySnapshot();
 
             // Everything above and below this line is non-mutating, and that ordering is the point.
             // TryAcceptSelection accepts *and* dismisses; calling it first meant that every refusal
@@ -2064,6 +2173,79 @@ namespace NovaTerminal.Controls
             _marklessSubmission.Poison();
             Session.SendInput(textToSend);
             return true;
+        }
+
+        /// <summary>
+        /// The command line the insertion planner is measured against: grid truth where it exists, and
+        /// in a markless session an <em>observed-empty</em> line when - and only when - the accumulator
+        /// can prove the line is empty.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <strong>V2 Phase 3a: the "browse-only in degraded sessions" rule is narrowed, not dropped.</strong>
+        /// Phase 1c refused all insertion without a snapshot, for a good reason: appending a whole
+        /// command to an unknown prefix is how <c>git sgit status</c> happens. But "unknown" was doing
+        /// two jobs. In the case the owner actually hit - open a markless SSH pane, press
+        /// <c>Ctrl+R</c>, pick a row - the prefix is not unknown at all. It is empty, and the pane can
+        /// prove it: the accumulator was reset by the last <c>Enter</c> (or <c>Ctrl+C</c>) and has
+        /// observed nothing since, and it poisons on every edit it cannot model. So this returns the
+        /// snapshot that says "the line was read and it is empty", which the planner already handles
+        /// as a fact rather than an absence, and the whole command is sent.
+        /// </para>
+        /// <para>
+        /// <strong>Why this is safe.</strong> Four independent things all have to agree, and each of
+        /// them fails closed:
+        /// </para>
+        /// <list type="number">
+        /// <item>the accumulator is <em>not poisoned</em> - so no arrow key, <c>Home</c>, <c>Delete</c>,
+        /// <c>Tab</c>, paste, prior insertion, agent injection or unrecognised chord has touched the
+        /// line since it was reset (the classification is an allow-list, so an unknown key poisons);</item>
+        /// <item>the accumulator is <em>empty</em> - the user has typed nothing since the reset, so
+        /// there is no prefix for the appended text to corrupt;</item>
+        /// <item><see cref="_hasUnechoedInput"/> is clear, checked by the caller before this runs - so
+        /// there are no keystrokes in flight to the shell that the pane has not seen come back. This is
+        /// the condition that closes the "typed a character and hit Enter in the same frame" window,
+        /// and it is the same gate the echo-race fix uses;</item>
+        /// <item>the controller's own gates still apply - a suppressed (pasted) submission and an alt
+        /// screen both refuse upstream of here.</item>
+        /// </list>
+        /// <para>
+        /// If any of them is in doubt the answer is <see langword="null"/> and the planner refuses,
+        /// exactly as before. And the failure mode of the remaining risk is bounded in a way the
+        /// original refusal's was not: insertion sends text to the shell's line editor and stops. The
+        /// user sees the command sitting on their prompt and has to press <c>Enter</c> themselves, so
+        /// the worst case is a visible, editable, deletable line - not a command that ran.
+        /// </para>
+        /// <para>
+        /// One honest cost: "the accumulator is clean and empty" is not the same as "the shell is at a
+        /// prompt". A markless pane running a program that reads stdin (<c>cat</c>, a REPL) satisfies
+        /// every condition, so an accepted row is typed into that program instead. That is what typing
+        /// the command by hand would also have done, and it is visible either way; the alternative -
+        /// refusing forever in every un-instrumented session - is the bug being fixed.
+        /// </para>
+        /// </remarks>
+        private AssistQuerySnapshot? TryReadInsertionQuerySnapshot()
+        {
+            AssistQuerySnapshot? gridTruth = _commandAssistController?.TryReadQuerySnapshot();
+            if (gridTruth.HasValue)
+            {
+                return gridTruth;
+            }
+
+            if (!_marklessSubmission.IsCleanAndEmpty)
+            {
+                return null;
+            }
+
+            // Deliberately constructed rather than read: the cursor is at offset 0 of an empty line,
+            // the entry is not multiline and no right prompt was trimmed, because none of those things
+            // can be true of a line with no characters in it. Going through the planner rather than
+            // sending the text directly keeps one refusal discipline for both paths.
+            return new AssistQuerySnapshot(
+                Text: string.Empty,
+                CursorOffset: 0,
+                IsMultiline: false,
+                RightPromptTrimmed: false);
         }
 
         internal static string DetermineShellKind(string? shellCommand)

--- a/src/NovaTerminal.CommandAssist/Application/AssistKey.cs
+++ b/src/NovaTerminal.CommandAssist/Application/AssistKey.cs
@@ -34,4 +34,16 @@ public enum AssistModifiers
     Alt = 1,
     Control = 2,
     Shift = 4,
+
+    /// <summary>
+    /// The platform command key (Windows/Super/Cmd).
+    /// </summary>
+    /// <remarks>
+    /// Modelled even though no assist shortcut uses it, because the router's accept rule is
+    /// <c>modifiers == None</c> exactly. Dropping <c>Meta</c> at the App boundary made a
+    /// <c>Win+Enter</c> look unmodified to the router while <c>TerminalPane</c>'s own
+    /// <c>modifiers == KeyModifiers.None</c> check saw it for what it was: the router claimed the key,
+    /// the pane declined to act on it, and the hint strip agreed with neither.
+    /// </remarks>
+    Meta = 8,
 }

--- a/src/NovaTerminal.CommandAssist/Application/AssistSessionStateMachine.cs
+++ b/src/NovaTerminal.CommandAssist/Application/AssistSessionStateMachine.cs
@@ -79,6 +79,75 @@ internal sealed class AssistSessionStateMachine
     public bool AllowsSuggestionRefresh => Mode is CommandAssistMode.Suggest or CommandAssistMode.Search;
 
     /// <summary>
+    /// True when the surface on screen is one the user asked for by name, so no placement heuristic
+    /// may hide it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Wider than <see cref="IsExplicitSession"/> on purpose, and the difference is what the two
+    /// questions are for. <see cref="IsExplicitSession"/> asks "may this session draw on history and
+    /// snippets" - a ranking-scope question, so Help and Fix (which rank nothing) are not part of it.
+    /// This asks "did the user ask to see something", which Help and a confident Fix popup plainly
+    /// did.
+    /// </para>
+    /// <para>
+    /// V2 Phase 3a consumers: <c>TerminalPane.ShouldSuppressConservativeRemoteAssist</c>, and the
+    /// opacity half of the placement-correction stack. Both exist to avoid putting an
+    /// <em>uninvited</em> overlay somewhere misleading on a pane whose prompt row is a guess; the
+    /// answer for a surface the user summoned is different, because hiding it entirely is not a
+    /// conservative outcome - it is the feature failing to appear (owner report: assist missing on one
+    /// pane of an SSH split). Note that the correction passes themselves still run for these surfaces:
+    /// what is bypassed is the hiding, not the correcting.
+    /// </para>
+    /// <para>
+    /// <see cref="AssistSessionState.FixHint"/> is deliberately out. It is the bubble-only affordance
+    /// for a diagnosis we are not confident about, i.e. the one Fix state the user did not ask for.
+    /// </para>
+    /// </remarks>
+    public bool IsUserRequestedSurface => State is
+        AssistSessionState.ExplicitBubble or
+        AssistSessionState.ExplicitPopup or
+        AssistSessionState.HistorySearch or
+        AssistSessionState.Help or
+        AssistSessionState.FixPopup;
+
+    /// <summary>
+    /// Whether an unmodified <c>Enter</c> belongs to Command Assist rather than to the shell.
+    /// </summary>
+    /// <param name="isPopupOpen">Whether the row list is on screen.</param>
+    /// <param name="hasSelection">Whether one of those rows is selected.</param>
+    /// <remarks>
+    /// <para>
+    /// <strong>The V2 Phase 3a keyboard change, and the reason it is a state predicate rather than a
+    /// key list.</strong> Accept used to be <c>Ctrl+Enter</c> only, so a user who opened
+    /// <c>Ctrl+R</c>, moved to a row and pressed <c>Enter</c> - which is what every shell's own
+    /// reverse-search teaches - submitted their (empty) command line instead, and the submission reset
+    /// dismissed the popup. Nothing was inserted and the surface vanished: the owner reported it as
+    /// "lists history but does no action when I select".
+    /// </para>
+    /// <para>
+    /// Ownership is therefore granted in exactly the state where <c>Enter</c> cannot mean anything
+    /// else: the row list is open <em>and</em> a row is selected. In Suggest mode that state is only
+    /// reachable by the user having moved the selection (<c>Up</c>/<c>Down</c> or a click - see
+    /// <see cref="OpenPopupForSelection"/>, the only transition that opens a Suggest popup), and in
+    /// Search mode it is reachable only because the user pressed <c>Ctrl+R</c>. Typing never reaches
+    /// it: <see cref="ObserveTypedInput"/> closes the popup, so the ordinary
+    /// type-a-command-and-press-Enter flow is untouched and <c>Enter</c> stays shell-owned there.
+    /// </para>
+    /// <para>
+    /// Help and Fix are excluded even when their popup is open with a row selected. Their rows are
+    /// documentation and diagnoses rather than a command line the user is composing, and a Fix popup
+    /// in particular is on screen <em>after</em> a submission, where the next <c>Enter</c> is much
+    /// more likely to be aimed at the shell. Both keep <c>Ctrl+Enter</c>.
+    /// </para>
+    /// </remarks>
+    public bool AllowsAcceptOnEnter(bool isPopupOpen, bool hasSelection) =>
+        isPopupOpen &&
+        hasSelection &&
+        State != AssistSessionState.Hidden &&
+        Mode is CommandAssistMode.Suggest or CommandAssistMode.Search;
+
+    /// <summary>
     /// Toggles the explicit assist session (the assist shortcut).
     /// </summary>
     /// <param name="isSurfaceVisible">

--- a/src/NovaTerminal.CommandAssist/Application/AssistSessionStateMachine.cs
+++ b/src/NovaTerminal.CommandAssist/Application/AssistSessionStateMachine.cs
@@ -141,6 +141,37 @@ internal sealed class AssistSessionStateMachine
     /// more likely to be aimed at the shell. Both keep <c>Ctrl+Enter</c>.
     /// </para>
     /// </remarks>
+    /// <summary>
+    /// Whether <c>Up</c> belongs to Command Assist rather than to the shell's history recall.
+    /// </summary>
+    /// <param name="isPopupOpen">Whether the row list is on screen.</param>
+    /// <remarks>
+    /// <para>
+    /// <strong>The PR #290 review fix, and the keyboard model it settles.</strong> Phase 3a shipped
+    /// <c>Up</c> and <c>Down</c> both owned whenever any surface was visible, which turned the passive
+    /// typing bubble into a trap: type <c>git st</c>, press <c>Up</c> expecting the shell's history,
+    /// and instead the assist ate the key, <c>MoveSelectionUp</c>'s clamp-to-zero opened the popup, and
+    /// the next <c>Enter</c> inserted a suggestion rather than running the command. Two keys were
+    /// silently redefined by a surface the user never asked for.
+    /// </para>
+    /// <para>
+    /// So the entry into the list is one-directional in the passive states: <c>Down</c> browses
+    /// suggestions (it has no meaning at a shell prompt, so nothing is taken), <c>Up</c> stays the
+    /// shell's history recall. This is what fish and PSReadLine teach. Once the popup is open the user
+    /// is demonstrably in the list and <c>Up</c> navigates it; and in a surface the user summoned by
+    /// name (<c>Ctrl+Space</c>, <c>Ctrl+R</c>, Help, a confident Fix popup - see
+    /// <see cref="IsUserRequestedSurface"/>) both arrows are owned from the first keypress, because
+    /// there the list <em>is</em> what the user asked for.
+    /// </para>
+    /// <para>
+    /// <see cref="AssistSessionState.FixHint"/> falls out on the passive side, which is right: it is
+    /// the one Fix state the user did not ask for, and <c>Down</c> still opens its popup.
+    /// </para>
+    /// </remarks>
+    public bool AllowsSelectionUp(bool isPopupOpen) =>
+        State != AssistSessionState.Hidden &&
+        (isPopupOpen || IsUserRequestedSurface);
+
     public bool AllowsAcceptOnEnter(bool isPopupOpen, bool hasSelection) =>
         isPopupOpen &&
         hasSelection &&

--- a/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
@@ -54,6 +54,7 @@ public sealed class CommandAssistController
     private readonly IErrorInsightService _errorInsightService;
     private readonly CommandAssistModeRouter _modeRouter;
     private readonly CommandAssistResultBuilder _resultBuilder;
+    private readonly Func<bool> _renderedSurfaceProbe;
 
     public CommandAssistController(
         IHistoryStore historyStore,
@@ -66,6 +67,7 @@ public sealed class CommandAssistController
         CommandAssistModeRouter? modeRouter,
         CommandAssistResultBuilder? resultBuilder,
         Func<AssistQuerySnapshot?>? queryProvider = null,
+        Func<bool>? renderedSurfaceProbe = null,
         Action<Action>? dispatch = null)
     {
         HistoryStore = historyStore;
@@ -77,11 +79,18 @@ public sealed class CommandAssistController
         _errorInsightService = errorInsightService ?? new EmptyErrorInsightService();
         _modeRouter = modeRouter ?? new CommandAssistModeRouter();
         _resultBuilder = resultBuilder ?? new CommandAssistResultBuilder();
+
+        // No probe means "there is no host hiding anything", which is the honest answer for a
+        // controller with no view attached (tests, the MCP surface): the only thing that can contradict
+        // the view-model's visibility is a host that renders it, and there is none.
+        _renderedSurfaceProbe = renderedSurfaceProbe ?? (() => true);
         ViewModel = new CommandAssistBarViewModel
         {
             // The hint strip and the key router must agree about what Enter does, so both read the
-            // same predicate rather than each deciding for itself.
-            AcceptOnEnterProbe = () => IsAcceptOnEnterArmed
+            // same predicate rather than each deciding for itself. Same for Up, which the strip used to
+            // advertise unconditionally and the passive bubble no longer owns.
+            AcceptOnEnterProbe = () => IsAcceptOnEnterArmed,
+            SelectionUpOwnedProbe = () => IsSelectionUpOwned
         };
         _dispatch = dispatch ?? (action => action());
         _capturePipeline = new CapturePipeline(historyStore, secretsFilter, _context);
@@ -113,13 +122,56 @@ public sealed class CommandAssistController
     /// "submit the command line". See <see cref="AssistSessionStateMachine.AllowsAcceptOnEnter"/>.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The single source of truth for the V2 Phase 3a keyboard change: the App's key interceptor puts
     /// this into <see cref="AssistKeyState"/>, and the bubble's hint strip renders it. Both are asking
     /// the same question of the same object.
+    /// </para>
+    /// <para>
+    /// <strong>Three terms, and the third is the PR #290 review fix.</strong>
+    /// <see cref="CommandAssistBarViewModel.IsVisible"/> is what the session believes; the host can
+    /// disagree, and on a short markless-SSH pane it does - <c>TerminalPane</c> hides the overlay host
+    /// outright when the conservative anchor check produces no layout, and drops it to zero opacity
+    /// while a placement correction settles. A <c>PassivePopup</c> is not a user-requested surface, so
+    /// neither bypass applies to it, and without this term a passive popup at zero pixels could own the
+    /// user's <c>Enter</c>: nothing on screen, and the command line does not submit.
+    /// <see cref="_renderedSurfaceProbe"/> is the host answering "is any of this actually rendered".
+    /// </para>
     /// </remarks>
     public bool IsAcceptOnEnterArmed =>
         ViewModel.IsVisible &&
+        _renderedSurfaceProbe() &&
         _state.AllowsAcceptOnEnter(ViewModel.IsPopupOpen, GetSelectedSuggestion() != null);
+
+    /// <summary>
+    /// Whether <c>Up</c> currently belongs to Command Assist rather than to the shell's history recall.
+    /// See <see cref="AssistSessionStateMachine.AllowsSelectionUp"/>.
+    /// </summary>
+    /// <remarks>
+    /// Reads the same way <see cref="IsAcceptOnEnterArmed"/> does, for the same reason: the App's key
+    /// interceptor asks this rather than deciding for itself, so there is one implementation of the
+    /// rule. The rendered-surface term is deliberately <em>not</em> repeated here - an <c>Up</c> that
+    /// only moves a selection cannot cost the user a submitted command, and refusing it on an invisible
+    /// surface would hand the shell a history recall in the middle of a browse the user can see coming
+    /// back the moment the correction pass settles.
+    /// </remarks>
+    public bool IsSelectionUpOwned =>
+        ViewModel.IsVisible &&
+        _state.AllowsSelectionUp(ViewModel.IsPopupOpen);
+
+    /// <summary>
+    /// The host's answer to "is the assist overlay actually rendered" changed, so republish everything
+    /// derived from it - the hint strip in particular.
+    /// </summary>
+    /// <remarks>
+    /// Without this the hint strip would lag the routing decision by one view-model change: the probe is
+    /// pulled during <see cref="CommandAssistBarViewModel.SyncPresentationState"/>, which only runs when
+    /// a view-model property is written, and the host's overlay visibility moves on render passes that
+    /// write nothing. The lag is in the safe direction (the strip under-promises), but "the strip and
+    /// the router cannot disagree" is the property this feature was given, so the host says when it
+    /// changed its mind.
+    /// </remarks>
+    public void NotifyRenderedSurfaceVisibilityChanged() => ViewModel.SyncPresentationState();
 
     /// <summary>
     /// Whether the surface on screen is one the user asked for, which no placement heuristic may
@@ -349,18 +401,25 @@ public sealed class CommandAssistController
         return SetSelectedIndex(nextIndex);
     }
 
+    /// <summary>
+    /// Moves the selection up one row. At the top of the list this is a no-op.
+    /// </summary>
+    /// <remarks>
+    /// The clamp used to be <c>SetSelectedIndex(0)</c>, which is not a no-op: it opens the popup and
+    /// arms <c>Enter</c> as side effects (see <see cref="SetSelectedIndex"/>). Combined with <c>Up</c>
+    /// being assist-owned in the passive states, that is the PR #290 review's second blocker - the key
+    /// the user pressed to reach their shell history built the surface that then ate their <c>Enter</c>.
+    /// <c>Up</c> is no longer routed here in those states, and this no longer creates a browse state
+    /// out of nothing even when it is.
+    /// </remarks>
     public bool MoveSelectionUp()
     {
-        if (_suggestions.Count == 0)
+        if (_suggestions.Count == 0 || ViewModel.SelectedIndex <= 0)
         {
             return false;
         }
 
-        int nextIndex = ViewModel.SelectedIndex <= 0
-            ? 0
-            : ViewModel.SelectedIndex - 1;
-
-        return SetSelectedIndex(nextIndex);
+        return SetSelectedIndex(ViewModel.SelectedIndex - 1);
     }
 
     /// <summary>
@@ -373,14 +432,6 @@ public sealed class CommandAssistController
     /// frame after the list shrank resolves.
     /// </returns>
     public bool TrySelectSuggestionAt(int index) => SetSelectedIndex(index);
-
-    /// <summary>
-    /// Whether <paramref name="index"/> is the row already selected - the "clicking the highlighted
-    /// row accepts it" test, which the view uses so a second single click does what a double click
-    /// does.
-    /// </summary>
-    public bool IsSuggestionSelectedAt(int index) =>
-        index >= 0 && index < _suggestions.Count && ViewModel.SelectedIndex == index;
 
     public bool TryGetInsertionText(out string? insertionText)
     {

--- a/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
@@ -77,7 +77,12 @@ public sealed class CommandAssistController
         _errorInsightService = errorInsightService ?? new EmptyErrorInsightService();
         _modeRouter = modeRouter ?? new CommandAssistModeRouter();
         _resultBuilder = resultBuilder ?? new CommandAssistResultBuilder();
-        ViewModel = new CommandAssistBarViewModel();
+        ViewModel = new CommandAssistBarViewModel
+        {
+            // The hint strip and the key router must agree about what Enter does, so both read the
+            // same predicate rather than each deciding for itself.
+            AcceptOnEnterProbe = () => IsAcceptOnEnterArmed
+        };
         _dispatch = dispatch ?? (action => action());
         _capturePipeline = new CapturePipeline(historyStore, secretsFilter, _context);
         _suggestionOrchestrator = new SuggestionOrchestrator(
@@ -102,6 +107,25 @@ public sealed class CommandAssistController
 
     /// <summary>What the session is doing right now. Exposed for diagnostics and tests.</summary>
     internal AssistSessionState SessionState => _state.State;
+
+    /// <summary>
+    /// Whether an unmodified <c>Enter</c> currently means "insert the selected row" rather than
+    /// "submit the command line". See <see cref="AssistSessionStateMachine.AllowsAcceptOnEnter"/>.
+    /// </summary>
+    /// <remarks>
+    /// The single source of truth for the V2 Phase 3a keyboard change: the App's key interceptor puts
+    /// this into <see cref="AssistKeyState"/>, and the bubble's hint strip renders it. Both are asking
+    /// the same question of the same object.
+    /// </remarks>
+    public bool IsAcceptOnEnterArmed =>
+        ViewModel.IsVisible &&
+        _state.AllowsAcceptOnEnter(ViewModel.IsPopupOpen, GetSelectedSuggestion() != null);
+
+    /// <summary>
+    /// Whether the surface on screen is one the user asked for, which no placement heuristic may
+    /// hide. See <see cref="AssistSessionStateMachine.IsUserRequestedSurface"/>.
+    /// </summary>
+    public bool IsUserRequestedSurface => ViewModel.IsVisible && _state.IsUserRequestedSurface;
 
     public void ToggleAssist()
     {
@@ -338,6 +362,25 @@ public sealed class CommandAssistController
 
         return SetSelectedIndex(nextIndex);
     }
+
+    /// <summary>
+    /// Selects a row by index because the user pointed at it. Opens the popup the same way
+    /// <c>Up</c>/<c>Down</c> do, so a click and an arrow key leave the session in the same state -
+    /// including the state that arms <c>Enter</c>.
+    /// </summary>
+    /// <returns>
+    /// <see langword="false"/> for an index no row occupies, which is how a click that arrives one
+    /// frame after the list shrank resolves.
+    /// </returns>
+    public bool TrySelectSuggestionAt(int index) => SetSelectedIndex(index);
+
+    /// <summary>
+    /// Whether <paramref name="index"/> is the row already selected - the "clicking the highlighted
+    /// row accepts it" test, which the view uses so a second single click does what a double click
+    /// does.
+    /// </summary>
+    public bool IsSuggestionSelectedAt(int index) =>
+        index >= 0 && index < _suggestions.Count && ViewModel.SelectedIndex == index;
 
     public bool TryGetInsertionText(out string? insertionText)
     {
@@ -659,7 +702,10 @@ public sealed class CommandAssistController
             ViewModel.IsPopupOpen = true;
         }
 
-        SyncSuggestionViewModel();
+        // Selection only. Rebuilding the row list here (which is what this used to do) replaces every
+        // container under the pointer, so hover died on each arrow key and the scroll position jumped
+        // back to the top - see CommandAssistSuggestionItemViewModel.
+        SyncSelectionState();
         return true;
     }
 
@@ -670,7 +716,34 @@ public sealed class CommandAssistController
             : null;
     }
 
+    /// <summary>
+    /// Rebuilds the row list from <see cref="_suggestions"/>. Call only when the rows themselves
+    /// changed; <see cref="SyncSelectionState"/> covers a selection move.
+    /// </summary>
     private void SyncSuggestionViewModel()
+    {
+        ViewModel.Suggestions.Clear();
+
+        for (int i = 0; i < _suggestions.Count; i++)
+        {
+            AssistSuggestion suggestion = _suggestions[i];
+            ViewModel.Suggestions.Add(new CommandAssistSuggestionItemViewModel(
+                displayText: suggestion.DisplayText,
+                descriptionText: suggestion.Description ?? string.Empty,
+                badgesText: string.Join("  ", suggestion.Badges),
+                metadataText: BuildMetadataText(suggestion),
+                isSelected: i == ViewModel.SelectedIndex,
+                type: suggestion.Type));
+        }
+
+        SyncSelectionState();
+    }
+
+    /// <summary>
+    /// Republishes everything that depends on <em>which</em> row is selected, mutating the existing
+    /// rows rather than replacing them.
+    /// </summary>
+    private void SyncSelectionState()
     {
         AssistSuggestion? selected = GetSelectedSuggestion();
         ViewModel.TopSuggestionText = selected?.DisplayText ?? string.Empty;
@@ -678,19 +751,10 @@ public sealed class CommandAssistController
         ViewModel.SelectedMetadataText = selected == null ? string.Empty : BuildMetadataText(selected);
         ViewModel.SelectedDescriptionText = selected?.Description ?? string.Empty;
         ViewModel.HasSuggestions = _suggestions.Count > 0;
-        ViewModel.Suggestions.Clear();
 
-        for (int i = 0; i < _suggestions.Count; i++)
+        for (int i = 0; i < ViewModel.Suggestions.Count; i++)
         {
-            AssistSuggestion suggestion = _suggestions[i];
-            ViewModel.Suggestions.Add(new CommandAssistSuggestionItemViewModel(
-                SelectionGlyph: i == ViewModel.SelectedIndex ? ">" : " ",
-                DisplayText: suggestion.DisplayText,
-                DescriptionText: suggestion.Description ?? string.Empty,
-                BadgesText: string.Join("  ", suggestion.Badges),
-                MetadataText: BuildMetadataText(suggestion),
-                IsSelected: i == ViewModel.SelectedIndex,
-                Type: suggestion.Type));
+            ViewModel.Suggestions[i].IsSelected = i == ViewModel.SelectedIndex;
         }
     }
 

--- a/src/NovaTerminal.CommandAssist/Application/CommandAssistKeyRouter.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CommandAssistKeyRouter.cs
@@ -13,13 +13,23 @@ namespace NovaTerminal.CommandAssist.Application;
 /// <param name="IsAcceptOnEnterArmed">
 /// Whether the session is in the browse state that makes an unmodified <c>Enter</c> mean "insert the
 /// selected row" - see <see cref="AssistSessionStateMachine.AllowsAcceptOnEnter"/>, which is where
-/// the rule lives. The router takes the answer rather than recomputing it: the state machine and the
-/// view-model between them know whether the popup is open and whether a row is selected, and a second
-/// implementation of that rule is a second thing to keep in sync.
+/// the rule lives, and <see cref="CommandAssistController.IsAcceptOnEnterArmed"/>, which adds the two
+/// facts the state machine cannot see: that the view-model is visible, and that the host's overlay is
+/// actually rendered. The router takes the answer rather than recomputing it: the state machine, the
+/// view-model and the host between them know whether the popup is open, whether a row is selected and
+/// whether any of it is on screen, and a second implementation of that rule is a second thing to keep
+/// in sync.
+/// </param>
+/// <param name="IsSelectionUpOwned">
+/// Whether <c>Up</c> belongs to Command Assist rather than to the shell's history recall - see
+/// <see cref="AssistSessionStateMachine.AllowsSelectionUp"/>. <c>Down</c> needs no equivalent: it is
+/// assist-owned whenever a surface is visible, because "browse the suggestions" is the only thing it
+/// can mean at a prompt.
 /// </param>
 public readonly record struct AssistKeyState(
     bool IsSurfaceVisible,
-    bool IsAcceptOnEnterArmed);
+    bool IsAcceptOnEnterArmed,
+    bool IsSelectionUpOwned);
 
 /// <summary>
 /// Decides whether a keystroke belongs to Command Assist or should fall through to the terminal.
@@ -52,8 +62,18 @@ public static class CommandAssistKeyRouter
             return state.IsAcceptOnEnterArmed;
         }
 
+        // Up is asymmetric with Down, and deliberately (PR #290 review). At a prompt with only a
+        // passive bubble up, Up means "recall my last command" in every shell the user has ever used,
+        // and taking it broke that: the assist consumed the key, opened its popup on the way through,
+        // and the Enter that followed inserted a suggestion instead of submitting. Down is the
+        // one-directional way into the list - it has no shell meaning at a prompt - and once the popup
+        // is open, or the user summoned the surface by name, Up navigates as it always did.
+        if (key == AssistKey.Up)
+        {
+            return state.IsSelectionUpOwned;
+        }
+
         return key == AssistKey.Escape ||
-               key == AssistKey.Up ||
                key == AssistKey.Down ||
                (isCtrl && !isShift && !isAlt && key == AssistKey.Enter) ||
                (isCtrl && isShift && key == AssistKey.P);

--- a/src/NovaTerminal.CommandAssist/Application/CommandAssistKeyRouter.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CommandAssistKeyRouter.cs
@@ -1,19 +1,40 @@
 namespace NovaTerminal.CommandAssist.Application;
 
 /// <summary>
+/// What the assist surface is doing, reduced to the two facts key routing branches on.
+/// </summary>
+/// <remarks>
+/// Passed as one value rather than as two bools so that adding a third fact does not silently change
+/// the meaning of an existing call site's positional arguments - the router is consulted from the
+/// App's key interceptor, which is the hottest path in the feature and the one place a wrong default
+/// would be least visible.
+/// </remarks>
+/// <param name="IsSurfaceVisible">Whether any assist surface is on screen.</param>
+/// <param name="IsAcceptOnEnterArmed">
+/// Whether the session is in the browse state that makes an unmodified <c>Enter</c> mean "insert the
+/// selected row" - see <see cref="AssistSessionStateMachine.AllowsAcceptOnEnter"/>, which is where
+/// the rule lives. The router takes the answer rather than recomputing it: the state machine and the
+/// view-model between them know whether the popup is open and whether a row is selected, and a second
+/// implementation of that rule is a second thing to keep in sync.
+/// </param>
+public readonly record struct AssistKeyState(
+    bool IsSurfaceVisible,
+    bool IsAcceptOnEnterArmed);
+
+/// <summary>
 /// Decides whether a keystroke belongs to Command Assist or should fall through to the terminal.
 /// </summary>
 /// <remarks>
 /// Public because the App's <c>TerminalPane</c> consults it on every key press. It is a pure
-/// static predicate over public types (<see cref="AssistKey"/>, <see cref="AssistModifiers"/>),
-/// so exposing it costs nothing and lets this assembly avoid granting the App
-/// <c>InternalsVisibleTo</c>.
+/// static predicate over public types (<see cref="AssistKey"/>, <see cref="AssistModifiers"/>,
+/// <see cref="AssistKeyState"/>), so exposing it costs nothing and lets this assembly avoid granting
+/// the App <c>InternalsVisibleTo</c>.
 /// </remarks>
 public static class CommandAssistKeyRouter
 {
-    public static bool IsAssistOwnedKey(bool isAssistVisible, AssistKey key, AssistModifiers modifiers)
+    public static bool IsAssistOwnedKey(AssistKeyState state, AssistKey key, AssistModifiers modifiers)
     {
-        if (!isAssistVisible)
+        if (!state.IsSurfaceVisible)
         {
             return false;
         }
@@ -21,6 +42,15 @@ public static class CommandAssistKeyRouter
         bool isCtrl = (modifiers & AssistModifiers.Control) != 0;
         bool isShift = (modifiers & AssistModifiers.Shift) != 0;
         bool isAlt = (modifiers & AssistModifiers.Alt) != 0;
+
+        // Unmodified Enter, and only while browsing (V2 Phase 3a). "Unmodified" is exact rather than
+        // "no Alt": a modified Enter is encoded as CSI u under the kitty disambiguate tier and means
+        // something to the shell's line editor, and Shift+Enter in particular is a newline in several
+        // of them. Ctrl+Enter keeps its own clause below and works in every state, browse or not.
+        if (key == AssistKey.Enter && modifiers == AssistModifiers.None)
+        {
+            return state.IsAcceptOnEnterArmed;
+        }
 
         return key == AssistKey.Escape ||
                key == AssistKey.Up ||

--- a/src/NovaTerminal.CommandAssist/Application/SuggestionOrchestrator.cs
+++ b/src/NovaTerminal.CommandAssist/Application/SuggestionOrchestrator.cs
@@ -45,22 +45,44 @@ namespace NovaTerminal.CommandAssist.Application;
 /// </remarks>
 internal sealed class SuggestionOrchestrator
 {
-    /// <summary>Rows the popup/bubble shows. M4.2's hard-coded cap; Phase 3 replaces it with scrolling.</summary>
-    public const int MaxDisplayedSuggestions = 5;
-
     /// <summary>
-    /// How many history candidates the ranking engine gets to choose from for a text query.
+    /// Rows the popup renders.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// M4.2 shipped this at 5 because the popup was a fixed-height list with no way to reach a sixth
+    /// row. V2 Phase 3a gave it a <c>ScrollViewer</c>, so the cap is now about how much ranked history
+    /// is worth holding rather than about how much fits: 50 is a scrollable list a user will page
+    /// through and abandon, not a screenful.
+    /// </para>
+    /// <para>
+    /// The bubble still shows one row, so this cap costs nothing when the popup is closed.
+    /// </para>
+    /// </remarks>
+    public const int MaxDisplayedSuggestions = 50;
+
+    /// <summary>
+    /// How many history candidates the ranking engine gets to choose from.
+    /// </summary>
+    /// <remarks>
+    /// <para>
     /// Wider than <see cref="MaxDisplayedSuggestions"/> on purpose. The store used to pre-rank with
     /// its own scoring function and hand back its own top five, so the engine only ever re-ordered
     /// a set the store had already picked. Now the store is a recall gate that truncates by
     /// recency, so it has to hand over enough rows for the engine's cwd / shell / profile / exit-code
     /// signals to matter - otherwise a relevant-but-older command could never reach the list.
-    /// Empty-query recall stays at the display cap: with no text to score, "most recent five" is
-    /// already the answer, and widening it would let the frequency signal outrank recency.
+    /// </para>
+    /// <para>
+    /// <strong>V2 Phase 3a: the empty-query path uses the same pool.</strong> It used to recall only
+    /// <see cref="MaxDisplayedSuggestions"/> entries, on the argument that "most recent five" is
+    /// already the answer when there is no text to score. That argument dies with context scoping: if
+    /// the store hands over five rows, all of them from whichever session ran most recently, no amount
+    /// of ranking can put *this* host's commands first - the host's commands were never in the set.
+    /// The owner's "the list shows commands from all sessions indiscriminately" is that truncation as
+    /// much as it is the absence of a ranking rule.
+    /// </para>
     /// </remarks>
-    private const int HistoryCandidatePoolSize = 50;
+    private const int HistoryCandidatePoolSize = 200;
 
     private readonly IHistoryStore _historyStore;
     private readonly ISnippetStore? _snippetStore;
@@ -186,13 +208,14 @@ internal sealed class SuggestionOrchestrator
                     _context.IsRemote,
                     IncludeHistorySuggestions: scope.IncludeHistory,
                     IncludeSnippetSuggestions: scope.IncludeSnippets,
-                    IncludePathSuggestions: scope.IncludePaths);
+                    IncludePathSuggestions: scope.IncludePaths,
+                    HostId: _context.HostId);
 
                 IReadOnlyList<CommandHistoryEntry> history = Array.Empty<CommandHistoryEntry>();
                 if (queryContext.IncludeHistorySuggestions)
                 {
                     history = string.IsNullOrWhiteSpace(query)
-                        ? await _historyStore.GetRecentAsync(MaxDisplayedSuggestions).ConfigureAwait(false)
+                        ? await _historyStore.GetRecentAsync(HistoryCandidatePoolSize).ConfigureAwait(false)
                         : await _historyStore.SearchAsync(query, HistoryCandidatePoolSize).ConfigureAwait(false);
                 }
 

--- a/src/NovaTerminal.CommandAssist/Domain/CommandAssistSuggestionEngine.cs
+++ b/src/NovaTerminal.CommandAssist/Domain/CommandAssistSuggestionEngine.cs
@@ -34,6 +34,37 @@ public sealed class CommandAssistSuggestionEngine : ISuggestionEngine
     internal const double EmptyQueryProfileMatchBoost = 200;
 
     /// <summary>
+    /// What an <em>unpinned</em> snippet is worth on the empty-query path.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>The PR #290 review's third blocker, decided explicitly.</strong> V2 Phase 3a gave
+    /// same-context history a partitioning boost of <see cref="EmptyQueryContextMatchBoost"/>, which
+    /// left an unpinned snippet scoring about 10 against every local history entry's 1001 - below
+    /// commands the user ran once and never thought about again. A snippet is user-authored text someone
+    /// deliberately saved; ranking it under ambient history is the wrong answer even if it is not the
+    /// worst one. The dead <c>+8 discoverability</c> nudge that was supposed to prevent this is gone
+    /// with this constant replacing it.
+    /// </para>
+    /// <para>
+    /// The band chosen is the same-profile one (deliberately the same number as
+    /// <see cref="EmptyQueryProfileMatchBoost"/>, not a coincidence): <em>above</em> cross-context
+    /// history, <em>below</em> the commands this very host ran. A snippet carries no host and no
+    /// profile, so it cannot claim to be from "here"; what it can claim is that a human wrote it down
+    /// on purpose, which is worth more than another machine's recency. A pinned snippet is unaffected -
+    /// pinning already satisfies both affinity terms below, which puts it in the top band, which is the
+    /// whole point of pinning.
+    /// </para>
+    /// <para>
+    /// The honest cost: with more same-context history entries than the display cap, an unpinned snippet
+    /// is below the fold. Pinning is the answer to that and is one keystroke
+    /// (<c>Ctrl+Shift+P</c>); hoisting every snippet above this host's own history would make the
+    /// empty-query list say "snippets first" for users who never asked for that.
+    /// </para>
+    /// </remarks>
+    internal const double EmptyQueryUnpinnedSnippetBandBoost = EmptyQueryProfileMatchBoost;
+
+    /// <summary>
     /// What a same-context history entry is worth once the user has typed something.
     /// </summary>
     /// <remarks>
@@ -175,14 +206,22 @@ public sealed class CommandAssistSuggestionEngine : ISuggestionEngine
                     // satisfy (a snippet carries no host and no profile). Without this, V2 Phase 3a's
                     // context boost would have silently demoted pinned snippets out of the top of an
                     // empty-query list, which is the one place users put things to find them.
-                    // An unpinned snippet is just a suggestion and ranks like one.
+                    // An unpinned snippet gets the empty-query band below instead.
+                    //
+                    // Side effect worth naming (PR #290 review): on the *text*-query path these two
+                    // flags are also what a pinned snippet's profileScore (20) and contextScore (30) are
+                    // computed from, so pinning is worth +50 there on top of its own pinScore (40) - a
+                    // pinned snippet outranks an equally-matching history entry by 90 rather than 40.
+                    // Deliberate: the boosts are affinity terms and a pinned snippet is in scope
+                    // everywhere by definition. Documented rather than tuned, because the text-query
+                    // tiers (prefix 120, token 70, contains 25) still dominate, so what the user typed
+                    // still decides the order.
                     isContextMatch: snippet.IsPinned,
                     isProfileMatch: snippet.IsPinned);
 
-                // Snippets should remain discoverable even with empty query.
-                if (string.IsNullOrWhiteSpace(query))
+                if (string.IsNullOrWhiteSpace(query) && !snippet.IsPinned)
                 {
-                    score += 8;
+                    score += EmptyQueryUnpinnedSnippetBandBoost;
                 }
 
                 return new

--- a/src/NovaTerminal.CommandAssist/Domain/CommandAssistSuggestionEngine.cs
+++ b/src/NovaTerminal.CommandAssist/Domain/CommandAssistSuggestionEngine.cs
@@ -7,6 +7,44 @@ namespace NovaTerminal.CommandAssist.Domain;
 
 public sealed class CommandAssistSuggestionEngine : ISuggestionEngine
 {
+    /// <summary>
+    /// What a same-context history entry is worth on the empty-query (<c>Ctrl+R</c>) path.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Large enough to <em>partition</em> rather than nudge: every other empty-query term together
+    /// tops out around 30 (recency is a tiebreak, not a score, and frequency is capped at 5), so this
+    /// puts every entry from the current host - or every local entry, on a local pane - above every
+    /// entry that is not, and orders within each band by the usual recency/frequency rules.
+    /// </para>
+    /// <para>
+    /// <strong>Partitioning, not filtering.</strong> The owner's report was that <c>Ctrl+R</c> "shows
+    /// commands from all sessions/tabs indiscriminately", and the fix is deliberately an ordering one:
+    /// a command run on another host is still in the list, below the fold, because reaching for a
+    /// command you remember running somewhere else is the reason a shared history exists. Hiding it
+    /// would trade one complaint for a worse one.
+    /// </para>
+    /// </remarks>
+    internal const double EmptyQueryContextMatchBoost = 1000;
+
+    /// <summary>
+    /// What a same-profile history entry is worth on the empty-query path: a secondary sort within
+    /// each context band, not a band of its own.
+    /// </summary>
+    internal const double EmptyQueryProfileMatchBoost = 200;
+
+    /// <summary>
+    /// What a same-context history entry is worth once the user has typed something.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately a nudge here rather than a partition. With a query on the line the user has said
+    /// what they are looking for, and the text-match terms (prefix 120, token prefix 70, contains 25)
+    /// are the better signal; a partition would rank a same-host subsequence match above a local
+    /// prefix match, which reads as the list ignoring what was typed. Sized to sit between the
+    /// existing cwd (12) and profile (20) signals and a text-match tier.
+    /// </remarks>
+    internal const double TextQueryContextMatchBoost = 30;
+
     private readonly IPathSuggestionProvider _pathSuggestionProvider;
 
     public CommandAssistSuggestionEngine(IPathSuggestionProvider? pathSuggestionProvider = null)
@@ -85,11 +123,12 @@ public sealed class CommandAssistSuggestionEngine : ISuggestionEngine
                     query,
                     latest.WorkingDirectory,
                     latest.ShellKind,
-                    latest.ProfileId,
                     latest.ExitCode,
                     context,
                     frequency,
-                    isPinned: false);
+                    isPinned: false,
+                    isContextMatch: IsSameSessionContext(latest, context),
+                    isProfileMatch: Matches(context.ProfileId, latest.ProfileId));
 
                 return new
                 {
@@ -125,11 +164,20 @@ public sealed class CommandAssistSuggestionEngine : ISuggestionEngine
                     query,
                     snippet.WorkingDirectory,
                     snippet.ShellKind,
-                    profileId: null,
                     exitCode: 0,
                     context,
                     frequency: 1,
-                    isPinned: snippet.IsPinned);
+                    isPinned: snippet.IsPinned,
+
+                    // A pinned snippet is in scope for every session by definition - that is what
+                    // pinning means - so it satisfies both affinity terms rather than being pushed
+                    // below every same-host history entry by a scoping rule it has no fields to
+                    // satisfy (a snippet carries no host and no profile). Without this, V2 Phase 3a's
+                    // context boost would have silently demoted pinned snippets out of the top of an
+                    // empty-query list, which is the one place users put things to find them.
+                    // An unpinned snippet is just a suggestion and ranks like one.
+                    isContextMatch: snippet.IsPinned,
+                    isProfileMatch: snippet.IsPinned);
 
                 // Snippets should remain discoverable even with empty query.
                 if (string.IsNullOrWhiteSpace(query))
@@ -162,11 +210,12 @@ public sealed class CommandAssistSuggestionEngine : ISuggestionEngine
         string query,
         string? workingDirectory,
         string? shellKind,
-        string? profileId,
         int? exitCode,
         CommandAssistQueryContext context,
         int frequency,
-        bool isPinned)
+        bool isPinned,
+        bool isContextMatch,
+        bool isProfileMatch)
     {
         if (string.IsNullOrWhiteSpace(text))
         {
@@ -175,7 +224,14 @@ public sealed class CommandAssistSuggestionEngine : ISuggestionEngine
 
         if (string.IsNullOrWhiteSpace(query))
         {
-            return 1 + Math.Min(frequency, 5) + (isPinned ? 20 : 0);
+            // The empty-query (Ctrl+R) path. Recency is the tiebreak rather than a term here - see the
+            // ThenByDescending in GetSuggestions - so the context boosts are the only thing large
+            // enough to reorder the list, which is exactly what V2 Phase 3a wants them to do.
+            return 1 +
+                   Math.Min(frequency, 5) +
+                   (isPinned ? 20 : 0) +
+                   (isContextMatch ? EmptyQueryContextMatchBoost : 0) +
+                   (isProfileMatch ? EmptyQueryProfileMatchBoost : 0);
         }
 
         string normalizedText = text.Trim();
@@ -200,11 +256,40 @@ public sealed class CommandAssistSuggestionEngine : ISuggestionEngine
         double frequencyScore = frequency * 4;
         double cwdScore = Matches(context.WorkingDirectory, workingDirectory) ? 12 : 0;
         double shellScore = Matches(context.ShellKind, shellKind) ? 4 : 0;
-        double profileScore = Matches(context.ProfileId, profileId) ? 20 : 0;
+        double profileScore = isProfileMatch ? 20 : 0;
+        double contextScore = isContextMatch ? TextQueryContextMatchBoost : 0;
         double successScore = exitCode == 0 ? 18 : exitCode.HasValue ? -8 : 0;
         double pinScore = isPinned ? 40 : 0;
 
-        return textMatchScore + frequencyScore + cwdScore + shellScore + profileScore + successScore + pinScore;
+        return textMatchScore + frequencyScore + cwdScore + shellScore + profileScore + contextScore + successScore + pinScore;
+    }
+
+    /// <summary>
+    /// Whether a history entry came from the same place the current pane is.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Two cases, and the asymmetry is deliberate. On a remote pane, "here" means <em>this host</em>:
+    /// the commands that make sense are the ones that ran on the box, and a host id is the only thing
+    /// that identifies it across sessions, tabs and reconnects (a session id would scope the list to
+    /// this tab, which is what a shell's own per-session history already does badly). On a local pane,
+    /// "here" means "not on somebody else's machine" - there is no local host id to compare, and
+    /// `ubuntu.example`'s `apt install` has no business at the top of a Windows prompt.
+    /// </para>
+    /// <para>
+    /// A remote pane with no host id (an SSH profile with the host still unresolved) matches nothing
+    /// rather than matching everything: an unknown context is not a context, and the fallback is the
+    /// pre-Phase-3a pure-recency order, which is merely unhelpful rather than wrong.
+    /// </para>
+    /// </remarks>
+    private static bool IsSameSessionContext(CommandHistoryEntry entry, CommandAssistQueryContext context)
+    {
+        if (!context.IsRemote)
+        {
+            return !entry.IsRemote;
+        }
+
+        return entry.IsRemote && Matches(context.HostId, entry.HostId);
     }
 
     private static IReadOnlyList<string> BuildHistoryBadges(CommandHistoryEntry entry, CommandAssistQueryContext context, int frequency)

--- a/src/NovaTerminal.CommandAssist/Models/CommandAssistQueryContext.cs
+++ b/src/NovaTerminal.CommandAssist/Models/CommandAssistQueryContext.cs
@@ -1,5 +1,12 @@
 namespace NovaTerminal.CommandAssist.Models;
 
+/// <param name="HostId">
+/// The remote host this pane is connected to, or <see langword="null"/> for a local pane. Together
+/// with <paramref name="IsRemote"/> it is what makes a history entry "from here": V2 Phase 3a ranks
+/// entries that share the current pane's host (or its localness) above the rest, which is the fix for
+/// the owner's report that <c>Ctrl+R</c> mixed every session's commands together. Declared last so
+/// that adding it could not silently re-bind an existing positional call site.
+/// </param>
 public sealed record CommandAssistQueryContext(
     string Input,
     string? WorkingDirectory,
@@ -8,4 +15,5 @@ public sealed record CommandAssistQueryContext(
     bool IsRemote = false,
     bool IncludeHistorySuggestions = true,
     bool IncludeSnippetSuggestions = true,
-    bool IncludePathSuggestions = true);
+    bool IncludePathSuggestions = true,
+    string? HostId = null);

--- a/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistBarViewModel.cs
+++ b/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistBarViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel;
 using System.Collections.ObjectModel;
 using System.Runtime.CompilerServices;
@@ -6,6 +7,15 @@ namespace NovaTerminal.CommandAssist.ViewModels;
 
 public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
 {
+    /// <summary>Shown while a row is selected in an open popup, where <c>Enter</c> inserts it.</summary>
+    internal const string BrowseHintText = "Enter insert  |  Up/Down browse  |  Esc close";
+
+    /// <summary>
+    /// Shown everywhere else. <c>Enter</c> is the shell's in this state, so the hint must not promise
+    /// it: a hint strip that advertises a key the surface does not own is worse than no hint strip.
+    /// </summary>
+    internal const string IdleHintText = "Up/Down browse  |  Ctrl+Enter insert  |  Esc close";
+
     private bool _isVisible;
     private string _modeLabel = "Suggest";
     private string _queryText = string.Empty;
@@ -29,6 +39,25 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
     public ObservableCollection<CommandAssistSuggestionItemViewModel> Suggestions { get; } = new();
     public CommandAssistBubbleViewModel Bubble { get; }
     public CommandAssistPopupViewModel Popup { get; }
+
+    /// <summary>
+    /// Answers "does an unmodified <c>Enter</c> insert the selected row right now". Installed by
+    /// <c>CommandAssistController</c>, which owns the state machine that decides it.
+    /// </summary>
+    /// <remarks>
+    /// A probe rather than a settable bool, and that is the whole point. The hint strip has to be
+    /// right in every state the surface can be in, and there are a dozen places in the controller
+    /// that change one of the inputs (visibility, popup, mode, selection). A pushed bool would need
+    /// updating at all of them and would be wrong at whichever one was forgotten; pulling the answer
+    /// during <see cref="SyncPresentationState"/> - which already runs on every one of those changes -
+    /// keeps one implementation of the rule, in the state machine, and no synchronization to get
+    /// wrong. Null (no controller) reads as "not armed", which is what a bare view-model in a test or
+    /// a designer should say.
+    /// </remarks>
+    internal Func<bool>? AcceptOnEnterProbe { get; set; }
+
+    /// <summary>Whether the hint strip is currently promising <c>Enter</c>. Presentation state, so it follows the probe.</summary>
+    public bool IsAcceptOnEnterArmed { get; private set; }
 
     public bool IsVisible
     {
@@ -106,6 +135,11 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
 
             _selectedIndex = value;
             OnPropertyChanged();
+
+            // Selection is an input to the hint strip and to the popup's scroll-into-view, so it has
+            // to publish like every other presentation fact. It did not before, because nothing
+            // downstream cared which row was selected.
+            SyncPresentationState();
         }
     }
 
@@ -223,15 +257,31 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
-    private void SyncPresentationState()
+    /// <summary>
+    /// Recomputes the derived surface state. Called from every setter that feeds it, which is why the
+    /// hint strip cannot drift out of step with the keyboard model.
+    /// </summary>
+    internal void SyncPresentationState()
     {
+        bool acceptOnEnterArmed = AcceptOnEnterProbe?.Invoke() ?? false;
+        if (acceptOnEnterArmed != IsAcceptOnEnterArmed)
+        {
+            IsAcceptOnEnterArmed = acceptOnEnterArmed;
+            OnPropertyChanged(nameof(IsAcceptOnEnterArmed));
+        }
+
+        string hintText = acceptOnEnterArmed ? BrowseHintText : IdleHintText;
+
         Bubble.IsVisible = IsVisible;
         Bubble.ModeLabel = ModeLabel;
         Bubble.QueryText = QueryText;
+        Bubble.ShortcutHintText = hintText;
         Bubble.SummaryText = !string.IsNullOrWhiteSpace(TopSuggestionText)
             ? TopSuggestionText
             : EmptyStateText;
 
+        Popup.ShortcutHintText = hintText;
+        Popup.SelectedIndex = SelectedIndex;
         Popup.IsVisible = IsVisible && IsPopupOpen;
         Popup.ModeLabel = ModeLabel;
         Popup.QueryText = QueryText;

--- a/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistBarViewModel.cs
+++ b/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistBarViewModel.cs
@@ -11,10 +11,22 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
     internal const string BrowseHintText = "Enter insert  |  Up/Down browse  |  Esc close";
 
     /// <summary>
-    /// Shown everywhere else. <c>Enter</c> is the shell's in this state, so the hint must not promise
-    /// it: a hint strip that advertises a key the surface does not own is worse than no hint strip.
+    /// Shown on a surface the user summoned that is not (yet) browsing a row. <c>Enter</c> is the
+    /// shell's in this state, so the hint must not promise it: a hint strip that advertises a key the
+    /// surface does not own is worse than no hint strip.
     /// </summary>
     internal const string IdleHintText = "Up/Down browse  |  Ctrl+Enter insert  |  Esc close";
+
+    /// <summary>
+    /// Shown on the passive typing bubble, where <c>Up</c> is the shell's history recall and only
+    /// <c>Down</c> opens the list.
+    /// </summary>
+    /// <remarks>
+    /// The same rule as <see cref="IdleHintText"/> applied to the key the PR #290 review gave back to
+    /// the shell. Promising "Up/Down browse" on a surface that owns exactly one of them is the bug this
+    /// constant exists to avoid, and it is the strip's whole job to be believable.
+    /// </remarks>
+    internal const string PassiveHintText = "Down browse  |  Ctrl+Enter insert  |  Esc close";
 
     private bool _isVisible;
     private string _modeLabel = "Suggest";
@@ -55,6 +67,17 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
     /// a designer should say.
     /// </remarks>
     internal Func<bool>? AcceptOnEnterProbe { get; set; }
+
+    /// <summary>
+    /// Answers "does <c>Up</c> belong to Command Assist right now". Installed by
+    /// <c>CommandAssistController</c> alongside <see cref="AcceptOnEnterProbe"/>, for the same reason
+    /// and read at the same moment.
+    /// </summary>
+    /// <remarks>
+    /// Null reads as "owned", which keeps a bare view-model - a designer, a test that builds one
+    /// directly - on the fuller hint rather than inventing a passive state it is not in.
+    /// </remarks>
+    internal Func<bool>? SelectionUpOwnedProbe { get; set; }
 
     /// <summary>Whether the hint strip is currently promising <c>Enter</c>. Presentation state, so it follows the probe.</summary>
     public bool IsAcceptOnEnterArmed { get; private set; }
@@ -270,7 +293,12 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
             OnPropertyChanged(nameof(IsAcceptOnEnterArmed));
         }
 
-        string hintText = acceptOnEnterArmed ? BrowseHintText : IdleHintText;
+        bool isSelectionUpOwned = SelectionUpOwnedProbe?.Invoke() ?? true;
+        string hintText = acceptOnEnterArmed
+            ? BrowseHintText
+            : isSelectionUpOwned
+                ? IdleHintText
+                : PassiveHintText;
 
         Bubble.IsVisible = IsVisible;
         Bubble.ModeLabel = ModeLabel;

--- a/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistBubbleViewModel.cs
+++ b/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistBubbleViewModel.cs
@@ -17,6 +17,7 @@ public sealed class CommandAssistBubbleViewModel : INotifyPropertyChanged
     /// </remarks>
     private string _shortcutHintText = CommandAssistBarViewModel.IdleHintText;
     private bool _showQueryText = true;
+    private bool _showShortcutHint = true;
 
     public bool IsVisible
     {
@@ -52,6 +53,24 @@ public sealed class CommandAssistBubbleViewModel : INotifyPropertyChanged
     {
         get => _showQueryText;
         set => SetField(ref _showQueryText, value);
+    }
+
+    /// <summary>
+    /// Whether the shortcut hint strip is rendered at all. Set by the host from the compact-layout
+    /// decision, like <see cref="ShowQueryText"/>.
+    /// </summary>
+    /// <remarks>
+    /// The PR #290 review's fifth blocker. The bubble's hint sits in an <c>Auto</c> column and the
+    /// suggestion summary in the <c>*</c> column, so at the 280 px bubble floor - which is exactly what
+    /// a split SSH pane produces - the hint took its full ~200 px of "Up/Down browse | Ctrl+Enter
+    /// insert | Esc close" and the summary, the only content in the bubble the user is actually reading,
+    /// was left with what remained. On a pane that narrow the hint is the first thing to go: it teaches
+    /// shortcuts, and the popup footer teaches the same ones with room to spare.
+    /// </remarks>
+    public bool ShowShortcutHint
+    {
+        get => _showShortcutHint;
+        set => SetField(ref _showShortcutHint, value);
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistBubbleViewModel.cs
+++ b/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistBubbleViewModel.cs
@@ -9,7 +9,13 @@ public sealed class CommandAssistBubbleViewModel : INotifyPropertyChanged
     private string _modeLabel = "Suggest";
     private string _queryText = string.Empty;
     private string _summaryText = string.Empty;
-    private string _shortcutHintText = "Ctrl+Enter insert  |  Ctrl+Shift+H help  |  Ctrl+R history";
+    /// <remarks>
+    /// Only a placeholder until the first <c>CommandAssistBarViewModel.SyncPresentationState</c>,
+    /// which happens in that class's constructor. The V2 Phase 3a hint strip is state-dependent, so
+    /// the constant that used to live here (and promised <c>Ctrl+Enter</c> unconditionally) is not a
+    /// meaningful default any more.
+    /// </remarks>
+    private string _shortcutHintText = CommandAssistBarViewModel.IdleHintText;
     private bool _showQueryText = true;
 
     public bool IsVisible

--- a/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistPopupViewModel.cs
+++ b/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistPopupViewModel.cs
@@ -17,6 +17,8 @@ public sealed class CommandAssistPopupViewModel : INotifyPropertyChanged
     private bool _hasSuggestions;
     private bool _showEmptyState;
     private bool _useCompactLayout;
+    private int _selectedIndex = -1;
+    private string _shortcutHintText = string.Empty;
 
     public CommandAssistPopupViewModel(ObservableCollection<CommandAssistSuggestionItemViewModel> suggestions)
     {
@@ -100,6 +102,23 @@ public sealed class CommandAssistPopupViewModel : INotifyPropertyChanged
     }
 
     public bool UseExpandedLayout => !UseCompactLayout;
+
+    /// <summary>
+    /// Which row is selected, or <c>-1</c>. The rows carry their own <c>IsSelected</c> for rendering;
+    /// this exists so the view can scroll the selected container into view without walking the list.
+    /// </summary>
+    public int SelectedIndex
+    {
+        get => _selectedIndex;
+        set => SetField(ref _selectedIndex, value);
+    }
+
+    /// <summary>The same learnable hint strip the bubble shows, repeated in the popup footer.</summary>
+    public string ShortcutHintText
+    {
+        get => _shortcutHintText;
+        set => SetField(ref _shortcutHintText, value);
+    }
 
     public ObservableCollection<CommandAssistSuggestionItemViewModel> Suggestions { get; }
 

--- a/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistSuggestionItemViewModel.cs
+++ b/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistSuggestionItemViewModel.cs
@@ -1,12 +1,85 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using NovaTerminal.CommandAssist.Models;
 
 namespace NovaTerminal.CommandAssist.ViewModels;
 
-public sealed record CommandAssistSuggestionItemViewModel(
-    string SelectionGlyph,
-    string DisplayText,
-    string DescriptionText,
-    string BadgesText,
-    string MetadataText,
-    bool IsSelected,
-    AssistSuggestionType Type);
+/// <summary>
+/// One row in the popup list.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why this stopped being a record (V2 Phase 3a).</strong> Selection used to be baked in at
+/// construction, so moving the selection meant clearing the <c>ObservableCollection</c> and rebuilding
+/// every row. That is invisible while the list is keyboard-only and fatal once it is not: a rebuild
+/// replaces the containers under the pointer, so hover state is lost on every arrow key, the
+/// <c>ScrollViewer</c> jumps back to the top, and a click lands on a control that no longer exists by
+/// the time the selection it caused is applied.
+/// </para>
+/// <para>
+/// So the rows are now stable objects with a mutable selection, and the controller mutates rather
+/// than rebuilds when only the selection changed. Reference identity is load-bearing in the other
+/// direction too: the view maps a clicked container back to an index with
+/// <c>Suggestions.IndexOf(item)</c>, which a record's value equality would answer with the first
+/// row that happens to carry the same text.
+/// </para>
+/// </remarks>
+public sealed class CommandAssistSuggestionItemViewModel : INotifyPropertyChanged
+{
+    private bool _isSelected;
+
+    public CommandAssistSuggestionItemViewModel(
+        string displayText,
+        string descriptionText,
+        string badgesText,
+        string metadataText,
+        bool isSelected,
+        AssistSuggestionType type)
+    {
+        DisplayText = displayText;
+        DescriptionText = descriptionText;
+        BadgesText = badgesText;
+        MetadataText = metadataText;
+        Type = type;
+        _isSelected = isSelected;
+    }
+
+    public string DisplayText { get; }
+
+    public string DescriptionText { get; }
+
+    public string BadgesText { get; }
+
+    public string MetadataText { get; }
+
+    public AssistSuggestionType Type { get; }
+
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set
+        {
+            if (_isSelected == value)
+            {
+                return;
+            }
+
+            _isSelected = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(SelectionGlyph));
+        }
+    }
+
+    /// <summary>
+    /// The caret drawn in the gutter. Derived from <see cref="IsSelected"/> rather than stored, so
+    /// the two can no longer disagree - which they could when both were constructor arguments.
+    /// </summary>
+    public string SelectionGlyph => IsSelected ? ">" : " ";
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/tests/NovaTerminal.App.Tests/CommandAssist/AssistSessionStateMachineTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/AssistSessionStateMachineTests.cs
@@ -416,6 +416,109 @@ public sealed class AssistSessionStateMachineTests
         Assert.Equal(CommandAssistMode.Suggest, machine.Mode);
     }
 
+    // -------------------------------------------------- accept on Enter (V2 Phase 3a)
+
+    /// <summary>
+    /// The states where an unmodified <c>Enter</c> inserts the selected row instead of submitting the
+    /// command line: the two ranking modes, with the popup open and a row selected.
+    /// </summary>
+    [Theory]
+    [InlineData(AssistSessionState.PassivePopup)]
+    [InlineData(AssistSessionState.ExplicitPopup)]
+    [InlineData(AssistSessionState.HistorySearch)]
+    public void AllowsAcceptOnEnter_WhenBrowsingARankedList_IsTrue(AssistSessionState state)
+    {
+        AssistSessionStateMachine machine = CreateInState(state);
+
+        Assert.True(machine.AllowsAcceptOnEnter(isPopupOpen: true, hasSelection: true));
+    }
+
+    /// <summary>
+    /// Help and Fix render content the user did not compose and Fix appears after a submission, so
+    /// their <c>Enter</c> stays the shell's; both keep <c>Ctrl+Enter</c>.
+    /// </summary>
+    [Theory]
+    [InlineData(AssistSessionState.Help)]
+    [InlineData(AssistSessionState.FixPopup)]
+    [InlineData(AssistSessionState.FixHint)]
+    public void AllowsAcceptOnEnter_InHelperModes_IsFalse(AssistSessionState state)
+    {
+        AssistSessionStateMachine machine = CreateInState(state);
+
+        Assert.False(machine.AllowsAcceptOnEnter(isPopupOpen: true, hasSelection: true));
+    }
+
+    /// <summary>
+    /// The typing flow, which must be untouched: a bubble is not a browse state whatever mode it is
+    /// in, so Enter reaches the shell and submits.
+    /// </summary>
+    [Theory]
+    [InlineData(AssistSessionState.PassiveBubble)]
+    [InlineData(AssistSessionState.ExplicitBubble)]
+    [InlineData(AssistSessionState.PassivePopup)]
+    [InlineData(AssistSessionState.HistorySearch)]
+    public void AllowsAcceptOnEnter_WithNoOpenPopup_IsFalse(AssistSessionState state)
+    {
+        AssistSessionStateMachine machine = CreateInState(state);
+
+        Assert.False(machine.AllowsAcceptOnEnter(isPopupOpen: false, hasSelection: true));
+    }
+
+    [Fact]
+    public void AllowsAcceptOnEnter_WithAnOpenPopupButNoSelectedRow_IsFalse()
+    {
+        AssistSessionStateMachine machine = CreateInState(AssistSessionState.HistorySearch);
+
+        Assert.False(machine.AllowsAcceptOnEnter(isPopupOpen: true, hasSelection: false));
+    }
+
+    /// <summary>
+    /// Rows left over from a session that was toggled off are still navigable (see
+    /// <c>OpenPopupForSelection</c>), so the Hidden guard is not redundant with the popup flag.
+    /// </summary>
+    [Fact]
+    public void AllowsAcceptOnEnter_WhenHidden_IsFalse()
+    {
+        AssistSessionStateMachine machine = CreateInState(AssistSessionState.Hidden);
+
+        Assert.False(machine.AllowsAcceptOnEnter(isPopupOpen: true, hasSelection: true));
+    }
+
+    // ------------------------------------------- user-requested surfaces (V2 Phase 3a)
+
+    /// <summary>
+    /// The surfaces no placement heuristic may hide. Wider than <c>IsExplicitSession</c>: Help and a
+    /// confident Fix popup were asked for even though they rank nothing.
+    /// </summary>
+    [Theory]
+    [InlineData(AssistSessionState.ExplicitBubble)]
+    [InlineData(AssistSessionState.ExplicitPopup)]
+    [InlineData(AssistSessionState.HistorySearch)]
+    [InlineData(AssistSessionState.Help)]
+    [InlineData(AssistSessionState.FixPopup)]
+    public void IsUserRequestedSurface_ForSummonedSurfaces_IsTrue(AssistSessionState state)
+    {
+        AssistSessionStateMachine machine = CreateInState(state);
+
+        Assert.True(machine.IsUserRequestedSurface);
+    }
+
+    /// <summary>
+    /// The passive surfaces, which the conservative-placement stack still applies to - including the
+    /// bubble-only Fix affordance, the one Fix state the user did not ask for.
+    /// </summary>
+    [Theory]
+    [InlineData(AssistSessionState.Hidden)]
+    [InlineData(AssistSessionState.PassiveBubble)]
+    [InlineData(AssistSessionState.PassivePopup)]
+    [InlineData(AssistSessionState.FixHint)]
+    public void IsUserRequestedSurface_ForUninvitedSurfaces_IsFalse(AssistSessionState state)
+    {
+        AssistSessionStateMachine machine = CreateInState(state);
+
+        Assert.False(machine.IsUserRequestedSurface);
+    }
+
     private static AssistSessionStateMachine CreateInState(AssistSessionState state)
     {
         var machine = new AssistSessionStateMachine();

--- a/tests/NovaTerminal.App.Tests/CommandAssist/AssistSessionStateMachineTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/AssistSessionStateMachineTests.cs
@@ -484,6 +484,69 @@ public sealed class AssistSessionStateMachineTests
         Assert.False(machine.AllowsAcceptOnEnter(isPopupOpen: true, hasSelection: true));
     }
 
+    // ------------------------------------- Up belongs to the shell while typing (PR #290 review)
+
+    /// <summary>
+    /// The blocker, at the layer that decides it: in a passive bubble the user did not ask for,
+    /// <c>Up</c> is the shell's history recall and Command Assist may not take it.
+    /// </summary>
+    /// <remarks>
+    /// <c>FixHint</c> is in the table for the same reason it is out of
+    /// <c>IsUserRequestedSurface</c>: it is a bubble-only affordance for a diagnosis nobody requested.
+    /// </remarks>
+    [Theory]
+    [InlineData(AssistSessionState.PassiveBubble)]
+    [InlineData(AssistSessionState.FixHint)]
+    public void AllowsSelectionUp_InAPassiveBubble_IsFalse(AssistSessionState state)
+    {
+        AssistSessionStateMachine machine = CreateInState(state);
+
+        Assert.False(machine.AllowsSelectionUp(isPopupOpen: false));
+    }
+
+    /// <summary>
+    /// Once the row list is open the user is demonstrably browsing it, so <c>Up</c> navigates - even in
+    /// a passive session, which is the one the user reached with <c>Down</c>.
+    /// </summary>
+    [Theory]
+    [InlineData(AssistSessionState.PassivePopup)]
+    [InlineData(AssistSessionState.ExplicitPopup)]
+    [InlineData(AssistSessionState.HistorySearch)]
+    [InlineData(AssistSessionState.Help)]
+    [InlineData(AssistSessionState.FixPopup)]
+    public void AllowsSelectionUp_WithTheListOpen_IsTrue(AssistSessionState state)
+    {
+        AssistSessionStateMachine machine = CreateInState(state);
+
+        Assert.True(machine.AllowsSelectionUp(isPopupOpen: true));
+    }
+
+    /// <summary>
+    /// A surface the user summoned by name owns both arrows from the first keypress: the list is what
+    /// they asked for, so reaching it must not require a specific direction.
+    /// </summary>
+    [Theory]
+    [InlineData(AssistSessionState.ExplicitBubble)]
+    [InlineData(AssistSessionState.HistorySearch)]
+    public void AllowsSelectionUp_InASummonedSurfaceWithNoOpenList_IsStillTrue(AssistSessionState state)
+    {
+        AssistSessionStateMachine machine = CreateInState(state);
+
+        Assert.True(machine.AllowsSelectionUp(isPopupOpen: false));
+    }
+
+    /// <summary>
+    /// Hidden owns nothing, popup flag or not - the same guard <c>AllowsAcceptOnEnter</c> needs, for the
+    /// same reason: leftover rows stay navigable objects while no surface is on screen.
+    /// </summary>
+    [Fact]
+    public void AllowsSelectionUp_WhenHidden_IsFalse()
+    {
+        AssistSessionStateMachine machine = CreateInState(AssistSessionState.Hidden);
+
+        Assert.False(machine.AllowsSelectionUp(isPopupOpen: true));
+    }
+
     // ------------------------------------------- user-requested surfaces (V2 Phase 3a)
 
     /// <summary>

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistControllerTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistControllerTests.cs
@@ -703,8 +703,11 @@ public sealed class CommandAssistControllerTests
         Assert.True(selected);
         Assert.Equal(1, controller.ViewModel.SelectedIndex);
         Assert.True(controller.ViewModel.IsPopupOpen);
-        Assert.True(controller.IsSuggestionSelectedAt(1));
-        Assert.False(controller.IsSuggestionSelectedAt(0));
+
+        // The row flags the popup view actually reads - the "is this row the selected one" question the
+        // deleted IsSuggestionSelectedAt used to answer for nobody but this test (PR #290 review).
+        Assert.False(controller.ViewModel.Suggestions[0].IsSelected);
+        Assert.True(controller.ViewModel.Suggestions[1].IsSelected);
         Assert.True(controller.IsAcceptOnEnterArmed);
     }
 
@@ -716,7 +719,159 @@ public sealed class CommandAssistControllerTests
         controller.ToggleAssist();
 
         Assert.False(controller.TrySelectSuggestionAt(0));
-        Assert.False(controller.IsSuggestionSelectedAt(0));
+        Assert.Empty(controller.ViewModel.Suggestions);
+    }
+
+    // ----------------------- an invisible overlay cannot arm Enter (PR #290 review)
+
+    /// <summary>
+    /// The first blocker at the controller: the session can believe a popup is up while the pane has
+    /// hidden or dimmed the overlay it renders - a passive popup on a short markless-SSH pane, which is
+    /// not a user-requested surface and so bypasses none of the pane's hiding. An armed <c>Enter</c>
+    /// there is a command line that silently does not submit.
+    /// </summary>
+    [Fact]
+    public async Task WhenTheHostSaysTheOverlayIsNotRendered_EnterIsNotArmedAndTheHintDoesNotPromiseIt()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        historyStore.Seed(
+            CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")),
+            CreateEntry("git stash", DateTimeOffset.Parse("2026-03-01T09:59:00+00:00")));
+        bool isOverlayRendered = true;
+        var controller = CreateController(historyStore, renderedSurfaceProbe: () => isOverlayRendered);
+
+        controller.OpenHistorySearch();
+        await historyStore.WaitForSearchSettledAsync();
+        await WaitForConditionAsync(() => controller.Suggestions.Count > 1);
+        controller.MoveSelectionDown();
+
+        // The control: with the overlay on screen this is the armed browse state.
+        Assert.True(controller.IsAcceptOnEnterArmed);
+        Assert.Contains("Enter insert", controller.ViewModel.Bubble.ShortcutHintText);
+
+        isOverlayRendered = false;
+        controller.NotifyRenderedSurfaceVisibilityChanged();
+
+        Assert.False(controller.IsAcceptOnEnterArmed);
+        Assert.False(controller.ViewModel.IsAcceptOnEnterArmed);
+        Assert.Contains("Ctrl+Enter insert", controller.ViewModel.Bubble.ShortcutHintText);
+        Assert.Contains("Ctrl+Enter insert", controller.ViewModel.Popup.ShortcutHintText);
+
+        // Selection and popup state are untouched: the surface is hidden, not dismissed, and it comes
+        // back the moment the pane finishes settling.
+        Assert.True(controller.ViewModel.IsPopupOpen);
+        Assert.Equal(1, controller.ViewModel.SelectedIndex);
+    }
+
+    // -------------------- Up belongs to the shell while typing (PR #290 review)
+
+    /// <summary>
+    /// The second blocker at the controller. Typing produces a passive bubble, and in it <c>Up</c> is
+    /// the shell's history recall - the App asks this before routing the key.
+    /// </summary>
+    [Fact]
+    public async Task WhileTypingWithOnlyABubbleUp_UpIsNotAssistOwned()
+    {
+        var grid = new FakeGrid();
+        CommandAssistController controller = CreatePassiveBubbleController(grid);
+
+        grid.SetLine("cd ./d");
+        controller.NotifyInputActivity();
+        await WaitForPassiveBubbleAsync(controller);
+
+        Assert.True(controller.ViewModel.IsVisible);
+        Assert.False(controller.ViewModel.IsPopupOpen);
+        Assert.False(controller.IsSelectionUpOwned);
+
+        // And the strip says so rather than advertising a key the surface has given back to the shell.
+        Assert.Contains("Down browse", controller.ViewModel.Bubble.ShortcutHintText);
+        Assert.DoesNotContain("Up/Down", controller.ViewModel.Bubble.ShortcutHintText);
+    }
+
+    /// <summary>
+    /// The other half: <c>Down</c> opens the list from that same state, after which <c>Up</c> navigates
+    /// it. Without this the rule above would be indistinguishable from "the assist never gets an arrow".
+    /// </summary>
+    [Fact]
+    public async Task AfterDownOpensTheListFromAPassiveBubble_UpBecomesAssistOwned()
+    {
+        var grid = new FakeGrid();
+        CommandAssistController controller = CreatePassiveBubbleController(grid);
+
+        grid.SetLine("cd ./d");
+        controller.NotifyInputActivity();
+        await WaitForPassiveBubbleAsync(controller);
+
+        Assert.True(controller.MoveSelectionDown());
+        Assert.True(controller.ViewModel.IsPopupOpen);
+        Assert.True(controller.IsSelectionUpOwned);
+    }
+
+    /// <summary>
+    /// An explicitly summoned surface owns both arrows from the first keypress: the user asked for the
+    /// list, so reaching it must not depend on which direction they reach in.
+    /// </summary>
+    [Fact]
+    public void AfterTheAssistShortcut_UpIsAssistOwnedWithNoOpenList()
+    {
+        var controller = CreateController();
+
+        controller.ToggleAssist();
+
+        // Ctrl+Space leaves the popup closed, so this is the summoned-surface branch rather than the
+        // open-list one - the two reasons Up can be owned, told apart.
+        Assert.False(controller.ViewModel.IsPopupOpen);
+        Assert.True(controller.IsSelectionUpOwned);
+    }
+
+    /// <summary>
+    /// <c>Up</c> at the top of the list is a no-op, and specifically not "select row 0": the old clamp
+    /// went through <c>SetSelectedIndex</c>, which opens the popup and arms <c>Enter</c>. That is how a
+    /// key pressed for shell history built the surface that then swallowed the next <c>Enter</c>.
+    /// </summary>
+    [Fact]
+    public async Task MoveSelectionUp_AtTheTopOfTheList_DoesNotOpenThePopupOrArmEnter()
+    {
+        var grid = new FakeGrid();
+        CommandAssistController controller = CreatePassiveBubbleController(grid);
+
+        grid.SetLine("cd ./d");
+        controller.NotifyInputActivity();
+        await WaitForPassiveBubbleAsync(controller);
+        Assert.Equal(0, controller.ViewModel.SelectedIndex);
+        Assert.False(controller.ViewModel.IsPopupOpen);
+
+        bool moved = controller.MoveSelectionUp();
+
+        Assert.False(moved);
+        Assert.False(controller.ViewModel.IsPopupOpen);
+        Assert.False(controller.IsAcceptOnEnterArmed);
+    }
+
+    /// <summary>
+    /// And inside an open list it still navigates. <c>Up</c> from row 1 lands on row 0 and stays there.
+    /// </summary>
+    [Fact]
+    public async Task MoveSelectionUp_InsideAnOpenList_MovesBackUpAndThenStops()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        historyStore.Seed(
+            CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")),
+            CreateEntry("git stash", DateTimeOffset.Parse("2026-03-01T09:59:00+00:00")));
+        var controller = CreateController(historyStore);
+
+        controller.OpenHistorySearch();
+        await historyStore.WaitForSearchSettledAsync();
+        await WaitForConditionAsync(() => controller.Suggestions.Count > 1);
+        Assert.True(controller.MoveSelectionDown());
+        Assert.Equal(1, controller.ViewModel.SelectedIndex);
+
+        Assert.True(controller.MoveSelectionUp());
+        Assert.Equal(0, controller.ViewModel.SelectedIndex);
+
+        Assert.False(controller.MoveSelectionUp());
+        Assert.Equal(0, controller.ViewModel.SelectedIndex);
+        Assert.True(controller.ViewModel.IsPopupOpen);
     }
 
     /// <summary>
@@ -1215,7 +1370,8 @@ public sealed class CommandAssistControllerTests
         ICommandDocsProvider? commandDocsProvider = null,
         IRecipeProvider? recipeProvider = null,
         IErrorInsightService? errorInsightService = null,
-        FakeGrid? grid = null)
+        FakeGrid? grid = null,
+        Func<bool>? renderedSurfaceProbe = null)
     {
         historyStore ??= new InMemoryHistoryStore();
         var filter = new SecretsFilter();
@@ -1236,7 +1392,8 @@ public sealed class CommandAssistControllerTests
             errorInsightService,
             modeRouter: null,
             resultBuilder: null,
-            queryProvider: grid == null ? null : grid.Read);
+            queryProvider: grid == null ? null : grid.Read,
+            renderedSurfaceProbe: renderedSurfaceProbe);
 
         if (grid != null)
         {
@@ -1354,11 +1511,71 @@ public sealed class CommandAssistControllerTests
         }
     }
 
+    /// <summary>
+    /// A controller whose passive typing bubble actually has rows in it.
+    /// </summary>
+    /// <remarks>
+    /// A passive Suggest session is scoped to <em>paths only</em> - unasked-for history rows were the
+    /// noisiest part of V1, see <c>SuggestionOrchestrator.ResolveScope</c> - so seeding history is not
+    /// enough to make one visible, and every history-seeded test in this file that calls
+    /// <c>ToggleAssist</c> first is in the <em>explicit</em> bubble state instead. The PR #290 review's
+    /// <c>Up</c> rule is specifically about the passive state, so it needs a path provider that answers.
+    /// </remarks>
+    private static CommandAssistController CreatePassiveBubbleController(FakeGrid grid)
+    {
+        return CreateController(
+            suggestionEngine: new CommandAssistSuggestionEngine(new FixedPathSuggestionProvider(
+                CreatePathRow("./docs/"),
+                CreatePathRow("./deploy.sh"))),
+            grid: grid);
+    }
+
+    /// <summary>
+    /// Waits for a passive bubble's ranking pass to be <em>finished</em>, not merely to have produced
+    /// rows.
+    /// </summary>
+    /// <remarks>
+    /// The test dispatch is the identity function, so <c>ApplyRefreshOutcome</c> runs on the pass's own
+    /// thread-pool thread while the test thread carries on. Waiting on the row count therefore returns
+    /// mid-apply, and the writes that come after it - closing the popup, publishing visibility - land on
+    /// top of whatever the test did next. <c>IsVisible</c> is the last of those writes, and it is false
+    /// until a pass lands (<c>NotifyInputActivity</c> sets it from the rows that were already up, which
+    /// is none), so it is the one flag that means "the pass is done".
+    /// </remarks>
+    private static Task WaitForPassiveBubbleAsync(CommandAssistController controller) =>
+        WaitForConditionAsync(() => controller.ViewModel.IsVisible && controller.Suggestions.Count > 1);
+
+    private static AssistSuggestion CreatePathRow(string text) => new(
+        Id: text,
+        Type: AssistSuggestionType.Path,
+        DisplayText: text,
+        InsertText: text,
+        Description: null,
+        Badges: Array.Empty<string>(),
+        Score: 50,
+        WorkingDirectory: null,
+        LastUsedAt: null,
+        ExitCode: null);
+
     /// <summary>Stubs out the filesystem so controller tests never depend on the working directory.</summary>
     private sealed class NoPathSuggestionProvider : IPathSuggestionProvider
     {
         public IReadOnlyList<AssistSuggestion> GetSuggestions(CommandAssistQueryContext context, int maxResults)
             => Array.Empty<AssistSuggestion>();
+    }
+
+    /// <summary>The opposite: a filesystem that always has these two entries in it.</summary>
+    private sealed class FixedPathSuggestionProvider : IPathSuggestionProvider
+    {
+        private readonly AssistSuggestion[] _suggestions;
+
+        public FixedPathSuggestionProvider(params AssistSuggestion[] suggestions)
+        {
+            _suggestions = suggestions;
+        }
+
+        public IReadOnlyList<AssistSuggestion> GetSuggestions(CommandAssistQueryContext context, int maxResults)
+            => context.IncludePathSuggestions ? _suggestions : Array.Empty<AssistSuggestion>();
     }
 
     private sealed class InMemoryHistoryStore : IHistoryStore

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistControllerTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistControllerTests.cs
@@ -585,6 +585,212 @@ public sealed class CommandAssistControllerTests
         Assert.True(controller.ViewModel.Popup.IsVisible);
     }
 
+    // ------------------------------------- accept-on-Enter, hint strip, mouse (V2 Phase 3a)
+
+    /// <summary>
+    /// The owner's first report end to end at the controller: <c>Ctrl+R</c>, move to a row, and now
+    /// <c>Enter</c> is the assist's key - and the bubble says so, which it never did before because
+    /// <c>ShortcutHintText</c> was on the view-model and bound nowhere.
+    /// </summary>
+    [Fact]
+    public async Task AfterHistorySearchAndASelectionMove_EnterIsArmedAndTheHintSaysSo()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        historyStore.Seed(
+            CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")),
+            CreateEntry("git stash", DateTimeOffset.Parse("2026-03-01T09:59:00+00:00")));
+        var controller = CreateController(historyStore);
+
+        controller.OpenHistorySearch();
+        await historyStore.WaitForSearchSettledAsync();
+        await WaitForConditionAsync(() => controller.Suggestions.Count > 1);
+        controller.MoveSelectionDown();
+
+        Assert.True(controller.IsAcceptOnEnterArmed);
+        Assert.True(controller.ViewModel.IsAcceptOnEnterArmed);
+        Assert.Contains("Enter insert", controller.ViewModel.Bubble.ShortcutHintText);
+        Assert.Contains("Enter insert", controller.ViewModel.Popup.ShortcutHintText);
+    }
+
+    /// <summary>
+    /// The typing flow, which the keyboard change must not touch: a passive bubble is not a browse
+    /// state, so <c>Enter</c> stays the shell's and the hint promises <c>Ctrl+Enter</c> instead.
+    /// </summary>
+    [Fact]
+    public async Task WhileTypingWithOnlyABubbleUp_EnterIsNotArmed()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        historyStore.Seed(CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")));
+        var grid = new FakeGrid();
+        var controller = CreateController(historyStore, grid: grid);
+        controller.ToggleAssist();
+
+        grid.SetLine("git st");
+        controller.NotifyInputActivity();
+        await historyStore.WaitForSearchSettledAsync();
+        await WaitForConditionAsync(() => controller.ViewModel.TopSuggestionText == "git status");
+
+        Assert.False(controller.ViewModel.IsPopupOpen);
+        Assert.False(controller.IsAcceptOnEnterArmed);
+        Assert.Contains("Ctrl+Enter insert", controller.ViewModel.Bubble.ShortcutHintText);
+    }
+
+    /// <summary>
+    /// Typing after a browse must disarm <c>Enter</c> again, or the very next command submission would
+    /// be swallowed by an insertion. The disarm is structural - typing closes the popup - and this pins
+    /// it because the consequence of losing it is the user's Enter not running their command.
+    /// </summary>
+    [Fact]
+    public async Task TypingAfterABrowse_DisarmsEnterAgain()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        historyStore.Seed(
+            CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")),
+            CreateEntry("git stash", DateTimeOffset.Parse("2026-03-01T09:59:00+00:00")));
+        var grid = new FakeGrid();
+        var controller = CreateController(historyStore, grid: grid);
+
+        controller.OpenHistorySearch();
+        await historyStore.WaitForSearchSettledAsync();
+        await WaitForConditionAsync(() => controller.Suggestions.Count > 1);
+        controller.MoveSelectionDown();
+        Assert.True(controller.IsAcceptOnEnterArmed);
+
+        grid.SetLine("git st");
+        controller.NotifyInputActivity();
+
+        Assert.False(controller.IsAcceptOnEnterArmed);
+    }
+
+    /// <summary>Escape disarms too: there is no row to accept once the surface is gone.</summary>
+    [Fact]
+    public async Task Escape_DisarmsEnter()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        historyStore.Seed(CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")));
+        var controller = CreateController(historyStore);
+
+        controller.OpenHistorySearch();
+        await historyStore.WaitForSearchSettledAsync();
+        await WaitForConditionAsync(() => controller.Suggestions.Count > 0);
+        controller.MoveSelectionDown();
+
+        controller.HandleEscape();
+
+        Assert.False(controller.IsAcceptOnEnterArmed);
+    }
+
+    /// <summary>
+    /// A click selects a row by index and opens the popup exactly as an arrow key would - including
+    /// arming <c>Enter</c>, so a click-then-Enter works the same as an arrow-then-Enter.
+    /// </summary>
+    [Fact]
+    public async Task TrySelectSuggestionAt_SelectsThatRowAndOpensThePopup()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        historyStore.Seed(
+            CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")),
+            CreateEntry("git stash", DateTimeOffset.Parse("2026-03-01T09:59:00+00:00")));
+        var grid = new FakeGrid();
+        var controller = CreateController(historyStore, grid: grid);
+        controller.ToggleAssist();
+        await historyStore.WaitForSearchSettledAsync();
+        await WaitForConditionAsync(() => controller.Suggestions.Count > 1);
+        Assert.False(controller.ViewModel.IsPopupOpen);
+
+        bool selected = controller.TrySelectSuggestionAt(1);
+
+        Assert.True(selected);
+        Assert.Equal(1, controller.ViewModel.SelectedIndex);
+        Assert.True(controller.ViewModel.IsPopupOpen);
+        Assert.True(controller.IsSuggestionSelectedAt(1));
+        Assert.False(controller.IsSuggestionSelectedAt(0));
+        Assert.True(controller.IsAcceptOnEnterArmed);
+    }
+
+    /// <summary>A click that arrives after the list shrank must not select anything.</summary>
+    [Fact]
+    public void TrySelectSuggestionAt_WithNoRows_Refuses()
+    {
+        var controller = CreateController();
+        controller.ToggleAssist();
+
+        Assert.False(controller.TrySelectSuggestionAt(0));
+        Assert.False(controller.IsSuggestionSelectedAt(0));
+    }
+
+    /// <summary>
+    /// Moving the selection must mutate the existing rows rather than replace them. Rebuilding is what
+    /// the controller used to do, and it is what made the popup unusable with a mouse: the containers
+    /// under the pointer are destroyed on every arrow key, so hover dies and the scroll position jumps
+    /// back to the top.
+    /// </summary>
+    [Fact]
+    public async Task MovingTheSelection_MutatesTheExistingRowsRatherThanRebuildingThem()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        historyStore.Seed(
+            CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")),
+            CreateEntry("git stash", DateTimeOffset.Parse("2026-03-01T09:59:00+00:00")));
+        var controller = CreateController(historyStore);
+
+        controller.OpenHistorySearch();
+        await historyStore.WaitForSearchSettledAsync();
+        await WaitForConditionAsync(() => controller.ViewModel.Suggestions.Count > 1);
+
+        var rowsBefore = controller.ViewModel.Suggestions.ToArray();
+        Assert.True(rowsBefore[0].IsSelected);
+
+        controller.MoveSelectionDown();
+
+        Assert.Same(rowsBefore[0], controller.ViewModel.Suggestions[0]);
+        Assert.Same(rowsBefore[1], controller.ViewModel.Suggestions[1]);
+        Assert.False(rowsBefore[0].IsSelected);
+        Assert.True(rowsBefore[1].IsSelected);
+        Assert.Equal(" ", rowsBefore[0].SelectionGlyph);
+        Assert.Equal(">", rowsBefore[1].SelectionGlyph);
+    }
+
+    /// <summary>
+    /// The visibility half of the third owner report: <c>Ctrl+R</c> is a surface the user asked for,
+    /// which is the fact every placement heuristic in <c>TerminalPane</c> now consults before hiding
+    /// anything.
+    /// </summary>
+    [Fact]
+    public void OpenHistorySearch_MarksTheSurfaceAsUserRequested()
+    {
+        var controller = CreateController();
+
+        Assert.False(controller.IsUserRequestedSurface);
+
+        controller.OpenHistorySearch();
+
+        Assert.True(controller.IsUserRequestedSurface);
+
+        controller.HandleEscape();
+
+        Assert.False(controller.IsUserRequestedSurface);
+    }
+
+    /// <summary>
+    /// A passive typing bubble is not user-requested, so the conservative markless-SSH placement stack
+    /// still applies to it. Without this the bypass would be unconditional.
+    /// </summary>
+    [Fact]
+    public async Task Typing_DoesNotMarkTheSurfaceAsUserRequested()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        historyStore.Seed(CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")));
+        var grid = new FakeGrid();
+        var controller = CreateController(historyStore, grid: grid);
+
+        grid.SetLine("git st");
+        controller.NotifyInputActivity();
+        await historyStore.WaitForSearchSettledAsync();
+
+        Assert.False(controller.IsUserRequestedSurface);
+    }
+
     [Fact]
     public void HandleEscape_WhenAssistIsVisible_DismissesAssist()
     {

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistKeyRouterTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistKeyRouterTests.cs
@@ -4,9 +4,30 @@ namespace NovaTerminal.Tests.CommandAssist;
 
 public sealed class CommandAssistKeyRouterTests
 {
-    private static readonly AssistKeyState Hidden = new(IsSurfaceVisible: false, IsAcceptOnEnterArmed: false);
-    private static readonly AssistKeyState Visible = new(IsSurfaceVisible: true, IsAcceptOnEnterArmed: false);
-    private static readonly AssistKeyState Browsing = new(IsSurfaceVisible: true, IsAcceptOnEnterArmed: true);
+    private static readonly AssistKeyState Hidden = new(
+        IsSurfaceVisible: false,
+        IsAcceptOnEnterArmed: false,
+        IsSelectionUpOwned: false);
+
+    /// <summary>A surface the user summoned: on screen, both arrows owned, nothing selected yet.</summary>
+    private static readonly AssistKeyState Visible = new(
+        IsSurfaceVisible: true,
+        IsAcceptOnEnterArmed: false,
+        IsSelectionUpOwned: true);
+
+    /// <summary>
+    /// The passive typing bubble: on screen, but <c>Up</c> is still the shell's history recall
+    /// (PR #290 review).
+    /// </summary>
+    private static readonly AssistKeyState PassiveBubble = new(
+        IsSurfaceVisible: true,
+        IsAcceptOnEnterArmed: false,
+        IsSelectionUpOwned: false);
+
+    private static readonly AssistKeyState Browsing = new(
+        IsSurfaceVisible: true,
+        IsAcceptOnEnterArmed: true,
+        IsSelectionUpOwned: true);
 
     [Theory]
     [InlineData(AssistKey.Up)]
@@ -15,6 +36,41 @@ public sealed class CommandAssistKeyRouterTests
     public void IsAssistOwnedKey_WhenAssistVisible_ConsumesNavigationKeys(AssistKey key)
     {
         bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(Visible, key, AssistModifiers.None);
+
+        Assert.True(owned);
+    }
+
+    // ------------------------------- Up is the shell's while typing (PR #290 review)
+
+    /// <summary>
+    /// The reported sequence at the routing layer: with only a passive bubble up, <c>Up</c> is not
+    /// Command Assist's, so it reaches the shell and recalls the previous command.
+    /// </summary>
+    [Fact]
+    public void IsAssistOwnedKey_WithAPassiveBubbleUp_LeavesUpToTheShell()
+    {
+        bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(PassiveBubble, AssistKey.Up, AssistModifiers.None);
+
+        Assert.False(owned);
+    }
+
+    /// <summary>
+    /// <c>Down</c> is the one-directional way in, and it stays owned in exactly the state that refuses
+    /// <c>Up</c> - without this the test above would be satisfied by the assist owning no arrows at all.
+    /// </summary>
+    [Fact]
+    public void IsAssistOwnedKey_WithAPassiveBubbleUp_StillConsumesDown()
+    {
+        bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(PassiveBubble, AssistKey.Down, AssistModifiers.None);
+
+        Assert.True(owned);
+    }
+
+    /// <summary>Escape is unaffected: dismissing an uninvited bubble is the one thing it is for.</summary>
+    [Fact]
+    public void IsAssistOwnedKey_WithAPassiveBubbleUp_StillConsumesEscape()
+    {
+        bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(PassiveBubble, AssistKey.Escape, AssistModifiers.None);
 
         Assert.True(owned);
     }
@@ -104,9 +160,22 @@ public sealed class CommandAssistKeyRouterTests
     public void IsAssistOwnedKey_WhenHidden_LeavesPlainEnterToTheShell()
     {
         bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(
-            new AssistKeyState(IsSurfaceVisible: false, IsAcceptOnEnterArmed: true),
+            new AssistKeyState(IsSurfaceVisible: false, IsAcceptOnEnterArmed: true, IsSelectionUpOwned: true),
             AssistKey.Enter,
             AssistModifiers.None);
+
+        Assert.False(owned);
+    }
+
+    /// <summary>
+    /// <c>Meta</c> reaches the router now (PR #290 review), so a <c>Win+Enter</c> is not "unmodified".
+    /// It used to be dropped at the App boundary, which made the router claim a key
+    /// <c>TerminalPane</c>'s own <c>modifiers == KeyModifiers.None</c> check then declined to act on.
+    /// </summary>
+    [Fact]
+    public void IsAssistOwnedKey_WhenBrowsing_DoesNotConsumeMetaEnterAsAccept()
+    {
+        bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(Browsing, AssistKey.Enter, AssistModifiers.Meta);
 
         Assert.False(owned);
     }
@@ -134,5 +203,19 @@ public sealed class CommandAssistKeyRouterTests
         bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(Browsing, AssistKey.Enter, AssistModifiers.Control);
 
         Assert.True(owned);
+    }
+
+    /// <summary>
+    /// The App-side mapping the test above depends on. Without it the router receives
+    /// <see cref="AssistModifiers.None"/> for a <c>Win+Enter</c> and the "unmodified Enter" rule means
+    /// something different on each side of the boundary.
+    /// </summary>
+    [Fact]
+    public void AssistKeyMapper_MapsMeta()
+    {
+        AssistModifiers mapped = NovaTerminal.Controls.AssistKeyMapper.ToAssistModifiers(
+            Avalonia.Input.KeyModifiers.Meta);
+
+        Assert.Equal(AssistModifiers.Meta, mapped);
     }
 }

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistKeyRouterTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistKeyRouterTests.cs
@@ -4,13 +4,17 @@ namespace NovaTerminal.Tests.CommandAssist;
 
 public sealed class CommandAssistKeyRouterTests
 {
+    private static readonly AssistKeyState Hidden = new(IsSurfaceVisible: false, IsAcceptOnEnterArmed: false);
+    private static readonly AssistKeyState Visible = new(IsSurfaceVisible: true, IsAcceptOnEnterArmed: false);
+    private static readonly AssistKeyState Browsing = new(IsSurfaceVisible: true, IsAcceptOnEnterArmed: true);
+
     [Theory]
     [InlineData(AssistKey.Up)]
     [InlineData(AssistKey.Down)]
     [InlineData(AssistKey.Escape)]
     public void IsAssistOwnedKey_WhenAssistVisible_ConsumesNavigationKeys(AssistKey key)
     {
-        bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(true, key, AssistModifiers.None);
+        bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(Visible, key, AssistModifiers.None);
 
         Assert.True(owned);
     }
@@ -18,7 +22,16 @@ public sealed class CommandAssistKeyRouterTests
     [Fact]
     public void IsAssistOwnedKey_WhenAssistVisible_DoesNotConsumeTab()
     {
-        bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(true, AssistKey.Tab, AssistModifiers.None);
+        bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(Visible, AssistKey.Tab, AssistModifiers.None);
+
+        Assert.False(owned);
+    }
+
+    /// <summary>Tab stays shell-owned even while browsing: completion belongs to the shell.</summary>
+    [Fact]
+    public void IsAssistOwnedKey_WhenBrowsing_StillDoesNotConsumeTab()
+    {
+        bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(Browsing, AssistKey.Tab, AssistModifiers.None);
 
         Assert.False(owned);
     }
@@ -26,7 +39,7 @@ public sealed class CommandAssistKeyRouterTests
     [Fact]
     public void IsAssistOwnedKey_WhenAssistVisible_ConsumesCtrlEnter()
     {
-        bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(true, AssistKey.Enter, AssistModifiers.Control);
+        bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(Visible, AssistKey.Enter, AssistModifiers.Control);
 
         Assert.True(owned);
     }
@@ -35,7 +48,7 @@ public sealed class CommandAssistKeyRouterTests
     public void IsAssistOwnedKey_WhenAssistVisible_ConsumesPinShortcut()
     {
         bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(
-            true,
+            Visible,
             AssistKey.P,
             AssistModifiers.Control | AssistModifiers.Shift);
 
@@ -48,7 +61,7 @@ public sealed class CommandAssistKeyRouterTests
     [InlineData(AssistKey.Escape)]
     public void IsAssistOwnedKey_WhenAssistHidden_DoesNotConsumeNavigationKeys(AssistKey key)
     {
-        bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(false, key, AssistModifiers.None);
+        bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(Hidden, key, AssistModifiers.None);
 
         Assert.False(owned);
     }
@@ -56,8 +69,70 @@ public sealed class CommandAssistKeyRouterTests
     [Fact]
     public void IsAssistOwnedKey_WhenAssistHidden_DoesNotConsumeCtrlEnter()
     {
-        bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(false, AssistKey.Enter, AssistModifiers.Control);
+        bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(Hidden, AssistKey.Enter, AssistModifiers.Control);
 
         Assert.False(owned);
+    }
+
+    // -------------------------------------------------------- accept on Enter (V2 Phase 3a)
+
+    /// <summary>
+    /// The owner's first report, at the routing layer: while a row is selected in an open popup,
+    /// <c>Enter</c> is the assist's, so it can insert instead of submitting an empty command line.
+    /// </summary>
+    [Fact]
+    public void IsAssistOwnedKey_WhenBrowsing_ConsumesPlainEnter()
+    {
+        bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(Browsing, AssistKey.Enter, AssistModifiers.None);
+
+        Assert.True(owned);
+    }
+
+    /// <summary>
+    /// The typing flow. A bubble with no row selected leaves <c>Enter</c> to the shell, so
+    /// type-a-command-and-run is exactly as it was before Phase 3a.
+    /// </summary>
+    [Fact]
+    public void IsAssistOwnedKey_WhenVisibleButNotBrowsing_LeavesPlainEnterToTheShell()
+    {
+        bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(Visible, AssistKey.Enter, AssistModifiers.None);
+
+        Assert.False(owned);
+    }
+
+    [Fact]
+    public void IsAssistOwnedKey_WhenHidden_LeavesPlainEnterToTheShell()
+    {
+        bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(
+            new AssistKeyState(IsSurfaceVisible: false, IsAcceptOnEnterArmed: true),
+            AssistKey.Enter,
+            AssistModifiers.None);
+
+        Assert.False(owned);
+    }
+
+    /// <summary>
+    /// A modified <c>Enter</c> is never the accept key, however armed the session is. Shift+Enter is a
+    /// newline in several line editors, and under the kitty disambiguate tier every modified Enter is a
+    /// distinct CSI u sequence the shell may act on - so "unmodified" is exact rather than "no Alt".
+    /// </summary>
+    [Theory]
+    [InlineData(AssistModifiers.Shift)]
+    [InlineData(AssistModifiers.Alt)]
+    [InlineData(AssistModifiers.Control | AssistModifiers.Shift)]
+    public void IsAssistOwnedKey_WhenBrowsing_DoesNotConsumeModifiedEnterAsAccept(AssistModifiers modifiers)
+    {
+        bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(Browsing, AssistKey.Enter, modifiers);
+
+        Assert.False(owned);
+    }
+
+    /// <summary>Ctrl+Enter is unaffected by the browse state; it worked everywhere and still does.</summary>
+    [Fact]
+    public void IsAssistOwnedKey_WhenBrowsing_StillConsumesCtrlEnter()
+    {
+        bool owned = CommandAssistKeyRouter.IsAssistOwnedKey(Browsing, AssistKey.Enter, AssistModifiers.Control);
+
+        Assert.True(owned);
     }
 }

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistLayoutTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistLayoutTests.cs
@@ -2,6 +2,7 @@ using NovaTerminal.Shell;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
@@ -440,6 +441,104 @@ public sealed class CommandAssistLayoutTests
         Assert.False(layout.UsesPromptAnchor);
         Assert.True(layout.BubbleRect.Bottom > 500 * 0.5,
             $"Expected conservative fallback to stay in lower safe zone when prompt hint rows lag pane height, but bottom was {layout.BubbleRect.Bottom}.");
+    }
+
+    // ------------------------------------------- explicit intent is never hidden (V2 Phase 3a)
+
+    /// <summary>
+    /// The owner's third report: in a tab split into two SSH panes, the assist did not appear on one of
+    /// them. A split halves the pane height, which puts both panes under the short-pane threshold, and
+    /// on the pane whose prompt was still in the upper band the conservative band check hid the overlay
+    /// outright - for <c>Ctrl+R</c> as readily as for an uninvited bubble.
+    /// </summary>
+    /// <remarks>
+    /// The geometry is copied exactly from
+    /// <c>TerminalPane_WhenRemotePromptIsInUpperBandOnShortPane_SuppressesConservativeAssistLayout</c>,
+    /// which is the negative control: without an explicitly requested surface the same pane still
+    /// returns null. The Escape at the end is a second control on the same instance, so the bypass
+    /// cannot be satisfied by "a controller exists" rather than by the session state.
+    /// </remarks>
+    [AvaloniaFact]
+    public void TerminalPane_WhenHistorySearchIsOpenOnAShortRemotePane_DoesNotSuppressTheOverlay()
+    {
+        using var pane = new TerminalPane
+        {
+            Width = 900,
+            Height = 220
+        };
+        ConfigureCommandAssist(pane);
+        pane.UpdateProfile(new TerminalProfile
+        {
+            Type = ConnectionType.SSH,
+            Command = "ssh.exe",
+            SshHost = "ubuntu.example"
+        });
+        pane.Measure(new Size(900, 220));
+        pane.Arrange(new Rect(0, 0, 900, 220));
+
+        TerminalView termView = Assert.IsType<TerminalView>(pane.FindControl<TerminalView>("TermView"));
+        Assert.NotNull(pane.Buffer);
+        termView.SetMetricsForTest(10, 18);
+        termView.Measure(new Size(900, 220));
+        termView.Arrange(new Rect(0, 0, 900, 220));
+        pane.Buffer.SetCursorPosition(0, 1);
+        AssertPromptHint(termView, expectedCursorRow: 1, expectedVisibleRows: 12);
+
+        // No marks are produced: this is a markless remote pane, the case the suppression exists for.
+        Assert.True(pane.OpenCommandAssistHistorySearch());
+
+        CommandAssistAnchorLayout layout = Assert.IsType<CommandAssistAnchorLayout>(
+            pane.CalculateCommandAssistAnchorLayoutForTest());
+
+        // Worst-case placement is the safe lower band, not invisibility.
+        Assert.False(layout.UsesMarkAnchor);
+        Assert.False(layout.UsesPromptAnchor);
+        Assert.True(layout.BubbleRect.Bottom > 220 * 0.5,
+            $"Expected the summoned surface to land in the lower safe band, but bottom was {layout.BubbleRect.Bottom}.");
+
+        // Control: dismiss the surface and the conservative suppression is back.
+        Assert.True(pane.TryHandleCommandAssistKey(Key.Escape, KeyModifiers.None));
+        Assert.Null(pane.CalculateCommandAssistAnchorLayoutForTest());
+    }
+
+    /// <summary>
+    /// The other half of the third report, checked directly rather than through geometry: both panes of
+    /// a split get their own initialized controller off one shared services graph, and <c>Ctrl+R</c>
+    /// opens on the second one as readily as on the first.
+    /// </summary>
+    /// <remarks>
+    /// <c>MainWindow.WirePane</c> is the funnel that assigns <c>CommandAssistServices</c> to every pane
+    /// it creates, including the ones a split adds, so the injection itself is structural. What this
+    /// pins is that nothing in the pane's own initialization is single-instance: a second pane sharing
+    /// the same history store and snippet store must build a second controller and a second view-model
+    /// rather than finding the first one's state.
+    /// </remarks>
+    [AvaloniaFact]
+    public void TwoPanesSharingOneServicesGraph_BothOpenTheirOwnHistorySearch()
+    {
+        using var first = new TerminalPane();
+        using var second = new TerminalPane();
+        ConfigureCommandAssist(first);
+        ConfigureCommandAssist(second);
+
+        Assert.True(first.OpenCommandAssistHistorySearch());
+        Assert.True(second.OpenCommandAssistHistorySearch());
+
+        CommandAssistBarViewModel firstViewModel = Assert.IsType<CommandAssistBarViewModel>(first.CommandAssistViewModel);
+        CommandAssistBarViewModel secondViewModel = Assert.IsType<CommandAssistBarViewModel>(second.CommandAssistViewModel);
+
+        Assert.NotSame(firstViewModel, secondViewModel);
+        Assert.True(firstViewModel.IsVisible);
+        Assert.True(secondViewModel.IsVisible);
+        Assert.True(firstViewModel.IsPopupOpen);
+        Assert.True(secondViewModel.IsPopupOpen);
+
+        // And they are independent: dismissing one leaves the other up, which is what "one pane of the
+        // split has no assist" would have looked like from the other direction.
+        Assert.True(first.TryHandleCommandAssistKey(Key.Escape, KeyModifiers.None));
+
+        Assert.False(firstViewModel.IsVisible);
+        Assert.True(secondViewModel.IsVisible);
     }
 
     // ------------------------------------------------------------ mark anchoring (V2 Phase 2a)
@@ -904,13 +1003,12 @@ public sealed class CommandAssistLayoutTests
         var suggestions = new ObservableCollection<CommandAssistSuggestionItemViewModel>
         {
             new(
-                SelectionGlyph: ">",
-                DisplayText: "git status",
-                DescriptionText: "Show working tree state.",
-                BadgesText: "History",
-                MetadataText: @"C:\repo",
-                IsSelected: true,
-                Type: AssistSuggestionType.History)
+                displayText: "git status",
+                descriptionText: "Show working tree state.",
+                badgesText: "History",
+                metadataText: @"C:\repo",
+                isSelected: true,
+                type: AssistSuggestionType.History)
         };
         var vm = new CommandAssistPopupViewModel(suggestions)
         {
@@ -944,13 +1042,12 @@ public sealed class CommandAssistLayoutTests
         var suggestions = new ObservableCollection<CommandAssistSuggestionItemViewModel>
         {
             new(
-                SelectionGlyph: ">",
-                DisplayText: "git status",
-                DescriptionText: "Show working tree state.",
-                BadgesText: "History",
-                MetadataText: @"C:\repo",
-                IsSelected: true,
-                Type: AssistSuggestionType.History)
+                displayText: "git status",
+                descriptionText: "Show working tree state.",
+                badgesText: "History",
+                metadataText: @"C:\repo",
+                isSelected: true,
+                type: AssistSuggestionType.History)
         };
         var vm = new CommandAssistPopupViewModel(suggestions)
         {

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistLayoutTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistLayoutTests.cs
@@ -502,16 +502,24 @@ public sealed class CommandAssistLayoutTests
     }
 
     /// <summary>
-    /// The other half of the third report, checked directly rather than through geometry: both panes of
-    /// a split get their own initialized controller off one shared services graph, and <c>Ctrl+R</c>
-    /// opens on the second one as readily as on the first.
+    /// The other half of the third report, checked directly rather than through geometry: two panes off
+    /// one shared services graph each get their own initialized controller, and <c>Ctrl+R</c> opens on
+    /// the second as readily as on the first.
     /// </summary>
     /// <remarks>
-    /// <c>MainWindow.WirePane</c> is the funnel that assigns <c>CommandAssistServices</c> to every pane
-    /// it creates, including the ones a split adds, so the injection itself is structural. What this
-    /// pins is that nothing in the pane's own initialization is single-instance: a second pane sharing
-    /// the same history store and snippet store must build a second controller and a second view-model
-    /// rather than finding the first one's state.
+    /// <para>
+    /// <strong>These are two standalone panes, not a split</strong> (PR #290 review, correcting an earlier
+    /// version of this comment that said "both panes of a split"). There is no <c>MainWindow</c>, no split
+    /// grid and no shared parent here - nothing about split *geometry* is under test, and the geometry
+    /// half of the report is covered by the short-pane suppression tests above.
+    /// </para>
+    /// <para>
+    /// What this does pin is the part a split would depend on: <c>MainWindow.WirePane</c> assigns
+    /// <c>CommandAssistServices</c> to every pane it creates, including the ones a split adds, so the
+    /// injection is structural - and nothing in a pane's own initialization may be single-instance. A
+    /// second pane sharing the same history store and snippet store must build a second controller and a
+    /// second view-model rather than finding the first one's state.
+    /// </para>
     /// </remarks>
     [AvaloniaFact]
     public void TwoPanesSharingOneServicesGraph_BothOpenTheirOwnHistorySearch()
@@ -995,6 +1003,182 @@ public sealed class CommandAssistLayoutTests
         Assert.True(view.IsVisible);
         Assert.Equal("Suggest", modeLabel.Text);
         Assert.Equal("git status", summary.Text);
+    }
+
+    // ------------------------- the hint strip may not squeeze the bubble (PR #290 review)
+
+    /// <summary>
+    /// 280 px is the bubble-width floor <c>CalculateCommandAssistSurfaceSizing</c> clamps to, which is
+    /// what a split SSH pane lands on. At that width the hint strip's <c>Auto</c> column beat the
+    /// summary's <c>*</c> column outright: the shortcut legend rendered in full and the suggestion - the
+    /// only content in the bubble anyone reads - got what was left, which was nothing.
+    /// </summary>
+    [AvaloniaFact]
+    public void CommandAssistBubbleView_AtTheNarrowBubbleFloor_CollapsingTheHintGivesTheSummaryItsWidth()
+    {
+        const double bubbleWidth = 280;
+
+        double squeezed = MeasureBubbleSummaryWidth(showShortcutHint: true, bubbleWidth);
+        double collapsed = MeasureBubbleSummaryWidth(showShortcutHint: false, bubbleWidth);
+
+        // 40% is the honest floor rather than a round half: the mode label and the column spacing are
+        // real content too, and at 280 px they are most of the rest of the bubble.
+        Assert.True(
+            collapsed >= bubbleWidth * 0.4,
+            $"With the hint collapsed the summary should keep a usable share of the bubble, but had " +
+            $"{collapsed:F0} of {bubbleWidth:F0} (with the hint shown: {squeezed:F0}).");
+        Assert.True(
+            squeezed < collapsed * 0.5,
+            $"The negative control failed: the hint must actually be what squeezes the summary, but it " +
+            $"had {squeezed:F0} px with the hint shown against {collapsed:F0} px without it. Either the " +
+            "layout changed or this test no longer measures the reported bug.");
+    }
+
+    /// <summary>
+    /// And the collapse is driven by the same compact-layout decision that already hides the query
+    /// echo, from the real placement path on a real narrow pane.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task TerminalPane_WhenTheBubbleIsNarrow_CollapsesTheShortcutHint()
+    {
+        using var pane = new TerminalPane
+        {
+            Width = 420,
+            Height = 420
+        };
+        ConfigureCommandAssist(pane);
+        pane.Measure(new Size(420, 420));
+        pane.Arrange(new Rect(0, 0, 420, 420));
+        await AtAnIntegratedPromptAsync(pane, "Get-ChildItem");
+        pane.OpenCommandAssistHelp();
+        await Task.Delay(50);
+        pane.Measure(new Size(420, 420));
+        pane.Arrange(new Rect(0, 0, 420, 420));
+
+        CommandAssistAnchorLayout layout = Assert.IsType<CommandAssistAnchorLayout>(pane.CalculateCommandAssistAnchorLayoutForTest());
+        CommandAssistBarViewModel vm = Assert.IsType<CommandAssistBarViewModel>(pane.CommandAssistViewModel);
+
+        Assert.True(layout.UseCompactBubbleLayout);
+        Assert.Equal(280, layout.BubbleRect.Width, precision: 1);
+        Assert.False(vm.Bubble.ShowShortcutHint);
+        Assert.False(vm.Bubble.ShowQueryText);
+    }
+
+    /// <summary>
+    /// The control: a pane with room keeps the hint, or the assertion above would be satisfied by a hint
+    /// that never renders anywhere.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task TerminalPane_WhenTheBubbleHasRoom_KeepsTheShortcutHint()
+    {
+        using var pane = new TerminalPane
+        {
+            Width = 900,
+            Height = 500
+        };
+        ConfigureCommandAssist(pane);
+        pane.Measure(new Size(900, 500));
+        pane.Arrange(new Rect(0, 0, 900, 500));
+        await AtAnIntegratedPromptAsync(pane, "Get-ChildItem");
+        pane.OpenCommandAssistHelp();
+        await Task.Delay(50);
+        pane.Measure(new Size(900, 500));
+        pane.Arrange(new Rect(0, 0, 900, 500));
+
+        CommandAssistAnchorLayout layout = Assert.IsType<CommandAssistAnchorLayout>(pane.CalculateCommandAssistAnchorLayoutForTest());
+        CommandAssistBarViewModel vm = Assert.IsType<CommandAssistBarViewModel>(pane.CommandAssistViewModel);
+
+        Assert.False(layout.UseCompactBubbleLayout);
+        Assert.True(vm.Bubble.ShowShortcutHint);
+    }
+
+    /// <summary>
+    /// The pass-through property, pinned (PR #290 review): the overlay host paints no background, so a
+    /// click anywhere except on a child reaches the terminal underneath, and the bubble - a status
+    /// readout with nothing to click, sitting right over the row the user selects text on - opts out of
+    /// hit testing individually.
+    /// </summary>
+    /// <remarks>
+    /// The host's own <c>IsHitTestVisible</c> is asserted <em>true</em> deliberately. It was false once,
+    /// which excludes the whole subtree: no click could reach a popup row, and a child cannot opt back
+    /// into hit testing its parent has switched off. Both halves have to stay as they are.
+    /// </remarks>
+    [AvaloniaFact]
+    public void TerminalPane_OverlayHostPassesClicksThroughAndTheBubbleTakesNone()
+    {
+        using var pane = new TerminalPane();
+        ConfigureCommandAssist(pane);
+
+        Grid overlayHost = Assert.IsType<Grid>(pane.FindControl<Grid>("CommandAssistOverlayHost"));
+        CommandAssistBubbleView bubbleView = Assert.IsType<CommandAssistBubbleView>(pane.FindControl<CommandAssistBubbleView>("CommandAssistBubble"));
+        CommandAssistPopupView popupView = Assert.IsType<CommandAssistPopupView>(pane.FindControl<CommandAssistPopupView>("CommandAssistPopup"));
+
+        Assert.Null(overlayHost.Background);
+        Assert.True(overlayHost.IsHitTestVisible);
+        Assert.False(bubbleView.IsHitTestVisible);
+        Assert.True(popupView.IsHitTestVisible);
+    }
+
+    /// <summary>
+    /// Right- and middle-clicks on the popup are swallowed rather than left to bubble into the pane,
+    /// where they would open the pane context menu over the list or paste into the shell beneath it.
+    /// </summary>
+    [Fact]
+    public void CommandAssistPopupView_SwallowsRightAndMiddleClicksOnly()
+    {
+        Assert.True(CommandAssistPopupView.IsSwallowedPointerButton(isRightButtonPressed: true, isMiddleButtonPressed: false));
+        Assert.True(CommandAssistPopupView.IsSwallowedPointerButton(isRightButtonPressed: false, isMiddleButtonPressed: true));
+        Assert.False(CommandAssistPopupView.IsSwallowedPointerButton(isRightButtonPressed: false, isMiddleButtonPressed: false));
+    }
+
+    /// <summary>
+    /// Arranges a bubble at <paramref name="width"/> and returns the arranged width of the summary
+    /// TextBlock - the <c>*</c> column's share of it.
+    /// </summary>
+    private static double MeasureBubbleSummaryWidth(bool showShortcutHint, double width)
+    {
+        var vm = new CommandAssistBubbleViewModel
+        {
+            IsVisible = true,
+            ModeLabel = "Suggest",
+            QueryText = "git st",
+            SummaryText = "git status --short --branch",
+            ShortcutHintText = CommandAssistBarViewModel.IdleHintText,
+
+            // Compact layout hides both, and the query echo is not what this measures.
+            ShowQueryText = false,
+            ShowShortcutHint = showShortcutHint
+        };
+        var view = new CommandAssistBubbleView
+        {
+            DataContext = vm,
+            Width = width,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top
+        };
+
+        // Hosted in a window rather than measured detached: the bubble's content lives behind a
+        // ContentPresenter, which only realizes its child during a layout pass from a visual root. A
+        // detached Measure/Arrange leaves every child at zero bounds, which would make this pass for the
+        // wrong reason.
+        var window = new Window
+        {
+            Content = view,
+            Width = width + 120,
+            Height = 200
+        };
+        try
+        {
+            window.Show();
+            RelayoutTo(window, view, new Size(width + 120, 200));
+
+            TextBlock summary = Assert.IsType<TextBlock>(view.FindControl<TextBlock>("BubbleSummaryText"));
+            return summary.Bounds.Width;
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     [AvaloniaFact]

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistSuggestionEngineTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistSuggestionEngineTests.cs
@@ -507,6 +507,75 @@ public sealed class CommandAssistSuggestionEngineTests
         Assert.Equal(AssistSuggestionType.Snippet, results[0].Type);
     }
 
+    /// <summary>
+    /// The PR #290 review's third blocker, and the decision it forced: an unpinned snippet sits in the
+    /// same-profile band on the empty-query path - above every cross-context history row, below the rows
+    /// this pane's own context produced.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The numbers are asserted rather than described because the band is the whole point: 50 local rows
+    /// score ~1202 each (1 + frequency + 1000 context + 200 profile), the snippet 202, and the row from
+    /// another host 2. So the snippet lands at index 50, immediately after the local rows and
+    /// immediately before the foreign one. Under the <c>+8</c> nudge this replaced it scored 10 and lost
+    /// to nothing except that foreign row - which is the state the review found.
+    /// </para>
+    /// <para>
+    /// <c>maxResults: 60</c> is deliberate and is the honest part of this decision: with a display cap
+    /// below the number of same-context rows, an unpinned snippet is below the fold. Pinning is the
+    /// answer to that (<c>GetSuggestions_WithNoQuery_KeepsPinnedSnippetsAboveContextMatchedHistory</c>),
+    /// and the test says so rather than choosing a cap that hides the trade-off.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void GetSuggestions_WithNoQuery_RanksUnpinnedSnippetsBelowThisContextsHistoryAndAboveTheRest()
+    {
+        var engine = new CommandAssistSuggestionEngine(new FakePathSuggestionProvider(Array.Empty<AssistSuggestion>()));
+        var context = new CommandAssistQueryContext(
+            Input: string.Empty,
+            WorkingDirectory: @"C:\repo",
+            ShellKind: "pwsh",
+            ProfileId: "profile-1");
+
+        List<CommandHistoryEntry> history = Enumerable.Range(0, 50)
+            .Select(i => CreateEntry(
+                $"dotnet build --project p{i}",
+                executedAt: DateTimeOffset.Parse("2026-03-01T12:00:00+00:00").AddMinutes(i)))
+            .ToList();
+        history.Add(CreateRemoteEntry("apt update", "other.example", DateTimeOffset.Parse("2026-03-01T13:00:00+00:00")));
+
+        var snippets = new[]
+        {
+            CreateSnippet("Deploy", "./deploy.sh --prod", isPinned: false)
+        };
+
+        IReadOnlyList<AssistSuggestion> results = engine.GetSuggestions(history, snippets, context, maxResults: 60);
+
+        int snippetIndex = IndexOfDisplayText(results, "Deploy");
+        int foreignIndex = IndexOfDisplayText(results, "apt update");
+
+        Assert.Equal(52, results.Count);
+        Assert.Equal(50, snippetIndex);
+        Assert.Equal(51, foreignIndex);
+        Assert.All(
+            results.Take(snippetIndex),
+            row => Assert.Equal(AssistSuggestionType.History, row.Type));
+    }
+
+    private static int IndexOfDisplayText(IReadOnlyList<AssistSuggestion> results, string displayText)
+    {
+        for (int i = 0; i < results.Count; i++)
+        {
+            if (string.Equals(results[i].DisplayText, displayText, StringComparison.Ordinal))
+            {
+                return i;
+            }
+        }
+
+        Assert.Fail($"'{displayText}' is not in the list at all: [{string.Join(", ", results.Select(x => x.DisplayText))}]");
+        return -1;
+    }
+
     private static CommandHistoryEntry CreateRemoteEntry(
         string commandText,
         string hostId,

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistSuggestionEngineTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistSuggestionEngineTests.cs
@@ -297,6 +297,237 @@ public sealed class CommandAssistSuggestionEngineTests
         Assert.All(results, suggestion => Assert.NotEqual(AssistSuggestionType.Path, suggestion.Type));
     }
 
+    // ------------------------------------------- context-scoped ranking (V2 Phase 3a)
+    //
+    // The owner's second report: "the list shows commands from all sessions/tabs indiscriminately".
+    // The fix is an ordering rule, not a filter - a command run somewhere else is still in the list,
+    // below the entries from here, because reaching for a command you remember running on another box
+    // is the reason a shared history exists at all.
+
+    /// <summary>
+    /// <c>Ctrl+R</c> on an SSH pane: this host's commands come first, and the local ones are still
+    /// there afterwards.
+    /// </summary>
+    [Fact]
+    public void GetSuggestions_WithNoQueryOnARemotePane_RanksThisHostsCommandsFirst()
+    {
+        var engine = new CommandAssistSuggestionEngine(new FakePathSuggestionProvider(Array.Empty<AssistSuggestion>()));
+        var context = new CommandAssistQueryContext(
+            Input: string.Empty,
+            WorkingDirectory: "/home/nova",
+            ShellKind: "bash",
+            ProfileId: "profile-ssh",
+            IsRemote: true,
+            HostId: "ubuntu.example");
+
+        // The local entry is the most recent, so pure recency (the pre-Phase-3a rule) puts it first.
+        var history = new[]
+        {
+            CreateEntry("dotnet build", executedAt: DateTimeOffset.Parse("2026-03-01T12:00:00+00:00")),
+            CreateRemoteEntry("systemctl status nova", "ubuntu.example", DateTimeOffset.Parse("2026-03-01T11:00:00+00:00")),
+            CreateRemoteEntry("journalctl -u nova", "other.example", DateTimeOffset.Parse("2026-03-01T11:30:00+00:00"))
+        };
+
+        IReadOnlyList<AssistSuggestion> results = engine.GetSuggestions(history, context, maxResults: 10);
+
+        Assert.Equal("systemctl status nova", results[0].DisplayText);
+        Assert.Contains(results, item => item.DisplayText == "dotnet build");
+        Assert.Contains(results, item => item.DisplayText == "journalctl -u nova");
+    }
+
+    /// <summary>
+    /// The same rule on a local pane, where "here" means "not on somebody else's machine": there is no
+    /// local host id to compare, so localness is the context.
+    /// </summary>
+    [Fact]
+    public void GetSuggestions_WithNoQueryOnALocalPane_RanksLocalCommandsFirst()
+    {
+        var engine = new CommandAssistSuggestionEngine(new FakePathSuggestionProvider(Array.Empty<AssistSuggestion>()));
+        var context = new CommandAssistQueryContext(
+            Input: string.Empty,
+            WorkingDirectory: @"C:\repo",
+            ShellKind: "pwsh",
+            ProfileId: "profile-1");
+
+        var history = new[]
+        {
+            CreateRemoteEntry("apt install ripgrep", "ubuntu.example", DateTimeOffset.Parse("2026-03-01T12:00:00+00:00")),
+            CreateEntry("dotnet build", executedAt: DateTimeOffset.Parse("2026-03-01T11:00:00+00:00"))
+        };
+
+        IReadOnlyList<AssistSuggestion> results = engine.GetSuggestions(history, context, maxResults: 10);
+
+        Assert.Equal("dotnet build", results[0].DisplayText);
+        Assert.Contains(results, item => item.DisplayText == "apt install ripgrep");
+    }
+
+    /// <summary>
+    /// Two remote hosts, one pane. Another host's entries rank below this host's - which is the case
+    /// the owner actually hit, since a single global recency list is dominated by whichever pane ran a
+    /// command last.
+    /// </summary>
+    [Fact]
+    public void GetSuggestions_WithNoQueryOnARemotePane_RanksOtherHostsBelowThisOne()
+    {
+        var engine = new CommandAssistSuggestionEngine(new FakePathSuggestionProvider(Array.Empty<AssistSuggestion>()));
+        var context = new CommandAssistQueryContext(
+            Input: string.Empty,
+            WorkingDirectory: "/home/nova",
+            ShellKind: "bash",
+            ProfileId: "profile-ssh",
+            IsRemote: true,
+            HostId: "ubuntu.example");
+
+        var history = new[]
+        {
+            CreateRemoteEntry("uptime", "other.example", DateTimeOffset.Parse("2026-03-01T12:00:00+00:00")),
+            CreateRemoteEntry("df -h", "ubuntu.example", DateTimeOffset.Parse("2026-03-01T09:00:00+00:00"))
+        };
+
+        IReadOnlyList<AssistSuggestion> results = engine.GetSuggestions(history, context, maxResults: 10);
+
+        Assert.Equal("df -h", results[0].DisplayText);
+        Assert.Equal("uptime", results[1].DisplayText);
+    }
+
+    /// <summary>
+    /// An SSH profile whose host is not yet known must not match everything. An unknown context is not
+    /// a context, and the fallback is the pre-Phase-3a recency order.
+    /// </summary>
+    [Fact]
+    public void GetSuggestions_OnARemotePaneWithNoHostId_AppliesNoContextBoost()
+    {
+        var engine = new CommandAssistSuggestionEngine(new FakePathSuggestionProvider(Array.Empty<AssistSuggestion>()));
+        var context = new CommandAssistQueryContext(
+            Input: string.Empty,
+            WorkingDirectory: "/home/nova",
+            ShellKind: "bash",
+
+            // Null so that the profile term cannot stand in for the host term this test is about.
+            ProfileId: null,
+            IsRemote: true,
+            HostId: null);
+
+        var history = new[]
+        {
+            CreateEntry("dotnet build", executedAt: DateTimeOffset.Parse("2026-03-01T12:00:00+00:00")),
+            CreateRemoteEntry("df -h", "ubuntu.example", DateTimeOffset.Parse("2026-03-01T11:00:00+00:00"))
+        };
+
+        IReadOnlyList<AssistSuggestion> results = engine.GetSuggestions(history, context, maxResults: 10);
+
+        Assert.Equal("dotnet build", results[0].DisplayText);
+    }
+
+    /// <summary>
+    /// The text-query path gets a host boost alongside the existing profile boost, sized as a nudge:
+    /// with equally good text matches the same-host row wins.
+    /// </summary>
+    [Fact]
+    public void GetSuggestions_WithATextQueryOnARemotePane_PrefersTheSameHostAmongEqualMatches()
+    {
+        var engine = new CommandAssistSuggestionEngine(new FakePathSuggestionProvider(Array.Empty<AssistSuggestion>()));
+        var context = new CommandAssistQueryContext(
+            Input: "systemctl s",
+            WorkingDirectory: "/home/nova",
+            ShellKind: "bash",
+            ProfileId: null,
+            IsRemote: true,
+            HostId: "ubuntu.example");
+
+        var history = new[]
+        {
+            CreateRemoteEntry("systemctl start nova", "other.example", DateTimeOffset.Parse("2026-03-01T12:00:00+00:00")),
+            CreateRemoteEntry("systemctl status nova", "ubuntu.example", DateTimeOffset.Parse("2026-03-01T09:00:00+00:00"))
+        };
+
+        IReadOnlyList<AssistSuggestion> results = engine.GetSuggestions(history, context, maxResults: 10);
+
+        Assert.Equal("systemctl status nova", results[0].DisplayText);
+        Assert.Equal("systemctl start nova", results[1].DisplayText);
+    }
+
+    /// <summary>
+    /// And the nudge must stay a nudge: a same-host row that matches the query worse than a local row
+    /// still loses. A partition here would read as the list ignoring what the user typed.
+    /// </summary>
+    [Fact]
+    public void GetSuggestions_WithATextQuery_DoesNotLetTheContextBoostBeatABetterTextMatch()
+    {
+        var engine = new CommandAssistSuggestionEngine(new FakePathSuggestionProvider(Array.Empty<AssistSuggestion>()));
+        var context = new CommandAssistQueryContext(
+            Input: "git st",
+            WorkingDirectory: "/home/nova",
+            ShellKind: "bash",
+            ProfileId: null,
+            IsRemote: true,
+            HostId: "ubuntu.example");
+
+        var history = new[]
+        {
+            // Prefix match (120) locally...
+            CreateEntry("git status", executedAt: DateTimeOffset.Parse("2026-03-01T09:00:00+00:00")),
+
+            // ...against a mere subsequence match (12) plus the host boost (30) on this host.
+            CreateRemoteEntry("grep -r it standalone", "ubuntu.example", DateTimeOffset.Parse("2026-03-01T12:00:00+00:00"))
+        };
+
+        IReadOnlyList<AssistSuggestion> results = engine.GetSuggestions(history, context, maxResults: 10);
+
+        Assert.Equal("git status", results[0].DisplayText);
+    }
+
+    /// <summary>
+    /// Pinned snippets keep their place at the top of an empty-query list. They have no host or
+    /// remoteness to compare, and pinning already means "in scope everywhere", so they share the
+    /// context band rather than being pushed below every same-host history row.
+    /// </summary>
+    [Fact]
+    public void GetSuggestions_WithNoQuery_KeepsPinnedSnippetsAboveContextMatchedHistory()
+    {
+        var engine = new CommandAssistSuggestionEngine(new FakePathSuggestionProvider(Array.Empty<AssistSuggestion>()));
+        var context = new CommandAssistQueryContext(
+            Input: string.Empty,
+            WorkingDirectory: @"C:\repo",
+            ShellKind: "pwsh",
+            ProfileId: "profile-1");
+
+        var history = new[]
+        {
+            CreateEntry("dotnet build", executedAt: DateTimeOffset.Parse("2026-03-01T12:00:00+00:00"))
+        };
+
+        var snippets = new[]
+        {
+            CreateSnippet("Deploy", "./deploy.sh --prod", isPinned: true)
+        };
+
+        IReadOnlyList<AssistSuggestion> results = engine.GetSuggestions(history, snippets, context, maxResults: 10);
+
+        Assert.Equal(AssistSuggestionType.Snippet, results[0].Type);
+    }
+
+    private static CommandHistoryEntry CreateRemoteEntry(
+        string commandText,
+        string hostId,
+        DateTimeOffset executedAt)
+    {
+        return new CommandHistoryEntry(
+            Id: Guid.NewGuid().ToString("N"),
+            CommandText: commandText,
+            ExecutedAt: executedAt,
+            ShellKind: "bash",
+            WorkingDirectory: "/home/nova",
+            ProfileId: "profile-ssh",
+            SessionId: "session-ssh",
+            HostId: hostId,
+            ExitCode: 0,
+            IsRemote: true,
+            IsRedacted: false,
+            Source: CommandCaptureSource.ShellIntegration,
+            DurationMs: null);
+    }
+
     private static CommandHistoryEntry CreateEntry(
         string commandText,
         string? profileId = "profile-1",

--- a/tests/NovaTerminal.App.Tests/Controls/PaneAssistInsertionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneAssistInsertionTests.cs
@@ -1,4 +1,6 @@
 using System.Reflection;
+using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
 using NovaTerminal.CommandAssist.Models;
@@ -132,6 +134,87 @@ public class PaneAssistInsertionTests
         Assert.False(fixture.PressEnter());
         Assert.Empty(fixture.Session.Sent);
         Assert.True(fixture.ViewModel.IsVisible);
+    }
+
+    // -------------------- an unrendered overlay owns nothing (PR #290 review)
+
+    /// <summary>
+    /// The first blocker, end to end. The session is in the browse state that arms <c>Enter</c>, and then
+    /// the pane's own placement-correction stack drops the overlay to zero opacity - which it does for up
+    /// to six render passes on a markless SSH pane, and which a passive popup does not get a bypass from.
+    /// An armed <c>Enter</c> there means the user's command line silently fails to submit while nothing
+    /// is on screen to explain why.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task WhenTheOverlayIsNotRendered_PlainEnterFallsThroughToTheShell()
+    {
+        using var fixture = await Fixture.AtAnIntegratedPromptAsync("git st", history: "git status");
+        Assert.True(fixture.PressDown());
+
+        // The control: the surface is up, so this is the state that would have inserted.
+        Assert.True(fixture.IsOverlayRendered);
+        Assert.True(fixture.ViewModel.IsPopupOpen);
+        Assert.True(fixture.ViewModel.IsAcceptOnEnterArmed);
+
+        fixture.DimOverlayLikeAPlacementCorrection();
+
+        Assert.False(fixture.IsOverlayRendered);
+        Assert.False(fixture.PressEnter());
+        Assert.Empty(fixture.Session.Sent);
+
+        // Hidden, not dismissed: the row is still selected and Ctrl+Enter - which never depended on the
+        // surface being legible - still works, so this refuses the ambiguous key only.
+        Assert.True(fixture.ViewModel.IsPopupOpen);
+        fixture.PressCtrlEnter();
+        Assert.Equal("atus", Assert.Single(fixture.Session.Sent));
+    }
+
+    // ------------------ Up is the shell's while typing (PR #290 review)
+
+    /// <summary>
+    /// The second blocker, as the exact sequence reported: type at a prompt with a passive bubble up,
+    /// press <c>Up</c> for the previous command, press <c>Enter</c> to run it. <c>Up</c> must reach the
+    /// shell, the popup must stay closed, and <c>Enter</c> must reach the shell too.
+    /// </summary>
+    /// <remarks>
+    /// Before the fix all three failed together: <c>Up</c> was assist-owned whenever any surface was
+    /// visible, <c>MoveSelectionUp</c>'s clamp-to-zero opened the popup as a side effect of selecting row
+    /// 0, and the resulting browse state armed <c>Enter</c> - so the key pressed for history recall built
+    /// the surface that swallowed the submission.
+    /// </remarks>
+    [AvaloniaFact]
+    public async Task WithAPassiveBubbleUp_UpAndEnterBothReachTheShell()
+    {
+        using var fixture = await Fixture.AtAPassivePathBubbleAsync();
+
+        Assert.True(fixture.ViewModel.IsVisible);
+        Assert.True(fixture.IsOverlayRendered);
+        Assert.False(fixture.ViewModel.IsPopupOpen);
+
+        Assert.False(fixture.PressUp());
+
+        Assert.False(fixture.ViewModel.IsPopupOpen);
+        Assert.False(fixture.ViewModel.IsAcceptOnEnterArmed);
+        Assert.False(fixture.PressEnter());
+        Assert.Empty(fixture.Session.Sent);
+    }
+
+    /// <summary>
+    /// And <c>Down</c> is the way in from that same state: it opens the list, after which <c>Enter</c>
+    /// inserts. Without this the test above would be satisfied by a passive bubble that owns no keys at
+    /// all, which is not the model - browsing while typing is the feature.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task WithAPassiveBubbleUp_DownOpensTheListAndThenEnterInserts()
+    {
+        using var fixture = await Fixture.AtAPassivePathBubbleAsync();
+
+        Assert.True(fixture.PressDown());
+
+        Assert.True(fixture.ViewModel.IsPopupOpen);
+        Assert.True(fixture.ViewModel.IsAcceptOnEnterArmed);
+        Assert.True(fixture.PressEnter());
+        Assert.NotEmpty(fixture.Session.Sent);
     }
 
     // -------------------------------------- degraded-session insertion (V2 Phase 3a)
@@ -323,6 +406,51 @@ public class PaneAssistInsertionTests
             return fixture;
         }
 
+        /// <summary>
+        /// The passive typing bubble: an instrumented prompt reading <c>cd ./d</c>, a real directory with
+        /// two matching entries in it, and no explicit session anywhere.
+        /// </summary>
+        /// <remarks>
+        /// Paths rather than history, because that is the only source a passive Suggest session is scoped
+        /// to (<c>SuggestionOrchestrator.ResolveScope</c>: unasked-for history rows were the noisiest part
+        /// of V1). Every other fixture here calls <c>ToggleCommandAssist</c> or <c>Ctrl+R</c>, which puts
+        /// the session in an <em>explicit</em> state where both arrows are assist-owned - so a fixture
+        /// that never asks for anything is what the PR #290 review's <c>Up</c> rule needs.
+        /// </remarks>
+        public static async Task<Fixture> AtAPassivePathBubbleAsync()
+        {
+            Fixture fixture = await CreateAsync(history: "git status");
+            Directory.CreateDirectory(Path.Combine(fixture._directory, "docs"));
+            Directory.CreateDirectory(Path.Combine(fixture._directory, "deploy"));
+            fixture.Pane.HandleWorkingDirectoryChangedForTest(fixture._directory);
+
+            fixture.Pane.ArmShellIntegrationTracker();
+            fixture.Pane.CreateAndWireParser();
+            fixture.Pane.Parser!.Process(PromptStart + "$ " + PromptEnd + "cd ./d");
+            await Task.Delay(50);
+
+            // A trigger, not content: the grid above is the query. The echo flag it sets is cleared
+            // straight away, because "bytes in flight" is a different refusal and not the one under test.
+            fixture.Pane.NotifyTypedTextObserved("d");
+            fixture.Pane.NoteSessionOutputApplied();
+
+            await fixture.WaitForAsync(() => fixture.ViewModel.Suggestions.Count > 1);
+            return fixture;
+        }
+
+        /// <summary>Whether the overlay this pane hosts is actually on screen.</summary>
+        public bool IsOverlayRendered => Pane.IsCommandAssistOverlayRendered;
+
+        /// <summary>
+        /// Leaves the overlay in the state a placement-correction pass leaves it in: hosted, believed
+        /// visible by the session, and rendering at zero opacity.
+        /// </summary>
+        public void DimOverlayLikeAPlacementCorrection()
+        {
+            Grid host = Assert.IsType<Grid>(Pane.FindControl<Grid>("CommandAssistOverlayHost"));
+            host.Opacity = 0.0;
+        }
+
         public void PressCtrlEnter() =>
             Pane.TryHandleCommandAssistKey(Key.Enter, KeyModifiers.Control);
 
@@ -332,6 +460,9 @@ public class PaneAssistInsertionTests
 
         public bool PressDown() =>
             Pane.TryHandleCommandAssistKey(Key.Down, KeyModifiers.None);
+
+        public bool PressUp() =>
+            Pane.TryHandleCommandAssistKey(Key.Up, KeyModifiers.None);
 
         public void Dispose()
         {
@@ -379,12 +510,22 @@ public class PaneAssistInsertionTests
                 Source: CommandCaptureSource.Heuristic,
                 DurationMs: null));
 
-            var pane = new TerminalPane();
+            // Laid out, not bare. The pane hides its own overlay host when it has no layout to place, and
+            // since the PR #290 review an unrendered overlay may not own Enter - so a pane that was never
+            // measured is a pane where the accept path is unreachable, and every Enter test here would be
+            // asserting the refusal rather than the insertion.
+            var pane = new TerminalPane
+            {
+                Width = 900,
+                Height = 500
+            };
             pane.CommandAssistServices = services;
             var settings = new TerminalSettings(); // constructed, not Load() - see #232
             settings.CommandAssistEnabled = true;
             settings.CommandAssistHistoryEnabled = true;
             pane.ApplySettings(settings);
+            pane.Measure(new Size(900, 500));
+            pane.Arrange(new Rect(0, 0, 900, 500));
 
             var session = new RecordingSession();
             typeof(TerminalPane)

--- a/tests/NovaTerminal.App.Tests/Controls/PaneAssistInsertionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneAssistInsertionTests.cs
@@ -79,27 +79,201 @@ public class PaneAssistInsertionTests
         Assert.False(fixture.ViewModel.IsVisible);
     }
 
+    // ------------------------------------------------- accept on Enter (V2 Phase 3a)
+
     /// <summary>
-    /// Destructive refusal. In a degraded session there is no snapshot, so the planner refuses -
-    /// but the pane used to call <c>TryAcceptSelection</c> (which accepts <em>and</em> dismisses)
-    /// before asking it, so the refusal arrived after the list was already gone. From the user's
-    /// side that is <c>Ctrl+Enter</c> silently deleting the thing they were browsing and sending
-    /// nothing: indistinguishable from a broken feature. The plan is computed from the
-    /// non-mutating read first; the surface is only touched once there is text to send.
+    /// The owner's first report, end to end through the real pane: browse to a row, press
+    /// <c>Enter</c>, and the suffix is sent. Before this, <c>Enter</c> went to the shell, submitted
+    /// the line and dismissed the popup on the way out - "lists history but does no action when I
+    /// select".
     /// </summary>
     [AvaloniaFact]
-    public async Task InADegradedSession_CtrlEnterRefusesWithoutTearingTheListDown()
+    public async Task WhenBrowsingARow_PlainEnterInsertsInsteadOfSubmitting()
+    {
+        using var fixture = await Fixture.AtAnIntegratedPromptAsync("git st", history: "git status");
+
+        // Down opens the popup over the bubble and selects a row: the browse state that owns Enter.
+        Assert.True(fixture.PressDown());
+
+        Assert.True(fixture.PressEnter());
+        Assert.Equal("atus", Assert.Single(fixture.Session.Sent));
+    }
+
+    /// <summary>
+    /// The typing flow, which the keyboard change must leave alone. With only the bubble up - no popup,
+    /// no browse - <c>Enter</c> is not consumed, so it reaches the shell and submits the command the
+    /// user typed.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task WhenOnlyTheBubbleIsUp_PlainEnterIsLeftToTheShell()
+    {
+        using var fixture = await Fixture.AtAnIntegratedPromptAsync("git st", history: "git status");
+
+        Assert.False(fixture.ViewModel.IsPopupOpen);
+
+        Assert.False(fixture.PressEnter());
+        Assert.Empty(fixture.Session.Sent);
+    }
+
+    /// <summary>
+    /// A refused insertion must not eat the key either. <c>Enter</c> is routed to the assist while
+    /// browsing, but if the insertion cannot be planned the pane returns false so the shell still gets
+    /// its Enter - a dead key would be a worse answer than the pre-Phase-3a behavior.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task WhenBrowsingButInsertionIsRefused_EnterFallsThroughToTheShell()
+    {
+        using var fixture = await Fixture.AtAnIntegratedPromptAsync("git st", history: "git status");
+        Assert.True(fixture.PressDown());
+
+        // The echo race: bytes are in flight, so no insertion may be planned.
+        fixture.Pane.NoteInputAwaitingEcho();
+
+        Assert.False(fixture.PressEnter());
+        Assert.Empty(fixture.Session.Sent);
+        Assert.True(fixture.ViewModel.IsVisible);
+    }
+
+    // -------------------------------------- degraded-session insertion (V2 Phase 3a)
+
+    /// <summary>
+    /// The narrowing of the Phase 1c "browse-only in degraded sessions" rule, and the owner's report
+    /// it answers: <c>Ctrl+R</c> on a markless pane listed history and nothing could be done with it.
+    /// </summary>
+    /// <remarks>
+    /// There is still no grid snapshot here. What changed is that "no snapshot" stopped meaning "the
+    /// prefix is unknown" in the one case where the pane can prove otherwise: the markless accumulator
+    /// was reset by the last Enter and has observed nothing since, so the line is empty and the whole
+    /// command may be sent. See <c>TerminalPane.TryReadInsertionQuerySnapshot</c>.
+    /// </remarks>
+    [AvaloniaFact]
+    public async Task InADegradedSessionWithAProvablyEmptyLine_CtrlEnterSendsTheWholeCommand()
     {
         using var fixture = await Fixture.DegradedAtAHistorySearchAsync(history: "git status");
 
-        Assert.True(fixture.ViewModel.IsVisible);
-        Assert.True(fixture.ViewModel.HasSuggestions);
+        fixture.PressCtrlEnter();
+
+        Assert.Equal("git status", Assert.Single(fixture.Session.Sent));
+    }
+
+    /// <summary>The same, through the new Enter path rather than <c>Ctrl+Enter</c>.</summary>
+    [AvaloniaFact]
+    public async Task InADegradedSessionWithAProvablyEmptyLine_EnterOnASelectionSendsTheWholeCommand()
+    {
+        using var fixture = await Fixture.DegradedAtAHistorySearchAsync(history: "git status");
+
+        Assert.True(fixture.PressDown());
+
+        Assert.True(fixture.PressEnter());
+        Assert.Equal("git status", Assert.Single(fixture.Session.Sent));
+    }
+
+    /// <summary>
+    /// The gate's first half. The user typed two characters and then opened history: the line is no
+    /// longer empty, the pane cannot see what is on it, and appending a whole command to it is how
+    /// <c>gigit status</c> happens. Refuse - and, as before, without tearing the list down.
+    /// </summary>
+    /// <remarks>
+    /// The echo flag is cleared deliberately. Typing sets it, and it would refuse on its own; clearing
+    /// it leaves the accumulator's "not empty" as the only reason this refuses, which is the property
+    /// under test.
+    /// </remarks>
+    [AvaloniaFact]
+    public async Task InADegradedSessionAfterTyping_CtrlEnterRefusesWithoutTearingTheListDown()
+    {
+        using var fixture = await Fixture.DegradedAtAHistorySearchAsync(history: "git status");
+
+        fixture.Pane.NotifyTypedTextObserved("gi");
+        fixture.Pane.NoteSessionOutputApplied();
 
         fixture.PressCtrlEnter();
 
         Assert.Empty(fixture.Session.Sent);
         Assert.True(fixture.ViewModel.IsVisible);
         Assert.True(fixture.ViewModel.HasSuggestions);
+    }
+
+    /// <summary>
+    /// The gate's second half. <c>Home</c> is not an assist-owned key and is not one the accumulator can
+    /// model, so it poisons: the accumulator's buffer is still empty but its answer is now "I cannot say
+    /// what is on this line", and an empty buffer must not be read as an empty line.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task InADegradedSessionWithAPoisonedLine_CtrlEnterRefuses()
+    {
+        using var fixture = await Fixture.DegradedAtAHistorySearchAsync(history: "git status");
+
+        Assert.False(fixture.Pane.TryHandleCommandAssistKey(Key.Home, KeyModifiers.None));
+
+        fixture.PressCtrlEnter();
+
+        Assert.Empty(fixture.Session.Sent);
+        Assert.True(fixture.ViewModel.IsVisible);
+        Assert.True(fixture.ViewModel.HasSuggestions);
+    }
+
+    /// <summary>
+    /// The gate's third half: the echo race applies to the degraded path too. A keystroke the shell has
+    /// not echoed means the pane's belief about the line is behind the shell's, whatever the accumulator
+    /// says.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task InADegradedSessionWithUnechoedInput_CtrlEnterRefuses()
+    {
+        using var fixture = await Fixture.DegradedAtAHistorySearchAsync(history: "git status");
+
+        fixture.Pane.NoteInputAwaitingEcho();
+
+        fixture.PressCtrlEnter();
+
+        Assert.Empty(fixture.Session.Sent);
+        Assert.True(fixture.ViewModel.IsVisible);
+    }
+
+    // ---------------------------------------------------------------- mouse (V2 Phase 3a)
+
+    /// <summary>
+    /// A single click selects the row it landed on and nothing more - browsing with the mouse must not
+    /// commit an edit to the command line.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task PointerSelect_SelectsTheRowWithoutSendingAnything()
+    {
+        using var fixture = await Fixture.AtAnIntegratedPromptAsync("git st", history: "git status");
+
+        fixture.Pane.OnCommandAssistSuggestionPointerSelected(0);
+
+        Assert.True(fixture.ViewModel.IsPopupOpen);
+        Assert.Equal(0, fixture.ViewModel.SelectedIndex);
+        Assert.Empty(fixture.Session.Sent);
+    }
+
+    /// <summary>
+    /// A double click - or a click on the already-selected row - runs the same insertion path
+    /// <c>Ctrl+Enter</c> does, gate for gate.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task PointerAccept_RunsTheSameInsertionPathAsCtrlEnter()
+    {
+        using var fixture = await Fixture.AtAnIntegratedPromptAsync("git st", history: "git status");
+
+        fixture.Pane.OnCommandAssistSuggestionPointerAccepted(0);
+
+        Assert.Equal("atus", Assert.Single(fixture.Session.Sent));
+        Assert.False(fixture.ViewModel.IsVisible);
+    }
+
+    /// <summary>A pointer accept obeys the echo gate, exactly as the keyboard path does.</summary>
+    [AvaloniaFact]
+    public async Task PointerAccept_WhenInputIsUnechoed_SendsNothing()
+    {
+        using var fixture = await Fixture.AtAnIntegratedPromptAsync("git st", history: "git status");
+        fixture.Pane.NoteInputAwaitingEcho();
+
+        fixture.Pane.OnCommandAssistSuggestionPointerAccepted(0);
+
+        Assert.Empty(fixture.Session.Sent);
+        Assert.True(fixture.ViewModel.IsVisible);
     }
 
     private sealed class Fixture : IDisposable
@@ -151,6 +325,13 @@ public class PaneAssistInsertionTests
 
         public void PressCtrlEnter() =>
             Pane.TryHandleCommandAssistKey(Key.Enter, KeyModifiers.Control);
+
+        /// <summary>Returns whether Command Assist consumed the key, i.e. whether the shell saw it.</summary>
+        public bool PressEnter() =>
+            Pane.TryHandleCommandAssistKey(Key.Enter, KeyModifiers.None);
+
+        public bool PressDown() =>
+            Pane.TryHandleCommandAssistKey(Key.Down, KeyModifiers.None);
 
         public void Dispose()
         {


### PR DESCRIPTION
Driven by owner dogfooding; implements part of Phase 3 of
`docs/plans/2026-08-01-command-assist-v2-plan.md`.

The product owner tested merged Phases 0-2 and reported three things. None of
them were tasks in Phase 3, and all three are the whole of what a user sees, so
they were pulled forward into a Phase 3a together with the two Phase 3 tasks
they touch (task 2, and task 3 in full). The rest of Phase 3 - passive bubble
policy, shortcut catalogue, gating decoupling, Settings UI, perf benchmark - is
Phase 3b and is NOT in this PR.

## The three reports, and how each is addressed

### 1. "Ctrl+R lists history but does no action when I select" (local AND SSH)

Three separate causes, all of them real:

- **Accept was `Ctrl+Enter`-only**, and nothing on screen said so.
  `CommandAssistBubbleViewModel.ShortcutHintText` has existed since M4.2 and was
  never bound to anything, so the one surface that could have taught the
  shortcuts rendered everything except them.
- **Plain `Enter` while browsing went to the shell**, which submitted the
  (usually empty) command line; the submission reset then dismissed the popup.
  From the user's side: nothing inserted, surface gone, "nothing happened".
- **In a markless session insertion refused outright** (#286's browse-only
  rule), so even `Ctrl+Enter` did nothing - silently, though non-destructively
  since the #286 B3 fix.

Fixed by the keyboard change below, by binding the hint strip (in the bubble and
in a new popup footer, with state-dependent content), and by narrowing the
degraded-insertion rule.

### 2. "The list shows commands from all sessions/tabs indiscriminately"

The engine has had profile/cwd/shell boosts since M2, but only on the text-query
path. `Ctrl+R` is the empty-query path, which went to `GetRecentAsync(5)`: pure
recency, zero context - and truncated to five candidates, so no ranking rule
could have helped, because on a machine with several panes those five rows are
all from whichever pane ran a command last. Fixed by context-aware ranking plus
a wider recall pool.

### 3. "In a tab with two SSH panes (split), the assist doesn't show up at all on one of them"

`TerminalPane.ShouldSuppressConservativeRemoteAssist` hides the overlay outright
on short markless-SSH panes whose prompt is still high in the pane - the "it
might be a login banner" hedge. A split halves the pane height, so both panes
fall under `ConservativeRemoteShortPaneHeightThreshold`, and on the one whose
prompt was in the upper band this returned true - for an explicit `Ctrl+R` as
readily as for an uninvited bubble.

The alternative cause was checked and ruled out: `MainWindow.WirePane` is the
funnel that assigns `CommandAssistServices`, and it covers split-created panes
and restored panes alike. A test pins the pane-level half of that (two panes on
one services graph both open their own independent history search).

## Enter ownership model (the deliberate change)

> `Enter` belongs to Command Assist only when the popup is open, a row is
> selected, and the mode is Suggest or Search.

The rule lives on `AssistSessionStateMachine.AllowsAcceptOnEnter`. Both
consumers ask it rather than reimplementing it: `CommandAssistKeyRouter` takes
the answer in a new `AssistKeyState`, and the hint strip is computed from the
same predicate through a probe the controller installs on the view-model - so
the hint cannot advertise a key the surface does not own.

Why it is safe:

- **The typing flow cannot reach that state.** In Suggest mode the only
  transition that opens a popup is `OpenPopupForSelection`, i.e. the user moved
  the selection with an arrow key or a click. In Search mode it is reachable
  only because the user pressed `Ctrl+R`. And `ObserveTypedInput` closes the
  popup, so type-a-command-then-`Enter` is untouched.
- **Only a completely unmodified `Enter` is taken.** Not "no Alt": `Shift+Enter`
  is a newline in several line editors, and under the kitty disambiguate tier
  every modified `Enter` is a distinct `CSI u` sequence the shell may act on.
- **A refusal is not a dead key.** If the insertion cannot be planned (line
  unreadable, keystroke unechoed, cursor mid-line, text pasted) the pane returns
  false and `Enter` falls through to the shell and submits, exactly as before
  this branch existed.
- **Help and Fix are excluded** even with a row selected. Their rows are
  documentation and diagnoses rather than a command line being composed, and a
  Fix popup is on screen right after a submission where the next `Enter` is most
  likely aimed at the shell. Both keep `Ctrl+Enter`.
- `Tab` stays shell-owned everywhere. `Ctrl+Enter` is unchanged in every state.

`docs/command-assist/CommandAssist.md` section 14 is rewritten around this - it
had been stale since `acd1cd0`, promising `Tab` to insert and `Enter` to execute.

## Degraded-session insertion: the safety argument

#286 refused all insertion without a grid snapshot, because appending a whole
command to an unknown prefix is how `git sgit status` happens. But "unknown" was
doing two jobs. In the case the owner hit - markless SSH pane, `Ctrl+R`, pick a
row - the prefix is not unknown, it is **empty**, and the pane can prove it. So
`TerminalPane.TryReadInsertionQuerySnapshot` supplies the planner
`AssistQuerySnapshot("", 0, false, false)`, which the planner already treats as
an observed fact rather than an absence, and the whole command is sent. It goes
through the planner rather than a direct send so there stays exactly one refusal
discipline.

Four conditions, all required, each failing closed:

1. **no grid snapshot** - grid truth still wins wherever it exists;
2. **the #287 accumulator is not poisoned** - no arrow key, `Home`, `Delete`,
   `Tab`, paste, prior insertion, agent injection or unrecognised chord since the
   reset; the key classification is an allow-list, so an unknown key poisons;
3. **the accumulator is empty** - nothing typed since the last `Enter` or
   `Ctrl+C`, so there is no prefix for an appended command to corrupt. An empty
   buffer alone is not enough: condition 2 is what makes "empty" mean "the line
   is empty" rather than "I stopped watching";
4. **no keystroke awaiting echo** (`_hasUnechoedInput`) - the same gate the echo
   race uses.

Paste suppression (`IsCurrentSubmissionSuppressed`) and the alt-screen check
still refuse upstream of all of it.

The argument also rests on the shape of the failure. Insertion sends text to the
shell's line editor and stops; the user sees the command sitting on their prompt
and presses `Enter` themselves. The worst case is a visible, editable, deletable
line - never a command that ran. Contrast the case #286 was written for, which
is equally visible but is produced by appending to text the user typed, which
conditions 2-4 exclude.

One residual cost, stated rather than hidden: "clean and empty" is not the same
as "the shell is at a prompt". A markless pane running a program that reads
stdin (`cat`, a REPL) satisfies every condition, so an accepted row is typed into
that program. Typing the command by hand would have done the same thing.
Documented in `CommandAssist_ShellIntegration_Gaps.md`.

## Context-scoping design

Ranking only, in `CommandAssistSuggestionEngine`; the stores stay recall gates.

- **Empty query (`Ctrl+R`):** same-context entry +1000, same-profile +200.
  Everything else on that path tops out around 30, so this **partitions** the
  list: every entry from here above every entry that is not, ordered within each
  band by the existing recency/frequency rules.
- **Text query:** same-context +30, sized as a nudge between the existing cwd
  (12) and profile (20) terms. A partition there would rank a same-host
  subsequence match above a local prefix match, which reads as the list ignoring
  what was typed. Both directions are pinned by tests.
- **"Same context" is asymmetric.** On a remote pane it means *this host*: a host
  id is the only thing identifying the box across sessions, tabs and reconnects
  (a session id would scope to one tab, which the shell's own history already
  does badly). On a local pane it means "not on somebody else's machine" - there
  is no local host id to compare. A remote pane with an unresolved host matches
  nothing rather than everything, falling back to the previous order.
- **Nothing is filtered.** A command run elsewhere is still in the list, below
  the fold. The complaint was about order, and global history is a feature.
- **Recall pool 5 -> 200** on the empty-query path, and `MaxDisplayedSuggestions`
  5 -> 50 now that the popup scrolls.
- Pinned snippets are treated as satisfying both affinity terms - pinning already
  means "in scope everywhere", and a snippet carries neither host nor profile.
  Without that, the new boost would have silently demoted pinned snippets out of
  the top of an empty-query list.

## Mouse support

- `CommandAssistOverlayHost` had `IsHitTestVisible="False"`, which excludes the
  whole subtree - **no click could ever have reached a row.** The host now
  hit-tests (it has no Background, so a click that misses a row still reaches the
  terminal) and the bubble opts out individually, being a status readout that sits
  over the prompt row users select text on.
- Hover via `:pointerover`; single click selects; double click, or a click on the
  already-selected row, accepts through the same gate `Ctrl+Enter` uses.
  Selecting on the first click is deliberate - browsing with the mouse must not
  commit an edit to the command line.
- `ScrollViewer` + `ContainerFromIndex(...).BringIntoView()` on selection change.
- **Not a `ListBox`**, which would have given hover/selection/scroll-into-view
  for free but takes keyboard focus off `TerminalView` on the first click, after
  which the user's next keystroke goes to the list instead of the shell. Rows are
  non-focusable `Border`s.
- Row view-models stopped being immutable records: a rebuild per selection move
  replaces the containers under the pointer, killing hover on every arrow key and
  resetting the scroll position. Reference identity also matters in the other
  direction - the view maps a clicked container back to an index with `IndexOf`,
  which value equality would answer with the first row carrying the same text.

## Explicit-intent visibility, precisely

`AssistSessionStateMachine.IsUserRequestedSurface` (ExplicitBubble,
ExplicitPopup, HistorySearch, Help, FixPopup - **not** FixHint, the one Fix state
the user did not ask for) is consulted by every overlay-hiding heuristic in
`TerminalPane`:

- `ShouldSuppressConservativeRemoteAssist` returns false for them. Worst case is
  the safe lower band, which is what the anchor calculator already produces
  without a reliable anchor.
- The placement-correction stack still **runs** for them - correcting jitter is
  the useful half and costs nothing - but may no longer drop them to zero
  opacity while settling, which for up to six render passes is indistinguishable
  from the feature not responding. The bypass is on the opacity write, and
  deliberately does **not** reset the pass counters: doing that on every
  placement pass would stop `MaxSshAssistCorrectionPasses` from ever being
  reached, and since a correction pass posts another placement pass, that is an
  unbounded render loop.

The suppression is unchanged for passive/auto surfaces on markless SSH, which is
the case it was written for.

## Verification

Clean build (obj/bin removed for App, CommandAssist and App.Tests - AXAML was
touched, and incremental builds mask AVLN errors).

| Suite | Result |
| --- | --- |
| `NovaTerminal.App.Tests` | 1995 passed, 15 skipped, 0 failed (2010 total) |
| `NovaTerminal.VT.Tests` | 329 passed, 0 failed |
| `NovaTerminal.Architecture.Tests` | 28 passed, 0 failed |

Mutation checks (each mutant applied alone, then reverted):

| Mutation | Result |
| --- | --- |
| Drop the explicit-intent bypass in `ShouldSuppressConservativeRemoteAssist` | 1 failure: `TerminalPane_WhenHistorySearchIsOpenOnAShortRemotePane_DoesNotSuppressTheOverlay` |
| Drop the clean+empty gate in `TryReadInsertionQuerySnapshot` | 2 failures: `InADegradedSessionAfterTyping_...RefusesWithoutTearingTheListDown`, `InADegradedSessionWithAPoisonedLine_CtrlEnterRefuses` |
| Drop `isPopupOpen` from `AllowsAcceptOnEnter` | 6 failures, including `WhileTypingWithOnlyABubbleUp_EnterIsNotArmed` and `TypingAfterABrowse_DisarmsEnterAgain` - the two that protect the typing flow |
| Drop the empty-query context boost in the engine | 2 failures: `...RanksThisHostsCommandsFirst`, `...RanksOtherHostsBelowThisOne` |

## What the reviewer should scrutinise

- **The `Enter` ownership rule.** It is the one change that can swallow a
  keystroke the user meant for the shell. The argument that typing cannot reach
  the armed state rests on `ObserveTypedInput` closing the popup and on
  `OpenPopupForSelection` being the only transition that opens a Suggest popup -
  worth re-deriving rather than taking on trust.
- **Arming `Enter` in Search mode without an arrow press.** `Ctrl+R` opens the
  popup with row 0 selected, so `Enter` is armed immediately. That matches every
  shell's reverse-search and is what the report asked for, but it does mean an
  accidental `Ctrl+R` followed by `Enter` inserts text instead of submitting an
  empty line. Visible and editable, but it is a judgement call.
- **The degraded-insert gate**, particularly condition 3 and the `cat`/REPL
  residual cost. This is a documented contract change to #286.
- **Empty-query recall 5 -> 200.** Frequency is capped at +5 and recency is a
  tiebreak, so an old-but-frequent command can now outrank a newer rare one
  within a context band. Judged acceptable; say so if not.
- **Pinned snippets sharing the context band.** Defensible but it is a semantic
  choice, not a mechanical one.
- **Untested seam:** the pointer plumbing itself (the XAML `PointerPressed`
  handler and `Classes.selected` binding) is exercised only through the pane's
  handler methods, not through synthetic pointer events. The opacity half of the
  explicit-intent bypass is likewise reasoned rather than asserted - it needs a
  live drifting render pass to reach.
- **Phase 3b is still open:** passive bubble policy, shortcut catalogue (which
  now has one more entry to catalogue - plain `Enter`), gating decoupling,
  Settings UI group, perf benchmark.

Do not merge without review.
