### PR TITLE
fix(windows): make PowerShell work on a machine that isn't a developer's

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
-    <Version>0.5.0</Version>
-    <AssemblyVersion>0.5.0.0</AssemblyVersion>
-    <FileVersion>0.5.0.0</FileVersion>
-    <InformationalVersion>0.5.0</InformationalVersion>
+    <Version>0.5.1</Version>
+    <AssemblyVersion>0.5.1.0</AssemblyVersion>
+    <FileVersion>0.5.1.0</FileVersion>
+    <InformationalVersion>0.5.1</InformationalVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/NovaTerminal.App/Shell/TerminalSettings.cs
+++ b/src/NovaTerminal.App/Shell/TerminalSettings.cs
@@ -195,26 +195,71 @@ namespace NovaTerminal.Shell
         }
 
         public static System.Collections.Generic.List<TerminalProfile> GetDefaultProfiles()
+            => GetDefaultProfiles(CommandIsInstalled);
+
+        /// <summary>
+        /// Builds the first-run profile list, keeping only the shells that are actually
+        /// installed. <paramref name="commandExists"/> is the seam the tests drive; production
+        /// passes <see cref="CommandIsInstalled"/>.
+        /// </summary>
+        /// <remarks>
+        /// The list used to be unconditional, which meant a "PowerShell" profile pointing at
+        /// <c>pwsh.exe</c> on machines with no PowerShell 7 — a visible, dead entry that failed
+        /// to spawn with a raw FFI error. Every developer machine has pwsh, so it survived seven
+        /// months until the first install on someone else's PC. Same latent bug on Linux, where
+        /// a Zsh profile was created whether or not zsh existed.
+        ///
+        /// Known limitation: profiles persist after first run, so installing PowerShell 7 later
+        /// does not make the profile appear — it has to be added by hand. Re-probing on every
+        /// load was rejected because it would resurrect profiles the user deliberately deleted.
+        /// </remarks>
+        internal static System.Collections.Generic.List<TerminalProfile> GetDefaultProfiles(
+            Func<string, bool> commandExists)
         {
-            if (OperatingSystem.IsWindows())
-            {
-                return new System.Collections.Generic.List<TerminalProfile>
+            ArgumentNullException.ThrowIfNull(commandExists);
+
+            (string Name, string Command)[] candidates = OperatingSystem.IsWindows()
+                ? new[]
                 {
-                    new TerminalProfile { Name = "Command Prompt", Command = "cmd.exe" },
-                    new TerminalProfile { Name = "PowerShell", Command = "pwsh.exe" },
-                    new TerminalProfile { Name = "Windows PowerShell", Command = "powershell.exe" }
-                };
-            }
-            else
-            {
-                return new System.Collections.Generic.List<TerminalProfile>
+                    ("Command Prompt", "cmd.exe"),
+                    ("PowerShell", "pwsh.exe"),
+                    ("Windows PowerShell", "powershell.exe"),
+                }
+                : new[]
                 {
-                    new TerminalProfile { Name = "Bash", Command = "/bin/bash" },
-                    new TerminalProfile { Name = "Zsh", Command = "/bin/zsh" },
-                    new TerminalProfile { Name = "Shell", Command = "/bin/sh" }
+                    ("Bash", "/bin/bash"),
+                    ("Zsh", "/bin/zsh"),
+                    ("Shell", "/bin/sh"),
                 };
+
+            var profiles = new System.Collections.Generic.List<TerminalProfile>();
+            foreach ((string name, string command) in candidates)
+            {
+                if (commandExists(command))
+                {
+                    profiles.Add(new TerminalProfile { Name = name, Command = command });
+                }
             }
+
+            if (profiles.Count == 0)
+            {
+                // A probe can fail wholesale — an empty PATH makes every lookup false. The
+                // constructor immediately does Profiles[0].Id, so an empty list is a startup
+                // crash: strictly worse than one profile that might not launch. Fall back to
+                // the shell the platform is guaranteed to have.
+                (string Name, string Command) floor = OperatingSystem.IsWindows()
+                    ? ("Command Prompt", "cmd.exe")
+                    : ("Shell", "/bin/sh");
+                profiles.Add(new TerminalProfile { Name = floor.Name, Command = floor.Command });
+            }
+
+            return profiles;
         }
+
+        private static bool CommandIsInstalled(string command)
+            => OperatingSystem.IsWindows()
+                ? ShellHelper.InPath(command)
+                : File.Exists(command);
 
         public TerminalSettings()
         {

--- a/src/NovaTerminal.CommandAssist/ShellIntegration/PowerShell/PowerShellShellIntegrationProvider.cs
+++ b/src/NovaTerminal.CommandAssist/ShellIntegration/PowerShell/PowerShellShellIntegrationProvider.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using NovaTerminal.CommandAssist.ShellIntegration.Contracts;
 
 namespace NovaTerminal.CommandAssist.ShellIntegration.PowerShell;
@@ -43,8 +42,13 @@ public sealed class PowerShellShellIntegrationProvider : IShellIntegrationProvid
                 BootstrapScriptPath: null);
         }
 
+        // The script is still written to disk, but the on-disk copy is now purely diagnostic
+        // (and what the remote-host installer reuses) — what the shell actually executes is the
+        // encoded copy on the command line. BootstrapScriptPath stays on the plan for both.
         string bootstrapScriptPath = PowerShellBootstrapBuilder.WriteScript(_bootstrapDirectory());
-        string mergedArguments = BuildPowerShellArguments(shellArguments, bootstrapScriptPath);
+        string mergedArguments = BuildPowerShellArguments(
+            shellArguments,
+            PowerShellBootstrapBuilder.BuildScript());
         return new ShellIntegrationLaunchPlan(
             IsIntegrated: true,
             ShellCommand: shellCommand,
@@ -52,19 +56,29 @@ public sealed class PowerShellShellIntegrationProvider : IShellIntegrationProvid
             BootstrapScriptPath: bootstrapScriptPath);
     }
 
-    private static string BuildPowerShellArguments(string? shellArguments, string bootstrapScriptPath)
+    /// <summary>
+    /// Builds <c>-NoLogo -NoExit -EncodedCommand &lt;base64&gt;</c>.
+    /// </summary>
+    /// <remarks>
+    /// The bootstrap is passed as an encoded command rather than <c>-File</c> because
+    /// <c>-File</c> is gated by PowerShell's execution policy. The stock Windows client
+    /// default is <c>Restricted</c>, which blocks every script file, so every PowerShell tab
+    /// opened with a red <c>UnauthorizedAccess</c> error and Command Assist silently did not
+    /// work. Reported from a real first-run install.
+    ///
+    /// <c>-EncodedCommand</c> was chosen over <c>-ExecutionPolicy Bypass</c> for two reasons:
+    /// <c>-ExecutionPolicy</c> on the command line is IGNORED when policy is set through Group
+    /// Policy, so it would not fix managed machines at all; and it relaxes the policy for the
+    /// whole session, meaning scripts the USER later runs in that tab would also bypass — a
+    /// side effect a terminal has no business imposing. Nothing is loaded from disk here, so
+    /// no policy applies, and the user's own policy is left exactly as they set it.
+    ///
+    /// Size is not a concern: the emitted script is ~2.7 KB, so ~7.4 KB once base64'd from
+    /// UTF-16LE, against a command-line limit of 32767.
+    /// </remarks>
+    private static string BuildPowerShellArguments(string? shellArguments, string bootstrapScript)
     {
         string original = shellArguments?.Trim() ?? string.Empty;
-
-        // Pass the bootstrap path to -File UNQUOTED. PowerShell's -File parser
-        // reads the raw command-line tail (not standard argv splitting), so any
-        // surrounding double quotes would be retained as part of the path value
-        // and rejected as "Illegal characters in path" (since '"' is an illegal
-        // Windows path char). The generated bootstrap path lives under
-        // %LOCALAPPDATA%\NovaTerminal\command-assist\ and only contains a space
-        // if the Windows username does -- in that uncommon case we fall back to
-        // the 8.3 short name, which has no spaces.
-        string fileArgPath = ResolveSpacelessPath(bootstrapScriptPath);
 
         if (!original.Contains("-NoLogo", StringComparison.OrdinalIgnoreCase))
         {
@@ -80,56 +94,39 @@ public sealed class PowerShellShellIntegrationProvider : IShellIntegrationProvid
                 : $"{original} -NoExit";
         }
 
-        if (!original.Contains("-File", StringComparison.OrdinalIgnoreCase))
-        {
-            original = string.IsNullOrWhiteSpace(original)
-                ? $"-File {fileArgPath}"
-                : $"{original} -File {fileArgPath}";
-        }
+        // -EncodedCommand goes LAST and unquoted. PowerShell treats every token after it as
+        // part of the command, so an argument placed afterwards is silently absorbed rather
+        // than applied. Base64 is alphanumeric plus '+/=' and never needs quoting.
+        string encoded = EncodeCommand(bootstrapScript);
+        original = string.IsNullOrWhiteSpace(original)
+            ? $"-EncodedCommand {encoded}"
+            : $"{original} -EncodedCommand {encoded}";
 
         return original.Trim();
     }
 
-    private static string ResolveSpacelessPath(string path)
-    {
-        if (!OperatingSystem.IsWindows() || !path.Any(char.IsWhiteSpace))
-        {
-            return path;
-        }
+    /// <summary>Base64 of the UTF-16LE bytes — the encoding PowerShell's -EncodedCommand expects.</summary>
+    private static string EncodeCommand(string script)
+        => Convert.ToBase64String(System.Text.Encoding.Unicode.GetBytes(script));
 
-        var buffer = new System.Text.StringBuilder(260);
-        uint result = NativeMethods.GetShortPathNameW(path, buffer, (uint)buffer.Capacity);
-        if (result == 0)
-        {
-            return path;
-        }
-
-        if (result > buffer.Capacity)
-        {
-            buffer.EnsureCapacity((int)result);
-            result = NativeMethods.GetShortPathNameW(path, buffer, (uint)buffer.Capacity);
-            if (result == 0)
-            {
-                return path;
-            }
-        }
-
-        string shortPath = buffer.ToString();
-        return shortPath.Any(char.IsWhiteSpace) ? path : shortPath;
-    }
-
-    private static class NativeMethods
-    {
-        [System.Runtime.InteropServices.DllImport("kernel32.dll", CharSet = System.Runtime.InteropServices.CharSet.Unicode, SetLastError = true)]
-        public static extern uint GetShortPathNameW(
-            [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPWStr)] string lpszLongPath,
-            System.Text.StringBuilder lpszShortPath,
-            uint cchBuffer);
-    }
-
+    /// <summary>
+    /// True when the user's own arguments already carry a script or command, in which case we
+    /// stay out of the way entirely.
+    /// </summary>
+    /// <remarks>
+    /// <c>-Command</c> and <c>-EncodedCommand</c> have to be caught alongside <c>-File</c>:
+    /// appending ours after the user's would be swallowed into theirs, and prepending would
+    /// swallow theirs into ours. Neither is recoverable, so integration is declined.
+    /// </remarks>
     private static bool ContainsUserScriptFile(string? shellArguments)
     {
-        return !string.IsNullOrWhiteSpace(shellArguments) &&
-               shellArguments.Contains("-File", StringComparison.OrdinalIgnoreCase);
+        if (string.IsNullOrWhiteSpace(shellArguments))
+        {
+            return false;
+        }
+
+        return shellArguments.Contains("-File", StringComparison.OrdinalIgnoreCase) ||
+               shellArguments.Contains("-EncodedCommand", StringComparison.OrdinalIgnoreCase) ||
+               shellArguments.Contains("-Command", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/PowerShellBootstrapExecutionPolicyTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/PowerShellBootstrapExecutionPolicyTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Text;
+using NovaTerminal.Shell;
+using NovaTerminal.CommandAssist.ShellIntegration.Contracts;
+using NovaTerminal.CommandAssist.ShellIntegration.PowerShell;
+using Xunit;
+
+namespace NovaTerminal.Tests.CommandAssist.ShellIntegration;
+
+/// <summary>
+/// The bootstrap used to be launched with <c>-File</c>, which PowerShell gates behind the
+/// execution policy. Stock Windows client default is <c>Restricted</c>, which blocks every
+/// script file — so every PowerShell tab opened with a red UnauthorizedAccess error and
+/// Command Assist silently did not work. Reported from a real first-run install.
+///
+/// <c>-EncodedCommand</c> is not policy-gated (nothing is loaded from disk) and, unlike
+/// <c>-ExecutionPolicy Bypass</c>, it does not relax the policy for anything the user
+/// subsequently runs in that session, and it is not overridden by Group Policy.
+/// </summary>
+public sealed class PowerShellBootstrapExecutionPolicyTests
+{
+    private static PowerShellShellIntegrationProvider NewProvider()
+        => new(() => AppPaths.CommandAssistDirectory);
+
+    [Fact]
+    public void CreateLaunchPlan_DoesNotUseFile_BecauseExecutionPolicyBlocksIt()
+    {
+        ShellIntegrationLaunchPlan plan = NewProvider().CreateLaunchPlan(
+            shellCommand: "powershell.exe",
+            shellArguments: "-NoLogo",
+            workingDirectory: @"C:\repo");
+
+        Assert.True(plan.IsIntegrated);
+        Assert.DoesNotContain("-File", plan.ShellArguments!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CreateLaunchPlan_PassesTheBootstrapAsAnEncodedCommand()
+    {
+        ShellIntegrationLaunchPlan plan = NewProvider().CreateLaunchPlan(
+            shellCommand: "powershell.exe",
+            shellArguments: null,
+            workingDirectory: null);
+
+        Assert.Contains("-EncodedCommand", plan.ShellArguments!, StringComparison.Ordinal);
+
+        string decoded = DecodeEncodedCommand(plan.ShellArguments!);
+
+        // Proves it is really our bootstrap that got encoded, not an empty string or
+        // a path. The sentinel is what the script uses to detect its own wrapper.
+        Assert.Contains("__nova_prompt_wrapper", decoded, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateLaunchPlan_PutsEncodedCommandLast_SoNothingIsSwallowedIntoIt()
+    {
+        ShellIntegrationLaunchPlan plan = NewProvider().CreateLaunchPlan(
+            shellCommand: "powershell.exe",
+            shellArguments: "-NoLogo",
+            workingDirectory: null);
+
+        // PowerShell treats every token after -EncodedCommand as part of the command,
+        // so any argument placed after it is silently absorbed rather than applied.
+        string args = plan.ShellArguments!;
+        int encodedAt = args.IndexOf("-EncodedCommand", StringComparison.Ordinal);
+        string tail = args[(encodedAt + "-EncodedCommand".Length)..].Trim();
+
+        Assert.DoesNotContain(" ", tail);
+    }
+
+    [Fact]
+    public void CreateLaunchPlan_StillKeepsNoLogoAndNoExit()
+    {
+        ShellIntegrationLaunchPlan plan = NewProvider().CreateLaunchPlan(
+            shellCommand: "powershell.exe",
+            shellArguments: null,
+            workingDirectory: null);
+
+        Assert.Contains("-NoLogo", plan.ShellArguments!, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("-NoExit", plan.ShellArguments!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CreateLaunchPlan_StillWritesTheScriptToDisk_SoTheRemoteInstallerAndDebuggingKeepWorking()
+    {
+        ShellIntegrationLaunchPlan plan = NewProvider().CreateLaunchPlan(
+            shellCommand: "powershell.exe",
+            shellArguments: null,
+            workingDirectory: null);
+
+        Assert.NotNull(plan.BootstrapScriptPath);
+        Assert.True(System.IO.File.Exists(plan.BootstrapScriptPath));
+    }
+
+    [Theory]
+    [InlineData("-Command Get-Date")]
+    [InlineData("-EncodedCommand RwBlAHQALQBEAGEAdABlAA==")]
+    public void CreateLaunchPlan_WhenUserAlreadySuppliesACommand_DoesNotClaimIntegration(string userArgs)
+    {
+        // Appending our own -EncodedCommand after the user's would be swallowed into
+        // theirs; prepending would swallow theirs into ours. Neither is recoverable,
+        // so stay out of the way — the same bail-out -File already had.
+        ShellIntegrationLaunchPlan plan = NewProvider().CreateLaunchPlan(
+            shellCommand: "powershell.exe",
+            shellArguments: userArgs,
+            workingDirectory: null);
+
+        Assert.False(plan.IsIntegrated);
+        Assert.Equal(userArgs, plan.ShellArguments);
+        Assert.Null(plan.BootstrapScriptPath);
+    }
+
+    private static string DecodeEncodedCommand(string shellArguments)
+    {
+        int at = shellArguments.IndexOf("-EncodedCommand", StringComparison.Ordinal);
+        Assert.True(at >= 0, "no -EncodedCommand in " + shellArguments);
+
+        string base64 = shellArguments[(at + "-EncodedCommand".Length)..].Trim();
+        return Encoding.Unicode.GetString(Convert.FromBase64String(base64));
+    }
+}

--- a/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/PowerShellShellIntegrationProviderTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/ShellIntegration/PowerShellShellIntegrationProviderTests.cs
@@ -20,15 +20,18 @@ public sealed class PowerShellShellIntegrationProviderTests
         Assert.Equal("pwsh.exe", plan.ShellCommand);
         Assert.Contains("-NoLogo", plan.ShellArguments);
         Assert.Contains("-NoExit", plan.ShellArguments);
-        Assert.Contains("-File", plan.ShellArguments);
-        Assert.Contains(plan.BootstrapScriptPath!, plan.ShellArguments, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("-EncodedCommand", plan.ShellArguments!, StringComparison.Ordinal);
         Assert.NotNull(plan.BootstrapScriptPath);
-        // -File must NOT be wrapped in double quotes: powershell.exe's -File
-        // parser reads the raw command-line tail (no argv splitting), so
-        // surrounding quotes get treated as part of the path value and the
-        // launch fails with "Illegal characters in path".
+
+        // The bootstrap path is deliberately NOT on the command line any more. It used to be
+        // passed to -File, which the execution policy blocks on a stock Windows machine; the
+        // script now travels as an encoded command instead. That also retired the whole -File
+        // quoting hazard (unquoted path, 8.3 short-name fallback for usernames with spaces)
+        // this test previously guarded — there is no path left to quote.
+        // See PowerShellBootstrapExecutionPolicyTests for the encoding contract.
+        Assert.DoesNotContain("-File", plan.ShellArguments!, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain(
-            $"\"{plan.BootstrapScriptPath}\"",
+            plan.BootstrapScriptPath!,
             plan.ShellArguments!,
             StringComparison.OrdinalIgnoreCase);
     }

--- a/tests/NovaTerminal.App.Tests/Shell/DefaultProfileAvailabilityTests.cs
+++ b/tests/NovaTerminal.App.Tests/Shell/DefaultProfileAvailabilityTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NovaTerminal.Shell;
+using Xunit;
+
+namespace NovaTerminal.Tests.Shell;
+
+/// <summary>
+/// The default profile list used to advertise shells that were not installed. On a stock
+/// Windows machine `pwsh.exe` (PowerShell 7) does not exist, so the "PowerShell" profile
+/// was a dead entry that failed to spawn with a raw FFI error. Reported from a real
+/// first-run install; see docs/CONFIG_STORAGE_CONTRACT.md for the release context.
+/// </summary>
+public sealed class DefaultProfileAvailabilityTests
+{
+    [Fact]
+    public void GetDefaultProfiles_OmitsProfilesWhoseCommandIsNotInstalled()
+    {
+        // Everything present except PowerShell 7 — the exact stock-Windows shape.
+        List<TerminalProfile> profiles = TerminalSettings.GetDefaultProfiles(
+            commandExists: command => !command.Contains("pwsh", StringComparison.OrdinalIgnoreCase));
+
+        Assert.DoesNotContain(
+            profiles,
+            p => p.Command.Contains("pwsh", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void GetDefaultProfiles_KeepsProfilesWhoseCommandIsInstalled()
+    {
+        List<TerminalProfile> profiles = TerminalSettings.GetDefaultProfiles(commandExists: _ => true);
+
+        // Nothing was filtered, so the full default set survives.
+        Assert.True(profiles.Count >= 3);
+    }
+
+    [Fact]
+    public void GetDefaultProfiles_NeverReturnsAnEmptyList_EvenWhenNothingIsDetected()
+    {
+        // A probe can fail wholesale — an empty PATH makes InPath return false for
+        // everything. TerminalSettings' constructor does Profiles[0].Id, so an empty
+        // list is an IndexOutOfRangeException on startup: worse than a dead profile.
+        List<TerminalProfile> profiles = TerminalSettings.GetDefaultProfiles(commandExists: _ => false);
+
+        Assert.NotEmpty(profiles);
+        Assert.All(profiles, p => Assert.False(string.IsNullOrWhiteSpace(p.Command)));
+    }
+
+    [Fact]
+    public void GetDefaultProfiles_ProbesTheCommandNotTheProfileName()
+    {
+        var probed = new List<string>();
+
+        TerminalSettings.GetDefaultProfiles(commandExists: command =>
+        {
+            probed.Add(command);
+            return true;
+        });
+
+        // "PowerShell" is a display name; "pwsh.exe" is what has to exist on disk.
+        Assert.DoesNotContain("PowerShell", probed);
+        Assert.All(probed, c => Assert.False(string.IsNullOrWhiteSpace(c)));
+    }
+}


### PR DESCRIPTION
Two first-run failures reported from the **first install of NovaTerminal on someone else's PC**. Both predate 0.5.0 — v0.4.0 has identical code — and both survived seven months because every developer machine happens to be immune to them.

## 1. The "PowerShell" profile pointed at a shell that wasn't installed

`GetDefaultProfiles` built its list unconditionally, including `pwsh.exe`. That's PowerShell 7, a separate download stock Windows doesn't have — so the profile was a visible, dead entry that failed with a raw FFI error:

```
[ERROR] Failed to spawn process: pwsh.exe
[DETAILS] ... CreateProcessW `"pwsh.exe -NoLogo -NoExit -File ..."` failed
          The system cannot find the file specified. (os error 2)
```

The codebase already knew how to check — `ShellHelper.GetDefaultShell` probes `pwsh → powershell → cmd` via `InPath` — the profile list just never used it. It does now, with a guaranteed floor so the list can never come back empty: both the constructor and `SshLegacyProfileMigrationService` index `Profiles[0]` immediately, so an empty list would be a startup crash rather than a dead profile.

Same latent bug existed on Linux, where a Zsh profile was created whether or not zsh was there. Also fixed.

**Known limitation, deliberately not solved:** profiles persist after first run, so installing PowerShell 7 *later* won't make the profile appear — it has to be added by hand. Re-probing on every load was rejected because it would resurrect profiles a user deliberately deleted.

## 2. Command Assist's bootstrap was blocked by the execution policy

The bootstrap was launched with `-File`, which PowerShell gates behind the execution policy. Stock Windows client default is `Restricted`, which blocks **every** script file:

```
File ...\command-assist-bootstrap.ps1 cannot be loaded because running scripts
is disabled on this system.
    + FullyQualifiedErrorId : UnauthorizedAccess
```

So every PowerShell tab opened with a red wall and shell integration silently didn't work. The shell itself started fine, which is why it never looked like a crash. `ExecutionPolicy` appeared **nowhere** in the source tree.

Now passed as `-EncodedCommand`. **Chosen over `-ExecutionPolicy Bypass` deliberately:** that switch is *ignored* when policy comes from Group Policy, so it wouldn't fix managed machines at all — and it relaxes policy for the whole session, meaning scripts the *user* later runs in that tab would also bypass, which isn't a side effect a terminal should impose. An encoded command loads nothing from disk, so no policy applies and the user's own policy is untouched.

Size checked rather than assumed: script is ~2.7 KB → ~7.4 KB base64'd from UTF-16LE, against a 32767 command-line limit.

This also **retires the `-File` quoting hazard** the old code carried — the unquoted path, the 8.3 short-name fallback for usernames with spaces, and the `GetShortPathNameW` P/Invoke behind it. There's no path on the command line any more, so there's nothing left to quote.

`-Command` and `-EncodedCommand` now join `-File` in the bail-out check: appending ours after a user's command would be swallowed into theirs, and prepending would swallow theirs into ours.

## Verification

Tests written first and watched fail — 5 red for the encoding change, 4 red for the profile filter (missing API), then green.

| | |
|---|---|
| App.Tests (shell-integration + CommandAssist + settings) | 1280 passed, 0 failed |
| Architecture.Tests | 54/54 |
| McpServer.Tests | 146/146 |

Also bumps `Directory.Build.props` to 0.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
