### PR TITLE
fix(tests): stop MainWindow tests from reading the developer's live settings.json

### DIFF
--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -2531,7 +2531,7 @@ namespace NovaTerminal
             _commandAssistServices = services.CommandAssist;
             InitializeComponent();
             _startup.Checkpoint("MainWindow.AfterInitializeComponent");
-            _settings = TerminalSettings.Load();
+            _settings = services.Settings ?? TerminalSettings.Load();
             _startup.Checkpoint("MainWindow.AfterSettingsLoad");
             _commandPaletteUsageStore = new CommandPaletteUsageStore(AppPaths.CommandPaletteUsageFilePath);
             _commandPaletteUsage = new Dictionary<string, CommandPaletteUsageEntry>(_commandPaletteUsageStore.Load(), StringComparer.OrdinalIgnoreCase);

--- a/src/NovaTerminal.App/Shell/AppServiceBundle.cs
+++ b/src/NovaTerminal.App/Shell/AppServiceBundle.cs
@@ -1,5 +1,12 @@
 namespace NovaTerminal.Shell;
 
+/// <summary>
+/// <paramref name="Settings"/> is null in production (MainWindow loads settings.json from disk).
+/// A non-null instance bypasses that load entirely: BuildForDesigner supplies fresh defaults so
+/// designer previews and test-created windows never read the developer's live settings file,
+/// whose contents (e.g. TabStripOrientation) would otherwise leak into layout assertions.
+/// </summary>
 public sealed record AppServiceBundle(
     StartupOrchestrator Startup,
-    CommandAssistServices CommandAssist);
+    CommandAssistServices CommandAssist,
+    TerminalSettings? Settings = null);

--- a/src/NovaTerminal.App/Shell/AppServices.cs
+++ b/src/NovaTerminal.App/Shell/AppServices.cs
@@ -27,6 +27,9 @@ public static class AppServices
         var tracker = StartupPerformanceTracker.Current ?? new StartupPerformanceTracker();
         var coordinator = new StartupRestoreCoordinator(action => action());
         var orchestrator = new StartupOrchestrator(tracker, coordinator);
-        return new AppServiceBundle(orchestrator, CommandAssistServices.CreateDefault());
+        // Fresh default settings, never TerminalSettings.Load(): designer previews and the tests
+        // that build windows through this path must not depend on whatever settings.json the
+        // developer's machine happens to carry (the #357 settings-bleed pathology).
+        return new AppServiceBundle(orchestrator, CommandAssistServices.CreateDefault(), new TerminalSettings());
     }
 }

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowStartupTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowStartupTests.cs
@@ -24,6 +24,45 @@ public sealed class MainWindowStartupTests
         Assert.NotNull(window);
     }
 
+    /// <summary>
+    /// Guards the settings-bleed pathology (#357's sibling): factory-created windows must take the
+    /// deterministic defaults BuildForDesigner puts on AppServiceBundle.Settings, never whatever
+    /// settings.json the machine happens to carry. Five MainWindowTitleBarTests failed on any dev
+    /// box whose live file said TabStripOrientation=Vertical while CI (no file at all) stayed
+    /// green - a revert of the seam only reproduces on such a machine, so this writes the
+    /// poisonous file explicitly and fails everywhere.
+    /// </summary>
+    [AvaloniaFact]
+    public void MainWindow_IgnoresOnDiskSettings_UsesBundleDefaults()
+    {
+        string tempRoot = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), $"novaterm_settings_bleed_guard_{System.Guid.NewGuid():N}");
+        string? previousRoot = System.Environment.GetEnvironmentVariable("NOVATERM_APPDATA_ROOT");
+        System.IO.Directory.CreateDirectory(tempRoot);
+
+        try
+        {
+            System.Environment.SetEnvironmentVariable("NOVATERM_APPDATA_ROOT", tempRoot);
+            System.IO.File.WriteAllText(
+                System.IO.Path.Combine(tempRoot, "settings.json"),
+                """{"TabStripOrientation":"Vertical","FontSize":99}""");
+
+            var window = TestMainWindowFactory.Create();
+
+            var settings = (TerminalSettings)typeof(NovaTerminal.MainWindow)
+                .GetField("_settings", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(window)!;
+
+            Assert.Equal("Horizontal", settings.TabStripOrientation);
+            Assert.Equal(14, settings.FontSize);
+        }
+        finally
+        {
+            System.Environment.SetEnvironmentVariable("NOVATERM_APPDATA_ROOT", previousRoot);
+            try { System.IO.Directory.Delete(tempRoot, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     [AvaloniaFact]
     public void MainWindow_LoadsWindowIconOnlyAfterDeferredHookRuns()
     {

--- a/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
@@ -383,10 +383,10 @@ public sealed class VerticalTabStripTests
         var tab = tabs.Items.Cast<TabItem>().First();
         // Clear it so the upcoming mode switch is the only possible source of "dirty" below.
         window.SetTabPreviewDirtyForTest(tab, false);
-        // Window startup itself may already have applied a vertical pass and recomputed the
-        // preview (TestMainWindowFactory loads the developer's real settings.json, which can be
-        // vertical) - clear the 250ms throttle window left over from that so the switch below
-        // isn't itself throttled into leaving the dirty flag set.
+        // Window startup's own initial tab-visuals pass may have armed the 250ms preview
+        // throttle - wait it out so the mode switch below isn't itself throttled into
+        // leaving the dirty flag set. (Startup uses deterministic default settings via
+        // AppServiceBundle.Settings, so that pass is always horizontal now.)
         System.Threading.Thread.Sleep(300);
 
         settings.TabStripOrientation = "Vertical";


### PR DESCRIPTION
## Problem

Five `MainWindowTitleBarTests` fail deterministically on pristine `origin/main` on any machine whose live `%LOCALAPPDATA%\NovaTerminal\settings.json` says `TabStripOrientation: "Vertical"` (possible since #356):

- `RebuildTitleBar_ConsecutiveRebuildsBeforeLayoutSettles_ConvergeWithoutAccumulatingOrLooping`
- `RebuildTitleBar_PinnedCountIncreases_TabHeaderMarginReflectsNewBarWidthAfterLayout`
- `OnRecordingStateChanged_RecordAutoSurfaces_AlsoRecomputesTabHeaderMargin`
- `UpdateTabOverflowIndicator_TabsClipped_TooltipComposesHiddenCountWithResolvedShortcut`
- `UpdateTabOverflowIndicator_TabsClippedWithUserShortcutOverride_TooltipUsesTheOverride`

## Root cause

`MainWindow`'s ctor calls `TerminalSettings.Load()`, so every `TestMainWindowFactory` window inherits whatever the developer's machine has on disk. The vertical tab strip zeroes the tab-header margin and skips overflow math entirely, breaking exactly the five horizontal-layout assertions (the other 16 tests in the file don't touch margins/clipping and pass either way). CI never catches it because CI has no settings file — `Load()` yields defaults. Same settings-bleed pathology as #357 (fixed for the agent registry in #358).

Verified empirically before fixing: baseline run fails the exact 5; the same run with `NOVATERM_APPDATA_ROOT` pointed at an empty directory passes 21/21.

## Fix

Composition-root seam, mirroring the #358 pattern:

- `AppServiceBundle` gains an optional `TerminalSettings? Settings` (null in production).
- `MainWindow`'s ctor uses `services.Settings ?? TerminalSettings.Load()`.
- `AppServices.BuildForDesigner()` — used only by tests and the XAML previewer; production goes through `Build()` — supplies `new TerminalSettings()`, so every test-created window sees exactly the defaults CI sees, on every machine. The post-import reload path inside `OpenSettings` still reads disk, unchanged.

The ctor's `MigrateLegacyProfiles` save can't fire with fresh defaults (no legacy SSH profiles), so tests can no longer write to the real settings file through that path either.

## Regression guard

The five fixed tests only fail on a machine whose file is Vertical, so a seam revert would stay green on CI. New `MainWindow_IgnoresOnDiskSettings_UsesBundleDefaults` writes a poisoned settings.json (`Vertical`, `FontSize: 99`) into a redirected root and asserts a factory window still gets defaults — verified to fail (`Expected: "Horizontal", Actual: "Vertical"`) with the ctor line reverted, and to pass with the fix.

## Verification

- `MainWindowTitleBarTests`: 21/21 pass post-fix with the real Vertical settings file in place, no env redirect.
- All 14 window-creating / bundle-touching test classes (`MainWindowStartupTests`, `MainWindowBackupPaletteTests`, `VerticalTabStripTests`, `AgentObserveIndicatorTests`, `AgentIndicatorTabRollupTests`, `AgentWindowVisibilityTests`, `MainWindowPaneWiringTests`, `MainWindowShellExitTests`, `MainWindowTabLookupTests`, `PaneParserWiringTests`, `SettingsWindowTitleBarShortcutRefreshTests`, `MainWindowCustomizeTitleBarSettingsTargetTests`, `AppServicesTests`, plus the title bar suite): 130/130 + 19/19 + 2/2 across runs, zero failures.
- `MainWindowBackupPaletteTests.ImportReplace_...` (the one test that writes settings.json and creates a window) passes: its assertion path adopts settings from `SettingsWindow`'s own disk reload, which this seam does not touch.
- Two local runs hit the known #81-family 5-min testhost hang flake mid-run (also reproduced once on pre-fix code under identical conditions, so unrelated to this change); every test that executed passed in all runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)