### PR TITLE
test(vt): decoder-wired e2e coverage for OSC 1337 and Kitty image paths

### DIFF
--- a/docs/vt_coverage_matrix.md
+++ b/docs/vt_coverage_matrix.md
@@ -148,7 +148,7 @@ It is designed to be:
 | OSC 52 | Clipboard | ⚠ Partial | Unit: `tests/NovaTerminal.App.Tests/OscUxTests.cs`, `tests/NovaTerminal.App.Tests/Controls/PaneParserWiringTests.cs` | Parser+App | Write-only (issue #268): valid base64 decodes and raises `AnsiParser.OnClipboardWrite`, capped at 1 MiB decoded (rejected on encoded length before decoding, re-checked after); invalid base64 dropped silently; a sequence with no payload separator at all is ignored rather than clearing the clipboard. Targets `c`/`p` both map to the system clipboard, other selection chars ignored. Query (`?`) always gets an empty-payload denial reply, never real clipboard contents — clipboard READ is unsupported by design (security). The echoed selection parameter is whitelisted to `c p q s 0-7` and length-capped first: responses go to the child process's stdin, so an unsanitized echo was a command-injection primitive (PR #280 review). Gated by `TerminalSettings.AllowOsc52ClipboardWrite` (default true, single global setting; per-profile/SSH-scoped opt-in is future work) |
 | OSC 8 | Hyperlinks | ✅ Supported | Unit: `tests/NovaTerminal.App.Tests/OscUxTests.cs` | Parser+Renderer+UI | Ctrl-click open path is app-level |
 | OSC 133 | Shell integration lifecycle | ⚠ Partial | Unit: `tests/NovaTerminal.App.Tests/OscShellIntegrationTests.cs` | Parser+Command Assist | Supports A/B/C/D markers; broader semantic prompt extensions not audited |
-| OSC 1337 | iTerm2 inline images | ⚠ Partial | Manual: `docs/qa/QA_GRAPHICS.md` | Parser+Renderer | Parser support exists, but targeted automated replay/unit coverage for OSC 1337 is still missing |
+| OSC 1337 | iTerm2 inline images | ✅ Supported | Unit: `tests/NovaTerminal.Rendering.Tests/InlineImageEndToEndTests.cs`, Manual: `docs/qa/QA_GRAPHICS.md` | Parser+Renderer | Requires `inline=1` and the `File=` arg shape; no `name=`/`size=` enforcement |
 | OSC 1339 | Windows conpty tunnel | 🧪 Experimental | Manual | Parser+Win | |
 
 ---
@@ -157,7 +157,7 @@ It is designed to be:
 
 | Feature | Notes | Status | Evidence | Ownership | Known deviations |
 |---|---|---:|---|---|---|
-| Kitty graphics protocol | APC / OSC forms | ✅ Supported | Unit: `tests/NovaTerminal.App.Tests/GraphicsTests.cs`, `tests/NovaTerminal.App.Tests/AnsiParserHardeningTests.cs` | Parser+Renderer | |
+| Kitty graphics protocol | APC / OSC forms | ✅ Supported | Unit: `tests/NovaTerminal.App.Tests/GraphicsTests.cs`, `tests/NovaTerminal.App.Tests/AnsiParserHardeningTests.cs`, `tests/NovaTerminal.Rendering.Tests/InlineImageEndToEndTests.cs` | Parser+Renderer | |
 | Placement, z-index, scrolling | Complex interactions | ⚠ Partial | Manual | Buffer+Renderer | |
 
 ---

--- a/src/NovaTerminal.App/Resources/vt-conformance-report.json
+++ b/src/NovaTerminal.App/Resources/vt-conformance-report.json
@@ -1,16 +1,16 @@
 {
   "schemaVersion": 1,
   "matrixPath": "docs/vt_coverage_matrix.md",
-  "matrixSha256": "2459dbd6100c91f121e856e0c0c54247eeca002a0a1ce4399c1d27dbf56d17f3",
+  "matrixSha256": "47d97ce2b29974163b73ada32f5935db95d318f874f5233b9ec5e46d595cdd2e",
   "summary": {
     "totalRows": 58,
-    "supportedCount": 19,
-    "partialCount": 33,
+    "supportedCount": 20,
+    "partialCount": 32,
     "experimentalCount": 1,
     "notSupportedCount": 4,
     "wontSupportCount": 1,
     "rowsWithLinkedEvidence": 35,
-    "supportedRowsWithLinkedEvidence": 19,
+    "supportedRowsWithLinkedEvidence": 20,
     "errorCount": 0,
     "warningCount": 0
   },
@@ -1033,22 +1033,27 @@
     {
       "section": "8) OSC sequences",
       "feature": "OSC 1337",
-      "status": "\u26A0 Partial",
+      "status": "\u2705 Supported",
       "specOrNotes": "",
-      "evidenceText": "Manual: \u0060docs/qa/QA_GRAPHICS.md\u0060",
+      "evidenceText": "Unit: \u0060tests/NovaTerminal.Rendering.Tests/InlineImageEndToEndTests.cs\u0060, Manual: \u0060docs/qa/QA_GRAPHICS.md\u0060",
       "evidenceKinds": [
-        "manual"
+        "manual",
+        "unit"
       ],
       "evidenceLinks": [
         {
           "path": "docs/qa/QA_GRAPHICS.md",
           "exists": true
+        },
+        {
+          "path": "tests/NovaTerminal.Rendering.Tests/InlineImageEndToEndTests.cs",
+          "exists": true
         }
       ],
-      "hasAutomatedEvidenceSignal": false,
+      "hasAutomatedEvidenceSignal": true,
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BRenderer",
-      "knownDeviations": "Parser support exists, but targeted automated replay/unit coverage for OSC 1337 is still missing",
+      "knownDeviations": "Requires \u0060inline=1\u0060 and the \u0060File=\u0060 arg shape; no \u0060name=\u0060/\u0060size=\u0060 enforcement",
       "sourceLine": 151
     },
     {
@@ -1072,7 +1077,7 @@
       "feature": "Kitty graphics protocol",
       "status": "\u2705 Supported",
       "specOrNotes": "APC / OSC forms",
-      "evidenceText": "Unit: \u0060tests/NovaTerminal.App.Tests/GraphicsTests.cs\u0060, \u0060tests/NovaTerminal.App.Tests/AnsiParserHardeningTests.cs\u0060",
+      "evidenceText": "Unit: \u0060tests/NovaTerminal.App.Tests/GraphicsTests.cs\u0060, \u0060tests/NovaTerminal.App.Tests/AnsiParserHardeningTests.cs\u0060, \u0060tests/NovaTerminal.Rendering.Tests/InlineImageEndToEndTests.cs\u0060",
       "evidenceKinds": [
         "unit"
       ],
@@ -1083,6 +1088,10 @@
         },
         {
           "path": "tests/NovaTerminal.App.Tests/GraphicsTests.cs",
+          "exists": true
+        },
+        {
+          "path": "tests/NovaTerminal.Rendering.Tests/InlineImageEndToEndTests.cs",
           "exists": true
         }
       ],

--- a/tests/NovaTerminal.Rendering.Tests/InlineImageEndToEndTests.cs
+++ b/tests/NovaTerminal.Rendering.Tests/InlineImageEndToEndTests.cs
@@ -1,0 +1,130 @@
+using System;
+using NovaTerminal.Rendering;
+using NovaTerminal.VT;
+using SkiaSharp;
+using Xunit;
+
+namespace NovaTerminal.Rendering.Tests;
+
+/// <summary>
+/// Decoder-wired end-to-end coverage for the inline image paths that reach
+/// <see cref="IImageDecoder.DecodeImageBytes"/> (the DCS sixel e2e lives next to the decoder
+/// tests in <see cref="SkiaImageDecoderTests"/>). Each test feeds the real wire encoding
+/// through the real parser with the production decoder and asserts a placed
+/// <see cref="TerminalImage"/> sized from the decoded bitmap — the assertions would fail
+/// with the pre-#369 wiring, where every path silently no-op'd.
+/// </summary>
+public class InlineImageEndToEndTests
+{
+    private static readonly bool SkiaAvailable = CheckSkiaAvailable();
+
+    private static bool CheckSkiaAvailable()
+    {
+        try
+        {
+            using var surface = SKSurface.Create(new SKImageInfo(1, 1, SKColorType.Rgba8888));
+            return surface != null;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static byte[] EncodePng3x5()
+    {
+        var source = new SKBitmap(3, 5);
+        using var image = SKImage.FromBitmap(source);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        return data.ToArray();
+    }
+
+    [Fact]
+    public void Osc1337_InlineImage_PlacesDecodedBitmapInBuffer()
+    {
+        Assert.SkipUnless(SkiaAvailable, "SkiaSharp native library not available on this platform.");
+
+        var buffer = new TerminalBuffer(80, 24);
+        var parser = new AnsiParser(buffer) { ImageDecoder = new SkiaImageDecoder() };
+        string base64 = Convert.ToBase64String(EncodePng3x5());
+
+        parser.Process("\x1b]1337;File=name=t.png;inline=1:" + base64 + "\x07");
+
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            var image = Assert.Single(buffer.Images);
+            Assert.IsType<SKBitmap>(image.ImageHandle);
+            // Auto-fit with fallback 10x20 cell metrics: width = max(10, ceil(3/10)) = 10,
+            // height = round(10 * (10/20) * (5/3)) = 8.
+            Assert.Equal(10, image.CellWidth);
+            Assert.Equal(8, image.CellHeight);
+        }
+        finally
+        {
+            buffer.Lock.ExitReadLock();
+        }
+    }
+
+    [Fact]
+    public void KittyChunkedApc_PlacesDecodedBitmapInBuffer()
+    {
+        Assert.SkipUnless(SkiaAvailable, "SkiaSharp native library not available on this platform.");
+
+        var buffer = new TerminalBuffer(80, 24);
+        // Non-tunneled Kitty APC is skipped when ConPTY filtering is likely (the Windows
+        // default); force it off to exercise the direct path Linux/macOS take.
+        var parser = new AnsiParser(buffer, forceConPtyFiltering: false) { ImageDecoder = new SkiaImageDecoder() };
+
+        string base64 = Convert.ToBase64String(EncodePng3x5());
+        string firstChunk = base64.Substring(0, base64.Length / 2);
+        string secondChunk = base64.Substring(base64.Length / 2);
+
+        parser.Process("\x1b_Gf=100,m=1;" + firstChunk + "\x1b\\");
+        Assert.Empty(buffer.Images); // m=1: accumulating, nothing finalized yet
+
+        parser.Process("\x1b_Gm=0;" + secondChunk + "\x1b\\");
+
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            var image = Assert.Single(buffer.Images);
+            Assert.IsType<SKBitmap>(image.ImageHandle);
+            // Auto-fit with fallback 10x20 cell metrics: width = ceil(3/10) = 1,
+            // height = ceil(1 * (10/20) * (5/3)) = 1.
+            Assert.Equal(1, image.CellWidth);
+            Assert.Equal(1, image.CellHeight);
+        }
+        finally
+        {
+            buffer.Lock.ExitReadLock();
+        }
+    }
+
+    [Fact]
+    public void KittyTunneledOverOsc1339_PlacesDecodedBitmapDespiteConPtyFiltering()
+    {
+        Assert.SkipUnless(SkiaAvailable, "SkiaSharp native library not available on this platform.");
+
+        var buffer = new TerminalBuffer(80, 24);
+        // The tunnel exists precisely because ConPTY strips DCS/APC: with filtering forced
+        // on, the direct APC path is skipped but the OSC 1339 tunnel must still decode.
+        var parser = new AnsiParser(buffer, forceConPtyFiltering: true) { ImageDecoder = new SkiaImageDecoder() };
+
+        string base64 = Convert.ToBase64String(EncodePng3x5());
+        parser.Process("\x1b]1339;Kitty:Gf=100,a=t,m=0;" + base64 + "\x07");
+
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            var image = Assert.Single(buffer.Images);
+            Assert.IsType<SKBitmap>(image.ImageHandle);
+            Assert.Equal(1, image.CellWidth);
+            Assert.Equal(1, image.CellHeight);
+        }
+        finally
+        {
+            buffer.Lock.ExitReadLock();
+        }
+    }
+}


### PR DESCRIPTION
Closes #370.

PR #369 wired the production decoder but shipped only one decoder-wired e2e test (DCS sixel). This adds the missing two paths from the issue:

- **OSC 1337 (iTerm2 inline)** — real `File=…;inline=1:<base64>` sequence through the real parser; asserts a placed `TerminalImage` with the auto-fit cell sizing (10×8 for a 3×5 PNG at fallback 10×20 metrics). The matrix's "targeted automated coverage still missing" note is now false, so the row moves ⚠ Partial → ✅.
- **Kitty APC, chunked** — `m=1`/`m=0` split base64; asserts nothing is placed mid-stream, then a single image after the final chunk. Runs with `forceConPtyFiltering: false` (the Linux/macOS default; on Windows the direct APC path is correctly skipped).
- **Kitty tunneled over OSC 1339** — with `forceConPtyFiltering: true` (the Windows default): the direct APC path is skipped but the tunnel decodes and places anyway. That bypass is the tunnel's entire reason to exist, and it had no decoder-wired test.

Conformance gate kept green: matrix rows updated and `vt-conformance-report.json` regenerated in the same commit.

All 80 Rendering.Tests pass locally, including the three new tests.