### PR TITLE
chore(build): pin the SDK to released 10.0.400 instead of a pulled preview

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,8 +1,8 @@
 {
   "//": "Pins the .NET SDK so hosted-runner bumps and local drift cannot change the toolchain silently (#174). CI installs this exact version via setup-dotnet's global-json-file input, so the workflows and this file cannot disagree the way `dotnet-version: 10.0.x` plus a hardcoded cache key did.",
-  "//rollForward": "latestPatch accepts servicing patches within the 10.0.3xx feature band but refuses a different band, keeping builds reproducible. Note the trade-off: because this is a preview SDK, CI depends on that build remaining downloadable - if it is ever pulled, bump this file rather than loosening the policy.",
+  "//rollForward": "latestPatch accepts servicing patches within the 10.0.4xx feature band but refuses a different band, keeping builds reproducible. 10.0.400 is a released SDK, so unlike the 10.0.300 preview this pin was on before, it is served from the normal release channel rather than depending on a build staying downloadable.",
   "sdk": {
-    "version": "10.0.300-preview.0.26177.108",
+    "version": "10.0.400",
     "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
# chore(build): pin the SDK to released 10.0.400 instead of a pulled preview

One line of substance: `global.json` moves from `10.0.300-preview.0.26177.108` to `10.0.400`.

## Why now

The pinned preview is no longer on the release CDN. Both flavours CI installs are gone:

| URL | Status |
|---|---|
| `builds.dotnet.microsoft.com/.../dotnet-sdk-10.0.300-preview.0.26177.108-linux-x64.tar.gz` | **404** |
| `builds.dotnet.microsoft.com/.../dotnet-sdk-10.0.300-preview.0.26177.108-win-x64.zip` | **404** |
| `ci.dot.net/public/.../dotnet-sdk-10.0.300-preview.0.26177.108-linux-x64.tar.gz` | 200 |
| `builds.dotnet.microsoft.com/.../dotnet-sdk-10.0.400-linux-x64.tar.gz` | 200 |

**CI is not broken today** — worth stating plainly, because the fix is easy to over-sell. `dotnet-install` tries `ci.dot.net/public` as a fallback and that feed still serves the build, so `setup-dotnet` keeps resolving the pin; the `Format (whitespace) (ubuntu-latest)` job, which cannot run without the SDK, is currently green. What has changed is that the toolchain now rests on a *pulled preview build staying available on a CI artifact feed*, which carries no such promise.

Local development is already affected, which is how this surfaced. A clean checkout on a machine that does not happen to have the build cached:

```
Requested SDK version: 10.0.300-preview.0.26177.108
global.json file: /home/behnam/Projects/nova-sdk-bump/global.json
Install the [10.0.300-preview.0.26177.108] .NET SDK or update global.json to match an installed SDK.
```

This is exactly the case the file wrote instructions for — *"if it is ever pulled, bump this file rather than loosening the policy"* — so the policy is untouched and only the version moves.

## What is deliberately unchanged

- **`rollForward` stays `latestPatch`**, now scoped to the `10.0.4xx` band. Servicing patches are accepted, a band change is still refused, builds stay reproducible. The reproducibility intent from #174 is intact.
- **No workflow changes.** Every job takes the version from this file via `setup-dotnet`'s `global-json-file`, and the SDK cache keys are `hashFiles('global.json')`, so both follow automatically. Nothing hardcodes an SDK version anywhere — grepped to confirm.
- The `//rollForward` comment is updated only because it described the old pin as a preview whose availability was the known trade-off. That trade-off is now resolved rather than merely noted: 10.0.400 is a released SDK served from the normal channel.

## Line endings

Written with **LF**, matching what the repo stores. `global.json` has no `.gitattributes` rule, so a CRLF save would have shown all eight lines as changed rather than the two that actually did. Hence a 2-line diff.

## Verification

Full solution builds and the suite passes on Linux with 10.0.400, and `dotnet format whitespace --verify-no-changes` is clean.

Three failures remain and none are from this change: the `GoldenSharedPng` box-drawing and block baselines already fail on `main` on Linux for unrelated font-resolution reasons, and they are filtered out of every CI job except the Windows-only golden one. #344 fixes those.

## Merge order

Independent of #344 — either can land first. If this one goes first, #344 picks it up on rebase and its CI stops depending on the fallback feed.
