### PR TITLE
feat(app): wire inline image decoding for sixel, iTerm2, and Kitty

### DIFF
--- a/docs/IMAGE_PROTOCOL_SUPPORT.md
+++ b/docs/IMAGE_PROTOCOL_SUPPORT.md
@@ -21,5 +21,6 @@ This document defines NovaTerminal image protocol behavior across platforms.
 
 ## Notes
 
+- Decoding is implemented by `NovaTerminal.Rendering.SkiaImageDecoder` (`SixelDecoder` for DCS/OSC 1339 sixel payloads, `SKBitmap.Decode` for Kitty/iTerm2 image bytes); decoded bitmaps render in the grid via `TerminalDrawOperation`'s image pass.
 - The fallback policy is intentionally conservative to avoid false advertising Kitty support through ConPTY.
 - If a future backend bypasses ConPTY filtering, this policy can be relaxed.

--- a/docs/vt_coverage_matrix.md
+++ b/docs/vt_coverage_matrix.md
@@ -166,7 +166,7 @@ It is designed to be:
 
 | Feature | Notes | Status | Evidence | Ownership | Known deviations |
 |---|---|---:|---|---|---|
-| SIXEL decode/render | | ⚠ Partial | Manual | Decoder+Renderer | |
+| SIXEL decode/render | Wired via `NovaTerminal.Rendering.SkiaImageDecoder` | ✅ Supported | Unit: `tests/NovaTerminal.Rendering.Tests/SixelDecoderTests.cs`, `tests/NovaTerminal.Rendering.Tests/SkiaImageDecoderTests.cs` | Decoder+Renderer | |
 | SIXEL scrolling behavior | | ❌ Not supported | — | Buffer+Renderer | |
 
 ---

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -2811,6 +2811,10 @@ namespace NovaTerminal.Controls
 
             Parser = new AnsiParser(Buffer);
 
+            // Inline images (sixel / iTerm2 / Kitty) decode to the SKBitmap handles the draw
+            // operation renders; without a decoder those parser paths silently no-op.
+            Parser.ImageDecoder = new NovaTerminal.Rendering.SkiaImageDecoder();
+
             // A device reply is text on the PTY that the keyboard path never produced: DA1, a DSR
             // cursor report, an answerback. Nothing here can promise the shell's line editor was not
             // reading when the query arrived, so history capture stands down for the rest of the

--- a/src/NovaTerminal.App/Resources/vt-conformance-report.json
+++ b/src/NovaTerminal.App/Resources/vt-conformance-report.json
@@ -1,16 +1,16 @@
 {
   "schemaVersion": 1,
   "matrixPath": "docs/vt_coverage_matrix.md",
-  "matrixSha256": "bcde51bbb2b60aa2055a21b8a66bc7044dcc65fd5c5e791eb5580193212bbc00",
+  "matrixSha256": "2459dbd6100c91f121e856e0c0c54247eeca002a0a1ce4399c1d27dbf56d17f3",
   "summary": {
     "totalRows": 58,
-    "supportedCount": 18,
-    "partialCount": 34,
+    "supportedCount": 19,
+    "partialCount": 33,
     "experimentalCount": 1,
     "notSupportedCount": 4,
     "wontSupportCount": 1,
-    "rowsWithLinkedEvidence": 34,
-    "supportedRowsWithLinkedEvidence": 18,
+    "rowsWithLinkedEvidence": 35,
+    "supportedRowsWithLinkedEvidence": 19,
     "errorCount": 0,
     "warningCount": 0
   },
@@ -1111,15 +1111,24 @@
     {
       "section": "10) SIXEL",
       "feature": "SIXEL decode/render",
-      "status": "\u26A0 Partial",
-      "specOrNotes": "",
-      "evidenceText": "Manual",
+      "status": "\u2705 Supported",
+      "specOrNotes": "Wired via \u0060NovaTerminal.Rendering.SkiaImageDecoder\u0060",
+      "evidenceText": "Unit: \u0060tests/NovaTerminal.Rendering.Tests/SixelDecoderTests.cs\u0060, \u0060tests/NovaTerminal.Rendering.Tests/SkiaImageDecoderTests.cs\u0060",
       "evidenceKinds": [
-        "manual"
+        "unit"
       ],
-      "evidenceLinks": [],
-      "hasAutomatedEvidenceSignal": false,
-      "hasLinkedEvidence": false,
+      "evidenceLinks": [
+        {
+          "path": "tests/NovaTerminal.Rendering.Tests/SixelDecoderTests.cs",
+          "exists": true
+        },
+        {
+          "path": "tests/NovaTerminal.Rendering.Tests/SkiaImageDecoderTests.cs",
+          "exists": true
+        }
+      ],
+      "hasAutomatedEvidenceSignal": true,
+      "hasLinkedEvidence": true,
       "ownership": "Decoder\u002BRenderer",
       "knownDeviations": "",
       "sourceLine": 169

--- a/src/NovaTerminal.App/UI/Replay/ReplayWindow.axaml.cs
+++ b/src/NovaTerminal.App/UI/Replay/ReplayWindow.axaml.cs
@@ -63,6 +63,8 @@ namespace NovaTerminal.UI.Replay
 
             _buffer = new TerminalBuffer(80, 24); // Init with default
             _parser = new AnsiParser(_buffer);
+            // Replays of sessions that drew inline images must render the same way live panes do.
+            _parser.ImageDecoder = new NovaTerminal.Rendering.SkiaImageDecoder();
             var termView = this.FindControl<TerminalView>("TermView");
             if (termView != null)
             {

--- a/src/NovaTerminal.Rendering/SkiaImageDecoder.cs
+++ b/src/NovaTerminal.Rendering/SkiaImageDecoder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using NovaTerminal.VT;
 using SkiaSharp;
 
@@ -12,6 +13,15 @@ namespace NovaTerminal.Rendering
     /// </summary>
     public sealed class SkiaImageDecoder : IImageDecoder
     {
+        /// <summary>
+        /// Largest declared width/height (in pixels) this decoder will materialize, applied
+        /// from the container header BEFORE any pixels are decoded. Mirrors AnsiParser's
+        /// post-decode guard: without a pre-decode bound, a small compressed payload can
+        /// declare enormous dimensions and force the full allocation during decode, before
+        /// the parser ever gets the chance to reject it.
+        /// </summary>
+        public int MaxPixelDimension { get; set; } = 2000;
+
         public object? DecodeImageBytes(byte[] imageData, out int pixelWidth, out int pixelHeight)
         {
             pixelWidth = 0;
@@ -28,7 +38,21 @@ namespace NovaTerminal.Rendering
             SKBitmap? bitmap;
             try
             {
-                bitmap = SKBitmap.Decode(imageData);
+                using var stream = new MemoryStream(imageData);
+                using SKCodec? codec = SKCodec.Create(stream);
+                if (codec == null)
+                {
+                    return null;
+                }
+
+                // Header check before materialization: rejecting here costs bytes, not the
+                // width x height x 4 allocation the full decode would make.
+                if (codec.Info.Width > MaxPixelDimension || codec.Info.Height > MaxPixelDimension)
+                {
+                    return null;
+                }
+
+                bitmap = SKBitmap.Decode(codec);
             }
             catch (Exception)
             {

--- a/src/NovaTerminal.Rendering/SkiaImageDecoder.cs
+++ b/src/NovaTerminal.Rendering/SkiaImageDecoder.cs
@@ -1,0 +1,69 @@
+using System;
+using NovaTerminal.VT;
+using SkiaSharp;
+
+namespace NovaTerminal.Rendering
+{
+    /// <summary>
+    /// Decodes inline image payloads (DCS sixel bodies, Kitty/iTerm2 image bytes) into the
+    /// bitmap handles the terminal draws. The draw operation pattern-matches the handle as
+    /// <see cref="SKBitmap"/> exactly, so an <see cref="IImageDecoder"/> implementation is
+    /// only reachable to the renderer when it produces that type.
+    /// </summary>
+    public sealed class SkiaImageDecoder : IImageDecoder
+    {
+        public object? DecodeImageBytes(byte[] imageData, out int pixelWidth, out int pixelHeight)
+        {
+            pixelWidth = 0;
+            pixelHeight = 0;
+
+            if (imageData == null || imageData.Length == 0)
+            {
+                return null;
+            }
+
+            // Sniffs the container (PNG/JPEG/WebP/...). Undecodable data must surface as a
+            // decode failure (null), never an exception — the payload is remote-controlled
+            // input handed over mid-parse.
+            SKBitmap? bitmap;
+            try
+            {
+                bitmap = SKBitmap.Decode(imageData);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+
+            if (bitmap == null)
+            {
+                return null;
+            }
+
+            pixelWidth = bitmap.Width;
+            pixelHeight = bitmap.Height;
+            return bitmap;
+        }
+
+        public object? DecodeSixel(string sixelData, out int pixelWidth, out int pixelHeight)
+        {
+            pixelWidth = 0;
+            pixelHeight = 0;
+
+            if (string.IsNullOrEmpty(sixelData))
+            {
+                return null;
+            }
+
+            SKBitmap? bitmap = new SixelDecoder().Decode(sixelData);
+            if (bitmap == null)
+            {
+                return null;
+            }
+
+            pixelWidth = bitmap.Width;
+            pixelHeight = bitmap.Height;
+            return bitmap;
+        }
+    }
+}

--- a/tests/NovaTerminal.App.Tests/Controls/PaneParserWiringTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneParserWiringTests.cs
@@ -63,6 +63,26 @@ public class PaneParserWiringTests
             + "per reconnect (#102). Either restore the fresh parser, or add a matching -= for each.");
     }
 
+    /// <summary>
+    /// The inline image decoder must ride along with every fresh parser: without it the
+    /// sixel/iTerm2/Kitty paths in <see cref="AnsiParser"/> silently no-op, so a reconnect
+    /// that forgot this line would drop image support with no error anywhere.
+    /// </summary>
+    [AvaloniaFact]
+    public void CreateAndWireParser_WiresTheInlineImageDecoder()
+    {
+        using var pane = new TerminalPane();
+
+        pane.CreateAndWireParser();
+
+        Assert.NotNull(pane.Parser);
+        Assert.IsType<NovaTerminal.Rendering.SkiaImageDecoder>(pane.Parser!.ImageDecoder);
+
+        // And after a reconnect, which replaces the parser wholesale.
+        pane.CreateAndWireParser();
+        Assert.IsType<NovaTerminal.Rendering.SkiaImageDecoder>(pane.Parser!.ImageDecoder);
+    }
+
     [AvaloniaFact]
     public void RewiringTheParser_LeavesExactlyOneHandlerPerHook()
     {

--- a/tests/NovaTerminal.Rendering.Tests/SkiaImageDecoderTests.cs
+++ b/tests/NovaTerminal.Rendering.Tests/SkiaImageDecoderTests.cs
@@ -90,6 +90,32 @@ public class SkiaImageDecoderTests
         Assert.Equal(0, height);
     }
 
+    /// <summary>
+    /// The dimension bound must fire from the container header BEFORE pixels are
+    /// materialized: a compressed payload declaring huge dimensions would otherwise force
+    /// the full decode allocation before any post-decode guard could reject it.
+    /// </summary>
+    [Fact]
+    public void DecodeImageBytes_DimensionsOverBound_RejectedBeforeMaterialization()
+    {
+        Assert.SkipUnless(SkiaAvailable, "SkiaSharp native library not available on this platform.");
+
+        byte[] png;
+        var source = new SKBitmap(3, 5);
+        using (var image = SKImage.FromBitmap(source))
+        using (var data = image.Encode(SKEncodedImageFormat.Png, 100))
+        {
+            png = data.ToArray();
+        }
+
+        var decoder = new SkiaImageDecoder { MaxPixelDimension = 1 };
+        var handle = decoder.DecodeImageBytes(png, out int width, out int height);
+
+        Assert.Null(handle);
+        Assert.Equal(0, width);
+        Assert.Equal(0, height);
+    }
+
     [Fact]
     public void DecodeImageBytes_EmptyBytes_ReturnsNull()
     {

--- a/tests/NovaTerminal.Rendering.Tests/SkiaImageDecoderTests.cs
+++ b/tests/NovaTerminal.Rendering.Tests/SkiaImageDecoderTests.cs
@@ -1,0 +1,132 @@
+using System;
+using NovaTerminal.Rendering;
+using NovaTerminal.VT;
+using SkiaSharp;
+using Xunit;
+
+namespace NovaTerminal.Rendering.Tests;
+
+public class SkiaImageDecoderTests
+{
+    // Decoding renders through the SkiaSharp native library. Same convention as
+    // SixelDecoderTests: present on Windows CI / dev machines, absent on the Linux
+    // gating runner — skip there rather than fail.
+    private static readonly bool SkiaAvailable = CheckSkiaAvailable();
+
+    private static bool CheckSkiaAvailable()
+    {
+        try
+        {
+            using var surface = SKSurface.Create(new SKImageInfo(1, 1, SKColorType.Rgba8888));
+            return surface != null;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    [Fact]
+    public void DecodeSixel_MinimalPayload_ReturnsBitmapWithPixelDimensions()
+    {
+        Assert.SkipUnless(SkiaAvailable, "SkiaSharp native library not available on this platform.");
+
+        // One 6-pixel band, one column wide (same payload as SixelDecoderTests).
+        var handle = new SkiaImageDecoder().DecodeSixel("0;0;0q#1;2;100;0;0#1~", out int width, out int height);
+
+        var bitmap = Assert.IsType<SKBitmap>(handle);
+        Assert.Equal(bitmap.Width, width);
+        Assert.Equal(bitmap.Height, height);
+        Assert.True(width > 0);
+        Assert.True(height > 0);
+    }
+
+    [Theory]
+    [InlineData("1;2;3")]   // no 'q' header terminator — anything below '?' is not sixel data
+    [InlineData("0;0;0q")]  // header but no pixel data
+    [InlineData("")]
+    public void DecodeSixel_PayloadWithoutRenderableData_ReturnsNull(string dcs)
+    {
+        Assert.SkipUnless(SkiaAvailable, "SkiaSharp native library not available on this platform.");
+
+        var handle = new SkiaImageDecoder().DecodeSixel(dcs, out int width, out int height);
+
+        Assert.Null(handle);
+        Assert.Equal(0, width);
+        Assert.Equal(0, height);
+    }
+
+    [Fact]
+    public void DecodeImageBytes_PngPayload_ReturnsBitmapWithPixelDimensions()
+    {
+        Assert.SkipUnless(SkiaAvailable, "SkiaSharp native library not available on this platform.");
+
+        byte[] png;
+        var source = new SKBitmap(3, 5);
+        using (var image = SKImage.FromBitmap(source))
+        using (var data = image.Encode(SKEncodedImageFormat.Png, 100))
+        {
+            png = data.ToArray();
+        }
+
+        var handle = new SkiaImageDecoder().DecodeImageBytes(png, out int width, out int height);
+
+        var bitmap = Assert.IsType<SKBitmap>(handle);
+        Assert.Equal(3, bitmap.Width);
+        Assert.Equal(5, bitmap.Height);
+        Assert.Equal(3, width);
+        Assert.Equal(5, height);
+    }
+
+    [Fact]
+    public void DecodeImageBytes_GarbageBytes_ReturnsNull()
+    {
+        Assert.SkipUnless(SkiaAvailable, "SkiaSharp native library not available on this platform.");
+
+        var handle = new SkiaImageDecoder().DecodeImageBytes(new byte[] { 0x01, 0x02, 0x03 }, out int width, out int height);
+
+        Assert.Null(handle);
+        Assert.Equal(0, width);
+        Assert.Equal(0, height);
+    }
+
+    [Fact]
+    public void DecodeImageBytes_EmptyBytes_ReturnsNull()
+    {
+        var handle = new SkiaImageDecoder().DecodeImageBytes(Array.Empty<byte>(), out int width, out int height);
+
+        Assert.Null(handle);
+        Assert.Equal(0, width);
+        Assert.Equal(0, height);
+    }
+
+    /// <summary>
+    /// End-to-end through the real parser: with the production decoder wired, a DCS sixel
+    /// sequence must place an image in the buffer sized from the decoded bitmap's pixels
+    /// (parser fallback cell metrics are 10x20 px). Without a decoder this path silently
+    /// no-ops — the exact defect this wiring fixes.
+    /// </summary>
+    [Fact]
+    public void AnsiParser_WithWiredDecoder_PlacesSixelImageInBuffer()
+    {
+        Assert.SkipUnless(SkiaAvailable, "SkiaSharp native library not available on this platform.");
+
+        var buffer = new TerminalBuffer(80, 24);
+        var parser = new AnsiParser(buffer) { ImageDecoder = new SkiaImageDecoder() };
+
+        parser.Process("\x1bP0;0;0q#1;2;100;0;0#1~\x1b\\");
+
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            var image = Assert.Single(buffer.Images);
+            Assert.IsType<SKBitmap>(image.ImageHandle);
+            Assert.Equal(1, image.CellWidth);  // ceil(1 px / 10 px fallback cell width)
+            Assert.Equal(1, image.CellHeight); // ceil(6 px / 20 px fallback cell height)
+        }
+        finally
+        {
+            buffer.Lock.ExitReadLock();
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`AnsiParser.ImageDecoder` was only ever assigned in tests, so every inline-image protocol silently no-op'd in production — DCS sixel, OSC 1337 (iTerm2), Kitty APC, and OSC 1339 tunneled payloads all decoded to nothing — while `docs/IMAGE_PROTOCOL_SUPPORT.md` advertised them as **Supported**. A review flagged this as: "No inline image decoding at all... sixel, iTerm2 and Kitty all silently no-op."

## Fix

The rest of the pipeline already existed: `TerminalBuffer` places, scrolls, and evicts images (`TerminalImage` overlay list), and `TerminalDrawOperation`'s image pass draws `SKBitmap` handles at cell rects. Only the decoder was missing.

- **New `NovaTerminal.Rendering.SkiaImageDecoder`** (`IImageDecoder` impl, placed next to the existing `SixelDecoder` per MODULE_OWNERSHIP.md):
  - `DecodeSixel` → `SixelDecoder.Decode` (stateless: fresh instance per call; the parser runs on the PTY pump thread)
  - `DecodeImageBytes` → `SKBitmap.Decode` with container sniffing (Kitty's `f=` param stays ignored, matching existing parser behavior)
  - Undecodable data — *including exceptions thrown by Skia* — surfaces as `null` (decode failure), never a throw mid-parse. The parser's existing 10 MB / 2000 px / 16 Mi-char guardrails still bound the work.
- **Wired at two production sites**: `TerminalPane.CreateAndWireParser()` (every live pane; a reconnect test pins that it survives parser replacement) and `ReplayWindow`'s parser, so replays render inline images identically to live panes. `WriteBanner` (text-only) and the headless `ReplayCommand` CLI stay unwired deliberately — nothing consumes handles there.

## Tests

- `SkiaImageDecoderTests` (Rendering.Tests): sixel dims, three deterministic null cases, PNG round-trip with dimension passthrough, garbage/empty bytes → null (the garbage test caught that `SKBitmap.Decode` *throws* on bad input in SkiaSharp 3.119 — hence the catch).
- End-to-end through the real parser: DCS sixel → placed `TerminalImage` with pixel-derived cell size (this exact path silently no-op'd before).
- `PaneParserWiringTests`: decoder is wired and survives `CreateAndWireParser` reconnects.

## Docs

- `IMAGE_PROTOCOL_SUPPORT.md`: note naming the implementation, so the Supported claims are traceable.
- `vt_coverage_matrix.md`: SIXEL decode/render ⚠ Partial/Manual → ✅ Supported with test evidence. (OSC 1337's missing targeted coverage remains accurately marked.)

## Out of scope (follow-ups)

- Bitmap disposal on eviction — tracked in #166; now more material since real `SKBitmap`s flow, but needs an ownership/grace design first (frames may still reference a handle — the #176 use-after-dispose hazard).
- OSC 1337 targeted automated coverage — new issue.
- Intermittent App.Tests hang observed during verification (reproduces on a clean tree) — new issue.

## Verification

`NovaTerminal.Rendering.Tests` 76/76, `NovaTerminal.VT.Tests` 375/375, App.Tests classes touching panes/replay/graphics/parsers 462/462, full solution builds clean.