### PR TITLE
fix(command-assist): accept works with PSReadLine predictions, direct bubble accept, staged Esc

### DIFF
--- a/src/NovaTerminal.App/CommandAssist/Views/CommandAssistBubbleView.axaml
+++ b/src/NovaTerminal.App/CommandAssist/Views/CommandAssistBubbleView.axaml
@@ -45,6 +45,7 @@
                 <ColumnDefinition Width="*" MinWidth="150"/>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
             <TextBlock x:Name="BubbleModeLabelText"
@@ -75,8 +76,12 @@
                 The integration chip (owner-approved addition). Deliberately the quietest thing on the
                 row: it answers "is the shell integration script working?" once per session and then
                 has nothing further to say, so it is sized and coloured to be findable rather than
-                noticed. Dropped before the hint strip's last rung, because it is the more skippable
-                of the two.
+                noticed.
+
+                The labelled form yields at the same width the hint strip's verbs do; what replaces it
+                is BubbleIntegrationGlyph below rather than nothing. See
+                CommandAssistBubbleViewModel.IntegrationGlyphText - dropping it whole is why the owner
+                never saw this chip once in a round of dogfooding.
             -->
             <Border Grid.Column="3"
                     x:Name="BubbleIntegrationChip"
@@ -114,6 +119,22 @@
                        FontSize="11"
                        VerticalAlignment="Center"
                        TextTrimming="CharacterEllipsis"/>
+
+            <!--
+                The collapse-exempt integration indicator. Last column, so it is the one thing whose
+                position does not move as the rest of the row gives up width, and it is one character
+                wide - less than the gap between two hint clauses, which is what makes exempting it
+                affordable. Same tooltip as the labelled chip; exactly one of the two is ever visible.
+            -->
+            <TextBlock Grid.Column="5"
+                       x:Name="BubbleIntegrationGlyph"
+                       Text="{Binding IntegrationGlyphText}"
+                       IsVisible="{Binding ShowIntegrationGlyph}"
+                       ToolTip.Tip="{Binding IntegrationStatusTooltip}"
+                       Margin="8,0,0,0"
+                       Foreground="#8B96A5"
+                       FontSize="10"
+                       VerticalAlignment="Center"/>
         </Grid>
     </Border>
 </UserControl>

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -4202,7 +4202,8 @@ namespace NovaTerminal.Controls
                     Text: line.Text,
                     CursorOffset: line.CursorOffset,
                     IsMultiline: line.IsMultiline,
-                    RightPromptTrimmed: line.RightPromptTrimmed)
+                    RightPromptTrimmed: line.RightPromptTrimmed,
+                    TextAfterCursorIsGhost: line.TextAfterCursorIsGhost)
                 : null;
         }
 

--- a/src/NovaTerminal.CommandAssist/Application/AssistQuerySnapshot.cs
+++ b/src/NovaTerminal.CommandAssist/Application/AssistQuerySnapshot.cs
@@ -39,11 +39,19 @@ namespace NovaTerminal.CommandAssist.Application;
 /// part of it that may not be what the user typed. Diagnostic only - see
 /// <see cref="IsUsableAsTypedPrefix"/> for why insertion does not branch on it.
 /// </param>
+/// <param name="TextAfterCursorIsGhost">
+/// The characters between <paramref name="CursorOffset"/> and the end of <paramref name="Text"/> are a
+/// shell's inline prediction painted past the cursor (PSReadLine's <c>InlineView</c>, fish's
+/// autosuggestion), not text the user typed. They are still present in <paramref name="Text"/> - this
+/// says what they are. See <c>NovaTerminal.VT.GridQueryReader.IsGhostSuffix</c> for the rule that sets
+/// it and <see cref="TypedPrefix"/> for the projection that acts on it.
+/// </param>
 public readonly record struct AssistQuerySnapshot(
     string Text,
     int CursorOffset,
     bool IsMultiline,
-    bool RightPromptTrimmed)
+    bool RightPromptTrimmed,
+    bool TextAfterCursorIsGhost = false)
 {
     /// <summary>
     /// Whether <see cref="Text"/> may be treated as a prefix the user typed and left the cursor at
@@ -84,9 +92,40 @@ public readonly record struct AssistQuerySnapshot(
     /// Windows PowerShell 5.1 leaves it painted. Same prompt, same shell family, opposite behaviour -
     /// which is what the owner saw.
     /// </para>
+    /// <para>
+    /// <strong>An inline prediction no longer counts as "the cursor is not at the end" (dogfood round
+    /// 4).</strong> The cursor test asks one question - would appending land text in the middle of what
+    /// the user typed - and a prediction painted past the cursor is not something the user typed. It is
+    /// display-only: the characters live in the shell's suggestion buffer, never in its input buffer, and
+    /// typing one more character makes the line editor recompute or discard them. So appending a suffix
+    /// over a ghost is exactly as safe as appending to a line with nothing after the cursor at all, and
+    /// <see cref="TextAfterCursorIsGhost"/> is the reader having <em>proved</em> which of the two
+    /// readings the cells are. Before this, "prediction" and "mid-line cursor" were indistinguishable and
+    /// refusing both was the only safe answer - which on pwsh with predictions on (the default) meant
+    /// refusing on every prompt, i.e. accept never worked. The proof, and the argument for why the
+    /// classification errs towards <see langword="false"/>, are on
+    /// <c>NovaTerminal.VT.GridQueryReader.IsGhostSuffix</c>. When the reader is not sure, the flag is
+    /// clear and this refuses exactly as it always did.
+    /// </para>
     /// </remarks>
     public bool IsUsableAsTypedPrefix =>
-        !IsMultiline && CursorOffset == Text.Length;
+        !IsMultiline && (CursorOffset == Text.Length || TextAfterCursorIsGhost);
+
+    /// <summary>
+    /// The part of <see cref="Text"/> the user actually typed: the whole line normally, and everything
+    /// left of the cursor when the reader proved the rest is a ghost.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is what a suffix-append insertion must be computed against, and it is deliberately distinct
+    /// from both of its neighbours. <see cref="Text"/> includes the prediction, so appending against it
+    /// would compute a delta against the shell's guess. <see cref="TextBeforeCursor"/> always truncates
+    /// at the cursor, which is right for ranking but wrong for insertion on a mid-line cursor, where the
+    /// text to the right is real and the append must be refused rather than measured. This truncates
+    /// only on the proof, and <see cref="IsUsableAsTypedPrefix"/> gates the rest.
+    /// </para>
+    /// </remarks>
+    public string TypedPrefix => TextAfterCursorIsGhost ? TextBeforeCursor : Text;
 
     /// <summary>
     /// <see cref="Text"/> up to the cursor: what the user has actually put on the line to the left of

--- a/src/NovaTerminal.CommandAssist/Application/AssistSessionStateMachine.cs
+++ b/src/NovaTerminal.CommandAssist/Application/AssistSessionStateMachine.cs
@@ -356,6 +356,50 @@ internal sealed class AssistSessionStateMachine
     public void Dismiss() => State = AssistSessionState.Hidden;
 
     /// <summary>
+    /// Escape's first stage in the passive flow: closes an uninvited popup and leaves the bubble it
+    /// grew out of on screen. Returns <see langword="false"/> - changing nothing - in every other
+    /// state, which is the caller's signal to fall through to <see cref="DismissForCurrentCommand"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Dogfood round 4, item 3.</strong> The passive flow reaches its popup by one keystroke -
+    /// <c>Down</c> on a bubble the user did not ask for - and Escape used to undo far more than that
+    /// one keystroke: it hid everything <em>and</em> took
+    /// <see cref="IsPassiveSurfaceSuppressed"/>, so the suggestion was gone for the rest of the command
+    /// line. The owner reported it as "Esc kills everything". A key that enters a surface and a key
+    /// that leaves it should be inverses, so <c>Down</c> now has one.
+    /// </para>
+    /// <para>
+    /// <strong><see cref="AssistSessionState.PassivePopup"/> only, deliberately.</strong> The other
+    /// popups are all surfaces the user summoned by name - <c>Ctrl+Space</c>, <c>Ctrl+R</c>, Help, a
+    /// confident Fix - and for those Escape means "I am done with the thing I asked for", so closing
+    /// outright is the answer they already give and the one every other list in the product gives.
+    /// Staging them would cost a second keypress to close something the user opened deliberately and
+    /// would make Escape's meaning depend on which surface happened to be up.
+    /// <see cref="AssistSessionState.FixPopup"/> is out for the same reason even though
+    /// <see cref="AssistSessionState.FixHint"/> can reach it: a Fix popup is on screen after a command
+    /// failed, where the user's next act is far more likely to be "clear this" than "show me less of
+    /// it".
+    /// </para>
+    /// <para>
+    /// Nothing else is touched. In particular this does <em>not</em> set
+    /// <see cref="IsPassiveSurfaceSuppressed"/> - the whole point is that the suggestion survives - and
+    /// it does not clear the selection, so the bubble goes on describing the row the user browsed to
+    /// and the insert chord goes on inserting that same row.
+    /// </para>
+    /// </remarks>
+    public bool TryCollapsePopupToBubble()
+    {
+        if (State != AssistSessionState.PassivePopup)
+        {
+            return false;
+        }
+
+        State = AssistSessionState.PassiveBubble;
+        return true;
+    }
+
+    /// <summary>
     /// The user dismissed the surface with Escape: hide it, and keep the passive bubble down for the
     /// rest of this command line.
     /// </summary>

--- a/src/NovaTerminal.CommandAssist/Application/CapturePipeline.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CapturePipeline.cs
@@ -53,7 +53,7 @@ internal sealed class CapturePipeline
     /// exactly as it does for a command that ran and failed. That gap is why the flag has a second
     /// source - see <see cref="MarkLastCommandInvalidAsync"/>.
     /// </remarks>
-    internal const int CommandNotFoundExitCode = 127;
+    internal const int CommandNotFoundExitCode = CommandHistoryEntry.CommandNotFoundExitCode;
 
     private string? _pendingEntryId;
     private string? _pendingCommandText;
@@ -226,7 +226,15 @@ internal sealed class CapturePipeline
     /// previous line arrived after the next had been typed.
     /// </para>
     /// </remarks>
-    public async Task MarkLastCommandInvalidAsync()
+    /// <param name="unresolvedCommandToken">
+    /// The name the shell could not resolve when the recogniser established it is the command's own
+    /// first token, or <see langword="null"/>. Non-null propagates the classification to every older
+    /// history entry starting with that word - see
+    /// <c>IHistoryStore.TryMarkInvalidCommandsByFirstTokenAsync</c>. This is what makes the flag reach
+    /// the owner's pre-existing <c>gti status</c> entries, which were captured before the flag existed
+    /// and would otherwise have needed the typo retyped once per distinct line to suppress.
+    /// </param>
+    public async Task MarkLastCommandInvalidAsync(string? unresolvedCommandToken = null)
     {
         string? entryId = _lastCompletedEntryId;
         if (string.IsNullOrWhiteSpace(entryId))
@@ -237,6 +245,14 @@ internal sealed class CapturePipeline
         try
         {
             await _historyStore.TryMarkInvalidCommandAsync(entryId);
+
+            // After the entry itself, and in the same best-effort block: the just-captured entry is the
+            // one the user can see the consequence of, so it is flagged first and a failure in the
+            // sweep cannot cost it.
+            if (!string.IsNullOrWhiteSpace(unresolvedCommandToken))
+            {
+                await _historyStore.TryMarkInvalidCommandsByFirstTokenAsync(unresolvedCommandToken!);
+            }
         }
         catch
         {

--- a/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
@@ -801,9 +801,20 @@ public sealed class CommandAssistController
         //
         // Best-effort and deliberately not awaited into the surface decision below: failing to mark a
         // typo must not also cost the user the fix suggestion for it.
-        if (fixes.Any(item => item.IsCommandNotFound))
+        //
+        // The token is threaded too, when the recogniser found the unresolved name in the command
+        // position: the classification is a fact about the name rather than about this one execution,
+        // so it is applied to every older entry that starts with it (dogfood round 4, item 4a). Without
+        // that, the owner's history - captured before the flag existed - kept offering him every
+        // `gti status` he had ever run until he retyped each one.
+        CommandFixSuggestion[] notFound = fixes.Where(item => item.IsCommandNotFound).ToArray();
+        if (notFound.Length > 0)
         {
-            await _capturePipeline.MarkLastCommandInvalidAsync();
+            string? unresolvedToken = notFound
+                .Select(item => item.UnresolvedCommandToken)
+                .FirstOrDefault(token => !string.IsNullOrWhiteSpace(token));
+
+            await _capturePipeline.MarkLastCommandInvalidAsync(unresolvedToken);
         }
 
         // Kept symmetrical with Help even though neither Fix branch below can currently render it:

--- a/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
@@ -528,10 +528,19 @@ public sealed class CommandAssistController
     }
 
     /// <summary>
-    /// The user pressed Escape. Takes the surface down, and keeps the passive bubble down for the rest
-    /// of this command line.
+    /// The user pressed Escape. In the passive flow this is staged: the first press closes the popup
+    /// back to the bubble it came from, and the second takes the surface down and keeps it down for the
+    /// rest of this command line.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// <strong>The staging (dogfood round 4, item 3).</strong> <c>Down</c> opens the passive popup in
+    /// one keystroke, so Escape needs to be able to undo one keystroke; before this it undid the whole
+    /// command line's worth of assist, and the owner's report was that Escape "kills everything". The
+    /// scope of the first stage is <see cref="AssistSessionStateMachine.TryCollapsePopupToBubble"/>,
+    /// which is passive-popup-only - the surfaces the user summoned by name still close outright on the
+    /// first press. The second press lands here as an ordinary bubble Escape, unchanged.
+    /// </para>
     /// <para>
     /// The per-command scope is V2 Phase 3b's, and it is what makes the passive bubble dismissible in
     /// any useful sense: before it, Escape hid a surface the next keystroke rebuilt. Explicit surfaces
@@ -565,6 +574,16 @@ public sealed class CommandAssistController
             }
 
             return false;
+        }
+
+        // Stage one: an uninvited popup collapses back to its bubble. Nothing else moves - the rows,
+        // the selection and the visibility all survive, which is what makes the suggestion still be
+        // there afterwards. No CancelPending either: a refresh already on its way is still wanted by
+        // the bubble that stays on screen.
+        if (_state.TryCollapsePopupToBubble())
+        {
+            ViewModel.IsPopupOpen = false;
+            return true;
         }
 
         _suggestionOrchestrator.CancelPending();

--- a/src/NovaTerminal.CommandAssist/Application/CommandAssistInsertionPlanner.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CommandAssistInsertionPlanner.cs
@@ -67,7 +67,11 @@ public static class CommandAssistInsertionPlanner
             return false;
         }
 
-        string text = line.Text;
+        // TypedPrefix, not Text: on a line whose tail the reader classified as an inline prediction the
+        // two differ, and measuring the delta against Text would compute it against the shell's guess -
+        // sending nothing when the prediction happens to match the suggestion, and refusing whenever it
+        // does not. The ghost is display-only; the typed characters are the line.
+        string text = line.TypedPrefix;
         if (text.Length == 0)
         {
             // An empty line is a fact here, not an absence of one: the grid was read and the line

--- a/src/NovaTerminal.CommandAssist/Domain/CommandErrorRecognizers.cs
+++ b/src/NovaTerminal.CommandAssist/Domain/CommandErrorRecognizers.cs
@@ -131,6 +131,11 @@ public static partial class CommandErrorRecognizers
 
         bool tokenIsTheCommand = string.Equals(token, signal.PrimaryToken, StringComparison.OrdinalIgnoreCase);
 
+        // Published only when the unresolved name is the command line's own first token. See
+        // CommandFixSuggestion.UnresolvedCommandToken: the consumer flags every history entry starting
+        // with this word, so a token that came from inside the command must not be carried.
+        string? unresolvedCommandToken = tokenIsTheCommand ? token : null;
+
         string? corrected = FixKnownCommands.TryCorrect(token, out int distance);
         if (corrected != null)
         {
@@ -166,6 +171,17 @@ public static partial class CommandErrorRecognizers
                 Description: "The shell searched PATH and found nothing by that name.",
                 Confidence: Explanatory,
                 Badges: ["Fix", "PATH"]));
+        }
+
+        // Stamped once at the exit rather than at each construction, for the reason RecognizerId is
+        // stamped centrally: a fix added to this method later would otherwise silently omit it, and the
+        // omission is invisible (the typo suppression just quietly stops reaching older entries).
+        if (unresolvedCommandToken != null)
+        {
+            for (int i = 0; i < results.Count; i++)
+            {
+                results[i] = results[i] with { UnresolvedCommandToken = unresolvedCommandToken };
+            }
         }
 
         return results;

--- a/src/NovaTerminal.CommandAssist/Domain/IHistoryStore.cs
+++ b/src/NovaTerminal.CommandAssist/Domain/IHistoryStore.cs
@@ -46,5 +46,31 @@ public interface IHistoryStore
     /// </remarks>
     Task<bool> TryMarkInvalidCommandAsync(string entryId, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Marks every stored entry whose command line starts with <paramref name="firstToken"/> as a
+    /// command the shell could not resolve, and reports how many were newly flagged.
+    /// </summary>
+    /// <param name="firstToken">
+    /// The unresolved program name, compared against <c>CommandHistoryEntry.FirstToken</c> of each
+    /// entry. Blank does nothing.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// <strong>Dogfood round 4, item 4a.</strong> The per-entry flag only ever described the entry the
+    /// classification arrived with, so a history written before the flag existed - which is every
+    /// user's history, and was certainly the owner's - kept every one of its typos eligible. Learning
+    /// that <c>gti</c> is not a program is a fact about the name, not about one execution of it, so it
+    /// applies to every line that starts with that name.
+    /// </para>
+    /// <para>
+    /// <strong>The caller must have established that the unresolved name is the command's own first
+    /// token.</strong> A <c>command not found</c> raised from inside <c>npm run build</c> names a token
+    /// that is not <c>npm</c>, and flagging by first token there would suppress every <c>npm</c> line
+    /// in the user's history. See <c>CommandFixSuggestion.UnresolvedCommandToken</c>, which is only
+    /// populated when the recogniser found the missing name in the command position.
+    /// </para>
+    /// </remarks>
+    Task<int> TryMarkInvalidCommandsByFirstTokenAsync(string firstToken, CancellationToken cancellationToken = default);
+
     Task ClearAsync(CancellationToken cancellationToken = default);
 }

--- a/src/NovaTerminal.CommandAssist/Models/CommandFixSuggestion.cs
+++ b/src/NovaTerminal.CommandAssist/Models/CommandFixSuggestion.cs
@@ -19,13 +19,29 @@ namespace NovaTerminal.CommandAssist.Models;
 /// table entry cannot forget to set it.
 /// </para>
 /// </param>
+/// <param name="UnresolvedCommandToken">
+/// The name the shell could not resolve, but <em>only</em> when that name is the command line's own
+/// first token. <see langword="null"/> otherwise, including for every recogniser that is not
+/// command-not-found.
+/// <para>
+/// <strong>Dogfood round 4, item 4a.</strong> It exists to carry one fact to
+/// <c>IHistoryStore.TryMarkInvalidCommandsByFirstTokenAsync</c>, which flags every older history entry
+/// beginning with the same word. The "only when it is the first token" restriction is the whole safety
+/// argument: <c>npm run build</c> can raise a command-not-found for a token that is not <c>npm</c>, and
+/// propagating <em>that</em> by first token would suppress every <c>npm</c> line the user has ever run.
+/// The recogniser already computes the distinction (it needs it to decide whether the fix rewrites the
+/// command or replaces a word inside it); this publishes it rather than recomputing it downstream from
+/// less information.
+/// </para>
+/// </param>
 public sealed record CommandFixSuggestion(
     string Title,
     string SuggestedCommand,
     string? Description,
     double Confidence,
     IReadOnlyList<string>? Badges = null,
-    string? RecognizerId = null)
+    string? RecognizerId = null,
+    string? UnresolvedCommandToken = null)
 {
     /// <summary>
     /// Whether a recogniser in the table stood behind this, as opposed to the fallback guess.

--- a/src/NovaTerminal.CommandAssist/Models/CommandHistoryEntry.cs
+++ b/src/NovaTerminal.CommandAssist/Models/CommandHistoryEntry.cs
@@ -22,6 +22,14 @@ namespace NovaTerminal.CommandAssist.Models;
 /// Declared last with a default so the JSONL format is unchanged for existing lines: a record
 /// written before this round simply has no such property and deserialises to <see langword="false"/>.
 /// </para>
+/// <para>
+/// <strong>Two ways it reaches entries written before the flag existed (dogfood round 4, item 4).</strong>
+/// The flag shipped with no way to look backwards, so the owner's history - full of the very
+/// <c>gti status</c> lines that motivated it - kept being offered, and the only cure was to run each
+/// typo again. Now <c>JsonlHistoryStore.TryMarkInvalidCommandsByFirstTokenAsync</c> propagates a fresh
+/// classification to every older entry that starts with the same word, and the loader backfills the
+/// exit-code signal - see <c>CommandNotFoundExitCode</c>.
+/// </para>
 /// </param>
 public sealed record CommandHistoryEntry(
     string Id,
@@ -37,4 +45,46 @@ public sealed record CommandHistoryEntry(
     bool IsRedacted,
     CommandCaptureSource Source,
     long? DurationMs,
-    bool IsInvalidCommand = false);
+    bool IsInvalidCommand = false)
+{
+    /// <summary>
+    /// The exit code every POSIX shell uses for "I could not find that program".
+    /// </summary>
+    /// <remarks>
+    /// bash, zsh and fish all report it; PowerShell does not, and reports 1 for an unresolved name
+    /// exactly as it does for a command that ran and failed. That gap is why the flag has a second
+    /// source. Lives on the model rather than on <c>CapturePipeline</c> because the storage layer
+    /// backfills against it too, and two copies of a magic number is how they drift.
+    /// </remarks>
+    public const int CommandNotFoundExitCode = 127;
+
+    /// <summary>
+    /// The first whitespace-delimited word of a command line - the name the shell tried to resolve -
+    /// or an empty string when there is not one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Deliberately naive: no quoting, no environment-variable prefixes, no <c>sudo</c> unwrapping. It
+    /// is used only to answer "is this the same mistyped program name", where the mistyped name is a
+    /// bare word by construction - if it had been quoted or assigned the shell would have resolved
+    /// something. A cleverer parse would widen what the retroactive flag reaches, and this is the one
+    /// operation in the feature that writes to entries the user is not currently looking at.
+    /// </para>
+    /// </remarks>
+    public static string FirstToken(string? commandText)
+    {
+        if (string.IsNullOrWhiteSpace(commandText))
+        {
+            return string.Empty;
+        }
+
+        string trimmed = commandText.TrimStart();
+        int end = 0;
+        while (end < trimmed.Length && !char.IsWhiteSpace(trimmed[end]))
+        {
+            end++;
+        }
+
+        return trimmed[..end];
+    }
+}

--- a/src/NovaTerminal.CommandAssist/Storage/JsonlHistoryStore.cs
+++ b/src/NovaTerminal.CommandAssist/Storage/JsonlHistoryStore.cs
@@ -292,6 +292,72 @@ public sealed class JsonlHistoryStore : IHistoryStore
             cancellationToken);
     }
 
+    /// <remarks>
+    /// <para>
+    /// One superseding record per newly-flagged entry, appended like any other patch, so the format
+    /// and the last-write-wins load rule are unchanged. Entries already carrying the flag are skipped
+    /// rather than rewritten: the common case after the first run is that this finds nothing to do, and
+    /// it must not turn into a file rewrite every time a user retypes the same typo.
+    /// </para>
+    /// <para>
+    /// <strong>Case-insensitive, matching the ranking engine.</strong>
+    /// <c>CommandAssistSuggestionEngine</c> groups history by <c>CommandText</c> under
+    /// <c>OrdinalIgnoreCase</c>, so <c>GTI status</c> and <c>gti status</c> are already one row there.
+    /// Flagging under <c>Ordinal</c> would leave the group's other spelling unflagged and the row would
+    /// still be offered - the suppression has to be at least as wide as the grouping or it does not
+    /// suppress anything. The cost is a case-sensitive filesystem where <c>Foo</c> and <c>foo</c> are
+    /// genuinely different programs, and there the user has already told us <em>one</em> of them does
+    /// not resolve.
+    /// </para>
+    /// </remarks>
+    public async Task<int> TryMarkInvalidCommandsByFirstTokenAsync(
+        string firstToken,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(firstToken))
+        {
+            return 0;
+        }
+
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            Dictionary<string, CommandHistoryEntry> index = await EnsureLoadedUnsafeAsync(cancellationToken);
+
+            List<CommandHistoryEntry> targets = index.Values
+                .Where(entry => !entry.IsInvalidCommand &&
+                                string.Equals(
+                                    CommandHistoryEntry.FirstToken(entry.CommandText),
+                                    firstToken,
+                                    StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            if (targets.Count == 0)
+            {
+                return 0;
+            }
+
+            foreach (CommandHistoryEntry entry in targets)
+            {
+                CommandHistoryEntry updated = entry with { IsInvalidCommand = true };
+
+                // Disk first, then the index, for the same reason as AppendAsync. Per entry rather
+                // than in a batch: a write that fails partway leaves the entries it did reach flagged
+                // on disk and in memory, which is a smaller wrong answer than an index that claims
+                // flags the file does not have.
+                await AppendLineUnsafeAsync(updated, cancellationToken);
+                index[entry.Id] = updated;
+            }
+
+            await CompactIfNeededUnsafeAsync(cancellationToken);
+            return targets.Count;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
     private async Task<bool> TryPatchAsync(
         string entryId,
         Func<CommandHistoryEntry, CommandHistoryEntry> patch,
@@ -503,7 +569,7 @@ public sealed class JsonlHistoryStore : IHistoryStore
                 }
 
                 // Last write wins: a superseding record patches the entry it shares an id with.
-                index[entry.Id] = entry;
+                index[entry.Id] = BackfillInvalidCommand(entry);
             }
         }
         catch (IOException)
@@ -516,6 +582,38 @@ public sealed class JsonlHistoryStore : IHistoryStore
 
         return (index, lineCount, sawCorruptLine, false);
     }
+
+    /// <summary>
+    /// Applies the exit-code half of the command-not-found classification to an entry read off disk
+    /// that predates the flag.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Dogfood round 4, item 4b.</strong> <c>IsInvalidCommand</c> is written at capture time,
+    /// so every line recorded before it existed came back <see langword="false"/> however it had
+    /// failed - including the exit-127 lines whose classification needs no recogniser and no output at
+    /// all. The information was on disk the whole time and simply was not being read.
+    /// </para>
+    /// <para>
+    /// <strong>Exactly the live rule, applied retroactively.</strong> The capture path flags on
+    /// <c>exitCode == 127</c> with no shell test (see
+    /// <c>CapturePipeline.IsCommandNotFoundExit</c>), so this does too. Deliberately not made cleverer
+    /// than its live counterpart: a backfill that flagged more than a fresh capture would have flagged
+    /// is a rule the user cannot have observed the product following, and a program that genuinely
+    /// exits 127 loses a suggestion either way. PowerShell's unresolved names report 1 and are not
+    /// reachable from here at all - the retroactive path
+    /// (<see cref="TryMarkInvalidCommandsByFirstTokenAsync"/>) is what covers those, the next time the
+    /// user reproduces one.
+    /// </para>
+    /// <para>
+    /// In memory only. Nothing is written back, so a load costs no I/O and the derivation stays
+    /// idempotent; compaction persists it if and when it rewrites the file for its own reasons.
+    /// </para>
+    /// </remarks>
+    private static CommandHistoryEntry BackfillInvalidCommand(CommandHistoryEntry entry) =>
+        !entry.IsInvalidCommand && entry.ExitCode == CommandHistoryEntry.CommandNotFoundExitCode
+            ? entry with { IsInvalidCommand = true }
+            : entry;
 
     private async Task AppendLineUnsafeAsync(CommandHistoryEntry entry, CancellationToken cancellationToken)
     {

--- a/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistBarViewModel.cs
+++ b/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistBarViewModel.cs
@@ -576,6 +576,15 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
     /// keyboard's most load-bearing promise; removing it there would make the strip flicker between two
     /// shapes on a browse.
     /// </para>
+    /// <para>
+    /// <strong>Browse is shed before insert (dogfood round 4, item 2).</strong> The terse rung used to
+    /// keep all three clauses and merely drop their verbs, which is the right trade when the three are
+    /// equally learnable and they are not. The owner's report was "no way to put it": he had found
+    /// <c>Down</c> - pressing an arrow key at a prompt is a free experiment anyone runs - and had not
+    /// found the insert chord, which nothing else in a terminal teaches and which no amount of poking
+    /// discovers. So the clause that survives one rung longer is the one the surface cannot be used
+    /// without. The full rung still advertises both.
+    /// </para>
     /// </remarks>
     private string BuildHintText(bool acceptOnEnterArmed, bool isSelectionUpOwned, bool isInsertionAvailable, bool terse)
     {
@@ -594,10 +603,12 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
 
         if (terse)
         {
-            // Keys only. Every clause keeps its meaning - the keys are the information and the verbs
-            // were the padding - at roughly half the width.
+            // Keys only, and browse dropped: at this width the strip has room for the action and the
+            // exit, and the action is the one the user cannot guess. When the line cannot be appended
+            // to there is no action to advertise, so browse comes back rather than leaving a strip
+            // that only says "Esc".
             return isInsertionAvailable
-                ? $"{browse}  |  {labels.Insert}  |  {labels.Dismiss}"
+                ? $"{labels.Insert}  |  {labels.Dismiss}"
                 : $"{browse}  |  {labels.Dismiss}";
         }
 

--- a/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistBarViewModel.cs
+++ b/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistBarViewModel.cs
@@ -39,6 +39,20 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
     /// <summary>The chip text for a session with no marks: capture is heuristic and Fix has no output tail.</summary>
     internal const string BasicStatusText = "basic";
 
+    /// <summary>
+    /// The collapsed form of the integrated chip. A filled dot, chosen over a letter or an icon glyph
+    /// because it renders in every monospace font a terminal user is plausibly running and carries no
+    /// language.
+    /// </summary>
+    internal const string IntegratedStatusGlyph = "●";
+
+    /// <summary>
+    /// The collapsed form of the basic chip: the same dot, hollow. The pair reads as one indicator with
+    /// two states rather than as two unrelated marks, which is the point - "basic" is a mode, not a
+    /// fault, so it gets the same shape rather than a warning sign.
+    /// </summary>
+    internal const string BasicStatusGlyph = "○";
+
     internal const string IntegratedStatusTooltip =
         "Shell integration is live: commands, exit codes and working directories come from the shell itself.";
 
@@ -547,10 +561,16 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
 
         Bubble.IntegrationStatusText = text;
         Bubble.IntegrationStatusTooltip = tooltip;
+        Bubble.IntegrationGlyphText = IsShellIntegrationLive ? IntegratedStatusGlyph : BasicStatusGlyph;
 
-        // Chrome, so it goes at the same width the hint strip goes: the chip answers a question the
-        // user asks once a session, and the suggestion answers one they are asking right now.
-        Bubble.ShowIntegrationStatus = BubbleHintDetail == AssistHintDetail.Full;
+        // The *label* is chrome and goes at the same width the hint strip goes: it answers a question
+        // the user asks once a session, and the suggestion answers one they are asking right now. The
+        // indicator itself does not go, it shrinks to a dot - see
+        // CommandAssistBubbleViewModel.IntegrationGlyphText for why the previous rule (drop it whole)
+        // meant the owner never saw it at all.
+        bool showLabel = BubbleHintDetail == AssistHintDetail.Full;
+        Bubble.ShowIntegrationStatus = showLabel;
+        Bubble.ShowIntegrationGlyph = !showLabel;
 
         Popup.IntegrationStatusText = text;
         Popup.IntegrationStatusTooltip = tooltip;

--- a/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistBubbleViewModel.cs
+++ b/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistBubbleViewModel.cs
@@ -22,6 +22,8 @@ public sealed class CommandAssistBubbleViewModel : INotifyPropertyChanged
     private string _integrationStatusText = string.Empty;
     private string _integrationStatusTooltip = string.Empty;
     private bool _showIntegrationStatus;
+    private string _integrationGlyphText = string.Empty;
+    private bool _showIntegrationGlyph;
 
     public bool IsVisible
     {
@@ -136,13 +138,51 @@ public sealed class CommandAssistBubbleViewModel : INotifyPropertyChanged
     }
 
     /// <summary>
-    /// Whether the chip is rendered. Follows the same width budget as the hint strip: it is chrome,
-    /// and chrome yields to content.
+    /// Whether the <em>labelled</em> chip is rendered. Follows the same width budget as the hint strip:
+    /// it is chrome, and chrome yields to content. When this is false the chip does not disappear - it
+    /// degrades to <see cref="IntegrationGlyphText"/>.
     /// </summary>
     public bool ShowIntegrationStatus
     {
         get => _showIntegrationStatus;
         set => SetField(ref _showIntegrationStatus, value);
+    }
+
+    /// <summary>
+    /// The one-character stand-in for the labelled chip: a filled dot for an integrated session, a
+    /// hollow one for a basic session.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Dogfood round 4, item 5.</strong> The chip was added last round and the owner never saw
+    /// it once, because the two places it lived were both places he was not: the popup footer, which
+    /// only exists while a popup is open, and a bubble slot that the progressive hint collapse dropped
+    /// at his pane width. A status indicator that is only visible at wide widths reports on sessions
+    /// that were never in doubt.
+    /// </para>
+    /// <para>
+    /// So the glyph is exempt from the collapse. It can afford to be: one character costs less width
+    /// than the space between two hint clauses, which is the reason the labelled form had to yield in
+    /// the first place. It carries the same tooltip as the chip, so the full sentence is still one
+    /// hover away, and it is the same fact in the same colour - the degradation is of the label, not of
+    /// the signal.
+    /// </para>
+    /// </remarks>
+    public string IntegrationGlyphText
+    {
+        get => _integrationGlyphText;
+        set => SetField(ref _integrationGlyphText, value);
+    }
+
+    /// <summary>
+    /// Whether the glyph stands in for the chip. Exactly the negation of
+    /// <see cref="ShowIntegrationStatus"/>: one of the two forms is always on screen, never both and
+    /// never neither.
+    /// </summary>
+    public bool ShowIntegrationGlyph
+    {
+        get => _showIntegrationGlyph;
+        set => SetField(ref _showIntegrationGlyph, value);
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/src/NovaTerminal.VT/GridCommandLine.cs
+++ b/src/NovaTerminal.VT/GridCommandLine.cs
@@ -49,11 +49,28 @@ namespace NovaTerminal.VT
     /// viewport row). Shifts under scrollback eviction like any other current-space row index.
     /// </param>
     /// <param name="EndRow">Last row of the span, same addressing space as <paramref name="StartRow"/>.</param>
+    /// <param name="TextAfterCursorIsGhost">
+    /// True when the cells between <paramref name="CursorOffset"/> and the end of
+    /// <paramref name="Text"/> were recognised as a shell's inline prediction - PSReadLine's
+    /// <c>InlineView</c> suggestion, fish's autosuggestion - painted past the cursor rather than as
+    /// text the user typed and moved back through. The characters are still in
+    /// <paramref name="Text"/>: this reports what they are, it does not remove them, because a
+    /// consumer that wants the whole painted line (history, display) still wants them. A consumer
+    /// that wants a <i>typed prefix</i> should take <paramref name="Text"/> up to
+    /// <paramref name="CursorOffset"/> when this is set.
+    /// <para>
+    /// Always <see langword="false"/> when the cursor is at the end of the text (there is nothing
+    /// past it to classify) and when the entry is multiline. The classification rule, and the
+    /// argument for why it errs towards <see langword="false"/>, are on
+    /// <c>GridQueryReader.IsGhostSuffix</c>.
+    /// </para>
+    /// </param>
     public readonly record struct GridCommandLine(
         string Text,
         int CursorOffset,
         bool IsMultiline,
         bool RightPromptTrimmed,
         int StartRow,
-        int EndRow);
+        int EndRow,
+        bool TextAfterCursorIsGhost = false);
 }

--- a/src/NovaTerminal.VT/GridQueryReader.cs
+++ b/src/NovaTerminal.VT/GridQueryReader.cs
@@ -75,6 +75,14 @@ namespace NovaTerminal.VT
     /// for why, and for what consumers may do with it.
     /// </para>
     /// <para>
+    /// <b>Inline predictions.</b> A shell that paints a suggestion past the cursor (PSReadLine's
+    /// <c>InlineView</c>, fish's autosuggestion) puts real cells on the grid that the user never
+    /// typed. The reader still returns them - it reports what is painted - but it also classifies
+    /// them, in <see cref="GridCommandLine.TextAfterCursorIsGhost"/>, using the one signal the grid
+    /// carries: the cells' style. See <c>IsGhostSuffix</c> for the rule and for why every ambiguity
+    /// in it resolves to "not a prediction".
+    /// </para>
+    /// <para>
     /// <b>Known limitation: multiline entries read from an earlier line.</b> The span stops at
     /// the end of the cursor's logical line, so if the user arrows <i>up</i> inside a
     /// continuation entry the reader returns that line alone with
@@ -245,6 +253,16 @@ namespace NovaTerminal.VT
             bool isMultiline = false;
             bool rightPromptTrimmed = false;
 
+            // Style bookkeeping for the ghost-suffix rule (see IsGhostSuffix). Collected in the same
+            // walk that builds the text because the mapping from a text offset back to the cell it
+            // came from is exactly what a second pass would have to reconstruct.
+            var typedStyles = new List<CellStyle>(4);
+            bool pastCursor = false;
+            int typedGlyphs = 0;
+            int suffixGlyphs = 0;
+            bool suffixIsUniform = true;
+            CellStyle suffixStyle = default;
+
             for (int row = startRow; row <= endRow; row++)
             {
                 int firstCol = row == startRow ? mark.Column : 0;
@@ -267,21 +285,55 @@ namespace NovaTerminal.VT
                     if (isCursorRow && col == cursorTextCol)
                     {
                         cursorOffset = text.Length;
+                        pastCursor = true;
                     }
 
-                    if (buffer.GetCellAbsolute(col, row).IsWideContinuation)
+                    TerminalCell cell = buffer.GetCellAbsolute(col, row);
+                    if (cell.IsWideContinuation)
                     {
                         continue; // trailing half of a double-width cell
                     }
 
                     string grapheme = buffer.GetGraphemeAbsolute(col, row);
-                    text.Append(string.IsNullOrEmpty(grapheme) || grapheme == "\0" ? " " : grapheme);
+                    bool isBlankGlyph = string.IsNullOrEmpty(grapheme) || grapheme == "\0" || grapheme == " ";
+                    text.Append(isBlankGlyph ? " " : grapheme);
+
+                    // A space paints no foreground, so it votes on neither region's style. Counting it
+                    // would make every gap between two words of a prediction look like a style change.
+                    if (isBlankGlyph)
+                    {
+                        continue;
+                    }
+
+                    CellStyle style = CellStyle.From(cell);
+                    if (pastCursor)
+                    {
+                        if (suffixGlyphs == 0)
+                        {
+                            suffixStyle = style;
+                        }
+                        else if (!suffixStyle.Equals(style))
+                        {
+                            suffixIsUniform = false;
+                        }
+
+                        suffixGlyphs++;
+                    }
+                    else
+                    {
+                        typedGlyphs++;
+                        if (!typedStyles.Contains(style))
+                        {
+                            typedStyles.Add(style);
+                        }
+                    }
                 }
 
                 if (isCursorRow && cursorOffset < 0)
                 {
                     // Cursor at (or past) the end of the row's content.
                     cursorOffset = text.Length;
+                    pastCursor = true;
                 }
 
                 if (!isLastRow && !wrapped)
@@ -298,14 +350,185 @@ namespace NovaTerminal.VT
 
             TrimBlankTail(text, cursorOffset);
 
+            bool textAfterCursorIsGhost =
+                cursorOffset < text.Length &&
+                !isMultiline &&
+                IsGhostSuffix(typedGlyphs, typedStyles, suffixGlyphs, suffixIsUniform, in suffixStyle);
+
             result = new GridCommandLine(
                 Text: text.ToString(),
                 CursorOffset: cursorOffset,
                 IsMultiline: isMultiline,
                 RightPromptTrimmed: rightPromptTrimmed,
                 StartRow: startRow,
-                EndRow: endRow);
+                EndRow: endRow,
+                TextAfterCursorIsGhost: textAfterCursorIsGhost);
             return true;
+        }
+
+        /// <summary>
+        /// Palette index 8 - "bright black", the classic dark grey.
+        /// </summary>
+        internal const int BrightBlackPaletteIndex = 8;
+
+        /// <summary>First index of the xterm-256 greyscale ramp. PSReadLine's shipped
+        /// <c>InlinePredictionColor</c> is <c>ESC[38;5;238m</c>, which sits inside it.</summary>
+        internal const int GreyscaleRampStart = 232;
+
+        /// <summary>Last index of the xterm-256 greyscale ramp.</summary>
+        internal const int GreyscaleRampEnd = 255;
+
+        /// <summary>
+        /// How far an RGB foreground's channels may spread and still count as grey. A prediction
+        /// colour given as a truecolour value is a neutral grey; 24 tolerates the slightly-warm greys
+        /// some themes use without admitting an actual hue.
+        /// </summary>
+        internal const int MaxGreyChannelSpread = 24;
+
+        /// <summary>
+        /// The brightest channel an RGB foreground may have and still count as recessive. Without
+        /// this, white (<c>#FFFFFF</c>) - which is grey by the spread test and is the single most
+        /// common foreground on a command line - would qualify.
+        /// </summary>
+        internal const int MaxRecessiveChannel = 160;
+
+        /// <summary>
+        /// Whether the cells between the cursor and the end of the line are a shell's inline
+        /// prediction painted past the cursor rather than text the user typed and arrowed back through.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>Why this exists.</b> PSReadLine's inline prediction (<c>PredictionSource
+        /// HistoryAndPlugin</c> + <c>PredictionViewStyle InlineView</c>, on by default for pwsh 7
+        /// users) is painted into the grid as real cells to the right of the cursor. Nothing in the
+        /// VT data model records "these cells are not input", so before this rule the reader
+        /// reported <c>Text</c> running past <c>CursorOffset</c> and every consumer that needed a
+        /// typed prefix - insertion above all - had to refuse. On a shell with predictions on that is
+        /// <i>every</i> prompt, so accept never worked at all. The colour is the only signal on the
+        /// grid that separates the two readings, so the colour is what this reads.
+        /// </para>
+        /// <para>
+        /// <b>The rule.</b> The suffix is classified as a ghost only when all five hold:
+        /// </para>
+        /// <list type="number">
+        /// <item><description><b>Something was typed.</b> At least one non-blank cell before the
+        /// cursor. A cursor at offset 0 with text to its right is <c>Home</c> pressed on a line the
+        /// user composed, and a shell shows no prediction for an empty line, so the ambiguity resolves
+        /// against ghosting.</description></item>
+        /// <item><description><b>The suffix is non-empty</b> - at least one non-blank cell past the
+        /// cursor.</description></item>
+        /// <item><description><b>The suffix is uniform.</b> Every non-blank cell past the cursor
+        /// carries one style. A prediction is painted in a single colour in one write; a line the
+        /// user typed and arrowed back through keeps its syntax highlighting, which changes at every
+        /// token boundary.</description></item>
+        /// <item><description><b>The suffix's style appears nowhere in the typed region.</b> The
+        /// typed region is normally styled too - PSReadLine colours commands, parameters, strings and
+        /// operators differently - so "different from the cell before the cursor" is not enough. This
+        /// is the whole-region test.</description></item>
+        /// <item><description><b>The suffix's style is recessive</b> - faint, italic, or a dim grey
+        /// foreground. See <see cref="IsRecessiveStyle"/>.</description></item>
+        /// </list>
+        /// <para>
+        /// <b>Why condition 5 is not redundant, which is the part worth keeping.</b> Conditions 1-4
+        /// alone accept a case they must not: type <c>echo hello</c>, press <c>Home</c>, then
+        /// <c>Right</c> five times. The typed region is <c>echo</c> in the command colour, the suffix
+        /// is <c>hello</c> in the argument colour - uniform, and absent from the typed region. Under
+        /// conditions 1-4 that reads as a ghost, and an append would splice text into the middle of
+        /// the user's line. Requiring the suffix style to be visually recessive costs nothing on the
+        /// case this feature exists for (a prediction is dim grey by construction: that is how the
+        /// user is meant to tell it apart from what they typed) and rules out every syntax-highlight
+        /// colour, which are chosen to be legible.
+        /// </para>
+        /// <para>
+        /// <b>The failure direction is deliberate.</b> A prediction colour this does not recognise -
+        /// a user who rebound <c>InlinePredictionColor</c> to something vivid - reads as "not a
+        /// ghost", and insertion refuses exactly as it did before. That is one keystroke of
+        /// convenience lost. The opposite error edits the command line the user is about to run.
+        /// When in doubt, not a ghost.
+        /// </para>
+        /// </remarks>
+        private static bool IsGhostSuffix(
+            int typedGlyphs,
+            List<CellStyle> typedStyles,
+            int suffixGlyphs,
+            bool suffixIsUniform,
+            in CellStyle suffixStyle)
+        {
+            return typedGlyphs > 0 &&
+                   suffixGlyphs > 0 &&
+                   suffixIsUniform &&
+                   !typedStyles.Contains(suffixStyle) &&
+                   IsRecessiveStyle(in suffixStyle);
+        }
+
+        /// <summary>
+        /// Whether a style is one a shell would paint a suggestion in rather than one it would paint
+        /// the user's own input in: faint, italic, or a dim grey foreground.
+        /// </summary>
+        /// <remarks>
+        /// The default foreground is never recessive - it is what unstyled input is painted in, and it
+        /// is the one colour a prediction cannot use without becoming indistinguishable from the line.
+        /// </remarks>
+        private static bool IsRecessiveStyle(in CellStyle style)
+        {
+            if (style.IsFaint || style.IsItalic)
+            {
+                return true;
+            }
+
+            if (style.IsDefaultForeground)
+            {
+                return false;
+            }
+
+            if (style.IsPaletteForeground)
+            {
+                long index = style.Foreground & 0xFFFF;
+                return index == BrightBlackPaletteIndex ||
+                       (index >= GreyscaleRampStart && index <= GreyscaleRampEnd);
+            }
+
+            int r = (int)((style.Foreground >> 16) & 0xFF);
+            int g = (int)((style.Foreground >> 8) & 0xFF);
+            int b = (int)(style.Foreground & 0xFF);
+            int max = Math.Max(r, Math.Max(g, b));
+            int min = Math.Min(r, Math.Min(g, b));
+
+            return max - min <= MaxGreyChannelSpread && max <= MaxRecessiveChannel;
+        }
+
+        /// <summary>
+        /// The part of a cell's appearance the ghost rule compares: foreground identity plus the two
+        /// attributes a shell uses to recess text.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Deliberately coarse. <c>Bold</c>, <c>Underline</c>, <c>Inverse</c> and the background are
+        /// all excluded, so two runs that differ only in one of those compare <i>equal</i> - and
+        /// comparing equal is the conservative answer, because condition 4 of
+        /// <see cref="IsGhostSuffix"/> then finds the suffix style in the typed region and refuses.
+        /// Adding attributes would make style classes finer, which makes "appears nowhere in the typed
+        /// region" easier to satisfy and the classification more eager. The rule is written to be hard
+        /// to satisfy.
+        /// </para>
+        /// <para>
+        /// The foreground is normalised: a cell flagged <c>DefaultForeground</c> carries an
+        /// unspecified <c>Fg</c> value, so it is folded to zero and told apart by the flag.
+        /// </para>
+        /// </remarks>
+        private readonly record struct CellStyle(
+            uint Foreground,
+            bool IsPaletteForeground,
+            bool IsDefaultForeground,
+            bool IsItalic,
+            bool IsFaint)
+        {
+            public static CellStyle From(in TerminalCell cell) => new(
+                Foreground: cell.IsDefaultForeground ? 0u : cell.Fg,
+                IsPaletteForeground: cell.IsPaletteForeground,
+                IsDefaultForeground: cell.IsDefaultForeground,
+                IsItalic: cell.IsItalic,
+                IsFaint: cell.IsFaint);
         }
 
         /// <summary>

--- a/tests/NovaTerminal.App.Tests/CommandAssist/AssistContentProviderSeamTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/AssistContentProviderSeamTests.cs
@@ -671,6 +671,9 @@ public sealed class AssistContentProviderSeamTests
         public Task<bool> TryMarkInvalidCommandAsync(string entryId, CancellationToken cancellationToken = default)
             => Task.FromResult(false);
 
+        public Task<int> TryMarkInvalidCommandsByFirstTokenAsync(string firstToken, CancellationToken cancellationToken = default)
+            => Task.FromResult(0);
+
         public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default, bool isInvalidCommand = false)
             => Task.FromResult(false);
 

--- a/tests/NovaTerminal.App.Tests/CommandAssist/AssistSessionStateMachineTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/AssistSessionStateMachineTests.cs
@@ -646,6 +646,69 @@ public sealed class AssistSessionStateMachineTests
         Assert.False(machine.IsUserRequestedSurface);
     }
 
+    // -------------------------------------------- staged Escape (dogfood round 4, item 3)
+
+    /// <summary>
+    /// The first stage, and the only state it applies in. <c>Down</c> on an uninvited bubble opens the
+    /// passive popup in one keystroke, so Escape has to be able to undo one keystroke.
+    /// </summary>
+    [Fact]
+    public void TryCollapsePopupToBubble_FromAPassivePopup_ReturnsToTheBubble()
+    {
+        AssistSessionStateMachine machine = CreateInState(AssistSessionState.PassivePopup);
+
+        Assert.True(machine.TryCollapsePopupToBubble());
+        Assert.Equal(AssistSessionState.PassiveBubble, machine.State);
+
+        // The whole point: the suggestion survives the first Escape, so the passive path is not
+        // suppressed and a refresh may still run.
+        Assert.False(machine.IsPassiveSurfaceSuppressed);
+        Assert.True(machine.AllowsPassiveSuggestions);
+    }
+
+    /// <summary>
+    /// Every other state declines and is left exactly where it was, so the caller falls through to the
+    /// ordinary dismissal. The surfaces the user summoned by name close on the first press, which is
+    /// what Escape means everywhere else in the product.
+    /// </summary>
+    [Theory]
+    [InlineData(AssistSessionState.Hidden)]
+    [InlineData(AssistSessionState.PassiveBubble)]
+    [InlineData(AssistSessionState.ExplicitBubble)]
+    [InlineData(AssistSessionState.ExplicitPopup)]
+    [InlineData(AssistSessionState.HistorySearch)]
+    [InlineData(AssistSessionState.Help)]
+    [InlineData(AssistSessionState.FixHint)]
+    [InlineData(AssistSessionState.FixPopup)]
+    public void TryCollapsePopupToBubble_InEveryOtherState_DeclinesAndChangesNothing(AssistSessionState state)
+    {
+        AssistSessionStateMachine machine = CreateInState(state);
+
+        Assert.False(machine.TryCollapsePopupToBubble());
+        Assert.Equal(state, machine.State);
+    }
+
+    /// <summary>
+    /// The two stages in sequence: popup to bubble, then bubble to gone-for-this-command. The second
+    /// press is an ordinary Escape and takes the suppression the first deliberately did not.
+    /// </summary>
+    [Fact]
+    public void StagedEscape_TakesTwoPressesToSuppressThePassiveSurface()
+    {
+        AssistSessionStateMachine machine = CreateInState(AssistSessionState.PassivePopup);
+
+        Assert.True(machine.TryCollapsePopupToBubble());
+        Assert.Equal(AssistSessionState.PassiveBubble, machine.State);
+        Assert.False(machine.IsPassiveSurfaceSuppressed);
+
+        Assert.False(machine.TryCollapsePopupToBubble());
+        machine.DismissForCurrentCommand();
+
+        Assert.Equal(AssistSessionState.Hidden, machine.State);
+        Assert.True(machine.IsPassiveSurfaceSuppressed);
+        Assert.False(machine.AllowsPassiveSuggestions);
+    }
+
     private static AssistSessionStateMachine CreateInState(AssistSessionState state)
     {
         var machine = new AssistSessionStateMachine();

--- a/tests/NovaTerminal.App.Tests/CommandAssist/AssistShortcutBindingTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/AssistShortcutBindingTests.cs
@@ -357,6 +357,9 @@ public sealed class AssistShortcutBindingTests
         public Task<bool> TryMarkInvalidCommandAsync(string entryId, CancellationToken cancellationToken = default)
             => Task.FromResult(false);
 
+        public Task<int> TryMarkInvalidCommandsByFirstTokenAsync(string firstToken, CancellationToken cancellationToken = default)
+            => Task.FromResult(0);
+
         public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default, bool isInvalidCommand = false)
             => Task.FromResult(false);
     }

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CapturePipelineTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CapturePipelineTests.cs
@@ -662,9 +662,13 @@ public sealed class CapturePipelineTests
     {
         private readonly List<CommandHistoryEntry> _entries = new();
         private readonly List<string> _patchedEntryIds = new();
+        private readonly List<string> _firstTokenSweeps = new();
 
         public IReadOnlyList<CommandHistoryEntry> Entries => _entries;
         public IReadOnlyList<string> PatchedEntryIds => _patchedEntryIds;
+
+        /// <summary>Every first-token sweep the pipeline asked for, in order.</summary>
+        public IReadOnlyList<string> FirstTokenSweeps => _firstTokenSweeps;
 
         public Task AppendAsync(CommandHistoryEntry entry, CancellationToken cancellationToken = default)
         {
@@ -694,6 +698,29 @@ public sealed class CapturePipelineTests
 
             _entries[index] = _entries[index] with { IsInvalidCommand = true };
             return Task.FromResult(true);
+        }
+
+        public Task<int> TryMarkInvalidCommandsByFirstTokenAsync(string firstToken, CancellationToken cancellationToken = default)
+        {
+            _firstTokenSweeps.Add(firstToken);
+
+            int flagged = 0;
+            for (int i = 0; i < _entries.Count; i++)
+            {
+                if (_entries[i].IsInvalidCommand ||
+                    !string.Equals(
+                        CommandHistoryEntry.FirstToken(_entries[i].CommandText),
+                        firstToken,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                _entries[i] = _entries[i] with { IsInvalidCommand = true };
+                flagged++;
+            }
+
+            return Task.FromResult(flagged);
         }
 
         public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default, bool isInvalidCommand = false)
@@ -732,6 +759,9 @@ public sealed class CapturePipelineTests
 
         public Task<bool> TryMarkInvalidCommandAsync(string entryId, CancellationToken cancellationToken = default)
             => Task.FromResult(false);
+
+        public Task<int> TryMarkInvalidCommandsByFirstTokenAsync(string firstToken, CancellationToken cancellationToken = default)
+            => Task.FromException<int>(new InvalidOperationException("simulated write failure"));
 
         public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default, bool isInvalidCommand = false)
             => Task.FromException<bool>(new InvalidOperationException("simulated write failure"));

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistControllerTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistControllerTests.cs
@@ -327,6 +327,80 @@ public sealed class CommandAssistControllerTests
     }
 
     /// <summary>
+    /// The retroactive half (dogfood round 4, item 4a). The owner's history already held <c>gti</c>
+    /// lines from before the flag existed; reproducing the typo once has to suppress all of them, not
+    /// just the line he happened to retype.
+    /// </summary>
+    /// <remarks>
+    /// The old entries are seeded unflagged and with an exit code that carries nothing - which is
+    /// exactly what a PowerShell capture from before this round looks like on disk, and why the
+    /// load-time 127 backfill cannot reach them.
+    /// </remarks>
+    [Fact]
+    public async Task HandleCommandFailureAsync_WhenTheFailureIsCommandNotFound_FlagsOlderEntriesWithTheSameFirstToken()
+    {
+        var store = new InMemoryHistoryStore();
+        store.Seed(
+            CreateEntry("gti log --oneline", DateTimeOffset.Parse("2026-02-01T10:00:00+00:00")),
+            CreateEntry("git status", DateTimeOffset.Parse("2026-02-01T10:01:00+00:00")));
+
+        var controller = CreateController(
+            historyStore: store,
+            errorInsightService: new RecordingErrorInsightService(
+                [new CommandFixSuggestion(
+                    "Did you mean git?",
+                    "git status",
+                    "Closest local match.",
+                    CommandErrorRecognizers.NearCertain,
+                    ["Fix", "Typo"],
+                    RecognizerId: "command-not-found",
+                    UnresolvedCommandToken: "gti")]));
+
+        await controller.HandleEnterAsync("gti status");
+        await controller.HandleCommandFinishedAsync(1);
+        await controller.HandleCommandFailureAsync(
+            CreateFailureContext("gti status", 1, "gti : The term 'gti' is not recognized as a name of a cmdlet"));
+
+        Assert.Equal(new[] { "gti" }, store.FirstTokenSweeps);
+        Assert.True(store.Entries.Single(entry => entry.CommandText == "gti status").IsInvalidCommand);
+        Assert.True(store.Entries.Single(entry => entry.CommandText == "gti log --oneline").IsInvalidCommand);
+
+        // The name is what was learned about, not the prefix: `git` is untouched.
+        Assert.False(store.Entries.Single(entry => entry.CommandText == "git status").IsInvalidCommand);
+    }
+
+    /// <summary>
+    /// No sweep when the unresolved name is not the command's own first token. A
+    /// <c>command not found</c> raised from inside <c>npm run build</c> names something that is not
+    /// <c>npm</c>, and flagging by first token there would suppress every <c>npm</c> line the user has.
+    /// </summary>
+    [Fact]
+    public async Task HandleCommandFailureAsync_WhenTheUnresolvedNameIsNotTheCommand_DoesNotSweepByFirstToken()
+    {
+        var store = new InMemoryHistoryStore();
+        store.Seed(CreateEntry("npm run test", DateTimeOffset.Parse("2026-02-01T10:00:00+00:00")));
+
+        var controller = CreateController(
+            historyStore: store,
+            errorInsightService: new RecordingErrorInsightService(
+                [new CommandFixSuggestion(
+                    "'rimraf' is not installed or not on PATH",
+                    "where rimraf",
+                    "The shell searched PATH and found nothing by that name.",
+                    CommandErrorRecognizers.Explanatory,
+                    ["Fix", "PATH"],
+                    RecognizerId: "command-not-found")]));
+
+        await controller.HandleEnterAsync("npm run build");
+        await controller.HandleCommandFinishedAsync(1);
+        await controller.HandleCommandFailureAsync(
+            CreateFailureContext("npm run build", 1, "rimraf: command not found"));
+
+        Assert.Empty(store.FirstTokenSweeps);
+        Assert.False(store.Entries.Single(entry => entry.CommandText == "npm run test").IsInvalidCommand);
+    }
+
+    /// <summary>
     /// A failure that is not a name-resolution failure leaves the entry alone.
     /// </summary>
     [Fact]
@@ -808,6 +882,25 @@ public sealed class CommandAssistControllerTests
             historyStore: new InMemoryHistoryStore(),
             suggestionEngine: suggestionEngine,
             grid: grid);
+
+        // Warm the caller-thread path before timing it. Everything NotifyInputActivity does on the
+        // calling thread - the state transition, the view-model writes and the hint-strip rebuild they
+        // trigger, and queueing the pass - is identical for a below-floor line; what differs happens
+        // inside the pass's Task.Run, on a worker, after this method has already returned. So this JITs
+        // exactly the code the stopwatch measures and none of the code it is measuring *for*.
+        //
+        // Without it the assertion was a cold-start JIT budget wearing a latency test's name: measured
+        // at 122-134 ms for the first call and 0 ms for every call after it, on a path that never waits
+        // for the engine at all. It passed only while the JIT happened to fit under 100 ms, and any
+        // change that grew this call graph - dogfood round 4 grew it by a few view-model writes -
+        // failed it without slowing anything down.
+        //
+        // The teeth are unaffected: the engine cannot be reached from a below-floor line (the pass
+        // returns at MinPassiveQueryLength before touching the store or the engine), so a regression
+        // that made the caller await the 250 ms engine would still show up on the timed call below.
+        grid.SetLine("c");
+        controller.NotifyInputActivity();
+
         grid.SetLine("cd ./d");
         var stopwatch = Stopwatch.StartNew();
 
@@ -1841,9 +1934,13 @@ public sealed class CommandAssistControllerTests
     private sealed class InMemoryHistoryStore : IHistoryStore
     {
         private readonly List<CommandHistoryEntry> _entries = new();
+        private readonly List<string> _firstTokenSweeps = new();
         private int _searchCount;
 
         public IReadOnlyList<CommandHistoryEntry> Entries => _entries;
+
+        /// <summary>Every retroactive first-token sweep the controller asked for, in order.</summary>
+        public IReadOnlyList<string> FirstTokenSweeps => _firstTokenSweeps;
 
         /// <summary>
         /// How many times the recall gate was queried. Lets a test assert that a refresh never
@@ -1933,6 +2030,29 @@ public sealed class CommandAssistControllerTests
             return Task.FromResult(true);
         }
 
+        public Task<int> TryMarkInvalidCommandsByFirstTokenAsync(string firstToken, CancellationToken cancellationToken = default)
+        {
+            _firstTokenSweeps.Add(firstToken);
+
+            int flagged = 0;
+            for (int i = 0; i < _entries.Count; i++)
+            {
+                if (_entries[i].IsInvalidCommand ||
+                    !string.Equals(
+                        CommandHistoryEntry.FirstToken(_entries[i].CommandText),
+                        firstToken,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                _entries[i] = _entries[i] with { IsInvalidCommand = true };
+                flagged++;
+            }
+
+            return Task.FromResult(flagged);
+        }
+
         public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default, bool isInvalidCommand = false)
         {
             int index = _entries.FindIndex(x => x.Id == entryId);
@@ -1997,6 +2117,9 @@ public sealed class CommandAssistControllerTests
         public Task<bool> TryMarkInvalidCommandAsync(string entryId, CancellationToken cancellationToken = default)
             => Task.FromResult(false);
 
+        public Task<int> TryMarkInvalidCommandsByFirstTokenAsync(string firstToken, CancellationToken cancellationToken = default)
+            => Task.FromResult(0);
+
         public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default, bool isInvalidCommand = false)
             => Task.FromResult(false);
 
@@ -2019,6 +2142,9 @@ public sealed class CommandAssistControllerTests
 
         public Task<bool> TryMarkInvalidCommandAsync(string entryId, CancellationToken cancellationToken = default)
             => Task.FromResult(false);
+
+        public Task<int> TryMarkInvalidCommandsByFirstTokenAsync(string firstToken, CancellationToken cancellationToken = default)
+            => Task.FromResult(0);
 
         public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default, bool isInvalidCommand = false)
             => Task.FromException<bool>(new InvalidOperationException("simulated write failure"));

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistGridTruthTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistGridTruthTests.cs
@@ -603,6 +603,9 @@ public sealed class CommandAssistGridTruthTests
         public Task<bool> TryMarkInvalidCommandAsync(string entryId, CancellationToken cancellationToken = default)
             => Task.FromResult(false);
 
+        public Task<int> TryMarkInvalidCommandsByFirstTokenAsync(string firstToken, CancellationToken cancellationToken = default)
+            => Task.FromResult(0);
+
         public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default, bool isInvalidCommand = false)
             => Task.FromResult(false);
 

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistInsertionPlannerTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistInsertionPlannerTests.cs
@@ -269,4 +269,108 @@ public sealed class CommandAssistInsertionPlannerTests
         Assert.True(created);
         Assert.Equal(expected, textToSend);
     }
+
+    // ------------------------------------------- inline predictions (dogfood round 4, item 1)
+
+    /// <summary>
+    /// A line the reader classified as "typed prefix, then a ghost": the whole painted line, the cursor
+    /// at the end of the typed part, and the flag set.
+    /// </summary>
+    private static AssistQuerySnapshot Ghosted(string typed, string ghost) =>
+        new(typed + ghost, typed.Length, IsMultiline: false, RightPromptTrimmed: false, TextAfterCursorIsGhost: true);
+
+    /// <summary>
+    /// The bug the owner hit, at the layer it is fixed. With a prediction painted past the cursor the
+    /// line reads as usable again, because a prediction is not text the user typed - it lives in the
+    /// shell's suggestion buffer, never in its input buffer, and the next keystroke recomputes it.
+    /// </summary>
+    [Fact]
+    public void GhostSuffix_MakesTheLineUsableAsATypedPrefix()
+    {
+        AssistQuerySnapshot line = Ghosted("docke", "r ps -a");
+
+        Assert.True(line.IsUsableAsTypedPrefix);
+        Assert.Equal("docke", line.TypedPrefix);
+    }
+
+    /// <summary>
+    /// And the delta is computed against the typed characters, not against the whole painted line. This
+    /// is the assertion that catches the half-fix: flip <c>TypedPrefix</c> back to <c>Text</c> in the
+    /// planner and the suffix comes out empty or wrong, because the prediction the shell guessed is not
+    /// the suggestion the user picked.
+    /// </summary>
+    [Fact]
+    public void GhostSuffix_IsMeasuredAgainstTheTypedCharactersOnly()
+    {
+        bool created = CommandAssistInsertionPlanner.TryCreateInsertion(
+            Ghosted("docke", "r ps -a"),
+            selectedCommand: "docker compose up",
+            out string? textToSend);
+
+        Assert.True(created);
+        Assert.Equal("r compose up", textToSend);
+    }
+
+    /// <summary>
+    /// One typed character and a full-line prediction - the shape a fresh prompt produces on the first
+    /// keystroke, and the one that used to refuse hardest.
+    /// </summary>
+    [Fact]
+    public void GhostSuffix_WorksFromASingleTypedCharacter()
+    {
+        bool created = CommandAssistInsertionPlanner.TryCreateInsertion(
+            Ghosted("d", "ocker compose up"),
+            selectedCommand: "docker ps",
+            out string? textToSend);
+
+        Assert.True(created);
+        Assert.Equal("ocker ps", textToSend);
+    }
+
+    /// <summary>
+    /// The typed part still has to be a prefix of the suggestion. The ghost widens which lines are
+    /// readable; it does not weaken what makes an append correct.
+    /// </summary>
+    [Fact]
+    public void GhostSuffix_StillRefusesWhenTheTypedTextIsNotAPrefix()
+    {
+        Assert.False(CommandAssistInsertionPlanner.TryCreateInsertion(
+            Ghosted("kubect", "l get pods"),
+            selectedCommand: "docker ps",
+            out string? textToSend));
+
+        Assert.Null(textToSend);
+    }
+
+    /// <summary>
+    /// A multiline entry is refused whatever the flag says. The two facts are independent - the flag
+    /// describes the region past the cursor, and a continuation prompt is text before it that the user
+    /// never typed - so the multiline term is kept as its own conjunct rather than folded in.
+    /// </summary>
+    [Fact]
+    public void GhostSuffix_DoesNotOverrideTheMultilineRefusal()
+    {
+        var line = new AssistQuerySnapshot(
+            "git commit\n> ",
+            CursorOffset: 10,
+            IsMultiline: true,
+            RightPromptTrimmed: false,
+            TextAfterCursorIsGhost: true);
+
+        Assert.False(line.IsUsableAsTypedPrefix);
+    }
+
+    /// <summary>
+    /// Without the flag nothing changes: a mid-line cursor refuses exactly as it did before this round.
+    /// The flag is the reader's proof, and no proof means no licence.
+    /// </summary>
+    [Fact]
+    public void WithoutTheGhostFlag_AMidLineCursorStillRefuses()
+    {
+        AssistQuerySnapshot line = Line("docker ps -a", cursorOffset: 5);
+
+        Assert.False(line.IsUsableAsTypedPrefix);
+        Assert.Equal("docker ps -a", line.TypedPrefix);
+        Assert.False(CommandAssistInsertionPlanner.TryCreateInsertion(line, "docker compose up", out _));
+    }
 }

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistLayoutTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistLayoutTests.cs
@@ -136,10 +136,12 @@ public sealed class CommandAssistLayoutTests
     }
 
     /// <summary>
-    /// The shortcut hint's middle rung: keys without verbs, so the suggestion keeps its width.
+    /// The shortcut hint's middle rung: keys without verbs, so the suggestion keeps its width - and
+    /// since dogfood round 4 the browse clause goes with them, so the one chord the user cannot guess
+    /// survives a rung longer than the one they can. See <c>CommandAssistBarViewModel.BuildHintText</c>.
     /// </summary>
     [Fact]
-    public void CommandAssistBarViewModel_WhenTheHintIsTerse_DropsTheVerbsAndKeepsTheKeys()
+    public void CommandAssistBarViewModel_WhenTheHintIsTerse_KeepsInsertAndDropsTheRest()
     {
         var vm = new CommandAssistBarViewModel
         {
@@ -149,7 +151,7 @@ public sealed class CommandAssistLayoutTests
         };
 
         Assert.True(vm.Bubble.ShowShortcutHint);
-        Assert.Equal("Up/Down  |  Ctrl+Enter  |  Esc", vm.Bubble.ShortcutHintText);
+        Assert.Equal("Ctrl+Enter  |  Esc", vm.Bubble.ShortcutHintText);
 
         // The popup has room and is unaffected: it is where the shortcuts are still taught.
         Assert.Equal(CommandAssistBarViewModel.IdleHintText, vm.Popup.ShortcutHintText);
@@ -1580,5 +1582,110 @@ public sealed class CommandAssistLayoutTests
             CommandAssistHistoryEnabled = true
         };
         pane.ApplySettings(settings);
+    }
+
+    // ------------------------- hint collapse order and the integration glyph (dogfood round 4)
+
+    private static CommandAssistBarViewModel PassiveBubble(AssistHintDetail detail) =>
+        new()
+        {
+            IsVisible = true,
+            ModeLabel = "Suggest",
+            QueryText = "doc",
+            TopSuggestionText = "docker ps",
+            BubbleHintDetail = detail
+        };
+
+    /// <summary>
+    /// At full width the strip advertises everything, insert included. This is the rung the owner's
+    /// wide panes get, and the clause he could not find has to be on it.
+    /// </summary>
+    [Fact]
+    public void BubbleHint_AtFullDetail_AdvertisesBrowseAndInsert()
+    {
+        string hint = PassiveBubble(AssistHintDetail.Full).Bubble.ShortcutHintText;
+
+        Assert.Contains("Down browse", hint);
+        Assert.Contains("Ctrl+Enter insert", hint);
+        Assert.Contains("Esc close", hint);
+    }
+
+    /// <summary>
+    /// The collapse order, and the assertion that fails if it is put back the way it was: browse is
+    /// shed a rung before insert. <c>Down</c> is discoverable by pressing an arrow key at a prompt;
+    /// <c>Ctrl+Enter</c> is discoverable nowhere, which is why the owner never found it.
+    /// </summary>
+    [Fact]
+    public void BubbleHint_AtTerseDetail_KeepsInsertAndDropsBrowse()
+    {
+        string hint = PassiveBubble(AssistHintDetail.Terse).Bubble.ShortcutHintText;
+
+        Assert.Contains("Ctrl+Enter", hint);
+        Assert.Contains("Esc", hint);
+        Assert.DoesNotContain("Down", hint);
+    }
+
+    /// <summary>
+    /// The one case where browse comes back at the terse rung: there is no insertion to advertise, so
+    /// dropping browse too would leave a strip that only says "Esc".
+    /// </summary>
+    [Fact]
+    public void BubbleHint_AtTerseDetailWithNoInsertionAvailable_FallsBackToBrowse()
+    {
+        var vm = new CommandAssistBarViewModel
+        {
+            InsertionAvailableProbe = () => false,
+            IsVisible = true,
+            ModeLabel = "Suggest",
+            TopSuggestionText = "docker ps",
+            BubbleHintDetail = AssistHintDetail.Terse
+        };
+
+        string hint = vm.Bubble.ShortcutHintText;
+
+        Assert.DoesNotContain("Ctrl+Enter", hint);
+        Assert.Contains("Down", hint);
+        Assert.Contains("Esc", hint);
+    }
+
+    /// <summary>
+    /// The chip is exempt from the collapse in its glyph form: at every rung, including the one that
+    /// hides the hint strip entirely, exactly one of the two forms is on screen. The owner went a whole
+    /// round of dogfooding without seeing this indicator once, because the old rule dropped it whole.
+    /// </summary>
+    [Theory]
+    [InlineData(AssistHintDetail.Full, true, false)]
+    [InlineData(AssistHintDetail.Terse, false, true)]
+    [InlineData(AssistHintDetail.Hidden, false, true)]
+    public void IntegrationIndicator_IsAlwaysOnScreenInOneFormOrTheOther(
+        AssistHintDetail detail,
+        bool expectLabel,
+        bool expectGlyph)
+    {
+        CommandAssistBarViewModel vm = PassiveBubble(detail);
+        vm.IsShellIntegrationLive = true;
+
+        Assert.Equal(expectLabel, vm.Bubble.ShowIntegrationStatus);
+        Assert.Equal(expectGlyph, vm.Bubble.ShowIntegrationGlyph);
+        Assert.NotEqual(vm.Bubble.ShowIntegrationStatus, vm.Bubble.ShowIntegrationGlyph);
+
+        // Whichever form is up, the sentence behind it is the same one hover away.
+        Assert.Equal(CommandAssistBarViewModel.IntegratedStatusTooltip, vm.Bubble.IntegrationStatusTooltip);
+    }
+
+    /// <summary>The glyph is the same fact as the label: filled for integrated, hollow for basic.</summary>
+    [Theory]
+    [InlineData(true, CommandAssistBarViewModel.IntegratedStatusGlyph, CommandAssistBarViewModel.IntegratedStatusText)]
+    [InlineData(false, CommandAssistBarViewModel.BasicStatusGlyph, CommandAssistBarViewModel.BasicStatusText)]
+    public void IntegrationGlyph_TracksTheSameStateAsTheLabel(
+        bool isLive,
+        string expectedGlyph,
+        string expectedLabel)
+    {
+        CommandAssistBarViewModel vm = PassiveBubble(AssistHintDetail.Terse);
+        vm.IsShellIntegrationLive = isLive;
+
+        Assert.Equal(expectedGlyph, vm.Bubble.IntegrationGlyphText);
+        Assert.Equal(expectedLabel, vm.Bubble.IntegrationStatusText);
     }
 }

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistPassiveBubbleTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistPassiveBubbleTests.cs
@@ -668,6 +668,133 @@ public sealed class CommandAssistPassiveBubbleTests
         Assert.Single(history.Entries);
     }
 
+    // ------------------------------------- staged Escape and bubble accept (dogfood round 4)
+
+    /// <summary>
+    /// The owner's flow, both stages. <c>Down</c> opens the popup; the first Escape puts it away and
+    /// leaves the suggestion on screen; the second takes the suggestion down for the rest of the line.
+    /// </summary>
+    /// <remarks>
+    /// Before this round the first Escape did both at once, which is what "Esc kills everything for the
+    /// command" meant: one keystroke in, two commands' worth of assist out.
+    /// </remarks>
+    [Fact]
+    public async Task EscapeFromAPassivePopup_ReturnsToTheBubbleAndKeepsTheSuggestion()
+    {
+        var history = new RecordingHistoryStore();
+        history.Seed("git status");
+        var grid = new FakeGrid();
+        var delay = new GatedDelay();
+        CommandAssistController controller = CreateController(history, grid, delay);
+
+        grid.SetLine("gi");
+        controller.NotifyInputActivity();
+        delay.ReleaseAll();
+        await WaitForAsync(() => controller.ViewModel.IsVisible);
+
+        Assert.True(controller.MoveSelectionDown());
+        Assert.True(controller.ViewModel.IsPopupOpen);
+
+        // Stage one.
+        Assert.True(controller.HandleEscape());
+        Assert.False(controller.ViewModel.IsPopupOpen);
+        Assert.True(controller.ViewModel.IsVisible);
+        Assert.NotEmpty(controller.Suggestions);
+        Assert.Equal("git status", controller.ViewModel.TopSuggestionText);
+
+        // Stage two: an ordinary bubble Escape.
+        Assert.True(controller.HandleEscape());
+        Assert.False(controller.ViewModel.IsVisible);
+        Assert.Empty(controller.Suggestions);
+    }
+
+    /// <summary>
+    /// And the second stage still suppresses for the rest of the command line - the staging adds a
+    /// press, it does not weaken what the press eventually does.
+    /// </summary>
+    [Fact]
+    public async Task TwoEscapesFromAPassivePopup_SuppressTheBubbleForTheRestOfTheCommand()
+    {
+        var history = new RecordingHistoryStore();
+        history.Seed("git status");
+        var grid = new FakeGrid();
+        var delay = new GatedDelay();
+        CommandAssistController controller = CreateController(history, grid, delay);
+
+        grid.SetLine("gi");
+        controller.NotifyInputActivity();
+        delay.ReleaseAll();
+        await WaitForAsync(() => controller.ViewModel.IsVisible);
+
+        controller.MoveSelectionDown();
+        controller.HandleEscape();
+        controller.HandleEscape();
+
+        grid.SetLine("git");
+        controller.NotifyInputActivity();
+        delay.ReleaseAll();
+        await Task.Delay(50);
+
+        Assert.False(controller.ViewModel.IsVisible);
+    }
+
+    /// <summary>
+    /// One press is not enough. The suggestion is still there, so a keystroke after it keeps ranking -
+    /// which is the difference the staging exists to make.
+    /// </summary>
+    [Fact]
+    public async Task OneEscapeFromAPassivePopup_DoesNotSuppressTheBubble()
+    {
+        var history = new RecordingHistoryStore();
+        history.Seed("git status");
+        var grid = new FakeGrid();
+        var delay = new GatedDelay();
+        CommandAssistController controller = CreateController(history, grid, delay);
+
+        grid.SetLine("gi");
+        controller.NotifyInputActivity();
+        delay.ReleaseAll();
+        await WaitForAsync(() => controller.ViewModel.IsVisible);
+
+        controller.MoveSelectionDown();
+        controller.HandleEscape();
+
+        grid.SetLine("git");
+        controller.NotifyInputActivity();
+        delay.ReleaseAll();
+
+        await WaitForAsync(() => controller.ViewModel.IsVisible);
+        Assert.Equal("git status", controller.ViewModel.TopSuggestionText);
+    }
+
+    /// <summary>
+    /// The bubble's implicit selection: the row it is displaying is row 0, and the insert chord takes
+    /// it without the user going through the popup first. This is what "Ctrl+Enter accepts the
+    /// displayed top-1" means at the controller - the key router already routes Insert whenever any
+    /// surface is visible.
+    /// </summary>
+    [Fact]
+    public async Task PassiveBubble_OffersItsDisplayedRowToTheInsertChord()
+    {
+        var history = new RecordingHistoryStore();
+        history.Seed("git status");
+        var grid = new FakeGrid();
+        var delay = new GatedDelay();
+        CommandAssistController controller = CreateController(history, grid, delay);
+
+        grid.SetLine("gi");
+        controller.NotifyInputActivity();
+        delay.ReleaseAll();
+        await WaitForAsync(() => controller.ViewModel.IsVisible);
+
+        // No popup, no arrow key, no explicit session - just the bubble the user was shown.
+        Assert.False(controller.ViewModel.IsPopupOpen);
+        Assert.Equal(0, controller.ViewModel.SelectedIndex);
+
+        Assert.True(controller.TryGetInsertionText(out string? insertionText));
+        Assert.Equal(controller.ViewModel.TopSuggestionText, insertionText);
+    }
+
     // ------------------------------------------------------------------ helpers
 
     private static CommandAssistController CreateController(
@@ -989,6 +1116,9 @@ public sealed class CommandAssistPassiveBubbleTests
 
         public Task<bool> TryMarkInvalidCommandAsync(string entryId, CancellationToken cancellationToken = default)
             => Task.FromResult(false);
+
+        public Task<int> TryMarkInvalidCommandsByFirstTokenAsync(string firstToken, CancellationToken cancellationToken = default)
+            => Task.FromResult(0);
 
         public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default, bool isInvalidCommand = false)
             => Task.FromResult(false);

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandErrorRecognizerTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandErrorRecognizerTests.cs
@@ -89,6 +89,42 @@ public sealed class CommandErrorRecognizerTests
     }
 
     /// <summary>
+    /// Every command-not-found fix publishes the unresolved name, on every shell, because the name is
+    /// what the retroactive history sweep is keyed on (dogfood round 4, item 4a).
+    /// </summary>
+    [Theory]
+    [InlineData("pwsh", PwshNotRecognized)]
+    [InlineData("powershell", WindowsPowerShellNotRecognized)]
+    [InlineData("cmd", CmdNotRecognized)]
+    [InlineData("bash", BashCommandNotFound)]
+    [InlineData("zsh", ZshCommandNotFound)]
+    [InlineData("fish", FishUnknownCommand)]
+    public async Task ACommandNotFound_PublishesTheUnresolvedName(string shell, string output)
+    {
+        IReadOnlyList<CommandFixSuggestion> result = await Analyze("gti status", 127, shell, output);
+
+        Assert.All(
+            result.Where(item => item.IsCommandNotFound),
+            item => Assert.Equal("gti", item.UnresolvedCommandToken));
+    }
+
+    /// <summary>
+    /// And it is withheld when the unresolved name came from inside the command rather than from the
+    /// command position. This is the conjunct that keeps the sweep from flagging every <c>npm</c> line
+    /// in a user's history because one script it ran was missing a tool.
+    /// </summary>
+    [Fact]
+    public async Task ACommandNotFoundRaisedFromInsideTheCommand_WithholdsTheUnresolvedName()
+    {
+        IReadOnlyList<CommandFixSuggestion> result =
+            await Analyze("npm run build", 127, "bash", "/usr/bin/bash: line 1: rimraf: command not found");
+
+        Assert.All(
+            result.Where(item => item.IsCommandNotFound),
+            item => Assert.Null(item.UnresolvedCommandToken));
+    }
+
+    /// <summary>
     /// The transposition case is why the distance metric has a transposition term at all: under
     /// plain Levenshtein <c>gti</c> is two edits from <c>git</c>, which is outside the budget a
     /// three-character token gets, and the most recognisable typo in the world would produce

--- a/tests/NovaTerminal.App.Tests/CommandAssist/JsonlHistoryStoreTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/JsonlHistoryStoreTests.cs
@@ -501,6 +501,136 @@ public sealed class JsonlHistoryStoreTests : IDisposable
     private static string Serialize(CommandHistoryEntry entry)
         => JsonSerializer.Serialize(entry, CommandAssistJsonLinesContext.Default.CommandHistoryEntry);
 
+    // ---------------------------- retroactive typo flagging (dogfood round 4, item 4)
+
+    /// <summary>
+    /// The owner's case. Three <c>gti</c> lines captured before the flag existed, all unflagged; he
+    /// reproduces the typo once and every one of them is suppressed, without his having to retype the
+    /// other two.
+    /// </summary>
+    [Fact]
+    public async Task TryMarkInvalidCommandsByFirstTokenAsync_FlagsEveryOlderEntryWithTheSameFirstToken()
+    {
+        JsonlHistoryStore store = CreateStore();
+        await store.AppendAsync(CreateEntry("gti status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")));
+        await store.AppendAsync(CreateEntry("gti log --oneline", DateTimeOffset.Parse("2026-03-01T10:01:00+00:00")));
+        await store.AppendAsync(CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:02:00+00:00")));
+
+        int flagged = await store.TryMarkInvalidCommandsByFirstTokenAsync("gti");
+
+        Assert.Equal(2, flagged);
+
+        IReadOnlyList<CommandHistoryEntry> entries = await CreateStore().GetRecentAsync(10);
+        Assert.All(
+            entries.Where(entry => entry.CommandText.StartsWith("gti", StringComparison.Ordinal)),
+            entry => Assert.True(entry.IsInvalidCommand));
+
+        // And nothing else moved: `git status` is a different program that happens to share a prefix.
+        Assert.False(entries.Single(entry => entry.CommandText == "git status").IsInvalidCommand);
+    }
+
+    /// <summary>
+    /// The sweep survives a reload, because it is written as superseding records rather than held in
+    /// memory - a flag the next launch forgets is not a suppression.
+    /// </summary>
+    [Fact]
+    public async Task TryMarkInvalidCommandsByFirstTokenAsync_PersistsAcrossStoreInstances()
+    {
+        JsonlHistoryStore store = CreateStore();
+        await store.AppendAsync(CreateEntry("gti status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")));
+
+        await store.TryMarkInvalidCommandsByFirstTokenAsync("gti");
+
+        IReadOnlyList<CommandHistoryEntry> entries = await CreateStore().GetRecentAsync(10);
+        Assert.True(entries.Single().IsInvalidCommand);
+    }
+
+    /// <summary>
+    /// Case-insensitive, matching how <c>CommandAssistSuggestionEngine</c> groups history: if the
+    /// grouping treats two spellings as one row, the suppression has to reach both or the row survives.
+    /// </summary>
+    [Fact]
+    public async Task TryMarkInvalidCommandsByFirstTokenAsync_MatchesCaseInsensitively()
+    {
+        JsonlHistoryStore store = CreateStore();
+        await store.AppendAsync(CreateEntry("GTI status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")));
+
+        Assert.Equal(1, await store.TryMarkInvalidCommandsByFirstTokenAsync("gti"));
+    }
+
+    /// <summary>
+    /// Idempotent, and it says so in its return value: a user who mistypes the same word twice must not
+    /// pay for a second pass of writes.
+    /// </summary>
+    [Fact]
+    public async Task TryMarkInvalidCommandsByFirstTokenAsync_SkipsEntriesAlreadyFlagged()
+    {
+        JsonlHistoryStore store = CreateStore();
+        await store.AppendAsync(CreateEntry("gti status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")));
+        await store.TryMarkInvalidCommandsByFirstTokenAsync("gti");
+
+        int lineCount = (await File.ReadAllLinesAsync(_historyPath)).Length;
+
+        Assert.Equal(0, await store.TryMarkInvalidCommandsByFirstTokenAsync("gti"));
+        Assert.Equal(lineCount, (await File.ReadAllLinesAsync(_historyPath)).Length);
+    }
+
+    [Fact]
+    public async Task TryMarkInvalidCommandsByFirstTokenAsync_WithABlankToken_DoesNothing()
+    {
+        JsonlHistoryStore store = CreateStore();
+        await store.AppendAsync(CreateEntry("gti status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")));
+
+        Assert.Equal(0, await store.TryMarkInvalidCommandsByFirstTokenAsync("   "));
+        Assert.False((await store.GetRecentAsync(10)).Single().IsInvalidCommand);
+    }
+
+    /// <summary>
+    /// The load-time backfill: an exit-127 line written before the flag existed comes back flagged,
+    /// because the information was on disk the whole time and was simply not being read.
+    /// </summary>
+    [Fact]
+    public async Task Load_BackfillsTheInvalidFlagForExitCode127()
+    {
+        // Written through the store so the line on disk is a real one - and with the flag left at its
+        // default, which is exactly what a pre-flag record deserialises to.
+        JsonlHistoryStore store = CreateStore();
+        await store.AppendAsync(CreateEntry("gti status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00"), exitCode: 127));
+        await store.AppendAsync(CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:01:00+00:00"), exitCode: 0));
+        await store.AppendAsync(CreateEntry("dotnet test", DateTimeOffset.Parse("2026-03-01T10:02:00+00:00"), exitCode: 1));
+
+        IReadOnlyList<CommandHistoryEntry> entries = await CreateStore().GetRecentAsync(10);
+
+        Assert.True(entries.Single(entry => entry.CommandText == "gti status").IsInvalidCommand);
+
+        // Exactly the live capture rule and no wider: a command that ran and failed is not a typo.
+        Assert.False(entries.Single(entry => entry.CommandText == "git status").IsInvalidCommand);
+        Assert.False(entries.Single(entry => entry.CommandText == "dotnet test").IsInvalidCommand);
+    }
+
+    /// <summary>
+    /// A never-completed entry has no exit code at all, and an absent code is not a 127.
+    /// </summary>
+    [Fact]
+    public async Task Load_DoesNotBackfillAnEntryWithNoExitCode()
+    {
+        JsonlHistoryStore store = CreateStore();
+        await store.AppendAsync(CreateEntry("gti status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00"), exitCode: null));
+
+        Assert.False((await CreateStore().GetRecentAsync(10)).Single().IsInvalidCommand);
+    }
+
+    [Theory]
+    [InlineData("gti status", "gti")]
+    [InlineData("   gti   status", "gti")]
+    [InlineData("gti", "gti")]
+    [InlineData("", "")]
+    [InlineData("   ", "")]
+    public void FirstToken_IsTheLeadingWord(string commandText, string expected)
+    {
+        Assert.Equal(expected, CommandHistoryEntry.FirstToken(commandText));
+    }
+
     private static CommandHistoryEntry CreateEntry(
         string commandText,
         DateTimeOffset? executedAt = null,

--- a/tests/NovaTerminal.App.Tests/Performance/CommandAssistPerformanceTests.cs
+++ b/tests/NovaTerminal.App.Tests/Performance/CommandAssistPerformanceTests.cs
@@ -464,6 +464,9 @@ public sealed class CommandAssistPerformanceTests
         public Task<bool> TryMarkInvalidCommandAsync(string entryId, CancellationToken cancellationToken = default)
             => Task.FromResult(false);
 
+        public Task<int> TryMarkInvalidCommandsByFirstTokenAsync(string firstToken, CancellationToken cancellationToken = default)
+            => Task.FromResult(0);
+
         public Task<bool> TryUpdateExecutionResultAsync(string entryId, int? exitCode, long? durationMs, CancellationToken cancellationToken = default, bool isInvalidCommand = false)
             => Task.FromResult(false);
     }

--- a/tests/NovaTerminal.VT.Tests/GridQueryReaderTests.cs
+++ b/tests/NovaTerminal.VT.Tests/GridQueryReaderTests.cs
@@ -1131,4 +1131,251 @@ public class GridQueryReaderTests
         Assert.True(GridQueryReader.TryReadTextEndingAtCursor(s.Buffer, 2, out _));
         Assert.False(s.Buffer.Lock.IsReadLockHeld);
     }
+
+    // ------------------------------------------------- inline predictions (ghost suffixes)
+
+    // PSReadLine's shipped InlinePredictionColor. Index 238 of the xterm-256 greyscale ramp.
+    private const string DimGrey = "\x1b[38;5;238m";
+
+    // A truecolour mid-grey, for the same job on a terminal configured with RGB colours.
+    private const string DimGreyRgb = "\x1b[38;2;106;106;106m";
+
+    private const string Italic = "\x1b[3m";
+    private const string Faint = "\x1b[2m";
+    private const string Green = "\x1b[32m";
+    private const string Yellow = "\x1b[33m";
+    private const string White = "\x1b[97m";
+    private const string Reset = "\x1b[0m";
+
+    /// <summary>Moves the cursor left, which is how a line editor parks it in front of its prediction.</summary>
+    private static string Left(int n) => $"\x1b[{n}D";
+
+    [Fact]
+    public void DimGreySuffixAfterPlainTypedText_IsGhost()
+    {
+        // Exactly what PSReadLine paints: the typed characters, the prediction in its own colour,
+        // then the cursor moved back to the end of what the user actually typed.
+        var s = new Session()
+            .Prompt()
+            .Write("docke")
+            .Write(DimGrey + "r ps -a" + Reset)
+            .Write(Left(7));
+
+        var line = s.Read();
+
+        Assert.Equal("docker ps -a", line.Text);
+        Assert.Equal(5, line.CursorOffset);
+        Assert.True(line.TextAfterCursorIsGhost);
+    }
+
+    [Fact]
+    public void DimGreySuffixGivenAsTruecolour_IsGhost()
+    {
+        // The palette form and the RGB form are the same colour arriving by different routes, and
+        // the rule must not be able to tell them apart - a terminal profile decides which one the
+        // shell emits, and the user did not choose it.
+        var s = new Session()
+            .Prompt()
+            .Write("git st")
+            .Write(DimGreyRgb + "atus" + Reset)
+            .Write(Left(4));
+
+        var line = s.Read();
+
+        Assert.Equal("git status", line.Text);
+        Assert.Equal(6, line.CursorOffset);
+        Assert.True(line.TextAfterCursorIsGhost);
+    }
+
+    [Fact]
+    public void ItalicSuffixInTheDefaultColour_IsGhost()
+    {
+        // Italic alone is enough to be recessive: several PSReadLine themes recess the prediction
+        // with the attribute rather than with a colour, and the owner's screenshot has both.
+        var s = new Session()
+            .Prompt()
+            .Write("doc")
+            .Write(Italic + "ker ps" + Reset)
+            .Write(Left(6));
+
+        var line = s.Read();
+
+        Assert.True(line.TextAfterCursorIsGhost);
+    }
+
+    [Fact]
+    public void FaintSuffix_IsGhost()
+    {
+        var s = new Session()
+            .Prompt()
+            .Write("doc")
+            .Write(Faint + "ker ps" + Reset)
+            .Write(Left(6));
+
+        Assert.True(s.Read().TextAfterCursorIsGhost);
+    }
+
+    [Fact]
+    public void SyntaxHighlightedTypedTextWithADimGreySuffix_IsGhost()
+    {
+        // The typed region is styled too - PSReadLine colours the command and its parameters
+        // differently - so the rule cannot be "the suffix differs from the cell before the cursor".
+        // The suffix's colour appears nowhere in the typed region, which is the test that holds.
+        var s = new Session()
+            .Prompt()
+            .Write(Green + "git" + Reset)
+            .Write(" ")
+            .Write(Yellow + "com" + Reset)
+            .Write(DimGrey + "mit -m \"wip\"" + Reset)
+            .Write(Left(12));
+
+        var line = s.Read();
+
+        Assert.Equal("git commit -m \"wip\"", line.Text);
+        Assert.Equal(7, line.CursorOffset);
+        Assert.True(line.TextAfterCursorIsGhost);
+    }
+
+    [Fact]
+    public void OneTypedCharacterWithAFullLinePrediction_IsGhost()
+    {
+        // The case the two-character ranking floor made visible: one keystroke, and the whole rest
+        // of the line is the shell's guess.
+        var s = new Session()
+            .Prompt()
+            .Write("d")
+            .Write(DimGrey + "ocker compose up" + Reset)
+            .Write(Left(16));
+
+        var line = s.Read();
+
+        Assert.Equal(1, line.CursorOffset);
+        Assert.True(line.TextAfterCursorIsGhost);
+    }
+
+    [Fact]
+    public void CursorMovedBackThroughUnstyledTypedText_IsNotGhost()
+    {
+        // Home, then Right five times. The text to the right is the user's, and appending to it
+        // would splice a suggestion into the middle of their line.
+        var s = new Session()
+            .Prompt()
+            .Write("echo hello")
+            .Write(Left(5));
+
+        var line = s.Read();
+
+        Assert.Equal("echo hello", line.Text);
+        Assert.Equal(5, line.CursorOffset);
+        Assert.False(line.TextAfterCursorIsGhost);
+    }
+
+    [Fact]
+    public void CursorMovedBackToATokenBoundaryInSyntaxHighlightedText_IsNotGhost()
+    {
+        // The case that makes the recessive-style test load-bearing rather than belt-and-braces.
+        // The suffix here is uniform (one argument, one colour) and its colour appears nowhere in
+        // the typed region (the command has its own), so every other condition of the rule is
+        // satisfied - and it is still the user's own text, sitting to the right of a cursor they
+        // moved. Only "the suffix is painted in a recessive style" rejects it.
+        var s = new Session()
+            .Prompt()
+            .Write(Green + "echo" + Reset)
+            .Write(" ")
+            .Write(White + "hello" + Reset)
+            .Write(Left(5));
+
+        var line = s.Read();
+
+        Assert.Equal("echo hello", line.Text);
+        Assert.Equal(5, line.CursorOffset);
+        Assert.False(line.TextAfterCursorIsGhost);
+    }
+
+    [Fact]
+    public void SuffixOfMixedStyles_IsNotGhost()
+    {
+        // A prediction is painted in one write and one colour. Two colours past the cursor is
+        // something else, whatever it is, and "whatever it is" resolves to "not a prediction".
+        var s = new Session()
+            .Prompt()
+            .Write("doc")
+            .Write(DimGrey + "ker" + Reset)
+            .Write(White + " ps" + Reset)
+            .Write(Left(6));
+
+        var line = s.Read();
+
+        Assert.Equal(3, line.CursorOffset);
+        Assert.False(line.TextAfterCursorIsGhost);
+    }
+
+    [Fact]
+    public void SuffixWhoseStyleAlsoAppearsInTheTypedRegion_IsNotGhost()
+    {
+        // A user who types in the same dim grey the prediction would use. Uniform and recessive,
+        // but not distinguishable from what they typed - so the reader declines to guess.
+        var s = new Session()
+            .Prompt()
+            .Write(DimGrey + "echo" + Reset)
+            .Write(" ")
+            .Write(DimGrey + "hello" + Reset)
+            .Write(Left(5));
+
+        var line = s.Read();
+
+        Assert.Equal(5, line.CursorOffset);
+        Assert.False(line.TextAfterCursorIsGhost);
+    }
+
+    [Fact]
+    public void CursorAtTheStartOfTheLine_IsNeverGhost()
+    {
+        // Home on a line the user composed. Nothing was typed to the left of the cursor, so the
+        // "appears nowhere in the typed region" test has no region to run against and would pass
+        // vacuously; a shell offers no prediction for an empty line, so the tie goes to "not a
+        // prediction".
+        var s = new Session()
+            .Prompt()
+            .Write(DimGrey + "echo hello" + Reset)
+            .Write(Left(10));
+
+        var line = s.Read();
+
+        Assert.Equal(0, line.CursorOffset);
+        Assert.False(line.TextAfterCursorIsGhost);
+    }
+
+    [Fact]
+    public void CursorAtTheEndOfTheLine_IsNeverGhost()
+    {
+        // Nothing past the cursor to classify. The flag is about the region, not about the line.
+        var line = new Session().Prompt().Write("git status").Read();
+
+        Assert.Equal(line.Text.Length, line.CursorOffset);
+        Assert.False(line.TextAfterCursorIsGhost);
+    }
+
+    [Fact]
+    public void GhostSuffixSpanningASoftWrap_IsGhost()
+    {
+        // A long prediction wraps like any other painted text, and the suffix's cells continue on
+        // the next row. The style scan follows the span rather than the row.
+        //
+        // The cursor is repositioned absolutely rather than with CUB: backwards cursor movement does
+        // not cross a row boundary, which is exactly why a line editor uses CUP after a wrap.
+        // "$ " puts the mark at column 2, so the end of "doc" is column 5 - row 1, column 6 in the
+        // 1-based coordinates CUP takes.
+        var s = new Session(cols: 20)
+            .Prompt()
+            .Write("doc")
+            .Write(DimGrey + "ker compose up --detach" + Reset)
+            .Write("\x1b[1;6H");
+
+        var line = s.Read();
+
+        Assert.Equal("docker compose up --detach", line.Text);
+        Assert.Equal(3, line.CursorOffset);
+        Assert.True(line.TextAfterCursorIsGhost);
+    }
 }


### PR DESCRIPTION
﻿Dogfood round 4, from the owner's screenshots on local pwsh 7 with PSReadLine
inline predictions ON (the default). Five items, each verified against the tree
before being fixed. This is the last blocker in front of the Phase 6 flag flip.

Base: main @ 477bac3 (#300 merged). Five logical commits, one per item.

---

## 1. Prediction-aware insertion

**Owner, verbatim:** "no way to put it".

**Diagnosis (confirmed).** With a PSReadLine prediction visible the shell paints
its suggestion into the grid to the right of the cursor. Those are real cells
and nothing in the VT data model records that the user did not type them, so
`GridCommandLine.Text` runs past `CursorOffset` on every prompt,
`AssistQuerySnapshot.IsUsableAsTypedPrefix` is false on every prompt, and
`CommandAssistInsertionPlanner.TryCreateInsertion` refuses. Enter falls through
to the shell; Ctrl+Enter is a dead key. The hint strip then drops its
"Ctrl+Enter insert" clause, because that clause is conditional on
`SuggestionRefreshOutcome.InsertionAppearsAvailable`, which is the same
predicate - so the feature also stops advertising the one chord that would have
worked. PR #293 wrote this up as a documented limitation. On the shell most
users run, with the setting most of them have, it means accept never works.

**Fix.** Style-aware prediction detection in the VT reader.
`GridQueryReader.TryReadCommandLine` now classifies the cells after the cursor
and reports the answer as `GridCommandLine.TextAfterCursorIsGhost`.
`AssistQuerySnapshot` carries it across the App boundary and gains
`TypedPrefix`; `IsUsableAsTypedPrefix` accepts a ghosted line; the planner
measures its delta against `TypedPrefix` rather than `Text`.

Appending is the correct response to a ghost, not a workaround for it: the
prediction lives in the shell's suggestion buffer and never in its input
buffer, and typed characters make the line editor recompute or discard it. The
ghost is display-only.

### THE GHOST-DETECTION RULE

A style class is `(foreground identity, italic, faint)`. Foreground identity is
the default-foreground flag, the palette flag, and the colour value; a cell
flagged default-foreground normalises to one class regardless of what is in its
colour field.

The run from the cursor to the logical end of the line is classified as a ghost
**only when all five hold**:

1. **Something was typed.** At least one non-blank cell before the cursor.
2. **The suffix is non-empty.** At least one non-blank cell after the cursor.
3. **The suffix is uniform.** Every non-blank cell after the cursor carries one
   style class.
4. **The suffix's style appears nowhere in the typed region.** Not "differs from
   the cell before the cursor" - the whole region.
5. **The suffix's style is recessive.** Faint, or italic, or a dim grey
   foreground: palette index 8, palette indices 232-255 (the xterm greyscale
   ramp, where PSReadLine's shipped `InlinePredictionColor` = `ESC[38;5;238m`
   sits), or an RGB colour whose channels spread by <= 24 with a maximum
   channel <= 160.

Blank cells vote on neither region - a space paints no foreground, and counting
it would make every gap inside a multi-word prediction look like a style change.
A multiline entry and a cursor at the end of the line are never ghosts.

**Conservatism argument.** Every ambiguity resolves to "not a ghost", which is
the pre-existing refusal: nothing gets worse, one keystroke of convenience is
lost.

- *Condition 5 is not redundant, and this is the case that proves it.* Type
  `echo hello`, press Home, then Right five times. Under conditions 1-4 alone
  that is a ghost: the suffix `hello` is one argument in one colour, and the
  command `echo` has its own colour, so the suffix is uniform and its style
  appears nowhere in the typed region. It is entirely the user's own text, and
  appending would splice a suggestion into the middle of the line they are
  about to run. A prediction is dim by construction - that is how the user is
  meant to tell it from what they typed - and no syntax-highlight colour is,
  because those are chosen to be legible. So the suffix must be recessive.
- *Condition 1 rules out `Home` on a composed line.* At cursor offset 0 the
  typed region is empty and condition 4 would pass vacuously. A shell offers no
  prediction for an empty line, so the tie goes against ghosting.
- *The style class is deliberately coarse.* Bold, underline, inverse and the
  background are all excluded, so two runs differing only in one of those
  compare **equal** - and comparing equal is the conservative answer, because
  condition 4 then finds the suffix style in the typed region and refuses.
  Adding attributes would make classes finer, "appears nowhere" easier to
  satisfy, and the classifier more eager.
- *An unrecognised prediction colour reads as "not a ghost".* A user who
  rebinds `InlinePredictionColor` to something vivid gets today's behaviour
  back, not a wrong insertion.

**When in doubt => not a ghost => refuse.**

**Tests (VT, 14 new).** Driven through the real `AnsiParser` with the SGR
sequences PSReadLine emits, not by poking cells: plain typed + dim grey ghost;
the same ghost as truecolour; italic ghost; faint ghost; syntax-highlighted
typed text + ghost; one typed character + full-line prediction; ghost spanning a
soft wrap. And the refusals: cursor moved back through unstyled text; the
`echo hello` + Home + Right counterexample; mixed-style suffix; a suffix whose
style also appears in the typed region; cursor at offset 0; cursor at end.

---

## 2. Direct accept from the bubble

**Owner, verbatim:** the passive bubble shows the top suggestion and offers no
way to take it; Down -> popup -> Enter was the only route, and it then refused
per item 1.

**Diagnosis - partly different from the prescription, and worth stating.**
Ctrl+Enter in the `PassiveBubble` state **already** accepted the displayed
top-1. `CommandAssistKeyRouter` resolves the insert chord whenever any surface
is visible, and `ApplyRefreshOutcome` leaves `SelectedIndex` at 0, so the
bubble's implicit selection is exactly the row it is displaying and
`TryGetInsertionText` returns it. No wiring was missing. What was missing was
any way for the user to know: with a prediction on the line the planner refused
(item 1) and the hint strip dropped the clause for the same reason, and at the
owner's pane width the terse rung spent its width dropping verbs from all three
clauses rather than dropping a clause.

**Fix.** Item 1 restores the accept. The collapse order changes so the strip
sheds **browse before insert**: pressing an arrow key at a prompt is a free
experiment anyone runs and the owner had already found Down, while Ctrl+Enter is
taught by nothing else in a terminal and is not reachable by poking. When there
is genuinely no insertion to advertise, browse comes back rather than leaving a
strip that only says `Esc`. The full rung still carries both; the popup footer
is unchanged; plain Enter stays shell-owned in the bubble state.

A controller test now pins the implicit selection directly - no popup, no arrow
key, no explicit session - so it cannot be lost silently now that the hint
promises it.

---

## 3. Staged Escape

**Owner, verbatim:** Down opens the popup; Esc then kills everything for the
command.

**Diagnosis (confirmed).** `CommandAssistController.HandleEscape` went straight
to `DismissForCurrentCommand` from every state: popup hidden, bubble hidden, and
`IsPassiveSurfaceSuppressed` taken, so the suggestion was gone for the rest of
the line. One keystroke in, a command line's worth of assist out.

**Fix.** `AssistSessionStateMachine.TryCollapsePopupToBubble` returns
`PassivePopup -> PassiveBubble` and false everywhere else, which is the
controller's signal to fall through to the existing dismissal. First press
closes the popup and leaves the rows, the selection and the visibility alone;
second press is the ordinary bubble Escape and suppresses as before.

**Explicit modes keep closing outright on the first press** - `Ctrl+Space`,
`Ctrl+R`, Help, and a confident Fix popup are surfaces the user summoned by
name, where Escape means "I am done with the thing I asked for". Staging them
would cost a press to close something opened deliberately and would make
Escape's meaning depend on which surface happened to be up. `FixPopup` is out
for the same reason even though `FixHint` can reach it: it is on screen after a
command failed, where the next act is more likely to be "clear this".

The collapse deliberately does not cancel a pass in flight (the bubble that
stays wants it) and does not clear the selection, so the bubble goes on
describing the browsed row and the insert chord goes on inserting that row.

---

## 4. Retroactive typo flagging

**Owner, verbatim:** old `gti status` entries still get suggested.

**Diagnosis (confirmed).** #300's `IsInvalidCommand` is written at capture time
only, so every entry recorded before it came back `false` however it had
failed. The owner's history was full of exactly the lines the flag exists to
suppress, and the only cure was to run each typo again, once per distinct line.

**Fix, two paths.**

**(a) Propagate by name.** Learning that `gti` is not a program is a fact about
the name, not about one execution, so
`IHistoryStore.TryMarkInvalidCommandsByFirstTokenAsync` flags every stored entry
whose first token matches - superseding records like any other patch, entries
already flagged skipped so a repeated typo costs no writes. Case-insensitive,
because `CommandAssistSuggestionEngine` groups history under
`OrdinalIgnoreCase` and a suppression narrower than the grouping does not
suppress the row.

The sweep runs **only when the unresolved name is the command line's own first
token**. A command-not-found raised from inside `npm run build` names something
that is not `npm`, and propagating that by first token would suppress every
`npm` line the user has. The recogniser already computes the distinction;
`CommandFixSuggestion.UnresolvedCommandToken` publishes it, stamped once at the
recogniser's exit so a fix added later cannot silently omit it.

**(b) Backfill on load.** An entry with `ExitCode == 127` comes back flagged.
Deliberately exactly the live capture rule and no wider - the capture path flags
on 127 with no shell test, so this does too, because a backfill that flagged
more than a fresh capture would have flagged is a rule the user cannot have
observed the product following. In-memory only, so a load costs no I/O and the
derivation is idempotent; compaction persists it if it rewrites the file
anyway. pwsh reports 1 for an unresolved name and is out of reach here - path
(a) covers those on the next reproduction, which is what the owner's case needs.

---

## 5. Chip visibility

**Owner:** never saw the integration chip once.

**Diagnosis (confirmed).** It lived in two places the owner was not: the popup
footer, which only exists while a popup is open, and a bubble slot gated on
`BubbleHintDetail == AssistHintDetail.Full`, which the progressive collapse
dropped whole at his pane width. A status indicator visible only at wide widths
reports on sessions that were never in doubt.

**Fix.** The labelled form still yields with the hint strip's verbs; what
replaces it is a collapse-exempt one-character glyph - filled dot for
integrated, hollow for basic - in the last column, so its position does not move
as the rest of the row gives up width. Exactly one of the two forms is on screen
at every rung including `Hidden`, and both carry the same tooltip. Exempting it
is affordable precisely because it is narrower than the gap between two hint
clauses. The popup footer keeps the labelled chip.

---

## Verification

CLEAN build. Per-project green:

| suite | result |
| --- | --- |
| App.Tests, `NovaTerminal.Tests.CommandAssist` (shell-integration harness suites excluded - they spawn real shells and hang on this box) | 872 passed, 0 failed |
| App.Tests, `Controls` + `Performance` | 181 passed, 0 failed |
| NovaTerminal.VT.Tests | 375 passed, 0 failed |
| NovaTerminal.Architecture.Tests | 33 passed, 0 failed |

### Mutation checks

| mutation | expected | observed |
| --- | --- | --- |
| drop the `suffixIsUniform` conjunct from `IsGhostSuffix` | ghost tests fail | `SuffixOfMixedStyles_IsNotGhost` FAILED |
| remove the retroactive first-token sweep from `CapturePipeline` | the old-`gti` test fails | `HandleCommandFailureAsync_..._FlagsOlderEntriesWithTheSameFirstToken` FAILED |
| make `TryCollapsePopupToBubble` always decline | the two-step test fails | `EscapeFromAPassivePopup_ReturnsToTheBubbleAndKeepsTheSuggestion` + `OneEscapeFromAPassivePopup_DoesNotSuppressTheBubble` FAILED |

### One pre-existing test adjusted, and why

`CommandAssistControllerTests.Typing_DoesNotBlockWhileSuggestionEngineIsSlow`
asserts `NotifyInputActivity` returns in under 100 ms while the engine takes
250 ms. It was measuring cold-start JIT, not latency: instrumented, the first
call took 122-134 ms and every call after it took 0 ms, on a path that never
waits for the engine at all. It passed only while the JIT happened to fit under
the budget, and this branch grew that call graph by a few view-model writes.

The test now warms the caller-thread path with one `NotifyInputActivity` on a
below-floor line before timing a second one. That JITs exactly the code the
stopwatch measures and none of the code it is measuring *for*: a below-floor
line returns at `MinPassiveQueryLength` inside the pass's `Task.Run`, on a
worker, before touching the store or the engine. The assertion keeps its teeth -
a regression that made the caller await the 250 ms engine still shows up on the
timed call. Verified 4/4 passing after the change, and the whole class green
(72 tests).

### Live pass

pwsh 7 with `Set-PSReadLineOption -PredictionSource HistoryAndPlugin
-PredictionViewStyle InlineView`, isolated `NOVATERM_APPDATA_ROOT`.

Ran against the clean build in an isolated `NOVATERM_APPDATA_ROOT`, pwsh 7 with
`Set-PSReadLineOption -PredictionSource HistoryAndPlugin -PredictionViewStyle
InlineView`. Shell integration reported live throughout (`integrated`). All
seven checks pass.

Substitution worth stating: `docker` is not on this box, so the prediction was
seeded with `dotnet --list-sdks` instead of `docker ...`. The shape is identical
- type a prefix, a long inline prediction is painted past the cursor - and the
prediction rendered in exactly the dim grey italic the ghost rule targets.

**1. Ctrl+Enter inserts with a prediction on the line.** Typed `dotne`; the line
showed `dotne` in the command colour followed by `t --list-sdks` in grey italic.
The bubble appeared reading `Suggest | dotne | dotnet --list-sdks`, i.e. ranked
on the typed prefix and not on the prediction. Ctrl+Enter inserted the suffix:
the line became a solid `dotnet --list-sdks` with the cursor at the end and the
prediction's styling gone. This is the case that refused on every prompt before
this branch.

**2. The bubble advertises the chord it accepts on.** The bubble's hint strip
read `Ctrl+Enter | Esc` at that pane width - the terse rung, with browse shed
and insert kept. Before this branch the same width and the same line produced
`Down | Esc`, because the insertion-available predicate was false with a
prediction painted.

**3. Down opens the popup and Enter inserts.** Down opened the row list (footer
`Enter insert | Up/Down browse | Esc close`); Up moved to the top row; Enter
inserted `t --list-sdks` onto the line and did **not** submit - the command did
not run and the prompt kept the composed text.

**4. Staged Escape.** From the open popup, the first Escape closed the popup and
left the bubble on screen still showing its suggestion. The second Escape took
the bubble down. A further keystroke on the same line brought nothing back
(suppression held), and after submitting, the next prompt showed the bubble
again.

**5. Retroactive typo flagging.** Two `gti` entries were written into the
isolated history as a pre-#300 capture looks on disk - unflagged, and with
`ExitCode: 1`, which is what pwsh reports for an unresolved name, so the
load-time 127 backfill could not reach them. Typing `gt` offered
`gti log --oneline --graph`: the owner's bug, reproduced. `gti status` was then
run once; the Fix popup recognised it ("Did you mean git?"). Typing `gt` again
produced **no suggestion at all**. On disk, the old
`gti log --oneline --graph` entry - which was never re-run - now carries a
superseding record with `IsInvalidCommand: true`, which is the retroactive sweep
and nothing else. (PSReadLine still predicts from its own history file; that is
the shell's and is deliberately untouched.)

**6. The integration glyph is visible.** The filled dot rendered at the far end
of the bubble at the terse rung, where the old rule dropped the chip entirely.
The popup footer carried the labelled `integrated` chip at the same time.

**7. Nothing ran by accident.** Every accept left the composed command sitting on
the prompt for the user to submit.


