### PR TITLE
fix(command-assist): dogfood-driven UX polish - recency-first history, readable bubble, fix-mode noise floor

### DIFF
--- a/src/NovaTerminal.App/CommandAssist/Views/CommandAssistBubbleView.axaml
+++ b/src/NovaTerminal.App/CommandAssist/Views/CommandAssistBubbleView.axaml
@@ -5,31 +5,93 @@
              x:DataType="viewModels:CommandAssistBubbleViewModel"
              x:Class="NovaTerminal.CommandAssist.Views.CommandAssistBubbleView"
              IsVisible="{Binding IsVisible}">
+    <UserControl.Styles>
+        <!--
+            The gap between the query and the suggestion closes when the suggestion is the tail of the
+            query rather than a separate thing (fish-style completion). ColumnSpacing cannot express
+            "usually 10, sometimes 0", so the columns are butted together and every element carries its
+            own left margin, which one class then overrides. See
+            CommandAssistBubbleViewModel.IsSummaryContinuation.
+        -->
+        <Style Selector="TextBlock#BubbleSummaryText">
+            <Setter Property="Margin" Value="10,0,0,0"/>
+        </Style>
+        <Style Selector="TextBlock#BubbleSummaryText.continuation">
+            <Setter Property="Margin" Value="0"/>
+        </Style>
+    </UserControl.Styles>
     <Border Background="#CC202020"
             BorderBrush="#404040"
             BorderThickness="1"
             CornerRadius="8"
             Padding="10,6">
-        <Grid ColumnDefinitions="Auto,Auto,*,Auto" ColumnSpacing="10">
+        <!--
+            Column priority is the whole point of this grid, and it used to be backwards.
+
+            The suggestion is the only thing in the bubble the user is reading; everything else is
+            chrome that explains it. Before the UX-polish round the suggestion sat in the one `*`
+            column with no floor while the mode label, the query and the hint strip all sat in `Auto`
+            columns that take their desired width first - so at the owner's pane width the suggestion
+            was the only thing that could shrink, and it shrank to `doc...`.
+
+            Now the content column has a MinWidth it never gives up, the query is capped so a long
+            failed command cannot crowd out the fix for it, and the hint strip collapses in two stages
+            before either (AssistHintDetail). Chrome yields to content, in that order.
+        -->
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto" MaxWidth="130"/>
+                <ColumnDefinition Width="*" MinWidth="150"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
             <TextBlock x:Name="BubbleModeLabelText"
                        Text="{Binding ModeLabel}"
                        Foreground="#8EC5FF"
                        FontWeight="SemiBold"
                        VerticalAlignment="Center"/>
+
             <TextBlock Grid.Column="1"
                        x:Name="BubbleQueryText"
                        Text="{Binding QueryText}"
                        IsVisible="{Binding ShowQueryText}"
+                       Margin="10,0,0,0"
                        Foreground="White"
                        FontFamily="Consolas"
                        VerticalAlignment="Center"
                        TextTrimming="CharacterEllipsis"/>
+
             <TextBlock x:Name="BubbleSummaryText"
                        Grid.Column="2"
+                       Classes.continuation="{Binding IsSummaryContinuation}"
                        Text="{Binding SummaryText}"
                        Foreground="#D7E8FF"
                        VerticalAlignment="Center"
                        TextTrimming="CharacterEllipsis"/>
+
+            <!--
+                The integration chip (owner-approved addition). Deliberately the quietest thing on the
+                row: it answers "is the shell integration script working?" once per session and then
+                has nothing further to say, so it is sized and coloured to be findable rather than
+                noticed. Dropped before the hint strip's last rung, because it is the more skippable
+                of the two.
+            -->
+            <Border Grid.Column="3"
+                    x:Name="BubbleIntegrationChip"
+                    IsVisible="{Binding ShowIntegrationStatus}"
+                    ToolTip.Tip="{Binding IntegrationStatusTooltip}"
+                    Margin="10,0,0,0"
+                    Background="#22FFFFFF"
+                    CornerRadius="4"
+                    Padding="5,1"
+                    VerticalAlignment="Center">
+                <TextBlock x:Name="BubbleIntegrationStatusText"
+                           Text="{Binding IntegrationStatusText}"
+                           Foreground="#8B96A5"
+                           FontSize="10"/>
+            </Border>
 
             <!--
                 The hint strip. Present on the view-model since M4.2 and never bound until V2 Phase 3a,
@@ -37,15 +99,16 @@
                 taught them rendered everything except them. Content is state-dependent (see
                 CommandAssistBarViewModel), so it never advertises a key the surface does not own.
 
-                It is also the lowest-priority content in the bubble, and the layout has to say so: this
-                is an Auto column next to the summary's *, so without a cap it wins every width argument
-                (PR #290 review). Collapsed outright in compact layout - the 280 px floor a split SSH
-                pane lands on - and capped otherwise so the summary keeps the remainder.
+                It is also the lowest-priority content in the bubble, and the layout has to say so.
+                Since the UX-polish round the collapse is progressive rather than all-or-nothing - full
+                text, then keys only, then gone - and the MaxWidth is the backstop for the case where
+                even the terse form is long because the user rebound the keys to something verbose.
             -->
             <TextBlock x:Name="BubbleShortcutHintText"
-                       Grid.Column="3"
+                       Grid.Column="4"
                        Text="{Binding ShortcutHintText}"
                        IsVisible="{Binding ShowShortcutHint}"
+                       Margin="10,0,0,0"
                        MaxWidth="240"
                        Foreground="#8B96A5"
                        FontSize="11"

--- a/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml
+++ b/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml
@@ -240,11 +240,33 @@
                 trimmed, because a credit cut off at the ellipsis is not a credit.
             -->
             <StackPanel Grid.Row="2" Spacing="3">
-                <TextBlock x:Name="PopupShortcutHintText"
-                           Text="{Binding ShortcutHintText}"
-                           Foreground="#8B96A5"
-                           FontSize="11"
-                           TextTrimming="CharacterEllipsis"/>
+                <Grid ColumnDefinitions="*,Auto">
+                    <TextBlock x:Name="PopupShortcutHintText"
+                               Text="{Binding ShortcutHintText}"
+                               Foreground="#8B96A5"
+                               FontSize="11"
+                               VerticalAlignment="Center"
+                               TextTrimming="CharacterEllipsis"/>
+
+                    <!--
+                        The integration chip, mirroring the bubble's. The popup keeps it at every
+                        width: this is the surface someone is looking at when a Ctrl+R list is
+                        shorter than they expected, and "basic" is very often the answer to why.
+                    -->
+                    <Border Grid.Column="1"
+                            x:Name="PopupIntegrationChip"
+                            ToolTip.Tip="{Binding IntegrationStatusTooltip}"
+                            Margin="8,0,0,0"
+                            Background="#22FFFFFF"
+                            CornerRadius="4"
+                            Padding="5,1"
+                            VerticalAlignment="Center">
+                        <TextBlock x:Name="PopupIntegrationStatusText"
+                                   Text="{Binding IntegrationStatusText}"
+                                   Foreground="#8B96A5"
+                                   FontSize="10"/>
+                    </Border>
+                </Grid>
                 <TextBlock x:Name="PopupAttributionText"
                            Text="{Binding AttributionText}"
                            IsVisible="{Binding HasAttribution}"

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -1580,13 +1580,23 @@ namespace NovaTerminal.Controls
             {
                 if (_boundCommandAssistViewModel != null)
                 {
-                    _boundCommandAssistViewModel.Bubble.ShowQueryText = !layout.UseCompactBubbleLayout;
+                    // The width budget only. Whether the query is worth showing at a width that could
+                    // hold it is the view-model's call - Fix mode declines it - so this sets the
+                    // permission rather than the outcome. See CommandAssistBarViewModel.AllowBubbleQueryText.
+                    _boundCommandAssistViewModel.AllowBubbleQueryText = !layout.UseCompactBubbleLayout;
 
-                    // Same rule, same reason, one more casualty of a 280 px bubble: the hint strip's Auto
-                    // column beat the summary's * column at the width a split SSH pane produces, so the
-                    // one thing the bubble exists to show was squeezed out by a legend for it
-                    // (PR #290 review). The popup footer still carries the shortcuts.
-                    _boundCommandAssistViewModel.Bubble.ShowShortcutHint = !layout.UseCompactBubbleLayout;
+                    // Same rule, same reason, one more casualty of a narrow bubble: the hint strip's
+                    // Auto column beat the summary's * column at the width a split SSH pane produces,
+                    // so the one thing the bubble exists to show was squeezed out by a legend for it
+                    // (PR #290 review). Since the UX-polish round the collapse has a middle rung -
+                    // keys without verbs - because the owner's pane was wider than the compact
+                    // threshold and still could not fit both. The popup footer always carries the
+                    // full shortcuts.
+                    _boundCommandAssistViewModel.BubbleHintDetail = layout.UseCompactBubbleLayout
+                        ? AssistHintDetail.Hidden
+                        : layout.UseTerseBubbleHint
+                            ? AssistHintDetail.Terse
+                            : AssistHintDetail.Full;
                 }
 
                 CommandAssistBubble.Width = layout.BubbleRect.Width;

--- a/src/NovaTerminal.CommandAssist/Application/CapturePipeline.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CapturePipeline.cs
@@ -45,8 +45,31 @@ internal sealed class CapturePipeline
     private readonly ISecretsFilter _secretsFilter;
     private readonly AssistSessionContext _context;
 
+    /// <summary>
+    /// The exit code every POSIX shell uses for "I could not find that program".
+    /// </summary>
+    /// <remarks>
+    /// bash, zsh and fish all report it; PowerShell does not, and reports 1 for an unresolved name
+    /// exactly as it does for a command that ran and failed. That gap is why the flag has a second
+    /// source - see <see cref="MarkLastCommandInvalidAsync"/>.
+    /// </remarks>
+    internal const int CommandNotFoundExitCode = 127;
+
     private string? _pendingEntryId;
     private string? _pendingCommandText;
+
+    /// <summary>
+    /// The entry the most recently finished command was written to, retained after the completion
+    /// patch has cleared <see cref="_pendingEntryId"/>.
+    /// </summary>
+    /// <remarks>
+    /// It exists for one caller and one ordering problem. The Fix-time recogniser is what identifies a
+    /// PowerShell command-not-found, and it runs <em>after</em> <c>CommandFinished</c> has already
+    /// patched the exit code and released the pending id; without somewhere to remember which entry
+    /// that was, the classification would arrive with nothing to apply itself to. Cleared when a new
+    /// command is captured, so a late classification can never be applied to the wrong entry.
+    /// </remarks>
+    private string? _lastCompletedEntryId;
 
     /// <summary>
     /// Whether the current prompt cycle has already contributed a structured history entry.
@@ -143,6 +166,10 @@ internal sealed class CapturePipeline
             await _historyStore.AppendAsync(entry);
             _pendingEntryId = entry.Id;
             _pendingCommandText = NormalizeCommandText(trimmed);
+
+            // A new command supersedes any classification still owed to the previous one. Without
+            // this, a Fix analysis that arrived late could mark the wrong entry as a typo.
+            _lastCompletedEntryId = null;
         }
         catch
         {
@@ -163,15 +190,62 @@ internal sealed class CapturePipeline
             return;
         }
 
+        _lastCompletedEntryId = pendingEntryId;
+
         try
         {
-            await _historyStore.TryUpdateExecutionResultAsync(pendingEntryId, exitCode, durationMs: null);
+            await _historyStore.TryUpdateExecutionResultAsync(
+                pendingEntryId,
+                exitCode,
+                durationMs: null,
+                isInvalidCommand: IsCommandNotFoundExit(exitCode));
         }
         catch
         {
             // History metadata enrichment is best-effort only.
         }
     }
+
+    /// <summary>
+    /// Records that the command behind the most recent entry was one the shell could not resolve, so
+    /// nothing may offer it back as a suggestion.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Called by <c>CommandAssistController.HandleCommandFailureAsync</c> when the recogniser table
+    /// classified the failure as <c>command-not-found</c>. It is the PowerShell half of the signal:
+    /// see <see cref="CommandNotFoundExitCode"/> for why the exit code cannot carry it there, and
+    /// <c>CommandHistoryEntry.IsInvalidCommand</c> for why the entry is flagged rather than deleted.
+    /// </para>
+    /// <para>
+    /// <strong>Only ever the completed entry, never the pending one.</strong> A failure analysis is
+    /// always preceded by the completion that reported the exit code - that is what tells the host a
+    /// command failed at all - so the completed entry is the right target by construction. Falling
+    /// back to the pending entry would buy nothing and would risk the one outcome worse than
+    /// suggesting a typo: silently suppressing a command that works, because an analysis of the
+    /// previous line arrived after the next had been typed.
+    /// </para>
+    /// </remarks>
+    public async Task MarkLastCommandInvalidAsync()
+    {
+        string? entryId = _lastCompletedEntryId;
+        if (string.IsNullOrWhiteSpace(entryId))
+        {
+            return;
+        }
+
+        try
+        {
+            await _historyStore.TryMarkInvalidCommandAsync(entryId);
+        }
+        catch
+        {
+            // Best-effort like every other write here: failing to suppress a typo must not take down
+            // the Fix suggestion the user is about to be shown for it.
+        }
+    }
+
+    private static bool IsCommandNotFoundExit(int? exitCode) => exitCode == CommandNotFoundExitCode;
 
     /// <summary>
     /// Consumes a shell-integration event: records what it proves about the session, then runs the
@@ -291,6 +365,10 @@ internal sealed class CapturePipeline
             _pendingEntryId = entry.Id;
             _pendingCommandText = normalizedCommandText;
             _structuredEntryWrittenThisCycle = true;
+
+            // See the same line in CaptureSubmissionAsync: a new command retires the previous one's
+            // right to a late classification.
+            _lastCompletedEntryId = null;
         }
         catch
         {
@@ -312,7 +390,12 @@ internal sealed class CapturePipeline
 
         try
         {
-            await _historyStore.TryUpdateExecutionResultAsync(pendingEntryId, shellEvent.ExitCode, durationMs);
+            await _historyStore.TryUpdateExecutionResultAsync(
+                pendingEntryId,
+                shellEvent.ExitCode,
+                durationMs,
+                isInvalidCommand: IsCommandNotFoundExit(shellEvent.ExitCode));
+            _lastCompletedEntryId = pendingEntryId;
             _pendingEntryId = null;
             _pendingCommandText = null;
         }

--- a/src/NovaTerminal.CommandAssist/Application/CommandAssistAnchorCalculator.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CommandAssistAnchorCalculator.cs
@@ -37,6 +37,24 @@ public sealed class CommandAssistAnchorCalculator
     private const double MinimumPromptWidth = 120;
     private const double CompactBubbleWidthThreshold = 320;
     private const double CompactPaneWidthThreshold = 560;
+
+    /// <summary>
+    /// Below this bubble width the shortcut hint drops its verbs and keeps its key names.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The middle rung the UX-polish round added between "full hint" and "no hint". The compact
+    /// threshold at 320 was the only step there was, so every width from 321 px upwards got the full
+    /// ~200 px strip - and the bubble the owner was actually looking at is in that range, which is why
+    /// his suggestion was ellipsised to six characters while a legend for keys he already knew kept
+    /// its full width.
+    /// </para>
+    /// <para>
+    /// 420 is the point at which the strip, the mode label and a query stop leaving the content
+    /// column its 150 px floor. Above it everything fits and nothing needs to give.
+    /// </para>
+    /// </remarks>
+    private const double TerseBubbleHintWidthThreshold = 420;
     // Band ratios. Every one of these is a hedge against not knowing where the prompt is; a
     // mark-anchored request bypasses all of them (see the class remarks). They survive because
     // markless sessions still exist -- an un-instrumented remote, a shell with integration
@@ -64,6 +82,11 @@ public sealed class CommandAssistAnchorCalculator
         bool useCompactBubbleLayout = paneWidth <= CompactPaneWidthThreshold ||
                                       request.BubbleWidth > availableWidth ||
                                       bubbleWidth <= CompactBubbleWidthThreshold;
+
+        // The middle rung. Only meaningful when the hint is rendered at all, so it is deliberately
+        // not or-ed with the compact decision: compact already hides the strip outright.
+        bool useTerseBubbleHint = !useCompactBubbleLayout &&
+                                  bubbleWidth <= TerseBubbleHintWidthThreshold;
         bool usesMarkAnchor = request.HasMarkAnchor &&
                               request.VisibleRows > 0 &&
                               request.MarkVisualRow >= 0 &&
@@ -166,7 +189,8 @@ public sealed class CommandAssistAnchorCalculator
             popupDirection,
             usesPromptAnchor,
             useCompactBubbleLayout,
-            usesMarkAnchor);
+            usesMarkAnchor,
+            useTerseBubbleHint);
     }
 
     private static AssistRect CreatePromptRect(
@@ -416,7 +440,8 @@ public sealed record CommandAssistAnchorLayout(
     CommandAssistPopupDirection PopupDirection,
     bool UsesPromptAnchor,
     bool UseCompactBubbleLayout,
-    bool UsesMarkAnchor = false);
+    bool UsesMarkAnchor = false,
+    bool UseTerseBubbleHint = false);
 
 public enum CommandAssistPopupDirection
 {

--- a/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
@@ -105,6 +105,12 @@ public sealed class CommandAssistController
     /// </remarks>
     private bool _isInsertionAvailable = true;
 
+    /// <summary>
+    /// The clock the relative-time captions are rendered against. Overridable so the buckets in
+    /// <see cref="AssistRelativeTime"/> can be tested without waiting for time to pass.
+    /// </summary>
+    internal Func<DateTimeOffset> Clock { get; set; } = () => DateTimeOffset.UtcNow;
+
     public CommandAssistController(
         IHistoryStore historyStore,
         ISecretsFilter secretsFilter,
@@ -768,6 +774,19 @@ public sealed class CommandAssistController
         CommandAssistMode mode = _modeRouter.ChooseModeForFailure(highestConfidence);
         IReadOnlyList<AssistSuggestion> suggestions = _resultBuilder.BuildFixSuggestions(fixes);
 
+        // The typo suppression's second signal (UX-polish round, issue 5). Exit code 127 is handled in
+        // CapturePipeline where the completion patch already lands, but PowerShell reports 1 for an
+        // unresolved name, so on Windows the only thing that knows a typo happened is the recogniser
+        // that just read "The term 'gti' is not recognized" out of the output tail. Thread it back to
+        // the entry the pipeline captured for this very command, before anything can offer it again.
+        //
+        // Best-effort and deliberately not awaited into the surface decision below: failing to mark a
+        // typo must not also cost the user the fix suggestion for it.
+        if (fixes.Any(item => item.IsCommandNotFound))
+        {
+            await _capturePipeline.MarkLastCommandInvalidAsync();
+        }
+
         // Kept symmetrical with Help even though neither Fix branch below can currently render it:
         // reaching Fix mode requires a confidence >= 0.8, which requires at least one row, and the
         // Suggest branch returns early when there are none. That was true of "No likely local fix
@@ -789,7 +808,11 @@ public sealed class CommandAssistController
             return true;
         }
 
-        if (suggestions.Count == 0)
+        // The noise floor (UX-polish round, issue 4). This used to be `suggestions.Count == 0`, i.e.
+        // every failing command in the session got a bubble whatever the ladder had managed to infer.
+        // See CommandAssistModeRouter.ShouldSurfacePassiveFix for what "actionable" means and why the
+        // suppressed rows are still reachable by an explicit Ctrl+Space.
+        if (!_modeRouter.ShouldSurfacePassiveFix(fixes))
         {
             return false;
         }
@@ -951,6 +974,7 @@ public sealed class CommandAssistController
         // grid, so this is also where the surface catches up with edits no keystroke reported.
         _isInsertionAvailable = outcome.InsertionAppearsAvailable;
         ViewModel.QueryText = outcome.Query;
+        PublishSessionStatus();
 
         // A ranking pass shows the user's own history, snippets and paths - nothing licensed. If a
         // Help surface left a credit behind, this is where it goes.
@@ -1027,6 +1051,21 @@ public sealed class CommandAssistController
         return true;
     }
 
+    /// <summary>
+    /// Republishes the session facts the surface displays about itself, as opposed to about its rows.
+    /// </summary>
+    /// <remarks>
+    /// Today that is just the integration chip. Pulled from
+    /// <see cref="AssistSessionContext.IsShellIntegrationLive"/> at publish time rather than pushed
+    /// when it changes, for the reason the hint-strip probes give: the flag moves on marker
+    /// observations deep in the capture path, and a pushed copy would be stale at whichever call site
+    /// forgot to update it.
+    /// </remarks>
+    private void PublishSessionStatus()
+    {
+        ViewModel.IsShellIntegrationLive = _context.IsShellIntegrationLive;
+    }
+
     private AssistSuggestion? GetSelectedSuggestion()
     {
         return ViewModel.SelectedIndex >= 0 && ViewModel.SelectedIndex < _suggestions.Count
@@ -1076,7 +1115,17 @@ public sealed class CommandAssistController
         }
     }
 
-    private static string BuildMetadataText(AssistSuggestion suggestion)
+    /// <summary>
+    /// The metadata caption under a row: where it ran, how long ago, and how it ended.
+    /// </summary>
+    /// <remarks>
+    /// The timestamp is relative since the UX-polish round. <c>Used 2026-08-04 15:23</c> made the
+    /// reader do arithmetic to answer the only question a <c>Ctrl+R</c> row raises, and it was the
+    /// one field that could have made the new recency ordering legible. See
+    /// <see cref="AssistRelativeTime"/>. The directory stays: it is the other half of the placement,
+    /// and the "Same dir" badge is a boolean where this is the actual path.
+    /// </remarks>
+    private string BuildMetadataText(AssistSuggestion suggestion)
     {
         List<string> parts = new();
         if (!string.IsNullOrWhiteSpace(suggestion.WorkingDirectory))
@@ -1086,7 +1135,7 @@ public sealed class CommandAssistController
 
         if (suggestion.LastUsedAt.HasValue)
         {
-            parts.Add($"Used {suggestion.LastUsedAt.Value:yyyy-MM-dd HH:mm}");
+            parts.Add(AssistRelativeTime.Format(suggestion.LastUsedAt.Value, Clock()));
         }
 
         if (suggestion.ExitCode.HasValue)
@@ -1118,6 +1167,7 @@ public sealed class CommandAssistController
         // SuggestionRefreshOutcome.InsertionAppearsAvailable - which is also the answer for Fix, published
         // after the line was submitted with the lifecycle gate already shut.
         _isInsertionAvailable = TryReadQuerySnapshot()?.IsUsableAsTypedPrefix ?? true;
+        PublishSessionStatus();
         ViewModel.ModeLabel = mode.ToString();
 
         // Help and Fix put their subject in the query field: the command Help was asked about, the

--- a/src/NovaTerminal.CommandAssist/Application/CommandAssistModeRouter.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CommandAssistModeRouter.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Linq;
+using NovaTerminal.CommandAssist.Domain;
 using NovaTerminal.CommandAssist.Models;
 
 namespace NovaTerminal.CommandAssist.Application;
@@ -5,6 +8,17 @@ namespace NovaTerminal.CommandAssist.Application;
 public sealed class CommandAssistModeRouter
 {
     private const double FixModeThreshold = 0.8;
+
+    /// <summary>
+    /// The lowest confidence anything in the recogniser table publishes, and a defensive lower bound
+    /// on what may put a bubble on screen unasked.
+    /// </summary>
+    /// <remarks>
+    /// Belt and braces rather than the actual gate - see
+    /// <see cref="ShouldSurfacePassiveFix"/>, where provenance does the work. This exists so that a
+    /// future recogniser publishing below the table's own weakest rung cannot surface by accident.
+    /// </remarks>
+    public const double PassiveFixConfidenceFloor = CommandErrorRecognizers.Explanatory;
 
     public CommandAssistMode ChooseModeForHelpRequest()
     {
@@ -16,5 +30,61 @@ public sealed class CommandAssistModeRouter
         return highestConfidence >= FixModeThreshold
             ? CommandAssistMode.Fix
             : CommandAssistMode.Suggest;
+    }
+
+    /// <summary>
+    /// Whether a failure's insights are worth showing in a bubble the user did not ask for.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>The UX-polish round's noise floor.</strong> The owner's complaint was "fix comes
+    /// sometimes when it is not needed", and the code agreed with him: <c>HandleCommandFailureAsync</c>
+    /// surfaced a bubble for <em>any</em> non-empty result list, so every non-zero exit in the session
+    /// produced one. His screenshot was a failing <c>print -l $precmd_functions</c> - a zsh builtin
+    /// that ran, printed something no recogniser models, and exited non-zero - answered with a
+    /// name-similarity guess, which is the ladder's bottom rung doing exactly what its own
+    /// documentation says it should not be trusted to do.
+    /// </para>
+    /// <para>
+    /// <strong>The gate is provenance, not confidence.</strong> A row may auto-surface if and only if
+    /// a recogniser in the table produced it: something read the output tail and recognised what it
+    /// said. Everything the owner complained about falls out of that one rule, because every one of
+    /// those rows came from <c>HeuristicErrorInsightService</c>'s fallback rather than the table - the
+    /// "output matched nothing" correction at 0.40, and the uninformed no-output guess at 0.55/0.70.
+    /// </para>
+    /// <para>
+    /// <strong>Why not a confidence threshold as well.</strong> The obvious version of this fix was
+    /// "confidence >= <see cref="CommandErrorRecognizers.Plausible"/>", and it was written that way
+    /// first. It is wrong in both directions. Too permissive, because the uninformed fallback is
+    /// priced at <see cref="CommandErrorRecognizers.Likely"/> (0.70) - deliberately, since with no
+    /// output to read a name-similarity guess is the best answer available, but "best available" is
+    /// not "worth interrupting for", and clearing a bar is not the same as having read anything. Too
+    /// strict, because <see cref="CommandErrorRecognizers.Explanatory"/> (0.40) is what the table
+    /// itself uses for a recognised failure that has no single command to run - and
+    /// <c>git status</c> outside a working tree, answered with "This directory is not inside a Git
+    /// repository", is exactly the case this feature exists for. Confidence measures how sure a
+    /// recogniser is of its remedy; it was never a measure of whether anything was understood.
+    /// </para>
+    /// <para>
+    /// Confidence still decides whether the <em>popup</em> opens over the user's next command - see
+    /// <see cref="ChooseModeForFailure"/> - which is the interruption that actually costs something.
+    /// </para>
+    /// <para>
+    /// <strong>What suppression costs, and why it is affordable.</strong> Nothing is discarded - the
+    /// insights are still computed and still available on demand, because Fix is reachable by
+    /// <c>Ctrl+Space</c> after a failure the same as before. The user who wants a guess can ask for
+    /// one; what they no longer get is a guess volunteered over every failing command they run. A
+    /// suggestion surface that is wrong a third of the time trains people to ignore it, and then it is
+    /// worth nothing on the occasion it is right.
+    /// </para>
+    /// </remarks>
+    public bool ShouldSurfacePassiveFix(IReadOnlyList<CommandFixSuggestion> fixes)
+    {
+        if (fixes is null || fixes.Count == 0)
+        {
+            return false;
+        }
+
+        return fixes.Any(item => item.IsRecognized && item.Confidence >= PassiveFixConfidenceFloor);
     }
 }

--- a/src/NovaTerminal.CommandAssist/Domain/AssistRelativeTime.cs
+++ b/src/NovaTerminal.CommandAssist/Domain/AssistRelativeTime.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Globalization;
+
+namespace NovaTerminal.CommandAssist.Domain;
+
+/// <summary>
+/// Renders a history timestamp the way a person reads one: "2m ago", "yesterday".
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why this exists (UX-polish round, owner dogfooding).</strong> The popup's metadata line
+/// used to read <c>Used 2026-08-04 15:23</c>. An absolute wall-clock stamp is the wrong unit for the
+/// question the user is actually asking of a <c>Ctrl+R</c> list - "is this the thing I just ran?" -
+/// and answering it required the reader to subtract two timestamps in their head, one of which they
+/// had to guess. It is also the only part of the row that could have explained the ordering, and it
+/// declined to.
+/// </para>
+/// <para>
+/// The buckets are deliberately coarse. This is a caption on a row that is already sorted by the
+/// same quantity, so precision past "which of these is newer" is noise; what it has to do is make
+/// the sort legible at a glance. Past a week it falls back to a date, because "23d ago" stops being
+/// something anyone can place and a date is what you would look for.
+/// </para>
+/// <para>
+/// <paramref name="now"/> is a parameter rather than a read of the clock so the buckets are
+/// testable without waiting for time to pass.
+/// </para>
+/// </remarks>
+public static class AssistRelativeTime
+{
+    /// <summary>
+    /// How recent an entry has to be to earn the "Recent" badge.
+    /// </summary>
+    /// <remarks>
+    /// Sized to "this sitting, more or less". The badge's job is to confirm the top of the list is
+    /// the top for a reason the user can check against their own memory, so it has to cover the
+    /// commands they remember running without also covering this morning's.
+    /// </remarks>
+    public static readonly TimeSpan RecentWindow = TimeSpan.FromMinutes(15);
+
+    /// <summary>Whether <paramref name="value"/> is inside <see cref="RecentWindow"/> of <paramref name="now"/>.</summary>
+    public static bool IsRecent(DateTimeOffset value, DateTimeOffset now)
+    {
+        TimeSpan age = now - value;
+        return age < RecentWindow;
+    }
+
+    /// <summary>
+    /// Formats <paramref name="value"/> relative to <paramref name="now"/>.
+    /// </summary>
+    /// <remarks>
+    /// A future timestamp - a clock skew between this box and an SSH host, which is common enough to
+    /// be worth handling - reads as "just now" rather than as a negative age. The entry is real and
+    /// the skew is not the user's problem.
+    /// </remarks>
+    public static string Format(DateTimeOffset value, DateTimeOffset now)
+    {
+        TimeSpan age = now - value;
+        if (age < TimeSpan.Zero)
+        {
+            return "just now";
+        }
+
+        if (age < TimeSpan.FromMinutes(1))
+        {
+            return "just now";
+        }
+
+        if (age < TimeSpan.FromHours(1))
+        {
+            return $"{(int)age.TotalMinutes}m ago";
+        }
+
+        if (age < TimeSpan.FromHours(24))
+        {
+            return $"{(int)age.TotalHours}h ago";
+        }
+
+        if (age < TimeSpan.FromHours(48))
+        {
+            return "yesterday";
+        }
+
+        if (age < TimeSpan.FromDays(7))
+        {
+            return $"{(int)age.TotalDays}d ago";
+        }
+
+        return value.ToLocalTime().ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+    }
+}

--- a/src/NovaTerminal.CommandAssist/Domain/CommandAssistSuggestionEngine.cs
+++ b/src/NovaTerminal.CommandAssist/Domain/CommandAssistSuggestionEngine.cs
@@ -76,11 +76,60 @@ public sealed class CommandAssistSuggestionEngine : ISuggestionEngine
     /// </remarks>
     internal const double TextQueryContextMatchBoost = 30;
 
-    private readonly IPathSuggestionProvider _pathSuggestionProvider;
+    /// <summary>
+    /// How much newer a same-directory entry is treated as being on the empty-query path.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>The UX-polish round's central decision, and the reason it is a time rather than a
+    /// score.</strong> The owner's report was two complaints with one cause: "no history even after
+    /// integration" and "sorting I don't understand". Neither was a capture bug - the entries were
+    /// all there. The empty-query score was
+    /// <c>1 + min(frequency,5) + pinned + context + profile</c>, and recency was a
+    /// <c>ThenByDescending</c> that only fires on an exact score tie. So inside the same-host band the
+    /// only live term was frequency, capped at 5: <c>vim .env</c> run five times last week scored 1006
+    /// and beat the command he had run ten seconds earlier in the directory he was standing in, which
+    /// scored 1002. The list was a frequency chart wearing a history list's clothes, and it was
+    /// telling the truth about its own ordering - which is why no amount of staring at it explained
+    /// anything.
+    /// </para>
+    /// <para>
+    /// <strong>Recency-first, because that is what Ctrl+R means.</strong> Every shell's reverse
+    /// search walks backwards through time, and a user who presses it is asking "what did I just
+    /// do". Frequency answers a different question well enough that it earned its place in the
+    /// text-query ranking, where the user has already narrowed the field by typing; with an empty
+    /// query it is the only thing keeping last week at the top. So it moves to a tiebreak - applied
+    /// after recency rather than before it, which is why <see cref="AssistSuggestion.Frequency"/> is
+    /// a field on the row instead of a term in the score.
+    /// </para>
+    /// <para>
+    /// <strong>Why the directory boost is a time offset.</strong> The brief asks for a same-directory
+    /// boost "that can lift very-recent same-cwd entries" without frequency becoming a driver again.
+    /// Expressed as a score band, cwd would simply replace frequency as the thing that outranks
+    /// recency, and the identical complaint would come back in a new costume: a same-directory
+    /// command from last Tuesday would sit above one from thirty seconds ago in the directory next
+    /// door. Expressed as a <em>recency bonus</em> the two signals stay commensurable - a
+    /// same-directory entry is ranked as if it were half an hour newer than it is, so it wins against
+    /// anything staler than that and loses to anything fresher. Half an hour is roughly "the current
+    /// sitting": long enough that stepping into a directory brings its recent work with you, short
+    /// enough that a command you ran moments ago is never buried by one you ran this morning.
+    /// </para>
+    /// <para>
+    /// The context band from PR #290 is untouched and still applied first. This reorders
+    /// <em>within</em> it.
+    /// </para>
+    /// </remarks>
+    internal static readonly TimeSpan EmptyQuerySameDirectoryRecencyBonus = TimeSpan.FromMinutes(30);
 
-    public CommandAssistSuggestionEngine(IPathSuggestionProvider? pathSuggestionProvider = null)
+    private readonly IPathSuggestionProvider _pathSuggestionProvider;
+    private readonly Func<DateTimeOffset> _clock;
+
+    public CommandAssistSuggestionEngine(
+        IPathSuggestionProvider? pathSuggestionProvider = null,
+        Func<DateTimeOffset>? clock = null)
     {
         _pathSuggestionProvider = pathSuggestionProvider ?? new FileSystemPathSuggestionProvider();
+        _clock = clock ?? (() => DateTimeOffset.UtcNow);
     }
 
     public IReadOnlyList<AssistSuggestion> GetSuggestions(
@@ -103,6 +152,7 @@ public sealed class CommandAssistSuggestionEngine : ISuggestionEngine
         }
 
         string query = context.Input?.Trim() ?? string.Empty;
+        DateTimeOffset now = _clock();
         List<AssistSuggestion> results = new();
         if (context.IncludePathSuggestions)
         {
@@ -111,7 +161,7 @@ public sealed class CommandAssistSuggestionEngine : ISuggestionEngine
 
         if (context.IncludeHistorySuggestions)
         {
-            results.AddRange(BuildHistorySuggestions(historyEntries, context, query));
+            results.AddRange(BuildHistorySuggestions(historyEntries, context, query, now));
         }
 
         if (context.IncludeSnippetSuggestions)
@@ -120,12 +170,51 @@ public sealed class CommandAssistSuggestionEngine : ISuggestionEngine
         }
         bool hasPathSuggestions = results.Any(x => x.Type == AssistSuggestionType.Path);
 
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            // The empty-query (Ctrl+R) order. The score now carries only the bands - context,
+            // profile, pin, snippet - and everything inside a band is decided by time, with the
+            // same-directory bonus folded into the timestamp. Frequency is the last word before the
+            // alphabetical stabiliser, which is the whole of the UX-polish reordering: see
+            // EmptyQuerySameDirectoryRecencyBonus.
+            return results
+                .OrderByDescending(x => ComputeEffectiveScore(x, hasPathSuggestions))
+                .ThenByDescending(x => ComputeEffectiveRecency(x, context))
+                .ThenByDescending(x => x.Frequency)
+                .ThenBy(x => x.DisplayText, StringComparer.OrdinalIgnoreCase)
+                .Take(maxResults)
+                .ToList();
+        }
+
+        // The text-query order is deliberately unchanged. With a query on the line the user has said
+        // what they are looking for, the text-match tiers dominate, and frequency is a legitimate
+        // signal for choosing between two rows that match equally well.
         return results
             .OrderByDescending(x => ComputeEffectiveScore(x, hasPathSuggestions))
             .ThenByDescending(x => x.LastUsedAt ?? DateTimeOffset.MinValue)
             .ThenBy(x => x.DisplayText, StringComparer.OrdinalIgnoreCase)
             .Take(maxResults)
             .ToList();
+    }
+
+    /// <summary>
+    /// The timestamp a row is ranked by on the empty-query path: when it actually ran, plus
+    /// <see cref="EmptyQuerySameDirectoryRecencyBonus"/> if it ran where the pane is standing now.
+    /// </summary>
+    private static DateTimeOffset ComputeEffectiveRecency(AssistSuggestion suggestion, CommandAssistQueryContext context)
+    {
+        DateTimeOffset lastUsed = suggestion.LastUsedAt ?? DateTimeOffset.MinValue;
+
+        // Guard the sentinel: adding to DateTimeOffset.MinValue is legal but would rank a row with no
+        // timestamp above a genuinely old one, which is backwards.
+        if (lastUsed == DateTimeOffset.MinValue)
+        {
+            return lastUsed;
+        }
+
+        return Matches(context.WorkingDirectory, suggestion.WorkingDirectory)
+            ? lastUsed + EmptyQuerySameDirectoryRecencyBonus
+            : lastUsed;
     }
 
     private static double ComputeEffectiveScore(AssistSuggestion suggestion, bool hasPathSuggestions)
@@ -141,9 +230,19 @@ public sealed class CommandAssistSuggestionEngine : ISuggestionEngine
     private static IEnumerable<AssistSuggestion> BuildHistorySuggestions(
         IReadOnlyList<CommandHistoryEntry> historyEntries,
         CommandAssistQueryContext context,
-        string query)
+        string query,
+        DateTimeOffset now)
     {
         return historyEntries
+            // The typo exclusion (UX-polish round). An entry whose failure was classified as
+            // command-not-found is a keystroke record, not a command: the owner's `gti status` was
+            // captured, then offered straight back to him on the next `gt`. Filtered here rather
+            // than at capture so the provenance survives - and filtered before the grouping so a
+            // later, real `gti` (someone installs it) is a different entry and ranks normally.
+            //
+            // Every path, including an explicit text search. They are typos; there is no query for
+            // which the honest answer is one.
+            .Where(x => !x.IsInvalidCommand)
             .GroupBy(x => x.CommandText, StringComparer.OrdinalIgnoreCase)
             .Select(group =>
             {
@@ -175,11 +274,12 @@ public sealed class CommandAssistSuggestionEngine : ISuggestionEngine
                 DisplayText: x.Latest.CommandText,
                 InsertText: x.Latest.CommandText,
                 Description: null,
-                Badges: BuildHistoryBadges(x.Latest, context, x.Frequency),
+                Badges: BuildHistoryBadges(x.Latest, context, x.Frequency, now),
                 Score: x.Score,
                 WorkingDirectory: x.Latest.WorkingDirectory,
                 LastUsedAt: x.Latest.ExecutedAt,
-                ExitCode: x.Latest.ExitCode));
+                ExitCode: x.Latest.ExitCode,
+                Frequency: x.Frequency));
     }
 
     private static IEnumerable<AssistSuggestion> BuildSnippetSuggestions(
@@ -263,11 +363,12 @@ public sealed class CommandAssistSuggestionEngine : ISuggestionEngine
 
         if (string.IsNullOrWhiteSpace(query))
         {
-            // The empty-query (Ctrl+R) path. Recency is the tiebreak rather than a term here - see the
-            // ThenByDescending in GetSuggestions - so the context boosts are the only thing large
-            // enough to reorder the list, which is exactly what V2 Phase 3a wants them to do.
+            // The empty-query (Ctrl+R) path. The score is now purely the band - context, profile,
+            // pin - and carries no frequency term at all. Ordering inside a band is time, then
+            // frequency, and both live in the OrderBy chain in GetSuggestions so that recency is
+            // applied first. The frequency term that used to be here is what made the owner's list
+            // unreadable; see EmptyQuerySameDirectoryRecencyBonus for the full account.
             return 1 +
-                   Math.Min(frequency, 5) +
                    (isPinned ? 20 : 0) +
                    (isContextMatch ? EmptyQueryContextMatchBoost : 0) +
                    (isProfileMatch ? EmptyQueryProfileMatchBoost : 0);
@@ -331,17 +432,40 @@ public sealed class CommandAssistSuggestionEngine : ISuggestionEngine
         return entry.IsRemote && Matches(context.HostId, entry.HostId);
     }
 
-    private static IReadOnlyList<string> BuildHistoryBadges(CommandHistoryEntry entry, CommandAssistQueryContext context, int frequency)
+    /// <summary>
+    /// The badges on a history row, in the order the ranking actually consulted the signals.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Badges are an explanation of the placement, so they have to be in the order the sort
+    /// applied them.</strong> The owner's screenshot had rows from a directory he had left, from a
+    /// week earlier, wearing "Frequent" - the badge was accurate and the ordering it described was
+    /// the thing he was complaining about. Now that the sort is recency, then directory, then
+    /// frequency, the badges read in that order too: "Recent" first because it is usually why the row
+    /// is where it is, "Same dir" next because it is the only other thing that can lift a row, and
+    /// "Frequent" demoted to the secondary signal it now is.
+    /// </para>
+    /// </remarks>
+    private static IReadOnlyList<string> BuildHistoryBadges(
+        CommandHistoryEntry entry,
+        CommandAssistQueryContext context,
+        int frequency,
+        DateTimeOffset now)
     {
         List<string> badges = new();
-        if (frequency > 1)
+        if (AssistRelativeTime.IsRecent(entry.ExecutedAt, now))
         {
-            badges.Add("Frequent");
+            badges.Add("Recent");
         }
 
         if (Matches(context.WorkingDirectory, entry.WorkingDirectory))
         {
-            badges.Add("Same cwd");
+            badges.Add("Same dir");
+        }
+
+        if (frequency > 1)
+        {
+            badges.Add("Frequent");
         }
 
         if (entry.ExitCode == 0)
@@ -362,7 +486,7 @@ public sealed class CommandAssistSuggestionEngine : ISuggestionEngine
 
         if (Matches(context.WorkingDirectory, snippet.WorkingDirectory))
         {
-            badges.Add("Same cwd");
+            badges.Add("Same dir");
         }
 
         return badges;

--- a/src/NovaTerminal.CommandAssist/Domain/HeuristicErrorInsightService.cs
+++ b/src/NovaTerminal.CommandAssist/Domain/HeuristicErrorInsightService.cs
@@ -93,7 +93,15 @@ public sealed class HeuristicErrorInsightService : IErrorInsightService
             IReadOnlyList<CommandFixSuggestion> matched = recognizer.Analyze(signal);
             if (matched.Count > 0)
             {
-                suggestions.AddRange(matched);
+                // Stamped here rather than inside each recogniser: the id is a fact about which table
+                // entry spoke, the recognisers are pure functions of the signal that do not know their
+                // own name, and a new entry cannot forget a step it does not perform. Downstream this
+                // is what separates a read of the output from a guess about the name - see
+                // CommandFixSuggestion.RecognizerId.
+                foreach (CommandFixSuggestion suggestion in matched)
+                {
+                    suggestions.Add(suggestion with { RecognizerId = recognizer.Id });
+                }
             }
         }
 

--- a/src/NovaTerminal.CommandAssist/Domain/IHistoryStore.cs
+++ b/src/NovaTerminal.CommandAssist/Domain/IHistoryStore.cs
@@ -20,6 +20,31 @@ public interface IHistoryStore
     Task<IReadOnlyList<CommandHistoryEntry>> SearchAsync(string query, int maxCandidates, CancellationToken cancellationToken = default);
 
     Task<IReadOnlyList<CommandHistoryEntry>> GetRecentAsync(int maxResults, CancellationToken cancellationToken = default);
-    Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Patches an entry with how the command turned out.
+    /// </summary>
+    /// <param name="isInvalidCommand">
+    /// Whether the exit code proved the shell could not resolve the name (127). Only ever <em>sets</em>
+    /// the flag: a later patch that does not know about the classification must not clear one an
+    /// earlier one established, which is what makes the two signals in
+    /// <c>CommandHistoryEntry.IsInvalidCommand</c> safe to apply in either order.
+    /// </param>
+    Task<bool> TryUpdateExecutionResultAsync(
+        string entryId,
+        int? exitCode,
+        long? durationMs,
+        CancellationToken cancellationToken = default,
+        bool isInvalidCommand = false);
+
+    /// <summary>
+    /// Marks an entry as a command the shell could not resolve, so it is never suggested again.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="TryUpdateExecutionResultAsync"/> because it arrives separately: the
+    /// classification that identifies a PowerShell typo comes from the Fix recogniser, after the exit
+    /// code has already been written. See <c>CapturePipeline.MarkLastCommandInvalidAsync</c>.
+    /// </remarks>
+    Task<bool> TryMarkInvalidCommandAsync(string entryId, CancellationToken cancellationToken = default);
+
     Task ClearAsync(CancellationToken cancellationToken = default);
 }

--- a/src/NovaTerminal.CommandAssist/Models/AssistSuggestion.cs
+++ b/src/NovaTerminal.CommandAssist/Models/AssistSuggestion.cs
@@ -8,6 +8,14 @@ namespace NovaTerminal.CommandAssist.Models;
 /// (see <c>docs/plans/2026-08-01-command-assist-v2-design.md</c>, "Keyboard and gating decisions"),
 /// so the property this record used to carry was set by one producer and read by nobody.
 /// </remarks>
+/// <param name="Frequency">
+/// How many history entries collapsed into this row. Carried on the suggestion rather than folded
+/// into <paramref name="Score"/> because of what the UX-polish round changed about the empty-query
+/// list: frequency is now a <em>tiebreak applied after recency</em>, and a term inside the score is
+/// necessarily applied before it. See
+/// <c>CommandAssistSuggestionEngine.EmptyQuerySameDirectoryRecencyBonus</c>.
+/// Declared last, with a default, so no existing call site had to move.
+/// </param>
 public sealed record AssistSuggestion(
     string Id,
     AssistSuggestionType Type,
@@ -18,4 +26,5 @@ public sealed record AssistSuggestion(
     double Score,
     string? WorkingDirectory,
     DateTimeOffset? LastUsedAt,
-    int? ExitCode);
+    int? ExitCode,
+    int Frequency = 1);

--- a/src/NovaTerminal.CommandAssist/Models/CommandFixSuggestion.cs
+++ b/src/NovaTerminal.CommandAssist/Models/CommandFixSuggestion.cs
@@ -2,9 +2,40 @@ using System.Collections.Generic;
 
 namespace NovaTerminal.CommandAssist.Models;
 
+/// <param name="RecognizerId">
+/// Which entry of <c>CommandErrorRecognizers.All</c> produced this, or <see langword="null"/> when it
+/// came from the service's uninformed-guess fallback instead of from the table.
+/// <para>
+/// <strong>Two consumers, both added in the UX-polish round.</strong> The noise floor in
+/// <c>CommandAssistModeRouter.ShouldSurfacePassiveFix</c> needs to tell "a recogniser read the output
+/// and understood it" from "nothing matched, so here is a name-similarity guess" - a distinction
+/// confidence alone cannot express, because the no-output fallback is priced at 0.7 and would clear
+/// any threshold low enough to admit a real explanation. And the typo suppression needs to know
+/// specifically that the failure was <c>command-not-found</c>, which is the one classification that
+/// says the history entry is a misspelling rather than a command.
+/// </para>
+/// <para>
+/// Stamped centrally in <c>HeuristicErrorInsightService</c> rather than by each recogniser, so a new
+/// table entry cannot forget to set it.
+/// </para>
+/// </param>
 public sealed record CommandFixSuggestion(
     string Title,
     string SuggestedCommand,
     string? Description,
     double Confidence,
-    IReadOnlyList<string>? Badges = null);
+    IReadOnlyList<string>? Badges = null,
+    string? RecognizerId = null)
+{
+    /// <summary>
+    /// Whether a recogniser in the table stood behind this, as opposed to the fallback guess.
+    /// </summary>
+    public bool IsRecognized => !string.IsNullOrEmpty(RecognizerId);
+
+    /// <summary>The recogniser id for an unresolved program name; see <see cref="RecognizerId"/>.</summary>
+    public const string CommandNotFoundRecognizerId = "command-not-found";
+
+    /// <summary>Whether this fix says the shell could not resolve the command's name.</summary>
+    public bool IsCommandNotFound =>
+        string.Equals(RecognizerId, CommandNotFoundRecognizerId, System.StringComparison.Ordinal);
+}

--- a/src/NovaTerminal.CommandAssist/Models/CommandHistoryEntry.cs
+++ b/src/NovaTerminal.CommandAssist/Models/CommandHistoryEntry.cs
@@ -2,6 +2,27 @@ using System;
 
 namespace NovaTerminal.CommandAssist.Models;
 
+/// <param name="IsInvalidCommand">
+/// Whether this command failed because the shell could not resolve its name - a typo, in practice.
+/// Such an entry is never offered as a suggestion by
+/// <c>CommandAssistSuggestionEngine</c>, on any path.
+/// <para>
+/// <strong>Why the entry is kept at all.</strong> The owner ran <c>gti status</c>, and the next time
+/// he typed <c>gt</c> the terminal helpfully offered <c>gti status</c> back. Capture is not the bug -
+/// the entry is a true record of what was run, and deleting it would make history disagree with the
+/// scrollback - so the flag suppresses the <em>offer</em> and leaves the record.
+/// </para>
+/// <para>
+/// Two signals set it, and both are needed. Exit code 127 is the POSIX convention and covers
+/// bash, zsh and fish; PowerShell reports 1 for an unresolved name and is indistinguishable from any
+/// other failure by exit code alone, so the Fix-time recogniser's classification of the output tail
+/// is threaded back through <c>CapturePipeline.MarkLastCommandInvalidAsync</c> to cover it.
+/// </para>
+/// <para>
+/// Declared last with a default so the JSONL format is unchanged for existing lines: a record
+/// written before this round simply has no such property and deserialises to <see langword="false"/>.
+/// </para>
+/// </param>
 public sealed record CommandHistoryEntry(
     string Id,
     string CommandText,
@@ -15,4 +36,5 @@ public sealed record CommandHistoryEntry(
     bool IsRemote,
     bool IsRedacted,
     CommandCaptureSource Source,
-    long? DurationMs);
+    long? DurationMs,
+    bool IsInvalidCommand = false);

--- a/src/NovaTerminal.CommandAssist/Storage/JsonlHistoryStore.cs
+++ b/src/NovaTerminal.CommandAssist/Storage/JsonlHistoryStore.cs
@@ -262,7 +262,40 @@ public sealed class JsonlHistoryStore : IHistoryStore
         }
     }
 
-    public async Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default)
+    public async Task<bool> TryUpdateExecutionResultAsync(
+        string entryId,
+        int? exitCode,
+        long? durationMs,
+        CancellationToken cancellationToken = default,
+        bool isInvalidCommand = false)
+    {
+        return await TryPatchAsync(
+            entryId,
+            existing => existing with
+            {
+                ExitCode = exitCode,
+                DurationMs = durationMs ?? existing.DurationMs,
+
+                // Latching, never clearing. See the parameter docs on IHistoryStore: the exit-code
+                // signal and the recogniser signal arrive independently and in either order, so a
+                // patch that has nothing to say about the classification must leave it alone.
+                IsInvalidCommand = existing.IsInvalidCommand || isInvalidCommand
+            },
+            cancellationToken);
+    }
+
+    public async Task<bool> TryMarkInvalidCommandAsync(string entryId, CancellationToken cancellationToken = default)
+    {
+        return await TryPatchAsync(
+            entryId,
+            existing => existing with { IsInvalidCommand = true },
+            cancellationToken);
+    }
+
+    private async Task<bool> TryPatchAsync(
+        string entryId,
+        Func<CommandHistoryEntry, CommandHistoryEntry> patch,
+        CancellationToken cancellationToken)
     {
         await _gate.WaitAsync(cancellationToken);
         try
@@ -273,11 +306,7 @@ public sealed class JsonlHistoryStore : IHistoryStore
                 return false;
             }
 
-            CommandHistoryEntry updated = existing with
-            {
-                ExitCode = exitCode,
-                DurationMs = durationMs ?? existing.DurationMs
-            };
+            CommandHistoryEntry updated = patch(existing);
 
             // Disk first, then the index, for the same reason as AppendAsync.
             await AppendLineUnsafeAsync(updated, cancellationToken);

--- a/src/NovaTerminal.CommandAssist/ViewModels/AssistHintDetail.cs
+++ b/src/NovaTerminal.CommandAssist/ViewModels/AssistHintDetail.cs
@@ -1,0 +1,30 @@
+namespace NovaTerminal.CommandAssist.ViewModels;
+
+/// <summary>
+/// How much of the shortcut hint strip the bubble has room to render.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The three rungs of the UX-polish round's progressive collapse. The rule they encode is that the
+/// hint strip is the lowest-priority thing in the bubble and must give up its width before the
+/// suggestion gives up a single character: the owner's bubble read <c>Suggest | dock | doc...</c>
+/// because the hint sat in an <c>Auto</c> column beside the suggestion's <c>*</c> and simply took
+/// what it wanted.
+/// </para>
+/// <para>
+/// Two rungs were not enough. The single boolean this replaces went straight from a ~200 px strip to
+/// nothing at the 320 px compact threshold, and the widths in between - which is where a normally
+/// split pane lives - got the full strip and an unreadable suggestion.
+/// </para>
+/// </remarks>
+public enum AssistHintDetail
+{
+    /// <summary>Keys and verbs: "Down browse | Ctrl+Enter insert | Esc close".</summary>
+    Full,
+
+    /// <summary>Keys only: "Down | Ctrl+Enter | Esc". Reminds rather than teaches.</summary>
+    Terse,
+
+    /// <summary>Nothing. The popup footer is the only place the shortcuts appear at this width.</summary>
+    Hidden
+}

--- a/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistBarViewModel.cs
+++ b/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistBarViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using System.Collections.ObjectModel;
 using System.Runtime.CompilerServices;
+using NovaTerminal.CommandAssist.Models;
 
 namespace NovaTerminal.CommandAssist.ViewModels;
 
@@ -32,6 +33,18 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
     /// </remarks>
     internal const string PassiveHintText = "Down browse  |  Ctrl+Enter insert  |  Esc close";
 
+    /// <summary>The chip text for a session whose shell is emitting OSC 133 marks.</summary>
+    internal const string IntegratedStatusText = "integrated";
+
+    /// <summary>The chip text for a session with no marks: capture is heuristic and Fix has no output tail.</summary>
+    internal const string BasicStatusText = "basic";
+
+    internal const string IntegratedStatusTooltip =
+        "Shell integration is live: commands, exit codes and working directories come from the shell itself.";
+
+    internal const string BasicStatusTooltip =
+        "No shell integration on this session. Command Assist still works, but history is captured heuristically and failing commands have no output to diagnose.";
+
     private AssistShortcutHintLabels _shortcutHintLabels = AssistShortcutHintLabels.Default;
     private bool _isVisible;
     private string _modeLabel = "Suggest";
@@ -46,6 +59,9 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
     private bool _showEmptyState;
     private bool _isPopupOpen;
     private string _attributionText = string.Empty;
+    private AssistHintDetail _bubbleHintDetail = AssistHintDetail.Full;
+    private bool _isShellIntegrationLive;
+    private bool _allowBubbleQueryText = true;
 
     public CommandAssistBarViewModel()
     {
@@ -347,6 +363,87 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
         }
     }
 
+    /// <summary>
+    /// How much of the shortcut hint the bubble has room for. Set by the host from the pane width.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Progressive collapse, because the hint must lose before the content does.</strong>
+    /// Previously this was a single boolean: the hint took its full width until the compact threshold
+    /// and then vanished. Between those two states lies the width the owner was actually running at,
+    /// where an <c>Auto</c> hint column quietly ate the suggestion down to six characters. The middle
+    /// rung drops the words and keeps the keys - the strip's job at that width is to remind, not to
+    /// teach, and the popup footer still teaches.
+    /// </para>
+    /// <para>
+    /// Only the bubble's strip collapses. The popup has room and keeps the full text.
+    /// </para>
+    /// </remarks>
+    /// <summary>
+    /// Whether the bubble has room to show the query alongside the suggestion. Host-set from the
+    /// compact-layout decision; the bubble may still suppress it for a reason of its own (Fix mode).
+    /// </summary>
+    /// <remarks>
+    /// The width budget and the editorial judgement are two different questions, and this is the
+    /// first. The host knows how wide the bubble is; only <see cref="ApplyBubbleContent"/> knows
+    /// whether the query is worth the space at that width.
+    /// </remarks>
+    public bool AllowBubbleQueryText
+    {
+        get => _allowBubbleQueryText;
+        set
+        {
+            if (_allowBubbleQueryText == value)
+            {
+                return;
+            }
+
+            _allowBubbleQueryText = value;
+            OnPropertyChanged();
+            SyncPresentationState();
+        }
+    }
+
+    public AssistHintDetail BubbleHintDetail
+    {
+        get => _bubbleHintDetail;
+        set
+        {
+            if (_bubbleHintDetail == value)
+            {
+                return;
+            }
+
+            _bubbleHintDetail = value;
+            OnPropertyChanged();
+            SyncPresentationState();
+        }
+    }
+
+    /// <summary>
+    /// Whether this session's shell is emitting OSC 133 marks. Drives the integration chip.
+    /// </summary>
+    /// <remarks>
+    /// Mirrors <c>AssistSessionContext.IsShellIntegrationLive</c>, republished by
+    /// <c>CommandAssistController</c> whenever it refreshes the surface. See
+    /// <see cref="CommandAssistBubbleViewModel.IntegrationStatusText"/>.
+    /// </remarks>
+    public bool IsShellIntegrationLive
+    {
+        get => _isShellIntegrationLive;
+        set
+        {
+            if (_isShellIntegrationLive == value)
+            {
+                return;
+            }
+
+            _isShellIntegrationLive = value;
+            OnPropertyChanged();
+            SyncPresentationState();
+        }
+    }
+
     public event PropertyChangedEventHandler? PropertyChanged;
 
     /// <summary>
@@ -364,15 +461,28 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
 
         bool isSelectionUpOwned = SelectionUpOwnedProbe?.Invoke() ?? true;
         bool isInsertionAvailable = InsertionAvailableProbe?.Invoke() ?? true;
-        string hintText = BuildHintText(acceptOnEnterArmed, isSelectionUpOwned, isInsertionAvailable);
+        string hintText = BuildHintText(acceptOnEnterArmed, isSelectionUpOwned, isInsertionAvailable, terse: false);
+        string bubbleHintText = BubbleHintDetail == AssistHintDetail.Terse
+            ? BuildHintText(acceptOnEnterArmed, isSelectionUpOwned, isInsertionAvailable, terse: true)
+            : hintText;
 
-        Bubble.IsVisible = IsVisible;
+        // Exactly one surface at a time (UX-polish round, issue 6). The bubble used to follow
+        // IsVisible alone while the popup followed IsVisible && IsPopupOpen, so opening the popup put
+        // both on screen: the owner's screenshot has a "History | vim .env | Enter insert" bubble
+        // rendered below an open History popup whose first row is the same `vim .env`. Two surfaces
+        // saying the same thing is not twice the information.
+        //
+        // The popup wins, rather than the bubble becoming a caption attached to it. The popup already
+        // renders the mode, the query, every row including the one the bubble was summarising, and a
+        // footer hint with room for the full text - so a caption would have nothing left to say that
+        // is not directly above it. Hiding one surface is also the change that cannot introduce a new
+        // layout to get wrong at a narrow width, which is what the rest of this round is about.
+        Bubble.IsVisible = IsVisible && !IsPopupOpen;
         Bubble.ModeLabel = ModeLabel;
-        Bubble.QueryText = QueryText;
-        Bubble.ShortcutHintText = hintText;
-        Bubble.SummaryText = !string.IsNullOrWhiteSpace(TopSuggestionText)
-            ? TopSuggestionText
-            : EmptyStateText;
+        Bubble.ShortcutHintText = bubbleHintText;
+        Bubble.ShowShortcutHint = BubbleHintDetail != AssistHintDetail.Hidden;
+        ApplyBubbleContent();
+        ApplyIntegrationStatus();
 
         Popup.ShortcutHintText = hintText;
         Popup.SelectedIndex = SelectedIndex;
@@ -387,6 +497,63 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
         Popup.HasSuggestions = HasSuggestions;
         Popup.ShowEmptyState = ShowEmptyState;
         Popup.AttributionText = AttributionText;
+    }
+
+    /// <summary>
+    /// Decides what the bubble's two content columns say, and whether they are one string or two.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Fix mode does not echo the failed command (UX-polish round, issue 4a).</strong> The
+    /// owner's screenshot read <c>Fix | print -l $precmd_functions | Di...</c>: the headline was the
+    /// command he had just watched fail, and the one new thing on the row - what to do about it - was
+    /// truncated to two characters. Help and Fix both used to put their subject in the query field,
+    /// which is right for Help (the thing you asked about is the caption) and wrong for Fix (the thing
+    /// that failed is already on screen directly above, in the scrollback, in full). So Fix gives its
+    /// width to the suggestion. The popup still shows the failed command, where there is room for
+    /// both.
+    /// </para>
+    /// <para>
+    /// Everything else is the fish-style continuation described on
+    /// <see cref="CommandAssistBubbleViewModel.IsSummaryContinuation"/>.
+    /// </para>
+    /// </remarks>
+    private void ApplyBubbleContent()
+    {
+        string summary = !string.IsNullOrWhiteSpace(TopSuggestionText)
+            ? TopSuggestionText
+            : EmptyStateText;
+        string query = QueryText ?? string.Empty;
+
+        bool isFixMode = string.Equals(ModeLabel, nameof(CommandAssistMode.Fix), StringComparison.OrdinalIgnoreCase);
+        bool showQuery = AllowBubbleQueryText && !isFixMode && query.Length > 0;
+
+        // The tail is only legible while the head is on screen, so the continuation is conditioned on
+        // the query actually being rendered rather than merely being non-empty.
+        bool isContinuation = showQuery &&
+                              summary.Length > query.Length &&
+                              summary.StartsWith(query, StringComparison.Ordinal);
+
+        Bubble.QueryText = query;
+        Bubble.ShowQueryText = showQuery;
+        Bubble.IsSummaryContinuation = isContinuation;
+        Bubble.SummaryText = isContinuation ? summary[query.Length..] : summary;
+    }
+
+    private void ApplyIntegrationStatus()
+    {
+        string text = IsShellIntegrationLive ? IntegratedStatusText : BasicStatusText;
+        string tooltip = IsShellIntegrationLive ? IntegratedStatusTooltip : BasicStatusTooltip;
+
+        Bubble.IntegrationStatusText = text;
+        Bubble.IntegrationStatusTooltip = tooltip;
+
+        // Chrome, so it goes at the same width the hint strip goes: the chip answers a question the
+        // user asks once a session, and the suggestion answers one they are asking right now.
+        Bubble.ShowIntegrationStatus = BubbleHintDetail == AssistHintDetail.Full;
+
+        Popup.IntegrationStatusText = text;
+        Popup.IntegrationStatusTooltip = tooltip;
     }
 
     /// <summary>
@@ -410,22 +577,33 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
     /// shapes on a browse.
     /// </para>
     /// </remarks>
-    private string BuildHintText(bool acceptOnEnterArmed, bool isSelectionUpOwned, bool isInsertionAvailable)
+    private string BuildHintText(bool acceptOnEnterArmed, bool isSelectionUpOwned, bool isInsertionAvailable, bool terse)
     {
         AssistShortcutHintLabels labels = _shortcutHintLabels;
 
         if (acceptOnEnterArmed)
         {
-            return $"{labels.Accept} insert  |  {labels.SelectionUp}/{labels.SelectionDown} browse  |  {labels.Dismiss} close";
+            return terse
+                ? $"{labels.Accept}  |  {labels.SelectionUp}/{labels.SelectionDown}  |  {labels.Dismiss}"
+                : $"{labels.Accept} insert  |  {labels.SelectionUp}/{labels.SelectionDown} browse  |  {labels.Dismiss} close";
         }
 
         string browse = isSelectionUpOwned
-            ? $"{labels.SelectionUp}/{labels.SelectionDown} browse"
-            : $"{labels.SelectionDown} browse";
+            ? $"{labels.SelectionUp}/{labels.SelectionDown}"
+            : $"{labels.SelectionDown}";
+
+        if (terse)
+        {
+            // Keys only. Every clause keeps its meaning - the keys are the information and the verbs
+            // were the padding - at roughly half the width.
+            return isInsertionAvailable
+                ? $"{browse}  |  {labels.Insert}  |  {labels.Dismiss}"
+                : $"{browse}  |  {labels.Dismiss}";
+        }
 
         return isInsertionAvailable
-            ? $"{browse}  |  {labels.Insert} insert  |  {labels.Dismiss} close"
-            : $"{browse}  |  {labels.Dismiss} close";
+            ? $"{browse} browse  |  {labels.Insert} insert  |  {labels.Dismiss} close"
+            : $"{browse} browse  |  {labels.Dismiss} close";
     }
 
     private void OnPropertyChanged([CallerMemberName] string? propertyName = null)

--- a/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistBubbleViewModel.cs
+++ b/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistBubbleViewModel.cs
@@ -18,6 +18,10 @@ public sealed class CommandAssistBubbleViewModel : INotifyPropertyChanged
     private string _shortcutHintText = CommandAssistBarViewModel.IdleHintText;
     private bool _showQueryText = true;
     private bool _showShortcutHint = true;
+    private bool _isSummaryContinuation;
+    private string _integrationStatusText = string.Empty;
+    private string _integrationStatusTooltip = string.Empty;
+    private bool _showIntegrationStatus;
 
     public bool IsVisible
     {
@@ -71,6 +75,74 @@ public sealed class CommandAssistBubbleViewModel : INotifyPropertyChanged
     {
         get => _showShortcutHint;
         set => SetField(ref _showShortcutHint, value);
+    }
+
+    /// <summary>
+    /// Whether <see cref="SummaryText"/> is the tail of a suggestion whose head is already on screen
+    /// as <see cref="QueryText"/>, and should therefore be drawn butted up against it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>The fish-style completion, and it is the single biggest win in the readability fix.</strong>
+    /// The owner's bubble read <c>Suggest | dock | doc...</c>: the summary column was repeating the
+    /// three characters he had already typed and then running out of room for the part he had not.
+    /// When the top suggestion extends the query, the query <em>is</em> the head of the answer, so the
+    /// summary only has to carry the tail - which roughly doubles the useful width of the column at no
+    /// cost, because nothing was lost. Rendered as <c>doc</c> in white followed immediately by
+    /// <c>ker compose up</c> in the suggestion colour, it reads as one string, which is what every
+    /// shell with inline autosuggestion has trained people to expect.
+    /// </para>
+    /// <para>
+    /// Only ever set when the query is actually being rendered - see
+    /// <c>CommandAssistBarViewModel.SyncPresentationState</c>. Showing a bare tail with its head
+    /// suppressed by the compact layout would be gibberish.
+    /// </para>
+    /// </remarks>
+    public bool IsSummaryContinuation
+    {
+        get => _isSummaryContinuation;
+        set => SetField(ref _isSummaryContinuation, value);
+    }
+
+    /// <summary>
+    /// The session's shell-integration state as a one-word chip: "integrated" or "basic".
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The owner-approved addition to this round. "Is the shell integration script actually working?"
+    /// was previously answerable only by running a command and seeing whether anything was captured,
+    /// which is a poor way to learn that the answer is no. The state was already known - it is
+    /// <c>AssistSessionContext.IsShellIntegrationLive</c>, the same disjunction the capture pipeline
+    /// gates on - and simply had no way to reach the screen.
+    /// </para>
+    /// <para>
+    /// Deliberately tiny and deliberately not an alert. A markless session is a supported,
+    /// working configuration - <c>cmd.exe</c> is never going to emit OSC 133 - so "basic" is a
+    /// statement of which mode you are in, not a warning that something is broken. The full sentence
+    /// lives in <see cref="IntegrationStatusTooltip"/>.
+    /// </para>
+    /// </remarks>
+    public string IntegrationStatusText
+    {
+        get => _integrationStatusText;
+        set => SetField(ref _integrationStatusText, value);
+    }
+
+    /// <summary>The sentence behind <see cref="IntegrationStatusText"/>, shown on hover.</summary>
+    public string IntegrationStatusTooltip
+    {
+        get => _integrationStatusTooltip;
+        set => SetField(ref _integrationStatusTooltip, value);
+    }
+
+    /// <summary>
+    /// Whether the chip is rendered. Follows the same width budget as the hint strip: it is chrome,
+    /// and chrome yields to content.
+    /// </summary>
+    public bool ShowIntegrationStatus
+    {
+        get => _showIntegrationStatus;
+        set => SetField(ref _showIntegrationStatus, value);
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistPopupViewModel.cs
+++ b/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistPopupViewModel.cs
@@ -20,6 +20,8 @@ public sealed class CommandAssistPopupViewModel : INotifyPropertyChanged
     private int _selectedIndex = -1;
     private string _shortcutHintText = string.Empty;
     private string _attributionText = string.Empty;
+    private string _integrationStatusText = string.Empty;
+    private string _integrationStatusTooltip = string.Empty;
 
     public CommandAssistPopupViewModel(ObservableCollection<CommandAssistSuggestionItemViewModel> suggestions)
     {
@@ -36,6 +38,28 @@ public sealed class CommandAssistPopupViewModel : INotifyPropertyChanged
     {
         get => _modeLabel;
         set => SetField(ref _modeLabel, value);
+    }
+
+    /// <summary>
+    /// The session's shell-integration state, shown in the popup footer beside the shortcut hint.
+    /// </summary>
+    /// <remarks>
+    /// The popup carries the chip unconditionally where the bubble drops it at narrow widths: the
+    /// popup is a summoned surface with a footer already, so there is room, and it is the surface a
+    /// user is looking at when they wonder why the list is emptier than they expected. See
+    /// <see cref="CommandAssistBubbleViewModel.IntegrationStatusText"/>.
+    /// </remarks>
+    public string IntegrationStatusText
+    {
+        get => _integrationStatusText;
+        set => SetField(ref _integrationStatusText, value);
+    }
+
+    /// <summary>The sentence behind <see cref="IntegrationStatusText"/>, shown on hover.</summary>
+    public string IntegrationStatusTooltip
+    {
+        get => _integrationStatusTooltip;
+        set => SetField(ref _integrationStatusTooltip, value);
     }
 
     public string QueryText

--- a/tests/NovaTerminal.App.Tests/CommandAssist/AssistContentProviderSeamTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/AssistContentProviderSeamTests.cs
@@ -668,7 +668,10 @@ public sealed class AssistContentProviderSeamTests
         public Task<IReadOnlyList<CommandHistoryEntry>> GetRecentAsync(int maxResults, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<CommandHistoryEntry>>([]);
 
-        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default)
+        public Task<bool> TryMarkInvalidCommandAsync(string entryId, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+
+        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default, bool isInvalidCommand = false)
             => Task.FromResult(false);
 
         public Task ClearAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/tests/NovaTerminal.App.Tests/CommandAssist/AssistRelativeTimeTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/AssistRelativeTimeTests.cs
@@ -1,0 +1,56 @@
+using NovaTerminal.CommandAssist.Domain;
+
+namespace NovaTerminal.Tests.CommandAssist;
+
+/// <summary>
+/// The relative-time captions that replaced <c>Used 2026-08-04 15:23</c> on history rows.
+/// </summary>
+public sealed class AssistRelativeTimeTests
+{
+    private static readonly DateTimeOffset Now = DateTimeOffset.Parse("2026-08-06T12:00:00+00:00");
+
+    [Theory]
+    [InlineData(0, "just now")]
+    [InlineData(30, "just now")]
+    [InlineData(90, "1m ago")]
+    [InlineData(60 * 2, "2m ago")]
+    [InlineData(60 * 59, "59m ago")]
+    [InlineData(60 * 60, "1h ago")]
+    [InlineData(60 * 60 * 5, "5h ago")]
+    [InlineData(60 * 60 * 25, "yesterday")]
+    [InlineData(60 * 60 * 47, "yesterday")]
+    [InlineData(60 * 60 * 49, "2d ago")]
+    [InlineData(60 * 60 * 24 * 6, "6d ago")]
+    public void Format_RendersTheAgeInTheCoarsestUnitThatStillPlacesIt(int ageSeconds, string expected)
+    {
+        Assert.Equal(expected, AssistRelativeTime.Format(Now.AddSeconds(-ageSeconds), Now));
+    }
+
+    /// <summary>
+    /// Past a week the age stops being placeable and a date is what someone would look for.
+    /// </summary>
+    [Fact]
+    public void Format_BeyondAWeek_FallsBackToADate()
+    {
+        Assert.Equal("2026-07-20", AssistRelativeTime.Format(Now.AddDays(-17), Now));
+    }
+
+    /// <summary>
+    /// Clock skew against an SSH host is common and is not the user's problem.
+    /// </summary>
+    [Fact]
+    public void Format_WhenTheEntryIsInTheFuture_ReadsAsJustNow()
+    {
+        Assert.Equal("just now", AssistRelativeTime.Format(Now.AddMinutes(4), Now));
+    }
+
+    [Theory]
+    [InlineData(60, true)]
+    [InlineData(60 * 14, true)]
+    [InlineData(60 * 16, false)]
+    [InlineData(60 * 60 * 24, false)]
+    public void IsRecent_MarksOnlyTheCurrentSitting(int ageSeconds, bool expected)
+    {
+        Assert.Equal(expected, AssistRelativeTime.IsRecent(Now.AddSeconds(-ageSeconds), Now));
+    }
+}

--- a/tests/NovaTerminal.App.Tests/CommandAssist/AssistShortcutBindingTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/AssistShortcutBindingTests.cs
@@ -354,7 +354,10 @@ public sealed class AssistShortcutBindingTests
         public Task<IReadOnlyList<NovaTerminal.CommandAssist.Models.CommandHistoryEntry>> SearchAsync(string query, int maxCandidates, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<NovaTerminal.CommandAssist.Models.CommandHistoryEntry>>(Array.Empty<NovaTerminal.CommandAssist.Models.CommandHistoryEntry>());
 
-        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default)
+        public Task<bool> TryMarkInvalidCommandAsync(string entryId, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+
+        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default, bool isInvalidCommand = false)
             => Task.FromResult(false);
     }
 }

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CapturePipelineTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CapturePipelineTests.cs
@@ -530,6 +530,105 @@ public sealed class CapturePipelineTests
         Assert.Empty(store.Entries);
     }
 
+    // ------------------------------------- UX-polish round: typos are flagged, never deleted
+
+    /// <summary>
+    /// Exit 127 is the POSIX shells' way of saying "no such command", and it is enough on its own.
+    /// </summary>
+    [Fact]
+    public async Task CompleteSubmissionAsync_WhenTheExitCodeIs127_FlagsTheEntryAsAnInvalidCommand()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, _) = CreatePipeline();
+        await pipeline.CaptureSubmissionAsync("gti status", isSubmissionSuppressed: false);
+
+        await pipeline.CompleteSubmissionAsync(127);
+
+        CommandHistoryEntry entry = Assert.Single(store.Entries);
+        Assert.True(entry.IsInvalidCommand);
+
+        // Flagged, not deleted: the record of what was run stays truthful.
+        Assert.Equal("gti status", entry.CommandText);
+        Assert.Equal(127, entry.ExitCode);
+    }
+
+    [Fact]
+    public async Task CommandFinished_WhenTheExitCodeIs127_FlagsTheStructuredEntryToo()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, AssistSessionContext context) = CreatePipeline();
+        context.SetShellIntegrationEnabled(true);
+        await pipeline.HandleShellIntegrationEventAsync(Accepted("gti status"));
+
+        await pipeline.HandleShellIntegrationEventAsync(Finished(127, TimeSpan.FromMilliseconds(12)));
+
+        Assert.True(Assert.Single(store.Entries).IsInvalidCommand);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    public async Task CompleteSubmissionAsync_ForAnOrdinaryExitCode_DoesNotFlagTheEntry(int exitCode)
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, _) = CreatePipeline();
+        await pipeline.CaptureSubmissionAsync("git push", isSubmissionSuppressed: false);
+
+        await pipeline.CompleteSubmissionAsync(exitCode);
+
+        Assert.False(Assert.Single(store.Entries).IsInvalidCommand);
+    }
+
+    /// <summary>
+    /// The PowerShell half: exit 1 tells us nothing, so the Fix recogniser's classification arrives
+    /// afterwards and patches the entry the completion has already released.
+    /// </summary>
+    [Fact]
+    public async Task MarkLastCommandInvalidAsync_AfterCompletion_FlagsTheEntryTheCompletionReleased()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, _) = CreatePipeline();
+        await pipeline.CaptureSubmissionAsync("gti status", isSubmissionSuppressed: false);
+        await pipeline.CompleteSubmissionAsync(1);
+
+        Assert.False(Assert.Single(store.Entries).IsInvalidCommand);
+
+        await pipeline.MarkLastCommandInvalidAsync();
+
+        Assert.True(Assert.Single(store.Entries).IsInvalidCommand);
+    }
+
+    /// <summary>
+    /// With nothing completed there is no target, and a pending command is explicitly not one.
+    /// </summary>
+    [Fact]
+    public async Task MarkLastCommandInvalidAsync_WithNothingCompleted_FlagsNothing()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, _) = CreatePipeline();
+        await pipeline.CaptureSubmissionAsync("gti status", isSubmissionSuppressed: false);
+
+        await pipeline.MarkLastCommandInvalidAsync();
+
+        Assert.False(Assert.Single(store.Entries).IsInvalidCommand);
+    }
+
+    /// <summary>
+    /// A late classification may never land on a command the user has since run.
+    /// </summary>
+    /// <remarks>
+    /// The failure mode this rules out is the worst one available: silently suppressing a command
+    /// that works, because an analysis of the previous line arrived after the next had been typed.
+    /// </remarks>
+    [Fact]
+    public async Task MarkLastCommandInvalidAsync_AfterANewCommandWasCaptured_FlagsNeitherEntry()
+    {
+        (CapturePipeline pipeline, InMemoryHistoryStore store, _) = CreatePipeline();
+        await pipeline.CaptureSubmissionAsync("gti status", isSubmissionSuppressed: false);
+        await pipeline.CompleteSubmissionAsync(1);
+        await pipeline.CaptureSubmissionAsync("git status", isSubmissionSuppressed: false);
+
+        await pipeline.MarkLastCommandInvalidAsync();
+
+        Assert.DoesNotContain(store.Entries, x => x.IsInvalidCommand);
+    }
+
     private static (CapturePipeline Pipeline, InMemoryHistoryStore Store, AssistSessionContext Context) CreatePipeline()
     {
         var store = new InMemoryHistoryStore();
@@ -585,7 +684,19 @@ public sealed class CapturePipelineTests
         public Task<IReadOnlyList<CommandHistoryEntry>> SearchAsync(string query, int maxCandidates, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<CommandHistoryEntry>>(_entries.Take(maxCandidates).ToList());
 
-        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default)
+        public Task<bool> TryMarkInvalidCommandAsync(string entryId, CancellationToken cancellationToken = default)
+        {
+            int index = _entries.FindIndex(x => x.Id == entryId);
+            if (index < 0)
+            {
+                return Task.FromResult(false);
+            }
+
+            _entries[index] = _entries[index] with { IsInvalidCommand = true };
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default, bool isInvalidCommand = false)
         {
             int index = _entries.FindIndex(x => x.Id == entryId);
             if (index < 0)
@@ -597,7 +708,10 @@ public sealed class CapturePipelineTests
             _entries[index] = _entries[index] with
             {
                 ExitCode = exitCode,
-                DurationMs = durationMs ?? _entries[index].DurationMs
+                DurationMs = durationMs ?? _entries[index].DurationMs,
+
+                // Latching, like the real store: see IHistoryStore.TryUpdateExecutionResultAsync.
+                IsInvalidCommand = _entries[index].IsInvalidCommand || isInvalidCommand
             };
             return Task.FromResult(true);
         }
@@ -616,7 +730,10 @@ public sealed class CapturePipelineTests
         public Task<IReadOnlyList<CommandHistoryEntry>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<CommandHistoryEntry>>(Array.Empty<CommandHistoryEntry>());
 
-        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default)
+        public Task<bool> TryMarkInvalidCommandAsync(string entryId, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+
+        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default, bool isInvalidCommand = false)
             => Task.FromException<bool>(new InvalidOperationException("simulated write failure"));
     }
 }

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistControllerTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistControllerTests.cs
@@ -182,14 +182,28 @@ public sealed class CommandAssistControllerTests
         Assert.Equal(AssistSuggestionType.Fix, controller.Suggestions[0].Type);
     }
 
+    /// <summary>
+    /// A recognised insight that is confident enough to be worth saying, but not enough to interrupt,
+    /// gets the bubble and not the popup.
+    /// </summary>
+    /// <remarks>
+    /// The middle band: a recogniser matched, so it surfaces, but the confidence is under the 0.8 that
+    /// opens the popup over whatever the user types next.
+    /// </remarks>
     [Fact]
-    public async Task HandleCommandFailureAsync_WhenInsightIsLowConfidence_DoesNotAutoOpenFixMode()
+    public async Task HandleCommandFailureAsync_WhenInsightIsRecognizedButNotConfident_ShowsTheBubbleWithoutThePopup()
     {
         var controller = CreateController(
             errorInsightService: new RecordingErrorInsightService(
-                [new CommandFixSuggestion("Maybe try something else", "git status", "Low confidence.", 0.2, ["Fix"])]));
+                [new CommandFixSuggestion(
+                    "Run it with elevated privileges",
+                    "sudo apt install ripgrep",
+                    "The operation needs privileges the current user does not have.",
+                    CommandErrorRecognizers.Plausible,
+                    ["Fix"],
+                    RecognizerId: "permission-denied")]));
 
-        bool opened = await controller.HandleCommandFailureAsync(CreateFailureContext("gti status", 1, "command failed"));
+        bool opened = await controller.HandleCommandFailureAsync(CreateFailureContext("apt install ripgrep", 1, "Permission denied"));
 
         Assert.False(opened);
         Assert.True(controller.ViewModel.IsVisible);
@@ -199,20 +213,170 @@ public sealed class CommandAssistControllerTests
         Assert.Contains(controller.Suggestions, item => item.Type == AssistSuggestionType.Fix);
     }
 
+    /// <summary>
+    /// The noise floor: an insight nothing in the recogniser table stood behind shows nothing at all.
+    /// </summary>
+    /// <remarks>
+    /// The owner's "fix comes sometimes when it is not needed", in the shape he actually hit it -
+    /// a zsh builtin that ran, printed something no recogniser models, and exited non-zero, answered
+    /// with a name-similarity guess. Before the UX-polish round the only condition here was "the list
+    /// is non-empty", so every non-zero exit in the session produced a bubble.
+    /// </remarks>
+    [Fact]
+    public async Task HandleCommandFailureAsync_WhenTheBestInsightIsAGuess_ShowsNothing()
+    {
+        var controller = CreateController(
+            errorInsightService: new RecordingErrorInsightService(
+                [new CommandFixSuggestion(
+                    "Did you mean printf?",
+                    "printf -l $precmd_functions",
+                    "The command failed for a reason this terminal does not recognise.",
+                    CommandErrorRecognizers.Explanatory,
+                    ["Fix", "Typo"])]));
+
+        bool opened = await controller.HandleCommandFailureAsync(
+            CreateFailureContext("print -l $precmd_functions", 1, "command failed"));
+
+        Assert.False(opened);
+        Assert.False(controller.ViewModel.IsVisible);
+        Assert.False(controller.ViewModel.IsPopupOpen);
+    }
+
+    /// <summary>
+    /// An unrecognised guess does not auto-surface however confident it claims to be.
+    /// </summary>
+    /// <remarks>
+    /// The reason the gate is provenance rather than confidence. The service's no-output fallback
+    /// publishes a one-edit correction at <see cref="CommandErrorRecognizers.Likely"/> - above any
+    /// threshold that would still admit a real explanation - on the strength of nothing but name
+    /// similarity.
+    /// </remarks>
+    [Fact]
+    public async Task HandleCommandFailureAsync_WhenTheInsightIsAnUnrecognizedGuess_ShowsNothing()
+    {
+        var controller = CreateController(
+            errorInsightService: new RecordingErrorInsightService(
+                [new CommandFixSuggestion(
+                    "Did you mean git?",
+                    "git status",
+                    "No output was captured for this command, so this is a name-similarity guess only.",
+                    CommandErrorRecognizers.Likely,
+                    ["Fix", "Typo"])]));
+
+        bool opened = await controller.HandleCommandFailureAsync(CreateFailureContext("gti status", 1, null));
+
+        Assert.False(opened);
+        Assert.False(controller.ViewModel.IsVisible);
+    }
+
     [Fact]
     public async Task MoveSelectionDown_WhenLowConfidenceFixAffordanceIsVisible_OpensPopup()
     {
         var controller = CreateController(
             errorInsightService: new RecordingErrorInsightService(
-                [new CommandFixSuggestion("Maybe try git status", "git status", "Low confidence.", 0.2, ["Fix"])]));
+                [new CommandFixSuggestion(
+                    "Run it with elevated privileges",
+                    "sudo apt install ripgrep",
+                    "The operation needs privileges the current user does not have.",
+                    CommandErrorRecognizers.Plausible,
+                    ["Fix"],
+                    RecognizerId: "permission-denied")]));
 
-        await controller.HandleCommandFailureAsync(CreateFailureContext("gti status", 1, "command failed"));
+        await controller.HandleCommandFailureAsync(CreateFailureContext("apt install ripgrep", 1, "Permission denied"));
 
         bool moved = controller.MoveSelectionDown();
 
         Assert.True(moved);
         Assert.True(controller.ViewModel.IsPopupOpen);
         Assert.True(controller.ViewModel.Popup.IsVisible);
+    }
+
+    /// <summary>
+    /// The end-to-end typo suppression: a recognised command-not-found marks the entry that was just
+    /// captured, so the next keystroke does not get it offered back.
+    /// </summary>
+    /// <remarks>
+    /// This is the PowerShell path, where the exit code is 1 and carries no information - the only
+    /// thing that knows a typo happened is the recogniser that read the output tail. See
+    /// <c>CommandHistoryEntry.IsInvalidCommand</c>.
+    /// </remarks>
+    [Fact]
+    public async Task HandleCommandFailureAsync_WhenTheFailureIsCommandNotFound_FlagsTheCapturedEntry()
+    {
+        var store = new InMemoryHistoryStore();
+        var controller = CreateController(
+            historyStore: store,
+            errorInsightService: new RecordingErrorInsightService(
+                [new CommandFixSuggestion(
+                    "Did you mean git?",
+                    "git status",
+                    "Closest local match.",
+                    CommandErrorRecognizers.NearCertain,
+                    ["Fix", "Typo"],
+                    RecognizerId: "command-not-found")]));
+
+        await controller.HandleEnterAsync("gti status");
+        await controller.HandleCommandFinishedAsync(1);
+
+        Assert.False(Assert.Single(store.Entries).IsInvalidCommand);
+
+        await controller.HandleCommandFailureAsync(
+            CreateFailureContext("gti status", 1, "gti : The term 'gti' is not recognized as a name of a cmdlet"));
+
+        Assert.True(Assert.Single(store.Entries).IsInvalidCommand);
+    }
+
+    /// <summary>
+    /// A failure that is not a name-resolution failure leaves the entry alone.
+    /// </summary>
+    [Fact]
+    public async Task HandleCommandFailureAsync_WhenTheFailureIsNotCommandNotFound_LeavesTheEntryOffered()
+    {
+        var store = new InMemoryHistoryStore();
+        var controller = CreateController(
+            historyStore: store,
+            errorInsightService: new RecordingErrorInsightService(
+                [new CommandFixSuggestion(
+                    "Set an upstream for this branch",
+                    "git push -u origin main",
+                    "The branch has no upstream.",
+                    CommandErrorRecognizers.ToolNamedTheFix,
+                    ["Fix"],
+                    RecognizerId: "git-no-upstream")]));
+
+        await controller.HandleEnterAsync("git push");
+        await controller.HandleCommandFinishedAsync(128);
+        await controller.HandleCommandFailureAsync(
+            CreateFailureContext("git push", 128, "fatal: The current branch main has no upstream branch."));
+
+        Assert.False(Assert.Single(store.Entries).IsInvalidCommand);
+    }
+
+    /// <summary>
+    /// The Fix bubble's headline is the suggestion, and the failed command is not echoed into it.
+    /// </summary>
+    [Fact]
+    public async Task HandleCommandFailureAsync_PutsTheSuggestionInTheBubbleAndNotTheFailedCommand()
+    {
+        var controller = CreateController(
+            errorInsightService: new RecordingErrorInsightService(
+                [new CommandFixSuggestion(
+                    "Did you mean git?",
+                    "git status",
+                    "Closest local match.",
+                    CommandErrorRecognizers.NearCertain,
+                    ["Fix", "Typo"],
+                    RecognizerId: "command-not-found")]));
+
+        await controller.HandleCommandFailureAsync(
+            CreateFailureContext("gti status", 127, "command not found"));
+
+        // The popup keeps the failed command as its caption - there is room for both there.
+        Assert.Equal("gti status", controller.ViewModel.QueryText);
+
+        // The bubble does not, and its summary is the fix rather than the failure.
+        Assert.False(controller.ViewModel.Bubble.ShowQueryText);
+        Assert.Equal("Did you mean git?", controller.ViewModel.Bubble.SummaryText);
     }
 
     [Fact]
@@ -1757,7 +1921,19 @@ public sealed class CommandAssistControllerTests
             return needleIndex == needle.Length;
         }
 
-        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default)
+        public Task<bool> TryMarkInvalidCommandAsync(string entryId, CancellationToken cancellationToken = default)
+        {
+            int index = _entries.FindIndex(x => x.Id == entryId);
+            if (index < 0)
+            {
+                return Task.FromResult(false);
+            }
+
+            _entries[index] = _entries[index] with { IsInvalidCommand = true };
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default, bool isInvalidCommand = false)
         {
             int index = _entries.FindIndex(x => x.Id == entryId);
             if (index < 0)
@@ -1768,7 +1944,10 @@ public sealed class CommandAssistControllerTests
             _entries[index] = _entries[index] with
             {
                 ExitCode = exitCode,
-                DurationMs = durationMs ?? _entries[index].DurationMs
+                DurationMs = durationMs ?? _entries[index].DurationMs,
+
+                // Latching, like the real store: see IHistoryStore.TryUpdateExecutionResultAsync.
+                IsInvalidCommand = _entries[index].IsInvalidCommand || isInvalidCommand
             };
             return Task.FromResult(true);
         }
@@ -1815,7 +1994,10 @@ public sealed class CommandAssistControllerTests
                 cancellationToken);
         }
 
-        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default)
+        public Task<bool> TryMarkInvalidCommandAsync(string entryId, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+
+        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default, bool isInvalidCommand = false)
             => Task.FromResult(false);
 
         public Task WaitForLastSearchAsync() => _lastSearchTask;
@@ -1835,7 +2017,10 @@ public sealed class CommandAssistControllerTests
         public Task<IReadOnlyList<CommandHistoryEntry>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<CommandHistoryEntry>>(Array.Empty<CommandHistoryEntry>());
 
-        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default)
+        public Task<bool> TryMarkInvalidCommandAsync(string entryId, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+
+        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default, bool isInvalidCommand = false)
             => Task.FromException<bool>(new InvalidOperationException("simulated write failure"));
     }
 

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistGridTruthTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistGridTruthTests.cs
@@ -600,7 +600,10 @@ public sealed class CommandAssistGridTruthTests
             return Task.FromResult(results);
         }
 
-        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default)
+        public Task<bool> TryMarkInvalidCommandAsync(string entryId, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+
+        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default, bool isInvalidCommand = false)
             => Task.FromResult(false);
 
         public void Seed(params string[] commandTexts)

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistLayoutTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistLayoutTests.cs
@@ -19,6 +19,16 @@ namespace NovaTerminal.Tests.CommandAssist;
 
 public sealed class CommandAssistLayoutTests
 {
+    /// <summary>
+    /// The fish-style split: when the suggestion extends the query, the bubble shows the query and
+    /// only the <em>tail</em> of the suggestion, which read together are the whole thing.
+    /// </summary>
+    /// <remarks>
+    /// This used to assert the summary was the full "git status" - i.e. that the bubble rendered
+    /// "git " and then "git status" beside it, repeating the three characters the user had already
+    /// typed and spending the width the round is trying to recover. See
+    /// <see cref="CommandAssistBubbleViewModel.IsSummaryContinuation"/>.
+    /// </remarks>
     [Fact]
     public void CommandAssistBarViewModel_MapsCompactBubbleState()
     {
@@ -33,7 +43,151 @@ public sealed class CommandAssistLayoutTests
         Assert.True(vm.Bubble.IsVisible);
         Assert.Equal("Suggest", vm.Bubble.ModeLabel);
         Assert.Equal("git ", vm.Bubble.QueryText);
+        Assert.True(vm.Bubble.ShowQueryText);
+        Assert.True(vm.Bubble.IsSummaryContinuation);
+        Assert.Equal("status", vm.Bubble.SummaryText);
+    }
+
+    /// <summary>
+    /// A suggestion that is not an extension of the query keeps its whole text in the summary.
+    /// </summary>
+    [Fact]
+    public void CommandAssistBarViewModel_WhenTheSuggestionDoesNotExtendTheQuery_KeepsTheWholeSummary()
+    {
+        var vm = new CommandAssistBarViewModel
+        {
+            IsVisible = true,
+            ModeLabel = "Suggest",
+            QueryText = "gti",
+            TopSuggestionText = "git status"
+        };
+
+        Assert.False(vm.Bubble.IsSummaryContinuation);
         Assert.Equal("git status", vm.Bubble.SummaryText);
+    }
+
+    /// <summary>
+    /// With the query column suppressed by the compact layout, the summary reverts to the full
+    /// suggestion: a bare tail with its head hidden would be gibberish.
+    /// </summary>
+    [Fact]
+    public void CommandAssistBarViewModel_WhenTheQueryIsHidden_DoesNotShowOnlyTheCompletionTail()
+    {
+        var vm = new CommandAssistBarViewModel
+        {
+            IsVisible = true,
+            ModeLabel = "Suggest",
+            QueryText = "git ",
+            TopSuggestionText = "git status",
+            AllowBubbleQueryText = false
+        };
+
+        Assert.False(vm.Bubble.ShowQueryText);
+        Assert.False(vm.Bubble.IsSummaryContinuation);
+        Assert.Equal("git status", vm.Bubble.SummaryText);
+    }
+
+    /// <summary>
+    /// The Fix bubble leads with the suggestion, not with the command that failed.
+    /// </summary>
+    /// <remarks>
+    /// The owner's screenshot read <c>Fix | print -l $precmd_functions | Di...</c>. The failed command
+    /// is already on screen in the scrollback; the fix for it is the only new information the bubble
+    /// carries, so it gets the width. See <c>CommandAssistBarViewModel.ApplyBubbleContent</c>.
+    /// </remarks>
+    [Fact]
+    public void CommandAssistBarViewModel_InFixMode_DoesNotEchoTheFailedCommand()
+    {
+        var vm = new CommandAssistBarViewModel
+        {
+            IsVisible = true,
+            ModeLabel = "Fix",
+            QueryText = "gti status",
+            TopSuggestionText = "Did you mean git?"
+        };
+
+        Assert.False(vm.Bubble.ShowQueryText);
+        Assert.False(vm.Bubble.IsSummaryContinuation);
+        Assert.Equal("Did you mean git?", vm.Bubble.SummaryText);
+    }
+
+    /// <summary>
+    /// Exactly one surface at a time: opening the popup takes the bubble down.
+    /// </summary>
+    /// <remarks>
+    /// The owner's screenshot had a "History | vim .env | Enter insert" bubble rendered below an open
+    /// History popup whose top row was the same <c>vim .env</c>. Both surfaces were bound and both
+    /// were visible, because the bubble followed <c>IsVisible</c> alone.
+    /// </remarks>
+    [Fact]
+    public void CommandAssistBarViewModel_WhenThePopupIsOpen_HidesTheBubble()
+    {
+        var vm = new CommandAssistBarViewModel
+        {
+            IsVisible = true,
+            ModeLabel = "History",
+            TopSuggestionText = "vim .env",
+            HasSuggestions = true,
+            IsPopupOpen = true
+        };
+
+        Assert.True(vm.Popup.IsVisible);
+        Assert.False(vm.Bubble.IsVisible);
+    }
+
+    /// <summary>
+    /// The shortcut hint's middle rung: keys without verbs, so the suggestion keeps its width.
+    /// </summary>
+    [Fact]
+    public void CommandAssistBarViewModel_WhenTheHintIsTerse_DropsTheVerbsAndKeepsTheKeys()
+    {
+        var vm = new CommandAssistBarViewModel
+        {
+            IsVisible = true,
+            ModeLabel = "Suggest",
+            BubbleHintDetail = AssistHintDetail.Terse
+        };
+
+        Assert.True(vm.Bubble.ShowShortcutHint);
+        Assert.Equal("Up/Down  |  Ctrl+Enter  |  Esc", vm.Bubble.ShortcutHintText);
+
+        // The popup has room and is unaffected: it is where the shortcuts are still taught.
+        Assert.Equal(CommandAssistBarViewModel.IdleHintText, vm.Popup.ShortcutHintText);
+    }
+
+    [Fact]
+    public void CommandAssistBarViewModel_WhenTheHintIsHidden_DropsTheStripEntirely()
+    {
+        var vm = new CommandAssistBarViewModel
+        {
+            IsVisible = true,
+            ModeLabel = "Suggest",
+            BubbleHintDetail = AssistHintDetail.Hidden
+        };
+
+        Assert.False(vm.Bubble.ShowShortcutHint);
+        Assert.False(vm.Bubble.ShowIntegrationStatus);
+    }
+
+    /// <summary>
+    /// The integration chip reports which capture mode the session is in.
+    /// </summary>
+    [Theory]
+    [InlineData(true, "integrated")]
+    [InlineData(false, "basic")]
+    public void CommandAssistBarViewModel_PublishesTheIntegrationChip(bool isLive, string expected)
+    {
+        var vm = new CommandAssistBarViewModel
+        {
+            IsVisible = true,
+            ModeLabel = "Suggest",
+            IsShellIntegrationLive = isLive
+        };
+
+        Assert.Equal(expected, vm.Bubble.IntegrationStatusText);
+        Assert.Equal(expected, vm.Popup.IntegrationStatusText);
+        Assert.True(vm.Bubble.ShowIntegrationStatus);
+        Assert.False(string.IsNullOrWhiteSpace(vm.Bubble.IntegrationStatusTooltip));
     }
 
     [Fact]
@@ -99,7 +253,11 @@ public sealed class CommandAssistLayoutTests
         Assert.NotNull(bubbleModeLabel);
         Assert.NotNull(popupDescription);
         Assert.Equal("Help", bubbleModeLabel.Text);
-        Assert.True(bubbleVm.IsVisible);
+
+        // One surface at a time (UX-polish round, issue 6). Help opens the popup, so the bubble
+        // stands down: it would otherwise render the same mode label, query and top suggestion the
+        // popup is already showing in full, directly above it.
+        Assert.False(bubbleVm.IsVisible);
         Assert.True(popupVm.IsVisible);
         Assert.Equal("Help", popupVm.ModeLabel);
         Assert.False(string.IsNullOrWhiteSpace(popupVm.SelectedDescriptionText));
@@ -1009,29 +1167,49 @@ public sealed class CommandAssistLayoutTests
 
     /// <summary>
     /// 280 px is the bubble-width floor <c>CalculateCommandAssistSurfaceSizing</c> clamps to, which is
-    /// what a split SSH pane lands on. At that width the hint strip's <c>Auto</c> column beat the
-    /// summary's <c>*</c> column outright: the shortcut legend rendered in full and the suggestion - the
-    /// only content in the bubble anyone reads - got what was left, which was nothing.
+    /// what a split SSH pane lands on. The suggestion must keep a readable column there whether or not
+    /// the hint strip is on screen.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>What this test used to assert, and why it was the wrong shape.</strong> It measured
+    /// that <em>collapsing</em> the hint gave the summary its width back, with a negative control
+    /// requiring the un-collapsed case to be less than half as wide - i.e. it pinned the existence of
+    /// the squeeze as much as the remedy, and was satisfied as long as hiding the hint helped. The
+    /// owner then ran into the squeeze at a width above the collapse threshold, where nothing was
+    /// hidden and the suggestion was ellipsised to <c>doc...</c> anyway.
+    /// </para>
+    /// <para>
+    /// So the invariant is now the floor itself: the content column has a <c>MinWidth</c> that the
+    /// chrome cannot take, and the hint is what overflows instead. The old negative control is
+    /// deliberately inverted - the two measurements must now be <em>close</em>, because the hint no
+    /// longer decides how much of the suggestion the user can read.
+    /// </para>
+    /// </remarks>
     [AvaloniaFact]
-    public void CommandAssistBubbleView_AtTheNarrowBubbleFloor_CollapsingTheHintGivesTheSummaryItsWidth()
+    public void CommandAssistBubbleView_AtTheNarrowBubbleFloor_TheSummaryKeepsItsMinimumWidth()
     {
         const double bubbleWidth = 280;
 
-        double squeezed = MeasureBubbleSummaryWidth(showShortcutHint: true, bubbleWidth);
-        double collapsed = MeasureBubbleSummaryWidth(showShortcutHint: false, bubbleWidth);
+        // The MinWidth on the content column, less the margin that separates it from the query.
+        const double summaryFloor = 150 - 10;
 
-        // 40% is the honest floor rather than a round half: the mode label and the column spacing are
-        // real content too, and at 280 px they are most of the rest of the bubble.
+        double withHint = MeasureBubbleSummaryWidth(showShortcutHint: true, bubbleWidth);
+        double withoutHint = MeasureBubbleSummaryWidth(showShortcutHint: false, bubbleWidth);
+
         Assert.True(
-            collapsed >= bubbleWidth * 0.4,
-            $"With the hint collapsed the summary should keep a usable share of the bubble, but had " +
-            $"{collapsed:F0} of {bubbleWidth:F0} (with the hint shown: {squeezed:F0}).");
+            withHint >= summaryFloor,
+            $"The suggestion must keep its floor with the hint strip on screen, but had {withHint:F0} px " +
+            $"of {bubbleWidth:F0} (floor {summaryFloor:F0}). This is the owner's 'doc...' bubble.");
         Assert.True(
-            squeezed < collapsed * 0.5,
-            $"The negative control failed: the hint must actually be what squeezes the summary, but it " +
-            $"had {squeezed:F0} px with the hint shown against {collapsed:F0} px without it. Either the " +
-            "layout changed or this test no longer measures the reported bug.");
+            withoutHint >= summaryFloor,
+            $"The suggestion must keep its floor with the hint strip collapsed too, but had " +
+            $"{withoutHint:F0} px of {bubbleWidth:F0} (floor {summaryFloor:F0}).");
+        Assert.True(
+            withHint >= withoutHint * 0.6,
+            $"The hint strip must no longer decide how much of the suggestion is readable, but the " +
+            $"summary had {withHint:F0} px with it and {withoutHint:F0} px without it. Chrome is " +
+            "supposed to overflow before content does.");
     }
 
     /// <summary>
@@ -1355,6 +1533,12 @@ public sealed class CommandAssistLayoutTests
         pane.OpenCommandAssistHelp();
         CommandAssistBarViewModel vm = Assert.IsType<CommandAssistBarViewModel>(pane.CommandAssistViewModel);
         vm.IsVisible = true;
+
+        // Help opens the popup, and since the UX-polish round an open popup takes the bubble down -
+        // exactly one surface at a time. These are bubble-placement tests, so they close it: the
+        // state under test is "a bubble is on screen and has to be put somewhere", which is what a
+        // passive Suggest surface looks like. See CommandAssistBarViewModel.SyncPresentationState.
+        vm.IsPopupOpen = false;
         Assert.True(vm.Bubble.IsVisible);
         return vm;
     }

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistModeRouterTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistModeRouterTests.cs
@@ -62,6 +62,104 @@ public sealed class CommandAssistModeRouterTests
         Assert.Equal(CommandAssistMode.Suggest, mode);
     }
 
+    // ------------------------------------------------ UX-polish round: the Fix noise floor
+
+    /// <summary>
+    /// Anything a recogniser stood behind may surface, at every confidence the table publishes.
+    /// </summary>
+    /// <remarks>
+    /// The 0.40 case is the one that matters and the one an earlier draft of this floor got wrong:
+    /// <c>Explanatory</c> is what the table uses for a recognised failure with no single command to
+    /// run, and <c>git status</c> outside a working tree - "This directory is not inside a Git
+    /// repository" - is exactly what the feature is for.
+    /// </remarks>
+    [Theory]
+    [InlineData(0.95)]
+    [InlineData(0.7)]
+    [InlineData(0.55)]
+    [InlineData(0.4)]
+    public void ShouldSurfacePassiveFix_ForAnythingTheTableRecognized_IsTrue(double confidence)
+    {
+        var router = new CommandAssistModeRouter();
+
+        Assert.True(router.ShouldSurfacePassiveFix(
+            [Fix("This directory is not inside a Git repository", confidence, recognizerId: "git-not-a-repository")]));
+    }
+
+    /// <summary>
+    /// An uninformed guess does not interrupt however confident it is about itself.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>This is the mutation check for the floor.</strong> Dropping <c>IsRecognized</c> from
+    /// <c>ShouldSurfacePassiveFix</c> lets every one of these back onto the screen and fails here.
+    /// </para>
+    /// <para>
+    /// The 0.70 row is the important one: it is the no-output name-similarity guess, priced above any
+    /// confidence threshold that would still admit a real explanation, which is why provenance rather
+    /// than confidence is the gate.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData(0.7)]
+    [InlineData(0.55)]
+    [InlineData(0.4)]
+    public void ShouldSurfacePassiveFix_ForAnUnrecognizedGuess_IsFalse(double confidence)
+    {
+        var router = new CommandAssistModeRouter();
+
+        Assert.False(router.ShouldSurfacePassiveFix([Fix("Did you mean git?", confidence, recognizerId: null)]));
+    }
+
+    /// <summary>
+    /// One recognised row carries a list that also holds guesses.
+    /// </summary>
+    [Fact]
+    public void ShouldSurfacePassiveFix_WhenAnyRowWasRecognized_IsTrue()
+    {
+        var router = new CommandAssistModeRouter();
+
+        Assert.True(router.ShouldSurfacePassiveFix(
+        [
+            Fix("Did you mean git?", 0.7, recognizerId: null),
+            Fix("Run it with ./", 0.7, recognizerId: "command-not-found")
+        ]));
+    }
+
+    /// <summary>
+    /// A list of nothing but guesses stays down, however many of them there are.
+    /// </summary>
+    [Fact]
+    public void ShouldSurfacePassiveFix_WhenEveryRowIsAGuess_IsFalse()
+    {
+        var router = new CommandAssistModeRouter();
+
+        Assert.False(router.ShouldSurfacePassiveFix(
+        [
+            Fix("Did you mean git?", 0.7, recognizerId: null),
+            Fix("Did you mean gh?", 0.55, recognizerId: null)
+        ]));
+    }
+
+    [Fact]
+    public void ShouldSurfacePassiveFix_WithNoInsights_IsFalse()
+    {
+        var router = new CommandAssistModeRouter();
+
+        Assert.False(router.ShouldSurfacePassiveFix([]));
+    }
+
+    private static CommandFixSuggestion Fix(string title, double confidence, string? recognizerId)
+    {
+        return new CommandFixSuggestion(
+            Title: title,
+            SuggestedCommand: "git status",
+            Description: null,
+            Confidence: confidence,
+            Badges: ["Fix"],
+            RecognizerId: recognizerId);
+    }
+
     [Theory]
     [InlineData("git status", "git")]
     [InlineData("Get-ChildItem -Force", "Get-ChildItem")]

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistPassiveBubbleTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistPassiveBubbleTests.cs
@@ -987,7 +987,10 @@ public sealed class CommandAssistPassiveBubbleTests
             return needleIndex == needle.Length;
         }
 
-        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default)
+        public Task<bool> TryMarkInvalidCommandAsync(string entryId, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+
+        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default, bool isInvalidCommand = false)
             => Task.FromResult(false);
     }
 }

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistSuggestionEngineTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistSuggestionEngineTests.cs
@@ -48,6 +48,240 @@ public sealed class CommandAssistSuggestionEngineTests
         Assert.Equal("Helper detail", suggestion.Description);
     }
 
+    // ---------------------------------------------- UX-polish round: recency-first empty query
+
+    /// <summary>
+    /// The owner's exact complaint, as a test: the command he ran seconds ago must outrank the one he
+    /// ran five times last week.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// His screenshot had <c>vim .env</c> and <c>git pull</c> at the top, badged "Frequent", from a
+    /// directory he was no longer in - while the commands he had just run sat below the fold. The old
+    /// empty-query score was <c>1 + min(frequency,5) + bands</c> with recency only a tiebreak on exact
+    /// equality, so five repetitions (1006) beat anything run once (1002) no matter when.
+    /// </para>
+    /// <para>
+    /// <strong>This is the mutation check for the ordering.</strong> Reverting
+    /// <c>CommandAssistSuggestionEngine</c> to score frequency on the empty-query path puts
+    /// <c>vim .env</c> first and fails here.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void GetSuggestions_WithAnEmptyQuery_RanksTheMostRecentCommandAboveTheMostFrequentOne()
+    {
+        DateTimeOffset now = DateTimeOffset.Parse("2026-08-06T12:00:00+00:00");
+        var engine = new CommandAssistSuggestionEngine(clock: () => now);
+        var context = new CommandAssistQueryContext(
+            Input: string.Empty,
+            WorkingDirectory: "/srv/app",
+            ShellKind: "bash",
+            ProfileId: "profile-1",
+            IncludePathSuggestions: false);
+
+        // Five runs of the same old command, and one run of a fresh one - the shape of his history.
+        var history = Enumerable
+            .Range(0, 5)
+            .Select(i => CreateEntry(
+                "vim .env",
+                executedAt: now.AddDays(-4).AddMinutes(i),
+                workingDirectory: "/root/apps/agent1"))
+            .Append(CreateEntry(
+                "docker compose up -d",
+                executedAt: now.AddSeconds(-20),
+                workingDirectory: "/srv/app"))
+            .ToArray();
+
+        IReadOnlyList<AssistSuggestion> results = engine.GetSuggestions(history, context, maxResults: 5);
+
+        Assert.Equal("docker compose up -d", results[0].DisplayText);
+        Assert.Equal("vim .env", results[1].DisplayText);
+    }
+
+    /// <summary>
+    /// Frequency survives as a tiebreak between two rows of the same age, which is all it is now for.
+    /// </summary>
+    [Fact]
+    public void GetSuggestions_WithAnEmptyQuery_UsesFrequencyOnlyToBreakARecencyTie()
+    {
+        DateTimeOffset now = DateTimeOffset.Parse("2026-08-06T12:00:00+00:00");
+        DateTimeOffset sameMoment = now.AddMinutes(-5);
+        var engine = new CommandAssistSuggestionEngine(clock: () => now);
+        var context = new CommandAssistQueryContext(
+            Input: string.Empty,
+            WorkingDirectory: "/srv/app",
+            ShellKind: "bash",
+            ProfileId: "profile-1",
+            IncludePathSuggestions: false);
+
+        var history = new[]
+        {
+            CreateEntry("make test", executedAt: sameMoment, workingDirectory: "/srv/app"),
+            CreateEntry("make build", executedAt: sameMoment.AddMinutes(-30), workingDirectory: "/srv/app"),
+            CreateEntry("make test", executedAt: sameMoment, workingDirectory: "/srv/app")
+        };
+
+        IReadOnlyList<AssistSuggestion> results = engine.GetSuggestions(history, context, maxResults: 5);
+
+        Assert.Equal("make test", results[0].DisplayText);
+        Assert.Equal(2, results[0].Frequency);
+    }
+
+    /// <summary>
+    /// The same-directory bonus is worth half an hour of recency: enough to lift the directory's own
+    /// recent work, not enough to bury something the user ran moments ago somewhere else.
+    /// </summary>
+    /// <remarks>
+    /// Both halves are asserted deliberately. A cwd <em>band</em> would satisfy the first and fail the
+    /// second, and would reproduce the owner's complaint with a different signal in the driving seat -
+    /// see <c>CommandAssistSuggestionEngine.EmptyQuerySameDirectoryRecencyBonus</c>.
+    /// </remarks>
+    [Fact]
+    public void GetSuggestions_WithAnEmptyQuery_TreatsSameDirectoryAsARecencyBonusNotABand()
+    {
+        DateTimeOffset now = DateTimeOffset.Parse("2026-08-06T12:00:00+00:00");
+        var engine = new CommandAssistSuggestionEngine(clock: () => now);
+        var context = new CommandAssistQueryContext(
+            Input: string.Empty,
+            WorkingDirectory: "/srv/app",
+            ShellKind: "bash",
+            ProfileId: "profile-1",
+            IncludePathSuggestions: false);
+
+        // The same-dir entry is older, but by less than the bonus, so it wins.
+        var lifts = new[]
+        {
+            CreateEntry("npm run dev", executedAt: now.AddMinutes(-20), workingDirectory: "/srv/app"),
+            CreateEntry("tail -f /var/log/syslog", executedAt: now.AddMinutes(-5), workingDirectory: "/var/log")
+        };
+
+        Assert.Equal("npm run dev", engine.GetSuggestions(lifts, context, maxResults: 5)[0].DisplayText);
+
+        // The same-dir entry is older by more than the bonus, so recency wins and the bonus does not
+        // become a band.
+        var doesNotLift = new[]
+        {
+            CreateEntry("npm run dev", executedAt: now.AddHours(-3), workingDirectory: "/srv/app"),
+            CreateEntry("tail -f /var/log/syslog", executedAt: now.AddMinutes(-5), workingDirectory: "/var/log")
+        };
+
+        Assert.Equal("tail -f /var/log/syslog", engine.GetSuggestions(doesNotLift, context, maxResults: 5)[0].DisplayText);
+    }
+
+    /// <summary>
+    /// The badges explain the placement, in the order the sort applied the signals.
+    /// </summary>
+    [Fact]
+    public void GetSuggestions_BadgesTheRowWithWhatPutItThere()
+    {
+        DateTimeOffset now = DateTimeOffset.Parse("2026-08-06T12:00:00+00:00");
+        var engine = new CommandAssistSuggestionEngine(clock: () => now);
+        var context = new CommandAssistQueryContext(
+            Input: string.Empty,
+            WorkingDirectory: "/srv/app",
+            ShellKind: "bash",
+            ProfileId: "profile-1",
+            IncludePathSuggestions: false);
+
+        var history = new[]
+        {
+            CreateEntry("docker ps", executedAt: now.AddMinutes(-2), workingDirectory: "/srv/app"),
+            CreateEntry("docker ps", executedAt: now.AddMinutes(-3), workingDirectory: "/srv/app"),
+            CreateEntry("apt update", executedAt: now.AddDays(-2), workingDirectory: "/etc")
+        };
+
+        IReadOnlyList<AssistSuggestion> results = engine.GetSuggestions(history, context, maxResults: 5);
+
+        AssistSuggestion recent = Assert.Single(results, x => x.DisplayText == "docker ps");
+        Assert.Equal(["Recent", "Same dir", "Frequent", "Worked"], recent.Badges);
+
+        AssistSuggestion old = Assert.Single(results, x => x.DisplayText == "apt update");
+        Assert.DoesNotContain("Recent", old.Badges);
+        Assert.DoesNotContain("Same dir", old.Badges);
+    }
+
+    // ---------------------------------------------- UX-polish round: typos are never suggested
+
+    /// <summary>
+    /// The owner typed <c>gti status</c>, it was captured, and the terminal offered it straight back.
+    /// </summary>
+    /// <remarks>
+    /// <strong>This is the mutation check for the invalid-command flag.</strong> Dropping the
+    /// <c>Where(x =&gt; !x.IsInvalidCommand)</c> filter in <c>BuildHistorySuggestions</c> makes
+    /// <c>gti status</c> the top suggestion for <c>gt</c> again and fails here.
+    /// </remarks>
+    [Fact]
+    public void GetSuggestions_NeverOffersACommandTheShellCouldNotResolve()
+    {
+        var engine = new CommandAssistSuggestionEngine();
+        var context = new CommandAssistQueryContext(
+            Input: "gt",
+            WorkingDirectory: @"C:\repo",
+            ShellKind: "pwsh",
+            ProfileId: "profile-1",
+            IncludePathSuggestions: false);
+
+        var history = new[]
+        {
+            CreateEntry("gti status", exitCode: 127, isInvalidCommand: true),
+            CreateEntry("git status", exitCode: 0)
+        };
+
+        IReadOnlyList<AssistSuggestion> results = engine.GetSuggestions(history, context, maxResults: 5);
+
+        Assert.DoesNotContain(results, x => x.DisplayText == "gti status");
+        Assert.Contains(results, x => x.DisplayText == "git status");
+    }
+
+    /// <summary>
+    /// Excluded on every path, including an explicit search for the typo's own text.
+    /// </summary>
+    /// <remarks>
+    /// The alternative - hide it in the passive bubble, keep it in an explicit <c>Ctrl+R</c> search -
+    /// was considered and rejected. There is no query for which the honest answer is a misspelling,
+    /// and a user who types <c>gti</c> looking for what went wrong wants the scrollback, not an offer
+    /// to run it again.
+    /// </remarks>
+    [Fact]
+    public void GetSuggestions_ExcludesInvalidCommandsFromExplicitSearchToo()
+    {
+        var engine = new CommandAssistSuggestionEngine();
+        var context = new CommandAssistQueryContext(
+            Input: "gti",
+            WorkingDirectory: @"C:\repo",
+            ShellKind: "pwsh",
+            ProfileId: "profile-1",
+            IncludePathSuggestions: false);
+
+        var history = new[] { CreateEntry("gti status", exitCode: 127, isInvalidCommand: true) };
+
+        Assert.Empty(engine.GetSuggestions(history, context, maxResults: 5));
+    }
+
+    /// <summary>
+    /// An unflagged entry with the same text still ranks: the filter is per entry, not per command
+    /// name, so installing the thing you kept mistyping brings it back.
+    /// </summary>
+    [Fact]
+    public void GetSuggestions_WhenTheSameTextLaterSucceeds_OffersTheGoodEntry()
+    {
+        var engine = new CommandAssistSuggestionEngine();
+        var context = new CommandAssistQueryContext(
+            Input: "gti",
+            WorkingDirectory: @"C:\repo",
+            ShellKind: "pwsh",
+            ProfileId: "profile-1",
+            IncludePathSuggestions: false);
+
+        var history = new[]
+        {
+            CreateEntry("gti status", exitCode: 127, isInvalidCommand: true),
+            CreateEntry("gti status", exitCode: 0)
+        };
+
+        Assert.Contains(engine.GetSuggestions(history, context, maxResults: 5), x => x.DisplayText == "gti status");
+    }
+
     [Fact]
     public void GetSuggestions_PinnedSnippetRanksAboveHistoryWithSimilarMatch()
     {
@@ -601,14 +835,16 @@ public sealed class CommandAssistSuggestionEngineTests
         string commandText,
         string? profileId = "profile-1",
         DateTimeOffset? executedAt = null,
-        int? exitCode = 0)
+        int? exitCode = 0,
+        string? workingDirectory = @"C:\repo",
+        bool isInvalidCommand = false)
     {
         return new CommandHistoryEntry(
             Id: Guid.NewGuid().ToString("N"),
             CommandText: commandText,
             ExecutedAt: executedAt ?? DateTimeOffset.Parse("2026-03-01T10:00:00+00:00"),
             ShellKind: "pwsh",
-            WorkingDirectory: @"C:\repo",
+            WorkingDirectory: workingDirectory,
             ProfileId: profileId,
             SessionId: "session-1",
             HostId: null,
@@ -616,7 +852,8 @@ public sealed class CommandAssistSuggestionEngineTests
             IsRemote: false,
             IsRedacted: false,
             Source: CommandCaptureSource.Heuristic,
-            DurationMs: null);
+            DurationMs: null,
+            IsInvalidCommand: isInvalidCommand);
     }
 
     private static CommandSnippet CreateSnippet(string name, string commandText, bool isPinned)

--- a/tests/NovaTerminal.App.Tests/CommandAssist/TerminalPaneCommandAssistShortcutTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/TerminalPaneCommandAssistShortcutTests.cs
@@ -187,8 +187,26 @@ public sealed class TerminalPaneCommandAssistShortcutTests
         await Task.Delay(50);
     }
 
+    /// <summary>
+    /// A non-zero exit with nothing readable behind it does not raise a surface.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>This assertion is inverted from what it used to be, and the inversion is the point of
+    /// the UX-polish round's issue 4.</strong> It previously asserted that any non-zero exit opened
+    /// Fix mode, which is precisely the behaviour the owner reported as "fix comes sometimes when it
+    /// is not needed". There is no output tail in this setup - nothing was painted on the grid - so
+    /// the insight service is on the bottom rung of its ladder and can only offer a name-similarity
+    /// guess. <c>CommandAssistModeRouter.ShouldSurfacePassiveFix</c> requires a recogniser to have
+    /// actually read something, so nothing surfaces.
+    /// </para>
+    /// <para>
+    /// The guess is still computed and still reachable: <c>Ctrl+Space</c> after the failure summons
+    /// it. What it no longer does is volunteer itself over every command that exits non-zero.
+    /// </para>
+    /// </remarks>
     [AvaloniaFact]
-    public async Task HandleCommandAssistCompletionAsync_WhenNonZeroExit_OpensFixModeForTrackedCommand()
+    public async Task HandleCommandAssistCompletionAsync_WhenNonZeroExitHasNoReadableOutput_StaysQuiet()
     {
         using var pane = new TerminalPane();
         ConfigureCommandAssist(pane);
@@ -198,8 +216,7 @@ public sealed class TerminalPaneCommandAssistShortcutTests
         await Task.Delay(50);
 
         CommandAssistBarViewModel vm = AssertViewModel(pane);
-        Assert.True(vm.IsVisible);
-        Assert.Equal("Fix", vm.ModeLabel);
+        Assert.False(vm.IsVisible);
     }
 
     [AvaloniaFact]

--- a/tests/NovaTerminal.App.Tests/Performance/CommandAssistPerformanceTests.cs
+++ b/tests/NovaTerminal.App.Tests/Performance/CommandAssistPerformanceTests.cs
@@ -461,7 +461,10 @@ public sealed class CommandAssistPerformanceTests
             return Task.FromResult<IReadOnlyList<CommandHistoryEntry>>(_entries.Take(maxCandidates).ToArray());
         }
 
-        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default)
+        public Task<bool> TryMarkInvalidCommandAsync(string entryId, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+
+        public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default, bool isInvalidCommand = false)
             => Task.FromResult(false);
     }
 


### PR DESCRIPTION
Pre-flag-flip polish from owner dogfooding.

The owner ran Command Assist against a real Ubuntu SSH host with the remote snippet
installed. The integration itself worked - marks flowed, commands were captured, exit
codes landed. What he got back was still not good enough to flip the Phase 6 flag, and
this PR is the six things he named, each verified in code before being changed.

One of the six diagnoses in the brief turned out to be wrong on inspection, and one of
my own fixes was wrong until a test caught it. Both are written up below rather than
quietly corrected.

---

## 1 + 2. "No history even after integration" / "Sorting I don't understand"

Two complaints, one cause.

**Diagnosis (confirmed).** Nothing was missing - the entries were all there. The
empty-query (Ctrl+R) score in `CommandAssistSuggestionEngine.ScoreText` was:

    1 + min(frequency,5) + pinned + contextBand + profileBand

with recency only a `ThenByDescending` that fires on *exact* score equality. Inside the
same-host band the single live term was frequency, capped at 5, and the current working
directory contributed nothing at all. So `vim .env` run five times last week scored 1006
and beat a command run once ten seconds ago in the directory he was standing in, which
scored 1002. His screenshot shows exactly that: `vim .env` and `git pull` badged
"Frequent" from `/root/apps/agent1`, a directory he had left, above everything recent.

The feature therefore looked broken ("no history") and the order looked arbitrary
("I don't understand"). Both readings were fair - the list was a frequency chart wearing
a history list's clothes.

**Fix - the ordering design.**

Ctrl+R means "what did I just do". Every shell's reverse search walks backwards through
time, so within the same-host context band from #290:

| Sort key | Was | Now |
|---|---|---|
| 1 | context / profile / pin band | context / profile / pin band (unchanged) |
| 2 | **frequency (capped 5)** | **effective recency** = ExecutedAt + 30min if same directory |
| 3 | recency (tiebreak only) | **frequency** (tiebreak only) |
| 4 | display text | display text |

Two decisions worth naming:

- **Frequency moved out of the score entirely**, onto `AssistSuggestion.Frequency`. A
  term inside the score is necessarily applied *before* the sort keys that follow it, so
  leaving it there at any weight would have kept it a driver.
- **The same-directory boost is a recency bonus of 30 minutes, not a band.** As a band,
  cwd would simply replace frequency as the thing that outranks recency, and the same
  complaint would come back in a new costume - a same-dir command from last Tuesday
  above one from thirty seconds ago next door. As a time offset the two signals stay
  commensurable: a same-dir entry ranks as if it were half an hour newer, so it wins
  against anything staler than that and loses to anything fresher. Half an hour is
  roughly "the current sitting".

**Text-query ranking is deliberately unchanged.** With a query on the line the user has
narrowed the field themselves, the text-match tiers dominate, and frequency is a fair
way to choose between two rows that match equally well.

**Made legible**, because an ordering nobody can see is an ordering nobody trusts:

- Metadata timestamps are relative - "2m ago", "yesterday" - instead of
  `Used 2026-08-04 15:23`. New `AssistRelativeTime`, with `now` passed in so the buckets
  are testable. The working directory stays.
- Badges are now in the order the sort consulted the signals: **"Recent"**, then
  **"Same dir"** (renamed from "Same cwd"), then **"Frequent"** demoted to the secondary
  signal it now is. His rows were badged accurately; the ordering they described was the
  thing he was complaining about.

---

## 3. "Suggestion is not readable"

**Diagnosis (confirmed).** His bubble read `Suggest | dock | doc...` - the suggestion
ellipsised to six characters while the hint strip kept its full width. On the Fix bubble
"Did you mean git?" got as far as "Di...".

The layout said so explicitly. `CommandAssistBubbleView` was
`ColumnDefinitions="Auto,Auto,*,Auto"`: the summary sat in the one `*` column with no
floor, while the mode label, the query and the hint strip sat in `Auto` columns that take
their desired width first. The suggestion was the only thing that could shrink.

**Fix**, in priority order:

1. The content column gets `MinWidth=150` that chrome cannot take, and the query column
   is capped at 130 so a long failed command cannot crowd out the fix for it.
2. The hint strip collapses **progressively** instead of all-or-nothing: full text ->
   keys only (`Up/Down | Ctrl+Enter | Esc`) -> gone. New `AssistHintDetail` enum and a
   420px threshold in the anchor calculator. The single boolean this replaces went
   straight from a ~200px strip to nothing at the 320px compact threshold, and the
   owner's pane was in the range *between*, where nothing was hidden and the suggestion
   was unreadable anyway.
3. **Fish-style completion - decided yes, and it is the biggest single win.** When the
   top suggestion extends the query, the summary carries only the tail: `doc` in white
   followed immediately by `ker compose up` in the suggestion colour reads as one string.
   It roughly doubles the useful width of the column at no cost, because nothing was
   lost. Conditioned on the query actually being rendered - a bare tail with its head
   suppressed by the compact layout would be gibberish.

The existing narrow-floor test asserted that *collapsing* the hint gave the summary its
width back, with a negative control requiring the un-collapsed case to be less than half
as wide. That test now asserts the floor itself and the negative control is inverted: the
two measurements must be close, because the hint no longer decides how much of the
suggestion is readable.

---

## 4. "Fix comes sometimes when it is not needed"

His screenshot: `Fix | print -l $precmd_functions | Di...`

Two bugs in one row.

**(a) The bubble echoed the failed command as its headline.** Partly a diagnosis
correction: the brief said the bubble "displays the FAILED COMMAND text instead of the
suggested fix". The suggestion was in fact present - as `Di...`. The real fault is that
`ApplyHelperSuggestions` puts the mode's subject in the query field for both Help and Fix,
which is right for Help (the thing you asked about is the caption) and wrong for Fix: the
command that failed is already on screen, in the scrollback, in full, directly above the
bubble. So Fix now suppresses the query in the bubble and gives that width to the
suggestion. The popup still shows the failed command, where there is room for both.

**(b) The noise floor.** `HandleCommandFailureAsync` surfaced a bubble for *any*
non-empty insight list, so every non-zero exit in the session produced one.

**The floor chosen: provenance, not confidence.**
`CommandAssistModeRouter.ShouldSurfacePassiveFix` admits a row if and only if a recogniser
in the table produced it (`RecognizerId != null`) - something read the output tail and
recognised what it said. Every row the owner complained about came from
`HeuristicErrorInsightService`'s *fallback* rather than the table: the "output matched
nothing" correction at 0.40, and the uninformed no-output guess at 0.55/0.70.

**This was first implemented as "confidence >= Plausible (0.55)" - the brief's suggested
rung - and that version is wrong in both directions.** Recording it because the second
half is not obvious:

- *Too permissive.* The uninformed fallback is priced at `Likely` (0.70) when it captured
  no output at all - deliberately, since with nothing to read a name-similarity guess is
  the best answer available. But "best available" is not "worth interrupting for", and
  clearing a bar is not the same as having read anything.
- *Too strict, and this is what caught it.* `Explanatory` (0.40) is what the table itself
  uses for a **recognised** failure that has no single command to run. `git status`
  outside a working tree, answered with "This directory is not inside a Git repository",
  is exactly what this feature is for - and the confidence version suppressed it.
  `PaneCommandOutputCaptureTests.AFailureWithOnlyAnExplanation_ShowsTheBubbleWithoutOpeningThePopup`
  failed, which is the test doing its job.

Confidence measures how sure a recogniser is of its *remedy*; it was never a measure of
whether anything was *understood*. It still decides whether the popup opens over the
user's next command (`ChooseModeForFailure`, 0.8), which is the interruption that
actually costs something. `PassiveFixConfidenceFloor` survives as a defensive lower bound
at the table's own weakest rung.

Nothing is discarded: the insights are still computed and Fix is still reachable by an
explicit `Ctrl+Space` after a failure. What the user no longer gets is a guess volunteered
over every command that exits non-zero. A suggestion surface that is wrong a third of the
time trains people to ignore it, and then it is worth nothing on the occasion it is right.

---

## 5. "It suggests gti when I was writing gti"

**Diagnosis (confirmed).** He mistyped `gti status`, it was captured like any other
command, and on his next `gt` it was offered straight back.

**Fix.** Capture is not the bug - the entry is a true record of what was run, and deleting
it would make history disagree with the scrollback. So the flag suppresses the *offer* and
leaves the record: `CommandHistoryEntry.IsInvalidCommand`, trailing and defaulted false,
so the JSONL format is unchanged and lines written before this PR deserialise to false.

Two signals set it, and both are needed:

- **Exit code 127**, the POSIX convention, patched in `CapturePipeline` where the exit
  code already lands. Covers bash, zsh, fish.
- **The Fix recogniser's classification**, threaded back through
  `CapturePipeline.MarkLastCommandInvalidAsync`. PowerShell reports 1 for an unresolved
  name and is indistinguishable from any other failure by exit code alone, so on Windows
  the only thing that knows a typo happened is the recogniser that read
  "The term 'gti' is not recognized" out of the output tail. `CommandFixSuggestion` gains
  `RecognizerId` to carry this, stamped centrally in `HeuristicErrorInsightService` so a
  new table entry cannot forget it.

`MarkLastCommandInvalidAsync` targets **only** the completed entry, never the pending one.
A failure analysis is always preceded by the completion that reported the exit code, so
the completed entry is the right target by construction; falling back to the pending entry
would risk the one outcome worse than suggesting a typo - silently suppressing a command
that *works*, because an analysis of the previous line arrived after the next had been
typed. The store patch latches rather than assigns, so the two signals are safe in either
order.

**Excluded everywhere**, including an explicit text search for the typo's own text, as the
brief specifies. There is no query for which the honest answer is a misspelling. The
filter runs per entry and *before* the grouping, so a later real entry with the same text
ranks normally - installing the thing you kept mistyping brings it back.

---

## 6. Dual-surface bug

**Diagnosis (confirmed), and it was one line.** `CommandAssistBarViewModel.SyncPresentationState`
had `Bubble.IsVisible = IsVisible` against `Popup.IsVisible = IsVisible && IsPopupOpen`,
so opening the popup put both surfaces on screen. His screenshot shows a
`History | vim .env | Enter insert` bubble below an open History popup whose top row is
the same `vim .env`.

**Fix, and the decision.** The popup wins and the bubble hides, rather than the bubble
becoming a slim caption attached to the popup. The popup already renders the mode, the
query, every row including the one the bubble was summarising, and a footer hint with room
for the full text - a caption would have nothing left to say that is not directly above
it. It is also the only option that cannot introduce a new layout to get wrong at a narrow
width, which is what the rest of this PR is about.

---

## Plus: integration status indicator (owner-approved)

A small chip reading **"integrated"** or **"basic"**, in the bubble beside the hint strip
and in the popup footer, with a tooltip explaining what each means.

The state was already known - `AssistSessionContext.IsShellIntegrationLive`, the same
disjunction the capture pipeline gates on - and simply had no way to reach the screen, so
"is the shell integration script working?" was answerable only by running a command and
seeing whether anything got captured.

Deliberately not an alert. A markless session is a supported, working configuration -
cmd.exe is never going to emit OSC 133 - so "basic" states which mode you are in rather
than warning that something is broken. It is dropped from the bubble before the hint
strip's last rung, because it is the more skippable of the two; the popup keeps it at
every width, since that is the surface someone is looking at when a Ctrl+R list is shorter
than they expected.

---

## Verification

**Build:** clean build of `NovaTerminal.App` and `NovaTerminal.App.Tests`, 0 errors.

**Tests** (App.Tests run per namespace - the whole-assembly run wedges on this box after
"Starting:" with no test output, which is the pre-existing solution-test wedge):

| Suite | Result |
|---|---|
| `NovaTerminal.Tests.CommandAssist` | 823 passed |
| `NovaTerminal.Tests.CommandAssist.ShellIntegration` | 179 passed |
| `NovaTerminal.Tests.CommandAssist.ShellIntegration.Integration` | 39 passed (11 skipped) |
| `NovaTerminal.Tests.Controls` | 166 passed |
| `NovaTerminal.AppTests.AgentHost` | 115 passed |
| `NovaTerminal.Tests` (root) | 289 passed |
| `NovaTerminal.Tests.Rendering` | 7 passed |
| `NovaTerminal.Tests.Performance` | 15 passed |
| `NovaTerminal.VT.Tests` | 362 passed |
| `NovaTerminal.Architecture.Tests` | 33 passed |
| **Total** | **2028 passed, 0 failed** |

`NovaTerminal.Tests.Ssh` hangs on this box. It references none of the code this PR
touches (checked), and the namespace opens network connections; treated as pre-existing
and environmental rather than a regression.

**Mutation checks** - each of the three load-bearing behaviours has a test that fails if
the fix is reverted:

| Mutation | Test that fails |
|---|---|
| Restore frequency to the empty-query score | `GetSuggestions_WithAnEmptyQuery_RanksTheMostRecentCommandAboveTheMostFrequentOne` |
| Drop the `IsInvalidCommand` filter in `BuildHistorySuggestions` | `GetSuggestions_NeverOffersACommandTheShellCouldNotResolve` |
| Drop `IsRecognized` from `ShouldSurfacePassiveFix` | `ShouldSurfacePassiveFix_ForAnUnrecognizedGuess_IsFalse` (all three rows) |

Additional coverage: the same-directory bonus is pinned in both directions (it lifts a
20-minute-old same-dir entry over a 5-minute-old one elsewhere, and does *not* lift a
3-hour-old one), the fish-style continuation is pinned including the compact-layout case
where it must not apply, the Fix bubble's headline, the single-surface rule, the terse
hint rung, the chip, the relative-time buckets, and the late-classification guard that
stops a stale typo analysis landing on a newer command.

**Live GUI verification: not yet run.** The machine was in active use (video call in
progress) when I reached this step, and the pass needs to drive the app with global
keystrokes - Ctrl+R, typed commands - which would have gone to whatever window had focus.
I stopped and asked rather than risk typing into a meeting window. An isolated instance
(`NOVATERM_APPDATA_ROOT` pointed at a scratch directory) was launched and confirmed to
start cleanly with the native DLLs present, then shut down so it would stop locking build
outputs.

The seven scenarios still to run:
1. commands in dir A, `cd` to dir B, one command, `Ctrl+R` -> B's command and recent ones
   on top, relative times visible
2. narrow pane, prefix with a long history match -> suggestion readable, hints yielded
3. a failing-but-not-typo command -> no Fix bubble (or one that meets the floor)
4. `gti status` -> Fix bubble reading "Did you mean git?"
5. after that failure, type `gt` -> `gti status` not suggested
6. `Ctrl+R` popup open -> exactly one surface visible
7. integrated session shows "integrated"; a cmd.exe session shows "basic"

---

## Not done

- Not merged, as instructed.
- Nothing pushed to `main`.
