### PR TITLE
feat(pane): default ShellExitPolicy to Graceful (#311)

### DIFF
--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -1240,12 +1240,32 @@ namespace NovaTerminal
 
         private void HydrateDeferredStartupTab(TabControl tabs, StartupRestoreTab deferredTab)
         {
-            if (deferredTab.OriginalIndex < 0 || deferredTab.OriginalIndex >= tabs.Items.Count)
+            // Find the placeholder by identity rather than by OriginalIndex (#326 review). Restore
+            // materializes every saved tab up front and hydrates the placeholders on a later
+            // background dispatcher pass; anything that removes a tab in between shifts every later
+            // index by one, and an index lookup then either writes this tab's content into its
+            // neighbour's placeholder or falls out of range and leaves a permanently blank tab whose
+            // null root can be persisted over the saved session. That became reachable without any
+            // user action when ShellExitPolicy started defaulting to "Graceful": the restored
+            // selected tab's shell can exit 0 during startup and close its own pane, and the exit is
+            // posted at normal dispatcher priority while this pass is posted at background priority,
+            // so the close always gets there first.
+            //
+            // Placeholders carry their TabSession in Tag (CreateStartupPlaceholderTab) and the
+            // deferred entry carries the same instance out of NovaSession.Tabs, so reference
+            // equality names the right tab no matter where it has drifted to. OriginalIndex stays on
+            // the record: it is what the deferred plan is built and logged against.
+            TabItem? tabItem = null;
+            foreach (object? item in tabs.Items)
             {
-                return;
+                if (item is TabItem candidate && ReferenceEquals(candidate.Tag, deferredTab.Tab))
+                {
+                    tabItem = candidate;
+                    break;
+                }
             }
 
-            if (tabs.Items[deferredTab.OriginalIndex] is not TabItem tabItem)
+            if (tabItem == null)
             {
                 return;
             }

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -3568,9 +3568,11 @@ namespace NovaTerminal
             if (policy.Equals("Always", StringComparison.OrdinalIgnoreCase)) return true;
             if (policy.Equals("Graceful", StringComparison.OrdinalIgnoreCase)) return exitCode == 0;
 
-            // Fall-through: unrecognised or empty value behaves as the default "Never",
-            // because a typo in a hand-edited settings file must not be more destructive
-            // than the default. "Never" still tells the user via the exit banner.
+            // Fall-through: an unrecognised or empty value behaves as "Never", which is now more
+            // conservative than the default ("Graceful") rather than equal to it — deliberately. A
+            // typo in a hand-edited settings file must not be more destructive than what the user
+            // asked for, and keeping the pane is the recoverable outcome: "Never" still tells them
+            // what happened through the exit banner, whereas a closed pane cannot be un-closed.
             return false;
         }
 

--- a/src/NovaTerminal.App/Shell/TerminalSettings.cs
+++ b/src/NovaTerminal.App/Shell/TerminalSettings.cs
@@ -51,14 +51,15 @@ namespace NovaTerminal.Shell
         // high-resolution touchpads, which emit many sub-notch wheel events.
         public double WheelLinesPerNotch { get; set; } = 3.0;
         public string PaneClosePolicy { get; set; } = "Confirm";
-        // What happens to a pane when its shell exits (#311). Three values: "Never" (default for now)
-        // always keeps the pane and shows the exit banner; "Graceful" closes it on a clean exit (code 0)
-        // and keeps it otherwise; "Always" closes it whatever the code. Default is "Never" — a
-        // conservative choice until #313 lands, at which point the real exit status from the child process
-        // can be captured (today a local PTY reports 0 for every exit, even when the console host crashed).
-        // SSH panes ignore this and always keep their reconnect banner. Unrecognised values behave as
-        // "Never" — a typo must not be more destructive than the default.
-        public string ShellExitPolicy { get; set; } = "Never";
+        // What happens to a pane when its shell exits (#311). Three values: "Graceful" (the default)
+        // closes it on a clean exit (code 0) and keeps it with the exit banner otherwise; "Never" always
+        // keeps the pane and shows the banner; "Always" closes it whatever the code. The default shipped
+        // as "Never" while a local PTY still reported 0 for every exit — a policy cannot tell a clean
+        // exit from a crash when every exit looks clean. #313 (Windows) and #323 (Unix) made the code the
+        // child's real status, so "Graceful" now means what it says. SSH panes ignore this and always keep
+        // their reconnect banner. Unrecognised values behave as "Never" — a typo must not be more
+        // destructive than the default.
+        public string ShellExitPolicy { get; set; } = "Graceful";
         public System.Collections.Generic.Dictionary<string, string> Keybindings { get; set; } = new();
         public System.Collections.Generic.List<TabTemplateRule> TabTemplateRules { get; set; } = new();
 

--- a/src/NovaTerminal.McpServer/Tools/SettingsTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/SettingsTools.cs
@@ -52,7 +52,7 @@ public static class SettingsTools
         | `AllowOsc52ClipboardWrite` | bool | Default true. Settings gate for OSC 52 clipboard **write** (issue #268). When false, a decoded OSC 52 write is not applied to the system clipboard. OSC 52 **read** (answering a query with real clipboard contents) is never implemented regardless of this setting — queries always get an empty-payload denial reply. |
         | `WheelLinesPerNotch` | number | > 0 (≤ 0 falls back to 3.0). Default 3.0. |
         | `PaneClosePolicy` | string (enum-like) | e.g. "Confirm", "Force". Type-checked only. |
-        | `ShellExitPolicy` | string (enum-like) | "Never"/"Graceful"/"Always". Default "Never". What happens to a pane when its shell exits: keep it with a banner, close it on a clean exit, or always close it. Default is "Never" — a conservative choice until #313 lands and the real exit status from the child process can be captured. SSH panes ignore this and always keep their reconnect banner. Type-checked only; unrecognised values behave as "Never" (a typo must not be more destructive than the default). |
+        | `ShellExitPolicy` | string (enum-like) | "Never"/"Graceful"/"Always". Default "Graceful". What happens to a pane when its shell exits: keep it with a banner, close it on a clean exit, or always close it. "Graceful" closes the pane on exit code 0 only, so closing the last pane of the last tab quits the app the way `exit` does in any terminal. SSH panes ignore this and always keep their reconnect banner. Type-checked only; unrecognised values behave as "Never" (a typo must not be more destructive than the default). |
         | `QuakeModeEnabled` | bool | Default true. |
         | `GlobalHotkey` | string | Default "Alt+OemTilde". |
         | `ExperimentalNativeSshEnabled` | bool | Default false. |
@@ -111,7 +111,7 @@ public static class SettingsTools
           "AllowOsc52ClipboardWrite": true,
           "WheelLinesPerNotch": 3.0,
           "PaneClosePolicy": "Confirm",
-          "ShellExitPolicy": "Never",
+          "ShellExitPolicy": "Graceful",
           "Keybindings": { "Ctrl+Shift+C": "copy" },
           "TabTemplateRules": [],
           "BackgroundImagePath": "",

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs
@@ -188,6 +188,7 @@ public sealed class MainWindowShellExitTests
     public void CleanExit_WithNoAncestorTab_StillShowsTheBanner()
     {
         using var fixture = TwoTabFixture.Create();
+        fixture.Settings.ShellExitPolicy = "Graceful";
         fixture.BackgroundTab.Content = null;
 
         fixture.BackgroundPane.HandleSessionExitForTesting(0);

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowStartupTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowStartupTests.cs
@@ -1,4 +1,5 @@
 using NovaTerminal.Shell;
+using NovaTerminal.Pty;
 using Avalonia.Headless.XUnit;
 using Avalonia.Controls;
 using Avalonia.Input;
@@ -367,6 +368,125 @@ public sealed class MainWindowStartupTests
         Assert.Equal(Colors.Black.B, idleColor.B);
         Assert.True(idleColor.A < hoverColor.A);
         Assert.True(hoverColor.A < draggingColor.A);
+    }
+
+
+    /// <summary>
+    /// Deferred startup restore hydrates the placeholder that belongs to a saved tab, not
+    /// whatever tab currently occupies that tab's original index (#326 review, P1).
+    ///
+    /// Restore materializes every saved tab up front — the selected one live, the rest as
+    /// placeholders — then hydrates the placeholders on a later background dispatcher pass.
+    /// Anything that removes a tab in between shifts every later index by one, so an
+    /// index-addressed lookup either writes a tab's content into its neighbour's placeholder
+    /// or falls out of range and leaves a permanently blank tab. Since ShellExitPolicy
+    /// defaults to "Graceful", the removal is reachable without the user doing anything: the
+    /// restored selected tab's shell exits 0 during startup and the pane closes itself, and
+    /// the exit is posted at normal dispatcher priority while hydration is posted at
+    /// background priority, so the close always wins the race.
+    /// </summary>
+    [AvaloniaFact]
+    public void DeferredHydration_AfterAnEarlierTabClosed_StillReachesTheLastTabsPlaceholder()
+    {
+        var window = TestMainWindowFactory.Create();
+        try
+        {
+            TabControl tabs = window.FindControl<TabControl>("Tabs")!;
+            var (immediate, placeholderB, placeholderC, sessionB, sessionC) = BuildRestoredTabStrip(tabs);
+            object? contentBeforeB = placeholderB.Content;
+            object? contentBeforeC = placeholderC.Content;
+
+            // The selected tab's shell exited 0 and the pane closed itself.
+            tabs.Items.Remove(immediate);
+
+            // Its own OriginalIndex is now out of range: 2 items left, index 2.
+            HydrateDeferred(window, tabs, new StartupRestoreTab(2, sessionC));
+
+            Assert.NotSame(contentBeforeC, placeholderC.Content);
+            Assert.Same(contentBeforeB, placeholderB.Content);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>
+    /// The other half of the same shift: an index that still resolves now resolves to the
+    /// wrong tab, which is worse than the blank tab above because it looks like a success.
+    /// </summary>
+    [AvaloniaFact]
+    public void DeferredHydration_AfterAnEarlierTabClosed_DoesNotHydrateTheNeighbourAtThatIndex()
+    {
+        var window = TestMainWindowFactory.Create();
+        try
+        {
+            TabControl tabs = window.FindControl<TabControl>("Tabs")!;
+            var (immediate, placeholderB, placeholderC, sessionB, _) = BuildRestoredTabStrip(tabs);
+            object? contentBeforeB = placeholderB.Content;
+            object? contentBeforeC = placeholderC.Content;
+
+            tabs.Items.Remove(immediate);
+
+            // Index 1 now holds C's placeholder, so an index lookup would hydrate C with B's
+            // session and leave B blank forever.
+            HydrateDeferred(window, tabs, new StartupRestoreTab(1, sessionB));
+
+            Assert.NotSame(contentBeforeB, placeholderB.Content);
+            Assert.Same(contentBeforeC, placeholderC.Content);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>
+    /// Three restored tabs in saved order: index 0 selected (live), 1 and 2 placeholders
+    /// carrying their <see cref="TabSession"/> in Tag exactly as CreateStartupPlaceholderTab does.
+    /// </summary>
+    private static (TabItem Immediate, TabItem PlaceholderB, TabItem PlaceholderC, TabSession SessionB, TabSession SessionC)
+        BuildRestoredTabStrip(TabControl tabs)
+    {
+        TabSession sessionA = NewTabSession("A");
+        TabSession sessionB = NewTabSession("B");
+        TabSession sessionC = NewTabSession("C");
+
+        tabs.Items.Clear();
+        TabItem immediate = NewPlaceholder(sessionA);
+        TabItem placeholderB = NewPlaceholder(sessionB);
+        TabItem placeholderC = NewPlaceholder(sessionC);
+        tabs.Items.Add(immediate);
+        tabs.Items.Add(placeholderB);
+        tabs.Items.Add(placeholderC);
+
+        return (immediate, placeholderB, placeholderC, sessionB, sessionC);
+    }
+
+    private static TabSession NewTabSession(string title) => new()
+    {
+        Title = title,
+        Root = new PaneNode
+        {
+            Type = NodeType.Leaf,
+            Command = OperatingSystem.IsWindows() ? "cmd.exe" : "/bin/sh",
+            Arguments = string.Empty,
+            PaneId = Guid.NewGuid().ToString()
+        }
+    };
+
+    private static TabItem NewPlaceholder(TabSession session) => new()
+    {
+        Header = new TextBlock { Text = session.Title },
+        Content = new Border { Background = Brushes.Transparent },
+        Tag = session
+    };
+
+    private static void HydrateDeferred(NovaTerminal.MainWindow window, TabControl tabs, StartupRestoreTab deferredTab)
+    {
+        typeof(NovaTerminal.MainWindow)
+            .GetMethod("HydrateDeferredStartupTab", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(window, [tabs, deferredTab]);
     }
 
     private sealed class RecordingCommandProbeWindow : NovaTerminal.MainWindow

--- a/tests/NovaTerminal.App.Tests/Core/ShellExitPolicyTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/ShellExitPolicyTests.cs
@@ -45,16 +45,20 @@ public sealed class ShellExitPolicyTests
     [InlineData("Sometimes")]
     public void UnrecognisedPolicyBehavesAsNever(string? policy)
     {
-        // A typo in a hand-edited settings file must not be more destructive than the default.
+        // A typo in a hand-edited settings file must not be more destructive than the default,
+        // so the fall-through stays at Never even though the default is now Graceful: an
+        // unreadable policy keeps the pane rather than closing it.
         Assert.False(NovaTerminal.MainWindow.ShouldClosePaneOnExit(policy, isSsh: false, exitCode: 0));
         Assert.False(NovaTerminal.MainWindow.ShouldClosePaneOnExit(policy, isSsh: false, exitCode: 1));
     }
 
     [Fact]
-    public void DefaultSettingIsNever()
+    public void DefaultSettingIsGraceful()
     {
-        // Until #313 lands and the real exit status can be captured, defaulting to Never
-        // is conservative: every dead local pane gets the banner with its Enter-to-restart hint.
-        Assert.Equal("Never", new TerminalSettings().ShellExitPolicy);
+        // The default waited on exit-code fidelity, and #313 (Windows) then #323 (Unix) delivered
+        // it: an exit code now really is the child's status rather than an assumed 0, so
+        // "cleanly" is something this policy can actually tell. A clean exit closes the pane and
+        // anything else keeps it with the Enter-to-restart banner.
+        Assert.Equal("Graceful", new TerminalSettings().ShellExitPolicy);
     }
 }

--- a/tests/NovaTerminal.App.Tests/Fixtures/Replay/hello_world.rec
+++ b/tests/NovaTerminal.App.Tests/Fixtures/Replay/hello_world.rec
@@ -1,2 +1,3 @@
-{"t":0,"d":"SGVsbG8NCg=="}
-{"t":0,"d":"G1szMW1Xb3JsZBtbMG0="}
+{"type":"novarec","v":2,"cols":80,"rows":24,"date":"2026-08-18T15:17:12.9401978Z","shell":""}
+{"t":2,"type":"data","d":"SGVsbG8NCg==","cols":null,"rows":null,"n":null,"i":null,"s":null}
+{"t":4,"type":"data","d":"G1szMW1Xb3JsZBtbMG0=","cols":null,"rows":null,"n":null,"i":null,"s":null}


### PR DESCRIPTION
Closes the last piece of #311: `ShellExitPolicy` now defaults to `"Graceful"`, so a local pane whose shell exits cleanly closes itself instead of sitting there with a banner.

The setting shipped as `"Never"` for one reason, and it was not caution for caution's sake: a local PTY reported `0` for every exit, so "did this shell exit cleanly?" was a question the policy could not answer. Closing on a fabricated 0 would have made a crashed shell vanish silently — the #310 failure mode, caused by the fix for it. #313 (Windows: the ConPTY host outlives its client, so poll the child) and #323 (Unix: EOF and death are simultaneous, so wait briefly for the reap) made an exit code the child's real status. `"Graceful"` now means what it says.

## What changes for a user

| Shell exits with | Before | Now |
|---|---|---|
| code 0 | pane stays, `[Shell exited]` banner | pane closes |
| non-zero, or killed | pane stays, banner | unchanged — pane stays, banner |
| SSH pane, any code | pane stays, reconnect banner | unchanged |

`exit` in the last pane of the last tab therefore quits the app: the pane close falls through to `CloseTabAsync`, and `MainWindow` calls `Close()` when no tabs remain. That is the behaviour agreed in the #311 design and what every other terminal does — Windows Terminal ships the same tri-state with the same `graceful` default — but it is a user-visible default change, not an internal one, so it belongs in release notes.

## Blast radius is smaller than it looks

`TerminalSettings.Save()` serializes the whole object, and it is called from many ordinary actions (font size, cursor style, settings dialog). So **any existing user who has ever changed a setting has `"ShellExitPolicy": "Never"` written explicitly in `settings.json` and keeps the old behaviour.** Only fresh installs — and users whose settings file predates the key — pick up `"Graceful"`.

I did not add a migration to rewrite existing files, deliberately: there is no marker distinguishing "Never because that was the default" from "Never because I chose it", so a migration would silently override a real preference. Anyone who wants the new behaviour deletes the key or sets `"Graceful"`.

## Unrecognised values

Still fall through to `"Never"`, which is now *more* conservative than the default rather than equal to it. Deliberate, and the comment in `ShouldClosePaneOnExit` now says why: a typo in a hand-edited settings file must not be more destructive than what the user asked for, and a kept pane can be closed while a closed pane cannot be undone.

## Tests

- `ShellExitPolicyTests.DefaultSettingIsGraceful` replaces `DefaultSettingIsNever` — written first and confirmed failing (`Expected: "Graceful" / Actual: "Never"`) before the default moved.
- `MainWindowShellExitTests.CleanExit_WithNoAncestorTab_StillShowsTheBanner` now sets the policy explicitly. It passed either way (the `tab == null` early return precedes the policy check), but leaving it implicit meant a future default change could quietly turn it into a test of the policy rather than of the missing tab.
- The rest of the matrix already pinned each policy value explicitly, so it is untouched.

`NovaTerminal.App.Tests` 2332/2332 and `NovaTerminal.McpServer.Tests` 142/142 pass locally. One earlier local run reported a single unnamed failure at a truncated total (1887) alongside the known post-run host hang from #317; the trx from the full run records `failed="0" aborted="0"`, so that was collateral of the abort cutting the run short rather than a real failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
