### PR TITLE
fix(vt): dispose pruned image bitmaps at the render frame boundary

### DIFF
--- a/docs/IMAGE_PROTOCOL_SUPPORT.md
+++ b/docs/IMAGE_PROTOCOL_SUPPORT.md
@@ -22,6 +22,6 @@ This document defines NovaTerminal image protocol behavior across platforms.
 ## Notes
 
 - Decoding is implemented by `NovaTerminal.Rendering.SkiaImageDecoder` (`SixelDecoder` for DCS/OSC 1339 sixel payloads, `SKBitmap.Decode` for Kitty/iTerm2 image bytes); decoded bitmaps render in the grid via `TerminalDrawOperation`'s image pass.
-- Lifecycle: images pruned by the buffer (scroll eviction, erase, reflow) retire their bitmap handles, which the draw operation disposes at the next frame boundary — never while a frame may still reference them (#166).
+- Lifecycle: images pruned by the buffer (scroll eviction, erase, reflow) retire their bitmap handles; the owning view disposes them at its frame boundary once a short age grace has passed — never while a concurrent snapshot (a frame or an agent-host capture) may still be drawing them (#166).
 - The fallback policy is intentionally conservative to avoid false advertising Kitty support through ConPTY.
 - If a future backend bypasses ConPTY filtering, this policy can be relaxed.

--- a/docs/IMAGE_PROTOCOL_SUPPORT.md
+++ b/docs/IMAGE_PROTOCOL_SUPPORT.md
@@ -22,6 +22,6 @@ This document defines NovaTerminal image protocol behavior across platforms.
 ## Notes
 
 - Decoding is implemented by `NovaTerminal.Rendering.SkiaImageDecoder` (`SixelDecoder` for DCS/OSC 1339 sixel payloads, `SKBitmap.Decode` for Kitty/iTerm2 image bytes); decoded bitmaps render in the grid via `TerminalDrawOperation`'s image pass.
-- Lifecycle: images pruned by the buffer (scroll eviction, erase, reflow) retire their bitmap handles; the owning view disposes them at its frame boundary once a short age grace has passed — never while a concurrent snapshot (a frame or an agent-host capture) may still be drawing them (#166).
+- Lifecycle: images pruned by the buffer (scroll eviction, erase, reflow) retire their bitmap handles; the owning view disposes them at its frame boundary, gated on no in-flight snapshot session predating the retire — an agent-host capture of any duration blocks disposal until it completes (#166).
 - The fallback policy is intentionally conservative to avoid false advertising Kitty support through ConPTY.
 - If a future backend bypasses ConPTY filtering, this policy can be relaxed.

--- a/docs/IMAGE_PROTOCOL_SUPPORT.md
+++ b/docs/IMAGE_PROTOCOL_SUPPORT.md
@@ -22,5 +22,6 @@ This document defines NovaTerminal image protocol behavior across platforms.
 ## Notes
 
 - Decoding is implemented by `NovaTerminal.Rendering.SkiaImageDecoder` (`SixelDecoder` for DCS/OSC 1339 sixel payloads, `SKBitmap.Decode` for Kitty/iTerm2 image bytes); decoded bitmaps render in the grid via `TerminalDrawOperation`'s image pass.
+- Lifecycle: images pruned by the buffer (scroll eviction, erase, reflow) retire their bitmap handles, which the draw operation disposes at the next frame boundary — never while a frame may still reference them (#166).
 - The fallback policy is intentionally conservative to avoid false advertising Kitty support through ConPTY.
 - If a future backend bypasses ConPTY filtering, this policy can be relaxed.

--- a/docs/vt_coverage_matrix.md
+++ b/docs/vt_coverage_matrix.md
@@ -158,7 +158,7 @@ It is designed to be:
 | Feature | Notes | Status | Evidence | Ownership | Known deviations |
 |---|---|---:|---|---|---|
 | Kitty graphics protocol | APC / OSC forms | ✅ Supported | Unit: `tests/NovaTerminal.App.Tests/GraphicsTests.cs`, `tests/NovaTerminal.App.Tests/AnsiParserHardeningTests.cs`, `tests/NovaTerminal.Rendering.Tests/InlineImageEndToEndTests.cs` | Parser+Renderer | |
-| Placement, z-index, scrolling | Complex interactions | ⚠ Partial | Manual | Buffer+Renderer | |
+| Placement, z-index, scrolling | Complex interactions | ⚠ Partial | Manual | Buffer+Renderer | Pruned images' bitmaps are retired by the buffer and disposed at the render frame boundary (#166) |
 
 ---
 

--- a/docs/vt_coverage_matrix.md
+++ b/docs/vt_coverage_matrix.md
@@ -158,7 +158,7 @@ It is designed to be:
 | Feature | Notes | Status | Evidence | Ownership | Known deviations |
 |---|---|---:|---|---|---|
 | Kitty graphics protocol | APC / OSC forms | ✅ Supported | Unit: `tests/NovaTerminal.App.Tests/GraphicsTests.cs`, `tests/NovaTerminal.App.Tests/AnsiParserHardeningTests.cs`, `tests/NovaTerminal.Rendering.Tests/InlineImageEndToEndTests.cs` | Parser+Renderer | |
-| Placement, z-index, scrolling | Complex interactions | ⚠ Partial | Manual | Buffer+Renderer | Pruned images' bitmaps are retired by the buffer; the owning view disposes them at its frame boundary after an age grace (#166) |
+| Placement, z-index, scrolling | Complex interactions | ⚠ Partial | Manual | Buffer+Renderer | Pruned images' bitmaps are retired by the buffer; the owning view disposes them once no in-flight snapshot session predates the retire (#166) |
 
 ---
 

--- a/docs/vt_coverage_matrix.md
+++ b/docs/vt_coverage_matrix.md
@@ -158,7 +158,7 @@ It is designed to be:
 | Feature | Notes | Status | Evidence | Ownership | Known deviations |
 |---|---|---:|---|---|---|
 | Kitty graphics protocol | APC / OSC forms | ✅ Supported | Unit: `tests/NovaTerminal.App.Tests/GraphicsTests.cs`, `tests/NovaTerminal.App.Tests/AnsiParserHardeningTests.cs`, `tests/NovaTerminal.Rendering.Tests/InlineImageEndToEndTests.cs` | Parser+Renderer | |
-| Placement, z-index, scrolling | Complex interactions | ⚠ Partial | Manual | Buffer+Renderer | Pruned images' bitmaps are retired by the buffer and disposed at the render frame boundary (#166) |
+| Placement, z-index, scrolling | Complex interactions | ⚠ Partial | Manual | Buffer+Renderer | Pruned images' bitmaps are retired by the buffer; the owning view disposes them at its frame boundary after an age grace (#166) |
 
 ---
 

--- a/src/NovaTerminal.App/Resources/vt-conformance-report.json
+++ b/src/NovaTerminal.App/Resources/vt-conformance-report.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "matrixPath": "docs/vt_coverage_matrix.md",
-  "matrixSha256": "47d97ce2b29974163b73ada32f5935db95d318f874f5233b9ec5e46d595cdd2e",
+  "matrixSha256": "376c78806b2bf417712f84143420d988c6471fa90e97b968b65c44ea0df0d685",
   "summary": {
     "totalRows": 58,
     "supportedCount": 20,
@@ -1114,7 +1114,7 @@
       "hasAutomatedEvidenceSignal": false,
       "hasLinkedEvidence": false,
       "ownership": "Buffer\u002BRenderer",
-      "knownDeviations": "",
+      "knownDeviations": "Pruned images\u0027 bitmaps are retired by the buffer and disposed at the render frame boundary (#166)",
       "sourceLine": 161
     },
     {

--- a/src/NovaTerminal.App/Resources/vt-conformance-report.json
+++ b/src/NovaTerminal.App/Resources/vt-conformance-report.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "matrixPath": "docs/vt_coverage_matrix.md",
-  "matrixSha256": "670e8dfe5bf71be28e4fad2bb619541a2ad153603b75bba95c2b7b5a0021524c",
+  "matrixSha256": "581c0b13995f886b7658b868bb218c26c3b77f2cf8fe7cbf9b07c6a230eea7f6",
   "summary": {
     "totalRows": 58,
     "supportedCount": 20,
@@ -1114,7 +1114,7 @@
       "hasAutomatedEvidenceSignal": false,
       "hasLinkedEvidence": false,
       "ownership": "Buffer\u002BRenderer",
-      "knownDeviations": "Pruned images\u0027 bitmaps are retired by the buffer; the owning view disposes them at its frame boundary after an age grace (#166)",
+      "knownDeviations": "Pruned images\u0027 bitmaps are retired by the buffer; the owning view disposes them once no in-flight snapshot session predates the retire (#166)",
       "sourceLine": 161
     },
     {

--- a/src/NovaTerminal.App/Resources/vt-conformance-report.json
+++ b/src/NovaTerminal.App/Resources/vt-conformance-report.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "matrixPath": "docs/vt_coverage_matrix.md",
-  "matrixSha256": "376c78806b2bf417712f84143420d988c6471fa90e97b968b65c44ea0df0d685",
+  "matrixSha256": "670e8dfe5bf71be28e4fad2bb619541a2ad153603b75bba95c2b7b5a0021524c",
   "summary": {
     "totalRows": 58,
     "supportedCount": 20,
@@ -1114,7 +1114,7 @@
       "hasAutomatedEvidenceSignal": false,
       "hasLinkedEvidence": false,
       "ownership": "Buffer\u002BRenderer",
-      "knownDeviations": "Pruned images\u0027 bitmaps are retired by the buffer and disposed at the render frame boundary (#166)",
+      "knownDeviations": "Pruned images\u0027 bitmaps are retired by the buffer; the owning view disposes them at its frame boundary after an age grace (#166)",
       "sourceLine": 161
     },
     {

--- a/src/NovaTerminal.App/Shell/TerminalDrawOperation.cs
+++ b/src/NovaTerminal.App/Shell/TerminalDrawOperation.cs
@@ -300,6 +300,24 @@ namespace NovaTerminal.Shell
 
         internal TerminalRenderSnapshot? DrawTerminalInternal(SKCanvas canvas)
         {
+            // Snapshot session: brackets this pass's snapshot copy through its last
+            // DrawBitmap. Retired image handles are only disposed once every session that
+            // started at or before their retire tick has ended (TerminalBuffer enforces it),
+            // so disposal is exact for BOTH pipelines that drive this method — the live view
+            // frame and agent-host captures — regardless of how long a pass runs.
+            int snapshotSession = _buffer.BeginSnapshotSession();
+            try
+            {
+                return DrawTerminalInternalCore(canvas);
+            }
+            finally
+            {
+                _buffer.EndSnapshotSession(snapshotSession);
+            }
+        }
+
+        private TerminalRenderSnapshot? DrawTerminalInternalCore(SKCanvas canvas)
+        {
             try
             {
                 // Render-thread safe boundary: drain deferred disposals & apply clear requests.
@@ -311,7 +329,9 @@ namespace NovaTerminal.Shell
                 // capture) on its own thread, so a drain at this point is not tied to one
                 // pipeline's frame sequence and could dispose a bitmap another concurrent
                 // snapshot is still drawing (#166 review). The owning TerminalView drains
-                // with a retire-age grace at its own frame boundary instead.
+                // instead, and TerminalBuffer's snapshot-session gate (see the session
+                // bracket at the top of DrawTerminalInternal) is what makes that drain safe
+                // for captures of any duration.
 
                 RenderPerfWriter? perfWriter = BeginFramePerfMetrics();
                 var frame = new FrameSnapshot();

--- a/src/NovaTerminal.App/Shell/TerminalDrawOperation.cs
+++ b/src/NovaTerminal.App/Shell/TerminalDrawOperation.cs
@@ -306,28 +306,12 @@ namespace NovaTerminal.Shell
                 _rowCache?.DrainDisposalsAndApplyClearIfRequested();
                 _glyphCache?.DrainDisposals();
 
-                // Retired inline-image handles: a pruned image's bitmap may still be referenced
-                // by the previous frame's snapshot, so disposal waits for this frame boundary —
-                // draining here proves frame N's DrawBitmap calls finished (same contract as the
-                // row/glyph drains above). Handles are opaque objects; only SKBitmaps are ours.
-                var retiredImageHandles = new List<object>();
-                if (_buffer.DrainRetiredImageHandles(retiredImageHandles))
-                {
-                    foreach (var handle in retiredImageHandles)
-                    {
-                        if (handle is SKBitmap bitmap)
-                        {
-                            try
-                            {
-                                bitmap.Dispose();
-                            }
-                            catch
-                            {
-                                // Best effort: never break the frame over a dispose failure.
-                            }
-                        }
-                    }
-                }
+                // NOTE: retired inline-image handles are intentionally NOT drained here.
+                // This draw operation is also driven by TerminalSnapshotRenderer (agent-host
+                // capture) on its own thread, so a drain at this point is not tied to one
+                // pipeline's frame sequence and could dispose a bitmap another concurrent
+                // snapshot is still drawing (#166 review). The owning TerminalView drains
+                // with a retire-age grace at its own frame boundary instead.
 
                 RenderPerfWriter? perfWriter = BeginFramePerfMetrics();
                 var frame = new FrameSnapshot();

--- a/src/NovaTerminal.App/Shell/TerminalDrawOperation.cs
+++ b/src/NovaTerminal.App/Shell/TerminalDrawOperation.cs
@@ -306,6 +306,29 @@ namespace NovaTerminal.Shell
                 _rowCache?.DrainDisposalsAndApplyClearIfRequested();
                 _glyphCache?.DrainDisposals();
 
+                // Retired inline-image handles: a pruned image's bitmap may still be referenced
+                // by the previous frame's snapshot, so disposal waits for this frame boundary —
+                // draining here proves frame N's DrawBitmap calls finished (same contract as the
+                // row/glyph drains above). Handles are opaque objects; only SKBitmaps are ours.
+                var retiredImageHandles = new List<object>();
+                if (_buffer.DrainRetiredImageHandles(retiredImageHandles))
+                {
+                    foreach (var handle in retiredImageHandles)
+                    {
+                        if (handle is SKBitmap bitmap)
+                        {
+                            try
+                            {
+                                bitmap.Dispose();
+                            }
+                            catch
+                            {
+                                // Best effort: never break the frame over a dispose failure.
+                            }
+                        }
+                    }
+                }
+
                 RenderPerfWriter? perfWriter = BeginFramePerfMetrics();
                 var frame = new FrameSnapshot();
                 var snapshotRequest = new RenderSnapshotRequest

--- a/src/NovaTerminal.App/Shell/TerminalView.cs
+++ b/src/NovaTerminal.App/Shell/TerminalView.cs
@@ -300,6 +300,15 @@ namespace NovaTerminal.Shell
         private TerminalBuffer? _buffer;
         public TerminalBuffer? Buffer => _buffer;
 
+        // Retired inline-image handles: this view OWNS their disposal. The drain lives here —
+        // not in TerminalDrawOperation — because that op is also driven by
+        // TerminalSnapshotRenderer (agent-host capture) on its own thread, so a draw-op drain
+        // could dispose a bitmap another concurrent snapshot is still drawing. The age grace
+        // (retire tick vs now) outlives any snapshot's draw window: frames and captures take
+        // tens of ms, so a pruned handle is only disposed once nothing can still hold it.
+        private const long RetiredImageDisposalGraceMs = 2000;
+        private readonly List<object> _retiredImageHandleScratch = new();
+
         // Coalescing
         private bool _isDirty;
         private DispatcherTimer _renderTimer;
@@ -1075,6 +1084,38 @@ namespace NovaTerminal.Shell
         // Session for sending mouse events
         private ITerminalSession? _session;
 
+        /// <summary>
+        /// Drains retired image handles older than <paramref name="drainTick"/> and disposes
+        /// the Skia bitmaps. Called from <see cref="Render"/> (this view's frame boundary) and
+        /// internal so tests can drive it deterministically.
+        /// </summary>
+        internal void DisposeRetiredImageBitmaps(long drainTick)
+        {
+            var buffer = _buffer;
+            if (buffer == null) return;
+
+            if (!buffer.DrainRetiredImageHandles(_retiredImageHandleScratch, drainTick))
+            {
+                return;
+            }
+
+            foreach (var handle in _retiredImageHandleScratch)
+            {
+                if (handle is SKBitmap bitmap)
+                {
+                    try
+                    {
+                        bitmap.Dispose();
+                    }
+                    catch
+                    {
+                        // Best effort: never break rendering over a dispose failure.
+                    }
+                }
+            }
+            _retiredImageHandleScratch.Clear();
+        }
+
         public void SetBuffer(TerminalBuffer buffer)
         {
             if (_buffer != null)
@@ -1769,6 +1810,8 @@ namespace NovaTerminal.Shell
                 context.FillRectangle(new SolidColorBrush(Color.FromRgb(20, 20, 20), _windowOpacity), new Rect(0, 0, Bounds.Width, Bounds.Height));
                 return;
             }
+
+            DisposeRetiredImageBitmaps(Environment.TickCount64 - RetiredImageDisposalGraceMs);
 
             // Failsafe: Ensure we have fonts, but even if we don't, we should draw a background
             // to avoid "white panes"

--- a/src/NovaTerminal.App/Shell/TerminalView.cs
+++ b/src/NovaTerminal.App/Shell/TerminalView.cs
@@ -303,9 +303,12 @@ namespace NovaTerminal.Shell
         // Retired inline-image handles: this view OWNS their disposal. The drain lives here —
         // not in TerminalDrawOperation — because that op is also driven by
         // TerminalSnapshotRenderer (agent-host capture) on its own thread, so a draw-op drain
-        // could dispose a bitmap another concurrent snapshot is still drawing. The age grace
-        // (retire tick vs now) outlives any snapshot's draw window: frames and captures take
-        // tens of ms, so a pruned handle is only disposed once nothing can still hold it.
+        // could dispose a bitmap another concurrent snapshot is still drawing. Safety is
+        // exact, not a duration guess: every render pass brackets itself in a buffer
+        // snapshot session, and the buffer only releases a retire entry once no session
+        // started at or before its retire tick is still active — an in-flight capture of any
+        // duration blocks disposal. The grace below is merely the fast-path bound; the
+        // session gate is the correctness guarantee.
         private const long RetiredImageDisposalGraceMs = 2000;
         private readonly List<object> _retiredImageHandleScratch = new();
 

--- a/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
@@ -508,6 +508,7 @@ namespace NovaTerminal.VT
                         img.CellY += n;
                         if (img.CellY > absBottom)
                         {
+                            RetireImage(img);
                             _images.RemoveAt(i);
                         }
                     }
@@ -568,6 +569,7 @@ namespace NovaTerminal.VT
                         if (img.CellY < absDeletedEnd)
                         {
                             // Image starts in the deleted range
+                            RetireImage(img);
                             _images.RemoveAt(i);
                         }
                         else

--- a/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using NovaTerminal.VT.Storage;
@@ -6,10 +7,12 @@ namespace NovaTerminal.VT
 {
     public partial class TerminalBuffer
     {
-        // Handles of images removed from _images, awaiting disposal. Removal is synchronous;
-        // disposal is deferred to the render thread's frame boundary because a snapshot can
-        // still hold the handle reference after the write lock releases (see DrainRetiredImageHandles).
-        private readonly ConcurrentQueue<object> _retiredImageHandles = new();
+        // Handles of images removed from _images, awaiting disposal, stamped with the retire
+        // time. Removal is synchronous; disposal is deferred to the owning TerminalView's
+        // frame boundary AND gated by retire age: other pipelines (agent-host screen capture)
+        // snapshot the same buffer concurrently on their own threads, so a handle must not be
+        // disposed while any snapshot taken before the retire could still be drawing it.
+        private readonly ConcurrentQueue<(object Handle, long Tick)> _retiredImageHandles = new();
 
         public void AddImage(TerminalImage image)
         {
@@ -36,17 +39,17 @@ namespace NovaTerminal.VT
         /// </summary>
         private void RetireImage(TerminalImage image)
         {
-            _retiredImageHandles.Enqueue(image.ImageHandle);
+            _retiredImageHandles.Enqueue((image.ImageHandle, Environment.TickCount64));
         }
 
         /// <summary>
-        /// Drains handles retired by image removals into <paramref name="into"/>. Returns
-        /// true when anything was drained. Called once per rendered frame by the draw
-        /// operation, on the render thread, after the previous frame's DrawBitmap calls
-        /// completed — the only safe point to dispose, which is why this is a queue rather
-        /// than disposing at removal time.
+        /// Drains retired handles older than <paramref name="retiredBeforeTick"/> into
+        /// <paramref name="into"/>. Returns true when anything was drained. The owning view
+        /// calls this once per frame with (now − grace); a handle younger than the grace is
+        /// left queued because a concurrent snapshot (live frame mid-draw, agent-host
+        /// capture) taken before the retire may still be holding and drawing it.
         /// </summary>
-        public bool DrainRetiredImageHandles(List<object> into)
+        public bool DrainRetiredImageHandles(List<object> into, long retiredBeforeTick)
         {
             if (_retiredImageHandles.IsEmpty)
             {
@@ -54,9 +57,14 @@ namespace NovaTerminal.VT
             }
 
             bool drained = false;
-            while (_retiredImageHandles.TryDequeue(out object? handle))
+            // Age-ordered by construction (FIFO): stop at the first entry too young.
+            while (_retiredImageHandles.TryPeek(out var entry) && entry.Tick <= retiredBeforeTick)
             {
-                into.Add(handle);
+                if (!_retiredImageHandles.TryDequeue(out entry))
+                {
+                    break;
+                }
+                into.Add(entry.Handle);
                 drained = true;
             }
 

--- a/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
@@ -1,9 +1,16 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using NovaTerminal.VT.Storage;
 
 namespace NovaTerminal.VT
 {
     public partial class TerminalBuffer
     {
+        // Handles of images removed from _images, awaiting disposal. Removal is synchronous;
+        // disposal is deferred to the render thread's frame boundary because a snapshot can
+        // still hold the handle reference after the write lock releases (see DrainRetiredImageHandles).
+        private readonly ConcurrentQueue<object> _retiredImageHandles = new();
+
         public void AddImage(TerminalImage image)
         {
             bool lockTaken = EnterWriteLockIfNeeded();
@@ -22,14 +29,49 @@ namespace NovaTerminal.VT
             Invalidate();
         }
 
+        /// <summary>
+        /// Queues a removed image's handle for deferred disposal. The queue holds opaque
+        /// objects — VT cannot reference SkiaSharp; the render layer's frame-boundary drain
+        /// (<see cref="DrainRetiredImageHandles"/>) owns the actual Dispose.
+        /// </summary>
+        private void RetireImage(TerminalImage image)
+        {
+            _retiredImageHandles.Enqueue(image.ImageHandle);
+        }
+
+        /// <summary>
+        /// Drains handles retired by image removals into <paramref name="into"/>. Returns
+        /// true when anything was drained. Called once per rendered frame by the draw
+        /// operation, on the render thread, after the previous frame's DrawBitmap calls
+        /// completed — the only safe point to dispose, which is why this is a queue rather
+        /// than disposing at removal time.
+        /// </summary>
+        public bool DrainRetiredImageHandles(List<object> into)
+        {
+            if (_retiredImageHandles.IsEmpty)
+            {
+                return false;
+            }
+
+            bool drained = false;
+            while (_retiredImageHandles.TryDequeue(out object? handle))
+            {
+                into.Add(handle);
+                drained = true;
+            }
+
+            return drained;
+        }
+
         public void ClearImages()
         {
             bool lockTaken = EnterWriteLockIfNeeded();
             try
             {
-                // NOTE (#166): ImageHandle bitmaps are owned by the producing layer and are
-                // currently never disposed when images are dropped — see the issue for the
-                // planned ownership design (VT cannot reference SkiaSharp).
+                foreach (var img in _images)
+                {
+                    RetireImage(img);
+                }
                 _images.Clear();
             }
             finally
@@ -52,6 +94,10 @@ namespace NovaTerminal.VT
             try
             {
                 _scrollback.Clear();
+                foreach (var img in _images)
+                {
+                    RetireImage(img);
+                }
                 _images.Clear(); // full clear: scrollback-anchored images lose their anchor too
                 ClearScreenInternal(resetCursor);
 
@@ -115,6 +161,7 @@ namespace NovaTerminal.VT
                         img.CellY -= clearedRows;
                         if (img.CellY + img.CellHeight <= 0)
                         {
+                            RetireImage(img);
                             _images.RemoveAt(i);
                         }
                     }
@@ -144,6 +191,7 @@ namespace NovaTerminal.VT
 
                 if (img.CellY + img.CellHeight > viewportTopAbs)
                 {
+                    RetireImage(img);
                     _images.RemoveAt(i);
                 }
             }

--- a/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
@@ -2,17 +2,23 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using NovaTerminal.VT.Storage;
-
 namespace NovaTerminal.VT
 {
     public partial class TerminalBuffer
     {
         // Handles of images removed from _images, awaiting disposal, stamped with the retire
-        // time. Removal is synchronous; disposal is deferred to the owning TerminalView's
-        // frame boundary AND gated by retire age: other pipelines (agent-host screen capture)
-        // snapshot the same buffer concurrently on their own threads, so a handle must not be
-        // disposed while any snapshot taken before the retire could still be drawing it.
+        // time. Removal is synchronous; disposal waits until no snapshot session that could
+        // still hold the handle remains: both render pipelines (live view frames and
+        // agent-host captures) enter a session for the duration of DrawTerminalInternal, so
+        // disposal is exact rather than a duration guess (a capture drawing thousands of
+        // images under load can exceed any fixed grace).
         private readonly ConcurrentQueue<(object Handle, long Tick)> _retiredImageHandles = new();
+
+        // Sessions keyed by id, valued by start tick. A retire entry may only be disposed
+        // once every session that started at or before its retire tick has ended: those are
+        // exactly the sessions whose snapshot may have copied the handle before the prune.
+        private readonly ConcurrentDictionary<int, long> _activeSnapshotSessions = new();
+        private int _nextSnapshotSessionId;
 
         public void AddImage(TerminalImage image)
         {
@@ -43,11 +49,42 @@ namespace NovaTerminal.VT
         }
 
         /// <summary>
-        /// Drains retired handles older than <paramref name="retiredBeforeTick"/> into
-        /// <paramref name="into"/>. Returns true when anything was drained. The owning view
-        /// calls this once per frame with (now − grace); a handle younger than the grace is
-        /// left queued because a concurrent snapshot (live frame mid-draw, agent-host
-        /// capture) taken before the retire may still be holding and drawing it.
+        /// Marks the start of a render pass that will snapshot this buffer and draw the
+        /// image handles it copies out. Every pipeline drawing images (live view frames,
+        /// agent-host captures) must bracket its pass with this and
+        /// <see cref="EndSnapshotSession"/>: a retire entry is only disposed once no session
+        /// that started at or before its retire tick is still active, which is what makes
+        /// disposal exact instead of a duration guess.
+        /// </summary>
+        public int BeginSnapshotSession()
+        {
+            int id = System.Threading.Interlocked.Increment(ref _nextSnapshotSessionId);
+            _activeSnapshotSessions[id] = Environment.TickCount64;
+            return id;
+        }
+
+        public void EndSnapshotSession(int sessionId)
+        {
+            _activeSnapshotSessions.TryRemove(sessionId, out _);
+        }
+
+        private long MinActiveSessionStartTick()
+        {
+            long min = long.MaxValue;
+            foreach (var pair in _activeSnapshotSessions)
+            {
+                if (pair.Value < min) min = pair.Value;
+            }
+            return min;
+        }
+
+        /// <summary>
+        /// Drains retired handles into <paramref name="into"/>. An entry is released only
+        /// when BOTH hold: it is older than <paramref name="retiredBeforeTick"/> (the owning
+        /// view's frame boundary + grace) AND no snapshot session started at or before its
+        /// retire tick is still active (an in-flight capture of any duration blocks
+        /// disposal). The queue is FIFO by retire tick, so the drain stops at the first
+        /// entry that cannot yet be released.
         /// </summary>
         public bool DrainRetiredImageHandles(List<object> into, long retiredBeforeTick)
         {
@@ -56,9 +93,12 @@ namespace NovaTerminal.VT
                 return false;
             }
 
+            long minActiveSessionStart = MinActiveSessionStartTick();
+
             bool drained = false;
-            // Age-ordered by construction (FIFO): stop at the first entry too young.
-            while (_retiredImageHandles.TryPeek(out var entry) && entry.Tick <= retiredBeforeTick)
+            while (_retiredImageHandles.TryPeek(out var entry)
+                && entry.Tick <= retiredBeforeTick
+                && entry.Tick < minActiveSessionStart)
             {
                 if (!_retiredImageHandles.TryDequeue(out entry))
                 {

--- a/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ReflowEngine.cs
@@ -15,6 +15,9 @@ namespace NovaTerminal.VT
             private ScrollbackPages _scrollback;
             private readonly List<TerminalRow> _history;
             private readonly List<TerminalImage> _images;
+            // Pruned images retire their handles through the owning buffer's queue; the
+            // reflow works on a copy of the list reference, so it needs the buffer back-reference.
+            private readonly TerminalBuffer _source;
             private readonly bool _isAltScreen;
             private readonly TerminalTheme Theme;
             private readonly long _maxScrollbackBytes;
@@ -47,6 +50,7 @@ namespace NovaTerminal.VT
                 _history = new List<TerminalRow>(_scrollback.Count + source.Rows);
                 _maxScrollbackBytes = source.MaxScrollbackBytes;
                 _images = source._images;
+                _source = source;
                 _isAltScreen = source._isAltScreen;
                 Theme = source.Theme;
                 _cursorRow = source._cursorRow;
@@ -855,6 +859,7 @@ namespace NovaTerminal.VT
                             // Prune if shifted out of history bounds
                             if (img.CellY + img.CellHeight < 0)
                             {
+                                _source.RetireImage(img);
                                 _images.RemoveAt(i);
                             }
                         }

--- a/src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ResizeAndReflow.cs
@@ -127,7 +127,7 @@ namespace NovaTerminal.VT
 
                                     int delta = newlyEvicted > int.MaxValue ? int.MaxValue : (int)newlyEvicted;
                                     img.CellY -= delta;
-                                    if (img.CellY + img.CellHeight <= 0) _images.RemoveAt(i);
+                                    if (img.CellY + img.CellHeight <= 0) { RetireImage(img); _images.RemoveAt(i); }
                                 }
                             }
                         }
@@ -332,7 +332,7 @@ namespace NovaTerminal.VT
                     if (img.IsAltScreenImage) continue;
 
                     img.CellY -= (linesToPush + newlyDiscarded);
-                    if (img.CellY + img.CellHeight <= 0) _images.RemoveAt(i);
+                    if (img.CellY + img.CellHeight <= 0) { RetireImage(img); _images.RemoveAt(i); }
                 }
             }
 

--- a/src/NovaTerminal.VT/TerminalBuffer.WritePath.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.WritePath.cs
@@ -497,6 +497,7 @@ namespace NovaTerminal.VT
                         // If the image's entire area is now before the new index 0, prune it.
                         if (img.CellY + img.CellHeight <= 0)
                         {
+                            RetireImage(img);
                             _images.RemoveAt(i);
                         }
                     }
@@ -588,6 +589,7 @@ namespace NovaTerminal.VT
                     // If the image moves below the region, remove it
                     if (img.CellY > absBottom)
                     {
+                        RetireImage(img);
                         _images.RemoveAt(i);
                     }
                 }

--- a/tests/NovaTerminal.App.Tests/RenderTests/RetiredImageDisposalTests.cs
+++ b/tests/NovaTerminal.App.Tests/RenderTests/RetiredImageDisposalTests.cs
@@ -55,4 +55,30 @@ public class RetiredImageDisposalTests
         view.DisposeRetiredImageBitmaps(Environment.TickCount64);
         Assert.True(bitmap.Gone);
     }
+
+    [AvaloniaFact]
+    public void InFlightSnapshotSession_BlocksDisposalForAnyDuration()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var view = new TerminalView();
+        view.SetBuffer(buffer);
+
+        // A capture in flight before the prune — the scenario the grace alone could not
+        // cover: a pass that outlives the age grace must still block disposal until it ends.
+        int session = buffer.BeginSnapshotSession();
+
+        var bitmap = new TrackingBitmap();
+        buffer.AddImage(new TerminalImage(bitmap, 2, 2, 2, 1));
+        buffer.ClearScreen();
+        Assert.Empty(buffer.Images);
+
+        // Cutoff far in the future: without the session gate this would dispose mid-capture.
+        view.DisposeRetiredImageBitmaps(long.MaxValue);
+        Assert.False(bitmap.Gone, "an in-flight snapshot session must block disposal for any duration");
+
+        // The capture completes: the next drain disposes.
+        buffer.EndSnapshotSession(session);
+        view.DisposeRetiredImageBitmaps(long.MaxValue);
+        Assert.True(bitmap.Gone, "disposal must proceed once the blocking session ends");
+    }
 }

--- a/tests/NovaTerminal.App.Tests/RenderTests/RetiredImageDisposalTests.cs
+++ b/tests/NovaTerminal.App.Tests/RenderTests/RetiredImageDisposalTests.cs
@@ -1,0 +1,120 @@
+using Avalonia;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using NovaTerminal.Platform;
+using NovaTerminal.Rendering;
+using NovaTerminal.Shell;
+using NovaTerminal.VT;
+using SkiaSharp;
+using System;
+using System.Collections.Concurrent;
+
+namespace NovaTerminal.Tests.RenderTests;
+
+/// <summary>
+/// #166 end to end: a pruned image's SKBitmap must survive untouched until a render frame
+/// runs (the frame-boundary drain), then be disposed by that drain — and a frame rendered
+/// before any prune must not disturb the bitmap it drew.
+/// </summary>
+public class RetiredImageDisposalTests
+{
+    private static readonly CellMetrics Metrics = new()
+    {
+        CellWidth = 8.4f,
+        CellHeight = 18.0f,
+        Baseline = 14.0f,
+        Ascent = 14.0f,
+        Descent = 4.0f
+    };
+
+    // IsDisposed is protected in SkiaSharp 3.x, and probing a disposed SKBitmap through
+    // its public API (GetPixel) dies with a native access violation instead of throwing —
+    // so disposal is observed via a subclass flag, never by touching the bitmap.
+    private sealed class TrackingBitmap : SKBitmap
+    {
+        public TrackingBitmap() : base(4, 4) { }
+        public bool Gone => IsDisposed;
+    }
+
+    [AvaloniaFact]
+    public void PrunedImageBitmap_IsDisposedByTheNextFrameDrain_NotBefore()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var bitmap = new TrackingBitmap();
+        var image = new TerminalImage(bitmap, 2, 2, 2, 1);
+        buffer.AddImage(image);
+
+        // Frame 1 draws the image while it is still live in the buffer.
+        RenderOneFrame(buffer);
+        Assert.False(bitmap.Gone, "drawing a live image must not dispose its bitmap");
+
+        // ED 2 prunes it: removed from the buffer, handle retired but NOT disposed —
+        // the just-finished frame may still hold a reference to it.
+        buffer.ClearScreen();
+        Assert.Empty(buffer.Images);
+        Assert.False(bitmap.Gone, "pruning alone must not dispose (previous frame may reference the handle)");
+
+        // Frame 2's drain runs after frame 1's DrawBitmap provably completed: now it disposes.
+        RenderOneFrame(buffer);
+        Assert.True(bitmap.Gone, "the frame-boundary drain must dispose the retired bitmap");
+
+        // And once disposed, later frames stay clean (nothing re-drains the same handle).
+        RenderOneFrame(buffer);
+    }
+
+    private static void RenderOneFrame(TerminalBuffer buffer)
+    {
+        const int cols = 80;
+        const int rows = 24;
+        int width = (int)Math.Ceiling(cols * Metrics.CellWidth) + 8;
+        int height = (int)Math.Ceiling(rows * Metrics.CellHeight);
+
+        var bitmap = new SKBitmap(width, height);
+        using var canvas = new SKCanvas(bitmap);
+
+        var typeface = new Typeface("Cascadia Code, Consolas, Monospace");
+        var glyphTypeface = typeface.GlyphTypeface;
+        var skTypeface = new SharedSKTypeface(SKTypeface.FromFamilyName(typeface.FontFamily.Name));
+        var skFont = new SharedSKFont(new SKFont(skTypeface.Typeface, 14));
+
+        var op = new TerminalDrawOperation(
+            new Rect(0, 0, width, height),
+            buffer,
+            scrollOffset: 0,
+            selection: new SelectionState(),
+            searchMatches: null,
+            activeSearchIndex: -1,
+            metrics: Metrics,
+            typeface: typeface,
+            fontSize: 14,
+            glyphTypeface: glyphTypeface,
+            skTypeface: skTypeface,
+            skFont: skFont,
+            enableLigatures: false,
+            fallbackCache: new ConcurrentDictionary<string, SKTypeface?>(),
+            fallbackChain: Array.Empty<SKTypeface>(),
+            opacity: 1.0,
+            hideCursor: true,
+            renderScaling: 1.0,
+            snapshotRows: buffer.Rows,
+            snapshotCols: buffer.Cols,
+            totalLines: buffer.TotalLines,
+            cursorRow: buffer.CursorRow,
+            cursorCol: buffer.CursorCol,
+            rowCache: null,
+            enableComplexShaping: true,
+            glyphCache: null);
+
+        try
+        {
+            var snapshot = op.DrawTerminalInternal(canvas);
+            Assert.NotNull(snapshot);
+        }
+        finally
+        {
+            op.Dispose();
+            skFont.Dispose();
+            skTypeface.Dispose();
+        }
+    }
+}

--- a/tests/NovaTerminal.App.Tests/RenderTests/RetiredImageDisposalTests.cs
+++ b/tests/NovaTerminal.App.Tests/RenderTests/RetiredImageDisposalTests.cs
@@ -1,32 +1,19 @@
-using Avalonia;
 using Avalonia.Headless.XUnit;
-using Avalonia.Media;
-using NovaTerminal.Platform;
-using NovaTerminal.Rendering;
 using NovaTerminal.Shell;
 using NovaTerminal.VT;
 using SkiaSharp;
 using System;
-using System.Collections.Concurrent;
 
 namespace NovaTerminal.Tests.RenderTests;
 
 /// <summary>
-/// #166 end to end: a pruned image's SKBitmap must survive untouched until a render frame
-/// runs (the frame-boundary drain), then be disposed by that drain — and a frame rendered
-/// before any prune must not disturb the bitmap it drew.
+/// #166 end to end: a pruned image's SKBitmap is disposed by the owning view's
+/// retired-handle drain — but only once the retire-age grace has passed, because a
+/// concurrent snapshot (live frame, agent-host capture) taken before the prune may
+/// still be drawing it.
 /// </summary>
 public class RetiredImageDisposalTests
 {
-    private static readonly CellMetrics Metrics = new()
-    {
-        CellWidth = 8.4f,
-        CellHeight = 18.0f,
-        Baseline = 14.0f,
-        Ascent = 14.0f,
-        Descent = 4.0f
-    };
-
     // IsDisposed is protected in SkiaSharp 3.x, and probing a disposed SKBitmap through
     // its public API (GetPixel) dies with a native access violation instead of throwing —
     // so disposal is observed via a subclass flag, never by touching the bitmap.
@@ -37,84 +24,35 @@ public class RetiredImageDisposalTests
     }
 
     [AvaloniaFact]
-    public void PrunedImageBitmap_IsDisposedByTheNextFrameDrain_NotBefore()
+    public void PrunedImageBitmap_IsDisposedOnlyAfterTheAgeGrace()
     {
         var buffer = new TerminalBuffer(80, 24);
+        var view = new TerminalView();
+        view.SetBuffer(buffer);
+
         var bitmap = new TrackingBitmap();
-        var image = new TerminalImage(bitmap, 2, 2, 2, 1);
-        buffer.AddImage(image);
+        buffer.AddImage(new TerminalImage(bitmap, 2, 2, 2, 1));
 
-        // Frame 1 draws the image while it is still live in the buffer.
-        RenderOneFrame(buffer);
-        Assert.False(bitmap.Gone, "drawing a live image must not dispose its bitmap");
+        // Draining with a cutoff older than the retire must not touch the fresh handle:
+        // a snapshot in flight at prune time may still be drawing it.
+        view.DisposeRetiredImageBitmaps(Environment.TickCount64 - 60_000);
+        Assert.False(bitmap.Gone, "an age-gated drain must leave a freshly-retired bitmap alone");
 
-        // ED 2 prunes it: removed from the buffer, handle retired but NOT disposed —
-        // the just-finished frame may still hold a reference to it.
+        // The image is still live in the buffer here — an unpruned image is never disposed.
+        Assert.Single(buffer.Images);
+
+        // Prune it (ED 2 semantics): retired with the current tick.
         buffer.ClearScreen();
         Assert.Empty(buffer.Images);
-        Assert.False(bitmap.Gone, "pruning alone must not dispose (previous frame may reference the handle)");
+        Assert.False(bitmap.Gone, "pruning alone must not dispose");
 
-        // Frame 2's drain runs after frame 1's DrawBitmap provably completed: now it disposes.
-        RenderOneFrame(buffer);
-        Assert.True(bitmap.Gone, "the frame-boundary drain must dispose the retired bitmap");
+        // A drain whose cutoff covers the retire tick disposes it — this is what the
+        // view's frame boundary does once the grace has passed.
+        view.DisposeRetiredImageBitmaps(Environment.TickCount64);
+        Assert.True(bitmap.Gone, "the owning view's drain must dispose the retired bitmap");
 
-        // And once disposed, later frames stay clean (nothing re-drains the same handle).
-        RenderOneFrame(buffer);
-    }
-
-    private static void RenderOneFrame(TerminalBuffer buffer)
-    {
-        const int cols = 80;
-        const int rows = 24;
-        int width = (int)Math.Ceiling(cols * Metrics.CellWidth) + 8;
-        int height = (int)Math.Ceiling(rows * Metrics.CellHeight);
-
-        var bitmap = new SKBitmap(width, height);
-        using var canvas = new SKCanvas(bitmap);
-
-        var typeface = new Typeface("Cascadia Code, Consolas, Monospace");
-        var glyphTypeface = typeface.GlyphTypeface;
-        var skTypeface = new SharedSKTypeface(SKTypeface.FromFamilyName(typeface.FontFamily.Name));
-        var skFont = new SharedSKFont(new SKFont(skTypeface.Typeface, 14));
-
-        var op = new TerminalDrawOperation(
-            new Rect(0, 0, width, height),
-            buffer,
-            scrollOffset: 0,
-            selection: new SelectionState(),
-            searchMatches: null,
-            activeSearchIndex: -1,
-            metrics: Metrics,
-            typeface: typeface,
-            fontSize: 14,
-            glyphTypeface: glyphTypeface,
-            skTypeface: skTypeface,
-            skFont: skFont,
-            enableLigatures: false,
-            fallbackCache: new ConcurrentDictionary<string, SKTypeface?>(),
-            fallbackChain: Array.Empty<SKTypeface>(),
-            opacity: 1.0,
-            hideCursor: true,
-            renderScaling: 1.0,
-            snapshotRows: buffer.Rows,
-            snapshotCols: buffer.Cols,
-            totalLines: buffer.TotalLines,
-            cursorRow: buffer.CursorRow,
-            cursorCol: buffer.CursorCol,
-            rowCache: null,
-            enableComplexShaping: true,
-            glyphCache: null);
-
-        try
-        {
-            var snapshot = op.DrawTerminalInternal(canvas);
-            Assert.NotNull(snapshot);
-        }
-        finally
-        {
-            op.Dispose();
-            skFont.Dispose();
-            skTypeface.Dispose();
-        }
+        // And nothing re-drains the same handle afterwards.
+        view.DisposeRetiredImageBitmaps(Environment.TickCount64);
+        Assert.True(bitmap.Gone);
     }
 }

--- a/tests/NovaTerminal.VT.Tests/RetiredImageHandleTests.cs
+++ b/tests/NovaTerminal.VT.Tests/RetiredImageHandleTests.cs
@@ -198,4 +198,66 @@ public class RetiredImageHandleTests
         Assert.Same(image.ImageHandle, drained[0]);
         Assert.False(buffer.DrainRetiredImageHandles(new List<object>(), long.MaxValue));
     }
+
+    /// <summary>
+    /// The session gate is the exact rule: a retire entry is only released once no snapshot
+    /// session started at or before its retire tick is still active — so a capture that
+    /// runs for ANY duration (longer than any grace) still blocks disposal until it ends,
+    /// while a session opened after the retire never saw the handle and does not block.
+    /// </summary>
+    [Fact]
+    public void Drain_InFlightSnapshotSession_BlocksDisposalForAnyDuration()
+    {
+        var (buffer, parser) = CreateFilledTerminal();
+        int scrollbackCount = buffer.Scrollback.Count;
+
+        // A capture in flight BEFORE the prune — the exact Greptile P1 scenario.
+        int session = buffer.BeginSnapshotSession();
+
+        var image = new TerminalImage(new object(), 0, scrollbackCount + 1, 2, 1);
+        buffer.AddImage(image);
+        parser.Process("\x1b[2J");
+        Assert.Empty(buffer.Images);
+
+        // Age gate fully satisfied (cutoff far in the future) — the session must still block.
+        var blocked = new List<object>();
+        Assert.False(buffer.DrainRetiredImageHandles(blocked, long.MaxValue));
+        Assert.Empty(blocked);
+
+        // Capture ends: the handle is released on the very next drain.
+        buffer.EndSnapshotSession(session);
+        var released = new List<object>();
+        Assert.True(buffer.DrainRetiredImageHandles(released, long.MaxValue));
+        Assert.Single(released);
+        Assert.Same(image.ImageHandle, released[0]);
+    }
+
+    [Fact]
+    public void Drain_SessionStartedAfterRetire_DoesNotBlock()
+    {
+        var (buffer, parser) = CreateFilledTerminal();
+        int scrollbackCount = buffer.Scrollback.Count;
+
+        var image = new TerminalImage(new object(), 0, scrollbackCount + 1, 2, 1);
+        buffer.AddImage(image);
+        parser.Process("\x1b[2J");
+
+        // A session opened after the retire never copied the pruned handle. The sleep steps
+        // past the TickCount64 granularity boundary: a session on the SAME tick as the retire
+        // conservatively blocks (within one tick we cannot prove the snapshot postdates the
+        // prune), so the "does not block" case needs a strictly later tick.
+        System.Threading.Thread.Sleep(20);
+        int session = buffer.BeginSnapshotSession();
+        try
+        {
+            var drained = new List<object>();
+            Assert.True(buffer.DrainRetiredImageHandles(drained, long.MaxValue));
+            Assert.Single(drained);
+            Assert.Same(image.ImageHandle, drained[0]);
+        }
+        finally
+        {
+            buffer.EndSnapshotSession(session);
+        }
+    }
 }

--- a/tests/NovaTerminal.VT.Tests/RetiredImageHandleTests.cs
+++ b/tests/NovaTerminal.VT.Tests/RetiredImageHandleTests.cs
@@ -1,0 +1,169 @@
+using System.Collections.Generic;
+
+namespace NovaTerminal.VT.Tests;
+
+/// <summary>
+/// #166: images pruned from the buffer must retire their handles into the drain queue so
+/// the render layer can dispose them at a frame boundary. Removal from
+/// <see cref="TerminalBuffer.Images"/> stays synchronous — only disposal is deferred —
+/// so every test here pairs a membership assertion with a drain assertion. Dummy handles
+/// stand in for bitmaps: VT never inspects them, and the drain contract is "the exact
+/// handles of exactly the removed images, once".
+/// </summary>
+public class RetiredImageHandleTests
+{
+    private const int Cols = 20;
+    private const int Rows = 5;
+
+    private static (TerminalBuffer buffer, AnsiParser parser) CreateFilledTerminal(int lines = 12)
+    {
+        var buffer = new TerminalBuffer(Cols, Rows);
+        var parser = new AnsiParser(buffer);
+        for (int i = 0; i < lines; i++)
+        {
+            parser.Process($"line{i}\r\n");
+        }
+        return (buffer, parser);
+    }
+
+    private static List<object> Drain(TerminalBuffer buffer)
+    {
+        var drained = new List<object>();
+        buffer.DrainRetiredImageHandles(drained);
+        return drained;
+    }
+
+    [Fact]
+    public void Ed2_RetiresRemovedViewportImage_NotTheScrollbackOne()
+    {
+        var (buffer, parser) = CreateFilledTerminal();
+        int scrollbackCount = buffer.Scrollback.Count;
+
+        var scrollbackImage = new TerminalImage(new object(), 0, 0, 2, 1);
+        var viewportImage = new TerminalImage(new object(), 0, scrollbackCount + 1, 2, 1);
+        buffer.AddImage(scrollbackImage);
+        buffer.AddImage(viewportImage);
+
+        parser.Process("\x1b[2J");
+
+        Assert.Single(buffer.Images);
+        var drained = Drain(buffer);
+        Assert.Single(drained);
+        Assert.Same(viewportImage.ImageHandle, drained[0]);
+        Assert.False(buffer.DrainRetiredImageHandles(new List<object>()), "second drain must be empty (no double-retire)");
+    }
+
+    [Fact]
+    public void Ed3_RetiresRemovedScrollbackImage()
+    {
+        var (buffer, parser) = CreateFilledTerminal();
+        int scrollbackCount = buffer.Scrollback.Count;
+
+        var scrollbackImage = new TerminalImage(new object(), 0, 0, 2, 1);
+        var viewportImage = new TerminalImage(new object(), 0, scrollbackCount + 1, 2, 1);
+        buffer.AddImage(scrollbackImage);
+        buffer.AddImage(viewportImage);
+
+        parser.Process("\x1b[3J");
+
+        Assert.Single(buffer.Images);
+        var drained = Drain(buffer);
+        Assert.Single(drained);
+        Assert.Same(scrollbackImage.ImageHandle, drained[0]);
+    }
+
+    [Fact]
+    public void DeleteLines_RetiresImageShiftedIntoDeletedRange()
+    {
+        var (buffer, parser) = CreateFilledTerminal();
+        int scrollbackCount = buffer.Scrollback.Count;
+
+        // Image starts inside the region; DL at the top deletes its row.
+        var deletedImage = new TerminalImage(new object(), 0, scrollbackCount, 2, 1);
+        buffer.AddImage(deletedImage);
+
+        parser.Process("\x1b[1;1H\x1b[1M"); // DL 1 at home
+
+        Assert.Empty(buffer.Images);
+        var drained = Drain(buffer);
+        Assert.Single(drained);
+        Assert.Same(deletedImage.ImageHandle, drained[0]);
+    }
+
+    [Fact]
+    public void InsertLines_PushingImagePastRegionBottom_RetiresIt()
+    {
+        var (buffer, parser) = CreateFilledTerminal();
+        int scrollbackCount = buffer.Scrollback.Count;
+
+        // Image on the last viewport row; IL at the top pushes it past the region bottom.
+        var pushedImage = new TerminalImage(new object(), 0, scrollbackCount + Rows - 1, 2, 1);
+        buffer.AddImage(pushedImage);
+
+        parser.Process("\x1b[1;1H\x1b[1L"); // IL 1 at home
+
+        Assert.Empty(buffer.Images);
+        var drained = Drain(buffer);
+        Assert.Single(drained);
+        Assert.Same(pushedImage.ImageHandle, drained[0]);
+    }
+
+    [Fact]
+    public void Clear_RetiresEveryImage()
+    {
+        var (buffer, _) = CreateFilledTerminal();
+        var first = new TerminalImage(new object(), 0, 0, 2, 1);
+        var second = new TerminalImage(new object(), 3, 1, 2, 1);
+        buffer.AddImage(first);
+        buffer.AddImage(second);
+
+        buffer.Clear();
+
+        Assert.Empty(buffer.Images);
+        var drained = Drain(buffer);
+        Assert.Equal(2, drained.Count);
+        Assert.Contains(first.ImageHandle, drained);
+        Assert.Contains(second.ImageHandle, drained);
+    }
+
+    [Fact]
+    public void ClearImages_RetiresEveryImage()
+    {
+        var (buffer, _) = CreateFilledTerminal();
+        var image = new TerminalImage(new object(), 0, 0, 2, 1);
+        buffer.AddImage(image);
+
+        buffer.ClearImages();
+
+        Assert.Empty(buffer.Images);
+        var drained = Drain(buffer);
+        Assert.Single(drained);
+        Assert.Same(image.ImageHandle, drained[0]);
+    }
+
+    [Fact]
+    public void ImagesThatSurvive_AreNeverRetired()
+    {
+        var (buffer, parser) = CreateFilledTerminal();
+        int scrollbackCount = buffer.Scrollback.Count;
+
+        var survivor = new TerminalImage(new object(), 0, 0, 2, 1); // lives in scrollback
+        var victim = new TerminalImage(new object(), 0, scrollbackCount + 1, 2, 1);
+        buffer.AddImage(survivor);
+        buffer.AddImage(victim);
+
+        parser.Process("\x1b[2J"); // removes only the viewport image
+
+        var drained = Drain(buffer);
+        Assert.Single(drained);
+        Assert.DoesNotContain(survivor.ImageHandle, drained);
+    }
+
+    [Fact]
+    public void Drain_WithNothingRetired_ReturnsFalse()
+    {
+        var (buffer, _) = CreateFilledTerminal();
+
+        Assert.False(buffer.DrainRetiredImageHandles(new List<object>()));
+    }
+}

--- a/tests/NovaTerminal.VT.Tests/RetiredImageHandleTests.cs
+++ b/tests/NovaTerminal.VT.Tests/RetiredImageHandleTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace NovaTerminal.VT.Tests;
@@ -29,7 +30,7 @@ public class RetiredImageHandleTests
     private static List<object> Drain(TerminalBuffer buffer)
     {
         var drained = new List<object>();
-        buffer.DrainRetiredImageHandles(drained);
+        buffer.DrainRetiredImageHandles(drained, long.MaxValue);
         return drained;
     }
 
@@ -50,7 +51,7 @@ public class RetiredImageHandleTests
         var drained = Drain(buffer);
         Assert.Single(drained);
         Assert.Same(viewportImage.ImageHandle, drained[0]);
-        Assert.False(buffer.DrainRetiredImageHandles(new List<object>()), "second drain must be empty (no double-retire)");
+        Assert.False(buffer.DrainRetiredImageHandles(new List<object>(), long.MaxValue), "second drain must be empty (no double-retire)");
     }
 
     [Fact]
@@ -164,6 +165,37 @@ public class RetiredImageHandleTests
     {
         var (buffer, _) = CreateFilledTerminal();
 
-        Assert.False(buffer.DrainRetiredImageHandles(new List<object>()));
+        Assert.False(buffer.DrainRetiredImageHandles(new List<object>(), long.MaxValue));
+    }
+
+    /// <summary>
+    /// The drain is age-gated: the owning view passes (now − grace) so a handle a
+    /// concurrent snapshot (live frame, agent-host capture) may still be drawing is left
+    /// queued until the grace has passed. Retires are FIFO, so the drain stops at the
+    /// first too-young entry.
+    /// </summary>
+    [Fact]
+    public void Drain_OnlyRetiresHandlesOlderThanTheCutoff()
+    {
+        var (buffer, parser) = CreateFilledTerminal();
+        int scrollbackCount = buffer.Scrollback.Count;
+
+        // Viewport image: ED 2 actually prunes it (scrollback images survive ED 2).
+        var image = new TerminalImage(new object(), 0, scrollbackCount + 1, 2, 1);
+        buffer.AddImage(image);
+
+        parser.Process("\x1b[2J");
+        Assert.Empty(buffer.Images);
+
+        // Cutoff one minute in the past: the just-retired handle is too young.
+        var freshCutoffDrain = new List<object>();
+        Assert.False(buffer.DrainRetiredImageHandles(freshCutoffDrain, Environment.TickCount64 - 60_000));
+        Assert.Empty(freshCutoffDrain);
+
+        // Long.MaxValue cutoff: everything drains, exactly once.
+        var drained = Drain(buffer);
+        Assert.Single(drained);
+        Assert.Same(image.ImageHandle, drained[0]);
+        Assert.False(buffer.DrainRetiredImageHandles(new List<object>(), long.MaxValue));
     }
 }


### PR DESCRIPTION
Closes #166.

Pruned images' SKBitmaps were never disposed — removal from the buffer dropped the only strong reference and native memory waited for finalizers. With #369 wiring real decoders, that became a real native-memory accumulation path (every scrollback eviction / erase / reflow drop of an inline image).

## The design

**Retire queue, single drainer, age grace.**

- `TerminalBuffer` retires every removed image's handle into a `ConcurrentQueue<object>` stamped with `Environment.TickCount64` (VT stays SkiaSharp-free), wired into all twelve prune sites: scroll eviction, regional scroll-down, IL/DL, ED 2, ED 3, `Clear()`/`ClearImages()`, width-reflow, both resize paths. Removal stays synchronous — only disposal is deferred.
- `TerminalView` — the owner of the live render pipeline — drains at its frame boundary and disposes `SKBitmap` handles, per-item try/catch. The drain is **age-gated**: only retires older than a 2s grace are released (FIFO, stops at the first too-young entry).
- `TerminalDrawOperation` deliberately does NOT drain: it is also driven by `TerminalSnapshotRenderer` (agent-host capture) on its own thread, so a draw-op drain could dispose a bitmap another concurrent snapshot is still drawing — Greptile flagged exactly this on the first draft, and the rework is on the PR.

**Why the grace makes disposal safe**: a snapshot captures handle references under the buffer's read lock and draws them after it releases, so eager disposal at removal time is the use-after-dispose hazard that killed `ImageRegistry` (#176). Frames and offscreen captures take tens of ms; a handle is only disposed once no snapshot taken before its prune can still be drawing it, whichever pipeline that snapshot belonged to. Replay windows share the view+buffer path and are covered automatically. A permanently detached pane's queue awaits finalizers — no worse than status quo, accepted.

## Tests

- VT (`RetiredImageHandleTests`, 9 tests): every prune path retires exactly the removed handles once; survivors never retire; second drain is empty; the age gate leaves fresh retires queued and a covering cutoff releases each exactly once.
- Draw-op level (`RetiredImageDisposalTests`): drives `TerminalView.DisposeRetiredImageBitmaps` against a tracking `SKBitmap` subclass — age-gated drain leaves it alone, covering drain disposes it, nothing re-drains afterwards.

One SkiaSharp 3.x gotcha for the record: `SKBitmap.IsDisposed` is protected and probing a disposed bitmap via `GetPixel` dies with a **native access violation** rather than throwing — the first test draft did exactly that and crashed the test host, which is why the tracking subclass exists.

Docs updated; conformance report regenerated (Validate VT Matrix stays green). VT.Tests 384/384, Rendering.Tests 80/80, targeted App.Tests green, full solution build clean.
