### PR TITLE
fix(shell): avoid throwing on case-colliding keys from user-editable JSON

### DIFF
--- a/src/NovaTerminal.App/SettingsWindow.axaml.cs
+++ b/src/NovaTerminal.App/SettingsWindow.axaml.cs
@@ -138,7 +138,17 @@ namespace NovaTerminal
             // Settings editor is local-profiles only; SSH connections are managed in Connection Manager.
             _profilesList = BuildLocalProfilesForEditor(_settings.Profiles);
             _settings.DefaultProfileId = ResolveDefaultLocalProfileId(_settings.DefaultProfileId, _profilesList);
-            _shortcutDraftBindings = new Dictionary<string, string>(_settings.Keybindings, StringComparer.OrdinalIgnoreCase);
+            // Assignment loop, not the `new Dictionary(source, comparer)` copy constructor: that
+            // constructor adds under the *new* comparer and throws ArgumentException when two
+            // source keys collapse. `_settings.Keybindings` comes straight out of settings.json
+            // with the default ordinal comparer, so a hand-edited pair like "Ctrl+A"/"ctrl+a"
+            // survives deserialization and would collapse here -- unguarded, in this constructor,
+            // that means the Settings window fails to open at all. Last one wins instead.
+            _shortcutDraftBindings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (KeyValuePair<string, string> binding in _settings.Keybindings)
+            {
+                _shortcutDraftBindings[binding.Key] = binding.Value;
+            }
 
             PopulateFonts();
             PopulateThemes();

--- a/src/NovaTerminal.App/Shell/Shortcuts/CommandPaletteUsageStore.cs
+++ b/src/NovaTerminal.App/Shell/Shortcuts/CommandPaletteUsageStore.cs
@@ -37,9 +37,23 @@ public sealed class CommandPaletteUsageStore
             Dictionary<string, CommandPaletteUsageEntry>? deserialized = JsonSerializer.Deserialize(
                 json,
                 AppJsonContext.Default.DictionaryStringCommandPaletteUsageEntry);
-            _entries = deserialized is not null
-                ? new Dictionary<string, CommandPaletteUsageEntry>(deserialized, StringComparer.OrdinalIgnoreCase)
-                : new Dictionary<string, CommandPaletteUsageEntry>(StringComparer.OrdinalIgnoreCase);
+            // Rebuilt with an explicit assignment loop rather than the
+            // `new Dictionary(source, comparer)` copy constructor: that constructor adds entries
+            // one by one under the *new* comparer and throws ArgumentException the moment two
+            // source keys collapse to the same key. `deserialized` carries the default ordinal
+            // comparer, so sibling JSON entries "find" and "Find" both survive deserialization
+            // intact and would collapse here. This file is hand-editable, and the catch below
+            // would swallow the throw by discarding the *entire* usage history -- so a
+            // typo-shaped duplicate must degrade to last-one-wins (in source enumeration order)
+            // by plain indexer assignment, which cannot throw.
+            _entries = new Dictionary<string, CommandPaletteUsageEntry>(StringComparer.OrdinalIgnoreCase);
+            if (deserialized is not null)
+            {
+                foreach (KeyValuePair<string, CommandPaletteUsageEntry> kv in deserialized)
+                {
+                    _entries[kv.Key] = kv.Value;
+                }
+            }
         }
         catch
         {

--- a/tests/NovaTerminal.App.Tests/Core/CommandPaletteUsageStoreTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/CommandPaletteUsageStoreTests.cs
@@ -16,7 +16,7 @@ public sealed class CommandPaletteUsageStoreTests
             store.RecordUse("settings", new DateTimeOffset(2026, 5, 26, 12, 0, 0, TimeSpan.Zero));
             store.Save();
             WaitFor(
-                () => File.Exists(path) && File.ReadAllText(path).Contains("settings", StringComparison.Ordinal),
+                () => ReadAllTextOrNull(path)?.Contains("settings", StringComparison.Ordinal) == true,
                 TimeSpan.FromSeconds(2));
 
             var reloaded = new CommandPaletteUsageStore(path);
@@ -59,6 +59,69 @@ public sealed class CommandPaletteUsageStoreTests
         finally
         {
             Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Load_KeysDifferingOnlyByCase_DoNotThrow_AndLastOneWins()
+    {
+        string tempRoot = CreateTempDirectory();
+        string path = Path.Combine(tempRoot, "command-palette-usage.json");
+
+        try
+        {
+            // JSON keys are ordinal-distinct, so "settings" and "Settings" both survive
+            // deserialization as sibling entries of a case-sensitive dictionary. Normalizing that
+            // to OrdinalIgnoreCase must not throw on the collision -- and it must not degrade to
+            // the empty-dictionary catch-all either, which is what the copy constructor's
+            // ArgumentException produced. Per the documented last-wins rule, the key enumerated
+            // last (here "Settings", in JSON document order) determines the surviving entry.
+            File.WriteAllText(
+                path,
+                """
+                {
+                  "settings": {
+                    "CommandId": "settings",
+                    "UseCount": 3,
+                    "LastUsedAt": "2026-05-26T12:00:00+00:00"
+                  },
+                  "Settings": {
+                    "CommandId": "Settings",
+                    "UseCount": 7,
+                    "LastUsedAt": "2026-05-27T12:00:00+00:00"
+                  }
+                }
+                """);
+
+            var store = new CommandPaletteUsageStore(path);
+            IReadOnlyDictionary<string, CommandPaletteUsageEntry> snapshot = store.Load();
+
+            Assert.Single(snapshot);
+            Assert.True(snapshot.TryGetValue("SETTINGS", out CommandPaletteUsageEntry? entry));
+            Assert.Equal(7, entry.UseCount);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Reads <paramref name="path"/>, treating "not there yet" and "momentarily unreadable" alike.
+    /// <see cref="CommandPaletteUsageStore.Save"/> writes on a background task, and File.WriteAllText
+    /// holds a write handle the whole time; a File.ReadAllText landing inside that window fails with
+    /// a sharing violation on Windows. Polling for the write to land must treat that IOException as
+    /// "keep waiting" rather than letting it escape the predicate and fail the test.
+    /// </summary>
+    private static string? ReadAllTextOrNull(string path)
+    {
+        try
+        {
+            return File.ReadAllText(path);
+        }
+        catch (IOException)
+        {
+            return null;
         }
     }
 


### PR DESCRIPTION
Follow-up to `3be8c66`, which fixed this bug class in `TitleBarLayoutResolver`. Two more sites had the same defect; this sweeps the rest of the repo clean.

## The bug

`new Dictionary<K,V>(source, comparer)` has repeated-`Add` semantics, not indexer-assignment semantics. It adds entries one by one under the **new** comparer and throws `ArgumentException` the moment two source keys collapse to the same key. Both sites below take their source from a hand-editable JSON file deserialized with the **default ordinal** comparer, so sibling keys differing only in case (`"find"` / `"Find"`) survive deserialization intact and collide on rebuild.

Both are now built empty with the target comparer and filled by an indexer-assignment loop — deterministic last-one-wins, cannot throw.

## Site 1 — `CommandPaletteUsageStore.Load` (not a crash; worse)

The call site sits inside the method's `try`, so the `ArgumentException` was caught and `_entries` reset to empty. The observable failure was never a crash — it was the silent discard of the **entire** palette usage history, on every launch, **permanently**: the next `Save()` overwrites the file with the empty result. Frequency-based palette ordering would just quietly stop working, with nothing in the logs.

Confirmed the source really is user-editable: `MainWindow` → `AppPaths.CommandPaletteUsageFilePath` (`<root>/command-palette-usage.json`) → round-tripped through `AppJsonContext.Default.DictionaryStringCommandPaletteUsageEntry`.

## Site 2 — `SettingsWindow` constructor (worse still)

`new Dictionary<string, string>(_settings.Keybindings, StringComparer.OrdinalIgnoreCase)`. `Keybindings` is a plain `Dictionary<string, string>` on `TerminalSettings`, deserialized from `settings.json` and never re-compared on load. This one is **unguarded** and in a window constructor, so a hand-edited `"Ctrl+A"` / `"ctrl+a"` pair means the Settings window throws on open rather than degrading.

Not covered by a test: `SettingsWindow` is never instantiated anywhere in `tests/`, and standing up an Avalonia window harness just for this line would be disproportionate. Flagging rather than forcing a fragile test.

## Test

`Load_KeysDifferingOnlyByCase_DoNotThrow_AndLastOneWins` — a `"settings"` / `"Settings"` pair asserting no throw, `Single()`, and last-wins. Verified it fails on the unfixed source with `Assert.Single() Failure: The collection was empty` (exactly the silent-discard mode described above) and passes on the fixed source.

## Sweep

Covered the explicit form, the target-typed `new(source, comparer)` form, and `ToDictionary(..., comparer)` — which shares the throw-on-duplicate semantics and is easy to miss. Every remaining site is safe, verified individually:

| Site | Why safe |
|---|---|
| `CommandPaletteUsageStore` `Save` / `EnsureEntries` | source already `OrdinalIgnoreCase` |
| `SettingsWindow.axaml.cs:1426`, `:2308` | source is `_shortcutDraftBindings`, already `OrdinalIgnoreCase` |
| `StartupPerformanceTracker.cs:127` | `Ordinal` → `Ordinal`, no collapse possible |
| `SshConnectionService.cs:173` | `GroupBy(..., OrdinalIgnoreCase)` first, so group keys are already unique under the target comparer |
| `JsonlHistoryStore.cs:718` | `ToDictionary` over `index.Values`, already keyed `Ordinal` by the same `entry.Id` |
| `ConnectionProfileTools.cs:482` | `HashSet` — `Add` returns false rather than throwing |

`HashSet`'s equivalent constructor is a non-issue by construction and needs no changes anywhere.

## Also: a pre-existing flake, separable

While running the tests I hit a real race in `RecordUse_PersistsCountAcrossReloads`, reproduced **1 in 8**. `Save()` writes on a background `Task.Run` via `File.WriteAllText`, which holds a write handle for the duration; the `WaitFor` predicate's `File.ReadAllText` landing in that window throws a sharing violation that escapes the predicate and fails the test.

Not a timeout problem — it failed in ~6ms, nowhere near the 2s ceiling, so raising the timeout would have masked it. The poll now treats `IOException` as "keep waiting" (`FileNotFoundException` derives from it, so the `File.Exists` check is subsumed). 15/15 green after.

This part was unrequested; it's easy to drop if you'd rather keep the diff strictly scoped.

## Verification

Wrapper scripts only, per `CLAUDE.md` — no raw `dotnet`, and never the full solution suite.

- `scripts/build.sh build src/NovaTerminal.App` → 0 errors
- `CommandPaletteUsageStoreTests` → 3/3, green 15 consecutive runs
- Filter across `Shortcut|Keybinding|CommandPalette|TitleBarLayout|Settings` → **93/93**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
