### PR TITLE
Add an executable VT capability contract

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -55,6 +55,9 @@ Fixes #
        without metrics will be sent back. -->
 
 - **Does this change VT coverage?**
-  <!-- If you added or changed a sequence: update docs/vt_coverage_matrix.md
-       AND regenerate src/NovaTerminal.App/Resources/vt-conformance-report.json,
-       or the VT Conformance check goes red. See CONTRIBUTING.md. -->
+  <!-- If you added or changed a catalog-owned sequence: update
+       src/NovaTerminal.VtContract/vt-capabilities.json and add or update its
+       executable case in tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs.
+       Also update docs/vt_coverage_matrix.md AND regenerate
+       src/NovaTerminal.App/Resources/vt-conformance-report.json, or the VT
+       Conformance check goes red. See CONTRIBUTING.md. -->

--- a/.github/workflows/vt-conformance.yml
+++ b/.github/workflows/vt-conformance.yml
@@ -7,6 +7,8 @@ on:
       - "docs/ghostty-gaps/vt_conformance_tooling.md"
       - "src/NovaTerminal.App/Resources/vt-conformance-report.json"
       - "src/NovaTerminal.Conformance/**"
+      - "src/NovaTerminal.VtContract/**"
+      - "tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs"
       # Parser/buffer changes can invalidate matrix claims even when the matrix
       # itself is untouched, so run the gate for them too (#156).
       - "src/NovaTerminal.VT/**"
@@ -18,6 +20,8 @@ on:
       - "docs/ghostty-gaps/vt_conformance_tooling.md"
       - "src/NovaTerminal.App/Resources/vt-conformance-report.json"
       - "src/NovaTerminal.Conformance/**"
+      - "src/NovaTerminal.VtContract/**"
+      - "tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs"
       - "src/NovaTerminal.VT/**"
       - ".github/workflows/vt-conformance.yml"
   workflow_dispatch:

--- a/NovaTerminal.sln
+++ b/NovaTerminal.sln
@@ -47,6 +47,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NovaTerminal.CommandAssist"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NovaTerminal.Backup", "src\NovaTerminal.Backup\NovaTerminal.Backup.csproj", "{77C2766D-8D87-43D3-BE92-42910ACFB648}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NovaTerminal.VtContract", "src\NovaTerminal.VtContract\NovaTerminal.VtContract.csproj", "{371D13FE-6F65-4AEA-9426-E6C954A572BD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -297,6 +299,18 @@ Global
 		{77C2766D-8D87-43D3-BE92-42910ACFB648}.Release|x64.Build.0 = Release|Any CPU
 		{77C2766D-8D87-43D3-BE92-42910ACFB648}.Release|x86.ActiveCfg = Release|Any CPU
 		{77C2766D-8D87-43D3-BE92-42910ACFB648}.Release|x86.Build.0 = Release|Any CPU
+		{371D13FE-6F65-4AEA-9426-E6C954A572BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{371D13FE-6F65-4AEA-9426-E6C954A572BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{371D13FE-6F65-4AEA-9426-E6C954A572BD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{371D13FE-6F65-4AEA-9426-E6C954A572BD}.Debug|x64.Build.0 = Debug|Any CPU
+		{371D13FE-6F65-4AEA-9426-E6C954A572BD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{371D13FE-6F65-4AEA-9426-E6C954A572BD}.Debug|x86.Build.0 = Debug|Any CPU
+		{371D13FE-6F65-4AEA-9426-E6C954A572BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{371D13FE-6F65-4AEA-9426-E6C954A572BD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{371D13FE-6F65-4AEA-9426-E6C954A572BD}.Release|x64.ActiveCfg = Release|Any CPU
+		{371D13FE-6F65-4AEA-9426-E6C954A572BD}.Release|x64.Build.0 = Release|Any CPU
+		{371D13FE-6F65-4AEA-9426-E6C954A572BD}.Release|x86.ActiveCfg = Release|Any CPU
+		{371D13FE-6F65-4AEA-9426-E6C954A572BD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -322,5 +336,6 @@ Global
 		{A7C4E9D1-6B2F-4E8A-9F31-5D8C7B0A2E64} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{5C0E7A31-9D24-4F17-8B6E-2A93C1F40D58} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{77C2766D-8D87-43D3-BE92-42910ACFB648} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{371D13FE-6F65-4AEA-9426-E6C954A572BD} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/docs/MODULE_OWNERSHIP.md
+++ b/docs/MODULE_OWNERSHIP.md
@@ -168,6 +168,31 @@ invariant changes.
 
 ---
 
+## NovaTerminal.VtContract (`src/NovaTerminal.VtContract/`)
+
+**Namespace:** `NovaTerminal.VtContract`
+**Depends on:** *(leaf — only BCL)*
+**Public surface:** `VtCapabilityCatalog`, `VtCapability`, `VtSupport`, `VtCapabilityManifestException`
+
+**Owns**
+- The machine-readable catalog of developer-facing VT capability claims
+- Strict validation of catalog schema, unique sequence keys, support states, evidence links, and parser contract case names
+
+**Non-responsibilities**
+- Parsing terminal input or dispatching escape sequences; `NovaTerminal.VT` remains the sole owner of runtime VT semantics
+- Rendering, application UI, PTY I/O, or MCP transport
+
+**Invariants** (enforced by `VtContract_csproj_has_no_project_references` and the VT capability contract tests)
+- Leaf assembly — no project references, so conformance tooling, parser tests, and MCP developer tools can consume the same claims without opening a path into terminal core
+- The embedded JSON is the canonical capability source; supported entries require concrete repository evidence and an executable parser contract case
+
+**Test authority**
+- Schema and parser contracts: `tests/NovaTerminal.VT.Tests/VtCapabilityCatalogTests.cs`, `tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs`
+- Matrix agreement: `tests/NovaTerminal.Platform.Tests/Conformance/VtConformanceToolTests.cs`
+- Developer-tool agreement: `tests/NovaTerminal.McpServer.Tests/V2ToolsTests.cs`
+
+---
+
 ## NovaTerminal.Backup (`src/NovaTerminal.Backup/`)
 
 **Namespace:** `NovaTerminal.Backup`
@@ -190,7 +215,7 @@ invariant changes.
   the existing `TimeProvider?` injection style.
 
 **Invariants** (enforced by `Backup_csproj_has_no_project_references` and
-`McpServer_csproj_only_references_AgentHostContractsAndBackup`)
+`McpServer_csproj_only_references_approved_leaf_dependencies`)
 - **Leaf assembly — no project references, ever.** This is what makes it safe for
   `NovaTerminal.McpServer` to reference: a leaf cannot smuggle in App, VT, Pty, or Rendering no
   matter what it depends on, because it depends on nothing. Task 10a's first attempt routed the

--- a/docs/ghostty-gaps/vt_conformance_tooling.md
+++ b/docs/ghostty-gaps/vt_conformance_tooling.md
@@ -65,11 +65,36 @@ Warnings:
 
 Warnings are included in the report but do not fail CI.
 
+## Capability Contract
+
+`src/NovaTerminal.VtContract/vt-capabilities.json` is the machine-readable source
+of truth for sequences promoted into the capability contract. Each supported
+entry names:
+
+- the CSI key and mnemonic exposed to consumers
+- the exact coverage-matrix feature row
+- a repository evidence path
+- an executable contract-case identifier
+
+`tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs` maps those case
+identifiers to parser assertions. A supported entry without an executable case
+fails the VT test suite. The conformance tool independently rejects missing or
+duplicated matrix rows, status mismatches, missing evidence files, and matrix
+rows that do not link the declared evidence. MCP VT explanations read the same
+catalog, so documentation, tooling, and tested parser behavior share one claim.
+
+Keep the catalog deliberately narrow: add a sequence only when its behavior is
+covered across relevant defaults, bounds, invalid forms, and split-input parser
+boundaries. The broader matrix remains the inventory for capabilities that have
+not yet been promoted into this executable contract.
+
 ## CI
 
 `.github/workflows/vt-conformance.yml` runs the validator on:
 
 - `docs/vt_coverage_matrix.md`
+- `src/NovaTerminal.VtContract/vt-capabilities.json`
+- `tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs`
 - conformance tooling source changes
 - workflow/doc updates for this tooling
 
@@ -131,6 +156,6 @@ Implementation note:
 ## Intentional Limitations
 
 - The parser only reads markdown tables that include both `Status` and `Evidence` columns.
-- The tool does not infer support from source code; the matrix remains the canonical input.
+- The tool does not infer support from source code; catalog-owned claims are validated against executable evidence, while the matrix remains the broader inventory.
 - Ownership paths are reported verbatim and are not path-validated.
 - Generic evidence text such as `Replay` or `Unit/Replay` is accepted for `✅ Supported` rows, but reported as a warning until concrete links are added.

--- a/docs/plans/2026-08-30-vt-capability-contract-design.md
+++ b/docs/plans/2026-08-30-vt-capability-contract-design.md
@@ -1,0 +1,70 @@
+# VT Capability Contract Design
+
+## Problem
+
+NovaTerminal describes VT support in several independent places: the hot-path
+`AnsiParser` switch, the Markdown coverage matrix, the generated application
+report, and the MCP escape-sequence explainer. Those descriptions can drift.
+After CNL (`CSI E`) and CPL (`CSI F`) were implemented, the MCP explainer and
+its tests still described them as unsupported, while the grouped coverage row
+remained partial. Existing CI validated each artifact internally but did not
+prove that their support claims agreed with real parser behavior.
+
+## Design
+
+Add a small machine-readable capability manifest owned by the conformance
+tooling. Each entry identifies one CSI sequence by mnemonic and final byte,
+records its support state, names a deterministic evidence case, and provides
+the explanation used by developer tooling. Keep `AnsiParser` unchanged: its
+switch remains the performance-sensitive implementation, while tests verify
+manifest claims by sending representative byte streams through the public
+parser API.
+
+The conformance tool will load and validate the manifest. Validation will fail
+when entries are duplicated, supported entries lack evidence, or evidence does
+not cover the declared sequence. The MCP explainer will read its CSI descriptions
+from the same embedded manifest data instead of maintaining separate support
+sentences. The Markdown coverage matrix remains the human-readable summary, but
+CNL, CPL, and CHA will have separate rows so partial support cannot hide which
+sequence lacks evidence. The generated application report will be regenerated
+from that corrected matrix.
+
+This is deliberately additive. It does not generate parser dispatch code,
+reflect into parser internals, or add work to terminal input processing.
+
+## Data Flow
+
+1. The capability manifest declares the supported CSI feature and its evidence
+   identifier.
+2. Conformance tests load the manifest and run every supported cursor movement
+   case through `AnsiParser`.
+3. The conformance CLI validates the manifest alongside the Markdown matrix.
+4. The MCP explainer consumes the same descriptions, preventing a second support
+   table from drifting.
+5. CI runs the conformance tests and report validation whenever the parser,
+   manifest, matrix, or tooling changes.
+
+## Validation and Failure Handling
+
+Manifest parsing is strict and deterministic. Invalid JSON, duplicate sequence
+keys, unknown support states, missing descriptions, or supported entries without
+evidence are validation errors. Tooling reports the offending entry and exits
+non-zero. Runtime terminal behavior is unaffected because the parser does not
+load the manifest.
+
+## Testing
+
+- First add failing MCP tests proving CNL and CPL must be reported as supported.
+- Add failing manifest-validation tests for duplicates and missing evidence.
+- Add a contract test that executes each supported cursor capability through
+  `AnsiParser`, including omitted/zero parameters, bounds, private/intermediate
+  rejection, and split-input equivalence where applicable.
+- Update the matrix and regenerate the embedded report.
+- Run focused VT, conformance, and MCP tests, then the repository's full wrapped
+  test and build verification.
+
+## Deferred Work
+
+Byte-accurate fixtures for additional producers, live nightly PTY probes, and
+semantic fuzz invariants remain valuable follow-ups. They are intentionally not
+part of this PR so the first enforcement layer stays reviewable and low risk.

--- a/docs/plans/2026-08-30-vt-capability-contract.md
+++ b/docs/plans/2026-08-30-vt-capability-contract.md
@@ -1,0 +1,222 @@
+# VT Capability Contract Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make supported CSI cursor capabilities a single machine-readable contract that CI proves against the real parser and developer-facing tooling.
+
+**Architecture:** Add a zero-project-reference `NovaTerminal.VtContract` leaf with an embedded JSON manifest and strict loader. Conformance tooling validates each manifest entry against the Markdown matrix, MCP explanations consume the same catalog, and VT tests execute every supported contract case through `AnsiParser`; the parser hot path remains unchanged.
+
+**Tech Stack:** .NET 10, C#, System.Text.Json, xUnit v3, GitHub Actions, existing NovaTerminal build wrappers.
+
+---
+
+### Task 1: Add the catalog contract test surface
+
+**Files:**
+- Create: `src/NovaTerminal.VtContract/NovaTerminal.VtContract.csproj`
+- Create: `src/NovaTerminal.VtContract/vt-capabilities.json`
+- Create: `src/NovaTerminal.VtContract/VtCapabilityCatalog.cs`
+- Modify: `tests/NovaTerminal.VT.Tests/NovaTerminal.VT.Tests.csproj`
+- Create: `tests/NovaTerminal.VT.Tests/VtCapabilityCatalogTests.cs`
+
+**Step 1: Write the failing validation tests**
+
+Add tests calling the wished-for `VtCapabilityCatalog.Parse` API. Assert that valid JSON returns deterministic `VtCapability` records and that duplicate keys, invalid support values, missing descriptions, and supported entries without `evidencePath` or `contractCase` throw `VtCapabilityManifestException` naming the bad entry.
+
+**Step 2: Run the tests to verify RED**
+
+Run:
+`rtk pwsh -NoProfile -File scripts/build.ps1 test tests/NovaTerminal.VT.Tests/NovaTerminal.VT.Tests.csproj --filter FullyQualifiedName~VtCapabilityCatalogTests`
+
+Expected: build failure because `NovaTerminal.VtContract` and `VtCapabilityCatalog` do not exist.
+
+**Step 3: Implement the minimal catalog leaf**
+
+Create a warning-clean zero-reference class library. Embed `vt-capabilities.json` as `NovaTerminal.VtContract.vt-capabilities.json`. Implement:
+
+```csharp
+public enum VtSupport { Supported, Partial, Unsupported }
+
+public sealed record VtCapability(
+    string Key,
+    string Mnemonic,
+    VtSupport Support,
+    string Description,
+    string MatrixFeature,
+    string? EvidencePath,
+    string? ContractCase);
+
+public static class VtCapabilityCatalog
+{
+    public static IReadOnlyList<VtCapability> All { get; }
+    public static IReadOnlyList<VtCapability> Parse(string json);
+}
+```
+
+Seed the first contract tranche with `CSI:E`/CNL, `CSI:F`/CPL, and `CSI:G`/CHA. Mark all three supported and point them at concrete parser tests and unique matrix features.
+
+**Step 4: Run the focused tests to verify GREEN**
+
+Run the command from Step 2. Expected: all catalog tests pass with no warnings.
+
+**Step 5: Commit**
+
+Commit as `feat(vt): add capability contract catalog`.
+
+### Task 2: Prove manifest claims against the real parser
+
+**Files:**
+- Modify: `tests/NovaTerminal.VT.Tests/CursorLinePositioningTests.cs`
+- Create: `tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs`
+
+**Step 1: Write the failing parser-contract tests**
+
+Enumerate every `Supported` catalog entry and dispatch its `ContractCase` to a deterministic real-parser assertion. Cover CNL, CPL, and CHA. For the CNL/CPL streams assert omitted and zero defaults, count movement, column reset, viewport/margin clamping, private/intermediate no-op behavior, and equivalence when the escape sequence is split at every byte boundary. Add a guard that fails whenever a supported manifest entry has no registered contract case.
+
+**Step 2: Run the tests to verify RED**
+
+Run:
+`rtk pwsh -NoProfile -File scripts/build.ps1 test tests/NovaTerminal.VT.Tests/NovaTerminal.VT.Tests.csproj --filter FullyQualifiedName~VtCapabilityContractTests`
+
+Expected: failure because the catalog's contract-case registry is not yet implemented and CHA lacks a registered contract assertion.
+
+**Step 3: Implement the minimal test contract registry**
+
+Add test-only handlers for `cursor-next-line`, `cursor-previous-line`, and `cursor-horizontal-absolute`. Reuse public `AnsiParser.Process` and `TerminalBuffer` state only; add no production parser API.
+
+**Step 4: Run focused and full VT tests**
+
+Run the command from Step 2, then:
+`rtk pwsh -NoProfile -File scripts/build.ps1 test tests/NovaTerminal.VT.Tests/NovaTerminal.VT.Tests.csproj`
+
+Expected: all VT tests pass.
+
+**Step 5: Commit**
+
+Commit as `test(vt): enforce supported cursor contracts`.
+
+### Task 3: Make conformance validation consume the catalog
+
+**Files:**
+- Modify: `src/NovaTerminal.Conformance/NovaTerminal.Conformance.csproj`
+- Modify: `src/NovaTerminal.Conformance/VtConformanceReportTool.cs`
+- Modify: `tests/NovaTerminal.Platform.Tests/Conformance/VtConformanceToolTests.cs`
+- Modify: `docs/vt_coverage_matrix.md`
+- Modify: `src/NovaTerminal.App/Resources/vt-conformance-report.json`
+
+**Step 1: Write failing matrix-contract tests**
+
+Add temporary-repository tests proving validation reports errors when a catalog feature is absent, when its matrix status disagrees with the manifest support value, when two capabilities share one matrix feature, or when the evidence path is missing. Add a current-repository assertion that all manifest entries match unique rows with existing evidence.
+
+**Step 2: Run the tests to verify RED**
+
+Run:
+`rtk pwsh -NoProfile -File scripts/build.ps1 test tests/NovaTerminal.Platform.Tests/NovaTerminal.Platform.Tests.csproj --filter FullyQualifiedName~VtConformanceToolTests`
+
+Expected: the new assertions fail because `Generate` does not validate the capability catalog.
+
+**Step 3: Implement catalog-to-matrix validation**
+
+Reference `NovaTerminal.VtContract` from the conformance project. Validate unique `MatrixFeature` values, exact status agreement, and repository-relative evidence existence. Emit deterministic `VtConformanceIssue` codes and retain the existing report schema.
+
+**Step 4: Correct the matrix and report**
+
+Replace grouped `CHA/CPL/CNL (G/F/E)` with unique `CHA (G)`, `CPL (F)`, and `CNL (E)` supported rows linked to concrete tests. Regenerate the embedded report with the existing conformance CLI.
+
+**Step 5: Run focused validation**
+
+Run the focused tests, then:
+`rtk pwsh -NoProfile -File scripts/build.ps1 run --project src/NovaTerminal.Conformance/NovaTerminal.Conformance.csproj -- --validate --check-report src/NovaTerminal.App/Resources/vt-conformance-report.json`
+
+Expected: zero validation errors and a matching embedded report.
+
+**Step 6: Commit**
+
+Commit as `feat(vt): validate capability claims against matrix`.
+
+### Task 4: Drive MCP explanations from the contract
+
+**Files:**
+- Modify: `src/NovaTerminal.McpServer/NovaTerminal.McpServer.csproj`
+- Modify: `src/NovaTerminal.McpServer/Tools/VtTools.cs`
+- Modify: `tests/NovaTerminal.McpServer.Tests/V2ToolsTests.cs`
+- Modify: `tests/NovaTerminal.Architecture.Tests/ProjectFileLayeringTests.cs`
+- Modify: `docs/MODULE_OWNERSHIP.md`
+
+**Step 1: Write failing explanation tests**
+
+Replace the stale unsupported assertions for `CSI E/F` with tests that require `CNL`/`CPL`, describe column-one movement, and contain no unsupported warning. Add a drift guard asserting every catalog key resolves through `ExplainEscapeSequence` with its mnemonic and support state.
+
+**Step 2: Run the tests to verify RED**
+
+Run:
+`rtk pwsh -NoProfile -File scripts/build.ps1 test tests/NovaTerminal.McpServer.Tests/NovaTerminal.McpServer.Tests.csproj --filter FullyQualifiedName~ExplainEscapeSequenceTests`
+
+Expected: CNL/CPL tests fail because the curated table still says they are unhandled.
+
+**Step 3: Implement shared explanations**
+
+Reference the zero-dependency contract leaf from MCP. Remove E/F/G duplicates from `SequenceTable`; resolve catalog keys first and format support state from the typed record. Update the explicit architecture allowlist and module documentation to permit only this additional zero-reference leaf.
+
+**Step 4: Run MCP and architecture tests**
+
+Run the focused MCP tests and:
+`rtk pwsh -NoProfile -File scripts/build.ps1 test tests/NovaTerminal.Architecture.Tests/NovaTerminal.Architecture.Tests.csproj`
+
+Expected: all tests pass and the layering invariant names all permitted MCP leaf dependencies.
+
+**Step 5: Commit**
+
+Commit as `fix(mcp): source VT explanations from capability contract`.
+
+### Task 5: Wire the contract into repository CI and solution metadata
+
+**Files:**
+- Modify: `NovaTerminal.sln`
+- Modify: `.github/workflows/vt-conformance.yml`
+- Modify: `.github/pull_request_template.md`
+- Modify: `docs/ghostty-gaps/vt_conformance_tooling.md`
+
+**Step 1: Write the failing workflow/documentation assertions**
+
+Extend the existing architecture or tooling tests to assert the conformance workflow watches `src/NovaTerminal.VtContract/**` and the PR template requires contract evidence for parser support changes.
+
+**Step 2: Run the focused tests to verify RED**
+
+Run the relevant architecture/tooling test filter. Expected: failure because the workflow and template do not mention the contract.
+
+**Step 3: Apply the minimal integration changes**
+
+Add the leaf project to the solution, include its path in conformance workflow triggers, and document the catalog/contract-test update rule and regeneration command. Keep the checklist advisory text aligned with the new hard CI validation.
+
+**Step 4: Run focused verification**
+
+Run VT, MCP, architecture, platform conformance, and conformance CLI checks. Expected: all pass.
+
+**Step 5: Commit**
+
+Commit as `ci(vt): gate capability contract changes`.
+
+### Task 6: Full verification and delivery
+
+**Files:**
+- Review: all changed files
+
+**Step 1: Run full wrapped verification**
+
+Run:
+
+```powershell
+rtk pwsh -NoProfile -File scripts/build.ps1 build NovaTerminal.sln -c Release
+rtk pwsh -NoProfile -File scripts/build.ps1 test -c Release
+```
+
+Expected: build and tests pass with no new warnings. Also confirm the conformance CLI reports zero errors and the embedded report matches.
+
+**Step 2: Review the complete diff**
+
+Check `rtk git diff main...HEAD`, ensure no parser hot-path changes, no unrelated files, deterministic JSON, and updated ownership documentation.
+
+**Step 3: Push and open the PR**
+
+Push `codex/vt-capability-contract`, create a PR describing the single-source contract, parser evidence, and verification, then watch CI and Greptile. For each valid finding, add a failing regression test first and apply the minimal fix.

--- a/docs/vt_coverage_matrix.md
+++ b/docs/vt_coverage_matrix.md
@@ -68,7 +68,9 @@ It is designed to be:
 |---|---|---:|---|---|---|
 | CUU/CUD/CUF/CUB (A/B/C/D) | Cursor up/down/forward/back | ⚠ Partial | Unit: `tests/NovaTerminal.App.Tests/PendingWrapTests.cs` | Parser+Buffer | Explicit CUF movement is covered via pending-wrap reset; dedicated CUU/CUD/CUB targeted coverage is still missing |
 | CUP / HVP (H/f) | Positioning, default params | ✅ Supported | Unit + Replay: `tests/NovaTerminal.App.Tests/CursorPositioningCompletionTests.cs`, `tests/NovaTerminal.App.Tests/ReplayTests/RegressionTests.cs` | Parser+Buffer | |
-| CHA/CPL/CNL (G/F/E) | Horizontal absolute / prev/next line | ⚠ Partial | Replay | Parser+Buffer | |
+| CHA (G) | Horizontal absolute | ✅ Supported | Unit: `tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs` | Parser+Buffer | |
+| CPL (F) | Previous line and column reset | ✅ Supported | Unit: `tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs` | Parser+Buffer | |
+| CNL (E) | Next line and column reset | ✅ Supported | Unit: `tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs` | Parser+Buffer | |
 | CHT (I) | Cursor forward tabulation | ✅ Supported | Unit: `tests/NovaTerminal.App.Tests/TabSystemTests.cs` | Parser+Buffer | |
 | CBT (Z) | Cursor backward tabulation | ✅ Supported | Unit: `tests/NovaTerminal.App.Tests/TabSystemTests.cs` | Parser+Buffer | |
 | VPA/HPA (d/G/`) | Absolute row/col | ✅ Supported | Unit: `tests/NovaTerminal.App.Tests/CursorPositioningCompletionTests.cs` | Parser+Buffer | |

--- a/src/NovaTerminal.App/Resources/vt-conformance-report.json
+++ b/src/NovaTerminal.App/Resources/vt-conformance-report.json
@@ -1,16 +1,16 @@
 {
   "schemaVersion": 1,
   "matrixPath": "docs/vt_coverage_matrix.md",
-  "matrixSha256": "581c0b13995f886b7658b868bb218c26c3b77f2cf8fe7cbf9b07c6a230eea7f6",
+  "matrixSha256": "867c7e97816e712c8b0c44b26c125e01418a8bbd306cd80ad42fe9491f3548d6",
   "summary": {
-    "totalRows": 58,
-    "supportedCount": 20,
-    "partialCount": 32,
+    "totalRows": 60,
+    "supportedCount": 23,
+    "partialCount": 31,
     "experimentalCount": 1,
     "notSupportedCount": 4,
     "wontSupportCount": 1,
-    "rowsWithLinkedEvidence": 35,
-    "supportedRowsWithLinkedEvidence": 20,
+    "rowsWithLinkedEvidence": 38,
+    "supportedRowsWithLinkedEvidence": 23,
     "errorCount": 0,
     "warningCount": 0
   },
@@ -26,77 +26,77 @@
       "order": 1,
       "title": "2) Cursor movement \u0026 positioning (CSI)",
       "startLine": 67,
-      "endLine": 75,
-      "rowCount": 7
+      "endLine": 77,
+      "rowCount": 9
     },
     {
       "order": 2,
       "title": "3) Erase \u0026 insert/delete (CSI)",
-      "startLine": 81,
-      "endLine": 88,
+      "startLine": 83,
+      "endLine": 90,
       "rowCount": 6
     },
     {
       "order": 3,
       "title": "4) Scrolling, margins, and origin mode",
-      "startLine": 94,
-      "endLine": 100,
+      "startLine": 96,
+      "endLine": 102,
       "rowCount": 5
     },
     {
       "order": 4,
       "title": "5) Screen buffers \u0026 modes (DEC private modes)",
-      "startLine": 106,
-      "endLine": 116,
+      "startLine": 108,
+      "endLine": 118,
       "rowCount": 9
     },
     {
       "order": 5,
       "title": "6) SGR attributes \u0026 colors",
-      "startLine": 122,
-      "endLine": 128,
+      "startLine": 124,
+      "endLine": 130,
       "rowCount": 5
     },
     {
       "order": 6,
       "title": "7) Tabs",
-      "startLine": 134,
-      "endLine": 137,
+      "startLine": 136,
+      "endLine": 139,
       "rowCount": 2
     },
     {
       "order": 7,
       "title": "8) OSC sequences",
-      "startLine": 143,
-      "endLine": 152,
+      "startLine": 145,
+      "endLine": 154,
       "rowCount": 8
     },
     {
       "order": 8,
       "title": "9) Kitty graphics / APC",
-      "startLine": 158,
-      "endLine": 161,
+      "startLine": 160,
+      "endLine": 163,
       "rowCount": 2
     },
     {
       "order": 9,
       "title": "10) SIXEL",
-      "startLine": 167,
-      "endLine": 170,
+      "startLine": 169,
+      "endLine": 172,
       "rowCount": 2
     },
     {
       "order": 10,
       "title": "11) Clipboard, selection, and hyperlinking",
-      "startLine": 176,
-      "endLine": 180,
+      "startLine": 178,
+      "endLine": 182,
       "rowCount": 3
     },
     {
       "order": 11,
       "title": "12) Unicode width, graphemes, and font behavior",
-      "startLine": 186,
-      "endLine": 190,
+      "startLine": 188,
+      "endLine": 192,
       "rowCount": 3
     }
   ],
@@ -276,19 +276,66 @@
     },
     {
       "section": "2) Cursor movement \u0026 positioning (CSI)",
-      "feature": "CHA/CPL/CNL (G/F/E)",
-      "status": "\u26A0 Partial",
-      "specOrNotes": "Horizontal absolute / prev/next line",
-      "evidenceText": "Replay",
+      "feature": "CHA (G)",
+      "status": "\u2705 Supported",
+      "specOrNotes": "Horizontal absolute",
+      "evidenceText": "Unit: \u0060tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs\u0060",
       "evidenceKinds": [
-        "replay"
+        "unit"
       ],
-      "evidenceLinks": [],
+      "evidenceLinks": [
+        {
+          "path": "tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs",
+          "exists": true
+        }
+      ],
       "hasAutomatedEvidenceSignal": true,
-      "hasLinkedEvidence": false,
+      "hasLinkedEvidence": true,
       "ownership": "Parser\u002BBuffer",
       "knownDeviations": "",
       "sourceLine": 71
+    },
+    {
+      "section": "2) Cursor movement \u0026 positioning (CSI)",
+      "feature": "CPL (F)",
+      "status": "\u2705 Supported",
+      "specOrNotes": "Previous line and column reset",
+      "evidenceText": "Unit: \u0060tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs\u0060",
+      "evidenceKinds": [
+        "unit"
+      ],
+      "evidenceLinks": [
+        {
+          "path": "tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs",
+          "exists": true
+        }
+      ],
+      "hasAutomatedEvidenceSignal": true,
+      "hasLinkedEvidence": true,
+      "ownership": "Parser\u002BBuffer",
+      "knownDeviations": "",
+      "sourceLine": 72
+    },
+    {
+      "section": "2) Cursor movement \u0026 positioning (CSI)",
+      "feature": "CNL (E)",
+      "status": "\u2705 Supported",
+      "specOrNotes": "Next line and column reset",
+      "evidenceText": "Unit: \u0060tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs\u0060",
+      "evidenceKinds": [
+        "unit"
+      ],
+      "evidenceLinks": [
+        {
+          "path": "tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs",
+          "exists": true
+        }
+      ],
+      "hasAutomatedEvidenceSignal": true,
+      "hasLinkedEvidence": true,
+      "ownership": "Parser\u002BBuffer",
+      "knownDeviations": "",
+      "sourceLine": 73
     },
     {
       "section": "2) Cursor movement \u0026 positioning (CSI)",
@@ -309,7 +356,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BBuffer",
       "knownDeviations": "",
-      "sourceLine": 72
+      "sourceLine": 74
     },
     {
       "section": "2) Cursor movement \u0026 positioning (CSI)",
@@ -330,7 +377,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BBuffer",
       "knownDeviations": "",
-      "sourceLine": 73
+      "sourceLine": 75
     },
     {
       "section": "2) Cursor movement \u0026 positioning (CSI)",
@@ -351,7 +398,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BBuffer",
       "knownDeviations": "",
-      "sourceLine": 74
+      "sourceLine": 76
     },
     {
       "section": "2) Cursor movement \u0026 positioning (CSI)",
@@ -372,7 +419,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BBuffer",
       "knownDeviations": "",
-      "sourceLine": 75
+      "sourceLine": 77
     },
     {
       "section": "3) Erase \u0026 insert/delete (CSI)",
@@ -403,7 +450,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BBuffer",
       "knownDeviations": "",
-      "sourceLine": 83
+      "sourceLine": 85
     },
     {
       "section": "3) Erase \u0026 insert/delete (CSI)",
@@ -424,7 +471,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BBuffer",
       "knownDeviations": "",
-      "sourceLine": 84
+      "sourceLine": 86
     },
     {
       "section": "3) Erase \u0026 insert/delete (CSI)",
@@ -440,7 +487,7 @@
       "hasLinkedEvidence": false,
       "ownership": "Parser\u002BBuffer",
       "knownDeviations": "Implemented in parser/buffer; needs targeted unit coverage",
-      "sourceLine": 85
+      "sourceLine": 87
     },
     {
       "section": "3) Erase \u0026 insert/delete (CSI)",
@@ -456,7 +503,7 @@
       "hasLinkedEvidence": false,
       "ownership": "Parser\u002BBuffer",
       "knownDeviations": "Implemented in parser/buffer; needs targeted unit coverage",
-      "sourceLine": 86
+      "sourceLine": 88
     },
     {
       "section": "3) Erase \u0026 insert/delete (CSI)",
@@ -472,7 +519,7 @@
       "hasLinkedEvidence": false,
       "ownership": "Buffer",
       "knownDeviations": "Scroll region interactions",
-      "sourceLine": 87
+      "sourceLine": 89
     },
     {
       "section": "3) Erase \u0026 insert/delete (CSI)",
@@ -488,7 +535,7 @@
       "hasLinkedEvidence": false,
       "ownership": "Parser\u002BBuffer",
       "knownDeviations": "Implemented in parser/buffer; needs targeted unit coverage",
-      "sourceLine": 88
+      "sourceLine": 90
     },
     {
       "section": "4) Scrolling, margins, and origin mode",
@@ -504,7 +551,7 @@
       "hasLinkedEvidence": false,
       "ownership": "Parser\u002BBuffer",
       "knownDeviations": "",
-      "sourceLine": 96
+      "sourceLine": 98
     },
     {
       "section": "4) Scrolling, margins, and origin mode",
@@ -520,7 +567,7 @@
       "hasLinkedEvidence": false,
       "ownership": "Parser\u002BBuffer",
       "knownDeviations": "",
-      "sourceLine": 97
+      "sourceLine": 99
     },
     {
       "section": "4) Scrolling, margins, and origin mode",
@@ -541,7 +588,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BBuffer",
       "knownDeviations": "",
-      "sourceLine": 98
+      "sourceLine": 100
     },
     {
       "section": "4) Scrolling, margins, and origin mode",
@@ -557,7 +604,7 @@
       "hasLinkedEvidence": false,
       "ownership": "Buffer",
       "knownDeviations": "Wide glyph edge cases",
-      "sourceLine": 99
+      "sourceLine": 101
     },
     {
       "section": "4) Scrolling, margins, and origin mode",
@@ -571,7 +618,7 @@
       "hasLinkedEvidence": false,
       "ownership": "\u2014",
       "knownDeviations": "Renderer concern",
-      "sourceLine": 100
+      "sourceLine": 102
     },
     {
       "section": "5) Screen buffers \u0026 modes (DEC private modes)",
@@ -601,7 +648,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Buffer",
       "knownDeviations": "Main scrollback is preserved and alt-screen output never enters scrollback. \u0060?47\u0060 reuses the existing alternate buffer/state without clearing; \u0060?1047\u0060 and \u0060?1049\u0060 clear and home the alternate buffer on entry. Nested/redundant alt-screen enters are treated as no-op, and a \u0060?1049\u0060 save is consumed by the first exit from alt-screen regardless of whether that exit uses \u0060?47l\u0060, \u0060?1047l\u0060, or \u0060?1049l\u0060.",
-      "sourceLine": 108
+      "sourceLine": 110
     },
     {
       "section": "5) Screen buffers \u0026 modes (DEC private modes)",
@@ -627,7 +674,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Buffer\u002BRenderer",
       "knownDeviations": "",
-      "sourceLine": 109
+      "sourceLine": 111
     },
     {
       "section": "5) Screen buffers \u0026 modes (DEC private modes)",
@@ -644,7 +691,7 @@
       "hasLinkedEvidence": false,
       "ownership": "Parser\u002BInput",
       "knownDeviations": "Parser/UI wiring exists; needs targeted key-mapping tests",
-      "sourceLine": 110
+      "sourceLine": 112
     },
     {
       "section": "5) Screen buffers \u0026 modes (DEC private modes)",
@@ -660,7 +707,7 @@
       "hasLinkedEvidence": false,
       "ownership": "Parser\u002BInput",
       "knownDeviations": "Mode flag tested; focus emission covered by app path, not headless UI test",
-      "sourceLine": 111
+      "sourceLine": 113
     },
     {
       "section": "5) Screen buffers \u0026 modes (DEC private modes)",
@@ -676,7 +723,7 @@
       "hasLinkedEvidence": false,
       "ownership": "Input layer",
       "knownDeviations": "",
-      "sourceLine": 112
+      "sourceLine": 114
     },
     {
       "section": "5) Screen buffers \u0026 modes (DEC private modes)",
@@ -701,7 +748,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Input layer",
       "knownDeviations": "\u0060?1001\u0060 (highlight tracking) and urxvt (\u0060?1015\u0060)/pixel-position (\u0060?1016\u0060) mouse coordinate encodings are not implemented; only X10 and SGR (\u0060?1006\u0060) coordinate encodings are supported. Coordinates are viewport-relative and 1-based on every report path (motion, press, release, wheel); the legacy X10 encoding clamps coordinates to its 223 ceiling rather than promoting the report to the SGR form the application never requested",
-      "sourceLine": 113
+      "sourceLine": 115
     },
     {
       "section": "5) Screen buffers \u0026 modes (DEC private modes)",
@@ -722,7 +769,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BRenderer",
       "knownDeviations": "",
-      "sourceLine": 114
+      "sourceLine": 116
     },
     {
       "section": "5) Screen buffers \u0026 modes (DEC private modes)",
@@ -755,7 +802,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BInput",
       "knownDeviations": "Scope: disambiguate-escape-codes tier (\u00600b1\u0060) only. Bits \u00600b10\u0060/\u00600b100\u0060/\u00600b1000\u0060/\u00600b10000\u0060 (event types, alternate keys, all-keys, associated text) are accepted but masked out on push/set, so the \u0060CSI ? u\u0060 reply only advertises flags actually honored. Key encoding covers Esc, modified Enter/Tab/Backspace, and ctrl/alt/super combinations on the spec\u0027s legacy-text keys; keypad and functional keys keep their legacy encodings (including modified arrows/Home/End/PgUp/PgDn - the spec\u0027s \u0060CSI 1;mod \u003Cletter\u003E\u0060 form is not emitted, so e.g. Ctrl\u002BLeft stays an unmodified \u0060CSI D\u0060). AltGr on Windows non-US layouts is reported as Control\u002BAlt; the encoder carves that combination out (falls through to legacy/text) so composed characters are not swallowed - the accepted trade-off is that literal Ctrl\u002BAlt\u002B\u0026lt;key\u0026gt; shortcuts on US layouts also lose kitty encoding, same as the pre-existing Alt-sends-ESC carve-out. Gated end-to-end by \u0060TerminalSettings.EnableKittyKeyboardProtocol\u0060 (default on): when off, the App-side encoder is skipped unconditionally and the \u0060CSI ? u\u0060 reply always reports flags 0 regardless of the pushed stack state. The tab-broadcast path in \u0060MainWindow\u0060 builds its own input independently of this encoder and always sends legacy encoding to broadcast targets regardless of their own flag state.",
-      "sourceLine": 115
+      "sourceLine": 117
     },
     {
       "section": "5) Screen buffers \u0026 modes (DEC private modes)",
@@ -776,7 +823,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser",
       "knownDeviations": "\u0060?9001\u0060 (ConPTY passthrough) is accepted by \u0060CSI ? Ps h/l\u0060 but has no tracked boolean state, so DECRQM reports it as \u0060Pm=0\u0060 (not recognized) rather than guessing. Dispatch keys on the \u0060$\u0060 intermediate exactly, so \u0060CSI ! p\u0060 (DECSTR, not implemented) and bare \u0060CSI p\u0060 are unaffected.",
-      "sourceLine": 116
+      "sourceLine": 118
     },
     {
       "section": "6) SGR attributes \u0026 colors",
@@ -798,7 +845,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BBuffer\u002BRenderer",
       "knownDeviations": "Underline style/color tracked separately",
-      "sourceLine": 124
+      "sourceLine": 126
     },
     {
       "section": "6) SGR attributes \u0026 colors",
@@ -814,7 +861,7 @@
       "hasLinkedEvidence": false,
       "ownership": "Parser\u002BBuffer",
       "knownDeviations": "",
-      "sourceLine": 125
+      "sourceLine": 127
     },
     {
       "section": "6) SGR attributes \u0026 colors",
@@ -830,7 +877,7 @@
       "hasLinkedEvidence": false,
       "ownership": "Parser\u002BBuffer",
       "knownDeviations": "",
-      "sourceLine": 126
+      "sourceLine": 128
     },
     {
       "section": "6) SGR attributes \u0026 colors",
@@ -846,7 +893,7 @@
       "hasLinkedEvidence": false,
       "ownership": "Parser\u002BBuffer",
       "knownDeviations": "",
-      "sourceLine": 127
+      "sourceLine": 129
     },
     {
       "section": "6) SGR attributes \u0026 colors",
@@ -860,7 +907,7 @@
       "hasLinkedEvidence": false,
       "ownership": "Buffer",
       "knownDeviations": "",
-      "sourceLine": 128
+      "sourceLine": 130
     },
     {
       "section": "7) Tabs",
@@ -881,7 +928,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BBuffer",
       "knownDeviations": "Custom tab stops are clipped on width shrink; columns exposed by width growth start with default 8-column tab stops",
-      "sourceLine": 136
+      "sourceLine": 138
     },
     {
       "section": "7) Tabs",
@@ -902,7 +949,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BBuffer",
       "knownDeviations": "\u0060CSI g\u0060 supports current-stop clear (\u00600\u0060/default) and clear-all (\u00603\u0060); other parameters are ignored",
-      "sourceLine": 137
+      "sourceLine": 139
     },
     {
       "section": "8) OSC sequences",
@@ -919,7 +966,7 @@
       "hasLinkedEvidence": false,
       "ownership": "App/UI",
       "knownDeviations": "",
-      "sourceLine": 145
+      "sourceLine": 147
     },
     {
       "section": "8) OSC sequences",
@@ -940,7 +987,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BApp",
       "knownDeviations": "",
-      "sourceLine": 146
+      "sourceLine": 148
     },
     {
       "section": "8) OSC sequences",
@@ -961,7 +1008,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BApp",
       "knownDeviations": "Query form (\u0060?\u0060) only; set form is ignored safely, no runtime palette change. Colors sourced from \u0060AnsiParser.DefaultForeground\u0060/\u0060DefaultBackground\u0060, wired from the active theme at parser creation and on \u0060TerminalPane.ApplySettings\u0060; falls back to fg C0C0C0 / bg 000000 when unset",
-      "sourceLine": 147
+      "sourceLine": 149
     },
     {
       "section": "8) OSC sequences",
@@ -986,7 +1033,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BApp",
       "knownDeviations": "Write-only (issue #268): valid base64 decodes and raises \u0060AnsiParser.OnClipboardWrite\u0060, capped at 1 MiB decoded (rejected on encoded length before decoding, re-checked after); invalid base64 dropped silently; a sequence with no payload separator at all is ignored rather than clearing the clipboard. Targets \u0060c\u0060/\u0060p\u0060 both map to the system clipboard, other selection chars ignored. Query (\u0060?\u0060) always gets an empty-payload denial reply, never real clipboard contents \u2014 clipboard READ is unsupported by design (security). The echoed selection parameter is whitelisted to \u0060c p q s 0-7\u0060 and length-capped first: responses go to the child process\u0027s stdin, so an unsanitized echo was a command-injection primitive (PR #280 review). Gated by \u0060TerminalSettings.AllowOsc52ClipboardWrite\u0060 (default true, single global setting; per-profile/SSH-scoped opt-in is future work)",
-      "sourceLine": 148
+      "sourceLine": 150
     },
     {
       "section": "8) OSC sequences",
@@ -1007,7 +1054,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BRenderer\u002BUI",
       "knownDeviations": "Ctrl-click open path is app-level",
-      "sourceLine": 149
+      "sourceLine": 151
     },
     {
       "section": "8) OSC sequences",
@@ -1028,7 +1075,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BCommand Assist",
       "knownDeviations": "Supports A/B/C/D markers; broader semantic prompt extensions not audited",
-      "sourceLine": 150
+      "sourceLine": 152
     },
     {
       "section": "8) OSC sequences",
@@ -1054,7 +1101,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BRenderer",
       "knownDeviations": "Requires \u0060inline=1\u0060 and the \u0060File=\u0060 arg shape; no \u0060name=\u0060/\u0060size=\u0060 enforcement",
-      "sourceLine": 151
+      "sourceLine": 153
     },
     {
       "section": "8) OSC sequences",
@@ -1070,7 +1117,7 @@
       "hasLinkedEvidence": false,
       "ownership": "Parser\u002BWin",
       "knownDeviations": "",
-      "sourceLine": 152
+      "sourceLine": 154
     },
     {
       "section": "9) Kitty graphics / APC",
@@ -1099,7 +1146,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BRenderer",
       "knownDeviations": "",
-      "sourceLine": 160
+      "sourceLine": 162
     },
     {
       "section": "9) Kitty graphics / APC",
@@ -1115,7 +1162,7 @@
       "hasLinkedEvidence": false,
       "ownership": "Buffer\u002BRenderer",
       "knownDeviations": "Pruned images\u0027 bitmaps are retired by the buffer; the owning view disposes them once no in-flight snapshot session predates the retire (#166)",
-      "sourceLine": 161
+      "sourceLine": 163
     },
     {
       "section": "10) SIXEL",
@@ -1140,7 +1187,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Decoder\u002BRenderer",
       "knownDeviations": "",
-      "sourceLine": 169
+      "sourceLine": 171
     },
     {
       "section": "10) SIXEL",
@@ -1154,7 +1201,7 @@
       "hasLinkedEvidence": false,
       "ownership": "Buffer\u002BRenderer",
       "knownDeviations": "",
-      "sourceLine": 170
+      "sourceLine": 172
     },
     {
       "section": "11) Clipboard, selection, and hyperlinking",
@@ -1170,7 +1217,7 @@
       "hasLinkedEvidence": false,
       "ownership": "UI",
       "knownDeviations": "",
-      "sourceLine": 178
+      "sourceLine": 180
     },
     {
       "section": "11) Clipboard, selection, and hyperlinking",
@@ -1184,7 +1231,7 @@
       "hasLinkedEvidence": false,
       "ownership": "UI",
       "knownDeviations": "",
-      "sourceLine": 179
+      "sourceLine": 181
     },
     {
       "section": "11) Clipboard, selection, and hyperlinking",
@@ -1205,7 +1252,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Parser\u002BUI",
       "knownDeviations": "Ctrl-click open path is app-level",
-      "sourceLine": 180
+      "sourceLine": 182
     },
     {
       "section": "12) Unicode width, graphemes, and font behavior",
@@ -1235,7 +1282,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Buffer\u002BRenderer",
       "knownDeviations": "Deterministic 0/1/2-cell model for combining marks, emoji modifiers, ZWJ emoji, variation selectors, and regional-indicator flags. No Unicode-version pin or full UAX #11 conformance table is documented yet.",
-      "sourceLine": 188
+      "sourceLine": 190
     },
     {
       "section": "12) Unicode width, graphemes, and font behavior",
@@ -1268,7 +1315,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Buffer\u002BRenderer",
       "knownDeviations": "Combining/variation attachment is covered for common terminal cases, including pending-wrap boundaries. Full extended-grapheme-cluster conformance is not claimed.",
-      "sourceLine": 189
+      "sourceLine": 191
     },
     {
       "section": "12) Unicode width, graphemes, and font behavior",
@@ -1297,7 +1344,7 @@
       "hasLinkedEvidence": true,
       "ownership": "Buffer\u002BRenderer",
       "knownDeviations": "Chunked ZWJ families, emoji modifiers, VS15/VS16, and chunked regional-indicator flag pairs are covered. Remaining gaps: cursor-addressing CSI remains cell-oriented, and width-changing selectors that arrive after a base glyph already placed at the last column are not guaranteed to retroactively reflow.",
-      "sourceLine": 190
+      "sourceLine": 192
     }
   ],
   "errors": [],

--- a/src/NovaTerminal.Conformance/NovaTerminal.Conformance.csproj
+++ b/src/NovaTerminal.Conformance/NovaTerminal.Conformance.csproj
@@ -2,4 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NovaTerminal.VtContract\NovaTerminal.VtContract.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/NovaTerminal.Conformance/VtConformanceReportTool.cs
+++ b/src/NovaTerminal.Conformance/VtConformanceReportTool.cs
@@ -339,10 +339,29 @@ public static class VtConformanceReportTool
             return;
         }
 
-        IReadOnlyList<VtCapability> capabilities;
+        if (!TryLoadCapabilities(manifestPath, relativeMatrixPath, errors, out IReadOnlyList<VtCapability> capabilities))
+        {
+            return;
+        }
+
+        AddDuplicateMatrixFeatureErrors(capabilities, relativeMatrixPath, errors);
+
+        foreach (VtCapability capability in capabilities)
+        {
+            ValidateCapability(repoRoot, relativeMatrixPath, rows, capability, errors);
+        }
+    }
+
+    private static bool TryLoadCapabilities(
+        string manifestPath,
+        string relativeMatrixPath,
+        List<VtConformanceIssue> errors,
+        out IReadOnlyList<VtCapability> capabilities)
+    {
         try
         {
             capabilities = VtCapabilityCatalog.Parse(File.ReadAllText(manifestPath));
+            return true;
         }
         catch (VtCapabilityManifestException exception)
         {
@@ -353,9 +372,16 @@ public static class VtConformanceReportTool
                 MatrixPath: relativeMatrixPath,
                 LineNumber: 0,
                 Feature: null));
-            return;
+            capabilities = Array.Empty<VtCapability>();
+            return false;
         }
+    }
 
+    private static void AddDuplicateMatrixFeatureErrors(
+        IReadOnlyList<VtCapability> capabilities,
+        string relativeMatrixPath,
+        List<VtConformanceIssue> errors)
+    {
         foreach (IGrouping<string, VtCapability> duplicate in capabilities
                      .GroupBy(capability => capability.MatrixFeature, StringComparer.Ordinal)
                      .Where(group => group.Count() > 1))
@@ -368,89 +394,103 @@ public static class VtConformanceReportTool
                 LineNumber: 0,
                 Feature: duplicate.Key));
         }
+    }
 
-        foreach (VtCapability capability in capabilities)
+    private static void ValidateCapability(
+        string repoRoot,
+        string relativeMatrixPath,
+        List<VtConformanceRow> rows,
+        VtCapability capability,
+        List<VtConformanceIssue> errors)
+    {
+        List<VtConformanceRow> matchingRows = rows
+            .Where(candidate => string.Equals(candidate.Feature, capability.MatrixFeature, StringComparison.Ordinal))
+            .ToList();
+        if (matchingRows.Count == 0)
         {
-            List<VtConformanceRow> matchingRows = rows
-                .Where(candidate => string.Equals(candidate.Feature, capability.MatrixFeature, StringComparison.Ordinal))
-                .ToList();
-            if (matchingRows.Count == 0)
-            {
-                errors.Add(new VtConformanceIssue(
-                    Code: "capability-matrix-feature-missing",
-                    Severity: IssueSeverity.Error,
-                    Message: $"Capability '{capability.Key}' expects matrix feature '{capability.MatrixFeature}'.",
-                    MatrixPath: relativeMatrixPath,
-                    LineNumber: 0,
-                    Feature: capability.MatrixFeature));
-                continue;
-            }
+            errors.Add(new VtConformanceIssue(
+                Code: "capability-matrix-feature-missing",
+                Severity: IssueSeverity.Error,
+                Message: $"Capability '{capability.Key}' expects matrix feature '{capability.MatrixFeature}'.",
+                MatrixPath: relativeMatrixPath,
+                LineNumber: 0,
+                Feature: capability.MatrixFeature));
+            return;
+        }
 
-            if (matchingRows.Count > 1)
-            {
-                errors.Add(new VtConformanceIssue(
-                    Code: "capability-matrix-row-duplicate",
-                    Severity: IssueSeverity.Error,
-                    Message: $"Capability '{capability.Key}' expects exactly one matrix row for feature '{capability.MatrixFeature}', but found {matchingRows.Count}.",
-                    MatrixPath: relativeMatrixPath,
-                    LineNumber: matchingRows[0].SourceLine,
-                    Feature: capability.MatrixFeature));
-                continue;
-            }
+        if (matchingRows.Count > 1)
+        {
+            errors.Add(new VtConformanceIssue(
+                Code: "capability-matrix-row-duplicate",
+                Severity: IssueSeverity.Error,
+                Message: $"Capability '{capability.Key}' expects exactly one matrix row for feature '{capability.MatrixFeature}', but found {matchingRows.Count}.",
+                MatrixPath: relativeMatrixPath,
+                LineNumber: matchingRows[0].SourceLine,
+                Feature: capability.MatrixFeature));
+            return;
+        }
 
-            VtConformanceRow row = matchingRows[0];
+        VtConformanceRow row = matchingRows[0];
 
-            if (!CapabilityStatusMatches(capability.Support, row.Status))
-            {
-                errors.Add(new VtConformanceIssue(
-                    Code: "capability-status-mismatch",
-                    Severity: IssueSeverity.Error,
-                    Message: $"Capability '{capability.Key}' is '{capability.Support}' but matrix feature '{row.Feature}' is '{row.Status}'.",
-                    MatrixPath: relativeMatrixPath,
-                    LineNumber: row.SourceLine,
-                    Feature: row.Feature));
-            }
+        if (!CapabilityStatusMatches(capability.Support, row.Status))
+        {
+            errors.Add(new VtConformanceIssue(
+                Code: "capability-status-mismatch",
+                Severity: IssueSeverity.Error,
+                Message: $"Capability '{capability.Key}' is '{capability.Support}' but matrix feature '{row.Feature}' is '{row.Status}'.",
+                MatrixPath: relativeMatrixPath,
+                LineNumber: row.SourceLine,
+                Feature: row.Feature));
+        }
 
-            if (capability.EvidencePath is not string evidencePath)
-            {
-                continue;
-            }
+        if (capability.EvidencePath is string evidencePath)
+        {
+            ValidateCapabilityEvidence(repoRoot, relativeMatrixPath, capability, row, evidencePath, errors);
+        }
+    }
 
-            string normalizedEvidencePath = evidencePath.Replace('\\', '/');
-            string absoluteEvidencePath = Path.GetFullPath(Path.Combine(
-                repoRoot,
-                normalizedEvidencePath.Replace('/', Path.DirectorySeparatorChar)));
-            if (!IsPathWithinRoot(repoRoot, absoluteEvidencePath))
-            {
-                errors.Add(new VtConformanceIssue(
-                    Code: "capability-evidence-path-outside-repo",
-                    Severity: IssueSeverity.Error,
-                    Message: $"Capability '{capability.Key}' evidence path '{normalizedEvidencePath}' resolves outside the repository.",
-                    MatrixPath: relativeMatrixPath,
-                    LineNumber: row.SourceLine,
-                    Feature: row.Feature));
-            }
-            else if (!File.Exists(absoluteEvidencePath) && !Directory.Exists(absoluteEvidencePath))
-            {
-                errors.Add(new VtConformanceIssue(
-                    Code: "capability-evidence-path-not-found",
-                    Severity: IssueSeverity.Error,
-                    Message: $"Capability '{capability.Key}' evidence path '{normalizedEvidencePath}' does not exist.",
-                    MatrixPath: relativeMatrixPath,
-                    LineNumber: row.SourceLine,
-                    Feature: row.Feature));
-            }
+    private static void ValidateCapabilityEvidence(
+        string repoRoot,
+        string relativeMatrixPath,
+        VtCapability capability,
+        VtConformanceRow row,
+        string evidencePath,
+        List<VtConformanceIssue> errors)
+    {
+        string normalizedEvidencePath = evidencePath.Replace('\\', '/');
+        string absoluteEvidencePath = Path.GetFullPath(Path.Combine(
+            repoRoot,
+            normalizedEvidencePath.Replace('/', Path.DirectorySeparatorChar)));
+        if (!IsPathWithinRoot(repoRoot, absoluteEvidencePath))
+        {
+            errors.Add(new VtConformanceIssue(
+                Code: "capability-evidence-path-outside-repo",
+                Severity: IssueSeverity.Error,
+                Message: $"Capability '{capability.Key}' evidence path '{normalizedEvidencePath}' resolves outside the repository.",
+                MatrixPath: relativeMatrixPath,
+                LineNumber: row.SourceLine,
+                Feature: row.Feature));
+        }
+        else if (!File.Exists(absoluteEvidencePath) && !Directory.Exists(absoluteEvidencePath))
+        {
+            errors.Add(new VtConformanceIssue(
+                Code: "capability-evidence-path-not-found",
+                Severity: IssueSeverity.Error,
+                Message: $"Capability '{capability.Key}' evidence path '{normalizedEvidencePath}' does not exist.",
+                MatrixPath: relativeMatrixPath,
+                LineNumber: row.SourceLine,
+                Feature: row.Feature));
+        }
 
-            if (!row.EvidenceLinks.Any(link => string.Equals(link.Path, normalizedEvidencePath, StringComparison.Ordinal)))
-            {
-                errors.Add(new VtConformanceIssue(
-                    Code: "capability-evidence-not-linked",
-                    Severity: IssueSeverity.Error,
-                    Message: $"Matrix feature '{row.Feature}' must link capability evidence '{normalizedEvidencePath}'.",
-                    MatrixPath: relativeMatrixPath,
-                    LineNumber: row.SourceLine,
-                    Feature: row.Feature));
-            }
+        if (!row.EvidenceLinks.Any(link => string.Equals(link.Path, normalizedEvidencePath, StringComparison.Ordinal)))
+        {
+            errors.Add(new VtConformanceIssue(
+                Code: "capability-evidence-not-linked",
+                Severity: IssueSeverity.Error,
+                Message: $"Matrix feature '{row.Feature}' must link capability evidence '{normalizedEvidencePath}'.",
+                MatrixPath: relativeMatrixPath,
+                LineNumber: row.SourceLine,
+                Feature: row.Feature));
         }
     }
 

--- a/src/NovaTerminal.Conformance/VtConformanceReportTool.cs
+++ b/src/NovaTerminal.Conformance/VtConformanceReportTool.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
+using NovaTerminal.VtContract;
 
 namespace NovaTerminal.Conformance;
 
@@ -33,6 +34,7 @@ public static class VtConformanceReportTool
         ParseFeatureTables(repoRoot, relativeMatrixPath, absoluteMatrixPath, normalizedMatrixText, rows, sections, errors, warnings);
 
         ValidateRows(relativeMatrixPath, rows, errors, warnings);
+        ValidateCapabilityCatalog(repoRoot, relativeMatrixPath, rows, errors);
 
         var summary = BuildSummary(rows, errors.Count, warnings.Count);
         return new VtConformanceReport(
@@ -320,6 +322,121 @@ public static class VtConformanceReportTool
             }
         }
     }
+
+    private static void ValidateCapabilityCatalog(
+        string repoRoot,
+        string relativeMatrixPath,
+        List<VtConformanceRow> rows,
+        List<VtConformanceIssue> errors)
+    {
+        string manifestPath = Path.Combine(
+            repoRoot,
+            "src",
+            "NovaTerminal.VtContract",
+            "vt-capabilities.json");
+        if (!File.Exists(manifestPath))
+        {
+            return;
+        }
+
+        IReadOnlyList<VtCapability> capabilities;
+        try
+        {
+            capabilities = VtCapabilityCatalog.Parse(File.ReadAllText(manifestPath));
+        }
+        catch (VtCapabilityManifestException exception)
+        {
+            errors.Add(new VtConformanceIssue(
+                Code: "capability-manifest-invalid",
+                Severity: IssueSeverity.Error,
+                Message: exception.Message,
+                MatrixPath: relativeMatrixPath,
+                LineNumber: 0,
+                Feature: null));
+            return;
+        }
+
+        foreach (IGrouping<string, VtCapability> duplicate in capabilities
+                     .GroupBy(capability => capability.MatrixFeature, StringComparer.Ordinal)
+                     .Where(group => group.Count() > 1))
+        {
+            errors.Add(new VtConformanceIssue(
+                Code: "capability-matrix-feature-duplicate",
+                Severity: IssueSeverity.Error,
+                Message: $"Capability matrix feature '{duplicate.Key}' is shared by: {string.Join(", ", duplicate.Select(capability => capability.Key))}.",
+                MatrixPath: relativeMatrixPath,
+                LineNumber: 0,
+                Feature: duplicate.Key));
+        }
+
+        foreach (VtCapability capability in capabilities)
+        {
+            VtConformanceRow? row = rows.SingleOrDefault(
+                candidate => string.Equals(candidate.Feature, capability.MatrixFeature, StringComparison.Ordinal));
+            if (row is null)
+            {
+                errors.Add(new VtConformanceIssue(
+                    Code: "capability-matrix-feature-missing",
+                    Severity: IssueSeverity.Error,
+                    Message: $"Capability '{capability.Key}' expects matrix feature '{capability.MatrixFeature}'.",
+                    MatrixPath: relativeMatrixPath,
+                    LineNumber: 0,
+                    Feature: capability.MatrixFeature));
+                continue;
+            }
+
+            if (!CapabilityStatusMatches(capability.Support, row.Status))
+            {
+                errors.Add(new VtConformanceIssue(
+                    Code: "capability-status-mismatch",
+                    Severity: IssueSeverity.Error,
+                    Message: $"Capability '{capability.Key}' is '{capability.Support}' but matrix feature '{row.Feature}' is '{row.Status}'.",
+                    MatrixPath: relativeMatrixPath,
+                    LineNumber: row.SourceLine,
+                    Feature: row.Feature));
+            }
+
+            if (capability.EvidencePath is not string evidencePath)
+            {
+                continue;
+            }
+
+            string normalizedEvidencePath = evidencePath.Replace('\\', '/');
+            string absoluteEvidencePath = Path.GetFullPath(Path.Combine(
+                repoRoot,
+                normalizedEvidencePath.Replace('/', Path.DirectorySeparatorChar)));
+            if (!File.Exists(absoluteEvidencePath) && !Directory.Exists(absoluteEvidencePath))
+            {
+                errors.Add(new VtConformanceIssue(
+                    Code: "capability-evidence-path-not-found",
+                    Severity: IssueSeverity.Error,
+                    Message: $"Capability '{capability.Key}' evidence path '{normalizedEvidencePath}' does not exist.",
+                    MatrixPath: relativeMatrixPath,
+                    LineNumber: row.SourceLine,
+                    Feature: row.Feature));
+            }
+
+            if (!row.EvidenceLinks.Any(link => string.Equals(link.Path, normalizedEvidencePath, StringComparison.Ordinal)))
+            {
+                errors.Add(new VtConformanceIssue(
+                    Code: "capability-evidence-not-linked",
+                    Severity: IssueSeverity.Error,
+                    Message: $"Matrix feature '{row.Feature}' must link capability evidence '{normalizedEvidencePath}'.",
+                    MatrixPath: relativeMatrixPath,
+                    LineNumber: row.SourceLine,
+                    Feature: row.Feature));
+            }
+        }
+    }
+
+    private static bool CapabilityStatusMatches(VtSupport support, string status)
+        => support switch
+        {
+            VtSupport.Supported => status.StartsWith('✅'),
+            VtSupport.Partial => status.StartsWith('⚠'),
+            VtSupport.Unsupported => status.StartsWith('❌'),
+            _ => false,
+        };
 
     private static VtConformanceSummary BuildSummary(IReadOnlyList<VtConformanceRow> rows, int errorCount, int warningCount)
     {

--- a/src/NovaTerminal.Conformance/VtConformanceReportTool.cs
+++ b/src/NovaTerminal.Conformance/VtConformanceReportTool.cs
@@ -371,9 +371,10 @@ public static class VtConformanceReportTool
 
         foreach (VtCapability capability in capabilities)
         {
-            VtConformanceRow? row = rows.SingleOrDefault(
-                candidate => string.Equals(candidate.Feature, capability.MatrixFeature, StringComparison.Ordinal));
-            if (row is null)
+            List<VtConformanceRow> matchingRows = rows
+                .Where(candidate => string.Equals(candidate.Feature, capability.MatrixFeature, StringComparison.Ordinal))
+                .ToList();
+            if (matchingRows.Count == 0)
             {
                 errors.Add(new VtConformanceIssue(
                     Code: "capability-matrix-feature-missing",
@@ -384,6 +385,20 @@ public static class VtConformanceReportTool
                     Feature: capability.MatrixFeature));
                 continue;
             }
+
+            if (matchingRows.Count > 1)
+            {
+                errors.Add(new VtConformanceIssue(
+                    Code: "capability-matrix-row-duplicate",
+                    Severity: IssueSeverity.Error,
+                    Message: $"Capability '{capability.Key}' expects exactly one matrix row for feature '{capability.MatrixFeature}', but found {matchingRows.Count}.",
+                    MatrixPath: relativeMatrixPath,
+                    LineNumber: matchingRows[0].SourceLine,
+                    Feature: capability.MatrixFeature));
+                continue;
+            }
+
+            VtConformanceRow row = matchingRows[0];
 
             if (!CapabilityStatusMatches(capability.Support, row.Status))
             {
@@ -405,7 +420,17 @@ public static class VtConformanceReportTool
             string absoluteEvidencePath = Path.GetFullPath(Path.Combine(
                 repoRoot,
                 normalizedEvidencePath.Replace('/', Path.DirectorySeparatorChar)));
-            if (!File.Exists(absoluteEvidencePath) && !Directory.Exists(absoluteEvidencePath))
+            if (!IsPathWithinRoot(repoRoot, absoluteEvidencePath))
+            {
+                errors.Add(new VtConformanceIssue(
+                    Code: "capability-evidence-path-outside-repo",
+                    Severity: IssueSeverity.Error,
+                    Message: $"Capability '{capability.Key}' evidence path '{normalizedEvidencePath}' resolves outside the repository.",
+                    MatrixPath: relativeMatrixPath,
+                    LineNumber: row.SourceLine,
+                    Feature: row.Feature));
+            }
+            else if (!File.Exists(absoluteEvidencePath) && !Directory.Exists(absoluteEvidencePath))
             {
                 errors.Add(new VtConformanceIssue(
                     Code: "capability-evidence-path-not-found",
@@ -427,6 +452,18 @@ public static class VtConformanceReportTool
                     Feature: row.Feature));
             }
         }
+    }
+
+    private static bool IsPathWithinRoot(string rootPath, string candidatePath)
+    {
+        string normalizedRoot = Path.TrimEndingDirectorySeparator(Path.GetFullPath(rootPath));
+        string rootPrefix = normalizedRoot + Path.DirectorySeparatorChar;
+        StringComparison comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        return candidatePath.Equals(normalizedRoot, comparison)
+            || candidatePath.StartsWith(rootPrefix, comparison);
     }
 
     private static bool CapabilityStatusMatches(VtSupport support, string status)

--- a/src/NovaTerminal.McpServer/NovaTerminal.McpServer.csproj
+++ b/src/NovaTerminal.McpServer/NovaTerminal.McpServer.csproj
@@ -4,9 +4,9 @@
     NovaTerminal MCP server: a local stdio MCP server that exposes project knowledge to AI
     coding agents, plus — per the agent-host direction (docs/agent-host/DIRECTION.md, A1) —
     opt-in, observe-only access to live terminal sessions, proxied over the app's local IPC
-    endpoint. Solution dependencies are the zero-reference contracts leaf
-    (NovaTerminal.AgentHost.Contracts) and NovaTerminal.Backup, a second zero-reference leaf
-    (BackupService for the read-only backup MCP tools). This server must never reference
+    endpoint. Solution dependencies are three zero-reference leaves:
+    NovaTerminal.AgentHost.Contracts (wire protocol), NovaTerminal.Backup (read-only backup
+    tools), and NovaTerminal.VtContract (developer-facing VT capability metadata). This server must never reference
     App, VT, Pty, Rendering, or NovaTerminal.Platform (Platform pulls in Pty transitively,
     which would silently reopen the same hole a direct Pty reference would - see
     docs/MODULE_OWNERSHIP.md), and must never touch SSH or credentials. Session access is
@@ -29,6 +29,7 @@
   <ItemGroup>
     <ProjectReference Include="..\NovaTerminal.AgentHost.Contracts\NovaTerminal.AgentHost.Contracts.csproj" />
     <ProjectReference Include="..\NovaTerminal.Backup\NovaTerminal.Backup.csproj" />
+    <ProjectReference Include="..\NovaTerminal.VtContract\NovaTerminal.VtContract.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NovaTerminal.McpServer/Tools/VtTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/VtTools.cs
@@ -130,8 +130,14 @@ public static class VtTools
                 : string.Empty;
 
             string key = "CSI:" + finalByte;
-            bool hasBareSingleParameter = prefix.All(c => c >= '0' && c <= '9');
-            return ((hasBareSingleParameter && ContractSequenceTable.TryGetValue(key, out var desc))
+            bool hasStandardParameterList = prefix.All(c => (c >= '0' && c <= '9') || c is ';' or ':');
+            bool isQualifiedCha = finalByte == 'G' && !hasStandardParameterList;
+            if (isQualifiedCha)
+            {
+                note += " [qualified form — NovaTerminal currently processes it as CHA]";
+            }
+
+            return (((hasStandardParameterList || isQualifiedCha) && ContractSequenceTable.TryGetValue(key, out var desc))
                     || SequenceTable.TryGetValue(key, out desc))
                 ? $"CSI sequence, final byte '{finalByte}'{note}: {desc}"
                 : $"CSI sequence with final byte '{finalByte}'{note}: not in the curated table. Params/intermediates: '{prefix}'.";

--- a/src/NovaTerminal.McpServer/Tools/VtTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/VtTools.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text;
 using ModelContextProtocol.Server;
+using NovaTerminal.VtContract;
 
 namespace NovaTerminal.McpServer.Tools;
 
@@ -42,15 +43,18 @@ public static class VtTools
 
     // Curated explanations for the most common control sequences, keyed by a normalized token.
     // CSI entries are keyed by final byte ("CSI:J"); OSC by numeric code ("OSC:0"); a few ESC/DCS.
+    private static readonly Dictionary<string, string> ContractSequenceTable =
+        VtCapabilityCatalog.All.ToDictionary(
+            capability => capability.Key,
+            FormatCapabilityDescription,
+            StringComparer.Ordinal);
+
     private static readonly Dictionary<string, string> SequenceTable = new()
     {
         ["CSI:A"] = "CUU — Cursor Up Ps times.",
         ["CSI:B"] = "CUD — Cursor Down Ps times.",
         ["CSI:C"] = "CUF — Cursor Forward Ps times.",
         ["CSI:D"] = "CUB — Cursor Back Ps times.",
-        ["CSI:E"] = "CNL — Cursor Next Line Ps times (column 1). NOT currently handled by NovaTerminal's parser.",
-        ["CSI:F"] = "CPL — Cursor Previous Line Ps times (column 1). NOT currently handled by NovaTerminal's parser.",
-        ["CSI:G"] = "CHA — Cursor Horizontal Absolute to column Ps.",
         ["CSI:H"] = "CUP — Cursor Position to row;col (1-based).",
         ["CSI:J"] = "ED — Erase in Display (0=below, 1=above, 2=all, 3=all+scrollback).",
         ["CSI:K"] = "EL — Erase in Line (0=right, 1=left, 2=whole line).",
@@ -125,7 +129,9 @@ public static class VtTools
                 ? $" [intermediate byte(s) '{intermediates}' present — may select a different function than the bare final byte]"
                 : string.Empty;
 
-            return SequenceTable.TryGetValue("CSI:" + finalByte, out var desc)
+            string key = "CSI:" + finalByte;
+            return (ContractSequenceTable.TryGetValue(key, out var desc)
+                    || SequenceTable.TryGetValue(key, out desc))
                 ? $"CSI sequence, final byte '{finalByte}'{note}: {desc}"
                 : $"CSI sequence with final byte '{finalByte}'{note}: not in the curated table. Params/intermediates: '{prefix}'.";
         }
@@ -174,6 +180,19 @@ public static class VtTools
         }
 
         return $"Unrecognized sequence '{sequence}'. Use forms like 'ESC[2J', 'CSI ?25h', 'OSC 7', 'ESC c', 'DCS', or 'APC'.";
+    }
+
+    private static string FormatCapabilityDescription(VtCapability capability)
+    {
+        string supportNote = capability.Support switch
+        {
+            VtSupport.Supported => string.Empty,
+            VtSupport.Partial => " PARTIALLY supported by NovaTerminal.",
+            VtSupport.Unsupported => " NOT currently handled by NovaTerminal's parser.",
+            _ => throw new InvalidOperationException($"Unknown VT support state '{capability.Support}'."),
+        };
+
+        return $"{capability.Mnemonic} — {capability.Description}{supportNote}";
     }
 
     [McpServerTool(Name = "novaterminal.generate_vt_test_plan"),

--- a/src/NovaTerminal.McpServer/Tools/VtTools.cs
+++ b/src/NovaTerminal.McpServer/Tools/VtTools.cs
@@ -130,7 +130,8 @@ public static class VtTools
                 : string.Empty;
 
             string key = "CSI:" + finalByte;
-            return (ContractSequenceTable.TryGetValue(key, out var desc)
+            bool hasBareSingleParameter = prefix.All(c => c >= '0' && c <= '9');
+            return ((hasBareSingleParameter && ContractSequenceTable.TryGetValue(key, out var desc))
                     || SequenceTable.TryGetValue(key, out desc))
                 ? $"CSI sequence, final byte '{finalByte}'{note}: {desc}"
                 : $"CSI sequence with final byte '{finalByte}'{note}: not in the curated table. Params/intermediates: '{prefix}'.";

--- a/src/NovaTerminal.VtContract/NovaTerminal.VtContract.csproj
+++ b/src/NovaTerminal.VtContract/NovaTerminal.VtContract.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="vt-capabilities.json" LogicalName="NovaTerminal.VtContract.vt-capabilities.json" />
+  </ItemGroup>
+</Project>

--- a/src/NovaTerminal.VtContract/VtCapabilityCatalog.cs
+++ b/src/NovaTerminal.VtContract/VtCapabilityCatalog.cs
@@ -49,9 +49,9 @@ public static class VtCapabilityCatalog
         ArgumentNullException.ThrowIfNull(json);
 
         ManifestDocument document = DeserializeManifest(json);
-        ValidateManifest(document);
+        IReadOnlyList<ManifestEntry> entries = ValidateManifest(document);
 
-        return ParseCapabilities(document.Capabilities!);
+        return ParseCapabilities(entries);
     }
 
     private static ManifestDocument DeserializeManifest(string json)
@@ -67,7 +67,7 @@ public static class VtCapabilityCatalog
         }
     }
 
-    private static void ValidateManifest(ManifestDocument document)
+    private static IReadOnlyList<ManifestEntry> ValidateManifest(ManifestDocument document)
     {
         if (document.SchemaVersion != 1)
         {
@@ -78,6 +78,8 @@ public static class VtCapabilityCatalog
         {
             throw new VtCapabilityManifestException("The VT capability manifest must contain a capabilities array.");
         }
+
+        return document.Capabilities;
     }
 
     private static ReadOnlyCollection<VtCapability> ParseCapabilities(IReadOnlyList<ManifestEntry> entries)

--- a/src/NovaTerminal.VtContract/VtCapabilityCatalog.cs
+++ b/src/NovaTerminal.VtContract/VtCapabilityCatalog.cs
@@ -112,7 +112,7 @@ public static class VtCapabilityCatalog
                 contractCase));
         }
 
-        return capabilities;
+        return capabilities.AsReadOnly();
     }
 
     private static IReadOnlyList<VtCapability> LoadEmbeddedManifest()

--- a/src/NovaTerminal.VtContract/VtCapabilityCatalog.cs
+++ b/src/NovaTerminal.VtContract/VtCapabilityCatalog.cs
@@ -1,0 +1,151 @@
+using System.Reflection;
+using System.Text.Json;
+
+namespace NovaTerminal.VtContract;
+
+public enum VtSupport
+{
+    Supported,
+    Partial,
+    Unsupported,
+}
+
+public sealed record VtCapability(
+    string Key,
+    string Mnemonic,
+    VtSupport Support,
+    string Description,
+    string MatrixFeature,
+    string? EvidencePath,
+    string? ContractCase);
+
+public sealed class VtCapabilityManifestException : Exception
+{
+    public VtCapabilityManifestException(string message)
+        : base(message)
+    {
+    }
+
+    public VtCapabilityManifestException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}
+
+public static class VtCapabilityCatalog
+{
+    private const string ResourceName = "NovaTerminal.VtContract.vt-capabilities.json";
+
+    private static JsonSerializerOptions JsonOptions { get; } = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public static IReadOnlyList<VtCapability> All { get; } = LoadEmbeddedManifest();
+
+    public static IReadOnlyList<VtCapability> Parse(string json)
+    {
+        ArgumentNullException.ThrowIfNull(json);
+
+        ManifestDocument? document;
+        try
+        {
+            document = JsonSerializer.Deserialize<ManifestDocument>(json, JsonOptions);
+        }
+        catch (JsonException exception)
+        {
+            throw new VtCapabilityManifestException("The VT capability manifest is not valid JSON.", exception);
+        }
+
+        if (document is null)
+        {
+            throw new VtCapabilityManifestException("The VT capability manifest is empty.");
+        }
+
+        if (document.SchemaVersion != 1)
+        {
+            throw new VtCapabilityManifestException($"Unsupported VT capability manifest schemaVersion '{document.SchemaVersion}'.");
+        }
+
+        if (document.Capabilities is null)
+        {
+            throw new VtCapabilityManifestException("The VT capability manifest must contain a capabilities array.");
+        }
+
+        var capabilities = new List<VtCapability>(document.Capabilities.Count);
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (ManifestEntry entry in document.Capabilities)
+        {
+            string key = Require(entry.Key, "key", "<unknown>");
+            if (!keys.Add(key))
+            {
+                throw new VtCapabilityManifestException($"Capability '{key}' has a duplicate key.");
+            }
+
+            string mnemonic = Require(entry.Mnemonic, "mnemonic", key);
+            string description = Require(entry.Description, "description", key);
+            string matrixFeature = Require(entry.MatrixFeature, "matrixFeature", key);
+            if (!Enum.TryParse(entry.Support, ignoreCase: true, out VtSupport support))
+            {
+                throw new VtCapabilityManifestException($"Capability '{key}' has unknown support value '{entry.Support}'.");
+            }
+
+            string? evidencePath = NullIfWhiteSpace(entry.EvidencePath);
+            string? contractCase = NullIfWhiteSpace(entry.ContractCase);
+            if (support == VtSupport.Supported && evidencePath is null)
+            {
+                throw new VtCapabilityManifestException($"Capability '{key}' is supported but has no evidencePath.");
+            }
+
+            if (support == VtSupport.Supported && contractCase is null)
+            {
+                throw new VtCapabilityManifestException($"Capability '{key}' is supported but has no contractCase.");
+            }
+
+            capabilities.Add(new VtCapability(
+                key,
+                mnemonic,
+                support,
+                description,
+                matrixFeature,
+                evidencePath,
+                contractCase));
+        }
+
+        return capabilities;
+    }
+
+    private static IReadOnlyList<VtCapability> LoadEmbeddedManifest()
+    {
+        Assembly assembly = typeof(VtCapabilityCatalog).Assembly;
+        using Stream? stream = assembly.GetManifestResourceStream(ResourceName);
+        if (stream is null)
+        {
+            throw new VtCapabilityManifestException($"Embedded VT capability manifest '{ResourceName}' was not found.");
+        }
+
+        using var reader = new StreamReader(stream);
+        return Parse(reader.ReadToEnd());
+    }
+
+    private static string Require(string? value, string fieldName, string key)
+    {
+        string? normalized = NullIfWhiteSpace(value);
+        return normalized
+            ?? throw new VtCapabilityManifestException($"Capability '{key}' must provide {fieldName}.");
+    }
+
+    private static string? NullIfWhiteSpace(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private sealed record ManifestDocument(int SchemaVersion, IReadOnlyList<ManifestEntry>? Capabilities);
+
+    private sealed record ManifestEntry(
+        string? Key,
+        string? Mnemonic,
+        string? Support,
+        string? Description,
+        string? MatrixFeature,
+        string? EvidencePath,
+        string? ContractCase);
+}

--- a/src/NovaTerminal.VtContract/VtCapabilityCatalog.cs
+++ b/src/NovaTerminal.VtContract/VtCapabilityCatalog.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using System.Reflection;
 using System.Text.Json;
 
@@ -47,21 +48,27 @@ public static class VtCapabilityCatalog
     {
         ArgumentNullException.ThrowIfNull(json);
 
-        ManifestDocument? document;
+        ManifestDocument document = DeserializeManifest(json);
+        ValidateManifest(document);
+
+        return ParseCapabilities(document.Capabilities!);
+    }
+
+    private static ManifestDocument DeserializeManifest(string json)
+    {
         try
         {
-            document = JsonSerializer.Deserialize<ManifestDocument>(json, JsonOptions);
+            return JsonSerializer.Deserialize<ManifestDocument>(json, JsonOptions)
+                ?? throw new VtCapabilityManifestException("The VT capability manifest is empty.");
         }
         catch (JsonException exception)
         {
             throw new VtCapabilityManifestException("The VT capability manifest is not valid JSON.", exception);
         }
+    }
 
-        if (document is null)
-        {
-            throw new VtCapabilityManifestException("The VT capability manifest is empty.");
-        }
-
+    private static void ValidateManifest(ManifestDocument document)
+    {
         if (document.SchemaVersion != 1)
         {
             throw new VtCapabilityManifestException($"Unsupported VT capability manifest schemaVersion '{document.SchemaVersion}'.");
@@ -71,54 +78,98 @@ public static class VtCapabilityCatalog
         {
             throw new VtCapabilityManifestException("The VT capability manifest must contain a capabilities array.");
         }
+    }
 
-        var capabilities = new List<VtCapability>(document.Capabilities.Count);
+    private static ReadOnlyCollection<VtCapability> ParseCapabilities(IReadOnlyList<ManifestEntry> entries)
+    {
+        var capabilities = new List<VtCapability>(entries.Count);
         var keys = new HashSet<string>(StringComparer.Ordinal);
         var contractCases = new HashSet<string>(StringComparer.Ordinal);
-        foreach (ManifestEntry entry in document.Capabilities)
+        foreach (ManifestEntry entry in entries)
         {
-            string key = Require(entry.Key, "key", "<unknown>");
-            if (!keys.Add(key))
-            {
-                throw new VtCapabilityManifestException($"Capability '{key}' has a duplicate key.");
-            }
-
-            string mnemonic = Require(entry.Mnemonic, "mnemonic", key);
-            string description = Require(entry.Description, "description", key);
-            string matrixFeature = Require(entry.MatrixFeature, "matrixFeature", key);
-            if (!Enum.TryParse(entry.Support, ignoreCase: true, out VtSupport support))
-            {
-                throw new VtCapabilityManifestException($"Capability '{key}' has unknown support value '{entry.Support}'.");
-            }
-
-            string? evidencePath = NullIfWhiteSpace(entry.EvidencePath);
-            string? contractCase = NullIfWhiteSpace(entry.ContractCase);
-            if (contractCase is not null && !contractCases.Add(contractCase))
-            {
-                throw new VtCapabilityManifestException($"Capability '{key}' has duplicate contractCase '{contractCase}'.");
-            }
-
-            if (support == VtSupport.Supported && evidencePath is null)
-            {
-                throw new VtCapabilityManifestException($"Capability '{key}' is supported but has no evidencePath.");
-            }
-
-            if (support == VtSupport.Supported && contractCase is null)
-            {
-                throw new VtCapabilityManifestException($"Capability '{key}' is supported but has no contractCase.");
-            }
-
-            capabilities.Add(new VtCapability(
-                key,
-                mnemonic,
-                support,
-                description,
-                matrixFeature,
-                evidencePath,
-                contractCase));
+            capabilities.Add(ParseCapability(entry, keys, contractCases));
         }
 
         return capabilities.AsReadOnly();
+    }
+
+    private static VtCapability ParseCapability(
+        ManifestEntry entry,
+        HashSet<string> keys,
+        HashSet<string> contractCases)
+    {
+        string key = Require(entry.Key, "key", "<unknown>");
+        EnsureUniqueKey(key, keys);
+
+        string mnemonic = Require(entry.Mnemonic, "mnemonic", key);
+        string description = Require(entry.Description, "description", key);
+        string matrixFeature = Require(entry.MatrixFeature, "matrixFeature", key);
+        VtSupport support = ParseSupport(entry.Support, key);
+        string? evidencePath = NullIfWhiteSpace(entry.EvidencePath);
+        string? contractCase = NullIfWhiteSpace(entry.ContractCase);
+
+        EnsureUniqueContractCase(key, contractCase, contractCases);
+        EnsureSupportedEvidence(key, support, evidencePath, contractCase);
+
+        return new VtCapability(
+            key,
+            mnemonic,
+            support,
+            description,
+            matrixFeature,
+            evidencePath,
+            contractCase);
+    }
+
+    private static void EnsureUniqueKey(string key, HashSet<string> keys)
+    {
+        if (!keys.Add(key))
+        {
+            throw new VtCapabilityManifestException($"Capability '{key}' has a duplicate key.");
+        }
+    }
+
+    private static VtSupport ParseSupport(string? value, string key)
+    {
+        if (Enum.TryParse(value, ignoreCase: true, out VtSupport support))
+        {
+            return support;
+        }
+
+        throw new VtCapabilityManifestException($"Capability '{key}' has unknown support value '{value}'.");
+    }
+
+    private static void EnsureUniqueContractCase(
+        string key,
+        string? contractCase,
+        HashSet<string> contractCases)
+    {
+        if (contractCase is not null && !contractCases.Add(contractCase))
+        {
+            throw new VtCapabilityManifestException($"Capability '{key}' has duplicate contractCase '{contractCase}'.");
+        }
+    }
+
+    private static void EnsureSupportedEvidence(
+        string key,
+        VtSupport support,
+        string? evidencePath,
+        string? contractCase)
+    {
+        if (support != VtSupport.Supported)
+        {
+            return;
+        }
+
+        if (evidencePath is null)
+        {
+            throw new VtCapabilityManifestException($"Capability '{key}' is supported but has no evidencePath.");
+        }
+
+        if (contractCase is null)
+        {
+            throw new VtCapabilityManifestException($"Capability '{key}' is supported but has no contractCase.");
+        }
     }
 
     private static IReadOnlyList<VtCapability> LoadEmbeddedManifest()

--- a/src/NovaTerminal.VtContract/VtCapabilityCatalog.cs
+++ b/src/NovaTerminal.VtContract/VtCapabilityCatalog.cs
@@ -74,6 +74,7 @@ public static class VtCapabilityCatalog
 
         var capabilities = new List<VtCapability>(document.Capabilities.Count);
         var keys = new HashSet<string>(StringComparer.Ordinal);
+        var contractCases = new HashSet<string>(StringComparer.Ordinal);
         foreach (ManifestEntry entry in document.Capabilities)
         {
             string key = Require(entry.Key, "key", "<unknown>");
@@ -92,6 +93,11 @@ public static class VtCapabilityCatalog
 
             string? evidencePath = NullIfWhiteSpace(entry.EvidencePath);
             string? contractCase = NullIfWhiteSpace(entry.ContractCase);
+            if (contractCase is not null && !contractCases.Add(contractCase))
+            {
+                throw new VtCapabilityManifestException($"Capability '{key}' has duplicate contractCase '{contractCase}'.");
+            }
+
             if (support == VtSupport.Supported && evidencePath is null)
             {
                 throw new VtCapabilityManifestException($"Capability '{key}' is supported but has no evidencePath.");

--- a/src/NovaTerminal.VtContract/vt-capabilities.json
+++ b/src/NovaTerminal.VtContract/vt-capabilities.json
@@ -1,0 +1,32 @@
+{
+  "schemaVersion": 1,
+  "capabilities": [
+    {
+      "key": "CSI:E",
+      "mnemonic": "CNL",
+      "support": "supported",
+      "description": "Cursor Next Line Ps times and reset to column 1.",
+      "matrixFeature": "CNL (E)",
+      "evidencePath": "tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs",
+      "contractCase": "cursor-next-line"
+    },
+    {
+      "key": "CSI:F",
+      "mnemonic": "CPL",
+      "support": "supported",
+      "description": "Cursor Previous Line Ps times and reset to column 1.",
+      "matrixFeature": "CPL (F)",
+      "evidencePath": "tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs",
+      "contractCase": "cursor-previous-line"
+    },
+    {
+      "key": "CSI:G",
+      "mnemonic": "CHA",
+      "support": "supported",
+      "description": "Cursor Horizontal Absolute to column Ps.",
+      "matrixFeature": "CHA (G)",
+      "evidencePath": "tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs",
+      "contractCase": "cursor-horizontal-absolute"
+    }
+  ]
+}

--- a/tests/NovaTerminal.Architecture.Tests/ProjectFileLayeringTests.cs
+++ b/tests/NovaTerminal.Architecture.Tests/ProjectFileLayeringTests.cs
@@ -25,8 +25,8 @@ public class ProjectFileLayeringTests
 
     // Same CA1861 reasoning as VtOnly above. Order matches the csproj's own ItemGroup so
     // Assert.Equal's ordered comparison doesn't need a Sort/OrderBy on either side.
-    private static readonly string[] AgentHostContractsAndBackup =
-        ["NovaTerminal.AgentHost.Contracts", "NovaTerminal.Backup"];
+    private static readonly string[] McpServerLeafDependencies =
+        ["NovaTerminal.AgentHost.Contracts", "NovaTerminal.Backup", "NovaTerminal.VtContract"];
 
     private static string RepoRoot()
     {
@@ -167,14 +167,14 @@ public class ProjectFileLayeringTests
     /// P2 on PR #245.
     /// </summary>
     [Fact]
-    public void McpServer_csproj_only_references_AgentHostContractsAndBackup()
+    public void McpServer_csproj_only_references_approved_leaf_dependencies()
     {
         var refs = ProjectReferences("src/NovaTerminal.McpServer/NovaTerminal.McpServer.csproj");
-        Assert.Equal(AgentHostContractsAndBackup, refs);
+        Assert.Equal(McpServerLeafDependencies, refs);
     }
 
     /// <summary>
-    /// The assertion that actually keeps <see cref="McpServer_csproj_only_references_AgentHostContractsAndBackup"/>
+    /// The assertion that actually keeps <see cref="McpServer_csproj_only_references_approved_leaf_dependencies"/>
     /// meaningful long-term. That test only pins McpServer's own reference list; it says
     /// nothing about what <c>NovaTerminal.Backup</c> itself can reach. Without this test,
     /// someone could add e.g. <c>NovaTerminal.Platform</c> as a "small, surely harmless"
@@ -188,6 +188,13 @@ public class ProjectFileLayeringTests
     public void Backup_csproj_has_no_project_references()
     {
         var refs = ProjectReferences("src/NovaTerminal.Backup/NovaTerminal.Backup.csproj");
+        Assert.Empty(refs);
+    }
+
+    [Fact]
+    public void VtContract_csproj_has_no_project_references()
+    {
+        var refs = ProjectReferences("src/NovaTerminal.VtContract/NovaTerminal.VtContract.csproj");
         Assert.Empty(refs);
     }
 

--- a/tests/NovaTerminal.Architecture.Tests/VtCapabilityIntegrationTests.cs
+++ b/tests/NovaTerminal.Architecture.Tests/VtCapabilityIntegrationTests.cs
@@ -1,0 +1,40 @@
+namespace NovaTerminal.Architecture.Tests;
+
+public class VtCapabilityIntegrationTests
+{
+    private static string RepoRoot()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "NovaTerminal.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate repository root from test output path.");
+    }
+
+    private static string ReadRepositoryFile(string relativePath) =>
+        File.ReadAllText(Path.Combine(RepoRoot(), relativePath));
+
+    [Fact]
+    public void Vt_conformance_workflow_watches_the_capability_contract()
+    {
+        var workflow = ReadRepositoryFile(".github/workflows/vt-conformance.yml");
+
+        Assert.Contains("src/NovaTerminal.VtContract/**", workflow, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Pull_request_template_requires_capability_contract_evidence()
+    {
+        var template = ReadRepositoryFile(".github/pull_request_template.md");
+
+        Assert.Contains("vt-capabilities.json", template, StringComparison.Ordinal);
+        Assert.Contains("VtCapabilityContractTests.cs", template, StringComparison.Ordinal);
+    }
+}

--- a/tests/NovaTerminal.McpServer.Tests/NovaTerminal.McpServer.Tests.csproj
+++ b/tests/NovaTerminal.McpServer.Tests/NovaTerminal.McpServer.Tests.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\NovaTerminal.McpServer\NovaTerminal.McpServer.csproj" />
+    <ProjectReference Include="..\..\src\NovaTerminal.VtContract\NovaTerminal.VtContract.csproj" />
     <!-- Test-only: the drift guard reflects over the real profile types. The MCP server
          itself must never reference NovaTerminal.Platform. -->
     <ProjectReference Include="..\..\src\NovaTerminal.Platform\NovaTerminal.Platform.csproj" />

--- a/tests/NovaTerminal.McpServer.Tests/V2ToolsTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/V2ToolsTests.cs
@@ -1,4 +1,5 @@
 using NovaTerminal.McpServer.Tools;
+using NovaTerminal.VtContract;
 
 namespace NovaTerminal.McpServer.Tests;
 
@@ -34,12 +35,39 @@ public class ExplainEscapeSequenceTests
     }
 
     [Theory]
-    [InlineData("CSI E")] // CNL — not in HandleCsi
-    [InlineData("CSI F")] // CPL — not in HandleCsi
     [InlineData("CSI b")] // REP — no handler
     public void UnhandledCsiSequences_AreMarkedUnsupported(string seq)
     {
         Assert.Contains("NOT currently handled", VtTools.ExplainEscapeSequence(seq), System.StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("CSI E", "CNL")]
+    [InlineData("CSI F", "CPL")]
+    [InlineData("CSI G", "CHA")]
+    public void SupportedCursorCapabilities_AreReportedFromContract(string sequence, string mnemonic)
+    {
+        string result = VtTools.ExplainEscapeSequence(sequence);
+
+        Assert.Contains(mnemonic, result, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("NOT currently handled", result, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("unsupported", result, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CatalogCapabilities_AgreeWithExplainerSupportClaims()
+    {
+        foreach (VtCapability capability in VtCapabilityCatalog.All)
+        {
+            string result = VtTools.ExplainEscapeSequence(capability.Key.Replace(':', ' '));
+
+            Assert.Contains(capability.Mnemonic, result, System.StringComparison.Ordinal);
+            if (capability.Support == VtSupport.Supported)
+            {
+                Assert.DoesNotContain("NOT currently handled", result, System.StringComparison.Ordinal);
+                Assert.DoesNotContain("unsupported", result, System.StringComparison.OrdinalIgnoreCase);
+            }
+        }
     }
 
     [Fact]

--- a/tests/NovaTerminal.McpServer.Tests/V2ToolsTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/V2ToolsTests.cs
@@ -54,6 +54,21 @@ public class ExplainEscapeSequenceTests
         Assert.DoesNotContain("unsupported", result, System.StringComparison.OrdinalIgnoreCase);
     }
 
+    [Theory]
+    [InlineData("CSI ?2E", "CNL")]
+    [InlineData("CSI ?2F", "CPL")]
+    [InlineData("CSI ?2G", "CHA")]
+    [InlineData("CSI 2$E", "CNL")]
+    [InlineData("CSI 2$F", "CPL")]
+    [InlineData("CSI 2$G", "CHA")]
+    public void QualifiedContractForms_AreNotReportedAsTheSupportedBareCapability(string sequence, string mnemonic)
+    {
+        string result = VtTools.ExplainEscapeSequence(sequence);
+
+        Assert.DoesNotContain(mnemonic, result, System.StringComparison.Ordinal);
+        Assert.Contains("not in the curated table", result, System.StringComparison.Ordinal);
+    }
+
     [Fact]
     public void CatalogCapabilities_AgreeWithExplainerSupportClaims()
     {

--- a/tests/NovaTerminal.McpServer.Tests/V2ToolsTests.cs
+++ b/tests/NovaTerminal.McpServer.Tests/V2ToolsTests.cs
@@ -57,16 +57,37 @@ public class ExplainEscapeSequenceTests
     [Theory]
     [InlineData("CSI ?2E", "CNL")]
     [InlineData("CSI ?2F", "CPL")]
-    [InlineData("CSI ?2G", "CHA")]
     [InlineData("CSI 2$E", "CNL")]
     [InlineData("CSI 2$F", "CPL")]
-    [InlineData("CSI 2$G", "CHA")]
     public void QualifiedContractForms_AreNotReportedAsTheSupportedBareCapability(string sequence, string mnemonic)
     {
         string result = VtTools.ExplainEscapeSequence(sequence);
 
         Assert.DoesNotContain(mnemonic, result, System.StringComparison.Ordinal);
         Assert.Contains("not in the curated table", result, System.StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("CSI 2;3E", "CNL")]
+    [InlineData("CSI 2;3F", "CPL")]
+    [InlineData("CSI 2;3G", "CHA")]
+    [InlineData("CSI 2:3E", "CNL")]
+    [InlineData("CSI 2:3F", "CPL")]
+    [InlineData("CSI 2:3G", "CHA")]
+    public void ParameterLists_ReportTheCapabilityAcceptedByTheParser(string sequence, string mnemonic)
+    {
+        Assert.Contains(mnemonic, VtTools.ExplainEscapeSequence(sequence), System.StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("CSI ?2G")]
+    [InlineData("CSI 2$G")]
+    public void QualifiedChaForms_ReportCurrentParserBehavior(string sequence)
+    {
+        string result = VtTools.ExplainEscapeSequence(sequence);
+
+        Assert.Contains("CHA", result, System.StringComparison.Ordinal);
+        Assert.Contains("qualified form", result, System.StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/NovaTerminal.Platform.Tests/Conformance/VtConformanceToolTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Conformance/VtConformanceToolTests.cs
@@ -255,6 +255,40 @@ public sealed class VtConformanceToolTests
         Assert.Contains(report.Errors, issue => issue.Code == "capability-evidence-path-not-found" && issue.Feature == "CNL (E)");
     }
 
+    [Fact]
+    public void Generate_ReportsErrorInsteadOfThrowingWhenCapabilityMatrixRowIsDuplicated()
+    {
+        using var repo = new TemporaryRepo();
+        const string featureRow = "| CNL (E) | Cursor contract | ✅ Supported | Unit: `tests/CursorContractTests.cs` | Parser+Buffer | |";
+        string matrix = MatrixRow("CNL (E)", "✅ Supported", "tests/CursorContractTests.cs")
+            .Replace(featureRow, $"{featureRow}\n{featureRow}", StringComparison.Ordinal);
+        repo.WriteFile("tests/CursorContractTests.cs", "// evidence");
+        repo.WriteFile("docs/vt_coverage_matrix.md", matrix);
+        repo.WriteFile("src/NovaTerminal.VtContract/vt-capabilities.json", CapabilityManifest(
+            CapabilityEntry("CSI:E", "CNL", "supported", "CNL (E)", "tests/CursorContractTests.cs", "cursor-next-line")));
+
+        VtConformanceReport report = VtConformanceReportTool.Generate(
+            repo.RootPath,
+            Path.Combine(repo.RootPath, "docs", "vt_coverage_matrix.md"));
+
+        Assert.Contains(report.Errors, issue => issue.Code == "capability-matrix-row-duplicate" && issue.Feature == "CNL (E)");
+    }
+
+    [Fact]
+    public void Generate_RejectsCapabilityEvidenceOutsideRepository()
+    {
+        using var repo = new TemporaryRepo();
+        repo.WriteFile("docs/vt_coverage_matrix.md", MatrixRow("CNL (E)", "✅ Supported", "../outside.cs"));
+        repo.WriteFile("src/NovaTerminal.VtContract/vt-capabilities.json", CapabilityManifest(
+            CapabilityEntry("CSI:E", "CNL", "supported", "CNL (E)", "../outside.cs", "cursor-next-line")));
+
+        VtConformanceReport report = VtConformanceReportTool.Generate(
+            repo.RootPath,
+            Path.Combine(repo.RootPath, "docs", "vt_coverage_matrix.md"));
+
+        Assert.Contains(report.Errors, issue => issue.Code == "capability-evidence-path-outside-repo" && issue.Feature == "CNL (E)");
+    }
+
     private static string MatrixRow(string feature, string status, string evidencePath)
         => $$"""
         # VT Conformance Matrix

--- a/tests/NovaTerminal.Platform.Tests/Conformance/VtConformanceToolTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Conformance/VtConformanceToolTests.cs
@@ -191,6 +191,110 @@ public sealed class VtConformanceToolTests
         Assert.NotEmpty(report.Rows);
     }
 
+    [Fact]
+    public void Generate_ReportsErrorWhenCapabilityMatrixFeatureIsMissing()
+    {
+        using var repo = new TemporaryRepo();
+        repo.WriteFile("tests/CursorContractTests.cs", "// evidence");
+        repo.WriteFile("docs/vt_coverage_matrix.md", MatrixRow("CHA (G)", "✅ Supported", "tests/CursorContractTests.cs"));
+        repo.WriteFile("src/NovaTerminal.VtContract/vt-capabilities.json", CapabilityManifest(
+            CapabilityEntry("CSI:E", "CNL", "supported", "CNL (E)", "tests/CursorContractTests.cs", "cursor-next-line")));
+
+        VtConformanceReport report = VtConformanceReportTool.Generate(
+            repo.RootPath,
+            Path.Combine(repo.RootPath, "docs", "vt_coverage_matrix.md"));
+
+        Assert.Contains(report.Errors, issue => issue.Code == "capability-matrix-feature-missing" && issue.Feature == "CNL (E)");
+    }
+
+    [Fact]
+    public void Generate_ReportsErrorWhenCapabilityStatusDisagreesWithMatrix()
+    {
+        using var repo = new TemporaryRepo();
+        repo.WriteFile("tests/CursorContractTests.cs", "// evidence");
+        repo.WriteFile("docs/vt_coverage_matrix.md", MatrixRow("CNL (E)", "⚠ Partial", "tests/CursorContractTests.cs"));
+        repo.WriteFile("src/NovaTerminal.VtContract/vt-capabilities.json", CapabilityManifest(
+            CapabilityEntry("CSI:E", "CNL", "supported", "CNL (E)", "tests/CursorContractTests.cs", "cursor-next-line")));
+
+        VtConformanceReport report = VtConformanceReportTool.Generate(
+            repo.RootPath,
+            Path.Combine(repo.RootPath, "docs", "vt_coverage_matrix.md"));
+
+        Assert.Contains(report.Errors, issue => issue.Code == "capability-status-mismatch" && issue.Feature == "CNL (E)");
+    }
+
+    [Fact]
+    public void Generate_ReportsErrorWhenCapabilitiesShareMatrixFeature()
+    {
+        using var repo = new TemporaryRepo();
+        repo.WriteFile("tests/CursorContractTests.cs", "// evidence");
+        repo.WriteFile("docs/vt_coverage_matrix.md", MatrixRow("CNL/CPL (E/F)", "✅ Supported", "tests/CursorContractTests.cs"));
+        repo.WriteFile("src/NovaTerminal.VtContract/vt-capabilities.json", CapabilityManifest(
+            CapabilityEntry("CSI:E", "CNL", "supported", "CNL/CPL (E/F)", "tests/CursorContractTests.cs", "cursor-next-line"),
+            CapabilityEntry("CSI:F", "CPL", "supported", "CNL/CPL (E/F)", "tests/CursorContractTests.cs", "cursor-previous-line")));
+
+        VtConformanceReport report = VtConformanceReportTool.Generate(
+            repo.RootPath,
+            Path.Combine(repo.RootPath, "docs", "vt_coverage_matrix.md"));
+
+        Assert.Contains(report.Errors, issue => issue.Code == "capability-matrix-feature-duplicate" && issue.Feature == "CNL/CPL (E/F)");
+    }
+
+    [Fact]
+    public void Generate_ReportsErrorWhenCapabilityEvidencePathIsMissing()
+    {
+        using var repo = new TemporaryRepo();
+        repo.WriteFile("docs/vt_coverage_matrix.md", MatrixRow("CNL (E)", "✅ Supported", "tests/MissingContractTests.cs"));
+        repo.WriteFile("src/NovaTerminal.VtContract/vt-capabilities.json", CapabilityManifest(
+            CapabilityEntry("CSI:E", "CNL", "supported", "CNL (E)", "tests/MissingContractTests.cs", "cursor-next-line")));
+
+        VtConformanceReport report = VtConformanceReportTool.Generate(
+            repo.RootPath,
+            Path.Combine(repo.RootPath, "docs", "vt_coverage_matrix.md"));
+
+        Assert.Contains(report.Errors, issue => issue.Code == "capability-evidence-path-not-found" && issue.Feature == "CNL (E)");
+    }
+
+    private static string MatrixRow(string feature, string status, string evidencePath)
+        => $$"""
+        # VT Conformance Matrix
+
+        ## Cursor movement
+
+        | Feature / Sequence | Spec / Notes | Status | Evidence | Ownership (code) | Known deviations |
+        |---|---|---:|---|---|---|
+        | {{feature}} | Cursor contract | {{status}} | Unit: `{{evidencePath}}` | Parser+Buffer | |
+        """;
+
+    private static string CapabilityManifest(params string[] entries)
+        => $$"""
+        {
+          "schemaVersion": 1,
+          "capabilities": [
+            {{string.Join(",\n", entries)}}
+          ]
+        }
+        """;
+
+    private static string CapabilityEntry(
+        string key,
+        string mnemonic,
+        string support,
+        string matrixFeature,
+        string evidencePath,
+        string contractCase)
+        => $$"""
+            {
+              "key": "{{key}}",
+              "mnemonic": "{{mnemonic}}",
+              "support": "{{support}}",
+              "description": "{{mnemonic}} description",
+              "matrixFeature": "{{matrixFeature}}",
+              "evidencePath": "{{evidencePath}}",
+              "contractCase": "{{contractCase}}"
+            }
+        """;
+
     private static string FindRepositoryRoot()
     {
         DirectoryInfo? directory = new(AppContext.BaseDirectory);

--- a/tests/NovaTerminal.VT.Tests/NovaTerminal.VT.Tests.csproj
+++ b/tests/NovaTerminal.VT.Tests/NovaTerminal.VT.Tests.csproj
@@ -21,5 +21,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\NovaTerminal.VT\NovaTerminal.VT.csproj" />
+    <ProjectReference Include="..\..\src\NovaTerminal.VtContract\NovaTerminal.VtContract.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/NovaTerminal.VT.Tests/VtCapabilityCatalogTests.cs
+++ b/tests/NovaTerminal.VT.Tests/VtCapabilityCatalogTests.cs
@@ -28,6 +28,16 @@ public sealed class VtCapabilityCatalogTests
     }
 
     [Fact]
+    public void Parse_ReturnsAReadOnlyCatalog()
+    {
+        IReadOnlyList<VtCapability> capabilities = VtCapabilityCatalog.Parse(Manifest(
+            Entry("CSI:E", "CNL", "supported", "cursor-next-line")));
+        ICollection<VtCapability> collection = Assert.IsAssignableFrom<ICollection<VtCapability>>(capabilities);
+
+        Assert.Throws<NotSupportedException>(() => collection.Add(capabilities[0]));
+    }
+
+    [Fact]
     public void Parse_RejectsDuplicateKeys()
     {
         string json = Manifest(

--- a/tests/NovaTerminal.VT.Tests/VtCapabilityCatalogTests.cs
+++ b/tests/NovaTerminal.VT.Tests/VtCapabilityCatalogTests.cs
@@ -1,0 +1,120 @@
+using NovaTerminal.VtContract;
+
+namespace NovaTerminal.VT.Tests;
+
+public sealed class VtCapabilityCatalogTests
+{
+    [Fact]
+    public void Parse_ReturnsTypedCapabilitiesInManifestOrder()
+    {
+        IReadOnlyList<VtCapability> capabilities = VtCapabilityCatalog.Parse(Manifest(
+            Entry("CSI:E", "CNL", "supported", "cursor-next-line"),
+            Entry("CSI:F", "CPL", "partial", null)));
+
+        Assert.Collection(
+            capabilities,
+            capability =>
+            {
+                Assert.Equal("CSI:E", capability.Key);
+                Assert.Equal("CNL", capability.Mnemonic);
+                Assert.Equal(VtSupport.Supported, capability.Support);
+                Assert.Equal("cursor-next-line", capability.ContractCase);
+            },
+            capability =>
+            {
+                Assert.Equal("CSI:F", capability.Key);
+                Assert.Equal(VtSupport.Partial, capability.Support);
+            });
+    }
+
+    [Fact]
+    public void Parse_RejectsDuplicateKeys()
+    {
+        string json = Manifest(
+            Entry("CSI:E", "CNL", "supported", "cursor-next-line"),
+            Entry("CSI:E", "CNL duplicate", "partial", null));
+
+        VtCapabilityManifestException error = Assert.Throws<VtCapabilityManifestException>(
+            () => VtCapabilityCatalog.Parse(json));
+
+        Assert.Contains("CSI:E", error.Message, StringComparison.Ordinal);
+        Assert.Contains("duplicate", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Parse_RejectsUnknownSupportValue()
+    {
+        string json = Manifest(Entry("CSI:E", "CNL", "complete", "cursor-next-line"));
+
+        VtCapabilityManifestException error = Assert.Throws<VtCapabilityManifestException>(
+            () => VtCapabilityCatalog.Parse(json));
+
+        Assert.Contains("CSI:E", error.Message, StringComparison.Ordinal);
+        Assert.Contains("complete", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Parse_RejectsMissingDescription()
+    {
+        string json = """
+        {
+          "schemaVersion": 1,
+          "capabilities": [
+            {
+              "key": "CSI:E",
+              "mnemonic": "CNL",
+              "support": "supported",
+              "description": "",
+              "matrixFeature": "CNL (E)",
+              "evidencePath": "tests/NovaTerminal.VT.Tests/CursorLinePositioningTests.cs",
+              "contractCase": "cursor-next-line"
+            }
+          ]
+        }
+        """;
+
+        VtCapabilityManifestException error = Assert.Throws<VtCapabilityManifestException>(
+            () => VtCapabilityCatalog.Parse(json));
+
+        Assert.Contains("CSI:E", error.Message, StringComparison.Ordinal);
+        Assert.Contains("description", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("evidencePath")]
+    [InlineData("contractCase")]
+    public void Parse_RejectsSupportedEntryWithoutRequiredContractField(string field)
+    {
+        string entry = Entry("CSI:E", "CNL", "supported", "cursor-next-line")
+            .Replace($"\"{field}\": \"{(field == "evidencePath" ? "tests/NovaTerminal.VT.Tests/CursorLinePositioningTests.cs" : "cursor-next-line")}\"", $"\"{field}\": null", StringComparison.Ordinal);
+
+        VtCapabilityManifestException error = Assert.Throws<VtCapabilityManifestException>(
+            () => VtCapabilityCatalog.Parse(Manifest(entry)));
+
+        Assert.Contains("CSI:E", error.Message, StringComparison.Ordinal);
+        Assert.Contains(field, error.Message, StringComparison.Ordinal);
+    }
+
+    private static string Manifest(params string[] entries)
+        => $$"""
+        {
+          "schemaVersion": 1,
+          "capabilities": [
+            {{string.Join(",\n", entries)}}
+          ]
+        }
+        """;
+
+    private static string Entry(string key, string mnemonic, string support, string? contractCase)
+        => $$"""
+            {
+              "key": "{{key}}",
+              "mnemonic": "{{mnemonic}}",
+              "support": "{{support}}",
+              "description": "{{mnemonic}} description",
+              "matrixFeature": "{{mnemonic}} ({{key[^1]}})",
+              "evidencePath": "tests/NovaTerminal.VT.Tests/CursorLinePositioningTests.cs",
+              "contractCase": {{(contractCase is null ? "null" : $"\"{contractCase}\"")}}
+            }
+        """;
+}

--- a/tests/NovaTerminal.VT.Tests/VtCapabilityCatalogTests.cs
+++ b/tests/NovaTerminal.VT.Tests/VtCapabilityCatalogTests.cs
@@ -52,6 +52,20 @@ public sealed class VtCapabilityCatalogTests
     }
 
     [Fact]
+    public void Parse_RejectsDuplicateContractCases()
+    {
+        string json = Manifest(
+            Entry("CSI:E", "CNL", "supported", "cursor-line"),
+            Entry("CSI:F", "CPL", "supported", "cursor-line"));
+
+        VtCapabilityManifestException error = Assert.Throws<VtCapabilityManifestException>(
+            () => VtCapabilityCatalog.Parse(json));
+
+        Assert.Contains("cursor-line", error.Message, StringComparison.Ordinal);
+        Assert.Contains("duplicate", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Parse_RejectsUnknownSupportValue()
     {
         string json = Manifest(Entry("CSI:E", "CNL", "complete", "cursor-next-line"));

--- a/tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs
+++ b/tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs
@@ -61,6 +61,8 @@ public sealed class VtCapabilityContractTests
         AssertPosition("\x1b[E", expectedRow: 4, expectedCol: 0);
         AssertPosition("\x1b[0E", expectedRow: 4, expectedCol: 0);
         AssertPosition("\x1b[2E", expectedRow: 5, expectedCol: 0);
+        AssertPosition("\x1b[2;3E", expectedRow: 5, expectedCol: 0);
+        AssertPosition("\x1b[2:3E", expectedRow: 5, expectedCol: 0);
         AssertPosition("\x1b[999E", expectedRow: 7, expectedCol: 0);
         AssertIgnored("\x1b[?2E");
         AssertIgnored("\x1b[2$E");
@@ -71,6 +73,8 @@ public sealed class VtCapabilityContractTests
         AssertPosition("\x1b[F", expectedRow: 2, expectedCol: 0);
         AssertPosition("\x1b[0F", expectedRow: 2, expectedCol: 0);
         AssertPosition("\x1b[2F", expectedRow: 1, expectedCol: 0);
+        AssertPosition("\x1b[2;3F", expectedRow: 1, expectedCol: 0);
+        AssertPosition("\x1b[2:3F", expectedRow: 1, expectedCol: 0);
         AssertPosition("\x1b[999F", expectedRow: 0, expectedCol: 0);
         AssertIgnored("\x1b[?2F");
         AssertIgnored("\x1b[2$F");
@@ -81,6 +85,10 @@ public sealed class VtCapabilityContractTests
         AssertPosition("\x1b[G", expectedRow: 3, expectedCol: 0);
         AssertPosition("\x1b[0G", expectedRow: 3, expectedCol: 0);
         AssertPosition("\x1b[4G", expectedRow: 3, expectedCol: 3);
+        AssertPosition("\x1b[2;3G", expectedRow: 3, expectedCol: 1);
+        AssertPosition("\x1b[2:3G", expectedRow: 3, expectedCol: 1);
+        AssertPosition("\x1b[?2G", expectedRow: 3, expectedCol: 1);
+        AssertPosition("\x1b[2$G", expectedRow: 3, expectedCol: 1);
         AssertPosition("\x1b[999G", expectedRow: 3, expectedCol: 11);
     }
 

--- a/tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs
+++ b/tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs
@@ -1,0 +1,129 @@
+using NovaTerminal.VtContract;
+
+namespace NovaTerminal.VT.Tests;
+
+public sealed class VtCapabilityContractTests
+{
+    private static readonly Dictionary<string, Action> ContractCases =
+        new(StringComparer.Ordinal)
+        {
+            ["cursor-next-line"] = AssertCursorNextLine,
+            ["cursor-previous-line"] = AssertCursorPreviousLine,
+            ["cursor-horizontal-absolute"] = AssertCursorHorizontalAbsolute,
+        };
+
+    private static readonly Dictionary<string, string> ContractSequences =
+        new(StringComparer.Ordinal)
+        {
+            ["cursor-next-line"] = "\x1b[2E",
+            ["cursor-previous-line"] = "\x1b[2F",
+            ["cursor-horizontal-absolute"] = "\x1b[4G",
+        };
+
+    public static IEnumerable<object[]> SupportedCapabilities()
+        => VtCapabilityCatalog.All
+            .Where(capability => capability.Support == VtSupport.Supported)
+            .Select(capability => new object[]
+            {
+                capability.Key,
+                capability.ContractCase!,
+            });
+
+    [Theory]
+    [MemberData(nameof(SupportedCapabilities))]
+    public void SupportedCapability_HasExecutableParserContract(string key, string contractCase)
+    {
+        bool registered = ContractCases.TryGetValue(contractCase, out Action? assertion);
+
+        Assert.True(registered, $"Supported capability '{key}' has no parser contract registered as '{contractCase}'.");
+        assertion!();
+    }
+
+    [Theory]
+    [MemberData(nameof(SupportedCapabilities))]
+    public void SupportedCapability_IsEquivalentAcrossEveryInputSplit(string key, string contractCase)
+    {
+        Assert.True(
+            ContractSequences.TryGetValue(contractCase, out string? sequence),
+            $"Supported capability '{key}' has no split-input sequence registered as '{contractCase}'.");
+
+        (int expectedRow, int expectedCol) = ProcessAtEverySplit(sequence!, splitAt: null);
+        for (int splitAt = 1; splitAt < sequence!.Length; splitAt++)
+        {
+            (int actualRow, int actualCol) = ProcessAtEverySplit(sequence, splitAt);
+            Assert.Equal(expectedRow, actualRow);
+            Assert.Equal(expectedCol, actualCol);
+        }
+    }
+
+    private static void AssertCursorNextLine()
+    {
+        AssertPosition("\x1b[E", expectedRow: 4, expectedCol: 0);
+        AssertPosition("\x1b[0E", expectedRow: 4, expectedCol: 0);
+        AssertPosition("\x1b[2E", expectedRow: 5, expectedCol: 0);
+        AssertPosition("\x1b[999E", expectedRow: 7, expectedCol: 0);
+        AssertIgnored("\x1b[?2E");
+        AssertIgnored("\x1b[2$E");
+    }
+
+    private static void AssertCursorPreviousLine()
+    {
+        AssertPosition("\x1b[F", expectedRow: 2, expectedCol: 0);
+        AssertPosition("\x1b[0F", expectedRow: 2, expectedCol: 0);
+        AssertPosition("\x1b[2F", expectedRow: 1, expectedCol: 0);
+        AssertPosition("\x1b[999F", expectedRow: 0, expectedCol: 0);
+        AssertIgnored("\x1b[?2F");
+        AssertIgnored("\x1b[2$F");
+    }
+
+    private static void AssertCursorHorizontalAbsolute()
+    {
+        AssertPosition("\x1b[G", expectedRow: 3, expectedCol: 0);
+        AssertPosition("\x1b[0G", expectedRow: 3, expectedCol: 0);
+        AssertPosition("\x1b[4G", expectedRow: 3, expectedCol: 3);
+        AssertPosition("\x1b[999G", expectedRow: 3, expectedCol: 11);
+    }
+
+    private static void AssertPosition(string sequence, int expectedRow, int expectedCol)
+    {
+        var buffer = new TerminalBuffer(cols: 12, rows: 8);
+        var parser = new AnsiParser(buffer);
+        parser.Process("\x1b[4;6H");
+
+        parser.Process(sequence);
+
+        Assert.Equal(expectedRow, buffer.CursorRow);
+        Assert.Equal(expectedCol, buffer.CursorCol);
+    }
+
+    private static void AssertIgnored(string sequence)
+    {
+        var buffer = new TerminalBuffer(cols: 12, rows: 8);
+        var parser = new AnsiParser(buffer);
+        parser.Process("\x1b[4;6H");
+
+        parser.Process(sequence);
+
+        Assert.Equal(3, buffer.CursorRow);
+        Assert.Equal(5, buffer.CursorCol);
+    }
+
+    private static (int Row, int Col) ProcessAtEverySplit(string sequence, int? splitAt)
+    {
+        var buffer = new TerminalBuffer(cols: 12, rows: 8);
+        var parser = new AnsiParser(buffer);
+        parser.Process("\x1b[4;6H");
+
+        if (splitAt is int index)
+        {
+            parser.Process(sequence[..index]);
+            parser.Process(sequence[index..]);
+        }
+        else
+        {
+            parser.Process(sequence);
+        }
+
+        return (buffer.CursorRow, buffer.CursorCol);
+    }
+}


### PR DESCRIPTION
## Summary

- add a small leaf `NovaTerminal.VtContract` project with an embedded, strictly validated capability manifest
- make supported CNL/CPL/CHA claims executable through manifest-driven parser contracts, including defaults, bounds, invalid forms, and every input split
- validate the manifest against the VT matrix/evidence, source MCP explanations from the same catalog, and gate future drift in CI and the PR checklist

## Test plan

- [x] `scripts/build.ps1 build NovaTerminal.sln -c Release --no-restore -v quiet` (0 errors)
- [x] `NovaTerminal.VT.Tests` — 416 passed
- [x] `NovaTerminal.Platform.Tests` — 171 passed, 30 environment skips
- [x] `NovaTerminal.McpServer.Tests` — 155 passed
- [x] `NovaTerminal.Architecture.Tests` — 59 passed
- [x] conformance validation — 60 rows, 0 errors, 0 warnings, embedded report matches

## Full-suite note

The unfiltered solution run completed VT, Platform, Rendering, MCP, and Architecture successfully. The unrelated App suite reached 1,232 passes and 13 environment skips before its runner became inactive in `AgentIndicatorTabRollupTests.A_write_marks_the_owning_tabs_label`. The same named test passed independently in 0.5 seconds; no capability-contract code touches that subsystem.
