### PR TITLE
fix(command-assist): make the first prompt of an integrated session work

### DIFF
--- a/docs/command-assist/CommandAssist_ShellIntegration_Gaps.md
+++ b/docs/command-assist/CommandAssist_ShellIntegration_Gaps.md
@@ -494,6 +494,77 @@ With a tracker armed, both that patch and the structured `CommandFinished` patch
 same entry; the first clears the pending id and the second silently does nothing, losing the
 duration. It is now keyed on whether the tracker is armed at all.
 
+## Added In V2 Phase 6 prep — marks survive a reflowing resize
+
+**The bug.** A local `pwsh` session's *first* prompt was fully degraded: no passive bubble, no
+grid-truth query, no structured capture — and everything worked from the second prompt on. Two
+hypotheses were on the table (the mark being invalidated after capture, or the tracker being armed
+too late). Instrumented live, it was the first, and the mechanism is worth writing down because the
+"first prompt" framing is a symptom, not the rule.
+
+**Measured timeline** (probe logging on a real `pwsh` pane, isolated `NOVATERM_APPDATA_ROOT`):
+
+```
+t=233ms  InitializeSession cols=138 rows=45          (buffer generation 3)
+t=239ms  ArmShellIntegrationTracker                  (H2 ruled out: armed before any byte)
+t=868ms  OSC 133;B  abs=0 gen=3  bufGen=3            (H1's premise ruled out: the mark IS recorded)
+t=4168ms Buffer.Resize 138x45 -> 170x54 reflow=True  (the user sizes the window)
+         ScrollbackPages.Clear gen 3 -> 4
+         new ScrollbackPages gen=5
+t=4400ms GridQueryReader REJECT generation markGen=3 bufGen=5
+```
+
+A width change rebuilds the scrollback store, which bumps `ScrollbackPages.Generation`, and every
+reader (`GridQueryReader`, `ShellMarkAnchorResolver`, `CommandOutputReader`) refuses a mark whose
+epoch no longer matches. That refusal is *correct* — a pre-reflow `AbsoluteRow` resolves to a
+plausible but wrong row, and nothing downstream can tell.
+
+**What was wrong was the assumption underneath it.** `ShellIntegrationMark`'s own remarks said the
+refusal was benign "because every shell re-prints its prompt after a resize, and the prompt itself
+carries the B mark". It does not. Measured on PSReadLine 2.3 (and noted as an aside during the
+PR #293 review before anyone connected it to this): **a resize repaints the input line and does not
+re-run the prompt function**, so no fresh `B` is emitted. The session therefore stayed markless for
+the whole of that command line and only recovered when the user submitted something and got a real
+new prompt. Because sizing the window is the first thing anyone does with a new one, the failure
+presented as "the first prompt is dead" — but the real rule is *any* reflowing resize between a `B`
+and the next prompt, at any point in the session.
+
+**The fix keeps the generation contract intact.** Loosening the check was rejected outright: it is
+the only thing standing between a consumer and a confidently wrong row. Instead the buffer now owns
+the live marks (`TerminalBuffer.CommandStartMark`, `TerminalBuffer.CommandOutputStartMark`) and the
+reflow **re-anchors** them, by logical-line index plus offset-in-logical-line — the same mapping it
+already applies to the cursor, the saved cursors and inline images. A re-anchored mark comes back
+with new `Row`/`Column`/`AbsoluteRow` *and* the new `Generation`, so there is no stale epoch left to
+reject. A caller holding its own pre-reflow copy is still refused, and there is a test that says so.
+
+**Caveats, all deliberate:**
+
+- **A mark the reflow cannot place is cleared, not guessed at.** Its logical line was trimmed away,
+  its offset landed past the re-wrapped line, or the rebuilt scrollback discarded its row. The
+  consumer then sees "no mark", which is exactly the pre-fix behaviour for that case.
+- **`ScrollbackPages.Clear()` from `CSI 3J` / `RIS` / the user's clear-buffer action still kills the
+  mark**, and should: the content it named is gone. Only the reflow path re-anchors, because only
+  the reflow knows where the content moved to.
+- **Alt-screen marks are never re-anchored.** The alt screen shares no row numbering with the main
+  screen the reflow rebuilds; mapping one across would invent a position.
+- **The failsafe branch clears both marks.** If the reflow throws, the buffer is reset to a clean
+  state and a mark pointing into it would resolve to a plausible row holding nothing.
+- **The re-anchor is a compare-and-swap.** The parser can land a fresh `B` on the PTY thread while
+  the reflow is working; writing the re-anchored older mark over it would leave readers anchored to
+  the previous prompt with perfectly valid-looking coordinates. If the slot moved, the newer mark
+  wins untouched.
+- **Not verified on zsh/fish/bash.** The fix is in the VT layer and is shell-agnostic — it repairs
+  whatever mark the buffer is holding, whoever emitted it, and a shell that *does* re-emit `B` on
+  resize simply overwrites the re-anchored one with an equivalent. Only `pwsh` is installed on the
+  dev box, so "verified on one shell, and the other three share the code path" is the honest claim.
+  Windows PowerShell shares PSReadLine with `pwsh` and therefore shares the symptom.
+
+**Unrelated observation, recorded not fixed.** The first command of a session is sometimes written
+to history twice — once by the heuristic path at `Enter` and once by the structured path at
+`OSC 133;C` — because `CapturePipeline`'s double-capture guard depends on the heuristic append
+having completed (`_pendingEntryId` set) before `C` is dispatched, and on the first command those
+two race. Reproduced live before and after this change, so it is pre-existing and independent of it.
+
 ## Current Limitations
 - shell integration **injection** is local-only; SSH launch plans skip provider injection
   because env-var overrides do not propagate across SSH. As of Phase 2a a remote that emits

--- a/docs/plans/2026-08-01-command-assist-v2-plan.md
+++ b/docs/plans/2026-08-01-command-assist-v2-plan.md
@@ -345,9 +345,37 @@ One thing found rather than built, recorded so it is not re-discovered: **"No li
 
 ## Phase 6 — Flag flip
 
+**Step 1's blocker is cleared.** Phase 3b dogfooding found that the *first prompt of a local `pwsh`
+session was fully degraded* — no passive bubble, no grid-truth query, no structured capture — with
+everything working from the second prompt on. That was the last pre-flag-flip item, and it is fixed.
+
+Root cause, from live probe logging rather than from reading: the first `OSC 133;B` **is** recorded,
+on time, against a tracker armed before the first byte (so the two standing hypotheses were half
+right and half wrong — the mark is not lost, and the ordering was never the problem). What kills it
+is the resize the user makes as soon as the window is up: a width change reflows the buffer, which
+rebuilds the absolute-row coordinate space and bumps `ScrollbackPages.Generation`, and every reader
+correctly refuses a mark from a dead epoch. The assumption that made that refusal look benign —
+written into `ShellIntegrationMark`'s own remarks — was that "every shell re-prints its prompt after
+a resize, and the repaint carries a fresh B". **It does not:** measured on PSReadLine 2.3, a resize
+repaints the *input line* without re-running the prompt function. So the session went markless for
+the rest of that command line and only recovered at the next real prompt. The "first prompt" framing
+is a symptom of when people resize, not a property of the first prompt.
+
+The fix does **not** relax the generation check, which is the only guard against a confidently wrong
+row. The buffer now owns the live marks (`TerminalBuffer.CommandStartMark` /
+`CommandOutputStartMark`) and the reflow **re-anchors** them by logical-line index plus
+offset-in-logical-line — the same mapping it already applies to the cursor, the saved cursors and
+inline images — so a mark comes out of a reflow with new coordinates *and* the new generation, and
+there is no stale epoch left to reject. A caller holding its own pre-reflow copy is still refused,
+and `GridQueryReaderTests.ReflowingResize_RefusesAMarkCopyTakenBeforeIt` pins that. Caveats
+(unplaceable marks are cleared not guessed at, `CSI 3J` still kills the mark, alt-screen marks are
+never re-anchored, the write-back is a compare-and-swap against a concurrent fresh `B`) are in the
+gaps doc under "Added In V2 Phase 6 prep". Verified live on `pwsh` before and after; the other three
+shells share the VT code path and are not installed on the dev box.
+
 1. Verify all six re-enable criteria from the design doc, plus the one item Phase 1 carried here:
    smoke scenarios 1–8 re-validated. (Phase 1's other carried item, task 7's markless capture-only
-   accumulator, landed in Phase 1d.)
+   accumulator, landed in Phase 1d. The first-prompt blocker above is cleared.)
 2. Update `CommandAssistDefaultDisabledTests` → `CommandAssistDefaultEnabledTests`; flip `TerminalSettings.CommandAssistEnabled = true`; changelog + docs refresh (`CommandAssist.md` rewritten to match V2 reality, §14 keyboard table fixed).
 3. New smoke checklist executed on Windows + Unix-over-SSH; record results in `docs/command-assist/`.
 

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -166,15 +166,46 @@ namespace NovaTerminal.Controls
         private readonly OrderedAsyncEventDispatcher _shellIntegrationEventDispatcher = new();
         private readonly CommandAssistAnchorCalculator _commandAssistAnchorCalculator = new();
 
-        // Newest OSC 133;B mark, written from the PTY read thread and read from the UI thread.
-        // A ShellIntegrationMark is five fields wide, so a plain nullable field could be torn
-        // across the two; the gate costs one uncontended lock per prompt.
-        private readonly object _commandStartMarkGate = new();
-        private ShellIntegrationMark? _latestCommandStartMark;
+        /// <summary>
+        /// Newest <c>OSC 133;B</c> mark (prompt end), written from the PTY read thread and read
+        /// from the UI thread. <see langword="null"/> when there is no live mark.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>Stored on the buffer, not in a field here.</b> A width-changing resize reflows the
+        /// buffer, which rebuilds the absolute-row coordinate space and bumps
+        /// <c>ScrollbackPages.Generation</c>; a mark held outside the buffer can only notice that
+        /// its epoch went stale and be discarded. That is the whole of the "the first prompt of a
+        /// session is dead" bug: PSReadLine repaints the input line on a resize but does not re-run
+        /// the prompt function, so no fresh <c>B</c> arrives and the pane is markless until the
+        /// user submits something. <see cref="TerminalBuffer.CommandStartMark"/> is re-anchored by
+        /// the reflow itself, which is the only code that knows where the marked cell moved to, and
+        /// it comes back carrying the new generation - so the generation contract is enforced
+        /// exactly as before and there is simply no stale epoch left to reject.
+        /// </para>
+        /// <para>
+        /// The buffer guards the slot with its own lock, which is what the pane's old
+        /// <c>_commandStartMarkGate</c> was for: a <see cref="ShellIntegrationMark"/> is five
+        /// fields wide and a plain nullable field could be torn across the two threads.
+        /// </para>
+        /// </remarks>
+        private ShellIntegrationMark? LatestCommandStartMark
+        {
+            get => Buffer?.CommandStartMark;
+            set
+            {
+                if (Buffer is { } buffer)
+                {
+                    buffer.CommandStartMark = value;
+                }
+            }
+        }
 
-        // Where the running command's output region begins, captured at OSC 133;C. Guarded by the
-        // same gate and for the same reason. See CaptureCommandOutputRegionStart.
-        private ShellIntegrationMark? _commandOutputRegionStart;
+        // Where the running command's output region begins (OSC 133;C) is
+        // TerminalBuffer.CommandOutputStartMark, on the buffer for the same reason as
+        // LatestCommandStartMark above: a resize between C and D would otherwise cost the failing
+        // command's captured output. The two call sites (CaptureCommandOutputRegionStart and
+        // TryCaptureFailureOutputTail) already hold a non-null buffer, so they read it directly.
 
         // The last output tail captured at OSC 133;D, already capped and already redacted. A test
         // seam only: the value the controller sees is passed as an argument, not read from here.
@@ -1345,11 +1376,7 @@ namespace NovaTerminal.Controls
         /// </remarks>
         private CommandAssistMarkAnchorHint? TryGetCommandAssistMarkAnchorHint()
         {
-            ShellIntegrationMark? mark;
-            lock (_commandStartMarkGate)
-            {
-                mark = _latestCommandStartMark;
-            }
+            ShellIntegrationMark? mark = LatestCommandStartMark;
 
             return mark is ShellIntegrationMark live
                 ? TermView.GetCommandAssistMarkAnchorHint(live)
@@ -2680,14 +2707,16 @@ namespace NovaTerminal.Controls
             {
                 // OSC 133;B == prompt end / start of user input. The mark position is the
                 // anchor Command Assist uses to read the live command line out of the grid.
-                // B rides inside the prompt string, so it is re-emitted on every repaint
-                // (resize, clear, zle reset-prompt) with fresh coordinates: keep the newest
-                // one rather than the first.
+                // B rides inside the prompt string, so it is re-emitted on every prompt the
+                // shell *prints* (a new prompt, clear, zle reset-prompt) with fresh
+                // coordinates: keep the newest one rather than the first. It is NOT re-emitted
+                // on a window resize - PSReadLine (measured on 2.3) repaints the input line
+                // without re-running the prompt function, and zsh/fish behave the same unless
+                // the user wired a resize hook. That is why the mark has to survive the reflow
+                // a resize triggers rather than waiting to be replaced; see
+                // TerminalBuffer.CommandStartMark, which is where this now lives.
                 NoteShellIntegrationMarkObserved();
-                lock (_commandStartMarkGate)
-                {
-                    _latestCommandStartMark = mark;
-                }
+                LatestCommandStartMark = mark;
 
                 _shellLifecycleTracker?.HandleCommandStarted(new ShellMarkPosition(
                     Row: mark.Row,
@@ -2734,15 +2763,11 @@ namespace NovaTerminal.Controls
                 // the final command text on. GridQueryReader.MaxSpanRows stays as a backstop for
                 // shells that emit B without a matching D, but it is no longer the only guard.
                 NoteShellIntegrationMarkObserved();
-                lock (_commandStartMarkGate)
-                {
-                    _latestCommandStartMark = null;
 
-                    // The output region ends here too. OnCommandFinished (above, same OSC 133;D)
-                    // has already read it; holding the mark past this point would let the *next*
-                    // failure read a region that starts inside this command's output.
-                    _commandOutputRegionStart = null;
-                }
+                // The output region ends here too. OnCommandFinished (above, same OSC 133;D)
+                // has already read it; holding the mark past this point would let the *next*
+                // failure read a region that starts inside this command's output.
+                Buffer?.ClearTrackedShellMarks();
 
                 _shellLifecycleTracker?.HandleCommandFinished(exitCode, durationMs);
 
@@ -2772,11 +2797,7 @@ namespace NovaTerminal.Controls
             // A restart or a profile switch reaches here; the pending line belonged to the shell
             // that is going away.
             _marklessSubmission.Reset();
-            lock (_commandStartMarkGate)
-            {
-                _latestCommandStartMark = null;
-                _commandOutputRegionStart = null;
-            }
+            Buffer?.ClearTrackedShellMarks();
 
             _lastFailureOutputTailForTest = null;
 
@@ -4114,11 +4135,7 @@ namespace NovaTerminal.Controls
                 return false;
             }
 
-            ShellIntegrationMark? mark;
-            lock (_commandStartMarkGate)
-            {
-                mark = _latestCommandStartMark;
-            }
+            ShellIntegrationMark? mark = buffer.CommandStartMark;
 
             return mark is ShellIntegrationMark live
                 && GridQueryReader.TryReadCommandLine(buffer, live, out line);
@@ -4134,8 +4151,9 @@ namespace NovaTerminal.Controls
         /// Callable from any thread, and it is: the suggestion orchestrator invokes it from the
         /// worker its refresh pass runs on, deliberately, so the read lands behind the queue hop
         /// rather than on the keystroke that triggered it. Both things it touches are safe for
-        /// that - the mark is read under <c>_commandStartMarkGate</c> and
-        /// <see cref="GridQueryReader"/> takes the buffer's own read lock.
+        /// that - the mark is read under the buffer's tracked-mark lock (see
+        /// <see cref="TerminalBuffer.CommandStartMark"/>) and <see cref="GridQueryReader"/> takes
+        /// the buffer's own read lock.
         /// </para>
         /// <para>
         /// The span's <c>StartRow</c>/<c>EndRow</c> are dropped rather than carried across. Nothing
@@ -4188,19 +4206,12 @@ namespace NovaTerminal.Controls
                 return;
             }
 
-            ShellIntegrationMark? commandLineMark;
-            lock (_commandStartMarkGate)
-            {
-                commandLineMark = _latestCommandStartMark;
-            }
+            ShellIntegrationMark? commandLineMark = buffer.CommandStartMark;
 
             bool captured = CommandOutputReader.TryCaptureOutputStart(
                 buffer, commandLineMark, out ShellIntegrationMark outputStart);
 
-            lock (_commandStartMarkGate)
-            {
-                _commandOutputRegionStart = captured ? outputStart : null;
-            }
+            buffer.CommandOutputStartMark = captured ? outputStart : null;
         }
 
         /// <summary>
@@ -4240,11 +4251,7 @@ namespace NovaTerminal.Controls
                 return null;
             }
 
-            ShellIntegrationMark? outputStart;
-            lock (_commandStartMarkGate)
-            {
-                outputStart = _commandOutputRegionStart;
-            }
+            ShellIntegrationMark? outputStart = buffer.CommandOutputStartMark;
 
             if (outputStart is not ShellIntegrationMark region)
             {

--- a/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
@@ -22,11 +22,28 @@ namespace NovaTerminal.VT
             private int _cursorCol;
             private readonly Func<string, int> _getGraphemeWidth;
 
+            // Shell-integration marks carried across the reflow. See TerminalBuffer's
+            // CommandStartMark for why they live on the buffer at all. Each is remapped by
+            // logical-line index + offset-in-logical-line, exactly like the cursor and the
+            // saved cursors, and cleared when it cannot be placed.
+            private ShellIntegrationMark? _commandStartMark;
+            private ShellIntegrationMark? _commandOutputStartMark;
+
+            // The values read at construction, kept so Apply can compare-and-swap. The parser
+            // runs on the PTY thread and can land a fresh OSC 133;B while the reflow is working;
+            // writing the re-anchored old mark over it would leave the readers pointing at the
+            // previous prompt with perfectly valid-looking coordinates, which is worse than the
+            // bug being fixed. If the slot moved under us, the newer mark wins untouched.
+            private readonly ShellIntegrationMark? _observedCommandStartMark;
+            private readonly ShellIntegrationMark? _observedCommandOutputStartMark;
+
             public ReflowEngineContext(TerminalBuffer source)
             {
                 _savedCursors = source._savedCursors;
                 _viewport = source._viewport;
                 _scrollback = source._scrollback;
+                _commandStartMark = _observedCommandStartMark = source.CommandStartMark;
+                _commandOutputStartMark = _observedCommandOutputStartMark = source.CommandOutputStartMark;
                 _history = new List<TerminalRow>(_scrollback.Count + source.Rows);
                 _maxScrollbackBytes = source.MaxScrollbackBytes;
                 _images = source._images;
@@ -50,6 +67,93 @@ namespace NovaTerminal.VT
                 target._scrollback = _scrollback;
                 target._cursorRow = _cursorRow;
                 target._cursorCol = _cursorCol;
+                if (target.CommandStartMark == _observedCommandStartMark)
+                {
+                    target.CommandStartMark = _commandStartMark;
+                }
+
+                if (target.CommandOutputStartMark == _observedCommandOutputStartMark)
+                {
+                    target.CommandOutputStartMark = _commandOutputStartMark;
+                }
+            }
+
+            /// <summary>
+            /// Physical row index (scrollback rows + viewport row) a tracked mark currently
+            /// names, or <c>-1</c> when the mark is not a live main-screen mark.
+            /// </summary>
+            /// <remarks>
+            /// <c>AbsoluteRow - TotalRowsEvicted</c> rather than <c>Row</c>: eviction may have
+            /// shifted the row since capture, and the absolute form is the one that survives it.
+            /// An alt-screen mark shares no numbering with the main screen the reflow rebuilds,
+            /// and a mark from another epoch is already meaningless, so both are refused here
+            /// rather than mapped to a plausible wrong row.
+            /// </remarks>
+            private int GetTrackedMarkPhysicalRow(ShellIntegrationMark? mark)
+            {
+                // Not gated on _isAltScreen: the reflow rebuilds the *main* screen even when the
+                // alt screen is the one on display (Resize swaps it in), and a main-screen mark
+                // names main-screen content either way.
+                if (mark is not ShellIntegrationMark live || live.IsAltScreen)
+                {
+                    return -1;
+                }
+
+                if (live.Generation != _scrollback.Generation)
+                {
+                    return -1;
+                }
+
+                long derived = live.AbsoluteRow - _scrollback.TotalRowsEvicted;
+                if (derived < 0 || derived > int.MaxValue)
+                {
+                    return -1;
+                }
+
+                return (int)derived;
+            }
+
+            /// <summary>
+            /// Rebuilds a tracked mark from the row/column the reflow placed it at, or returns
+            /// <see langword="null"/> when it could not be placed.
+            /// </summary>
+            /// <param name="newPhysRow">Index into the reflowed row list, or <c>-1</c>.</param>
+            /// <param name="newPhysCol">Column within that row.</param>
+            /// <param name="discardedRows">
+            /// Rows the rebuilt scrollback evicted while being refilled. Subtracting it converts
+            /// a reflowed-row index into the buffer's current addressing space, which is the same
+            /// conversion the image re-anchoring below performs.
+            /// </param>
+            private ShellIntegrationMark? RebuildTrackedMark(
+                ShellIntegrationMark? original, int newPhysRow, int newPhysCol, int discardedRows, int newCols)
+            {
+                if (original is not ShellIntegrationMark live || newPhysRow < 0)
+                {
+                    return null;
+                }
+
+                int row = newPhysRow - discardedRows;
+                if (row < 0)
+                {
+                    return null; // the marked line was discarded while the scrollback was rebuilt
+                }
+
+                // A mark parked one past the last column has no cell to name once the row is
+                // re-wrapped; refusing is the same answer the readers would give.
+                if (newPhysCol < 0 || newPhysCol >= newCols)
+                {
+                    return null;
+                }
+
+                return live with
+                {
+                    Row = row,
+                    Column = newPhysCol,
+                    // TotalRowsEvicted of the rebuilt store is exactly discardedRows, so
+                    // AbsoluteRow = discardedRows + row collapses to the reflowed index.
+                    AbsoluteRow = newPhysRow,
+                    Generation = _scrollback.Generation,
+                };
             }
 
             private int GetGraphemeWidth(string textElement)
@@ -84,6 +188,17 @@ namespace NovaTerminal.VT
                     int absAltSavedIdx = _scrollback.Count + _savedCursors.Alt.Row;
                     int altSavedLogicalIdx = -1;
                     int altSavedInLogicalOffset = -1;
+
+                    // Shell-integration marks ride through on the same (logical line, offset)
+                    // identity the cursors use. -1 means "not a live main-screen mark", which
+                    // short-circuits every tracking branch below and leaves the slot cleared.
+                    int absCommandStartIdx = GetTrackedMarkPhysicalRow(_commandStartMark);
+                    int commandStartLogicalIdx = -1;
+                    int commandStartInLogicalOffset = -1;
+
+                    int absOutputStartIdx = GetTrackedMarkPhysicalRow(_commandOutputStartMark);
+                    int outputStartLogicalIdx = -1;
+                    int outputStartInLogicalOffset = -1;
 
                     // 2. Physical Extraction with Padding Trim
 
@@ -168,6 +283,18 @@ namespace NovaTerminal.VT
                         {
                             altSavedLogicalIdx = logicalLines.Count;
                             altSavedInLogicalOffset = (logicalCellsCount - currentLogStart) + _savedCursors.Alt.Col;
+                        }
+
+                        if (i == absCommandStartIdx && _commandStartMark is ShellIntegrationMark cs)
+                        {
+                            commandStartLogicalIdx = logicalLines.Count;
+                            commandStartInLogicalOffset = (logicalCellsCount - currentLogStart) + cs.Column;
+                        }
+
+                        if (i == absOutputStartIdx && _commandOutputStartMark is ShellIntegrationMark os)
+                        {
+                            outputStartLogicalIdx = logicalLines.Count;
+                            outputStartInLogicalOffset = (logicalCellsCount - currentLogStart) + os.Column;
                         }
 
                         int validLen = physRow.Cells.Length;
@@ -274,6 +401,21 @@ namespace NovaTerminal.VT
                             if (i == absCursorPhysicalIdx && _cursorCol > validLen)
                             {
                                 validLen = _cursorCol;
+                            }
+
+                            // Same rule for a tracked shell mark: an OSC 133;B on a prompt whose
+                            // tail is blank (every prompt that ends in a space, once the line is
+                            // empty) would otherwise have its column trimmed out of the logical
+                            // stream and the mark would be dropped by a resize that changed
+                            // nothing about where the prompt ends.
+                            if (i == absCommandStartIdx && _commandStartMark is ShellIntegrationMark csPad && csPad.Column > validLen)
+                            {
+                                validLen = csPad.Column;
+                            }
+
+                            if (i == absOutputStartIdx && _commandOutputStartMark is ShellIntegrationMark osPad && osPad.Column > validLen)
+                            {
+                                validLen = osPad.Column;
                             }
                         }
 
@@ -437,6 +579,10 @@ namespace NovaTerminal.VT
                     int newMainSavedPhysCol = -1;
                     int newAltSavedPhysRow = -1;
                     int newAltSavedPhysCol = -1;
+                    int newCommandStartPhysRow = -1;
+                    int newCommandStartPhysCol = -1;
+                    int newOutputStartPhysRow = -1;
+                    int newOutputStartPhysCol = -1;
                     int historyRowCount = 0; // Tracks physical rows generated from original history
                     var newStartFlowIndices = new int[logicalLines.Count];
 
@@ -503,6 +649,8 @@ namespace NovaTerminal.VT
                             if (i == cursorLogicalIdx) { newCursorPhysRow = allFlowedRows.Count; newCursorPhysCol = 0; }
                             if (i == mainSavedLogicalIdx) { newMainSavedPhysRow = allFlowedRows.Count; newMainSavedPhysCol = 0; }
                             if (i == altSavedLogicalIdx) { newAltSavedPhysRow = allFlowedRows.Count; newAltSavedPhysCol = 0; }
+                            if (i == commandStartLogicalIdx) { newCommandStartPhysRow = allFlowedRows.Count; newCommandStartPhysCol = 0; }
+                            if (i == outputStartLogicalIdx) { newOutputStartPhysRow = allFlowedRows.Count; newOutputStartPhysCol = 0; }
                             allFlowedRows.Add(new TerminalRow(newCols, Theme.Foreground, Theme.Background));
                         }
                         else
@@ -553,6 +701,24 @@ namespace NovaTerminal.VT
                                     {
                                         newAltSavedPhysRow = allFlowedRows.Count;
                                         newAltSavedPhysCol = altSavedInLogicalOffset - processed;
+                                    }
+                                }
+
+                                if (i == commandStartLogicalIdx)
+                                {
+                                    if (commandStartInLogicalOffset >= processed && commandStartInLogicalOffset < processed + newCols)
+                                    {
+                                        newCommandStartPhysRow = allFlowedRows.Count;
+                                        newCommandStartPhysCol = commandStartInLogicalOffset - processed;
+                                    }
+                                }
+
+                                if (i == outputStartLogicalIdx)
+                                {
+                                    if (outputStartInLogicalOffset >= processed && outputStartInLogicalOffset < processed + newCols)
+                                    {
+                                        newOutputStartPhysRow = allFlowedRows.Count;
+                                        newOutputStartPhysCol = outputStartInLogicalOffset - processed;
                                     }
                                 }
 
@@ -624,6 +790,14 @@ namespace NovaTerminal.VT
 
                     int discardedRows = (int)newScrollback.TotalRowsEvicted;
                     _scrollback = newScrollback;
+
+                    // Re-anchor the shell-integration marks now that the new store exists: the
+                    // rebuild reads _scrollback.Generation, which must be the *new* epoch. A mark
+                    // the flow could not place comes back null.
+                    _commandStartMark = RebuildTrackedMark(
+                        _commandStartMark, newCommandStartPhysRow, newCommandStartPhysCol, discardedRows, newCols);
+                    _commandOutputStartMark = RebuildTrackedMark(
+                        _commandOutputStartMark, newOutputStartPhysRow, newOutputStartPhysCol, discardedRows, newCols);
 
                     // Fill viewport
                     // If vpCount < newRows (Growth), we will have empty space at the bottom (Top Anchoring).
@@ -746,6 +920,10 @@ namespace NovaTerminal.VT
                 {
                     TerminalLogger.Error("Reflow failed; buffer reset to a clean state. " + ex);
                     // Failsafe: if reflow crashes, we just reset the buffer to a clean state to avoid permanent hang
+                    // The content the marks named is gone with it, so they go too - a mark pointing
+                    // into a blank buffer would resolve to a plausible row holding nothing.
+                    _commandStartMark = null;
+                    _commandOutputStartMark = null;
                     _scrollback = new ScrollbackPages(newCols, _sharedPagePool, _maxScrollbackBytes);
                     _viewport = new TerminalRow[newRows];
                     for (int i = 0; i < newRows; i++) _viewport[i] = new TerminalRow(newCols, Theme.Foreground, Theme.Background);

--- a/src/NovaTerminal.VT/TerminalBuffer.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.cs
@@ -132,6 +132,65 @@ namespace NovaTerminal.VT
         // Thread safety
         public readonly System.Threading.ReaderWriterLockSlim Lock = new System.Threading.ReaderWriterLockSlim(System.Threading.LockRecursionPolicy.NoRecursion);
 
+        // ── Reflow-tracked shell-integration marks ───────────────────────────────
+        //
+        // Why the buffer holds these rather than the consumer that captured them: a
+        // reflowing (width-changing) resize rebuilds the whole absolute-row coordinate
+        // space, and the *only* place that knows where a given cell moved to is the
+        // reflow itself. A holder outside the buffer can do nothing but notice that its
+        // Generation went stale and throw the mark away — which is exactly the bug this
+        // slot exists to fix: PSReadLine repaints the input line on a resize but does not
+        // re-run the prompt function, so no fresh OSC 133;B ever arrives and the mark
+        // stays dead for the rest of that command line.
+        //
+        // Registering the mark here lets TerminalBuffer.ReflowEngine re-anchor it the same
+        // way it already re-anchors the cursor, the saved cursors and inline images: by
+        // logical-line index plus offset-in-logical-line. The mark comes out of the reflow
+        // with fresh Row/Column/AbsoluteRow *and* the fresh Generation, so the generation
+        // contract is untouched — every reader still refuses a mark whose epoch does not
+        // match, and there simply is no stale epoch to refuse any more.
+        //
+        // A mark the reflow cannot place (its line was trimmed away, the offset landed
+        // past the reflowed line, its row aged out) is cleared rather than guessed at,
+        // which lands the consumer back on today's behaviour: "no mark", never a wrong one.
+        private readonly object _trackedMarkGate = new();
+        private ShellIntegrationMark? _commandStartMark;
+        private ShellIntegrationMark? _commandOutputStartMark;
+
+        /// <summary>
+        /// The newest <c>OSC 133;B</c> mark (prompt end / start of the user's input), or
+        /// <see langword="null"/>. Re-anchored across a reflowing resize; see the field
+        /// comments above. Independently locked, so a reader never sees a torn record and
+        /// never has to hold <see cref="Lock"/> just to read it.
+        /// </summary>
+        public ShellIntegrationMark? CommandStartMark
+        {
+            get { lock (_trackedMarkGate) { return _commandStartMark; } }
+            set { lock (_trackedMarkGate) { _commandStartMark = value; } }
+        }
+
+        /// <summary>
+        /// Where the running command's output region begins (captured at <c>OSC 133;C</c>),
+        /// or <see langword="null"/>. Tracked for the same reason and by the same machinery
+        /// as <see cref="CommandStartMark"/>: a resize between <c>C</c> and <c>D</c> would
+        /// otherwise cost the failing command's captured output.
+        /// </summary>
+        public ShellIntegrationMark? CommandOutputStartMark
+        {
+            get { lock (_trackedMarkGate) { return _commandOutputStartMark; } }
+            set { lock (_trackedMarkGate) { _commandOutputStartMark = value; } }
+        }
+
+        /// <summary>Drops both tracked marks. Used when a session is replaced.</summary>
+        public void ClearTrackedShellMarks()
+        {
+            lock (_trackedMarkGate)
+            {
+                _commandStartMark = null;
+                _commandOutputStartMark = null;
+            }
+        }
+
         public TerminalBuffer(int cols, int rows)
         {
             Cols = cols;

--- a/tests/NovaTerminal.App.Tests/Controls/PaneGridCommandLineTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneGridCommandLineTests.cs
@@ -86,4 +86,48 @@ public class PaneGridCommandLineTests
         Assert.True(pane.TryGetGridCommandLine(out GridCommandLine next));
         Assert.Equal("ls", next.Text);
     }
+
+    [AvaloniaFact]
+    public void AResizeOnTheFirstPromptDoesNotCostTheMark()
+    {
+        // The whole of the "first prompt of a session is dead" report. A width change reflows
+        // the buffer, which rebuilds the absolute-row coordinate space and bumps
+        // ScrollbackPages.Generation - and a resize does NOT make the shell re-emit OSC 133;B
+        // (PSReadLine 2.3 repaints the input line without re-running the prompt function). So
+        // the pane went markless for the rest of that command line: no passive bubble, no
+        // grid-truth query, no structured capture. Since sizing the window is the first thing a
+        // user does with a new one, it looked like the first prompt specifically.
+        //
+        // The mark now lives on the buffer and the reflow re-anchors it; nothing about the
+        // generation check was relaxed. See NovaTerminal.VT.Tests.ShellMarkReflowTests.
+        using var pane = new TerminalPane();
+        pane.CreateAndWireParser();
+
+        pane.Parser!.Process("\x1b]133;A\x07user@host:~$ " + PromptEnd + "ec");
+        Assert.True(pane.TryGetGridCommandLine(out _));
+
+        pane.Buffer!.Resize(60, 24);
+
+        Assert.True(pane.TryGetGridCommandLine(out GridCommandLine line));
+        Assert.Equal("ec", line.Text);
+        Assert.Equal(2, line.CursorOffset);
+    }
+
+    [AvaloniaFact]
+    public void AResizeAfterCommandCompletionStillLeavesNoMark()
+    {
+        // The re-anchoring must not resurrect a mark OSC 133;D dropped: between one command's
+        // end and the next prompt there is no input line, and "no mark" is the honest answer.
+        using var pane = new TerminalPane();
+        pane.CreateAndWireParser();
+
+        pane.Parser!.Process("\x1b]133;A\x07$ " + PromptEnd + "git status");
+        pane.Parser!.Process(CommandExecuted);
+        pane.Parser!.Process("\r\n On branch main\r\n");
+        pane.Parser!.Process(CommandFinished);
+
+        pane.Buffer!.Resize(60, 24);
+
+        Assert.False(pane.TryGetGridCommandLine(out _));
+    }
 }

--- a/tests/NovaTerminal.VT.Tests/GridQueryReaderTests.cs
+++ b/tests/NovaTerminal.VT.Tests/GridQueryReaderTests.cs
@@ -572,11 +572,19 @@ public class GridQueryReaderTests
     }
 
     [Fact]
-    public void ReflowingResize_IsRefused()
+    public void ReflowingResize_RefusesAMarkCopyTakenBeforeIt()
     {
-        // A width change re-wraps every logical line and rebuilds the scrollback store, so the
-        // mark's coordinates describe a layout that no longer exists. Benign in practice: every
-        // shell repaints its prompt after a resize, and the repaint carries a fresh B.
+        // A width change re-wraps every logical line and rebuilds the scrollback store, so a
+        // *copy* of the mark taken before it describes a layout that no longer exists, and the
+        // generation check is the only thing that can tell. This Session holds exactly such a
+        // copy (it never publishes to the buffer), so this stays refused.
+        //
+        // What is NOT true, and what the comment here used to claim, is that this is benign
+        // because "every shell repaints its prompt after a resize". Measured on PSReadLine 2.3:
+        // a resize repaints the *input line* and does not re-run the prompt function, so no
+        // fresh B arrives and the session stays markless for the rest of that command line. The
+        // fix is to re-anchor the buffer's own copy inside the reflow rather than to relax
+        // anything here; see NovaTerminal.VT.Tests.ShellMarkReflowTests.
         var s = new Session(cols: 40, rows: 6).Prompt().Write("git status");
 
         s.Buffer.Resize(24, 6);

--- a/tests/NovaTerminal.VT.Tests/ShellMarkReflowTests.cs
+++ b/tests/NovaTerminal.VT.Tests/ShellMarkReflowTests.cs
@@ -1,0 +1,300 @@
+using System.Collections.Generic;
+using NovaTerminal.VT;
+
+namespace NovaTerminal.VT.Tests;
+
+/// <summary>
+/// Shell-integration marks re-anchored across a reflowing (width-changing) resize.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The bug these pin.</b> A width change rebuilds the scrollback store, which bumps
+/// <c>ScrollbackPages.Generation</c>, and every reader refuses a mark whose epoch no longer
+/// matches. That refusal is correct — a pre-reflow <c>AbsoluteRow</c> resolves to a plausible
+/// but wrong row — but it left the session markless, because <b>a resize does not make the
+/// shell re-emit <c>OSC 133;B</c></b>: PSReadLine (measured on 2.3) repaints the input line
+/// without re-running the prompt function, and zsh/fish behave the same unless the user wired a
+/// resize hook. So Command Assist lost the passive bubble, the grid-truth query and the
+/// structured capture for the whole of that command line, and only recovered when the user
+/// submitted something and got a fresh prompt. Since the first thing a user does with a new
+/// window is size it, that presented as "the first prompt of a session is dead".
+/// </para>
+/// <para>
+/// <b>What the fix does, and does not, change.</b> The generation check is untouched: a mark
+/// carrying a dead epoch is still refused, and <c>GridQueryReaderTests</c> keeps a test that
+/// says so for a caller holding its own pre-reflow copy. What changed is that the buffer now
+/// carries the live marks (<see cref="TerminalBuffer.CommandStartMark"/>,
+/// <see cref="TerminalBuffer.CommandOutputStartMark"/>) and the reflow re-anchors them by
+/// logical-line index plus offset-in-logical-line — the same mapping it already applies to the
+/// cursor, the saved cursors and inline images — so the mark comes out the other side with new
+/// coordinates <i>and</i> the new generation. There is no stale epoch left to reject.
+/// </para>
+/// <para>
+/// Everything is driven through the real parser and the real <c>Resize</c>, because the wrap
+/// flags and the scrollback/viewport split the re-anchoring depends on are produced by that path
+/// and nowhere else. The <see cref="Session"/> helper mirrors what <c>TerminalPane</c> does with
+/// the parser callback: store the newest <c>B</c> on the buffer.
+/// </para>
+/// </remarks>
+public class ShellMarkReflowTests
+{
+    private const string PromptStart = "\x1b]133;A\x07";
+    private const string PromptEnd = "\x1b]133;B\x07";
+
+    private sealed class Session
+    {
+        public Session(int cols = 40, int rows = 6, int? maxHistory = null)
+        {
+            Buffer = new TerminalBuffer(cols, rows);
+            if (maxHistory is int history)
+            {
+                Buffer.MaxHistory = history;
+            }
+
+            Parser = new AnsiParser(Buffer);
+
+            // Exactly what TerminalPane does on OSC 133;B: publish the newest mark to the
+            // buffer, which is what makes it survive a reflow. The raw marks are kept too so a
+            // test can assert on the pre-reflow copy.
+            Parser.OnCommandStarted = mark =>
+            {
+                RawMarks.Add(mark);
+                Buffer.CommandStartMark = mark;
+            };
+        }
+
+        public TerminalBuffer Buffer { get; }
+
+        public AnsiParser Parser { get; }
+
+        public List<ShellIntegrationMark> RawMarks { get; } = new();
+
+        /// <summary>The mark as it was captured, never re-anchored.</summary>
+        public ShellIntegrationMark RawMark => RawMarks[^1];
+
+        /// <summary>The live mark the buffer carries — re-anchored by any reflow since capture.</summary>
+        public ShellIntegrationMark? TrackedMark => Buffer.CommandStartMark;
+
+        public Session Write(string data)
+        {
+            Parser.Process(data);
+            return this;
+        }
+
+        public Session Prompt(string text = "$ ") => Write(PromptStart + text + PromptEnd);
+
+        public bool TryReadTracked(out GridCommandLine line)
+        {
+            line = default;
+            return TrackedMark is ShellIntegrationMark live
+                && GridQueryReader.TryReadCommandLine(Buffer, live, out line);
+        }
+
+        public GridCommandLine ReadTracked()
+        {
+            Assert.True(TryReadTracked(out GridCommandLine line), "the tracked mark should still resolve");
+            return line;
+        }
+    }
+
+    // ------------------------------------------------------------------ the regression
+
+    [Fact]
+    public void NarrowingResize_ReanchorsTheMark_SoTheCommandLineStillReads()
+    {
+        // The live repro, reduced: prompt, two typed characters, then the resize the user makes
+        // as soon as the window is up. Before the fix the tracked mark's generation went stale
+        // here and the pane was markless until the next prompt.
+        var s = new Session(cols: 40, rows: 6).Prompt().Write("ec");
+
+        long generationBefore = s.Buffer.Scrollback.Generation;
+        s.Buffer.Resize(24, 6);
+
+        Assert.NotEqual(generationBefore, s.Buffer.Scrollback.Generation);
+        Assert.Equal(s.Buffer.Scrollback.Generation, s.TrackedMark!.Value.Generation);
+
+        GridCommandLine line = s.ReadTracked();
+        Assert.Equal("ec", line.Text);
+        Assert.Equal(2, line.CursorOffset);
+    }
+
+    [Fact]
+    public void WideningResize_ReanchorsTheMark()
+    {
+        var s = new Session(cols: 40, rows: 6).Prompt().Write("git status");
+
+        s.Buffer.Resize(80, 6);
+
+        Assert.Equal("git status", s.ReadTracked().Text);
+    }
+
+    [Fact]
+    public void APreReflowCopyOfTheMarkIsStillRefused()
+    {
+        // The generation contract, unchanged and deliberately so. The fix does not loosen the
+        // check; it removes the stale epoch by re-anchoring the buffer's own copy. A caller that
+        // squirrelled the mark away before the resize still holds coordinates for a layout that
+        // no longer exists, and still gets nothing.
+        var s = new Session(cols: 40, rows: 6).Prompt().Write("git status");
+
+        s.Buffer.Resize(24, 6);
+
+        Assert.NotEqual(s.Buffer.Scrollback.Generation, s.RawMark.Generation);
+        Assert.False(GridQueryReader.TryReadCommandLine(s.Buffer, s.RawMark, out _));
+    }
+
+    [Fact]
+    public void ReanchoringSurvivesScrollbackAboveThePrompt()
+    {
+        // The interesting half of the arithmetic: rows above the prompt are re-wrapped too, so
+        // the mark's row moves by however many extra physical rows the narrower width produced.
+        var s = new Session(cols: 40, rows: 6);
+        for (int i = 0; i < 12; i++) s.Write($"a rather long output line number {i}\r\n");
+        s.Prompt().Write("ls -la");
+
+        Assert.True(s.Buffer.Scrollback.Count > 0, "there must be history to re-wrap");
+        int markRowBefore = s.TrackedMark!.Value.Row;
+
+        s.Buffer.Resize(20, 6);
+
+        Assert.NotEqual(markRowBefore, s.TrackedMark!.Value.Row);
+        Assert.Equal("ls -la", s.ReadTracked().Text);
+    }
+
+    [Fact]
+    public void ReanchoringSurvivesAnInputLineThatRewrapsAcrossRows()
+    {
+        // Narrow enough that the prompt plus the typed text no longer fits on one row, so the
+        // mark's own logical line is split. The re-anchor has to land on the right physical row
+        // *and* the right column within it.
+        var s = new Session(cols: 60, rows: 6).Prompt().Write("echo one two three four five");
+
+        s.Buffer.Resize(20, 6);
+
+        GridCommandLine line = s.ReadTracked();
+        Assert.Equal("echo one two three four five", line.Text);
+        Assert.Equal(28, line.CursorOffset);
+        Assert.True(line.EndRow > line.StartRow, "the input must actually have re-wrapped");
+    }
+
+    [Fact]
+    public void RepeatedResizes_KeepTheMarkUsable()
+    {
+        // A drag produces a burst of them; nothing may accumulate drift.
+        var s = new Session(cols: 40, rows: 6).Prompt().Write("git status");
+
+        foreach (int cols in new[] { 30, 55, 22, 80, 31 })
+        {
+            s.Buffer.Resize(cols, 6);
+            Assert.Equal("git status", s.ReadTracked().Text);
+        }
+    }
+
+    [Fact]
+    public void HeightOnlyResize_DoesNotDisturbTheTrackedMark()
+    {
+        // Negative control: the fast path never reflowed and never bumped the generation, so the
+        // re-anchoring must not touch anything here either.
+        var s = new Session(cols: 40, rows: 6);
+        for (int i = 0; i < 4; i++) s.Write($"line {i}\r\n");
+        s.Prompt().Write("git status");
+
+        ShellIntegrationMark before = s.TrackedMark!.Value;
+        s.Buffer.Resize(40, 3);
+
+        Assert.Equal(before, s.TrackedMark!.Value);
+        Assert.Equal("git status", s.ReadTracked().Text);
+    }
+
+    // ------------------------------------------------------------------ still refused
+
+    [Fact]
+    public void AClearedScrollbackStillKillsTheTrackedMark()
+    {
+        // CSI 3J genuinely destroys the content the mark named; re-anchoring is neither possible
+        // nor wanted. The tracked mark keeps its old epoch and the reader refuses it, which is
+        // the pre-fix behaviour and the correct one.
+        var s = new Session(cols: 40, rows: 10);
+        for (int i = 0; i < 5; i++) s.Write($"out {i}\r\n");
+        s.Prompt().Write("ls");
+
+        Assert.True(s.TryReadTracked(out _));
+
+        s.Write("\x1b[3J");
+
+        Assert.NotEqual(s.Buffer.Scrollback.Generation, s.TrackedMark!.Value.Generation);
+        Assert.False(s.TryReadTracked(out _));
+    }
+
+    [Fact]
+    public void AnAltScreenMarkIsNotReanchored()
+    {
+        // The alt screen has no scrollback and shares no row numbering with the main screen the
+        // reflow rebuilds. Mapping such a mark into main-screen coordinates would invent one.
+        var s = new Session(cols: 40, rows: 6);
+        s.Write("\x1b[?1049h").Write("\x1b[H").Prompt("> ").Write("q");
+
+        Assert.True(s.TrackedMark!.Value.IsAltScreen);
+        s.Buffer.Resize(24, 6);
+
+        Assert.False(s.TryReadTracked(out _));
+    }
+
+    [Fact]
+    public void AMarkWhoseRowNoLongerExistsIsCleared_NotGuessedAt()
+    {
+        // A mark pointing past the end of the reconstructed content cannot be placed. The slot
+        // must come back empty rather than holding coordinates the reflow made up.
+        var buffer = new TerminalBuffer(40, 6)
+        {
+            CommandStartMark = new ShellIntegrationMark(
+                Row: 0, Column: 0, AbsoluteRow: 5_000, IsAltScreen: false, Generation: 0),
+        };
+
+        buffer.Resize(24, 6);
+
+        Assert.Null(buffer.CommandStartMark);
+    }
+
+    // ------------------------------------------------------------------ the other mark
+
+    [Fact]
+    public void TheOutputRegionMarkIsReanchoredToo()
+    {
+        // Captured at OSC 133;C and read at OSC 133;D. A resize in between is exactly as likely
+        // as one on the prompt - it is the window in which a long command is running - and
+        // losing it costs Fix mode the failing command's output.
+        var s = new Session(cols: 40, rows: 10).Prompt().Write("false");
+
+        Assert.True(CommandOutputReader.TryCaptureOutputStart(
+            s.Buffer, s.TrackedMark, out ShellIntegrationMark outputStart));
+        s.Buffer.CommandOutputStartMark = outputStart;
+
+        s.Write("\r\nboom: it went wrong\r\n");
+        s.Buffer.Resize(28, 10);
+
+        Assert.NotNull(s.Buffer.CommandOutputStartMark);
+        Assert.Equal(s.Buffer.Scrollback.Generation, s.Buffer.CommandOutputStartMark!.Value.Generation);
+        Assert.True(CommandOutputReader.TryReadOutputTail(
+            s.Buffer, s.Buffer.CommandOutputStartMark!.Value, out string tail));
+        Assert.Contains("boom: it went wrong", tail);
+    }
+
+    // ------------------------------------------------------------------ overlay anchoring
+
+    [Fact]
+    public void TheOverlayAnchorResolvesAgainstTheReanchoredMark()
+    {
+        // ShellMarkAnchorResolver enforces the same generation rule, so the bubble was placed by
+        // the geometric fallback (or not at all) for the whole of a resized command line.
+        var s = new Session(cols: 40, rows: 6);
+        for (int i = 0; i < 3; i++) s.Write($"line {i}\r\n");
+        s.Prompt().Write("ls");
+
+        s.Buffer.Resize(26, 6);
+
+        Assert.True(ShellMarkAnchorResolver.TryResolveVisualRow(
+            s.Buffer, s.TrackedMark!.Value, scrollOffset: 0, visibleRows: 6, out int visualRow));
+        Assert.InRange(visualRow, 0, 5);
+    }
+}


### PR DESCRIPTION
The last pre-flag-flip item from Phase 3b dogfooding: the first prompt of a local `pwsh` session was
fully degraded - no passive bubble, no grid-truth query, no capture with `Source=ShellIntegration` -
and everything worked from the second prompt on.

## Root cause

Instrumented rather than reasoned about: temporary probes on mark recording, on every
`ScrollbackPages` generation bump with a stack reason, on every reader rejection with which check
failed, and on tracker arming vs the first parser bytes. Live `pwsh` pane, isolated
`NOVATERM_APPDATA_ROOT`.

Both standing hypotheses were half right.

**H2 (the tracker is armed after the first bytes) is wrong.** The tracker is armed inside
`InitializeSessionCore`, before the PTY is spawned:

```
t=233ms  InitializeSession cols=138 rows=45          buffer generation 3
t=239ms  ArmShellIntegrationTracker                  <- before any byte exists
t=868ms  OSC 133;B  abs=0 gen=3  bufGen=3  tracker=True
```

**H1's premise is wrong too - the mark is not lost, it is recorded correctly and on time.** What was
right is the second half: it is invalidated afterwards. Continuing the same log, at the moment the
window is sized:

```
t=4168ms Buffer.Resize 138x45 -> 170x54 reflow=True
         ScrollbackPages.Clear gen 3 -> 4
         new ScrollbackPages cols=170 gen=5
t=4400ms GridQueryReader REJECT generation markGen=3 bufGen=5 abs=0
         TryGetGridCommandLine ok=False
```

A width change rebuilds the scrollback store, which bumps `ScrollbackPages.Generation`, and
`GridQueryReader`, `ShellMarkAnchorResolver` and `CommandOutputReader` all refuse a mark whose epoch
no longer matches. That refusal is correct - a pre-reflow `AbsoluteRow` resolves to a plausible but
wrong row, and no arithmetic downstream can catch it.

**The actual defect is the assumption underneath the refusal.** `ShellIntegrationMark`'s own remarks
said it was benign "because every shell re-prints its prompt after a resize, and the prompt itself
carries the B mark". It does not. There is no `OSC 133;B` anywhere in the log after the resize:
measured on PSReadLine 2.3, a resize repaints the *input line* and does not re-run the prompt
function. (This was observed in passing during the PR #293 review, in the context of Escape
suppression, and nobody connected it to this.) So the pane stayed markless for the whole of that
command line and only recovered when the user submitted something and got a real new prompt.

**The "first prompt" framing is a symptom, not the rule.** The real rule is *any* reflowing resize
between a `B` and the next prompt. It presents as the first prompt because sizing the window is the
first thing anyone does with a new one - and it is invisible from the second prompt on because by
then the user has stopped resizing and every submission mints a fresh mark.

A third cause was ruled out along the way: `Source=Heuristic` on a session's *first* command is by
design (`CapturePipeline`'s double-capture guard), not a symptom.

## The fix, and why it preserves the generation contract

Loosening the generation check was rejected outright - it is the only thing standing between a
consumer and a confidently wrong row, and every reader depends on it.

Instead, `TerminalBuffer` now owns the live marks (`CommandStartMark`, `CommandOutputStartMark`) and
**the reflow re-anchors them**. Only the reflow knows where a given cell moved to, so only the reflow
can do this; a holder outside the buffer can do nothing but notice its epoch went stale. The mapping
is by logical-line index plus offset-in-logical-line - byte for byte the same identity the reflow
already uses for the cursor, the saved cursors and inline images - and the rebuilt mark carries the
*new* generation. The contract is enforced exactly as before; there is simply no stale epoch left to
reject.

Deliberate refusals, all of which land the consumer on today's behaviour ("no mark", never a wrong
one):

- a mark the reflow cannot place (line trimmed away, offset past the re-wrapped line, row discarded
  while the scrollback was rebuilt) is cleared, not guessed at
- `ScrollbackPages.Clear()` from `CSI 3J` / `RIS` / clear-buffer still kills the mark, and should:
  the content it named is gone
- alt-screen marks are never re-anchored - the alt screen shares no row numbering with the main
  screen the reflow rebuilds
- the failsafe catch (reflow threw, buffer reset) drops both marks
- the write-back is a compare-and-swap: the parser can land a fresh `B` on the PTY thread mid-reflow,
  and writing the re-anchored older mark over it would leave readers anchored to the previous prompt
  with valid-looking coordinates. The newer mark wins untouched.

The pane's `_commandStartMarkGate` is gone; the buffer's tracked-mark lock does the same job (a
`ShellIntegrationMark` is five fields wide and would tear across the PTY and UI threads).

## Shells affected

The bug is in the VT layer and is shell-agnostic: it is triggered by a reflowing resize, not by any
shell's behaviour, and the fix repairs whatever mark the buffer holds regardless of who emitted it. A
shell that *does* re-emit `B` on resize simply overwrites the re-anchored mark with an equivalent
one, so nothing regresses either way.

What is shell-specific is only how likely you are to see it. `pwsh` and Windows PowerShell share
PSReadLine and therefore share the symptom exactly. zsh, fish and bash are not installed on the dev
box, so the honest claim is "verified live on one shell, and the other three share the code path".

## Live verification

Isolated `NOVATERM_APPDATA_ROOT`, real `pwsh` pane, own instance killed afterwards.

**Before:** fresh session, first prompt, window sized, two characters typed ->
`GridQueryReader REJECT generation markGen=3 bufGen=5`, `TryGetGridCommandLine ok=False`, no bubble
on screen.

**After:** same sequence -> `TryGetGridCommandLine ok=True text='echo nova-beta-two' cur=2` and the
bubble reads `Suggest | ec | echo nova-beta-two | Down browse | Esc close`, anchored under the
prompt. Second prompt still fine; the first command of the session is still captured and still
enriched with its exit code and duration at `133;D`.

## Tests

| Suite | Result |
| --- | --- |
| `NovaTerminal.VT.Tests` (whole project) | 362 passed, 0 failed |
| `NovaTerminal.App.Tests`, `NovaTerminal.Tests.Controls` | 166 passed, 0 failed |
| `NovaTerminal.App.Tests`, `NovaTerminal.Tests.CommandAssist` | 768 passed, 0 failed |
| `NovaTerminal.App.Tests`, everything else | 1557 total, 2 failed |
| `NovaTerminal.Architecture.Tests` | 33 passed |

The two failures in the "everything else" half are the known load-dependent flakes
(`MemoryLeakTest.Resize_MemoryStability_StressTest`,
`CommandAssistPerformanceTests.FirstSuggestion_...`, p95 58ms against a 50ms tripwire on a loaded
box). Both pass in isolation, re-run together immediately afterwards: 2 passed, 0 failed. The memory
one is a resize test and this PR touches resize, so it was re-run deliberately rather than waved off.

New tests - `tests/NovaTerminal.VT.Tests/ShellMarkReflowTests.cs`, 12 cases:

- `NarrowingResize_ReanchorsTheMark_SoTheCommandLineStillReads` (the reduced live repro)
- `WideningResize_ReanchorsTheMark`
- `ReanchoringSurvivesScrollbackAboveThePrompt` (rows above the prompt re-wrap too, so the mark's row
  moves)
- `ReanchoringSurvivesAnInputLineThatRewrapsAcrossRows` (the mark's own logical line is split; the
  re-anchor has to land on the right row *and* the right column in it)
- `RepeatedResizes_KeepTheMarkUsable` (a drag is a burst; nothing may accumulate drift)
- `TheOutputRegionMarkIsReanchoredToo` (the `C`-to-`D` window, read back through
  `CommandOutputReader`)
- `TheOverlayAnchorResolvesAgainstTheReanchoredMark` (`ShellMarkAnchorResolver` enforces the same
  rule, so the bubble was placed by the geometric fallback for the whole of a resized command line)
- and the negative half, which is where the contract is: `APreReflowCopyOfTheMarkIsStillRefused`,
  `AClearedScrollbackStillKillsTheTrackedMark`, `AnAltScreenMarkIsNotReanchored`,
  `AMarkWhoseRowNoLongerExistsIsCleared_NotGuessedAt`,
  `HeightOnlyResize_DoesNotDisturbTheTrackedMark`

Plus `PaneGridCommandLineTests.AResizeOnTheFirstPromptDoesNotCostTheMark` (end-to-end shape of the
report) and `AResizeAfterCommandCompletionStillLeavesNoMark` (the re-anchoring must not resurrect a
mark `133;D` dropped).

`GridQueryReaderTests.ReflowingResize_IsRefused` is renamed to
`ReflowingResize_RefusesAMarkCopyTakenBeforeIt` and its comment corrected: it pinned the refusal
*and* the wrong reason for the refusal being harmless. It still passes unchanged, which is the point.

**Mutation check.** Reverting the re-anchoring write-back for `CommandStartMark` (one `if` disabled
in `ReflowEngineContext.Apply`): exactly the 7 re-anchoring cases fail and the 5 negative cases pass,
including `TheOutputRegionMarkIsReanchoredToo` - which is the right discrimination, since the mutant
only kills the command-start slot. `PaneGridCommandLineTests.AResizeOnTheFirstPromptDoesNotCostTheMark`
fails and the other 5 in that class pass.

## Docs

- `docs/command-assist/CommandAssist_ShellIntegration_Gaps.md`: new section with the measured
  timeline, the PSReadLine finding, why loosening the check was rejected, and the caveats above. Also
  records one unrelated thing found and not fixed: the first command of a session is sometimes
  written to history twice, because `CapturePipeline`'s double-capture guard depends on the heuristic
  append having completed before `133;C` is dispatched, and on the first command those two race.
  Reproduced live both before and after this change, so it is pre-existing and independent.
- `docs/plans/2026-08-01-command-assist-v2-plan.md`: Phase 6 step 1's blocker recorded as cleared.

All temporary instrumentation is removed - the probe type, the call sites and the live-debug
launcher scripts. Nothing here logs.
