### PR TITLE
perf(ssh): bound the native event queue with producer backpressure

### DIFF
--- a/docs/native-ssh/Native_SSH_Test_Matrix.md
+++ b/docs/native-ssh/Native_SSH_Test_Matrix.md
@@ -81,7 +81,10 @@ Rows marked Automated run in the `Native SSH Docker E2E` CI job (Linux), which s
   whose peer stops reading can no longer stall the session's terminal I/O
   (issue #173 item 2).
 - The native event queue itself is bounded (issue #173 item 1): data-bearing
-  events (terminal output, forward-channel data) share a 4 MiB byte budget, and
+  events (terminal output, forward-channel data) share a 4 MiB budget — each
+  event charged its payload plus a flat per-event surcharge, so zero-length
+  data frames (which consume no SSH window and are never throttled by flow
+  control) cannot grow the queue's overhead unbounded either — and
   at the budget the channel readers park instead of reading on — an unread russh
   channel stops having its window replenished, so SSH flow control makes the
   remote hold the stream. A `cat bigfile` against a stalled poll loop now caps

--- a/docs/native-ssh/Native_SSH_Test_Matrix.md
+++ b/docs/native-ssh/Native_SSH_Test_Matrix.md
@@ -80,6 +80,15 @@ Rows marked Automated run in the `Native SSH Docker E2E` CI job (Linux), which s
   by a dedicated pump, in both the managed and Rust layers, so a forwarded port
   whose peer stops reading can no longer stall the session's terminal I/O
   (issue #173 item 2).
+- The native event queue itself is bounded (issue #173 item 1): data-bearing
+  events (terminal output, forward-channel data) share a 4 MiB byte budget, and
+  at the budget the channel readers park instead of reading on — an unread russh
+  channel stops having its window replenished, so SSH flow control makes the
+  remote hold the stream. A `cat bigfile` against a stalled poll loop now caps
+  out at the budget plus one in-flight window instead of buffering the whole
+  stream. Control events (prompts, exit, close, forward open/EOF/close notices)
+  are exempt, so a full queue can never hold back the events that let the
+  managed side notice and act.
 - Both directions are bounded at 1 MB per forward channel, but they resolve
   overflow differently, because only one of them has anywhere to push back to:
   - **Remote to local** (managed queue): over budget, the channel is closed.

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -114,6 +114,17 @@ pub const NOVA_SSH_RESULT_WOULD_BLOCK: c_int = -8;
 /// NOVA_SSH_RESULT_WOULD_BLOCK rather than growing the queue without limit.
 const MAX_QUEUED_FORWARD_WRITE_BYTES: usize = 1024 * 1024;
 
+/// Ceiling on data-bearing payload bytes (Data, ForwardChannelData) queued toward the managed
+/// poll loop. At the ceiling the channel readers park in `queue_data_event` instead of reading
+/// on; an unread russh channel stops having its window replenished, so SSH flow control makes
+/// the *remote* hold the stream rather than this process buffering it (#173 item 1).
+///
+/// Sized above the SSH channel window (2 MiB in this russh config) so a healthy poll loop can
+/// never trip it — even a full window arriving during one idle poll gap fits — while a stalled
+/// consumer of `cat bigfile` now caps out at this budget plus one in-flight window instead of
+/// accumulating the entire stream. Control events are exempt: see `queue_data_event`.
+const MAX_QUEUED_EVENT_BYTES: usize = 4 * 1024 * 1024;
+
 /// Runs an FFI body, converting any panic into `on_panic` instead of unwinding
 /// across the C boundary (which is undefined behavior). The body is asserted
 /// unwind-safe because FFI bodies operate on raw pointers owned by the caller.
@@ -211,6 +222,12 @@ struct SharedState {
     // "would this block?" without touching the async side. A std Mutex, not tokio's: the reader is
     // an FFI thread with no runtime under it. See forward_write_budget.
     forward_write_budgets: Mutex<HashMap<u32, Arc<AtomicUsize>>>,
+    // Data-bearing payload bytes currently in `events`, kept outside the queue's Mutex so the
+    // async producers can check the budget without contending with the FFI poll thread's lock.
+    queued_data_bytes: AtomicUsize,
+    // Wakes producers parked in `queue_data_event` when the poll loop drains below the budget,
+    // or when the session closes (see mark_closed).
+    event_space_notify: tokio::sync::Notify,
 }
 
 struct QueuedEvent {
@@ -596,6 +613,8 @@ impl SharedState {
             closed: Mutex::new(false),
             closed_notify: tokio::sync::Notify::new(),
             forward_write_budgets: Mutex::new(HashMap::new()),
+            queued_data_bytes: AtomicUsize::new(0),
+            event_space_notify: tokio::sync::Notify::new(),
         }
     }
 
@@ -642,6 +661,12 @@ impl SharedState {
         }
     }
 
+    /// Queues a control event: prompts, Connected, ExitStatus, Error, Closed, forward
+    /// open/EOF/close notices. Never blocks and never counts toward the data budget — those
+    /// events are few and tiny, and a queue full of stalled terminal output must not be able
+    /// to hold back the very events that let the managed side notice and act.
+    ///
+    /// Data-bearing events (Data, ForwardChannelData) go through `queue_data_event` instead.
     fn queue_event(&self, event: QueuedEvent) {
         if *self.closed.lock().unwrap_or_else(|e| e.into_inner()) {
             return;
@@ -651,6 +676,46 @@ impl SharedState {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .push_back(event);
+    }
+
+    /// Queues a data-bearing event, parking until the queue is under MAX_QUEUED_EVENT_BYTES
+    /// first. Parking the caller is the whole mechanism, not a stopgap: the callers are channel
+    /// readers, and a reader that stops consuming lets russh's bounded per-channel buffer fill,
+    /// which stalls the session task's socket reads, which stops window replenishment — so SSH
+    /// flow control makes the remote hold the stream instead of this process buffering an
+    /// unbounded backlog (#173 item 1).
+    ///
+    /// The known cost, accepted deliberately: while a producer is parked the session's select
+    /// loop (or a forward reader) is not doing anything else, so writes, resizes and keepalive
+    /// traffic stall with it. That only happens when the managed poll loop has already stopped
+    /// draining for multiple megabytes' worth of output — a consumer that is stalled, not slow —
+    /// and the alternative was growing the queue by the whole remaining stream.
+    ///
+    /// Ordering is preserved per producer: a parked producer emits nothing else until admitted,
+    /// so its later control events (EOF, Closed) still queue after the data they follow.
+    ///
+    /// Returns false if the session closed while parked; the caller should stop reading.
+    async fn queue_data_event(&self, event: QueuedEvent) -> bool {
+        loop {
+            // Create-notified-then-check, like wait_closed: a drain or close that lands between
+            // the check and the await must not be missed.
+            let notified = self.event_space_notify.notified();
+            if self.is_closed() {
+                return false;
+            }
+            // Admit while strictly under budget, even if this event overshoots it. The budget is
+            // a soft cap (same rule as the forward-write budget): any single event can always
+            // make progress once the queue drains, so no payload size can wedge a producer.
+            if self.queued_data_bytes.load(Ordering::Acquire) < MAX_QUEUED_EVENT_BYTES {
+                break;
+            }
+            notified.await;
+        }
+
+        self.queued_data_bytes
+            .fetch_add(event.payload.len(), Ordering::AcqRel);
+        self.queue_event(event);
+        true
     }
 
     /// Removes and returns the head event if its payload fits in `payload_capacity`; otherwise
@@ -687,7 +752,26 @@ impl SharedState {
 
         // Moves the payload out; nothing is duplicated.
         match events.pop_front() {
-            Some(event) => EventRead::Ready(event),
+            Some(event) => {
+                if matches!(
+                    event.kind,
+                    NovaSshEventKind::Data | NovaSshEventKind::ForwardChannelData
+                ) {
+                    // Saturating on purpose: FFI tests (and any future direct caller) can queue a
+                    // data-kind event through queue_event without the budget accounting, and an
+                    // underflow here would wrap the counter to a huge value and park every
+                    // producer forever. Short is safe; wrapped is a wedged session.
+                    let len = event.payload.len();
+                    let _ = self.queued_data_bytes.fetch_update(
+                        Ordering::AcqRel,
+                        Ordering::Acquire,
+                        |bytes| Some(bytes.saturating_sub(len)),
+                    );
+                    self.event_space_notify.notify_waiters();
+                }
+
+                EventRead::Ready(event)
+            }
             None => EventRead::Empty,
         }
     }
@@ -722,6 +806,9 @@ impl SharedState {
         *self.closed.lock().unwrap_or_else(|e| e.into_inner()) = true;
         self.response_cv.notify_all();
         self.closed_notify.notify_waiters();
+        // A producer parked in queue_data_event must observe the close and bail, or
+        // nova_ssh_close would join a worker that is waiting for a drain that will never come.
+        self.event_space_notify.notify_waiters();
     }
 }
 
@@ -3006,21 +3093,30 @@ fn run_session(
                 }
                 message = channel.wait() => {
                     match message {
+                        // Both data arms park on the byte budget. While parked, this loop reads
+                        // nothing further — including WorkerCommands — which is intended: the
+                        // budget only fills when the managed poll loop has stopped draining, and
+                        // an unread channel is what makes SSH flow control throttle the remote.
+                        // A close still gets through, via queue_data_event's is_closed check.
                         Some(ChannelMsg::Data { data }) => {
-                            shared.queue_event(QueuedEvent {
+                            if !shared.queue_data_event(QueuedEvent {
                                 kind: NovaSshEventKind::Data,
                                 payload: data.to_vec(),
                                 status_code: 0,
                                 flags: NOVA_SSH_EVENT_FLAG_BINARY,
-                            });
+                            }).await {
+                                break;
+                            }
                         }
                         Some(ChannelMsg::ExtendedData { data, .. }) => {
-                            shared.queue_event(QueuedEvent {
+                            if !shared.queue_data_event(QueuedEvent {
                                 kind: NovaSshEventKind::Data,
                                 payload: data.to_vec(),
                                 status_code: 0,
                                 flags: NOVA_SSH_EVENT_FLAG_BINARY,
-                            });
+                            }).await {
+                                break;
+                            }
                         }
                         Some(ChannelMsg::ExitStatus { exit_status }) => {
                             shared.queue_event(QueuedEvent {
@@ -3177,21 +3273,34 @@ async fn open_direct_tcpip_channel(
     tokio::spawn(async move {
         loop {
             match read_half.wait().await {
+                // The data arms share the session-wide byte budget with terminal output. A
+                // parked reader stops consuming this channel only; on a closed session it just
+                // breaks — session teardown owns the map and task cleanup at that point.
                 Some(ChannelMsg::Data { data }) => {
-                    reader_shared.queue_event(QueuedEvent {
-                        kind: NovaSshEventKind::ForwardChannelData,
-                        payload: data.to_vec(),
-                        status_code: channel_id as i32,
-                        flags: NOVA_SSH_EVENT_FLAG_BINARY,
-                    });
+                    if !reader_shared
+                        .queue_data_event(QueuedEvent {
+                            kind: NovaSshEventKind::ForwardChannelData,
+                            payload: data.to_vec(),
+                            status_code: channel_id as i32,
+                            flags: NOVA_SSH_EVENT_FLAG_BINARY,
+                        })
+                        .await
+                    {
+                        break;
+                    }
                 }
                 Some(ChannelMsg::ExtendedData { data, .. }) => {
-                    reader_shared.queue_event(QueuedEvent {
-                        kind: NovaSshEventKind::ForwardChannelData,
-                        payload: data.to_vec(),
-                        status_code: channel_id as i32,
-                        flags: NOVA_SSH_EVENT_FLAG_BINARY,
-                    });
+                    if !reader_shared
+                        .queue_data_event(QueuedEvent {
+                            kind: NovaSshEventKind::ForwardChannelData,
+                            payload: data.to_vec(),
+                            status_code: channel_id as i32,
+                            flags: NOVA_SSH_EVENT_FLAG_BINARY,
+                        })
+                        .await
+                    {
+                        break;
+                    }
                 }
                 Some(ChannelMsg::Eof) => {
                     reader_shared.queue_event(QueuedEvent {
@@ -5267,5 +5376,165 @@ mod forward_write_backpressure_tests {
 
         assert_eq!(NOVA_SSH_RESULT_CLOSED, write(handle, 6, 2048));
         assert_eq!(0, budget.load(Ordering::Acquire));
+    }
+}
+
+/// Event-queue byte budget (#173 item 1).
+///
+/// These pin the SharedState half of the contract: data-bearing events park their producer at the
+/// budget and are released by draining (or by close), while control events are never gated. The
+/// channel-reader half — that a parked reader makes SSH flow control throttle the remote — is
+/// russh's window machinery and needs a live server; the Docker E2E suite exercises that path.
+#[cfg(test)]
+mod event_queue_budget_tests {
+    use super::*;
+
+    fn data_event(len: usize) -> QueuedEvent {
+        QueuedEvent {
+            kind: NovaSshEventKind::Data,
+            payload: vec![0u8; len],
+            status_code: 0,
+            flags: NOVA_SSH_EVENT_FLAG_BINARY,
+        }
+    }
+
+    fn control_event(len: usize) -> QueuedEvent {
+        QueuedEvent {
+            kind: NovaSshEventKind::ExitStatus,
+            payload: vec![0u8; len],
+            status_code: 0,
+            flags: NOVA_SSH_EVENT_FLAG_JSON,
+        }
+    }
+
+    /// Lets the spawned producer make progress on the current-thread test runtime, then reports
+    /// whether it finished. Several yields, not one: admission takes a wake plus a re-check.
+    async fn settle(task: &tokio::task::JoinHandle<bool>) -> bool {
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+        task.is_finished()
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn under_budget_data_is_admitted_immediately_and_drain_releases_bytes() {
+        let shared = Arc::new(SharedState::new());
+
+        assert!(
+            shared
+                .queue_data_event(data_event(MAX_QUEUED_EVENT_BYTES))
+                .await
+        );
+        assert_eq!(
+            MAX_QUEUED_EVENT_BYTES,
+            shared.queued_data_bytes.load(Ordering::Acquire)
+        );
+
+        match shared.take_event_if_fits(usize::MAX) {
+            EventRead::Ready(event) => assert_eq!(MAX_QUEUED_EVENT_BYTES, event.payload.len()),
+            _ => panic!("the queued data event must pop"),
+        }
+
+        assert_eq!(0, shared.queued_data_bytes.load(Ordering::Acquire));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn over_budget_data_parks_its_producer_until_the_queue_drains() {
+        let shared = Arc::new(SharedState::new());
+
+        // One admitted event may overshoot the budget (soft cap); the *next* one must park.
+        assert!(
+            shared
+                .queue_data_event(data_event(MAX_QUEUED_EVENT_BYTES))
+                .await
+        );
+
+        let parked = tokio::spawn({
+            let shared = shared.clone();
+            async move { shared.queue_data_event(data_event(1)).await }
+        });
+
+        assert!(
+            !settle(&parked).await,
+            "a producer over budget must park, not enqueue"
+        );
+
+        match shared.take_event_if_fits(usize::MAX) {
+            EventRead::Ready(_) => {}
+            _ => panic!("draining must succeed"),
+        }
+
+        assert!(
+            settle(&parked).await,
+            "draining below budget must wake the parked producer"
+        );
+        assert!(parked.await.expect("producer task must not panic"));
+        assert_eq!(1, shared.queued_data_bytes.load(Ordering::Acquire));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn close_wakes_a_parked_producer_and_refuses_its_event() {
+        let shared = Arc::new(SharedState::new());
+
+        assert!(
+            shared
+                .queue_data_event(data_event(MAX_QUEUED_EVENT_BYTES))
+                .await
+        );
+
+        let parked = tokio::spawn({
+            let shared = shared.clone();
+            async move { shared.queue_data_event(data_event(1)).await }
+        });
+        assert!(!settle(&parked).await);
+
+        shared.mark_closed();
+
+        assert!(settle(&parked).await, "close must wake a parked producer");
+        assert!(
+            !parked.await.expect("producer task must not panic"),
+            "an event refused by close must report false so the reader stops"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn control_events_neither_count_toward_nor_wait_on_the_budget() {
+        let shared = Arc::new(SharedState::new());
+
+        // A control payload larger than the whole budget still admits the next data event
+        // immediately: only data-bearing bytes count.
+        shared.queue_event(control_event(MAX_QUEUED_EVENT_BYTES * 2));
+        assert_eq!(0, shared.queued_data_bytes.load(Ordering::Acquire));
+        assert!(shared.queue_data_event(data_event(16)).await);
+
+        // Popping the control event must not touch the data counter either — FIFO order, the
+        // control event is at the head.
+        match shared.take_event_if_fits(usize::MAX) {
+            EventRead::Ready(event) => assert_eq!(NovaSshEventKind::ExitStatus, event.kind),
+            _ => panic!("the control event must pop first"),
+        }
+        assert_eq!(16, shared.queued_data_bytes.load(Ordering::Acquire));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn popping_unaccounted_data_saturates_instead_of_wrapping_the_counter() {
+        let shared = Arc::new(SharedState::new());
+
+        // FFI tests queue data-kind events through queue_event, bypassing the accounting. The
+        // pop-side decrement must saturate at zero for them: a wrapped counter would read as
+        // "gigabytes queued" and park every later producer forever.
+        shared.queue_event(data_event(1024));
+        assert_eq!(0, shared.queued_data_bytes.load(Ordering::Acquire));
+
+        match shared.take_event_if_fits(usize::MAX) {
+            EventRead::Ready(_) => {}
+            _ => panic!("the event must pop"),
+        }
+
+        assert_eq!(0, shared.queued_data_bytes.load(Ordering::Acquire));
+        assert!(
+            shared.queue_data_event(data_event(1)).await,
+            "the counter must still admit producers after the unaccounted pop"
+        );
     }
 }

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -125,6 +125,22 @@ const MAX_QUEUED_FORWARD_WRITE_BYTES: usize = 1024 * 1024;
 /// accumulating the entire stream. Control events are exempt: see `queue_data_event`.
 const MAX_QUEUED_EVENT_BYTES: usize = 4 * 1024 * 1024;
 
+/// Flat surcharge each data-bearing event contributes to the budget on top of its payload
+/// length, approximating what a queued event actually costs (the QueuedEvent struct, its Vec
+/// header, the VecDeque slot). Without it, zero-length Data messages would be free: they consume
+/// no SSH window either — flow control counts data bytes — so a peer spamming empty data frames
+/// would grow the queue's per-event overhead without bound while the byte counter never moved.
+/// With the surcharge the budget caps the queue at ~64K events even if every one is empty,
+/// keeping real memory within the same order as the budget itself.
+const QUEUED_DATA_EVENT_OVERHEAD_BYTES: usize = 64;
+
+/// What one data-bearing event charges against MAX_QUEUED_EVENT_BYTES. Admission and release
+/// must both use this — an event released cheaper than it was admitted leaks budget until the
+/// producers park forever, and the reverse drifts the cap upward.
+fn queued_data_event_cost(payload_len: usize) -> usize {
+    payload_len.saturating_add(QUEUED_DATA_EVENT_OVERHEAD_BYTES)
+}
+
 /// Runs an FFI body, converting any panic into `on_panic` instead of unwinding
 /// across the C boundary (which is undefined behavior). The body is asserted
 /// unwind-safe because FFI bodies operate on raw pointers owned by the caller.
@@ -712,8 +728,10 @@ impl SharedState {
             notified.await;
         }
 
-        self.queued_data_bytes
-            .fetch_add(event.payload.len(), Ordering::AcqRel);
+        self.queued_data_bytes.fetch_add(
+            queued_data_event_cost(event.payload.len()),
+            Ordering::AcqRel,
+        );
         self.queue_event(event);
         true
     }
@@ -761,11 +779,11 @@ impl SharedState {
                     // data-kind event through queue_event without the budget accounting, and an
                     // underflow here would wrap the counter to a huge value and park every
                     // producer forever. Short is safe; wrapped is a wedged session.
-                    let len = event.payload.len();
+                    let cost = queued_data_event_cost(event.payload.len());
                     let _ = self.queued_data_bytes.fetch_update(
                         Ordering::AcqRel,
                         Ordering::Acquire,
-                        |bytes| Some(bytes.saturating_sub(len)),
+                        |bytes| Some(bytes.saturating_sub(cost)),
                     );
                     self.event_space_notify.notify_waiters();
                 }
@@ -5426,7 +5444,7 @@ mod event_queue_budget_tests {
                 .await
         );
         assert_eq!(
-            MAX_QUEUED_EVENT_BYTES,
+            queued_data_event_cost(MAX_QUEUED_EVENT_BYTES),
             shared.queued_data_bytes.load(Ordering::Acquire)
         );
 
@@ -5469,7 +5487,10 @@ mod event_queue_budget_tests {
             "draining below budget must wake the parked producer"
         );
         assert!(parked.await.expect("producer task must not panic"));
-        assert_eq!(1, shared.queued_data_bytes.load(Ordering::Acquire));
+        assert_eq!(
+            queued_data_event_cost(1),
+            shared.queued_data_bytes.load(Ordering::Acquire)
+        );
     }
 
     #[tokio::test(start_paused = true)]
@@ -5513,7 +5534,50 @@ mod event_queue_budget_tests {
             EventRead::Ready(event) => assert_eq!(NovaSshEventKind::ExitStatus, event.kind),
             _ => panic!("the control event must pop first"),
         }
-        assert_eq!(16, shared.queued_data_bytes.load(Ordering::Acquire));
+        assert_eq!(
+            queued_data_event_cost(16),
+            shared.queued_data_bytes.load(Ordering::Acquire)
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn empty_data_events_still_consume_budget_and_eventually_park() {
+        // Codex review finding on this change: zero-length Data frames consume no SSH window
+        // (flow control counts data bytes), so without a per-event surcharge a peer could spam
+        // them forever — never throttled, never counted, queue overhead growing without bound.
+        // The surcharge makes each empty event cost QUEUED_DATA_EVENT_OVERHEAD_BYTES, so the
+        // budget still fills and the producer still parks.
+        let shared = Arc::new(SharedState::new());
+
+        assert!(shared.queue_data_event(data_event(0)).await);
+        assert_eq!(
+            QUEUED_DATA_EVENT_OVERHEAD_BYTES,
+            shared.queued_data_bytes.load(Ordering::Acquire)
+        );
+
+        let empties_to_fill = MAX_QUEUED_EVENT_BYTES / QUEUED_DATA_EVENT_OVERHEAD_BYTES;
+        for _ in 1..empties_to_fill {
+            assert!(shared.queue_data_event(data_event(0)).await);
+        }
+
+        let parked = tokio::spawn({
+            let shared = shared.clone();
+            async move { shared.queue_data_event(data_event(0)).await }
+        });
+        assert!(
+            !settle(&parked).await,
+            "a stream of empty data events must fill the budget and park, not bypass it"
+        );
+
+        match shared.take_event_if_fits(usize::MAX) {
+            EventRead::Ready(_) => {}
+            _ => panic!("draining must succeed"),
+        }
+        assert!(
+            settle(&parked).await,
+            "draining must wake the parked producer"
+        );
+        assert!(parked.await.expect("producer task must not panic"));
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
## What this changes

`queue_event` in rusty_ssh had no bound: a `cat bigfile` while the managed poll loop was stalled accumulated the entire stream in process memory. Data-bearing events (terminal `Data`, `ForwardChannelData`) now share a 4 MiB byte budget; at the budget the channel readers park in a new `queue_data_event` instead of reading on, and parking the reader is the whole mechanism — an unread russh channel fills its bounded per-channel buffer, which stalls the session task's socket reads, which stops window replenishment, so SSH flow control makes the **remote** hold the stream. A stalled consumer now caps at the budget plus one in-flight window (~6 MiB) instead of the whole file.

Fixes the remaining half of #173 item 1 (the pop-returning-owned poll that killed the per-poll payload copy landed earlier as `take_event_if_fits`). Items 1 and 2 of #173 are now both done; item 3 (managed-side poll latency/allocations) stays open.

Design points a reviewer will want to check:

- **Control events are exempt** — prompts, `Connected`, `ExitStatus`, `Error`, forward open/EOF/close notices never block and never count toward the budget. A queue full of stalled terminal output must not hold back the events that let the managed side notice and act. Ordering survives because each producer emits its control events only after its own data is admitted.
- **Verified against russh 0.59's source, not assumed**: the client session task `await`s each channel's bounded (100-message) buffer and the default window is 2 MiB, so the park genuinely propagates to the remote. The budget sits above the window, so a healthy poll loop can never trip it — even a full window landing during one idle poll gap fits.
- **Close cannot deadlock the new wait**: `mark_closed` wakes parked producers, `queue_data_event` reports the close, the reader breaks — otherwise `nova_ssh_close` would join a worker waiting for a drain that never comes (the #155 lesson applied to a new wait). The `Notify` create-then-check pattern is the same one `wait_closed` already relies on.
- **The pop-side decrement saturates** rather than wrapping: FFI tests queue data-kind events directly through `queue_event` without the accounting, and an underflowed counter would read as gigabytes queued and park every producer forever.
- **Accepted cost, documented in the code**: while a producer is parked, the session's select loop processes nothing else (writes, resizes, keepalives). That only happens when the managed poll loop has already stopped draining for multiple megabytes — a consumer that is stalled, not slow — and the alternative was unbounded growth.

## Invariant and ownership

- **What invariant does this change affect?** Bounded memory for the native SSH output path: no amount of remote output can grow the event queue past its budget, and no full queue can suppress or reorder a control event. Ordering per producer is unchanged.
- **Which module owns that invariant?** `src/NovaTerminal.App/native/rusty_ssh` (SharedState); the FFI poll contract with NovaTerminal.Platform is unchanged — no managed code is touched.

## Tests

- **What tests cover this change?** Five new SharedState tests in `event_queue_budget_tests` (lib.rs): immediate admission under budget with byte accounting released on drain; a producer over budget parks and is woken by a drain (mutation-verified — removing the drain notification fails exactly that test); close wakes a parked producer and refuses its event; control events neither count toward nor wait on the budget; popping unaccounted data saturates instead of wrapping the counter. The flow-control half (parked reader → remote throttled) needs a live server and is exercised by the existing Docker E2E suite, which pushes real bulk output and forward traffic through this queue.

- **Which categories did you run locally?**
  - [ ] full unfiltered run (`scripts/build.sh test`)
  - [ ] `Category=Replay`
  - [ ] `Category=RenderMetrics`
  - [ ] `Category=PtySmoke`
  - [ ] `tests/NovaTerminal.App.Tests` (non-blocking in CI — check it yourself)
  - [ ] full local CI rehearsal (`ci/run.sh` / `ci/run.ps1`)

  This diff is Rust-only plus one doc file — no managed code changes, so the .NET categories are unaffected by it (and the authoring container still has no .NET SDK; CI runs them regardless). What did run locally: `cargo test` (87 passing, 5 new), the mutation check above, and clippy + rustfmt, both byte-identical to main's baseline.

## Impact

- **Does this affect cross-platform behavior?** No — the change is inside the Rust crate, identical on all platforms. Docker E2E exercises it on Linux; Rust FFI tests run on both CI OSes.
- **Does this change renderer metrics?** Not applicable — no renderer code touched. It is a perf change to the SSH output path: steady-state throughput is unaffected (the budget only engages when the consumer stops draining), and memory under a stalled consumer drops from unbounded to ~6 MiB.
- **Does this change VT coverage?** Not applicable — no VT sequences touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHPUK1JQgoV6t4RsSNeXKs

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHPUK1JQgoV6t4RsSNeXKs)_