### PR TITLE
fix(tabs): ask the logical tree which tab owns a pane (#319, #314)

### DIFF
--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -5857,27 +5857,25 @@ namespace NovaTerminal
 
         private TerminalPane? ResolvePaneForTab(TabItem tabItem)
         {
-            if (_activePaneByTab.TryGetValue(tabItem, out var pane))
+            // Ignore stale mappings when pane was removed/disposed.
+            //
+            // The logical tree answers this, not the visual one (#319): MainWindow.axaml's
+            // TabControl template hosts content in PART_SelectedContentHost, a sibling of the
+            // header presenter, so a TabItem is never a *visual* ancestor of its own content
+            // and the old check compared null == tabItem — always false. Every call therefore
+            // discarded the cache and fell through to FindFirstPane below, so a split tab
+            // resolved its FIRST pane instead of the active one: leaving such a tab and
+            // returning activated the wrong pane, and CloseTabAsync attributed the close to
+            // the wrong pane in the agent journal.
+            //
+            // Zoom needs no special case: while a tab is zoomed its Content *is* the zoomed
+            // pane, so that pane validates here, and a cached non-zoomed pane correctly reads
+            // as stale — the fallback then returns the zoomed pane, which is the right answer
+            // while zoomed.
+            if (_activePaneByTab.TryGetValue(tabItem, out var pane)
+                && pane.FindLogicalAncestorOfType<TabItem>() == tabItem)
             {
-                // Ignore stale mappings when pane was removed/disposed.
-                //
-                // The logical tree answers this, not the visual one (#319): MainWindow.axaml's
-                // TabControl template hosts content in PART_SelectedContentHost, a sibling of the
-                // header presenter, so a TabItem is never a *visual* ancestor of its own content
-                // and the old check compared null == tabItem — always false. Every call therefore
-                // discarded the cache and fell through to FindFirstPane below, so a split tab
-                // resolved its FIRST pane instead of the active one: leaving such a tab and
-                // returning activated the wrong pane, and CloseTabAsync attributed the close to
-                // the wrong pane in the agent journal.
-                //
-                // Zoom needs no special case: while a tab is zoomed its Content *is* the zoomed
-                // pane, so that pane validates here, and a cached non-zoomed pane correctly reads
-                // as stale — the fallback then returns the zoomed pane, which is the right answer
-                // while zoomed.
-                if (pane.FindLogicalAncestorOfType<TabItem>() == tabItem)
-                {
-                    return pane;
-                }
+                return pane;
             }
 
             if (tabItem.Content is Control content)

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -115,7 +115,6 @@ namespace NovaTerminal
             public bool HasActivity { get; set; }
             public bool HasBell { get; set; }
             public DateTime LastBellUtc { get; set; }
-            public int? LastExitCode { get; set; }
         }
 
         internal enum TabHeaderPointerAction
@@ -920,12 +919,6 @@ namespace NovaTerminal
                 {
                     label = $"{label} ⚠️";
                 }
-            }
-
-            if (state.LastExitCode.HasValue)
-            {
-                string statusGlyph = state.LastExitCode.Value == 0 ? " ✓" : $" ✖{state.LastExitCode.Value}";
-                label += statusGlyph;
             }
 
             if (state.HasBell)
@@ -2669,8 +2662,6 @@ namespace NovaTerminal
             pane.PaneActionRequested -= OnPaneActionRequested;
             pane.OutputReceived -= OnPaneOutputReceived;
             pane.BellReceived -= OnPaneBellReceived;
-            pane.CommandStarted -= OnPaneCommandStarted;
-            pane.CommandFinished -= OnPaneCommandFinished;
             pane.ProcessExited -= OnPaneProcessExited;
             pane.LongCommandCompleted -= OnPaneLongCommandCompleted;
 
@@ -2680,8 +2671,6 @@ namespace NovaTerminal
             pane.PaneActionRequested += OnPaneActionRequested;
             pane.OutputReceived += OnPaneOutputReceived;
             pane.BellReceived += OnPaneBellReceived;
-            pane.CommandStarted += OnPaneCommandStarted;
-            pane.CommandFinished += OnPaneCommandFinished;
             pane.ProcessExited += OnPaneProcessExited;
             pane.LongCommandCompleted += OnPaneLongCommandCompleted;
         }
@@ -2695,8 +2684,6 @@ namespace NovaTerminal
             pane.PaneActionRequested -= OnPaneActionRequested;
             pane.OutputReceived -= OnPaneOutputReceived;
             pane.BellReceived -= OnPaneBellReceived;
-            pane.CommandStarted -= OnPaneCommandStarted;
-            pane.CommandFinished -= OnPaneCommandFinished;
             pane.ProcessExited -= OnPaneProcessExited;
             pane.LongCommandCompleted -= OnPaneLongCommandCompleted;
         }
@@ -2740,7 +2727,14 @@ namespace NovaTerminal
 
         private void OnPaneBellReceived(TerminalPane pane)
         {
-            var tab = pane.FindAncestorOfType<TabItem>();
+            // ResolveOwningTabForPane rather than a tree walk (#314): it carries the
+            // _paneOwnerTab cache and a rebuild fallback, so it also answers for a pane whose
+            // tab is currently zoomed — EnterPaneZoom detaches the tab's other panes from the
+            // logical tree, and a bell from one of those should still mark the tab. The previous
+            // FindAncestorOfType<TabItem> call was a visual-tree lookup that never resolved for
+            // any pane, so this handler returned here every time and the bell indicator had
+            // never once appeared.
+            var tab = ResolveOwningTabForPane(pane);
             if (tab == null) return;
 
             if (!TryGetSelectedTab(out var selectedTab) || selectedTab != tab)
@@ -2756,28 +2750,6 @@ namespace NovaTerminal
                 state.HasBell = true;
                 QueueTabVisualRefresh(tab);
             }
-        }
-
-        private void OnPaneCommandStarted(TerminalPane pane)
-        {
-            var tab = pane.FindAncestorOfType<TabItem>();
-            if (tab == null) return;
-
-            var state = GetOrCreateTabState(tab);
-            state.LastExitCode = null;
-            QueueTabVisualRefresh(tab);
-        }
-
-        private void OnPaneCommandFinished(TerminalPane pane, int? exitCode)
-        {
-            if (!exitCode.HasValue) return;
-
-            var tab = pane.FindAncestorOfType<TabItem>();
-            if (tab == null) return;
-
-            var state = GetOrCreateTabState(tab);
-            state.LastExitCode = exitCode.Value;
-            QueueTabVisualRefresh(tab);
         }
 
         private void OnPaneLongCommandCompleted(TerminalPane pane, string? commandText, int? exitCode, TimeSpan duration)
@@ -2818,13 +2790,13 @@ namespace NovaTerminal
                 return;
             }
 
-            // Deliberately not recording exitCode on the tab's state here (#311 fix-wave finding
-            // A). Doing so lets the ✓/✖N tab-strip glyph render, but the only place that clears it
-            // — OnPaneCommandStarted — resolves its TabItem via the visual tree, which (like the
-            // comment on ClosePaneAsync explains) never resolves for a TabControl's Content, so
-            // the glyph would render once and then stick forever, including across a successful
-            // restart. The whole glyph story (set, clear, and telling a process-exit apart from a
-            // command-exit) is deferred to a follow-up issue; see #311.
+            // The tab strip says nothing about exit codes, deliberately (#311, then #314). The
+            // ✓/✖N glyph it used to carry was written both per-command and on process exit and
+            // rendered identically, so a dead shell looked exactly like a failed command — and
+            // the only code that cleared it never ran, because it asked for its TabItem through
+            // the visual tree. #314 resolved that by deleting the glyph rather than reviving an
+            // ambiguous marker: a dead pane announces itself in the pane body instead. If a tab
+            // marker is ever wanted, it needs its own state and its own reset, not this one.
 
             if (!ShouldClosePaneOnExit(_settings.ShellExitPolicy, isSsh: false, exitCode))
             {
@@ -5888,7 +5860,21 @@ namespace NovaTerminal
             if (_activePaneByTab.TryGetValue(tabItem, out var pane))
             {
                 // Ignore stale mappings when pane was removed/disposed.
-                if (pane.FindAncestorOfType<TabItem>() == tabItem)
+                //
+                // The logical tree answers this, not the visual one (#319): MainWindow.axaml's
+                // TabControl template hosts content in PART_SelectedContentHost, a sibling of the
+                // header presenter, so a TabItem is never a *visual* ancestor of its own content
+                // and the old check compared null == tabItem — always false. Every call therefore
+                // discarded the cache and fell through to FindFirstPane below, so a split tab
+                // resolved its FIRST pane instead of the active one: leaving such a tab and
+                // returning activated the wrong pane, and CloseTabAsync attributed the close to
+                // the wrong pane in the agent journal.
+                //
+                // Zoom needs no special case: while a tab is zoomed its Content *is* the zoomed
+                // pane, so that pane validates here, and a cached non-zoomed pane correctly reads
+                // as stale — the fallback then returns the zoomed pane, which is the right answer
+                // while zoomed.
+                if (pane.FindLogicalAncestorOfType<TabItem>() == tabItem)
                 {
                     return pane;
                 }

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowTabLookupTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowTabLookupTests.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using NovaTerminal.Controls;
+using NovaTerminal.Pty;
+using NovaTerminal.Shell;
+
+namespace NovaTerminal.Tests.Core;
+
+/// <summary>
+/// #319 and #314: MainWindow answers "which tab owns this pane" with
+/// <c>pane.FindAncestorOfType&lt;TabItem&gt;()</c>, a *visual*-tree lookup that can never
+/// resolve — MainWindow.axaml's TabControl template hosts content in
+/// <c>PART_SelectedContentHost</c>, a sibling of the header presenter, so a TabItem is never a
+/// visual ancestor of its own content. Every site that asked the question that way was silently
+/// answering "no tab", which is why the bell indicator never appeared and why a split tab
+/// resolved the wrong pane.
+/// </summary>
+public sealed class MainWindowTabLookupTests
+{
+    /// <summary>
+    /// #319: the cached active pane was discarded on every call, because the staleness check
+    /// compared <c>null == tabItem</c>. The fallback then returned the *first* pane in the tab,
+    /// so leaving a split tab and coming back activated the wrong pane, and a closed split tab
+    /// was attributed to the wrong pane in the agent journal.
+    /// </summary>
+    [AvaloniaFact]
+    public void ResolvePaneForTab_ReturnsTheActivePane_NotTheFirstOneInASplit()
+    {
+        using var fixture = SplitTabFixture.Create();
+
+        // Exactly what focusing the second pane does in production.
+        fixture.Invoke("UpdateActivePane", fixture.SecondPane);
+
+        var resolved = (TerminalPane?)fixture.Invoke("ResolvePaneForTab", fixture.Tab);
+
+        Assert.Same(fixture.SecondPane, resolved);
+    }
+
+    /// <summary>
+    /// #314 (bell only): a bell in a background tab's pane must mark that tab. The handler
+    /// bailed out before it could, because the tab lookup never resolved.
+    /// </summary>
+    [AvaloniaFact]
+    public void Bell_InABackgroundTabsPane_MarksThatTab()
+    {
+        using var fixture = SplitTabFixture.Create();
+
+        // The handler deliberately ignores bells in the tab you are already looking at, so the
+        // fixture's tab must not be selected — which is also the case that matters to a user.
+        Assert.NotSame(fixture.Tab, fixture.Tabs.SelectedItem);
+
+        fixture.Invoke("OnPaneBellReceived", fixture.FirstPane);
+
+        Assert.True(fixture.TabHasBell(), "a bell in a background tab's pane must set that tab's bell marker");
+    }
+
+    private sealed class SplitTabFixture : IDisposable
+    {
+        private SplitTabFixture(NovaTerminal.MainWindow window, TabControl tabs, TabItem tab, TerminalPane first, TerminalPane second)
+        {
+            Window = window;
+            Tabs = tabs;
+            Tab = tab;
+            FirstPane = first;
+            SecondPane = second;
+        }
+
+        public NovaTerminal.MainWindow Window { get; }
+        public TabControl Tabs { get; }
+        public TabItem Tab { get; }
+        public TerminalPane FirstPane { get; }
+        public TerminalPane SecondPane { get; }
+
+        public object? Invoke(string method, params object?[] args)
+        {
+            MethodInfo m = typeof(NovaTerminal.MainWindow)
+                .GetMethod(method, BindingFlags.Instance | BindingFlags.NonPublic)
+                ?? throw new MissingMethodException($"MainWindow.{method} not found");
+            return m.Invoke(Window, args);
+        }
+
+        public bool TabHasBell()
+        {
+            object state = Invoke("GetOrCreateTabState", Tab)!;
+            return (bool)state.GetType().GetProperty("HasBell")!.GetValue(state)!;
+        }
+
+        public static SplitTabFixture Create()
+        {
+            AppServiceBundle bundle = AppServices.BuildForDesigner();
+            var window = new NovaTerminal.MainWindow(bundle);
+            TabControl tabs = window.FindControl<TabControl>("Tabs")!;
+            var settings = (TerminalSettings)typeof(NovaTerminal.MainWindow)
+                .GetField("_settings", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(window)!;
+
+            tabs.Items.Clear();
+
+            // A split tab, built the way session restore builds one: a Split root over two
+            // leaves. Two panes is the whole point — with one pane, "the first pane" and "the
+            // active pane" are the same and #319 is invisible.
+            var tabSession = new TabSession
+            {
+                Title = "Split",
+                Root = new PaneNode
+                {
+                    Type = NodeType.Split,
+                    SplitOrientation = 0,
+                    Children = new List<PaneNode>
+                    {
+                        NewLeaf(),
+                        NewLeaf(),
+                    },
+                },
+            };
+
+            TabItem tab = SessionManager.CreateRestoredTabItem(tabSession, settings)!;
+            tabs.Items.Add(tab);
+
+            // A second tab, selected, so the tab under test is a background tab.
+            TabItem other = SessionManager.CreateRestoredTabItem(
+                new TabSession { Title = "Other", Root = NewLeaf() }, settings)!;
+            tabs.Items.Add(other);
+            tabs.SelectedItem = other;
+
+            typeof(NovaTerminal.MainWindow)
+                .GetMethod("InitializeRestoredTabs", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(window, [tabs]);
+
+            var panes = new List<TerminalPane>();
+            CollectPanes(tab.Content as Control, panes);
+            Assert.Equal(2, panes.Count);
+
+            return new SplitTabFixture(window, tabs, tab, panes[0], panes[1]);
+        }
+
+        private static PaneNode NewLeaf() => new()
+        {
+            Type = NodeType.Leaf,
+            Command = "cmd.exe",
+            Arguments = string.Empty,
+            PaneId = Guid.NewGuid().ToString(),
+        };
+
+        private static void CollectPanes(Control? control, List<TerminalPane> into)
+        {
+            switch (control)
+            {
+                case null:
+                    return;
+                case TerminalPane pane:
+                    into.Add(pane);
+                    return;
+                case Panel panel:
+                    foreach (Control child in panel.Children)
+                    {
+                        CollectPanes(child, into);
+                    }
+                    return;
+                case ContentControl contentControl:
+                    CollectPanes(contentControl.Content as Control, into);
+                    return;
+                case Decorator decorator:
+                    CollectPanes(decorator.Child, into);
+                    return;
+            }
+        }
+
+        public void Dispose() => Window.Close();
+    }
+}

--- a/tests/NovaTerminal.App.Tests/PtyChildExitDetectionTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtyChildExitDetectionTests.cs
@@ -79,18 +79,27 @@ namespace NovaTerminal.Tests
 
             int? code = await WaitForExitAsync(session, TimeSpan.FromSeconds(30));
 
-            // Only "exited, and not the clean 0 it used to claim" is asserted here.
+            // What this test is for: the session notices, rather than sitting there believing a
+            // dead shell is alive. The *value* is asserted by TheShellsRealExitCodeIsReported,
+            // which uses `exit 42` and is meaningful on every platform.
             //
-            // The exact value cannot be: .NET's Process.Kill terminates with -1, which is
-            // also the value of RustPtySession.ReadFailureExitCode - so on Windows a
-            // managed-tool kill is genuinely indistinguishable from "this session's reads
-            // failed". That collision predates this change and is not worth a behaviour
-            // change here (both readings mean the same thing to a user: the shell is gone),
-            // but it is why this test asserts the fact of the exit while
-            // TheShellsRealExitCodeIsReported asserts the value.
+            // The code deliberately is not asserted cross-platform, and the first version of
+            // this test was wrong to try (it asserted non-zero and failed on ubuntu CI):
+            //   * Unix reports a signal death with WEXITSTATUS 0, so a SIGKILL'd shell
+            //     legitimately surfaces as 0 - indistinguishable here from a clean exit.
+            //   * On Windows .NET's Process.Kill terminates with -1, which also happens to be
+            //     RustPtySession.ReadFailureExitCode, so a managed-tool kill is
+            //     indistinguishable from "this session's reads failed". That collision predates
+            //     this test and means the same thing to a user either way.
             Assert.NotNull(code);
-            Assert.NotEqual(0, code!.Value);
             Assert.False(session.IsProcessRunning, "a session whose shell was killed must not report itself as running");
+
+            if (OperatingSystem.IsWindows())
+            {
+                // Windows does carry a distinct status for a terminated process, so hold it to
+                // that: reporting a clean 0 here would be the old "assumed 0" bug returning.
+                Assert.NotEqual(0, code!.Value);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #319. Fixes #314.

Both are the same root cause, split into two issues because one needed a decision and one didn't: `pane.FindAncestorOfType<TabItem>()` is a **visual**-tree lookup, and it can never resolve in this app. `MainWindow.axaml`'s `TabControl` template hosts content in `PART_SelectedContentHost`, a sibling of the header `ItemsPresenter`, so a `TabItem` is never a visual ancestor of its own content. Every site that asked "which tab owns this pane" that way was silently answering "no tab".

## #319 — a split tab resolved the wrong pane

`ResolvePaneForTab` cached the active pane and then checked the cache for staleness with `pane.FindAncestorOfType<TabItem>() == tabItem`, i.e. `null == tabItem`, i.e. always false. So the cache was discarded on every call and the fallback returned `FindFirstPane(content)` — the **first** pane in the tab, not the active one.

Two observable consequences, both fixed:

- leaving a split tab and coming back activated pane 1 rather than the pane you were in;
- `CloseTabAsync` published its audit event with `ResolvePaneForTab(tab)`, so a closed split tab was attributed to the wrong pane in the agent activity journal.

Zoom needs no special case, which is worth stating because it looks like it should: while a tab is zoomed its `Content` *is* the zoomed pane, so that pane validates; a cached non-zoomed pane correctly reads as stale, and the fallback then returns the zoomed pane — the right answer while zoomed.

## #314 — bell only

`OnPaneBellReceived` had the same dead lookup, so the tab's 🔔 indicator had never once appeared. It now asks `ResolveOwningTabForPane`, which carries the `_paneOwnerTab` cache and a rebuild fallback and therefore also answers for a pane whose tab is currently zoomed — `EnterPaneZoom` detaches the tab's other panes from the logical tree, and a bell from one of those should still mark the tab.

Per the decision on #314, the `✓`/`✖N` per-command glyph is **deleted rather than revived**. It was written by both `OnPaneCommandFinished` (per command) and, until #315, `OnPaneProcessExited` (the shell itself ended), and rendered identically — so a dead shell looked exactly like a failed command. The only thing that cleared it was one of the dead sites. Reviving it would have shipped an ambiguous marker with no working reset; a dead pane already announces itself in the pane body since #315.

Removed: `OnPaneCommandStarted`, `OnPaneCommandFinished`, their wiring, `TabState.LastExitCode`, and the glyph in the label builder. `TerminalPane.LastExitCode` is a different, live property and is untouched. The `CommandStarted` / `CommandFinished` pane events stay — MainWindow was their only subscriber, and the agent status machine has its own wiring inside the pane.

A stale comment in `OnPaneProcessExited` that explained why the glyph was left off now explains why it is gone.

## Tests

`MainWindowTabLookupTests`, both written first and confirmed failing for the right reasons before the fix:

- `ResolvePaneForTab_ReturnsTheActivePane_NotTheFirstOneInASplit` — builds a real split tab through `SessionManager.CreateRestoredTabItem`, focuses the second pane via the production `UpdateActivePane`, and asserts the resolve returns it. Failed with "values are not the same instance" before.
- `Bell_InABackgroundTabsPane_MarksThatTab` — asserts the tab is not selected first, since the handler deliberately ignores bells in the tab you are looking at, then rings and asserts the marker. Failed with no marker before.

## Manual check still worth doing

The bell and the focus behaviour are both visible things, and neither is provable headlessly:

1. Split a tab, focus the second pane, switch away and back → focus returns to the second pane.
2. In a background tab's pane, `printf '\a'` → that tab shows 🔔.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
