### PR TITLE
fix(command-assist): one-line suggestion rows - metadata lives in the detail panel

### DIFF
--- a/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml
+++ b/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml
@@ -76,33 +76,36 @@
                                                 Classes.selected="{Binding IsSelected}"
                                                 Margin="0,1"
                                                 PointerPressed="OnSuggestionRowPointerPressed">
-                                            <Grid ColumnDefinitions="Auto,*,Auto">
+                                            <!--
+                                                One-line row (owner request, V2 row-density round):
+                                                the command text is the row. Time, cwd, exit code and
+                                                badge text used to stack three lines high here; all of
+                                                it survives, just in the detail panel this row feeds
+                                                (SelectedDescriptionText / SelectedMetadataText /
+                                                SelectedBadgesText on the popup view-model) rather than
+                                                repeated on every row. The one exception is Pinned: it
+                                                is the one fact that changes which rows exist rather
+                                                than merely describing the selected one, so it keeps a
+                                                single subtle glyph in the gutter instead of moving out
+                                                entirely.
+                                            -->
+                                            <Grid ColumnDefinitions="Auto,Auto,*">
                                                 <TextBlock Text="{Binding SelectionGlyph}"
                                                            Foreground="#8EC5FF"
                                                            Width="12"
-                                                           VerticalAlignment="Top"/>
-                                                <StackPanel Grid.Column="1"
-                                                            Spacing="1">
-                                                    <TextBlock Text="{Binding DisplayText}"
-                                                               Foreground="White"
-                                                               FontFamily="Consolas"
-                                                               TextTrimming="CharacterEllipsis"/>
-                                                    <TextBlock Text="{Binding DescriptionText}"
-                                                               Foreground="#C8E1FF"
-                                                               FontSize="11"
-                                                               TextWrapping="Wrap"/>
-                                                    <TextBlock Text="{Binding MetadataText}"
-                                                               Foreground="#9CA3AF"
-                                                               FontSize="11"
-                                                               TextTrimming="CharacterEllipsis"/>
-                                                </StackPanel>
-                                                <TextBlock Grid.Column="2"
-                                                           Text="{Binding BadgesText}"
-                                                           Foreground="#C8E1FF"
+                                                           VerticalAlignment="Center"/>
+                                                <TextBlock Grid.Column="1"
+                                                           Text="📌"
                                                            FontSize="11"
-                                                           HorizontalAlignment="Right"
-                                                           Margin="8,0,0,0"
-                                                           TextWrapping="Wrap"/>
+                                                           Width="16"
+                                                           VerticalAlignment="Center"
+                                                           IsVisible="{Binding IsPinned}"/>
+                                                <TextBlock Grid.Column="2"
+                                                           Text="{Binding DisplayText}"
+                                                           Foreground="White"
+                                                           FontFamily="Consolas"
+                                                           VerticalAlignment="Center"
+                                                           TextTrimming="CharacterEllipsis"/>
                                             </Grid>
                                         </Border>
                                     </DataTemplate>
@@ -189,33 +192,36 @@
                                                 Classes.selected="{Binding IsSelected}"
                                                 Margin="0,1"
                                                 PointerPressed="OnSuggestionRowPointerPressed">
-                                            <Grid ColumnDefinitions="Auto,*,Auto">
+                                            <!--
+                                                One-line row (owner request, V2 row-density round):
+                                                the command text is the row. Time, cwd, exit code and
+                                                badge text used to stack three lines high here; all of
+                                                it survives, just in the detail panel this row feeds
+                                                (SelectedDescriptionText / SelectedMetadataText /
+                                                SelectedBadgesText on the popup view-model) rather than
+                                                repeated on every row. The one exception is Pinned: it
+                                                is the one fact that changes which rows exist rather
+                                                than merely describing the selected one, so it keeps a
+                                                single subtle glyph in the gutter instead of moving out
+                                                entirely.
+                                            -->
+                                            <Grid ColumnDefinitions="Auto,Auto,*">
                                                 <TextBlock Text="{Binding SelectionGlyph}"
                                                            Foreground="#8EC5FF"
                                                            Width="12"
-                                                           VerticalAlignment="Top"/>
-                                                <StackPanel Grid.Column="1"
-                                                            Spacing="1">
-                                                    <TextBlock Text="{Binding DisplayText}"
-                                                               Foreground="White"
-                                                               FontFamily="Consolas"
-                                                               TextTrimming="CharacterEllipsis"/>
-                                                    <TextBlock Text="{Binding DescriptionText}"
-                                                               Foreground="#C8E1FF"
-                                                               FontSize="11"
-                                                               TextWrapping="Wrap"/>
-                                                    <TextBlock Text="{Binding MetadataText}"
-                                                               Foreground="#9CA3AF"
-                                                               FontSize="11"
-                                                               TextTrimming="CharacterEllipsis"/>
-                                                </StackPanel>
-                                                <TextBlock Grid.Column="2"
-                                                           Text="{Binding BadgesText}"
-                                                           Foreground="#C8E1FF"
+                                                           VerticalAlignment="Center"/>
+                                                <TextBlock Grid.Column="1"
+                                                           Text="📌"
                                                            FontSize="11"
-                                                           HorizontalAlignment="Right"
-                                                           Margin="8,0,0,0"
-                                                           TextWrapping="Wrap"/>
+                                                           Width="16"
+                                                           VerticalAlignment="Center"
+                                                           IsVisible="{Binding IsPinned}"/>
+                                                <TextBlock Grid.Column="2"
+                                                           Text="{Binding DisplayText}"
+                                                           Foreground="White"
+                                                           FontFamily="Consolas"
+                                                           VerticalAlignment="Center"
+                                                           TextTrimming="CharacterEllipsis"/>
                                             </Grid>
                                         </Border>
                                     </DataTemplate>

--- a/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistSuggestionItemViewModel.cs
+++ b/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistSuggestionItemViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using NovaTerminal.CommandAssist.Models;
@@ -53,6 +54,21 @@ public sealed class CommandAssistSuggestionItemViewModel : INotifyPropertyChange
     public string MetadataText { get; }
 
     public AssistSuggestionType Type { get; }
+
+    /// <summary>
+    /// Whether this row carries the "Pinned" badge.
+    /// </summary>
+    /// <remarks>
+    /// Row density (owner request, V2 row-density round) moved every other per-row caption -
+    /// description, metadata, the full badge line - into the detail panel only, since the popup's
+    /// <see cref="BadgesText"/> is no longer rendered on the row itself. Pinned is the one exception:
+    /// it changes which rows are worth a second look while browsing, not just what the reader learns
+    /// about the row already selected, so it earns a single glyph in the row rather than a trip to the
+    /// detail panel. Derived from <see cref="BadgesText"/> rather than a new constructor parameter, so
+    /// every existing call site - and every "Pinned" badge origin in
+    /// <c>CommandAssistSuggestionEngine.BuildSnippetBadges</c> - stays the single source of truth.
+    /// </remarks>
+    public bool IsPinned => BadgesText.Contains("Pinned", StringComparison.Ordinal);
 
     public bool IsSelected
     {


### PR DESCRIPTION
Owner's request, verbatim: "i am not ok with the ui, just removing time (9m ago) alone can help showing lot more info."

## What changed

Each suggestion row in the Command Assist popup (Ctrl+R and friends) used to spend three visual
lines on one command:

1. the command text
2. a description line
3. a metadata line (working directory, relative time like "9m ago", exit code)

...plus a badge column ("Recent", "Frequent", "Pinned", etc.) rendered to the right of the command
text. That is the layout the owner's screenshot showed - a tall popup that only fit about 3 rows.

The detail panel to the right of the row list already renders all of that for the selected row
(command, description, badges, metadata/time/cwd/exit code) - it was just duplicated on every row.

This change removes the duplication. Each row is now exactly one line: the caret glyph, an optional
pin glyph, and the command text. Nothing else. The detail panel is unchanged - it still shows time,
badges, cwd and exit code for whichever row is selected.

The one exception is "Pinned": since a pin changes which rows exist to look at (not just what the
selected row describes), a pinned row keeps a single subtle glyph (matching the existing "pinned"
pin glyph convention used elsewhere in the app, e.g. `MainWindow.axaml.cs`) in the row gutter. No
other badge text renders inline.

## Before / after (same popup size)

- Before: ~3 rows visible in the tested popup height (each row ~3 lines + description + metadata +
  badge line).
- After: same popup height budget (the existing ~160-220px clamp is untouched), one line per row -
  roughly 3x as many rows visible. No code change to the popup sizing clamps or the 50-row
  fetch/display cap; density alone does the work, as intended.

## What moved where

- Row template (`CommandAssistPopupView.axaml`, both the expanded and compact
  `ItemsControl.ItemTemplate` DataTemplates): dropped the `DescriptionText` and `MetadataText`
  TextBlocks and the right-aligned `BadgesText` TextBlock. Row `Grid` is now
  `Auto,Auto,*` - caret glyph, pin glyph (visible only when pinned), command text.
- `CommandAssistSuggestionItemViewModel.cs`: added a derived `IsPinned` property
  (`BadgesText.Contains("Pinned")`), used only to show/hide the row's pin glyph. `DescriptionText`,
  `BadgesText` and `MetadataText` fields are untouched - the detail panel
  (`SelectedDescriptionText` / `SelectedBadgesText` / `SelectedMetadataText` on
  `CommandAssistPopupViewModel`) still binds independently and is unaffected.
- Relative-time formatting (`AssistRelativeTime`, exercised by `AssistRelativeTimeTests`) is
  untouched - it still feeds the detail panel's metadata line, just no longer duplicated per row.

## Verification

- Clean build (`scripts/build.ps1 clean` + `build`) of `src/NovaTerminal.App` and
  `tests/NovaTerminal.App.Tests` - required after an `.axaml` change to rule out AVLN2000 being
  masked by an incremental build. No warnings/errors from the XAML compile.
- `NovaTerminal.App.Tests`, namespace `NovaTerminal.Tests.CommandAssist`: 880 tests, 0 failed.
- `NovaTerminal.App.Tests`, full suite minus `NovaTerminal.Tests.Ssh`: 2306 total, 0 failed, 15
  skipped (environment-conditional: fish/zsh not installed, font goldens disabled) - includes
  `CommandAssistOverlayContentRenderTests` (the pixel-ink render guards for the popup) and
  `CommandAssistLayoutTests` (popup sizing clamps).
- `NovaTerminal.VT.Tests`: 375 total, 0 failed.
- `NovaTerminal.Architecture.Tests`: 33 total, 0 failed.

Live before/after screenshots of the running popup were not captured in this pass: the isolated
verification instance launched in this remote session did not composite reliably for screen capture
(a rendering/session anomaly unrelated to the code change - confirmed by Win32 window queries
succeeding while pixel capture did not), and rather than risk a misdirected keystroke or click on the
owner's own live NovaTerminal window on a heavily multi-tasking desktop, the live-GUI pass was
stopped and the isolated test process was torn down cleanly. The automated pixel-ink render guard
(`CommandAssistOverlayContentRenderTests.CommandAssistPopupView_RendersInkWhereTheSuggestionRowsAre`)
still asserts the row list renders real text content post-change, and passes.
