### PR TITLE
fix(command-assist): restore overlay content, and stop accept refusing on a PSReadLine-rendered prompt

### DIFF
--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -1057,8 +1057,44 @@ namespace NovaTerminal.Controls
                 "App composition root; a pane created outside that path must set it explicitly.");
         }
 
+        /// <summary>
+        /// Hands the bar view-model's two child view-models to the two overlay views.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <strong>Why the UI-thread hop.</strong> Everything below writes Avalonia properties -
+        /// <c>DataContext</c> on the two views, and <c>Width</c>/<c>Height</c>/<c>Margin</c> through
+        /// <see cref="UpdateCommandAssistOverlayPlacement"/> - and Avalonia property writes are
+        /// UI-thread-only. This method is reachable off it: Command Assist is initialized lazily on
+        /// first use (see <see cref="ApplySettings"/>, which deliberately does *not* construct the
+        /// controller), and in a real session the first use is not a keystroke but the shell-integration
+        /// event pump. <c>OSC 133;B</c> arrives on the PTY reader thread, goes onto
+        /// <c>_shellIntegrationEventDispatcher</c>, and reaches
+        /// <see cref="EnsureCommandAssistInitialized"/> from there - before the user has touched the
+        /// keyboard.
+        /// </para>
+        /// <para>
+        /// Without the hop the first <c>DataContext</c> write throws "The calling thread cannot access
+        /// this object because a different thread owns it", the throw is swallowed by the
+        /// fire-and-forget dispatch in <c>OnShellIntegrationEventObserved</c>, and - because
+        /// <see cref="_boundCommandAssistViewModel"/> is already assigned by then - the pane goes on
+        /// believing it is bound. Key routing, visibility and sizing all keep working, so the overlay
+        /// appears, correctly sized, with a null <c>DataContext</c> on both views. Both views use
+        /// <c>x:CompileBindings</c>, where a null data root is a silent no-value rather than a logged
+        /// binding error, so the surfaces render their chrome and not one character of content. That is
+        /// the post-3a "empty dark rectangles" regression, and it is why it was invisible to tests that
+        /// drive the pane from the UI thread: with the dispatcher's semaphore uncontended the await
+        /// completes synchronously and the bind never leaves the caller's thread.
+        /// </para>
+        /// </remarks>
         private void BindCommandAssistViews(CommandAssistBarViewModel? viewModel)
         {
+            if (!Dispatcher.UIThread.CheckAccess())
+            {
+                Dispatcher.UIThread.Post(() => BindCommandAssistViews(viewModel));
+                return;
+            }
+
             if (!ReferenceEquals(_boundCommandAssistViewModel, viewModel))
             {
                 if (_boundCommandAssistViewModel != null)
@@ -1087,8 +1123,22 @@ namespace NovaTerminal.Controls
             UpdateCommandAssistOverlayPlacement();
         }
 
+        /// <summary>
+        /// Points the two overlay views at permanently-hidden view-models when the feature is off.
+        /// </summary>
+        /// <remarks>
+        /// Marshalled for the same reason as <see cref="BindCommandAssistViews"/>: it writes
+        /// <c>DataContext</c>, and <see cref="InitializeCommandAssist"/> - its only caller - runs
+        /// wherever the first Command Assist entry point happened to be.
+        /// </remarks>
         private void ClearCommandAssistBindings()
         {
+            if (!Dispatcher.UIThread.CheckAccess())
+            {
+                Dispatcher.UIThread.Post(ClearCommandAssistBindings);
+                return;
+            }
+
             if (_boundCommandAssistViewModel != null)
             {
                 _boundCommandAssistViewModel.PropertyChanged -= OnCommandAssistViewModelPropertyChanged;
@@ -3892,7 +3942,21 @@ namespace NovaTerminal.Controls
             // never open and grid-truth query state would be dead on arrival. The early-out is
             // therefore gone, and the repaint cost -- one dispatcher hop per prompt paint, doing an
             // idempotent bool set and a marker observation -- is the price of the gate.
-            _ = _shellIntegrationEventDispatcher.EnqueueAsync(() => HandleShellIntegrationEventAsync(shellEvent));
+            //
+            // Faults are logged rather than dropped. This dispatch is fire-and-forget, so an exception
+            // anywhere in the handler used to vanish into an unobserved Task - which is how a
+            // cross-thread Avalonia write inside Command Assist initialization could break the assist
+            // overlay's content with no error anywhere (the post-3a blank-overlay regression, fixed in
+            // BindCommandAssistViews). One log line is the difference between that and a mystery.
+            _ = _shellIntegrationEventDispatcher
+                .EnqueueAsync(() => HandleShellIntegrationEventAsync(shellEvent))
+                .ContinueWith(
+                    static task => TerminalLogger.Log(
+                        LogLevel.Error,
+                        "Shell integration event dispatch failed: " + task.Exception),
+                    CancellationToken.None,
+                    TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
         }
 
         /// <summary>

--- a/src/NovaTerminal.VT/GridQueryReader.cs
+++ b/src/NovaTerminal.VT/GridQueryReader.cs
@@ -296,6 +296,8 @@ namespace NovaTerminal.VT
                 cursorOffset = text.Length;
             }
 
+            TrimBlankTail(text, cursorOffset);
+
             result = new GridCommandLine(
                 Text: text.ToString(),
                 CursorOffset: cursorOffset,
@@ -476,10 +478,56 @@ namespace NovaTerminal.VT
         }
 
         /// <summary>
-        /// Exclusive end column for a soft-wrapped row. Such a row is full of input by
-        /// definition, except for the one-cell hole a double-width character leaves when it
-        /// does not fit in the last column and wraps early.
+        /// Drops the run of blank cells the span ends on, never cutting left of the cursor.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <see cref="ContentRowEnd"/> already applies this rule to the span's final row, and for a
+        /// single-row span that is the whole story. It is not, once the span runs to a second row:
+        /// every row before the last is read out to <see cref="SoftWrappedRowEnd"/>, which is the
+        /// full width, because a soft-wrapped row is <i>usually</i> full of input. PSReadLine breaks
+        /// that assumption on every render. It repaints the whole logical line and pads to the right
+        /// edge to erase what was there before, and the padding writes one cell past the last column
+        /// — so the terminal wraps, the row's wrap flag is set for real, and the cursor is then moved
+        /// back to the input. The row is now flagged wrapped while its tail is blanks and its
+        /// continuation row is empty.
+        /// </para>
+        /// <para>
+        /// Without this, a pwsh prompt that PSReadLine has rendered once reads as the typed text plus
+        /// the remainder of the row as spaces. <see cref="GridCommandLine.CursorOffset"/> is still
+        /// correct, so the text no longer ends at the cursor and
+        /// <c>AssistQuerySnapshot.IsUsableAsTypedPrefix</c> goes false: every Command Assist insertion
+        /// on that prompt refuses, which the user sees as "Enter and Ctrl+Enter do nothing" (the
+        /// second live V2 Phase 3a bug). An empty prompt is the worst case - it reads as a hundred
+        /// spaces rather than as the empty string the planner has a fast path for.
+        /// </para>
+        /// <para>
+        /// Only spaces are dropped, and only past the cursor. Trailing spaces the user typed and left
+        /// the cursor after are input (see <c>TrailingSpacesLeftOfTheCursorAreKept</c>), and a
+        /// <c>'\n'</c> stops the trim: a hard line break is content the reader observed, not slack.
+        /// </para>
+        /// </remarks>
+        private static void TrimBlankTail(StringBuilder text, int cursorOffset)
+        {
+            int end = text.Length;
+            while (end > cursorOffset && text[end - 1] == ' ')
+            {
+                end--;
+            }
+
+            text.Length = end;
+        }
+
+        /// <summary>
+        /// Exclusive end column for a soft-wrapped row: the full width, minus the one-cell hole a
+        /// double-width character leaves when it does not fit in the last column and wraps early.
+        /// </summary>
+        /// <remarks>
+        /// A wrapped row is <i>usually</i> full of input, which is why this does not trim - but "the
+        /// terminal wrapped here" and "this row is full of input" are not the same statement, and
+        /// PSReadLine's erase-to-the-right-edge render produces a wrapped row with a blank tail. The
+        /// tail is dropped after assembly instead; see <see cref="TrimBlankTail"/>.
+        /// </remarks>
         /// <remarks>
         /// The hole is not distinguishable from content. A typed space in the last column of a
         /// row whose next row begins with a wide character produces a byte-identical grid to the

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistOverlayContentRenderTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistOverlayContentRenderTests.cs
@@ -113,6 +113,88 @@ public sealed class CommandAssistOverlayContentRenderTests
     }
 
     /// <summary>
+    /// The other thing an off-UI-thread initialization can break silently: the rendered-surface probe
+    /// must be answering "yes" by the time the user's <c>Enter</c> arrives.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>CommandAssistController.IsAcceptOnEnterArmed</c> folds in a probe the pane installs during
+    /// <c>InitializeCommandAssist</c> - <c>CommandAssistOverlayHost.IsVisible &amp;&amp; Opacity &gt; 0</c> -
+    /// and the overlay host's visibility is written by a placement pass that only runs when a view-model
+    /// property changes. Initialization now marshals to the UI thread, so the order of "probe installed",
+    /// "views bound" and "first placement pass" is decided by the dispatcher rather than by the calling
+    /// thread; a probe that ended up stale-false would leave <c>Enter</c> unarmed on a surface the user
+    /// can plainly see, and the only symptom would be an <c>Enter</c> that submits.
+    /// </para>
+    /// <para>
+    /// So this drives the real order: shell integration off the PTY thread, then <c>Ctrl+R</c>, then
+    /// browse - and asserts the probe agrees with the screen. It is the guard for the hypothesis the
+    /// second live bug was first blamed on; the bug itself turned out to be in the grid read (see
+    /// <c>PaneAssistInsertionTests.OnAPromptPsReadLineHasRendered_CtrlEnterStillSendsTheSuffix</c>), and
+    /// this pins that the probe is not a second, latent copy of the same failure.
+    /// </para>
+    /// </remarks>
+    [AvaloniaFact]
+    public async Task TerminalPane_WhenShellIntegrationArrivesOffTheUiThread_ArmsEnterOnceTheOverlayIsShown()
+    {
+        // Ctrl+R needs something to list before a row can be selected, and a selected row is what
+        // arms Enter. Awaited rather than blocked on: this runs on the headless dispatcher thread.
+        await TestCommandAssistServices.Instance.HistoryStore.AppendAsync(new CommandHistoryEntry(
+            Id: Guid.NewGuid().ToString("N"),
+            CommandText: "git status",
+            ExecutedAt: DateTimeOffset.UtcNow,
+            ShellKind: "pwsh",
+            WorkingDirectory: null,
+            ProfileId: null,
+            SessionId: null,
+            HostId: null,
+            ExitCode: 0,
+            IsRemote: false,
+            IsRedacted: false,
+            Source: CommandCaptureSource.Heuristic,
+            DurationMs: null));
+
+        using var pane = new TerminalPane
+        {
+            Width = 900,
+            Height = 500
+        };
+        ConfigureCommandAssist(pane);
+        pane.Measure(new Size(900, 500));
+        pane.Arrange(new Rect(0, 0, 900, 500));
+        pane.ArmShellIntegrationTracker();
+        pane.CreateAndWireParser();
+
+        await Task.Run(() =>
+        {
+            Assert.False(
+                Dispatcher.UIThread.CheckAccess(),
+                "This test is meaningless unless initialization really is triggered off the UI thread.");
+            pane.Parser!.Process("\x1b]133;A\x07PS C:\\> \x1b]133;B\x07");
+        });
+
+        await WaitForAsync(
+            () => pane.CommandAssistViewModel is CommandAssistBarViewModel,
+            "Command Assist to initialize from the off-thread shell-integration burst");
+
+        var viewModel = Assert.IsType<CommandAssistBarViewModel>(pane.CommandAssistViewModel);
+
+        // Ctrl+R: a surface the user asked for, with the row list open.
+        pane.OpenCommandAssistHistorySearch();
+        await WaitForAsync(() => viewModel.HasSuggestions, "the history list to fill");
+
+        Assert.True(
+            pane.IsCommandAssistOverlayRendered,
+            "the pane's own probe must say the overlay it just placed is on screen");
+        Assert.True(viewModel.IsVisible);
+        Assert.True(viewModel.IsPopupOpen);
+        Assert.True(
+            viewModel.IsAcceptOnEnterArmed,
+            "Enter must be armed on a visible popup with a row selected; a stale probe would leave it " +
+            "unarmed and the user's Enter would submit instead of inserting.");
+    }
+
+    /// <summary>
     /// The symptom guard for the popup: rendered rows must contain ink.
     /// </summary>
     [AvaloniaFact]

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistOverlayContentRenderTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistOverlayContentRenderTests.cs
@@ -1,0 +1,480 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Layout;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using NovaTerminal.CommandAssist.Models;
+using NovaTerminal.CommandAssist.ViewModels;
+using NovaTerminal.CommandAssist.Views;
+using NovaTerminal.Controls;
+using NovaTerminal.Shell;
+using SkiaSharp;
+
+namespace NovaTerminal.Tests.CommandAssist;
+
+/// <summary>
+/// Guards that the Command Assist overlay actually puts content on screen.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Written after the post-V2-Phase-3a regression where the bubble and popup rendered as empty dark
+/// rounded rectangles: correct chrome, correct size, not one character of text. Nothing in the
+/// existing suite noticed, because every other assist test either checks view-model state or reaches
+/// a named <c>TextBlock</c> through <c>FindControl</c> - and both of those are perfectly healthy on a
+/// surface whose <c>DataContext</c> is null. The views use <c>x:CompileBindings</c>, where a null data
+/// root is a silent no-value rather than a logged binding error, so the failure had no signature at
+/// all above the pixels.
+/// </para>
+/// <para>
+/// So these tests assert at the two levels the old ones skipped: that initialization survives arriving
+/// off the UI thread (the mechanism), and that the rendered raster is not uniform background in the
+/// regions that are supposed to carry text (the symptom).
+/// </para>
+/// </remarks>
+public sealed class CommandAssistOverlayContentRenderTests
+{
+    /// <summary>
+    /// Minimum fraction of a text region's pixels that must differ from its background colour.
+    /// </summary>
+    /// <remarks>
+    /// Glyph strokes are thin, so the honest bar is low: a line of antialiased 11-14pt text covers a
+    /// few percent of its own bounding box and far less of a region sized to hold several rows. The
+    /// value only has to separate "some ink" from "none", which is the whole distinction the
+    /// regression turned on - see <see cref="PixelGuard_ReportsBlank_WhenPopupHasNoDataContext"/>,
+    /// which pins the other side of it.
+    /// </remarks>
+    private const double MinimumInkFraction = 0.002;
+
+    /// <summary>
+    /// Per-channel-sum distance at which a pixel counts as ink rather than background.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately generous. The point is to be indifferent to themes: any foreground the product
+    /// might legitimately choose sits far further than this from the card fill it is drawn on, while
+    /// antialiasing fringes and the card's own subtle inner panels do not.
+    /// </remarks>
+    private const int InkChannelDistance = 24;
+
+    /// <summary>
+    /// The mechanism guard: Command Assist initialization must survive arriving off the UI thread.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the test that would have caught the regression. Command Assist is constructed lazily on
+    /// first use, and in a real session first use is not a keystroke: <c>OSC 133;B</c> from the shell
+    /// arrives on the PTY reader thread and reaches <c>EnsureCommandAssistInitialized</c> through the
+    /// serialized shell-integration dispatcher. <c>BindCommandAssistViews</c> then wrote
+    /// <c>DataContext</c> from there, which Avalonia refuses across threads; the throw was swallowed by
+    /// a fire-and-forget dispatch, and because the pane had already recorded the view-model it went on
+    /// believing it was bound.
+    /// </para>
+    /// <para>
+    /// Every pre-existing test drove the parser directly from the test thread, where the dispatcher's
+    /// semaphore is uncontended and the await therefore completes synchronously - so the bind never
+    /// left the UI thread and the bug was invisible. The <c>Task.Run</c> below is the entire difference,
+    /// and it is not artificial: it is what the PTY reader does.
+    /// </para>
+    /// </remarks>
+    [AvaloniaFact]
+    public async Task TerminalPane_WhenShellIntegrationArrivesOffTheUiThread_StillBindsOverlayViewModels()
+    {
+        using var pane = new TerminalPane();
+        ConfigureCommandAssist(pane);
+        pane.ArmShellIntegrationTracker();
+        pane.CreateAndWireParser();
+
+        await Task.Run(() =>
+        {
+            Assert.False(
+                Dispatcher.UIThread.CheckAccess(),
+                "This test is meaningless unless the shell-integration burst really is parsed off the UI thread.");
+            pane.Parser!.Process("\x1b]133;A\x07PS C:\\> \x1b]133;B\x07git status");
+        });
+
+        CommandAssistBubbleView bubbleView =
+            Assert.IsType<CommandAssistBubbleView>(pane.FindControl<CommandAssistBubbleView>("CommandAssistBubble"));
+        CommandAssistPopupView popupView =
+            Assert.IsType<CommandAssistPopupView>(pane.FindControl<CommandAssistPopupView>("CommandAssistPopup"));
+
+        await WaitForAsync(
+            () => bubbleView.DataContext is CommandAssistBubbleViewModel &&
+                  popupView.DataContext is CommandAssistPopupViewModel,
+            "the overlay views to receive their view-models after an off-UI-thread initialization");
+
+        Assert.IsType<CommandAssistBubbleViewModel>(bubbleView.DataContext);
+        Assert.IsType<CommandAssistPopupViewModel>(popupView.DataContext);
+    }
+
+    /// <summary>
+    /// The symptom guard for the popup: rendered rows must contain ink.
+    /// </summary>
+    [AvaloniaFact]
+    public void CommandAssistPopupView_RendersInkWhereTheSuggestionRowsAre()
+    {
+        CommandAssistPopupViewModel vm = CreatePopupViewModel();
+        var view = new CommandAssistPopupView
+        {
+            DataContext = vm,
+            Width = 520,
+            Height = 220,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top
+        };
+
+        WithRenderedView(view, 520, 220, (bitmap, rendered) =>
+        {
+            AssertRegionHasInk(bitmap, rendered, "PopupSuggestionsList", "the suggestion row list");
+            AssertRegionHasInk(bitmap, rendered, "PopupModeLabelText", "the popup mode label");
+            AssertRegionHasInk(bitmap, rendered, "PopupShortcutHintText", "the popup hint strip");
+        });
+    }
+
+    /// <summary>
+    /// The symptom guard for the bubble: the mode label and hint strip must contain ink.
+    /// </summary>
+    [AvaloniaFact]
+    public void CommandAssistBubbleView_RendersInkWhereTheModeLabelIs()
+    {
+        var vm = new CommandAssistBubbleViewModel
+        {
+            IsVisible = true,
+            ModeLabel = "History",
+            QueryText = "git st",
+            SummaryText = "git status --short",
+            ShortcutHintText = CommandAssistBarViewModel.BrowseHintText,
+            ShowQueryText = true,
+            ShowShortcutHint = true
+        };
+        var view = new CommandAssistBubbleView
+        {
+            DataContext = vm,
+            Width = 420,
+            Height = 36,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top
+        };
+
+        WithRenderedView(view, 420, 36, (bitmap, rendered) =>
+        {
+            AssertRegionHasInk(bitmap, rendered, "BubbleModeLabelText", "the bubble mode label");
+            AssertRegionHasInk(bitmap, rendered, "BubbleSummaryText", "the bubble suggestion summary");
+            AssertRegionHasInk(bitmap, rendered, "BubbleShortcutHintText", "the bubble hint strip");
+        });
+    }
+
+    /// <summary>
+    /// Proves the ink measurement can actually fail, by reproducing what the owner saw.
+    /// </summary>
+    /// <remarks>
+    /// A popup with no <c>DataContext</c> is exactly the regression: the card, the border and the inner
+    /// panels all paint, the control reports itself visible (the root's <c>IsVisible</c> binding has no
+    /// data root to read, so it keeps its default), and every <c>TextBlock</c> resolves to nothing.
+    /// Without this test the two guards above would be unfalsifiable - a metric that never fails
+    /// certifies nothing. With it, "not blank" is a claim the suite can lose.
+    /// </remarks>
+    [AvaloniaFact]
+    public void PixelGuard_ReportsBlank_WhenPopupHasNoDataContext()
+    {
+        var view = new CommandAssistPopupView
+        {
+            DataContext = null,
+            Width = 520,
+            Height = 220,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top
+        };
+
+        WithRenderedView(view, 520, 220, (bitmap, rendered) =>
+        {
+            // The same two regions the positive guard measures, measured the same way. Deliberately not
+            // the whole card: the border and the rounded corners are ink by any definition, and a
+            // negative control that has to exclude them is not measuring what the positive one measures.
+            // The mode label is left out because with no data context it has no text and therefore no
+            // width at all - a different, cruder symptom that RegionOf rejects outright.
+            AssertRegionIsBlank(bitmap, rendered, "PopupSuggestionsList", "the suggestion row list");
+            AssertRegionIsBlank(bitmap, rendered, "PopupShortcutHintText", "the popup hint strip");
+        });
+    }
+
+    private static CommandAssistPopupViewModel CreatePopupViewModel()
+    {
+        var suggestions = new ObservableCollection<CommandAssistSuggestionItemViewModel>
+        {
+            new(
+                displayText: "git status --short",
+                descriptionText: "Show the working tree status.",
+                badgesText: "History",
+                metadataText: @"C:\repo | used today",
+                isSelected: true,
+                type: AssistSuggestionType.History),
+            new(
+                displayText: "git commit --amend",
+                descriptionText: "Rewrite the most recent commit.",
+                badgesText: "History",
+                metadataText: @"C:\repo | used yesterday",
+                isSelected: false,
+                type: AssistSuggestionType.History),
+            new(
+                displayText: "git push --force-with-lease",
+                descriptionText: "Update the remote branch safely.",
+                badgesText: "History",
+                metadataText: @"C:\repo | used last week",
+                isSelected: false,
+                type: AssistSuggestionType.History)
+        };
+
+        return new CommandAssistPopupViewModel(suggestions)
+        {
+            IsVisible = true,
+            ModeLabel = "History",
+            QueryText = "git",
+            TopSuggestionText = "git status --short",
+            SelectedDescriptionText = "Show the working tree status.",
+            SelectedBadgesText = "History",
+            SelectedMetadataText = @"C:\repo | used today",
+            HasSuggestions = true,
+            ShowEmptyState = false,
+            ShortcutHintText = CommandAssistBarViewModel.BrowseHintText,
+            UseCompactLayout = false
+        };
+    }
+
+    /// <summary>
+    /// Shows <paramref name="view"/> in a window, lays it out, rasterizes it, and hands both to
+    /// <paramref name="assert"/>.
+    /// </summary>
+    /// <remarks>
+    /// Hosted in a <see cref="Window"/> rather than measured detached for the same reason the layout
+    /// tests are: the content lives behind a <c>ContentPresenter</c> that only realizes its child
+    /// during a layout pass from a visual root, and an <c>ItemsControl</c>'s row containers do not exist
+    /// at all until then. A detached pass would leave every descendant at zero bounds, and a pixel test
+    /// over a zero-sized region is a test that cannot fail.
+    /// </remarks>
+    private static void WithRenderedView(Control view, int width, int height, Action<SKBitmap, Control> assert)
+    {
+        var window = new Window
+        {
+            Content = view,
+            Width = width + 40,
+            Height = height + 40
+        };
+
+        try
+        {
+            window.Show();
+            RelayoutTo(window, view, new Size(width + 40, height + 40));
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(
+                view.Bounds.Width > 0 && view.Bounds.Height > 0,
+                $"The view under test arranged to {view.Bounds}, so there is nothing to rasterize.");
+
+            using SKBitmap bitmap = Rasterize(view);
+            assert(bitmap, view);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    private static SKBitmap Rasterize(Control view)
+    {
+        var pixelSize = new PixelSize(
+            Math.Max(1, (int)Math.Ceiling(view.Bounds.Width)),
+            Math.Max(1, (int)Math.Ceiling(view.Bounds.Height)));
+
+        using var target = new RenderTargetBitmap(pixelSize, new Vector(96, 96));
+        target.Render(view);
+
+        using var stream = new MemoryStream();
+        target.Save(stream);
+        stream.Position = 0;
+
+        return SKBitmap.Decode(stream)
+               ?? throw new InvalidOperationException(
+                   "Could not decode the rendered overlay. If this started failing, check that the " +
+                   "headless test app still renders for real (AvaloniaHeadlessPlatformOptions." +
+                   "UseHeadlessDrawing must be false) - the stub drawing backend produces an empty " +
+                   "raster, which would make every pixel guard in this file vacuous.");
+    }
+
+    private static void AssertRegionHasInk(SKBitmap bitmap, Control root, string childName, string description)
+    {
+        PixelRect region = RegionOf(bitmap, root, childName);
+        double ink = MeasureInkFraction(bitmap, region);
+
+        Assert.True(
+            ink >= MinimumInkFraction,
+            $"{description} rendered as uniform background: only {ink:P3} of the {region.Width}x{region.Height} " +
+            $"region around '{childName}' differs from its most common colour. This is the shape of the " +
+            "post-Phase-3a regression - chrome and layout intact, no text - so suspect the surface's " +
+            "DataContext or a binding before suspecting the threshold.");
+    }
+
+    private static void AssertRegionIsBlank(SKBitmap bitmap, Control root, string childName, string description)
+    {
+        PixelRect region = RegionOf(bitmap, root, childName);
+        double ink = MeasureInkFraction(bitmap, region);
+
+        Assert.True(
+            ink < MinimumInkFraction,
+            $"{description} was expected to render as uniform background on a popup with no DataContext, " +
+            $"but {ink:P3} of the {region.Width}x{region.Height} region around '{childName}' differs from " +
+            "its most common colour. If the popup grew a design-time fallback, re-point this control at " +
+            "something still genuinely blank rather than deleting it: the positive guards in this file " +
+            "mean nothing without a demonstration that the measurement can fail.");
+    }
+
+    /// <summary>
+    /// The bounds of a named descendant, in the rasterized bitmap's pixel space.
+    /// </summary>
+    private static PixelRect RegionOf(SKBitmap bitmap, Control root, string childName)
+    {
+        Control child = Assert.IsAssignableFrom<Control>(root.FindControl<Control>(childName));
+        Assert.True(
+            child.Bounds.Width > 0 && child.Bounds.Height > 0,
+            $"'{childName}' arranged to {child.Bounds}. A zero-sized region would make the ink check vacuous.");
+
+        Point? offset = child.TranslatePoint(new Point(0, 0), root);
+        Assert.NotNull(offset);
+
+        // Grown by a pixel on every side: TranslatePoint works in device-independent units and the
+        // raster is snapped, so a region clipped exactly to the reported bounds can shave the outermost
+        // row of glyph pixels off a single-line TextBlock.
+        int left = Math.Max(0, (int)Math.Floor(offset!.Value.X) - 1);
+        int top = Math.Max(0, (int)Math.Floor(offset.Value.Y) - 1);
+        int right = Math.Min(bitmap.Width, (int)Math.Ceiling(offset.Value.X + child.Bounds.Width) + 1);
+        int bottom = Math.Min(bitmap.Height, (int)Math.Ceiling(offset.Value.Y + child.Bounds.Height) + 1);
+
+        Assert.True(
+            right > left && bottom > top,
+            $"'{childName}' translated to an empty region ({left},{top})-({right},{bottom}) inside a " +
+            $"{bitmap.Width}x{bitmap.Height} raster.");
+
+        return new PixelRect(left, top, right - left, bottom - top);
+    }
+
+    /// <summary>
+    /// The fraction of pixels in <paramref name="region"/> that are not the region's background.
+    /// </summary>
+    /// <remarks>
+    /// Background is taken as the most common colour rather than a hard-coded one, which is what keeps
+    /// this indifferent to themes and to the popup's own layered panel fills. Anything far enough from
+    /// that colour is ink - text, the selection highlight, a border - and the guards only ever ask
+    /// whether there is any.
+    /// </remarks>
+    private static double MeasureInkFraction(SKBitmap bitmap, PixelRect region)
+    {
+        var histogram = new Dictionary<uint, int>();
+        var pixels = new SKColor[region.Width * region.Height];
+        int index = 0;
+
+        for (int y = region.Y; y < region.Y + region.Height; y++)
+        {
+            for (int x = region.X; x < region.X + region.Width; x++)
+            {
+                SKColor color = bitmap.GetPixel(x, y);
+                pixels[index++] = color;
+                uint key = (uint)((color.Red << 16) | (color.Green << 8) | color.Blue);
+                histogram[key] = histogram.TryGetValue(key, out int count) ? count + 1 : 1;
+            }
+        }
+
+        uint background = 0;
+        int best = -1;
+        foreach (KeyValuePair<uint, int> entry in histogram)
+        {
+            if (entry.Value > best)
+            {
+                best = entry.Value;
+                background = entry.Key;
+            }
+        }
+
+        int backgroundRed = (int)((background >> 16) & 0xFF);
+        int backgroundGreen = (int)((background >> 8) & 0xFF);
+        int backgroundBlue = (int)(background & 0xFF);
+
+        int ink = 0;
+        foreach (SKColor color in pixels)
+        {
+            int distance = Math.Abs(color.Red - backgroundRed) +
+                           Math.Abs(color.Green - backgroundGreen) +
+                           Math.Abs(color.Blue - backgroundBlue);
+            if (distance > InkChannelDistance)
+            {
+                ink++;
+            }
+        }
+
+        return pixels.Length == 0 ? 0 : (double)ink / pixels.Length;
+    }
+
+    /// <summary>
+    /// Pumps the dispatcher until <paramref name="condition"/> holds, or fails describing what it was
+    /// waiting for.
+    /// </summary>
+    private static async Task WaitForAsync(Func<bool> condition, string what, int timeoutMs = 2000)
+    {
+        for (int elapsed = 0; elapsed < timeoutMs; elapsed += 25)
+        {
+            Dispatcher.UIThread.RunJobs();
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(25);
+        }
+
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(condition(), $"Timed out after {timeoutMs} ms waiting for {what}.");
+    }
+
+    /// <summary>
+    /// Re-runs layout from <paramref name="root"/> down to <paramref name="leaf"/>.
+    /// </summary>
+    /// <remarks>
+    /// Same reason as the copy in <c>CommandAssistLayoutTests</c>: <c>InvalidateMeasure</c> registers
+    /// with the visual root's layout manager rather than walking up, so a hand-driven
+    /// <c>Measure</c>/<c>Arrange</c> would short-circuit at the first still-valid ancestor and leave the
+    /// leaf at its old bounds.
+    /// </remarks>
+    private static void RelayoutTo(Control root, Visual leaf, Size size)
+    {
+        for (Visual? visual = leaf; visual is not null; visual = visual.GetVisualParent())
+        {
+            if (visual is Layoutable layoutable)
+            {
+                layoutable.InvalidateMeasure();
+                layoutable.InvalidateArrange();
+            }
+
+            if (ReferenceEquals(visual, root))
+            {
+                break;
+            }
+        }
+
+        root.Measure(size);
+        root.Arrange(new Rect(size));
+    }
+
+    private static void ConfigureCommandAssist(TerminalPane pane)
+    {
+        pane.CommandAssistServices = TestCommandAssistServices.Instance;
+        pane.ApplySettings(new TerminalSettings
+        {
+            CommandAssistEnabled = true,
+            CommandAssistHistoryEnabled = true
+        });
+    }
+}

--- a/tests/NovaTerminal.App.Tests/Controls/PaneAssistInsertionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneAssistInsertionTests.cs
@@ -313,6 +313,80 @@ public class PaneAssistInsertionTests
         Assert.True(fixture.ViewModel.IsVisible);
     }
 
+    // ------------------- the prompt row PSReadLine has rendered (second live bug)
+
+    /// <summary>
+    /// The second live V2 Phase 3a bug, end to end: on a pwsh prompt PSReadLine has rendered once,
+    /// <c>Ctrl+Enter</c> inserted nothing and plain <c>Enter</c> silently submitted instead.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Nothing about Command Assist's state was wrong - the popup was open, a row was selected, the
+    /// overlay was rendered and <c>Enter</c> was armed (the hint strip said so). The grid read was
+    /// wrong. PSReadLine repaints the whole logical line and pads to the right edge to erase what was
+    /// there before, and the padding crosses the edge, so the prompt row carries a real wrap flag with
+    /// a blank tail. <c>GridQueryReader</c> read every row before the last out to the full width, so
+    /// the command line came back as the typed text plus the remainder of the row as spaces:
+    /// <c>CursorOffset</c> correct, <c>Text</c> no longer ending at the cursor,
+    /// <c>IsUsableAsTypedPrefix</c> false, every insertion refused.
+    /// </para>
+    /// <para>
+    /// Which is why both keys broke at once, in the two ways the design says they should when an
+    /// insertion is refused: <c>Ctrl+Enter</c> is consumed and sends nothing, and <c>Enter</c> falls
+    /// through to the shell, submits, and the submission reset takes the popup down with it. The
+    /// symptom is indistinguishable from "Enter was never armed", which is what sent the first
+    /// investigation at the rendered-surface probe.
+    /// </para>
+    /// <para>
+    /// The fixture opens history with <c>Ctrl+R</c> rather than the assist toggle on purpose: an
+    /// all-blank query counts as whitespace, so the recency list still fills and the rows are up in
+    /// both the broken and the fixed build. What the assertion turns on is the insertion, not whether
+    /// anything got ranked.
+    /// </para>
+    /// </remarks>
+    [AvaloniaFact]
+    public async Task OnAPromptPsReadLineHasRendered_CtrlEnterStillSendsTheSuffix()
+    {
+        using var fixture = await Fixture.AtAPsReadLineRenderedPromptAsync("git st", history: "git status");
+
+        // The controls: this is the state that is supposed to insert.
+        Assert.True(fixture.IsOverlayRendered);
+        Assert.True(fixture.ViewModel.IsPopupOpen);
+        Assert.True(fixture.ViewModel.IsAcceptOnEnterArmed);
+
+        fixture.PressCtrlEnter();
+
+        Assert.Equal("atus", Assert.Single(fixture.Session.Sent));
+    }
+
+    /// <summary>The same prompt through the <c>Enter</c> path, which is how the owner met it.</summary>
+    [AvaloniaFact]
+    public async Task OnAPromptPsReadLineHasRendered_PlainEnterInsertsInsteadOfSubmitting()
+    {
+        using var fixture = await Fixture.AtAPsReadLineRenderedPromptAsync("git st", history: "git status");
+
+        Assert.True(fixture.PressEnter());
+        Assert.Equal("atus", Assert.Single(fixture.Session.Sent));
+    }
+
+    /// <summary>
+    /// An empty prompt PSReadLine has rendered: the whole command goes out, because the line was read
+    /// and it is empty.
+    /// </summary>
+    /// <remarks>
+    /// The worst case of the same bug and the one that produced the report. The planner's empty-line
+    /// fast path needs <c>Text</c> to be empty; a row of blanks instead took the prefix branch, where
+    /// no suggestion starts with a hundred spaces.
+    /// </remarks>
+    [AvaloniaFact]
+    public async Task OnAnEmptyPromptPsReadLineHasRendered_EnterSendsTheWholeCommand()
+    {
+        using var fixture = await Fixture.AtAPsReadLineRenderedPromptAsync(string.Empty, history: "git status");
+
+        Assert.True(fixture.PressEnter());
+        Assert.Equal("git status", Assert.Single(fixture.Session.Sent));
+    }
+
     // ---------------------------------------------------------------- mouse (V2 Phase 3a)
 
     /// <summary>
@@ -392,6 +466,49 @@ public class PaneAssistInsertionTests
             // An explicit session is what widens the suggestion scope back out to history.
             fixture.Pane.ToggleCommandAssist();
             await fixture.WaitForAsync(() => fixture.ViewModel.TopSuggestionText == history);
+            return fixture;
+        }
+
+        /// <summary>
+        /// An instrumented pwsh prompt as it looks after PSReadLine has rendered it once, with the
+        /// history list up from <c>Ctrl+R</c>.
+        /// </summary>
+        /// <remarks>
+        /// The padding run is the whole point: PSReadLine erases to the right edge and one cell past
+        /// it, which is a real autowrap, so the prompt row ends up flagged wrapped with a blank
+        /// continuation row under it. Written through the parser rather than by setting the flag, so
+        /// this stays a statement about what the shell does rather than about buffer internals.
+        /// </remarks>
+        public static async Task<Fixture> AtAPsReadLineRenderedPromptAsync(string commandLine, string history)
+        {
+            Fixture fixture = await CreateAsync(history);
+            fixture.Pane.ArmShellIntegrationTracker();
+            fixture.Pane.CreateAndWireParser();
+            fixture.Pane.Parser!.Process(PromptStart + "$ " + PromptEnd + commandLine);
+
+            int cols = fixture.Pane.Buffer!.Cols;
+            int used = 2 + commandLine.Length; // "$ " plus what is typed
+            Assert.True(cols > used, "the fixture's prompt must fit on one row");
+            fixture.Pane.Parser!.Process(new string(' ', cols - used + 1));
+            fixture.Pane.Parser!.Process($"\x1b[1;{used + 1}H");
+
+            TerminalBuffer buffer = fixture.Pane.Buffer!;
+            buffer.Lock.EnterReadLock();
+            try
+            {
+                Assert.True(
+                    buffer.IsRowWrappedAbsolute(0),
+                    "the simulated render must actually have wrapped the prompt row");
+            }
+            finally
+            {
+                buffer.Lock.ExitReadLock();
+            }
+
+            await Task.Delay(50);
+
+            fixture.Pane.OpenCommandAssistHistorySearch();
+            await fixture.WaitForAsync(() => fixture.ViewModel.HasSuggestions);
             return fixture;
         }
 

--- a/tests/NovaTerminal.App.Tests/TestAppBuilder.cs
+++ b/tests/NovaTerminal.App.Tests/TestAppBuilder.cs
@@ -9,8 +9,20 @@ namespace NovaTerminal.Tests
 {
     public class TestAppBuilder
     {
+        /// <remarks>
+        /// <para>
+        /// <c>UseHeadlessDrawing = false</c> routes drawing through the Skia backend registered above
+        /// instead of the headless stub. The stub accepts every draw call and produces an empty raster,
+        /// which is fine while nothing looks at pixels and useless the moment something does: it would
+        /// make <c>CommandAssistOverlayContentRenderTests</c> pass on a blank image, certifying exactly
+        /// the regression it exists to catch.
+        /// </para>
+        /// </remarks>
         public static AppBuilder BuildAvaloniaApp() => AppBuilder.Configure<App>()
             .UseSkia()
-            .UseHeadless(new AvaloniaHeadlessPlatformOptions());
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions
+            {
+                UseHeadlessDrawing = false
+            });
     }
 }

--- a/tests/NovaTerminal.VT.Tests/GridQueryReaderTests.cs
+++ b/tests/NovaTerminal.VT.Tests/GridQueryReaderTests.cs
@@ -176,6 +176,99 @@ public class GridQueryReaderTests
         Assert.Equal(1, line.CursorOffset);
     }
 
+    // ------------------------------------------- PSReadLine's erase-to-the-edge render
+
+    /// <summary>
+    /// Renders the way PSReadLine does: repaint the input, pad to the right edge to erase whatever
+    /// was there before, let the padding cross the edge, then put the cursor back on the input.
+    /// </summary>
+    /// <remarks>
+    /// The crossing is the part that matters. It is a real autowrap, so the row's wrap flag is set
+    /// for real and a blank continuation row appears below - and from then on the prompt row is a
+    /// wrapped row whose tail is slack rather than input, which is the state the reader used to
+    /// mis-read. Reproduced through the parser rather than by setting the flag directly, because
+    /// "the flag can be set on a row that is not full" is exactly the claim under test.
+    /// </remarks>
+    private static Session PsReadLineRenderedPrompt(string input, int cols = 40)
+    {
+        const int markColumn = 2; // "$ "
+        var s = new Session(cols: cols, rows: 6).Prompt().Write(input);
+
+        int used = markColumn + input.Length;
+        s.Write(new string(' ', cols - used + 1));   // pads to the edge, then one cell past it
+        s.Write($"\x1b[1;{used + 1}H");              // cursor back to the end of the input
+
+        AssertRowIsWrapped(s.Buffer, 0);
+        return s;
+    }
+
+    /// <summary>
+    /// Asserts a row carries the wrap flag. Under the buffer's read lock, which every cell and row
+    /// accessor asserts is held.
+    /// </summary>
+    private static void AssertRowIsWrapped(TerminalBuffer buffer, int absoluteRow)
+    {
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            Assert.True(
+                buffer.IsRowWrappedAbsolute(absoluteRow),
+                $"row {absoluteRow} must actually have wrapped, or this test proves nothing");
+        }
+        finally
+        {
+            buffer.Lock.ExitReadLock();
+        }
+    }
+
+    [Fact]
+    public void AfterAPsReadLineRender_TheLineIsNotPaddedWithTheRestOfTheRow()
+    {
+        // The second live V2 Phase 3a bug. The text picked up every blank cell to the right edge
+        // because the span ran onto the (empty) continuation row and every row before the last is
+        // read out to the full width. CursorOffset stayed correct, so Text stopped ending at the
+        // cursor - and Command Assist reads that as "not a typed prefix" and refuses every
+        // insertion. Enter and Ctrl+Enter both did nothing on a pwsh prompt.
+        var s = PsReadLineRenderedPrompt("git st");
+
+        var line = s.Read();
+
+        Assert.Equal("git st", line.Text);
+        Assert.Equal(6, line.CursorOffset);
+        Assert.Equal(6, line.Text.Length); // i.e. the text still ends at the cursor
+        Assert.Equal(1, line.EndRow);      // the span really did run onto the continuation row
+    }
+
+    [Fact]
+    public void AfterAPsReadLineRenderOfAnEmptyLine_TheLineReadsAsEmpty()
+    {
+        // The worst case, and the one the owner hit: an empty prompt read as a hundred spaces.
+        // The planner has a fast path for a line that is empty - "the grid was read and there is
+        // nothing on it, so send the whole command" - and a row of blanks misses it entirely.
+        var s = PsReadLineRenderedPrompt(string.Empty);
+
+        var line = s.Read();
+
+        Assert.Equal(string.Empty, line.Text);
+        Assert.Equal(0, line.CursorOffset);
+        Assert.Equal(1, line.EndRow);
+    }
+
+    [Fact]
+    public void AGenuinelyWrappedLine_KeepsEveryColumnOfItsFirstRow()
+    {
+        // The control. Dropping the blank tail must not become "stop at the cursor's row": a line
+        // long enough to wrap for real has no slack on the row it wrapped from, and every one of
+        // those columns is typed input.
+        string input = "echo " + new string('a', 40);
+        var s = new Session(cols: 20, rows: 6).Prompt().Write(input);
+
+        var line = s.Read();
+
+        Assert.Equal(input, line.Text);
+        Assert.Equal(input.Length, line.CursorOffset);
+    }
+
     [Fact]
     public void HistoryRecall_IsReadFromTheGridEvenThoughNoKeystrokesProducedIt()
     {


### PR DESCRIPTION
This PR fixes **two** live Command Assist bugs found by driving the real GUI
after #290 merged. They are independent: the first is why the overlay had no
content, the second is why nothing happened when you selected a row. Bug 1 was
masking Bug 2 - with the surface blank there was no way to see that accept was
also broken.

- Bug 1 - blank overlay - `df0103d`, `12ea69d`
- Bug 2 - accept inserts nothing - `51b340b`

---

# Bug 1 - the overlay rendered no content

## Symptom

After #290 merged, the Command Assist bubble and popup render as empty dark
rounded rectangles: chrome, border and background all present, sized correctly,
and not one character of content - no rows, no mode label, no hint strip, no
empty-state text. Reported by the product owner on both pwsh 7 and Windows
PowerShell.

Reproduced on a local build of cbd3f85 before changing anything, and the
screenshot matches the report exactly.

## Root cause

`TerminalPane.BindCommandAssistViews` wrote Avalonia properties from a
background thread.

Command Assist is constructed lazily on first use. `ApplySettings` deliberately
does not construct it (`if (_commandAssistController != null ||
!IsCommandAssistFeatureEnabled())`), so nothing initializes it on the UI thread
at pane setup. In a real session the first use is not a keystroke: `OSC 133;B`
arrives on the PTY reader thread, `OnShellIntegrationEventObserved` queues it on
`_shellIntegrationEventDispatcher`, and `HandleShellIntegrationEventAsync` calls
`EnsureCommandAssistInitialized()` from there - at the first prompt, before the
user has touched the keyboard.

`BindCommandAssistViews` then reached this line off the UI thread:

    src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
        CommandAssistBubble.DataContext = viewModel?.Bubble;

and Avalonia threw:

    System.InvalidOperationException: The calling thread cannot access this
    object because a different thread owns it.

Confirmed by instrumenting the method in a real run:

    [BINDDIAG]  BindCommandAssistViews vm=set bubbleField=set popupField=set
                uiThread=False tid=8
    [BINDDIAG2] THREW System.InvalidOperationException: The calling thread
                cannot access this object because a different thread owns it.
    [BLANKDIAG] POPUP dc=<null> selfVis=True selfBounds=12,114,520,220
                modeLabel: text='' fs=14 ff=Inter fg=#ff8ec5ff vis=True

Three things then conspired to make the failure completely silent:

1. The dispatch was fire-and-forget (`_ = ...EnqueueAsync(...)`), so the faulted
   Task was never observed and nothing was logged.
2. `_boundCommandAssistViewModel = viewModel` happens *before* the first view
   write, so the pane went on believing it was bound. Key routing, visibility
   and `UpdateCommandAssistOverlayPlacement` all kept working - which is why the
   overlay appears at all, and why it is correctly sized.
3. Both views declare `x:CompileBindings="True"`. On a compiled binding a null
   data root is a legitimate no-value, not an error, so nothing was written to
   the binding log either. Every `TextBlock` simply resolved to empty.

Why it started at #290 rather than earlier: the same off-thread entry point
existed before, but the surface used to be initialized by the passive typing
path on the UI thread first, and a successful earlier bind leaves the
`DataContext` in place regardless of a later off-thread throw. #290 made the
overlay explicit-intent-only, so the shell-integration pump became the first
thing to initialize Command Assist in a session, and it runs off the UI thread.

## Fix

`BindCommandAssistViews` and `ClearCommandAssistBindings` marshal to the UI
thread and re-enter. Both write `DataContext`, and `BindCommandAssistViews` also
reaches `Width`/`Height`/`Margin` through `UpdateCommandAssistOverlayPlacement`,
so the hop covers every Avalonia write on the path and makes both correct from
any caller on any thread.

The shell-integration dispatch also logs its faults now instead of dropping
them, so the next thread-affinity bug in that handler is one log line rather
than a mystery.

Nothing else changed - no XAML, no view-models, no view code-behind.

## Why the existing tests missed it

`OrderedAsyncEventDispatcher.EnqueueAsync` awaits an uncontended
`SemaphoreSlim`, which completes synchronously. Headless tests call
`pane.Parser!.Process(...)` from the test thread, which *is* the UI thread, so
the bind never left it and every assertion held. The suite already asserted
`Assert.IsType<CommandAssistPopupViewModel>(popupView.DataContext)` - it was
simply never exercised on the path production takes.

## Regression guards

New file: `tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistOverlayContentRenderTests.cs`

Mechanism guard - `TerminalPane_WhenShellIntegrationArrivesOffTheUiThread_StillBindsOverlayViewModels`

  Parses the shell-integration burst inside `Task.Run` (asserting first that it
  really is off the UI thread), then pumps the dispatcher and requires both
  views to end up with their view-models. Not artificial: `Task.Run` is standing
  in for the PTY reader. Verified to FAIL against the unfixed
  `BindCommandAssistViews` ("Timed out after 2000 ms waiting for the overlay
  views to receive their view-models") and to pass with the fix.

Symptom guards - `CommandAssistPopupView_RendersInkWhereTheSuggestionRowsAre`,
`CommandAssistBubbleView_RendersInkWhereTheModeLabelIs`

  Host the view in a window (so the `ContentPresenter` realizes its child and
  the `ItemsControl` builds row containers), rasterize it via
  `RenderTargetBitmap`, then assert the regions around `PopupSuggestionsList`,
  `PopupModeLabelText`, `PopupShortcutHintText`, `BubbleModeLabelText`,
  `BubbleSummaryText` and `BubbleShortcutHintText` are not uniform background.
  The popup case uses three real suggestion rows.

  Robust to theme changes by construction: each region's background is taken as
  its own most common colour rather than a hard-coded value, and the assertion
  is only that some fraction of pixels differ from it. No exact-pixel baseline,
  no golden PNG to rebase.

Negative control - `PixelGuard_ReportsBlank_WhenPopupHasNoDataContext`

  Renders a popup with `DataContext = null` - literally the reported bug - and
  asserts the same two regions ARE blank by the same measurement. Without this
  the positive guards would be unfalsifiable; with it, "not blank" is a claim
  the suite can lose.

`TestAppBuilder` now sets `UseHeadlessDrawing = false` so drawing goes through
the already-registered Skia backend. The default stub backend accepts every draw
call and produces an empty raster, which would have made all three pixel guards
pass on a blank image - certifying exactly the regression they exist to catch.
No other App.Tests test changed behaviour as a result.

## Verification

Real GUI app on Windows, driven and screenshotted (dev build from this
worktree, isolated `NOVATERM_APPDATA_ROOT` so the owner's settings were
untouched):

BEFORE (cbd3f85, unfixed) - Ctrl+R after building history: popup renders as an
empty translucent card. Both inner panels (list panel and detail panel) are
visible and correctly proportioned, so layout ran; header row, row list, detail
panel and footer are all completely textless. Bubble likewise an empty rounded
rectangle.

AFTER (this branch, clean build) - Ctrl+R renders in full:
  - popup mode label "History"
  - three suggestion rows with the selection caret, badges ("Frequent", "Same
    cwd", "Worked") and metadata lines
  - detail panel showing the selected command, badges, path, "Used ..." and
    "Exit 0"
  - footer hint strip "Enter insert | Up/Down browse | Esc close"
  - bubble showing mode label "History", the summary, and the same hint strip

Mouse click still selects: a single left click on the second row moved the
selection caret and the highlight to that row, updated the detail panel to that
row's command and exit code, and updated the bubble summary. Keyboard Up/Down
also moves the selection.

## Sizing note

No sizing regression. `CommandAssistPopupHeight` is still 220 and
`CommandAssistPopupWidth` still 520, and the pane still applies
`Math.Clamp(paneHeight * 0.45, 160, 220)`. The instrumented run measured the
popup at exactly `520x220` DIP on a maximized window. The owner's impression of
an oversized popup is 520x220 DIP at 150% display scaling, which is ~780x330
physical pixels - large on screen, but the pre-#290 clamp, unchanged.

---

# Bug 2 - accept inserted nothing (the owner's "does no action when I select")

## Symptom

With the overlay content restored, in a real integrated pwsh session with a row
browsed in the Ctrl+R popup:

  - plain Enter closed the surface and inserted nothing (the empty line was
    submitted to the shell instead);
  - Ctrl+Enter left the popup open and inserted nothing;
  - no exception was logged anywhere.

## What it was NOT

The first hypothesis was that #290-B1's `renderedSurfaceProbe` was stale-false,
leaving Enter unarmed. Disproved by live instrumentation. At the keypress:

    [AssistKeyProbe] key=Return mods=None owned=True vis=True armed=True
                     upOwned=True popup=True sel=1 rows=4 overlayRendered=True

Enter was armed, the router granted it, the overlay probe said "rendered", the
hint strip read "Enter insert". Nothing about Command Assist's own state was
wrong. Ctrl+Enter never consults the probe at all and failed identically, which
is what ruled the whole hypothesis out: whatever broke had to be downstream of
key routing, on the path both keys share.

## Root cause - one cause, both symptoms

`GridQueryReader` read a PSReadLine-rendered prompt row as the typed text plus
the remainder of the row as spaces.

PSReadLine repaints the whole logical line on every render and pads to the right
edge to erase what was there before, and the padding crosses the edge. That is a
real autowrap: the prompt row's wrap flag is genuinely set, a blank continuation
row appears under it, and the cursor is then moved back onto the input. From
that first render on - i.e. after the user types a single character, or after one
successful insertion - the prompt row is a wrapped row whose tail is slack
rather than input.

`GridQueryReader` reads every row before the last out to `SoftWrappedRowEnd`,
which is the full width, on the documented assumption that "a soft-wrapped row
is full of input by definition". PSReadLine breaks that assumption. Live probe
output, non-empty line first:

    gatedQuery=',echo charlie-three                              <81 spaces>'
      cur=19 ml=False rp=False usable=False rawGridOk=True rows=20..21
    refuse: planner refused for insert=',echo charlie-three'

and the same prompt with an empty command line:

    gatedQuery='                                                <100 spaces>'
      cur=0 ml=False rp=False usable=False rawGridOk=True rows=20..21
    refuse: planner refused for insert=',dir'

`CursorOffset` is correct in both. `Text` is not, so it no longer ends at the
cursor, so `AssistQuerySnapshot.IsUsableAsTypedPrefix` is false, so
`CommandAssistInsertionPlanner` refuses - every time, for every row. The empty
prompt is the worst case: it misses the planner's "the grid was read and the
line is empty, send the whole command" fast path entirely and takes the prefix
branch, where no suggestion starts with a hundred spaces.

Both reported symptoms follow from that single refusal, and they are exactly
what the design says a refused insertion should do:

  - `Ctrl+Enter` is consumed unconditionally and sends nothing -> "popup stays
    open, nothing inserted";
  - `Enter` returns the insertion's result, so a refusal falls through to the
    shell, which submits the (empty) line, and `ResetSubmissionState` takes the
    popup down on the way out -> "the surface closed and nothing happened".

Which is why it was indistinguishable from "Enter was never armed".

## Fix

`src/NovaTerminal.VT/GridQueryReader.cs` - `TrimBlankTail`: drop the run of
blank cells the assembled span ends on, never cutting left of the cursor and
stopping at a `'\n'`.

This is the same rule `ContentRowEnd` already applies to the span's *final* row,
now applied to the whole span. It is deliberately not "stop following the wrap
flag": a line that wrapped for real has no slack on the row it wrapped from, and
every column of it is typed input. And trailing spaces the user typed and parked
the cursor after are still kept - the trim never crosses the cursor.

Side benefit: the ranking query and the mode label were reading the same padded
string, so this also stops Ctrl+R on a rendered prompt falling back to the plain
recency list when it should have been filtering.

No changes to Command Assist, the router, the state machine, the planner or the
pane.

## Why the existing tests missed it

Every fixture builds its buffer by writing the prompt and the input and stopping
there, which is a clean unwrapped row - the state a real prompt is in for
exactly as long as it takes PSReadLine to render once. `CommandAssistKeyRouter`,
`AssistSessionStateMachine` and `PaneAssistInsertionTests` were all green, and
all correct: the bug was in the terminal read, one layer below everything they
assert.

## Regression guards

`tests/NovaTerminal.VT.Tests/GridQueryReaderTests.cs`

  - `AfterAPsReadLineRender_TheLineIsNotPaddedWithTheRestOfTheRow`
  - `AfterAPsReadLineRenderOfAnEmptyLine_TheLineReadsAsEmpty`

  Both reproduce the render through the real parser - write the input, pad to
  the edge, cross it, move the cursor back - and assert the wrap flag really did
  get set before asserting anything else, so the tests cannot silently stop
  exercising the case. FAIL-FIRST CONFIRMED: with `TrimBlankTail` disabled both
  fail with "Assert.Equal() Failure: Strings differ" (2 failed of 72 in the
  class); with it, 0.

  - `AGenuinelyWrappedLine_KeepsEveryColumnOfItsFirstRow`

  The control: a line long enough to wrap for real keeps every column. Without
  it, "trim the tail" could degrade into "stop at the cursor's row" and still
  look fixed.

`tests/NovaTerminal.App.Tests/Controls/PaneAssistInsertionTests.cs` - new
`AtAPsReadLineRenderedPromptAsync` fixture (parser, mark, grid reader,
controller gate, planner, recording session), plus:

  - `OnAPromptPsReadLineHasRendered_CtrlEnterStillSendsTheSuffix`
  - `OnAPromptPsReadLineHasRendered_PlainEnterInsertsInsteadOfSubmitting`
  - `OnAnEmptyPromptPsReadLineHasRendered_EnterSendsTheWholeCommand`

  The first asserts the arming preconditions as controls (`IsOverlayRendered`,
  `IsPopupOpen`, `IsAcceptOnEnterArmed`) before asserting the send, so a future
  failure says which half broke. FAIL-FIRST CONFIRMED: on the unfixed reader all
  three fail - "Assert.Single() Failure: The collection was empty" for
  Ctrl+Enter, and `PressEnter()` returning false (key not consumed, i.e. it went
  to the shell) for the two Enter cases.

  The fixture opens history with Ctrl+R rather than the assist toggle on
  purpose: an all-blank query counts as whitespace, so the recency list fills in
  both the broken and the fixed build and the assertion turns on the insertion
  rather than on whether anything got ranked.

`tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistOverlayContentRenderTests.cs`

  - `TerminalPane_WhenShellIntegrationArrivesOffTheUiThread_ArmsEnterOnceTheOverlayIsShown`

  The guard for the hypothesis this bug was first blamed on, since the Bug 1 fix
  moved initialization onto the dispatcher and so put "probe installed", "views
  bound" and "first placement pass" in an order the calling thread no longer
  decides. Initializes Command Assist from the PTY-side thread (`Task.Run`,
  asserting it really is off the UI thread), opens Ctrl+R, then requires
  `pane.IsCommandAssistOverlayRendered` and the published
  `IsAcceptOnEnterArmed` to agree with the screen. Demonstrably able to fail: a
  probe hardwired to `false` while the overlay is up fails it (along with 7
  other arming-dependent tests).

## Live verification, after the fix

Real GUI, dev build from this worktree, isolated `NOVATERM_APPDATA_ROOT`,
integrated pwsh 7 session with 133 marks flowing. Screenshotted at every step,
and each step run on a prompt row PSReadLine had already rendered (the state
that used to refuse):

  - typing flow unaffected: typed `echo verify-typing-flow`, Enter submitted it
    and the shell printed `verify-typing-flow`;
  - Ctrl+R -> Down -> Enter: prompt line became
    `PS C:\Users\behna> ,dir` (the second row inserted), popup closed;
  - Ctrl+R -> Ctrl+Enter: prompt line became
    `PS C:\Users\behna> echo verify-typing-flow` (the top row inserted), popup
    closed;
  - Ctrl+R -> Esc: popup closed, prompt line still empty, nothing submitted.

Before the fix, in the same session, the same steps produced an empty submit
(Enter) and a no-op (Ctrl+Enter), with the refusal logged at the planner.

---

# Tests

  NovaTerminal.App.Tests            Total 2048, Failed 0, Skipped 15
  NovaTerminal.VT.Tests             Total  332, Failed 0
  NovaTerminal.Architecture.Tests   Total   28, Failed 0

Run per project against the built xunit host rather than through a solution-wide
`dotnet test`. The `VtReportCliTests` Release-shim flake reported in an earlier
revision of this description did not recur.

Clean build (`scripts/build.ps1 clean` then `build src/NovaTerminal.App`): 0
errors, no AVLN diagnostics.
