### PR TITLE
fix(tests): serialize the one class that boots Avalonia by hand, sweep stale hosts (#317)

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -42,17 +42,30 @@ if ($verbs -contains $dotnetArgs[0]) {
     if ([Environment]::OSVersion.Platform -eq [PlatformID]::Win32NT) {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
         try {
-            $stale = @(Get-CimInstance Win32_Process -Filter "Name = 'dotnet.exe'" -ErrorAction Stop |
+            # Two families of leftover process lock this tree's build output:
+            #   * MCP servers, which clients respawn on the next tool call, and
+            #   * test hosts from an interrupted `test` run (testhost.exe, and xunit v3's
+            #     own <Project>.Tests.exe), which nothing respawns and which make the next
+            #     run fail with "file is in use" or sit there looking hung (#317).
+            # Scoped to this tree, so a run in one worktree never touches another's.
+            # Caveat worth knowing: a genuinely concurrent `test` run from THIS tree would
+            # be killed too. That is the accepted trade - the silent-lock failure mode cost
+            # hours of debugging, and NOVA_KEEP_STALE_HOSTS=1 opts out.
+            $keepStale = $env:NOVA_KEEP_STALE_HOSTS -eq '1'
+            $stale = @(Get-CimInstance Win32_Process -ErrorAction Stop |
                 Where-Object {
                     $_.CommandLine -and
-                    $_.CommandLine -like '*NovaTerminal.McpServer.dll*' -and
-                    $_.CommandLine -like "*$repoRoot*"
+                    $_.CommandLine -like "*$repoRoot*" -and
+                    (
+                        ($_.Name -eq 'dotnet.exe' -and $_.CommandLine -like '*NovaTerminal.McpServer.dll*') -or
+                        (-not $keepStale -and ($_.Name -eq 'testhost.exe' -or $_.Name -like '*.Tests.exe'))
+                    )
                 })
             foreach ($p in $stale) {
                 Stop-Process -Id $p.ProcessId -Force -ErrorAction SilentlyContinue
             }
             if ($stale.Count -gt 0) {
-                Write-Output "build.ps1: killed $($stale.Count) stale NovaTerminal.McpServer process(es) locking bin outputs."
+                Write-Output "build.ps1: killed $($stale.Count) stale process(es) locking this tree's bin outputs: $(($stale | ForEach-Object { $_.Name }) -join ', ')."
             }
         } catch {
             Write-Output "build.ps1: stale-server sweep skipped ($($_.Exception.Message))"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -28,8 +28,51 @@ fi
 # in ways that make a generic insert here unsafe.
 verb="$1"
 shift
+
+# Sweep processes that lock this tree's build output before compiling: MCP servers that
+# clients left running, and test hosts from an interrupted `test` run. On Windows those hold
+# the DLLs open, so the next run fails with "file is in use" or sits there looking hung
+# (#317) - the same sweep build.ps1 does, which this wrapper was missing entirely, so which
+# wrapper you happened to use decided whether you got the protection.
+#
+# Windows-only by nature: this is a file-locking problem. Delegated to PowerShell because the
+# match needs each process's command line to scope it to THIS tree. NOVA_KEEP_STALE_HOSTS=1
+# opts out (a genuinely concurrent `test` run from this tree would otherwise be killed too).
+sweep_stale_hosts() {
+    case "$(uname -s)" in
+        MINGW*|MSYS*|CYGWIN*) ;;
+        *) return 0 ;;
+    esac
+    command -v powershell.exe >/dev/null 2>&1 || return 0
+
+    local repo_root
+    repo_root="$(cd "$(dirname "$0")/.." && pwd -W 2>/dev/null || cd "$(dirname "$0")/.." && pwd)"
+
+    KEEP_STALE="${NOVA_KEEP_STALE_HOSTS:-0}" REPO_ROOT="$repo_root" powershell.exe -NoProfile -NonInteractive -Command '
+        # pwd -W hands us forward slashes; process command lines carry backslashes, so a
+        # -like match on the raw value would never fire and the sweep would be a silent no-op.
+        $repoRoot = ($env:REPO_ROOT -replace "/", "\\")
+        $keepStale = $env:KEEP_STALE -eq "1"
+        try {
+            $stale = @(Get-CimInstance Win32_Process -ErrorAction Stop | Where-Object {
+                $_.CommandLine -and $_.CommandLine -like "*$repoRoot*" -and (
+                    ($_.Name -eq "dotnet.exe" -and $_.CommandLine -like "*NovaTerminal.McpServer.dll*") -or
+                    (-not $keepStale -and ($_.Name -eq "testhost.exe" -or $_.Name -like "*.Tests.exe"))
+                )
+            })
+            foreach ($p in $stale) { Stop-Process -Id $p.ProcessId -Force -ErrorAction SilentlyContinue }
+            if ($stale.Count -gt 0) {
+                Write-Output ("build.sh: killed {0} stale process(es) locking this tree''s bin outputs: {1}." -f $stale.Count, (($stale | ForEach-Object { $_.Name }) -join ", "))
+            }
+        } catch {
+            Write-Output "build.sh: stale-host sweep skipped ($($_.Exception.Message))"
+        }
+    ' 2>/dev/null || true
+}
+
 case "$verb" in
     build|test|publish|pack|msbuild|clean)
+        sweep_stale_hosts
         exec dotnet "$verb" -nodeReuse:false "$@"
         ;;
     *)

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentHostCaptureProtocolTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentHostCaptureProtocolTests.cs
@@ -17,7 +17,16 @@ namespace NovaTerminal.AppTests.AgentHost;
 /// production <see cref="TerminalSnapshotRenderer"/> — the same path the golden
 /// PNG baselines pin down — with no window or visual tree involved, which is why
 /// these run headless.
+///
+/// In the GoldenPng collection (#317) because that is where every other test that boots the
+/// Avalonia headless platform lives, and the platform can only be booted once, by one thread.
+/// Left as [Fact] deliberately: these tests do named-pipe I/O, and moving them onto the
+/// framework's dispatcher thread with [AvaloniaFact] stalls any sweep that also runs the pane
+/// tests - an intermittent failure traded for a worse hang. Serialising them against the other
+/// Avalonia users is what removes the race; running them on that thread is not needed, since
+/// they want the font manager rather than a visual tree.
 /// </summary>
+[Collection("GoldenPng")]
 public class AgentHostCaptureProtocolTests : IDisposable
 {
     private readonly string _tempDir;

--- a/tests/NovaTerminal.Architecture.Tests/AvaloniaTestSchedulingTests.cs
+++ b/tests/NovaTerminal.Architecture.Tests/AvaloniaTestSchedulingTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace NovaTerminal.Architecture.Tests;
+
+/// <summary>
+/// #317: the Avalonia headless platform can only be booted once, by one thread, and whichever
+/// thread boots it owns the dispatcher from then on. A test class that boots it from a plain
+/// <c>[Fact]</c> constructor — on whatever thread xUnit happened to pick — therefore races the
+/// test framework's own initialisation, and the loser throws "The calling thread cannot access
+/// this object because a different thread owns it". That is not hypothetical: it made
+/// <c>AgentHostCaptureProtocolTests</c> fail in any sweep that also ran other Avalonia tests,
+/// which in turn made every broad <c>--filter</c> run unreliable.
+///
+/// The rule that fixes it is a scheduling one: everything that boots the platform lives in the
+/// single non-parallel "GoldenPng" collection, so those classes can never run alongside each
+/// other. A source scan rather than a runtime check, because by the time the race has happened
+/// the damage is a confusing failure in an unrelated test.
+///
+/// Note the rule is about the *collection*, not about using <c>[AvaloniaFact]</c>: moving
+/// pipe-I/O tests onto the framework's dispatcher thread stalled whole sweeps, so
+/// <c>AgentHostCaptureProtocolTests</c> deliberately stays on <c>[Fact]</c>.
+/// </summary>
+public class AvaloniaTestSchedulingTests
+{
+    // A call site, not the bare identifier: this file names the method in its own prose,
+    // and a guard that flags itself is worse than no guard.
+    private const string Booter = "SnapshotService.EnsureAvaloniaInitialized(";
+    private const string RequiredCollection = "[Collection(\"GoldenPng\")]";
+
+    private static string RepoRoot()
+    {
+        DirectoryInfo? dir = new(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "NovaTerminal.sln")))
+            {
+                return dir.FullName;
+            }
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException("Could not locate repository root from test output path.");
+    }
+
+    [Fact]
+    public void EveryTestThatBootsAvaloniaIsInTheSerializedCollection()
+    {
+        string tests = Path.Combine(RepoRoot(), "tests");
+        var offenders = new List<string>();
+
+        foreach (string file in Directory.EnumerateFiles(tests, "*.cs", SearchOption.AllDirectories))
+        {
+            // Skip build output: bin/obj carry copies of sources under some SDK versions.
+            string relative = Path.GetRelativePath(RepoRoot(), file).Replace('\\', '/');
+            if (relative.Contains("/bin/", StringComparison.Ordinal)
+                || relative.Contains("/obj/", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            string text = File.ReadAllText(file);
+            if (!text.Contains(Booter, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            // Two files mention the call without making it: the helper that declares it, and
+            // this guard, whose needle and prose both contain it. A scan that flags its own
+            // source is a guard nobody can keep green.
+            string name = Path.GetFileName(file);
+            if (name == "SnapshotService.cs" || name == "AvaloniaTestSchedulingTests.cs")
+            {
+                continue;
+            }
+
+            if (!text.Contains(RequiredCollection, StringComparison.Ordinal))
+            {
+                offenders.Add(relative);
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "These test files boot the Avalonia headless platform but are not in the serialized "
+            + "\"GoldenPng\" collection, so they can race another Avalonia test's initialisation (#317): "
+            + string.Join(", ", offenders));
+    }
+}


### PR DESCRIPTION
Addresses #317 — symptoms 1 and 3. Deliberately **not** a closing reference: symptom 2 (the `~Ssh` hang)
does not reproduce and is not fixed here, so #317 should stay open scoped to that. See the bottom section.

## Symptom 1: the headless-init race — fixed

`AgentHostCaptureProtocolTests` booted the Avalonia headless platform from its constructor, on whatever thread xUnit happened to pick. The platform can only be booted once, and whichever thread boots it owns the dispatcher from then on — so that call raced the test framework's own initialisation, and the loser threw `The calling thread cannot access this object because a different thread owns it`.

One class, but it poisoned every broad `--filter` sweep, which is what made local test runs untrustworthy. A/B on the sweep that exposed it:

| | `~Pane\|~TabClose\|~AgentHostCapture` |
|---|---|
| before | 5+ failures in `AgentHostCaptureProtocolTests` |
| after | **284/284 in 22s**, twice |

The fix is scheduling only: `[Collection("GoldenPng")]`, the non-parallel collection where every other test that boots the platform already lives.

**Not** converted to `[AvaloniaFact]`, and that is the interesting part. I tried that first — it looks like the tidy fix, and it made things worse: these tests do named-pipe I/O, and running them on the framework's dispatcher thread stalled any sweep that also ran the pane tests (>420s, killed by my own timeout). `AgentHostCapture|Pane` reproduced it; `AgentHostCapture|TabClose` did not. They want the font manager, not a visual tree. The class comment records this so the next person doesn't "tidy" it back.

`AvaloniaTestSchedulingTests` guards the rule with a source scan. It was verified by removing the attribute and watching it fail, not merely by watching it pass — and it skips its own file, because a scan whose needle appears in its own source flags itself (it did, twice, before I noticed).

## Symptom 3: stale hosts holding locks — mitigated

`build.ps1` already killed stale MCP servers under the invoking tree. It now also kills stale test hosts (`testhost.exe` and xunit v3's `<Project>.Tests.exe`), which nothing respawns and which make the next run fail with "file is in use" or sit there looking hung.

`build.sh` had **no sweep at all**, so which wrapper you happened to use decided whether you got the protection. It has one now, delegating to PowerShell because the match needs each process's command line to scope it to the invoking tree.

Two details worth reviewing:

- `pwd -W` hands back forward slashes while command lines carry backslashes, so the naive match would have been a silent no-op. Normalised, then dry-run checked: the matcher finds the 6 real MCP servers under the main tree and correctly finds nothing from a worktree.
- A genuinely concurrent `test` run from the *same* tree would also be killed. That is the accepted trade — the silent-lock failure mode cost hours — and `NOVA_KEEP_STALE_HOSTS=1` opts out.

Worth noting for the issue's framing: the lock I actually hit (an undeletable worktree) was an **MCP server launched from that worktree's bin**, not a test host. The existing sweep never reaches it, because you delete a worktree from somewhere else.

## Symptom 2: the `~Ssh` hang — not reproducible

`--filter "FullyQualifiedName~Ssh"` completes in a clean worktree, **with or without** this change: 203/203 in 4-5s both ways. So nothing here claims to fix it, and I have not left it marked fixed. My best remaining guess is that it was a consequence of symptom 1 or 3 in the tree where I saw it (stale hosts plus the init race), but that is a guess, and the issue should stay open on that point until someone sees it again with evidence.

One related observation from the same session, unexplained: the same filter reported **268** tests on one run and **156** on another. If that recurs it deserves its own issue — a filter whose match count moves is a worse problem than a slow suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
