### PR TITLE
feat(ssh): remote forwards in the native backend

### DIFF
--- a/docs/SSH_ROADMAP.md
+++ b/docs/SSH_ROADMAP.md
@@ -27,6 +27,7 @@ The native SSH initiative is implemented behind conservative rollout controls.
 - Local port forwarding
 - Direct-host dynamic port forwarding (SOCKS5)
 - Jump-host support, single hop or a chain of any length (nested direct-tcpip, as OpenSSH treats `-J`)
+- Remote port forwarding (server-side `tcpip-forward` listeners, as OpenSSH treats `-R`)
 - Rollout controls, backend selector, and stable failure classification
 - Resize coalescing for fullscreen TUIs (vim, htop, tmux)
 - Keepalive honoring user settings
@@ -40,16 +41,13 @@ The native SSH initiative is implemented behind conservative rollout controls.
   the app under Settings > SSH.
 - Native SSH does **not** silently fall back to OpenSSH on failure.
 - Whether native *can* serve a given profile is answered in one place,
-  `NativeSshCapability.Evaluate` — a remote forward is the one shape it refuses
-  (jump-hop chains used to be the other, and are served natively now). The
-  connection editor asks it at save time (so an unusable native profile cannot be
-  saved), `SshSessionFactory` asks it before building a session, and
-  `NativeSshSession` / `NativePortForwardSession` share its wording instead of
-  spelling their own.
-- The two native refusals are deliberately distinguishable: the global toggle is a
-  rollout decision the user can reverse in settings, an unsupported shape is not.
-  Warnings and errors lead with the shape when both apply, so nobody is sent to
-  settings to fix something settings cannot fix.
+  `NativeSshCapability.Evaluate` — which refuses nothing today: remote forwards
+  were the last unsupported shape (jump-hop chains before them), and both are
+  served natively now. The gate and its call sites (editor at save time, factory
+  and session at connect time) stay wired so the next unsupported shape gets one
+  refusal reaching all of them at once.
+- With no unsupported shapes, the only native refusal left is the global
+  experimental toggle — reversible under Settings > SSH.
 - Native SSH file transfers use the built-in native SFTP path.
 - Native SSH transfer dialogs can autocomplete remote paths when an active session for that profile already exists.
 - Native SSH single-file transfers show live byte progress when the total size is known; folder transfers report per-file progress only.
@@ -61,7 +59,10 @@ The native SSH initiative is implemented behind conservative rollout controls.
   (its own host-key verification and authentication) nested over a direct-tcpip
   channel of the previous hop; SFTP transfers and remote browsing take the same
   chain.
-- Remote forwarding is **not** supported in the native backend.
+- Native SSH supports remote forwards: a `tcpip-forward` listener is requested on
+  the server per rule once the session is established, and incoming connections
+  ride the same forward-channel machinery as the outgoing kinds. A request the
+  server refuses is loud but not fatal, matching `ssh -R`.
 
 ### Verification
 

--- a/docs/SSH_ROADMAP.md
+++ b/docs/SSH_ROADMAP.md
@@ -41,12 +41,14 @@ The native SSH initiative is implemented behind conservative rollout controls.
   the app under Settings > SSH.
 - Native SSH does **not** silently fall back to OpenSSH on failure.
 - Whether native *can* serve a given profile is answered in one place,
-  `NativeSshCapability.Evaluate` — which refuses nothing today: remote forwards
-  were the last unsupported shape (jump-hop chains before them), and both are
-  served natively now. The gate and its call sites (editor at save time, factory
-  and session at connect time) stay wired so the next unsupported shape gets one
-  refusal reaching all of them at once.
-- With no unsupported shapes, the only native refusal left is the global
+  `NativeSshCapability.Evaluate`. Its one refusal today is a remote forward with
+  source port 0 (a server-allocated listen port, OpenSSH's `-R 0:`): the native
+  backend matches incoming connections back to their rule by the requested port,
+  so a server-picked port has no rule to land on yet. Everything else — jump-hop
+  chains, local/dynamic/remote forwards — is served natively. The gate's call
+  sites (editor at save time, factory and session at connect time) all enforce
+  the same verdict.
+- Beyond that one shape, the only native refusal left is the global
   experimental toggle — reversible under Settings > SSH.
 - Native SSH file transfers use the built-in native SFTP path.
 - Native SSH transfer dialogs can autocomplete remote paths when an active session for that profile already exists.
@@ -60,9 +62,13 @@ The native SSH initiative is implemented behind conservative rollout controls.
   channel of the previous hop; SFTP transfers and remote browsing take the same
   chain.
 - Native SSH supports remote forwards: a `tcpip-forward` listener is requested on
-  the server per rule once the session is established, and incoming connections
-  ride the same forward-channel machinery as the outgoing kinds. A request the
-  server refuses is loud but not fatal, matching `ssh -R`.
+  the server per rule once the session is established (the Connected event, so no
+  thread waits out the handshake), and incoming connections ride the same
+  forward-channel machinery as the outgoing kinds. A request the server refuses
+  is loud but not fatal, matching `ssh -R`: the warning is printed into the
+  terminal and the session survives. Forwarded-tcpip channels the client never
+  asked for are refused at the Rust handler, so an unsolicited open from a
+  hostile server is never registered.
 
 ### Verification
 

--- a/docs/native-ssh/Native_SSH_Test_Matrix.md
+++ b/docs/native-ssh/Native_SSH_Test_Matrix.md
@@ -76,10 +76,11 @@ Rows marked Automated run in the `Native SSH Docker E2E` CI job (Linux), which s
   toggleable in the app under Settings > SSH.
 - `OpenSsh` remains the default backend for new profiles.
 - Native backend refusal is explicit when the global experimental toggle is disabled.
-- `NativeSshCapability` refuses nothing today — remote forwards were its last
-  unsupported shape. The gate and every call site (profile editor at save time,
-  factory and session at connect time) stay wired, so the next shape the backend
-  cannot serve gets one refusal reaching all of them at once.
+- `NativeSshCapability` has one refusal today: a remote forward with source port 0
+  (a server-allocated listen port), which the backend cannot yet match back to a
+  rule. The gate and every call site (profile editor at save time, factory and
+  session at connect time) stay wired, so any shape the backend cannot serve gets
+  one refusal reaching all of them at once.
 - Forward-channel data reaching the local socket is queued per channel and written
   by a dedicated pump, in both the managed and Rust layers, so a forwarded port
   whose peer stops reading can no longer stall the session's terminal I/O
@@ -113,10 +114,22 @@ Rows marked Automated run in the `Native SSH Docker E2E` CI job (Linux), which s
   The chain crosses the FFI as a JSON array (`jump_hops_json` / the SFTP request's `jumpHops`),
   so chain length never renegotiates the ABI.
 - Remote forwarding is supported natively: the backend sends a `tcpip-forward`
-  global request per remote rule once the session is established, and each
-  connection arriving on the server's listener rides the same forward-channel
-  machinery (queues, pumps, budgets) as the outgoing kinds — the announcement
-  event registers the channel before its first data event can be seen, so no
-  bytes are lost while the local destination is being dialled. A request the
-  server refuses is loud but not fatal, matching `ssh -R`: the session survives
-  and the log names the forward that is not listening.
+  global request per remote rule once the session is established (on the
+  Connected event, sequentially on one task — no thread-pool worker waits out
+  the handshake per rule), and each connection arriving on the server's listener
+  rides the same forward-channel machinery (queues, pumps, budgets) as the
+  outgoing kinds — the announcement event registers the channel before its first
+  data event can be seen, so no bytes are lost while the local destination is
+  being dialled. A request the server refuses is loud but not fatal, matching
+  `ssh -R`: the session survives and a warning naming the listener is printed
+  into the terminal, not only the log.
+- Unsolicited `forwarded-tcpip` opens are refused at the Rust handler: until the
+  session has sent at least one `tcpip-forward` request, a server-opened forward
+  channel is closed without being registered, so a hostile server cannot park
+  unbounded channels on a session that configured no forwards. The managed poll
+  loop also closes an announced channel when no forward session exists, as a
+  second line of defense.
+- Duplicate remote rules asking for the same `(bind address, port)` listener are
+  refused deterministically: the first rule wins, the duplicate is named in a
+  terminal warning, and incoming connections are matched by `(address, port)`
+  with a port-only fallback taken only when it cannot choose wrongly.

--- a/docs/native-ssh/Native_SSH_Test_Matrix.md
+++ b/docs/native-ssh/Native_SSH_Test_Matrix.md
@@ -38,6 +38,8 @@ Verified by automated tests:
 - Dockerized jump-host tunnelling: a one-hop session, a two-hop chain running a live command, and
   dynamic forwarding through a hop — each hop dialling the fixture container back into itself, so
   every hop is a real nested SSH session without a multi-container fixture
+- Dockerized remote forwarding: a tcpip-forward listener on the server, dialled from inside the
+  container by the session's own shell, carrying real bytes to a local destination and back
 
 ## Manual Matrix
 
@@ -58,6 +60,7 @@ Rows marked Automated run in the `Native SSH Docker E2E` CI job (Linux), which s
 | Terminal behavior | Fullscreen/alt-screen TUI | Automated + pending manual | Dockerized native SSH validates alternate-screen recovery and `vim` downward scrolling; still validate against a real host |
 | Forwarding | One local forward | Automated | `LocalForward_CarriesRealBytesToTheEchoService` |
 | Forwarding | One direct-host dynamic forward | Automated | `DynamicForward_CarriesRealBytesThroughSocks5ToTheEchoService` |
+| Forwarding | Remote forward | Automated | `NativeSshDockerRemoteForwardE2eTests.RemoteForward_CarriesRealBytesFromTheServerToALocalDestination`; the reply is transformed by the local destination so the assertion cannot match the echoed command |
 | Forwarding | One-hop jump-host dynamic forward | Automated | `NativeSshDockerJumpChainE2eTests.DynamicForward_ThroughAJumpHop_...`; forward channels ride the target session regardless of how it was reached |
 | Jump host | One-hop jump host | Automated + pending manual | `NativeSshDockerJumpChainE2eTests.JumpHost_OneHop_...` (the hop dials the fixture container back into itself); still validate against a real bastion |
 | Jump host | Multi-hop jump chain | Automated + pending manual | `NativeSshDockerJumpChainE2eTests.JumpChain_TwoHops_...` runs a live command through two nested tunnels; still validate against real distinct bastions |
@@ -73,10 +76,10 @@ Rows marked Automated run in the `Native SSH Docker E2E` CI job (Linux), which s
   toggleable in the app under Settings > SSH.
 - `OpenSsh` remains the default backend for new profiles.
 - Native backend refusal is explicit when the global experimental toggle is disabled.
-- The one profile shape the native backend cannot serve (a remote forward) is
-  refused by `NativeSshCapability` at profile-save time as well as at connect
-  time, so such a profile can no longer be saved as `Native` and then fail on use.
-  See the rollout guidance in `docs/SSH_ROADMAP.md`.
+- `NativeSshCapability` refuses nothing today — remote forwards were its last
+  unsupported shape. The gate and every call site (profile editor at save time,
+  factory and session at connect time) stay wired, so the next shape the backend
+  cannot serve gets one refusal reaching all of them at once.
 - Forward-channel data reaching the local socket is queued per channel and written
   by a dedicated pump, in both the managed and Rust layers, so a forwarded port
   whose peer stops reading can no longer stall the session's terminal I/O
@@ -109,4 +112,11 @@ Rows marked Automated run in the `Native SSH Docker E2E` CI job (Linux), which s
   ordered client → target, each hop with its own host-key verification and authentication.
   The chain crosses the FFI as a JSON array (`jump_hops_json` / the SFTP request's `jumpHops`),
   so chain length never renegotiates the ABI.
-- Remote forwarding remains unsupported in the native backend.
+- Remote forwarding is supported natively: the backend sends a `tcpip-forward`
+  global request per remote rule once the session is established, and each
+  connection arriving on the server's listener rides the same forward-channel
+  machinery (queues, pumps, budgets) as the outgoing kinds — the announcement
+  event registers the channel before its first data event can be seen, so no
+  bytes are lost while the local destination is being dialled. A request the
+  server refuses is loud but not fatal, matching `ssh -R`: the session survives
+  and the log names the forward that is not listening.

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -11,7 +11,7 @@ use std::io::Cursor;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::{Component, Path, PathBuf};
 use std::ptr;
-use std::sync::atomic::{AtomicI64, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex, OnceLock, mpsc as std_mpsc};
 use std::thread;
 use std::time::Duration;
@@ -254,6 +254,10 @@ struct SharedState {
     // Wakes producers parked in `queue_data_event` when the poll loop drains below the budget,
     // or when the session closes (see mark_closed).
     event_space_notify: tokio::sync::Notify,
+    // Whether this session ever sent a tcpip-forward global request. A server may only open
+    // forwarded-tcpip channels for listeners the client asked it for (RFC 4254 §7.2); until the
+    // first request is made, any such open is unsolicited and is refused at the handler.
+    remote_forward_requested: AtomicBool,
 }
 
 struct QueuedEvent {
@@ -661,7 +665,18 @@ impl SharedState {
             forward_write_budgets: Mutex::new(HashMap::new()),
             queued_data_bytes: AtomicUsize::new(0),
             event_space_notify: tokio::sync::Notify::new(),
+            remote_forward_requested: AtomicBool::new(false),
         }
+    }
+
+    /// Marked before the tcpip-forward request is sent, not after its reply: a server that opens
+    /// a forwarded-tcpip channel the instant it binds the listener must not race the flag.
+    fn mark_remote_forward_requested(&self) {
+        self.remote_forward_requested.store(true, Ordering::SeqCst);
+    }
+
+    fn has_requested_remote_forward(&self) -> bool {
+        self.remote_forward_requested.load(Ordering::SeqCst)
     }
 
     /// The queued-byte counter for one forward channel, or `None` if the channel is not (or no
@@ -890,6 +905,15 @@ impl client::Handler for NovaClientHandler {
                 let _ = channel.close().await;
                 return Ok(());
             };
+
+            // Same verdict for the target session before its first tcpip-forward request: a
+            // channel nobody asked for gets no registration, no reader task, no event. Without
+            // this, a hostile server could park unbounded open channels on a session whose
+            // profile configured no forwards at all — the managed side would never even see them.
+            if !shared.has_requested_remote_forward() {
+                let _ = channel.close().await;
+                return Ok(());
+            }
 
             register_forward_channel(channel, forward_channels, shared.clone(), |channel_id| {
                 shared.queue_event(QueuedEvent {
@@ -3223,9 +3247,11 @@ fn run_session(
                             // same trade OpenDirectTcpIp already makes: both happen at session
                             // setup or on user action, and the caller needs the verdict — a
                             // remote forward that failed must fail loudly, not queue silently.
+                            shared.mark_remote_forward_requested();
                             let result = session
                                 .tcpip_forward(address, port)
                                 .await
+                                .map(|reported| resolved_remote_forward_port(port, reported))
                                 .map_err(anyhow::Error::from);
                             let _ = reply.send(result);
                         }
@@ -3369,6 +3395,15 @@ async fn open_direct_tcpip_channel(
         .await?;
 
     Ok(register_forward_channel(channel, forward_channels, shared, |_| {}).await)
+}
+
+/// The port a remote-forward listener actually bound. RFC 4254 §7.1 has the server include a
+/// port in REQUEST_SUCCESS only when the request asked for port 0 (server-allocated); for an
+/// explicit port the reply is empty, which russh's `tcpip_forward` surfaces as `Ok(0)`. Taking
+/// that 0 at face value would report every successful explicit-port forward as "listening on
+/// port 0" — success on an explicit port means the server bound exactly the port it was asked.
+fn resolved_remote_forward_port(requested: u32, reported: u32) -> u32 {
+    if reported == 0 { requested } else { reported }
 }
 
 /// Wires an open channel — outgoing direct-tcpip or incoming forwarded-tcpip; the machinery is
@@ -5833,6 +5868,29 @@ mod remote_forward_request_tests {
 
         responder.join().expect("responder must not panic");
         assert_eq!(NOVA_SSH_RESULT_OK, nova_ssh_close(handle));
+    }
+
+    /// russh yields `Ok(0)` for the empty REQUEST_SUCCESS a server sends when an explicit port
+    /// was requested (RFC 4254 §7.1 puts a port in the reply only for port-0 requests). The
+    /// worker must report the port that is actually listening, not the encoding artifact.
+    #[test]
+    fn an_explicit_port_request_answered_with_zero_resolves_to_the_requested_port() {
+        assert_eq!(18080, resolved_remote_forward_port(18080, 0));
+        // A server that echoes (or, for port 0, allocates) a port is believed as-is.
+        assert_eq!(18080, resolved_remote_forward_port(18080, 18080));
+        assert_eq!(49152, resolved_remote_forward_port(0, 49152));
+    }
+
+    /// The unsolicited-channel gate: a session starts having asked for nothing, and flips —
+    /// permanently — when the first tcpip-forward request is sent. server_channel_open_forwarded_tcpip
+    /// refuses every open before that flip.
+    #[test]
+    fn a_fresh_session_has_requested_no_remote_forward_until_one_is_marked() {
+        let shared = SharedState::new();
+        assert!(!shared.has_requested_remote_forward());
+
+        shared.mark_remote_forward_requested();
+        assert!(shared.has_requested_remote_forward());
     }
 
     #[test]

--- a/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
+++ b/src/NovaTerminal.App/native/rusty_ssh/src/lib.rs
@@ -84,6 +84,10 @@ pub enum NovaSshEventKind {
     ForwardChannelData = 10,
     ForwardChannelEof = 11,
     ForwardChannelClosed = 12,
+    /// The server opened a forwarded-tcpip channel for a remote forward this session requested.
+    /// status_code carries the channel id; the JSON payload carries the addresses, so the managed
+    /// side can match the connection to its forward rule and dial the local destination.
+    ForwardChannelIncoming = 13,
 }
 
 #[repr(u32)]
@@ -108,6 +112,12 @@ pub const NOVA_SSH_RESULT_PANIC: c_int = -7;
 /// the caller is expected to retry, which is what applies backpressure to the local socket it is
 /// reading from. Only nova_ssh_channel_write returns this.
 pub const NOVA_SSH_RESULT_WOULD_BLOCK: c_int = -8;
+
+/// The server refused a tcpip-forward request (or the request could not be sent). Distinct from
+/// CHANNEL_OPEN_FAILED because nothing channel-shaped exists yet — the refusal is of the remote
+/// listener itself, and the caller's recovery is to report the forward as unavailable, not to
+/// retry a channel.
+pub const NOVA_SSH_RESULT_REMOTE_FORWARD_FAILED: c_int = -9;
 
 /// Per-forward-channel ceiling on bytes queued toward the remote, mirroring the managed side's
 /// budget for the opposite direction. Reaching it makes nova_ssh_channel_write report
@@ -308,6 +318,11 @@ enum WorkerCommand {
         originator_port: u32,
         reply: std_mpsc::Sender<anyhow::Result<u32>>,
     },
+    RequestRemoteForward {
+        address: String,
+        port: u32,
+        reply: std_mpsc::Sender<anyhow::Result<u32>>,
+    },
     WriteForwardChannel {
         channel_id: u32,
         data: Vec<u8>,
@@ -401,6 +416,21 @@ struct NovaClientHandler {
     shared: Arc<SharedState>,
     host: String,
     port: u16,
+    /// Where an incoming forwarded-tcpip channel gets wired in, present only on the target
+    /// session's handler. Jump hops carry None: only the target session ever requests a remote
+    /// forward, so a hop server opening a forwarded channel is unsolicited and gets refused.
+    forward_channels: Option<ForwardChannels>,
+}
+
+/// Payload of a ForwardChannelIncoming event: which remote listener the connection arrived on
+/// (so the managed side can match it to a forward rule) and who dialled it.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ForwardChannelIncomingPayload<'a> {
+    connected_address: &'a str,
+    connected_port: u32,
+    originator_address: &'a str,
+    originator_port: u32,
 }
 
 #[derive(Clone)]
@@ -833,6 +863,54 @@ impl SharedState {
 impl client::Handler for NovaClientHandler {
     type Error = russh::Error;
 
+    /// The server opened a channel for a connection that arrived on a remote-forward listener.
+    /// Wire it into the forward machinery and announce it; the managed side matches the
+    /// announcement to its forward rule and dials the local destination. Runs on the session
+    /// task, so nothing here may block on anything slower than the channels-map lock.
+    fn server_channel_open_forwarded_tcpip(
+        &mut self,
+        channel: russh::Channel<client::Msg>,
+        connected_address: &str,
+        connected_port: u32,
+        originator_address: &str,
+        originator_port: u32,
+        _session: &mut client::Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        let forward_channels = self.forward_channels.clone();
+        let shared = self.shared.clone();
+        let connected_address = connected_address.to_owned();
+        let originator_address = originator_address.to_owned();
+
+        async move {
+            // No map means this session never requests remote forwards — it is a jump hop, and a
+            // hop server opening a forwarded channel is unsolicited. Refuse it outright rather
+            // than plumbing it through for the managed side to refuse later: an unrequested
+            // channel from an intermediary deserves no processing at all.
+            let Some(forward_channels) = forward_channels else {
+                let _ = channel.close().await;
+                return Ok(());
+            };
+
+            register_forward_channel(channel, forward_channels, shared.clone(), |channel_id| {
+                shared.queue_event(QueuedEvent {
+                    kind: NovaSshEventKind::ForwardChannelIncoming,
+                    payload: serde_json::to_vec(&ForwardChannelIncomingPayload {
+                        connected_address: &connected_address,
+                        connected_port,
+                        originator_address: &originator_address,
+                        originator_port,
+                    })
+                    .unwrap_or_default(),
+                    status_code: channel_id as i32,
+                    flags: NOVA_SSH_EVENT_FLAG_JSON,
+                });
+            })
+            .await;
+
+            Ok(())
+        }
+    }
+
     fn check_server_key(
         &mut self,
         server_public_key: &ssh_key::PublicKey,
@@ -1099,6 +1177,55 @@ pub extern "C" fn nova_ssh_open_direct_tcpip(
         match reply_rx.recv() {
             Ok(Ok(channel_id)) => channel_id as c_int,
             Ok(Err(_)) => NOVA_SSH_RESULT_CHANNEL_OPEN_FAILED,
+            Err(_) => NOVA_SSH_RESULT_CLOSED,
+        }
+    })
+}
+
+/// Asks the server to open a remote-forward listener on `address:port` (a tcpip-forward global
+/// request). Returns the bound port (>= 0) on success — the server may differ from the request
+/// only when asked for port 0 — or a negative NOVA_SSH_RESULT code. Blocks the calling thread
+/// until the server answers, like nova_ssh_open_direct_tcpip; callers should not hold a UI
+/// thread on it. Connections arriving on the listener surface as ForwardChannelIncoming events.
+#[unsafe(no_mangle)]
+pub extern "C" fn nova_ssh_request_remote_forward(
+    handle: usize,
+    address: *const c_char,
+    port: u16,
+) -> c_int {
+    ffi_guard(NOVA_SSH_RESULT_PANIC, || {
+        let address = match read_c_arg(address).required() {
+            Some(value) => value,
+            None => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
+        };
+
+        let session = match registry_get(handle) {
+            Some(s) => s,
+            None => return NOVA_SSH_RESULT_INVALID_ARGUMENT,
+        };
+
+        let (reply_tx, reply_rx) = std_mpsc::channel();
+        let command = WorkerCommand::RequestRemoteForward {
+            address,
+            port: port as u32,
+            reply: reply_tx,
+        };
+
+        {
+            let guard = session.command_tx.lock().unwrap_or_else(|p| p.into_inner());
+            match guard.as_ref() {
+                Some(tx) => {
+                    if tx.send(command).is_err() {
+                        return NOVA_SSH_RESULT_CLOSED;
+                    }
+                }
+                None => return NOVA_SSH_RESULT_CLOSED,
+            }
+        }
+
+        match reply_rx.recv() {
+            Ok(Ok(bound_port)) => bound_port as c_int,
+            Ok(Err(_)) => NOVA_SSH_RESULT_REMOTE_FORWARD_FAILED,
             Err(_) => NOVA_SSH_RESULT_CLOSED,
         }
     })
@@ -2921,6 +3048,7 @@ async fn establish_session(
     config: &ConnectConfig,
     shared: &Arc<SharedState>,
     client_config: Arc<client::Config>,
+    forward_channels: ForwardChannels,
 ) -> anyhow::Result<(
     Vec<client::Handle<NovaClientHandler>>,
     client::Handle<NovaClientHandler>,
@@ -2933,6 +3061,7 @@ async fn establish_session(
             shared: shared.clone(),
             host: hop.host.clone(),
             port: hop.port,
+            forward_channels: None,
         };
 
         let mut hop_session = match jump_sessions.last() {
@@ -2962,6 +3091,7 @@ async fn establish_session(
         shared: shared.clone(),
         host: config.host.clone(),
         port: config.port,
+        forward_channels: Some(forward_channels),
     };
 
     let mut session = if let Some(last_jump) = jump_sessions.last() {
@@ -3033,7 +3163,7 @@ fn run_session(
         // on user interaction (host-key and password prompts), and mark_closed already
         // unblocks those via wait_for_response.
         let (jump_sessions, mut session, mut channel) = tokio::select! {
-            result = establish_session(&config, &shared, client_config.clone()) => result?,
+            result = establish_session(&config, &shared, client_config.clone(), forward_channels.clone()) => result?,
             _ = shared.wait_closed() => {
                 // Closed while connecting: exit cleanly; nova_ssh_close is joining us.
                 return Ok(());
@@ -3086,6 +3216,17 @@ fn run_session(
                                 originator_port,
                             )
                             .await;
+                            let _ = reply.send(result);
+                        }
+                        Some(WorkerCommand::RequestRemoteForward { address, port, reply }) => {
+                            // Awaiting the server's reply here briefly holds the select loop, the
+                            // same trade OpenDirectTcpIp already makes: both happen at session
+                            // setup or on user action, and the caller needs the verdict — a
+                            // remote forward that failed must fail loudly, not queue silently.
+                            let result = session
+                                .tcpip_forward(address, port)
+                                .await
+                                .map_err(anyhow::Error::from);
                             let _ = reply.send(result);
                         }
                         // These three only queue onto the target channel's writer task. They used to
@@ -3227,6 +3368,24 @@ async fn open_direct_tcpip_channel(
         )
         .await?;
 
+    Ok(register_forward_channel(channel, forward_channels, shared, |_| {}).await)
+}
+
+/// Wires an open channel — outgoing direct-tcpip or incoming forwarded-tcpip; the machinery is
+/// direction-agnostic once the channel exists — into the forward plumbing: a writer task with its
+/// write budget, the channels-map entry, and a reader task feeding the event queue.
+///
+/// `before_reader` runs after the channel is reachable through the map but before the reader task
+/// can deliver a single byte. That slot exists for incoming channels: their announcement event
+/// must be queued there, or data events could reach the managed side while the channel id still
+/// means nothing to it — and a channel announced before the map entry existed could be closed
+/// into a void. Outgoing channels pass a no-op; their id travels through the FFI return instead.
+async fn register_forward_channel(
+    channel: russh::Channel<client::Msg>,
+    forward_channels: ForwardChannels,
+    shared: Arc<SharedState>,
+    before_reader: impl FnOnce(u32),
+) -> u32 {
     let channel_id = u32::from(channel.id());
     let (mut read_half, write_half) = channel.split();
 
@@ -3286,6 +3445,8 @@ async fn open_direct_tcpip_channel(
         },
     );
 
+    before_reader(channel_id);
+
     let reader_shared = shared.clone();
     let reader_channels = forward_channels.clone();
     tokio::spawn(async move {
@@ -3343,7 +3504,7 @@ async fn open_direct_tcpip_channel(
         }
     });
 
-    Ok(channel_id)
+    channel_id
 }
 
 /// Queues one item for a forward channel's writer task. Only ever awaits the map lock, never the
@@ -5600,5 +5761,99 @@ mod event_queue_budget_tests {
             shared.queue_data_event(data_event(1)).await,
             "the counter must still admit producers after the unaccounted pop"
         );
+    }
+}
+
+/// nova_ssh_request_remote_forward's FFI contract: argument validation, the round trip through
+/// the worker command, and the mapping of a server refusal onto its own result code. The live
+/// half — a real tcpip-forward against a real sshd, and the forwarded-tcpip channels it produces —
+/// runs in the Docker E2E suite.
+#[cfg(test)]
+mod remote_forward_request_tests {
+    use super::*;
+
+    fn session_with_command_channel() -> (usize, mpsc::UnboundedReceiver<WorkerCommand>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let handle = registry_insert(NovaSshSession {
+            shared: Arc::new(SharedState::new()),
+            command_tx: Mutex::new(Some(tx)),
+            worker: Mutex::new(None),
+        }) as usize;
+        (handle, rx)
+    }
+
+    #[test]
+    fn request_validates_handle_address_and_liveness() {
+        let address = CString::new("127.0.0.1").unwrap();
+
+        assert_eq!(
+            NOVA_SSH_RESULT_INVALID_ARGUMENT,
+            nova_ssh_request_remote_forward(usize::MAX, address.as_ptr(), 8080),
+            "an unknown handle must be refused"
+        );
+
+        let handle = registry_insert(stub_session()) as usize;
+        assert_eq!(
+            NOVA_SSH_RESULT_INVALID_ARGUMENT,
+            nova_ssh_request_remote_forward(handle, ptr::null(), 8080),
+            "a null bind address must be refused, not defaulted — the caller is naming a listener"
+        );
+        assert_eq!(
+            NOVA_SSH_RESULT_CLOSED,
+            nova_ssh_request_remote_forward(handle, address.as_ptr(), 8080),
+            "a session with no worker command channel is closed, not invalid"
+        );
+        assert_eq!(NOVA_SSH_RESULT_OK, nova_ssh_close(handle));
+    }
+
+    #[test]
+    fn request_round_trips_the_bound_port_through_the_worker() {
+        let (handle, mut rx) = session_with_command_channel();
+
+        // Stands in for the worker's select arm: receive the command, answer with the port the
+        // server bound. The FFI call blocks its thread on the reply, hence the second thread.
+        let responder = std::thread::spawn(move || match rx.blocking_recv() {
+            Some(WorkerCommand::RequestRemoteForward {
+                address,
+                port,
+                reply,
+            }) => {
+                assert_eq!("127.0.0.1", address);
+                assert_eq!(9101, port);
+                let _ = reply.send(Ok(9101));
+            }
+            _ => panic!("expected a RequestRemoteForward command"),
+        });
+
+        let address = CString::new("127.0.0.1").unwrap();
+        assert_eq!(
+            9101,
+            nova_ssh_request_remote_forward(handle, address.as_ptr(), 9101)
+        );
+
+        responder.join().expect("responder must not panic");
+        assert_eq!(NOVA_SSH_RESULT_OK, nova_ssh_close(handle));
+    }
+
+    #[test]
+    fn a_server_refusal_maps_to_the_remote_forward_result_code() {
+        let (handle, mut rx) = session_with_command_channel();
+
+        let responder = std::thread::spawn(move || match rx.blocking_recv() {
+            Some(WorkerCommand::RequestRemoteForward { reply, .. }) => {
+                let _ = reply.send(Err(anyhow::anyhow!("administratively prohibited")));
+            }
+            _ => panic!("expected a RequestRemoteForward command"),
+        });
+
+        let address = CString::new("127.0.0.1").unwrap();
+        assert_eq!(
+            NOVA_SSH_RESULT_REMOTE_FORWARD_FAILED,
+            nova_ssh_request_remote_forward(handle, address.as_ptr(), 9102),
+            "a refusal is its own outcome — not closed, not a channel-open failure"
+        );
+
+        responder.join().expect("responder must not panic");
+        assert_eq!(NOVA_SSH_RESULT_OK, nova_ssh_close(handle));
     }
 }

--- a/src/NovaTerminal.Platform/Ssh/Native/INativeSshInterop.cs
+++ b/src/NovaTerminal.Platform/Ssh/Native/INativeSshInterop.cs
@@ -37,6 +37,20 @@ public interface INativeSshInterop
         WriteChannel(sessionHandle, channelId, data);
         return true;
     }
+    /// <summary>
+    /// Asks the server to open a remote-forward listener (a tcpip-forward global request) and
+    /// returns the port it bound. Connections arriving on that listener surface as
+    /// <see cref="NativeSshEventKind.ForwardChannelIncoming"/> events. Blocking FFI/network call —
+    /// it waits for the server's verdict — so callers offload it, never hold a UI thread on it.
+    /// </summary>
+    /// <remarks>
+    /// Default implementation throws: a test double that never expects remote forwards should fail
+    /// a test that reaches for one, and the double that does expect them overrides.
+    /// </remarks>
+    int RequestRemoteForward(NovaSshSafeHandle sessionHandle, string bindAddress, int port) =>
+        throw new NotSupportedException(
+            $"{GetType().Name} does not implement remote forwards.");
+
     void SendChannelEof(NovaSshSafeHandle sessionHandle, int channelId);
     void CloseChannel(NovaSshSafeHandle sessionHandle, int channelId);
     void SubmitResponse(NovaSshSafeHandle sessionHandle, NativeSshResponseKind responseKind, ReadOnlySpan<byte> data);

--- a/src/NovaTerminal.Platform/Ssh/Native/NativePortForwardSession.cs
+++ b/src/NovaTerminal.Platform/Ssh/Native/NativePortForwardSession.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Channels;
 using NovaTerminal.Platform.Ssh.Models;
 
@@ -41,6 +42,10 @@ public sealed class NativePortForwardSession : IDisposable
     private readonly Func<NetworkStream, byte[], CancellationToken, Task> _socksReplyWriter;
     private readonly CancellationTokenSource _lifetimeCts = new();
     private readonly List<TcpListener> _listeners = [];
+
+    // Remote-forward rules, so an incoming forwarded-tcpip channel can be matched back to the
+    // rule whose listener it arrived on. Populated only in the constructor; read from HandleEvent.
+    private readonly List<PortForward> _remoteForwards = [];
     private readonly ConcurrentDictionary<int, ForwardChannelState> _channels = new();
     private int _disposed;
 
@@ -73,20 +78,20 @@ public sealed class NativePortForwardSession : IDisposable
         _log = log ?? (_ => { });
         _socksReplyWriter = socksReplyWriter ?? throw new ArgumentNullException(nameof(socksReplyWriter));
 
-        // Checked up front rather than per-forward inside the loop: an unsupported kind is a property
-        // of the profile, not of a bind, so there is no reason to open listeners we are about to tear
-        // down again. Wording comes from NativeSshCapability so it matches what the editor showed.
-        NativeSshCapabilityResult capability = NativeSshCapability.Evaluate(forwards, jumpHops: null);
-        if (!capability.IsSupported)
-        {
-            throw new NotSupportedException(capability.Explanation);
-        }
-
         try
         {
             foreach (PortForward forward in forwards)
             {
-                StartListener(forward);
+                // Remote forwards have no local listener — the listener lives on the server, and
+                // the request for it can only be made once the session is established.
+                if (forward.Kind == PortForwardKind.Remote)
+                {
+                    StartRemoteForward(forward);
+                }
+                else
+                {
+                    StartListener(forward);
+                }
             }
         }
         catch
@@ -107,6 +112,14 @@ public sealed class NativePortForwardSession : IDisposable
     {
         if (nextEvent == null)
         {
+            return;
+        }
+
+        // Incoming channels are the one event about a channel this map has never seen: the
+        // announcement is what creates the entry, so it must be handled before the lookup.
+        if (nextEvent.Kind == NativeSshEventKind.ForwardChannelIncoming)
+        {
+            HandleIncomingForwardChannel(nextEvent);
             return;
         }
 
@@ -203,9 +216,110 @@ public sealed class NativePortForwardSession : IDisposable
         {
             PortForwardKind.Local => Task.Run(() => AcceptLocalLoopAsync(listener, forward, _lifetimeCts.Token)),
             PortForwardKind.Dynamic => Task.Run(() => AcceptDynamicLoopAsync(listener, forward, _lifetimeCts.Token)),
-            _ => throw new NotSupportedException(
-                NativeSshCapability.Evaluate([forward], jumpHops: null).Explanation)
+            // Remote never reaches this method (the constructor routes it to StartRemoteForward),
+            // so only a kind this code has never heard of lands here.
+            _ => throw new NotSupportedException($"Unsupported port-forward kind '{forward.Kind}'.")
         };
+    }
+
+    private void StartRemoteForward(PortForward forward)
+    {
+        _remoteForwards.Add(forward);
+
+        // Empty bind address means the OpenSSH default for -R: the server's loopback.
+        string bindAddress = string.IsNullOrWhiteSpace(forward.BindAddress)
+            ? "localhost"
+            : forward.BindAddress.Trim();
+
+        // Off the constructor for two reasons: the worker only answers commands once the session
+        // is established (connect and auth can involve prompts), and the interop call blocks until
+        // the server's verdict arrives. A refusal is loud but not fatal — the same behavior ssh
+        // itself has for -R ("Warning: remote port forwarding failed") — so the session survives
+        // and the log names exactly which forward is not listening.
+        _ = Task.Run(() =>
+        {
+            try
+            {
+                int boundPort = _interop.RequestRemoteForward(_sessionHandle, bindAddress, forward.SourcePort);
+                _log($"[NativePortForwardSession] Remote forward listening on {bindAddress}:{boundPort} for {forward}.");
+            }
+            catch (Exception ex)
+            {
+                _log($"[NativePortForwardSession] Remote forward {forward} failed: {ex.Message}");
+            }
+        }, _lifetimeCts.Token);
+    }
+
+    /// <summary>
+    /// A connection arrived on a remote-forward listener. The channel state is registered
+    /// immediately, on the poll loop — its data events may be queued right behind this one, and
+    /// the state's outbound queue is what holds them in order while the local destination is
+    /// still being dialled. The dial itself happens on a background task.
+    /// </summary>
+    private void HandleIncomingForwardChannel(NativeSshEvent nextEvent)
+    {
+        int channelId = nextEvent.StatusCode;
+
+        int connectedPort;
+        try
+        {
+            using JsonDocument payload = JsonDocument.Parse(nextEvent.Payload);
+            connectedPort = payload.RootElement.GetProperty("connectedPort").GetInt32();
+        }
+        catch (Exception ex)
+        {
+            _log($"[NativePortForwardSession] Unreadable incoming forward payload for channel {channelId}: {ex.Message}");
+            TryCloseInteropChannel(channelId);
+            return;
+        }
+
+        PortForward? rule = _remoteForwards.FirstOrDefault(candidate => candidate.SourcePort == connectedPort);
+        if (rule == null)
+        {
+            // Unsolicited: no rule asked for a listener on this port, so there is nowhere this
+            // connection is allowed to go. Refuse it rather than guess a destination.
+            _log($"[NativePortForwardSession] Incoming forward channel {channelId} on port {connectedPort} matches no remote forward rule; closing it.");
+            TryCloseInteropChannel(channelId);
+            return;
+        }
+
+        var state = new ForwardChannelState(channelId);
+        if (!_channels.TryAdd(channelId, state))
+        {
+            TryCloseInteropChannel(channelId);
+            return;
+        }
+
+        _ = Task.Run(() => ConnectIncomingForwardAsync(state, rule, _lifetimeCts.Token), _lifetimeCts.Token);
+    }
+
+    private async Task ConnectIncomingForwardAsync(ForwardChannelState state, PortForward rule, CancellationToken cancellationToken)
+    {
+        var client = new TcpClient();
+        try
+        {
+            await client.ConnectAsync(rule.DestinationHost, rule.DestinationPort, cancellationToken).ConfigureAwait(false);
+            state.AttachTransport(client);
+        }
+        catch (Exception ex)
+        {
+            client.Dispose();
+            _log($"[NativePortForwardSession] Remote forward channel {state.ChannelId} could not reach {rule.DestinationHost}:{rule.DestinationPort}: {ex.Message}");
+            RemoveChannel(state.ChannelId, closeInteropChannel: true);
+            return;
+        }
+
+        // Teardown may have removed the channel while the dial was in flight; its RemoveChannel saw
+        // a transport-less state, so the socket is ours to close. A removal racing past this check
+        // instead lands the pumps on a disposed socket, which they already treat as end-of-channel.
+        if (!_channels.ContainsKey(state.ChannelId))
+        {
+            client.Dispose();
+            return;
+        }
+
+        _ = Task.Run(() => PumpClientToSshAsync(state, cancellationToken), cancellationToken);
+        _ = Task.Run(() => PumpSshToClientAsync(state, cancellationToken), cancellationToken);
     }
 
     private async Task AcceptLocalLoopAsync(TcpListener listener, PortForward forward, CancellationToken cancellationToken)
@@ -505,22 +619,27 @@ public sealed class NativePortForwardSession : IDisposable
 
         if (closeInteropChannel)
         {
-            try
-            {
-                _interop.CloseChannel(_sessionHandle, channelId);
-            }
-            catch (Exception ex)
-            {
-                _log($"[NativePortForwardSession] Failed to close channel {channelId}: {ex.Message}");
-            }
+            TryCloseInteropChannel(channelId);
         }
 
         try
         {
-            channel.Client.Dispose();
+            channel.Client?.Dispose();
         }
         catch
         {
+        }
+    }
+
+    private void TryCloseInteropChannel(int channelId)
+    {
+        try
+        {
+            _interop.CloseChannel(_sessionHandle, channelId);
+        }
+        catch (Exception ex)
+        {
+            _log($"[NativePortForwardSession] Failed to close channel {channelId}: {ex.Message}");
         }
     }
 
@@ -643,11 +762,11 @@ public sealed class NativePortForwardSession : IDisposable
         return addresses.First(address => address.AddressFamily is AddressFamily.InterNetwork or AddressFamily.InterNetworkV6);
     }
 
-    private static void TryShutdown(TcpClient client, SocketShutdown how)
+    private static void TryShutdown(TcpClient? client, SocketShutdown how)
     {
         try
         {
-            client.Client.Shutdown(how);
+            client?.Client.Shutdown(how);
         }
         catch
         {
@@ -680,11 +799,15 @@ public sealed class NativePortForwardSession : IDisposable
     {
         private int _queuedOutboundBytes;
 
-        public ForwardChannelState(int channelId, TcpClient client)
+        /// <summary>
+        /// For incoming (remote-forward) channels, whose local transport does not exist yet: the
+        /// SSH side is live immediately, so the state — above all its outbound queue — must exist
+        /// before the dial to the destination completes. Pumps start only after
+        /// <see cref="AttachTransport"/>, so they never observe the null transport.
+        /// </summary>
+        public ForwardChannelState(int channelId)
         {
             ChannelId = channelId;
-            Client = client;
-            Stream = client.GetStream();
 
             // Unbounded channel with our own byte budget, rather than a bounded channel: the budget
             // has to apply to data only. Eof/Closed markers must always be admittable, or a channel
@@ -701,10 +824,22 @@ public sealed class NativePortForwardSession : IDisposable
             });
         }
 
+        public ForwardChannelState(int channelId, TcpClient client)
+            : this(channelId)
+        {
+            AttachTransport(client);
+        }
+
         public int ChannelId { get; }
-        public TcpClient Client { get; }
-        public NetworkStream Stream { get; }
+        public TcpClient? Client { get; private set; }
+        public NetworkStream Stream { get; private set; } = null!;
         public Channel<ForwardOutbound> Outbound { get; }
+
+        public void AttachTransport(TcpClient client)
+        {
+            Client = client;
+            Stream = client.GetStream();
+        }
 
         public int QueuedOutboundBytes => Volatile.Read(ref _queuedOutboundBytes);
 

--- a/src/NovaTerminal.Platform/Ssh/Native/NativePortForwardSession.cs
+++ b/src/NovaTerminal.Platform/Ssh/Native/NativePortForwardSession.cs
@@ -830,15 +830,26 @@ public sealed class NativePortForwardSession : IDisposable
             AttachTransport(client);
         }
 
+        private NetworkStream? _stream;
+
         public int ChannelId { get; }
         public TcpClient? Client { get; private set; }
-        public NetworkStream Stream { get; private set; } = null!;
         public Channel<ForwardOutbound> Outbound { get; }
+
+        /// <summary>
+        /// The local transport. Throws rather than null-refs if read before
+        /// <see cref="AttachTransport"/>: the pumps are only ever started after the transport is
+        /// attached, so reaching the throw means that contract was broken — a loud, named failure
+        /// beats a NullReferenceException three calls later.
+        /// </summary>
+        public NetworkStream Stream =>
+            _stream ?? throw new InvalidOperationException(
+                $"Forward channel {ChannelId} has no transport attached yet.");
 
         public void AttachTransport(TcpClient client)
         {
             Client = client;
-            Stream = client.GetStream();
+            _stream = client.GetStream();
         }
 
         public int QueuedOutboundBytes => Volatile.Read(ref _queuedOutboundBytes);

--- a/src/NovaTerminal.Platform/Ssh/Native/NativePortForwardSession.cs
+++ b/src/NovaTerminal.Platform/Ssh/Native/NativePortForwardSession.cs
@@ -222,14 +222,21 @@ public sealed class NativePortForwardSession : IDisposable
         };
     }
 
+    /// <summary>
+    /// The bind address a remote rule asks the server for. Empty means the OpenSSH default for
+    /// -R: the server's loopback. Also the string incoming announcements are matched against, so
+    /// request and match can never disagree about the default.
+    /// </summary>
+    private static string RemoteBindAddress(PortForward forward) =>
+        string.IsNullOrWhiteSpace(forward.BindAddress)
+            ? "localhost"
+            : forward.BindAddress.Trim();
+
     private void StartRemoteForward(PortForward forward)
     {
         _remoteForwards.Add(forward);
 
-        // Empty bind address means the OpenSSH default for -R: the server's loopback.
-        string bindAddress = string.IsNullOrWhiteSpace(forward.BindAddress)
-            ? "localhost"
-            : forward.BindAddress.Trim();
+        string bindAddress = RemoteBindAddress(forward);
 
         // Off the constructor for two reasons: the worker only answers commands once the session
         // is established (connect and auth can involve prompts), and the interop call blocks until
@@ -260,10 +267,12 @@ public sealed class NativePortForwardSession : IDisposable
     {
         int channelId = nextEvent.StatusCode;
 
+        string connectedAddress;
         int connectedPort;
         try
         {
             using JsonDocument payload = JsonDocument.Parse(nextEvent.Payload);
+            connectedAddress = payload.RootElement.GetProperty("connectedAddress").GetString() ?? string.Empty;
             connectedPort = payload.RootElement.GetProperty("connectedPort").GetInt32();
         }
         catch (Exception ex)
@@ -273,12 +282,12 @@ public sealed class NativePortForwardSession : IDisposable
             return;
         }
 
-        PortForward? rule = _remoteForwards.FirstOrDefault(candidate => candidate.SourcePort == connectedPort);
+        PortForward? rule = MatchRemoteForwardRule(connectedAddress, connectedPort);
         if (rule == null)
         {
-            // Unsolicited: no rule asked for a listener on this port, so there is nowhere this
-            // connection is allowed to go. Refuse it rather than guess a destination.
-            _log($"[NativePortForwardSession] Incoming forward channel {channelId} on port {connectedPort} matches no remote forward rule; closing it.");
+            // Unsolicited or ambiguous: either no rule asked for this listener, or more than one
+            // could have and the address decides nothing. Refuse rather than guess a destination.
+            _log($"[NativePortForwardSession] Incoming forward channel {channelId} from listener {connectedAddress}:{connectedPort} matches no remote forward rule unambiguously; closing it.");
             TryCloseInteropChannel(channelId);
             return;
         }
@@ -291,6 +300,28 @@ public sealed class NativePortForwardSession : IDisposable
         }
 
         _ = Task.Run(() => ConnectIncomingForwardAsync(state, rule, _lifetimeCts.Token), _lifetimeCts.Token);
+    }
+
+    /// <summary>
+    /// Which remote rule an incoming connection belongs to. Exact (address, port) first: rules can
+    /// legitimately share a port across different bind addresses, and the requests race — the rule
+    /// whose listener actually bound may not be the first one with the port, so a port-only pick
+    /// could route traffic to the wrong local service. The port-only fallback exists because some
+    /// servers normalize the address they echo ("localhost" requested, "127.0.0.1" announced), and
+    /// it is taken only while it cannot choose wrongly — exactly one rule on the port.
+    /// </summary>
+    private PortForward? MatchRemoteForwardRule(string connectedAddress, int connectedPort)
+    {
+        PortForward? exact = _remoteForwards.FirstOrDefault(rule =>
+            rule.SourcePort == connectedPort
+            && string.Equals(RemoteBindAddress(rule), connectedAddress, StringComparison.OrdinalIgnoreCase));
+        if (exact != null)
+        {
+            return exact;
+        }
+
+        List<PortForward> byPort = _remoteForwards.Where(rule => rule.SourcePort == connectedPort).ToList();
+        return byPort.Count == 1 ? byPort[0] : null;
     }
 
     private async Task ConnectIncomingForwardAsync(ForwardChannelState state, PortForward rule, CancellationToken cancellationToken)

--- a/src/NovaTerminal.Platform/Ssh/Native/NativePortForwardSession.cs
+++ b/src/NovaTerminal.Platform/Ssh/Native/NativePortForwardSession.cs
@@ -39,6 +39,12 @@ public sealed class NativePortForwardSession : IDisposable
     private readonly NovaSshSafeHandle _sessionHandle;
     private readonly INativeSshInterop _interop;
     private readonly Action<string> _log;
+
+    // User-facing warnings (terminal output), as distinct from the diagnostic _log. A remote
+    // forward the server refused must be as visible as ssh -R's "Warning: remote port forwarding
+    // failed" — a session that looks healthy while a requested listener silently does not exist
+    // is exactly the silent degradation the native backend promises not to have.
+    private readonly Action<string> _warn;
     private readonly Func<NetworkStream, byte[], CancellationToken, Task> _socksReplyWriter;
     private readonly CancellationTokenSource _lifetimeCts = new();
     private readonly List<TcpListener> _listeners = [];
@@ -48,13 +54,15 @@ public sealed class NativePortForwardSession : IDisposable
     private readonly List<PortForward> _remoteForwards = [];
     private readonly ConcurrentDictionary<int, ForwardChannelState> _channels = new();
     private int _disposed;
+    private int _remoteForwardsRequested;
 
     public NativePortForwardSession(
         NovaSshSafeHandle sessionHandle,
         IReadOnlyList<PortForward> forwards,
         INativeSshInterop interop,
-        Action<string>? log = null)
-        : this(sessionHandle, forwards, interop, log, WriteSocksReplyAsync)
+        Action<string>? log = null,
+        Action<string>? warn = null)
+        : this(sessionHandle, forwards, interop, log, warn, WriteSocksReplyAsync)
     {
     }
 
@@ -63,6 +71,7 @@ public sealed class NativePortForwardSession : IDisposable
         IReadOnlyList<PortForward> forwards,
         INativeSshInterop interop,
         Action<string>? log,
+        Action<string>? warn,
         Func<NetworkStream, byte[], CancellationToken, Task> socksReplyWriter)
     {
         if (sessionHandle is null || sessionHandle.IsInvalid || sessionHandle.IsClosed)
@@ -76,6 +85,7 @@ public sealed class NativePortForwardSession : IDisposable
         _sessionHandle = sessionHandle;
         _interop = interop;
         _log = log ?? (_ => { });
+        _warn = warn ?? (_ => { });
         _socksReplyWriter = socksReplyWriter ?? throw new ArgumentNullException(nameof(socksReplyWriter));
 
         try
@@ -83,10 +93,11 @@ public sealed class NativePortForwardSession : IDisposable
             foreach (PortForward forward in forwards)
             {
                 // Remote forwards have no local listener — the listener lives on the server, and
-                // the request for it can only be made once the session is established.
+                // the request for it can only be made once the session is established (see
+                // NotifySessionEstablished). Only collected here.
                 if (forward.Kind == PortForwardKind.Remote)
                 {
-                    StartRemoteForward(forward);
+                    CollectRemoteForward(forward);
                 }
                 else
                 {
@@ -110,7 +121,9 @@ public sealed class NativePortForwardSession : IDisposable
     /// </summary>
     public void HandleEvent(NativeSshEvent nextEvent)
     {
-        if (nextEvent == null)
+        // Dropping events after disposal is safe (the native close tears every channel down), and
+        // it keeps a late event off the disposed _lifetimeCts that the incoming path would touch.
+        if (nextEvent == null || Volatile.Read(ref _disposed) != 0)
         {
             return;
         }
@@ -216,7 +229,7 @@ public sealed class NativePortForwardSession : IDisposable
         {
             PortForwardKind.Local => Task.Run(() => AcceptLocalLoopAsync(listener, forward, _lifetimeCts.Token)),
             PortForwardKind.Dynamic => Task.Run(() => AcceptDynamicLoopAsync(listener, forward, _lifetimeCts.Token)),
-            // Remote never reaches this method (the constructor routes it to StartRemoteForward),
+            // Remote never reaches this method (the constructor routes it to CollectRemoteForward),
             // so only a kind this code has never heard of lands here.
             _ => throw new NotSupportedException($"Unsupported port-forward kind '{forward.Kind}'.")
         };
@@ -232,19 +245,72 @@ public sealed class NativePortForwardSession : IDisposable
             ? "localhost"
             : forward.BindAddress.Trim();
 
-    private void StartRemoteForward(PortForward forward)
+    private void CollectRemoteForward(PortForward forward)
     {
-        _remoteForwards.Add(forward);
-
+        // Two rules asking the server for the very same listener cannot both be honored: their
+        // connections would be indistinguishable, so whichever rule matched first would take the
+        // second rule's traffic to the wrong destination. First rule wins, deterministically, and
+        // the loser is refused by name rather than raced.
         string bindAddress = RemoteBindAddress(forward);
-
-        // Off the constructor for two reasons: the worker only answers commands once the session
-        // is established (connect and auth can involve prompts), and the interop call blocks until
-        // the server's verdict arrives. A refusal is loud but not fatal — the same behavior ssh
-        // itself has for -R ("Warning: remote port forwarding failed") — so the session survives
-        // and the log names exactly which forward is not listening.
-        _ = Task.Run(() =>
+        if (_remoteForwards.Any(existing =>
+                existing.SourcePort == forward.SourcePort
+                && string.Equals(RemoteBindAddress(existing), bindAddress, StringComparison.OrdinalIgnoreCase)))
         {
+            _log($"[NativePortForwardSession] Duplicate remote forward {forward} ignored: an earlier rule already claims {bindAddress}:{forward.SourcePort}.");
+            _warn($"Warning: duplicate remote forward for {bindAddress}:{forward.SourcePort} ignored; the first rule wins.");
+            return;
+        }
+
+        _remoteForwards.Add(forward);
+    }
+
+    /// <summary>
+    /// The session is established (the Connected event arrived); ask the server for the remote
+    /// listeners now. Not in the constructor, deliberately: the worker only answers commands once
+    /// connect and auth (which can involve prompts) have finished, and the interop call blocks its
+    /// thread until the server's verdict arrives — requesting from the constructor parked one
+    /// thread-pool worker per rule for the whole handshake, which on a constrained pool could
+    /// starve the very poll loop that answers the auth prompts. One task, sequential requests,
+    /// only once there is a session to ask. Idempotent.
+    /// </summary>
+    public void NotifySessionEstablished()
+    {
+        if (_remoteForwards.Count == 0
+            || Interlocked.Exchange(ref _remoteForwardsRequested, 1) != 0
+            || Volatile.Read(ref _disposed) != 0)
+        {
+            return;
+        }
+
+        CancellationToken lifetimeToken;
+        try
+        {
+            lifetimeToken = _lifetimeCts.Token;
+        }
+        catch (ObjectDisposedException)
+        {
+            // Disposed between the check above and here; there is no session left to ask.
+            return;
+        }
+
+        _ = Task.Run(() => RequestRemoteForwards(lifetimeToken), lifetimeToken);
+    }
+
+    private void RequestRemoteForwards(CancellationToken cancellationToken)
+    {
+        foreach (PortForward forward in _remoteForwards)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            string bindAddress = RemoteBindAddress(forward);
+
+            // A refusal is loud but not fatal — the same behavior ssh itself has for -R
+            // ("Warning: remote port forwarding failed") — so the session survives, the log
+            // carries the detail, and the warning reaches the terminal where the user can see
+            // which forward is not listening.
             try
             {
                 int boundPort = _interop.RequestRemoteForward(_sessionHandle, bindAddress, forward.SourcePort);
@@ -253,8 +319,9 @@ public sealed class NativePortForwardSession : IDisposable
             catch (Exception ex)
             {
                 _log($"[NativePortForwardSession] Remote forward {forward} failed: {ex.Message}");
+                _warn($"Warning: remote port forwarding failed for {bindAddress}:{forward.SourcePort}.");
             }
-        }, _lifetimeCts.Token);
+        }
     }
 
     /// <summary>
@@ -312,12 +379,22 @@ public sealed class NativePortForwardSession : IDisposable
     /// </summary>
     private PortForward? MatchRemoteForwardRule(string connectedAddress, int connectedPort)
     {
-        PortForward? exact = _remoteForwards.FirstOrDefault(rule =>
-            rule.SourcePort == connectedPort
-            && string.Equals(RemoteBindAddress(rule), connectedAddress, StringComparison.OrdinalIgnoreCase));
-        if (exact != null)
+        // Exactly one exact match or none: CollectRemoteForward refuses duplicate (address, port)
+        // rules at setup, so more than one here means that invariant broke — refuse rather than
+        // route a connection to a destination that is a coin flip.
+        List<PortForward> exact = _remoteForwards
+            .Where(rule =>
+                rule.SourcePort == connectedPort
+                && string.Equals(RemoteBindAddress(rule), connectedAddress, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        if (exact.Count == 1)
         {
-            return exact;
+            return exact[0];
+        }
+
+        if (exact.Count > 1)
+        {
+            return null;
         }
 
         List<PortForward> byPort = _remoteForwards.Where(rule => rule.SourcePort == connectedPort).ToList();

--- a/src/NovaTerminal.Platform/Ssh/Native/NativeSshCapability.cs
+++ b/src/NovaTerminal.Platform/Ssh/Native/NativeSshCapability.cs
@@ -3,14 +3,20 @@ using NovaTerminal.Platform.Ssh.Models;
 namespace NovaTerminal.Platform.Ssh.Native;
 
 /// <summary>
-/// Why the native SSH backend cannot serve a profile, if it cannot. Currently only
-/// <see cref="None"/>: remote forwards were the last unsupported shape, and they gained native
-/// <c>tcpip-forward</c> support. The enum stays because the gate stays — see
+/// Why the native SSH backend cannot serve a profile, if it cannot. See
 /// <see cref="NativeSshCapability"/>.
 /// </summary>
 public enum NativeSshUnsupportedReason
 {
-    None = 0
+    None = 0,
+
+    /// <summary>
+    /// A remote forward with source port 0 asks the server to allocate the listen port
+    /// (OpenSSH's <c>-R 0:...</c>). The native backend matches incoming connections back to
+    /// their rule by the port the rule requested, so a server-picked port has no rule to land
+    /// on yet. OpenSSH serves this shape; native refuses it by name until it can.
+    /// </summary>
+    RemoteForwardWithServerAllocatedPort = 1
 }
 
 /// <summary>
@@ -60,13 +66,24 @@ public static class NativeSshCapability
         IReadOnlyCollection<PortForward>? forwards,
         IReadOnlyCollection<SshJumpHop>? jumpHops)
     {
-        // Every profile shape is supported today: jump chains of any length (one nested
+        // Almost every profile shape is supported: jump chains of any length (one nested
         // direct-tcpip hop per entry, as OpenSSH treats -J), and local, dynamic, and remote
-        // forwards alike. The parameters and the gate's call sites stay wired even so — the next
-        // shape the backend cannot serve gets its refusal here, reaching the profile editor,
-        // the factory, and the session in one change, which is the whole reason this type exists.
-        _ = forwards;
+        // forwards alike. The one refusal left below reaches the profile editor, the factory,
+        // and the session at once — which is the whole reason this type exists.
         _ = jumpHops;
+
+        if (forwards != null)
+        {
+            foreach (PortForward forward in forwards)
+            {
+                if (forward.Kind == PortForwardKind.Remote && forward.SourcePort == 0)
+                {
+                    return NativeSshCapabilityResult.Unsupported(
+                        NativeSshUnsupportedReason.RemoteForwardWithServerAllocatedPort,
+                        "The native SSH backend cannot serve a remote forward with source port 0 (a server-allocated listen port). Give the forward an explicit port, or switch this profile's backend to OpenSSH.");
+                }
+            }
+        }
 
         return NativeSshCapabilityResult.Supported;
     }

--- a/src/NovaTerminal.Platform/Ssh/Native/NativeSshCapability.cs
+++ b/src/NovaTerminal.Platform/Ssh/Native/NativeSshCapability.cs
@@ -3,17 +3,14 @@ using NovaTerminal.Platform.Ssh.Models;
 namespace NovaTerminal.Platform.Ssh.Native;
 
 /// <summary>
-/// Why the native SSH backend cannot serve a profile, if it cannot.
+/// Why the native SSH backend cannot serve a profile, if it cannot. Currently only
+/// <see cref="None"/>: remote forwards were the last unsupported shape, and they gained native
+/// <c>tcpip-forward</c> support. The enum stays because the gate stays — see
+/// <see cref="NativeSshCapability"/>.
 /// </summary>
 public enum NativeSshUnsupportedReason
 {
-    None = 0,
-
-    /// <summary>
-    /// The profile carries a remote (server-side listener) forward. The native backend has no
-    /// <c>tcpip-forward</c> support, so there is nothing to degrade to.
-    /// </summary>
-    RemotePortForward = 1
+    None = 0
 }
 
 /// <summary>
@@ -63,19 +60,13 @@ public static class NativeSshCapability
         IReadOnlyCollection<PortForward>? forwards,
         IReadOnlyCollection<SshJumpHop>? jumpHops)
     {
-        // Jump hops of any length are supported: the native backend nests one direct-tcpip hop
-        // per entry, the way OpenSSH treats a -J chain. The parameter stays so callers keep
-        // stating the whole shape they are asking about, and so a future hop-shaped limit has
-        // somewhere to live.
+        // Every profile shape is supported today: jump chains of any length (one nested
+        // direct-tcpip hop per entry, as OpenSSH treats -J), and local, dynamic, and remote
+        // forwards alike. The parameters and the gate's call sites stay wired even so — the next
+        // shape the backend cannot serve gets its refusal here, reaching the profile editor,
+        // the factory, and the session in one change, which is the whole reason this type exists.
+        _ = forwards;
         _ = jumpHops;
-
-        if (forwards != null && forwards.Any(forward => forward.Kind is not PortForwardKind.Local and not PortForwardKind.Dynamic))
-        {
-            return NativeSshCapabilityResult.Unsupported(
-                NativeSshUnsupportedReason.RemotePortForward,
-                "The native SSH backend supports local and dynamic port forwards only. "
-                + "Remove the remote forward, or switch this profile to the OpenSSH backend.");
-        }
 
         return NativeSshCapabilityResult.Supported;
     }

--- a/src/NovaTerminal.Platform/Ssh/Native/NativeSshEvent.cs
+++ b/src/NovaTerminal.Platform/Ssh/Native/NativeSshEvent.cs
@@ -22,7 +22,15 @@ public enum NativeSshEventKind
     Closed = 9,
     ForwardChannelData = 10,
     ForwardChannelEof = 11,
-    ForwardChannelClosed = 12
+    ForwardChannelClosed = 12,
+
+    /// <summary>
+    /// The server opened a forwarded-tcpip channel for a remote forward this session requested.
+    /// StatusCode carries the channel id; the JSON payload names the listener the connection
+    /// arrived on and its originator, so the forward session can match it to a rule and dial the
+    /// local destination.
+    /// </summary>
+    ForwardChannelIncoming = 13
 }
 
 public enum NativeSshResponseKind
@@ -69,4 +77,7 @@ public sealed class NativeSshEvent
 
     public static NativeSshEvent ForwardChannelClosed(int channelId) =>
         new(NativeSshEventKind.ForwardChannelClosed, Array.Empty<byte>(), channelId, NativeSshEventFlags.Json);
+
+    public static NativeSshEvent ForwardChannelIncoming(int channelId, byte[] payload) =>
+        new(NativeSshEventKind.ForwardChannelIncoming, payload, channelId, NativeSshEventFlags.Json);
 }

--- a/src/NovaTerminal.Platform/Ssh/Native/NativeSshInterop.cs
+++ b/src/NovaTerminal.Platform/Ssh/Native/NativeSshInterop.cs
@@ -27,6 +27,10 @@ public sealed partial class NativeSshInterop : INativeSshInterop
     // from TryWriteChannel, never as an exception: the caller is meant to retry, and that retry is
     // what applies backpressure to the local socket it is reading from.
     private const int ResultWouldBlock = -8;
+
+    // The server refused a tcpip-forward request. Its own code because the remedy differs from a
+    // failed channel open: there is no channel, and the forward should be reported unavailable.
+    private const int ResultRemoteForwardFailed = -9;
     private static readonly NativeSftpTransferProgressCallback SftpTransferProgressCallback = OnNativeSftpTransferProgress;
     private static readonly IntPtr SftpTransferProgressCallbackPointer =
         Marshal.GetFunctionPointerForDelegate(SftpTransferProgressCallback);
@@ -444,6 +448,43 @@ public sealed partial class NativeSshInterop : INativeSshInterop
         {
             FreeUtf8(hostPtr);
             FreeUtf8(originatorPtr);
+        }
+    }
+
+    public int RequestRemoteForward(NovaSshSafeHandle sessionHandle, string bindAddress, int port)
+    {
+        if (sessionHandle is null || sessionHandle.IsInvalid || sessionHandle.IsClosed)
+        {
+            throw new InvalidOperationException("Cannot request a remote forward without a session handle.");
+        }
+
+        if (string.IsNullOrWhiteSpace(bindAddress))
+        {
+            throw new ArgumentException("A bind address is required for a remote forward.", nameof(bindAddress));
+        }
+
+        if (port is < 1 or > 65535)
+        {
+            throw new ArgumentOutOfRangeException(nameof(port), "The remote forward port must be between 1 and 65535.");
+        }
+
+        IntPtr addressPtr = IntPtr.Zero;
+        try
+        {
+            addressPtr = Marshal.StringToCoTaskMemUTF8(bindAddress);
+            int boundPort = NativeMethods.nova_ssh_request_remote_forward(sessionHandle, addressPtr, checked((ushort)port));
+            if (boundPort >= 0)
+            {
+                return boundPort;
+            }
+
+            throw new InvalidOperationException(boundPort == ResultRemoteForwardFailed
+                ? $"The server refused the remote forward on {bindAddress}:{port}."
+                : $"Native SSH remote-forward request failed with result {boundPort}.");
+        }
+        finally
+        {
+            FreeUtf8(addressPtr);
         }
     }
 
@@ -1007,6 +1048,9 @@ public sealed partial class NativeSshInterop : INativeSshInterop
 
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_open_direct_tcpip")]
         public static extern int nova_ssh_open_direct_tcpip(NovaSshSafeHandle session, in NativeDirectTcpIpOpenArgs args);
+
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_request_remote_forward")]
+        public static extern int nova_ssh_request_remote_forward(NovaSshSafeHandle session, IntPtr address, ushort port);
 
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "nova_ssh_channel_write")]
         public static extern int nova_ssh_channel_write(NovaSshSafeHandle session, uint channelId, byte[] data, nuint dataLength);

--- a/src/NovaTerminal.Platform/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Platform/Ssh/Sessions/NativeSshSession.cs
@@ -63,9 +63,9 @@ public sealed class NativeSshSession : ITerminalSession
     {
         ArgumentNullException.ThrowIfNull(profile);
 
-        // Single gate for every shape the native backend cannot serve — none today, with remote
-        // forwards now implemented, but the wiring stays: the next unsupported shape gets its
-        // refusal in NativeSshCapability and is enforced here and at profile-save time at once.
+        // Single gate for every shape the native backend cannot serve — today only a remote
+        // forward with a server-allocated port (source port 0). The refusal lives in
+        // NativeSshCapability and is enforced here and at profile-save time at once.
         NativeSshCapabilityResult capability = NativeSshCapability.Evaluate(profile);
         if (!capability.IsSupported)
         {
@@ -93,7 +93,14 @@ public sealed class NativeSshSession : ITerminalSession
         {
             if (profile.Forwards.Count != 0)
             {
-                _portForwardSession = new NativePortForwardSession(_sessionHandle, profile.Forwards, _interop, _log);
+                // warn: forwarding failures the user must see (a refused remote listener, above
+                // all) go to the terminal, ssh-style, not only to the diagnostic log.
+                _portForwardSession = new NativePortForwardSession(
+                    _sessionHandle,
+                    profile.Forwards,
+                    _interop,
+                    _log,
+                    warn: message => EmitText($"{message}\r\n"));
                 foreach (PortForward forward in profile.Forwards)
                 {
                     _metrics.RecordForwardSetup(forward.ToString());
@@ -374,8 +381,14 @@ public sealed class NativeSshSession : ITerminalSession
         DisableFlightRecording();
         _pollCts.Cancel();
         _metrics.MarkDisconnected("Disposed");
-        _portForwardSession?.Dispose();
-        CloseNativeHandle();
+
+        // The poll loop is drained BEFORE the forward session is disposed: it is the only caller
+        // of HandleEvent/NotifySessionEstablished, so waiting here is what guarantees neither runs
+        // against a disposed forward session (whose CancellationTokenSource throws once disposed).
+        // Only a poll loop stuck past the 2s ceiling — e.g. an interaction handler ignoring its
+        // cancellation token — can still race, and then teardown proceeding anyway is the lesser
+        // evil. CloseNativeHandle is last (the loop's own finally usually beats it to the close);
+        // the native close tears down every channel the forward session's best-effort closes miss.
         try
         {
             _pollTask.Wait(TimeSpan.FromSeconds(2));
@@ -383,10 +396,10 @@ public sealed class NativeSshSession : ITerminalSession
         catch (AggregateException ex) when (ex.InnerExceptions.All(inner => inner is TaskCanceledException or OperationCanceledException))
         {
         }
-        finally
-        {
-            _pollCts.Dispose();
-        }
+
+        _portForwardSession?.Dispose();
+        CloseNativeHandle();
+        _pollCts.Dispose();
     }
 
     private async Task PollLoopAsync()
@@ -406,6 +419,9 @@ public sealed class NativeSshSession : ITerminalSession
                 {
                     case NativeSshEventKind.Connected:
                         _metrics.MarkConnected();
+                        // Remote-forward listeners can only be requested of a session that
+                        // exists; this event is what says it does.
+                        _portForwardSession?.NotifySessionEstablished();
                         break;
                     case NativeSshEventKind.Data:
                         EmitOutput(nextEvent.Payload);
@@ -414,7 +430,21 @@ public sealed class NativeSshSession : ITerminalSession
                     case NativeSshEventKind.ForwardChannelEof:
                     case NativeSshEventKind.ForwardChannelClosed:
                     case NativeSshEventKind.ForwardChannelIncoming:
-                        _portForwardSession?.HandleEvent(nextEvent);
+                        if (_portForwardSession != null)
+                        {
+                            _portForwardSession.HandleEvent(nextEvent);
+                        }
+                        else if (nextEvent.Kind == NativeSshEventKind.ForwardChannelIncoming)
+                        {
+                            // The server opened a forwarded-tcpip channel at a session that
+                            // never configured a forward. Unsolicited — refuse it. Merely
+                            // dropping the event would leave the channel registered and open on
+                            // the native side, and a hostile server could grow that without
+                            // bound. (The Rust handler refuses these too; this is the managed
+                            // line of defense.)
+                            RefuseUnsolicitedForwardChannel(nextEvent.StatusCode);
+                        }
+
                         break;
                     case NativeSshEventKind.ExitStatus:
                         TryNotifyExit(nextEvent.StatusCode);
@@ -601,6 +631,23 @@ public sealed class NativeSshSession : ITerminalSession
             // blocks here — e.g. synchronously awaiting a UI-thread response — would
             // stall the poll loop and any new subscriber.
             handler?.Invoke(text);
+        }
+    }
+
+    private void RefuseUnsolicitedForwardChannel(int channelId)
+    {
+        _log($"[NativeSshSession] Closing unsolicited forward channel {channelId}: this session has no forwards configured.");
+        try
+        {
+            NovaSshSafeHandle? handle = _sessionHandle;
+            if (handle != null)
+            {
+                _interop.CloseChannel(handle, channelId);
+            }
+        }
+        catch (Exception ex) when (!IsCriticalException(ex))
+        {
+            _log($"[NativeSshSession] Failed to close unsolicited forward channel {channelId}: {ex.Message}");
         }
     }
 

--- a/src/NovaTerminal.Platform/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Platform/Ssh/Sessions/NativeSshSession.cs
@@ -63,9 +63,9 @@ public sealed class NativeSshSession : ITerminalSession
     {
         ArgumentNullException.ThrowIfNull(profile);
 
-        // Single gate for every shape the native backend cannot serve (remote forwards).
-        // The editor asks NativeSshCapability the same question at save time, so reaching this throw
-        // means either a profile saved before the check existed or a caller constructing us directly.
+        // Single gate for every shape the native backend cannot serve — none today, with remote
+        // forwards now implemented, but the wiring stays: the next unsupported shape gets its
+        // refusal in NativeSshCapability and is enforced here and at profile-save time at once.
         NativeSshCapabilityResult capability = NativeSshCapability.Evaluate(profile);
         if (!capability.IsSupported)
         {
@@ -413,6 +413,7 @@ public sealed class NativeSshSession : ITerminalSession
                     case NativeSshEventKind.ForwardChannelData:
                     case NativeSshEventKind.ForwardChannelEof:
                     case NativeSshEventKind.ForwardChannelClosed:
+                    case NativeSshEventKind.ForwardChannelIncoming:
                         _portForwardSession?.HandleEvent(nextEvent);
                         break;
                     case NativeSshEventKind.ExitStatus:

--- a/tests/NovaTerminal.App.Tests/Ssh/NewSshConnectionViewModelTests.cs
+++ b/tests/NovaTerminal.App.Tests/Ssh/NewSshConnectionViewModelTests.cs
@@ -293,8 +293,10 @@ public sealed class NewSshConnectionViewModelTests
     }
 
     [Fact]
-    public void Validate_ForNativeProfileWithRemoteForward_FailsWithAnActionableError()
+    public void Validate_ForNativeProfileWithRemoteForward_Succeeds()
     {
+        // This shape used to be refused at save time as the capability gate's last unsupported
+        // one. Remote forwards are served natively now, so it must save cleanly with no warning.
         var vm = new NewSshConnectionViewModel
         {
             HostName = "native.internal",
@@ -310,11 +312,9 @@ public sealed class NewSshConnectionViewModelTests
             DestinationPort = 80
         });
 
-        bool valid = vm.Validate();
-
-        Assert.False(valid);
-        Assert.Contains("remote forward", vm.ValidationError, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("OpenSSH", vm.ValidationError, StringComparison.OrdinalIgnoreCase);
+        Assert.True(vm.Validate());
+        Assert.Equal(string.Empty, vm.ValidationError);
+        Assert.Equal(string.Empty, vm.BackendWarning);
     }
 
     [Fact]
@@ -379,14 +379,14 @@ public sealed class NewSshConnectionViewModelTests
     }
 
     [Fact]
-    public void BackendWarning_ForUnsupportedShape_NamesTheShapeRatherThanTheGlobalToggle()
+    public void BackendWarning_WithEveryShapeSupported_ReportsOnlyTheGlobalToggle()
     {
+        // With no unsupported shapes left, the only thing the warning can legitimately say about a
+        // native profile — however it is shaped — is that the global toggle is off.
         var vm = new NewSshConnectionViewModel
         {
             HostName = "native.internal",
             BackendKind = SshBackendKind.Native,
-            // Toggle off as well: enabling it would not make this profile connectable, so the warning
-            // must not send the user to settings.
             ExperimentalNativeSshEnabled = false
         };
         vm.Forwards.Add(new PortForward
@@ -397,13 +397,15 @@ public sealed class NewSshConnectionViewModelTests
             DestinationPort = 80
         });
 
-        Assert.Contains("remote forward", vm.BackendWarning, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("disabled globally", vm.BackendWarning, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("disabled globally", vm.BackendWarning, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
     public void BackendWarning_IsRaisedWhenForwardsChange()
     {
+        // The collection hook must keep re-evaluating the warning even while every shape is
+        // supported: it is what lets a future unsupported shape surface as the user edits,
+        // rather than only at save.
         var vm = new NewSshConnectionViewModel
         {
             HostName = "native.internal",
@@ -423,6 +425,6 @@ public sealed class NewSshConnectionViewModelTests
         });
 
         Assert.Contains(nameof(NewSshConnectionViewModel.BackendWarning), raised);
-        Assert.Contains("remote forward", vm.BackendWarning, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(string.Empty, vm.BackendWarning);
     }
 }

--- a/tests/NovaTerminal.Platform.Tests/Ssh/NativePortForwardSessionTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/NativePortForwardSessionTests.cs
@@ -489,6 +489,110 @@ public sealed class NativePortForwardSessionTests
     /// Refuses the first <c>refusalsPerWrite</c> attempts of every distinct write, then accepts,
     /// standing in for a native queue that is briefly over budget.
     /// </summary>
+    [Fact]
+    public async Task RemoteForward_RequestsAListenerFromTheServer()
+    {
+        var interop = new FakeNativeSshInterop();
+
+        using var session = new NativePortForwardSession(
+            FakeHandle(30),
+            [CreateRemoteForward(19000, "127.0.0.1", 9200)],
+            interop);
+
+        // Off the constructor by design: the request can only be answered once the session is
+        // established, so it runs on a background task.
+        await WaitUntilAsync(() => interop.RemoteForwardRequests.Count == 1);
+        Assert.Equal(("localhost", 19000), interop.RemoteForwardRequests[0]);
+    }
+
+    [Fact]
+    public async Task IncomingForwardChannel_DialsTheDestinationAndCarriesBytesBothWays()
+    {
+        var interop = new FakeNativeSshInterop();
+        int destinationPort = GetFreePort();
+        var destination = new TcpListener(IPAddress.Loopback, destinationPort);
+        destination.Start();
+
+        try
+        {
+            using var session = new NativePortForwardSession(
+                FakeHandle(31),
+                [CreateRemoteForward(19001, "127.0.0.1", destinationPort)],
+                interop);
+
+            // The data event is queued immediately behind the announcement, before the dial to the
+            // destination can possibly have completed. Nothing may be lost to that gap: the channel
+            // state (and its ordered outbound queue) must exist from the announcement onward.
+            byte[] payload = Encoding.ASCII.GetBytes("remote-forwarded-request");
+            session.HandleEvent(NativeSshEvent.ForwardChannelIncoming(77, IncomingPayload(19001)));
+            session.HandleEvent(NativeSshEvent.ForwardChannelData(77, payload));
+
+            using TcpClient accepted = await destination.AcceptTcpClientAsync();
+            NetworkStream stream = accepted.GetStream();
+            byte[] received = await ReadExactlyAsync(stream, payload.Length, TimeSpan.FromSeconds(10));
+            Assert.Equal(payload, received);
+
+            // And the reply direction rides the same channel toward the remote.
+            byte[] reply = Encoding.ASCII.GetBytes("remote-forwarded-reply");
+            await stream.WriteAsync(reply);
+            await stream.FlushAsync();
+            await WaitUntilAsync(() => interop.ChannelWrites(77).Length == reply.Length);
+            Assert.Equal(reply, interop.ChannelWrites(77));
+        }
+        finally
+        {
+            destination.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task IncomingForwardChannel_WithNoMatchingRule_IsRefused()
+    {
+        var interop = new FakeNativeSshInterop();
+
+        using var session = new NativePortForwardSession(
+            FakeHandle(32),
+            [CreateRemoteForward(19002, "127.0.0.1", 9300)],
+            interop);
+
+        // An announcement for a port no rule asked about has no destination it is allowed to reach.
+        session.HandleEvent(NativeSshEvent.ForwardChannelIncoming(78, IncomingPayload(28000)));
+
+        await WaitUntilAsync(() => interop.ClosedChannelIds.Contains(78));
+    }
+
+    [Fact]
+    public async Task IncomingForwardChannel_WhenTheDestinationRefuses_ClosesTheChannel()
+    {
+        var interop = new FakeNativeSshInterop();
+        // A freshly probed free port with nothing listening: the dial must fail fast.
+        int deadPort = GetFreePort();
+
+        using var session = new NativePortForwardSession(
+            FakeHandle(33),
+            [CreateRemoteForward(19003, "127.0.0.1", deadPort)],
+            interop);
+
+        session.HandleEvent(NativeSshEvent.ForwardChannelIncoming(79, IncomingPayload(19003)));
+
+        await WaitUntilAsync(() => interop.ClosedChannelIds.Contains(79));
+    }
+
+    private static byte[] IncomingPayload(int connectedPort) =>
+        Encoding.UTF8.GetBytes(
+            $"{{\"connectedAddress\":\"localhost\",\"connectedPort\":{connectedPort},\"originatorAddress\":\"192.0.2.10\",\"originatorPort\":50000}}");
+
+    private static PortForward CreateRemoteForward(int sourcePort, string destinationHost, int destinationPort)
+    {
+        return new PortForward
+        {
+            Kind = PortForwardKind.Remote,
+            SourcePort = sourcePort,
+            DestinationHost = destinationHost,
+            DestinationPort = destinationPort
+        };
+    }
+
     private sealed class BackpressuringNativeSshInterop : FakeNativeSshInterop
     {
         private readonly int _refusalsPerWrite;
@@ -679,6 +783,8 @@ public sealed class NativePortForwardSessionTests
         private readonly List<NativePortForwardOpenOptions> _openRequests = [];
         private readonly List<int> _closedChannelIds = [];
         private readonly List<int> _openedChannelIds = [];
+        private readonly List<(string BindAddress, int Port)> _remoteForwardRequests = [];
+        private readonly Dictionary<int, List<byte>> _channelWrites = [];
 
         public IReadOnlyList<NativePortForwardOpenOptions> OpenRequests
         {
@@ -695,6 +801,22 @@ public sealed class NativePortForwardSessionTests
         public IReadOnlyList<int> ClosedChannelIds
         {
             get { lock (_collectionsLock) { return _closedChannelIds.ToArray(); } }
+        }
+
+        public IReadOnlyList<(string BindAddress, int Port)> RemoteForwardRequests
+        {
+            get { lock (_collectionsLock) { return _remoteForwardRequests.ToArray(); } }
+        }
+
+        /// <summary>Everything written toward the remote on one channel, in order.</summary>
+        public byte[] ChannelWrites(int channelId)
+        {
+            lock (_collectionsLock)
+            {
+                return _channelWrites.TryGetValue(channelId, out List<byte>? bytes)
+                    ? bytes.ToArray()
+                    : [];
+            }
         }
 
         public NovaSshSafeHandle Connect(NativeSshConnectionOptions options) => new(new IntPtr(1), ownsHandle: false);
@@ -741,6 +863,27 @@ public sealed class NativePortForwardSessionTests
 
         public void WriteChannel(NovaSshSafeHandle sessionHandle, int channelId, ReadOnlySpan<byte> data)
         {
+            byte[] copied = data.ToArray();
+            lock (_collectionsLock)
+            {
+                if (!_channelWrites.TryGetValue(channelId, out List<byte>? bytes))
+                {
+                    bytes = [];
+                    _channelWrites[channelId] = bytes;
+                }
+
+                bytes.AddRange(copied);
+            }
+        }
+
+        public int RequestRemoteForward(NovaSshSafeHandle sessionHandle, string bindAddress, int port)
+        {
+            lock (_collectionsLock)
+            {
+                _remoteForwardRequests.Add((bindAddress, port));
+            }
+
+            return port;
         }
 
         // Declared (rather than left to the interface's default) so a derived fake can override it.

--- a/tests/NovaTerminal.Platform.Tests/Ssh/NativePortForwardSessionTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/NativePortForwardSessionTests.cs
@@ -578,9 +578,91 @@ public sealed class NativePortForwardSessionTests
         await WaitUntilAsync(() => interop.ClosedChannelIds.Contains(79));
     }
 
-    private static byte[] IncomingPayload(int connectedPort) =>
+    [Fact]
+    public async Task IncomingForwardChannel_WithTwoRulesOnOnePort_RoutesByBindAddress()
+    {
+        // Two rules can legitimately share a port on different bind addresses, and the listener
+        // requests race — the rule whose listener actually bound may not be the first with the
+        // port. The announcement's address is what decides where the connection is allowed to go.
+        var interop = new FakeNativeSshInterop();
+        int firstDestinationPort = GetFreePort();
+        int secondDestinationPort = GetFreePort();
+        var secondDestination = new TcpListener(IPAddress.Loopback, secondDestinationPort);
+        secondDestination.Start();
+
+        try
+        {
+            PortForward first = CreateRemoteForward(19010, "127.0.0.1", firstDestinationPort);
+            first.BindAddress = "198.51.100.1";
+            PortForward second = CreateRemoteForward(19010, "127.0.0.1", secondDestinationPort);
+            second.BindAddress = "198.51.100.2";
+
+            using var session = new NativePortForwardSession(FakeHandle(34), [first, second], interop);
+
+            session.HandleEvent(NativeSshEvent.ForwardChannelIncoming(80, IncomingPayload(19010, "198.51.100.2")));
+
+            // The connection must land at the SECOND rule's destination — a port-only pick would
+            // have dialled the first.
+            using TcpClient accepted = await secondDestination.AcceptTcpClientAsync().WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.NotNull(accepted);
+        }
+        finally
+        {
+            secondDestination.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task IncomingForwardChannel_WithOneRuleOnThePort_ToleratesServerAddressNormalization()
+    {
+        // A rule bound as "localhost" may be announced back as "127.0.0.1" by a server that
+        // normalizes. With exactly one rule on the port there is nothing to confuse, so the
+        // port-only fallback must accept it.
+        var interop = new FakeNativeSshInterop();
+        int destinationPort = GetFreePort();
+        var destination = new TcpListener(IPAddress.Loopback, destinationPort);
+        destination.Start();
+
+        try
+        {
+            using var session = new NativePortForwardSession(
+                FakeHandle(35),
+                [CreateRemoteForward(19011, "127.0.0.1", destinationPort)],
+                interop);
+
+            session.HandleEvent(NativeSshEvent.ForwardChannelIncoming(81, IncomingPayload(19011, "127.0.0.1")));
+
+            using TcpClient accepted = await destination.AcceptTcpClientAsync().WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.NotNull(accepted);
+        }
+        finally
+        {
+            destination.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task IncomingForwardChannel_WithAmbiguousAddress_IsRefused()
+    {
+        // Two rules on the port, an address matching neither: any pick could be the wrong one,
+        // so the only safe answer is no.
+        var interop = new FakeNativeSshInterop();
+
+        PortForward first = CreateRemoteForward(19012, "127.0.0.1", 9400);
+        first.BindAddress = "198.51.100.1";
+        PortForward second = CreateRemoteForward(19012, "127.0.0.1", 9401);
+        second.BindAddress = "198.51.100.2";
+
+        using var session = new NativePortForwardSession(FakeHandle(36), [first, second], interop);
+
+        session.HandleEvent(NativeSshEvent.ForwardChannelIncoming(82, IncomingPayload(19012, "203.0.113.9")));
+
+        await WaitUntilAsync(() => interop.ClosedChannelIds.Contains(82));
+    }
+
+    private static byte[] IncomingPayload(int connectedPort, string connectedAddress = "localhost") =>
         Encoding.UTF8.GetBytes(
-            $"{{\"connectedAddress\":\"localhost\",\"connectedPort\":{connectedPort},\"originatorAddress\":\"192.0.2.10\",\"originatorPort\":50000}}");
+            $"{{\"connectedAddress\":\"{connectedAddress}\",\"connectedPort\":{connectedPort},\"originatorAddress\":\"192.0.2.10\",\"originatorPort\":50000}}");
 
     private static PortForward CreateRemoteForward(int sourcePort, string destinationHost, int destinationPort)
     {

--- a/tests/NovaTerminal.Platform.Tests/Ssh/NativePortForwardSessionTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/NativePortForwardSessionTests.cs
@@ -490,7 +490,7 @@ public sealed class NativePortForwardSessionTests
     /// standing in for a native queue that is briefly over budget.
     /// </summary>
     [Fact]
-    public async Task RemoteForward_RequestsAListenerFromTheServer()
+    public async Task RemoteForward_RequestsAListenerFromTheServer_OnlyOnceTheSessionIsEstablished()
     {
         var interop = new FakeNativeSshInterop();
 
@@ -499,10 +499,84 @@ public sealed class NativePortForwardSessionTests
             [CreateRemoteForward(19000, "127.0.0.1", 9200)],
             interop);
 
-        // Off the constructor by design: the request can only be answered once the session is
-        // established, so it runs on a background task.
+        // Not at construction: the request blocks its thread until the worker answers, and the
+        // worker only answers once connect and auth are done. Requesting from the constructor
+        // parked one thread-pool worker per rule for the whole handshake (Codex review on #333).
+        await Task.Delay(100);
+        Assert.Empty(interop.RemoteForwardRequests);
+
+        session.NotifySessionEstablished();
         await WaitUntilAsync(() => interop.RemoteForwardRequests.Count == 1);
         Assert.Equal(("localhost", 19000), interop.RemoteForwardRequests[0]);
+
+        // Idempotent: the Connected event should only ever fire once, but a second notification
+        // must not re-request the listener either way.
+        session.NotifySessionEstablished();
+        await Task.Delay(100);
+        Assert.Single(interop.RemoteForwardRequests);
+    }
+
+    [Fact]
+    public async Task RemoteForward_WhenTheServerRefuses_WarnsWhereTheUserCanSeeIt()
+    {
+        // A refused -R is loud but not fatal in ssh; the native backend must match both halves.
+        // The warning has to reach the terminal, not only the diagnostic log — a session that
+        // looks healthy while its requested listener silently does not exist is the silent
+        // degradation the backend promises not to have.
+        var interop = new RefusingRemoteForwardInterop();
+        var warnings = new ConcurrentQueue<string>();
+
+        using var session = new NativePortForwardSession(
+            FakeHandle(37),
+            [CreateRemoteForward(19004, "127.0.0.1", 9500)],
+            interop,
+            log: null,
+            warn: warnings.Enqueue);
+
+        session.NotifySessionEstablished();
+
+        await WaitUntilAsync(() => !warnings.IsEmpty);
+        Assert.Contains(warnings, warning => warning.Contains("localhost:19004", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task RemoteForward_DuplicateRules_RequestOneListenerAndWarnAboutTheLoser()
+    {
+        // Two rules asking for the same server listener cannot both be honored — their incoming
+        // connections would be indistinguishable, and traffic could land at the wrong
+        // destination. First rule wins deterministically; the duplicate is named, not raced.
+        var interop = new FakeNativeSshInterop();
+        var warnings = new ConcurrentQueue<string>();
+        int firstDestinationPort = GetFreePort();
+        var firstDestination = new TcpListener(IPAddress.Loopback, firstDestinationPort);
+        firstDestination.Start();
+
+        try
+        {
+            using var session = new NativePortForwardSession(
+                FakeHandle(38),
+                [
+                    CreateRemoteForward(19005, "127.0.0.1", firstDestinationPort),
+                    CreateRemoteForward(19005, "127.0.0.1", 9601)
+                ],
+                interop,
+                log: null,
+                warn: warnings.Enqueue);
+
+            session.NotifySessionEstablished();
+
+            await WaitUntilAsync(() => interop.RemoteForwardRequests.Count == 1);
+            Assert.Contains(warnings, warning => warning.Contains("19005", StringComparison.Ordinal));
+
+            // And an incoming connection on the port lands at the FIRST rule's destination.
+            session.HandleEvent(NativeSshEvent.ForwardChannelIncoming(83, IncomingPayload(19005)));
+            using TcpClient accepted = await firstDestination.AcceptTcpClientAsync().WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.NotNull(accepted);
+        }
+        finally
+        {
+            firstDestination.Stop();
+        }
     }
 
     [Fact]
@@ -673,6 +747,14 @@ public sealed class NativePortForwardSessionTests
             DestinationHost = destinationHost,
             DestinationPort = destinationPort
         };
+    }
+
+    /// <summary>A server that refuses every tcpip-forward request, the way NativeSshInterop
+    /// surfaces it: a thrown exception naming the listener.</summary>
+    private sealed class RefusingRemoteForwardInterop : FakeNativeSshInterop
+    {
+        public override int RequestRemoteForward(NovaSshSafeHandle sessionHandle, string bindAddress, int port) =>
+            throw new InvalidOperationException($"The server refused the remote forward on {bindAddress}:{port}.");
     }
 
     private sealed class BackpressuringNativeSshInterop : FakeNativeSshInterop
@@ -958,7 +1040,8 @@ public sealed class NativePortForwardSessionTests
             }
         }
 
-        public int RequestRemoteForward(NovaSshSafeHandle sessionHandle, string bindAddress, int port)
+        // Virtual so a derived fake can stand in for a server that refuses the request.
+        public virtual int RequestRemoteForward(NovaSshSafeHandle sessionHandle, string bindAddress, int port)
         {
             lock (_collectionsLock)
             {
@@ -1009,11 +1092,12 @@ public sealed class NativePortForwardSessionTests
                 typeof(IReadOnlyList<PortForward>),
                 typeof(INativeSshInterop),
                 typeof(Action<string>),
+                typeof(Action<string>),
                 typeof(Func<NetworkStream, byte[], CancellationToken, Task>)
             ],
             modifiers: null)
             ?? throw new InvalidOperationException("Could not find NativePortForwardSession private reply-writer constructor.");
 
-        return (NativePortForwardSession)ctor.Invoke([sessionHandle, forwards, interop, null!, replyWriter]);
+        return (NativePortForwardSession)ctor.Invoke([sessionHandle, forwards, interop, null!, null!, replyWriter]);
     }
 }

--- a/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshCapabilityTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshCapabilityTests.cs
@@ -66,11 +66,43 @@ public sealed class NativeSshCapabilityTests
     public void Evaluate_ForRemoteForwardBehindAJumpChain_IsSupported()
     {
         // The two shapes that were each the gate's reason to refuse at some point, combined —
-        // the strongest form of "the gate refuses nothing today".
+        // both are served natively now (the gate's one refusal left is a remote forward with a
+        // server-allocated port).
         SshProfile profile = CreateProfile();
         profile.JumpHops.Add(new SshJumpHop { Host = "jump-one.internal" });
         profile.JumpHops.Add(new SshJumpHop { Host = "jump-two.internal" });
         profile.Forwards.Add(new PortForward { Kind = PortForwardKind.Remote, SourcePort = 8080, DestinationHost = "svc", DestinationPort = 80 });
+
+        Assert.True(NativeSshCapability.Evaluate(profile).IsSupported);
+    }
+
+    [Fact]
+    public void Evaluate_ForRemoteForwardWithPortZero_IsRefusedByName()
+    {
+        // -R 0:... asks the server to allocate the listen port. The native backend routes
+        // incoming connections back to their rule by the requested port, so a server-picked
+        // port has no rule to land on — the gate must refuse the shape up front, not let the
+        // request die in a background task's log (Codex review on #333).
+        SshProfile profile = CreateProfile();
+        profile.Forwards.Add(new PortForward { Kind = PortForwardKind.Remote, SourcePort = 0, DestinationHost = "svc", DestinationPort = 80 });
+
+        NativeSshCapabilityResult result = NativeSshCapability.Evaluate(profile);
+
+        Assert.False(result.IsSupported);
+        Assert.Equal(NativeSshUnsupportedReason.RemoteForwardWithServerAllocatedPort, result.Reason);
+        Assert.Contains("port 0", result.Explanation, StringComparison.Ordinal);
+        Assert.Contains("OpenSSH", result.Explanation, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Evaluate_ForLocalOrDynamicForwardWithPortZero_IsSupported()
+    {
+        // Port 0 is only ambiguous for remote forwards: a local or dynamic listener binds an
+        // ephemeral port on this machine, where the OS answers immediately and no rule matching
+        // is involved.
+        SshProfile profile = CreateProfile();
+        profile.Forwards.Add(new PortForward { Kind = PortForwardKind.Local, SourcePort = 0, DestinationHost = "svc", DestinationPort = 80 });
+        profile.Forwards.Add(new PortForward { Kind = PortForwardKind.Dynamic, SourcePort = 0 });
 
         Assert.True(NativeSshCapability.Evaluate(profile).IsSupported);
     }

--- a/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshCapabilityTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshCapabilityTests.cs
@@ -18,6 +18,7 @@ public sealed class NativeSshCapabilityTests
     [Theory]
     [InlineData(PortForwardKind.Local)]
     [InlineData(PortForwardKind.Dynamic)]
+    [InlineData(PortForwardKind.Remote)]
     public void Evaluate_ForForwardKindsTheNativeBackendImplements_IsSupported(PortForwardKind kind)
     {
         SshProfile profile = CreateProfile();
@@ -27,34 +28,20 @@ public sealed class NativeSshCapabilityTests
     }
 
     [Fact]
-    public void Evaluate_ForRemoteForward_IsUnsupportedAndNamesBothFixes()
+    public void Evaluate_ForEveryForwardKindTogether_IsSupported()
     {
-        SshProfile profile = CreateProfile();
-        profile.Forwards.Add(new PortForward
-        {
-            Kind = PortForwardKind.Remote,
-            SourcePort = 8080,
-            DestinationHost = "svc.internal",
-            DestinationPort = 80
-        });
-
-        NativeSshCapabilityResult result = NativeSshCapability.Evaluate(profile);
-
-        Assert.False(result.IsSupported);
-        Assert.Equal(NativeSshUnsupportedReason.RemotePortForward, result.Reason);
-        Assert.Contains("remote forward", result.Explanation, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("OpenSSH", result.Explanation, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public void Evaluate_ForRemoteForwardAmongSupportedOnes_StillReportsUnsupported()
-    {
+        // Remote forwards were the gate's last refusal. With them served natively, a profile
+        // mixing all three kinds — the shape that used to be refused for its remote member —
+        // must evaluate as supported.
         SshProfile profile = CreateProfile();
         profile.Forwards.Add(new PortForward { Kind = PortForwardKind.Local, SourcePort = 15000, DestinationHost = "a", DestinationPort = 1 });
         profile.Forwards.Add(new PortForward { Kind = PortForwardKind.Remote, SourcePort = 15001, DestinationHost = "b", DestinationPort = 2 });
         profile.Forwards.Add(new PortForward { Kind = PortForwardKind.Dynamic, SourcePort = 15002 });
 
-        Assert.Equal(NativeSshUnsupportedReason.RemotePortForward, NativeSshCapability.Evaluate(profile).Reason);
+        NativeSshCapabilityResult result = NativeSshCapability.Evaluate(profile);
+
+        Assert.True(result.IsSupported);
+        Assert.Equal(NativeSshUnsupportedReason.None, result.Reason);
     }
 
     [Theory]
@@ -76,16 +63,16 @@ public sealed class NativeSshCapabilityTests
     }
 
     [Fact]
-    public void Evaluate_ForRemoteForwardBehindAJumpChain_StillReportsTheForward()
+    public void Evaluate_ForRemoteForwardBehindAJumpChain_IsSupported()
     {
-        // The chain is no longer a problem, so the remote forward must be what gets reported —
-        // not masked by hops that are now fine.
+        // The two shapes that were each the gate's reason to refuse at some point, combined —
+        // the strongest form of "the gate refuses nothing today".
         SshProfile profile = CreateProfile();
         profile.JumpHops.Add(new SshJumpHop { Host = "jump-one.internal" });
         profile.JumpHops.Add(new SshJumpHop { Host = "jump-two.internal" });
         profile.Forwards.Add(new PortForward { Kind = PortForwardKind.Remote, SourcePort = 8080, DestinationHost = "svc", DestinationPort = 80 });
 
-        Assert.Equal(NativeSshUnsupportedReason.RemotePortForward, NativeSshCapability.Evaluate(profile).Reason);
+        Assert.True(NativeSshCapability.Evaluate(profile).IsSupported);
     }
 
     [Fact]

--- a/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshDockerRemoteForwardE2eTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshDockerRemoteForwardE2eTests.cs
@@ -1,0 +1,127 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using NovaTerminal.Platform.Ssh.Models;
+using NovaTerminal.Platform.Ssh.Sessions;
+using NovaTerminal.Platform.Tests.Infra;
+using NovaTerminal.VT;
+using static NovaTerminal.Platform.Tests.Ssh.NativeSshDockerTestWaits;
+
+namespace NovaTerminal.Platform.Tests.Ssh;
+
+/// <summary>
+/// The remote-forward row of docs/native-ssh/Native_SSH_Test_Matrix.md, against a real sshd.
+///
+/// Direction matters here: the listener lives on the SERVER, and the connection travels toward
+/// the client. The fixture container's own shell session drives it — socat inside the container
+/// dials the remote listener, the tunnel carries the bytes to this test, and a local destination
+/// server answers with a transformed payload. Transformed on purpose: the dialling command is
+/// echoed into the terminal, so asserting on the raw payload would match the echo of what was
+/// typed; the transformed reply can only have come back through the tunnel.
+/// </summary>
+public sealed class NativeSshDockerRemoteForwardE2eTests
+{
+    private static readonly TimeSpan PromptTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// The port the remote listener binds inside the container. Fixed rather than probed: each
+    /// test container has its own network namespace, so there is nothing to collide with.
+    /// </summary>
+    private const int RemoteListenPort = 18080;
+
+    [DockerFact]
+    [Trait("Category", "DockerE2E")]
+    [Trait("Target", "NativeSsh")]
+    public async Task RemoteForward_CarriesRealBytesFromTheServerToALocalDestination()
+    {
+        await using var fixture = await DockerSshFixture.StartAsync();
+
+        // The local destination the tunnel must reach: reads one request, answers with a
+        // transformed copy, and closes its send side so socat sees end-of-stream and exits.
+        var destination = new TcpListener(IPAddress.Loopback, 0);
+        destination.Start();
+        int destinationPort = ((IPEndPoint)destination.LocalEndpoint).Port;
+        _ = Task.Run(() => AnswerOneConnectionAsync(destination));
+
+        try
+        {
+            var buffer = new TerminalBuffer(120, 30);
+            var parser = new AnsiParser(buffer);
+            var handler = new NativeSshTestInteractionHandler(fixture.Password);
+
+            var profile = new SshProfile
+            {
+                Id = Guid.NewGuid(),
+                Name = "Docker Native SSH (remote forward)",
+                BackendKind = SshBackendKind.Native,
+                Host = fixture.Host,
+                User = fixture.UserName,
+                Port = fixture.Port
+            };
+            profile.Forwards.Add(new PortForward
+            {
+                Kind = PortForwardKind.Remote,
+                SourcePort = RemoteListenPort,
+                DestinationHost = "127.0.0.1",
+                DestinationPort = destinationPort
+            });
+
+            using var session = new NativeSshSession(profile, cols: 120, rows: 30, interactionHandler: handler);
+            session.OnOutputReceived += parser.Process;
+
+            await WaitUntilAsync(() => SnapshotContains(buffer, "nova$"), PromptTimeout, "shell prompt before remote forwarding");
+
+            // The tcpip-forward request races the prompt (it is made once the session is
+            // established, on its own task), so the dial retries until the listener exists.
+            // socat prints whatever comes back through the tunnel into this very terminal.
+            session.SendInput(
+                $"for i in $(seq 1 50); do printf 'remote-ping' | socat -T 10 - TCP:127.0.0.1:{RemoteListenPort} && break; sleep 0.2; done\n");
+
+            await WaitUntilAsync(
+                () => SnapshotContains(buffer, "reply:remote-ping"),
+                TimeSpan.FromSeconds(30),
+                "the transformed reply travelling server -> tunnel -> local destination -> back");
+        }
+        finally
+        {
+            destination.Stop();
+        }
+    }
+
+    private static async Task AnswerOneConnectionAsync(TcpListener destination)
+    {
+        try
+        {
+            using TcpClient client = await destination.AcceptTcpClientAsync();
+            NetworkStream stream = client.GetStream();
+
+            // Read the whole known payload, not whatever the first read returns — a split
+            // "remote-p"/"ing" would otherwise produce a truncated reply and a flaky assertion.
+            byte[] request = new byte[Encoding.ASCII.GetByteCount("remote-ping")];
+            int offset = 0;
+            while (offset < request.Length)
+            {
+                int read = await stream.ReadAsync(request.AsMemory(offset));
+                if (read == 0)
+                {
+                    break;
+                }
+
+                offset += read;
+            }
+
+            byte[] reply = Encoding.ASCII.GetBytes("reply:" + Encoding.ASCII.GetString(request, 0, offset));
+            await stream.WriteAsync(reply);
+            await stream.FlushAsync();
+            client.Client.Shutdown(SocketShutdown.Send);
+
+            // Give socat a moment to drain before the socket is torn down with the using.
+            await Task.Delay(TimeSpan.FromMilliseconds(250));
+        }
+        catch
+        {
+            // Failures surface as the missing reply in the terminal assertion; nothing useful to
+            // do with them here.
+        }
+    }
+}

--- a/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshSessionTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshSessionTests.cs
@@ -233,6 +233,73 @@ public sealed class NativeSshSessionTests
         Assert.Contains("PROMPT_COMMAND", interop.LastConnectOptions.BashCwdBootstrap, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task UnsolicitedIncomingForwardChannel_WithNoForwardsConfigured_IsClosedNotLeaked()
+    {
+        // A profile with no forwards has no NativePortForwardSession, so before this fix the
+        // announcement was silently dropped — the channel stayed registered and open on the
+        // native side, and a hostile server could grow that without bound. The event must be
+        // answered with a close, not ignored.
+        var interop = new FakeNativeSshInterop();
+        interop.Enqueue(NativeSshEvent.ForwardChannelIncoming(
+            41,
+            Encoding.UTF8.GetBytes("{\"connectedAddress\":\"localhost\",\"connectedPort\":18080,\"originatorAddress\":\"192.0.2.1\",\"originatorPort\":50000}")));
+
+        using var session = new NativeSshSession(CreateProfile(), interop: interop);
+
+        await WaitUntilAsync(() => interop.ClosedChannelIds.Contains(41));
+    }
+
+    [Fact]
+    public async Task RemoteForward_IsRequestedWhenTheConnectedEventArrives()
+    {
+        var interop = new FakeNativeSshInterop();
+        SshProfile profile = CreateProfile();
+        profile.Forwards.Add(new PortForward
+        {
+            Kind = PortForwardKind.Remote,
+            SourcePort = 18081,
+            DestinationHost = "127.0.0.1",
+            DestinationPort = 9000
+        });
+
+        using var session = new NativeSshSession(profile, interop: interop);
+
+        // Nothing to request until the session exists; the Connected event is what says it does.
+        await Task.Delay(100);
+        Assert.Empty(interop.RemoteForwardRequests);
+
+        interop.Enqueue(new NativeSshEvent(NativeSshEventKind.Connected, []));
+
+        await WaitUntilAsync(() => interop.RemoteForwardRequests.Count == 1);
+        Assert.Equal(("localhost", 18081), interop.RemoteForwardRequests[0]);
+    }
+
+    [Fact]
+    public async Task RemoteForward_ARefusedRequestWarnsInTheTerminal()
+    {
+        // ssh -R prints "Warning: remote port forwarding failed" into the session; the native
+        // backend keeps the session alive the same way, so the warning must be equally visible.
+        var interop = new FakeNativeSshInterop { RefuseRemoteForwards = true };
+        SshProfile profile = CreateProfile();
+        profile.Forwards.Add(new PortForward
+        {
+            Kind = PortForwardKind.Remote,
+            SourcePort = 18082,
+            DestinationHost = "127.0.0.1",
+            DestinationPort = 9001
+        });
+
+        var outputs = new ConcurrentQueue<string>();
+        using var session = new NativeSshSession(profile, interop: interop);
+        session.OnOutputReceived += outputs.Enqueue;
+
+        interop.Enqueue(new NativeSshEvent(NativeSshEventKind.Connected, []));
+
+        await WaitUntilAsync(() => string.Concat(outputs).Contains("localhost:18082", StringComparison.Ordinal));
+        Assert.Contains("Warning", string.Concat(outputs), StringComparison.Ordinal);
+    }
+
     private static SshProfile CreateProfile()
     {
         return new SshProfile
@@ -271,6 +338,15 @@ public sealed class NativeSshSessionTests
         public int CloseCallCount { get; private set; }
         public NativeSshConnectionOptions? LastConnectOptions { get; private set; }
         public Exception? ResizeException { get; set; }
+        public bool RefuseRemoteForwards { get; set; }
+
+        // Written from the poll loop / request task while tests poll them; ConcurrentQueue keeps
+        // the reads safe without a lock.
+        private readonly ConcurrentQueue<int> _closedChannelIds = new();
+        private readonly ConcurrentQueue<(string BindAddress, int Port)> _remoteForwardRequests = new();
+
+        public IReadOnlyList<int> ClosedChannelIds => _closedChannelIds.ToArray();
+        public IReadOnlyList<(string BindAddress, int Port)> RemoteForwardRequests => _remoteForwardRequests.ToArray();
 
         public NovaSshSafeHandle Connect(NativeSshConnectionOptions options)
         {
@@ -331,6 +407,18 @@ public sealed class NativeSshSessionTests
 
         public void CloseChannel(NovaSshSafeHandle sessionHandle, int channelId)
         {
+            _closedChannelIds.Enqueue(channelId);
+        }
+
+        public int RequestRemoteForward(NovaSshSafeHandle sessionHandle, string bindAddress, int port)
+        {
+            if (RefuseRemoteForwards)
+            {
+                throw new InvalidOperationException($"The server refused the remote forward on {bindAddress}:{port}.");
+            }
+
+            _remoteForwardRequests.Enqueue((bindAddress, port));
+            return port;
         }
 
         public void Close(NovaSshSafeHandle sessionHandle)

--- a/tests/NovaTerminal.Platform.Tests/Ssh/SshSessionFactoryTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/SshSessionFactoryTests.cs
@@ -76,8 +76,11 @@ public sealed class SshSessionFactoryTests
     }
 
     [Fact]
-    public void Create_ForNativeProfileWithRemoteForward_RefusesWithCapabilityReasonNotTheToggleMessage()
+    public void Create_ForNativeProfileWithRemoteForward_BuildsASession()
     {
+        // This exact shape used to be the capability gate's last refusal ("supports local and
+        // dynamic port forwards only"). Remote forwards are served natively now, so the factory
+        // must route the profile like any other native one.
         var profileId = Guid.Parse("3f1e1c02-9a4b-4c1d-8b5e-6d0a2f7c1b44");
         var store = new InMemorySshProfileStore(new SshProfile
         {
@@ -100,14 +103,10 @@ public sealed class SshSessionFactoryTests
         var logs = new List<string>();
 
         var factory = new SshSessionFactory(store, launcher: null, nativeInterop: new StubNativeSshInterop());
+        using ITerminalSession session = factory.Create(profileId, log: logs.Add);
 
-        NotSupportedException ex = Assert.Throws<NotSupportedException>(() => factory.Create(profileId, log: logs.Add));
-
-        // The two refusals must stay distinguishable: this profile is not fixable in settings, so it
-        // must not be reported as "native SSH is disabled globally".
-        Assert.Contains("remote forward", ex.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("disabled globally", ex.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains(logs, message => message.Contains("refused reason=RemotePortForward", StringComparison.Ordinal));
+        Assert.IsType<NativeSshSession>(session);
+        Assert.DoesNotContain(logs, message => message.Contains("refused", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]


### PR DESCRIPTION
## What this changes

The last shape `NativeSshCapability` refused. The native backend now requests a `tcpip-forward` listener on the server per remote-forward rule and serves the connections that arrive on it, so `-R`-style forwards work without the OpenSSH backend — and the capability gate refuses nothing.

Fixes no tracked issue; this completes the native-SSH gap plan (after #325, #328, #330, #331, #332).

Details:

- **rusty_ssh**: a `RequestRemoteForward` worker command awaits `session.tcpip_forward` and replies with the bound port through the existing reply pattern, exposed as `nova_ssh_request_remote_forward`. A server refusal maps to a new `NOVA_SSH_RESULT_REMOTE_FORWARD_FAILED` code — distinct from `CHANNEL_OPEN_FAILED` because nothing channel-shaped exists to retry. Incoming `forwarded-tcpip` channels land in a new `server_channel_open_forwarded_tcpip` handler on the **target session's handler only**; jump hops carry no channels map and close unsolicited opens outright. The channel-wiring body of `open_direct_tcpip_channel` is extracted as `register_forward_channel` — the machinery is direction-agnostic once the channel exists — with a `before_reader` hook that queues the `ForwardChannelIncoming` announcement after the map entry exists but before the reader task can deliver a byte, so data can neither race ahead of the announcement nor address an id the managed side cannot close.
- **Managed**: `NativePortForwardSession` requests listeners on a background task (the worker only answers once the session is established, and a refusal is loud but not fatal, matching `ssh -R`'s warning), registers incoming channel state synchronously on the poll loop — the ordered outbound queue holds any data while the local destination is being dialled — then connects and starts the same pumps, budgets, and backpressure the outgoing kinds use. A connection announcing a port no rule asked for is refused rather than dialled anywhere.
- **Capability**: `NativeSshCapability.Evaluate` now refuses nothing. The gate and all its call sites (editor at save time, factory and session at connect time) stay wired, so the next unsupported shape gets one refusal reaching all of them at once.

Explicitly NOT claimed by this PR: parity with OpenSSH for a default flip. The native backend still lacks ssh-agent auth (the connection editor's recommended method) and silently ignores `MuxOptions`/`ExtraSshArgs`; those are the remaining blockers for changing the default backend, discussed with the owner.

## Invariant and ownership

- **What invariant does this change affect?** No-silent-degradation, in both directions: a refused `tcpip-forward` request is logged loudly by name (session survives, like `ssh -R`), an unsolicited incoming channel is refused rather than dialled anywhere, and the announcement-before-first-byte ordering guarantees no forwarded bytes are dropped while the destination dial is in flight.
- **Which module owns that invariant?** NovaTerminal.Platform (`Ssh/Native`), with the FFI contract shared with `src/NovaTerminal.App/native/rusty_ssh`.

## Tests

- **What tests cover this change?**
  - Rust (`cargo test`, 91 passing locally): 3 new FFI-contract tests for `nova_ssh_request_remote_forward` — argument validation, the round trip through the worker command with the bound port, and the refusal mapping to its own result code.
  - `NativePortForwardSessionTests` (4 new): the listener request is made with OpenSSH's `-R` bind default; an incoming channel dials the destination and carries bytes both ways **including data queued behind the announcement before the dial completes** (the ordering the `before_reader` hook exists for); an incoming channel matching no rule is refused; an unreachable destination closes the channel.
  - Existing tests that pinned the remote-forward refusal flip to pinning acceptance (`NativeSshCapabilityTests`, `SshSessionFactoryTests`, `NewSshConnectionViewModelTests`).
  - **Docker E2E** (`NativeSshDockerRemoteForwardE2eTests`, runs in the blocking `Native SSH Docker E2E` job): socat inside the fixture container dials the remote listener the session requested; a local destination answers with a *transformed* reply, so the assertion cannot match the echo of the typed command — only bytes that actually crossed the tunnel both ways.

- **Which categories did you run locally?**
  - [ ] full unfiltered run (`scripts/build.sh test`)
  - [ ] `Category=Replay`
  - [ ] `Category=RenderMetrics`
  - [ ] `Category=PtySmoke`
  - [ ] `tests/NovaTerminal.App.Tests` (non-blocking in CI — check it yourself)
  - [ ] full local CI rehearsal (`ci/run.sh` / `ci/run.ps1`)

  Rust tests, clippy, and rustfmt ran locally (clippy/rustfmt byte-identical to main's baseline). The .NET categories did not: no .NET SDK is reachable from the authoring container (same as every PR on this branch); CI is the compile and the test run, and the Docker E2E job is the real exercise for the new tunnel path. `NovaTerminal.App.Tests` changes are the view-model test flips, which CI runs even though that job is non-blocking.

## Impact

- **Does this affect cross-platform behavior?** The tunnel logic is platform-neutral (managed + Rust, same code paths everywhere); Docker E2E exercises it on Linux, Rust FFI tests run on both CI OSes.
- **Does this change renderer metrics?** Not applicable — no renderer code touched.
- **Does this change VT coverage?** Not applicable — no VT sequences touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHPUK1JQgoV6t4RsSNeXKs

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHPUK1JQgoV6t4RsSNeXKs)_