### PR TITLE
fix(pty): wait briefly for the child's status instead of assuming 0 (#323)

### DIFF
--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -75,6 +75,23 @@ namespace NovaTerminal.Pty
         /// arriving are a race.
         internal const int ChildExitDrainGraceMs = 250;
 
+        /// How long the exit notification waits for the child's status before giving up and
+        /// reporting 0 (#323).
+        ///
+        /// EOF is not proof that the status is available yet. On Unix the pty slave closes the
+        /// instant the shell dies, so EOF and death are simultaneous and the child has not been
+        /// reaped at that microsecond: measured on Ubuntu, portable-pty's try_wait() says "still
+        /// running" at 0 ms and reports the real status at ~20 ms. A single non-blocking attempt
+        /// therefore loses the race and the old fallback fabricated a clean 0 — so a killed shell
+        /// on Linux was indistinguishable from `exit`, which is the confusion #313 exists to
+        /// remove. Windows never showed it because the ConPTY host outlives its client, so the
+        /// pipe does not EOF and the watcher always had time.
+        ///
+        /// 500 ms is ~25x the observed window and only ever elapses when the status genuinely
+        /// cannot be determined, in which case the wait is the least of the problems.
+        internal const int ChildStatusWaitMs = 500;
+        private const int ChildStatusPollMs = 20;
+
         private Thread? _exitWatchThread;
 
         // Written once by the exit-watch thread, read by the read/process loops. Two fields
@@ -87,6 +104,44 @@ namespace NovaTerminal.Pty
         /// the expected consequence of cancelling it, not a session failure worth reporting
         /// as <see cref="ReadFailureExitCode"/>.
         private bool ChildExitObserved => Volatile.Read(ref _childExitObserved) == 1;
+
+        /// The status to report when the stream has ended: the child's real one, waited for
+        /// briefly if it is not available yet (#323), or 0 when it cannot be determined.
+        ///
+        /// Called from the one place that notifies a normal exit, so the EOF path, the
+        /// read-error path and the watcher all get the same treatment.
+        private int ResolveExitCodeForNotification()
+        {
+            if (ChildExitObserved)
+            {
+                return Volatile.Read(ref _childExitCode);
+            }
+
+            var deadline = DateTime.UtcNow.AddMilliseconds(ChildStatusWaitMs);
+            while (DateTime.UtcNow < deadline)
+            {
+                if (TryCaptureChildExit())
+                {
+                    return Volatile.Read(ref _childExitCode);
+                }
+
+                // Cancellation means the session is being torn down: stop waiting on a status
+                // nobody is going to read and let Dispose finish.
+                if (_cts.IsCancellationRequested || _handle.IsClosed || _handle.IsInvalid)
+                {
+                    break;
+                }
+
+                Thread.Sleep(ChildStatusPollMs);
+            }
+
+            // Deliberately loud: "the stream ended and we never learned why" used to be
+            // indistinguishable from "the shell exited cleanly", and that silence is what #323
+            // was about.
+            PtyLogger.Warning(
+                $"[RustPtySession] Child status unavailable {ChildStatusWaitMs}ms after the stream ended; reporting 0.");
+            return 0;
+        }
 
         /// Asks the native layer whether the child has exited and records its status if so.
         /// Returns true when the child is gone.
@@ -1086,9 +1141,8 @@ namespace NovaTerminal.Pty
                 // misbehaving subscriber can't take down the host; still notify exit below.
                 PtyLogger.Error($"[RustPtySession] ProcessLoop terminated by unhandled exception: {ex}");
             }
-            // The child's real status when the watcher observed it (#313); 0 otherwise, which
-            // is the pre-existing reading of "the stream ended and we know nothing more".
-            TryNotifyExit(ChildExitObserved ? Volatile.Read(ref _childExitCode) : 0);
+            // The child's real status, waited for briefly if EOF got here first (#313, #323).
+            TryNotifyExit(ResolveExitCodeForNotification());
         }
 
         public void SendInput(string input)
@@ -1242,6 +1296,10 @@ namespace NovaTerminal.Pty
 
             // Last-resort notification for a session nobody else reported (first-caller-wins,
             // so a real exit already observed upstream keeps its code).
+            //
+            // No bounded wait here, unlike ProcessLoop (#323): reaching this line means the pane
+            // is being torn down, so the user is closing a tab and a snappy close matters more
+            // than an exit code nobody will look at.
             TryNotifyExit(ChildExitObserved ? Volatile.Read(ref _childExitCode) : 0);
         }
 

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -125,19 +125,22 @@ namespace NovaTerminal.Pty
                     return Volatile.Read(ref _childExitCode);
                 }
 
-                // Cancellation means the session is being torn down: stop waiting on a status
-                // nobody is going to read and let Dispose finish.
+                // Teardown, not an unavailable status: the session is being disposed, so nobody
+                // is waiting for this code and Dispose wants its join. Return without the
+                // warning below — Dispose cancels _cts before joining ProcessLoop, so warning
+                // here would fire on every ordinary close of a running pane and drown the one
+                // case the warning exists for (Codex review on #324).
                 if (_cts.IsCancellationRequested || _handle.IsClosed || _handle.IsInvalid)
                 {
-                    break;
+                    return 0;
                 }
 
                 Thread.Sleep(ChildStatusPollMs);
             }
 
-            // Deliberately loud: "the stream ended and we never learned why" used to be
-            // indistinguishable from "the shell exited cleanly", and that silence is what #323
-            // was about.
+            // Only a genuine deadline expiry gets here, and it is deliberately loud: "the stream
+            // ended and we never learned why" used to be indistinguishable from "the shell exited
+            // cleanly", and that silence is what #323 was about.
             PtyLogger.Warning(
                 $"[RustPtySession] Child status unavailable {ChildStatusWaitMs}ms after the stream ended; reporting 0.");
             return 0;

--- a/tests/NovaTerminal.App.Tests/PtyChildExitDetectionTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtyChildExitDetectionTests.cs
@@ -79,27 +79,20 @@ namespace NovaTerminal.Tests
 
             int? code = await WaitForExitAsync(session, TimeSpan.FromSeconds(30));
 
-            // What this test is for: the session notices, rather than sitting there believing a
-            // dead shell is alive. The *value* is asserted by TheShellsRealExitCodeIsReported,
-            // which uses `exit 42` and is meaningful on every platform.
+            // A killed shell must never be reported as a clean 0 — that is the whole point, on
+            // every platform. Windows reports -1 (what .NET's Process.Kill terminates with, and
+            // incidentally the same value as ReadFailureExitCode, a pre-existing collision that
+            // means the same thing to a user); Linux reports 1, which is what portable-pty maps a
+            // signal death to.
             //
-            // The code deliberately is not asserted cross-platform, and the first version of
-            // this test was wrong to try (it asserted non-zero and failed on ubuntu CI):
-            //   * Unix reports a signal death with WEXITSTATUS 0, so a SIGKILL'd shell
-            //     legitimately surfaces as 0 - indistinguishable here from a clean exit.
-            //   * On Windows .NET's Process.Kill terminates with -1, which also happens to be
-            //     RustPtySession.ReadFailureExitCode, so a managed-tool kill is
-            //     indistinguishable from "this session's reads failed". That collision predates
-            //     this test and means the same thing to a user either way.
+            // This assertion was briefly Windows-only, because on ubuntu it saw 0 and I read that
+            // as a platform quirk. It was not: EOF and death are simultaneous on Unix, so the
+            // single non-blocking status check lost the race and the notification fabricated a 0
+            // (#323). The weakened assertion was hiding the bug, which is why it is back to
+            // asserting the same thing everywhere — and why ubuntu CI is the run that proves it.
             Assert.NotNull(code);
+            Assert.NotEqual(0, code!.Value);
             Assert.False(session.IsProcessRunning, "a session whose shell was killed must not report itself as running");
-
-            if (OperatingSystem.IsWindows())
-            {
-                // Windows does carry a distinct status for a terminated process, so hold it to
-                // that: reporting a clean 0 here would be the old "assumed 0" bug returning.
-                Assert.NotEqual(0, code!.Value);
-            }
         }
 
         [Fact]

--- a/tests/NovaTerminal.App.Tests/PtyChildExitDetectionTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtyChildExitDetectionTests.cs
@@ -97,6 +97,26 @@ namespace NovaTerminal.Tests
 
         [Fact]
         [Trait("Category", "PtySmoke")]
+        public async Task ClosingALiveSessionDoesNotClaimTheStatusWasUnavailable()
+        {
+            // From the Codex review on #324: Dispose cancels the token before joining
+            // ProcessLoop, so the status resolver stops waiting almost immediately. Warning at
+            // that point would fire on every ordinary close of a running pane and drown the one
+            // case the warning exists for — a stream that ended with no status behind it.
+            using var log = PtyLogCapture.Attach();
+
+            using (var session = NewSession())
+            {
+                await WaitForPromptAsync(session);
+            } // Dispose: a normal close of a session whose shell is still alive.
+
+            await Task.Delay(200);
+
+            Assert.DoesNotContain("Child status unavailable", log.ToString(), StringComparison.Ordinal);
+        }
+
+        [Fact]
+        [Trait("Category", "PtySmoke")]
         public async Task ALiveShellIsNotReportedAsExited()
         {
             // The other half: the watcher must not manufacture an exit for a healthy session,


### PR DESCRIPTION
Fixes #323. Unix half of #313.

## The bug

A killed shell reported exit code **0** on Linux, so a crash and a deliberate `exit` were indistinguishable again — the confusion #313 exists to remove, on the platform #313 did not cover.

EOF is not proof that the status is available yet. On Unix the pty slave closes the instant the shell dies, so EOF and death are simultaneous and the child has not been reaped at that microsecond. The read loop asked exactly once, lost the race, and the notification fell back to an assumed 0.

Measured on Ubuntu 22.04 with a standalone portable-pty probe:

```
pid=1926 alive, sending SIGKILL
try_wait after 20ms -> exit_code=1 success=false
```

`Ok(None)` at 0 ms, the real status at ~20 ms.

**Not portable-pty's mapping.** `From<std::process::ExitStatus>` uses `code: status.code().unwrap_or(1)`, and Rust reports `None` for a signal death, so portable-pty yields `1` — as the probe shows. The 0 was ours.

**Why Windows never showed it.** There the ConPTY host outlives its client shell, so the pipe never EOFs and the 200 ms watcher always had time to capture the status. The bug hid behind the very quirk that motivated #313.

## The fix

`ResolveExitCodeForNotification` polls for the status for up to 500 ms (~25x the observed window) at the single place that reports a normal exit — so the EOF path, the read-error path and the watcher all get identical treatment. It only ever waits when the status genuinely is not available yet; when the watcher already captured it (the Windows case) it returns immediately.

When the status still cannot be determined it **logs a warning** and reports 0. "The stream ended and we never learned why" used to be silently indistinguishable from "the shell exited cleanly", and that silence was the bug.

`Dispose`'s last-resort notification deliberately does **not** wait: reaching it means the pane is being torn down, so a snappy tab close beats an exit code nobody will read.

## How this is proven

The test assertion goes back to cross-platform, and that is the actual proof:

```csharp
Assert.NotEqual(0, code!.Value);   // Linux reports 1, Windows -1
```

That assertion was briefly Windows-only. I weakened it in #320 after ubuntu CI saw 0, reading it as a platform quirk (Unix `WEXITSTATUS` being 0 for signal deaths). That reading was wrong — it was this race — and the weakened assertion was hiding the bug rather than describing reality. **ubuntu CI is the run that proves this PR**; on Windows the test passes either way.

Local (Windows): `PtyChildExitDetectionTests` 4/4, `PtyReadFailure` + `PtySmokeTests` 13/13, `Category=PtySmoke` 21/21.

## Still not enough to flip the default

`ShellExitPolicy` stays `"Never"`. With this, a killed shell reports a real code on both platforms, which removes the blocker I raised in #313 — but flipping the default is a behaviour change for every user and deserves its own PR and its own manual pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
