### PR TITLE
fix(ci): clear the standing ubuntu App.Tests failures and the AOT publish break

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1006,8 +1006,19 @@ jobs:
       - name: Restore
         run: dotnet restore
 
+      # -p:SkipCliShim=true matches release.yml's Publish AOT step, and is required rather than
+      # tidy. BuildCliShim invokes NovaTerminal.Cli out of band with -p:BuildProjectReferences=false
+      # (that is what breaks the cycle - this project's build is what places the CLI beside it), and
+      # the nested invocation carries no RuntimeIdentifier, so it looks for this project's reference
+      # assembly at the RID-less obj/Release/net10.0/ref/. A self-contained RID publish writes its
+      # intermediates under a win-x64/linux-x64/osx-arm64 subdirectory, so on a clean checkout that
+      # path never exists and the nested build dies on a bare CS0006 naming it. Passing the RID down
+      # does not help: the CLI references this project as an executable and then wants its apphost,
+      # which a self-contained build never writes to obj. The shim is a framework-dependent artifact
+      # and would be the wrong thing to embed here anyway - the AOT binary dispatches the CLI modes
+      # itself (see Program.cs), which is why released bundles skip it too.
       - name: Publish AOT
-        run: dotnet publish src/NovaTerminal.App/NovaTerminal.App.csproj -c ${{ env.CONFIGURATION }} -r ${{ matrix.rid }} --self-contained true -p:PublishAot=true -o artifacts/publish/${{ matrix.rid }}
+        run: dotnet publish src/NovaTerminal.App/NovaTerminal.App.csproj -c ${{ env.CONFIGURATION }} -r ${{ matrix.rid }} --self-contained true -p:PublishAot=true -p:SkipCliShim=true -o artifacts/publish/${{ matrix.rid }}
 
       - name: Upload AOT bundle
         if: always()

--- a/src/NovaTerminal.App/NovaTerminal.App.csproj
+++ b/src/NovaTerminal.App/NovaTerminal.App.csproj
@@ -219,6 +219,45 @@
       Condition="'@(CliShimPublishArtifacts)' != ''" />
   </Target>
 
+  <!-- The Delete tasks that clear stale NovaTerminal.Cli* live inside the two shim targets, so
+       gating those targets gated the cleanup with them. That matters because `dotnet publish` never
+       clears its output directory: publishing a self-contained bundle over a directory that already
+       held a framework-dependent shim would keep the shim, shipping the exact artifact the gate
+       exists to exclude. These run the same deletions whenever the shim is deliberately absent.
+
+       Their condition is broader than WarnCliShimNotEmbedded's on purpose. An explicit
+       -p:SkipCliShim=true means "do not embed the shim", which has to also mean "and do not leave an
+       old one lying in the output" - so the cleanup fires for deliberate opt-outs, while the warning
+       does not. One is about the artifact, the other about signal.
+
+       Scoped to $(OutDir)/$(PublishDir), which for a RID build are the RID-specific subdirectories,
+       so a RID publish never reaches into the RID-less bin that a framework-dependent build owns. -->
+  <Target Name="RemoveStaleCliShimFromBuildOutput"
+    AfterTargets="Build"
+    Condition="'$(DesignTimeBuild)' != 'true' and '$(IsCrossTargetingBuild)' != 'true' and ('$(SkipCliShim)' == 'true' or '$(RuntimeIdentifier)' != '' or '$(SelfContained)' == 'true')">
+    <ItemGroup>
+      <StaleCliShimBuildArtifacts Include="$(OutDir)NovaTerminal.Cli*" />
+      <StaleLegacyGuiBuildArtifacts Include="$(OutDir)NovaTerminal.Gui*" />
+    </ItemGroup>
+
+    <Delete Files="@(StaleCliShimBuildArtifacts)" Condition="'@(StaleCliShimBuildArtifacts)' != ''" />
+    <Delete Files="@(StaleLegacyGuiBuildArtifacts)" Condition="'@(StaleLegacyGuiBuildArtifacts)' != ''" />
+  </Target>
+
+  <!-- The publish half of RemoveStaleCliShimFromBuildOutput - see the comment there. Separate
+       because it hooks Publish and clears $(PublishDir), which is a different directory. -->
+  <Target Name="RemoveStaleCliShimFromPublishOutput"
+    AfterTargets="Publish"
+    Condition="'$(DesignTimeBuild)' != 'true' and '$(IsCrossTargetingBuild)' != 'true' and ('$(SkipCliShim)' == 'true' or '$(RuntimeIdentifier)' != '' or '$(SelfContained)' == 'true')">
+    <ItemGroup>
+      <StaleCliShimPublishArtifacts Include="$(PublishDir)NovaTerminal.Cli*" />
+      <StaleLegacyGuiPublishArtifacts Include="$(PublishDir)NovaTerminal.Gui*" />
+    </ItemGroup>
+
+    <Delete Files="@(StaleCliShimPublishArtifacts)" Condition="'@(StaleCliShimPublishArtifacts)' != ''" />
+    <Delete Files="@(StaleLegacyGuiPublishArtifacts)" Condition="'@(StaleLegacyGuiPublishArtifacts)' != ''" />
+  </Target>
+
   <!-- A bundle that quietly lost its CLI would be found by a user, not by CI, so an implicit skip
        announces itself. Deliberate opt-outs (-p:SkipCliShim=true) are excluded: they are already a
        statement of intent, and warning at them would train everyone to ignore this. Attached to

--- a/src/NovaTerminal.App/NovaTerminal.App.csproj
+++ b/src/NovaTerminal.App/NovaTerminal.App.csproj
@@ -123,9 +123,42 @@
       Text="[RustNative] Rust SSH build complete." />
   </Target>
 
+  <!-- The shim is a framework-dependent artifact, and only a RID-less framework-dependent build
+       can produce it. Two independent reasons, both load-bearing:
+
+         * How it is built. Both shim targets invoke the CLI out of band with
+           -p:BuildProjectReferences=false, which is what breaks the cycle - this project's build
+           is what places the CLI's binaries beside it. That nested invocation carries no
+           RuntimeIdentifier, so it resolves this project's reference assembly at the RID-less
+           obj\$(Configuration)\$(TargetFramework)\ref\ path. A RID-specific build writes its
+           intermediates under a $(RuntimeIdentifier) subdirectory instead, and
+           BuildProjectReferences=false means the nested build cannot produce the RID-less copy
+           either - so CSC fails with a bare CS0006 naming a path nothing asked for. It only ever
+           appeared to work when an earlier RID-less build had left that file behind, which is why
+           no local flow caught it and only the dispatch-only AOT lane in ci.yml ever failed.
+           Propagating the RID downward does not rescue it: the CLI references this project as an
+           executable and then wants its apphost, which a self-contained build never writes to obj.
+
+         * What it would produce. Even built, a framework-dependent NovaTerminal.Cli.dll and
+           deps.json sitting in a self-contained or AOT bundle name a shared runtime that the
+           bundle deliberately does not carry. The artifact would be wrong, not merely awkward to
+           build - which is why release.yml skips it and lets the AOT binary dispatch the CLI modes
+           itself (see Program.cs).
+
+       So those builds skip the shim, and WarnCliShimNotEmbedded says so rather than leaving the
+       omission silent. Callers that already opt out explicitly with -p:SkipCliShim=true (ci.yml,
+       release.yml) skip quietly, because they have said what they meant.
+
+       The test lives in the target conditions rather than in a property beside CliProjectPath
+       above, and that placement is load-bearing: -r sets RuntimeIdentifier as a global property,
+       but a plain `dotnet publish` of this project has the SDK infer one - PublishAot is set
+       unconditionally at the top of this file - and that inference happens in Sdk.targets, after
+       the project body has been evaluated. A property declared in the body would read empty and
+       miss exactly that case. Target conditions are evaluated when the target is scheduled, so
+       they see the final value either way. -->
   <Target Name="BuildCliShim"
     AfterTargets="Build"
-    Condition="'$(DesignTimeBuild)' != 'true' and '$(IsCrossTargetingBuild)' != 'true' and '$(SkipCliShim)' != 'true'">
+    Condition="'$(DesignTimeBuild)' != 'true' and '$(IsCrossTargetingBuild)' != 'true' and '$(SkipCliShim)' != 'true' and '$(RuntimeIdentifier)' == '' and '$(SelfContained)' != 'true'">
 
     <!-- -nodeReuse:false and -p:UseSharedCompilation=false prevent the nested dotnet build
          from spawning daemons (MSBuild worker nodes and VBCSCompiler) that inherit pipe handles
@@ -157,9 +190,10 @@
       Condition="'@(CliShimBuildArtifacts)' != ''" />
   </Target>
 
+  <!-- Gated identically to BuildCliShim - see the comment there for why. -->
   <Target Name="PublishCliShim"
     AfterTargets="Publish"
-    Condition="'$(DesignTimeBuild)' != 'true' and '$(IsCrossTargetingBuild)' != 'true' and '$(SkipCliShim)' != 'true'">
+    Condition="'$(DesignTimeBuild)' != 'true' and '$(IsCrossTargetingBuild)' != 'true' and '$(SkipCliShim)' != 'true' and '$(RuntimeIdentifier)' == '' and '$(SelfContained)' != 'true'">
 
     <MakeDir Directories="$(CliPublishOutputDir)" />
     <Exec Command="dotnet publish &quot;$(CliProjectPath)&quot; -c $(Configuration) --no-restore -nodeReuse:false -p:BuildProjectReferences=false -p:UseSharedCompilation=false -o &quot;$(CliPublishOutputDir)&quot;" />
@@ -183,6 +217,17 @@
       DestinationFolder="$(PublishDir)"
       SkipUnchangedFiles="true"
       Condition="'@(CliShimPublishArtifacts)' != ''" />
+  </Target>
+
+  <!-- A bundle that quietly lost its CLI would be found by a user, not by CI, so an implicit skip
+       announces itself. Deliberate opt-outs (-p:SkipCliShim=true) are excluded: they are already a
+       statement of intent, and warning at them would train everyone to ignore this. Attached to
+       Build rather than Publish because Publish depends on Build, so either flow warns once. -->
+  <Target Name="WarnCliShimNotEmbedded"
+    AfterTargets="Build"
+    Condition="'$(DesignTimeBuild)' != 'true' and '$(IsCrossTargetingBuild)' != 'true' and '$(SkipCliShim)' != 'true' and ('$(RuntimeIdentifier)' != '' or '$(SelfContained)' == 'true')">
+    <Warning
+      Text="NovaTerminal.Cli was not embedded beside this build. The CLI shim needs a RID-less, framework-dependent build to produce it, and this one has RuntimeIdentifier='$(RuntimeIdentifier)' SelfContained='$(SelfContained)'; see the comment on BuildCliShim in NovaTerminal.App.csproj. This is the supported shape for a self-contained or AOT bundle - the published binary dispatches the CLI modes itself - so pass -p:SkipCliShim=true to say so and silence this." />
   </Target>
 
   <!-- Native Rust libraries (rusty_pty / rusty_ssh) are produced during the build by

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistLayoutTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistLayoutTests.cs
@@ -2307,6 +2307,19 @@ public sealed class CommandAssistLayoutTests
     /// tolerance.
     /// </para>
     /// <para>
+    /// <strong>Why the slack budget is measured rather than a flat number.</strong> The constants
+    /// budget a fixed height per text line, and on the machine they were derived from the estimate is
+    /// exact - every row case measures to the pixel. A platform whose fonts resolve differently draws
+    /// a shorter line box, and the estimate then carries that difference once per line: the CI Linux
+    /// runners come in 2 px short per line, which is 6 px of slack for one row and 12 px for four.
+    /// A flat tolerance either fails there for a reason that is not a template change, or is loosened
+    /// until it stops catching the template changes it exists for. So the drift is measured off the
+    /// same template - two adjacent row counts give the row the platform actually draws against the
+    /// row the constants assume - and the budget is that drift times the number of text lines the
+    /// case puts on screen, plus a small allowance for anything it does not explain. Unexplained
+    /// slack is held to the same few pixels everywhere.
+    /// </para>
+    /// <para>
     /// Row counts stop at four because five rows plus chrome exceeds the 220 px ceiling, where the
     /// estimate is supposed to stop tracking the content and the list is supposed to scroll. The
     /// clamp itself is pinned separately, in
@@ -2336,44 +2349,74 @@ public sealed class CommandAssistLayoutTests
         bool hasAttribution,
         double popupWidth)
     {
-        const double tolerance = 8;
+        // Slack the estimate may carry that the platform's own text metrics do not explain. Anything
+        // beyond this is template drift, which is the thing this test exists to catch.
+        const double unexplainedSlackTolerance = 8;
 
-        var suggestions = new ObservableCollection<CommandAssistSuggestionItemViewModel>();
-        for (int i = 0; i < rowCount; i++)
+        CommandAssistPopupViewModel BuildViewModel(int rows, bool empty, bool attribution)
         {
-            suggestions.Add(new CommandAssistSuggestionItemViewModel(
-                displayText: $"git commit --message \"row {i}\"",
-                descriptionText: string.Empty,
-                badgesText: string.Empty,
-                metadataText: string.Empty,
-                isSelected: i == 0,
-                type: AssistSuggestionType.History));
+            var suggestions = new ObservableCollection<CommandAssistSuggestionItemViewModel>();
+            for (int i = 0; i < rows; i++)
+            {
+                suggestions.Add(new CommandAssistSuggestionItemViewModel(
+                    displayText: $"git commit --message \"row {i}\"",
+                    descriptionText: string.Empty,
+                    badgesText: string.Empty,
+                    metadataText: string.Empty,
+                    isSelected: i == 0,
+                    type: AssistSuggestionType.History));
+            }
+
+            return new CommandAssistPopupViewModel(suggestions)
+            {
+                IsVisible = true,
+                ModeLabel = "History",
+                QueryText = "git",
+                SelectedFooterText = @"C:\repo  |  2 min ago  |  Exit 0",
+                ShortcutHintText = CommandAssistBarViewModel.BrowseHintText,
+                AttributionText = attribution ? "Command examples from tldr-pages, CC-BY-SA 4.0." : string.Empty,
+
+                // The longest shipped empty-state string, so this measures the worst case the product
+                // can currently produce rather than a convenient short one.
+                EmptyStateText = empty ? AssistEmptyStates.NoHistoryMatch : string.Empty,
+                ShowEmptyState = empty,
+                HasSuggestions = !empty
+            };
         }
 
-        var vm = new CommandAssistPopupViewModel(suggestions)
-        {
-            IsVisible = true,
-            ModeLabel = "History",
-            QueryText = "git",
-            SelectedFooterText = @"C:\repo  |  2 min ago  |  Exit 0",
-            ShortcutHintText = CommandAssistBarViewModel.BrowseHintText,
-            AttributionText = hasAttribution ? "Command examples from tldr-pages, CC-BY-SA 4.0." : string.Empty,
-
-            // The longest shipped empty-state string, so this measures the worst case the product can
-            // currently produce rather than a convenient short one.
-            EmptyStateText = showEmptyState ? AssistEmptyStates.NoHistoryMatch : string.Empty,
-            ShowEmptyState = showEmptyState,
-            HasSuggestions = !showEmptyState
-        };
+        static double Estimate(int rows, bool empty, bool attribution) =>
+            TerminalPane.EstimateCommandAssistPopupHeight(
+                new TerminalPane.CommandAssistPopupContentSize(rows, empty, attribution),
+                paneHeight: 2000);
 
         string what = showEmptyState
             ? $"the empty state at {popupWidth:F0} px"
             : $"{rowCount} row(s)";
 
-        double measured = MeasureNaturalPopupHeight(vm, popupWidth);
-        double estimated = TerminalPane.EstimateCommandAssistPopupHeight(
-            new TerminalPane.CommandAssistPopupContentSize(rowCount, showEmptyState, hasAttribution),
-            paneHeight: 2000);
+        double measured = MeasureNaturalPopupHeight(BuildViewModel(rowCount, showEmptyState, hasAttribution), popupWidth);
+        double estimated = Estimate(rowCount, showEmptyState, hasAttribution);
+
+        // How much shorter one text line box really is than the constants budget for it, measured on
+        // the platform running the test rather than assumed. Two adjacent row counts differ by exactly
+        // one row, so the gap between their estimates is the row constant and the gap between their
+        // measurements is the row the platform actually draws; the difference is the drift. Four and
+        // three rather than two and one because the one-row estimate sits on the floor, where a future
+        // floor change would quietly flatten the subtraction - both of these are above the floor and
+        // under the ceiling.
+        double lineBoxDrift = Math.Max(
+            0,
+            (Estimate(4, false, false) - Estimate(3, false, false))
+                - (MeasureNaturalPopupHeight(BuildViewModel(4, false, false), popupWidth)
+                    - MeasureNaturalPopupHeight(BuildViewModel(3, false, false), popupWidth)));
+
+        // Counted off the template: one line box per row - or the empty state's single body line in
+        // their place - plus the header line and the footer line, plus the attribution credit when
+        // there is one.
+        int textLineBoxes = 2
+            + (showEmptyState ? 1 : rowCount)
+            + (hasAttribution ? 1 : 0);
+
+        double tolerance = unexplainedSlackTolerance + (textLineBoxes * lineBoxDrift);
 
         Assert.True(
             estimated >= measured,
@@ -2384,8 +2427,11 @@ public sealed class CommandAssistLayoutTests
         Assert.True(
             estimated - measured <= tolerance,
             $"The estimate for {what} was {estimated:F1} px against a measured {measured:F1} px, " +
-            $"which is {estimated - measured:F1} px of empty card under the content " +
-            $"(tolerance {tolerance:F0}).");
+            $"which is {estimated - measured:F1} px of empty card under the content - more than the " +
+            $"{tolerance:F1} px budget ({unexplainedSlackTolerance:F0} px of unexplained slack plus " +
+            $"{textLineBoxes} text line(s) at {lineBoxDrift:F1} px of measured font drift each). " +
+            "Re-derive the chrome and row constants in TerminalPane from CommandAssistPopupView.axaml " +
+            "rather than widening the tolerance.");
     }
 
     /// <summary>

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistLayoutTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistLayoutTests.cs
@@ -2353,6 +2353,13 @@ public sealed class CommandAssistLayoutTests
         // beyond this is template drift, which is the thing this test exists to catch.
         const double unexplainedSlackTolerance = 8;
 
+        // The most a single line box may fall short of the height the constants budget for it before
+        // the difference stops being a font and starts being the template. The ubuntu runners come in
+        // 2 px short, so this leaves a pixel of headroom for another font stack while still catching a
+        // row that lost 4 px of padding. Raising it past the smallest real template change it has to
+        // catch would defeat the row assertion below.
+        const double maxLineBoxDrift = 3;
+
         CommandAssistPopupViewModel BuildViewModel(int rows, bool empty, bool attribution)
         {
             var suggestions = new ObservableCollection<CommandAssistSuggestionItemViewModel>();
@@ -2403,11 +2410,24 @@ public sealed class CommandAssistLayoutTests
         // three rather than two and one because the one-row estimate sits on the floor, where a future
         // floor change would quietly flatten the subtraction - both of these are above the floor and
         // under the ceiling.
-        double lineBoxDrift = Math.Max(
-            0,
-            (Estimate(4, false, false) - Estimate(3, false, false))
-                - (MeasureNaturalPopupHeight(BuildViewModel(4, false, false), popupWidth)
-                    - MeasureNaturalPopupHeight(BuildViewModel(3, false, false), popupWidth)));
+        double estimatedRowHeight = Estimate(4, false, false) - Estimate(3, false, false);
+        double measuredRowHeight =
+            MeasureNaturalPopupHeight(BuildViewModel(4, false, false), popupWidth)
+            - MeasureNaturalPopupHeight(BuildViewModel(3, false, false), popupWidth);
+        double lineBoxDrift = Math.Max(0, estimatedRowHeight - measuredRowHeight);
+
+        // The drift is measured off the row, so a row that has genuinely shrunk in the template
+        // inflates it - and the budget below multiplies it by the row count, which would absorb
+        // exactly the regression this test exists to catch. A shorter outer padding cancels in the
+        // subtraction above and still shows up as unexplained slack, but a shorter row does not, so
+        // the row is pinned here on its own.
+        Assert.True(
+            lineBoxDrift <= maxLineBoxDrift,
+            $"One row measured {measuredRowHeight:F1} px against the {estimatedRowHeight:F1} px the " +
+            $"row constant budgets, a {lineBoxDrift:F1} px shortfall - more than a difference in font " +
+            $"metrics explains ({maxLineBoxDrift:F0} px). The row in CommandAssistPopupView.axaml has " +
+            "changed height: re-derive CommandAssistPopupRowHeight in TerminalPane from the template " +
+            "rather than raising this bound.");
 
         // Counted off the template: one line box per row - or the empty state's single body line in
         // their place - plus the header line and the footer line, plus the attribution credit when

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/RemoteInstallerIntegrationTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/Integration/RemoteInstallerIntegrationTests.cs
@@ -71,11 +71,6 @@ public sealed class RemoteInstallerIntegrationTests : IDisposable
     /// RemoteShellIntegrationInstallerTests; and the real PTY path is still covered by
     /// <see cref="AfterInstalling_ANewInteractiveShell_EmitsTheLifecycle"/>.
     /// </remarks>
-    /// <param name="pathOverride">
-    /// Replaces <c>PATH</c> for the child. On real Linux bash this alone hides <c>base64</c> and
-    /// <c>gzip</c>; kept for that platform even though it is not sufficient on Git Bash - see
-    /// <paramref name="shadowDecodeTools"/>.
-    /// </param>
     /// <param name="shadowDecodeTools">
     /// Prepends bash functions named <c>base64</c> and <c>gzip</c> that both fail, shadowing the
     /// real commands regardless of <c>PATH</c>. Needed because Git Bash's MSYS runtime injects
@@ -84,9 +79,11 @@ public sealed class RemoteInstallerIntegrationTests : IDisposable
     /// <c>/mingw64/bin:/usr/bin:...</c> first - so an empty-directory <c>PATH</c> override alone
     /// never hides <c>base64</c>/<c>gzip</c> on this platform and the installer always "succeeds".
     /// A bash function takes precedence over a <c>PATH</c> lookup for a simple command, which is
-    /// what lets this actually exercise the failure branch on Windows.
+    /// what lets this exercise the failure branch on every platform - and, unlike a <c>PATH</c>
+    /// override, hides the two tools under test without also hiding the ones the installer needs to
+    /// reach them.
     /// </param>
-    private string RunInstaller(string? pathOverride = null, bool shadowDecodeTools = false)
+    private string RunInstaller(bool shadowDecodeTools = false)
     {
         string? bash = ShellHarness.FindBash();
         if (bash is null)
@@ -112,10 +109,6 @@ public sealed class RemoteInstallerIntegrationTests : IDisposable
         };
         startInfo.ArgumentList.Add(pastePath.Replace('\\', '/'));
         startInfo.Environment["HOME"] = HomeForShell;
-        if (pathOverride is not null)
-        {
-            startInfo.Environment["PATH"] = pathOverride;
-        }
 
         using Process process = Process.Start(startInfo)!;
         string stdout = process.StandardOutput.ReadToEnd();
@@ -391,22 +384,26 @@ public sealed class RemoteInstallerIntegrationTests : IDisposable
     /// cannot diagnose.
     /// </summary>
     /// <remarks>
-    /// An empty-directory <c>PATH</c> override is not enough here: Git Bash's MSYS runtime
-    /// unconditionally prepends <c>/mingw64/bin:/usr/bin</c> to <c>PATH</c> before the script sees
-    /// it (still true with <c>--noprofile --norc</c>, so it is not a sourced file), which means
-    /// <c>base64</c>/<c>gzip</c> are always found there regardless of what this test passes as
-    /// <c>PATH</c> - the installer "succeeds" and this test's whole premise silently fails to hold.
-    /// <see cref="RunInstaller"/>'s <c>shadowDecodeTools</c> additionally defines bash functions
-    /// named <c>base64</c>/<c>gzip</c> that fail, which take precedence over any <c>PATH</c> lookup
-    /// and so reach the failure branch on every platform.
+    /// <para>
+    /// The two tools are hidden with bash functions named <c>base64</c> and <c>gzip</c> that fail,
+    /// not by emptying <c>PATH</c>. A function beats a <c>PATH</c> lookup for a simple command, so
+    /// this reaches the decode's failure branch on every platform - which a <c>PATH</c> override does
+    /// not: Git Bash's MSYS runtime unconditionally prepends <c>/mingw64/bin:/usr/bin</c> before the
+    /// script sees it (still true with <c>--noprofile --norc</c>, so it is not a sourced file), so
+    /// the real <c>base64</c>/<c>gzip</c> are always found and the installer "succeeds".
+    /// </para>
+    /// <para>
+    /// The override used to be passed as well, belt-and-braces for Linux where it does hide the two
+    /// tools. On Linux it also hid <c>mktemp</c>, and the one-liner needs a temp file <em>before</em>
+    /// it decodes anything - so the installer failed at "mktemp could not create a temp file" and
+    /// this test's own branch was never reached on the platform the override was there for. Hiding
+    /// exactly the two tools under test, and nothing else the installer depends on, is the point.
+    /// </para>
     /// </remarks>
     [Fact]
     public void Installer_WithoutBase64OrGzip_ReportsFailureAndWritesNothing()
     {
-        string emptyDir = Path.Combine(_home, "empty-path");
-        Directory.CreateDirectory(emptyDir);
-
-        string output = RunInstaller(pathOverride: emptyDir.Replace('\\', '/'), shadowDecodeTools: true);
+        string output = RunInstaller(shadowDecodeTools: true);
 
         Assert.Contains("nova: install failed", output, StringComparison.Ordinal);
         Assert.Contains("base64", output, StringComparison.Ordinal);


### PR DESCRIPTION
## What this changes

Two CI lanes were reporting green while broken, and this fixes both plus the reason each could hide.

The `Unit Tests (ubuntu-latest)` lane failed **6 App.Tests on every run, including on `main`** — invisible because that step is `continue-on-error`. The lane's own comment claims "a genuine regression shows as a failed (non-blocking) check", which could not be true while 6 failures stood permanently: a 7th looked exactly like the existing 6. Baseline was `Failed: 6, Passed: 2539, Total: 2556`; it is now `Failed: 0, Passed: 2545, Total: 2556` — same total, same skips, exactly the six flipped.

The `AOT Publish` lane failed on all three OSes with a bare `CS0006`. It is gated `if: github.event_name == 'workflow_dispatch'`, so no push or PR ever ran it and nothing reported the breakage.

No issue numbers — both were found by auditing the non-blocking lane. #81 is referenced below as context only; it is **not** fixed here.

### 1. Linux font drift in `PopupHeightEstimate_MatchesTheRenderedTemplate` (5 theory cases)

Not "font metrics differ on Linux, so relax it". The constants in `TerminalPane` are pixel-exact on the platform they were derived from — I forced the assertion to print its numbers and every row case measures **0 px** of slack on Windows. On the ubuntu runners **every text line box in the template measures exactly 2 px shorter**, so the estimate carries that difference once per line: 6 px at one row, 12 px at four. That model accounts for all 7 cases on both platforms exactly, including the empty state and the attribution line.

A flat tolerance cannot express this: it either fails on Linux for a reason that is not a template change, or gets widened until it stops catching the template changes it exists for. So the drift is now **measured off the same template** — two adjacent row counts give the row the platform actually draws versus the row the constants assume — and the budget is that drift times the number of text lines the case puts on screen, plus the original 8 px of unexplained slack. Windows measures 0 px of drift, so its budget stays exactly 8 px. Nothing was loosened on the platform the constants encode.

Verified the guard still bites: shortening the template by 10 px fails all 7 cases and reports `0.0 px of measured font drift`, because a fixed-chrome change cancels in the row-delta subtraction and cannot be absorbed by the drift term.

### 2. `Installer_WithoutBase64OrGzip_ReportsFailureAndWritesNothing`

The test passed an empty-directory `PATH` override *and* bash functions shadowing `base64`/`gzip`. On Linux the override also hid **`mktemp`**, and the installer one-liner needs a temp file *before* it decodes anything — so it failed at `mktemp could not create a temp file` and the branch under test was never reached on the very platform the override was there for. The shadow functions beat a `PATH` lookup everywhere, which made the override redundant; dropping it hides exactly the two tools under test and nothing the installer needs to reach them.

### 3. `AOT Publish` — the missing `-p:SkipCliShim=true`

`BuildCliShim` invokes NovaTerminal.Cli out of band with `-p:BuildProjectReferences=false` (that is what breaks the cycle — App's build is what places the CLI beside it). The nested invocation carries no RuntimeIdentifier, so it resolves App's reference assembly at the RID-less `obj/Release/net10.0/ref/`. A self-contained RID publish writes its intermediates under a RID subdirectory, so on a clean checkout that path never exists and nothing can produce it — hence `CS0006` naming a path nothing asked for. It only ever appeared to work when an earlier RID-less build had left that file behind, which is why no local flow caught it.

`release.yml`'s Publish AOT step already passes `-p:SkipCliShim=true` for exactly this reason. **This lane was that command minus the flag.**

Propagating the RID down is not the fix: the CLI references App as an executable and then wants App's apphost, and a self-contained build never writes one to obj (verified by inspecting `obj/Release/net10.0/win-x64` after a completed RID build). The shim is inherently framework-dependent — a managed `NovaTerminal.Cli.dll` plus `deps.json` in a self-contained bundle names a shared runtime the bundle deliberately does not carry — and the AOT binary dispatches all three CLI modes itself (`Program.cs`).

AOT compilation itself was never broken.

### 4. Gating the shim on the build shape (`NovaTerminal.App.csproj`)

Adding the flag fixed the lane but left the trap armed for the next RID publish. Both shim targets now require the only shape that can produce a framework-dependent shim — RID-less and not self-contained — and `WarnCliShimNotEmbedded` explains any *implicit* omission. Deliberate opt-outs stay silent: a caller that passed `-p:SkipCliShim=true` has said what it meant, and warning at it would train everyone to ignore the warning. The explicit flags in `ci.yml`/`release.yml` are now redundant with the gate but kept, because they document intent at the call site.

**Reviewer note on placement.** The test lives in the target conditions, not in a property beside `CliProjectPath`, and that is load-bearing. `-r` supplies `RuntimeIdentifier` as a global property, but a plain `dotnet publish` of this project has the SDK *infer* one — `PublishAot` is unconditional at the top of the file — and that inference happens in `Sdk.targets`, **after** the project body is evaluated. A body-level property reads empty and misses exactly that case. My first attempt made a related mistake in the other direction: it gated on `PublishAot`, which is declared unconditionally and therefore says nothing about any given build, silently disabling the shim for *every* ordinary build. The regression check below is what caught it.

## Invariant and ownership

- **What invariant does this change affect?**

  No product invariant — no `src/` behaviour changes. Two are test-only; the shim gate affects **build-output composition**: which shapes embed `NovaTerminal.Cli` beside the app. The invariant it now enforces is that the shim is only produced by the RID-less framework-dependent build that can actually produce it, rather than depending on leftover intermediates.

- **Which module owns that invariant?**

  `NovaTerminal.App` (the shim targets and `NovaTerminal.App.csproj` own the CLI-shim contract); the test changes sit in `tests/NovaTerminal.App.Tests`.

## Tests

- **What tests cover this change?**

  - `CommandAssistLayoutTests.PopupHeightEstimate_MatchesTheRenderedTemplate` (7 theory cases) — rewritten so the slack budget is derived from measured platform metrics; the anti-clip assertion (`estimated >= measured`) is unchanged and still unconditional on every platform.
  - `RemoteInstallerIntegrationTests.Installer_WithoutBase64OrGzip_ReportsFailureAndWritesNothing` — now actually reaches the branch it asserts on, on Linux as well as Windows.
  - The build changes are verified by build shape rather than by xUnit; the four shapes and their outcomes are listed under Impact.

- **Which categories did you run locally?**

  - [ ] full unfiltered run (`scripts/build.sh test`)
  - [ ] `Category=Replay`
  - [ ] `Category=RenderMetrics`
  - [ ] `Category=PtySmoke`
  - [x] `tests/NovaTerminal.App.Tests` (non-blocking in CI — check it yourself)
  - [ ] full local CI rehearsal (`ci/run.sh` / `ci/run.ps1`)

  Being precise, since the unchecked boxes are deliberate. Locally I ran the two affected classes (`CommandAssistLayoutTests` + `RemoteInstallerIntegrationTests`: 115 passed, 0 failed, 2 pre-existing environment skips) rather than a full unfiltered run. The remaining categories were covered by three full `workflow_dispatch` runs of `ci.yml` on this branch, the last of which is **22 jobs success, 2 skipped** (nightly-only) — including Replay, RenderMetrics, PtySmoke, Golden PNGs and Native SSH Docker E2E on both platforms.

  Because App.Tests is non-blocking, I did not trust the green check: I pulled the raw job logs and grepped. `[FAIL]` count is **0** on both, with `Failed: 0, Passed: 2545, Skipped: 11` on ubuntu and `Failed: 0, Passed: 2539, Skipped: 17` on windows.

## Impact

- **Does this affect cross-platform behavior?**

  Yes, and that is the point of two of the four changes. Both test fixes are specifically about Linux-vs-Windows divergence. Verified on Windows locally and on ubuntu/windows in CI. The installer fix was additionally verified against **real Linux bash via WSL**: the old configuration reproduces `nova: install failed - mktemp could not create a temp file`, the new one reaches `... needs a working base64 and gzip`.

  I could not run the popup test on Linux locally — `global.json` pins SDK `10.0.300-preview` and the WSL image has `10.0.111`, and that pin is deliberate, so I left it alone. CI covers it.

  The shim gate is platform-independent; all three `AOT Publish` OSes (ubuntu, windows, macos) went from failing to green, having previously failed with the identical error on each.

  Build shapes verified locally, the RID ones under the clean-checkout condition that produced the CI failure (RID-less ref assembly and apphost deleted first):

  | shape | result |
  |---|---|
  | plain `build` | shim embedded, all five `NovaTerminal.Cli.*` files, no warning |
  | plain `publish` | RID inferred as `win-x64`, shim skipped **with** warning, exit 0 |
  | `-r` + `SkipCliShim` | skipped silently (0 warnings), 37 MB native exe, exit 0 |
  | `-r` without the flag | skipped with warning, exit 0 — **previously died on `CS0006`** |

  **Behaviour change worth knowing:** a local `dotnet publish` of the App no longer drops `NovaTerminal.Cli.*` into the output — it warns instead. That flow only ever worked when a previous RID-less build had left a reference assembly behind, and the artifact it produced was wrong for an AOT bundle anyway. Flagging it in case a habit or script relies on it.

- **Does this change renderer metrics?**

  No. No renderer or rendering-path code is touched; the popup change is confined to a test's tolerance derivation. Render Metrics jobs are green on both platforms.

- **Does this change VT coverage?**

  No. No VT sequences added or changed, so `docs/vt_coverage_matrix.md` and `vt-conformance-report.json` are untouched.

## Two things left open, deliberately

1. **`continue-on-error` still hides a real regression from `gh pr checks`.** Zeroing the baseline makes grepping the log meaningful, but a step-level `continue-on-error` still leaves the *job* green — which is why I grepped rather than trusting the check. A follow-up step reading `unit_app.trx` and failing/annotating on `Failed > 0`, while still tolerating the #81 teardown hang, would close it. Out of scope here.
2. **`AOT Publish` remains dispatch-only.** It is green now, and stays green only as long as someone remembers to dispatch it. The csproj gate removes the specific trap but not the blind spot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
