### PR TITLE
fix(pty): contain native-interop failures in the child-status probe, and rebuild rusty_pty when its source changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,8 @@ jobs:
       # Cache both target/release and target_linux/release: the Linux csproj
       # consumes the .so from target_linux/release, so it must be part of the
       # cache or a cache hit leaves the staged path empty and the Build step
-      # below is skipped. Key bumped to v2 to invalidate caches that only
-      # contained target/release.
+      # below is skipped. The v2 bump invalidated older caches that contained only
+      # target/release; the v3 bump on the key itself is explained there.
       - name: Cache native binary
         id: native-bin-cache
         uses: actions/cache@v4
@@ -103,7 +103,14 @@ jobs:
           path: |
             src/NovaTerminal.App/native/target/release
             src/NovaTerminal.App/native/target_linux/release
-          key: native-bin-v2-${{ matrix.os }}-${{ hashFiles('src/NovaTerminal.App/native/src/**', 'src/NovaTerminal.App/native/Cargo.toml', 'src/NovaTerminal.App/native/Cargo.lock') }}
+          # Key version bumped to v3 for the rusty_pty input-hash stamp
+          # (native/target/release/.nova-rust-inputs.sha256). A v2 payload predates the stamp,
+          # so restoring one would make BuildRustNative call the binary stale and invoke cargo -
+          # on a runner where this same cache hit skipped the toolchain install and the cargo
+          # registry cache. Worse, actions/cache does not re-save on an exact key hit, so the
+          # stamp would never enter the v2 payload and every hit would pay that rebuild forever.
+          # Bumping forces one miss, whose save captures the stamp.
+          key: native-bin-v3-${{ matrix.os }}-${{ hashFiles('src/NovaTerminal.App/native/src/**', 'src/NovaTerminal.App/native/Cargo.toml', 'src/NovaTerminal.App/native/Cargo.lock') }}
 
       - name: Install Rust
         if: steps.native-bin-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,7 +42,14 @@ jobs:
           path: |
             src/NovaTerminal.App/native/target/release
             src/NovaTerminal.App/native/target_linux/release
-          key: native-bin-v2-ubuntu-latest-${{ hashFiles('src/NovaTerminal.App/native/src/**', 'src/NovaTerminal.App/native/Cargo.toml', 'src/NovaTerminal.App/native/Cargo.lock') }}
+          # Key version bumped to v3 for the rusty_pty input-hash stamp
+          # (native/target/release/.nova-rust-inputs.sha256). A v2 payload predates the stamp,
+          # so restoring one would make BuildRustNative call the binary stale and invoke cargo -
+          # on a runner where this same cache hit skipped the toolchain install and the cargo
+          # registry cache. Worse, actions/cache does not re-save on an exact key hit, so the
+          # stamp would never enter the v2 payload and every hit would pay that rebuild forever.
+          # Bumping forces one miss, whose save captures the stamp.
+          key: native-bin-v3-ubuntu-latest-${{ hashFiles('src/NovaTerminal.App/native/src/**', 'src/NovaTerminal.App/native/Cargo.toml', 'src/NovaTerminal.App/native/Cargo.lock') }}
 
       - name: Install Rust
         if: steps.native-bin-cache.outputs.cache-hit != 'true'
@@ -171,7 +178,16 @@ jobs:
         uses: actions/cache@v4
         with:
           path: src/NovaTerminal.App/native/target/release
-          key: native-bin-${{ matrix.os }}-${{ hashFiles('src/NovaTerminal.App/native/src/**', 'src/NovaTerminal.App/native/Cargo.toml', 'src/NovaTerminal.App/native/Cargo.lock') }}
+          # Key version bumped to v3 for the rusty_pty input-hash stamp
+          # (native/target/release/.nova-rust-inputs.sha256). A v2 payload predates the stamp,
+          # so restoring one would make BuildRustNative call the binary stale and invoke cargo -
+          # on a runner where this same cache hit skipped the toolchain install and the cargo
+          # registry cache. Worse, actions/cache does not re-save on an exact key hit, so the
+          # stamp would never enter the v2 payload and every hit would pay that rebuild forever.
+          # Bumping forces one miss, whose save captures the stamp.
+          # Kept in its own namespace: this job caches only target/release, and sharing a
+          # key with ci.yml's fuller payload is what the v2 bump existed to undo.
+          key: native-bin-target-only-v3-${{ matrix.os }}-${{ hashFiles('src/NovaTerminal.App/native/src/**', 'src/NovaTerminal.App/native/Cargo.toml', 'src/NovaTerminal.App/native/Cargo.lock') }}
 
       - name: Install Rust
         if: steps.native-bin-cache.outputs.cache-hit != 'true'

--- a/src/NovaTerminal.App/NovaTerminal.App.csproj
+++ b/src/NovaTerminal.App/NovaTerminal.App.csproj
@@ -61,6 +61,22 @@
 
   <PropertyGroup>
     <NativeProjectDir>$(MSBuildProjectDirectory)\native\</NativeProjectDir>
+
+    <!-- What a release cargo build actually writes for rusty_pty, per platform. -->
+    <RustPtyNativeCargoOutput Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))">$(NativeProjectDir)target\release\rusty_pty.dll</RustPtyNativeCargoOutput>
+    <RustPtyNativeCargoOutput Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))">$(NativeProjectDir)target\release\librusty_pty.so</RustPtyNativeCargoOutput>
+    <RustPtyNativeCargoOutput Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))">$(NativeProjectDir)target\release\librusty_pty.dylib</RustPtyNativeCargoOutput>
+
+    <!-- Linux only: the Content items below consume the .so from target_linux\release, not from
+         cargo's own target\release. CI stages it with an explicit `cp`; BuildRustNative now does
+         the same, so a local Linux build produces a usable output at all - without it
+         target_linux stays empty, the Content item is dropped, and the app ships with no PTY. -->
+    <RustPtyNativeStagedOutput Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))">$(NativeProjectDir)target_linux\release\librusty_pty.so</RustPtyNativeStagedOutput>
+
+    <!-- Records the hash of the inputs the current binary was built from. Lives inside
+         target\release because that directory is both gitignored and part of CI's
+         native-binary cache, so a cache hit restores the stamp along with the binary. -->
+    <RustPtyNativeStamp>$(NativeProjectDir)target\release\.nova-rust-inputs.sha256</RustPtyNativeStamp>
     <RustSshNativeProjectDir>$(NativeProjectDir)rusty_ssh\</RustSshNativeProjectDir>
     <RustSshNativeOutput Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))">$(RustSshNativeProjectDir)target\release\rusty_ssh.dll</RustSshNativeOutput>
     <RustSshNativeOutput Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))">$(RustSshNativeProjectDir)target\release\librusty_ssh.so</RustSshNativeOutput>
@@ -68,23 +84,74 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <RustPtyNativeInputs Include="$(NativeProjectDir)Cargo.toml" />
+    <RustPtyNativeInputs Include="$(NativeProjectDir)Cargo.lock" />
+    <RustPtyNativeInputs Include="$(NativeProjectDir)src\**\*.rs" />
+
     <RustSshNativeInputs Include="$(RustSshNativeProjectDir)Cargo.toml" />
     <RustSshNativeInputs Include="$(RustSshNativeProjectDir)Cargo.lock" />
     <RustSshNativeInputs Include="$(RustSshNativeProjectDir)src\**\*.rs" />
   </ItemGroup>
 
-  <Target Name="BuildRustNative"
-    BeforeTargets="PrepareForBuild"
-    Condition="'$(DesignTimeBuild)' != 'true'
-      and '$(IsCrossTargetingBuild)' != 'true'
-      and '$(SKIP_RUST_NATIVE_BUILD)' != '1'
-      and (
-        ($([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows))) and !Exists('$(NativeProjectDir)target\release\rusty_pty.dll'))
-        or
-        ($([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux))) and !Exists('$(NativeProjectDir)target_linux\release\librusty_pty.so'))
-        or
-        ($([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX))) and !Exists('$(NativeProjectDir)target\release\librusty_pty.dylib'))
-      )">
+  <!-- Decides whether rusty_pty needs rebuilding, by content rather than by existence.
+
+       This target used to be conditioned on `!Exists(<the native library>)`, so it ran exactly
+       once - the first build in a fresh tree - and never again. Editing native\src\lib.rs
+       therefore did not rebuild the library, and `PreserveNewest` then faithfully copied the
+       unchanged binary onward, so every bin\ directory in the tree kept a stale rusty_pty for
+       as long as the file existed. That is how a build predating the `pty_try_get_exit_code`
+       export survived in tests\NovaTerminal.App.Tests\bin and threw EntryPointNotFoundException
+       at runtime - a failure that looks nothing like a stale-artifact problem from the test
+       output, and whose collateral damage landed on unrelated tests.
+
+       Why a hash stamp rather than MSBuild's Inputs/Outputs, which is what the sibling
+       BuildRustSshNative target uses: Inputs/Outputs compares timestamps, and `actions/checkout`
+       gives every source file a fresh mtime while `actions/cache` restores the binary with its
+       original one. On a CI cache hit - the common case - a timestamp check would therefore call
+       a content-identical binary stale and recompile all 36 crates on a runner whose cargo
+       registry cache was skipped precisely because the binary was already cached, on the same
+       dep-fetch path that already flakes. Hashing the inputs instead agrees with what CI's cache
+       key already asserts (it is keyed on hashFiles of these same files), so a cache hit stays
+       free while a real source edit still rebuilds. -->
+  <Target Name="CheckRustNativeUpToDate" Condition="'$(RustPtyNativeCargoOutput)' != ''">
+
+    <GetFileHash Files="@(RustPtyNativeInputs)" Algorithm="SHA256">
+      <Output TaskParameter="Items" ItemName="_RustPtyNativeHashedInputs" />
+    </GetFileHash>
+
+    <ReadLinesFromFile File="$(RustPtyNativeStamp)" Condition="Exists('$(RustPtyNativeStamp)')">
+      <Output TaskParameter="Lines" ItemName="_RustPtyNativeStampLines" />
+    </ReadLinesFromFile>
+
+    <PropertyGroup>
+      <!-- Keyed on names relative to the crate, not absolute paths, so the stamp survives being
+           cached on one machine and restored at another path (CI caches, git worktrees). Naming
+           each file also catches an added or deleted source, which a single combined hash of the
+           contents alone would not. -->
+      <RustPtyNativeInputsHash>@(_RustPtyNativeHashedInputs->'%(RecursiveDir)%(Filename)%(Extension)=%(FileHash)', ';')</RustPtyNativeInputsHash>
+      <RustPtyNativeStampHash>@(_RustPtyNativeStampLines)</RustPtyNativeStampHash>
+
+      <RustPtyNativeUpToDate>false</RustPtyNativeUpToDate>
+      <RustPtyNativeUpToDate Condition="Exists('$(RustPtyNativeCargoOutput)')
+        and '$(RustPtyNativeStampHash)' != ''
+        and '$(RustPtyNativeStampHash)' == '$(RustPtyNativeInputsHash)'">true</RustPtyNativeUpToDate>
+      <!-- Linux consumes the staged copy, so a missing one is out of date even when cargo's own
+           output is current - the shape a cache that restored target\release but not
+           target_linux\release leaves behind. -->
+      <RustPtyNativeUpToDate Condition="'$(RustPtyNativeStagedOutput)' != ''
+        and !Exists('$(RustPtyNativeStagedOutput)')">false</RustPtyNativeUpToDate>
+    </PropertyGroup>
+  </Target>
+
+  <!-- The cargo invocation, split out from BuildRustNative so the up-to-date property can
+       actually gate it. MSBuild evaluates a target's Condition *before* building that target's
+       DependsOnTargets, so a property a dependency computes cannot appear in the condition of
+       the target depending on it - and the result is a check that silently never fires rather
+       than an error. Ordering it as the second dependency fixes that: by the time this target's
+       own Condition is evaluated, CheckRustNativeUpToDate has already run. -->
+  <Target Name="RunCargoBuildRustNative"
+    Condition="'$(RustPtyNativeCargoOutput)' != ''
+      and '$(RustPtyNativeUpToDate)' != 'true'">
 
     <Message Importance="high"
       Text="[RustNative] Building Rust native library in: $(NativeProjectDir)" />
@@ -96,9 +163,33 @@
       StandardOutputImportance="High"
       StandardErrorImportance="High" />
 
+    <Copy Condition="'$(RustPtyNativeStagedOutput)' != ''"
+      SourceFiles="$(RustPtyNativeCargoOutput)"
+      DestinationFiles="$(RustPtyNativeStagedOutput)"
+      SkipUnchangedFiles="true" />
+
+    <!-- Written only after cargo succeeds, so a failed build leaves the tree out of date and the
+         next build retries instead of trusting a binary that was never produced. -->
+    <WriteLinesToFile File="$(RustPtyNativeStamp)"
+      Lines="$(RustPtyNativeInputsHash)"
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true" />
+
     <Message Importance="high"
       Text="[RustNative] Build complete." />
   </Target>
+
+  <!-- Kept under the original name: PrepareForBuild hooks here, and
+       IncludeNativeLibrariesInOutput below depends on it. The environment guards live here so
+       that a design-time build or SKIP_RUST_NATIVE_BUILD=1 skips the hashing too, not just the
+       cargo call. -->
+  <Target Name="BuildRustNative"
+    BeforeTargets="PrepareForBuild"
+    DependsOnTargets="CheckRustNativeUpToDate;RunCargoBuildRustNative"
+    Condition="'$(DesignTimeBuild)' != 'true'
+      and '$(IsCrossTargetingBuild)' != 'true'
+      and '$(SKIP_RUST_NATIVE_BUILD)' != '1'
+      and '$(RustPtyNativeCargoOutput)' != ''" />
 
   <Target Name="BuildRustSshNative"
     BeforeTargets="PrepareForBuild"

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -1056,7 +1056,7 @@ namespace NovaTerminal.Pty
                     // The cost of this ordering is that subscribers observe the exit a few
                     // microseconds before the handle is released. That is the lesser evil: a
                     // brief window versus a permanently wrong exit code.
-                    TryNotifyExit(ReadFailureExitCode);
+                    TryNotifyExitSafely(() => ReadFailureExitCode);
 
                     // Then tear down. Reporting the exit alone would leave the UI recording
                     // a terminated session while the child process, the writer thread and
@@ -1182,7 +1182,9 @@ namespace NovaTerminal.Pty
                 PtyLogger.Error($"[RustPtySession] ProcessLoop terminated by unhandled exception: {ex}");
             }
             // The child's real status, waited for briefly if EOF got here first (#313, #323).
-            TryNotifyExit(ResolveExitCodeForNotification());
+            // Guarded: this line runs after the catch-alls above, so it is the one place in this
+            // loop where a throw would escape the thread. See TryNotifyExitSafely.
+            TryNotifyExitSafely(ResolveExitCodeForNotification);
         }
 
         public void SendInput(string input)
@@ -1340,7 +1342,7 @@ namespace NovaTerminal.Pty
             // No bounded wait here, unlike ProcessLoop (#323): reaching this line means the pane
             // is being torn down, so the user is closing a tab and a snappy close matters more
             // than an exit code nobody will look at.
-            TryNotifyExit(ChildExitObserved ? Volatile.Read(ref _childExitCode) : 0);
+            TryNotifyExitSafely(() => ChildExitObserved ? Volatile.Read(ref _childExitCode) : 0);
         }
 
         /// Observes the injection task's outcome and removes its script if the shell
@@ -1392,6 +1394,35 @@ namespace NovaTerminal.Pty
             {
                 // Best effort: a leftover temp script must never fail a disposal.
                 PtyLogger.Warning($"[RustPtySession] PS init script cleanup failed: {ex.Message}");
+            }
+        }
+
+        /// Resolves and notifies the exit without letting the attempt escape the caller.
+        ///
+        /// Both halves can throw for reasons the session does not control: the resolver polls the
+        /// native layer, and TryNotifyExit raises OnExit, which is arbitrary subscriber code. This
+        /// class deliberately does not guard event invocation itself - OnOutputReceived is raised
+        /// bare too - because the background loops' catch-alls are where subscriber exceptions are
+        /// contained. The exit notification was the one call sitting outside that protection, and
+        /// the cost differed by caller:
+        ///
+        ///   * ProcessLoop calls it after its try/catch, so a throw escaped a dedicated thread -
+        ///     terminating the process rather than the session.
+        ///   * ReadLoop calls it from its `finally` on the read-failure path, ahead of the
+        ///     teardown that cancels the token and completes the output queue. A throw escaped the
+        ///     whole try statement and took that teardown with it, leaving the session half-alive
+        ///     with ProcessLoop parked on a queue nobody would complete.
+        ///   * Dispose calls it last, where nothing is skipped - but a throwing handler still has
+        ///     no business making `using (session)` throw.
+        private void TryNotifyExitSafely(Func<int> resolveCode)
+        {
+            try
+            {
+                TryNotifyExit(resolveCode());
+            }
+            catch (Exception ex)
+            {
+                PtyLogger.Error($"[RustPtySession] Exit notification failed: {ex}");
             }
         }
 

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -99,6 +99,10 @@ namespace NovaTerminal.Pty
         private int _childExitObserved;
         private int _childExitCode;
 
+        // Set the first time the child-status probe fails, so the condition is reported once
+        // per session instead of once per poll. See the catch in TryCaptureChildExit.
+        private int _probeFailureLogged;
+
         /// True once the child shell has been observed to have exited. The read loop uses
         /// this to stop counting read failures: once the shell is gone, a failing read is
         /// the expected consequence of cancelling it, not a session failure worth reporting
@@ -203,8 +207,25 @@ namespace NovaTerminal.Pty
                 // pty_try_get_exit_code, throws EntryPointNotFoundException from this call. A
                 // session cannot repair its own native library; it can say so and carry on with
                 // the status unknown.
-                PtyLogger.Error(
-                    $"[RustPtySession] Child status probe failed; treating the child's exit status as unknown: {ex}");
+                // Logged once per session, not once per call. A missing export does not heal, and
+                // the watcher polls every ChildExitPollIntervalMs for the life of the pane (the EOF
+                // resolver adds one every ChildStatusPollMs on top), so formatting the full
+                // exception every time turned graceful degradation into roughly five error records
+                // a second, indefinitely, for a single idle affected pane - a flood that buries the
+                // rest of the log precisely while the session is coping (Codex review on #341).
+                //
+                // Suppressing rather than demoting to Debug: the sink's minimum level is the host's
+                // choice, so a Debug line is still a flood wherever debug logging is on. The first
+                // message says that further failures are silent, so the log does not imply the
+                // condition healed.
+                if (Interlocked.Exchange(ref _probeFailureLogged, 1) == 0)
+                {
+                    PtyLogger.Error(
+                        "[RustPtySession] Child status probe failed; treating the child's exit status as"
+                        + " unknown. Further probe failures on this session are not logged: "
+                        + ex);
+                }
+
                 return false;
             }
         }

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -171,7 +171,7 @@ namespace NovaTerminal.Pty
 
             try
             {
-                if (Native.pty_try_get_exit_code(_handle, out int code) != 1)
+                if (_tryGetExitCode(_handle, out int code) != 1)
                 {
                     return false;
                 }
@@ -184,6 +184,28 @@ namespace NovaTerminal.Pty
             catch (ObjectDisposedException)
             {
                 return false; // handle released under us — Dispose owns the teardown
+            }
+            catch (Exception ex)
+            {
+                // An interop failure is a status we could not learn, not a session failure -
+                // exactly what a native -1 already means here, and already handled as such
+                // downstream. Letting it escape cost far more than the status, because this is
+                // called from three places: the exit watcher, the read loop's EOF/error
+                // branches, and ResolveExitCodeForNotification - whose call site in ProcessLoop
+                // sits *outside* that loop's try/catch. So a single throw killed the watcher on
+                // its first tick (silently reverting the session to the EOF-only detection #313
+                // exists to replace) and then took the exit notification with it as an unhandled
+                // exception on a dedicated thread, which a test host reports as a catastrophic
+                // failure of the entire run rather than as anything to do with this session.
+                //
+                // The failure that prompted this: a stale rusty_pty build in a test output
+                // directory, exporting every other pty_* function but predating
+                // pty_try_get_exit_code, throws EntryPointNotFoundException from this call. A
+                // session cannot repair its own native library; it can say so and carry on with
+                // the status unknown.
+                PtyLogger.Error(
+                    $"[RustPtySession] Child status probe failed; treating the child's exit status as unknown: {ex}");
+                return false;
             }
         }
 
@@ -606,6 +628,16 @@ namespace NovaTerminal.Pty
 
         private readonly PtyReadDelegate _readFromPty;
 
+        /// The native child-status probe, injectable for the same reason as
+        /// <see cref="PtyReadDelegate"/>: `pty_try_get_exit_code` is a static P/Invoke, so
+        /// without a seam here the interop-failure handling in
+        /// <see cref="TryCaptureChildExit"/> is unreachable from a test. Returns 1 with
+        /// `exitCode` set once the child has gone, 0 while it is running, and -1 when the
+        /// status cannot be determined.
+        internal delegate int PtyTryGetExitCodeDelegate(PtySafeHandle handle, out int exitCode);
+
+        private readonly PtyTryGetExitCodeDelegate _tryGetExitCode;
+
         public RustPtySession(
             string shellCommand,
             int cols = 120,
@@ -622,15 +654,18 @@ namespace NovaTerminal.Pty
                 cwd,
                 skipPowerShellPostLaunchInit,
                 environmentOverrides,
-                readFromPty: null)
+                readFromPty: null,
+                tryGetExitCode: null)
         {
         }
 
-        /// Test-facing constructor. Identical to the public one except that the PTY read
-        /// call can be substituted: `Native.pty_read` is a static P/Invoke, so without a
-        /// seam here the read loop's error handling (bounded retry, teardown, failure exit
-        /// code) is unreachable from a test. The session still spawns a real shell, so the
-        /// teardown path is exercised against a real handle and a real child process.
+        /// Test-facing constructor. Identical to the public one except that the two native
+        /// calls the background loops depend on can be substituted: `Native.pty_read` and
+        /// `Native.pty_try_get_exit_code` are static P/Invokes, so without a seam here the
+        /// read loop's error handling (bounded retry, teardown, failure exit code) and the
+        /// child-status probe's interop-failure handling are unreachable from a test. The
+        /// session still spawns a real shell, so the teardown path is exercised against a
+        /// real handle and a real child process.
         internal RustPtySession(
             string shellCommand,
             int cols,
@@ -639,7 +674,8 @@ namespace NovaTerminal.Pty
             string? cwd,
             bool skipPowerShellPostLaunchInit,
             IReadOnlyDictionary<string, string>? environmentOverrides,
-            PtyReadDelegate? readFromPty)
+            PtyReadDelegate? readFromPty,
+            PtyTryGetExitCodeDelegate? tryGetExitCode = null)
         {
             // Validate before anything else: everything below either marshals these strings
             // to the native layer or derives from them. A bad value must fail here with a
@@ -657,6 +693,7 @@ namespace NovaTerminal.Pty
             }
 
             _readFromPty = readFromPty ?? Native.pty_read;
+            _tryGetExitCode = tryGetExitCode ?? Native.pty_try_get_exit_code;
             ShellCommand = shellCommand;
             ShellArguments = args;
             _cols = cols;

--- a/tests/NovaTerminal.App.Tests/PtyChildExitDetectionTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtyChildExitDetectionTests.cs
@@ -130,35 +130,6 @@ namespace NovaTerminal.Tests
             Assert.True(session.IsProcessRunning, "a shell sitting at its prompt is still running");
         }
 
-        /// Tees <see cref="NovaTerminal.Pty.PtyLogger"/> into a string for the duration of a
-        /// test, so an assertion can attach what the session actually did. These sessions
-        /// drive real shells, and their failures are timing-shaped: without the log a failure
-        /// tells you the code was wrong and nothing about why.
-        private sealed class PtyLogCapture : IDisposable
-        {
-            private readonly System.Text.StringBuilder _log = new();
-            private readonly Action<NovaTerminal.Pty.PtyLogLevel, string>? _previous;
-
-            private PtyLogCapture()
-            {
-                _previous = NovaTerminal.Pty.PtyLogger.Sink;
-                NovaTerminal.Pty.PtyLogger.Sink = (level, message) =>
-                {
-                    lock (_log) { _log.AppendLine($"[{level}] {message}"); }
-                    _previous?.Invoke(level, message);
-                };
-            }
-
-            public static PtyLogCapture Attach() => new();
-
-            public void Dispose() => NovaTerminal.Pty.PtyLogger.Sink = _previous;
-
-            public override string ToString()
-            {
-                lock (_log) { return _log.ToString(); }
-            }
-        }
-
         private static RustPtySession NewSession()
         {
             return new RustPtySession(

--- a/tests/NovaTerminal.App.Tests/PtyChildStatusProbeFailureTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtyChildStatusProbeFailureTests.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using NovaTerminal.Pty;
+using NovaTerminal.Shell;
+using Xunit;
+
+namespace NovaTerminal.Tests
+{
+    /// <summary>
+    /// The child-status probe must survive a native-interop failure.
+    ///
+    /// <c>TryCaptureChildExit</c> caught only <see cref="ObjectDisposedException"/>, so any
+    /// other interop failure — the honest example being an
+    /// <see cref="EntryPointNotFoundException"/> from a <c>rusty_pty</c> build that predates
+    /// the <c>pty_try_get_exit_code</c> export — escaped into whichever loop had called it.
+    /// The loops each have a catch-all, so the visible result was not a clean failure but a
+    /// dead exit watcher and a "terminated by unhandled exception" line blaming the loop,
+    /// which reads as a code regression rather than the environment problem it is.
+    ///
+    /// A missing export is exactly the kind of thing a session cannot fix and must not be
+    /// destroyed by: the status is simply unknown, which is a state this class already
+    /// handles (a native -1 means the same thing).
+    /// </summary>
+    [Collection(PtyRealShellCollection.Name)]
+    public class PtyChildStatusProbeFailureTests
+    {
+        /// The substituted probe's failure. Chosen because it is the real one: a stale native
+        /// library exports every other pty_* function, so the session starts, spawns a shell
+        /// and reads normally — and then fails on this one call.
+        private static RustPtySession.PtyTryGetExitCodeDelegate FailingProbe(Action? onCall = null)
+        {
+            return (RustPtySession.PtySafeHandle handle, out int exitCode) =>
+            {
+                onCall?.Invoke();
+                exitCode = 0;
+                throw new EntryPointNotFoundException(
+                    "Unable to find an entry point named 'pty_try_get_exit_code' in DLL 'rusty_pty'.");
+            };
+        }
+
+        /// A read that keeps the session healthy and busy. The success branch never probes,
+        /// so with this substitute every probe call is the exit watcher's own.
+        private static int HealthyRead(RustPtySession.PtySafeHandle handle, byte[] buffer, int length)
+        {
+            Thread.Sleep(25);
+            buffer[0] = (byte)'x';
+            return 1;
+        }
+
+        [Fact]
+        [Trait("Category", "PtySmoke")]
+        public async Task AnInteropFailureDoesNotKillTheChildExitWatcher()
+        {
+            // The watcher polls every ChildExitPollIntervalMs for the life of the session. A
+            // probe failure it cannot contain kills it on the first tick, and the session
+            // silently regresses to EOF-only exit detection — the #313 bug, back again, with
+            // nothing in the pane to say so.
+            int probes = 0;
+            using var session = NewSession(
+                readFromPty: HealthyRead,
+                tryGetExitCode: FailingProbe(() => Interlocked.Increment(ref probes)));
+
+            await WaitUntilAsync(() => Volatile.Read(ref probes) >= 3, TimeSpan.FromSeconds(10));
+
+            Assert.True(
+                Volatile.Read(ref probes) >= 3,
+                $"the watcher stopped polling after {Volatile.Read(ref probes)} probe(s); "
+                + "a failing probe must not end the watch");
+        }
+
+        [Fact]
+        [Trait("Category", "PtySmoke")]
+        public async Task AnInteropFailureIsLoggedAndTheEndOfStreamStillReportsAnExit()
+        {
+            // The other half: the status resolver polls the same probe on its way to
+            // notifying the exit, and that call site sits outside ProcessLoop's try/catch —
+            // so a probe that throws took the exit notification with it.
+            using var log = PtyLogCapture.Attach();
+            using var session = NewSession(
+                readFromPty: (handle, buffer, length) => 0, // EOF immediately
+                tryGetExitCode: FailingProbe());
+
+            int? code = await WaitForExitAsync(session, TimeSpan.FromSeconds(20));
+
+            string logText = log.ToString();
+
+            // Unknown, so 0 — the same answer a native -1 produces, which is the point: an
+            // interop failure is a status we could not learn, not a session failure.
+            Assert.True(
+                code == 0,
+                $"expected a reported exit of 0, got {code?.ToString() ?? "no exit"}.\nPTY log:\n{logText}");
+
+            // Logged, because "we asked and the native layer could not be called" is the one
+            // piece of information that distinguishes this from an ordinary unknown status.
+            Assert.Contains("Child status probe failed", logText, StringComparison.Ordinal);
+
+            // And not misattributed to whichever loop happened to be holding the call.
+            Assert.DoesNotContain("terminated by unhandled exception", logText, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        [Trait("Category", "PtySmoke")]
+        public async Task ADisposedHandleIsStillTreatedAsTeardownRatherThanAFailure()
+        {
+            // ObjectDisposedException keeps its own quiet branch: it means Dispose released
+            // the handle under us and owns the teardown. Widening the catch must not start
+            // logging an error on every ordinary close of a pane.
+            using var log = PtyLogCapture.Attach();
+
+            using (var session = NewSession(
+                readFromPty: HealthyRead,
+                tryGetExitCode: (RustPtySession.PtySafeHandle handle, out int exitCode) =>
+                {
+                    exitCode = 0;
+                    throw new ObjectDisposedException(nameof(RustPtySession.PtySafeHandle));
+                }))
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1));
+            }
+
+            await Task.Delay(200);
+
+            Assert.DoesNotContain("Child status probe failed", log.ToString(), StringComparison.Ordinal);
+        }
+
+        private static RustPtySession NewSession(
+            RustPtySession.PtyReadDelegate readFromPty,
+            RustPtySession.PtyTryGetExitCodeDelegate tryGetExitCode)
+        {
+            // A real shell is still spawned so the teardown acts on a real handle; only the
+            // two native calls the background loops make are substituted.
+            return new RustPtySession(
+                ShellHelper.GetDefaultShell(),
+                80,
+                24,
+                args: null,
+                cwd: null,
+                // Irrelevant here, and its SendInput would race the substituted read loop.
+                skipPowerShellPostLaunchInit: true,
+                environmentOverrides: null,
+                readFromPty: readFromPty,
+                tryGetExitCode: tryGetExitCode);
+        }
+
+        private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+        {
+            var sw = Stopwatch.StartNew();
+            while (!condition() && sw.Elapsed < timeout)
+            {
+                await Task.Delay(25);
+            }
+        }
+
+        /// Returns the reported exit code, or null if none arrived within the timeout. Falls
+        /// back to <see cref="RustPtySession.ExitCode"/> so an exit reported before the
+        /// handler was attached still counts — the loops start in the constructor.
+        private static async Task<int?> WaitForExitAsync(RustPtySession session, TimeSpan timeout)
+        {
+            var exited = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            void OnExit(int code) => exited.TrySetResult(code);
+
+            session.OnExit += OnExit;
+            try
+            {
+                if (session.ExitCode.HasValue)
+                {
+                    return session.ExitCode;
+                }
+
+                await Task.WhenAny(exited.Task, Task.Delay(timeout));
+                return exited.Task.IsCompletedSuccessfully ? exited.Task.Result : session.ExitCode;
+            }
+            finally
+            {
+                session.OnExit -= OnExit;
+            }
+        }
+    }
+}

--- a/tests/NovaTerminal.App.Tests/PtyChildStatusProbeFailureTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtyChildStatusProbeFailureTests.cs
@@ -72,6 +72,32 @@ namespace NovaTerminal.Tests
 
         [Fact]
         [Trait("Category", "PtySmoke")]
+        public async Task ARepeatedInteropFailureIsLoggedOnceNotOnEveryPoll()
+        {
+            // A missing export does not heal. The watcher polls every ChildExitPollIntervalMs
+            // for the life of the pane, so formatting the full exception on each call turns
+            // graceful degradation into ~5 error records a second, indefinitely, for one idle
+            // affected pane - and the EOF resolver adds one every ChildStatusPollMs on top.
+            // Report the condition once and let the watch carry on quietly.
+            using var log = PtyLogCapture.Attach();
+
+            int probes = 0;
+            using var session = NewSession(
+                readFromPty: HealthyRead,
+                tryGetExitCode: FailingProbe(() => Interlocked.Increment(ref probes)));
+
+            await WaitUntilAsync(() => Volatile.Read(ref probes) >= 5, TimeSpan.FromSeconds(15));
+
+            int observedProbes = Volatile.Read(ref probes);
+            Assert.True(
+                observedProbes >= 5,
+                $"only {observedProbes} probe(s) happened; the watcher must poll repeatedly for this to mean anything");
+
+            Assert.Equal(1, CountOccurrences(log.ToString(), "Child status probe failed"));
+        }
+
+        [Fact]
+        [Trait("Category", "PtySmoke")]
         public async Task AnInteropFailureIsLoggedAndTheEndOfStreamStillReportsAnExit()
         {
             // The other half: the status resolver polls the same probe on its way to
@@ -142,6 +168,19 @@ namespace NovaTerminal.Tests
                 environmentOverrides: null,
                 readFromPty: readFromPty,
                 tryGetExitCode: tryGetExitCode);
+        }
+
+        private static int CountOccurrences(string haystack, string needle)
+        {
+            int count = 0;
+            for (int i = haystack.IndexOf(needle, StringComparison.Ordinal);
+                 i >= 0;
+                 i = haystack.IndexOf(needle, i + needle.Length, StringComparison.Ordinal))
+            {
+                count++;
+            }
+
+            return count;
         }
 
         private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)

--- a/tests/NovaTerminal.App.Tests/PtyExitNotificationFailureTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtyExitNotificationFailureTests.cs
@@ -38,26 +38,24 @@ namespace NovaTerminal.Tests
             // (and only) caller of TryNotifyExit. This isolates ProcessLoop's call site.
             using var log = PtyLogCapture.Attach();
 
-            int eof = 0;
+            // A real pty_read parks until the shell writes something or the stream ends, so the
+            // substitute parks too - on a gate the test opens. That ordering is the whole test:
+            // the loops start in the constructor, so a substitute that reports EOF straight away
+            // can notify the exit before the handler is attached, leaving the test asserting
+            // nothing. A gate makes "not until I say so" explicit instead of inferring it from a
+            // sleep being longer than the test's own setup.
+            using var readyForEof = new ManualResetEventSlim(false);
             using var session = NewSession((handle, buffer, length) =>
             {
-                if (Volatile.Read(ref eof) == 1)
-                {
-                    return 0;
-                }
-
-                Thread.Sleep(25);
-                buffer[0] = (byte)'x';
-                return 1;
+                // Bounded so a failing test cannot park this thread indefinitely.
+                readyForEof.Wait(TimeSpan.FromSeconds(10));
+                return 0;
             });
 
             Thread process = await WaitForLoopThreadAsync(() => session.ProcessLoopThread);
 
-            // Subscribe before releasing the EOF: the loops start in the constructor, so a read
-            // substitute that reports EOF immediately can notify the exit before the handler is
-            // attached, and the test would assert nothing at all.
             session.OnExit += _ => throw new InvalidOperationException("exit subscriber blew up");
-            Volatile.Write(ref eof, 1);
+            readyForEof.Set();
 
             await WaitUntilAsync(() => !process.IsAlive, TimeSpan.FromSeconds(20));
 
@@ -77,23 +75,21 @@ namespace NovaTerminal.Tests
             // the site under test and ProcessLoop's later call is a no-op.
             using var log = PtyLogCapture.Attach();
 
-            int failReads = 0;
+            // Parked until the test opens the gate, then failing for good - so the read loop
+            // exhausts MaxConsecutiveReadErrors and reaches its `finally` only after the throwing
+            // handler is attached. The loop's own bounded retry paces the failures; nothing here
+            // needs to.
+            using var readyToFail = new ManualResetEventSlim(false);
             using var session = NewSession((handle, buffer, length) =>
             {
-                if (Volatile.Read(ref failReads) == 1)
-                {
-                    return -1;
-                }
-
-                Thread.Sleep(25);
-                buffer[0] = (byte)'x';
-                return 1;
+                readyToFail.Wait(TimeSpan.FromSeconds(10));
+                return -1;
             });
 
             Thread process = await WaitForLoopThreadAsync(() => session.ProcessLoopThread);
 
             session.OnExit += _ => throw new InvalidOperationException("exit subscriber blew up");
-            Volatile.Write(ref failReads, 1);
+            readyToFail.Set();
 
             await WaitUntilAsync(() => !process.IsAlive, TimeSpan.FromSeconds(30));
 

--- a/tests/NovaTerminal.App.Tests/PtyExitNotificationFailureTests.cs
+++ b/tests/NovaTerminal.App.Tests/PtyExitNotificationFailureTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using NovaTerminal.Pty;
+using NovaTerminal.Shell;
+using Xunit;
+
+namespace NovaTerminal.Tests
+{
+    /// <summary>
+    /// Notifying the exit must not be able to kill the thread doing it.
+    ///
+    /// <c>OnExit</c> raises arbitrary subscriber code, exactly like <c>OnOutputReceived</c> — and
+    /// this class deliberately does not guard either invocation, because the loops' own catch-alls
+    /// are where subscriber exceptions are contained (see the comment on ProcessLoop). The exit
+    /// notification was the one call that sat *outside* that protection at both of the sites that
+    /// run on a dedicated thread:
+    ///
+    ///   * ProcessLoop calls it after its try/catch, so a throwing subscriber escaped the thread
+    ///     entirely — an unhandled exception on a dedicated thread, which tears down the process
+    ///     rather than the session.
+    ///   * ReadLoop calls it from its `finally` on the read-failure path, *before* the teardown
+    ///     that cancels the token and completes the output queue. A throw there escaped the whole
+    ///     try statement and took the teardown with it, so the session was left half-alive with
+    ///     ProcessLoop parked on a queue nobody would ever complete.
+    ///
+    /// Both are reachable from the public API by one badly behaved event handler.
+    /// </summary>
+    [Collection(PtyRealShellCollection.Name)]
+    public class PtyExitNotificationFailureTests
+    {
+        [Fact]
+        [Trait("Category", "PtySmoke")]
+        public async Task AThrowingExitSubscriberDoesNotEscapeTheProcessLoop()
+        {
+            // EOF, so ReadLoop's finally does not claim the exit and ProcessLoop is the first
+            // (and only) caller of TryNotifyExit. This isolates ProcessLoop's call site.
+            using var log = PtyLogCapture.Attach();
+
+            int eof = 0;
+            using var session = NewSession((handle, buffer, length) =>
+            {
+                if (Volatile.Read(ref eof) == 1)
+                {
+                    return 0;
+                }
+
+                Thread.Sleep(25);
+                buffer[0] = (byte)'x';
+                return 1;
+            });
+
+            Thread process = await WaitForLoopThreadAsync(() => session.ProcessLoopThread);
+
+            // Subscribe before releasing the EOF: the loops start in the constructor, so a read
+            // substitute that reports EOF immediately can notify the exit before the handler is
+            // attached, and the test would assert nothing at all.
+            session.OnExit += _ => throw new InvalidOperationException("exit subscriber blew up");
+            Volatile.Write(ref eof, 1);
+
+            await WaitUntilAsync(() => !process.IsAlive, TimeSpan.FromSeconds(20));
+
+            string logText = log.ToString();
+            Assert.Contains("Exit notification failed", logText, StringComparison.Ordinal);
+            Assert.False(
+                process.IsAlive,
+                $"ProcessLoop must exit normally after a throwing subscriber.\nPTY log:\n{logText}");
+        }
+
+        [Fact]
+        [Trait("Category", "PtySmoke")]
+        public async Task AThrowingExitSubscriberDoesNotSkipTheReadFailureTeardown()
+        {
+            // Repeated read failures make ReadLoop give up and claim the exit code from its
+            // `finally`, ahead of the teardown. TryNotifyExit is first-caller-wins, so this is
+            // the site under test and ProcessLoop's later call is a no-op.
+            using var log = PtyLogCapture.Attach();
+
+            int failReads = 0;
+            using var session = NewSession((handle, buffer, length) =>
+            {
+                if (Volatile.Read(ref failReads) == 1)
+                {
+                    return -1;
+                }
+
+                Thread.Sleep(25);
+                buffer[0] = (byte)'x';
+                return 1;
+            });
+
+            Thread process = await WaitForLoopThreadAsync(() => session.ProcessLoopThread);
+
+            session.OnExit += _ => throw new InvalidOperationException("exit subscriber blew up");
+            Volatile.Write(ref failReads, 1);
+
+            await WaitUntilAsync(() => !process.IsAlive, TimeSpan.FromSeconds(30));
+
+            string logText = log.ToString();
+            Assert.Contains("Exit notification failed", logText, StringComparison.Ordinal);
+
+            // The real damage a throw did here was not the lost notification but the skipped
+            // teardown: without _cts.Cancel() and CompleteAdding(), ProcessLoop stays blocked on
+            // the output queue for the life of the process. A dead ProcessLoop thread is the
+            // observable proof that the teardown ran anyway.
+            Assert.False(
+                process.IsAlive,
+                $"the read-failure teardown must still run after a throwing subscriber.\nPTY log:\n{logText}");
+            Assert.Equal(RustPtySession.ReadFailureExitCode, session.ExitCode);
+        }
+
+        private static RustPtySession NewSession(RustPtySession.PtyReadDelegate readFromPty)
+        {
+            return new RustPtySession(
+                ShellHelper.GetDefaultShell(),
+                80,
+                24,
+                args: null,
+                cwd: null,
+                // Irrelevant here, and its SendInput would race the substituted read loop.
+                skipPowerShellPostLaunchInit: true,
+                environmentOverrides: null,
+                readFromPty: readFromPty);
+        }
+
+        private static async Task<Thread> WaitForLoopThreadAsync(Func<Thread?> accessor)
+        {
+            await WaitUntilAsync(() => accessor() is not null, TimeSpan.FromSeconds(10));
+            return accessor() ?? throw new TimeoutException("the PTY loop thread did not start");
+        }
+
+        private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+        {
+            var sw = Stopwatch.StartNew();
+            while (!condition() && sw.Elapsed < timeout)
+            {
+                await Task.Delay(25);
+            }
+        }
+    }
+}

--- a/tests/NovaTerminal.App.Tests/PtyLogCapture.cs
+++ b/tests/NovaTerminal.App.Tests/PtyLogCapture.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Text;
+using NovaTerminal.Pty;
+
+namespace NovaTerminal.Tests
+{
+    /// <summary>
+    /// Tees <see cref="PtyLogger"/> into a string for the duration of a test, so an
+    /// assertion can attach what the session actually did — and so a test can assert on the
+    /// diagnostics themselves, which for the PTY layer are part of the contract: several
+    /// failure paths are *defined* as "log it and carry on".
+    ///
+    /// These sessions drive real shells and their failures are timing-shaped: without the
+    /// log a failure tells you the code was wrong and nothing about why.
+    ///
+    /// <see cref="PtyLogger.Sink"/> is process-global, so every class using this must be in
+    /// <see cref="PtyRealShellCollection"/> — otherwise two parallel classes swap the sink
+    /// under each other and Dispose restores the wrong one.
+    /// </summary>
+    internal sealed class PtyLogCapture : IDisposable
+    {
+        private readonly StringBuilder _log = new();
+        private readonly Action<PtyLogLevel, string>? _previous;
+
+        private PtyLogCapture()
+        {
+            _previous = PtyLogger.Sink;
+            PtyLogger.Sink = (level, message) =>
+            {
+                lock (_log) { _log.AppendLine($"[{level}] {message}"); }
+                _previous?.Invoke(level, message);
+            };
+        }
+
+        public static PtyLogCapture Attach() => new();
+
+        public void Dispose() => PtyLogger.Sink = _previous;
+
+        public override string ToString()
+        {
+            lock (_log) { return _log.ToString(); }
+        }
+    }
+}


### PR DESCRIPTION
A stale `rusty_pty.dll` in a test output directory threw `EntryPointNotFoundException` and took unrelated tests down with it. Three commits: contain the interop failure, stop the exit notification escaping its thread, and fix the build-level reason the stale DLL survived in the first place.

Each commit stands alone and is reviewable on its own.

## 1. `46790cd` — contain a native-interop failure in the child-status probe

`TryCaptureChildExit` caught only `ObjectDisposedException`, so any other interop failure from `pty_try_get_exit_code` escaped. The real one: a `rusty_pty` build exporting every other `pty_*` function but predating this export, which throws `EntryPointNotFoundException`.

The blast radius was much wider than the lost status, because the probe has three callers:

- the **exit watcher**, which died on its first tick — silently reverting the session to the EOF-only exit detection #313 exists to replace;
- the **read loop**'s EOF and error branches, which logged the throw as `ReadLoop terminated by unhandled exception`, blaming the loop;
- **`ResolveExitCodeForNotification`**, whose call site in `ProcessLoop` sat outside that loop's `try`/`catch` — so the throw escaped a dedicated thread and no exit was ever reported.

That last one is the amplification mechanism. The test host calls it a catastrophic failure of the whole run:

```
[FATAL ERROR] System.EntryPointNotFoundException
Catastrophic failure: ... Unable to find an entry point named 'pty_try_get_exit_code'
```

Which is how an environment problem became cross-test collateral damage that reads as a code regression — `PtyThreadLifecycleTests.Dispose_WhileReadBlocked_JoinsLoopThreadsPromptly` being the visible casualty, since its assertion is precisely that the loop thread exited cleanly.

An interop failure is a status we could not learn, not a session failure — exactly what a native `-1` already means, and already handled as such downstream. So log it and report "unknown". `ObjectDisposedException` keeps its own quiet branch: it means `Dispose` owns the teardown, and logging an error there would fire on every ordinary close of a pane.

The native status probe is now injectable alongside the existing `pty_read` seam, since a static P/Invoke leaves this path otherwise unreachable from a test. `PtyLogCapture` moves out of `PtyChildExitDetectionTests` into its own file now that a second class asserts on the diagnostics.

## 2. `b5ec03a` — stop the exit notification escaping the thread that raises it

Found while fixing the above. `OnExit` raises arbitrary subscriber code, exactly like `OnOutputReceived`, and this class deliberately guards neither invocation — the background loops' catch-alls are where subscriber exceptions get contained. The exit notification was the one call sitting outside that protection, at all three of its call sites:

| Call site | What an escape cost |
|---|---|
| `ProcessLoop` (after its catch-alls) | Escaped a dedicated thread → process down, not session down |
| `ReadLoop`'s `finally` (read-failure path) | Escaped the whole `try` and **took the teardown with it** — no `_cts.Cancel()`, no `CompleteAdding()`, leaving `ProcessLoop` parked forever on a queue nobody would complete |
| `Dispose` (last statement) | Nothing skipped, but a throwing handler still made `using (session)` throw |

The `ReadLoop` one is the interesting find: the crash was the *second*-worst consequence.

All three now route through one `TryNotifyExitSafely(Func<int>)`. Taking a `Func` rather than an `int` is load-bearing — `ResolveExitCodeForNotification` polls the native layer, so the resolution has to be inside the guard too.

Deliberately **not** guarding `OnExit?.Invoke` inside `TryNotifyExit`: `EmitOutput` raises `OnOutputReceived` bare and relies on `ProcessLoop`'s catch-all. Guarding at the invocation site would fix the symptom while contradicting the design.

Both dedicated-thread sites are reachable from the public API by one badly behaved event handler, so both get a test. The read-failure test asserts on a dead `ProcessLoop` thread rather than on the logged error, because the skipped teardown — not the lost notification — was the real damage.

## 3. `8462e69` — rebuild `rusty_pty` when its Rust source changes

The root cause of the stale DLL. `BuildRustNative` was conditioned on `!Exists(<the native library>)`, so it ran **once** in a fresh tree and never again. Editing `native/src/lib.rs` did not rebuild the library, and `PreserveNewest` then faithfully copied the unchanged binary onward, so every `bin/` directory kept a stale `rusty_pty` for as long as the file existed. The sibling `BuildRustSshNative` had proper `Inputs`/`Outputs` all along.

Reproduced before changing anything: touched `lib.rs`, built, and the build reported success while leaving both the source DLL and the test-output copy untouched and four days older than the source.

The check is now over content, not existence. **Not** MSBuild's `Inputs`/`Outputs`, because that compares timestamps: `actions/checkout` gives every source file a fresh mtime while `actions/cache` restores the binary with its original one. On a CI cache hit — the common case — it would call a content-identical binary stale and recompile all 36 crates on a runner whose cargo registry cache was skipped *precisely because* the binary was already cached, on the same dep-fetch path that already flakes. Hashing the inputs agrees with what CI's cache key already asserts (it is keyed on `hashFiles` of these same files), so a cache hit stays free.

Two things fell out of doing it properly:

- **The cargo call moved into its own target.** MSBuild evaluates a target's `Condition` *before* building that target's `DependsOnTargets`, so a property a dependency computes cannot gate the target depending on it — and it fails silently as a check that never fires, which is what the first attempt here did.
- **On Linux the build now stages the `.so` into `target_linux/release`**, the path the `Content` items actually consume. CI did this with an explicit `cp` and the csproj never did, so a local Linux build left `target_linux` empty, the `Content` item dropped, and the app had no PTY at all. A separate pre-existing bug this closes incidentally.

## Verification

| Suite | Result |
|---|---|
| `Category=PtySmoke` (App.Tests) | 27/27 pass |
| `NovaTerminal.Architecture.Tests` | 35/35 pass |
| App.Tests headless lane (CI's filter) | 1896/1897 pass |
| Full solution build | succeeded, 0 errors |

Every test here was watched failing first, for the expected reason, before the fix that makes it pass.

The one App.Tests failure is `CommandPaletteUsageStoreTests.RecordUse_PersistsCountAcrossReloads`, an `IOException` on a locked `%TEMP%` file. It passes in isolation and lives in a file no commit here touches — a file-lock flake under parallel load. That run also ended in the known #81 headless host-hang after all tests had completed.

Build-target behaviour verified on Windows across the matrix that matters:

- no change → skips cargo entirely
- mtime-only `touch` → still skips (the point of hashing content)
- real source edit → rebuilds **and** propagates the new DLL into `tests/NovaTerminal.App.Tests/bin`
- reverting the edit → rebuilds back

Not verified on Linux or macOS — I have no runner for either. The Linux staging copy and the per-platform output paths are reasoned from CI's own `cp` steps, so ubuntu CI on this PR is the real check on that part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
