### PR TITLE
chore(release): bump version to 0.6.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
-    <Version>0.5.1</Version>
-    <AssemblyVersion>0.5.1.0</AssemblyVersion>
-    <FileVersion>0.5.1.0</FileVersion>
-    <InformationalVersion>0.5.1</InformationalVersion>
+    <Version>0.6.0</Version>
+    <AssemblyVersion>0.6.0.0</AssemblyVersion>
+    <FileVersion>0.6.0.0</FileVersion>
+    <InformationalVersion>0.6.0</InformationalVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/docs/CONFIG_STORAGE_CONTRACT.md
+++ b/docs/CONFIG_STORAGE_CONTRACT.md
@@ -95,6 +95,7 @@ All paths are properties of
 | `ssh\native_known_hosts.json` | native-backend known hosts |
 | `command-assist\history.jsonl` | append-only command history |
 | `command-assist\snippets.json` | saved snippets |
+| `backups\` | automatic configuration snapshots written by the backup subsystem |
 | `recordings\` | terminal recordings |
 | `logs\` | `debug.log`, `startup_error.txt`, `workspace_audit.log`, … |
 
@@ -118,7 +119,13 @@ sometimes contain secrets, and recordings capture arbitrary terminal output. Any
 to be shareable should exclude them or say plainly that it does not. `logs\` is also bulk and
 noise — usually not worth carrying.
 
-**Anything written for recovery belongs under the config root.** Automatic snapshots, exported archives and rollback state must live under `AppPaths.RootDirectory` (or a user-chosen path), never under the install root — the install root is deleted on uninstall, which would take the recovery data with it.
+**Anything written for recovery belongs under the config root.** Automatic snapshots,
+exported archives and rollback state must live under `AppPaths.RootDirectory` (or a
+user-chosen path), never under the install root, which uninstall deletes. `backups\` is
+the concrete case: those snapshots are only safe because the install root is a separate
+directory. Under a packId matching the app name they would sit inside the folder uninstall
+deletes, so the rollback safety net would be destroyed by the exact event you would want to
+roll back from.
 
 **Expect files to be locked on Windows.** A running instance holds `logs\debug.log` open, so a
 naive recursive copy of the config root fails partway. Either exclude `logs\`, or require the


### PR DESCRIPTION
`0.5.1` was set when the release was two Windows bugfixes. Since then main has gained a complete **configuration backup and restore subsystem** (#362) and a **macOS Velopack installer** with its own update feed (#363). Those are features, so this is a minor release, not a patch.

Either number works for the updater — both sort above 0.5.0 — but a patch version tells users "bugfixes only", and nobody would go looking for a macOS installer or a backup feature behind it.

Also records `backups\` in the configuration storage contract. #362 added `AppPaths.BackupsDirectory` and the inventory table didn't list it, so the doc went stale within a day of being written. The recovery-location constraint now names it as the concrete case: those snapshots are only safe *because* the install root is a separate directory — under a packId matching the app name they'd have sat inside the folder uninstall deletes, and the rollback safety net would be destroyed by the exact event you'd want to roll back from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
