### PR TITLE
fix(tests): isolate PaneAgentStatusBarTests from the process-wide agent registry

### DIFF
--- a/src/NovaTerminal.App/AgentHost/AgentSessionRegistry.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentSessionRegistry.cs
@@ -19,7 +19,45 @@ namespace NovaTerminal.AgentHost
     public sealed class AgentSessionRegistry
     {
         /// <summary>Process-wide instance used by the app wiring. Tests construct their own.</summary>
-        public static AgentSessionRegistry Instance { get; } = new();
+        public static AgentSessionRegistry Instance => _instanceOverride ?? ProcessInstance;
+
+        private static readonly AgentSessionRegistry ProcessInstance = new();
+
+        // Thread-local, not a plain static: the override exists so one test can
+        // isolate the panes it constructs, and a plain static would redirect
+        // panes any other test happens to be constructing at the same moment —
+        // recreating the exact cross-test interference it is here to remove.
+        [ThreadStatic]
+        private static AgentSessionRegistry? _instanceOverride;
+
+        /// <summary>
+        /// Redirects <see cref="Instance"/> on the current thread to
+        /// <paramref name="registry"/> until the returned scope is disposed.
+        ///
+        /// Test seam (#357): TerminalPane hard-wires <see cref="Instance"/>, a
+        /// process-wide singleton shared by every concurrently-running test.
+        /// Anything subscribed there — a leaked MainWindow, the agent-host
+        /// endpoint another test's window started from the developer's real
+        /// settings — hears a test pane's registration and publishes actability
+        /// onto it, so tests about a pane's birth state need panes registered
+        /// somewhere nothing else is listening. Scope it synchronously around
+        /// construction: the pane captures the registry it registered with, so
+        /// the override does not need to survive past the constructor.
+        /// </summary>
+        internal static IDisposable OverrideInstanceForTesting(AgentSessionRegistry registry)
+        {
+            ArgumentNullException.ThrowIfNull(registry);
+            var scope = new InstanceOverrideScope(_instanceOverride);
+            _instanceOverride = registry;
+            return scope;
+        }
+
+        private sealed class InstanceOverrideScope : IDisposable
+        {
+            private readonly AgentSessionRegistry? _previous;
+            public InstanceOverrideScope(AgentSessionRegistry? previous) => _previous = previous;
+            public void Dispose() => _instanceOverride = _previous;
+        }
 
         private readonly ConcurrentDictionary<Guid, AgentSessionRegistration> _sessions = new();
 

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -96,7 +96,7 @@ namespace NovaTerminal.Controls
             {
                 if (_paneId == value) return;
                 var oldId = _paneId;
-                if (NovaTerminal.AgentHost.AgentSessionRegistry.Instance.Rekey(oldId, value))
+                if ((_agentRegistry ?? NovaTerminal.AgentHost.AgentSessionRegistry.Instance).Rekey(oldId, value))
                 {
                     _paneId = value;
                 }
@@ -121,6 +121,11 @@ namespace NovaTerminal.Controls
         private bool _isUpdatingScroll = false;
         private bool _disposed;
         private NovaTerminal.AgentHost.AgentSessionRegistration? _agentRegistration;
+        // The registry this pane registered with, captured at SetupCommon so
+        // Rekey and Unregister always target the same registry Register did —
+        // even when a test redirected AgentSessionRegistry.Instance for the
+        // construction (#357). Pane and registry must never disagree.
+        private NovaTerminal.AgentHost.AgentSessionRegistry? _agentRegistry;
         private bool _agentActable;
         // Whether UpdateStatusBarUI has rendered the SSH forwarding half of the
         // status bar at least once. See UpdateForwardingStatus.
@@ -579,7 +584,8 @@ namespace NovaTerminal.Controls
                 profileId: Profile?.Id);
             // A3 act: an agent typing into this pane is text the keyboard path never saw.
             _agentRegistration.InputInjected = NotifyExternalInputSent;
-            NovaTerminal.AgentHost.AgentSessionRegistry.Instance.Register(_agentRegistration);
+            _agentRegistry = NovaTerminal.AgentHost.AgentSessionRegistry.Instance;
+            _agentRegistry.Register(_agentRegistration);
             // Seed act-reachability from the registration instead of waiting for
             // the first ActabilityChanged. AgentHostService.OnSessionRegistered
             // publishes it synchronously inside Register above — i.e. one line
@@ -3933,7 +3939,7 @@ namespace NovaTerminal.Controls
             if (_disposed) return null;
             _disposed = true;
 
-            NovaTerminal.AgentHost.AgentSessionRegistry.Instance.Unregister(PaneId);
+            (_agentRegistry ?? NovaTerminal.AgentHost.AgentSessionRegistry.Instance).Unregister(PaneId);
             if (_agentRegistration != null)
             {
                 _agentRegistration.AttentionMachine.Changed -= OnAgentAttentionChanged;

--- a/tests/NovaTerminal.App.Tests/Controls/PaneAgentStatusBarTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneAgentStatusBarTests.cs
@@ -21,10 +21,36 @@ namespace NovaTerminal.Tests.Controls;
 /// </summary>
 public class PaneAgentStatusBarTests
 {
+    // Every pane in this class registers into this test-owned registry rather
+    // than the process-wide AgentSessionRegistry.Instance (#357). The singleton
+    // is shared with every concurrently-running test class: a MainWindow test's
+    // window subscribes to it and — when the developer's real settings have
+    // Agent Access enabled — starts the process-wide AgentHostService, whose
+    // SessionRegistered hook and 1 s sweep mark every registration actable.
+    // That made a fresh pane here be born actable and turned this class's
+    // IsAgentActable=true writes into no-change writes that never raise.
+    // xUnit constructs a new instance of this class per test, so the registry
+    // is per-test state: nothing external is subscribed to it, and the
+    // SessionRegistered subscriptions below can only ever see this test's own
+    // panes.
+    private readonly AgentSessionRegistry _registry = new();
+
+    // The override is scoped synchronously around construction only: the pane
+    // captures the registry it registered with for Rekey/Unregister, and a
+    // wider scope could leak onto other test cases interleaved on the shared
+    // headless UI thread.
+    private TerminalPane MakeLocalPane()
+    {
+        using (AgentSessionRegistry.OverrideInstanceForTesting(_registry))
+        {
+            return new TerminalPane("cmd.exe");
+        }
+    }
+
     [AvaloniaFact]
     public void A_non_actable_local_pane_shows_no_status_bar()
     {
-        using var pane = new TerminalPane("cmd.exe");
+        using var pane = MakeLocalPane();
         pane.ApplyAgentAttention(new AgentAttentionSnapshot(AgentAttentionTier.Idle, null, null), isActable: false);
 
         Assert.False(GetStatusBar(pane).IsVisible);
@@ -33,7 +59,7 @@ public class PaneAgentStatusBarTests
     [AvaloniaFact]
     public void An_actable_pane_shows_the_bar_with_the_baseline_segment()
     {
-        using var pane = new TerminalPane("cmd.exe");
+        using var pane = MakeLocalPane();
         pane.ApplyAgentAttention(new AgentAttentionSnapshot(AgentAttentionTier.Idle, null, null), isActable: true);
 
         Assert.True(GetStatusBar(pane).IsVisible);
@@ -43,7 +69,7 @@ public class PaneAgentStatusBarTests
     [AvaloniaFact]
     public void Activity_does_not_change_the_bars_visibility()
     {
-        using var pane = new TerminalPane("cmd.exe");
+        using var pane = MakeLocalPane();
         pane.ApplyAgentAttention(new AgentAttentionSnapshot(AgentAttentionTier.Idle, null, null), isActable: false);
         Assert.False(GetStatusBar(pane).IsVisible);
 
@@ -57,7 +83,7 @@ public class PaneAgentStatusBarTests
     [AvaloniaFact]
     public void The_wrote_tier_names_the_method()
     {
-        using var pane = new TerminalPane("cmd.exe");
+        using var pane = MakeLocalPane();
         pane.ApplyAgentAttention(
             new AgentAttentionSnapshot(AgentAttentionTier.Wrote, DateTimeOffset.UtcNow, "sendInput"),
             isActable: true);
@@ -138,7 +164,7 @@ public class PaneAgentStatusBarTests
         // actually looks at, so leaving it inert while the window-level light is
         // actionable is backwards. Its visibility is still owned solely by
         // UpdateStatusBarVisibility, alongside the panel inside it.
-        using var pane = new TerminalPane("cmd.exe");
+        using var pane = MakeLocalPane();
         pane.ApplyAgentAttention(new AgentAttentionSnapshot(AgentAttentionTier.Idle, null, null), isActable: false);
         Assert.False(GetAgentButton(pane).IsVisible);
 
@@ -157,7 +183,7 @@ public class PaneAgentStatusBarTests
         // The handler resolves VisualRoot as MainWindow; a pane that is not
         // attached to one (every unit test, and any pane mid-construction) must
         // no-op rather than throw.
-        using var pane = new TerminalPane("cmd.exe");
+        using var pane = MakeLocalPane();
         pane.ApplyAgentAttention(new AgentAttentionSnapshot(AgentAttentionTier.Idle, null, null), isActable: true);
 
         GetAgentButton(pane).RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
@@ -168,7 +194,7 @@ public class PaneAgentStatusBarTests
     [AvaloniaFact]
     public void The_tooltip_names_the_tier()
     {
-        using var pane = new TerminalPane("cmd.exe");
+        using var pane = MakeLocalPane();
 
         pane.ApplyAgentAttention(new AgentAttentionSnapshot(AgentAttentionTier.Idle, null, null), isActable: true);
         Assert.Contains("can read", GetAgentTooltip(pane), StringComparison.OrdinalIgnoreCase);
@@ -183,7 +209,7 @@ public class PaneAgentStatusBarTests
         // "agent typed" is sticky for at least ten seconds, so the two-word
         // label alone cannot distinguish a write from a moment ago from one the
         // user already saw. The tooltip carries the clock time and the method.
-        using var pane = new TerminalPane("cmd.exe");
+        using var pane = MakeLocalPane();
         var writtenAt = DateTimeOffset.UtcNow;
 
         pane.ApplyAgentAttention(
@@ -204,7 +230,7 @@ public class PaneAgentStatusBarTests
         // it. Before the fix, nothing told an already-open idle pane to
         // re-render, so the bar never appeared. No NoteRead/NoteWrote/tier
         // change anywhere in this test — only the actability flip.
-        using var pane = new TerminalPane("cmd.exe");
+        using var pane = MakeLocalPane();
         pane.ApplyAgentAttention(new AgentAttentionSnapshot(AgentAttentionTier.Idle, null, null), isActable: false);
         Assert.False(GetStatusBar(pane).IsVisible);
 
@@ -225,7 +251,7 @@ public class PaneAgentStatusBarTests
         // every registration. If the setter raised on every write rather than
         // only on an actual change, this would become a perpetual
         // once-per-second Dispatcher.UIThread.Post per pane.
-        using var pane = new TerminalPane("cmd.exe");
+        using var pane = MakeLocalPane();
         var registration = pane.AgentRegistrationForTesting;
         Assert.NotNull(registration);
 
@@ -270,7 +296,7 @@ public class PaneAgentStatusBarTests
         // value. It does not (and cannot, deterministically) reproduce the
         // thread interleave itself; what it pins is the property that makes
         // the interleave harmless.
-        using var pane = new TerminalPane("cmd.exe");
+        using var pane = MakeLocalPane();
         pane.ApplyAgentAttention(new AgentAttentionSnapshot(AgentAttentionTier.Idle, null, null), isActable: false);
         Assert.False(GetStatusBar(pane).IsVisible);
 
@@ -326,11 +352,14 @@ public class PaneAgentStatusBarTests
         // subscribed to anything. No Dispatcher.UIThread.RunJobs() anywhere in
         // this test: the assertion is that the pane was *constructed* with its
         // bar, not that it acquired one later.
+        // Subscribed on this test's own registry, never on the process-wide
+        // Instance: there this handler would also hear (and mark actable) panes
+        // other test classes are registering concurrently (#357).
         void MarkActable(AgentSessionRegistration r) => r.IsAgentActable = true;
-        AgentSessionRegistry.Instance.SessionRegistered += MarkActable;
+        _registry.SessionRegistered += MarkActable;
         try
         {
-            using var pane = new TerminalPane("cmd.exe");
+            using var pane = MakeLocalPane();
 
             Assert.True(GetStatusBar(pane).IsVisible);
             Assert.True(GetAgentSegment(pane).IsVisible);
@@ -340,7 +369,7 @@ public class PaneAgentStatusBarTests
         }
         finally
         {
-            AgentSessionRegistry.Instance.SessionRegistered -= MarkActable;
+            _registry.SessionRegistered -= MarkActable;
         }
     }
 
@@ -353,7 +382,7 @@ public class PaneAgentStatusBarTests
         // up, skip UpdateStatusBarUI, and leave the SSH label blank inside a
         // visible bar until some rule's status happened to change.
         void MarkActable(AgentSessionRegistration r) => r.IsAgentActable = true;
-        AgentSessionRegistry.Instance.SessionRegistered += MarkActable;
+        _registry.SessionRegistered += MarkActable;
         try
         {
             using var pane = MakeSshPaneWithForward();
@@ -365,7 +394,7 @@ public class PaneAgentStatusBarTests
         }
         finally
         {
-            AgentSessionRegistry.Instance.SessionRegistered -= MarkActable;
+            _registry.SessionRegistered -= MarkActable;
         }
     }
 
@@ -432,7 +461,7 @@ public class PaneAgentStatusBarTests
         // The seeding must copy the registration's real answer, not assume one:
         // with nothing marking it actable, a fresh local pane has no bar and so
         // gives up none of the terminal's rows.
-        using var pane = new TerminalPane("cmd.exe");
+        using var pane = MakeLocalPane();
 
         Assert.False(GetStatusBar(pane).IsVisible);
         Assert.False(GetAgentSegment(pane).IsVisible);
@@ -472,7 +501,7 @@ public class PaneAgentStatusBarTests
     // TerminalProfile.Forwards is List<ForwardingRule>; SshProfile.Forwards is
     // List<PortForward> and is a different thing entirely. No real session is
     // started: the status bar only reads Profile.Forwards.
-    private static TerminalPane MakeSshPaneWithForward()
+    private TerminalPane MakeSshPaneWithForward()
     {
         var profile = new TerminalProfile
         {
@@ -485,6 +514,9 @@ public class PaneAgentStatusBarTests
             LocalAddress = "8080",
             RemoteAddress = "localhost:80",
         });
-        return new TerminalPane(profile, SshDiagnosticsLevel.None);
+        using (AgentSessionRegistry.OverrideInstanceForTesting(_registry))
+        {
+            return new TerminalPane(profile, SshDiagnosticsLevel.None);
+        }
     }
 }


### PR DESCRIPTION
Fixes #357.

## Root cause

`PaneAgentStatusBarTests` depended on process-global state. `MainWindow`'s ctor loads the developer's **real** `TerminalSettings` and pushes them into the process-wide `AgentHostService.Instance`; on a machine with Agent Access enabled, any window-creating test class starts the endpoint, whose `SessionRegistered` hook and 1 s sweep mark **every** registration in `AgentSessionRegistry.Instance` actable. Test windows are never closed, so this outlives their class. Consequences for this class:

- a fresh `TerminalPane` was born actable → `A_pane_born_non_actable_still_starts_with_no_bar` failed;
- `IsAgentActable = true` became a no-change write that never raises `ActabilityChanged` → `An_actability_flip_with_no_tier_transition_surfaces_the_bar` and `Repeated_identical_actability_writes_raise_the_event_once` failed.

Conversely, the class's own two `SessionRegistered += MarkActable` subscriptions marked panes other classes were registering concurrently.

## Fix (the issue's "make the registry injectable" option)

- `AgentSessionRegistry.Instance` gains a `[ThreadStatic]`, disposable test override (`OverrideInstanceForTesting`) — thread-local so one test's isolation can't redirect panes another test is constructing.
- `TerminalPane` captures the registry it registered with and uses it for `Rekey`/`Unregister`, so pane and registry always agree even when `Instance` was redirected during construction.
- `PaneAgentStatusBarTests` constructs every pane against a fresh per-test registry (override scoped synchronously around construction only), and both `MarkActable` subscriptions move onto that private registry — nothing external can hear this class's panes, and this class can no longer touch anyone else's.

## Verification

| Run | Before | After |
|---|---|---|
| Repro pair (`PaneAgentStatusBarTests\|MainWindowTitleBarTests`), pre-#356 base | Failed: 3 / Passed: 37 | Passed: 40/40 |
| `PaneAgentStatusBarTests` alone | 19/19 | 19/19 |
| All `*Agent*` + `PaneAssistInsertionTests` | — | 261/261 |

Note: on current `main` (post-#356) the same pair filter shows 5 additional `MainWindowTitleBarTests` failures that are **pre-existing** — they reproduce identically on pristine `origin/main` without this change (8 failures there = those 5 + the 3 this PR fixes; 5 remain with this PR). They look like the same settings-bleed pathology (MainWindow tests reading the developer's live settings, which now carry vertical-tab state) and deserve their own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)