### PR TITLE
Return viewport to the input line on user input

### DIFF
--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -806,6 +806,7 @@ namespace NovaTerminal.Controls
                 if (!string.IsNullOrEmpty(_pendingEscapedPath) && Session != null)
                 {
                     NotifyExternalInputSent();
+                    TermView.ScrollToInputLine();
                     Session.SendInput(_pendingEscapedPath);
                     _pendingPasteFilePath = null;
                     _pendingEscapedPath = null;
@@ -821,6 +822,7 @@ namespace NovaTerminal.Controls
                     {
                         string content = await System.IO.File.ReadAllTextAsync(_pendingPasteFilePath);
                         NotifyExternalInputSent();
+                        TermView.ScrollToInputLine();
                         NovaTerminal.Platform.Input.TerminalInputSender.SendBracketedPaste(Session, content);
                     }
                     catch (Exception ex)
@@ -2236,6 +2238,14 @@ namespace NovaTerminal.Controls
         /// </remarks>
         internal void NotifyExternalInputSent() => _marklessSubmission.Poison();
 
+        /// <summary>
+        /// Brings the terminal viewport back to the live input line, for input that enters the
+        /// PTY from outside <see cref="TerminalView"/>'s own key/text handling (window clipboard
+        /// paste, toast path paste). Writing while scrolled up into scrollback must reveal the
+        /// line being written; see <see cref="TerminalView.ScrollToInputLine"/>.
+        /// </summary>
+        public void ScrollToInputLine() => TermView.ScrollToInputLine();
+
         private async Task HandleCommandAssistEnterObservedAsync(string? submittedText)
         {
             if (!EnsureCommandAssistInitialized())
@@ -2618,6 +2628,7 @@ namespace NovaTerminal.Controls
             // handling. No bracketed paste for either half: bracketed content is literal by
             // definition, so a DEL inside it would be inserted as a character rather than executed as
             // an erase.
+            TermView.ScrollToInputLine();
             Session.SendInput(new string('\x7f', plan.BackspaceCount) + plan.TextToSend);
 
             // The grid is now behind the shell by everything we just sent, and the next accept must

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -5370,6 +5370,7 @@ namespace NovaTerminal
                         text,
                         _currentPane.Buffer?.Modes.IsBracketedPasteMode == true);
 
+                    _currentPane.ScrollToInputLine();
                     _currentPane.Session.SendInput(text);
                     return;
                 }
@@ -5392,6 +5393,7 @@ namespace NovaTerminal
                             ? NovaTerminal.Platform.Input.ClipboardImage.ToWslMountPath(path)
                             : path;
                         _currentPane.NotifyExternalInputSent();
+                        _currentPane.ScrollToInputLine();
                         _currentPane.Session.SendInput(NovaTerminal.Platform.Input.ClipboardImage.QuotePathForInput(sendPath));
                     }
                     finally

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -2465,6 +2465,7 @@ namespace NovaTerminal
                 // Broadcast bytes never went through the receiving pane's key handling, so its
                 // markless submission accumulator cannot model them.
                 pane.NotifyExternalInputSent();
+                pane.ScrollToInputLine();
                 pane.Session?.SendInput(sequence);
             }
         }
@@ -2481,6 +2482,7 @@ namespace NovaTerminal
             {
                 if (pane == _currentPane) continue;
                 pane.NotifyExternalInputSent();
+                pane.ScrollToInputLine();
                 pane.Session?.SendInput(text);
             }
         }

--- a/src/NovaTerminal.App/Shell/TerminalView.cs
+++ b/src/NovaTerminal.App/Shell/TerminalView.cs
@@ -119,7 +119,7 @@ namespace NovaTerminal.Shell
             if (!e.Handled && _session != null && !string.IsNullOrEmpty(e.Text))
             {
                 ResetCursorBlink();
-                _session.SendInput(e.Text);
+                SendUserInput(e.Text);
                 TextInputObserved?.Invoke(e.Text);
                 e.Handled = true;
             }
@@ -167,7 +167,7 @@ namespace NovaTerminal.Shell
             // even if a TUI already pushed flag 1 onto the buffer's ModeState.
             if (_enableKittyKeyboardProtocol && TryEncodeKittyKey(key, keyModifiers, out string? kittySequence))
             {
-                _session.SendInput(kittySequence!);
+                SendUserInput(kittySequence!);
                 return true;
             }
 
@@ -178,7 +178,7 @@ namespace NovaTerminal.Shell
                 string? altSequence = TerminalInputModeEncoder.EncodeAltKey(key, keyModifiers);
                 if (altSequence != null)
                 {
-                    _session.SendInput(altSequence);
+                    SendUserInput(altSequence);
                     return true;
                 }
             }
@@ -194,21 +194,21 @@ namespace NovaTerminal.Shell
                         // TerminalPane.OnKeyDown, which owns the reconnect-on-Enter logic.
                         return false;
                     }
-                    _session.SendInput("\r");
+                    SendUserInput("\r");
                     EnterObserved?.Invoke();
                     return true;
                 case Key.Back:
-                    _session.SendInput("\x7f");
+                    SendUserInput("\x7f");
                     BackspaceObserved?.Invoke();
                     return true;
                 case Key.Tab:
                     // Shift+Tab must emit the back-tab (CBT) sequence ESC [ Z, exactly as
                     // xterm does. TUIs like Claude Code rely on it for reverse navigation
                     // (e.g. cycling permission modes backward); a literal tab breaks that.
-                    _session.SendInput((keyModifiers & KeyModifiers.Shift) != 0 ? "\x1b[Z" : "\t");
+                    SendUserInput((keyModifiers & KeyModifiers.Shift) != 0 ? "\x1b[Z" : "\t");
                     return true;
                 case Key.Escape:
-                    _session.SendInput("\x1b");
+                    SendUserInput("\x1b");
                     return true;
 
                 default:
@@ -219,7 +219,7 @@ namespace NovaTerminal.Shell
                             // Ctrl+A = 1, Ctrl+Z = 26
                             // ASCII Control Characters
                             char ctrlChar = (char)(key - Key.A + 1);
-                            _session.SendInput(ctrlChar.ToString());
+                            SendUserInput(ctrlChar.ToString());
                             return true;
                         }
                     }
@@ -235,7 +235,7 @@ namespace NovaTerminal.Shell
                         }
                         else
                         {
-                            _session.SendInput("\x03");
+                            SendUserInput("\x03");
                         }
                         return true;
                     }
@@ -262,7 +262,7 @@ namespace NovaTerminal.Shell
             string? sequence = TerminalInputModeEncoder.EncodeSpecialKey(key, _buffer?.Modes);
             if (sequence != null)
             {
-                _session.SendInput(sequence);
+                SendUserInput(sequence);
                 return true;
             }
 
@@ -610,7 +610,7 @@ namespace NovaTerminal.Shell
 
                         if (!string.IsNullOrEmpty(result.TextToSend))
                         {
-                            _session.SendInput(result.TextToSend);
+                            SendUserInput(result.TextToSend);
                             PasteObserved?.Invoke(result.TextToSend);
                         }
 
@@ -631,7 +631,7 @@ namespace NovaTerminal.Shell
 
             if (e.DataTransfer.TryGetText() is string text && !string.IsNullOrWhiteSpace(text))
             {
-                _session.SendInput(text);
+                SendUserInput(text);
                 PasteObserved?.Invoke(text);
                 e.Handled = true;
             }
@@ -1397,6 +1397,31 @@ namespace NovaTerminal.Shell
         public void SetScrollOffset(int offset)
         {
             ScrollOffset = offset;
+        }
+
+        /// <summary>
+        /// Returns the viewport to the live input line (offset 0). Typing while scrolled up
+        /// into scrollback must show the line being written, so every user-originated input
+        /// path snaps here first. No-op when already at the bottom or when there is nothing
+        /// to scroll (e.g. the alternate screen, where maxScroll is 0).
+        /// </summary>
+        /// <remarks>
+        /// Only <em>input</em> does this. Output keeps the user's position via
+        /// <see cref="EnsureCursorVisible"/>'s near-bottom rule, and protocol-driven sends
+        /// that are not writing (focus reports, mouse reports, device replies) must not
+        /// scroll at all - those bypass <see cref="SendUserInput"/> by design.
+        /// </remarks>
+        public void ScrollToInputLine() => ScrollOffset = 0;
+
+        /// <summary>
+        /// Sends user-originated input (keystroke, typed text, pasted or dropped text) to
+        /// the PTY after returning the viewport to the live line, so what the user is
+        /// writing stays visible even when they had scrolled up into scrollback.
+        /// </summary>
+        private void SendUserInput(string text)
+        {
+            ScrollToInputLine();
+            _session?.SendInput(text);
         }
 
 

--- a/tests/NovaTerminal.App.Tests/Input/TerminalViewScrollToInputTests.cs
+++ b/tests/NovaTerminal.App.Tests/Input/TerminalViewScrollToInputTests.cs
@@ -1,0 +1,160 @@
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Moq;
+using NovaTerminal.Pty;
+using NovaTerminal.Shell;
+using NovaTerminal.VT;
+using Xunit;
+
+namespace NovaTerminal.Tests.Input
+{
+    /// <summary>
+    /// Writing while scrolled up into scrollback must bring the viewport back to the live
+    /// input line: the user cannot see what they type otherwise. Only user-originated input
+    /// (typed text, keys that reach the PTY, pasted/dropped text) does this. Keys that never
+    /// reach the PTY - Command-Assist-owned keys, dead-session Enter, Ctrl+C-as-copy - keep
+    /// the scrolled position, and so must every non-writing send (focus reports, mouse
+    /// reports), which stay outside <see cref="TerminalView"/> snap path by design.
+    /// </summary>
+    public class TerminalViewScrollToInputTests
+    {
+        private sealed class TestTerminalView : TerminalView
+        {
+            public void RaiseTextInputForTest(string text)
+            {
+                OnTextInput(new TextInputEventArgs { Text = text });
+            }
+        }
+
+        private static TerminalBuffer CreateBufferWithScrollback()
+        {
+            var buffer = new TerminalBuffer(80, 24);
+            var parser = new AnsiParser(buffer);
+            for (int i = 1; i <= 40; i++)
+            {
+                parser.Process($"line {i}\r\n");
+            }
+            Assert.True(buffer.Scrollback.Count > 0, "test setup: expected scrollback");
+            return buffer;
+        }
+
+        private static (TestTerminalView View, Mock<ITerminalSession> Session) CreateScrolledUpView(bool processRunning = true)
+        {
+            var session = new Mock<ITerminalSession>();
+            session.SetupGet(x => x.IsProcessRunning).Returns(processRunning);
+            var view = new TestTerminalView();
+            TerminalBuffer buffer = CreateBufferWithScrollback();
+            view.SetBuffer(buffer);
+            view.SetSession(session.Object);
+            int maxScroll = Math.Max(0, buffer.TotalLines - buffer.Rows);
+            view.ScrollOffset = maxScroll;
+            Assert.True(view.ScrollOffset > 0, "test setup: expected the view to be scrolled up");
+            return (view, session);
+        }
+
+        [AvaloniaFact]
+        public void HandleKeyDownCore_WhenScrolledUp_TypingTabReturnsToInputLine()
+        {
+            var (view, session) = CreateScrolledUpView();
+
+            bool handled = view.HandleKeyDownCore(Key.Tab, KeyModifiers.None);
+
+            Assert.True(handled);
+            Assert.Equal(0, view.ScrollOffset);
+            session.Verify(x => x.SendInput("\t"), Times.Once);
+        }
+
+        [AvaloniaFact]
+        public void HandleKeyDownCore_WhenScrolledUp_EnterReturnsToInputLine()
+        {
+            var (view, session) = CreateScrolledUpView();
+
+            bool handled = view.HandleKeyDownCore(Key.Enter, KeyModifiers.None);
+
+            Assert.True(handled);
+            Assert.Equal(0, view.ScrollOffset);
+            session.Verify(x => x.SendInput("\r"), Times.Once);
+        }
+
+        [AvaloniaFact]
+        public void HandleKeyDownCore_WhenScrolledUp_ArrowKeyReturnsToInputLine()
+        {
+            // Arrow keys edit the (invisible) command line through the shell, so they count
+            // as writing just like printable text does.
+            var (view, session) = CreateScrolledUpView();
+
+            bool handled = view.HandleKeyDownCore(Key.Up, KeyModifiers.None);
+
+            Assert.True(handled);
+            Assert.Equal(0, view.ScrollOffset);
+            session.Verify(x => x.SendInput(It.IsAny<string>()), Times.Once);
+        }
+
+        [AvaloniaFact]
+        public void TextInput_WhenScrolledUp_TypedTextReturnsToInputLine()
+        {
+            var (view, session) = CreateScrolledUpView();
+
+            view.RaiseTextInputForTest("x");
+
+            Assert.Equal(0, view.ScrollOffset);
+            session.Verify(x => x.SendInput("x"), Times.Once);
+        }
+
+        [AvaloniaFact]
+        public void HandleKeyDownCore_WhenScrolledUp_DeadSessionEnterKeepsScrollPosition()
+        {
+            // Enter on a dead session is reconnect affordance, not terminal input - nothing
+            // is being written, so the user's reading position must stay put.
+            var (view, session) = CreateScrolledUpView(processRunning: false);
+
+            bool handled = view.HandleKeyDownCore(Key.Enter, KeyModifiers.None);
+
+            Assert.False(handled);
+            Assert.True(view.ScrollOffset > 0);
+            session.Verify(x => x.SendInput(It.IsAny<string>()), Times.Never);
+        }
+
+        [AvaloniaFact]
+        public void HandleKeyDownCore_WhenScrolledUp_InterceptorOwnedKeyKeepsScrollPosition()
+        {
+            // Command Assist owns the key: it never reaches the PTY, so it must not yank the
+            // viewport back to the input line.
+            var (view, session) = CreateScrolledUpView();
+            view.KeyDownInterceptor = (key, modifiers) => key == Key.Tab;
+
+            bool handled = view.HandleKeyDownCore(Key.Tab, KeyModifiers.None);
+
+            Assert.True(handled);
+            Assert.True(view.ScrollOffset > 0);
+            session.Verify(x => x.SendInput(It.IsAny<string>()), Times.Never);
+        }
+
+        [AvaloniaFact]
+        public void HandleKeyDownCore_WhenScrolledUp_CopyWithSelectionKeepsScrollPosition()
+        {
+            // Ctrl+C with a selection copies instead of sending SIGINT - reading and copying
+            // scrollback must not snap the viewport away from what is being read.
+            var (view, session) = CreateScrolledUpView();
+            view.SetSelectionForTest(0, 0, 0, 3);
+
+            bool handled = view.HandleKeyDownCore(Key.C, KeyModifiers.Control);
+
+            Assert.True(handled);
+            Assert.True(view.ScrollOffset > 0);
+            session.Verify(x => x.SendInput(It.IsAny<string>()), Times.Never);
+        }
+
+        [AvaloniaFact]
+        public void ScrollToInputLine_WhenAlreadyAtBottom_IsNoOp()
+        {
+            var buffer = new TerminalBuffer(80, 24);
+            var view = new TerminalView();
+            view.SetBuffer(buffer);
+
+            view.ScrollToInputLine();
+
+            Assert.Equal(0, view.ScrollOffset);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

When the terminal is scrolled up into scrollback, typing goes to the PTY but the input line stays off-screen — the user is writing blind. Other terminals snap the viewport back to the live line on input; NovaTerminal didn't.

## Change

Every **user-originated** input path now returns the viewport to the live input line (`ScrollOffset = 0`) before sending:

- `TerminalView`: new private `SendUserInput()` wraps all PTY-bound sends in `OnTextInput`, `HandleKeyDownCore` (Enter, Backspace, Tab, Escape, Ctrl-chars, alt sequences, kitty protocol, encoded special keys) and the drag-and-drop paste paths; new public `ScrollToInputLine()`.
- `TerminalPane`: toast path-paste buttons and the Command Assist Ctrl+Enter insertion snap too; small public `ScrollToInputLine()` delegating to the view.
- `MainWindow`: clipboard paste (text and image-path branches) snap before sending.

Deliberately **not** scrolling:

- Output keeps the existing near-bottom follow rule (`EnsureCursorVisible`), so streaming output still doesn't yank a scrolled-up reader.
- Non-writing sends never scroll: focus reports, mouse reports, parser device replies, Command-Assist-owned keys, Ctrl+C-as-copy, dead-session Enter.

No-op when already at the bottom or on the alternate screen (maxScroll = 0).

## Tests

8 new tests in `TerminalViewScrollToInputTests` covering the snap on Tab/Enter/arrows/typed text and position preservation for dead-session Enter, assist-owned keys, and copy-with-selection.