### PR TITLE
chore(build): kill stale NovaTerminal.McpServer processes before compiling

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -31,6 +31,33 @@ $verbs = @('build','test','publish','pack','msbuild','clean')
 if ($verbs -contains $dotnetArgs[0]) {
     $rest = @($dotnetArgs | Select-Object -Skip 1)
     $dotnetArgs = @($dotnetArgs[0], '-nodeReuse:false') + $rest
+
+    # Kill stale NovaTerminal.McpServer processes before compiling. MCP clients
+    # (Claude Desktop, Cowork, etc.) launch the server from this repo's bin output
+    # and often leave it running, which locks the DLLs and fails the build with
+    # "file is in use". Killing is always safe: clients respawn the server on the
+    # next tool call. Scoped to servers launched from THIS repo tree only.
+    # Note: $env:OS is not reliable here (some hosts spawn children with a stripped
+    # environment), so use the runtime's own platform check.
+    if ([Environment]::OSVersion.Platform -eq [PlatformID]::Win32NT) {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+        try {
+            $stale = @(Get-CimInstance Win32_Process -Filter "Name = 'dotnet.exe'" -ErrorAction Stop |
+                Where-Object {
+                    $_.CommandLine -and
+                    $_.CommandLine -like '*NovaTerminal.McpServer.dll*' -and
+                    $_.CommandLine -like "*$repoRoot*"
+                })
+            foreach ($p in $stale) {
+                Stop-Process -Id $p.ProcessId -Force -ErrorAction SilentlyContinue
+            }
+            if ($stale.Count -gt 0) {
+                Write-Output "build.ps1: killed $($stale.Count) stale NovaTerminal.McpServer process(es) locking bin outputs."
+            }
+        } catch {
+            Write-Output "build.ps1: stale-server sweep skipped ($($_.Exception.Message))"
+        }
+    }
 }
 
 & dotnet @dotnetArgs


### PR DESCRIPTION
Fixes the recurring "build blocked because the MCP server is holding the DLLs" problem.

MCP clients (Claude Desktop, Cowork, etc.) launch NovaTerminal.McpServer from this repo's bin output and routinely leave the process running. Every subsequent build then fails with file-in-use errors until the processes are killed by hand -- six of them had accumulated at the last occurrence (4x Release, 2x Debug).

scripts/build.ps1 now sweeps stale servers before compile verbs (build/test/publish/pack/msbuild/clean):

- Matches only dotnet.exe processes whose command line references NovaTerminal.McpServer.dll under THIS repo tree, so servers launched from other checkouts or unrelated dotnet processes are untouched.
- Killing is always safe: MCP clients respawn the server on the next tool call.
- Windows-only (guarded by OSVersion.Platform, not env:OS -- the latter arrives empty under hosts that spawn children with a stripped environment, which is exactly the environment this script runs in).
- Failures in the sweep are logged and never fail the build.

Verified end-to-end on this machine: launched a decoy server from the worktree bin, ran the wrapper, observed "build.ps1: killed 1 stale NovaTerminal.McpServer process(es) locking bin outputs." in the captured log, decoy gone, build 0 errors. Script parses clean under both pwsh and Windows PowerShell 5.1.

build.sh is deliberately untouched: the lock problem is Windows-specific (Linux allows deleting open files).
