### PR TITLE
test(ssh): fixture image v3 and a CI gate that actually runs the Docker E2E suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,97 @@ jobs:
             **/*.trx
             **/*.dmp
 
+  # Native SSH end-to-end against a real sshd in a container.
+  #
+  # These tests existed before this job did, and never ran anywhere: every one is a
+  # [DockerFact], which self-skips unless NOVATERM_ENABLE_DOCKER_E2E=1, and nothing in CI set
+  # it. The suite was written, committed, skipped, and counted as coverage — which is why the
+  # test matrix still listed auth, host-key and forwarding as "pending manual" while a
+  # Dockerized suite sat next to it. This job is what makes the difference between the two
+  # visible.
+  #
+  # Deliberately blocking rather than continue-on-error. A non-blocking lane here would repeat
+  # the mistake #127 caught in the Render Metrics job: a check whose name claims coverage it
+  # does not enforce. If it turns flaky, the fix is to stabilise the fixture, not to silence
+  # the gate.
+  #
+  # Linux only: the tests drive `docker` through the CLI, and ubuntu-latest is the runner image
+  # with a working Linux Docker daemon. The Windows runners would need Linux-container support
+  # that is not available there, and nothing under test is platform-specific — the fixture
+  # exercises the same rusty_ssh library either way.
+  native_ssh_docker_e2e:
+    name: Native SSH Docker E2E (ubuntu-latest)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [build]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache .NET SDK
+        uses: actions/cache@v4
+        with:
+          path: ~/.dotnet
+          key: dotnet-sdk-${{ runner.os }}-${{ hashFiles('global.json') }}
+          restore-keys: dotnet-sdk-${{ runner.os }}-
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        env:
+          DOTNET_INSTALL_DIR: ~/.dotnet
+        with:
+          global-json-file: global.json
+          cache: true
+          cache-dependency-path: "**/*.csproj"
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dotnet-build-ubuntu-latest
+          path: tests
+
+      # zip artifacts drop Unix execute bits; the test host needs them back. librusty_ssh.so
+      # travels in this artifact too (Platform.Tests copies it as Content), so the P/Invoke
+      # surface these tests exercise is already in place — no Rust rebuild needed.
+      - name: Restore execute permissions
+        run: |
+          find tests -path "*/bin/Release/net*" -type f \
+            ! -name "*.dll" ! -name "*.json" ! -name "*.pdb" ! -name "*.xml" \
+            ! -name "*.so" ! -name "*.dylib" ! -name "*.a" ! -name "*.txt" \
+            | xargs chmod +x
+
+      - name: Docker preflight
+        run: docker info --format 'server={{.ServerVersion}}'
+
+      - name: Restore
+        run: dotnet restore
+
+      # The fixture builds the image itself on first use (DockerSshFixture.EnsureImageBuiltAsync),
+      # so there is no separate build step here; a failure to build surfaces as a test failure
+      # with the docker output attached.
+      - name: Test (native SSH Docker E2E)
+        env:
+          NOVATERM_ENABLE_DOCKER_E2E: '1'
+          SKIP_RUST_NATIVE_BUILD: '1'
+        shell: bash
+        run: |
+          dotnet test tests/NovaTerminal.Platform.Tests -c "$CONFIGURATION" --no-build --no-restore \
+            --filter "Category=DockerE2E" \
+            --logger "trx;LogFileName=native_ssh_docker_e2e.trx"
+
+      # No "collect container logs" step on purpose: the fixture runs containers with --rm and
+      # removes them in DisposeAsync, which still executes when a test fails, so by the time a
+      # post-step ran there would be nothing left to read. The diagnostics live where they are
+      # actually available instead — DockerSshFixture attaches `docker logs` output to the
+      # readiness timeouts it throws, so the failure reaches the .trx with the logs in it.
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-ssh-docker-e2e
+          retention-days: 5
+          path: "**/native_ssh_docker_e2e.trx"
+
   # Coverage measurement (#117). coverlet.collector was pinned in
   # Directory.Packages.props and referenced by all five test projects, but nothing ever
   # enabled it - no invocation passed a collect switch and no report was produced.

--- a/docs/native-ssh/Native_SSH_Test_Matrix.md
+++ b/docs/native-ssh/Native_SSH_Test_Matrix.md
@@ -28,31 +28,43 @@ Verified by automated tests:
 - native rollout gating and failure classification
 - native session input, resize, output decoding, and exit behavior
 - Dockerized native SSH connect/auth, command execution, alternate-screen recovery, resize-burst recovery, and `vim` downward-scroll behavior
+- Dockerized private-key auth (unencrypted and passphrase-protected) and keyboard-interactive auth
+  against a server that refuses every other method for that user
+- Dockerized host-key reporting: the algorithm and fingerprint the backend surfaces are compared
+  against what `ssh-keygen` says the server's key is, and a refused key is proven to stop the
+  connection before any credential is solicited
+- Dockerized local and dynamic (SOCKS5) forwarding carrying real bytes to an in-container echo
+  service, rather than only opening a channel
 
 ## Manual Matrix
 
-The following checks still require manual validation against real SSH endpoints.
+Rows marked Automated run in the `Native SSH Docker E2E` CI job (Linux), which sets
+`NOVATERM_ENABLE_DOCKER_E2E=1`. Everything else still needs a human against a real endpoint.
 
 | Area | Scenario | Status | Notes |
 | --- | --- | --- | --- |
 | OpenSSH parity | Existing OpenSSH backend connects exactly as before | Pending manual | No code path fallback was added; validate with a known-good host |
 | Native auth | Password auth | Pending manual | Dialog path is automated, endpoint still needs live verification |
-| Native auth | Private key auth | Pending manual | Test with an unencrypted key |
-| Native auth | Encrypted private key auth | Pending manual | Test passphrase prompt path with a real key |
-| Native auth | Keyboard-interactive auth | Pending manual | Test against a host that requires challenge-response |
-| Host keys | First trust flow | Pending manual | Confirm dialog copy and persistence path |
+| Native auth | Private key auth | Automated | `NativeSshDockerAuthE2eTests.PrivateKeyAuth_WithUnencryptedKey_...` |
+| Native auth | Encrypted private key auth | Automated | `NativeSshDockerAuthE2eTests.PrivateKeyAuth_WithEncryptedKey_...` |
+| Native auth | Keyboard-interactive auth | Automated | `NativeSshDockerAuthE2eTests.KeyboardInteractiveAuth_...`; the image's `kbdnova` user refuses password and pubkey |
+| Host keys | First trust flow | Automated + pending manual | `HostKeyPrompt_CarriesTheAlgorithmAndFingerprintTheServerActuallyHas` covers the reported key; dialog copy is still a UI check |
 | Host keys | Trusted reconnect | Pending manual | Confirm no dialog after trust is recorded |
-| Host keys | Changed key path | Pending manual | Confirm changed-host-key warning copy and replacement trust |
+| Host keys | Changed key path | Automated + pending manual | Store logic is unit-tested and `HostKeyPrompt_WhenRefused_NeverReachesTheCredentialPrompt` pins fail-closed; warning copy is still a UI check |
 | Terminal behavior | Resize handling | Pending manual | Verify shell survives repeated resize |
 | Terminal behavior | Fullscreen/alt-screen TUI | Automated + pending manual | Dockerized native SSH validates alternate-screen recovery and `vim` downward scrolling; still validate against a real host |
-| Forwarding | One local forward | Pending manual | Validate actual traffic through the forwarded port |
-| Forwarding | One direct-host dynamic forward | Pending manual | Validate actual SOCKS5 traffic through the forwarded port |
+| Forwarding | One local forward | Automated | `LocalForward_CarriesRealBytesToTheEchoService` |
+| Forwarding | One direct-host dynamic forward | Automated | `DynamicForward_CarriesRealBytesThroughSocks5ToTheEchoService` |
 | Forwarding | One-hop jump-host dynamic forward | Follow-up | Not implemented in the native backend yet |
-| Jump host | One-hop jump host | Pending manual | Validate end-to-end session through a real bastion |
+| Jump host | One-hop jump host | Pending manual | Needs a second container as bastion on a shared docker network; fixture is single-container today |
 | Rollback | Broken native profile switched back to OpenSSH | Pending manual | Confirm backend selector flow is obvious and safe |
 
 ## Rollout Notes
 
+- The Dockerized suite runs in CI as the `Native SSH Docker E2E` job (Linux, blocking).
+  Before that job existed the suite was `[DockerFact]`-gated on `NOVATERM_ENABLE_DOCKER_E2E`
+  and nothing in CI set it, so it was written and then never executed — the reason auth and
+  forwarding rows above stayed "pending manual" while a Dockerized suite sat beside them.
 - Native SSH remains opt-in through `TerminalSettings.ExperimentalNativeSshEnabled`.
 - `OpenSsh` remains the default backend for new profiles.
 - Native backend refusal is explicit when the global experimental toggle is disabled.

--- a/tests/NovaTerminal.ExternalSuites/NativeSsh/Dockerfile
+++ b/tests/NovaTerminal.ExternalSuites/NativeSsh/Dockerfile
@@ -21,18 +21,19 @@ RUN useradd -m -s /bin/bash nova \
     && useradd -m -s /bin/bash kbdnova \
     && echo "kbdnova:kbd-pass" | chpasswd
 
-# Key material is generated during the build, never committed. A private key literal in the
-# repository would be a secret-scanning finding on every clone and every fork, and these keys only
-# need to be consistent within a single image build — DockerSshFixture copies them out of the
-# container at test time. Both public halves authorize `nova`, so which key a test presents decides
-# whether it exercises the plain or the passphrase-protected path.
+# No key material is generated here, and none is committed either.
+#
+# The obvious middle ground — generate the test keys during the build — is what the first version of
+# this file did, and it is wrong: it puts a private key inside the image, which travels with the image
+# to anyone who ever pulls or exports it. SonarCloud flags exactly that ("Credentials should not be
+# hard-coded: change this code not to store a secret in the image"), and it is right to.
+#
+# So the image only prepares the directories. DockerSshFixture generates the keypairs inside the
+# running container and copies the private halves out — the container is started with --rm, so the
+# keys live and die with one test. See ProvisionTestKeysAsync.
 RUN mkdir -p /novaterm-keys \
-    && ssh-keygen -q -t ed25519 -N '' -C novaterm-plain -f /novaterm-keys/id_ed25519 \
-    && ssh-keygen -q -t ed25519 -N 'nova-key-pass' -C novaterm-encrypted -f /novaterm-keys/id_ed25519_encrypted \
     && mkdir -p /home/nova/.ssh \
-    && cat /novaterm-keys/id_ed25519.pub /novaterm-keys/id_ed25519_encrypted.pub > /home/nova/.ssh/authorized_keys \
     && chmod 700 /home/nova/.ssh \
-    && chmod 600 /home/nova/.ssh/authorized_keys \
     && chown -R nova:nova /home/nova/.ssh
 
 # Global block first, then the Match block: sshd applies Match sections in file order, and anything

--- a/tests/NovaTerminal.ExternalSuites/NativeSsh/Dockerfile
+++ b/tests/NovaTerminal.ExternalSuites/NativeSsh/Dockerfile
@@ -1,21 +1,56 @@
+# Native SSH end-to-end fixture image.
+#
+# v3 exists to make the auth rows of docs/native-ssh/Native_SSH_Test_Matrix.md automatable. v2 set
+# `PubkeyAuthentication no` and `KbdInteractiveAuthentication no`, so private-key, encrypted-key and
+# keyboard-interactive auth could only ever be checked by hand — the matrix listed them as "pending
+# manual" because the server refused those methods, not because the tests were hard to write.
 FROM debian:12-slim
 
+# socat backs a trivial echo service (see the entrypoint) so forwarding tests can assert that real
+# bytes complete the round trip, rather than only that a channel opened.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends openssh-server bash zsh fish ca-certificates vim-tiny \
+    && apt-get install -y --no-install-recommends openssh-server bash zsh fish ca-certificates vim-tiny socat \
     && rm -rf /var/lib/apt/lists/*
 
+# Two users, because one cannot cover both cases:
+#   nova    - password auth (as in v2, so existing tests are unaffected) plus public-key auth.
+#   kbdnova - keyboard-interactive ONLY. Without a user that refuses password and pubkey, a client
+#             can satisfy the server without ever exercising the challenge-response path.
 RUN useradd -m -s /bin/bash nova \
-    && echo "nova:nova-pass" | chpasswd
+    && echo "nova:nova-pass" | chpasswd \
+    && useradd -m -s /bin/bash kbdnova \
+    && echo "kbdnova:kbd-pass" | chpasswd
 
-RUN mkdir -p /var/run/sshd /home/nova/.ssh \
+# Key material is generated during the build, never committed. A private key literal in the
+# repository would be a secret-scanning finding on every clone and every fork, and these keys only
+# need to be consistent within a single image build — DockerSshFixture copies them out of the
+# container at test time. Both public halves authorize `nova`, so which key a test presents decides
+# whether it exercises the plain or the passphrase-protected path.
+RUN mkdir -p /novaterm-keys \
+    && ssh-keygen -q -t ed25519 -N '' -C novaterm-plain -f /novaterm-keys/id_ed25519 \
+    && ssh-keygen -q -t ed25519 -N 'nova-key-pass' -C novaterm-encrypted -f /novaterm-keys/id_ed25519_encrypted \
+    && mkdir -p /home/nova/.ssh \
+    && cat /novaterm-keys/id_ed25519.pub /novaterm-keys/id_ed25519_encrypted.pub > /home/nova/.ssh/authorized_keys \
+    && chmod 700 /home/nova/.ssh \
+    && chmod 600 /home/nova/.ssh/authorized_keys \
+    && chown -R nova:nova /home/nova/.ssh
+
+# Global block first, then the Match block: sshd applies Match sections in file order, and anything
+# after a Match belongs to that Match until the next one.
+RUN mkdir -p /var/run/sshd \
     && printf '%s\n' \
         'PasswordAuthentication yes' \
-        'PermitRootLogin no' \
-        'PubkeyAuthentication no' \
+        'PubkeyAuthentication yes' \
         'KbdInteractiveAuthentication no' \
-        'ChallengeResponseAuthentication no' \
+        'PermitRootLogin no' \
+        'UsePAM yes' \
+        'AllowTcpForwarding yes' \
         'UseDNS no' \
         'PrintMotd no' \
+        'Match User kbdnova' \
+        '    PasswordAuthentication no' \
+        '    PubkeyAuthentication no' \
+        '    KbdInteractiveAuthentication yes' \
         > /etc/ssh/sshd_config.d/novaterm.conf
 
 RUN ssh-keygen -A
@@ -25,8 +60,22 @@ RUN printf "export PS1='nova$ '\n" > /home/nova/.bashrc \
     && mkdir -p /home/nova/.config/fish \
     && printf "function fish_prompt\n    printf 'nova$ '\nend\n" > /home/nova/.config/fish/config.fish \
     && printf "if [ -f ~/.bashrc ]; then . ~/.bashrc; fi\n" > /home/nova/.bash_profile \
-    && chown -R nova:nova /home/nova
+    && chown -R nova:nova /home/nova \
+    && printf "export PS1='nova$ '\n" > /home/kbdnova/.bashrc \
+    && printf "if [ -f ~/.bashrc ]; then . ~/.bashrc; fi\n" > /home/kbdnova/.bash_profile \
+    && chown -R kbdnova:kbdnova /home/kbdnova
+
+# sshd stays PID 1 via exec, so container stop signals still reach it. The echo service is a
+# background child rather than a second supervised process: if it dies the forwarding tests fail
+# loudly, which is the correct outcome, and nothing else depends on it.
+RUN printf '%s\n' \
+        '#!/bin/sh' \
+        'set -e' \
+        'socat TCP-LISTEN:9001,fork,reuseaddr EXEC:/bin/cat &' \
+        'exec /usr/sbin/sshd -D -e' \
+        > /usr/local/bin/novaterm-entrypoint.sh \
+    && chmod +x /usr/local/bin/novaterm-entrypoint.sh
 
 EXPOSE 22
 
-CMD ["/usr/sbin/sshd", "-D", "-e"]
+CMD ["/usr/local/bin/novaterm-entrypoint.sh"]

--- a/tests/NovaTerminal.Platform.Tests/Ssh/DockerSshFixture.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/DockerSshFixture.cs
@@ -3,7 +3,7 @@ using System.Net.Sockets;
 
 namespace NovaTerminal.Platform.Tests.Ssh;
 
-/// <summary>Which of the image's build-time test keys to use.</summary>
+/// <summary>Which of the per-container test keys to use. Both are generated when the fixture starts.</summary>
 internal enum NativeSshTestKey
 {
     /// <summary>Unencrypted; authenticates without any passphrase prompt.</summary>
@@ -20,6 +20,10 @@ internal sealed class DockerSshFixture : IAsyncDisposable
     // would silently serve the new tests a server that rejects the methods they are testing.
     private const string ImageTag = "novaterm-native-ssh-e2e:v3";
     private const int EchoServicePortValue = 9001;
+
+    // Needed as a constant because ProvisionTestKeysAsync is static (it runs before the fixture
+    // instance exists) and has to pass the same passphrase to ssh-keygen that tests will answer with.
+    private const string PrivateKeyPassphraseValue = "nova-key-pass";
     private string _containerName = string.Empty;
     private bool _started;
 
@@ -43,7 +47,7 @@ internal sealed class DockerSshFixture : IAsyncDisposable
     public string KeyboardInteractivePassword => "kbd-pass";
 
     /// <summary>Passphrase for <see cref="NativeSshTestKey.PassphraseProtected"/>.</summary>
-    public string PrivateKeyPassphrase => "nova-key-pass";
+    public string PrivateKeyPassphrase => PrivateKeyPassphraseValue;
 
     /// <summary>
     /// Port of the in-container TCP echo service, as seen from the SSH server itself. Forward tests
@@ -119,9 +123,10 @@ internal sealed class DockerSshFixture : IAsyncDisposable
     }
 
     /// <summary>
-    /// Copies one of the image's build-time private keys to <paramref name="destinationPath"/> on the
-    /// host, so a test can point <c>IdentityFilePath</c> at it. The keys are generated per image build
-    /// rather than committed — see the Dockerfile for why.
+    /// Copies one of the container's private keys to <paramref name="destinationPath"/> on the host, so
+    /// a test can point <c>IdentityFilePath</c> at it. The keys are generated per container by
+    /// <see cref="ProvisionTestKeysAsync"/> — never committed, and never stored in the image. See the
+    /// Dockerfile for why.
     /// </summary>
     public async Task<string> CopyPrivateKeyAsync(NativeSshTestKey key, string destinationPath)
     {
@@ -157,6 +162,7 @@ internal sealed class DockerSshFixture : IAsyncDisposable
         int mappedPort = await ResolveMappedPortAsync(containerName).ConfigureAwait(false);
         await WaitForPortAsync(containerName, mappedPort).ConfigureAwait(false);
         await WaitForEchoServiceAsync(containerName).ConfigureAwait(false);
+        await ProvisionTestKeysAsync(containerName).ConfigureAwait(false);
 
         var fixture = new DockerSshFixture(mappedPort)
         {
@@ -259,6 +265,38 @@ internal sealed class DockerSshFixture : IAsyncDisposable
         string finalLogs = await RunDockerCommandAsync($"logs {containerName}", throwOnFailure: false).ConfigureAwait(false);
         throw new TimeoutException(
             $"Docker SSH server on port {port} did not become ready within 30 seconds. State: {finalStatus}. Logs: {finalLogs}");
+    }
+
+    /// <summary>
+    /// Generates the two test keypairs inside the running container and authorizes them for
+    /// <see cref="UserName"/>.
+    ///
+    /// Done here rather than in the Dockerfile so no private key is ever stored in the image — an
+    /// image carries its contents to anyone who pulls or exports it, and a build-time key would be a
+    /// secret baked in for the image's whole life. The container runs with <c>--rm</c>, so these keys
+    /// exist only for the duration of one test.
+    /// </summary>
+    private static async Task ProvisionTestKeysAsync(string containerName)
+    {
+        // One exec so the keys, the authorized_keys file and its permissions cannot be half-applied.
+        // sshd refuses to honour authorized_keys unless it is owned by the user and not group/world
+        // writable, so the chown/chmod are load-bearing rather than tidiness.
+        string script =
+            "ssh-keygen -q -t ed25519 -N '' -C novaterm-plain -f /novaterm-keys/id_ed25519 && " +
+            $"ssh-keygen -q -t ed25519 -N '{PrivateKeyPassphraseValue}' -C novaterm-encrypted -f /novaterm-keys/id_ed25519_encrypted && " +
+            "cat /novaterm-keys/id_ed25519.pub /novaterm-keys/id_ed25519_encrypted.pub > /home/nova/.ssh/authorized_keys && " +
+            "chown nova:nova /home/nova/.ssh/authorized_keys && " +
+            "chmod 600 /home/nova/.ssh/authorized_keys && " +
+            "echo keys-provisioned";
+
+        string output = await RunDockerCommandAsync($"exec {containerName} sh -c \"{script}\"")
+            .ConfigureAwait(false);
+
+        if (!output.Contains("keys-provisioned", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Failed to provision test keys in container '{containerName}'. Output: {output}");
+        }
     }
 
     /// <summary>

--- a/tests/NovaTerminal.Platform.Tests/Ssh/DockerSshFixture.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/DockerSshFixture.cs
@@ -3,9 +3,23 @@ using System.Net.Sockets;
 
 namespace NovaTerminal.Platform.Tests.Ssh;
 
+/// <summary>Which of the image's build-time test keys to use.</summary>
+internal enum NativeSshTestKey
+{
+    /// <summary>Unencrypted; authenticates without any passphrase prompt.</summary>
+    Plain = 0,
+
+    /// <summary>Encrypted with <see cref="DockerSshFixture.PrivateKeyPassphrase"/>.</summary>
+    PassphraseProtected = 1
+}
+
 internal sealed class DockerSshFixture : IAsyncDisposable
 {
-    private const string ImageTag = "novaterm-native-ssh-e2e:v2";
+    // v3 turns on public-key and keyboard-interactive auth, which v2 refused outright. Bumping the
+    // tag matters: EnsureImageBuiltAsync reuses any already-built image with this name, so a stale v2
+    // would silently serve the new tests a server that rejects the methods they are testing.
+    private const string ImageTag = "novaterm-native-ssh-e2e:v3";
+    private const int EchoServicePortValue = 9001;
     private string _containerName = string.Empty;
     private bool _started;
 
@@ -18,6 +32,24 @@ internal sealed class DockerSshFixture : IAsyncDisposable
     public int Port { get; }
     public string UserName => "nova";
     public string Password => "nova-pass";
+
+    /// <summary>
+    /// A user the server allows ONLY via keyboard-interactive. Password and public-key auth are
+    /// refused for it, so a client cannot accidentally satisfy the server by another route and leave
+    /// the challenge-response path untested.
+    /// </summary>
+    public string KeyboardInteractiveUserName => "kbdnova";
+
+    public string KeyboardInteractivePassword => "kbd-pass";
+
+    /// <summary>Passphrase for <see cref="NativeSshTestKey.PassphraseProtected"/>.</summary>
+    public string PrivateKeyPassphrase => "nova-key-pass";
+
+    /// <summary>
+    /// Port of the in-container TCP echo service, as seen from the SSH server itself. Forward tests
+    /// use it as the destination so they can assert bytes complete the round trip.
+    /// </summary>
+    public int EchoServicePort => EchoServicePortValue;
 
     public async Task WriteTextFileAsync(string path, string contents)
     {
@@ -75,6 +107,27 @@ internal sealed class DockerSshFixture : IAsyncDisposable
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Copies one of the image's build-time private keys to <paramref name="destinationPath"/> on the
+    /// host, so a test can point <c>IdentityFilePath</c> at it. The keys are generated per image build
+    /// rather than committed — see the Dockerfile for why.
+    /// </summary>
+    public async Task<string> CopyPrivateKeyAsync(NativeSshTestKey key, string destinationPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(destinationPath);
+
+        string remotePath = key switch
+        {
+            NativeSshTestKey.Plain => "/novaterm-keys/id_ed25519",
+            NativeSshTestKey.PassphraseProtected => "/novaterm-keys/id_ed25519_encrypted",
+            _ => throw new ArgumentOutOfRangeException(nameof(key), key, "Unknown test key.")
+        };
+
+        await RunDockerCommandAsync($"cp {_containerName}:{remotePath} \"{destinationPath}\"")
+            .ConfigureAwait(false);
+        return destinationPath;
+    }
+
     public static async Task<DockerSshFixture> StartAsync()
     {
         await EnsureDockerAvailableAsync().ConfigureAwait(false);
@@ -92,6 +145,7 @@ internal sealed class DockerSshFixture : IAsyncDisposable
 
         int mappedPort = await ResolveMappedPortAsync(containerName).ConfigureAwait(false);
         await WaitForPortAsync(containerName, mappedPort).ConfigureAwait(false);
+        await WaitForEchoServiceAsync(containerName).ConfigureAwait(false);
 
         var fixture = new DockerSshFixture(mappedPort)
         {
@@ -194,6 +248,34 @@ internal sealed class DockerSshFixture : IAsyncDisposable
         string finalLogs = await RunDockerCommandAsync($"logs {containerName}", throwOnFailure: false).ConfigureAwait(false);
         throw new TimeoutException(
             $"Docker SSH server on port {port} did not become ready within 30 seconds. State: {finalStatus}. Logs: {finalLogs}");
+    }
+
+    /// <summary>
+    /// Waits for the entrypoint's echo service to accept connections. Checked at fixture start rather
+    /// than inside the forwarding tests so a broken echo service reports itself as such, instead of
+    /// surfacing later as a forwarding test that mysteriously reads no bytes back.
+    /// </summary>
+    private static async Task WaitForEchoServiceAsync(string containerName)
+    {
+        // socat exits non-zero when it cannot connect, so the marker only reaches stdout on success —
+        // RunDockerCommandAsync collapses any failure to an empty string, which alone is ambiguous.
+        string probe = $"exec {containerName} sh -c \"socat -u OPEN:/dev/null TCP:127.0.0.1:{EchoServicePortValue} && echo echo-service-ready\"";
+
+        DateTime deadline = DateTime.UtcNow.AddSeconds(20);
+        while (DateTime.UtcNow < deadline)
+        {
+            string output = await RunDockerCommandAsync(probe, throwOnFailure: false).ConfigureAwait(false);
+            if (output.Contains("echo-service-ready", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            await Task.Delay(250).ConfigureAwait(false);
+        }
+
+        string logs = await RunDockerCommandAsync($"logs {containerName}", throwOnFailure: false).ConfigureAwait(false);
+        throw new TimeoutException(
+            $"Echo service on container port {EchoServicePortValue} did not accept connections within 20 seconds. Logs: {logs}");
     }
 
     private static async Task<string> RunDockerCommandAsync(string arguments, bool throwOnFailure = true)

--- a/tests/NovaTerminal.Platform.Tests/Ssh/DockerSshFixture.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/DockerSshFixture.cs
@@ -62,6 +62,17 @@ internal sealed class DockerSshFixture : IAsyncDisposable
             await File.WriteAllTextAsync(tempFile, contents).ConfigureAwait(false);
             await RunDockerCommandAsync($"cp \"{tempFile}\" {_containerName}:{path}")
                 .ConfigureAwait(false);
+
+            // `docker cp` writes the file as root and carries the host file's mode across, and
+            // Path.GetTempFileName() creates 0600 on Linux. The result was a remote file the SSH user
+            // could not read, so every SFTP download test failed with "Permission denied" — on Linux
+            // only, which is why it went unnoticed until this suite first ran in CI.
+            //
+            // Fixed here rather than per-test: every caller writes a file it intends the session user
+            // to be able to fetch, and 0644 owned by that user is what such a file looks like.
+            await RunDockerCommandAsync(
+                $"exec {_containerName} sh -c \"chown {UserName}:{UserName} '{path}' && chmod 644 '{path}'\"")
+                .ConfigureAwait(false);
         }
         finally
         {

--- a/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshDockerAuthE2eTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshDockerAuthE2eTests.cs
@@ -1,0 +1,278 @@
+using System.Net;
+using System.Net.Sockets;
+using NovaTerminal.Platform.Ssh.Interactions;
+using NovaTerminal.Platform.Ssh.Models;
+using NovaTerminal.Platform.Ssh.Sessions;
+using NovaTerminal.Platform.Tests.Infra;
+using NovaTerminal.VT;
+using static NovaTerminal.Platform.Tests.Ssh.NativeSshDockerTestWaits;
+
+namespace NovaTerminal.Platform.Tests.Ssh;
+
+/// <summary>
+/// The auth, host-key and forwarding rows that docs/native-ssh/Native_SSH_Test_Matrix.md listed as
+/// "pending manual". They were manual because the v2 fixture image refused public-key and
+/// keyboard-interactive auth and had nothing to forward traffic to — not because they resist
+/// automation. v3 supplies both, so these run against a real sshd.
+/// </summary>
+public sealed class NativeSshDockerAuthE2eTests
+{
+    private static readonly TimeSpan PromptTimeout = TimeSpan.FromSeconds(30);
+
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
+    public async Task PrivateKeyAuth_WithUnencryptedKey_AuthenticatesWithoutAskingForAnything()
+    {
+        await using var fixture = await DockerSshFixture.StartAsync();
+
+        string tempRoot = CreateTempRoot("nova-native-key-plain");
+        try
+        {
+            string keyPath = await fixture.CopyPrivateKeyAsync(
+                NativeSshTestKey.Plain,
+                Path.Combine(tempRoot, "id_ed25519"));
+
+            var buffer = new TerminalBuffer(120, 30);
+            var parser = new AnsiParser(buffer);
+            var handler = new NativeSshTestInteractionHandler(fixture.Password);
+
+            SshProfile profile = CreateProfile(fixture);
+            profile.AuthMode = SshAuthMode.IdentityFile;
+            profile.IdentityFilePath = keyPath;
+
+            using var session = new NativeSshSession(profile, cols: 120, rows: 30, interactionHandler: handler);
+            session.OnOutputReceived += parser.Process;
+
+            await WaitUntilAsync(() => SnapshotContains(buffer, "nova$"), PromptTimeout, "shell prompt after key auth");
+
+            // A usable key must satisfy the server outright: no password, no passphrase. Only the
+            // host-key question is expected, because sessions never receive a known-hosts path.
+            Assert.DoesNotContain(handler.RequestSnapshot(), request => request.Kind == SshInteractionKind.Password);
+            Assert.DoesNotContain(handler.RequestSnapshot(), request => request.Kind == SshInteractionKind.Passphrase);
+            Assert.Contains(handler.RequestSnapshot(), request => request.Kind == SshInteractionKind.UnknownHostKey);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
+    public async Task PrivateKeyAuth_WithEncryptedKey_PromptsForThePassphraseAndThenAuthenticates()
+    {
+        await using var fixture = await DockerSshFixture.StartAsync();
+
+        string tempRoot = CreateTempRoot("nova-native-key-encrypted");
+        try
+        {
+            string keyPath = await fixture.CopyPrivateKeyAsync(
+                NativeSshTestKey.PassphraseProtected,
+                Path.Combine(tempRoot, "id_ed25519_encrypted"));
+
+            var buffer = new TerminalBuffer(120, 30);
+            var parser = new AnsiParser(buffer);
+            var handler = new NativeSshTestInteractionHandler(
+                fixture.Password,
+                passphrase: fixture.PrivateKeyPassphrase);
+
+            SshProfile profile = CreateProfile(fixture);
+            profile.AuthMode = SshAuthMode.IdentityFile;
+            profile.IdentityFilePath = keyPath;
+
+            using var session = new NativeSshSession(profile, cols: 120, rows: 30, interactionHandler: handler);
+            session.OnOutputReceived += parser.Process;
+
+            await WaitUntilAsync(() => SnapshotContains(buffer, "nova$"), PromptTimeout, "shell prompt after encrypted key auth");
+
+            // The passphrase is what unlocks the key; the password path must not be reached at all.
+            Assert.Contains(handler.RequestSnapshot(), request => request.Kind == SshInteractionKind.Passphrase);
+            Assert.DoesNotContain(handler.RequestSnapshot(), request => request.Kind == SshInteractionKind.Password);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
+    public async Task KeyboardInteractiveAuth_ForAUserThatAcceptsNothingElse_Authenticates()
+    {
+        await using var fixture = await DockerSshFixture.StartAsync();
+
+        var buffer = new TerminalBuffer(120, 30);
+        var parser = new AnsiParser(buffer);
+        var handler = new NativeSshTestInteractionHandler(fixture.KeyboardInteractivePassword);
+
+        SshProfile profile = CreateProfile(fixture);
+        profile.User = fixture.KeyboardInteractiveUserName;
+
+        using var session = new NativeSshSession(profile, cols: 120, rows: 30, interactionHandler: handler);
+        session.OnOutputReceived += parser.Process;
+
+        await WaitUntilAsync(() => SnapshotContains(buffer, "nova$"), PromptTimeout, "shell prompt after keyboard-interactive auth");
+
+        // The backend asks for a password unconditionally before it ever tries keyboard-interactive
+        // (see `authenticate` in rusty_ssh), so a password request here is expected and not a failure.
+        // What matters is that the password attempt was refused by the server and the challenge-response
+        // fallback carried the session.
+        Assert.Contains(handler.RequestSnapshot(), request => request.Kind == SshInteractionKind.KeyboardInteractive);
+    }
+
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
+    public async Task HostKeyPrompt_CarriesTheAlgorithmAndFingerprintTheServerActuallyHas()
+    {
+        await using var fixture = await DockerSshFixture.StartAsync();
+
+        SshHostKeyInfo expected = await fixture.GetHostKeyAsync();
+
+        var buffer = new TerminalBuffer(120, 30);
+        var parser = new AnsiParser(buffer);
+        var handler = new NativeSshTestInteractionHandler(fixture.Password);
+
+        using var session = new NativeSshSession(CreateProfile(fixture), cols: 120, rows: 30, interactionHandler: handler);
+        session.OnOutputReceived += parser.Process;
+
+        await WaitUntilAsync(() => SnapshotContains(buffer, "nova$"), PromptTimeout, "shell prompt");
+
+        SshInteractionRequest hostKeyRequest = Assert.Single(
+            handler.RequestSnapshot().Where(request => request.Kind == SshInteractionKind.UnknownHostKey));
+
+        // Unit tests can pin the trust-store logic but not the derivation: this compares what the
+        // backend reported against what ssh-keygen says the server's key is.
+        Assert.Equal(expected.Algorithm, hostKeyRequest.Algorithm);
+        Assert.Equal(expected.Fingerprint, hostKeyRequest.Fingerprint);
+        Assert.Equal(fixture.Host, hostKeyRequest.Host);
+        Assert.Equal(fixture.Port, hostKeyRequest.Port);
+    }
+
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
+    public async Task HostKeyPrompt_WhenRefused_NeverReachesTheCredentialPrompt()
+    {
+        await using var fixture = await DockerSshFixture.StartAsync();
+
+        var buffer = new TerminalBuffer(120, 30);
+        var parser = new AnsiParser(buffer);
+        var handler = new NativeSshTestInteractionHandler(fixture.Password, acceptHostKeys: false);
+
+        using var session = new NativeSshSession(CreateProfile(fixture), cols: 120, rows: 30, interactionHandler: handler);
+        session.OnOutputReceived += parser.Process;
+
+        await WaitUntilAsync(
+            () => handler.RequestSnapshot().Any(request => request.Kind == SshInteractionKind.UnknownHostKey),
+            PromptTimeout,
+            "host-key prompt");
+
+        // Fail closed: verification happens during the handshake, so refusing the key must stop the
+        // connection before any credential is solicited, and no shell may appear.
+        await AssertStaysTrueAsync(
+            () => !handler.RequestSnapshot().Any(request => request.Kind is SshInteractionKind.Password or SshInteractionKind.Passphrase)
+                  && !SnapshotContains(buffer, "nova$"),
+            TimeSpan.FromSeconds(5),
+            "no credential prompt and no shell after refusing the host key");
+    }
+
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
+    public async Task LocalForward_CarriesRealBytesToTheEchoService()
+    {
+        await using var fixture = await DockerSshFixture.StartAsync();
+
+        int localPort = GetFreeLocalPort();
+        var buffer = new TerminalBuffer(120, 30);
+        var parser = new AnsiParser(buffer);
+        var handler = new NativeSshTestInteractionHandler(fixture.Password);
+
+        SshProfile profile = CreateProfile(fixture);
+        profile.Forwards.Add(new PortForward
+        {
+            Kind = PortForwardKind.Local,
+            BindAddress = "127.0.0.1",
+            SourcePort = localPort,
+            // Destination is resolved by the SSH server, so this is the container's own loopback.
+            DestinationHost = "127.0.0.1",
+            DestinationPort = fixture.EchoServicePort
+        });
+
+        using var session = new NativeSshSession(profile, cols: 120, rows: 30, interactionHandler: handler);
+        session.OnOutputReceived += parser.Process;
+
+        // Wait for the shell first: the listener binds during construction, but a channel cannot open
+        // until the session is established and authenticated.
+        await WaitUntilAsync(() => SnapshotContains(buffer, "nova$"), PromptTimeout, "shell prompt before forwarding");
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(IPAddress.Loopback, localPort);
+
+        const string payload = "local-forward-round-trip";
+        string echoed = await EchoRoundTripAsync(client.GetStream(), payload, TimeSpan.FromSeconds(30));
+
+        Assert.Equal(payload, echoed);
+    }
+
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
+    public async Task DynamicForward_CarriesRealBytesThroughSocks5ToTheEchoService()
+    {
+        await using var fixture = await DockerSshFixture.StartAsync();
+
+        int localPort = GetFreeLocalPort();
+        var buffer = new TerminalBuffer(120, 30);
+        var parser = new AnsiParser(buffer);
+        var handler = new NativeSshTestInteractionHandler(fixture.Password);
+
+        SshProfile profile = CreateProfile(fixture);
+        profile.Forwards.Add(new PortForward
+        {
+            Kind = PortForwardKind.Dynamic,
+            BindAddress = "127.0.0.1",
+            SourcePort = localPort
+        });
+
+        using var session = new NativeSshSession(profile, cols: 120, rows: 30, interactionHandler: handler);
+        session.OnOutputReceived += parser.Process;
+
+        await WaitUntilAsync(() => SnapshotContains(buffer, "nova$"), PromptTimeout, "shell prompt before forwarding");
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(IPAddress.Loopback, localPort);
+        NetworkStream stream = client.GetStream();
+
+        await Socks5ConnectAsync(stream, "127.0.0.1", fixture.EchoServicePort, TimeSpan.FromSeconds(30));
+
+        const string payload = "socks5-round-trip";
+        string echoed = await EchoRoundTripAsync(stream, payload, TimeSpan.FromSeconds(30));
+
+        Assert.Equal(payload, echoed);
+    }
+
+    private static string CreateTempRoot(string prefix)
+    {
+        string tempRoot = Path.Combine(Path.GetTempPath(), $"{prefix}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+        return tempRoot;
+    }
+
+    private static SshProfile CreateProfile(DockerSshFixture fixture)
+    {
+        return new SshProfile
+        {
+            Id = Guid.NewGuid(),
+            Name = "Docker Native SSH (auth)",
+            BackendKind = SshBackendKind.Native,
+            Host = fixture.Host,
+            User = fixture.UserName,
+            Port = fixture.Port
+        };
+    }
+}

--- a/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshDockerTestWaits.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshDockerTestWaits.cs
@@ -1,0 +1,146 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using NovaTerminal.Replay;
+using NovaTerminal.VT;
+
+namespace NovaTerminal.Platform.Tests.Ssh;
+
+/// <summary>
+/// Waiting and traffic helpers shared by the Docker end-to-end suites.
+///
+/// NativeSshDockerE2eTests predates this and carries its own private copies of the snapshot/wait
+/// helpers; they are left alone rather than migrated, because that file is the only coverage for the
+/// existing e2e set and churning it to share twenty lines is a poor trade.
+/// </summary>
+internal static class NativeSshDockerTestWaits
+{
+    public static bool SnapshotContains(TerminalBuffer buffer, string value) =>
+        BufferSnapshot.Capture(buffer).Lines.Any(line => line.Contains(value, StringComparison.Ordinal));
+
+    public static bool SnapshotContainsExactLine(TerminalBuffer buffer, string value) =>
+        BufferSnapshot.Capture(buffer).Lines.Any(line => line == value);
+
+    public static async Task WaitUntilAsync(Func<bool> predicate, TimeSpan timeout, string description)
+    {
+        DateTime deadline = DateTime.UtcNow.Add(timeout);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (predicate())
+            {
+                return;
+            }
+
+            await Task.Delay(100).ConfigureAwait(false);
+        }
+
+        Assert.True(predicate(), $"Timed out waiting for {description}.");
+    }
+
+    /// <summary>
+    /// True once <paramref name="predicate"/> has held for the whole window. For asserting something
+    /// does NOT happen — where a single check right after connecting proves nothing, because the thing
+    /// under test may simply not have got there yet.
+    /// </summary>
+    public static async Task AssertStaysTrueAsync(Func<bool> predicate, TimeSpan window, string description)
+    {
+        DateTime deadline = DateTime.UtcNow.Add(window);
+        while (DateTime.UtcNow < deadline)
+        {
+            Assert.True(predicate(), $"Expected {description} to hold for {window.TotalSeconds:0}s, but it stopped holding.");
+            await Task.Delay(100).ConfigureAwait(false);
+        }
+    }
+
+    public static int GetFreeLocalPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    /// <summary>
+    /// Writes a payload to an already-connected stream and reads exactly as many bytes back, which is
+    /// what the fixture's echo service returns. Proves a forward carries data, not merely that a
+    /// channel opened.
+    /// </summary>
+    public static async Task<string> EchoRoundTripAsync(NetworkStream stream, string payload, TimeSpan timeout)
+    {
+        byte[] outbound = Encoding.ASCII.GetBytes(payload);
+        using var cts = new CancellationTokenSource(timeout);
+
+        await stream.WriteAsync(outbound, cts.Token).ConfigureAwait(false);
+        await stream.FlushAsync(cts.Token).ConfigureAwait(false);
+
+        byte[] inbound = new byte[outbound.Length];
+        int offset = 0;
+        while (offset < inbound.Length)
+        {
+            int read = await stream.ReadAsync(inbound.AsMemory(offset, inbound.Length - offset), cts.Token).ConfigureAwait(false);
+            if (read == 0)
+            {
+                throw new IOException($"Forward closed after {offset} of {inbound.Length} echoed bytes.");
+            }
+
+            offset += read;
+        }
+
+        return Encoding.ASCII.GetString(inbound);
+    }
+
+    /// <summary>
+    /// Minimal SOCKS5 client: no-auth greeting, then CONNECT to the given host and port. Returns once
+    /// the proxy has reported success, leaving the stream ready for payload traffic.
+    /// </summary>
+    public static async Task Socks5ConnectAsync(NetworkStream stream, string host, int port, TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+
+        byte[] greeting = [0x05, 0x01, 0x00];
+        await stream.WriteAsync(greeting, cts.Token).ConfigureAwait(false);
+        await stream.FlushAsync(cts.Token).ConfigureAwait(false);
+
+        byte[] greetingReply = await ReadExactlyAsync(stream, 2, cts.Token).ConfigureAwait(false);
+        Assert.Equal(0x05, greetingReply[0]);
+        Assert.Equal(0x00, greetingReply[1]);
+
+        byte[] hostBytes = Encoding.ASCII.GetBytes(host);
+        byte[] request = new byte[7 + hostBytes.Length];
+        request[0] = 0x05;             // version
+        request[1] = 0x01;             // CONNECT
+        request[2] = 0x00;             // reserved
+        request[3] = 0x03;             // domain name
+        request[4] = (byte)hostBytes.Length;
+        Buffer.BlockCopy(hostBytes, 0, request, 5, hostBytes.Length);
+        request[5 + hostBytes.Length] = (byte)((port >> 8) & 0xFF);
+        request[6 + hostBytes.Length] = (byte)(port & 0xFF);
+
+        await stream.WriteAsync(request, cts.Token).ConfigureAwait(false);
+        await stream.FlushAsync(cts.Token).ConfigureAwait(false);
+
+        // Reply is 10 bytes for the IPv4 bind address this backend always reports.
+        byte[] connectReply = await ReadExactlyAsync(stream, 10, cts.Token).ConfigureAwait(false);
+        Assert.Equal(0x05, connectReply[0]);
+        Assert.Equal(0x00, connectReply[1]);
+    }
+
+    private static async Task<byte[]> ReadExactlyAsync(NetworkStream stream, int length, CancellationToken cancellationToken)
+    {
+        byte[] buffer = new byte[length];
+        int offset = 0;
+        while (offset < length)
+        {
+            int read = await stream.ReadAsync(buffer.AsMemory(offset, length - offset), cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+            {
+                throw new IOException($"Stream closed after {offset} of {length} expected bytes.");
+            }
+
+            offset += read;
+        }
+
+        return buffer;
+    }
+}

--- a/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshTestInteractionHandler.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshTestInteractionHandler.cs
@@ -5,13 +5,49 @@ namespace NovaTerminal.Platform.Tests.Ssh;
 internal sealed class NativeSshTestInteractionHandler : ISshInteractionHandler
 {
     private readonly string _password;
+    private readonly string? _passphrase;
+    private readonly string? _keyboardSecret;
+    private readonly bool _acceptHostKeys;
 
-    public NativeSshTestInteractionHandler(string password)
+    /// <param name="password">Answer for a password prompt.</param>
+    /// <param name="passphrase">
+    /// Answer for a private-key passphrase prompt. Left null, a passphrase prompt is a test failure —
+    /// a test that did not expect one wants to hear about it rather than silently succeed.
+    /// </param>
+    /// <param name="keyboardSecret">
+    /// Answer for every prompt in a keyboard-interactive challenge. Defaults to
+    /// <paramref name="password"/>, which is what PAM asks for on this fixture's image.
+    /// </param>
+    /// <param name="acceptHostKeys">
+    /// False cancels host-key prompts instead of accepting them, so a test can assert the backend
+    /// fails closed on a refused key rather than continuing.
+    /// </param>
+    public NativeSshTestInteractionHandler(
+        string password,
+        string? passphrase = null,
+        string? keyboardSecret = null,
+        bool acceptHostKeys = true)
     {
         _password = password;
+        _passphrase = passphrase;
+        _keyboardSecret = keyboardSecret;
+        _acceptHostKeys = acceptHostKeys;
     }
 
     public List<SshInteractionRequest> Requests { get; } = new();
+
+    /// <summary>
+    /// A locked copy of <see cref="Requests"/>. Tests that poll — waiting for a prompt to arrive, or
+    /// asserting one never does — must not enumerate the live list: the session's own thread adds to it
+    /// concurrently, which throws mid-enumeration rather than failing the assertion it was checking.
+    /// </summary>
+    public IReadOnlyList<SshInteractionRequest> RequestSnapshot()
+    {
+        lock (Requests)
+        {
+            return Requests.ToArray();
+        }
+    }
 
     public Task<SshInteractionResponse> HandleAsync(SshInteractionRequest request, CancellationToken cancellationToken)
     {
@@ -22,9 +58,31 @@ internal sealed class NativeSshTestInteractionHandler : ISshInteractionHandler
 
         return Task.FromResult(request.Kind switch
         {
-            SshInteractionKind.UnknownHostKey or SshInteractionKind.ChangedHostKey => SshInteractionResponse.AcceptHostKey(),
+            SshInteractionKind.UnknownHostKey or SshInteractionKind.ChangedHostKey =>
+                _acceptHostKeys ? SshInteractionResponse.AcceptHostKey() : SshInteractionResponse.Cancel(),
             SshInteractionKind.Password => SshInteractionResponse.FromSecret(_password),
+            SshInteractionKind.Passphrase => SshInteractionResponse.FromSecret(
+                _passphrase ?? throw new InvalidOperationException(
+                    "Native SSH asked for a key passphrase, but this test did not supply one.")),
+            SshInteractionKind.KeyboardInteractive => BuildKeyboardResponse(request),
             _ => throw new InvalidOperationException($"Unexpected native SSH interaction kind '{request.Kind}' in Docker E2E test.")
         });
+    }
+
+    /// <summary>
+    /// One answer per prompt the server actually sent. PAM commonly opens with an informational
+    /// challenge carrying no prompts at all, and answering that with a secret it never asked for makes
+    /// the exchange fail — so an empty challenge gets an empty response.
+    /// </summary>
+    private SshInteractionResponse BuildKeyboardResponse(SshInteractionRequest request)
+    {
+        string secret = _keyboardSecret ?? _password;
+        if (request.KeyboardPrompts.Count == 0)
+        {
+            return SshInteractionResponse.FromKeyboardResponses();
+        }
+
+        return SshInteractionResponse.FromKeyboardResponses(
+            request.KeyboardPrompts.Select(_ => secret).ToArray());
     }
 }


### PR DESCRIPTION
## What this changes

The native SSH Docker suite has never run anywhere. Every test is a `[DockerFact]`, which self-skips unless `NOVATERM_ENABLE_DOCKER_E2E=1`, and nothing in CI set it — so the suite was written, committed, skipped, and counted as coverage. That is why `docs/native-ssh/Native_SSH_Test_Matrix.md` still listed auth, host keys and forwarding as "pending manual" while a Dockerized suite sat next to them.

Two halves, and neither works without the other. A gate alone would just run a suite that cannot reach those paths: v2 set `PubkeyAuthentication no` and `KbdInteractiveAuthentication no`, so private-key, encrypted-key and keyboard-interactive auth were unreachable by construction, and there was nothing on the far side of a forward to send bytes to. An image alone would keep not running.

**Image v3**
- Public-key auth on, with an unencrypted and a passphrase-protected key generated at build time. Generated, not committed: a private key literal in the repo is a secret-scanning finding on every clone and fork, and these only need to be consistent within one image build. The fixture copies them out with `docker cp`.
- A `kbdnova` user that refuses password and pubkey, so keyboard-interactive is the only way in. Without it, a client can satisfy the server by another route and leave the challenge-response path untested while looking green.
- A socat echo service, so forwarding tests assert bytes complete the round trip instead of only that a channel opened. Fixture start waits for it, so a broken echo service reports itself rather than surfacing later as a forward that reads nothing back.

**Seven tests, seven matrix rows**: plain-key auth (asks for nothing), encrypted-key auth (passphrase, never a password), keyboard-interactive, host-key reporting compared against `ssh-keygen`'s view of the server's own key, fail-closed on a refused host key, and real traffic through local and SOCKS5 forwards.

**The CI gate**: `Native SSH Docker E2E`, Linux, `needs: [build]`, blocking.

## Invariant and ownership

- **What invariant does this change affect?**

  That the test matrix means what it says. The specific claim being repaired is "verified by automated tests" — a suite that never executes is not verification, and a check whose name implies coverage it does not enforce is worse than no check. No production invariant changes; no `src/` file is touched.

- **Which module owns that invariant?**

  `NovaTerminal.Platform` owns the SSH stack under test; the fixture, tests and image all live in `tests/`. The workflow change is CI infrastructure.

## Tests

- **What tests cover this change?**

  The change *is* tests. New: `tests/NovaTerminal.Platform.Tests/Ssh/NativeSshDockerAuthE2eTests.cs` (7 `[DockerFact]` cases) and `NativeSshDockerTestWaits.cs` (waits, a SOCKS5 client, an echo round-trip helper). Extended: `DockerSshFixture` (v3 tag, key copy-out, keyboard-interactive user, echo-service readiness) and `NativeSshTestInteractionHandler` (passphrase and keyboard-interactive answers, an option to refuse host keys, and a locked `RequestSnapshot()` so polling assertions cannot enumerate the list while the session thread appends to it).

  Two behaviours found by reading `rusty_ssh` while writing these, both encoded in the tests rather than papered over: the backend prompts for a password **unconditionally** before it ever tries keyboard-interactive, so that test expects a password request and asserts on the fallback; and sessions never receive a known-hosts path (`NativeJumpHostConnector` does not set one), so every session connect raises a host-key prompt and trust is decided by the handler.

- **Which categories did you run locally?**

  - [ ] full unfiltered run (`scripts/build.sh test`)
  - [ ] `Category=Replay`
  - [ ] `Category=RenderMetrics`
  - [ ] `Category=PtySmoke`
  - [ ] `tests/NovaTerminal.App.Tests` (non-blocking in CI — check it yourself)
  - [ ] full local CI rehearsal (`ci/run.sh` / `ci/run.ps1`)

  **None — nothing here has been executed.** The environment this was written in has no reachable Docker daemon: the CLI is present and `dockerd` starts, but the egress proxy returns `Forbidden` on registry blob fetches, so the base image cannot be pulled, the image cannot be built, and the tests cannot run. There is also no .NET SDK, so the C# is uncompiled.

  That is unusual for a test change and worth stating plainly rather than leaving a reader to infer it from empty checkboxes: **this job's own first run on this PR is the verification.** If it lands red I will diagnose and push, not merge past it.

## Impact

- **Does this affect cross-platform behavior?**

  The job is Linux-only, because the tests drive `docker` through the CLI and `ubuntu-latest` is the runner image with a working Linux Docker daemon. Nothing under test is platform-specific — the same `rusty_ssh` library is exercised either way — and the existing per-OS lanes are untouched.

- **Does this change renderer metrics?**

  No. No renderer code is touched.

- **Does this change VT coverage?**

  No sequences added or changed. `docs/vt_coverage_matrix.md` and the conformance report are untouched.

## Notes for review

**Why blocking rather than `continue-on-error`.** A non-blocking lane here would repeat what #127 caught in the Render Metrics job: a check that runs but cannot fail, whose name claims coverage it does not enforce. That is the exact failure mode this PR exists to remove, so introducing a softer version of it would be self-defeating. If the suite turns out flaky, the fix is to stabilise the fixture.

**Scope: the jump-host rows are not included.** They need a second container as a bastion on a shared docker network, and the fixture is single-container. Building that on a suite nobody has yet observed to pass is the wrong order, so the matrix now says exactly that instead of leaving it implied. This converts 7 of the 13 manual rows.

**One acknowledged duplication.** `NativeSshDockerE2eTests` predates this and keeps its own private copies of the snapshot/wait helpers. They are left alone rather than migrated to the new shared class: that file is the only coverage for the existing e2e set, and churning it to share twenty lines is a poor trade against a suite that has never run. Noted in the new file so it reads as a decision rather than an oversight.

**Runtime cost.** ~20 `[DockerFact]` cases, each starting a fresh container, plus one image build per runner (no layer cache configured). Job timeout is 30 minutes; if that proves tight, a buildx cache is the first lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHPUK1JQgoV6t4RsSNeXKs

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHPUK1JQgoV6t4RsSNeXKs)_