### PR TITLE
feat(agent-output): render command output as markdown in a side panel

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,6 +35,10 @@
     <!-- Architecture testing (added in Phase 2 but reserved here for one-shot CPM) -->
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
 
+    <!-- Agent Output panel: markdown parsing only (no UI dependency); the Avalonia
+         rendering is NovaTerminal.App's own MarkdownRenderer. -->
+    <PackageVersion Include="Markdig" Version="1.3.2" />
+
     <!-- MCP Dev Companion (NovaTerminal.McpServer) -->
     <PackageVersion Include="ModelContextProtocol" Version="1.4.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml
@@ -1,0 +1,72 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="380" d:DesignHeight="600"
+             x:Class="NovaTerminal.AgentOutput.AgentOutputPanel"
+             Width="380">
+    <!-- Chrome matches the pane's other hand-styled surfaces (RemoteFilesSidebar, the assist
+         overlay): fixed dark palette, hairline left edge. Width lives here so the presenter
+         column in TerminalPane stays Auto-sized. -->
+    <Border Background="#1B1D21" BorderBrush="#31353A" BorderThickness="1,0,0,0">
+        <Grid RowDefinitions="Auto,*">
+            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="6" Margin="10,8,10,6">
+                <StackPanel Spacing="1">
+                    <TextBlock Text="Agent Output"
+                               Foreground="#F3F6FA"
+                               FontSize="13"
+                               FontWeight="SemiBold"/>
+                    <TextBlock x:Name="StatusText"
+                               Foreground="#96A0AE"
+                               FontSize="10.5"
+                               IsVisible="False"/>
+                </StackPanel>
+
+                <Button x:Name="BtnCopyAll"
+                        Grid.Column="1"
+                        Content="Copy"
+                        FontSize="11"
+                        Padding="7,2"
+                        VerticalAlignment="Top"
+                        ToolTip.Tip="Copy the raw markdown source"
+                        Click="OnCopyAllClick"/>
+                <Button x:Name="BtnClose"
+                        Grid.Column="2"
+                        Content="✕"
+                        FontSize="11"
+                        Padding="6,2"
+                        VerticalAlignment="Top"
+                        ToolTip.Tip="Close the panel"
+                        Click="OnCloseClick"/>
+            </Grid>
+
+            <!-- Empty state and the rendered markdown occupy the same row; exactly one is visible.
+                 Rendered content is a StackPanel the code-behind rebuilds on each update - the
+                 markdown comes from the terminal grid as one text snapshot, so there is no
+                 incremental binding to a collection. -->
+            <StackPanel x:Name="EmptyState"
+                        Grid.Row="1"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Center"
+                        Margin="24,0">
+                <TextBlock Text="No output yet"
+                           Foreground="#96A0AE"
+                           FontSize="13"
+                           TextAlignment="Center"/>
+                <TextBlock Text="Run a command — its output renders here as markdown."
+                           Foreground="#6B737F"
+                           FontSize="11"
+                           TextWrapping="Wrap"
+                           TextAlignment="Center"
+                           Margin="0,4,0,0"/>
+            </StackPanel>
+
+            <ScrollViewer x:Name="ContentScroll"
+                          Grid.Row="1"
+                          Padding="12,0,12,10"
+                          IsVisible="False">
+                <StackPanel x:Name="MarkdownHost"/>
+            </ScrollViewer>
+        </Grid>
+    </Border>
+</UserControl>

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml
@@ -53,7 +53,7 @@
                            Foreground="#96A0AE"
                            FontSize="13"
                            TextAlignment="Center"/>
-                <TextBlock Text="Run a command — its output renders here as markdown."
+                <TextBlock Text="Run a command with this panel open — its output renders here as markdown."
                            Foreground="#6B737F"
                            FontSize="11"
                            TextWrapping="Wrap"

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml
@@ -63,7 +63,7 @@
 
             <ScrollViewer x:Name="ContentScroll"
                           Grid.Row="1"
-                          Padding="12,0,12,10"
+                          Padding="12,4,12,18"
                           IsVisible="False">
                 <StackPanel x:Name="MarkdownHost"/>
             </ScrollViewer>

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml.cs
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml.cs
@@ -164,7 +164,7 @@ public partial class AgentOutputPanel : UserControl
                (uri.Scheme == "http" || uri.Scheme == "https" || uri.Scheme == "mailto");
     }
 
-    private void OpenLink(string url)
+    private async void OpenLink(string url)
     {
         if (!IsSafeExternalUrl(url))
         {
@@ -172,17 +172,12 @@ public partial class AgentOutputPanel : UserControl
             return;
         }
 
-        try
+        // Avalonia's launcher, not a raw Process.Start: it resolves the platform URL handler and
+        // fails soft when no TopLevel is attached (headless tests, early construction).
+        TopLevel? topLevel = TopLevel.GetTopLevel(this);
+        if (topLevel is not null)
         {
-            _ = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
-            {
-                FileName = url,
-                UseShellExecute = true,
-            });
-        }
-        catch (Exception ex)
-        {
-            System.Diagnostics.Debug.WriteLine($"[AgentOutputPanel] Opening link failed: {ex.Message}");
+            await topLevel.Launcher.LaunchUriAsync(new Uri(url, UriKind.Absolute));
         }
     }
 }

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml.cs
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
@@ -104,8 +105,8 @@ public partial class AgentOutputPanel : UserControl
         Control rendered = MarkdownRenderer.Build(
             markdown,
             this,
-            onCopyText: text => CopyToClipboard(text),
-            onOpenLink: OpenLink);
+            onCopyText: text => _ = CopyToClipboardAsync(text),
+            onOpenLink: url => _ = OpenLinkAsync(url));
         MarkdownHost.Children.Add(rendered);
 
         if (wasPinned && isStreaming)
@@ -134,14 +135,17 @@ public partial class AgentOutputPanel : UserControl
         string markdown = _viewModel?.MarkdownText;
         if (!string.IsNullOrEmpty(markdown))
         {
-            CopyToClipboard(markdown);
+            _ = CopyToClipboardAsync(markdown);
         }
     }
 
     private void OnCloseClick(object? sender, RoutedEventArgs e)
         => CloseRequested?.Invoke();
 
-    private async void CopyToClipboard(string text)
+    // Task-returning rather than async void (SonarCloud S3168): both are fire-and-forget UI
+    // side effects, so the discard at each call site is the containment — an exception surfaces
+    // as a task result nobody awaits instead of crashing the process.
+    private async Task CopyToClipboardAsync(string text)
     {
         // TopLevel is null in headless tests and before the pane attaches; a copy that silently
         // does nothing there is the correct degradation.
@@ -164,7 +168,7 @@ public partial class AgentOutputPanel : UserControl
                (uri.Scheme == "http" || uri.Scheme == "https" || uri.Scheme == "mailto");
     }
 
-    private async void OpenLink(string url)
+    private async Task OpenLinkAsync(string url)
     {
         if (!IsSafeExternalUrl(url))
         {

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml.cs
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml.cs
@@ -152,10 +152,26 @@ public partial class AgentOutputPanel : UserControl
         }
     }
 
+    /// <summary>
+    /// The link schemes allowed to reach the OS shell handler. A security boundary rather than a
+    /// nicety: agent output is untrusted text, and UseShellExecute on an unvalidated string would
+    /// happily launch an executable when a crafted markdown link names one (a bare file path, a
+    /// file: URL, a custom protocol handler). Only web and mail links may leave the app.
+    /// </summary>
+    internal static bool IsSafeExternalUrl(string url)
+    {
+        return Uri.TryCreate(url, UriKind.Absolute, out Uri? uri) &&
+               (uri.Scheme == "http" || uri.Scheme == "https" || uri.Scheme == "mailto");
+    }
+
     private void OpenLink(string url)
     {
-        // Same shell-open shape as MainWindow.OpenPathInShell: UseShellExecute resolves the
-        // platform handler (browser on https/mailto) without this app linking a launcher.
+        if (!IsSafeExternalUrl(url))
+        {
+            System.Diagnostics.Debug.WriteLine($"[AgentOutputPanel] Blocked non-web link: {url}");
+            return;
+        }
+
         try
         {
             _ = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml.cs
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml.cs
@@ -1,0 +1,172 @@
+using System;
+using System.ComponentModel;
+using Avalonia.Controls;
+using Avalonia.Input.Platform;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+
+namespace NovaTerminal.AgentOutput;
+
+/// <summary>
+/// The Agent Output side panel: header, empty state, and the markdown-rendered output region.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The view-model is attached with <see cref="SetViewModel"/> rather than DataContext binding:
+/// the panel's markdown content cannot be a binding anyway (it is a rebuilt control tree, not a
+/// list), and keeping everything in code keeps the compiled-bindings surface to zero for a view
+/// that exists to host generated content.
+/// </para>
+/// <para>
+/// <b>Follow tail.</b> While a command streams, the panel keeps the newest content on screen -
+/// but only if the user is already at the bottom. A reader who scrolled up to study an earlier
+/// section is never yanked back down; the release condition is scrolling back to the end.
+/// </para>
+/// </remarks>
+public partial class AgentOutputPanel : UserControl
+{
+    private AgentOutputViewModel? _viewModel;
+    private bool _pinnedToBottom = true;
+    private double _lastOffsetY = -1;
+
+    public AgentOutputPanel()
+    {
+        InitializeComponent();
+
+        // Pin-state tracking: only an actual offset move counts as the user's intent. Extent
+        // growth from streaming content fires ScrollChanged without moving the offset, and that
+        // must not unpin a reader sitting at the bottom.
+        ContentScroll.ScrollChanged += (_, _) =>
+        {
+            double offsetY = ContentScroll.Offset.Y;
+            bool offsetMoved = Math.Abs(offsetY - _lastOffsetY) > 0.5;
+            _lastOffsetY = offsetY;
+
+            if (!offsetMoved)
+            {
+                return;
+            }
+
+            _pinnedToBottom = offsetY + ContentScroll.Viewport.Height >= ContentScroll.Extent.Height - 4;
+        };
+    }
+
+    /// <summary>Raised when the user asks to close the panel (the ✕ button).</summary>
+    public event Action? CloseRequested;
+
+    /// <summary>Attaches the pane's view model. May be called once; the pane owns the lifetime.</summary>
+    public void SetViewModel(AgentOutputViewModel viewModel)
+    {
+        if (_viewModel is not null)
+        {
+            _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
+        }
+
+        _viewModel = viewModel;
+        _viewModel.PropertyChanged += OnViewModelPropertyChanged;
+        Render();
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        // Always on the UI thread: the tracker posts its updates through the pane's dispatcher.
+        if (e.PropertyName is nameof(AgentOutputViewModel.MarkdownText) or nameof(AgentOutputViewModel.HasContent))
+        {
+            Render();
+        }
+        else if (e.PropertyName is nameof(AgentOutputViewModel.StatusText) or nameof(AgentOutputViewModel.IsStreaming))
+        {
+            UpdateStatus();
+        }
+    }
+
+    private void Render()
+    {
+        string markdown = _viewModel?.MarkdownText ?? string.Empty;
+        bool hasContent = markdown.Length > 0;
+
+        EmptyState.IsVisible = !hasContent;
+        ContentScroll.IsVisible = hasContent;
+        BtnCopyAll.IsEnabled = hasContent;
+
+        if (!hasContent)
+        {
+            MarkdownHost.Children.Clear();
+            return;
+        }
+
+        // The scroll offset is captured before the swap and restored after: a reader parked mid-
+        // document (follow-tail disengaged) stays parked when the content beneath them changes.
+        bool wasPinned = _pinnedToBottom;
+        bool isStreaming = _viewModel?.IsStreaming ?? false;
+
+        MarkdownHost.Children.Clear();
+        Control rendered = MarkdownRenderer.Build(
+            markdown,
+            this,
+            onCopyText: text => CopyToClipboard(text),
+            onOpenLink: OpenLink);
+        MarkdownHost.Children.Add(rendered);
+
+        if (wasPinned && isStreaming)
+        {
+            // ContentScroll must be measured before ScrollToEnd means anything; layout runs at
+            // the end of this dispatcher cycle.
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (_pinnedToBottom)
+                {
+                    ContentScroll.ScrollToEnd();
+                }
+            }, DispatcherPriority.Background);
+        }
+    }
+
+    private void UpdateStatus()
+    {
+        string? status = _viewModel?.StatusText;
+        StatusText.Text = status;
+        StatusText.IsVisible = !string.IsNullOrEmpty(status);
+    }
+
+    private void OnCopyAllClick(object? sender, RoutedEventArgs e)
+    {
+        string markdown = _viewModel?.MarkdownText;
+        if (!string.IsNullOrEmpty(markdown))
+        {
+            CopyToClipboard(markdown);
+        }
+    }
+
+    private void OnCloseClick(object? sender, RoutedEventArgs e)
+        => CloseRequested?.Invoke();
+
+    private async void CopyToClipboard(string text)
+    {
+        // TopLevel is null in headless tests and before the pane attaches; a copy that silently
+        // does nothing there is the correct degradation.
+        var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+        if (clipboard is not null)
+        {
+            await clipboard.SetTextAsync(text);
+        }
+    }
+
+    private void OpenLink(string url)
+    {
+        // Same shell-open shape as MainWindow.OpenPathInShell: UseShellExecute resolves the
+        // platform handler (browser on https/mailto) without this app linking a launcher.
+        try
+        {
+            _ = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = url,
+                UseShellExecute = true,
+            });
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[AgentOutputPanel] Opening link failed: {ex.Message}");
+        }
+    }
+}

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputRegionTracker.cs
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputRegionTracker.cs
@@ -76,6 +76,7 @@ public sealed class AgentOutputRegionTracker : IDisposable
     private bool _enabled;
     private bool _regionActive;
     private ShellIntegrationMark? _heuristicStart;
+    private ShellIntegrationMark? _previousHeuristicStart;
     private int _lastPostedHash;
     private int _lastPostedStreaming;
     private int _dedupeStale;
@@ -250,6 +251,10 @@ public sealed class AgentOutputRegionTracker : IDisposable
         // there is no B mark. False on an active alt screen, which is the right refusal.
         if (CommandOutputReader.TryCaptureOutputStart(buffer, null, out ShellIntegrationMark start))
         {
+            // The displaced row is kept as a retry. An Enter that submitted nothing - a bare
+            // prompt, which is a keystroke away at any idle shell - pins a row whose region stays
+            // empty forever, and it must not bury the response sitting right above it.
+            _previousHeuristicStart = _heuristicStart;
             _heuristicStart = start;
         }
     }
@@ -289,6 +294,7 @@ public sealed class AgentOutputRegionTracker : IDisposable
     {
         _regionActive = false;
         _heuristicStart = null;
+        _previousHeuristicStart = null;
         AdvanceGeneration();
     }
 
@@ -360,11 +366,27 @@ public sealed class AgentOutputRegionTracker : IDisposable
                 _heuristicStart = null;
             }
 
+            // A corrective flush still owes the panel something. Leaving it on its empty state
+            // while readable output sits on screen is the worst of the three answers.
+            if (fallbackToRecentTail)
+            {
+                PostCorrectiveFallback(buffer, generation);
+            }
+
             return;
         }
 
         if (Volatile.Read(ref _generation) != generation)
         {
+            return;
+        }
+
+        // An empty region is a real answer while a command streams - it has printed nothing yet -
+        // but on a corrective flush it means the remembered row did not pan out, and the panel
+        // must not blank out over output the user can see above it.
+        if (text.Length == 0 && fallbackToRecentTail && !_regionActive)
+        {
+            PostCorrectiveFallback(buffer, generation);
             return;
         }
 
@@ -375,6 +397,35 @@ public sealed class AgentOutputRegionTracker : IDisposable
         // re-marks itself on the next debounce tick, one window later.
         bool live = streaming && (_regionActive || !fallbackToRecentTail);
         DeliverUpdate(text, live, generation);
+    }
+
+    /// <summary>
+    /// What a corrective flush posts when the newest remembered row cannot answer: the row before
+    /// it, and failing that the prompt-shape snapshot.
+    /// </summary>
+    /// <remarks>
+    /// The ladder exists because the newest row is not always the interesting one. Pressing Enter
+    /// at an idle prompt pins a row that will never hold output, and it lands on top of the row
+    /// for the response the user actually wants to read. Retrying the displaced row recovers that
+    /// response exactly; the snapshot below it is the guess of last resort, and guesses at prompt
+    /// shape are why this ladder is preferred over starting there.
+    /// </remarks>
+    private void PostCorrectiveFallback(TerminalBuffer buffer, int generation)
+    {
+        if (_previousHeuristicStart is ShellIntegrationMark previous &&
+            CommandOutputReader.TryReadOutputTail(buffer, previous, RegionBudget, out string text) &&
+            text.Length > 0)
+        {
+            if (Volatile.Read(ref _generation) != generation)
+            {
+                return;
+            }
+
+            DeliverUpdate(text, streaming: false, generation);
+            return;
+        }
+
+        TryPostRecentTailSnapshot(buffer, generation);
     }
 
     /// <summary>

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputRegionTracker.cs
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputRegionTracker.cs
@@ -362,8 +362,10 @@ public sealed class AgentOutputRegionTracker : IDisposable
         // No edges bound a snapshot, so the raw tail is a fragment of the whole conversation:
         // prompts, echoed commands, and several rounds of responses interleaved. Split at the
         // prompt lines and deliver the latest round's response - in a long agent chat that is
-        // "the response", not the whole pane.
-        text = RecentTailSanitizer.ExtractLastResponse(text);
+        // "the response", not the whole pane. Indentation is normalized before delivery: agent
+        // responses indent examples under list items, and 4-space indents would otherwise parse
+        // those sections as code blocks.
+        text = RecentTailSanitizer.NormalizeIndentation(RecentTailSanitizer.ExtractLastResponse(text));
         if (text.Length == 0)
         {
             return;

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputRegionTracker.cs
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputRegionTracker.cs
@@ -359,9 +359,11 @@ public sealed class AgentOutputRegionTracker : IDisposable
             return;
         }
 
-        // No edges bound a snapshot, so prompt and echoed-command lines ride the raw tail; trim
-        // them off both ends and deliver the response.
-        text = RecentTailSanitizer.Trim(text);
+        // No edges bound a snapshot, so the raw tail is a fragment of the whole conversation:
+        // prompts, echoed commands, and several rounds of responses interleaved. Split at the
+        // prompt lines and deliver the latest round's response - in a long agent chat that is
+        // "the response", not the whole pane.
+        text = RecentTailSanitizer.ExtractLastResponse(text);
         if (text.Length == 0)
         {
             return;

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputRegionTracker.cs
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputRegionTracker.cs
@@ -109,18 +109,42 @@ public sealed class AgentOutputRegionTracker : IDisposable
     /// </summary>
     public void NotifyCommandFinished()
     {
-        if (_enabled)
+        // Order is load-bearing: resolve the final read's region start while the flag still says
+        // a region is live (the provider is a field read; the grid walk below still happens on
+        // the parse thread, before any repaint), then flip the flag, THEN bump the generation.
+        // Flip-before-bump closes the interleaving where a debounce callback starts between the
+        // two: from this instant every background reader either sees a cleared flag - and has
+        // nothing to read - or a bumped generation - and is dropped. A streaming:true update in
+        // the final generation is therefore impossible.
+        ShellIntegrationMark? start = _regionActive ? _commandOutputStartProvider() : null;
+        _regionActive = false;
+        AdvanceGeneration();
+
+        if (!_enabled || start is not ShellIntegrationMark mark)
         {
-            // Bump BEFORE the final read, then read under the post-bump generation: in-flight
-            // background reads die at their own checks, while this read's dispatched closure
-            // validates against the new generation and survives the transition. The region flag
-            // is still up here, so the read still resolves the C mark; by the time any later
-            // observer looks, the flag is down and the state is consistent.
-            AdvanceGeneration();
-            ReadAndPostCore(streaming: false, Volatile.Read(ref _generation));
+            return;
         }
 
-        _regionActive = false;
+        // The final read runs under the post-bump generation, explicitly bound to the resolved
+        // mark rather than to the (now cleared) flag, so it survives this very transition.
+        int generation = Volatile.Read(ref _generation);
+        TerminalBuffer? buffer = _bufferProvider();
+        if (buffer is null || buffer.IsAltScreenActive)
+        {
+            return;
+        }
+
+        if (!CommandOutputReader.TryReadOutputTail(buffer, mark, RegionBudget, out string text))
+        {
+            return;
+        }
+
+        if (Volatile.Read(ref _generation) != generation)
+        {
+            return;
+        }
+
+        DeliverUpdate(text, streaming: false, generation);
     }
 
     /// <summary>
@@ -211,9 +235,10 @@ public sealed class AgentOutputRegionTracker : IDisposable
         }
 
         // The read is stale the moment the state it was based on changes (C, D, reset, disable).
-        // Checked again inside the dispatched closure: the background read can straddle a
-        // transition, and without this a late streaming:true dispatch would park the panel on
-        // "streaming…" after D, or resurrect a reset command's output.
+        // Checked below after the walk, and once more inside DeliverUpdate's dispatched closure:
+        // the background read can straddle a transition, and without this a late streaming:true
+        // dispatch would park the panel on "streaming…" after D, or resurrect a reset command's
+        // output.
         TerminalBuffer? buffer = _bufferProvider();
         if (buffer is null || buffer.IsAltScreenActive)
         {
@@ -244,25 +269,43 @@ public sealed class AgentOutputRegionTracker : IDisposable
             return;
         }
 
-        // string.GetHashCode is randomized per process but stable within one, which is all a
-        // change detector needs. The streaming flag participates in the dedupe on purpose: the
-        // text often does not change between the last debounce tick and D, and the panel's
-        // status line must still get the "streaming ended" update.
-        int hash = text.GetHashCode();
-        int streamingFlag = streaming ? 1 : 0;
-        if (Interlocked.Exchange(ref _lastPostedHash, hash) == hash &&
-            Volatile.Read(ref _lastPostedStreaming) == streamingFlag)
-        {
-            return;
-        }
+        DeliverUpdate(text, streaming, generation);
+    }
 
-        Volatile.Write(ref _lastPostedStreaming, streamingFlag);
+    /// <summary>
+    /// Hands one read result to the UI thread, dropping it if its generation has been superseded
+    /// meanwhile, and committing the dedupe state only when delivery actually happens.
+    /// </summary>
+    /// <remarks>
+    /// The dedupe commit lives <i>inside</i> the closure on purpose. Committing before dispatch
+    /// (the previous shape) let a dropped update still mark its hash and streaming flag as
+    /// delivered - so a later, legitimate same-text update in the new generation was suppressed
+    /// and the panel stayed stale. Deduping here, on the serialized UI side and behind the
+    /// generation check, keeps the two decisions atomic.
+    /// </remarks>
+    private void DeliverUpdate(string text, bool streaming, int generation)
+    {
         _dispatch(() =>
         {
-            if (Volatile.Read(ref _generation) == generation)
+            if (Volatile.Read(ref _generation) != generation)
             {
-                _onUpdate(text, streaming);
+                return;
             }
+
+            // string.GetHashCode is randomized per process but stable within one, which is all a
+            // change detector needs. The streaming flag participates in the dedupe on purpose:
+            // the text often does not change between the last debounce tick and D, and the
+            // panel's status line must still get the "streaming ended" update.
+            int hash = text.GetHashCode();
+            int streamingFlag = streaming ? 1 : 0;
+            if (Interlocked.Exchange(ref _lastPostedHash, hash) == hash &&
+                Volatile.Read(ref _lastPostedStreaming) == streamingFlag)
+            {
+                return;
+            }
+
+            Volatile.Write(ref _lastPostedStreaming, streamingFlag);
+            _onUpdate(text, streaming);
         });
     }
 

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputRegionTracker.cs
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputRegionTracker.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Threading;
+using NovaTerminal.VT;
+
+namespace NovaTerminal.AgentOutput;
+
+/// <summary>
+/// Tracks one pane's current command <i>output region</i> and posts its text as it grows, so the
+/// Agent Output panel can render it as markdown while the command streams.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Where the region comes from.</b> With shell integration, the pane already captures the
+/// <c>OSC 133;C</c> edge into <c>TerminalBuffer.CommandOutputStartMark</c>
+/// (<see cref="CommandOutputReader.TryCaptureOutputStart"/>); the tracker resolves that mark at
+/// read time and inherits every staleness rule of the marked read. Without shell integration no C
+/// edge ever arrives, so <see cref="CaptureHeuristicStart"/> pins the region start from the cursor
+/// at Enter time - a weaker, display-only contract (prompt lines can leak in), which is exactly
+/// what <see cref="CommandOutputReader.TryReadRecentTail"/> documents for the markless shape.
+/// </para>
+/// <para>
+/// <b>Threading.</b> <see cref="NotifyInvalidate"/> fires on the PTY parse thread for every chunk
+/// the parser writes; it does nothing but re-arm a debounce timer. The actual grid read runs on a
+/// threadpool thread - <see cref="CommandOutputReader"/> takes the buffer read lock itself, and
+/// the render snapshot path already reads from off the parse thread the same way. Results cross
+/// back through the pane's UI dispatcher. The one synchronous read is <see cref="NotifyCommandFinished"/>:
+/// at <c>OSC 133;D</c> the grid still holds the finished command's output, and by the time a
+/// debounced read could run the next prompt has painted over its tail. That read runs on the
+/// parse thread, bounded by the same budget that caps every other read.
+/// </para>
+/// <para>
+/// <b>Why a hash.</b> A streaming agent repaints churn into the region between debounce ticks;
+/// hashing the assembled text skips the no-op updates those ticks would otherwise post, and the
+/// panel rebuilds only when the text truly changed.
+/// </para>
+/// </remarks>
+public sealed class AgentOutputRegionTracker : IDisposable
+{
+    /// <summary>Logical lines kept. Sized for a large agent response, not an error tail.</summary>
+    public const int MaxRegionLines = 400;
+
+    /// <summary>Character ceiling on the region text handed to the renderer.</summary>
+    public const int MaxRegionChars = 128 * 1024;
+
+    /// <summary>Physical-row backstop, independent of the logical-line budget.</summary>
+    public const int MaxRegionRows = 2048;
+
+    /// <summary>The budget every region read walks under.</summary>
+    public static readonly OutputTailBudget RegionBudget = new(MaxRegionLines, MaxRegionChars, MaxRegionRows);
+
+    /// <summary>How long grid invalidations are coalesced before a background read runs.</summary>
+    public static readonly TimeSpan DebounceDelay = TimeSpan.FromMilliseconds(300);
+
+    private readonly Func<TerminalBuffer?> _bufferProvider;
+    private readonly Func<ShellIntegrationMark?> _commandOutputStartProvider;
+    private readonly Action<Action> _dispatch;
+    private readonly Action<string, bool> _onUpdate;
+    private readonly Timer _debounceTimer;
+
+    private bool _enabled;
+    private bool _regionActive;
+    private ShellIntegrationMark? _heuristicStart;
+    private int _lastPostedHash;
+    private int _lastPostedStreaming;
+    private int _disposed;
+
+    /// <param name="bufferProvider">The pane's live buffer, resolved at read time.</param>
+    /// <param name="commandOutputStartProvider">
+    /// The <c>OSC 133;C</c> region start the pane captured, or null for a markless session.
+    /// </param>
+    /// <param name="dispatch">Marshals the posted update onto the UI thread.</param>
+    /// <param name="onUpdate">
+    /// Receives (regionText, isStreaming) on the UI thread. Only called when the text changed.
+    /// </param>
+    public AgentOutputRegionTracker(
+        Func<TerminalBuffer?> bufferProvider,
+        Func<ShellIntegrationMark?> commandOutputStartProvider,
+        Action<Action> dispatch,
+        Action<string, bool> onUpdate)
+    {
+        _bufferProvider = bufferProvider;
+        _commandOutputStartProvider = commandOutputStartProvider;
+        _dispatch = dispatch;
+        _onUpdate = onUpdate;
+        _debounceTimer = new Timer(ReadScheduled, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+    }
+
+    /// <summary>
+    /// The shell accepted a command (<c>OSC 133;C</c>). Called on the parse thread, right after
+    /// the pane captured the region start.
+    /// </summary>
+    public void NotifyCommandAccepted()
+    {
+        if (_enabled)
+        {
+            _regionActive = true;
+            _heuristicStart = null;
+        }
+    }
+
+    /// <summary>
+    /// The command finished (<c>OSC 133;D</c>). Called on the parse thread while the grid still
+    /// holds the output: the final read happens here, synchronously, and not on a debounce tick.
+    /// </summary>
+    public void NotifyCommandFinished()
+    {
+        if (_enabled)
+        {
+            // Read before flipping the flag: the C mark the read resolves against is still live
+            // at this instant, and the posted update must say the stream just ended.
+            ReadAndPost(streaming: false);
+        }
+
+        _regionActive = false;
+    }
+
+    /// <summary>
+    /// Grid invalidation. Called on the parse thread for every parser write; when a region is
+    /// being tracked, coalesces invalidations into one background read per debounce window.
+    /// </summary>
+    public void NotifyInvalidate()
+    {
+        if (_enabled && (_regionActive || _heuristicStart.HasValue))
+        {
+            _debounceTimer.Change(DebounceDelay, Timeout.InfiniteTimeSpan);
+        }
+    }
+
+    /// <summary>
+    /// Markless fallback: pin the region start from the cursor at Enter time. Called on the UI
+    /// thread from the pane's Enter observation, and only when shell integration is not active -
+    /// with integration, <see cref="NotifyCommandAccepted"/> owns the region.
+    /// </summary>
+    public void CaptureHeuristicStart()
+    {
+        if (!_enabled || _regionActive)
+        {
+            return;
+        }
+
+        TerminalBuffer? buffer = _bufferProvider();
+        if (buffer is null)
+        {
+            return;
+        }
+
+        // A bare capture: the cursor row is the input-line end the reader falls back to when
+        // there is no B mark. False on an active alt screen, which is the right refusal.
+        if (CommandOutputReader.TryCaptureOutputStart(buffer, null, out ShellIntegrationMark start))
+        {
+            _heuristicStart = start;
+        }
+    }
+
+    /// <summary>Panel state changed. Enabled trackers read; disabled ones do nothing.</summary>
+    public void SetEnabled(bool enabled)
+    {
+        _enabled = enabled;
+        if (!enabled)
+        {
+            _debounceTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        }
+    }
+
+    /// <summary>Reads the region now (async, debounced away from the caller's thread).</summary>
+    public void FlushNow()
+    {
+        if (_enabled)
+        {
+            _debounceTimer.Change(TimeSpan.Zero, Timeout.InfiniteTimeSpan);
+        }
+    }
+
+    /// <summary>Session restart: drop the heuristic mark and the streaming flag. The pane calls
+    /// this when its shell goes away, since both belong to the shell that is gone.</summary>
+    public void Reset()
+    {
+        _regionActive = false;
+        _heuristicStart = null;
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        SetEnabled(false);
+        _debounceTimer.Dispose();
+    }
+
+    private void ReadScheduled(object? state) => ReadAndPost(streaming: true);
+
+    private void ReadAndPost(bool streaming)
+    {
+        if (!_enabled)
+        {
+            return;
+        }
+
+        TerminalBuffer? buffer = _bufferProvider();
+        if (buffer is null || buffer.IsAltScreenActive)
+        {
+            return;
+        }
+
+        ShellIntegrationMark? start = _regionActive ? _commandOutputStartProvider() : _heuristicStart;
+        if (start is not ShellIntegrationMark mark)
+        {
+            return;
+        }
+
+        if (!CommandOutputReader.TryReadOutputTail(buffer, mark, RegionBudget, out string text))
+        {
+            // A dead generation (scrollback reset) is fatal for the mark, per the reader's
+            // contract. The heuristic mark is the tracker's own, so it dies here; the pane's C
+            // mark is the pane's to clear.
+            if (!_regionActive)
+            {
+                _heuristicStart = null;
+            }
+
+            return;
+        }
+
+        // string.GetHashCode is randomized per process but stable within one, which is all a
+        // change detector needs. The streaming flag participates in the dedupe on purpose: the
+        // text often does not change between the last debounce tick and D, and the panel's
+        // status line must still get the "streaming ended" update.
+        int hash = text.GetHashCode();
+        int streamingFlag = streaming ? 1 : 0;
+        if (Interlocked.Exchange(ref _lastPostedHash, hash) == hash &&
+            Volatile.Read(ref _lastPostedStreaming) == streamingFlag)
+        {
+            return;
+        }
+
+        Volatile.Write(ref _lastPostedStreaming, streamingFlag);
+        _dispatch(() => _onUpdate(text, streaming));
+    }
+}

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputRegionTracker.cs
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputRegionTracker.cs
@@ -62,6 +62,7 @@ public sealed class AgentOutputRegionTracker : IDisposable
     private ShellIntegrationMark? _heuristicStart;
     private int _lastPostedHash;
     private int _lastPostedStreaming;
+    private int _recentTailFallback;
     private int _generation;
     private int _disposed;
 
@@ -196,11 +197,17 @@ public sealed class AgentOutputRegionTracker : IDisposable
         }
     }
 
-    /// <summary>Reads the region now (async, debounced away from the caller's thread).</summary>
-    public void FlushNow()
+    /// <summary>
+    /// Reads the region now (async, debounced away from the caller's thread). With
+    /// <paramref name="includeRecentTailFallback"/>, a read that finds no region being tracked
+    /// falls back to a one-shot snapshot of the recent on-screen output - what a panel opened
+    /// <i>after</i> the interesting command already finished should show instead of nothing.
+    /// </summary>
+    public void FlushNow(bool includeRecentTailFallback = false)
     {
         if (_enabled)
         {
+            Volatile.Write(ref _recentTailFallback, includeRecentTailFallback ? 1 : 0);
             _debounceTimer.Change(TimeSpan.Zero, Timeout.InfiniteTimeSpan);
         }
     }
@@ -225,9 +232,12 @@ public sealed class AgentOutputRegionTracker : IDisposable
         _debounceTimer.Dispose();
     }
 
-    private void ReadScheduled(object? state) => ReadAndPostCore(streaming: true, Volatile.Read(ref _generation));
+    private void ReadScheduled(object? state) => ReadAndPostCore(
+        streaming: true,
+        Volatile.Read(ref _generation),
+        fallbackToRecentTail: Interlocked.Exchange(ref _recentTailFallback, 0) == 1);
 
-    private void ReadAndPostCore(bool streaming, int generation)
+    private void ReadAndPostCore(bool streaming, int generation, bool fallbackToRecentTail = false)
     {
         if (!_enabled)
         {
@@ -248,6 +258,11 @@ public sealed class AgentOutputRegionTracker : IDisposable
         ShellIntegrationMark? start = _regionActive ? _commandOutputStartProvider() : _heuristicStart;
         if (start is not ShellIntegrationMark mark)
         {
+            if (fallbackToRecentTail)
+            {
+                TryPostRecentTailSnapshot(buffer, generation);
+            }
+
             return;
         }
 
@@ -270,6 +285,29 @@ public sealed class AgentOutputRegionTracker : IDisposable
         }
 
         DeliverUpdate(text, streaming, generation);
+    }
+
+    /// <summary>
+    /// One-shot snapshot of the recent on-screen output, for a panel opened when nothing is being
+    /// tracked - the command that produced what is on screen has already finished, and with no
+    /// edges left in the grid there is no region to resolve. This is the
+    /// <see cref="CommandOutputReader.TryReadRecentTail"/> display contract: what the user can
+    /// see above the cursor, prompt lines included, not a vouched-for output region. Posted as
+    /// finished; the next command started with the panel open takes over tracking normally.
+    /// </summary>
+    private void TryPostRecentTailSnapshot(TerminalBuffer buffer, int generation)
+    {
+        if (!CommandOutputReader.TryReadRecentTail(buffer, RegionBudget, out string text))
+        {
+            return;
+        }
+
+        if (Volatile.Read(ref _generation) != generation)
+        {
+            return;
+        }
+
+        DeliverUpdate(text, streaming: false, generation);
     }
 
     /// <summary>

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputRegionTracker.cs
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputRegionTracker.cs
@@ -51,10 +51,26 @@ public sealed class AgentOutputRegionTracker : IDisposable
     /// <summary>How long grid invalidations are coalesced before a background read runs.</summary>
     public static readonly TimeSpan DebounceDelay = TimeSpan.FromMilliseconds(300);
 
+    /// <summary>
+    /// Cadence for markdown-presence checks while the panel is closed - the MD button's
+    /// visibility rides on this, and it updates on a lazy beat rather than per chunk.
+    /// </summary>
+    public static readonly TimeSpan PresenceDebounceDelay = TimeSpan.FromMilliseconds(1500);
+
+    /// <summary>
+    /// Presence checks run quickly right after a command finishes (the moment the button becomes
+    /// relevant) instead of waiting out the lazy cadence.
+    /// </summary>
+    public static readonly TimeSpan PresenceSoonDelay = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>Budget for the presence check: detection needs the tail's shape, not its bulk.</summary>
+    public static readonly OutputTailBudget PresenceBudget = new(80, 16 * 1024, 256);
+
     private readonly Func<TerminalBuffer?> _bufferProvider;
     private readonly Func<ShellIntegrationMark?> _commandOutputStartProvider;
     private readonly Action<Action> _dispatch;
     private readonly Action<string, bool> _onUpdate;
+    private readonly Action<bool>? _markdownPresenceChanged;
     private readonly Timer _debounceTimer;
 
     private bool _enabled;
@@ -64,6 +80,7 @@ public sealed class AgentOutputRegionTracker : IDisposable
     private int _lastPostedStreaming;
     private int _recentTailFallback;
     private int _generation;
+    private int _lastPresence = -1;
     private int _disposed;
 
     /// <param name="bufferProvider">The pane's live buffer, resolved at read time.</param>
@@ -78,12 +95,14 @@ public sealed class AgentOutputRegionTracker : IDisposable
         Func<TerminalBuffer?> bufferProvider,
         Func<ShellIntegrationMark?> commandOutputStartProvider,
         Action<Action> dispatch,
-        Action<string, bool> onUpdate)
+        Action<string, bool> onUpdate,
+        Action<bool>? markdownPresenceChanged = null)
     {
         _bufferProvider = bufferProvider;
         _commandOutputStartProvider = commandOutputStartProvider;
         _dispatch = dispatch;
         _onUpdate = onUpdate;
+        _markdownPresenceChanged = markdownPresenceChanged;
         _debounceTimer = new Timer(ReadScheduled, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
     }
 
@@ -121,7 +140,16 @@ public sealed class AgentOutputRegionTracker : IDisposable
         _regionActive = false;
         AdvanceGeneration();
 
-        if (!_enabled || start is not ShellIntegrationMark mark)
+        if (!_enabled)
+        {
+            // The panel is closed, so D delivered nothing - but this is exactly the moment the
+            // MD button's fate changes: the finished output is on screen and the presence check
+            // should see it promptly rather than wait out the lazy cadence.
+            _debounceTimer.Change(PresenceSoonDelay, Timeout.InfiniteTimeSpan);
+            return;
+        }
+
+        if (start is not ShellIntegrationMark mark)
         {
             return;
         }
@@ -149,14 +177,23 @@ public sealed class AgentOutputRegionTracker : IDisposable
     }
 
     /// <summary>
-    /// Grid invalidation. Called on the parse thread for every parser write; when a region is
-    /// being tracked, coalesces invalidations into one background read per debounce window.
+    /// Grid invalidation. Called on the parse thread for every parser write. While a region is
+    /// being tracked it coalesces invalidations into one background read per debounce window;
+    /// while the panel is closed it drives the lazy markdown-presence cadence instead, which is
+    /// what decides whether the pane's MD button is visible at all.
     /// </summary>
     public void NotifyInvalidate()
     {
-        if (_enabled && (_regionActive || _heuristicStart.HasValue))
+        if (_enabled)
         {
-            _debounceTimer.Change(DebounceDelay, Timeout.InfiniteTimeSpan);
+            if (_regionActive || _heuristicStart.HasValue)
+            {
+                _debounceTimer.Change(DebounceDelay, Timeout.InfiniteTimeSpan);
+            }
+        }
+        else
+        {
+            _debounceTimer.Change(PresenceDebounceDelay, Timeout.InfiniteTimeSpan);
         }
     }
 
@@ -192,8 +229,11 @@ public sealed class AgentOutputRegionTracker : IDisposable
         _enabled = enabled;
         if (!enabled)
         {
-            _debounceTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+            // Stop any pending region read, then recompute the MD button's presence for the
+            // just-closed panel: the toggle must reflect what is on screen now, not whatever
+            // was true while the panel was open.
             AdvanceGeneration();
+            _debounceTimer.Change(PresenceSoonDelay, Timeout.InfiniteTimeSpan);
         }
     }
 
@@ -232,10 +272,22 @@ public sealed class AgentOutputRegionTracker : IDisposable
         _debounceTimer.Dispose();
     }
 
-    private void ReadScheduled(object? state) => ReadAndPostCore(
-        streaming: true,
-        Volatile.Read(ref _generation),
-        fallbackToRecentTail: Interlocked.Exchange(ref _recentTailFallback, 0) == 1);
+    private void ReadScheduled(object? state)
+    {
+        // While the panel is closed the timer drives markdown-presence detection instead of
+        // region reads - nothing is being tracked, and the MD button's visibility is the thing
+        // that needs updating.
+        if (!_enabled && !_regionActive && !_heuristicStart.HasValue)
+        {
+            CheckMarkdownPresence(Volatile.Read(ref _generation));
+            return;
+        }
+
+        ReadAndPostCore(
+            streaming: true,
+            Volatile.Read(ref _generation),
+            fallbackToRecentTail: Interlocked.Exchange(ref _recentTailFallback, 0) == 1);
+    }
 
     private void ReadAndPostCore(bool streaming, int generation, bool fallbackToRecentTail = false)
     {
@@ -308,6 +360,39 @@ public sealed class AgentOutputRegionTracker : IDisposable
         }
 
         DeliverUpdate(text, streaming: false, generation);
+    }
+
+    /// <summary>
+    /// The MD button's visibility check: does the recent on-screen output look like markdown?
+    /// Runs only while the panel is closed (open panels keep the toggle visible via their checked
+    /// state), and the result crosses to the UI only when it changes.
+    /// </summary>
+    private void CheckMarkdownPresence(int generation)
+    {
+        TerminalBuffer? buffer = _bufferProvider();
+        if (buffer is null || buffer.IsAltScreenActive)
+        {
+            return;
+        }
+
+        if (!CommandOutputReader.TryReadRecentTail(buffer, PresenceBudget, out string text))
+        {
+            return;
+        }
+
+        if (Volatile.Read(ref _generation) != generation)
+        {
+            return;
+        }
+
+        bool looksLikeMarkdown = MarkdownPresenceDetector.LooksLikeMarkdown(text);
+        int flag = looksLikeMarkdown ? 1 : 0;
+        if (Interlocked.Exchange(ref _lastPresence, flag) == flag)
+        {
+            return;
+        }
+
+        _dispatch(() => _markdownPresenceChanged?.Invoke(looksLikeMarkdown));
     }
 
     /// <summary>

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputRegionTracker.cs
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputRegionTracker.cs
@@ -78,6 +78,7 @@ public sealed class AgentOutputRegionTracker : IDisposable
     private ShellIntegrationMark? _heuristicStart;
     private int _lastPostedHash;
     private int _lastPostedStreaming;
+    private int _dedupeStale;
     private int _recentTailFallback;
     private int _generation;
     private int _lastPresence = -1;
@@ -194,6 +195,26 @@ public sealed class AgentOutputRegionTracker : IDisposable
         else
         {
             _debounceTimer.Change(PresenceDebounceDelay, Timeout.InfiniteTimeSpan);
+        }
+    }
+
+    /// <summary>
+    /// The pane switched between the primary and alternate screen.
+    /// </summary>
+    /// <remarks>
+    /// Entering needs nothing: the panel is hidden, and every read already refuses while the
+    /// alternate screen is active. Leaving is the load-bearing half. A command that finished
+    /// under a full-screen program had its final read refused for exactly that reason, so
+    /// "streaming" is the last thing the panel heard about output that is long done - and
+    /// restoring visibility alone would put that stale status back on screen. The corrective
+    /// read carries the recent-tail fallback because D cleared the region on its way past,
+    /// leaving no edges to resolve; that path posts as finished, which is the status being fixed.
+    /// </remarks>
+    public void NotifyAltScreenChanged(bool isAltScreenActive)
+    {
+        if (!isAltScreenActive)
+        {
+            FlushNow(includeRecentTailFallback: true);
         }
     }
 
@@ -433,8 +454,14 @@ public sealed class AgentOutputRegionTracker : IDisposable
             // panel's status line must still get the "streaming ended" update.
             int hash = text.GetHashCode();
             int streamingFlag = streaming ? 1 : 0;
-            if (Interlocked.Exchange(ref _lastPostedHash, hash) == hash &&
-                Volatile.Read(ref _lastPostedStreaming) == streamingFlag)
+
+            // Both reads happen before the decision so the hash is committed either way: a
+            // delivery forced through by stale dedupe state still has to leave the posted pair
+            // describing what the panel now shows.
+            bool sameText = Interlocked.Exchange(ref _lastPostedHash, hash) == hash;
+            bool sameStreaming = Volatile.Read(ref _lastPostedStreaming) == streamingFlag;
+            bool stale = Interlocked.Exchange(ref _dedupeStale, 0) == 1;
+            if (!stale && sameText && sameStreaming)
             {
                 return;
             }
@@ -444,5 +471,23 @@ public sealed class AgentOutputRegionTracker : IDisposable
         });
     }
 
-    private void AdvanceGeneration() => Interlocked.Increment(ref _generation);
+    /// <summary>
+    /// Supersedes every in-flight read, and marks the dedupe state as belonging to a generation
+    /// that is now gone.
+    /// </summary>
+    /// <remarks>
+    /// Staling the dedupe is what makes the next delivery unconditional. The posted hash and
+    /// streaming flag only answer "did the panel already hear this <i>within</i> one generation";
+    /// across a transition (C, D, reset, panel close) the panel's state can have moved on its
+    /// own, so the same pair no longer means the panel is up to date. The concrete leak without
+    /// this: reopening the panel on a still-running command whose output has not changed clears
+    /// the streaming status, then has its restoring flush dropped as a duplicate - the running
+    /// command reads as finished until it next prints. Transitions are rare and meaningful, so
+    /// the cost is at most one redundant update each.
+    /// </remarks>
+    private void AdvanceGeneration()
+    {
+        Interlocked.Increment(ref _generation);
+        Volatile.Write(ref _dedupeStale, 1);
+    }
 }

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputRegionTracker.cs
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputRegionTracker.cs
@@ -62,6 +62,7 @@ public sealed class AgentOutputRegionTracker : IDisposable
     private ShellIntegrationMark? _heuristicStart;
     private int _lastPostedHash;
     private int _lastPostedStreaming;
+    private int _generation;
     private int _disposed;
 
     /// <param name="bufferProvider">The pane's live buffer, resolved at read time.</param>
@@ -89,13 +90,17 @@ public sealed class AgentOutputRegionTracker : IDisposable
     /// The shell accepted a command (<c>OSC 133;C</c>). Called on the parse thread, right after
     /// the pane captured the region start.
     /// </summary>
+    /// <remarks>
+    /// Deliberately <b>not</b> gated on <see cref="_enabled"/>: a panel opened while a command is
+    /// already running must adopt that command's live region, and the C edge is the only moment
+    /// its start is answerable. State set while disabled costs nothing - a disabled tracker never
+    /// reads - and <see cref="SetEnabled"/> plus <see cref="FlushNow"/> pick the region up.
+    /// </remarks>
     public void NotifyCommandAccepted()
     {
-        if (_enabled)
-        {
-            _regionActive = true;
-            _heuristicStart = null;
-        }
+        _regionActive = true;
+        _heuristicStart = null;
+        AdvanceGeneration();
     }
 
     /// <summary>
@@ -106,9 +111,13 @@ public sealed class AgentOutputRegionTracker : IDisposable
     {
         if (_enabled)
         {
-            // Read before flipping the flag: the C mark the read resolves against is still live
-            // at this instant, and the posted update must say the stream just ended.
-            ReadAndPost(streaming: false);
+            // Bump BEFORE the final read, then read under the post-bump generation: in-flight
+            // background reads die at their own checks, while this read's dispatched closure
+            // validates against the new generation and survives the transition. The region flag
+            // is still up here, so the read still resolves the C mark; by the time any later
+            // observer looks, the flag is down and the state is consistent.
+            AdvanceGeneration();
+            ReadAndPostCore(streaming: false, Volatile.Read(ref _generation));
         }
 
         _regionActive = false;
@@ -159,6 +168,7 @@ public sealed class AgentOutputRegionTracker : IDisposable
         if (!enabled)
         {
             _debounceTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+            AdvanceGeneration();
         }
     }
 
@@ -177,6 +187,7 @@ public sealed class AgentOutputRegionTracker : IDisposable
     {
         _regionActive = false;
         _heuristicStart = null;
+        AdvanceGeneration();
     }
 
     public void Dispose()
@@ -190,15 +201,19 @@ public sealed class AgentOutputRegionTracker : IDisposable
         _debounceTimer.Dispose();
     }
 
-    private void ReadScheduled(object? state) => ReadAndPost(streaming: true);
+    private void ReadScheduled(object? state) => ReadAndPostCore(streaming: true, Volatile.Read(ref _generation));
 
-    private void ReadAndPost(bool streaming)
+    private void ReadAndPostCore(bool streaming, int generation)
     {
         if (!_enabled)
         {
             return;
         }
 
+        // The read is stale the moment the state it was based on changes (C, D, reset, disable).
+        // Checked again inside the dispatched closure: the background read can straddle a
+        // transition, and without this a late streaming:true dispatch would park the panel on
+        // "streaming…" after D, or resurrect a reset command's output.
         TerminalBuffer? buffer = _bufferProvider();
         if (buffer is null || buffer.IsAltScreenActive)
         {
@@ -224,6 +239,11 @@ public sealed class AgentOutputRegionTracker : IDisposable
             return;
         }
 
+        if (Volatile.Read(ref _generation) != generation)
+        {
+            return;
+        }
+
         // string.GetHashCode is randomized per process but stable within one, which is all a
         // change detector needs. The streaming flag participates in the dedupe on purpose: the
         // text often does not change between the last debounce tick and D, and the panel's
@@ -237,6 +257,14 @@ public sealed class AgentOutputRegionTracker : IDisposable
         }
 
         Volatile.Write(ref _lastPostedStreaming, streamingFlag);
-        _dispatch(() => _onUpdate(text, streaming));
+        _dispatch(() =>
+        {
+            if (Volatile.Read(ref _generation) == generation)
+            {
+                _onUpdate(text, streaming);
+            }
+        });
     }
+
+    private void AdvanceGeneration() => Interlocked.Increment(ref _generation);
 }

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputRegionTracker.cs
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputRegionTracker.cs
@@ -223,9 +223,19 @@ public sealed class AgentOutputRegionTracker : IDisposable
     /// thread from the pane's Enter observation, and only when shell integration is not active -
     /// with integration, <see cref="NotifyCommandAccepted"/> owns the region.
     /// </summary>
+    /// <remarks>
+    /// Deliberately <b>not</b> gated on <see cref="_enabled"/>, for the same reason
+    /// <see cref="NotifyCommandAccepted"/> is not: Enter is the only moment this row is
+    /// answerable, and a panel opened afterwards still needs it. Without the remembered row the
+    /// snapshot has to guess where the response starts by recognizing prompt shapes, which only
+    /// works for the handful of prompts <c>RecentTailSanitizer</c> knows - a themed prompt
+    /// (powerline segments, a right-aligned clock) matches none of them, and the panel then
+    /// renders the whole pane, shell banner included. Remembering the row costs a struct while
+    /// the panel is closed and removes the guess entirely.
+    /// </remarks>
     public void CaptureHeuristicStart()
     {
-        if (!_enabled || _regionActive)
+        if (_regionActive)
         {
             return;
         }
@@ -296,9 +306,10 @@ public sealed class AgentOutputRegionTracker : IDisposable
     private void ReadScheduled(object? state)
     {
         // While the panel is closed the timer drives markdown-presence detection instead of
-        // region reads - nothing is being tracked, and the MD button's visibility is the thing
-        // that needs updating.
-        if (!_enabled && !_regionActive && !_heuristicStart.HasValue)
+        // region reads: the MD button's visibility is the thing that needs updating, and
+        // ReadAndPostCore would refuse anyway. This covers the closed-panel ticks that now
+        // carry a remembered Enter row, which the earlier shape routed into that refusal.
+        if (!_enabled)
         {
             CheckMarkdownPresence(Volatile.Read(ref _generation));
             return;
@@ -357,7 +368,13 @@ public sealed class AgentOutputRegionTracker : IDisposable
             return;
         }
 
-        DeliverUpdate(text, streaming, generation);
+        // A corrective flush - the panel just opened, or the alternate screen just closed - that
+        // resolved its region from a remembered Enter row rather than a live C mark is looking at
+        // history. The markless path has no D edge, so "streaming" there is a guess that nothing
+        // would ever retract; post it finished instead. A command that really is still printing
+        // re-marks itself on the next debounce tick, one window later.
+        bool live = streaming && (_regionActive || !fallbackToRecentTail);
+        DeliverUpdate(text, live, generation);
     }
 
     /// <summary>

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputRegionTracker.cs
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputRegionTracker.cs
@@ -359,6 +359,14 @@ public sealed class AgentOutputRegionTracker : IDisposable
             return;
         }
 
+        // No edges bound a snapshot, so prompt and echoed-command lines ride the raw tail; trim
+        // them off both ends and deliver the response.
+        text = RecentTailSanitizer.Trim(text);
+        if (text.Length == 0)
+        {
+            return;
+        }
+
         DeliverUpdate(text, streaming: false, generation);
     }
 

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputViewModel.cs
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputViewModel.cs
@@ -136,6 +136,19 @@ public sealed class AgentOutputViewModel : INotifyPropertyChanged
         StatusText = isStreaming ? "streaming…" : string.Empty;
     }
 
+    /// <summary>
+    /// Clears the streaming status while keeping the text. Called when the panel reopens: a
+    /// command that finished while the panel was closed never delivered its final update (D
+    /// skips the read for a hidden panel), so without this the reopened panel would show the
+    /// previous output labeled "streaming…" indefinitely. If a live region does exist, the
+    /// tracker's flush immediately re-marks it as streaming.
+    /// </summary>
+    public void ClearStreaming()
+    {
+        IsStreaming = false;
+        StatusText = string.Empty;
+    }
+
     private void OnPropertyChanged(string propertyName)
         => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 }

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputViewModel.cs
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputViewModel.cs
@@ -1,0 +1,141 @@
+using System;
+using System.ComponentModel;
+
+namespace NovaTerminal.AgentOutput;
+
+/// <summary>
+/// State of the per-pane Agent Output panel.
+/// </summary>
+/// <remarks>
+/// Plain <see cref="INotifyPropertyChanged"/>, matching the Command Assist view models - no
+/// binding framework, no toolkit. <see cref="IsPanelOpen"/> is the user's intent (the toggle);
+/// <see cref="IsAltScreenSuppressed"/> is the pane telling the panel a full-screen program owns
+/// the grid. <see cref="IsShown"/> is the effective visibility both feed, so the pane never has
+/// to combine the two conditions itself.
+/// </remarks>
+public sealed class AgentOutputViewModel : INotifyPropertyChanged
+{
+    private bool _isPanelOpen;
+    private bool _isAltScreenSuppressed;
+    private bool _isStreaming;
+    private string _markdownText = string.Empty;
+    private string _statusText = string.Empty;
+
+    /// <summary>Raised when any bound property changes.</summary>
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>The user toggled the panel open. Survives an alt-screen suppression.</summary>
+    public bool IsPanelOpen
+    {
+        get => _isPanelOpen;
+        set
+        {
+            if (_isPanelOpen == value)
+            {
+                return;
+            }
+
+            bool wasShown = IsShown;
+            _isPanelOpen = value;
+            OnPropertyChanged(nameof(IsPanelOpen));
+            if (IsShown != wasShown)
+            {
+                OnPropertyChanged(nameof(IsShown));
+            }
+        }
+    }
+
+    /// <summary>True while a full-screen program owns the grid; the panel stays down.</summary>
+    public bool IsAltScreenSuppressed
+    {
+        get => _isAltScreenSuppressed;
+        set
+        {
+            if (_isAltScreenSuppressed == value)
+            {
+                return;
+            }
+
+            // IsShown only changes when the panel is open; raising it while closed would make
+            // the pane flip the presenter for no reason.
+            bool wasShown = IsShown;
+            _isAltScreenSuppressed = value;
+            OnPropertyChanged(nameof(IsAltScreenSuppressed));
+            if (IsShown != wasShown)
+            {
+                OnPropertyChanged(nameof(IsShown));
+            }
+        }
+    }
+
+    /// <summary>Effective visibility: the panel is up exactly when open and not suppressed.</summary>
+    public bool IsShown => _isPanelOpen && !_isAltScreenSuppressed;
+
+    /// <summary>
+    /// True from <c>OSC 133;C</c> until <c>OSC 133;D</c> - the command is producing output, so
+    /// the panel's next line may not be its last. Markless sessions stream until the next Enter.
+    /// </summary>
+    public bool IsStreaming
+    {
+        get => _isStreaming;
+        private set
+        {
+            if (_isStreaming == value)
+            {
+                return;
+            }
+
+            _isStreaming = value;
+            OnPropertyChanged(nameof(IsStreaming));
+        }
+    }
+
+    /// <summary>The raw markdown text of the tracked output region.</summary>
+    public string MarkdownText
+    {
+        get => _markdownText;
+        private set
+        {
+            if (_markdownText == value)
+            {
+                return;
+            }
+
+            _markdownText = value;
+            OnPropertyChanged(nameof(MarkdownText));
+            OnPropertyChanged(nameof(HasContent));
+        }
+    }
+
+    /// <summary>False until the tracked region has produced any text.</summary>
+    public bool HasContent => _markdownText.Length > 0;
+
+    /// <summary>Short line under the title: streaming state, or empty when idle.</summary>
+    public string StatusText
+    {
+        get => _statusText;
+        private set
+        {
+            if (_statusText == value)
+            {
+                return;
+            }
+
+            _statusText = value;
+            OnPropertyChanged(nameof(StatusText));
+        }
+    }
+
+    /// <summary>
+    /// Applies one region read. Called on the UI thread by the pane, out of the tracker.
+    /// </summary>
+    public void SetUpdate(string markdownText, bool isStreaming)
+    {
+        IsStreaming = isStreaming;
+        MarkdownText = markdownText;
+        StatusText = isStreaming ? "streaming…" : string.Empty;
+    }
+
+    private void OnPropertyChanged(string propertyName)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}

--- a/src/NovaTerminal.App/AgentOutput/MarkdownPresenceDetector.cs
+++ b/src/NovaTerminal.App/AgentOutput/MarkdownPresenceDetector.cs
@@ -19,8 +19,9 @@ namespace NovaTerminal.AgentOutput;
 /// </para>
 /// <para>
 /// <b>False negative</b> (button hidden on real markdown): costs discoverability. Two distinct
-/// strong signals, or one strong signal plus a couple of list lines, is the floor real agent
-/// output clears easily and incidental terminal noise does not.
+/// strong signals, one strong signal plus a couple of list lines, or a list of at least three
+/// items on its own, is the floor real agent output clears easily and incidental terminal noise
+/// mostly does not.
 /// </para>
 /// <para>
 /// Detection is line-structural on purpose - no regex, no markdown parse. It runs against a
@@ -29,6 +30,19 @@ namespace NovaTerminal.AgentOutput;
 /// </remarks>
 public static class MarkdownPresenceDetector
 {
+    /// <summary>
+    /// List lines that carry a verdict on their own, with no corroborating strong signal.
+    /// </summary>
+    /// <remarks>
+    /// Three, because that is where the two error costs cross. A bare pair of dash lines is
+    /// ordinary in build and install logs, so two cannot be enough; three list items with nothing
+    /// else markdown-shaped around them is already far more likely to be an answer than a log.
+    /// The known price is a shell banner that opens with three bullets - clink's does - putting
+    /// the button on a fresh pane until real output scrolls past it. That is the cheap direction
+    /// of the trade this class documents.
+    /// </remarks>
+    private const int ListOnlyFloor = 3;
+
     public static bool LooksLikeMarkdown(string text)
     {
         bool fence = false;
@@ -73,7 +87,14 @@ public static class MarkdownPresenceDetector
         }
 
         int strongSignals = (fence ? 1 : 0) + (heading ? 1 : 0) + (table ? 1 : 0) + (taskList ? 1 : 0);
-        return strongSignals >= 2 || (strongSignals >= 1 && listLines >= 2);
+
+        // The third clause is the one that admits a bullets-only answer. Without it the strong
+        // signals gate everything, and "explain X in three bullets" - no heading, no fence, no
+        // table, no checkboxes - could not reach the bar at any number of bullets, which hid the
+        // button on the single most common shape the panel exists for.
+        return strongSignals >= 2
+            || (strongSignals >= 1 && listLines >= 2)
+            || listLines >= ListOnlyFloor;
     }
 
     private static bool IsFence(string line)

--- a/src/NovaTerminal.App/AgentOutput/MarkdownPresenceDetector.cs
+++ b/src/NovaTerminal.App/AgentOutput/MarkdownPresenceDetector.cs
@@ -1,0 +1,147 @@
+using System;
+
+namespace NovaTerminal.AgentOutput;
+
+/// <summary>
+/// Decides whether a chunk of terminal output looks like markdown, using distinct structural
+/// signals rather than a single pattern.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This gates the visibility of the pane's MD toggle, so both error directions matter and are
+/// weighted differently:
+/// </para>
+/// <para>
+/// <b>False positive</b> (button appears on non-markdown): cheap - clicking renders text that
+/// reads fine as plain paragraphs, and the panel closes again. Terminal output is full of
+/// markdown-<i>adjacent</i> fragments - a lone <c># comment</c>, <c>-----</c> separators, dash
+/// bullets in build logs - so single weak signals must never trigger it.
+/// </para>
+/// <para>
+/// <b>False negative</b> (button hidden on real markdown): costs discoverability. Two distinct
+/// strong signals, or one strong signal plus a couple of list lines, is the floor real agent
+/// output clears easily and incidental terminal noise does not.
+/// </para>
+/// <para>
+/// Detection is line-structural on purpose - no regex, no markdown parse. It runs against a
+/// bounded recent-output tail on a background cadence per pane.
+/// </para>
+/// </remarks>
+public static class MarkdownPresenceDetector
+{
+    public static bool LooksLikeMarkdown(string text)
+    {
+        bool fence = false;
+        bool heading = false;
+        bool table = false;
+        bool taskList = false;
+        int listLines = 0;
+
+        foreach (string rawLine in (text ?? string.Empty).Split('\n'))
+        {
+            string line = rawLine.TrimStart();
+            if (line.Length == 0)
+            {
+                continue;
+            }
+
+            if (IsFence(line))
+            {
+                fence = true;
+            }
+            else if (IsHeading(line))
+            {
+                heading = true;
+            }
+            else if (IsTaskList(line))
+            {
+                taskList = true;
+                listLines++;
+            }
+            else
+            {
+                if (IsTableDelimiter(line))
+                {
+                    table = true;
+                }
+
+                if (IsListLine(line))
+                {
+                    listLines++;
+                }
+            }
+        }
+
+        int strongSignals = (fence ? 1 : 0) + (heading ? 1 : 0) + (table ? 1 : 0) + (taskList ? 1 : 0);
+        return strongSignals >= 2 || (strongSignals >= 1 && listLines >= 2);
+    }
+
+    private static bool IsFence(string line)
+        => line.StartsWith("```", StringComparison.Ordinal);
+
+    /// <summary>1-6 '#' characters followed by whitespace - "#tag" and "##" alone do not count.</summary>
+    private static bool IsHeading(string line)
+    {
+        int i = 0;
+        while (i < line.Length && i < 6 && line[i] == '#')
+        {
+            i++;
+        }
+
+        return i > 0 && i < line.Length && line[i] == ' ';
+    }
+
+    /// <summary>
+    /// A GFM delimiter row: pipes and dashes/colons only, with at least one of each -
+    /// what separates the header of a markdown table from its body.
+    /// </summary>
+    private static bool IsTableDelimiter(string line)
+    {
+        bool hasPipe = false;
+        bool hasDash = false;
+
+        foreach (char c in line)
+        {
+            if (c == '|')
+            {
+                hasPipe = true;
+            }
+            else if (c == '-')
+            {
+                hasDash = true;
+            }
+            else if (c != ':' && !char.IsWhiteSpace(c))
+            {
+                return false;
+            }
+        }
+
+        return hasPipe && hasDash;
+    }
+
+    private static bool IsTaskList(string line)
+        => line.Length >= 6
+           && (line[0] == '-' || line[0] == '*' || line[0] == '+')
+           && line[1] == ' '
+           && line[2] == '['
+           && (line[3] == ' ' || line[3] == 'x' || line[3] == 'X')
+           && line[4] == ']';
+
+    /// <summary>Bullet or ordered list items. Weak signal: logs and diffs are full of dashes.</summary>
+    private static bool IsListLine(string line)
+    {
+        if (line.Length >= 2 && (line[0] == '-' || line[0] == '*' || line[0] == '+') && line[1] == ' ')
+        {
+            return true;
+        }
+
+        // "1. " / "12. " - digits then a dot, then whitespace.
+        int i = 0;
+        while (i < line.Length && i < 3 && char.IsAsciiDigit(line[i]))
+        {
+            i++;
+        }
+
+        return i > 0 && i < line.Length - 1 && line[i] == '.' && line[i + 1] == ' ';
+    }
+}

--- a/src/NovaTerminal.App/AgentOutput/MarkdownRenderer.cs
+++ b/src/NovaTerminal.App/AgentOutput/MarkdownRenderer.cs
@@ -131,7 +131,7 @@ public static class MarkdownRenderer
                     break;
 
 
-                // YamlFrontMatter and anything else unrecognized: skip.
+                    // YamlFrontMatter and anything else unrecognized: skip.
             }
         }
     }
@@ -466,8 +466,8 @@ public static class MarkdownRenderer
                     AppendInlines(target, nested, theme, onCopyText, onOpenLink);
                     break;
 
-                // HtmlInline / HtmlEntityInline: deliberately dropped (DisableHtml already kept
-                // raw HTML blocks out; these are stragglers).
+                    // HtmlInline / HtmlEntityInline: deliberately dropped (DisableHtml already kept
+                    // raw HTML blocks out; these are stragglers).
             }
         }
     }

--- a/src/NovaTerminal.App/AgentOutput/MarkdownRenderer.cs
+++ b/src/NovaTerminal.App/AgentOutput/MarkdownRenderer.cs
@@ -1,0 +1,664 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Markdig;
+using Markdig.Extensions.Tables;
+using Markdig.Extensions.TaskLists;
+using Markdig.Helpers;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+using MInline = Markdig.Syntax.Inlines.Inline;
+
+namespace NovaTerminal.AgentOutput;
+
+/// <summary>
+/// Renders markdown text as an Avalonia control tree for the Agent Output panel.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Parse and render are deliberately separate layers.</b> Markdig owns the parsing (its
+/// advanced extensions bring GFM tables, task lists and strikethrough, and
+/// <see cref="MarkdownPipelineBuilder.DisableHtml"/> keeps raw HTML out of the tree - agent
+/// output is untrusted text, and an HTML passthrough would be an injection seam); this class owns
+/// every pixel after that. There is no markdown XAML library in the dependency set, and the
+/// panel's chrome has to match the pane's hand-styled surfaces, so a renderer of a few hundred
+/// lines was the smaller dependency than a library's theming system.
+/// </para>
+/// <para>
+/// <b>Colors resolve per build, not per binding.</b> <see cref="Build"/> prefers the app's
+/// <c>Nt*</c> theme brushes (see <c>ThemePaletteResources</c>) and falls back to the same fixed
+/// palette the sibling surfaces (RemoteFilesSidebar, the assist overlay) hard-code, so a theme
+/// resource that is absent at runtime degrades to the known look instead of to transparent text
+/// on transparent background. The renderer re-runs on every content change, so a theme switch is
+/// picked up on the next rebuild.
+/// </para>
+/// <para>
+/// <b>Unknown blocks are skipped, not crashed on.</b> The walk pattern-matches the block types
+/// agent CLIs actually emit and ignores everything else; a future Markdig extension surfaces as
+/// missing content, never as an exception mid-render.
+/// </para>
+/// </remarks>
+public static class MarkdownRenderer
+{
+    private const string MonospaceFontFamily = "Cascadia Mono PL, Consolas, Menlo, monospace";
+
+    private static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder()
+        .UseAdvancedExtensions()
+        .DisableHtml()
+        .Build();
+
+    // Fixed fallback palette, matching the pane's other hand-styled surfaces.
+    private static readonly IBrush FallbackForeground = new SolidColorBrush(Color.FromRgb(0xF3, 0xF6, 0xFA));
+    private static readonly IBrush FallbackSecondary = new SolidColorBrush(Color.FromRgb(0x96, 0xA0, 0xAE));
+    private static readonly IBrush FallbackCodeBackground = new SolidColorBrush(Color.FromRgb(0x16, 0x18, 0x1C));
+    private static readonly IBrush FallbackPanel = new SolidColorBrush(Color.FromRgb(0x1B, 0x1D, 0x21));
+    private static readonly IBrush FallbackHairline = new SolidColorBrush(Color.FromRgb(0x2A, 0x2F, 0x35));
+    private static readonly IBrush FallbackAccent = new SolidColorBrush(Color.FromRgb(0x4C, 0x8B, 0xD8));
+
+    /// <param name="markdown">The raw markdown source.</param>
+    /// <param name="resourceAnchor">
+    /// Element whose resource scope the <c>Nt*</c> brushes are resolved from (usually the panel).
+    /// </param>
+    /// <param name="onCopyText">Invoked when the user copies a code block or inline run.</param>
+    /// <param name="onOpenLink">Invoked when the user clicks a link.</param>
+    public static Control Build(
+        string markdown,
+        StyledElement resourceAnchor,
+        Action<string>? onCopyText = null,
+        Action<string>? onOpenLink = null)
+    {
+        MarkdownDocument document = Markdown.Parse(markdown ?? string.Empty, Pipeline);
+        var theme = Theme.Resolve(resourceAnchor);
+
+        var root = new StackPanel { Spacing = 2 };
+        AppendBlocks(root.Children, document, theme, onCopyText, onOpenLink);
+        return root;
+    }
+
+    private static void AppendBlocks(
+        IList<Control> target,
+        IEnumerable<Block> blocks,
+        Theme theme,
+        Action<string>? onCopyText,
+        Action<string>? onOpenLink)
+    {
+        foreach (Block block in blocks)
+        {
+            switch (block)
+            {
+                case HeadingBlock h:
+                    target.Add(BuildHeading(h, theme));
+                    break;
+
+                case ParagraphBlock paragraph:
+                    target.Add(BuildParagraph(paragraph, theme, onCopyText, onOpenLink));
+                    break;
+
+                case FencedCodeBlock fenced:
+                    target.Add(BuildCodeBlock(GetLinesText(fenced), fenced.Info.ToString(), theme, onCopyText));
+                    break;
+
+                case CodeBlock code:
+                    target.Add(BuildCodeBlock(GetLinesText(code), null, theme, onCopyText));
+                    break;
+
+                case ListBlock list:
+                    target.Add(BuildList(list, theme, onCopyText, onOpenLink));
+                    break;
+
+                case QuoteBlock quote:
+                    target.Add(BuildQuote(quote, theme, onCopyText, onOpenLink));
+                    break;
+
+                case ThematicBreakBlock:
+                    target.Add(new Border
+                    {
+                        Height = 1,
+                        Margin = new Thickness(0, 8, 0, 8),
+                        Background = theme.Hairline,
+                    });
+                    break;
+
+                case Table table:
+                    target.Add(BuildTable(table, theme, onCopyText, onOpenLink));
+                    break;
+
+
+                // YamlFrontMatter and anything else unrecognized: skip.
+            }
+        }
+    }
+
+    private static Control BuildHeading(HeadingBlock heading, Theme theme)
+    {
+        double size = heading.Level switch
+        {
+            1 => 21,
+            2 => 18,
+            3 => 15.5,
+            4 => 14,
+            _ => 13,
+        };
+
+        var textBlock = new TextBlock
+        {
+            TextWrapping = TextWrapping.Wrap,
+            FontSize = size,
+            FontWeight = FontWeight.SemiBold,
+            Foreground = theme.Foreground,
+            Margin = new Thickness(0, heading.Level <= 2 ? 10 : 8, 0, 4),
+        };
+        AppendInlines(textBlock.Inlines!, heading.Inline, theme, onCopyText: null, onOpenLink: null);
+        return textBlock;
+    }
+
+    private static Control BuildParagraph(
+        ParagraphBlock paragraph,
+        Theme theme,
+        Action<string>? onCopyText,
+        Action<string>? onOpenLink)
+    {
+        var textBlock = new SelectableTextBlock
+        {
+            TextWrapping = TextWrapping.Wrap,
+            FontSize = 13,
+            Foreground = theme.Foreground,
+            Margin = new Thickness(0, 3, 0, 3),
+        };
+        AppendInlines(textBlock.Inlines!, paragraph.Inline, theme, onCopyText, onOpenLink);
+        return textBlock;
+    }
+
+    private static Control BuildCodeBlock(
+        string code,
+        string? language,
+        Theme theme,
+        Action<string>? onCopyText)
+    {
+        var codeText = new SelectableTextBlock
+        {
+            TextWrapping = TextWrapping.Wrap,
+            FontSize = 12,
+            FontFamily = new FontFamily(MonospaceFontFamily),
+            Foreground = theme.Foreground,
+        };
+        codeText.Inlines!.Add(new Run { Text = code });
+
+        var header = new Grid { ColumnDefinitions = ColumnDefinitions.Parse("*,Auto") };
+        if (!string.IsNullOrWhiteSpace(language))
+        {
+            header.Children.Add(new TextBlock
+            {
+                Text = language,
+                FontSize = 11,
+                Foreground = theme.Secondary,
+                VerticalAlignment = VerticalAlignment.Center,
+            });
+        }
+
+        var copyButton = new Button
+        {
+            Content = "Copy",
+            FontSize = 10.5,
+            Padding = new Thickness(6, 1),
+            HorizontalAlignment = HorizontalAlignment.Right,
+        };
+        copyButton.Click += (_, _) => onCopyText?.Invoke(code);
+        TrySetHandCursor(copyButton);
+        Grid.SetColumn(copyButton, 1);
+        header.Children.Add(copyButton);
+
+        return new Border
+        {
+            Background = theme.CodeBackground,
+            BorderBrush = theme.Hairline,
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(5),
+            Margin = new Thickness(0, 6, 0, 6),
+            Child = new StackPanel
+            {
+                Children =
+                {
+                    new Border
+                    {
+                        BorderBrush = theme.Hairline,
+                        BorderThickness = new Thickness(0, 0, 0, 1),
+                        Padding = new Thickness(8, 4, 8, 3),
+                        Child = header,
+                    },
+                    new Border
+                    {
+                        Padding = new Thickness(8, 6, 8, 8),
+                        Child = codeText,
+                    },
+                },
+            },
+        };
+    }
+
+    private static Control BuildList(
+        ListBlock list,
+        Theme theme,
+        Action<string>? onCopyText,
+        Action<string>? onOpenLink)
+    {
+        var panel = new StackPanel { Margin = new Thickness(0, 3, 0, 3) };
+        int itemNumber = ParseOrderedStart(list);
+
+        foreach (Block item in list)
+        {
+            if (item is not ListItemBlock listItem)
+            {
+                continue;
+            }
+
+            string bullet = list.IsOrdered ? $"{itemNumber++}." : "•";
+            bool? checkedState = TryGetTaskState(listItem);
+
+            var row = new Grid
+            {
+                ColumnDefinitions = ColumnDefinitions.Parse("Auto,*"),
+                Margin = new Thickness(0, 1),
+            };
+
+            var markerText = new TextBlock
+            {
+                Text = checkedState.HasValue ? (checkedState.Value ? "☑" : "☐") : bullet,
+                FontSize = 13,
+                Foreground = checkedState.HasValue ? theme.Accent : theme.Secondary,
+                VerticalAlignment = VerticalAlignment.Top,
+                Margin = new Thickness(12, 0, 6, 0),
+            };
+            row.Children.Add(markerText);
+
+            var itemContent = new StackPanel { Spacing = 2 };
+            AppendBlocks(itemContent.Children, listItem, theme, onCopyText, onOpenLink);
+            Grid.SetColumn(itemContent, 1);
+            row.Children.Add(itemContent);
+
+            panel.Children.Add(row);
+        }
+
+        return panel;
+    }
+
+    private static Control BuildQuote(
+        QuoteBlock quote,
+        Theme theme,
+        Action<string>? onCopyText,
+        Action<string>? onOpenLink)
+    {
+        var content = new StackPanel { Spacing = 2 };
+        AppendBlocks(content.Children, quote, theme, onCopyText, onOpenLink);
+
+        return new Border
+        {
+            BorderBrush = theme.Hairline,
+            BorderThickness = new Thickness(0, 0, 0, 0),
+            Background = theme.PanelBackground,
+            CornerRadius = new CornerRadius(0, 4, 4, 0),
+            Margin = new Thickness(0, 4, 0, 4),
+            Padding = new Thickness(10, 4, 8, 4),
+            Child = new Grid
+            {
+                ColumnDefinitions = ColumnDefinitions.Parse("Auto,*"),
+                Children =
+                {
+                    new Border
+                    {
+                        Width = 2,
+                        Margin = new Thickness(0, 2, 8, 2),
+                        Background = theme.Accent,
+                    },
+                    content,
+                },
+            },
+        };
+    }
+
+    private static Control BuildTable(
+        Table table,
+        Theme theme,
+        Action<string>? onCopyText,
+        Action<string>? onOpenLink)
+    {
+        int columnCount = Math.Max(table.ColumnDefinitions.Count, 1);
+        var grid = new Grid { Margin = new Thickness(0, 6, 0, 6) };
+        for (int i = 0; i < columnCount; i++)
+        {
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        }
+
+        int rowIndex = 0;
+        foreach (Block rowBlock in table)
+        {
+            if (rowBlock is not TableRow row)
+            {
+                continue;
+            }
+
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            int columnIndex = 0;
+
+            foreach (Block cellBlock in row)
+            {
+                if (cellBlock is not TableCell cell)
+                {
+                    continue;
+                }
+
+                var cellContent = new StackPanel { Spacing = 2 };
+                AppendBlocks(cellContent.Children, cell, theme, onCopyText, onOpenLink);
+
+                if (row.IsHeader)
+                {
+                    Boldify(cellContent);
+                }
+
+                var cellBorder = new Border
+                {
+                    BorderBrush = theme.Hairline,
+                    BorderThickness = new Thickness(0, 0, 1, 1),
+                    Padding = new Thickness(7, 4),
+                    Background = row.IsHeader ? theme.PanelBackground : null,
+                    Child = cellContent,
+                };
+
+                Grid.SetRow(cellBorder, rowIndex);
+                Grid.SetColumn(cellBorder, Math.Min(columnIndex, columnCount - 1));
+                grid.Children.Add(cellBorder);
+                columnIndex++;
+            }
+
+            rowIndex++;
+        }
+
+        // Close the left and top edges of the cell borders drawn above.
+        return new Border
+        {
+            BorderBrush = theme.Hairline,
+            BorderThickness = new Thickness(1, 1, 0, 0),
+            Child = grid,
+        };
+    }
+
+    private static void AppendInlines(
+        InlineCollection target,
+        ContainerInline? container,
+        Theme theme,
+        Action<string>? onCopyText,
+        Action<string>? onOpenLink)
+    {
+        if (container is null)
+        {
+            return;
+        }
+
+        foreach (MInline inline in container)
+        {
+            switch (inline)
+            {
+                case LiteralInline literal:
+                    target.Add(new Run { Text = literal.Content.ToString() });
+                    break;
+
+                case CodeInline code:
+                    target.Add(new InlineUIContainer
+                    {
+                        Child = new Border
+                        {
+                            Background = theme.CodeBackground,
+                            CornerRadius = new CornerRadius(3),
+                            Padding = new Thickness(4, 0.5, 4, 1),
+                            Child = new TextBlock
+                            {
+                                Text = code.Content,
+                                FontSize = 12,
+                                FontFamily = new FontFamily(MonospaceFontFamily),
+                                Foreground = theme.Secondary,
+                            },
+                        },
+                    });
+                    break;
+
+                case EmphasisInline emphasis:
+                    AppendEmphasis(target, emphasis, theme, onCopyText, onOpenLink);
+                    break;
+
+                case LinkInline link when link.IsImage:
+                    // No image support in v1: keep the link text so nothing disappears silently.
+                    AppendLink(target, link, theme, onOpenLink);
+                    break;
+
+                case LinkInline link:
+                    AppendLink(target, link, theme, onOpenLink);
+                    break;
+
+                case AutolinkInline autolink:
+                    AppendLinkTarget(
+                        target,
+                        autolink.Url,
+                        autolink.IsEmail ? "mailto:" + autolink.Url : autolink.Url,
+                        theme,
+                        onOpenLink);
+                    break;
+
+                case LineBreakInline:
+                    target.Add(new LineBreak());
+                    break;
+
+                case TaskList taskList:
+                    target.Add(new Run
+                    {
+                        Text = taskList.Checked ? "☑ " : "☐ ",
+                        Foreground = theme.Accent,
+                    });
+                    break;
+
+                case ContainerInline nested:
+                    AppendInlines(target, nested, theme, onCopyText, onOpenLink);
+                    break;
+
+                // HtmlInline / HtmlEntityInline: deliberately dropped (DisableHtml already kept
+                // raw HTML blocks out; these are stragglers).
+            }
+        }
+    }
+
+    private static void AppendEmphasis(
+        InlineCollection target,
+        EmphasisInline emphasis,
+        Theme theme,
+        Action<string>? onCopyText,
+        Action<string>? onOpenLink)
+    {
+        bool isStrike = emphasis.DelimiterChar == '~';
+        bool isBold = !isStrike && emphasis.DelimiterCount >= 2;
+
+        var outer = new Span();
+        AppendInlines(outer.Inlines, emphasis, theme, onCopyText, onOpenLink);
+
+        if (isStrike)
+        {
+            outer.TextDecorations = TextDecorations.Strikethrough;
+        }
+        else if (isBold)
+        {
+            outer.FontWeight = FontWeight.Bold;
+        }
+        else
+        {
+            outer.FontStyle = FontStyle.Italic;
+        }
+
+        target.Add(outer);
+    }
+
+    private static void AppendLink(
+        InlineCollection target,
+        LinkInline link,
+        Theme theme,
+        Action<string>? onOpenLink)
+    {
+        AppendLinkTarget(target, link.Url, GetLiteralText(link), theme, onOpenLink);
+    }
+
+    private static void AppendLinkTarget(
+        InlineCollection target,
+        string url,
+        string label,
+        Theme theme,
+        Action<string>? onOpenLink)
+    {
+        var linkText = new TextBlock
+        {
+            Text = string.IsNullOrWhiteSpace(label) ? url : label,
+            FontSize = 13,
+            Foreground = theme.Accent,
+            TextDecorations = TextDecorations.Underline,
+        };
+        linkText.PointerPressed += (_, _) => onOpenLink?.Invoke(url);
+        TrySetHandCursor(linkText);
+        target.Add(new InlineUIContainer { Child = linkText });
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    /// <summary>
+    /// Hand cursor for click affordances. Cursor instantiation needs the platform's cursor
+    /// factory, which only exists once an Avalonia application is up - plain unit tests construct
+    /// these controls without one, so the affordance silently degrades to a normal cursor there.
+    /// </summary>
+    private static void TrySetHandCursor(InputElement element)
+    {
+        if (Application.Current is not null)
+        {
+            element.Cursor = new Cursor(StandardCursorType.Hand);
+        }
+    }
+
+    /// <summary>The code block's source, joined from its physical lines.</summary>
+    private static string GetLinesText(CodeBlock codeBlock)
+    {
+        var builder = new StringBuilder();
+        foreach (StringLine line in codeBlock.Lines)
+        {
+            builder.AppendLine(line.ToString());
+        }
+
+        return builder.ToString().TrimEnd((char)13, (char)10);
+    }
+
+    private static int ParseOrderedStart(ListBlock list)
+    {
+        if (!list.IsOrdered || !int.TryParse(list.OrderedStart.ToString(), out int start))
+        {
+            return 1;
+        }
+
+        return start;
+    }
+
+    /// <summary>
+    /// Task-list state, when the item is one: Markdig 1.x parses the checkbox marker into a
+    /// TaskList inline at the head of the item's first paragraph.
+    /// </summary>
+    private static bool? TryGetTaskState(ListItemBlock listItem)
+    {
+        foreach (Block block in listItem)
+        {
+            if (block is ParagraphBlock { Inline: not null } paragraph)
+            {
+                foreach (MInline inline in paragraph.Inline)
+                {
+                    if (inline is TaskList taskList)
+                    {
+                        return taskList.Checked;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static void Boldify(StackPanel panel)
+    {
+        foreach (Control child in panel.Children)
+        {
+            if (child is TextBlock textBlock)
+            {
+                textBlock.FontWeight = FontWeight.SemiBold;
+            }
+        }
+    }
+
+    /// <summary>The plain text of an inline subtree (links, emphasis), literals only.</summary>
+    private static string GetLiteralText(ContainerInline container)
+    {
+        var builder = new StringBuilder();
+        CollectLiteralText(container, builder);
+        return builder.ToString();
+    }
+
+    private static void CollectLiteralText(ContainerInline container, StringBuilder builder)
+    {
+        foreach (MInline inline in container)
+        {
+            switch (inline)
+            {
+                case LiteralInline literal:
+                    builder.Append(literal.ToString());
+                    break;
+
+                case CodeInline code:
+                    builder.Append(code.Content);
+                    break;
+
+                case ContainerInline nested:
+                    CollectLiteralText(nested, builder);
+                    break;
+            }
+        }
+    }
+
+    /// <summary>Resolved brush set for one render pass.</summary>
+    private sealed class Theme
+    {
+        internal required IBrush Foreground { get; init; }
+        internal required IBrush Secondary { get; init; }
+        internal required IBrush CodeBackground { get; init; }
+        internal required IBrush PanelBackground { get; init; }
+        internal required IBrush Hairline { get; init; }
+        internal required IBrush Accent { get; init; }
+
+        internal static Theme Resolve(StyledElement anchor)
+        {
+            return new Theme
+            {
+                Foreground = Find(anchor, "NtFg", FallbackForeground),
+                Secondary = Find(anchor, "NtFg3", FallbackSecondary),
+                CodeBackground = Find(anchor, "NtPanelAlt", FallbackCodeBackground),
+                PanelBackground = Find(anchor, "NtPanel", FallbackPanel),
+                Hairline = Find(anchor, "NtHairline", FallbackHairline),
+                Accent = Find(anchor, "NtBlue", FallbackAccent),
+            };
+        }
+
+        private static IBrush Find(StyledElement anchor, string key, IBrush fallback)
+        {
+            // Control themes put brushes in as object values; anything that is not a brush
+            // (an unexpected override) degrades to the fixed fallback rather than crashing.
+            return anchor.TryFindResource(key, out object? value) && value is IBrush brush
+                ? brush
+                : fallback;
+        }
+    }
+}

--- a/src/NovaTerminal.App/AgentOutput/MarkdownRenderer.cs
+++ b/src/NovaTerminal.App/AgentOutput/MarkdownRenderer.cs
@@ -155,7 +155,7 @@ public static class MarkdownRenderer
             Foreground = theme.Foreground,
             Margin = new Thickness(0, heading.Level <= 2 ? 10 : 8, 0, 4),
         };
-        AppendInlines(textBlock.Inlines!, heading.Inline, theme, onCopyText: null, onOpenLink: null);
+        AppendInlines(textBlock.Inlines, heading.Inline, theme, onCopyText: null, onOpenLink: null);
         return textBlock;
     }
 
@@ -172,7 +172,7 @@ public static class MarkdownRenderer
             Foreground = theme.Foreground,
             Margin = new Thickness(0, 3, 0, 3),
         };
-        AppendInlines(textBlock.Inlines!, paragraph.Inline, theme, onCopyText, onOpenLink);
+        AppendInlines(textBlock.Inlines, paragraph.Inline, theme, onCopyText, onOpenLink);
         return textBlock;
     }
 
@@ -189,7 +189,7 @@ public static class MarkdownRenderer
             FontFamily = new FontFamily(MonospaceFontFamily),
             Foreground = theme.Foreground,
         };
-        codeText.Inlines!.Add(new Run { Text = code });
+        codeText.Inlines?.Add(new Run { Text = code });
 
         var header = new Grid { ColumnDefinitions = ColumnDefinitions.Parse("*,Auto") };
         if (!string.IsNullOrWhiteSpace(language))
@@ -270,7 +270,7 @@ public static class MarkdownRenderer
 
             var markerText = new TextBlock
             {
-                Text = checkedState.HasValue ? (checkedState.Value ? "☑" : "☐") : bullet,
+                Text = ResolveItemMarker(bullet, checkedState),
                 FontSize = 13,
                 Foreground = checkedState.HasValue ? theme.Accent : theme.Secondary,
                 VerticalAlignment = VerticalAlignment.Top,
@@ -587,6 +587,17 @@ public static class MarkdownRenderer
         }
 
         return null;
+    }
+
+    /// <summary>The glyph a list item starts with: the checkbox for task items, else the bullet.</summary>
+    private static string ResolveItemMarker(string bullet, bool? checkedState)
+    {
+        if (!checkedState.HasValue)
+        {
+            return bullet;
+        }
+
+        return checkedState.Value ? "☑" : "☐";
     }
 
     private static void Boldify(StackPanel panel)

--- a/src/NovaTerminal.App/AgentOutput/RecentTailSanitizer.cs
+++ b/src/NovaTerminal.App/AgentOutput/RecentTailSanitizer.cs
@@ -91,6 +91,58 @@ public static class RecentTailSanitizer
         return string.Empty;
     }
 
+    /// <summary>
+    /// Strips deep leading indentation from lines outside fenced code blocks.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// In markdown, 4+ leading spaces mean "code block". For terminal-captured output that
+    /// interpretation is poison: agent responses indent their examples under list items, and
+    /// every one of those sections then renders as a raw code box - fence markers, heading
+    /// markers and all. The indentation in a grid-derived tail is formatting noise, not intent.
+    /// </para>
+    /// <para>
+    /// Lines inside fenced blocks are preserved verbatim - code indentation is meaningful. The
+    /// fence state toggles on lines starting with <c>```</c> (after trimming), which also lets an
+    /// indented fence itself be dedented into a parseable one. Shallow indentation (1-3 spaces -
+    /// nested list items) is left alone so list structure survives.
+    /// </para>
+    /// </remarks>
+    public static string NormalizeIndentation(string text)
+    {
+        string[] lines = (text ?? string.Empty).Replace("\r\n", "\n").Split('\n');
+        bool inFence = false;
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            string trimmedStart = lines[i].TrimStart();
+            if (trimmedStart.StartsWith("```", StringComparison.Ordinal))
+            {
+                inFence = !inFence;
+                lines[i] = trimmedStart;
+                continue;
+            }
+
+            if (!inFence && CountLeadingWhitespace(lines[i]) >= 4)
+            {
+                lines[i] = trimmedStart;
+            }
+        }
+
+        return string.Join('\n', lines);
+    }
+
+    private static int CountLeadingWhitespace(string line)
+    {
+        int i = 0;
+        while (i < line.Length && (line[i] == ' ' || line[i] == '\t'))
+        {
+            i++;
+        }
+
+        return i;
+    }
+
     internal static bool IsPromptLike(string line)
     {
         if (line.Length == 0 || line.Length > MaxPromptLength)

--- a/src/NovaTerminal.App/AgentOutput/RecentTailSanitizer.cs
+++ b/src/NovaTerminal.App/AgentOutput/RecentTailSanitizer.cs
@@ -26,26 +26,69 @@ public static class RecentTailSanitizer
 {
     private const int MaxPromptLength = 200;
 
-    public static string Trim(string text)
+    /// <summary>
+    /// Extracts the most recent command's response from a recent-tail snapshot.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A long agent conversation is rounds of <i>prompt → response</i> all over the same grid, so
+    /// trimming the snapshot's two ends (see <see cref="Trim"/>) cannot describe "the response":
+    /// prompts are interleaved throughout, and the raw tail is a fragment of several rounds at
+    /// once. Prompt-shaped lines are therefore treated as <b>segment boundaries</b>: the tail
+    /// splits into per-command segments, each beginning at a prompt (whose line - prompt and
+    /// echoed command alike - is dropped), and the last segment holding any content is the
+    /// response the user just read on screen.
+    /// </para>
+    /// <para>
+    /// Known limitation, accepted on purpose: an agent that prints a prompt-shaped line
+    /// mid-response splits that response. Mis-splits degrade to "a later fragment of the answer",
+    /// never to content from an earlier round.
+    /// </para>
+    /// </remarks>
+    public static string ExtractLastResponse(string text)
     {
         string[] lines = (text ?? string.Empty).Replace("\r\n", "\n").Split('\n');
 
-        int start = 0;
-        int end = lines.Length - 1;
-
-        while (start <= end && (lines[start].Length == 0 || IsPromptLike(lines[start])))
+        List<string> current = new(lines.Length);
+        List<string[]> segments = new();
+        foreach (string line in lines)
         {
-            start++;
+            if (IsPromptLike(line))
+            {
+                segments.Add(current.ToArray());
+                current.Clear();
+                continue;
+            }
+
+            current.Add(line);
         }
 
-        while (end >= start && (lines[end].Length == 0 || IsPromptLike(lines[end])))
+        segments.Add(current.ToArray());
+
+        // The last segment with content wins: earlier segments are earlier rounds of the
+        // conversation, and a trailing bare prompt produces an empty final segment.
+        for (int i = segments.Count - 1; i >= 0; i--)
         {
-            end--;
+            string[] segment = segments[i];
+            int start = 0;
+            int end = segment.Length - 1;
+            while (start <= end && segment[start].Trim().Length == 0)
+            {
+                start++;
+            }
+
+            while (end >= start && segment[end].Trim().Length == 0)
+            {
+                end--;
+            }
+
+            if (start <= end)
+            {
+                return string.Join('\n', segment, start, end - start + 1);
+            }
         }
 
-        return start > end
-            ? string.Empty
-            : string.Join('\n', lines, start, end - start + 1);
+        return string.Empty;
     }
 
     internal static bool IsPromptLike(string line)

--- a/src/NovaTerminal.App/AgentOutput/RecentTailSanitizer.cs
+++ b/src/NovaTerminal.App/AgentOutput/RecentTailSanitizer.cs
@@ -1,0 +1,87 @@
+using System;
+
+namespace NovaTerminal.AgentOutput;
+
+/// <summary>
+/// Trims prompt-like lines from both ends of a recent-output snapshot, leaving what reads as the
+/// command's response.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The recent-tail snapshot exists for panels opened after the fact, where no OSC 133 edges
+/// bound the output - so the raw tail includes the shell prompt before the command, the echoed
+/// command line itself, and the next prompt after it. Rendered as markdown those are noise, and
+/// they are also the most recognizable noise there is: prompts have shapes.
+/// </para>
+/// <para>
+/// The shapes covered are the conservative set - <c>PS D:\path&gt;</c> (PowerShell),
+/// <c>D:\path&gt;</c> (cmd), and <c>user@host:path$</c>-style (POSIX) - matched only at the
+/// snapshot's two ends. A conservative match is the right bias here: mid-response lines are
+/// never touched, so a response that happens to contain something prompt-shaped keeps it, while
+/// a snapshot that leads or trails with real prompts loses nothing but chrome. Blank lines at
+/// the ends go with them.
+/// </para>
+/// </remarks>
+public static class RecentTailSanitizer
+{
+    private const int MaxPromptLength = 200;
+
+    public static string Trim(string text)
+    {
+        string[] lines = (text ?? string.Empty).Replace("\r\n", "\n").Split('\n');
+
+        int start = 0;
+        int end = lines.Length - 1;
+
+        while (start <= end && (lines[start].Length == 0 || IsPromptLike(lines[start])))
+        {
+            start++;
+        }
+
+        while (end >= start && (lines[end].Length == 0 || IsPromptLike(lines[end])))
+        {
+            end--;
+        }
+
+        return start > end
+            ? string.Empty
+            : string.Join('\n', lines, start, end - start + 1);
+    }
+
+    internal static bool IsPromptLike(string line)
+    {
+        if (line.Length == 0 || line.Length > MaxPromptLength)
+        {
+            return false;
+        }
+
+        // PowerShell: "PS D:\projects>" - and with the echoed command riding along,
+        // "PS D:\projects> aichat ..." (the chevron is in the middle, not the end).
+        if (line.StartsWith("PS ", StringComparison.Ordinal) && line.IndexOf('>') > 2)
+        {
+            return true;
+        }
+
+        // cmd: "D:\projects>" / "D:\projects> agent.exe" - drive letter, colon, backslash,
+        // and the prompt chevron somewhere after the path.
+        if (line.Length >= 4 && char.IsAsciiLetter(line[0]) && line[1] == ':' && line[2] == '\\' &&
+            line.IndexOf('>') >= 3)
+        {
+            return true;
+        }
+
+        // POSIX: "user@host:~/demo$" / "user@host:~/demo$ llm ..." - user@host shape, then the
+        // path separator, then the prompt character (with or without the command after it).
+        int at = line.IndexOf('@');
+        if (at > 0)
+        {
+            int colon = line.IndexOf(':', at);
+            if (colon > at && line.IndexOfAny(['$', '#'], colon) > colon)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml
@@ -18,18 +18,40 @@
         <Style Selector="ScrollBar:pointerover">
             <Setter Property="Opacity" Value="1.0"/>
         </Style>
-        <!-- Agent Output toggle: hover-revealed chrome. Resting at 0.4 opacity it reads as part
-            of the pane edge; any hover over the pane brings it to full, and an open panel keeps
-            it lit regardless (the :checked pseudo-class), so the affordance that closes it is
-            always findable. -->
+        <!-- Agent Output toggle. Hidden at rest (opacity 0, no hit testing - an invisible
+            button must not catch clicks meant for the terminal); hovering anywhere over the pane
+            reveals it, and an open panel keeps it lit and clickable regardless (the :checked
+            pseudo-class), so the affordance that closes it is always findable. The custom
+            template exists because the default Fluent ToggleButton chrome carries MinHeight=32
+            and padding that rendered the 18px button half-clipped. -->
         <Style Selector="ToggleButton#AgentOutputToggle">
-            <Setter Property="Opacity" Value="0.4"/>
+            <Setter Property="Opacity" Value="0"/>
+            <Setter Property="IsHitTestVisible" Value="False"/>
+            <Setter Property="MinHeight" Value="0"/>
+            <Setter Property="MinWidth" Value="0"/>
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <Border Background="{TemplateBinding Background}"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          Foreground="{TemplateBinding Foreground}"
+                                          HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
         </Style>
         <Style Selector="Grid:pointerover ToggleButton#AgentOutputToggle">
             <Setter Property="Opacity" Value="1"/>
+            <Setter Property="IsHitTestVisible" Value="True"/>
         </Style>
         <Style Selector="ToggleButton#AgentOutputToggle:checked">
             <Setter Property="Opacity" Value="1"/>
+            <Setter Property="IsHitTestVisible" Value="True"/>
             <Setter Property="Background" Value="#2B4C6F"/>
             <Setter Property="Foreground" Value="#CFE3F7"/>
         </Style>
@@ -134,11 +156,13 @@
                     <!-- Agent Output toggle: the activation surface for the markdown side panel.
                         It lives here rather than in the context menu because local (non-SSH) panes
                         have their context menu detached entirely (InitializeSessionCore), and
-                        agent CLIs run overwhelmingly in local panes. Focusable=False so it can
-                        never take keyboard focus from the terminal. -->
+                        agent CLIs run overwhelmingly in local panes. Visibility is owned by the
+                        tracker's markdown-presence detection (hidden until the recent on-screen
+                        output looks like markdown); opacity/hit-testing ride the styles. -->
                     <ToggleButton x:Name="AgentOutputToggle"
                                   Grid.Row="0"
                                   ZIndex="60"
+                                  IsVisible="False"
                                   HorizontalAlignment="Right"
                                   VerticalAlignment="Top"
                                   Margin="0,8,18,0"

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml
@@ -18,6 +18,21 @@
         <Style Selector="ScrollBar:pointerover">
             <Setter Property="Opacity" Value="1.0"/>
         </Style>
+        <!-- Agent Output toggle: hover-revealed chrome. Resting at 0.4 opacity it reads as part
+            of the pane edge; any hover over the pane brings it to full, and an open panel keeps
+            it lit regardless (the :checked pseudo-class), so the affordance that closes it is
+            always findable. -->
+        <Style Selector="ToggleButton#AgentOutputToggle">
+            <Setter Property="Opacity" Value="0.4"/>
+        </Style>
+        <Style Selector="Grid:pointerover ToggleButton#AgentOutputToggle">
+            <Setter Property="Opacity" Value="1"/>
+        </Style>
+        <Style Selector="ToggleButton#AgentOutputToggle:checked">
+            <Setter Property="Opacity" Value="1"/>
+            <Setter Property="Background" Value="#2B4C6F"/>
+            <Setter Property="Foreground" Value="#CFE3F7"/>
+        </Style>
     </UserControl.Styles>
 
     <Border Padding="0">
@@ -43,7 +58,7 @@
 
             <Grid x:Name="PaneContentGrid"
                   Grid.Row="0"
-                  ColumnDefinitions="*,Auto">
+                  ColumnDefinitions="*,Auto,Auto">
                 <Grid x:Name="TerminalLayerHost"
                       Grid.Column="0">
                     <!-- Terminal View Layer -->
@@ -116,6 +131,30 @@
                         </Grid>
                     </Border>
 
+                    <!-- Agent Output toggle: the activation surface for the markdown side panel.
+                        It lives here rather than in the context menu because local (non-SSH) panes
+                        have their context menu detached entirely (InitializeSessionCore), and
+                        agent CLIs run overwhelmingly in local panes. Focusable=False so it can
+                        never take keyboard focus from the terminal. -->
+                    <ToggleButton x:Name="AgentOutputToggle"
+                                  Grid.Row="0"
+                                  ZIndex="60"
+                                  HorizontalAlignment="Right"
+                                  VerticalAlignment="Top"
+                                  Margin="0,8,18,0"
+                                  Width="30"
+                                  Height="18"
+                                  Content="MD"
+                                  FontSize="9"
+                                  FontWeight="SemiBold"
+                                  CornerRadius="3"
+                                  Background="#2A2D33"
+                                  Foreground="#96A0AE"
+                                  BorderThickness="0"
+                                  Focusable="False"
+                                  Cursor="Hand"
+                                  ToolTip.Tip="Render agent output as markdown"/>
+
                     <!--
                         The host itself has no Background, so it is transparent to hit testing and a
                         click anywhere except on a child still reaches the terminal underneath. It used
@@ -141,8 +180,15 @@
                     </Grid>
                 </Grid>
 
-                <ContentControl x:Name="RemoteFilesSidebarPresenter"
+                <!-- Agent Output markdown panel. Sits between the terminal and the SFTP sidebar
+                    so both can be open at once; lazy-hosted like the sidebar, visibility owned
+                    by AgentOutputViewModel.IsShown (user toggle minus alt-screen suppression). -->
+                <ContentControl x:Name="AgentOutputPanelPresenter"
                                 Grid.Column="1"
+                                IsVisible="False" />
+
+                <ContentControl x:Name="RemoteFilesSidebarPresenter"
+                                Grid.Column="2"
                                 IsVisible="False" />
             </Grid>
 

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -246,6 +246,13 @@ namespace NovaTerminal.Controls
         private IRemoteDirectoryBrowserService _remoteDirectoryBrowserService = new RemoteDirectoryBrowserService();
         private RemoteFilesSidebarViewModel? _remoteFilesSidebarViewModel;
         private RemoteFilesSidebar? _remoteFilesSidebarHost;
+
+        // Agent Output panel state, created in SetupCommon alongside the other pane-lifetime
+        // services. The tracker owns the debounced region reads; the view model owns visibility
+        // (user toggle minus alt-screen suppression); the host is the lazily-created view.
+        private AgentOutput.AgentOutputViewModel? _agentOutput;
+        private AgentOutput.AgentOutputRegionTracker? _agentOutputTracker;
+        private AgentOutput.AgentOutputPanel? _agentOutputPanelHost;
         private bool _isRemoteFilesSidebarTestServiceConfigured;
         private string? _currentRecordingFilePath;
         private int _clipboardWriteAttemptsForTest;
@@ -722,6 +729,42 @@ namespace NovaTerminal.Controls
             {
                 Buffer.OnScreenSwitched += OnBufferScreenSwitched;
             }
+
+            // Agent Output (markdown side panel). The tracker hangs off the same buffer-lifetime
+            // subscription point as OnScreenSwitched above; OnInvalidate fires on the parse thread
+            // and the tracker only re-arms a debounce timer there. Notification wiring into the
+            // parser lives in CaptureCommandOutputRegionStart (C) and the OnCommandFinished
+            // handler (D) - both already parse-thread, both already at the right instant.
+            _agentOutput = new AgentOutput.AgentOutputViewModel();
+            _agentOutputTracker = new AgentOutput.AgentOutputRegionTracker(
+                () => Buffer,
+                () => Buffer?.CommandOutputStartMark,
+                dispatch: action =>
+                {
+                    if (Dispatcher.UIThread.CheckAccess())
+                    {
+                        action();
+                    }
+                    else
+                    {
+                        Dispatcher.UIThread.Post(action);
+                    }
+                },
+                onUpdate: (text, streaming) => _agentOutput.SetUpdate(text, streaming));
+            if (Buffer != null)
+            {
+                Buffer.OnInvalidate += _agentOutputTracker.NotifyInvalidate;
+            }
+            // Property hook rather than Click: the panel's ✕ unchecks the toggle programmatically
+            // (host.CloseRequested), and that path must close the panel exactly like a user click.
+            AgentOutputToggle.PropertyChanged += (_, e) =>
+            {
+                if (e.Property == ToggleButton.IsCheckedProperty)
+                {
+                    SetAgentOutputPanelOpen(AgentOutputToggle.IsChecked == true);
+                }
+            };
+            TermView.EnterObserved += OnAgentOutputEnterObserved;
 
             // Load Settings
             ApplySettings(initialSettings ?? TerminalSettings.Load());
@@ -2077,6 +2120,87 @@ namespace NovaTerminal.Controls
             _commandAssistController?.HandleAltScreenChanged(isAltScreen);
             UpdateRemoteFilesSidebarVisibility();
             UpdateRemoteFilesSidebarEntryPointState();
+            if (_agentOutput != null)
+            {
+                _agentOutput.IsAltScreenSuppressed = isAltScreen;
+                UpdateAgentOutputPanelVisibility();
+            }
+        }
+
+        // ------------------------------------------------------------- Agent Output panel
+        //
+        // The markdown side panel: a per-pane, manually toggled view over the current command's
+        // output region. It reads the grid, it never writes it - the terminal core is untouched,
+        // and the whole feature turns off the moment the user closes the panel.
+
+        /// <summary>
+        /// The toggle flipped. Creates the panel view on first open; the tracker only reads the
+        /// grid while the panel is open.
+        /// </summary>
+        private void SetAgentOutputPanelOpen(bool open)
+        {
+            if (_agentOutput == null)
+            {
+                return;
+            }
+
+            _agentOutput.IsPanelOpen = open;
+            if (open)
+            {
+                EnsureAgentOutputPanelHost();
+                _agentOutputTracker?.SetEnabled(true);
+                _agentOutputTracker?.FlushNow();
+            }
+            else
+            {
+                _agentOutputTracker?.SetEnabled(false);
+            }
+
+            UpdateAgentOutputPanelVisibility();
+        }
+
+        private void UpdateAgentOutputPanelVisibility()
+        {
+            if (_agentOutput != null)
+            {
+                AgentOutputPanelPresenter.IsVisible = _agentOutput.IsShown;
+            }
+        }
+
+        /// <summary>Lazily builds the panel view, mirroring EnsureRemoteFilesSidebarHost.</summary>
+        private void EnsureAgentOutputPanelHost()
+        {
+            if (_agentOutputPanelHost != null || _agentOutput == null)
+            {
+                return;
+            }
+
+            var host = new AgentOutput.AgentOutputPanel();
+            host.SetViewModel(_agentOutput);
+            host.CloseRequested += () => AgentOutputToggle.IsChecked = false;
+            AgentOutputPanelPresenter.Content = host;
+            _agentOutputPanelHost = host;
+        }
+
+        /// <summary>
+        /// Enter observed with shell integration inactive: pin the output-region start from the
+        /// cursor, the markless fallback. Without this, sessions without shell integration have
+        /// no region to track at all. Runs after <see cref="OnCommandAssistEnterObserved"/>,
+        /// synchronously on the UI thread, for the same narrow-window reason that method does.
+        /// </summary>
+        private void OnAgentOutputEnterObserved()
+        {
+            if (_agentOutput is not { IsPanelOpen: true })
+            {
+                return;
+            }
+
+            if (_isShellIntegrationActive)
+            {
+                return;
+            }
+
+            _agentOutputTracker?.CaptureHeuristicStart();
         }
 
         /// <remarks>
@@ -2983,6 +3107,13 @@ namespace NovaTerminal.Controls
             {
                 _agentRegistration?.StatusMachine.NotifyCommandFinished(exitCode);
 
+                // The Agent Output panel's final read must happen here, on the parse thread: D is
+                // the last instant the grid still holds the command's output, and a debounced
+                // background read would race the next prompt painting over the tail. Bounded by
+                // the same budget as every other read. OnCommandFinishedDetailed (below) clears
+                // the tracked marks after this.
+                _agentOutputTracker?.NotifyCommandFinished();
+
                 // Captured here, on the parse thread, and only for a failure. By the time the UI
                 // post below runs, the shell has painted the next prompt over the last rows of the
                 // output and may already be running the next command; D is the last instant at
@@ -3048,6 +3179,9 @@ namespace NovaTerminal.Controls
             _isShellIntegrationActive = false;
             _hasObservedShellIntegrationMark = false;
             _shellIntegrationEnvOverrides = null;
+            // The Agent Output tracker's heuristic region mark belongs to the shell that is going
+            // away; drop it with the rest of the per-session state.
+            _agentOutputTracker?.Reset();
             // A restart or a profile switch reaches here; the pending line belonged to the shell
             // that is going away.
             _marklessSubmission.Reset();
@@ -3970,7 +4104,13 @@ namespace NovaTerminal.Controls
             if (Buffer != null)
             {
                 Buffer.OnScreenSwitched -= OnBufferScreenSwitched;
+                if (_agentOutputTracker != null)
+                {
+                    Buffer.OnInvalidate -= _agentOutputTracker.NotifyInvalidate;
+                }
             }
+            _agentOutputTracker?.Dispose();
+            _agentOutputTracker = null;
             _statusTimer?.Stop();
             _statusTimer = null;
             SftpService.Instance.JobUpdated -= Sftp_JobUpdated;
@@ -4697,6 +4837,11 @@ namespace NovaTerminal.Controls
                 buffer, commandLineMark, out ShellIntegrationMark outputStart);
 
             buffer.CommandOutputStartMark = captured ? outputStart : null;
+
+            // The Agent Output tracker starts streaming here too: it resolves the region from the
+            // same buffer mark at read time, so this notification only flips it into streaming
+            // state and clears any markless heuristic start.
+            _agentOutputTracker?.NotifyCommandAccepted();
         }
 
         /// <summary>

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -761,7 +761,7 @@ namespace NovaTerminal.Controls
             {
                 if (e.Property == ToggleButton.IsCheckedProperty)
                 {
-                    SetAgentOutputPanelOpen(AgentOutputToggle.IsChecked == true);
+                    SetAgentOutputPanelOpen(AgentOutputToggle.IsChecked ?? false);
                 }
             };
             TermView.EnterObserved += OnAgentOutputEnterObserved;

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -2130,6 +2130,11 @@ namespace NovaTerminal.Controls
                 _agentOutput.IsAltScreenSuppressed = isAltScreen;
                 UpdateAgentOutputPanelVisibility();
             }
+
+            // Showing the panel again is not enough on the way out: the final update for a
+            // command that finished under the full-screen program was refused while the
+            // alternate screen was up, so the tracker owes the panel a corrective read.
+            _agentOutputTracker?.NotifyAltScreenChanged(isAltScreen);
         }
 
         // ------------------------------------------------------------- Agent Output panel

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -750,7 +750,12 @@ namespace NovaTerminal.Controls
                         Dispatcher.UIThread.Post(action);
                     }
                 },
-                onUpdate: (text, streaming) => _agentOutput.SetUpdate(text, streaming));
+                onUpdate: (text, streaming) => _agentOutput.SetUpdate(text, streaming),
+
+                // The MD toggle only exists when the recent on-screen output actually looks like
+                // markdown - detection runs on the tracker's lazy closed-panel cadence, and this
+                // callback fires on the UI thread only when the verdict changes.
+                markdownPresenceChanged: present => AgentOutputToggle.IsVisible = present);
             if (Buffer != null)
             {
                 Buffer.OnInvalidate += _agentOutputTracker.NotifyInvalidate;

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -2155,7 +2155,11 @@ namespace NovaTerminal.Controls
                 // still claim the old output is streaming. Clear that first; if a live region
                 // does exist, the flush below immediately re-marks it as streaming.
                 _agentOutput.ClearStreaming();
-                _agentOutputTracker?.FlushNow();
+
+                // Fallback on: nothing is tracked when the panel opens onto output that already
+                // finished (no live C mark, no Enter-time heuristic yet), and the panel should
+                // show that output as a recent-tail snapshot rather than an empty state.
+                _agentOutputTracker?.FlushNow(includeRecentTailFallback: true);
             }
             else
             {

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -2149,6 +2149,12 @@ namespace NovaTerminal.Controls
             {
                 EnsureAgentOutputPanelHost();
                 _agentOutputTracker?.SetEnabled(true);
+
+                // A command that finished while the panel was closed never delivered its final
+                // update (D skips the read for a hidden panel), so the reopened view model may
+                // still claim the old output is streaming. Clear that first; if a live region
+                // does exist, the flush below immediately re-marks it as streaming.
+                _agentOutput.ClearStreaming();
                 _agentOutputTracker?.FlushNow();
             }
             else

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -2210,11 +2210,8 @@ namespace NovaTerminal.Controls
         /// </summary>
         private void OnAgentOutputEnterObserved()
         {
-            if (_agentOutput is not { IsPanelOpen: true })
-            {
-                return;
-            }
-
+            // Not gated on the panel being open: the row is only answerable at Enter, and a panel
+            // opened later needs it to bound the response instead of guessing at prompt shapes.
             if (_isShellIntegrationActive)
             {
                 return;

--- a/src/NovaTerminal.App/NovaTerminal.App.csproj
+++ b/src/NovaTerminal.App/NovaTerminal.App.csproj
@@ -26,6 +26,8 @@
     <PackageReference Include="SkiaSharp.HarfBuzz" />
     <PackageReference Include="SkiaSharp.NativeAssets.Win32" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
+    <!-- Agent Output panel: markdown parsing for the rendered side panel. -->
+    <PackageReference Include="Markdig" />
     <!-- Windows installer + auto-update (#91). Version is pinned centrally in
          Directory.Packages.props and must match the vpk tool version in release.yml. -->
     <PackageReference Include="Velopack" />

--- a/src/NovaTerminal.VT/CommandOutputReader.cs
+++ b/src/NovaTerminal.VT/CommandOutputReader.cs
@@ -5,6 +5,29 @@ using System.Text;
 namespace NovaTerminal.VT
 {
     /// <summary>
+    /// The caps a <see cref="CommandOutputReader"/> tail read walks under. Counted the same way
+    /// the reader counts them: logical lines after soft-wrapped physical rows are joined,
+    /// characters after that, physical rows as the independent backstop.
+    /// </summary>
+    /// <remarks>
+    /// The reader's own defaults (<see cref="CommandOutputReader.MaxOutputLines"/> etc.) are sized
+    /// for error recognition - the useful part of a huge output is at the end. Consumers that want
+    /// a whole response rather than its tail (the Agent Output panel) pass a larger budget; the
+    /// cap is still applied before the string leaves the reader, so a budget is a hard bound on
+    /// both the work and the result.
+    /// </remarks>
+    /// <param name="MaxLines">Logical lines kept.</param>
+    /// <param name="MaxChars">Character ceiling on the assembled tail.</param>
+    /// <param name="MaxRows">Upper bound on physical rows walked.</param>
+    public readonly record struct OutputTailBudget(int MaxLines, int MaxChars, int MaxRows)
+    {
+        public static readonly OutputTailBudget Default = new(
+            CommandOutputReader.MaxOutputLines,
+            CommandOutputReader.MaxOutputChars,
+            CommandOutputReader.MaxOutputRows);
+    }
+
+    /// <summary>
     /// Reads the tail of a finished command's <i>output region</i> out of the grid: the rows
     /// between the <c>OSC 133;C</c> edge (the shell accepted the line and is about to run it) and
     /// the <c>OSC 133;D</c> edge (it finished).
@@ -167,6 +190,20 @@ namespace NovaTerminal.VT
             ShellIntegrationMark outputStart,
             out string outputTail)
         {
+            return TryReadOutputTail(buffer, outputStart, OutputTailBudget.Default, out outputTail);
+        }
+
+        /// <summary>
+        /// The same read as
+        /// <see cref="TryReadOutputTail(TerminalBuffer, ShellIntegrationMark, out string)"/> under a
+        /// caller-chosen <see cref="OutputTailBudget"/>.
+        /// </summary>
+        public static bool TryReadOutputTail(
+            TerminalBuffer buffer,
+            ShellIntegrationMark outputStart,
+            in OutputTailBudget budget,
+            out string outputTail)
+        {
             outputTail = string.Empty;
             if (buffer is null)
             {
@@ -184,7 +221,64 @@ namespace NovaTerminal.VT
 
             try
             {
-                return TryReadOutputTailLocked(buffer, outputStart, out outputTail);
+                return TryReadOutputTailLocked(buffer, outputStart, budget, out outputTail);
+            }
+            finally
+            {
+                if (lockTaken)
+                {
+                    buffer.Lock.ExitReadLock();
+                }
+            }
+        }
+
+        /// <summary>
+        /// The most recent output on the main screen, walked back from the cursor until the budget
+        /// is spent - for a session with no <c>OSC 133;C</c> mark to bound the region.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>This is the markless fallback.</b> Without shell integration there is no
+        /// <see cref="ShellIntegrationMark"/> for <see cref="TryCaptureOutputStart"/> to anchor on,
+        /// and the honest answer to "what did the last command print" is then "whatever rows are
+        /// still on the grid above the cursor" - prompt lines included. That is a weaker contract
+        /// than the marked read, and callers must present it as one: the result is a display tail,
+        /// not a vouched-for output region.
+        /// </para>
+        /// <para>
+        /// Everything else is the same walk: soft-wrapped rows joined, trailing blanks dropped, the
+        /// budget applied before the string leaves this class.
+        /// </para>
+        /// </remarks>
+        public static bool TryReadRecentTail(TerminalBuffer buffer, out string outputTail)
+        {
+            return TryReadRecentTail(buffer, OutputTailBudget.Default, out outputTail);
+        }
+
+        /// <summary>See <see cref="TryReadRecentTail(TerminalBuffer, out string)"/>.</summary>
+        public static bool TryReadRecentTail(
+            TerminalBuffer buffer,
+            in OutputTailBudget budget,
+            out string outputTail)
+        {
+            outputTail = string.Empty;
+            if (buffer is null)
+            {
+                return false;
+            }
+
+            bool lockTaken = false;
+            if (!buffer.Lock.IsReadLockHeld &&
+                !buffer.Lock.IsWriteLockHeld &&
+                !buffer.Lock.IsUpgradeableReadLockHeld)
+            {
+                buffer.Lock.EnterReadLock();
+                lockTaken = true;
+            }
+
+            try
+            {
+                return TryReadRecentTailLocked(buffer, budget, out outputTail);
             }
             finally
             {
@@ -250,6 +344,7 @@ namespace NovaTerminal.VT
         private static bool TryReadOutputTailLocked(
             TerminalBuffer buffer,
             ShellIntegrationMark outputStart,
+            in OutputTailBudget budget,
             out string outputTail)
         {
             outputTail = string.Empty;
@@ -290,6 +385,53 @@ namespace NovaTerminal.VT
                 // anything, with the prompt not yet repainted). Empty output, truthfully.
                 return true;
             }
+
+            return TryReadTailFromRowLocked(buffer, startRow, budget, out outputTail);
+        }
+
+        private static bool TryReadRecentTailLocked(
+            TerminalBuffer buffer,
+            in OutputTailBudget budget,
+            out string outputTail)
+        {
+            outputTail = string.Empty;
+
+            if (buffer.IsAltScreenActive)
+            {
+                return false;
+            }
+
+            int cols = buffer.Cols;
+            if (cols <= 0)
+            {
+                return false;
+            }
+
+            int totalRows = buffer.InternalTotalLines;
+            int cursorRow = buffer.Scrollback.Count + buffer.InternalCursorRow;
+            if (cursorRow < 0 || cursorRow >= totalRows)
+            {
+                return false;
+            }
+
+            return TryReadTailFromRowLocked(buffer, 0, budget, out outputTail);
+        }
+
+        /// <summary>
+        /// The shared bounded walk: from <paramref name="startRow"/> down to the cursor, newest
+        /// first, stopping when any part of the budget is spent. Both readers above have already
+        /// validated the coordinate space; this method only walks and assembles.
+        /// </summary>
+        private static bool TryReadTailFromRowLocked(
+            TerminalBuffer buffer,
+            int startRow,
+            in OutputTailBudget budget,
+            out string outputTail)
+        {
+            outputTail = string.Empty;
+
+            int cols = buffer.Cols;
+            int cursorRow = buffer.Scrollback.Count + buffer.InternalCursorRow;
 
             // Deferred autowrap: after a character lands on the last column the cursor stays parked
             // there with the wrap pending, so its *text* position is one past it.
@@ -333,12 +475,12 @@ namespace NovaTerminal.VT
                     logicalLines++;
                 }
 
-                if (rows.Count >= MaxOutputRows)
+                if (rows.Count >= budget.MaxRows)
                 {
                     break;
                 }
 
-                if (startsLogicalLine && (logicalLines >= MaxOutputLines || collected >= MaxOutputChars))
+                if (startsLogicalLine && (logicalLines >= budget.MaxLines || collected >= budget.MaxChars))
                 {
                     break;
                 }
@@ -346,7 +488,7 @@ namespace NovaTerminal.VT
 
             rows.Reverse();
 
-            var builder = new StringBuilder(Math.Min(collected, MaxOutputChars) + rows.Count);
+            var builder = new StringBuilder(Math.Min(collected, budget.MaxChars) + rows.Count);
             for (int i = 0; i < rows.Count; i++)
             {
                 builder.Append(rows[i].Text);
@@ -357,9 +499,9 @@ namespace NovaTerminal.VT
             }
 
             string assembled = builder.ToString();
-            if (assembled.Length > MaxOutputChars)
+            if (assembled.Length > budget.MaxChars)
             {
-                assembled = assembled[^MaxOutputChars..];
+                assembled = assembled[^budget.MaxChars..];
             }
 
             outputTail = assembled;

--- a/src/NovaTerminal.VT/CommandOutputReader.cs
+++ b/src/NovaTerminal.VT/CommandOutputReader.cs
@@ -420,7 +420,8 @@ namespace NovaTerminal.VT
         /// <summary>
         /// The shared bounded walk: from <paramref name="startRow"/> down to the cursor, newest
         /// first, stopping when any part of the budget is spent. Both readers above have already
-        /// validated the coordinate space; this method only walks and assembles.
+        /// validated the coordinate space; this method only orchestrates - cursor column, trailing
+        /// blank trim, the row collection, the assembly - each in its own helper below.
         /// </summary>
         private static bool TryReadTailFromRowLocked(
             TerminalBuffer buffer,
@@ -432,23 +433,67 @@ namespace NovaTerminal.VT
 
             int cols = buffer.Cols;
             int cursorRow = buffer.Scrollback.Count + buffer.InternalCursorRow;
+            int cursorTextCol = CursorTextColumn(buffer, cols);
+            int endRow = TrimTrailingBlankRows(buffer, startRow, cursorRow, cursorTextCol, cols);
+            List<PhysicalRow> rows = CollectRowsWithinBudget(buffer, startRow, endRow, cursorRow, cursorTextCol, cols, budget);
 
-            // Deferred autowrap: after a character lands on the last column the cursor stays parked
-            // there with the wrap pending, so its *text* position is one past it.
+            outputTail = AssembleTail(rows, budget);
+            return true;
+        }
+
+        /// <summary>
+        /// The cursor's text column, honoring deferred autowrap: after a character lands on the
+        /// last column the cursor stays parked there with the wrap pending, so its <i>text</i>
+        /// position is one past it.
+        /// </summary>
+        private static int CursorTextColumn(TerminalBuffer buffer, int cols)
+        {
             int cursorTextCol = buffer.IsPendingWrap
                 ? Math.Min(buffer.InternalCursorCol + 1, cols)
                 : buffer.InternalCursorCol;
-            cursorTextCol = Math.Clamp(cursorTextCol, 0, cols);
+            return Math.Clamp(cursorTextCol, 0, cols);
+        }
 
+        /// <summary>
+        /// Trailing blank rows are slack, not output: at D the shell has emitted the final newline
+        /// and the cursor sits on a row the next prompt has not painted yet.
+        /// </summary>
+        private static int TrimTrailingBlankRows(
+            TerminalBuffer buffer,
+            int startRow,
+            int cursorRow,
+            int cursorTextCol,
+            int cols)
+        {
             int endRow = cursorRow;
-
-            // Trailing blank rows are slack, not output: at D the shell has emitted the final
-            // newline and the cursor sits on a row the next prompt has not painted yet.
-            while (endRow > startRow && IsRowBlank(buffer, endRow, endRow == cursorRow ? cursorTextCol : cols))
+            while (endRow > startRow && IsRowBlank(buffer, endRow, RowScanEndColumn(endRow, cursorRow, cursorTextCol, cols)))
             {
                 endRow--;
             }
 
+            return endRow;
+        }
+
+        /// <summary>
+        /// The exclusive end column for scanning a row: the cursor row stops at the cursor's text
+        /// position, every other row spans the full width.
+        /// </summary>
+        private static int RowScanEndColumn(int row, int cursorRow, int cursorTextCol, int cols)
+            => row == cursorRow ? cursorTextCol : cols;
+
+        /// <summary>
+        /// The walk itself, newest first, stopping when any part of the budget is spent. Returns
+        /// the physical rows in reading order.
+        /// </summary>
+        private static List<PhysicalRow> CollectRowsWithinBudget(
+            TerminalBuffer buffer,
+            int startRow,
+            int endRow,
+            int cursorRow,
+            int cursorTextCol,
+            int cols,
+            in OutputTailBudget budget)
+        {
             var rows = new List<PhysicalRow>();
             int logicalLines = 0;
             int collected = 0;
@@ -456,11 +501,7 @@ namespace NovaTerminal.VT
             for (int row = endRow; row >= startRow; row--)
             {
                 bool wrapsIntoNext = row < endRow && buffer.IsRowWrappedAbsolute(row);
-                int endCol = row == cursorRow
-                    ? cursorTextCol
-                    : wrapsIntoNext
-                        ? SoftWrappedRowEnd(buffer, row, cols)
-                        : LastNonBlankColumn(buffer, row, cols) + 1;
+                int endCol = RowTextEndColumn(buffer, row, endRow, cursorRow, cursorTextCol, cols, wrapsIntoNext);
 
                 // A row that soft-wrapped into the next one keeps its trailing cells: they are the
                 // middle of a logical line, and trimming them would glue the two halves of a
@@ -475,18 +516,66 @@ namespace NovaTerminal.VT
                     logicalLines++;
                 }
 
-                if (rows.Count >= budget.MaxRows)
-                {
-                    break;
-                }
-
-                if (startsLogicalLine && (logicalLines >= budget.MaxLines || collected >= budget.MaxChars))
+                if (BudgetSpent(rows.Count, startsLogicalLine, logicalLines, collected, budget))
                 {
                     break;
                 }
             }
 
             rows.Reverse();
+            return rows;
+        }
+
+        /// <summary>
+        /// The exclusive end column a row contributes as text: the cursor row stops at the
+        /// cursor's text position, a row that soft-wrapped into the next one keeps its trailing
+        /// cells through the soft-wrap hole, and any other row ends after its last non-blank cell.
+        /// </summary>
+        private static int RowTextEndColumn(
+            TerminalBuffer buffer,
+            int row,
+            int endRow,
+            int cursorRow,
+            int cursorTextCol,
+            int cols,
+            bool wrapsIntoNext)
+        {
+            if (row == cursorRow)
+            {
+                return cursorTextCol;
+            }
+
+            if (wrapsIntoNext)
+            {
+                return SoftWrappedRowEnd(buffer, row, cols);
+            }
+
+            return LastNonBlankColumn(buffer, row, cols) + 1;
+        }
+
+        private static bool BudgetSpent(
+            int rowCount,
+            bool startsLogicalLine,
+            int logicalLines,
+            int collected,
+            in OutputTailBudget budget)
+        {
+            if (rowCount >= budget.MaxRows)
+            {
+                return true;
+            }
+
+            return startsLogicalLine && (logicalLines >= budget.MaxLines || collected >= budget.MaxChars);
+        }
+
+        /// <summary>Joins the rows, newlines only at real line breaks, clamped to the budget.</summary>
+        private static string AssembleTail(List<PhysicalRow> rows, in OutputTailBudget budget)
+        {
+            int collected = 0;
+            foreach (PhysicalRow row in rows)
+            {
+                collected += row.Text.Length;
+            }
 
             var builder = new StringBuilder(Math.Min(collected, budget.MaxChars) + rows.Count);
             for (int i = 0; i < rows.Count; i++)
@@ -504,8 +593,7 @@ namespace NovaTerminal.VT
                 assembled = assembled[^budget.MaxChars..];
             }
 
-            outputTail = assembled;
-            return true;
+            return assembled;
         }
 
         private readonly record struct PhysicalRow(string Text, bool WrapsIntoNext);

--- a/src/NovaTerminal.VT/CommandOutputReader.cs
+++ b/src/NovaTerminal.VT/CommandOutputReader.cs
@@ -501,7 +501,7 @@ namespace NovaTerminal.VT
             for (int row = endRow; row >= startRow; row--)
             {
                 bool wrapsIntoNext = row < endRow && buffer.IsRowWrappedAbsolute(row);
-                int endCol = RowTextEndColumn(buffer, row, endRow, cursorRow, cursorTextCol, cols, wrapsIntoNext);
+                int endCol = RowTextEndColumn(buffer, row, cursorRow, cursorTextCol, cols, wrapsIntoNext);
 
                 // A row that soft-wrapped into the next one keeps its trailing cells: they are the
                 // middle of a logical line, and trimming them would glue the two halves of a
@@ -534,7 +534,6 @@ namespace NovaTerminal.VT
         private static int RowTextEndColumn(
             TerminalBuffer buffer,
             int row,
-            int endRow,
             int cursorRow,
             int cursorTextCol,
             int cols,

--- a/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputPanelTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputPanelTests.cs
@@ -1,0 +1,90 @@
+using System;
+using Avalonia.Controls;
+using NovaTerminal.AgentOutput;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
+namespace NovaTerminal.Tests.AgentOutput;
+
+/// <summary>
+/// The panel view's contract with its view model: content swaps rebuild the markdown host, the
+/// empty state and the rendered view are mutually exclusive, and the status line tracks
+/// streaming. No pixels - the assist overlay tests already cover the "chrome but no content"
+/// failure mode class, and these assertions pin the state machine that feeds it. AvaloniaFact,
+/// not plain facts: the panel is a XAML UserControl, and InitializeComponent needs the headless
+/// application up.
+/// </summary>
+public sealed class AgentOutputPanelTests
+{
+    private static AgentOutputPanel CreatePanel(out AgentOutputViewModel viewModel)
+    {
+        viewModel = new AgentOutputViewModel();
+        var panel = new AgentOutputPanel();
+        panel.SetViewModel(viewModel);
+        return panel;
+    }
+
+    [AvaloniaFact]
+    public void Initially_ShowsTheEmptyState()
+    {
+        var panel = CreatePanel(out _);
+
+        Assert.True(panel.FindControl<StackPanel>("EmptyState").IsVisible);
+        Assert.False(panel.FindControl<ScrollViewer>("ContentScroll").IsVisible);
+        Assert.False(panel.FindControl<Button>("BtnCopyAll").IsEnabled);
+    }
+
+    [AvaloniaFact]
+    public void ContentUpdate_SwapsEmptyStateForTheRenderedView()
+    {
+        var panel = CreatePanel(out var viewModel);
+
+        viewModel.SetUpdate("# Heading\n\nparagraph", isStreaming: true);
+
+        Assert.False(panel.FindControl<StackPanel>("EmptyState").IsVisible);
+        Assert.True(panel.FindControl<ScrollViewer>("ContentScroll").IsVisible);
+        Assert.True(panel.FindControl<Button>("BtnCopyAll").IsEnabled);
+        Assert.NotEmpty(panel.FindControl<StackPanel>("MarkdownHost").Children);
+    }
+
+    [AvaloniaFact]
+    public void StreamingStatus_ShowsInTheHeader_AndClearsWhenFinished()
+    {
+        var panel = CreatePanel(out var viewModel);
+        var status = panel.FindControl<TextBlock>("StatusText");
+
+        viewModel.SetUpdate("content", isStreaming: true);
+        Assert.True(status.IsVisible);
+        Assert.Equal("streaming…", status.Text);
+
+        viewModel.SetUpdate("content", isStreaming: false);
+        Assert.False(status.IsVisible);
+    }
+
+    [AvaloniaFact]
+    public void ClearingTheContent_ReturnsToTheEmptyState()
+    {
+        var panel = CreatePanel(out var viewModel);
+        viewModel.SetUpdate("## gone soon", isStreaming: false);
+
+        viewModel.SetUpdate(string.Empty, isStreaming: false);
+
+        Assert.True(panel.FindControl<StackPanel>("EmptyState").IsVisible);
+        Assert.Empty(panel.FindControl<StackPanel>("MarkdownHost").Children);
+    }
+
+    [AvaloniaFact]
+    public void IdenticalContentUpdate_DoesNotRebuildTheHost()
+    {
+        var panel = CreatePanel(out var viewModel);
+        viewModel.SetUpdate("# stable", isStreaming: false);
+        var host = panel.FindControl<StackPanel>("MarkdownHost");
+        Control first = host.Children[0];
+
+        // Same text, same hash: the tracker's dedupe contract means the host must not churn -
+        // a streaming agent repaints constantly, and every rebuild is a layout pass.
+        viewModel.SetUpdate("# stable", isStreaming: false);
+
+        Assert.Same(first, host.Children[0]);
+    }
+}

--- a/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputPanelTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputPanelTests.cs
@@ -87,4 +87,29 @@ public sealed class AgentOutputPanelTests
 
         Assert.Same(first, host.Children[0]);
     }
+
+    // ---------------------------------------------------------------- link scheme allowlist
+
+    [Theory]
+    [InlineData("https://example.com/page")]
+    [InlineData("http://example.com/")]
+    [InlineData("mailto:someone@example.com")]
+    public void WebAndMailLinks_AreAllowedThroughTheAllowlist(string url)
+    {
+        Assert.True(AgentOutputPanel.IsSafeExternalUrl(url));
+    }
+
+    [Theory]
+    [InlineData("C:\\Windows\\System32\\calc.exe")]
+    [InlineData("file:///C:/Windows/System32/calc.exe")]
+    [InlineData("ms-settings:windowsupdate")]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("../../etc/passwd")]
+    [InlineData("")]
+    public void ExecutablePaths_FileUrls_AndCustomSchemes_AreBlocked(string url)
+    {
+        // Agent output is untrusted: a crafted [label](target) must never name something the
+        // shell handler would launch or hand to a protocol handler.
+        Assert.False(AgentOutputPanel.IsSafeExternalUrl(url));
+    }
 }

--- a/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputRegionTrackerTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputRegionTrackerTests.cs
@@ -1,0 +1,302 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NovaTerminal.AgentOutput;
+using NovaTerminal.VT;
+using Xunit;
+
+namespace NovaTerminal.Tests.AgentOutput;
+
+/// <summary>
+/// The per-pane region tracker: what it posts, when, and what it refuses to post.
+/// </summary>
+/// <remarks>
+/// The tracker is the piece that turns grid invalidations into panel updates, so the tests pin
+/// the contract the panel depends on: streaming updates only after the debounce window, the final
+/// update synchronously at <c>OSC 133;D</c>, no-op text never posted twice, and every refusal the
+/// reader contract implies (alt screen, dead generation, disabled, reset). Driven through the
+/// real parser and buffer, like the VT-side reader tests.
+/// </remarks>
+public sealed class AgentOutputRegionTrackerTests
+{
+    private const string PromptStart = "\x1b]133;A\x07";
+    private const string PromptEnd = "\x1b]133;B\x07";
+    private const string AcceptMark = "\x1b]133;C\x07";
+
+    private sealed class Harness : IDisposable
+    {
+        private readonly object _gate = new();
+        private ShellIntegrationMark? _commandLineMark;
+        private ShellIntegrationMark? _outputStart;
+
+        public Harness(bool enabled = true)
+        {
+            Buffer = new TerminalBuffer(40, 8);
+            Parser = new AnsiParser(Buffer);
+            Parser.OnCommandStarted = mark => _commandLineMark = mark;
+
+            Tracker = new AgentOutputRegionTracker(
+                () => Buffer,
+                () => _outputStart,
+                dispatch: action => action(), // synchronous "UI thread"
+                onUpdate: (text, streaming) =>
+                {
+                    lock (_gate)
+                    {
+                        Updates.Add((text, streaming));
+                    }
+                });
+            Tracker.SetEnabled(enabled);
+        }
+
+        public TerminalBuffer Buffer { get; }
+
+        public AnsiParser Parser { get; }
+
+        public AgentOutputRegionTracker Tracker { get; }
+
+        public List<(string Text, bool Streaming)> Updates { get; } = new();
+
+        public int UpdateCount
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return Updates.Count;
+                }
+            }
+        }
+
+        public string LastText
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return Updates[^1].Text;
+                }
+            }
+        }
+
+        public bool LastStreaming
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return Updates[^1].Streaming;
+                }
+            }
+        }
+
+        /// <summary>A prompt with shell integration, then a submitted line with the C edge.</summary>
+        public Harness Accept(string commandLine)
+        {
+            Parser.Process(PromptStart + "$ " + PromptEnd);
+            Parser.Process(commandLine);
+            Parser.Process(AcceptMark);
+            _outputStart = CommandOutputReader.TryCaptureOutputStart(Buffer, _commandLineMark, out var start)
+                ? start
+                : null;
+            Tracker.NotifyCommandAccepted();
+            return this;
+        }
+
+        public Harness Output(params string[] lines)
+            => Write("\r\n" + string.Join("\r\n", lines) + "\r\n");
+
+        public Harness Write(string data)
+        {
+            Parser.Process(data);
+            return this;
+        }
+
+        /// <summary>The OSC 133;D edge - the tracker's synchronous final read.</summary>
+        public void Finish() => Tracker.NotifyCommandFinished();
+
+        /// <summary>
+        /// The markless shape: no C edge ever arrives, so the region start is pinned from the
+        /// cursor the way the pane does at Enter. Enables the tracker first, matching the pane -
+        /// the capture only runs while the panel is open.
+        /// </summary>
+        public Harness CaptureHeuristicStart()
+        {
+            Tracker.SetEnabled(true);
+            Tracker.CaptureHeuristicStart();
+            return this;
+        }
+
+        public void Dispose() => Tracker.Dispose();
+    }
+
+    private static async Task WaitForAsync(Func<bool> condition, int timeoutMs = 3000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(25);
+        }
+
+        Assert.True(condition(), "condition not met within the timeout");
+    }
+
+    private static int PastDebounceMs
+        => (int)AgentOutputRegionTracker.DebounceDelay.TotalMilliseconds + 250;
+
+    [Fact]
+    public async Task AcceptedCommand_StreamsRegionTextAsItGrows()
+    {
+        using var h = new Harness()
+            .Accept("agent --task")
+            .Output("## Plan", "first chunk");
+
+        h.Tracker.NotifyInvalidate();
+        await WaitForAsync(() => h.UpdateCount > 0);
+
+        Assert.Contains("## Plan", h.LastText, StringComparison.Ordinal);
+        Assert.Contains("first chunk", h.LastText, StringComparison.Ordinal);
+        Assert.True(h.LastStreaming);
+    }
+
+    [Fact]
+    public void FinishedCommand_PostsTheFinalUpdateSynchronously()
+    {
+        // No waiting here on purpose: at D the grid is about to be repainted, so the final read
+        // must not be deferred to a debounce tick.
+        using var h = new Harness()
+            .Accept("agent --task")
+            .Output("done");
+
+        h.Finish();
+
+        Assert.Equal(1, h.UpdateCount);
+        Assert.Contains("done", h.LastText, StringComparison.Ordinal);
+        Assert.False(h.LastStreaming);
+    }
+
+    [Fact]
+    public async Task RepeatedInvalidations_WithoutNewOutput_PostNoDuplicateUpdates()
+    {
+        using var h = new Harness()
+            .Accept("agent --task")
+            .Output("stable output");
+
+        h.Tracker.NotifyInvalidate();
+        await WaitForAsync(() => h.UpdateCount > 0);
+
+        int afterFirst = h.UpdateCount;
+        h.Tracker.NotifyInvalidate();
+        h.Tracker.NotifyInvalidate();
+        h.Tracker.NotifyInvalidate();
+        await Task.Delay(PastDebounceMs);
+
+        Assert.Equal(afterFirst, h.UpdateCount);
+    }
+
+    [Fact]
+    public void InvalidationsBeforeTheDebounceWindow_PostNothing()
+    {
+        using var h = new Harness()
+            .Accept("agent --task")
+            .Output("not yet");
+
+        h.Tracker.NotifyInvalidate();
+
+        Assert.Equal(0, h.UpdateCount);
+    }
+
+    [Fact]
+    public async Task MarklessSession_WithHeuristicStart_TracksRecentOutput()
+    {
+        using var h = new Harness(enabled: false);
+        h.Write(PromptStart + "$ " + PromptEnd); // a prompt, but never a C edge
+        h.CaptureHeuristicStart();
+        h.Output("raw markdown response");
+
+        h.Tracker.NotifyInvalidate();
+        await WaitForAsync(() => h.UpdateCount > 0);
+
+        Assert.Contains("raw markdown response", h.LastText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AltScreenWhileTracked_PostsNoUpdates()
+    {
+        using var h = new Harness()
+            .Accept("vim")
+            .Output("some output");
+
+        h.Write("\x1b[?1049h"); // a full-screen program takes over the grid
+        h.Tracker.NotifyInvalidate();
+        await Task.Delay(PastDebounceMs);
+
+        Assert.Equal(0, h.UpdateCount);
+    }
+
+    [Fact]
+    public async Task ScrollbackResetWhileTracked_PostsNoUpdates()
+    {
+        using var h = new Harness()
+            .Accept("agent --task")
+            .Output("real output");
+
+        // CSI 3J: the coordinate-space epoch changes, and a stale mark must never resolve to
+        // someone else's rows. The reader refuses; the tracker stays silent.
+        h.Write("\x1b[3J\x1b[H");
+        h.Write("unrelated content");
+        h.Tracker.NotifyInvalidate();
+        await Task.Delay(PastDebounceMs);
+
+        Assert.Equal(0, h.UpdateCount);
+    }
+
+    [Fact]
+    public void DisabledTracker_IgnoresEverything()
+    {
+        using var h = new Harness(enabled: false)
+            .Accept("agent --task")
+            .Output("ignored");
+
+        h.Finish();
+        h.Tracker.NotifyInvalidate();
+
+        Assert.Equal(0, h.UpdateCount);
+    }
+
+    [Fact]
+    public void FinishWhileDisabled_ClearsStreamingWithoutPosting()
+    {
+        using var h = new Harness();
+
+        // Enabled for the accept, disabled before D: the D read must not fire, and the next
+        // invalidation must not resume streaming state from the finished command.
+        h.Accept("agent --task");
+        h.Output("partial");
+        h.Tracker.SetEnabled(false);
+        h.Finish();
+        h.Tracker.NotifyInvalidate();
+
+        Assert.Equal(0, h.UpdateCount);
+    }
+
+    [Fact]
+    public async Task Reset_ClearsTheHeuristicRegion()
+    {
+        using var h = new Harness(enabled: false);
+        h.Write(PromptStart + "$ " + PromptEnd);
+        h.CaptureHeuristicStart();
+        h.Tracker.Reset();
+        h.Output("after reset");
+
+        h.Tracker.NotifyInvalidate();
+        await Task.Delay(PastDebounceMs);
+
+        Assert.Equal(0, h.UpdateCount);
+    }
+}

--- a/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputRegionTrackerTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputRegionTrackerTests.cs
@@ -498,6 +498,55 @@ public sealed class AgentOutputRegionTrackerTests
     }
 
     [Fact]
+    public async Task PanelOpenedAfterAMarklessCommand_ShowsThatCommandsOutputOnly()
+    {
+        // The real-world shape behind the whole-pane bug: a themed prompt (powerline segments,
+        // no "PS ", no drive letter at column 0, no user@host) that prompt-shape matching cannot
+        // recognize, so the snapshot handed the panel the entire scrollback - shell banner and
+        // every earlier round included. The remembered Enter row bounds it instead.
+        using var h = new Harness(enabled: false);
+        h.Write("Clink v1.9.25.dc17e7\r\nCopyright (c) 2012-2018 Martin Ridgers\r\n");
+        h.Write(" behna \uE0B0  ~ \uE0B0 \u276F earlier --round\r\n");
+        h.Write("## Earlier answer\r\n");
+
+        // The prompt for the command that matters, then Enter - observed while the panel is
+        // CLOSED, which is exactly the case the old gate threw away.
+        h.Write(" behna \uE0B0  ~ \uE0B0 \u276F agent --task");
+        h.Tracker.CaptureHeuristicStart();
+        h.Output("## Latest answer", "the payload");
+
+        // The panel opens after the fact.
+        h.Tracker.SetEnabled(true);
+        h.Tracker.FlushNow(includeRecentTailFallback: true);
+        await WaitForAsync(() => h.UpdateCount > 0);
+
+        Assert.Contains("## Latest answer", h.LastText, StringComparison.Ordinal);
+        Assert.Contains("the payload", h.LastText, StringComparison.Ordinal);
+        Assert.DoesNotContain("Clink", h.LastText, StringComparison.Ordinal);
+        Assert.DoesNotContain("Earlier answer", h.LastText, StringComparison.Ordinal);
+
+        // Opened after the fact, so the panel is looking at history, not a live stream.
+        Assert.False(h.LastStreaming);
+    }
+
+    [Fact]
+    public async Task PanelOpenedWithNoEnterEverObserved_StillFallsBackToTheSnapshot()
+    {
+        // Output that predates the app - or a pane that never saw an Enter - has no remembered
+        // row to bound, so the prompt-shape snapshot stays the last resort rather than the panel
+        // showing nothing at all.
+        using var h = new Harness(enabled: false);
+        h.Write("## Answer from before\r\nstill worth showing\r\n");
+
+        h.Tracker.SetEnabled(true);
+        h.Tracker.FlushNow(includeRecentTailFallback: true);
+        await WaitForAsync(() => h.UpdateCount > 0);
+
+        Assert.Contains("Answer from before", h.LastText, StringComparison.Ordinal);
+        Assert.False(h.LastStreaming);
+    }
+
+    [Fact]
     public async Task AltScreenWhileTracked_PostsNoUpdates()
     {
         using var h = new Harness()

--- a/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputRegionTrackerTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputRegionTrackerTests.cs
@@ -181,6 +181,43 @@ public sealed class AgentOutputRegionTrackerTests
     }
 
     [Fact]
+    public async Task PanelEnabledWhileACommandIsRunning_AdoptsTheLiveRegion()
+    {
+        // The C edge arrived while the panel was closed: the tracker must still adopt that
+        // command's region when it is enabled mid-flight, instead of showing nothing until the
+        // next command starts.
+        using var h = new Harness(enabled: false)
+            .Accept("agent --task")
+            .Output("already streaming");
+
+        h.Tracker.SetEnabled(true);
+        h.Tracker.FlushNow();
+        await WaitForAsync(() => h.UpdateCount > 0);
+
+        Assert.Contains("already streaming", h.LastText, StringComparison.Ordinal);
+        Assert.True(h.LastStreaming);
+    }
+
+    [Fact]
+    public void FinishedCommand_PostsFinalState_EvenWhenABackgroundReadWasScheduled()
+    {
+        // A debounced read armed during streaming overlaps the D edge: D's synchronous read
+        // bumps the generation, so whatever that background read dispatches later must be
+        // dropped rather than overwrite the finished state. The synchronous harness dispatch
+        // makes the ordering deterministic here: the background timer cannot interleave, and
+        // this pins that D's own post survives its own generation bump.
+        using var h = new Harness()
+            .Accept("agent --task")
+            .Output("final text");
+
+        h.Tracker.NotifyInvalidate();
+        h.Finish();
+
+        Assert.Equal(1, h.UpdateCount);
+        Assert.False(h.LastStreaming);
+    }
+
+    [Fact]
     public async Task RepeatedInvalidations_WithoutNewOutput_PostNoDuplicateUpdates()
     {
         using var h = new Harness()

--- a/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputRegionTrackerTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputRegionTrackerTests.cs
@@ -29,7 +29,7 @@ public sealed class AgentOutputRegionTrackerTests
         private ShellIntegrationMark? _commandLineMark;
         private ShellIntegrationMark? _outputStart;
 
-        public Harness(bool enabled = true)
+        public Harness(bool enabled = true, bool deferDispatch = false)
         {
             Buffer = new TerminalBuffer(40, 8);
             Parser = new AnsiParser(Buffer);
@@ -38,7 +38,24 @@ public sealed class AgentOutputRegionTrackerTests
             Tracker = new AgentOutputRegionTracker(
                 () => Buffer,
                 () => _outputStart,
-                dispatch: action => action(), // synchronous "UI thread"
+                dispatch: action =>
+                {
+                    // Deferred mode stands in for the UI-thread hop: the update is produced but
+                    // not delivered, so tests can transition the tracker in between and deliver
+                    // afterwards - the interleaving production hits when a background read
+                    // straddles an OSC 133 edge.
+                    if (deferDispatch)
+                    {
+                        lock (_gate)
+                        {
+                            PendingActions.Add(action);
+                        }
+                    }
+                    else
+                    {
+                        action();
+                    }
+                },
                 onUpdate: (text, streaming) =>
                 {
                     lock (_gate)
@@ -56,6 +73,53 @@ public sealed class AgentOutputRegionTrackerTests
         public AgentOutputRegionTracker Tracker { get; }
 
         public List<(string Text, bool Streaming)> Updates { get; } = new();
+
+        /// <summary>Undelivered updates, oldest first, when dispatch is deferred.</summary>
+        public List<Action> PendingActions { get; } = new();
+
+        public int PendingCount
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return PendingActions.Count;
+                }
+            }
+        }
+
+        /// <summary>Delivers the queued updates in queue order.</summary>
+        public void DeliverPending()
+        {
+            Action[] toDeliver;
+            lock (_gate)
+            {
+                toDeliver = PendingActions.ToArray();
+                PendingActions.Clear();
+            }
+
+            foreach (Action action in toDeliver)
+            {
+                action();
+            }
+        }
+
+        /// <summary>Delivers the queued updates newest first - the adversarial order a threadpool
+        /// read and the UI dispatcher can produce when a background read straddles an edge.</summary>
+        public void DeliverPendingNewestFirst()
+        {
+            Action[] toDeliver;
+            lock (_gate)
+            {
+                toDeliver = PendingActions.ToArray();
+                PendingActions.Clear();
+            }
+
+            for (int i = toDeliver.Length - 1; i >= 0; i--)
+            {
+                toDeliver[i]();
+            }
+        }
 
         public int UpdateCount
         {
@@ -196,6 +260,55 @@ public sealed class AgentOutputRegionTrackerTests
 
         Assert.Contains("already streaming", h.LastText, StringComparison.Ordinal);
         Assert.True(h.LastStreaming);
+    }
+
+    [Fact]
+    public async Task DroppedUpdate_DoesNotPoisonDedupe_ForTheSameTextInANewGeneration()
+    {
+        // Produced-but-undelivered updates must not commit dedupe state: an update dropped by a
+        // generation transition (here, Reset while the UI dispatch is pending) leaves no trace,
+        // so the same text delivered in the next generation still reaches the panel.
+        using var h = new Harness(enabled: false, deferDispatch: true);
+        h.Accept("agent --task").Output("chunk");
+        h.Tracker.SetEnabled(true);
+        h.Tracker.FlushNow();
+        await WaitForAsync(() => h.PendingCount > 0);
+
+        h.Tracker.Reset();
+        h.DeliverPending(); // dropped: its generation is gone; hash must NOT be committed
+        Assert.Equal(0, h.UpdateCount);
+
+        // A fresh command printing the identical text: the identical hash/streaming pair must
+        // not be mistaken for the undelivered update above.
+        h.Accept("agent --task").Output("chunk");
+        h.Tracker.FlushNow();
+        await WaitForAsync(() => h.PendingCount > 0);
+        h.DeliverPending();
+
+        Assert.Equal(1, h.UpdateCount);
+        Assert.True(h.LastStreaming);
+    }
+
+    [Fact]
+    public async Task StaleStreamingUpdateDeliveredAfterCompletion_IsDropped()
+    {
+        // A background read produced while streaming can reach the UI after the D edge; whether
+        // it delivers before or after the final update, it must not win - the panel ends on the
+        // finished, non-streaming state either way.
+        using var h = new Harness(deferDispatch: true);
+        h.Accept("agent --task").Output("final text");
+        h.Tracker.NotifyInvalidate();
+        h.Tracker.FlushNow();
+        await WaitForAsync(() => h.PendingCount > 0); // queued: gen G, streaming true
+
+        h.Finish(); // bumps to G+1, queues the final gen G+1 streaming:false update
+
+        // Adversarial order: the stale streaming update delivers last.
+        h.DeliverPendingNewestFirst();
+
+        Assert.True(h.UpdateCount >= 1);
+        Assert.False(h.LastStreaming);
+        Assert.Contains("final text", h.LastText, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputRegionTrackerTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputRegionTrackerTests.cs
@@ -448,6 +448,30 @@ public sealed class AgentOutputRegionTrackerTests
     }
 
     [Fact]
+    public async Task PanelReopenedOnAnUnchangedRunningCommand_RestoresTheStreamingUpdate()
+    {
+        using var h = new Harness()
+            .Accept("agent --task")
+            .Output("stable output");
+
+        h.Tracker.NotifyInvalidate();
+        await WaitForAsync(() => h.UpdateCount > 0);
+        int afterFirst = h.UpdateCount;
+
+        // Close and reopen the panel while the command is still running and its output has not
+        // changed. The pane clears the view model's streaming status on open and depends on this
+        // flush to restore it, so an update deduplicated against what the pre-close generation
+        // posted would leave a running command displayed as finished.
+        h.Tracker.SetEnabled(false);
+        h.Tracker.SetEnabled(true);
+        h.Tracker.FlushNow(includeRecentTailFallback: true);
+        await WaitForAsync(() => h.UpdateCount > afterFirst);
+
+        Assert.Contains("stable output", h.LastText, StringComparison.Ordinal);
+        Assert.True(h.LastStreaming);
+    }
+
+    [Fact]
     public void InvalidationsBeforeTheDebounceWindow_PostNothing()
     {
         using var h = new Harness()
@@ -482,6 +506,46 @@ public sealed class AgentOutputRegionTrackerTests
 
         h.Write("\x1b[?1049h"); // a full-screen program takes over the grid
         h.Tracker.NotifyInvalidate();
+        await Task.Delay(PastDebounceMs);
+
+        Assert.Equal(0, h.UpdateCount);
+    }
+
+    [Fact]
+    public async Task LeavingAltScreenAfterTheCommandFinished_CorrectsTheStreamingStatus()
+    {
+        using var h = new Harness()
+            .Accept("agent --task")
+            .Output("## Result", "the answer");
+
+        h.Tracker.NotifyInvalidate();
+        await WaitForAsync(() => h.UpdateCount > 0);
+        Assert.True(h.LastStreaming);
+
+        // A full-screen program takes the grid, and the command finishes underneath it. D's read
+        // refuses on an active alt screen, so "streaming" is the last thing the panel heard.
+        h.Write("[?1049h");
+        h.Finish();
+        Assert.True(h.LastStreaming);
+
+        // Back on the primary screen the panel is shown again, and it must not still present the
+        // finished command as streaming.
+        h.Write("[?1049l");
+        h.Tracker.NotifyAltScreenChanged(false);
+        await WaitForAsync(() => !h.LastStreaming);
+
+        Assert.False(h.LastStreaming);
+    }
+
+    [Fact]
+    public async Task EnteringAltScreen_PostsNothing()
+    {
+        using var h = new Harness()
+            .Accept("agent --task")
+            .Output("some output");
+
+        h.Write("[?1049h");
+        h.Tracker.NotifyAltScreenChanged(true);
         await Task.Delay(PastDebounceMs);
 
         Assert.Equal(0, h.UpdateCount);

--- a/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputRegionTrackerTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputRegionTrackerTests.cs
@@ -263,6 +263,60 @@ public sealed class AgentOutputRegionTrackerTests
     }
 
     [Fact]
+    public async Task EnableWithNothingTracked_ShowsTheRecentOnScreenOutput_AsAFinishedSnapshot()
+    {
+        // The panel opened onto output that already finished: no live C mark, no Enter-time
+        // heuristic. The flush falls back to a one-shot recent-tail snapshot so the user sees
+        // what is on screen instead of an empty state.
+        using var h = new Harness(enabled: false);
+        h.Write(PromptStart + "$ " + PromptEnd);
+        h.Output("## on screen");
+
+        h.Tracker.SetEnabled(true);
+        h.Tracker.FlushNow(includeRecentTailFallback: true);
+        await WaitForAsync(() => h.UpdateCount > 0);
+
+        Assert.Contains("## on screen", h.LastText, StringComparison.Ordinal);
+        Assert.False(h.LastStreaming);
+    }
+
+    [Fact]
+    public async Task FlushWithoutTheFallback_WithNothingTracked_PostsNothing()
+    {
+        using var h = new Harness(enabled: false);
+        h.Write(PromptStart + "$ " + PromptEnd);
+        h.Output("## on screen");
+
+        h.Tracker.SetEnabled(true);
+        h.Tracker.FlushNow();
+        await Task.Delay(PastDebounceMs);
+
+        Assert.Equal(0, h.UpdateCount);
+    }
+
+    [Fact]
+    public async Task RecentTailSnapshot_DoesNotTakeOverTracking()
+    {
+        // The snapshot is one-shot: the next command started with the panel open takes over
+        // tracking normally (heuristic capture), replacing the snapshot text.
+        using var h = new Harness(enabled: false);
+        h.Write(PromptStart + "$ " + PromptEnd);
+        h.Output("old screen content");
+
+        h.Tracker.SetEnabled(true);
+        h.Tracker.FlushNow(includeRecentTailFallback: true);
+        await WaitForAsync(() => h.UpdateCount > 0);
+
+        h.Tracker.CaptureHeuristicStart();
+        h.Output("## new command");
+        h.Tracker.NotifyInvalidate();
+        await WaitForAsync(() => h.UpdateCount > 1);
+
+        Assert.Contains("## new command", h.LastText, StringComparison.Ordinal);
+        Assert.True(h.LastStreaming);
+    }
+
+    [Fact]
     public async Task DroppedUpdate_DoesNotPoisonDedupe_ForTheSameTextInANewGeneration()
     {
         // Produced-but-undelivered updates must not commit dedupe state: an update dropped by a

--- a/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputRegionTrackerTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputRegionTrackerTests.cs
@@ -547,6 +547,56 @@ public sealed class AgentOutputRegionTrackerTests
     }
 
     [Fact]
+    public async Task PanelOpenedAfterAnIdleEnter_ShowsThePrecedingResponse()
+    {
+        // Reported from the running app: the panel opened on its "No output yet" empty state
+        // while the response was still on screen. Enter at an idle prompt - a keystroke away at
+        // any shell sitting at a prompt - pins a row whose region is empty forever, and it
+        // displaced the row belonging to the response above it.
+        using var h = new Harness(enabled: false);
+        h.Write("Clink v1.9.25.dc17e7\r\n");
+        h.Write(" behna \uE0B0  ~ \uE0B0 \u276F agent --task");
+        h.Tracker.CaptureHeuristicStart();
+        h.Output("## Latest answer", "the payload");
+
+        // The command finished, the shell drew a fresh prompt, and Enter landed on it.
+        h.Write(" behna \uE0B0  ~ \uE0B0 \u276F ");
+        h.Tracker.CaptureHeuristicStart();
+
+        h.Tracker.SetEnabled(true);
+        h.Tracker.FlushNow(includeRecentTailFallback: true);
+        await WaitForAsync(() => h.UpdateCount > 0);
+
+        // The displaced row answers, so the response is recovered exactly - not blanked, and not
+        // widened into the whole pane by falling straight through to the prompt-shape snapshot.
+        Assert.Contains("## Latest answer", h.LastText, StringComparison.Ordinal);
+        Assert.Contains("the payload", h.LastText, StringComparison.Ordinal);
+        Assert.DoesNotContain("Clink", h.LastText, StringComparison.Ordinal);
+        Assert.False(h.LastStreaming);
+    }
+
+    [Fact]
+    public async Task CorrectiveFlushWithADeadRow_FallsBackToTheSnapshot()
+    {
+        // A scrollback reset kills the remembered row outright (the reader refuses a mark from a
+        // dead coordinate epoch). The corrective flush must still put something in the panel.
+        using var h = new Harness(enabled: false);
+        h.Write(" behna \uE0B0  ~ \uE0B0 \u276F agent --task");
+        h.Tracker.CaptureHeuristicStart();
+        h.Output("## Answer", "payload");
+
+        h.Write("\x1b[3J\x1b[H");
+        h.Write("## After the reset\r\nstill readable");
+
+        h.Tracker.SetEnabled(true);
+        h.Tracker.FlushNow(includeRecentTailFallback: true);
+        await WaitForAsync(() => h.UpdateCount > 0);
+
+        Assert.Contains("After the reset", h.LastText, StringComparison.Ordinal);
+        Assert.False(h.LastStreaming);
+    }
+
+    [Fact]
     public async Task AltScreenWhileTracked_PostsNoUpdates()
     {
         using var h = new Harness()

--- a/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputRegionTrackerTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputRegionTrackerTests.cs
@@ -62,6 +62,13 @@ public sealed class AgentOutputRegionTrackerTests
                     {
                         Updates.Add((text, streaming));
                     }
+                },
+                markdownPresenceChanged: present =>
+                {
+                    lock (_gate)
+                    {
+                        PresenceChanges.Add(present);
+                    }
                 });
             Tracker.SetEnabled(enabled);
         }
@@ -73,6 +80,9 @@ public sealed class AgentOutputRegionTrackerTests
         public AgentOutputRegionTracker Tracker { get; }
 
         public List<(string Text, bool Streaming)> Updates { get; } = new();
+
+        /// <summary>Markdown-presence verdicts, in the order the tracker raised them.</summary>
+        public List<bool> PresenceChanges { get; } = new();
 
         /// <summary>Undelivered updates, oldest first, when dispatch is deferred.</summary>
         public List<Action> PendingActions { get; } = new();
@@ -314,6 +324,40 @@ public sealed class AgentOutputRegionTrackerTests
 
         Assert.Contains("## new command", h.LastText, StringComparison.Ordinal);
         Assert.True(h.LastStreaming);
+    }
+
+    [Fact]
+    public async Task MarkdownOutputWhilePanelClosed_RaisesPresenceTrue()
+    {
+        // The MD button's visibility path: with the panel closed, invalidations drive the lazy
+        // presence cadence, and real markdown on screen must raise a true verdict.
+        using var h = new Harness(enabled: false);
+        h.Write(PromptStart + "$ " + PromptEnd);
+        h.Output("## Title", "", "```python", "x = 1", "```", "", "- [x] shipped");
+
+        h.Tracker.NotifyInvalidate();
+        await WaitForAsync(() => h.PresenceChanges.Count > 0, timeoutMs: 6000);
+
+        Assert.True(h.PresenceChanges[^1]);
+    }
+
+    [Fact]
+    public async Task PlainOutputAfterMarkdown_RaisesPresenceFalse()
+    {
+        // Once the markdown scrolls out of the detection window, the verdict must flip back -
+        // the button disappears again instead of latching on forever.
+        using var h = new Harness(enabled: false);
+        h.Write(PromptStart + "$ " + PromptEnd);
+        h.Output("## Title", "", "```python", "x = 1", "```");
+        h.Tracker.NotifyInvalidate();
+        await WaitForAsync(() => h.PresenceChanges.Count > 0, timeoutMs: 6000);
+
+        string[] noise = Enumerable.Range(1, 120).Select(i => $"log line {i} with plain text").ToArray();
+        h.Output(noise);
+        h.Tracker.NotifyInvalidate();
+        await WaitForAsync(() => h.PresenceChanges.Count > 1 && h.PresenceChanges[^1] == false, timeoutMs: 8000);
+
+        Assert.False(h.PresenceChanges[^1]);
     }
 
     [Fact]

--- a/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputViewModelTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputViewModelTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NovaTerminal.AgentOutput;
+using Xunit;
+
+namespace NovaTerminal.Tests.AgentOutput;
+
+/// <summary>
+/// Panel visibility is the user's toggle minus alt-screen suppression; content flows through one
+/// change-notification per actual change. The pane and the panel view both hang off these
+/// properties, so the tests pin the seam rather than the class.
+/// </summary>
+public sealed class AgentOutputViewModelTests
+{
+    private static List<string> Changed(AgentOutputViewModel vm, Action mutate)
+    {
+        var names = new List<string>();
+        void Handler(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+            => names.Add(e.PropertyName ?? string.Empty);
+
+        vm.PropertyChanged += Handler;
+        try
+        {
+            mutate();
+        }
+        finally
+        {
+            vm.PropertyChanged -= Handler;
+        }
+
+        return names;
+    }
+
+    [Fact]
+    public void HiddenByDefault()
+    {
+        var vm = new AgentOutputViewModel();
+
+        Assert.False(vm.IsPanelOpen);
+        Assert.False(vm.IsShown);
+        Assert.False(vm.HasContent);
+        Assert.Equal(string.Empty, vm.MarkdownText);
+    }
+
+    [Fact]
+    public void OpeningThePanel_ShowsItOnlyWhenNotSuppressed()
+    {
+        var vm = new AgentOutputViewModel();
+
+        vm.IsAltScreenSuppressed = true;
+        vm.IsPanelOpen = true;
+        Assert.False(vm.IsShown, "a full-screen program owns the grid");
+
+        vm.IsAltScreenSuppressed = false;
+        Assert.True(vm.IsShown);
+    }
+
+    [Fact]
+    public void SuppressionChange_RaisesIsShown_WhenThePanelIsOpen()
+    {
+        var vm = new AgentOutputViewModel { IsPanelOpen = true };
+
+        var names = Changed(vm, () => vm.IsAltScreenSuppressed = true);
+
+        Assert.Contains(nameof(AgentOutputViewModel.IsShown), names);
+        Assert.Contains(nameof(AgentOutputViewModel.IsAltScreenSuppressed), names);
+    }
+
+    [Fact]
+    public void SuppressionWhileClosed_DoesNotClaimVisibilityChange()
+    {
+        var vm = new AgentOutputViewModel { IsPanelOpen = false };
+
+        var names = Changed(vm, () => vm.IsAltScreenSuppressed = true);
+
+        Assert.DoesNotContain(nameof(AgentOutputViewModel.IsShown), names);
+    }
+
+    [Fact]
+    public void NoOpMutations_RaiseNothing()
+    {
+        var vm = new AgentOutputViewModel();
+        vm.SetUpdate("text", isStreaming: true);
+
+        var names = Changed(vm, () =>
+        {
+            vm.IsPanelOpen = vm.IsPanelOpen;
+            vm.IsAltScreenSuppressed = vm.IsAltScreenSuppressed;
+            vm.SetUpdate("text", isStreaming: true);
+        });
+
+        Assert.Empty(names);
+    }
+
+    [Fact]
+    public void SetUpdate_UpdatesContentAndStatus()
+    {
+        var vm = new AgentOutputViewModel();
+
+        vm.SetUpdate("## hello", isStreaming: true);
+        Assert.Equal("## hello", vm.MarkdownText);
+        Assert.True(vm.HasContent);
+        Assert.True(vm.IsStreaming);
+        Assert.Equal("streaming…", vm.StatusText);
+
+        vm.SetUpdate("## hello", isStreaming: false);
+        Assert.False(vm.IsStreaming);
+        Assert.Equal(string.Empty, vm.StatusText);
+    }
+
+    [Fact]
+    public void PropertyChanges_CarryThePropertyName()
+    {
+        var vm = new AgentOutputViewModel();
+
+        var names = Changed(vm, () => vm.SetUpdate("x", isStreaming: false));
+
+        Assert.Contains(nameof(AgentOutputViewModel.MarkdownText), names);
+        Assert.Contains(nameof(AgentOutputViewModel.HasContent), names);
+        Assert.Equal(2, names.Count);
+    }
+}

--- a/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputViewModelTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputViewModelTests.cs
@@ -110,6 +110,24 @@ public sealed class AgentOutputViewModelTests
     }
 
     [Fact]
+    public void ClearStreaming_KeepsTheText_ButEndsTheStaleStatus()
+    {
+        // The reopen path: a command that finished while the panel was closed never delivered
+        // its final update, so the view model can hold old text flagged streaming. Clearing
+        // keeps the text readable but drops the "streaming…" label; a live region re-marks it
+        // via the next SetUpdate.
+        var vm = new AgentOutputViewModel();
+        vm.SetUpdate("partial output", isStreaming: true);
+
+        vm.ClearStreaming();
+
+        Assert.Equal("partial output", vm.MarkdownText);
+        Assert.True(vm.HasContent);
+        Assert.False(vm.IsStreaming);
+        Assert.Equal(string.Empty, vm.StatusText);
+    }
+
+    [Fact]
     public void PropertyChanges_CarryThePropertyName()
     {
         var vm = new AgentOutputViewModel();

--- a/tests/NovaTerminal.App.Tests/AgentOutput/MarkdownPresenceDetectorTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/MarkdownPresenceDetectorTests.cs
@@ -66,7 +66,66 @@ public sealed class MarkdownPresenceDetectorTests
         Assert.True(MarkdownPresenceDetector.LooksLikeMarkdown(markdown));
     }
 
+    [Fact]
+    public void BulletsOnlyAnswer_IsDetected()
+    {
+        // Reported from the running app: "claude -p explain X in 3 bullets" left the MD button
+        // hidden. A bullets-only answer carries no heading, fence, table or task list, so the
+        // strong-signal floor was unreachable at any number of bullets - and this is the single
+        // most common shape the panel exists to render.
+        const string output = """
+            Here is the breakdown:
+
+            - **AI Harness** wraps the model in a tool-calling loop.
+            - **Context** is assembled per turn from files and prior messages.
+            - **Tools** are declared as schemas the model can invoke.
+            """;
+        Assert.True(MarkdownPresenceDetector.LooksLikeMarkdown(output));
+    }
+
+    [Fact]
+    public void NumberedAnswerWithoutAHeading_IsDetected()
+    {
+        // The same shape, ordered - agents alternate between the two freely.
+        const string output = """
+            Three steps:
+            1. Read the config
+            2. Apply fixes
+            3. Re-run the build
+            """;
+        Assert.True(MarkdownPresenceDetector.LooksLikeMarkdown(output));
+    }
+
     // ---------------------------------------------------------------- noise that must not trigger
+
+    [Fact]
+    public void TwoBulletsAlone_IsBelowTheBar()
+    {
+        // The floor is three: a bare pair of dash lines is common in build and install logs and
+        // carries no other markdown structure to corroborate it.
+        const string output = """
+            notes:
+            - first
+            - second
+            """;
+        Assert.False(MarkdownPresenceDetector.LooksLikeMarkdown(output));
+    }
+
+    [Fact]
+    public void ThreeBulletShellBanner_IsDetected_AcceptedFalsePositive()
+    {
+        // The documented cost of the three-list-line floor: clink's startup banner is three dash
+        // bullets, so a fresh cmd pane shows the MD button. Accepted on this class's stated bias -
+        // a pointless button is cheap, a hidden feature is not - and it ages out of the panel's
+        // recent-tail window as soon as real output scrolls in.
+        const string output = """
+            Clink v1.9.32 is available.
+            - To apply the update, run 'clink update'.
+            - To stop checking for updates, run 'clink set clink.autoupdate off'.
+            - To view the release notes, visit the Releases page:
+            """;
+        Assert.True(MarkdownPresenceDetector.LooksLikeMarkdown(output));
+    }
 
     [Fact]
     public void PlainProgramOutput_IsNotDetected()

--- a/tests/NovaTerminal.App.Tests/AgentOutput/MarkdownPresenceDetectorTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/MarkdownPresenceDetectorTests.cs
@@ -1,0 +1,123 @@
+using System;
+using NovaTerminal.AgentOutput;
+using Xunit;
+
+namespace NovaTerminal.Tests.AgentOutput;
+
+/// <summary>
+/// The markdown-presence heuristic that gates the MD toggle's visibility. The two error
+/// directions have different costs - a false positive is a pointless button, a false negative is
+/// a hidden feature - so these tests pin the boundary from both sides: real agent-style output
+/// must clear the bar, and the noise terminal output is full of (log separators, comments,
+/// dash fragments) must not.
+/// </summary>
+public sealed class MarkdownPresenceDetectorTests
+{
+    private const string AgentStyleOutput = """
+        Analyzing the project...
+
+        ## Plan
+        1. Read the config
+        2. Apply fixes
+
+        | File | Status |
+        |------|--------|
+        | a.cs | fixed |
+
+        ```csharp
+        var x = 1;
+        ```
+
+        - [x] done
+        - [ ] pending
+        """;
+
+    [Fact]
+    public void AgentStyleOutput_IsDetected()
+    {
+        Assert.True(MarkdownPresenceDetector.LooksLikeMarkdown(AgentStyleOutput));
+    }
+
+    [Fact]
+    public void HeadingPlusFencedCode_IsDetected()
+    {
+        const string markdown = "## Summary\nFixed the bug.\n\n```\npatch text\n```";
+        Assert.True(MarkdownPresenceDetector.LooksLikeMarkdown(markdown));
+    }
+
+    [Fact]
+    public void HeadingPlusTable_IsDetected()
+    {
+        const string markdown = "# Results\n\n| a | b |\n|---|---|\n| 1 | 2 |";
+        Assert.True(MarkdownPresenceDetector.LooksLikeMarkdown(markdown));
+    }
+
+    [Fact]
+    public void HeadingPlusTwoListItems_IsDetected()
+    {
+        const string markdown = "## Next steps\n- rebuild\n- redeploy";
+        Assert.True(MarkdownPresenceDetector.LooksLikeMarkdown(markdown));
+    }
+
+    [Fact]
+    public void NumberedListPlusHeading_IsDetected()
+    {
+        const string markdown = "## Steps\n1. first\n2. second";
+        Assert.True(MarkdownPresenceDetector.LooksLikeMarkdown(markdown));
+    }
+
+    // ---------------------------------------------------------------- noise that must not trigger
+
+    [Fact]
+    public void PlainProgramOutput_IsNotDetected()
+    {
+        const string output = "Build started...\nCompiling 12 files\nBuild succeeded.\n    0 Warning(s)";
+        Assert.False(MarkdownPresenceDetector.LooksLikeMarkdown(output));
+    }
+
+    [Fact]
+    public void SingleHeadingAlone_IsNotDetected()
+    {
+        // One heading is a single strong signal; build logs and scripts legitimately emit them.
+        const string output = "# build log header\ngcc -o foo foo.c\ndone";
+        Assert.False(MarkdownPresenceDetector.LooksLikeMarkdown(output));
+    }
+
+    [Fact]
+    public void HashWithoutSpace_IsNotAHeading()
+    {
+        // "#tag" style fragments are not ATX headings.
+        const string output = "#tag1 released\n#tag2 released\nsee the changelog";
+        Assert.False(MarkdownPresenceDetector.LooksLikeMarkdown(output));
+    }
+
+    [Fact]
+    public void SeparatorLines_AreNotTables()
+    {
+        // Log/rules separators are dashes without pipes.
+        const string output = "## 章节\n--------\nplain text\n--------\nmore text";
+        Assert.False(MarkdownPresenceDetector.LooksLikeMarkdown(output));
+    }
+
+    [Fact]
+    public void SingleDashBullet_IsBelowTheBar()
+    {
+        const string output = "notes:\n- first item only";
+        Assert.False(MarkdownPresenceDetector.LooksLikeMarkdown(output));
+    }
+
+    [Fact]
+    public void EmptyAndNull_AreNotDetected()
+    {
+        Assert.False(MarkdownPresenceDetector.LooksLikeMarkdown(string.Empty));
+        Assert.False(MarkdownPresenceDetector.LooksLikeMarkdown(null!));
+    }
+
+    [Fact]
+    public void BareFenceAlone_IsBelowTheBar()
+    {
+        // ``` on its own shows up in shell transcripts; one strong signal is not enough.
+        const string output = "$ cat out.txt\n```\nsome text\n```";
+        Assert.False(MarkdownPresenceDetector.LooksLikeMarkdown(output));
+    }
+}

--- a/tests/NovaTerminal.App.Tests/AgentOutput/MarkdownRendererTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/MarkdownRendererTests.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Controls.Documents;
+using Avalonia.Media;
+using NovaTerminal.AgentOutput;
+using Xunit;
+
+namespace NovaTerminal.Tests.AgentOutput;
+
+/// <summary>
+/// The markdown-to-Avalonia renderer: the block subset agent CLIs emit, the emphasis and code
+/// inline shapes, and the two safety behaviors the panel depends on (raw HTML never becomes
+/// content, unknown blocks never crash the walk).
+/// </summary>
+/// <remarks>
+/// Plain control-tree construction, no layout or styling - so the tests run without a headless
+/// application. Colors resolve from a bare anchor with no theme resources, which exercises the
+/// fixed-fallback path: the same degradation an unthemed surface gets.
+/// </remarks>
+public sealed class MarkdownRendererTests
+{
+    private static readonly Border Anchor = new();
+
+    private static IEnumerable<Control> Descendants(Control control)
+    {
+        switch (control)
+        {
+            case Panel panel:
+                foreach (Control child in panel.Children)
+                {
+                    yield return child;
+                    foreach (Control nested in Descendants(child))
+                    {
+                        yield return nested;
+                    }
+                }
+
+                break;
+
+            case Border border when border.Child is Control child:
+                yield return child;
+                foreach (Control nested in Descendants(child))
+                {
+                    yield return nested;
+                }
+
+                break;
+
+            case ContentControl content when content.Content is Control child:
+                yield return child;
+                foreach (Control nested in Descendants(child))
+                {
+                    yield return nested;
+                }
+
+                break;
+        }
+    }
+
+    private static IEnumerable<TextBlock> TextBlocks(Control root)
+        => Descendants(root).OfType<TextBlock>();
+
+    private static string TextOf(TextBlock block)
+    {
+        // Markers set Text directly; paragraphs carry Inlines. Either, never both.
+        if (block.Inlines is not { Count: > 0 })
+        {
+            return block.Text ?? string.Empty;
+        }
+
+        var builder = new System.Text.StringBuilder();
+        if (block.Inlines is not null)
+        {
+            foreach (Inline inline in block.Inlines)
+            {
+                if (inline is Run run)
+                {
+                    builder.Append(run.Text);
+                }
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    [Fact]
+    public void Heading_BecomesBoldText_SizedByLevel()
+    {
+        var root = (StackPanel)MarkdownRenderer.Build("# Title\n\n### Sub", Anchor);
+
+        var headings = TextBlocks(root).ToList();
+        Assert.Equal("Title", TextOf((TextBlock)root.Children[0]));
+        Assert.Equal(FontWeight.SemiBold, ((TextBlock)root.Children[0]).FontWeight);
+        Assert.True(((TextBlock)root.Children[0]).FontSize > ((TextBlock)root.Children[1]).FontSize);
+        Assert.Equal("Sub", TextOf(headings[1]));
+    }
+
+    [Fact]
+    public void Paragraph_WithBoldAndItalic_ProducesStyledRuns()
+    {
+        var root = (StackPanel)MarkdownRenderer.Build("plain **bold** and *slant* text", Anchor);
+
+        var paragraph = (SelectableTextBlock)root.Children[0];
+        var runs = paragraph.Inlines!.OfType<Span>().SelectMany(s => s.Inlines!.OfType<Run>()).ToList();
+
+        Assert.Equal("plain  and  text", TextOf(paragraph));
+        Assert.Equal(2, runs.Count);
+        Assert.Equal("bold", runs[0].Text);
+        Assert.Equal(FontWeight.Bold, ((Span)runs[0].Parent!).FontWeight);
+        Assert.Equal("slant", runs[1].Text);
+        Assert.Equal(FontStyle.Italic, ((Span)runs[1].Parent!).FontStyle);
+    }
+
+    [Fact]
+    public void FencedCodeBlock_RendersItsText_WithACopyButton()
+    {
+        var root = (StackPanel)MarkdownRenderer.Build("```csharp\nvar x = 1;\n```\n", Anchor);
+
+        Control? copyButton = Descendants(root).FirstOrDefault(c => c is Button { Content: "Copy" });
+        Assert.NotNull(copyButton);
+
+        TextBlock? code = TextBlocks(root).FirstOrDefault(b => TextOf(b).Contains("var x = 1;", StringComparison.Ordinal));
+        Assert.NotNull(code);
+    }
+
+    [Fact]
+    public void InlineCode_RendersAsAChip()
+    {
+        var root = (StackPanel)MarkdownRenderer.Build("run `npm test` now", Anchor);
+
+        var paragraph = (SelectableTextBlock)root.Children[0];
+        bool hasChip = paragraph.Inlines!.OfType<InlineUIContainer>()
+            .Any(c => c.Child is Border { Child: TextBlock chip } && TextOf(chip) == "npm test");
+        Assert.True(hasChip);
+    }
+
+    [Fact]
+    public void Lists_RenderTheirItems_AndOrdering()
+    {
+        var root = (StackPanel)MarkdownRenderer.Build("1. first\n2. second\n\n- bullet\n", Anchor);
+
+        var markers = TextBlocks(root)
+            .Select(TextOf)
+            .Where(t => t is "1." or "2." or "•")
+            .ToList();
+
+        Assert.Equal(new[] { "1.", "2.", "•" }, markers);
+    }
+
+    [Fact]
+    public void TaskListItem_RendersACheckboxGlyph()
+    {
+        var root = (StackPanel)MarkdownRenderer.Build("- [x] done\n- [ ] pending\n", Anchor);
+
+        string all = string.Concat(TextBlocks(root).Select(TextOf));
+        Assert.Contains("\u2611", all, StringComparison.Ordinal);
+        Assert.Contains("\u2610", all, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Table_RendersHeaderAndRows()
+    {
+        var root = (StackPanel)MarkdownRenderer.Build("| a | b |\n|---|---|\n| 1 | 2 |\n", Anchor);
+
+        Grid? grid = Descendants(root).OfType<Grid>()
+            .FirstOrDefault(g => g.RowDefinitions.Count > 0);
+        Assert.NotNull(grid);
+        Assert.Equal(2, grid!.RowDefinitions.Count);
+        Assert.Equal(2, grid.ColumnDefinitions.Count);
+
+        string all = string.Concat(TextBlocks(root).Select(TextOf));
+        Assert.Contains("a", all, StringComparison.Ordinal);
+        Assert.Contains("2", all, StringComparison.Ordinal);
+        Assert.DoesNotContain("---", all, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BlockQuote_RendersItsParagraphs()
+    {
+        var root = (StackPanel)MarkdownRenderer.Build("> quoted wisdom\n", Anchor);
+
+        Assert.Contains("quoted wisdom", TextBlocks(root).Select(TextOf), StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public void Link_RendersItsLabel_ForClicking()
+    {
+        var root = (StackPanel)MarkdownRenderer.Build("see [the docs](https://example.com) here", Anchor);
+
+        // The link renders as a TextBlock inside an InlineUIContainer of the paragraph, which
+        // the Panel/Border walker does not cross - collect inline-hosted blocks explicitly.
+        var inlineBlocks = ((SelectableTextBlock)root.Children[0]).Inlines!
+            .OfType<InlineUIContainer>()
+            .Select(c => c.Child)
+            .OfType<TextBlock>()
+            .Select(TextOf)
+            .ToList();
+
+        Assert.Contains("the docs", inlineBlocks);
+    }
+
+    [Fact]
+    public void RawHtml_IsTreatedAsPlainText()
+    {
+        // DisableHtml keeps the tags from becoming structure. Whatever leaks through as literal
+        // text is inert: the panel renders Avalonia text, never evaluates markup, so a stray
+        // <script> in agent output is characters on screen and nothing else.
+        var root = (StackPanel)MarkdownRenderer.Build("before\n\n<script>alert(1)</script>\n\nafter", Anchor);
+
+        string all = string.Concat(TextBlocks(root).Select(TextOf));
+        Assert.Contains("before", all, StringComparison.Ordinal);
+        Assert.Contains("after", all, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UnrecognizedFrontMatter_IsSkipped_WithoutCrashing()
+    {
+        var root = (StackPanel)MarkdownRenderer.Build("---\ntitle: something\n---\n\nbody text", Anchor);
+
+        string all = string.Concat(TextBlocks(root).Select(TextOf));
+        Assert.Contains("body text", all, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SoftWrapDamage_InTheSource_IsJustText()
+    {
+        // The grid reader hands the renderer already-joined logical lines; a very long paragraph
+        // must flow through the text wrapper, not be re-broken by the renderer.
+        var root = (StackPanel)MarkdownRenderer.Build(new string('x', 500), Anchor);
+
+        var paragraph = (SelectableTextBlock)root.Children[0];
+        Assert.Equal(500, TextOf(paragraph).Length);
+    }
+
+    [Fact]
+    public void CopyButton_ForwardsTheCodeText()
+    {
+        string? copied = null;
+        var root = (StackPanel)MarkdownRenderer.Build(
+            "```\nsome code\n```\n",
+            Anchor,
+            onCopyText: text => copied = text);
+
+        var button = (Button)Descendants(root).First(c => c is Button);
+        button.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+        Assert.Equal("some code", copied);
+    }
+}

--- a/tests/NovaTerminal.App.Tests/AgentOutput/RecentTailSanitizerTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/RecentTailSanitizerTests.cs
@@ -5,72 +5,49 @@ using Xunit;
 namespace NovaTerminal.Tests.AgentOutput;
 
 /// <summary>
-/// The snapshot sanitizer: prompt lines off both ends of a recent-tail snapshot, response text
-/// untouched. Every case maps to what the panel's user saw in practice - a PowerShell agent run
-/// whose tail was "PS D:\projects&gt;" and whose head was the echoed prompt+command.
+/// Snapshot extraction: a recent-output tail of a terminal is rounds of prompt → response all
+/// over the same grid, and the panel must render <b>the latest response</b> - prompt lines are
+/// segment boundaries, echoed commands are dropped with them, and the last segment with content
+/// wins.
 /// </summary>
 public sealed class RecentTailSanitizerTests
 {
+    /// <summary>A super-long agent chat, abridged: three rounds of prompt → response.</summary>
+    private const string LongChat = """
+        PS D:\projects> zcode -p "first question"
+        ### First answer
+        early content
+        PS D:\projects> zcode -p "second question"
+        ## Second answer
+        middle content with more detail
+        PS D:\projects> zcode -p "third question"
+        ### Third answer
+        latest content
+        PS D:\projects>
+        """;
+
     [Fact]
-    public void PowerShellPromptAndEcho_AreTrimmedFromBothEnds()
+    public void SuperLongChat_YieldsOnlyTheLatestResponse()
+    {
+        string response = RecentTailSanitizer.ExtractLastResponse(LongChat);
+
+        Assert.Equal("### Third answer\nlatest content", response);
+    }
+
+    [Fact]
+    public void SingleCommand_YieldsItsResponse()
     {
         const string snapshot = "PS D:\\projects> aichat \"cheat sheet\"\n### Text styles\nplain body\nWant this saved?\nPS D:\\projects>";
 
-        string trimmed = RecentTailSanitizer.Trim(snapshot);
-
-        Assert.Equal("### Text styles\nplain body\nWant this saved?", trimmed);
+        Assert.Equal("### Text styles\nplain body\nWant this saved?", RecentTailSanitizer.ExtractLastResponse(snapshot));
     }
 
     [Fact]
-    public void CmdPrompt_IsTrimmed()
+    public void ResponseWithBlankLines_KeepsThem()
     {
-        const string snapshot = "D:\\projects> agent.exe\n## Result\ndone\nD:\\projects>";
+        const string snapshot = "PS D:\\p> run\nfirst para\n\nsecond para\nPS D:\\p>";
 
-        Assert.Equal("## Result\ndone", RecentTailSanitizer.Trim(snapshot));
-    }
-
-    [Fact]
-    public void PosixPrompt_IsTrimmed()
-    {
-        const string snapshot = "user@host:~/demo$ llm \"hi\"\n**Hello!**\nuser@host:~/demo$";
-
-        Assert.Equal("**Hello!**", RecentTailSanitizer.Trim(snapshot));
-    }
-
-    [Fact]
-    public void BlankLinesAtTheEnds_GoWithThePrompts()
-    {
-        const string snapshot = "PS D:\\p> cmd\n\nbody line\n\n\nPS D:\\p>";
-
-        Assert.Equal("body line", RecentTailSanitizer.Trim(snapshot));
-    }
-
-    [Fact]
-    public void MidResponsePromptShapedLines_AreKept()
-    {
-        // Only the two ends are touched. A response that quotes a prompt mid-body keeps it -
-        // trimming content the agent actually printed would be lying about the response.
-        const string snapshot = "PS D:\\p> q\nanswer line\nimagine a prompt here > like this\nPS D:\\p>";
-
-        string trimmed = RecentTailSanitizer.Trim(snapshot);
-
-        Assert.Contains("imagine a prompt here > like this", trimmed, StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public void ResponseLinesEndingInDollar_AreKept()
-    {
-        const string snapshot = "PS D:\\p> price check\ncosts 5$\ntotal 10 euros\nPS D:\\p>";
-
-        string trimmed = RecentTailSanitizer.Trim(snapshot);
-
-        Assert.Contains("costs 5$", trimmed, StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public void AllPromptLines_TrimsToEmpty()
-    {
-        Assert.Equal(string.Empty, RecentTailSanitizer.Trim("PS D:\\p>\nPS D:\\p> dir\nPS D:\\p>"));
+        Assert.Equal("first para\n\nsecond para", RecentTailSanitizer.ExtractLastResponse(snapshot));
     }
 
     [Fact]
@@ -78,6 +55,43 @@ public sealed class RecentTailSanitizerTests
     {
         const string response = "## Answer\nwith detail";
 
-        Assert.Equal(response, RecentTailSanitizer.Trim(response));
+        Assert.Equal(response, RecentTailSanitizer.ExtractLastResponse(response));
+    }
+
+    [Fact]
+    public void PosixPrompt_SplitsToo()
+    {
+        const string snapshot = "user@host:~/demo$ llm \"hi\"\n**Hello!**\nuser@host:~/demo$ llm \"bye\"\n**Bye!**\nuser@host:~/demo$";
+
+        Assert.Equal("**Bye!**", RecentTailSanitizer.ExtractLastResponse(snapshot));
+    }
+
+    [Fact]
+    public void CmdPrompt_SplitsToo()
+    {
+        const string snapshot = "D:\\projects> agent.exe\n## Result\ndone\nD:\\projects> agent.exe --again\n## Result 2\nfine\nD:\\projects>";
+
+        Assert.Equal("## Result 2\nfine", RecentTailSanitizer.ExtractLastResponse(snapshot));
+    }
+
+    [Fact]
+    public void EmptySegments_AreSkipped()
+    {
+        // A trailing bare prompt is an empty segment; the response before it wins.
+        const string snapshot = "PS D:\\p> first\ncontent\nPS D:\\p>";
+
+        Assert.Equal("content", RecentTailSanitizer.ExtractLastResponse(snapshot));
+    }
+
+    [Fact]
+    public void AllPromptsAndBlanks_TrimsToEmpty()
+    {
+        Assert.Equal(string.Empty, RecentTailSanitizer.ExtractLastResponse("PS D:\\p>\nPS D:\\p> dir\nPS D:\\p>"));
+    }
+
+    [Fact]
+    public void Null_IsEmpty()
+    {
+        Assert.Equal(string.Empty, RecentTailSanitizer.ExtractLastResponse(null!));
     }
 }

--- a/tests/NovaTerminal.App.Tests/AgentOutput/RecentTailSanitizerTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/RecentTailSanitizerTests.cs
@@ -94,4 +94,53 @@ public sealed class RecentTailSanitizerTests
     {
         Assert.Equal(string.Empty, RecentTailSanitizer.ExtractLastResponse(null!));
     }
+
+    // ---------------------------------------------------------------- indentation normalization
+
+    [Fact]
+    public void IndentedExamples_AreDedentedOutsideFences()
+    {
+        // The exact shape from the field report: a markdown guide indents its examples under
+        // list items; 4-space indents would otherwise parse every example as a code block.
+        const string snapshot = "## Quote example\n\n    > Nested quote.\n    > — *Attribution*\n\n## Code example\n\n    ## Code\n    body text";
+
+        string normalized = RecentTailSanitizer.NormalizeIndentation(snapshot);
+
+        Assert.DoesNotContain("\n    >", normalized, StringComparison.Ordinal);
+        Assert.Contains("> Nested quote.", normalized, StringComparison.Ordinal);
+        Assert.Contains("## Code", normalized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FencedContent_KeepsItsIndentation()
+    {
+        const string snapshot = "```python\ndef greet(name):\n    return f\"Hi {name}\"\n```\n";
+
+        string normalized = RecentTailSanitizer.NormalizeIndentation(snapshot);
+
+        Assert.Contains("    return", normalized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnIndentedFence_Itself_IsDedentedAndToggles()
+    {
+        // A fence indented under a list item: the fence lines dedent (so it parses as a fence)
+        // while the code inside stays verbatim - code indentation is meaningful.
+        const string snapshot = "- item\n    ```js\n    const answer = 42;\n    ```\ndone";
+
+        string normalized = RecentTailSanitizer.NormalizeIndentation(snapshot);
+
+        Assert.Contains("```js\n    const answer = 42;\n```", normalized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DeepListNesting_IsFlattened()
+    {
+        // The accepted trade: 4-space list nesting is indistinguishable from an indented code
+        // block in a grid-derived tail, and the code-block reading is the one that spams raw
+        // markdown boxes - so deep nesting flattens.
+        const string snapshot = "- top\n  - nested\n    - deeper";
+
+        Assert.Equal("- top\n  - nested\n- deeper", RecentTailSanitizer.NormalizeIndentation(snapshot));
+    }
 }

--- a/tests/NovaTerminal.App.Tests/AgentOutput/RecentTailSanitizerTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/RecentTailSanitizerTests.cs
@@ -1,0 +1,83 @@
+using System;
+using NovaTerminal.AgentOutput;
+using Xunit;
+
+namespace NovaTerminal.Tests.AgentOutput;
+
+/// <summary>
+/// The snapshot sanitizer: prompt lines off both ends of a recent-tail snapshot, response text
+/// untouched. Every case maps to what the panel's user saw in practice - a PowerShell agent run
+/// whose tail was "PS D:\projects&gt;" and whose head was the echoed prompt+command.
+/// </summary>
+public sealed class RecentTailSanitizerTests
+{
+    [Fact]
+    public void PowerShellPromptAndEcho_AreTrimmedFromBothEnds()
+    {
+        const string snapshot = "PS D:\\projects> aichat \"cheat sheet\"\n### Text styles\nplain body\nWant this saved?\nPS D:\\projects>";
+
+        string trimmed = RecentTailSanitizer.Trim(snapshot);
+
+        Assert.Equal("### Text styles\nplain body\nWant this saved?", trimmed);
+    }
+
+    [Fact]
+    public void CmdPrompt_IsTrimmed()
+    {
+        const string snapshot = "D:\\projects> agent.exe\n## Result\ndone\nD:\\projects>";
+
+        Assert.Equal("## Result\ndone", RecentTailSanitizer.Trim(snapshot));
+    }
+
+    [Fact]
+    public void PosixPrompt_IsTrimmed()
+    {
+        const string snapshot = "user@host:~/demo$ llm \"hi\"\n**Hello!**\nuser@host:~/demo$";
+
+        Assert.Equal("**Hello!**", RecentTailSanitizer.Trim(snapshot));
+    }
+
+    [Fact]
+    public void BlankLinesAtTheEnds_GoWithThePrompts()
+    {
+        const string snapshot = "PS D:\\p> cmd\n\nbody line\n\n\nPS D:\\p>";
+
+        Assert.Equal("body line", RecentTailSanitizer.Trim(snapshot));
+    }
+
+    [Fact]
+    public void MidResponsePromptShapedLines_AreKept()
+    {
+        // Only the two ends are touched. A response that quotes a prompt mid-body keeps it -
+        // trimming content the agent actually printed would be lying about the response.
+        const string snapshot = "PS D:\\p> q\nanswer line\nimagine a prompt here > like this\nPS D:\\p>";
+
+        string trimmed = RecentTailSanitizer.Trim(snapshot);
+
+        Assert.Contains("imagine a prompt here > like this", trimmed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ResponseLinesEndingInDollar_AreKept()
+    {
+        const string snapshot = "PS D:\\p> price check\ncosts 5$\ntotal 10 euros\nPS D:\\p>";
+
+        string trimmed = RecentTailSanitizer.Trim(snapshot);
+
+        Assert.Contains("costs 5$", trimmed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AllPromptLines_TrimsToEmpty()
+    {
+        Assert.Equal(string.Empty, RecentTailSanitizer.Trim("PS D:\\p>\nPS D:\\p> dir\nPS D:\\p>"));
+    }
+
+    [Fact]
+    public void NoPromptsAtAll_IsReturnedUnchanged()
+    {
+        const string response = "## Answer\nwith detail";
+
+        Assert.Equal(response, RecentTailSanitizer.Trim(response));
+    }
+}

--- a/tests/NovaTerminal.App.Tests/Controls/PaneSubscriptionLifetimeTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneSubscriptionLifetimeTests.cs
@@ -145,7 +145,9 @@ public class PaneSubscriptionLifetimeTests
             "BackspaceObserved=1",
             "CommandAssistAnchorHintChanged=1",
             "DropNotice=1",
-            "EnterObserved=1",
+            // 2: the assist Enter accumulator plus the Agent Output markless region capture. Both
+            // construction-time pane-owned handlers; TermView dies with the pane.
+            "EnterObserved=2",
             "PasteObserved=1",
             "Ready=1",
             "ScrollStateChanged=1",

--- a/tests/NovaTerminal.VT.Tests/CommandOutputReaderBudgetTests.cs
+++ b/tests/NovaTerminal.VT.Tests/CommandOutputReaderBudgetTests.cs
@@ -1,0 +1,224 @@
+using System;
+using System.Linq;
+using NovaTerminal.VT;
+
+namespace NovaTerminal.VT.Tests;
+
+/// <summary>
+/// The budgeted and markless reads: <see cref="CommandOutputReader.TryReadOutputTail(TerminalBuffer, ShellIntegrationMark, in OutputTailBudget, out string)"/>
+/// and <see cref="CommandOutputReader.TryReadRecentTail(TerminalBuffer, out string)"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The default caps (40 logical lines / 8 KB) are sized for error recognition. The Agent Output
+/// panel reads a whole agent response through a larger budget, and sessions without shell
+/// integration have no <c>OSC 133;C</c> mark to bound the region at all - both paths share the
+/// marked read's walk, so the tests pin what matters about each: the budget is a hard cap applied
+/// before the string leaves the reader, the newest lines win, and the staleness rules (generation
+/// epoch, alt screen) hold unchanged.
+/// </para>
+/// <para>
+/// Driven through the real parser and write path, like <see cref="CommandOutputReaderTests"/>,
+/// because wrap flags and scrollback paging are produced there and nowhere else.
+/// </para>
+/// </remarks>
+public class CommandOutputReaderBudgetTests
+{
+    private const string PromptStart = "\x1b]133;A\x07";
+    private const string PromptEnd = "\x1b]133;B\x07";
+
+    private static string[] Lines(int count)
+        => Enumerable.Range(1, count).Select(i => $"line {i}").ToArray();
+
+    private sealed class Session
+    {
+        private ShellIntegrationMark? _commandLineMark;
+        private ShellIntegrationMark? _outputStart;
+
+        public Session(int cols = 40, int rows = 8, int? maxHistory = null)
+        {
+            Buffer = new TerminalBuffer(cols, rows);
+            if (maxHistory is int history)
+            {
+                Buffer.MaxHistory = history;
+            }
+
+            Parser = new AnsiParser(Buffer);
+            Parser.OnCommandStarted = mark => _commandLineMark = mark;
+        }
+
+        public TerminalBuffer Buffer { get; }
+
+        public AnsiParser Parser { get; }
+
+        public ShellIntegrationMark? OutputStart => _outputStart;
+
+        public Session Write(string data)
+        {
+            Parser.Process(data);
+            return this;
+        }
+
+        public Session Prompt(string text = "$ ") => Write(PromptStart + text + PromptEnd);
+
+        public Session Submit(string commandLine)
+        {
+            Write(commandLine);
+            Write("\x1b]133;C\x07");
+            _outputStart = CommandOutputReader.TryCaptureOutputStart(Buffer, _commandLineMark, out var start)
+                ? start
+                : null;
+            return this;
+        }
+
+        public Session Output(params string[] lines)
+            => Write("\r\n" + string.Join("\r\n", lines) + "\r\n");
+    }
+
+    // ---------------------------------------------------------------- budgeted marked read
+
+    [Fact]
+    public void TheDefaultBudget_ReadsExactlyWhatTheLegacyOverloadReads()
+    {
+        var s = new Session(maxHistory: 256)
+            .Prompt()
+            .Submit("noisy")
+            .Output(Lines(60));
+
+        Assert.True(CommandOutputReader.TryReadOutputTail(s.Buffer, s.OutputStart!.Value, out string legacy));
+        Assert.True(CommandOutputReader.TryReadOutputTail(
+            s.Buffer, s.OutputStart.Value, OutputTailBudget.Default, out string budgeted));
+
+        Assert.Equal(legacy, budgeted);
+        Assert.Equal(40, legacy.Split('\n').Length);
+    }
+
+    [Fact]
+    public void ALargerLineBudget_ReadsBeyondTheDefaultCap()
+    {
+        var s = new Session(maxHistory: 256)
+            .Prompt()
+            .Submit("noisy")
+            .Output(Lines(60));
+
+        var budget = new OutputTailBudget(MaxLines: 100, MaxChars: 64 * 1024, MaxRows: 512);
+        Assert.True(CommandOutputReader.TryReadOutputTail(s.Buffer, s.OutputStart!.Value, budget, out string tail));
+
+        string[] lines = tail.Split('\n');
+        Assert.Equal(60, lines.Length);
+        Assert.Equal("line 1", lines[0]);
+        Assert.Equal("line 60", lines[^1]);
+    }
+
+    [Fact]
+    public void ALineBudget_ClampsToTheRequestedLines_KeepingTheNewest()
+    {
+        var s = new Session(maxHistory: 256)
+            .Prompt()
+            .Submit("noisy")
+            .Output(Lines(100));
+
+        var budget = new OutputTailBudget(MaxLines: 10, MaxChars: 64 * 1024, MaxRows: 512);
+        Assert.True(CommandOutputReader.TryReadOutputTail(s.Buffer, s.OutputStart!.Value, budget, out string tail));
+
+        string[] lines = tail.Split('\n');
+        Assert.Equal(10, lines.Length);
+        Assert.Equal("line 91", lines[0]);
+        Assert.Equal("line 100", lines[^1]);
+    }
+
+    [Fact]
+    public void ACharBudget_ClampsHard_AndKeepsTheEnd()
+    {
+        var s = new Session()
+            .Prompt()
+            .Submit("dense")
+            .Output("aaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbb", "zzz");
+
+        var budget = new OutputTailBudget(MaxLines: 100, MaxChars: 10, MaxRows: 512);
+        Assert.True(CommandOutputReader.TryReadOutputTail(s.Buffer, s.OutputStart!.Value, budget, out string tail));
+
+        Assert.True(tail.Length <= 10, $"tail was {tail.Length} chars");
+        Assert.EndsWith("zzz", tail, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The budget changes the caps, not the staleness rules: a generation mismatch is still fatal,
+    /// because a larger budget reading someone else's rows would be worse than a smaller one.
+    /// </summary>
+    [Fact]
+    public void ABudgetedRead_AfterAScrollbackReset_IsStillRefused()
+    {
+        var s = new Session()
+            .Prompt()
+            .Submit("something")
+            .Output("real output");
+
+        s.Write("\x1b[3J\x1b[H");
+        s.Write("unrelated content that is now on the row the mark points at");
+
+        var budget = new OutputTailBudget(MaxLines: 100, MaxChars: 64 * 1024, MaxRows: 512);
+        Assert.False(CommandOutputReader.TryReadOutputTail(s.Buffer, s.OutputStart!.Value, budget, out _));
+    }
+
+    // ---------------------------------------------------------------- markless recent tail
+
+    [Fact]
+    public void RecentTail_WithoutAMark_ReturnsTheRowsAboveTheCursor_PromptIncluded()
+    {
+        // No Submit, no C capture - the markless shape. The honest answer is everything still on
+        // the grid above the cursor, prompt line included.
+        var s = new Session()
+            .Prompt()
+            .Output("first line", "second line");
+
+        Assert.Null(s.OutputStart);
+        Assert.True(CommandOutputReader.TryReadRecentTail(s.Buffer, out string tail));
+
+        // The prompt row's trailing space is dropped by the reader's trailing-blank trim.
+        Assert.Equal("$\nfirst line\nsecond line", tail);
+    }
+
+    [Fact]
+    public void RecentTail_RespectsTheBudget_KeepingTheNewest()
+    {
+        var s = new Session(maxHistory: 256)
+            .Prompt()
+            .Output(Lines(50));
+
+        var budget = new OutputTailBudget(MaxLines: 5, MaxChars: 64 * 1024, MaxRows: 512);
+        Assert.True(CommandOutputReader.TryReadRecentTail(s.Buffer, budget, out string tail));
+
+        string[] lines = tail.Split('\n');
+        Assert.Equal(5, lines.Length);
+        Assert.Equal("line 46", lines[0]);
+        Assert.Equal("line 50", lines[^1]);
+    }
+
+    [Fact]
+    public void RecentTail_WhileTheAltScreenIsActive_IsRefused()
+    {
+        var s = new Session()
+            .Prompt()
+            .Output("some output");
+
+        s.Write("\x1b[?1049h");
+
+        Assert.False(CommandOutputReader.TryReadRecentTail(s.Buffer, out _));
+    }
+
+    [Fact]
+    public void RecentTail_JoinsSoftWrappedRowsLikeTheMarkedRead()
+    {
+        // One logical line wider than the pane (40 cols), wrapped by the terminal. The join is
+        // what keeps a wrapped paragraph parseable as one markdown line - a contiguous match of
+        // the full 90-char string proves the wrapped halves were rejoined.
+        var longLine = new string('x', 90);
+        var s = new Session()
+            .Prompt()
+            .Output(longLine);
+
+        Assert.True(CommandOutputReader.TryReadRecentTail(s.Buffer, out string tail));
+        Assert.Contains(longLine, tail, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a per-pane, manually toggled **Agent Output** side panel that live-renders the current command's output region as formatted markdown, aimed at AI agent CLIs that print raw markdown into the terminal
- The panel *reads* the grid; the VT parser/renderer and terminal core are untouched (additive `CommandOutputReader` overloads only — budgeted reads plus a markless `TryReadRecentTail` fallback, default behavior unchanged)
- New `NovaTerminal.App/AgentOutput` subsystem: debounced region tracker (OSC 133;C mark when shell integration is present, Enter-time heuristic fallback otherwise), Markdig-to-Avalonia renderer (headings, code blocks with copy buttons, lists, tables, task lists, links), panel view and view model
- Terminal pane wiring: hover-revealed `MD` toggle (context menu is unreachable on local panes), side column next to the SFTP sidebar, auto-hide in alt-screen/TUI mode, session-reset and dispose wiring

## Security
- Link targets are scheme-allowlisted (http/https/mailto only) before opening via Avalonia's launcher — a crafted `[label](C:\...\tool.exe)` in agent output cannot launch a binary (found by Mimosa scan; rescan of this branch shows no findings in the new code)

## Test Plan
- [x] `NovaTerminal.VT.Tests` — 412 passed (incl. 13 new budget/markless reader tests)
- [x] `NovaTerminal.Architecture.Tests` — 56 passed (layering guards hold)
- [x] `NovaTerminal.App.Tests` CommandAssist — 1267 passed; Controls — 190 passed (incl. subscription-lifetime expected-set update for the new construction-time `EnterObserved` handler)
- [x] `NovaTerminal.App.Tests` AgentOutput — 44 passed (tracker debounce/refusals, renderer block subset + raw-HTML inertness, view model, panel view, link allowlist)
- [ ] Manual: toggle `MD` in a pane, run an agent CLI that emits raw markdown, watch the panel stream; verify it hides during a fullscreen TUI and restores after