### PR TITLE
macOS: Velopack .app + .pkg installer, osx update feed, unsigned v1 with signing seam

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1040,6 +1040,72 @@ jobs:
       - name: Publish AOT
         run: dotnet publish src/NovaTerminal.App/NovaTerminal.App.csproj -c ${{ env.CONFIGURATION }} -r ${{ matrix.rid }} --self-contained true -p:PublishAot=true -p:SkipCliShim=true -o artifacts/publish/${{ matrix.rid }}
 
+      # ---- macOS packaging dry run (osx-arm64 only): the same vpk pack invocation
+      # ---- release.yml runs, minus the download/upload-release steps. None of this is
+      # ---- runnable from a Windows or Linux dev box, so this dispatch lane is the only
+      # ---- way to verify the NovaTerminal.app bundle, the .pkg installer and the osx
+      # ---- feed asset names BEFORE a real tag ships them. The vpk version is pinned to
+      # ---- the same 1.2.0 as release.yml and Directory.Packages.props — the three must
+      # ---- stay in lockstep.
+      - name: Install vpk
+        if: matrix.rid == 'osx-arm64'
+        run: dotnet tool install -g vpk --version 1.2.0
+
+      - name: Generate macOS app icon (.icns)
+        if: matrix.rid == 'osx-arm64'
+        run: packaging/macos/make-icns.sh src/NovaTerminal.App/Assets/nova_icon.png artifacts/icon/nova_icon.icns
+
+      # 0.0.1-ci: a dry-run version that can never collide with a real release's feed
+      # (vpk rejects anything below 0.0.1, so 0.0.0-ci is not an option here).
+      # Assertions mirror what release.yml asserts post-pack, so a silent vpk change
+      # fails HERE rather than at the next tag.
+      - name: Pack macOS bundle (Velopack dry run)
+        if: matrix.rid == 'osx-arm64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # StripSymbols=true leaves a ~94 MB NovaTerminal.dSYM beside the binary (3x the
+          # binary's own size). Delete it at the source AND exclude it in vpk: deletion
+          # keeps empty dSYM directory skeletons out of the bundle entirely, --exclude
+          # (vpk's built-in default covers only .pdb) is defense-in-depth. Nothing else
+          # consumes the symbols - the raw publish-dir zip this dSYM used to ship in no
+          # longer exists for macOS.
+          rm -rf artifacts/publish/osx-arm64/NovaTerminal.dSYM
+          vpk pack \
+            --packId NovaTerminalApp \
+            --packVersion 0.0.1-ci \
+            --packDir artifacts/publish/osx-arm64 \
+            --mainExe NovaTerminal \
+            --packTitle NovaTerminal \
+            --packAuthors benyblack \
+            --bundleId com.benyblack.NovaTerminal \
+            --icon artifacts/icon/nova_icon.icns \
+            --exclude 'NovaTerminal\.dSYM' \
+            --outputDir artifacts/velopack-dryrun
+
+          echo "Velopack dry-run output:"
+          ls -l artifacts/velopack-dryrun
+
+          test -n "$(ls artifacts/velopack-dryrun/*-osx-Setup.pkg 2>/dev/null || true)" || { echo "vpk pack produced no -osx-Setup.pkg" >&2; exit 1; }
+          test -n "$(ls artifacts/velopack-dryrun/*-osx-Portable.zip 2>/dev/null || true)" || { echo "vpk pack produced no -osx-Portable.zip" >&2; exit 1; }
+          test -f artifacts/velopack-dryrun/NovaTerminalApp-0.0.1-ci-osx-full.nupkg || { echo "vpk pack produced no full nupkg" >&2; exit 1; }
+          test -f artifacts/velopack-dryrun/releases.osx.json || { echo "vpk pack produced no releases.osx.json" >&2; exit 1; }
+          # StripSymbols leaves the dSYM beside the binary; the rm + --exclude above keep
+          # it out of the bundle users download. Pin that: no dSYM entry may appear in
+          # the Portable zip at all, not even an empty directory skeleton.
+          if unzip -l artifacts/velopack-dryrun/NovaTerminalApp-osx-Portable.zip | grep -q "dSYM"; then
+            echo "NovaTerminal.dSYM leaked into the Portable bundle" >&2
+            exit 1
+          fi
+
+      - name: Upload macOS packaging dry-run artifacts
+        if: matrix.rid == 'osx-arm64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-packaging-dryrun
+          retention-days: 7
+          path: artifacts/velopack-dryrun
+
       - name: Upload AOT bundle
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,7 +263,12 @@ jobs:
           RELEASE_VERSION: ${{ needs.release_metadata.outputs.release_version }}
         run: dotnet publish src/NovaTerminal.App/NovaTerminal.App.csproj -c ${{ env.CONFIGURATION }} -r ${{ matrix.rid }} --self-contained true -p:PublishAot=true -p:SkipCliShim=true "-p:Version=$RELEASE_VERSION" "-p:InformationalVersion=$RELEASE_VERSION" -o artifacts/publish/${{ matrix.rid }}
 
+      # osx-arm64 is excluded here: its user-facing zip is the Velopack Portable bundle
+      # (NovaTerminal.app inside a ditto zip) built by the macOS Velopack steps below and
+      # uploaded under this same NovaTerminal-osx-arm64-<tag>.zip name. Archiving the raw
+      # publish directory too would ship a second, near-identical zip.
       - name: Archive bundle
+        if: matrix.rid != 'osx-arm64'
         shell: pwsh
         # Same reasoning as the metadata job's env block, for PowerShell: in a double-quoted
         # string `"$(...)"` is a subexpression PowerShell EXECUTES, so a tag named
@@ -281,29 +286,36 @@ jobs:
           if (Test-Path $dest) { Remove-Item $dest -Force }
           Compress-Archive -Path "$source/*" -DestinationPath $dest
 
+      # osx-arm64 skips this for the same reason as Archive bundle above: the mac zip
+      # uploads from the Velopack output directory instead.
       - name: Upload release asset
+        if: matrix.rid != 'osx-arm64'
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ needs.release_metadata.outputs.release_tag }}
           files: artifacts/release/NovaTerminal-${{ matrix.rid }}-${{ needs.release_metadata.outputs.release_tag }}.zip
 
-      # ---- Windows installer + update feed (#91). win-x64 only; the other two RIDs
-      # ---- keep shipping portable zips exactly as before.
+      # ---- Velopack installers + update feeds (#91). win-x64 and osx-arm64; linux-x64
+      # ---- keeps shipping its portable zip exactly as before.
       - name: Install vpk
-        if: matrix.rid == 'win-x64'
+        if: matrix.rid == 'win-x64' || matrix.rid == 'osx-arm64'
         run: dotnet tool install -g vpk --version 1.2.0
 
       - name: Download previous Velopack release (for delta generation)
         id: velopack_download
-        if: matrix.rid == 'win-x64'
+        if: matrix.rid == 'win-x64' || matrix.rid == 'osx-arm64'
         continue-on-error: true
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           New-Item -ItemType Directory -Force -Path artifacts/velopack | Out-Null
-          # First release ever, or no prior Velopack assets: nothing to download, and a
-          # full-only release is the correct outcome rather than a failed one.
+          # First release on a channel, or no prior Velopack assets in that channel's feed:
+          # nothing to download, and a full-only release is the correct outcome rather than
+          # a failed one. The channel is resolved from the runner's OS (vpk's
+          # DefaultName.GetDefaultChannel: win on windows-latest, osx on macos-latest), so
+          # each lane only ever sees its own channel's packages even though the step body
+          # is shared.
           vpk download github --repoUrl https://github.com/benyblack/NovaTerminal --token $env:GH_TOKEN --outputDir artifacts/velopack
 
       - name: Pack Windows installer (Velopack)
@@ -335,8 +347,13 @@ jobs:
           # create_release sets from the tag's SemVer suffix) and drafts, so counting a beta's
           # full package here would demand a delta that vpk was never going to download —
           # blocking the first STABLE release after any prerelease. (Codex P2 on #340.)
+          # It also excludes -osx-full.nupkg assets: the win channel's full packages have no
+          # channel suffix (the suffix is only omitted for the default win channel), while
+          # the osx channel's do — so a bare endswith("-full.nupkg") counts BOTH channels
+          # once mac releases exist, demanding a win delta from a download that only ever
+          # fetched the win feed.
           $priorFullRaw = gh api "repos/$env:GITHUB_REPOSITORY/releases?per_page=100" `
-            --jq '[.[] | select(.tag_name != env.RELEASE_TAG) | select(.prerelease == false) | select(.draft == false) | .assets[]? | select(.name | endswith("-full.nupkg"))] | length'
+            --jq '[.[] | select(.tag_name != env.RELEASE_TAG) | select(.prerelease == false) | select(.draft == false) | .assets[]? | select(.name | endswith("-full.nupkg") and (endswith("-osx-full.nupkg") | not))] | length'
 
           # Check the exit code before trusting the output, and check it IMMEDIATELY - any
           # other command in between overwrites $LASTEXITCODE. GitHub's pwsh wrapper sets
@@ -454,6 +471,155 @@ jobs:
             artifacts/velopack/NovaTerminalApp-${{ needs.release_metadata.outputs.release_version }}-full.nupkg
             artifacts/velopack/NovaTerminalApp-${{ needs.release_metadata.outputs.release_version }}-delta.nupkg
             artifacts/velopack/releases.win.json
+
+      # ---- macOS installer + update feed. osx-arm64 only. vpk builds NovaTerminal.app
+      # ---- from the raw publish directory (generated Info.plist, .icns into
+      # ---- Contents/Resources, everything else into Contents/MacOS — which is what the
+      # ---- app's AppContext.BaseDirectory resource lookups expect), a .pkg installer,
+      # ---- full/delta nupkgs for the osx channel, and a ditto Portable zip of the .app.
+      # ---- The osx channel suffix keeps every asset name distinct from the win lane's
+      # ---- (the suffix is only omitted for the default win channel), so both lanes can
+      # ---- upload into the same GitHub release without collisions.
+      - name: Generate macOS app icon (.icns)
+        if: matrix.rid == 'osx-arm64'
+        run: packaging/macos/make-icns.sh src/NovaTerminal.App/Assets/nova_icon.png artifacts/icon/nova_icon.icns
+
+      - name: Pack macOS installer (Velopack)
+        if: matrix.rid == 'osx-arm64'
+        shell: bash
+        # Same rule as every other script in this file: the tag and version reach the
+        # script through env, never by interpolation into its source. (Codex P1 on #340.)
+        env:
+          RELEASE_TAG: ${{ needs.release_metadata.outputs.release_tag }}
+          RELEASE_VERSION: ${{ needs.release_metadata.outputs.release_version }}
+          DOWNLOAD_OUTCOME: ${{ steps.velopack_download.outcome }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          ver="$RELEASE_VERSION"
+          tag="$RELEASE_TAG"
+
+          # Same disambiguation as the Windows lane (see its long comment): an empty
+          # artifacts/velopack directory is either "no prior Velopack osx release"
+          # (legitimate — the only correct outcome on the first mac release) or "the
+          # download step failed" (transient). Ask the releases API which case it is.
+          # The filter mirrors what `vpk download github` fetches for the osx channel:
+          # prereleases and drafts excluded, and only -osx-full.nupkg assets counted —
+          # the win lane's full packages (no channel suffix) must not be counted here,
+          # or this lane would demand a delta its download never fetched.
+          if ! prior_full_raw=$(gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+              --jq '[.[] | select(.tag_name != env.RELEASE_TAG) | select(.prerelease == false) | select(.draft == false) | .assets[]? | select(.name | endswith("-osx-full.nupkg"))] | length'); then
+            echo "Querying the releases API failed (gh exit code $?). Cannot tell a first mac release from a transient failure, and guessing wrong publishes a release with no delta. Re-run the workflow for this tag." >&2
+            exit 1
+          fi
+          if [[ ! "$prior_full_raw" =~ ^[0-9]+$ ]]; then
+            echo "The releases API query returned '$prior_full_raw', which is not a count. Refusing to guess whether a delta is expected." >&2
+            exit 1
+          fi
+          prior_full_count=$((prior_full_raw))
+          expect_delta=$(( prior_full_count > 0 ? 1 : 0 ))
+          echo "Prior osx full packages on GitHub (excluding $tag): $prior_full_count. Download step outcome: $DOWNLOAD_OUTCOME."
+
+          if (( expect_delta )) && [[ "$DOWNLOAD_OUTCOME" != "success" ]]; then
+            echo "A prior Velopack osx release exists, but 'vpk download github' did not succeed (outcome: $DOWNLOAD_OUTCOME). Packing now would publish a full-only release and silently drop delta updates. Re-run the workflow for this tag once GitHub is reachable." >&2
+            exit 1
+          fi
+          if (( expect_delta )); then
+            echo "A delta is expected and will be asserted after packing."
+          else
+            echo "No prior Velopack osx release; full-only output is the correct result."
+          fi
+
+          # Same re-run idempotency as the Windows lane: `vpk download github` picks the
+          # max-version osx full, which for an already-published tag is the tag's OWN
+          # NovaTerminalApp-$ver-osx-full.nupkg — and `vpk pack` then hard-fails with
+          # "There is a release in channel osx which is equal or greater to the current
+          # version". Drop this version's own artifacts first.
+          rm -f artifacts/velopack/NovaTerminalApp-"$ver"-osx-*.nupkg
+
+          # packId matches the Windows lane deliberately: it is the updater's application
+          # identity. On macOS it only names the update cache
+          # (~/Library/Caches/velopack/NovaTerminalApp); the app itself installs as
+          # /Applications/NovaTerminal.app, so the Windows uninstall-hazard (packId == the
+          # config root) does not apply here. --bundleId: vpk's default would be
+          # com.benyblack.NovaTerminalApp; this matches the public identity (winget:
+          # benyblack.NovaTerminal) instead.
+          #
+          # No --signAppIdentity/--signInstallIdentity/--notaryProfile on purpose: no
+          # Apple Developer certificate exists today. vpk warns "Package will not be
+          # signed or notarized" and packages everything unsigned; the app still runs,
+          # because on arm64 the linker ad-hoc-signs the AOT binary and the Rust dylibs.
+          # The seam for enabling real signing later is exactly these three flags plus a
+          # keychain import — documented in packaging/macos/README.md.
+          # StripSymbols=true leaves a ~94 MB NovaTerminal.dSYM beside the binary (3x the
+          # binary's own size). Delete it at the source AND exclude it in vpk: deletion
+          # keeps empty dSYM directory skeletons out of the bundle entirely, --exclude
+          # (vpk's built-in default exclusion only covers Windows .pdb files) is
+          # defense-in-depth. Nothing else consumes the symbols - the raw publish-dir zip
+          # this dSYM used to ship in no longer exists for macOS.
+          rm -rf artifacts/publish/osx-arm64/NovaTerminal.dSYM
+          vpk pack \
+            --packId NovaTerminalApp \
+            --packVersion "$ver" \
+            --packDir artifacts/publish/osx-arm64 \
+            --mainExe NovaTerminal \
+            --packTitle NovaTerminal \
+            --packAuthors benyblack \
+            --bundleId com.benyblack.NovaTerminal \
+            --icon artifacts/icon/nova_icon.icns \
+            --exclude 'NovaTerminal\.dSYM' \
+            --outputDir artifacts/velopack
+
+          # The installer's and the zip's file names are ours to choose — nothing
+          # resolves them by name. The zip keeps the exact name the raw publish
+          # directory used to ship under, so existing download links keep working;
+          # its content is now the NovaTerminal.app bundle instead of loose files.
+          # Matched by glob because vpk includes the channel in the names it produces.
+          setup_pkg=$(ls artifacts/velopack/*-osx-Setup.pkg 2>/dev/null | head -n 1 || true)
+          if [[ -z "$setup_pkg" ]]; then
+            echo "vpk pack produced no -osx-Setup.pkg" >&2
+            exit 1
+          fi
+          mv "$setup_pkg" "artifacts/velopack/NovaTerminal-Setup-osx-arm64-$tag.pkg"
+
+          portable_zip=$(ls artifacts/velopack/*-osx-Portable.zip 2>/dev/null | head -n 1 || true)
+          if [[ -z "$portable_zip" ]]; then
+            echo "vpk pack produced no -osx-Portable.zip" >&2
+            exit 1
+          fi
+          mv "$portable_zip" "artifacts/velopack/NovaTerminal-osx-arm64-$tag.zip"
+
+          echo "Velopack output:"
+          ls -l artifacts/velopack
+
+          # Assert here rather than at the upload step, for the same reason as the
+          # Windows lane: the first mac release legitimately produces no delta, so
+          # fail_on_unmatched_files must stay permissive and the signal belongs here.
+          if [[ ! -f "artifacts/velopack/NovaTerminalApp-$ver-osx-full.nupkg" ]]; then
+            echo "vpk pack produced no NovaTerminalApp-$ver-osx-full.nupkg - the osx update feed would be unusable." >&2
+            exit 1
+          fi
+          if (( expect_delta )) && [[ ! -f "artifacts/velopack/NovaTerminalApp-$ver-osx-delta.nupkg" ]]; then
+            echo "A prior Velopack osx release exists but vpk pack produced no NovaTerminalApp-$ver-osx-delta.nupkg - delta generation silently failed." >&2
+            exit 1
+          fi
+
+      # Same known-and-benign property as the win feed: releases.osx.json lists the
+      # previous release's full nupkg too (the download step placed it in the output
+      # directory for delta generation and `vpk pack` re-indexes everything). The
+      # version-scoped paths below keep stale nupkgs from being re-uploaded onto this
+      # release.
+      - name: Upload macOS installer and update feed
+        if: matrix.rid == 'osx-arm64'
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          tag_name: ${{ needs.release_metadata.outputs.release_tag }}
+          files: |
+            artifacts/velopack/NovaTerminal-Setup-osx-arm64-${{ needs.release_metadata.outputs.release_tag }}.pkg
+            artifacts/velopack/NovaTerminal-osx-arm64-${{ needs.release_metadata.outputs.release_tag }}.zip
+            artifacts/velopack/NovaTerminalApp-${{ needs.release_metadata.outputs.release_version }}-osx-full.nupkg
+            artifacts/velopack/NovaTerminalApp-${{ needs.release_metadata.outputs.release_version }}-osx-delta.nupkg
+            artifacts/velopack/releases.osx.json
 
   # Opens a submission PR to microsoft/winget-pkgs for the just-published Windows
   # zip (portable package; see packaging/winget/). Optional and self-skipping:

--- a/README.md
+++ b/README.md
@@ -70,9 +70,27 @@ so SmartScreen will warn on first run. Choose *More info → Run anyway*.
 
 **Linux / macOS**
 
-Installer packaging is not available yet — download the `linux-x64` or `osx-arm64` zip from the
-[latest release](https://github.com/benyblack/NovaTerminal/releases/latest) and extract it
-anywhere, or build from source.
+- **macOS (Apple Silicon)** — download `NovaTerminal-Setup-osx-arm64-<tag>.pkg` from the
+  [latest release](https://github.com/benyblack/NovaTerminal/releases/latest) and run it;
+  it installs into `/Applications` (or `~/Applications`) as a proper `NovaTerminal.app`
+  bundle. Alternatively grab `NovaTerminal-osx-arm64-<tag>.zip`, open it, and drag
+  `NovaTerminal.app` to `/Applications`.
+- **Linux** — download the `linux-x64` zip and extract it anywhere, or build from source.
+
+macOS builds installed via the `.pkg` check for updates in the background and apply them
+on restart, same as Windows. If the app lives in `/Applications`, macOS will ask for your
+password once per update.
+
+The installer and the app are **not code-signed or notarized yet**
+([#91](https://github.com/benyblack/NovaTerminal/issues/91)), so Gatekeeper blocks the
+first launch. On macOS 13+:
+
+1. Try to open `NovaTerminal` once (it will be blocked — that's expected).
+2. Open **System Settings → Privacy & Security**, scroll down, and click **Open Anyway**.
+3. Confirm — macOS remembers the approval for subsequent launches and updates.
+
+From a terminal, the one-liner equivalent is
+`xattr -cr /Applications/NovaTerminal.app`.
 
 For build steps, jump to [Build & test](#build--test) below.
 

--- a/docs/superpowers/specs/2026-08-28-macos-installer-velopack-design.md
+++ b/docs/superpowers/specs/2026-08-28-macos-installer-velopack-design.md
@@ -1,0 +1,128 @@
+# macOS Installer + Auto-Update (Velopack)
+
+Date: 2026-08-28
+Status: implemented
+Companion to: `2026-08-24-windows-installer-velopack-design.md` (the Windows lane this mirrors)
+
+## Summary
+
+Give macOS a real installer and update channel by extending the existing Velopack lane
+to `osx-arm64`: `vpk pack` builds a `NovaTerminal.app` bundle from the raw NativeAOT
+publish directory, a `.pkg` installer, full/delta nupkgs for an `osx` channel, and a
+Portable zip of the `.app`. No Apple Developer certificate exists, so v1 ships **unsigned**
+(the binaries themselves run: see "Signing" below), with the Gatekeeper path documented for
+users and the exact signing diff documented for later.
+
+## What exists today (before this change)
+
+- `release.yml`'s `publish_aot` zips the raw osx-arm64 publish directory as
+  `NovaTerminal-osx-arm64-<tag>.zip` — loose files, no `.app`, no installer.
+- The app is macOS-ready at runtime: `VelopackApp.Build().Run()` runs in `Program.Main`
+  on all OSes, `VelopackUpdateService` + `GithubSource` are cross-platform, chrome is
+  traffic-light-aware, secrets use the Keychain, and `librusty_pty.dylib` /
+  `librusty_ssh.dylib` are built on the mac runner.
+- Bundled resources resolve via `AppContext.BaseDirectory` (fonts, `themes/**`), so
+  everything from the publish directory must sit in `Contents/MacOS/` — which is exactly
+  where `vpk pack` puts a plain `--packDir`.
+
+## Facts verified against the vpk 1.2.0 source
+
+These were read out of `velopack/velopack` (`develop`) rather than assumed, because they
+are load-bearing for a two-channel release page:
+
+1. **Asset naming** (`VelopackDefaults`/`DefaultName.GetUniqueAssetSuffix`): nupkgs,
+   installers and portable zips get a `-{channel}` suffix **except** when the channel is
+   the default `win` channel. So the win lane produces `NovaTerminalApp-<ver>-full.nupkg`
+   while the osx lane produces `NovaTerminalApp-<ver>-osx-full.nupkg`,
+   `NovaTerminalApp-<ver>-osx-Setup.pkg`, `NovaTerminalApp-<ver>-osx-Portable.zip` —
+   no collisions inside one GitHub release.
+2. **Channel resolution** (`RepositoryOptions.Channel` → `DefaultName.GetDefaultChannel`):
+   `vpk download github` on a macOS runner targets the `osx` channel, on a Windows runner
+   the `win` channel. Each lane's download/pack directory therefore only ever contains
+   its own channel's packages even though the step body is shared.
+3. **Signing default** (`OsxPackCommandRunner.CodeSign`): with no `--signAppIdentity`,
+   vpk logs `Package will not be signed or notarized` and **packages everything
+   unsigned**; with an identity + `--notaryProfile` it signs, notarizes, staples and
+   `spctl`-assesses. There is no ad-hoc fallback inside vpk itself — none is needed (next
+   point).
+4. **Why unsigned still runs**: on arm64 the macOS linker applies ad-hoc signatures to
+   the NativeAOT binary and cargo's `.dylib` outputs at build time, and
+   SkiaSharp/HarfBuzz ship maintainer-signed dylibs. Gatekeeper's quarantine check is the
+   only gate that fails, and "Open Anyway" clears it once.
+5. **Bundle generation** (`OsxBundleCommandRunner`): the generated `Info.plist` sets
+   CFBundleName/Executable/Identifier (`--bundleId`), version strings from
+   `--packVersion`, `NSHighResolutionCapable`, and `CFBundleIconFile` from `--icon`
+   (copied verbatim into `Contents/Resources` — it must be an `.icns`). It does **not**
+   set `LSMinimumSystemVersion`.
+6. **Updates on macOS**: packages cache to `~/Library/Caches/velopack/NovaTerminalApp`,
+   the `.app` bundle is replaced in place; if the app is in `/Applications`, the updater
+   elevates via an AppleScript admin prompt. App Sandbox is unsupported (not used here).
+
+## Decisions
+
+- **Velopack rather than hand-rolled `.app` + DMG**: the app already embeds the Velopack
+  hooks and updater; vpk produces the bundle, installer and feed in one step the repo
+  already trusts on Windows. A DMG would be bespoke scripting with no update benefit.
+- **`--packId NovaTerminalApp`** (same as Windows): on mac it only names the update
+  cache; the app installs as `/Applications/NovaTerminal.app`, so the Windows
+  uninstall-deletes-config hazard cannot occur.
+- **`--bundleId com.benyblack.NovaTerminal`**: vpk's default would be
+  `com.benyblack.NovaTerminalApp` (derived from packAuthors+packId);
+  `benyblack.NovaTerminal` matches the public identity (winget package id). The Keychain
+  `kSecAttrService = "NovaTerminal"` is unrelated and unchanged.
+- **Release assets** (user decision): the `.pkg`, plus the Portable `.app` zip renamed to
+  the exact existing `NovaTerminal-osx-arm64-<tag>.zip` name — one obvious download, old
+  links keep working, content upgrades from loose files to the bundle. The generic
+  "Archive bundle"/"Upload release asset" steps skip `osx-arm64`.
+- **Apple Silicon only** (user decision): no `osx-x64` lane. A second architecture would
+  need explicit non-default channels and doubles mac CI time; follow-up if ever needed.
+- **Unsigned v1, documented seam, nothing pre-wired**: matching the repo's established
+  posture (the Windows lane's signing seam was likewise never wired). The exact flip-to-
+  signed diff lives in `packaging/macos/README.md`; it is three vpk flags plus a keychain
+  import step.
+
+## Changes
+
+- `packaging/macos/make-icns.sh` — `sips` + `iconutil` iconset generation from
+  `nova_icon.png` (1024×1024 source; every size is a downscale). PNG stays the single
+  source of truth; no `.icns` committed. The script forces `-s format png` because the
+  source asset turned out to be JPEG data mislabeled with a `.png` extension (JFIF magic
+  bytes) — without the explicit format, sips writes JPEG bytes into `.png`-named iconset
+  files and `iconutil` fails with "Failed to generate ICNS".
+- `release.yml` (`publish_aot`): osx-arm64-gated `vpk` install / icns / download /
+  pack / upload steps, bash on the mac runner, mirroring the Windows lane's
+  injection-safety conventions and its delta-expectation discipline (the gh-api count
+  filters `-osx-full.nupkg`; re-run idempotency deletes `NovaTerminalApp-<ver>-osx-*.nupkg`).
+  `vpk pack` runs after `rm -rf artifacts/publish/osx-arm64/NovaTerminal.dSYM` and passes
+  `--exclude 'NovaTerminal\.dSYM'`: `StripSymbols=true` leaves a ~94 MB dSYM beside the
+  binary (3× the binary's size), vpk's built-in `--exclude` default covers only Windows
+  `.pdb` files, and exclusion alone still leaves empty dSYM directory skeletons in the
+  ditto zip (verified: the nupkg dropped 46→32.5 MB once the content was excluded).
+- `release.yml` Windows lane fix: the prior-full jq count now excludes `-osx-full.nupkg`
+  assets — a bare `endswith("-full.nupkg")` would count both channels once mac releases
+  exist and demand a win delta the win download never fetched.
+- `ci.yml` (`aot_publish`, dispatch-only): same `vpk pack` at version `0.0.0-ci` with
+  assertions, uploaded as the `macos-packaging-dryrun` artifact — the only way to verify
+  packaging without cutting a release, since none of it runs on Windows/Linux dev boxes.
+- `README.md`: macOS install section (pkg/zip, update behavior, Gatekeeper walkthrough).
+- `packaging/macos/README.md`: asset table, dry-run instructions, the signing seam.
+
+## Testing
+
+- No unit-testable surface (workflow + shell + docs only) — consistent with how the
+  Windows installer lane landed.
+- The ci.yml dispatch lane is the verification gate: it asserts the Setup pkg, Portable
+  zip, full nupkg and `releases.osx.json` all materialize with the expected names.
+- First real tag will exercise the download/delta path (expected: full-only, asserted as
+  correct for a first channel release).
+
+## Open questions / follow-ups
+
+- `LSMinimumSystemVersion` is absent from vpk's generated plist (see known-limitations
+  note in `packaging/macos/README.md`); revisit with a `--plist` template if a floor ever
+  needs enforcing.
+- Signing + notarization once an Apple Developer Program membership exists (#91).
+- A native macOS menu bar (`NativeMenu`) — a UX/polish concern, not packaging; the app
+  draws its own chrome today.
+- `osx-x64` lane and/or a universal binary (NativeAOT can't produce one directly; it
+  would take `lipo` over two full publish trees — not worth it now).

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -1,0 +1,103 @@
+# macOS packaging
+
+This folder holds the macOS packaging pieces used by the release workflow:
+
+- `make-icns.sh` — derives `nova_icon.icns` from `src/NovaTerminal.App/Assets/nova_icon.png`
+  at packaging time (`sips` + `iconutil`). The PNG stays the single source of truth across
+  platforms; no `.icns` binary is committed.
+
+The actual bundling is done by [Velopack](https://velopack.io) (`vpk pack`) in
+`.github/workflows/release.yml`, mirroring the Windows lane:
+
+| Release asset | Produced by | Notes |
+|---|---|---|
+| `NovaTerminal-Setup-osx-arm64-<tag>.pkg` | `vpk pack` (renamed from `*-osx-Setup.pkg`) | Standard macOS installer; offers /Applications or ~/Applications |
+| `NovaTerminal-osx-arm64-<tag>.zip` | `vpk pack` (renamed from `*-osx-Portable.zip`) | Same file name the raw loose-files zip always used; now contains the `NovaTerminal.app` bundle |
+| `NovaTerminalApp-<ver>-osx-full.nupkg` / `-osx-delta.nupkg` | `vpk pack` | The osx update channel consumed by the in-app updater |
+| `releases.osx.json` | `vpk pack` | The osx feed index (`GithubSource` in `VelopackUpdateService` resolves it) |
+
+Facts worth knowing (all verified against the vpk 1.2.0 source, see
+`docs/superpowers/specs/2026-08-28-macos-installer-velopack-design.md`):
+
+- The default macOS channel is `osx`, and its assets carry an `-osx` suffix
+  (`NovaTerminalApp-<ver>-osx-full.nupkg`). Only the *win* default channel omits the
+  suffix, so the two lanes never collide inside one GitHub release.
+- `vpk download github` resolves its channel from the runner's OS, so each lane only ever
+  downloads its own channel's prior full package for delta generation.
+- The app bundle installs as `/Applications/NovaTerminal.app`; Velopack's update cache
+  lives at `~/Library/Caches/velopack/NovaTerminalApp`. User data stays where it always
+  was (`~/.local/share/NovaTerminal` via `AppPaths`) and is never touched by updates or
+  uninstall.
+
+## Dry run without cutting a release
+
+The `AOT Publish` job in `.github/workflows/ci.yml` is `workflow_dispatch`-only and runs
+the same `vpk pack` (version `0.0.0-ci`) plus assertions, uploading
+`macos-packaging-dryrun` as a workflow artifact. Use it to verify bundle structure, the
+pkg, and asset names before tagging. None of this is runnable from a Windows or Linux
+dev box.
+
+## Current state: unsigned (the "signing seam")
+
+No Apple Developer Program membership exists today, so releases ship **unsigned and
+un-notarized**. `vpk pack` is invoked without signing options; it logs
+`Package will not be signed or notarized` and packages everything anyway. The app still
+runs: on arm64, `ld` ad-hoc-signs the NativeAOT binary and the Rust dylibs at build time,
+and the SkiaSharp/HarfBuzz dylibs ship signed by their maintainers.
+
+The first-launch Gatekeeper flow for users is documented in the main `README.md`
+(System Settings → Privacy & Security → "Open Anyway" on macOS 15+, or
+`xattr -cr /Applications/NovaTerminal.app` in Terminal).
+
+### Turning signing + notarization on later
+
+This is deliberately **not** pre-wired with secret-gated workflow steps: an untestable
+dead path in a release pipeline is worse than a documented diff. When a Developer ID
+certificate exists, the change is exactly this:
+
+1. Create a "Developer ID Application" and a "Developer ID Installer" certificate
+   (appleid.apple.com → Certificates), export both as one `.p12`.
+2. Store repo secrets: `MAC_CERT_P12_BASE64` (base64 of the p12), `MAC_CERT_PASSWORD`,
+   `MAC_SIGN_APP_IDENTITY` (e.g. `Developer ID Application: Beny Black (TEAMID)`),
+   `MAC_SIGN_INSTALL_IDENTITY` (e.g. `Developer ID Installer: Beny Black (TEAMID)`),
+   `MAC_NOTARY_PROFILE` (a notarytool profile name), plus `MAC_APPLE_ID`, `MAC_TEAM_ID`,
+   `MAC_APP_SPECIFIC_PASSWORD`.
+3. In the osx-arm64 leg of `publish_aot` in `release.yml`, add a step before `vpk pack`
+   that imports the keychain and stores the notarytool profile:
+
+   ```bash
+   cert_path=$(mktemp -d)/cert.p12
+   echo "$MAC_CERT_P12_BASE64" | base64 --decode > "$cert_path"
+   security create-keychain -p "$MAC_CERT_PASSWORD" build.keychain
+   security default-keychain -s build.keychain
+   security unlock-keychain -p "$MAC_CERT_PASSWORD" build.keychain
+   security import "$cert_path" -k build.keychain -P "$MAC_CERT_PASSWORD" -T /usr/bin/codesign
+   security set-key-partition-list -S apple-tool:,apple: -k "$MAC_CERT_PASSWORD" build.keychain
+   xcrun notarytool store-credentials "$MAC_NOTARY_PROFILE" \
+     --apple-id "$MAC_APPLE_ID" --team-id "$MAC_TEAM_ID" --password "$MAC_APP_SPECIFIC_PASSWORD" \
+     --keychain build.keychain
+   ```
+
+4. Add these flags to `vpk pack`:
+
+   ```
+   --signAppIdentity "$MAC_SIGN_APP_IDENTITY" \
+   --signInstallIdentity "$MAC_SIGN_INSTALL_IDENTITY" \
+   --notaryProfile "$MAC_NOTARY_PROFILE" \
+   --keychain "$HOME/Library/Keychains/build.keychain"
+   ```
+
+vpk then signs the app bundle and dylibs (deep signing), signs the pkg, submits for
+notarization, staples the ticket, and runs `spctl` assessments — verified in vpk's
+`OsxPackCommandRunner`/`CodeSign`. Nothing else in the pipeline changes: same asset
+names, same feed, updater-agnostic.
+
+### Known limitations
+
+- vpk's generated `Info.plist` sets no `LSMinimumSystemVersion`; .NET 10's own macOS floor
+  governs what actually runs. If an explicit floor is ever needed, pass a fully specified
+  plist via `--plist` (mutually exclusive with `--bundleId`) — note the plist must then
+  carry the version strings per release itself.
+- Signing cannot be back-dated onto already-published releases; users who installed an
+  unsigned build keep their Gatekeeper approval and continue updating normally (updates
+  written by the running app never pass through Gatekeeper).

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -98,6 +98,10 @@ names, same feed, updater-agnostic.
   governs what actually runs. If an explicit floor is ever needed, pass a fully specified
   plist via `--plist` (mutually exclusive with `--bundleId`) — note the plist must then
   carry the version strings per release itself.
+- The bundle carries ~600 KB of `NovaTerminal.*.pdb` files beside the binary (the IL
+  project symbols the AOT publish emits). vpk's documented `.pdb` default exclusion does
+  not strip these from the macOS bundle contents; harmless, kept rather than spending a
+  release-lane iteration on it.
 - Signing cannot be back-dated onto already-published releases; users who installed an
   unsigned build keep their Gatekeeper approval and continue updating normally (updates
   written by the running app never pass through Gatekeeper).

--- a/packaging/macos/make-icns.sh
+++ b/packaging/macos/make-icns.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Generate a macOS .icns from the source PNG icon.
+#
+# Usage: make-icns.sh <source.png> <output.icns>
+#
+# Runs on macOS only (sips + iconutil ship with the OS). The PNG stays the single
+# source of truth for the app icon on every platform; this script derives the
+# Apple-specific format at packaging time instead of committing a binary to the
+# repo. nova_icon.png is 1024x1024, so every iconset size is a high-quality
+# downscale.
+set -euo pipefail
+
+if [[ "$(uname)" != "Darwin" ]]; then
+    echo "make-icns.sh must run on macOS (needs sips and iconutil)." >&2
+    exit 1
+fi
+
+if [[ $# -ne 2 ]]; then
+    echo "Usage: $0 <source.png> <output.icns>" >&2
+    exit 1
+fi
+
+source_png=$1
+output_icns=$2
+
+if [[ ! -f "$source_png" ]]; then
+    echo "Source icon not found: $source_png" >&2
+    exit 1
+fi
+
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+iconset="$workdir/icon.iconset"
+mkdir -p "$iconset"
+
+# Apple's required iconset layout: each size plus its @2x retina variant. sips -z
+# takes <height> <width>; both are square here.
+#
+# -s format png is load-bearing: the source asset is JPEG data despite its .png
+# extension (JFIF magic bytes), and without an explicit format sips sniffs the
+# input, warns "Output file suffix should be jpg", writes JPEG bytes into the
+# .png-named iconset files, and iconutil then fails with "Failed to generate
+# ICNS". Forcing the output format makes the script indifferent to what the
+# source really is.
+resize() {
+    local px=$1 name=$2
+    sips -s format png -z "$px" "$px" "$source_png" --out "$iconset/$name.png" >/dev/null
+}
+
+resize 16   icon_16x16
+resize 32   icon_16x16@2x
+resize 32   icon_32x32
+resize 64   icon_32x32@2x
+resize 128  icon_128x128
+resize 256  icon_128x128@2x
+resize 256  icon_256x256
+resize 512  icon_256x256@2x
+resize 512  icon_512x512
+resize 1024 icon_512x512@2x
+
+mkdir -p "$(dirname "$output_icns")"
+iconutil -c icns "$iconset" -o "$output_icns"
+
+echo "Wrote $output_icns"


### PR DESCRIPTION
## Summary

- **macOS gets a real installer and update channel** by extending the Velopack lane Windows already uses to `osx-arm64`: `vpk pack` builds `NovaTerminal.app` from the raw AOT publish output (generated `Info.plist` with `com.benyblack.NovaTerminal`, `.icns` in `Contents/Resources`, binary + Rust/Skia dylibs + `Assets`/`themes` in `Contents/MacOS`), a `NovaTerminal-Setup-osx-arm64-<tag>.pkg`, full/delta nupkgs for the `osx` channel, and `releases.osx.json`. The in-app updater already wired for Windows picks the mac feed up unchanged.
- **One mac zip, no link breakage**: the Velopack Portable zip of the `.app` is uploaded under the exact existing `NovaTerminal-osx-arm64-<tag>.zip` name (content upgrades from loose files to the bundle); the generic Archive/Upload steps skip `osx-arm64`. No asset-name collisions with the win lane — verified from vpk source that the `-osx` channel suffix is only omitted for the default `win` channel — and the Windows lane's prior-full jq count now excludes `-osx-full.nupkg` accordingly.
- **Unsigned v1 by design** (no Apple Developer cert): vpk warns and packages anyway; the app runs because `ld` ad-hoc-signs the arm64 AOT binary and cargo dylibs. Gatekeeper first-launch steps are documented in the README, and the complete flip-to-signed-and-notarized diff (three vpk flags + keychain import) is documented in `packaging/macos/README.md` — matching the repo's unwired-seam posture for Windows signing.
- **New `make-icns.sh`** generates the `.icns` from `nova_icon.png` in CI. Two repo bugs found and handled: the source "png" is actually JPEG data (script forces `-s format png`), and `StripSymbols` left a **94 MB `.dSYM`** inside the bundle — now deleted + `--exclude`d, cutting the bundle from 178.6 MB to 70.7 MB.

## Verification

- New dispatch-only dry-run lane in `ci.yml` runs the same `vpk pack` at `0.0.1-ci` with assertions and uploads `macos-packaging-dryrun`. Verified end-to-end on this branch: run https://github.com/benyblack/NovaTerminal/actions/runs/33173345413 — `AOT Publish (macos-latest)` green; artifact inspected (bundle structure, Info.plist ids, asset names, zero dSYM entries, feed JSON).
- That run's only red job is `PTY Smoke Tests (windows-latest)` — a timing-flaky test, green on the identical code in runs 33165783412 / 33168876658, and this branch touches no C#/PTY code.
- First tagged release will correctly publish full-only (no delta) for the new osx channel; the workflow asserts that is the expected outcome.

## Notes / follow-ups

- ~600 KB of `NovaTerminal.*.pdb` files ride along in the bundle (vpk's `.pdb` default exclusion doesn't strip them from mac bundle contents) — noted in `packaging/macos/README.md`, kept as-is.
- Out of scope: `osx-x64` lane, DMG, native `NativeMenu`, wiring real signing secrets (#91).
- Design rationale and all vpk-source findings: `docs/superpowers/specs/2026-08-28-macos-installer-velopack-design.md`.
- Heads-up: the mimosa security-scanner hook failed to complete (ENOBUFS) on every commit of this branch, so no full security audit pass has run over it yet.