### PR TITLE
fix(pty): sideload the ConPTY host so a conhost crash can't kill the pane (#310)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,5 +38,9 @@
     <!-- MCP Dev Companion (NovaTerminal.McpServer) -->
     <PackageVersion Include="ModelContextProtocol" Version="1.4.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+
+    <!-- Sideloaded ConPTY host (#310). Ships conpty.dll + OpenConsole.exe so panes are
+         hosted by a known-good console host instead of whatever conhost.exe the OS has. -->
+    <PackageVersion Include="Microsoft.Windows.Console.ConPTY" Version="1.24.260710001" />
   </ItemGroup>
 </Project>

--- a/src/NovaTerminal.App/NovaTerminal.App.csproj
+++ b/src/NovaTerminal.App/NovaTerminal.App.csproj
@@ -26,10 +26,11 @@
     <PackageReference Include="SkiaSharp.HarfBuzz" />
     <PackageReference Include="SkiaSharp.NativeAssets.Win32" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
-    <!-- Sideloaded ConPTY host (#310). Nothing to compile against: we only want the two native
-         files out of it, and IncludeSideloadedConPtyHost below places them by hand. The package's
-         own build/targets keys off $(PlatformTarget), which is empty for this AnyCPU app, so it
-         would copy nothing - ExcludeAssets keeps it from running at all. -->
+    <!-- Sideloaded ConPTY host (#310). Nothing to compile against: we only want the native files
+         out of it, and the Content items further down place them by hand. The package's own
+         build/targets keys off $(PlatformTarget), which for this AnyCPU app is empty on a plain
+         build - so leaving it in charge would copy nothing. ExcludeAssets keeps it out entirely
+         rather than having its item copies race ours when a RID does set PlatformTarget. -->
     <PackageReference Include="Microsoft.Windows.Console.ConPTY" GeneratePathProperty="true"
       ExcludeAssets="all" PrivateAssets="all" />
   </ItemGroup>
@@ -261,8 +262,28 @@
     <!-- No RID (plain `build`): ship the host matching the machine doing the building. -->
     <NovaConPtyArch Condition="'$(NovaConPtyArch)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</NovaConPtyArch>
     <NovaConPtyDll>$(PkgMicrosoft_Windows_Console_ConPTY)\runtimes\win-$(NovaConPtyArch)\native\conpty.dll</NovaConPtyDll>
-    <NovaOpenConsoleExe>$(PkgMicrosoft_Windows_Console_ConPTY)\build\native\runtimes\$(NovaConPtyArch)\OpenConsole.exe</NovaOpenConsoleExe>
+    <NovaConPtyHostDir>$(PkgMicrosoft_Windows_Console_ConPTY)\build\native\runtimes\</NovaConPtyHostDir>
   </PropertyGroup>
+
+  <!-- One host per machine architecture this build can *run on*, not one for the architecture it
+       was built for: conpty.dll resolves OpenConsole.exe by machine arch, so an x64 bundle started
+       on Windows-on-ARM needs the arm64 host or it quietly falls back to the OS conhost - and
+       win-x64 is the only Windows RID release.yml produces, so that is the bundle ARM64 users get.
+       This mirrors the package's own ConptyRequires*Host matrix in
+       build/Microsoft.Windows.Console.ConPTY.props. -->
+  <ItemGroup Condition="'$(NovaTargetsWindows)' == 'true'">
+    <NovaRequiredConPtyHost Include="$(NovaConPtyHostDir)arm64\OpenConsole.exe">
+      <Link>arm64\OpenConsole.exe</Link>
+    </NovaRequiredConPtyHost>
+    <NovaRequiredConPtyHost Include="$(NovaConPtyHostDir)x64\OpenConsole.exe"
+      Condition="'$(NovaConPtyArch)' == 'x64' or '$(NovaConPtyArch)' == 'x86'">
+      <Link>x64\OpenConsole.exe</Link>
+    </NovaRequiredConPtyHost>
+    <NovaRequiredConPtyHost Include="$(NovaConPtyHostDir)x86\OpenConsole.exe"
+      Condition="'$(NovaConPtyArch)' == 'x86'">
+      <Link>x86\OpenConsole.exe</Link>
+    </NovaRequiredConPtyHost>
+  </ItemGroup>
 
   <ItemGroup Condition="'$(NovaTargetsWindows)' == 'true'">
     <Content Include="$(NovaConPtyDll)" Condition="Exists('$(NovaConPtyDll)')">
@@ -270,8 +291,8 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
-    <Content Include="$(NovaOpenConsoleExe)" Condition="Exists('$(NovaOpenConsoleExe)')">
-      <Link>$(NovaConPtyArch)\OpenConsole.exe</Link>
+    <!-- Link comes from the item declarations above. -->
+    <Content Include="@(NovaRequiredConPtyHost)">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
@@ -284,8 +305,8 @@
     Condition="'$(NovaTargetsWindows)' == 'true'">
     <Error Condition="!Exists('$(NovaConPtyDll)')"
       Text="[ConPTY] Sideloaded conpty.dll not found at '$(NovaConPtyDll)'. Panes would fall back to the OS conhost.exe (see #310). Check the Microsoft.Windows.Console.ConPTY package layout/version." />
-    <Error Condition="!Exists('$(NovaOpenConsoleExe)')"
-      Text="[ConPTY] Sideloaded OpenConsole.exe not found at '$(NovaOpenConsoleExe)'. conpty.dll would fall back to the OS conhost.exe (see #310). Check the Microsoft.Windows.Console.ConPTY package layout/version." />
+    <Error Condition="!Exists('%(NovaRequiredConPtyHost.Identity)')"
+      Text="[ConPTY] Sideloaded OpenConsole.exe not found at '%(NovaRequiredConPtyHost.Identity)'. conpty.dll would fall back to the OS conhost.exe on that machine architecture (see #310). Check the Microsoft.Windows.Console.ConPTY package layout/version." />
   </Target>
 
   <ItemGroup>

--- a/src/NovaTerminal.App/NovaTerminal.App.csproj
+++ b/src/NovaTerminal.App/NovaTerminal.App.csproj
@@ -26,6 +26,12 @@
     <PackageReference Include="SkiaSharp.HarfBuzz" />
     <PackageReference Include="SkiaSharp.NativeAssets.Win32" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
+    <!-- Sideloaded ConPTY host (#310). Nothing to compile against: we only want the two native
+         files out of it, and IncludeSideloadedConPtyHost below places them by hand. The package's
+         own build/targets keys off $(PlatformTarget), which is empty for this AnyCPU app, so it
+         would copy nothing - ExcludeAssets keeps it from running at all. -->
+    <PackageReference Include="Microsoft.Windows.Console.ConPTY" GeneratePathProperty="true"
+      ExcludeAssets="all" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -225,6 +231,61 @@
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
     </ItemGroup>
+  </Target>
+
+  <!-- Sideloaded ConPTY host (#310).
+
+       portable-pty loads the pseudoconsole entry points from a `conpty.dll` sitting next to the
+       executable and only falls back to kernel32's CreatePseudoConsole when it finds none
+       (portable-pty-0.9.0/src/win/psuedocon.rs `load_conpty`). That sideloaded DLL in turn spawns
+       `<its own directory>\<arch>\OpenConsole.exe` - hence the arch subfolder link below, which is
+       the layout the package itself uses.
+
+       Without these two files every pane is hosted by whatever conhost.exe the OS ships, bugs
+       included: opencode 1.18.x's exit crashed conhost 10.0.26100.8972 (integer divide by zero /
+       access violation), which tore down the pseudoconsole and killed the pane's pwsh with it -
+       the user saw a frozen pane and reported "I can't exit opencode". Windows Terminal and
+       WezTerm sideload their own host for exactly this reason. -->
+  <PropertyGroup>
+    <!-- Gate on the *target*, not the build host: `-r linux-x64` from a Windows machine must not
+         drop a Windows console host into the bundle, and `-r win-x64` is still Windows even when
+         cross-published. -->
+    <NovaTargetsWindows Condition="'$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier.StartsWith('win'))</NovaTargetsWindows>
+    <NovaTargetsWindows Condition="'$(RuntimeIdentifier)' == ''">$([MSBuild]::IsOSPlatform('Windows'))</NovaTargetsWindows>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(NovaTargetsWindows)' == 'true'">
+    <NovaConPtyArch Condition="'$(NovaConPtyArch)' == '' and $(RuntimeIdentifier.EndsWith('arm64'))">arm64</NovaConPtyArch>
+    <NovaConPtyArch Condition="'$(NovaConPtyArch)' == '' and $(RuntimeIdentifier.EndsWith('x86'))">x86</NovaConPtyArch>
+    <NovaConPtyArch Condition="'$(NovaConPtyArch)' == '' and $(RuntimeIdentifier.EndsWith('x64'))">x64</NovaConPtyArch>
+    <!-- No RID (plain `build`): ship the host matching the machine doing the building. -->
+    <NovaConPtyArch Condition="'$(NovaConPtyArch)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</NovaConPtyArch>
+    <NovaConPtyDll>$(PkgMicrosoft_Windows_Console_ConPTY)\runtimes\win-$(NovaConPtyArch)\native\conpty.dll</NovaConPtyDll>
+    <NovaOpenConsoleExe>$(PkgMicrosoft_Windows_Console_ConPTY)\build\native\runtimes\$(NovaConPtyArch)\OpenConsole.exe</NovaOpenConsoleExe>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(NovaTargetsWindows)' == 'true'">
+    <Content Include="$(NovaConPtyDll)" Condition="Exists('$(NovaConPtyDll)')">
+      <Link>conpty.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Include="$(NovaOpenConsoleExe)" Condition="Exists('$(NovaOpenConsoleExe)')">
+      <Link>$(NovaConPtyArch)\OpenConsole.exe</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
+  <!-- A missing file here does not fail the build, it silently reverts every pane to the OS
+       conhost - the exact regression #310 is about. Fail loudly instead: the paths above are
+       package-layout assumptions, and a version bump is where they break. -->
+  <Target Name="VerifySideloadedConPtyHost" BeforeTargets="Build"
+    Condition="'$(NovaTargetsWindows)' == 'true'">
+    <Error Condition="!Exists('$(NovaConPtyDll)')"
+      Text="[ConPTY] Sideloaded conpty.dll not found at '$(NovaConPtyDll)'. Panes would fall back to the OS conhost.exe (see #310). Check the Microsoft.Windows.Console.ConPTY package layout/version." />
+    <Error Condition="!Exists('$(NovaOpenConsoleExe)')"
+      Text="[ConPTY] Sideloaded OpenConsole.exe not found at '$(NovaOpenConsoleExe)'. conpty.dll would fall back to the OS conhost.exe (see #310). Check the Microsoft.Windows.Console.ConPTY package layout/version." />
   </Target>
 
   <ItemGroup>

--- a/tests/NovaTerminal.Architecture.Tests/ProjectFileLayeringTests.cs
+++ b/tests/NovaTerminal.Architecture.Tests/ProjectFileLayeringTests.cs
@@ -157,4 +157,30 @@ public class ProjectFileLayeringTests
         var refs = ProjectReferences("src/NovaTerminal.McpServer/NovaTerminal.McpServer.csproj");
         Assert.Equal(AgentHostContractsOnly, refs);
     }
+
+    /// <summary>
+    /// #310: panes must be hosted by the sideloaded ConPTY host, not the OS conhost.exe.
+    /// portable-pty only uses it when a <c>conpty.dll</c> sits next to the executable, and that
+    /// DLL only finds its server at <c>&lt;arch&gt;\OpenConsole.exe</c> — so both files have to be
+    /// in the app output. Losing them does not fail the build and does not fail any behavioural
+    /// test; it silently puts every session back on the console host whose crash killed the
+    /// user's shell in #310. The csproj's own VerifySideloadedConPtyHost target guards the
+    /// package layout, which is a different failure: this guards the copy items themselves.
+    /// </summary>
+    [Fact]
+    public void App_csproj_must_ship_the_sideloaded_conpty_host()
+    {
+        var path = Path.Combine(RepoRoot(), "src/NovaTerminal.App/NovaTerminal.App.csproj");
+        var doc = XDocument.Load(path);
+
+        var links = doc.Descendants("Content")
+            .Select(c => (string?)c.Element("Link") ?? string.Empty)
+            .Select(l => l.Replace('\\', '/'))
+            .ToArray();
+
+        Assert.Contains("conpty.dll", links);
+        Assert.Contains(links, l => l.EndsWith("/OpenConsole.exe", StringComparison.OrdinalIgnoreCase));
+
+        Assert.Contains("Microsoft.Windows.Console.ConPTY", PackageReferences("src/NovaTerminal.App/NovaTerminal.App.csproj"));
+    }
 }

--- a/tests/NovaTerminal.Architecture.Tests/ProjectFileLayeringTests.cs
+++ b/tests/NovaTerminal.Architecture.Tests/ProjectFileLayeringTests.cs
@@ -170,17 +170,38 @@ public class ProjectFileLayeringTests
     [Fact]
     public void App_csproj_must_ship_the_sideloaded_conpty_host()
     {
-        var path = Path.Combine(RepoRoot(), "src/NovaTerminal.App/NovaTerminal.App.csproj");
-        var doc = XDocument.Load(path);
+        const string appCsproj = "src/NovaTerminal.App/NovaTerminal.App.csproj";
+        var doc = XDocument.Load(Path.Combine(RepoRoot(), appCsproj));
 
-        var links = doc.Descendants("Content")
-            .Select(c => (string?)c.Element("Link") ?? string.Empty)
-            .Select(l => l.Replace('\\', '/'))
+        Assert.Contains("Microsoft.Windows.Console.ConPTY", PackageReferences(appCsproj));
+
+        // conpty.dll has to sit next to the exe (that is the only place portable-pty looks), and
+        // the hosts have to be declared per machine architecture, arm64 included: an x64 bundle
+        // started on Windows-on-ARM resolves the arm64 host, and win-x64 is the only Windows RID
+        // released.
+        var hostLinks = doc.Descendants("NovaRequiredConPtyHost")
+            .Select(e => ((string?)e.Element("Link") ?? string.Empty).Replace('\\', '/'))
             .ToArray();
+        Assert.Contains("arm64/OpenConsole.exe", hostLinks);
 
-        Assert.Contains("conpty.dll", links);
-        Assert.Contains(links, l => l.EndsWith("/OpenConsole.exe", StringComparison.OrdinalIgnoreCase));
+        var conPtyDll = doc.Descendants("Content")
+            .SingleOrDefault(c => ((string?)c.Element("Link") ?? string.Empty) == "conpty.dll");
+        Assert.NotNull(conPtyDll);
 
-        Assert.Contains("Microsoft.Windows.Console.ConPTY", PackageReferences("src/NovaTerminal.App/NovaTerminal.App.csproj"));
+        var hostCopy = doc.Descendants("Content")
+            .SingleOrDefault(c => ((string?)c.Attribute("Include") ?? string.Empty)
+                .Contains("@(NovaRequiredConPtyHost)", StringComparison.Ordinal));
+        Assert.NotNull(hostCopy);
+
+        // Both copy destinations, not just one: an output-only copy keeps every dev build working
+        // while the released bundle silently ships without a console host - which is #310 again,
+        // for users only.
+        foreach (var item in new[] { conPtyDll, hostCopy })
+        {
+            Assert.False(string.IsNullOrWhiteSpace((string?)item!.Element("CopyToOutputDirectory")),
+                $"Content '{(string?)item.Attribute("Include")}' must declare CopyToOutputDirectory.");
+            Assert.False(string.IsNullOrWhiteSpace((string?)item.Element("CopyToPublishDirectory")),
+                $"Content '{(string?)item.Attribute("Include")}' must declare CopyToPublishDirectory.");
+        }
     }
 }


### PR DESCRIPTION
Fixes #310.

## Why

A user reported "I can't exit opencode" with a screen recording: opencode's TUI exits, and then the pane is dead — primary screen half-restored, no prompt, no opencode farewell message, keystrokes swallowed. The same opencode build exits cleanly in Windows Terminal on the same machine.

opencode 1.18.x's exit crashes the **OS console host**. conhost dies, the pseudoconsole goes with it, and the pane's shell (`pwsh`, plus an intermediate `cmd` if there is one) dies too. All NovaTerminal sees is EOF.

We were on the system host in the first place because `pty_spawn_impl` takes the portable-pty path for the GUI (no real console → passthrough is skipped), and portable-pty only uses a private console host when it finds a `conpty.dll` next to the executable:

```rust
// portable-pty-0.9.0/src/win/psuedocon.rs:52
// We prefer to use a sideloaded conpty.dll and openconsole.exe host deployed
if let Ok(sideloaded) = ConPtyFuncs::open(Path::new("conpty.dll")) { ... }
```

We shipped neither file, so every pane inherited whatever `conhost.exe` the OS has — bugs included. Windows Terminal and WezTerm both sideload their own host for exactly this reason.

## What changed

- `Microsoft.Windows.Console.ConPTY` pinned in `Directory.Packages.props`.
- `NovaTerminal.App.csproj` copies `conpty.dll` next to the exe and `OpenConsole.exe` into the `<arch>\` subfolder `conpty.dll` looks in, for build **and** publish output. No code change is needed — portable-pty picks it up on its own.
- Arch comes from the RID when publishing, otherwise from the build machine. Gated on the *target* (`win-*` RIDs and RID-less Windows builds), so `-r linux-x64` stays clean. Verified by property evaluation: `linux-x64` → `NovaTargetsWindows=False`, `win-arm64` → `arm64`.
- Two guards, because losing these files fails no build and no behavioural test — it just silently puts every pane back on the OS host:
  - `VerifySideloadedConPtyHost` errors at build time if the package layout moves (a version bump is where that happens).
  - `App_csproj_must_ship_the_sideloaded_conpty_host` guards the copy items themselves.

## Verification

A headless harness drives the same spawn path the GUI uses (portable-pty forced via `NOVA_PTY_NO_PASSTHROUGH`, the real `AnsiParser` answering device reports so PSReadLine and opencode both get their replies), launches opencode 1.18.16, sends `/exit`, then proves the shell is alive by making it evaluate `'NOVA'+'-ALIVE'`. One variable — the two files next to the exe — six runs each:

| Console host | Runs where the shell died | Host state on failure |
|---|---|---|
| system `conhost.exe` 10.0.26100.8972 | **3 / 6** | exited `0xC0000005` (access violation) |
| sideloaded `OpenConsole.exe` 1.24.260710001 | **0 / 6** | alive every run |

The crash is intermittent (~50%) and correlates exactly: host crashed ⇒ pane dead, host alive ⇒ clean exit. The two runs in the real GUI app before this change both crashed, with WER entries for `conhost.exe` (`0xc0000094` integer divide by zero, `0xc0000005` access violation) followed by `pwsh.exe` faulting in `Microsoft.PowerShell.ConsoleHost.dll`.

Also verified: `dotnet publish -r win-x64` ships both files; `NovaTerminal.Architecture.Tests` 34/34 pass.

## Notes / out of scope

- The rust ConPTY **passthrough** path (`win32::spawn_with_passthrough`, taken only when the host has a real console — CLI and some test runs) still calls kernel32 directly and so still uses the OS host. The GUI never takes that path, which is the user-facing case.
- The other half of the reported experience — a pane that dies silently and looks like a hung program — is #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
