### PR TITLE
fix(backup): refresh the Command Assist snippet list on Import/Restore reload

### DIFF
--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -6409,7 +6409,7 @@ namespace NovaTerminal
         /// <summary>
         /// F1: a successful Import or Restore run from the Backup page changes settings.json (and
         /// possibly more) on disk while this dialog is still open (see
-        /// <c>SettingsWindow.ReloadSettingsAfterExternalChange</c>). Before this fix, only the
+        /// <c>SettingsWindow.ReloadSettingsAfterExternalChangeAsync</c>). Before this fix, only the
         /// <paramref name="saved"/> == true branch below adopted that change; closing the dialog any
         /// other way - Cancel, or the window's X, both of which surface here as
         /// <paramref name="saved"/> == false - left <c>_settings</c> pointing at the stale
@@ -6427,7 +6427,7 @@ namespace NovaTerminal
         /// <c>OpenSettings</c> itself reaches a real <c>Window.ShowDialog</c>, which this repo's
         /// headless test host cannot return from. A test can build a <see cref="SettingsWindow"/>
         /// through the same reflection seam <c>SettingsWindowBackupSectionTests</c> uses to invoke
-        /// <c>ReloadSettingsAfterExternalChange</c>, then call this method directly with
+        /// <c>ReloadSettingsAfterExternalChangeAsync</c>, then call this method directly with
         /// <paramref name="saved"/> = false to simulate Cancel/X after a successful import.
         /// </summary>
         internal void ApplySettingsWindowResult(SettingsWindow sw, bool saved, PreviewSnapshot previewSnapshot)

--- a/src/NovaTerminal.App/SettingsWindow.axaml.cs
+++ b/src/NovaTerminal.App/SettingsWindow.axaml.cs
@@ -1269,6 +1269,22 @@ namespace NovaTerminal
             // for a window opened outside MainWindow.OpenSettings: TryGetSnippetEditor returns null
             // when CommandAssistSnippetStore is unset and the panel simply says so.
             await ReloadCommandAssistSnippetsAsync();
+
+            // Codex review (PR #364, P2): refreshing this window's panel is only half of what a
+            // snippet change owes the app. MainWindow.OpenSettings subscribes
+            // DismissCommandAssistSurfaces to this event, and the add/edit/delete paths all raise it,
+            // because the rows an open assist bubble or popup is showing are a snapshot of a ranking
+            // pass that nothing else invalidates (see DismissCommandAssistSurfaces' own remarks,
+            // written for the identical "Clear history" case). An import/restore is the most
+            // destructive snippet change there is - snippets.json is replaced wholesale in BOTH modes
+            // - so without this a popup left open behind the dialog goes on displaying, and
+            // accepting, snippets the import just deleted.
+            //
+            // Raised unconditionally rather than only when the bundle actually carried Snippets, for
+            // the same reason ConfigurationReplacedExternally is set unconditionally above: dismissing
+            // a surface that did not need it costs the user nothing (the next keystroke rebuilds it
+            // from the store), while missing one shows them rows that no longer exist.
+            OnCommandAssistSnippetsChanged?.Invoke();
         }
 
         /// <summary>

--- a/src/NovaTerminal.App/SettingsWindow.axaml.cs
+++ b/src/NovaTerminal.App/SettingsWindow.axaml.cs
@@ -33,7 +33,7 @@ namespace NovaTerminal
 
         /// <summary>
         /// F1: set once a successful Import or Restore has replaced configuration on disk out from
-        /// under this window (see <see cref="ReloadSettingsAfterExternalChange"/>). The owning
+        /// under this window (see <see cref="ReloadSettingsAfterExternalChangeAsync"/>). The owning
         /// <c>MainWindow.OpenSettings</c> must adopt the reloaded <see cref="Settings"/> regardless
         /// of how this dialog eventually closes - Save, Cancel, or the window's X - because closing
         /// any other way than Save previously left <c>MainWindow._settings</c> pointing at the
@@ -1116,7 +1116,7 @@ namespace NovaTerminal
                         // PRE-import state - if this window's Save is clicked afterward, it would
                         // silently overwrite the very change Import just made with that stale
                         // snapshot. Reload before anything else can touch _settings again.
-                        ReloadSettingsAfterExternalChange();
+                        await ReloadSettingsAfterExternalChangeAsync();
                     }
 
                     // M2: surface the service's own outcome message rather than a generic one -
@@ -1158,7 +1158,7 @@ namespace NovaTerminal
                         // I1: same reasoning as the Import handler above - Restore just changed
                         // settings.json (and possibly more) on disk, and this window's in-memory
                         // state must not be allowed to stomp it on a later Save.
-                        ReloadSettingsAfterExternalChange();
+                        await ReloadSettingsAfterExternalChangeAsync();
                     }
 
                     SetStatus(
@@ -1188,8 +1188,15 @@ namespace NovaTerminal
         /// (profiles/shortcuts/title-bar derivation, then the UI-control population methods), so
         /// the already-open window's controls reflect the new on-disk state too rather than
         /// merely fixing what gets written back on the next Save.
+        /// <para>
+        /// Asynchronous solely because of the trailing snippet reload (see the comment at the end
+        /// of the body); everything else here is synchronous and completes before the first
+        /// suspension point. Callers must await it - both the Import and Restore click handlers
+        /// already do - so the whole window, snippet rows included, is consistent with disk before
+        /// the success status is shown.
+        /// </para>
         /// </summary>
-        private void ReloadSettingsAfterExternalChange()
+        private async System.Threading.Tasks.Task ReloadSettingsAfterExternalChangeAsync()
         {
             // F1: record that configuration was replaced externally so MainWindow.OpenSettings can
             // adopt the reload below no matter how this dialog eventually closes. Set unconditionally
@@ -1246,11 +1253,27 @@ namespace NovaTerminal
 
             LoadTitleBarDraft();
             RebuildTitleBarRows();
+
+            // The one populate path that is NOT reachable by repeating the constructor's sequence,
+            // and the reason this method is async at all. PopulateCommandAssistSnippetsPanel is
+            // driven by WireCommandAssistSnippetsRow's one-shot `Opened` handler rather than by the
+            // constructor, because the snippet store arrives by property assignment after the
+            // constructor has run. This method runs on an ALREADY-OPEN window and never reopens it,
+            // so `Opened` does not fire again: without this call, an import/restore whose bundle
+            // carries a different command-assist/snippets.json (which BackupService replaces
+            // wholesale in BOTH modes) leaves the visible rows describing the pre-import file until
+            // the window is closed and reopened - and the user can edit or delete against them.
+            //
+            // Awaited last, after every synchronous repopulation above, so the parts of this method
+            // that cannot fail on I/O are already done before the first suspension point. Null-safe
+            // for a window opened outside MainWindow.OpenSettings: TryGetSnippetEditor returns null
+            // when CommandAssistSnippetStore is unset and the panel simply says so.
+            await ReloadCommandAssistSnippetsAsync();
         }
 
         /// <summary>
         /// Fix (I1 residual #2): <c>_selectedProfile</c> points at an entry of the PRE-reload
-        /// <c>_profilesList</c>. <see cref="ReloadSettingsAfterExternalChange"/> rebuilds
+        /// <c>_profilesList</c>. <see cref="ReloadSettingsAfterExternalChangeAsync"/> rebuilds
         /// <c>_profilesList</c> with fresh <see cref="TerminalProfile"/> instances (freshly
         /// deserialized from the reloaded settings.json) but, without this, never re-points
         /// <c>_selectedProfile</c> at the corresponding new instance - it is left dangling,
@@ -1555,7 +1578,7 @@ namespace NovaTerminal
 
             // Codex review round 3: seed BOTH the global font and the selected profile's own
             // override (if any), rather than ??-ing them down to one. In the reload path
-            // (ReloadSettingsAfterExternalChange), _selectedProfile is still the PRE-reload
+            // (ReloadSettingsAfterExternalChangeAsync), _selectedProfile is still the PRE-reload
             // object — RepointSelectedProfileAfterReload does not run until after this — so a
             // profile with a font override used to make _selectedProfile?.FontFamily win the ??
             // and silently hide _settings.FontFamily from this seeding entirely. That left a

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowBackupPaletteTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowBackupPaletteTests.cs
@@ -148,7 +148,7 @@ public sealed class MainWindowBackupPaletteTests
     /// just-imported settings.json with the stale pre-import configuration.
     ///
     /// Drives the real seams: a real <see cref="BackupService.Import"/> (Replace mode), the private
-    /// <c>SettingsWindow.ReloadSettingsAfterExternalChange</c> the Import click handler calls on
+    /// <c>SettingsWindow.ReloadSettingsAfterExternalChangeAsync</c> the Import click handler calls on
     /// success (same reflection seam <c>SettingsWindowBackupSectionTests</c> uses -
     /// <c>Window.ShowDialog</c> hangs this headless host, so the dialog itself is never opened), then
     /// <c>MainWindow.ApplySettingsWindowResult</c> with <c>saved: false</c> - simulating Cancel/X -
@@ -156,7 +156,7 @@ public sealed class MainWindowBackupPaletteTests
     /// invocation of "Font: Increase" stands in for "any ordinary action afterwards".
     /// </summary>
     [AvaloniaFact]
-    public void ImportReplace_ThenCancelSettings_ThenOrdinarySave_KeepsTheImportedConfiguration()
+    public async Task ImportReplace_ThenCancelSettings_ThenOrdinarySave_KeepsTheImportedConfiguration()
     {
         using var source = BackupTestTree.CreatePopulated();
         source.WriteFile("settings.json", """{"FontSize":77,"ThemeName":"FromImport"}""");
@@ -182,9 +182,9 @@ public sealed class MainWindowBackupPaletteTests
             Assert.True(importOutcome.Success, importOutcome.Message);
 
             var reloadMethod = typeof(NovaTerminal.SettingsWindow).GetMethod(
-                "ReloadSettingsAfterExternalChange", BindingFlags.Instance | BindingFlags.NonPublic);
+                "ReloadSettingsAfterExternalChangeAsync", BindingFlags.Instance | BindingFlags.NonPublic);
             Assert.NotNull(reloadMethod);
-            reloadMethod!.Invoke(settingsWindow, null);
+            await (Task)reloadMethod!.Invoke(settingsWindow, null)!;
             Assert.True(settingsWindow.ConfigurationReplacedExternally);
 
             var previewSnapshot = new NovaTerminal.MainWindow.PreviewSnapshot(

--- a/tests/NovaTerminal.App.Tests/Core/SettingsWindowBackupSectionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/SettingsWindowBackupSectionTests.cs
@@ -6,6 +6,8 @@ using Avalonia.Headless.XUnit;
 using Avalonia.Input;
 using Avalonia.LogicalTree;
 using NovaTerminal.Backup;
+using NovaTerminal.CommandAssist.Models;
+using NovaTerminal.CommandAssist.Storage;
 using NovaTerminal.Tests.Backup;
 using Xunit;
 
@@ -419,12 +421,12 @@ public sealed class SettingsWindowBackupSectionTests
     /// <c>Window.ShowDialog</c> hangs this host) - and unlike Restore's confirmation, no test seam
     /// exists for either. Per the plan's own guidance, this drives the underlying method chain
     /// directly instead: a real <see cref="BackupService.Import"/> call, then the private
-    /// <c>ReloadSettingsAfterExternalChange</c> the click handler calls on success (reached via
+    /// <c>ReloadSettingsAfterExternalChangeAsync</c> the click handler calls on success (reached via
     /// reflection, the same established pattern <c>BuildRestoreConfirmationText</c> uses
     /// elsewhere in this file), then a real BtnSave click.
     /// </summary>
     [AvaloniaFact]
-    public void Import_ThenSave_DoesNotRevertTheImportedSettings()
+    public async Task Import_ThenSave_DoesNotRevertTheImportedSettings()
     {
         using var source = BackupTestTree.CreatePopulated();
         source.WriteFile("settings.json", """{"FontSize":77,"ThemeName":"FromImport"}""");
@@ -441,10 +443,7 @@ public sealed class SettingsWindowBackupSectionTests
         var outcome = targetService.Import(bundle, ImportMode.Replace);
         Assert.True(outcome.Success, outcome.Message);
 
-        var reloadMethod = typeof(NovaTerminal.SettingsWindow).GetMethod(
-            "ReloadSettingsAfterExternalChange", BindingFlags.Instance | BindingFlags.NonPublic);
-        Assert.NotNull(reloadMethod);
-        reloadMethod!.Invoke(window, null);
+        await InvokeReloadAfterExternalChangeAsync(window);
 
         var btnSave = window.FindControl<Button>("BtnSave")!;
         btnSave.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
@@ -456,7 +455,7 @@ public sealed class SettingsWindowBackupSectionTests
 
     /// <summary>
     /// I1 residual, Fix 1 (scoped re-review): <c>PopulateThemes</c> fills the theme combo boxes
-    /// from disk once, at construction. <c>ReloadSettingsAfterExternalChange</c> did not re-run it,
+    /// from disk once, at construction. <c>ReloadSettingsAfterExternalChangeAsync</c> did not re-run it,
     /// so an import bringing a NEW theme file plus a settings.json naming it left the combo holding
     /// the pre-import theme list — no entry for the imported theme. <c>LoadCurrentSettings</c>'s
     /// theme-selection loop then had nothing to select, left <c>SelectedItem</c> on the stale
@@ -471,7 +470,7 @@ public sealed class SettingsWindowBackupSectionTests
     /// makes the stale selection observable at Save.
     /// </summary>
     [AvaloniaFact]
-    public void Import_BringingNewTheme_ThenSave_PersistsTheImportedThemeName()
+    public async Task Import_BringingNewTheme_ThenSave_PersistsTheImportedThemeName()
     {
         using var source = BackupTestTree.CreateEmpty();
         source.WriteFile("settings.json", """{"FontSize":14,"ThemeName":"Imported"}""");
@@ -490,10 +489,7 @@ public sealed class SettingsWindowBackupSectionTests
         var outcome = targetService.Import(bundle, ImportMode.Replace);
         Assert.True(outcome.Success, outcome.Message);
 
-        var reloadMethod = typeof(NovaTerminal.SettingsWindow).GetMethod(
-            "ReloadSettingsAfterExternalChange", BindingFlags.Instance | BindingFlags.NonPublic);
-        Assert.NotNull(reloadMethod);
-        reloadMethod!.Invoke(window, null);
+        await InvokeReloadAfterExternalChangeAsync(window);
 
         var btnSave = window.FindControl<Button>("BtnSave")!;
         btnSave.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
@@ -508,7 +504,7 @@ public sealed class SettingsWindowBackupSectionTests
     /// fonts. <c>PopulateFonts</c> builds its list via
     /// <c>BuildFontFamilyChoices(..., _selectedProfile?.FontFamily ?? _settings.FontFamily)</c> —
     /// it explicitly seeds the configured font even when it is not installed locally. Before the
-    /// fix, <c>ReloadSettingsAfterExternalChange</c> called <c>PopulateThemes</c> but not
+    /// fix, <c>ReloadSettingsAfterExternalChangeAsync</c> called <c>PopulateThemes</c> but not
     /// <c>PopulateFonts</c>, so a bundle imported from another machine naming a font absent here
     /// left <c>FontList</c> holding the pre-import choices; <c>LoadCurrentSettings</c> could not
     /// select the imported font, and a later Save wrote the stale font back over it.
@@ -522,7 +518,7 @@ public sealed class SettingsWindowBackupSectionTests
     /// this bug.
     /// </summary>
     [AvaloniaFact]
-    public void Import_BringingFontNotInstalledLocally_ThenSave_PersistsTheImportedFontFamily()
+    public async Task Import_BringingFontNotInstalledLocally_ThenSave_PersistsTheImportedFontFamily()
     {
         const string importedFont = "TotallyNotARealFont-XYZ123";
 
@@ -543,10 +539,7 @@ public sealed class SettingsWindowBackupSectionTests
         var outcome = targetService.Import(bundle, ImportMode.Replace);
         Assert.True(outcome.Success, outcome.Message);
 
-        var reloadMethod = typeof(NovaTerminal.SettingsWindow).GetMethod(
-            "ReloadSettingsAfterExternalChange", BindingFlags.Instance | BindingFlags.NonPublic);
-        Assert.NotNull(reloadMethod);
-        reloadMethod!.Invoke(window, null);
+        await InvokeReloadAfterExternalChangeAsync(window);
 
         var btnSave = window.FindControl<Button>("BtnSave")!;
         btnSave.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
@@ -554,6 +547,111 @@ public sealed class SettingsWindowBackupSectionTests
         using var afterSave = target.ReadJson("settings.json");
         Assert.Equal(importedFont, afterSave.RootElement.GetProperty("FontFamily").GetString());
     }
+
+    /// <summary>
+    /// Sibling of <see cref="Import_BringingFontNotInstalledLocally_ThenSave_PersistsTheImportedFontFamily"/>
+    /// and <see cref="Import_BringingNewTheme_ThenSave_PersistsTheImportedThemeName"/>, for the one
+    /// populate path the reload did not cover: the Command Assist snippet list.
+    ///
+    /// Every other <c>Populate*</c> is called straight from the constructor, so
+    /// <c>ReloadSettingsAfterExternalChangeAsync</c> could re-run it by simply repeating the constructor's
+    /// sequence. <c>PopulateCommandAssistSnippetsPanel</c> is different — it is reached through
+    /// <c>WireCommandAssistSnippetsRow</c>'s <c>Opened += async (_, _) =&gt; await
+    /// ReloadCommandAssistSnippetsAsync()</c> handler, because the store arrives by property
+    /// assignment after the constructor has run. <c>Opened</c> fires once, the first time the window
+    /// is shown; the reload runs on an ALREADY-OPEN window and does not reopen it, so before this fix
+    /// nothing refreshed the snippet rows. An import whose bundle carries a different
+    /// <c>command-assist/snippets.json</c> (which <c>BackupService</c> replaces wholesale in BOTH
+    /// modes) left the visible list showing the pre-import snippets until the window was closed and
+    /// reopened.
+    ///
+    /// Unlike the theme/font siblings, the observable damage is not at Save — snippets do not live in
+    /// settings.json and the Save button never writes them — it is the stale rows themselves, which
+    /// the user can then edit or delete, acting on a list that no longer describes the file. So this
+    /// asserts on the panel's contents directly.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task Import_BringingNewSnippets_RefreshesTheAlreadyOpenSnippetsPanel()
+    {
+        using var source = BackupTestTree.CreateEmpty();
+        source.WriteFile("settings.json", """{"FontSize":14,"ThemeName":"Default"}""");
+        await new JsonSnippetStore(SnippetsPathIn(source))
+            .UpsertAsync(NewSnippet("imported-1", "Imported snippet", "echo imported"));
+        string bundle = Path.Combine(source.Root, "import.novabackup");
+        Assert.True(new BackupService(source.Root).Export(bundle).Success);
+
+        using var target = BackupTestTree.CreatePopulated();
+        // The live store MainWindow.OpenSettings injects — a real JsonSnippetStore over the target
+        // tree's own file, so the import below genuinely changes what it reads.
+        var targetStore = new JsonSnippetStore(SnippetsPathIn(target));
+        await targetStore.UpsertAsync(NewSnippet("local-1", "Local snippet", "echo local"));
+
+        using var _ = OverrideAppDataRoot(target.Root);
+        var window = new NovaTerminal.SettingsWindow { CommandAssistSnippetStore = targetStore };
+
+        // Stands in for the one-shot Opened handler: the window is open and its snippet list has
+        // already been populated from the pre-import file.
+        await InvokeReloadCommandAssistSnippetsAsync(window);
+        Assert.Equal(new[] { "Local snippet" }, SnippetRowNames(window));
+
+        var outcome = new BackupService(target.Root).Import(bundle, ImportMode.Replace);
+        Assert.True(outcome.Success, outcome.Message);
+
+        await InvokeReloadAfterExternalChangeAsync(window);
+
+        Assert.Equal(new[] { "Imported snippet" }, SnippetRowNames(window));
+    }
+
+    private static string SnippetsPathIn(BackupTestTree tree)
+        => Path.Combine(tree.Root, "command-assist", "snippets.json");
+
+    private static CommandSnippet NewSnippet(string id, string name, string command) => new(
+        Id: id,
+        Name: name,
+        CommandText: command,
+        Description: null,
+        ShellKind: null,
+        WorkingDirectory: null,
+        IsPinned: true,
+        CreatedAt: DateTimeOffset.UnixEpoch,
+        LastUsedAt: null);
+
+    /// <summary>
+    /// The names shown by the rows currently in <c>CommandAssistSnippetsPanel</c> — the first
+    /// <see cref="TextBox"/> of each row, which <c>CreateCommandAssistSnippetRow</c> seeds with the
+    /// snippet's name. Reading the built controls rather than the editor's list is the point: the bug
+    /// is precisely that the two can disagree.
+    /// </summary>
+    private static string[] SnippetRowNames(NovaTerminal.SettingsWindow window)
+    {
+        var panel = window.FindControl<StackPanel>("CommandAssistSnippetsPanel")!;
+        return panel.Children
+            .Select(row => row.GetLogicalDescendants().OfType<TextBox>().First().Text ?? "")
+            .ToArray();
+    }
+
+    private static async Task InvokeReloadCommandAssistSnippetsAsync(NovaTerminal.SettingsWindow window)
+    {
+        var method = typeof(NovaTerminal.SettingsWindow).GetMethod(
+            "ReloadCommandAssistSnippetsAsync", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        await (Task)method!.Invoke(window, null)!;
+    }
+
+    /// <summary>
+    /// Drives the private <c>ReloadSettingsAfterExternalChangeAsync</c> the Import and Restore click
+    /// handlers call on success. Reflection, and awaited: the method became a <see cref="Task"/> when
+    /// the Command Assist snippet reload (genuinely async - it re-reads the store's file) joined the
+    /// synchronous repopulation, so invoking without awaiting would race the assertions that follow.
+    /// </summary>
+    private static async Task InvokeReloadAfterExternalChangeAsync(NovaTerminal.SettingsWindow window)
+    {
+        var method = typeof(NovaTerminal.SettingsWindow).GetMethod(
+            "ReloadSettingsAfterExternalChangeAsync", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        await (Task)method!.Invoke(window, null)!;
+    }
+
 
     /// <summary>
     /// Finding 2 (Codex review round 2, PR #362): the Merge/Replace import prompt says Merge
@@ -613,7 +711,7 @@ public sealed class SettingsWindowBackupSectionTests
 
     /// <summary>
     /// I1 residual, Fix 2 (scoped re-review): <c>_selectedProfile</c> points at an entry of the
-    /// PRE-reload <c>_profilesList</c>. <c>ReloadSettingsAfterExternalChange</c> rebuilds
+    /// PRE-reload <c>_profilesList</c>. <c>ReloadSettingsAfterExternalChangeAsync</c> rebuilds
     /// <c>_profilesList</c> with fresh <c>TerminalProfile</c> instances (freshly deserialized from
     /// the reloaded settings.json) but, before this fix, never re-pointed <c>_selectedProfile</c> —
     /// it was left dangling, referencing an object no longer reachable from <c>_profilesList</c>.
@@ -628,7 +726,7 @@ public sealed class SettingsWindowBackupSectionTests
     /// edit landed on the live post-reload profile object, not a detached pre-reload one.
     /// </summary>
     [AvaloniaFact]
-    public void ReloadAfterExternalChange_ThenEditSelectedProfile_ThenSave_PersistsTheEdit()
+    public async Task ReloadAfterExternalChange_ThenEditSelectedProfile_ThenSave_PersistsTheEdit()
     {
         using var tree = BackupTestTree.CreateEmpty();
         const string profileId = "11111111-1111-1111-1111-111111111111";
@@ -656,10 +754,7 @@ public sealed class SettingsWindowBackupSectionTests
              "Profiles":[{"Id":"{{profileId}}","Name":"Original","Command":"{{ProfileCommandForThisOs}}"}]}
             """);
 
-        var reloadMethod = typeof(NovaTerminal.SettingsWindow).GetMethod(
-            "ReloadSettingsAfterExternalChange", BindingFlags.Instance | BindingFlags.NonPublic);
-        Assert.NotNull(reloadMethod);
-        reloadMethod!.Invoke(window, null);
+        await InvokeReloadAfterExternalChangeAsync(window);
 
         // Edit the profile's name exactly as a user typing after the reload would: set the
         // TextBox's Text, then raise the real KeyUp event ProfileNameInput's handler listens for.

--- a/tests/NovaTerminal.App.Tests/Core/SettingsWindowBackupSectionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/SettingsWindowBackupSectionTests.cs
@@ -602,6 +602,58 @@ public sealed class SettingsWindowBackupSectionTests
         Assert.Equal(new[] { "Imported snippet" }, SnippetRowNames(window));
     }
 
+    /// <summary>
+    /// Codex review (PR #364, P2): refreshing the Settings snippet panel is only half of what a
+    /// snippet change owes the app. <c>MainWindow.OpenSettings</c> subscribes
+    /// <c>DismissCommandAssistSurfaces</c> to <c>OnCommandAssistSnippetsChanged</c>, and the add,
+    /// edit and delete paths all raise it - the rows an open assist bubble or popup is showing are a
+    /// snapshot of a ranking pass, and nothing else invalidates them (see that method's own remarks,
+    /// written for the identical "Clear history" case).
+    ///
+    /// An import or restore is the most destructive snippet change there is: <c>BackupService</c>
+    /// replaces <c>snippets.json</c> wholesale in BOTH modes, so every snippet the user had can
+    /// vanish at once. Without this notification a popup left open behind the Settings dialog goes on
+    /// displaying - and accepting - snippets the import just deleted, until some later suggestion
+    /// refresh happens to rebuild it.
+    ///
+    /// Asserts on the event rather than on pane state because the event IS the seam MainWindow wires
+    /// to; a pane-level assertion would need a whole MainWindow and would still be testing this same
+    /// handoff one indirection later.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task ReloadAfterExternalChange_NotifiesTheHostThatSnippetsChanged()
+    {
+        // A bundle with no snippets at all: the import removes the local one outright, which is the
+        // case where stale rows in an open popup are actively wrong rather than merely out of date.
+        using var source = BackupTestTree.CreateEmpty();
+        source.WriteFile("settings.json", """{"FontSize":14,"ThemeName":"Default"}""");
+        source.WriteFile(Path.Combine("command-assist", "snippets.json"), "[]");
+        string bundle = Path.Combine(source.Root, "import.novabackup");
+        Assert.True(new BackupService(source.Root).Export(bundle).Success);
+
+        using var target = BackupTestTree.CreatePopulated();
+        var targetStore = new JsonSnippetStore(SnippetsPathIn(target));
+        await targetStore.UpsertAsync(NewSnippet("local-1", "Local snippet", "echo local"));
+
+        using var _ = OverrideAppDataRoot(target.Root);
+        var window = new NovaTerminal.SettingsWindow { CommandAssistSnippetStore = targetStore };
+
+        int notifications = 0;
+        window.OnCommandAssistSnippetsChanged += () => notifications++;
+
+        await InvokeReloadCommandAssistSnippetsAsync(window);
+        Assert.Equal(new[] { "Local snippet" }, SnippetRowNames(window));
+
+        var outcome = new BackupService(target.Root).Import(bundle, ImportMode.Replace);
+        Assert.True(outcome.Success, outcome.Message);
+
+        await InvokeReloadAfterExternalChangeAsync(window);
+
+        // The panel emptying is the precondition; the notification is the point.
+        Assert.Empty(SnippetRowNames(window));
+        Assert.Equal(1, notifications);
+    }
+
     private static string SnippetsPathIn(BackupTestTree tree)
         => Path.Combine(tree.Root, "command-assist", "snippets.json");
 
@@ -620,13 +672,19 @@ public sealed class SettingsWindowBackupSectionTests
     /// The names shown by the rows currently in <c>CommandAssistSnippetsPanel</c> — the first
     /// <see cref="TextBox"/> of each row, which <c>CreateCommandAssistSnippetRow</c> seeds with the
     /// snippet's name. Reading the built controls rather than the editor's list is the point: the bug
-    /// is precisely that the two can disagree.
+    /// is precisely that the two can disagree. The empty-list placeholder is not a row and is skipped.
     /// </summary>
     private static string[] SnippetRowNames(NovaTerminal.SettingsWindow window)
     {
         var panel = window.FindControl<StackPanel>("CommandAssistSnippetsPanel")!;
+
+        // FirstOrDefault, not First: an empty snippet list is a legitimate panel state, and
+        // PopulateCommandAssistSnippetsPanel renders it as a single explanatory TextBlock with no
+        // TextBox in it. Only children that actually carry an editor are snippet rows.
         return panel.Children
-            .Select(row => row.GetLogicalDescendants().OfType<TextBox>().First().Text ?? "")
+            .Select(row => row.GetLogicalDescendants().OfType<TextBox>().FirstOrDefault())
+            .Where(nameEditor => nameEditor != null)
+            .Select(nameEditor => nameEditor!.Text ?? "")
             .ToArray();
     }
 


### PR DESCRIPTION
## The bug

`ReloadSettingsAfterExternalChange` (added in #362) re-runs every `Populate*` the constructor calls, so an already-open Settings window reflects freshly imported or restored settings, themes, fonts, profiles, shortcuts and title-bar layout.

`PopulateCommandAssistSnippetsPanel` is the one populate path it could not reach that way. It is driven by `WireCommandAssistSnippetsRow`'s one-shot handler:

```csharp
Opened += async (_, _) => await ReloadCommandAssistSnippetsAsync();
```

…because the snippet store arrives by property assignment *after* the constructor has run. The reload runs on an **already-open** window and never reopens it, so `Opened` never refires. Importing or restoring a bundle carrying a different `command-assist/snippets.json` — which `BackupService` replaces wholesale in **both** Merge and Replace modes — left the visible rows describing the pre-import file until the window was closed and reopened. The user could then edit or delete against a list that no longer describes the file.

Noticed while fixing the sibling `PopulateFonts` gap in ad23d32; left out of scope there because it is a different (async, `Opened`-triggered) code path.

## The fix

`ReloadSettingsAfterExternalChange` → `ReloadSettingsAfterExternalChangeAsync`, with `await ReloadCommandAssistSnippetsAsync()` appended after all the synchronous repopulation.

Renaming rather than adding a second entry point keeps exactly one complete "configuration was replaced on disk" path, so a future caller cannot pick up the incomplete half — the same reasoning the existing doc comment gives for setting `ConfigurationReplacedExternally` inside the method rather than in the handlers.

The snippet reload runs **last**, so nothing that cannot fail on I/O is left pending at the first suspension point. Both the Import and Restore click handlers were already `async` and now await it, which also means the success status is shown only once the whole window — snippet rows included — agrees with disk.

Null-safety in the new path is already handled: `TryGetSnippetEditor` returns null when `CommandAssistSnippetStore` is unset, `PopulateCommandAssistSnippetsPanel` then renders "Snippets are not available in this window.", and `ShowRemoteShellIntegrationStatus` no-ops on a null `TextBlock`. In that case the whole method also completes synchronously, which is why the click-driven `RestoreSelected_ThenSave_...` test still works unchanged.

Five reflection call sites (four in `SettingsWindowBackupSectionTests`, one in `MainWindowBackupPaletteTests`) now await the returned `Task`; doc-comment references in both windows updated.

## Test

`Import_BringingNewSnippets_RefreshesTheAlreadyOpenSnippetsPanel` injects a real `JsonSnippetStore` over the target tree, seeds the panel the way the `Opened` handler would, imports a bundle with different snippets, drives the reload, and asserts on the `TextBox` contents of the rows actually built in `CommandAssistSnippetsPanel` — not on the editor's list, since the bug is precisely that the two disagree.

Unlike the theme/font siblings it cannot assert at Save: snippets do not live in `settings.json` and Save never writes them, so the stale rows themselves are the damage.

RED/GREEN, following this branch's sabotage-verification convention:

- **RED** against the pre-fix synchronous method — failed on the panel assertion, `Expected: "Imported snippet" / Actual: "Local snippet"`. The pre-import assertion passed, so the harness itself was sound.
- **GREEN** after the fix; all 19 tests in the file pass.
- **Sabotage** — replacing the one added `await ReloadCommandAssistSnippetsAsync()` with `Task.CompletedTask` reproduces exactly that failure, and only in that one test (18 others still green).

## Verification

Built with `scripts/build.sh` throughout, never raw `dotnet build`.

- **1476 tests** across the SettingsWindow / MainWindow / Backup / Snippet / CommandAssist filters: **1458 passed, 13 skipped, 5 failed**.
- The 5 failures are all `MainWindowTitleBarTests` and **pre-existing**, not caused by this change — confirmed by reverting all four files to `HEAD`, rebuilding, and running the identical filter: same 5 failures, 328 tests vs 329 with the new test. They are the known "window tests load the developer's live `TerminalSettings`" class of failure.
- `dotnet format whitespace --verify-no-changes --no-restore` clean on both projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
