### PR TITLE
test: serialize xunit collections (fixes #371 suite hang; exposes 8 ordering-sensitive UI tests)

### DIFF
--- a/tests/NovaTerminal.App.Tests/NovaTerminal.App.Tests.csproj
+++ b/tests/NovaTerminal.App.Tests/NovaTerminal.App.Tests.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <Content Include="corpus\**\*.*" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/NovaTerminal.App.Tests/xunit.runner.json
+++ b/tests/NovaTerminal.App.Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "parallelizeTestCollections": false
+}


### PR DESCRIPTION
Draft: merge decision pending CI data — see #371 for full analysis.

**Fixes the hang**: with `parallelizeTestCollections: false`, the full suite completes deterministically (~2.5 min locally) instead of deadlocking in the shared Avalonia headless session (dump analysis + experiment log in #371).

**Known trade-off**: locally (Windows), serialization surfaces 8 ordering-sensitive failures across `SettingsWindowTitleBarSectionTests`, `AgentObserveIndicatorTests`, `MainWindowTitleBarTests` — all `Dispatcher.VerifyAccess`/`MediaContextClock.Subscribe` thread-affinity violations, i.e. UI objects (animations/transitions) outliving their owning thread across test app lifetimes.

**What this PR needs before merging**: CI results on both OSes with serialization on. If green everywhere, the local failures are Windows-env artifacts and this lands. If red, the three classes need proper app-lifetime hygiene (or a dedicated collection) first — that work would then be the actual fix for #371.