### PR TITLE
fix(command-assist): close password-capture holes and restore accept on cmd.exe and Windows PowerShell

### DIFF
--- a/docs/command-assist/CommandAssist.md
+++ b/docs/command-assist/CommandAssist.md
@@ -162,6 +162,19 @@ every pane's assist surface, so rows that were on screen when the store was empt
 something the user can still accept. The remote shell-integration snippet copy affordance from Phase 2b
 sits directly below.
 
+**Clear history also deletes the pre-V2 files**, and that is a privacy fix rather than tidiness. V1's
+Enter-time capture read a keystroke mirror with no echo check at all, so a password typed at a
+non-echoing prompt in a markless session *was* written to `history.json` verbatim — `SecretsFilter` is
+pattern-based and a bare secret has no pattern. `JsonlHistoryStore` migrates that file into
+`history.jsonl` unfiltered and renames the source to `history.json.bak`, so before this a user who
+suspected a secret in their history and pressed the only button offered still had it on disk in the
+backup, under a confirmation prompt that said "this deletes every recorded command". `ClearAsync` now
+removes `history.jsonl`, `history.json` and `history.json.bak`; the confirmation copy says so.
+
+If you ran a Nova build from before PR #286 (V2 Phase 1c, 2026-08-02), assume anything you typed at a
+hidden prompt in a `cmd.exe` or un-instrumented SSH pane may be in your history, and clear it. Builds
+from #286 onward cannot capture it: see the echo gate below.
+
 `CommandAssistHistoryEnabled` used to be a second master flag by accident: `IsCommandAssistFeatureEnabled`
 required it, so turning capture off killed the bubble, the popup, Help, Fix and path suggestions too.
 Phase 3b decoupled them.

--- a/src/NovaTerminal.App/Controls/MarklessSubmissionAccumulator.cs
+++ b/src/NovaTerminal.App/Controls/MarklessSubmissionAccumulator.cs
@@ -58,6 +58,54 @@ namespace NovaTerminal.Controls
         /// </remarks>
         private volatile bool _poisoned;
 
+        /// <summary>
+        /// The terminal answered a device query (DA, DSR, DECRQM, an OSC colour report) on this
+        /// command line. Blocks history capture; deliberately does <em>not</em> block
+        /// <see cref="IsCleanAndEmpty"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <strong>This split is the fix for the owner's "Enter puts nothing in the terminal on
+        /// cmd.exe" report, and the asymmetry is the whole of it.</strong> A device reply is bytes
+        /// Nova wrote to the PTY that no keystroke produced. In the ordinary case the program that
+        /// issued the query reads them back - that is why it asked - and the command line is
+        /// untouched. In the pathological case (a query printed by something that then stopped
+        /// reading, the classic <c>cat</c> of a crafted file) they land in the shell's line editor as
+        /// literal input, sitting to the <em>left</em> of everything the user then types.
+        /// </para>
+        /// <para>
+        /// Those two cases are indistinguishable at the moment the reply is sent, so the two
+        /// consumers get the answer their own failure mode deserves:
+        /// </para>
+        /// <list type="bullet">
+        /// <item><description><b>Capture refuses.</b> The pathological case is undetectable
+        /// downstream: <c>TerminalPane.ReadEchoedMarklessSubmission</c> compares this buffer against
+        /// the same number of characters ending at the cursor, and injected bytes sit further left
+        /// than that window, so the echo gate matches and a command the user never ran
+        /// (<c>&lt;junk&gt;git status</c> recorded as <c>git status</c>) reaches permanent history.
+        /// <see cref="TryReadSubmission"/> therefore answers null for the rest of the line, exactly as
+        /// a poison would.</description></item>
+        /// <item><description><b>Insertion does not.</b> It asks a different question - "is the line
+        /// empty" - and a wrong answer costs something bounded and visible: the suggestion is typed
+        /// after the junk, on screen, editable, and the user still has to press Enter. That is the
+        /// same cost <c>TerminalPane.TryReadInsertionQuerySnapshot</c> already documents and accepts
+        /// for a markless pane running a program that reads stdin.</description></item>
+        /// </list>
+        /// <para>
+        /// The status quo it replaces was not a conservative choice, it was a dead feature. ConPTY
+        /// (and Clink, and any shell that probes the terminal at startup) issues a cursor-position
+        /// query while the first prompt is being drawn, so a local <c>cmd.exe</c> pane was poisoned
+        /// before the user touched the keyboard: measured live, <c>Ctrl+R</c> then <c>Enter</c> on a
+        /// brand-new pane refused every time, silently, and only started working after the first
+        /// command had been submitted (which is what resets the accumulator).
+        /// </para>
+        /// <para>
+        /// <c>volatile</c> for the same reason as <see cref="_poisoned"/>: the parser's response
+        /// callback runs on the PTY read thread.
+        /// </para>
+        /// </remarks>
+        private volatile bool _deviceReplyObserved;
+
         internal bool IsPoisoned => _poisoned;
 
         /// <summary>
@@ -71,6 +119,10 @@ namespace NovaTerminal.Controls
         /// whole command may be sent to it. See
         /// <c>TerminalPane.TryReadInsertionQuerySnapshot</c> for the rest of the gate (the echo flag,
         /// paste suppression, the alt screen).
+        /// <para>
+        /// Deliberately blind to <see cref="_deviceReplyObserved"/>, which is the one place this
+        /// question and the capture question are allowed to disagree. See that field for why.
+        /// </para>
         /// </remarks>
         internal bool IsCleanAndEmpty => !_poisoned && _buffer.Length == 0;
 
@@ -130,11 +182,18 @@ namespace NovaTerminal.Controls
         /// <summary>Something happened to the command line that this class cannot model.</summary>
         internal void Poison() => _poisoned = true;
 
+        /// <summary>
+        /// The terminal replied to a device query. See <see cref="_deviceReplyObserved"/> for why
+        /// this is not <see cref="Poison"/>.
+        /// </summary>
+        internal void ObserveDeviceReply() => _deviceReplyObserved = true;
+
         /// <summary>New command line: forget the text and clear the poison.</summary>
         internal void Reset()
         {
             _buffer.Clear();
             _poisoned = false;
+            _deviceReplyObserved = false;
         }
 
         /// <summary>
@@ -142,7 +201,11 @@ namespace NovaTerminal.Controls
         /// able to say. Does not reset — the caller resets after the read, because Enter is both
         /// the read point and the reset point and the order matters.
         /// </summary>
-        internal string? TryReadSubmission() => _poisoned ? null : _buffer.ToString();
+        /// <remarks>
+        /// A device reply refuses here as firmly as a poison does, and only here; see
+        /// <see cref="_deviceReplyObserved"/>.
+        /// </remarks>
+        internal string? TryReadSubmission() => _poisoned || _deviceReplyObserved ? null : _buffer.ToString();
 
         /// <summary>
         /// How a key press observed at <c>TerminalPane.TryHandleCommandAssistKey</c> affects the

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -2526,14 +2526,16 @@ namespace NovaTerminal.Controls
             Parser = new AnsiParser(Buffer);
 
             // A device reply is text on the PTY that the keyboard path never produced: DA1, a DSR
-            // cursor report, an answerback. Nothing here can promise the shell's line editor was
-            // not reading when the query arrived, and a reply that lands in a line editor is
-            // literal input in exactly the way a paste is - so the accumulator can no longer
-            // describe the line. Poison rather than reset, for the same reason
-            // NotifyExternalInputSent poisons: the writer cannot say whether what it sent ended the
-            // line. Subscribed here rather than beside the SendInput handler in
-            // InitializeSessionCore so it exists whenever a parser does, session or not.
-            Parser.OnResponse += _ => _marklessSubmission.Poison();
+            // cursor report, an answerback. Nothing here can promise the shell's line editor was not
+            // reading when the query arrived, so history capture stands down for the rest of the
+            // line - but the accumulator is *not* poisoned outright, because a local pane is sent one
+            // of these before the user has touched the keyboard (ConPTY and Clink both probe the
+            // terminal while the first prompt is drawn) and a poison there disabled suggestion
+            // insertion for the whole session. See MarklessSubmissionAccumulator's
+            // _deviceReplyObserved for the full argument and the measurement. Subscribed here rather
+            // than beside the SendInput handler in InitializeSessionCore so it exists whenever a
+            // parser does, session or not.
+            Parser.OnResponse += _ => _marklessSubmission.ObserveDeviceReply();
 
             // OSC 10/11 (fg/bg color query) answers come from the active theme; without this,
             // a freshly-created parser would fall back to AnsiParser's hardcoded defaults until

--- a/src/NovaTerminal.App/SettingsWindow.axaml
+++ b/src/NovaTerminal.App/SettingsWindow.axaml
@@ -584,7 +584,8 @@
                             <Grid ColumnDefinitions="*,360" Margin="24,0,0,0">
                                 <StackPanel Grid.Column="0" Spacing="2">
                                     <TextBlock Classes="RowLabel" Text="Remember commands"/>
-                                    <TextBlock Classes="RowDesc" TextWrapping="Wrap" Text="Record the commands you run so they can be suggested and searched with Ctrl+R. Values that look like secrets are redacted before anything is written. With this off the assistant still suggests file paths and explains failures - it just stops writing history."/>
+                                    <TextBlock Classes="RowDesc" TextWrapping="Wrap" Text="Record the commands you run so they can be suggested and searched with Ctrl+R. Only what the shell echoed on screen is recorded, so a password typed at a hidden prompt is never captured, and common secret-bearing arguments (--password, tokens, bearer headers) are redacted before anything is written. Other secrets typed as part of a visible command are not. With this off the assistant still suggests file paths and explains failures - it just stops writing history."/>
+                                    <TextBlock Classes="RowDesc" TextWrapping="Wrap" Text="Suspect something sensitive is in there? Clear history erases every recorded command, including anything carried over from an older version of Nova."/>
                                     <TextBlock Name="CommandAssistHistoryStatus" Classes="RowDesc" TextWrapping="Wrap" Text="" IsVisible="False"/>
                                 </StackPanel>
                                 <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Spacing="10">

--- a/src/NovaTerminal.App/SettingsWindow.axaml.cs
+++ b/src/NovaTerminal.App/SettingsWindow.axaml.cs
@@ -1519,7 +1519,7 @@ namespace NovaTerminal
                     clearButton.Content = "Confirm clear";
                     ShowRemoteShellIntegrationStatus(
                         status,
-                        "This deletes every recorded command. Click again to confirm.");
+                        "This deletes every recorded command, including history carried over from an older version. Click again to confirm.");
                     return;
                 }
 

--- a/src/NovaTerminal.CommandAssist/Application/AssistQuerySnapshot.cs
+++ b/src/NovaTerminal.CommandAssist/Application/AssistQuerySnapshot.cs
@@ -33,10 +33,11 @@ namespace NovaTerminal.CommandAssist.Application;
 /// typed prefix.
 /// </param>
 /// <param name="RightPromptTrimmed">
-/// A right-aligned prompt (zsh <c>RPROMPT</c>, fish <c>fish_right_prompt</c>, starship's right
-/// prompt) was recognised on the final row and excluded. The reader's trim is deliberately
-/// conservative, but "conservative" is not "certain": the tail of the line is the one part of it
-/// that may not be what the user typed.
+/// A right-aligned prompt (zsh <c>RPROMPT</c>, fish <c>fish_right_prompt</c>, oh-my-posh's and
+/// starship's right prompts) was recognised on the final row and excluded. The reader's trim is
+/// deliberately conservative, but "conservative" is not "certain": the tail of the line is the one
+/// part of it that may not be what the user typed. Diagnostic only - see
+/// <see cref="IsUsableAsTypedPrefix"/> for why insertion does not branch on it.
 /// </param>
 public readonly record struct AssistQuerySnapshot(
     string Text,
@@ -49,19 +50,43 @@ public readonly record struct AssistQuerySnapshot(
     /// the end of - the assumption every suffix-append insertion rests on.
     /// </summary>
     /// <remarks>
-    /// Three ways it fails, and all three are ordinary rather than exotic:
+    /// <para>
+    /// Two ways it fails, and both are ordinary rather than exotic:
+    /// </para>
     /// <list type="bullet">
     /// <item>the cursor is not at the end, so appending would land text in the middle of the line;</item>
     /// <item>the entry is multiline, so the text contains continuation-prompt cells that were never
-    /// typed;</item>
-    /// <item>a right prompt was trimmed, so the tail of the line is the reader's judgement rather
-    /// than an observation.</item>
+    /// typed.</item>
     /// </list>
+    /// <para>
     /// Ranking and help still run on an untrustworthy snapshot - a bad ranking shows the wrong rows,
     /// which the user ignores. A bad insertion edits the user's command line.
+    /// </para>
+    /// <para>
+    /// <strong><see cref="RightPromptTrimmed"/> used to be a third term, and removing it is the fix
+    /// for the owner's "Enter puts nothing in the terminal on Windows PowerShell" report.</strong> It
+    /// was redundant with the cursor test, and the redundancy is provable rather than probable.
+    /// <c>GridQueryReader.FindRightPromptGapStart</c> searches for the separating gap with its floor at
+    /// <c>max(firstCol, cursorCol)</c>, so the trim boundary is always at or after the cursor and
+    /// <em>nothing left of the cursor is ever discarded</em>. Whatever the reader removed - a genuine
+    /// right prompt or, in the case its five conditions were meant to catch, typed input that happened
+    /// to look like one - it was removed from the region past the cursor, which
+    /// <c>CommandAssistInsertionPlanner</c> does not read: the planner compares
+    /// <see cref="Text"/> against the selected command only when <see cref="CursorOffset"/> equals its
+    /// length, i.e. exactly when the trimmed region was empty of anything before the cursor.
+    /// </para>
+    /// <para>
+    /// The cost of keeping it was not theoretical. A right-aligned prompt (oh-my-posh's, zsh's
+    /// <c>RPROMPT</c>, starship's) painted on the input row sets the flag on <em>every</em> prompt, so
+    /// every accept refused for the life of the session. Windows PowerShell shows this and pwsh 7 does
+    /// not for a reason that has nothing to do with correctness: PSReadLine 2.3 repaints the input line
+    /// out to the right edge and erases the right prompt off the grid, while the 2.0 that ships with
+    /// Windows PowerShell 5.1 leaves it painted. Same prompt, same shell family, opposite behaviour -
+    /// which is what the owner saw.
+    /// </para>
     /// </remarks>
     public bool IsUsableAsTypedPrefix =>
-        !IsMultiline && !RightPromptTrimmed && CursorOffset == Text.Length;
+        !IsMultiline && CursorOffset == Text.Length;
 
     /// <summary>
     /// <see cref="Text"/> up to the cursor: what the user has actually put on the line to the left of

--- a/src/NovaTerminal.CommandAssist/Storage/JsonlHistoryStore.cs
+++ b/src/NovaTerminal.CommandAssist/Storage/JsonlHistoryStore.cs
@@ -187,6 +187,38 @@ public sealed class JsonlHistoryStore : IHistoryStore
         }
     }
 
+    /// <summary>
+    /// Deletes every recorded command: the live log, the un-migrated V1 file, and the backup the
+    /// migration leaves behind.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>The two legacy files are the privacy half of this method, added after the owner's
+    /// "I suspect it captures my passwords" report.</strong> The V1 capture path that Phase 1c
+    /// deleted read a keystroke mirror with no echo check at all, so a password typed at a
+    /// non-echoing prompt in a markless session <em>was</em> written to <c>history.json</c> verbatim
+    /// - <c>SecretsFilter</c> matches nothing on a bare word. Those entries are then copied into
+    /// <c>history.jsonl</c> unfiltered by
+    /// <see cref="TryMigrateLegacyFileUnsafeAsync"/>, and the source is renamed to
+    /// <c>history.json.bak</c> rather than deleted.
+    /// </para>
+    /// <para>
+    /// Truncating only <c>history.jsonl</c> therefore left the very entries the user is trying to
+    /// erase sitting on disk in the backup, while the confirmation prompt said "this deletes every
+    /// recorded command". A user who suspects a secret is in their history has exactly one control,
+    /// and it has to be true.
+    /// </para>
+    /// <para>
+    /// Deleting the un-migrated <c>history.json</c> matters for a second reason: without it, a
+    /// <c>ClearAsync</c> that runs before the first read (which is a legal order - it does not load)
+    /// would leave the legacy file to be migrated in on the next launch, re-materialising everything
+    /// the user just cleared.
+    /// </para>
+    /// <para>
+    /// Deletion failures are swallowed. A locked backup file must not turn "clear my history" into
+    /// an error that leaves the live log intact, which is the strictly worse outcome.
+    /// </para>
+    /// </remarks>
     public async Task ClearAsync(CancellationToken cancellationToken = default)
     {
         await _gate.WaitAsync(cancellationToken);
@@ -196,10 +228,37 @@ public sealed class JsonlHistoryStore : IHistoryStore
             _loadIncomplete = false;
             _capChangePendingCompaction = false;
             await WriteAllUnsafeAsync(Array.Empty<CommandHistoryEntry>(), cancellationToken);
+            DeleteLegacyFilesUnsafe();
         }
         finally
         {
             _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Removes the pre-JSONL history file and the backup the migration renames it to. Best-effort.
+    /// </summary>
+    private void DeleteLegacyFilesUnsafe()
+    {
+        if (string.IsNullOrWhiteSpace(_legacyFilePath))
+        {
+            return;
+        }
+
+        foreach (string path in new[] { _legacyFilePath!, _legacyFilePath + ".bak" })
+        {
+            try
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+            catch
+            {
+                // See the remarks on ClearAsync: a locked legacy file must not fail the clear.
+            }
         }
     }
 

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistInsertionPlannerTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistInsertionPlannerTests.cs
@@ -182,16 +182,61 @@ public sealed class CommandAssistInsertionPlannerTests
     }
 
     /// <summary>
-    /// Refusal 4 - a right prompt was trimmed. The reader's RPROMPT heuristic is deliberately
-    /// conservative, but conservative means "over-returns rather than deletes"; when it did fire,
-    /// the tail of the line is an inference and the tail is exactly what a suffix append attaches
-    /// to.
+    /// <strong>A trimmed right prompt is no longer a refusal, and this is the owner's "Enter puts
+    /// nothing in the terminal on Windows PowerShell" report at planner scope.</strong>
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// It used to be refusal 4, on the reasoning that the tail of the line was the reader's inference
+    /// and the tail is what a suffix append attaches to. The first half is true and the second is not:
+    /// <c>GridQueryReader.FindRightPromptGapStart</c> floors its search at the cursor column, so the
+    /// trim boundary is always at or after the cursor and never removes anything the append is measured
+    /// against. What survives is <see cref="AssistQuerySnapshot.IsUsableAsTypedPrefix"/>'s cursor test,
+    /// which is the real guard.
+    /// </para>
+    /// <para>
+    /// Left in as a refusal it made Command Assist inert for anyone with a right-aligned prompt -
+    /// oh-my-posh, zsh <c>RPROMPT</c>, starship - because the flag is then set on every prompt the
+    /// shell paints.
+    /// </para>
+    /// </remarks>
     [Fact]
-    public void TryCreateInsertion_WhenARightPromptWasTrimmed_Refuses()
+    public void TryCreateInsertion_WhenARightPromptWasTrimmed_StillSendsTheSuffix()
     {
         bool created = CommandAssistInsertionPlanner.TryCreateInsertion(
             Line("git st", rightPromptTrimmed: true),
+            selectedCommand: "git status",
+            out string? textToSend);
+
+        Assert.True(created);
+        Assert.Equal("atus", textToSend);
+    }
+
+    /// <summary>
+    /// The empty-line case of the same prompt, which is the one the owner actually pressed
+    /// <c>Enter</c> on: <c>Ctrl+R</c> at a bare prompt whose row carries a right-aligned badge.
+    /// </summary>
+    [Fact]
+    public void TryCreateInsertion_OnAnEmptyLineWithARightPromptTrimmed_SendsTheWholeCommand()
+    {
+        bool created = CommandAssistInsertionPlanner.TryCreateInsertion(
+            Line(string.Empty, rightPromptTrimmed: true),
+            selectedCommand: "git status",
+            out string? textToSend);
+
+        Assert.True(created);
+        Assert.Equal("git status", textToSend);
+    }
+
+    /// <summary>
+    /// The guard that did the work all along is untouched: a trimmed right prompt with the cursor
+    /// somewhere else on the line still refuses, because the cursor is not at the end.
+    /// </summary>
+    [Fact]
+    public void TryCreateInsertion_WhenARightPromptWasTrimmedAndTheCursorIsMidLine_StillRefuses()
+    {
+        bool created = CommandAssistInsertionPlanner.TryCreateInsertion(
+            Line("git st", cursorOffset: 3, rightPromptTrimmed: true),
             selectedCommand: "git status",
             out string? textToSend);
 

--- a/tests/NovaTerminal.App.Tests/CommandAssist/JsonlHistoryStoreTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/JsonlHistoryStoreTests.cs
@@ -194,6 +194,63 @@ public sealed class JsonlHistoryStoreTests : IDisposable
         Assert.Empty(await CreateStore().GetRecentAsync(10));
     }
 
+    /// <summary>
+    /// <strong>"Clear history" has to be true, and the backup the migration leaves behind is where a
+    /// V1-captured secret would still be sitting.</strong>
+    /// </summary>
+    /// <remarks>
+    /// The V1 Enter-time capture read a keystroke mirror with no echo check, so a password typed at a
+    /// non-echoing prompt in a markless session was written to <c>history.json</c> verbatim -
+    /// <c>SecretsFilter</c> matches nothing on a bare word. The migration copies those entries into
+    /// <c>history.jsonl</c> unfiltered and renames the source to <c>.bak</c>, so truncating only the
+    /// live log left exactly the entries the user was trying to erase on disk, under a confirmation
+    /// prompt that said otherwise. A user who suspects a secret is in their history has one control
+    /// and it has to work.
+    /// </remarks>
+    [Fact]
+    public async Task ClearAsync_AlsoDeletesTheMigratedLegacyBackup()
+    {
+        await File.WriteAllTextAsync(
+            _legacyPath,
+            JsonSerializer.Serialize(
+                new List<CommandHistoryEntry> { CreateEntry("hunter2") },
+                CommandAssistJsonContext.Default.ListCommandHistoryEntry));
+
+        JsonlHistoryStore store = CreateStore();
+
+        // The read is what runs the migration; after it, the secret lives in two files.
+        Assert.Single(await store.GetRecentAsync(10));
+        Assert.True(File.Exists(_legacyPath + ".bak"));
+
+        await store.ClearAsync();
+
+        Assert.Empty(await store.GetRecentAsync(10));
+        Assert.False(File.Exists(_legacyPath + ".bak"));
+    }
+
+    /// <summary>
+    /// And an un-migrated legacy file goes too, or the next launch migrates it straight back in.
+    /// </summary>
+    /// <remarks>
+    /// Reachable because <c>ClearAsync</c> does not load: clearing before anything has read the store
+    /// writes an empty <c>history.jsonl</c>, which then permanently suppresses the migration guard -
+    /// so without this the entries would survive both the clear and every later read, invisible.
+    /// </remarks>
+    [Fact]
+    public async Task ClearAsync_BeforeAnyRead_AlsoDeletesTheUnmigratedLegacyFile()
+    {
+        await File.WriteAllTextAsync(
+            _legacyPath,
+            JsonSerializer.Serialize(
+                new List<CommandHistoryEntry> { CreateEntry("hunter2") },
+                CommandAssistJsonContext.Default.ListCommandHistoryEntry));
+
+        await CreateStore().ClearAsync();
+
+        Assert.False(File.Exists(_legacyPath));
+        Assert.Empty(await CreateStore().GetRecentAsync(10));
+    }
+
     [Fact]
     public async Task GetRecentAsync_WhenLineIsCorrupt_SkipsItAndKeepsTheRest()
     {

--- a/tests/NovaTerminal.App.Tests/Controls/MarklessSubmissionAccumulatorTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/MarklessSubmissionAccumulatorTests.cs
@@ -10,6 +10,92 @@ namespace NovaTerminal.Tests.Controls;
 /// </summary>
 public class MarklessSubmissionAccumulatorTests
 {
+    // ------------------------------------------------ device replies (dogfood report 2, cmd.exe)
+
+    /// <summary>
+    /// A device reply stands history capture down for the rest of the line. It is not observable
+    /// which of the two things happened - the program that issued the query read its answer, or the
+    /// answer landed in the shell's line editor as literal input to the left of everything typed
+    /// since - and the second one would put a command the user never ran into permanent history.
+    /// </summary>
+    [Fact]
+    public void AfterADeviceReply_CaptureRefusesEvenThoughTheTypedTextIsKnown()
+    {
+        var accumulator = new MarklessSubmissionAccumulator();
+
+        accumulator.AppendTypedText("git status");
+        accumulator.ObserveDeviceReply();
+
+        Assert.Null(accumulator.TryReadSubmission());
+    }
+
+    /// <summary>
+    /// <strong>And it deliberately does not answer the insertion question, which is the fix for the
+    /// owner's "Enter puts nothing in the terminal on cmd.exe" report.</strong>
+    /// </summary>
+    /// <remarks>
+    /// ConPTY and Clink both probe the terminal while the first prompt is drawn, so a local markless
+    /// pane receives one of these before the user has touched the keyboard. Treating it as a poison
+    /// made <c>IsCleanAndEmpty</c> false from session start, which is the sole gate on degraded-mode
+    /// insertion: <c>Ctrl+R</c> then <c>Enter</c> on a brand-new <c>cmd.exe</c> pane sent nothing,
+    /// silently, until the user had submitted a command by hand. Insertion's failure mode is a
+    /// visible, editable line rather than a permanent record, so it gets the other answer.
+    /// </remarks>
+    [Fact]
+    public void AfterADeviceReplyOnAnUntouchedLine_TheLineIsStillProvablyEmpty()
+    {
+        var accumulator = new MarklessSubmissionAccumulator();
+
+        accumulator.ObserveDeviceReply();
+
+        Assert.True(accumulator.IsCleanAndEmpty);
+        Assert.False(accumulator.IsPoisoned);
+    }
+
+    /// <summary>
+    /// The carve-out is scoped to "nothing has been typed". A device reply plus typed characters is
+    /// still a non-empty line, so insertion refuses for the ordinary reason.
+    /// </summary>
+    [Fact]
+    public void AfterADeviceReplyAndTyping_TheLineIsNotEmpty()
+    {
+        var accumulator = new MarklessSubmissionAccumulator();
+
+        accumulator.ObserveDeviceReply();
+        accumulator.AppendTypedText("gi");
+
+        Assert.False(accumulator.IsCleanAndEmpty);
+    }
+
+    /// <summary>A real poison still wins over an empty buffer, device reply or not.</summary>
+    [Fact]
+    public void ADeviceReplyDoesNotUnPoison()
+    {
+        var accumulator = new MarklessSubmissionAccumulator();
+
+        accumulator.Poison();
+        accumulator.ObserveDeviceReply();
+
+        Assert.False(accumulator.IsCleanAndEmpty);
+        Assert.Null(accumulator.TryReadSubmission());
+    }
+
+    /// <summary>
+    /// The reply is scoped to the command line it arrived on, like every other fact here: a new line
+    /// starts clean and can be captured again.
+    /// </summary>
+    [Fact]
+    public void Reset_ClearsTheDeviceReply()
+    {
+        var accumulator = new MarklessSubmissionAccumulator();
+
+        accumulator.ObserveDeviceReply();
+        accumulator.Reset();
+        accumulator.AppendTypedText("git status");
+
+        Assert.Equal("git status", accumulator.TryReadSubmission());
+    }
+
     [Fact]
     public void TypingThenReading_ReturnsExactlyWhatWasTyped()
     {

--- a/tests/NovaTerminal.App.Tests/Controls/PaneAssistInsertionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneAssistInsertionTests.cs
@@ -3,6 +3,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
+using NovaTerminal.CommandAssist.Application;
 using NovaTerminal.CommandAssist.Models;
 using NovaTerminal.CommandAssist.ViewModels;
 using NovaTerminal.Controls;
@@ -313,6 +314,118 @@ public class PaneAssistInsertionTests
         Assert.True(fixture.ViewModel.IsVisible);
     }
 
+    // ------------- a terminal that answered a device query (dogfood report 2, cmd.exe)
+
+    /// <summary>
+    /// <strong>The owner's "Enter puts nothing in the terminal if I am in cmd" report, reproduced
+    /// through the real parser.</strong> A markless pane whose terminal has answered a device query -
+    /// which ConPTY and Clink both provoke while the first prompt is being drawn - could never insert
+    /// anything for the life of the session.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>ESC [ 6 n</c> is a cursor-position report request; the parser answers it on the pane's
+    /// behalf, which is what raises <c>AnsiParser.OnResponse</c>. That used to poison the markless
+    /// accumulator outright, and the accumulator being clean <em>and</em> empty is the whole of the
+    /// degraded-mode insertion gate - so <c>Ctrl+R</c>, pick a row, <c>Enter</c> sent nothing, with no
+    /// user-visible cause and nothing on screen to explain it. Only submitting a command by hand
+    /// (which resets the accumulator) unstuck it, which is why it read as "the feature does not work
+    /// in cmd".
+    /// </para>
+    /// <para>
+    /// The query goes through <c>Parser.Process</c> rather than being simulated, so this test fails if
+    /// the response plumbing is rewired as well as if the gate regresses.
+    /// </para>
+    /// </remarks>
+    [AvaloniaFact]
+    public async Task InADegradedSessionAfterTheTerminalAnsweredADeviceQuery_EnterStillSendsTheWholeCommand()
+    {
+        using var fixture = await Fixture.DegradedAtAHistorySearchAsync(history: "git status");
+
+        fixture.Pane.Parser!.Process("\x1b[6n");
+
+        Assert.True(fixture.PressDown());
+        Assert.True(fixture.PressEnter());
+        Assert.Equal("git status", Assert.Single(fixture.Session.Sent));
+    }
+
+    /// <summary>The same through <c>Ctrl+Enter</c>, which is the chord the pane's own gate is written for.</summary>
+    [AvaloniaFact]
+    public async Task InADegradedSessionAfterTheTerminalAnsweredADeviceQuery_CtrlEnterStillSendsTheWholeCommand()
+    {
+        using var fixture = await Fixture.DegradedAtAHistorySearchAsync(history: "git status");
+
+        fixture.Pane.Parser!.Process("\x1b[6n");
+
+        fixture.PressCtrlEnter();
+
+        Assert.Equal("git status", Assert.Single(fixture.Session.Sent));
+    }
+
+    // The other half of the split - history capture still refusing after a device reply - is pinned
+    // by PaneMarklessCaptureTests.InAMarklessSession_AParserDeviceReplyStopsTheLineBeingCaptured.
+
+    // ------------- a prompt with a right-aligned badge (dogfood report 2, Windows PowerShell)
+
+    /// <summary>
+    /// <strong>The owner's "Enter puts nothing in the terminal if I am in windows powershell"
+    /// report, reproduced through the real parser and grid reader.</strong>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The prompt is an oh-my-posh-shaped one: input on the left, a right-aligned badge painted at the
+    /// far edge of the same row. <c>GridQueryReader</c> recognises the badge and excludes it, which is
+    /// correct and is what keeps it out of the query - but it also raised <c>RightPromptTrimmed</c>,
+    /// and <c>AssistQuerySnapshot.IsUsableAsTypedPrefix</c> treated that as fatal. Since the flag is
+    /// set on <em>every</em> prompt such a shell paints, every accept refused for the life of the
+    /// session.
+    /// </para>
+    /// <para>
+    /// Why it split along shell lines the way the owner saw: pwsh 7's PSReadLine 2.3 repaints the input
+    /// line out to the right edge and erases the badge off the grid, so the flag is never raised there.
+    /// The PSReadLine 2.0 that ships with Windows PowerShell 5.1 leaves it painted. Same prompt, same
+    /// shell family, opposite outcome - and <c>cmd.exe</c> failed at the same time for the entirely
+    /// separate reason above, which is what made one report out of two bugs.
+    /// </para>
+    /// </remarks>
+    [AvaloniaFact]
+    public async Task OnAPromptWithARightAlignedBadge_EnterInsertsInsteadOfSubmitting()
+    {
+        using var fixture = await Fixture.AtAPromptWithARightAlignedBadgeAsync("git st", history: "git status");
+
+        Assert.True(fixture.PressEnter());
+        Assert.Equal("atus", Assert.Single(fixture.Session.Sent));
+    }
+
+    /// <summary>
+    /// The empty-line case, which is the exact keystroke sequence reported: <c>Ctrl+R</c> at a bare
+    /// prompt, then <c>Enter</c>.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task OnAnEmptyPromptWithARightAlignedBadge_EnterSendsTheWholeCommand()
+    {
+        using var fixture = await Fixture.AtAPromptWithARightAlignedBadgeAsync(string.Empty, history: "git status");
+
+        Assert.True(fixture.PressEnter());
+        Assert.Equal("git status", Assert.Single(fixture.Session.Sent));
+    }
+
+    /// <summary>
+    /// The badge is still excluded from the query - relaxing the insertion rule must not turn the right
+    /// prompt into text the assist thinks the user typed.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task OnAPromptWithARightAlignedBadge_TheBadgeIsNotPartOfTheQuery()
+    {
+        using var fixture = await Fixture.AtAPromptWithARightAlignedBadgeAsync("git st", history: "git status");
+
+        AssistQuerySnapshot snapshot = fixture.Pane.TryReadGatedAssistQuerySnapshotForTest()!.Value;
+
+        Assert.Equal("git st", snapshot.Text);
+        Assert.True(snapshot.RightPromptTrimmed);
+        Assert.True(snapshot.IsUsableAsTypedPrefix);
+    }
+
     // ------------------- the prompt row PSReadLine has rendered (second live bug)
 
     /// <summary>
@@ -509,6 +622,57 @@ public class PaneAssistInsertionTests
 
             fixture.Pane.OpenCommandAssistHistorySearch();
             await fixture.WaitForAsync(() => fixture.ViewModel.HasSuggestions);
+            return fixture;
+        }
+
+        /// <summary>
+        /// An instrumented prompt whose input row also carries a right-aligned badge, with the
+        /// history list up from <c>Ctrl+R</c>. This is the oh-my-posh / zsh <c>RPROMPT</c> shape as
+        /// PSReadLine 2.0 leaves it on the grid.
+        /// </summary>
+        /// <remarks>
+        /// The badge is painted by moving the cursor to the right edge, writing there, and moving
+        /// back to the input - which is exactly what a right prompt is - rather than by setting a
+        /// flag, so what this pins is the reader's recognition of a real screen shape. The badge is
+        /// deliberately narrow and the gap deliberately wide, because
+        /// <c>GridQueryReader.FindRightPromptGapStart</c> only recognises a right prompt when the gap
+        /// dominates the badge; a fixture that failed those conditions would leave
+        /// <c>RightPromptTrimmed</c> clear and the test would pass without testing anything.
+        /// </remarks>
+        public static async Task<Fixture> AtAPromptWithARightAlignedBadgeAsync(string commandLine, string history)
+        {
+            const string Badge = "in pwsh";
+
+            Fixture fixture = await CreateAsync(history);
+            fixture.Pane.ArmShellIntegrationTracker();
+            fixture.Pane.CreateAndWireParser();
+            fixture.Pane.Parser!.Process(PromptStart + "$ " + PromptEnd + commandLine);
+
+            int cols = fixture.Pane.Buffer!.Cols;
+            int inputEndColumn = 2 + commandLine.Length; // "$ " plus what is typed
+            Assert.True(
+                cols - Badge.Length > inputEndColumn + GridQueryReader.MinRightPromptGap,
+                "the fixture needs a gap wide enough for the reader to recognise the badge");
+            Assert.True(
+                Badge.Length <= cols / GridQueryReader.MaxRightPromptWidthDivisor,
+                "the fixture's badge must be narrow enough to be a badge");
+
+            // 1-based CUP: paint the badge flush against the right edge, then put the cursor back
+            // where the line editor left it.
+            fixture.Pane.Parser!.Process($"\x1b[1;{cols - Badge.Length + 1}H{Badge}");
+            fixture.Pane.Parser!.Process($"\x1b[1;{inputEndColumn + 1}H");
+
+            await Task.Delay(50);
+
+            fixture.Pane.OpenCommandAssistHistorySearch();
+            await fixture.WaitForAsync(() => fixture.ViewModel.HasSuggestions);
+
+            AssistQuerySnapshot snapshot = fixture.Pane.TryReadGatedAssistQuerySnapshotForTest()
+                ?? throw new InvalidOperationException("the fixture's prompt must be readable");
+            Assert.True(
+                snapshot.RightPromptTrimmed,
+                "the fixture must actually reproduce a trimmed right prompt");
+
             return fixture;
         }
 

--- a/tests/NovaTerminal.App.Tests/Controls/PaneMarklessCaptureTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneMarklessCaptureTests.cs
@@ -379,8 +379,19 @@ public class PaneMarklessCaptureTests
     /// <summary>
     /// A device reply — DA1 here, but a DSR cursor report or an answerback the same way — is text
     /// on the PTY that the keyboard never produced. If it arrives while a line editor is reading,
-    /// it lands in the line exactly as a paste would.
+    /// it lands in the line exactly as a paste would, to the <em>left</em> of everything the user
+    /// types afterwards — which the echo gate cannot see, because it compares the accumulated text
+    /// against the same number of characters ending at the cursor and the injected bytes sit further
+    /// left than that window. So the capture path refuses.
     /// </summary>
+    /// <remarks>
+    /// This is one half of a deliberate split, and the assertion here is the half that must not move.
+    /// The other half - insertion, which asks "is the line empty" rather than "what was typed", and
+    /// whose failure mode is a visible editable line rather than a permanent record - keeps working
+    /// after a device reply, and is pinned by
+    /// <c>PaneAssistInsertionTests.InADegradedSessionAfterTheTerminalAnsweredADeviceQuery_EnterStillSendsTheWholeCommand</c>.
+    /// See <c>MarklessSubmissionAccumulator</c>'s <c>_deviceReplyObserved</c>.
+    /// </remarks>
     [AvaloniaFact]
     public async Task InAMarklessSession_AParserDeviceReplyStopsTheLineBeingCaptured()
     {
@@ -433,6 +444,76 @@ public class PaneMarklessCaptureTests
         fixture.PressEnter();
 
         Assert.True(await fixture.NothingWasCapturedAsync());
+    }
+
+    /// <summary>
+    /// <strong>The owner's "I suspect it also captures my passwords" report, in the shape that is
+    /// hardest to see: an <em>instrumented</em> session where the password prompt belongs to a
+    /// program the shell is running.</strong>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// It is easy to assume the echo gate is only load-bearing for markless panes, because that is
+    /// the session the accumulator was written for. It is not. Between the <c>OSC 133;C</c> that
+    /// accepts a line and the next <c>B</c>, an instrumented session has no command line to read
+    /// either, so <c>TerminalPane.OnCommandAssistEnterObserved</c> falls back to the accumulator
+    /// exactly as <c>cmd.exe</c> does - and the accumulator was reset by the last <c>Enter</c>, so at
+    /// the remote <c>password:</c> prompt it is holding a clean, unpoisoned copy of the secret with
+    /// nothing else standing in the way. Measured on a live pwsh 7 and Windows PowerShell pane during
+    /// the dogfood audit: at the second <c>Enter</c> the accumulator held the marker string and the
+    /// echo gate was the only thing that dropped it.
+    /// </para>
+    /// <para>
+    /// The <c>C</c> here deliberately carries no payload. A payload-bearing <c>C</c> would also set
+    /// <c>AssistSessionContext.IsStructuredCaptureActive</c> and stand the heuristic path down
+    /// entirely, so the test would pass without the gate ever being consulted. This shape - the
+    /// payload-less <c>C</c> that iTerm2's and VS Code's snippets emit, and that the remote snippet
+    /// degrades to - leaves the heuristic path armed, which is the case worth pinning.
+    /// </para>
+    /// </remarks>
+    [AvaloniaFact]
+    public async Task InAnIntegratedSession_APasswordTypedWhileACommandIsRunningIsNotCaptured()
+    {
+        using var fixture = await Fixture.IntegratedAsync("ssh host");
+
+        fixture.PressEnter();
+        CommandHistoryEntry entry = await fixture.WaitForSingleEntryAsync();
+        Assert.Equal("ssh host", entry.CommandText);
+
+        // The shell says the line was accepted, which shuts the command-input window: from here the
+        // grid offers nothing and the pane is back on the accumulator.
+        fixture.Echo("\x1b]133;C\x07");
+        await Task.Delay(50);
+        Assert.Null(fixture.Pane.TryReadGatedAssistQuerySnapshotForTest());
+
+        fixture.Echo("\r\nhost's password: ");
+        fixture.Type("hunter2", echo: false);
+        fixture.PressEnter();
+
+        Assert.True(await fixture.OnlyTheFirstEntryWasCapturedAsync("ssh host"));
+    }
+
+    /// <summary>
+    /// The control for the test above: the same session, the same closed window, a prompt that
+    /// <em>does</em> echo. Without this, "nothing was captured" would be satisfied by a fallback path
+    /// that had simply stopped working.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task InAnIntegratedSession_AnEchoedLineAfterTheWindowClosedIsStillCaptured()
+    {
+        using var fixture = await Fixture.IntegratedAsync("cat > notes");
+
+        fixture.PressEnter();
+        await fixture.WaitForSingleEntryAsync();
+
+        fixture.Echo("\x1b]133;C\x07");
+        await Task.Delay(50);
+
+        fixture.Echo("\r\n");
+        fixture.Type("hello there");
+        fixture.PressEnter();
+
+        Assert.True(await fixture.WaitForEntryAsync("hello there"));
     }
 
     private sealed class Fixture : IDisposable
@@ -549,6 +630,28 @@ public class PaneMarklessCaptureTests
                 if (elapsed >= timeoutMs)
                 {
                     throw new TimeoutException("No history entry was captured.");
+                }
+
+                await Task.Delay(10);
+                elapsed += 10;
+            }
+        }
+
+        /// <summary>Whether <paramref name="expected"/> shows up in the store within the timeout.</summary>
+        public async Task<bool> WaitForEntryAsync(string expected, int timeoutMs = 2000)
+        {
+            int elapsed = 0;
+            while (true)
+            {
+                IReadOnlyList<CommandHistoryEntry> entries = await _historyStore.GetRecentAsync(10);
+                if (entries.Any(entry => entry.CommandText == expected))
+                {
+                    return true;
+                }
+
+                if (elapsed >= timeoutMs)
+                {
+                    return false;
                 }
 
                 await Task.Delay(10);


### PR DESCRIPTION
# fix(command-assist): close password-capture holes and restore accept on cmd.exe and Windows PowerShell

Two owner reports from dogfooding the merged Phase 0-3 stack (main @ 8a9fa1c).

- **Report 1 (security):** "I suspect it also captures my passwords as an item in the history."
- **Report 2:** "Enter key on command assistant put nothing in the terminal if I am in cmd or windows powershell. it works on ssh and other powershell [pwsh 7]."

Everything below was reproduced live, before and after, in isolated `NOVATERM_APPDATA_ROOT`
instances driven through the app's real keyboard path. The owner's own history file was never
opened.

---

## Report 1 - password-capture audit

### Verdict

**No live capture path can record a non-echoed secret.** Every path that can append to
`history.jsonl` was walked and then reproduced on a running pane; each one refused. The
reproductions are now permanent regression tests rather than a one-off check.

**But there is a real place a password can still be sitting, and it is the one control the user has
to erase it.** See "the legacy files" below. If the owner ran a Nova build from before PR #286
(2026-08-02), the recommendation is: **press Clear history.**

### Every writer into history, and what gates it

There are exactly two `AppendAsync` call sites in `src/`, both in `CapturePipeline`, plus one
patch path.

| # | Path | Gate that stops a secret | Verdict | Reproduced |
| --- | --- | --- | --- | --- |
| 1 | Heuristic Enter-time, **grid source** (instrumented session, `B..C` window open) | The text is read from the grid between the `OSC 133;B` mark and the cursor. A prompt that does not echo paints nothing, so the read is empty and `CapturePipeline` drops empty submissions. | Closed | Windows PowerShell 5.1, pwsh 7 |
| 2 | Heuristic Enter-time, **markless accumulator source** (`cmd.exe`, bailed bootstrap, un-instrumented SSH) | `TerminalPane.ReadEchoedMarklessSubmission` requires the accumulated text to be painted on the grid ending at the cursor (PR #287). A no-echo prompt fails it. | Closed | cmd.exe, live |
| 3 | Heuristic Enter-time, **markless accumulator inside an instrumented session** - the hole that is easy to miss: after `133;C` and before the next `B` an integrated pane has no grid line either and falls back to the accumulator exactly as `cmd.exe` does | Same echo gate. The accumulator really was holding the marker string at the password prompt; the gate is the only thing that dropped it. | Closed | pwsh 7 and Windows PowerShell, live |
| 4 | Structured `OSC 133;C` payload | Only records what the shell reports it accepted. PSReadLine's Enter handler is not active during `Read-Host -AsSecureString` or a native prompt, so no `C` is emitted for one. | Closed | Windows PowerShell, live (no `C` at the password prompt) |
| 5 | Remote bash snippet over SSH (`history 1` since #289) | bash does not add a password typed at a `sudo`/`ssh` prompt to its history, and the `DEBUG` trap does not fire for input read by a child process. No `C` is emitted. | Closed by construction | Not reproduced live (no SSH host available in the sandbox); covered by `RemoteBashSnippetIntegrationTests` |
| 6 | `TryUpdateExecutionResultAsync` (exit-code / duration patch) | Re-serializes an entry that already passed 1-5. Cannot introduce new text. | N/A | - |

`SecretsFilter` is explicitly **not** load-bearing here and never could be: it is pattern-based
and a bare password has no pattern. The echo gate is what does the work.

### Live reproductions

All three ran with `CommandAssistEnabled=true`, `CommandAssistHistoryEnabled=true`, an isolated
appdata root, and instrumentation on the capture path.

1. **Integrated Windows PowerShell 5.1** - `$s = Read-Host -AsSecureString 'pw'`, then typed
   `hunter2secretmarker` + Enter.
   Observed: no grid snapshot (the `B..C` window was shut by the `C` for the `Read-Host` line);
   the accumulator held all 19 characters, clean and unpoisoned; the echo gate read the grid as
   empty at the cursor and returned null. `history.jsonl`: no match for `hunter2`.
2. **Markless cmd.exe** - `powershell -NoProfile -Command "$s=Read-Host -AsSecureString pw"`, then
   typed `hunter2cmdmarker` + Enter. Same result; `history.jsonl` empty.
3. **Re-run of (2) after the Report 2 fixes**, because those relax the accumulator: typed
   `hunter2postfix`. Still refused, `history.jsonl` still empty.

The control in each case is a visible command typed at the same prompt, which *is* captured - so
"nothing was written" is not "capture is broken".

### Where a password can still be: the legacy files

V1's Enter-time capture read a keystroke mirror with **no echo check at all**. Confirmed against
the tree at `893eaf4^` (the commit before PR #286, V2 Phase 1c, 2026-08-02):

```csharp
public void HandleTextInput(string text)
{
    ...
    ViewModel.QueryText += text;      // every keystroke, no echo check
}

public async Task HandleEnterAsync()
{
    await _capturePipeline.CaptureSubmissionAsync(
        ViewModel.QueryText,          // the shadow buffer, verbatim
        _state.IsCurrentSubmissionSuppressed);
}
```

`CaptureSubmissionAsync` at that commit gated on alt-screen, structured-capture-active,
paste-suppression, non-empty and single-line - and nothing else. So on a pre-#286 build, `ssh host`
/ Enter / `hunter2` / Enter in a markless session wrote `hunter2` to `history.json` with
`IsRedacted: false`. **That is very likely what the owner is remembering, and those entries are
still in his history today**, because `JsonlHistoryStore.TryMigrateLegacyFileUnsafeAsync` copies
`history.json` into `history.jsonl` verbatim - no re-filtering, no re-inspection - and then renames
the source to `history.json.bak` rather than deleting it.

Worse: **Clear history did not remove either legacy file.** It truncated `history.jsonl` only,
under a confirmation prompt that read "This deletes every recorded command." A user who suspected a
secret and pressed the only button offered still had it on disk.

**Fixed here.** `ClearAsync` now deletes `history.jsonl`, `history.json` and `history.json.bak`.
Deleting the un-migrated file matters twice: `ClearAsync` does not load, so clearing before any read
writes an empty `history.jsonl` that permanently suppresses the migration guard, and the entries
would otherwise survive the clear *and* every later read, invisible. Deletion failures are swallowed
so a locked backup cannot turn "clear my history" into an error that leaves the live log intact.

### Settings copy corrected

The row said "Values that look like secrets are redacted before anything is written." Six patterns
are (`--password X`, `?token=`, `sshpass -p`, `Authorization: Bearer`, `JWT=`, `Password=;`).
`--password=x`, `-phunter2`, `PGPASSWORD=`, `user:pass@host`, `-u user:pass` and others are not. The
new text states what is actually true - only what the shell echoed is recorded, so a hidden prompt
is never captured - and adds a line pointing at Clear history for anything suspected.

`docs/command-assist/CommandAssist.md` carries the same explanation plus the pre-#286 note.

---

## Report 2 - Enter inserts nothing on cmd.exe and Windows PowerShell

**Two independent root causes that happened to land on the two shells the owner named.** That is
why it read as one bug.

### Root cause A - cmd.exe and every markless pane: a device reply poisoned the line

`TerminalPane.CreateAndWireParser` poisoned the markless accumulator on every
`AnsiParser.OnResponse` - the terminal's own answer to a DA / DSR / DECRQM / OSC colour query. A
poison only clears on Enter or Ctrl+C, and "the accumulator is clean and empty" is the entire gate
on degraded-mode insertion (`TerminalPane.TryReadInsertionQuerySnapshot`).

ConPTY and Clink both probe the terminal while the first prompt is drawn. Measured on a live
cmd.exe pane:

```
20:22:34.756 [poison] parser response len=6          <- 30 ms after session start
20:22:45.099 [insert] unechoed=False accPoisoned=True accCleanEmpty=False grid=null
20:22:45.100 [insert] refuse: planner (query=null)
20:22:45.101 [enter]  source=markless accRawLen=-1 submittedLen=-1
```

That is `Ctrl+R` then `Enter` on a brand-new pane: refused, silently, with the popup vanishing
because `Enter` fell through to the shell and submitted an empty line. It only started working
after the user had run a command by hand - which is exactly "it does not work in cmd".

**Fix.** Split the fact rather than dropping it. A device reply now sets a separate
`_deviceReplyObserved` flag which still refuses **history capture** for the rest of the line, and
does not affect the **is-the-line-empty** answer insertion uses.

The asymmetry is deliberate and is argued in the code: the pathological case (a query printed by
something that then stopped reading, so the answer lands in the line editor as literal input to the
*left* of everything typed after it) is undetectable downstream for capture - the echo gate compares
the accumulated text against the same number of characters ending at the cursor, and the injected
bytes sit further left than that window, so a command the user never ran would reach permanent
history. For insertion the wrong answer is a suggestion typed after visible junk, on screen,
editable, and the user still has to press Enter - the same cost `TryReadInsertionQuerySnapshot`
already documents and accepts for a markless pane running a program that reads stdin.

Side effect worth stating: the first command of a markless session is still not captured, because
the startup device reply refuses capture until the first Enter resets the line. That is the
conservative direction and it is unchanged by this PR.

### Root cause B - Windows PowerShell: a right-aligned prompt refused every accept

`AssistQuerySnapshot.IsUsableAsTypedPrefix` had three terms, and one of them was
`!RightPromptTrimmed`. A prompt that paints a badge at the right edge of the input row - oh-my-posh
(the owner's), zsh `RPROMPT`, starship - raises that flag on **every** prompt. Measured live on
Windows PowerShell:

```
20:33:08 [launch] integrated shellKind=pwsh cmd=powershell.exe args=-NoLogo -NoExit -File ...
20:33:09 [mark] PromptReady / CommandStarted        <- 5.1 IS fully integrated
20:25:12 [insert] unechoed=False accCleanEmpty=True grid=len=0,cur=0
20:25:12 [insert] refuse: planner (query=len=0,cur=0,multi=False,rp=True)
```

Note what this rules out: Windows PowerShell **is** integrated, the bootstrap **does** run (no
execution-policy problem on this box), marks **are** emitted, `C` **does** carry the command text,
and the grid read is correct. The line is provably empty, the cursor is at offset 0 - and the
planner refused anyway, on the right-prompt term alone.

**Fix.** Drop the term. It was redundant, provably rather than probably:
`GridQueryReader.FindRightPromptGapStart` floors its gap search at the cursor column, so the trim
boundary is always at or after the cursor and *nothing left of the cursor is ever discarded*.
Whatever it removed - a real right prompt, or typed input its five conditions exist to protect - was
removed from the region past the cursor, which the planner does not read: it only computes a delta
when `CursorOffset == Text.Length`, i.e. exactly when the trimmed region held nothing before the
cursor. The cursor test was doing the work all along and stays. The flag stays on the record as a
diagnostic and is still used to keep the badge out of the query.

**Why it split along shell lines the way the report describes:** pwsh 7's PSReadLine 2.3 repaints
the input line out to the right edge and erases the badge off the grid, so the flag is never raised
there. The PSReadLine 2.0 that ships with Windows PowerShell 5.1 leaves it painted. Same prompt,
same shell family, opposite outcome.

---

## Live verification checklist

Each row: fresh app instance, isolated `NOVATERM_APPDATA_ROOT`, keys sent through the app's real
keyboard path, isolated `history.jsonl` inspected afterwards.

| Scenario | Before | After |
| --- | --- | --- |
| cmd.exe, fresh pane, `Ctrl+R` -> `Enter` | refuses (`accPoisoned=True`), popup vanishes, nothing inserted | **inserts**; `echo epsilon-marker` appears on the prompt un-run |
| cmd.exe, fresh pane, `Ctrl+R` -> `Down` -> `Enter` | refuses | **inserts** |
| Windows PowerShell 5.1, `Ctrl+R` -> `Enter` | refuses (`rp=True`) | **inserts** |
| Windows PowerShell 5.1, `Ctrl+R` -> `Down` -> `Enter` | refuses | **inserts** |
| pwsh 7, `Ctrl+R` -> `Enter` | inserts | **still inserts** (no regression) |
| cmd.exe, typed command + Enter | captured (2nd command onward) | **still captured** |
| Windows PowerShell, typed command + Enter | captured via grid + `133;C` | **still captured** |
| Integrated Windows PowerShell, `Read-Host -AsSecureString` + marker + Enter | not captured | **still not captured** |
| Markless cmd.exe, non-echoing prompt + marker + Enter | not captured | **still not captured** |

---

## Test inventory

New (11) and changed (2):

**`MarklessSubmissionAccumulatorTests`** (5 new)
- `AfterADeviceReply_CaptureRefusesEvenThoughTheTypedTextIsKnown`
- `AfterADeviceReplyOnAnUntouchedLine_TheLineIsStillProvablyEmpty`
- `AfterADeviceReplyAndTyping_TheLineIsNotEmpty`
- `ADeviceReplyDoesNotUnPoison`
- `Reset_ClearsTheDeviceReply`

**`PaneAssistInsertionTests`** (5 new, parser-driven end to end)
- `InADegradedSessionAfterTheTerminalAnsweredADeviceQuery_EnterStillSendsTheWholeCommand`
- `InADegradedSessionAfterTheTerminalAnsweredADeviceQuery_CtrlEnterStillSendsTheWholeCommand`
- `OnAPromptWithARightAlignedBadge_EnterInsertsInsteadOfSubmitting`
- `OnAnEmptyPromptWithARightAlignedBadge_EnterSendsTheWholeCommand`
- `OnAPromptWithARightAlignedBadge_TheBadgeIsNotPartOfTheQuery`

The right-prompt fixture paints its badge by moving the cursor to the right edge and writing there -
what a right prompt actually is - and asserts the reader recognised it, so it cannot pass by failing
to reproduce the shape.

**`CommandAssistInsertionPlannerTests`** (1 rewritten + 2 new)
- `TryCreateInsertion_WhenARightPromptWasTrimmed_StillSendsTheSuffix` (was `_Refuses`)
- `TryCreateInsertion_OnAnEmptyLineWithARightPromptTrimmed_SendsTheWholeCommand`
- `TryCreateInsertion_WhenARightPromptWasTrimmedAndTheCursorIsMidLine_StillRefuses`

**`PaneMarklessCaptureTests`** (2 new)
- `InAnIntegratedSession_APasswordTypedWhileACommandIsRunningIsNotCaptured` - the report 1 path
  that had no coverage. The `C` deliberately carries no payload, so `IsStructuredCaptureActive`
  stays false and the heuristic path stays armed: without that, the test would pass without the echo
  gate ever being consulted.
- `InAnIntegratedSession_AnEchoedLineAfterTheWindowClosedIsStillCaptured` - the control.

**`JsonlHistoryStoreTests`** (2 new)
- `ClearAsync_AlsoDeletesTheMigratedLegacyBackup`
- `ClearAsync_BeforeAnyRead_AlsoDeletesTheUnmigratedLegacyFile`

### Mutation check

Each fix was reverted in place and the suites re-run:

| Mutation | Tests that failed |
| --- | --- |
| restore `!RightPromptTrimmed` in `IsUsableAsTypedPrefix` | 5 (2 planner, 3 pane) |
| restore `Poison()` on `Parser.OnResponse` | 2 pane |
| make `TryReadSubmission` ignore `_deviceReplyObserved` | 2 (1 unit, 1 pane capture) |
| remove `DeleteLegacyFilesUnsafe()` from `ClearAsync` | 2 store |

### Suites

Clean build. Run by namespace (a single-process full `App.Tests` run wedges, pre-existing).

```
App.Tests  AgentHost                     115  0 failed
App.Tests  Tests                         282  0 failed
App.Tests  Tests.Buffer                    5  0 failed
App.Tests  Tests.BufferTests              13  0 failed
App.Tests  Tests.CommandAssist           617  0 failed
App.Tests  Tests.CommandAssist.ShellInt  179  0 failed
App.Tests  Tests.Controls                152  0 failed
App.Tests  Tests.Core                    261  0 failed
App.Tests  Tests.Input                   141  0 failed
App.Tests  Tests.Paths                     4  0 failed
App.Tests  Tests.Regressions              17  0 failed
App.Tests  Tests.Rendering                 7  0 failed
App.Tests  Tests.RenderTests              83  0 failed (4 skipped)
App.Tests  Tests.ReplayTests              48  0 failed
App.Tests  Tests.Shell                    25  0 failed
App.Tests  Tests.Ssh                     144  0 failed
App.Tests  Tests.Storage                  10  0 failed
App.Tests  Tests.Tools                     3  0 failed
App.Tests  Tests.Performance              15  0 failed
VT.Tests                                 332  0 failed
Architecture.Tests                        28  0 failed
McpServer.Tests                          142  0 failed
```

Total: 2620 tests, 0 failures, 4 skipped.

---

## Not fixed here, found on the way

**Duplicate history entries for the first command of an integrated session.** Observed live on
Windows PowerShell: the heuristic entry and the structured `133;C` entry both land, because
`CapturePipeline`'s first-command dedup sets `_pendingCommandText` *after* an `await`, while
`HandleShellIntegrationEventAsync` runs on the serialized dispatcher ~10 ms later. Cosmetic (both
rows are the same command), pre-existing, and worth its own change.

```
{"CommandText":"echo zeta-marker", ... "Source":0}
{"CommandText":"echo zeta-marker", ... "Source":1}
```

---

## What the owner should do

**Press Clear history** (Settings -> Terminal -> Command assistant). If any Nova build from before
2026-08-02 recorded a password, that is where it is, and until this PR the button did not reach it.
