### PR TITLE
fix(ssh): one capability gate for native profiles, and forward writes off the poll loop

### DIFF
--- a/docs/SSH_ROADMAP.md
+++ b/docs/SSH_ROADMAP.md
@@ -38,6 +38,16 @@ The native SSH initiative is implemented behind conservative rollout controls.
 - `OpenSsh` remains the default backend.
 - `Native` is gated by `TerminalSettings.ExperimentalNativeSshEnabled`.
 - Native SSH does **not** silently fall back to OpenSSH on failure.
+- Whether native *can* serve a given profile is answered in one place,
+  `NativeSshCapability.Evaluate` — remote forwards and jump-hop chains are the two
+  shapes it refuses. The connection editor asks it at save time (so an unusable
+  native profile cannot be saved), `SshSessionFactory` asks it before building a
+  session, and `NativeSshSession` / `JumpHostConnectPlan` /
+  `NativePortForwardSession` share its wording instead of spelling their own.
+- The two native refusals are deliberately distinguishable: the global toggle is a
+  rollout decision the user can reverse in settings, an unsupported shape is not.
+  Warnings and errors lead with the shape when both apply, so nobody is sent to
+  settings to fix something settings cannot fix.
 - Native SSH file transfers use the built-in native SFTP path.
 - Native SSH transfer dialogs can autocomplete remote paths when an active session for that profile already exists.
 - Native SSH single-file transfers show live byte progress when the total size is known; folder transfers report per-file progress only.
@@ -51,6 +61,28 @@ The native SSH initiative is implemented behind conservative rollout controls.
 
 - See [`docs/native-ssh/Native_SSH_Test_Matrix.md`](native-ssh/Native_SSH_Test_Matrix.md)
   for the automated verification set and the remaining manual checks.
+
+### Open question: routing a profile that expressed no preference
+
+`NativeSshCapability` answers "can native serve this profile?", which is what a
+future default flip needs — but it is deliberately *not* wired to a routing
+decision yet, and `SshBackendKind` still has only `OpenSsh` and `Native`.
+
+Adding an `Auto` value looks like the obvious next step and is a trap in its
+current form. Roughly eight sites decide native-only behaviour by comparing the
+**persisted** backend kind to `SshBackendKind.Native` — the SFTP path
+(`SftpService`), the remote file browser and path autocomplete
+(`RemoteDirectoryBrowserService`), session-scoped password memory
+(`ActiveSshSessionRegistry`), replay/agent-host descriptors, and the pane's own
+checks. An `Auto` profile that resolved to native at connect time would silently
+take the *OpenSSH* path in all of them, so file transfers and remote browsing
+would quietly use `scp`/no-op paths against a native session. The backend combo in
+the editor also binds straight to `Enum.GetValues<SshBackendKind>()`, so a new
+value appears in the UI unlabelled.
+
+So `Auto` needs a resolved-backend concept threaded through those call sites
+first — a session-scoped answer rather than a profile field. That is its own
+change, not a rider on the capability gate.
 
 ---
 

--- a/docs/native-ssh/Native_SSH_Test_Matrix.md
+++ b/docs/native-ssh/Native_SSH_Test_Matrix.md
@@ -63,8 +63,17 @@ The following checks still require manual validation against real SSH endpoints.
 - Forward-channel data reaching the local socket is queued per channel and written
   by a dedicated pump, in both the managed and Rust layers, so a forwarded port
   whose peer stops reading can no longer stall the session's terminal I/O
-  (issue #173 item 2). A channel that exceeds its 1 MB outbound budget is closed
-  rather than buffered without limit or truncated.
+  (issue #173 item 2).
+- Both directions are bounded at 1 MB per forward channel, but they resolve
+  overflow differently, because only one of them has anywhere to push back to:
+  - **Remote to local** (managed queue): over budget, the channel is closed.
+    Draining slower is not an option — the source is the shared SSH poll loop, and
+    stalling it is the bug being fixed.
+  - **Local to remote** (native queue): over budget,
+    `nova_ssh_channel_write` returns `NOVA_SSH_RESULT_WOULD_BLOCK` and the managed
+    pump retries. That stops it reading the local socket, so TCP flow control
+    throttles the local peer and nothing is dropped or closed for slowness alone.
+    `INativeSshInterop.TryWriteChannel` is the managed half of that contract.
 - Native backend now supports local and direct-host dynamic forwarding.
 - Remote forwarding remains unsupported in the native backend.
 - Dynamic forwarding through one-hop jump hosts remains follow-up work.

--- a/docs/native-ssh/Native_SSH_Test_Matrix.md
+++ b/docs/native-ssh/Native_SSH_Test_Matrix.md
@@ -56,6 +56,15 @@ The following checks still require manual validation against real SSH endpoints.
 - Native SSH remains opt-in through `TerminalSettings.ExperimentalNativeSshEnabled`.
 - `OpenSsh` remains the default backend for new profiles.
 - Native backend refusal is explicit when the global experimental toggle is disabled.
+- Profile shapes the native backend cannot serve (remote forwards, jump-hop chains)
+  are refused by `NativeSshCapability` at profile-save time as well as at connect
+  time, so such a profile can no longer be saved as `Native` and then fail on use.
+  See the rollout guidance in `docs/SSH_ROADMAP.md`.
+- Forward-channel data reaching the local socket is queued per channel and written
+  by a dedicated pump, in both the managed and Rust layers, so a forwarded port
+  whose peer stops reading can no longer stall the session's terminal I/O
+  (issue #173 item 2). A channel that exceeds its 1 MB outbound budget is closed
+  rather than buffered without limit or truncated.
 - Native backend now supports local and direct-host dynamic forwarding.
 - Remote forwarding remains unsupported in the native backend.
 - Dynamic forwarding through one-hop jump hosts remains follow-up work.

--- a/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
+++ b/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 using NovaTerminal.Platform;
 using NovaTerminal.VT;
 using NovaTerminal.Platform.Ssh.Models;
+using NovaTerminal.Platform.Ssh.Native;
 
 namespace NovaTerminal.ViewModels.Ssh;
 
@@ -52,6 +53,12 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
     {
         JumpHops = new ObservableCollection<SshJumpHop>();
         Forwards = new ObservableCollection<PortForward>();
+
+        // BackendWarning now reads these collections, so it has to be re-evaluated when they change —
+        // adding a remote forward to a native profile should surface the problem right away, not at
+        // save. Property setters raise it themselves; collection mutation has no setter to hook.
+        JumpHops.CollectionChanged += (_, _) => OnPropertyChanged(nameof(BackendWarning));
+        Forwards.CollectionChanged += (_, _) => OnPropertyChanged(nameof(BackendWarning));
     }
 
     public Guid? ProfileId
@@ -234,10 +241,29 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
         set => SetField(ref _remoteShellKind, value);
     }
 
-    public string BackendWarning =>
-        BackendKind == SshBackendKind.Native && !ExperimentalNativeSshEnabled
-            ? "Native SSH is disabled globally. Enable ExperimentalNativeSshEnabled in settings or switch this profile back to OpenSSH."
-            : string.Empty;
+    public string BackendWarning
+    {
+        get
+        {
+            if (BackendKind != SshBackendKind.Native)
+            {
+                return string.Empty;
+            }
+
+            // Capability outranks the global toggle on purpose: if native could not serve this shape
+            // even with the toggle on, "enable ExperimentalNativeSshEnabled" sends the user down a
+            // dead end. Name the real blocker first.
+            NativeSshCapabilityResult capability = NativeSshCapability.Evaluate(Forwards, JumpHops);
+            if (!capability.IsSupported)
+            {
+                return capability.Explanation;
+            }
+
+            return ExperimentalNativeSshEnabled
+                ? string.Empty
+                : "Native SSH is disabled globally. Enable ExperimentalNativeSshEnabled in settings or switch this profile back to OpenSSH.";
+        }
+    }
 
     public bool Validate()
     {
@@ -278,6 +304,21 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
         {
             ValidationError = "ControlPersist seconds cannot be negative.";
             return false;
+        }
+
+        // A native profile whose shape the native backend cannot serve is a profile that can never
+        // connect — it used to save fine and then fail at connect time with a NotSupportedException
+        // banner. Refuse the save instead, and say which of the two fixes applies. Note this is
+        // independent of ExperimentalNativeSshEnabled: saving a native profile while the toggle is off
+        // stays allowed (the toggle is reversible; the shape is not).
+        if (BackendKind == SshBackendKind.Native)
+        {
+            NativeSshCapabilityResult capability = NativeSshCapability.Evaluate(Forwards, JumpHops);
+            if (!capability.IsSupported)
+            {
+                ValidationError = capability.Explanation;
+                return false;
+            }
         }
 
         if (IsIdentityFileAuth && !string.IsNullOrWhiteSpace(IdentityFilePath))

--- a/src/NovaTerminal.App/native/rusty_ssh/Cargo.toml
+++ b/src/NovaTerminal.App/native/rusty_ssh/Cargo.toml
@@ -19,3 +19,9 @@ tokio = { version = "1.48.0", features = ["fs", "io-util", "net", "rt", "sync", 
 # Wipes credential buffers on drop. Already present transitively via russh/ring;
 # declared directly because this crate uses Zeroizing in its own auth paths.
 zeroize = "1.8"
+
+[dev-dependencies]
+# `macros` for #[tokio::test]; `test-util` for start_paused, which lets the forward-channel teardown
+# test advance past FORWARD_CHANNEL_DRAIN_TIMEOUT instantly instead of sleeping two real seconds.
+# Dev-only: neither feature reaches the cdylib the app loads.
+tokio = { version = "1.48.0", features = ["macros", "rt", "test-util", "time"] }

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -4892,6 +4892,15 @@ mod connect_arg_encoding_tests {
 mod forward_channel_queue_tests {
     use super::*;
 
+    /// Snapshot of what a recording channel's writer task has seen.
+    ///
+    /// Poison-tolerant, like every other lock in this file: the crate deliberately recovers the guard
+    /// rather than propagating a poisoned lock (see the ffi_guard work), so that one panicking thread
+    /// cannot turn every later acquisition into a second panic. A test is no reason to break that.
+    fn seen_labels(seen: &Arc<Mutex<Vec<&'static str>>>) -> Vec<&'static str> {
+        seen.lock().unwrap_or_else(|e| e.into_inner()).clone()
+    }
+
     /// A forward channel whose "writer task" just records what it received, in order.
     fn recording_channel() -> (
         ForwardChannelHandle,
@@ -4911,7 +4920,10 @@ mod forward_channel_queue_tests {
                     ForwardWrite::Eof => "eof",
                     ForwardWrite::Close => "close",
                 };
-                task_seen.lock().unwrap().push(label);
+                task_seen
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .push(label);
                 if label == "close" {
                     break;
                 }
@@ -4946,7 +4958,7 @@ mod forward_channel_queue_tests {
         close_forward_channel(&channels, 7).await;
 
         finished.notified().await;
-        assert_eq!(vec!["data", "data", "eof", "close"], *seen.lock().unwrap());
+        assert_eq!(vec!["data", "data", "eof", "close"], seen_labels(&seen));
     }
 
     #[tokio::test]
@@ -4961,7 +4973,7 @@ mod forward_channel_queue_tests {
         write_forward_channel(&channels, 9, vec![2]).await;
 
         finished.notified().await;
-        assert_eq!(vec!["data", "close"], *seen.lock().unwrap());
+        assert_eq!(vec!["data", "close"], seen_labels(&seen));
         assert!(channels.lock().await.is_empty());
     }
 
@@ -4991,7 +5003,7 @@ mod forward_channel_queue_tests {
         drop(removed.writes);
 
         let _ = tokio::time::timeout(Duration::from_secs(5), finished.notified()).await;
-        assert_eq!(vec!["data", "data"], *seen.lock().unwrap());
+        assert_eq!(vec!["data", "data"], seen_labels(&seen));
     }
 
     #[tokio::test]
@@ -5004,8 +5016,8 @@ mod forward_channel_queue_tests {
         close_all_forward_channels(&channels).await;
 
         assert!(channels.lock().await.is_empty());
-        assert_eq!(vec!["close"], *first_seen.lock().unwrap());
-        assert_eq!(vec!["close"], *second_seen.lock().unwrap());
+        assert_eq!(vec!["close"], seen_labels(&first_seen));
+        assert_eq!(vec!["close"], seen_labels(&second_seen));
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -11,7 +11,7 @@ use std::io::Cursor;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::{Component, Path, PathBuf};
 use std::ptr;
-use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex, OnceLock, mpsc as std_mpsc};
 use std::thread;
 use std::time::Duration;
@@ -102,6 +102,15 @@ pub const NOVA_SSH_RESULT_CHANNEL_OPEN_FAILED: c_int = -4;
 pub const NOVA_SSH_RESULT_NOT_IMPLEMENTED: c_int = -5;
 pub const NOVA_SSH_RESULT_CANCELED: c_int = -6;
 pub const NOVA_SSH_RESULT_PANIC: c_int = -7;
+/// A forward channel has more data queued toward the remote than its budget allows. Not an error:
+/// the caller is expected to retry, which is what applies backpressure to the local socket it is
+/// reading from. Only nova_ssh_channel_write returns this.
+pub const NOVA_SSH_RESULT_WOULD_BLOCK: c_int = -8;
+
+/// Per-forward-channel ceiling on bytes queued toward the remote, mirroring the managed side's
+/// budget for the opposite direction. Reaching it makes nova_ssh_channel_write report
+/// NOVA_SSH_RESULT_WOULD_BLOCK rather than growing the queue without limit.
+const MAX_QUEUED_FORWARD_WRITE_BYTES: usize = 1024 * 1024;
 
 /// Runs an FFI body, converting any panic into `on_panic` instead of unwinding
 /// across the C boundary (which is undefined behavior). The body is asserted
@@ -196,6 +205,10 @@ struct SharedState {
     // aborted promptly instead of blocking `worker.join()` (and, transitively,
     // the .NET finalizer thread) indefinitely. See #155.
     closed_notify: tokio::sync::Notify,
+    // Bytes queued toward the remote per forward channel, so nova_ssh_channel_write can answer
+    // "would this block?" without touching the async side. A std Mutex, not tokio's: the reader is
+    // an FFI thread with no runtime under it. See forward_write_budget.
+    forward_write_budgets: Mutex<HashMap<u32, Arc<AtomicUsize>>>,
 }
 
 struct QueuedEvent {
@@ -546,7 +559,35 @@ impl SharedState {
             response_cv: Condvar::new(),
             closed: Mutex::new(false),
             closed_notify: tokio::sync::Notify::new(),
+            forward_write_budgets: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// The queued-byte counter for one forward channel, or `None` if the channel is not (or no
+    /// longer) open. `None` means "do not throttle": an unknown id is either already torn down or was
+    /// never ours, and in both cases the write is a harmless no-op further down.
+    fn forward_write_budget(&self, channel_id: u32) -> Option<Arc<AtomicUsize>> {
+        self.forward_write_budgets
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(&channel_id)
+            .cloned()
+    }
+
+    fn register_forward_write_budget(&self, channel_id: u32, budget: Arc<AtomicUsize>) {
+        self.forward_write_budgets
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(channel_id, budget);
+    }
+
+    /// Dropping the counter is what unblocks a managed pump that is retrying against a channel which
+    /// has since closed: the next write finds no budget, is accepted, and no-ops.
+    fn unregister_forward_write_budget(&self, channel_id: u32) {
+        self.forward_write_budgets
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&channel_id);
     }
 
     fn is_closed(&self) -> bool {
@@ -945,13 +986,44 @@ pub extern "C" fn nova_ssh_channel_write(
             unsafe { std::slice::from_raw_parts(data, data_len) }.to_vec()
         };
 
-        send_command(
+        // Backpressure instead of unbounded queueing. Without this the caller can push data toward a
+        // remote that has stopped consuming it, and every payload accumulates in the per-channel
+        // writer queue until memory runs out. Reporting WOULD_BLOCK makes the caller stop reading its
+        // local socket, and TCP flow control throttles the local peer from there — no data is dropped
+        // and no channel is closed for being merely slow.
+        let budget = session.shared.forward_write_budget(channel_id);
+        if let Some(budget) = &budget {
+            // Check-then-add without a CAS loop: for a given channel only that channel's pump calls
+            // this, and the writer task only ever subtracts. So a concurrent release can make this
+            // admit a payload it would otherwise refuse — never the reverse.
+            let queued = budget.load(Ordering::Acquire);
+
+            // Always admit into an empty queue, even an oversized payload: refusing it forever would
+            // wedge a channel against a chunk nothing is actually blocking.
+            if queued > 0 && queued.saturating_add(bytes.len()) > MAX_QUEUED_FORWARD_WRITE_BYTES {
+                return NOVA_SSH_RESULT_WOULD_BLOCK;
+            }
+
+            budget.fetch_add(bytes.len(), Ordering::AcqRel);
+        }
+
+        let reserved = bytes.len();
+        let result = send_command(
             &session,
             WorkerCommand::WriteForwardChannel {
                 channel_id,
                 data: bytes,
             },
-        )
+        );
+
+        // Nothing will ever write these bytes, so nothing would ever release the reservation.
+        if result != NOVA_SSH_RESULT_OK {
+            if let Some(budget) = &budget {
+                budget.fetch_sub(reserved, Ordering::AcqRel);
+            }
+        }
+
+        result
     })
 }
 
@@ -3029,13 +3101,28 @@ async fn open_direct_tcpip_channel(
     // half directly, so a remote that stopped reading a forwarded connection stalled the loop — and
     // with it the shell channel's own reads and writes. Now the loop only queues, and blocking lives
     // here where it can only hold up this one channel.
+    // The queue stays unbounded; the bound is enforced at the FFI door instead, where the caller can
+    // be told to retry (see nova_ssh_channel_write). This counter is that bound's state.
+    let write_budget = Arc::new(AtomicUsize::new(0));
+    shared.register_forward_write_budget(channel_id, write_budget.clone());
+
     let (write_tx, mut write_rx) = mpsc::unbounded_channel::<ForwardWrite>();
+    let writer_budget = write_budget.clone();
+    let writer_shared = shared.clone();
     let writer_task = tokio::spawn(async move {
         // Ends when the sender is dropped (channel removed) after draining what is already queued.
         while let Some(write) = write_rx.recv().await {
             match write {
                 ForwardWrite::Data(data) => {
-                    if write_half.data(Cursor::new(data)).await.is_err() {
+                    let queued = data.len();
+                    let write_result = write_half.data(Cursor::new(data)).await;
+
+                    // Released whether or not the write succeeded: on failure the loop ends and the
+                    // budget goes away with the channel, but a stuck counter in between would make a
+                    // retrying caller spin against a channel that is already finished.
+                    writer_budget.fetch_sub(queued, Ordering::AcqRel);
+
+                    if write_result.is_err() {
                         break;
                     }
                 }
@@ -3050,6 +3137,12 @@ async fn open_direct_tcpip_channel(
                 }
             }
         }
+
+        // Every removal path ends this task — an explicit Close, a write failure, or the handle being
+        // dropped out of the map — so cleaning the budget up here covers all of them at once. It also
+        // has to happen: a leftover full counter would make a managed pump retry forever against a
+        // channel that no longer exists.
+        writer_shared.unregister_forward_write_budget(channel_id);
     });
 
     forward_channels.lock().await.insert(
@@ -4939,5 +5032,151 @@ mod forward_channel_queue_tests {
         close_all_forward_channels(&channels).await;
 
         assert!(channels.lock().await.is_empty());
+    }
+}
+
+/// Forward-write backpressure (Codex review on #325).
+///
+/// The per-channel writer queue is unbounded by design; the bound lives at the FFI door, where the
+/// caller can be told to retry. Retrying is what stops it reading its local socket, which is the only
+/// mechanism that throttles the local peer without dropping bytes or closing a merely-slow channel.
+#[cfg(test)]
+mod forward_write_backpressure_tests {
+    use super::*;
+
+    /// A registered session whose command channel accepts sends, plus a budget for `channel_id`.
+    ///
+    /// The receiver comes back with it and must stay bound for the test's duration: dropping it closes
+    /// the channel, and every send then fails with CLOSED instead of exercising the budget.
+    fn session_with_budget(
+        channel_id: u32,
+    ) -> (
+        usize,
+        Arc<AtomicUsize>,
+        Arc<SharedState>,
+        mpsc::UnboundedReceiver<WorkerCommand>,
+    ) {
+        let shared = Arc::new(SharedState::new());
+        let (command_tx, command_rx) = mpsc::unbounded_channel();
+
+        let budget = Arc::new(AtomicUsize::new(0));
+        shared.register_forward_write_budget(channel_id, budget.clone());
+
+        let handle = registry_insert(NovaSshSession {
+            shared: shared.clone(),
+            command_tx: Mutex::new(Some(command_tx)),
+            worker: Mutex::new(None),
+        }) as usize;
+
+        (handle, budget, shared, command_rx)
+    }
+
+    fn write(handle: usize, channel_id: u32, len: usize) -> c_int {
+        let data = vec![7u8; len];
+        nova_ssh_channel_write(handle, channel_id, data.as_ptr(), data.len())
+    }
+
+    #[test]
+    fn writes_within_the_budget_are_accepted_and_reserve_their_bytes() {
+        let (handle, budget, _shared, _command_rx) = session_with_budget(1);
+
+        assert_eq!(NOVA_SSH_RESULT_OK, write(handle, 1, 4096));
+        assert_eq!(4096, budget.load(Ordering::Acquire));
+
+        assert_eq!(NOVA_SSH_RESULT_OK, write(handle, 1, 1024));
+        assert_eq!(5120, budget.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn a_write_past_the_budget_reports_would_block_and_reserves_nothing() {
+        let (handle, budget, _shared, _command_rx) = session_with_budget(2);
+
+        // Fill the budget exactly, then ask for one more byte.
+        assert_eq!(
+            NOVA_SSH_RESULT_OK,
+            write(handle, 2, MAX_QUEUED_FORWARD_WRITE_BYTES)
+        );
+        assert_eq!(
+            MAX_QUEUED_FORWARD_WRITE_BYTES,
+            budget.load(Ordering::Acquire)
+        );
+
+        assert_eq!(NOVA_SSH_RESULT_WOULD_BLOCK, write(handle, 2, 1));
+
+        // The refused payload must not have been counted, or the queue would never recover.
+        assert_eq!(
+            MAX_QUEUED_FORWARD_WRITE_BYTES,
+            budget.load(Ordering::Acquire)
+        );
+    }
+
+    #[test]
+    fn an_oversized_payload_is_admitted_into_an_empty_queue() {
+        // Refusing it would wedge the channel: nothing is draining, so the queue can never get
+        // emptier than empty, and the caller would retry forever.
+        let (handle, budget, _shared, _command_rx) = session_with_budget(3);
+
+        let oversized = MAX_QUEUED_FORWARD_WRITE_BYTES * 2;
+        assert_eq!(NOVA_SSH_RESULT_OK, write(handle, 3, oversized));
+        assert_eq!(oversized, budget.load(Ordering::Acquire));
+
+        // But it does not become a licence for the next one.
+        assert_eq!(NOVA_SSH_RESULT_WOULD_BLOCK, write(handle, 3, 1));
+    }
+
+    #[test]
+    fn releasing_budget_lets_a_refused_write_through_on_retry() {
+        let (handle, budget, _shared, _command_rx) = session_with_budget(4);
+
+        assert_eq!(
+            NOVA_SSH_RESULT_OK,
+            write(handle, 4, MAX_QUEUED_FORWARD_WRITE_BYTES)
+        );
+        assert_eq!(NOVA_SSH_RESULT_WOULD_BLOCK, write(handle, 4, 64));
+
+        // What the writer task does once a write reaches the remote.
+        budget.fetch_sub(MAX_QUEUED_FORWARD_WRITE_BYTES, Ordering::AcqRel);
+
+        assert_eq!(NOVA_SSH_RESULT_OK, write(handle, 4, 64));
+        assert_eq!(64, budget.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn a_channel_with_no_budget_is_never_throttled() {
+        // An id the session does not know is either already torn down or never ours. Throttling it
+        // would leave a managed pump retrying against a channel that will never drain.
+        let (handle, _budget, shared, _command_rx) = session_with_budget(5);
+
+        assert_eq!(NOVA_SSH_RESULT_OK, write(handle, 99, 8));
+
+        // Same once a known channel's budget is unregistered, which is how teardown releases a
+        // caller that is mid-retry.
+        assert_eq!(
+            NOVA_SSH_RESULT_OK,
+            write(handle, 5, MAX_QUEUED_FORWARD_WRITE_BYTES)
+        );
+        assert_eq!(NOVA_SSH_RESULT_WOULD_BLOCK, write(handle, 5, 1));
+
+        shared.unregister_forward_write_budget(5);
+        assert_eq!(NOVA_SSH_RESULT_OK, write(handle, 5, 1));
+    }
+
+    #[test]
+    fn a_write_that_cannot_be_queued_releases_its_reservation() {
+        // send_command fails once the session is closed. If the reservation survived that, the budget
+        // would be permanently short by the size of a payload nothing will ever write.
+        let shared = Arc::new(SharedState::new());
+        let budget = Arc::new(AtomicUsize::new(0));
+        shared.register_forward_write_budget(6, budget.clone());
+
+        let handle = registry_insert(NovaSshSession {
+            shared: shared.clone(),
+            // No sender: stands in for a session whose worker has gone.
+            command_tx: Mutex::new(None),
+            worker: Mutex::new(None),
+        }) as usize;
+
+        assert_eq!(NOVA_SSH_RESULT_CLOSED, write(handle, 6, 2048));
+        assert_eq!(0, budget.load(Ordering::Acquire));
     }
 }

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -205,6 +205,23 @@ struct QueuedEvent {
     flags: u32,
 }
 
+/// One item for a forward channel's writer task, in the order the managed side asked for it.
+enum ForwardWrite {
+    Data(Vec<u8>),
+    Eof,
+    Close,
+}
+
+/// A live forward channel, represented by a queue into its writer task rather than by the channel's
+/// write half. The write half is owned by that task alone; nothing else can `await` it, which is what
+/// keeps a stalled forward from freezing the session worker's select loop.
+struct ForwardChannelHandle {
+    writes: mpsc::UnboundedSender<ForwardWrite>,
+    writer_task: tokio::task::JoinHandle<()>,
+}
+
+type ForwardChannels = Arc<tokio::sync::Mutex<HashMap<u32, ForwardChannelHandle>>>;
+
 /// A queued event's shape, without its payload. Lets the FFI report `payload_len` so the caller can
 /// size a buffer, without copying anything (#173 item 1).
 #[derive(Clone, Copy)]
@@ -2676,6 +2693,9 @@ fn join_remote_path(base: &str, child: &str) -> String {
 /// instead of a wall-clock timeout.
 const TCP_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// How long session teardown waits for forward-channel writer tasks to flush their close.
+const FORWARD_CHANNEL_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
+
 async fn connect_tcp_with_timeout(host: &str, port: u16) -> anyhow::Result<tokio::net::TcpStream> {
     match tokio::time::timeout(
         TCP_CONNECT_TIMEOUT,
@@ -2875,17 +2895,21 @@ fn run_session(
                             .await;
                             let _ = reply.send(result);
                         }
+                        // These three only queue onto the target channel's writer task. They used to
+                        // `await` the write half here and propagate with `?`, which meant a single
+                        // failed forward-channel write tore down the entire session — terminal
+                        // included. A forward channel can now only take itself down.
                         Some(WorkerCommand::WriteForwardChannel { channel_id, data }) => {
-                            write_forward_channel(forward_channels.clone(), channel_id, data).await?;
+                            write_forward_channel(&forward_channels, channel_id, data).await;
                         }
                         Some(WorkerCommand::ForwardChannelEof { channel_id }) => {
-                            send_forward_channel_eof(forward_channels.clone(), channel_id).await?;
+                            send_forward_channel_eof(&forward_channels, channel_id).await;
                         }
                         Some(WorkerCommand::CloseForwardChannel { channel_id }) => {
-                            close_forward_channel(forward_channels.clone(), channel_id).await?;
+                            close_forward_channel(&forward_channels, channel_id).await;
                         }
                         Some(WorkerCommand::Close) | None => {
-                            close_all_forward_channels(forward_channels.clone()).await;
+                            close_all_forward_channels(&forward_channels).await;
                             let _ = channel.eof().await;
                             let _ = channel.close().await;
                             break;
@@ -2982,9 +3006,7 @@ fn coalesce_pending_resize_commands(
 
 async fn open_direct_tcpip_channel(
     session: &client::Handle<NovaClientHandler>,
-    forward_channels: Arc<
-        tokio::sync::Mutex<HashMap<u32, Arc<russh::ChannelWriteHalf<client::Msg>>>>,
-    >,
+    forward_channels: ForwardChannels,
     shared: Arc<SharedState>,
     host_to_connect: String,
     port_to_connect: u32,
@@ -3002,10 +3024,41 @@ async fn open_direct_tcpip_channel(
 
     let channel_id = u32::from(channel.id());
     let (mut read_half, write_half) = channel.split();
-    forward_channels
-        .lock()
-        .await
-        .insert(channel_id, Arc::new(write_half));
+
+    // Writer task per forward channel. The session worker's select loop used to `await` the write
+    // half directly, so a remote that stopped reading a forwarded connection stalled the loop — and
+    // with it the shell channel's own reads and writes. Now the loop only queues, and blocking lives
+    // here where it can only hold up this one channel.
+    let (write_tx, mut write_rx) = mpsc::unbounded_channel::<ForwardWrite>();
+    let writer_task = tokio::spawn(async move {
+        // Ends when the sender is dropped (channel removed) after draining what is already queued.
+        while let Some(write) = write_rx.recv().await {
+            match write {
+                ForwardWrite::Data(data) => {
+                    if write_half.data(Cursor::new(data)).await.is_err() {
+                        break;
+                    }
+                }
+                ForwardWrite::Eof => {
+                    if write_half.eof().await.is_err() {
+                        break;
+                    }
+                }
+                ForwardWrite::Close => {
+                    let _ = write_half.close().await;
+                    break;
+                }
+            }
+        }
+    });
+
+    forward_channels.lock().await.insert(
+        channel_id,
+        ForwardChannelHandle {
+            writes: write_tx,
+            writer_task,
+        },
+    );
 
     let reader_shared = shared.clone();
     let reader_channels = forward_channels.clone();
@@ -3054,73 +3107,69 @@ async fn open_direct_tcpip_channel(
     Ok(channel_id)
 }
 
-async fn write_forward_channel(
-    forward_channels: Arc<
-        tokio::sync::Mutex<HashMap<u32, Arc<russh::ChannelWriteHalf<client::Msg>>>>,
-    >,
+/// Queues one item for a forward channel's writer task. Only ever awaits the map lock, never the
+/// network, so callers on the session worker's select loop cannot be stalled by a slow peer.
+async fn queue_forward_write(
+    forward_channels: &ForwardChannels,
     channel_id: u32,
-    data: Vec<u8>,
-) -> anyhow::Result<()> {
-    let writer = {
-        let channels = forward_channels.lock().await;
-        channels.get(&channel_id).cloned()
-    };
-
-    if let Some(writer) = writer {
-        writer.data(Cursor::new(data)).await?;
-    }
-
-    Ok(())
-}
-
-async fn send_forward_channel_eof(
-    forward_channels: Arc<
-        tokio::sync::Mutex<HashMap<u32, Arc<russh::ChannelWriteHalf<client::Msg>>>>,
-    >,
-    channel_id: u32,
-) -> anyhow::Result<()> {
-    let writer = {
-        let channels = forward_channels.lock().await;
-        channels.get(&channel_id).cloned()
-    };
-
-    if let Some(writer) = writer {
-        writer.eof().await?;
-    }
-
-    Ok(())
-}
-
-async fn close_forward_channel(
-    forward_channels: Arc<
-        tokio::sync::Mutex<HashMap<u32, Arc<russh::ChannelWriteHalf<client::Msg>>>>,
-    >,
-    channel_id: u32,
-) -> anyhow::Result<()> {
-    let writer = forward_channels.lock().await.remove(&channel_id);
-    if let Some(writer) = writer {
-        writer.close().await?;
-    }
-
-    Ok(())
-}
-
-async fn close_all_forward_channels(
-    forward_channels: Arc<
-        tokio::sync::Mutex<HashMap<u32, Arc<russh::ChannelWriteHalf<client::Msg>>>>,
-    >,
+    write: ForwardWrite,
 ) {
-    let writers = {
+    let sender = {
+        let channels = forward_channels.lock().await;
+        channels
+            .get(&channel_id)
+            .map(|handle| handle.writes.clone())
+    };
+
+    if let Some(sender) = sender {
+        // A send error means the writer task already ended (the channel died under us); the
+        // subsequent ForwardChannelClosed event is what the managed side acts on.
+        let _ = sender.send(write);
+    }
+}
+
+async fn write_forward_channel(forward_channels: &ForwardChannels, channel_id: u32, data: Vec<u8>) {
+    queue_forward_write(forward_channels, channel_id, ForwardWrite::Data(data)).await;
+}
+
+async fn send_forward_channel_eof(forward_channels: &ForwardChannels, channel_id: u32) {
+    queue_forward_write(forward_channels, channel_id, ForwardWrite::Eof).await;
+}
+
+async fn close_forward_channel(forward_channels: &ForwardChannels, channel_id: u32) {
+    // Removed from the map first so nothing can be queued behind the close, but the close itself is
+    // handed to the writer task so it lands *after* the data already queued ahead of it. Closing the
+    // write half here directly would truncate whatever was still in flight.
+    let handle = forward_channels.lock().await.remove(&channel_id);
+    if let Some(handle) = handle {
+        let _ = handle.writes.send(ForwardWrite::Close);
+    }
+}
+
+async fn close_all_forward_channels(forward_channels: &ForwardChannels) {
+    let handles = {
         let mut channels = forward_channels.lock().await;
         channels
             .drain()
-            .map(|(_, writer)| writer)
+            .map(|(_, handle)| handle)
             .collect::<Vec<_>>()
     };
 
-    for writer in writers {
-        let _ = writer.close().await;
+    let mut writer_tasks = Vec::with_capacity(handles.len());
+    for handle in handles {
+        let _ = handle.writes.send(ForwardWrite::Close);
+        writer_tasks.push(handle.writer_task);
     }
+
+    // Give the writer tasks a bounded chance to flush their close. Bounded because a task blocked
+    // writing to a remote that has stopped reading would otherwise hang session teardown, which is
+    // reached from nova_ssh_close and must not block the .NET finalizer thread (#155).
+    let drain = async {
+        for writer_task in writer_tasks {
+            let _ = writer_task.await;
+        }
+    };
+    let _ = tokio::time::timeout(FORWARD_CHANNEL_DRAIN_TIMEOUT, drain).await;
 }
 
 async fn authenticate(
@@ -4737,5 +4786,158 @@ mod connect_arg_encoding_tests {
 
         assert!(config.identity_file.is_none());
         assert_eq!("xterm-256color", config.term);
+    }
+}
+
+/// Forward-channel write queueing (#173 item 2).
+///
+/// These exercise the queue in front of a forward channel's writer task, which is the part that keeps
+/// a stalled forward off the session worker's select loop. The writer task itself owns a russh
+/// `ChannelWriteHalf` that cannot be fabricated without a live server, so the tests stand in their own
+/// task behind an identical sender — the queueing, ordering and teardown rules are what they pin.
+#[cfg(test)]
+mod forward_channel_queue_tests {
+    use super::*;
+
+    /// A forward channel whose "writer task" just records what it received, in order.
+    fn recording_channel() -> (
+        ForwardChannelHandle,
+        Arc<Mutex<Vec<&'static str>>>,
+        Arc<tokio::sync::Notify>,
+    ) {
+        let (writes, mut write_rx) = mpsc::unbounded_channel::<ForwardWrite>();
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let finished = Arc::new(tokio::sync::Notify::new());
+
+        let task_seen = seen.clone();
+        let task_finished = finished.clone();
+        let writer_task = tokio::spawn(async move {
+            while let Some(write) = write_rx.recv().await {
+                let label = match write {
+                    ForwardWrite::Data(_) => "data",
+                    ForwardWrite::Eof => "eof",
+                    ForwardWrite::Close => "close",
+                };
+                task_seen.lock().unwrap().push(label);
+                if label == "close" {
+                    break;
+                }
+            }
+            task_finished.notify_waiters();
+        });
+
+        (
+            ForwardChannelHandle {
+                writes,
+                writer_task,
+            },
+            seen,
+            finished,
+        )
+    }
+
+    async fn channels_with(channel_id: u32, handle: ForwardChannelHandle) -> ForwardChannels {
+        let channels: ForwardChannels = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        channels.lock().await.insert(channel_id, handle);
+        channels
+    }
+
+    #[tokio::test]
+    async fn writes_eof_and_close_reach_the_writer_in_order() {
+        let (handle, seen, finished) = recording_channel();
+        let channels = channels_with(7, handle).await;
+
+        write_forward_channel(&channels, 7, vec![1, 2, 3]).await;
+        write_forward_channel(&channels, 7, vec![4]).await;
+        send_forward_channel_eof(&channels, 7).await;
+        close_forward_channel(&channels, 7).await;
+
+        finished.notified().await;
+        assert_eq!(vec!["data", "data", "eof", "close"], *seen.lock().unwrap());
+    }
+
+    #[tokio::test]
+    async fn close_removes_the_channel_so_later_writes_are_dropped_not_reordered() {
+        let (handle, seen, finished) = recording_channel();
+        let channels = channels_with(9, handle).await;
+
+        write_forward_channel(&channels, 9, vec![1]).await;
+        close_forward_channel(&channels, 9).await;
+        // Arrives after the close was queued: it must not slip in front of it, and must not resurrect
+        // the channel either.
+        write_forward_channel(&channels, 9, vec![2]).await;
+
+        finished.notified().await;
+        assert_eq!(vec!["data", "close"], *seen.lock().unwrap());
+        assert!(channels.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn writes_to_an_unknown_channel_are_ignored() {
+        let channels: ForwardChannels = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+
+        // No channel 42: the managed side can legitimately still be draining events for a channel the
+        // reader task already removed. Must be a no-op, not a panic.
+        write_forward_channel(&channels, 42, vec![1]).await;
+        send_forward_channel_eof(&channels, 42).await;
+        close_forward_channel(&channels, 42).await;
+
+        assert!(channels.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn dropping_the_handle_still_delivers_what_was_already_queued() {
+        // Removing a channel drops its sender. Anything queued before that must still reach the writer
+        // rather than being discarded mid-stream.
+        let (handle, seen, finished) = recording_channel();
+        let channels = channels_with(11, handle).await;
+
+        write_forward_channel(&channels, 11, vec![1]).await;
+        write_forward_channel(&channels, 11, vec![2]).await;
+        let removed = channels.lock().await.remove(&11).expect("channel present");
+        drop(removed.writes);
+
+        let _ = tokio::time::timeout(Duration::from_secs(5), finished.notified()).await;
+        assert_eq!(vec!["data", "data"], *seen.lock().unwrap());
+    }
+
+    #[tokio::test]
+    async fn close_all_drains_every_channel() {
+        let (first, first_seen, _first_done) = recording_channel();
+        let (second, second_seen, _second_done) = recording_channel();
+        let channels = channels_with(1, first).await;
+        channels.lock().await.insert(2, second);
+
+        close_all_forward_channels(&channels).await;
+
+        assert!(channels.lock().await.is_empty());
+        assert_eq!(vec!["close"], *first_seen.lock().unwrap());
+        assert_eq!(vec!["close"], *second_seen.lock().unwrap());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn close_all_gives_up_on_a_writer_that_never_finishes() {
+        // Teardown is reached from nova_ssh_close, so it must not wait on a writer task blocked
+        // against a remote that stopped reading (#155). The map is still emptied.
+        let (writes, mut write_rx) = mpsc::unbounded_channel::<ForwardWrite>();
+        let writer_task = tokio::spawn(async move {
+            // Takes the close but never returns, standing in for a blocked network write.
+            let _ = write_rx.recv().await;
+            std::future::pending::<()>().await;
+        });
+        let channels = channels_with(
+            3,
+            ForwardChannelHandle {
+                writes,
+                writer_task,
+            },
+        )
+        .await;
+
+        // start_paused auto-advances time when nothing is runnable, so the drain timeout elapses
+        // instantly rather than costing two real seconds.
+        close_all_forward_channels(&channels).await;
+
+        assert!(channels.lock().await.is_empty());
     }
 }

--- a/src/NovaTerminal.Platform/Ssh/Native/INativeSshInterop.cs
+++ b/src/NovaTerminal.Platform/Ssh/Native/INativeSshInterop.cs
@@ -19,6 +19,24 @@ public interface INativeSshInterop
     void Resize(NovaSshSafeHandle sessionHandle, int cols, int rows);
     int OpenDirectTcpIp(NovaSshSafeHandle sessionHandle, NativePortForwardOpenOptions options);
     void WriteChannel(NovaSshSafeHandle sessionHandle, int channelId, ReadOnlySpan<byte> data);
+
+    /// <summary>
+    /// Queues forward-channel data toward the remote, reporting whether it was accepted.
+    /// <see langword="false"/> means the channel already has more queued than its budget allows: not
+    /// an error, and nothing was consumed. The caller should retry, which is what stops it reading its
+    /// local socket and lets TCP flow control throttle the local peer — the alternative to either
+    /// growing the queue without limit or closing a channel for being merely slow.
+    /// </summary>
+    /// <remarks>
+    /// Default implementation delegates to <see cref="WriteChannel"/> and reports acceptance, so an
+    /// interop that has no queue of its own (test doubles, in-memory fakes) needs no changes. Only the
+    /// real FFI can answer this meaningfully, and only it overrides.
+    /// </remarks>
+    bool TryWriteChannel(NovaSshSafeHandle sessionHandle, int channelId, ReadOnlySpan<byte> data)
+    {
+        WriteChannel(sessionHandle, channelId, data);
+        return true;
+    }
     void SendChannelEof(NovaSshSafeHandle sessionHandle, int channelId);
     void CloseChannel(NovaSshSafeHandle sessionHandle, int channelId);
     void SubmitResponse(NovaSshSafeHandle sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data);

--- a/src/NovaTerminal.Platform/Ssh/Native/JumpHostConnectPlan.cs
+++ b/src/NovaTerminal.Platform/Ssh/Native/JumpHostConnectPlan.cs
@@ -18,9 +18,12 @@ public sealed class JumpHostConnectPlan
     {
         ArgumentNullException.ThrowIfNull(profile);
 
-        if (profile.JumpHops.Count > 1)
+        // Defence in depth: NativeSshSession already refused this shape via NativeSshCapability, but
+        // the plan is constructible on its own. Share the wording so the two cannot drift.
+        NativeSshCapabilityResult capability = NativeSshCapability.Evaluate(profile);
+        if (capability.Reason == NativeSshUnsupportedReason.MultipleJumpHops)
         {
-            throw new NotSupportedException("Multiple jump hops are not supported by the native SSH backend yet.");
+            throw new NotSupportedException(capability.Explanation);
         }
 
         return new JumpHostConnectPlan

--- a/src/NovaTerminal.Platform/Ssh/Native/NativePortForwardSession.cs
+++ b/src/NovaTerminal.Platform/Ssh/Native/NativePortForwardSession.cs
@@ -236,8 +236,11 @@ public sealed class NativePortForwardSession : IDisposable
                     continue;
                 }
 
-                _ = Task.Run(() => PumpClientToSshAsync(state, cancellationToken));
-                _ = Task.Run(() => PumpSshToClientAsync(state, cancellationToken));
+                // Token passed to Task.Run as well as into the pump: once the session is being torn
+                // down there is no reason to schedule a pump at all, and it matches what the dynamic
+                // accept path already does for the same two calls.
+                _ = Task.Run(() => PumpClientToSshAsync(state, cancellationToken), cancellationToken);
+                _ = Task.Run(() => PumpSshToClientAsync(state, cancellationToken), cancellationToken);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {

--- a/src/NovaTerminal.Platform/Ssh/Native/NativePortForwardSession.cs
+++ b/src/NovaTerminal.Platform/Ssh/Native/NativePortForwardSession.cs
@@ -16,6 +16,13 @@ public sealed class NativePortForwardSession : IDisposable
     /// </summary>
     private const int MaxQueuedOutboundBytesPerChannel = 1024 * 1024;
 
+    /// <summary>
+    /// How long to wait before retrying a forward-channel write the native side refused for want of
+    /// queue space. Polling because the FFI has no completion signal to await; short enough that it
+    /// costs throughput only while a forward is genuinely backed up.
+    /// </summary>
+    private static readonly TimeSpan ForwardWriteRetryDelay = TimeSpan.FromMilliseconds(5);
+
     private const byte SocksVersion5 = 0x05;
     private const byte SocksCommandConnect = 0x01;
     private const byte SocksAuthNoAuthentication = 0x00;
@@ -445,7 +452,15 @@ public sealed class NativePortForwardSession : IDisposable
                     break;
                 }
 
-                _interop.WriteChannel(_sessionHandle, channel.ChannelId, buffer.AsSpan(0, bytesRead));
+                // Retry rather than force the write through. A refusal means the native side already
+                // has more queued toward the remote than its budget allows, so the right response is
+                // to stop reading this socket — which is exactly what looping here does, and which
+                // lets TCP flow control throttle the local peer. Neither bytes nor the channel are
+                // sacrificed for a remote that is merely slow.
+                while (!_interop.TryWriteChannel(_sessionHandle, channel.ChannelId, buffer.AsSpan(0, bytesRead)))
+                {
+                    await Task.Delay(ForwardWriteRetryDelay, cancellationToken).ConfigureAwait(false);
+                }
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/src/NovaTerminal.Platform/Ssh/Native/NativePortForwardSession.cs
+++ b/src/NovaTerminal.Platform/Ssh/Native/NativePortForwardSession.cs
@@ -2,12 +2,20 @@ using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
+using System.Threading.Channels;
 using NovaTerminal.Platform.Ssh.Models;
 
 namespace NovaTerminal.Platform.Ssh.Native;
 
 public sealed class NativePortForwardSession : IDisposable
 {
+    /// <summary>
+    /// Per-channel ceiling on bytes waiting to reach the local socket. Exceeding it closes that one
+    /// forward channel — see <see cref="EnqueueOutbound"/> for why neither waiting nor dropping is an
+    /// option. Sized so a stalled channel costs about a megabyte rather than the whole stream.
+    /// </summary>
+    private const int MaxQueuedOutboundBytesPerChannel = 1024 * 1024;
+
     private const byte SocksVersion5 = 0x05;
     private const byte SocksCommandConnect = 0x01;
     private const byte SocksAuthNoAuthentication = 0x00;
@@ -58,15 +66,19 @@ public sealed class NativePortForwardSession : IDisposable
         _log = log ?? (_ => { });
         _socksReplyWriter = socksReplyWriter ?? throw new ArgumentNullException(nameof(socksReplyWriter));
 
+        // Checked up front rather than per-forward inside the loop: an unsupported kind is a property
+        // of the profile, not of a bind, so there is no reason to open listeners we are about to tear
+        // down again. Wording comes from NativeSshCapability so it matches what the editor showed.
+        NativeSshCapabilityResult capability = NativeSshCapability.Evaluate(forwards, jumpHops: null);
+        if (!capability.IsSupported)
+        {
+            throw new NotSupportedException(capability.Explanation);
+        }
+
         try
         {
             foreach (PortForward forward in forwards)
             {
-                if (forward.Kind is not PortForwardKind.Local and not PortForwardKind.Dynamic)
-                {
-                    throw new NotSupportedException("Native SSH currently supports local and dynamic port forwards only.");
-                }
-
                 StartListener(forward);
             }
         }
@@ -77,6 +89,13 @@ public sealed class NativePortForwardSession : IDisposable
         }
     }
 
+    /// <summary>
+    /// Hands a forward-channel event to the owning channel's outbound queue. Called from
+    /// <c>NativeSshSession.PollLoopAsync</c>, so it must never block: this used to write straight to
+    /// the local socket, which meant one slow consumer of a forwarded port froze *all* terminal output
+    /// for the session until it drained (#173 item 2). Enqueueing keeps the poll loop moving and lets
+    /// a dedicated pump per channel absorb the blocking write.
+    /// </summary>
     public void HandleEvent(NativeSshEvent nextEvent)
     {
         if (nextEvent == null)
@@ -89,26 +108,45 @@ public sealed class NativePortForwardSession : IDisposable
             return;
         }
 
-        try
+        // EOF and close travel through the same queue as the data rather than acting immediately.
+        // Ordering is the whole point: shutting the send side down (or disposing the socket) while
+        // bytes were still queued behind it would truncate the proxied stream.
+        switch (nextEvent.Kind)
         {
-            switch (nextEvent.Kind)
-            {
-                case NativeSshEventKind.ForwardChannelData:
-                    channel.Stream.Write(nextEvent.Payload, 0, nextEvent.Payload.Length);
-                    break;
-                case NativeSshEventKind.ForwardChannelEof:
-                    TryShutdown(channel.Client, SocketShutdown.Send);
-                    break;
-                case NativeSshEventKind.ForwardChannelClosed:
-                    RemoveChannel(channel.ChannelId, closeInteropChannel: false);
-                    break;
-            }
+            case NativeSshEventKind.ForwardChannelData:
+                EnqueueOutbound(channel, new ForwardOutbound(ForwardOutboundKind.Data, nextEvent.Payload));
+                break;
+            case NativeSshEventKind.ForwardChannelEof:
+                EnqueueOutbound(channel, new ForwardOutbound(ForwardOutboundKind.Eof, []));
+                break;
+            case NativeSshEventKind.ForwardChannelClosed:
+                EnqueueOutbound(channel, new ForwardOutbound(ForwardOutboundKind.Closed, []));
+                break;
         }
-        catch (Exception ex)
+    }
+
+    private void EnqueueOutbound(ForwardChannelState channel, ForwardOutbound item)
+    {
+        if (channel.TryEnqueueOutbound(item, MaxQueuedOutboundBytesPerChannel))
         {
-            _log($"[NativePortForwardSession] Forward channel {channel.ChannelId} failed: {ex.Message}");
-            RemoveChannel(channel.ChannelId, closeInteropChannel: true);
+            return;
         }
+
+        // Two ways to land here: the queue is over budget, or teardown completed it between the
+        // lookup and the write. Both end with the channel gone, but only the first is a real event —
+        // RemoveChannel drops the channel from _channels before completing the queue, so a still-
+        // present channel means genuine overflow.
+        //
+        // Closing the channel is the only honest response to overflow: waiting would reintroduce the
+        // poll-loop stall this queue exists to remove, and discarding bytes mid-stream would silently
+        // corrupt what is, from the peer's view, a plain TCP connection. A dead forward is
+        // diagnosable; a corrupted one is not.
+        if (_channels.ContainsKey(channel.ChannelId))
+        {
+            _log($"[NativePortForwardSession] Forward channel {channel.ChannelId} exceeded its {MaxQueuedOutboundBytesPerChannel}-byte outbound budget ({channel.QueuedOutboundBytes} queued); closing it.");
+        }
+
+        RemoveChannel(channel.ChannelId, closeInteropChannel: true);
     }
 
     public void Dispose()
@@ -158,7 +196,8 @@ public sealed class NativePortForwardSession : IDisposable
         {
             PortForwardKind.Local => Task.Run(() => AcceptLocalLoopAsync(listener, forward, _lifetimeCts.Token)),
             PortForwardKind.Dynamic => Task.Run(() => AcceptDynamicLoopAsync(listener, forward, _lifetimeCts.Token)),
-            _ => throw new NotSupportedException("Native SSH currently supports local and dynamic port forwards only.")
+            _ => throw new NotSupportedException(
+                NativeSshCapability.Evaluate([forward], jumpHops: null).Explanation)
         };
     }
 
@@ -191,6 +230,7 @@ public sealed class NativePortForwardSession : IDisposable
                 }
 
                 _ = Task.Run(() => PumpClientToSshAsync(state, cancellationToken));
+                _ = Task.Run(() => PumpSshToClientAsync(state, cancellationToken));
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -304,6 +344,7 @@ public sealed class NativePortForwardSession : IDisposable
             }
 
             _ = Task.Run(() => PumpClientToSshAsync(state, cancellationToken), cancellationToken);
+            _ = Task.Run(() => PumpSshToClientAsync(state, cancellationToken), cancellationToken);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -335,6 +376,58 @@ public sealed class NativePortForwardSession : IDisposable
         {
             _log($"[NativePortForwardSession] Dynamic client setup for {forward} failed: {ex.Message}");
             client.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Drains one channel's outbound queue into its local socket. Runs on its own task so a blocking
+    /// write here cannot reach the SSH poll loop; the queue in front of it is what makes that safe.
+    /// </summary>
+    private async Task PumpSshToClientAsync(ForwardChannelState channel, CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (await channel.Outbound.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                while (channel.Outbound.Reader.TryRead(out ForwardOutbound item))
+                {
+                    if (item.Kind == ForwardOutboundKind.Data)
+                    {
+                        await channel.Stream.WriteAsync(item.Payload, cancellationToken).ConfigureAwait(false);
+                        channel.OnOutboundWritten(item.Payload.Length);
+                        continue;
+                    }
+
+                    // Everything queued ahead of this marker has now been written.
+                    await channel.Stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+                    if (item.Kind == ForwardOutboundKind.Eof)
+                    {
+                        TryShutdown(channel.Client, SocketShutdown.Send);
+                        continue;
+                    }
+
+                    // Closed: the remote end is gone and the local socket has seen everything it was
+                    // owed. closeInteropChannel: false — the SSH channel closed on its own.
+                    RemoveChannel(channel.ChannelId, closeInteropChannel: false);
+                    return;
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Dispose() is tearing every channel down already.
+        }
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException or SocketException)
+        {
+            // Local peer went away mid-write. Close the SSH side too, so the remote is not left
+            // holding a half-open channel.
+            RemoveChannel(channel.ChannelId, closeInteropChannel: true);
+        }
+        catch (Exception ex)
+        {
+            _log($"[NativePortForwardSession] Outbound pump for channel {channel.ChannelId} failed: {ex.Message}");
+            RemoveChannel(channel.ChannelId, closeInteropChannel: true);
         }
     }
 
@@ -387,6 +480,10 @@ public sealed class NativePortForwardSession : IDisposable
         {
             return;
         }
+
+        // Releases the outbound pump's WaitToReadAsync so the task ends instead of lingering until
+        // session teardown. Anything still queued is deliberately abandoned — the socket is going.
+        channel.CompleteOutbound();
 
         if (closeInteropChannel)
         {
@@ -552,17 +649,85 @@ public sealed class NativePortForwardSession : IDisposable
         public byte ReplyCode { get; }
     }
 
+    private enum ForwardOutboundKind
+    {
+        Data = 0,
+        Eof = 1,
+        Closed = 2
+    }
+
+    private readonly record struct ForwardOutbound(ForwardOutboundKind Kind, byte[] Payload);
+
     private sealed class ForwardChannelState
     {
+        private int _queuedOutboundBytes;
+
         public ForwardChannelState(int channelId, TcpClient client)
         {
             ChannelId = channelId;
             Client = client;
             Stream = client.GetStream();
+
+            // Unbounded channel with our own byte budget, rather than a bounded channel: the budget
+            // has to apply to data only. Eof/Closed markers must always be admittable, or a channel
+            // that hit its cap could never be told the stream ended — the same control-event carve-out
+            // the native event queue needs (#173 item 1).
+            Outbound = Channel.CreateUnbounded<ForwardOutbound>(new UnboundedChannelOptions
+            {
+                // Exactly one reader: this channel's outbound pump.
+                SingleReader = true
+
+                // SingleWriter deliberately left false. Writes only ever come from the poll loop, but
+                // CompleteOutbound is also a writer-side operation and is called from teardown on other
+                // threads (Dispose, the pump itself), so the single-writer guarantee would not hold.
+            });
         }
 
         public int ChannelId { get; }
         public TcpClient Client { get; }
         public NetworkStream Stream { get; }
+        public Channel<ForwardOutbound> Outbound { get; }
+
+        public int QueuedOutboundBytes => Volatile.Read(ref _queuedOutboundBytes);
+
+        public bool TryEnqueueOutbound(ForwardOutbound item, int maxQueuedBytes)
+        {
+            bool isData = item.Kind == ForwardOutboundKind.Data;
+
+            if (isData)
+            {
+                // Check-then-add without a CAS loop is safe here: HandleEvent is the only writer, and
+                // the reader only ever decreases the counter, so a concurrent decrement can make this
+                // admit a payload it would otherwise refuse — never the other way round.
+                int queued = Volatile.Read(ref _queuedOutboundBytes);
+
+                // Always admit into an empty queue, even an oversized payload: refusing it forever
+                // would kill a channel for a chunk that nothing is actually blocking.
+                if (queued > 0 && queued + item.Payload.Length > maxQueuedBytes)
+                {
+                    return false;
+                }
+
+                Interlocked.Add(ref _queuedOutboundBytes, item.Payload.Length);
+            }
+
+            if (Outbound.Writer.TryWrite(item))
+            {
+                return true;
+            }
+
+            // The queue was completed by teardown between the lookup and here.
+            if (isData)
+            {
+                Interlocked.Add(ref _queuedOutboundBytes, -item.Payload.Length);
+            }
+
+            return false;
+        }
+
+        public void OnOutboundWritten(int byteCount) =>
+            Interlocked.Add(ref _queuedOutboundBytes, -byteCount);
+
+        public void CompleteOutbound() => Outbound.Writer.TryComplete();
     }
 }

--- a/src/NovaTerminal.Platform/Ssh/Native/NativeSshCapability.cs
+++ b/src/NovaTerminal.Platform/Ssh/Native/NativeSshCapability.cs
@@ -1,0 +1,92 @@
+using NovaTerminal.Platform.Ssh.Models;
+
+namespace NovaTerminal.Platform.Ssh.Native;
+
+/// <summary>
+/// Why the native SSH backend cannot serve a profile, if it cannot.
+/// </summary>
+public enum NativeSshUnsupportedReason
+{
+    None = 0,
+
+    /// <summary>
+    /// The profile carries a remote (server-side listener) forward. The native backend has no
+    /// <c>tcpip-forward</c> support, so there is nothing to degrade to.
+    /// </summary>
+    RemotePortForward = 1,
+
+    /// <summary>
+    /// The profile chains more than one jump hop. The native backend nests exactly one
+    /// direct-tcpip hop today.
+    /// </summary>
+    MultipleJumpHops = 2
+}
+
+/// <summary>
+/// The verdict for one profile: supported, or unsupported with a user-facing explanation that
+/// names the fix.
+/// </summary>
+public readonly record struct NativeSshCapabilityResult(NativeSshUnsupportedReason Reason, string Explanation)
+{
+    public bool IsSupported => Reason == NativeSshUnsupportedReason.None;
+
+    public static NativeSshCapabilityResult Supported { get; } =
+        new(NativeSshUnsupportedReason.None, string.Empty);
+
+    public static NativeSshCapabilityResult Unsupported(NativeSshUnsupportedReason reason, string explanation) =>
+        new(reason, explanation);
+}
+
+/// <summary>
+/// Single source of truth for "can the native SSH backend serve this profile?".
+///
+/// The answer used to be spelled out in three places that could drift apart — the session
+/// constructor, the jump-host plan, and the port-forward session — each throwing its own wording,
+/// and none of them reachable before a connect was already underway. Concentrating it here lets the
+/// profile editor refuse to save a native profile that could never connect, and lets a caller ask
+/// the question without constructing a session.
+///
+/// Deliberately NOT a fallback mechanism. A profile explicitly set to <see cref="SshBackendKind.Native"/>
+/// still fails loudly when native cannot serve it (see
+/// <c>docs/plans/2026-03-31-native-ssh-rollout-controls-design.md</c>); this type only makes the
+/// refusal early and uniform. Routing a profile that has expressed no preference is a separate
+/// question — see the note in <c>docs/SSH_ROADMAP.md</c>.
+/// </summary>
+public static class NativeSshCapability
+{
+    public static NativeSshCapabilityResult Evaluate(SshProfile profile)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+
+        return Evaluate(profile.Forwards, profile.JumpHops);
+    }
+
+    /// <summary>
+    /// Overload for callers holding an in-progress edit rather than a saved profile (the connection
+    /// editor's observable collections), so validating a draft does not require minting a profile.
+    /// </summary>
+    public static NativeSshCapabilityResult Evaluate(
+        IReadOnlyCollection<PortForward>? forwards,
+        IReadOnlyCollection<SshJumpHop>? jumpHops)
+    {
+        // Jump hops first: a profile with both problems is more likely to be reshaped around the
+        // hop chain than around the forward, so lead with the structural one.
+        if (jumpHops is { Count: > 1 })
+        {
+            return NativeSshCapabilityResult.Unsupported(
+                NativeSshUnsupportedReason.MultipleJumpHops,
+                "Multiple jump hops are not supported by the native SSH backend yet. "
+                + "Use a single jump hop, or switch this profile to the OpenSSH backend.");
+        }
+
+        if (forwards != null && forwards.Any(forward => forward.Kind is not PortForwardKind.Local and not PortForwardKind.Dynamic))
+        {
+            return NativeSshCapabilityResult.Unsupported(
+                NativeSshUnsupportedReason.RemotePortForward,
+                "The native SSH backend supports local and dynamic port forwards only. "
+                + "Remove the remote forward, or switch this profile to the OpenSSH backend.");
+        }
+
+        return NativeSshCapabilityResult.Supported;
+    }
+}

--- a/src/NovaTerminal.Platform/Ssh/Native/NativeSshInterop.cs
+++ b/src/NovaTerminal.Platform/Ssh/Native/NativeSshInterop.cs
@@ -21,6 +21,11 @@ public sealed partial class NativeSshInterop : INativeSshInterop
     private const int ResultClosed = -3;
     private const int ResultCanceled = -6;
     private const int ResultPanic = -7;
+
+    // A forward channel is over its queued-byte budget toward the remote. Surfaced as a false return
+    // from TryWriteChannel, never as an exception: the caller is meant to retry, and that retry is
+    // what applies backpressure to the local socket it is reading from.
+    private const int ResultWouldBlock = -8;
     private static readonly NativeSftpTransferProgressCallback SftpTransferProgressCallback = OnNativeSftpTransferProgress;
     private static readonly IntPtr SftpTransferProgressCallbackPointer =
         Marshal.GetFunctionPointerForDelegate(SftpTransferProgressCallback);
@@ -445,24 +450,44 @@ public sealed partial class NativeSshInterop : INativeSshInterop
 
     public void WriteChannel(NovaSshSafeHandle sessionHandle, int channelId, ReadOnlySpan<byte> data)
     {
+        // Callers that cannot handle backpressure get a loud failure rather than silent data loss:
+        // dropping bytes out of a forwarded stream corrupts it invisibly. Production callers use
+        // TryWriteChannel and retry.
+        if (!TryWriteChannel(sessionHandle, channelId, data))
+        {
+            throw new InvalidOperationException(
+                $"Native SSH channel {channelId} has no room for this write. Use TryWriteChannel and retry.");
+        }
+    }
+
+    public bool TryWriteChannel(NovaSshSafeHandle sessionHandle, int channelId, ReadOnlySpan<byte> data)
+    {
         if (sessionHandle is null || sessionHandle.IsInvalid || sessionHandle.IsClosed || channelId < 0)
         {
-            return;
+            return true;
         }
 
         byte[] payload = data.ToArray();
         try
         {
             int rc = NativeMethods.nova_ssh_channel_write(sessionHandle, checked((uint)channelId), payload, (nuint)payload.Length);
+
+            // Not an error, and nothing was consumed: the channel's queue toward the remote is full.
+            if (rc == ResultWouldBlock)
+            {
+                return false;
+            }
+
             if (rc is ResultOk or ResultInvalidArgument or ResultClosed)
             {
-                return;
+                return true;
             }
 
             throw new InvalidOperationException($"Native SSH channel write failed with result {rc}.");
         }
         catch (ObjectDisposedException)
         {
+            return true;
         }
     }
 

--- a/src/NovaTerminal.Platform/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Platform/Ssh/Sessions/NativeSshSession.cs
@@ -63,9 +63,13 @@ public sealed class NativeSshSession : ITerminalSession
     {
         ArgumentNullException.ThrowIfNull(profile);
 
-        if (profile.Forwards.Any(forward => forward.Kind is not PortForwardKind.Local and not PortForwardKind.Dynamic))
+        // Single gate for every shape the native backend cannot serve (remote forwards, hop chains).
+        // The editor asks NativeSshCapability the same question at save time, so reaching this throw
+        // means either a profile saved before the check existed or a caller constructing us directly.
+        NativeSshCapabilityResult capability = NativeSshCapability.Evaluate(profile);
+        if (!capability.IsSupported)
         {
-            throw new NotSupportedException("Native SSH backend currently supports local and dynamic port forwards only.");
+            throw new NotSupportedException(capability.Explanation);
         }
 
         _ = diagnosticsLevel;

--- a/src/NovaTerminal.Platform/Ssh/Sessions/SshSessionFactory.cs
+++ b/src/NovaTerminal.Platform/Ssh/Sessions/SshSessionFactory.cs
@@ -75,6 +75,17 @@ public sealed class SshSessionFactory : ISshSessionFactory
                 "Native SSH is disabled globally. Switch this profile back to OpenSSH or enable ExperimentalNativeSshEnabled.");
         }
 
+        // Two distinct refusals, deliberately distinguishable: the toggle above is a rollout decision
+        // the user can reverse in settings, while this one is a shape the native backend cannot serve
+        // at all. Same no-silent-fallback rule for both — a profile that asked for Native never gets
+        // quietly downgraded to OpenSSH.
+        NativeSshCapabilityResult capability = NativeSshCapability.Evaluate(profile);
+        if (!capability.IsSupported)
+        {
+            log?.Invoke($"[SshSessionFactory] backend=native refused reason={capability.Reason} profile={profile.Name}");
+            throw new NotSupportedException(capability.Explanation);
+        }
+
         string path = profile.JumpHops.Count switch
         {
             0 => "direct",

--- a/tests/NovaTerminal.App.Tests/Ssh/NewSshConnectionViewModelTests.cs
+++ b/tests/NovaTerminal.App.Tests/Ssh/NewSshConnectionViewModelTests.cs
@@ -291,4 +291,134 @@ public sealed class NewSshConnectionViewModelTests
 
         Assert.Equal(string.Empty, vm.BackendWarning);
     }
+
+    [Fact]
+    public void Validate_ForNativeProfileWithRemoteForward_FailsWithAnActionableError()
+    {
+        var vm = new NewSshConnectionViewModel
+        {
+            HostName = "native.internal",
+            UserName = "nova",
+            BackendKind = SshBackendKind.Native,
+            ExperimentalNativeSshEnabled = true
+        };
+        vm.Forwards.Add(new PortForward
+        {
+            Kind = PortForwardKind.Remote,
+            SourcePort = 8080,
+            DestinationHost = "svc.internal",
+            DestinationPort = 80
+        });
+
+        bool valid = vm.Validate();
+
+        Assert.False(valid);
+        Assert.Contains("remote forward", vm.ValidationError, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("OpenSSH", vm.ValidationError, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Validate_ForNativeProfileWithJumpHopChain_Fails()
+    {
+        var vm = new NewSshConnectionViewModel
+        {
+            HostName = "target.internal",
+            UserName = "nova",
+            BackendKind = SshBackendKind.Native,
+            ExperimentalNativeSshEnabled = true
+        };
+        vm.JumpHops.Add(new SshJumpHop { Host = "jump-one.internal" });
+        vm.JumpHops.Add(new SshJumpHop { Host = "jump-two.internal" });
+
+        Assert.False(vm.Validate());
+        Assert.Contains("Multiple jump hops", vm.ValidationError, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_ForNativeProfileWithSupportedForwards_Succeeds()
+    {
+        var vm = new NewSshConnectionViewModel
+        {
+            HostName = "native.internal",
+            UserName = "nova",
+            BackendKind = SshBackendKind.Native,
+            ExperimentalNativeSshEnabled = true
+        };
+        vm.Forwards.Add(new PortForward { Kind = PortForwardKind.Local, SourcePort = 15000, DestinationHost = "svc", DestinationPort = 80 });
+        vm.Forwards.Add(new PortForward { Kind = PortForwardKind.Dynamic, SourcePort = 15001 });
+        vm.JumpHops.Add(new SshJumpHop { Host = "jump.internal" });
+
+        Assert.True(vm.Validate());
+        Assert.Equal(string.Empty, vm.ValidationError);
+    }
+
+    [Fact]
+    public void Validate_ForOpenSshProfileWithRemoteForward_Succeeds()
+    {
+        // The capability gate is native-only: remote forwards are a first-class OpenSSH feature.
+        var vm = new NewSshConnectionViewModel
+        {
+            HostName = "openssh.internal",
+            UserName = "nova",
+            BackendKind = SshBackendKind.OpenSsh
+        };
+        vm.Forwards.Add(new PortForward
+        {
+            Kind = PortForwardKind.Remote,
+            SourcePort = 8080,
+            DestinationHost = "svc.internal",
+            DestinationPort = 80
+        });
+
+        Assert.True(vm.Validate());
+        Assert.Equal(string.Empty, vm.ValidationError);
+    }
+
+    [Fact]
+    public void BackendWarning_ForUnsupportedShape_NamesTheShapeRatherThanTheGlobalToggle()
+    {
+        var vm = new NewSshConnectionViewModel
+        {
+            HostName = "native.internal",
+            BackendKind = SshBackendKind.Native,
+            // Toggle off as well: enabling it would not make this profile connectable, so the warning
+            // must not send the user to settings.
+            ExperimentalNativeSshEnabled = false
+        };
+        vm.Forwards.Add(new PortForward
+        {
+            Kind = PortForwardKind.Remote,
+            SourcePort = 8080,
+            DestinationHost = "svc.internal",
+            DestinationPort = 80
+        });
+
+        Assert.Contains("remote forward", vm.BackendWarning, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("disabled globally", vm.BackendWarning, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BackendWarning_IsRaisedWhenForwardsChange()
+    {
+        var vm = new NewSshConnectionViewModel
+        {
+            HostName = "native.internal",
+            BackendKind = SshBackendKind.Native,
+            ExperimentalNativeSshEnabled = true
+        };
+
+        var raised = new List<string?>();
+        vm.PropertyChanged += (_, args) => raised.Add(args.PropertyName);
+
+        vm.Forwards.Add(new PortForward
+        {
+            Kind = PortForwardKind.Remote,
+            SourcePort = 8080,
+            DestinationHost = "svc.internal",
+            DestinationPort = 80
+        });
+
+        Assert.Contains(nameof(NewSshConnectionViewModel.BackendWarning), raised);
+        Assert.Contains("remote forward", vm.BackendWarning, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/tests/NovaTerminal.Platform.Tests/Ssh/NativePortForwardSessionTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/NativePortForwardSessionTests.cs
@@ -358,6 +358,104 @@ public sealed class NativePortForwardSessionTests
             request.PortToConnect == 8443);
     }
 
+    [Fact]
+    public async Task HandleEvent_WithALocalPeerThatNeverReads_DoesNotBlockTheCaller()
+    {
+        // The regression this pins: HandleEvent used to write straight to the local socket from
+        // NativeSshSession's poll loop, so a forwarded port whose consumer stopped reading froze all
+        // terminal output for the session (#173 item 2). Sixteen megabytes at a peer that reads nothing
+        // is far past anything the kernel will buffer, so the old code would block here.
+        var interop = new FakeNativeSshInterop();
+        int listenPort = GetFreePort();
+
+        using var session = new NativePortForwardSession(
+            FakeHandle(23),
+            [CreateForward(listenPort, "svc.internal", 9000)],
+            interop);
+
+        using TcpClient client = await ConnectLoopbackAsync(listenPort);
+        client.ReceiveBufferSize = 1024;
+
+        await WaitUntilAsync(() => interop.OpenedChannelIds.Count == 1);
+        int channelId = interop.OpenedChannelIds[0];
+
+        byte[] chunk = new byte[64 * 1024];
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        for (int i = 0; i < 256; i++)
+        {
+            session.HandleEvent(NativeSshEvent.ForwardChannelData(channelId, chunk));
+        }
+
+        stopwatch.Stop();
+
+        // Real cost is microseconds; the ceiling is loose enough to survive a loaded CI runner while
+        // still failing outright on a blocking write.
+        Assert.True(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(10),
+            $"HandleEvent blocked for {stopwatch.Elapsed} while the local peer was not reading.");
+
+        // And the channel that could not keep up is closed rather than buffered without limit.
+        await WaitUntilAsync(() => interop.ClosedChannelIds.Contains(channelId));
+    }
+
+    [Fact]
+    public async Task ForwardChannelEof_ArrivesAfterTheDataQueuedAheadOfIt()
+    {
+        // EOF travels through the same queue as the data. Acting on it immediately would shut the send
+        // side down while bytes were still queued behind it, truncating the proxied stream.
+        var interop = new FakeNativeSshInterop();
+        int listenPort = GetFreePort();
+
+        using var session = new NativePortForwardSession(
+            FakeHandle(24),
+            [CreateForward(listenPort, "svc.internal", 9001)],
+            interop);
+
+        using TcpClient client = await ConnectLoopbackAsync(listenPort);
+        await WaitUntilAsync(() => interop.OpenedChannelIds.Count == 1);
+        int channelId = interop.OpenedChannelIds[0];
+
+        byte[] payload = Encoding.ASCII.GetBytes("forwarded-payload");
+        session.HandleEvent(NativeSshEvent.ForwardChannelData(channelId, payload));
+        session.HandleEvent(NativeSshEvent.ForwardChannelEof(channelId));
+
+        NetworkStream stream = client.GetStream();
+        byte[] received = await ReadExactlyAsync(stream, payload.Length, TimeSpan.FromSeconds(10));
+        Assert.Equal(payload, received);
+
+        // Only now may the peer see end-of-stream.
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        int read = await stream.ReadAsync(new byte[1], cts.Token);
+        Assert.Equal(0, read);
+    }
+
+    [Fact]
+    public async Task ForwardChannelClosed_FlushesQueuedDataAndDoesNotCloseTheSshChannelAgain()
+    {
+        var interop = new FakeNativeSshInterop();
+        int listenPort = GetFreePort();
+
+        using var session = new NativePortForwardSession(
+            FakeHandle(25),
+            [CreateForward(listenPort, "svc.internal", 9002)],
+            interop);
+
+        using TcpClient client = await ConnectLoopbackAsync(listenPort);
+        await WaitUntilAsync(() => interop.OpenedChannelIds.Count == 1);
+        int channelId = interop.OpenedChannelIds[0];
+
+        byte[] payload = Encoding.ASCII.GetBytes("last-bytes-before-close");
+        session.HandleEvent(NativeSshEvent.ForwardChannelData(channelId, payload));
+        session.HandleEvent(NativeSshEvent.ForwardChannelClosed(channelId));
+
+        NetworkStream stream = client.GetStream();
+        byte[] received = await ReadExactlyAsync(stream, payload.Length, TimeSpan.FromSeconds(10));
+        Assert.Equal(payload, received);
+
+        // The SSH channel closed on its own; asking the native side to close it again would be wrong.
+        Assert.DoesNotContain(channelId, interop.ClosedChannelIds);
+    }
+
     private static PortForward CreateForward(int sourcePort, string destinationHost, int destinationPort)
     {
         return new PortForward
@@ -504,10 +602,18 @@ public sealed class NativePortForwardSessionTests
         private readonly object _collectionsLock = new();
         private readonly List<NativePortForwardOpenOptions> _openRequests = [];
         private readonly List<int> _closedChannelIds = [];
+        private readonly List<int> _openedChannelIds = [];
 
         public IReadOnlyList<NativePortForwardOpenOptions> OpenRequests
         {
             get { lock (_collectionsLock) { return _openRequests.ToArray(); } }
+        }
+
+        /// <summary>Ids handed out by <see cref="OpenDirectTcpIp"/>, so tests can address a channel
+        /// without assuming the counter's starting value.</summary>
+        public IReadOnlyList<int> OpenedChannelIds
+        {
+            get { lock (_collectionsLock) { return _openedChannelIds.ToArray(); } }
         }
 
         public IReadOnlyList<int> ClosedChannelIds
@@ -548,11 +654,13 @@ public sealed class NativePortForwardSessionTests
 
         public int OpenDirectTcpIp(NovaSshSafeHandle sessionHandle, NativePortForwardOpenOptions options)
         {
+            int channelId = Interlocked.Increment(ref _nextChannelId);
             lock (_collectionsLock)
             {
                 _openRequests.Add(options);
+                _openedChannelIds.Add(channelId);
             }
-            return Interlocked.Increment(ref _nextChannelId);
+            return channelId;
         }
 
         public void WriteChannel(NovaSshSafeHandle sessionHandle, int channelId, ReadOnlySpan<byte> data)

--- a/tests/NovaTerminal.Platform.Tests/Ssh/NativePortForwardSessionTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/NativePortForwardSessionTests.cs
@@ -456,6 +456,81 @@ public sealed class NativePortForwardSessionTests
         Assert.DoesNotContain(channelId, interop.ClosedChannelIds);
     }
 
+    [Fact]
+    public async Task ClientToSshPump_RetriesRefusedWritesInsteadOfDroppingThem()
+    {
+        // The native side refuses a write when a forward channel is over its queued-byte budget
+        // toward the remote (Codex review on #325). The pump must treat that as "try again", not as
+        // "delivered": dropping the bytes would silently corrupt the proxied stream, and forcing them
+        // through would restore the unbounded queue the budget exists to prevent.
+        var interop = new BackpressuringNativeSshInterop(refusalsPerWrite: 3);
+        int listenPort = GetFreePort();
+
+        using var session = new NativePortForwardSession(
+            FakeHandle(26),
+            [CreateForward(listenPort, "svc.internal", 9003)],
+            interop);
+
+        using TcpClient client = await ConnectLoopbackAsync(listenPort);
+        await WaitUntilAsync(() => interop.OpenedChannelIds.Count == 1);
+
+        byte[] payload = Encoding.ASCII.GetBytes("bytes-that-must-survive-backpressure");
+        await client.GetStream().WriteAsync(payload);
+        await client.GetStream().FlushAsync();
+
+        await WaitUntilAsync(() => interop.WrittenBytes.Count >= payload.Length);
+
+        Assert.Equal(payload, interop.WrittenBytes.Take(payload.Length).ToArray());
+        // Refused attempts must not have been counted as delivered.
+        Assert.True(interop.RefusedAttempts >= 3, $"Expected the pump to absorb refusals; saw {interop.RefusedAttempts}.");
+    }
+
+    /// <summary>
+    /// Refuses the first <c>refusalsPerWrite</c> attempts of every distinct write, then accepts,
+    /// standing in for a native queue that is briefly over budget.
+    /// </summary>
+    private sealed class BackpressuringNativeSshInterop : FakeNativeSshInterop
+    {
+        private readonly int _refusalsPerWrite;
+        private readonly object _writeLock = new();
+        private readonly List<byte> _written = [];
+        private int _pendingRefusals;
+        private int _refusedAttempts;
+
+        public BackpressuringNativeSshInterop(int refusalsPerWrite)
+        {
+            _refusalsPerWrite = refusalsPerWrite;
+            _pendingRefusals = refusalsPerWrite;
+        }
+
+        public IReadOnlyList<byte> WrittenBytes
+        {
+            get { lock (_writeLock) { return _written.ToArray(); } }
+        }
+
+        public int RefusedAttempts
+        {
+            get { lock (_writeLock) { return _refusedAttempts; } }
+        }
+
+        public override bool TryWriteChannel(NovaSshSafeHandle sessionHandle, int channelId, ReadOnlySpan<byte> data)
+        {
+            lock (_writeLock)
+            {
+                if (_pendingRefusals > 0)
+                {
+                    _pendingRefusals--;
+                    _refusedAttempts++;
+                    return false;
+                }
+
+                _written.AddRange(data.ToArray());
+                _pendingRefusals = _refusalsPerWrite;
+                return true;
+            }
+        }
+    }
+
     private static PortForward CreateForward(int sourcePort, string destinationHost, int destinationPort)
     {
         return new PortForward
@@ -585,7 +660,8 @@ public sealed class NativePortForwardSessionTests
         Assert.True(predicate(), "Condition was not met before timeout.");
     }
 
-    private sealed class FakeNativeSshInterop : INativeSshInterop
+    // Not sealed: BackpressuringNativeSshInterop overrides only the write path.
+    private class FakeNativeSshInterop : INativeSshInterop
     {
         private readonly ConcurrentQueue<NativeSshEvent> _events = new();
         private int _nextChannelId = 100;
@@ -665,6 +741,13 @@ public sealed class NativePortForwardSessionTests
 
         public void WriteChannel(NovaSshSafeHandle sessionHandle, int channelId, ReadOnlySpan<byte> data)
         {
+        }
+
+        // Declared (rather than left to the interface's default) so a derived fake can override it.
+        public virtual bool TryWriteChannel(NovaSshSafeHandle sessionHandle, int channelId, ReadOnlySpan<byte> data)
+        {
+            WriteChannel(sessionHandle, channelId, data);
+            return true;
         }
 
         public void SendChannelEof(NovaSshSafeHandle sessionHandle, int channelId)

--- a/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshCapabilityTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshCapabilityTests.cs
@@ -1,0 +1,116 @@
+using NovaTerminal.Platform.Ssh.Models;
+using NovaTerminal.Platform.Ssh.Native;
+
+namespace NovaTerminal.Platform.Tests.Ssh;
+
+public sealed class NativeSshCapabilityTests
+{
+    [Fact]
+    public void Evaluate_ForPlainProfile_IsSupported()
+    {
+        NativeSshCapabilityResult result = NativeSshCapability.Evaluate(CreateProfile());
+
+        Assert.True(result.IsSupported);
+        Assert.Equal(NativeSshUnsupportedReason.None, result.Reason);
+        Assert.Equal(string.Empty, result.Explanation);
+    }
+
+    [Theory]
+    [InlineData(PortForwardKind.Local)]
+    [InlineData(PortForwardKind.Dynamic)]
+    public void Evaluate_ForForwardKindsTheNativeBackendImplements_IsSupported(PortForwardKind kind)
+    {
+        SshProfile profile = CreateProfile();
+        profile.Forwards.Add(new PortForward { Kind = kind, SourcePort = 15000 });
+
+        Assert.True(NativeSshCapability.Evaluate(profile).IsSupported);
+    }
+
+    [Fact]
+    public void Evaluate_ForRemoteForward_IsUnsupportedAndNamesBothFixes()
+    {
+        SshProfile profile = CreateProfile();
+        profile.Forwards.Add(new PortForward
+        {
+            Kind = PortForwardKind.Remote,
+            SourcePort = 8080,
+            DestinationHost = "svc.internal",
+            DestinationPort = 80
+        });
+
+        NativeSshCapabilityResult result = NativeSshCapability.Evaluate(profile);
+
+        Assert.False(result.IsSupported);
+        Assert.Equal(NativeSshUnsupportedReason.RemotePortForward, result.Reason);
+        Assert.Contains("remote forward", result.Explanation, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("OpenSSH", result.Explanation, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Evaluate_ForRemoteForwardAmongSupportedOnes_StillReportsUnsupported()
+    {
+        SshProfile profile = CreateProfile();
+        profile.Forwards.Add(new PortForward { Kind = PortForwardKind.Local, SourcePort = 15000, DestinationHost = "a", DestinationPort = 1 });
+        profile.Forwards.Add(new PortForward { Kind = PortForwardKind.Remote, SourcePort = 15001, DestinationHost = "b", DestinationPort = 2 });
+        profile.Forwards.Add(new PortForward { Kind = PortForwardKind.Dynamic, SourcePort = 15002 });
+
+        Assert.Equal(NativeSshUnsupportedReason.RemotePortForward, NativeSshCapability.Evaluate(profile).Reason);
+    }
+
+    [Fact]
+    public void Evaluate_ForSingleJumpHop_IsSupported()
+    {
+        SshProfile profile = CreateProfile();
+        profile.JumpHops.Add(new SshJumpHop { Host = "jump.internal" });
+
+        Assert.True(NativeSshCapability.Evaluate(profile).IsSupported);
+    }
+
+    [Fact]
+    public void Evaluate_ForJumpHopChain_IsUnsupportedWithTheEstablishedWording()
+    {
+        SshProfile profile = CreateProfile();
+        profile.JumpHops.Add(new SshJumpHop { Host = "jump-one.internal" });
+        profile.JumpHops.Add(new SshJumpHop { Host = "jump-two.internal" });
+
+        NativeSshCapabilityResult result = NativeSshCapability.Evaluate(profile);
+
+        Assert.False(result.IsSupported);
+        Assert.Equal(NativeSshUnsupportedReason.MultipleJumpHops, result.Reason);
+        // JumpHostConnectPlan surfaces this same string; its test pins the prefix.
+        Assert.Contains("Multiple jump hops", result.Explanation, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Evaluate_WhenBothProblemsPresent_ReportsTheHopChainFirst()
+    {
+        SshProfile profile = CreateProfile();
+        profile.JumpHops.Add(new SshJumpHop { Host = "jump-one.internal" });
+        profile.JumpHops.Add(new SshJumpHop { Host = "jump-two.internal" });
+        profile.Forwards.Add(new PortForward { Kind = PortForwardKind.Remote, SourcePort = 8080, DestinationHost = "svc", DestinationPort = 80 });
+
+        Assert.Equal(NativeSshUnsupportedReason.MultipleJumpHops, NativeSshCapability.Evaluate(profile).Reason);
+    }
+
+    [Fact]
+    public void Evaluate_WithNullCollections_IsSupported()
+    {
+        // The draft overload is called with whatever the editor holds; neither collection is required.
+        Assert.True(NativeSshCapability.Evaluate(forwards: null, jumpHops: null).IsSupported);
+    }
+
+    [Fact]
+    public void Evaluate_WithNullProfile_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => NativeSshCapability.Evaluate((SshProfile)null!));
+    }
+
+    private static SshProfile CreateProfile() => new()
+    {
+        Id = Guid.Parse("2b0d2f6c-3f5b-4f0a-9a4f-0f0a5b7c9d11"),
+        Name = "native",
+        Host = "target.internal",
+        User = "nova",
+        BackendKind = SshBackendKind.Native
+    };
+}

--- a/tests/NovaTerminal.Platform.Tests/Ssh/SshSessionFactoryTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/SshSessionFactoryTests.cs
@@ -75,6 +75,70 @@ public sealed class SshSessionFactoryTests
         Assert.Contains("OpenSSH", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void Create_ForNativeProfileWithRemoteForward_RefusesWithCapabilityReasonNotTheToggleMessage()
+    {
+        var profileId = Guid.Parse("3f1e1c02-9a4b-4c1d-8b5e-6d0a2f7c1b44");
+        var store = new InMemorySshProfileStore(new SshProfile
+        {
+            Id = profileId,
+            Name = "native-remote-forward",
+            Host = "native.internal",
+            User = "nova",
+            BackendKind = SshBackendKind.Native,
+            Forwards =
+            [
+                new PortForward
+                {
+                    Kind = PortForwardKind.Remote,
+                    SourcePort = 8080,
+                    DestinationHost = "svc.internal",
+                    DestinationPort = 80
+                }
+            ]
+        });
+        var logs = new List<string>();
+
+        var factory = new SshSessionFactory(store, launcher: null, nativeInterop: new StubNativeSshInterop());
+
+        NotSupportedException ex = Assert.Throws<NotSupportedException>(() => factory.Create(profileId, log: logs.Add));
+
+        // The two refusals must stay distinguishable: this profile is not fixable in settings, so it
+        // must not be reported as "native SSH is disabled globally".
+        Assert.Contains("remote forward", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("disabled globally", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(logs, message => message.Contains("refused reason=RemotePortForward", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Create_ForNativeProfileWithJumpHopChain_RefusesBeforeBuildingASession()
+    {
+        var profileId = Guid.Parse("5c7d9e10-2b3a-4d5e-9f01-7a8b9c0d1e22");
+        var store = new InMemorySshProfileStore(new SshProfile
+        {
+            Id = profileId,
+            Name = "native-multi-hop",
+            Host = "target.internal",
+            User = "nova",
+            BackendKind = SshBackendKind.Native,
+            JumpHops =
+            [
+                new SshJumpHop { Host = "jump-one.internal" },
+                new SshJumpHop { Host = "jump-two.internal" }
+            ]
+        });
+
+        var factory = new SshSessionFactory(store, launcher: null, nativeInterop: new StubNativeSshInterop());
+
+        NotSupportedException ex = Assert.Throws<NotSupportedException>(() => factory.Create(profileId));
+
+        Assert.Contains("Multiple jump hops", ex.Message, StringComparison.Ordinal);
+    }
+
+    // Not covered here: an OpenSSH profile carrying a remote forward. The capability gate sits in the
+    // Native arm of SshSessionFactory.Create, so OpenSSH cannot reach it — and asserting that through
+    // the factory would construct a real OpenSshSession, which compiles an ssh_config to disk.
+
     private sealed class InMemorySshProfileStore : ISshProfileStore
     {
         public InMemorySshProfileStore(SshProfile profile)


### PR DESCRIPTION
## What this changes

Two changes to the native SSH backend, both prerequisites for ever defaulting it on.

**Capability gate.** Whether native can serve a profile was spelled out in three places that could drift apart — `NativeSshSession`, `JumpHostConnectPlan` and `NativePortForwardSession`, each with its own wording — and none of them reachable until a connect was already underway. A profile with a remote forward or a jump-hop chain saved happily and then failed at connect time with an exception banner. `NativeSshCapability.Evaluate` is now the single answer, consulted by the profile editor at save time, by `SshSessionFactory` before it builds a session, and by the three former throw sites for their wording.

**Forward writes off the poll loop.** `HandleEvent` wrote straight to the local socket from `NativeSshSession.PollLoopAsync`, so a forwarded port whose consumer stopped reading froze *all* terminal output for the session. Data, EOF and close now queue per channel with a dedicated pump doing the blocking write. The same shape existed one layer down in the Rust worker's `select!` loop, so both layers are fixed — patching only the managed side would have relocated the stall rather than removed it.

Addresses item 2 of #173. Items 1 (bounded native event queue) and 3 (poll latency, allocations) are untouched, so this is deliberately not a closing reference.

## Invariant and ownership

- **What invariant does this change affect?**

  Two. First, the native-SSH rollout contract from `docs/plans/2026-03-31-native-ssh-rollout-controls-design.md`: native never silently falls back to OpenSSH, and refusals are explicit. That invariant is preserved — a profile that asked for `Native` still fails loudly; the refusal just happens earlier and in one place. No default changed.

  Second, forward-channel integrity: bytes proxied through a forward must arrive intact and in order. EOF and close now travel through the same queue as the data rather than acting immediately, because acting on EOF while bytes were still queued behind it truncated the stream.

- **Which module owns that invariant?**

  `NovaTerminal.Platform` — owns the entire SSH stack including native interop with `rusty_ssh`. The Rust half lives in `src/NovaTerminal.App/native/rusty_ssh/`. One view-model file in `NovaTerminal.App` changed for the editor-side validation.

## Tests

- **What tests cover this change?**

  New, Platform.Tests:
  - `Ssh/NativeSshCapabilityTests.cs` — 10 cases: supported shapes, remote forward, hop chain, both-problems precedence, null handling, and that the hop-chain wording keeps the prefix `JumpHostConnectPlanTests` already pins.
  - `Ssh/NativePortForwardSessionTests.cs` — `HandleEvent_WithALocalPeerThatNeverReads_DoesNotBlockTheCaller` (the stall regression: 16 MB at a peer that reads nothing, which the old synchronous write could not survive), `ForwardChannelEof_ArrivesAfterTheDataQueuedAheadOfIt` (the truncation ordering), `ForwardChannelClosed_FlushesQueuedDataAndDoesNotCloseTheSshChannelAgain`.
  - `Ssh/SshSessionFactoryTests.cs` — the two refusals stay distinguishable: a capability refusal must not be reported as "native SSH is disabled globally", and it logs the reason name (`refused reason=RemotePortForward`).

  New, App.Tests: `Ssh/NewSshConnectionViewModelTests.cs` — save is refused for a native profile with a remote forward or a hop chain, allowed for supported forwards and for OpenSSH profiles with a remote forward, and `BackendWarning` names the shape rather than the toggle when both apply.

  New, Rust: `forward_channel_queue_tests` in `rusty_ssh/src/lib.rs` — 6 cases covering queue ordering, unknown channel ids, removal-still-drains, and the bounded teardown wait. Mutation-verified: wiring the EOF path to send `Close` instead makes the ordering test fail.

  Not covered, and called out in the test file rather than left silent: an OpenSSH profile carrying a remote forward asserted through `SshSessionFactory`. The gate sits in the `Native` arm so OpenSSH cannot reach it, and asserting via the factory would construct a real `OpenSshSession`, which compiles an `ssh_config` to disk. The equivalent property is covered at the view-model level.

- **Which categories did you run locally?**

  - [ ] full unfiltered run (`scripts/build.sh test`)
  - [ ] `Category=Replay`
  - [ ] `Category=RenderMetrics`
  - [ ] `Category=PtySmoke`
  - [x] `tests/NovaTerminal.App.Tests` (non-blocking in CI — check it yourself)
  - [ ] full local CI rehearsal (`ci/run.sh` / `ci/run.ps1`)

  Precisely what ran, since that ticked box is partial:

  - `tests/NovaTerminal.Platform.Tests --filter "FullyQualifiedName~Ssh"` on Windows: 113 passed, 0 failed, 18 skipped (the `DockerFact` E2E set, which needs `NOVATERM_ENABLE_DOCKER_E2E=1` — the same set CI skips today).
  - `tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~NewSshConnectionViewModel"` on Windows: 20 passed, 0 failed. A filtered subset, not the whole project — narrowed to sidestep #317.
  - `cargo test` for `rusty_ssh` on Linux: 73 passed. `cargo fmt --check` clean on everything added (the crate has pre-existing fmt drift elsewhere, untouched).

  Not run: the full unfiltered suite, the four dedicated categories, and the CI rehearsal. Nothing here touches the renderer, VT, replay or PTY paths, so I leant on CI for those rather than claiming runs that did not happen.

## Impact

- **Does this affect cross-platform behavior?**

  No platform-specific code paths. `System.Threading.Channels` and the tokio task/queue changes are platform-neutral. Tested on Windows (the C# suites) and Linux (the Rust suite); macOS untested and unaffected by anything specific to it.

- **Does this change renderer metrics?**

  No — nothing in the render path changes. Worth noting the indirect direction though: a forwarded port that stalls no longer blocks the SSH poll loop, so terminal output during that condition improves rather than regresses. No metric harness covers it.

- **Does this change VT coverage?**

  No. No sequences added or changed, so `docs/vt_coverage_matrix.md` and the conformance report are untouched.

## Notes for review

Two decisions worth a reviewer's attention:

**Overflow closes the channel.** A forward channel that exceeds its 1 MB outbound budget is closed rather than buffered without limit or trimmed. Waiting would reintroduce the poll-loop stall the queue exists to remove, and dropping bytes mid-stream would silently corrupt what is, to the peer, a plain TCP connection — a dead forward is diagnosable, a corrupted one is not. The honest limitation: a *legitimately* slow local consumer that cannot absorb 1 MB while we queue it will now see its forward closed. Removing that trade-off needs per-forward-channel flow control in the native layer (not acking the SSH window until the local socket drains), which is its own change.

**No `Auto` backend kind.** The capability evaluator is what a future default flip needs, but it is deliberately not wired to a routing decision and no enum value was added. About eight sites decide native-only behaviour by comparing the *persisted* backend kind to `Native` — SFTP, remote browsing, path autocomplete, session-scoped password memory, replay/agent descriptors, the pane's own checks — so an `Auto` profile resolving to native at connect time would silently take the OpenSSH path in all of them. The editor combo also binds straight to `Enum.GetValues` over `SshBackendKind`, so a new value would appear unlabelled. That needs a session-scoped resolved-backend concept threaded through those call sites first; recorded in `docs/SSH_ROADMAP.md` so the enum value does not get added without it.

Also fixed in passing: the three forward-channel commands in the Rust `select!` loop propagated their write result with `?`, so one failed forward-channel write tore down the entire session, terminal included. They can now only take their own channel down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHPUK1JQgoV6t4RsSNeXKs