### PR TITLE
fix(pty): stop persisting blank pane commands, and reject empty/NUL-bearing strings at the spawn boundary

### DIFF
--- a/scripts/run-sidecar.ps1
+++ b/scripts/run-sidecar.ps1
@@ -55,6 +55,18 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+# pwsh (PowerShell 7+) only, as the shebang says. The body uses $IsWindows and multi-segment
+# Join-Path, neither of which exists in Windows PowerShell 5.1: run it as
+# `powershell -File scripts/run-sidecar.ps1` and the first Join-Path below dies with
+# "A positional parameter cannot be found that accepts argument 'NovaTerminal.App'" - a message
+# with no connection to the actual requirement. Worse, $IsWindows is simply $null under 5.1, so
+# a script that got past the Join-Paths would silently take the non-Windows branches. Refuse up
+# front and name the fix.
+if ($PSVersionTable.PSEdition -eq 'Desktop') {
+    Write-Error "[sidecar] This script requires PowerShell 7+ (pwsh); Windows PowerShell 5.1 is not supported. Run: pwsh -File scripts/run-sidecar.ps1"
+    exit 1
+}
+
 $repoRoot = Split-Path -Parent $PSScriptRoot
 # Build path segments with Join-Path (no embedded separators) so they're correct on every OS.
 $appProject = Join-Path $repoRoot 'src' 'NovaTerminal.App'

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -469,6 +469,12 @@ namespace NovaTerminal.Controls
             _sshDiagnosticsLevel = SshDiagnosticsLevel.None;
             Buffer = new TerminalBuffer(80, 24);
             TermView.SetBuffer(Buffer);
+            // Record the requested command NOW, not only once the session starts. Until
+            // InitializeSessionCore ran, the shell lived solely in this lambda's closure,
+            // while ShellCommand — the property the OnAttachedToVisualTree fallback,
+            // Reconnect() and session persistence all read — was still string.Empty. Any of
+            // those reaching the pane first therefore lost the requested shell entirely.
+            ShellCommand = shell ?? string.Empty;
             TermView.Ready += (c, r) => InitializeSession(shell, null, c, r);
             SetupCommon(initialSettings);
             StartupPerformanceTracker.Current?.TryMarkCheckpoint("TerminalPane.Ctor.AfterSetupCommon");
@@ -486,6 +492,10 @@ namespace NovaTerminal.Controls
             _sshDiagnosticsLevel = SshDiagnosticsLevel.None;
             Buffer = new TerminalBuffer(80, 24);
             TermView.SetBuffer(Buffer);
+            // See the single-argument overload: the requested command must be observable
+            // before the session starts, or the attach-time fallback spawns an empty one.
+            ShellCommand = shell ?? string.Empty;
+            ShellArgs = args ?? string.Empty;
             TermView.Ready += (c, r) => InitializeSession(shell, null, c, r, args);
             SetupCommon(initialSettings);
             StartupPerformanceTracker.Current?.TryMarkCheckpoint("TerminalPane.Ctor.AfterSetupCommon");
@@ -515,6 +525,10 @@ namespace NovaTerminal.Controls
             Buffer = new TerminalBuffer(80, 24);
             TermView.SetBuffer(Buffer);
             TermView.ShellOverride = profile.ShellOverride;
+            // As above: keep the profile's command visible to the attach-time fallback,
+            // Reconnect() and persistence before the first session exists.
+            ShellCommand = profile.Command ?? string.Empty;
+            ShellArgs = profile.Arguments ?? string.Empty;
             TermView.Ready += (c, r) => InitializeSession(profile.Command, profile, c, r);
             SetupCommon(useInitialSettings ? initialSettings : null);
             StartupPerformanceTracker.Current?.TryMarkCheckpoint("TerminalPane.Ctor.AfterSetupCommon");
@@ -2532,8 +2546,18 @@ namespace NovaTerminal.Controls
             if (cw > 0) Parser!.CellWidth = cw;
             if (ch > 0) Parser!.CellHeight = ch;
 
-            // Setup Session
-            string effectiveShell = shell ?? ShellHelper.GetDefaultShell();
+            // Setup Session.
+            //
+            // Deliberately IsNullOrWhiteSpace, not `??`: an EMPTY command is just as
+            // unspawnable as a null one, and it is the value that actually reaches here in
+            // practice. `ShellCommand` starts out as string.Empty and is fed straight back
+            // into this method by the OnAttachedToVisualTree fallback and by Reconnect(),
+            // and a restored pane whose persisted Command was empty arrives the same way.
+            // With `??` all of those spawned "", which the native layer resolved to the
+            // first %PATH% *directory* and reported as "Access is denied" against a path the
+            // user never typed. The default shell is always spawnable, so preferring it over
+            // a blank is strictly better than failing.
+            string effectiveShell = string.IsNullOrWhiteSpace(shell) ? ShellHelper.GetDefaultShell() : shell;
             string args = explicitArgs ?? profile?.Arguments ?? "";
             InitializeSessionCore(effectiveShell, args, profile, cols, rows);
         }

--- a/src/NovaTerminal.App/Shell/SessionManager.cs
+++ b/src/NovaTerminal.App/Shell/SessionManager.cs
@@ -102,7 +102,14 @@ namespace NovaTerminal.Shell
                     ProfileId = pane.Profile?.Id.ToString(),
                     SshProfileId = pane.Profile?.Type == ConnectionType.SSH ? pane.Profile.Id.ToString() : null,
                     PaneId = pane.PaneId.ToString(),
-                    Command = pane.ShellCommand,
+                    // Never persist a blank command. A pane that has not started a session
+                    // yet reports ShellCommand == string.Empty, and writing that out produced
+                    // a session file whose leaf said "run nothing" — which the restore below
+                    // then faithfully tried to run, spawning an empty command on every
+                    // subsequent launch and re-saving the same blank on exit. Storing null
+                    // instead makes the leaf explicitly command-less, which restore reads as
+                    // "use the default shell".
+                    Command = string.IsNullOrWhiteSpace(pane.ShellCommand) ? null : pane.ShellCommand,
                     Arguments = pane.ShellArgs
                 };
             }
@@ -313,8 +320,17 @@ namespace NovaTerminal.Shell
                 }
                 else
                 {
-                    // Fallback to command args if profile missing
-                    pane = new TerminalPane(node.Command ?? "cmd.exe", node.Arguments ?? "", settings);
+                    // Fallback to command args if profile missing.
+                    //
+                    // IsNullOrWhiteSpace, not `??`: session files written before the capture
+                    // above learned to skip blanks contain "Command": "", and `??` does not
+                    // fire for an empty string — so the pane was constructed with "" and
+                    // spawned nothing. Those files are still on disk, so this reads them
+                    // correctly rather than relying on the capture fix alone.
+                    pane = new TerminalPane(
+                        string.IsNullOrWhiteSpace(node.Command) ? ShellHelper.GetDefaultShell() : node.Command,
+                        node.Arguments ?? "",
+                        settings);
                 }
 
                 if (!string.IsNullOrWhiteSpace(node.PaneId) && Guid.TryParse(node.PaneId, out var paneId))

--- a/src/NovaTerminal.App/native/src/lib.rs
+++ b/src/NovaTerminal.App/native/src/lib.rs
@@ -614,6 +614,31 @@ fn parse_env_overrides(envs: *const c_char) -> Vec<(String, String)> {
     out
 }
 
+/// Reported when a spawn is asked to run nothing.
+///
+/// Worth spelling out because the OS-level symptom is actively misleading. On Windows,
+/// portable-pty resolves the program name by joining it onto each `%PATH%` entry and taking
+/// the first candidate that *exists* (`cmdbuilder.rs::search_path`) -- and joining an empty
+/// name onto a directory yields that directory, which exists. `CreateProcessW` is then asked
+/// to execute a folder and fails with `Access is denied. (os error 5)`, naming a `%PATH%`
+/// entry the caller never mentioned. Refuse before that happens, and say so.
+const EMPTY_COMMAND_ERROR: &str =
+    "cmd was empty: refusing to spawn. An empty program name resolves to the first PATH \
+     directory, which the OS then rejects with a misleading 'Access is denied'.";
+
+/// `Some(reason)` when the command cannot be spawned as given, `None` to attempt it.
+///
+/// Whitespace counts as empty: `CommandBuilder::new("  ")` is no more runnable than
+/// `CommandBuilder::new("")`, and a stray space is exactly what a hand-edited settings or
+/// session file produces.
+fn reject_unspawnable_command(cmd: &str) -> Option<&'static str> {
+    if cmd.trim().is_empty() {
+        Some(EMPTY_COMMAND_ERROR)
+    } else {
+        None
+    }
+}
+
 /// Decide whether to bypass the Windows `PSEUDOCONSOLE_PASSTHROUGH` spawn path.
 ///
 /// Passthrough silently drops a child's direct stdout writes (e.g. PowerShell 7's
@@ -678,6 +703,12 @@ fn pty_spawn_impl(
         }
         CStr::from_ptr(cmd).to_string_lossy()
     };
+    // Before either spawn path: both the ConPTY passthrough and portable-pty build a command
+    // line from this string, and neither treats "nothing to run" as an error of its own.
+    if let Some(reason) = reject_unspawnable_command(cmd_str.as_ref()) {
+        set_last_error(reason);
+        return std::ptr::null_mut();
+    }
     let args_str = unsafe {
         if args.is_null() {
             None
@@ -1291,6 +1322,39 @@ mod last_error_tests {
         let (rc, message) = read_last_error(128);
         assert!(rc > 0);
         assert_eq!(message, "cmd was null");
+    }
+
+    // An empty command used to reach CreateProcessW, which resolved it to the first %PATH%
+    // directory and reported "Access is denied" against a path nobody asked for. The spawn
+    // must fail here instead, with a message that names the real problem.
+    #[test]
+    fn empty_cmd_is_rejected_before_the_os_sees_it() {
+        let _guard = crate::handle_test_lock();
+        for blank in ["", "   ", "\t"] {
+            let c_cmd = CString::new(blank).unwrap();
+            let state = pty_spawn(c_cmd.as_ptr(), std::ptr::null(), std::ptr::null(), 80, 24);
+            assert!(state.is_null(), "spawning {blank:?} should fail");
+
+            let (rc, message) = read_last_error(512);
+            assert!(rc > 0, "expected a message for {blank:?}, got rc={rc}");
+            assert!(
+                message.contains("cmd was empty"),
+                "message should name the empty command; got: {message}"
+            );
+            // The OS was never asked, so nothing it says can appear here. (The message
+            // *mentions* the denial it prevents, hence matching on the API name and the
+            // errno rather than on the phrase.)
+            assert!(
+                !message.contains("CreateProcessW") && !message.contains("os error 5"),
+                "the OS should never have been asked; got: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_real_command_is_not_rejected_as_empty() {
+        assert_eq!(reject_unspawnable_command("cmd.exe"), None);
+        assert_eq!(reject_unspawnable_command(" cmd.exe "), None);
     }
 
     #[test]

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -409,6 +409,60 @@ namespace NovaTerminal.Pty
         private int _cols;
         private int _rows;
 
+        /// Message for a spawn attempt with no command. Shared with the tests so the
+        /// contract is asserted, not re-typed.
+        internal const string EmptyCommandMessage =
+            "Cannot start a terminal session: no shell command was supplied.";
+
+        /// <summary>
+        /// Rejects a command that is empty or whitespace, before it reaches the native layer.
+        /// </summary>
+        /// <remarks>
+        /// An empty command is not a spawn failure the OS reports usefully. On Windows,
+        /// portable-pty resolves the program name by joining it onto each %PATH% entry
+        /// (cmdbuilder.rs <c>search_path</c>) and taking the first candidate that *exists* —
+        /// and <c>Path::join("")</c> of a directory is that directory, which exists. So an
+        /// empty command resolves to the first directory on %PATH% and CreateProcessW is
+        /// asked to execute a folder, failing with "Access is denied. (os error 5)". The
+        /// reported command line is then a %PATH% entry the user never typed, which sends
+        /// debugging in entirely the wrong direction (it named a VMware directory in the
+        /// original report). Fail here, where the message can say what is actually wrong.
+        /// </remarks>
+        internal static string ValidateShellCommand(string? shellCommand)
+        {
+            if (string.IsNullOrWhiteSpace(shellCommand))
+            {
+                throw new ArgumentException(EmptyCommandMessage, nameof(shellCommand));
+            }
+
+            return RejectEmbeddedNuls(shellCommand, nameof(shellCommand))!;
+        }
+
+        /// <summary>
+        /// Rejects a string carrying an embedded NUL before it is marshalled to the native side.
+        /// </summary>
+        /// <remarks>
+        /// Every string on this boundary is marshalled as <see cref="UnmanagedType.LPUTF8Str"/>,
+        /// i.e. a NUL-terminated C string, and Rust reads it back with
+        /// <c>CStr::from_ptr</c> — which stops at the FIRST NUL. An embedded NUL therefore
+        /// cannot be detected on the Rust side at all: it silently truncates, and the child
+        /// is spawned with a command/cwd that is a prefix of what the caller asked for. This
+        /// is the only place the whole string is still visible, so it is the only place the
+        /// check can be made.
+        /// </remarks>
+        internal static string? RejectEmbeddedNuls(string? value, string parameterName)
+        {
+            if (value != null && value.IndexOf('\0') >= 0)
+            {
+                throw new ArgumentException(
+                    $"Cannot start a terminal session: {parameterName} contains an embedded NUL character, " +
+                    "which would be silently truncated when passed to the native PTY layer.",
+                    parameterName);
+            }
+
+            return value;
+        }
+
         /// The PTY read call, injectable so tests can drive the read loop's failure
         /// handling. `pty_read` returns the byte count, 0 for EOF, or a negative value for
         /// any error - see MaxConsecutiveReadErrors.
@@ -451,6 +505,21 @@ namespace NovaTerminal.Pty
             IReadOnlyDictionary<string, string>? environmentOverrides,
             PtyReadDelegate? readFromPty)
         {
+            // Validate before anything else: everything below either marshals these strings
+            // to the native layer or derives from them. A bad value must fail here with a
+            // message that names the problem, not deep inside CreateProcessW.
+            shellCommand = ValidateShellCommand(shellCommand);
+            args = RejectEmbeddedNuls(args, nameof(args));
+            cwd = RejectEmbeddedNuls(cwd, nameof(cwd));
+            if (environmentOverrides != null)
+            {
+                foreach (var kv in environmentOverrides)
+                {
+                    RejectEmbeddedNuls(kv.Key, "environment variable name");
+                    RejectEmbeddedNuls(kv.Value, $"the value of environment variable '{kv.Key}'");
+                }
+            }
+
             _readFromPty = readFromPty ?? Native.pty_read;
             ShellCommand = shellCommand;
             ShellArguments = args;

--- a/tests/NovaTerminal.App.Tests/PtySpawnFailureTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtySpawnFailureTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using NovaTerminal.Pty;
 using Xunit;
 
@@ -43,6 +44,79 @@ namespace NovaTerminal.Tests
                 separator > 0,
                 $"expected a native reason appended to the message, got: {ex.Message}");
             Assert.NotEmpty(ex.Message.Substring(separator + 3).Trim());
+        }
+
+        /// <summary>
+        /// An empty command must be refused here, not by the OS.
+        /// </summary>
+        /// <remarks>
+        /// Reported symptom: a pane showed
+        /// <c>Failed to create Rust PTY session for '': failed to spawn '': CreateProcessW
+        /// `"C:\Program Files (x86)\VMware\VMware Workstation\bin\\"` ... Access is denied.
+        /// (os error 5)</c>. Nothing in the app ever mentioned VMware — portable-pty resolves a
+        /// program name by joining it onto each %PATH% entry and taking the first candidate that
+        /// exists, and joining "" onto a directory is that directory. So the empty command became
+        /// "execute the first folder on %PATH%", and the OS's refusal named a path the user had
+        /// nothing to do with. Every minute spent on that message was wasted.
+        /// </remarks>
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("\t")]
+        public void Spawning_an_empty_command_fails_with_a_message_about_the_empty_command(string blank)
+        {
+            var ex = Assert.Throws<ArgumentException>(
+                () => new RustPtySession(blank, cols: 80, rows: 24));
+
+            Assert.Contains(RustPtySession.EmptyCommandMessage, ex.Message, StringComparison.Ordinal);
+            // The failure the old code produced. If it ever comes back, it comes back from the OS
+            // with this in it.
+            Assert.DoesNotContain("Access is denied", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("CreateProcessW", ex.Message, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// A NUL cannot be caught on the Rust side: every string here is marshalled as a
+        /// NUL-terminated C string and read back with <c>CStr::from_ptr</c>, which stops at the
+        /// first NUL. Left unchecked, the child is silently spawned from a prefix of what the
+        /// caller asked for — so the check has to happen while the whole string is still visible.
+        /// </summary>
+        [Fact]
+        public void Spawning_a_command_with_an_embedded_nul_is_rejected_rather_than_truncated()
+        {
+            // Truncation would make this "cmd.exe" and spawn a perfectly good shell — the
+            // dangerous outcome, because it silently runs something other than what was asked.
+            var ex = Assert.Throws<ArgumentException>(
+                () => new RustPtySession("cmd.exe\0-rm-rf", cols: 80, rows: 24));
+
+            Assert.Contains("NUL", ex.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void Spawn_arguments_with_an_embedded_nul_are_rejected()
+        {
+            Assert.Throws<ArgumentException>(
+                () => new RustPtySession("cmd.exe", cols: 80, rows: 24, args: "/c echo\0hi"));
+        }
+
+        [Fact]
+        public void A_working_directory_with_an_embedded_nul_is_rejected()
+        {
+            Assert.Throws<ArgumentException>(
+                () => new RustPtySession("cmd.exe", cols: 80, rows: 24, cwd: "C:\\Users\0"));
+        }
+
+        [Fact]
+        public void An_environment_override_with_an_embedded_nul_is_rejected()
+        {
+            var overrides = new Dictionary<string, string> { ["ZDOTDIR"] = "/tmp\0/evil" };
+
+            Assert.Throws<ArgumentException>(
+                () => new RustPtySession(
+                    "cmd.exe",
+                    cols: 80,
+                    rows: 24,
+                    environmentOverrides: overrides));
         }
     }
 }

--- a/tests/NovaTerminal.App.Tests/Shell/SessionEmptyCommandTests.cs
+++ b/tests/NovaTerminal.App.Tests/Shell/SessionEmptyCommandTests.cs
@@ -1,0 +1,106 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using NovaTerminal.Controls;
+using NovaTerminal.Pty;
+using NovaTerminal.Shell;
+using Xunit;
+
+namespace NovaTerminal.Tests.Shell;
+
+/// <summary>
+/// The session file must never carry — or act on — a blank shell command.
+/// </summary>
+/// <remarks>
+/// Field report: every launch opened a pane showing
+/// <c>Failed to spawn process:</c> with no command named, and
+/// <c>failed to spawn '': CreateProcessW `"...\VMware Workstation\bin\\"` ... Access is denied</c>.
+/// The user's <c>last_session.json</c> held a single leaf with <c>"Command": ""</c>:
+/// <list type="number">
+///   <item>a pane that had not started a session yet reports <c>ShellCommand == string.Empty</c>,
+///         and the capture wrote that out verbatim;</item>
+///   <item>on restore, <c>node.Command ?? "cmd.exe"</c> did not fire — <c>""</c> is not null — so
+///         the pane was built with an empty command;</item>
+///   <item>the pane spawned it, failed, and kept <c>ShellCommand == ""</c>, which the next
+///         shutdown persisted again.</item>
+/// </list>
+/// Self-sustaining: once written, the terminal was dead on every subsequent launch and no
+/// amount of restarting cleared it. Both halves are covered here — the write must not produce
+/// a blank, and the read must not trust one, because session files written by the old code are
+/// still on disk.
+/// </remarks>
+public class SessionEmptyCommandTests
+{
+    private static TabSession LeafTab(string? command) => new()
+    {
+        Title = "Restored",
+        Root = new PaneNode
+        {
+            Type = NodeType.Leaf,
+            Command = command,
+            Arguments = string.Empty,
+            PaneId = Guid.NewGuid().ToString()
+        }
+    };
+
+    [AvaloniaTheory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void Restoring_a_leaf_without_a_usable_command_falls_back_to_the_default_shell(string? command)
+    {
+        TabItem restored = SessionManager.CreateRestoredTabItem(LeafTab(command), new TerminalSettings())!;
+
+        var pane = (TerminalPane)restored.Content!;
+        Assert.Equal(ShellHelper.GetDefaultShell(), pane.ShellCommand);
+    }
+
+    [AvaloniaFact]
+    public void Restoring_a_leaf_with_a_real_command_keeps_it()
+    {
+        // The fallback must not swallow a command that was perfectly good.
+        TabItem restored = SessionManager.CreateRestoredTabItem(LeafTab("cmd.exe"), new TerminalSettings())!;
+
+        var pane = (TerminalPane)restored.Content!;
+        Assert.Equal("cmd.exe", pane.ShellCommand);
+    }
+
+    [AvaloniaFact]
+    public void Capturing_a_pane_that_never_started_a_session_records_no_command()
+    {
+        // A pane is only measured once it is laid out, so a window closed early captures panes
+        // in exactly this state. `null` (not "") is what makes the restore fallback fire.
+        using var pane = new TerminalPane();
+        Assert.Equal(string.Empty, pane.ShellCommand);
+
+        NovaSession captured = CaptureSingle(pane);
+
+        Assert.Null(captured.Tabs[0].Root!.Command);
+    }
+
+    [AvaloniaFact]
+    public void A_captured_and_restored_unstarted_pane_is_still_spawnable()
+    {
+        // The full loop the bug lived in: capture an unstarted pane, restore it, and the
+        // restored pane must have something it can actually run. Before the fix this round-trip
+        // produced ""  -> "" -> a spawn of the first %PATH% directory.
+        using var pane = new TerminalPane();
+        NovaSession captured = CaptureSingle(pane);
+
+        TabItem restored = SessionManager.CreateRestoredTabItem(captured.Tabs[0], new TerminalSettings())!;
+
+        var restoredPane = (TerminalPane)restored.Content!;
+        Assert.False(
+            string.IsNullOrWhiteSpace(restoredPane.ShellCommand),
+            "a restored pane must carry a command it can spawn");
+    }
+
+    private static NovaSession CaptureSingle(TerminalPane pane)
+    {
+        var tabs = new TabControl();
+        tabs.Items.Add(new TabItem { Header = "Terminal", Content = pane });
+        var window = new Window { Content = tabs };
+
+        return SessionManager.CaptureSession(window, tabs);
+    }
+}


### PR DESCRIPTION
## Symptom

Every launch of the app opened a dead pane:

```
[ERROR] Failed to spawn process:
[DETAILS] Failed to create Rust PTY session for '': failed to spawn '':
CreateProcessW `"\"C:\\Program Files (x86)\\VMware\\VMware Workstation\\bin\\\\"\0"`
in cwd `Some("C:\\Users\\behna\0")` failed: Access is denied. (os error 5)
```

Restarting never cleared it.

## Root cause

Two independent halves, plus one red herring.

### (a) A blank command written to, and read back from, the session file

The reporter's `%LOCALAPPDATA%\NovaTerminal\sessions\last_session.json` held a single
leaf with `"Command": ""`, and `logs\debug.log` recorded
`[RustPtySession] Spawning '' args='' cwd='' at 112x28`. The state re-created itself
on every run:

1. `SessionManager.BuildPaneTree` persisted `pane.ShellCommand` verbatim. A pane that
   has not started a session yet reports `string.Empty`, so the file said "run nothing".
2. `RestorePaneTree`'s `node.Command ?? "cmd.exe"` did not fire, because `""` is not
   `null`. The pane was rebuilt with an empty command.
3. `TerminalPane.InitializeSession` chose its fallback the same way
   (`shell ?? ShellHelper.GetDefaultShell()`), so the blank survived to the spawn.
4. The spawn failed, the pane kept `ShellCommand == ""`, and the next shutdown
   persisted the same blank again.

Contributing: the pane only recorded its requested command once
`InitializeSessionCore` ran. Until then the shell lived solely in the `TermView.Ready`
closure, while `ShellCommand` -- the property the `OnAttachedToVisualTree` fallback,
`Reconnect()` and session capture all read -- was still empty. A pane whose attach beat
its Ready event discarded the shell it was asked for.

### (b) Nothing on the spawn path refused an empty command

`RustPtySession` passed `""` through, and the native `pty_spawn_impl` rejected only a
NULL cmd, not an empty one. portable-pty then resolves a program name by joining it
onto each `%PATH%` entry and taking the first candidate that *exists*
(`cmdbuilder.rs::search_path`) -- and `Path::join("")` of a directory is that directory,
which exists. So `""` resolved to the first `%PATH%` entry, `CreateProcessW` was asked
to execute a folder, and the OS answered `Access is denied. (os error 5)` while naming
a VMware directory nobody had mentioned. The message actively misdirected the
investigation.

### The NULs were not a marshalling bug

The `\0`s in the report (`...bin\\"\0`, `Some("C:\Users\behna\0")`) are portable-pty's
own terminators: `cmdbuilder.rs` pushes a `0` onto the wide cmdline and cwd buffers,
and `win/psuedocon.rs` Debug-prints those buffers whole. The `C:\Users\behna` cwd is
likewise portable-pty's `USERPROFILE` fallback (`current_directory()` -> `cwd.or(home)`),
not something the app sent -- the app's own log line for the same spawn reads
`cwd=''`. No string was mangled on the way across. The NUL validation below is defence
in depth, not the fix for that symptom.

## The fix

| Layer | Change |
|---|---|
| Session capture | Persist `null` instead of a blank command, so the leaf is explicitly command-less. |
| Session restore | `IsNullOrWhiteSpace`, not `??`, falling back to `ShellHelper.GetDefaultShell()`. Not redundant with the capture fix: files written by the old code are already on disk. |
| Pane | `IsNullOrWhiteSpace` fallback in `InitializeSession`; record the requested command on the pane at construction so the attach-time fallback and capture can see it. |
| PTY boundary | `RustPtySession` rejects an empty/whitespace command, and rejects an embedded NUL in command, args, cwd or environment overrides. A NUL cannot be caught in Rust: `CStr::from_ptr` stops at the first one, so the string would silently truncate. This is the last place it is fully visible. |
| Native | `pty_spawn_impl` refuses an empty command with a message that names it, before either spawn path builds a command line. |
| scripts/run-sidecar.ps1 | Unrelated to the bug, found while reproducing through it: the script is pwsh-only but failed under Windows PowerShell 5.1 with "A positional parameter cannot be found that accepts argument 'NovaTerminal.App'". It now says what it needs. |

## Live verification

Both runs used an isolated `NOVATERM_APPDATA_ROOT` seeded with the reporter's exact
`last_session.json` (`"Command": ""`). The owner's real appdata was not touched.

Before (main @ 0014677 build, unchanged binary):

```
[RustPtySession] Spawning '' args='' cwd='' at 138x45
```
and the pane showed the reported error verbatim, VMware path and all.

After (`pwsh scripts/run-sidecar.ps1` from this branch, same seeded session file):

```
[RustPtySession] Spawning 'pwsh.exe' args='-NoLogo -NoExit -File ...bootstrap.ps1' cwd='' at 138x45
```
a live `PS C:\Users\behna>` prompt, and on graceful close the session file recorded
`"Command": "pwsh.exe"` -- the self-sustaining loop is broken.

## Tests

New:
- `SessionEmptyCommandTests` (6): restore of a leaf with `""`/whitespace/`null` falls
  back to the default shell; a real command is kept; capture of an unstarted pane
  records no command; the capture -> restore round-trip yields something spawnable.
- `PtySpawnFailureTests` (+7): empty and whitespace commands fail with the
  empty-command message and never mention `CreateProcessW`; embedded NULs in command,
  args, cwd and env are rejected rather than truncated.
- `rusty_pty` (+2): empty/whitespace cmd is rejected before the OS sees it; a real
  command is not.

Mutation check on the root-cause test: reverting either half of the session fix fails
5 of the 6 new `SessionEmptyCommandTests`; the sixth (a real command is kept) stays
green, which is what it is there for.

Suites, all green: App.Tests `Tests.Shell` 31, `Tests.Core` 261, `Tests.Controls` 166,
`PtySpawnFailureTests` 9; VT 362; Architecture 33; Platform 140 (18 skipped);
`cargo test --lib` 23. Clean solution build, 0 errors.

Rust code changed, so the native DLL must be rebuilt (`cargo build --release` in
`src/NovaTerminal.App/native`, or delete `native/target/release/rusty_pty.dll` and let
the csproj target run it).
