### PR TITLE
feat(ssh): default new profiles to the native backend

### DIFF
--- a/docs/SSH_ROADMAP.md
+++ b/docs/SSH_ROADMAP.md
@@ -4,10 +4,10 @@ _Last reviewed: 2026-04-27._
 
 NovaTerminal supports two SSH backends:
 
-- **OpenSSH** (default, production) — drives `ssh` in a PTY with a
+- **OpenSSH** (production) — drives `ssh` in a PTY with a
   NovaTerminal-generated config file.
-- **Native SSH** (experimental, opt-in) — an in-process Rust SSH crate with a
-  poll-based ABI, bypassing external `ssh` entirely.
+- **Native SSH** (default for new profiles) — an in-process Rust SSH crate with
+  a poll-based ABI, bypassing external `ssh` entirely.
 
 ---
 
@@ -46,9 +46,14 @@ The native SSH initiative is implemented behind conservative rollout controls.
 
 ### Rollout guidance
 
-- `OpenSsh` remains the default backend.
-- `Native` is gated by `TerminalSettings.ExperimentalNativeSshEnabled`, toggleable in
-  the app under Settings > SSH.
+- `Native` is the default backend for NEW profiles, wherever the global native
+  toggle (`TerminalSettings.ExperimentalNativeSshEnabled`, on by default,
+  Settings > SSH) is enabled; with the toggle off, new profiles default to
+  `OpenSsh`, so the default can never point at a backend that refuses to
+  connect. Existing profiles keep their stored backend, and the model-level
+  defaults stay `OpenSsh` on purpose: a profile store whose JSON predates the
+  backend field must load as the backend it was actually using, never silently
+  migrate.
 - Native SSH does **not** silently fall back to OpenSSH on failure.
 - Settings the native backend cannot honor are warned about, not silently
   dropped: a native profile with multiplexing (ControlMaster) options or extra

--- a/docs/native-ssh/Native_SSH_Test_Matrix.md
+++ b/docs/native-ssh/Native_SSH_Test_Matrix.md
@@ -77,13 +77,18 @@ Rows marked Automated run in the `Native SSH Docker E2E` CI job (Linux), which s
   Before that job existed the suite was `[DockerFact]`-gated on `NOVATERM_ENABLE_DOCKER_E2E`
   and nothing in CI set it, so it was written and then never executed — the reason auth and
   forwarding rows above stayed "pending manual" while a Dockerized suite sat beside them.
-- Native SSH remains opt-in through `TerminalSettings.ExperimentalNativeSshEnabled`,
-  toggleable in the app under Settings > SSH.
+- Native SSH is enabled by default (`TerminalSettings.ExperimentalNativeSshEnabled`,
+  toggleable in the app under Settings > SSH), and new profiles default to the
+  Native backend while the toggle is on. Existing profiles keep their stored
+  backend; model-level defaults stay `OpenSsh` so old stores never migrate
+  silently.
 - Multiplexing (ControlMaster) options and extra SSH arguments are OpenSSH-client
   settings the native backend cannot honor. They are warned about in the profile
   editor and in the terminal at connect time — never silently dropped — and stay
   stored for a switch back to OpenSSH.
-- `OpenSsh` remains the default backend for new profiles.
+- `Native` is the default backend for new profiles while the global toggle is on
+  (see above); `OpenSsh` remains available per profile and stays the default
+  wherever the toggle is off.
 - Native backend refusal is explicit when the global experimental toggle is disabled.
 - `NativeSshCapability` has one refusal today: a remote forward with source port 0
   (a server-allocated listen port), which the backend cannot yet match back to a

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -5308,7 +5308,14 @@ namespace NovaTerminal
         private async Task ShowNewSshConnectionDialogAsync(TerminalProfile? existingProfile)
         {
             var vm = _sshConnectionService.CreateEditorViewModel(existingProfile);
-            vm.BackendKind ??= NovaTerminal.Platform.Ssh.Models.SshBackendKind.OpenSsh;
+            // The default backend for a NEW profile follows the global toggle: native where it is
+            // enabled, OpenSSH where it is not — so the default can never point at a backend that
+            // would refuse to connect. Existing profiles arrive with their stored kind and are
+            // never re-defaulted. Model-level defaults stay OpenSsh on purpose (old stores whose
+            // JSON predates the field must not silently migrate); this is the creation surface.
+            vm.BackendKind ??= _settings.ExperimentalNativeSshEnabled
+                ? NovaTerminal.Platform.Ssh.Models.SshBackendKind.Native
+                : NovaTerminal.Platform.Ssh.Models.SshBackendKind.OpenSsh;
             vm.ExperimentalNativeSshEnabled = _settings.ExperimentalNativeSshEnabled;
             var dialog = new NewSshConnectionView(vm);
             ApplyThemeToDialogWindow(dialog);

--- a/src/NovaTerminal.App/SettingsWindow.axaml
+++ b/src/NovaTerminal.App/SettingsWindow.axaml
@@ -969,8 +969,8 @@
 
                             <Grid ColumnDefinitions="*,360">
                                 <StackPanel Grid.Column="0" Spacing="2">
-                                    <TextBlock Classes="RowLabel" Text="Native SSH backend (experimental)"/>
-                                    <TextBlock Classes="RowDesc" Text="Allow profiles set to the Native backend to connect with NovaTerminal's built-in SSH client instead of the system ssh. Applies to new connections only; sessions already open are unaffected. While this is off, a profile explicitly set to Native refuses to connect rather than silently falling back — OpenSSH profiles are unaffected either way."/>
+                                    <TextBlock Classes="RowLabel" Text="Native SSH backend"/>
+                                    <TextBlock Classes="RowDesc" Text="Allow profiles set to the Native backend to connect with NovaTerminal's built-in SSH client instead of the system ssh. On by default; while it is on, new SSH profiles default to the Native backend (existing profiles keep their backend). Applies to new connections only; sessions already open are unaffected. While this is off, a profile explicitly set to Native refuses to connect rather than silently falling back — OpenSSH profiles are unaffected either way."/>
                                 </StackPanel>
                                 <CheckBox Name="NativeSshToggle" Grid.Column="1" Classes="Toggle" Content="" HorizontalAlignment="Right" VerticalAlignment="Center"/>
                             </Grid>

--- a/src/NovaTerminal.App/Shell/TerminalSettings.cs
+++ b/src/NovaTerminal.App/Shell/TerminalSettings.cs
@@ -93,7 +93,11 @@ namespace NovaTerminal.Shell
         public bool CommandAssistPassiveBubbleEnabled { get; set; } = true;
         public bool CommandAssistShellIntegrationEnabled { get; set; } = true;
         public bool CommandAssistPowerShellIntegrationEnabled { get; set; } = true;
-        public bool ExperimentalNativeSshEnabled { get; set; } = false;
+        // On by default since the native backend reached parity (agent auth, jump chains, all
+        // three forward kinds, SFTP) and every gap warns instead of degrading silently. Users
+        // whose settings.json already stores an explicit false keep it — this default only
+        // reaches fresh installs and settings files predating the field.
+        public bool ExperimentalNativeSshEnabled { get; set; } = true;
         // Agent-host observe surface (docs/agent-host/DIRECTION.md, milestone A1).
         // Off by default: when false, no local IPC endpoint exists at all and AI
         // agents cannot read any terminal session. Observe-only in v1 — there is

--- a/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
+++ b/src/NovaTerminal.App/ViewModels/Ssh/NewSshConnectionViewModel.cs
@@ -388,7 +388,10 @@ public sealed class NewSshConnectionViewModel : INotifyPropertyChanged
         return new SshProfile
         {
             Id = id,
-            BackendKind = BackendKind ?? SshBackendKind.OpenSsh,
+            // Unset means "the caller never primed a backend" (the dialog primes it from the
+            // global toggle before showing). The fallback follows the same rule, so a VM used
+            // without the priming can never default to a backend the toggle would refuse.
+            BackendKind = BackendKind ?? (ExperimentalNativeSshEnabled ? SshBackendKind.Native : SshBackendKind.OpenSsh),
             Name = name,
             GroupPath = NormalizeGroup(Group),
             Notes = Notes?.Trim() ?? string.Empty,

--- a/src/NovaTerminal.McpServer/Tools/SettingsTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/SettingsTools.cs
@@ -55,7 +55,7 @@ public static class SettingsTools
         | `ShellExitPolicy` | string (enum-like) | "Never"/"Graceful"/"Always". Default "Graceful". What happens to a pane when its shell exits: keep it with a banner, close it on a clean exit, or always close it. "Graceful" closes the pane on exit code 0 only, so closing the last pane of the last tab quits the app the way `exit` does in any terminal. SSH panes ignore this and always keep their reconnect banner. Type-checked only; unrecognised values behave as "Never" (a typo must not be more destructive than the default). |
         | `QuakeModeEnabled` | bool | Default true. |
         | `GlobalHotkey` | string | Default "Alt+OemTilde". |
-        | `ExperimentalNativeSshEnabled` | bool | Default false. |
+        | `ExperimentalNativeSshEnabled` | bool | Default true. |
         | `AgentAccessObserveEnabled` | bool | Default false. Enables the local agent-host observe endpoint (read-only session access for AI agents). |
         | `AgentReplayExportEnabled` | bool | Default false. Sub-gate on top of the observe toggle: allows agents to export a session's recent output as a replay file (output + resizes only, never input). |
         | `AgentScreenshotEnabled` | bool | Default false. Sub-gate on top of the observe toggle: allows agents to render a session to a PNG image (novaterminal.capture_screen). |

--- a/tests/NovaTerminal.App.Tests/Core/TerminalSettingsDefaultsTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/TerminalSettingsDefaultsTests.cs
@@ -1,0 +1,15 @@
+using NovaTerminal.Shell;
+
+namespace NovaTerminal.Tests.Core;
+
+public sealed class TerminalSettingsDefaultsTests
+{
+    [Fact]
+    public void ExperimentalNativeSshEnabled_DefaultsOn()
+    {
+        // The default-flip contract: fresh installs (and settings files predating the field) get
+        // the native backend enabled, which is what lets new profiles default to it. A stored
+        // explicit false still wins at load time — this only pins the constructed default.
+        Assert.True(new TerminalSettings().ExperimentalNativeSshEnabled);
+    }
+}

--- a/tests/NovaTerminal.App.Tests/Ssh/NewSshConnectionViewModelTests.cs
+++ b/tests/NovaTerminal.App.Tests/Ssh/NewSshConnectionViewModelTests.cs
@@ -401,6 +401,43 @@ public sealed class NewSshConnectionViewModelTests
     }
 
     [Fact]
+    public void ToSshProfile_WithNoBackendPrimed_FollowsTheGlobalToggle()
+    {
+        // The default backend for a new profile tracks the native toggle: Native where native is
+        // enabled, OpenSSH where it is not — a default must never point at a backend that would
+        // refuse to connect. (The dialog primes BackendKind the same way before showing; this
+        // fallback is for any caller that skips the priming.)
+        var enabled = new NewSshConnectionViewModel
+        {
+            HostName = "flip.internal",
+            ExperimentalNativeSshEnabled = true
+        };
+        var disabled = new NewSshConnectionViewModel
+        {
+            HostName = "flip.internal",
+            ExperimentalNativeSshEnabled = false
+        };
+
+        Assert.Equal(SshBackendKind.Native, enabled.ToSshProfile().BackendKind);
+        Assert.Equal(SshBackendKind.OpenSsh, disabled.ToSshProfile().BackendKind);
+    }
+
+    [Fact]
+    public void ToSshProfile_KeepsAnExplicitBackendChoiceOverTheDefault()
+    {
+        // Only the unset case is defaulted. A profile explicitly on OpenSSH stays there no matter
+        // what the toggle says — existing profiles are never re-defaulted.
+        var vm = new NewSshConnectionViewModel
+        {
+            HostName = "explicit.internal",
+            ExperimentalNativeSshEnabled = true,
+            BackendKind = SshBackendKind.OpenSsh
+        };
+
+        Assert.Equal(SshBackendKind.OpenSsh, vm.ToSshProfile().BackendKind);
+    }
+
+    [Fact]
     public void BackendWarning_ForNativeProfileWithMux_NamesTheIgnoredSetting()
     {
         // Mux (ControlMaster) drives the OpenSSH client; the native backend has no equivalent.

--- a/tests/NovaTerminal.Platform.Tests/Ssh/JsonSshProfileStoreTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/JsonSshProfileStoreTests.cs
@@ -8,6 +8,11 @@ public sealed class JsonSshProfileStoreTests
     [Fact]
     public void SshProfile_DefaultsBackendKindToOpenSsh()
     {
+        // Deliberately unchanged by the default-backend flip: this model default is what a
+        // deserialized profile gets when its JSON predates the BackendKind field, so it must
+        // stay OpenSsh — an old store's profiles were connecting via OpenSSH and must not
+        // silently migrate. The Native default for NEW profiles lives at the creation surface
+        // (the editor dialog and its ToSshProfile fallback), not here.
         var profile = new SshProfile
         {
             Name = "default-backend",


### PR DESCRIPTION
## What this changes

The flip. The native backend reached functional parity — agent auth (#334), jump chains of any length (#330), local/dynamic/remote forwards (#325/#333), SFTP and remote browsing, host keys, keepalives — and every remaining gap warns instead of degrading silently (#335). This makes it the default at the **creation surfaces**, and only there:

- **`TerminalSettings.ExperimentalNativeSshEnabled` defaults on.** A settings.json that stores an explicit `false` keeps it at load; the new default reaches fresh installs and settings files predating the field. The Settings > SSH toggle and its copy are updated (the "(experimental)" label is dropped; the off-behavior sentence — explicit Native profiles refuse rather than silently fall back — is unchanged and still true).
- **A NEW profile's backend follows the global toggle**: `Native` where native is enabled, `OpenSsh` where it is not — so the default can never point at a backend that would refuse to connect. Primed in the connection dialog before it shows (the backend combo displays the default), mirrored in `ToSshProfile`'s fallback for unprimed callers.

**Deliberately NOT flipped:** the `SshProfile` and `TerminalProfile` model-level defaults stay `OpenSsh`. Those defaults are what a deserialized profile receives when its JSON predates the backend field — an old store's profiles were connecting via OpenSSH and must not silently migrate. This is also why the flip is not a blanket "model default = Native": existing profiles keep their stored backend everywhere, the per-profile selector and the global toggle remain the rollback paths, and native still never falls back to OpenSSH silently. (This also sidesteps the `Auto` trap documented in `docs/SSH_ROADMAP.md` — new profiles persist `Native` explicitly, so the persisted-kind call sites stay correct.)

## Invariant and ownership

- **What invariant does this change affect?** No-silent-anything, in both directions: no profile silently *migrates* backend (model defaults untouched; only unset new-profile choices are defaulted), and the defaulted backend can never dead-end (it tracks the toggle). The existing refusal behavior for explicit-Native-with-toggle-off is unchanged.
- **Which module owns that invariant?** The creation surfaces in `NovaTerminal.App` (dialog priming, editor fallback, settings default); the deserialization-safety half lives with the model defaults in `NovaTerminal.Platform` (`SshProfile`) and `NovaTerminal.App` (`TerminalProfile`), which this PR pins with a comment and test rather than changes.

## Tests

- **What tests cover this change?**
  - `TerminalSettingsDefaultsTests` (new): the constructed default of `ExperimentalNativeSshEnabled` is true.
  - `NewSshConnectionViewModelTests` (2 new): an unprimed profile defaults to `Native` with the toggle on and `OpenSsh` with it off; an explicit `OpenSsh` choice survives regardless of the toggle.
  - `JsonSshProfileStoreTests.SshProfile_DefaultsBackendKindToOpenSsh` (kept, comment strengthened): the model default that guards old stores is pinned as deliberately unchanged.

- **Which categories did you run locally?**
  - [ ] full unfiltered run (`scripts/build.sh test`)
  - [ ] `Category=Replay`
  - [ ] `Category=RenderMetrics`
  - [ ] `Category=PtySmoke`
  - [ ] `tests/NovaTerminal.App.Tests` (non-blocking in CI — check it yourself)
  - [ ] full local CI rehearsal (`ci/run.sh` / `ci/run.ps1`)

  C#-only change; no .NET SDK is reachable from the authoring container (same as every PR on this branch), so CI is the compile and the test run. **This PR is intentionally awaiting manual dogfooding before merge** — the owner is testing the native backend against real hosts first; CI green is necessary but not sufficient here.

## Impact

- **Does this affect cross-platform behavior?** The default logic is platform-neutral. What changes per platform is which backend new profiles exercise by default — the native backend's per-platform surface (agent discovery, PTY behavior) is covered by its own suites, with the known gap that macOS and Windows native paths have less automated coverage than Linux (see the test matrix).
- **Does this change renderer metrics?** Not applicable — no renderer code touched.
- **Does this change VT coverage?** Not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHPUK1JQgoV6t4RsSNeXKs

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHPUK1JQgoV6t4RsSNeXKs)_