### PR TITLE
fix(pty): default unix sessions to the user's login shell

### DIFF
--- a/src/NovaTerminal.App/Shell/TerminalSettings.cs
+++ b/src/NovaTerminal.App/Shell/TerminalSettings.cs
@@ -215,30 +215,55 @@ namespace NovaTerminal.Shell
         /// </remarks>
         internal static System.Collections.Generic.List<TerminalProfile> GetDefaultProfiles(
             Func<string, bool> commandExists)
+            => GetDefaultProfiles(DefaultProfileCandidates(), commandExists);
+
+        /// <summary>The first-run candidates for this platform. On Unix the detected login
+        /// shell leads, so <c>DefaultProfileId</c> lands on the shell the user actually uses
+        /// rather than whichever fixed entry happens to exist.</summary>
+        private static (string Name, string Command)[] DefaultProfileCandidates() => OperatingSystem.IsWindows()
+            ? new[]
+            {
+                ("Command Prompt", "cmd.exe"),
+                ("PowerShell", "pwsh.exe"),
+                ("Windows PowerShell", "powershell.exe"),
+            }
+            : UnixProfileCandidates(ShellHelper.GetDefaultShell());
+
+        /// <summary>
+        /// The Unix first-run candidates: the login shell, then the fixed trio. A login shell
+        /// that collides with the trio (a zsh user's <c>/bin/zsh</c>) is dropped by the dedup
+        /// in the profile builder, not here — this stays a plain list so callers can see what
+        /// was offered.
+        /// </summary>
+        internal static (string Name, string Command)[] UnixProfileCandidates(string loginShell)
+            => new[]
+            {
+                ("Default Shell", loginShell),
+                ("Bash", "/bin/bash"),
+                ("Zsh", "/bin/zsh"),
+                ("Shell", "/bin/sh"),
+            };
+
+        /// <summary>
+        /// Filters <paramref name="candidates"/> down to the shells that are installed,
+        /// dropping a command that an earlier candidate already added.
+        /// </summary>
+        internal static System.Collections.Generic.List<TerminalProfile> GetDefaultProfiles(
+            (string Name, string Command)[] candidates,
+            Func<string, bool> commandExists)
         {
             ArgumentNullException.ThrowIfNull(commandExists);
 
-            (string Name, string Command)[] candidates = OperatingSystem.IsWindows()
-                ? new[]
-                {
-                    ("Command Prompt", "cmd.exe"),
-                    ("PowerShell", "pwsh.exe"),
-                    ("Windows PowerShell", "powershell.exe"),
-                }
-                : new[]
-                {
-                    ("Bash", "/bin/bash"),
-                    ("Zsh", "/bin/zsh"),
-                    ("Shell", "/bin/sh"),
-                };
-
             var profiles = new System.Collections.Generic.List<TerminalProfile>();
+            var addedCommands = new System.Collections.Generic.HashSet<string>(System.StringComparer.Ordinal);
             foreach ((string name, string command) in candidates)
             {
-                if (commandExists(command))
+                if (!commandExists(command) || !addedCommands.Add(command))
                 {
-                    profiles.Add(new TerminalProfile { Name = name, Command = command });
+                    continue;
                 }
+
+                profiles.Add(new TerminalProfile { Name = name, Command = command });
             }
 
             if (profiles.Count == 0)

--- a/src/NovaTerminal.App/Shell/TerminalSettings.cs
+++ b/src/NovaTerminal.App/Shell/TerminalSettings.cs
@@ -217,33 +217,6 @@ namespace NovaTerminal.Shell
             Func<string, bool> commandExists)
             => GetDefaultProfiles(DefaultProfileCandidates(), commandExists);
 
-        /// <summary>The first-run candidates for this platform. On Unix the detected login
-        /// shell leads, so <c>DefaultProfileId</c> lands on the shell the user actually uses
-        /// rather than whichever fixed entry happens to exist.</summary>
-        private static (string Name, string Command)[] DefaultProfileCandidates() => OperatingSystem.IsWindows()
-            ? new[]
-            {
-                ("Command Prompt", "cmd.exe"),
-                ("PowerShell", "pwsh.exe"),
-                ("Windows PowerShell", "powershell.exe"),
-            }
-            : UnixProfileCandidates(ShellHelper.GetDefaultShell());
-
-        /// <summary>
-        /// The Unix first-run candidates: the login shell, then the fixed trio. A login shell
-        /// that collides with the trio (a zsh user's <c>/bin/zsh</c>) is dropped by the dedup
-        /// in the profile builder, not here — this stays a plain list so callers can see what
-        /// was offered.
-        /// </summary>
-        internal static (string Name, string Command)[] UnixProfileCandidates(string loginShell)
-            => new[]
-            {
-                ("Default Shell", loginShell),
-                ("Bash", "/bin/bash"),
-                ("Zsh", "/bin/zsh"),
-                ("Shell", "/bin/sh"),
-            };
-
         /// <summary>
         /// Filters <paramref name="candidates"/> down to the shells that are installed,
         /// dropping a command that an earlier candidate already added.
@@ -280,6 +253,33 @@ namespace NovaTerminal.Shell
 
             return profiles;
         }
+
+        /// <summary>The first-run candidates for this platform. On Unix the detected login
+        /// shell leads, so <c>DefaultProfileId</c> lands on the shell the user actually uses
+        /// rather than whichever fixed entry happens to exist.</summary>
+        private static (string Name, string Command)[] DefaultProfileCandidates() => OperatingSystem.IsWindows()
+            ? new[]
+            {
+                ("Command Prompt", "cmd.exe"),
+                ("PowerShell", "pwsh.exe"),
+                ("Windows PowerShell", "powershell.exe"),
+            }
+            : UnixProfileCandidates(ShellHelper.GetDefaultShell());
+
+        /// <summary>
+        /// The Unix first-run candidates: the login shell, then the fixed trio. A login shell
+        /// that collides with the trio (a zsh user's <c>/bin/zsh</c>) is dropped by the dedup
+        /// in the profile builder, not here — this stays a plain list so callers can see what
+        /// was offered.
+        /// </summary>
+        internal static (string Name, string Command)[] UnixProfileCandidates(string loginShell)
+            => new[]
+            {
+                ("Default Shell", loginShell),
+                ("Bash", "/bin/bash"),
+                ("Zsh", "/bin/zsh"),
+                ("Shell", "/bin/sh"),
+            };
 
         private static bool CommandIsInstalled(string command)
             => OperatingSystem.IsWindows()

--- a/src/NovaTerminal.Pty/ShellHelper.cs
+++ b/src/NovaTerminal.Pty/ShellHelper.cs
@@ -26,7 +26,7 @@ namespace NovaTerminal.Pty
 
             return GetUnixDefaultShell(
                 Environment.GetEnvironmentVariable,
-                File.Exists,
+                IsLaunchableShell,
                 ReadLoginShellFromPasswd);
         }
 
@@ -45,25 +45,33 @@ namespace NovaTerminal.Pty
         /// mostly answers Linux. The old zsh/bash/sh probe stays as the floor so a machine
         /// where neither source answers behaves exactly as before.
         ///
-        /// Every answer is probed with <paramref name="fileExists"/> before being trusted: a
+        /// Every answer is probed with <paramref name="isLaunchable"/> before being trusted: a
         /// $SHELL left pointing at a since-uninstalled shell (brew remove, chsh followed by
         /// deletion) must fall through, not be handed to CreateProcess as a guaranteed
-        /// launch. It is the same conservatism as <see cref="ResolveExecutableOrDefault"/>:
-        /// a shell we resolve is a shell we vouch for.
+        /// launch, and neither may a file this account cannot actually execute (see
+        /// <see cref="IsLaunchableShell"/>). It is the same conservatism as
+        /// <see cref="ResolveExecutableOrDefault"/>: a shell we resolve is a shell we vouch for.
+        ///
+        /// The passwd step is a plain /etc/passwd read, so accounts served only through NSS
+        /// (SSSD, LDAP, Active Directory) are invisible to it. Those sessions normally carry
+        /// $SHELL from the login environment; when they do not, the floor below degrades to
+        /// exactly the pre-login-shell behaviour rather than to something new. Deriving the
+        /// answer through getpwuid instead would need a libc P/Invoke, which this cold a
+        /// path is deliberately not paying for.
         /// </remarks>
         internal static string GetUnixDefaultShell(
             Func<string, string?> getEnvironmentVariable,
-            Func<string, bool> fileExists,
+            Func<string, bool> isLaunchable,
             Func<string?> readLoginShellFromPasswd)
         {
             string? fromEnvironment = getEnvironmentVariable("SHELL");
-            if (!string.IsNullOrWhiteSpace(fromEnvironment) && fileExists(fromEnvironment))
+            if (!string.IsNullOrWhiteSpace(fromEnvironment) && isLaunchable(fromEnvironment))
             {
                 return fromEnvironment;
             }
 
             string? fromPasswd = readLoginShellFromPasswd();
-            if (!string.IsNullOrWhiteSpace(fromPasswd) && fileExists(fromPasswd))
+            if (!string.IsNullOrWhiteSpace(fromPasswd) && isLaunchable(fromPasswd))
             {
                 return fromPasswd;
             }
@@ -71,10 +79,41 @@ namespace NovaTerminal.Pty
             string[] shells = { "/bin/zsh", "/bin/bash", "/bin/sh" };
             foreach (var shell in shells)
             {
-                if (fileExists(shell)) return shell;
+                if (isLaunchable(shell)) return shell;
             }
             return "/bin/sh";
         }
+
+        /// <summary>
+        /// True when <paramref name="path"/> exists and, on Unix, carries an execute bit.
+        /// </summary>
+        /// <remarks>
+        /// File.Exists alone accepts a file whose mode has no x bit, and the PTY's exec then
+        /// fails with EACCES — the exact dead pane this resolution chain exists to avoid
+        /// handing out. Unreadable mode metadata is trusted as before rather than rejected:
+        /// a stat that fails is not evidence that the shell is broken.
+        /// </remarks>
+        internal static bool IsLaunchableShell(string path)
+        {
+            if (!File.Exists(path)) return false;
+            if (OperatingSystem.IsWindows()) return true;
+
+            try
+            {
+                return HasAnyExecuteBit(File.GetUnixFileMode(path));
+            }
+            catch
+            {
+                // Best effort: a platform without mode metadata, or a lost race with the
+                // file's removal, falls back to the existence verdict.
+                return true;
+            }
+        }
+
+        internal static bool HasAnyExecuteBit(UnixFileMode mode)
+            => mode.HasFlag(UnixFileMode.UserExecute)
+                || mode.HasFlag(UnixFileMode.GroupExecute)
+                || mode.HasFlag(UnixFileMode.OtherExecute);
 
         private static string? ReadLoginShellFromPasswd()
         {

--- a/src/NovaTerminal.Pty/ShellHelper.cs
+++ b/src/NovaTerminal.Pty/ShellHelper.cs
@@ -6,6 +6,12 @@ namespace NovaTerminal.Pty
 {
     public static class ShellHelper
     {
+        /// <summary>
+        /// This platform's shell for every "the user did not name one" path: new profiles,
+        /// blank configured commands, session restore of a command written for another OS.
+        /// On Unix that is the user's actual login shell — environment first, then the passwd
+        /// database — not a preference order between whichever shells happen to be installed.
+        /// </summary>
         public static string GetDefaultShell()
         {
             if (OperatingSystem.IsWindows())
@@ -17,15 +23,98 @@ namespace NovaTerminal.Pty
                 }
                 return "cmd.exe";
             }
-            else
+
+            return GetUnixDefaultShell(
+                Environment.GetEnvironmentVariable,
+                File.Exists,
+                ReadLoginShellFromPasswd);
+        }
+
+        /// <summary>
+        /// The Unix half of <see cref="GetDefaultShell"/>, as a resolution chain: $SHELL,
+        /// then the passwd entry for the current user, then the old existence probe as the
+        /// floor. The delegates exist so the chain is testable from any platform; production
+        /// passes the real environment, filesystem and passwd reader.
+        /// </summary>
+        /// <remarks>
+        /// $SHELL leads because it is what launchd sets from the login shell for GUI
+        /// applications on macOS and what the desktop session sets on most Linux distros —
+        /// the one place the login shell is already answered without re-deriving it. The
+        /// passwd lookup covers the sessions that never got a $SHELL; macOS GUI users are
+        /// absent from /etc/passwd (Directory Services owns them), so in practice that step
+        /// mostly answers Linux. The old zsh/bash/sh probe stays as the floor so a machine
+        /// where neither source answers behaves exactly as before.
+        ///
+        /// Every answer is probed with <paramref name="fileExists"/> before being trusted: a
+        /// $SHELL left pointing at a since-uninstalled shell (brew remove, chsh followed by
+        /// deletion) must fall through, not be handed to CreateProcess as a guaranteed
+        /// launch. It is the same conservatism as <see cref="ResolveExecutableOrDefault"/>:
+        /// a shell we resolve is a shell we vouch for.
+        /// </remarks>
+        internal static string GetUnixDefaultShell(
+            Func<string, string?> getEnvironmentVariable,
+            Func<string, bool> fileExists,
+            Func<string?> readLoginShellFromPasswd)
+        {
+            string? fromEnvironment = getEnvironmentVariable("SHELL");
+            if (!string.IsNullOrWhiteSpace(fromEnvironment) && fileExists(fromEnvironment))
             {
-                string[] shells = { "/bin/zsh", "/bin/bash", "/bin/sh" };
-                foreach (var shell in shells)
-                {
-                    if (File.Exists(shell)) return shell;
-                }
-                return "/bin/sh";
+                return fromEnvironment;
             }
+
+            string? fromPasswd = readLoginShellFromPasswd();
+            if (!string.IsNullOrWhiteSpace(fromPasswd) && fileExists(fromPasswd))
+            {
+                return fromPasswd;
+            }
+
+            string[] shells = { "/bin/zsh", "/bin/bash", "/bin/sh" };
+            foreach (var shell in shells)
+            {
+                if (fileExists(shell)) return shell;
+            }
+            return "/bin/sh";
+        }
+
+        private static string? ReadLoginShellFromPasswd()
+        {
+            try
+            {
+                return ParseLoginShellFromPasswd(File.ReadAllLines("/etc/passwd"), Environment.UserName);
+            }
+            catch
+            {
+                // Unreadable is an expected shape, not a failure: macOS keeps its users in
+                // Directory Services, and there is nothing to answer with. The floor probe
+                // in GetUnixDefaultShell takes it from here.
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// The login shell (the seventh passwd field) for <paramref name="username"/>, or
+        /// null when the file has no usable entry for that user.
+        /// </summary>
+        /// <remarks>
+        /// Matched on the user name rather than the uid: the uid would need a getpwuid
+        /// P/Invoke, and .NET already resolved <see cref="Environment.UserName"/> from the
+        /// same account database the passwd file was generated from.
+        /// </remarks>
+        internal static string? ParseLoginShellFromPasswd(string[] lines, string? username)
+        {
+            if (string.IsNullOrWhiteSpace(username)) return null;
+
+            foreach (string line in lines)
+            {
+                string[] fields = line.Split(':');
+                if (fields.Length >= 7 &&
+                    string.Equals(fields[0], username, StringComparison.Ordinal))
+                {
+                    return fields[6];
+                }
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/src/NovaTerminal.Pty/ShellHelper.cs
+++ b/src/NovaTerminal.Pty/ShellHelper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace NovaTerminal.Pty
 {
@@ -85,35 +86,52 @@ namespace NovaTerminal.Pty
         }
 
         /// <summary>
-        /// True when <paramref name="path"/> exists and, on Unix, carries an execute bit.
+        /// True when <paramref name="path"/> exists and this account can execute it.
         /// </summary>
         /// <remarks>
-        /// File.Exists alone accepts a file whose mode has no x bit, and the PTY's exec then
-        /// fails with EACCES — the exact dead pane this resolution chain exists to avoid
-        /// handing out. Unreadable mode metadata is trusted as before rather than rejected:
-        /// a stat that fails is not evidence that the shell is broken.
+        /// File.Exists alone accepts a file whose mode has no x bit at all, and even an
+        /// execute-bit check accepts a bit from a permission class that does not apply to
+        /// this process - owner-only exec on a file the account does not own fails with
+        /// EACCES all the same. So on Unix the verdict is <c>access(X_OK)</c>, which asks
+        /// exactly the kernel's question for this uid and gid. That call is the primary
+        /// probe, not the only tier: libc missing or unanswerable degrades to the mode
+        /// heuristic, and unreadable mode metadata degrades further to the existence
+        /// verdict. The PTY spawn remains the final arbiter either way.
         /// </remarks>
         internal static bool IsLaunchableShell(string path)
+            => IsLaunchableShell(path, ExecProbeAnswersExecutable);
+
+        internal static bool IsLaunchableShell(string path, Func<string, bool> execProbe)
         {
             if (!File.Exists(path)) return false;
             if (OperatingSystem.IsWindows()) return true;
 
             try
             {
-                return HasAnyExecuteBit(File.GetUnixFileMode(path));
+                return execProbe(path);
             }
             catch
             {
-                // Best effort: a platform without mode metadata, or a lost race with the
-                // file's removal, falls back to the existence verdict.
-                return true;
+                // The native probe cannot answer on this platform. Fall back to the mode
+                // heuristic; if even the mode is unreadable, trust the existence verdict.
+                try { return HasAnyExecuteBit(File.GetUnixFileMode(path)); }
+                catch { return true; }
             }
         }
 
+        /// <summary>A mode heuristic, used only when <c>access</c> cannot answer.</summary>
         internal static bool HasAnyExecuteBit(UnixFileMode mode)
             => mode.HasFlag(UnixFileMode.UserExecute)
                 || mode.HasFlag(UnixFileMode.GroupExecute)
                 || mode.HasFlag(UnixFileMode.OtherExecute);
+
+        private static bool ExecProbeAnswersExecutable(string path)
+            => access(path, X_OK) == 0;
+
+        private const int X_OK = 1;
+
+        [DllImport("libc")]
+        private static extern int access([MarshalAs(UnmanagedType.LPUTF8Str)] string pathname, int mode);
 
         private static string? ReadLoginShellFromPasswd()
         {

--- a/tests/NovaTerminal.App.Tests/Core/DefaultShellResolutionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/DefaultShellResolutionTests.cs
@@ -239,4 +239,55 @@ public sealed class DefaultShellResolutionTests
             try { File.Delete(path); } catch { /* best effort */ }
         }
     }
+
+    // access(X_OK) is the primary probe because a bit from a permission class that does not
+    // apply to this process (owner-only exec on a file we do not own) still ends in EACCES.
+    // The seam tests pin the tiers without needing a mis-permissioned file.
+    [Fact]
+    public void IsLaunchableShell_ProbeDenies_IsRejected()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Skip("The probe is only consulted on Unix.");
+        }
+
+        string path = Path.Combine(Path.GetTempPath(), "nova probe denied " + Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            File.WriteAllText(path, "");
+            // Owner-exec bits set, but the kernel-level probe says no anyway.
+            File.SetUnixFileMode(path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+            Assert.False(ShellHelper.IsLaunchableShell(path, _ => false));
+        }
+        finally
+        {
+            try { File.Delete(path); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void IsLaunchableShell_ProbeUnavailable_FallsBackToTheModeHeuristic()
+    {
+        string path = Path.Combine(Path.GetTempPath(), "nova probe blind " + Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            File.WriteAllText(path, "");
+            if (!OperatingSystem.IsWindows())
+            {
+                File.SetUnixFileMode(path,
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            }
+
+            Assert.True(ShellHelper.IsLaunchableShell(
+                path, _ => throw new InvalidOperationException("no libc here")));
+        }
+        finally
+        {
+            try { File.Delete(path); } catch { /* best effort */ }
+        }
+    }
 }

--- a/tests/NovaTerminal.App.Tests/Core/DefaultShellResolutionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/DefaultShellResolutionTests.cs
@@ -164,4 +164,79 @@ public sealed class DefaultShellResolutionTests
 
         Assert.Null(ShellHelper.ParseLoginShellFromPasswd(lines, "user"));
     }
+
+    // --- IsLaunchableShell: existence plus, on Unix, an execute bit. A mode-0644 $SHELL
+    // used to pass the probe and then fail the PTY's exec with EACCES. ---
+
+    [Theory]
+    [InlineData(UnixFileMode.UserExecute)]
+    [InlineData(UnixFileMode.GroupExecute)]
+    [InlineData(UnixFileMode.OtherExecute)]
+    [InlineData(UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupExecute)]
+    public void HasAnyExecuteBit_AnyExecuteBitQualifies(UnixFileMode mode)
+    {
+        Assert.True(ShellHelper.HasAnyExecuteBit(mode));
+    }
+
+    [Theory]
+    [InlineData(UnixFileMode.None)]
+    [InlineData(UnixFileMode.UserRead | UnixFileMode.UserWrite)]
+    [InlineData(UnixFileMode.UserRead | UnixFileMode.GroupRead | UnixFileMode.OtherRead)]
+    public void HasAnyExecuteBit_ReadAndWriteAloneDoNotQualify(UnixFileMode mode)
+    {
+        Assert.False(ShellHelper.HasAnyExecuteBit(mode));
+    }
+
+    [Fact]
+    public void IsLaunchableShell_MissingFile_IsRejected()
+    {
+        Assert.False(ShellHelper.IsLaunchableShell(
+            Path.Combine(Path.GetTempPath(), "nova missing shell " + Guid.NewGuid().ToString("N"))));
+    }
+
+    [Fact]
+    public void IsLaunchableShell_ExecutableFile_IsAccepted()
+    {
+        string path = Path.Combine(Path.GetTempPath(), "nova launchable " + Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            File.WriteAllText(path, "");
+            if (!OperatingSystem.IsWindows())
+            {
+                // Temp files arrive 0644 on Unix; hand the owner the x bit being asserted on.
+                File.SetUnixFileMode(path,
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            }
+
+            Assert.True(ShellHelper.IsLaunchableShell(path));
+        }
+        finally
+        {
+            try { File.Delete(path); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void IsLaunchableShell_UnixFileWithoutExecuteBit_IsRejected()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Skip("Execute bits are a Unix fact; Windows accepts any existing file.");
+        }
+
+        // A fresh temp file is born 0644 on Unix, which is exactly the shape being rejected.
+        string path = Path.Combine(Path.GetTempPath(), "nova not executable " + Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            File.WriteAllText(path, "");
+
+            Assert.False(ShellHelper.IsLaunchableShell(path));
+        }
+        finally
+        {
+            try { File.Delete(path); } catch { /* best effort */ }
+        }
+    }
 }

--- a/tests/NovaTerminal.App.Tests/Core/DefaultShellResolutionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/DefaultShellResolutionTests.cs
@@ -1,0 +1,167 @@
+using NovaTerminal.Pty;
+using Xunit;
+
+namespace NovaTerminal.Tests.Core;
+
+/// <summary>
+/// Covers the Unix half of <see cref="ShellHelper.GetDefaultShell"/>, which used to answer
+/// from a hardcoded zsh/bash/sh preference order and so opened zsh for a bash user whose
+/// machine happened to have zsh installed. It now resolves the user's actual login shell:
+/// $SHELL first, then the passwd entry, with the old probe kept only as the floor.
+/// </summary>
+/// <remarks>
+/// The chain takes its environment, filesystem and passwd reads as delegates, so these run
+/// identically on every platform — nothing here touches the real ones. Windows's half of
+/// GetDefaultShell is untouched and covered by the runnable-shell smoke test.
+/// </remarks>
+public sealed class DefaultShellResolutionTests
+{
+    private static Func<string, string?> EnvironmentWith(string? value) => _ => value;
+
+    /// <summary>Only <paramref name="existing"/> passes the existence probe.</summary>
+    private static Func<string, bool> OnlyExists(string existing) => path => path == existing;
+
+    [Fact]
+    public void EnvironmentShell_Wins_WhenItExists()
+    {
+        // The whole point: a fish user gets fish, not the first entry of a fixed list.
+        string shell = ShellHelper.GetUnixDefaultShell(
+            EnvironmentWith("/usr/bin/fish"),
+            OnlyExists("/usr/bin/fish"),
+            () => "/bin/bash");
+
+        Assert.Equal("/usr/bin/fish", shell);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BlankEnvironmentShell_IsTreatedAsUnset(string? shell)
+    {
+        Assert.Equal(
+            "/bin/bash",
+            ShellHelper.GetUnixDefaultShell(EnvironmentWith(shell), OnlyExists("/bin/bash"), () => "/bin/bash"));
+    }
+
+    // A $SHELL left pointing at a since-removed shell must fall through, not be handed to
+    // the launcher as launchable.
+    [Fact]
+    public void StaleEnvironmentShell_FallsThroughToThePasswdAnswer()
+    {
+        string shell = ShellHelper.GetUnixDefaultShell(
+            EnvironmentWith("/opt/homebrew/bin/fish"),
+            path => path == "/usr/bin/fish",
+            () => "/usr/bin/fish");
+
+        Assert.Equal("/usr/bin/fish", shell);
+    }
+
+    [Fact]
+    public void Passwd_Answers_WhenTheEnvironmentHasNoShell()
+    {
+        string shell = ShellHelper.GetUnixDefaultShell(
+            EnvironmentWith(null),
+            OnlyExists("/usr/bin/fish"),
+            () => "/usr/bin/fish");
+
+        Assert.Equal("/usr/bin/fish", shell);
+    }
+
+    [Fact]
+    public void StalePasswdShell_FallsThroughToTheFloorProbe()
+    {
+        string shell = ShellHelper.GetUnixDefaultShell(
+            EnvironmentWith(null),
+            OnlyExists("/bin/zsh"),
+            () => "/opt/gone-from-disk/shell");
+
+        Assert.Equal("/bin/zsh", shell);
+    }
+
+    // The floor is the old behaviour, byte for byte: zsh, bash, then sh.
+    [Fact]
+    public void NothingAnswersAnywhere_FallsToBinSh()
+    {
+        string shell = ShellHelper.GetUnixDefaultShell(
+            EnvironmentWith(null),
+            _ => false,
+            () => null);
+
+        Assert.Equal("/bin/sh", shell);
+    }
+
+    [Fact]
+    public void FloorProbe_KeepsTheOldPreferenceOrder()
+    {
+        string shell = ShellHelper.GetUnixDefaultShell(
+            EnvironmentWith(null),
+            path => path == "/bin/bash",
+            () => null);
+
+        Assert.Equal("/bin/bash", shell);
+    }
+
+    [Fact]
+    public void ProductionChain_StillResolvesARunnableShell()
+    {
+        // Pins that the production delegates stay wired: a real environment, real filesystem.
+        Assert.False(string.IsNullOrWhiteSpace(ShellHelper.GetDefaultShell()));
+    }
+
+    // --- ParseLoginShellFromPasswd: the pure half of the passwd lookup. ---
+
+    [Fact]
+    public void ParseLoginShell_ReturnsTheSeventhField_OfTheMatchingUser()
+    {
+        string[] lines =
+        {
+            "root:x:0:0:root:/root:/bin/bash",
+            "svc:x:1000:1000:Service:/home/svc:/usr/sbin/nologin",
+        };
+
+        Assert.Equal("/usr/sbin/nologin", ShellHelper.ParseLoginShellFromPasswd(lines, "svc"));
+    }
+
+    [Fact]
+    public void ParseLoginShell_UnknownUser_ReturnsNull()
+    {
+        string[] lines = { "root:x:0:0:root:/root:/bin/bash" };
+
+        Assert.Null(ShellHelper.ParseLoginShellFromPasswd(lines, "nobody-here"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ParseLoginShell_BlankUsername_ReturnsNull(string? username)
+    {
+        string[] lines = { "root:x:0:0:root:/root:/bin/bash" };
+
+        Assert.Null(ShellHelper.ParseLoginShellFromPasswd(lines, username));
+    }
+
+    // passwd carries historical noise - comments, and NIS entries that are not real users.
+    // A line that does not parse must be skipped, never crash the lookup.
+    [Theory]
+    [InlineData("# a comment")]
+    [InlineData("+@somegroup")]
+    [InlineData("no-colons-here")]
+    [InlineData("")]
+    public void ParseLoginShell_MalformedLines_AreSkipped(string noise)
+    {
+        string[] lines = { noise, "user:x:1000:1000::/home/user:/usr/bin/fish" };
+
+        Assert.Equal("/usr/bin/fish", ShellHelper.ParseLoginShellFromPasswd(lines, "user"));
+    }
+
+    // A user line with too few fields is not a usable entry either.
+    [Fact]
+    public void ParseLoginShell_TruncatedEntry_IsSkipped()
+    {
+        string[] lines = { "user:x:1000" };
+
+        Assert.Null(ShellHelper.ParseLoginShellFromPasswd(lines, "user"));
+    }
+}

--- a/tests/NovaTerminal.App.Tests/Shell/DefaultProfileAvailabilityTests.cs
+++ b/tests/NovaTerminal.App.Tests/Shell/DefaultProfileAvailabilityTests.cs
@@ -62,4 +62,57 @@ public sealed class DefaultProfileAvailabilityTests
         Assert.DoesNotContain("PowerShell", probed);
         Assert.All(probed, c => Assert.False(string.IsNullOrWhiteSpace(c)));
     }
+
+    // --- The Unix candidates: the login shell leads, and must not duplicate the trio. ---
+
+    [Fact]
+    public void UnixCandidates_LeadWithTheLoginShell_WhenItIsNotOneOfTheFixedEntries()
+    {
+        List<TerminalProfile> profiles = TerminalSettings.GetDefaultProfiles(
+            TerminalSettings.UnixProfileCandidates("/usr/bin/fish"),
+            commandExists: _ => true);
+
+        // DefaultProfileId is Profiles[0].Id, so leading with the login shell is what makes
+        // first run open the shell the user actually uses.
+        Assert.Equal("Default Shell", profiles[0].Name);
+        Assert.Equal("/usr/bin/fish", profiles[0].Command);
+        Assert.Equal(4, profiles.Count);
+        Assert.Equal(4, profiles.Select(p => p.Command).Distinct().Count());
+    }
+
+    [Fact]
+    public void UnixCandidates_LoginShellAmongTheFixedEntries_IsNotDuplicated()
+    {
+        List<TerminalProfile> profiles = TerminalSettings.GetDefaultProfiles(
+            TerminalSettings.UnixProfileCandidates("/bin/bash"),
+            commandExists: _ => true);
+
+        Assert.Equal("Default Shell", profiles[0].Name);
+        Assert.Single(profiles, p => p.Command == "/bin/bash");
+        Assert.Equal(3, profiles.Count);
+    }
+
+    [Fact]
+    public void UnixCandidates_ExistenceFilterStillApplies()
+    {
+        List<TerminalProfile> profiles = TerminalSettings.GetDefaultProfiles(
+            TerminalSettings.UnixProfileCandidates("/usr/bin/fish"),
+            commandExists: command => command != "/bin/zsh");
+
+        Assert.DoesNotContain(profiles, p => p.Command == "/bin/zsh");
+        Assert.Equal(3, profiles.Count);
+    }
+
+    [Fact]
+    public void UnixCandidates_NothingInstalled_FallsToTheGuaranteedFloor()
+    {
+        List<TerminalProfile> profiles = TerminalSettings.GetDefaultProfiles(
+            TerminalSettings.UnixProfileCandidates("/usr/bin/fish"),
+            commandExists: _ => false);
+
+        // The floor is platform-shaped: /bin/sh on Unix, cmd.exe where this test runs.
+        string floor = OperatingSystem.IsWindows() ? "cmd.exe" : "/bin/sh";
+        Assert.Single(profiles);
+        Assert.Equal(floor, profiles[0].Command);
+    }
 }


### PR DESCRIPTION
## Problem

`ShellHelper.GetDefaultShell()` answered Unix from a hardcoded `/bin/zsh` → `/bin/bash` → `/bin/sh` existence probe. It never asked what the user's login shell actually is, so:

- a Linux user whose login shell is **bash** got **zsh** whenever zsh happened to be installed (it is first in the list),
- fish / nushell / dash users could never get their shell as the default,
- macOS only worked by accident, because Apple ships `/bin/zsh` as the login shell.

Every "the user did not name one" path funnels through this function: new sessions with blank or foreign commands (`TerminalPane`), the **New Profile** button (`SettingsWindow`, `TerminalProfile`), and session-restore substitution (`MainWindow`) — so fixing it in one place fixes all of them.

## Change

- **`NovaTerminal.Pty/ShellHelper.cs`** — the Unix branch now resolves the real login shell via a chain:
  1. `/bin/bash.exe` (what launchd sets from the login shell for GUI apps on macOS; desktop sessions set it on most Linux distros),
  2. the seventh passwd field for the current user (covers sessions without `/bin/bash.exe`; matched by username, malformed/comment/NIS lines skipped),
  3. the old zsh/bash/sh probe, kept verbatim as the floor so machines where neither source answers behave exactly as before.

  Every answer is probed with `File.Exists` before being trusted, so a stale `/bin/bash.exe` pointing at a since-uninstalled shell falls through instead of failing at spawn. The chain and the passwd parser are `internal` overloads taking delegates (the same seam pattern as `GetDefaultProfiles(commandExists)`), so tests are deterministic on every platform.

- **`NovaTerminal.App/Shell/TerminalSettings.cs`** — the Unix first-run profile list now leads with a **"Default Shell"** profile for the resolved login shell, followed by the fixed Bash/Zsh/Shell trio; a login shell that collides with the trio is deduped, not duplicated. Since `DefaultProfileId` is `Profiles[0]`, first run now opens the shell the user actually uses. Windows behavior is untouched.

Existing users' `settings.json` is unaffected — profiles persist, so the new list only reaches fresh installs and the no-native-shells repair path.

## Test plan

- New `DefaultShellResolutionTests` (17 cases): chain ordering, blank/stale `/bin/bash.exe` fall-through, stale passwd fall-through, floor ordering, and passwd parsing (unknown user, blank username, comment/NIS/malformed lines, truncated entries).
- 4 new cases in `DefaultProfileAvailabilityTests`: login shell leads, no duplication against the trio, existence filter still applies, guaranteed floor when nothing is installed.
- All 81 tests in the three affected suites pass; full solution builds with 0 errors.