### PR TITLE
fix(command-assist): full-width popup rows, one footer line, match highlight, dimmed failures, content-sized height

### DIFF
--- a/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml
+++ b/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml
@@ -1,10 +1,18 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:viewModels="clr-namespace:NovaTerminal.CommandAssist.ViewModels;assembly=NovaTerminal.CommandAssist"
+             xmlns:controls="clr-namespace:NovaTerminal.Controls;assembly=NovaTerminal"
              x:CompileBindings="True"
              x:DataType="viewModels:CommandAssistPopupViewModel"
              x:Class="NovaTerminal.CommandAssist.Views.CommandAssistPopupView"
              IsVisible="{Binding IsVisible}">
+    <!--
+        The controls: xmlns says assembly=NovaTerminal, not NovaTerminal.App. The project is
+        NovaTerminal.App but its AssemblyName is NovaTerminal, and clr-namespace resolves against the
+        assembly name. Spelled out rather than left to default to "the current assembly", because this
+        file lives under CommandAssist/ with an x:Class in the CommandAssist namespace, so which
+        assembly is "current" is the least obvious thing on the page.
+    -->
     <UserControl.Styles>
         <!--
             Row visuals. Hover is pure CSS-style state, so pointer feedback costs no code: the
@@ -24,6 +32,35 @@
         </Style>
         <Style Selector="Border.assistRow.selected">
             <Setter Property="Background" Value="#332F6FEB"/>
+        </Style>
+
+        <!--
+            Failed rows are dimmed, and that is the whole treatment (UX round 7). It replaces the
+            "Exit 1" clause the row used to hand to the detail panel: while scanning a history list
+            the reader does not need the number, they need the row to be less interesting than the
+            ones beside it. No strikethrough either - the command is still perfectly runnable, it
+            just did not work last time.
+
+            Foreground is set through these styles rather than on the control, because a local value
+            beats a style and the dim would then never apply.
+        -->
+        <Style Selector="Border.assistRow controls|MatchHighlightTextBlock">
+            <Setter Property="Foreground" Value="#FFFFFF"/>
+            <Setter Property="HighlightBrush" Value="#8EC5FF"/>
+        </Style>
+        <Style Selector="Border.assistRow.failed controls|MatchHighlightTextBlock">
+            <Setter Property="Foreground" Value="#8B96A5"/>
+            <Setter Property="HighlightBrush" Value="#6E8DB5"/>
+        </Style>
+        <!--
+            Selected *and* failed. Without this rung the dim would land on the one row Enter is about
+            to act on, over a highlight fill that already lowers its contrast - so the least legible
+            row on screen would be the active one. It stays dimmer than a healthy row, so the failure
+            is still readable as a failure.
+        -->
+        <Style Selector="Border.assistRow.failed.selected controls|MatchHighlightTextBlock">
+            <Setter Property="Foreground" Value="#C3CBD6"/>
+            <Setter Property="HighlightBrush" Value="#8EC5FF"/>
         </Style>
     </UserControl.Styles>
     <!--
@@ -56,222 +93,127 @@
                            TextTrimming="CharacterEllipsis"/>
             </Grid>
 
-            <Grid Grid.Row="1"
-                  ColumnDefinitions="3*,2*"
-                  ColumnSpacing="12"
-                  IsVisible="{Binding UseExpandedLayout}">
-                <Border Background="#22101010"
-                        CornerRadius="6"
-                        Padding="8">
-                    <Grid>
-                        <ScrollViewer x:Name="PopupSuggestionsScroller"
-                                      HorizontalScrollBarVisibility="Disabled"
-                                      VerticalScrollBarVisibility="Auto"
-                                      IsVisible="{Binding HasSuggestions}">
-                            <ItemsControl x:Name="PopupSuggestionsList"
-                                          ItemsSource="{Binding Suggestions}">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate x:DataType="viewModels:CommandAssistSuggestionItemViewModel">
-                                        <Border Classes="assistRow"
-                                                Classes.selected="{Binding IsSelected}"
-                                                Margin="0,1"
-                                                PointerPressed="OnSuggestionRowPointerPressed">
-                                            <!--
-                                                One-line row (owner request, V2 row-density round):
-                                                the command text is the row. Time, cwd, exit code and
-                                                badge text used to stack three lines high here; all of
-                                                it survives, just in the detail panel this row feeds
-                                                (SelectedDescriptionText / SelectedMetadataText /
-                                                SelectedBadgesText on the popup view-model) rather than
-                                                repeated on every row. The one exception is Pinned: it
-                                                is the one fact that changes which rows exist rather
-                                                than merely describing the selected one, so it keeps a
-                                                single subtle glyph in the gutter instead of moving out
-                                                entirely.
-                                            -->
-                                            <Grid ColumnDefinitions="Auto,Auto,*">
-                                                <TextBlock Text="{Binding SelectionGlyph}"
-                                                           Foreground="#8EC5FF"
-                                                           Width="12"
-                                                           VerticalAlignment="Center"/>
-                                                <TextBlock Grid.Column="1"
-                                                           Text="📌"
-                                                           FontSize="11"
-                                                           Width="16"
-                                                           VerticalAlignment="Center"
-                                                           IsVisible="{Binding IsPinned}"/>
-                                                <TextBlock Grid.Column="2"
-                                                           Text="{Binding DisplayText}"
-                                                           Foreground="White"
-                                                           FontFamily="Consolas"
-                                                           VerticalAlignment="Center"
-                                                           TextTrimming="CharacterEllipsis"/>
-                                            </Grid>
-                                        </Border>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
-                        </ScrollViewer>
+            <!--
+                The whole body is the row list (owner request, UX round 7). There used to be a
+                two-column grid here, with a detail panel taking 40% of the width to restate the
+                selected row and its captions while the rows had 60% and ellipsised commands that
+                would have fitted in the space the restatement was using. The captions now live on
+                one footer line, and the rows get the width.
 
-                        <TextBlock x:Name="PopupEmptyStateTextBlock"
-                                   Text="{Binding EmptyStateText}"
-                                   Foreground="#9CA3AF"
-                                   HorizontalAlignment="Center"
-                                   VerticalAlignment="Center"
-                                   IsVisible="{Binding ShowEmptyState}"
-                                   TextWrapping="Wrap"/>
-                    </Grid>
-                </Border>
-
-                <Border x:Name="PopupDetailPanel"
-                        Grid.Column="1"
-                        Background="#1C151515"
-                        CornerRadius="6"
-                        Padding="8"
-                        IsVisible="{Binding UseExpandedLayout}">
-                    <StackPanel Spacing="4">
-                        <TextBlock Text="{Binding TopSuggestionText}"
-                                   Foreground="White"
-                                   FontFamily="Consolas"
-                                   TextWrapping="Wrap"/>
-                        <TextBlock x:Name="PopupSelectedDescriptionTextBlock"
-                                   Text="{Binding SelectedDescriptionText}"
-                                   Foreground="#C8E1FF"
-                                   FontSize="11"
-                                   TextWrapping="Wrap"/>
-                        <TextBlock Text="{Binding SelectedBadgesText}"
-                                   Foreground="#C8E1FF"
-                                   FontSize="11"
-                                   TextWrapping="Wrap"/>
-                        <TextBlock Text="{Binding SelectedMetadataText}"
-                                   Foreground="#9CA3AF"
-                                   FontSize="11"
-                                   TextWrapping="Wrap"/>
-                    </StackPanel>
-                </Border>
-            </Grid>
-
+                Deleting the panel also deleted the reason there were two row templates: the compact
+                variant existed only to drop the detail panel on a narrow pane, so with the panel gone
+                the two were the same markup twice and the flag choosing between them chose between
+                identical outcomes. Both are gone rather than left behind as a no-op switch.
+            -->
             <Border Grid.Row="1"
-                    x:Name="PopupCompactPanel"
+                    x:Name="PopupResultsPanel"
                     Background="#22101010"
                     CornerRadius="6"
-                    Padding="8"
-                    IsVisible="{Binding UseCompactLayout}">
-                <Grid RowDefinitions="Auto,*"
-                      RowSpacing="8">
-                    <StackPanel Spacing="4"
-                                IsVisible="{Binding HasSuggestions}">
-                        <TextBlock Text="{Binding TopSuggestionText}"
-                                   Foreground="White"
-                                   FontFamily="Consolas"
-                                   TextWrapping="Wrap"/>
-                        <TextBlock Text="{Binding SelectedDescriptionText}"
-                                   Foreground="#C8E1FF"
-                                   FontSize="11"
-                                   TextWrapping="Wrap"/>
-                        <TextBlock Text="{Binding SelectedBadgesText}"
-                                   Foreground="#C8E1FF"
-                                   FontSize="11"
-                                   TextWrapping="Wrap"/>
-                        <TextBlock Text="{Binding SelectedMetadataText}"
-                                   Foreground="#9CA3AF"
-                                   FontSize="11"
-                                   TextWrapping="Wrap"/>
-                    </StackPanel>
+                    Padding="8">
+                <Grid>
+                    <ScrollViewer x:Name="PopupSuggestionsScroller"
+                                  HorizontalScrollBarVisibility="Disabled"
+                                  VerticalScrollBarVisibility="Auto"
+                                  IsVisible="{Binding HasSuggestions}">
+                        <ItemsControl x:Name="PopupSuggestionsList"
+                                      ItemsSource="{Binding Suggestions}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="viewModels:CommandAssistSuggestionItemViewModel">
+                                    <Border Classes="assistRow"
+                                            Classes.selected="{Binding IsSelected}"
+                                            Classes.failed="{Binding HasFailed}"
+                                            Margin="0,1"
+                                            PointerPressed="OnSuggestionRowPointerPressed">
+                                        <!--
+                                            One-line row: the command text is the row. Time, cwd, exit
+                                            code and badge text used to stack three lines high here;
+                                            all of it survives on the footer line that describes
+                                            whichever row is selected. Two facts stay on the row
+                                            itself, because both change which rows are worth a second
+                                            look rather than merely describing the selected one - the
+                                            pin glyph, and the dim that says this command failed.
+                                        -->
+                                        <Grid ColumnDefinitions="Auto,Auto,*">
+                                            <TextBlock Text="{Binding SelectionGlyph}"
+                                                       Foreground="#8EC5FF"
+                                                       Width="12"
+                                                       VerticalAlignment="Center"/>
+                                            <TextBlock Grid.Column="1"
+                                                       Text="📌"
+                                                       FontSize="11"
+                                                       Width="16"
+                                                       VerticalAlignment="Center"
+                                                       IsVisible="{Binding IsPinned}"/>
+                                            <controls:MatchHighlightTextBlock
+                                                       Grid.Column="2"
+                                                       Classes="rowCommandText"
+                                                       SourceText="{Binding DisplayText}"
+                                                       HighlightStart="{Binding HighlightStart}"
+                                                       HighlightLength="{Binding HighlightLength}"
+                                                       FontFamily="Consolas"
+                                                       VerticalAlignment="Center"
+                                                       TextTrimming="CharacterEllipsis"/>
+                                        </Grid>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
 
-                    <Grid Grid.Row="1">
-                        <ScrollViewer x:Name="PopupCompactSuggestionsScroller"
-                                      HorizontalScrollBarVisibility="Disabled"
-                                      VerticalScrollBarVisibility="Auto"
-                                      IsVisible="{Binding HasSuggestions}">
-                            <ItemsControl x:Name="PopupCompactSuggestionsList"
-                                          ItemsSource="{Binding Suggestions}">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate x:DataType="viewModels:CommandAssistSuggestionItemViewModel">
-                                        <Border Classes="assistRow"
-                                                Classes.selected="{Binding IsSelected}"
-                                                Margin="0,1"
-                                                PointerPressed="OnSuggestionRowPointerPressed">
-                                            <!--
-                                                One-line row (owner request, V2 row-density round):
-                                                the command text is the row. Time, cwd, exit code and
-                                                badge text used to stack three lines high here; all of
-                                                it survives, just in the detail panel this row feeds
-                                                (SelectedDescriptionText / SelectedMetadataText /
-                                                SelectedBadgesText on the popup view-model) rather than
-                                                repeated on every row. The one exception is Pinned: it
-                                                is the one fact that changes which rows exist rather
-                                                than merely describing the selected one, so it keeps a
-                                                single subtle glyph in the gutter instead of moving out
-                                                entirely.
-                                            -->
-                                            <Grid ColumnDefinitions="Auto,Auto,*">
-                                                <TextBlock Text="{Binding SelectionGlyph}"
-                                                           Foreground="#8EC5FF"
-                                                           Width="12"
-                                                           VerticalAlignment="Center"/>
-                                                <TextBlock Grid.Column="1"
-                                                           Text="📌"
-                                                           FontSize="11"
-                                                           Width="16"
-                                                           VerticalAlignment="Center"
-                                                           IsVisible="{Binding IsPinned}"/>
-                                                <TextBlock Grid.Column="2"
-                                                           Text="{Binding DisplayText}"
-                                                           Foreground="White"
-                                                           FontFamily="Consolas"
-                                                           VerticalAlignment="Center"
-                                                           TextTrimming="CharacterEllipsis"/>
-                                            </Grid>
-                                        </Border>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
-                        </ScrollViewer>
-
-                        <TextBlock Text="{Binding EmptyStateText}"
-                                   Foreground="#9CA3AF"
-                                   HorizontalAlignment="Center"
-                                   VerticalAlignment="Center"
-                                   IsVisible="{Binding ShowEmptyState}"
-                                   TextWrapping="Wrap"/>
-                    </Grid>
+                    <TextBlock x:Name="PopupEmptyStateTextBlock"
+                               Text="{Binding EmptyStateText}"
+                               Foreground="#9CA3AF"
+                               HorizontalAlignment="Center"
+                               VerticalAlignment="Center"
+                               IsVisible="{Binding ShowEmptyState}"
+                               TextWrapping="Wrap"/>
                 </Grid>
             </Border>
 
             <!--
-                Footer. The hint strip is always there; the attribution line appears under it only
-                when the rows on screen carry a licence that has to be credited - today that is the
-                tldr-derived command catalogue in Help mode (V2 Phase 4b). Wrapped rather than
-                trimmed, because a credit cut off at the ellipsis is not a credit.
+                Footer. One line: what the selected row is, then the hint strip, then the integration
+                dot - with the attribution line under it when the rows on screen carry a licence that
+                has to be credited, today the tldr-derived command catalogue in Help mode (V2 Phase
+                4b). The credit wraps rather than trims, because a credit cut off at the ellipsis is
+                not a credit.
+
+                The squeeze order is deliberate and is the reverse of a "content first" instinct. The
+                metadata takes the star column and is the only thing that trims; the hints and the dot
+                are Auto and never give up a character. This footer is the only place Enter and Esc
+                are taught, and a legend that ellipsises is not a legend - whereas a working directory
+                cut short still says which machine and roughly where.
             -->
             <StackPanel Grid.Row="2" Spacing="3">
-                <Grid ColumnDefinitions="*,Auto">
-                    <TextBlock x:Name="PopupShortcutHintText"
-                               Text="{Binding ShortcutHintText}"
-                               Foreground="#8B96A5"
+                <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="10">
+                    <TextBlock x:Name="PopupSelectedFooterText"
+                               Text="{Binding SelectedFooterText}"
+                               Foreground="#9CA3AF"
                                FontSize="11"
                                VerticalAlignment="Center"
                                TextTrimming="CharacterEllipsis"/>
 
+                    <TextBlock Grid.Column="1"
+                               x:Name="PopupShortcutHintText"
+                               Text="{Binding ShortcutHintText}"
+                               Foreground="#8B96A5"
+                               FontSize="11"
+                               VerticalAlignment="Center"/>
+
                     <!--
-                        The integration chip, mirroring the bubble's. The popup keeps it at every
-                        width: this is the surface someone is looking at when a Ctrl+R list is
-                        shorter than they expected, and "basic" is very often the answer to why.
+                        The integration indicator, in the bubble's collapsed form. It was a labelled
+                        chip here until the footer became one line; the word was the clause with the
+                        least to say per pixel, and the dot keeps the indicator on screen at every
+                        width - which is the point, since this is the surface someone is looking at
+                        when a Ctrl+R list is shorter than they expected and "basic" is the answer.
+                        The word survives as the tooltip, which is also what a screen reader gets.
                     -->
-                    <Border Grid.Column="1"
-                            x:Name="PopupIntegrationChip"
-                            ToolTip.Tip="{Binding IntegrationStatusTooltip}"
-                            Margin="8,0,0,0"
-                            Background="#22FFFFFF"
-                            CornerRadius="4"
-                            Padding="5,1"
-                            VerticalAlignment="Center">
-                        <TextBlock x:Name="PopupIntegrationStatusText"
-                                   Text="{Binding IntegrationStatusText}"
-                                   Foreground="#8B96A5"
-                                   FontSize="10"/>
-                    </Border>
+                    <TextBlock Grid.Column="2"
+                               x:Name="PopupIntegrationGlyph"
+                               Text="{Binding IntegrationGlyphText}"
+                               ToolTip.Tip="{Binding IntegrationStatusTooltip}"
+                               Foreground="#8B96A5"
+                               FontSize="10"
+                               VerticalAlignment="Center"/>
                 </Grid>
                 <TextBlock x:Name="PopupAttributionText"
                            Text="{Binding AttributionText}"

--- a/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml.cs
+++ b/src/NovaTerminal.App/CommandAssist/Views/CommandAssistPopupView.axaml.cs
@@ -72,9 +72,9 @@ public partial class CommandAssistPopupView : UserControl
     /// </summary>
     /// <remarks>
     /// Needed because the row list is an <c>ItemsControl</c> rather than a selecting control: nothing
-    /// else knows that one of its children is special. Both list instances are asked, because the
-    /// compact and expanded layouts are separate subtrees and only one of them is realized at a time -
-    /// the unrealized one has no container for the index and answers null, which is the no-op.
+    /// else knows that one of its children is special. One list, since UX round 7 collapsed the
+    /// compact and expanded layouts into a single template - this used to ask both and let the
+    /// unrealized one answer null.
     /// </remarks>
     private void BringSelectedRowIntoView()
     {
@@ -85,7 +85,6 @@ public partial class CommandAssistPopupView : UserControl
         }
 
         BringIntoView(PopupSuggestionsList, index);
-        BringIntoView(PopupCompactSuggestionsList, index);
     }
 
     private static void BringIntoView(ItemsControl? list, int index)

--- a/src/NovaTerminal.App/Controls/MatchHighlightTextBlock.cs
+++ b/src/NovaTerminal.App/Controls/MatchHighlightTextBlock.cs
@@ -1,0 +1,168 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Media;
+
+namespace NovaTerminal.Controls
+{
+    /// <summary>
+    /// A single-line <see cref="TextBlock"/> that paints one run of its text in a second brush.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Why a control and not markup.</strong> The Command Assist rows need the matched part of
+    /// the command emphasised, and a row is one line that must still ellipsize when the popup is
+    /// narrower than the command. <c>Text="{Binding DisplayText}"</c> cannot colour part of a string,
+    /// and the obvious alternative - three <c>TextBlock</c>s in a <c>StackPanel</c> - breaks the
+    /// trimming: each segment would measure and ellipsize on its own, so a long command would be cut
+    /// in the middle of the highlighted run with the tail still fully drawn beside it. One
+    /// <c>TextBlock</c> with three <c>Run</c>s is laid out as one line and trims once, at the end,
+    /// which is the behaviour the row already had.
+    /// </para>
+    /// <para>
+    /// The span is supplied rather than searched for. Deciding <em>where</em> the match is belongs to
+    /// the row view-model, which knows what the query was and can say so in a test that needs no
+    /// rendering; this control only draws what it is told, including "nothing", which is what an empty
+    /// or non-contiguous match produces.
+    /// </para>
+    /// </remarks>
+    public class MatchHighlightTextBlock : TextBlock
+    {
+        /// <summary>The whole string to draw. Bound instead of <c>Text</c>, which this control owns.</summary>
+        public static readonly StyledProperty<string?> SourceTextProperty =
+            AvaloniaProperty.Register<MatchHighlightTextBlock, string?>(nameof(SourceText));
+
+        /// <summary>Index of the run to emphasise, or a negative value for none.</summary>
+        public static readonly StyledProperty<int> HighlightStartProperty =
+            AvaloniaProperty.Register<MatchHighlightTextBlock, int>(nameof(HighlightStart), -1);
+
+        /// <summary>Length of the run to emphasise. Zero means none.</summary>
+        public static readonly StyledProperty<int> HighlightLengthProperty =
+            AvaloniaProperty.Register<MatchHighlightTextBlock, int>(nameof(HighlightLength));
+
+        /// <summary>Brush for the emphasised run. Null falls back to the control's own foreground.</summary>
+        public static readonly StyledProperty<IBrush?> HighlightBrushProperty =
+            AvaloniaProperty.Register<MatchHighlightTextBlock, IBrush?>(nameof(HighlightBrush));
+
+        public MatchHighlightTextBlock()
+        {
+            RebuildInlines();
+        }
+
+        public string? SourceText
+        {
+            get => GetValue(SourceTextProperty);
+            set => SetValue(SourceTextProperty, value);
+        }
+
+        public int HighlightStart
+        {
+            get => GetValue(HighlightStartProperty);
+            set => SetValue(HighlightStartProperty, value);
+        }
+
+        public int HighlightLength
+        {
+            get => GetValue(HighlightLengthProperty);
+            set => SetValue(HighlightLengthProperty, value);
+        }
+
+        public IBrush? HighlightBrush
+        {
+            get => GetValue(HighlightBrushProperty);
+            set => SetValue(HighlightBrushProperty, value);
+        }
+
+        /// <summary>
+        /// Splits <paramref name="text"/> into the part before the match, the match, and the part
+        /// after it - or returns <see langword="null"/> when there is no drawable match.
+        /// </summary>
+        /// <remarks>
+        /// Static and Avalonia-free so every boundary case (empty span, span at either end, a span
+        /// that runs off the end of a text that has since changed) is assertable without a render
+        /// pass. The out-of-range case is not defensive noise: the two spans and the text arrive as
+        /// three independent bindings, so there is a frame in which the new text is paired with the
+        /// old offsets, and the honest answer for that frame is "no highlight" rather than a throw.
+        /// </remarks>
+        internal static (string Before, string Match, string After)? SplitForHighlight(string? text, int start, int length)
+        {
+            if (string.IsNullOrEmpty(text) || length <= 0 || start < 0 || start >= text!.Length)
+            {
+                return null;
+            }
+
+            if (start + length > text.Length)
+            {
+                return null;
+            }
+
+            return (text[..start], text.Substring(start, length), text[(start + length)..]);
+        }
+
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            base.OnPropertyChanged(change);
+
+            if (change.Property == SourceTextProperty ||
+                change.Property == HighlightStartProperty ||
+                change.Property == HighlightLengthProperty ||
+                change.Property == HighlightBrushProperty)
+            {
+                RebuildInlines();
+            }
+        }
+
+        /// <summary>
+        /// Republishes the inline runs for the current text and span.
+        /// </summary>
+        /// <remarks>
+        /// Empty segments are dropped rather than added as zero-length runs. A match at index 0 or at
+        /// the very end therefore produces two runs, not three with a blank on one side: the visible
+        /// result is identical and the run list stays something a test can read literally.
+        /// </remarks>
+        private void RebuildInlines()
+        {
+            string text = SourceText ?? string.Empty;
+            InlineCollection? inlines = Inlines;
+
+            if (inlines == null)
+            {
+                // No inline collection to write into (a bare, never-templated instance). The plain
+                // text is still the right thing to draw; the highlight is the part that is optional.
+                Text = text;
+                return;
+            }
+
+            inlines.Clear();
+
+            (string Before, string Match, string After)? split = SplitForHighlight(text, HighlightStart, HighlightLength);
+            if (split == null)
+            {
+                if (text.Length > 0)
+                {
+                    inlines.Add(new Run(text));
+                }
+
+                return;
+            }
+
+            if (split.Value.Before.Length > 0)
+            {
+                inlines.Add(new Run(split.Value.Before));
+            }
+
+            var match = new Run(split.Value.Match);
+            if (HighlightBrush != null)
+            {
+                match.Foreground = HighlightBrush;
+            }
+
+            inlines.Add(match);
+
+            if (split.Value.After.Length > 0)
+            {
+                inlines.Add(new Run(split.Value.After));
+            }
+        }
+    }
+}

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -244,8 +244,32 @@ namespace NovaTerminal.Controls
         private const double CommandAssistBubbleHeight = 36;
         private const double CommandAssistPopupWidth = 520;
         private const double CommandAssistPopupHeight = 220;
-        private const double CompactPopupWidthThreshold = 420;
-        private const double CompactPopupHeightThreshold = 180;
+
+        // ---- Content-sized popup height (UX round 7).
+        //
+        // Every number below is read off CommandAssistPopupView.axaml rather than tuned by eye, and
+        // CommandAssistLayoutTests.TerminalPane_PopupHeightEstimate_MatchesTheRenderedTemplate
+        // measures the real control against them - so a template change that invalidates the estimate
+        // fails in the suite instead of showing up as a popup with a gap under its last row.
+        //
+        // Chrome, top to bottom:
+        //   outer Border BorderThickness 1, twice                            2
+        //   outer Border Padding 12, twice                                  24
+        //   root Grid RowSpacing 10, two gaps between its three rows        20
+        //   header line (mode label / query at the default font size)       19
+        //   results Border Padding 8, twice                                 16
+        //   footer line (FontSize 11)                                       15
+        private const double CommandAssistPopupChromeHeight = 96;
+
+        // One row: a default-size line box (19) inside Border Padding "4,2" (4) and Margin "0,1" (2).
+        private const double CommandAssistPopupRowHeight = 25;
+
+        // The attribution credit, when there is one: StackPanel Spacing 3 plus one 10pt line.
+        private const double CommandAssistPopupAttributionHeight = 19;
+
+        // The "no matches" popup is a caption, not a list, and gets one line's worth of body rather
+        // than the tall empty box a fixed 220 produced.
+        private const int CommandAssistPopupEmptyStateRows = 1;
         private const double ConservativeRemotePromptBandStartRatio = 0.55;
         private const int ConservativeRemoteMinVisibleRows = 8;
         private const double ConservativeRemoteShortPaneHeightThreshold = 300;
@@ -1312,7 +1336,10 @@ namespace NovaTerminal.Controls
             bool hasMarkAnchor = markHint.HasValue;
             float fallbackCellHeight = TermView.Metrics.CellHeight > 0 ? TermView.Metrics.CellHeight : 18;
             int fallbackVisibleRows = TermView.Rows > 0 ? TermView.Rows : 1;
-            CommandAssistSurfaceSizing sizing = CalculateCommandAssistSurfaceSizing(paneWidth, paneHeight);
+            CommandAssistSurfaceSizing sizing = CalculateCommandAssistSurfaceSizing(
+                paneWidth,
+                paneHeight,
+                ReadCommandAssistPopupContentSize());
             bool hasReliablePromptAnchor = IsCommandAssistPromptAnchorReliable(promptHint, hasMarkAnchor);
             float anchorCellHeight = markHint?.CellHeight ?? promptHint?.CellHeight ?? fallbackCellHeight;
             int hintCursorRow = promptHint?.VisibleCursorVisualRow ?? 0;
@@ -1521,17 +1548,94 @@ namespace NovaTerminal.Controls
             return true;
         }
 
-        private static CommandAssistSurfaceSizing CalculateCommandAssistSurfaceSizing(double paneWidth, double paneHeight)
+        /// <summary>
+        /// Reads the popup's current contents off the bound view-model, for the height estimate.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The row count comes from <c>CommandAssistBarViewModel.SuggestionCount</c> rather than from
+        /// <c>Suggestions.Count</c>, and that is what makes the placement re-run at all. A placement
+        /// pass is triggered by <see cref="OnCommandAssistViewModelPropertyChanged"/>, which listens to
+        /// the bar view-model; the collection is rebuilt without any property on it changing, so
+        /// before the count was published a <c>Ctrl+R</c> filter that went from six rows to two left
+        /// the popup at its six-row height. Reading the same property the notification came from also
+        /// means the two can never disagree.
+        /// </para>
+        /// <para>
+        /// Not the popup view-model's copy: the pane holds the bar view-model, and the bar publishes
+        /// to the popup <em>after</em> raising its own change - so a read through the popup during
+        /// that notification would be one pass stale.
+        /// </para>
+        /// </remarks>
+        private CommandAssistPopupContentSize ReadCommandAssistPopupContentSize()
+        {
+            CommandAssistBarViewModel? viewModel = _boundCommandAssistViewModel;
+            if (viewModel == null)
+            {
+                return new CommandAssistPopupContentSize(0, false, false);
+            }
+
+            return new CommandAssistPopupContentSize(
+                viewModel.SuggestionCount,
+                viewModel.ShowEmptyState,
+                !string.IsNullOrWhiteSpace(viewModel.AttributionText));
+        }
+
+        private static CommandAssistSurfaceSizing CalculateCommandAssistSurfaceSizing(
+            double paneWidth,
+            double paneHeight,
+            CommandAssistPopupContentSize content)
         {
             double bubbleWidth = Math.Clamp(paneWidth * 0.44, 280, CommandAssistBubbleWidth);
             double popupWidth = Math.Clamp(paneWidth * 0.58, 360, CommandAssistPopupWidth);
-            double popupHeight = Math.Clamp(paneHeight * 0.45, 160, CommandAssistPopupHeight);
+            double popupHeight = EstimateCommandAssistPopupHeight(content, paneHeight);
 
             return new CommandAssistSurfaceSizing(
                 BubbleWidth: bubbleWidth,
                 BubbleHeight: CommandAssistBubbleHeight,
                 PopupWidth: popupWidth,
                 PopupHeight: popupHeight);
+        }
+
+        /// <summary>
+        /// How tall the popup wants to be for the rows it is about to show.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <strong>Why the height is estimated up front instead of measured.</strong> The obvious
+        /// shrink-to-fit - <c>Height = NaN</c> with a <c>MaxHeight</c> cap - is wrong here, and
+        /// silently so. <c>CommandAssistAnchorCalculator.CreatePopupRect</c> places an upward popup by
+        /// subtracting the <em>requested</em> height from the bubble's top edge, and the pane applies
+        /// the result as <c>Margin.Top</c> inside a top-aligned grid. An auto-sized popup asked for
+        /// 220 and drawn at 120 would therefore hang 100 px above the prompt, attached to nothing.
+        /// Feeding the desired height into the request instead keeps the popup a fixed rectangle -
+        /// one that happens to be exactly the size of its contents - and every placement rule
+        /// downstream keeps working unchanged.
+        /// </para>
+        /// <para>
+        /// The estimate is allowed to be a little generous and must never be short: too tall leaves a
+        /// few pixels of card under the last row, too short clips it. The clamp keeps the old
+        /// <c>paneHeight * 0.45</c> ceiling, so a long list behaves exactly as it did and scrolls.
+        /// </para>
+        /// </remarks>
+        internal static double EstimateCommandAssistPopupHeight(CommandAssistPopupContentSize content, double paneHeight)
+        {
+            int rows = content.ShowEmptyState
+                ? CommandAssistPopupEmptyStateRows
+                : Math.Max(1, content.RowCount);
+
+            double desired = CommandAssistPopupChromeHeight + (rows * CommandAssistPopupRowHeight);
+            if (content.HasAttribution)
+            {
+                desired += CommandAssistPopupAttributionHeight;
+            }
+
+            // The floor is one row's worth of popup, not the old 160: a single-row Ctrl+R answer that
+            // reserved 160 px was most of the box the owner asked us to stop drawing.
+            double floor = CommandAssistPopupChromeHeight + CommandAssistPopupRowHeight;
+            double ceiling = Math.Max(floor, Math.Clamp(paneHeight * 0.45, floor, CommandAssistPopupHeight));
+
+            return Math.Clamp(desired, floor, ceiling);
         }
 
         private void UpdateCommandAssistOverlayPlacement()
@@ -1613,13 +1717,6 @@ namespace NovaTerminal.Controls
 
             if (CommandAssistPopup != null)
             {
-                if (_boundCommandAssistViewModel != null)
-                {
-                    _boundCommandAssistViewModel.Popup.UseCompactLayout =
-                        layout.PopupRect.Width <= CompactPopupWidthThreshold ||
-                        layout.PopupRect.Height <= CompactPopupHeightThreshold;
-                }
-
                 CommandAssistPopup.Width = layout.PopupRect.Width;
                 CommandAssistPopup.Height = layout.PopupRect.Height;
                 CommandAssistPopup.MinHeight = layout.PopupRect.Height;
@@ -4384,6 +4481,20 @@ namespace NovaTerminal.Controls
             double BubbleHeight,
             double PopupWidth,
             double PopupHeight);
+
+        /// <summary>
+        /// The three facts about the popup's contents that change how tall it needs to be.
+        /// </summary>
+        /// <remarks>
+        /// Internal, and a parameter rather than something
+        /// <see cref="EstimateCommandAssistPopupHeight"/> reads off the bound view-model, so the
+        /// height rule is a pure function the suite can drive across row counts without a pane, a
+        /// session or a render pass.
+        /// </remarks>
+        internal readonly record struct CommandAssistPopupContentSize(
+            int RowCount,
+            bool ShowEmptyState,
+            bool HasAttribution);
 
         private sealed class TestRemoteDirectoryBrowserService : IRemoteDirectoryBrowserService
         {

--- a/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
@@ -1094,6 +1094,7 @@ public sealed class CommandAssistController
         ViewModel.EmptyStateText = string.Empty;
         ViewModel.ShowEmptyState = false;
         ViewModel.HasSuggestions = false;
+        ViewModel.SuggestionCount = 0;
         ViewModel.AttributionText = string.Empty;
         ViewModel.Suggestions.Clear();
         _suggestions.Clear();
@@ -1159,7 +1160,15 @@ public sealed class CommandAssistController
                 badgesText: string.Join("  ", suggestion.Badges),
                 metadataText: BuildMetadataText(suggestion),
                 isSelected: i == ViewModel.SelectedIndex,
-                type: suggestion.Type));
+                type: suggestion.Type,
+
+                // The query the rows were ranked against, so each row can point at the run of text
+                // that earned its place. Read off the view-model rather than passed in, because both
+                // entry points write it there first - ApplyRefreshOutcome from the ranking pass,
+                // ApplyHelperSuggestions from the Help/Fix subject - and a second parameter would be
+                // one more thing for a future third entry point to forget.
+                queryText: ViewModel.QueryText,
+                exitCode: suggestion.ExitCode));
         }
 
         SyncSelectionState();
@@ -1177,6 +1186,12 @@ public sealed class CommandAssistController
         ViewModel.SelectedMetadataText = selected == null ? string.Empty : BuildMetadataText(selected);
         ViewModel.SelectedDescriptionText = selected?.Description ?? string.Empty;
         ViewModel.HasSuggestions = _suggestions.Count > 0;
+
+        // Published from here rather than from SyncSuggestionViewModel because this is the one
+        // method both row-changing and selection-changing paths end in, and the setter ignores a
+        // repeat - so a selection move costs nothing and a re-rank that happens to return the same
+        // number of rows does not re-place the popup.
+        ViewModel.SuggestionCount = _suggestions.Count;
 
         for (int i = 0; i < ViewModel.Suggestions.Count; i++)
         {

--- a/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistBarViewModel.cs
+++ b/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistBarViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using NovaTerminal.CommandAssist.Models;
 
@@ -69,6 +70,7 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
     private string _selectedMetadataText = string.Empty;
     private string _selectedDescriptionText = string.Empty;
     private string _emptyStateText = string.Empty;
+    private int _suggestionCount;
     private bool _hasSuggestions;
     private bool _showEmptyState;
     private bool _isPopupOpen;
@@ -307,6 +309,46 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
         }
     }
 
+    /// <summary>
+    /// How many rows the popup is showing. Published so the pane can size the popup to its content.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A property rather than a <c>CollectionChanged</c> subscription on <see cref="Suggestions"/>,
+    /// because the controller rebuilds that collection with a <c>Clear</c> followed by N <c>Add</c>s:
+    /// a listener would see N+1 notifications per ranking pass, each one re-running placement, and
+    /// <c>Ctrl+R</c> re-ranks on every keystroke. This fires once per pass at most.
+    /// </para>
+    /// <para>
+    /// The change gate is <em>not</em> what keeps placement cheap, and it should not be read that way.
+    /// <see cref="QueryText"/>, <see cref="ModeLabel"/> and <see cref="AttributionText"/> each publish
+    /// their own change, and <c>TerminalPane.OnCommandAssistViewModelPropertyChanged</c> re-places on
+    /// any property of this view-model - so the ordinary keystroke, where the query moved and the row
+    /// count happened not to, re-places anyway. What this property adds is the one case none of the
+    /// others cover: the row count changing with nothing else moving, which is a change in the popup's
+    /// height that would otherwise go unannounced.
+    /// </para>
+    /// <para>
+    /// The count and not the collection: nothing downstream needs the rows, only how many there are,
+    /// and a value type cannot be mistaken for a live view of a list that is about to be rebuilt.
+    /// </para>
+    /// </remarks>
+    public int SuggestionCount
+    {
+        get => _suggestionCount;
+        set
+        {
+            if (_suggestionCount == value)
+            {
+                return;
+            }
+
+            _suggestionCount = value;
+            OnPropertyChanged();
+            SyncPresentationState();
+        }
+    }
+
     public bool HasSuggestions
     {
         get => _hasSuggestions;
@@ -503,14 +545,38 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
         Popup.IsVisible = IsVisible && IsPopupOpen;
         Popup.ModeLabel = ModeLabel;
         Popup.QueryText = QueryText;
-        Popup.TopSuggestionText = TopSuggestionText;
         Popup.SelectedBadgesText = SelectedBadgesText;
         Popup.SelectedMetadataText = SelectedMetadataText;
         Popup.SelectedDescriptionText = SelectedDescriptionText;
+        Popup.SelectedFooterText = BuildSelectedFooterText();
         Popup.EmptyStateText = EmptyStateText;
         Popup.HasSuggestions = HasSuggestions;
         Popup.ShowEmptyState = ShowEmptyState;
         Popup.AttributionText = AttributionText;
+    }
+
+    /// <summary>
+    /// Joins whatever the surface knows about the selected row into the popup's single footer line.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Description first, then badges, then metadata: least to most mechanical, so the clause the
+    /// reader is most likely to want survives the ellipsis. Empty parts are dropped rather than
+    /// joined through, because a line that opens with a separator reads as content that failed to
+    /// load. With every part empty - no selection, or a row that carries nothing - the result is the
+    /// empty string, and the footer renders nothing rather than a bare "  |  ".
+    /// </para>
+    /// <para>
+    /// The separator is the one <c>CommandAssistController.BuildMetadataText</c> already uses inside
+    /// the metadata clause, so the whole line reads as one list rather than as two nested ones.
+    /// </para>
+    /// </remarks>
+    internal string BuildSelectedFooterText()
+    {
+        return string.Join(
+            "  |  ",
+            new[] { SelectedDescriptionText, SelectedBadgesText, SelectedMetadataText }
+                .Where(part => !string.IsNullOrWhiteSpace(part)));
     }
 
     /// <summary>
@@ -572,7 +638,12 @@ public sealed class CommandAssistBarViewModel : INotifyPropertyChanged
         Bubble.ShowIntegrationStatus = showLabel;
         Bubble.ShowIntegrationGlyph = !showLabel;
 
+        // The popup takes the collapsed form unconditionally. Its footer is one line shared by the
+        // metadata, the hint strip and this, and the label is the clause with the least to say per
+        // pixel; the dot keeps the indicator on screen at every width, which is the property the
+        // bubble's own collapse exists to protect.
         Popup.IntegrationStatusText = text;
+        Popup.IntegrationGlyphText = IsShellIntegrationLive ? IntegratedStatusGlyph : BasicStatusGlyph;
         Popup.IntegrationStatusTooltip = tooltip;
     }
 

--- a/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistPopupViewModel.cs
+++ b/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistPopupViewModel.cs
@@ -9,18 +9,18 @@ public sealed class CommandAssistPopupViewModel : INotifyPropertyChanged
     private bool _isVisible;
     private string _modeLabel = "Suggest";
     private string _queryText = string.Empty;
-    private string _topSuggestionText = string.Empty;
     private string _selectedBadgesText = string.Empty;
     private string _selectedMetadataText = string.Empty;
     private string _selectedDescriptionText = string.Empty;
+    private string _selectedFooterText = string.Empty;
     private string _emptyStateText = string.Empty;
     private bool _hasSuggestions;
     private bool _showEmptyState;
-    private bool _useCompactLayout;
     private int _selectedIndex = -1;
     private string _shortcutHintText = string.Empty;
     private string _attributionText = string.Empty;
     private string _integrationStatusText = string.Empty;
+    private string _integrationGlyphText = string.Empty;
     private string _integrationStatusTooltip = string.Empty;
 
     public CommandAssistPopupViewModel(ObservableCollection<CommandAssistSuggestionItemViewModel> suggestions)
@@ -41,18 +41,35 @@ public sealed class CommandAssistPopupViewModel : INotifyPropertyChanged
     }
 
     /// <summary>
-    /// The session's shell-integration state, shown in the popup footer beside the shortcut hint.
+    /// The session's shell-integration state in words. No longer rendered in the popup - the footer
+    /// shows <see cref="IntegrationGlyphText"/> - but still the accessible name behind the dot.
     /// </summary>
     /// <remarks>
-    /// The popup carries the chip unconditionally where the bubble drops it at narrow widths: the
-    /// popup is a summoned surface with a footer already, so there is room, and it is the surface a
-    /// user is looking at when they wonder why the list is emptier than they expected. See
-    /// <see cref="CommandAssistBubbleViewModel.IntegrationStatusText"/>.
+    /// The label lost its place when the popup footer became one line (UX round 7): the metadata, the
+    /// hint strip and the indicator now share a strip that used to carry the hint strip alone, and a
+    /// five-to-ten character word that answers a once-per-session question is exactly the thing that
+    /// gives its width up first. The indicator itself does not go, it shrinks to the dot - the same
+    /// collapse the bubble already makes, for the same reason. See
+    /// <see cref="CommandAssistBubbleViewModel.IntegrationGlyphText"/>.
     /// </remarks>
     public string IntegrationStatusText
     {
         get => _integrationStatusText;
         set => SetField(ref _integrationStatusText, value);
+    }
+
+    /// <summary>
+    /// The one-character form of the integration indicator, and the only form the popup renders.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately the bubble's glyph pair rather than a second vocabulary: the two surfaces are
+    /// alternatives to each other, never on screen together, so a user who learns the hollow dot on
+    /// one must not meet a different mark for the same state on the other.
+    /// </remarks>
+    public string IntegrationGlyphText
+    {
+        get => _integrationGlyphText;
+        set => SetField(ref _integrationGlyphText, value);
     }
 
     /// <summary>The sentence behind <see cref="IntegrationStatusText"/>, shown on hover.</summary>
@@ -68,11 +85,10 @@ public sealed class CommandAssistPopupViewModel : INotifyPropertyChanged
         set => SetField(ref _queryText, value);
     }
 
-    public string TopSuggestionText
-    {
-        get => _topSuggestionText;
-        set => SetField(ref _topSuggestionText, value);
-    }
+    // The popup used to carry a TopSuggestionText of its own, relayed from the bar view-model. It was
+    // the headline of the detail panel; with the panel gone (UX round 7) and the rows running full
+    // width, the selected row *is* that string, and a second copy of it had no renderer and no reader.
+    // CommandAssistBarViewModel.TopSuggestionText stays - it still drives the bubble summary.
 
     public string SelectedBadgesText
     {
@@ -92,6 +108,30 @@ public sealed class CommandAssistPopupViewModel : INotifyPropertyChanged
         set => SetField(ref _selectedDescriptionText, value);
     }
 
+    /// <summary>
+    /// Everything the footer says about the selected row, already joined into one line.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A derived view of <see cref="SelectedDescriptionText"/>, <see cref="SelectedBadgesText"/> and
+    /// <see cref="SelectedMetadataText"/>, composed in exactly one place -
+    /// <c>CommandAssistBarViewModel.SyncPresentationState</c> - rather than assembled out of three
+    /// bindings in the XAML. Three <c>TextBlock</c>s in a row cannot share one ellipsis: each would
+    /// trim independently, so a long working directory would clip its own segment while the badge
+    /// beside it kept every character. One string trims once, at the end, which is what a reader
+    /// expects from a line that ran out of room.
+    /// </para>
+    /// <para>
+    /// The three sources stay: the bubble reads them, and they are what the controller actually
+    /// knows. This is the popup's rendering of them, not a replacement for them.
+    /// </para>
+    /// </remarks>
+    public string SelectedFooterText
+    {
+        get => _selectedFooterText;
+        set => SetField(ref _selectedFooterText, value);
+    }
+
     public string EmptyStateText
     {
         get => _emptyStateText;
@@ -109,24 +149,6 @@ public sealed class CommandAssistPopupViewModel : INotifyPropertyChanged
         get => _showEmptyState;
         set => SetField(ref _showEmptyState, value);
     }
-
-    public bool UseCompactLayout
-    {
-        get => _useCompactLayout;
-        set
-        {
-            if (_useCompactLayout == value)
-            {
-                return;
-            }
-
-            _useCompactLayout = value;
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(UseCompactLayout)));
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(UseExpandedLayout)));
-        }
-    }
-
-    public bool UseExpandedLayout => !UseCompactLayout;
 
     /// <summary>
     /// Which row is selected, or <c>-1</c>. The rows carry their own <c>IsSelected</c> for rendering;

--- a/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistSuggestionItemViewModel.cs
+++ b/src/NovaTerminal.CommandAssist/ViewModels/CommandAssistSuggestionItemViewModel.cs
@@ -35,7 +35,9 @@ public sealed class CommandAssistSuggestionItemViewModel : INotifyPropertyChange
         string badgesText,
         string metadataText,
         bool isSelected,
-        AssistSuggestionType type)
+        AssistSuggestionType type,
+        string queryText = "",
+        int? exitCode = null)
     {
         DisplayText = displayText;
         DescriptionText = descriptionText;
@@ -43,6 +45,9 @@ public sealed class CommandAssistSuggestionItemViewModel : INotifyPropertyChange
         MetadataText = metadataText;
         Type = type;
         _isSelected = isSelected;
+        ExitCode = exitCode;
+
+        (HighlightStart, HighlightLength) = FindHighlight(displayText, queryText);
     }
 
     public string DisplayText { get; }
@@ -55,16 +60,55 @@ public sealed class CommandAssistSuggestionItemViewModel : INotifyPropertyChange
 
     public AssistSuggestionType Type { get; }
 
+    /// <summary>How the command behind this row ended, or <see langword="null"/> when nothing knows.</summary>
+    public int? ExitCode { get; }
+
+    /// <summary>
+    /// Whether the command behind this row is known to have failed.
+    /// </summary>
+    /// <remarks>
+    /// A null exit code is <em>not</em> a failure. Snippets have never run, a markless session never
+    /// learned how its commands ended, and dimming either of those would be the row telling the user
+    /// something the product does not know. Only an exit code that exists and is non-zero earns the
+    /// dim. This replaces the failure badge: a row the user is scanning does not need the number, it
+    /// needs to be less interesting than the rows beside it.
+    /// </remarks>
+    public bool HasFailed => ExitCode.HasValue && ExitCode.Value != 0;
+
+    /// <summary>
+    /// Where the user's query matches <see cref="DisplayText"/>, or <c>-1</c> when it does not.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Why the offset is recomputed here rather than carried from the matcher.</strong>
+    /// <c>CommandAssistSuggestionEngine.ScoreText</c> records no positions - it answers "how well"
+    /// and never "where" - and threading a position through <c>AssistSuggestion</c> would widen a
+    /// record with a dozen construction sites for the benefit of one <c>TextBlock</c>.
+    /// </para>
+    /// <para>
+    /// A plain case-insensitive <c>IndexOf</c> is not an approximation of what the matcher did: three
+    /// of its four text-match paths - whole-string prefix, token prefix, contains - are satisfied by a
+    /// contiguous case-insensitive occurrence of the whole query, so <c>IndexOf</c> finds exactly the
+    /// run that earned the score. The fourth, the subsequence path, has no contiguous run to point at
+    /// by construction; highlighting nothing there is the honest answer, and inventing a span the
+    /// matcher never used would be worse than none.
+    /// </para>
+    /// </remarks>
+    public int HighlightStart { get; }
+
+    /// <summary>Length of the matched run, or <c>0</c> when there is nothing to highlight.</summary>
+    public int HighlightLength { get; }
+
     /// <summary>
     /// Whether this row carries the "Pinned" badge.
     /// </summary>
     /// <remarks>
     /// Row density (owner request, V2 row-density round) moved every other per-row caption -
-    /// description, metadata, the full badge line - into the detail panel only, since the popup's
-    /// <see cref="BadgesText"/> is no longer rendered on the row itself. Pinned is the one exception:
-    /// it changes which rows are worth a second look while browsing, not just what the reader learns
-    /// about the row already selected, so it earns a single glyph in the row rather than a trip to the
-    /// detail panel. Derived from <see cref="BadgesText"/> rather than a new constructor parameter, so
+    /// description, metadata, the full badge line - out of the row, into the one footer line that
+    /// describes whichever row is selected. Pinned is the one exception: it changes which rows are
+    /// worth a second look while browsing, not just what the reader learns about the row already
+    /// selected, so it earns a single glyph in the row rather than a trip to the footer.
+    /// Derived from <see cref="BadgesText"/> rather than a new constructor parameter, so
     /// every existing call site - and every "Pinned" badge origin in
     /// <c>CommandAssistSuggestionEngine.BuildSnippetBadges</c> - stays the single source of truth.
     /// </remarks>
@@ -93,6 +137,29 @@ public sealed class CommandAssistSuggestionItemViewModel : INotifyPropertyChange
     public string SelectionGlyph => IsSelected ? ">" : " ";
 
     public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>
+    /// Locates the query inside the row text. See <see cref="HighlightStart"/> for why this is a
+    /// plain <c>IndexOf</c> and not a reconstruction of the matcher's scoring.
+    /// </summary>
+    internal static (int Start, int Length) FindHighlight(string displayText, string queryText)
+    {
+        if (string.IsNullOrEmpty(displayText) || string.IsNullOrWhiteSpace(queryText))
+        {
+            return (-1, 0);
+        }
+
+        // Trimmed to match ScoreText, which trims both sides before comparing. Without it a query
+        // the user is still typing ("git ") would fail to find a run the matcher scored a hit on.
+        string needle = queryText.Trim();
+        if (needle.Length == 0 || needle.Length > displayText.Length)
+        {
+            return (-1, 0);
+        }
+
+        int start = displayText.IndexOf(needle, StringComparison.OrdinalIgnoreCase);
+        return start < 0 ? (-1, 0) : (start, needle.Length);
+    }
 
     private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
     {

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistLayoutTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistLayoutTests.cs
@@ -1,15 +1,18 @@
 using NovaTerminal.Shell;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Documents;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
 using Avalonia.Layout;
+using Avalonia.Media;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using System.Collections.ObjectModel;
 using NovaTerminal.CommandAssist.Application;
 using NovaTerminal.Controls;
 using NovaTerminal.CommandAssist.Models;
+using NovaTerminal.CommandAssist.Providers;
 using NovaTerminal.CommandAssist.ViewModels;
 using NovaTerminal.CommandAssist.Views;
 using NovaTerminal.Platform;
@@ -250,10 +253,13 @@ public sealed class CommandAssistLayoutTests
         var popupVm = Assert.IsType<CommandAssistPopupViewModel>(popupView.DataContext);
 
         var bubbleModeLabel = bubbleView.FindControl<TextBlock>("BubbleModeLabelText");
-        var popupDescription = popupView.FindControl<TextBlock>("PopupSelectedDescriptionTextBlock");
+
+        // The footer line, not the detail panel's description block: UX round 7 folded description,
+        // badges and metadata into one composed string and deleted the panel that showed them apart.
+        var popupFooter = popupView.FindControl<TextBlock>("PopupSelectedFooterText");
 
         Assert.NotNull(bubbleModeLabel);
-        Assert.NotNull(popupDescription);
+        Assert.NotNull(popupFooter);
         Assert.Equal("Help", bubbleModeLabel.Text);
 
         // One surface at a time (UX-polish round, issue 6). Help opens the popup, so the bubble
@@ -1090,8 +1096,24 @@ public sealed class CommandAssistLayoutTests
         Assert.Equal(layout.PopupRect.Top, popupView.Margin.Top, precision: 1);
     }
 
+    /// <summary>
+    /// A narrow pane gets the same popup a wide one does: one row list, full width, no side panel.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This replaces <c>TerminalPane_WhenPopupIsNarrow_UsesCompactPopupLayout</c>. That test asserted
+    /// the compact layout hid the detail panel at 420 px, which was a real behaviour until UX round 7
+    /// deleted the panel at every width. With nothing left for the flag to switch between, both the
+    /// flag and the second template went; the property worth pinning now is that the narrow case has
+    /// no second template to diverge - the same named list is realized, and it is the whole body.
+    /// </para>
+    /// <para>
+    /// Driven through the real pane rather than a bare view because the deleted flag was written from
+    /// <c>UpdateCommandAssistOverlayPlacement</c>: it is the placement path that has to stop caring.
+    /// </para>
+    /// </remarks>
     [AvaloniaFact]
-    public async Task TerminalPane_WhenPopupIsNarrow_UsesCompactPopupLayout()
+    public async Task TerminalPane_WhenPopupIsNarrow_StillUsesTheSingleFullWidthRowList()
     {
         using var pane = new TerminalPane
         {
@@ -1109,10 +1131,11 @@ public sealed class CommandAssistLayoutTests
 
         CommandAssistPopupView popupView = Assert.IsType<CommandAssistPopupView>(pane.FindControl<CommandAssistPopupView>("CommandAssistPopup"));
         CommandAssistPopupViewModel vm = Assert.IsType<CommandAssistPopupViewModel>(popupView.DataContext);
-        Border detailPanel = Assert.IsType<Border>(popupView.FindControl<Border>("PopupDetailPanel"));
 
-        Assert.True(vm.UseCompactLayout);
-        Assert.False(detailPanel.IsVisible);
+        Assert.Null(popupView.FindControl<Border>("PopupDetailPanel"));
+        Assert.Null(popupView.FindControl<Border>("PopupCompactPanel"));
+        Assert.NotNull(popupView.FindControl<ItemsControl>("PopupSuggestionsList"));
+        Assert.True(vm.HasSuggestions, "A popup with no rows would make the layout assertion vacuous.");
     }
 
     [AvaloniaFact]
@@ -1362,7 +1385,7 @@ public sealed class CommandAssistLayoutTests
     }
 
     [AvaloniaFact]
-    public void CommandAssistPopupView_BindsResultListAndDetailState()
+    public void CommandAssistPopupView_BindsResultListAndFooterState()
     {
         var suggestions = new ObservableCollection<CommandAssistSuggestionItemViewModel>
         {
@@ -1378,8 +1401,8 @@ public sealed class CommandAssistLayoutTests
         {
             IsVisible = true,
             ModeLabel = "Help",
-            TopSuggestionText = "git status",
             SelectedDescriptionText = "Show working tree state.",
+            SelectedFooterText = @"Show working tree state.  |  History  |  C:\repo",
             HasSuggestions = true
         };
         var view = new CommandAssistPopupView
@@ -1388,20 +1411,31 @@ public sealed class CommandAssistLayoutTests
         };
 
         var modeLabel = view.FindControl<TextBlock>("PopupModeLabelText");
-        var description = view.FindControl<TextBlock>("PopupSelectedDescriptionTextBlock");
+        var footer = view.FindControl<TextBlock>("PopupSelectedFooterText");
         var list = view.FindControl<ItemsControl>("PopupSuggestionsList");
 
         Assert.NotNull(modeLabel);
-        Assert.NotNull(description);
+        Assert.NotNull(footer);
         Assert.NotNull(list);
         Assert.True(view.IsVisible);
         Assert.Equal("Help", modeLabel.Text);
-        Assert.Equal("Show working tree state.", description.Text);
+        Assert.Equal(@"Show working tree state.  |  History  |  C:\repo", footer.Text);
         Assert.Single(vm.Suggestions);
     }
 
+    /// <summary>
+    /// The detail panel is gone at every width, and so is the second row template it justified.
+    /// </summary>
+    /// <remarks>
+    /// This replaces <c>CommandAssistPopupView_WhenCompactLayout_HidesDetailPane</c>, which asserted
+    /// the compact flag hid the panel. Both the panel and the flag were deleted in UX round 7 (owner
+    /// request): with the rows running full width there was nothing for the compact template to do
+    /// differently, and a flag that selects between two identical outcomes is a phantom. Asserting
+    /// the named controls are absent is what keeps a well-meaning revert from quietly reintroducing
+    /// them - <c>FindControl</c> returning null is the only signature their absence has.
+    /// </remarks>
     [AvaloniaFact]
-    public void CommandAssistPopupView_WhenCompactLayout_HidesDetailPane()
+    public void CommandAssistPopupView_HasNoDetailPanelAndOneRowTemplate()
     {
         var suggestions = new ObservableCollection<CommandAssistSuggestionItemViewModel>
         {
@@ -1417,19 +1451,66 @@ public sealed class CommandAssistLayoutTests
         {
             IsVisible = true,
             ModeLabel = "Help",
-            TopSuggestionText = "git status",
-            SelectedDescriptionText = "Show working tree state.",
-            HasSuggestions = true,
-            UseCompactLayout = true
+            HasSuggestions = true
         };
         var view = new CommandAssistPopupView
         {
             DataContext = vm
         };
 
-        Border detailPanel = Assert.IsType<Border>(view.FindControl<Border>("PopupDetailPanel"));
+        Assert.Null(view.FindControl<Border>("PopupDetailPanel"));
+        Assert.Null(view.FindControl<Border>("PopupCompactPanel"));
+        Assert.Null(view.FindControl<ItemsControl>("PopupCompactSuggestionsList"));
+        Assert.NotNull(view.FindControl<ItemsControl>("PopupSuggestionsList"));
+    }
 
-        Assert.False(detailPanel.IsVisible);
+    /// <summary>
+    /// With the panel gone, the row list is the popup's whole body width.
+    /// </summary>
+    /// <remarks>
+    /// The old layout gave the rows a <c>3*</c> of a <c>3*,2*</c> grid - 60% of the body, less a 12 px
+    /// gap - which is what ellipsised commands that had room to spare beside them. "Full width" is
+    /// asserted as a fraction of the card rather than an exact number so the padding constants stay
+    /// free to move; 0.85 is comfortably above anything the two-column grid could have produced.
+    /// </remarks>
+    [AvaloniaFact]
+    public void CommandAssistPopupView_RowListSpansTheFullBodyWidth()
+    {
+        const double popupWidth = 520;
+
+        CommandAssistPopupViewModel vm = CreatePopulatedPopupViewModel();
+        var view = new CommandAssistPopupView
+        {
+            DataContext = vm,
+            Width = popupWidth,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top
+        };
+
+        var window = new Window
+        {
+            Content = view,
+            Width = popupWidth + 80,
+            Height = 300
+        };
+
+        try
+        {
+            window.Show();
+            RelayoutTo(window, view, new Size(popupWidth + 80, 300));
+
+            ItemsControl list = Assert.IsType<ItemsControl>(view.FindControl<ItemsControl>("PopupSuggestionsList"));
+
+            Assert.True(
+                list.Bounds.Width >= popupWidth * 0.85,
+                $"The row list arranged to {list.Bounds.Width:F0} px of a {popupWidth:F0} px popup. " +
+                "The detail panel took 40% of the body; if the rows are back under that share, the " +
+                "two-column grid has returned.");
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     [AvaloniaFact]
@@ -1687,5 +1768,757 @@ public sealed class CommandAssistLayoutTests
 
         Assert.Equal(expectedGlyph, vm.Bubble.IntegrationGlyphText);
         Assert.Equal(expectedLabel, vm.Bubble.IntegrationStatusText);
+    }
+
+    // ------------------------- UX round 7: one footer line
+
+    /// <summary>
+    /// The footer is one composed string: description, then badges, then metadata.
+    /// </summary>
+    [Fact]
+    public void PopupFooter_JoinsDescriptionBadgesAndMetadata()
+    {
+        var vm = new CommandAssistBarViewModel
+        {
+            IsVisible = true,
+            IsPopupOpen = true,
+            ModeLabel = "History",
+            SelectedDescriptionText = "Show working tree state.",
+            SelectedBadgesText = "History  Same dir",
+            SelectedMetadataText = @"C:\repo  |  2 min ago  |  Exit 0"
+        };
+
+        Assert.Equal(
+            @"Show working tree state.  |  History  Same dir  |  C:\repo  |  2 min ago  |  Exit 0",
+            vm.Popup.SelectedFooterText);
+    }
+
+    /// <summary>
+    /// Missing parts are dropped, not joined through: no leading, trailing or doubled separator.
+    /// </summary>
+    /// <remarks>
+    /// The common case, not an edge case. A history row has no description and a snippet has no
+    /// metadata, so a naive three-way join would open most Ctrl+R footers with "  |  ".
+    /// </remarks>
+    [Theory]
+    [InlineData("", "History", @"C:\repo", @"History  |  C:\repo")]
+    [InlineData("Show it.", "", @"C:\repo", @"Show it.  |  C:\repo")]
+    [InlineData("Show it.", "History", "", "Show it.  |  History")]
+    [InlineData("", "", @"C:\repo", @"C:\repo")]
+    public void PopupFooter_OmitsTheEmptyParts(
+        string description,
+        string badges,
+        string metadata,
+        string expected)
+    {
+        var vm = new CommandAssistBarViewModel
+        {
+            IsVisible = true,
+            IsPopupOpen = true,
+            SelectedDescriptionText = description,
+            SelectedBadgesText = badges,
+            SelectedMetadataText = metadata
+        };
+
+        Assert.Equal(expected, vm.Popup.SelectedFooterText);
+    }
+
+    /// <summary>
+    /// With nothing selected the footer is empty, not a bare pair of separators.
+    /// </summary>
+    [Fact]
+    public void PopupFooter_WithNothingSelected_IsEmpty()
+    {
+        var vm = new CommandAssistBarViewModel
+        {
+            IsVisible = true,
+            IsPopupOpen = true,
+            ModeLabel = "History"
+        };
+
+        Assert.Equal(string.Empty, vm.Popup.SelectedFooterText);
+    }
+
+    /// <summary>
+    /// The squeeze order: the metadata trims, the hint strip and the dot never do.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The owner's call, and the reverse of a content-first instinct. The footer is the only place
+    /// <c>Enter</c> and <c>Esc</c> are taught, and a legend cut off at the ellipsis has stopped being
+    /// a legend; a working directory cut short still says which machine and roughly where.
+    /// </para>
+    /// <para>
+    /// Measured against the hint's own unconstrained desired width rather than against a pixel
+    /// number, so re-binding the shortcut keys to something longer does not make this test lie. The
+    /// metadata is asserted to have actually been squeezed, or the whole thing would pass on a popup
+    /// wide enough for everything.
+    /// </para>
+    /// </remarks>
+    [AvaloniaFact]
+    public void PopupFooter_WhenTheFooterIsTight_TrimsTheMetadataAndNotTheHints()
+    {
+        const double popupWidth = 360;
+
+        CommandAssistPopupViewModel vm = CreatePopulatedPopupViewModel();
+        vm.SelectedFooterText =
+            @"Show the working tree status.  |  History  Same dir  |  C:\very\long\working\directory\that\keeps\going  |  2 minutes ago  |  Exit 0";
+        vm.ShortcutHintText = CommandAssistBarViewModel.BrowseHintText;
+
+        var view = new CommandAssistPopupView
+        {
+            DataContext = vm,
+            Width = popupWidth,
+            Height = 220,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top
+        };
+
+        var window = new Window
+        {
+            Content = view,
+            Width = popupWidth + 80,
+            Height = 300
+        };
+
+        try
+        {
+            window.Show();
+            RelayoutTo(window, view, new Size(popupWidth + 80, 300));
+
+            TextBlock hint = Assert.IsType<TextBlock>(view.FindControl<TextBlock>("PopupShortcutHintText"));
+            TextBlock footer = Assert.IsType<TextBlock>(view.FindControl<TextBlock>("PopupSelectedFooterText"));
+            TextBlock glyph = Assert.IsType<TextBlock>(view.FindControl<TextBlock>("PopupIntegrationGlyph"));
+
+            var unconstrainedHint = new TextBlock
+            {
+                Text = hint.Text,
+                FontSize = hint.FontSize,
+                FontFamily = hint.FontFamily
+            };
+            unconstrainedHint.Measure(Size.Infinity);
+
+            Assert.True(
+                hint.Bounds.Width >= unconstrainedHint.DesiredSize.Width - 0.5,
+                $"The hint strip arranged to {hint.Bounds.Width:F0} px but wants " +
+                $"{unconstrainedHint.DesiredSize.Width:F0} px, so it has been squeezed. The hints are " +
+                "the one thing in this footer that must never give up a character.");
+            Assert.True(glyph.Bounds.Width > 0, "The integration dot must survive the squeeze too.");
+            Assert.True(
+                footer.Bounds.Width < unconstrainedHint.DesiredSize.Width * 3,
+                $"The metadata arranged to {footer.Bounds.Width:F0} px in a {popupWidth:F0} px popup, " +
+                "which is not tight enough for this test to be measuring a squeeze at all.");
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>
+    /// The popup's integration indicator is the bubble's dot, not the old labelled chip - and the
+    /// sentence behind it is still there for hover and for a screen reader.
+    /// </summary>
+    [Theory]
+    [InlineData(true, CommandAssistBarViewModel.IntegratedStatusGlyph, CommandAssistBarViewModel.IntegratedStatusTooltip)]
+    [InlineData(false, CommandAssistBarViewModel.BasicStatusGlyph, CommandAssistBarViewModel.BasicStatusTooltip)]
+    public void PopupIntegrationIndicator_IsTheBubblesDotWithTheSameTooltip(
+        bool isLive,
+        string expectedGlyph,
+        string expectedTooltip)
+    {
+        var vm = new CommandAssistBarViewModel
+        {
+            IsVisible = true,
+            IsPopupOpen = true,
+            ModeLabel = "History",
+            IsShellIntegrationLive = isLive
+        };
+
+        Assert.Equal(expectedGlyph, vm.Popup.IntegrationGlyphText);
+        Assert.Equal(expectedGlyph, vm.Bubble.IntegrationGlyphText);
+        Assert.Equal(expectedTooltip, vm.Popup.IntegrationStatusTooltip);
+
+        // The word is no longer rendered, but it is still published: it is what the tooltip and the
+        // accessible name are built from, and dropping it would make the dot unnameable.
+        Assert.False(string.IsNullOrWhiteSpace(vm.Popup.IntegrationStatusText));
+    }
+
+    /// <summary>The rendered footer carries the dot and its tooltip, and no chip.</summary>
+    [AvaloniaFact]
+    public void CommandAssistPopupView_RendersTheIntegrationDotAndNotTheChip()
+    {
+        CommandAssistPopupViewModel vm = CreatePopulatedPopupViewModel();
+        vm.IntegrationGlyphText = CommandAssistBarViewModel.BasicStatusGlyph;
+        vm.IntegrationStatusTooltip = CommandAssistBarViewModel.BasicStatusTooltip;
+
+        var view = new CommandAssistPopupView
+        {
+            DataContext = vm
+        };
+
+        Assert.Null(view.FindControl<Border>("PopupIntegrationChip"));
+
+        TextBlock glyph = Assert.IsType<TextBlock>(view.FindControl<TextBlock>("PopupIntegrationGlyph"));
+        Assert.Equal(CommandAssistBarViewModel.BasicStatusGlyph, glyph.Text);
+        Assert.Equal(CommandAssistBarViewModel.BasicStatusTooltip, ToolTip.GetTip(glyph));
+    }
+
+    /// <summary>
+    /// The licence credit keeps its own wrapped line under the footer, untrimmed.
+    /// </summary>
+    /// <remarks>
+    /// Pinned because the footer rearrangement is exactly the kind of change that would sweep it into
+    /// the ellipsised column. A credit cut off at the ellipsis is not a credit, and this one is a
+    /// CC-BY-SA obligation rather than a nicety.
+    /// </remarks>
+    [AvaloniaFact]
+    public void CommandAssistPopupView_KeepsTheAttributionOnItsOwnWrappedLine()
+    {
+        CommandAssistPopupViewModel vm = CreatePopulatedPopupViewModel();
+        vm.AttributionText = "Command examples from tldr-pages, CC-BY-SA 4.0.";
+
+        var view = new CommandAssistPopupView
+        {
+            DataContext = vm
+        };
+
+        TextBlock attribution = Assert.IsType<TextBlock>(view.FindControl<TextBlock>("PopupAttributionText"));
+
+        Assert.True(attribution.IsVisible);
+        Assert.Equal(TextWrapping.Wrap, attribution.TextWrapping);
+        Assert.Equal(TextTrimming.None, attribution.TextTrimming);
+        Assert.Equal("Command examples from tldr-pages, CC-BY-SA 4.0.", attribution.Text);
+    }
+
+    // ------------------------- UX round 7: matched-substring highlight
+
+    /// <summary>
+    /// Where the highlight lands, across every boundary the query can hit.
+    /// </summary>
+    /// <remarks>
+    /// The subsequence case is the interesting one. The matcher scores <c>gs</c> against
+    /// <c>git status</c> on its subsequence path, which has no contiguous run to point at; the row
+    /// answers "no highlight" rather than inventing a span the matcher never used.
+    /// </remarks>
+    [Theory]
+    [InlineData("git status", "", -1, 0)]                 // no query: nothing typed, nothing to point at
+    [InlineData("git status", "git", 0, 3)]               // at index 0
+    [InlineData("git status", "status", 4, 6)]            // at the end
+    [InlineData("git status", "tat", 5, 3)]               // in the middle
+    [InlineData("git status", "GIT", 0, 3)]               // typed uppercase, row lowercase
+    [InlineData("Get-ChildItem", "get", 0, 3)]            // typed lowercase, row uppercase
+    [InlineData("git", "git status", -1, 0)]              // query longer than the row
+    [InlineData("git status", "docker", -1, 0)]           // no match at all
+    [InlineData("git status", "gs", -1, 0)]               // subsequence only: no contiguous run
+    [InlineData("git status", "   ", -1, 0)]              // whitespace-only query
+    [InlineData("git status", "git ", 0, 3)]              // trailing space trimmed, as the matcher does
+    public void SuggestionRow_HighlightsTheMatchedRun(
+        string displayText,
+        string query,
+        int expectedStart,
+        int expectedLength)
+    {
+        var row = new CommandAssistSuggestionItemViewModel(
+            displayText: displayText,
+            descriptionText: string.Empty,
+            badgesText: string.Empty,
+            metadataText: string.Empty,
+            isSelected: false,
+            type: AssistSuggestionType.History,
+            queryText: query);
+
+        Assert.Equal(expectedStart, row.HighlightStart);
+        Assert.Equal(expectedLength, row.HighlightLength);
+    }
+
+    /// <summary>
+    /// The control turns the span into runs, and keeps trimming on the whole line.
+    /// </summary>
+    [Fact]
+    public void MatchHighlightTextBlock_SplitsIntoBeforeMatchAndAfter()
+    {
+        Assert.Equal(("git ", "sta", "tus"), MatchHighlightTextBlock.SplitForHighlight("git status", 4, 3));
+        Assert.Equal((string.Empty, "git", " status"), MatchHighlightTextBlock.SplitForHighlight("git status", 0, 3));
+        Assert.Equal(("git ", "status", string.Empty), MatchHighlightTextBlock.SplitForHighlight("git status", 4, 6));
+        Assert.Null(MatchHighlightTextBlock.SplitForHighlight("git status", -1, 0));
+        Assert.Null(MatchHighlightTextBlock.SplitForHighlight("git status", 4, 0));
+        Assert.Null(MatchHighlightTextBlock.SplitForHighlight(string.Empty, 0, 3));
+
+        // The span outlives the text by a frame when the two bindings update independently.
+        Assert.Null(MatchHighlightTextBlock.SplitForHighlight("git", 4, 6));
+        Assert.Null(MatchHighlightTextBlock.SplitForHighlight("git status", 8, 6));
+    }
+
+    /// <summary>
+    /// The rendered inlines: three runs for a match in the middle, one for no match.
+    /// </summary>
+    /// <remarks>
+    /// Asserted on the inlines rather than on pixels because the runs are the thing: a single
+    /// <c>TextBlock</c> laying out three runs is what keeps <c>TextTrimming</c> working on the whole
+    /// command, which a three-<c>TextBlock</c> <c>StackPanel</c> would have broken.
+    /// </remarks>
+    [AvaloniaFact]
+    public void MatchHighlightTextBlock_BuildsInlineRunsForTheSpan()
+    {
+        var highlight = new SolidColorBrush(Colors.Aqua);
+        var block = new MatchHighlightTextBlock
+        {
+            SourceText = "git status",
+            HighlightStart = 4,
+            HighlightLength = 3,
+            HighlightBrush = highlight,
+            TextTrimming = TextTrimming.CharacterEllipsis
+        };
+
+        Assert.Equal(new[] { "git ", "sta", "tus" }, RunTexts(block));
+        Assert.Same(highlight, Assert.IsType<Run>(block.Inlines![1]).Foreground);
+
+        // Only the matched run is emphasised. The others carry no explicit brush, which is what lets
+        // them inherit the row's foreground - including the dim a failed row applies.
+        Assert.False(
+            ReferenceEquals(highlight, Assert.IsType<Run>(block.Inlines[0]).Foreground),
+            "The run before the match must not take the highlight brush.");
+        Assert.False(
+            ReferenceEquals(highlight, Assert.IsType<Run>(block.Inlines[2]).Foreground),
+            "The run after the match must not take the highlight brush.");
+        Assert.Equal(TextTrimming.CharacterEllipsis, block.TextTrimming);
+
+        // A match at index 0 has no "before", so it is two runs and not three with a blank.
+        block.HighlightStart = 0;
+        block.HighlightLength = 3;
+        Assert.Equal(new[] { "git", " status" }, RunTexts(block));
+
+        // No match: the whole string, one run, still trimmed as one line.
+        block.HighlightStart = -1;
+        block.HighlightLength = 0;
+        Assert.Equal(new[] { "git status" }, RunTexts(block));
+
+        // And the text can change out from under a stale span without throwing or highlighting.
+        block.SourceText = "ls";
+        Assert.Equal(new[] { "ls" }, RunTexts(block));
+    }
+
+    private static string[] RunTexts(MatchHighlightTextBlock block)
+    {
+        return block.Inlines!.OfType<Run>().Select(run => run.Text ?? string.Empty).ToArray();
+    }
+
+    // ------------------------- UX round 7: failed rows are dimmed
+
+    /// <summary>
+    /// Which exit codes count as a failure. Null is not one of them.
+    /// </summary>
+    /// <remarks>
+    /// A snippet has never run and a markless session never learned how its commands ended; dimming
+    /// either would be the row claiming knowledge the product does not have.
+    /// </remarks>
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    [InlineData(127, true)]
+    [InlineData(-1, true)]
+    public void SuggestionRow_HasFailedOnlyForANonZeroExitCode(int? exitCode, bool expected)
+    {
+        var row = new CommandAssistSuggestionItemViewModel(
+            displayText: "git status",
+            descriptionText: string.Empty,
+            badgesText: string.Empty,
+            metadataText: string.Empty,
+            isSelected: false,
+            type: AssistSuggestionType.History,
+            exitCode: exitCode);
+
+        Assert.Equal(expected, row.HasFailed);
+    }
+
+    /// <summary>
+    /// A failed row is dimmer than a healthy one, and a failed row that is also <em>selected</em> is
+    /// legible again - dimmer than healthy, brighter than an unselected failure.
+    /// </summary>
+    /// <remarks>
+    /// The three-way ordering is the assertion, not the hexes: it is what says the failure is still
+    /// readable as a failure while the row Enter is about to act on is still readable at all. Pinning
+    /// the numbers instead would fail on any palette change without saying which property broke.
+    /// </remarks>
+    [AvaloniaFact]
+    public void CommandAssistPopupView_DimsFailedRowsAndKeepsTheSelectedOneLegible()
+    {
+        var suggestions = new ObservableCollection<CommandAssistSuggestionItemViewModel>
+        {
+            FailedRow("git push", isSelected: false),
+            FailedRow("git rebase -i", isSelected: true),
+            new(
+                displayText: "git status",
+                descriptionText: string.Empty,
+                badgesText: string.Empty,
+                metadataText: string.Empty,
+                isSelected: false,
+                type: AssistSuggestionType.History,
+                exitCode: 0)
+        };
+        var vm = new CommandAssistPopupViewModel(suggestions)
+        {
+            IsVisible = true,
+            ModeLabel = "History",
+            HasSuggestions = true
+        };
+        var view = new CommandAssistPopupView
+        {
+            DataContext = vm,
+            Width = 520,
+            Height = 220,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top
+        };
+
+        var window = new Window
+        {
+            Content = view,
+            Width = 600,
+            Height = 300
+        };
+
+        try
+        {
+            window.Show();
+            RelayoutTo(window, view, new Size(600, 300));
+
+            List<MatchHighlightTextBlock> rows = view.GetVisualDescendants()
+                .OfType<MatchHighlightTextBlock>()
+                .ToList();
+            Assert.Equal(3, rows.Count);
+
+            double failed = Luminance(rows[0].Foreground);
+            double failedAndSelected = Luminance(rows[1].Foreground);
+            double healthy = Luminance(rows[2].Foreground);
+
+            Assert.True(
+                failed < healthy,
+                $"A failed row must be dimmer than a healthy one, but measured {failed:F0} against {healthy:F0}.");
+            Assert.True(
+                failedAndSelected > failed,
+                $"A failed row that is selected must climb back out of the dim, but measured " +
+                $"{failedAndSelected:F0} against {failed:F0}. This is the row Enter acts on.");
+            Assert.True(
+                failedAndSelected < healthy,
+                $"...without becoming indistinguishable from a healthy row: measured " +
+                $"{failedAndSelected:F0} against {healthy:F0}.");
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    private static CommandAssistSuggestionItemViewModel FailedRow(string displayText, bool isSelected) =>
+        new(
+            displayText: displayText,
+            descriptionText: string.Empty,
+            badgesText: string.Empty,
+            metadataText: string.Empty,
+            isSelected: isSelected,
+            type: AssistSuggestionType.History,
+            exitCode: 1);
+
+    /// <summary>
+    /// Rec. 601 luma, which is close enough to "how bright does this look".
+    /// </summary>
+    /// <remarks>
+    /// Typed as <c>ISolidColorBrush</c>, not <c>SolidColorBrush</c>: a brush that arrives from a style
+    /// setter is the immutable variant, so an exact-type assertion would fail on the styled rows this
+    /// is here to measure.
+    /// </remarks>
+    private static double Luminance(IBrush? brush)
+    {
+        Color color = Assert.IsAssignableFrom<ISolidColorBrush>(brush).Color;
+        return (0.299 * color.R) + (0.587 * color.G) + (0.114 * color.B);
+    }
+
+    // ------------------------- UX round 7: the popup is as tall as its rows
+
+    /// <summary>
+    /// The height grows a row at a time, stops at a floor, and stops at the old ceiling.
+    /// </summary>
+    [Fact]
+    public void PopupHeightEstimate_TracksTheRowCountBetweenAFloorAndTheOldCeiling()
+    {
+        double one = TerminalPane.EstimateCommandAssistPopupHeight(
+            new TerminalPane.CommandAssistPopupContentSize(1, false, false), paneHeight: 1000);
+        double two = TerminalPane.EstimateCommandAssistPopupHeight(
+            new TerminalPane.CommandAssistPopupContentSize(2, false, false), paneHeight: 1000);
+        double five = TerminalPane.EstimateCommandAssistPopupHeight(
+            new TerminalPane.CommandAssistPopupContentSize(5, false, false), paneHeight: 1000);
+        double fifty = TerminalPane.EstimateCommandAssistPopupHeight(
+            new TerminalPane.CommandAssistPopupContentSize(50, false, false), paneHeight: 1000);
+        double none = TerminalPane.EstimateCommandAssistPopupHeight(
+            new TerminalPane.CommandAssistPopupContentSize(0, false, false), paneHeight: 1000);
+
+        Assert.True(two > one, $"Two rows must be taller than one, but measured {two:F0} and {one:F0}.");
+        Assert.True(five > two, $"Five rows must be taller than two, but measured {five:F0} and {two:F0}.");
+        Assert.Equal(one, none);
+        Assert.Equal(220, fifty, precision: 1);
+        Assert.True(one < 220, $"A one-row popup must be shorter than the old fixed 220, but was {one:F0}.");
+    }
+
+    /// <summary>
+    /// The empty-state popup is a caption, not a tall empty box.
+    /// </summary>
+    [Fact]
+    public void PopupHeightEstimate_ForTheEmptyState_IsTheFloor()
+    {
+        double empty = TerminalPane.EstimateCommandAssistPopupHeight(
+            new TerminalPane.CommandAssistPopupContentSize(0, ShowEmptyState: true, HasAttribution: false),
+            paneHeight: 1000);
+        double oneRow = TerminalPane.EstimateCommandAssistPopupHeight(
+            new TerminalPane.CommandAssistPopupContentSize(1, false, false), paneHeight: 1000);
+
+        Assert.Equal(oneRow, empty);
+        Assert.True(empty < 220, $"The 'no matches' popup must not be the old 220 px box, but was {empty:F0}.");
+    }
+
+    /// <summary>A short pane still wins: the old paneHeight * 0.45 ceiling is unchanged.</summary>
+    [Fact]
+    public void PopupHeightEstimate_OnAShortPane_StaysUnderTheProportionalCeiling()
+    {
+        double onAShortPane = TerminalPane.EstimateCommandAssistPopupHeight(
+            new TerminalPane.CommandAssistPopupContentSize(50, false, false), paneHeight: 320);
+
+        Assert.True(
+            onAShortPane <= 320 * 0.45 + 0.001,
+            $"A 50-row list on a 320 px pane asked for {onAShortPane:F0} px, over the 45% ceiling.");
+    }
+
+    /// <summary>
+    /// The estimate is measured against the real template, which is what keeps it honest.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every constant behind <c>EstimateCommandAssistPopupHeight</c> is read off
+    /// <c>CommandAssistPopupView.axaml</c> - paddings, the border, the row spacing, the row's own
+    /// padding and margin. Constants derived from a template drift the moment the template does, and
+    /// the symptom is subtle: a few pixels of empty card under the last row, or a clipped footer.
+    /// So this arranges the actual control at its natural height and compares.
+    /// </para>
+    /// <para>
+    /// The estimate must never be <em>short</em> - that clips - and is allowed to be a few pixels
+    /// generous. If this fails, re-derive the constants from the template rather than widening the
+    /// tolerance.
+    /// </para>
+    /// <para>
+    /// Row counts stop at four because five rows plus chrome exceeds the 220 px ceiling, where the
+    /// estimate is supposed to stop tracking the content and the list is supposed to scroll. The
+    /// clamp itself is pinned separately, in
+    /// <see cref="PopupHeightEstimate_TracksTheRowCountBetweenAFloorAndTheOldCeiling"/>.
+    /// </para>
+    /// <para>
+    /// The empty state is measured at two widths, and that is not redundancy. Its body is one wrapping
+    /// <c>TextBlock</c>, so whether it fits on one line is a function of the popup's width and of how
+    /// long the string is - and the estimate budgets exactly one line for it. 360 px is the floor
+    /// <c>CalculateCommandAssistSurfaceSizing</c> clamps the popup to, so it is the width at which a
+    /// future empty-state string would wrap first. The longest one currently shipped
+    /// (<see cref="AssistEmptyStates.NoHistoryMatch"/>) is the one under test, so a new string longer
+    /// than it fails here rather than on the owner's screen.
+    /// </para>
+    /// </remarks>
+    [AvaloniaTheory]
+    [InlineData(1, false, false, 520)]
+    [InlineData(2, false, false, 520)]
+    [InlineData(3, false, false, 520)]
+    [InlineData(4, false, false, 520)]
+    [InlineData(2, false, true, 520)]
+    [InlineData(0, true, false, 520)]
+    [InlineData(0, true, false, 360)]
+    public void PopupHeightEstimate_MatchesTheRenderedTemplate(
+        int rowCount,
+        bool showEmptyState,
+        bool hasAttribution,
+        double popupWidth)
+    {
+        const double tolerance = 8;
+
+        var suggestions = new ObservableCollection<CommandAssistSuggestionItemViewModel>();
+        for (int i = 0; i < rowCount; i++)
+        {
+            suggestions.Add(new CommandAssistSuggestionItemViewModel(
+                displayText: $"git commit --message \"row {i}\"",
+                descriptionText: string.Empty,
+                badgesText: string.Empty,
+                metadataText: string.Empty,
+                isSelected: i == 0,
+                type: AssistSuggestionType.History));
+        }
+
+        var vm = new CommandAssistPopupViewModel(suggestions)
+        {
+            IsVisible = true,
+            ModeLabel = "History",
+            QueryText = "git",
+            SelectedFooterText = @"C:\repo  |  2 min ago  |  Exit 0",
+            ShortcutHintText = CommandAssistBarViewModel.BrowseHintText,
+            AttributionText = hasAttribution ? "Command examples from tldr-pages, CC-BY-SA 4.0." : string.Empty,
+
+            // The longest shipped empty-state string, so this measures the worst case the product can
+            // currently produce rather than a convenient short one.
+            EmptyStateText = showEmptyState ? AssistEmptyStates.NoHistoryMatch : string.Empty,
+            ShowEmptyState = showEmptyState,
+            HasSuggestions = !showEmptyState
+        };
+
+        string what = showEmptyState
+            ? $"the empty state at {popupWidth:F0} px"
+            : $"{rowCount} row(s)";
+
+        double measured = MeasureNaturalPopupHeight(vm, popupWidth);
+        double estimated = TerminalPane.EstimateCommandAssistPopupHeight(
+            new TerminalPane.CommandAssistPopupContentSize(rowCount, showEmptyState, hasAttribution),
+            paneHeight: 2000);
+
+        Assert.True(
+            estimated >= measured,
+            $"The estimate for {what} was {estimated:F1} px but the template needs {measured:F1} px, " +
+            "so the popup would clip. Re-derive the chrome and row constants in TerminalPane from " +
+            "CommandAssistPopupView.axaml - and if this is the empty state, check whether the string " +
+            "has grown long enough to wrap onto a second line, which the one-line budget does not cover.");
+        Assert.True(
+            estimated - measured <= tolerance,
+            $"The estimate for {what} was {estimated:F1} px against a measured {measured:F1} px, " +
+            $"which is {estimated - measured:F1} px of empty card under the content " +
+            $"(tolerance {tolerance:F0}).");
+    }
+
+    /// <summary>
+    /// Placement re-runs when the row count changes, not only on resize or a visibility flip.
+    /// </summary>
+    /// <remarks>
+    /// This is the half that makes the content-sized popup actually shrink in use. Ctrl+R re-ranks on
+    /// every keystroke, so the popup goes from a full list to two rows without the pane resizing or
+    /// the surface being reopened; before the count was published, nothing told the pane to re-place.
+    /// </remarks>
+    [AvaloniaFact]
+    public async Task TerminalPane_WhenTheRowCountChanges_RepositionsThePopupAtTheNewHeight()
+    {
+        using var pane = new TerminalPane
+        {
+            Width = 900,
+            Height = 500
+        };
+        ConfigureCommandAssist(pane);
+        pane.Measure(new Size(900, 500));
+        pane.Arrange(new Rect(0, 0, 900, 500));
+        await AtAnIntegratedPromptAsync(pane, "Get-ChildItem");
+        pane.OpenCommandAssistHelp();
+        await Task.Delay(50);
+        pane.Measure(new Size(900, 500));
+        pane.Arrange(new Rect(0, 0, 900, 500));
+
+        CommandAssistPopupView popupView = Assert.IsType<CommandAssistPopupView>(pane.FindControl<CommandAssistPopupView>("CommandAssistPopup"));
+        CommandAssistBarViewModel vm = Assert.IsType<CommandAssistBarViewModel>(pane.CommandAssistViewModel);
+
+        vm.SuggestionCount = 5;
+        double tall = popupView.Height;
+        double tallTop = popupView.Margin.Top;
+
+        vm.SuggestionCount = 1;
+        double shortened = popupView.Height;
+        double shortenedTop = popupView.Margin.Top;
+
+        Assert.True(
+            shortened < tall,
+            $"Dropping from five rows to one left the popup at {shortened:F0} px against {tall:F0}. " +
+            "Nothing re-ran placement, so a Ctrl+R filter keeps the box it opened with.");
+        Assert.True(
+            shortenedTop > tallTop,
+            $"The shorter popup must stay attached to the prompt, so its top moves down from " +
+            $"{tallTop:F0} to {shortenedTop:F0}. An unmoved top is a popup floating away from the bubble.");
+    }
+
+    /// <summary>
+    /// Arranges the popup at its natural height and returns it.
+    /// </summary>
+    /// <remarks>
+    /// Hosted in a window with no explicit height and top alignment, so the measured value is what the
+    /// template wants rather than what a test told it to be.
+    /// </remarks>
+    private static double MeasureNaturalPopupHeight(CommandAssistPopupViewModel vm, double width)
+    {
+        var view = new CommandAssistPopupView
+        {
+            DataContext = vm,
+            Width = width,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top
+        };
+
+        var window = new Window
+        {
+            Content = view,
+            Width = width + 80,
+            Height = 600
+        };
+
+        try
+        {
+            window.Show();
+            RelayoutTo(window, view, new Size(width + 80, 600));
+            Assert.True(view.Bounds.Height > 0, "The popup arranged to nothing, so there is no height to compare.");
+            return view.Bounds.Height;
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>Three history rows and a filled footer - the popup as a user actually sees it.</summary>
+    private static CommandAssistPopupViewModel CreatePopulatedPopupViewModel()
+    {
+        var suggestions = new ObservableCollection<CommandAssistSuggestionItemViewModel>
+        {
+            new(
+                displayText: "git status --short",
+                descriptionText: "Show the working tree status.",
+                badgesText: "History",
+                metadataText: @"C:\repo  |  2 min ago  |  Exit 0",
+                isSelected: true,
+                type: AssistSuggestionType.History,
+                queryText: "git",
+                exitCode: 0),
+            new(
+                displayText: "git commit --amend",
+                descriptionText: "Rewrite the most recent commit.",
+                badgesText: "History",
+                metadataText: @"C:\repo  |  yesterday  |  Exit 0",
+                isSelected: false,
+                type: AssistSuggestionType.History,
+                queryText: "git",
+                exitCode: 0),
+            new(
+                displayText: "git push --force-with-lease",
+                descriptionText: "Update the remote branch safely.",
+                badgesText: "History",
+                metadataText: @"C:\repo  |  last week  |  Exit 1",
+                isSelected: false,
+                type: AssistSuggestionType.History,
+                queryText: "git",
+                exitCode: 1)
+        };
+
+        return new CommandAssistPopupViewModel(suggestions)
+        {
+            IsVisible = true,
+            ModeLabel = "History",
+            QueryText = "git",
+            SelectedDescriptionText = "Show the working tree status.",
+            SelectedBadgesText = "History",
+            SelectedMetadataText = @"C:\repo  |  2 min ago  |  Exit 0",
+            SelectedFooterText = @"Show the working tree status.  |  History  |  C:\repo  |  2 min ago  |  Exit 0",
+            HasSuggestions = true,
+            ShortcutHintText = CommandAssistBarViewModel.BrowseHintText,
+            IntegrationGlyphText = CommandAssistBarViewModel.BasicStatusGlyph,
+            IntegrationStatusText = CommandAssistBarViewModel.BasicStatusText,
+            IntegrationStatusTooltip = CommandAssistBarViewModel.BasicStatusTooltip
+        };
     }
 }

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistOverlayContentRenderTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistOverlayContentRenderTests.cs
@@ -275,13 +275,18 @@ public sealed class CommandAssistOverlayContentRenderTests
 
         WithRenderedView(view, 520, 220, (bitmap, rendered) =>
         {
-            // The same two regions the positive guard measures, measured the same way. Deliberately not
-            // the whole card: the border and the rounded corners are ink by any definition, and a
-            // negative control that has to exclude them is not measuring what the positive one measures.
-            // The mode label is left out because with no data context it has no text and therefore no
+            // Two regions the positive guard measures, measured the same way. Deliberately not the
+            // whole card: the border and the rounded corners are ink by any definition, and a negative
+            // control that has to exclude them is not measuring what the positive one measures. The
+            // mode label is left out because with no data context it has no text and therefore no
             // width at all - a different, cruder symptom that RegionOf rejects outright.
+            //
+            // The hint strip is left out for the same reason since UX round 7: the one-line footer
+            // put it in an Auto column so that it can never be squeezed, which also means it has no
+            // width when it has no text. The footer's metadata column is the star one, so it keeps
+            // its width while staying genuinely blank - which is exactly what this control needs.
             AssertRegionIsBlank(bitmap, rendered, "PopupSuggestionsList", "the suggestion row list");
-            AssertRegionIsBlank(bitmap, rendered, "PopupShortcutHintText", "the popup hint strip");
+            AssertRegionIsBlank(bitmap, rendered, "PopupSelectedFooterText", "the popup footer metadata");
         });
     }
 
@@ -317,14 +322,15 @@ public sealed class CommandAssistOverlayContentRenderTests
             IsVisible = true,
             ModeLabel = "History",
             QueryText = "git",
-            TopSuggestionText = "git status --short",
             SelectedDescriptionText = "Show the working tree status.",
             SelectedBadgesText = "History",
             SelectedMetadataText = @"C:\repo | used today",
+            SelectedFooterText = @"Show the working tree status.  |  History  |  C:\repo | used today",
             HasSuggestions = true,
             ShowEmptyState = false,
             ShortcutHintText = CommandAssistBarViewModel.BrowseHintText,
-            UseCompactLayout = false
+            IntegrationGlyphText = CommandAssistBarViewModel.BasicStatusGlyph,
+            IntegrationStatusTooltip = CommandAssistBarViewModel.BasicStatusTooltip
         };
     }
 


### PR DESCRIPTION
Popup polish round, from dogfood feedback. Five changes, one PR.

## 1. The detail side panel is gone

Rows are the popup now. They span the full body width instead of sharing it 3:2 with a
panel that repeated what the selected row already said.

Following that through: with the panel removed, the "expanded" and "compact" row
templates were byte-identical duplicates, so they collapse into one. `UseCompactLayout`
/ `UseExpandedLayout` and the `CompactPopupWidthThreshold` / `CompactPopupHeightThreshold`
constants are deleted rather than left switching between two identical things - the
popup has one layout at every width. The bubble's own compact/terse thresholds in
`CommandAssistAnchorCalculator` are a separate system and are untouched.

`CommandAssistPopupViewModel.TopSuggestionText` went with it: nothing bound it once the
panel was gone. The bar view-model's copy stays - that one drives the bubble summary.

## 2. One footer line

`[selected-row metadata, ellipsized] | [key hints] | [integration dot]`

The metadata is star-sized and absorbs every bit of squeeze; the hints and the dot are
Auto and are never trimmed. Enter/Esc discoverability is the whole point of the hint
strip, so it does not get to be the thing that disappears when a pane is narrow.

The labelled integration chip becomes a dot, matching the bubble's collapse-exempt dot
from #301. The tooltip text is unchanged, so the "why is this list shorter than I
expected" answer is still one hover away.

Footer text is composed in exactly one place (`CommandAssistBarViewModel.SyncPresentationState`)
from the non-empty parts of description / badges / metadata. The three underlying
properties survive - the bubble and the controller tests use them.

The CC-BY-SA attribution line is untouched: still its own wrapped, never-trimmed line
below the footer. A credit cut off at the ellipsis is not a credit.

## 3. Matched substring is highlighted in rows

Computed at the row view-model layer as `DisplayText.IndexOf(query, OrdinalIgnoreCase)`,
not threaded through `AssistSuggestion`.

That is not a shortcut - it is exactly equivalent to the engine's scoring. All three
contiguous match paths (prefix 120, token-prefix 70, contains 25) are whole-query
matches, so `IndexOf` reproduces them precisely. The only path it does not light up is
subsequence-only (score 12), which by definition has no contiguous run to highlight, and
highlighting nothing there is the honest answer rather than a bug.

Rendered by a new `MatchHighlightTextBlock : TextBlock` that rebuilds `Inlines` on
change. A three-TextBlock StackPanel was rejected: it would have broken `TextTrimming`
on the full string, and one-line rows have to keep ellipsizing.

## 4. Failed rows are dimmed - no badges

`ExitCode` non-null and non-zero dims the row foreground. A null exit code (snippets,
unknown) is not a failure. Selected-and-failed keeps its own brighter rung so the row
Enter is about to act on stays legible; a test asserts the luminance ordering rather
than the hex values.

## 5. The popup shrinks to fit its rows

Height is computed from the row count BEFORE the anchor calculation and passed in as the
requested height, rather than auto-sizing the control. Auto-sizing looks correct and is
not: the popup is positioned by `Margin.Top` inside a Grid with `VerticalAlignment=Top`,
so a shorter popup placed upward would float away from the prompt and leave a gap under
itself.

Constants were measured against the real headless render, not guessed: row 25px, chrome
96px, attribution 19px, floor 121px. Ceiling is unchanged (`Clamp(paneHeight * 0.45, .., 220)`).
`PopupHeightEstimate_MatchesTheRenderedTemplate` measures the live control and fails if
the estimate is ever short (which would clip rows) or more than 8px generous (which would
let drift accumulate silently). Measured slack today: 0px at 1-4 rows, 2px with
attribution, 6px for the empty state.

Placement re-runs on a change-gated `SuggestionCount` rather than `CollectionChanged` -
the controller rebuilds with Clear + N Adds, so a collection listener would fire N+1
placement passes per ranking pass.

## Testing

New/changed tests in `CommandAssistLayoutTests` (95 passing, was 93) and
`CommandAssistOverlayContentRenderTests`: no detail panel and one template; rows span the
full width; footer composition including the all-empty case; footer squeeze order (hints
arranged to non-zero width when the metadata is long); dot renders and keeps its tooltip;
highlight offsets across 11 boundary cases (empty query, match at 0, match at end, query
longer than text, no match, case-crossing both directions, subsequence-only); failed-row
dim including selected+failed; height estimate against the live render for 1-4 rows, the
attribution case, and the empty state at both 520px and the 360px floor; placement re-runs
on row-count change.

All new guard tests were mutation-checked - 12 mutants introduced, each confirmed to fail
the test that claims to catch it, all reverted.

Green after a clean build (the .axaml change makes a dirty build meaningless):
`CommandAssistLayoutTests` 95, `CommandAssistOverlayContentRenderTests` 5,
`CommandAssistControllerTests` 79, `CommandAssistPassiveBubbleTests` 29,
`CommandAssistGridTruthTests` 20, `AssistContentProviderSeamTests` 31,
`PaneAssistInsertionTests` 24, `CommandAssistSuggestionEngineTests` 27,
`CommandAssistAnchorCalculatorTests` 28, `TerminalViewKeyHandlingTests` 22.

Reviewed by a second agent: approved, no blockers, three nits raised and all three fixed
before push.

## Known / not verified

- Not verified live. Everything visual is asserted through headless layout and brush
  values. Worth a look before merge: whether the failed-row dim reads as "quietly
  de-emphasised" or as "greyed out and unreadable" on a real monitor.
- Height constants are measured at the default headless font and DPI. There is no
  app-wide UI font-scale setting today (only the terminal grid font is configurable), so
  drift risk is low, but this is untested at non-default DPI.
- A whole-namespace test run reported 1007 passed and then hung in the shell-harness
  integration tests. That matches the known pre-existing solution-level wedge and nothing
  in this diff plausibly causes a hang (no new off-UI-thread writes, no new synchronous
  measure in a hot path), but it was not bisected to prove it.
- `MatchHighlightTextBlock` could in principle split a base character from a trailing
  combining mark into two runs if a match boundary lands mid-grapheme. Avalonia shapes
  runs as one continuous line so this is likely benign; not verified against a real render.
  Surrogate pairs are ruled out - a match length always equals the needle's UTF-16 length.
