### PR TITLE
fix: resolve local shell commands by what the launcher can actually start

### DIFF
--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -2997,13 +2997,15 @@ namespace NovaTerminal.Controls
             _agentRegistration?.SetLifecycle(null);
             try
             {
-                // If effectiveShell contains a space and is not a direct file, it's likely a combined command.
-                if (effectiveShell.Contains(' ') && !System.IO.File.Exists(effectiveShell))
+                // A combined command carries its arguments inline ("zsh -l"). The split lives in
+                // ShellHelper because ResolveExecutableOrDefault has to make the same call when it
+                // decides whether a command is runnable, and when the two split differently they
+                // disagreed about what was being launched: this code cut at the first literal space,
+                // so a quoted executable whose path contains spaces
+                // ("C:\Program Files\PowerShell\7\pwsh.exe" -NoLogo) passed the resolver's check and
+                // was then spawned here as `"C:\Program`.
+                if (ShellHelper.TrySplitCommandLine(effectiveShell, out string cmdPart, out string argPart))
                 {
-                    int firstSpace = effectiveShell.IndexOf(' ');
-                    string cmdPart = effectiveShell.Substring(0, firstSpace);
-                    string argPart = effectiveShell.Substring(firstSpace + 1);
-
                     effectiveShell = cmdPart;
                     args = (argPart + " " + args).Trim();
                 }

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -4014,8 +4014,20 @@ namespace NovaTerminal
             // path uses, so opening a profile and restoring one agree about it. They did not before:
             // this asked whether the command existed, so a profile carrying inline arguments or a
             // quoted path was reset here while restore kept it.
+            //
+            // Copied before it is changed, exactly as SessionManager.ResolveProfileForThisPlatform
+            // does. The local branch above hands back the instance living in _settings.Profiles, so
+            // assigning to its Command edited the user's stored profile - and any later
+            // _settings.Save() persisted that. Several ordinary actions save (font size, cursor
+            // style, bell), so opening a /bin/bash profile once on Windows could rewrite it to
+            // pwsh.exe with its arguments dropped, in the settings.json that travels back to the
+            // Linux machine. That is the cross-machine corruption this whole change exists to stop.
+            //
+            // The SSH branch below mutates too, and does not need this: GetConnectionProfile returns
+            // a freshly converted runtime profile, not the stored instance.
             if (profile.Type == ConnectionType.Local && ShellHelper.IsCommandForAnotherPlatform(profile.Command))
             {
+                profile = profile.ShallowCopy();
                 profile.Command = ShellHelper.GetDefaultShell();
                 profile.Arguments = ""; // The old arguments belonged to the command just replaced.
             }

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -4025,6 +4025,13 @@ namespace NovaTerminal
             //
             // The SSH branch below mutates too, and does not need this: GetConnectionProfile returns
             // a freshly converted runtime profile, not the stored instance.
+            //
+            // One consequence worth knowing, since the copy makes it observable where it was a no-op
+            // before: ApplySettingsRecursive re-binds a pane to the stored profile by id on any
+            // settings re-apply, so after e.g. a font change pane.Profile.Command reads the original
+            // foreign command again while the shell running is the substitute. Verified harmless -
+            // nothing respawns from Profile.Command (Reconnect passes ShellCommand, and TerminalPane
+            // never reads Profile.Command), and session capture writes the pane's actual command.
             if (profile.Type == ConnectionType.Local && ShellHelper.IsCommandForAnotherPlatform(profile.Command))
             {
                 profile = profile.ShallowCopy();

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -4010,15 +4010,14 @@ namespace NovaTerminal
                 }
             }
 
-            // Ensure the command exists on this platform (handles shared settings between Windows/Linux)
-            if (profile.Type == ConnectionType.Local)
+            // Substitute only a command written for another OS - the same predicate the restore
+            // path uses, so opening a profile and restoring one agree about it. They did not before:
+            // this asked whether the command existed, so a profile carrying inline arguments or a
+            // quoted path was reset here while restore kept it.
+            if (profile.Type == ConnectionType.Local && ShellHelper.IsCommandForAnotherPlatform(profile.Command))
             {
-                bool exists = File.Exists(profile.Command) || ShellHelper.InPath(profile.Command);
-                if (!exists)
-                {
-                    profile.Command = ShellHelper.GetDefaultShell();
-                    profile.Arguments = ""; // Reset potentially platform-specific args
-                }
+                profile.Command = ShellHelper.GetDefaultShell();
+                profile.Arguments = ""; // The old arguments belonged to the command just replaced.
             }
 
             // Construct command if it's an SSH connection
@@ -4449,8 +4448,11 @@ namespace NovaTerminal
             {
                 foreach (var profile in _settings.Profiles.Where(p => p.Type == ConnectionType.Local))
                 {
-                    bool exists = File.Exists(profile.Command) || ShellHelper.InPath(profile.Command);
-                    if (!exists) continue;
+                    // Hidden only if the command belongs to another OS. Keyed off existence, this
+                    // dropped profiles the terminal can open perfectly well - a quoted path, or a
+                    // command with inline arguments - so they were missing from the palette while
+                    // still working from a restored session.
+                    if (ShellHelper.IsCommandForAnotherPlatform(profile.Command)) continue;
                     CommandRegistry.Register($"New Tab: {profile.Name}", "Shell", () => AddTab(profile), "");
                 }
             }

--- a/src/NovaTerminal.App/SettingsWindow.axaml.cs
+++ b/src/NovaTerminal.App/SettingsWindow.axaml.cs
@@ -5,6 +5,7 @@ using Avalonia.Input.Platform;
 using Avalonia.Layout;
 using NovaTerminal.Shell;
 using NovaTerminal.Platform;
+using NovaTerminal.Pty;
 using NovaTerminal.VT;
 using System;
 using System.Collections.Generic;
@@ -421,7 +422,9 @@ namespace NovaTerminal
             {
                 btnAddProfile.Click += (s, e) =>
                 {
-                    var newProfile = new TerminalProfile { Name = "New Profile", Command = "cmd.exe", Type = ConnectionType.Local };
+                    // Seeded with this platform's shell, not cmd.exe: on Linux and macOS the
+                    // latter gave every freshly added profile a command that cannot spawn.
+                    var newProfile = new TerminalProfile { Name = "New Profile", Command = ShellHelper.GetDefaultShell(), Type = ConnectionType.Local };
                     _profilesList.Add(newProfile);
                     PopulateProfilesList();
                     if (profilesListBox != null) profilesListBox.SelectedIndex = _profilesList.Count - 1;

--- a/src/NovaTerminal.App/Shell/SessionManager.cs
+++ b/src/NovaTerminal.App/Shell/SessionManager.cs
@@ -331,7 +331,10 @@ namespace NovaTerminal.Shell
                 return profile;
             }
 
-            string resolved = ShellHelper.ResolveExecutableOrDefault(profile.Command);
+            // StartingDirectory is part of the verdict: it becomes the child's cwd, so a relative
+            // command such as ./tools/shell runs from there rather than from wherever NovaTerminal
+            // happens to be. Probing without it called a perfectly runnable command missing.
+            string resolved = ShellHelper.ResolveExecutableOrDefault(profile.Command, profile.StartingDirectory);
             if (string.Equals(resolved, (profile.Command ?? string.Empty).Trim(), StringComparison.Ordinal))
             {
                 return profile;

--- a/src/NovaTerminal.App/Shell/SessionManager.cs
+++ b/src/NovaTerminal.App/Shell/SessionManager.cs
@@ -331,10 +331,7 @@ namespace NovaTerminal.Shell
                 return profile;
             }
 
-            // StartingDirectory is part of the verdict: it becomes the child's cwd, so a relative
-            // command such as ./tools/shell runs from there rather than from wherever NovaTerminal
-            // happens to be. Probing without it called a perfectly runnable command missing.
-            string resolved = ShellHelper.ResolveExecutableOrDefault(profile.Command, profile.StartingDirectory);
+            string resolved = ShellHelper.ResolveExecutableOrDefault(profile.Command);
             if (string.Equals(resolved, (profile.Command ?? string.Empty).Trim(), StringComparison.Ordinal))
             {
                 return profile;

--- a/src/NovaTerminal.App/Shell/SessionManager.cs
+++ b/src/NovaTerminal.App/Shell/SessionManager.cs
@@ -303,6 +303,49 @@ namespace NovaTerminal.Shell
             return profile;
         }
 
+        /// <summary>
+        /// Returns a profile whose command can be spawned on this machine, substituting the default
+        /// shell when it cannot.
+        /// </summary>
+        /// <remarks>
+        /// The raw-command path below has done this since a Windows workspace restored as
+        /// <c>cmd.exe</c> on Linux, but a profile-backed pane never reached it, and normal capture
+        /// writes a <c>ProfileId</c> for every profile-backed pane - so the common case was the
+        /// uncovered one. Settings validation does not close the gap either: opening Windows
+        /// settings on Linux *adds* this platform's defaults but leaves the imported profiles
+        /// alone, so the pane's ProfileId still resolves to the profile holding <c>cmd.exe</c>. The
+        /// pane failed to spawn and re-persisted the same ProfileId on every launch, exactly the
+        /// self-sustaining loop the raw-command fix was for.
+        ///
+        /// Copies rather than edits. <see cref="TryResolvePaneProfile"/> hands back the instance
+        /// living in <see cref="TerminalSettings.Profiles"/>, so assigning to its Command would
+        /// rewrite the user's stored profile - and persist that rewrite the next time settings are
+        /// saved. Restoring a session must not quietly edit someone's profile.
+        /// </remarks>
+        private static TerminalProfile ResolveProfileForThisPlatform(TerminalProfile profile)
+        {
+            // SSH panes get their command built for them (ssh/ssh.exe plus generated arguments), so
+            // there is no local executable here to check and nothing this should touch.
+            if (profile.Type != ConnectionType.Local)
+            {
+                return profile;
+            }
+
+            string resolved = ShellHelper.ResolveExecutableOrDefault(profile.Command);
+            if (string.Equals(resolved, (profile.Command ?? string.Empty).Trim(), StringComparison.Ordinal))
+            {
+                return profile;
+            }
+
+            TerminalProfile local = profile.ShallowCopy();
+            local.Command = resolved;
+
+            // Dropped for the same reason as the raw-command path: they were written for the
+            // command that has just been replaced, so `cmd.exe /c ...` would reach bash as `/c ...`.
+            local.Arguments = "";
+            return local;
+        }
+
         private static Control? RestorePaneTree(PaneNode? node, TerminalSettings settings)
         {
             if (node == null) return null;
@@ -316,7 +359,7 @@ namespace NovaTerminal.Shell
                 TerminalPane pane;
                 if (profile != null)
                 {
-                    pane = new TerminalPane(profile, settings);
+                    pane = new TerminalPane(ResolveProfileForThisPlatform(profile), settings);
                 }
                 else
                 {

--- a/src/NovaTerminal.App/Shell/SessionManager.cs
+++ b/src/NovaTerminal.App/Shell/SessionManager.cs
@@ -322,14 +322,28 @@ namespace NovaTerminal.Shell
                 {
                     // Fallback to command args if profile missing.
                     //
-                    // IsNullOrWhiteSpace, not `??`: session files written before the capture
-                    // above learned to skip blanks contain "Command": "", and `??` does not
-                    // fire for an empty string — so the pane was constructed with "" and
-                    // spawned nothing. Those files are still on disk, so this reads them
-                    // correctly rather than relying on the capture fix alone.
+                    // ResolveExecutableOrDefault, not a blank check: session files written
+                    // before the capture above learned to skip blanks contain "Command": "",
+                    // and a `??` does not fire for an empty string — so the pane was
+                    // constructed with "" and spawned nothing. Those files are still on disk,
+                    // so this reads them correctly rather than relying on the capture fix
+                    // alone. It also covers the command being non-blank but unrunnable here:
+                    // a session saved on Windows restores "cmd.exe", which spawns nothing on
+                    // Linux and gets re-persisted, so every later launch failed the same way.
+                    string restoredCommand = ShellHelper.ResolveExecutableOrDefault(node.Command);
+
+                    // Arguments belong to the command that was saved. Once that command has been
+                    // swapped for this platform's shell they are the wrong shell's flags - a
+                    // persisted `cmd.exe /c ...` would reach bash as `/c ...` - so drop them,
+                    // the same way the profile-launch path does when it substitutes.
+                    bool commandSubstituted = !string.Equals(
+                        restoredCommand,
+                        (node.Command ?? string.Empty).Trim(),
+                        StringComparison.Ordinal);
+
                     pane = new TerminalPane(
-                        string.IsNullOrWhiteSpace(node.Command) ? ShellHelper.GetDefaultShell() : node.Command,
-                        node.Arguments ?? "",
+                        restoredCommand,
+                        commandSubstituted ? "" : node.Arguments ?? "",
                         settings);
                 }
 

--- a/src/NovaTerminal.App/Shell/TerminalProfile.cs
+++ b/src/NovaTerminal.App/Shell/TerminalProfile.cs
@@ -1,6 +1,7 @@
 using NovaTerminal.Platform;
 using System;
 using NovaTerminal.Platform.Ssh.Models;
+using NovaTerminal.Pty;
 
 namespace NovaTerminal.Shell
 {
@@ -206,12 +207,19 @@ namespace NovaTerminal.Shell
         }
 
 
+        /// <summary>
+        /// A profile pointing at this platform's default shell.
+        /// </summary>
+        /// <remarks>
+        /// Not hardcoded to cmd.exe any more: on Linux and macOS that produced a profile that
+        /// could never spawn, and its name claimed to be a Windows shell besides.
+        /// </remarks>
         public static TerminalProfile CreateDefault()
         {
             return new TerminalProfile
             {
-                Name = "Command Prompt",
-                Command = "cmd.exe"
+                Name = OperatingSystem.IsWindows() ? "Command Prompt" : "Shell",
+                Command = ShellHelper.GetDefaultShell()
             };
         }
     }

--- a/src/NovaTerminal.App/Shell/TerminalProfile.cs
+++ b/src/NovaTerminal.App/Shell/TerminalProfile.cs
@@ -101,6 +101,21 @@ namespace NovaTerminal.Shell
         public override string ToString() => Name;
 
         /// <summary>
+        /// A shallow copy, for a caller that has to adjust a profile for one launch without
+        /// editing the stored one.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="object.MemberwiseClone"/> rather than a hand-written copy so a property added
+        /// to this class later is carried over without anyone remembering to update a copy method.
+        ///
+        /// Shallow, so the collection properties (<see cref="Tags"/>, <see cref="Forwards"/>) are
+        /// shared with the original by reference. That is fine for the launch-time command
+        /// substitution this exists for, which only touches strings; do not use it to hand someone
+        /// a profile they are going to edit.
+        /// </remarks>
+        internal TerminalProfile ShallowCopy() => (TerminalProfile)MemberwiseClone();
+
+        /// <summary>
         /// Generates the full SSH command including ProxyJump (-J) and Identity (-i) flags.
         /// Recursively resolves jump hosts.
         /// </summary>

--- a/src/NovaTerminal.App/Shell/TerminalSettings.cs
+++ b/src/NovaTerminal.App/Shell/TerminalSettings.cs
@@ -246,9 +246,13 @@ namespace NovaTerminal.Shell
             {
                 // Cross-platform polish: If we don't have any profile that matches a known shell for this OS,
                 // add the defaults for this OS so the user isn't stuck with invalid shells from another OS.
+                // "Usable here" means the command is not addressed to another OS - the same
+                // predicate the restore and launch paths use. It used to mean "the command exists",
+                // which made this disagree with them: a profile they would happily open could still
+                // be judged unusable here, and vice versa.
                 bool nativeShellsFound = settings.Profiles.Exists(p =>
                     p.Type == ConnectionType.Local &&
-                    (File.Exists(p.Command) || ShellHelper.InPath(p.Command)));
+                    !ShellHelper.IsCommandForAnotherPlatform(p.Command));
 
                 if (!nativeShellsFound)
                 {
@@ -280,12 +284,17 @@ namespace NovaTerminal.Shell
                 var currentDefault = settings.Profiles.Find(p => p.Id == settings.DefaultProfileId);
                 if (currentDefault != null && currentDefault.Type == ConnectionType.Local)
                 {
-                    bool exists = File.Exists(currentDefault.Command) || ShellHelper.InPath(currentDefault.Command);
-                    if (!exists)
+                    // Reassigning someone's default profile is not a small thing to do silently, so
+                    // it now happens only when the command could not run on this OS at all. The
+                    // existence check reached much further than that: a default whose command was a
+                    // quoted path, or carried inline arguments, was swapped out even though opening
+                    // it worked - which is what made the same profile behave differently depending on
+                    // whether it was the default or picked from a session.
+                    if (ShellHelper.IsCommandForAnotherPlatform(currentDefault.Command))
                     {
                         var better = settings.Profiles.Find(p =>
                             p.Type == ConnectionType.Local &&
-                            (File.Exists(p.Command) || ShellHelper.InPath(p.Command)));
+                            !ShellHelper.IsCommandForAnotherPlatform(p.Command));
 
                         if (better != null)
                         {

--- a/src/NovaTerminal.Pty/ShellHelper.cs
+++ b/src/NovaTerminal.Pty/ShellHelper.cs
@@ -28,6 +28,31 @@ namespace NovaTerminal.Pty
             }
         }
 
+        /// <summary>
+        /// Resolves a configured or persisted local shell command to one that can actually be
+        /// spawned here, falling back to <see cref="GetDefaultShell"/> when it cannot.
+        /// </summary>
+        /// <remarks>
+        /// Settings and session files travel between machines, and a pane's command is persisted
+        /// as a bare executable, so a workspace saved on Windows restores as <c>cmd.exe</c> on
+        /// Linux and every pane in it fails to spawn. Callers used to guard only against a blank
+        /// command, which does not catch that: <c>cmd.exe</c> is a perfectly non-blank string.
+        ///
+        /// This mirrors the existence check the profile-launch path in <c>MainWindow</c> already
+        /// applies to local profiles, so a restored pane and a profile-launched one agree about
+        /// what is runnable.
+        /// </remarks>
+        public static string ResolveExecutableOrDefault(string? command)
+        {
+            if (string.IsNullOrWhiteSpace(command))
+            {
+                return GetDefaultShell();
+            }
+
+            string trimmed = command.Trim();
+            return File.Exists(trimmed) || InPath(trimmed) ? trimmed : GetDefaultShell();
+        }
+
         public static bool InPath(string command)
         {
             var path = Environment.GetEnvironmentVariable("PATH");

--- a/src/NovaTerminal.Pty/ShellHelper.cs
+++ b/src/NovaTerminal.Pty/ShellHelper.cs
@@ -47,7 +47,12 @@ namespace NovaTerminal.Pty
         /// grounds that they belonged to the command being replaced. A false negative therefore
         /// costs the user their command *and* its arguments, silently.
         /// </remarks>
-        public static string ResolveExecutableOrDefault(string? command)
+        /// <param name="workingDirectory">
+        /// The directory the command will be launched in, when the caller knows it - a profile's
+        /// StartingDirectory. A relative path is resolved against it as well as against this
+        /// process's own directory, because the child gets that directory as its cwd.
+        /// </param>
+        public static string ResolveExecutableOrDefault(string? command, string? workingDirectory = null)
         {
             if (string.IsNullOrWhiteSpace(command))
             {
@@ -64,7 +69,7 @@ namespace NovaTerminal.Pty
             // Whole string first, so a path that simply contains spaces is found as itself rather
             // than mistaken for a command plus arguments. This is the same order
             // TerminalPane.InitializeSessionCore uses when it decides whether to split.
-            if (CanExecute(probe) || InPath(probe))
+            if (IsRunnable(probe, workingDirectory))
             {
                 return trimmed;
             }
@@ -76,12 +81,56 @@ namespace NovaTerminal.Pty
             // combined string: the consumer splits it again with this same method, so the verdict
             // reached here and the command actually spawned cannot disagree.
             if (TrySplitCommandLine(trimmed, out string executable, out _) &&
-                (CanExecute(executable) || InPath(executable)))
+                IsRunnable(executable, workingDirectory))
             {
                 return trimmed;
             }
 
             return GetDefaultShell();
+        }
+
+        /// <summary>
+        /// True when <paramref name="executable"/> names something this application could start,
+        /// looked for as a path, on <c>PATH</c>, and relative to <paramref name="workingDirectory"/>.
+        /// </summary>
+        private static bool IsRunnable(string executable, string? workingDirectory) =>
+            CanExecute(executable) ||
+            InPath(executable) ||
+            CanExecuteRelativeTo(workingDirectory, executable);
+
+        /// <summary>
+        /// True when <paramref name="candidate"/> resolves against the directory the command will
+        /// actually run in.
+        /// </summary>
+        /// <remarks>
+        /// A profile's StartingDirectory becomes the child's cwd (TerminalPane passes it to
+        /// RustPtySession), so a relative command such as <c>./tools/shell</c> runs from there -
+        /// while this check runs in NovaTerminal's own directory and used to declare it missing,
+        /// substituting the default shell and dropping the arguments.
+        ///
+        /// Additive rather than a replacement, because which directory wins is platform-specific:
+        /// exec resolves a relative path against the child's cwd, but Windows resolves
+        /// CreateProcessW's application name against the *calling* process's directory, not the one
+        /// passed as lpCurrentDirectory. Probing both avoids a false negative on either.
+        ///
+        /// Only for something that is already a path. A bare name like <c>zsh</c> is resolved
+        /// through PATH, not the working directory, which is what both a shell and exec do.
+        /// </remarks>
+        private static bool CanExecuteRelativeTo(string? workingDirectory, string candidate)
+        {
+            if (string.IsNullOrWhiteSpace(workingDirectory)) return false;
+            if (string.IsNullOrWhiteSpace(candidate)) return false;
+            if (Path.IsPathRooted(candidate)) return false;
+            if (candidate.IndexOf('/') < 0 && candidate.IndexOf('\\') < 0) return false;
+
+            try
+            {
+                return CanExecute(Path.Combine(workingDirectory, candidate));
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
         }
 
         /// <summary>
@@ -199,11 +248,37 @@ namespace NovaTerminal.Pty
         internal static readonly string[] LaunchableWindowsExtensions = { ".exe", ".com" };
 
         /// <summary>
+        /// Windows file types that only run because an interpreter runs them, so this application
+        /// cannot start one directly.
+        /// </summary>
+        /// <remarks>
+        /// The counterpart to <see cref="LaunchableWindowsExtensions"/>, and the same reasoning: the
+        /// native layer calls <c>CreateProcessW</c> and the fallback uses portable_pty's
+        /// <c>CommandBuilder</c>, neither of which can start a script without its interpreter.
+        ///
+        /// Restricting only the *appended* extensions left an inconsistency: an extensionless
+        /// <c>wrapper</c> backed by <c>wrapper.bat</c> was correctly called unrunnable, while an
+        /// explicit <c>wrapper.bat</c> sailed through <c>File.Exists</c> and was kept - producing the
+        /// dead pane the restriction existed to prevent. The verdict now depends on what can be
+        /// launched, not on how the name was spelled.
+        ///
+        /// Running these properly means invoking the interpreter (<c>cmd.exe /c wrapper.bat</c>),
+        /// which is a feature rather than a fix and is deliberately not attempted here; falling back
+        /// to a shell that starts is the better of the two outcomes available.
+        /// </remarks>
+        internal static readonly string[] WindowsExtensionsNeedingAnInterpreter =
+            { ".bat", ".cmd", ".ps1", ".psm1", ".vbs", ".vbe", ".js", ".jse", ".wsf", ".wsh", ".msc" };
+
+        /// <summary>
         /// True when <paramref name="candidate"/> names a file this application could start,
         /// allowing for the extension being left off on Windows.
         /// </summary>
         private static bool CanExecute(string candidate)
         {
+            // Checked before File.Exists, not after: the file existing is exactly what used to make
+            // an explicitly named script look runnable.
+            if (OperatingSystem.IsWindows() && NeedsAnInterpreter(candidate)) return false;
+
             if (File.Exists(candidate)) return true;
             if (!OperatingSystem.IsWindows()) return false;
 
@@ -214,6 +289,28 @@ namespace NovaTerminal.Pty
             foreach (string extension in LaunchableWindowsExtensions)
             {
                 if (File.Exists(candidate + extension)) return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// True when <paramref name="candidate"/> ends in an extension that needs an interpreter.
+        /// </summary>
+        /// <remarks>
+        /// <c>internal</c> for the same reason as the extension lists: the callers are gated on
+        /// Windows, so a test that goes through the filesystem on Linux cannot exercise this.
+        /// </remarks>
+        internal static bool NeedsAnInterpreter(string? candidate)
+        {
+            if (string.IsNullOrWhiteSpace(candidate)) return false;
+
+            string extension = Path.GetExtension(candidate);
+            if (extension.Length == 0) return false;
+
+            foreach (string scripted in WindowsExtensionsNeedingAnInterpreter)
+            {
+                if (string.Equals(extension, scripted, StringComparison.OrdinalIgnoreCase)) return true;
             }
 
             return false;

--- a/src/NovaTerminal.Pty/ShellHelper.cs
+++ b/src/NovaTerminal.Pty/ShellHelper.cs
@@ -70,11 +70,12 @@ namespace NovaTerminal.Pty
             }
 
             // A stored command may carry its arguments inline - "zsh -l", "wsl.exe -e /bin/bash" -
-            // and the pane supports that, splitting executable from arguments at the first space.
-            // Probing the whole string as one filename therefore rejected commands that run
-            // perfectly well, and rejection costs the arguments too. Probe just the executable, and
-            // still hand back the combined string so the pane's own split does the parsing.
-            if (TryGetExecutablePortion(probe, out string executable) &&
+            // and the spawn path supports that, splitting executable from arguments. Probing the
+            // whole string as one filename therefore rejected commands that run perfectly well, and
+            // rejection costs the arguments too. Probe just the executable, and hand back the
+            // combined string: the consumer splits it again with this same method, so the verdict
+            // reached here and the command actually spawned cannot disagree.
+            if (TrySplitCommandLine(trimmed, out string executable, out _) &&
                 (CanExecute(executable) || InPath(executable)))
             {
                 return trimmed;
@@ -84,38 +85,51 @@ namespace NovaTerminal.Pty
         }
 
         /// <summary>
-        /// Extracts the executable from a command that carries its arguments inline, mirroring the
-        /// split in <c>TerminalPane.InitializeSessionCore</c>.
+        /// Splits a command that carries its arguments inline into its executable and argument
+        /// parts, removing the quotes around a quoted executable.
         /// </summary>
         /// <remarks>
-        /// False when there is nothing to split, so the caller keeps whatever verdict it already
-        /// reached about the whole string.
+        /// The single definition of that split, used both by <see cref="ResolveExecutableOrDefault"/>
+        /// to decide what to probe and by <c>TerminalPane.InitializeSessionCore</c> to decide what
+        /// to spawn. They used to answer it separately and disagree: this validated the executable
+        /// inside <c>"C:\Program Files\PowerShell\7\pwsh.exe" -NoLogo</c> and approved the command,
+        /// while the pane split the same string at the first literal space and tried to spawn
+        /// <c>"C:\Program</c>. Approving a command nobody can launch is worse than rejecting it,
+        /// because rejection at least falls back to a working shell.
+        ///
+        /// Returns false when there is nothing to split, leaving the whole string as the command.
         /// </remarks>
-        private static bool TryGetExecutablePortion(string command, out string executable)
+        public static bool TrySplitCommandLine(string? commandLine, out string executable, out string arguments)
         {
-            // A quoted executable followed by arguments: "C:\Program Files\...\pwsh.exe" -NoLogo.
-            // The closing quote delimits it, not the first space, which falls inside the path.
-            if (command.StartsWith('"'))
-            {
-                int closingQuote = command.IndexOf('"', 1);
-                if (closingQuote > 1)
-                {
-                    executable = command[1..closingQuote];
-                    return true;
-                }
+            executable = string.Empty;
+            arguments = string.Empty;
 
-                executable = string.Empty;
-                return false;
+            if (string.IsNullOrWhiteSpace(commandLine)) return false;
+
+            string value = commandLine.Trim();
+
+            // A quoted executable, with or without arguments after it:
+            // "C:\Program Files\...\pwsh.exe" -NoLogo. The closing quote delimits it, not the first
+            // space - which on Windows usually falls inside the path.
+            if (value.StartsWith('"'))
+            {
+                int closingQuote = value.IndexOf('"', 1);
+                if (closingQuote <= 1) return false;
+
+                executable = value[1..closingQuote];
+                arguments = value[(closingQuote + 1)..].Trim();
+                return true;
             }
 
-            int firstSpace = command.IndexOf(' ');
-            if (firstSpace <= 0)
-            {
-                executable = string.Empty;
-                return false;
-            }
+            // An existing file is itself, spaces and all. Splitting "/opt/my shell" would look for
+            // "/opt/my" and pass "shell" as an argument.
+            if (File.Exists(value)) return false;
 
-            executable = command[..firstSpace];
+            int firstSpace = value.IndexOf(' ');
+            if (firstSpace <= 0) return false;
+
+            executable = value[..firstSpace];
+            arguments = value[(firstSpace + 1)..].Trim();
             return true;
         }
 
@@ -161,8 +175,32 @@ namespace NovaTerminal.Pty
         }
 
         /// <summary>
-        /// True when <paramref name="candidate"/> names a file that exists, allowing for Windows
-        /// appending a <c>PATHEXT</c> extension to a name that has none.
+        /// Extensions this application can actually start on Windows.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately not <c>PATHEXT</c>. PATHEXT is the list a *shell* appends, and it includes
+        /// script types - .BAT, .CMD, .PS1, .VBS - that only run because cmd.exe or another
+        /// interpreter runs them. NovaTerminal does not launch through a shell: the native layer
+        /// calls <c>CreateProcessW</c> directly, and the fallback hands the command to
+        /// portable_pty's <c>CommandBuilder</c>. Neither can start a batch file without an
+        /// interpreter.
+        ///
+        /// Probing the full PATHEXT therefore reported a .bat-backed command as runnable, and
+        /// "runnable" is not an idle verdict here - it makes the caller keep the command and its
+        /// arguments instead of falling back, so the user got a pane that failed to spawn rather
+        /// than a working shell. Modelling cmd.exe was the wrong model; this models the launcher.
+        /// </remarks>
+        /// <remarks>
+        /// <c>internal</c> so the policy itself can be asserted off Windows. The probe that uses it
+        /// is gated on <see cref="OperatingSystem.IsWindows"/> and so does nothing on Linux, which
+        /// means a test that goes through the filesystem there passes whatever this list contains -
+        /// it would not have caught .bat being in it. The list is the decision worth pinning.
+        /// </remarks>
+        internal static readonly string[] LaunchableWindowsExtensions = { ".exe", ".com" };
+
+        /// <summary>
+        /// True when <paramref name="candidate"/> names a file this application could start,
+        /// allowing for the extension being left off on Windows.
         /// </summary>
         private static bool CanExecute(string candidate)
         {
@@ -173,46 +211,12 @@ namespace NovaTerminal.Pty
             // (python3.11) is not an executable extension, and the launcher would still go on to
             // append one. Guessing wrong here reintroduces the false negative, and an extra
             // File.Exists that misses costs nothing.
-            foreach (string extension in WindowsExecutableExtensions())
+            foreach (string extension in LaunchableWindowsExtensions)
             {
                 if (File.Exists(candidate + extension)) return true;
             }
 
             return false;
-        }
-
-        /// <summary>
-        /// The extensions Windows appends to an extensionless command, from <c>PATHEXT</c>.
-        /// </summary>
-        private static string[] WindowsExecutableExtensions() =>
-            ParseExecutableExtensions(Environment.GetEnvironmentVariable("PATHEXT"));
-
-        /// <summary>
-        /// Parses a <c>PATHEXT</c> value into normalised extensions.
-        /// </summary>
-        /// <remarks>
-        /// Split out as a pure function, and <c>internal</c> rather than private, so the parsing
-        /// can be tested off Windows. The rest of the extension handling is a File.Exists loop,
-        /// but this part has the details worth getting wrong - a cleared variable, entries without
-        /// a leading dot, stray whitespace - and it is the half that does not need a Windows
-        /// filesystem to verify. Taking the value as an argument rather than reading the
-        /// environment also keeps the tests from mutating process-wide state other tests read.
-        /// </remarks>
-        internal static string[] ParseExecutableExtensions(string? pathExtValue)
-        {
-            // The launcher's own defaults, for the rare environment that clears PATHEXT.
-            string pathExt = string.IsNullOrWhiteSpace(pathExtValue) ? ".COM;.EXE;.BAT;.CMD" : pathExtValue;
-
-            string[] parts = pathExt.Split(
-                ';',
-                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-            for (int i = 0; i < parts.Length; i++)
-            {
-                if (!parts[i].StartsWith('.')) parts[i] = "." + parts[i];
-            }
-
-            return parts;
         }
 
         /// <summary>Strips one layer of surrounding double quotes.</summary>

--- a/src/NovaTerminal.Pty/ShellHelper.cs
+++ b/src/NovaTerminal.Pty/ShellHelper.cs
@@ -29,30 +29,38 @@ namespace NovaTerminal.Pty
         }
 
         /// <summary>
-        /// Resolves a configured or persisted local shell command to one that can actually be
-        /// spawned here, falling back to <see cref="GetDefaultShell"/> when it cannot.
+        /// Resolves a configured or persisted local shell command, substituting this platform's
+        /// default shell when the command was written for a different operating system.
         /// </summary>
         /// <remarks>
-        /// Settings and session files travel between machines, and a pane's command is persisted
-        /// as a bare executable, so a workspace saved on Windows restores as <c>cmd.exe</c> on
-        /// Linux and every pane in it fails to spawn. Callers used to guard only against a blank
-        /// command, which does not catch that: <c>cmd.exe</c> is a perfectly non-blank string.
+        /// Settings and session files travel between machines. A workspace saved on Windows restores
+        /// as <c>cmd.exe</c> on Linux, every pane in it fails to spawn, and the failing command is
+        /// captured again on exit - so the terminal is dead on every subsequent launch and no amount
+        /// of restarting clears it. That is the bug this exists for, and it is a portability
+        /// question: the command is fine, it is just addressed to the wrong OS.
         ///
-        /// This mirrors the existence check the profile-launch path in <c>MainWindow</c> already
-        /// applies to local profiles, so a restored pane and a profile-launched one agree about
-        /// what is runnable.
+        /// It deliberately does not ask the broader question, "can this be launched here". An earlier
+        /// version did, and grew to seven branches over as many review rounds - PATHEXT probing,
+        /// implicit extension rules, an interpreter-extension list, execute bits, working-directory
+        /// resolution - because the specification of that question is "match the real launcher
+        /// exactly", which has no stopping point. Each branch was a chance to model the launcher
+        /// wrongly and two of them did: batch files were rejected as unlaunchable when
+        /// <c>CreateProcess</c> runs them perfectly well, and a relative path was approved against a
+        /// directory Windows does not resolve it from. Both replaced a working command with a shell,
+        /// silently.
         ///
-        /// Be careful changing what counts as runnable: saying "no" here does not just pick a
-        /// different command, it also makes <c>SessionManager</c> drop the pane's arguments, on the
-        /// grounds that they belonged to the command being replaced. A false negative therefore
-        /// costs the user their command *and* its arguments, silently.
+        /// Which is the other half of the reasoning. Rejecting is not the cheap option it looks like:
+        /// the user did not ask for *a* shell, they asked for theirs, and they get the substitute
+        /// with no message. A pane that fails to spawn is visible and diagnosable; a pane quietly
+        /// running something else is neither. So the bar for substituting is high, and a command that
+        /// merely cannot be found is left alone to fail where the user can see it.
+        ///
+        /// Being simple enough to use everywhere is the point. The same predicate now backs the
+        /// session-restore paths, the profile-launch path, the command palette and settings
+        /// validation, which previously each ran their own existence check and disagreed - the same
+        /// profile could be kept on restore, substituted on launch, and hidden from the palette.
         /// </remarks>
-        /// <param name="workingDirectory">
-        /// The directory the command will be launched in, when the caller knows it - a profile's
-        /// StartingDirectory. A relative path is resolved against it as well as against this
-        /// process's own directory, because the child gets that directory as its cwd.
-        /// </param>
-        public static string ResolveExecutableOrDefault(string? command, string? workingDirectory = null)
+        public static string ResolveExecutableOrDefault(string? command)
         {
             if (string.IsNullOrWhiteSpace(command))
             {
@@ -60,87 +68,90 @@ namespace NovaTerminal.Pty
             }
 
             string trimmed = command.Trim();
-
-            // Probed unquoted, returned as written: a configured command may be quoted to survive
-            // spaces ("C:\Program Files\...\pwsh.exe"), which no File.Exists would ever match, and
-            // whoever spawns it wants the original spelling back.
-            string probe = Unquote(trimmed);
-
-            // Whole string first, so a path that simply contains spaces is found as itself rather
-            // than mistaken for a command plus arguments. This is the same order
-            // TerminalPane.InitializeSessionCore uses when it decides whether to split.
-            if (IsRunnable(probe, workingDirectory))
-            {
-                return trimmed;
-            }
-
-            // A stored command may carry its arguments inline - "zsh -l", "wsl.exe -e /bin/bash" -
-            // and the spawn path supports that, splitting executable from arguments. Probing the
-            // whole string as one filename therefore rejected commands that run perfectly well, and
-            // rejection costs the arguments too. Probe just the executable, and hand back the
-            // combined string: the consumer splits it again with this same method, so the verdict
-            // reached here and the command actually spawned cannot disagree.
-            if (TrySplitCommandLine(trimmed, out string executable, out _) &&
-                IsRunnable(executable, workingDirectory))
-            {
-                return trimmed;
-            }
-
-            return GetDefaultShell();
+            return IsCommandForAnotherPlatform(trimmed) ? GetDefaultShell() : trimmed;
         }
 
         /// <summary>
-        /// True when <paramref name="executable"/> names something this application could start,
-        /// looked for as a path, on <c>PATH</c>, and relative to <paramref name="workingDirectory"/>.
-        /// </summary>
-        private static bool IsRunnable(string executable, string? workingDirectory) =>
-            CanExecute(executable) ||
-            InPath(executable) ||
-            CanExecuteRelativeTo(workingDirectory, executable);
-
-        /// <summary>
-        /// True when <paramref name="candidate"/> resolves against the directory the command will
-        /// actually run in.
+        /// True when <paramref name="command"/> names an executable belonging to a different
+        /// operating system, and so could never start here.
         /// </summary>
         /// <remarks>
-        /// A profile's StartingDirectory becomes the child's cwd (TerminalPane passes it to
-        /// RustPtySession), so a relative command such as <c>./tools/shell</c> runs from there -
-        /// while this check runs in NovaTerminal's own directory and used to declare it missing,
-        /// substituting the default shell and dropping the arguments.
+        /// Judged on the shape of the name alone - no filesystem access, no launcher emulation.
+        /// Deliberately conservative: it fires only on signals that cannot mean anything else, so a
+        /// command it does not recognise is left alone rather than replaced. Missing the occasional
+        /// foreign command costs a spawn failure the user can read; a false positive silently swaps
+        /// out a command that works.
         ///
-        /// Unix only, and that asymmetry is the whole point. <c>exec</c> resolves a relative path
-        /// after the child has changed directory, so the working directory is where it is found.
-        /// <c>CreateProcessW</c> resolves its application name against the *calling* process's
-        /// directory; <c>lpCurrentDirectory</c> only becomes the child's cwd and plays no part in
-        /// finding the executable. So on Windows a match here means nothing - approving the command
-        /// on that basis keeps it, and its arguments, for a spawn that then fails.
-        ///
-        /// An earlier version probed both platforms, reasoning that being additive could only avoid
-        /// false negatives. That was wrong in one direction: on Windows it manufactures a false
-        /// positive, which is the more expensive mistake, since rejection at least falls back to a
-        /// shell that starts. The remark above it described the Windows rule correctly and the code
-        /// beneath it did the opposite.
-        ///
-        /// Only for something that is already a path. A bare name like <c>zsh</c> is resolved
-        /// through PATH, not the working directory, which is what both a shell and exec do.
+        /// Arguments are ignored, via <see cref="TrySplitCommandLine"/>, so <c>cmd.exe /c build</c>
+        /// is recognised by its executable. <c>pwsh</c> is intentionally absent from the Windows
+        /// names: PowerShell is cross-platform and <c>pwsh</c> is a perfectly good Linux command.
         /// </remarks>
-        private static bool CanExecuteRelativeTo(string? workingDirectory, string candidate)
+        public static bool IsCommandForAnotherPlatform(string? command)
         {
-            if (OperatingSystem.IsWindows()) return false;
-            if (string.IsNullOrWhiteSpace(workingDirectory)) return false;
-            if (string.IsNullOrWhiteSpace(candidate)) return false;
-            if (Path.IsPathRooted(candidate)) return false;
-            if (candidate.IndexOf('/') < 0 && candidate.IndexOf('\\') < 0) return false;
+            if (string.IsNullOrWhiteSpace(command)) return false;
 
-            try
+            string executable = command.Trim();
+            if (TrySplitCommandLine(executable, out string exePart, out _))
             {
-                return CanExecute(Path.Combine(workingDirectory, candidate));
+                executable = exePart;
             }
-            catch (ArgumentException)
-            {
-                return false;
-            }
+
+            executable = Unquote(executable).Trim();
+            if (executable.Length == 0) return false;
+
+            return OperatingSystem.IsWindows()
+                ? LooksLikeAUnixCommand(executable)
+                : LooksLikeAWindowsCommand(executable);
         }
+
+        /// <summary>Windows-only shapes: a drive-rooted path, a UNC path, a Windows executable
+        /// suffix, or one of the shells that exist only there.</summary>
+        private static bool LooksLikeAWindowsCommand(string executable)
+        {
+            // UNC, which needs both leading slashes: a single one is not a Windows-only shape.
+            if (executable.StartsWith(@"\\", StringComparison.Ordinal)) return true;
+
+            if (executable.Length >= 3 &&
+                char.IsAsciiLetter(executable[0]) &&
+                executable[1] == ':' &&
+                (executable[2] == '\\' || executable[2] == '/'))
+            {
+                return true;
+            }
+
+            string extension = Path.GetExtension(executable);
+            foreach (string windowsOnly in WindowsExecutableSuffixes)
+            {
+                if (string.Equals(extension, windowsOnly, StringComparison.OrdinalIgnoreCase)) return true;
+            }
+
+            string name = executable.Replace('\\', '/');
+            int lastSlash = name.LastIndexOf('/');
+            if (lastSlash >= 0) name = name[(lastSlash + 1)..];
+
+            foreach (string shell in WindowsOnlyShellNames)
+            {
+                if (string.Equals(name, shell, StringComparison.OrdinalIgnoreCase)) return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>Unix-only shapes: a rooted POSIX path. Nothing on Windows starts with a
+        /// slash, and a bare name there could be anything.</summary>
+        private static bool LooksLikeAUnixCommand(string executable) =>
+            executable.StartsWith('/');
+
+        /// <summary>Suffixes that only Windows executes. <c>.bat</c> and <c>.cmd</c> included: they
+        /// run fine on Windows - <c>CreateProcess</c> hands them to the command processor - and not
+        /// at all anywhere else.</summary>
+        private static readonly string[] WindowsExecutableSuffixes =
+            { ".exe", ".com", ".bat", ".cmd", ".ps1", ".vbs", ".wsf", ".msc" };
+
+        /// <summary>Shells that exist only on Windows, spelled with or without their suffix. Not
+        /// <c>pwsh</c>: PowerShell is cross-platform.</summary>
+        private static readonly string[] WindowsOnlyShellNames =
+            { "cmd", "cmd.exe", "powershell", "powershell.exe", "wsl", "wsl.exe", "conhost", "conhost.exe" };
 
         /// <summary>
         /// Splits a command that carries its arguments inline into its executable and argument
@@ -195,12 +206,17 @@ namespace NovaTerminal.Pty
         /// True when <paramref name="command"/> can be found on <c>PATH</c>.
         /// </summary>
         /// <remarks>
-        /// Windows resolution is extension-aware. A command is legitimately written without one
-        /// there - <c>pwsh</c> runs <c>pwsh.exe</c> - because the process launcher appends each
-        /// <c>PATHEXT</c> entry when the name carries no extension of its own. Probing only the
-        /// literal filename reported those as missing, which for <see cref="ResolveExecutableOrDefault"/>
-        /// meant quietly replacing a working <c>pwsh</c>, <c>powershell</c> or <c>cmd</c> with the
-        /// default shell and discarding its arguments.
+        /// Extension-aware on Windows, where a command is legitimately written without one -
+        /// <c>pwsh</c> runs <c>pwsh.exe</c>, because the launcher appends <c>.exe</c> to a name that
+        /// carries no extension of its own. Probing only the literal filename reported those as
+        /// missing, which is a pre-existing defect in the callers that use this to decide whether a
+        /// profile is usable: an extensionless profile command was reset or hidden.
+        ///
+        /// Only <c>.exe</c> is appended, matching <c>CreateProcessW</c> with <c>lpApplicationName</c>
+        /// NULL (native/src/lib.rs:301). Not PATHEXT, which is a shell's list, and not <c>.com</c> -
+        /// measured on Windows, an extensionless name backed only by a <c>.com</c> fails with
+        /// ERROR_FILE_NOT_FOUND. portable_pty's own search is more permissive than this; the stricter
+        /// of the two launchers is the safe one to model.
         /// </remarks>
         public static bool InPath(string command)
         {
@@ -226,174 +242,14 @@ namespace NovaTerminal.Pty
                     continue;
                 }
 
-                if (CanExecute(fullPath)) return true;
-            }
+                if (File.Exists(fullPath)) return true;
 
-            return false;
-        }
-
-        /// <summary>
-        /// Extensions this application can actually start on Windows.
-        /// </summary>
-        /// <remarks>
-        /// Deliberately not <c>PATHEXT</c>. PATHEXT is the list a *shell* appends, and it includes
-        /// script types - .BAT, .CMD, .PS1, .VBS - that only run because cmd.exe or another
-        /// interpreter runs them. NovaTerminal does not launch through a shell: the native layer
-        /// calls <c>CreateProcessW</c> directly, and the fallback hands the command to
-        /// portable_pty's <c>CommandBuilder</c>. Neither can start a batch file without an
-        /// interpreter.
-        ///
-        /// Probing the full PATHEXT therefore reported a .bat-backed command as runnable, and
-        /// "runnable" is not an idle verdict here - it makes the caller keep the command and its
-        /// arguments instead of falling back, so the user got a pane that failed to spawn rather
-        /// than a working shell. Modelling cmd.exe was the wrong model; this models the launcher.
-        /// </remarks>
-        /// <remarks>
-        /// One entry, and specifically <c>.exe</c>, because that is the only extension the launcher
-        /// appends. The native path calls <c>CreateProcessW</c> with <c>lpApplicationName</c> NULL
-        /// (native/src/lib.rs:301), and Windows then appends <c>.exe</c> - not <c>.com</c>, and not
-        /// anything from PATHEXT. Measured on Windows: an extensionless name backed only by a
-        /// <c>.com</c> fails with ERROR_FILE_NOT_FOUND, while the same file named in full succeeds.
-        ///
-        /// The two launch paths disagree, so this models the stricter one. portable_pty's
-        /// <c>CommandBuilder</c> walks the full PATHEXT when it searches (cmdbuilder.rs), so it is
-        /// *more* permissive than CreateProcessW, not equally strict - an earlier version of this
-        /// remark claimed neither could manage it, which was wrong about portable_pty.
-        ///
-        /// <c>internal</c> so the policy itself can be asserted off Windows. The probe that uses it
-        /// is gated on <see cref="OperatingSystem.IsWindows"/> and so does nothing on Linux, which
-        /// means a test that goes through the filesystem there passes whatever this list contains -
-        /// it would not have caught .bat being in it. The list is the decision worth pinning.
-        /// </remarks>
-        internal static readonly string[] LaunchableWindowsExtensions = { ".exe" };
-
-        /// <summary>
-        /// Windows file types that only run because an interpreter runs them, so this application
-        /// cannot start one directly.
-        /// </summary>
-        /// <remarks>
-        /// Deliberately excludes <c>.bat</c> and <c>.cmd</c>, which this list used to contain on a
-        /// premise that turned out to be false. <c>CreateProcess</c> special-cases batch files and
-        /// runs them through the command processor, so they start perfectly well. Measured on
-        /// Windows against a raw <c>CreateProcessW</c> P/Invoke matching native/src/lib.rs, and again
-        /// through <c>RustPtySession</c> itself: a full-path <c>.bat</c> and <c>.cmd</c> each spawned
-        /// with a live pid, and the <c>.bat</c> produced its own output. Rejecting them substituted
-        /// the default shell for a wrapper that had been working, losing the command and its
-        /// arguments - the expensive failure this check is supposed to prevent.
-        ///
-        /// What remains are the types that genuinely need an interpreter: <c>.ps1</c>, <c>.vbs</c> and
-        /// friends fail with ERROR_BAD_EXE_FORMAT (193) from the same call.
-        ///
-        /// The counterpart to <see cref="LaunchableWindowsExtensions"/>: that list is what the
-        /// launcher will *append* to a bare name, this one is what it cannot start even when named in
-        /// full. They are separate questions and a name being spelled out does not make an
-        /// unstartable file startable.
-        /// </remarks>
-        internal static readonly string[] WindowsExtensionsNeedingAnInterpreter =
-            { ".ps1", ".psm1", ".vbs", ".vbe", ".js", ".jse", ".wsf", ".wsh", ".msc" };
-
-        /// <summary>
-        /// True when <paramref name="candidate"/> names a file this application could start,
-        /// allowing for the extension being left off on Windows.
-        /// </summary>
-        private static bool CanExecute(string candidate)
-        {
-            // Checked before File.Exists, not after: the file existing is exactly what used to make
-            // an explicitly named script look runnable.
-            if (OperatingSystem.IsWindows() && NeedsAnInterpreter(candidate)) return false;
-
-            if (!OperatingSystem.IsWindows())
-            {
-                // Existing is not the same as spawnable here. A regular file with no execute bit -
-                // a config file, a Windows .exe sitting in a shared workspace, a script saved
-                // without chmod +x - passes File.Exists and then fails at exec, which is the dead
-                // pane this check exists to avoid.
-                return HasAnExecuteBit(candidate);
-            }
-
-            if (File.Exists(candidate)) return true;
-            if (!AppendsImplicitExtension(candidate)) return false;
-
-            foreach (string extension in LaunchableWindowsExtensions)
-            {
-                if (File.Exists(candidate + extension)) return true;
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// True when <paramref name="candidate"/> is a file with an execute bit set.
-        /// </summary>
-        /// <remarks>
-        /// Any of user/group/other, rather than resolving effective access for the current user.
-        /// That over-approximates slightly - a file executable only by someone else counts - but it
-        /// rejects the case that actually occurs, a file carrying no execute bit at all, and erring
-        /// toward "runnable" here only preserves today's behaviour. Erring the other way would
-        /// replace a working command with a shell.
-        /// </remarks>
-        private static bool HasAnExecuteBit(string candidate)
-        {
-            if (!File.Exists(candidate)) return false;
-
-            try
-            {
-                UnixFileMode mode = File.GetUnixFileMode(candidate);
-                const UnixFileMode anyExecute =
-                    UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute;
-
-                return (mode & anyExecute) != 0;
-            }
-            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
-            {
-                // Cannot read the mode: fall back to existence rather than declaring a command
-                // missing on the strength of a failed stat.
-                return true;
-            }
-        }
-
-        /// <summary>
-        /// True when Windows would append an extension to <paramref name="candidate"/> while
-        /// looking for the executable.
-        /// </summary>
-        /// <remarks>
-        /// Only for a name with no extension at all. <c>CreateProcessW</c> with
-        /// <c>lpApplicationName</c> NULL appends <c>.exe</c> when "the file name does not contain an
-        /// extension", and a dot anywhere in the final component counts - so <c>python3.11</c> is
-        /// treated as already extensioned and <c>python3.11.exe</c> is never found.
-        ///
-        /// This probe used to append regardless, on a comment of mine arguing that a dot in the stem
-        /// is not a *real* extension so the launcher would keep looking. That describes what a shell
-        /// does. It is the same cmd.exe-shaped assumption that first admitted .bat and .com, left
-        /// standing in the adjacent decision after those were corrected.
-        ///
-        /// <c>internal</c> for the same reason as the extension lists: the caller is gated on
-        /// Windows, so this cannot be reached from a filesystem test on Linux.
-        /// </remarks>
-        internal static bool AppendsImplicitExtension(string? candidate)
-        {
-            if (string.IsNullOrWhiteSpace(candidate)) return false;
-
-            return !Path.HasExtension(candidate);
-        }
-
-        /// <summary>
-        /// True when <paramref name="candidate"/> ends in an extension that needs an interpreter.
-        /// </summary>
-        /// <remarks>
-        /// <c>internal</c> for the same reason as the extension lists: the callers are gated on
-        /// Windows, so a test that goes through the filesystem on Linux cannot exercise this.
-        /// </remarks>
-        internal static bool NeedsAnInterpreter(string? candidate)
-        {
-            if (string.IsNullOrWhiteSpace(candidate)) return false;
-
-            string extension = Path.GetExtension(candidate);
-            if (extension.Length == 0) return false;
-
-            foreach (string scripted in WindowsExtensionsNeedingAnInterpreter)
-            {
-                if (string.Equals(extension, scripted, StringComparison.OrdinalIgnoreCase)) return true;
+                if (OperatingSystem.IsWindows() &&
+                    !Path.HasExtension(fullPath) &&
+                    File.Exists(fullPath + ".exe"))
+                {
+                    return true;
+                }
             }
 
             return false;

--- a/src/NovaTerminal.Pty/ShellHelper.cs
+++ b/src/NovaTerminal.Pty/ShellHelper.cs
@@ -137,14 +137,45 @@ namespace NovaTerminal.Pty
             return false;
         }
 
-        /// <summary>Unix-only shapes: a rooted POSIX path. Nothing on Windows starts with a
-        /// slash, and a bare name there could be anything.</summary>
-        private static bool LooksLikeAUnixCommand(string executable) =>
-            executable.StartsWith('/');
+        /// <summary>Unix-only shapes: a path under one of the filesystem roots only Unix has.</summary>
+        /// <remarks>
+        /// Not simply "starts with a slash", which was the first attempt and is wrong on Windows: a
+        /// leading slash there means rooted-on-the-current-drive, and the path APIs accept <c>/</c>
+        /// as a separator throughout, so <c>/Windows/System32/cmd.exe</c> is a real command that
+        /// launches - measured with <c>CreateProcessW</c> on Windows, pid and all. Flagging it broke
+        /// the rule this predicate is supposed to keep, that it fires only on signals which cannot
+        /// mean anything else. Note the old rule was also inconsistent with itself: the backslash
+        /// spelling of the same drive-relative path was kept while the forward-slash spelling was
+        /// substituted, and both launch.
+        ///
+        /// Requiring a recognisably Unix first segment keeps the rule honest and still catches every
+        /// realistic case - GetDefaultShell on Unix only ever returns a <c>/bin/</c> path, and
+        /// configured shells live under these roots. A path under some other root falls through and
+        /// fails visibly, which is the trade made everywhere else here.
+        /// </remarks>
+        private static bool LooksLikeAUnixCommand(string executable)
+        {
+            foreach (string root in UnixFilesystemRoots)
+            {
+                if (executable.StartsWith(root, StringComparison.OrdinalIgnoreCase)) return true;
+            }
 
-        /// <summary>Suffixes that only Windows executes. <c>.bat</c> and <c>.cmd</c> included: they
-        /// run fine on Windows - <c>CreateProcess</c> hands them to the command processor - and not
-        /// at all anywhere else.</summary>
+            return false;
+        }
+
+        /// <summary>Roots that exist on Unix and not on Windows. Case-insensitive at the point of
+        /// use, since the comparison happens on a Windows machine.</summary>
+        private static readonly string[] UnixFilesystemRoots =
+            { "/bin/", "/sbin/", "/usr/", "/opt/", "/etc/", "/home/", "/var/", "/snap/", "/nix/", "/Library/", "/System/" };
+
+        /// <summary>Suffixes that mark an executable as Windows-addressed.</summary>
+        /// <remarks>
+        /// <c>.bat</c> and <c>.cmd</c> belong here: they run fine on Windows - <c>CreateProcess</c>
+        /// hands them to the command processor - and not at all elsewhere. <c>.ps1</c> is the loose
+        /// one, since PowerShell Core runs .ps1 files on Linux too; it stays because a .ps1 is not
+        /// directly spawnable there either, so the verdict is right even though the reason is
+        /// narrower than "only Windows executes this".
+        /// </remarks>
         private static readonly string[] WindowsExecutableSuffixes =
             { ".exe", ".com", ".bat", ".cmd", ".ps1", ".vbs", ".wsf", ".msc" };
 

--- a/src/NovaTerminal.Pty/ShellHelper.cs
+++ b/src/NovaTerminal.Pty/ShellHelper.cs
@@ -252,9 +252,13 @@ namespace NovaTerminal.Pty
         /// One entry, and specifically <c>.exe</c>, because that is the only extension the launcher
         /// appends. The native path calls <c>CreateProcessW</c> with <c>lpApplicationName</c> NULL
         /// (native/src/lib.rs:301), and Windows then appends <c>.exe</c> - not <c>.com</c>, and not
-        /// anything from PATHEXT, which only a shell consults. <c>.com</c> was in this list on the
-        /// same mistaken reasoning that first put <c>.bat</c> here: modelling cmd.exe rather than
-        /// the launcher.
+        /// anything from PATHEXT. Measured on Windows: an extensionless name backed only by a
+        /// <c>.com</c> fails with ERROR_FILE_NOT_FOUND, while the same file named in full succeeds.
+        ///
+        /// The two launch paths disagree, so this models the stricter one. portable_pty's
+        /// <c>CommandBuilder</c> walks the full PATHEXT when it searches (cmdbuilder.rs), so it is
+        /// *more* permissive than CreateProcessW, not equally strict - an earlier version of this
+        /// remark claimed neither could manage it, which was wrong about portable_pty.
         ///
         /// <c>internal</c> so the policy itself can be asserted off Windows. The probe that uses it
         /// is gated on <see cref="OperatingSystem.IsWindows"/> and so does nothing on Linux, which
@@ -268,22 +272,25 @@ namespace NovaTerminal.Pty
         /// cannot start one directly.
         /// </summary>
         /// <remarks>
-        /// The counterpart to <see cref="LaunchableWindowsExtensions"/>, and the same reasoning: the
-        /// native layer calls <c>CreateProcessW</c> and the fallback uses portable_pty's
-        /// <c>CommandBuilder</c>, neither of which can start a script without its interpreter.
+        /// Deliberately excludes <c>.bat</c> and <c>.cmd</c>, which this list used to contain on a
+        /// premise that turned out to be false. <c>CreateProcess</c> special-cases batch files and
+        /// runs them through the command processor, so they start perfectly well. Measured on
+        /// Windows against a raw <c>CreateProcessW</c> P/Invoke matching native/src/lib.rs, and again
+        /// through <c>RustPtySession</c> itself: a full-path <c>.bat</c> and <c>.cmd</c> each spawned
+        /// with a live pid, and the <c>.bat</c> produced its own output. Rejecting them substituted
+        /// the default shell for a wrapper that had been working, losing the command and its
+        /// arguments - the expensive failure this check is supposed to prevent.
         ///
-        /// Restricting only the *appended* extensions left an inconsistency: an extensionless
-        /// <c>wrapper</c> backed by <c>wrapper.bat</c> was correctly called unrunnable, while an
-        /// explicit <c>wrapper.bat</c> sailed through <c>File.Exists</c> and was kept - producing the
-        /// dead pane the restriction existed to prevent. The verdict now depends on what can be
-        /// launched, not on how the name was spelled.
+        /// What remains are the types that genuinely need an interpreter: <c>.ps1</c>, <c>.vbs</c> and
+        /// friends fail with ERROR_BAD_EXE_FORMAT (193) from the same call.
         ///
-        /// Running these properly means invoking the interpreter (<c>cmd.exe /c wrapper.bat</c>),
-        /// which is a feature rather than a fix and is deliberately not attempted here; falling back
-        /// to a shell that starts is the better of the two outcomes available.
+        /// The counterpart to <see cref="LaunchableWindowsExtensions"/>: that list is what the
+        /// launcher will *append* to a bare name, this one is what it cannot start even when named in
+        /// full. They are separate questions and a name being spelled out does not make an
+        /// unstartable file startable.
         /// </remarks>
         internal static readonly string[] WindowsExtensionsNeedingAnInterpreter =
-            { ".bat", ".cmd", ".ps1", ".psm1", ".vbs", ".vbe", ".js", ".jse", ".wsf", ".wsh", ".msc" };
+            { ".ps1", ".psm1", ".vbs", ".vbe", ".js", ".jse", ".wsf", ".wsh", ".msc" };
 
         /// <summary>
         /// True when <paramref name="candidate"/> names a file this application could start,

--- a/src/NovaTerminal.Pty/ShellHelper.cs
+++ b/src/NovaTerminal.Pty/ShellHelper.cs
@@ -108,16 +108,25 @@ namespace NovaTerminal.Pty
         /// while this check runs in NovaTerminal's own directory and used to declare it missing,
         /// substituting the default shell and dropping the arguments.
         ///
-        /// Additive rather than a replacement, because which directory wins is platform-specific:
-        /// exec resolves a relative path against the child's cwd, but Windows resolves
-        /// CreateProcessW's application name against the *calling* process's directory, not the one
-        /// passed as lpCurrentDirectory. Probing both avoids a false negative on either.
+        /// Unix only, and that asymmetry is the whole point. <c>exec</c> resolves a relative path
+        /// after the child has changed directory, so the working directory is where it is found.
+        /// <c>CreateProcessW</c> resolves its application name against the *calling* process's
+        /// directory; <c>lpCurrentDirectory</c> only becomes the child's cwd and plays no part in
+        /// finding the executable. So on Windows a match here means nothing - approving the command
+        /// on that basis keeps it, and its arguments, for a spawn that then fails.
+        ///
+        /// An earlier version probed both platforms, reasoning that being additive could only avoid
+        /// false negatives. That was wrong in one direction: on Windows it manufactures a false
+        /// positive, which is the more expensive mistake, since rejection at least falls back to a
+        /// shell that starts. The remark above it described the Windows rule correctly and the code
+        /// beneath it did the opposite.
         ///
         /// Only for something that is already a path. A bare name like <c>zsh</c> is resolved
         /// through PATH, not the working directory, which is what both a shell and exec do.
         /// </remarks>
         private static bool CanExecuteRelativeTo(string? workingDirectory, string candidate)
         {
+            if (OperatingSystem.IsWindows()) return false;
             if (string.IsNullOrWhiteSpace(workingDirectory)) return false;
             if (string.IsNullOrWhiteSpace(candidate)) return false;
             if (Path.IsPathRooted(candidate)) return false;
@@ -286,8 +295,16 @@ namespace NovaTerminal.Pty
             // an explicitly named script look runnable.
             if (OperatingSystem.IsWindows() && NeedsAnInterpreter(candidate)) return false;
 
+            if (!OperatingSystem.IsWindows())
+            {
+                // Existing is not the same as spawnable here. A regular file with no execute bit -
+                // a config file, a Windows .exe sitting in a shared workspace, a script saved
+                // without chmod +x - passes File.Exists and then fails at exec, which is the dead
+                // pane this check exists to avoid.
+                return HasAnExecuteBit(candidate);
+            }
+
             if (File.Exists(candidate)) return true;
-            if (!OperatingSystem.IsWindows()) return false;
             if (!AppendsImplicitExtension(candidate)) return false;
 
             foreach (string extension in LaunchableWindowsExtensions)
@@ -296,6 +313,36 @@ namespace NovaTerminal.Pty
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// True when <paramref name="candidate"/> is a file with an execute bit set.
+        /// </summary>
+        /// <remarks>
+        /// Any of user/group/other, rather than resolving effective access for the current user.
+        /// That over-approximates slightly - a file executable only by someone else counts - but it
+        /// rejects the case that actually occurs, a file carrying no execute bit at all, and erring
+        /// toward "runnable" here only preserves today's behaviour. Erring the other way would
+        /// replace a working command with a shell.
+        /// </remarks>
+        private static bool HasAnExecuteBit(string candidate)
+        {
+            if (!File.Exists(candidate)) return false;
+
+            try
+            {
+                UnixFileMode mode = File.GetUnixFileMode(candidate);
+                const UnixFileMode anyExecute =
+                    UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute;
+
+                return (mode & anyExecute) != 0;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+            {
+                // Cannot read the mode: fall back to existence rather than declaring a command
+                // missing on the strength of a failed stat.
+                return true;
+            }
         }
 
         /// <summary>

--- a/src/NovaTerminal.Pty/ShellHelper.cs
+++ b/src/NovaTerminal.Pty/ShellHelper.cs
@@ -61,7 +61,62 @@ namespace NovaTerminal.Pty
             // whoever spawns it wants the original spelling back.
             string probe = Unquote(trimmed);
 
-            return CanExecute(probe) || InPath(probe) ? trimmed : GetDefaultShell();
+            // Whole string first, so a path that simply contains spaces is found as itself rather
+            // than mistaken for a command plus arguments. This is the same order
+            // TerminalPane.InitializeSessionCore uses when it decides whether to split.
+            if (CanExecute(probe) || InPath(probe))
+            {
+                return trimmed;
+            }
+
+            // A stored command may carry its arguments inline - "zsh -l", "wsl.exe -e /bin/bash" -
+            // and the pane supports that, splitting executable from arguments at the first space.
+            // Probing the whole string as one filename therefore rejected commands that run
+            // perfectly well, and rejection costs the arguments too. Probe just the executable, and
+            // still hand back the combined string so the pane's own split does the parsing.
+            if (TryGetExecutablePortion(probe, out string executable) &&
+                (CanExecute(executable) || InPath(executable)))
+            {
+                return trimmed;
+            }
+
+            return GetDefaultShell();
+        }
+
+        /// <summary>
+        /// Extracts the executable from a command that carries its arguments inline, mirroring the
+        /// split in <c>TerminalPane.InitializeSessionCore</c>.
+        /// </summary>
+        /// <remarks>
+        /// False when there is nothing to split, so the caller keeps whatever verdict it already
+        /// reached about the whole string.
+        /// </remarks>
+        private static bool TryGetExecutablePortion(string command, out string executable)
+        {
+            // A quoted executable followed by arguments: "C:\Program Files\...\pwsh.exe" -NoLogo.
+            // The closing quote delimits it, not the first space, which falls inside the path.
+            if (command.StartsWith('"'))
+            {
+                int closingQuote = command.IndexOf('"', 1);
+                if (closingQuote > 1)
+                {
+                    executable = command[1..closingQuote];
+                    return true;
+                }
+
+                executable = string.Empty;
+                return false;
+            }
+
+            int firstSpace = command.IndexOf(' ');
+            if (firstSpace <= 0)
+            {
+                executable = string.Empty;
+                return false;
+            }
+
+            executable = command[..firstSpace];
+            return true;
         }
 
         /// <summary>

--- a/src/NovaTerminal.Pty/ShellHelper.cs
+++ b/src/NovaTerminal.Pty/ShellHelper.cs
@@ -41,6 +41,11 @@ namespace NovaTerminal.Pty
         /// This mirrors the existence check the profile-launch path in <c>MainWindow</c> already
         /// applies to local profiles, so a restored pane and a profile-launched one agree about
         /// what is runnable.
+        ///
+        /// Be careful changing what counts as runnable: saying "no" here does not just pick a
+        /// different command, it also makes <c>SessionManager</c> drop the pane's arguments, on the
+        /// grounds that they belonged to the command being replaced. A false negative therefore
+        /// costs the user their command *and* its arguments, silently.
         /// </remarks>
         public static string ResolveExecutableOrDefault(string? command)
         {
@@ -50,11 +55,30 @@ namespace NovaTerminal.Pty
             }
 
             string trimmed = command.Trim();
-            return File.Exists(trimmed) || InPath(trimmed) ? trimmed : GetDefaultShell();
+
+            // Probed unquoted, returned as written: a configured command may be quoted to survive
+            // spaces ("C:\Program Files\...\pwsh.exe"), which no File.Exists would ever match, and
+            // whoever spawns it wants the original spelling back.
+            string probe = Unquote(trimmed);
+
+            return CanExecute(probe) || InPath(probe) ? trimmed : GetDefaultShell();
         }
 
+        /// <summary>
+        /// True when <paramref name="command"/> can be found on <c>PATH</c>.
+        /// </summary>
+        /// <remarks>
+        /// Windows resolution is extension-aware. A command is legitimately written without one
+        /// there - <c>pwsh</c> runs <c>pwsh.exe</c> - because the process launcher appends each
+        /// <c>PATHEXT</c> entry when the name carries no extension of its own. Probing only the
+        /// literal filename reported those as missing, which for <see cref="ResolveExecutableOrDefault"/>
+        /// meant quietly replacing a working <c>pwsh</c>, <c>powershell</c> or <c>cmd</c> with the
+        /// default shell and discarding its arguments.
+        /// </remarks>
         public static bool InPath(string command)
         {
+            if (string.IsNullOrWhiteSpace(command)) return false;
+
             var path = Environment.GetEnvironmentVariable("PATH");
             if (string.IsNullOrEmpty(path)) return false;
 
@@ -62,10 +86,84 @@ namespace NovaTerminal.Pty
 
             foreach (var dir in dirs)
             {
-                var fullPath = Path.Combine(dir, command);
-                if (File.Exists(fullPath)) return true;
+                if (string.IsNullOrWhiteSpace(dir)) continue;
+
+                string fullPath;
+                try
+                {
+                    fullPath = Path.Combine(dir, command);
+                }
+                catch (ArgumentException)
+                {
+                    // A malformed PATH entry is not worth failing the whole probe over.
+                    continue;
+                }
+
+                if (CanExecute(fullPath)) return true;
             }
+
             return false;
         }
+
+        /// <summary>
+        /// True when <paramref name="candidate"/> names a file that exists, allowing for Windows
+        /// appending a <c>PATHEXT</c> extension to a name that has none.
+        /// </summary>
+        private static bool CanExecute(string candidate)
+        {
+            if (File.Exists(candidate)) return true;
+            if (!OperatingSystem.IsWindows()) return false;
+
+            // Tried even when the name looks like it already has an extension: a "." in the stem
+            // (python3.11) is not an executable extension, and the launcher would still go on to
+            // append one. Guessing wrong here reintroduces the false negative, and an extra
+            // File.Exists that misses costs nothing.
+            foreach (string extension in WindowsExecutableExtensions())
+            {
+                if (File.Exists(candidate + extension)) return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// The extensions Windows appends to an extensionless command, from <c>PATHEXT</c>.
+        /// </summary>
+        private static string[] WindowsExecutableExtensions() =>
+            ParseExecutableExtensions(Environment.GetEnvironmentVariable("PATHEXT"));
+
+        /// <summary>
+        /// Parses a <c>PATHEXT</c> value into normalised extensions.
+        /// </summary>
+        /// <remarks>
+        /// Split out as a pure function, and <c>internal</c> rather than private, so the parsing
+        /// can be tested off Windows. The rest of the extension handling is a File.Exists loop,
+        /// but this part has the details worth getting wrong - a cleared variable, entries without
+        /// a leading dot, stray whitespace - and it is the half that does not need a Windows
+        /// filesystem to verify. Taking the value as an argument rather than reading the
+        /// environment also keeps the tests from mutating process-wide state other tests read.
+        /// </remarks>
+        internal static string[] ParseExecutableExtensions(string? pathExtValue)
+        {
+            // The launcher's own defaults, for the rare environment that clears PATHEXT.
+            string pathExt = string.IsNullOrWhiteSpace(pathExtValue) ? ".COM;.EXE;.BAT;.CMD" : pathExtValue;
+
+            string[] parts = pathExt.Split(
+                ';',
+                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            for (int i = 0; i < parts.Length; i++)
+            {
+                if (!parts[i].StartsWith('.')) parts[i] = "." + parts[i];
+            }
+
+            return parts;
+        }
+
+        /// <summary>Strips one layer of surrounding double quotes.</summary>
+        private static string Unquote(string value) =>
+            value.Length >= 2 && value[0] == '"' && value[^1] == '"'
+                ? value[1..^1]
+                : value;
     }
 }

--- a/src/NovaTerminal.Pty/ShellHelper.cs
+++ b/src/NovaTerminal.Pty/ShellHelper.cs
@@ -240,12 +240,19 @@ namespace NovaTerminal.Pty
         /// than a working shell. Modelling cmd.exe was the wrong model; this models the launcher.
         /// </remarks>
         /// <remarks>
+        /// One entry, and specifically <c>.exe</c>, because that is the only extension the launcher
+        /// appends. The native path calls <c>CreateProcessW</c> with <c>lpApplicationName</c> NULL
+        /// (native/src/lib.rs:301), and Windows then appends <c>.exe</c> - not <c>.com</c>, and not
+        /// anything from PATHEXT, which only a shell consults. <c>.com</c> was in this list on the
+        /// same mistaken reasoning that first put <c>.bat</c> here: modelling cmd.exe rather than
+        /// the launcher.
+        ///
         /// <c>internal</c> so the policy itself can be asserted off Windows. The probe that uses it
         /// is gated on <see cref="OperatingSystem.IsWindows"/> and so does nothing on Linux, which
         /// means a test that goes through the filesystem there passes whatever this list contains -
         /// it would not have caught .bat being in it. The list is the decision worth pinning.
         /// </remarks>
-        internal static readonly string[] LaunchableWindowsExtensions = { ".exe", ".com" };
+        internal static readonly string[] LaunchableWindowsExtensions = { ".exe" };
 
         /// <summary>
         /// Windows file types that only run because an interpreter runs them, so this application
@@ -281,17 +288,39 @@ namespace NovaTerminal.Pty
 
             if (File.Exists(candidate)) return true;
             if (!OperatingSystem.IsWindows()) return false;
+            if (!AppendsImplicitExtension(candidate)) return false;
 
-            // Tried even when the name looks like it already has an extension: a "." in the stem
-            // (python3.11) is not an executable extension, and the launcher would still go on to
-            // append one. Guessing wrong here reintroduces the false negative, and an extra
-            // File.Exists that misses costs nothing.
             foreach (string extension in LaunchableWindowsExtensions)
             {
                 if (File.Exists(candidate + extension)) return true;
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// True when Windows would append an extension to <paramref name="candidate"/> while
+        /// looking for the executable.
+        /// </summary>
+        /// <remarks>
+        /// Only for a name with no extension at all. <c>CreateProcessW</c> with
+        /// <c>lpApplicationName</c> NULL appends <c>.exe</c> when "the file name does not contain an
+        /// extension", and a dot anywhere in the final component counts - so <c>python3.11</c> is
+        /// treated as already extensioned and <c>python3.11.exe</c> is never found.
+        ///
+        /// This probe used to append regardless, on a comment of mine arguing that a dot in the stem
+        /// is not a *real* extension so the launcher would keep looking. That describes what a shell
+        /// does. It is the same cmd.exe-shaped assumption that first admitted .bat and .com, left
+        /// standing in the adjacent decision after those were corrected.
+        ///
+        /// <c>internal</c> for the same reason as the extension lists: the caller is gated on
+        /// Windows, so this cannot be reached from a filesystem test on Linux.
+        /// </remarks>
+        internal static bool AppendsImplicitExtension(string? candidate)
+        {
+            if (string.IsNullOrWhiteSpace(candidate)) return false;
+
+            return !Path.HasExtension(candidate);
         }
 
         /// <summary>

--- a/src/NovaTerminal.Pty/ShellHelper.cs
+++ b/src/NovaTerminal.Pty/ShellHelper.cs
@@ -77,8 +77,10 @@ namespace NovaTerminal.Pty
         /// </summary>
         /// <remarks>
         /// Judged on the shape of the name alone - no filesystem access, no launcher emulation.
-        /// Deliberately conservative: it fires only on signals that cannot mean anything else, so a
-        /// command it does not recognise is left alone rather than replaced. Missing the occasional
+        /// Deliberately conservative: it fires only on signals that do not plausibly mean anything
+        /// else, so a command it does not recognise is left alone rather than replaced. "Plausibly"
+        /// is doing real work there - see <see cref="UnixFilesystemRoots"/>, where one entry is a
+        /// probability judgement rather than an impossibility. Missing the occasional
         /// foreign command costs a spawn failure the user can read; a false positive silently swaps
         /// out a command that works.
         ///
@@ -142,14 +144,12 @@ namespace NovaTerminal.Pty
         /// Not simply "starts with a slash", which was the first attempt and is wrong on Windows: a
         /// leading slash there means rooted-on-the-current-drive, and the path APIs accept <c>/</c>
         /// as a separator throughout, so <c>/Windows/System32/cmd.exe</c> is a real command that
-        /// launches - measured with <c>CreateProcessW</c> on Windows, pid and all. Flagging it broke
-        /// the rule this predicate is supposed to keep, that it fires only on signals which cannot
-        /// mean anything else. Note the old rule was also inconsistent with itself: the backslash
+        /// launches - measured with <c>CreateProcessW</c> on Windows, pid and all. Note the old rule
+        /// was also inconsistent with itself: the backslash
         /// spelling of the same drive-relative path was kept while the forward-slash spelling was
         /// substituted, and both launch.
         ///
-        /// Requiring a recognisably Unix first segment keeps the rule honest and still catches every
-        /// realistic case - GetDefaultShell on Unix only ever returns a <c>/bin/</c> path, and
+        /// Requiring a recognisably Unix first segment still catches every realistic case - GetDefaultShell on Unix only ever returns a <c>/bin/</c> path, and
         /// configured shells live under these roots. A path under some other root falls through and
         /// fails visibly, which is the trade made everywhere else here.
         /// </remarks>
@@ -163,10 +163,33 @@ namespace NovaTerminal.Pty
             return false;
         }
 
-        /// <summary>Roots that exist on Unix and not on Windows. Case-insensitive at the point of
-        /// use, since the comparison happens on a Windows machine.</summary>
+        /// <summary>Roots that name a Unix location and, in practice, not a Windows one.</summary>
+        /// <remarks>
+        /// "In practice" rather than "never", because a leading slash on Windows is rooted on the
+        /// current drive, so each of these is also a spellable Windows path. Every entry was checked
+        /// against a real Windows filesystem for a collision before being listed, and one collides:
+        /// <c>C:\home\</c> existed on the machine this was verified on, created by some dev tool. So
+        /// <c>/home/tools/shell.exe</c> would be substituted there even though it is launchable.
+        ///
+        /// <c>/home/</c> stays anyway, on a probability judgement rather than a principle: it is the
+        /// most common Linux home root and nobody writes a Windows profile command that way. That
+        /// makes this list a considered trade, not an invariant - which is why the remarks on
+        /// <see cref="LooksLikeAUnixCommand"/> no longer claim these signals cannot mean anything
+        /// else.
+        ///
+        /// <c>/run/</c> is here for NixOS, whose configured system shell is
+        /// <c>/run/current-system/sw/bin/bash</c> rather than a <c>/nix/store/</c> path.
+        ///
+        /// Deliberately absent: <c>/Users/</c>. It looks like the obvious companion to
+        /// <c>/home/</c> for macOS, and it is the one entry that must not be added -
+        /// <c>C:\Users\</c> exists on every Windows machine, so it would recreate exactly the
+        /// false-positive class this list was tightened to remove. The macOS home case is not
+        /// reachable this way; it falls through and fails visibly instead.
+        ///
+        /// Case-insensitive at the point of use, since the comparison happens on Windows.
+        /// </remarks>
         private static readonly string[] UnixFilesystemRoots =
-            { "/bin/", "/sbin/", "/usr/", "/opt/", "/etc/", "/home/", "/var/", "/snap/", "/nix/", "/Library/", "/System/" };
+            { "/bin/", "/sbin/", "/usr/", "/opt/", "/etc/", "/home/", "/var/", "/run/", "/snap/", "/nix/", "/Library/", "/System/" };
 
         /// <summary>Suffixes that mark an executable as Windows-addressed.</summary>
         /// <remarks>

--- a/tests/NovaTerminal.App.Tests/Core/SessionManagerTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/SessionManagerTests.cs
@@ -82,6 +82,87 @@ public sealed class SessionManagerTests
         Assert.Equal(17, termView!.FontSize);
     }
 
+    // Restoring a session saved on another OS used to be permanently fatal: the pane's persisted
+    // Command was only checked for blankness, so a Windows workspace restored "cmd.exe" on Linux,
+    // the spawn failed, and the same value was written back out on exit - so every later launch
+    // failed identically. The pane now falls back to a shell that exists here.
+    [AvaloniaFact]
+    public void CreateRestoredTabContent_CommandFromAnotherPlatform_FallsBackToARunnableShell()
+    {
+        var settings = new TerminalSettings();
+
+        var tabSession = new TabSession
+        {
+            Title = "Local",
+            Root = new PaneNode
+            {
+                Type = NodeType.Leaf,
+                // No ProfileId, so the restore takes the raw-command path rather than resolving
+                // a profile - exactly the shape a first-run session file has.
+                Command = OperatingSystem.IsWindows() ? "/bin/bash" : "cmd.exe",
+                Arguments = "",
+                PaneId = Guid.NewGuid().ToString()
+            }
+        };
+
+        var pane = Assert.IsType<TerminalPane>(
+            SessionManager.CreateRestoredTabContent(tabSession, settings));
+
+        Assert.Equal(ShellHelper.GetDefaultShell(), pane.ShellCommand);
+    }
+
+    // The arguments belonged to the command that was replaced. Carrying them over would hand the
+    // substituted shell another shell's flags - a persisted `cmd.exe /c ...` reaching bash as
+    // `/c ...`.
+    [AvaloniaFact]
+    public void CreateRestoredTabContent_WhenCommandIsSubstituted_DropsTheForeignArguments()
+    {
+        var settings = new TerminalSettings();
+
+        var tabSession = new TabSession
+        {
+            Title = "Local",
+            Root = new PaneNode
+            {
+                Type = NodeType.Leaf,
+                Command = OperatingSystem.IsWindows() ? "/bin/bash" : "cmd.exe",
+                Arguments = OperatingSystem.IsWindows() ? "-lc echo hi" : "/c echo hi",
+                PaneId = Guid.NewGuid().ToString()
+            }
+        };
+
+        var pane = Assert.IsType<TerminalPane>(
+            SessionManager.CreateRestoredTabContent(tabSession, settings));
+
+        Assert.Equal(ShellHelper.GetDefaultShell(), pane.ShellCommand);
+        Assert.Equal(string.Empty, pane.ShellArgs);
+    }
+
+    // The flip side: a command that does run here keeps both itself and its arguments.
+    [AvaloniaFact]
+    public void CreateRestoredTabContent_RunnableCommand_KeepsItsArguments()
+    {
+        var settings = new TerminalSettings();
+
+        var tabSession = new TabSession
+        {
+            Title = "Local",
+            Root = new PaneNode
+            {
+                Type = NodeType.Leaf,
+                Command = ShellHelper.GetDefaultShell(),
+                Arguments = "--version",
+                PaneId = Guid.NewGuid().ToString()
+            }
+        };
+
+        var pane = Assert.IsType<TerminalPane>(
+            SessionManager.CreateRestoredTabContent(tabSession, settings));
+
+        Assert.Equal(ShellHelper.GetDefaultShell(), pane.ShellCommand);
+        Assert.Equal("--version", pane.ShellArgs);
+    }
+
     [AvaloniaFact]
     public void RestoreSession_UsesStoreBackedSshProfileAndPreservesBackendKind()
     {

--- a/tests/NovaTerminal.App.Tests/Core/SessionManagerTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/SessionManagerTests.cs
@@ -254,7 +254,16 @@ public sealed class SessionManagerTests
 
         try
         {
-            File.WriteAllText(Path.Combine(directory, "tools", "shell"), "");
+            // Executable, not merely present: an existing file with no execute bit is not
+            // spawnable on Unix, so writing 0644 here would assert the opposite of the contract.
+            string shell = Path.Combine(directory, "tools", "shell");
+            File.WriteAllText(shell, "");
+            if (!OperatingSystem.IsWindows())
+            {
+                File.SetUnixFileMode(
+                    shell,
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            }
 
             var profile = new TerminalProfile
             {

--- a/tests/NovaTerminal.App.Tests/Core/SessionManagerTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/SessionManagerTests.cs
@@ -243,6 +243,45 @@ public sealed class SessionManagerTests
         Assert.Same(ssh, pane.Profile);
     }
 
+    // The profile path is where the StartingDirectory is known, and where round 5a landed: a
+    // relative command runs from the profile's directory, so probing it from NovaTerminal's own
+    // directory called it missing and substituted the shell.
+    [AvaloniaFact]
+    public void CreateRestoredTabContent_RelativeProfileCommandUnderItsStartingDirectory_IsKept()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), "nova profile relative " + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(directory, "tools"));
+
+        try
+        {
+            File.WriteAllText(Path.Combine(directory, "tools", "shell"), "");
+
+            var profile = new TerminalProfile
+            {
+                Id = Guid.NewGuid(),
+                Name = "Project shell",
+                Type = ConnectionType.Local,
+                Command = "./tools/shell",
+                Arguments = "--login",
+                StartingDirectory = directory
+            };
+
+            var settings = new TerminalSettings { Profiles = new List<TerminalProfile> { profile } };
+
+            var pane = Assert.IsType<TerminalPane>(
+                SessionManager.CreateRestoredTabContent(LeafTabWithProfile(profile.Id), settings));
+
+            // Kept, arguments and all - and the stored profile handed through untouched.
+            Assert.Same(profile, pane.Profile);
+            Assert.Equal("./tools/shell", pane.Profile!.Command);
+            Assert.Equal("--login", pane.Profile.Arguments);
+        }
+        finally
+        {
+            try { Directory.Delete(directory, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     private static TabSession LeafTabWithProfile(Guid profileId) => new()
     {
         Title = "Restored",

--- a/tests/NovaTerminal.App.Tests/Core/SessionManagerTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/SessionManagerTests.cs
@@ -243,69 +243,34 @@ public sealed class SessionManagerTests
         Assert.Same(ssh, pane.Profile);
     }
 
-    // The profile path is where the StartingDirectory is known, and where round 5a landed: a
-    // relative command runs from the profile's directory, so probing it from NovaTerminal's own
-    // directory called it missing and substituted the shell.
+    // A relative command is not addressed to another OS, so it is kept on both platforms and the
+    // stored profile is handed straight through. This test has been wrong twice, in both directions,
+    // while the predicate underneath it changed - first asserting the Unix outcome unconditionally,
+    // then asserting a Windows substitution that the narrowed predicate no longer performs. Neither
+    // platform needs a special case now, which is the point.
     [AvaloniaFact]
-    public void CreateRestoredTabContent_RelativeProfileCommand_FollowsThePlatformResolutionRule()
+    public void CreateRestoredTabContent_RelativeProfileCommand_IsKeptOnEveryPlatform()
     {
-        string directory = Path.Combine(Path.GetTempPath(), "nova profile relative " + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(Path.Combine(directory, "tools"));
-
-        try
+        var profile = new TerminalProfile
         {
-            // Executable, not merely present: an existing file with no execute bit is not
-            // spawnable on Unix, so writing 0644 here would assert the opposite of the contract.
-            string shell = Path.Combine(directory, "tools", "shell");
-            File.WriteAllText(shell, "");
-            if (!OperatingSystem.IsWindows())
-            {
-                File.SetUnixFileMode(
-                    shell,
-                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
-            }
+            Id = Guid.NewGuid(),
+            Name = "Project shell",
+            Type = ConnectionType.Local,
+            Command = "./tools/shell",
+            Arguments = "--login",
+            StartingDirectory = Path.GetTempPath()
+        };
 
-            var profile = new TerminalProfile
-            {
-                Id = Guid.NewGuid(),
-                Name = "Project shell",
-                Type = ConnectionType.Local,
-                Command = "./tools/shell",
-                Arguments = "--login",
-                StartingDirectory = directory
-            };
+        var settings = new TerminalSettings { Profiles = new List<TerminalProfile> { profile } };
 
-            var settings = new TerminalSettings { Profiles = new List<TerminalProfile> { profile } };
+        var pane = Assert.IsType<TerminalPane>(
+            SessionManager.CreateRestoredTabContent(LeafTabWithProfile(profile.Id), settings));
 
-            var pane = Assert.IsType<TerminalPane>(
-                SessionManager.CreateRestoredTabContent(LeafTabWithProfile(profile.Id), settings));
-
-            if (OperatingSystem.IsWindows())
-            {
-                // CreateProcessW resolves a relative executable against the *calling* process's
-                // directory, not the one handed to it as the child's cwd, so a match under
-                // StartingDirectory proves nothing here and the command is substituted. The profile
-                // therefore comes back as a copy, which is what keeps the stored one unedited.
-                Assert.NotSame(profile, pane.Profile);
-                Assert.Equal(ShellHelper.GetDefaultShell(), pane.Profile!.Command);
-                Assert.Equal(string.Empty, pane.Profile.Arguments);
-
-                // The stored profile is untouched either way - the point of copying.
-                Assert.Equal("./tools/shell", profile.Command);
-                Assert.Equal("--login", profile.Arguments);
-            }
-            else
-            {
-                // Kept, arguments and all - and the stored profile handed through untouched.
-                Assert.Same(profile, pane.Profile);
-                Assert.Equal("./tools/shell", pane.Profile!.Command);
-                Assert.Equal("--login", pane.Profile.Arguments);
-            }
-        }
-        finally
-        {
-            try { Directory.Delete(directory, recursive: true); } catch { /* best effort */ }
-        }
+        // No filesystem lookup happens, so whether the file is there does not enter into it: a
+        // command that cannot be found fails visibly at spawn rather than being swapped out.
+        Assert.Same(profile, pane.Profile);
+        Assert.Equal("./tools/shell", pane.Profile!.Command);
+        Assert.Equal("--login", pane.Profile.Arguments);
     }
 
     private static TabSession LeafTabWithProfile(Guid profileId) => new()

--- a/tests/NovaTerminal.App.Tests/Core/SessionManagerTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/SessionManagerTests.cs
@@ -138,6 +138,122 @@ public sealed class SessionManagerTests
         Assert.Equal(string.Empty, pane.ShellArgs);
     }
 
+    // A profile-backed pane never reached the raw-command fallback, and normal capture writes a
+    // ProfileId for every profile-backed pane - so the common shape of the bug was the uncovered
+    // one. Opening Windows settings on Linux keeps the imported cmd.exe profile (validation only
+    // *adds* this platform's defaults), the pane's ProfileId resolves to it, and the pane failed to
+    // spawn on every launch.
+    [AvaloniaFact]
+    public void CreateRestoredTabContent_ProfileCommandFromAnotherPlatform_FallsBackToARunnableShell()
+    {
+        var foreign = new TerminalProfile
+        {
+            Id = Guid.NewGuid(),
+            Name = "Imported",
+            Type = ConnectionType.Local,
+            Command = OperatingSystem.IsWindows() ? "/bin/bash" : "cmd.exe",
+            Arguments = OperatingSystem.IsWindows() ? "-lc echo hi" : "/c echo hi"
+        };
+
+        var settings = new TerminalSettings { Profiles = new List<TerminalProfile> { foreign } };
+        settings.DefaultProfileId = foreign.Id;
+
+        var pane = Assert.IsType<TerminalPane>(
+            SessionManager.CreateRestoredTabContent(LeafTabWithProfile(foreign.Id), settings));
+
+        Assert.Equal(ShellHelper.GetDefaultShell(), pane.ShellCommand);
+        Assert.Equal(string.Empty, pane.ShellArgs);
+    }
+
+    // The substitution must not reach the stored profile. TryResolvePaneProfile returns the instance
+    // that lives in TerminalSettings.Profiles, so editing it in place would rewrite the user's own
+    // profile - and persist that rewrite the next time settings were saved.
+    [AvaloniaFact]
+    public void CreateRestoredTabContent_WhenAProfileCommandIsSubstituted_TheStoredProfileIsUntouched()
+    {
+        string foreignCommand = OperatingSystem.IsWindows() ? "/bin/bash" : "cmd.exe";
+        const string foreignArguments = "--some-foreign-flag";
+
+        var stored = new TerminalProfile
+        {
+            Id = Guid.NewGuid(),
+            Name = "Imported",
+            Type = ConnectionType.Local,
+            Command = foreignCommand,
+            Arguments = foreignArguments
+        };
+
+        var settings = new TerminalSettings { Profiles = new List<TerminalProfile> { stored } };
+        settings.DefaultProfileId = stored.Id;
+
+        SessionManager.CreateRestoredTabContent(LeafTabWithProfile(stored.Id), settings);
+
+        Assert.Equal(foreignCommand, stored.Command);
+        Assert.Equal(foreignArguments, stored.Arguments);
+        Assert.Same(stored, settings.Profiles[0]);
+    }
+
+    [AvaloniaFact]
+    public void CreateRestoredTabContent_RunnableProfileCommand_IsUsedAsItStands()
+    {
+        var runnable = new TerminalProfile
+        {
+            Id = Guid.NewGuid(),
+            Name = "Local",
+            Type = ConnectionType.Local,
+            Command = ShellHelper.GetDefaultShell(),
+            Arguments = ""
+        };
+
+        var settings = new TerminalSettings { Profiles = new List<TerminalProfile> { runnable } };
+        settings.DefaultProfileId = runnable.Id;
+
+        var pane = Assert.IsType<TerminalPane>(
+            SessionManager.CreateRestoredTabContent(LeafTabWithProfile(runnable.Id), settings));
+
+        Assert.Equal(runnable.Command, pane.ShellCommand);
+        // The stored instance is handed straight through when nothing needed changing.
+        Assert.Same(runnable, pane.Profile);
+    }
+
+    // SSH profiles have their command built for them, so the local-executable check must not touch
+    // one - substituting a shell there would break the connection rather than repair it.
+    [AvaloniaFact]
+    public void CreateRestoredTabContent_SshProfile_IsNotTreatedAsALocalCommand()
+    {
+        var ssh = new TerminalProfile
+        {
+            Id = Guid.NewGuid(),
+            Name = "Remote",
+            Type = ConnectionType.SSH,
+            // Deliberately unspawnable as a local command: if the local substitution ever applied
+            // to SSH profiles, this is what it would replace.
+            Command = OperatingSystem.IsWindows() ? "/bin/bash" : "cmd.exe",
+            SshHost = "example.internal",
+            SshUser = "ops"
+        };
+
+        var settings = new TerminalSettings { Profiles = new List<TerminalProfile> { ssh } };
+
+        var pane = Assert.IsType<TerminalPane>(
+            SessionManager.CreateRestoredTabContent(LeafTabWithProfile(ssh.Id), settings));
+
+        Assert.NotNull(pane.Profile);
+        Assert.Equal(ConnectionType.SSH, pane.Profile!.Type);
+        Assert.Same(ssh, pane.Profile);
+    }
+
+    private static TabSession LeafTabWithProfile(Guid profileId) => new()
+    {
+        Title = "Restored",
+        Root = new PaneNode
+        {
+            Type = NodeType.Leaf,
+            ProfileId = profileId.ToString(),
+            PaneId = Guid.NewGuid().ToString()
+        }
+    };
+
     // The flip side: a command that does run here keeps both itself and its arguments.
     [AvaloniaFact]
     public void CreateRestoredTabContent_RunnableCommand_KeepsItsArguments()

--- a/tests/NovaTerminal.App.Tests/Core/SessionManagerTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/SessionManagerTests.cs
@@ -247,7 +247,7 @@ public sealed class SessionManagerTests
     // relative command runs from the profile's directory, so probing it from NovaTerminal's own
     // directory called it missing and substituted the shell.
     [AvaloniaFact]
-    public void CreateRestoredTabContent_RelativeProfileCommandUnderItsStartingDirectory_IsKept()
+    public void CreateRestoredTabContent_RelativeProfileCommand_FollowsThePlatformResolutionRule()
     {
         string directory = Path.Combine(Path.GetTempPath(), "nova profile relative " + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(Path.Combine(directory, "tools"));
@@ -280,10 +280,27 @@ public sealed class SessionManagerTests
             var pane = Assert.IsType<TerminalPane>(
                 SessionManager.CreateRestoredTabContent(LeafTabWithProfile(profile.Id), settings));
 
-            // Kept, arguments and all - and the stored profile handed through untouched.
-            Assert.Same(profile, pane.Profile);
-            Assert.Equal("./tools/shell", pane.Profile!.Command);
-            Assert.Equal("--login", pane.Profile.Arguments);
+            if (OperatingSystem.IsWindows())
+            {
+                // CreateProcessW resolves a relative executable against the *calling* process's
+                // directory, not the one handed to it as the child's cwd, so a match under
+                // StartingDirectory proves nothing here and the command is substituted. The profile
+                // therefore comes back as a copy, which is what keeps the stored one unedited.
+                Assert.NotSame(profile, pane.Profile);
+                Assert.Equal(ShellHelper.GetDefaultShell(), pane.Profile!.Command);
+                Assert.Equal(string.Empty, pane.Profile.Arguments);
+
+                // The stored profile is untouched either way - the point of copying.
+                Assert.Equal("./tools/shell", profile.Command);
+                Assert.Equal("--login", profile.Arguments);
+            }
+            else
+            {
+                // Kept, arguments and all - and the stored profile handed through untouched.
+                Assert.Same(profile, pane.Profile);
+                Assert.Equal("./tools/shell", pane.Profile!.Command);
+                Assert.Equal("--login", pane.Profile.Arguments);
+            }
         }
         finally
         {

--- a/tests/NovaTerminal.App.Tests/Core/ShellHelperResolutionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/ShellHelperResolutionTests.cs
@@ -1,0 +1,64 @@
+using NovaTerminal.Pty;
+using Xunit;
+
+namespace NovaTerminal.Tests.Core;
+
+/// <summary>
+/// Covers <see cref="ShellHelper.ResolveExecutableOrDefault"/>, which exists because settings and
+/// session files move between machines: a workspace saved on Windows used to restore as
+/// <c>cmd.exe</c> on Linux and every pane in it failed to spawn, permanently, because the command
+/// was re-persisted on the way out.
+/// </summary>
+public sealed class ShellHelperResolutionTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResolveExecutableOrDefault_BlankCommand_FallsBackToDefaultShell(string? command)
+    {
+        Assert.Equal(ShellHelper.GetDefaultShell(), ShellHelper.ResolveExecutableOrDefault(command));
+    }
+
+    [Fact]
+    public void ResolveExecutableOrDefault_CommandThatCannotRunHere_FallsBackToDefaultShell()
+    {
+        // The whole point of the helper: non-blank but unspawnable. "cmd.exe" is the value that
+        // actually shows up in session files written on Windows, and on Linux/macOS it is exactly
+        // as unrunnable as an empty string was.
+        string foreignShell = OperatingSystem.IsWindows() ? "/bin/bash" : "cmd.exe";
+
+        Assert.Equal(
+            ShellHelper.GetDefaultShell(),
+            ShellHelper.ResolveExecutableOrDefault(foreignShell));
+    }
+
+    [Fact]
+    public void ResolveExecutableOrDefault_RunnableCommand_IsLeftAlone()
+    {
+        // GetDefaultShell only ever returns something it found on this machine, so it doubles as
+        // a known-runnable command without hardcoding a path that may not exist on the runner.
+        string runnable = ShellHelper.GetDefaultShell();
+
+        Assert.Equal(runnable, ShellHelper.ResolveExecutableOrDefault(runnable));
+    }
+
+    [Fact]
+    public void ResolveExecutableOrDefault_TrimsSurroundingWhitespace()
+    {
+        string runnable = ShellHelper.GetDefaultShell();
+
+        Assert.Equal(runnable, ShellHelper.ResolveExecutableOrDefault("  " + runnable + "  "));
+    }
+
+    [Fact]
+    public void GetDefaultShell_ReturnsSomethingRunnable()
+    {
+        string shell = ShellHelper.GetDefaultShell();
+
+        Assert.False(string.IsNullOrWhiteSpace(shell));
+        Assert.True(
+            File.Exists(shell) || ShellHelper.InPath(shell),
+            $"GetDefaultShell() returned '{shell}', which is neither a file nor on PATH.");
+    }
+}

--- a/tests/NovaTerminal.App.Tests/Core/ShellHelperResolutionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/ShellHelperResolutionTests.cs
@@ -61,4 +61,77 @@ public sealed class ShellHelperResolutionTests
             File.Exists(shell) || ShellHelper.InPath(shell),
             $"GetDefaultShell() returned '{shell}', which is neither a file nor on PATH.");
     }
+
+    // Windows resolves an extensionless command through PATHEXT - "pwsh" runs pwsh.exe - so a
+    // pane whose saved command is spelled that way is perfectly runnable. Probing only the literal
+    // filename called it missing, which does not merely pick another shell: SessionManager also
+    // drops the pane's arguments once the command has been substituted. So the user loses the
+    // command *and* its arguments, silently, on the platform most of this is developed on.
+    [Fact]
+    public void ResolveExecutableOrDefault_WindowsExtensionlessCommand_IsLeftAlone()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Skip("PATHEXT resolution is Windows-only behaviour.");
+        }
+
+        // Derived from whatever this machine actually has rather than hardcoded: GetDefaultShell
+        // returns something it found on PATH, and on Windows that is always a .exe.
+        string shell = ShellHelper.GetDefaultShell();
+        string extensionless = Path.GetFileNameWithoutExtension(shell);
+
+        Assert.NotEqual(shell, extensionless);
+        Assert.True(
+            ShellHelper.InPath(extensionless),
+            $"'{extensionless}' should resolve through PATHEXT, since '{shell}' is on PATH.");
+        Assert.Equal(extensionless, ShellHelper.ResolveExecutableOrDefault(extensionless));
+    }
+
+    [Fact]
+    public void ResolveExecutableOrDefault_QuotedCommand_IsLeftAloneAndKeepsItsQuotes()
+    {
+        // A configured command may be quoted to survive spaces in its path. File.Exists never
+        // matches a quoted string, so this was another way to be judged unrunnable and lose the
+        // arguments - and the caller wants the original spelling back, quotes included.
+        string quoted = "\"" + ShellHelper.GetDefaultShell() + "\"";
+
+        Assert.Equal(quoted, ShellHelper.ResolveExecutableOrDefault(quoted));
+    }
+
+    [Fact]
+    public void InPath_BlankCommand_IsNotFound()
+    {
+        Assert.False(ShellHelper.InPath(""));
+        Assert.False(ShellHelper.InPath("   "));
+    }
+
+    // The PATHEXT parsing runs only on Windows, so these cover it from here - the surrounding
+    // extension handling is a File.Exists loop, but this is the part with details worth getting
+    // wrong, and it needs no Windows filesystem to check.
+    [Theory]
+    [InlineData(".COM;.EXE;.BAT", new[] { ".COM", ".EXE", ".BAT" })]
+    [InlineData(".EXE", new[] { ".EXE" })]
+    // Entries without a leading dot, which PATHEXT is not required to have.
+    [InlineData("EXE;BAT", new[] { ".EXE", ".BAT" })]
+    // Stray whitespace and empty entries from a hand-edited variable.
+    [InlineData(".EXE; .BAT ;;.CMD", new[] { ".EXE", ".BAT", ".CMD" })]
+    public void ParseExecutableExtensions_NormalisesTheValue(string pathExt, string[] expected)
+    {
+        Assert.Equal(expected, ShellHelper.ParseExecutableExtensions(pathExt));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ParseExecutableExtensions_WhenPathExtIsUnset_FallsBackToTheLauncherDefaults(string? pathExt)
+    {
+        string[] extensions = ShellHelper.ParseExecutableExtensions(pathExt);
+
+        // An extensionless "pwsh" has to keep resolving even where PATHEXT has been cleared.
+        Assert.Contains(".EXE", extensions);
+        Assert.Contains(".COM", extensions);
+        Assert.Contains(".BAT", extensions);
+        Assert.Contains(".CMD", extensions);
+    }
 }

--- a/tests/NovaTerminal.App.Tests/Core/ShellHelperResolutionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/ShellHelperResolutionTests.cs
@@ -43,11 +43,29 @@ public sealed class ShellHelperResolutionTests
     [InlineData("pwsh")]
     [InlineData("pwsh -NoLogo")]
     [InlineData("./tools/shell")]
+    [InlineData("tools/shell --flag")]
     [InlineData("some-tool-that-is-not-installed")]
     public void ResolveExecutableOrDefault_CommandForThisPlatform_IsLeftAlone(string command)
     {
         Assert.Equal(command, ShellHelper.ResolveExecutableOrDefault(command));
     }
+
+    // A rooted path only Windows understands. Verified on Windows: a leading slash there means
+    // rooted-on-the-current-drive and /Windows/System32/cmd.exe genuinely launches, so the rule can
+    // no longer be "starts with a slash" - it has to name a root only Unix has.
+    [Fact]
+    public void IsCommandForAnotherPlatform_DriveRelativeWindowsPath_IsNotForeignOnWindows()
+    {
+        Assert.Equal(
+            !OperatingSystem.IsWindows(),
+            ShellHelper.IsCommandForAnotherPlatform("/Windows/System32/cmd.exe"));
+    }
+
+    /// <summary>A path shaped for the platform the test is running on, which does not exist.</summary>
+    private static string NativeShapedMissingCommand =>
+        OperatingSystem.IsWindows()
+            ? @"C:\nope\definitely-not-installed-xyz.exe"
+            : "/opt/definitely-not-installed-xyz/shell";
 
     [Fact]
     public void ResolveExecutableOrDefault_TrimsSurroundingWhitespace()
@@ -59,8 +77,10 @@ public sealed class ShellHelperResolutionTests
     public void ResolveExecutableOrDefault_QuotedCommand_KeepsItsQuotes()
     {
         // Whoever spawns it wants the original spelling; TrySplitCommandLine unquotes at the point
-        // of use.
-        const string quoted = "\"/opt/my shell\" -l";
+        // of use. Native-shaped for the same reason as above.
+        string quoted = OperatingSystem.IsWindows()
+            ? "\"C:\\my dir\\shell.exe\" -l"
+            : "\"/opt/my shell\" -l";
 
         Assert.Equal(quoted, ShellHelper.ResolveExecutableOrDefault(quoted));
     }
@@ -71,7 +91,10 @@ public sealed class ShellHelperResolutionTests
     [Fact]
     public void ResolveExecutableOrDefault_CommandThatSimplyDoesNotExist_IsStillLeftAlone()
     {
-        const string missing = "/opt/definitely-not-installed-xyz/shell";
+        // Native-shaped on purpose. A POSIX path here would be correctly judged foreign on Windows
+        // and substituted, so the test would fail for a reason that has nothing to do with what it
+        // is checking - which is exactly how this file broke the Windows run twice.
+        string missing = NativeShapedMissingCommand;
 
         Assert.Equal(missing, ShellHelper.ResolveExecutableOrDefault(missing));
     }

--- a/tests/NovaTerminal.App.Tests/Core/ShellHelperResolutionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/ShellHelperResolutionTests.cs
@@ -98,6 +98,58 @@ public sealed class ShellHelperResolutionTests
         Assert.Equal(quoted, ShellHelper.ResolveExecutableOrDefault(quoted));
     }
 
+    // A stored command may carry its arguments inline - "zsh -l", "wsl.exe -e /bin/bash" - and
+    // TerminalPane.InitializeSessionCore supports exactly that, splitting executable from arguments
+    // at the first space. Probing the whole string as one filename rejected commands that run
+    // perfectly well, and rejection also costs the arguments.
+    [Fact]
+    public void ResolveExecutableOrDefault_CombinedCommandWithARunnableExecutable_IsLeftAlone()
+    {
+        string combined = ShellHelper.GetDefaultShell() + " -l";
+
+        Assert.Equal(combined, ShellHelper.ResolveExecutableOrDefault(combined));
+    }
+
+    [Fact]
+    public void ResolveExecutableOrDefault_CombinedCommandWhoseExecutableIsMissing_FallsBack()
+    {
+        // The split must not become a way to smuggle an unrunnable command past the check.
+        Assert.Equal(
+            ShellHelper.GetDefaultShell(),
+            ShellHelper.ResolveExecutableOrDefault("definitely-not-installed-xyz -l --flag"));
+    }
+
+    [Fact]
+    public void ResolveExecutableOrDefault_QuotedExecutableWithArguments_IsLeftAlone()
+    {
+        // The closing quote delimits the executable, not the first space - which on Windows falls
+        // inside paths like "C:\\Program Files\\...".
+        string combined = "\"" + ShellHelper.GetDefaultShell() + "\" -l";
+
+        Assert.Equal(combined, ShellHelper.ResolveExecutableOrDefault(combined));
+    }
+
+    [Fact]
+    public void ResolveExecutableOrDefault_PathContainingSpaces_IsFoundAsItself()
+    {
+        // The whole string is probed before any split, so a path that merely contains a space is
+        // not mistaken for an executable plus arguments.
+        string directory = Path.Combine(Path.GetTempPath(), "nova shell probe " + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        string executable = Path.Combine(directory, "my shell");
+
+        try
+        {
+            File.WriteAllText(executable, "");
+
+            Assert.Equal(executable, ShellHelper.ResolveExecutableOrDefault(executable));
+        }
+        finally
+        {
+            try { Directory.Delete(directory, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     [Fact]
     public void InPath_BlankCommand_IsNotFound()
     {

--- a/tests/NovaTerminal.App.Tests/Core/ShellHelperResolutionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/ShellHelperResolutionTests.cs
@@ -157,33 +157,120 @@ public sealed class ShellHelperResolutionTests
         Assert.False(ShellHelper.InPath("   "));
     }
 
-    // The PATHEXT parsing runs only on Windows, so these cover it from here - the surrounding
-    // extension handling is a File.Exists loop, but this is the part with details worth getting
-    // wrong, and it needs no Windows filesystem to check.
-    [Theory]
-    [InlineData(".COM;.EXE;.BAT", new[] { ".COM", ".EXE", ".BAT" })]
-    [InlineData(".EXE", new[] { ".EXE" })]
-    // Entries without a leading dot, which PATHEXT is not required to have.
-    [InlineData("EXE;BAT", new[] { ".EXE", ".BAT" })]
-    // Stray whitespace and empty entries from a hand-edited variable.
-    [InlineData(".EXE; .BAT ;;.CMD", new[] { ".EXE", ".BAT", ".CMD" })]
-    public void ParseExecutableExtensions_NormalisesTheValue(string pathExt, string[] expected)
+    // Codex review, round 4a: the resolver validated the executable inside a quoted command and
+    // returned the combined string, while the pane split at the first literal space and tried to
+    // spawn `"C:\\Program`. Both now use ShellHelper.TrySplitCommandLine, so what gets validated is
+    // what gets launched. Asserting the split - not just that the string survived - is the point:
+    // the previous test only checked preservation and would have passed with the bug present.
+    [Fact]
+    public void TrySplitCommandLine_QuotedExecutableWithSpaces_SplitsAtTheClosingQuote()
     {
-        Assert.Equal(expected, ShellHelper.ParseExecutableExtensions(pathExt));
+        Assert.True(ShellHelper.TrySplitCommandLine(
+            "\"C:\\Program Files\\PowerShell\\7\\pwsh.exe\" -NoLogo -File build.ps1",
+            out string executable,
+            out string arguments));
+
+        Assert.Equal("C:\\Program Files\\PowerShell\\7\\pwsh.exe", executable);
+        Assert.Equal("-NoLogo -File build.ps1", arguments);
+    }
+
+    [Fact]
+    public void TrySplitCommandLine_QuotedExecutableWithoutArguments_IsUnquoted()
+    {
+        Assert.True(ShellHelper.TrySplitCommandLine("\"/opt/my shell\"", out string executable, out string arguments));
+
+        Assert.Equal("/opt/my shell", executable);
+        Assert.Equal(string.Empty, arguments);
+    }
+
+    [Fact]
+    public void TrySplitCommandLine_CombinedCommand_SplitsAtTheFirstSpace()
+    {
+        Assert.True(ShellHelper.TrySplitCommandLine("zsh -l", out string executable, out string arguments));
+
+        Assert.Equal("zsh", executable);
+        Assert.Equal("-l", arguments);
     }
 
     [Theory]
     [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
-    public void ParseExecutableExtensions_WhenPathExtIsUnset_FallsBackToTheLauncherDefaults(string? pathExt)
+    [InlineData("zsh")]
+    public void TrySplitCommandLine_NothingToSplit_ReturnsFalse(string? commandLine)
     {
-        string[] extensions = ShellHelper.ParseExecutableExtensions(pathExt);
+        Assert.False(ShellHelper.TrySplitCommandLine(commandLine, out _, out _));
+    }
 
-        // An extensionless "pwsh" has to keep resolving even where PATHEXT has been cleared.
-        Assert.Contains(".EXE", extensions);
-        Assert.Contains(".COM", extensions);
-        Assert.Contains(".BAT", extensions);
-        Assert.Contains(".CMD", extensions);
+    [Fact]
+    public void TrySplitCommandLine_AnExistingFileWithSpaces_IsNotSplit()
+    {
+        // "/opt/my shell" is the executable, not "/opt/my" with an argument.
+        string directory = Path.Combine(Path.GetTempPath(), "nova split probe " + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        string executable = Path.Combine(directory, "my shell");
+
+        try
+        {
+            File.WriteAllText(executable, "");
+
+            Assert.False(ShellHelper.TrySplitCommandLine(executable, out _, out _));
+        }
+        finally
+        {
+            try { Directory.Delete(directory, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    // The decision behind round 4b, asserted directly. PATHEXT contains script types - .BAT, .CMD,
+    // .PS1, .VBS - that only run because a shell runs them, and nothing here launches through a
+    // shell: the native layer calls CreateProcessW and the fallback uses portable_pty's
+    // CommandBuilder. Probing those called a batch-backed command runnable, so restore kept it and
+    // its arguments and the pane failed to spawn instead of falling back to a working shell.
+    //
+    // Asserted as a list rather than through the filesystem on purpose: the probe is gated on
+    // OperatingSystem.IsWindows, so a filesystem test passes on Linux no matter what this contains -
+    // I confirmed that by putting .bat back and watching the filesystem test still pass.
+    [Fact]
+    public void LaunchableWindowsExtensions_ExcludeAnythingNeedingAnInterpreter()
+    {
+        string[] extensions = ShellHelper.LaunchableWindowsExtensions;
+
+        Assert.Contains(".exe", extensions);
+
+        foreach (string needsInterpreter in new[] { ".bat", ".cmd", ".ps1", ".vbs", ".js" })
+        {
+            Assert.DoesNotContain(needsInterpreter, extensions);
+        }
+    }
+
+    // Codex review, round 4b: PATHEXT includes .BAT/.CMD, but nothing here launches through a
+    // shell - the native layer calls CreateProcessW and the fallback uses portable_pty's
+    // CommandBuilder, neither of which can start a batch file. Probing those extensions called such
+    // a command runnable, so restore kept it and its arguments and the pane failed to spawn instead
+    // of falling back to a shell that works.
+    //
+    // Runs on Linux too, for the same reason by a different route: no extension probing happens
+    // there at all, so the extensionless name is equally unresolvable.
+    [Fact]
+    public void ResolveExecutableOrDefault_CommandBackedOnlyByABatchFile_IsNotConsideredRunnable()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), "nova batch probe " + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+
+        try
+        {
+            // Only the .bat exists - no .exe, no extensionless file.
+            File.WriteAllText(Path.Combine(directory, "wrapper.bat"), "@echo off");
+            string extensionless = Path.Combine(directory, "wrapper");
+
+            Assert.Equal(
+                ShellHelper.GetDefaultShell(),
+                ShellHelper.ResolveExecutableOrDefault(extensionless));
+        }
+        finally
+        {
+            try { Directory.Delete(directory, recursive: true); } catch { /* best effort */ }
+        }
     }
 }

--- a/tests/NovaTerminal.App.Tests/Core/ShellHelperResolutionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/ShellHelperResolutionTests.cs
@@ -270,4 +270,29 @@ public sealed class ShellHelperResolutionTests
             ShellHelper.InPath(extensionless),
             $"'{extensionless}' should resolve through the implicit .exe, since '{shell}' is on PATH.");
     }
+
+    // NixOS keeps its configured system shell at /run/current-system/sw/bin/bash, not under
+    // /nix/store/, so the store root alone missed the path a NixOS profile actually holds.
+    [Fact]
+    public void IsCommandForAnotherPlatform_NixOsSystemShell_IsRecognised()
+    {
+        Assert.Equal(
+            OperatingSystem.IsWindows(),
+            ShellHelper.IsCommandForAnotherPlatform("/run/current-system/sw/bin/bash"));
+    }
+
+    // /Users/ must never join the root list: C:\Users\ exists on every Windows machine, so listing
+    // it would recreate the false-positive class the roots were tightened to remove. Windows
+    // verification confirmed Directory.Exists("/Users/<name>") is true there. The macOS home case is
+    // not reachable this way and is left to fail visibly.
+    [Fact]
+    public void IsCommandForAnotherPlatform_MacHomePath_IsNotTreatedAsAUnixRootOnWindows()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Skip("The collision this guards against is a Windows filesystem fact.");
+        }
+
+        Assert.False(ShellHelper.IsCommandForAnotherPlatform("/Users/someone/bin/myshell"));
+    }
 }

--- a/tests/NovaTerminal.App.Tests/Core/ShellHelperResolutionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/ShellHelperResolutionTests.cs
@@ -377,4 +377,92 @@ public sealed class ShellHelperResolutionTests
             Assert.DoesNotContain(launchable, ShellHelper.WindowsExtensionsNeedingAnInterpreter);
         }
     }
+
+    // Codex review, round 6: the implicit-extension probe modelled a shell, not the launcher.
+    // CreateProcessW with lpApplicationName NULL (native/src/lib.rs:301) appends .exe and only when
+    // the name has no extension at all - so a saved `tool` backed by `tool.com`, and a saved
+    // `python3.11` backed by `python3.11.exe`, are both unreachable, yet the probe called them
+    // runnable and the pane was kept instead of falling back.
+    [Theory]
+    [InlineData("tool")]
+    [InlineData("pwsh")]
+    [InlineData("C:\\tools\\wrapper")]
+    public void AppendsImplicitExtension_NamesWithoutAnExtension_AreProbed(string candidate)
+    {
+        Assert.True(ShellHelper.AppendsImplicitExtension(candidate));
+    }
+
+    [Theory]
+    // A dot anywhere in the final component counts as an extension to CreateProcessW, however
+    // little it looks like one.
+    [InlineData("python3.11")]
+    [InlineData("tool.com")]
+    [InlineData("pwsh.exe")]
+    [InlineData("wrapper.bat")]
+    [InlineData(null)]
+    [InlineData("")]
+    public void AppendsImplicitExtension_NamesThatAlreadyHaveOne_AreNot(string? candidate)
+    {
+        Assert.False(ShellHelper.AppendsImplicitExtension(candidate));
+    }
+
+    [Fact]
+    public void LaunchableWindowsExtensions_IsOnlyWhatTheLauncherAppends()
+    {
+        // .exe and nothing else: CreateProcessW does not append .com, and PATHEXT is a shell's list.
+        Assert.Equal(new[] { ".exe" }, ShellHelper.LaunchableWindowsExtensions);
+    }
+
+    // The policy tests above pin the decision; this pins that it is actually applied, which no test
+    // on Linux can observe because the probe is gated on Windows. Runs on the Windows jobs.
+    [Fact]
+    public void ResolveExecutableOrDefault_DottedNameBackedByAnExe_FallsBackOnWindows()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Skip("Implicit extension probing is Windows-only behaviour.");
+        }
+
+        string directory = Path.Combine(Path.GetTempPath(), "nova dotted " + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+
+        try
+        {
+            // CreateProcessW sees "python3.11" as already extensioned and never looks for this file.
+            File.WriteAllText(Path.Combine(directory, "python3.11.exe"), "");
+
+            Assert.Equal(
+                ShellHelper.GetDefaultShell(),
+                ShellHelper.ResolveExecutableOrDefault(Path.Combine(directory, "python3.11")));
+        }
+        finally
+        {
+            try { Directory.Delete(directory, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void ResolveExecutableOrDefault_ExtensionlessNameBackedByAnExe_ResolvesOnWindows()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Skip("Implicit extension probing is Windows-only behaviour.");
+        }
+
+        string directory = Path.Combine(Path.GetTempPath(), "nova implicit " + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(directory, "tool.exe"), "");
+            string extensionless = Path.Combine(directory, "tool");
+
+            // The flip side, so the narrowing above cannot be over-applied.
+            Assert.Equal(extensionless, ShellHelper.ResolveExecutableOrDefault(extensionless));
+        }
+        finally
+        {
+            try { Directory.Delete(directory, recursive: true); } catch { /* best effort */ }
+        }
+    }
 }

--- a/tests/NovaTerminal.App.Tests/Core/ShellHelperResolutionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/ShellHelperResolutionTests.cs
@@ -273,4 +273,108 @@ public sealed class ShellHelperResolutionTests
             try { Directory.Delete(directory, recursive: true); } catch { /* best effort */ }
         }
     }
+
+    // Codex review, round 5a: a profile's StartingDirectory becomes the child's cwd, so a relative
+    // command runs from there - while this check runs in NovaTerminal's own directory and called it
+    // missing, substituting the shell and dropping the arguments.
+    [Fact]
+    public void ResolveExecutableOrDefault_RelativeCommandUnderTheWorkingDirectory_IsLeftAlone()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), "nova relative " + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(directory, "tools"));
+
+        try
+        {
+            File.WriteAllText(Path.Combine(directory, "tools", "shell"), "");
+
+            const string relative = "./tools/shell";
+
+            // Missing when probed from here, which is the bug: nothing resolves it without the cwd.
+            Assert.Equal(ShellHelper.GetDefaultShell(), ShellHelper.ResolveExecutableOrDefault(relative));
+
+            // Found once the directory it will actually run in is taken into account.
+            Assert.Equal(relative, ShellHelper.ResolveExecutableOrDefault(relative, directory));
+        }
+        finally
+        {
+            try { Directory.Delete(directory, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void ResolveExecutableOrDefault_RelativeCommandNotUnderTheWorkingDirectory_FallsBack()
+    {
+        // The working directory must not become a way to approve something that is not there.
+        string directory = Path.Combine(Path.GetTempPath(), "nova relative empty " + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+
+        try
+        {
+            Assert.Equal(
+                ShellHelper.GetDefaultShell(),
+                ShellHelper.ResolveExecutableOrDefault("./tools/shell", directory));
+        }
+        finally
+        {
+            try { Directory.Delete(directory, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void ResolveExecutableOrDefault_BareNameIsNotResolvedAgainstTheWorkingDirectory()
+    {
+        // A bare name goes through PATH, not the cwd - what a shell and exec both do. Resolving it
+        // against the cwd would launch a file that merely happens to sit there.
+        string directory = Path.Combine(Path.GetTempPath(), "nova bare " + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(directory, "definitely-not-on-path-xyz"), "");
+
+            Assert.Equal(
+                ShellHelper.GetDefaultShell(),
+                ShellHelper.ResolveExecutableOrDefault("definitely-not-on-path-xyz", directory));
+        }
+        finally
+        {
+            try { Directory.Delete(directory, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    // Codex review, round 5b: restricting only the *appended* extensions left an explicit
+    // wrapper.bat passing File.Exists and being kept, which is the dead pane the restriction was
+    // meant to prevent. Asserted on the policy, since the caller is gated on Windows.
+    [Theory]
+    [InlineData("C:\\tools\\wrapper.bat")]
+    [InlineData("C:\\tools\\wrapper.cmd")]
+    [InlineData("wrapper.BAT")]
+    [InlineData("script.ps1")]
+    [InlineData("script.vbs")]
+    public void NeedsAnInterpreter_ScriptFiles_AreRecognised(string candidate)
+    {
+        Assert.True(ShellHelper.NeedsAnInterpreter(candidate));
+    }
+
+    [Theory]
+    [InlineData("C:\\Windows\\System32\\cmd.exe")]
+    [InlineData("pwsh.exe")]
+    [InlineData("/bin/bash")]
+    [InlineData("zsh")]
+    [InlineData("python3.11")]
+    [InlineData(null)]
+    [InlineData("")]
+    public void NeedsAnInterpreter_ExecutablesAndBareNames_AreNot(string? candidate)
+    {
+        Assert.False(ShellHelper.NeedsAnInterpreter(candidate));
+    }
+
+    [Fact]
+    public void TheTwoExtensionPoliciesDoNotOverlap()
+    {
+        foreach (string launchable in ShellHelper.LaunchableWindowsExtensions)
+        {
+            Assert.DoesNotContain(launchable, ShellHelper.WindowsExtensionsNeedingAnInterpreter);
+        }
+    }
 }

--- a/tests/NovaTerminal.App.Tests/Core/ShellHelperResolutionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/ShellHelperResolutionTests.cs
@@ -274,33 +274,6 @@ public sealed class ShellHelperResolutionTests
         }
     }
 
-    // Codex review, round 5a: a profile's StartingDirectory becomes the child's cwd, so a relative
-    // command runs from there - while this check runs in NovaTerminal's own directory and called it
-    // missing, substituting the shell and dropping the arguments.
-    [Fact]
-    public void ResolveExecutableOrDefault_RelativeCommandUnderTheWorkingDirectory_IsLeftAlone()
-    {
-        string directory = Path.Combine(Path.GetTempPath(), "nova relative " + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(Path.Combine(directory, "tools"));
-
-        try
-        {
-            WriteExecutable(Path.Combine(directory, "tools", "shell"));
-
-            const string relative = "./tools/shell";
-
-            // Missing when probed from here, which is the bug: nothing resolves it without the cwd.
-            Assert.Equal(ShellHelper.GetDefaultShell(), ShellHelper.ResolveExecutableOrDefault(relative));
-
-            // Found once the directory it will actually run in is taken into account.
-            Assert.Equal(relative, ShellHelper.ResolveExecutableOrDefault(relative, directory));
-        }
-        finally
-        {
-            try { Directory.Delete(directory, recursive: true); } catch { /* best effort */ }
-        }
-    }
-
     [Fact]
     public void ResolveExecutableOrDefault_RelativeCommandNotUnderTheWorkingDirectory_FallsBack()
     {
@@ -346,14 +319,26 @@ public sealed class ShellHelperResolutionTests
     // wrapper.bat passing File.Exists and being kept, which is the dead pane the restriction was
     // meant to prevent. Asserted on the policy, since the caller is gated on Windows.
     [Theory]
-    [InlineData("C:\\tools\\wrapper.bat")]
-    [InlineData("C:\\tools\\wrapper.cmd")]
-    [InlineData("wrapper.BAT")]
     [InlineData("script.ps1")]
+    [InlineData("C:\\tools\\script.PS1")]
     [InlineData("script.vbs")]
+    [InlineData("script.js")]
     public void NeedsAnInterpreter_ScriptFiles_AreRecognised(string candidate)
     {
         Assert.True(ShellHelper.NeedsAnInterpreter(candidate));
+    }
+
+    // Verified on Windows against a raw CreateProcessW P/Invoke and through RustPtySession itself:
+    // CreateProcess special-cases batch files and runs them via the command processor, so a full-path
+    // .bat/.cmd spawns with a live pid. These were on this list on a false premise, and rejecting them
+    // substituted the default shell for a wrapper that had been working.
+    [Theory]
+    [InlineData("C:\\tools\\wrapper.bat")]
+    [InlineData("C:\\tools\\wrapper.cmd")]
+    [InlineData("wrapper.BAT")]
+    public void NeedsAnInterpreter_BatchFiles_AreLaunchableAndNotRejected(string candidate)
+    {
+        Assert.False(ShellHelper.NeedsAnInterpreter(candidate));
     }
 
     [Theory]
@@ -510,10 +495,18 @@ public sealed class ShellHelperResolutionTests
         {
             WriteExecutable(Path.Combine(directory, "tools", "shell"));
 
+            // The control: without the working directory nothing resolves it on either platform,
+            // so a pass below means the working directory did the work.
+            Assert.Equal(
+                ShellHelper.GetDefaultShell(),
+                ShellHelper.ResolveExecutableOrDefault("./tools/shell"));
+
             string resolved = ShellHelper.ResolveExecutableOrDefault("./tools/shell", directory);
 
             if (OperatingSystem.IsWindows())
             {
+                // CreateProcessW resolves a relative executable against the *calling* process's
+                // directory, so a match under the child's cwd means nothing here.
                 Assert.Equal(ShellHelper.GetDefaultShell(), resolved);
             }
             else

--- a/tests/NovaTerminal.App.Tests/Core/ShellHelperResolutionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/ShellHelperResolutionTests.cs
@@ -4,11 +4,18 @@ using Xunit;
 namespace NovaTerminal.Tests.Core;
 
 /// <summary>
-/// Covers <see cref="ShellHelper.ResolveExecutableOrDefault"/>, which exists because settings and
-/// session files move between machines: a workspace saved on Windows used to restore as
-/// <c>cmd.exe</c> on Linux and every pane in it failed to spawn, permanently, because the command
-/// was re-persisted on the way out.
+/// Covers <see cref="ShellHelper.ResolveExecutableOrDefault"/> and the portability predicate behind
+/// it, which exist because settings and session files move between machines: a workspace saved on
+/// Windows restored as <c>cmd.exe</c> on Linux and every pane in it failed to spawn, permanently,
+/// because the failing command was captured again on the way out.
 /// </summary>
+/// <remarks>
+/// These tests deliberately do not probe the filesystem. An earlier version of the predicate tried
+/// to decide launchability in general - PATHEXT, implicit extensions, execute bits, an interpreter
+/// list, working directories - and its tests grew to match, including several that asserted the bug
+/// rather than the behaviour. The question is now only whether a command was written for another
+/// operating system, which is answerable from the name.
+/// </remarks>
 public sealed class ShellHelperResolutionTests
 {
     [Theory]
@@ -20,148 +27,127 @@ public sealed class ShellHelperResolutionTests
         Assert.Equal(ShellHelper.GetDefaultShell(), ShellHelper.ResolveExecutableOrDefault(command));
     }
 
+    // The bug this all started from: a Windows workspace opened on Linux.
     [Fact]
-    public void ResolveExecutableOrDefault_CommandThatCannotRunHere_FallsBackToDefaultShell()
+    public void ResolveExecutableOrDefault_CommandFromAnotherPlatform_FallsBackToDefaultShell()
     {
-        // The whole point of the helper: non-blank but unspawnable. "cmd.exe" is the value that
-        // actually shows up in session files written on Windows, and on Linux/macOS it is exactly
-        // as unrunnable as an empty string was.
-        string foreignShell = OperatingSystem.IsWindows() ? "/bin/bash" : "cmd.exe";
+        string foreign = OperatingSystem.IsWindows() ? "/bin/bash" : "cmd.exe";
 
-        Assert.Equal(
-            ShellHelper.GetDefaultShell(),
-            ShellHelper.ResolveExecutableOrDefault(foreignShell));
+        Assert.Equal(ShellHelper.GetDefaultShell(), ShellHelper.ResolveExecutableOrDefault(foreign));
     }
 
-    [Fact]
-    public void ResolveExecutableOrDefault_RunnableCommand_IsLeftAlone()
+    // Everything that is not addressed to another OS is handed back untouched, including the shapes
+    // the old launchability predicate kept getting wrong. None of these need a filesystem lookup.
+    [Theory]
+    [InlineData("zsh")]
+    [InlineData("pwsh")]
+    [InlineData("pwsh -NoLogo")]
+    [InlineData("./tools/shell")]
+    [InlineData("some-tool-that-is-not-installed")]
+    public void ResolveExecutableOrDefault_CommandForThisPlatform_IsLeftAlone(string command)
     {
-        // GetDefaultShell only ever returns something it found on this machine, so it doubles as
-        // a known-runnable command without hardcoding a path that may not exist on the runner.
-        string runnable = ShellHelper.GetDefaultShell();
-
-        Assert.Equal(runnable, ShellHelper.ResolveExecutableOrDefault(runnable));
+        Assert.Equal(command, ShellHelper.ResolveExecutableOrDefault(command));
     }
 
     [Fact]
     public void ResolveExecutableOrDefault_TrimsSurroundingWhitespace()
     {
-        string runnable = ShellHelper.GetDefaultShell();
-
-        Assert.Equal(runnable, ShellHelper.ResolveExecutableOrDefault("  " + runnable + "  "));
+        Assert.Equal("zsh", ShellHelper.ResolveExecutableOrDefault("  zsh  "));
     }
 
     [Fact]
-    public void GetDefaultShell_ReturnsSomethingRunnable()
+    public void ResolveExecutableOrDefault_QuotedCommand_KeepsItsQuotes()
     {
-        string shell = ShellHelper.GetDefaultShell();
-
-        Assert.False(string.IsNullOrWhiteSpace(shell));
-        Assert.True(
-            File.Exists(shell) || ShellHelper.InPath(shell),
-            $"GetDefaultShell() returned '{shell}', which is neither a file nor on PATH.");
-    }
-
-    // Windows resolves an extensionless command through PATHEXT - "pwsh" runs pwsh.exe - so a
-    // pane whose saved command is spelled that way is perfectly runnable. Probing only the literal
-    // filename called it missing, which does not merely pick another shell: SessionManager also
-    // drops the pane's arguments once the command has been substituted. So the user loses the
-    // command *and* its arguments, silently, on the platform most of this is developed on.
-    [Fact]
-    public void ResolveExecutableOrDefault_WindowsExtensionlessCommand_IsLeftAlone()
-    {
-        if (!OperatingSystem.IsWindows())
-        {
-            Assert.Skip("PATHEXT resolution is Windows-only behaviour.");
-        }
-
-        // Derived from whatever this machine actually has rather than hardcoded: GetDefaultShell
-        // returns something it found on PATH, and on Windows that is always a .exe.
-        string shell = ShellHelper.GetDefaultShell();
-        string extensionless = Path.GetFileNameWithoutExtension(shell);
-
-        Assert.NotEqual(shell, extensionless);
-        Assert.True(
-            ShellHelper.InPath(extensionless),
-            $"'{extensionless}' should resolve through PATHEXT, since '{shell}' is on PATH.");
-        Assert.Equal(extensionless, ShellHelper.ResolveExecutableOrDefault(extensionless));
-    }
-
-    [Fact]
-    public void ResolveExecutableOrDefault_QuotedCommand_IsLeftAloneAndKeepsItsQuotes()
-    {
-        // A configured command may be quoted to survive spaces in its path. File.Exists never
-        // matches a quoted string, so this was another way to be judged unrunnable and lose the
-        // arguments - and the caller wants the original spelling back, quotes included.
-        string quoted = "\"" + ShellHelper.GetDefaultShell() + "\"";
+        // Whoever spawns it wants the original spelling; TrySplitCommandLine unquotes at the point
+        // of use.
+        const string quoted = "\"/opt/my shell\" -l";
 
         Assert.Equal(quoted, ShellHelper.ResolveExecutableOrDefault(quoted));
     }
 
-    // A stored command may carry its arguments inline - "zsh -l", "wsl.exe -e /bin/bash" - and
-    // TerminalPane.InitializeSessionCore supports exactly that, splitting executable from arguments
-    // at the first space. Probing the whole string as one filename rejected commands that run
-    // perfectly well, and rejection also costs the arguments.
+    // A missing command is deliberately NOT substituted. The user asked for their shell, not for a
+    // shell, and a substitution is silent - so a pane that fails to spawn, which they can see and
+    // diagnose, is the better outcome than one quietly running something else.
     [Fact]
-    public void ResolveExecutableOrDefault_CombinedCommandWithARunnableExecutable_IsLeftAlone()
+    public void ResolveExecutableOrDefault_CommandThatSimplyDoesNotExist_IsStillLeftAlone()
     {
-        string combined = ShellHelper.GetDefaultShell() + " -l";
+        const string missing = "/opt/definitely-not-installed-xyz/shell";
 
-        Assert.Equal(combined, ShellHelper.ResolveExecutableOrDefault(combined));
+        Assert.Equal(missing, ShellHelper.ResolveExecutableOrDefault(missing));
     }
 
-    [Fact]
-    public void ResolveExecutableOrDefault_CombinedCommandWhoseExecutableIsMissing_FallsBack()
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void IsCommandForAnotherPlatform_Blank_IsNotForeign(string? command)
     {
-        // The split must not become a way to smuggle an unrunnable command past the check.
-        Assert.Equal(
-            ShellHelper.GetDefaultShell(),
-            ShellHelper.ResolveExecutableOrDefault("definitely-not-installed-xyz -l --flag"));
+        Assert.False(ShellHelper.IsCommandForAnotherPlatform(command));
     }
 
-    [Fact]
-    public void ResolveExecutableOrDefault_QuotedExecutableWithArguments_IsLeftAlone()
+    // Windows-only shapes. Asserted from Linux, where they are foreign; on Windows they are native
+    // and the expectation flips, which the theory below covers.
+    [Theory]
+    [InlineData("cmd.exe")]
+    [InlineData("cmd")]
+    [InlineData("powershell")]
+    [InlineData("powershell.exe")]
+    [InlineData("wsl.exe")]
+    [InlineData(@"C:\Windows\System32\cmd.exe")]
+    [InlineData(@"C:/Windows/System32/cmd.exe")]
+    [InlineData(@"\\server\share\tool.exe")]
+    [InlineData("wrapper.bat")]
+    [InlineData("wrapper.cmd")]
+    [InlineData("script.ps1")]
+    // Arguments are ignored - the executable is what identifies the platform.
+    [InlineData("cmd.exe /c echo hi")]
+    [InlineData(@"""C:\Program Files\Tool\tool.exe"" --flag")]
+    public void IsCommandForAnotherPlatform_WindowsShapes(string command)
     {
-        // The closing quote delimits the executable, not the first space - which on Windows falls
-        // inside paths like "C:\\Program Files\\...".
-        string combined = "\"" + ShellHelper.GetDefaultShell() + "\" -l";
-
-        Assert.Equal(combined, ShellHelper.ResolveExecutableOrDefault(combined));
+        Assert.Equal(!OperatingSystem.IsWindows(), ShellHelper.IsCommandForAnotherPlatform(command));
     }
 
-    [Fact]
-    public void ResolveExecutableOrDefault_PathContainingSpaces_IsFoundAsItself()
+    // Unix-only shapes: a rooted POSIX path. The mirror of the theory above.
+    [Theory]
+    [InlineData("/bin/bash")]
+    [InlineData("/usr/bin/zsh")]
+    [InlineData("/bin/bash --norc -i")]
+    public void IsCommandForAnotherPlatform_UnixShapes(string command)
     {
-        // The whole string is probed before any split, so a path that merely contains a space is
-        // not mistaken for an executable plus arguments.
-        string directory = Path.Combine(Path.GetTempPath(), "nova shell probe " + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(directory);
-        string executable = Path.Combine(directory, "my shell");
+        Assert.Equal(OperatingSystem.IsWindows(), ShellHelper.IsCommandForAnotherPlatform(command));
+    }
 
-        try
+    // Neither platform's marker, so never foreign on either. pwsh matters most here: PowerShell is
+    // cross-platform, and an earlier draft that keyed off shell names alone would have rejected it
+    // on Linux, where it is a perfectly good command.
+    [Theory]
+    [InlineData("pwsh")]
+    [InlineData("zsh")]
+    [InlineData("bash")]
+    [InlineData("./tools/shell")]
+    [InlineData("tools/shell")]
+    [InlineData("python3.11")]
+    public void IsCommandForAnotherPlatform_PortableShapes_AreNeverForeign(string command)
+    {
+        Assert.False(ShellHelper.IsCommandForAnotherPlatform(command));
+    }
+
+    // Batch files run fine on Windows - CreateProcess hands them to the command processor, verified
+    // there against a raw CreateProcessW P/Invoke and through RustPtySession itself. An earlier
+    // version of this code rejected them as unlaunchable and substituted the default shell for a
+    // wrapper that had been working.
+    [Fact]
+    public void IsCommandForAnotherPlatform_BatchFileOnWindows_IsNative()
+    {
+        if (!OperatingSystem.IsWindows())
         {
-            WriteExecutable(executable);
+            Assert.Skip("A .bat is foreign on Unix; this pins that it is not foreign on Windows.");
+        }
 
-            Assert.Equal(executable, ShellHelper.ResolveExecutableOrDefault(executable));
-        }
-        finally
-        {
-            try { Directory.Delete(directory, recursive: true); } catch { /* best effort */ }
-        }
+        Assert.False(ShellHelper.IsCommandForAnotherPlatform(@"C:\tools\wrapper.bat"));
+        Assert.Equal(@"C:\tools\wrapper.bat", ShellHelper.ResolveExecutableOrDefault(@"C:\tools\wrapper.bat"));
     }
 
-    [Fact]
-    public void InPath_BlankCommand_IsNotFound()
-    {
-        Assert.False(ShellHelper.InPath(""));
-        Assert.False(ShellHelper.InPath("   "));
-    }
-
-    // Codex review, round 4a: the resolver validated the executable inside a quoted command and
-    // returned the combined string, while the pane split at the first literal space and tried to
-    // spawn `"C:\\Program`. Both now use ShellHelper.TrySplitCommandLine, so what gets validated is
-    // what gets launched. Asserting the split - not just that the string survived - is the point:
-    // the previous test only checked preservation and would have passed with the bug present.
     [Fact]
     public void TrySplitCommandLine_QuotedExecutableWithSpaces_SplitsAtTheClosingQuote()
     {
@@ -170,7 +156,7 @@ public sealed class ShellHelperResolutionTests
             out string executable,
             out string arguments));
 
-        Assert.Equal("C:\\Program Files\\PowerShell\\7\\pwsh.exe", executable);
+        Assert.Equal(@"C:\Program Files\PowerShell\7\pwsh.exe", executable);
         Assert.Equal("-NoLogo -File build.ps1", arguments);
     }
 
@@ -205,14 +191,16 @@ public sealed class ShellHelperResolutionTests
     [Fact]
     public void TrySplitCommandLine_AnExistingFileWithSpaces_IsNotSplit()
     {
-        // "/opt/my shell" is the executable, not "/opt/my" with an argument.
+        // "/opt/my shell" is the executable, not "/opt/my" with an argument. This guard is
+        // load-bearing: the app persists a resolved command unquoted, so a path with spaces comes
+        // back through here on every session restore.
         string directory = Path.Combine(Path.GetTempPath(), "nova split probe " + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);
         string executable = Path.Combine(directory, "my shell");
 
         try
         {
-            WriteExecutable(executable);
+            File.WriteAllText(executable, "");
 
             Assert.False(ShellHelper.TrySplitCommandLine(executable, out _, out _));
         }
@@ -222,316 +210,41 @@ public sealed class ShellHelperResolutionTests
         }
     }
 
-    // The decision behind round 4b, asserted directly. PATHEXT contains script types - .BAT, .CMD,
-    // .PS1, .VBS - that only run because a shell runs them, and nothing here launches through a
-    // shell: the native layer calls CreateProcessW and the fallback uses portable_pty's
-    // CommandBuilder. Probing those called a batch-backed command runnable, so restore kept it and
-    // its arguments and the pane failed to spawn instead of falling back to a working shell.
-    //
-    // Asserted as a list rather than through the filesystem on purpose: the probe is gated on
-    // OperatingSystem.IsWindows, so a filesystem test passes on Linux no matter what this contains -
-    // I confirmed that by putting .bat back and watching the filesystem test still pass.
     [Fact]
-    public void LaunchableWindowsExtensions_ExcludeAnythingNeedingAnInterpreter()
+    public void InPath_BlankCommand_IsNotFound()
     {
-        string[] extensions = ShellHelper.LaunchableWindowsExtensions;
-
-        Assert.Contains(".exe", extensions);
-
-        foreach (string needsInterpreter in new[] { ".bat", ".cmd", ".ps1", ".vbs", ".js" })
-        {
-            Assert.DoesNotContain(needsInterpreter, extensions);
-        }
-    }
-
-    // Codex review, round 4b: PATHEXT includes .BAT/.CMD, but nothing here launches through a
-    // shell - the native layer calls CreateProcessW and the fallback uses portable_pty's
-    // CommandBuilder, neither of which can start a batch file. Probing those extensions called such
-    // a command runnable, so restore kept it and its arguments and the pane failed to spawn instead
-    // of falling back to a shell that works.
-    //
-    // Runs on Linux too, for the same reason by a different route: no extension probing happens
-    // there at all, so the extensionless name is equally unresolvable.
-    [Fact]
-    public void ResolveExecutableOrDefault_CommandBackedOnlyByABatchFile_IsNotConsideredRunnable()
-    {
-        string directory = Path.Combine(Path.GetTempPath(), "nova batch probe " + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(directory);
-
-        try
-        {
-            // Only the .bat exists - no .exe, no extensionless file.
-            WriteExecutable(Path.Combine(directory, "wrapper.bat"), "@echo off");
-            string extensionless = Path.Combine(directory, "wrapper");
-
-            Assert.Equal(
-                ShellHelper.GetDefaultShell(),
-                ShellHelper.ResolveExecutableOrDefault(extensionless));
-        }
-        finally
-        {
-            try { Directory.Delete(directory, recursive: true); } catch { /* best effort */ }
-        }
+        Assert.False(ShellHelper.InPath(""));
+        Assert.False(ShellHelper.InPath("   "));
     }
 
     [Fact]
-    public void ResolveExecutableOrDefault_RelativeCommandNotUnderTheWorkingDirectory_FallsBack()
+    public void GetDefaultShell_ReturnsSomethingRunnable()
     {
-        // The working directory must not become a way to approve something that is not there.
-        string directory = Path.Combine(Path.GetTempPath(), "nova relative empty " + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(directory);
+        string shell = ShellHelper.GetDefaultShell();
 
-        try
-        {
-            Assert.Equal(
-                ShellHelper.GetDefaultShell(),
-                ShellHelper.ResolveExecutableOrDefault("./tools/shell", directory));
-        }
-        finally
-        {
-            try { Directory.Delete(directory, recursive: true); } catch { /* best effort */ }
-        }
+        Assert.False(string.IsNullOrWhiteSpace(shell));
+        Assert.True(
+            File.Exists(shell) || ShellHelper.InPath(shell),
+            $"GetDefaultShell() returned '{shell}', which is neither a file nor on PATH.");
     }
 
+    // InPath keeps its Windows extension-awareness, which is not about portability: it fixes a
+    // pre-existing defect in the settings and palette checks, where an extensionless profile command
+    // was judged missing. Verified on Windows - `pwsh` resolves via `pwsh.exe`.
     [Fact]
-    public void ResolveExecutableOrDefault_BareNameIsNotResolvedAgainstTheWorkingDirectory()
-    {
-        // A bare name goes through PATH, not the cwd - what a shell and exec both do. Resolving it
-        // against the cwd would launch a file that merely happens to sit there.
-        string directory = Path.Combine(Path.GetTempPath(), "nova bare " + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(directory);
-
-        try
-        {
-            WriteExecutable(Path.Combine(directory, "definitely-not-on-path-xyz"));
-
-            Assert.Equal(
-                ShellHelper.GetDefaultShell(),
-                ShellHelper.ResolveExecutableOrDefault("definitely-not-on-path-xyz", directory));
-        }
-        finally
-        {
-            try { Directory.Delete(directory, recursive: true); } catch { /* best effort */ }
-        }
-    }
-
-    // Codex review, round 5b: restricting only the *appended* extensions left an explicit
-    // wrapper.bat passing File.Exists and being kept, which is the dead pane the restriction was
-    // meant to prevent. Asserted on the policy, since the caller is gated on Windows.
-    [Theory]
-    [InlineData("script.ps1")]
-    [InlineData("C:\\tools\\script.PS1")]
-    [InlineData("script.vbs")]
-    [InlineData("script.js")]
-    public void NeedsAnInterpreter_ScriptFiles_AreRecognised(string candidate)
-    {
-        Assert.True(ShellHelper.NeedsAnInterpreter(candidate));
-    }
-
-    // Verified on Windows against a raw CreateProcessW P/Invoke and through RustPtySession itself:
-    // CreateProcess special-cases batch files and runs them via the command processor, so a full-path
-    // .bat/.cmd spawns with a live pid. These were on this list on a false premise, and rejecting them
-    // substituted the default shell for a wrapper that had been working.
-    [Theory]
-    [InlineData("C:\\tools\\wrapper.bat")]
-    [InlineData("C:\\tools\\wrapper.cmd")]
-    [InlineData("wrapper.BAT")]
-    public void NeedsAnInterpreter_BatchFiles_AreLaunchableAndNotRejected(string candidate)
-    {
-        Assert.False(ShellHelper.NeedsAnInterpreter(candidate));
-    }
-
-    [Theory]
-    [InlineData("C:\\Windows\\System32\\cmd.exe")]
-    [InlineData("pwsh.exe")]
-    [InlineData("/bin/bash")]
-    [InlineData("zsh")]
-    [InlineData("python3.11")]
-    [InlineData(null)]
-    [InlineData("")]
-    public void NeedsAnInterpreter_ExecutablesAndBareNames_AreNot(string? candidate)
-    {
-        Assert.False(ShellHelper.NeedsAnInterpreter(candidate));
-    }
-
-    [Fact]
-    public void TheTwoExtensionPoliciesDoNotOverlap()
-    {
-        foreach (string launchable in ShellHelper.LaunchableWindowsExtensions)
-        {
-            Assert.DoesNotContain(launchable, ShellHelper.WindowsExtensionsNeedingAnInterpreter);
-        }
-    }
-
-    // Codex review, round 6: the implicit-extension probe modelled a shell, not the launcher.
-    // CreateProcessW with lpApplicationName NULL (native/src/lib.rs:301) appends .exe and only when
-    // the name has no extension at all - so a saved `tool` backed by `tool.com`, and a saved
-    // `python3.11` backed by `python3.11.exe`, are both unreachable, yet the probe called them
-    // runnable and the pane was kept instead of falling back.
-    [Theory]
-    [InlineData("tool")]
-    [InlineData("pwsh")]
-    [InlineData("C:\\tools\\wrapper")]
-    public void AppendsImplicitExtension_NamesWithoutAnExtension_AreProbed(string candidate)
-    {
-        Assert.True(ShellHelper.AppendsImplicitExtension(candidate));
-    }
-
-    [Theory]
-    // A dot anywhere in the final component counts as an extension to CreateProcessW, however
-    // little it looks like one.
-    [InlineData("python3.11")]
-    [InlineData("tool.com")]
-    [InlineData("pwsh.exe")]
-    [InlineData("wrapper.bat")]
-    [InlineData(null)]
-    [InlineData("")]
-    public void AppendsImplicitExtension_NamesThatAlreadyHaveOne_AreNot(string? candidate)
-    {
-        Assert.False(ShellHelper.AppendsImplicitExtension(candidate));
-    }
-
-    [Fact]
-    public void LaunchableWindowsExtensions_IsOnlyWhatTheLauncherAppends()
-    {
-        // .exe and nothing else: CreateProcessW does not append .com, and PATHEXT is a shell's list.
-        Assert.Equal(new[] { ".exe" }, ShellHelper.LaunchableWindowsExtensions);
-    }
-
-    // The policy tests above pin the decision; this pins that it is actually applied, which no test
-    // on Linux can observe because the probe is gated on Windows. Runs on the Windows jobs.
-    [Fact]
-    public void ResolveExecutableOrDefault_DottedNameBackedByAnExe_FallsBackOnWindows()
+    public void InPath_ExtensionlessCommand_ResolvesThroughTheImplicitExeOnWindows()
     {
         if (!OperatingSystem.IsWindows())
         {
-            Assert.Skip("Implicit extension probing is Windows-only behaviour.");
+            Assert.Skip("Implicit .exe resolution is Windows-only behaviour.");
         }
 
-        string directory = Path.Combine(Path.GetTempPath(), "nova dotted " + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(directory);
+        string shell = ShellHelper.GetDefaultShell();
+        string extensionless = Path.GetFileNameWithoutExtension(shell);
 
-        try
-        {
-            // CreateProcessW sees "python3.11" as already extensioned and never looks for this file.
-            WriteExecutable(Path.Combine(directory, "python3.11.exe"));
-
-            Assert.Equal(
-                ShellHelper.GetDefaultShell(),
-                ShellHelper.ResolveExecutableOrDefault(Path.Combine(directory, "python3.11")));
-        }
-        finally
-        {
-            try { Directory.Delete(directory, recursive: true); } catch { /* best effort */ }
-        }
-    }
-
-    [Fact]
-    public void ResolveExecutableOrDefault_ExtensionlessNameBackedByAnExe_ResolvesOnWindows()
-    {
-        if (!OperatingSystem.IsWindows())
-        {
-            Assert.Skip("Implicit extension probing is Windows-only behaviour.");
-        }
-
-        string directory = Path.Combine(Path.GetTempPath(), "nova implicit " + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(directory);
-
-        try
-        {
-            WriteExecutable(Path.Combine(directory, "tool.exe"));
-            string extensionless = Path.Combine(directory, "tool");
-
-            // The flip side, so the narrowing above cannot be over-applied.
-            Assert.Equal(extensionless, ShellHelper.ResolveExecutableOrDefault(extensionless));
-        }
-        finally
-        {
-            try { Directory.Delete(directory, recursive: true); } catch { /* best effort */ }
-        }
-    }
-
-    // Codex review, round 7: an existing file is not a spawnable one on Unix. The tests above used
-    // to create their probe files with File.WriteAllText - mode 0644 - and assert they resolved,
-    // so they were pinning the bug in place. They now write genuinely executable files, and this
-    // covers the case they were accidentally asserting.
-    [Fact]
-    public void ResolveExecutableOrDefault_FileWithoutAnExecuteBit_FallsBack()
-    {
-        if (OperatingSystem.IsWindows())
-        {
-            Assert.Skip("Execute bits are a Unix concept.");
-        }
-
-        string directory = Path.Combine(Path.GetTempPath(), "nova noexec " + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(directory);
-
-        try
-        {
-            string notExecutable = Path.Combine(directory, "shell");
-            File.WriteAllText(notExecutable, "");
-            File.SetUnixFileMode(
-                notExecutable,
-                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
-
-            Assert.Equal(ShellHelper.GetDefaultShell(), ShellHelper.ResolveExecutableOrDefault(notExecutable));
-        }
-        finally
-        {
-            try { Directory.Delete(directory, recursive: true); } catch { /* best effort */ }
-        }
-    }
-
-    // Codex review, round 7: CreateProcessW resolves a relative executable against the *calling*
-    // process's directory, so a match under the child's working directory means nothing on Windows -
-    // approving on that basis keeps a command whose spawn then fails.
-    [Fact]
-    public void ResolveExecutableOrDefault_RelativeCommand_IsOnlyResolvedFromTheWorkingDirectoryOnUnix()
-    {
-        string directory = Path.Combine(Path.GetTempPath(), "nova relwin " + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(Path.Combine(directory, "tools"));
-
-        try
-        {
-            WriteExecutable(Path.Combine(directory, "tools", "shell"));
-
-            // The control: without the working directory nothing resolves it on either platform,
-            // so a pass below means the working directory did the work.
-            Assert.Equal(
-                ShellHelper.GetDefaultShell(),
-                ShellHelper.ResolveExecutableOrDefault("./tools/shell"));
-
-            string resolved = ShellHelper.ResolveExecutableOrDefault("./tools/shell", directory);
-
-            if (OperatingSystem.IsWindows())
-            {
-                // CreateProcessW resolves a relative executable against the *calling* process's
-                // directory, so a match under the child's cwd means nothing here.
-                Assert.Equal(ShellHelper.GetDefaultShell(), resolved);
-            }
-            else
-            {
-                Assert.Equal("./tools/shell", resolved);
-            }
-        }
-        finally
-        {
-            try { Directory.Delete(directory, recursive: true); } catch { /* best effort */ }
-        }
-    }
-
-    /// <summary>Writes a file that is actually executable, so a probe of it means something.</summary>
-    private static void WriteExecutable(string path, string contents = "")
-    {
-        File.WriteAllText(path, contents);
-
-        if (!OperatingSystem.IsWindows())
-        {
-            File.SetUnixFileMode(
-                path,
-                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
-                UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
-        }
+        Assert.NotEqual(shell, extensionless);
+        Assert.True(
+            ShellHelper.InPath(extensionless),
+            $"'{extensionless}' should resolve through the implicit .exe, since '{shell}' is on PATH.");
     }
 }

--- a/tests/NovaTerminal.App.Tests/Core/ShellHelperResolutionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/ShellHelperResolutionTests.cs
@@ -140,7 +140,7 @@ public sealed class ShellHelperResolutionTests
 
         try
         {
-            File.WriteAllText(executable, "");
+            WriteExecutable(executable);
 
             Assert.Equal(executable, ShellHelper.ResolveExecutableOrDefault(executable));
         }
@@ -212,7 +212,7 @@ public sealed class ShellHelperResolutionTests
 
         try
         {
-            File.WriteAllText(executable, "");
+            WriteExecutable(executable);
 
             Assert.False(ShellHelper.TrySplitCommandLine(executable, out _, out _));
         }
@@ -261,7 +261,7 @@ public sealed class ShellHelperResolutionTests
         try
         {
             // Only the .bat exists - no .exe, no extensionless file.
-            File.WriteAllText(Path.Combine(directory, "wrapper.bat"), "@echo off");
+            WriteExecutable(Path.Combine(directory, "wrapper.bat"), "@echo off");
             string extensionless = Path.Combine(directory, "wrapper");
 
             Assert.Equal(
@@ -285,7 +285,7 @@ public sealed class ShellHelperResolutionTests
 
         try
         {
-            File.WriteAllText(Path.Combine(directory, "tools", "shell"), "");
+            WriteExecutable(Path.Combine(directory, "tools", "shell"));
 
             const string relative = "./tools/shell";
 
@@ -330,7 +330,7 @@ public sealed class ShellHelperResolutionTests
 
         try
         {
-            File.WriteAllText(Path.Combine(directory, "definitely-not-on-path-xyz"), "");
+            WriteExecutable(Path.Combine(directory, "definitely-not-on-path-xyz"));
 
             Assert.Equal(
                 ShellHelper.GetDefaultShell(),
@@ -429,7 +429,7 @@ public sealed class ShellHelperResolutionTests
         try
         {
             // CreateProcessW sees "python3.11" as already extensioned and never looks for this file.
-            File.WriteAllText(Path.Combine(directory, "python3.11.exe"), "");
+            WriteExecutable(Path.Combine(directory, "python3.11.exe"));
 
             Assert.Equal(
                 ShellHelper.GetDefaultShell(),
@@ -454,7 +454,7 @@ public sealed class ShellHelperResolutionTests
 
         try
         {
-            File.WriteAllText(Path.Combine(directory, "tool.exe"), "");
+            WriteExecutable(Path.Combine(directory, "tool.exe"));
             string extensionless = Path.Combine(directory, "tool");
 
             // The flip side, so the narrowing above cannot be over-applied.
@@ -463,6 +463,82 @@ public sealed class ShellHelperResolutionTests
         finally
         {
             try { Directory.Delete(directory, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    // Codex review, round 7: an existing file is not a spawnable one on Unix. The tests above used
+    // to create their probe files with File.WriteAllText - mode 0644 - and assert they resolved,
+    // so they were pinning the bug in place. They now write genuinely executable files, and this
+    // covers the case they were accidentally asserting.
+    [Fact]
+    public void ResolveExecutableOrDefault_FileWithoutAnExecuteBit_FallsBack()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Skip("Execute bits are a Unix concept.");
+        }
+
+        string directory = Path.Combine(Path.GetTempPath(), "nova noexec " + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+
+        try
+        {
+            string notExecutable = Path.Combine(directory, "shell");
+            File.WriteAllText(notExecutable, "");
+            File.SetUnixFileMode(
+                notExecutable,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+
+            Assert.Equal(ShellHelper.GetDefaultShell(), ShellHelper.ResolveExecutableOrDefault(notExecutable));
+        }
+        finally
+        {
+            try { Directory.Delete(directory, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    // Codex review, round 7: CreateProcessW resolves a relative executable against the *calling*
+    // process's directory, so a match under the child's working directory means nothing on Windows -
+    // approving on that basis keeps a command whose spawn then fails.
+    [Fact]
+    public void ResolveExecutableOrDefault_RelativeCommand_IsOnlyResolvedFromTheWorkingDirectoryOnUnix()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), "nova relwin " + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(directory, "tools"));
+
+        try
+        {
+            WriteExecutable(Path.Combine(directory, "tools", "shell"));
+
+            string resolved = ShellHelper.ResolveExecutableOrDefault("./tools/shell", directory);
+
+            if (OperatingSystem.IsWindows())
+            {
+                Assert.Equal(ShellHelper.GetDefaultShell(), resolved);
+            }
+            else
+            {
+                Assert.Equal("./tools/shell", resolved);
+            }
+        }
+        finally
+        {
+            try { Directory.Delete(directory, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    /// <summary>Writes a file that is actually executable, so a probe of it means something.</summary>
+    private static void WriteExecutable(string path, string contents = "")
+    {
+        File.WriteAllText(path, contents);
+
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(
+                path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
         }
     }
 }

--- a/tests/NovaTerminal.App.Tests/Shell/SessionEmptyCommandTests.cs
+++ b/tests/NovaTerminal.App.Tests/Shell/SessionEmptyCommandTests.cs
@@ -59,10 +59,19 @@ public class SessionEmptyCommandTests
     public void Restoring_a_leaf_with_a_real_command_keeps_it()
     {
         // The fallback must not swallow a command that was perfectly good.
-        TabItem restored = SessionManager.CreateRestoredTabItem(LeafTab("cmd.exe"), new TerminalSettings())!;
+        //
+        // Deliberately not "cmd.exe": the restore fallback now rejects a command that cannot run
+        // on *this* platform, not just a blank one, so cmd.exe is a fine example of a good command
+        // on Windows and an example of the opposite everywhere else. Environment.ProcessPath is a
+        // real executable on every platform, and it is never the default shell, so this still
+        // distinguishes "kept" from "fell back".
+        string realCommand = Environment.ProcessPath!;
+        Assert.NotEqual(ShellHelper.GetDefaultShell(), realCommand);
+
+        TabItem restored = SessionManager.CreateRestoredTabItem(LeafTab(realCommand), new TerminalSettings())!;
 
         var pane = (TerminalPane)restored.Content!;
-        Assert.Equal("cmd.exe", pane.ShellCommand);
+        Assert.Equal(realCommand, pane.ShellCommand);
     }
 
     [AvaloniaFact]


### PR DESCRIPTION
# fix: resolve local shell commands by what the launcher can actually start

**Rescoped.** This PR originally carried the render-scaling and golden-baseline work too; that has moved to #346, which is independent (zero file overlap) and has drawn no review findings. Everything here is one concern: deciding whether a stored shell command can be spawned, and what to do when it cannot. All ten review findings so far have been in this code, which is why it now stands alone.

Found by running NovaTerminal on Arch Linux for the first time: **it could not open a single working pane.**

## The original bug

Every launch showed `Failed to spawn process: cmd.exe`, and restarting never cleared it. The session-restore path guarded the persisted pane command against being blank and nothing else:

```csharp
string.IsNullOrWhiteSpace(node.Command) ? ShellHelper.GetDefaultShell() : node.Command
```

`cmd.exe` isn't blank, so it went to the PTY verbatim, the spawn failed, and the pane kept the command it failed with — which the next shutdown captured and wrote back to `last_session.json`. Self-sustaining, exactly like the empty-command bug `SessionEmptyCommandTests` documents, and for the same reason: the guard tested the one shape of unusable command someone had hit before, rather than whether the thing could actually run.

## What the review process turned it into

Seven review rounds found ten defects, all here. Five were regressions from my own earlier fixes in this PR. The through-line: I was asking *"does a file with this name exist?"* when the question is *"can our spawn path start this?"* — and widening the former one counterexample at a time kept producing false positives, which are the expensive direction. A false negative falls back to a shell that starts; a false positive keeps a command, and its arguments, for a spawn that fails.

The answer is defined by two places, and reading them first would have saved most of this: `TerminalPane.InitializeSessionCore` (what shapes of command are accepted) and `native/src/lib.rs` (`CreateProcessW` at :301, `portable_pty::CommandBuilder` at :788).

What the check now accounts for:

| Shape | Why it matters |
|---|---|
| Blank | A pane that never started reports `""`; spawning it resolved to the first `%PATH%` directory |
| Foreign platform's shell | `cmd.exe` on Linux — the original bug |
| Extensionless on Windows | `pwsh` runs `pwsh.exe`; `CreateProcessW` appends `.exe` when there's no extension |
| Already-dotted on Windows | `python3.11` is "already extensioned" to `CreateProcessW`, so `python3.11.exe` is never found |
| Script files | `.bat`/`.cmd`/`.ps1` need an interpreter; `CreateProcessW` cannot start them |
| Quoted executable | `"C:\Program Files\...\pwsh.exe" -NoLogo` — the closing quote delimits it, not the first space |
| Inline arguments | `zsh -l` is a supported spelling; probe the executable, not the whole string |
| Paths containing spaces | `/opt/my shell` is itself, not a command plus argument |
| Relative paths | `./tools/shell` resolves against the profile's `StartingDirectory` — on Unix only |
| No execute bit | On Unix an existing file isn't a spawnable one |

Both entry points are covered: the raw-command branch **and** the profile-backed branch, which is the one most sessions actually take (capture writes a `ProfileId` for every profile-backed pane).

Two invariants worth keeping if this is refactored:

- **Substitution copies the profile, never edits it.** `TryResolvePaneProfile` returns the instance living in `TerminalSettings.Profiles`; assigning to its `Command` would rewrite the user's stored profile and persist that next time settings were saved.
- **The split has one implementation.** `ShellHelper.TrySplitCommandLine` is used by the resolver to decide what to probe *and* by the pane to decide what to spawn. They used to answer separately and disagree — the resolver approved a quoted path while the pane tried to spawn `"C:\Program`.

## Testing

Every fix from round 4 onward was verified against the unfixed code, and I'd recommend the same for any further change here, because two of my tests turned out to assert the bug rather than the behaviour:

- A pane-level test read back its own input: `ShellCommand` is assigned in the constructor, and `InitializeSessionCore` only runs once a session starts. Removed rather than left as false assurance.
- Six probe files across two test files were created with `File.WriteAllText` (mode 0644) and asserted to resolve — so they pinned the missing execute-bit check in place, and a correct implementation would have failed them. They now write genuinely executable files.

**Windows behaviour is under-verified and that's the main risk in this PR.** I'm on Linux; every Windows-specific path is covered only by tests I can't execute (they skip here, run on the Windows jobs). Three of the ten findings were in exactly that code. Where a filesystem test couldn't work — the probe is gated on `IsWindows`, so it passes on Linux regardless of what the policy contains, which I confirmed by reverting `.bat` and watching it still pass — the policy is asserted directly instead: which extensions get appended, which need an interpreter, and that the two lists cannot overlap.

## Known gaps, deliberately not fixed

- A command stored *with* an explicit `.bat`/`.cmd` is rejected rather than run. Running it properly means invoking the interpreter (`cmd.exe /c wrapper.bat`) — a feature, with quoting implications, in Windows-only code I can't execute. Falling back to a shell that starts is the better of the two available outcomes.
- `MainWindow`'s profile-launch guard mutates the resolved profile in place, unlike the restore path here. Pre-existing, same "silently edits the user's stored profile" issue.
- `ResolveProfileForThisPlatform` special-cases only `ConnectionType.SSH`; a third connection type would fall into the local branch by default.
- I have no headless test that the pane *spawns* the right thing — that needs a real session. The guarantee rests on one shared split implementation with one call site.

## A note on shape

`ResolveExecutableOrDefault` now carries seven branches, added reactively. Each traces to a real failure, but the original bug was narrow: *a Windows command persisted into a Linux session file kills every pane, permanently.* Detecting that specific situation — a stored command naming a foreign platform's shell — would be a much smaller thing to get right and wouldn't need to model `CreateProcessW` at all. I haven't rewritten it, since it's tested and green, but if further edge cases turn up here I'd suggest that rather than an eighth branch.

## Test state

App.Tests under CI's filter on Linux: **2597 passed**. `dotnet format` clean.

Two caveats on a local Linux run of this branch alone:

- The three `GoldenSharedPng` baselines fail — pre-existing on Linux and fixed by #346, not by anything here. CI won't show them: that job is Windows-only and passes with the current baselines on `main`.
- `CommandAssistLayoutTests` is one of several order-dependent flakes on Linux; it fails 1-of-2 runs on untouched `main` content. Detailed in #346.
