### PR TITLE
feat(ssh): warn when a native profile carries mux options or extra SSH args

### DIFF
--- a/docs/SSH_ROADMAP.md
+++ b/docs/SSH_ROADMAP.md
@@ -50,6 +50,12 @@ The native SSH initiative is implemented behind conservative rollout controls.
 - `Native` is gated by `TerminalSettings.ExperimentalNativeSshEnabled`, toggleable in
   the app under Settings > SSH.
 - Native SSH does **not** silently fall back to OpenSSH on failure.
+- Settings the native backend cannot honor are warned about, not silently
+  dropped: a native profile with multiplexing (ControlMaster) options or extra
+  SSH arguments — both of which drive the OpenSSH client and have no native
+  equivalent — gets a notice in the profile editor and a warning line in the
+  terminal at connect time. The settings stay stored, so switching the profile
+  back to OpenSSH restores them intact.
 - Whether native *can* serve a given profile is answered in one place,
   `NativeSshCapability.Evaluate`. Its one refusal today is a remote forward with
   source port 0 (a server-allocated listen port, OpenSSH's `-R 0:`): the native

--- a/docs/native-ssh/Native_SSH_Test_Matrix.md
+++ b/docs/native-ssh/Native_SSH_Test_Matrix.md
@@ -79,6 +79,10 @@ Rows marked Automated run in the `Native SSH Docker E2E` CI job (Linux), which s
   forwarding rows above stayed "pending manual" while a Dockerized suite sat beside them.
 - Native SSH remains opt-in through `TerminalSettings.ExperimentalNativeSshEnabled`,
   toggleable in the app under Settings > SSH.
+- Multiplexing (ControlMaster) options and extra SSH arguments are OpenSSH-client
+  settings the native backend cannot honor. They are warned about in the profile
+  editor and in the terminal at connect time — never silently dropped — and stay
+  stored for a switch back to OpenSSH.
 - `OpenSsh` remains the default backend for new profiles.
 - Native backend refusal is explicit when the global experimental toggle is disabled.
 - `NativeSshCapability` has one refusal today: a remote forward with source port 0

--- a/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
+++ b/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
@@ -202,7 +202,15 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
     public bool EnableMux
     {
         get => _enableMux;
-        set => SetField(ref _enableMux, value);
+        set
+        {
+            if (SetField(ref _enableMux, value))
+            {
+                // BackendWarning names mux as OpenSSH-only on native profiles; toggling it must
+                // surface (or clear) that notice immediately, not at save.
+                OnPropertyChanged(nameof(BackendWarning));
+            }
+        }
     }
 
     public int ControlPersistSeconds
@@ -214,7 +222,14 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
     public string ExtraSshArgs
     {
         get => _extraSshArgs;
-        set => SetField(ref _extraSshArgs, value);
+        set
+        {
+            if (SetField(ref _extraSshArgs, value))
+            {
+                // Same as EnableMux: the native backend cannot pass CLI arguments to anything.
+                OnPropertyChanged(nameof(BackendWarning));
+            }
+        }
     }
 
     public bool ConnectAfterSave
@@ -259,9 +274,34 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
                 return capability.Explanation;
             }
 
-            return ExperimentalNativeSshEnabled
-                ? string.Empty
-                : "Native SSH is disabled globally. Turn it on under Settings > SSH, or switch this profile back to OpenSSH.";
+            // Warnings, not refusals, from here down: each of these is a valid profile that will
+            // connect. They compose — a disabled toggle and ignored settings are both worth
+            // knowing about — with the blocking one named first.
+            var warnings = new List<string>();
+            if (!ExperimentalNativeSshEnabled)
+            {
+                warnings.Add("Native SSH is disabled globally. Turn it on under Settings > SSH, or switch this profile back to OpenSSH.");
+            }
+
+            // Deliberately a warning rather than a save-time refusal: these settings stay stored
+            // so switching the profile back to OpenSSH restores them intact — but connecting
+            // natively must not look like they apply when they cannot.
+            bool ignoresMux = EnableMux;
+            bool ignoresExtraArgs = !string.IsNullOrWhiteSpace(ExtraSshArgs);
+            if (ignoresMux && ignoresExtraArgs)
+            {
+                warnings.Add("Multiplexing (ControlMaster) and extra SSH arguments drive the OpenSSH client; the native backend ignores both.");
+            }
+            else if (ignoresMux)
+            {
+                warnings.Add("Multiplexing (ControlMaster) is an OpenSSH client feature; the native backend ignores it.");
+            }
+            else if (ignoresExtraArgs)
+            {
+                warnings.Add("Extra SSH arguments drive the OpenSSH client; the native backend ignores them.");
+            }
+
+            return string.Join(" ", warnings);
         }
     }
 

--- a/src/NovaTerminal.Platform/Ssh/Sessions/NativeSshSession.cs
+++ b/src/NovaTerminal.Platform/Ssh/Sessions/NativeSshSession.cs
@@ -73,6 +73,8 @@ public sealed class NativeSshSession : ITerminalSession
         }
 
         _ = diagnosticsLevel;
+        // The parsed CLI arguments the factory passes derive from profile.ExtraSshArgs, which the
+        // warning below names in the terminal — discarded here, but never silently.
         _ = extraArgs;
         _cols = cols;
         _rows = rows;
@@ -84,6 +86,22 @@ public sealed class NativeSshSession : ITerminalSession
         _profileUser = profile.User;
         _profileHost = profile.Host;
         _allowVaultPasswordReuse = profile.Id != Guid.Empty;
+
+        // Settings this backend cannot honor are named in the terminal, not silently dropped —
+        // the no-silent-degradation contract. Both drive the OpenSSH client (a ControlMaster
+        // socket, CLI arguments) and have no native equivalent; they stay stored so switching
+        // the profile back to OpenSSH restores them. Emitted before the first output, and
+        // buffered for the first subscriber, so they are never scrolled away by the banner.
+        if (profile.MuxOptions?.Enabled == true)
+        {
+            EmitText("Warning: multiplexing (ControlMaster) is an OpenSSH client feature; the native backend ignores this profile's mux options.\r\n");
+        }
+
+        if (!string.IsNullOrWhiteSpace(profile.ExtraSshArgs))
+        {
+            EmitText("Warning: extra SSH arguments drive the OpenSSH client; the native backend ignores this profile's extra arguments.\r\n");
+        }
+
         JumpHostConnectPlan connectPlan = JumpHostConnectPlan.Create(profile);
         NativeSshConnectionOptions connectionOptions = CreateConnectionOptions(connectPlan, profile, cols, rows);
         _log($"[NativeSshSession] backend=native path={_jumpHostConnector.DescribePath(connectPlan)} target={connectionOptions.User}@{connectionOptions.Host}:{connectionOptions.Port}");

--- a/tests/NovaTerminal.App.Tests/Ssh/NewSshConnectionViewModelTests.cs
+++ b/tests/NovaTerminal.App.Tests/Ssh/NewSshConnectionViewModelTests.cs
@@ -401,6 +401,93 @@ public sealed class NewSshConnectionViewModelTests
     }
 
     [Fact]
+    public void BackendWarning_ForNativeProfileWithMux_NamesTheIgnoredSetting()
+    {
+        // Mux (ControlMaster) drives the OpenSSH client; the native backend has no equivalent.
+        // A warning, not a refusal: the setting stays stored so switching back to OpenSSH
+        // restores it — but the user must know it will not apply.
+        var vm = new NewSshConnectionViewModel
+        {
+            HostName = "native.internal",
+            BackendKind = SshBackendKind.Native,
+            ExperimentalNativeSshEnabled = true,
+            EnableMux = true
+        };
+
+        Assert.Contains("Multiplexing", vm.BackendWarning, StringComparison.Ordinal);
+        Assert.Contains("ignores", vm.BackendWarning, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BackendWarning_ForNativeProfileWithExtraArgs_NamesTheIgnoredSetting()
+    {
+        var vm = new NewSshConnectionViewModel
+        {
+            HostName = "native.internal",
+            BackendKind = SshBackendKind.Native,
+            ExperimentalNativeSshEnabled = true,
+            ExtraSshArgs = "-o Compression=yes"
+        };
+
+        Assert.Contains("Extra SSH arguments", vm.BackendWarning, StringComparison.Ordinal);
+        Assert.Contains("ignores", vm.BackendWarning, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BackendWarning_ComposesTheGlobalToggleAndIgnoredSettings()
+    {
+        // Both facts matter at once — the blocking one (toggle) first, the ignored settings
+        // still named rather than swallowed by it.
+        var vm = new NewSshConnectionViewModel
+        {
+            HostName = "native.internal",
+            BackendKind = SshBackendKind.Native,
+            ExperimentalNativeSshEnabled = false,
+            EnableMux = true,
+            ExtraSshArgs = "-vv"
+        };
+
+        Assert.Contains("disabled globally", vm.BackendWarning, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("ignores both", vm.BackendWarning, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BackendWarning_ForOpenSshProfileWithMuxAndExtraArgs_IsEmpty()
+    {
+        // The settings apply on OpenSSH; there is nothing to warn about.
+        var vm = new NewSshConnectionViewModel
+        {
+            HostName = "host.internal",
+            BackendKind = SshBackendKind.OpenSsh,
+            EnableMux = true,
+            ExtraSshArgs = "-4"
+        };
+
+        Assert.Equal(string.Empty, vm.BackendWarning);
+    }
+
+    [Fact]
+    public void BackendWarning_IsRaisedWhenMuxOrExtraArgsChange()
+    {
+        var vm = new NewSshConnectionViewModel
+        {
+            HostName = "native.internal",
+            BackendKind = SshBackendKind.Native,
+            ExperimentalNativeSshEnabled = true
+        };
+
+        var raised = new List<string>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName ?? string.Empty);
+
+        vm.EnableMux = true;
+        vm.ExtraSshArgs = "-o Compression=yes";
+
+        Assert.True(
+            raised.Count(name => name == nameof(NewSshConnectionViewModel.BackendWarning)) >= 2,
+            "Toggling mux and editing extra args must each re-evaluate the warning immediately, not at save.");
+    }
+
+    [Fact]
     public void BackendWarning_IsRaisedWhenForwardsChange()
     {
         // The collection hook must keep re-evaluating the warning even while every shape is

--- a/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshSessionTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/NativeSshSessionTests.cs
@@ -285,6 +285,47 @@ public sealed class NativeSshSessionTests
     }
 
     [Fact]
+    public void Connect_WithMuxEnabled_WarnsInTheTerminalThatNativeIgnoresIt()
+    {
+        // ControlMaster multiplexing drives the OpenSSH client; the native backend has no
+        // equivalent. The setting is ignored, but never silently — the no-silent-degradation
+        // contract — and the warning is buffered, so even a subscriber attaching later sees it.
+        SshProfile profile = CreateProfile();
+        profile.MuxOptions.Enabled = true;
+
+        var outputs = new List<string>();
+        using var session = new NativeSshSession(profile, interop: new FakeNativeSshInterop());
+        session.OnOutputReceived += outputs.Add;
+
+        Assert.Contains(outputs, text => text.Contains("multiplexing", StringComparison.OrdinalIgnoreCase)
+            && text.Contains("ignores", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Connect_WithExtraSshArgs_WarnsInTheTerminalThatNativeIgnoresThem()
+    {
+        SshProfile profile = CreateProfile();
+        profile.ExtraSshArgs = "-o Compression=yes";
+
+        var outputs = new List<string>();
+        using var session = new NativeSshSession(profile, interop: new FakeNativeSshInterop());
+        session.OnOutputReceived += outputs.Add;
+
+        Assert.Contains(outputs, text => text.Contains("extra SSH arguments", StringComparison.OrdinalIgnoreCase)
+            && text.Contains("ignores", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Connect_WithNeitherMuxNorExtraArgs_EmitsNoIgnoredSettingsWarning()
+    {
+        var outputs = new List<string>();
+        using var session = new NativeSshSession(CreateProfile(), interop: new FakeNativeSshInterop());
+        session.OnOutputReceived += outputs.Add;
+
+        Assert.DoesNotContain(outputs, text => text.Contains("ignores", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task UnsolicitedIncomingForwardChannel_WithNoForwardsConfigured_IsClosedNotLeaked()
     {
         // A profile with no forwards has no NativePortForwardSession, so before this fix the


### PR DESCRIPTION
## What this changes

Multiplexing (ControlMaster) options and extra SSH arguments drive the OpenSSH client — a control socket, CLI flags — and have no native equivalent, so the native backend has always ignored them. Silently, which is the one thing the backend promises not to do. This completes the honor-or-warn item from the default-flip blocker list (after #334's agent auth); the settings now warn on both surfaces:

- **Profile editor**: `BackendWarning` names the ignored settings for a native profile — "Multiplexing (ControlMaster) is an OpenSSH client feature; the native backend ignores it", the analogous message for extra arguments, and a combined wording when both are set. It composes with the existing global-toggle notice (the blocking one named first) and re-evaluates live as `EnableMux` and `ExtraSshArgs` change, not only at save. Deliberately a warning rather than a save refusal: the settings stay stored so switching the profile back to OpenSSH restores them intact.
- **Connect time**: `NativeSshSession` prints a warning line into the terminal for each ignored setting, emitted before the first output and buffered for the first subscriber, so it cannot be scrolled away or missed. The constructor's discarded `extraArgs` parameter is annotated to point at the warning — discarded, but never silently.

With this merged, the remaining blocker for flipping the default backend is soak time on the opt-in.

## Invariant and ownership

- **What invariant does this change affect?** No-silent-degradation, extended to configuration: a setting the native backend cannot honor is named where the user can see it (editor and terminal), instead of quietly not applying. No behavior of the settings themselves changes — they were ignored before and are ignored now; only the silence is removed.
- **Which module owns that invariant?** NovaTerminal.Platform (`Ssh/Sessions`) for the connect-time warning; the profile editor's warning lives with the existing `BackendWarning` in `NovaTerminal.App`.

## Tests

- **What tests cover this change?**
  - `NewSshConnectionViewModelTests` (5 new): the mux and extra-args notices are named for native profiles; the notice composes with the global-toggle warning; an OpenSSH profile with both settings warns about nothing; toggling `EnableMux` / editing `ExtraSshArgs` re-evaluates `BackendWarning` immediately.
  - `NativeSshSessionTests` (3 new): a native session with mux enabled (and separately, with extra args) carries the warning in its terminal output via the buffered replay; a session with neither emits no ignored-settings warning.

- **Which categories did you run locally?**
  - [ ] full unfiltered run (`scripts/build.sh test`)
  - [ ] `Category=Replay`
  - [ ] `Category=RenderMetrics`
  - [ ] `Category=PtySmoke`
  - [ ] `tests/NovaTerminal.App.Tests` (non-blocking in CI — check it yourself)
  - [ ] full local CI rehearsal (`ci/run.sh` / `ci/run.ps1`)

  No Rust code changes in this PR, so there was nothing to run locally: no .NET SDK is reachable from the authoring container (same as every PR on this branch), and CI is the compile and the test run. The `NovaTerminal.App.Tests` additions are the five editor-warning tests — CI runs them even though that job is non-blocking.

## Impact

- **Does this affect cross-platform behavior?** No — string composition in the editor and terminal output in the session, identical on every platform.
- **Does this change renderer metrics?** Not applicable — no renderer code touched.
- **Does this change VT coverage?** Not applicable — the warning lines are plain text with CRLF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHPUK1JQgoV6t4RsSNeXKs

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHPUK1JQgoV6t4RsSNeXKs)_