### PR TITLE
feat(command-assist): fzf replace-on-accept in Ctrl+R history search

### DIFF
--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -2426,6 +2426,15 @@ namespace NovaTerminal.Controls
         /// the original window open. It cannot go the other way: output that has been parsed is
         /// output that is in the grid.
         /// </para>
+        /// <para>
+        /// <strong>That window is wider than it was, and is a known follow-up.</strong> Under the
+        /// additive rule a read taken inside it produced <c>git staatus</c> - a wrong append. Under
+        /// <see cref="CommandAssistInsertionStyle.ReplaceTypedPrefix"/> it produces a wrong
+        /// <em>count</em>, so the deletes stop one character short and the command lands against the
+        /// survivor. Same pre-existing hole, larger blast radius; closing it needs a signal that
+        /// distinguishes "the bytes I sent came back" from "some output arrived", which the parser
+        /// does not offer today.
+        /// </para>
         /// </remarks>
         internal void NoteInputAwaitingEcho() => _hasUnechoedInput = true;
 
@@ -2499,8 +2508,20 @@ namespace NovaTerminal.Controls
                 return false;
             }
 
-            if (!CommandAssistInsertionPlanner.TryCreateInsertion(existingQuery, insertionText, out string? textToSend) ||
-                string.IsNullOrEmpty(textToSend))
+            // The style is session state, so the controller answers it rather than the pane guessing
+            // from what happens to be on screen: accepting a row out of explicit Ctrl+R history search
+            // replaces the typed filter, and every other surface stays strictly additive. See
+            // CommandAssistController.AcceptReplacesTypedQuery.
+            CommandAssistInsertionStyle style = _commandAssistController.AcceptReplacesTypedQuery
+                ? CommandAssistInsertionStyle.ReplaceTypedPrefix
+                : CommandAssistInsertionStyle.Append;
+
+            // The emptiness guard is on the *plan*, not on a string. A plan of pure deletes with no
+            // text would read as non-empty to string.IsNullOrEmpty and would erase the user's line for
+            // nothing; a plan with neither is the no-op the planner promises never to return, and this
+            // is where that promise is checked rather than trusted.
+            if (!CommandAssistInsertionPlanner.TryCreatePlan(existingQuery, insertionText, style, out CommandAssistInsertionPlan plan) ||
+                (plan.BackspaceCount == 0 && plan.TextToSend.Length == 0))
             {
                 return false;
             }
@@ -2517,7 +2538,25 @@ namespace NovaTerminal.Controls
             // is still holding a line it can no longer describe, and Ctrl+Enter is the one key the
             // interceptor deliberately does not poison on (Command Assist owns it).
             _marklessSubmission.Poison();
-            Session.SendInput(textToSend);
+
+            // One SendInput, and that is a requirement rather than tidiness. Each call UTF-8 encodes
+            // and enqueues one byte[] onto the session's single-consumer writer thread, and
+            // Parser.OnResponse writes to that same session from the *parse* thread (device-report
+            // replies, which ConPTY and Clink both provoke). Two calls would leave a window in which a
+            // reply could be interleaved between the deletes and the text - i.e. between erasing the
+            // user's line and putting the command back on it.
+            //
+            // \x7f (DEL) is this codebase's backspace byte on the wire; see TerminalView's key
+            // handling. No bracketed paste for either half: bracketed content is literal by
+            // definition, so a DEL inside it would be inserted as a character rather than executed as
+            // an erase.
+            Session.SendInput(new string('\x7f', plan.BackspaceCount) + plan.TextToSend);
+
+            // The grid is now behind the shell by everything we just sent, and the next accept must
+            // not be planned against it. Omitting this was a latent bug even under the additive rule
+            // (two fast Ctrl+Enters would compute the second delta against a pre-insertion line); under
+            // replace it is the difference between a stale count and an erased command line.
+            NoteInputAwaitingEcho();
             return true;
         }
 
@@ -2568,6 +2607,18 @@ namespace NovaTerminal.Controls
         /// every condition, so an accepted row is typed into that program instead. That is what typing
         /// the command by hand would also have done, and it is visible either way; the alternative -
         /// refusing forever in every un-instrumented session - is the bug being fixed.
+        /// </para>
+        /// <para>
+        /// <strong>Unchanged by the replace style, and deliberately so.</strong> The synthetic snapshot
+        /// below has <c>Text == ""</c>, so its typed prefix is empty and a replace plans zero deletes:
+        /// the degraded path is bit-identical under both styles, and no new gate is needed here. The
+        /// reason it needs none is worth stating, because the obvious instinct is to add one. Replace
+        /// needs a <em>count</em>, which is strictly more than append needed; in a markless session the
+        /// pane can prove <em>whether</em> the line is empty but never <em>how many</em> characters a
+        /// non-empty line holds - and the only markless case where the count is knowable is the case
+        /// where it is zero, which is exactly the case where the two styles already agree. So there is
+        /// nothing for an extra gate to catch. <c>CommandAssistGridTruthTests</c> and
+        /// <c>PaneAssistInsertionTests</c> both pin the degraded refusal under the replace style.
         /// </para>
         /// </remarks>
         private AssistQuerySnapshot? TryReadInsertionQuerySnapshot()

--- a/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
@@ -149,7 +149,14 @@ public sealed class CommandAssistController
             // advertise unconditionally and the passive bubble no longer owns.
             AcceptOnEnterProbe = () => IsAcceptOnEnterArmed,
             SelectionUpOwnedProbe = () => IsSelectionUpOwned,
-            InsertionAvailableProbe = () => _isInsertionAvailable
+
+            // Two terms, because there are two ways an accept can refuse and the strip must not
+            // promise a key for either. The first is the line: the last ranking pass recorded whether
+            // the command line was one an insertion can be measured against. The second is the row,
+            // and it is per-selection rather than per-pass, which is why it is evaluated here rather
+            // than folded into _isInsertionAvailable - SyncPresentationState runs on every
+            // SelectedIndex write, so browsing re-asks the question.
+            InsertionAvailableProbe = () => _isInsertionAvailable && SelectedRowCanBeInserted()
         };
         _dispatch = dispatch ?? (action => action());
         _capturePipeline = new CapturePipeline(historyStore, secretsFilter, _context);
@@ -242,6 +249,89 @@ public sealed class CommandAssistController
         ViewModel.IsVisible &&
         _renderedSurfaceProbe() &&
         _state.AllowsAcceptOnEnter(ViewModel.IsPopupOpen, GetSelectedSuggestion() != null);
+
+    /// <summary>
+    /// Whether accepting a row means "replace what the user typed with it" rather than "extend what
+    /// the user typed into it".
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// True in Search mode - explicit <c>Ctrl+R</c> history search - and nowhere else. There the
+    /// characters on the command line are a <em>filter over the list</em>, so the row the user picked
+    /// is the command they want, whether or not it happens to start with what they typed; every
+    /// reverse-search and fuzzy finder resolves the accept the same way. In Suggest mode the same
+    /// characters are the start of a command the user is composing, so an accept may only extend
+    /// them, and in Help and Fix there is nothing to replace. See
+    /// <c>CommandAssistInsertionPlanner</c> for what each answer costs and which refusals survive
+    /// both.
+    /// </para>
+    /// <para>
+    /// Exposed as the decision rather than as a <c>Mode</c> property, matching the rest of this file
+    /// (<see cref="IsAcceptOnEnterArmed"/>, <see cref="IsSelectionUpOwned"/>,
+    /// <see cref="IsUserRequestedSurface"/>): the App gets the answer to a question it has, not the
+    /// state to derive it from. <see cref="SessionState"/> stays <c>internal</c> - the App is
+    /// deliberately not on this assembly's <c>InternalsVisibleTo</c> list - so a public member here is
+    /// the only way the pane can know, and making it this one keeps the rule in a single place.
+    /// </para>
+    /// <para>
+    /// No visibility or rendered-surface term, unlike <see cref="IsAcceptOnEnterArmed"/>. This does
+    /// not decide <em>whether</em> an accept happens - the routing predicates and the planner's own
+    /// refusals do that - only what an accept that has already been authorised means.
+    /// </para>
+    /// </remarks>
+    public bool AcceptReplacesTypedQuery => _state.Mode == CommandAssistMode.Search;
+
+    /// <summary>
+    /// Whether the highlighted row is one an insertion can send at all: rows carrying a line break are
+    /// not.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>CommandAssistInsertionPlanner</c> refuses a row containing <c>\n</c> or <c>\r</c> for both
+    /// styles, because <c>SendInput</c> writes raw bytes with no bracketed paste on this path - the
+    /// newline would <em>submit</em> the line rather than land in it, and under replace it would submit
+    /// against a line just erased. A multi-line snippet is the row that reaches that refusal in
+    /// practice (see <c>SnippetEditor.ResolveName</c>, which exists for pasted multi-line commands).
+    /// </para>
+    /// <para>
+    /// The refusal is right; a refusal the hint strip has already promised is not. Without this term
+    /// the strip advertises "insert" on a multi-line snippet, and the insert chord - which consumes the
+    /// key whether or not anything was sent - becomes a dead key with no feedback. The strip's own
+    /// rule is that under-promising is fine and promising a key that does nothing is worse than
+    /// showing no strip at all.
+    /// </para>
+    /// <para>
+    /// This reaches the conditional half of the strip only - the bubble, where the insert chord is the
+    /// advertised action. <c>CommandAssistBarViewModel.BuildHintText</c> keeps the clause
+    /// unconditionally once <c>Enter</c> is armed, by an existing and deliberate decision (arming
+    /// already requires an open popup with a selected row, and dropping the clause there would make the
+    /// strip flicker between two shapes while browsing). So a multi-line row browsed in an open popup
+    /// still shows "insert" and still refuses; that is the pre-existing shape of every refusal on the
+    /// armed path, not something this term regressed.
+    /// </para>
+    /// <para>
+    /// Deliberately narrower than filtering multi-line rows out of the ranked list. The list is also a
+    /// browse surface - in <c>Ctrl+R</c> it is the user's own history, which they asked to see - and
+    /// making entries vanish with no explanation trades a legible disabled hint for an illegible
+    /// absence. Pin, unpin, Explain and the detail panel all keep working on the row.
+    /// </para>
+    /// <para>
+    /// No selection reads as insertable, matching the probe's own null-means-available convention:
+    /// with nothing highlighted there is no row to disqualify, and
+    /// <see cref="IsAcceptOnEnterArmed"/> already governs that case.
+    /// </para>
+    /// </remarks>
+    private bool SelectedRowCanBeInserted()
+    {
+        AssistSuggestion? selected = GetSelectedSuggestion();
+        if (selected == null)
+        {
+            return true;
+        }
+
+        string insertText = selected.InsertText ?? string.Empty;
+        return insertText.IndexOf('\n') < 0 && insertText.IndexOf('\r') < 0;
+    }
 
     /// <summary>
     /// Whether <c>Up</c> currently belongs to Command Assist rather than to the shell's history recall.

--- a/src/NovaTerminal.CommandAssist/Application/CommandAssistInsertionPlan.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CommandAssistInsertionPlan.cs
@@ -1,0 +1,74 @@
+namespace NovaTerminal.CommandAssist.Application;
+
+/// <summary>
+/// How an accepted row is turned into bytes: extend what the user typed, or throw it away and
+/// send the row whole.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The style is a property of the <em>surface the accept came from</em>, not of the row and not
+/// of the line. <see cref="Append"/> is the rule everywhere Command Assist offers a completion -
+/// the passive typing bubble, the explicit Suggest session, the direct insert chord - and it is
+/// the rule that lets the feature never destroy anything the user typed.
+/// <see cref="ReplaceTypedPrefix"/> exists for exactly one surface: explicit history search, where
+/// the typed characters are a <em>filter over the list</em> rather than the start of the command,
+/// and every reverse-search and fuzzy finder in existence resolves the accept the same way.
+/// </para>
+/// <para>
+/// Deciding it at the call site rather than inside the planner is deliberate. The planner is a pure
+/// function over a snapshot and a row; "which surface is the user in" is session state it has no
+/// access to and should not grow a dependency on. See
+/// <c>CommandAssistController.AcceptReplacesTypedQuery</c> for the one place that answers it.
+/// </para>
+/// </remarks>
+public enum CommandAssistInsertionStyle
+{
+    /// <summary>
+    /// Send only the characters the row adds to what is already on the line, and refuse whenever
+    /// the row is not an extension of it. Command Assist deletes nothing.
+    /// </summary>
+    Append,
+
+    /// <summary>
+    /// Erase the typed prefix and send the row whole. Accepting any row means running that row -
+    /// fzf semantics - so a row that shares no prefix with the query is accepted rather than
+    /// refused.
+    /// </summary>
+    ReplaceTypedPrefix
+}
+
+/// <summary>
+/// What the terminal must be sent to turn the current command line into the accepted row: some
+/// number of backward deletes, then some text.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Invariant: a plan returned with <see langword="true"/> is never <c>(0, "")</c>.</strong>
+/// A successful plan always changes the line. The planner enforces it by refusing the two shapes
+/// that could produce a no-op - an empty row and a line that already equals the row - and the pane
+/// re-checks it before sending, because "we planned successfully and sent nothing" is
+/// indistinguishable to the user from the feature being broken, and that indistinguishability is
+/// what PR #294 was about.
+/// </para>
+/// <para>
+/// <strong><see cref="BackspaceCount"/> is a count of UTF-16 code units, not of graphemes and not
+/// of grid cells.</strong> The full argument lives on
+/// <see cref="CommandAssistInsertionPlanner.TryCreatePlan"/>, because that is where the count is
+/// produced and where someone will be tempted to "fix" it.
+/// </para>
+/// <para>
+/// The two halves are kept apart rather than pre-concatenated into one string so the count stays
+/// assertable. A planner that returned <c>"\x7f\x7f\x7fecho hi"</c> would make every test about the
+/// count a test about string prefixes, and would defeat the pane's own emptiness guard - the
+/// rejected alternative recorded on the planner.
+/// </para>
+/// </remarks>
+/// <param name="BackspaceCount">
+/// How many <c>DEL</c> (<c>0x7f</c>) bytes to send before <paramref name="TextToSend"/>. Zero for
+/// every <see cref="CommandAssistInsertionStyle.Append"/> plan, and zero for a replace on a line the
+/// grid reported as empty.
+/// </param>
+/// <param name="TextToSend">
+/// The characters to send after the deletes. Never <see langword="null"/> on a successful plan.
+/// </param>
+public readonly record struct CommandAssistInsertionPlan(int BackspaceCount, string TextToSend);

--- a/src/NovaTerminal.CommandAssist/Application/CommandAssistInsertionPlanner.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CommandAssistInsertionPlanner.cs
@@ -1,9 +1,11 @@
+using System;
+using System.Diagnostics;
+
 namespace NovaTerminal.CommandAssist.Application;
 
 /// <summary>
-/// Works out the delta the terminal must be sent to turn what is already on the command line into
-/// the selected suggestion - or refuses, when the line is not one a suffix can safely be appended
-/// to.
+/// Works out what the terminal must be sent to turn what is already on the command line into the
+/// selected suggestion - or refuses, when the line is not one it can prove the shape of.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -12,42 +14,175 @@ namespace NovaTerminal.CommandAssist.Application;
 /// values, so exposing it lets this assembly avoid granting the App <c>InternalsVisibleTo</c>.
 /// </para>
 /// <para>
-/// <strong>Insertion stays additive (Phase 1c).</strong> The rule has always been "send only the
-/// characters the suggestion adds" - Command Assist never deletes what the user typed, never moves
-/// the cursor, never rewrites the line. What changed is what the rule is computed against: V1 used
-/// the keystroke mirror, so every edit it could not see produced a delta against a line that did not
-/// exist. Now the input is an <see cref="AssistQuerySnapshot"/> read out of the grid, and the cases
-/// the mirror got wrong are the cases this refuses.
+/// <strong>Additive everywhere except explicit history search.</strong> The rule for most of this
+/// feature's life was "send only the characters the suggestion adds" - Command Assist never deletes
+/// what the user typed, never moves the cursor, never rewrites the line - and that is still the rule
+/// for the passive typing bubble, for an explicit Suggest session, and for the direct insert chord.
+/// <see cref="CommandAssistInsertionStyle.ReplaceTypedPrefix"/> carves out one surface:
+/// <c>Ctrl+R</c> history search, where the characters on the line are a filter over a list rather
+/// than the start of a command, and accepting a row means running <em>that row</em>. Everywhere else
+/// the style is <see cref="CommandAssistInsertionStyle.Append"/> and the arithmetic is bit-identical
+/// to what it always was.
 /// </para>
 /// <para>
-/// <strong>Refusal is a feature.</strong> A refused insertion costs the user one keystroke of
-/// convenience. A wrong one edits their command line - the thing they are about to run. Every
-/// condition below resolves that asymmetry the same way.
+/// <strong>Why the carve-out was necessary rather than nice.</strong> <c>JsonlHistoryStore</c>
+/// filters by <em>subsequence</em>, so a non-prefix row is the ordinary case in a filtered history
+/// list, not an edge case: type <c>git</c>, select <c>echo git-alpha</c>, press <c>Enter</c>, and the
+/// additive rule refuses - the key falls through to the shell, and the shell runs <c>git</c>. The
+/// user asked for one command and got a different one. Additive's promise ("we never damage the
+/// line") is worth a refusal when the alternative is a wrong edit; it is not worth a refusal when the
+/// alternative is the user's own explicit selection.
+/// </para>
+/// <para>
+/// <strong>Refusal is still a feature, and the refusals that remain are the ones that protect the
+/// line.</strong> Replace relaxes exactly one condition - the row no longer has to start with the
+/// query. Everything else is untouched, because every other refusal is about whether the planner can
+/// <em>see</em> the line rather than about whether the row extends it:
+/// </para>
+/// <list type="bullet">
+/// <item>no grid truth at all (a markless session, a closed lifecycle gate) - nothing to count;</item>
+/// <item>a multiline entry - the text contains continuation-prompt cells the user never typed, so
+/// any count taken from it is wrong;</item>
+/// <item>a cursor that is neither at the end nor in front of a proven ghost - backspaces delete
+/// <em>leftwards</em>, so a replace here would erase the head of the line, leave the tail, and insert
+/// the command in front of the survivor;</item>
+/// <item>the line already being the selected command - erasing N characters to retype the identical
+/// N is pure flicker, and it is precisely the window in which "the deletes land but the insert does
+/// not" costs the user their line for no gain.</item>
+/// </list>
+/// <para>
+/// <strong>Replace is not undoable by Command Assist.</strong> There is no inverse operation here and
+/// no snapshot kept: once the deletes are on the wire the typed characters are gone as far as this
+/// feature is concerned. What the user has is their shell's own undo - <c>Ctrl+_</c> in readline,
+/// <c>Ctrl+Z</c> in PSReadLine - and nothing in this code path should be documented or described as
+/// though the edit were reversible from our side.
+/// </para>
+/// <para>
+/// <strong>Known limitation, accepted: vi command mode.</strong> With <c>set -o vi</c> (readline/zle)
+/// or <c>Set-PSReadLineOption -EditMode Vi</c>, <c>DEL</c> in command mode may move the cursor left
+/// rather than delete a character, so a replace would leave the typed characters in place and insert
+/// the command after them. This is not detectable from the grid - the mode is invisible to us - and
+/// additive insertion is already meaningless in vi command mode (the "typed prefix" is not where the
+/// next character would land), so it is recorded here as an accepted risk rather than treated as a
+/// blocker.
 /// </para>
 /// </remarks>
 public static class CommandAssistInsertionPlanner
 {
     /// <summary>
-    /// Computes the text to send so that the command line becomes <paramref name="selectedCommand"/>,
-    /// or returns <see langword="false"/> if that cannot be done by appending.
+    /// Computes the deletes-then-text the terminal must be sent so that the command line becomes
+    /// <paramref name="selectedCommand"/>, or returns <see langword="false"/> when that cannot be
+    /// done safely.
     /// </summary>
     /// <param name="query">
     /// The live command line, or <see langword="null"/> when the session is markless or the shell is
-    /// not in its line editor. <see langword="null"/> always refuses: without grid truth there is no
-    /// way to know what is already on the line, and appending a whole command to an unknown prefix
-    /// produces <c>git sgit status</c>. Insertion is a prefix-dependent feature, and degraded mode
-    /// does not offer those.
+    /// not in its line editor. <see langword="null"/> always refuses, for both styles. Without grid
+    /// truth there is no way to know what is already on the line: appending a whole command to an
+    /// unknown prefix produces <c>git sgit status</c>, and replacing needs a <em>count</em>, which is
+    /// strictly more information than appending needed. Degraded mode does not offer either.
     /// </param>
     /// <param name="selectedCommand">The suggestion the user accepted.</param>
-    /// <param name="textToSend">The suffix to send; <see langword="null"/> on refusal.</param>
-    public static bool TryCreateInsertion(
+    /// <param name="style">
+    /// Whether this accept extends the line or replaces the typed query. Chosen by the caller from
+    /// session state - see <c>CommandAssistController.AcceptReplacesTypedQuery</c>.
+    /// </param>
+    /// <param name="plan">The deletes and text to send; <c>default</c> on refusal.</param>
+    /// <remarks>
+    /// <para>
+    /// <strong>The counting unit, which is the subtle part.</strong>
+    /// <see cref="CommandAssistInsertionPlan.BackspaceCount"/> is
+    /// <see cref="AssistQuerySnapshot.TypedPrefix"/><c>.Length</c>: UTF-16 code units, taken from the
+    /// typed prefix and never from <see cref="AssistQuerySnapshot.Text"/>. <c>Text</c> includes the
+    /// shell's inline prediction - typically ten to forty characters the user never typed - so
+    /// counting from it would erase most of a line the user had barely started.
+    /// </para>
+    /// <para>
+    /// Code units rather than graphemes, and this is the thing a later reader will want to "fix".
+    /// <c>GridQueryReader</c> appends one <em>grapheme</em> per non-wide-continuation cell, so
+    /// <c>Text.Length</c> is a code-unit count with no grapheme or cell count carried across the
+    /// seam. On the other side, readline, zle and fish each delete one codepoint per backward-delete
+    /// and PSReadLine deletes one .NET <c>char</c> (modern versions coalescing surrogate pairs) - all
+    /// of which are <em>at most</em> the number of UTF-16 code units. So the count does not have to be
+    /// exact: under replace we always delete to the start of the input buffer, backward-delete at
+    /// position 0 is a no-op in all four editors, and an overshoot is therefore absorbed by the
+    /// start-of-line floor at the cost of a bell. What we need is an upper bound, and code units are
+    /// one. (Measured rather than assumed: <c>PtyBackspaceAtLineStartTests</c> types three characters
+    /// through the real PTY, waits for the grid to show them, sends <em>five</em> <c>DEL</c> bytes, and
+    /// requires the grid to come back to exactly the prompt it started from - so it establishes that
+    /// <c>0x7f</c> deletes one character per byte <em>and</em> that the two surplus deletes are
+    /// absorbed, and it cannot pass on a session that silently died.)
+    /// </para>
+    /// <para>
+    /// Grapheme counting would be actively wrong, because it errs the other way: <c>e</c> +
+    /// <c>U+0301</c> is one grapheme but two backward-deletes in readline, so a grapheme count
+    /// <em>under</em>-counts combining sequences and leaves debris on the line - which the inserted
+    /// command is then appended to, producing exactly the corruption this whole file exists to
+    /// prevent. Undershoot is unrecoverable; overshoot is a bell.
+    /// <c>CommandAssistInsertionPlannerTests</c> pins three cases (a combining sequence, two CJK
+    /// characters, one non-BMP emoji) so a refactor towards graphemes has to argue with a test rather
+    /// than with a comment.
+    /// </para>
+    /// <para>
+    /// The empty-line case used to be an early return of its own ("an empty line is a fact, send the
+    /// whole command"). It is gone, because the shared arithmetic already produces exactly that
+    /// answer: with a zero-length typed prefix, append sends <c>selectedCommand[0..]</c> with no
+    /// deletes and replace sends <c>selectedCommand</c> with zero deletes. Numerically identical, and
+    /// a second branch would only be somewhere for a stray backspace to appear.
+    /// </para>
+    /// <para>
+    /// <strong>Rejected alternatives, so they are not re-proposed.</strong> (1) Prepending the
+    /// <c>\x7f</c> bytes into the returned string: makes the count untestable, and defeats the pane's
+    /// <c>IsNullOrEmpty</c> guard because a string of pure deletes reads as non-empty. (2) A separate
+    /// <c>TryCreateReplacement</c>: duplicates ninety percent of the refusal discipline above, which
+    /// is the part that must not drift between the two styles. (3) A pane-side erase step before the
+    /// accept: reintroduces the accept-before-plan ordering bug PR #294 fixed, where a refusal after
+    /// the accept tore the surface down and sent nothing.
+    /// </para>
+    /// <para>
+    /// <strong>(4) Refusing a replace on a soft-wrapped query. Tried, measured, reverted.</strong> The
+    /// motivation is real: <c>GridQueryReader.SoftWrappedRowEnd</c> documents a case where a typed
+    /// space in the last column before a wide character is dropped, which under-counts by one -
+    /// harmless to an append (an under-count could only ever produce a refusal) and corrupting to a
+    /// replace (it leaves a character behind for the inserted command to be appended to). The available
+    /// signal is not good enough, though. Carrying <c>GridCommandLine.EndRow &gt; StartRow</c> across
+    /// the App boundary and refusing on it makes <em>every PSReadLine-rendered prompt</em> refuse,
+    /// empty ones included: PSReadLine erases to the right edge and one cell past it, which is a real
+    /// autowrap, so the span runs onto a blank continuation row and the bit gets set on a single-row
+    /// command line. Measured - <c>PaneAssistInsertionTests.OnAPromptPsReadLineHasRendered_*</c> and
+    /// <c>OnAnEmptyPromptPsReadLineHasRendered_EnterSendsTheWholeCommand</c> all fail. That is the same
+    /// shape of bug as the <c>RightPromptTrimmed</c> refusal PR #301 removed: a guard that fires on
+    /// every prompt a common shell paints, so the feature is simply inert.
+    /// </para>
+    /// <para>
+    /// <strong>What was rejected is the broad signal, not the idea.</strong> The hazard is real and
+    /// still open: a query long enough to wrap, whose last column before the seam holds a typed space
+    /// followed by a wide character, reads back one character short, and a replace then leaves the
+    /// leftmost character on the line - <c>gecho git-alpha</c>. The signal a fix wants is narrower than
+    /// the one tried here: a bool raised only when <c>GridQueryReader.SoftWrappedRowEnd</c> actually
+    /// returned <c>cols - 1</c> for a row at or before the <em>cursor</em> row. That fires on the
+    /// defect and on nothing else, where <c>EndRow &gt; StartRow</c> fires on every PSReadLine repaint.
+    /// It needs a reader change, so it is a follow-up rather than part of this change; until then the
+    /// hazard is accepted and stated rather than papered over with a guard that disables the feature.
+    /// </para>
+    /// </remarks>
+    public static bool TryCreatePlan(
         AssistQuerySnapshot? query,
         string? selectedCommand,
-        out string? textToSend)
+        CommandAssistInsertionStyle style,
+        out CommandAssistInsertionPlan plan)
     {
-        textToSend = null;
+        plan = default;
 
         if (string.IsNullOrEmpty(selectedCommand))
+        {
+            return false;
+        }
+
+        // A row carrying a line break would be *submitted* rather than inserted - SendInput writes
+        // raw bytes with no bracketed-paste wrapping on this path - and under replace it would be
+        // submitted against a line we have just erased. Cheap, and it fails closed for both styles
+        // rather than leaving one of them holding a sharper edge than the other.
+        if (selectedCommand.IndexOf('\n') >= 0 || selectedCommand.IndexOf('\r') >= 0)
         {
             return false;
         }
@@ -57,40 +192,89 @@ public static class CommandAssistInsertionPlanner
             return false;
         }
 
-        // The three ways a snapshot fails to be a typed prefix - cursor mid-line, multiline entry,
-        // trimmed right prompt - are spelled out on AssistQuerySnapshot.IsUsableAsTypedPrefix. Each
-        // one breaks the append in its own way: the cursor decides where sent text lands, a
-        // continuation prompt is text in the snapshot the user never typed, and a trimmed right
-        // prompt means the tail of the line is the reader's inference rather than an observation.
+        // The two ways a snapshot fails to be a typed prefix - cursor mid-line, multiline entry - are
+        // spelled out on AssistQuerySnapshot.IsUsableAsTypedPrefix. Each breaks both styles, in its
+        // own way: the cursor decides where sent text lands *and* which characters the deletes eat,
+        // and a continuation prompt is text in the snapshot the user never typed, so no count taken
+        // from it is right.
         if (!line.IsUsableAsTypedPrefix)
         {
             return false;
         }
 
         // TypedPrefix, not Text: on a line whose tail the reader classified as an inline prediction the
-        // two differ, and measuring the delta against Text would compute it against the shell's guess -
-        // sending nothing when the prediction happens to match the suggestion, and refusing whenever it
-        // does not. The ghost is display-only; the typed characters are the line.
-        string text = line.TypedPrefix;
-        if (text.Length == 0)
-        {
-            // An empty line is a fact here, not an absence of one: the grid was read and the line
-            // is empty. Sending the whole command is exactly right.
-            textToSend = selectedCommand;
-            return true;
-        }
+        // two differ, and measuring against Text would compute the delta against the shell's guess -
+        // and, under replace, would count the shell's guess into the number of characters to erase.
+        // The ghost is display-only; the typed characters are the line.
+        string typed = line.TypedPrefix;
+        bool replaces = style == CommandAssistInsertionStyle.ReplaceTypedPrefix;
 
-        if (!selectedCommand.StartsWith(text, System.StringComparison.Ordinal))
+        // The one condition replace relaxes. Append must refuse a row that does not extend the line,
+        // because the only edit it is allowed to make is at the end; replace is not making that edit.
+        if (!replaces && !selectedCommand.StartsWith(typed, StringComparison.Ordinal))
         {
             return false;
         }
 
-        if (selectedCommand.Length == text.Length)
+        // Both styles refuse when the line already *is* the command. For append that is the old
+        // "same length as a proven prefix, so the suffix is empty" test, restated as what it always
+        // meant. For replace it is a real decision rather than a fallout: erasing N characters to
+        // retype the identical N is flicker with a failure mode attached, and refusing keeps the
+        // invariant that a successful plan is never a no-op.
+        if (string.Equals(selectedCommand, typed, StringComparison.Ordinal))
         {
             return false;
         }
 
-        textToSend = selectedCommand[text.Length..];
+        // One arithmetic for both styles. Uniform in the replace case *including* when the row does
+        // happen to start with the query: no "optimise back to append when it is a prefix" branch.
+        // Three reasons. One behaviour per surface, so the user does not have to know which. The
+        // bytes on the wire must not vary with which row happens to be highlighted. And the
+        // optimisation would make the delete path dead code on the *common* Ctrl+R accept - type
+        // `git`, take `git status` - leaving it live only on the rarer rows; a path skipped in the
+        // common case is a path that rots.
+        int backspaceCount = replaces ? typed.Length : 0;
+        string textToSend = replaces ? selectedCommand : selectedCommand[typed.Length..];
+
+        plan = new CommandAssistInsertionPlan(backspaceCount, textToSend);
+        return true;
+    }
+
+    /// <summary>
+    /// The additive-only entry point: computes the suffix to append, or returns
+    /// <see langword="false"/> if the line cannot be extended into
+    /// <paramref name="selectedCommand"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>A public, test-only shim.</strong> There are no production callers left: the pane calls
+    /// <see cref="TryCreatePlan"/> directly, because it has to choose a style. This is kept anyway, and
+    /// kept public, because it is the pin - a signature that <em>cannot</em> express an erase, which
+    /// every additive test written before the replace style still goes through unchanged. That is what
+    /// makes "additive is untouched" a fact the suite checks rather than a claim a reviewer has to
+    /// verify by reading the diff. Deleting it under the dead-code rule would delete the evidence, not
+    /// the dead code.
+    /// </para>
+    /// </remarks>
+    /// <param name="query">See <see cref="TryCreatePlan"/>.</param>
+    /// <param name="selectedCommand">The suggestion the user accepted.</param>
+    /// <param name="textToSend">The suffix to send; <see langword="null"/> on refusal.</param>
+    public static bool TryCreateInsertion(
+        AssistQuerySnapshot? query,
+        string? selectedCommand,
+        out string? textToSend)
+    {
+        if (!TryCreatePlan(query, selectedCommand, CommandAssistInsertionStyle.Append, out CommandAssistInsertionPlan plan))
+        {
+            textToSend = null;
+            return false;
+        }
+
+        Debug.Assert(
+            plan.BackspaceCount == 0,
+            "An Append plan must never erase; the whole point of this overload is that it cannot.");
+
+        textToSend = plan.TextToSend;
         return true;
     }
 }

--- a/tests/NovaTerminal.App.Tests/CommandAssist/AssistSessionStateMachineTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/AssistSessionStateMachineTests.cs
@@ -51,6 +51,36 @@ public sealed class AssistSessionStateMachineTests
         Assert.Equal(expected, CreateInState(state).Mode);
     }
 
+    /// <summary>
+    /// The state axis of <c>CommandAssistController.AcceptReplacesTypedQuery</c>: accepting a row
+    /// replaces what the user typed in explicit history search and nowhere else.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The controller's property is <c>Mode == Search</c>, so this is that predicate evaluated over the
+    /// whole state space - which is worth stating separately from
+    /// <see cref="Mode_IsDerivedFromState"/> even though it follows from it. What a future reader will
+    /// be tempted to change is the <em>scope of replace</em> ("surely an explicit Suggest session should
+    /// replace too"), and this is the row they have to edit to do it. The controller-side wiring is
+    /// pinned by <c>CommandAssistGridTruthTests.AcceptReplacesTypedQuery_IsTrueOnlyForExplicitHistorySearch</c>,
+    /// and the behavioural consequence by <c>PaneAssistInsertionTests.InSuggestMode_EnterOnANonPrefixRowStillRefuses</c>.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData(AssistSessionState.Hidden, false)]
+    [InlineData(AssistSessionState.PassiveBubble, false)]
+    [InlineData(AssistSessionState.PassivePopup, false)]
+    [InlineData(AssistSessionState.ExplicitBubble, false)]
+    [InlineData(AssistSessionState.ExplicitPopup, false)]
+    [InlineData(AssistSessionState.HistorySearch, true)]
+    [InlineData(AssistSessionState.Help, false)]
+    [InlineData(AssistSessionState.FixHint, false)]
+    [InlineData(AssistSessionState.FixPopup, false)]
+    public void AcceptReplacesTypedQuery_IsTrueOnlyInHistorySearch(AssistSessionState state, bool expected)
+    {
+        Assert.Equal(expected, CreateInState(state).Mode == CommandAssistMode.Search);
+    }
+
     [Theory]
     [InlineData(AssistSessionState.Hidden, false)]
     [InlineData(AssistSessionState.PassiveBubble, false)]

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistGridTruthTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistGridTruthTests.cs
@@ -354,10 +354,123 @@ public sealed class CommandAssistGridTruthTests
     }
 
     /// <summary>
+    /// <strong>The scope of replace-on-accept, as the controller reports it.</strong> Only an explicit
+    /// history search means "the typed characters are a filter, so take the row whole"; every Suggest
+    /// surface goes on meaning "extend what I have typed".
+    /// </summary>
+    /// <remarks>
+    /// The state-space half of this - that <see cref="AssistSessionState.HistorySearch"/> is the only
+    /// state mapping to <c>Search</c>, for all nine states - is pinned by
+    /// <c>AssistSessionStateMachineTests.AcceptReplacesTypedQuery_IsTrueOnlyInHistorySearch</c>. This is
+    /// the wiring: that the controller's public answer follows the real transitions the App drives.
+    /// </remarks>
+    [Fact]
+    public async Task AcceptReplacesTypedQuery_IsTrueOnlyForExplicitHistorySearch()
+    {
+        var harness = Harness.Create(seed: new[] { "git status" });
+        await harness.PromptReadyAsync();
+        harness.Grid.SetLine("git");
+
+        Assert.False(harness.Controller.AcceptReplacesTypedQuery);
+
+        harness.Controller.ToggleAssist();
+        await harness.WaitForConditionAsync(() => harness.Controller.Suggestions.Count > 0);
+        Assert.False(harness.Controller.AcceptReplacesTypedQuery);
+
+        harness.Controller.OpenHistorySearch();
+        await harness.WaitForConditionAsync(() => harness.Controller.Suggestions.Count > 0);
+        Assert.True(harness.Controller.AcceptReplacesTypedQuery);
+
+        // An accept closes the session, and a closed session is a Suggest one again - so a stale
+        // "replace" cannot outlive the surface that justified it.
+        Assert.True(harness.Controller.TryAcceptSelection(out _));
+        Assert.False(harness.Controller.AcceptReplacesTypedQuery);
+    }
+
+    /// <summary>
+    /// And it survives typing, which is the whole point of PR #304: a filter keystroke narrows the list
+    /// without leaving <see cref="AssistSessionState.HistorySearch"/>, so the accept that follows still
+    /// takes the row whole rather than reverting to an append halfway through a search.
+    /// </summary>
+    [Fact]
+    public async Task AcceptReplacesTypedQuery_SurvivesTypingInsideHistorySearch()
+    {
+        var harness = Harness.Create(seed: new[] { "echo git-alpha" });
+        await harness.PromptReadyAsync();
+
+        harness.Controller.OpenHistorySearch();
+        await harness.WaitForConditionAsync(() => harness.Controller.Suggestions.Count > 0);
+        Assert.True(harness.Controller.AcceptReplacesTypedQuery);
+
+        harness.Grid.SetLine("git");
+        harness.Controller.NotifyInputActivity();
+        await harness.WaitForQueryAsync("git");
+
+        Assert.Equal(AssistSessionState.HistorySearch, harness.Controller.SessionState);
+        Assert.True(harness.Controller.AcceptReplacesTypedQuery);
+    }
+
+    /// <summary>
+    /// <strong>The hint strip stops advertising insert on a row the planner is going to refuse.</strong>
+    /// A row carrying a line break cannot be sent - the newline would submit rather than insert - so
+    /// the bubble drops the clause instead of promising a chord that consumes the key and does nothing.
+    /// </summary>
+    /// <remarks>
+    /// The row itself stays in the list and stays browsable; only the promise goes. See
+    /// <c>CommandAssistController.SelectedRowCanBeInserted</c> for why that is the trade, and why the
+    /// clause survives on the armed (<c>Enter</c>) path regardless.
+    /// </remarks>
+    [Fact]
+    public async Task AMultiLineRowIsNotAdvertisedAsInsertable()
+    {
+        var harness = Harness.Create(seed: new[] { "echo one\necho two" });
+        await harness.PromptReadyAsync();
+        harness.Grid.SetLine("echo");
+
+        harness.Controller.ToggleAssist();
+        await harness.WaitForConditionAsync(() => harness.Controller.Suggestions.Count > 0);
+
+        // The bubble, not the popup: the popup's strip is the armed path, where the clause is
+        // unconditional by an older decision.
+        Assert.False(harness.Controller.ViewModel.IsPopupOpen);
+        Assert.Contains('\n', harness.Controller.Suggestions[0].InsertText);
+        Assert.DoesNotContain(" insert", harness.Controller.ViewModel.Bubble.ShortcutHintText, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The control for the test above: the same surface with an ordinary single-line row still
+    /// advertises the chord. Without this, "no insert clause" would be satisfied by a strip that never
+    /// shows one.
+    /// </summary>
+    [Fact]
+    public async Task ASingleLineRowIsStillAdvertisedAsInsertable()
+    {
+        var harness = Harness.Create(seed: new[] { "echo one" });
+        await harness.PromptReadyAsync();
+        harness.Grid.SetLine("echo");
+
+        harness.Controller.ToggleAssist();
+        await harness.WaitForConditionAsync(() => harness.Controller.Suggestions.Count > 0);
+
+        Assert.False(harness.Controller.ViewModel.IsPopupOpen);
+        Assert.Contains(" insert", harness.Controller.ViewModel.Bubble.ShortcutHintText, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// The other half of the degraded-Search decision: you can browse the rows, but nothing may be
     /// spliced into a command line nobody can see. The planner is what refuses; this pins that the
     /// controller hands it a null snapshot rather than an empty-string stand-in.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Both styles, and the replace half is the load-bearing one.</strong> This is a
+    /// <c>Ctrl+R</c> session, so <see cref="CommandAssistController.AcceptReplacesTypedQuery"/> is true
+    /// here and an accept that got through would erase characters rather than only add them. Replace
+    /// also needs strictly more than append did - a <em>count</em> - and there is nothing to count from
+    /// a snapshot that does not exist. This test is the whole argument for why no new degraded-mode gate
+    /// was added anywhere for the replace style: the refusal it already had covers it.
+    /// </para>
+    /// </remarks>
     [Fact]
     public async Task Degraded_SelectingAHistoryRowYieldsNoInsertionPlan()
     {
@@ -368,6 +481,7 @@ public sealed class CommandAssistGridTruthTests
 
         Assert.True(harness.Controller.TryGetInsertionText(out string? selected));
         Assert.Equal("git status", selected);
+        Assert.True(harness.Controller.AcceptReplacesTypedQuery);
 
         Assert.Null(harness.Controller.TryReadQuerySnapshot());
         Assert.False(CommandAssistInsertionPlanner.TryCreateInsertion(
@@ -375,6 +489,13 @@ public sealed class CommandAssistGridTruthTests
             selected,
             out string? textToSend));
         Assert.Null(textToSend);
+
+        Assert.False(CommandAssistInsertionPlanner.TryCreatePlan(
+            harness.Controller.TryReadQuerySnapshot(),
+            selected,
+            CommandAssistInsertionStyle.ReplaceTypedPrefix,
+            out CommandAssistInsertionPlan plan));
+        Assert.Equal(default, plan);
     }
 
     /// <summary>

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistInsertionPlannerTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistInsertionPlannerTests.cs
@@ -1,15 +1,27 @@
+using System.Collections.Generic;
 using NovaTerminal.CommandAssist.Application;
 
 namespace NovaTerminal.Tests.CommandAssist;
 
 /// <summary>
-/// The planner's contract in two halves: the suffix arithmetic (unchanged since V1) and the
-/// refusals (new in Phase 1c, and the reason the arithmetic can now be trusted). Every refusal here
-/// is a line V1 would have happily computed a delta against, using a keystroke mirror that had no
-/// idea the line had moved.
+/// The planner's contract in three parts: the suffix arithmetic (unchanged since V1), the refusals
+/// (Phase 1c, and the reason the arithmetic can be trusted), and the replace style (history search
+/// only, and the reason the refusals still hold under it).
 /// </summary>
+/// <remarks>
+/// <para>
+/// Every refusal here is a line V1 would have happily computed a delta against, using a keystroke
+/// mirror that had no idea the line had moved. They are written as theories over both
+/// <see cref="CommandAssistInsertionStyle"/> values wherever the rule is shared, because the thing
+/// that must not drift is precisely that the two styles refuse the <em>same</em> unreadable lines -
+/// replace relaxes one condition and one only.
+/// </para>
+/// </remarks>
 public sealed class CommandAssistInsertionPlannerTests
 {
+    private const CommandAssistInsertionStyle Append = CommandAssistInsertionStyle.Append;
+    private const CommandAssistInsertionStyle Replace = CommandAssistInsertionStyle.ReplaceTypedPrefix;
+
     private static AssistQuerySnapshot Line(
         string text,
         int? cursorOffset = null,
@@ -17,6 +29,43 @@ public sealed class CommandAssistInsertionPlannerTests
         bool rightPromptTrimmed = false)
     {
         return new AssistQuerySnapshot(text, cursorOffset ?? text.Length, isMultiline, rightPromptTrimmed);
+    }
+
+    /// <summary>
+    /// A line the reader classified as "typed prefix, then a ghost": the whole painted line, the cursor
+    /// at the end of the typed part, and the flag set.
+    /// </summary>
+    private static AssistQuerySnapshot Ghosted(string typed, string ghost) =>
+        new(typed + ghost, typed.Length, IsMultiline: false, RightPromptTrimmed: false, TextAfterCursorIsGhost: true);
+
+    /// <summary>Asserts a refusal and that nothing was written to the out parameter.</summary>
+    private static void AssertRefuses(
+        AssistQuerySnapshot? query,
+        string? selectedCommand,
+        CommandAssistInsertionStyle style)
+    {
+        Assert.False(CommandAssistInsertionPlanner.TryCreatePlan(
+            query,
+            selectedCommand,
+            style,
+            out CommandAssistInsertionPlan plan));
+
+        Assert.Equal(default, plan);
+    }
+
+    /// <summary>Asserts a successful plan and returns it.</summary>
+    private static CommandAssistInsertionPlan AssertPlans(
+        AssistQuerySnapshot? query,
+        string? selectedCommand,
+        CommandAssistInsertionStyle style)
+    {
+        Assert.True(CommandAssistInsertionPlanner.TryCreatePlan(
+            query,
+            selectedCommand,
+            style,
+            out CommandAssistInsertionPlan plan));
+
+        return plan;
     }
 
     // ---------------------------------------- the typed prefix projection (PR #293, blocker 1)
@@ -51,18 +100,25 @@ public sealed class CommandAssistInsertionPlannerTests
     /// <summary>
     /// And it is not a substitute for <c>IsUsableAsTypedPrefix</c>: a prediction and a mid-line cursor are
     /// indistinguishable on the grid, so insertion still refuses on both. Having a good prefix to rank on
-    /// does not make an append safe.
+    /// does not make an append safe - nor a replace, whose deletes would eat the head of the line and
+    /// leave the tail sitting after the inserted command.
     /// </summary>
-    [Fact]
-    public void TextBeforeCursor_DoesNotMakeAMidLineCursorInsertable()
+    [Theory]
+    [InlineData(Append)]
+    [InlineData(Replace)]
+    public void TextBeforeCursor_DoesNotMakeAMidLineCursorInsertable(CommandAssistInsertionStyle style)
     {
         AssistQuerySnapshot line = Line("echo hello-world", cursorOffset: 2);
 
         Assert.Equal("ec", line.TextBeforeCursor);
         Assert.False(line.IsUsableAsTypedPrefix);
+        AssertRefuses(line, "echo hello", style);
+
         Assert.False(CommandAssistInsertionPlanner.TryCreateInsertion(line, "echo hello", out string? textToSend));
         Assert.Null(textToSend);
     }
+
+    // ---------------------------------------------------------------- the additive arithmetic
 
     [Fact]
     public void TryCreateInsertion_WhenLineIsPrefix_ReturnsOnlySuffix()
@@ -117,68 +173,74 @@ public sealed class CommandAssistInsertionPlannerTests
         Assert.Null(textToSend);
     }
 
-    [Fact]
-    public void TryCreateInsertion_WhenSelectedCommandIsEmpty_ReturnsFalse()
+    [Theory]
+    [InlineData(Append)]
+    [InlineData(Replace)]
+    public void TryCreateInsertion_WhenSelectedCommandIsEmpty_ReturnsFalse(CommandAssistInsertionStyle style)
     {
-        bool created = CommandAssistInsertionPlanner.TryCreateInsertion(
+        AssertRefuses(Line("git st"), string.Empty, style);
+
+        Assert.False(CommandAssistInsertionPlanner.TryCreateInsertion(
             Line("git st"),
             selectedCommand: string.Empty,
-            out string? textToSend);
-
-        Assert.False(created);
+            out string? textToSend));
         Assert.Null(textToSend);
     }
 
     /// <summary>
     /// Refusal 1 - no grid truth. A markless session cannot see the command line, so it cannot know
     /// that sending "git status" onto a line already reading "git s" produces "git sgit status".
-    /// Insertion is a prefix-dependent feature and degraded mode does not offer those.
+    /// Replace needs strictly more than that - a <em>count</em> - so it refuses here too, and this is
+    /// the whole of the degraded-mode answer: no new gate anywhere, because the one markless case where
+    /// the count is knowable is the case where it is zero.
     /// </summary>
-    [Fact]
-    public void TryCreateInsertion_WithoutGridTruth_Refuses()
+    [Theory]
+    [InlineData(Append)]
+    [InlineData(Replace)]
+    public void TryCreateInsertion_WithoutGridTruth_Refuses(CommandAssistInsertionStyle style)
     {
-        bool created = CommandAssistInsertionPlanner.TryCreateInsertion(
+        AssertRefuses(query: null, "git status", style);
+
+        Assert.False(CommandAssistInsertionPlanner.TryCreateInsertion(
             query: null,
             selectedCommand: "git status",
-            out string? textToSend);
-
-        Assert.False(created);
+            out string? textToSend));
         Assert.Null(textToSend);
     }
 
     /// <summary>
     /// Refusal 2 - the cursor is not at the end. The user pressed Home or Left; sent text lands at
-    /// the cursor, so the "suffix" would be spliced into the middle of the command.
+    /// the cursor, so the "suffix" would be spliced into the middle of the command - and a replace's
+    /// deletes run leftwards from there, erasing the head and leaving the tail behind.
     /// </summary>
     [Theory]
-    [InlineData(0)]
-    [InlineData(3)]
-    [InlineData(5)]
-    public void TryCreateInsertion_WhenTheCursorIsNotAtTheEnd_Refuses(int cursorOffset)
+    [InlineData(0, Append)]
+    [InlineData(3, Append)]
+    [InlineData(5, Append)]
+    [InlineData(0, Replace)]
+    [InlineData(3, Replace)]
+    [InlineData(5, Replace)]
+    public void TryCreateInsertion_WhenTheCursorIsNotAtTheEnd_Refuses(
+        int cursorOffset,
+        CommandAssistInsertionStyle style)
     {
-        bool created = CommandAssistInsertionPlanner.TryCreateInsertion(
-            Line("git st", cursorOffset),
-            selectedCommand: "git status",
-            out string? textToSend);
-
-        Assert.False(created);
-        Assert.Null(textToSend);
+        AssertRefuses(Line("git st", cursorOffset), "git status", style);
     }
 
     /// <summary>
     /// Refusal 3 - multiline. The snapshot contains whatever the shell painted as a continuation
-    /// prompt, so the text is not a prefix the user typed even when it happens to start one.
+    /// prompt, so the text is not a prefix the user typed even when it happens to start one - and it is
+    /// not a count of anything the user typed either, which is why replace cannot relax it.
     /// </summary>
-    [Fact]
-    public void TryCreateInsertion_WhenTheEntryIsMultiline_Refuses()
+    [Theory]
+    [InlineData(Append)]
+    [InlineData(Replace)]
+    public void TryCreateInsertion_WhenTheEntryIsMultiline_Refuses(CommandAssistInsertionStyle style)
     {
-        bool created = CommandAssistInsertionPlanner.TryCreateInsertion(
+        AssertRefuses(
             Line("for i in 1 2 3\n> do echo", isMultiline: true),
-            selectedCommand: "for i in 1 2 3\n> do echo $i; done",
-            out string? textToSend);
-
-        Assert.False(created);
-        Assert.Null(textToSend);
+            "for i in 1 2 3\n> do echo $i; done",
+            style);
     }
 
     /// <summary>
@@ -192,7 +254,8 @@ public sealed class CommandAssistInsertionPlannerTests
     /// <c>GridQueryReader.FindRightPromptGapStart</c> floors its search at the cursor column, so the
     /// trim boundary is always at or after the cursor and never removes anything the append is measured
     /// against. What survives is <see cref="AssistQuerySnapshot.IsUsableAsTypedPrefix"/>'s cursor test,
-    /// which is the real guard.
+    /// which is the real guard. The same floor is why replace never reaches into the trimmed region
+    /// either: it deletes leftwards from a cursor that is at or before the trim.
     /// </para>
     /// <para>
     /// Left in as a refusal it made Command Assist inert for anyone with a right-aligned prompt -
@@ -229,19 +292,19 @@ public sealed class CommandAssistInsertionPlannerTests
     }
 
     /// <summary>
-    /// The guard that did the work all along is untouched: a trimmed right prompt with the cursor
-    /// somewhere else on the line still refuses, because the cursor is not at the end.
+    /// The guard that did the work all along is untouched, for both styles: a trimmed right prompt with
+    /// the cursor somewhere else on the line still refuses, because the cursor is not at the end.
     /// </summary>
-    [Fact]
-    public void TryCreateInsertion_WhenARightPromptWasTrimmedAndTheCursorIsMidLine_StillRefuses()
+    [Theory]
+    [InlineData(Append)]
+    [InlineData(Replace)]
+    public void TryCreateInsertion_WhenARightPromptWasTrimmedAndTheCursorIsMidLine_StillRefuses(
+        CommandAssistInsertionStyle style)
     {
-        bool created = CommandAssistInsertionPlanner.TryCreateInsertion(
+        AssertRefuses(
             Line("git st", cursorOffset: 3, rightPromptTrimmed: true),
-            selectedCommand: "git status",
-            out string? textToSend);
-
-        Assert.False(created);
-        Assert.Null(textToSend);
+            "git status",
+            style);
     }
 
     /// <summary>
@@ -271,13 +334,6 @@ public sealed class CommandAssistInsertionPlannerTests
     }
 
     // ------------------------------------------- inline predictions (dogfood round 4, item 1)
-
-    /// <summary>
-    /// A line the reader classified as "typed prefix, then a ghost": the whole painted line, the cursor
-    /// at the end of the typed part, and the flag set.
-    /// </summary>
-    private static AssistQuerySnapshot Ghosted(string typed, string ghost) =>
-        new(typed + ghost, typed.Length, IsMultiline: false, RightPromptTrimmed: false, TextAfterCursorIsGhost: true);
 
     /// <summary>
     /// The bug the owner hit, at the layer it is fixed. With a prediction painted past the cursor the
@@ -328,8 +384,8 @@ public sealed class CommandAssistInsertionPlannerTests
     }
 
     /// <summary>
-    /// The typed part still has to be a prefix of the suggestion. The ghost widens which lines are
-    /// readable; it does not weaken what makes an append correct.
+    /// The typed part still has to be a prefix of the suggestion <em>under append</em>. The ghost widens
+    /// which lines are readable; it does not weaken what makes an append correct.
     /// </summary>
     [Fact]
     public void GhostSuffix_StillRefusesWhenTheTypedTextIsNotAPrefix()
@@ -358,19 +414,255 @@ public sealed class CommandAssistInsertionPlannerTests
             TextAfterCursorIsGhost: true);
 
         Assert.False(line.IsUsableAsTypedPrefix);
+        AssertRefuses(line, "git commit --amend", Append);
+        AssertRefuses(line, "git commit --amend", Replace);
     }
 
     /// <summary>
     /// Without the flag nothing changes: a mid-line cursor refuses exactly as it did before this round.
-    /// The flag is the reader's proof, and no proof means no licence.
+    /// The flag is the reader's proof, and no proof means no licence - for either style.
     /// </summary>
-    [Fact]
-    public void WithoutTheGhostFlag_AMidLineCursorStillRefuses()
+    [Theory]
+    [InlineData(Append)]
+    [InlineData(Replace)]
+    public void WithoutTheGhostFlag_AMidLineCursorStillRefuses(CommandAssistInsertionStyle style)
     {
         AssistQuerySnapshot line = Line("docker ps -a", cursorOffset: 5);
 
         Assert.False(line.IsUsableAsTypedPrefix);
         Assert.Equal("docker ps -a", line.TypedPrefix);
-        Assert.False(CommandAssistInsertionPlanner.TryCreateInsertion(line, "docker compose up", out _));
+        AssertRefuses(line, "docker compose up", style);
+    }
+
+    // ------------------------------------------------ the replace style (explicit history search)
+
+    /// <summary>
+    /// <strong>The reported bug, verbatim.</strong> Type <c>git</c>, open <c>Ctrl+R</c>, pick
+    /// <c>echo git-alpha</c> - a row the subsequence filter matched and no prefix rule ever will - and
+    /// press <c>Enter</c>. Under append the planner refused, <c>Enter</c> fell through to the shell, and
+    /// the shell ran <c>git</c>: the user asked for one command and got another.
+    /// </summary>
+    [Fact]
+    public void UnderReplace_ANonPrefixRowErasesTheQueryAndSendsTheWholeCommand()
+    {
+        CommandAssistInsertionPlan plan = AssertPlans(Line("git"), "echo git-alpha", Replace);
+
+        Assert.Equal(3, plan.BackspaceCount);
+        Assert.Equal("echo git-alpha", plan.TextToSend);
+    }
+
+    /// <summary>The plan sibling of the append-only refusal above, at the same fixture.</summary>
+    [Fact]
+    public void UnderReplace_ARowThatDoesNotStartWithTheLineIsAccepted()
+    {
+        CommandAssistInsertionPlan plan = AssertPlans(Line("kubectl"), "git status", Replace);
+
+        Assert.Equal(7, plan.BackspaceCount);
+        Assert.Equal("git status", plan.TextToSend);
+    }
+
+    /// <summary>
+    /// <strong>A prefix row under replace is still a full replace, not an append.</strong> Type
+    /// <c>git</c>, take <c>git status</c>: three deletes and the whole command, never <c>(0, " status")</c>.
+    /// </summary>
+    /// <remarks>
+    /// The optimisation is deliberately not taken. One behaviour per surface, so the user does not have
+    /// to know which; the bytes on the wire must not depend on which row happens to be highlighted; and
+    /// optimising here would make the delete path dead code on the <em>common</em> <c>Ctrl+R</c> accept
+    /// and live only on the rarer non-prefix rows, which is how a path rots.
+    /// </remarks>
+    [Fact]
+    public void UnderReplace_APrefixRowIsStillAFullReplaceRatherThanAnAppend()
+    {
+        CommandAssistInsertionPlan plan = AssertPlans(Line("git"), "git status", Replace);
+
+        Assert.Equal(3, plan.BackspaceCount);
+        Assert.Equal("git status", plan.TextToSend);
+    }
+
+    /// <summary>
+    /// An empty line under replace is zero deletes and the whole command - numerically identical to the
+    /// append answer, and produced by the same arithmetic rather than by a second branch. The exact
+    /// zero is the assertion: a stray backspace here would ring the bell on every <c>Ctrl+R</c> accept
+    /// at a bare prompt, which is the most common accept there is.
+    /// </summary>
+    [Fact]
+    public void UnderReplace_AnEmptyLinePlansNoDeletesAtAll()
+    {
+        CommandAssistInsertionPlan plan = AssertPlans(Line(string.Empty), "git status", Replace);
+
+        Assert.Equal(0, plan.BackspaceCount);
+        Assert.Equal("git status", plan.TextToSend);
+    }
+
+    /// <summary>
+    /// Exact match still refuses under replace. Erasing N characters to retype the identical N is pure
+    /// flicker, and it is exactly the window in which "the deletes land but the insert does not" costs
+    /// the user their line for nothing. It also keeps the invariant that a successful plan changes
+    /// something.
+    /// </summary>
+    [Fact]
+    public void UnderReplace_ALineThatAlreadyIsTheCommandRefuses()
+    {
+        AssertRefuses(Line("git status"), "git status", Replace);
+    }
+
+    /// <summary>
+    /// The ghost is not backspaced. <c>kubect</c> typed with <c>l get pods</c> predicted past the cursor
+    /// is <em>six</em> deletes, not sixteen: the prediction lives in the shell's suggestion buffer and
+    /// there is nothing there to delete. Counting from <c>Text</c> instead of <c>TypedPrefix</c> is the
+    /// mutation this catches.
+    /// </summary>
+    [Fact]
+    public void UnderReplace_TheGhostSuffixIsNotCounted()
+    {
+        CommandAssistInsertionPlan plan = AssertPlans(Ghosted("kubect", "l get pods"), "docker ps", Replace);
+
+        Assert.Equal(6, plan.BackspaceCount);
+        Assert.Equal("docker ps", plan.TextToSend);
+    }
+
+    /// <summary>
+    /// <strong>The counting unit: UTF-16 code units, not graphemes and not grid cells.</strong>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// These three cases exist so that a refactor towards grapheme counting has to argue with a test
+    /// rather than with a comment.
+    /// </para>
+    /// <list type="bullet">
+    /// <item><c>caf</c> + <c>e</c> + <c>U+0301</c> is four graphemes and five code units. readline needs
+    /// five backward-deletes to clear it, because it deletes a codepoint at a time and the combining
+    /// acute is its own codepoint. A grapheme count would say four and leave the accent on the line, and
+    /// the inserted command would be appended to it - undershoot is the unrecoverable direction.</item>
+    /// <item>Two CJK characters are two code units even though they occupy four grid columns. The count
+    /// is a count of characters the editor holds, not of cells the terminal paints; the reader already
+    /// collapses a wide character's trailing cell.</item>
+    /// <item>One non-BMP emoji is a surrogate pair: two code units, one codepoint. Here the count
+    /// <em>overshoots</em> - PSReadLine coalesces the pair and needs one delete - and that is the safe
+    /// direction, because the extra delete lands at the start of an empty input buffer and does
+    /// nothing (see <c>PtyBackspaceAtLineStartTests</c>).</item>
+    /// </list>
+    /// <para>
+    /// The inputs are spelled with <c>\u</c> escapes rather than as literals on purpose: an editor, a
+    /// source normalisation pass or an encoding round-trip could quietly turn the decomposed
+    /// <c>e</c>-plus-accent into the precomposed character, which would leave the first case asserting
+    /// four code units and testing nothing at all.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData("cafe\u0301", 5)]
+    [InlineData("\u4F60\u597D", 2)]
+    [InlineData("\U0001F600", 2)]
+    public void UnderReplace_TheBackspaceCountIsInUtf16CodeUnits(string typed, int expected)
+    {
+        CommandAssistInsertionPlan plan = AssertPlans(Line(typed), "git status", Replace);
+
+        Assert.Equal(expected, plan.BackspaceCount);
+        Assert.Equal(typed.Length, plan.BackspaceCount);
+        Assert.Equal("git status", plan.TextToSend);
+    }
+
+    /// <summary>
+    /// A row carrying a line break is refused by both styles. <c>SendInput</c> writes raw bytes with no
+    /// bracketed-paste wrapping on this path, so the newline would <em>submit</em> the line rather than
+    /// be inserted into it - and under replace it would submit against a line we had just erased.
+    /// </summary>
+    [Theory]
+    [InlineData(Append)]
+    [InlineData(Replace)]
+    public void ARowContainingALineBreakIsRefused(CommandAssistInsertionStyle style)
+    {
+        AssertRefuses(Line(string.Empty), "echo one\necho two", style);
+        AssertRefuses(Line(string.Empty), "echo one\r\necho two", style);
+    }
+
+    /// <summary>
+    /// <strong>The invariant, as a property over the whole matrix: a successful plan is never
+    /// <c>(0, "")</c>.</strong>
+    /// </summary>
+    /// <remarks>
+    /// The pane re-checks this before sending, and this is why it can. A plan that changed nothing would
+    /// dismiss the surface and send no bytes, which is indistinguishable to the user from the feature
+    /// being broken - the failure PR #294 was about. Written as a sweep rather than as one more example
+    /// so that a new refusal, or a new style, is covered the day it is added.
+    /// </remarks>
+    [Fact]
+    public void ASuccessfulPlanNeverChangesNothing()
+    {
+        AssistQuerySnapshot?[] queries =
+        {
+            null,
+            Line(string.Empty),
+            Line("git"),
+            Line("git status"),
+            Line("kubectl"),
+            Line("git st", cursorOffset: 2),
+            Line("git st", rightPromptTrimmed: true),
+            Line("for i in 1 2 3\n> do echo", isMultiline: true),
+            Ghosted("kubect", "l get pods"),
+            Ghosted("git", " status --short")
+        };
+
+        string?[] commands = { null, string.Empty, "git", "git status", "echo git-alpha", "echo a\nb" };
+        CommandAssistInsertionStyle[] styles = { Append, Replace };
+
+        var planned = new List<CommandAssistInsertionPlan>();
+
+        foreach (AssistQuerySnapshot? query in queries)
+        {
+            foreach (string? command in commands)
+            {
+                foreach (CommandAssistInsertionStyle style in styles)
+                {
+                    if (!CommandAssistInsertionPlanner.TryCreatePlan(
+                            query,
+                            command,
+                            style,
+                            out CommandAssistInsertionPlan plan))
+                    {
+                        Assert.Equal(default, plan);
+                        continue;
+                    }
+
+                    planned.Add(plan);
+                    Assert.False(
+                        plan.BackspaceCount == 0 && plan.TextToSend.Length == 0,
+                        $"'{query?.Text ?? "<null>"}' + '{command}' ({style}) planned a no-op.");
+                    Assert.True(plan.BackspaceCount >= 0);
+                    Assert.NotNull(plan.TextToSend);
+                }
+            }
+        }
+
+        // The sweep has to actually reach the success path, or the property above is vacuous.
+        Assert.NotEmpty(planned);
+    }
+
+    /// <summary>
+    /// The append forwarder is exactly <c>TryCreatePlan</c> with the append style and no deletes - which
+    /// is what lets every pre-existing additive test go on pinning the additive rule literally.
+    /// </summary>
+    [Theory]
+    [InlineData("git st", "git status")]
+    [InlineData("", "git status")]
+    [InlineData("kubectl", "git status")]
+    [InlineData("git status", "git status")]
+    public void TryCreateInsertion_IsTryCreatePlanWithTheAppendStyle(string text, string selectedCommand)
+    {
+        bool viaForwarder = CommandAssistInsertionPlanner.TryCreateInsertion(
+            Line(text),
+            selectedCommand,
+            out string? textToSend);
+
+        bool viaPlan = CommandAssistInsertionPlanner.TryCreatePlan(
+            Line(text),
+            selectedCommand,
+            Append,
+            out CommandAssistInsertionPlan plan);
+
+        Assert.Equal(viaPlan, viaForwarder);
+        Assert.Equal(0, plan.BackspaceCount);
+        Assert.Equal(viaPlan ? plan.TextToSend : null, textToSend);
     }
 }

--- a/tests/NovaTerminal.App.Tests/Controls/PaneAssistInsertionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneAssistInsertionTests.cs
@@ -273,6 +273,13 @@ public class PaneAssistInsertionTests
         fixture.PressCtrlEnter();
 
         Assert.Empty(fixture.Session.Sent);
+
+        // Asserted by content as well as by emptiness. This fixture is in Ctrl+R, which is exactly the
+        // scope where an accept erases the typed query - and the pane cannot see how long that query
+        // is here. A regression that let a replace through in a degraded session would show up as
+        // deletes on the wire, so the deletes are named rather than left to Assert.Empty to imply.
+        Assert.DoesNotContain(fixture.Session.Sent, sent => sent.Contains('\u007f'));
+
         Assert.True(fixture.ViewModel.IsVisible);
         Assert.True(fixture.ViewModel.HasSuggestions);
     }
@@ -387,6 +394,12 @@ public class PaneAssistInsertionTests
     /// shell family, opposite outcome - and <c>cmd.exe</c> failed at the same time for the entirely
     /// separate reason above, which is what made one report out of two bugs.
     /// </para>
+    /// <para>
+    /// The expected bytes are a replace rather than the suffix because this fixture opens the list with
+    /// <c>Ctrl+R</c>: six deletes for <c>git st</c> and then the whole command. That is the
+    /// history-search rule, not a property of this prompt shape - what this test is for is still the
+    /// right prompt, and the trim floor at the cursor is why the deletes cannot reach the badge.
+    /// </para>
     /// </remarks>
     [AvaloniaFact]
     public async Task OnAPromptWithARightAlignedBadge_EnterInsertsInsteadOfSubmitting()
@@ -394,7 +407,7 @@ public class PaneAssistInsertionTests
         using var fixture = await Fixture.AtAPromptWithARightAlignedBadgeAsync("git st", history: "git status");
 
         Assert.True(fixture.PressEnter());
-        Assert.Equal("atus", Assert.Single(fixture.Session.Sent));
+        Assert.Equal("\u007f\u007f\u007f\u007f\u007f\u007fgit status", Assert.Single(fixture.Session.Sent));
     }
 
     /// <summary>
@@ -469,7 +482,10 @@ public class PaneAssistInsertionTests
 
         fixture.PressCtrlEnter();
 
-        Assert.Equal("atus", Assert.Single(fixture.Session.Sent));
+        // Six deletes and the whole command: this fixture is in Ctrl+R history search, where an accept
+        // replaces the typed query. The bug under test is still the grid read - a build with the
+        // padding-run regression refuses here and sends nothing at all.
+        Assert.Equal("\u007f\u007f\u007f\u007f\u007f\u007fgit status", Assert.Single(fixture.Session.Sent));
     }
 
     /// <summary>The same prompt through the <c>Enter</c> path, which is how the owner met it.</summary>
@@ -479,7 +495,7 @@ public class PaneAssistInsertionTests
         using var fixture = await Fixture.AtAPsReadLineRenderedPromptAsync("git st", history: "git status");
 
         Assert.True(fixture.PressEnter());
-        Assert.Equal("atus", Assert.Single(fixture.Session.Sent));
+        Assert.Equal("\u007f\u007f\u007f\u007f\u007f\u007fgit status", Assert.Single(fixture.Session.Sent));
     }
 
     /// <summary>
@@ -487,9 +503,11 @@ public class PaneAssistInsertionTests
     /// and it is empty.
     /// </summary>
     /// <remarks>
-    /// The worst case of the same bug and the one that produced the report. The planner's empty-line
-    /// fast path needs <c>Text</c> to be empty; a row of blanks instead took the prefix branch, where
-    /// no suggestion starts with a hundred spaces.
+    /// The worst case of the same bug and the one that produced the report. The planner's arithmetic
+    /// needs <c>Text</c> to be empty to plan a bare send; a row of blanks instead read as a hundred
+    /// typed spaces, which no suggestion starts with and which a replace would have tried to erase.
+    /// The bytes are unchanged by the replace style precisely because the line is empty: zero deletes,
+    /// whole command.
     /// </remarks>
     [AvaloniaFact]
     public async Task OnAnEmptyPromptPsReadLineHasRendered_EnterSendsTheWholeCommand()
@@ -498,6 +516,84 @@ public class PaneAssistInsertionTests
 
         Assert.True(fixture.PressEnter());
         Assert.Equal("git status", Assert.Single(fixture.Session.Sent));
+    }
+
+    // ------------------- replace-on-accept in explicit history search (the #304 follow-up)
+
+    /// <summary>
+    /// <strong>The reported bug, end to end through the real pane.</strong> Type <c>git</c>, press
+    /// <c>Ctrl+R</c>, highlight <c>echo git-alpha</c> - a row the subsequence filter matched - and press
+    /// <c>Enter</c>. Before this the planner refused, <c>Enter</c> fell through to the shell, and the
+    /// shell ran <c>git</c>.
+    /// </summary>
+    /// <remarks>
+    /// <c>Assert.Single</c> matters as much as the value. The deletes and the text go out in one
+    /// <c>SendInput</c> because <c>Parser.OnResponse</c> writes to the same session from the parse
+    /// thread: two calls would leave a window for a device-report reply to land between erasing the
+    /// user's line and putting the command back on it.
+    /// </remarks>
+    [AvaloniaFact]
+    public async Task InHistorySearch_EnterOnANonPrefixRowErasesTheQueryAndSendsTheCommand()
+    {
+        using var fixture = await Fixture.AtAnIntegratedHistorySearchAsync("git", history: "echo git-alpha");
+
+        Assert.True(fixture.PressEnter());
+        Assert.Equal("\u007f\u007f\u007fecho git-alpha", Assert.Single(fixture.Session.Sent));
+    }
+
+    /// <summary>
+    /// <strong>The scoping pin.</strong> The same prompt and the same row, reached through the assist
+    /// toggle instead of <c>Ctrl+R</c>: Suggest mode is still strictly additive, so a non-prefix row
+    /// refuses, <c>Enter</c> falls through to the shell, and nothing goes out.
+    /// </summary>
+    /// <remarks>
+    /// If this starts failing, replace has leaked out of history search - which is a bug in the change,
+    /// not a stale expectation. It is the counterpart of the test above and they share everything except
+    /// which key opened the list.
+    /// </remarks>
+    [AvaloniaFact]
+    public async Task InSuggestMode_EnterOnANonPrefixRowStillRefuses()
+    {
+        using var fixture = await Fixture.AtAnIntegratedPromptAsync("git", history: "echo git-alpha");
+
+        Assert.True(fixture.PressDown());
+        Assert.True(fixture.ViewModel.IsAcceptOnEnterArmed);
+
+        Assert.False(fixture.PressEnter());
+        Assert.Empty(fixture.Session.Sent);
+    }
+
+    /// <summary>
+    /// The echo gate is armed by the accept itself. Everything the pane just sent is in flight, so the
+    /// grid is behind the shell until it comes back - and the next accept must refuse rather than
+    /// measure against a line the shell has already left.
+    /// </summary>
+    /// <remarks>
+    /// Missing before this change, and latent even under the additive rule: two fast <c>Ctrl+Enter</c>s
+    /// computed the second delta against the pre-insertion line. Under replace the same gap is a count
+    /// taken against the wrong line, which erases the wrong number of characters.
+    /// </remarks>
+    [AvaloniaFact]
+    public async Task AfterASuccessfulAccept_TheEchoGateIsArmed()
+    {
+        using var fixture = await Fixture.AtAnIntegratedHistorySearchAsync("git", history: "echo git-alpha");
+
+        Assert.False(fixture.Pane.HasUnechoedInput);
+
+        Assert.True(fixture.PressEnter());
+
+        Assert.True(fixture.Pane.HasUnechoedInput);
+    }
+
+    /// <summary>A pointer accept in history search produces exactly the bytes <c>Enter</c> does.</summary>
+    [AvaloniaFact]
+    public async Task InHistorySearch_PointerAcceptSendsTheSameBytesAsEnter()
+    {
+        using var fixture = await Fixture.AtAnIntegratedHistorySearchAsync("git", history: "echo git-alpha");
+
+        fixture.Pane.OnCommandAssistSuggestionPointerAccepted(0);
+
+        Assert.Equal("\u007f\u007f\u007fecho git-alpha", Assert.Single(fixture.Session.Sent));
     }
 
     // ---------------------------------------------------------------- mouse (V2 Phase 3a)
@@ -578,6 +674,29 @@ public class PaneAssistInsertionTests
 
             // An explicit session is what widens the suggestion scope back out to history.
             fixture.Pane.ToggleCommandAssist();
+            await fixture.WaitForAsync(() => fixture.ViewModel.TopSuggestionText == history);
+            return fixture;
+        }
+
+        /// <summary>
+        /// The same instrumented prompt, but with the list opened by <c>Ctrl+R</c> rather than by the
+        /// assist toggle - i.e. in the one scope where an accept replaces the typed query.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately a sibling of <see cref="AtAnIntegratedPromptAsync"/> rather than a flag on it:
+        /// the pair exists so that a scoping test can hold the prompt, the typed text and the row
+        /// constant and vary only which key opened the list.
+        /// </remarks>
+        public static async Task<Fixture> AtAnIntegratedHistorySearchAsync(string commandLine, string history)
+        {
+            Fixture fixture = await CreateAsync(history);
+            fixture.Pane.ArmShellIntegrationTracker();
+            fixture.Pane.CreateAndWireParser();
+            fixture.Pane.Parser!.Process(PromptStart + "$ " + PromptEnd + commandLine);
+
+            await Task.Delay(50);
+
+            fixture.Pane.OpenCommandAssistHistorySearch();
             await fixture.WaitForAsync(() => fixture.ViewModel.TopSuggestionText == history);
             return fixture;
         }

--- a/tests/NovaTerminal.App.Tests/Controls/PaneGridTruthDesyncTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneGridTruthDesyncTests.cs
@@ -98,6 +98,11 @@ public class PaneGridTruthDesyncTests
     /// what the user will run - but it is no longer a prefix an append can extend, and the snapshot
     /// says so.
     /// </summary>
+    /// <remarks>
+    /// Replace refuses on the same read, and for a sharper reason: its deletes run leftwards from the
+    /// cursor, so a replace here would eat <c>git sta</c>, leave <c>tus</c> behind, and insert the
+    /// command in front of the survivor.
+    /// </remarks>
     [AvaloniaFact]
     public async Task AfterAnArrowKey_TheTextIsUnchangedButItIsNoLongerAnAppendableParent()
     {
@@ -111,6 +116,11 @@ public class PaneGridTruthDesyncTests
         Assert.Equal(7, line?.CursorOffset);
         Assert.False(line?.IsUsableAsTypedPrefix);
         Assert.False(CommandAssistInsertionPlanner.TryCreateInsertion(line, "git status --short", out _));
+        Assert.False(CommandAssistInsertionPlanner.TryCreatePlan(
+            line,
+            "git status --short",
+            CommandAssistInsertionStyle.ReplaceTypedPrefix,
+            out _));
     }
 
     /// <summary>

--- a/tests/NovaTerminal.App.Tests/PtyBackspaceAtLineStartTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtyBackspaceAtLineStartTests.cs
@@ -1,0 +1,355 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using NovaTerminal.Pty;
+using NovaTerminal.VT;
+using Xunit;
+
+namespace NovaTerminal.Tests;
+
+/// <summary>
+/// The empirical foundation under Command Assist's replace-on-accept arithmetic: <c>DEL</c>
+/// (<c>0x7f</c>) deletes exactly one character, and once the input line is empty further deletes do
+/// nothing at all.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>CommandAssistInsertionPlanner</c> counts backspaces in UTF-16 code units, which is an
+/// <em>upper bound</em> on the number of backward-deletes any line editor needs - readline, zle and
+/// fish delete a codepoint at a time, PSReadLine a .NET <c>char</c>. The safety argument for using an
+/// upper bound is that the overshoot is absorbed at the start of the input buffer. That argument is
+/// load-bearing (an undershoot would leave debris the inserted command is appended to), so it is
+/// established here by measurement rather than by assertion, through the product's own PTY layer and
+/// its own parser and grid.
+/// </para>
+/// <para>
+/// <strong>Each case is a round trip, and that is what stops it passing vacuously.</strong> Type
+/// three characters, wait until the grid shows them, then send <em>five</em> deletes and require the
+/// grid to come back to exactly the prompt it started from. The typing leg proves the write actually
+/// reached the shell and the shell is alive and echoing - without it, a session that died after
+/// painting its prompt, or a <c>SendInput</c> that dropped the write (it swallows the two
+/// shutdown-race exceptions by design), would leave before and after trivially equal and the test
+/// green having measured nothing. The delete leg then proves three things at once: <c>0x7f</c> is the
+/// delete byte, it removes one character per byte, and the two surplus deletes are absorbed rather
+/// than eating the prompt.
+/// </para>
+/// <para>
+/// The final assertion reads the whole cursor row, not just the text behind the cursor. Behind the
+/// cursor alone cannot tell "deleted three characters" from "moved the cursor three columns left",
+/// which is exactly the vi-command-mode behaviour the planner records as an accepted risk; requiring
+/// the probe string to be gone from the row distinguishes them.
+/// </para>
+/// <para>
+/// <strong>Coverage, stated so a green run is not over-read.</strong> This class runs on the gating
+/// PtySmoke job on both <c>windows-latest</c> and <c>ubuntu-latest</c>, so pwsh 7 and Windows
+/// PowerShell are measured on the Windows runner and bash on the Linux one. On a Windows box bash is
+/// reached through WSL if a distribution is installed - a maintainer convenience, not CI coverage,
+/// since the Windows runner has no distribution and reports that case as an explicit skip. zsh and
+/// fish are not measured anywhere: the code's claim about them rests on zle and fish documentation.
+/// Nothing here is ever submitted, so no shell writes a history entry.
+/// </para>
+/// </remarks>
+[Collection(PtyRealShellCollection.Name)]
+public class PtyBackspaceAtLineStartTests
+{
+    /// <summary>
+    /// Three characters, deleted by five bytes: the surplus is the point. Deliberately a string no
+    /// prompt, path or banner would contain, because the final assertion is that it is gone.
+    /// </summary>
+    private const string Probe = "zqj";
+
+    private const string FiveDeletes = "\u007f\u007f\u007f\u007f\u007f";
+
+    /// <summary>Enough to cover any prompt these shells draw on one row, and less than a row.</summary>
+    private const int PromptReadLength = 60;
+
+    private const int PollIntervalMs = 250;
+    private const int PollAttempts = 60;
+
+    [Fact]
+    [Trait("Category", "PtySmoke")]
+    public async Task InPwsh7_TypingThenFiveDeletesLeavesThePromptUntouched()
+    {
+        string? shell = FindFirstExisting(
+            @"C:\Program Files\PowerShell\7\pwsh.exe",
+            @"C:\Program Files\PowerShell\7-preview\pwsh.exe");
+
+        await AssertTypeThenDeleteRoundTripAsync(shell, args: "-NoLogo -NoProfile", label: "pwsh 7");
+    }
+
+    [Fact]
+    [Trait("Category", "PtySmoke")]
+    public async Task InWindowsPowerShell_TypingThenFiveDeletesLeavesThePromptUntouched()
+    {
+        // PSReadLine 2.0 rather than 2.3, which is a different renderer and has already produced one
+        // Command Assist bug the newer one did not (the right-prompt trim, PR #301).
+        string? shell = FindFirstExisting(
+            Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.System),
+                "WindowsPowerShell",
+                "v1.0",
+                "powershell.exe"));
+
+        await AssertTypeThenDeleteRoundTripAsync(shell, args: "-NoLogo -NoProfile", label: "Windows PowerShell");
+    }
+
+    /// <summary>
+    /// bash/readline in emacs mode: natively on the Linux runner, and through WSL on a Windows box
+    /// that has a distribution. <c>--norc</c> keeps the user's own configuration - and their
+    /// <c>INPUTRC</c> - out of it, so what is measured is stock readline.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PtySmoke")]
+    public async Task InBash_TypingThenFiveDeletesLeavesThePromptUntouched()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            await AssertTypeThenDeleteRoundTripAsync(
+                FindFirstExisting("/bin/bash", "/usr/bin/bash"),
+                args: "--norc -i",
+                label: "bash");
+            return;
+        }
+
+        await AssertTypeThenDeleteRoundTripAsync(
+            IsWslUsable() ? "wsl.exe" : null,
+            args: "-e /bin/bash --norc -i",
+            label: "bash (WSL)");
+    }
+
+    private static async Task AssertTypeThenDeleteRoundTripAsync(string? shell, string? args, string label)
+    {
+        if (shell is null)
+        {
+            // An explicit, visible skip rather than a silent return: this class gates CI on two
+            // runners, and a case that quietly measures nothing must still say so in the results.
+            Assert.Skip($"{label} is not available on this machine; nothing was measured.");
+            return;
+        }
+
+        var buffer = new TerminalBuffer(80, 24);
+
+        using var session = new RustPtySession(
+            shell, 80, 24, args, cwd: null, skipPowerShellPostLaunchInit: true);
+
+        // OnResponse is not optional here. ConPTY opens with a cursor-position report request
+        // (ESC [ 6 n) and the shell does not draw its first prompt until the terminal answers, so a
+        // parser wired without it sits at a blank grid forever. Production wires exactly this, which
+        // is also why an insertion has to share the session's writer with the parse thread.
+        var parser = new AnsiParser(buffer)
+        {
+            OnResponse = session.SendInput
+        };
+
+        // The parse runs on the session's own output thread, exactly as it does in a live pane; the
+        // buffer's reader/writer lock is what makes the reads below safe against it.
+        session.OnOutputReceived += text => parser.Process(text);
+
+        CursorContext before = await WaitForASettledPromptAsync(buffer, label);
+
+        // Leg one: prove the write path works and the shell is echoing. If this times out the failure
+        // names the real cause instead of surfacing later as a meaningless prompt diff.
+        session.SendInput(Probe);
+        await WaitForAsync(
+            buffer,
+            context => context.TextBeforeCursor == before.TextBeforeCursor + Probe,
+            $"'{label}' never echoed the typed probe '{Probe}'. The shell may have exited, or the " +
+            $"write was dropped. Prompt before typing was '{Describe(before.TextBeforeCursor)}'");
+
+        // Leg two: five deletes for three characters. Polling for the return to `before` rather than
+        // sleeping a fixed period - a no-op produces no output in some shells and a bell in others, so
+        // there is nothing to wait for except the state we are asserting, and on a fast box this costs
+        // one poll interval instead of two seconds on every CI run.
+        session.SendInput(FiveDeletes);
+        CursorContext after = await WaitForAsync(
+            buffer,
+            context => context == before,
+            $"'{label}' did not return to its original prompt after {FiveDeletes.Length} deletes over " +
+            $"{Probe.Length} typed characters. Expected '{Describe(before.TextBeforeCursor)}' at " +
+            $"({before.Row},{before.Col})");
+
+        Assert.Equal(before, after);
+
+        // Behind the cursor is not enough on its own: an editor that moved the cursor left rather than
+        // deleting would produce the same text behind it and leave the probe sitting past it.
+        Assert.DoesNotContain(Probe, ReadCursorRowText(buffer), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Polls until the text ending at the cursor stops changing, so the measurement is not taken
+    /// mid-banner or mid-repaint.
+    /// </summary>
+    /// <remarks>
+    /// Fails at the settle point rather than returning whatever it last saw. This class runs on a
+    /// gating job with no <c>continue-on-error</c>, and on a cold runner still repainting at the cap
+    /// the old behaviour surfaced as a prompt diff that said nothing about the real cause.
+    /// </remarks>
+    private static async Task<CursorContext> WaitForASettledPromptAsync(TerminalBuffer buffer, string label)
+    {
+        CursorContext previous = default;
+
+        for (int i = 0; i < PollAttempts; i++)
+        {
+            await Task.Delay(PollIntervalMs);
+            CursorContext current = ReadCursorContext(buffer);
+
+            if (!string.IsNullOrWhiteSpace(current.TextBeforeCursor) && current == previous)
+            {
+                return current;
+            }
+
+            previous = current;
+        }
+
+        Assert.Fail(
+            $"'{label}' never settled on a prompt within {PollAttempts * PollIntervalMs / 1000}s. " +
+            $"Last read was '{Describe(previous.TextBeforeCursor)}' at ({previous.Row},{previous.Col}).");
+        return default;
+    }
+
+    private static async Task<CursorContext> WaitForAsync(
+        TerminalBuffer buffer,
+        Func<CursorContext, bool> predicate,
+        string failureMessage)
+    {
+        CursorContext current = default;
+
+        for (int i = 0; i < PollAttempts; i++)
+        {
+            await Task.Delay(PollIntervalMs);
+            current = ReadCursorContext(buffer);
+            if (predicate(current))
+            {
+                return current;
+            }
+        }
+
+        Assert.Fail(
+            $"{failureMessage}, but after {PollAttempts * PollIntervalMs / 1000}s the grid read " +
+            $"'{Describe(current.TextBeforeCursor)}' at ({current.Row},{current.Col}).");
+        return default;
+    }
+
+    private static CursorContext ReadCursorContext(TerminalBuffer buffer)
+    {
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            GridQueryReader.TryReadTextEndingAtCursor(buffer, PromptReadLength, out string text);
+            return new CursorContext(text, buffer.CursorRow, buffer.CursorCol);
+        }
+        finally
+        {
+            buffer.Lock.ExitReadLock();
+        }
+    }
+
+    /// <summary>The whole row the cursor is on, including anything painted past the cursor.</summary>
+    private static string ReadCursorRowText(TerminalBuffer buffer)
+    {
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            int row = buffer.Scrollback.Count + buffer.CursorRow;
+            var text = new StringBuilder(buffer.Cols);
+            for (int col = 0; col < buffer.Cols; col++)
+            {
+                string grapheme = buffer.GetGraphemeAbsolute(col, row);
+                text.Append(string.IsNullOrEmpty(grapheme) || grapheme == "\0" ? " " : grapheme);
+            }
+
+            return text.ToString();
+        }
+        finally
+        {
+            buffer.Lock.ExitReadLock();
+        }
+    }
+
+    /// <summary>Renders a grid read for a failure message without letting control bytes garble it.</summary>
+    private static string Describe(string? text) =>
+        (text ?? string.Empty).Replace("\u001b", "<ESC>", StringComparison.Ordinal);
+
+    private static string? FindFirstExisting(params string[] candidates)
+    {
+        foreach (string candidate in candidates)
+        {
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Whether <c>wsl.exe</c> can actually run something. The executable ships with Windows whether or
+    /// not a distribution is installed, so its presence proves nothing and the Windows CI runner would
+    /// otherwise spawn a session that only ever prints an installation notice.
+    /// </summary>
+    private static bool IsWslUsable()
+    {
+        Process? probe = null;
+        try
+        {
+            probe = Process.Start(new ProcessStartInfo("wsl.exe", "-e /bin/true")
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            });
+
+            if (probe is null)
+            {
+                return false;
+            }
+
+            if (!probe.WaitForExit(10_000))
+            {
+                // Disposing the Process object does not stop the process. A probe that hung would
+                // otherwise leave wsl.exe running for the life of the agent, and this is the only
+                // place in this file that starts something outside the PTY layer's own lifecycle.
+                TryKill(probe);
+                return false;
+            }
+
+            return probe.ExitCode == 0;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+        finally
+        {
+            probe?.Dispose();
+        }
+    }
+
+    private static void TryKill(Process process)
+    {
+        try
+        {
+            process.Kill(entireProcessTree: true);
+        }
+        catch (Exception)
+        {
+            // Already gone, or not ours to kill. Nothing useful to do either way.
+        }
+    }
+
+    /// <summary>
+    /// What the grid says about the input line: the text ending at the cursor, and where the cursor
+    /// is. Value equality is the whole assertion - "the prompt came back and the caret came back".
+    /// </summary>
+    /// <remarks>
+    /// The row past the cursor is deliberately not part of this. A shell's inline prediction lives
+    /// there and repaints on its own schedule, which would make the settle loop and the equality
+    /// check flaky; the one thing that has to be checked past the cursor is checked separately and
+    /// by content (<see cref="Probe"/> is gone), which prediction noise cannot forge.
+    /// </remarks>
+    private readonly record struct CursorContext(string TextBeforeCursor, int Row, int Col);
+}


### PR DESCRIPTION
Fixes the gap #304 exposed: type `git` in Ctrl+R, select `echo git-alpha`, press Enter -
the planner refused (the row is not a prefix of what you typed), Enter fell through, and
the shell ran `git`.

Non-prefix rows are not an edge case. `JsonlHistoryStore.SearchAsync` filters by
SUBSEQUENCE, so typing `gs` matches `git status`, `git stash` and `echo goose-sauce`.
Most filtered rows in a Ctrl+R list cannot be reached by appending.

## What changes

fzf semantics, scoped to explicit history search ONLY. In `Ctrl+R`, accepting any row
erases what you typed and inserts the full command. Suggest mode, the passive bubble and
`Ctrl+Enter` direct bubble accept stay strictly additive - this is the first and only
exception to the additive-insertion rule, and it is fenced at one decision point.

Mechanism: N backspaces then the command, in ONE `SendInput`.

## Why one write, and why DEL

One call is required, not tidy. `Parser.OnResponse` writes to the same session from the
PARSE thread (device-report replies), so two calls would leave a window for a reply to
interleave between the erase and the insert. `RustPtySession.SendInput` encodes once into
a single buffer on a single-consumer writer, so a queue failure drops the whole payload
rather than half of it - the "deletes landed, text did not" loss is not reachable.

`\x7f` (DEL), matching what `TerminalView` already sends for the Backspace key. No
bracketed paste on either half: bracketed content is literal by definition, so a DEL byte
inside it would be inserted rather than executed.

## The count

`BackspaceCount = TypedPrefix.Length`, in UTF-16 CODE UNITS, from `TypedPrefix` and never
from `Text` (`Text` includes the PSReadLine ghost suffix - 10 to 40 characters the user
never typed).

Code units are deliberately an UPPER BOUND, not an exact count. readline, zle, fish and
PSReadLine each delete at most one code unit per backward-delete, and backward-delete at
column 0 is a no-op - and replace always deletes to the start of the input buffer, so
overshoot is absorbed at the floor at the cost of a bell. Grapheme counting would be
WRONG in the dangerous direction: it UNDER-counts combining sequences (`e` + U+0301 is one
grapheme but readline needs two deletes), and undercounting leaves debris that the
inserted command is then appended to.

That argument is measured, not asserted. `PtyBackspaceAtLineStartTests` spawns real shells
through `RustPtySession` -> `AnsiParser` -> `TerminalBuffer` and does a round trip: settle
on a prompt, type a 3-character probe, poll until the grid shows it, send FIVE deletes,
poll until the grid is byte-identical to the settled prompt, and assert the probe is gone
from the whole cursor row. Passing requires all three facts at once: `0x7f` is the delete
byte, it removes one character per byte, and the two surplus deletes are absorbed rather
than eating the prompt. Reading the full row rather than just text-behind-the-cursor is
what separates "deleted three" from "moved the cursor left three".

Verified live against three deliberate mutants: deletes never sent, two deletes instead of
five, probe never sent - each fails with a message naming its own cause. The undershoot
mutant leaves `z` on the line, which is the debris the code-units argument predicts.

Covered: pwsh 7 (PSReadLine 2.3) and Windows PowerShell 5.1 (PSReadLine 2.0) on the
Windows runner; bash natively on the Linux runner. WSL is only a maintainer fallback on a
Windows box and reports an explicit skip when absent, so the gating job never depends on
it. zsh and fish are NOT covered - neither is installed on any runner, and their behaviour
rests on zle/fish documentation only.

## What still refuses

Only the not-a-prefix refusal is relaxed, and only for Replace. Everything that protects
the line survives under both styles, pinned by theories over both:

- no grid truth (degraded / markless sessions)
- `IsMultiline` - `Text` contains continuation-prompt cells the user never typed, so any
  count derived from it is wrong
- cursor not at end and not a proven ghost - backspaces delete LEFT, so this would erase
  the head, leave the tail, and insert in front of the survivor
- empty selected command
- exact match - erasing N characters to retype the identical N is pure flicker, and it is
  exactly the window where a partial send would cost the line for nothing

Degraded sessions need NO new gate, and that falls out rather than being arranged: the
synthetic markless snapshot has `Text == ""`, so replace plans zero deletes and is
bit-identical to today. In a markless session the pane can prove WHETHER the line is empty
but never HOW MANY characters a non-empty line holds - and the one case where the count is
knowable is the case where it is zero, which is where both styles already agree.

## Two bugs found on the way

**`NoteInputAwaitingEcho()` was never called after an insertion send.** Already wrong on
main - two fast `Ctrl+Enter`s race the echo - and corruption under replace, where a
stale-by-one read sends one delete too few and the command lands against the survivor.
Now armed after the send, pinned by a test.

**The newline guard is a tightening of Append, not just of Replace.** Snippets can contain
newlines, and a multi-line row previously sent the remainder INCLUDING `\n` with no
bracketed paste - submitting the command halfway through. `TryCreatePlan` now refuses rows
containing `\n`/`\r` under both styles. That is a real fix, but it made `Ctrl+Enter`
consume the key and do nothing while the hint strip still advertised "insert", so the
strip's insertion probe now also asks whether the SELECTED ROW is insertable, not just
whether the line is. Partial by design: `BuildHintText` deliberately keeps the insert
clause unconditionally once Enter is armed (dropping it would make the strip flicker while
browsing), so a multi-line row browsed in an open popup still shows "insert" and still
refuses. That is the pre-existing shape of every refusal on the armed path; it is
documented in the code rather than papered over.

## Also considered and rejected

Refusing replace on soft-wrapped lines (`IsSoftWrapped = EndRow > StartRow`) was
implemented, measured and reverted: it refuses EVERY PSReadLine-rendered prompt, empty
ones included, because PSReadLine erases one cell past the right edge and that is a real
autowrap. Three prompt tests went to "nothing sent". This is the #301 failure mode - a
guard that fires on every prompt a common shell paints. The rejected alternative is
recorded in the planner along with the narrower signal a real fix would need.

Prepending `\x7f` into the existing `out string` was rejected: it makes the count
untestable and defeats the pane's emptiness guard. A separate `TryCreateReplacement` was
rejected: it duplicates 90% of the refusal discipline. A pane-side erase step was
rejected: it reintroduces the accept-before-plan ordering bug #294 fixed.

Replace is uniform in Search scope - even a row that DOES start with the query is a full
replace. Preferring append when the prefix happens to match would make the backspace path
dead code on the common accept (type `git`, take `git status`) and alive only on the rarer
rows, and a path skipped in the common case rots.

## Not undoable

Command Assist has no undo. If the deletes land and the insert does not, the typed query
is gone; shell-native undo (`Ctrl+_` in readline, `Ctrl+Z` in PSReadLine) is the only
recovery. In Search scope the erased text is a search query rather than a command, which
is what makes the scoping decision safe. Stated in the planner remarks rather than implied
away.

Known limitation, not detectable from the grid: in vi command mode (`set -o vi`,
`Set-PSReadLineOption -EditMode Vi`) DEL may move the cursor left instead of deleting.
Additive insertion is already meaningless in vi command mode, so this is an accepted risk.

## Testing

`TryCreateInsertion` is kept as a public test-only shim over `TryCreatePlan(..., Append)`
so every pre-existing additive test keeps pinning the additive rule LITERALLY unchanged
rather than by inspection. The Suggest-scope pane expectations are byte-identical in the
diff - if any of them had moved, replace would have leaked.

Per class: CommandAssistInsertionPlannerTests 55, CommandAssistGridTruthTests 24,
PaneAssistInsertionTests 28, PaneGridTruthDesyncTests 5, AssistSessionStateMachineTests
219, CommandAssistControllerTests 79, CommandAssistPassiveBubbleTests 29,
CommandAssistLayoutTests 95, TerminalPaneCommandAssistShortcutTests 16,
PaneMarklessCaptureTests 42, SnippetEditorTests 13, PtyBackspaceAtLineStartTests 3. Zero
failures.

Mutation-checked, 10 mutants, each confirmed to fail the named test: count from `Text`;
grapheme count instead of code units; replace forced in Suggest scope; two `SendInput`
calls; `NoteInputAwaitingEcho()` dropped; `IsUsableAsTypedPrefix` relaxed for replace;
stray backspace on an empty line; replace allowed on a null snapshot; prefix rows
"optimised" back to append; exact-match refusal dropped. Plus three more against the PTY
round trip.

Reviewed by a second agent (opus, given that this is the first destructive write Command
Assist performs): approved, no blockers, findings fixed before push.

## Follow-ups, not in this PR

- `GridQueryReader.SoftWrappedRowEnd` drops a typed space in the last column before a wide
  character, under-counting by one. Harmless under Append (it produced a refusal),
  corruption under Replace: a query of ~78+ characters with a trailing space at exactly the
  wrap column and a wide character next would leave the leftmost character behind
  (`gecho git-alpha`). Needs a narrow reader signal - a bool raised only when
  `SoftWrappedRowEnd` actually dropped a cell on a row at or before the cursor row.
- The echo gate is cleared by ANY parsed session output, so a background job printing a
  line can clear it before the user's last keystroke echoes. Pre-existing; the blast radius
  widened from a wrong append to a wrong count. Closing it needs a "the bytes I sent came
  back" signal the parser does not offer today.
- `Ctrl+R` accepts have not been driven in the real app yet. Everything here is headless
  tests plus real PTY child processes.
