### PR TITLE
fix(vt): keep dotnet terminal logger updates in place

### DIFF
--- a/docs/plans/2026-08-30-dotnet-terminal-logger-cursor-lines-design.md
+++ b/docs/plans/2026-08-30-dotnet-terminal-logger-cursor-lines-design.md
@@ -1,0 +1,22 @@
+# .NET Terminal Logger Cursor-Line Design
+
+## Problem
+
+.NET 10's terminal logger redraws its progress area with `CSI Ps F` (Cursor Preceding Line), followed by carriage return and line feed. NovaTerminal currently does not handle CSI `F`, so the cursor remains on its current row and each refresh advances to another row. The elapsed-time text therefore forms a vertical staircase instead of updating in place.
+
+## Design
+
+Implement the standard CSI `E` (Cursor Next Line) and CSI `F` (Cursor Preceding Line) commands in `AnsiParser`. Both commands move vertically by `Ps`, defaulting zero or an omitted parameter to one, and set the cursor column to zero. Vertical movement follows the existing CSI `A`/`B` behavior: clamp to the active scrolling region when the cursor starts inside it, otherwise clamp to viewport bounds.
+
+The change stays entirely in the VT parser. It does not alter PTY input, terminal-grid rendering, Command Assist, or application UI.
+
+## Testing
+
+Add deterministic parser tests that cover:
+
+- CSI `E` and `F` default, explicit, and large distances.
+- Column reset to zero.
+- Scroll-region and viewport clamping.
+- A reduced stream matching .NET 10's `CSI 1 F`, CR, LF refresh pattern, proving repeated updates overwrite one progress row instead of consuming new rows.
+
+Run the focused regression tests, the complete VT test project, and a build before opening the pull request.

--- a/docs/plans/2026-08-30-dotnet-terminal-logger-cursor-lines.md
+++ b/docs/plans/2026-08-30-dotnet-terminal-logger-cursor-lines.md
@@ -28,7 +28,7 @@ Process an initial progress row followed by repeated `\x1b[1F\r\n\x1b[K...\r\n` 
 Run:
 
 ```powershell
-dotnet test tests/NovaTerminal.VT.Tests/NovaTerminal.VT.Tests.csproj -nologo -nodeReuse:false --filter FullyQualifiedName~CursorLinePositioningTests
+rtk pwsh -NoProfile -File scripts/build.ps1 test tests/NovaTerminal.VT.Tests/NovaTerminal.VT.Tests.csproj -nologo --filter FullyQualifiedName~CursorLinePositioningTests
 ```
 
 Expected: failures showing that CSI `E` and `F` leave the cursor row/column unchanged and that the refresh stream consumes extra rows.
@@ -61,7 +61,7 @@ Expected: all `CursorLinePositioningTests` pass.
 **Step 1: Run the complete VT test project**
 
 ```powershell
-dotnet test tests/NovaTerminal.VT.Tests/NovaTerminal.VT.Tests.csproj -nologo --no-restore -nodeReuse:false
+rtk pwsh -NoProfile -File scripts/build.ps1 test tests/NovaTerminal.VT.Tests/NovaTerminal.VT.Tests.csproj -nologo --no-restore
 ```
 
 Expected: zero failed tests.
@@ -69,20 +69,20 @@ Expected: zero failed tests.
 **Step 2: Build the VT project**
 
 ```powershell
-dotnet build src/NovaTerminal.VT/NovaTerminal.VT.csproj -nologo --no-restore -nodeReuse:false
+rtk pwsh -NoProfile -File scripts/build.ps1 build src/NovaTerminal.VT/NovaTerminal.VT.csproj -nologo --no-restore
 ```
 
 Expected: exit code zero; any analyzer warnings match the clean baseline.
 
 **Step 3: Review the diff and commit**
 
-Review `git diff --check` and the complete branch diff, then commit the parser and regression tests with a focused fix message.
+Review `rtk git diff --check` and the complete branch diff, then commit the parser and regression tests with a focused fix message.
 
 ### Task 4: Publish and respond to review
 
 **Step 1: Push and open a pull request**
 
-Push `codex/dotnet-terminal-logger-cursor-lines` and create a PR describing the captured .NET 10 sequence, parser fix, and verification.
+Use `rtk git push` to publish `codex/dotnet-terminal-logger-cursor-lines`, then use `rtk gh pr create` to open a PR describing the captured .NET 10 sequence, parser fix, and verification.
 
 **Step 2: Monitor checks and Greptile review**
 

--- a/docs/plans/2026-08-30-dotnet-terminal-logger-cursor-lines.md
+++ b/docs/plans/2026-08-30-dotnet-terminal-logger-cursor-lines.md
@@ -1,0 +1,93 @@
+# .NET Terminal Logger Cursor-Line Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make .NET 10 terminal-logger progress redraws update in place by supporting the standard CSI cursor-line commands.
+
+**Architecture:** Add CSI `E` and `F` routing beside the existing relative cursor commands in `AnsiParser`. Keep movement semantics consistent with CSI `A` and `B`, including scroll-region clamping, while resetting the horizontal cursor position as required by CNL/CPL.
+
+**Tech Stack:** C# 14, .NET 10, xUnit v3
+
+---
+
+### Task 1: Reproduce the missing CNL/CPL behavior
+
+**Files:**
+- Create: `tests/NovaTerminal.VT.Tests/CursorLinePositioningTests.cs`
+
+**Step 1: Write the failing cursor-command tests**
+
+Add theories for omitted, zero, explicit, and oversized CSI `E`/`F` parameters. Start from a nonzero column and assert the expected clamped row and column zero. Add cases with a restricted scrolling region and cases starting outside that region.
+
+**Step 2: Write the failing .NET refresh regression test**
+
+Process an initial progress row followed by repeated `\x1b[1F\r\n\x1b[K...\r\n` refreshes. Assert that the refreshed text occupies the same row and that no timer staircase appears below it.
+
+**Step 3: Run the focused tests to verify RED**
+
+Run:
+
+```powershell
+dotnet test tests/NovaTerminal.VT.Tests/NovaTerminal.VT.Tests.csproj -nologo -nodeReuse:false --filter FullyQualifiedName~CursorLinePositioningTests
+```
+
+Expected: failures showing that CSI `E` and `F` leave the cursor row/column unchanged and that the refresh stream consumes extra rows.
+
+### Task 2: Implement standard CSI E/F handling
+
+**Files:**
+- Modify: `src/NovaTerminal.VT/AnsiParser.cs`
+
+**Step 1: Implement CSI E**
+
+Add a `case 'E'` next-line command beside CSI `B`. Use `Math.Max(1, arg0)`, apply the same scroll-region/viewport clamping as CSI `B`, set `CursorCol` to zero, and invalidate the buffer.
+
+**Step 2: Implement CSI F**
+
+Add a `case 'F'` preceding-line command beside CSI `A`. Use `Math.Max(1, arg0)`, apply the same scroll-region/viewport clamping as CSI `A`, set `CursorCol` to zero, and invalidate the buffer.
+
+**Step 3: Run the focused tests to verify GREEN**
+
+Run the filtered command from Task 1.
+
+Expected: all `CursorLinePositioningTests` pass.
+
+### Task 3: Verify and commit the fix
+
+**Files:**
+- Test: `tests/NovaTerminal.VT.Tests/CursorLinePositioningTests.cs`
+- Modify: `src/NovaTerminal.VT/AnsiParser.cs`
+
+**Step 1: Run the complete VT test project**
+
+```powershell
+dotnet test tests/NovaTerminal.VT.Tests/NovaTerminal.VT.Tests.csproj -nologo --no-restore -nodeReuse:false
+```
+
+Expected: zero failed tests.
+
+**Step 2: Build the VT project**
+
+```powershell
+dotnet build src/NovaTerminal.VT/NovaTerminal.VT.csproj -nologo --no-restore -nodeReuse:false
+```
+
+Expected: exit code zero; any analyzer warnings match the clean baseline.
+
+**Step 3: Review the diff and commit**
+
+Review `git diff --check` and the complete branch diff, then commit the parser and regression tests with a focused fix message.
+
+### Task 4: Publish and respond to review
+
+**Step 1: Push and open a pull request**
+
+Push `codex/dotnet-terminal-logger-cursor-lines` and create a PR describing the captured .NET 10 sequence, parser fix, and verification.
+
+**Step 2: Monitor checks and Greptile review**
+
+Wait for automated checks and Greptile feedback. Read all feedback, verify each finding against the VT semantics and tests, and implement only technically valid changes.
+
+**Step 3: Re-verify and push review fixes**
+
+For each accepted finding, add or adjust a failing test first when behavior changes, implement the minimal fix, run focused and complete VT tests, commit, and push.

--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -807,6 +807,7 @@ namespace NovaTerminal.VT
                         }
                         break;
                     case 'F': // Cursor Preceding Line
+                        if (leader == '\0' && intermediates.Length == 0)
                         {
                             int dist = Math.Max(1, arg0);
                             if (_buffer.CursorRow >= _buffer.ScrollTop && _buffer.CursorRow <= _buffer.ScrollBottom)
@@ -828,6 +829,7 @@ namespace NovaTerminal.VT
                         }
                         break;
                     case 'E': // Cursor Next Line
+                        if (leader == '\0' && intermediates.Length == 0)
                         {
                             int dist = Math.Max(1, arg0);
                             if (_buffer.CursorRow >= _buffer.ScrollTop && _buffer.CursorRow <= _buffer.ScrollBottom)

--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -806,6 +806,17 @@ namespace NovaTerminal.VT
                             _buffer.Invalidate();
                         }
                         break;
+                    case 'F': // Cursor Preceding Line
+                        {
+                            int dist = Math.Max(1, arg0);
+                            if (_buffer.CursorRow >= _buffer.ScrollTop && _buffer.CursorRow <= _buffer.ScrollBottom)
+                                _buffer.CursorRow = Math.Max(_buffer.ScrollTop, _buffer.CursorRow - dist);
+                            else
+                                _buffer.CursorRow = Math.Max(0, _buffer.CursorRow - dist);
+                            _buffer.CursorCol = 0;
+                            _buffer.Invalidate();
+                        }
+                        break;
                     case 'B': // Cursor Down
                         {
                             int dist = Math.Max(1, arg0);
@@ -813,6 +824,17 @@ namespace NovaTerminal.VT
                                 _buffer.CursorRow = Math.Min(_buffer.ScrollBottom, _buffer.CursorRow + dist);
                             else
                                 _buffer.CursorRow = Math.Min(_buffer.Rows - 1, _buffer.CursorRow + dist);
+                            _buffer.Invalidate();
+                        }
+                        break;
+                    case 'E': // Cursor Next Line
+                        {
+                            int dist = Math.Max(1, arg0);
+                            if (_buffer.CursorRow >= _buffer.ScrollTop && _buffer.CursorRow <= _buffer.ScrollBottom)
+                                _buffer.CursorRow = Math.Min(_buffer.ScrollBottom, _buffer.CursorRow + dist);
+                            else
+                                _buffer.CursorRow = Math.Min(_buffer.Rows - 1, _buffer.CursorRow + dist);
+                            _buffer.CursorCol = 0;
                             _buffer.Invalidate();
                         }
                         break;

--- a/tests/NovaTerminal.VT.Tests/CursorLinePositioningTests.cs
+++ b/tests/NovaTerminal.VT.Tests/CursorLinePositioningTests.cs
@@ -75,6 +75,23 @@ public class CursorLinePositioningTests
         Assert.Equal(0, buffer.CursorCol);
     }
 
+    [Theory]
+    [InlineData("\x1b[?2E")]
+    [InlineData("\x1b[2$E")]
+    [InlineData("\x1b[?2F")]
+    [InlineData("\x1b[2$F")]
+    public void CnlAndCpl_PrivateOrIntermediateVariantsAreIgnored(string sequence)
+    {
+        var buffer = new TerminalBuffer(cols: 12, rows: 8);
+        var parser = new AnsiParser(buffer);
+        parser.Process("\x1b[4;6H");
+
+        parser.Process(sequence);
+
+        Assert.Equal(3, buffer.CursorRow);
+        Assert.Equal(5, buffer.CursorCol);
+    }
+
     [Fact]
     public void DotnetTerminalLoggerRefresh_ReusesProgressRow()
     {

--- a/tests/NovaTerminal.VT.Tests/CursorLinePositioningTests.cs
+++ b/tests/NovaTerminal.VT.Tests/CursorLinePositioningTests.cs
@@ -1,0 +1,113 @@
+using System.Text;
+
+namespace NovaTerminal.VT.Tests;
+
+public class CursorLinePositioningTests
+{
+    [Theory]
+    [InlineData("\x1b[E", 4)]
+    [InlineData("\x1b[0E", 4)]
+    [InlineData("\x1b[2E", 5)]
+    [InlineData("\x1b[999E", 7)]
+    public void Cnl_MovesDownAndResetsColumn(string sequence, int expectedRow)
+    {
+        var buffer = new TerminalBuffer(cols: 12, rows: 8);
+        var parser = new AnsiParser(buffer);
+        parser.Process("\x1b[4;6H");
+
+        parser.Process(sequence);
+
+        Assert.Equal(expectedRow, buffer.CursorRow);
+        Assert.Equal(0, buffer.CursorCol);
+    }
+
+    [Theory]
+    [InlineData("\x1b[F", 2)]
+    [InlineData("\x1b[0F", 2)]
+    [InlineData("\x1b[2F", 1)]
+    [InlineData("\x1b[999F", 0)]
+    public void Cpl_MovesUpAndResetsColumn(string sequence, int expectedRow)
+    {
+        var buffer = new TerminalBuffer(cols: 12, rows: 8);
+        var parser = new AnsiParser(buffer);
+        parser.Process("\x1b[4;6H");
+
+        parser.Process(sequence);
+
+        Assert.Equal(expectedRow, buffer.CursorRow);
+        Assert.Equal(0, buffer.CursorCol);
+    }
+
+    [Theory]
+    [InlineData("\x1b[999E", 5)]
+    [InlineData("\x1b[999F", 2)]
+    public void CnlAndCpl_ClampToMarginsWhenCursorStartsInsideScrollRegion(
+        string sequence,
+        int expectedRow)
+    {
+        var buffer = new TerminalBuffer(cols: 12, rows: 8);
+        var parser = new AnsiParser(buffer);
+        parser.Process("\x1b[3;6r");
+        parser.Process("\x1b[5;6H");
+
+        parser.Process(sequence);
+
+        Assert.Equal(expectedRow, buffer.CursorRow);
+        Assert.Equal(0, buffer.CursorCol);
+    }
+
+    [Theory]
+    [InlineData("\x1b[1;6H", "\x1b[999E", 7)]
+    [InlineData("\x1b[8;6H", "\x1b[999F", 0)]
+    public void CnlAndCpl_ClampToViewportWhenCursorStartsOutsideScrollRegion(
+        string startPosition,
+        string sequence,
+        int expectedRow)
+    {
+        var buffer = new TerminalBuffer(cols: 12, rows: 8);
+        var parser = new AnsiParser(buffer);
+        parser.Process("\x1b[3;6r");
+        parser.Process(startPosition);
+
+        parser.Process(sequence);
+
+        Assert.Equal(expectedRow, buffer.CursorRow);
+        Assert.Equal(0, buffer.CursorCol);
+    }
+
+    [Fact]
+    public void DotnetTerminalLoggerRefresh_ReusesProgressRow()
+    {
+        var buffer = new TerminalBuffer(cols: 40, rows: 8);
+        var parser = new AnsiParser(buffer);
+        parser.Process("Build started\r\n");
+
+        parser.Process("\x1b[1F\r\n\x1b[K\x1b[31G(0.4s)");
+        parser.Process("\x1b[1F\r\n\x1b[K\x1b[31G(0.5s)");
+
+        Assert.Equal(1, buffer.CursorRow);
+        Assert.EndsWith("(0.5s)", GetRowText(buffer, 1), StringComparison.Ordinal);
+        Assert.DoesNotContain("(0.4s)", GetRowText(buffer, 1), StringComparison.Ordinal);
+        Assert.Equal(string.Empty, GetRowText(buffer, 2));
+        Assert.Equal(string.Empty, GetRowText(buffer, 3));
+    }
+
+    private static string GetRowText(TerminalBuffer buffer, int row)
+    {
+        var text = new StringBuilder(buffer.Cols);
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            for (int col = 0; col < buffer.Cols; col++)
+            {
+                text.Append(buffer.GetGrapheme(col, row));
+            }
+        }
+        finally
+        {
+            buffer.Lock.ExitReadLock();
+        }
+
+        return text.ToString().TrimEnd();
+    }
+}


### PR DESCRIPTION
## Summary
- handle standard CSI E/F cursor-line movement in the VT parser
- prevent .NET 10 terminal-logger refreshes from consuming new rows
- cover defaults, clamping, scroll margins, and the captured refresh pattern

## Test plan
- dotnet test tests/NovaTerminal.VT.Tests/NovaTerminal.VT.Tests.csproj -nologo --no-restore -nodeReuse:false (399 passed)
- dotnet build src/NovaTerminal.VT/NovaTerminal.VT.csproj -nologo --no-restore -nodeReuse:false (0 warnings, 0 errors)
- git diff --check HEAD~1 HEAD