### PR TITLE
fix(command-assist): typing in history search filters instead of closing the popup

### DIFF
--- a/src/NovaTerminal.CommandAssist/Application/AssistSessionStateMachine.cs
+++ b/src/NovaTerminal.CommandAssist/Application/AssistSessionStateMachine.cs
@@ -178,8 +178,17 @@ internal sealed class AssistSessionStateMachine
     /// reachable by the user having moved the selection (<c>Up</c>/<c>Down</c> or a click - see
     /// <see cref="OpenPopupForSelection"/>, the only transition that opens a Suggest popup), and in
     /// Search mode it is reachable only because the user pressed <c>Ctrl+R</c>. Typing never reaches
-    /// it: <see cref="ObserveTypedInput"/> closes the popup, so the ordinary
+    /// it from the passive flow: <see cref="ObserveTypedInput"/> closes the popup, so the ordinary
     /// type-a-command-and-press-Enter flow is untouched and <c>Enter</c> stays shell-owned there.
+    /// </para>
+    /// <para>
+    /// <strong>Typing inside history search keeps it armed, and that is the point.</strong> Since
+    /// typing no longer leaves <see cref="AssistSessionState.HistorySearch"/>, the popup and its
+    /// selection survive a filter keystroke, so <c>Enter</c> goes on inserting the highlighted row
+    /// while the user narrows the list. That is what <c>Ctrl+R</c> means everywhere else - the match
+    /// is what <c>Enter</c> takes - and it is the state the user is demonstrably in, having summoned a
+    /// list of history entries and then described which one. <c>Escape</c> is the way back to a
+    /// shell-owned <c>Enter</c>, exactly as it is for the row list opened by <c>Ctrl+R</c> alone.
     /// </para>
     /// <para>
     /// Help and Fix are excluded even when their popup is open with a row selected. Their rows are
@@ -279,9 +288,38 @@ internal sealed class AssistSessionStateMachine
 
     /// <summary>
     /// The user typed into the shell. Returns to Suggest mode with the popup closed, preserving
-    /// whether this is an explicit session - typing on after a history search stays explicit.
+    /// whether this is an explicit session - except in <see cref="AssistSessionState.HistorySearch"/>,
+    /// where typing is the filter and the session stays where it is.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// <strong>History search keeps itself, and this is a policy reversal.</strong> Phase 0c had this
+    /// transition drop <see cref="AssistSessionState.HistorySearch"/> to
+    /// <see cref="AssistSessionState.ExplicitBubble"/>, on the reading that typing is a return to the
+    /// Suggest scope with the explicitness carried along - <c>ObserveTypedInput_ReturnsToSuggestPreservingExplicitness</c>
+    /// pinned exactly that. What it meant in the user's hands was that <c>Ctrl+R</c> followed by a
+    /// single character closed the popup: the owner's report is "when Ctrl+R shows history, if I type
+    /// it just hides that instead of searching". Every shell's reverse-search and every fuzzy finder
+    /// does the opposite - the list stays up and narrows - and there is nothing else the keystroke
+    /// could plausibly have meant, because the user summoned a list of history entries and then began
+    /// describing which one.
+    /// </para>
+    /// <para>
+    /// The explicitness the old transition was protecting is not lost, it is stronger: staying in
+    /// <see cref="AssistSessionState.HistorySearch"/> is still an <see cref="IsExplicitSession"/> and
+    /// still an <see cref="IsUserRequestedSurface"/>, so everything the old ExplicitBubble bought
+    /// (history and snippets in scope, a surface no placement heuristic may hide, immunity from the
+    /// per-command Escape suppression) holds, and the mode the user asked for holds too.
+    /// </para>
+    /// <para>
+    /// Nothing about where the keystroke <em>goes</em> changes: the character is not search-box input,
+    /// it reaches the shell like any other, and the query the refreshed ranking reads is the command
+    /// line the shell painted (<see cref="AssistQuerySnapshot.TextBeforeCursor"/>). Backspace arrives
+    /// here as the same event and narrows the query back the same way. The passive flow and the
+    /// helper states are untouched: typing out of Help or Fix still drops to a passive bubble, which
+    /// is right, because there the keystroke is the user moving on from content they asked to read
+    /// rather than refining it.
+    /// </para>
     /// <para>
     /// <strong>Known weakness, accepted rather than fixed:</strong> one keystroke after a paste
     /// clears <see cref="IsCurrentSubmissionSuppressed"/>, so "paste a command, add a character,
@@ -306,6 +344,14 @@ internal sealed class AssistSessionStateMachine
     public void ObserveTypedInput()
     {
         IsCurrentSubmissionSuppressed = false;
+
+        // Typing in history search is the search. Written as an early return rather than folded into
+        // the ternary because IsExplicitSession is true here too, so the ternary cannot express it.
+        if (State == AssistSessionState.HistorySearch)
+        {
+            return;
+        }
+
         State = IsExplicitSession ? AssistSessionState.ExplicitBubble : AssistSessionState.PassiveBubble;
     }
 

--- a/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
@@ -352,6 +352,18 @@ public sealed class CommandAssistController
     /// Backspace deliberately has no separate entry point and no "is there anything to delete"
     /// guard. Whether the line got shorter is the grid's business.
     /// </para>
+    /// <para>
+    /// <strong>History search filters rather than closing.</strong> A keystroke used to mean the same
+    /// thing in every mode - drop to a Suggest bubble with the popup shut - and in
+    /// <c>Ctrl+R</c> that read as the surface being dismissed by the first character of the thing the
+    /// user opened it to look for (the owner's report: "when Ctrl+R shows history, if I type it just
+    /// hides that instead of searching"). In Search mode the surface now stands still and the
+    /// refresh does the work: <see cref="AssistSessionStateMachine.ObserveTypedInput"/> keeps the
+    /// state, so <see cref="QueueRefreshSuggestions"/> re-ranks the history-only Search scope against
+    /// the query the pass reads off the grid. The keystroke still reaches the shell - there is no
+    /// search box, and the query is the command line - so the debounce that coalesces passive typing
+    /// applies here too.
+    /// </para>
     /// </remarks>
     public void NotifyInputActivity()
     {
@@ -361,6 +373,21 @@ public sealed class CommandAssistController
         }
 
         _state.ObserveTypedInput();
+
+        if (_state.Mode == CommandAssistMode.Search)
+        {
+            // Held rather than merely left alone. Nothing else in this method can reach a Search
+            // session (an explicit surface is exempt from the passive suppression below, and its
+            // visibility does not depend on the rows a refresh happens to produce), so stating the
+            // invariant here is what keeps a filter keystroke from ever being the thing that takes
+            // the popup down. The label is deliberately not rewritten: it was decided when the
+            // surface opened, from a grid read this path must not repeat per keystroke.
+            ViewModel.IsPopupOpen = true;
+            ViewModel.IsVisible = true;
+            QueueRefreshSuggestions(isTypingTriggered: true);
+            return;
+        }
+
         ViewModel.ModeLabel = "Suggest";
         ViewModel.IsPopupOpen = false;
 
@@ -1018,9 +1045,21 @@ public sealed class CommandAssistController
         {
             _suggestions.Clear();
             _suggestions.AddRange(outcome.Suggestions);
+
+            // Reset to the top row on every pass, fzf-style. The rows are a different list than the
+            // one the old selection indexed into, so carrying the index over would move the highlight
+            // to an unrelated command; index 0 is the best match for what the user has typed so far,
+            // which is the row they mean if they stop typing and press the accept key.
             ViewModel.SelectedIndex = _suggestions.Count > 0 ? 0 : -1;
-            ViewModel.EmptyStateText = string.Empty;
-            ViewModel.ShowEmptyState = false;
+
+            // The empty state a filtered history search needs: see AssistEmptyStates.NoHistoryMatch.
+            // Only with a query - a Search pass that read no query at all is the degraded recency list,
+            // and "no matching commands" would blame the user's typing for a markless session.
+            bool isEmptyHistorySearch = outcome.RequestedMode == CommandAssistMode.Search &&
+                                        _suggestions.Count == 0 &&
+                                        !string.IsNullOrEmpty(outcome.Query);
+            ViewModel.EmptyStateText = isEmptyHistorySearch ? AssistEmptyStates.NoHistoryMatch : string.Empty;
+            ViewModel.ShowEmptyState = isEmptyHistorySearch;
             SyncSuggestionViewModel();
         }
 

--- a/src/NovaTerminal.CommandAssist/Providers/AssistEmptyStates.cs
+++ b/src/NovaTerminal.CommandAssist/Providers/AssistEmptyStates.cs
@@ -37,6 +37,19 @@ public static class AssistEmptyStates
     /// <summary>A command failed and no recogniser matched it. The pre-Phase-5 string.</summary>
     public const string NoLocalFix = "No likely local fix found.";
 
+    /// <summary>
+    /// History search was filtered down to nothing by the command line the user is typing.
+    /// </summary>
+    /// <remarks>
+    /// The one entry here that belongs to the ranking pass rather than to a content provider, and it
+    /// only became reachable when typing started filtering the <c>Ctrl+R</c> list instead of closing
+    /// it. Without it, narrowing past the last match leaves an open popup containing nothing, which
+    /// reads as the surface having broken rather than as the search having no answer. It is kept
+    /// beside the others because it answers the same question they do - what does a surface say when
+    /// it has nothing to show - and splitting one string out would cost a second home for it.
+    /// </remarks>
+    public const string NoHistoryMatch = "No matching commands in history.";
+
     /// <summary>Nothing is registered to answer documentation questions.</summary>
     public const string NoHelpProvider = "No help provider is configured.";
 

--- a/tests/NovaTerminal.App.Tests/CommandAssist/AssistSessionStateMachineTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/AssistSessionStateMachineTests.cs
@@ -179,17 +179,45 @@ public sealed class AssistSessionStateMachineTests
         Assert.Equal(AssistSessionState.FixHint, tentative.State);
     }
 
+    /// <summary>
+    /// Typing returns every state to Suggest, carrying the explicitness with it - except history
+    /// search, which typing <em>is</em>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>The HistorySearch row changed, and the row it replaced was a shipped bug.</strong> This
+    /// table used to say <c>HistorySearch -> ExplicitBubble</c>, under the name
+    /// <c>ObserveTypedInput_ReturnsToSuggestPreservingExplicitness</c>: Phase 0c read a keystroke as
+    /// "the user is composing a command again", and preserved the one thing it thought was worth
+    /// keeping from a <c>Ctrl+R</c> session, its explicitness. What the user saw was the history popup
+    /// vanishing on the first character of the thing they had opened it to look for - the owner's
+    /// report, verbatim: "when Ctrl+R shows history, if I type it just hides that instead of
+    /// searching".
+    /// </para>
+    /// <para>
+    /// The old row's intent survives, re-expressed rather than dropped: explicitness was never lost by
+    /// typing and still is not, because <see cref="AssistSessionState.HistorySearch"/> is itself an
+    /// explicit session (see <c>IsExplicitSession_IsDerivedFromState</c> above, which is where that
+    /// property is now pinned for this state). Staying put is the stronger form of the same guarantee -
+    /// the session keeps both its explicitness and the mode the user asked for.
+    /// </para>
+    /// <para>
+    /// Every other row is deliberately untouched, and the Help and Fix rows are the ones to be careful
+    /// about: typing out of a helper surface is the user moving on from content they asked to read, not
+    /// refining it, so those still drop to a passive bubble.
+    /// </para>
+    /// </remarks>
     [Theory]
     [InlineData(AssistSessionState.Hidden, AssistSessionState.PassiveBubble)]
     [InlineData(AssistSessionState.PassiveBubble, AssistSessionState.PassiveBubble)]
     [InlineData(AssistSessionState.PassivePopup, AssistSessionState.PassiveBubble)]
     [InlineData(AssistSessionState.ExplicitBubble, AssistSessionState.ExplicitBubble)]
     [InlineData(AssistSessionState.ExplicitPopup, AssistSessionState.ExplicitBubble)]
-    [InlineData(AssistSessionState.HistorySearch, AssistSessionState.ExplicitBubble)]
+    [InlineData(AssistSessionState.HistorySearch, AssistSessionState.HistorySearch)]
     [InlineData(AssistSessionState.Help, AssistSessionState.PassiveBubble)]
     [InlineData(AssistSessionState.FixHint, AssistSessionState.PassiveBubble)]
     [InlineData(AssistSessionState.FixPopup, AssistSessionState.PassiveBubble)]
-    public void ObserveTypedInput_ReturnsToSuggestPreservingExplicitness(
+    public void ObserveTypedInput_ReturnsToSuggestPreservingExplicitness_ExceptInHistorySearch(
         AssistSessionState state,
         AssistSessionState expected)
     {
@@ -198,7 +226,15 @@ public sealed class AssistSessionStateMachineTests
         machine.ObserveTypedInput();
 
         Assert.Equal(expected, machine.State);
+
+        // The half of the old name that did not change: whatever typing did to the state, an explicit
+        // session is still explicit afterwards.
+        if (CreateInState(state).IsExplicitSession)
+        {
+            Assert.True(machine.IsExplicitSession);
+        }
     }
+
 
     [Theory]
     [InlineData(AssistSessionState.Hidden)]
@@ -400,20 +436,45 @@ public sealed class AssistSessionStateMachineTests
     }
 
     /// <summary>
-    /// The one path that has to survive the split: Ctrl+R, then keep typing. The session stays
-    /// explicit, which is what widens the suggestion scope back out to history and snippets.
+    /// The one path that has to survive the split: <c>Ctrl+R</c>, then keep typing. The session stays
+    /// explicit - and now stays in Search, because typing after <c>Ctrl+R</c> is the search.
     /// </summary>
+    /// <remarks>
+    /// The original of this test asserted <c>ExplicitBubble</c> and <c>Suggest</c>, which is what the
+    /// Phase 0c transition produced and what the owner saw as the popup closing on the first character
+    /// he typed. Its intent - "explicitness survives typing" - is asserted below in its own right
+    /// rather than through the state that used to carry it; see
+    /// <c>ObserveTypedInput_ReturnsToSuggestPreservingExplicitness_ExceptInHistorySearch</c> for the
+    /// table row and the reasoning.
+    /// </remarks>
     [Fact]
-    public void HistorySearch_ThenTyping_StaysAnExplicitSession()
+    public void HistorySearch_ThenTyping_StaysAnExplicitHistorySearch()
     {
         var machine = new AssistSessionStateMachine();
 
         machine.OpenSearch();
         machine.ObserveTypedInput();
 
-        Assert.Equal(AssistSessionState.ExplicitBubble, machine.State);
+        // Was ExplicitBubble/Suggest. The assertion that changed is the mode, and it changed because
+        // "keep typing after Ctrl+R" means "narrow this list", not "start composing a command": see
+        // AssistSessionStateMachine.ObserveTypedInput.
+        Assert.Equal(AssistSessionState.HistorySearch, machine.State);
+        Assert.Equal(CommandAssistMode.Search, machine.Mode);
+
+        // The properties the old assertions were standing in for, asserted directly. Explicitness is
+        // what widens the ranking scope and exempts the surface from the passive Escape suppression;
+        // being user-requested is what stops a placement heuristic hiding it. Both held before this
+        // change and both still hold, which is the whole of what the old expectation was protecting.
         Assert.True(machine.IsExplicitSession);
-        Assert.Equal(CommandAssistMode.Suggest, machine.Mode);
+        Assert.True(machine.IsUserRequestedSurface);
+        Assert.True(machine.AllowsSuggestionRefresh);
+        Assert.True(machine.AllowsPassiveSuggestions);
+
+        // Backspace arrives as the same event, and a query erased back to nothing is still a search:
+        // the surface stays up showing the recency list rather than closing under the user.
+        machine.ObserveTypedInput();
+
+        Assert.Equal(AssistSessionState.HistorySearch, machine.State);
     }
 
     // ------------------------------- passive suppression has to end somehow (PR #293, blocker 2)

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistControllerTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistControllerTests.cs
@@ -1,6 +1,7 @@
 using NovaTerminal.CommandAssist.Application;
 using NovaTerminal.CommandAssist.Domain;
 using NovaTerminal.CommandAssist.Models;
+using NovaTerminal.CommandAssist.Providers;
 using NovaTerminal.CommandAssist.ShellIntegration.Contracts;
 using System.Diagnostics;
 
@@ -993,6 +994,20 @@ public sealed class CommandAssistControllerTests
     /// be swallowed by an insertion. The disarm is structural - typing closes the popup - and this pins
     /// it because the consequence of losing it is the user's Enter not running their command.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The browse this starts from is a Suggest one (<c>Ctrl+Space</c> then <c>Down</c>), where it used
+    /// to be a <c>Ctrl+R</c> one. That is not an incidental rewrite: typing in history search no longer
+    /// closes the popup, so the structural disarm this test is named for does not happen there - and
+    /// must not, because in a reverse search the accept key taking the highlighted match is the whole
+    /// interaction. See <c>TypingInHistorySearch_KeepsEnterArmedOnTheNewTopRow</c> for that side, and
+    /// <c>Escape_DisarmsEnter</c> for the key that does hand <c>Enter</c> back to the shell there.
+    /// </para>
+    /// <para>
+    /// The flow this protects - type a command, browse a suggestion, keep typing, press Enter to run
+    /// what you typed - is unchanged and is the one that would cost the user a submitted command.
+    /// </para>
+    /// </remarks>
     [Fact]
     public async Task TypingAfterABrowse_DisarmsEnterAgain()
     {
@@ -1003,7 +1018,7 @@ public sealed class CommandAssistControllerTests
         var grid = new FakeGrid();
         var controller = CreateController(historyStore, grid: grid);
 
-        controller.OpenHistorySearch();
+        controller.ToggleAssist();
         await historyStore.WaitForSearchSettledAsync();
         await WaitForConditionAsync(() => controller.Suggestions.Count > 1);
         controller.MoveSelectionDown();
@@ -1013,6 +1028,232 @@ public sealed class CommandAssistControllerTests
         controller.NotifyInputActivity();
 
         Assert.False(controller.IsAcceptOnEnterArmed);
+    }
+
+    // ------------------------------ typing filters history search instead of closing it
+
+    /// <summary>
+    /// The owner's report: "when Ctrl+R shows history, if I type it just hides that instead of
+    /// searching". Typing now narrows the list in place, which is what every shell's reverse search and
+    /// every fuzzy finder does.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Mutation check:</strong> put the <c>HistorySearch -> ExplicitBubble</c> transition back
+    /// in <c>AssistSessionStateMachine.ObserveTypedInput</c> and this fails on the popup assertion -
+    /// the rows still narrow, because an explicit Suggest session ranks history too, but the surface
+    /// the user was reading is gone.
+    /// </para>
+    /// <para>
+    /// The keystroke is not search-box input and there is no search box: the character reaches the
+    /// shell, the shell paints it, and the query the pass ranks on is read back off the grid. That is
+    /// why this test moves the fake grid rather than handing the controller any text.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task TypingInHistorySearch_FiltersTheRowsAndKeepsThePopupOpen()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        historyStore.Seed(
+            CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")),
+            CreateEntry("git stash", DateTimeOffset.Parse("2026-03-01T09:59:00+00:00")),
+            CreateEntry("npm run build", DateTimeOffset.Parse("2026-03-01T09:58:00+00:00")));
+        var grid = new FakeGrid();
+        var controller = CreateController(historyStore, grid: grid);
+
+        controller.OpenHistorySearch();
+        await WaitForConditionAsync(() => controller.Suggestions.Count == 3);
+
+        grid.SetLine("git");
+        controller.NotifyInputActivity();
+        await WaitForConditionAsync(() => controller.ViewModel.QueryText == "git" &&
+                                          controller.Suggestions.Count == 2);
+
+        Assert.Equal(AssistSessionState.HistorySearch, controller.SessionState);
+        Assert.True(controller.ViewModel.IsVisible);
+        Assert.True(controller.ViewModel.IsPopupOpen);
+        Assert.True(controller.ViewModel.Popup.IsVisible);
+        Assert.Equal("History", controller.ViewModel.ModeLabel);
+        Assert.DoesNotContain(controller.Suggestions, row => row.InsertText == "npm run build");
+    }
+
+    /// <summary>
+    /// Backspace is the same event and widens the list back out. Nothing tells Command Assist that a
+    /// character was deleted rather than added - the grid simply says the line is shorter now.
+    /// </summary>
+    [Fact]
+    public async Task BackspaceInHistorySearch_WidensTheRowsAgain()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        historyStore.Seed(
+            CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")),
+            CreateEntry("git stash", DateTimeOffset.Parse("2026-03-01T09:59:00+00:00")));
+        var grid = new FakeGrid();
+        var controller = CreateController(historyStore, grid: grid);
+
+        controller.OpenHistorySearch();
+        await WaitForConditionAsync(() => controller.Suggestions.Count == 2);
+
+        grid.SetLine("git status");
+        controller.NotifyInputActivity();
+        await WaitForConditionAsync(() => controller.ViewModel.QueryText == "git status" &&
+                                          controller.Suggestions.Count == 1);
+
+        grid.SetLine("git st");
+        controller.NotifyInputActivity();
+        await WaitForConditionAsync(() => controller.ViewModel.QueryText == "git st" &&
+                                          controller.Suggestions.Count == 2);
+
+        Assert.Equal(AssistSessionState.HistorySearch, controller.SessionState);
+        Assert.True(controller.ViewModel.IsPopupOpen);
+    }
+
+    /// <summary>
+    /// Erasing the line back to nothing leaves the user where <c>Ctrl+R</c> put them - the recency list,
+    /// still open - rather than closing the surface they never asked to close.
+    /// </summary>
+    [Fact]
+    public async Task ErasingTheLineInHistorySearch_FallsBackToTheRecencyList()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        historyStore.Seed(
+            CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")),
+            CreateEntry("npm run build", DateTimeOffset.Parse("2026-03-01T09:58:00+00:00")));
+        var grid = new FakeGrid();
+        var controller = CreateController(historyStore, grid: grid);
+
+        controller.OpenHistorySearch();
+        await WaitForConditionAsync(() => controller.Suggestions.Count == 2);
+
+        grid.SetLine("git");
+        controller.NotifyInputActivity();
+        await WaitForConditionAsync(() => controller.Suggestions.Count == 1);
+
+        // Ctrl+U, or one backspace too many. Either way the grid says the line is empty.
+        grid.SetLine(string.Empty);
+        controller.NotifyInputActivity();
+        await WaitForConditionAsync(() => controller.ViewModel.QueryText.Length == 0 &&
+                                          controller.Suggestions.Count == 2);
+
+        Assert.Equal(AssistSessionState.HistorySearch, controller.SessionState);
+        Assert.True(controller.ViewModel.IsVisible);
+        Assert.True(controller.ViewModel.IsPopupOpen);
+        Assert.False(controller.ViewModel.ShowEmptyState);
+    }
+
+    /// <summary>
+    /// Every query change resets the highlight to the top row, fzf-style: the rows are a different list
+    /// than the one the old index pointed into, so keeping the index would move the highlight to an
+    /// unrelated command.
+    /// </summary>
+    [Fact]
+    public async Task TypingInHistorySearch_ResetsTheSelectionToTheTopRow()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        historyStore.Seed(
+            CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")),
+            CreateEntry("git stash", DateTimeOffset.Parse("2026-03-01T09:59:00+00:00")),
+            CreateEntry("npm run build", DateTimeOffset.Parse("2026-03-01T09:57:00+00:00")));
+        var grid = new FakeGrid();
+        var controller = CreateController(historyStore, grid: grid);
+
+        controller.OpenHistorySearch();
+        await WaitForConditionAsync(() => controller.Suggestions.Count == 3);
+        controller.MoveSelectionDown();
+        controller.MoveSelectionDown();
+        Assert.Equal(2, controller.ViewModel.SelectedIndex);
+
+        grid.SetLine("git st");
+        controller.NotifyInputActivity();
+        await WaitForConditionAsync(() => controller.ViewModel.QueryText == "git st" &&
+                                          controller.Suggestions.Count == 2);
+
+        Assert.Equal(0, controller.ViewModel.SelectedIndex);
+        Assert.Equal(controller.Suggestions[0].DisplayText, controller.ViewModel.TopSuggestionText);
+    }
+
+    /// <summary>
+    /// The accept key follows the filtering: it stays armed on whatever the new top row is, which is
+    /// what makes "Ctrl+R, type a few characters, press Enter" work the way every shell teaches.
+    /// </summary>
+    [Fact]
+    public async Task TypingInHistorySearch_KeepsEnterArmedOnTheNewTopRow()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        historyStore.Seed(
+            CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")),
+            CreateEntry("npm run build", DateTimeOffset.Parse("2026-03-01T09:58:00+00:00")));
+        var grid = new FakeGrid();
+        var controller = CreateController(historyStore, grid: grid);
+
+        controller.OpenHistorySearch();
+        await WaitForConditionAsync(() => controller.Suggestions.Count == 2);
+
+        grid.SetLine("npm");
+        controller.NotifyInputActivity();
+        await WaitForConditionAsync(() => controller.ViewModel.QueryText == "npm" &&
+                                          controller.Suggestions.Count == 1);
+
+        Assert.True(controller.IsAcceptOnEnterArmed);
+        Assert.True(controller.TryGetInsertionText(out string? insertionText));
+        Assert.Equal("npm run build", insertionText);
+    }
+
+    /// <summary>
+    /// Narrowing past the last match keeps the popup open and says why. An open list containing nothing
+    /// reads as the surface having broken; the sentence is what makes it read as the search having no
+    /// answer.
+    /// </summary>
+    [Fact]
+    public async Task TypingInHistorySearch_WithNoMatches_KeepsThePopupOpenAndSaysSo()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        historyStore.Seed(CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")));
+        var grid = new FakeGrid();
+        var controller = CreateController(historyStore, grid: grid);
+
+        controller.OpenHistorySearch();
+        await WaitForConditionAsync(() => controller.Suggestions.Count == 1);
+
+        grid.SetLine("qqq");
+        controller.NotifyInputActivity();
+        await WaitForConditionAsync(() => controller.ViewModel.QueryText == "qqq" &&
+                                          controller.Suggestions.Count == 0);
+
+        Assert.Equal(AssistSessionState.HistorySearch, controller.SessionState);
+        Assert.True(controller.ViewModel.IsVisible);
+        Assert.True(controller.ViewModel.IsPopupOpen);
+        Assert.True(controller.ViewModel.ShowEmptyState);
+        Assert.Equal(AssistEmptyStates.NoHistoryMatch, controller.ViewModel.Popup.EmptyStateText);
+        Assert.False(controller.IsAcceptOnEnterArmed);
+    }
+
+    /// <summary>
+    /// The query is the text left of the cursor, so PSReadLine's inline prediction cannot filter the
+    /// list to its own guess. The same rule as PR #293's blocker 1, now reachable from Search mode
+    /// because Search mode is where a keystroke lands.
+    /// </summary>
+    [Fact]
+    public async Task TypingInHistorySearch_RanksOnTheTextBeforeTheCursor()
+    {
+        var historyStore = new InMemoryHistoryStore();
+        historyStore.Seed(
+            CreateEntry("npm run build", DateTimeOffset.Parse("2026-03-01T10:00:00+00:00")),
+            CreateEntry("git status", DateTimeOffset.Parse("2026-03-01T09:59:00+00:00")));
+        var grid = new FakeGrid();
+        var controller = CreateController(historyStore, grid: grid);
+
+        controller.OpenHistorySearch();
+        await WaitForConditionAsync(() => controller.Suggestions.Count == 2);
+
+        // The user typed `np`; the shell painted `npm run build` and left the cursor after the two
+        // characters that are actually theirs.
+        grid.SetLine("npm run build", cursorOffset: 2);
+        controller.NotifyInputActivity();
+        await WaitForConditionAsync(() => controller.ViewModel.QueryText == "np");
+
+        Assert.Equal("np", controller.ViewModel.QueryText);
+        Assert.Equal(AssistSessionState.HistorySearch, controller.SessionState);
     }
 
     /// <summary>Escape disarms too: there is no row to accept once the surface is gone.</summary>

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistPassiveBubbleTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistPassiveBubbleTests.cs
@@ -612,6 +612,47 @@ public sealed class CommandAssistPassiveBubbleTests
         Assert.Equal(0, delay.RequestCount);
     }
 
+    /// <summary>
+    /// Typing <em>inside</em> history search is debounced, unlike the <c>Ctrl+R</c> that opened it.
+    /// </summary>
+    /// <remarks>
+    /// The two halves of the rule meeting in one surface. Opening is a single deliberate act with
+    /// nothing to coalesce, so it is instant; the characters that follow are keystrokes like any others
+    /// - each one costs a grid read, a store recall and a ranking pass - so a burst produces one pass,
+    /// not one per character. Nothing special was needed to get this: the filter refresh is queued as
+    /// typing-triggered, so it rides the coalescing the passive path already had.
+    /// </remarks>
+    [Fact]
+    public async Task TypingInHistorySearch_IsDebouncedLikePassiveTyping()
+    {
+        var history = new RecordingHistoryStore();
+        history.Seed("git status");
+        var grid = new FakeGrid();
+        var delay = new GatedDelay();
+        CommandAssistController controller = CreateController(history, grid, delay);
+
+        controller.OpenHistorySearch();
+        await WaitForAsync(() => controller.Suggestions.Count > 0);
+        Assert.Equal(0, delay.RequestCount);
+        Assert.Equal(1, history.SearchCount);
+
+        foreach (string line in new[] { "g", "gi", "git" })
+        {
+            grid.SetLine(line);
+            controller.NotifyInputActivity();
+        }
+
+        // Every one of them is still sitting in the debounce: the store has seen nothing since the
+        // recency recall the open asked for.
+        Assert.Equal(1, history.SearchCount);
+        delay.ReleaseAll();
+
+        await WaitForAsync(() => controller.ViewModel.QueryText == "git");
+        Assert.Equal(3, delay.RequestCount);
+        Assert.Equal(2, history.SearchCount);
+        Assert.Equal(new[] { "git" }, history.SearchQueries);
+    }
+
     // ------------------------------------------------------------------ gating decoupled (task 3)
 
     /// <summary>


### PR DESCRIPTION
## The bug

Owner report: "when Ctrl+R shows history, if I type it just hides that instead of searching."

Ctrl+R opened the history popup, and the first character typed took it down. What the user got was
a list they had summoned, dismissed by the first character of the thing they had summoned it to find.
Every shell's reverse search and every fuzzy finder does the opposite: the list stays up and narrows.

## Root cause

`AssistSessionStateMachine.ObserveTypedInput()` transitioned `HistorySearch -> ExplicitBubble`, and
`CommandAssistController.NotifyInputActivity()` then closed the popup and relabelled the surface
"Suggest". The keystroke reached the shell (correct - there is no search box, the query is the
command line), but the search intent was thrown away with the state.

## Old policy vs new

**Old (Phase 0c):** a keystroke means "the user is composing a command again", so every state returns
to Suggest, carrying its explicitness along. In `Ctrl+R` that read as the popup being dismissed by the
search term.

**New:** typing (and backspace) in `HistorySearch` keeps `HistorySearch`. The popup stays open, the
refresh re-ranks the history-only Search scope against the query the pass reads off the grid, and the
selection resets to the top row on every query change (fzf-style).

Specifics:

- Backspace arrives as the same event and re-widens the list.
- An erased line (empty query) stays in history search showing the recency list - the Ctrl+R initial
  state - rather than closing.
- Narrowing past the last match keeps the popup open and shows a new empty state,
  `AssistEmptyStates.NoHistoryMatch` ("No matching commands in history."). It is only shown when there
  is a query, so a markless session's recency list is never labelled a failed search.
- Ranking uses `AssistQuerySnapshot.TextBeforeCursor`, so PSReadLine's inline prediction cannot filter
  the list to the shell's guess (the PR #293 blocker-1 rule, now reachable from Search mode).
- Filter refreshes are queued as typing-triggered, so they ride the existing 75 ms debounce.
  `OpenHistorySearch` itself stays un-debounced and instant.
- Passive-flow transitions are untouched. Typing out of Help or Fix still drops to a passive bubble:
  there the keystroke is the user moving on from content they asked to read, not refining it.
- Escape, accept and submit are unchanged. Escape still closes an explicit surface outright (the #301
  staging is passive-popup-only).
- Hint strip: unchanged and still accurate. With the popup open and a row selected it reads
  "Enter insert | Up/Down browse | Esc close", which is what the keys now do while filtering.

## The pinned test, and how its intent was re-expressed

`AssistSessionStateMachineTests.ObserveTypedInput_ReturnsToSuggestPreservingExplicitness` pinned the
old transition with the row `[InlineData(HistorySearch, ExplicitBubble)]`. It was not deleted:

- The row is now `[InlineData(HistorySearch, HistorySearch)]`, the test is renamed
  `..._ExceptInHistorySearch`, and a remark explains the policy change and why the other eight rows
  did not move.
- The intent - "explicitness survives typing" - is asserted directly rather than through the state
  that used to carry it: the test now also asserts `IsExplicitSession` still holds for every state
  that had it. Staying in `HistorySearch` is the stronger form of the same guarantee, since
  `HistorySearch` is itself an explicit session and a user-requested surface.
- `HistorySearch_ThenTyping_StaysAnExplicitSession` (the companion named test) is renamed
  `..._StaysAnExplicitHistorySearch` and now asserts `IsExplicitSession`, `IsUserRequestedSurface`,
  `AllowsSuggestionRefresh` and `AllowsPassiveSuggestions` in their own right.
- `CommandAssistControllerTests.TypingAfterABrowse_DisarmsEnterAgain` now starts from a Suggest browse
  (Ctrl+Space then Down) instead of a Ctrl+R one. The flow it protects - type, browse, keep typing,
  press Enter to run what you typed - is unchanged; the disarm simply does not happen in a reverse
  search, where the accept key taking the highlighted match is the whole interaction.

## New tests

`CommandAssistControllerTests`: typing filters and the popup stays open; backspace re-widens; erasing
the line falls back to the recency list; the selection resets to row 0; Enter stays armed on the new
top row; no matches keeps the popup open with the empty state; ranking uses the text before the cursor.
`CommandAssistPassiveBubbleTests`: typing inside history search is debounced like passive typing while
the Ctrl+R that opened it is not.

## Verification

Clean build (clean + rebuild), 0 errors.

Tests: 338 green across `AssistSessionStateMachineTests`, `CommandAssistControllerTests`,
`CommandAssistPassiveBubbleTests`, `CommandAssistGridTruthTests`. A further 364 green across the rest
of the Command Assist and pane suites (layout, overlay render, pane shortcuts, key handling, shortcut
bindings, content-provider seam, key router, insertion planner, suggestion engine, capture pipeline,
pane insertion, markless capture, grid desync, grid command line).

Mutation check: reverting the transition (making `ObserveTypedInput` drop `HistorySearch` again) fails
exactly 8 tests - the re-expressed pinned pair and the six new controller filter tests - and nothing
else.

## Live pass

Built the app and drove it against an isolated `NOVATERM_APPDATA_ROOT` with a pwsh profile and shell
integration live ("integrated" chip):

- `Ctrl+R` opens the History popup with the recency list.
- Typing `git` keeps the popup open, the header becomes `History  git`, and the rows narrow from
  five commands to the three git ones. The typed characters are visible on the shell line behind the
  popup.
- With PSReadLine's inline prediction painted past the cursor (`git` + a dim `pull`), the query used
  was `git` - the prediction did not reach the ranking.
- Backspace to `g` re-widens; backspace to empty returns the header to `History` and the rows to the
  recency list, popup still open.
- `Esc` closes.
- `Enter` on a filtered list inserts the selected row: typing `echo g` and pressing Enter left
  `echo git-alpha` on the command line, unsubmitted.

## Known limitation found while verifying (pre-existing, not introduced here)

`CommandAssistInsertionPlanner` is append-only: it can complete a row only when the selected command
starts with what is on the line. So filtering by a term that is not a prefix - typing `git` and
selecting `echo git-alpha` - refuses, and the accept falls through to the shell, which submits what was
typed. That is the documented pre-existing behaviour of a refused accept, and it is not a regression
(before this change typing closed the popup, so Enter was never assist-owned there at all), but a
substring filter makes it far easier to reach. Making accept replace the line the way fzf does is a
separate policy decision - it would mean Command Assist deleting characters the user typed, which the
planner's "insertion stays additive" rule currently forbids - and belongs in its own issue.
