### PR TITLE
feat(pane): a dead pane says so, and can close itself on a clean exit (#311)

### DIFF
--- a/docs/plans/2026-08-12-dead-pane-indicator-design.md
+++ b/docs/plans/2026-08-12-dead-pane-indicator-design.md
@@ -37,14 +37,14 @@ None of it reached the screen. Three specifics:
 
 ## The behaviour contract
 
-`ShellExitPolicy` is a string setting, `"Never" | "Graceful" | "Always"`, default `"Graceful"`.
+`ShellExitPolicy` is a string setting, `"Never" | "Graceful" | "Always"`, default `"Never"`.
 
 | Pane | Exit | Policy | Behaviour |
 |---|---|---|---|
-| Local | 0 | `Graceful` (default) | Pane closes. Last pane in the tab closes the tab; last tab closes the window. |
-| Local | 0 | `Never` | Banner, pane stays. |
+| Local | 0 | `Never` (default) | Banner, pane stays. |
+| Local | 0 | `Graceful` (opt-in) | Pane closes. Last pane in the tab closes the tab; last tab closes the window. |
 | Local | non-zero, or host/PTY died | `Graceful`, `Never` | Banner, pane stays. |
-| Local | any | `Always` | Pane closes. |
+| Local | any | `Always` (opt-in) | Pane closes. |
 | SSH | any | any | Unchanged: existing SSH banner, Enter reconnects, never auto-closes. |
 
 Local banner text, mirroring the SSH one's shape (exit-code line omitted when the code is 0, as SSH
@@ -67,7 +67,8 @@ in the buffer and therefore in scrollback, `read_screen`, and replay exports).
   gone, and an unattended modal is the stuck state this issue is about. Same reasoning as the
   existing agent-initiated close.
 - **`exit` in the only tab quits the app.** `CloseTab` calls `Close()` when the last tab goes. This
-  matches every other terminal and is the accepted consequence of the `Graceful` default.
+  matches every other terminal and only happens under the opted-in `Graceful` policy; the default
+  `Never` keeps the pane for manual restart.
 
 ## Composition
 
@@ -115,7 +116,7 @@ background pane today.
 
 ### Settings surface
 
-- `TerminalSettings.ShellExitPolicy = "Graceful"`, next to `PaneClosePolicy`.
+- `TerminalSettings.ShellExitPolicy = "Never"`, next to `PaneClosePolicy`.
 - **settings.json only, no `SettingsWindow` control** — its sibling `PaneClosePolicy` has none
   either, and matching that is better than growing the settings window for this. A UI control for
   both policies together is reasonable follow-up work.
@@ -123,6 +124,17 @@ background pane today.
   and the writable-field list updated, or `SettingsToolsDriftGuardTests` fails.
 - An unrecognised value behaves as `"Graceful"`: this setting decides whether a pane disappears, and
   a typo in a hand-edited settings file must not silently mean "never tell me anything again".
+
+### Default change: from Graceful to Never
+
+This design was agreed with the default set to `"Graceful"`, but a maintainer decision changed it to
+`"Never"` before implementation. Reason: a local PTY reports exit code 0 for every session end —
+`RustPtySession` fires its exit notification with a hardcoded 0 on EOF. Because of this, `"Graceful"`
+(close on clean exit) cannot tell a clean `exit` from a shell that died because its console host
+crashed, which is exactly the failure #311 exists to announce. Defaulting to `"Never"` means every
+dead local pane gets the banner and its Enter-to-restart hint. `"Graceful"` remains available for
+anyone who opts in, and it becomes the right default once **#313** lands and the real exit status
+from the child process is plumbed through.
 
 ## Data flow
 

--- a/docs/plans/2026-08-12-dead-pane-indicator-design.md
+++ b/docs/plans/2026-08-12-dead-pane-indicator-design.md
@@ -122,8 +122,8 @@ background pane today.
   both policies together is reasonable follow-up work.
 - `SettingsTools` needs the documented-field row, the sample JSON entry, the enum-like-string list,
   and the writable-field list updated, or `SettingsToolsDriftGuardTests` fails.
-- An unrecognised value behaves as `"Graceful"`: this setting decides whether a pane disappears, and
-  a typo in a hand-edited settings file must not silently mean "never tell me anything again".
+- An unrecognised value behaves as the default `"Never"`: a typo in a hand-edited settings file must
+  not be more destructive than the default, and `"Never"` still tells the user (it shows the banner).
 
 ### Default change: from Graceful to Never
 

--- a/docs/plans/2026-08-12-dead-pane-indicator-design.md
+++ b/docs/plans/2026-08-12-dead-pane-indicator-design.md
@@ -116,7 +116,9 @@ background pane today.
 ### Settings surface
 
 - `TerminalSettings.ShellExitPolicy = "Graceful"`, next to `PaneClosePolicy`.
-- A dropdown in `SettingsWindow` beside the existing pane-close policy control.
+- **settings.json only, no `SettingsWindow` control** — its sibling `PaneClosePolicy` has none
+  either, and matching that is better than growing the settings window for this. A UI control for
+  both policies together is reasonable follow-up work.
 - `SettingsTools` needs the documented-field row, the sample JSON entry, the enum-like-string list,
   and the writable-field list updated, or `SettingsToolsDriftGuardTests` fails.
 - An unrecognised value behaves as `"Graceful"`: this setting decides whether a pane disappears, and

--- a/docs/plans/2026-08-12-dead-pane-indicator-design.md
+++ b/docs/plans/2026-08-12-dead-pane-indicator-design.md
@@ -1,0 +1,190 @@
+# A pane whose shell dies says so (#311)
+
+A local pane whose PTY dies just freezes: last screen still up, cursor still drawn, keystrokes
+swallowed, nothing on screen about what happened. This gives it a sentence, and closes the pane
+when the shell exited cleanly.
+
+Written to `docs/plans/` rather than `docs/superpowers/specs/` to sit next to the rest of this
+repository's design documents.
+
+## The problem
+
+A user reported "I can't exit opencode" with a screen recording. opencode had exited fine; the
+console host crashed on its way out (#310) and took the shell with it. The pane looked exactly like
+a hung foreground program, so they kept typing into a dead session, gave up, and switched to another
+terminal.
+
+The information all existed:
+
+- `novaterminal.get_session_status` reported `exited`.
+- `debug.log` recorded `[RustPtySession] EOF received.`
+- `TerminalPane.ProcessExited` fired, and `MainWindow.OnPaneProcessExited` stored the exit code.
+
+None of it reached the screen. Three specifics:
+
+1. **The recovery already works and is invisible.** `ShouldReconnectOnEnter` is
+   `session == null || !session.IsProcessRunning` — not SSH-specific — and `Reconnect()` re-runs
+   `InitializeSession`. Enter in a dead local pane already restarts the shell today. `TerminalView`
+   even goes out of its way to let Enter bubble on a dead session, twice (plain and kitty encoders).
+   Nothing tells the user.
+2. **The banner is gated on SSH.** `HandleSessionExit` writes
+   `[SSH session disconnected] / [Exit code: N] / [Press Enter to reconnect]` only when
+   `Profile?.Type == ConnectionType.SSH`. Local panes get silence.
+3. **The tab glyph is ambiguous.** `state.LastExitCode` is written both by `OnPaneCommandFinished`
+   (per-command, from shell integration) and by `OnPaneProcessExited`, and renders as `✓` / `✖N`
+   either way. A dead shell looks identical to a command that failed. In the reported case the shell
+   died with code 0, so the tab showed `✓`.
+
+## The behaviour contract
+
+`ShellExitPolicy` is a string setting, `"Never" | "Graceful" | "Always"`, default `"Graceful"`.
+
+| Pane | Exit | Policy | Behaviour |
+|---|---|---|---|
+| Local | 0 | `Graceful` (default) | Pane closes. Last pane in the tab closes the tab; last tab closes the window. |
+| Local | 0 | `Never` | Banner, pane stays. |
+| Local | non-zero, or host/PTY died | `Graceful`, `Never` | Banner, pane stays. |
+| Local | any | `Always` | Pane closes. |
+| SSH | any | any | Unchanged: existing SSH banner, Enter reconnects, never auto-closes. |
+
+Local banner text, mirroring the SSH one's shape (exit-code line omitted when the code is 0, as SSH
+already does):
+
+```
+[Shell exited]
+[Exit code: 1]
+[Press Enter to restart]
+```
+
+Unstyled, written through the existing `WriteBanner` (which parses it as terminal input, so it lands
+in the buffer and therefore in scrollback, `read_screen`, and replay exports).
+
+### What overrides the close
+
+- **A protected tab never auto-closes.** `CloseTabAsync` already returns false for
+  `IsProtected`; the pane gets the banner instead. Protection cannot be defeated by a dying shell.
+- **Auto-close skips the confirmation dialog** (`PaneClosePolicy = "Confirm"`). The shell is already
+  gone, and an unattended modal is the stuck state this issue is about. Same reasoning as the
+  existing agent-initiated close.
+- **`exit` in the only tab quits the app.** `CloseTab` calls `Close()` when the last tab goes. This
+  matches every other terminal and is the accepted consequence of the `Graceful` default.
+
+## Composition
+
+The decision is a pure function; the two side effects live where they already live.
+
+**`SessionExitDecision.For(policy, isSsh, exitCode)` → `TryClose | BannerOnly`** — new static, no
+Avalonia, no I/O. SSH is always `BannerOnly`. `Never` is always `BannerOnly`. `Always` is
+`TryClose`. `Graceful` is `TryClose` when `exitCode == 0`. Protection and reentrancy deliberately do
+**not** appear here; see the fallback rule below.
+
+**`TerminalPane`** keeps `HandleSessionExit` as the single exit funnel and its SSH branch untouched.
+It gains `internal void WriteLocalExitBanner(int code)`. The pane does not read the setting and does
+not decide anything, so no `ApplySettings` whitelist entry is needed.
+
+**`MainWindow.OnPaneProcessExited`** owns the decision, because it is the only party that knows the
+tab, its protected state, and the settings. It asks `SessionExitDecision`, then either writes the
+banner or attempts the close. It stays a `void` event handler and hands the close to a private
+`async Task` helper (`HandlePaneExitAsync`) rather than becoming `async void`, so the fallback below
+observes the close result instead of firing and forgetting it.
+
+**The fallback rule:** on `TryClose`, attempt the close and write the banner if the close did not
+happen. A refusal can come from a protected tab, from the `_closePaneInProgress` /
+`_closeTabInProgress` reentrancy guards, or from a pane with no ancestor tab. Every one of those
+paths must end with a pane that says something rather than a pane that says nothing — which is the
+whole point of the issue. This is why protection is not a parameter of the decision: it stays
+enforced in exactly one place.
+
+### The close has to target the pane, not the active one
+
+`PaneAction.Close` → `CloseActivePaneAsync` is the wrong vehicle, and the reason is worth writing
+down. It reads `_currentPane` for the split case but falls back to `tabs.SelectedItem` when the pane
+is alone in its tab, and its zoom-exit path uses `TryGetSelectedTab`. `UpdateActivePane(pane)` does
+not select the pane's tab. So a shell dying in a **background** tab — a long-running build, an agent
+session, exactly the tabs you are not watching — would close the tab the user is currently looking
+at.
+
+So: extract `ClosePaneAsync(TerminalPane pane, bool skipConfirm)` from `CloseActivePaneAsync`, with
+every `tabs.SelectedItem` / `TryGetSelectedTab` replaced by `pane.FindAncestorOfType<TabItem>()`,
+and redefine `CloseActivePaneAsync(skipConfirm)` as `ClosePaneAsync(_currentPane, skipConfirm)`. The
+split-promotion body is already pane-relative and moves unchanged. `ClosePaneAsync` returns
+`Task<bool>` so the fallback rule above can see a refusal.
+
+This also fixes the same latent bug on the agent-initiated close path, which can be handed a
+background pane today.
+
+### Settings surface
+
+- `TerminalSettings.ShellExitPolicy = "Graceful"`, next to `PaneClosePolicy`.
+- A dropdown in `SettingsWindow` beside the existing pane-close policy control.
+- `SettingsTools` needs the documented-field row, the sample JSON entry, the enum-like-string list,
+  and the writable-field list updated, or `SettingsToolsDriftGuardTests` fails.
+- An unrecognised value behaves as `"Graceful"`: this setting decides whether a pane disappears, and
+  a typo in a hand-edited settings file must not silently mean "never tell me anything again".
+
+## Data flow
+
+```
+PTY EOF
+  └─ RustPtySession.OnExit (background thread)
+       └─ Dispatcher.UIThread.Post                       [already present]
+            └─ TerminalPane.HandleSessionExit
+                 ├─ ignores stale sessions (ReferenceEquals guard)   [already present]
+                 ├─ LastExitCode = code                              [already present]
+                 ├─ SSH: WriteSshDisconnectedBanner                  [already present]
+                 └─ ProcessExited                                    [already present]
+                      └─ MainWindow.OnPaneProcessExited
+                           ├─ tab state + glyph refresh              [already present]
+                           └─ SessionExitDecision.For(...)
+                                ├─ BannerOnly → pane.WriteLocalExitBanner(code)
+                                └─ TryClose   → HandlePaneExitAsync (private async Task)
+                                                 └─ await ClosePaneAsync(pane, skipConfirm: true)
+                                                      └─ false → pane.WriteLocalExitBanner(code)
+```
+
+Recovery after a banner needs no new code: Enter → `TerminalPane.OnKeyDown` →
+`ShouldReconnectOnEnter` → `Reconnect()`, which clears `LastExitCode` (so the tab glyph clears too),
+writes `[Reconnecting...]`, and calls `InitializeSession`.
+
+## Edge cases
+
+- **Stale exits.** A session that has already been replaced by `Reconnect()` is dropped by the
+  existing `ReferenceEquals(Session, session)` guard.
+- **No tab.** `OnPaneProcessExited` already returns early when the pane has no ancestor tab; with
+  the fallback rule the pane still gets its banner first.
+- **Exit during a close.** The reentrancy guards make the close a no-op; the fallback writes the
+  banner. Worst case the user sees a banner in a pane that is about to vanish.
+- **Zoomed pane.** `ClosePaneAsync` exits zoom for the pane's own tab, not the selected one.
+- **Agent registration.** `ProcessExited` already drives `StatusMachine.NotifyExited(exitCode)`
+  before any of this, so agent status stays correct whether the pane closes or stays.
+- **Broadcast tabs.** A closed pane leaves broadcast membership via the existing `CloseTab` /
+  `ClosePaneAsync` cleanup; no new bookkeeping.
+
+## Testing
+
+Unit, no UI:
+
+- `SessionExitDecision` matrix: three policies × {0, non-zero} × {local, SSH}.
+- Unrecognised policy string falls back to `Graceful`.
+
+Pane-level, via the existing `HandleSessionExitForTesting` seam (already used by
+`TerminalPaneSshDisconnectTests`):
+
+- Local non-zero exit writes `[Shell exited]`, `[Exit code: N]`, `[Press Enter to restart]`.
+- Local exit 0 omits the exit-code line.
+- The SSH banner is unchanged, asserted byte-for-byte.
+
+Headless `MainWindow` (`AvaloniaTestCase`):
+
+- `Graceful` + clean exit closes the dying pane's tab.
+- `Graceful` + clean exit in a **background** tab closes that tab and leaves the selected tab alone.
+  This is the regression test for the targeting bug above.
+- A protected tab survives a clean exit and shows the banner instead.
+- `Never` keeps the pane and shows the banner.
+
+## Out of scope
+
+- **The ambiguous tab glyph.** `LastExitCode` conflating last-command-exit with process-exit
+  deserves its own issue: after this change the pane is unambiguous, the tab strip still is not.
+- **SSH auto-close.** Deliberately excluded; remote sessions keep their reconnect affordance.
+- **The console-host crash itself.** That is #310, already fixed by sideloading the ConPTY host.

--- a/docs/plans/2026-08-12-dead-pane-indicator-plan.md
+++ b/docs/plans/2026-08-12-dead-pane-indicator-plan.md
@@ -15,7 +15,7 @@ Design: [`docs/plans/2026-08-12-dead-pane-indicator-design.md`](2026-08-12-dead-
 - **Build and test only through the wrappers:** `scripts/build.ps1 <args>` (PowerShell) or `scripts/build.sh <args>` (bash). A raw `dotnet build` hangs when stdout is captured. See CLAUDE.md.
 - **Never run the whole solution's tests** — that is 20–30 minutes of headless Avalonia. Run the one project, with a `--filter`.
 - The first build in a fresh worktree compiles the Rust natives via cargo (several minutes). Do not pass `SKIP_RUST_NATIVE_BUILD=1` for the test tasks here: `NovaTerminal.App.Tests` panes need `rusty_pty.dll` in the output.
-- **Setting name and values, exactly:** `ShellExitPolicy`, one of `"Never"`, `"Graceful"`, `"Always"`, default `"Never"`. Unrecognised values behave as `"Graceful"`.
+- **Setting name and values, exactly:** `ShellExitPolicy`, one of `"Never"`, `"Graceful"`, `"Always"`, default `"Never"`. Unrecognised values behave as `"Never"` (a typo must not be more destructive than the default).
 - **Banner text, exactly** (the exit-code line is omitted when the code is 0):
   ```
   [Shell exited]
@@ -140,7 +140,7 @@ In `src/NovaTerminal.App/Shell/TerminalSettings.cs`, directly below `public stri
         // conservative choice until #313 lands, at which point the real exit status from the child process
         // can be captured (today a local PTY reports 0 for every exit, even when the console host crashed).
         // SSH panes ignore this and always keep their reconnect banner. Unrecognised values behave as
-        // "Graceful".
+        // "Never" — a typo must not be more destructive than the default.
         public string ShellExitPolicy { get; set; } = "Never";
 ```
 
@@ -165,9 +165,12 @@ In `src/NovaTerminal.App/MainWindow.axaml.cs`, directly above `internal static b
 
             if (policy.Equals("Never", StringComparison.OrdinalIgnoreCase)) return false;
             if (policy.Equals("Always", StringComparison.OrdinalIgnoreCase)) return true;
+            if (policy.Equals("Graceful", StringComparison.OrdinalIgnoreCase)) return exitCode == 0;
 
-            // "Graceful" and anything unrecognised.
-            return exitCode == 0;
+            // Fall-through: unrecognised or empty value behaves as the default "Never",
+            // because a typo in a hand-edited settings file must not be more destructive
+            // than the default. "Never" still tells the user via the exit banner.
+            return false;
         }
 ```
 

--- a/docs/plans/2026-08-12-dead-pane-indicator-plan.md
+++ b/docs/plans/2026-08-12-dead-pane-indicator-plan.md
@@ -1,0 +1,891 @@
+# Dead pane indicator (#311) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A local pane whose shell dies says so and offers Enter-to-restart, and a pane whose shell exited cleanly closes itself.
+
+**Architecture:** The exit funnel already exists — `RustPtySession.OnExit` → (UI thread) `TerminalPane.HandleSessionExit` → `ProcessExited` → `MainWindow.OnPaneProcessExited`. This plan adds a pure policy function, a banner writer on the pane, a pane-targeted close on the window, and wires the three together at the end of that funnel. SSH panes keep their existing banner and never auto-close.
+
+**Tech Stack:** C# / .NET 10, Avalonia 12, xunit v3 (`[Fact]` for pure logic, `[AvaloniaFact]` for anything touching controls).
+
+Design: [`docs/plans/2026-08-12-dead-pane-indicator-design.md`](2026-08-12-dead-pane-indicator-design.md).
+
+## Global Constraints
+
+- **Build and test only through the wrappers:** `scripts/build.ps1 <args>` (PowerShell) or `scripts/build.sh <args>` (bash). A raw `dotnet build` hangs when stdout is captured. See CLAUDE.md.
+- **Never run the whole solution's tests** — that is 20–30 minutes of headless Avalonia. Run the one project, with a `--filter`.
+- The first build in a fresh worktree compiles the Rust natives via cargo (several minutes). Do not pass `SKIP_RUST_NATIVE_BUILD=1` for the test tasks here: `NovaTerminal.App.Tests` panes need `rusty_pty.dll` in the output.
+- **Setting name and values, exactly:** `ShellExitPolicy`, one of `"Never"`, `"Graceful"`, `"Always"`, default `"Graceful"`. Unrecognised values behave as `"Graceful"`.
+- **Banner text, exactly** (the exit-code line is omitted when the code is 0):
+  ```
+  [Shell exited]
+  [Exit code: N]
+  [Press Enter to restart]
+  ```
+- SSH panes are out of scope for every behaviour change here. The existing `[SSH session disconnected]` banner must remain byte-for-byte identical.
+- `ShellExitPolicy` is settings.json-only, with no `SettingsWindow` control. This matches its sibling `PaneClosePolicy`, which has no UI either. (The design doc said "a dropdown beside the existing pane-close policy control"; there is no such control — the design is wrong on that one point and this plan is the correction.)
+- Do not add the setting to `TerminalPane.ApplySettings`'s `effectiveSettings` whitelist. The pane never reads this setting; `MainWindow` does.
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `src/NovaTerminal.App/Shell/TerminalSettings.cs` | Holds `ShellExitPolicy` | 1 |
+| `src/NovaTerminal.App/MainWindow.axaml.cs` | `ShouldClosePaneOnExit` (pure), `ClosePaneAsync` (pane-targeted), exit wiring | 1, 3, 4 |
+| `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs` | `WriteLocalExitBanner` | 2 |
+| `src/NovaTerminal.McpServer/Tools/SettingsTools.cs` | Agent-facing settings docs + validation | 5 |
+| `tests/NovaTerminal.App.Tests/Core/ShellExitPolicyTests.cs` (new) | Policy matrix | 1 |
+| `tests/NovaTerminal.App.Tests/Core/TerminalPaneExitBannerTests.cs` (new) | Banner text | 2 |
+| `tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs` (new) | Close targeting + end-to-end exit behaviour | 3, 4 |
+
+---
+
+### Task 1: The exit policy decision
+
+Pure function plus the setting that feeds it. Nothing is wired yet, so behaviour does not change.
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Shell/TerminalSettings.cs:53` (add next to `PaneClosePolicy`)
+- Modify: `src/NovaTerminal.App/MainWindow.axaml.cs:3493` (add next to `ShouldAutoAcceptRunningPaneClose`)
+- Test: `tests/NovaTerminal.App.Tests/Core/ShellExitPolicyTests.cs` (create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `TerminalSettings.ShellExitPolicy` (string, default `"Graceful"`); `internal static bool NovaTerminal.MainWindow.ShouldClosePaneOnExit(string? shellExitPolicy, bool isSsh, int exitCode)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/NovaTerminal.App.Tests/Core/ShellExitPolicyTests.cs`:
+
+```csharp
+using NovaTerminal.Shell;
+
+namespace NovaTerminal.Tests.Core;
+
+/// <summary>
+/// #311: which shell exits close the pane. Pure policy — no window, no pane, no Avalonia,
+/// mirroring how <see cref="TabClosePolicyTests"/> covers the sibling pane-close policy.
+/// </summary>
+public sealed class ShellExitPolicyTests
+{
+    [Theory]
+    // Graceful (the default): a clean exit closes, anything else leaves the pane with a banner.
+    [InlineData("Graceful", 0, false, true)]
+    [InlineData("Graceful", 1, false, false)]
+    [InlineData("Graceful", 255, false, false)]
+    // Never: nothing ever closes on its own.
+    [InlineData("Never", 0, false, false)]
+    [InlineData("Never", 1, false, false)]
+    // Always: the exit code stops mattering.
+    [InlineData("Always", 0, false, true)]
+    [InlineData("Always", 1, false, true)]
+    // SSH panes never auto-close, whatever the policy says.
+    [InlineData("Graceful", 0, true, false)]
+    [InlineData("Always", 0, true, false)]
+    [InlineData("Always", 1, true, false)]
+    public void PolicyDecidesWhetherTheDyingPaneCloses(string policy, int exitCode, bool isSsh, bool expected)
+    {
+        Assert.Equal(expected, NovaTerminal.MainWindow.ShouldClosePaneOnExit(policy, isSsh, exitCode));
+    }
+
+    [Theory]
+    [InlineData("graceful")]
+    [InlineData("  Graceful  ")]
+    [InlineData("ALWAYS")]
+    public void PolicyMatchingIsCaseAndWhitespaceInsensitive(string policy)
+    {
+        // "ALWAYS" closes on a non-zero code; the two Graceful spellings do not.
+        bool expected = policy.Trim().Equals("ALWAYS", StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(expected, NovaTerminal.MainWindow.ShouldClosePaneOnExit(policy, isSsh: false, exitCode: 1));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("Sometimes")]
+    public void UnrecognisedPolicyBehavesAsGraceful(string? policy)
+    {
+        // A typo in a hand-edited settings file must not silently mean "never tell me anything".
+        Assert.True(NovaTerminal.MainWindow.ShouldClosePaneOnExit(policy, isSsh: false, exitCode: 0));
+        Assert.False(NovaTerminal.MainWindow.ShouldClosePaneOnExit(policy, isSsh: false, exitCode: 1));
+    }
+
+    [Fact]
+    public void DefaultSettingIsGraceful()
+    {
+        Assert.Equal("Graceful", new TerminalSettings().ShellExitPolicy);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~ShellExitPolicyTests"
+```
+
+Expected: compile error — `'MainWindow' does not contain a definition for 'ShouldClosePaneOnExit'` and `'TerminalSettings' does not contain a definition for 'ShellExitPolicy'`.
+
+- [ ] **Step 3: Add the setting**
+
+In `src/NovaTerminal.App/Shell/TerminalSettings.cs`, directly below `public string PaneClosePolicy { get; set; } = "Confirm";`:
+
+```csharp
+        // What happens to a pane when its shell exits (#311). "Never" always keeps the pane and
+        // shows the exit banner; "Graceful" (default) closes it on a clean exit (code 0) and keeps
+        // it otherwise; "Always" closes it whatever the code. SSH panes ignore this and always
+        // keep their reconnect banner. Unrecognised values behave as "Graceful".
+        public string ShellExitPolicy { get; set; } = "Graceful";
+```
+
+- [ ] **Step 4: Add the decision**
+
+In `src/NovaTerminal.App/MainWindow.axaml.cs`, directly above `internal static bool ShouldAutoAcceptRunningPaneClose(`:
+
+```csharp
+        /// <summary>
+        /// #311: whether a pane whose shell just exited should close itself. Protection and
+        /// close-in-progress guards deliberately live outside this decision — the caller attempts
+        /// the close and falls back to the banner if it does not happen, so that a pane which
+        /// cannot close still says something.
+        /// </summary>
+        internal static bool ShouldClosePaneOnExit(string? shellExitPolicy, bool isSsh, int exitCode)
+        {
+            // A dropped SSH session keeps its [Press Enter to reconnect] banner regardless: the
+            // remote end may have cost an MFA prompt or a jump host to reach.
+            if (isSsh) return false;
+
+            string policy = shellExitPolicy?.Trim() ?? string.Empty;
+
+            if (policy.Equals("Never", StringComparison.OrdinalIgnoreCase)) return false;
+            if (policy.Equals("Always", StringComparison.OrdinalIgnoreCase)) return true;
+
+            // "Graceful" and anything unrecognised.
+            return exitCode == 0;
+        }
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~ShellExitPolicyTests"
+```
+
+Expected: PASS, 15 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/NovaTerminal.App/Shell/TerminalSettings.cs src/NovaTerminal.App/MainWindow.axaml.cs tests/NovaTerminal.App.Tests/Core/ShellExitPolicyTests.cs
+git commit -m "feat(pane): add ShellExitPolicy and the exit-close decision (#311)"
+```
+
+---
+
+### Task 2: The local exit banner
+
+The pane gains a way to say its shell is gone. Still not wired — only the new method's own test calls it.
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs:3753` (next to `WriteSshDisconnectedBanner`)
+- Test: `tests/NovaTerminal.App.Tests/Core/TerminalPaneExitBannerTests.cs` (create)
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: `internal void TerminalPane.WriteLocalExitBanner(int code)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/NovaTerminal.App.Tests/Core/TerminalPaneExitBannerTests.cs`. The `GetVisiblePlainText` helper is copied from `tests/NovaTerminal.App.Tests/Ssh/TerminalPaneSshDisconnectTests.cs`, where it is private:
+
+```csharp
+using Avalonia.Headless.XUnit;
+using NovaTerminal.Controls;
+using NovaTerminal.Platform;
+using NovaTerminal.VT;
+
+namespace NovaTerminal.Tests.Core;
+
+/// <summary>
+/// #311: a local pane whose shell died must say so, and must say how to get it back — Enter
+/// already restarts it (<c>TerminalPane.ShouldReconnectOnEnter</c> is not SSH-gated), which is
+/// exactly the part users could not discover.
+/// </summary>
+public sealed class TerminalPaneExitBannerTests
+{
+    [AvaloniaFact]
+    public void LocalExitBanner_NonZeroCode_NamesTheCodeAndTheRestartKey()
+    {
+        using var pane = new TerminalPane(LocalProfile());
+
+        pane.WriteLocalExitBanner(1);
+
+        string visibleText = GetVisiblePlainText(pane.Buffer!);
+        Assert.Contains("[Shell exited]", visibleText, StringComparison.Ordinal);
+        Assert.Contains("[Exit code: 1]", visibleText, StringComparison.Ordinal);
+        Assert.Contains("[Press Enter to restart]", visibleText, StringComparison.Ordinal);
+    }
+
+    [AvaloniaFact]
+    public void LocalExitBanner_CleanExit_OmitsTheExitCodeLine()
+    {
+        using var pane = new TerminalPane(LocalProfile());
+
+        pane.WriteLocalExitBanner(0);
+
+        string visibleText = GetVisiblePlainText(pane.Buffer!);
+        Assert.Contains("[Shell exited]", visibleText, StringComparison.Ordinal);
+        Assert.DoesNotContain("Exit code", visibleText, StringComparison.Ordinal);
+        Assert.Contains("[Press Enter to restart]", visibleText, StringComparison.Ordinal);
+    }
+
+    [AvaloniaFact]
+    public void SshDisconnectBanner_IsUnchanged()
+    {
+        // #311 must not disturb the banner SSH users already know.
+        var profile = new TerminalProfile
+        {
+            Name = "Native SSH",
+            Type = ConnectionType.SSH,
+            SshHost = "server.example",
+            SshUser = "nova"
+        };
+        using var pane = new TerminalPane(profile);
+
+        pane.HandleSessionExitForTesting(17);
+
+        string visibleText = GetVisiblePlainText(pane.Buffer!);
+        Assert.Contains("[SSH session disconnected]", visibleText, StringComparison.Ordinal);
+        Assert.Contains("[Exit code: 17]", visibleText, StringComparison.Ordinal);
+        Assert.Contains("[Press Enter to reconnect]", visibleText, StringComparison.Ordinal);
+        Assert.DoesNotContain("Shell exited", visibleText, StringComparison.Ordinal);
+    }
+
+    private static TerminalProfile LocalProfile() => new()
+    {
+        Name = "PowerShell",
+        Type = ConnectionType.Local,
+        Command = "pwsh.exe"
+    };
+
+    private static string GetVisiblePlainText(TerminalBuffer buffer)
+    {
+        var field = typeof(TerminalBuffer).GetField("_viewport", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var viewport = (TerminalRow[])field!.GetValue(buffer)!;
+        return string.Join("\n", viewport.Select(GetRowText)).TrimEnd();
+    }
+
+    private static string GetRowText(TerminalRow row)
+    {
+        char[] chars = row.Cells.Select(c => c.Character == '\0' ? ' ' : c.Character).ToArray();
+        return new string(chars).TrimEnd();
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~TerminalPaneExitBannerTests"
+```
+
+Expected: compile error — `'TerminalPane' does not contain a definition for 'WriteLocalExitBanner'`.
+
+- [ ] **Step 3: Write the banner**
+
+In `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs`, directly below `WriteSshDisconnectedBanner`:
+
+```csharp
+        /// <summary>
+        /// #311: a local pane whose shell exited. Same shape as the SSH banner — including
+        /// dropping the exit-code line when the code is 0 — because the restart it advertises is
+        /// the same mechanism: Enter on a dead session reaches <see cref="Reconnect"/>.
+        /// No interpolated value is caller- or remote-derived, so nothing needs sanitizing.
+        /// </summary>
+        internal void WriteLocalExitBanner(int code)
+        {
+            string exitCodeLine = code == 0
+                ? string.Empty
+                : $"[Exit code: {code}]\r\n";
+            WriteBanner(
+                $"\r\n[Shell exited]\r\n{exitCodeLine}[Press Enter to restart]\r\n");
+        }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~TerminalPaneExitBannerTests"
+```
+
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/Controls/TerminalPane.axaml.cs tests/NovaTerminal.App.Tests/Core/TerminalPaneExitBannerTests.cs
+git commit -m "feat(pane): banner for a local shell that exited (#311)"
+```
+
+---
+
+### Task 3: Close the pane that died, not the one on screen
+
+`CloseActivePaneAsync` reads `_currentPane` for the split case but falls back to `tabs.SelectedItem` when the pane is alone in its tab, and its zoom-exit uses `TryGetSelectedTab`. `UpdateActivePane(pane)` does not select that pane's tab. Auto-close routed through it would close whatever tab the user is looking at when a background shell dies. This task makes the close pane-targeted, and returns whether it happened.
+
+**Files:**
+- Modify: `src/NovaTerminal.App/MainWindow.axaml.cs:3364-3456` (`CloseActivePaneAsync`)
+- Test: `tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs` (create)
+
+**Interfaces:**
+- Consumes: nothing from Tasks 1–2.
+- Produces: `private async Task<bool> ClosePaneAsync(TerminalPane pane, bool skipConfirm = false)` — true when the pane (or its tab) actually went away. `CloseActivePaneAsync(bool skipConfirm = false)` stays as the caller for user-initiated closes.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs`:
+
+```csharp
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using NovaTerminal.Controls;
+using NovaTerminal.Shell;
+
+namespace NovaTerminal.Tests.Core;
+
+/// <summary>
+/// #311. The targeting test is the important one: a shell dying in a background tab — a build, an
+/// agent session, exactly the tabs you are not watching — must not close the tab in front of you.
+/// </summary>
+public sealed class MainWindowShellExitTests
+{
+    [AvaloniaFact]
+    public async Task ClosePaneAsync_ClosesTheGivenPanesTab_NotTheSelectedOne()
+    {
+        using var fixture = TwoTabFixture.Create();
+
+        bool closed = await fixture.ClosePaneAsync(fixture.BackgroundPane, skipConfirm: true);
+
+        Assert.True(closed);
+        Assert.Single(fixture.Tabs.Items);
+        Assert.Same(fixture.SelectedTab, fixture.Tabs.Items[0]);
+    }
+
+    private sealed class TwoTabFixture : IDisposable
+    {
+        private TwoTabFixture(NovaTerminal.MainWindow window, TabControl tabs, TabItem selectedTab, TerminalPane backgroundPane)
+        {
+            Window = window;
+            Tabs = tabs;
+            SelectedTab = selectedTab;
+            BackgroundPane = backgroundPane;
+        }
+
+        public NovaTerminal.MainWindow Window { get; }
+        public TabControl Tabs { get; }
+        public TabItem SelectedTab { get; }
+        public TerminalPane BackgroundPane { get; }
+
+        public Task<bool> ClosePaneAsync(TerminalPane pane, bool skipConfirm)
+        {
+            var method = typeof(NovaTerminal.MainWindow)
+                .GetMethod("ClosePaneAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            return (Task<bool>)method.Invoke(Window, [pane, skipConfirm])!;
+        }
+
+        public static TwoTabFixture Create()
+        {
+            AppServiceBundle bundle = AppServices.BuildForDesigner();
+            var window = new NovaTerminal.MainWindow(bundle);
+            TabControl tabs = window.FindControl<TabControl>("Tabs")!;
+            var settings = (TerminalSettings)typeof(NovaTerminal.MainWindow)
+                .GetField("_settings", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(window)!;
+
+            tabs.Items.Clear();
+            TabItem background = CreateTab(window, tabs, settings, "Background");
+            TabItem selected = CreateTab(window, tabs, settings, "Selected");
+            tabs.SelectedItem = selected;
+
+            return new TwoTabFixture(window, tabs, selected, (TerminalPane)background.Content!);
+        }
+
+        private static TabItem CreateTab(NovaTerminal.MainWindow window, TabControl tabs, TerminalSettings settings, string title)
+        {
+            var tabSession = new TabSession
+            {
+                Title = title,
+                Root = new PaneNode
+                {
+                    Type = NodeType.Leaf,
+                    Command = "cmd.exe",
+                    Arguments = string.Empty,
+                    PaneId = Guid.NewGuid().ToString()
+                }
+            };
+
+            TabItem tab = SessionManager.CreateRestoredTabItem(tabSession, settings)!;
+            tabs.Items.Add(tab);
+
+            // The production entry point for restored content — it is what wires the pane's
+            // events to the window (ProcessExited included, which Task 4 depends on).
+            typeof(NovaTerminal.MainWindow)
+                .GetMethod("InitializeRestoredTabs", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(window, [tabs]);
+
+            return tab;
+        }
+
+        public void Dispose() => Window.Close();
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~MainWindowShellExitTests"
+```
+
+Expected: FAIL — `GetMethod("ClosePaneAsync")` returns null, so the test throws `NullReferenceException`.
+
+- [ ] **Step 3: Extract the pane-targeted close**
+
+In `src/NovaTerminal.App/MainWindow.axaml.cs`, replace the whole of `CloseActivePaneAsync` (lines 3364–3456) with:
+
+```csharp
+        private Task CloseActivePaneAsync(bool skipConfirm = false)
+        {
+            if (_currentPane == null) return Task.CompletedTask;
+            return ClosePaneAsync(_currentPane, skipConfirm);
+        }
+
+        /// <summary>
+        /// Closes a specific pane, resolving everything from that pane rather than from the
+        /// selection. The distinction matters for #311: a shell can die in a background tab, and
+        /// the old selection-based fallback would have closed the tab the user was looking at.
+        /// Returns true when the pane (or its tab) actually went away — callers use that to fall
+        /// back to a banner when a protected tab or an in-flight close refuses.
+        /// </summary>
+        private async Task<bool> ClosePaneAsync(TerminalPane pane, bool skipConfirm = false)
+        {
+            if (_closePaneInProgress || pane == null) return false;
+            _closePaneInProgress = true;
+
+            try
+            {
+                var paneToClose = pane;
+                var paneTab = paneToClose.FindAncestorOfType<TabItem>();
+                if (paneTab != null && _paneZoomStateByTab.ContainsKey(paneTab))
+                {
+                    ExitPaneZoom(paneTab, publishEvent: true);
+                }
+
+                // Agent-initiated and exit-driven closes bypass the confirmation dialog: an agent
+                // can't answer a modal, a dead shell has nothing left to lose, and an unattended
+                // prompt is the stuck state #311 is about.
+                if (!skipConfirm && !await ShouldClosePaneAsync(paneToClose))
+                {
+                    FocusPaneTerminal(paneToClose, defer: true);
+                    return false;
+                }
+
+                // Check if we are in a split (Parent is Grid with multiple children/splitter)
+                if (paneToClose.Parent is Grid parentGrid && parentGrid.Children.Count >= 2)
+                {
+                    // We are in a split!
+                    // 1. Identify Sibling (The non-splitter control that isn't us)
+                    var sibling = parentGrid.Children.OfType<Control>()
+                                        .FirstOrDefault(c => c != paneToClose && !(c is GridSplitter));
+
+                    if (sibling != null)
+                    {
+                        // 2. Identify Grandparent
+                        var grandParent = parentGrid.Parent;
+
+                        // 3. Detach visuals
+                        parentGrid.Children.Clear();
+
+                        // 4. Promote Sibling to Grandparent
+                        if (grandParent is ContentPresenter cp) cp.Content = sibling;
+                        else if (grandParent is TabItem tab) tab.Content = sibling;
+                        else if (grandParent is Grid gpGrid)
+                        {
+                            Grid.SetRow(sibling, Grid.GetRow(parentGrid));
+                            Grid.SetColumn(sibling, Grid.GetColumn(parentGrid));
+                            Grid.SetRowSpan(sibling, Grid.GetRowSpan(parentGrid));
+                            Grid.SetColumnSpan(sibling, Grid.GetColumnSpan(parentGrid));
+
+                            int index = gpGrid.Children.IndexOf(parentGrid);
+                            if (index >= 0)
+                            {
+                                gpGrid.Children.RemoveAt(index);
+                                gpGrid.Children.Insert(index, sibling);
+                            }
+                            else gpGrid.Children.Add(sibling);
+                        }
+                        else if (grandParent is Panel p)
+                        {
+                            int index = p.Children.IndexOf(parentGrid);
+                            p.Children.Remove(parentGrid);
+                            if (index >= 0) p.Children.Insert(index, sibling);
+                            else p.Children.Add(sibling);
+                        }
+
+                        // 5. Dispose the closed pane
+                        DisposeControlTree(paneToClose);
+
+                        // 6. Focus Sibling
+                        FocusFirstPane(sibling);
+                        UpdatePaneAutomationLabels();
+                        if (paneTab != null)
+                        {
+                            RefreshLayoutModelForTab(paneTab);
+                            PublishPaneEvent(paneTab, paneToClose, PaneAuditEventKind.Close);
+                        }
+                        return true;
+                    }
+                }
+
+                // Fallback: If not in a split, close the pane's own tab.
+                if (paneTab != null)
+                {
+                    return await CloseTabAsync(paneTab, skipProcessChecks: true);
+                }
+
+                return false;
+            }
+            finally
+            {
+                _closePaneInProgress = false;
+            }
+        }
+```
+
+Two behaviour notes for the reviewer: the zoom-exit and the tab fallback now use `paneTab` instead of the selection, and the method reports success. `CloseActivePaneAsync` keeps its signature so its existing callers (`CloseActivePane`, the command registry, `PaneAction.Close`) are untouched.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~MainWindowShellExitTests"
+```
+
+Expected: PASS, 1 test.
+
+- [ ] **Step 5: Check nothing else regressed**
+
+`CloseActivePaneAsync` is on the user-facing close path, so run the pane and tab suites:
+
+```bash
+scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~Pane|FullyQualifiedName~TabClose"
+```
+
+Expected: PASS, no new failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/NovaTerminal.App/MainWindow.axaml.cs tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs
+git commit -m "refactor(panes): close the pane you name, not the selected one (#311)"
+```
+
+---
+
+### Task 4: Wire the exit path
+
+**Files:**
+- Modify: `src/NovaTerminal.App/MainWindow.axaml.cs:2803` (`OnPaneProcessExited`)
+- Test: `tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs` (extend)
+
+**Interfaces:**
+- Consumes: `MainWindow.ShouldClosePaneOnExit` (Task 1), `TerminalPane.WriteLocalExitBanner` (Task 2), `MainWindow.ClosePaneAsync` (Task 3).
+- Produces: nothing later tasks depend on.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs`, inside the existing class, above the `TwoTabFixture` nested class. `GetVisiblePlainText`/`GetRowText` are the same helpers as Task 2 — copy them in as private statics of this class too:
+
+```csharp
+    [AvaloniaFact]
+    public void CleanExit_UnderGraceful_ClosesTheDyingPanesTab_AndLeavesTheSelectedOne()
+    {
+        using var fixture = TwoTabFixture.Create();
+        fixture.Settings.ShellExitPolicy = "Graceful";
+
+        fixture.BackgroundPane.HandleSessionExitForTesting(0);
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        Assert.Single(fixture.Tabs.Items);
+        Assert.Same(fixture.SelectedTab, fixture.Tabs.Items[0]);
+    }
+
+    [AvaloniaFact]
+    public void NonZeroExit_UnderGraceful_KeepsThePaneAndShowsTheBanner()
+    {
+        using var fixture = TwoTabFixture.Create();
+        fixture.Settings.ShellExitPolicy = "Graceful";
+
+        fixture.BackgroundPane.HandleSessionExitForTesting(1);
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(2, fixture.Tabs.Items.Count);
+        string visibleText = GetVisiblePlainText(fixture.BackgroundPane.Buffer!);
+        Assert.Contains("[Shell exited]", visibleText, StringComparison.Ordinal);
+        Assert.Contains("[Exit code: 1]", visibleText, StringComparison.Ordinal);
+    }
+
+    [AvaloniaFact]
+    public void CleanExit_UnderNever_KeepsThePaneAndShowsTheBanner()
+    {
+        using var fixture = TwoTabFixture.Create();
+        fixture.Settings.ShellExitPolicy = "Never";
+
+        fixture.BackgroundPane.HandleSessionExitForTesting(0);
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(2, fixture.Tabs.Items.Count);
+        string visibleText = GetVisiblePlainText(fixture.BackgroundPane.Buffer!);
+        Assert.Contains("[Shell exited]", visibleText, StringComparison.Ordinal);
+        Assert.DoesNotContain("Exit code", visibleText, StringComparison.Ordinal);
+    }
+
+    [AvaloniaFact]
+    public void CleanExit_OnAProtectedTab_KeepsThePaneAndFallsBackToTheBanner()
+    {
+        // A dying shell must not be able to defeat tab protection — and a pane that cannot close
+        // still has to say something, which is the whole point of #311.
+        using var fixture = TwoTabFixture.Create();
+        fixture.Settings.ShellExitPolicy = "Graceful";
+        fixture.ProtectBackgroundTab();
+
+        fixture.BackgroundPane.HandleSessionExitForTesting(0);
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(2, fixture.Tabs.Items.Count);
+        Assert.Contains("[Shell exited]", GetVisiblePlainText(fixture.BackgroundPane.Buffer!), StringComparison.Ordinal);
+    }
+```
+
+Add these members to `TwoTabFixture` (and keep `BackgroundTab` from `Create` by storing the `TabItem`):
+
+```csharp
+        public TerminalSettings Settings { get; private init; } = null!;
+
+        public TabItem BackgroundTab { get; private init; } = null!;
+
+        public void ProtectBackgroundTab()
+        {
+            object state = typeof(NovaTerminal.MainWindow)
+                .GetMethod("GetOrCreateTabState", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(Window, [BackgroundTab])!;
+            state.GetType().GetProperty("IsProtected")!.SetValue(state, true);
+        }
+```
+
+and set `Settings`/`BackgroundTab` in `Create` (`settings` and `background` are already local variables there).
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~MainWindowShellExitTests"
+```
+
+Expected: the four new tests FAIL — no banner text in the buffer, and both tabs still present in the Graceful clean-exit case.
+
+- [ ] **Step 3: Wire the handler**
+
+In `src/NovaTerminal.App/MainWindow.axaml.cs`, replace `OnPaneProcessExited` with:
+
+```csharp
+        private void OnPaneProcessExited(TerminalPane pane, int exitCode)
+        {
+            var tab = pane.FindAncestorOfType<TabItem>();
+            if (tab == null)
+            {
+                // No tab to close or mark; the pane still has to say what happened.
+                pane.WriteLocalExitBanner(exitCode);
+                return;
+            }
+
+            var state = GetOrCreateTabState(tab);
+            state.LastExitCode = exitCode;
+            QueueTabVisualRefresh(tab);
+
+            // SSH panes write their own [SSH session disconnected] banner in HandleSessionExit and
+            // never auto-close, so there is nothing left to do for them here.
+            if (pane.Profile?.Type == ConnectionType.SSH) return;
+
+            if (!ShouldClosePaneOnExit(_settings.ShellExitPolicy, isSsh: false, exitCode))
+            {
+                pane.WriteLocalExitBanner(exitCode);
+                return;
+            }
+
+            _ = HandlePaneExitCloseAsync(pane, exitCode);
+        }
+
+        /// <summary>
+        /// #311: try to close a pane whose shell exited cleanly, and fall back to the banner when
+        /// the close does not happen — a protected tab, an in-flight close, or a pane that has
+        /// already left the tree. Every one of those paths has to end with a pane that says
+        /// something rather than a pane that silently ignores you.
+        /// </summary>
+        private async Task HandlePaneExitCloseAsync(TerminalPane pane, int exitCode)
+        {
+            bool closed = await ClosePaneAsync(pane, skipConfirm: true);
+            if (!closed)
+            {
+                pane.WriteLocalExitBanner(exitCode);
+            }
+        }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~MainWindowShellExitTests"
+```
+
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Run the neighbouring suites**
+
+```bash
+scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~Pane|FullyQualifiedName~Ssh|FullyQualifiedName~TabClose"
+```
+
+Expected: PASS, no new failures — in particular the SSH disconnect tests, which assert the banner this change must not touch.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/NovaTerminal.App/MainWindow.axaml.cs tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs
+git commit -m "feat(pane): announce a dead shell, close it when it exited cleanly (#311)"
+```
+
+---
+
+### Task 5: Agent-facing settings surface
+
+`SettingsToolsDriftGuardTests` reflects over `TerminalSettings` and fails when a field is missing from the MCP server's field lists, so this task is not optional.
+
+**Files:**
+- Modify: `src/NovaTerminal.McpServer/Tools/SettingsTools.cs:54` (docs table), `:112` (example JSON), `:160` (`StringFields`), `:172` (`KnownFields`)
+- Test: `tests/NovaTerminal.McpServer.Tests/SettingsToolsDriftGuardTests.cs` (existing, unmodified)
+
+**Interfaces:**
+- Consumes: `TerminalSettings.ShellExitPolicy` (Task 1).
+- Produces: nothing.
+
+- [ ] **Step 1: Run the drift guard to verify it fails**
+
+```bash
+scripts/build.ps1 test tests/NovaTerminal.McpServer.Tests --filter "FullyQualifiedName~SettingsToolsDriftGuardTests"
+```
+
+Expected: FAIL — `KnownFields_AreExactlyTheSerializedSettings` and `StringFields_AreExactlyTheStringSettings` report `ShellExitPolicy` missing.
+
+- [ ] **Step 2: Add the docs row**
+
+In `src/NovaTerminal.McpServer/Tools/SettingsTools.cs`, directly below the `PaneClosePolicy` row:
+
+```
+        | `ShellExitPolicy` | string (enum-like) | "Never"/"Graceful"/"Always". Default "Graceful". What happens to a pane when its shell exits: keep it with a banner, close it on a clean exit, or always close it. SSH panes ignore this and always keep their reconnect banner. Type-checked only; unrecognised values behave as "Graceful". |
+```
+
+- [ ] **Step 3: Add the example entry**
+
+Directly below `"PaneClosePolicy": "Confirm",` in the example JSON block:
+
+```
+          "ShellExitPolicy": "Graceful",
+```
+
+- [ ] **Step 4: Add it to both field lists**
+
+In `StringFields`, extend the last line:
+
+```csharp
+        "BlurEffect", "CursorStyle", "PaneClosePolicy", "ShellExitPolicy", "BackgroundImageStretch",
+```
+
+In `KnownFields`, extend the `WheelLinesPerNotch` line:
+
+```csharp
+        "WheelLinesPerNotch", "PaneClosePolicy", "ShellExitPolicy", "Keybindings", "TabTemplateRules",
+```
+
+- [ ] **Step 5: Run the drift guard to verify it passes**
+
+```bash
+scripts/build.ps1 test tests/NovaTerminal.McpServer.Tests --filter "FullyQualifiedName~SettingsToolsDriftGuardTests"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/NovaTerminal.McpServer/Tools/SettingsTools.cs
+git commit -m "docs(mcp): document ShellExitPolicy in the settings tools (#311)"
+```
+
+---
+
+### Task 6: Verify the whole thing by hand
+
+Automated tests cover the decision, the banner and the targeting. What they cannot cover is the thing the user reported: a pane that looks alive but is not. Do this once against a real build before opening the PR.
+
+**Files:** none.
+
+- [ ] **Step 1: Build and run the app**
+
+```bash
+scripts/build.ps1 build src/NovaTerminal.App
+```
+
+Then launch `src/NovaTerminal.App/bin/Debug/net10.0/NovaTerminal.exe`.
+
+- [ ] **Step 2: Clean exit closes the pane**
+
+In a local tab, type `exit`. Expected: the tab closes. With a second tab open, the window stays.
+
+- [ ] **Step 3: An abnormal death announces itself**
+
+Open a local tab, note its shell PID (`$PID` in pwsh), and kill it from another terminal:
+
+```bash
+taskkill /PID <pid> /F
+```
+
+Expected: the pane stays and shows `[Shell exited]`, `[Exit code: 1]`, `[Press Enter to restart]`. Press Enter: the shell comes back and the tab's `✖1` glyph clears.
+
+- [ ] **Step 4: A background tab dies without disturbing the front one**
+
+With two tabs open, kill the *background* tab's shell as above while looking at the other tab. Expected: the visible tab is untouched; switching to the background tab shows the banner.
+
+- [ ] **Step 5: SSH is unchanged**
+
+Open an SSH tab, `exit` from the remote shell. Expected: the old `[SSH session disconnected]` / `[Press Enter to reconnect]` banner, and the tab stays open.
+
+- [ ] **Step 6: Commit nothing, open the PR**
+
+```bash
+git push -u origin feat/311-dead-pane-indicator
+gh pr create --base main --title "feat(pane): a dead pane says so, and a clean exit closes it (#311)" --body "Fixes #311. <summary + the manual verification results from steps 2-5>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** behaviour contract → Tasks 1 and 4; banner text → Task 2; protected-tab and reentrancy fallback → Task 4 (with the pane-targeted close it depends on in Task 3); SSH untouched → asserted in Tasks 2 and 4; settings surface → Tasks 1 and 5; data flow → Task 4; testing section → Tasks 1–4 plus the manual pass in Task 6. The spec's `SettingsWindow` dropdown is deliberately not implemented — see Global Constraints.
+
+**Deviations from the design doc, both deliberate:**
+1. The decision is `MainWindow.ShouldClosePaneOnExit(...)`, a static on `MainWindow` next to `ShouldAutoAcceptRunningPaneClose`, rather than a new `SessionExitDecision` type. Same purity, same testability (`[Fact]`, no Avalonia harness — see `TabClosePolicyTests`), and it follows the existing house pattern for pane-close policy.
+2. No settings UI, because the sibling `PaneClosePolicy` has none either.
+
+**Placeholder scan:** none — every step names its file, its exact code, its command and its expected output.
+
+**Type consistency:** `ShouldClosePaneOnExit(string?, bool, int) → bool` (Task 1) is called with `(_settings.ShellExitPolicy, isSsh: false, exitCode)` in Task 4. `WriteLocalExitBanner(int)` (Task 2) is called in Task 4 in four places. `ClosePaneAsync(TerminalPane, bool) → Task<bool>` (Task 3) is awaited in Task 4's `HandlePaneExitCloseAsync`. Banner strings are identical between Task 2's implementation and Tasks 2/4's assertions.

--- a/docs/plans/2026-08-12-dead-pane-indicator-plan.md
+++ b/docs/plans/2026-08-12-dead-pane-indicator-plan.md
@@ -15,7 +15,7 @@ Design: [`docs/plans/2026-08-12-dead-pane-indicator-design.md`](2026-08-12-dead-
 - **Build and test only through the wrappers:** `scripts/build.ps1 <args>` (PowerShell) or `scripts/build.sh <args>` (bash). A raw `dotnet build` hangs when stdout is captured. See CLAUDE.md.
 - **Never run the whole solution's tests** — that is 20–30 minutes of headless Avalonia. Run the one project, with a `--filter`.
 - The first build in a fresh worktree compiles the Rust natives via cargo (several minutes). Do not pass `SKIP_RUST_NATIVE_BUILD=1` for the test tasks here: `NovaTerminal.App.Tests` panes need `rusty_pty.dll` in the output.
-- **Setting name and values, exactly:** `ShellExitPolicy`, one of `"Never"`, `"Graceful"`, `"Always"`, default `"Graceful"`. Unrecognised values behave as `"Graceful"`.
+- **Setting name and values, exactly:** `ShellExitPolicy`, one of `"Never"`, `"Graceful"`, `"Always"`, default `"Never"`. Unrecognised values behave as `"Graceful"`.
 - **Banner text, exactly** (the exit-code line is omitted when the code is 0):
   ```
   [Shell exited]
@@ -52,7 +52,7 @@ Pure function plus the setting that feeds it. Nothing is wired yet, so behaviour
 
 **Interfaces:**
 - Consumes: nothing.
-- Produces: `TerminalSettings.ShellExitPolicy` (string, default `"Graceful"`); `internal static bool NovaTerminal.MainWindow.ShouldClosePaneOnExit(string? shellExitPolicy, bool isSsh, int exitCode)`.
+- Produces: `TerminalSettings.ShellExitPolicy` (string, default `"Never"`); `internal static bool NovaTerminal.MainWindow.ShouldClosePaneOnExit(string? shellExitPolicy, bool isSsh, int exitCode)`.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -112,9 +112,11 @@ public sealed class ShellExitPolicyTests
     }
 
     [Fact]
-    public void DefaultSettingIsGraceful()
+    public void DefaultSettingIsNever()
     {
-        Assert.Equal("Graceful", new TerminalSettings().ShellExitPolicy);
+        // Until #313 lands and the real exit status can be captured, defaulting to Never
+        // is conservative: every dead local pane gets the banner with its Enter-to-restart hint.
+        Assert.Equal("Never", new TerminalSettings().ShellExitPolicy);
     }
 }
 ```
@@ -132,11 +134,14 @@ Expected: compile error — `'MainWindow' does not contain a definition for 'Sho
 In `src/NovaTerminal.App/Shell/TerminalSettings.cs`, directly below `public string PaneClosePolicy { get; set; } = "Confirm";`:
 
 ```csharp
-        // What happens to a pane when its shell exits (#311). "Never" always keeps the pane and
-        // shows the exit banner; "Graceful" (default) closes it on a clean exit (code 0) and keeps
-        // it otherwise; "Always" closes it whatever the code. SSH panes ignore this and always
-        // keep their reconnect banner. Unrecognised values behave as "Graceful".
-        public string ShellExitPolicy { get; set; } = "Graceful";
+        // What happens to a pane when its shell exits (#311). Three values: "Never" (default for now)
+        // always keeps the pane and shows the exit banner; "Graceful" closes it on a clean exit (code 0)
+        // and keeps it otherwise; "Always" closes it whatever the code. Default is "Never" — a
+        // conservative choice until #313 lands, at which point the real exit status from the child process
+        // can be captured (today a local PTY reports 0 for every exit, even when the console host crashed).
+        // SSH panes ignore this and always keep their reconnect banner. Unrecognised values behave as
+        // "Graceful".
+        public string ShellExitPolicy { get; set; } = "Never";
 ```
 
 - [ ] **Step 4: Add the decision**
@@ -816,7 +821,7 @@ Expected: FAIL — `KnownFields_AreExactlyTheSerializedSettings` and `StringFiel
 In `src/NovaTerminal.McpServer/Tools/SettingsTools.cs`, directly below the `PaneClosePolicy` row:
 
 ```
-        | `ShellExitPolicy` | string (enum-like) | "Never"/"Graceful"/"Always". Default "Graceful". What happens to a pane when its shell exits: keep it with a banner, close it on a clean exit, or always close it. SSH panes ignore this and always keep their reconnect banner. Type-checked only; unrecognised values behave as "Graceful". |
+        | `ShellExitPolicy` | string (enum-like) | "Never"/"Graceful"/"Always". Default "Never". What happens to a pane when its shell exits: keep it with a banner, close it on a clean exit, or always close it. Default is "Never" — a conservative choice until #313 lands and the real exit status from the child process can be captured. SSH panes ignore this and always keep their reconnect banner. Type-checked only; unrecognised values behave as "Graceful". |
 ```
 
 - [ ] **Step 3: Add the example entry**
@@ -824,7 +829,7 @@ In `src/NovaTerminal.McpServer/Tools/SettingsTools.cs`, directly below the `Pane
 Directly below `"PaneClosePolicy": "Confirm",` in the example JSON block:
 
 ```
-          "ShellExitPolicy": "Graceful",
+          "ShellExitPolicy": "Never",
 ```
 
 - [ ] **Step 4: Add it to both field lists**

--- a/docs/plans/2026-08-12-dead-pane-indicator-plan.md
+++ b/docs/plans/2026-08-12-dead-pane-indicator-plan.md
@@ -35,6 +35,7 @@ Design: [`docs/plans/2026-08-12-dead-pane-indicator-design.md`](2026-08-12-dead-
 | `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs` | `WriteLocalExitBanner` | 2 |
 | `src/NovaTerminal.McpServer/Tools/SettingsTools.cs` | Agent-facing settings docs + validation | 5 |
 | `tests/NovaTerminal.App.Tests/Core/ShellExitPolicyTests.cs` (new) | Policy matrix | 1 |
+| `tests/NovaTerminal.App.Tests/Infra/TerminalBufferText.cs` (new) | Shared "what does the buffer show" test helper | 2 |
 | `tests/NovaTerminal.App.Tests/Core/TerminalPaneExitBannerTests.cs` (new) | Banner text | 2 |
 | `tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs` (new) | Close targeting + end-to-end exit behaviour | 3, 4 |
 
@@ -188,21 +189,58 @@ The pane gains a way to say its shell is gone. Still not wired — only the new 
 
 **Files:**
 - Modify: `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs:3753` (next to `WriteSshDisconnectedBanner`)
+- Create: `tests/NovaTerminal.App.Tests/Infra/TerminalBufferText.cs`
 - Test: `tests/NovaTerminal.App.Tests/Core/TerminalPaneExitBannerTests.cs` (create)
 
 **Interfaces:**
 - Consumes: nothing from Task 1.
-- Produces: `internal void TerminalPane.WriteLocalExitBanner(int code)`.
+- Produces: `internal void TerminalPane.WriteLocalExitBanner(int code)`; `internal static string NovaTerminal.Tests.Infra.TerminalBufferText.Visible(TerminalBuffer buffer)` — Task 4's tests use it too.
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Write the shared buffer-text helper**
 
-Create `tests/NovaTerminal.App.Tests/Core/TerminalPaneExitBannerTests.cs`. The `GetVisiblePlainText` helper is copied from `tests/NovaTerminal.App.Tests/Ssh/TerminalPaneSshDisconnectTests.cs`, where it is private:
+`TerminalPaneSshDisconnectTests` has this logic as a private static; Task 4 needs it as well, so it
+lands in one shared place rather than being copied a third time. Create
+`tests/NovaTerminal.App.Tests/Infra/TerminalBufferText.cs`:
+
+```csharp
+using NovaTerminal.VT;
+
+namespace NovaTerminal.Tests.Infra;
+
+/// <summary>
+/// What a pane actually shows: the viewport rendered as plain text, for asserting on banners and
+/// other terminal output. The buffer's viewport is private, hence the reflection.
+/// </summary>
+internal static class TerminalBufferText
+{
+    public static string Visible(TerminalBuffer buffer)
+    {
+        var field = typeof(TerminalBuffer).GetField(
+            "_viewport",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var viewport = (TerminalRow[])field!.GetValue(buffer)!;
+        return string.Join("\n", viewport.Select(RowText)).TrimEnd();
+    }
+
+    private static string RowText(TerminalRow row)
+    {
+        char[] chars = row.Cells.Select(c => c.Character == '\0' ? ' ' : c.Character).ToArray();
+        return new string(chars).TrimEnd();
+    }
+}
+```
+
+Leave `TerminalPaneSshDisconnectTests` alone — migrating it is unrelated churn for this task.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/NovaTerminal.App.Tests/Core/TerminalPaneExitBannerTests.cs`:
 
 ```csharp
 using Avalonia.Headless.XUnit;
 using NovaTerminal.Controls;
 using NovaTerminal.Platform;
-using NovaTerminal.VT;
+using NovaTerminal.Tests.Infra;
 
 namespace NovaTerminal.Tests.Core;
 
@@ -220,7 +258,7 @@ public sealed class TerminalPaneExitBannerTests
 
         pane.WriteLocalExitBanner(1);
 
-        string visibleText = GetVisiblePlainText(pane.Buffer!);
+        string visibleText = TerminalBufferText.Visible(pane.Buffer!);
         Assert.Contains("[Shell exited]", visibleText, StringComparison.Ordinal);
         Assert.Contains("[Exit code: 1]", visibleText, StringComparison.Ordinal);
         Assert.Contains("[Press Enter to restart]", visibleText, StringComparison.Ordinal);
@@ -233,7 +271,7 @@ public sealed class TerminalPaneExitBannerTests
 
         pane.WriteLocalExitBanner(0);
 
-        string visibleText = GetVisiblePlainText(pane.Buffer!);
+        string visibleText = TerminalBufferText.Visible(pane.Buffer!);
         Assert.Contains("[Shell exited]", visibleText, StringComparison.Ordinal);
         Assert.DoesNotContain("Exit code", visibleText, StringComparison.Ordinal);
         Assert.Contains("[Press Enter to restart]", visibleText, StringComparison.Ordinal);
@@ -254,7 +292,7 @@ public sealed class TerminalPaneExitBannerTests
 
         pane.HandleSessionExitForTesting(17);
 
-        string visibleText = GetVisiblePlainText(pane.Buffer!);
+        string visibleText = TerminalBufferText.Visible(pane.Buffer!);
         Assert.Contains("[SSH session disconnected]", visibleText, StringComparison.Ordinal);
         Assert.Contains("[Exit code: 17]", visibleText, StringComparison.Ordinal);
         Assert.Contains("[Press Enter to reconnect]", visibleText, StringComparison.Ordinal);
@@ -267,23 +305,10 @@ public sealed class TerminalPaneExitBannerTests
         Type = ConnectionType.Local,
         Command = "pwsh.exe"
     };
-
-    private static string GetVisiblePlainText(TerminalBuffer buffer)
-    {
-        var field = typeof(TerminalBuffer).GetField("_viewport", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        var viewport = (TerminalRow[])field!.GetValue(buffer)!;
-        return string.Join("\n", viewport.Select(GetRowText)).TrimEnd();
-    }
-
-    private static string GetRowText(TerminalRow row)
-    {
-        char[] chars = row.Cells.Select(c => c.Character == '\0' ? ' ' : c.Character).ToArray();
-        return new string(chars).TrimEnd();
-    }
 }
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [ ] **Step 3: Run the test to verify it fails**
 
 ```bash
 scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~TerminalPaneExitBannerTests"
@@ -291,7 +316,7 @@ scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName
 
 Expected: compile error — `'TerminalPane' does not contain a definition for 'WriteLocalExitBanner'`.
 
-- [ ] **Step 3: Write the banner**
+- [ ] **Step 4: Write the banner**
 
 In `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs`, directly below `WriteSshDisconnectedBanner`:
 
@@ -312,7 +337,7 @@ In `src/NovaTerminal.App/Controls/TerminalPane.axaml.cs`, directly below `WriteS
         }
 ```
 
-- [ ] **Step 4: Run the tests to verify they pass**
+- [ ] **Step 5: Run the tests to verify they pass**
 
 ```bash
 scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~TerminalPaneExitBannerTests"
@@ -320,10 +345,10 @@ scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName
 
 Expected: PASS, 3 tests.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
-git add src/NovaTerminal.App/Controls/TerminalPane.axaml.cs tests/NovaTerminal.App.Tests/Core/TerminalPaneExitBannerTests.cs
+git add src/NovaTerminal.App/Controls/TerminalPane.axaml.cs tests/NovaTerminal.App.Tests/Infra/TerminalBufferText.cs tests/NovaTerminal.App.Tests/Core/TerminalPaneExitBannerTests.cs
 git commit -m "feat(pane): banner for a local shell that exited (#311)"
 ```
 
@@ -604,7 +629,7 @@ git commit -m "refactor(panes): close the pane you name, not the selected one (#
 
 - [ ] **Step 1: Write the failing tests**
 
-Add to `tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs`, inside the existing class, above the `TwoTabFixture` nested class. `GetVisiblePlainText`/`GetRowText` are the same helpers as Task 2 — copy them in as private statics of this class too:
+Add to `tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs`, inside the existing class, above the `TwoTabFixture` nested class. Add `using NovaTerminal.Tests.Infra;` to the file's usings — `TerminalBufferText.Visible` is the shared helper Task 2 created:
 
 ```csharp
     [AvaloniaFact]
@@ -630,7 +655,7 @@ Add to `tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs`, inside t
         Avalonia.Threading.Dispatcher.UIThread.RunJobs();
 
         Assert.Equal(2, fixture.Tabs.Items.Count);
-        string visibleText = GetVisiblePlainText(fixture.BackgroundPane.Buffer!);
+        string visibleText = TerminalBufferText.Visible(fixture.BackgroundPane.Buffer!);
         Assert.Contains("[Shell exited]", visibleText, StringComparison.Ordinal);
         Assert.Contains("[Exit code: 1]", visibleText, StringComparison.Ordinal);
     }
@@ -645,7 +670,7 @@ Add to `tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs`, inside t
         Avalonia.Threading.Dispatcher.UIThread.RunJobs();
 
         Assert.Equal(2, fixture.Tabs.Items.Count);
-        string visibleText = GetVisiblePlainText(fixture.BackgroundPane.Buffer!);
+        string visibleText = TerminalBufferText.Visible(fixture.BackgroundPane.Buffer!);
         Assert.Contains("[Shell exited]", visibleText, StringComparison.Ordinal);
         Assert.DoesNotContain("Exit code", visibleText, StringComparison.Ordinal);
     }
@@ -663,7 +688,7 @@ Add to `tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs`, inside t
         Avalonia.Threading.Dispatcher.UIThread.RunJobs();
 
         Assert.Equal(2, fixture.Tabs.Items.Count);
-        Assert.Contains("[Shell exited]", GetVisiblePlainText(fixture.BackgroundPane.Buffer!), StringComparison.Ordinal);
+        Assert.Contains("[Shell exited]", TerminalBufferText.Visible(fixture.BackgroundPane.Buffer!), StringComparison.Ordinal);
     }
 ```
 

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -3760,6 +3760,21 @@ namespace NovaTerminal.Controls
         }
 
         /// <summary>
+        /// #311: a local pane whose shell exited. Same shape as the SSH banner — including
+        /// dropping the exit-code line when the code is 0 — because the restart it advertises is
+        /// the same mechanism: Enter on a dead session reaches <see cref="Reconnect"/>.
+        /// No interpolated value is caller- or remote-derived, so nothing needs sanitizing.
+        /// </summary>
+        internal void WriteLocalExitBanner(int code)
+        {
+            string exitCodeLine = code == 0
+                ? string.Empty
+                : $"[Exit code: {code}]\r\n";
+            WriteBanner(
+                $"\r\n[Shell exited]\r\n{exitCodeLine}[Press Enter to restart]\r\n");
+        }
+
+        /// <summary>
         /// Strips control characters (C0 incl. ESC, DEL, and C1) from interpolated banner values.
         /// Banner text is parsed as terminal input, so remote- or profile-derived values such as
         /// SSH/spawn error messages could otherwise smuggle escape sequences that move the cursor,

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -2832,14 +2832,37 @@ namespace NovaTerminal
         /// #311: try to close a pane whose shell exited cleanly, and fall back to the banner when
         /// the close does not happen — a protected tab, an in-flight close, or a pane that has
         /// already left the tree. Every one of those paths has to end with a pane that says
-        /// something rather than a pane that silently ignores you.
+        /// something rather than a pane that silently ignores you. This runs fire-and-forget from
+        /// <see cref="OnPaneProcessExited"/>, so a throw here has no other observer: catch it,
+        /// log it the same way other unexpected UI-side failures in this file do, and still fall
+        /// back to the banner. There are three outcomes now: closed (nothing more to do), not
+        /// closed (banner), and threw (log + banner).
         /// </summary>
         private async Task HandlePaneExitCloseAsync(TerminalPane pane, int exitCode)
         {
-            bool closed = await ClosePaneAsync(pane, skipConfirm: true);
-            if (!closed)
+            bool closed;
+            try
+            {
+                closed = await ClosePaneAsync(pane, skipConfirm: true);
+            }
+            catch (Exception ex)
+            {
+                TerminalLogger.Error($"[MainWindow] ClosePaneAsync failed while closing a pane whose shell exited (exit code {exitCode}): {ex.Message}");
+                closed = false;
+            }
+
+            if (closed)
+            {
+                return;
+            }
+
+            try
             {
                 pane.WriteLocalExitBanner(exitCode);
+            }
+            catch (Exception ex)
+            {
+                TerminalLogger.Error($"[MainWindow] WriteLocalExitBanner failed for a pane whose shell exited (exit code {exitCode}): {ex.Message}");
             }
         }
 

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -3490,6 +3490,27 @@ namespace NovaTerminal
             }
         }
 
+        /// <summary>
+        /// #311: whether a pane whose shell just exited should close itself. Protection and
+        /// close-in-progress guards deliberately live outside this decision — the caller attempts
+        /// the close and falls back to the banner if it does not happen, so that a pane which
+        /// cannot close still says something.
+        /// </summary>
+        internal static bool ShouldClosePaneOnExit(string? shellExitPolicy, bool isSsh, int exitCode)
+        {
+            // A dropped SSH session keeps its [Press Enter to reconnect] banner regardless: the
+            // remote end may have cost an MFA prompt or a jump host to reach.
+            if (isSsh) return false;
+
+            string policy = shellExitPolicy?.Trim() ?? string.Empty;
+
+            if (policy.Equals("Never", StringComparison.OrdinalIgnoreCase)) return false;
+            if (policy.Equals("Always", StringComparison.OrdinalIgnoreCase)) return true;
+
+            // "Graceful" and anything unrecognised.
+            return exitCode == 0;
+        }
+
         internal static bool ShouldAutoAcceptRunningPaneClose(
             bool isProcessRunning,
             bool hasActiveChildProcesses,

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -3601,9 +3601,12 @@ namespace NovaTerminal
 
             if (policy.Equals("Never", StringComparison.OrdinalIgnoreCase)) return false;
             if (policy.Equals("Always", StringComparison.OrdinalIgnoreCase)) return true;
+            if (policy.Equals("Graceful", StringComparison.OrdinalIgnoreCase)) return exitCode == 0;
 
-            // "Graceful" and anything unrecognised.
-            return exitCode == 0;
+            // Fall-through: unrecognised or empty value behaves as the default "Never",
+            // because a typo in a hand-edited settings file must not be more destructive
+            // than the default. "Never" still tells the user via the exit banner.
+            return false;
         }
 
         internal static bool ShouldAutoAcceptRunningPaneClose(

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -3527,22 +3527,15 @@ namespace NovaTerminal
                         // 6. Focus Sibling
                         FocusFirstPane(sibling);
                         UpdatePaneAutomationLabels();
-                        if (paneTab != null)
-                        {
-                            RefreshLayoutModelForTab(paneTab);
-                            PublishPaneEvent(paneTab, paneToClose, PaneAuditEventKind.Close);
-                        }
+                        RefreshLayoutModelForTab(paneTab);
+                        PublishPaneEvent(paneTab, paneToClose, PaneAuditEventKind.Close);
                         return true;
                     }
                 }
 
-                // Fallback: If not in a split, close the pane's own tab.
-                if (paneTab != null)
-                {
-                    return await CloseTabAsync(paneTab, skipProcessChecks: true);
-                }
-
-                return false;
+                // Fallback: If not in a split, close the pane's own tab. paneTab is non-null from
+                // the early return above, so there is no null branch left to guard here.
+                return await CloseTabAsync(paneTab, skipProcessChecks: true);
             }
             finally
             {

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -2803,12 +2803,44 @@ namespace NovaTerminal
 
         private void OnPaneProcessExited(TerminalPane pane, int exitCode)
         {
-            var tab = pane.FindAncestorOfType<TabItem>();
-            if (tab == null) return;
+            var tab = pane.FindLogicalAncestorOfType<TabItem>();
+            if (tab == null)
+            {
+                // No tab to close or mark; the pane still has to say what happened.
+                pane.WriteLocalExitBanner(exitCode);
+                return;
+            }
 
             var state = GetOrCreateTabState(tab);
             state.LastExitCode = exitCode;
             QueueTabVisualRefresh(tab);
+
+            // SSH panes write their own [SSH session disconnected] banner in HandleSessionExit and
+            // never auto-close, so there is nothing left to do for them here.
+            if (pane.Profile?.Type == ConnectionType.SSH) return;
+
+            if (!ShouldClosePaneOnExit(_settings.ShellExitPolicy, isSsh: false, exitCode))
+            {
+                pane.WriteLocalExitBanner(exitCode);
+                return;
+            }
+
+            _ = HandlePaneExitCloseAsync(pane, exitCode);
+        }
+
+        /// <summary>
+        /// #311: try to close a pane whose shell exited cleanly, and fall back to the banner when
+        /// the close does not happen — a protected tab, an in-flight close, or a pane that has
+        /// already left the tree. Every one of those paths has to end with a pane that says
+        /// something rather than a pane that silently ignores you.
+        /// </summary>
+        private async Task HandlePaneExitCloseAsync(TerminalPane pane, int exitCode)
+        {
+            bool closed = await ClosePaneAsync(pane, skipConfirm: true);
+            if (!closed)
+            {
+                pane.WriteLocalExitBanner(exitCode);
+            }
         }
 
         private void OnPaneActionRequested(TerminalPane pane, PaneAction action)

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
 using Avalonia.Controls.Primitives;
+using Avalonia.LogicalTree;
 using Avalonia.VisualTree;
 using Avalonia.Controls.Presenters;
 using NovaTerminal.Shell;
@@ -3361,28 +3362,46 @@ namespace NovaTerminal
             _ = CloseActivePaneAsync();
         }
 
-        private async Task CloseActivePaneAsync(bool skipConfirm = false)
+        private Task CloseActivePaneAsync(bool skipConfirm = false)
         {
-            if (_closePaneInProgress || _currentPane == null) return;
+            if (_currentPane == null) return Task.CompletedTask;
+            return ClosePaneAsync(_currentPane, skipConfirm);
+        }
+
+        /// <summary>
+        /// Closes a specific pane, resolving everything from that pane rather than from the
+        /// selection. The distinction matters for #311: a shell can die in a background tab, and
+        /// the old selection-based fallback would have closed the tab the user was looking at.
+        /// Returns true when the pane (or its tab) actually went away — callers use that to fall
+        /// back to a banner when a protected tab or an in-flight close refuses.
+        /// </summary>
+        private async Task<bool> ClosePaneAsync(TerminalPane pane, bool skipConfirm = false)
+        {
+            if (_closePaneInProgress || pane == null) return false;
             _closePaneInProgress = true;
 
             try
             {
-                var paneToClose = _currentPane;
-                if (paneToClose == null) return;
-                if (TryGetSelectedTab(out var selectedTab) && _paneZoomStateByTab.ContainsKey(selectedTab))
+                var paneToClose = pane;
+                // FindAncestorOfType<TabItem> (visual tree) never resolves here: Avalonia's
+                // TabControl renders only the selected item's Content through its own
+                // PART_SelectedContentHost presenter, so a TabItem is never a visual ancestor of
+                // its own Content — selected or not. The logical tree is what's actually reliable
+                // (ContentControl sets the logical parent immediately on assignment, same
+                // mechanism the split-detection Parent check below already leans on).
+                var paneTab = paneToClose.FindLogicalAncestorOfType<TabItem>();
+                if (paneTab != null && _paneZoomStateByTab.ContainsKey(paneTab))
                 {
-                    ExitPaneZoom(selectedTab, publishEvent: true);
-                    paneToClose = _currentPane;
-                    if (paneToClose == null) return;
+                    ExitPaneZoom(paneTab, publishEvent: true);
                 }
-                // Agent-initiated close bypasses the confirmation dialog: an agent
-                // can't answer a modal, and the act opt-in + journal entry are the
-                // consent surface (A3 threat model).
+
+                // Agent-initiated and exit-driven closes bypass the confirmation dialog: an agent
+                // can't answer a modal, a dead shell has nothing left to lose, and an unattended
+                // prompt is the stuck state #311 is about.
                 if (!skipConfirm && !await ShouldClosePaneAsync(paneToClose))
                 {
                     FocusPaneTerminal(paneToClose, defer: true);
-                    return;
+                    return false;
                 }
 
                 // Check if we are in a split (Parent is Grid with multiple children/splitter)
@@ -3433,21 +3452,22 @@ namespace NovaTerminal
                         // 6. Focus Sibling
                         FocusFirstPane(sibling);
                         UpdatePaneAutomationLabels();
-                        if (TryGetSelectedTab(out selectedTab))
+                        if (paneTab != null)
                         {
-                            RefreshLayoutModelForTab(selectedTab);
-                            PublishPaneEvent(selectedTab, paneToClose, PaneAuditEventKind.Close);
+                            RefreshLayoutModelForTab(paneTab);
+                            PublishPaneEvent(paneTab, paneToClose, PaneAuditEventKind.Close);
                         }
-                        return;
+                        return true;
                     }
                 }
 
-                // Fallback: If not in a split, close the tab
-                var tabs = this.FindControl<TabControl>("Tabs");
-                if (tabs?.SelectedItem is TabItem ti)
+                // Fallback: If not in a split, close the pane's own tab.
+                if (paneTab != null)
                 {
-                    await CloseTabAsync(ti, skipProcessChecks: true);
+                    return await CloseTabAsync(paneTab, skipProcessChecks: true);
                 }
+
+                return false;
             }
             finally
             {

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -2803,21 +2803,28 @@ namespace NovaTerminal
 
         private void OnPaneProcessExited(TerminalPane pane, int exitCode)
         {
+            // SSH panes write their own [SSH session disconnected] banner in HandleSessionExit and
+            // never auto-close, so there is nothing left to do for them here. This has to run
+            // before the tab==null branch below: an SSH pane that has already left the logical
+            // tree by the time its shell exits must not also get a local banner written on top of
+            // the one HandleSessionExit already wrote (#311 fix-wave finding B).
+            if (pane.Profile?.Type == ConnectionType.SSH) return;
+
             var tab = pane.FindLogicalAncestorOfType<TabItem>();
             if (tab == null)
             {
-                // No tab to close or mark; the pane still has to say what happened.
+                // No tab to close; the pane still has to say what happened.
                 pane.WriteLocalExitBanner(exitCode);
                 return;
             }
 
-            var state = GetOrCreateTabState(tab);
-            state.LastExitCode = exitCode;
-            QueueTabVisualRefresh(tab);
-
-            // SSH panes write their own [SSH session disconnected] banner in HandleSessionExit and
-            // never auto-close, so there is nothing left to do for them here.
-            if (pane.Profile?.Type == ConnectionType.SSH) return;
+            // Deliberately not recording exitCode on the tab's state here (#311 fix-wave finding
+            // A). Doing so lets the ✓/✖N tab-strip glyph render, but the only place that clears it
+            // — OnPaneCommandStarted — resolves its TabItem via the visual tree, which (like the
+            // comment on ClosePaneAsync explains) never resolves for a TabControl's Content, so
+            // the glyph would render once and then stick forever, including across a successful
+            // restart. The whole glyph story (set, clear, and telling a process-exit apart from a
+            // command-exit) is deferred to a follow-up issue; see #311.
 
             if (!ShouldClosePaneOnExit(_settings.ShellExitPolicy, isSsh: false, exitCode))
             {
@@ -3445,7 +3452,20 @@ namespace NovaTerminal
                 // (ContentControl sets the logical parent immediately on assignment, same
                 // mechanism the split-detection Parent check below already leans on).
                 var paneTab = paneToClose.FindLogicalAncestorOfType<TabItem>();
-                if (paneTab != null && _paneZoomStateByTab.ContainsKey(paneTab))
+                if (paneTab == null)
+                {
+                    // A zoomed tab's EnterPaneZoom replaces TabItem.Content with only the zoomed
+                    // pane, so the tab's original split Grid — and every non-zoomed sibling still
+                    // inside it — is detached from the logical tree and has no TabItem ancestor.
+                    // Falling through to the split branch below for such a pane would clear that
+                    // detached Grid's Children while its Parent is null: none of the promotion
+                    // branches match, and the sibling pane is silently orphaned with its shell
+                    // still running. Returning false here instead lets the caller fall back to a
+                    // banner (#311 fix-wave finding C).
+                    return false;
+                }
+
+                if (_paneZoomStateByTab.ContainsKey(paneTab))
                 {
                     ExitPaneZoom(paneTab, publishEvent: true);
                 }

--- a/src/NovaTerminal.App/Shell/TerminalSettings.cs
+++ b/src/NovaTerminal.App/Shell/TerminalSettings.cs
@@ -57,7 +57,7 @@ namespace NovaTerminal.Shell
         // conservative choice until #313 lands, at which point the real exit status from the child process
         // can be captured (today a local PTY reports 0 for every exit, even when the console host crashed).
         // SSH panes ignore this and always keep their reconnect banner. Unrecognised values behave as
-        // "Graceful".
+        // "Never" — a typo must not be more destructive than the default.
         public string ShellExitPolicy { get; set; } = "Never";
         public System.Collections.Generic.Dictionary<string, string> Keybindings { get; set; } = new();
         public System.Collections.Generic.List<TabTemplateRule> TabTemplateRules { get; set; } = new();

--- a/src/NovaTerminal.App/Shell/TerminalSettings.cs
+++ b/src/NovaTerminal.App/Shell/TerminalSettings.cs
@@ -51,11 +51,14 @@ namespace NovaTerminal.Shell
         // high-resolution touchpads, which emit many sub-notch wheel events.
         public double WheelLinesPerNotch { get; set; } = 3.0;
         public string PaneClosePolicy { get; set; } = "Confirm";
-        // What happens to a pane when its shell exits (#311). "Never" always keeps the pane and
-        // shows the exit banner; "Graceful" (default) closes it on a clean exit (code 0) and keeps
-        // it otherwise; "Always" closes it whatever the code. SSH panes ignore this and always
-        // keep their reconnect banner. Unrecognised values behave as "Graceful".
-        public string ShellExitPolicy { get; set; } = "Graceful";
+        // What happens to a pane when its shell exits (#311). Three values: "Never" (default for now)
+        // always keeps the pane and shows the exit banner; "Graceful" closes it on a clean exit (code 0)
+        // and keeps it otherwise; "Always" closes it whatever the code. Default is "Never" — a
+        // conservative choice until #313 lands, at which point the real exit status from the child process
+        // can be captured (today a local PTY reports 0 for every exit, even when the console host crashed).
+        // SSH panes ignore this and always keep their reconnect banner. Unrecognised values behave as
+        // "Graceful".
+        public string ShellExitPolicy { get; set; } = "Never";
         public System.Collections.Generic.Dictionary<string, string> Keybindings { get; set; } = new();
         public System.Collections.Generic.List<TabTemplateRule> TabTemplateRules { get; set; } = new();
 

--- a/src/NovaTerminal.App/Shell/TerminalSettings.cs
+++ b/src/NovaTerminal.App/Shell/TerminalSettings.cs
@@ -51,6 +51,11 @@ namespace NovaTerminal.Shell
         // high-resolution touchpads, which emit many sub-notch wheel events.
         public double WheelLinesPerNotch { get; set; } = 3.0;
         public string PaneClosePolicy { get; set; } = "Confirm";
+        // What happens to a pane when its shell exits (#311). "Never" always keeps the pane and
+        // shows the exit banner; "Graceful" (default) closes it on a clean exit (code 0) and keeps
+        // it otherwise; "Always" closes it whatever the code. SSH panes ignore this and always
+        // keep their reconnect banner. Unrecognised values behave as "Graceful".
+        public string ShellExitPolicy { get; set; } = "Graceful";
         public System.Collections.Generic.Dictionary<string, string> Keybindings { get; set; } = new();
         public System.Collections.Generic.List<TabTemplateRule> TabTemplateRules { get; set; } = new();
 

--- a/src/NovaTerminal.App/native/src/lib.rs
+++ b/src/NovaTerminal.App/native/src/lib.rs
@@ -1059,6 +1059,80 @@ pub extern "C" fn pty_get_pid(state_ptr: *mut PtyState) -> c_int {
     })
 }
 
+/// Non-blocking check for "has the child shell exited, and with what status".
+///
+/// Returns 1 and writes `out_code` when the child has exited, 0 while it is still
+/// running, and -1 when the status cannot be determined (bad arguments, or a state
+/// that owns neither a process handle nor a `Child`).
+///
+/// This exists because pipe EOF is NOT a reliable exit signal on Windows: with
+/// ConPTY the output pipe stays open for as long as the console host lives, and the
+/// host outlives its client shell. A session that watched only for EOF therefore
+/// never noticed a shell exiting - it only noticed the host *crashing* (#313). The
+/// caller polls this instead, so a clean `exit` and a killed shell are both seen,
+/// with the shell's real status rather than an assumed 0.
+#[unsafe(no_mangle)]
+pub extern "C" fn pty_try_get_exit_code(state_ptr: *mut PtyState, out_code: *mut c_int) -> c_int {
+    ffi_guard(-1, || {
+        if state_ptr.is_null() || out_code.is_null() {
+            return -1;
+        }
+        // Clone the Arc without consuming the caller's ref (same idiom as pty_read).
+        let state = unsafe {
+            let arc = Arc::from_raw(state_ptr);
+            let cloned = arc.clone();
+            let _ = Arc::into_raw(arc);
+            cloned
+        };
+
+        #[cfg(windows)]
+        {
+            // ConPTY passthrough path: we hold the child's process handle directly.
+            if let Ok(h_process_opt) = state.h_process.lock() {
+                if let Some(h_process) = *h_process_opt {
+                    unsafe {
+                        use windows_sys::Win32::System::Threading::{
+                            GetExitCodeProcess, WaitForSingleObject,
+                        };
+                        // Zero-timeout wait, not GetExitCodeProcess alone: a process may
+                        // legitimately exit with 259 (STILL_ACTIVE), which would read as
+                        // "still running" forever.
+                        const WAIT_OBJECT_0: u32 = 0;
+                        if WaitForSingleObject(h_process, 0) != WAIT_OBJECT_0 {
+                            return 0;
+                        }
+                        let mut code: u32 = 0;
+                        if GetExitCodeProcess(h_process, &mut code) == 0 {
+                            return -1;
+                        }
+                        *out_code = code as c_int;
+                        return 1;
+                    }
+                }
+            }
+        }
+
+        // portable-pty path (every platform): try_wait() is non-blocking, so the child
+        // lock is held only briefly and can never deadlock against pty_close.
+        if let Ok(mut child_opt) = state.child.lock() {
+            if let Some(child) = child_opt.as_mut() {
+                return match child.try_wait() {
+                    Ok(Some(status)) => {
+                        unsafe {
+                            *out_code = status.exit_code() as c_int;
+                        }
+                        1
+                    }
+                    Ok(None) => 0,
+                    Err(_) => -1,
+                };
+            }
+        }
+
+        -1
+    })
+}
+
 /// Unblock an in-flight `pty_read` so the caller's read thread can be joined.
 ///
 /// The blocked read holds `state.reader`'s lock, so we must NEVER touch `reader`
@@ -1181,6 +1255,124 @@ pub extern "C" fn pty_close(state_ptr: *mut PtyState) {
 
         // Drop logic handles the rest (reader, writer, master)
     })
+}
+
+#[cfg(test)]
+mod child_exit_tests {
+    use super::*;
+    use std::ffi::CString;
+
+    /// Types `exit 3` at a real shell and polls pty_try_get_exit_code until it reports the
+    /// exit with that status. This is the signal the managed side relies on instead of pipe
+    /// EOF, which never arrives while the ConPTY host outlives its client (#313) — and it is
+    /// the exact scenario from that bug: a shell ending because the user asked it to.
+    ///
+    /// The shell is driven by writing to it rather than by argv (`cmd.exe /c ...`), because
+    /// portable-pty quotes every argument and a quoted `"/c"` makes cmd.exe ignore the
+    /// switch and start interactively instead.
+    #[test]
+    fn reports_the_childs_real_exit_status() {
+        #[cfg(windows)]
+        let shell = "cmd.exe";
+        #[cfg(not(windows))]
+        let shell = "/bin/sh";
+
+        let shell_c = CString::new(shell).unwrap();
+        let state = pty_spawn(
+            shell_c.as_ptr(),
+            std::ptr::null(),
+            std::ptr::null(),
+            80,
+            24,
+        );
+        assert!(!state.is_null(), "spawn failed: {}", take_last_error_for_test());
+
+        // Alive before we ask it to leave: this is what makes the assertion below meaningful
+        // rather than "the status was 1 all along".
+        let mut code: c_int = i32::MIN;
+        assert_eq!(
+            pty_try_get_exit_code(state, &mut code),
+            0,
+            "a freshly spawned shell must report as running"
+        );
+
+        // Drain output while we wait, and answer the one device report a real terminal must
+        // answer. Without this the shell (Clink-hooked cmd.exe here) blocks forever on its
+        // startup `ESC[6n` cursor-position query and never reads the `exit` below — the same
+        // trap that silently stalls any PTY harness that only reads.
+        let state_addr = state as usize;
+        let reader = std::thread::spawn(move || {
+            let sp = state_addr as *mut PtyState;
+            let mut buf = [0u8; 4096];
+            loop {
+                let n = pty_read(sp, buf.as_mut_ptr(), buf.len() as c_int);
+                if n <= 0 {
+                    return;
+                }
+                if buf[..n as usize].windows(4).any(|w| w == b"\x1b[6n") {
+                    let report = b"\x1b[1;1R";
+                    let _ = pty_write(sp, report.as_ptr(), report.len() as c_int);
+                }
+            }
+        });
+
+        let command = b"exit 3\r\n";
+        let written = pty_write(state, command.as_ptr(), command.len() as c_int);
+        assert_eq!(written, command.len() as c_int, "failed to write to the shell");
+
+        let mut status = 0;
+        // Generous: a cold shell on a loaded CI box takes a while to start, read and exit.
+        for _ in 0..300 {
+            status = pty_try_get_exit_code(state, &mut code);
+            if status == 1 {
+                break;
+            }
+            assert_eq!(status, 0, "status must be 'running' until it is 'exited'");
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+
+        assert_eq!(status, 1, "child never reported an exit");
+        assert_eq!(code, 3, "the child's real status must be reported, not an assumed 0");
+
+        // Idempotent: the watcher may poll again before the managed side tears down.
+        let mut again: c_int = i32::MIN;
+        assert_eq!(pty_try_get_exit_code(state, &mut again), 1);
+        assert_eq!(again, 3);
+
+        // The pipe outlives the shell (that is the whole point), so the reader has to be
+        // broken out of rather than waited on.
+        pty_cancel_read(state);
+        let _ = reader.join();
+        pty_close(state);
+    }
+
+    #[test]
+    fn rejects_null_arguments() {
+        let mut code: c_int = 0;
+        assert_eq!(pty_try_get_exit_code(std::ptr::null_mut(), &mut code), -1);
+
+        // A live state with a null out-pointer must not be written through.
+        #[cfg(windows)]
+        let cmd = "cmd.exe";
+        #[cfg(not(windows))]
+        let cmd = "/bin/sh";
+        let cmd_c = CString::new(cmd).unwrap();
+        let state = pty_spawn(cmd_c.as_ptr(), std::ptr::null(), std::ptr::null(), 80, 24);
+        assert!(!state.is_null());
+        assert_eq!(pty_try_get_exit_code(state, std::ptr::null_mut()), -1);
+        pty_close(state);
+    }
+
+    /// Drains the thread-local channel so a spawn failure can be reported in the assert.
+    fn take_last_error_for_test() -> String {
+        let mut buf = vec![0i8; 512];
+        let rc = pty_last_error(buf.as_mut_ptr() as *mut c_char, buf.len() as c_int);
+        if rc <= 0 {
+            return "<no native error recorded>".to_string();
+        }
+        let bytes: Vec<u8> = buf.iter().take_while(|b| **b != 0).map(|b| *b as u8).collect();
+        String::from_utf8_lossy(&bytes).into_owned()
+    }
 }
 
 #[cfg(test)]

--- a/src/NovaTerminal.McpServer/Tools/SettingsTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/SettingsTools.cs
@@ -52,6 +52,7 @@ public static class SettingsTools
         | `AllowOsc52ClipboardWrite` | bool | Default true. Settings gate for OSC 52 clipboard **write** (issue #268). When false, a decoded OSC 52 write is not applied to the system clipboard. OSC 52 **read** (answering a query with real clipboard contents) is never implemented regardless of this setting — queries always get an empty-payload denial reply. |
         | `WheelLinesPerNotch` | number | > 0 (≤ 0 falls back to 3.0). Default 3.0. |
         | `PaneClosePolicy` | string (enum-like) | e.g. "Confirm", "Force". Type-checked only. |
+        | `ShellExitPolicy` | string (enum-like) | "Never"/"Graceful"/"Always". Default "Graceful". What happens to a pane when its shell exits: keep it with a banner, close it on a clean exit, or always close it. SSH panes ignore this and always keep their reconnect banner. Type-checked only; unrecognised values behave as "Graceful". |
         | `QuakeModeEnabled` | bool | Default true. |
         | `GlobalHotkey` | string | Default "Alt+OemTilde". |
         | `ExperimentalNativeSshEnabled` | bool | Default false. |
@@ -110,6 +111,7 @@ public static class SettingsTools
           "AllowOsc52ClipboardWrite": true,
           "WheelLinesPerNotch": 3.0,
           "PaneClosePolicy": "Confirm",
+          "ShellExitPolicy": "Graceful",
           "Keybindings": { "Ctrl+Shift+C": "copy" },
           "TabTemplateRules": [],
           "BackgroundImagePath": "",
@@ -157,7 +159,7 @@ public static class SettingsTools
     internal static readonly string[] StringFields =
     {
         "FontFamily", "ThemeName", "BackgroundImagePath", "GlobalHotkey",
-        "BlurEffect", "CursorStyle", "PaneClosePolicy", "BackgroundImageStretch",
+        "BlurEffect", "CursorStyle", "PaneClosePolicy", "ShellExitPolicy", "BackgroundImageStretch",
     };
 
     internal static readonly string[] ArrayFields = { "Profiles", "TabTemplateRules" };
@@ -169,7 +171,7 @@ public static class SettingsTools
         "EnableLigatures", "EnableComplexShaping", "CursorStyle", "CursorBlink",
         "BellAudioEnabled", "BellVisualEnabled", "SmoothScrolling", "EnableLinkDetection",
         "EnableKittyKeyboardProtocol", "AllowOsc52ClipboardWrite",
-        "WheelLinesPerNotch", "PaneClosePolicy", "Keybindings", "TabTemplateRules",
+        "WheelLinesPerNotch", "PaneClosePolicy", "ShellExitPolicy", "Keybindings", "TabTemplateRules",
         "BackgroundImagePath", "BackgroundImageOpacity", "BackgroundImageStretch",
         "QuakeModeEnabled", "GlobalHotkey", "CommandAssistEnabled", "CommandAssistHistoryEnabled",
         "CommandAssistMaxHistoryEntries", "CommandAssistPassiveBubbleEnabled",

--- a/src/NovaTerminal.McpServer/Tools/SettingsTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/SettingsTools.cs
@@ -52,7 +52,7 @@ public static class SettingsTools
         | `AllowOsc52ClipboardWrite` | bool | Default true. Settings gate for OSC 52 clipboard **write** (issue #268). When false, a decoded OSC 52 write is not applied to the system clipboard. OSC 52 **read** (answering a query with real clipboard contents) is never implemented regardless of this setting — queries always get an empty-payload denial reply. |
         | `WheelLinesPerNotch` | number | > 0 (≤ 0 falls back to 3.0). Default 3.0. |
         | `PaneClosePolicy` | string (enum-like) | e.g. "Confirm", "Force". Type-checked only. |
-        | `ShellExitPolicy` | string (enum-like) | "Never"/"Graceful"/"Always". Default "Graceful". What happens to a pane when its shell exits: keep it with a banner, close it on a clean exit, or always close it. SSH panes ignore this and always keep their reconnect banner. Type-checked only; unrecognised values behave as "Graceful". |
+        | `ShellExitPolicy` | string (enum-like) | "Never"/"Graceful"/"Always". Default "Never". What happens to a pane when its shell exits: keep it with a banner, close it on a clean exit, or always close it. Default is "Never" — a conservative choice until #313 lands and the real exit status from the child process can be captured. SSH panes ignore this and always keep their reconnect banner. Type-checked only; unrecognised values behave as "Graceful". |
         | `QuakeModeEnabled` | bool | Default true. |
         | `GlobalHotkey` | string | Default "Alt+OemTilde". |
         | `ExperimentalNativeSshEnabled` | bool | Default false. |
@@ -111,7 +111,7 @@ public static class SettingsTools
           "AllowOsc52ClipboardWrite": true,
           "WheelLinesPerNotch": 3.0,
           "PaneClosePolicy": "Confirm",
-          "ShellExitPolicy": "Graceful",
+          "ShellExitPolicy": "Never",
           "Keybindings": { "Ctrl+Shift+C": "copy" },
           "TabTemplateRules": [],
           "BackgroundImagePath": "",

--- a/src/NovaTerminal.McpServer/Tools/SettingsTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/SettingsTools.cs
@@ -52,7 +52,7 @@ public static class SettingsTools
         | `AllowOsc52ClipboardWrite` | bool | Default true. Settings gate for OSC 52 clipboard **write** (issue #268). When false, a decoded OSC 52 write is not applied to the system clipboard. OSC 52 **read** (answering a query with real clipboard contents) is never implemented regardless of this setting — queries always get an empty-payload denial reply. |
         | `WheelLinesPerNotch` | number | > 0 (≤ 0 falls back to 3.0). Default 3.0. |
         | `PaneClosePolicy` | string (enum-like) | e.g. "Confirm", "Force". Type-checked only. |
-        | `ShellExitPolicy` | string (enum-like) | "Never"/"Graceful"/"Always". Default "Never". What happens to a pane when its shell exits: keep it with a banner, close it on a clean exit, or always close it. Default is "Never" — a conservative choice until #313 lands and the real exit status from the child process can be captured. SSH panes ignore this and always keep their reconnect banner. Type-checked only; unrecognised values behave as "Graceful". |
+        | `ShellExitPolicy` | string (enum-like) | "Never"/"Graceful"/"Always". Default "Never". What happens to a pane when its shell exits: keep it with a banner, close it on a clean exit, or always close it. Default is "Never" — a conservative choice until #313 lands and the real exit status from the child process can be captured. SSH panes ignore this and always keep their reconnect banner. Type-checked only; unrecognised values behave as "Never" (a typo must not be more destructive than the default). |
         | `QuakeModeEnabled` | bool | Default true. |
         | `GlobalHotkey` | string | Default "Alt+OemTilde". |
         | `ExperimentalNativeSshEnabled` | bool | Default false. |

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -56,6 +56,79 @@ namespace NovaTerminal.Pty
         /// process may still be alive; the *session* is what has failed.
         internal const int ReadFailureExitCode = -1;
 
+        // Child-exit watch (#313). Pipe EOF is not a reliable exit signal: with ConPTY the
+        // output pipe stays open while the console host lives, and the host outlives its
+        // client shell - measured at 159s and counting after a shell exited. A session that
+        // waited only for EOF therefore never learned that a shell had ended (clean `exit`
+        // or kill alike); it only learned that a host had *crashed*, which is why the pane
+        // in #311's own bug report sat there looking alive. So we poll the child's status
+        // and treat that as the authoritative exit signal, keeping EOF as a second trigger.
+        //
+        // 200 ms is a compromise: fast enough that a tab reacts to `exit` without a
+        // perceptible lag, slow enough to be free (one non-blocking status check per
+        // session per tick).
+        internal const int ChildExitPollIntervalMs = 200;
+
+        /// Grace given to the read loop to drain output the shell wrote just before exiting,
+        /// after the child is seen to be gone but before the read is cancelled. Without it a
+        /// command's final line can be cut off, since the child's death and the last bytes
+        /// arriving are a race.
+        internal const int ChildExitDrainGraceMs = 250;
+
+        private Thread? _exitWatchThread;
+
+        // Written once by the exit-watch thread, read by the read/process loops. Two fields
+        // rather than an int? so the read is atomic without a lock.
+        private int _childExitObserved;
+        private int _childExitCode;
+
+        /// True once the child shell has been observed to have exited. The read loop uses
+        /// this to stop counting read failures: once the shell is gone, a failing read is
+        /// the expected consequence of cancelling it, not a session failure worth reporting
+        /// as <see cref="ReadFailureExitCode"/>.
+        private bool ChildExitObserved => Volatile.Read(ref _childExitObserved) == 1;
+
+        /// Asks the native layer whether the child has exited and records its status if so.
+        /// Returns true when the child is gone.
+        ///
+        /// Called from the read loop's EOF and error branches, not only from the watcher,
+        /// because both can beat the watcher's next tick — and whoever gets there first
+        /// decides the reported code. A killed shell makes reads fail immediately, so the
+        /// read loop would otherwise hit its failure limit (20 x 50 ms) and report
+        /// <see cref="ReadFailureExitCode"/> about a second before the watcher could say what
+        /// actually happened. Asking here classifies "reads are failing because the shell is
+        /// gone" apart from "reads are failing while the shell lives" at the moment it
+        /// matters, rather than racing it.
+        private bool TryCaptureChildExit()
+        {
+            if (ChildExitObserved)
+            {
+                return true;
+            }
+
+            if (_handle.IsClosed || _handle.IsInvalid)
+            {
+                return false;
+            }
+
+            try
+            {
+                if (Native.pty_try_get_exit_code(_handle, out int code) != 1)
+                {
+                    return false;
+                }
+
+                Volatile.Write(ref _childExitCode, code);
+                Volatile.Write(ref _childExitObserved, 1);
+                PtyLogger.Info($"[RustPtySession] Child exited with code {code}.");
+                return true;
+            }
+            catch (ObjectDisposedException)
+            {
+                return false; // handle released under us — Dispose owns the teardown
+            }
+        }
+
         // PowerShell post-launch init injection. Held so Dispose can observe the task's
         // failures instead of dropping them, and delete the script if the shell never
         // sourced it (the script deletes itself on the happy path). Both are written from
@@ -221,6 +294,11 @@ namespace NovaTerminal.Pty
 
             [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void pty_cancel_read(PtySafeHandle state);
+
+            // 1 = the child exited and exitCode is set, 0 = still running, -1 = unknown.
+            // Non-blocking; see the Rust doc comment for why EOF alone cannot be trusted.
+            [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+            public static extern int pty_try_get_exit_code(PtySafeHandle state, out int exitCode);
 
             // Raw overload used only by PtySafeHandle.ReleaseHandle().
             [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
@@ -585,9 +663,13 @@ namespace NovaTerminal.Pty
             _readLoopThread = new Thread(ReadLoop) { IsBackground = true, Name = $"PtyRead-{Id:N}" };
             _processLoopThread = new Thread(ProcessLoop) { IsBackground = true, Name = $"PtyProcess-{Id:N}" };
             _writeLoopThread = new Thread(WriteLoop) { IsBackground = true, Name = $"PtyWrite-{Id:N}" };
+            // Same dedicated-thread reasoning as the loops above; this one spends its life
+            // asleep, waking every ChildExitPollIntervalMs for one non-blocking status check.
+            _exitWatchThread = new Thread(ExitWatchLoop) { IsBackground = true, Name = $"PtyExitWatch-{Id:N}" };
             _readLoopThread.Start();
             _processLoopThread.Start();
             _writeLoopThread.Start();
+            _exitWatchThread.Start();
 
             // POST-LAUNCH INJECTION for PowerShell
             if (!skipPowerShellPostLaunchInit &&
@@ -818,12 +900,25 @@ namespace NovaTerminal.Pty
                     else if (read == 0) // EOF
                     {
                         PtyLogger.Info("[RustPtySession] EOF received.");
+                        // Learn the child's real status before unwinding, so an EOF that
+                        // followed a death reports that death's code rather than 0.
+                        TryCaptureChildExit();
                         break;
                     }
                     else // read < 0: error
                     {
                         // Reset decoder state on error to prevent corruption
                         _utf8Decoder.Reset();
+
+                        if (TryCaptureChildExit())
+                        {
+                            // The shell is gone: either the watcher cancelled this read, or the
+                            // shell was killed and the pipe failed before the watcher's next
+                            // tick (#313). Either way a failing read is the consequence, not a
+                            // session failure — counting it would report ReadFailureExitCode
+                            // and bury the child's real status.
+                            break;
+                        }
 
                         if (++consecutiveReadErrors >= MaxConsecutiveReadErrors)
                         {
@@ -913,6 +1008,64 @@ namespace NovaTerminal.Pty
             }
         }
 
+        /// Polls the child shell's status and turns its death into the session's exit
+        /// signal. See the ChildExitPollIntervalMs comment for why EOF cannot carry this.
+        ///
+        /// The loop does not notify the exit itself: it records the status, gives the read
+        /// loop a moment to drain what the shell wrote on its way out, then cancels the
+        /// read. The read loop unwinds, the process loop drains the queue, and the existing
+        /// single notification point reports the recorded code — so output still precedes
+        /// the exit event, exactly as on the EOF path.
+        private void ExitWatchLoop()
+        {
+            try
+            {
+                while (!_cts.Token.IsCancellationRequested)
+                {
+                    if (_handle.IsClosed || _handle.IsInvalid)
+                    {
+                        return;
+                    }
+
+                    if (TryCaptureChildExit())
+                    {
+                        // Let the tail of the shell's output arrive before we break the read.
+                        if (_cts.Token.WaitHandle.WaitOne(ChildExitDrainGraceMs))
+                        {
+                            return; // disposing anyway; Dispose owns the teardown
+                        }
+
+                        if (!_handle.IsClosed && !_handle.IsInvalid)
+                        {
+                            // The pipe may never EOF on its own (the console host is still
+                            // alive), so unblock the read the same way Dispose does.
+                            try { Native.pty_cancel_read(_handle); }
+                            catch (ObjectDisposedException) { /* raced Dispose */ }
+                        }
+                        return;
+                    }
+
+                    // status == 0 (running) or -1 (unknown, e.g. a state with neither a
+                    // process handle nor a Child): keep watching. A permanently unknown
+                    // status just means we fall back to the EOF trigger, as before.
+                    if (_cts.Token.WaitHandle.WaitOne(ChildExitPollIntervalMs))
+                    {
+                        return;
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Normal shutdown.
+            }
+            catch (Exception ex)
+            {
+                // Dedicated thread: an escape would crash the process. The cost of losing
+                // this watcher is the old behaviour (EOF-only detection), not a crash.
+                PtyLogger.Error($"[RustPtySession] ExitWatchLoop terminated by unhandled exception: {ex}");
+            }
+        }
+
         private void ProcessLoop()
         {
             try
@@ -933,7 +1086,9 @@ namespace NovaTerminal.Pty
                 // misbehaving subscriber can't take down the host; still notify exit below.
                 PtyLogger.Error($"[RustPtySession] ProcessLoop terminated by unhandled exception: {ex}");
             }
-            TryNotifyExit(0);
+            // The child's real status when the watcher observed it (#313); 0 otherwise, which
+            // is the pre-existing reading of "the stream ended and we know nothing more".
+            TryNotifyExit(ChildExitObserved ? Volatile.Read(ref _childExitCode) : 0);
         }
 
         public void SendInput(string input)
@@ -1060,6 +1215,15 @@ namespace NovaTerminal.Pty
                 PtyLogger.Warning("[RustPtySession] WriteLoop did not exit within join timeout.");
             }
 
+            // 4c. Join the exit watcher (#313). It only ever sleeps on the cancellation
+            //     token or makes one non-blocking call, so it unwinds on the Cancel above;
+            //     joining it before the handle is released keeps it from calling into a
+            //     closed handle (which it also guards against).
+            if (!(_exitWatchThread?.Join(DisposeJoinTimeout) ?? true))
+            {
+                PtyLogger.Warning("[RustPtySession] ExitWatchLoop did not exit within join timeout.");
+            }
+
             // 5. Release the handle. SafeHandle guarantees pty_close runs only once
             //    no pty_* call is in flight, so this is UAF-safe even if a join timed out.
             _handle.Dispose();
@@ -1076,7 +1240,9 @@ namespace NovaTerminal.Pty
             //    simply the position with no failure mode.
             CleanUpPowerShellInit();
 
-            TryNotifyExit(0);
+            // Last-resort notification for a session nobody else reported (first-caller-wins,
+            // so a real exit already observed upstream keeps its code).
+            TryNotifyExit(ChildExitObserved ? Volatile.Read(ref _childExitCode) : 0);
         }
 
         /// Observes the injection task's outcome and removes its script if the shell

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs
@@ -183,6 +183,27 @@ public sealed class MainWindowShellExitTests
         Assert.Contains("[Shell exited]", TerminalBufferText.Visible(fixture.BackgroundPane.Buffer!), StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// Fix round 1 (#311 review finding): the <c>tab == null</c> branch of
+    /// <c>OnPaneProcessExited</c> — a pane that has already left the tree by the time its shell
+    /// exits — had no coverage. Detach the pane from its tab's <c>Content</c> before it exits so
+    /// <c>FindLogicalAncestorOfType&lt;TabItem&gt;()</c> resolves to null (the same mechanism
+    /// <c>ClosePaneAsync</c>'s own comment documents: a <c>ContentControl</c> sets/clears the
+    /// logical parent immediately on assignment), and confirm the pane still gets the banner
+    /// instead of silently going quiet.
+    /// </summary>
+    [AvaloniaFact]
+    public void CleanExit_WithNoAncestorTab_StillShowsTheBanner()
+    {
+        using var fixture = TwoTabFixture.Create();
+        fixture.BackgroundTab.Content = null;
+
+        fixture.BackgroundPane.HandleSessionExitForTesting(0);
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        Assert.Contains("[Shell exited]", TerminalBufferText.Visible(fixture.BackgroundPane.Buffer!), StringComparison.Ordinal);
+    }
+
     private sealed class TwoTabFixture : IDisposable
     {
         private TwoTabFixture(NovaTerminal.MainWindow window, TabControl tabs, TabItem selectedTab, TerminalPane backgroundPane)

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs
@@ -1,0 +1,95 @@
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using NovaTerminal.Controls;
+using NovaTerminal.Pty;
+using NovaTerminal.Shell;
+
+namespace NovaTerminal.Tests.Core;
+
+/// <summary>
+/// #311. The targeting test is the important one: a shell dying in a background tab — a build, an
+/// agent session, exactly the tabs you are not watching — must not close the tab in front of you.
+/// </summary>
+public sealed class MainWindowShellExitTests
+{
+    [AvaloniaFact]
+    public async Task ClosePaneAsync_ClosesTheGivenPanesTab_NotTheSelectedOne()
+    {
+        using var fixture = TwoTabFixture.Create();
+
+        bool closed = await fixture.ClosePaneAsync(fixture.BackgroundPane, skipConfirm: true);
+
+        Assert.True(closed);
+        Assert.Single(fixture.Tabs.Items);
+        Assert.Same(fixture.SelectedTab, fixture.Tabs.Items[0]);
+    }
+
+    private sealed class TwoTabFixture : IDisposable
+    {
+        private TwoTabFixture(NovaTerminal.MainWindow window, TabControl tabs, TabItem selectedTab, TerminalPane backgroundPane)
+        {
+            Window = window;
+            Tabs = tabs;
+            SelectedTab = selectedTab;
+            BackgroundPane = backgroundPane;
+        }
+
+        public NovaTerminal.MainWindow Window { get; }
+        public TabControl Tabs { get; }
+        public TabItem SelectedTab { get; }
+        public TerminalPane BackgroundPane { get; }
+
+        public Task<bool> ClosePaneAsync(TerminalPane pane, bool skipConfirm)
+        {
+            var method = typeof(NovaTerminal.MainWindow)
+                .GetMethod("ClosePaneAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            return (Task<bool>)method.Invoke(Window, [pane, skipConfirm])!;
+        }
+
+        public static TwoTabFixture Create()
+        {
+            AppServiceBundle bundle = AppServices.BuildForDesigner();
+            var window = new NovaTerminal.MainWindow(bundle);
+            TabControl tabs = window.FindControl<TabControl>("Tabs")!;
+            var settings = (TerminalSettings)typeof(NovaTerminal.MainWindow)
+                .GetField("_settings", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(window)!;
+
+            tabs.Items.Clear();
+            TabItem background = CreateTab(window, tabs, settings, "Background");
+            TabItem selected = CreateTab(window, tabs, settings, "Selected");
+            tabs.SelectedItem = selected;
+
+            return new TwoTabFixture(window, tabs, selected, (TerminalPane)background.Content!);
+        }
+
+        private static TabItem CreateTab(NovaTerminal.MainWindow window, TabControl tabs, TerminalSettings settings, string title)
+        {
+            var tabSession = new TabSession
+            {
+                Title = title,
+                Root = new PaneNode
+                {
+                    Type = NodeType.Leaf,
+                    Command = "cmd.exe",
+                    Arguments = string.Empty,
+                    PaneId = Guid.NewGuid().ToString()
+                }
+            };
+
+            TabItem tab = SessionManager.CreateRestoredTabItem(tabSession, settings)!;
+            tabs.Items.Add(tab);
+
+            // The production entry point for restored content — it is what wires the pane's
+            // events to the window (ProcessExited included, which Task 4 depends on).
+            typeof(NovaTerminal.MainWindow)
+                .GetMethod("InitializeRestoredTabs", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(window, [tabs]);
+
+            return tab;
+        }
+
+        public void Dispose() => Window.Close();
+    }
+}

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs
@@ -13,23 +13,29 @@ namespace NovaTerminal.Tests.Core;
 /// </summary>
 /// <remarks>
 /// Fix round 1 (#311 review finding): a reviewer flagged that this class, the only caller of
-/// <c>ClosePaneAsync</c>/<c>ClosePaneAsync</c>/<c>CloseActivePane</c> in the repo, exercised
-/// exactly one branch (single-leaf pane, background tab, <c>skipConfirm: true</c>), so the
-/// split-promotion and confirmation-gate paths the task brief protects had no actual regression
-/// coverage despite the report implying otherwise.
+/// <c>ClosePaneAsync</c>/<c>CloseActivePaneAsync</c> in the repo, exercised exactly one branch
+/// (single-leaf pane, background tab, <c>skipConfirm: true</c>), so the split-promotion and
+/// confirmation-gate paths the task brief protects had no actual regression coverage despite the
+/// report implying otherwise.
 ///
-/// The declined half of the confirmation gate (<c>skipConfirm: false</c> with a pane the policy
-/// would actually question) is deliberately NOT covered here. Reaching it requires
-/// <c>ShouldAutoAcceptRunningPaneClose</c> to return false, which for a non-SSH, non-WSL pane
-/// means it has active child processes or unsafe shell args — and once that gate is not
-/// auto-accepted, <c>ShowRunningProcessCloseConfirmationAsync</c> opens a real modal
-/// (<c>await dialog.ShowDialog(this)</c>) that only resolves when a button is clicked. Nothing in
-/// this headless suite can click that button, and there is no way to fake
-/// <c>HasActiveChildProcesses</c> true without either a real child process or a production-code
-/// seam that does not exist today, so driving the decline path would hang the test run rather than
-/// assert anything. The auto-accept half is covered instead
-/// (<see cref="ClosePaneAsync_WithConfirmationEnabled_AutoAcceptsWhenNoProcessIsRunning"/>), which
-/// at least proves the gate is consulted rather than unconditionally bypassed.
+/// Fix round 2 (#311 review finding): a second reviewer correctly pointed out that the round-1
+/// justification for skipping the declined confirmation branch was wrong — <c>TerminalPane.Session</c>
+/// (private setter) is reachable by reflection exactly like the private methods this file already
+/// invokes, so a fake session with <c>HasActiveChildProcesses = true</c> is entirely possible. That
+/// was tried: attach such a stub to a non-SSH, non-WSL pane and call <c>ClosePaneAsync</c> with
+/// <c>skipConfirm: false</c>. <c>ShouldAutoAcceptRunningPaneClose</c> does decline as expected, and
+/// control reaches <c>ShowRunningProcessCloseConfirmationAsync</c>'s <c>await dialog.ShowDialog(this)</c>
+/// — a real, modal <c>Window.ShowDialog</c> with no owner ever shown and no button for anything to
+/// click. That call did not return: the test process (<c>testhost.exe</c> and the app's own test
+/// host) sat alive and unresponsive well past when the run should have finished, confirmed by
+/// checking process start times and having to <c>Stop-Process -Force</c> both to reclaim the build
+/// output lock afterward. Even racing the close task against a <c>Task.Delay</c> timeout inside the
+/// test did not help — the UI thread was stuck inside <c>ShowDialog</c> itself, so the timeout's
+/// continuation never got a turn. The actual, accurate blocker is exactly what round 1 described as
+/// unlikely — dismissing a real modal headlessly — not an inability to fake the session state. The
+/// declined branch remains uncovered here for that reason; the auto-accept half is covered instead
+/// (<see cref="ClosePaneAsync_WithConfirmationEnabled_AutoAcceptsWhenNoProcessIsRunning"/>), which at
+/// least proves the gate is consulted rather than unconditionally bypassed.
 /// </remarks>
 public sealed class MainWindowShellExitTests
 {
@@ -62,7 +68,36 @@ public sealed class MainWindowShellExitTests
 
         Assert.True(closed);
         Assert.Equal(tabCountBefore, fixture.Tabs.Items.Count);
-        Assert.Same(fixture.SplitTab, fixture.Tabs.Items[fixture.Tabs.Items.IndexOf(fixture.SplitTab)]);
+        Assert.Contains(fixture.SplitTab, fixture.Tabs.Items.OfType<TabItem>());
+        Assert.Same(fixture.Sibling, fixture.SplitTab.Content);
+    }
+
+    /// <summary>
+    /// Fix round 2 (#311 review finding, item 1): the brief calls out that the zoom-exit at the
+    /// top of <c>ClosePaneAsync</c> changed from looking at the selected tab to looking at the
+    /// closed pane's own tab, and nothing exercised that line — every prior fixture here zooms
+    /// nothing. This drives the real production zoom path (<c>EnterPaneZoom</c>, the same method
+    /// <c>TogglePaneZoomForCurrentTab</c> calls) on the split tab, then selects a DIFFERENT tab
+    /// before closing: a selection-based zoom-exit (the old bug) would look at the wrong tab and
+    /// never clear the zoom or restore the split's Grid parentage, so the split-promotion below it
+    /// would silently fall through to closing the whole tab instead. A pane-tab-based zoom-exit
+    /// (the fix) clears it regardless of what happens to be selected.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task ClosePaneAsync_WhenItsTabIsZoomed_ExitsZoomForThatTabRegardlessOfSelection()
+    {
+        using var fixture = SplitPaneFixture.Create();
+        fixture.EnterZoomOnSplitTab();
+        Assert.True(fixture.IsTabZoomed(fixture.SplitTab), "Test setup failed: split tab did not enter zoom.");
+
+        // The old bug looked at the selected tab; make sure it is NOT the tab being closed.
+        fixture.Tabs.SelectedItem = fixture.OtherTab;
+
+        bool closed = await fixture.ClosePaneAsync(fixture.PaneToClose, skipConfirm: true);
+
+        Assert.True(closed);
+        Assert.False(fixture.IsTabZoomed(fixture.SplitTab), "ClosePaneAsync must exit zoom on the closed pane's own tab, not the selected one.");
+        Assert.Contains(fixture.SplitTab, fixture.Tabs.Items.OfType<TabItem>());
         Assert.Same(fixture.Sibling, fixture.SplitTab.Content);
     }
 
@@ -169,13 +204,15 @@ public sealed class MainWindowShellExitTests
             TabControl tabs,
             TabItem splitTab,
             TerminalPane paneToClose,
-            TerminalPane sibling)
+            TerminalPane sibling,
+            TabItem otherTab)
         {
             Window = window;
             Tabs = tabs;
             SplitTab = splitTab;
             PaneToClose = paneToClose;
             Sibling = sibling;
+            OtherTab = otherTab;
         }
 
         public NovaTerminal.MainWindow Window { get; }
@@ -184,11 +221,44 @@ public sealed class MainWindowShellExitTests
         public TerminalPane PaneToClose { get; }
         public TerminalPane Sibling { get; }
 
+        /// <summary>
+        /// An unrelated tab, present so the zoom-exit regression test can select it and prove
+        /// <c>ClosePaneAsync</c> resolves the zoom to close from the closed pane's own tab, not
+        /// from whatever tab happens to be selected.
+        /// </summary>
+        public TabItem OtherTab { get; }
+
         public Task<bool> ClosePaneAsync(TerminalPane pane, bool skipConfirm)
         {
             var method = typeof(NovaTerminal.MainWindow)
                 .GetMethod("ClosePaneAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
             return (Task<bool>)method.Invoke(Window, [pane, skipConfirm])!;
+        }
+
+        /// <summary>
+        /// Drives the actual production zoom path — the same private <c>EnterPaneZoom</c> method
+        /// <c>TogglePaneZoomForCurrentTab</c> calls — directly on <see cref="SplitTab"/>, without
+        /// requiring it to be the currently selected tab (the public toggle path only ever zooms
+        /// the selection).
+        /// </summary>
+        public void EnterZoomOnSplitTab()
+        {
+            var method = typeof(NovaTerminal.MainWindow)
+                .GetMethod("EnterPaneZoom", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var entered = (bool)method.Invoke(Window, [SplitTab, PaneToClose, true])!;
+            if (!entered)
+            {
+                throw new InvalidOperationException("EnterPaneZoom refused to zoom the split tab's pane.");
+            }
+        }
+
+        /// <summary>Reads the private <c>_paneZoomStateByTab</c> dictionary this file cannot see the type of.</summary>
+        public bool IsTabZoomed(TabItem tab)
+        {
+            var field = typeof(NovaTerminal.MainWindow)
+                .GetField("_paneZoomStateByTab", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var dictionary = (System.Collections.IDictionary)field.GetValue(Window)!;
+            return dictionary.Contains(tab);
         }
 
         public static SplitPaneFixture Create()
@@ -229,9 +299,22 @@ public sealed class MainWindowShellExitTests
                     Sizes = { "1*", "1*" }
                 }
             };
+            var otherTabSession = new TabSession
+            {
+                Title = "Other",
+                Root = new PaneNode
+                {
+                    Type = NodeType.Leaf,
+                    Command = "cmd.exe",
+                    Arguments = string.Empty,
+                    PaneId = Guid.NewGuid().ToString()
+                }
+            };
 
             TabItem splitTab = SessionManager.CreateRestoredTabItem(tabSession, settings)!;
             tabs.Items.Add(splitTab);
+            TabItem otherTab = SessionManager.CreateRestoredTabItem(otherTabSession, settings)!;
+            tabs.Items.Add(otherTab);
             tabs.SelectedItem = splitTab;
 
             // The production entry point for restored content — it is what wires the panes'
@@ -251,7 +334,7 @@ public sealed class MainWindowShellExitTests
                     $"Expected the split to restore exactly two panes, found {panes.Count}.");
             }
 
-            return new SplitPaneFixture(window, tabs, splitTab, panes[0], panes[1]);
+            return new SplitPaneFixture(window, tabs, splitTab, panes[0], panes[1], otherTab);
         }
 
         public void Dispose() => Window.Close();

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs
@@ -11,6 +11,26 @@ namespace NovaTerminal.Tests.Core;
 /// #311. The targeting test is the important one: a shell dying in a background tab — a build, an
 /// agent session, exactly the tabs you are not watching — must not close the tab in front of you.
 /// </summary>
+/// <remarks>
+/// Fix round 1 (#311 review finding): a reviewer flagged that this class, the only caller of
+/// <c>ClosePaneAsync</c>/<c>ClosePaneAsync</c>/<c>CloseActivePane</c> in the repo, exercised
+/// exactly one branch (single-leaf pane, background tab, <c>skipConfirm: true</c>), so the
+/// split-promotion and confirmation-gate paths the task brief protects had no actual regression
+/// coverage despite the report implying otherwise.
+///
+/// The declined half of the confirmation gate (<c>skipConfirm: false</c> with a pane the policy
+/// would actually question) is deliberately NOT covered here. Reaching it requires
+/// <c>ShouldAutoAcceptRunningPaneClose</c> to return false, which for a non-SSH, non-WSL pane
+/// means it has active child processes or unsafe shell args — and once that gate is not
+/// auto-accepted, <c>ShowRunningProcessCloseConfirmationAsync</c> opens a real modal
+/// (<c>await dialog.ShowDialog(this)</c>) that only resolves when a button is clicked. Nothing in
+/// this headless suite can click that button, and there is no way to fake
+/// <c>HasActiveChildProcesses</c> true without either a real child process or a production-code
+/// seam that does not exist today, so driving the decline path would hang the test run rather than
+/// assert anything. The auto-accept half is covered instead
+/// (<see cref="ClosePaneAsync_WithConfirmationEnabled_AutoAcceptsWhenNoProcessIsRunning"/>), which
+/// at least proves the gate is consulted rather than unconditionally bypassed.
+/// </remarks>
 public sealed class MainWindowShellExitTests
 {
     [AvaloniaFact]
@@ -19,6 +39,49 @@ public sealed class MainWindowShellExitTests
         using var fixture = TwoTabFixture.Create();
 
         bool closed = await fixture.ClosePaneAsync(fixture.BackgroundPane, skipConfirm: true);
+
+        Assert.True(closed);
+        Assert.Single(fixture.Tabs.Items);
+        Assert.Same(fixture.SelectedTab, fixture.Tabs.Items[0]);
+    }
+
+    /// <summary>
+    /// Fix round 1 (#311 review finding): the brief protects split-promotion behaviour, but the
+    /// original test only ever exercised the single-leaf/tab-fallback branch of
+    /// <c>ClosePaneAsync</c>. This drives a real split — built the same way session restore does,
+    /// via <c>SessionManager.CreateRestoredTabItem</c> with a <c>NodeType.Split</c> root — and
+    /// checks that closing one leaf promotes its sibling into the tab rather than closing the tab.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task ClosePaneAsync_ClosesOneOfASplitPair_PromotesSiblingIntoTheTab()
+    {
+        using var fixture = SplitPaneFixture.Create();
+        int tabCountBefore = fixture.Tabs.Items.Count;
+
+        bool closed = await fixture.ClosePaneAsync(fixture.PaneToClose, skipConfirm: true);
+
+        Assert.True(closed);
+        Assert.Equal(tabCountBefore, fixture.Tabs.Items.Count);
+        Assert.Same(fixture.SplitTab, fixture.Tabs.Items[fixture.Tabs.Items.IndexOf(fixture.SplitTab)]);
+        Assert.Same(fixture.Sibling, fixture.SplitTab.Content);
+    }
+
+    /// <summary>
+    /// Fix round 1 (#311 review finding): covers the confirmation gate on the
+    /// <c>skipConfirm: false</c> path, which the original test never touched at all (it always
+    /// passed <c>skipConfirm: true</c>). A restored pane in these tests never actually spawns a
+    /// shell (no real PTY is started unless the pane is attached to a live visual tree), so
+    /// <c>TerminalPane.IsProcessRunning</c> is false and <c>ShouldAutoAcceptRunningPaneClose</c>
+    /// auto-accepts without showing the confirmation dialog. That is the only half of this branch
+    /// reachable headlessly — see the class remarks for why the declined half is not covered here.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task ClosePaneAsync_WithConfirmationEnabled_AutoAcceptsWhenNoProcessIsRunning()
+    {
+        using var fixture = TwoTabFixture.Create();
+        Assert.False(fixture.BackgroundPane.IsProcessRunning, "This test's premise is that no real shell is running.");
+
+        bool closed = await fixture.ClosePaneAsync(fixture.BackgroundPane, skipConfirm: false);
 
         Assert.True(closed);
         Assert.Single(fixture.Tabs.Items);
@@ -88,6 +151,107 @@ public sealed class MainWindowShellExitTests
                 .Invoke(window, [tabs]);
 
             return tab;
+        }
+
+        public void Dispose() => Window.Close();
+    }
+
+    /// <summary>
+    /// Fix round 1 (#311 review finding): builds a tab holding a real split — the same shape
+    /// <c>SessionManager.CreateRestoredTabItem</c> produces from a <c>NodeType.Split</c> root with
+    /// two <c>NodeType.Leaf</c> children — so the split-promotion branch of
+    /// <c>ClosePaneAsync</c> has an actual regression test.
+    /// </summary>
+    private sealed class SplitPaneFixture : IDisposable
+    {
+        private SplitPaneFixture(
+            NovaTerminal.MainWindow window,
+            TabControl tabs,
+            TabItem splitTab,
+            TerminalPane paneToClose,
+            TerminalPane sibling)
+        {
+            Window = window;
+            Tabs = tabs;
+            SplitTab = splitTab;
+            PaneToClose = paneToClose;
+            Sibling = sibling;
+        }
+
+        public NovaTerminal.MainWindow Window { get; }
+        public TabControl Tabs { get; }
+        public TabItem SplitTab { get; }
+        public TerminalPane PaneToClose { get; }
+        public TerminalPane Sibling { get; }
+
+        public Task<bool> ClosePaneAsync(TerminalPane pane, bool skipConfirm)
+        {
+            var method = typeof(NovaTerminal.MainWindow)
+                .GetMethod("ClosePaneAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            return (Task<bool>)method.Invoke(Window, [pane, skipConfirm])!;
+        }
+
+        public static SplitPaneFixture Create()
+        {
+            AppServiceBundle bundle = AppServices.BuildForDesigner();
+            var window = new NovaTerminal.MainWindow(bundle);
+            TabControl tabs = window.FindControl<TabControl>("Tabs")!;
+            var settings = (TerminalSettings)typeof(NovaTerminal.MainWindow)
+                .GetField("_settings", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(window)!;
+
+            tabs.Items.Clear();
+
+            var tabSession = new TabSession
+            {
+                Title = "Split",
+                Root = new PaneNode
+                {
+                    Type = NodeType.Split,
+                    SplitOrientation = 0, // horizontal (columns), matches SessionManager's default
+                    Children =
+                    {
+                        new PaneNode
+                        {
+                            Type = NodeType.Leaf,
+                            Command = "cmd.exe",
+                            Arguments = string.Empty,
+                            PaneId = Guid.NewGuid().ToString()
+                        },
+                        new PaneNode
+                        {
+                            Type = NodeType.Leaf,
+                            Command = "cmd.exe",
+                            Arguments = string.Empty,
+                            PaneId = Guid.NewGuid().ToString()
+                        }
+                    },
+                    Sizes = { "1*", "1*" }
+                }
+            };
+
+            TabItem splitTab = SessionManager.CreateRestoredTabItem(tabSession, settings)!;
+            tabs.Items.Add(splitTab);
+            tabs.SelectedItem = splitTab;
+
+            // The production entry point for restored content — it is what wires the panes'
+            // events to the window, same as the single-leaf fixture above.
+            typeof(NovaTerminal.MainWindow)
+                .GetMethod("InitializeRestoredTabs", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(window, [tabs]);
+
+            // SessionManager.RestorePaneTree builds the split as a Grid whose Children are
+            // [child0, GridSplitter, child1] (splitter inserted before every child but the
+            // first) — OfType<TerminalPane>() filters the splitter out and preserves order.
+            var grid = (Grid)splitTab.Content!;
+            var panes = grid.Children.OfType<TerminalPane>().ToList();
+            if (panes.Count != 2)
+            {
+                throw new InvalidOperationException(
+                    $"Expected the split to restore exactly two panes, found {panes.Count}.");
+            }
+
+            return new SplitPaneFixture(window, tabs, splitTab, panes[0], panes[1]);
         }
 
         public void Dispose() => Window.Close();

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs
@@ -4,6 +4,7 @@ using Avalonia.Headless.XUnit;
 using NovaTerminal.Controls;
 using NovaTerminal.Pty;
 using NovaTerminal.Shell;
+using NovaTerminal.Tests.Infra;
 
 namespace NovaTerminal.Tests.Core;
 
@@ -123,6 +124,65 @@ public sealed class MainWindowShellExitTests
         Assert.Same(fixture.SelectedTab, fixture.Tabs.Items[0]);
     }
 
+    [AvaloniaFact]
+    public void CleanExit_UnderGraceful_ClosesTheDyingPanesTab_AndLeavesTheSelectedOne()
+    {
+        using var fixture = TwoTabFixture.Create();
+        fixture.Settings.ShellExitPolicy = "Graceful";
+
+        fixture.BackgroundPane.HandleSessionExitForTesting(0);
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        Assert.Single(fixture.Tabs.Items);
+        Assert.Same(fixture.SelectedTab, fixture.Tabs.Items[0]);
+    }
+
+    [AvaloniaFact]
+    public void NonZeroExit_UnderGraceful_KeepsThePaneAndShowsTheBanner()
+    {
+        using var fixture = TwoTabFixture.Create();
+        fixture.Settings.ShellExitPolicy = "Graceful";
+
+        fixture.BackgroundPane.HandleSessionExitForTesting(1);
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(2, fixture.Tabs.Items.Count);
+        string visibleText = TerminalBufferText.Visible(fixture.BackgroundPane.Buffer!);
+        Assert.Contains("[Shell exited]", visibleText, StringComparison.Ordinal);
+        Assert.Contains("[Exit code: 1]", visibleText, StringComparison.Ordinal);
+    }
+
+    [AvaloniaFact]
+    public void CleanExit_UnderNever_KeepsThePaneAndShowsTheBanner()
+    {
+        using var fixture = TwoTabFixture.Create();
+        fixture.Settings.ShellExitPolicy = "Never";
+
+        fixture.BackgroundPane.HandleSessionExitForTesting(0);
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(2, fixture.Tabs.Items.Count);
+        string visibleText = TerminalBufferText.Visible(fixture.BackgroundPane.Buffer!);
+        Assert.Contains("[Shell exited]", visibleText, StringComparison.Ordinal);
+        Assert.DoesNotContain("Exit code", visibleText, StringComparison.Ordinal);
+    }
+
+    [AvaloniaFact]
+    public void CleanExit_OnAProtectedTab_KeepsThePaneAndFallsBackToTheBanner()
+    {
+        // A dying shell must not be able to defeat tab protection — and a pane that cannot close
+        // still has to say something, which is the whole point of #311.
+        using var fixture = TwoTabFixture.Create();
+        fixture.Settings.ShellExitPolicy = "Graceful";
+        fixture.ProtectBackgroundTab();
+
+        fixture.BackgroundPane.HandleSessionExitForTesting(0);
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(2, fixture.Tabs.Items.Count);
+        Assert.Contains("[Shell exited]", TerminalBufferText.Visible(fixture.BackgroundPane.Buffer!), StringComparison.Ordinal);
+    }
+
     private sealed class TwoTabFixture : IDisposable
     {
         private TwoTabFixture(NovaTerminal.MainWindow window, TabControl tabs, TabItem selectedTab, TerminalPane backgroundPane)
@@ -137,6 +197,16 @@ public sealed class MainWindowShellExitTests
         public TabControl Tabs { get; }
         public TabItem SelectedTab { get; }
         public TerminalPane BackgroundPane { get; }
+        public TerminalSettings Settings { get; private init; } = null!;
+        public TabItem BackgroundTab { get; private init; } = null!;
+
+        public void ProtectBackgroundTab()
+        {
+            object state = typeof(NovaTerminal.MainWindow)
+                .GetMethod("GetOrCreateTabState", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(Window, [BackgroundTab])!;
+            state.GetType().GetProperty("IsProtected")!.SetValue(state, true);
+        }
 
         public Task<bool> ClosePaneAsync(TerminalPane pane, bool skipConfirm)
         {
@@ -159,7 +229,11 @@ public sealed class MainWindowShellExitTests
             TabItem selected = CreateTab(window, tabs, settings, "Selected");
             tabs.SelectedItem = selected;
 
-            return new TwoTabFixture(window, tabs, selected, (TerminalPane)background.Content!);
+            return new TwoTabFixture(window, tabs, selected, (TerminalPane)background.Content!)
+            {
+                Settings = settings,
+                BackgroundTab = background
+            };
         }
 
         private static TabItem CreateTab(NovaTerminal.MainWindow window, TabControl tabs, TerminalSettings settings, string title)

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs
@@ -34,9 +34,23 @@ namespace NovaTerminal.Tests.Core;
 /// test did not help — the UI thread was stuck inside <c>ShowDialog</c> itself, so the timeout's
 /// continuation never got a turn. The actual, accurate blocker is exactly what round 1 described as
 /// unlikely — dismissing a real modal headlessly — not an inability to fake the session state. The
-/// declined branch remains uncovered here for that reason; the auto-accept half is covered instead
-/// (<see cref="ClosePaneAsync_WithConfirmationEnabled_AutoAcceptsWhenNoProcessIsRunning"/>), which at
-/// least proves the gate is consulted rather than unconditionally bypassed.
+/// declined branch remains uncovered here for that reason.
+///
+/// Fix round 3 (#311 final review finding D): round 1 added
+/// <c>ClosePaneAsync_WithConfirmationEnabled_AutoAcceptsWhenNoProcessIsRunning</c> to cover the
+/// auto-accept half of the <c>skipConfirm: false</c> path and claimed it "proves the gate is
+/// consulted rather than unconditionally bypassed." That claim does not hold: with
+/// <c>IsProcessRunning == false</c>, <c>ShouldAutoAcceptRunningPaneClose</c> auto-accepts, so the
+/// pane closes whether <c>ClosePaneAsync</c> actually calls <c>ShouldClosePaneAsync</c> or the
+/// <c>!skipConfirm &amp;&amp;</c> check were deleted outright — the test asserts the same
+/// <c>closed == true</c> / one-tab-remains outcome either way and cannot fail from that
+/// difference. Strengthening it would need a seam that observes whether the gate ran (a spy on
+/// <c>ShouldClosePaneAsync</c>, or a way to tell "gate ran and said yes" apart from "gate never
+/// ran"), which does not exist and is out of scope to add here. The test was deleted rather than
+/// kept as false coverage; the gate's own decision logic
+/// (<c>ShouldAutoAcceptRunningPaneClose</c>) already has direct coverage elsewhere (see
+/// <c>TabClosePolicyTests</c>), and the declined branch remains uncovered for the modal-deadlock
+/// reason described above.
 /// </remarks>
 public sealed class MainWindowShellExitTests
 {
@@ -100,28 +114,6 @@ public sealed class MainWindowShellExitTests
         Assert.False(fixture.IsTabZoomed(fixture.SplitTab), "ClosePaneAsync must exit zoom on the closed pane's own tab, not the selected one.");
         Assert.Contains(fixture.SplitTab, fixture.Tabs.Items.OfType<TabItem>());
         Assert.Same(fixture.Sibling, fixture.SplitTab.Content);
-    }
-
-    /// <summary>
-    /// Fix round 1 (#311 review finding): covers the confirmation gate on the
-    /// <c>skipConfirm: false</c> path, which the original test never touched at all (it always
-    /// passed <c>skipConfirm: true</c>). A restored pane in these tests never actually spawns a
-    /// shell (no real PTY is started unless the pane is attached to a live visual tree), so
-    /// <c>TerminalPane.IsProcessRunning</c> is false and <c>ShouldAutoAcceptRunningPaneClose</c>
-    /// auto-accepts without showing the confirmation dialog. That is the only half of this branch
-    /// reachable headlessly — see the class remarks for why the declined half is not covered here.
-    /// </summary>
-    [AvaloniaFact]
-    public async Task ClosePaneAsync_WithConfirmationEnabled_AutoAcceptsWhenNoProcessIsRunning()
-    {
-        using var fixture = TwoTabFixture.Create();
-        Assert.False(fixture.BackgroundPane.IsProcessRunning, "This test's premise is that no real shell is running.");
-
-        bool closed = await fixture.ClosePaneAsync(fixture.BackgroundPane, skipConfirm: false);
-
-        Assert.True(closed);
-        Assert.Single(fixture.Tabs.Items);
-        Assert.Same(fixture.SelectedTab, fixture.Tabs.Items[0]);
     }
 
     [AvaloniaFact]

--- a/tests/NovaTerminal.App.Tests/Core/ShellExitPolicyTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/ShellExitPolicyTests.cs
@@ -43,10 +43,10 @@ public sealed class ShellExitPolicyTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("Sometimes")]
-    public void UnrecognisedPolicyBehavesAsGraceful(string? policy)
+    public void UnrecognisedPolicyBehavesAsNever(string? policy)
     {
-        // A typo in a hand-edited settings file must not silently mean "never tell me anything".
-        Assert.True(NovaTerminal.MainWindow.ShouldClosePaneOnExit(policy, isSsh: false, exitCode: 0));
+        // A typo in a hand-edited settings file must not be more destructive than the default.
+        Assert.False(NovaTerminal.MainWindow.ShouldClosePaneOnExit(policy, isSsh: false, exitCode: 0));
         Assert.False(NovaTerminal.MainWindow.ShouldClosePaneOnExit(policy, isSsh: false, exitCode: 1));
     }
 

--- a/tests/NovaTerminal.App.Tests/Core/ShellExitPolicyTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/ShellExitPolicyTests.cs
@@ -51,8 +51,10 @@ public sealed class ShellExitPolicyTests
     }
 
     [Fact]
-    public void DefaultSettingIsGraceful()
+    public void DefaultSettingIsNever()
     {
-        Assert.Equal("Graceful", new TerminalSettings().ShellExitPolicy);
+        // Until #313 lands and the real exit status can be captured, defaulting to Never
+        // is conservative: every dead local pane gets the banner with its Enter-to-restart hint.
+        Assert.Equal("Never", new TerminalSettings().ShellExitPolicy);
     }
 }

--- a/tests/NovaTerminal.App.Tests/Core/ShellExitPolicyTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/ShellExitPolicyTests.cs
@@ -1,0 +1,58 @@
+using NovaTerminal.Shell;
+
+namespace NovaTerminal.Tests.Core;
+
+/// <summary>
+/// #311: which shell exits close the pane. Pure policy — no window, no pane, no Avalonia,
+/// mirroring how <see cref="TabClosePolicyTests"/> covers the sibling pane-close policy.
+/// </summary>
+public sealed class ShellExitPolicyTests
+{
+    [Theory]
+    // Graceful (the default): a clean exit closes, anything else leaves the pane with a banner.
+    [InlineData("Graceful", 0, false, true)]
+    [InlineData("Graceful", 1, false, false)]
+    [InlineData("Graceful", 255, false, false)]
+    // Never: nothing ever closes on its own.
+    [InlineData("Never", 0, false, false)]
+    [InlineData("Never", 1, false, false)]
+    // Always: the exit code stops mattering.
+    [InlineData("Always", 0, false, true)]
+    [InlineData("Always", 1, false, true)]
+    // SSH panes never auto-close, whatever the policy says.
+    [InlineData("Graceful", 0, true, false)]
+    [InlineData("Always", 0, true, false)]
+    [InlineData("Always", 1, true, false)]
+    public void PolicyDecidesWhetherTheDyingPaneCloses(string policy, int exitCode, bool isSsh, bool expected)
+    {
+        Assert.Equal(expected, NovaTerminal.MainWindow.ShouldClosePaneOnExit(policy, isSsh, exitCode));
+    }
+
+    [Theory]
+    [InlineData("graceful")]
+    [InlineData("  Graceful  ")]
+    [InlineData("ALWAYS")]
+    public void PolicyMatchingIsCaseAndWhitespaceInsensitive(string policy)
+    {
+        // "ALWAYS" closes on a non-zero code; the two Graceful spellings do not.
+        bool expected = policy.Trim().Equals("ALWAYS", StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(expected, NovaTerminal.MainWindow.ShouldClosePaneOnExit(policy, isSsh: false, exitCode: 1));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("Sometimes")]
+    public void UnrecognisedPolicyBehavesAsGraceful(string? policy)
+    {
+        // A typo in a hand-edited settings file must not silently mean "never tell me anything".
+        Assert.True(NovaTerminal.MainWindow.ShouldClosePaneOnExit(policy, isSsh: false, exitCode: 0));
+        Assert.False(NovaTerminal.MainWindow.ShouldClosePaneOnExit(policy, isSsh: false, exitCode: 1));
+    }
+
+    [Fact]
+    public void DefaultSettingIsGraceful()
+    {
+        Assert.Equal("Graceful", new TerminalSettings().ShellExitPolicy);
+    }
+}

--- a/tests/NovaTerminal.App.Tests/Core/TerminalPaneExitBannerTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/TerminalPaneExitBannerTests.cs
@@ -1,0 +1,70 @@
+using Avalonia.Headless.XUnit;
+using NovaTerminal.Controls;
+using NovaTerminal.Platform;
+using NovaTerminal.Shell;
+using NovaTerminal.Tests.Infra;
+
+namespace NovaTerminal.Tests.Core;
+
+/// <summary>
+/// #311: a local pane whose shell died must say so, and must say how to get it back — Enter
+/// already restarts it (<c>TerminalPane.ShouldReconnectOnEnter</c> is not SSH-gated), which is
+/// exactly the part users could not discover.
+/// </summary>
+public sealed class TerminalPaneExitBannerTests
+{
+    [AvaloniaFact]
+    public void LocalExitBanner_NonZeroCode_NamesTheCodeAndTheRestartKey()
+    {
+        using var pane = new TerminalPane(LocalProfile());
+
+        pane.WriteLocalExitBanner(1);
+
+        string visibleText = TerminalBufferText.Visible(pane.Buffer!);
+        Assert.Contains("[Shell exited]", visibleText, StringComparison.Ordinal);
+        Assert.Contains("[Exit code: 1]", visibleText, StringComparison.Ordinal);
+        Assert.Contains("[Press Enter to restart]", visibleText, StringComparison.Ordinal);
+    }
+
+    [AvaloniaFact]
+    public void LocalExitBanner_CleanExit_OmitsTheExitCodeLine()
+    {
+        using var pane = new TerminalPane(LocalProfile());
+
+        pane.WriteLocalExitBanner(0);
+
+        string visibleText = TerminalBufferText.Visible(pane.Buffer!);
+        Assert.Contains("[Shell exited]", visibleText, StringComparison.Ordinal);
+        Assert.DoesNotContain("Exit code", visibleText, StringComparison.Ordinal);
+        Assert.Contains("[Press Enter to restart]", visibleText, StringComparison.Ordinal);
+    }
+
+    [AvaloniaFact]
+    public void SshDisconnectBanner_IsUnchanged()
+    {
+        // #311 must not disturb the banner SSH users already know.
+        var profile = new TerminalProfile
+        {
+            Name = "Native SSH",
+            Type = ConnectionType.SSH,
+            SshHost = "server.example",
+            SshUser = "nova"
+        };
+        using var pane = new TerminalPane(profile);
+
+        pane.HandleSessionExitForTesting(17);
+
+        string visibleText = TerminalBufferText.Visible(pane.Buffer!);
+        Assert.Contains("[SSH session disconnected]", visibleText, StringComparison.Ordinal);
+        Assert.Contains("[Exit code: 17]", visibleText, StringComparison.Ordinal);
+        Assert.Contains("[Press Enter to reconnect]", visibleText, StringComparison.Ordinal);
+        Assert.DoesNotContain("Shell exited", visibleText, StringComparison.Ordinal);
+    }
+
+    private static TerminalProfile LocalProfile() => new()
+    {
+        Name = "PowerShell",
+        Type = ConnectionType.Local,
+        Command = "pwsh.exe"
+    };
+}

--- a/tests/NovaTerminal.App.Tests/Core/TerminalPaneExitBannerTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/TerminalPaneExitBannerTests.cs
@@ -1,6 +1,5 @@
 using Avalonia.Headless.XUnit;
 using NovaTerminal.Controls;
-using NovaTerminal.Platform;
 using NovaTerminal.Shell;
 using NovaTerminal.Tests.Infra;
 

--- a/tests/NovaTerminal.App.Tests/Infra/TerminalBufferText.cs
+++ b/tests/NovaTerminal.App.Tests/Infra/TerminalBufferText.cs
@@ -1,0 +1,25 @@
+using NovaTerminal.VT;
+
+namespace NovaTerminal.Tests.Infra;
+
+/// <summary>
+/// What a pane actually shows: the viewport rendered as plain text, for asserting on banners and
+/// other terminal output. The buffer's viewport is private, hence the reflection.
+/// </summary>
+internal static class TerminalBufferText
+{
+    public static string Visible(TerminalBuffer buffer)
+    {
+        var field = typeof(TerminalBuffer).GetField(
+            "_viewport",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var viewport = (TerminalRow[])field!.GetValue(buffer)!;
+        return string.Join("\n", viewport.Select(RowText)).TrimEnd();
+    }
+
+    private static string RowText(TerminalRow row)
+    {
+        char[] chars = row.Cells.Select(c => c.Character == '\0' ? ' ' : c.Character).ToArray();
+        return new string(chars).TrimEnd();
+    }
+}

--- a/tests/NovaTerminal.App.Tests/PtyChildExitDetectionTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtyChildExitDetectionTests.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using NovaTerminal.Pty;
+using NovaTerminal.Shell;
+using Xunit;
+
+namespace NovaTerminal.Tests
+{
+    /// <summary>
+    /// #313: a session must notice that its shell has ended.
+    ///
+    /// Pipe EOF cannot carry that on Windows. With ConPTY the output pipe stays open for as
+    /// long as the console host lives, and the host outlives its client shell — measured at
+    /// 159s and counting after a shell had exited. A session that waited only for EOF
+    /// therefore never learned that a shell was gone: it only learned that a host had
+    /// *crashed*. That is why the pane in #311's bug report sat there looking alive, and why
+    /// #311's banner never appeared in a real build even with every headless test passing —
+    /// those tests raise the exit event directly, so they cover everything downstream of it
+    /// and nothing upstream.
+    ///
+    /// These tests drive real shells and assert on the event itself, which is the piece that
+    /// was missing.
+    /// </summary>
+    [Collection(PtyRealShellCollection.Name)]
+    public class PtyChildExitDetectionTests
+    {
+        [Fact]
+        [Trait("Category", "PtySmoke")]
+        public async Task ACleanExitIsReportedWithCodeZero()
+        {
+            using var session = NewSession();
+            await WaitForPromptAsync(session);
+
+            using var log = PtyLogCapture.Attach();
+            session.SendInput("exit\r");
+
+            int? code = await WaitForExitAsync(session, TimeSpan.FromSeconds(30));
+
+            // The log is attached because the interesting failure is a wrong *code*, not a
+            // missing exit: under parallel load this reported a non-zero code once, and
+            // "Assert.Equal(0, code)" alone cannot tell you whether the shell died early,
+            // the read loop claimed the exit first, or `exit` landed mid-startup.
+            Assert.True(code == 0, $"expected a clean 0, got {code?.ToString() ?? "no exit"}.\nPTY log:\n{log}");
+            Assert.False(session.IsProcessRunning, "the session must not report itself as running once its shell has gone");
+        }
+
+        [Fact]
+        [Trait("Category", "PtySmoke")]
+        public async Task TheShellsRealExitCodeIsReported()
+        {
+            // The assertion that #313 is really about: not "an exit happened" but "the exit
+            // carried the shell's own status". Before the fix every local session reported 0,
+            // so a crashed console host and a deliberate `exit` were indistinguishable.
+            // 42 is arbitrary and understood by cmd, pwsh and sh alike.
+            using var session = NewSession();
+            await WaitForPromptAsync(session);
+
+            session.SendInput("exit 42\r");
+
+            int? code = await WaitForExitAsync(session, TimeSpan.FromSeconds(30));
+
+            Assert.Equal(42, code);
+        }
+
+        [Fact]
+        [Trait("Category", "PtySmoke")]
+        public async Task AKilledShellIsReportedAsExited()
+        {
+            using var session = NewSession();
+            await WaitForPromptAsync(session);
+
+            int pid = session.Pid ?? throw new InvalidOperationException("the session reported no pid");
+            using (Process shell = Process.GetProcessById(pid))
+            {
+                shell.Kill(entireProcessTree: true);
+            }
+
+            int? code = await WaitForExitAsync(session, TimeSpan.FromSeconds(30));
+
+            // Only "exited, and not the clean 0 it used to claim" is asserted here.
+            //
+            // The exact value cannot be: .NET's Process.Kill terminates with -1, which is
+            // also the value of RustPtySession.ReadFailureExitCode - so on Windows a
+            // managed-tool kill is genuinely indistinguishable from "this session's reads
+            // failed". That collision predates this change and is not worth a behaviour
+            // change here (both readings mean the same thing to a user: the shell is gone),
+            // but it is why this test asserts the fact of the exit while
+            // TheShellsRealExitCodeIsReported asserts the value.
+            Assert.NotNull(code);
+            Assert.NotEqual(0, code!.Value);
+            Assert.False(session.IsProcessRunning, "a session whose shell was killed must not report itself as running");
+        }
+
+        [Fact]
+        [Trait("Category", "PtySmoke")]
+        public async Task ALiveShellIsNotReportedAsExited()
+        {
+            // The other half: the watcher must not manufacture an exit for a healthy session,
+            // or every pane would announce itself dead a fraction of a second after opening.
+            using var session = NewSession();
+            await WaitForPromptAsync(session);
+
+            int? code = await WaitForExitAsync(session, TimeSpan.FromSeconds(3));
+
+            Assert.Null(code);
+            Assert.True(session.IsProcessRunning, "a shell sitting at its prompt is still running");
+        }
+
+        /// Tees <see cref="NovaTerminal.Pty.PtyLogger"/> into a string for the duration of a
+        /// test, so an assertion can attach what the session actually did. These sessions
+        /// drive real shells, and their failures are timing-shaped: without the log a failure
+        /// tells you the code was wrong and nothing about why.
+        private sealed class PtyLogCapture : IDisposable
+        {
+            private readonly System.Text.StringBuilder _log = new();
+            private readonly Action<NovaTerminal.Pty.PtyLogLevel, string>? _previous;
+
+            private PtyLogCapture()
+            {
+                _previous = NovaTerminal.Pty.PtyLogger.Sink;
+                NovaTerminal.Pty.PtyLogger.Sink = (level, message) =>
+                {
+                    lock (_log) { _log.AppendLine($"[{level}] {message}"); }
+                    _previous?.Invoke(level, message);
+                };
+            }
+
+            public static PtyLogCapture Attach() => new();
+
+            public void Dispose() => NovaTerminal.Pty.PtyLogger.Sink = _previous;
+
+            public override string ToString()
+            {
+                lock (_log) { return _log.ToString(); }
+            }
+        }
+
+        private static RustPtySession NewSession()
+        {
+            return new RustPtySession(
+                ShellHelper.GetDefaultShell(),
+                80,
+                24,
+                args: null,
+                cwd: null,
+                // The injection would race our own SendInput and is irrelevant here.
+                skipPowerShellPostLaunchInit: true);
+        }
+
+        /// Waits until the shell has produced output, so `exit` is typed at a shell that is
+        /// actually reading. Without this the test races shell startup.
+        private static async Task WaitForPromptAsync(RustPtySession session)
+        {
+            var sawOutput = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            void OnOutput(string _) => sawOutput.TrySetResult(true);
+
+            session.OnOutputReceived += OnOutput;
+            try
+            {
+                await Task.WhenAny(sawOutput.Task, Task.Delay(TimeSpan.FromSeconds(20)));
+            }
+            finally
+            {
+                session.OnOutputReceived -= OnOutput;
+            }
+
+            // The prompt is drawn a beat after the first bytes; a short settle keeps the
+            // typed command from landing mid-startup.
+            await Task.Delay(500);
+        }
+
+        /// Returns the reported exit code, or null if none arrived within the timeout.
+        /// Falls back to <see cref="RustPtySession.ExitCode"/> so a fast exit reported
+        /// before the handler is attached still counts.
+        private static async Task<int?> WaitForExitAsync(RustPtySession session, TimeSpan timeout)
+        {
+            var exited = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            void OnExit(int code) => exited.TrySetResult(code);
+
+            session.OnExit += OnExit;
+            try
+            {
+                if (session.ExitCode.HasValue)
+                {
+                    return session.ExitCode;
+                }
+
+                await Task.WhenAny(exited.Task, Task.Delay(timeout));
+                return exited.Task.IsCompletedSuccessfully ? exited.Task.Result : session.ExitCode;
+            }
+            finally
+            {
+                session.OnExit -= OnExit;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #311.

## Why

A local pane whose shell died just froze — last screen up, cursor drawn, keystrokes swallowed, nothing said. That is how #310 reached us: "I can't exit opencode". opencode had exited fine; the console host crashed and took the shell with it, and the pane looked exactly like a hung program.

The recovery already existed and was invisible: `ShouldReconnectOnEnter` is not SSH-gated, so **Enter in a dead local pane already restarted the shell** — nothing ever said so. SSH panes had had a banner for ages; local panes got silence because that branch was gated on `ConnectionType.SSH`.

## What this does

- A dead local pane now says so, in the same shape as the SSH banner: `[Shell exited]`, `[Exit code: N]` (omitted when 0), `[Press Enter to restart]`.
- New `ShellExitPolicy` setting (settings.json only, like its sibling `PaneClosePolicy`): `"Never"` | `"Graceful"` | `"Always"`.
- `ClosePaneAsync(pane, skipConfirm)` closes **the pane you name**, not the selected one. Extracted from `CloseActivePaneAsync`, which fell back to `tabs.SelectedItem` — so a shell dying in a background tab would have closed whatever tab you were looking at.
- Protected tabs, the reentrancy guards and a tabless pane all fall back to the banner: every path ends with a pane that says something.
- SSH panes are untouched: their own banner, Enter reconnects, never auto-closed.

**The default is `"Never"`, not the `"Graceful"` the design was agreed with**, and that is the most important thing in this PR to know about. See #313: a local PTY reports exit code 0 for *every* session end — `RustPtySession` fires its exit notification with a hardcoded `0` on EOF and nothing plumbs the child's real status. So `"Graceful"` (close on a clean exit) cannot tell `exit` from a crashed console host, and shipping it as the default would have closed the pane — and the window, if it were the last tab — in exactly the scenario #311 exists to announce. Once #313 lands, flipping the default is a one-line change. An unrecognised policy value also falls back to `"Never"`: a typo must not be more destructive than the default.

## Review trail

Built task-by-task with a review after each, then a whole-branch review. What those caught, in case it saves you re-deriving it:

- **The tab lookup never worked.** `pane.FindAncestorOfType<TabItem>()` (visual tree) returns null for *every* pane: the `TabControl` template hosts content in `PART_SelectedContentHost`, a sibling of the header presenter, so a `TabItem` is never a visual ancestor of its content. Two sites needed it and now use `FindLogicalAncestorOfType`. Four other sites are dead code today — the bell indicator and the per-command tab glyphs — and `ResolvePaneForTab`'s staleness check always reads stale, so a split tab can resolve the wrong pane. Left alone deliberately, filed as #314.
- **The revived lookup switched on a glyph with no live reset.** Fixing `OnPaneProcessExited`'s lookup made the `✓`/`✖N` glyph render, but its only reset (`OnPaneCommandStarted`) is one of the dead sites — so a pane would wear a stale "dead" marker forever, including after a successful restart. The bookkeeping is deliberately not recorded here; the glyph story goes to #314.
- **An SSH double-banner** on the tabless path, fixed by hoisting the SSH check to the top of the handler.
- **A zoomed tab can orphan a sibling.** `EnterPaneZoom` detaches the tab's split `Grid`, so a non-zoomed pane has no logical `TabItem`; the split branch would then clear a parentless Grid's children, match no promotion branch, and orphan the sibling with its shell running — while returning `true`. Now returns false and falls back to the banner.
- **A throwing close would have swallowed the fallback.** The fire-and-forget close now catches, logs via `TerminalLogger.Error`, and still writes the banner.
- One test that could not fail was deleted rather than kept as decoration; the confirmation-declined branch is documented as un-coverable headlessly (a real `ShowDialog` modal — attempting it hung the test host, confirmed) rather than faked.

## Tests

`ShellExitPolicyTests` 17/17 · `TerminalPaneExitBannerTests` 3/3 · `MainWindowShellExitTests` 8/8 (background-tab targeting, split promotion, zoom-exit, Graceful/Never/protected-tab behaviour, tabless banner) · `SettingsToolsDriftGuardTests` 4/4 · SSH suite 158/158.

The SSH suite had to be run in three sub-filter partitions: the single `~Ssh` filter reproducibly hangs on this machine, and `AgentHostCaptureProtocolTests` fails only under broad parallel filters (13/13 alone) because it initialises the Avalonia headless platform in its constructor rather than via `[AvaloniaFact]`. Both are pre-existing and unrelated — same family as the flake notes already in this repo — but they made every broad sweep in this branch unreliable, so CI's full run is the real check here.

## Manual verification — not yet done

The one thing tests cannot see is a pane that looks alive but isn't, so this needs a human pass before merge (build is at `src/NovaTerminal.App/bin/Debug/net10.0/NovaTerminal.exe`):

1. Local tab, type `exit` → banner `[Shell exited]` + `[Press Enter to restart]`, pane stays (default `Never`). Press Enter → shell returns.
2. Local tab, kill the shell from outside (`taskkill /PID <pid> /F`) → same banner. Note: **no `[Exit code: N]` line** until #313, because the PTY reports 0 for every exit.
3. Two tabs, kill the *background* tab's shell while looking at the other → the visible tab is untouched; the background tab shows the banner.
4. Set `"ShellExitPolicy": "Graceful"` in settings.json, then `exit` in a tab with a second tab open → the tab closes.
5. SSH tab, `exit` from the remote shell → the old `[SSH session disconnected]` / `[Press Enter to reconnect]` banner, tab stays.

## Follow-ups filed

- #313 — PTY reports exit code 0 for every local session end (blocks defaulting to `Graceful`)
- #314 — the dead tab-decoration lookups, plus `ResolvePaneForTab` resolving the wrong pane in a split

🤖 Generated with [Claude Code](https://claude.com/claude-code)
