### PR TITLE
ci: wire macOS codesigning + notarization behind MAC_* secrets

### DIFF
--- a/.github/actions/setup-mac-signing/action.yml
+++ b/.github/actions/setup-mac-signing/action.yml
@@ -80,6 +80,11 @@ runs:
           exit 1
         fi
 
+        # Every keychain reference below uses this explicit full path, never the bare
+        # name: `security` resolves bare names suffix-flexibly (name, name.keychain,
+        # name.keychain-db), but notarytool — and vpk's codesign call — take literal
+        # file paths and fail with "file doesn't exist" on the unresolved variant.
+        # Creating with an explicit path guarantees the exact file exists.
         keychain="$HOME/Library/Keychains/build.keychain"
         cert_dir=$(mktemp -d)
         cert_path="$cert_dir/cert.p12"
@@ -88,30 +93,36 @@ runs:
         trap 'rm -rf "$cert_dir"' EXIT
         printf '%s' "$CERT_P12_BASE64" | base64 --decode > "$cert_path"
 
-        security create-keychain -p "$CERT_PASSWORD" build.keychain
+        security create-keychain -p "$CERT_PASSWORD" "$keychain"
+        # Turn any future path mismatch into a named failure here, before notarytool
+        # or vpk surface it as a confusing "file doesn't exist".
+        if [[ ! -f "$keychain" ]]; then
+          echo "::error::security create-keychain did not produce '$keychain'." >&2
+          exit 1
+        fi
         # 6h autolock so the identity stays usable for the whole job, including vpk's
         # synchronous wait for Apple to finish notarizing.
-        security set-keychain-settings -lut 21600 build.keychain
-        security unlock-keychain -p "$CERT_PASSWORD" build.keychain
+        security set-keychain-settings -lut 21600 "$keychain"
+        security unlock-keychain -p "$CERT_PASSWORD" "$keychain"
         # -T names the binaries allowed to use the key without a prompt; productbuild
         # sits beside codesign because vpk signs the .pkg with it.
-        security import "$cert_path" -k build.keychain -P "$CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productbuild
+        security import "$cert_path" -k "$keychain" -P "$CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productbuild
         # openssl can only place one private key in a p12, so the no-Mac route carries
         # the Installer identity in a second file; the Mac Keychain Access single
         # export folds both into cert.p12 and never sets this input.
         if [[ -n "${INSTALLER_P12_BASE64:-}" ]]; then
           installer_path="$cert_dir/installer.p12"
           printf '%s' "$INSTALLER_P12_BASE64" | base64 --decode > "$installer_path"
-          security import "$installer_path" -k build.keychain -P "$CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productbuild
+          security import "$installer_path" -k "$keychain" -P "$CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productbuild
         fi
         # Non-interactive key access for those Apple-signed tools.
-        security set-key-partition-list -S apple-tool:,apple: -k "$CERT_PASSWORD" build.keychain
-        # build.keychain first in the search list: vpk passes --keychain to codesign
-        # explicitly, but productbuild and notarytool resolve identities and the stored
-        # profile through the user search list.
-        security list-keychain -d user -s build.keychain login
+        security set-key-partition-list -S apple-tool:,apple: -k "$CERT_PASSWORD" "$keychain"
+        # The build keychain first in the search list: vpk passes --keychain to
+        # codesign explicitly, but productbuild and notarytool resolve identities and
+        # the stored profile through the user search list.
+        security list-keychain -d user -s "$keychain" login
 
-        identities=$(security find-identity -v build.keychain)
+        identities=$(security find-identity -v "$keychain")
         echo "$identities"
         if [[ "$identities" != *"$SIGN_APP_IDENTITY"* ]]; then
           echo "::error::Developer ID Application identity '$SIGN_APP_IDENTITY' not found in the keychain imported from MAC_CERT_P12_BASE64." >&2

--- a/.github/actions/setup-mac-signing/action.yml
+++ b/.github/actions/setup-mac-signing/action.yml
@@ -94,12 +94,20 @@ runs:
         printf '%s' "$CERT_P12_BASE64" | base64 --decode > "$cert_path"
 
         security create-keychain -p "$CERT_PASSWORD" "$keychain"
-        # Turn any future path mismatch into a named failure here, before notarytool
-        # or vpk surface it as a confusing "file doesn't exist".
+        # `security` resolves bare keychain names suffix-flexibly, but notarytool and
+        # vpk's codesign need the literal existing file — and some macOS versions
+        # materialize build.keychain-db even when given this explicit .keychain path.
+        # Locate whatever was actually created; fail with the directory listing if
+        # nothing matches, so the log shows where the keychain went.
         if [[ ! -f "$keychain" ]]; then
-          echo "::error::security create-keychain did not produce '$keychain'." >&2
+          keychain=$(ls "$HOME/Library/Keychains/"build.keychain* 2>/dev/null | head -n 1 || true)
+        fi
+        if [[ -z "${keychain:-}" || ! -f "$keychain" ]]; then
+          echo "::error::could not find the created build keychain (expected $HOME/Library/Keychains/build.keychain*). Directory contents:" >&2
+          ls -la "$HOME/Library/Keychains" >&2 || true
           exit 1
         fi
+        echo "Using keychain: $keychain"
         # 6h autolock so the identity stays usable for the whole job, including vpk's
         # synchronous wait for Apple to finish notarizing.
         security set-keychain-settings -lut 21600 "$keychain"

--- a/.github/actions/setup-mac-signing/action.yml
+++ b/.github/actions/setup-mac-signing/action.yml
@@ -1,0 +1,134 @@
+name: Set up macOS signing keychain
+description: >-
+  Imports the Developer ID Application + Installer identities from one or two
+  base64-encoded .p12 files into a dedicated build keychain and stores an xcrun
+  notarytool credentials profile in it, for Velopack's --signAppIdentity/
+  --signInstallIdentity/--notaryProfile/--keychain flags. All-or-nothing by design:
+  every required input must be non-empty, both identities must resolve in the
+  keychain, and Apple must accept the notarytool credentials — so a misconfigured
+  secret fails here, named, instead of deep inside vpk's codesign/productbuild/
+  notarytool calls.
+
+inputs:
+  cert-p12-base64:
+    description: >-
+      Base64 of the .p12 holding the Developer ID Application identity (and, on the
+      Mac single-export route, the Installer identity too).
+    required: true
+  installer-p12-base64:
+    description: >-
+      Base64 of a separate .p12 holding the Developer ID Installer identity.
+      Optional: omit when cert-p12-base64 already contains both identities. Must use
+      the same export password as cert-p12-base64.
+    required: false
+  cert-password:
+    description: Password of the .p12 (doubles as the build keychain password).
+    required: true
+  sign-app-identity:
+    description: 'e.g. Developer ID Application: Beny Black (TEAMID)'
+    required: true
+  sign-install-identity:
+    description: 'e.g. Developer ID Installer: Beny Black (TEAMID)'
+    required: true
+  notary-profile:
+    description: Keychain profile name vpk passes to notarytool.
+    required: true
+  apple-id:
+    description: Apple ID used for notarization.
+    required: true
+  team-id:
+    description: Apple Developer Team ID.
+    required: true
+  app-specific-password:
+    description: App-specific password for the Apple ID (notarytool).
+    required: true
+
+outputs:
+  imported:
+    description: '"1" when the keychain and notarytool profile were set up.'
+    value: ${{ steps.keychain.outputs.imported }}
+  keychain:
+    description: Absolute path of the created keychain.
+    value: ${{ steps.keychain.outputs.keychain }}
+
+runs:
+  using: composite
+  steps:
+    - id: keychain
+      shell: bash
+      env:
+        CERT_P12_BASE64: ${{ inputs.cert-p12-base64 }}
+        INSTALLER_P12_BASE64: ${{ inputs.installer-p12-base64 }}
+        CERT_PASSWORD: ${{ inputs.cert-password }}
+        SIGN_APP_IDENTITY: ${{ inputs.sign-app-identity }}
+        SIGN_INSTALL_IDENTITY: ${{ inputs.sign-install-identity }}
+        NOTARY_PROFILE: ${{ inputs.notary-profile }}
+        APPLE_ID: ${{ inputs.apple-id }}
+        TEAM_ID: ${{ inputs.team-id }}
+        APP_SPECIFIC_PASSWORD: ${{ inputs.app-specific-password }}
+      run: |
+        set -euo pipefail
+
+        missing=""
+        for v in CERT_P12_BASE64 CERT_PASSWORD SIGN_APP_IDENTITY SIGN_INSTALL_IDENTITY NOTARY_PROFILE APPLE_ID TEAM_ID APP_SPECIFIC_PASSWORD; do
+          if [[ -z "${!v:-}" ]]; then
+            missing="$missing $v"
+          fi
+        done
+        if [[ -n "$missing" ]]; then
+          echo "::error::macOS signing inputs incomplete (missing:$missing). Set all MAC_* repo secrets, or unset MAC_CERT_P12_BASE64 to fall back to the unsigned lane." >&2
+          exit 1
+        fi
+
+        keychain="$HOME/Library/Keychains/build.keychain"
+        cert_dir=$(mktemp -d)
+        cert_path="$cert_dir/cert.p12"
+        # The decoded p12s only ever live on the ephemeral runner; the trap keeps
+        # them out of anything later uploaded even when a command below fails.
+        trap 'rm -rf "$cert_dir"' EXIT
+        printf '%s' "$CERT_P12_BASE64" | base64 --decode > "$cert_path"
+
+        security create-keychain -p "$CERT_PASSWORD" build.keychain
+        # 6h autolock so the identity stays usable for the whole job, including vpk's
+        # synchronous wait for Apple to finish notarizing.
+        security set-keychain-settings -lut 21600 build.keychain
+        security unlock-keychain -p "$CERT_PASSWORD" build.keychain
+        # -T names the binaries allowed to use the key without a prompt; productbuild
+        # sits beside codesign because vpk signs the .pkg with it.
+        security import "$cert_path" -k build.keychain -P "$CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productbuild
+        # openssl can only place one private key in a p12, so the no-Mac route carries
+        # the Installer identity in a second file; the Mac Keychain Access single
+        # export folds both into cert.p12 and never sets this input.
+        if [[ -n "${INSTALLER_P12_BASE64:-}" ]]; then
+          installer_path="$cert_dir/installer.p12"
+          printf '%s' "$INSTALLER_P12_BASE64" | base64 --decode > "$installer_path"
+          security import "$installer_path" -k build.keychain -P "$CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productbuild
+        fi
+        # Non-interactive key access for those Apple-signed tools.
+        security set-key-partition-list -S apple-tool:,apple: -k "$CERT_PASSWORD" build.keychain
+        # build.keychain first in the search list: vpk passes --keychain to codesign
+        # explicitly, but productbuild and notarytool resolve identities and the stored
+        # profile through the user search list.
+        security list-keychain -d user -s build.keychain login
+
+        identities=$(security find-identity -v build.keychain)
+        echo "$identities"
+        if [[ "$identities" != *"$SIGN_APP_IDENTITY"* ]]; then
+          echo "::error::Developer ID Application identity '$SIGN_APP_IDENTITY' not found in the keychain imported from MAC_CERT_P12_BASE64." >&2
+          exit 1
+        fi
+        if [[ "$identities" != *"$SIGN_INSTALL_IDENTITY"* ]]; then
+          echo "::error::Developer ID Installer identity '$SIGN_INSTALL_IDENTITY' not found in the imported keychain. Include both identities in MAC_CERT_P12_BASE64, or set MAC_INSTALLER_CERT_P12_BASE64 to a p12 containing the Installer identity." >&2
+          exit 1
+        fi
+
+        # Contacts Apple: a wrong Apple ID / team ID / app-specific password fails
+        # here, not inside vpk after minutes of packing.
+        xcrun notarytool store-credentials "$NOTARY_PROFILE" \
+          --apple-id "$APPLE_ID" \
+          --team-id "$TEAM_ID" \
+          --password "$APP_SPECIFIC_PASSWORD" \
+          --keychain "$keychain"
+
+        echo "imported=1" >> "$GITHUB_OUTPUT"
+        echo "keychain=$keychain" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -985,7 +985,10 @@ jobs:
     name: AOT Publish (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     if: github.event_name == 'workflow_dispatch'
-    timeout-minutes: 40
+    # 90 rather than 40: the signed mac lane waits synchronously on Apple's
+    # notarization queue inside vpk pack, which alone can run 10-30+ minutes on a
+    # slow day — 40 was cutting the job down mid-wait.
+    timeout-minutes: 90
     needs: [build]
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -998,6 +998,12 @@ jobs:
           - os: macos-latest
             rid: osx-arm64
 
+    # The secrets context is not allowed in step-level `if` (the workflow fails to
+    # parse), so the signing gate is materialized here as an env boolean the macOS
+    # keychain step can test. Mirrors release.yml's publish_aot.
+    env:
+      MAC_SIGNING_ENABLED: ${{ secrets.MAC_CERT_P12_BASE64 != '' }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -1055,6 +1061,26 @@ jobs:
         if: matrix.rid == 'osx-arm64'
         run: packaging/macos/make-icns.sh src/NovaTerminal.App/Assets/nova_icon.png artifacts/icon/nova_icon.icns
 
+      # Same secret-gated signing setup as release.yml's osx-arm64 lane (same action,
+      # same gate), so this dispatch lane is also the pre-tag validation of the whole
+      # codesign/notarize/staple path — not just of the unsigned packaging. When
+      # MAC_CERT_P12_BASE64 is unset the step (and the flags below) is skipped and the
+      # dry run packs unsigned, as it always did. See packaging/macos/README.md.
+      - name: Set up macOS signing keychain
+        id: mac_signing
+        if: matrix.rid == 'osx-arm64' && env.MAC_SIGNING_ENABLED == 'true'
+        uses: ./.github/actions/setup-mac-signing
+        with:
+          cert-p12-base64: ${{ secrets.MAC_CERT_P12_BASE64 }}
+          installer-p12-base64: ${{ secrets.MAC_INSTALLER_CERT_P12_BASE64 }}
+          cert-password: ${{ secrets.MAC_CERT_PASSWORD }}
+          sign-app-identity: ${{ secrets.MAC_SIGN_APP_IDENTITY }}
+          sign-install-identity: ${{ secrets.MAC_SIGN_INSTALL_IDENTITY }}
+          notary-profile: ${{ secrets.MAC_NOTARY_PROFILE }}
+          apple-id: ${{ secrets.MAC_APPLE_ID }}
+          team-id: ${{ secrets.MAC_TEAM_ID }}
+          app-specific-password: ${{ secrets.MAC_APP_SPECIFIC_PASSWORD }}
+
       # 0.0.1-ci: a dry-run version that can never collide with a real release's feed
       # (vpk rejects anything below 0.0.1, so 0.0.0-ci is not an option here).
       # Assertions mirror what release.yml asserts post-pack, so a silent vpk change
@@ -1062,6 +1088,14 @@ jobs:
       - name: Pack macOS bundle (Velopack dry run)
         if: matrix.rid == 'osx-arm64'
         shell: bash
+        env:
+          # Signing reaches the script through env, never interpolated into its source;
+          # when the keychain step was skipped these are empty and vpk stays unsigned.
+          MAC_SIGNING: ${{ steps.mac_signing.outputs.imported }}
+          MAC_SIGN_KEYCHAIN: ${{ steps.mac_signing.outputs.keychain }}
+          MAC_SIGN_APP_IDENTITY: ${{ secrets.MAC_SIGN_APP_IDENTITY }}
+          MAC_SIGN_INSTALL_IDENTITY: ${{ secrets.MAC_SIGN_INSTALL_IDENTITY }}
+          MAC_NOTARY_PROFILE: ${{ secrets.MAC_NOTARY_PROFILE }}
         run: |
           set -euo pipefail
           # StripSymbols=true leaves a ~94 MB NovaTerminal.dSYM beside the binary (3x the
@@ -1071,6 +1105,17 @@ jobs:
           # consumes the symbols - the raw publish-dir zip this dSYM used to ship in no
           # longer exists for macOS.
           rm -rf artifacts/publish/osx-arm64/NovaTerminal.dSYM
+          # Same secret-gated signing flags as release.yml (see its comments there);
+          # the +guard keeps an empty array valid under set -u on bash 3.2.
+          sign_args=()
+          if [[ "${MAC_SIGNING:-}" == "1" ]]; then
+            sign_args+=(
+              --signAppIdentity "$MAC_SIGN_APP_IDENTITY"
+              --signInstallIdentity "$MAC_SIGN_INSTALL_IDENTITY"
+              --notaryProfile "$MAC_NOTARY_PROFILE"
+              --keychain "$MAC_SIGN_KEYCHAIN"
+            )
+          fi
           vpk pack \
             --packId NovaTerminalApp \
             --packVersion 0.0.1-ci \
@@ -1081,7 +1126,8 @@ jobs:
             --bundleId com.benyblack.NovaTerminal \
             --icon artifacts/icon/nova_icon.icns \
             --exclude 'NovaTerminal\.dSYM' \
-            --outputDir artifacts/velopack-dryrun
+            --outputDir artifacts/velopack-dryrun \
+            ${sign_args[@]+"${sign_args[@]}"}
 
           echo "Velopack dry-run output:"
           ls -l artifacts/velopack-dryrun

--- a/.github/workflows/mac-signing-smoke.yml
+++ b/.github/workflows/mac-signing-smoke.yml
@@ -1,0 +1,45 @@
+name: macOS signing smoke
+
+# Fast credential check for the macOS signing setup: runs exactly the keychain
+# import + notarytool profile store the release and dry-run lanes perform, but
+# without building or packing. Dispatch this after touching any MAC_* secret;
+# it reaches the verdict in under a minute and fails naming the offending
+# secret, instead of burning a full CI run to reach the keychain step.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  keychain:
+    name: Import signing keychain
+    runs-on: macos-latest
+    timeout-minutes: 5
+    # Same gate shape as the job-level env in ci.yml / release.yml: the secrets
+    # context is not allowed in step-level `if`.
+    env:
+      MAC_SIGNING_ENABLED: ${{ secrets.MAC_CERT_P12_BASE64 != '' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up macOS signing keychain
+        if: env.MAC_SIGNING_ENABLED == 'true'
+        uses: ./.github/actions/setup-mac-signing
+        with:
+          cert-p12-base64: ${{ secrets.MAC_CERT_P12_BASE64 }}
+          installer-p12-base64: ${{ secrets.MAC_INSTALLER_CERT_P12_BASE64 }}
+          cert-password: ${{ secrets.MAC_CERT_PASSWORD }}
+          sign-app-identity: ${{ secrets.MAC_SIGN_APP_IDENTITY }}
+          sign-install-identity: ${{ secrets.MAC_SIGN_INSTALL_IDENTITY }}
+          notary-profile: ${{ secrets.MAC_NOTARY_PROFILE }}
+          apple-id: ${{ secrets.MAC_APPLE_ID }}
+          team-id: ${{ secrets.MAC_TEAM_ID }}
+          app-specific-password: ${{ secrets.MAC_APP_SPECIFIC_PASSWORD }}
+
+      - name: Fail loudly when signing is not configured
+        if: env.MAC_SIGNING_ENABLED != 'true'
+        run: |
+          echo "::error::MAC_CERT_P12_BASE64 is not set. This smoke exists to validate the signing secrets, so an unset gate is a failure here, not a skip." >&2
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,6 +227,12 @@ jobs:
           - os: macos-latest
             rid: osx-arm64
 
+    # The secrets context is not allowed in step-level `if` (the workflow fails to
+    # parse), so the signing gate is materialized here as an env boolean the macOS
+    # keychain step can test.
+    env:
+      MAC_SIGNING_ENABLED: ${{ secrets.MAC_CERT_P12_BASE64 != '' }}
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -484,6 +490,27 @@ jobs:
         if: matrix.rid == 'osx-arm64'
         run: packaging/macos/make-icns.sh src/NovaTerminal.App/Assets/nova_icon.png artifacts/icon/nova_icon.icns
 
+      # ---- Apple signing + notarization, gated on the presence of MAC_CERT_P12_BASE64
+      # ---- so the lane keeps its unsigned behavior until all MAC_* secrets exist (the
+      # ---- gate, the secret list and the one-time setup are documented in
+      # ---- packaging/macos/README.md). The action fails fast on a half-configured
+      # ---- secret set, an identity the p12 does not contain, or Apple rejecting the
+      # ---- notarytool credentials.
+      - name: Set up macOS signing keychain
+        id: mac_signing
+        if: matrix.rid == 'osx-arm64' && env.MAC_SIGNING_ENABLED == 'true'
+        uses: ./.github/actions/setup-mac-signing
+        with:
+          cert-p12-base64: ${{ secrets.MAC_CERT_P12_BASE64 }}
+          installer-p12-base64: ${{ secrets.MAC_INSTALLER_CERT_P12_BASE64 }}
+          cert-password: ${{ secrets.MAC_CERT_PASSWORD }}
+          sign-app-identity: ${{ secrets.MAC_SIGN_APP_IDENTITY }}
+          sign-install-identity: ${{ secrets.MAC_SIGN_INSTALL_IDENTITY }}
+          notary-profile: ${{ secrets.MAC_NOTARY_PROFILE }}
+          apple-id: ${{ secrets.MAC_APPLE_ID }}
+          team-id: ${{ secrets.MAC_TEAM_ID }}
+          app-specific-password: ${{ secrets.MAC_APP_SPECIFIC_PASSWORD }}
+
       - name: Pack macOS installer (Velopack)
         if: matrix.rid == 'osx-arm64'
         shell: bash
@@ -494,6 +521,15 @@ jobs:
           RELEASE_VERSION: ${{ needs.release_metadata.outputs.release_version }}
           DOWNLOAD_OUTCOME: ${{ steps.velopack_download.outcome }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Signing reaches the script through env like everything else: the identity
+          # strings contain spaces and parentheses, so they must never be interpolated
+          # into script source. When the keychain step was skipped these are empty and
+          # the MAC_SIGNING guard below leaves vpk unsigned, exactly as before.
+          MAC_SIGNING: ${{ steps.mac_signing.outputs.imported }}
+          MAC_SIGN_KEYCHAIN: ${{ steps.mac_signing.outputs.keychain }}
+          MAC_SIGN_APP_IDENTITY: ${{ secrets.MAC_SIGN_APP_IDENTITY }}
+          MAC_SIGN_INSTALL_IDENTITY: ${{ secrets.MAC_SIGN_INSTALL_IDENTITY }}
+          MAC_NOTARY_PROFILE: ${{ secrets.MAC_NOTARY_PROFILE }}
         run: |
           set -euo pipefail
           ver="$RELEASE_VERSION"
@@ -545,12 +581,14 @@ jobs:
           # com.benyblack.NovaTerminalApp; this matches the public identity (winget:
           # benyblack.NovaTerminal) instead.
           #
-          # No --signAppIdentity/--signInstallIdentity/--notaryProfile on purpose: no
-          # Apple Developer certificate exists today. vpk warns "Package will not be
-          # signed or notarized" and packages everything unsigned; the app still runs,
-          # because on arm64 the linker ad-hoc-signs the AOT binary and the Rust dylibs.
-          # The seam for enabling real signing later is exactly these three flags plus a
-          # keychain import — documented in packaging/macos/README.md.
+          # Signing is secret-gated (see the "Set up macOS signing keychain" step above):
+          # when that step ran, vpk signs the app bundle and dylibs (deep signing), signs
+          # the pkg, submits for notarization, staples the ticket, and runs spctl
+          # assessments — failing the step if any of that breaks. Without the secret, vpk
+          # warns "Package will not be signed or notarized" and packages everything
+          # unsigned; the app still runs, because on arm64 the linker ad-hoc-signs the
+          # AOT binary and the Rust dylibs. Details: packaging/macos/README.md.
+          #
           # StripSymbols=true leaves a ~94 MB NovaTerminal.dSYM beside the binary (3x the
           # binary's own size). Delete it at the source AND exclude it in vpk: deletion
           # keeps empty dSYM directory skeletons out of the bundle entirely, --exclude
@@ -558,6 +596,17 @@ jobs:
           # defense-in-depth. Nothing else consumes the symbols - the raw publish-dir zip
           # this dSYM used to ship in no longer exists for macOS.
           rm -rf artifacts/publish/osx-arm64/NovaTerminal.dSYM
+          # The +guarded expansion keeps an empty array valid under set -u even if the
+          # runner resolves shell: bash to macOS's 3.2 /bin/bash.
+          sign_args=()
+          if [[ "${MAC_SIGNING:-}" == "1" ]]; then
+            sign_args+=(
+              --signAppIdentity "$MAC_SIGN_APP_IDENTITY"
+              --signInstallIdentity "$MAC_SIGN_INSTALL_IDENTITY"
+              --notaryProfile "$MAC_NOTARY_PROFILE"
+              --keychain "$MAC_SIGN_KEYCHAIN"
+            )
+          fi
           vpk pack \
             --packId NovaTerminalApp \
             --packVersion "$ver" \
@@ -568,7 +617,8 @@ jobs:
             --bundleId com.benyblack.NovaTerminal \
             --icon artifacts/icon/nova_icon.icns \
             --exclude 'NovaTerminal\.dSYM' \
-            --outputDir artifacts/velopack
+            --outputDir artifacts/velopack \
+            ${sign_args[@]+"${sign_args[@]}"}
 
           # The installer's and the zip's file names are ours to choose — nothing
           # resolves them by name. The zip keeps the exact name the raw publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,7 +214,10 @@ jobs:
   publish_aot:
     name: Publish AOT (${{ matrix.rid }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
+    # 90 rather than 40: the signed mac lane waits synchronously on Apple's
+    # notarization queue inside vpk pack, which alone can run 10-30+ minutes on a
+    # slow day — 40 was cutting the job down mid-wait.
+    timeout-minutes: 90
     needs: [release_metadata, create_release, build_native, release_tests]
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,6 +234,34 @@ jobs:
       MAC_SIGNING_ENABLED: ${{ secrets.MAC_CERT_P12_BASE64 != '' }}
 
     steps:
+      # ---- macOS signing setup precedes the checkout_ref checkout on purpose: that
+      # ---- ref (the dispatch input target_commitish) can name a revision older than
+      # ---- the workflow's own ref, and the local action below resolves from the
+      # ---- workspace tree — which such a revision would not contain (Greptile P1 on
+      # ---- #382). So: check the workflow's own ref out first (it provides the
+      # ---- action), import the keychain + notarytool profile (both live outside the
+      # ---- workspace, so the re-checkout's clean cannot disturb them), then check
+      # ---- out the release revision the build actually packages. Gated like the
+      # ---- keychain step, so the unsigned lane keeps a single checkout.
+      - name: Checkout workflow ref (provides the local signing action)
+        if: matrix.rid == 'osx-arm64' && env.MAC_SIGNING_ENABLED == 'true'
+        uses: actions/checkout@v4
+
+      - name: Set up macOS signing keychain
+        id: mac_signing
+        if: matrix.rid == 'osx-arm64' && env.MAC_SIGNING_ENABLED == 'true'
+        uses: ./.github/actions/setup-mac-signing
+        with:
+          cert-p12-base64: ${{ secrets.MAC_CERT_P12_BASE64 }}
+          installer-p12-base64: ${{ secrets.MAC_INSTALLER_CERT_P12_BASE64 }}
+          cert-password: ${{ secrets.MAC_CERT_PASSWORD }}
+          sign-app-identity: ${{ secrets.MAC_SIGN_APP_IDENTITY }}
+          sign-install-identity: ${{ secrets.MAC_SIGN_INSTALL_IDENTITY }}
+          notary-profile: ${{ secrets.MAC_NOTARY_PROFILE }}
+          apple-id: ${{ secrets.MAC_APPLE_ID }}
+          team-id: ${{ secrets.MAC_TEAM_ID }}
+          app-specific-password: ${{ secrets.MAC_APP_SPECIFIC_PASSWORD }}
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.release_metadata.outputs.checkout_ref }}
@@ -490,27 +518,6 @@ jobs:
         if: matrix.rid == 'osx-arm64'
         run: packaging/macos/make-icns.sh src/NovaTerminal.App/Assets/nova_icon.png artifacts/icon/nova_icon.icns
 
-      # ---- Apple signing + notarization, gated on the presence of MAC_CERT_P12_BASE64
-      # ---- so the lane keeps its unsigned behavior until all MAC_* secrets exist (the
-      # ---- gate, the secret list and the one-time setup are documented in
-      # ---- packaging/macos/README.md). The action fails fast on a half-configured
-      # ---- secret set, an identity the p12 does not contain, or Apple rejecting the
-      # ---- notarytool credentials.
-      - name: Set up macOS signing keychain
-        id: mac_signing
-        if: matrix.rid == 'osx-arm64' && env.MAC_SIGNING_ENABLED == 'true'
-        uses: ./.github/actions/setup-mac-signing
-        with:
-          cert-p12-base64: ${{ secrets.MAC_CERT_P12_BASE64 }}
-          installer-p12-base64: ${{ secrets.MAC_INSTALLER_CERT_P12_BASE64 }}
-          cert-password: ${{ secrets.MAC_CERT_PASSWORD }}
-          sign-app-identity: ${{ secrets.MAC_SIGN_APP_IDENTITY }}
-          sign-install-identity: ${{ secrets.MAC_SIGN_INSTALL_IDENTITY }}
-          notary-profile: ${{ secrets.MAC_NOTARY_PROFILE }}
-          apple-id: ${{ secrets.MAC_APPLE_ID }}
-          team-id: ${{ secrets.MAC_TEAM_ID }}
-          app-specific-password: ${{ secrets.MAC_APP_SPECIFIC_PASSWORD }}
-
       - name: Pack macOS installer (Velopack)
         if: matrix.rid == 'osx-arm64'
         shell: bash
@@ -581,7 +588,7 @@ jobs:
           # com.benyblack.NovaTerminalApp; this matches the public identity (winget:
           # benyblack.NovaTerminal) instead.
           #
-          # Signing is secret-gated (see the "Set up macOS signing keychain" step above):
+          # Signing is secret-gated (the keychain is set up at the top of this job):
           # when that step ran, vpk signs the app bundle and dylibs (deep signing), signs
           # the pkg, submits for notarization, staples the ticket, and runs spctl
           # assessments — failing the step if any of that breaks. Without the secret, vpk

--- a/README.md
+++ b/README.md
@@ -81,9 +81,10 @@ macOS builds installed via the `.pkg` check for updates in the background and ap
 on restart, same as Windows. If the app lives in `/Applications`, macOS will ask for your
 password once per update.
 
-The installer and the app are **not code-signed or notarized yet**
-([#91](https://github.com/benyblack/NovaTerminal/issues/91)), so Gatekeeper blocks the
-first launch. On macOS 13+:
+Releases built while the macOS signing secrets are unset (see
+[packaging/macos](packaging/macos/README.md), tracking
+[#91](https://github.com/benyblack/NovaTerminal/issues/91)) are **not code-signed or
+notarized**, so Gatekeeper blocks their first launch. On macOS 13+:
 
 1. Try to open `NovaTerminal` once (it will be blocked — that's expected).
 2. Open **System Settings → Privacy & Security**, scroll down, and click **Open Anyway**.

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -100,10 +100,15 @@ imports one or two accordingly.
   ```bash
   curl -LO https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer
   openssl x509 -inform der -in DeveloperIDG2CA.cer -out DeveloperIDG2CA.pem
+  # The algorithm profile matters: OpenSSL 3's defaults (AES-256 PBES2 + SHA-256
+  # MAC) fail to import via macOS's `security` tool with a bogus "wrong password"
+  # error (OpenRadar FB8988319). 3DES + SHA-1 is the compatible set.
   openssl pkcs12 -export -out app.p12 -inkey app.key \
-    -in developerID_application.cer -certfile DeveloperIDG2CA.pem -name "Developer ID Application"
+    -in developerID_application.cer -certfile DeveloperIDG2CA.pem -name "Developer ID Application" \
+    -certpbe PBE-SHA1-3DES -keypbe PBE-SHA1-3DES -macalg sha1
   openssl pkcs12 -export -out installer.p12 -inkey installer.key \
-    -in developerID_installer.cer -certfile DeveloperIDG2CA.pem -name "Developer ID Installer"
+    -in developerID_installer.cer -certfile DeveloperIDG2CA.pem -name "Developer ID Installer" \
+    -certpbe PBE-SHA1-3DES -keypbe PBE-SHA1-3DES -macalg sha1
   base64 -w 0 app.p12 > app.p12.b64        # macOS: base64 -i app.p12 -o app.p12.b64
   base64 -w 0 installer.p12 > installer.p12.b64
   ```

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -32,65 +32,109 @@ Facts worth knowing (all verified against the vpk 1.2.0 source, see
 ## Dry run without cutting a release
 
 The `AOT Publish` job in `.github/workflows/ci.yml` is `workflow_dispatch`-only and runs
-the same `vpk pack` (version `0.0.0-ci`) plus assertions, uploading
+the same `vpk pack` (version `0.0.1-ci`) plus assertions, uploading
 `macos-packaging-dryrun` as a workflow artifact. Use it to verify bundle structure, the
-pkg, and asset names before tagging. None of this is runnable from a Windows or Linux
-dev box.
+pkg, and asset names before tagging — and, once the `MAC_*` secrets are set, the whole
+sign/notarize/staple path too. None of this is runnable from a Windows or Linux dev box.
 
-## Current state: unsigned (the "signing seam")
+## Signing + notarization (secret-gated)
 
-No Apple Developer Program membership exists today, so releases ship **unsigned and
-un-notarized**. `vpk pack` is invoked without signing options; it logs
-`Package will not be signed or notarized` and packages everything anyway. The app still
-runs: on arm64, `ld` ad-hoc-signs the NativeAOT binary and the Rust dylibs at build time,
-and the SkiaSharp/HarfBuzz dylibs ship signed by their maintainers.
+Signing is wired into both `vpk pack` lanes (the release lane in `release.yml` and the
+dry run above) but **gated on the `MAC_CERT_P12_BASE64` repo secret**:
 
-The first-launch Gatekeeper flow for users is documented in the main `README.md`
-(System Settings → Privacy & Security → "Open Anyway" on macOS 15+, or
-`xattr -cr /Applications/NovaTerminal.app` in Terminal).
+- Secret set → `.github/actions/setup-mac-signing` imports the Developer ID identities
+  into a build keychain and stores the notarytool profile, and `vpk pack` runs with
+  `--signAppIdentity`/`--signInstallIdentity`/`--notaryProfile`/`--keychain`. vpk then
+  signs the app bundle and dylibs (deep signing), signs the pkg, submits for
+  notarization, staples the ticket, and runs `spctl` assessments — verified in vpk's
+  `OsxPackCommandRunner`/`CodeSign`.
+- Secret unset → both lanes behave exactly as they did before: `vpk pack` warns
+  "Package will not be signed or notarized" and packages everything unsigned. The app
+  still runs, because on arm64 `ld` ad-hoc-signs the NativeAOT binary and the Rust
+  dylibs at build time, and the SkiaSharp/HarfBuzz dylibs ship signed by their
+  maintainers.
 
-### Turning signing + notarization on later
+The gate is all-or-nothing: the action fails fast (naming the missing secret) if
+`MAC_CERT_P12_BASE64` is set but any other required `MAC_*` secret is missing, the
+imported keychain lacks one of the two identities, or Apple rejects the notarytool
+credentials — rather than letting `vpk pack` fail minutes later inside
+codesign/productbuild.
 
-This is deliberately **not** pre-wired with secret-gated workflow steps: an untestable
-dead path in a release pipeline is worse than a documented diff. When a Developer ID
-certificate exists, the change is exactly this:
+### One-time setup
 
-1. Create a "Developer ID Application" and a "Developer ID Installer" certificate
-   (appleid.apple.com → Certificates), export both as one `.p12`.
-2. Store repo secrets: `MAC_CERT_P12_BASE64` (base64 of the p12), `MAC_CERT_PASSWORD`,
-   `MAC_SIGN_APP_IDENTITY` (e.g. `Developer ID Application: Beny Black (TEAMID)`),
-   `MAC_SIGN_INSTALL_IDENTITY` (e.g. `Developer ID Installer: Beny Black (TEAMID)`),
-   `MAC_NOTARY_PROFILE` (a notarytool profile name), plus `MAC_APPLE_ID`, `MAC_TEAM_ID`,
-   `MAC_APP_SPECIFIC_PASSWORD`.
-3. In the osx-arm64 leg of `publish_aot` in `release.yml`, add a step before `vpk pack`
-   that imports the keychain and stores the notarytool profile:
+Prerequisites: a **paid Apple Developer Program membership** (a free Apple ID cannot
+create Developer ID certificates or submit for notarization), and an app-specific
+password for notarytool (appleid.apple.com → Sign-In and Security → App-Specific
+Passwords).
 
-   ```bash
-   cert_path=$(mktemp -d)/cert.p12
-   echo "$MAC_CERT_P12_BASE64" | base64 --decode > "$cert_path"
-   security create-keychain -p "$MAC_CERT_PASSWORD" build.keychain
-   security default-keychain -s build.keychain
-   security unlock-keychain -p "$MAC_CERT_PASSWORD" build.keychain
-   security import "$cert_path" -k build.keychain -P "$MAC_CERT_PASSWORD" -T /usr/bin/codesign
-   security set-key-partition-list -S apple-tool:,apple: -k "$MAC_CERT_PASSWORD" build.keychain
-   xcrun notarytool store-credentials "$MAC_NOTARY_PROFILE" \
-     --apple-id "$MAC_APPLE_ID" --team-id "$MAC_TEAM_ID" --password "$MAC_APP_SPECIFIC_PASSWORD" \
-     --keychain build.keychain
-   ```
+**1. Create the two certificates.** On developer.apple.com → Certificates, Identifiers
+& Profiles → Certificates → **+**, create one **Developer ID Application** and one
+**Developer ID Installer** certificate. Each needs a CSR:
 
-4. Add these flags to `vpk pack`:
+- *With a Mac*: Keychain Access → Certificate Assistant → Request a Certificate from a
+  Certificate Authority… (keeps the key in the login keychain), then double-click each
+  downloaded `.cer` to pair it with its key.
+- *Without a Mac* — openssl works everywhere and Git Bash on Windows ships it. The
+  `MSYS_NO_PATHCONV=1` prefix stops Git Bash from rewriting the leading-slash `-subj`
+  into a Windows path; it is inert on macOS/Linux:
 
-   ```
-   --signAppIdentity "$MAC_SIGN_APP_IDENTITY" \
-   --signInstallIdentity "$MAC_SIGN_INSTALL_IDENTITY" \
-   --notaryProfile "$MAC_NOTARY_PROFILE" \
-   --keychain "$HOME/Library/Keychains/build.keychain"
-   ```
+  ```bash
+  MSYS_NO_PATHCONV=1 openssl req -new -newkey rsa:2048 -nodes -keyout app.key -out app.csr -subj "/CN=NovaTerminal"
+  MSYS_NO_PATHCONV=1 openssl req -new -newkey rsa:2048 -nodes -keyout installer.key -out installer.csr -subj "/CN=NovaTerminal"
+  ```
 
-vpk then signs the app bundle and dylibs (deep signing), signs the pkg, submits for
-notarization, staples the ticket, and runs `spctl` assessments — verified in vpk's
-`OsxPackCommandRunner`/`CodeSign`. Nothing else in the pipeline changes: same asset
-names, same feed, updater-agnostic.
+  Upload `app.csr` for the Developer ID Application certificate, `installer.csr` for
+  the Developer ID Installer certificate, and download both `.cer` files. Keep the
+  `.key` files: they are the certificate private keys (re-exporting or moving the
+  identities later requires them; losing them means revoking and reissuing).
+
+**2. Produce the p12(s).** The identities may travel as one combined p12 (Mac route)
+or as two files (openssl route — a p12 can only carry one private key); the CI action
+imports one or two accordingly.
+
+- *Mac route (one file)*: in Keychain Access select both new certificate+key pairs and
+  export them as a single `.p12`.
+- *openssl route (two files)* — Apple serves the intermediate as DER, and notarization
+  requires the signature to carry it, so fold it in via `-certfile`:
+
+  ```bash
+  curl -LO https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer
+  openssl x509 -inform der -in DeveloperIDG2CA.cer -out DeveloperIDG2CA.pem
+  openssl pkcs12 -export -out app.p12 -inkey app.key \
+    -in developerID_application.cer -certfile DeveloperIDG2CA.pem -name "Developer ID Application"
+  openssl pkcs12 -export -out installer.p12 -inkey installer.key \
+    -in developerID_installer.cer -certfile DeveloperIDG2CA.pem -name "Developer ID Installer"
+  base64 -w 0 app.p12 > app.p12.b64        # macOS: base64 -i app.p12 -o app.p12.b64
+  base64 -w 0 installer.p12 > installer.p12.b64
+  ```
+
+  The exact identity strings for the secrets below are the certificate CNs — read them
+  verbatim with
+  `openssl x509 -inform der -in developerID_application.cer -noout -subject`, which
+  prints e.g. `subject=CN = Developer ID Application: LEGAL NAME (TEAMID), …`. That
+  parenthesized 10-character value is also the team ID.
+
+**3. Set the repo secrets:**
+
+| Secret | Value |
+|---|---|
+| `MAC_CERT_P12_BASE64` | base64 of the `.p12` with the Developer ID Application identity (the combined Mac export holds both) |
+| `MAC_INSTALLER_CERT_P12_BASE64` | *optional* — base64 of a separate `.p12` with the Developer ID Installer identity (the openssl route); omit on the Mac route |
+| `MAC_CERT_PASSWORD` | the `.p12` export password (use the same password for both files on the openssl route) |
+| `MAC_SIGN_APP_IDENTITY` | `Developer ID Application: <legal name> (TEAMID)` — the CN, verbatim |
+| `MAC_SIGN_INSTALL_IDENTITY` | `Developer ID Installer: <legal name> (TEAMID)` — the CN, verbatim |
+| `MAC_NOTARY_PROFILE` | any profile name, e.g. `nova-notary` |
+| `MAC_APPLE_ID` | the Apple ID |
+| `MAC_TEAM_ID` | the 10-character team ID (Membership page) |
+| `MAC_APP_SPECIFIC_PASSWORD` | the app-specific password |
+
+4. Dispatch the `AOT Publish` workflow once before tagging: the mac lane performs the
+   same signed pack at version `0.0.1-ci`, so a broken certificate, identity string, or
+   notarytool credential fails there instead of at the next release.
+
+The first-launch Gatekeeper flow documented in the main `README.md` (System Settings →
+Privacy & Security → "Open Anyway" on macOS 15+, or `xattr -cr` in Terminal) applies to
+unsigned builds; drop that section from `README.md` when the first signed release ships.
 
 ### Known limitations
 


### PR DESCRIPTION
## What

Turns on Apple signing + notarization for the macOS lanes, gated on the presence of the `MAC_CERT_P12_BASE64` repo secret so behavior is unchanged until the full `MAC_*` secret set exists (now configured).

- New composite action `.github/actions/setup-mac-signing`: imports the Developer ID Application + Installer identities from one or two base64 p12s into a build keychain, stores the notarytool profile, and fails fast — naming the offending secret — on a half-configured set, a p12 missing an identity, or Apple rejecting credentials.
- `release.yml` osx-arm64 lane: keychain setup step + `vpk pack` gains `--signAppIdentity/--signInstallIdentity/--notaryProfile/--keychain` only when that step ran. vpk then deep-signs the app, signs the pkg, notarizes, staples, and runs its spctl checks.
- `ci.yml` AOT Publish dry run: same wiring, so the dispatch lane validates the full sign/notarize/staple path before a tag.
- Docs: `packaging/macos/README.md` (gate, secret table, Mac + Git-Bash-openssl cert routes); main README Gatekeeper note scoped to unsigned builds.

Asset names, the osx update feed, and the updater are unchanged. Already-published unsigned installs keep their Gatekeeper approval and update normally.

## Validation

- YAML parses on all three files; every touched run script passes `bash -n`; the empty-signing-args expansion is guarded for bash 3.2 under `set -u`.
- The openssl cert-prep pipeline in the docs was executed end-to-end locally (CSR → DER intermediate → `-certfile` p12 → base64).
- End-to-end signing runs on a macos runner only: dispatch **Actions → CI → AOT Publish** on this branch — the mac lane should import both identities and pack signed at `0.0.1-ci`.