### PR TITLE
feat(settings): SSH tab with a toggle for the experimental native backend

### DIFF
--- a/docs/SSH_ROADMAP.md
+++ b/docs/SSH_ROADMAP.md
@@ -36,7 +36,8 @@ The native SSH initiative is implemented behind conservative rollout controls.
 ### Rollout guidance
 
 - `OpenSsh` remains the default backend.
-- `Native` is gated by `TerminalSettings.ExperimentalNativeSshEnabled`.
+- `Native` is gated by `TerminalSettings.ExperimentalNativeSshEnabled`, toggleable in
+  the app under Settings > SSH.
 - Native SSH does **not** silently fall back to OpenSSH on failure.
 - Whether native *can* serve a given profile is answered in one place,
   `NativeSshCapability.Evaluate` — a remote forward is the one shape it refuses

--- a/docs/native-ssh/Native_SSH_Test_Matrix.md
+++ b/docs/native-ssh/Native_SSH_Test_Matrix.md
@@ -69,7 +69,8 @@ Rows marked Automated run in the `Native SSH Docker E2E` CI job (Linux), which s
   Before that job existed the suite was `[DockerFact]`-gated on `NOVATERM_ENABLE_DOCKER_E2E`
   and nothing in CI set it, so it was written and then never executed — the reason auth and
   forwarding rows above stayed "pending manual" while a Dockerized suite sat beside them.
-- Native SSH remains opt-in through `TerminalSettings.ExperimentalNativeSshEnabled`.
+- Native SSH remains opt-in through `TerminalSettings.ExperimentalNativeSshEnabled`,
+  toggleable in the app under Settings > SSH.
 - `OpenSsh` remains the default backend for new profiles.
 - Native backend refusal is explicit when the global experimental toggle is disabled.
 - The one profile shape the native backend cannot serve (a remote forward) is

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -5333,7 +5333,7 @@ namespace NovaTerminal
                     {
                         await ShowSimpleMessageDialogAsync(
                             "Native SSH disabled",
-                            "This profile was saved with the Native backend, but native SSH is disabled globally. Enable ExperimentalNativeSshEnabled in settings or switch the profile back to OpenSSH.");
+                            "This profile was saved with the Native backend, but native SSH is disabled globally. Turn it on under Settings > SSH or switch the profile back to OpenSSH.");
                         return;
                     }
 

--- a/src/NovaTerminal.App/SettingsWindow.axaml
+++ b/src/NovaTerminal.App/SettingsWindow.axaml
@@ -321,6 +321,18 @@
                             </ListBoxItem>
                         </ListBox>
 
+                        <TextBlock Classes="SectionHeader" Text="CONNECTION" Margin="14,18,14,8"/>
+                        <ListBox Name="ConnectionNav"
+                                 Classes="SideNav"
+                                 SelectionMode="Single">
+                            <ListBoxItem>
+                                <Grid ColumnDefinitions="20,*">
+                                    <TextBlock Grid.Column="0" Text="⇄" FontSize="13" Foreground="{StaticResource NtFg3}" VerticalAlignment="Center"/>
+                                    <TextBlock Grid.Column="1" Text="SSH" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                                </Grid>
+                            </ListBoxItem>
+                        </ListBox>
+
                         <Border Margin="14,18,14,8"
                                 Padding="0,12,0,0"
                                 BorderBrush="{StaticResource NtHairline}"
@@ -897,29 +909,6 @@
                     </ScrollViewer>
                 </TabItem>
 
-                <!-- ┌──── SSH ────┐ -->
-                <TabItem Header="SSH">
-                    <ScrollViewer VerticalScrollBarVisibility="Auto">
-                        <StackPanel Margin="32,28,32,28" Spacing="0">
-
-                            <StackPanel Margin="0,0,0,24">
-                                <TextBlock Classes="H1" Text="SSH"/>
-                                <TextBlock Classes="Subtitle" Margin="0,4,0,0" Text="Global SSH behavior. Per-connection options (host, auth, jump hosts, forwards) live on each profile."/>
-                            </StackPanel>
-
-                            <Grid ColumnDefinitions="*,360">
-                                <StackPanel Grid.Column="0" Spacing="2">
-                                    <TextBlock Classes="RowLabel" Text="Native SSH backend (experimental)"/>
-                                    <TextBlock Classes="RowDesc" Text="Allow profiles set to the Native backend to connect with NovaTerminal's built-in SSH client instead of the system ssh. Applies to new connections only; sessions already open are unaffected. While this is off, a profile explicitly set to Native refuses to connect rather than silently falling back — OpenSSH profiles are unaffected either way."/>
-                                </StackPanel>
-                                <CheckBox Name="NativeSshToggle" Grid.Column="1" Classes="Toggle" Content="" HorizontalAlignment="Right" VerticalAlignment="Center"/>
-                            </Grid>
-                            <Border BorderBrush="{StaticResource NtHairline}" BorderThickness="0,0,0,1" Margin="0,14,0,14"/>
-
-                        </StackPanel>
-                    </ScrollViewer>
-                </TabItem>
-
                 <!-- ┌──── Agent Access ────┐ -->
                 <TabItem Header="Agent Access">
                     <ScrollViewer VerticalScrollBarVisibility="Auto">
@@ -964,6 +953,29 @@
                                 </StackPanel>
                                 <CheckBox Name="AgentAccessActToggle" Grid.Column="1" Classes="Toggle" Content="" HorizontalAlignment="Right" VerticalAlignment="Center"/>
                             </Grid>
+                        </StackPanel>
+                    </ScrollViewer>
+                </TabItem>
+
+                <!-- ┌──── SSH ────┐ -->
+                <TabItem Header="SSH">
+                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <StackPanel Margin="32,28,32,28" Spacing="0">
+
+                            <StackPanel Margin="0,0,0,24">
+                                <TextBlock Classes="H1" Text="SSH"/>
+                                <TextBlock Classes="Subtitle" Margin="0,4,0,0" Text="Global SSH behavior. Per-connection options (host, auth, jump hosts, forwards) live on each profile."/>
+                            </StackPanel>
+
+                            <Grid ColumnDefinitions="*,360">
+                                <StackPanel Grid.Column="0" Spacing="2">
+                                    <TextBlock Classes="RowLabel" Text="Native SSH backend (experimental)"/>
+                                    <TextBlock Classes="RowDesc" Text="Allow profiles set to the Native backend to connect with NovaTerminal's built-in SSH client instead of the system ssh. Applies to new connections only; sessions already open are unaffected. While this is off, a profile explicitly set to Native refuses to connect rather than silently falling back — OpenSSH profiles are unaffected either way."/>
+                                </StackPanel>
+                                <CheckBox Name="NativeSshToggle" Grid.Column="1" Classes="Toggle" Content="" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                            </Grid>
+                            <Border BorderBrush="{StaticResource NtHairline}" BorderThickness="0,0,0,1" Margin="0,14,0,14"/>
+
                         </StackPanel>
                     </ScrollViewer>
                 </TabItem>

--- a/src/NovaTerminal.App/SettingsWindow.axaml
+++ b/src/NovaTerminal.App/SettingsWindow.axaml
@@ -897,6 +897,29 @@
                     </ScrollViewer>
                 </TabItem>
 
+                <!-- ┌──── SSH ────┐ -->
+                <TabItem Header="SSH">
+                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <StackPanel Margin="32,28,32,28" Spacing="0">
+
+                            <StackPanel Margin="0,0,0,24">
+                                <TextBlock Classes="H1" Text="SSH"/>
+                                <TextBlock Classes="Subtitle" Margin="0,4,0,0" Text="Global SSH behavior. Per-connection options (host, auth, jump hosts, forwards) live on each profile."/>
+                            </StackPanel>
+
+                            <Grid ColumnDefinitions="*,360">
+                                <StackPanel Grid.Column="0" Spacing="2">
+                                    <TextBlock Classes="RowLabel" Text="Native SSH backend (experimental)"/>
+                                    <TextBlock Classes="RowDesc" Text="Allow profiles set to the Native backend to connect with NovaTerminal's built-in SSH client instead of the system ssh. Applies to new connections only; sessions already open are unaffected. While this is off, a profile explicitly set to Native refuses to connect rather than silently falling back — OpenSSH profiles are unaffected either way."/>
+                                </StackPanel>
+                                <CheckBox Name="NativeSshToggle" Grid.Column="1" Classes="Toggle" Content="" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                            </Grid>
+                            <Border BorderBrush="{StaticResource NtHairline}" BorderThickness="0,0,0,1" Margin="0,14,0,14"/>
+
+                        </StackPanel>
+                    </ScrollViewer>
+                </TabItem>
+
                 <!-- ┌──── Agent Access ────┐ -->
                 <TabItem Header="Agent Access">
                     <ScrollViewer VerticalScrollBarVisibility="Auto">

--- a/src/NovaTerminal.App/SettingsWindow.axaml.cs
+++ b/src/NovaTerminal.App/SettingsWindow.axaml.cs
@@ -1990,6 +1990,8 @@ namespace NovaTerminal
             var commandAssistToggle = this.FindControl<CheckBox>("CommandAssistToggle");
             var agentAccessObserveToggle = this.FindControl<CheckBox>("AgentAccessObserveToggle");
 
+            var nativeSshToggle = this.FindControl<CheckBox>("NativeSshToggle");
+            if (nativeSshToggle != null) nativeSshToggle.IsChecked = _settings.ExperimentalNativeSshEnabled;
             if (agentAccessObserveToggle != null) agentAccessObserveToggle.IsChecked = _settings.AgentAccessObserveEnabled;
             var agentReplayExportToggle = this.FindControl<CheckBox>("AgentReplayExportToggle");
             if (agentReplayExportToggle != null) agentReplayExportToggle.IsChecked = _settings.AgentReplayExportEnabled;
@@ -2242,6 +2244,8 @@ namespace NovaTerminal
             if (commandAssistHistoryToggle != null) _settings.CommandAssistHistoryEnabled = commandAssistHistoryToggle.IsChecked == true;
             var commandAssistShellIntegrationToggle = this.FindControl<CheckBox>("CommandAssistShellIntegrationToggle");
             if (commandAssistShellIntegrationToggle != null) _settings.CommandAssistShellIntegrationEnabled = commandAssistShellIntegrationToggle.IsChecked == true;
+            var nativeSshToggle = this.FindControl<CheckBox>("NativeSshToggle");
+            if (nativeSshToggle != null) _settings.ExperimentalNativeSshEnabled = nativeSshToggle.IsChecked == true;
             var agentAccessObserveToggle = this.FindControl<CheckBox>("AgentAccessObserveToggle");
             if (agentAccessObserveToggle != null) _settings.AgentAccessObserveEnabled = agentAccessObserveToggle.IsChecked == true;
             var agentReplayExportToggle = this.FindControl<CheckBox>("AgentReplayExportToggle");

--- a/src/NovaTerminal.App/SettingsWindow.axaml.cs
+++ b/src/NovaTerminal.App/SettingsWindow.axaml.cs
@@ -101,15 +101,22 @@ namespace NovaTerminal
             var tabs = this.FindControl<TabControl>("MainTabs");
             if (tabs != null) tabs.SelectedIndex = initialTab;
 
-            // Keep the two sidebar list boxes in sync with the tab control. The previous single
+            // Keep the sidebar list boxes in sync with the tab control. The previous single
             // list box drove selection via a direct SelectedIndex binding; that breaks once the
-            // sidebar is split (InterfaceNav holds tabs 0-2, AssistantNav holds tabs 3-4), so
-            // route everything through this small dispatcher instead.
+            // sidebar is split (InterfaceNav holds tabs 0-2, AssistantNav holds tabs 3-4,
+            // ConnectionNav holds tab 5), so route everything through this small dispatcher
+            // instead. The tab header strip is not the navigation — these lists are — so a new
+            // tab MUST get a sidebar item and a mapping here, or it is unreachable. That is not
+            // hypothetical: the SSH tab initially shipped without one, which silently remapped
+            // the "Agent Access" item onto SSH and stranded the real Agent Access tab
+            // (Codex review finding on #332). New tabs go at the END of the TabControl so the
+            // existing offsets stay true.
             var interfaceNav = this.FindControl<ListBox>("InterfaceNav");
             var assistantNav = this.FindControl<ListBox>("AssistantNav");
-            if (tabs != null && interfaceNav != null && assistantNav != null)
+            var connectionNav = this.FindControl<ListBox>("ConnectionNav");
+            if (tabs != null && interfaceNav != null && assistantNav != null && connectionNav != null)
             {
-                tabs.SelectionChanged += (_, _) => SyncSidebarFromTabs(tabs, interfaceNav, assistantNav);
+                tabs.SelectionChanged += (_, _) => SyncSidebarFromTabs(tabs, interfaceNav, assistantNav, connectionNav);
                 interfaceNav.SelectionChanged += (_, _) =>
                 {
                     if (interfaceNav.SelectedIndex < 0) return;
@@ -120,7 +127,12 @@ namespace NovaTerminal
                     if (assistantNav.SelectedIndex < 0) return;
                     tabs.SelectedIndex = assistantNav.SelectedIndex + 3;
                 };
-                SyncSidebarFromTabs(tabs, interfaceNav, assistantNav);
+                connectionNav.SelectionChanged += (_, _) =>
+                {
+                    if (connectionNav.SelectedIndex < 0) return;
+                    tabs.SelectedIndex = connectionNav.SelectedIndex + 5;
+                };
+                SyncSidebarFromTabs(tabs, interfaceNav, assistantNav, connectionNav);
             }
 
             // Settings editor is local-profiles only; SSH connections are managed in Connection Manager.
@@ -856,18 +868,19 @@ namespace NovaTerminal
         }
 
         /// <summary>
-        /// Mirror the current tab control selection into the two sidebar list boxes.
+        /// Mirror the current tab control selection into the sidebar list boxes.
         /// InterfaceNav owns tabs 0-2 (Appearance / Profiles / Shortcuts), AssistantNav owns
-        /// tabs 3-4 (Command Assist / Agent Access). The exact other list box is cleared so
-        /// only one item ever reads as selected.
+        /// tabs 3-4 (Command Assist / Agent Access), ConnectionNav owns tab 5 (SSH). The other
+        /// list boxes are cleared so only one item ever reads as selected.
         /// </summary>
-        private static void SyncSidebarFromTabs(TabControl tabs, ListBox interfaceNav, ListBox assistantNav)
+        private static void SyncSidebarFromTabs(TabControl tabs, ListBox interfaceNav, ListBox assistantNav, ListBox connectionNav)
         {
             var idx = tabs.SelectedIndex;
             if (idx < 0)
             {
                 interfaceNav.SelectedIndex = -1;
                 assistantNav.SelectedIndex = -1;
+                connectionNav.SelectedIndex = -1;
                 return;
             }
 
@@ -875,11 +888,19 @@ namespace NovaTerminal
             {
                 interfaceNav.SelectedIndex = idx;
                 assistantNav.SelectedIndex = -1;
+                connectionNav.SelectedIndex = -1;
+            }
+            else if (idx < 5)
+            {
+                interfaceNav.SelectedIndex = -1;
+                assistantNav.SelectedIndex = idx - 3;
+                connectionNav.SelectedIndex = -1;
             }
             else
             {
                 interfaceNav.SelectedIndex = -1;
-                assistantNav.SelectedIndex = idx - 3;
+                assistantNav.SelectedIndex = -1;
+                connectionNav.SelectedIndex = idx - 5;
             }
         }
 

--- a/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
+++ b/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
@@ -251,7 +251,7 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
             }
 
             // Capability outranks the global toggle on purpose: if native could not serve this shape
-            // even with the toggle on, "enable ExperimentalNativeSshEnabled" sends the user down a
+            // even with the toggle on, "turn it on under Settings > SSH" sends the user down a
             // dead end. Name the real blocker first.
             NativeSshCapabilityResult capability = NativeSshCapability.Evaluate(Forwards, JumpHops);
             if (!capability.IsSupported)
@@ -261,7 +261,7 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
 
             return ExperimentalNativeSshEnabled
                 ? string.Empty
-                : "Native SSH is disabled globally. Enable ExperimentalNativeSshEnabled in settings or switch this profile back to OpenSSH.";
+                : "Native SSH is disabled globally. Turn it on under Settings > SSH, or switch this profile back to OpenSSH.";
         }
     }
 

--- a/src/NovaTerminal.Platform/Ssh/Sessions/SshSessionFactory.cs
+++ b/src/NovaTerminal.Platform/Ssh/Sessions/SshSessionFactory.cs
@@ -72,7 +72,7 @@ public sealed class SshSessionFactory : ISshSessionFactory
         if (!_nativeSshEnabled)
         {
             throw new InvalidOperationException(
-                "Native SSH is disabled globally. Switch this profile back to OpenSSH or enable ExperimentalNativeSshEnabled.");
+                "Native SSH is disabled globally. Switch this profile back to OpenSSH, or turn on the native SSH backend under Settings > SSH (ExperimentalNativeSshEnabled).");
         }
 
         // Two distinct refusals, deliberately distinguishable: the toggle above is a rollout decision


### PR DESCRIPTION
## What this changes

`ExperimentalNativeSshEnabled` existed only as a JSON field: every refusal message told the user to "enable it in settings", and the settings window had nowhere to do that. The advice was a dead end. This adds a new **SSH** tab in the settings window (between Command Assist and Agent Access) with one row — *Native SSH backend (experimental)* — wired as a toggle-pill CheckBox through `LoadCurrentSettings`/`SaveAndClose`, mirroring the Agent Access toggles line-for-line.

The tab is global-scope on purpose: the toggle is a rollout control, and placing it inside the per-profile editor would misstate what it governs. It also gives future SSH-wide settings (remote-forward policy, known-hosts management) a home.

The three refusal messages now point somewhere real: "Turn it on under Settings > SSH" replaces "enable ExperimentalNativeSshEnabled in settings" in `SshSessionFactory`, `NewSshConnectionViewModel.BackendWarning`, and MainWindow's saved-profile notice. The factory message keeps the setting's key name in parentheses for anyone scripting settings.json through the MCP tools. The row's description states the semantics the backend actually has: applies to new connections only, native profiles refuse rather than silently fall back while it is off, OpenSSH profiles unaffected either way.

Fixes no tracked issue; this is the next item from the native-SSH gap plan (after #325, #328, #330, #331).

## Invariant and ownership

- **What invariant does this change affect?** None of the backend's — the no-silent-fallback rule, the capability gate, and the setting's default (`false`) are untouched. The change is that the gate's documented remedy is now reachable in the UI, and the messages naming it are truthful.
- **Which module owns that invariant?** NovaTerminal.App (SettingsWindow, message copy); the gate itself stays in NovaTerminal.Platform.

## Tests

- **What tests cover this change?** The message rewordings are covered by the existing pins: `SshSessionFactoryTests` (asserts "disabled" + "OpenSSH", both kept) and `NewSshConnectionViewModelTests` (asserts "disabled globally", kept). The new tab and its load/save wiring are code-behind UI, which this repo does not unit-test for any of the existing toggles either — Avalonia's compiled-XAML step in the Build job catches markup errors, and the wiring is a two-line copy of the adjacent Agent Access pattern.

- **Which categories did you run locally?**
  - [ ] full unfiltered run (`scripts/build.sh test`)
  - [ ] `Category=Replay`
  - [ ] `Category=RenderMetrics`
  - [ ] `Category=PtySmoke`
  - [ ] `tests/NovaTerminal.App.Tests` (non-blocking in CI — check it yourself)
  - [ ] full local CI rehearsal (`ci/run.sh` / `ci/run.ps1`)

  None ran locally — same authoring-container situation as #330/#331 (no .NET SDK reachable). The diff is 35 lines of UI wiring, message copy, and docs; CI's Build + Unit Tests jobs are the verification. Worth a human glance at the new tab's layout on a real machine, since no automated check sees rendered UI.

## Impact

- **Does this affect cross-platform behavior?** No — Avalonia UI, identical markup on all platforms; no platform-specific code touched.
- **Does this change renderer metrics?** Not applicable — no renderer code touched.
- **Does this change VT coverage?** Not applicable — no VT sequences touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHPUK1JQgoV6t4RsSNeXKs

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHPUK1JQgoV6t4RsSNeXKs)_