### PR TITLE
fix(rendering): rounded box corners are arcs, not diagonal chamfers

### DIFF
--- a/src/NovaTerminal.App/Shell/TerminalDrawOperation.cs
+++ b/src/NovaTerminal.App/Shell/TerminalDrawOperation.cs
@@ -1789,6 +1789,11 @@ namespace NovaTerminal.Shell
         private float FromDevicePx(int px)
             => (float)(px / _renderScaling);
 
+        /// <inheritdoc cref="FromDevicePx(int)"/>
+        /// <remarks>For geometry that lands between pixels, such as the centreline of an odd-width stroke.</remarks>
+        private float FromDevicePxF(double px)
+            => (float)(px / _renderScaling);
+
         private float Snap(double logical)
             => (float)(Math.Round(logical * _renderScaling, MidpointRounding.AwayFromZero) / _renderScaling);
 
@@ -2577,64 +2582,55 @@ namespace NovaTerminal.Shell
             {
                 int halfW = Math.Max(1, (x2px - x1px) / 2);
                 int halfH = Math.Max(1, (y2px - y1px) / 2);
-                int insetPx = Math.Max(0, strokePx / 2);
-                int leftPx = x1px + insetPx;
-                int rightPx = x2px - insetPx;
-                int topPx = y1px + insetPx;
-                int bottomPx = y2px - insetPx;
-                if (rightPx <= leftPx || bottomPx <= topPx) return;
+                int strokeSlack = Math.Max(1, strokePx / 2);
 
-                int radiusPx = Math.Max(1, Math.Min(halfW, halfH) - Math.Max(1, strokePx / 2));
-                float strokeDip = FromDevicePx(Math.Max(1, strokePx));
+                // Half the smaller half-cell, so the straight runs still reach from the cell edge
+                // most of the way to the midpoint the way the ─ and │ primitives do. A radius of a
+                // whole half-cell turns the corner into a full-quadrant sweep that reads as a
+                // diagonal chamfer with a stepped notch where the two borders should meet.
+                int radiusCeiling = Math.Max(1, Math.Min(halfW, halfH) - strokeSlack);
+                int radiusPx = Math.Clamp(Math.Min(halfW, halfH) / 2, 1, radiusCeiling);
+
+                bool goesRight = (cornerSeg & SegRight) != 0;
+                bool goesDown = (cornerSeg & SegDown) != 0;
+                if (goesRight == ((cornerSeg & SegLeft) != 0)) return; // not one of the four arcs
+                if (goesDown == ((cornerSeg & SegUp) != 0)) return;
+
+                // The straight parts are the same grid-aligned fills the other box primitives use, so
+                // an arc cell joins its neighbours seamlessly.
+                if (goesRight) DrawHorizontal(xMidPx + radiusPx, x2px, yMidPx, strokePx);
+                else DrawHorizontal(x1px, xMidPx - radiusPx, yMidPx, strokePx);
+
+                if (goesDown) DrawVertical(yMidPx + radiusPx, y2px, xMidPx, strokePx);
+                else DrawVertical(y1px, yMidPx - radiusPx, xMidPx, strokePx);
+
+                // Centre of the stroke those fills produced: DrawHorizontal/DrawVertical span
+                // [c - strokePx/2, c - strokePx/2 + strokePx), which is offset by half a pixel from
+                // the midpoint for odd stroke widths. The arc has to ride the same centreline.
+                float hCenterY = yMidPx - (strokePx / 2) + (strokePx / 2f);
+                float vCenterX = xMidPx - (strokePx / 2) + (strokePx / 2f);
+                float arcStartX = goesRight ? xMidPx + radiusPx : xMidPx - radiusPx;
+                float arcEndY = goesDown ? yMidPx + radiusPx : yMidPx - radiusPx;
 
                 using var roundedPaint = new SKPaint
                 {
                     Color = color,
                     Style = SKPaintStyle.Stroke,
-                    IsAntialias = false,
-                    StrokeWidth = strokeDip,
+                    // The straight runs stay crisp because they are pixel fills; the curve is the one
+                    // part that needs coverage blending, or a small-radius turn is a visible staircase.
+                    IsAntialias = true,
+                    StrokeWidth = FromDevicePxF(Math.Max(1, strokePx)),
                     StrokeCap = SKStrokeCap.Butt,
                     StrokeJoin = SKStrokeJoin.Round
                 };
 
                 using var path = new SKPath();
-                switch (cornerSeg)
-                {
-                    case SegRight | SegDown: // ╭
-                        path.MoveTo(FromDevicePx(rightPx), FromDevicePx(yMidPx));
-                        path.LineTo(FromDevicePx(xMidPx + radiusPx), FromDevicePx(yMidPx));
-                        path.QuadTo(
-                            FromDevicePx(xMidPx + radiusPx), FromDevicePx(yMidPx + radiusPx),
-                            FromDevicePx(xMidPx), FromDevicePx(yMidPx + radiusPx));
-                        path.LineTo(FromDevicePx(xMidPx), FromDevicePx(bottomPx));
-                        break;
-                    case SegLeft | SegDown: // ╮
-                        path.MoveTo(FromDevicePx(leftPx), FromDevicePx(yMidPx));
-                        path.LineTo(FromDevicePx(xMidPx - radiusPx), FromDevicePx(yMidPx));
-                        path.QuadTo(
-                            FromDevicePx(xMidPx - radiusPx), FromDevicePx(yMidPx + radiusPx),
-                            FromDevicePx(xMidPx), FromDevicePx(yMidPx + radiusPx));
-                        path.LineTo(FromDevicePx(xMidPx), FromDevicePx(bottomPx));
-                        break;
-                    case SegLeft | SegUp: // ╯
-                        path.MoveTo(FromDevicePx(leftPx), FromDevicePx(yMidPx));
-                        path.LineTo(FromDevicePx(xMidPx - radiusPx), FromDevicePx(yMidPx));
-                        path.QuadTo(
-                            FromDevicePx(xMidPx - radiusPx), FromDevicePx(yMidPx - radiusPx),
-                            FromDevicePx(xMidPx), FromDevicePx(yMidPx - radiusPx));
-                        path.LineTo(FromDevicePx(xMidPx), FromDevicePx(topPx));
-                        break;
-                    case SegRight | SegUp: // ╰
-                        path.MoveTo(FromDevicePx(rightPx), FromDevicePx(yMidPx));
-                        path.LineTo(FromDevicePx(xMidPx + radiusPx), FromDevicePx(yMidPx));
-                        path.QuadTo(
-                            FromDevicePx(xMidPx + radiusPx), FromDevicePx(yMidPx - radiusPx),
-                            FromDevicePx(xMidPx), FromDevicePx(yMidPx - radiusPx));
-                        path.LineTo(FromDevicePx(xMidPx), FromDevicePx(topPx));
-                        break;
-                    default:
-                        return;
-                }
+                path.MoveTo(FromDevicePxF(arcStartX), FromDevicePxF(hCenterY));
+                // Control point on the corner vertex — where the two centrelines cross. Putting it on
+                // the arc's centre instead bows the curve away from the corner and past the diagonal.
+                path.QuadTo(
+                    FromDevicePxF(vCenterX), FromDevicePxF(hCenterY),
+                    FromDevicePxF(vCenterX), FromDevicePxF(arcEndY));
 
                 canvas.Save();
                 canvas.ClipRect(SKRect.Create(FromDevicePx(x1px), FromDevicePx(y1px), FromDevicePx(x2px - x1px), FromDevicePx(y2px - y1px)));

--- a/tests/NovaTerminal.App.Tests/RenderTests/RoundedBoxCornerTests.cs
+++ b/tests/NovaTerminal.App.Tests/RenderTests/RoundedBoxCornerTests.cs
@@ -1,0 +1,192 @@
+using Avalonia.Headless.XUnit;
+using NovaTerminal.Platform;
+using NovaTerminal.Rendering;
+using NovaTerminal.Shell;
+using NovaTerminal.Tests.Infra;
+using NovaTerminal.VT;
+using SkiaSharp;
+using Xunit;
+
+namespace NovaTerminal.Tests.RenderTests
+{
+    /// <summary>
+    /// Shape guards for the rounded-corner arcs (U+256D-U+2570) the primitive renderer draws for
+    /// Rich/Typer/lazygit style panels.
+    /// </summary>
+    /// <remarks>
+    /// The regression these exist for: the arc was drawn as a quadratic whose control point sat on the
+    /// arc <em>centre</em> instead of the corner vertex, with a radius of a whole half-cell and
+    /// antialiasing off. The turn therefore started at the cell edge and swept the entire quadrant as a
+    /// hard-edged diagonal — a chamfered box with a stepped notch where the border should meet, instead
+    /// of the tight rounded corner every other terminal draws.
+    ///
+    /// Both guards read features the renderer chose (the border centreline row/column) rather than
+    /// hard-coded pixel offsets, so they do not encode the pixel grid's origin inset.
+    /// </remarks>
+    [Collection("GoldenPng")]
+    public sealed class RoundedBoxCornerTests
+    {
+        // A cell about the size of a 14pt terminal font at 150% scaling: big enough that a
+        // half-cell-radius turn and a tight one are far apart in pixels.
+        private static readonly CellMetrics Metrics = new()
+        {
+            CellWidth = 16.0f,
+            CellHeight = 36.0f,
+            Baseline = 28.0f,
+            Ascent = 28.0f,
+            Descent = 8.0f
+        };
+
+        private const int Cols = 4;
+        private const int Rows = 3;
+
+        [AvaloniaFact]
+        public void Arcs_LeaveAStraightRunFromTheCellEdge_SoTheBorderIsNotChamfered()
+        {
+            using SKBitmap bmp = RenderRoundedBox();
+            var g = Geometry.Measure(bmp);
+
+            float halfW = Metrics.CellWidth / 2f;
+            float halfH = Metrics.CellHeight / 2f;
+            float minRunX = halfW / 3f;
+            float minRunY = halfH / 3f;
+
+            // Top-left: the horizontal border must still be drawn from the corner cell's right edge
+            // inward, and the vertical border from its bottom edge upward.
+            AssertRun((g.LeftCol + halfW) - g.FirstLitXOnRow(bmp, g.TopRow), minRunX, "top-left horizontal");
+            AssertRun((g.TopRow + halfH) - g.FirstLitYOnCol(bmp, g.LeftCol), minRunY, "top-left vertical");
+
+            AssertRun(g.LastLitXOnRow(bmp, g.TopRow) - (g.RightCol - halfW), minRunX, "top-right horizontal");
+            AssertRun((g.TopRow + halfH) - g.FirstLitYOnCol(bmp, g.RightCol), minRunY, "top-right vertical");
+
+            AssertRun((g.LeftCol + halfW) - g.FirstLitXOnRow(bmp, g.BottomRow), minRunX, "bottom-left horizontal");
+            AssertRun(g.LastLitYOnCol(bmp, g.LeftCol) - (g.BottomRow - halfH), minRunY, "bottom-left vertical");
+
+            AssertRun(g.LastLitXOnRow(bmp, g.BottomRow) - (g.RightCol - halfW), minRunX, "bottom-right horizontal");
+            AssertRun(g.LastLitYOnCol(bmp, g.RightCol) - (g.BottomRow - halfH), minRunY, "bottom-right vertical");
+        }
+
+        [AvaloniaFact]
+        public void Arcs_AreAntialiased_SoTheyReadAsCurvesRatherThanStaircases()
+        {
+            using SKBitmap bmp = RenderRoundedBox();
+            var g = Geometry.Measure(bmp);
+
+            // A hard-edged (aliased) arc paints every pixel either background or full foreground. A
+            // real curve lands partially on the pixels it crosses.
+            int partial = 0;
+            int cw = (int)Metrics.CellWidth;
+            int chh = (int)Metrics.CellHeight;
+            for (int y = System.Math.Max(0, g.TopRow - chh / 2); y < System.Math.Min(bmp.Height, g.TopRow + chh / 2); y++)
+            {
+                for (int x = System.Math.Max(0, g.LeftCol - cw / 2); x < System.Math.Min(bmp.Width, g.LeftCol + cw); x++)
+                {
+                    int lum = Lum(bmp.GetPixel(x, y));
+                    if (lum > 24 && lum < 200) partial++;
+                }
+            }
+
+            Assert.True(partial > 0, "The top-left arc painted no partially covered pixels; it is an aliased staircase, not a curve.");
+        }
+
+        private static void AssertRun(float actual, float required, string what)
+            => Assert.True(
+                actual >= required,
+                $"{what} straight run was {actual:F1}px; expected at least {required:F1}px before the turn starts. " +
+                "A shorter run means the arc ate the whole half-cell and the corner reads as a diagonal chamfer.");
+
+        private static SKBitmap RenderRoundedBox()
+        {
+            var buffer = new TerminalBuffer(Cols, Rows)
+            {
+                Theme = new TerminalTheme { Foreground = TermColor.White, Background = TermColor.Black }
+            };
+            new AnsiParser(buffer).Process("╭──╮\r\n│  │\r\n╰──╯");
+
+            int width = (int)System.Math.Ceiling(Cols * Metrics.CellWidth);
+            int height = (int)System.Math.Ceiling(Rows * Metrics.CellHeight);
+
+            using var glyphCache = new GlyphCache();
+            return SnapshotService.Capture(buffer, Metrics, width, height, new SnapshotCaptureOptions
+            {
+                ForceBoxDrawingPrimitives = true,
+                GlyphCache = glyphCache,
+                HideCursor = true
+            });
+        }
+
+        private static int Lum(SKColor c) => (c.Red + c.Green + c.Blue) / 3;
+
+        private static bool Lit(SKColor c) => Lum(c) > 24;
+
+        /// <summary>The four border centrelines the renderer actually chose, found by ink density.</summary>
+        private readonly struct Geometry
+        {
+            public int TopRow { get; init; }
+            public int BottomRow { get; init; }
+            public int LeftCol { get; init; }
+            public int RightCol { get; init; }
+
+            public static Geometry Measure(SKBitmap bmp)
+            {
+                int halfH = bmp.Height / 2;
+                int halfW = bmp.Width / 2;
+                return new Geometry
+                {
+                    TopRow = DensestRow(bmp, 0, halfH),
+                    BottomRow = DensestRow(bmp, halfH, bmp.Height),
+                    LeftCol = DensestCol(bmp, 0, halfW),
+                    RightCol = DensestCol(bmp, halfW, bmp.Width)
+                };
+            }
+
+            private static int DensestRow(SKBitmap bmp, int from, int to)
+            {
+                int best = from, bestCount = -1;
+                for (int y = from; y < to; y++)
+                {
+                    int count = 0;
+                    for (int x = 0; x < bmp.Width; x++) if (Lit(bmp.GetPixel(x, y))) count++;
+                    if (count > bestCount) { bestCount = count; best = y; }
+                }
+                return best;
+            }
+
+            private static int DensestCol(SKBitmap bmp, int from, int to)
+            {
+                int best = from, bestCount = -1;
+                for (int x = from; x < to; x++)
+                {
+                    int count = 0;
+                    for (int y = 0; y < bmp.Height; y++) if (Lit(bmp.GetPixel(x, y))) count++;
+                    if (count > bestCount) { bestCount = count; best = x; }
+                }
+                return best;
+            }
+
+            public int FirstLitXOnRow(SKBitmap bmp, int y)
+            {
+                for (int x = 0; x < bmp.Width; x++) if (Lit(bmp.GetPixel(x, y))) return x;
+                return bmp.Width;
+            }
+
+            public int LastLitXOnRow(SKBitmap bmp, int y)
+            {
+                for (int x = bmp.Width - 1; x >= 0; x--) if (Lit(bmp.GetPixel(x, y))) return x;
+                return -1;
+            }
+
+            public int FirstLitYOnCol(SKBitmap bmp, int x)
+            {
+                for (int y = 0; y < bmp.Height; y++) if (Lit(bmp.GetPixel(x, y))) return y;
+                return bmp.Height;
+            }
+
+            public int LastLitYOnCol(SKBitmap bmp, int x)
+            {
+                for (int y = bmp.Height - 1; y >= 0; y--) if (Lit(bmp.GetPixel(x, y))) return y;
+                return -1;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What this changes

The primitive renderer draws the box-drawing block itself, and its rounded-corner arc (U+256D–U+2570) was wrong in two ways, so Rich/Typer/lazygit panels rendered with flared bracket corners instead of the tight rounded corner every other terminal draws. Spotted comparing `unsloth -h` side by side with Windows Terminal.

Two defects in `DrawRoundedCornerStroke`:

1. **The quadratic control point sat on the arc''s centre instead of the corner vertex.** A quad with the centre as control bows *away* from the corner — its midpoint lands 1.06·r from the corner where a real quarter arc sits at 0.41·r — so the curve swung outward past the diagonal.
2. **The radius was a whole half-cell** (`min(halfW,halfH) - stroke/2`), so the turn started at the cell boundary and left no straight run, notching each border short by half a cell.

Plus `IsAntialias = false` on the curve, which made a small-radius turn a visible staircase.

Rendered pixel map of `╭──╮` at a 16×36 cell, before — a 7px diagonal, not an arc:

```
..................####################################......
.................#....................................#....
................##....................................##...
............####........................................####
............#...............................................
```

The fix moves the control point to the corner vertex where the two centrelines cross, caps the radius at half the smaller half-cell so the straight runs still reach nearly to the midpoint, and draws those runs with the same grid-aligned `DrawHorizontal`/`DrawVertical` fills the other primitives use — so an arc cell joins its neighbours seamlessly and stays crisp. Only the curve is antialiased, riding the same stroke centreline, which needs a float device-pixel conversion for odd stroke widths.


## Invariant and ownership

- **What invariant does this change affect?** Box-drawing primitives fill cell-edge to cell-edge so TUI borders have no gaps at cell boundaries — the invariant `BoxDrawingContinuityTests` guards. The arc cells now use the same grid-aligned fills as `─`/`│` for their straight runs, so they join neighbours on the same centreline rather than on their own path geometry.
- **Which module owns that invariant?** `NovaTerminal.App` (`Shell/TerminalDrawOperation.cs`). No VT semantics involved — the renderer''s reading of the code point is unchanged.

## Tests

- **What tests cover this change?** New `tests/NovaTerminal.App.Tests/RenderTests/RoundedBoxCornerTests.cs`:
  - `Arcs_LeaveAStraightRunFromTheCellEdge_SoTheBorderIsNotChamfered` — all four corners of a rendered box must keep a straight run of at least a third of the half-cell before the turn starts.
  - `Arcs_AreAntialiased_SoTheyReadAsCurvesRatherThanStaircases` — the arc must paint partially covered pixels; an aliased staircase paints only background or full foreground.

  Both were written first and confirmed failing on the old code (`top-left horizontal straight run was 2.0px; expected at least 2.7px` and `painted no partially covered pixels`). They measure the border centrelines the renderer picks by ink density rather than hard-coding pixel offsets, so they do not encode the pixel grid''s origin inset.

- **Which categories did you run locally?** Windows, `scripts/build.ps1`.

  - [ ] full unfiltered run (`scripts/build.sh test`)
  - [ ] `Category=Replay`
  - [x] `Category=RenderMetrics` — 39 passed (run together with `GoldenSharedPng`)
  - [ ] `Category=PtySmoke`
  - [x] `tests/NovaTerminal.App.Tests` — `Category!=ShellIntegration`: 2525 passed, 1 failed, 4 skipped. The failure is `CommandPaletteUsageStoreTests.RecordUse_PersistsCountAcrossReloads`, which passes in isolation and is unrelated to rendering (shared on-disk store across parallel tests).
  - [x] `Category=GoldenSharedPng` — passed; no golden baseline covers U+256D–U+2570, so none needed regenerating.
  - [ ] full local CI rehearsal (`ci/run.ps1`)

  Also ran `tests/NovaTerminal.Rendering.Tests` (68 passed) and the whole `NovaTerminal.Tests.RenderTests` namespace (81 passed, 4 skipped).

## Impact

- **Does this affect cross-platform behavior?** No — the primitive path is platform-independent Skia drawing. Verified on Windows only; the tests are headless and font-independent, so they gate the same shape everywhere.
- **Does this change renderer metrics?** No measurable change. Same number of draw calls per arc cell (two rect fills plus one path stroke, where it was one path stroke before), and arcs are a handful of cells per TUI frame. `Category=RenderMetrics` passes unchanged, including the cache-effectiveness and batch-flush assertions.
- **Does this change VT coverage?** No. No sequence added or changed; this is pixel geometry for code points the parser already handled.

## Verification

Rendered through the same `SnapshotService` path the app uses. Before: each corner flares outward past the border lines like a bracket, and the top and bottom borders stop half a cell short of the side borders. After: a tight rounded corner, borders meeting cleanly. Reproduce either image with a 4-cell-wide `╭──╮`/`│  │`/`╰──╯` capture at any cell size — the pixel map above is the 16×36 case.

Not verified in the live app: Settings → Agent access is off here, so `novaterminal_capture_screen` could not grab a real pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

