### PR TITLE
packaging(winget): cut the 0.4.0 manifest set and correct the submission notes

### DIFF
--- a/packaging/winget/0.4.0/benyblack.NovaTerminal.installer.yaml
+++ b/packaging/winget/0.4.0/benyblack.NovaTerminal.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: benyblack.NovaTerminal
+PackageVersion: 0.4.0
+
+# NovaTerminal releases ship as self-contained AOT bundles zipped per platform
+# (see .github/workflows/release.yml). There is no signed installer, so the
+# Windows package is delivered as a portable app extracted from the release zip
+# — no code-signing certificate required for winget onboarding.
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: NovaTerminal.exe
+    PortableCommandAlias: nova
+
+# Portable packages install per-user and need no elevation.
+UpgradeBehavior: uninstallPrevious
+
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/benyblack/NovaTerminal/releases/download/v0.4.0/NovaTerminal-win-x64-v0.4.0.zip
+    InstallerSha256: 9EE68DA502507F5BEE387640AFCCF4ECCD2D634EFC3586FC906DE13304A04B07
+
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/packaging/winget/0.4.0/benyblack.NovaTerminal.locale.en-US.yaml
+++ b/packaging/winget/0.4.0/benyblack.NovaTerminal.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: benyblack.NovaTerminal
+PackageVersion: 0.4.0
+PackageLocale: en-US
+Publisher: Behnam Yousefi
+PublisherUrl: https://github.com/benyblack
+PublisherSupportUrl: https://github.com/benyblack/NovaTerminal/issues
+Author: Behnam Yousefi
+PackageName: NovaTerminal
+PackageUrl: https://github.com/benyblack/NovaTerminal
+License: MIT
+LicenseUrl: https://github.com/benyblack/NovaTerminal/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Behnam Yousefi
+CopyrightUrl: https://github.com/benyblack/NovaTerminal/blob/main/LICENSE
+ShortDescription: A correct, deterministic, cross-platform terminal emulator with a cell-based VT engine, deterministic session replay, and native SSH.
+Description: |-
+  NovaTerminal is a cross-platform terminal emulator built on a cell-based virtual-terminal
+  engine with strong VT/ANSI conformance, deterministic session recording and replay, and a
+  native SSH client (profiles, jump hosts, port forwarding). It is self-contained: this package
+  is a portable build extracted from the official release archive and runs without an installer.
+Moniker: novaterminal
+Tags:
+  - terminal
+  - terminal-emulator
+  - console
+  - ssh
+  - vt
+  - ansi
+  - developer-tools
+  - avalonia
+ReleaseNotesUrl: https://github.com/benyblack/NovaTerminal/releases/tag/v0.4.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/packaging/winget/0.4.0/benyblack.NovaTerminal.yaml
+++ b/packaging/winget/0.4.0/benyblack.NovaTerminal.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: benyblack.NovaTerminal
+PackageVersion: 0.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -29,9 +29,9 @@ packaging/winget/<version>/
 On a Windows machine with the winget client:
 
 ```powershell
-winget validate --manifest packaging\winget\0.3.0
+winget validate --manifest packaging\winget\0.4.0
 # Optional end-to-end install test in a throwaway context:
-winget install --manifest packaging\winget\0.3.0
+winget install --manifest packaging\winget\0.4.0
 ```
 
 `winget validate` checks schema and required fields offline. `winget install --manifest` downloads
@@ -57,7 +57,7 @@ $sha = (Get-FileHash "$env:TEMP\nova-winget\$asset" -Algorithm SHA256).Hash
 #    (Create the dir first and copy contents with a wildcard — `Copy-Item -Recurse`
 #    onto an existing dir nests the source folder instead of copying its contents.)
 New-Item -ItemType Directory -Force -Path packaging\winget\$ver | Out-Null
-Copy-Item packaging\winget\0.3.0\* packaging\winget\$ver
+Copy-Item packaging\winget\0.4.0\* packaging\winget\$ver
 # In each file: set PackageVersion: X.Y.Z
 # In the installer file: set the new InstallerUrl and InstallerSha256 ($url / $sha)
 # In the locale file: update ReleaseNotesUrl to the vX.Y.Z tag and refresh the description
@@ -78,11 +78,19 @@ on first launch of the unsigned exe; that resolves when code-signing lands (a se
 
 ## Notes / caveats
 
-- **Version vs. feature drift.** The `0.3.0` manifest describes NovaTerminal *as of that release*.
-  The agent-host surface (observe / status / act / replay export, milestones A1–A4) landed after
-  v0.3.0 and is unreleased at the time of writing; do not advertise those capabilities in a manifest
-  until the release actually contains them (cut a new `vX.Y.Z` first, then a matching manifest).
+- **Version vs. feature drift.** Each `<version>` manifest describes NovaTerminal *as of that
+  release*. The `0.4.0` set carries the `0.3.0` description verbatim — it was bumped for version,
+  URL and hash only. Do not advertise a capability in a manifest until the release actually
+  contains it (cut a new `vX.Y.Z` first, then a matching manifest).
 - **x64 only.** Releases currently publish `win-x64`. Add an `arm64` installer entry when the
   release workflow starts producing a `win-arm64` bundle.
-- **Auto-submission (optional follow-up).** A release-workflow step using `wingetcreate` with a
-  PAT can open the winget-pkgs PR automatically on each tag; kept manual for now.
+- **Auto-submission is wired but dormant.** `release.yml` has a `submit_winget` job that runs
+  `wingetcreate update` on each tag push. It self-skips when the `WINGET_PAT` repository secret is
+  absent, which is the state today — every release so far has logged
+  `WINGET_PAT not set; skipping winget-pkgs submission.` and reported success. A green Release run
+  therefore does **not** mean anything reached winget.
+- **The package is not in winget-pkgs yet.** `manifests/b/benyblack/NovaTerminal/` does not exist
+  upstream, so `winget install benyblack.NovaTerminal` does not work. Because `submit_winget` uses
+  `wingetcreate update`, which requires the package to already exist, it would fail even with the
+  secret set. Unblock in this order: run `submit-first-time.ps1` to open the bootstrap PR, wait for
+  it to merge, then set `WINGET_PAT` so subsequent tags auto-submit.

--- a/packaging/winget/submit-first-time.ps1
+++ b/packaging/winget/submit-first-time.ps1
@@ -18,7 +18,7 @@
     at https://github.com/settings/tokens. This script never stores it.
 
 .PARAMETER Version
-    The manifest version folder to submit. Default: 0.3.0.
+    The manifest version folder to submit. Default: 0.4.0.
 
 .PARAMETER Token
     GitHub PAT. If omitted, the WINGET_PAT environment variable is used.
@@ -27,11 +27,11 @@
     ./submit-first-time.ps1 -Token ghp_xxx
 
 .EXAMPLE
-    $env:WINGET_PAT = 'ghp_xxx'; ./submit-first-time.ps1 -Version 0.3.0
+    $env:WINGET_PAT = 'ghp_xxx'; ./submit-first-time.ps1 -Version 0.4.0
 #>
 [CmdletBinding()]
 param(
-    [string]$Version = "0.3.0",
+    [string]$Version = "0.4.0",
     [string]$Token = $env:WINGET_PAT
 )
 


### PR DESCRIPTION
## What this changes

The in-repo winget manifests stopped at `0.3.0` while releases reached `v0.4.0`. This adds the `0.4.0` set and corrects two notes in the README that no longer described reality.

While cutting it, two things turned up that are worth stating plainly, because a green Release run currently implies neither is true:

- **`submit_winget` has never submitted anything.** It self-skips without the `WINGET_PAT` secret, which is the state today — every release has logged `WINGET_PAT not set; skipping winget-pkgs submission.` and reported success.
- **The package was never bootstrapped upstream.** `manifests/b/benyblack/NovaTerminal/` did not exist in `microsoft/winget-pkgs`. Since the job uses `wingetcreate update`, which requires the package to already exist, it would have failed even with the secret set.

Both are now written into `packaging/winget/README.md`, along with the order needed to unblock them.

Fixes # (n/a — refs #91)

## Invariant and ownership

- **What invariant does this change affect?** None — packaging metadata and docs only. No product code is touched.
- **Which module owns that invariant?** n/a

## Tests

- **What tests cover this change?** No automated tests; there is no test project for packaging manifests. Verified with the real toolchain instead: `winget validate --manifest packaging\winget\0.4.0` → `Manifest validation succeeded`.

  The manifests have also now been validated end to end upstream. The bootstrap submission is microsoft/winget-pkgs#419465, where all ten validation stages passed — including `08. Installation Validation` (41m49s), which downloads the real zip, verifies the SHA256, and installs the portable package in a sandbox.

- **Which categories did you run locally?** None applicable — no compiled code changed.

  - [ ] full unfiltered run (`scripts/build.sh test`)
  - [ ] `Category=Replay`
  - [ ] `Category=RenderMetrics`
  - [ ] `Category=PtySmoke`
  - [ ] `tests/NovaTerminal.App.Tests` (non-blocking in CI — check it yourself)
  - [ ] full local CI rehearsal (`ci/run.sh` / `ci/run.ps1`)

## Impact

- **Does this affect cross-platform behavior?** No. Windows packaging metadata only; the Linux and macOS release assets are untouched.
- **Does this change renderer metrics?** No.
- **Does this change VT coverage?** No.

## Notes for the reviewer

The installer SHA256 was taken from the published asset's GitHub digest rather than by re-downloading the 77 MB zip, then confirmed by upstream stage 08. The `ShortDescription`/`Description` are deliberately carried over from `0.3.0` unchanged, per the README's own rule about not advertising capabilities a release does not yet contain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)