### PR TITLE
fix(tabs): sidebar preview line shows agent content, not TUI chrome

### DIFF
--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -100,6 +100,15 @@ namespace NovaTerminal
         private readonly SshLegacyProfileMigrationService _sshLegacyMigrationService;
         private static readonly TimeSpan BellDebounceWindow = TimeSpan.FromMilliseconds(750);
 
+        /// <summary>
+        /// Minimum spacing between preview-line recomputes for a given tab while it is marked
+        /// dirty. Recomputing on every batched visual refresh is O(rows*cols) grapheme reads
+        /// under the buffer's read lock per tab per pass (contending with the parser's writes),
+        /// which gets expensive with several streaming tabs refreshing many times a second. See
+        /// <see cref="UpdateVerticalTabExtras"/> for the dirty+throttle gate this backs.
+        /// </summary>
+        private static readonly TimeSpan PreviewRefreshInterval = TimeSpan.FromMilliseconds(250);
+
         /// <summary>Tab-label marker for "an agent typed into a pane in this tab".</summary>
         internal const string AgentWroteGlyph = "⌨";  // keyboard
 
@@ -176,6 +185,8 @@ namespace NovaTerminal
             public TabStatusTracker Status { get; } = new();
             public TabTrackerStatus RenderedStatus { get; set; }
             public TabPreviewTracker Preview { get; } = new();
+            public bool PreviewDirty { get; set; }
+            public DateTime LastPreviewUpdateUtc { get; set; }
         }
 
         internal enum TabHeaderPointerAction
@@ -396,6 +407,10 @@ namespace NovaTerminal
         }
 
         internal TabStatusTracker GetTabStatusTracker(TabItem tab) => GetOrCreateTabState(tab).Status;
+
+        internal bool GetTabPreviewDirtyForTest(TabItem tab) => GetOrCreateTabState(tab).PreviewDirty;
+
+        internal void SetTabPreviewDirtyForTest(TabItem tab, bool dirty) => GetOrCreateTabState(tab).PreviewDirty = dirty;
 
         /// <summary>Timer-driven decay pass: re-evaluates every tab's heuristic status and queues a
         /// visual refresh only for tabs whose rendered status changed. Vertical mode only.</summary>
@@ -877,6 +892,12 @@ namespace NovaTerminal
             foreach (var tab in tabs.Items.Cast<TabItem>())
             {
                 ConfigureTabHeader(tab, GetTabHeaderText(tab));
+
+                // A mode swap rebuilds the header content, discarding whatever text the
+                // TabPreviewLine TextBlock previously held - mark dirty so the first vertical
+                // pass after this repopulates it instead of leaving it blank until the next
+                // output/status-timer tick.
+                GetOrCreateTabState(tab).PreviewDirty = true;
             }
 
             if (vertical && _tabStatusTimer == null)
@@ -3312,7 +3333,9 @@ namespace NovaTerminal
             var tab = ResolveOwningTabForPane(pane);
             if (tab == null) return;
 
-            GetOrCreateTabState(tab).Status.NoteOutput(DateTime.UtcNow);
+            var tabState = GetOrCreateTabState(tab);
+            tabState.Status.NoteOutput(DateTime.UtcNow);
+            tabState.PreviewDirty = true;
 
             if (TryGetSelectedTab(out var selectedTabForStartup) && selectedTabForStartup == tab && ResolvePaneForTab(selectedTabForStartup) == pane)
             {
@@ -5148,9 +5171,29 @@ namespace NovaTerminal
                 };
             }
 
+            // Preview recompute is gated behind a dirty flag + throttle: with several streaming
+            // tabs, this visual-refresh pass can run many times a second, and each recompute is
+            // an O(rows*cols) grapheme walk under the buffer's read lock (contending with the
+            // parser's writes) plus per-row string allocation. Freshness is therefore best-effort
+            // (<= PreviewRefreshInterval behind the latest output) while a tab streams; the
+            // 1s tab-status timer's Working -> quiet transition (and selection changes, which
+            // also trigger a refresh) always fires at least one more pass after a burst ends, so
+            // the final line still lands even if the last throttle window was mid-recompute.
             if (FindTabHeaderDescendant<TextBlock>(tab.Header, "TabPreviewLine") is { } preview)
             {
-                preview.Text = ReadPaneLastLine(ResolvePaneForTab(tab), state);
+                if (state.PreviewDirty)
+                {
+                    var now = DateTime.UtcNow;
+                    if (now - state.LastPreviewUpdateUtc >= PreviewRefreshInterval)
+                    {
+                        preview.Text = ReadPaneLastLine(ResolvePaneForTab(tab), state);
+                        state.PreviewDirty = false;
+                        state.LastPreviewUpdateUtc = now;
+                    }
+                    // else: still within the throttle window - skip this pass, stay dirty so a
+                    // later pass picks it up.
+                }
+                // else: nothing new since the last recompute - leave the existing text alone.
             }
         }
 

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -175,6 +175,7 @@ namespace NovaTerminal
             public AgentHost.AgentAttentionTier AgentTier { get; set; }
             public TabStatusTracker Status { get; } = new();
             public TabTrackerStatus RenderedStatus { get; set; }
+            public TabPreviewTracker Preview { get; } = new();
         }
 
         internal enum TabHeaderPointerAction
@@ -5149,28 +5150,31 @@ namespace NovaTerminal
 
             if (FindTabHeaderDescendant<TextBlock>(tab.Header, "TabPreviewLine") is { } preview)
             {
-                preview.Text = ReadPaneLastLine(ResolvePaneForTab(tab));
+                preview.Text = ReadPaneLastLine(ResolvePaneForTab(tab), state);
             }
         }
 
-        private static string ReadPaneLastLine(TerminalPane? pane)
+        private static string ReadPaneLastLine(TerminalPane? pane, TabRuntimeState state)
         {
             var buffer = pane?.Buffer;
             if (buffer == null) return string.Empty;
 
-            // GetLastNonEmptyRowText takes the buffer read lock itself (NoRecursion —
+            // GetVisibleRowTexts takes the buffer read lock itself (NoRecursion —
             // do NOT wrap this call in another Lock.EnterReadLock).
-            string text = NovaTerminal.VT.Export.TerminalExporter.GetLastNonEmptyRowText(buffer);
+            string[] rows = NovaTerminal.VT.Export.TerminalExporter.GetVisibleRowTexts(buffer);
 
             // Unwritten mid-row cells can surface as raw NUL graphemes; a NUL reaching the
             // preview TextBlock renders as invisible garbage, so swap it for a space and re-trim
             // (the exporter's own TrimEnd may no longer be meaningful once NULs become spaces).
-            if (text.IndexOf('\0') >= 0)
+            for (int i = 0; i < rows.Length; i++)
             {
-                text = text.Replace('\0', ' ').TrimEnd();
+                if (rows[i].IndexOf('\0') >= 0)
+                {
+                    rows[i] = rows[i].Replace('\0', ' ').TrimEnd();
+                }
             }
 
-            return text;
+            return state.Preview.Update(rows);
         }
 
         private void SplitPane(Avalonia.Layout.Orientation orientation)

--- a/src/NovaTerminal.App/Shell/TabPreviewTracker.cs
+++ b/src/NovaTerminal.App/Shell/TabPreviewTracker.cs
@@ -1,0 +1,103 @@
+using System;
+
+namespace NovaTerminal.Shell
+{
+    /// <summary>
+    /// Tracks the vertical tab sidebar's one-line output preview for a single tab, picking the
+    /// bottom-most row whose content has meaningfully changed since the last update rather than
+    /// simply the bottom-most non-empty row.
+    ///
+    /// TUI-style agent CLIs (Claude Code and similar) pin a static status/input bar to the very
+    /// bottom of the screen — a prompt box, a spinner, a token counter — that is almost always
+    /// the last non-empty row but never carries new information: it just sits there or ticks a
+    /// counter. Picking "the bottom-most non-empty row" for the preview therefore locks onto that
+    /// chrome forever and the sidebar preview never changes. Instead, this tracker scans upward
+    /// from the bottom for the first row that both has content and looks like new output (rather
+    /// than the same chrome with a spinner glyph or a token count updated), and falls back to
+    /// keeping whatever the previous preview was when nothing on screen qualifies — so a quiet
+    /// screen (nothing changed at all) doesn't blank out a perfectly good preview.
+    /// </summary>
+    internal sealed class TabPreviewTracker
+    {
+        /// <summary>
+        /// Fraction of character positions (over the longer of the two strings) that must differ
+        /// for a row to count as "meaningfully changed" rather than "the same chrome with a minor
+        /// tick" (spinner glyph, token counter, elapsed timer, etc).
+        /// </summary>
+        internal const double MeaningfulChangeRatio = 0.4;
+
+        private string[] _previousRows = Array.Empty<string>();
+        private string _preview = string.Empty;
+
+        /// <summary>
+        /// Feeds the tab's current visible viewport rows (top-to-bottom, each already
+        /// <c>TrimEnd</c>'ed) into the tracker and returns the updated preview text.
+        /// </summary>
+        public string Update(string[] currentRows)
+        {
+            if (_previousRows.Length == 0)
+            {
+                // Cold start: no history to diff against, so keep today's behavior — the
+                // bottom-most non-empty row.
+                _preview = FindBottomMostNonEmpty(currentRows);
+            }
+            else
+            {
+                for (int i = currentRows.Length - 1; i >= 0; i--)
+                {
+                    string current = currentRows[i];
+                    if (string.IsNullOrEmpty(current)) continue;
+
+                    string? previous = i < _previousRows.Length ? _previousRows[i] : null;
+                    if (IsMeaningfulChange(previous, current))
+                    {
+                        _preview = current;
+                        break;
+                    }
+                }
+                // If no row qualified, `_preview` is left untouched (sticky).
+            }
+
+            _previousRows = currentRows;
+            return _preview;
+        }
+
+        private static string FindBottomMostNonEmpty(string[] rows)
+        {
+            for (int i = rows.Length - 1; i >= 0; i--)
+            {
+                if (!string.IsNullOrEmpty(rows[i])) return rows[i];
+            }
+
+            return string.Empty;
+        }
+
+        /// <summary>
+        /// True when <paramref name="current"/> differs enough from <paramref name="previous"/>
+        /// to count as new content rather than the same static row with a minor tick (spinner
+        /// glyph, token counter, elapsed timer). A null/empty previous value always counts as
+        /// changed (there's nothing to compare against — e.g. a row index that didn't exist
+        /// before). Otherwise this compares position-by-position over the longer of the two
+        /// strings (positions past the end of the shorter one count as differing) and requires
+        /// at least <see cref="MeaningfulChangeRatio"/> of positions to differ.
+        /// </summary>
+        public static bool IsMeaningfulChange(string? previous, string current)
+        {
+            if (string.IsNullOrEmpty(previous)) return true;
+
+            int maxLen = Math.Max(previous.Length, current.Length);
+            if (maxLen == 0) return false;
+
+            int diffCount = 0;
+            for (int i = 0; i < maxLen; i++)
+            {
+                char a = i < previous.Length ? previous[i] : '\0';
+                char b = i < current.Length ? current[i] : '\0';
+                if (a != b) diffCount++;
+            }
+
+            double ratio = (double)diffCount / maxLen;
+            return ratio >= MeaningfulChangeRatio;
+        }
+    }
+}

--- a/src/NovaTerminal.VT/Export/TerminalExporter.cs
+++ b/src/NovaTerminal.VT/Export/TerminalExporter.cs
@@ -90,6 +90,49 @@ namespace NovaTerminal.VT.Export
             }
         }
 
+        /// <summary>
+        /// One trimmed-of-trailing-whitespace string per viewport row, top-to-bottom (index 0 =
+        /// top row) — the per-row building block behind <see cref="GetLastNonEmptyRowText"/>,
+        /// exposed so callers can apply their own "which row is the interesting one" heuristic
+        /// instead of always taking the bottom-most non-empty row. Acquires the buffer read lock
+        /// itself; callers must NOT already hold it (<see cref="TerminalBuffer.Lock"/> is a
+        /// <see cref="System.Threading.ReaderWriterLockSlim"/> with <see cref="System.Threading.LockRecursionPolicy.NoRecursion"/>,
+        /// so re-entering it throws).
+        /// </summary>
+        public static string[] GetVisibleRowTexts(TerminalBuffer buffer)
+        {
+            buffer.Lock.EnterReadLock();
+            try
+            {
+                var rows = new string[buffer.Rows];
+                for (int r = 0; r < buffer.Rows; r++)
+                {
+                    int lastNonEmpty = -1;
+                    var rowSb = new StringBuilder();
+                    for (int c = 0; c < buffer.Cols; c++)
+                    {
+                        var cell = buffer.GetCell(c, r);
+                        if (cell.IsWideContinuation) continue;
+
+                        string text = buffer.GetGrapheme(c, r);
+                        rowSb.Append(text);
+                        if (!string.IsNullOrWhiteSpace(text) && text != "\0")
+                        {
+                            lastNonEmpty = rowSb.Length;
+                        }
+                    }
+
+                    rows[r] = lastNonEmpty >= 0 ? rowSb.ToString(0, lastNonEmpty) : string.Empty;
+                }
+
+                return rows;
+            }
+            finally
+            {
+                buffer.Lock.ExitReadLock();
+            }
+        }
+
         public static string ExportToAnsi(TerminalBuffer buffer)
         {
             buffer.Lock.EnterReadLock();

--- a/src/NovaTerminal.VT/Export/TerminalExporter.cs
+++ b/src/NovaTerminal.VT/Export/TerminalExporter.cs
@@ -61,24 +61,10 @@ namespace NovaTerminal.VT.Export
             {
                 for (int r = buffer.Rows - 1; r >= 0; r--)
                 {
-                    int lastNonEmpty = -1;
-                    var rowSb = new StringBuilder();
-                    for (int c = 0; c < buffer.Cols; c++)
+                    string text = ReadRowText(buffer, r);
+                    if (text.Length > 0)
                     {
-                        var cell = buffer.GetCell(c, r);
-                        if (cell.IsWideContinuation) continue;
-
-                        string text = buffer.GetGrapheme(c, r);
-                        rowSb.Append(text);
-                        if (!string.IsNullOrWhiteSpace(text) && text != "\0")
-                        {
-                            lastNonEmpty = rowSb.Length;
-                        }
-                    }
-
-                    if (lastNonEmpty >= 0)
-                    {
-                        return rowSb.ToString().Substring(0, lastNonEmpty);
+                        return text;
                     }
                 }
 
@@ -107,22 +93,7 @@ namespace NovaTerminal.VT.Export
                 var rows = new string[buffer.Rows];
                 for (int r = 0; r < buffer.Rows; r++)
                 {
-                    int lastNonEmpty = -1;
-                    var rowSb = new StringBuilder();
-                    for (int c = 0; c < buffer.Cols; c++)
-                    {
-                        var cell = buffer.GetCell(c, r);
-                        if (cell.IsWideContinuation) continue;
-
-                        string text = buffer.GetGrapheme(c, r);
-                        rowSb.Append(text);
-                        if (!string.IsNullOrWhiteSpace(text) && text != "\0")
-                        {
-                            lastNonEmpty = rowSb.Length;
-                        }
-                    }
-
-                    rows[r] = lastNonEmpty >= 0 ? rowSb.ToString(0, lastNonEmpty) : string.Empty;
+                    rows[r] = ReadRowText(buffer, r);
                 }
 
                 return rows;
@@ -131,6 +102,35 @@ namespace NovaTerminal.VT.Export
             {
                 buffer.Lock.ExitReadLock();
             }
+        }
+
+        /// <summary>
+        /// Shared per-row cell walk behind <see cref="GetLastNonEmptyRowText"/> and
+        /// <see cref="GetVisibleRowTexts"/>: builds row <paramref name="row"/>'s text (skipping
+        /// wide-continuation cells, appending each cell's grapheme), then trims it to end right
+        /// after the last character that isn't whitespace or a NUL grapheme — i.e. trailing
+        /// whitespace/NUL is dropped, same as a <c>TrimEnd</c> that also treats "\0" as
+        /// trimmable. Returns <see cref="string.Empty"/> for a row with no such character.
+        /// Callers must already hold <see cref="TerminalBuffer.Lock"/> (read lock is sufficient).
+        /// </summary>
+        private static string ReadRowText(TerminalBuffer buffer, int row)
+        {
+            int lastNonEmpty = -1;
+            var rowSb = new StringBuilder();
+            for (int c = 0; c < buffer.Cols; c++)
+            {
+                var cell = buffer.GetCell(c, row);
+                if (cell.IsWideContinuation) continue;
+
+                string text = buffer.GetGrapheme(c, row);
+                rowSb.Append(text);
+                if (!string.IsNullOrWhiteSpace(text) && text != "\0")
+                {
+                    lastNonEmpty = rowSb.Length;
+                }
+            }
+
+            return lastNonEmpty >= 0 ? rowSb.ToString(0, lastNonEmpty) : string.Empty;
         }
 
         public static string ExportToAnsi(TerminalBuffer buffer)

--- a/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
@@ -312,4 +312,93 @@ public sealed class VerticalTabStripTests
         Assert.NotNull(method);
         method!.Invoke(window, new object[] { false });
     }
+
+    // Regression coverage for the perf fix: recomputing the preview line on every batched
+    // visual refresh is an O(rows*cols) grapheme walk under the buffer's read lock per tab per
+    // pass, which gets expensive with several streaming tabs. The fix gates the recompute behind
+    // a PreviewDirty flag + a 250ms throttle (PreviewRefreshInterval) - these three tests drive
+    // that gate directly via the GetTabPreviewDirtyForTest/SetTabPreviewDirtyForTest seam
+    // (mirroring the GetTabStatusTracker seam already used above) since real pane output isn't
+    // practical to simulate in the headless test host.
+
+    [AvaloniaFact]
+    public void UpdateTabVisuals_PreviewNotDirty_LeavesExistingTextUntouched()
+    {
+        var window = CreateShownWindow();
+        var settings = GetSettings(window);
+        settings.TabStripOrientation = "Vertical";
+        window.ApplyTabLayout();
+        Dispatcher.UIThread.RunJobs(); // let the initial dirty-from-mode-switch pass settle
+
+        var tabs = window.FindControl<TabControl>("Tabs")!;
+        var tab = tabs.Items.Cast<TabItem>().First();
+        var preview = NovaTerminal.MainWindow.FindTabHeaderDescendant<TextBlock>(tab.Header, "TabPreviewLine");
+        Assert.NotNull(preview);
+
+        window.SetTabPreviewDirtyForTest(tab, false);
+        preview!.Text = "SENTINEL_UNCHANGED";
+
+        window.UpdateTabVisuals();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("SENTINEL_UNCHANGED", preview.Text);
+    }
+
+    [AvaloniaFact]
+    public void UpdateTabVisuals_PreviewDirtyPastThrottleWindow_RecomputesAndReplacesSentinel()
+    {
+        var window = CreateShownWindow();
+        var settings = GetSettings(window);
+        settings.TabStripOrientation = "Vertical";
+        window.ApplyTabLayout();
+        Dispatcher.UIThread.RunJobs(); // let the initial dirty-from-mode-switch pass settle
+
+        var tabs = window.FindControl<TabControl>("Tabs")!;
+        var tab = tabs.Items.Cast<TabItem>().First();
+        var preview = NovaTerminal.MainWindow.FindTabHeaderDescendant<TextBlock>(tab.Header, "TabPreviewLine");
+        Assert.NotNull(preview);
+
+        preview!.Text = "SENTINEL_STALE";
+        window.SetTabPreviewDirtyForTest(tab, true);
+        // Clear the 250ms throttle window left over from the initial settle pass above, so this
+        // recompute isn't itself throttled.
+        System.Threading.Thread.Sleep(300);
+
+        window.UpdateTabVisuals();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.NotEqual("SENTINEL_STALE", preview.Text);
+    }
+
+    [AvaloniaFact]
+    public void ApplyTabLayout_ModeSwitch_MarksPreviewDirty_SoFirstPassRepopulatesIt()
+    {
+        var window = CreateShownWindow();
+        var settings = GetSettings(window);
+        settings.TabStripOrientation = "Horizontal";
+        window.ApplyTabLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        var tabs = window.FindControl<TabControl>("Tabs")!;
+        var tab = tabs.Items.Cast<TabItem>().First();
+        // Clear it so the upcoming mode switch is the only possible source of "dirty" below.
+        window.SetTabPreviewDirtyForTest(tab, false);
+        // Window startup itself may already have applied a vertical pass and recomputed the
+        // preview (TestMainWindowFactory loads the developer's real settings.json, which can be
+        // vertical) - clear the 250ms throttle window left over from that so the switch below
+        // isn't itself throttled into leaving the dirty flag set.
+        System.Threading.Thread.Sleep(300);
+
+        settings.TabStripOrientation = "Vertical";
+        window.ApplyTabLayout();
+
+        Assert.True(window.GetTabPreviewDirtyForTest(tab),
+            "mode switch must mark the preview dirty so the first vertical pass repopulates it");
+
+        Dispatcher.UIThread.RunJobs(); // the deferred UpdateTabVisuals pass consumes the dirty flag
+
+        var preview = NovaTerminal.MainWindow.FindTabHeaderDescendant<TextBlock>(tab.Header, "TabPreviewLine");
+        Assert.NotNull(preview);
+        Assert.False(window.GetTabPreviewDirtyForTest(tab), "the first vertical pass should have recomputed and cleared dirty");
+    }
 }

--- a/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
@@ -143,7 +143,14 @@ public sealed class VerticalTabStripTests
     [AvaloniaFact]
     public void HorizontalMode_KeepsPlainHeaders()
     {
-        var window = CreateShownWindow(); // default settings = horizontal
+        var window = CreateShownWindow();
+        // Force horizontal explicitly rather than trusting the loaded settings: window-creating
+        // tests read the developer's real TerminalSettings, and a dev machine left in vertical
+        // mode would otherwise make this test's premise false.
+        GetSettings(window).TabStripOrientation = "Horizontal";
+        window.ApplyTabLayout();
+        Dispatcher.UIThread.RunJobs();
+
         var tabs = window.FindControl<TabControl>("Tabs")!;
         var tab = tabs.Items.Cast<TabItem>().First();
         Assert.Null(NovaTerminal.MainWindow.FindTabHeaderDescendant<TextBlock>(tab.Header, "TabPreviewLine"));
@@ -187,7 +194,14 @@ public sealed class VerticalTabStripTests
     [AvaloniaFact]
     public void VerticalMode_ShowsResizeGrip_HorizontalHidesIt()
     {
-        var window = CreateShownWindow(); // default settings = horizontal
+        var window = CreateShownWindow();
+        // Force horizontal explicitly rather than trusting the loaded settings: window-creating
+        // tests read the developer's real TerminalSettings, and a dev machine left in vertical
+        // mode would otherwise make this test's premise false.
+        GetSettings(window).TabStripOrientation = "Horizontal";
+        window.ApplyTabLayout();
+        Dispatcher.UIThread.RunJobs();
+
         var gripHorizontal = FindResizeGrip(window);
         Assert.NotNull(gripHorizontal);
         Assert.False(gripHorizontal!.IsVisible);

--- a/tests/NovaTerminal.App.Tests/TabPreviewTrackerTests.cs
+++ b/tests/NovaTerminal.App.Tests/TabPreviewTrackerTests.cs
@@ -1,0 +1,120 @@
+using NovaTerminal.Shell;
+
+public sealed class TabPreviewTrackerTests
+{
+    [Fact]
+    public void FirstUpdate_ReturnsBottomMostNonEmptyRow()
+    {
+        var tracker = new TabPreviewTracker();
+
+        string preview = tracker.Update(new[] { "hello", "", "world" });
+
+        Assert.Equal("world", preview);
+    }
+
+    [Fact]
+    public void FirstUpdate_EmptyScreen_ReturnsEmptyString()
+    {
+        var tracker = new TabPreviewTracker();
+
+        string preview = tracker.Update(new[] { "", "", "" });
+
+        Assert.Equal(string.Empty, preview);
+    }
+
+    [Fact]
+    public void StaticBottomChrome_NewContentRowAbove_PreviewIsContentRow()
+    {
+        var tracker = new TabPreviewTracker();
+        tracker.Update(new[] { "hello", "", "auto mode on (shift+tab to cycle)" });
+
+        string preview = tracker.Update(new[]
+        {
+            "hello",
+            "The agent replied with a new line",
+            "auto mode on (shift+tab to cycle)",
+        });
+
+        Assert.Equal("The agent replied with a new line", preview);
+    }
+
+    [Fact]
+    public void SpinnerOnlyChangeInBottomRow_PreviewStaysSticky()
+    {
+        var tracker = new TabPreviewTracker();
+        // Long row, only the token count changes (< 40% of characters differ).
+        const string previous = "Working... (esc to interrupt) · 3.4k tokens · 12s";
+        const string current = "Working... (esc to interrupt) · 3.5k tokens · 12s";
+
+        tracker.Update(new[] { "hello", "", previous });
+        string preview = tracker.Update(new[] { "hello", "", current });
+
+        // Nothing qualified as meaningfully changed, so the preview stays what it was —
+        // which, on the FIRST update, was the bottom-most non-empty row (cold start).
+        Assert.Equal(previous, preview);
+    }
+
+    [Fact]
+    public void GenuineFullBottomRowChange_PlainShellCase_PreviewIsBottomRow()
+    {
+        var tracker = new TabPreviewTracker();
+        tracker.Update(new[] { "", "", "" });
+
+        string preview = tracker.Update(new[] { "", "", "$ cargo build" });
+
+        Assert.Equal("$ cargo build", preview);
+    }
+
+    [Fact]
+    public void RowCountShrink_DoesNotThrow_IndexBeyondOldCountsAsChanged()
+    {
+        var tracker = new TabPreviewTracker();
+        tracker.Update(new[] { "a", "b", "c", "d" });
+
+        string preview = tracker.Update(new[] { "x" });
+
+        Assert.Equal("x", preview);
+    }
+
+    [Fact]
+    public void RowCountGrow_DoesNotThrow_NewRowsCountAsChanged()
+    {
+        var tracker = new TabPreviewTracker();
+        tracker.Update(new[] { "a" });
+
+        string preview = tracker.Update(new[] { "a", "b", "new bottom row" });
+
+        Assert.Equal("new bottom row", preview);
+    }
+
+    [Fact]
+    public void NoRowQualifies_KeepsPreviousPreview()
+    {
+        var tracker = new TabPreviewTracker();
+        tracker.Update(new[] { "hello", "", "status bar text here" });
+
+        // Second update: bottom row unchanged, others empty -> nothing qualifies.
+        string preview = tracker.Update(new[] { "hello", "", "status bar text here" });
+
+        Assert.Equal("status bar text here", preview);
+    }
+
+    [Theory]
+    [InlineData(null, "anything", true)]
+    [InlineData("", "anything", true)]
+    [InlineData("identical text here", "identical text here", false)]
+    [InlineData("totally different content", "completely unlike the first one!", true)]
+    public void IsMeaningfulChange_BoundaryCases(string? previous, string current, bool expected)
+    {
+        Assert.Equal(expected, TabPreviewTracker.IsMeaningfulChange(previous, current));
+    }
+
+    [Fact]
+    public void IsMeaningfulChange_SpinnerGlyphOnly_IsBelowThreshold()
+    {
+        const string previous = "Working... (esc to interrupt) · 3.4k tokens · 12s";
+        const string current = "Working... (esc to interrupt) · 3.5k tokens · 12s";
+
+        Assert.False(TabPreviewTracker.IsMeaningfulChange(previous, current));
+    }
+}

--- a/tests/NovaTerminal.Platform.Tests/Export/TerminalExporterTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Export/TerminalExporterTests.cs
@@ -103,6 +103,22 @@ namespace NovaTerminal.Platform.Tests.Export
             Assert.Equal("hello", text);
         }
 
+        [Fact]
+        public void GetVisibleRowTexts_ReturnsPerRowTrimmedTexts_TopToBottom()
+        {
+            var buffer = new TerminalBuffer(80, 3);
+            WriteRow(buffer, 0, "alpha");
+            WriteRow(buffer, 1, "beta   ");
+            // row 2 left blank
+
+            string[] rows = TerminalExporter.GetVisibleRowTexts(buffer);
+
+            Assert.Equal(3, rows.Length);
+            Assert.Equal("alpha", rows[0]);
+            Assert.Equal("beta", rows[1]);
+            Assert.Equal(string.Empty, rows[2]);
+        }
+
         // Writes each character of `text` directly into row `row`'s cells, starting at column 0 —
         // mirrors the direct ViewportRows[].Cells[] construction used above for precise per-cell
         // control (buffer.WriteContent doesn't interpret \r/\n as cursor motion, so it can't be


### PR DESCRIPTION
## What this changes

Follow-up to #356. The vertical tab sidebar's preview line took the bottom-most non-empty screen row — but for TUI-style agent CLIs (the feature's headline use case) that row is static status-bar chrome, so e.g. a Claude Code tab permanently previewed "auto mode on (shift+tab to cy…" and never anything the agent actually said.

The preview now tracks the **bottom-most meaningfully-changed row**: a new pure `TabPreviewTracker` (one per tab) diffs the visible rows against the previous refresh and picks the lowest row whose text changed in ≥40% of character positions — so a spinner tick or token-counter update in a long chrome row doesn't win, but genuine new output does. When nothing meaningful changed the previous preview sticks; the first refresh falls back to the old bottom-most-non-empty behavior. Plain shells behave exactly as before (their bottom row genuinely changes).

Second commit hardens `VerticalTabStripTests`: two tests asserted the horizontal *default* while window-creating tests load the developer's live settings.json — they failed on any machine where vertical mode was left enabled. They now pin the orientation explicitly.

## Invariant and ownership

- **What invariant does this change affect?** Buffer lock contract (`TerminalBuffer.Lock`, NoRecursion): the new `TerminalExporter.GetVisibleRowTexts` acquires the read lock itself, mirroring `GetLastNonEmptyRowText`; the MainWindow call path holds no lock around it.
- **Which module owns that invariant?** NovaTerminal.VT.

## Tests

- **What tests cover this change?**
  - `tests/NovaTerminal.App.Tests/TabPreviewTrackerTests.cs` — 13 tests: cold start, static-chrome-vs-new-content selection, realistic spinner/token-counter stickiness, plain-shell full-row change, row-count shrink/grow, change-ratio boundaries
  - `tests/NovaTerminal.Platform.Tests/Export/TerminalExporterTests.cs` — `GetVisibleRowTexts` row texts top-to-bottom, trimming, empty rows
  - `tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs` — orientation pinned explicitly (test-only hardening)
- **Which categories did you run locally?**
  - [ ] full unfiltered run (`scripts/build.sh test`)
  - [ ] `Category=Replay`
  - [ ] `Category=RenderMetrics`
  - [ ] `Category=PtySmoke`
  - [x] `tests/NovaTerminal.App.Tests` (non-blocking in CI — check it yourself): targeted feature filter (VerticalTabStripTests + TabPreviewTrackerTests + TabStatusTrackerTests) 32/32 green post-rebase with `--blame-hang-timeout 5m`; Platform.Tests 165/165
  - [ ] full local CI rehearsal (`ci/run.sh` / `ci/run.ps1`)

## Impact

- **Does this affect cross-platform behavior?** No — pure text diffing over the existing buffer API; developed/tested on Windows.
- **Does this change renderer metrics?** No renderer changes. Note for reviewers: the preview path now snapshots all viewport rows per tab per refresh (O(rows×cols), needed as the diff baseline) instead of early-exiting at the first non-empty bottom row. This runs only in vertical mode inside the existing batched Background-priority refresh; flagged in internal review as worth a smoke-check with several busy tabs, not a blocker.
- **Does this change VT coverage?** No sequences added or changed.

**Known minor follow-ups:** `GetVisibleRowTexts` duplicates `GetLastNonEmptyRowText`'s per-row body (could share a helper); viewport-resize semantics of the row diff are treat-as-changed (reasonable, undocumented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)