### PR TITLE
feat(command-assist): one-line installer for remote shell integration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,9 +27,11 @@
 
 # The remote shell-integration snippets (V2 Phase 2b) are pasted onto a remote POSIX host, so a CRLF
 # working tree would put `$'\r': command not found` on every line of the file the user just wrote.
-# `*.sh` above already covers one of the three. `RemoteShellIntegrationSnippets.Read` normalizes as
-# well, so this is belt and braces for anyone reading the files out of the tree directly.
-assets/shell-integration/*   text eol=lf
+# `*.sh` above already covers most of them. `RemoteShellIntegrationSnippets.Read` normalizes as
+# well, so this is belt and braces for anyone reading the files out of the tree directly. `**`
+# rather than `*`: the installers under `assets/shell-integration/install/` are a directory deeper,
+# and nova-install.ps1 has no other rule declaring it LF.
+assets/shell-integration/**   text eol=lf
 
 # Rust sources: LF, matching cargo/rustfmt convention and the crates' own history.
 *.rs        text eol=lf

--- a/assets/shell-integration/install/nova-install-fish.sh
+++ b/assets/shell-integration/install/nova-install-fish.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Nova Terminal remote shell integration installer (fish).
+#
+# POSIX sh, not fish: fish cannot parse a heredoc, and the snippet below is data. Run as a child
+# process by the one-liner Settings copies, then deleted. $1 is the shell name ("fish"), accepted
+# for symmetry with nova-install.sh and unused - conf.d is sourced automatically, so there is no
+# rc file to patch and no shell to detect.
+
+__nova_dir="$HOME/.config/fish/conf.d"
+if ! mkdir -p "$__nova_dir"; then
+    echo "nova: could not create $__nova_dir"
+    exit 1
+fi
+
+__nova_dest="$__nova_dir/nova-shell-integration.fish"
+
+cat > "$__nova_dest" <<'__NOVA_SNIPPET_EOF__'
+@@NOVA_SNIPPET@@
+__NOVA_SNIPPET_EOF__
+
+if [ ! -s "$__nova_dest" ]; then
+    echo "nova: could not write $__nova_dest"
+    exit 1
+fi
+
+echo "nova: wrote ~/.config/fish/conf.d/nova-shell-integration.fish"
+echo "nova: conf.d is sourced automatically - there is nothing to add to a config file."
+echo "nova: run  source ~/.config/fish/conf.d/nova-shell-integration.fish  to enable it in this session,"
+echo "nova: or open a new Nova session to this host."

--- a/assets/shell-integration/install/nova-install.ps1
+++ b/assets/shell-integration/install/nova-install.ps1
@@ -1,0 +1,46 @@
+# Nova Terminal remote shell integration installer (PowerShell).
+#
+# Decoded to a temp file by the one-liner Settings copies, invoked with the call operator (& ) so it
+# runs in a CHILD SCOPE - nothing it defines reaches your session - and then deleted. $PROFILE is
+# still visible here because it is an automatic variable in every scope.
+#
+# The parameters exist so this file is testable without touching the developer's real profile; the
+# generated one-liner passes none of them.
+
+param(
+    [string]$ProfilePath = $PROFILE,
+    [string]$DestDir = $HOME
+)
+
+$dest = Join-Path $DestDir '.nova-shell-integration.ps1'
+$snippet = @'
+@@NOVA_SNIPPET@@
+'@
+
+# WriteAllText with an explicit no-BOM UTF-8 rather than Set-Content -Encoding utf8NoBOM: that
+# parameter value does not exist on Windows PowerShell 5.1, and a remote host may be running it.
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[IO.File]::WriteAllText($dest, $snippet, $utf8NoBom)
+
+if (-not (Test-Path -LiteralPath $dest)) {
+    Write-Host "nova: could not write $dest"
+    exit 1
+}
+Write-Host 'nova: wrote ~/.nova-shell-integration.ps1'
+
+$loader = '. ~/.nova-shell-integration.ps1'
+$profileDir = Split-Path -Parent $ProfilePath
+if ($profileDir -and -not (Test-Path -LiteralPath $profileDir)) {
+    New-Item -ItemType Directory -Force -Path $profileDir | Out-Null
+}
+
+if ((Test-Path -LiteralPath $ProfilePath) -and
+    (Select-String -LiteralPath $ProfilePath -SimpleMatch 'nova-shell-integration' -Quiet)) {
+    Write-Host 'nova: loader line already present in $PROFILE - unchanged'
+} else {
+    Add-Content -LiteralPath $ProfilePath -Value $loader
+    Write-Host 'nova: added loader line to $PROFILE'
+}
+
+Write-Host 'nova: run  . ~/.nova-shell-integration.ps1  to enable it in this session,'
+Write-Host 'nova: or open a new Nova session to this host.'

--- a/assets/shell-integration/install/nova-install.ps1
+++ b/assets/shell-integration/install/nova-install.ps1
@@ -38,6 +38,18 @@ if ((Test-Path -LiteralPath $ProfilePath) -and
     (Select-String -LiteralPath $ProfilePath -SimpleMatch 'nova-shell-integration' -Quiet)) {
     Write-Host 'nova: loader line already present in $PROFILE - unchanged'
 } else {
+    # Add-Content appends at the exact end of the file with no separator of its own. A profile
+    # that does not end in a newline (common - many editors don't add one) would otherwise get the
+    # loader line concatenated onto the user's last line instead of appended as its own line. Skip
+    # this for a file that does not exist yet or is empty - Get-Content -Raw returns $null/empty
+    # there, so the check below is a no-op and the Add-Content further down creates the file.
+    if (Test-Path -LiteralPath $ProfilePath) {
+        $existingProfileContent = Get-Content -LiteralPath $ProfilePath -Raw -ErrorAction SilentlyContinue
+        if ($existingProfileContent -and
+            $existingProfileContent.Substring($existingProfileContent.Length - 1) -ne "`n") {
+            Add-Content -LiteralPath $ProfilePath -Value ''
+        }
+    }
     Add-Content -LiteralPath $ProfilePath -Value $loader
     Write-Host 'nova: added loader line to $PROFILE'
 }

--- a/assets/shell-integration/install/nova-install.ps1
+++ b/assets/shell-integration/install/nova-install.ps1
@@ -20,10 +20,12 @@ $snippet = @'
 # WriteAllText with an explicit no-BOM UTF-8 rather than Set-Content -Encoding utf8NoBOM: that
 # parameter value does not exist on Windows PowerShell 5.1, and a remote host may be running it.
 $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
-[IO.File]::WriteAllText($dest, $snippet, $utf8NoBom)
-
-if (-not (Test-Path -LiteralPath $dest)) {
-    Write-Host "nova: could not write $dest"
+try {
+    [IO.File]::WriteAllText($dest, $snippet, $utf8NoBom)
+} catch {
+    # try/catch rather than a Test-Path afterwards: WriteAllText throws on failure, so the file
+    # always exists by the time a Test-Path could run and the check could never fire.
+    Write-Host "nova: could not write $dest - $($_.Exception.Message)"
     exit 1
 }
 Write-Host 'nova: wrote ~/.nova-shell-integration.ps1'
@@ -34,25 +36,44 @@ if ($profileDir -and -not (Test-Path -LiteralPath $profileDir)) {
     New-Item -ItemType Directory -Force -Path $profileDir | Out-Null
 }
 
+$novaStatus = 0
+
+# A regex anchored to the start of a non-comment line rather than -SimpleMatch anywhere in the
+# file. The marker is the file name, so a hand-typed variant of the loader line still counts, but
+# a profile whose only mention is a comment - a previous attempt commented out, or a note to self -
+# must not be read as "already installed" and left without a loader line. '#' is PowerShell's
+# comment character too, so this is the same rule the sh installer applies.
 if ((Test-Path -LiteralPath $ProfilePath) -and
-    (Select-String -LiteralPath $ProfilePath -SimpleMatch 'nova-shell-integration' -Quiet)) {
-    Write-Host 'nova: loader line already present in $PROFILE - unchanged'
+    (Select-String -LiteralPath $ProfilePath -Pattern '^[^#]*nova-shell-integration' -Quiet)) {
+    Write-Host "nova: loader line already present in $ProfilePath - unchanged"
 } else {
     # Add-Content appends at the exact end of the file with no separator of its own. A profile
     # that does not end in a newline (common - many editors don't add one) would otherwise get the
     # loader line concatenated onto the user's last line instead of appended as its own line. Skip
     # this for a file that does not exist yet or is empty - Get-Content -Raw returns $null/empty
     # there, so the check below is a no-op and the Add-Content further down creates the file.
-    if (Test-Path -LiteralPath $ProfilePath) {
-        $existingProfileContent = Get-Content -LiteralPath $ProfilePath -Raw -ErrorAction SilentlyContinue
-        if ($existingProfileContent -and
-            $existingProfileContent.Substring($existingProfileContent.Length - 1) -ne "`n") {
-            Add-Content -LiteralPath $ProfilePath -Value ''
+    #
+    # -ErrorAction Stop on both appends. Add-Content's default is Continue: a profile the user
+    # cannot write - read-only, ACL-denied, a directory in the way, a full disk - reports the
+    # error and lets the script carry on to print "added loader line" over the top of it, which
+    # sends the user looking in the right file for a line that was never written.
+    try {
+        if (Test-Path -LiteralPath $ProfilePath) {
+            $existingProfileContent = Get-Content -LiteralPath $ProfilePath -Raw -ErrorAction SilentlyContinue
+            if ($existingProfileContent -and
+                $existingProfileContent.Substring($existingProfileContent.Length - 1) -ne "`n") {
+                Add-Content -LiteralPath $ProfilePath -Value '' -ErrorAction Stop
+            }
         }
+        Add-Content -LiteralPath $ProfilePath -Value $loader -ErrorAction Stop
+        Write-Host "nova: added loader line to $ProfilePath"
+    } catch {
+        Write-Host "nova: could not write $ProfilePath - add this line to it by hand:"
+        Write-Host "nova:   $loader"
+        $novaStatus = 1
     }
-    Add-Content -LiteralPath $ProfilePath -Value $loader
-    Write-Host 'nova: added loader line to $PROFILE'
 }
 
 Write-Host 'nova: run  . ~/.nova-shell-integration.ps1  to enable it in this session,'
 Write-Host 'nova: or open a new Nova session to this host.'
+exit $novaStatus

--- a/assets/shell-integration/install/nova-install.sh
+++ b/assets/shell-integration/install/nova-install.sh
@@ -43,22 +43,41 @@ esac
 
 __nova_loader='[ -f ~/.nova-shell-integration.sh ] && . ~/.nova-shell-integration.sh'
 
+__nova_status=0
+
 if [ -z "$__nova_rc" ]; then
     echo "nova: could not tell which shell you use - add this line to your rc file:"
     echo "nova:   $__nova_loader"
-elif [ -f "$__nova_rc" ] && grep -q 'nova-shell-integration' "$__nova_rc" 2>/dev/null; then
+# '^[^#]*' rather than a bare substring match: the marker is the file name, so a hand-typed
+# variant of the loader line still counts, but a rc file whose only mention is a comment - a
+# previous attempt commented out, or a note to self - must not be read as "already installed"
+# and left without a loader line while the installer reports success.
+elif [ -f "$__nova_rc" ] && grep -q '^[^#]*nova-shell-integration' "$__nova_rc" 2>/dev/null; then
     echo "nova: loader line already present in $__nova_rc_display - unchanged"
 else
     # A rc file that does not end in a newline (common - many editors don't add one) would
     # otherwise get the loader line concatenated onto its last line instead of appended as its
     # own line. Guarded for the common case where the file does not exist yet: tail on a missing
     # file prints nothing to stdout, so this is a no-op and >> below creates it.
+    #
+    # Both appends are status-checked. A rc file the user cannot write - root-owned, chattr +i,
+    # a read-only $HOME on NFS or in a container, a full disk - makes >> fail while the shell
+    # carries on to the next command, so an unchecked append prints "added loader line" over the
+    # top of the real error and sends the user looking in the right file for a line that was
+    # never written.
+    __nova_appended=1
     if [ -f "$__nova_rc" ] && [ -n "$(tail -c1 "$__nova_rc" 2>/dev/null)" ]; then
-        printf '\n' >> "$__nova_rc"
+        printf '\n' >> "$__nova_rc" || __nova_appended=
     fi
-    printf '%s\n' "$__nova_loader" >> "$__nova_rc"
-    echo "nova: added loader line to $__nova_rc_display"
+    if [ -n "$__nova_appended" ] && printf '%s\n' "$__nova_loader" >> "$__nova_rc"; then
+        echo "nova: added loader line to $__nova_rc_display"
+    else
+        echo "nova: could not write $__nova_rc_display - add this line to it by hand:"
+        echo "nova:   $__nova_loader"
+        __nova_status=1
+    fi
 fi
 
 echo "nova: run  . ~/.nova-shell-integration.sh  to enable it in this session,"
 echo "nova: or open a new Nova session to this host."
+exit $__nova_status

--- a/assets/shell-integration/install/nova-install.sh
+++ b/assets/shell-integration/install/nova-install.sh
@@ -49,6 +49,13 @@ if [ -z "$__nova_rc" ]; then
 elif [ -f "$__nova_rc" ] && grep -q 'nova-shell-integration' "$__nova_rc" 2>/dev/null; then
     echo "nova: loader line already present in $__nova_rc_display - unchanged"
 else
+    # A rc file that does not end in a newline (common - many editors don't add one) would
+    # otherwise get the loader line concatenated onto its last line instead of appended as its
+    # own line. Guarded for the common case where the file does not exist yet: tail on a missing
+    # file prints nothing to stdout, so this is a no-op and >> below creates it.
+    if [ -f "$__nova_rc" ] && [ -n "$(tail -c1 "$__nova_rc" 2>/dev/null)" ]; then
+        printf '\n' >> "$__nova_rc"
+    fi
     printf '%s\n' "$__nova_loader" >> "$__nova_rc"
     echo "nova: added loader line to $__nova_rc_display"
 fi

--- a/assets/shell-integration/install/nova-install.sh
+++ b/assets/shell-integration/install/nova-install.sh
@@ -47,7 +47,7 @@ if [ -z "$__nova_rc" ]; then
     echo "nova: could not tell which shell you use - add this line to your rc file:"
     echo "nova:   $__nova_loader"
 elif [ -f "$__nova_rc" ] && grep -q 'nova-shell-integration' "$__nova_rc" 2>/dev/null; then
-    echo "nova: loader line already in $__nova_rc_display - unchanged"
+    echo "nova: loader line already present in $__nova_rc_display - unchanged"
 else
     printf '%s\n' "$__nova_loader" >> "$__nova_rc"
     echo "nova: added loader line to $__nova_rc_display"

--- a/assets/shell-integration/install/nova-install.sh
+++ b/assets/shell-integration/install/nova-install.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# Nova Terminal remote shell integration installer (bash and zsh).
+#
+# Settings copies a one-line command that decodes this file into a temp file, runs it as a CHILD
+# process, and deletes it. It is deliberately never sourced into your interactive shell: $1 carries
+# the shell name, expanded by the live shell inside that one-liner, so nothing has to be sourced to
+# find out which rc file to patch, and nothing this file defines can leak into your session.
+#
+# It writes ~/.nova-shell-integration.sh, adds the loader line to the matching rc file if it is not
+# already there, and prints what it did. Running it twice changes nothing the second time.
+
+__nova_shell="$1"
+if [ -z "$__nova_shell" ]; then
+    __nova_shell=$(basename "${SHELL:-}" 2>/dev/null)
+fi
+
+__nova_dest="$HOME/.nova-shell-integration.sh"
+
+cat > "$__nova_dest" <<'__NOVA_SNIPPET_EOF__'
+@@NOVA_SNIPPET@@
+__NOVA_SNIPPET_EOF__
+
+if [ ! -s "$__nova_dest" ]; then
+    echo "nova: could not write $__nova_dest"
+    exit 1
+fi
+echo "nova: wrote ~/.nova-shell-integration.sh"
+
+case "$__nova_shell" in
+    zsh)
+        __nova_rc="$HOME/.zshrc"
+        __nova_rc_display="~/.zshrc"
+        ;;
+    bash)
+        __nova_rc="$HOME/.bashrc"
+        __nova_rc_display="~/.bashrc"
+        ;;
+    *)
+        __nova_rc=""
+        __nova_rc_display=""
+        ;;
+esac
+
+__nova_loader='[ -f ~/.nova-shell-integration.sh ] && . ~/.nova-shell-integration.sh'
+
+if [ -z "$__nova_rc" ]; then
+    echo "nova: could not tell which shell you use - add this line to your rc file:"
+    echo "nova:   $__nova_loader"
+elif [ -f "$__nova_rc" ] && grep -q 'nova-shell-integration' "$__nova_rc" 2>/dev/null; then
+    echo "nova: loader line already in $__nova_rc_display - unchanged"
+else
+    printf '%s\n' "$__nova_loader" >> "$__nova_rc"
+    echo "nova: added loader line to $__nova_rc_display"
+fi
+
+echo "nova: run  . ~/.nova-shell-integration.sh  to enable it in this session,"
+echo "nova: or open a new Nova session to this host."

--- a/docs/command-assist/RemoteShellIntegration.md
+++ b/docs/command-assist/RemoteShellIntegration.md
@@ -40,18 +40,55 @@ nova: run  . ~/.nova-shell-integration.sh  to enable it in this session,
 nova: or open a new Nova session to this host.
 ```
 
-One line and one history entry, rather than the 300-line paste this replaced. The line decodes a
+One line and one history entry, rather than a 300-line paste. The line decodes a
 gzipped copy of the snippet into a temp file, runs it as a **child process**, and deletes it. It
 never sources anything into your live shell: the shell's identity is expanded by your shell and
 handed to the installer as an argument, so it knows whether to patch `~/.bashrc` or `~/.zshrc`
 without touching your session. Running it twice changes nothing the second time — the loader line is
-added only if it isn't already there, including when you placed it by hand.
+added only if it isn't already there, including when you placed it by hand. A line that only
+*mentions* the file inside a comment does not count as already there.
+
+If it cannot write your rc file — root-owned, `chattr +i`, a read-only `$HOME`, a full disk — it
+says so, prints the loader line for you to add by hand, and exits non-zero. It never reports a
+change it did not make.
 
 Integration starts with your next session to that host. The third line above is there if you want it
 sooner in the shell you pasted into.
 
 fish needs no loader line at all: its snippet goes to `~/.config/fish/conf.d/`, which fish sources
 automatically.
+
+### The 4096-byte paste limit
+
+The one line is about 8.5 KB for bash/zsh and for pwsh. A tty in **canonical mode** discards
+everything past 4096 bytes of a single line (`N_TTY_BUF_SIZE`), so on those hosts those two lines do
+not survive the paste. fish's is under 4 KB (its snippet is a third the size) and is not affected.
+
+Interactive bash, zsh and fish put the tty in raw mode — readline, ZLE, fish's own reader — so a
+normal SSH session to a normal login shell is fine, which is the case you will hit almost every
+time. Canonical mode is what you get at `docker exec -it <c> sh`, on busybox/Alpine `ash`, with
+`dash` as `/bin/sh`, on serial and IPMI consoles, and in pwsh without PSReadLine.
+
+**What it looks like when it happens.** The base64 payload starts at byte 9 or 10 of the line and
+runs past byte 7500, so a cut at 4096 always lands in the middle of it and takes the closing quote
+with it. Your shell therefore rejects the line outright — nothing of Nova's runs, nothing is
+written, and there is no `nova:` message:
+
+```
+bash: unexpected EOF while looking for matching `''
+```
+
+bash and zsh may instead sit at a `>` continuation prompt waiting for the quote to be closed; press
+Ctrl-C. pwsh says `The string is missing the terminator: '.`
+
+The fix on such a host is **Copy plain snippet**, or paste the one line into a file and run the
+file.
+
+The one-liner *does* carry its own payload length and check it before decoding, but that guard is
+for a different failure: bytes lost from the **middle** of the line while the end still arrives — a
+flaky link, a multiplexer dropping a chunk of a paste. There it reports `nova: install failed - the
+pasted line was cut short (N of M payload characters)` instead of blaming `base64`/`gzip` for a
+decode failure they did not cause.
 
 ### Placing the file yourself
 
@@ -135,6 +172,27 @@ path reads the parser's mark directly and predates the switch having a remote me
 
 ## Threat model
 
+**What you are pasting.** The installer line carries the whole snippet inline, gzipped and
+base64-encoded. There is no `curl`, no `wget`, no URL and no network fetch: nothing is downloaded at
+paste time, so there is no window between copying the line and running it in which a server, a CDN,
+a DNS answer or a TLS interception could substitute different content, and it works on a host with
+no outbound network at all. That is a real property and it is worth having.
+
+It is also the whole of the mitigation, and it is worth being plain about what it does not cover.
+What you paste is an ~8 KB opaque blob, and there is nothing on the remote host — or in the pasted
+line — that lets you check it against the reviewable sources in `assets/shell-integration/install/`
+and `assets/shell-integration/`. There is no checksum you can compare, because a checksum shipped
+alongside the blob by the same build is not evidence. You are trusting the Nova build that produced
+the clipboard contents, exactly as much as you would trust a script it downloaded for you, minus the
+network. Pasting opaque blobs into production servers is a habit worth being deliberate about, and
+this feature does encourage it.
+
+If that trade is wrong for a particular host, **Copy plain snippet** puts the readable file on the
+clipboard instead. It is the same content, in a form you can read before you run it and diff against
+the repository, and the rest of what the installer does is two commands you can do by hand: write
+the file, add one loader line to your rc file (the exact line is in the row next to the button, and
+above in this page).
+
 **What an instrumented remote session lets the far end do.** OSC 133 marks are bytes on the pane's
 output stream, and nothing about a byte stream says who wrote it. On an SSH session that means the
 remote host — or anything running on it, or anything that can get output onto that stream — can
@@ -180,6 +238,23 @@ once there is a second reason to touch the suggestion row rendering.
 
 ## Troubleshooting
 
+- **The paste produced an unmatched-quote error, or the shell sits at a `>` prompt.** The host's tty
+  is in canonical mode and cut the line at 4096 bytes — see
+  [The 4096-byte paste limit](#the-4096-byte-paste-limit). Nothing was written; nothing of Nova's
+  ran.
+- **`nova: install failed - the pasted line was cut short`.** Different failure: the line arrived
+  but with bytes missing from the middle. Retry the paste; if it keeps happening the transport is
+  dropping data.
+- **`nova: install failed - this host needs a working base64 and gzip`.** This one means what it
+  says — the host could not decode the payload (on bash/zsh and pwsh its length was checked first,
+  so it did arrive whole).
+  busybox and coreutils both provide `base64` and `gzip`; a hardened `$PATH` that hides them is the
+  other common cause. Use **Copy plain snippet** if you would rather not install anything.
+- **`nova: install failed - mktemp could not create a temp file`.** No `mktemp` on the host, or
+  `$TMPDIR` is unwritable or mounted `noexec`. There is deliberately no fallback temp path: a
+  predictable name in `/tmp` is a symlink attack on a shared host.
+- **`nova: could not write ~/.bashrc - add this line to it by hand`.** The snippet was written; only
+  the rc edit failed. Add the line it printed, or fix the rc file's permissions and re-run.
 - **Nothing changed.** Marks only take effect on a *new* session; sourcing the snippet into a shell
   Nova is already attached to works, but the prompt has to repaint at least once for `B` to land.
 - **Suggestions appear but history stays empty.** Check `CommandAssistHistoryEnabled`; capture is

--- a/docs/command-assist/RemoteShellIntegration.md
+++ b/docs/command-assist/RemoteShellIntegration.md
@@ -30,49 +30,35 @@ sidebar's problem and not this one.
 ## Install
 
 Settings → **Command assistant** → **Remote shell integration**: pick the remote shell, press
-**Copy snippet**. The whole snippet goes on your clipboard; the row then tells you the two commands
-to run. The snippet repeats the same instructions in its own header comment, so they survive the
-trip to the remote host.
+**Copy installer**, paste the one line at the prompt on that host, press Enter. It prints what it
+did:
 
-### bash and zsh
-
-One file covers both; it dispatches on `$BASH_VERSION` / `$ZSH_VERSION` when it loads.
-
-```sh
-cat > ~/.nova-shell-integration.sh
-# ...paste, then press Ctrl-D...
-
-# bash:
-echo '[ -f ~/.nova-shell-integration.sh ] && . ~/.nova-shell-integration.sh' >> ~/.bashrc
-# zsh:
-echo '[ -f ~/.nova-shell-integration.sh ] && . ~/.nova-shell-integration.sh' >> ~/.zshrc
+```
+nova: wrote ~/.nova-shell-integration.sh
+nova: added loader line to ~/.zshrc
+nova: run  . ~/.nova-shell-integration.sh  to enable it in this session,
+nova: or open a new Nova session to this host.
 ```
 
-Then open a new Nova session to that host.
+One line and one history entry, rather than the 300-line paste this replaced. The line decodes a
+gzipped copy of the snippet into a temp file, runs it as a **child process**, and deletes it. It
+never sources anything into your live shell: the shell's identity is expanded by your shell and
+handed to the installer as an argument, so it knows whether to patch `~/.bashrc` or `~/.zshrc`
+without touching your session. Running it twice changes nothing the second time — the loader line is
+added only if it isn't already there, including when you placed it by hand.
 
-### fish
+Integration starts with your next session to that host. The third line above is there if you want it
+sooner in the shell you pasted into.
 
-fish is not POSIX sh — `case`, `$-`, `local`, function and array syntax all differ — so it gets its
-own file rather than a branch in the sh one.
+fish needs no loader line at all: its snippet goes to `~/.config/fish/conf.d/`, which fish sources
+automatically.
 
-```fish
-mkdir -p ~/.config/fish/conf.d
-cat > ~/.config/fish/conf.d/nova-shell-integration.fish
-# ...paste, then press Ctrl-D...
-```
+### Placing the file yourself
 
-`conf.d` is auto-sourced, so there is no loader line to add.
-
-### PowerShell
-
-```powershell
-cat > ~/.nova-shell-integration.ps1
-# ...paste, then press Ctrl-D...
-Add-Content $PROFILE '. ~/.nova-shell-integration.ps1'
-```
-
-`$PROFILE`'s directory may not exist yet:
-`New-Item -ItemType Directory -Force -Path (Split-Path $PROFILE)`.
+**Copy plain snippet** puts the whole file on the clipboard instead, and the row tells you where it
+goes. That is the path for a dotfiles repo, `/etc/profile.d`, or reading the snippet before you
+trust it — the installers themselves are readable files in the repository under
+`assets/shell-integration/install/`.
 
 ## What the snippets promise
 

--- a/src/NovaTerminal.App/SettingsWindow.axaml
+++ b/src/NovaTerminal.App/SettingsWindow.axaml
@@ -884,12 +884,13 @@
                             <Grid ColumnDefinitions="*,360">
                                 <StackPanel Grid.Column="0" Spacing="2">
                                     <TextBlock Classes="RowLabel" Text="Remote shell integration"/>
-                                    <TextBlock Classes="RowDesc" TextWrapping="Wrap" Text="Nova cannot install shell integration over SSH. Copy the snippet for the remote shell, paste it on the host, and the command assistant works there too: history, suggestions read from the prompt line, exit codes and prompt-anchored placement. Filesystem path suggestions stay off for remote sessions - they would list the local disk."/>
+                                    <TextBlock Classes="RowDesc" TextWrapping="Wrap" Text="Nova cannot install shell integration over SSH. Copy the one-line installer for the remote shell, paste it at the prompt on that host, and the command assistant works there too: history, suggestions read from the prompt line, exit codes and prompt-anchored placement. Filesystem path suggestions stay off for remote sessions - they would list the local disk."/>
                                     <TextBlock Name="RemoteShellIntegrationStatus" Classes="RowDesc" TextWrapping="Wrap" Text="" IsVisible="False"/>
                                 </StackPanel>
                                 <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Spacing="6">
                                     <ComboBox Name="RemoteShellIntegrationShellList" MinWidth="150"/>
-                                    <Button Name="BtnCopyRemoteShellIntegration" Classes="Pill" Content="Copy snippet"/>
+                                    <Button Name="BtnCopyRemoteShellIntegration" Classes="Pill" Content="Copy installer"/>
+                                    <Button Name="BtnCopyRemoteShellIntegrationSnippet" Classes="Pill" Content="Copy plain snippet"/>
                                 </StackPanel>
                             </Grid>
                         </StackPanel>

--- a/src/NovaTerminal.App/SettingsWindow.axaml.cs
+++ b/src/NovaTerminal.App/SettingsWindow.axaml.cs
@@ -1533,9 +1533,9 @@ namespace NovaTerminal
         /// The primary action: one line the user pastes at the remote prompt.
         /// </summary>
         /// <remarks>
-        /// The status text describes what the paste does rather than what the user must do next,
-        /// because after this change there is no next step - the installer writes the snippet and
-        /// patches the rc file itself. It deliberately does not promise the current session becomes
+        /// The status text describes what the paste does rather than what the user must do next:
+        /// the installer writes the snippet and patches the rc file itself, so there is no next
+        /// step to describe. It deliberately does not promise the current session becomes
         /// integrated: the installer runs as a child process and never touches the live shell, so
         /// marks arrive with the next session.
         /// </remarks>

--- a/src/NovaTerminal.App/SettingsWindow.axaml.cs
+++ b/src/NovaTerminal.App/SettingsWindow.axaml.cs
@@ -1553,12 +1553,19 @@ namespace NovaTerminal
                 }
 
                 await clipboard.SetTextAsync(RemoteShellIntegrationSnippets.BuildInstallerCommand(shell));
+
+                string? loaderLine = RemoteShellIntegrationSnippets.GetLoaderLine(shell);
+                string writeDescription = loaderLine != null
+                    ? $"It writes {RemoteShellIntegrationSnippets.GetRemotePath(shell)} and adds the loader " +
+                      "line to your rc file if it isn't already there."
+                    : $"It writes {RemoteShellIntegrationSnippets.GetRemotePath(shell)}, which is sourced " +
+                      "automatically, so there is nothing else to add.";
+
                 ShowRemoteShellIntegrationStatus(
                     status,
                     $"Copied the installer for {RemoteShellIntegrationSnippets.GetDisplayName(shell)}. " +
-                    "Paste it at the remote prompt and press Enter - one line, one history entry. It writes " +
-                    $"{RemoteShellIntegrationSnippets.GetRemotePath(shell)} and adds the loader line to your " +
-                    "config file if it isn't already there.");
+                    "Paste it at the remote prompt and press Enter - one line, one history entry. " +
+                    writeDescription);
             }
             catch (Exception ex)
             {

--- a/src/NovaTerminal.App/SettingsWindow.axaml.cs
+++ b/src/NovaTerminal.App/SettingsWindow.axaml.cs
@@ -1497,9 +1497,10 @@ namespace NovaTerminal
         private void WireRemoteShellIntegrationRow()
         {
             var shellList = this.FindControl<ComboBox>("RemoteShellIntegrationShellList");
-            var copyButton = this.FindControl<Button>("BtnCopyRemoteShellIntegration");
+            var copyInstallerButton = this.FindControl<Button>("BtnCopyRemoteShellIntegration");
+            var copySnippetButton = this.FindControl<Button>("BtnCopyRemoteShellIntegrationSnippet");
             var status = this.FindControl<TextBlock>("RemoteShellIntegrationStatus");
-            if (shellList == null || copyButton == null)
+            if (shellList == null || copyInstallerButton == null)
             {
                 return;
             }
@@ -1509,16 +1510,62 @@ namespace NovaTerminal
                 .ToList();
             shellList.SelectedIndex = 0;
 
-            copyButton.Click += async (_, _) =>
+            RemoteShellIntegrationShell SelectedShell()
             {
                 int index = Math.Clamp(
                     shellList.SelectedIndex,
                     0,
                     RemoteShellIntegrationSnippets.All.Count - 1);
-                await CopyRemoteShellIntegrationSnippetAsync(
-                    RemoteShellIntegrationSnippets.All[index],
-                    status);
-            };
+                return RemoteShellIntegrationSnippets.All[index];
+            }
+
+            copyInstallerButton.Click += async (_, _) =>
+                await CopyRemoteShellIntegrationInstallerAsync(SelectedShell(), status);
+
+            if (copySnippetButton != null)
+            {
+                copySnippetButton.Click += async (_, _) =>
+                    await CopyRemoteShellIntegrationSnippetAsync(SelectedShell(), status);
+            }
+        }
+
+        /// <summary>
+        /// The primary action: one line the user pastes at the remote prompt.
+        /// </summary>
+        /// <remarks>
+        /// The status text describes what the paste does rather than what the user must do next,
+        /// because after this change there is no next step - the installer writes the snippet and
+        /// patches the rc file itself. It deliberately does not promise the current session becomes
+        /// integrated: the installer runs as a child process and never touches the live shell, so
+        /// marks arrive with the next session.
+        /// </remarks>
+        private async System.Threading.Tasks.Task CopyRemoteShellIntegrationInstallerAsync(
+            RemoteShellIntegrationShell shell,
+            TextBlock? status)
+        {
+            try
+            {
+                var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+                if (clipboard == null)
+                {
+                    ShowRemoteShellIntegrationStatus(status, "Clipboard is not available.");
+                    return;
+                }
+
+                await clipboard.SetTextAsync(RemoteShellIntegrationSnippets.BuildInstallerCommand(shell));
+                ShowRemoteShellIntegrationStatus(
+                    status,
+                    $"Copied the installer for {RemoteShellIntegrationSnippets.GetDisplayName(shell)}. " +
+                    "Paste it at the remote prompt and press Enter - one line, one history entry. It writes " +
+                    $"{RemoteShellIntegrationSnippets.GetRemotePath(shell)} and adds the loader line to your " +
+                    "config file if it isn't already there.");
+            }
+            catch (Exception ex)
+            {
+                // Reported in the row rather than swallowed: the whole point of the affordance is
+                // that the user now has the installer, and silently not having it looks identical.
+                ShowRemoteShellIntegrationStatus(status, $"Could not copy the installer: {ex.Message}");
+            }
         }
 
         private async System.Threading.Tasks.Task CopyRemoteShellIntegrationSnippetAsync(

--- a/src/NovaTerminal.CommandAssist/NovaTerminal.CommandAssist.csproj
+++ b/src/NovaTerminal.CommandAssist/NovaTerminal.CommandAssist.csproj
@@ -25,6 +25,8 @@
                       LogicalName="NovaTerminal.CommandAssist.ShellIntegration.Remote.nova-install.sh" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\..\assets\shell-integration\install\nova-install-fish.sh"
                       LogicalName="NovaTerminal.CommandAssist.ShellIntegration.Remote.nova-install-fish.sh" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\..\assets\shell-integration\install\nova-install.ps1"
+                      LogicalName="NovaTerminal.CommandAssist.ShellIntegration.Remote.nova-install.ps1" />
   </ItemGroup>
 
   <!-- Bundled offline command-knowledge catalogue (V2 Phase 4b, closes #250). Generated from a

--- a/src/NovaTerminal.CommandAssist/NovaTerminal.CommandAssist.csproj
+++ b/src/NovaTerminal.CommandAssist/NovaTerminal.CommandAssist.csproj
@@ -23,6 +23,8 @@
                       LogicalName="NovaTerminal.CommandAssist.ShellIntegration.Remote.nova-shell-integration.ps1" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\..\assets\shell-integration\install\nova-install.sh"
                       LogicalName="NovaTerminal.CommandAssist.ShellIntegration.Remote.nova-install.sh" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\..\assets\shell-integration\install\nova-install-fish.sh"
+                      LogicalName="NovaTerminal.CommandAssist.ShellIntegration.Remote.nova-install-fish.sh" />
   </ItemGroup>
 
   <!-- Bundled offline command-knowledge catalogue (V2 Phase 4b, closes #250). Generated from a

--- a/src/NovaTerminal.CommandAssist/NovaTerminal.CommandAssist.csproj
+++ b/src/NovaTerminal.CommandAssist/NovaTerminal.CommandAssist.csproj
@@ -21,6 +21,8 @@
                       LogicalName="NovaTerminal.CommandAssist.ShellIntegration.Remote.nova-shell-integration.fish" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\..\assets\shell-integration\nova-shell-integration.ps1"
                       LogicalName="NovaTerminal.CommandAssist.ShellIntegration.Remote.nova-shell-integration.ps1" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\..\assets\shell-integration\install\nova-install.sh"
+                      LogicalName="NovaTerminal.CommandAssist.ShellIntegration.Remote.nova-install.sh" />
   </ItemGroup>
 
   <!-- Bundled offline command-knowledge catalogue (V2 Phase 4b, closes #250). Generated from a

--- a/src/NovaTerminal.CommandAssist/ShellIntegration/Remote/RemoteShellIntegrationSnippets.cs
+++ b/src/NovaTerminal.CommandAssist/ShellIntegration/Remote/RemoteShellIntegrationSnippets.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Reflection;
 using System.Text;
 
@@ -61,18 +62,21 @@ public static class RemoteShellIntegrationSnippets
         {
             [RemoteShellIntegrationShell.BashOrZsh] = new(
                 FileName: "nova-shell-integration.sh",
+                InstallerFileName: "nova-install.sh",
                 DisplayName: "bash / zsh",
                 RemotePath: "~/.nova-shell-integration.sh",
                 LoaderLine: "[ -f ~/.nova-shell-integration.sh ] && . ~/.nova-shell-integration.sh",
                 LoaderTarget: "~/.bashrc (bash) or ~/.zshrc (zsh)"),
             [RemoteShellIntegrationShell.Fish] = new(
                 FileName: "nova-shell-integration.fish",
+                InstallerFileName: "nova-install-fish.sh",
                 DisplayName: "fish",
                 RemotePath: "~/.config/fish/conf.d/nova-shell-integration.fish",
                 LoaderLine: null,
                 LoaderTarget: null),
             [RemoteShellIntegrationShell.PowerShell] = new(
                 FileName: "nova-shell-integration.ps1",
+                InstallerFileName: "nova-install.ps1",
                 DisplayName: "PowerShell",
                 RemotePath: "~/.nova-shell-integration.ps1",
                 LoaderLine: ". ~/.nova-shell-integration.ps1",
@@ -106,33 +110,126 @@ public static class RemoteShellIntegrationSnippets
     public static string? GetLoaderTarget(RemoteShellIntegrationShell shell) => Get(shell).LoaderTarget;
 
     /// <summary>
-    /// The snippet text, exactly as shipped. This is what the Settings "Copy snippet" action puts on
-    /// the clipboard: the whole file, install instructions included in its header comment, so a user
-    /// who pastes it into <c>cat &gt; ...</c> and forgets the rest can read what to do next out of
-    /// the file they just wrote.
+    /// The snippet text, exactly as shipped, backing the "Copy plain snippet" action. This is the
+    /// whole file, install instructions included in its header comment, so a user who pastes it into
+    /// <c>cat &gt; ...</c> and forgets the rest can read what to do next out of the file they just
+    /// wrote.
     /// </summary>
     /// <remarks>
     /// Line endings are normalized to LF. The snippet is destined for a POSIX shell (or a pwsh that
     /// does not care), and a CRLF that survives a Windows checkout with
     /// <c>core.autocrlf=true</c> would give bash <c>$'\r': command not found</c> on every line.
     /// </remarks>
-    public static string Read(RemoteShellIntegrationShell shell)
+    public static string Read(RemoteShellIntegrationShell shell) => ReadResource(Get(shell).FileName);
+
+    /// <summary>
+    /// The one-line command Settings' "Copy installer" action puts on the clipboard.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// One line, because one line is one history entry and one prompt cycle. The 300-line paste this
+    /// replaced flooded the scrollback, was slow to redraw in any shell with syntax highlighting,
+    /// left the rc edit as a manual step users forget, and on a Windows remote could not work at all
+    /// (<c>cat</c> there is an alias for <c>Get-Content</c>, so <c>cat &gt; file</c> has no input).
+    /// </para>
+    /// <para>
+    /// The payload is gzip+base64: 6.4 KB instead of 17.0 KB for the bash/zsh snippet, and base64's
+    /// alphabet contains no shell metacharacter, so the single quotes around it can never need
+    /// escaping. It decodes to an installer script that runs as a <em>child process</em> - the live
+    /// shell is never sourced into, and the shell's identity reaches the installer as an argument
+    /// the live shell expanded.
+    /// </para>
+    /// <para>
+    /// This reverses the argument the class used to make against generated installers, which was
+    /// that a blob cannot be read before it runs. It is answered instead by the installers being
+    /// reviewable files under <c>assets/shell-integration/install/</c> and by
+    /// <see cref="Read"/> still backing a "Copy plain snippet" action in the same row.
+    /// </para>
+    /// </remarks>
+    public static string BuildInstallerCommand(RemoteShellIntegrationShell shell)
+    {
+        string blob = Compress(BuildInstallerScript(shell));
+
+        string template = shell switch
+        {
+            RemoteShellIntegrationShell.BashOrZsh =>
+                """
+                __nova_t=$(mktemp 2>/dev/null || printf /tmp/nova-si.%s "$$"); printf %s '@@BLOB@@' | base64 -d 2>/dev/null | gzip -dc 2>/dev/null > "$__nova_t"; if [ -s "$__nova_t" ]; then sh "$__nova_t" "${ZSH_VERSION:+zsh}${BASH_VERSION:+bash}"; else echo "nova: install failed - this host needs base64 and gzip"; fi; rm -f "$__nova_t"; unset __nova_t
+                """,
+            _ => throw new ArgumentOutOfRangeException(nameof(shell), shell, "No installer ships for this shell."),
+        };
+
+        return template.Replace("@@BLOB@@", blob, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The installer script the one-liner's payload decodes to: the template for
+    /// <paramref name="shell"/> with its snippet substituted in.
+    /// </summary>
+    /// <remarks>
+    /// Internal because the round-trip test needs the expectation. The delimiter guard is not
+    /// defensive noise: a snippet line that collided with the heredoc terminator would silently
+    /// truncate the installed file rather than fail, and the failure would surface on the user's
+    /// remote host rather than here.
+    /// </remarks>
+    internal static string BuildInstallerScript(RemoteShellIntegrationShell shell) =>
+        BuildInstallerScript(shell, ReadResource(Get(shell).FileName));
+
+    /// <summary>
+    /// <see cref="BuildInstallerScript(RemoteShellIntegrationShell)"/> with the snippet supplied.
+    /// </summary>
+    /// <remarks>
+    /// The overload exists for the delimiter-guard test: no shipped snippet collides, and one that
+    /// did would be a bug found on a user's remote host rather than here.
+    /// </remarks>
+    internal static string BuildInstallerScript(RemoteShellIntegrationShell shell, string snippet)
     {
         SnippetDescriptor descriptor = Get(shell);
-        string resourceName = ResourcePrefix + descriptor.FileName;
+        string template = ReadResource(descriptor.InstallerFileName);
+
+        const string Delimiter = "__NOVA_SNIPPET_EOF__";
+        foreach (string line in snippet.Split('\n'))
+        {
+            if (line.StartsWith(Delimiter, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Snippet '{descriptor.FileName}' contains a line starting with the installer's " +
+                    $"heredoc delimiter '{Delimiter}', which would truncate the installed file. " +
+                    "Rename the delimiter in the installer template.");
+            }
+        }
+
+        return template.Replace("@@NOVA_SNIPPET@@", snippet.TrimEnd('\n'), StringComparison.Ordinal);
+    }
+
+    private static string ReadResource(string fileName)
+    {
+        string resourceName = ResourcePrefix + fileName;
 
         using Stream? stream = typeof(RemoteShellIntegrationSnippets).Assembly
             .GetManifestResourceStream(resourceName);
         if (stream == null)
         {
             throw new InvalidOperationException(
-                $"Embedded shell-integration snippet '{resourceName}' is missing from " +
+                $"Embedded shell-integration resource '{resourceName}' is missing from " +
                 $"{typeof(RemoteShellIntegrationSnippets).Assembly.GetName().Name}. It is embedded " +
                 "from assets/shell-integration/ by NovaTerminal.CommandAssist.csproj.");
         }
 
         using var reader = new StreamReader(stream, Encoding.UTF8);
         return reader.ReadToEnd().Replace("\r\n", "\n");
+    }
+
+    private static string Compress(string text)
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes(text);
+        using var output = new MemoryStream();
+        using (var gzip = new GZipStream(output, CompressionLevel.SmallestSize, leaveOpen: true))
+        {
+            gzip.Write(bytes, 0, bytes.Length);
+        }
+
+        return Convert.ToBase64String(output.ToArray());
     }
 
     /// <summary>
@@ -192,6 +289,7 @@ public static class RemoteShellIntegrationSnippets
 
     private sealed record SnippetDescriptor(
         string FileName,
+        string InstallerFileName,
         string DisplayName,
         string RemotePath,
         string? LoaderLine,

--- a/src/NovaTerminal.CommandAssist/ShellIntegration/Remote/RemoteShellIntegrationSnippets.cs
+++ b/src/NovaTerminal.CommandAssist/ShellIntegration/Remote/RemoteShellIntegrationSnippets.cs
@@ -160,6 +160,10 @@ public static class RemoteShellIntegrationSnippets
                 """
                 set -l __nova_t (mktemp); printf %s '@@BLOB@@' | base64 -d | gzip -dc > $__nova_t; sh $__nova_t fish; rm -f $__nova_t; set -e __nova_t
                 """,
+            RemoteShellIntegrationShell.PowerShell =>
+                """
+                $__nova_t=[IO.Path]::GetTempPath()+[Guid]::NewGuid().ToString('N')+'.ps1'; $__nova_g=[IO.Compression.GZipStream]::new([IO.MemoryStream]::new([Convert]::FromBase64String('@@BLOB@@')),[IO.Compression.CompressionMode]::Decompress); $__nova_o=[IO.File]::Create($__nova_t); $__nova_g.CopyTo($__nova_o); $__nova_o.Dispose(); $__nova_g.Dispose(); & $__nova_t; Remove-Item $__nova_t; Remove-Variable __nova_t,__nova_g,__nova_o
+                """,
             _ => throw new ArgumentOutOfRangeException(nameof(shell), shell, "No installer ships for this shell."),
         };
 
@@ -191,15 +195,22 @@ public static class RemoteShellIntegrationSnippets
         SnippetDescriptor descriptor = Get(shell);
         string template = ReadResource(descriptor.InstallerFileName);
 
-        const string Delimiter = "__NOVA_SNIPPET_EOF__";
+        // The delimiter that would end the embedded literal early: a heredoc terminator for the sh
+        // installers, the here-string terminator for the PowerShell one. A snippet line starting
+        // with it would truncate the installed file - or, in PowerShell, turn the remainder of the
+        // snippet into code.
+        string delimiter = shell == RemoteShellIntegrationShell.PowerShell
+            ? "'@"
+            : "__NOVA_SNIPPET_EOF__";
+
         foreach (string line in snippet.Split('\n'))
         {
-            if (line.StartsWith(Delimiter, StringComparison.Ordinal))
+            if (line.StartsWith(delimiter, StringComparison.Ordinal))
             {
                 throw new InvalidOperationException(
-                    $"Snippet '{descriptor.FileName}' contains a line starting with the installer's " +
-                    $"heredoc delimiter '{Delimiter}', which would truncate the installed file. " +
-                    "Rename the delimiter in the installer template.");
+                    $"Snippet '{descriptor.FileName}' contains a line starting with '{delimiter}', " +
+                    "the installer template's terminator, which would truncate the installed file. " +
+                    "Rename the terminator in the installer template.");
             }
         }
 

--- a/src/NovaTerminal.CommandAssist/ShellIntegration/Remote/RemoteShellIntegrationSnippets.cs
+++ b/src/NovaTerminal.CommandAssist/ShellIntegration/Remote/RemoteShellIntegrationSnippets.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Reflection;
@@ -127,23 +128,90 @@ public static class RemoteShellIntegrationSnippets
     /// </summary>
     /// <remarks>
     /// <para>
-    /// One line, because one line is one history entry and one prompt cycle. The 300-line paste this
-    /// replaced flooded the scrollback, was slow to redraw in any shell with syntax highlighting,
-    /// left the rc edit as a manual step users forget, and on a Windows remote could not work at all
-    /// (<c>cat</c> there is an alias for <c>Get-Content</c>, so <c>cat &gt; file</c> has no input).
+    /// One line, because one line is one history entry and one prompt cycle. The alternative - the
+    /// user pastes the 300-line snippet itself - floods the scrollback, is slow to redraw in any
+    /// shell with syntax highlighting, leaves the rc edit as a manual step users forget, and on a
+    /// Windows remote cannot work at all (<c>cat</c> there is an alias for <c>Get-Content</c>, so
+    /// <c>cat &gt; file</c> has no input). That path is still one click away as "Copy plain
+    /// snippet"; it is just not the default.
     /// </para>
     /// <para>
-    /// The payload is gzip+base64: 6.4 KB instead of 17.0 KB for the bash/zsh snippet, and base64's
-    /// alphabet contains no shell metacharacter, so the single quotes around it can never need
-    /// escaping. It decodes to an installer script that runs as a <em>child process</em> - the live
-    /// shell is never sourced into, and the shell's identity reaches the installer as an argument
-    /// the live shell expanded.
+    /// The payload is gzip+base64, roughly half the bytes of the installer script it decodes to,
+    /// and base64's alphabet contains no shell metacharacter, so the single quotes around it can
+    /// never need escaping. Exact sizes are not quoted here because they move with every snippet
+    /// edit; <c>Installer_StaysWithinItsLengthBudget</c> in RemoteShellIntegrationInstallerTests is
+    /// where the current measurement lives. It decodes to an installer script that runs as a
+    /// <em>child process</em> - the live shell is never sourced into, and the shell's identity
+    /// reaches the installer as an argument the live shell expanded.
     /// </para>
     /// <para>
-    /// This reverses the argument the class used to make against generated installers, which was
-    /// that a blob cannot be read before it runs. It is answered instead by the installers being
-    /// reviewable files under <c>assets/shell-integration/install/</c> and by
-    /// <see cref="Read"/> still backing a "Copy plain snippet" action in the same row.
+    /// A base64 blob cannot be read before it runs, which is a real objection to shipping one. It
+    /// is answered by what the blob contains: a gzipped copy of a reviewable file under
+    /// <c>assets/shell-integration/install/</c>, and nothing else - plus <see cref="Read"/> still
+    /// backing a "Copy plain snippet" action in the same row for a user who would rather place the
+    /// file themselves. See docs/command-assist/RemoteShellIntegration.md for what that does and
+    /// does not buy.
+    /// </para>
+    /// <para>
+    /// <b>The temp file comes from <c>mktemp</c> or the install does not happen.</b> There is no
+    /// fallback path. The obvious one - <c>printf /tmp/nova-si.%s "$$"</c> - was tried and removed:
+    /// <c>mktemp</c> gives 0600 and <c>O_EXCL</c>, that name gives neither. <c>$$</c> is visible in
+    /// <c>ps</c>, so the path is predictable, and <c>&gt;</c> follows symlinks and leaves an
+    /// existing file's mode and owner alone. On a shared host another local user can pre-create it
+    /// 0666 and rewrite the contents between the redirect and <c>sh "$__nova_t"</c> - code
+    /// execution as the victim - or point it at <c>~/.bashrc</c> and have the redirect truncate
+    /// that instead, no race required. A safe fallback would need <c>set -C</c> plus an
+    /// unpredictable name, which is more machinery than a rarely-taken path is worth; failing with
+    /// a message naming <c>mktemp</c> is the whole of the recovery story.
+    /// </para>
+    /// <para>
+    /// <b>The bash/zsh and pwsh arms carry their own payload length and check it before decoding.</b>
+    /// What that catches is <em>mid-stream byte loss</em>: a flaky link, a multiplexer dropping a
+    /// chunk of a paste, anything that removes bytes from the middle while the tail still arrives.
+    /// Without it the shortened payload reaches the decoder and the only symptom is a decode
+    /// failure, which the installer would have to blame on missing <c>base64</c>/<c>gzip</c> -
+    /// sending the user to install coreutils on a host that already has them.
+    /// </para>
+    /// <para>
+    /// It deliberately does <em>not</em> catch a canonical-mode tty cut, and cannot. The line is
+    /// over 4 KB and <c>N_TTY_BUF_SIZE</c> is 4096, so a tty in canonical mode
+    /// (<c>docker exec -it c sh</c>, busybox <c>ash</c>, <c>dash</c> as <c>/bin/sh</c>, serial and
+    /// IPMI consoles, pwsh without PSReadLine) discards everything past 4096 bytes of the line. But
+    /// the payload literal opens at byte 9 (bash) or 10 (pwsh) and closes past 7500, so a tail cut
+    /// at 4096 always lands <em>inside</em> the quoted blob and takes the closing quote with it:
+    /// bash answers <c>unexpected EOF while looking for matching '</c> and pwsh
+    /// <c>The string is missing the terminator: '.</c>, and none of our code runs at all. There is
+    /// no arrangement of a tail truncation that leaves the guard reachable. Interactive bash, zsh
+    /// and fish read in raw mode via readline/ZLE and never hit this, which is why pasting by hand
+    /// always works.
+    /// </para>
+    /// <para>
+    /// The <b>fish</b> arm has no length check. Its payload is a third the size and the whole line
+    /// fits under 4096, so it is the one arm that cannot be truncated by a tty in the first place -
+    /// and the check is 300-odd bytes of the headroom that makes that true. Its other guards
+    /// (<c>mktemp</c>, the decode status, both failure messages) are the same as bash's.
+    /// </para>
+    /// <para>
+    /// The decode branch is chosen on the <em>pipeline's exit status</em>, not on the temp file
+    /// being non-empty. <c>gzip -dc</c> writes what it managed to inflate before it fails, so a
+    /// corrupt payload leaves a non-empty, syntactically broken installer that <c>[ -s ]</c> would
+    /// wave through and <c>sh</c> would then run: an unterminated heredoc writes a truncated
+    /// snippet, the installer reports "wrote", appends the loader line, and every future shell on
+    /// that host sources a broken file.
+    /// </para>
+    /// <para>
+    /// The pwsh arm's <c>&amp; $__nova_t</c> sits <em>outside</em> the decode's <c>try</c>, gated on a
+    /// success flag. Inside it, a terminating error raised by the installer script itself would be
+    /// caught by the decode's handler and reported as "the payload did not unpack" - a diagnosis
+    /// about the blob for a failure that had nothing to do with it.
+    /// </para>
+    /// <para>
+    /// <c>base64 -d</c> is the GNU spelling. macOS's <c>/usr/bin/base64</c> predating Ventura only
+    /// accepts <c>-D</c>, so the sh and fish arms probe with a four-character test vector once and
+    /// fall back. A <c>-d ||</c> <c>-D</c> retry on the real payload is not an option: the first
+    /// attempt would already have consumed stdin. The variable holds the bare letter and the dash
+    /// is concatenated at the call site, so that fish's <c>set</c> never sees a value that looks
+    /// like one of its own options.
     /// </para>
     /// </remarks>
     public static string BuildInstallerCommand(RemoteShellIntegrationShell shell)
@@ -154,20 +222,22 @@ public static class RemoteShellIntegrationSnippets
         {
             RemoteShellIntegrationShell.BashOrZsh =>
                 """
-                __nova_t=$(mktemp 2>/dev/null || printf /tmp/nova-si.%s "$$"); printf %s '@@BLOB@@' | base64 -d 2>/dev/null | gzip -dc 2>/dev/null > "$__nova_t"; if [ -s "$__nova_t" ]; then sh "$__nova_t" "${ZSH_VERSION:+zsh}${BASH_VERSION:+bash}"; else echo "nova: install failed - this host needs base64 and gzip"; fi; rm -f "$__nova_t"; unset __nova_t
+                __nova_b='@@BLOB@@'; if [ ${#__nova_b} -ne @@BLOBLEN@@ ]; then echo "nova: install failed - the pasted line was cut short (${#__nova_b} of @@BLOBLEN@@ payload characters). A terminal in canonical mode drops everything past 4096 bytes of one line; use Copy plain snippet on this host."; elif __nova_t=$(mktemp); then __nova_d=d; printf %s Kg== | base64 -d >/dev/null 2>&1 || __nova_d=D; if printf %s "$__nova_b" | base64 "-$__nova_d" | gzip -dc > "$__nova_t"; then sh "$__nova_t" "${ZSH_VERSION:+zsh}${BASH_VERSION:+bash}"; else echo "nova: install failed - this host needs a working base64 and gzip to unpack the payload"; fi; rm -f "$__nova_t"; else echo "nova: install failed - mktemp could not create a temp file"; fi; unset __nova_b __nova_t __nova_d
                 """,
             RemoteShellIntegrationShell.Fish =>
                 """
-                set -l __nova_t (mktemp); printf %s '@@BLOB@@' | base64 -d | gzip -dc > $__nova_t; sh $__nova_t fish; rm -f $__nova_t; set -e __nova_t
+                set -l __nova_b '@@BLOB@@'; set -l __nova_t (mktemp); set -l __nova_d d; if test -z "$__nova_t"; echo "nova: install failed - mktemp could not create a temp file"; else; printf %s Kg== | base64 -d >/dev/null 2>&1; or set __nova_d D; if printf %s $__nova_b | base64 -$__nova_d | gzip -dc > $__nova_t; sh $__nova_t fish; else; echo "nova: install failed - this host needs a working base64 and gzip to unpack the payload"; end; rm -f $__nova_t; end; set -e __nova_b __nova_t __nova_d
                 """,
             RemoteShellIntegrationShell.PowerShell =>
                 """
-                $__nova_t=[IO.Path]::GetTempPath()+[Guid]::NewGuid().ToString('N')+'.ps1'; $__nova_g=[IO.Compression.GZipStream]::new([IO.MemoryStream]::new([Convert]::FromBase64String('@@BLOB@@')),[IO.Compression.CompressionMode]::Decompress); $__nova_o=[IO.File]::Create($__nova_t); $__nova_g.CopyTo($__nova_o); $__nova_o.Dispose(); $__nova_g.Dispose(); & $__nova_t; Remove-Item $__nova_t; Remove-Variable __nova_t,__nova_g,__nova_o
+                $__nova_b='@@BLOB@@'; if($__nova_b.Length -ne @@BLOBLEN@@){Write-Host "nova: install failed - the pasted line was cut short ($($__nova_b.Length) of @@BLOBLEN@@ payload characters). A console in canonical mode drops everything past 4096 bytes of one line; use Copy plain snippet on this host."}else{$__nova_t=[IO.Path]::GetTempPath()+[Guid]::NewGuid().ToString('N')+'.ps1'; try{$__nova_g=[IO.Compression.GZipStream]::new([IO.MemoryStream]::new([Convert]::FromBase64String($__nova_b)),[IO.Compression.CompressionMode]::Decompress); $__nova_o=[IO.File]::Create($__nova_t); $__nova_g.CopyTo($__nova_o); $__nova_o.Dispose(); $__nova_g.Dispose(); $__nova_ok=$true}catch{Write-Host "nova: install failed - the payload did not unpack: $($_.Exception.Message)"}finally{if($__nova_o){$__nova_o.Dispose()}; if($__nova_g){$__nova_g.Dispose()}}; if($__nova_ok){& $__nova_t}; Remove-Item $__nova_t -ErrorAction SilentlyContinue}; Remove-Variable __nova_b,__nova_t,__nova_g,__nova_o,__nova_ok -ErrorAction SilentlyContinue
                 """,
             _ => throw new ArgumentOutOfRangeException(nameof(shell), shell, "No installer ships for this shell."),
         };
 
-        return template.Replace("@@BLOB@@", blob, StringComparison.Ordinal);
+        return template
+            .Replace("@@BLOBLEN@@", blob.Length.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal)
+            .Replace("@@BLOB@@", blob, StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -253,17 +323,16 @@ public static class RemoteShellIntegrationSnippets
     /// <remarks>
     /// <para>
     /// This is the secondary path. The primary one is <see cref="BuildInstallerCommand"/>, and these
-    /// instructions belong to the "Copy plain snippet" action beside it.
+    /// instructions belong to the "Copy plain snippet" action beside it. It exists for the user who
+    /// wants to read the file before trusting it, or who is placing it from a dotfiles repo or
+    /// <c>/etc/profile.d</c> rather than pasting at a prompt - the one thing a base64 one-liner
+    /// cannot offer.
     /// </para>
     /// <para>
-    /// The class used to argue against a generated installer on the grounds that a base64 blob
-    /// cannot be read before it is run. That objection was real and is now met differently: the
-    /// installers are reviewable files under <c>assets/shell-integration/install/</c>, and this
-    /// readable path is still one click away in the same row. What the 300-line paste cost was not
-    /// worth keeping - a flooded scrollback, a slow paste in any shell with syntax highlighting, an
-    /// rc edit left to the user, and a PowerShell recipe that could not work on a Windows remote at
-    /// all, where <c>cat</c> is an alias for <c>Get-Content</c> and so <c>cat &gt; file</c> has no
-    /// input to read.
+    /// It is not the default because of what it costs when it is: a 300-line paste floods the
+    /// scrollback, is slow to redraw in any shell with syntax highlighting, leaves the rc edit to
+    /// the user, and on a Windows remote cannot work at all, where <c>cat</c> is an alias for
+    /// <c>Get-Content</c> and so <c>cat &gt; file</c> has no input to read.
     /// </para>
     /// <para>
     /// <c>cat &gt; path</c> plus Ctrl-D rather than an editor: it is the one recipe that works on a

--- a/src/NovaTerminal.CommandAssist/ShellIntegration/Remote/RemoteShellIntegrationSnippets.cs
+++ b/src/NovaTerminal.CommandAssist/ShellIntegration/Remote/RemoteShellIntegrationSnippets.cs
@@ -252,12 +252,18 @@ public static class RemoteShellIntegrationSnippets
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The clipboard carries the snippet itself rather than a generated one-line installer, and the
-    /// instructions are shown rather than pasted. A generated installer would have to be a heredoc
-    /// (which fish cannot parse), a base64 blob (which the user cannot read before running), or a
-    /// download (which needs a URL the app does not have). Handing over the file and telling the
-    /// user where to put it is the version with no hidden machinery, and the snippet repeats these
-    /// same steps in its own header comment so they survive the trip to the remote host.
+    /// This is the secondary path. The primary one is <see cref="BuildInstallerCommand"/>, and these
+    /// instructions belong to the "Copy plain snippet" action beside it.
+    /// </para>
+    /// <para>
+    /// The class used to argue against a generated installer on the grounds that a base64 blob
+    /// cannot be read before it is run. That objection was real and is now met differently: the
+    /// installers are reviewable files under <c>assets/shell-integration/install/</c>, and this
+    /// readable path is still one click away in the same row. What the 300-line paste cost was not
+    /// worth keeping - a flooded scrollback, a slow paste in any shell with syntax highlighting, an
+    /// rc edit left to the user, and a PowerShell recipe that could not work on a Windows remote at
+    /// all, where <c>cat</c> is an alias for <c>Get-Content</c> and so <c>cat &gt; file</c> has no
+    /// input to read.
     /// </para>
     /// <para>
     /// <c>cat &gt; path</c> plus Ctrl-D rather than an editor: it is the one recipe that works on a

--- a/src/NovaTerminal.CommandAssist/ShellIntegration/Remote/RemoteShellIntegrationSnippets.cs
+++ b/src/NovaTerminal.CommandAssist/ShellIntegration/Remote/RemoteShellIntegrationSnippets.cs
@@ -156,6 +156,10 @@ public static class RemoteShellIntegrationSnippets
                 """
                 __nova_t=$(mktemp 2>/dev/null || printf /tmp/nova-si.%s "$$"); printf %s '@@BLOB@@' | base64 -d 2>/dev/null | gzip -dc 2>/dev/null > "$__nova_t"; if [ -s "$__nova_t" ]; then sh "$__nova_t" "${ZSH_VERSION:+zsh}${BASH_VERSION:+bash}"; else echo "nova: install failed - this host needs base64 and gzip"; fi; rm -f "$__nova_t"; unset __nova_t
                 """,
+            RemoteShellIntegrationShell.Fish =>
+                """
+                set -l __nova_t (mktemp); printf %s '@@BLOB@@' | base64 -d | gzip -dc > $__nova_t; sh $__nova_t fish; rm -f $__nova_t; set -e __nova_t
+                """,
             _ => throw new ArgumentOutOfRangeException(nameof(shell), shell, "No installer ships for this shell."),
         };
 

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/RemoteInstallerIntegrationTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/RemoteInstallerIntegrationTests.cs
@@ -1,0 +1,282 @@
+using System.Diagnostics;
+using System.Text;
+using NovaTerminal.CommandAssist.ShellIntegration.Remote;
+
+namespace NovaTerminal.Tests.CommandAssist.ShellIntegration.Integration;
+
+/// <summary>
+/// The generated one-liner, run the way a user pastes it: through a real bash, with
+/// <c>HOME</c> redirected to a temp directory.
+/// </summary>
+/// <remarks>
+/// <para>
+/// RemoteShellIntegrationInstallerTests asserts on the command's text, which cannot see the bugs
+/// this file was written for: a heredoc that drops a line, an rc file patched twice, a
+/// <c>grep -q</c> marker that misses a hand-placed loader line, or a decode failure that writes an
+/// empty snippet and reports success.
+/// </para>
+/// <para>
+/// The installer itself needs no TTY, so it runs under <c>bash -c</c> via
+/// <see cref="Process"/>. Only the last test - "and afterwards the marks actually flow" - needs an
+/// interactive shell, and that one goes through <see cref="ShellHarness"/> on a real PTY.
+/// </para>
+/// <para>
+/// Skipped when bash is absent. <c>HOME</c> is a per-test temp directory so the developer's own
+/// dotfiles are never touched, and it is passed with forward slashes because Git Bash resolves
+/// <c>$HOME/...</c> more predictably that way.
+/// </para>
+/// </remarks>
+[Trait("Category", "ShellIntegration")]
+[Collection(nameof(ShellIntegrationCollection))]
+public sealed class RemoteInstallerIntegrationTests : IDisposable
+{
+    private readonly string _home;
+
+    public RemoteInstallerIntegrationTests()
+    {
+        _home = Path.Combine(Path.GetTempPath(), $"nova_installer_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_home);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_home, recursive: true); } catch { }
+    }
+
+    private string HomeForShell => _home.Replace('\\', '/');
+
+    private string SnippetPath => Path.Combine(_home, ".nova-shell-integration.sh");
+
+    private string BashrcPath => Path.Combine(_home, ".bashrc");
+
+    /// <summary>Runs the pasted one-liner under a non-interactive bash and returns its output.</summary>
+    /// <param name="pathOverride">
+    /// Replaces <c>PATH</c> for the child. On real Linux bash this alone hides <c>base64</c> and
+    /// <c>gzip</c>; kept for that platform even though it is not sufficient on Git Bash - see
+    /// <paramref name="shadowDecodeTools"/>.
+    /// </param>
+    /// <param name="shadowDecodeTools">
+    /// Prepends bash functions named <c>base64</c> and <c>gzip</c> that both fail, shadowing the
+    /// real commands regardless of <c>PATH</c>. Needed because Git Bash's MSYS runtime injects
+    /// <c>/mingw64/bin:/usr/bin</c> at the front of <c>PATH</c> unconditionally - confirmed with
+    /// <c>PATH=/nonexistent bash.exe --noprofile --norc -c 'echo $PATH'</c> still reporting
+    /// <c>/mingw64/bin:/usr/bin:...</c> first - so an empty-directory <c>PATH</c> override alone
+    /// never hides <c>base64</c>/<c>gzip</c> on this platform and the installer always "succeeds".
+    /// A bash function takes precedence over a <c>PATH</c> lookup for a simple command, which is
+    /// what lets this actually exercise the failure branch on Windows.
+    /// </param>
+    private string RunInstaller(string? pathOverride = null, bool shadowDecodeTools = false)
+    {
+        string? bash = ShellHarness.FindBash();
+        if (bash is null)
+        {
+            Assert.Skip("bash not found on this system");
+        }
+
+        string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(
+            RemoteShellIntegrationShell.BashOrZsh);
+        if (shadowDecodeTools)
+        {
+            command = "base64() { return 1; }; gzip() { return 1; }; " + command;
+        }
+
+        var startInfo = new ProcessStartInfo(bash)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add("-c");
+        startInfo.ArgumentList.Add(command);
+        startInfo.Environment["HOME"] = HomeForShell;
+        if (pathOverride is not null)
+        {
+            startInfo.Environment["PATH"] = pathOverride;
+        }
+
+        using Process process = Process.Start(startInfo)!;
+        string stdout = process.StandardOutput.ReadToEnd();
+        string stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "installer did not finish within 30s");
+
+        return stdout + stderr;
+    }
+
+    private static int CountLoaderLines(string rcContent) => rcContent
+        .Split('\n')
+        .Count(line => line.Contains("nova-shell-integration", StringComparison.Ordinal));
+
+    // ---- the happy path -------------------------------------------------------------------------
+
+    [Fact]
+    public void Installer_WritesTheSnippetByteForByte()
+    {
+        string output = RunInstaller();
+
+        Assert.True(File.Exists(SnippetPath), $"snippet not written. output:\n{output}");
+        Assert.Equal(
+            RemoteShellIntegrationSnippets.Read(RemoteShellIntegrationShell.BashOrZsh).TrimEnd('\n'),
+            File.ReadAllText(SnippetPath).Replace("\r\n", "\n").TrimEnd('\n'));
+        Assert.Contains("nova: wrote ~/.nova-shell-integration.sh", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The rc edit is the step users forget, so the installer does it - and it detects bash from the
+    /// <c>${BASH_VERSION:+bash}</c> the live shell expands into the child's argv, with nothing
+    /// sourced.
+    /// </summary>
+    [Fact]
+    public void Installer_AddsTheLoaderLineToBashrc()
+    {
+        string output = RunInstaller();
+
+        Assert.True(File.Exists(BashrcPath), $"~/.bashrc not created. output:\n{output}");
+        string rc = File.ReadAllText(BashrcPath);
+        Assert.Contains(
+            RemoteShellIntegrationSnippets.GetLoaderLine(RemoteShellIntegrationShell.BashOrZsh)!,
+            rc,
+            StringComparison.Ordinal);
+        Assert.Contains("nova: added loader line to ~/.bashrc", output, StringComparison.Ordinal);
+    }
+
+    // ---- idempotency ----------------------------------------------------------------------------
+
+    [Fact]
+    public void Installer_RunTwice_LeavesExactlyOneLoaderLine()
+    {
+        RunInstaller();
+        string secondOutput = RunInstaller();
+
+        Assert.Equal(1, CountLoaderLines(File.ReadAllText(BashrcPath)));
+        Assert.Contains("already present", secondOutput, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// A user who followed the old docs already has the loader line. The marker is the file name
+    /// rather than our exact line, so a hand-typed variant is still recognized.
+    /// </summary>
+    [Fact]
+    public void Installer_HandPlacedLoaderLine_IsNotDuplicated()
+    {
+        File.WriteAllText(
+            BashrcPath,
+            "PS1='test$ '\nsource ~/.nova-shell-integration.sh\n",
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        RunInstaller();
+
+        Assert.Equal(1, CountLoaderLines(File.ReadAllText(BashrcPath)));
+    }
+
+    // ---- failure ---------------------------------------------------------------------------------
+
+    /// <summary>
+    /// With no <c>base64</c> or <c>gzip</c> reachable the decode produces an empty temp file. The
+    /// one-liner must say so rather than silently install nothing, which is the failure mode a user
+    /// cannot diagnose.
+    /// </summary>
+    /// <remarks>
+    /// An empty-directory <c>PATH</c> override is not enough here: Git Bash's MSYS runtime
+    /// unconditionally prepends <c>/mingw64/bin:/usr/bin</c> to <c>PATH</c> before the script sees
+    /// it (still true with <c>--noprofile --norc</c>, so it is not a sourced file), which means
+    /// <c>base64</c>/<c>gzip</c> are always found there regardless of what this test passes as
+    /// <c>PATH</c> - the installer "succeeds" and this test's whole premise silently fails to hold.
+    /// <see cref="RunInstaller"/>'s <c>shadowDecodeTools</c> additionally defines bash functions
+    /// named <c>base64</c>/<c>gzip</c> that fail, which take precedence over any <c>PATH</c> lookup
+    /// and so reach the failure branch on every platform.
+    /// </remarks>
+    [Fact]
+    public void Installer_WithoutBase64OrGzip_ReportsFailureAndWritesNothing()
+    {
+        string emptyDir = Path.Combine(_home, "empty-path");
+        Directory.CreateDirectory(emptyDir);
+
+        string output = RunInstaller(pathOverride: emptyDir.Replace('\\', '/'), shadowDecodeTools: true);
+
+        Assert.Contains("nova: install failed", output, StringComparison.Ordinal);
+        Assert.False(File.Exists(SnippetPath), "snippet written despite a failed decode");
+    }
+
+    // ---- and afterwards, the marks flow ----------------------------------------------------------
+
+    /// <summary>
+    /// The end-to-end claim: install, then start an interactive bash that reads the rc file the
+    /// installer patched, and the OSC 133 lifecycle arrives. This is what the user gets on their
+    /// next session, and it is asserted through the production PTY + parser path.
+    /// </summary>
+    [Fact]
+    public void AfterInstalling_ANewInteractiveShell_EmitsTheLifecycle()
+    {
+        RunInstaller();
+
+        string? bash = ShellHarness.FindBash();
+        if (bash is null)
+        {
+            Assert.Skip("bash not found on this system");
+        }
+
+        // The installer writes only the loader line; a prompt is needed for the 133;B mark to have
+        // somewhere to land, so prepend one the same way RemoteBashSnippetIntegrationTests does.
+        string rc = File.ReadAllText(BashrcPath);
+        File.WriteAllText(
+            BashrcPath,
+            "PS1='nova-test$ '\n" + rc,
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        var env = new Dictionary<string, string> { ["HOME"] = HomeForShell };
+        HarnessResult result = ShellHarness.Run(
+            bash,
+            $"--rcfile \"{BashrcPath.Replace('\\', '/')}\" -i",
+            "echo hello\nexit 0\n",
+            env,
+            TimeSpan.FromSeconds(20));
+
+        Assert.Contains(result.Events, e => e.Kind == "A");
+        Assert.Contains(result.Events, e => e.Kind == "B");
+        Assert.Contains(
+            result.Events.Where(e => e.Kind == "C").Select(e => e.DecodedCommand),
+            t => t == "echo hello");
+        Assert.Contains(result.Events, e => e.Kind == "D" && e.DecodedFinish.exitCode == 0);
+    }
+
+    // ---- the live shell is untouched -------------------------------------------------------------
+
+    /// <summary>
+    /// The design's central promise: the installer runs as a child, so nothing it defines can reach
+    /// the shell that pasted the line. Asserted by checking the calling shell afterwards for the
+    /// installer's own variables and for the snippet's marker function.
+    /// </summary>
+    [Fact]
+    public void Installer_LeavesNothingBehindInTheCallingShell()
+    {
+        string? bash = ShellHarness.FindBash();
+        if (bash is null)
+        {
+            Assert.Skip("bash not found on this system");
+        }
+
+        string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(
+            RemoteShellIntegrationShell.BashOrZsh);
+        string probe =
+            command +
+            "; echo \"probe-dest=[${__nova_dest-}]\"" +
+            "; echo \"probe-temp=[${__nova_t-}]\"";
+
+        var startInfo = new ProcessStartInfo(bash)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add("-c");
+        startInfo.ArgumentList.Add(probe);
+        startInfo.Environment["HOME"] = HomeForShell;
+
+        using Process process = Process.Start(startInfo)!;
+        string output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "probe did not finish within 30s");
+
+        Assert.Contains("probe-dest=[]", output, StringComparison.Ordinal);
+        Assert.Contains("probe-temp=[]", output, StringComparison.Ordinal);
+    }
+}

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/RemoteInstallerIntegrationTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/RemoteInstallerIntegrationTests.cs
@@ -50,6 +50,27 @@ public sealed class RemoteInstallerIntegrationTests : IDisposable
     private string BashrcPath => Path.Combine(_home, ".bashrc");
 
     /// <summary>Runs the pasted one-liner under a non-interactive bash and returns its output.</summary>
+    /// <remarks>
+    /// The one-liner goes into a file that bash is pointed at, rather than into <c>bash -c</c>.
+    /// Git Bash's MSYS runtime rebuilds argv from the Windows command line and caps it just under
+    /// 8192 characters - measured here: 8100, 8150 and 8180 all arrive whole, 8190, 8191, 8200 and
+    /// 8300 all fail hard with <c>unexpected EOF while looking for matching quote</c>. It is a
+    /// clean error, not a silent truncation, but it is indistinguishable from a quoting bug in the
+    /// generated command, which is how it first presented.
+    /// </remarks>
+    /// <remarks>
+    /// Worth recording why this changed: the payload-length check added for the truncation
+    /// diagnosis grew the bash/zsh one-liner from 7721 to 8688 characters, which crossed that cap.
+    /// <c>-c</c> worked before the check and cannot carry the line after it - a second, quieter
+    /// cost of the check, alongside the ~300 bytes that kept it off the fish arm.
+    /// </remarks>
+    /// <remarks>
+    /// Nothing is lost by the move. <c>bash -c &lt;string&gt;</c> was never a tty paste either, so no
+    /// tty behaviour was under test; bash parses a one-line script file identically; <c>$0</c> and
+    /// <c>$@</c> are unused by the one-liner; "it is exactly one line" is pinned in
+    /// RemoteShellIntegrationInstallerTests; and the real PTY path is still covered by
+    /// <see cref="AfterInstalling_ANewInteractiveShell_EmitsTheLifecycle"/>.
+    /// </remarks>
     /// <param name="pathOverride">
     /// Replaces <c>PATH</c> for the child. On real Linux bash this alone hides <c>base64</c> and
     /// <c>gzip</c>; kept for that platform even though it is not sufficient on Git Bash - see
@@ -80,14 +101,16 @@ public sealed class RemoteInstallerIntegrationTests : IDisposable
             command = "base64() { return 1; }; gzip() { return 1; }; " + command;
         }
 
+        string pastePath = Path.Combine(_home, "paste.sh");
+        File.WriteAllText(pastePath, command + "\n", new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
         var startInfo = new ProcessStartInfo(bash)
         {
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
         };
-        startInfo.ArgumentList.Add("-c");
-        startInfo.ArgumentList.Add(command);
+        startInfo.ArgumentList.Add(pastePath.Replace('\\', '/'));
         startInfo.Environment["HOME"] = HomeForShell;
         if (pathOverride is not null)
         {
@@ -105,6 +128,50 @@ public sealed class RemoteInstallerIntegrationTests : IDisposable
     private static int CountLoaderLines(string rcContent) => rcContent
         .Split('\n')
         .Count(line => line.Contains("nova-shell-integration", StringComparison.Ordinal));
+
+    /// <summary>
+    /// Runs the decoded installer script directly under bash, with an explicit shell argument, and
+    /// returns its output and exit status.
+    /// </summary>
+    /// <remarks>
+    /// The script rather than the one-liner, because the one-liner's exit status is its cleanup's:
+    /// it ends in <c>unset</c>/<c>rm -f</c> so that nothing is left behind in the calling shell,
+    /// and those succeed whatever the installer did. The installer's own status is the thing worth
+    /// asserting on, and it is what a user piping this into <c>sh</c> would see.
+    /// </remarks>
+    private (string Output, int ExitCode) RunInstallerScript(string shellArgument, string? shellEnv = null)
+    {
+        string? bash = ShellHarness.FindBash();
+        if (bash is null)
+        {
+            Assert.Skip("bash not found on this system");
+        }
+
+        string installerPath = Path.Combine(_home, "nova-install.sh");
+        File.WriteAllText(
+            installerPath,
+            RemoteShellIntegrationSnippets.BuildInstallerScript(RemoteShellIntegrationShell.BashOrZsh),
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        var startInfo = new ProcessStartInfo(bash)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add(installerPath.Replace('\\', '/'));
+        startInfo.ArgumentList.Add(shellArgument);
+        startInfo.Environment["HOME"] = HomeForShell;
+        if (shellEnv is not null)
+        {
+            startInfo.Environment["SHELL"] = shellEnv;
+        }
+
+        using Process process = Process.Start(startInfo)!;
+        string output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "installer did not finish within 30s");
+        return (output, process.ExitCode);
+    }
 
     // ---- the happy path -------------------------------------------------------------------------
 
@@ -166,6 +233,37 @@ public sealed class RemoteInstallerIntegrationTests : IDisposable
         RunInstaller();
 
         Assert.Equal(1, CountLoaderLines(File.ReadAllText(BashrcPath)));
+    }
+
+    /// <summary>
+    /// A rc file whose only mention of the snippet is inside a comment is not an installation. A
+    /// bare substring match reads it as one, prints "already present - unchanged", writes nothing,
+    /// and the feature never works - and the user has no reason to look again, because the
+    /// installer said it was already done.
+    /// </summary>
+    /// <remarks>
+    /// Not a hypothetical: the natural way to turn this off is to comment the loader line out, and
+    /// `# see ~/.nova-shell-integration.sh` is a plausible note to leave next to something else.
+    /// The marker stays the file name (so a hand-typed loader variant still counts) but is anchored
+    /// to a non-comment position on the line.
+    /// </remarks>
+    [Fact]
+    public void Installer_MentionOnlyInsideAComment_StillAddsTheLoaderLine()
+    {
+        File.WriteAllText(
+            BashrcPath,
+            "# I disabled nova-shell-integration on purpose\n",
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        string output = RunInstaller();
+
+        string rc = File.ReadAllText(BashrcPath).Replace("\r\n", "\n");
+        Assert.Contains(
+            RemoteShellIntegrationSnippets.GetLoaderLine(RemoteShellIntegrationShell.BashOrZsh)!,
+            rc,
+            StringComparison.Ordinal);
+        Assert.Contains("nova: added loader line to ~/.bashrc", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("already present", output, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -311,7 +409,159 @@ public sealed class RemoteInstallerIntegrationTests : IDisposable
         string output = RunInstaller(pathOverride: emptyDir.Replace('\\', '/'), shadowDecodeTools: true);
 
         Assert.Contains("nova: install failed", output, StringComparison.Ordinal);
+        Assert.Contains("base64", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("cut short", output, StringComparison.Ordinal);
         Assert.False(File.Exists(SnippetPath), "snippet written despite a failed decode");
+    }
+
+    /// <summary>
+    /// What a canonical-mode tty cut actually does: the shell rejects the line on the unterminated
+    /// quote and none of the installer runs.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// B3's whole premise is truncation, so the suite truncates. <c>N_TTY_BUF_SIZE</c> is 4096 and
+    /// a tty in canonical mode discards the rest of a longer line, so this feeds the shell exactly
+    /// the first 4095 bytes of the real generated command.
+    /// </para>
+    /// <para>
+    /// This asserts what happens, not what would be convenient. The payload literal opens at byte 9
+    /// and closes past 7500, so the cut always lands inside the quoted blob and takes the closing
+    /// quote with it - the payload-length check is unreachable for a tail cut and no <c>nova:</c>
+    /// line is ever printed. The check earns its place on mid-stream byte loss instead, where the
+    /// tail arrives and the middle does not. Getting this wrong in the other direction is the
+    /// failure this test exists to prevent: a future edit that made the guard *look* reachable
+    /// here, and a message promising a diagnosis the user will never see.
+    /// </para>
+    /// <para>
+    /// pwsh behaves the same way for the same reason - <c>The string is missing the terminator:
+    /// '.</c> - and is not run here only because it needs no shell-specific proof beyond this one.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void Installer_TruncatedAtTheCanonicalTtyLimit_FailsInTheShellBeforeAnyOfOurCodeRuns()
+    {
+        string? bash = ShellHarness.FindBash();
+        if (bash is null)
+        {
+            Assert.Skip("bash not found on this system");
+        }
+
+        string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(
+            RemoteShellIntegrationShell.BashOrZsh);
+        Assert.True(command.Length > 4096, "the one-liner fits in one canonical-mode line; this test is moot");
+
+        string cutPath = Path.Combine(_home, "cut-paste.sh");
+        File.WriteAllText(
+            cutPath,
+            command[..4095] + "\n",
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        var startInfo = new ProcessStartInfo(bash)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add(cutPath.Replace('\\', '/'));
+        startInfo.Environment["HOME"] = HomeForShell;
+
+        using Process process = Process.Start(startInfo)!;
+        string output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "truncated paste did not finish within 30s");
+
+        Assert.NotEqual(0, process.ExitCode);
+        Assert.DoesNotContain("nova:", output, StringComparison.Ordinal);
+        Assert.False(File.Exists(SnippetPath), $"snippet written from a truncated paste. output:\n{output}");
+        Assert.False(File.Exists(BashrcPath), $"~/.bashrc written from a truncated paste. output:\n{output}");
+    }
+
+    /// <summary>
+    /// The rc file cannot be written. The installer must not claim it added the loader line.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A directory in the rc file's place is the cheapest reproduction; the real ones are a
+    /// root-owned or <c>chattr +i</c> rc file, a read-only <c>$HOME</c> (NFS, a container), and a
+    /// full disk. In all of them <c>&gt;&gt;</c> fails, the shell prints the real error and carries
+    /// on, and an unchecked append then prints "added loader line" over the top of it. The user is
+    /// told it worked, gets no marks, and the installer's own report sends them looking in the
+    /// right file for a line that was never written.
+    /// </para>
+    /// <para>
+    /// Three things are asserted because any one of them alone can pass while the bug is present:
+    /// no success claim, a printed loader line the user can place by hand, and a non-zero status
+    /// for anything driving this from a script.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void Installer_WhenTheRcFileCannotBeWritten_SaysSoAndExitsNonZero()
+    {
+        Directory.CreateDirectory(BashrcPath);
+
+        (string output, int exitCode) = RunInstallerScript("bash");
+
+        Assert.DoesNotContain("nova: added loader line", output, StringComparison.Ordinal);
+        Assert.Contains("nova: could not write ~/.bashrc", output, StringComparison.Ordinal);
+        Assert.Contains(
+            RemoteShellIntegrationSnippets.GetLoaderLine(RemoteShellIntegrationShell.BashOrZsh)!,
+            output,
+            StringComparison.Ordinal);
+        Assert.NotEqual(0, exitCode);
+    }
+
+    /// <summary>
+    /// The same failure against a rc file that exists and has no trailing newline, which is the
+    /// path that goes through the <em>second</em> append - the <c>printf '\n'</c> that keeps the
+    /// loader off the end of the user's last line. Unguarded, that one fails, execution continues,
+    /// and the loader append then fails too and prints success anyway.
+    /// </summary>
+    /// <remarks>
+    /// Read-only permissions rather than a directory, because a directory takes the
+    /// <c>[ -f ]</c>-false path and never reaches the newline fix. Skipped where the append
+    /// succeeds anyway - root ignores the mode bits, and Git Bash's chmod does not map onto
+    /// Windows ACLs - and the skip is decided by trying it rather than by guessing the platform.
+    /// </remarks>
+    [Fact]
+    public void Installer_WhenTheRcFileWithoutTrailingNewlineIsReadOnly_SaysSoAndExitsNonZero()
+    {
+        File.WriteAllText(
+            BashrcPath,
+            "export FOO=bar",
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(BashrcPath, UnixFileMode.UserRead);
+        }
+
+        bool appendWasRefused;
+        try
+        {
+            File.AppendAllText(BashrcPath, "\n");
+            appendWasRefused = false;
+        }
+        catch (Exception e) when (e is UnauthorizedAccessException or IOException)
+        {
+            appendWasRefused = true;
+        }
+
+        if (!appendWasRefused)
+        {
+            Assert.Skip("this process can append to a read-only file (root, or Windows ACLs)");
+        }
+
+        (string output, int exitCode) = RunInstallerScript("bash");
+
+        if (!OperatingSystem.IsWindows())
+        {
+            // Restore write so Dispose can delete the temp HOME.
+            File.SetUnixFileMode(BashrcPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+
+        Assert.DoesNotContain("nova: added loader line", output, StringComparison.Ordinal);
+        Assert.Contains("nova: could not write ~/.bashrc", output, StringComparison.Ordinal);
+        Assert.NotEqual(0, exitCode);
+        Assert.Equal("export FOO=bar", File.ReadAllText(BashrcPath));
     }
 
     // ---- and afterwards, the marks flow ----------------------------------------------------------
@@ -408,6 +658,12 @@ public sealed class RemoteInstallerIntegrationTests : IDisposable
     /// required would ship undetected. This test runs the actual generated one-liner through
     /// <c>fish -c</c>, mirroring <see cref="RunInstaller"/>'s bash equivalent.
     /// </summary>
+    /// <remarks>
+    /// The output assertions are specific on purpose. <c>Assert.Contains("nova:")</c> would pass on
+    /// every failure message the installer has, including a false claim of success - which is the
+    /// exact hole that let the fish status lie survive its own fix. So: the success line in full,
+    /// no "install failed" of any kind, and nothing fish itself complained about.
+    /// </remarks>
     [Fact]
     public void FishOneLiner_RunsUnderRealFish()
     {
@@ -439,7 +695,20 @@ public sealed class RemoteInstallerIntegrationTests : IDisposable
         Assert.Equal(
             RemoteShellIntegrationSnippets.Read(RemoteShellIntegrationShell.Fish).TrimEnd('\n'),
             File.ReadAllText(dest).Replace("\r\n", "\n").TrimEnd('\n'));
-        Assert.Contains("nova:", output, StringComparison.Ordinal);
+        Assert.Contains(
+            "nova: wrote ~/.config/fish/conf.d/nova-shell-integration.fish",
+            output,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "nova: conf.d is sourced automatically - there is nothing to add to a config file.",
+            output,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("install failed", output, StringComparison.Ordinal);
+        // fish prefixes its own diagnostics with "fish:", and none of the installer's four output
+        // lines contains that string. Without this, a wrapper that errored on the redirect and then
+        // degraded `sh $__nova_t fish` to `sh fish` would still leave the assertions above green
+        // on a host where a previous run had already written conf.d.
+        Assert.DoesNotContain("fish:", output, StringComparison.Ordinal);
     }
 
     // ---- the live shell is untouched -------------------------------------------------------------
@@ -464,7 +733,12 @@ public sealed class RemoteInstallerIntegrationTests : IDisposable
         string probe =
             command +
             "; echo \"probe-dest=[${__nova_dest-}]\"" +
-            "; echo \"probe-temp=[${__nova_t-}]\"";
+            "; echo \"probe-temp=[${__nova_t-}]\"" +
+            "; echo \"probe-blob=[${__nova_b-}]\"";
+
+        // Via a file, not -c: see RunInstaller's remarks on Git Bash's 8191-character argv cap.
+        string probePath = Path.Combine(_home, "probe.sh");
+        File.WriteAllText(probePath, probe + "\n", new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
 
         var startInfo = new ProcessStartInfo(bash)
         {
@@ -472,8 +746,7 @@ public sealed class RemoteInstallerIntegrationTests : IDisposable
             RedirectStandardError = true,
             UseShellExecute = false,
         };
-        startInfo.ArgumentList.Add("-c");
-        startInfo.ArgumentList.Add(probe);
+        startInfo.ArgumentList.Add(probePath.Replace('\\', '/'));
         startInfo.Environment["HOME"] = HomeForShell;
 
         using Process process = Process.Start(startInfo)!;
@@ -482,6 +755,9 @@ public sealed class RemoteInstallerIntegrationTests : IDisposable
 
         Assert.Contains("probe-dest=[]", output, StringComparison.Ordinal);
         Assert.Contains("probe-temp=[]", output, StringComparison.Ordinal);
+        // The payload now lands in a variable rather than being piped straight from a literal, so
+        // there is a ~7 KB string to clean up as well.
+        Assert.Contains("probe-blob=[]", output, StringComparison.Ordinal);
     }
 
     // ---- powershell ---------------------------------------------------------------------------
@@ -553,6 +829,95 @@ public sealed class RemoteInstallerIntegrationTests : IDisposable
     }
 
     /// <summary>
+    /// The PowerShell half of
+    /// <see cref="Installer_WhenTheRcFileCannotBeWritten_SaysSoAndExitsNonZero"/>. <c>Add-Content</c>
+    /// defaults to <c>-ErrorAction Continue</c>: it reports the error and lets the script run on to
+    /// print "added loader line" over the top of it.
+    /// </summary>
+    [Fact]
+    public void PowerShellInstaller_WhenTheProfileCannotBeWritten_SaysSoAndExitsNonZero()
+    {
+        string? pwsh = FindPwsh();
+        if (pwsh is null)
+        {
+            Assert.Skip("pwsh not found on this system");
+        }
+
+        string installerPath = WritePowerShellInstaller();
+        string profilePath = Path.Combine(_home, "profile.ps1");
+        Directory.CreateDirectory(profilePath);
+
+        (string output, int exitCode) = RunPwshWithExitCode(pwsh, installerPath, profilePath);
+
+        Assert.DoesNotContain("nova: added loader line", output, StringComparison.Ordinal);
+        Assert.Contains("nova: could not write", output, StringComparison.Ordinal);
+        Assert.Contains(
+            RemoteShellIntegrationSnippets.GetLoaderLine(RemoteShellIntegrationShell.PowerShell)!,
+            output,
+            StringComparison.Ordinal);
+        Assert.NotEqual(0, exitCode);
+    }
+
+    /// <summary>
+    /// The PowerShell half of <see cref="Installer_MentionOnlyInsideAComment_StillAddsTheLoaderLine"/>.
+    /// <c>#</c> is PowerShell's comment character too, so <c>-SimpleMatch</c> anywhere in the file
+    /// reads a commented-out attempt as an installation.
+    /// </summary>
+    [Fact]
+    public void PowerShellInstaller_MentionOnlyInsideAComment_StillAddsTheLoaderLine()
+    {
+        string? pwsh = FindPwsh();
+        if (pwsh is null)
+        {
+            Assert.Skip("pwsh not found on this system");
+        }
+
+        string installerPath = WritePowerShellInstaller();
+        string profilePath = Path.Combine(_home, "profile.ps1");
+        File.WriteAllText(
+            profilePath,
+            "# I disabled nova-shell-integration on purpose\n",
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        string output = RunPwsh(pwsh, installerPath, profilePath);
+
+        Assert.Contains(
+            RemoteShellIntegrationSnippets.GetLoaderLine(RemoteShellIntegrationShell.PowerShell)!,
+            File.ReadAllText(profilePath).Replace("\r\n", "\n"),
+            StringComparison.Ordinal);
+        Assert.Contains("nova: added loader line", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("already present", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The installer names the profile it patched. It used to print the literal string
+    /// <c>$PROFILE</c> - single-quoted, so never expanded - which on a host where the user has more
+    /// than one profile path says nothing about which file to go and look at. The sh installer names
+    /// the real file; this one must too.
+    /// </summary>
+    [Fact]
+    public void PowerShellInstaller_NamesTheProfileItPatched()
+    {
+        string? pwsh = FindPwsh();
+        if (pwsh is null)
+        {
+            Assert.Skip("pwsh not found on this system");
+        }
+
+        string installerPath = WritePowerShellInstaller();
+        string profilePath = Path.Combine(_home, "profile.ps1");
+
+        string output = RunPwsh(pwsh, installerPath, profilePath) + RunPwsh(pwsh, installerPath, profilePath);
+
+        Assert.DoesNotContain("$PROFILE", output, StringComparison.Ordinal);
+        Assert.Contains($"nova: added loader line to {profilePath}", output, StringComparison.Ordinal);
+        Assert.Contains(
+            $"nova: loader line already present in {profilePath}",
+            output,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// <see cref="PowerShellInstaller_WritesTheSnippetAndPatchesTheProfileOnce"/> invokes the
     /// installer via <c>-File</c>, which parses the script as its own document and never exercises
     /// the generated one-liner's own syntax - the wrapper that decodes and runs it. This parses (but
@@ -617,7 +982,13 @@ public sealed class RemoteInstallerIntegrationTests : IDisposable
         return null;
     }
 
-    private string RunPwsh(string pwsh, string installerPath, string profilePath)
+    private string RunPwsh(string pwsh, string installerPath, string profilePath) =>
+        RunPwshWithExitCode(pwsh, installerPath, profilePath).Output;
+
+    private (string Output, int ExitCode) RunPwshWithExitCode(
+        string pwsh,
+        string installerPath,
+        string profilePath)
     {
         var startInfo = new ProcessStartInfo(pwsh)
         {
@@ -637,6 +1008,17 @@ public sealed class RemoteInstallerIntegrationTests : IDisposable
         using Process process = Process.Start(startInfo)!;
         string output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
         Assert.True(process.WaitForExit(60_000), "pwsh installer did not finish within 60s");
-        return output;
+        return (output, process.ExitCode);
+    }
+
+    private string WritePowerShellInstaller()
+    {
+        string installerPath = Path.Combine(_home, "nova-install.ps1");
+        File.WriteAllText(
+            installerPath,
+            RemoteShellIntegrationSnippets.BuildInstallerScript(
+                RemoteShellIntegrationShell.PowerShell),
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        return installerPath;
     }
 }

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/RemoteInstallerIntegrationTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/RemoteInstallerIntegrationTests.cs
@@ -168,6 +168,123 @@ public sealed class RemoteInstallerIntegrationTests : IDisposable
         Assert.Equal(1, CountLoaderLines(File.ReadAllText(BashrcPath)));
     }
 
+    /// <summary>
+    /// A `.bashrc` with no trailing newline is common (many editors don't add one). The append must
+    /// not land on the same line as the user's last line - it must first ensure the file ends in a
+    /// newline, then add the loader on its own line. A regression here breaks the user's last rc line
+    /// AND leaves the loader unreadable by the shell, on a remote host, while the installer still
+    /// reports success.
+    /// </summary>
+    [Fact]
+    public void Installer_BashrcWithoutTrailingNewline_PreservesLastLineAndAddsLoaderOnItsOwnLine()
+    {
+        File.WriteAllText(
+            BashrcPath,
+            "export FOO=bar",
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        string output = RunInstaller();
+
+        string expectedLoader = RemoteShellIntegrationSnippets.GetLoaderLine(RemoteShellIntegrationShell.BashOrZsh)!;
+        string rc = File.ReadAllText(BashrcPath).Replace("\r\n", "\n");
+        Assert.Equal($"export FOO=bar\n{expectedLoader}\n", rc);
+        Assert.Equal(1, CountLoaderLines(rc));
+        Assert.Contains("nova: added loader line to ~/.bashrc", output, StringComparison.Ordinal);
+    }
+
+    // ---- shell selection -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Every other behavioural test drives the bash arm via <c>${BASH_VERSION:+bash}</c>. This test
+    /// invokes the installer directly with an explicit "zsh" argument (the same technique
+    /// <see cref="FishInstaller_WritesTheSnippetIntoConfD"/> uses for fish) so the <c>zsh)</c> case
+    /// arm is actually exercised: it must patch <c>~/.zshrc</c>, not <c>~/.bashrc</c>.
+    /// </summary>
+    [Fact]
+    public void Installer_WithZshArgument_PatchesZshrcNotBashrc()
+    {
+        string? bash = ShellHarness.FindBash();
+        if (bash is null)
+        {
+            Assert.Skip("bash not found on this system");
+        }
+
+        string installer = RemoteShellIntegrationSnippets.BuildInstallerScript(
+            RemoteShellIntegrationShell.BashOrZsh);
+        string installerPath = Path.Combine(_home, "nova-install.sh");
+        File.WriteAllText(installerPath, installer, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        var startInfo = new ProcessStartInfo(bash)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add(installerPath.Replace('\\', '/'));
+        startInfo.ArgumentList.Add("zsh");
+        startInfo.Environment["HOME"] = HomeForShell;
+
+        using Process process = Process.Start(startInfo)!;
+        string output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "installer did not finish within 30s");
+
+        string zshrcPath = Path.Combine(_home, ".zshrc");
+        Assert.True(File.Exists(zshrcPath), $"~/.zshrc not created. output:\n{output}");
+        Assert.False(File.Exists(BashrcPath), "~/.bashrc should not be touched when zsh is selected");
+        Assert.Contains(
+            RemoteShellIntegrationSnippets.GetLoaderLine(RemoteShellIntegrationShell.BashOrZsh)!,
+            File.ReadAllText(zshrcPath),
+            StringComparison.Ordinal);
+        Assert.Contains("nova: added loader line to ~/.zshrc", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The <c>*)</c> arm: no argument and an unrecognized/unset <c>$SHELL</c>. The installer cannot
+    /// silently do nothing here - it must tell the user it could not tell which shell they use and
+    /// print the loader line for them to add by hand, and it must not create either rc file.
+    /// </summary>
+    [Fact]
+    public void Installer_WithUnrecognizedShell_TellsTheUserAndPrintsTheLoaderLine()
+    {
+        string? bash = ShellHarness.FindBash();
+        if (bash is null)
+        {
+            Assert.Skip("bash not found on this system");
+        }
+
+        string installer = RemoteShellIntegrationSnippets.BuildInstallerScript(
+            RemoteShellIntegrationShell.BashOrZsh);
+        string installerPath = Path.Combine(_home, "nova-install.sh");
+        File.WriteAllText(installerPath, installer, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        var startInfo = new ProcessStartInfo(bash)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add(installerPath.Replace('\\', '/'));
+        startInfo.ArgumentList.Add(string.Empty);
+        startInfo.Environment["HOME"] = HomeForShell;
+        // Override whatever $SHELL the test machine happens to have so the fallback resolves to
+        // something the case statement's zsh)/bash) arms cannot match, deterministically reaching *).
+        startInfo.Environment["SHELL"] = "/bin/nonsense-shell";
+
+        using Process process = Process.Start(startInfo)!;
+        string output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "installer did not finish within 30s");
+
+        Assert.Contains("nova: could not tell which shell you use", output, StringComparison.Ordinal);
+        Assert.Contains(
+            RemoteShellIntegrationSnippets.GetLoaderLine(RemoteShellIntegrationShell.BashOrZsh)!,
+            output,
+            StringComparison.Ordinal);
+        Assert.False(File.Exists(BashrcPath), "~/.bashrc should not be created when the shell is unknown");
+        Assert.False(
+            File.Exists(Path.Combine(_home, ".zshrc")),
+            "~/.zshrc should not be created when the shell is unknown");
+    }
+
     // ---- failure ---------------------------------------------------------------------------------
 
     /// <summary>
@@ -330,7 +447,8 @@ public sealed class RemoteInstallerIntegrationTests : IDisposable
     /// <summary>
     /// The design's central promise: the installer runs as a child, so nothing it defines can reach
     /// the shell that pasted the line. Asserted by checking the calling shell afterwards for the
-    /// installer's own variables and for the snippet's marker function.
+    /// installer's own variables, <c>__nova_dest</c> and <c>__nova_t</c> - not the snippet, which this
+    /// probe does not source and so cannot say anything about.
     /// </summary>
     [Fact]
     public void Installer_LeavesNothingBehindInTheCallingShell()
@@ -399,6 +517,91 @@ public sealed class RemoteInstallerIntegrationTests : IDisposable
             File.ReadAllText(dest).Replace("\r\n", "\n").TrimEnd('\n'));
         Assert.Equal(1, CountLoaderLines(File.ReadAllText(profilePath)));
         Assert.Contains("already present", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The PowerShell equivalent of
+    /// <see cref="Installer_BashrcWithoutTrailingNewline_PreservesLastLineAndAddsLoaderOnItsOwnLine"/>:
+    /// <c>Add-Content</c> against a profile that does not end in a newline concatenates the loader
+    /// onto the user's last line instead of appending it as its own line.
+    /// </summary>
+    [Fact]
+    public void PowerShellInstaller_ProfileWithoutTrailingNewline_PreservesLastLineAndAddsLoaderOnItsOwnLine()
+    {
+        string? pwsh = FindPwsh();
+        if (pwsh is null)
+        {
+            Assert.Skip("pwsh not found on this system");
+        }
+
+        string installerPath = Path.Combine(_home, "nova-install.ps1");
+        File.WriteAllText(
+            installerPath,
+            RemoteShellIntegrationSnippets.BuildInstallerScript(
+                RemoteShellIntegrationShell.PowerShell),
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        string profilePath = Path.Combine(_home, "profile.ps1");
+        File.WriteAllText(profilePath, "$x = 1", new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        string output = RunPwsh(pwsh, installerPath, profilePath);
+
+        string expectedLoader = RemoteShellIntegrationSnippets.GetLoaderLine(RemoteShellIntegrationShell.PowerShell)!;
+        string profile = File.ReadAllText(profilePath).Replace("\r\n", "\n");
+        Assert.Equal($"$x = 1\n{expectedLoader}\n", profile);
+        Assert.Contains("nova: added loader line", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// <see cref="PowerShellInstaller_WritesTheSnippetAndPatchesTheProfileOnce"/> invokes the
+    /// installer via <c>-File</c>, which parses the script as its own document and never exercises
+    /// the generated one-liner's own syntax - the wrapper that decodes and runs it. This parses (but
+    /// does not execute, to avoid touching the developer's real <c>$PROFILE</c>) the actual generated
+    /// <see cref="RemoteShellIntegrationSnippets.BuildInstallerCommand"/> string for the PowerShell
+    /// shell through <see cref="System.Management.Automation.Language.Parser.ParseInput"/> in a real
+    /// pwsh, so a quoting or precedence slip in the wrapper template would fail here.
+    /// </summary>
+    [Fact]
+    public void PowerShellOneLiner_ParsesWithoutErrors()
+    {
+        string? pwsh = FindPwsh();
+        if (pwsh is null)
+        {
+            Assert.Skip("pwsh not found on this system");
+        }
+
+        string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(
+            RemoteShellIntegrationShell.PowerShell);
+        string commandPath = Path.Combine(_home, "nova-install-oneliner.txt");
+        File.WriteAllText(commandPath, command, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        string parseScript =
+            "$__cmd = Get-Content -LiteralPath '" + commandPath.Replace('\\', '/') + "' -Raw\n" +
+            "$__tokens = $null\n" +
+            "$__errors = $null\n" +
+            "[void][System.Management.Automation.Language.Parser]::ParseInput($__cmd, [ref]$__tokens, [ref]$__errors)\n" +
+            "if ($__errors.Count -gt 0) {\n" +
+            "    $__errors | ForEach-Object { [Console]::Error.WriteLine($_.ToString()) }\n" +
+            "    exit 1\n" +
+            "} else {\n" +
+            "    exit 0\n" +
+            "}\n";
+
+        var startInfo = new ProcessStartInfo(pwsh)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add("-NoProfile");
+        startInfo.ArgumentList.Add("-NonInteractive");
+        startInfo.ArgumentList.Add("-Command");
+        startInfo.ArgumentList.Add(parseScript);
+
+        using Process process = Process.Start(startInfo)!;
+        string output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "parse check did not finish within 30s");
+        Assert.True(process.ExitCode == 0, $"one-liner failed to parse:\n{output}\ncommand:\n{command}");
     }
 
     private static string? FindPwsh()

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/RemoteInstallerIntegrationTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/RemoteInstallerIntegrationTests.cs
@@ -365,4 +365,75 @@ public sealed class RemoteInstallerIntegrationTests : IDisposable
         Assert.Contains("probe-dest=[]", output, StringComparison.Ordinal);
         Assert.Contains("probe-temp=[]", output, StringComparison.Ordinal);
     }
+
+    // ---- powershell ---------------------------------------------------------------------------
+
+    /// <summary>
+    /// The PowerShell installer, run by a real pwsh with both of its parameters redirected into the
+    /// temp HOME. The parameters are the only reason this is testable: <c>$PROFILE</c> resolves
+    /// under the developer's Documents directory and cannot be redirected by an environment variable.
+    /// </summary>
+    [Fact]
+    public void PowerShellInstaller_WritesTheSnippetAndPatchesTheProfileOnce()
+    {
+        string? pwsh = FindPwsh();
+        if (pwsh is null)
+        {
+            Assert.Skip("pwsh not found on this system");
+        }
+
+        string installerPath = Path.Combine(_home, "nova-install.ps1");
+        File.WriteAllText(
+            installerPath,
+            RemoteShellIntegrationSnippets.BuildInstallerScript(
+                RemoteShellIntegrationShell.PowerShell),
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        string profilePath = Path.Combine(_home, "profile.ps1");
+        string output = RunPwsh(pwsh, installerPath, profilePath) + RunPwsh(pwsh, installerPath, profilePath);
+
+        string dest = Path.Combine(_home, ".nova-shell-integration.ps1");
+        Assert.True(File.Exists(dest), $"snippet not written. output:\n{output}");
+        Assert.Equal(
+            RemoteShellIntegrationSnippets.Read(RemoteShellIntegrationShell.PowerShell).TrimEnd('\n'),
+            File.ReadAllText(dest).Replace("\r\n", "\n").TrimEnd('\n'));
+        Assert.Equal(1, CountLoaderLines(File.ReadAllText(profilePath)));
+        Assert.Contains("already present", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? FindPwsh()
+    {
+        string? pathEnv = Environment.GetEnvironmentVariable("PATH");
+        if (pathEnv is null) return null;
+        string exe = OperatingSystem.IsWindows() ? "pwsh.exe" : "pwsh";
+        foreach (string dir in pathEnv.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            string candidate = Path.Combine(dir, exe);
+            if (File.Exists(candidate)) return candidate;
+        }
+        return null;
+    }
+
+    private string RunPwsh(string pwsh, string installerPath, string profilePath)
+    {
+        var startInfo = new ProcessStartInfo(pwsh)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add("-NoProfile");
+        startInfo.ArgumentList.Add("-NonInteractive");
+        startInfo.ArgumentList.Add("-File");
+        startInfo.ArgumentList.Add(installerPath);
+        startInfo.ArgumentList.Add("-ProfilePath");
+        startInfo.ArgumentList.Add(profilePath);
+        startInfo.ArgumentList.Add("-DestDir");
+        startInfo.ArgumentList.Add(_home);
+
+        using Process process = Process.Start(startInfo)!;
+        string output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(60_000), "pwsh installer did not finish within 60s");
+        return output;
+    }
 }

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/RemoteInstallerIntegrationTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/RemoteInstallerIntegrationTests.cs
@@ -283,6 +283,48 @@ public sealed class RemoteInstallerIntegrationTests : IDisposable
             File.ReadAllText(dest).Replace("\r\n", "\n").TrimEnd('\n'));
     }
 
+    /// <summary>
+    /// FishInstaller_WritesTheSnippetIntoConfD deliberately runs the *installer* (POSIX sh) under
+    /// bash, because the installer itself is sh - but that means nothing in the suite exercises the
+    /// fish one-liner *wrapper* (<c>set -l __nova_t (mktemp); ...</c>) through a real fish. A bad
+    /// quote, an operator precedence slip, or an accidental <c>$(...)</c> where <c>(...)</c> is
+    /// required would ship undetected. This test runs the actual generated one-liner through
+    /// <c>fish -c</c>, mirroring <see cref="RunInstaller"/>'s bash equivalent.
+    /// </summary>
+    [Fact]
+    public void FishOneLiner_RunsUnderRealFish()
+    {
+        string? fish = ShellHarness.FindFish();
+        if (fish is null)
+        {
+            Assert.Skip("fish not found on this system");
+        }
+
+        string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(
+            RemoteShellIntegrationShell.Fish);
+
+        var startInfo = new ProcessStartInfo(fish)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add("-c");
+        startInfo.ArgumentList.Add(command);
+        startInfo.Environment["HOME"] = HomeForShell;
+
+        using Process process = Process.Start(startInfo)!;
+        string output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "fish one-liner did not finish within 30s");
+
+        string dest = Path.Combine(_home, ".config", "fish", "conf.d", "nova-shell-integration.fish");
+        Assert.True(File.Exists(dest), $"fish snippet not written. output:\n{output}");
+        Assert.Equal(
+            RemoteShellIntegrationSnippets.Read(RemoteShellIntegrationShell.Fish).TrimEnd('\n'),
+            File.ReadAllText(dest).Replace("\r\n", "\n").TrimEnd('\n'));
+        Assert.Contains("nova:", output, StringComparison.Ordinal);
+    }
+
     // ---- the live shell is untouched -------------------------------------------------------------
 
     /// <summary>

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/RemoteInstallerIntegrationTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/RemoteInstallerIntegrationTests.cs
@@ -239,6 +239,50 @@ public sealed class RemoteInstallerIntegrationTests : IDisposable
         Assert.Contains(result.Events, e => e.Kind == "D" && e.DecodedFinish.exitCode == 0);
     }
 
+    // ---- fish -------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The fish installer is POSIX sh, so it is exercised under bash: the payload it writes is fish
+    /// content, but nothing about running the installer needs fish present. That the fish snippet
+    /// itself works is FishShellIntegrationTests' job.
+    /// </summary>
+    [Fact]
+    public void FishInstaller_WritesTheSnippetIntoConfD()
+    {
+        string? bash = ShellHarness.FindBash();
+        if (bash is null)
+        {
+            Assert.Skip("bash not found on this system");
+        }
+
+        // Run the fish installer's payload directly: the fish one-liner is fish syntax, which bash
+        // cannot parse, and what is under test here is the installer it decodes to.
+        string installer = RemoteShellIntegrationSnippets.BuildInstallerScript(
+            RemoteShellIntegrationShell.Fish);
+        string installerPath = Path.Combine(_home, "nova-install-fish.sh");
+        File.WriteAllText(installerPath, installer, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        var startInfo = new ProcessStartInfo(bash)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add(installerPath.Replace('\\', '/'));
+        startInfo.ArgumentList.Add("fish");
+        startInfo.Environment["HOME"] = HomeForShell;
+
+        using Process process = Process.Start(startInfo)!;
+        string output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "fish installer did not finish within 30s");
+
+        string dest = Path.Combine(_home, ".config", "fish", "conf.d", "nova-shell-integration.fish");
+        Assert.True(File.Exists(dest), $"fish snippet not written. output:\n{output}");
+        Assert.Equal(
+            RemoteShellIntegrationSnippets.Read(RemoteShellIntegrationShell.Fish).TrimEnd('\n'),
+            File.ReadAllText(dest).Replace("\r\n", "\n").TrimEnd('\n'));
+    }
+
     // ---- the live shell is untouched -------------------------------------------------------------
 
     /// <summary>

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/RemoteShellIntegrationInstallerTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/RemoteShellIntegrationInstallerTests.cs
@@ -1,0 +1,132 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using NovaTerminal.CommandAssist.ShellIntegration.Remote;
+
+namespace NovaTerminal.Tests.CommandAssist.ShellIntegration;
+
+/// <summary>
+/// The one-line installer Settings copies (see
+/// docs/plans/2026-08-06-remote-shell-integration-installer-design.md).
+/// </summary>
+/// <remarks>
+/// These are static assertions on the generated command. They exist to pin the three properties the
+/// design rests on and that nothing else can catch: it is one line (two lines would be two history
+/// entries, which is the whole point of the change), the payload is pure base64 (which is why no
+/// escaping logic exists anywhere in this path), and the snippet survives the compress/encode round
+/// trip byte-for-byte. RemoteInstallerIntegrationTests is the layer that says it *works*.
+/// </remarks>
+public sealed class RemoteShellIntegrationInstallerTests
+{
+    [Fact]
+    public void BashOrZshInstaller_IsExactlyOneLine()
+    {
+        string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(
+            RemoteShellIntegrationShell.BashOrZsh);
+
+        Assert.DoesNotContain("\n", command, StringComparison.Ordinal);
+        Assert.DoesNotContain("\r", command, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The single-quoted payload is the reason this design has no escaping logic: base64's alphabet
+    /// contains no shell metacharacter, so the quoting can never be wrong. If an encoding change
+    /// ever put a quote or a backslash in there, every one-liner would break at the paste.
+    /// </summary>
+    [Fact]
+    public void BashOrZshInstaller_CarriesPureBase64InSingleQuotes()
+    {
+        string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(
+            RemoteShellIntegrationShell.BashOrZsh);
+
+        Match match = Regex.Match(command, @"printf %s '([^']*)'");
+
+        Assert.True(match.Success, $"no single-quoted printf payload in: {command}");
+        Assert.Matches("^[A-Za-z0-9+/=]+$", match.Groups[1].Value);
+    }
+
+    [Fact]
+    public void BashOrZshInstaller_PayloadDecodesToTheInstallerScript()
+    {
+        string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(
+            RemoteShellIntegrationShell.BashOrZsh);
+        string payload = Regex.Match(command, @"printf %s '([^']*)'").Groups[1].Value;
+
+        string decoded = Decompress(payload);
+
+        Assert.Equal(
+            RemoteShellIntegrationSnippets.BuildInstallerScript(
+                RemoteShellIntegrationShell.BashOrZsh),
+            decoded);
+    }
+
+    /// <summary>
+    /// The snippet has to arrive on the remote host unchanged; a heredoc that mangled it would still
+    /// produce a plausible-looking installer.
+    /// </summary>
+    [Fact]
+    public void BashOrZshInstaller_EmbedsTheSnippetByteForByte()
+    {
+        string installer = RemoteShellIntegrationSnippets.BuildInstallerScript(
+            RemoteShellIntegrationShell.BashOrZsh);
+        string snippet = RemoteShellIntegrationSnippets.Read(RemoteShellIntegrationShell.BashOrZsh);
+
+        Assert.Contains(snippet.TrimEnd('\n'), installer, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The installer's loader line and the descriptor's must be the same string, or the row tells
+    /// the user one thing and the installer writes another.
+    /// </summary>
+    [Fact]
+    public void BashOrZshInstaller_UsesTheDescriptorsLoaderLine()
+    {
+        string installer = RemoteShellIntegrationSnippets.BuildInstallerScript(
+            RemoteShellIntegrationShell.BashOrZsh);
+        string? loader = RemoteShellIntegrationSnippets.GetLoaderLine(
+            RemoteShellIntegrationShell.BashOrZsh);
+
+        Assert.NotNull(loader);
+        Assert.Contains(loader, installer, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A snippet line starting with the heredoc terminator would end the heredoc early, so the
+    /// installed file would be silently truncated and the rest of the snippet would run as shell
+    /// commands on the user's remote host. Failing at copy time is the only place this can be caught.
+    /// </summary>
+    [Fact]
+    public void BuildInstallerScript_ThrowsWhenTheSnippetCollidesWithTheDelimiter()
+    {
+        string colliding = "echo one\n__NOVA_SNIPPET_EOF__\necho two\n";
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            RemoteShellIntegrationSnippets.BuildInstallerScript(
+                RemoteShellIntegrationShell.BashOrZsh,
+                colliding));
+
+        Assert.Contains("__NOVA_SNIPPET_EOF__", exception.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>And no shipped snippet collides, which is why the guard never fires in practice.</summary>
+    [Theory]
+    [InlineData(RemoteShellIntegrationShell.BashOrZsh)]
+    public void NoSnippet_CollidesWithTheInstallerDelimiter(RemoteShellIntegrationShell shell)
+    {
+        string installer = RemoteShellIntegrationSnippets.BuildInstallerScript(shell);
+        string snippet = RemoteShellIntegrationSnippets.Read(shell);
+
+        Assert.Contains("__NOVA_SNIPPET_EOF__", installer, StringComparison.Ordinal);
+        Assert.DoesNotContain("__NOVA_SNIPPET_EOF__", snippet, StringComparison.Ordinal);
+    }
+
+    internal static string Decompress(string base64)
+    {
+        byte[] raw = Convert.FromBase64String(base64);
+        using var input = new MemoryStream(raw);
+        using var gzip = new System.IO.Compression.GZipStream(
+            input, System.IO.Compression.CompressionMode.Decompress);
+        using var output = new MemoryStream();
+        gzip.CopyTo(output);
+        return Encoding.UTF8.GetString(output.ToArray());
+    }
+}

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/RemoteShellIntegrationInstallerTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/RemoteShellIntegrationInstallerTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
 using NovaTerminal.CommandAssist.ShellIntegration.Remote;
@@ -38,9 +39,9 @@ public sealed class RemoteShellIntegrationInstallerTests
         string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(
             RemoteShellIntegrationShell.BashOrZsh);
 
-        Match match = Regex.Match(command, @"printf %s '([^']*)'");
+        Match match = Regex.Match(command, PayloadPattern);
 
-        Assert.True(match.Success, $"no single-quoted printf payload in: {command}");
+        Assert.True(match.Success, $"no single-quoted payload assignment in: {command}");
         Assert.Matches("^[A-Za-z0-9+/=]+$", match.Groups[1].Value);
     }
 
@@ -49,7 +50,7 @@ public sealed class RemoteShellIntegrationInstallerTests
     {
         string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(
             RemoteShellIntegrationShell.BashOrZsh);
-        string payload = Regex.Match(command, @"printf %s '([^']*)'").Groups[1].Value;
+        string payload = ExtractPayload(command);
 
         string decoded = Decompress(payload);
 
@@ -140,8 +141,9 @@ public sealed class RemoteShellIntegrationInstallerTests
         string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(
             RemoteShellIntegrationShell.Fish);
 
+        Assert.Contains("set -l __nova_b '", command, StringComparison.Ordinal);
         Assert.Contains("set -l __nova_t (mktemp)", command, StringComparison.Ordinal);
-        Assert.Contains("set -e __nova_t", command, StringComparison.Ordinal);
+        Assert.Contains("set -e __nova_b __nova_t __nova_d", command, StringComparison.Ordinal);
         Assert.DoesNotContain("$(mktemp)", command, StringComparison.Ordinal);
     }
 
@@ -150,7 +152,7 @@ public sealed class RemoteShellIntegrationInstallerTests
     {
         string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(
             RemoteShellIntegrationShell.Fish);
-        string payload = Regex.Match(command, @"printf %s '([^']*)'").Groups[1].Value;
+        string payload = ExtractPayload(command);
 
         Assert.Equal(
             RemoteShellIntegrationSnippets.BuildInstallerScript(RemoteShellIntegrationShell.Fish),
@@ -224,9 +226,10 @@ public sealed class RemoteShellIntegrationInstallerTests
     {
         string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(
             RemoteShellIntegrationShell.PowerShell);
-        string payload = Regex.Match(command, @"FromBase64String\('([^']*)'\)").Groups[1].Value;
+        string payload = ExtractPayload(command);
 
         Assert.Matches("^[A-Za-z0-9+/=]+$", payload);
+        Assert.Contains("FromBase64String($__nova_b)", command, StringComparison.Ordinal);
         Assert.Equal(
             RemoteShellIntegrationSnippets.BuildInstallerScript(
                 RemoteShellIntegrationShell.PowerShell),
@@ -245,6 +248,193 @@ public sealed class RemoteShellIntegrationInstallerTests
         Assert.DoesNotContain(
             snippet.Split('\n'),
             line => line.StartsWith("'@", StringComparison.Ordinal));
+    }
+
+    // ---- truncation and length --------------------------------------------------------------
+
+    /// <summary>
+    /// The two arms that carry a payload-length check compare against a literal, and that literal
+    /// is the length the payload actually has.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// What the check catches is <em>mid-stream byte loss</em> - a flaky link, a multiplexer
+    /// dropping a chunk of a paste - where bytes vanish from the middle and the tail still arrives.
+    /// It does not catch a canonical-mode tty cut and cannot:
+    /// <see cref="Integration.RemoteInstallerIntegrationTests.Installer_TruncatedAtTheCanonicalTtyLimit_FailsInTheShellBeforeAnyOfOurCodeRuns"/>
+    /// runs that case and shows the shell rejecting the line on the unterminated quote, with none
+    /// of the installer reached.
+    /// </para>
+    /// <para>
+    /// Without the comparison, mid-stream loss surfaces only as a decode failure, and the
+    /// installer's only honest guess would be "this host needs base64 and gzip" - on a host that
+    /// has both. A literal that drifted out of step with the payload would be worse than none:
+    /// every paste would report truncation. Hence both halves of this assertion.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData(RemoteShellIntegrationShell.BashOrZsh)]
+    [InlineData(RemoteShellIntegrationShell.PowerShell)]
+    public void Installer_ComparesThePayloadAgainstItsRealLength(RemoteShellIntegrationShell shell)
+    {
+        string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(shell);
+
+        // "-ne " cannot occur inside the payload: base64's alphabet is [A-Za-z0-9+/=].
+        Match guard = Regex.Match(command, @"-ne (\d+)");
+
+        Assert.True(guard.Success, $"no payload-length guard in: {command}");
+        Assert.Equal(ExtractPayload(command).Length.ToString(CultureInfo.InvariantCulture), guard.Groups[1].Value);
+    }
+
+    /// <summary>
+    /// Mid-stream loss and a broken decoder get different sentences. The point of the length check
+    /// is that the installer stops having to blame one for the other.
+    /// </summary>
+    [Theory]
+    [InlineData(RemoteShellIntegrationShell.BashOrZsh)]
+    [InlineData(RemoteShellIntegrationShell.PowerShell)]
+    public void Installer_DistinguishesTruncationFromAFailedDecode(RemoteShellIntegrationShell shell)
+    {
+        string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(shell);
+
+        Assert.Contains("cut short", command, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "install failed - this host needs base64 and gzip",
+            command,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// fish carries no length check, and the reason is the number this test pins: fish is the one
+    /// arm whose whole line fits under <c>N_TTY_BUF_SIZE</c>, so it is the one arm a tty cannot
+    /// truncate - and a length check costs ~300 bytes of exactly the headroom that makes that true.
+    /// Adding one would put fish on the edge of the failure it was meant to report.
+    /// </summary>
+    /// <remarks>
+    /// The bound is 4096 rather than "current length plus slack" on purpose: 4096 is the property
+    /// that matters. If a snippet edit ever pushes fish over it, the answer is to shrink the
+    /// snippet or to accept the loss and add the check back - not to raise this number.
+    /// </remarks>
+    [Fact]
+    public void FishInstaller_FitsUnderTheCanonicalTtyLineLimit_AndSoCarriesNoLengthCheck()
+    {
+        string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(
+            RemoteShellIntegrationShell.Fish);
+
+        Assert.True(
+            command.Length < 4096,
+            $"fish one-liner is {command.Length} chars, at or over the 4096-byte N_TTY_BUF_SIZE limit");
+        Assert.DoesNotContain("cut short", command, StringComparison.Ordinal);
+        Assert.DoesNotContain("string length", command, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A tripwire, not a target: it exists so that a snippet edit which doubles the payload is
+    /// noticed here rather than on a user's remote host. The docs page quotes "about 8.5 KB" for
+    /// bash/zsh and pwsh; if this fails, re-measure and update it.
+    /// </summary>
+    [Theory]
+    [InlineData(RemoteShellIntegrationShell.BashOrZsh, 10_240)]
+    [InlineData(RemoteShellIntegrationShell.PowerShell, 10_240)]
+    public void Installer_StaysWithinItsLengthBudget(RemoteShellIntegrationShell shell, int budget)
+    {
+        string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(shell);
+
+        Assert.True(
+            command.Length <= budget,
+            $"{shell} one-liner is {command.Length} chars, over the {budget} budget");
+    }
+
+    /// <summary>
+    /// The <c>mktemp</c> fallback that used to be here - <c>printf /tmp/nova-si.%s "$$"</c> - is a
+    /// local privilege-escalation hole and must not come back. <c>mktemp</c> gives 0600 and
+    /// <c>O_EXCL</c>; a name built from <c>$$</c> (visible in <c>ps</c>) gives neither, and
+    /// <c>&gt;</c> follows symlinks and leaves an existing file's mode and owner alone. Another
+    /// local user pre-creates the path 0666 and rewrites it between the redirect and
+    /// <c>sh "$__nova_t"</c>, or points it at <c>~/.bashrc</c> and lets the redirect truncate that.
+    /// </summary>
+    [Theory]
+    [InlineData(RemoteShellIntegrationShell.BashOrZsh)]
+    [InlineData(RemoteShellIntegrationShell.Fish)]
+    public void ShInstallers_HaveNoPredictableTempFileFallback(RemoteShellIntegrationShell shell)
+    {
+        string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(shell);
+
+        Assert.Contains("mktemp", command, StringComparison.Ordinal);
+        Assert.DoesNotContain("/tmp/nova-si", command, StringComparison.Ordinal);
+        Assert.DoesNotContain("$$", command, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// <c>base64 -d</c> is the GNU spelling; macOS's <c>/usr/bin/base64</c> before Ventura only
+    /// accepts <c>-D</c>. The sh arms probe once with a test vector rather than retrying the real
+    /// payload, because the first attempt would already have consumed stdin. The variable holds the
+    /// bare letter so fish's <c>set</c> never sees a value shaped like one of its own options.
+    /// </summary>
+    [Theory]
+    [InlineData(RemoteShellIntegrationShell.BashOrZsh)]
+    [InlineData(RemoteShellIntegrationShell.Fish)]
+    public void ShInstallers_ProbeForTheBsdBase64DecodeFlag(RemoteShellIntegrationShell shell)
+    {
+        string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(shell);
+
+        Assert.Contains("printf %s Kg== | base64 -d >/dev/null 2>&1", command, StringComparison.Ordinal);
+        Assert.Matches(@"__nova_d\s*=?\s*D\b", command);
+        Assert.DoesNotContain("__nova_d -D", command, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The decode branch is taken on the pipeline's exit status, never on the temp file being
+    /// non-empty: <c>gzip -dc</c> writes what it inflated before it failed, so a corrupt payload
+    /// leaves a non-empty, syntactically broken installer that <c>[ -s ]</c> waves through and
+    /// <c>sh</c> then runs - an unterminated heredoc writes a truncated snippet, "wrote" is
+    /// printed, the loader line is appended, and every future shell sources a broken file.
+    /// </summary>
+    [Fact]
+    public void BashOrZshInstaller_BranchesOnTheDecodeStatusNotTheFileSize()
+    {
+        string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(
+            RemoteShellIntegrationShell.BashOrZsh);
+
+        Assert.Contains(
+            "if printf %s \"$__nova_b\" | base64 \"-$__nova_d\" | gzip -dc > \"$__nova_t\"; then",
+            command,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("[ -s \"$__nova_t\" ]", command, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The fish arm had no error handling at all while its bash sibling had three checks. With no
+    /// <c>mktemp</c>, <c>$__nova_t</c> expands to zero arguments, the redirect is a fish error, and
+    /// <c>sh $__nova_t fish</c> degrades to <c>sh fish</c> - which fails silently as far as the user
+    /// can tell.
+    /// </summary>
+    [Fact]
+    public void FishInstaller_HandlesTheSameFailuresAsItsBashSibling()
+    {
+        string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(
+            RemoteShellIntegrationShell.Fish);
+
+        Assert.Contains("if test -z \"$__nova_t\"", command, StringComparison.Ordinal);
+        Assert.Contains("nova: install failed - mktemp", command, StringComparison.Ordinal);
+        Assert.Contains(
+            "if printf %s $__nova_b | base64 -$__nova_d | gzip -dc > $__nova_t;",
+            command,
+            StringComparison.Ordinal);
+        Assert.Contains("nova: install failed - this host needs a working base64", command, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The single-quoted payload assignment each arm opens with. The blob is base64, so
+    /// <c>[^']*</c> cannot terminate early.
+    /// </summary>
+    private const string PayloadPattern = @"__nova_b\s*=?\s*'([^']*)'";
+
+    private static string ExtractPayload(string command)
+    {
+        Match match = Regex.Match(command, PayloadPattern);
+        Assert.True(match.Success, $"no payload found in: {command}");
+        return match.Groups[1].Value;
     }
 
     internal static string Decompress(string base64)

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/RemoteShellIntegrationInstallerTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/RemoteShellIntegrationInstallerTests.cs
@@ -110,6 +110,7 @@ public sealed class RemoteShellIntegrationInstallerTests
     /// <summary>And no shipped snippet collides, which is why the guard never fires in practice.</summary>
     [Theory]
     [InlineData(RemoteShellIntegrationShell.BashOrZsh)]
+    [InlineData(RemoteShellIntegrationShell.Fish)]
     public void NoSnippet_CollidesWithTheInstallerDelimiter(RemoteShellIntegrationShell shell)
     {
         string installer = RemoteShellIntegrationSnippets.BuildInstallerScript(shell);
@@ -117,6 +118,65 @@ public sealed class RemoteShellIntegrationInstallerTests
 
         Assert.Contains("__NOVA_SNIPPET_EOF__", installer, StringComparison.Ordinal);
         Assert.DoesNotContain("__NOVA_SNIPPET_EOF__", snippet, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FishInstaller_IsExactlyOneLine()
+    {
+        string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(
+            RemoteShellIntegrationShell.Fish);
+
+        Assert.DoesNotContain("\n", command, StringComparison.Ordinal);
+        Assert.DoesNotContain("\r", command, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// fish syntax, not sh: <c>set -l</c> and <c>(mktemp)</c> rather than <c>$(mktemp)</c>. Pasting
+    /// an sh one-liner into fish fails on the first command substitution.
+    /// </summary>
+    [Fact]
+    public void FishInstaller_UsesFishSyntax()
+    {
+        string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(
+            RemoteShellIntegrationShell.Fish);
+
+        Assert.Contains("set -l __nova_t (mktemp)", command, StringComparison.Ordinal);
+        Assert.Contains("set -e __nova_t", command, StringComparison.Ordinal);
+        Assert.DoesNotContain("$(mktemp)", command, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FishInstaller_PayloadDecodesToTheInstallerScript()
+    {
+        string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(
+            RemoteShellIntegrationShell.Fish);
+        string payload = Regex.Match(command, @"printf %s '([^']*)'").Groups[1].Value;
+
+        Assert.Equal(
+            RemoteShellIntegrationSnippets.BuildInstallerScript(RemoteShellIntegrationShell.Fish),
+            Decompress(payload));
+    }
+
+    /// <summary>
+    /// The fish installer is POSIX sh carrying fish content: the wrapper must not have been written
+    /// in fish by mistake, and the payload must be the fish snippet.
+    /// </summary>
+    [Fact]
+    public void FishInstaller_IsPosixShCarryingTheFishSnippet()
+    {
+        string installer = RemoteShellIntegrationSnippets.BuildInstallerScript(
+            RemoteShellIntegrationShell.Fish);
+
+        Assert.StartsWith("#!/bin/sh", installer, StringComparison.Ordinal);
+        Assert.Contains(
+            RemoteShellIntegrationSnippets.Read(RemoteShellIntegrationShell.Fish).TrimEnd('\n'),
+            installer,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            RemoteShellIntegrationSnippets.GetRemotePath(RemoteShellIntegrationShell.Fish)
+                .Replace("~/", string.Empty, StringComparison.Ordinal),
+            installer,
+            StringComparison.Ordinal);
     }
 
     internal static string Decompress(string base64)

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/RemoteShellIntegrationInstallerTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/RemoteShellIntegrationInstallerTests.cs
@@ -179,6 +179,74 @@ public sealed class RemoteShellIntegrationInstallerTests
             StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void PowerShellInstaller_IsExactlyOneLine()
+    {
+        string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(
+            RemoteShellIntegrationShell.PowerShell);
+
+        Assert.DoesNotContain("\n", command, StringComparison.Ordinal);
+        Assert.DoesNotContain("\r", command, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Pure .NET: a remote pwsh on Windows has no base64 or gzip on PATH, and its `cat` is an alias
+    /// for Get-Content - which is exactly why the old `cat &gt; file` recipe could not work there.
+    /// </summary>
+    [Fact]
+    public void PowerShellInstaller_UsesNoExternalTools()
+    {
+        string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(
+            RemoteShellIntegrationShell.PowerShell);
+
+        Assert.Contains("[Convert]::FromBase64String(", command, StringComparison.Ordinal);
+        Assert.Contains("GZipStream", command, StringComparison.Ordinal);
+        Assert.DoesNotContain("base64 -d", command, StringComparison.Ordinal);
+        Assert.DoesNotContain("gzip", command, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The call operator, not dot-sourcing: a child scope is what keeps the installer out of the
+    /// user's session. A stray `. $__nova_t` here would reintroduce exactly what the design gave up.
+    /// </summary>
+    [Fact]
+    public void PowerShellInstaller_InvokesTheScriptInAChildScope()
+    {
+        string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(
+            RemoteShellIntegrationShell.PowerShell);
+
+        Assert.Contains("& $__nova_t", command, StringComparison.Ordinal);
+        Assert.DoesNotContain(". $__nova_t", command, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PowerShellInstaller_PayloadDecodesToTheInstallerScript()
+    {
+        string command = RemoteShellIntegrationSnippets.BuildInstallerCommand(
+            RemoteShellIntegrationShell.PowerShell);
+        string payload = Regex.Match(command, @"FromBase64String\('([^']*)'\)").Groups[1].Value;
+
+        Assert.Matches("^[A-Za-z0-9+/=]+$", payload);
+        Assert.Equal(
+            RemoteShellIntegrationSnippets.BuildInstallerScript(
+                RemoteShellIntegrationShell.PowerShell),
+            Decompress(payload));
+    }
+
+    /// <summary>
+    /// The here-string terminator is <c>'@</c> at the start of a line. A snippet line beginning with
+    /// it would end the string early and turn the rest of the snippet into code.
+    /// </summary>
+    [Fact]
+    public void PowerShellSnippet_DoesNotCollideWithTheHereStringTerminator()
+    {
+        string snippet = RemoteShellIntegrationSnippets.Read(RemoteShellIntegrationShell.PowerShell);
+
+        Assert.DoesNotContain(
+            snippet.Split('\n'),
+            line => line.StartsWith("'@", StringComparison.Ordinal));
+    }
+
     internal static string Decompress(string base64)
     {
         byte[] raw = Convert.FromBase64String(base64);


### PR DESCRIPTION
Replaces the copy-a-300-line-snippet flow for remote shell integration with a one-line
installer. Settings now offers "Copy installer" first and keeps the plain snippet as the
secondary path.

The first eight commits are pre-existing work from an earlier session. The last commit is
this round's review response - four blockers plus follow-ups, detailed below.

## How it works

The one-liner inlines a gzip+base64 payload, decodes it to a temp file, and runs it with
`sh` / `&`. Three arms: bash+zsh, fish, PowerShell.

**Nothing is fetched over the network.** The payload is fully inlined - no `curl`, no URL,
no supply-chain surface. That is the whole security story, and it is also the whole
mitigation: a user cannot verify that the 7 KB blob on their clipboard corresponds to the
reviewable sources in `assets/shell-integration/install/`. The threat model in
`docs/command-assist/RemoteShellIntegration.md` now says so plainly, and points at
"Copy plain snippet" as the out for anyone who wants to read what they are pasting.

Injection is structurally impossible rather than escaped away: the only interpolated value
is the base64 blob, whose alphabet is `[A-Za-z0-9+/=]`, so it cannot contain a quote, `$`,
backtick, `;`, newline, or `$(`. No host name, path, or other user-controlled value reaches
the generated command at all. Verified independently in all three shells, including fish's
distinct single-quote rules and PowerShell's backtick escape.

Neither installer needs an exec bit or a non-`noexec` `/tmp` - `sh <file>` and `& <file>`
both read rather than execute.

## Review blockers found and fixed

This branch was reviewed before merge. Four blockers, each reproduced with evidence, each
re-verified against that same reproduction after the fix.

**1. Both installers claimed success when the rc append had failed.** `printf ... >>` and
`Add-Content` had their status unchecked, so with a root-owned, `chattr +i`, or read-only
rc file the output read `nova: added loader line to ~/.bashrc` and exited 0. This is the
same bug an earlier commit on this branch already fixed for fish - the other two arms were
never checked. The asymmetry that gives it away: the snippet write was checked, only the rc
append was not. Now both appends are status-checked; on failure the installer says it could
not write, prints the loader line for the user to add by hand, and exits non-zero.

**2. The `mktemp` fallback was a local code-execution hole.**
`mktemp 2>/dev/null || printf /tmp/nova-si.%s "$$"` - `mktemp` gives 0600 and `O_EXCL`, the
fallback gives neither. `/tmp/nova-si.<pid>` is predictable (`$$` is visible in `ps`), and
`>` follows symlinks and does not change an existing file's mode or owner. On a shared host,
another local user pre-creates the path 0666, waits for a paste on a box where `mktemp` is
absent (busybox) or fails (unwritable `$TMPDIR`, a common hardening setting), and overwrites
the contents between the redirect and `sh "$__nova_t"`. A symlink variant needs no race at
all: point it at `~/.bashrc` and the redirect destroys the rc file. The fallback is deleted;
`mktemp` failing now fails the install cleanly. A safe fallback would need `set -C` plus an
unpredictable name - rejected as more machinery than the case is worth, and recorded as such.

**3. The "one line" is 7.7 KB, and the failure was misdiagnosed.** `N_TTY_BUF_SIZE` is 4096
and applies whenever ICANON is on - `docker exec -it <c> sh`, busybox/Alpine `ash`, `dash`
as `/bin/sh`, serial consoles, pwsh without PSReadLine. Interactive bash/zsh/fish use raw
mode via readline/ZLE, which is why this passed manual testing. Truncated, the decode failed
and the installer reported `this host needs base64 and gzip` on a host that had both,
sending users to install coreutils on a production container.
Now each of bash/zsh and pwsh embeds its payload length and compares before decoding, and
the decode branch keeps the base64/gzip message - accurate, because truncation has been
ruled out first. Also folded in: the branch is now the pipeline's exit status rather than
`[ -s ]`, which closes a related hole where `gzip -dc` writes output before failing, so a
partially inflated payload passed the size check and got executed - writing a truncated
snippet and appending a loader line that every future shell would then source.

**Honest limit, and it is written into the code and the docs rather than glossed:** the
length check catches mid-stream byte loss (a flaky link, a multiplexer dropping a paste
chunk). It cannot catch a canonical-mode tail cut. The opening quote sits at byte 9 and the
closing quote at 7966, so a 4096-byte cut always lands inside the payload literal and the
shell fails first with `unexpected EOF while looking for matching '` - none of our code
runs. A test now feeds the first 4095 bytes to a real bash and pins exactly that.

**4. The idempotency guard was a bare substring match.** A `.bashrc` containing only
`# I disabled nova-shell-integration on purpose` made the installer report "already present"
and write nothing - so a user who had previously commented the line out could never install.
Now anchored to a non-comment occurrence (`^[^#]*`), which also correctly tolerates an
indented loader line inside an `if` block.

## Also in the fix commit

- The fish arm had no error handling at all, unlike its bash sibling - now symmetric
  (mktemp check, decode-status branch, failure messages).
- fish deliberately carries NO length check. It is the one arm that fits under 4096
  (3680 bytes, 416 to spare); adding the check cost 324 bytes and left only 92, putting the
  arm on the edge of the very failure the check exists to report. A test asserts both the
  bound and the absence of the check, so the reasoning is enforced rather than just written
  down.
- PowerShell printed the literal string `$PROFILE` instead of the resolved path.
- `& $__nova_t` moved out of the decode `try`, so an error from the installer script is no
  longer reported as "the payload did not unpack".
- An unreachable `Test-Path` after `[IO.File]::WriteAllText` (which throws) became a real
  try/catch.
- `base64 -d` is the GNU spelling; older macOS only accepts `-D`. Now probed once, with the
  bare letter stored so fish's `set` never sees an option-shaped value.
- Two wrong size figures in a doc comment (off by 15-35%) replaced with a statement that
  cannot rot, pointing at the test that holds the measurement.
- Changelog-style comments ("this reverses the argument the class used to make", "rather
  than the 300-line paste this replaced") rewritten to state the reasoning as it stands.

## Testing

`RemoteShellIntegrationInstallerTests` 30, `RemoteInstallerIntegrationTests` 20 passed /
2 skipped, `RemoteShellIntegrationSnippetTests` 44, `PaneRemoteShellIntegrationTests` 17.
Clean build, 0 errors, no warnings in any changed file.

The integration tests really do run real shells - `bash`, `fish`, `pwsh` via `Process`,
asserting on files on disk, with the last one going through a real PTY and the production
OSC 133 parser. Every test scopes `HOME` / `-ProfilePath` / `-DestDir` to a per-test temp
directory; none can touch a real dotfile.

Two skips, both explicit rather than silent: `FishOneLiner_RunsUnderRealFish` (no fish on
Windows - it runs on Linux CI, which installs it) and a read-only-rc variant that self-skips
by trying the append rather than guessing the platform.

New guard tests are mutation-checked. Note for anyone repeating that: `copy /b` preserves
the source file's mtime, so a restore-from-backup can leave the file older than the compiled
DLL, MSBuild skips the recompile, and a `--no-build` run re-executes the mutant binary while
the source on disk is correct - a way to certify a mutant as clean. Touch the file and
rebuild.

`.gitattributes` was verified, not assumed: `git check-attr` and `git ls-files --eol`
confirm `text eol=lf` and `i/lf w/lf` on all three installers - LF in the index and in the
Windows working tree, checked as bytes. Without that, every installer would arrive with
`bad interpreter: /bin/bash^M`.

## Not verified

- The fish one-liner has never been executed - no fish on this box, and it is the only
  wholly unexercised shell path locally. Linux CI runs it.
- A real 4096-byte tty truncation. Byte lengths and quote offsets were measured precisely
  and the ICANON limit is well established, but nothing was pasted into a live ICANON shell.
- PowerShell 3.0/4.0 (`[...]::new()` needs 5.0+) and `ExecutionPolicy Restricted` blocking
  `& $__nova_t`. Worth a troubleshooting line later.
- Older macOS `base64 -D` - the probe is written but no macOS was available to run it.
- The Settings button row: two pills now share a 360px column, and the arithmetic suggests
  they may overflow (~443px). Flagged deliberately rather than blind-fixed - it wants eyes,
  not a guess. `SettingsWindow.axaml` layout is otherwise untouched by the fix commit.

## Note on CI weight

These tests carry `[Trait("Category","ShellIntegration")]` and so land in the App.Tests lane,
which `ci.yml` marks non-blocking (#81, Avalonia headless deadlock). So the only real
verification of a security-sensitive artifact runs in a job that cannot fail the build.
Pre-existing structure, not introduced here, but it changes what "the tests pass" is worth
on this particular PR.
