### PR TITLE
feat(connections): delete a connection and forget its saved password

### DIFF
--- a/docs/superpowers/plans/2026-08-27-connection-manager-delete-and-forget-password.md
+++ b/docs/superpowers/plans/2026-08-27-connection-manager-delete-and-forget-password.md
@@ -1,0 +1,945 @@
+# Connection Manager Delete + Forget Saved Password Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the user delete an SSH connection from the connection manager (with confirmation, purging its saved password) and see/remove a saved password for the selected connection.
+
+**Architecture:** Three layers, bottom-up. (1) `VaultService` gains a new `ISavedPasswordAccess` interface — probe and purge over *profile-scoped* vault keys only. (2) `ConnectionManager` (an Avalonia `UserControl`) gains a Danger trash button that raises a new event, and a "Saved password" detail row driven by an injected `ISavedPasswordAccess`. (3) `MainWindow` handles the delete event: themed confirm dialog, store delete, vault purge, `RefreshProfileUIs()`. The control never touches the profile store; it only raises events — matching the existing convention for Edit/Copy/Details.
+
+**Tech Stack:** .NET 10, C#, Avalonia (XAML + imperative code-behind, no MVVM bindings in this control's detail panel), xUnit + `Avalonia.Headless.XUnit` (`[AvaloniaFact]`).
+
+## Global Constraints
+
+- **Build only via wrapper scripts.** `scripts/build.ps1 <args>` (PowerShell) or `scripts/build.sh <args>` (bash). Never raw `dotnet build` — it leaks MSBuild daemons that inherit stdout/stderr and hang the calling tool.
+- **Run tests targeted, never solution-wide.** A full-solution `dotnet test` is ~20–30 min (headless Avalonia). Use `scripts/build.ps1 test tests/NovaTerminal.App.Tests` and, where possible, `--filter`.
+- Existing `ISshPasswordVault` in `VaultService.cs` must **not** gain members — `tests/NovaTerminal.App.Tests/Ssh/SshConnectionServiceTests.cs:826` has a `RecordingSshPasswordVault` implementing it, and widening the interface would break it. Add a **separate** interface.
+- Vault key sets are already defined in `VaultService`. Use `GetProfileScopedSshPasswordKeysForProfile` (canonical + per-profile legacy, **excludes** the shared `SSH:{user}@{host}` alias). Never use `GetSshPasswordKeysForProfile` for either probe or purge.
+- Never probe the vault via `ResolveSshPasswordForProfile` — it migrates legacy keys to canonical, i.e. it *writes*.
+- The `Button.Danger` style and the `NtRed` brush already exist in `ConnectionManager.axaml`. Do not add new styles or palette keys.
+- Test project has `<Using Include="Xunit" />`, so **no** `using Xunit;` line in test files.
+- Branch: `feat/connection-manager-delete-and-forget-password` (already created off `origin/main`, spec commit `2615372` on it).
+
+---
+
+## File Structure
+
+**Modified:**
+
+- `src/NovaTerminal.App/Shell/VaultService.cs` — add `ISavedPasswordAccess` interface + three `VaultService` members. Currently 219 lines; grows ~45. Stays focused (it is exactly this file's responsibility).
+- `src/NovaTerminal.App/Controls/ConnectionManager.axaml` — one column + button in the action bar (line 522); one row in the CONNECTION grid (line 566).
+- `src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs` — one event, one property, three handlers/renderers. Currently 654 lines; grows ~60.
+- `src/NovaTerminal.App/MainWindow.axaml.cs` — two wiring lines in `EnsureConnectionManagerControl()` (line ~5166) plus two new private methods. Already ~5900 lines; this follows the file's established pattern and is not the place to restructure.
+
+**Test files:**
+
+- `tests/NovaTerminal.App.Tests/Core/VaultServiceSavedPasswordTests.cs` — **new**. Vault-layer behaviour. Kept separate from `VaultServiceDisabledModeTests.cs` so the saved-password contract reads as one unit.
+- `tests/NovaTerminal.App.Tests/Ssh/ConnectionManagerTests.cs` — extended. Control-layer behaviour, reusing the file's existing `CreateMeasuredConnectionManager` / `SelectFirstRow` / `FindButtonByToolTip` / `CreateSshProfile` helpers.
+
+**Task order is bottom-up so each task's tests can pass on their own:** Task 1 (vault) → Task 2 (delete button + event) → Task 3 (saved-password row) → Task 4 (MainWindow wiring).
+
+---
+
+### Task 1: `ISavedPasswordAccess` on `VaultService`
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Shell/VaultService.cs` (add interface after `ISshPasswordVault` at line 11; add members to `VaultService`)
+- Test: `tests/NovaTerminal.App.Tests/Core/VaultServiceSavedPasswordTests.cs` (create)
+
+**Interfaces:**
+- Consumes: existing `VaultService.GetProfileScopedSshPasswordKeysForProfile(TerminalProfile)`, `GetSecret(string)`, `RemoveSecret(string)`, `PersistenceAvailable`, `GetCanonicalSshProfileKey(Guid)`, `GetLegacySshKeys(TerminalProfile, bool)`; `NovaTerminal.Shell.Secrets.InMemorySecretStore`.
+- Produces: `NovaTerminal.Shell.ISavedPasswordAccess` with `bool IsVaultAvailable { get; }`, `bool HasSavedPassword(TerminalProfile profile)`, `bool ForgetSavedPassword(TerminalProfile profile)`. Implemented by `VaultService`. Tasks 3 and 4 depend on these exact names.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/NovaTerminal.App.Tests/Core/VaultServiceSavedPasswordTests.cs`:
+
+```csharp
+using System;
+using NovaTerminal.Shell;
+using NovaTerminal.Shell.Secrets;
+
+namespace NovaTerminal.Tests.Core;
+
+// Note: both TerminalProfile and ConnectionType live in NovaTerminal.Shell
+// (src/NovaTerminal.App/Shell/TerminalProfile.cs). Do not add a
+// `using NovaTerminal.Platform;` — it is not needed here.
+
+public class VaultServiceSavedPasswordTests
+{
+    private sealed class UnavailableStore : ISecretStore
+    {
+        public bool IsAvailable => false;
+        public string? Read(string key) => "should-not-be-read";
+        public void Write(string key, string value) => throw new InvalidOperationException("must not write");
+        public bool Delete(string key) => throw new InvalidOperationException("must not delete");
+    }
+
+    private static TerminalProfile CreateProfile(string name = "Prod")
+    {
+        return new TerminalProfile
+        {
+            Type = ConnectionType.SSH,
+            Name = name,
+            SshHost = "prod.internal",
+            SshUser = "ops"
+        };
+    }
+
+    [Fact]
+    public void IsVaultAvailable_ReflectsStore()
+    {
+        Assert.True(new VaultService(new InMemorySecretStore()).IsVaultAvailable);
+        Assert.False(new VaultService(new UnavailableStore()).IsVaultAvailable);
+    }
+
+    [Fact]
+    public void HasSavedPassword_IsFalse_WhenNothingStored()
+    {
+        var vault = new VaultService(new InMemorySecretStore());
+        Assert.False(vault.HasSavedPassword(CreateProfile()));
+    }
+
+    [Fact]
+    public void HasSavedPassword_IsTrue_ForCanonicalKey()
+    {
+        var store = new InMemorySecretStore();
+        var vault = new VaultService(store);
+        TerminalProfile profile = CreateProfile();
+
+        store.Write(VaultService.GetCanonicalSshProfileKey(profile.Id), "secret");
+
+        Assert.True(vault.HasSavedPassword(profile));
+    }
+
+    [Fact]
+    public void HasSavedPassword_IsTrue_ForPerProfileLegacyKey()
+    {
+        var store = new InMemorySecretStore();
+        var vault = new VaultService(store);
+        TerminalProfile profile = CreateProfile();
+
+        store.Write($"profile_{profile.Id}_password", "secret");
+
+        Assert.True(vault.HasSavedPassword(profile));
+    }
+
+    [Fact]
+    public void HasSavedPassword_IsFalse_ForSharedAliasOnly()
+    {
+        // The shared SSH:{user}@{host} alias may be resolved by sibling profiles
+        // on the same host, so it is deliberately outside this profile's scope.
+        var store = new InMemorySecretStore();
+        var vault = new VaultService(store);
+        TerminalProfile profile = CreateProfile();
+
+        store.Write("SSH:ops@prod.internal", "secret");
+
+        Assert.False(vault.HasSavedPassword(profile));
+    }
+
+    [Fact]
+    public void HasSavedPassword_DoesNotWriteToStore()
+    {
+        // Must not go through ResolveSshPasswordForProfile, which migrates a
+        // legacy hit to the canonical key as a side effect.
+        var store = new InMemorySecretStore();
+        var vault = new VaultService(store);
+        TerminalProfile profile = CreateProfile();
+        string legacyKey = $"profile_{profile.Id}_password";
+
+        store.Write(legacyKey, "secret");
+        Assert.True(vault.HasSavedPassword(profile));
+
+        Assert.Null(store.Read(VaultService.GetCanonicalSshProfileKey(profile.Id)));
+        Assert.Equal("secret", store.Read(legacyKey));
+    }
+
+    [Fact]
+    public void ForgetSavedPassword_ClearsCanonicalAndPerProfileLegacyKeys()
+    {
+        var store = new InMemorySecretStore();
+        var vault = new VaultService(store);
+        TerminalProfile profile = CreateProfile();
+        string canonicalKey = VaultService.GetCanonicalSshProfileKey(profile.Id);
+        string legacyIdKey = $"profile_{profile.Id}_password";
+        string legacyNamedKey = "SSH:Prod:ops@prod.internal";
+
+        store.Write(canonicalKey, "a");
+        store.Write(legacyIdKey, "b");
+        store.Write(legacyNamedKey, "c");
+
+        Assert.True(vault.ForgetSavedPassword(profile));
+
+        Assert.Null(store.Read(canonicalKey));
+        Assert.Null(store.Read(legacyIdKey));
+        Assert.Null(store.Read(legacyNamedKey));
+        Assert.False(vault.HasSavedPassword(profile));
+    }
+
+    [Fact]
+    public void ForgetSavedPassword_LeavesSharedAliasIntact()
+    {
+        var store = new InMemorySecretStore();
+        var vault = new VaultService(store);
+        TerminalProfile profile = CreateProfile();
+
+        store.Write(VaultService.GetCanonicalSshProfileKey(profile.Id), "mine");
+        store.Write("SSH:ops@prod.internal", "shared");
+
+        Assert.True(vault.ForgetSavedPassword(profile));
+
+        Assert.Equal("shared", store.Read("SSH:ops@prod.internal"));
+    }
+
+    [Fact]
+    public void ForgetSavedPassword_ReturnsFalse_WhenNothingStored()
+    {
+        var vault = new VaultService(new InMemorySecretStore());
+        Assert.False(vault.ForgetSavedPassword(CreateProfile()));
+    }
+
+    [Fact]
+    public void SavedPasswordMembers_WhenVaultUnavailable_AreSafeNoOps()
+    {
+        // UnavailableStore throws on Read/Write/Delete; the IsAvailable guards in
+        // GetSecret/RemoveSecret must short-circuit before touching it.
+        var vault = new VaultService(new UnavailableStore());
+        TerminalProfile profile = CreateProfile();
+
+        Assert.False(vault.IsVaultAvailable);
+        Assert.False(vault.HasSavedPassword(profile));
+        Assert.False(vault.ForgetSavedPassword(profile));
+    }
+
+    [Fact]
+    public void ForgetSavedPassword_Throws_OnNullProfile()
+    {
+        var vault = new VaultService(new InMemorySecretStore());
+        Assert.Throws<ArgumentNullException>(() => vault.ForgetSavedPassword(null!));
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter FullyQualifiedName~VaultServiceSavedPasswordTests
+```
+
+Expected: compile FAIL — `'VaultService' does not contain a definition for 'IsVaultAvailable'` / `'HasSavedPassword'` / `'ForgetSavedPassword'`.
+
+- [ ] **Step 3: Add the interface**
+
+In `src/NovaTerminal.App/Shell/VaultService.cs`, immediately after the closing brace of `ISshPasswordVault` (line 11):
+
+```csharp
+    /// <summary>
+    /// Read/clear access to the password a profile has saved in the OS credential store.
+    /// </summary>
+    /// <remarks>
+    /// Both members operate on <em>profile-scoped</em> keys only — the canonical
+    /// <c>SSH:PROFILE:{guid}</c> key plus this profile's own legacy keys. The shared
+    /// <c>SSH:{user}@{host}</c> alias is excluded on purpose: sibling profiles on the same
+    /// host resolve through it, so clearing it here would silently break them.
+    ///
+    /// Consequence: a password stored <em>only</em> under that shared alias reports
+    /// <see cref="HasSavedPassword"/> as <see langword="false"/> even though
+    /// <see cref="VaultService.ResolveSshPasswordForProfile"/> will still auto-fill from it at
+    /// connect time. Such a secret migrates to a profile-scoped key on first use, after which
+    /// this reports correctly. That is a legacy-store artifact, and preferable to letting one
+    /// profile delete another's password.
+    /// </remarks>
+    public interface ISavedPasswordAccess
+    {
+        /// <summary>True when the underlying credential store can be read and written.</summary>
+        bool IsVaultAvailable { get; }
+
+        /// <summary>True when a profile-scoped password is stored for <paramref name="profile"/>.</summary>
+        bool HasSavedPassword(TerminalProfile profile);
+
+        /// <summary>Clears every profile-scoped password key; true if anything was removed.</summary>
+        bool ForgetSavedPassword(TerminalProfile profile);
+    }
+```
+
+- [ ] **Step 4: Implement on `VaultService`**
+
+Change the class declaration:
+
+```csharp
+    public class VaultService
+        : ISshPasswordVault, ISavedPasswordAccess
+```
+
+Add these members next to `PersistenceAvailable` (line 27):
+
+```csharp
+        public bool IsVaultAvailable => _store.IsAvailable;
+
+        public bool HasSavedPassword(TerminalProfile profile)
+        {
+            ArgumentNullException.ThrowIfNull(profile);
+
+            // GetSecret, not ResolveSshPasswordForProfile: the latter migrates a legacy hit
+            // to the canonical key, and this runs on every selection change in the UI.
+            foreach (string key in GetProfileScopedSshPasswordKeysForProfile(profile))
+            {
+                if (!string.IsNullOrEmpty(GetSecret(key)))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool ForgetSavedPassword(TerminalProfile profile)
+        {
+            ArgumentNullException.ThrowIfNull(profile);
+
+            bool removedAny = false;
+            foreach (string key in GetProfileScopedSshPasswordKeysForProfile(profile))
+            {
+                removedAny |= RemoveSecret(key);
+            }
+
+            return removedAny;
+        }
+```
+
+`System.Linq` is not needed — the loops are explicit. `System` and `System.Collections.Generic` are already imported.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter FullyQualifiedName~VaultServiceSavedPasswordTests
+```
+
+Expected: PASS, 11 tests.
+
+- [ ] **Step 6: Re-run the existing vault tests (no regression)**
+
+```bash
+scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter FullyQualifiedName~VaultService
+```
+
+Expected: PASS. `VaultServiceDisabledModeTests` must be unaffected.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/NovaTerminal.App/Shell/VaultService.cs tests/NovaTerminal.App.Tests/Core/VaultServiceSavedPasswordTests.cs
+git commit -m "feat(vault): ISavedPasswordAccess to probe and clear a profile's saved password"
+```
+
+---
+
+### Task 2: Delete button raises `OnDeleteProfileRequested`
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Controls/ConnectionManager.axaml:522` (action bar `Grid`)
+- Modify: `src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs` (event near line 34; handler near `OnDeleteClick` peers at line 462–487)
+- Test: `tests/NovaTerminal.App.Tests/Ssh/ConnectionManagerTests.cs`
+
+**Interfaces:**
+- Consumes: existing `ConnectionManager.TryGetRow(object?, out SshProfileRowViewModel)`, `SshProfileRowViewModel.Profile`.
+- Produces: `public event Action<TerminalProfile>? OnDeleteProfileRequested;` on `ConnectionManager`. Task 4 subscribes to it. Button tooltip is exactly `"Delete connection"`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/NovaTerminal.App.Tests/Ssh/ConnectionManagerTests.cs`, add after `DetailsAction_RaisesConnectionDetailsRequested_ForSelectedRow` (ends ~line 88):
+
+```csharp
+    [AvaloniaFact]
+    public void DeleteAction_RaisesDeleteProfileRequested_ForSelectedRow()
+    {
+        var control = CreateMeasuredConnectionManager();
+        TerminalProfile profile = CreateSshProfile("Prod", favorite: false);
+        control.LoadProfiles(new[] { profile });
+        SelectFirstRow(control);
+
+        TerminalProfile? receivedProfile = null;
+        control.OnDeleteProfileRequested += p => receivedProfile = p;
+
+        var deleteButton = FindButtonByToolTip(control, "Delete connection");
+        Assert.NotNull(deleteButton);
+
+        deleteButton!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+        Assert.Same(profile, receivedProfile);
+    }
+
+    [AvaloniaFact]
+    public void DeleteAction_DoesNotRaise_WhenNoRowSelected()
+    {
+        var control = CreateMeasuredConnectionManager();
+        control.LoadProfiles(new[] { CreateSshProfile("Prod", favorite: false) });
+
+        bool raised = false;
+        control.OnDeleteProfileRequested += _ => raised = true;
+
+        var deleteButton = FindButtonByToolTip(control, "Delete connection");
+        Assert.NotNull(deleteButton);
+
+        deleteButton!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+        Assert.False(raised);
+    }
+
+    [AvaloniaFact]
+    public void DeleteAction_DoesNotRemoveRowItself()
+    {
+        // The control only raises; MainWindow owns the store delete and the refresh.
+        var control = CreateMeasuredConnectionManager();
+        control.LoadProfiles(new[] { CreateSshProfile("Prod", favorite: false) });
+        SelectFirstRow(control);
+        control.OnDeleteProfileRequested += _ => { };
+
+        FindButtonByToolTip(control, "Delete connection")!
+            .RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+        Assert.Equal(1, GetListItemCount(control));
+        Assert.Single(control.GetAllProfiles());
+    }
+```
+
+Also update the existing hit-target guard (line 36) so it covers the new button. Replace its `actionTips` array and count assertion:
+
+```csharp
+        string[] actionTips =
+        {
+            "Toggle favorite",
+            "Edit connection",
+            "Copy launch command",
+            "Connection details",
+            "Delete connection"
+        };
+```
+
+and
+
+```csharp
+        Assert.Equal(5, actionButtons.Count);
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter FullyQualifiedName~ConnectionManagerTests
+```
+
+Expected: compile FAIL — `'ConnectionManager' does not contain a definition for 'OnDeleteProfileRequested'`.
+
+- [ ] **Step 3: Add the XAML button**
+
+In `src/NovaTerminal.App/Controls/ConnectionManager.axaml`, change line 522 to add an eleventh column:
+
+```xml
+                        <Grid Margin="0,10,0,0" ColumnDefinitions="Auto,Auto,Auto,Auto,*,Auto,Auto,Auto,Auto,Auto,Auto">
+```
+
+Then, immediately after the `Grid.Column="9"` "Connection details" button (closes ~line 555) and before the `</Grid>`, add:
+
+```xml
+                            <Button Grid.Column="10" Classes="IconBtn Danger" Click="OnDeleteClick" ToolTip.Tip="Delete connection">
+                                <PathIcon Data="M9,3V4H4V6H5V19A2,2 0 0,0 7,21H17A2,2 0 0,0 19,19V6H20V4H15V3H9M7,6H17V19H7V6M9,8V17H11V8H9M13,8V17H15V8H13Z" Width="14" Height="14"/>
+                            </Button>
+```
+
+- [ ] **Step 4: Add the event and handler**
+
+In `src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs`, add to the event block (after line 34, `OnNewConnectionRequested`):
+
+```csharp
+        public event Action<TerminalProfile>? OnDeleteProfileRequested;
+```
+
+Add the handler after `OnDetailsClick` (ends line 487):
+
+```csharp
+        private void OnDeleteClick(object? sender, RoutedEventArgs e)
+        {
+            if (TryGetRow(sender, out var row))
+            {
+                e.Handled = true;
+                OnDeleteProfileRequested?.Invoke(row.Profile);
+            }
+        }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter FullyQualifiedName~ConnectionManagerTests
+```
+
+Expected: PASS. `SecondaryActionButtons_ReserveSquareHitTargets` now finds 5 buttons, all ≥30×30 (the `IconBtn` style sets `Width`/`Height` to 30; `Danger` only overrides `Foreground`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/NovaTerminal.App/Controls/ConnectionManager.axaml src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs tests/NovaTerminal.App.Tests/Ssh/ConnectionManagerTests.cs
+git commit -m "feat(connections): delete action in the connection manager detail bar"
+```
+
+---
+
+### Task 3: "Saved password" detail row + Forget button
+
+**Files:**
+- Modify: `src/NovaTerminal.App/Controls/ConnectionManager.axaml:566-576` (CONNECTION grid)
+- Modify: `src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs` (property; `RenderDetail` at line 372; `RenderEmptyDetail` at line 364; new handler + renderer)
+- Test: `tests/NovaTerminal.App.Tests/Ssh/ConnectionManagerTests.cs`
+
+**Interfaces:**
+- Consumes: `NovaTerminal.Shell.ISavedPasswordAccess` from Task 1; existing `SetText(string, string)`, `TryGetRow`, `RenderDetail`.
+- Produces: `public ISavedPasswordAccess? SavedPasswordAccess { get; set; }` on `ConnectionManager`. Task 4 assigns `MainWindow.Vault` to it. Control names: `KvSavedPassword` (`TextBlock`), `BtnForgetSavedPassword` (`Button`).
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/NovaTerminal.App.Tests/Ssh/ConnectionManagerTests.cs`, add a test double at the bottom of the class, just above the `FindButtonByToolTip` helper:
+
+```csharp
+    private sealed class FakeSavedPasswordAccess : NovaTerminal.Shell.ISavedPasswordAccess
+    {
+        public bool IsVaultAvailable { get; set; } = true;
+        public bool Saved { get; set; }
+        public int ForgetCallCount { get; private set; }
+        public TerminalProfile? LastForgotten { get; private set; }
+
+        public bool HasSavedPassword(TerminalProfile profile) => Saved;
+
+        public bool ForgetSavedPassword(TerminalProfile profile)
+        {
+            ForgetCallCount++;
+            LastForgotten = profile;
+            bool had = Saved;
+            Saved = false;
+            return had;
+        }
+    }
+```
+
+And add these tests after the Task 2 tests:
+
+```csharp
+    [AvaloniaFact]
+    public void SavedPasswordRow_ShowsYes_AndEnablesForget_WhenPasswordStored()
+    {
+        var control = CreateMeasuredConnectionManager();
+        control.SavedPasswordAccess = new FakeSavedPasswordAccess { Saved = true };
+        control.LoadProfiles(new[] { CreateSshProfile("Prod", favorite: false) });
+        SelectFirstRow(control);
+
+        Assert.Equal("Yes", FindControl<TextBlock>(control, "KvSavedPassword").Text);
+        var forget = FindControl<Button>(control, "BtnForgetSavedPassword");
+        Assert.True(forget.IsVisible);
+        Assert.True(forget.IsEnabled);
+    }
+
+    [AvaloniaFact]
+    public void SavedPasswordRow_ShowsNo_AndDisablesForget_WhenNothingStored()
+    {
+        var control = CreateMeasuredConnectionManager();
+        control.SavedPasswordAccess = new FakeSavedPasswordAccess { Saved = false };
+        control.LoadProfiles(new[] { CreateSshProfile("Prod", favorite: false) });
+        SelectFirstRow(control);
+
+        Assert.Equal("No", FindControl<TextBlock>(control, "KvSavedPassword").Text);
+        Assert.False(FindControl<Button>(control, "BtnForgetSavedPassword").IsEnabled);
+    }
+
+    [AvaloniaFact]
+    public void SavedPasswordRow_ShowsVaultUnavailable_WhenStoreIsUnavailable()
+    {
+        var control = CreateMeasuredConnectionManager();
+        control.SavedPasswordAccess = new FakeSavedPasswordAccess { IsVaultAvailable = false, Saved = true };
+        control.LoadProfiles(new[] { CreateSshProfile("Prod", favorite: false) });
+        SelectFirstRow(control);
+
+        Assert.Equal("Vault unavailable", FindControl<TextBlock>(control, "KvSavedPassword").Text);
+        Assert.False(FindControl<Button>(control, "BtnForgetSavedPassword").IsEnabled);
+    }
+
+    [AvaloniaFact]
+    public void SavedPasswordRow_HidesForget_WhenNoAccessorInjected()
+    {
+        var control = CreateMeasuredConnectionManager();
+        control.LoadProfiles(new[] { CreateSshProfile("Prod", favorite: false) });
+        SelectFirstRow(control);
+
+        Assert.Equal("—", FindControl<TextBlock>(control, "KvSavedPassword").Text);
+        Assert.False(FindControl<Button>(control, "BtnForgetSavedPassword").IsVisible);
+    }
+
+    [AvaloniaFact]
+    public void ForgetSavedPassword_FlipsRowToNo_DisablesButton_AndKeepsSelection()
+    {
+        var control = CreateMeasuredConnectionManager();
+        var access = new FakeSavedPasswordAccess { Saved = true };
+        control.SavedPasswordAccess = access;
+        TerminalProfile profile = CreateSshProfile("Prod", favorite: false);
+        control.LoadProfiles(new[] { profile });
+        SelectFirstRow(control);
+
+        var forget = FindControl<Button>(control, "BtnForgetSavedPassword");
+        forget.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+        Assert.Equal(1, access.ForgetCallCount);
+        Assert.Same(profile, access.LastForgotten);
+        Assert.Equal("No", FindControl<TextBlock>(control, "KvSavedPassword").Text);
+        Assert.False(forget.IsEnabled);
+
+        // No LoadProfiles reload — the selection must survive.
+        var list = FindControl<ListBox>(control, "ConnectionsList");
+        Assert.Equal(0, list.SelectedIndex);
+    }
+
+    [AvaloniaFact]
+    public void ForgetSavedPassword_DoesNothing_WhenNoRowSelected()
+    {
+        var control = CreateMeasuredConnectionManager();
+        var access = new FakeSavedPasswordAccess { Saved = true };
+        control.SavedPasswordAccess = access;
+        control.LoadProfiles(new[] { CreateSshProfile("Prod", favorite: false) });
+
+        FindControl<Button>(control, "BtnForgetSavedPassword")
+            .RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+        Assert.Equal(0, access.ForgetCallCount);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter FullyQualifiedName~ConnectionManagerTests
+```
+
+Expected: compile FAIL — `'ConnectionManager' does not contain a definition for 'SavedPasswordAccess'`.
+
+- [ ] **Step 3: Add the XAML row**
+
+In `src/NovaTerminal.App/Controls/ConnectionManager.axaml`, change line 566 to add a sixth row:
+
+```xml
+                            <Grid ColumnDefinitions="130,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" Margin="0,0,0,0">
+```
+
+Then, immediately after the `KvAuth` `TextBlock` (line 576) and before the closing `</Grid>`, add:
+
+```xml
+                                <TextBlock Grid.Row="5" Grid.Column="0" Text="Saved password" Foreground="{StaticResource NtFg3}" FontSize="13" Margin="0,4"/>
+                                <StackPanel Grid.Row="5" Grid.Column="1" Orientation="Horizontal" Spacing="10" Margin="0,4" VerticalAlignment="Center">
+                                    <TextBlock Name="KvSavedPassword" Text="—" FontFamily="{StaticResource NtMono}" FontSize="12.5" Foreground="{StaticResource NtFg}" VerticalAlignment="Center"/>
+                                    <Button Name="BtnForgetSavedPassword"
+                                            Classes="Pill"
+                                            Content="Forget saved password"
+                                            Click="OnForgetSavedPasswordClick"
+                                            ToolTip.Tip="Remove this connection's password from the OS credential store"/>
+                                </StackPanel>
+```
+
+- [ ] **Step 4: Add the property, renderer and handler**
+
+In `src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs`:
+
+Add `using NovaTerminal.Shell;` — already present at line 8, so no import change.
+
+Add the property after the `CardBackground`/`SecondaryForeground` block (after line 120):
+
+```csharp
+        /// <summary>
+        /// Vault access used to show and clear the selected connection's saved password.
+        /// Left null in tests and design-time; the row then reads "—" and Forget is hidden.
+        /// </summary>
+        public ISavedPasswordAccess? SavedPasswordAccess { get; set; }
+```
+
+Add to the end of `RenderDetail` (line 372), just before `UpdateLaunchPreview();`:
+
+```csharp
+            RenderSavedPasswordState(row);
+```
+
+Add to `RenderEmptyDetail` (line 364) — the whole detail grid is hidden there, so nothing to reset; leave it unchanged.
+
+Add these two methods after `DescribeAuth` (ends line 413):
+
+```csharp
+        private void RenderSavedPasswordState(SshProfileRowViewModel row)
+        {
+            var forgetButton = this.FindControl<Button>("BtnForgetSavedPassword");
+
+            if (SavedPasswordAccess == null)
+            {
+                SetText("KvSavedPassword", "—");
+                if (forgetButton != null)
+                {
+                    forgetButton.IsVisible = false;
+                    forgetButton.IsEnabled = false;
+                }
+                return;
+            }
+
+            if (forgetButton != null)
+            {
+                forgetButton.IsVisible = true;
+            }
+
+            if (!SavedPasswordAccess.IsVaultAvailable)
+            {
+                SetText("KvSavedPassword", "Vault unavailable");
+                if (forgetButton != null) forgetButton.IsEnabled = false;
+                return;
+            }
+
+            bool saved = SavedPasswordAccess.HasSavedPassword(row.Profile);
+            SetText("KvSavedPassword", saved ? "Yes" : "No");
+            if (forgetButton != null) forgetButton.IsEnabled = saved;
+        }
+
+        private void OnForgetSavedPasswordClick(object? sender, RoutedEventArgs e)
+        {
+            if (SavedPasswordAccess == null || !TryGetRow(sender, out var row))
+            {
+                return;
+            }
+
+            e.Handled = true;
+            SavedPasswordAccess.ForgetSavedPassword(row.Profile);
+
+            // Re-render this row in place rather than reloading: LoadProfiles rebuilds every
+            // SshProfileRowViewModel, so ApplyFilters' identity check drops the selection.
+            RenderSavedPasswordState(row);
+        }
+```
+
+Note on `TryGetRow`: it returns `_selectedRow` when one exists, otherwise falls back to walking `sender`'s `DataContext`/`Tag` ancestors. With no selection, the Forget button lives in the detail panel whose `DataContext` is the `SshManagerViewModel`, not a row — so the walk finds nothing and returns false. That is what `ForgetSavedPassword_DoesNothing_WhenNoRowSelected` asserts.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter FullyQualifiedName~ConnectionManagerTests
+```
+
+Expected: PASS, including the Task 2 tests and `ConnectionManager_CanArrangeWithinSmallOverlay` (the new row is inside the already-scrolling `ScrollViewer` at line 560).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/NovaTerminal.App/Controls/ConnectionManager.axaml src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs tests/NovaTerminal.App.Tests/Ssh/ConnectionManagerTests.cs
+git commit -m "feat(connections): show and clear a connection's saved password"
+```
+
+---
+
+### Task 4: Wire delete + vault access into `MainWindow`
+
+**Files:**
+- Modify: `src/NovaTerminal.App/MainWindow.axaml.cs` — `EnsureConnectionManagerControl()` (line 5166–5209); two new private methods placed after `ShowNewSshConnectionDialogAsync` (ends ~line 5535)
+
+**Interfaces:**
+- Consumes: `ConnectionManager.OnDeleteProfileRequested` (Task 2), `ConnectionManager.SavedPasswordAccess` (Task 3), `VaultService.ForgetSavedPassword` (Task 1); existing `MainWindow.Vault` (`static VaultService?`, line 3326), `_sshConnectionService.DeleteProfile(Guid)`, `RefreshProfileUIs()`, `CreateThemedDialogWindow(string, double, double, bool)`.
+- Produces: nothing consumed by later tasks. Last task.
+
+- [ ] **Step 1: Wire the control**
+
+In `EnsureConnectionManagerControl()`, after `connManager.ApplyTheme(_settings.ActiveTheme);` (line 5180) add:
+
+```csharp
+            connManager.SavedPasswordAccess = Vault;
+```
+
+And after the `connManager.OnEditProfile += …` block (ends line 5206) add:
+
+```csharp
+            connManager.OnDeleteProfileRequested += async (profile) =>
+            {
+                await DeleteSshProfileAsync(profile);
+            };
+```
+
+- [ ] **Step 2: Add the delete flow**
+
+Add after `ShowNewSshConnectionDialogAsync` (ends ~line 5535):
+
+```csharp
+        private async Task DeleteSshProfileAsync(TerminalProfile profile)
+        {
+            if (profile == null)
+            {
+                return;
+            }
+
+            string label = string.IsNullOrWhiteSpace(profile.Name)
+                ? "this connection"
+                : $"\"{profile.Name.Trim()}\"";
+
+            if (!await ShowDeleteConnectionConfirmationAsync(label))
+            {
+                return;
+            }
+
+            try
+            {
+                _sshConnectionService.DeleteProfile(profile.Id);
+
+                // Purge AFTER the store delete: if the delete throws, the secret stays put
+                // rather than being orphaned from a profile that still exists.
+                Vault?.ForgetSavedPassword(profile);
+
+                RefreshProfileUIs();
+            }
+            catch (Exception ex)
+            {
+                await ShowSimpleMessageDialogAsync("Delete connection", ex.Message);
+            }
+        }
+
+        private async Task<bool> ShowDeleteConnectionConfirmationAsync(string label)
+        {
+            bool confirmed = false;
+
+            var dialog = CreateThemedDialogWindow("Delete connection?", 480, 210, canResize: false);
+
+            var cancelButton = new Button
+            {
+                Content = "Cancel",
+                Width = 92
+            };
+            cancelButton.Click += (_, __) =>
+            {
+                confirmed = false;
+                dialog.Close();
+            };
+
+            var deleteButton = new Button
+            {
+                Content = "Delete",
+                Width = 92
+            };
+            deleteButton.Click += (_, __) =>
+            {
+                confirmed = true;
+                dialog.Close();
+            };
+
+            dialog.Content = new Border
+            {
+                Padding = new Thickness(16),
+                Child = new StackPanel
+                {
+                    Spacing = 12,
+                    Children =
+                    {
+                        new TextBlock
+                        {
+                            Text = $"Delete {label}?",
+                            FontWeight = FontWeight.SemiBold,
+                            TextWrapping = TextWrapping.Wrap
+                        },
+                        new TextBlock
+                        {
+                            Text = "The saved connection and any password stored for it are removed. "
+                                 + "Panes already connected keep running until you close them.",
+                            Opacity = 0.8,
+                            TextWrapping = TextWrapping.Wrap
+                        },
+                        new StackPanel
+                        {
+                            Orientation = Avalonia.Layout.Orientation.Horizontal,
+                            HorizontalAlignment = HorizontalAlignment.Right,
+                            Spacing = 8,
+                            Children = { cancelButton, deleteButton }
+                        }
+                    }
+                }
+            };
+
+            await dialog.ShowDialog(this);
+            return confirmed;
+        }
+```
+
+This mirrors `ShowRunningProcessCloseConfirmationAsync` (line 4277) — same `CreateThemedDialogWindow` + local `bool confirmed` + `await dialog.ShowDialog(this)` shape. All types used (`Button`, `Border`, `StackPanel`, `TextBlock`, `Thickness`, `FontWeight`, `HorizontalAlignment`, `TextWrapping`) are already imported in this file.
+
+- [ ] **Step 3: Build the app**
+
+```bash
+scripts/build.ps1 build src/NovaTerminal.App
+```
+
+Expected: build succeeds, no warnings introduced.
+
+- [ ] **Step 4: Run the affected test projects**
+
+```bash
+scripts/build.ps1 test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~ConnectionManager|FullyQualifiedName~VaultService|FullyQualifiedName~SshConnectionService"
+```
+
+Expected: PASS. Nothing here changes `TerminalSettings` or connection-profile schema, so the `NovaTerminal.McpServer.Tests` drift guards are untouched — but if the reviewer wants belt-and-braces:
+
+```bash
+scripts/build.ps1 test tests/NovaTerminal.McpServer.Tests
+```
+
+- [ ] **Step 5: Manual smoke test**
+
+Automated GUI driving is unreliable here, so verify by hand. Do **not** use
+`scripts/build.ps1 run` — the wrapper deliberately omits `run` from its
+`-nodeReuse:false` insert, so a captured-stdout run can hang. Build, then launch
+the produced executable yourself from an ordinary terminal:
+
+```bash
+scripts/build.ps1 build src/NovaTerminal.App -c Debug
+```
+
+then run `src/NovaTerminal.App/bin/Debug/net10.0/NovaTerminal.App.exe`
+(`net10.0` is the TFM from `Directory.Build.props:20`).
+
+Then:
+1. Open the connection manager. Select a connection. Confirm a red trash icon sits at the right end of the action bar with tooltip "Delete connection".
+2. In the detail body under CONNECTION, confirm a **Saved password** row reading `No` with a greyed-out "Forget saved password" button.
+3. Connect to a host with password auth, tick "Remember password" in the prompt, connect. Reopen the manager, reselect that connection — the row should read `Yes` and the button should be enabled.
+4. Click "Forget saved password". The row flips to `No`, the button greys out, **and the row stays selected in the list**.
+5. Reconnect — you should be prompted for the password again.
+6. Click the trash icon. Confirm the dialog names the connection and mentions the password. Cancel — the connection is still listed.
+7. Click trash again, confirm Delete. The row disappears; check the New Tab menu and command palette no longer offer it.
+8. Open a session on a connection, then delete that connection while the pane is live. The pane must keep running.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/NovaTerminal.App/MainWindow.axaml.cs
+git commit -m "feat(connections): confirm and delete a connection, purging its saved password"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| Feature 1 — UI (Danger trash button, action bar column) | Task 2, Step 3 |
+| Feature 1 — Control (`OnDeleteProfileRequested`, `OnDeleteClick`) | Task 2, Step 4 |
+| Feature 1 — Host (`DeleteSshProfileAsync`, confirm, purge order, `RefreshProfileUIs`) | Task 4, Steps 1–2 |
+| Feature 1 — Deleting a profile in use | Task 4, Step 5 item 8 (manual); no code needed |
+| Feature 2 — `ISavedPasswordAccess` + `VaultService` impl | Task 1, Steps 3–4 |
+| Feature 2 — profile-scoped keys only; probe without writing | Task 1, Step 4 + tests 5–7 |
+| Feature 2 — shared-alias caveat documented in XML docs | Task 1, Step 3 |
+| Feature 2 — UI row + Forget button | Task 3, Step 3 |
+| Feature 2 — 4-state render table | Task 3, Step 4 (`RenderSavedPasswordState`) |
+| Feature 2 — no confirm, no reload, selection preserved | Task 3, Step 4 + `ForgetSavedPassword_FlipsRowToNo…` |
+| Testing items 1–7 | Tasks 1–3 |
+| Out of scope: editor checkbox, MCP tools | not touched by any task |
+
+No gaps.
+
+**Placeholder scan:** no TBD/TODO; every code step carries the actual code; no "similar to Task N".
+
+**Type consistency:** `ISavedPasswordAccess` / `IsVaultAvailable` / `HasSavedPassword` / `ForgetSavedPassword` are spelled identically in Tasks 1, 3, 4. `OnDeleteProfileRequested` matches between Tasks 2 and 4. `SavedPasswordAccess` matches between Tasks 3 and 4. Control names `KvSavedPassword` / `BtnForgetSavedPassword` match between Task 3's XAML, code and tests. Tooltip `"Delete connection"` matches between Task 2's XAML and both its new test and the amended `actionTips` array.
+
+**One deviation from the spec, deliberate:** the spec's Files-touched list said "`tests/NovaTerminal.App.Tests/Core/` — new or extended `VaultService` tests". The plan creates a new file, `VaultServiceSavedPasswordTests.cs`, rather than extending `VaultServiceDisabledModeTests.cs`, whose name would no longer describe its contents.

--- a/docs/superpowers/plans/2026-08-27-connection-manager-delete-and-forget-password.md
+++ b/docs/superpowers/plans/2026-08-27-connection-manager-delete-and-forget-password.md
@@ -936,7 +936,14 @@ git commit -m "feat(connections): confirm and delete a connection, purging its s
 | Testing items 1–7 | Tasks 1–3 |
 | Out of scope: editor checkbox, MCP tools | not touched by any task |
 
-No gaps.
+**Dropped:** Testing item 8 (a combined `SshConnectionService`-level check
+that delete removes the profile from the store *and* purges the
+profile-scoped vault keys) is intentionally not implemented. It is not
+implementable as specified: `SshConnectionService.DeleteProfile` delegates
+straight to `JsonSshProfileStore.DeleteProfile` and never touches the vault —
+the purge lives in `MainWindow.DeleteSshProfileAsync` by design. The store-
+delete and the vault-purge are covered separately instead, at their own
+layers (see the corrected Testing section of the design spec).
 
 **Placeholder scan:** no TBD/TODO; every code step carries the actual code; no "similar to Task N".
 

--- a/docs/superpowers/specs/2026-08-27-connection-manager-delete-and-forget-password-design.md
+++ b/docs/superpowers/specs/2026-08-27-connection-manager-delete-and-forget-password-design.md
@@ -230,10 +230,20 @@ No confirmation dialog, and no `LoadProfiles` refresh:
 7. With an unavailable store, `IsVaultAvailable` is false, `HasSavedPassword` is
    false, and `ForgetSavedPassword` returns false without throwing.
 
-A `SshConnectionService`-level check that delete removes the profile from the
-store and purges the profile-scoped vault keys, using the existing
-`RecordingSshPasswordVault`-style fake in `SshConnectionServiceTests` where it
-fits.
+A combined `SshConnectionService`-level check ("delete removes the profile
+from the store and purges the profile-scoped vault keys") is not implementable
+as originally written: `SshConnectionService.DeleteProfile` delegates straight
+to `JsonSshProfileStore.DeleteProfile` and never touches the vault
+(`src/NovaTerminal.App/Services/Ssh/SshConnectionService.cs:161-164`) — the
+purge lives in `MainWindow.DeleteSshProfileAsync` by design, after the store
+delete succeeds (see the vault-scoping remarks on `ISavedPasswordAccess`).
+The store-delete and the vault-purge are instead verified separately, at
+their own layers: `SshConnectionServiceTests` covers `DeleteProfile` against
+the store, and items 5-7 above cover `VaultService.ForgetSavedPassword`
+against the vault. The combined end-to-end flow (delete a connection that has
+a saved password, confirm both the profile and its secret are gone) is
+covered by the manual smoke test, not an automated `SshConnectionService`
+test.
 
 ## Files touched
 

--- a/docs/superpowers/specs/2026-08-27-connection-manager-delete-and-forget-password-design.md
+++ b/docs/superpowers/specs/2026-08-27-connection-manager-delete-and-forget-password-design.md
@@ -1,0 +1,245 @@
+# Connection Manager: delete a connection, forget a saved password
+
+Date: 2026-08-27
+
+## Problem
+
+The connection manager detail panel exposes Favorite, Edit, Copy launch command,
+and Connection details. It has no way to **delete** a connection, and the app has
+no way at all to **remove a saved SSH password**.
+
+Current state of the code:
+
+- `SshConnectionService.DeleteProfile(Guid)` exists and is reachable from no UI.
+- `ConnectionManager.axaml` already carries an unused `Button.Danger` style,
+  commented `<!-- Danger icon button (delete) -->`.
+- `VaultService.ApplyRememberPasswordPreference` is defined but called from
+  nowhere in `src/`. Passwords are only ever *written*, from the
+  "Remember password" checkbox in `AuthPromptDialog` via
+  `SshInteractionService.HandlePasswordAsync`.
+- `NewSshConnectionViewModel.RememberPasswordInVault` exists but is not bound in
+  `NewSshConnectionView.axaml`.
+
+So a saved password is write-only: once stored, nothing in the product removes it.
+
+## Scope
+
+In scope:
+
+1. Delete a connection from the connection manager, with confirmation, purging
+   the profile's vault password.
+2. Show whether a password is saved for the selected connection, and forget it.
+
+Out of scope:
+
+- Wiring `NewSshConnectionViewModel.RememberPasswordInVault` into the editor
+  dialog. `ApplyRememberPasswordPreference` stays uncalled.
+- MCP tooling. `ConnectionProfileTools` is schema/validation-only and has no
+  mutating tools. No `TerminalSettings` field changes, so the `SettingsTools`
+  drift guards are unaffected.
+- Disconnecting live panes that are running a deleted profile (see
+  "Deleting a profile in use" below).
+
+## Feature 1 — Delete a connection
+
+### UI
+
+`src/NovaTerminal.App/Controls/ConnectionManager.axaml`: the detail action bar is
+a `Grid` with `ColumnDefinitions="Auto,Auto,Auto,Auto,*,Auto,Auto,Auto,Auto,Auto"`.
+Add one more `Auto` column and place a trash `Button` in it:
+
+- `Classes="IconBtn Danger"`
+- `ToolTip.Tip="Delete connection"`
+- `Click="OnDeleteClick"`
+
+`Button.Danger` already exists in that file's styles and sets `Foreground` to
+`{StaticResource NtRed}`. `ThemePaletteResources.Apply` already remaps `NtRed`
+from `theme.Red`, so the button themes correctly with no palette work.
+
+### Control
+
+`ConnectionManager.axaml.cs`:
+
+```csharp
+public event Action<TerminalProfile>? OnDeleteProfileRequested;
+
+private void OnDeleteClick(object? sender, RoutedEventArgs e)
+{
+    if (TryGetRow(sender, out var row))
+    {
+        e.Handled = true;
+        OnDeleteProfileRequested?.Invoke(row.Profile);
+    }
+}
+```
+
+This mirrors `OnEditClick` / `OnCopyCommandClick` / `OnDetailsClick` exactly. The
+control deletes nothing itself; it only raises. That keeps the control free of
+service and vault dependencies for the destructive path, and matches the existing
+event-out / MainWindow-handles convention.
+
+### Host
+
+`MainWindow.axaml.cs`, in `EnsureConnectionManagerControl()`:
+
+```csharp
+connManager.OnDeleteProfileRequested += async profile =>
+{
+    await DeleteSshProfileAsync(profile);
+};
+```
+
+`DeleteSshProfileAsync(TerminalProfile profile)`:
+
+1. Show a themed modal built the way `ConfirmBundleCommandsAsync` builds one —
+   `CreateThemedDialogWindow("Delete connection?", ..., canResize: false)`, a
+   wrapped message naming the connection, Cancel and Delete buttons, a local
+   `bool confirmed`, `await dialog.ShowDialog(this)`. The message states that any
+   saved password will also be forgotten.
+2. On cancel, return.
+3. `_sshConnectionService.DeleteProfile(profile.Id)`.
+4. Purge the vault: `MainWindow.Vault?.ForgetSavedPassword(profile)` (see
+   Feature 2). Purge after the store delete so a store failure leaves the secret
+   in place rather than orphaning a profile from its password.
+5. `RefreshProfileUIs()` — already re-runs `PopulateNewTabMenu()`,
+   `SetupCommandPalette()`, and
+   `_connectionManagerControl?.LoadProfiles(_sshConnectionService.GetConnectionProfiles())`,
+   which drops the row and clears the detail panel.
+
+### Deleting a profile in use
+
+Deleting does not disconnect a pane already running that profile. A pane holds
+its own `TerminalProfile` reference, and `ApplySettingsRecursive` already
+null-guards `GetConnectionProfile(pane.Profile.Id)` returning null and keeps the
+pane's existing copy. So the live session survives until closed normally. This is
+deliberate: killing a running shell as a side effect of tidying the connection
+list would be worse than leaving it be.
+
+## Feature 2 — Forget a saved password
+
+### Vault surface
+
+`src/NovaTerminal.App/Shell/VaultService.cs` gains an interface alongside the
+existing `ISshPasswordVault`:
+
+```csharp
+public interface ISavedPasswordAccess
+{
+    bool IsVaultAvailable { get; }
+    bool HasSavedPassword(TerminalProfile profile);
+    bool ForgetSavedPassword(TerminalProfile profile);
+}
+```
+
+`VaultService` implements it:
+
+- `IsVaultAvailable` => the existing `PersistenceAvailable` (`_store.IsAvailable`).
+- `HasSavedPassword` => any of `GetProfileScopedSshPasswordKeysForProfile(profile)`
+  reads back a non-empty value via `GetSecret`.
+- `ForgetSavedPassword` => `RemoveSecret` over every key in
+  `GetProfileScopedSshPasswordKeysForProfile(profile)`; returns true if any
+  removal returned true.
+
+Two deliberate choices:
+
+**Profile-scoped keys only.** `GetProfileScopedSshPasswordKeysForProfile` yields
+the canonical `SSH:PROFILE:{guid}` key plus the per-profile legacy keys, and
+excludes the shared `SSH:{user}@{host}` alias that
+`GetSshPasswordKeysForProfile` includes. Forgetting one profile's password must
+not delete a secret a sibling profile on the same host also resolves through.
+Probe and purge use the same key set so the UI can never show a state the button
+cannot clear.
+
+**Probe with `GetSecret`, not `ResolveSshPasswordForProfile`.** The latter
+migrates a legacy hit to the canonical key, i.e. it *writes*. A probe that runs
+on every selection change must not have that side effect.
+
+Known caveat, to be documented in the interface XML docs: a password stored only
+under the shared `SSH:{user}@{host}` alias reads as "not saved" here, while
+`ResolveSshPasswordForProfile` will still auto-fill from it at connect time. Such
+a secret migrates to a profile-scoped key on first use, after which the row
+reports correctly. This is a legacy-store artifact and is preferred to the
+alternative, where forgetting profile A's password silently breaks profile B.
+
+### UI
+
+The detail body's `CONNECTION` grid is `ColumnDefinitions="130,*"` with
+`RowDefinitions="Auto,Auto,Auto,Auto,Auto"` (Host, Port, User, Group, Auth). Add
+a sixth `Auto` row, **Saved password**. Column 0 is the `Saved password` label,
+matching the five above it. Column 1 holds a horizontal `StackPanel`
+(`Spacing="10"`, `VerticalAlignment="Center"`) containing:
+
+- `KvSavedPassword` `TextBlock` reading `Yes`, `No`, or `Vault unavailable`,
+  styled like the other value cells (`NtMono`, `FontSize="12.5"`).
+- A `Forget saved password` button (`Classes="Pill"`, name
+  `BtnForgetSavedPassword`, `Click="OnForgetSavedPasswordClick"`).
+
+`ConnectionManager` gains:
+
+```csharp
+public ISavedPasswordAccess? SavedPasswordAccess { get; set; }
+```
+
+set by `EnsureConnectionManagerControl()` to `MainWindow.Vault`.
+
+`RenderDetail(row)` calls a new `RenderSavedPasswordState(row)`:
+
+| `SavedPasswordAccess` state          | Row text            | Button        |
+|--------------------------------------|---------------------|---------------|
+| null                                 | `—`                 | not visible   |
+| `IsVaultAvailable == false`          | `Vault unavailable` | disabled      |
+| available, `HasSavedPassword` true   | `Yes`               | enabled       |
+| available, `HasSavedPassword` false  | `No`                | disabled      |
+
+`OnForgetSavedPasswordClick` resolves the row via `TryGetRow`, calls
+`ForgetSavedPassword`, then re-runs `RenderSavedPasswordState(row)` for that same
+row.
+
+No confirmation dialog, and no `LoadProfiles` refresh:
+
+- Forgetting a password is low-stakes — worst case is one extra prompt on the
+  next connect. A modal for that is friction without a payoff.
+- The row flipping to `No` and the button greying out *is* the feedback.
+- Re-rendering in place rather than reloading keeps the list selection.
+  `LoadProfiles` rebuilds every `SshProfileRowViewModel`, so `ApplyFilters`'
+  `nextRows.Contains(_selectedRow)` check fails and selection is lost. That is
+  acceptable for Delete (the row is gone) but wrong here.
+
+## Testing
+
+`tests/NovaTerminal.App.Tests/Ssh/ConnectionManagerTests.cs`, headless
+`[AvaloniaFact]`, following the existing `CreateMeasuredConnectionManager` /
+`SelectFirstRow` / `FindButtonByToolTip` helpers:
+
+1. Delete button raises `OnDeleteProfileRequested` with the selected profile.
+2. `SecondaryActionButtons_ReserveSquareHitTargets` — add `"Delete connection"`
+   to `actionTips` and change `Assert.Equal(4, actionButtons.Count)` to `5`.
+   Without this the new button is silently uncovered by the hit-target guard.
+3. Saved-password row renders `Yes` / `No` / `Vault unavailable` across the three
+   vault states, driven by a test double for `ISavedPasswordAccess`.
+4. Forget flips the row to `No`, disables the button, and leaves the list
+   selection intact.
+
+`VaultService` unit tests over `InMemorySecretStore`:
+
+5. `ForgetSavedPassword` clears the canonical key and the per-profile legacy
+   keys, and leaves the shared `SSH:{user}@{host}` alias intact.
+6. `HasSavedPassword` is true for a canonical-key secret and for a per-profile
+   legacy secret, false for a shared-alias-only secret, and performs no write
+   (the store's contents are unchanged after a probe).
+7. With an unavailable store, `IsVaultAvailable` is false, `HasSavedPassword` is
+   false, and `ForgetSavedPassword` returns false without throwing.
+
+A `SshConnectionService`-level check that delete removes the profile from the
+store and purges the profile-scoped vault keys, using the existing
+`RecordingSshPasswordVault`-style fake in `SshConnectionServiceTests` where it
+fits.
+
+## Files touched
+
+- `src/NovaTerminal.App/Controls/ConnectionManager.axaml`
+- `src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs`
+- `src/NovaTerminal.App/Shell/VaultService.cs`
+- `src/NovaTerminal.App/MainWindow.axaml.cs`
+- `tests/NovaTerminal.App.Tests/Ssh/ConnectionManagerTests.cs`
+- `tests/NovaTerminal.App.Tests/Core/` — new or extended `VaultService` tests

--- a/src/NovaTerminal.App/Controls/ConnectionManager.axaml
+++ b/src/NovaTerminal.App/Controls/ConnectionManager.axaml
@@ -123,6 +123,14 @@
             <Setter Property="Foreground" Value="{StaticResource NtRed}"/>
         </Style>
 
+        <!-- Favourite toggle's "on" state. This replaces a separate yellow indicator star that
+             used to sit beside the title: once the toggle moved into the title row the two would
+             have been adjacent stars meaning different things, so one control now carries both
+             the action and the state. Unset, the icon inherits IconBtn's Foreground. -->
+        <Style Selector="PathIcon.favOn">
+            <Setter Property="Foreground" Value="{StaticResource NtYellow}"/>
+        </Style>
+
         <!-- Filter chip toggle -->
         <Style Selector="ToggleButton.Chip">
             <Setter Property="Background" Value="Transparent"/>
@@ -481,7 +489,14 @@
                         BorderThickness="0,0,0,1"
                         Padding="24,20,24,16">
                     <StackPanel Spacing="6">
-                        <Grid ColumnDefinitions="Auto,Auto,Auto,*,Auto">
+                        <!-- Title row. The title column is `*` with ellipsis trimming, NOT Auto: an Auto
+                             column grows with a long connection name and would push the icon cluster and the
+                             status badge out of the panel, which is the clipping failure this panel already
+                             had once. The title yields instead.
+                             The secondary icon cluster lives here rather than in the action bar below, filling
+                             the void that used to sit between the title and the IDLE badge. That keeps the
+                             action bar a single row and puts destructive Delete far from the primary Open. -->
+                        <Grid ColumnDefinitions="Auto,*,Auto,Auto">
                             <Ellipse Width="10" Height="10" Fill="{StaticResource NtFg4}" VerticalAlignment="Center"/>
                             <TextBlock Grid.Column="1"
                                        Name="DetailTitle"
@@ -489,19 +504,36 @@
                                        Text="—"
                                        FontSize="20"
                                        FontWeight="SemiBold"
+                                       TextTrimming="CharacterEllipsis"
                                        Foreground="{StaticResource NtFg}"
                                        VerticalAlignment="Center"/>
-                            <PathIcon Grid.Column="2"
-                                      Name="DetailFavStar"
-                                      Margin="10,0,0,0"
-                                      Data="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z"
-                                      Width="16" Height="16"
-                                      Foreground="{StaticResource NtYellow}"
-                                      IsVisible="False"
-                                      VerticalAlignment="Center"/>
-                            <StackPanel Grid.Column="4"
+                            <WrapPanel Grid.Column="2"
+                                       Name="DetailActionBarIcons"
+                                       Orientation="Horizontal"
+                                       Margin="16,0,0,0"
+                                       VerticalAlignment="Center"
+                                       ItemSpacing="6"
+                                       LineSpacing="6">
+                                <Button Classes="IconBtn" Click="OnFavoriteClick" ToolTip.Tip="Toggle favorite">
+                                    <PathIcon Name="DetailFavStar" Data="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z" Width="14" Height="14"/>
+                                </Button>
+                                <Button Classes="IconBtn" Click="OnEditClick" ToolTip.Tip="Edit connection">
+                                    <PathIcon Data="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z" Width="14" Height="14"/>
+                                </Button>
+                                <Button Classes="IconBtn" Click="OnCopyCommandClick" ToolTip.Tip="Copy launch command">
+                                    <PathIcon Data="M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M19,21H8V7H19V21Z" Width="14" Height="14"/>
+                                </Button>
+                                <Button Classes="IconBtn" Click="OnDetailsClick" ToolTip.Tip="Connection details">
+                                    <PathIcon Data="M11,17H13V11H11M12,9A1,1 0 0,0 13,8A1,1 0 0,0 12,7A1,1 0 0,0 11,8A1,1 0 0,0 12,9M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z" Width="14" Height="14"/>
+                                </Button>
+                                <Button Classes="IconBtn Danger" Click="OnDeleteClick" ToolTip.Tip="Delete connection">
+                                    <PathIcon Data="M9,3V4H4V6H5V19A2,2 0 0,0 7,21H17A2,2 0 0,0 19,19V6H20V4H15V3H9M7,6H17V19H7V6M9,8V17H11V8H9M13,8V17H15V8H13Z" Width="14" Height="14"/>
+                                </Button>
+                            </WrapPanel>
+                            <StackPanel Grid.Column="3"
                                         Orientation="Horizontal"
                                         Spacing="6"
+                                        Margin="16,0,0,0"
                                         VerticalAlignment="Center">
                                 <Ellipse Width="8" Height="8" Fill="{StaticResource NtFg4}" VerticalAlignment="Center"/>
                                 <TextBlock Text="IDLE"
@@ -518,62 +550,34 @@
                                    FontSize="13"
                                    Foreground="{StaticResource NtFg3}"/>
 
-                        <!-- Action bar, two deliberate rows inside a capped panel.
-                             The detail panel is ~516px (the overlay is MaxWidth=1080 and this column gets
-                             3/5 of width-220) while the actions need ~550px, so a single row essentially
-                             never fits — a fixed-column Grid used to arrange the trailing controls outside
-                             the panel, where they were clipped and unreachable.
-                             Row 1 is the primary actions, row 2 the secondary icon cluster. Both rows are flush
-                             left, matching every other element in this panel (title, endpoint, the Host/Port/User
-                             grid); right-aligning row 2 made it overhang row 1 and left a void under the pills.
-                             Splitting on the group boundary rather than wherever the pixels run out keeps
-                             the cluster intact, keeps icon positions stable across widths, and keeps the
-                             destructive Delete away from the primary Open button. Each row is still a
-                             WrapPanel so nothing can be clipped at narrow widths either. -->
-                        <StackPanel Name="DetailActionBar" Margin="0,10,0,0" Spacing="6">
-                            <WrapPanel Name="DetailActionBarPrimary"
-                                       Orientation="Horizontal"
-                                       ItemSpacing="6"
-                                       LineSpacing="6">
-                                <Button Classes="Primary"
-                                        Click="OnOpenCurrentClick"
-                                        ToolTip.Tip="Open in current pane">
-                                    <StackPanel Orientation="Horizontal" Spacing="6">
-                                        <PathIcon Data="M8,5.14V19.14L19,12.14L8,5.14Z" Width="11" Height="11" Foreground="#0a1622"/>
-                                        <TextBlock Text="Open"/>
-                                    </StackPanel>
-                                </Button>
-                                <Button Classes="Pill" Content="+ Tab"   Click="OnOpenNewTabClick"/>
-                                <Button Classes="Pill" Content="Split &#x21D2;" Click="OnSplitHorizontalClick"/>
-                                <Button Classes="Pill" Content="Split &#x21D3;" Click="OnSplitVerticalClick"/>
+                        <!-- Action bar: the launch actions only. The secondary icon cluster moved up into the
+                             title row, so this is a single row again.
+                             Still a WrapPanel, not a fixed-column Grid: the detail panel is ~516px (the overlay
+                             is MaxWidth=1080 and this column gets 3/5 of width-220), and a Grid here previously
+                             arranged the trailing controls outside the panel where they were clipped and
+                             unreachable. Wrapping degrades instead of hiding. -->
+                        <WrapPanel Name="DetailActionBar"
+                                   Margin="0,10,0,0"
+                                   Orientation="Horizontal"
+                                   ItemSpacing="6"
+                                   LineSpacing="6">
+                            <Button Classes="Primary"
+                                    Click="OnOpenCurrentClick"
+                                    ToolTip.Tip="Open in current pane">
+                                <StackPanel Orientation="Horizontal" Spacing="6">
+                                    <PathIcon Data="M8,5.14V19.14L19,12.14L8,5.14Z" Width="11" Height="11" Foreground="#0a1622"/>
+                                    <TextBlock Text="Open"/>
+                                </StackPanel>
+                            </Button>
+                            <Button Classes="Pill" Content="+ Tab"   Click="OnOpenNewTabClick"/>
+                            <Button Classes="Pill" Content="Split &#x21D2;" Click="OnSplitHorizontalClick"/>
+                            <Button Classes="Pill" Content="Split &#x21D3;" Click="OnSplitVerticalClick"/>
 
-                                <ComboBox Name="DiagnosticsCombo"
-                                          Classes="Diag"
-                                          Width="130"
-                                          ToolTip.Tip="Diagnostics level"/>
-                            </WrapPanel>
-                            <WrapPanel Name="DetailActionBarIcons"
-                                       Orientation="Horizontal"
-                                       HorizontalAlignment="Left"
-                                       ItemSpacing="6"
-                                       LineSpacing="6">
-                                <Button Classes="IconBtn" Click="OnFavoriteClick" ToolTip.Tip="Toggle favorite">
-                                    <PathIcon Data="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z" Width="14" Height="14"/>
-                                </Button>
-                                <Button Classes="IconBtn" Click="OnEditClick" ToolTip.Tip="Edit connection">
-                                    <PathIcon Data="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z" Width="14" Height="14"/>
-                                </Button>
-                                <Button Classes="IconBtn" Click="OnCopyCommandClick" ToolTip.Tip="Copy launch command">
-                                    <PathIcon Data="M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M19,21H8V7H19V21Z" Width="14" Height="14"/>
-                                </Button>
-                                <Button Classes="IconBtn" Click="OnDetailsClick" ToolTip.Tip="Connection details">
-                                    <PathIcon Data="M11,17H13V11H11M12,9A1,1 0 0,0 13,8A1,1 0 0,0 12,7A1,1 0 0,0 11,8A1,1 0 0,0 12,9M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z" Width="14" Height="14"/>
-                                </Button>
-                                <Button Classes="IconBtn Danger" Click="OnDeleteClick" ToolTip.Tip="Delete connection">
-                                    <PathIcon Data="M9,3V4H4V6H5V19A2,2 0 0,0 7,21H17A2,2 0 0,0 19,19V6H20V4H15V3H9M7,6H17V19H7V6M9,8V17H11V8H9M13,8V17H15V8H13Z" Width="14" Height="14"/>
-                                </Button>
-                            </WrapPanel>
-                        </StackPanel>
+                            <ComboBox Name="DiagnosticsCombo"
+                                      Classes="Diag"
+                                      Width="130"
+                                      ToolTip.Tip="Diagnostics level"/>
+                        </WrapPanel>
                     </StackPanel>
                 </Border>
 

--- a/src/NovaTerminal.App/Controls/ConnectionManager.axaml
+++ b/src/NovaTerminal.App/Controls/ConnectionManager.axaml
@@ -518,10 +518,17 @@
                                    FontSize="13"
                                    Foreground="{StaticResource NtFg3}"/>
 
-                        <!-- Action bar -->
-                        <Grid Margin="0,10,0,0" ColumnDefinitions="Auto,Auto,Auto,Auto,*,Auto,Auto,Auto,Auto,Auto,Auto">
-                            <Button Grid.Column="0"
-                                    Classes="Primary"
+                        <!-- Action bar. A WrapPanel, not a Grid: the detail panel is capped at ~516px
+                             (the overlay is MaxWidth=1080 and this column gets 3/5 of width-220), which is
+                             narrower than this bar's content. A fixed column Grid silently arranged the
+                             trailing controls outside the panel and they were clipped away. Wrapping keeps
+                             every action reachable at any width. -->
+                        <WrapPanel Name="DetailActionBar"
+                                   Margin="0,10,0,0"
+                                   Orientation="Horizontal"
+                                   ItemSpacing="6"
+                                   LineSpacing="6">
+                            <Button Classes="Primary"
                                     Click="OnOpenCurrentClick"
                                     ToolTip.Tip="Open in current pane">
                                 <StackPanel Orientation="Horizontal" Spacing="6">
@@ -529,33 +536,31 @@
                                     <TextBlock Text="Open"/>
                                 </StackPanel>
                             </Button>
-                            <Button Grid.Column="1" Classes="Pill" Margin="6,0,0,0" Content="+ Tab"     Click="OnOpenNewTabClick"/>
-                            <Button Grid.Column="2" Classes="Pill" Margin="6,0,0,0" Content="Split ⇒"   Click="OnSplitHorizontalClick"/>
-                            <Button Grid.Column="3" Classes="Pill" Margin="6,0,0,0" Content="Split ⇓"   Click="OnSplitVerticalClick"/>
+                            <Button Classes="Pill" Content="+ Tab"   Click="OnOpenNewTabClick"/>
+                            <Button Classes="Pill" Content="Split &#x21D2;" Click="OnSplitHorizontalClick"/>
+                            <Button Classes="Pill" Content="Split &#x21D3;" Click="OnSplitVerticalClick"/>
 
                             <ComboBox Name="DiagnosticsCombo"
-                                      Grid.Column="5"
                                       Classes="Diag"
                                       Width="130"
-                                      Margin="6,0,8,0"
                                       ToolTip.Tip="Diagnostics level"/>
 
-                            <Button Grid.Column="6" Classes="IconBtn" Click="OnFavoriteClick" ToolTip.Tip="Toggle favorite">
+                            <Button Classes="IconBtn" Click="OnFavoriteClick" ToolTip.Tip="Toggle favorite">
                                 <PathIcon Data="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z" Width="14" Height="14"/>
                             </Button>
-                            <Button Grid.Column="7" Classes="IconBtn" Click="OnEditClick" ToolTip.Tip="Edit connection">
+                            <Button Classes="IconBtn" Click="OnEditClick" ToolTip.Tip="Edit connection">
                                 <PathIcon Data="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z" Width="14" Height="14"/>
                             </Button>
-                            <Button Grid.Column="8" Classes="IconBtn" Click="OnCopyCommandClick" ToolTip.Tip="Copy launch command">
+                            <Button Classes="IconBtn" Click="OnCopyCommandClick" ToolTip.Tip="Copy launch command">
                                 <PathIcon Data="M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M19,21H8V7H19V21Z" Width="14" Height="14"/>
                             </Button>
-                            <Button Grid.Column="9" Classes="IconBtn" Click="OnDetailsClick" ToolTip.Tip="Connection details">
+                            <Button Classes="IconBtn" Click="OnDetailsClick" ToolTip.Tip="Connection details">
                                 <PathIcon Data="M11,17H13V11H11M12,9A1,1 0 0,0 13,8A1,1 0 0,0 12,7A1,1 0 0,0 11,8A1,1 0 0,0 12,9M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z" Width="14" Height="14"/>
                             </Button>
-                            <Button Grid.Column="10" Classes="IconBtn Danger" Click="OnDeleteClick" ToolTip.Tip="Delete connection">
+                            <Button Classes="IconBtn Danger" Click="OnDeleteClick" ToolTip.Tip="Delete connection">
                                 <PathIcon Data="M9,3V4H4V6H5V19A2,2 0 0,0 7,21H17A2,2 0 0,0 19,19V6H20V4H15V3H9M7,6H17V19H7V6M9,8V17H11V8H9M13,8V17H15V8H13Z" Width="14" Height="14"/>
                             </Button>
-                        </Grid>
+                        </WrapPanel>
                     </StackPanel>
                 </Border>
 

--- a/src/NovaTerminal.App/Controls/ConnectionManager.axaml
+++ b/src/NovaTerminal.App/Controls/ConnectionManager.axaml
@@ -523,12 +523,14 @@
                              3/5 of width-220) while the actions need ~550px, so a single row essentially
                              never fits — a fixed-column Grid used to arrange the trailing controls outside
                              the panel, where they were clipped and unreachable.
-                             Row 1 is the primary actions, row 2 the secondary icon cluster, right-aligned.
+                             Row 1 is the primary actions, row 2 the secondary icon cluster. Both rows are flush
+                             left, matching every other element in this panel (title, endpoint, the Host/Port/User
+                             grid); right-aligning row 2 made it overhang row 1 and left a void under the pills.
                              Splitting on the group boundary rather than wherever the pixels run out keeps
                              the cluster intact, keeps icon positions stable across widths, and keeps the
                              destructive Delete away from the primary Open button. Each row is still a
                              WrapPanel so nothing can be clipped at narrow widths either. -->
-                        <StackPanel Name="DetailActionBar" Margin="0,10,0,0" Spacing="8">
+                        <StackPanel Name="DetailActionBar" Margin="0,10,0,0" Spacing="6">
                             <WrapPanel Name="DetailActionBarPrimary"
                                        Orientation="Horizontal"
                                        ItemSpacing="6"
@@ -552,7 +554,7 @@
                             </WrapPanel>
                             <WrapPanel Name="DetailActionBarIcons"
                                        Orientation="Horizontal"
-                                       HorizontalAlignment="Right"
+                                       HorizontalAlignment="Left"
                                        ItemSpacing="6"
                                        LineSpacing="6">
                                 <Button Classes="IconBtn" Click="OnFavoriteClick" ToolTip.Tip="Toggle favorite">

--- a/src/NovaTerminal.App/Controls/ConnectionManager.axaml
+++ b/src/NovaTerminal.App/Controls/ConnectionManager.axaml
@@ -519,7 +519,7 @@
                                    Foreground="{StaticResource NtFg3}"/>
 
                         <!-- Action bar -->
-                        <Grid Margin="0,10,0,0" ColumnDefinitions="Auto,Auto,Auto,Auto,*,Auto,Auto,Auto,Auto,Auto">
+                        <Grid Margin="0,10,0,0" ColumnDefinitions="Auto,Auto,Auto,Auto,*,Auto,Auto,Auto,Auto,Auto,Auto">
                             <Button Grid.Column="0"
                                     Classes="Primary"
                                     Click="OnOpenCurrentClick"
@@ -551,6 +551,9 @@
                             </Button>
                             <Button Grid.Column="9" Classes="IconBtn" Click="OnDetailsClick" ToolTip.Tip="Connection details">
                                 <PathIcon Data="M11,17H13V11H11M12,9A1,1 0 0,0 13,8A1,1 0 0,0 12,7A1,1 0 0,0 11,8A1,1 0 0,0 12,9M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z" Width="14" Height="14"/>
+                            </Button>
+                            <Button Grid.Column="10" Classes="IconBtn Danger" Click="OnDeleteClick" ToolTip.Tip="Delete connection">
+                                <PathIcon Data="M9,3V4H4V6H5V19A2,2 0 0,0 7,21H17A2,2 0 0,0 19,19V6H20V4H15V3H9M7,6H17V19H7V6M9,8V17H11V8H9M13,8V17H15V8H13Z" Width="14" Height="14"/>
                             </Button>
                         </Grid>
                     </StackPanel>

--- a/src/NovaTerminal.App/Controls/ConnectionManager.axaml
+++ b/src/NovaTerminal.App/Controls/ConnectionManager.axaml
@@ -518,49 +518,60 @@
                                    FontSize="13"
                                    Foreground="{StaticResource NtFg3}"/>
 
-                        <!-- Action bar. A WrapPanel, not a Grid: the detail panel is capped at ~516px
-                             (the overlay is MaxWidth=1080 and this column gets 3/5 of width-220), which is
-                             narrower than this bar's content. A fixed column Grid silently arranged the
-                             trailing controls outside the panel and they were clipped away. Wrapping keeps
-                             every action reachable at any width. -->
-                        <WrapPanel Name="DetailActionBar"
-                                   Margin="0,10,0,0"
-                                   Orientation="Horizontal"
-                                   ItemSpacing="6"
-                                   LineSpacing="6">
-                            <Button Classes="Primary"
-                                    Click="OnOpenCurrentClick"
-                                    ToolTip.Tip="Open in current pane">
-                                <StackPanel Orientation="Horizontal" Spacing="6">
-                                    <PathIcon Data="M8,5.14V19.14L19,12.14L8,5.14Z" Width="11" Height="11" Foreground="#0a1622"/>
-                                    <TextBlock Text="Open"/>
-                                </StackPanel>
-                            </Button>
-                            <Button Classes="Pill" Content="+ Tab"   Click="OnOpenNewTabClick"/>
-                            <Button Classes="Pill" Content="Split &#x21D2;" Click="OnSplitHorizontalClick"/>
-                            <Button Classes="Pill" Content="Split &#x21D3;" Click="OnSplitVerticalClick"/>
+                        <!-- Action bar, two deliberate rows inside a capped panel.
+                             The detail panel is ~516px (the overlay is MaxWidth=1080 and this column gets
+                             3/5 of width-220) while the actions need ~550px, so a single row essentially
+                             never fits — a fixed-column Grid used to arrange the trailing controls outside
+                             the panel, where they were clipped and unreachable.
+                             Row 1 is the primary actions, row 2 the secondary icon cluster, right-aligned.
+                             Splitting on the group boundary rather than wherever the pixels run out keeps
+                             the cluster intact, keeps icon positions stable across widths, and keeps the
+                             destructive Delete away from the primary Open button. Each row is still a
+                             WrapPanel so nothing can be clipped at narrow widths either. -->
+                        <StackPanel Name="DetailActionBar" Margin="0,10,0,0" Spacing="8">
+                            <WrapPanel Name="DetailActionBarPrimary"
+                                       Orientation="Horizontal"
+                                       ItemSpacing="6"
+                                       LineSpacing="6">
+                                <Button Classes="Primary"
+                                        Click="OnOpenCurrentClick"
+                                        ToolTip.Tip="Open in current pane">
+                                    <StackPanel Orientation="Horizontal" Spacing="6">
+                                        <PathIcon Data="M8,5.14V19.14L19,12.14L8,5.14Z" Width="11" Height="11" Foreground="#0a1622"/>
+                                        <TextBlock Text="Open"/>
+                                    </StackPanel>
+                                </Button>
+                                <Button Classes="Pill" Content="+ Tab"   Click="OnOpenNewTabClick"/>
+                                <Button Classes="Pill" Content="Split &#x21D2;" Click="OnSplitHorizontalClick"/>
+                                <Button Classes="Pill" Content="Split &#x21D3;" Click="OnSplitVerticalClick"/>
 
-                            <ComboBox Name="DiagnosticsCombo"
-                                      Classes="Diag"
-                                      Width="130"
-                                      ToolTip.Tip="Diagnostics level"/>
-
-                            <Button Classes="IconBtn" Click="OnFavoriteClick" ToolTip.Tip="Toggle favorite">
-                                <PathIcon Data="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z" Width="14" Height="14"/>
-                            </Button>
-                            <Button Classes="IconBtn" Click="OnEditClick" ToolTip.Tip="Edit connection">
-                                <PathIcon Data="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z" Width="14" Height="14"/>
-                            </Button>
-                            <Button Classes="IconBtn" Click="OnCopyCommandClick" ToolTip.Tip="Copy launch command">
-                                <PathIcon Data="M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M19,21H8V7H19V21Z" Width="14" Height="14"/>
-                            </Button>
-                            <Button Classes="IconBtn" Click="OnDetailsClick" ToolTip.Tip="Connection details">
-                                <PathIcon Data="M11,17H13V11H11M12,9A1,1 0 0,0 13,8A1,1 0 0,0 12,7A1,1 0 0,0 11,8A1,1 0 0,0 12,9M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z" Width="14" Height="14"/>
-                            </Button>
-                            <Button Classes="IconBtn Danger" Click="OnDeleteClick" ToolTip.Tip="Delete connection">
-                                <PathIcon Data="M9,3V4H4V6H5V19A2,2 0 0,0 7,21H17A2,2 0 0,0 19,19V6H20V4H15V3H9M7,6H17V19H7V6M9,8V17H11V8H9M13,8V17H15V8H13Z" Width="14" Height="14"/>
-                            </Button>
-                        </WrapPanel>
+                                <ComboBox Name="DiagnosticsCombo"
+                                          Classes="Diag"
+                                          Width="130"
+                                          ToolTip.Tip="Diagnostics level"/>
+                            </WrapPanel>
+                            <WrapPanel Name="DetailActionBarIcons"
+                                       Orientation="Horizontal"
+                                       HorizontalAlignment="Right"
+                                       ItemSpacing="6"
+                                       LineSpacing="6">
+                                <Button Classes="IconBtn" Click="OnFavoriteClick" ToolTip.Tip="Toggle favorite">
+                                    <PathIcon Data="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z" Width="14" Height="14"/>
+                                </Button>
+                                <Button Classes="IconBtn" Click="OnEditClick" ToolTip.Tip="Edit connection">
+                                    <PathIcon Data="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z" Width="14" Height="14"/>
+                                </Button>
+                                <Button Classes="IconBtn" Click="OnCopyCommandClick" ToolTip.Tip="Copy launch command">
+                                    <PathIcon Data="M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M19,21H8V7H19V21Z" Width="14" Height="14"/>
+                                </Button>
+                                <Button Classes="IconBtn" Click="OnDetailsClick" ToolTip.Tip="Connection details">
+                                    <PathIcon Data="M11,17H13V11H11M12,9A1,1 0 0,0 13,8A1,1 0 0,0 12,7A1,1 0 0,0 11,8A1,1 0 0,0 12,9M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z" Width="14" Height="14"/>
+                                </Button>
+                                <Button Classes="IconBtn Danger" Click="OnDeleteClick" ToolTip.Tip="Delete connection">
+                                    <PathIcon Data="M9,3V4H4V6H5V19A2,2 0 0,0 7,21H17A2,2 0 0,0 19,19V6H20V4H15V3H9M7,6H17V19H7V6M9,8V17H11V8H9M13,8V17H15V8H13Z" Width="14" Height="14"/>
+                                </Button>
+                            </WrapPanel>
+                        </StackPanel>
                     </StackPanel>
                 </Border>
 

--- a/src/NovaTerminal.App/Controls/ConnectionManager.axaml
+++ b/src/NovaTerminal.App/Controls/ConnectionManager.axaml
@@ -566,7 +566,7 @@
                         <!-- Connection details -->
                         <StackPanel Spacing="10">
                             <TextBlock Classes="SectionHeader" Text="CONNECTION"/>
-                            <Grid ColumnDefinitions="130,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto" Margin="0,0,0,0">
+                            <Grid ColumnDefinitions="130,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" Margin="0,0,0,0">
                                 <TextBlock Grid.Row="0" Grid.Column="0" Text="Host"        Foreground="{StaticResource NtFg3}" FontSize="13" Margin="0,4"/>
                                 <TextBlock Grid.Row="0" Grid.Column="1" Name="KvHost"  Text="—" FontFamily="{StaticResource NtMono}" FontSize="12.5" Foreground="{StaticResource NtFg}" Margin="0,4"/>
                                 <TextBlock Grid.Row="1" Grid.Column="0" Text="Port"        Foreground="{StaticResource NtFg3}" FontSize="13" Margin="0,4"/>
@@ -577,6 +577,15 @@
                                 <TextBlock Grid.Row="3" Grid.Column="1" Name="KvGroup" Text="—" FontFamily="{StaticResource NtMono}" FontSize="12.5" Foreground="{StaticResource NtFg}" Margin="0,4"/>
                                 <TextBlock Grid.Row="4" Grid.Column="0" Text="Auth"        Foreground="{StaticResource NtFg3}" FontSize="13" Margin="0,4"/>
                                 <TextBlock Grid.Row="4" Grid.Column="1" Name="KvAuth"  Text="—" FontFamily="{StaticResource NtMono}" FontSize="12.5" Foreground="{StaticResource NtFg}" Margin="0,4"/>
+                                <TextBlock Grid.Row="5" Grid.Column="0" Text="Saved password" Foreground="{StaticResource NtFg3}" FontSize="13" Margin="0,4"/>
+                                <StackPanel Grid.Row="5" Grid.Column="1" Orientation="Horizontal" Spacing="10" Margin="0,4" VerticalAlignment="Center">
+                                    <TextBlock Name="KvSavedPassword" Text="—" FontFamily="{StaticResource NtMono}" FontSize="12.5" Foreground="{StaticResource NtFg}" VerticalAlignment="Center"/>
+                                    <Button Name="BtnForgetSavedPassword"
+                                            Classes="Pill"
+                                            Content="Forget saved password"
+                                            Click="OnForgetSavedPasswordClick"
+                                            ToolTip.Tip="Remove this connection's password from the OS credential store"/>
+                                </StackPanel>
                             </Grid>
                         </StackPanel>
 

--- a/src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs
+++ b/src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs
@@ -120,6 +120,12 @@ namespace NovaTerminal.Controls
             set => SetValue(SecondaryForegroundProperty, value);
         }
 
+        /// <summary>
+        /// Vault access used to show and clear the selected connection's saved password.
+        /// Left null in tests and design-time; the row then reads "—" and Forget is hidden.
+        /// </summary>
+        public ISavedPasswordAccess? SavedPasswordAccess { get; set; }
+
         // Preserved for source compatibility with MainWindow's theme refresh path.
         public void ApplyTheme(TerminalTheme theme)
         {
@@ -394,6 +400,7 @@ namespace NovaTerminal.Controls
             var notes = this.FindControl<TextBlock>("DetailNotes");
             if (notes != null) notes.Text = string.IsNullOrWhiteSpace(row.Notes) ? "(no notes)" : row.Notes;
 
+            RenderSavedPasswordState(row);
             UpdateLaunchPreview();
         }
 
@@ -411,6 +418,53 @@ namespace NovaTerminal.Controls
             }
 
             return "agent";
+        }
+
+        private void RenderSavedPasswordState(SshProfileRowViewModel row)
+        {
+            var forgetButton = this.FindControl<Button>("BtnForgetSavedPassword");
+
+            if (SavedPasswordAccess == null)
+            {
+                SetText("KvSavedPassword", "—");
+                if (forgetButton != null)
+                {
+                    forgetButton.IsVisible = false;
+                    forgetButton.IsEnabled = false;
+                }
+                return;
+            }
+
+            if (forgetButton != null)
+            {
+                forgetButton.IsVisible = true;
+            }
+
+            if (!SavedPasswordAccess.IsVaultAvailable)
+            {
+                SetText("KvSavedPassword", "Vault unavailable");
+                if (forgetButton != null) forgetButton.IsEnabled = false;
+                return;
+            }
+
+            bool saved = SavedPasswordAccess.HasSavedPassword(row.Profile);
+            SetText("KvSavedPassword", saved ? "Yes" : "No");
+            if (forgetButton != null) forgetButton.IsEnabled = saved;
+        }
+
+        private void OnForgetSavedPasswordClick(object? sender, RoutedEventArgs e)
+        {
+            if (SavedPasswordAccess == null || !TryGetRow(sender, out var row))
+            {
+                return;
+            }
+
+            e.Handled = true;
+            SavedPasswordAccess.ForgetSavedPassword(row.Profile);
+
+            // Re-render this row in place rather than reloading: LoadProfiles rebuilds every
+            // SshProfileRowViewModel, so ApplyFilters' identity check drops the selection.
+            RenderSavedPasswordState(row);
         }
 
         private void UpdateLaunchPreview()

--- a/src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs
+++ b/src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs
@@ -391,8 +391,7 @@ namespace NovaTerminal.Controls
             SetText("KvGroup", string.IsNullOrWhiteSpace(row.GroupPath) ? "Ungrouped" : row.GroupPath);
             SetText("KvAuth", DescribeAuth(row.Profile));
 
-            var fav = this.FindControl<PathIcon>("DetailFavStar");
-            if (fav != null) fav.IsVisible = row.IsFavorite;
+            SetFavoriteIndicator(row.IsFavorite);
 
             var tagsControl = this.FindControl<ItemsControl>("DetailTags");
             if (tagsControl != null) tagsControl.ItemsSource = row.Tags.Where(t => !string.Equals(t, "favorite", StringComparison.OrdinalIgnoreCase)).ToList();
@@ -408,6 +407,15 @@ namespace NovaTerminal.Controls
         {
             var tb = this.FindControl<TextBlock>(controlName);
             if (tb != null) tb.Text = text;
+        }
+
+        // The favourite star is the toggle button's own icon, not a separate indicator:
+        // both live in the title row now, so one control carries the action and the state.
+        // Unset, the icon falls back to IconBtn's Foreground via the style.
+        private void SetFavoriteIndicator(bool isFavorite)
+        {
+            var fav = this.FindControl<PathIcon>("DetailFavStar");
+            fav?.Classes.Set("favOn", isFavorite);
         }
 
         private static string DescribeAuth(TerminalProfile profile)
@@ -564,8 +572,7 @@ namespace NovaTerminal.Controls
             UpdateGroupCounts();
             RebuildTags();
 
-            var fav = this.FindControl<PathIcon>("DetailFavStar");
-            if (fav != null) fav.IsVisible = row.IsFavorite;
+            SetFavoriteIndicator(row.IsFavorite);
 
             OnProfilesChanged?.Invoke();
         }

--- a/src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs
+++ b/src/NovaTerminal.App/Controls/ConnectionManager.axaml.cs
@@ -32,6 +32,7 @@ namespace NovaTerminal.Controls
         public event Action? OnProfilesChanged;
         public event Action? OnSyncRequested;
         public event Action? OnNewConnectionRequested;
+        public event Action<TerminalProfile>? OnDeleteProfileRequested;
 
         private readonly SshManagerViewModel _viewModel = new();
         private readonly ObservableCollection<GroupNode> _groups = new();
@@ -483,6 +484,15 @@ namespace NovaTerminal.Controls
             {
                 e.Handled = true;
                 OnConnectionDetailsRequested?.Invoke(row.Profile, GetSelectedDiagnosticsLevel());
+            }
+        }
+
+        private void OnDeleteClick(object? sender, RoutedEventArgs e)
+        {
+            if (TryGetRow(sender, out var row))
+            {
+                e.Handled = true;
+                OnDeleteProfileRequested?.Invoke(row.Profile);
             }
         }
 

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -5679,6 +5679,7 @@ namespace NovaTerminal
 
             var connManager = new ConnectionManager();
             connManager.ApplyTheme(_settings.ActiveTheme);
+            connManager.SavedPasswordAccess = Vault;
             connManager.OnQuickOpenRequested += (profile, target, diagnosticsLevel) =>
             {
                 HandleSshQuickOpen(profile, target, diagnosticsLevel);
@@ -5704,6 +5705,10 @@ namespace NovaTerminal
             connManager.OnEditProfile += async (profile) =>
             {
                 await ShowNewSshConnectionDialogAsync(profile);
+            };
+            connManager.OnDeleteProfileRequested += async (profile) =>
+            {
+                await DeleteSshProfileAsync(profile);
             };
 
             host.Content = connManager;
@@ -6025,6 +6030,102 @@ namespace NovaTerminal
             {
                 System.Diagnostics.Debug.WriteLine($"[MainWindow] Failed to save SSH connection: {ex.Message}");
             }
+        }
+
+        private async Task DeleteSshProfileAsync(TerminalProfile profile)
+        {
+            if (profile == null)
+            {
+                return;
+            }
+
+            string label = string.IsNullOrWhiteSpace(profile.Name)
+                ? "this connection"
+                : $"\"{profile.Name.Trim()}\"";
+
+            if (!await ShowDeleteConnectionConfirmationAsync(label))
+            {
+                return;
+            }
+
+            try
+            {
+                _sshConnectionService.DeleteProfile(profile.Id);
+
+                // Purge AFTER the store delete: if the delete throws, the secret stays put
+                // rather than being orphaned from a profile that still exists.
+                Vault?.ForgetSavedPassword(profile);
+
+                RefreshProfileUIs();
+            }
+            catch (Exception ex)
+            {
+                await ShowSimpleMessageDialogAsync("Delete connection", ex.Message);
+            }
+        }
+
+        private async Task<bool> ShowDeleteConnectionConfirmationAsync(string label)
+        {
+            bool confirmed = false;
+
+            var dialog = CreateThemedDialogWindow("Delete connection?", 480, 210, canResize: false);
+
+            var cancelButton = new Button
+            {
+                Content = "Cancel",
+                Width = 92
+            };
+            cancelButton.Click += (_, __) =>
+            {
+                confirmed = false;
+                dialog.Close();
+            };
+
+            var deleteButton = new Button
+            {
+                Content = "Delete",
+                Width = 92
+            };
+            deleteButton.Click += (_, __) =>
+            {
+                confirmed = true;
+                dialog.Close();
+            };
+
+            dialog.Content = new Border
+            {
+                Padding = new Thickness(16),
+                Child = new StackPanel
+                {
+                    Spacing = 12,
+                    Children =
+                    {
+                        new TextBlock
+                        {
+                            Text = $"Delete {label}?",
+                            FontWeight = FontWeight.SemiBold,
+                            TextWrapping = TextWrapping.Wrap
+                        },
+                        new TextBlock
+                        {
+                            Text = "The saved connection and any password stored for it are removed. "
+                                 + "Panes already connected keep running until you close them.",
+                            Opacity = 0.8,
+                            TextWrapping = TextWrapping.Wrap
+                        },
+                        new StackPanel
+                        {
+                            Orientation = Avalonia.Layout.Orientation.Horizontal,
+                            HorizontalAlignment = HorizontalAlignment.Right,
+                            Spacing = 8,
+                            Children = { cancelButton, deleteButton }
+                        }
+                    }
+                }
+            };
+
+            await dialog.ShowDialog(this);
+            return confirmed;
         }
 
         private async Task CopySshLaunchCommandAsync(TerminalProfile profile, SshDiagnosticsLevel diagnosticsLevel)

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -6039,9 +6039,14 @@ namespace NovaTerminal
                 return;
             }
 
-            string label = string.IsNullOrWhiteSpace(profile.Name)
+            string trimmedName = string.IsNullOrWhiteSpace(profile.Name) ? string.Empty : profile.Name.Trim();
+            const int maxLabelLength = 60;
+            string displayName = trimmedName.Length > maxLabelLength
+                ? trimmedName[..maxLabelLength] + "…"
+                : trimmedName;
+            string label = string.IsNullOrWhiteSpace(displayName)
                 ? "this connection"
-                : $"\"{profile.Name.Trim()}\"";
+                : $"\"{displayName}\"";
 
             if (!await ShowDeleteConnectionConfirmationAsync(label))
             {
@@ -6052,11 +6057,13 @@ namespace NovaTerminal
             {
                 _sshConnectionService.DeleteProfile(profile.Id);
 
-                // Purge AFTER the store delete: if the delete throws, the secret stays put
-                // rather than being orphaned from a profile that still exists.
-                Vault?.ForgetSavedPassword(profile);
-
+                // Refresh right after the store delete so the UI drops the deleted connection
+                // even if the vault purge below throws. Purge still runs AFTER the store
+                // delete: if the delete itself throws, the secret stays put rather than being
+                // orphaned from a profile that still exists.
                 RefreshProfileUIs();
+
+                Vault?.ForgetSavedPassword(profile);
             }
             catch (Exception ex)
             {
@@ -6073,7 +6080,8 @@ namespace NovaTerminal
             var cancelButton = new Button
             {
                 Content = "Cancel",
-                Width = 92
+                Width = 92,
+                IsCancel = true
             };
             cancelButton.Click += (_, __) =>
             {
@@ -6091,6 +6099,11 @@ namespace NovaTerminal
                 confirmed = true;
                 dialog.Close();
             };
+
+            // Give Cancel initial focus: combined with IsCancel above, Escape reliably backs
+            // out of a dialog the user may have opened by accident. Delete intentionally has
+            // no IsDefault, so Enter never triggers the destructive action.
+            dialog.Opened += (_, __) => cancelButton.Focus();
 
             dialog.Content = new Border
             {

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -6057,13 +6057,23 @@ namespace NovaTerminal
             {
                 _sshConnectionService.DeleteProfile(profile.Id);
 
-                // Refresh right after the store delete so the UI drops the deleted connection
-                // even if the vault purge below throws. Purge still runs AFTER the store
-                // delete: if the delete itself throws, the secret stays put rather than being
-                // orphaned from a profile that still exists.
-                RefreshProfileUIs();
-
-                Vault?.ForgetSavedPassword(profile);
+                // Two orderings matter here and they pull in opposite directions, so the
+                // purge is sequenced and the refresh is guaranteed:
+                //   * the purge runs AFTER the store delete, so if the delete throws the
+                //     secret stays put rather than being orphaned from a profile that
+                //     still exists;
+                //   * the refresh runs in a finally, so a throwing purge cannot leave the
+                //     deleted connection sitting in the list.
+                // Ordering them without the finally forces a choice between an orphaned
+                // secret and a stale row; this way neither failure mode exists.
+                try
+                {
+                    Vault?.ForgetSavedPassword(profile);
+                }
+                finally
+                {
+                    RefreshProfileUIs();
+                }
             }
             catch (Exception ex)
             {

--- a/src/NovaTerminal.App/Shell/VaultService.cs
+++ b/src/NovaTerminal.App/Shell/VaultService.cs
@@ -10,8 +10,36 @@ namespace NovaTerminal.Shell
         void ApplyRememberPasswordPreference(TerminalProfile profile, bool rememberPasswordInVault, string? password = null);
     }
 
+    /// <summary>
+    /// Read/clear access to the password a profile has saved in the OS credential store.
+    /// </summary>
+    /// <remarks>
+    /// Both members operate on <em>profile-scoped</em> keys only — the canonical
+    /// <c>SSH:PROFILE:{guid}</c> key plus this profile's own legacy keys. The shared
+    /// <c>SSH:{user}@{host}</c> alias is excluded on purpose: sibling profiles on the same
+    /// host resolve through it, so clearing it here would silently break them.
+    ///
+    /// Consequence: a password stored <em>only</em> under that shared alias reports
+    /// <see cref="HasSavedPassword"/> as <see langword="false"/> even though
+    /// <see cref="VaultService.ResolveSshPasswordForProfile"/> will still auto-fill from it at
+    /// connect time. Such a secret migrates to a profile-scoped key on first use, after which
+    /// this reports correctly. That is a legacy-store artifact, and preferable to letting one
+    /// profile delete another's password.
+    /// </remarks>
+    public interface ISavedPasswordAccess
+    {
+        /// <summary>True when the underlying credential store can be read and written.</summary>
+        bool IsVaultAvailable { get; }
+
+        /// <summary>True when a profile-scoped password is stored for <paramref name="profile"/>.</summary>
+        bool HasSavedPassword(TerminalProfile profile);
+
+        /// <summary>Clears every profile-scoped password key; true if anything was removed.</summary>
+        bool ForgetSavedPassword(TerminalProfile profile);
+    }
+
     public class VaultService
-        : ISshPasswordVault
+        : ISshPasswordVault, ISavedPasswordAccess
     {
         private readonly ISecretStore _store;
 
@@ -25,6 +53,38 @@ namespace NovaTerminal.Shell
         }
 
         public bool PersistenceAvailable => _store.IsAvailable;
+
+        public bool IsVaultAvailable => _store.IsAvailable;
+
+        public bool HasSavedPassword(TerminalProfile profile)
+        {
+            ArgumentNullException.ThrowIfNull(profile);
+
+            // GetSecret, not ResolveSshPasswordForProfile: the latter migrates a legacy hit
+            // to the canonical key, and this runs on every selection change in the UI.
+            foreach (string key in GetProfileScopedSshPasswordKeysForProfile(profile))
+            {
+                if (!string.IsNullOrEmpty(GetSecret(key)))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool ForgetSavedPassword(TerminalProfile profile)
+        {
+            ArgumentNullException.ThrowIfNull(profile);
+
+            bool removedAny = false;
+            foreach (string key in GetProfileScopedSshPasswordKeysForProfile(profile))
+            {
+                removedAny |= RemoveSecret(key);
+            }
+
+            return removedAny;
+        }
 
         public static string GetCanonicalSshProfileKey(Guid profileId)
         {

--- a/src/NovaTerminal.App/Shell/VaultService.cs
+++ b/src/NovaTerminal.App/Shell/VaultService.cs
@@ -15,9 +15,11 @@ namespace NovaTerminal.Shell
     /// </summary>
     /// <remarks>
     /// Both members operate on <em>profile-scoped</em> keys only — the canonical
-    /// <c>SSH:PROFILE:{guid}</c> key plus this profile's own legacy keys. The shared
-    /// <c>SSH:{user}@{host}</c> alias is excluded on purpose: sibling profiles on the same
-    /// host resolve through it, so clearing it here would silently break them.
+    /// <c>SSH:PROFILE:{guid}</c> key plus legacy keys <em>derived from this profile's current
+    /// Name/SshUser/SshHost</em> (see <see cref="VaultService.GetLegacySshKeys"/>), not from
+    /// its id. The shared <c>SSH:{user}@{host}</c> alias is excluded on purpose: sibling
+    /// profiles on the same host resolve through it, so clearing it here would silently break
+    /// them.
     ///
     /// Consequence: a password stored <em>only</em> under that shared alias reports
     /// <see cref="HasSavedPassword"/> as <see langword="false"/> even though
@@ -25,6 +27,17 @@ namespace NovaTerminal.Shell
     /// connect time. Such a secret migrates to a profile-scoped key on first use, after which
     /// this reports correctly. That is a legacy-store artifact, and preferable to letting one
     /// profile delete another's password.
+    ///
+    /// Because the legacy keys are name-derived rather than id-derived, two further quirks
+    /// follow. First, two profiles that happen to share identical Name + SshUser + SshHost
+    /// share that legacy key too, so forgetting or deleting one clears a key the sibling also
+    /// resolves through — the same failure mode the shared-alias exclusion above was designed
+    /// to prevent, reached through a narrower door. Second, if a profile was renamed (or its
+    /// SshUser/SshHost changed) after a legacy secret was written under the old values,
+    /// <see cref="ForgetSavedPassword"/> can no longer derive that key and the secret stays in
+    /// the OS credential store permanently; it is inert
+    /// (<see cref="VaultService.ResolveSshPasswordForProfile"/> derives the same name-based
+    /// keys and also cannot find it) but it is never removed.
     /// </remarks>
     public interface ISavedPasswordAccess
     {

--- a/tests/NovaTerminal.App.Tests/Core/VaultServiceSavedPasswordTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/VaultServiceSavedPasswordTests.cs
@@ -1,0 +1,164 @@
+using System;
+using NovaTerminal.Shell;
+using NovaTerminal.Shell.Secrets;
+
+namespace NovaTerminal.Tests.Core;
+
+// Note: both TerminalProfile and ConnectionType live in NovaTerminal.Shell
+// (src/NovaTerminal.App/Shell/TerminalProfile.cs). Do not add a
+// `using NovaTerminal.Platform;` — it is not needed here.
+
+public class VaultServiceSavedPasswordTests
+{
+    private sealed class UnavailableStore : ISecretStore
+    {
+        public bool IsAvailable => false;
+        public string? Read(string key) => "should-not-be-read";
+        public void Write(string key, string value) => throw new InvalidOperationException("must not write");
+        public bool Delete(string key) => throw new InvalidOperationException("must not delete");
+    }
+
+    private static TerminalProfile CreateProfile(string name = "Prod")
+    {
+        return new TerminalProfile
+        {
+            Type = ConnectionType.SSH,
+            Name = name,
+            SshHost = "prod.internal",
+            SshUser = "ops"
+        };
+    }
+
+    [Fact]
+    public void IsVaultAvailable_ReflectsStore()
+    {
+        Assert.True(new VaultService(new InMemorySecretStore()).IsVaultAvailable);
+        Assert.False(new VaultService(new UnavailableStore()).IsVaultAvailable);
+    }
+
+    [Fact]
+    public void HasSavedPassword_IsFalse_WhenNothingStored()
+    {
+        var vault = new VaultService(new InMemorySecretStore());
+        Assert.False(vault.HasSavedPassword(CreateProfile()));
+    }
+
+    [Fact]
+    public void HasSavedPassword_IsTrue_ForCanonicalKey()
+    {
+        var store = new InMemorySecretStore();
+        var vault = new VaultService(store);
+        TerminalProfile profile = CreateProfile();
+
+        store.Write(VaultService.GetCanonicalSshProfileKey(profile.Id), "secret");
+
+        Assert.True(vault.HasSavedPassword(profile));
+    }
+
+    [Fact]
+    public void HasSavedPassword_IsTrue_ForPerProfileLegacyKey()
+    {
+        var store = new InMemorySecretStore();
+        var vault = new VaultService(store);
+        TerminalProfile profile = CreateProfile();
+
+        store.Write($"profile_{profile.Id}_password", "secret");
+
+        Assert.True(vault.HasSavedPassword(profile));
+    }
+
+    [Fact]
+    public void HasSavedPassword_IsFalse_ForSharedAliasOnly()
+    {
+        // The shared SSH:{user}@{host} alias may be resolved by sibling profiles
+        // on the same host, so it is deliberately outside this profile's scope.
+        var store = new InMemorySecretStore();
+        var vault = new VaultService(store);
+        TerminalProfile profile = CreateProfile();
+
+        store.Write("SSH:ops@prod.internal", "secret");
+
+        Assert.False(vault.HasSavedPassword(profile));
+    }
+
+    [Fact]
+    public void HasSavedPassword_DoesNotWriteToStore()
+    {
+        // Must not go through ResolveSshPasswordForProfile, which migrates a
+        // legacy hit to the canonical key as a side effect.
+        var store = new InMemorySecretStore();
+        var vault = new VaultService(store);
+        TerminalProfile profile = CreateProfile();
+        string legacyKey = $"profile_{profile.Id}_password";
+
+        store.Write(legacyKey, "secret");
+        Assert.True(vault.HasSavedPassword(profile));
+
+        Assert.Null(store.Read(VaultService.GetCanonicalSshProfileKey(profile.Id)));
+        Assert.Equal("secret", store.Read(legacyKey));
+    }
+
+    [Fact]
+    public void ForgetSavedPassword_ClearsCanonicalAndPerProfileLegacyKeys()
+    {
+        var store = new InMemorySecretStore();
+        var vault = new VaultService(store);
+        TerminalProfile profile = CreateProfile();
+        string canonicalKey = VaultService.GetCanonicalSshProfileKey(profile.Id);
+        string legacyIdKey = $"profile_{profile.Id}_password";
+        string legacyNamedKey = "SSH:Prod:ops@prod.internal";
+
+        store.Write(canonicalKey, "a");
+        store.Write(legacyIdKey, "b");
+        store.Write(legacyNamedKey, "c");
+
+        Assert.True(vault.ForgetSavedPassword(profile));
+
+        Assert.Null(store.Read(canonicalKey));
+        Assert.Null(store.Read(legacyIdKey));
+        Assert.Null(store.Read(legacyNamedKey));
+        Assert.False(vault.HasSavedPassword(profile));
+    }
+
+    [Fact]
+    public void ForgetSavedPassword_LeavesSharedAliasIntact()
+    {
+        var store = new InMemorySecretStore();
+        var vault = new VaultService(store);
+        TerminalProfile profile = CreateProfile();
+
+        store.Write(VaultService.GetCanonicalSshProfileKey(profile.Id), "mine");
+        store.Write("SSH:ops@prod.internal", "shared");
+
+        Assert.True(vault.ForgetSavedPassword(profile));
+
+        Assert.Equal("shared", store.Read("SSH:ops@prod.internal"));
+    }
+
+    [Fact]
+    public void ForgetSavedPassword_ReturnsFalse_WhenNothingStored()
+    {
+        var vault = new VaultService(new InMemorySecretStore());
+        Assert.False(vault.ForgetSavedPassword(CreateProfile()));
+    }
+
+    [Fact]
+    public void SavedPasswordMembers_WhenVaultUnavailable_AreSafeNoOps()
+    {
+        // UnavailableStore throws on Read/Write/Delete; the IsAvailable guards in
+        // GetSecret/RemoveSecret must short-circuit before touching it.
+        var vault = new VaultService(new UnavailableStore());
+        TerminalProfile profile = CreateProfile();
+
+        Assert.False(vault.IsVaultAvailable);
+        Assert.False(vault.HasSavedPassword(profile));
+        Assert.False(vault.ForgetSavedPassword(profile));
+    }
+
+    [Fact]
+    public void ForgetSavedPassword_Throws_OnNullProfile()
+    {
+        var vault = new VaultService(new InMemorySecretStore());
+        Assert.Throws<ArgumentNullException>(() => vault.ForgetSavedPassword(null!));
+    }
+}

--- a/tests/NovaTerminal.App.Tests/Ssh/ConnectionManagerTests.cs
+++ b/tests/NovaTerminal.App.Tests/Ssh/ConnectionManagerTests.cs
@@ -44,7 +44,8 @@ public sealed class ConnectionManagerTests
             "Toggle favorite",
             "Edit connection",
             "Copy launch command",
-            "Connection details"
+            "Connection details",
+            "Delete connection"
         };
 
         var actionButtons = control.GetVisualDescendants()
@@ -52,7 +53,7 @@ public sealed class ConnectionManagerTests
             .Where(button => ToolTip.GetTip(button) is string tip && actionTips.Contains(tip))
             .ToList();
 
-        Assert.Equal(4, actionButtons.Count);
+        Assert.Equal(5, actionButtons.Count);
         Assert.All(actionButtons, button =>
         {
             Assert.True(button.Width >= 30, $"Expected '{ToolTip.GetTip(button)}' width >= 30 but was {button.Width}.");
@@ -83,6 +84,58 @@ public sealed class ConnectionManagerTests
         Assert.NotNull(receivedProfile);
         Assert.Equal("Prod", receivedProfile!.Name);
         Assert.Equal(SshDiagnosticsLevel.None, receivedLevel);
+    }
+
+    [AvaloniaFact]
+    public void DeleteAction_RaisesDeleteProfileRequested_ForSelectedRow()
+    {
+        var control = CreateMeasuredConnectionManager();
+        TerminalProfile profile = CreateSshProfile("Prod", favorite: false);
+        control.LoadProfiles(new[] { profile });
+        SelectFirstRow(control);
+
+        TerminalProfile? receivedProfile = null;
+        control.OnDeleteProfileRequested += p => receivedProfile = p;
+
+        var deleteButton = FindButtonByToolTip(control, "Delete connection");
+        Assert.NotNull(deleteButton);
+
+        deleteButton!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+        Assert.Same(profile, receivedProfile);
+    }
+
+    [AvaloniaFact]
+    public void DeleteAction_DoesNotRaise_WhenNoRowSelected()
+    {
+        var control = CreateMeasuredConnectionManager();
+        control.LoadProfiles(new[] { CreateSshProfile("Prod", favorite: false) });
+
+        bool raised = false;
+        control.OnDeleteProfileRequested += _ => raised = true;
+
+        var deleteButton = FindButtonByToolTip(control, "Delete connection");
+        Assert.NotNull(deleteButton);
+
+        deleteButton!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+        Assert.False(raised);
+    }
+
+    [AvaloniaFact]
+    public void DeleteAction_DoesNotRemoveRowItself()
+    {
+        // The control only raises; MainWindow owns the store delete and the refresh.
+        var control = CreateMeasuredConnectionManager();
+        control.LoadProfiles(new[] { CreateSshProfile("Prod", favorite: false) });
+        SelectFirstRow(control);
+        control.OnDeleteProfileRequested += _ => { };
+
+        FindButtonByToolTip(control, "Delete connection")!
+            .RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+        Assert.Equal(1, GetListItemCount(control));
+        Assert.Single(control.GetAllProfiles());
     }
 
     [AvaloniaFact]

--- a/tests/NovaTerminal.App.Tests/Ssh/ConnectionManagerTests.cs
+++ b/tests/NovaTerminal.App.Tests/Ssh/ConnectionManagerTests.cs
@@ -139,6 +139,92 @@ public sealed class ConnectionManagerTests
     }
 
     [AvaloniaFact]
+    public void SavedPasswordRow_ShowsYes_AndEnablesForget_WhenPasswordStored()
+    {
+        var control = CreateMeasuredConnectionManager();
+        control.SavedPasswordAccess = new FakeSavedPasswordAccess { Saved = true };
+        control.LoadProfiles(new[] { CreateSshProfile("Prod", favorite: false) });
+        SelectFirstRow(control);
+
+        Assert.Equal("Yes", FindControl<TextBlock>(control, "KvSavedPassword").Text);
+        var forget = FindControl<Button>(control, "BtnForgetSavedPassword");
+        Assert.True(forget.IsVisible);
+        Assert.True(forget.IsEnabled);
+    }
+
+    [AvaloniaFact]
+    public void SavedPasswordRow_ShowsNo_AndDisablesForget_WhenNothingStored()
+    {
+        var control = CreateMeasuredConnectionManager();
+        control.SavedPasswordAccess = new FakeSavedPasswordAccess { Saved = false };
+        control.LoadProfiles(new[] { CreateSshProfile("Prod", favorite: false) });
+        SelectFirstRow(control);
+
+        Assert.Equal("No", FindControl<TextBlock>(control, "KvSavedPassword").Text);
+        Assert.False(FindControl<Button>(control, "BtnForgetSavedPassword").IsEnabled);
+    }
+
+    [AvaloniaFact]
+    public void SavedPasswordRow_ShowsVaultUnavailable_WhenStoreIsUnavailable()
+    {
+        var control = CreateMeasuredConnectionManager();
+        control.SavedPasswordAccess = new FakeSavedPasswordAccess { IsVaultAvailable = false, Saved = true };
+        control.LoadProfiles(new[] { CreateSshProfile("Prod", favorite: false) });
+        SelectFirstRow(control);
+
+        Assert.Equal("Vault unavailable", FindControl<TextBlock>(control, "KvSavedPassword").Text);
+        Assert.False(FindControl<Button>(control, "BtnForgetSavedPassword").IsEnabled);
+    }
+
+    [AvaloniaFact]
+    public void SavedPasswordRow_HidesForget_WhenNoAccessorInjected()
+    {
+        var control = CreateMeasuredConnectionManager();
+        control.LoadProfiles(new[] { CreateSshProfile("Prod", favorite: false) });
+        SelectFirstRow(control);
+
+        Assert.Equal("—", FindControl<TextBlock>(control, "KvSavedPassword").Text);
+        Assert.False(FindControl<Button>(control, "BtnForgetSavedPassword").IsVisible);
+    }
+
+    [AvaloniaFact]
+    public void ForgetSavedPassword_FlipsRowToNo_DisablesButton_AndKeepsSelection()
+    {
+        var control = CreateMeasuredConnectionManager();
+        var access = new FakeSavedPasswordAccess { Saved = true };
+        control.SavedPasswordAccess = access;
+        TerminalProfile profile = CreateSshProfile("Prod", favorite: false);
+        control.LoadProfiles(new[] { profile });
+        SelectFirstRow(control);
+
+        var forget = FindControl<Button>(control, "BtnForgetSavedPassword");
+        forget.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+        Assert.Equal(1, access.ForgetCallCount);
+        Assert.Same(profile, access.LastForgotten);
+        Assert.Equal("No", FindControl<TextBlock>(control, "KvSavedPassword").Text);
+        Assert.False(forget.IsEnabled);
+
+        // No LoadProfiles reload — the selection must survive.
+        var list = FindControl<ListBox>(control, "ConnectionsList");
+        Assert.Equal(0, list.SelectedIndex);
+    }
+
+    [AvaloniaFact]
+    public void ForgetSavedPassword_DoesNothing_WhenNoRowSelected()
+    {
+        var control = CreateMeasuredConnectionManager();
+        var access = new FakeSavedPasswordAccess { Saved = true };
+        control.SavedPasswordAccess = access;
+        control.LoadProfiles(new[] { CreateSshProfile("Prod", favorite: false) });
+
+        FindControl<Button>(control, "BtnForgetSavedPassword")
+            .RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+        Assert.Equal(0, access.ForgetCallCount);
+    }
+
+    [AvaloniaFact]
     public void DetailPane_ShowsTypedIdentityFileAuthDescription()
     {
         var control = CreateMeasuredConnectionManager();
@@ -364,6 +450,25 @@ public sealed class ConnectionManagerTests
         };
 
         handler!.Invoke(control, new object?[] { toggle, new RoutedEventArgs(ToggleButton.ClickEvent) });
+    }
+
+    private sealed class FakeSavedPasswordAccess : NovaTerminal.Shell.ISavedPasswordAccess
+    {
+        public bool IsVaultAvailable { get; set; } = true;
+        public bool Saved { get; set; }
+        public int ForgetCallCount { get; private set; }
+        public TerminalProfile? LastForgotten { get; private set; }
+
+        public bool HasSavedPassword(TerminalProfile profile) => Saved;
+
+        public bool ForgetSavedPassword(TerminalProfile profile)
+        {
+            ForgetCallCount++;
+            LastForgotten = profile;
+            bool had = Saved;
+            Saved = false;
+            return had;
+        }
     }
 
     private static Button? FindButtonByToolTip(ConnectionManager control, string tip)

--- a/tests/NovaTerminal.App.Tests/Ssh/ConnectionManagerTests.cs
+++ b/tests/NovaTerminal.App.Tests/Ssh/ConnectionManagerTests.cs
@@ -34,12 +34,33 @@ public sealed class ConnectionManagerTests
         Assert.True(raised);
     }
 
+    // Asserts ARRANGED bounds, not Button.Width/Height. Those are the style-set
+    // StyledProperties: they read 30 from the IconBtn style even when the button was
+    // arranged into an empty rect, so the original version of this test could not tell a
+    // real hit target from no layout at all.
+    //
+    // Scope, precisely: this covers hit-target SIZE. It does not detect clipping — the
+    // delete button that was invisible in the running app was arranged 30x30 at X=520
+    // inside a 468px parent, so these assertions would have passed. Position relative to
+    // the panel is ActionBarControls_AreArrangedInsideTheDetailPanel's job. The two
+    // together cover size and placement.
+    //
+    // Show() + RunJobs() is what produces a real layout pass: the detail panel starts
+    // collapsed, and Measure with an unchanged constraint returns the cached empty-state
+    // desired size, leaving the whole detail header arranged at zero.
     [AvaloniaFact]
     public void SecondaryActionButtons_ReserveSquareHitTargets()
     {
-        var control = CreateMeasuredConnectionManager(800, 500);
+        var control = new ConnectionManager();
+        var host = new Grid();
+        host.Children.Add(control);
+        var window = new Window { Width = 1080, Height = 720, Content = host };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
         control.LoadProfiles(new[] { CreateSshProfile("Prod", favorite: true) });
-        SelectFirstRow(control);
+        FindControl<ListBox>(control, "ConnectionsList").SelectedIndex = 0;
+        Dispatcher.UIThread.RunJobs();
 
         string[] actionTips =
         {
@@ -58,8 +79,12 @@ public sealed class ConnectionManagerTests
         Assert.Equal(5, actionButtons.Count);
         Assert.All(actionButtons, button =>
         {
-            Assert.True(button.Width >= 30, $"Expected '{ToolTip.GetTip(button)}' width >= 30 but was {button.Width}.");
-            Assert.True(button.Height >= 30, $"Expected '{ToolTip.GetTip(button)}' height >= 30 but was {button.Height}.");
+            Assert.True(
+                button.Bounds.Width >= 30,
+                $"Expected '{ToolTip.GetTip(button)}' arranged width >= 30 but was {button.Bounds.Width}.");
+            Assert.True(
+                button.Bounds.Height >= 30,
+                $"Expected '{ToolTip.GetTip(button)}' arranged height >= 30 but was {button.Bounds.Height}.");
         });
     }
 

--- a/tests/NovaTerminal.App.Tests/Ssh/ConnectionManagerTests.cs
+++ b/tests/NovaTerminal.App.Tests/Ssh/ConnectionManagerTests.cs
@@ -3,6 +3,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
 using Avalonia.Interactivity;
 using Avalonia.VisualTree;
 using NovaTerminal.Controls;
@@ -364,6 +365,66 @@ public sealed class ConnectionManagerTests
 
         Assert.True(control.Bounds.Width <= 760, $"Expected width <= 760 but was {control.Bounds.Width}.");
         Assert.True(control.Bounds.Height <= 520, $"Expected height <= 520 but was {control.Bounds.Height}.");
+    }
+
+
+    // Regression guard for the delete/details icons being arranged outside the detail
+    // panel and clipped away (invisible in the running app while every behavioural test
+    // passed). Note SecondaryActionButtons_ReserveSquareHitTargets asserts Button.Width,
+    // which is the STYLE-SET property and reads 30 even when the arranged width is 0 —
+    // it cannot detect clipping. This asserts real arranged geometry instead.
+    //
+    // Show() + RunJobs() is required rather than Measure/Arrange: DetailContent starts
+    // collapsed, and a manual Measure with an unchanged constraint returns the cached
+    // empty-state desired size, leaving the entire detail header arranged at zero.
+    [AvaloniaTheory]
+    [InlineData(1080.0)]
+    [InlineData(900.0)]
+    [InlineData(1400.0)]
+    public void ActionBarControls_AreArrangedInsideTheDetailPanel(double width)
+    {
+        var control = new ConnectionManager();
+        var host = new Grid();
+        host.Children.Add(control);
+        var window = new Window { Width = width, Height = 720, Content = host };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        control.LoadProfiles(new[] { CreateSshProfile("Prod", favorite: false) });
+        var list = FindControl<ListBox>(control, "ConnectionsList");
+        list.SelectedIndex = 0;
+        Dispatcher.UIThread.RunJobs();
+
+        var panel = FindControl<Grid>(control, "DetailColumn");
+        Assert.True(panel.Bounds.Width > 0, "detail panel was not arranged");
+
+        string[] actionTips =
+        {
+            "Open in current pane",
+            "Toggle favorite",
+            "Edit connection",
+            "Copy launch command",
+            "Connection details",
+            "Delete connection"
+        };
+
+        foreach (string tip in actionTips)
+        {
+            Button? button = FindButtonByToolTip(control, tip);
+            Assert.NotNull(button);
+
+            Point origin = button!.TranslatePoint(new Point(0, 0), panel)
+                ?? throw new Xunit.Sdk.XunitException($"'{tip}' is not connected to the detail panel.");
+
+            Assert.True(
+                button.Bounds.Width > 0 && button.Bounds.Height > 0,
+                $"'{tip}' arranged with an empty rect ({button.Bounds}).");
+
+            double right = origin.X + button.Bounds.Width;
+            Assert.True(
+                right <= panel.Bounds.Width + 0.5,
+                $"'{tip}' is clipped at width {width}: right edge {right:F1} exceeds detail panel width {panel.Bounds.Width:F1}.");
+        }
     }
 
     private static ConnectionManager CreateMeasuredConnectionManager(double width = 1080, double height = 720)

--- a/tests/NovaTerminal.App.Tests/Ssh/ConnectionManagerTests.cs
+++ b/tests/NovaTerminal.App.Tests/Ssh/ConnectionManagerTests.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
 using Avalonia.Interactivity;
+using Avalonia.Media;
 using Avalonia.VisualTree;
 using NovaTerminal.Controls;
 using NovaTerminal.Platform;
@@ -425,6 +426,41 @@ public sealed class ConnectionManagerTests
                 right <= panel.Bounds.Width + 0.5,
                 $"'{tip}' is clipped at width {width}: right edge {right:F1} exceeds detail panel width {panel.Bounds.Width:F1}.");
         }
+    }
+
+
+    // The favourite star is now the toggle button's own icon carrying both action and state
+    // (it replaced a separate yellow indicator that would have sat beside it in the title row).
+    // Nothing covered the old indicator, so this pins the new mechanism.
+    [AvaloniaFact]
+    public void FavoriteToggle_IconCarriesFavoriteState()
+    {
+        var control = CreateMeasuredConnectionManager();
+        control.LoadProfiles(new[] { CreateSshProfile("Prod", favorite: false) });
+        SelectFirstRow(control);
+
+        var star = FindControl<PathIcon>(control, "DetailFavStar");
+        Assert.False(star.Classes.Contains("favOn"), "a non-favorite connection should not show the lit star.");
+
+        FindButtonByToolTip(control, "Toggle favorite")!
+            .RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+        Assert.True(star.Classes.Contains("favOn"), "toggling on should light the star.");
+
+        FindButtonByToolTip(control, "Toggle favorite")!
+            .RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+        Assert.False(star.Classes.Contains("favOn"), "toggling off should unlight the star.");
+    }
+
+    [AvaloniaFact]
+    public void FavoriteToggle_IconIsLit_ForAnAlreadyFavoriteConnection()
+    {
+        var control = CreateMeasuredConnectionManager();
+        control.LoadProfiles(new[] { CreateSshProfile("Prod", favorite: true) });
+        SelectFirstRow(control);
+
+        Assert.True(
+            FindControl<PathIcon>(control, "DetailFavStar").Classes.Contains("favOn"),
+            "selecting a favorite connection should render the star lit.");
     }
 
     private static ConnectionManager CreateMeasuredConnectionManager(double width = 1080, double height = 720)


### PR DESCRIPTION
## What this changes

The connection manager could not delete a connection, and the app had **no way at all to remove a saved SSH password** — the vault was write-only. `AuthPromptDialog`'s "Remember password" checkbox stored a secret via `SshInteractionService`, and nothing in the product ever removed it. This adds a Delete action (with confirmation, purging the profile's saved password) and a "Saved password" row with a Forget button.

Two pieces of dead code turn out to have been waiting for exactly this: `SshConnectionService.DeleteProfile(Guid)` existed but was reachable from no UI, and `ConnectionManager.axaml` carried an unused `Button.Danger` style commented `<!-- Danger icon button (delete) -->`.

It also fixes a **pre-existing layout bug found while smoke-testing this work**: the detail panel's action bar was arranging its trailing controls outside the panel, where they were clipped and unreachable. ⓘ Connection details had already been invisible before this branch; the new Delete button made it two. See "The clipping bug" below — that section is the most useful part of this PR for a reviewer.

Fixes # — no linked issue; reported directly.

## Invariant and ownership

- **What invariant does this change affect?**

  Vault key scoping: which credential-store keys belong to a given SSH profile, and therefore which ones may be deleted on its behalf. The new `ISavedPasswordAccess` probe and purge both operate on `GetProfileScopedSshPasswordKeysForProfile` — the canonical `SSH:PROFILE:{guid}` key plus that profile's name-derived legacy keys — and deliberately **exclude** the shared `SSH:{user}@{host}` alias, because sibling profiles on the same host resolve through it. Probe and purge use the same key set, so the UI can never show a state the button cannot clear.

  Two consequences are documented in the interface's `<remarks>` rather than silently accepted:
  - A password stored *only* under the shared alias reports "not saved" while `ResolveSshPasswordForProfile` still auto-fills from it at connect time. It migrates to a profile-scoped key on first use.
  - The legacy key `SSH:{name}:{user}@{host}` is name-derived, not GUID-scoped, so two profiles with identical Name+SshUser+SshHost share it, and a renamed profile's legacy secret can no longer be derived (it stays in the credential store, inert).

  A second invariant: the probe must never write. `HasSavedPassword` uses `GetSecret`, not `ResolveSshPasswordForProfile`, because the latter migrates legacy keys to canonical and the probe runs on every selection change. `HasSavedPassword_DoesNotWriteToStore` pins this.

- **Which module owns that invariant?**

  `NovaTerminal.App` — `src/NovaTerminal.App/Shell/VaultService.cs` for the key scoping, `src/NovaTerminal.App/Controls/ConnectionManager.axaml{,.cs}` and `MainWindow.axaml.cs` for the UI. No VT, renderer, buffer, or PTY code is touched.

## The clipping bug

Worth reading before the rest of the review, because it is the part that nearly shipped broken.

Every automated test passed, the delete button was in the visual tree with the right tooltip and the right handler, its three behavioural tests were green — and in the running app the button did not exist on screen. So did ⓘ Connection details, which had been missing since before this branch.

Measured geometry at a 1080px overlay:

| | |
|---|---|
| `DetailColumn` (detail panel) | 516px |
| action bar | 468px |
| ⓘ Connection details | right edge **544** — outside the panel |
| 🗑 Delete | arranged at **X=520**, width 30 — 82px past the edge |

The connection overlay is capped at `MaxWidth="1080"` (`MainWindow.axaml:328`) and this column gets 3/5 of `width - 220`, so the detail panel is ~516px no matter the monitor; the header's `Padding="24,20,24,16"` leaves ~467px for a bar whose content needs ~550px. As a fixed 11-column `Grid` the overflow was arranged outside the panel and clipped. **Widening the window cannot help** — the cap is fixed. At a 900px overlay even ★ Toggle favorite clipped.

**Why no test caught it:** `SecondaryActionButtons_ReserveSquareHitTargets` asserted `button.Width >= 30` — the *style-set* `StyledProperty`, not arranged geometry, which reads 30 straight from the `IconBtn` style even when the button was arranged into an empty rect. It verified the style was applied and nothing about layout. I had amended that test believing it covered the new button; it could not.

It now asserts arranged `Bounds`, and its comment states the real scope: it covers hit-target **size** and still does not detect clipping — the invisible button was arranged 30×30 at X=520 inside a 468px parent, so even the bounds assertions pass on it. Placement is `ActionBarControls_AreArrangedInsideTheDetailPanel`'s job; the two together cover size and position.

I swept the rest of the test suites for the same pattern (`Assert` on a `Control`'s `Width`/`Height`/`Max*` rather than `Bounds`). **It is not widespread.** Two other hits, neither worth changing: `RemoteFilesSidebarTests.Sidebar_UsesCompactChromeWidth` checks `chrome.Width == 288` without ever arranging the control, so it honestly verifies the declared width (weak, but not claiming more); and `CommandAssistLayoutTests` asserts `popupView.MaxHeight`, a computed constraint whose derivation is the actual thing under test. Everything else was `Rect` output from pure layout calculators, `Bitmap` dimensions, or capture DTOs — all real values.

**Fix:** the secondary icon cluster (★ ✏ 📋 ⓘ 🗑) moved up into the **title row**, filling a void that already sat between the connection name and the IDLE badge. The action bar below is a single `WrapPanel` of launch actions again (Open / + Tab / Split ⇒ / Split ⇓ / diagnostics). Final shape:

```
● Pi                          ★ ✏ 📋 ⓘ 🗑    ● IDLE
behnam@xpi:22
▶ Open   + Tab   Split ⇒   Split ⇓   None ⌄
```

It stays a `WrapPanel` rather than reverting to a `Grid`, because a fixed-column Grid is what arranged the trailing controls outside the panel in the first place; wrapping degrades instead of hiding.

Two things fell out of that move and are part of this PR:

- **`DetailTitle` moved from an `Auto` column to `*` with `CharacterEllipsis`.** An Auto column grows with a long connection name, which would have pushed the cluster and the status badge out of the panel — re-introducing the exact bug above. The title yields instead. This one matters: without it, moving the icons up would have been a regression for anyone with a verbose connection name.
- **The standalone yellow `DetailFavStar` indicator is gone.** It lived in the title row already, so once the ★ *toggle* moved up there would have been two adjacent stars meaning different things. The toggle's own icon now carries the state via a `favOn` class (yellow when set, inheriting `IconBtn`'s grey otherwise). This is a small user-visible change beyond the PR's stated scope — flagged rather than buried.

## Tests

- **What tests cover this change?**

  `tests/NovaTerminal.App.Tests/Core/VaultServiceSavedPasswordTests.cs` (new, 11 tests) — key scoping and the no-write invariant:
  - `HasSavedPassword_IsTrue_ForCanonicalKey`, `_ForPerProfileLegacyKey`, `_IsFalse_ForSharedAliasOnly`
  - `HasSavedPassword_DoesNotWriteToStore`
  - `ForgetSavedPassword_ClearsCanonicalAndPerProfileLegacyKeys`, `_LeavesSharedAliasIntact`, `_ReturnsFalse_WhenNothingStored`, `_Throws_OnNullProfile`
  - `SavedPasswordMembers_WhenVaultUnavailable_AreSafeNoOps`, `IsVaultAvailable_ReflectsStore`, `HasSavedPassword_IsFalse_WhenNothingStored`

  The negative tests use a store that *throws* on `Write`/`Delete` and returns a bogus non-null from `Read`, so they prove the `IsAvailable` short-circuits fire rather than merely asserting a return value.

  `tests/NovaTerminal.App.Tests/Ssh/ConnectionManagerTests.cs` (12 new, 1 amended):
  - `DeleteAction_RaisesDeleteProfileRequested_ForSelectedRow`, `_DoesNotRaise_WhenNoRowSelected`, `_DoesNotRemoveRowItself`
  - `SavedPasswordRow_ShowsYes_AndEnablesForget_WhenPasswordStored`, `_ShowsNo_AndDisablesForget_WhenNothingStored`, `_ShowsVaultUnavailable_WhenStoreIsUnavailable`, `_HidesForget_WhenNoAccessorInjected`
  - `ForgetSavedPassword_FlipsRowToNo_DisablesButton_AndKeepsSelection`, `_DoesNothing_WhenNoRowSelected`
  - **`ActionBarControls_AreArrangedInsideTheDetailPanel`** (theory: 900 / 1080 / 1400px) — asserts each action control's arranged right edge lies within the detail panel and that its rect is non-empty. Fails on the old layout with `'Connection details' is clipped at width 1080: right edge 544.0 exceeds detail panel width 516.0`.
  - `FavoriteToggle_IconCarriesFavoriteState`, `FavoriteToggle_IconIsLit_ForAnAlreadyFavoriteConnection` — pin the folded favourite indicator. The mechanism they replace had **no** coverage (`DetailFavStar` appeared in two code sites and zero tests). Given this branch had already shipped one vacuous assertion, both were mutation-tested: with `SetFavoriteIndicator` stubbed to a no-op they fail, with the real code they pass.
  - `SecondaryActionButtons_ReserveSquareHitTargets` amended 4 → 5 buttons with the new tooltip. Kept for style coverage, but see the caveat above — it cannot detect clipping.

  Note for anyone writing headless layout tests here: `Measure`/`Arrange` is not sufficient. `DetailContent` starts collapsed, and a manual `Measure` with an unchanged constraint returns the cached empty-state desired size, leaving the whole detail header arranged at zero — which is what made the geometry look fine. `Show()` + `Dispatcher.UIThread.RunJobs()` is required to get a real layout pass.

  MainWindow's confirm/delete/purge wiring has no automated test — GUI wiring in a file with no dialog test harness. Verified by build, the suites above, and the manual smoke test.

- **Which categories did you run locally?**

  - [ ] full unfiltered run (`scripts/build.sh test`)
  - [ ] `Category=Replay`
  - [ ] `Category=RenderMetrics`
  - [ ] `Category=PtySmoke`
  - [x] `tests/NovaTerminal.App.Tests` — full project, see below
  - [ ] full local CI rehearsal (`ci/run.sh` / `ci/run.ps1`)

  Being precise, because this template correctly notes App.Tests is non-blocking in CI (#81) and this change lives entirely in it:

  **Targeted runs — green.** 53/53 on `FullyQualifiedName~ConnectionManager|FullyQualifiedName~VaultService` at the final layout (71/71 with `SshConnectionService` added, measured before the last two layout commits).

  **Full `App.Tests` project run** (CI's category exclusions plus `Category!=ShellIntegration`): **1770 passed, 1 failed, 1771 total in 4 s.** The wall clock was ~25 minutes, all of it the documented #81 host-hang *after* the tests finish — the run ends `Test Run Aborted.` with results already reported. That run predates the layout fix; the targeted runs above are post-fix.

  The one failure is `NovaTerminal.Tests.Core.CommandPaletteUsageStoreTests.RecordUse_PersistsCountAcrossReloads`, a **pre-existing load flake unrelated to this change**:

  - Passes 2/2 in isolation in 78 ms.
  - `CommandPaletteUsageStore.Save()` fires a `Task.Run` and returns; the test then waits ≤ 2 s for the file. With 1771 tests in parallel inside a 4-second run, the queued write can miss that deadline — the same threadpool-starvation family as #81.
  - It uses a GUID-unique temp directory and constructs the store directly, touching no `MainWindow`, `ConnectionManager`, or `VaultService` code. No path from this diff.
  - Load, not a masked race: a race would fail in isolation too, or produce a wrong `UseCount` rather than a missing file.

  Filed as #355 with the suggested fix (let `Save()` expose its in-flight write so the test can await it, rather than raising the 2 s ceiling). Deliberately not touched here.

  Replay / RenderMetrics / PtySmoke / Stress / GoldenSharedPng were not run: this change touches no VT, renderer, buffer, or PTY code, so it has no plausible path into them.

## Impact

- **Does this affect cross-platform behavior?**

  Yes, in one respect worth reviewer attention. The saved-password probe runs on every selection change in the connection list, and each call can cost up to three credential-store reads. On Windows (`CredRead`) this is a fast local call and invisible. On Linux each miss is a blocking `secret_password_lookupv_sync` D-Bus round trip to the Secret Service **on the UI thread**; on macOS each is a `SecItemCopyMatching`. Holding an arrow key through a long connection list could mean many sync IPC calls. A machine with no keyring short-circuits at `IsAvailable == false` for zero cost. Memoizing the probe per profile id for the lifetime of a `LoadProfiles` cycle is the obvious follow-up; deliberately left out to avoid adding cache invalidation here.

  Tested on Windows only. The three `ISecretStore` implementations are pre-existing and untouched.

  The layout fix is platform-independent (Avalonia layout), but it does depend on font metrics for the pill labels, so the exact wrap behaviour at narrow widths may differ slightly on Linux/macOS. The two-row split does not: it is structural.

- **Does this change renderer metrics?**

  No. No renderer, buffer, or VT code is touched.

- **Does this change VT coverage?**

  No. No escape sequences added or changed.

## Manual smoke test

Run on Windows by the author against this branch, and re-run after the final layout change. **Confirmed working:** the Delete action (confirmation dialog, deletion, list refresh), the Forget saved password flow, and the full icon cluster — trash and ⓘ included — being visible and correctly laid out.

Not explicitly exercised, and fine to leave to review: deleting a connection while a pane is still connected to it (expected: the pane keeps running — `ApplySettingsRecursive` null-guards the missing profile and keeps the pane's copy), and behaviour under a non-Windows credential store.

## Reviewer notes

Deliberate design decisions, so they don't read as oversights:

- **Vault purge happens after the store delete**, inside the same `try`, so a store failure leaves the secret in place rather than orphaning it from a profile that still exists.
- **The purge is sequenced and the refresh is guaranteed.** These two orderings pull in opposite directions: purge-then-refresh leaves a deleted row on screen if the purge throws, refresh-then-purge orphans the secret if the refresh throws. So the purge runs after the store delete (a failed delete leaves the secret with the profile that still exists) and the refresh runs in a `finally` (a throwing purge cannot leave a stale row). Neither failure mode exists.
- **Forget has no confirmation dialog.** The row flipping to `No` and the button disabling is the feedback; worst case is one extra prompt on the next connect.
- **Forget re-renders in place rather than calling `LoadProfiles`**, because `LoadProfiles` rebuilds every `SshProfileRowViewModel` and `ApplyFilters`' identity check would silently drop the list selection. `ForgetSavedPassword_FlipsRowToNo_DisablesButton_AndKeepsSelection` guards this.
- **Deleting a profile does not disconnect a live pane** running it. Killing a running shell as a side effect of tidying the connection list would be worse.
- **The editor dialog's `RememberPasswordInVault` checkbox is still unwired** and `ApplyRememberPasswordPreference` still uncalled — explicitly out of scope. This PR adds the detail-panel surface only.
- The delete button **raises an event and deletes nothing itself**, matching the existing Edit/Copy/Details convention; `MainWindow` owns the confirmation and the deletion. `DeleteAction_DoesNotRemoveRowItself` pins that boundary.
- The delete confirmation truncates the connection name at 60 characters, because the dialog is a fixed 480×210 with `CanResize: false` and an unbounded name could push the buttons out of reach. Its Cancel button is `IsCancel` and takes initial focus; Delete is deliberately **not** `IsDefault`, so Enter cannot trigger a destructive action.

Design spec and implementation plan are committed on the branch under `docs/superpowers/`. The spec's Testing section was corrected on this branch: it originally asked for a `SshConnectionService`-level test asserting both the store delete and the vault purge, which is not implementable — `SshConnectionService.DeleteProfile` delegates straight to `JsonSshProfileStore` and touches no vault, the purge living in `MainWindow` by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
