### PR TITLE
docs: refresh the README and landing site for 0.5.0 and 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,11 +110,39 @@ For build steps, jump to [Build & test](#build--test) below.
 ### UI
 
 - Tabs and split panes
+- Vertical tab sidebar (`Ctrl+Shift+L`) with per-tab status and a live output preview
 - Command palette
 - Search overlay
 - Profiles (local & SSH)
 - Themes and fonts
 - Live settings (no restart)
+
+### Command Assist
+
+Suggestions anchored to what the shell actually reports, rather than to a guess
+about where the prompt ends — built on OSC 133 shell-integration marks.
+
+- Reads the live command line from the terminal grid, not a shadow copy
+- History search, snippet management, and a tldr-derived command catalogue
+- Fix mode proposes a correction from a failed command's own output
+- Passive suggestion bubble with rebindable shortcuts
+- One-line shell-integration installer for remote hosts, with mark detection over SSH
+- Still captures commands in sessions that emit no marks at all
+
+### Configuration backup & restore
+
+- Export settings, themes, connections, workspaces, policy and snippets to a
+  single portable `.novabackup` file, and import it on another machine
+- Six independently selectable categories; import merges or replaces
+- Automatic background snapshots, deduplicated by content hash and retention-capped
+- A snapshot is taken before every import and restore, so both are reversible
+- Available from **Settings → Backup & Restore**, the command palette, and the CLI
+  (`backup export|import|list|restore`); agents get read-only export and list MCP tools
+
+> Connection passwords are **not** included in a bundle. They live in the OS
+> credential store, not in the config folder, so imported SSH profiles need their
+> passwords re-entered on first connect. See
+> [`docs/CONFIG_STORAGE_CONTRACT.md`](docs/CONFIG_STORAGE_CONTRACT.md).
 
 ### Graphics & inline images
 

--- a/site/src/components/Features.astro
+++ b/site/src/components/Features.astro
@@ -19,11 +19,38 @@ const groups = [
     body: 'A modern UI for people who live in the terminal: tabs, splits, command palette, search, profiles, and live settings — no restart required.',
     items: [
       'Tabs, split panes, and workspace templates',
+      'Vertical tab sidebar with per-tab status and output preview',
       'Command palette (Ctrl+Shift+P) and tab list',
       'Search overlay with regex support',
       'Profiles for local and SSH sessions',
       'Themes, fonts, and font sizing',
       'Live settings — no restart required',
+    ],
+  },
+  {
+    title: 'Command Assist',
+    eyebrow: 'Assistance',
+    body: 'Suggestions anchored to what the shell actually reports, not to a guess about where your prompt ends — built on OSC 133 shell-integration marks, with a one-line installer for remote hosts.',
+    items: [
+      'Reads the live command line from the grid, not a shadow copy',
+      'History search, snippets, and a tldr-derived command catalogue',
+      'Fix mode proposes a correction from a failed command’s own output',
+      'Passive suggestion bubble with rebindable shortcuts',
+      'One-line shell-integration installer for remote hosts over SSH',
+      'Works in sessions with no marks at all',
+    ],
+  },
+  {
+    title: 'Backup & restore',
+    eyebrow: 'Your config',
+    body: 'Move your setup between machines, or roll it back after something goes wrong — settings, themes, connections, workspaces, policy and snippets in one portable file.',
+    items: [
+      'Export and import a single portable .novabackup file',
+      'Six independently selectable categories',
+      'Merge into an existing setup, or replace it outright',
+      'Automatic background snapshots, deduplicated by content hash',
+      'A snapshot is taken before every import and restore',
+      'Settings page, command palette, and CLI verbs for scripted setups',
     ],
   },
   {

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -1,30 +1,41 @@
 ---
 // Release asset names follow the workflow in `.github/workflows/release.yml`:
-// `NovaTerminal-{rid}-{tag}.zip` (e.g. `NovaTerminal-linux-x64-v0.3.0.zip`).
-// The Windows winget package id lives in
+// installers are `NovaTerminal-Setup-{rid}-{tag}.{exe,pkg}`, portable bundles are
+// `NovaTerminal-{rid}-{tag}.zip`. The Windows winget package id lives in
 // `packaging/winget/0.3.0/benyblack.NovaTerminal.yaml`.
+//
+// Ordered Windows, macOS, Linux: the two platforms with an installer come first,
+// because that is the path most people should take.
 const releases = [
   {
     platform: 'Windows',
     arch: 'x64',
+    installer: 'NovaTerminal-Setup-win-x64-<tag>.exe',
+    installerNote:
+      'Per-user install — no admin prompt. Adds Start Menu and Desktop shortcuts, and updates itself in the background.',
     asset: 'NovaTerminal-win-x64-<tag>.zip',
     cmd: 'winget install benyblack.NovaTerminal',
   },
   {
-    platform: 'Linux',
-    arch: 'x64',
-    asset: 'NovaTerminal-linux-x64-<tag>.zip',
-    cmd:
-      'unzip NovaTerminal-linux-x64-<tag>.zip\n' +
-      'chmod +x NovaTerminal && ./NovaTerminal',
-  },
-  {
     platform: 'macOS',
     arch: 'arm64',
+    installer: 'NovaTerminal-Setup-osx-arm64-<tag>.pkg',
+    installerNote:
+      'Installs a proper NovaTerminal.app bundle, and updates itself in the background.',
     asset: 'NovaTerminal-osx-arm64-<tag>.zip',
     cmd:
       'unzip NovaTerminal-osx-arm64-<tag>.zip\n' +
       'open NovaTerminal.app',
+  },
+  {
+    platform: 'Linux',
+    arch: 'x64',
+    installer: null,
+    installerNote: null,
+    asset: 'NovaTerminal-linux-x64-<tag>.zip',
+    cmd:
+      'unzip NovaTerminal-linux-x64-<tag>.zip\n' +
+      'chmod +x NovaTerminal && ./NovaTerminal',
   },
 ];
 
@@ -72,10 +83,25 @@ const buildSteps = [
         Pick a build, get to work.
       </h2>
       <p class="lede mt-4 max-w-2xl">
-        GitHub release assets ship as Native AOT bundles for
+        Windows and macOS have one-click installers that keep themselves up to
+        date — a new version downloads in the background and applies on your next
+        restart. Every platform also ships a portable Native AOT bundle for
         <code class="rounded bg-ink-800/60 px-1.5 py-0.5 text-nova-200">win-x64</code>,
         <code class="rounded bg-ink-800/60 px-1.5 py-0.5 text-nova-200">linux-x64</code>, and
-        <code class="rounded bg-ink-800/60 px-1.5 py-0.5 text-nova-200">osx-arm64</code>. Every release runs the gating unit-test lane on all three OSes before any bundle is published. Replace <code class="rounded bg-ink-800/60 px-1.5 py-0.5 text-nova-200">&lt;tag&gt;</code> with the version you downloaded.
+        <code class="rounded bg-ink-800/60 px-1.5 py-0.5 text-nova-200">osx-arm64</code>; portable builds have no updater. Every release runs the gating unit-test lane on all three OSes before any bundle is published. Replace <code class="rounded bg-ink-800/60 px-1.5 py-0.5 text-nova-200">&lt;tag&gt;</code> with the version you downloaded.
+      </p>
+      <p class="mt-4 max-w-2xl text-sm text-ink-400">
+        Installers are not code-signed yet, so Windows SmartScreen and macOS
+        Gatekeeper will warn on first run — see
+        {' '}
+        <a
+          href="https://github.com/benyblack/NovaTerminal/issues/91"
+          rel="noopener"
+          class="text-nova-300"
+        >
+          issue #91
+        </a>
+        .
       </p>
     </div>
 
@@ -101,7 +127,23 @@ const buildSteps = [
               </a>
               .
             </p>
-            <p class="mt-2 font-mono text-[11px] text-ink-400">
+
+            {rel.installer && (
+              <div class="mt-4">
+                <p class="text-xs font-semibold uppercase tracking-wider text-nova-300">
+                  Installer — recommended
+                </p>
+                <p class="mt-1 font-mono text-[11px] text-ink-400">
+                  {rel.installer}
+                </p>
+                <p class="mt-1.5 text-sm text-ink-300">{rel.installerNote}</p>
+              </div>
+            )}
+
+            <p class="mt-4 text-xs font-semibold uppercase tracking-wider text-ink-400">
+              {rel.installer ? 'Portable — no updater' : 'Portable'}
+            </p>
+            <p class="mt-1 font-mono text-[11px] text-ink-400">
               {rel.asset}
             </p>
             <pre class="code-block mt-3 text-xs leading-relaxed"><code>{rel.cmd}</code></pre>


### PR DESCRIPTION
Both had fallen behind what actually ships. The landing site was the worse of the two: **its install section offered only portable zips**, so it told people to download a zip on the two platforms that now have real installers.

## Site

- **Install leads with the installers** — `NovaTerminal-Setup-win-x64-<tag>.exe` and `NovaTerminal-Setup-osx-arm64-<tag>.pkg` — and says they keep themselves up to date. The portable zip stays, explicitly labelled *"Portable — no updater"*. Linux correctly shows no installer.
- **Reordered Windows, macOS, Linux**, so the platforms with an installer come first.
- **Names the code-signing gap** and links #91. Otherwise a SmartScreen or Gatekeeper warning reads as "this download is suspicious" rather than "this is expected".
- **Adds Command Assist and Backup & restore** feature groups, and the vertical tab sidebar to the UI group.

## README

- **Adds a Command Assist section.** It was missing entirely, despite being ~24 commits of 0.5.0.
- **Adds Configuration backup & restore**, including the callout that bundles carry **no connection passwords** — imported SSH profiles look complete but can't authenticate until they're re-entered. That's the most likely source of confused bug reports, so it's stated rather than left to be discovered.
- **Adds the vertical tab sidebar** and its `Ctrl+Shift+L` binding to the UI list.

## Verification

Built the site and grepped the rendered `dist/index.html` rather than trusting the build's exit code:

| Check | Result |
|---|---|
| Both installer asset names present | ✓ |
| `Installer — recommended` blocks | exactly 2 (Windows, macOS — none for Linux, so the conditional works) |
| `Portable — no updater` labels | 2 |
| Command Assist / novabackup / vertical sidebar / SmartScreen copy | ✓ |

Docs and site only — no app code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
