### PR TITLE
fix(command-assist): retire a history.json stranded beside a live history.jsonl

### DIFF
--- a/docs/command-assist/CommandAssist.md
+++ b/docs/command-assist/CommandAssist.md
@@ -171,6 +171,17 @@ suspected a secret in their history and pressed the only button offered still ha
 backup, under a confirmation prompt that said "this deletes every recorded command". `ClearAsync` now
 removes `history.jsonl`, `history.json` and `history.json.bak`; the confirmation copy says so.
 
+**And no `history.json` survives a load, migrated or not.** The migration guard used to skip the legacy
+file entirely once `history.jsonl` existed, so a `history.json` stranded beside a live log — what you get
+when the migration wrote the JSONL and then failed at the rename, or when a pre-V2 build ran again
+afterwards — stayed on disk for the life of the machine, retired by nothing but Clear history. That is
+the file that can hold a password verbatim, so `JsonlHistoryStore` now renames it to
+`history.json.bak` on the next load even when there is nothing to migrate it into. It is retired
+without being read back in: V1 ids carry into the JSONL unchanged, so replaying those records would
+overwrite live entries with their pre-patch selves and drop every exit code and typo flag collected
+since. Anyone who wants those commands back has the `.bak`; anyone who wants them gone has Clear
+history.
+
 If you ran a Nova build from before PR #286 (V2 Phase 1c, 2026-08-02), assume anything you typed at a
 hidden prompt in a `cmd.exe` or un-instrumented SSH pane may be in your history, and clear it. Builds
 from #286 onward cannot capture it: see the echo gate below.

--- a/src/NovaTerminal.CommandAssist/Storage/JsonlHistoryStore.cs
+++ b/src/NovaTerminal.CommandAssist/Storage/JsonlHistoryStore.cs
@@ -209,10 +209,11 @@ public sealed class JsonlHistoryStore : IHistoryStore
     /// and it has to be true.
     /// </para>
     /// <para>
-    /// Deleting the un-migrated <c>history.json</c> matters for a second reason: without it, a
-    /// <c>ClearAsync</c> that runs before the first read (which is a legal order - it does not load)
-    /// would leave the legacy file to be migrated in on the next launch, re-materialising everything
-    /// the user just cleared.
+    /// Deleting the un-migrated <c>history.json</c> is the other half. <c>ClearAsync</c> does not load,
+    /// so clearing before the first read is a legal order and leaves an empty <c>history.jsonl</c>
+    /// beside an untouched V1 file - which the next load would then retire to <c>.bak</c> rather than
+    /// delete (see <see cref="TryMigrateLegacyFileUnsafeAsync"/>), quietly preserving the very entries
+    /// the user asked to erase.
     /// </para>
     /// <para>
     /// Deletion failures are swallowed. A locked backup file must not turn "clear my history" into
@@ -459,15 +460,50 @@ public sealed class JsonlHistoryStore : IHistoryStore
     }
 
     /// <summary>
-    /// One-time conversion of the pre-JSONL <c>history.json</c>. The legacy file is renamed to
-    /// <c>.bak</c> rather than deleted: it is user data, and a bad conversion should be recoverable.
+    /// One-time conversion of the pre-JSONL <c>history.json</c>, returning whether this call is the
+    /// one that wrote the log. Either way the legacy file does not survive: it is renamed to
+    /// <c>.bak</c> rather than deleted, because it is user data and a bad conversion should be
+    /// recoverable.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>A legacy file stranded beside an existing <c>history.jsonl</c> is retired without being
+    /// read.</b> This used to be the guard's do-nothing case - <c>File.Exists(_filePath)</c> meant
+    /// "migration already happened, leave the disk alone" - which left the V1 file there for the rest
+    /// of the machine's life, retired by nothing but the user pressing Clear history. It is reachable:
+    /// a migration whose <c>WriteAll</c> succeeded and whose rename failed lands exactly here, as does
+    /// a pre-V2 build run again afterwards. And it is the file that can hold a password verbatim (see
+    /// the remarks on <see cref="ClearAsync"/>), so the invariant has to be "no <c>history.json</c>
+    /// survives a load", not "no <c>history.json</c> survives a migration".
+    /// </para>
+    /// <para>
+    /// <b>Retired, not imported.</b> V1 ids carry into the JSONL unchanged, so replaying those records
+    /// over a live log would overwrite entries with their pre-patch selves and drop the exit codes and
+    /// typo flags collected since - and in the case that gets here, the log was written from this very
+    /// file already. The recoverable copy is the answer for the remainder: an operator who wants those
+    /// commands back has <c>history.json.bak</c>.
+    /// </para>
+    /// </remarks>
     private async Task<bool> TryMigrateLegacyFileUnsafeAsync(CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(_legacyFilePath) ||
-            File.Exists(_filePath) ||
-            !File.Exists(_legacyFilePath))
+        if (string.IsNullOrWhiteSpace(_legacyFilePath) || !File.Exists(_legacyFilePath))
         {
+            return false;
+        }
+
+        if (File.Exists(_filePath))
+        {
+            try
+            {
+                RetireLegacyFileUnsafe();
+            }
+            catch
+            {
+                // Housekeeping, not a read. A rename that cannot happen - a legacy file held open by
+                // something else, a read-only volume - must not turn every history read into an error.
+                // The next launch retries it.
+            }
+
             return false;
         }
 
@@ -496,19 +532,28 @@ public sealed class JsonlHistoryStore : IHistoryStore
                     .Reverse(),
                 cancellationToken);
 
-            string backupPath = _legacyFilePath + ".bak";
-            if (File.Exists(backupPath))
-            {
-                File.Delete(backupPath);
-            }
-
-            File.Move(_legacyFilePath, backupPath);
+            RetireLegacyFileUnsafe();
             return true;
         }
         catch
         {
             return false;
         }
+    }
+
+    /// <summary>
+    /// Renames the pre-JSONL <c>history.json</c> to <c>history.json.bak</c>, replacing any earlier
+    /// backup.
+    /// </summary>
+    private void RetireLegacyFileUnsafe()
+    {
+        string backupPath = _legacyFilePath + ".bak";
+        if (File.Exists(backupPath))
+        {
+            File.Delete(backupPath);
+        }
+
+        File.Move(_legacyFilePath!, backupPath);
     }
 
     /// <summary>

--- a/src/NovaTerminal.CommandAssist/Storage/JsonlHistoryStore.cs
+++ b/src/NovaTerminal.CommandAssist/Storage/JsonlHistoryStore.cs
@@ -495,7 +495,7 @@ public sealed class JsonlHistoryStore : IHistoryStore
         {
             try
             {
-                RetireLegacyFileUnsafe();
+                RetireLegacyFileUnsafe(_legacyFilePath);
             }
             catch
             {
@@ -532,7 +532,7 @@ public sealed class JsonlHistoryStore : IHistoryStore
                     .Reverse(),
                 cancellationToken);
 
-            RetireLegacyFileUnsafe();
+            RetireLegacyFileUnsafe(_legacyFilePath);
             return true;
         }
         catch
@@ -545,15 +545,20 @@ public sealed class JsonlHistoryStore : IHistoryStore
     /// Renames the pre-JSONL <c>history.json</c> to <c>history.json.bak</c>, replacing any earlier
     /// backup.
     /// </summary>
-    private void RetireLegacyFileUnsafe()
+    /// <remarks>
+    /// Takes the path rather than reading <see cref="_legacyFilePath"/>, so that "there is a legacy
+    /// path" is a precondition the signature states and the callers' own null check discharges -
+    /// rather than an assertion this method makes about a field it cannot see checked.
+    /// </remarks>
+    private static void RetireLegacyFileUnsafe(string legacyFilePath)
     {
-        string backupPath = _legacyFilePath + ".bak";
+        string backupPath = legacyFilePath + ".bak";
         if (File.Exists(backupPath))
         {
             File.Delete(backupPath);
         }
 
-        File.Move(_legacyFilePath!, backupPath);
+        File.Move(legacyFilePath, backupPath);
     }
 
     /// <summary>

--- a/tests/NovaTerminal.App.Tests/CommandAssist/JsonlHistoryStoreTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/JsonlHistoryStoreTests.cs
@@ -233,8 +233,9 @@ public sealed class JsonlHistoryStoreTests : IDisposable
     /// </summary>
     /// <remarks>
     /// Reachable because <c>ClearAsync</c> does not load: clearing before anything has read the store
-    /// writes an empty <c>history.jsonl</c>, which then permanently suppresses the migration guard -
-    /// so without this the entries would survive both the clear and every later read, invisible.
+    /// writes an empty <c>history.jsonl</c> beside an untouched V1 file, and the next load retires that
+    /// file to <c>.bak</c> rather than deleting it - so without this the entries the user asked to erase
+    /// would sit there through the clear and every later read, invisible.
     /// </remarks>
     [Fact]
     public async Task ClearAsync_BeforeAnyRead_AlsoDeletesTheUnmigratedLegacyFile()
@@ -465,17 +466,92 @@ public sealed class JsonlHistoryStoreTests : IDisposable
         Assert.Equal("command-9", entries[0].CommandText);
     }
 
+    /// <summary>
+    /// A <c>history.json</c> stranded beside a live <c>history.jsonl</c> is retired to <c>.bak</c> on
+    /// the next load, and its records are not replayed into the log.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The migration guard used to skip the legacy file outright once <c>history.jsonl</c> existed, so
+    /// this pairing - reachable when the migration wrote the JSONL and then failed at the rename, or
+    /// when a pre-V2 build ran again afterwards - left the V1 file sitting there for good, retired by
+    /// nothing except the user pressing Clear history. That is the file that can hold a password
+    /// verbatim (see the remarks on <c>ClearAsync</c>), so "the V1 file does not survive a load" has to
+    /// hold whether or not there was anywhere to migrate it into.
+    /// </para>
+    /// <para>
+    /// Retired, not imported: V1 ids carry into the JSONL unchanged, so replaying those records would
+    /// overwrite live entries with their pre-patch selves and drop every exit code and typo flag
+    /// collected since.
+    /// </para>
+    /// </remarks>
     [Fact]
-    public async Task Load_WhenJsonlAlreadyExists_LeavesLegacyFileAlone()
+    public async Task Load_WhenJsonlAlreadyExists_RetiresTheStrandedLegacyFileWithoutImportingIt()
     {
-        await File.WriteAllTextAsync(_legacyPath, "[]");
+        await File.WriteAllTextAsync(
+            _legacyPath,
+            JsonSerializer.Serialize(
+                new List<CommandHistoryEntry> { CreateEntry("hunter2") },
+                CommandAssistJsonContext.Default.ListCommandHistoryEntry));
         await File.WriteAllLinesAsync(_historyPath, new[] { Serialize(CreateEntry("git status")) });
 
         IReadOnlyList<CommandHistoryEntry> entries = await CreateStore().GetRecentAsync(10);
 
-        Assert.Single(entries);
+        Assert.Equal("git status", Assert.Single(entries).CommandText);
+        Assert.False(File.Exists(_legacyPath));
+        Assert.True(File.Exists(_legacyPath + ".bak"));
+    }
+
+    /// <summary>
+    /// The stranded case can arrive with a <c>.bak</c> already on disk - a migration that succeeded,
+    /// then a pre-V2 build that wrote <c>history.json</c> again - and it is the newer file that has to
+    /// end up retired.
+    /// </summary>
+    [Fact]
+    public async Task Load_WhenAStrandedLegacyFileAndAnOlderBackupBothExist_RetiresTheStrandedOne()
+    {
+        await File.WriteAllTextAsync(_legacyPath + ".bak", "[]");
+        await File.WriteAllTextAsync(
+            _legacyPath,
+            JsonSerializer.Serialize(
+                new List<CommandHistoryEntry> { CreateEntry("hunter2") },
+                CommandAssistJsonContext.Default.ListCommandHistoryEntry));
+        await File.WriteAllLinesAsync(_historyPath, new[] { Serialize(CreateEntry("git status")) });
+
+        Assert.Equal("git status", Assert.Single(await CreateStore().GetRecentAsync(10)).CommandText);
+
+        Assert.False(File.Exists(_legacyPath));
+        Assert.Contains("hunter2", await File.ReadAllTextAsync(_legacyPath + ".bak"), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Retiring the stranded legacy file is housekeeping, so a rename that cannot happen - a legacy
+    /// file held open by a backup agent, a read-only volume - costs the rename and nothing else. The
+    /// next launch retries it.
+    /// </summary>
+    /// <remarks>
+    /// The failure is provoked with a directory parked on the backup path rather than an open handle,
+    /// because that fails the same way on every platform: POSIX <c>rename</c> ignores the advisory lock
+    /// that <c>FileShare.None</c> takes, so the Windows-only trick would quietly succeed on the Linux
+    /// leg of the matrix and assert nothing.
+    /// </remarks>
+    [Fact]
+    public async Task Load_WhenTheStrandedLegacyFileCannotBeRetired_StillReturnsHistory()
+    {
+        await File.WriteAllTextAsync(_legacyPath, "[]");
+        await File.WriteAllLinesAsync(_historyPath, new[] { Serialize(CreateEntry("git status")) });
+
+        string blocked = _legacyPath + ".bak";
+        Directory.CreateDirectory(blocked);
+        await File.WriteAllTextAsync(Path.Combine(blocked, "in-the-way.txt"), "x");
+
+        Assert.Equal("git status", Assert.Single(await CreateStore().GetRecentAsync(10)).CommandText);
         Assert.True(File.Exists(_legacyPath));
-        Assert.False(File.Exists(_legacyPath + ".bak"));
+
+        Directory.Delete(blocked, recursive: true);
+
+        Assert.Equal("git status", Assert.Single(await CreateStore().GetRecentAsync(10)).CommandText);
+        Assert.False(File.Exists(_legacyPath));
     }
 
     [Fact]


### PR DESCRIPTION
## The bug

`JsonlHistoryStore.TryMigrateLegacyFileUnsafeAsync` treated `File.Exists(_filePath)` as *"migration already happened, leave the disk alone"*. So a pre-V2 `history.json` sitting next to a live `history.jsonl` was never migrated, never renamed to `.bak`, and never deleted — except by the user pressing **Clear history**.

Observed live, not theoretical: a 3.7KB `history.json` in `%LOCALAPPDATA%\NovaTerminal\command-assist` alongside an active log.

The pairing is reachable two ways: a migration whose `WriteAll` succeeded and whose rename then failed lands exactly there, as does a pre-V2 build run again afterwards.

It matters because that is the file that can hold a password **verbatim**. V1's Enter-time capture read a keystroke mirror with no echo check, so a secret typed at a non-echoing prompt in a markless session went into `history.json` unfiltered — `SecretsFilter` matches nothing on a bare word. Leaving it there indefinitely is precisely the exposure the migration's rename-to-`.bak` design exists to bound, so the invariant has to be **"no `history.json` survives a load"**, not "no `history.json` survives a migration".

## The fix

The stranded file is renamed to `history.json.bak` on the next load.

**Renamed, not deleted** — matching the migration path's own rule. It is user data, and `ClearAsync` already deletes both `history.json` and `history.json.bak`, so this puts the file under the one control whose confirmation prompt promises to erase every recorded command. Being straight about the limit: this does not shrink the secret's footprint by itself, it moves the stranded file onto the path Clear history sweeps and stops it being invisible dead weight.

**Retired without being read back in.** V1 ids carry into the JSONL unchanged, so replaying those records over a live log would overwrite entries with their pre-patch selves and drop every exit code and typo flag collected since — and in the case that gets here, the log was written from that very file already. Anyone who wants those commands back has the `.bak`.

The rename is wrapped: housekeeping that cannot happen (a legacy file held open by a backup agent, a read-only volume) must not turn every history read into an error, and the next launch retries it.

`RetireLegacyFileUnsafe` now holds the rename/replace-old-backup logic, shared with the migration path. Also corrects a now-stale paragraph in the `ClearAsync` remarks: it said a surviving `history.json` would be *migrated back in* on the next launch — with this change it would be retired to `.bak` instead, still preserving what the user asked to erase, which is why `ClearAsync` deletes it.

## Tests

Written first, each watched failing for the right reason.

- `Load_WhenJsonlAlreadyExists_LeavesLegacyFileAlone` asserted the old behaviour as intent (`Assert.True(File.Exists(_legacyPath))`) and is **replaced** by `Load_WhenJsonlAlreadyExists_RetiresTheStrandedLegacyFileWithoutImportingIt`, which also pins that the legacy entry does not enter the log.
- `Load_WhenAStrandedLegacyFileAndAnOlderBackupBothExist_RetiresTheStrandedOne` — the plausible "migration succeeded, then a pre-V2 build wrote `history.json` again" state. This one passed on arrival, so I proved it can fail by temporarily removing the stale-backup delete and watching the stranded file survive.
- `Load_WhenTheStrandedLegacyFileCannotBeRetired_StillReturnsHistory` — failed with `IOException` out of `GetRecentAsync` before the guard existed.

One thing worth a reviewer's attention: that last test deliberately does **not** use the `FileShare.None` trick used elsewhere in the file. App.Tests runs on `ubuntu-latest` as well as `windows-latest`, and POSIX `rename` ignores the advisory lock `FileShare.None` takes — so the Windows-only provocation would have quietly succeeded on the Linux leg and asserted nothing. A non-empty directory parked on the backup path fails identically on both.

## Verification

```
scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~CommandAssist"
Passed! - Failed: 0, Passed: 1227, Skipped: 13, Total: 1240
```

Run against the restored, non-mutated code. The Pane suites were skipped as provably unreachable: `TestCommandAssistServices` constructs the store with `legacyHistoryFilePath: null`, so those tests return at the first guard.

## Upgrade note for anyone with a stranded file

Next launch renames it to `history.json.bak`. If you want it gone rather than renamed, **Settings → Terminal → Clear history** deletes all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
