### PR TITLE
Vertical tabs: drag-to-reorder, agent-aware status, overflow pill, move-tab shortcuts

### DIFF
--- a/src/NovaTerminal.App/MainWindow.axaml
+++ b/src/NovaTerminal.App/MainWindow.axaml
@@ -50,6 +50,18 @@
             <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
         </Style>
 
+        <!-- Vertical mode replaces the horizontal selected-tab underline (App.axaml's
+             "TabItem:selected /template/Border#PART_Border" sets BorderThickness 0 0 0 2,
+             which outranks the template's BorderThickness binding) with a 3px LEFT accent
+             bar: UpdateTabVisuals keeps a constant 3,0,0,0 thickness on every TabItem and
+             paints only the selected one's BorderBrush. Re-asserting the thickness here
+             (window styles apply after the App ones) lets that value reach the template
+             border on the selected tab; unselected tabs get it via the plain template
+             binding. -->
+        <Style Selector="TabControl.vertical-tabs TabItem:selected /template/ Border#PART_Border">
+            <Setter Property="BorderThickness" Value="3 0 0 0"/>
+        </Style>
+
         <!-- GridSplitter Custom Template for thinner lines with larger hit area -->
         <Style Selector="GridSplitter">
             <Setter Property="Background" Value="#2D2D2D"/>

--- a/src/NovaTerminal.App/MainWindow.axaml
+++ b/src/NovaTerminal.App/MainWindow.axaml
@@ -145,6 +145,40 @@
                                             ZIndex="10"
                                             IsVisible="False"
                                             IsHitTestVisible="False" />
+                                    <!-- Vertical-mode overflow pill: a bottom-pinned affordance
+                                         over the scrolling headers when rows run past the sidebar
+                                         viewport (horizontal mode keeps the title-bar
+                                         TabOverflowBadge instead). Inert by default exactly like
+                                         PART_TabInsertIndicator above - IsVisible=False and colors
+                                         unset here; UpdateTabOverflowPill (from
+                                         UpdateTabHeaderViewport) owns visibility, text and
+                                         Background/Foreground. The code-set background is opaque so
+                                         rows scroll under it, and this fixed top hairline separates
+                                         it from the last visible row. Focusable=False keeps clicks
+                                         from stealing keyboard focus from the terminal (same rule
+                                         as BtnNewTab). The right margin keeps the pill clear of
+                                         PART_TabStripResizeGrip (right-edge, 5px wide, full
+                                         height): without it the pill would cover the grip's
+                                         bottom-right corner and make the strip un-resizable while
+                                         tabs overflow. -->
+                                    <Button Name="PART_TabOverflowPill"
+                                            Focusable="False"
+                                            Cursor="Hand"
+                                            Padding="0,6"
+                                            HorizontalAlignment="Stretch"
+                                            VerticalAlignment="Bottom"
+                                            Margin="0,0,10,0"
+                                            ZIndex="5"
+                                            IsVisible="False"
+                                            BorderThickness="0,1,0,0"
+                                            BorderBrush="#28FFFFFF">
+                                        <Button.Content>
+                                            <TextBlock Name="PART_TabOverflowPillText"
+                                                       FontSize="10"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center"/>
+                                        </Button.Content>
+                                    </Button>
                                 </Grid>
                                 <ContentPresenter Name="PART_SelectedContentHost"
                                                 Margin="0"

--- a/src/NovaTerminal.App/MainWindow.axaml
+++ b/src/NovaTerminal.App/MainWindow.axaml
@@ -116,6 +116,17 @@
                                             Background="Transparent"
                                             Cursor="SizeWestEast"
                                             IsVisible="False" />
+                                    <!-- Drag-to-reorder insert indicator: a 2px accent line at the
+                                         current drop gap. It lives in this Grid (ZIndex keeps it above
+                                         the headers) so it can span the strip in either orientation;
+                                         MainWindow's drag wiring owns background, length, position and
+                                         visibility, so the element is inert in XAML alone. -->
+                                    <Border Name="PART_TabInsertIndicator"
+                                            Width="2"
+                                            CornerRadius="1"
+                                            ZIndex="10"
+                                            IsVisible="False"
+                                            IsHitTestVisible="False" />
                                 </Grid>
                                 <ContentPresenter Name="PART_SelectedContentHost"
                                                 Margin="0"

--- a/src/NovaTerminal.App/MainWindow.axaml
+++ b/src/NovaTerminal.App/MainWindow.axaml
@@ -116,13 +116,19 @@
                                             Background="Transparent"
                                             Cursor="SizeWestEast"
                                             IsVisible="False" />
-                                    <!-- Drag-to-reorder insert indicator: a 2px accent line at the
+                                    <!-- Drag-to-reorder insert indicator: an accent line at the
                                          current drop gap. It lives in this Grid (ZIndex keeps it above
-                                         the headers) so it can span the strip in either orientation;
-                                         MainWindow's drag wiring owns background, length, position and
-                                         visibility, so the element is inert in XAML alone. -->
+                                         the headers) so it can span the strip in either orientation.
+                                         The static look (brush, corner radius, top-left alignment) is
+                                         set here once; MainWindow's drag wiring owns thickness, length,
+                                         position and visibility - the thickness runs along Width in
+                                         vertical mode and along Height in horizontal, sourced solely
+                                         from TabInsertIndicatorThickness in code, so no Width/Height
+                                         is set here on purpose. -->
                                     <Border Name="PART_TabInsertIndicator"
-                                            Width="2"
+                                            Background="#4FB0D4"
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Top"
                                             CornerRadius="1"
                                             ZIndex="10"
                                             IsVisible="False"

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -172,8 +172,9 @@ namespace NovaTerminal
         // microseconds before selection is restored - the SelectionChanged handler bails on
         // that transient promotion (see the guard at its top).
         private bool _isTabReorderCommitting;
-        // Hoisted like TabAttentionBrush: assigned on every drag start, not per-move.
-        private static readonly IBrush TabInsertIndicatorBrush = new SolidColorBrush(Color.Parse("#4FB0D4"));
+        // Single source of truth for the indicator's thickness (applied along Width in
+        // vertical mode, Height in horizontal - the XAML element deliberately sets no
+        // size). Brush/alignment live in the template XAML.
         private const double TabInsertIndicatorThickness = 2;
         private const double TabInsertIndicatorMinLength = 16;
 
@@ -866,6 +867,21 @@ namespace NovaTerminal
             if (_isTabReorderDragging)
             {
                 if (!ReferenceEquals(e.Pointer.Captured, headerHost)) return;
+
+                // Zombie-drag guard: the release event can be lost outright (quake-mode
+                // ToggleVisibility -> Hide() mid-drag), leaving capture set and the drag
+                // "alive" on the hidden window - the auto-scroll timer keeps ticking and,
+                // after re-show, buttonless hover moves keep driving the drag until some
+                // stray click commits an unintended reorder. A move with the button up
+                // means the gesture is physically over: cancel - never commit - through
+                // the same capture-releasing cleanup Escape uses. Mirrors the armed
+                // branch's staleness check below.
+                if (!e.GetCurrentPoint(headerHost).Properties.IsLeftButtonPressed)
+                {
+                    CancelTabReorderDrag();
+                    return;
+                }
+
                 UpdateTabDrag(e);
                 return;
             }
@@ -1008,14 +1024,13 @@ namespace NovaTerminal
             }
 
             // Length spans the dragged header's row/column (2px thick along the other axis),
-            // centered in the strip along the cross-axis.
+            // centered in the strip along the cross-axis. Background and alignment are
+            // constant, set once in the template XAML - only the per-drag values (thickness
+            // axis, length, margin, visibility) are assigned here.
             double crossLength = _isVerticalTabStrip
                 ? Math.Max(TabInsertIndicatorMinLength, _tabDragPressedHost?.Bounds.Height ?? 0)
                 : Math.Max(TabInsertIndicatorMinLength, _tabDragPressedHost?.Bounds.Width ?? 0);
 
-            indicator.Background = TabInsertIndicatorBrush;
-            indicator.HorizontalAlignment = HorizontalAlignment.Left;
-            indicator.VerticalAlignment = VerticalAlignment.Top;
             if (_isVerticalTabStrip)
             {
                 indicator.Width = TabInsertIndicatorThickness;
@@ -1061,21 +1076,33 @@ namespace NovaTerminal
                 ? scrollViewer.Extent.Height - scrollViewer.Viewport.Height
                 : scrollViewer.Extent.Width - scrollViewer.Viewport.Width;
             double next = Math.Clamp(offset + delta, 0, Math.Max(0, maxOffset));
-            scrollViewer.Offset = vertical
-                ? new Vector(scrollViewer.Offset.X, next)
-                : new Vector(next, scrollViewer.Offset.Y);
 
-            // Content scrolled under the parked pointer: its content-space position
-            // (viewport + offset) moved with it, so re-derive the insert index instead of
+            // Content scrolled under the parked pointer, so its content-space position
+            // (viewport + offset) moved with it: re-derive the insert index instead of
             // letting the drop gap lag behind the headers until the next pointer move.
+            //
+            // Ordering constraint: assigning Offset only invalidates arrange - the
+            // header bounds and the presenter->sidebar transform below still measure
+            // PRE-scroll geometry until the next layout pass. So everything here must
+            // derive from the PRE-scroll `offset`: pointer content-space =
+            // _tabDragPointerAxisPos + offset, the same frame GetTabHeaderBoundsInStrip
+            // reports. Mixing post-scroll pointer math (`+ next`) with pre-scroll bounds
+            // desynchronizes the indicator and drop index by up to one 12 DIP step, so a
+            // drop right after a scroll tick could pick the neighboring slot. Only move
+            // the Offset afterwards; layout catches up by the next tick (33ms), which
+            // then recomputes from the settled offset.
             var bounds = GetTabHeaderBoundsInStrip();
             if (bounds.Count > 0)
             {
                 _tabDragInsertIndex = TabDragModel.ComputeInsertIndex(
-                    HeaderCenters(bounds), _tabDragPointerAxisPos + next);
+                    HeaderCenters(bounds), _tabDragPointerAxisPos + offset);
             }
 
             PositionTabInsertIndicator(bounds);
+
+            scrollViewer.Offset = vertical
+                ? new Vector(scrollViewer.Offset.X, next)
+                : new Vector(next, scrollViewer.Offset.Y);
         }
 
         private void OnTabReorderPointerReleased(TabItem tab, Border headerHost, PointerReleasedEventArgs e)
@@ -3257,7 +3284,13 @@ namespace NovaTerminal
                 // An in-flight tab reorder drag owns the pointer; Escape aborts it before
                 // anything else - in particular before the broadcast-to-panes fallback at
                 // the bottom of this handler, which would otherwise also feed the raw ESC
-                // byte to the terminals while the user is only canceling a drag.
+                // byte to the terminals while the user is only canceling a drag. That
+                // priority holds only because this handler is registered with
+                // RoutingStrategies.Tunnel (the AddHandler call near the bottom of
+                // OnOpened): the tunneling window handler runs before the focused
+                // TerminalView's bubble-phase Escape handling (which sends "\x1b" to the
+                // PTY), so the drag is canceled and the event marked handled before the
+                // key could reach the pane.
                 if (_isTabReorderDragging && e.Key == Key.Escape)
                 {
                     CancelTabReorderDrag();
@@ -7481,6 +7514,9 @@ namespace NovaTerminal
             _recordingToastTimer.Stop();
             _updateCheckTimer.Stop();
             _tabStatusTimer?.Stop();
+            // A mid-drag close can beat the release/capture-lost cleanup, and a live
+            // DispatcherTimer would keep ticking (and rooting) the closed window.
+            _tabDragAutoScrollTimer?.Stop();
             _globalHotkey?.Dispose();
             // Dispose the snapshot scheduler before the agent-host teardown below: its Dispose
             // performs a best-effort final flush, which writes a snapshot, which logs — and the

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -1803,7 +1803,8 @@ namespace NovaTerminal
         /// UpdateTabHeaderViewport), or selection shifts (SelectionChanged →
         /// UpdateTabHeaderViewport), all of which already re-run this. Colors are reapplied
         /// on every visible pass so a theme change takes effect without a tab/viewport
-        /// change (two small brush allocations, same precedent as UpdateTabVisuals).</summary>
+        /// change (two small brush allocations - pill background and pill text
+        /// foreground - same precedent as UpdateTabVisuals).</summary>
         private void UpdateTabOverflowPill(ScrollViewer scrollViewer)
         {
             var pill = FindTabTemplatePart<Button>("PART_TabOverflowPill");
@@ -1832,6 +1833,10 @@ namespace NovaTerminal
                 return;
             }
 
+            // Occlusion semantics: the pill overlays the bottom ~25px of the viewport,
+            // so the lowest strictly-fully-visible row may be counted hidden (an
+            // undercount of one at most) - the semantic is "row doesn't fully fit
+            // above the pill", an accepted approximation matching the title-bar badge.
             int hiddenCount = CountHiddenTabs(
                 scrollViewer.Bounds.Height,
                 tabs.Items.Cast<TabItem>().Select(t => t.Bounds.Height),
@@ -1844,10 +1849,10 @@ namespace NovaTerminal
 
             var theme = _settings.ActiveTheme;
             pill.Background = new SolidColorBrush(theme.Background.ToAvaloniaColor());
-            // Same luminance-contrast pick as UpdateTabVisuals' header text, so the pill
-            // reads on both light and dark theme backgrounds.
-            double luminance = (0.299 * theme.Background.R + 0.587 * theme.Background.G + 0.114 * theme.Background.B) / 255.0;
-            pillText.Foreground = luminance > 0.5 ? Brushes.Black : Brushes.White;
+            // Same luminance-contrast pick as UpdateTabVisuals' header text, via the
+            // shared GetContrastForeground helper, so the pill reads on both light
+            // and dark theme backgrounds.
+            pillText.Foreground = new SolidColorBrush(theme.GetContrastForeground().ToAvaloniaColor());
             pillText.Text = $"+{hiddenCount} more";
             pill.IsVisible = true;
         }
@@ -6430,8 +6435,8 @@ namespace NovaTerminal
             CommandRegistry.Register("Close Pane", "General", () => CloseActivePane(), GetEffectiveShortcutBinding("close_pane", "Ctrl+Shift+W"), "close_pane");
             CommandRegistry.Register("Tab: Next (MRU)", "General", () => SwitchTabByMru(reverse: false), GetEffectiveShortcutBinding("next_tab", "Ctrl+Tab"), "next_tab");
             CommandRegistry.Register("Tab: Previous (MRU)", "General", () => SwitchTabByMru(reverse: true), GetEffectiveShortcutBinding("prev_tab", "Ctrl+Shift+Tab"), "prev_tab");
-            CommandRegistry.Register("Tab: Move Up", "General", () => MoveSelectedTab(-1), GetEffectiveShortcutBinding("move_tab_prev", "Ctrl+Shift+PageUp"), "move_tab_prev");
-            CommandRegistry.Register("Tab: Move Down", "General", () => MoveSelectedTab(1), GetEffectiveShortcutBinding("move_tab_next", "Ctrl+Shift+PageDown"), "move_tab_next");
+            CommandRegistry.Register("Tab: Move Previous", "General", () => MoveSelectedTab(-1), GetEffectiveShortcutBinding("move_tab_prev", "Ctrl+Shift+PageUp"), "move_tab_prev");
+            CommandRegistry.Register("Tab: Move Next", "General", () => MoveSelectedTab(1), GetEffectiveShortcutBinding("move_tab_next", "Ctrl+Shift+PageDown"), "move_tab_next");
             CommandRegistry.Register("Tab: Open Tab List", "General", () => PopulateTabListMenu(showFlyout: true), GetEffectiveShortcutBinding(TitleBarCatalog.OpenTabListId, "Ctrl+Shift+O"), TitleBarCatalog.OpenTabListId);
             CommandRegistry.Register("Tabs: Toggle Vertical Tab Sidebar", "General", () => ToggleTabOrientation(), GetEffectiveShortcutBinding("toggle_tab_orientation", "Ctrl+Shift+L"), "toggle_tab_orientation");
             CommandRegistry.Register("Tab: Rename Current", "General", () => _ = RenameSelectedTabAsync(), "");

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -143,6 +143,44 @@ namespace NovaTerminal
             get => _isTabStripGripDragging;
             set => _isTabStripGripDragging = value;
         }
+
+        // ---- Tab drag-to-reorder state (handlers near OnTabHeaderPointerPressed) ----
+        // A left press on a header host only ARMS a reorder; the drag begins once
+        // TabDragModel.ShouldStartDrag sees >= 5 DIP of movement along the strip axis, so a
+        // plain click keeps its select-on-press behavior. From that point the pressed header
+        // host holds pointer capture and is dimmed, PART_TabInsertIndicator marks the drop
+        // gap, and an auto-scroll DispatcherTimer runs near the viewport edges. The reorder
+        // itself only moves entries inside Tabs.Items - the same TabItem instances and pane
+        // content are reused (ApplyTabLayout's PART_SelectedContentHost ownership contract).
+        private bool _isTabReorderDragging;
+        private bool _isTabHeaderLeftPressPending;
+        private Border? _tabDragPressedHost;
+        private IPointer? _tabDragPointer;
+        private TabControl? _tabDragTabs;
+        private double _tabDragPressAxisPos;
+        // Pointer position along the strip axis in the header ScrollViewer's VIEWPORT
+        // coordinate space - kept fresh on every move so the auto-scroll tick can evaluate
+        // the edge zones without waiting for another pointer event. Viewport space (unlike
+        // the ItemsPresenter's content space, which the insert-index math uses) is what
+        // stays constant while the pointer parks in an edge zone and only the strip
+        // scrolls underneath. NaN = "no position yet"; TabDragModel treats that as no-op.
+        private double _tabDragPointerAxisPos = double.NaN;
+        private int _tabDragInsertIndex;
+        private DispatcherTimer? _tabDragAutoScrollTimer;
+        // True only inside the RemoveAt/Insert window of CommitTabReorder. TabControl is
+        // AlwaysSelected, so removing the (selected) dragged tab promotes index 0 for the
+        // microseconds before selection is restored - the SelectionChanged handler bails on
+        // that transient promotion (see the guard at its top).
+        private bool _isTabReorderCommitting;
+        // Hoisted like TabAttentionBrush: assigned on every drag start, not per-move.
+        private static readonly IBrush TabInsertIndicatorBrush = new SolidColorBrush(Color.Parse("#4FB0D4"));
+        private const double TabInsertIndicatorThickness = 2;
+        private const double TabInsertIndicatorMinLength = 16;
+
+        /// <summary>Test-only seam: exposes the mid-reorder-drag state (same pattern as
+        /// <see cref="IsTabStripGripDraggingForTest"/>).</summary>
+        internal bool IsTabReorderDraggingForTest => _isTabReorderDragging;
+
         private bool _isDraggingTransferOverlay;
         private Point _transferOverlayDragStart;
         private Point _transferOverlayOffsetStart;
@@ -671,6 +709,7 @@ namespace NovaTerminal
 
             headerHost.ContextFlyout = new MenuFlyout();
             headerHost.PointerPressed += (_, e) => OnTabHeaderPointerPressed(tab, e);
+            WireTabHeaderReorderDrag(tab, headerHost);
             ToolTip.SetTip(headerHost, text);
             return headerHost;
         }
@@ -727,6 +766,7 @@ namespace NovaTerminal
 
             headerHost.ContextFlyout = new MenuFlyout();
             headerHost.PointerPressed += (_, e) => OnTabHeaderPointerPressed(tab, e);
+            WireTabHeaderReorderDrag(tab, headerHost);
             ToolTip.SetTip(headerHost, text);
             return headerHost;
         }
@@ -780,6 +820,359 @@ namespace NovaTerminal
                     e.Handled = true;
                     ShowTabContextMenu(tab, headerHost, flyout, ShouldDeferTabContextMenuOpen(wasSelected));
                 }
+            }
+        }
+
+        // ---- Tab drag-to-reorder (pure math lives in Shell/TabDragModel.cs) ----
+        //
+        // Subscribed by both header factories, so the behavior is axis-generic: which
+        // coordinate feeds TabDragModel is decided by _isVerticalTabStrip, and header bounds
+        // and pointer positions are both measured in the ItemsPresenter's (content)
+        // coordinate space so scrolling is accounted for. The reorder only moves entries
+        // inside Tabs.Items - TabItem instances and their pane content are never recreated
+        // (ApplyTabLayout's ownership contract for PART_SelectedContentHost).
+        private void WireTabHeaderReorderDrag(TabItem tab, Border headerHost)
+        {
+            headerHost.PointerPressed += (_, e) => OnTabReorderPointerPressed(tab, headerHost, e);
+            headerHost.PointerMoved += (_, e) => OnTabReorderPointerMoved(tab, headerHost, e);
+            headerHost.PointerReleased += (_, e) => OnTabReorderPointerReleased(tab, headerHost, e);
+            // Involuntary capture loss (another control steals it, window deactivates
+            // mid-drag) must abort without committing - the same non-committing-cleanup
+            // contract the sidebar grip's PointerCaptureLost follows.
+            headerHost.PointerCaptureLost += (_, _) => EndTabReorderDrag();
+        }
+
+        private void OnTabReorderPointerPressed(TabItem tab, Border headerHost, PointerPressedEventArgs e)
+        {
+            // Middle/right presses have already been claimed (handled) by
+            // OnTabHeaderPointerPressed for select/close/context-menu; only an unhandled
+            // left press can become a reorder drag.
+            if (e.Handled || !e.GetCurrentPoint(headerHost).Properties.IsLeftButtonPressed)
+            {
+                _isTabHeaderLeftPressPending = false;
+                return;
+            }
+
+            // Arm, don't capture (yet): a plain click must keep its existing behavior, and a
+            // capture here would break hover on the other headers before any drag starts.
+            _isTabHeaderLeftPressPending = true;
+            _tabDragPressedHost = headerHost;
+            _tabDragTabs = this.FindControl<TabControl>("Tabs");
+            _tabDragPressAxisPos = GetTabStripAxisPosition(e);
+        }
+
+        private void OnTabReorderPointerMoved(TabItem tab, Border headerHost, PointerEventArgs e)
+        {
+            if (_isTabReorderDragging)
+            {
+                if (!ReferenceEquals(e.Pointer.Captured, headerHost)) return;
+                UpdateTabDrag(e);
+                return;
+            }
+
+            if (!_isTabHeaderLeftPressPending || !ReferenceEquals(_tabDragPressedHost, headerHost)) return;
+
+            // The button coming up outside this host (nothing captured yet) leaves the armed
+            // press stale; the next buttonless move over the host must not graduate it.
+            if (!e.GetCurrentPoint(headerHost).Properties.IsLeftButtonPressed)
+            {
+                _isTabHeaderLeftPressPending = false;
+                return;
+            }
+
+            // The grip owns the pointer for the duration of a sidebar resize; a header move
+            // arriving then is a stray cross-route event, not a reorder gesture. Likewise a
+            // single-tab strip can never reorder.
+            if (_isTabStripGripDragging || _tabDragTabs == null || _tabDragTabs.Items.Count < 2)
+            {
+                _isTabHeaderLeftPressPending = false;
+                return;
+            }
+
+            var axisPos = GetTabStripAxisPosition(e);
+            if (!TabDragModel.ShouldStartDrag(_tabDragPressAxisPos, axisPos)) return;
+
+            BeginTabReorderDrag(headerHost, e);
+        }
+
+        private void BeginTabReorderDrag(Border headerHost, PointerEventArgs e)
+        {
+            _isTabHeaderLeftPressPending = false;
+            _isTabReorderDragging = true;
+            _tabDragPointer = e.Pointer;
+            e.Pointer.Capture(headerHost);
+            headerHost.Opacity = 0.5;
+
+            UpdateTabDrag(e);
+
+            // Auto-scroll near the viewport edges runs on a timer rather than only on moves:
+            // once the pointer parks inside an edge zone, it stops generating PointerMoved
+            // events but the strip must keep scrolling.
+            _tabDragAutoScrollTimer ??= CreateTabDragAutoScrollTimer();
+            _tabDragAutoScrollTimer.Start();
+        }
+
+        private DispatcherTimer CreateTabDragAutoScrollTimer()
+        {
+            var timer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(33) };
+            timer.Tick += (_, _) => AutoScrollTabDrag();
+            return timer;
+        }
+
+        private void UpdateTabDrag(PointerEventArgs e)
+        {
+            var axisPos = GetTabStripAxisPosition(e);
+            if (!double.IsFinite(axisPos)) return;
+
+            // Viewport-space pointer position for the auto-scroll tick: content-space minus
+            // the current scroll offset (content = viewport + offset).
+            var scrollViewer = FindTabHeaderScrollViewer();
+            double offset = scrollViewer == null
+                ? 0
+                : (_isVerticalTabStrip ? scrollViewer.Offset.Y : scrollViewer.Offset.X);
+            _tabDragPointerAxisPos = axisPos - offset;
+
+            var bounds = GetTabHeaderBoundsInStrip();
+            if (bounds.Count == 0) return;
+
+            _tabDragInsertIndex = TabDragModel.ComputeInsertIndex(HeaderCenters(bounds), axisPos);
+            PositionTabInsertIndicator(bounds);
+        }
+
+        private static List<double> HeaderCenters(List<(double Start, double End)> bounds)
+        {
+            var centers = new List<double>(bounds.Count);
+            foreach (var extent in bounds)
+            {
+                centers.Add((extent.Start + extent.End) / 2);
+            }
+
+            return centers;
+        }
+
+        /// <summary>Pointer position along the strip axis in the ItemsPresenter's (content)
+        /// coordinate space - the same space <see cref="GetTabHeaderBoundsInStrip"/> reports,
+        /// so scrolling never desynchronizes the two. Non-finite when the presenter or the
+        /// position transform is unavailable; TabDragModel's guards treat that as
+        /// "no drag start / insert index 0".</summary>
+        private double GetTabStripAxisPosition(PointerEventArgs e)
+        {
+            var presenter = FindTabItemsPresenter();
+            if (presenter == null) return double.NaN;
+            var position = e.GetPosition(presenter);
+            return _isVerticalTabStrip ? position.Y : position.X;
+        }
+
+        /// <summary>Along-axis extent of every tab's header container (the TabItem itself, a
+        /// realized child of the items panel) in the ItemsPresenter's coordinate space, in
+        /// visual (= Items) order. The dragged tab keeps its original slot until commit, so
+        /// the list always reflects the pre-reorder order ComputeInsertIndex expects.</summary>
+        private List<(double Start, double End)> GetTabHeaderBoundsInStrip()
+        {
+            var bounds = new List<(double Start, double End)>();
+            var presenter = FindTabItemsPresenter();
+            var tabs = _tabDragTabs ?? this.FindControl<TabControl>("Tabs");
+            if (presenter == null || tabs == null) return bounds;
+
+            foreach (var tab in tabs.Items.Cast<TabItem>())
+            {
+                var topLeft = tab.TranslatePoint(new Point(0, 0), presenter);
+                if (topLeft == null) continue;
+                bounds.Add(_isVerticalTabStrip
+                    ? (topLeft.Value.Y, topLeft.Value.Y + tab.Bounds.Height)
+                    : (topLeft.Value.X, topLeft.Value.X + tab.Bounds.Width));
+            }
+
+            return bounds;
+        }
+
+        private void PositionTabInsertIndicator(List<(double Start, double End)> bounds)
+        {
+            var indicator = FindTabTemplatePart<Border>("PART_TabInsertIndicator");
+            var sidebar = FindTabTemplatePart<Grid>("PART_TabSidebar");
+            if (indicator == null || sidebar == null || bounds.Count == 0) return;
+
+            // Gap along the axis: the near edge of the header currently at the insert index,
+            // or the far edge of the last header when dropping at the very end.
+            var index = Math.Clamp(_tabDragInsertIndex, 0, bounds.Count);
+            double edge = index < bounds.Count ? bounds[index].Start : bounds[bounds.Count - 1].End;
+
+            // Translate the content-space edge into the sidebar Grid's space (the indicator's
+            // parent), so auto-scrolling mid-drag keeps the line glued to the on-screen gap.
+            var gapInContent = _isVerticalTabStrip ? new Point(0, edge) : new Point(edge, 0);
+            var gapInSidebar = FindTabItemsPresenter()?.TranslatePoint(gapInContent, sidebar);
+            if (gapInSidebar == null)
+            {
+                indicator.IsVisible = false;
+                return;
+            }
+
+            // Length spans the dragged header's row/column (2px thick along the other axis),
+            // centered in the strip along the cross-axis.
+            double crossLength = _isVerticalTabStrip
+                ? Math.Max(TabInsertIndicatorMinLength, _tabDragPressedHost?.Bounds.Height ?? 0)
+                : Math.Max(TabInsertIndicatorMinLength, _tabDragPressedHost?.Bounds.Width ?? 0);
+
+            indicator.Background = TabInsertIndicatorBrush;
+            indicator.HorizontalAlignment = HorizontalAlignment.Left;
+            indicator.VerticalAlignment = VerticalAlignment.Top;
+            if (_isVerticalTabStrip)
+            {
+                indicator.Width = TabInsertIndicatorThickness;
+                indicator.Height = crossLength;
+                indicator.Margin = new Thickness(
+                    sidebar.Bounds.Width / 2 - TabInsertIndicatorThickness / 2, gapInSidebar.Value.Y, 0, 0);
+            }
+            else
+            {
+                indicator.Height = TabInsertIndicatorThickness;
+                indicator.Width = crossLength;
+                indicator.Margin = new Thickness(
+                    gapInSidebar.Value.X, sidebar.Bounds.Height / 2 - TabInsertIndicatorThickness / 2, 0, 0);
+            }
+
+            indicator.IsVisible = true;
+        }
+
+        private void AutoScrollTabDrag()
+        {
+            if (!_isTabReorderDragging)
+            {
+                _tabDragAutoScrollTimer?.Stop();
+                return;
+            }
+
+            var scrollViewer = FindTabHeaderScrollViewer();
+            if (scrollViewer == null) return;
+
+            // _tabDragPointerAxisPos is already viewport-space (where the edge zones live),
+            // and it stays constant while the pointer parks and the strip scrolls - so the
+            // tick keeps scrolling until the extent clamp stops it, rather than the pointer
+            // "drifting" out of the zone it is physically still in.
+            bool vertical = _isVerticalTabStrip;
+            double viewportLength = vertical ? scrollViewer.Viewport.Height : scrollViewer.Viewport.Width;
+            double delta = TabDragModel.ComputeAutoScrollDelta(0, viewportLength, _tabDragPointerAxisPos);
+            if (delta == 0) return;
+
+            // Clamp to the scrollable extent (Extent - Viewport), mirroring what the
+            // ScrollViewer itself would do with an out-of-range Offset assignment.
+            double offset = vertical ? scrollViewer.Offset.Y : scrollViewer.Offset.X;
+            double maxOffset = vertical
+                ? scrollViewer.Extent.Height - scrollViewer.Viewport.Height
+                : scrollViewer.Extent.Width - scrollViewer.Viewport.Width;
+            double next = Math.Clamp(offset + delta, 0, Math.Max(0, maxOffset));
+            scrollViewer.Offset = vertical
+                ? new Vector(scrollViewer.Offset.X, next)
+                : new Vector(next, scrollViewer.Offset.Y);
+
+            // Content scrolled under the parked pointer: its content-space position
+            // (viewport + offset) moved with it, so re-derive the insert index instead of
+            // letting the drop gap lag behind the headers until the next pointer move.
+            var bounds = GetTabHeaderBoundsInStrip();
+            if (bounds.Count > 0)
+            {
+                _tabDragInsertIndex = TabDragModel.ComputeInsertIndex(
+                    HeaderCenters(bounds), _tabDragPointerAxisPos + next);
+            }
+
+            PositionTabInsertIndicator(bounds);
+        }
+
+        private void OnTabReorderPointerReleased(TabItem tab, Border headerHost, PointerReleasedEventArgs e)
+        {
+            if (_isTabReorderDragging && ReferenceEquals(e.Pointer.Captured, headerHost))
+            {
+                // Releasing capture synchronously raises PointerCaptureLost, which runs the
+                // shared non-committing cleanup; commit afterwards, ordered by the final
+                // insert index.
+                e.Pointer.Capture(null);
+                CommitTabReorder(tab);
+                return;
+            }
+
+            // An armed press that never crossed the drag threshold ends here (a plain
+            // click): disarm without touching anything.
+            if (_isTabHeaderLeftPressPending && ReferenceEquals(_tabDragPressedHost, headerHost))
+            {
+                _isTabHeaderLeftPressPending = false;
+            }
+        }
+
+        private void CommitTabReorder(TabItem draggedTab)
+        {
+            var tabs = _tabDragTabs ?? this.FindControl<TabControl>("Tabs");
+            if (tabs == null) return;
+
+            int oldIndex = tabs.Items.IndexOf(draggedTab);
+            if (oldIndex < 0) return;
+
+            // ComputeInsertIndex ran over the pre-reorder order (the dragged header never
+            // leaves its slot during the drag), so a target past the dragged tab collapses by
+            // one once the dragged tab is removed from Items.
+            int insertIndex = Math.Clamp(_tabDragInsertIndex, 0, tabs.Items.Count);
+            int newIndex = insertIndex > oldIndex ? insertIndex - 1 : insertIndex;
+
+            if (newIndex != oldIndex)
+            {
+                // Selected-item removal under TabControl's AlwaysSelected mode promotes
+                // whatever lands at index 0 to SelectedItem until the restore below - the
+                // SelectionChanged handler skips that transient promotion via
+                // _isTabReorderCommitting (no MRU touch, no attention clear, no focus steal
+                // on a tab the user never actually viewed), then the restore re-runs the
+                // full select path for the dragged tab with the final Items order. The
+                // mutation itself is the same remove-from-live-ItemCollection pattern
+                // CloseTab uses: the TabItem and its pane content are reused, never
+                // recreated (ApplyTabLayout's ownership contract).
+                _isTabReorderCommitting = true;
+                try
+                {
+                    tabs.Items.RemoveAt(oldIndex);
+                    tabs.Items.Insert(newIndex, draggedTab);
+                }
+                finally
+                {
+                    _isTabReorderCommitting = false;
+                }
+            }
+
+            tabs.SelectedItem = draggedTab;
+        }
+
+        /// <summary>Shared non-committing cleanup for drag end, Escape and involuntary
+        /// capture loss alike: hide the indicator, restore the dimmed header, stop the
+        /// auto-scroll timer. Does not reset <c>_tabDragInsertIndex</c> - the release
+        /// handler still needs it for its commit after capture release runs this first.</summary>
+        private void EndTabReorderDrag()
+        {
+            _isTabReorderDragging = false;
+            _isTabHeaderLeftPressPending = false;
+            if (_tabDragPressedHost != null)
+            {
+                _tabDragPressedHost.Opacity = 1;
+            }
+
+            _tabDragPressedHost = null;
+            _tabDragPointer = null;
+            _tabDragTabs = null;
+            _tabDragAutoScrollTimer?.Stop();
+            if (FindTabTemplatePart<Border>("PART_TabInsertIndicator") is { } indicator)
+            {
+                indicator.IsVisible = false;
+            }
+        }
+
+        /// <summary>Aborts an in-flight reorder drag without committing (Escape). Dropping
+        /// capture raises PointerCaptureLost on the header host, running the shared
+        /// <see cref="EndTabReorderDrag"/> cleanup - the same contract as a capture steal.</summary>
+        private void CancelTabReorderDrag()
+        {
+            if (_tabDragPointer?.Captured != null)
+            {
+                _tabDragPointer.Capture(null);
+            }
+            else
+            {
+                EndTabReorderDrag();
             }
         }
 
@@ -1086,6 +1479,11 @@ namespace NovaTerminal
                 // the 1s tab-status timer) must not reset it back to the stale persisted value,
                 // or the in-progress drag is silently discarded (visible snap-back, and a
                 // release without another move would persist the reverted width).
+                //
+                // A reorder drag needs no analogous guard: it owns neither Width, Height nor
+                // Offset - only the insert indicator (positioned in PART_TabSidebar space) and
+                // the dragged header's opacity, none of which this method resets. Rewriting the
+                // identical sizing values below is a no-op for an in-flight reorder.
                 if (!_isTabStripGripDragging)
                 {
                     scrollViewer.Width = TabStripLayout.ClampSidebarWidth(_settings.VerticalTabStripWidth);
@@ -2694,6 +3092,15 @@ namespace NovaTerminal
             {
                 tabs.SelectionChanged += (s, e) =>
                 {
+                    // A reorder commit removes the selected (dragged) tab from Items and
+                    // reinserts it at the drop index; TabControl's AlwaysSelected mode
+                    // promotes index 0 to SelectedItem for the duration of that window (see
+                    // CommitTabReorder). That promotion is an implementation artifact, not a
+                    // user selection: skip it entirely (MRU touch, attention clear, focus
+                    // handoff) - the restore of the dragged tab right after re-enters here
+                    // with the true final selection and runs the full path.
+                    if (_isTabReorderCommitting) return;
+
                     var sw = System.Diagnostics.Stopwatch.StartNew();
                     bool updatedSpecific = false;
                     foreach (var removed in e.RemovedItems.OfType<TabItem>())
@@ -2847,6 +3254,17 @@ namespace NovaTerminal
             // Keyboard Shortcuts
             this.AddHandler(KeyDownEvent, (s, e) =>
             {
+                // An in-flight tab reorder drag owns the pointer; Escape aborts it before
+                // anything else - in particular before the broadcast-to-panes fallback at
+                // the bottom of this handler, which would otherwise also feed the raw ESC
+                // byte to the terminals while the user is only canceling a drag.
+                if (_isTabReorderDragging && e.Key == Key.Escape)
+                {
+                    CancelTabReorderDrag();
+                    e.Handled = true;
+                    return;
+                }
+
                 var modifiers = e.KeyModifiers;
                 bool isCtrl = (modifiers & KeyModifiers.Control) != 0;
                 bool isShift = (modifiers & KeyModifiers.Shift) != 0;

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -556,8 +556,9 @@ namespace NovaTerminal
 
             // Precise running state, one pass over the registry snapshot before the per-tab
             // loop: any tab owning a pane whose agent-session status machine reports Running
-            // has a command in flight. The output-burst heuristic above decays after 2 quiet
-            // seconds, so a silently-thinking agent CLI (60s between tokens is normal) would
+            // has a command in flight. The output-burst heuristic below (Status.Evaluate in
+            // the per-tab loop) decays after 2 quiet seconds, so a silently-thinking agent
+            // CLI (60s between tokens is normal) would
             // flip its dot back to idle; the per-session status machine knows better. Same
             // registration→tab mapping as RefreshTabAgentAttention (TabId vs the persistent
             // tab id). Snapshot() is thread-safe; GetRegistrations() hands back a point-in-time
@@ -588,7 +589,10 @@ namespace NovaTerminal
                 // Same change-driven queueing as RenderedStatus: the flag feeds
                 // ResolveTabDot via UpdateVerticalTabExtras, which only runs in vertical
                 // mode (horizontal headers never read it - stale-but-unread there, cost
-                // zero, which is why this whole method is vertical-only).
+                // zero, which is why this whole method is vertical-only). One benign
+                // transient: flipping horizontal→vertical re-enters with up to 1s of
+                // stale dot state until the first tick resyncs - self-correcting and
+                // cosmetic, so it needs no mode-flip hook here.
                 bool running = runningTabIds.Contains(GetPersistentTabId(tab));
                 if (running != state.HasRunningCommand)
                 {

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -199,6 +199,13 @@ namespace NovaTerminal
         // set in MainWindow.axaml's styles.
         private const double DefaultVerticalTabRowHeight = 44;
         private const double TabInsertIndicatorMinLength = 16;
+        // Tag marking a template part whose one-time wiring has already happened (resize
+        // grip, overflow pill), so repeated ApplyTabLayout passes cannot double-subscribe.
+        private const string TemplatePartWiredTag = "wired";
+        // Command ids for the keyboard move-tab actions (ShortcutCatalog keys + command
+        // palette ids + usage recording must all agree).
+        private const string MoveTabPrevCommandId = "move_tab_prev";
+        private const string MoveTabNextCommandId = "move_tab_next";
 
         /// <summary>Test-only seam: exposes the mid-reorder-drag state (same pattern as
         /// <see cref="IsTabStripGripDraggingForTest"/>).</summary>
@@ -962,8 +969,8 @@ namespace NovaTerminal
         // (ApplyTabLayout's ownership contract for PART_SelectedContentHost).
         private void WireTabHeaderReorderDrag(TabItem tab, Border headerHost)
         {
-            headerHost.PointerPressed += (_, e) => OnTabReorderPointerPressed(tab, headerHost, e);
-            headerHost.PointerMoved += (_, e) => OnTabReorderPointerMoved(tab, headerHost, e);
+            headerHost.PointerPressed += (_, e) => OnTabReorderPointerPressed(headerHost, e);
+            headerHost.PointerMoved += (_, e) => OnTabReorderPointerMoved(headerHost, e);
             headerHost.PointerReleased += (_, e) => OnTabReorderPointerReleased(tab, headerHost, e);
             // Involuntary capture loss (another control steals it, window deactivates
             // mid-drag) must abort without committing - the same non-committing-cleanup
@@ -971,7 +978,7 @@ namespace NovaTerminal
             headerHost.PointerCaptureLost += (_, _) => EndTabReorderDrag();
         }
 
-        private void OnTabReorderPointerPressed(TabItem tab, Border headerHost, PointerPressedEventArgs e)
+        private void OnTabReorderPointerPressed(Border headerHost, PointerPressedEventArgs e)
         {
             // Middle/right presses have already been claimed (handled) by
             // OnTabHeaderPointerPressed for select/close/context-menu; only an unhandled
@@ -990,7 +997,7 @@ namespace NovaTerminal
             _tabDragPressAxisPos = GetTabStripAxisPosition(e);
         }
 
-        private void OnTabReorderPointerMoved(TabItem tab, Border headerHost, PointerEventArgs e)
+        private void OnTabReorderPointerMoved(Border headerHost, PointerEventArgs e)
         {
             if (_isTabReorderDragging)
             {
@@ -1071,9 +1078,12 @@ namespace NovaTerminal
             // Viewport-space pointer position for the auto-scroll tick: content-space minus
             // the current scroll offset (content = viewport + offset).
             var scrollViewer = FindTabHeaderScrollViewer();
-            double offset = scrollViewer == null
-                ? 0
-                : (_isVerticalTabStrip ? scrollViewer.Offset.Y : scrollViewer.Offset.X);
+            double offset = 0;
+            if (scrollViewer != null)
+            {
+                offset = _isVerticalTabStrip ? scrollViewer.Offset.Y : scrollViewer.Offset.X;
+            }
+
             _tabDragPointerAxisPos = axisPos - offset;
 
             var bounds = GetTabHeaderBoundsInStrip();
@@ -1151,27 +1161,30 @@ namespace NovaTerminal
                 return;
             }
 
-            // Length spans the dragged header's row/column (2px thick along the other axis),
-            // centered in the strip along the cross-axis. Background and alignment are
-            // constant, set once in the template XAML - only the per-drag values (thickness
-            // axis, length, margin, visibility) are assigned here.
+            // The bar spans the drop gap like a divider between adjacent tabs: its length
+            // runs along the CROSS axis (the dragged header's row width in vertical mode,
+            // its column height in horizontal mode) and the 2-DIP thickness runs along the
+            // drag axis, straddling the gap edge. Background and alignment are constant,
+            // set once in the template XAML - only the per-drag values (thickness axis,
+            // length, margin, visibility) are assigned here.
             double crossLength = _isVerticalTabStrip
-                ? Math.Max(TabInsertIndicatorMinLength, _tabDragPressedHost?.Bounds.Height ?? 0)
-                : Math.Max(TabInsertIndicatorMinLength, _tabDragPressedHost?.Bounds.Width ?? 0);
+                ? Math.Max(TabInsertIndicatorMinLength, _tabDragPressedHost?.Bounds.Width ?? 0)
+                : Math.Max(TabInsertIndicatorMinLength, _tabDragPressedHost?.Bounds.Height ?? 0);
 
             if (_isVerticalTabStrip)
-            {
-                indicator.Width = TabInsertIndicatorThickness;
-                indicator.Height = crossLength;
-                indicator.Margin = new Thickness(
-                    sidebar.Bounds.Width / 2 - TabInsertIndicatorThickness / 2, gapInSidebar.Value.Y, 0, 0);
-            }
-            else
             {
                 indicator.Height = TabInsertIndicatorThickness;
                 indicator.Width = crossLength;
                 indicator.Margin = new Thickness(
-                    gapInSidebar.Value.X, sidebar.Bounds.Height / 2 - TabInsertIndicatorThickness / 2, 0, 0);
+                    0, gapInSidebar.Value.Y - TabInsertIndicatorThickness / 2, 0, 0);
+            }
+            else
+            {
+                indicator.Width = TabInsertIndicatorThickness;
+                indicator.Height = crossLength;
+                indicator.Margin = new Thickness(
+                    gapInSidebar.Value.X - TabInsertIndicatorThickness / 2,
+                    Math.Max(0, (sidebar.Bounds.Height - crossLength) / 2), 0, 0);
             }
 
             indicator.IsVisible = true;
@@ -1589,8 +1602,8 @@ namespace NovaTerminal
             var grip = this.GetVisualDescendants().OfType<Border>()
                 .FirstOrDefault(b => b.Name == "PART_TabStripResizeGrip");
             var scrollViewer = FindTabHeaderScrollViewer();
-            if (grip == null || scrollViewer == null || Equals(grip.Tag, "wired")) return;
-            grip.Tag = "wired";
+            if (grip == null || scrollViewer == null || Equals(grip.Tag, TemplatePartWiredTag)) return;
+            grip.Tag = TemplatePartWiredTag;
 
             double startWidth = 0;
             double startX = 0;
@@ -1867,8 +1880,8 @@ namespace NovaTerminal
         private void WireTabOverflowPill()
         {
             var pill = FindTabTemplatePart<Button>("PART_TabOverflowPill");
-            if (pill == null || Equals(pill.Tag, "wired")) return;
-            pill.Tag = "wired";
+            if (pill == null || Equals(pill.Tag, TemplatePartWiredTag)) return;
+            pill.Tag = TemplatePartWiredTag;
 
             // Focusable=False (XAML) keeps the click from moving keyboard focus off the
             // terminal; the open flyout takes focus only while open, like any menu.
@@ -1913,62 +1926,68 @@ namespace NovaTerminal
             }
         }
 
-        private void PopulateTabListMenu(bool showFlyout = false, Control? anchorOverride = null)
+        /// <summary>Resolves where the tab-list menu anchors and which flyout to populate:
+        /// an explicit override (the vertical overflow pill), else the pinned Tab List
+        /// button (its flyout created and attached on first use), else the "..." overflow
+        /// button or the title-bar host panel as a fallback anchor with a dedicated
+        /// long-lived flyout. Null when no anchor exists at all.</summary>
+        private (Control Anchor, MenuFlyout Flyout)? ResolveTabListMenuHost(Control? anchorOverride)
         {
-            var tabs = this.FindControl<TabControl>("Tabs");
-            if (tabs == null) return;
-
-            Control? anchor;
-            MenuFlyout flyout;
             if (anchorOverride is not null)
             {
                 // Vertical overflow pill path: anchor the menu at the pill instead of the
                 // title bar, into the pill-dedicated flyout (see _tabOverflowPillFlyout for
                 // why it cannot ride the pill's own Flyout property). The item-building and
-                // show logic below is shared verbatim with the title-bar paths.
-                anchor = anchorOverride;
-                flyout = _tabOverflowPillFlyout ??= new MenuFlyout();
+                // show logic in PopulateTabListMenu is shared verbatim with the title-bar paths.
+                return (anchorOverride, _tabOverflowPillFlyout ??= new MenuFlyout());
             }
-            else
-            {
-                // "open_tab_list" may legitimately be Overflow or Hidden per the user's title bar
-                // layout, in which case FindTitleBarButton returns null for its dedicated button - but
-                // the action must still be reachable by shortcut and command palette (that is the whole
-                // premise of Hidden: still there, just not a dedicated icon). DO NOT simplify this back
-                // to the button-only lookup: that was exactly the bug (Codex P2 on PR #342) - with no
-                // fallback, setting Tab List to Overflow or Hidden turned the overflow menu item, the
-                // Ctrl+Shift+O shortcut, and the command palette entry all into silent no-ops. Fall back
-                // to the overflow button when it exists, and finally to the title bar host panel itself,
-                // which always exists.
-                var button = FindTitleBarButton(TitleBarCatalog.OpenTabListId);
-                var host = this.FindControl<StackPanel>("TitleBarItemsHost");
-                var overflowButton = host?.Children.OfType<Button>()
-                    .FirstOrDefault(b => b.Name == TitleBarViewFactory.OverflowButtonName);
-                anchor = (Control?)button ?? (Control?)overflowButton ?? host;
-                if (anchor == null) return;
 
-                // A pinned item's own button starts out with no popup menu attached, so this method is
-                // where one gets created and attached, the first time it is needed. The overflow ("...")
-                // button is different: it already carries its own popup, prebuilt to list whichever
-                // actions do not have a dedicated icon right now, and grabbing hold of that same popup
-                // here would silently replace those contents the next time someone opens the "..." menu.
-                // The panel hosting the title bar buttons cannot carry a popup at all. So whenever the
-                // anchor is not a pinned item's own button, this method falls back to one dedicated menu
-                // kept alive across calls purely to support that case.
-                if (button is not null)
+            // "open_tab_list" may legitimately be Overflow or Hidden per the user's title bar
+            // layout, in which case FindTitleBarButton returns null for its dedicated button - but
+            // the action must still be reachable by shortcut and command palette (that is the whole
+            // premise of Hidden: still there, just not a dedicated icon). DO NOT simplify this back
+            // to the button-only lookup: that was exactly the bug (Codex P2 on PR #342) - with no
+            // fallback, setting Tab List to Overflow or Hidden turned the overflow menu item, the
+            // Ctrl+Shift+O shortcut, and the command palette entry all into silent no-ops. Fall back
+            // to the overflow button when it exists, and finally to the title bar host panel itself,
+            // which always exists.
+            var button = FindTitleBarButton(TitleBarCatalog.OpenTabListId);
+            var host = this.FindControl<StackPanel>("TitleBarItemsHost");
+            var overflowButton = host?.Children.OfType<Button>()
+                .FirstOrDefault(b => b.Name == TitleBarViewFactory.OverflowButtonName);
+            var anchor = (Control?)button ?? (Control?)overflowButton ?? host;
+            if (anchor == null) return null;
+
+            // A pinned item's own button starts out with no popup menu attached, so this is
+            // where one gets created and attached, the first time it is needed. The overflow ("...")
+            // button is different: it already carries its own popup, prebuilt to list whichever
+            // actions do not have a dedicated icon right now, and grabbing hold of that same popup
+            // here would silently replace those contents the next time someone opens the "..." menu.
+            // The panel hosting the title bar buttons cannot carry a popup at all. So whenever the
+            // anchor is not a pinned item's own button, fall back to one dedicated menu kept alive
+            // across calls purely to support that case.
+            if (button is not null)
+            {
+                if (button.Flyout is not MenuFlyout existing)
                 {
-                    if (button.Flyout is not MenuFlyout existing)
-                    {
-                        existing = new MenuFlyout();
-                        button.Flyout = existing;
-                    }
-                    flyout = existing;
+                    existing = new MenuFlyout();
+                    button.Flyout = existing;
                 }
-                else
-                {
-                    flyout = _tabListFallbackFlyout ??= new MenuFlyout();
-                }
+
+                return (anchor, existing);
             }
+
+            return (anchor, _tabListFallbackFlyout ??= new MenuFlyout());
+        }
+
+        private void PopulateTabListMenu(bool showFlyout = false, Control? anchorOverride = null)
+        {
+            var tabs = this.FindControl<TabControl>("Tabs");
+            if (tabs == null) return;
+
+            var resolved = ResolveTabListMenuHost(anchorOverride);
+            if (resolved == null) return;
+            var (anchor, flyout) = resolved.Value;
 
             flyout.Items.Clear();
             int index = 1;
@@ -3788,8 +3807,8 @@ namespace NovaTerminal
                         return;
                     }
                 }
-                bool moveTabPrevShortcut = IsShortcut(e, "move_tab_prev", "Ctrl+Shift+PageUp");
-                bool moveTabNextShortcut = IsShortcut(e, "move_tab_next", "Ctrl+Shift+PageDown");
+                bool moveTabPrevShortcut = IsShortcut(e, MoveTabPrevCommandId, "Ctrl+Shift+PageUp");
+                bool moveTabNextShortcut = IsShortcut(e, MoveTabNextCommandId, "Ctrl+Shift+PageDown");
                 if (moveTabPrevShortcut || moveTabNextShortcut)
                 {
                     // Keyboard move is meaningless mid-drag; swallowing the shortcut keeps
@@ -3800,7 +3819,7 @@ namespace NovaTerminal
                         e.Handled = true;
                         return;
                     }
-                    RecordCommandUsage(moveTabPrevShortcut ? "move_tab_prev" : "move_tab_next");
+                    RecordCommandUsage(moveTabPrevShortcut ? MoveTabPrevCommandId : MoveTabNextCommandId);
                     MoveSelectedTab(moveTabPrevShortcut ? -1 : 1);
                     e.Handled = true;
                     return;
@@ -6443,8 +6462,8 @@ namespace NovaTerminal
             CommandRegistry.Register("Close Pane", "General", () => CloseActivePane(), GetEffectiveShortcutBinding("close_pane", "Ctrl+Shift+W"), "close_pane");
             CommandRegistry.Register("Tab: Next (MRU)", "General", () => SwitchTabByMru(reverse: false), GetEffectiveShortcutBinding("next_tab", "Ctrl+Tab"), "next_tab");
             CommandRegistry.Register("Tab: Previous (MRU)", "General", () => SwitchTabByMru(reverse: true), GetEffectiveShortcutBinding("prev_tab", "Ctrl+Shift+Tab"), "prev_tab");
-            CommandRegistry.Register("Tab: Move Previous", "General", () => MoveSelectedTab(-1), GetEffectiveShortcutBinding("move_tab_prev", "Ctrl+Shift+PageUp"), "move_tab_prev");
-            CommandRegistry.Register("Tab: Move Next", "General", () => MoveSelectedTab(1), GetEffectiveShortcutBinding("move_tab_next", "Ctrl+Shift+PageDown"), "move_tab_next");
+            CommandRegistry.Register("Tab: Move Previous", "General", () => MoveSelectedTab(-1), GetEffectiveShortcutBinding(MoveTabPrevCommandId, "Ctrl+Shift+PageUp"), MoveTabPrevCommandId);
+            CommandRegistry.Register("Tab: Move Next", "General", () => MoveSelectedTab(1), GetEffectiveShortcutBinding(MoveTabNextCommandId, "Ctrl+Shift+PageDown"), MoveTabNextCommandId);
             CommandRegistry.Register("Tab: Open Tab List", "General", () => PopulateTabListMenu(showFlyout: true), GetEffectiveShortcutBinding(TitleBarCatalog.OpenTabListId, "Ctrl+Shift+O"), TitleBarCatalog.OpenTabListId);
             CommandRegistry.Register("Tabs: Toggle Vertical Tab Sidebar", "General", () => ToggleTabOrientation(), GetEffectiveShortcutBinding("toggle_tab_orientation", "Ctrl+Shift+L"), "toggle_tab_orientation");
             CommandRegistry.Register("Tab: Rename Current", "General", () => _ = RenameSelectedTabAsync(), "");

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -241,9 +241,11 @@ namespace NovaTerminal
             public TabStatusTracker Status { get; } = new();
             public TabTrackerStatus RenderedStatus { get; set; }
 
-            /// <summary>True while a pane in this tab has a command running (agent session
-            /// status aggregation). Populated by a later change; until then this stays false
-            /// and the tab dot falls back to the output-burst heuristic alone.</summary>
+            /// <summary>True while any pane in this tab has a command running — the agent-session
+            /// status machine's precise per-session state (see <see cref="RefreshTabStatuses"/>),
+            /// which survives silent stretches that decay the output-burst heuristic. Feeds
+            /// <see cref="TabStatusPresentation.ResolveTabDot"/> via
+            /// <see cref="UpdateVerticalTabExtras"/>; vertical mode only.</summary>
             public bool HasRunningCommand { get; set; }
             public TabPreviewTracker Preview { get; } = new();
             public bool PreviewDirty { get; set; }
@@ -518,6 +520,15 @@ namespace NovaTerminal
 
         internal TabStatusTracker GetTabStatusTracker(TabItem tab) => GetOrCreateTabState(tab).Status;
 
+        /// <summary>Test-only seam: reads the precise running-command flag
+        /// <see cref="RefreshTabStatuses"/> populates from agent-session registrations (same
+        /// pattern as <see cref="GetTabStatusTracker"/>).</summary>
+        internal bool IsTabRunningCommandForTest(TabItem tab) => GetOrCreateTabState(tab).HasRunningCommand;
+
+        /// <summary>Test-only seam: reads the last status the 1 Hz pass rendered (the heuristic
+        /// input ResolveTabDot pairs with <see cref="IsTabRunningCommandForTest"/>).</summary>
+        internal TabTrackerStatus GetTabRenderedStatusForTest(TabItem tab) => GetOrCreateTabState(tab).RenderedStatus;
+
         internal bool GetTabPreviewDirtyForTest(TabItem tab) => GetOrCreateTabState(tab).PreviewDirty;
 
         internal void SetTabPreviewDirtyForTest(TabItem tab, bool dirty) => GetOrCreateTabState(tab).PreviewDirty = dirty;
@@ -534,13 +545,34 @@ namespace NovaTerminal
             state.AgentTier = agentTier;
         }
 
-        /// <summary>Timer-driven decay pass: re-evaluates every tab's heuristic status and queues a
-        /// visual refresh only for tabs whose rendered status changed. Vertical mode only.</summary>
+        /// <summary>Timer-driven decay pass: re-evaluates every tab's heuristic status and
+        /// precise running-command flag (agent-session registry), queueing a visual refresh
+        /// only for tabs where either changed. Vertical mode only.</summary>
         internal void RefreshTabStatuses()
         {
             if (!_isVerticalTabStrip) return;
             var tabs = this.FindControl<TabControl>("Tabs");
             if (tabs == null) return;
+
+            // Precise running state, one pass over the registry snapshot before the per-tab
+            // loop: any tab owning a pane whose agent-session status machine reports Running
+            // has a command in flight. The output-burst heuristic above decays after 2 quiet
+            // seconds, so a silently-thinking agent CLI (60s between tokens is normal) would
+            // flip its dot back to idle; the per-session status machine knows better. Same
+            // registration→tab mapping as RefreshTabAgentAttention (TabId vs the persistent
+            // tab id). Snapshot() is thread-safe; GetRegistrations() hands back a point-in-time
+            // array, so no registry lock is held. 1 Hz over at most dozens of registrations:
+            // one HashSet per tick is the whole allocation cost.
+            var runningTabIds = new HashSet<Guid>();
+            foreach (var registration in AgentHost.AgentSessionRegistry.Instance.GetRegistrations())
+            {
+                var tabId = registration.TabId;
+                if (tabId.HasValue
+                    && registration.StatusMachine.Snapshot().Kind == AgentHost.AgentSessionStatusKind.Running)
+                {
+                    runningTabIds.Add(tabId.Value);
+                }
+            }
 
             var now = DateTime.UtcNow;
             foreach (TabItem tab in tabs.Items.Cast<TabItem>())
@@ -550,6 +582,17 @@ namespace NovaTerminal
                 if (status != state.RenderedStatus)
                 {
                     state.RenderedStatus = status;
+                    QueueTabVisualRefresh(tab);
+                }
+
+                // Same change-driven queueing as RenderedStatus: the flag feeds
+                // ResolveTabDot via UpdateVerticalTabExtras, which only runs in vertical
+                // mode (horizontal headers never read it - stale-but-unread there, cost
+                // zero, which is why this whole method is vertical-only).
+                bool running = runningTabIds.Contains(GetPersistentTabId(tab));
+                if (running != state.HasRunningCommand)
+                {
+                    state.HasRunningCommand = running;
                     QueueTabVisualRefresh(tab);
                 }
             }

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -843,10 +843,11 @@ namespace NovaTerminal
             // suffixes that used to live inside the truncated title text (bell/activity/
             // agent glyphs). Hidden until UpdateVerticalTabExtras turns the tab's marker
             // set back on; not hit-testable so pointer presses stay on the header host
-            // (select + context menu + drag-reorder). Chip colors match the in-pane agent
-            // segment and the existing tab attention constant (see the Tab*ChipBrush
-            // declarations above).
-            TextBlock Chip(string name, string glyph, IBrush foreground, string toolTip)
+            // (select + context menu + drag-reorder), which also means no per-chip
+            // tooltips (a hit-test-invisible control never sees pointer-enter). Chip
+            // colors match the in-pane agent segment and the existing tab attention
+            // constant (see the Tab*ChipBrush declarations above).
+            TextBlock Chip(string name, string glyph, IBrush foreground)
             {
                 var chip = new TextBlock
                 {
@@ -857,14 +858,13 @@ namespace NovaTerminal
                     IsVisible = false,
                     IsHitTestVisible = false,
                 };
-                ToolTip.SetTip(chip, toolTip);
                 return chip;
             }
 
-            var bellChip = Chip("TabBellChip", "🔔", TabBellChipBrush, "Bell");
-            var activityChip = Chip("TabActivityChip", "•", TabActivityChipBrush, "Recent activity");
-            var agentWroteChip = Chip("TabAgentWroteChip", AgentWroteGlyph, TabAgentWroteChipBrush, "Agent typed here");
-            var agentWatchedChip = Chip("TabAgentWatchedChip", AgentWatchedGlyph, TabAgentWatchedChipBrush, "Agent reading");
+            var bellChip = Chip("TabBellChip", "🔔", TabBellChipBrush);
+            var activityChip = Chip("TabActivityChip", "•", TabActivityChipBrush);
+            var agentWroteChip = Chip("TabAgentWroteChip", AgentWroteGlyph, TabAgentWroteChipBrush);
+            var agentWatchedChip = Chip("TabAgentWatchedChip", AgentWatchedGlyph, TabAgentWatchedChipBrush);
 
             var chipsColumn = new StackPanel
             {
@@ -3792,6 +3792,14 @@ namespace NovaTerminal
                 bool moveTabNextShortcut = IsShortcut(e, "move_tab_next", "Ctrl+Shift+PageDown");
                 if (moveTabPrevShortcut || moveTabNextShortcut)
                 {
+                    // Keyboard move is meaningless mid-drag; swallowing the shortcut keeps
+                    // reorder mutations single-threaded through the drag path (cf. the
+                    // Escape guard above).
+                    if (_isTabReorderDragging)
+                    {
+                        e.Handled = true;
+                        return;
+                    }
                     RecordCommandUsage(moveTabPrevShortcut ? "move_tab_prev" : "move_tab_next");
                     MoveSelectedTab(moveTabPrevShortcut ? -1 : 1);
                     e.Handled = true;

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -99,6 +99,12 @@ namespace NovaTerminal
         // overflow button already owns a different MenuFlyout for its own menu, and the
         // TitleBarItemsHost StackPanel fallback has no Flyout property to hold one at all.
         private MenuFlyout? _tabListFallbackFlyout;
+        // Dedicated flyout for the vertical overflow pill (PART_TabOverflowPill): same
+        // keep-alive rationale as _tabListFallbackFlyout - the pill is a Button that must
+        // NOT carry this as its own Flyout (Button auto-opens an empty flyout on click
+        // before the lazy populate could fill it), so MainWindow owns the instance and
+        // PopulateTabListMenu(anchorOverride: pill) fills + shows it on demand.
+        private MenuFlyout? _tabOverflowPillFlyout;
         private bool _closePaneInProgress;
         private bool _closeTabInProgress;
         private readonly SshConnectionService _sshConnectionService;
@@ -187,6 +193,11 @@ namespace NovaTerminal
         // vertical mode, Height in horizontal - the XAML element deliberately sets no
         // size). Brush/alignment live in the template XAML.
         private const double TabInsertIndicatorThickness = 2;
+        // Estimated height of one vertical tab row: the fallback CountHiddenTabs uses for
+        // headers not yet measured (Bounds.Height 0 before the first layout pass) when the
+        // vertical overflow pill counts hidden rows. Matches the vertical TabItem MinHeight
+        // set in MainWindow.axaml's styles.
+        private const double DefaultVerticalTabRowHeight = 44;
         private const double TabInsertIndicatorMinLength = 16;
 
         /// <summary>Test-only seam: exposes the mid-reorder-drag state (same pattern as
@@ -1256,22 +1267,32 @@ namespace NovaTerminal
             int insertIndex = Math.Clamp(_tabDragInsertIndex, 0, tabs.Items.Count);
             int newIndex = insertIndex > oldIndex ? insertIndex - 1 : insertIndex;
 
+            ReorderTabInItems(tabs, draggedTab, newIndex);
+        }
+
+        /// <summary>The single reorder primitive, shared by the drag commit
+        /// (<see cref="CommitTabReorder"/>) and <see cref="MoveSelectedTab"/>: reinserts
+        /// the tab at <paramref name="newIndex"/> inside the guarded
+        /// <see cref="_isTabReorderCommitting"/> window (TabControl's AlwaysSelected mode
+        /// promotes index 0 to SelectedItem for the microseconds before the restore below -
+        /// the SelectionChanged handler skips that transient promotion: no MRU touch, no
+        /// attention clear, no focus steal on a tab the user never actually viewed), then
+        /// restores the moved tab as the selection, which re-runs the full select path with
+        /// the final Items order. The mutation itself is the same
+        /// remove-from-live-ItemCollection pattern CloseTab uses: the TabItem and its pane
+        /// content are reused, never recreated (ApplyTabLayout's ownership contract).</summary>
+        private void ReorderTabInItems(TabControl tabs, TabItem movedTab, int newIndex)
+        {
+            int oldIndex = tabs.Items.IndexOf(movedTab);
+            if (oldIndex < 0) return;
+
             if (newIndex != oldIndex)
             {
-                // Selected-item removal under TabControl's AlwaysSelected mode promotes
-                // whatever lands at index 0 to SelectedItem until the restore below - the
-                // SelectionChanged handler skips that transient promotion via
-                // _isTabReorderCommitting (no MRU touch, no attention clear, no focus steal
-                // on a tab the user never actually viewed), then the restore re-runs the
-                // full select path for the dragged tab with the final Items order. The
-                // mutation itself is the same remove-from-live-ItemCollection pattern
-                // CloseTab uses: the TabItem and its pane content are reused, never
-                // recreated (ApplyTabLayout's ownership contract).
                 _isTabReorderCommitting = true;
                 try
                 {
                     tabs.Items.RemoveAt(oldIndex);
-                    tabs.Items.Insert(newIndex, draggedTab);
+                    tabs.Items.Insert(newIndex, movedTab);
                 }
                 finally
                 {
@@ -1279,7 +1300,33 @@ namespace NovaTerminal
                 }
             }
 
-            tabs.SelectedItem = draggedTab;
+            tabs.SelectedItem = movedTab;
+        }
+
+        /// <summary>Moves the selected tab one slot along the strip (delta -1/+1), clamped
+        /// at the ends - the keyboard counterpart of drag-to-reorder, committing through the
+        /// same <see cref="ReorderTabInItems"/> semantics (pinned/protected tabs move
+        /// freely, consistent with the drag path). Internal for headless tests.</summary>
+        internal void MoveSelectedTab(int delta)
+        {
+            var tabs = this.FindControl<TabControl>("Tabs");
+            if (tabs?.SelectedItem is not TabItem selected) return;
+
+            int currentIndex = tabs.Items.IndexOf(selected);
+            int newIndex = ComputeMoveTabIndex(currentIndex, tabs.Items.Count, delta);
+            if (newIndex < 0 || newIndex == currentIndex) return;
+
+            ReorderTabInItems(tabs, selected, newIndex);
+        }
+
+        /// <summary>Pure move-tab index math: the clamped target for moving the tab at
+        /// <paramref name="currentIndex"/> by <paramref name="delta"/> slots. Returns -1
+        /// when no move is expressible (no tabs, a single tab, or an out-of-range current
+        /// index); a clamp back onto <paramref name="currentIndex"/> is a caller no-op.</summary>
+        internal static int ComputeMoveTabIndex(int currentIndex, int count, int delta)
+        {
+            if (count <= 1 || currentIndex < 0 || currentIndex >= count) return -1;
+            return Math.Clamp(currentIndex + delta, 0, count - 1);
         }
 
         /// <summary>Shared non-committing cleanup for drag end, Escape and involuntary
@@ -1508,6 +1555,7 @@ namespace NovaTerminal
             Dispatcher.UIThread.Post(() =>
             {
                 WireTabStripResizeGrip();
+                WireTabOverflowPill();
                 UpdateTabVisuals();
             }, DispatcherPriority.Background);
         }
@@ -1640,6 +1688,7 @@ namespace NovaTerminal
                 // UpdateTabOverflowIndicator's own vertical guard so the reset logic (badge,
                 // tab-list button tooltip/foreground) lives in one place.
                 UpdateTabOverflowIndicator();
+                UpdateTabOverflowPill(scrollViewer);
                 return;
             }
 
@@ -1661,6 +1710,7 @@ namespace NovaTerminal
             scrollViewer.ClipToBounds = true;
 
             UpdateTabOverflowIndicator();
+            UpdateTabOverflowPill(scrollViewer);
         }
 
         private void UpdateTabOverflowIndicator()
@@ -1739,6 +1789,87 @@ namespace NovaTerminal
             return hiddenCount;
         }
 
+        /// <summary>Drives the vertical-mode overflow pill (PART_TabOverflowPill): visible
+        /// with "+N more" when tab rows run past the sidebar viewport, hidden otherwise -
+        /// including every horizontal pass, where the title-bar TabOverflowBadge owns the
+        /// affordance instead (UpdateTabOverflowIndicator, deliberately untouched here).
+        /// CountHiddenTabs is axis-generic 1D packing math, so the vertical pass simply
+        /// feeds it the viewport height and the header heights.
+        ///
+        /// Called only from UpdateTabHeaderViewport - deliberately NOT from the
+        /// RefreshTabStatuses 1 Hz tick: the hidden count can only change when tabs are
+        /// added/removed (AddTab/CloseTab both route through UpdateTabVisuals →
+        /// UpdateTabHeaderViewport), the viewport resizes (window/title-bar SizeChanged →
+        /// UpdateTabHeaderViewport), or selection shifts (SelectionChanged →
+        /// UpdateTabHeaderViewport), all of which already re-run this. Colors are reapplied
+        /// on every visible pass so a theme change takes effect without a tab/viewport
+        /// change (two small brush allocations, same precedent as UpdateTabVisuals).</summary>
+        private void UpdateTabOverflowPill(ScrollViewer scrollViewer)
+        {
+            var pill = FindTabTemplatePart<Button>("PART_TabOverflowPill");
+            if (pill == null) return;
+
+            // The text part is the pill's XAML Content, read straight off the property
+            // rather than via a visual-tree lookup: a hidden control is never measured,
+            // so while the pill is IsVisible=False its own template (and with it the
+            // TextBlock's visual-tree presence) has never been applied - a visual lookup
+            // would come back empty and the pill could never become visible at all.
+            // Content still holds the TextBlock instance, and setting its text/foreground
+            // works pre-materialization: the ContentPresenter shows it with these values
+            // on the first pass after visibility turns on.
+            if (pill.Content is not TextBlock pillText) return;
+
+            if (!_isVerticalTabStrip)
+            {
+                pill.IsVisible = false;
+                return;
+            }
+
+            var tabs = this.FindControl<TabControl>("Tabs");
+            if (tabs == null)
+            {
+                pill.IsVisible = false;
+                return;
+            }
+
+            int hiddenCount = CountHiddenTabs(
+                scrollViewer.Bounds.Height,
+                tabs.Items.Cast<TabItem>().Select(t => t.Bounds.Height),
+                fallbackTabWidth: DefaultVerticalTabRowHeight);
+            if (hiddenCount <= 0)
+            {
+                pill.IsVisible = false;
+                return;
+            }
+
+            var theme = _settings.ActiveTheme;
+            pill.Background = new SolidColorBrush(theme.Background.ToAvaloniaColor());
+            // Same luminance-contrast pick as UpdateTabVisuals' header text, so the pill
+            // reads on both light and dark theme backgrounds.
+            double luminance = (0.299 * theme.Background.R + 0.587 * theme.Background.G + 0.114 * theme.Background.B) / 255.0;
+            pillText.Foreground = luminance > 0.5 ? Brushes.Black : Brushes.White;
+            pillText.Text = $"+{hiddenCount} more";
+            pill.IsVisible = true;
+        }
+
+        /// <summary>Wires the vertical overflow pill (PART_TabOverflowPill) click: opens the
+        /// tab-list menu anchored at the pill (PopulateTabListMenu's anchorOverride path),
+        /// the same lazy-populate-flyout-on-demand pattern the tab headers' ContextFlyout
+        /// uses. The pill is a permanent part of the single inline template (like the resize
+        /// grip, see ApplyTabLayout's remarks), so wiring happens once per window instance
+        /// (guarded Tag) and survives every mode flip; a hidden pill in horizontal mode is
+        /// not hit-tested, so the handler is inert there.</summary>
+        private void WireTabOverflowPill()
+        {
+            var pill = FindTabTemplatePart<Button>("PART_TabOverflowPill");
+            if (pill == null || Equals(pill.Tag, "wired")) return;
+            pill.Tag = "wired";
+
+            // Focusable=False (XAML) keeps the click from moving keyboard focus off the
+            // terminal; the open flyout takes focus only while open, like any menu.
+            pill.Click += (_, _) => PopulateTabListMenu(showFlyout: true, anchorOverride: pill);
+        }
+
         private void EnsureSelectedTabHeaderVisible()
         {
             if (_isVerticalTabStrip)
@@ -1777,48 +1908,61 @@ namespace NovaTerminal
             }
         }
 
-        private void PopulateTabListMenu(bool showFlyout = false)
+        private void PopulateTabListMenu(bool showFlyout = false, Control? anchorOverride = null)
         {
             var tabs = this.FindControl<TabControl>("Tabs");
             if (tabs == null) return;
 
-            // "open_tab_list" may legitimately be Overflow or Hidden per the user's title bar
-            // layout, in which case FindTitleBarButton returns null for its dedicated button - but
-            // the action must still be reachable by shortcut and command palette (that is the whole
-            // premise of Hidden: still there, just not a dedicated icon). DO NOT simplify this back
-            // to the button-only lookup: that was exactly the bug (Codex P2 on PR #342) - with no
-            // fallback, setting Tab List to Overflow or Hidden turned the overflow menu item, the
-            // Ctrl+Shift+O shortcut, and the command palette entry all into silent no-ops. Fall back
-            // to the overflow button when it exists, and finally to the title bar host panel itself,
-            // which always exists.
-            var button = FindTitleBarButton(TitleBarCatalog.OpenTabListId);
-            var host = this.FindControl<StackPanel>("TitleBarItemsHost");
-            var overflowButton = host?.Children.OfType<Button>()
-                .FirstOrDefault(b => b.Name == TitleBarViewFactory.OverflowButtonName);
-            Control? anchor = (Control?)button ?? (Control?)overflowButton ?? host;
-            if (anchor == null) return;
-
-            // A pinned item's own button starts out with no popup menu attached, so this method is
-            // where one gets created and attached, the first time it is needed. The overflow ("...")
-            // button is different: it already carries its own popup, prebuilt to list whichever
-            // actions do not have a dedicated icon right now, and grabbing hold of that same popup
-            // here would silently replace those contents the next time someone opens the "..." menu.
-            // The panel hosting the title bar buttons cannot carry a popup at all. So whenever the
-            // anchor is not a pinned item's own button, this method falls back to one dedicated menu
-            // kept alive across calls purely to support that case.
+            Control? anchor;
             MenuFlyout flyout;
-            if (button is not null)
+            if (anchorOverride is not null)
             {
-                if (button.Flyout is not MenuFlyout existing)
-                {
-                    existing = new MenuFlyout();
-                    button.Flyout = existing;
-                }
-                flyout = existing;
+                // Vertical overflow pill path: anchor the menu at the pill instead of the
+                // title bar, into the pill-dedicated flyout (see _tabOverflowPillFlyout for
+                // why it cannot ride the pill's own Flyout property). The item-building and
+                // show logic below is shared verbatim with the title-bar paths.
+                anchor = anchorOverride;
+                flyout = _tabOverflowPillFlyout ??= new MenuFlyout();
             }
             else
             {
-                flyout = _tabListFallbackFlyout ??= new MenuFlyout();
+                // "open_tab_list" may legitimately be Overflow or Hidden per the user's title bar
+                // layout, in which case FindTitleBarButton returns null for its dedicated button - but
+                // the action must still be reachable by shortcut and command palette (that is the whole
+                // premise of Hidden: still there, just not a dedicated icon). DO NOT simplify this back
+                // to the button-only lookup: that was exactly the bug (Codex P2 on PR #342) - with no
+                // fallback, setting Tab List to Overflow or Hidden turned the overflow menu item, the
+                // Ctrl+Shift+O shortcut, and the command palette entry all into silent no-ops. Fall back
+                // to the overflow button when it exists, and finally to the title bar host panel itself,
+                // which always exists.
+                var button = FindTitleBarButton(TitleBarCatalog.OpenTabListId);
+                var host = this.FindControl<StackPanel>("TitleBarItemsHost");
+                var overflowButton = host?.Children.OfType<Button>()
+                    .FirstOrDefault(b => b.Name == TitleBarViewFactory.OverflowButtonName);
+                anchor = (Control?)button ?? (Control?)overflowButton ?? host;
+                if (anchor == null) return;
+
+                // A pinned item's own button starts out with no popup menu attached, so this method is
+                // where one gets created and attached, the first time it is needed. The overflow ("...")
+                // button is different: it already carries its own popup, prebuilt to list whichever
+                // actions do not have a dedicated icon right now, and grabbing hold of that same popup
+                // here would silently replace those contents the next time someone opens the "..." menu.
+                // The panel hosting the title bar buttons cannot carry a popup at all. So whenever the
+                // anchor is not a pinned item's own button, this method falls back to one dedicated menu
+                // kept alive across calls purely to support that case.
+                if (button is not null)
+                {
+                    if (button.Flyout is not MenuFlyout existing)
+                    {
+                        existing = new MenuFlyout();
+                        button.Flyout = existing;
+                    }
+                    flyout = existing;
+                }
+                else
+                {
+                    flyout = _tabListFallbackFlyout ??= new MenuFlyout();
+                }
             }
 
             flyout.Items.Clear();
@@ -3638,6 +3782,15 @@ namespace NovaTerminal
                         e.Handled = true;
                         return;
                     }
+                }
+                bool moveTabPrevShortcut = IsShortcut(e, "move_tab_prev", "Ctrl+Shift+PageUp");
+                bool moveTabNextShortcut = IsShortcut(e, "move_tab_next", "Ctrl+Shift+PageDown");
+                if (moveTabPrevShortcut || moveTabNextShortcut)
+                {
+                    RecordCommandUsage(moveTabPrevShortcut ? "move_tab_prev" : "move_tab_next");
+                    MoveSelectedTab(moveTabPrevShortcut ? -1 : 1);
+                    e.Handled = true;
+                    return;
                 }
                 if (IsShortcut(e, TitleBarCatalog.OpenTabListId, "Ctrl+Shift+O"))
                 {
@@ -6277,6 +6430,8 @@ namespace NovaTerminal
             CommandRegistry.Register("Close Pane", "General", () => CloseActivePane(), GetEffectiveShortcutBinding("close_pane", "Ctrl+Shift+W"), "close_pane");
             CommandRegistry.Register("Tab: Next (MRU)", "General", () => SwitchTabByMru(reverse: false), GetEffectiveShortcutBinding("next_tab", "Ctrl+Tab"), "next_tab");
             CommandRegistry.Register("Tab: Previous (MRU)", "General", () => SwitchTabByMru(reverse: true), GetEffectiveShortcutBinding("prev_tab", "Ctrl+Shift+Tab"), "prev_tab");
+            CommandRegistry.Register("Tab: Move Up", "General", () => MoveSelectedTab(-1), GetEffectiveShortcutBinding("move_tab_prev", "Ctrl+Shift+PageUp"), "move_tab_prev");
+            CommandRegistry.Register("Tab: Move Down", "General", () => MoveSelectedTab(1), GetEffectiveShortcutBinding("move_tab_next", "Ctrl+Shift+PageDown"), "move_tab_next");
             CommandRegistry.Register("Tab: Open Tab List", "General", () => PopulateTabListMenu(showFlyout: true), GetEffectiveShortcutBinding(TitleBarCatalog.OpenTabListId, "Ctrl+Shift+O"), TitleBarCatalog.OpenTabListId);
             CommandRegistry.Register("Tabs: Toggle Vertical Tab Sidebar", "General", () => ToggleTabOrientation(), GetEffectiveShortcutBinding("toggle_tab_orientation", "Ctrl+Shift+L"), "toggle_tab_orientation");
             CommandRegistry.Register("Tab: Rename Current", "General", () => _ = RenameSelectedTabAsync(), "");

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -126,6 +126,17 @@ namespace NovaTerminal
         // Hoisted out of UpdateVerticalTabExtras: that method runs per tab per visual-refresh
         // pass, and allocating a new SolidColorBrush per tab per pass adds up.
         private static readonly IBrush TabAttentionBrush = new SolidColorBrush(Color.Parse("#FFD25A"));
+
+        // Agent-aware tab status colors (dot + marker chips). They intentionally match the
+        // in-pane agent segment (TerminalPane.ApplyAgentAttention: dot #E8A33D/#4FB0D4, text
+        // #F0C07A/#7FC3DC) and the existing tab attention constant above, so the same tier
+        // reads as one color everywhere it appears.
+        private static readonly IBrush TabAgentWroteDotBrush = new SolidColorBrush(Color.FromArgb(0xFF, 0xE8, 0xA3, 0x3D));
+        private static readonly IBrush TabAgentWatchedDotBrush = new SolidColorBrush(Color.FromArgb(0xFF, 0x4F, 0xB0, 0xD4));
+        private static readonly IBrush TabBellChipBrush = TabAttentionBrush; // #FFD25A
+        private static readonly IBrush TabActivityChipBrush = new SolidColorBrush(Color.FromArgb(0x99, 0xFF, 0xFF, 0xFF));
+        private static readonly IBrush TabAgentWroteChipBrush = new SolidColorBrush(Color.FromArgb(0xFF, 0xF0, 0xC0, 0x7A));
+        private static readonly IBrush TabAgentWatchedChipBrush = new SolidColorBrush(Color.FromArgb(0xFF, 0x7F, 0xC3, 0xDC));
         private bool _isVerticalTabStrip;
         internal bool IsVerticalTabStripActive => _isVerticalTabStrip;
 
@@ -229,6 +240,11 @@ namespace NovaTerminal
             public AgentHost.AgentAttentionTier AgentTier { get; set; }
             public TabStatusTracker Status { get; } = new();
             public TabTrackerStatus RenderedStatus { get; set; }
+
+            /// <summary>True while a pane in this tab has a command running (agent session
+            /// status aggregation). Populated by a later change; until then this stays false
+            /// and the tab dot falls back to the output-burst heuristic alone.</summary>
+            public bool HasRunningCommand { get; set; }
             public TabPreviewTracker Preview { get; } = new();
             public bool PreviewDirty { get; set; }
             public DateTime LastPreviewUpdateUtc { get; set; }
@@ -506,6 +522,18 @@ namespace NovaTerminal
 
         internal void SetTabPreviewDirtyForTest(TabItem tab, bool dirty) => GetOrCreateTabState(tab).PreviewDirty = dirty;
 
+        /// <summary>Test-only seam: sets the marker inputs UpdateVerticalTabExtras resolves
+        /// the chip visibilities and dot color from (same pattern as
+        /// <see cref="SetTabPreviewDirtyForTest"/>), since driving real bell/agent events in
+        /// the headless test host is impractical.</summary>
+        internal void SetTabMarkerStateForTest(TabItem tab, bool hasBell, bool hasActivity, AgentHost.AgentAttentionTier agentTier)
+        {
+            var state = GetOrCreateTabState(tab);
+            state.HasBell = hasBell;
+            state.HasActivity = hasActivity;
+            state.AgentTier = agentTier;
+        }
+
         /// <summary>Timer-driven decay pass: re-evaluates every tab's heuristic status and queues a
         /// visual refresh only for tabs whose rendered status changed. Vertical mode only.</summary>
         internal void RefreshTabStatuses()
@@ -740,28 +768,70 @@ namespace NovaTerminal
             {
                 Name = "TabPreviewLine",
                 Text = string.Empty,
-                Foreground = new SolidColorBrush(Color.FromArgb(0x99, 0xFF, 0xFF, 0xFF)),
+                Foreground = TabActivityChipBrush,
                 FontSize = 10,
                 TextTrimming = TextTrimming.CharacterEllipsis,
                 Margin = new Thickness(0, 2, 0, 0)
             };
 
-            // Title BEFORE preview: FindTabHeaderTextBlock takes the first TextBlock as the
-            // title, and UpdateTabVisuals rewrites that one with the display label.
+            // Title BEFORE preview (and before the chips): FindTabHeaderTextBlock takes the
+            // first TextBlock as the title, and UpdateTabVisuals rewrites that one with the
+            // display label.
             var textColumn = new StackPanel { Orientation = Avalonia.Layout.Orientation.Vertical };
             textColumn.Children.Add(headerText);
             textColumn.Children.Add(previewText);
 
-            var row = new Grid { ColumnDefinitions = new ColumnDefinitions("Auto,*") };
+            // Trailing status chips: the compact replacements for the attention-marker
+            // suffixes that used to live inside the truncated title text (bell/activity/
+            // agent glyphs). Hidden until UpdateVerticalTabExtras turns the tab's marker
+            // set back on; not hit-testable so pointer presses stay on the header host
+            // (select + context menu + drag-reorder). Chip colors match the in-pane agent
+            // segment and the existing tab attention constant (see the Tab*ChipBrush
+            // declarations above).
+            TextBlock Chip(string name, string glyph, IBrush foreground, string toolTip)
+            {
+                var chip = new TextBlock
+                {
+                    Name = name,
+                    Text = glyph,
+                    Foreground = foreground,
+                    FontSize = 10,
+                    IsVisible = false,
+                    IsHitTestVisible = false,
+                };
+                ToolTip.SetTip(chip, toolTip);
+                return chip;
+            }
+
+            var bellChip = Chip("TabBellChip", "🔔", TabBellChipBrush, "Bell");
+            var activityChip = Chip("TabActivityChip", "•", TabActivityChipBrush, "Recent activity");
+            var agentWroteChip = Chip("TabAgentWroteChip", AgentWroteGlyph, TabAgentWroteChipBrush, "Agent typed here");
+            var agentWatchedChip = Chip("TabAgentWatchedChip", AgentWatchedGlyph, TabAgentWatchedChipBrush, "Agent reading");
+
+            var chipsColumn = new StackPanel
+            {
+                Orientation = Avalonia.Layout.Orientation.Horizontal,
+                Margin = new Thickness(6, 0, 0, 0),
+                VerticalAlignment = VerticalAlignment.Center
+            };
+            chipsColumn.Children.Add(bellChip);
+            chipsColumn.Children.Add(activityChip);
+            chipsColumn.Children.Add(agentWroteChip);
+            chipsColumn.Children.Add(agentWatchedChip);
+
+            var row = new Grid { ColumnDefinitions = new ColumnDefinitions("Auto,*,Auto") };
             Grid.SetColumn(statusDot, 0);
             Grid.SetColumn(textColumn, 1);
+            Grid.SetColumn(chipsColumn, 2);
             row.Children.Add(statusDot);
             row.Children.Add(textColumn);
+            row.Children.Add(chipsColumn);
 
             var headerHost = new Border
             {
                 Background = Brushes.Transparent,
-                Padding = new Thickness(10, 6),
+                // Right padding keeps the chips clear of the header's trailing edge.
+                Padding = new Thickness(10, 6, 8, 6),
                 Child = row
             };
 
@@ -1948,11 +2018,43 @@ namespace NovaTerminal
         /// <see cref="TruncateTabLabelWithSuffix"/>'s degenerate-case branch
         /// returns the front of the combined suffix, and the marker occupies
         /// the front.
+        ///
+        /// <paramref name="includeMarkers"/> false is the vertical-header mode:
+        /// attention renders as trailing chips there (UpdateVerticalTabExtras),
+        /// so the marker suffix is neither appended nor reserved during
+        /// truncation — the prefixes (pinned/protected/forwarding) live in the
+        /// base label and stay in both modes. The tooltip
+        /// (<see cref="BuildFullTabLabel"/>), tab-list flyout
+        /// (<see cref="GetTabMenuLabel"/>) and automation labels keep their
+        /// markers regardless of mode.
         /// </summary>
-        private Dictionary<TabItem, string> BuildTabDisplayLabels(IReadOnlyList<TabItem> tabs, int maxLength)
+        private Dictionary<TabItem, string> BuildTabDisplayLabels(IReadOnlyList<TabItem> tabs, int maxLength, bool includeMarkers = true)
+            => ResolveTabDisplayLabels(
+                tabs,
+                t => BuildBaseTabLabel(t),
+                t => GetAttentionMarkerSuffix(GetOrCreateTabState(t)),
+                t => "~" + GetTabId(t).ToString("N").Substring(0, 4),
+                maxLength,
+                includeMarkers);
+
+        /// <summary>
+        /// Pure core of <see cref="BuildTabDisplayLabels"/>: same truncation, marker
+        /// reservation, and collision-disambiguation behavior, with the per-tab string
+        /// sources injected so tests can drive it as plain facts without a window (the
+        /// instance method only contributes state-derived strings).
+        /// </summary>
+        internal static Dictionary<TTab, string> ResolveTabDisplayLabels<TTab>(
+            IReadOnlyList<TTab> tabs,
+            Func<TTab, string> baseLabelOf,
+            Func<TTab, string> markerSuffixOf,
+            Func<TTab, string> collisionHintOf,
+            int maxLength,
+            bool includeMarkers)
         {
-            var baseLabels = tabs.ToDictionary(t => t, BuildBaseTabLabel);
-            var markers = tabs.ToDictionary(t => t, t => GetAttentionMarkerSuffix(GetOrCreateTabState(t)));
+            var baseLabels = tabs.ToDictionary(t => t, baseLabelOf);
+            var markers = includeMarkers
+                ? tabs.ToDictionary(t => t, markerSuffixOf)
+                : tabs.ToDictionary(t => t, static _ => string.Empty);
             var truncated = tabs.ToDictionary(t => t, t => TruncateTabLabelWithSuffix(baseLabels[t], maxLength, markers[t]));
 
             var collisions = tabs
@@ -1963,8 +2065,7 @@ namespace NovaTerminal
             {
                 foreach (var tab in group)
                 {
-                    string hint = "~" + GetTabId(tab).ToString("N").Substring(0, 4);
-                    truncated[tab] = TruncateTabLabelWithSuffix(baseLabels[tab], maxLength, markers[tab] + hint);
+                    truncated[tab] = TruncateTabLabelWithSuffix(baseLabels[tab], maxLength, markers[tab] + collisionHintOf(tab));
                 }
             }
 
@@ -5637,11 +5738,33 @@ namespace NovaTerminal
             var contrastForeground = luminance > 0.5 ? Brushes.Black : Brushes.White;
 
             var tabItems = tabs.Items.Cast<TabItem>().ToList();
-            var labels = BuildTabDisplayLabels(tabItems, 44);
+            // Vertical headers show attention as trailing chips (UpdateVerticalTabExtras),
+            // so their title text omits the marker suffix; horizontal headers keep the
+            // suffix inside the title as before.
+            var labels = BuildTabDisplayLabels(tabItems, 44, includeMarkers: !_isVerticalTabStrip);
 
             foreach (TabItem ti in tabItems)
             {
                 ti.BorderBrush = ti.IsSelected ? borderBrush : Brushes.Transparent;
+
+                // Vertical: a constant 3px left thickness on EVERY tab, selected or not, so
+                // the BorderBrush line above paints the selected tab a 3px accent bar —
+                // constant (rather than only-when-selected) because toggling thickness on
+                // selection would shift the title 3px every time. (The selected tab's
+                // PART_Border needs the companion re-assert style in MainWindow.axaml's
+                // Window.Styles: App.axaml's selected underline setter outranks the template
+                // binding.) Horizontal: ClearValue rather than a local Thickness(0), so no
+                // leftover local value competes with the App.axaml selected style
+                // ("TabItem:selected /template/Border#PART_Border", BorderThickness 0 0 0 2),
+                // which keeps driving the underline — hence the asymmetry.
+                if (_isVerticalTabStrip)
+                {
+                    ti.BorderThickness = new Thickness(3, 0, 0, 0);
+                }
+                else
+                {
+                    ti.ClearValue(TabItem.BorderThicknessProperty);
+                }
 
                 if (FindTabHeaderTextBlock(ti.Header) is TextBlock tb)
                 {
@@ -5669,15 +5792,29 @@ namespace NovaTerminal
 
         private void UpdateVerticalTabExtras(TabItem tab, TabRuntimeState state, IBrush workingBrush)
         {
+            // One pure resolve per tab per pass drives both the dot and the marker chips —
+            // the vertical replacement for the title-suffix attention markers (which the
+            // display-label builder no longer appends in vertical mode).
+            var markers = TabStatusPresentation.ResolveTabMarkers(
+                state.HasBell, state.HasActivity, state.AgentTier, _settings.AgentIndicatorTabRollup);
+            var dotVisual = TabStatusPresentation.ResolveTabDot(state.RenderedStatus, markers, state.HasRunningCommand);
+
             if (FindTabHeaderDescendant<Avalonia.Controls.Shapes.Ellipse>(tab.Header, "TabStatusDot") is { } dot)
             {
-                dot.Fill = state.RenderedStatus switch
+                dot.Fill = dotVisual switch
                 {
-                    TabTrackerStatus.Working => workingBrush,
-                    TabTrackerStatus.Attention => TabAttentionBrush,
+                    TabDotVisual.Working => workingBrush,
+                    TabDotVisual.Attention => TabAttentionBrush,
+                    TabDotVisual.AgentWrote => TabAgentWroteDotBrush,
+                    TabDotVisual.AgentWatched => TabAgentWatchedDotBrush,
                     _ => Brushes.Transparent,
                 };
             }
+
+            SetChipVisibility(tab, "TabBellChip", markers.Bell);
+            SetChipVisibility(tab, "TabActivityChip", markers.Activity);
+            SetChipVisibility(tab, "TabAgentWroteChip", markers.AgentWrote);
+            SetChipVisibility(tab, "TabAgentWatchedChip", markers.AgentWatched);
 
             // Preview recompute is gated behind a dirty flag + throttle: with several streaming
             // tabs, this visual-refresh pass can run many times a second, and each recompute is
@@ -5702,6 +5839,17 @@ namespace NovaTerminal
                     // later pass picks it up.
                 }
                 // else: nothing new since the last recompute - leave the existing text alone.
+            }
+        }
+
+        /// <summary>Flips one named marker chip's visibility in a vertical header. No-op when
+        /// the chip is absent (e.g. the header was built by the horizontal factory), which
+        /// keeps callers uniform across both header kinds.</summary>
+        private static void SetChipVisibility(TabItem tab, string chipName, bool visible)
+        {
+            if (FindTabHeaderDescendant<TextBlock>(tab.Header, chipName) is { } chip)
+            {
+                chip.IsVisible = visible;
             }
         }
 

--- a/src/NovaTerminal.App/Shell/Shortcuts/ShortcutCatalog.cs
+++ b/src/NovaTerminal.App/Shell/Shortcuts/ShortcutCatalog.cs
@@ -16,6 +16,8 @@ public static class ShortcutCatalog
         new("close_tab", "Close Tab", "General", ShortcutScope.App, "Ctrl+W"),
         new("next_tab", "Tab: Next (MRU)", "General", ShortcutScope.App, "Ctrl+Tab"),
         new("prev_tab", "Tab: Previous (MRU)", "General", ShortcutScope.App, "Ctrl+Shift+Tab"),
+        new("move_tab_prev", "Tab: Move Previous", "General", ShortcutScope.App, "Ctrl+Shift+PageUp"),
+        new("move_tab_next", "Tab: Move Next", "General", ShortcutScope.App, "Ctrl+Shift+PageDown"),
         new(TitleBarCatalog.OpenTabListId, "Tab: Open Tab List", "General", ShortcutScope.App, "Ctrl+Shift+O"),
         new("font_increase", "Font: Increase", "View", ShortcutScope.App, "Ctrl+OemPlus"),
         new("font_increase_alt", "Font: Increase (Alt)", "View", ShortcutScope.App, "Ctrl+Add"),

--- a/src/NovaTerminal.App/Shell/TabDragModel.cs
+++ b/src/NovaTerminal.App/Shell/TabDragModel.cs
@@ -21,15 +21,18 @@ namespace NovaTerminal.Shell
         internal const double AutoScrollStep = 12;
 
         /// <summary>True once the pointer has moved at least <paramref name="threshold"/> along the
-        /// drag axis from the press position, in either direction.</summary>
+        /// drag axis from the press position, in either direction. Non-finite positions return false.</summary>
         internal static bool ShouldStartDrag(double pressPos, double currentPos, double threshold = DragStartThreshold)
-            => Math.Abs(currentPos - pressPos) >= threshold;
+            => double.IsFinite(pressPos) && double.IsFinite(currentPos) && Math.Abs(currentPos - pressPos) >= threshold;
 
         /// <summary>Insertion index in [0..count]: the number of headers whose center is strictly
-        /// less than <paramref name="pointerPos"/>, i.e. the drop happens before the first header
-        /// whose center is below/right of the pointer. An empty list returns 0.</summary>
+        /// less than <paramref name="pointerPos"/>, i.e. before the first header whose center is at
+        /// or beyond the pointer. An empty list returns 0, and a non-finite pointer position returns 0.</summary>
         internal static int ComputeInsertIndex(IReadOnlyList<double> headerCenters, double pointerPos)
         {
+            if (!double.IsFinite(pointerPos))
+                return 0;
+
             var index = 0;
             for (var i = 0; i < headerCenters.Count; i++)
             {

--- a/src/NovaTerminal.App/Shell/TabDragModel.cs
+++ b/src/NovaTerminal.App/Shell/TabDragModel.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+
+namespace NovaTerminal.Shell
+{
+    /// <summary>
+    /// Pure math for pointer-driven tab reordering. Axis-generic: the caller passes
+    /// whichever coordinate applies (Y in vertical mode, X in horizontal), so there is
+    /// no orientation concept here. No Avalonia types so the tests stay plain [Fact]s
+    /// (same split as TabStripLayout).
+    /// </summary>
+    internal static class TabDragModel
+    {
+        /// <summary>Movement (DIP) along the drag axis required before a press becomes a drag.</summary>
+        internal const double DragStartThreshold = 5;
+
+        /// <summary>Distance (DIP) from either viewport edge that triggers auto-scroll during a drag.</summary>
+        internal const double AutoScrollEdgeZone = 24;
+
+        /// <summary>Distance (DIP) scrolled per auto-scroll tick.</summary>
+        internal const double AutoScrollStep = 12;
+
+        /// <summary>True once the pointer has moved at least <paramref name="threshold"/> along the
+        /// drag axis from the press position, in either direction.</summary>
+        internal static bool ShouldStartDrag(double pressPos, double currentPos, double threshold = DragStartThreshold)
+            => Math.Abs(currentPos - pressPos) >= threshold;
+
+        /// <summary>Insertion index in [0..count]: the number of headers whose center is strictly
+        /// less than <paramref name="pointerPos"/>, i.e. the drop happens before the first header
+        /// whose center is below/right of the pointer. An empty list returns 0.</summary>
+        internal static int ComputeInsertIndex(IReadOnlyList<double> headerCenters, double pointerPos)
+        {
+            var index = 0;
+            for (var i = 0; i < headerCenters.Count; i++)
+            {
+                if (headerCenters[i] < pointerPos)
+                    index++;
+            }
+
+            return index;
+        }
+
+        /// <summary>Auto-scroll offset for one tick while dragging near a viewport edge: negative
+        /// scrolls toward the start (up/left), positive toward the end (down/right), 0 inside the
+        /// safe zone. Degenerate inputs (non-finite pointer, viewportLength &lt;= 0, or an edge zone
+        /// that covers the whole viewport) return 0.</summary>
+        internal static double ComputeAutoScrollDelta(double viewportStart, double viewportLength, double pointerPos, double edgeZone = AutoScrollEdgeZone, double step = AutoScrollStep)
+        {
+            if (!double.IsFinite(pointerPos) || viewportLength <= 0 || edgeZone * 2 >= viewportLength)
+                return 0;
+
+            if (pointerPos < viewportStart + edgeZone)
+                return -step;
+            if (pointerPos > viewportStart + viewportLength - edgeZone)
+                return step;
+            return 0;
+        }
+    }
+}

--- a/src/NovaTerminal.App/Shell/TabStatusPresentation.cs
+++ b/src/NovaTerminal.App/Shell/TabStatusPresentation.cs
@@ -1,0 +1,100 @@
+namespace NovaTerminal.Shell
+{
+    /// <summary>Which single calm state the vertical tab header's status dot paints.</summary>
+    internal enum TabDotVisual
+    {
+        /// <summary>Nothing worth a dot: no attention, agent write, work, or watched tier.</summary>
+        None,
+
+        /// <summary>Output burst in flight (or a running command): the theme-blue dot.</summary>
+        Working,
+
+        /// <summary>Bell or attention status: the amber dot.</summary>
+        Attention,
+
+        /// <summary>An agent typed into the tab: the amber agent dot.</summary>
+        AgentWrote,
+
+        /// <summary>An agent is reading the tab (policy "All" only): the blue agent dot.</summary>
+        AgentWatched,
+    }
+
+    /// <summary>
+    /// The discrete attention markers a vertical tab header shows as trailing chips.
+    /// Unlike the dot (exactly one <see cref="TabDotVisual"/>), several markers can be
+    /// visible at once; only bell and plain activity are mutually exclusive.
+    /// </summary>
+    /// <param name="Bell">A bell fired on the tab and has not been acknowledged.</param>
+    /// <param name="Activity">Recent output activity (never true when <paramref name="Bell"/> is).</param>
+    /// <param name="AgentWrote">An agent typed into a pane in this tab, unacknowledged.</param>
+    /// <param name="AgentWatched">An agent read a pane in this tab; only surfaced under the "All" rollup policy.</param>
+    internal readonly record struct TabMarkerSet(bool Bell, bool Activity, bool AgentWrote, bool AgentWatched);
+
+    /// <summary>
+    /// Pure decision logic for the vertical tab header's agent-aware status presentation:
+    /// which marker chips are visible and which single state the status dot paints. No
+    /// Avalonia types so the tests stay plain [Fact]s (same split as TabDragModel /
+    /// TabStripLayout); <c>MainWindow.UpdateVerticalTabExtras</c> turns these results
+    /// into actual brushes and chip visibilities on the existing visual-refresh pass —
+    /// nothing here runs per output tick.
+    /// </summary>
+    internal static class TabStatusPresentation
+    {
+        /// <summary>
+        /// Resolves the marker chips for one tab from its raw inputs. Bell wins over
+        /// plain activity (mirrors <c>MainWindow.GetAttentionMarkerSuffix</c>'s
+        /// exclusivity); the agent tiers are independent of both. A watched tier only
+        /// counts under rollup policy "All" — the same rule
+        /// <c>MainWindow.ShouldShowTierInTabStrip</c> applies (a write always shows; an
+        /// unknown or null policy behaves as "WritesOnly", hiding reads).
+        /// </summary>
+        /// <remarks>Callers pass the tab state's stored tier, which
+        /// <c>MainWindow.RefreshTabAgentAttention</c> has already filtered through the
+        /// same policy — re-checking here keeps the helper pure and correct on raw
+        /// inputs, and is idempotent on already-filtered ones.</remarks>
+        internal static TabMarkerSet ResolveTabMarkers(
+            bool hasBell,
+            bool hasActivity,
+            AgentHost.AgentAttentionTier agentTier,
+            string? rollupPolicy)
+        {
+            return new TabMarkerSet(
+                Bell: hasBell,
+                Activity: hasActivity && !hasBell,
+                AgentWrote: agentTier == AgentHost.AgentAttentionTier.Wrote,
+                AgentWatched: agentTier == AgentHost.AgentAttentionTier.Watched
+                              && string.Equals(rollupPolicy, "All", System.StringComparison.Ordinal));
+        }
+
+        /// <summary>
+        /// Resolves the single dot visual (highest precedence first): attention (bell or
+        /// attention status) beats an agent write, which beats working output (or a
+        /// running command), which beats a watched tier. The header shows exactly one
+        /// calm dot so an idle-glancing user is never asked to parse a colored cluster.
+        /// </summary>
+        internal static TabDotVisual ResolveTabDot(TabTrackerStatus status, TabMarkerSet markers, bool hasRunningCommand)
+        {
+            if (status == TabTrackerStatus.Attention || markers.Bell)
+            {
+                return TabDotVisual.Attention;
+            }
+
+            if (markers.AgentWrote)
+            {
+                return TabDotVisual.AgentWrote;
+            }
+
+            if (status == TabTrackerStatus.Working || hasRunningCommand)
+            {
+                return TabDotVisual.Working;
+            }
+
+            if (markers.AgentWatched)
+            {
+                return TabDotVisual.AgentWatched;
+            }
+
+            return TabDotVisual.None;
+        }
+    }
+}

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowTitleBarTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowTitleBarTests.cs
@@ -699,7 +699,9 @@ public sealed class MainWindowTitleBarTests
     {
         var method = typeof(NovaTerminal.MainWindow).GetMethod("PopulateTabListMenu", BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.NotNull(method);
-        method!.Invoke(window, [showFlyout]);
+        // Reflection Invoke fills no optional parameters - the anchor override must be
+        // passed explicitly (null = title-bar anchor chain, the pre-pill behavior).
+        method!.Invoke(window, [showFlyout, null]);
     }
 
     private static void InvokeUpdateTabOverflowIndicator(NovaTerminal.MainWindow window)

--- a/tests/NovaTerminal.App.Tests/Core/ShortcutCatalogTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/ShortcutCatalogTests.cs
@@ -25,4 +25,24 @@ public sealed class ShortcutCatalogTests
         Assert.Equal("General", settingsEntry.Category);
         Assert.Equal("Ctrl+,", settingsEntry.DefaultBinding);
     }
+
+    [Fact]
+    public void GetEntries_IncludesMoveTabShortcuts_WithPageKeyDefaults()
+    {
+        ShortcutCatalogEntry prev = Assert.Single(
+            ShortcutCatalog.GetEntries(),
+            entry => entry.CommandId == "move_tab_prev");
+        ShortcutCatalogEntry next = Assert.Single(
+            ShortcutCatalog.GetEntries(),
+            entry => entry.CommandId == "move_tab_next");
+
+        Assert.Equal("Tab: Move Previous", prev.Title);
+        Assert.Equal("Tab: Move Next", next.Title);
+        Assert.Equal("General", prev.Category);
+        Assert.Equal("General", next.Category);
+        Assert.Equal(ShortcutScope.App, prev.Scope);
+        Assert.Equal(ShortcutScope.App, next.Scope);
+        Assert.Equal("Ctrl+Shift+PageUp", prev.DefaultBinding);
+        Assert.Equal("Ctrl+Shift+PageDown", next.DefaultBinding);
+    }
 }

--- a/tests/NovaTerminal.App.Tests/Core/TabBehaviorTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/TabBehaviorTests.cs
@@ -80,6 +80,28 @@ public sealed class TabBehaviorTests
         Assert.Equal(1, hidden);
     }
 
+    [Theory]
+    [InlineData(0, 3, -1, 0)]    // clamped at the top edge: target collapses to a no-op
+    [InlineData(0, 3, 1, 1)]
+    [InlineData(1, 3, 1, 2)]
+    [InlineData(2, 3, 1, 2)]     // clamped at the bottom edge
+    [InlineData(2, 3, -1, 1)]
+    [InlineData(1, 3, -5, 0)]    // oversized delta clamps, never wraps
+    [InlineData(1, 3, 5, 2)]
+    [InlineData(0, 1, 1, -1)]    // single tab: nothing to move
+    [InlineData(0, 0, 1, -1)]    // empty strip
+    [InlineData(-1, 3, 1, -1)]   // out-of-range current index
+    [InlineData(3, 3, -1, -1)]
+    public void ComputeMoveTabIndex_ClampsTargetOrRejects(
+        int currentIndex,
+        int count,
+        int delta,
+        int expected)
+    {
+        int target = NovaTerminal.MainWindow.ComputeMoveTabIndex(currentIndex, count, delta);
+        Assert.Equal(expected, target);
+    }
+
     [Fact]
     public void GetTabHeaderViewportMargin_NonMac_UsesOnlyRightReservation()
     {

--- a/tests/NovaTerminal.App.Tests/Core/TabRunningCommandTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/TabRunningCommandTests.cs
@@ -1,0 +1,184 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using NovaTerminal.AgentHost;
+using NovaTerminal.Shell;
+using Xunit;
+
+namespace NovaTerminal.Tests.Core;
+
+/// <summary>
+/// The precise "command in flight" half of the vertical tab dot: MainWindow.
+/// RefreshTabStatuses aggregates AgentSessionStatusKind.Running from the
+/// process-wide agent-session registry onto each tab's HasRunningCommand flag
+/// (keyed by the registration's TabId vs the tab's persistent id), and the
+/// existing ResolveTabDot plumbing turns that flag into the theme-blue working
+/// dot even when the 2 s output-burst heuristic has already decayed to Idle.
+///
+/// The window is created through TestMainWindowFactory (real constructor, fresh
+/// default settings via AppServices.BuildForDesigner). Its first tab is a real
+/// pane whose registration lands in AgentSessionRegistry.Instance — the same
+/// process-wide singleton every other window-creating test shares — so these
+/// tests follow AgentIndicatorTabRollupTests.RunIsolated: point
+/// NOVATERM_APPDATA_ROOT at a scratch directory (so nothing reaches the
+/// developer's real app data), snapshot the registry before creating the
+/// window, and diff afterwards to isolate the registration this window added.
+///
+/// Registry cleanup mirrors production CloseTab: Window.Close() alone never
+/// disposes panes (the real close path runs DisposeControlTree →
+/// TerminalPane.DetachFromUiThread → Unregister), so the finally block
+/// unregisters the diffed registration explicitly. Without that, the driven
+/// status machine would stay reachable through the shared registry forever.
+/// </summary>
+public sealed class TabRunningCommandTests
+{
+    private static TerminalSettings GetSettings(MainWindow window)
+        => (TerminalSettings)typeof(MainWindow)
+            .GetField("_settings", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(window)!;
+
+    private static void MakeVertical(MainWindow window)
+    {
+        GetSettings(window).TabStripOrientation = "Vertical";
+        window.ApplyTabLayout();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    /// <summary>A second, pane-less tab (plain factory — no PTY spawn, no registration),
+    /// laid out vertically so it renders a header like any other tab.</summary>
+    private static TabItem AddPlainVerticalTab(MainWindow window)
+    {
+        var tabs = window.FindControl<TabControl>("Tabs")!;
+        var tab = new TabItem { Content = new Border() };
+        tabs.Items.Add(tab);
+        window.ApplyTabLayout(); // rebuild headers so the new tab gets a vertical row
+        Dispatcher.UIThread.RunJobs();
+        return tab;
+    }
+
+    private static Avalonia.Media.Color? DotColorOf(TabItem tab)
+    {
+        var dot = MainWindow.FindTabHeaderDescendant<Avalonia.Controls.Shapes.Ellipse>(tab.Header, "TabStatusDot");
+        return (dot?.Fill as Avalonia.Media.ISolidColorBrush)?.Color;
+    }
+
+    private static void RunIsolated(Action<MainWindow, AgentSessionRegistration> body)
+    {
+        string tempRoot = Path.Combine(Path.GetTempPath(), $"novaterm_tab_running_test_{Guid.NewGuid():N}");
+        string? previousRoot = Environment.GetEnvironmentVariable("NOVATERM_APPDATA_ROOT");
+        Directory.CreateDirectory(tempRoot);
+
+        AgentSessionRegistration? registration = null;
+        try
+        {
+            Environment.SetEnvironmentVariable("NOVATERM_APPDATA_ROOT", tempRoot);
+
+            var before = AgentSessionRegistry.Instance.GetRegistrations();
+            var window = TestMainWindowFactory.Create();
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var added = AgentSessionRegistry.Instance.GetRegistrations().Except(before).ToArray();
+            registration = Assert.Single(added);
+
+            body(window, registration);
+        }
+        finally
+        {
+            // Production CloseTab runs DisposeControlTree → DetachFromUiThread →
+            // Unregister; Window.Close() alone never does, so do the unregister half
+            // explicitly. This also retires whatever status the test drove the
+            // machine to: an unregistered pane's machine is reachable by nobody.
+            if (registration != null)
+            {
+                AgentSessionRegistry.Instance.Unregister(registration.PaneId);
+            }
+
+            Environment.SetEnvironmentVariable("NOVATERM_APPDATA_ROOT", previousRoot);
+            try { Directory.Delete(tempRoot, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [AvaloniaFact]
+    public void RefreshTabStatuses_RunningRegistration_FlagsOnlyTheOwningTab_AndClearsOnFinish()
+    {
+        RunIsolated((window, registration) =>
+        {
+            MakeVertical(window);
+            var tabs = window.FindControl<TabControl>("Tabs")!;
+            var tabA = tabs.Items.Cast<TabItem>().First(); // the real-pane tab this window opened with
+            var tabB = AddPlainVerticalTab(window);
+
+            // The mapping the aggregation relies on: AddTab associated the pane's
+            // registration with tab A's persistent id.
+            Assert.Equal(window.GetPersistentTabId(tabA), registration.TabId);
+
+            // Baseline: nothing is running, both tabs flag false after a pass.
+            window.RefreshTabStatuses();
+            Dispatcher.UIThread.RunJobs();
+            Assert.False(window.IsTabRunningCommandForTest(tabA));
+            Assert.False(window.IsTabRunningCommandForTest(tabB));
+
+            // Precise tier: a shell-integration command start drives the machine to
+            // Running regardless of output (deterministic — no clocks, no sweeps).
+            registration.StatusMachine.NotifyCommandStarted();
+            Assert.Equal(AgentSessionStatusKind.Running, registration.StatusMachine.Snapshot().Kind);
+
+            window.RefreshTabStatuses();
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(window.IsTabRunningCommandForTest(tabA), "the tab owning the running pane must be flagged");
+            Assert.False(window.IsTabRunningCommandForTest(tabB), "a tab with no running pane must stay unflagged");
+
+            registration.StatusMachine.NotifyCommandFinished(0);
+            Assert.NotEqual(AgentSessionStatusKind.Running, registration.StatusMachine.Snapshot().Kind);
+
+            window.RefreshTabStatuses();
+            Dispatcher.UIThread.RunJobs();
+            Assert.False(window.IsTabRunningCommandForTest(tabA), "the flag must clear once no pane reports Running");
+        });
+    }
+
+    [AvaloniaFact]
+    public void RefreshTabStatuses_RunningCommand_PaintsWorkingDotWhileHeuristicStaysIdle()
+    {
+        RunIsolated((window, registration) =>
+        {
+            MakeVertical(window);
+            var tabA = AddPlainVerticalTab(window);
+
+            // The real pane's shell greets asynchronously when its PTY warms up, which
+            // races the heuristic's 2 s decay window and would make "RenderedStatus is
+            // Idle" a timing assertion. Re-associating the registration with the
+            // pane-less tab (the same AgentSessionRegistry.SetTabAssociation production
+            // runs when a pane lands in a different tab) pins the mapping input while
+            // giving the observed tab a tracker that deterministically never sees
+            // output — so only the precise Running flag can paint its dot.
+            Assert.True(AgentSessionRegistry.Instance.SetTabAssociation(
+                registration.PaneId, window.GetPersistentTabId(tabA)));
+
+            registration.StatusMachine.NotifyCommandStarted();
+            window.RefreshTabStatuses();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(window.IsTabRunningCommandForTest(tabA));
+            Assert.Equal(TabTrackerStatus.Idle, window.GetTabRenderedStatusForTest(tabA));
+            // Working dot = the theme-blue workingBrush UpdateTabVisuals passes to
+            // UpdateVerticalTabExtras — not the amber attention or agent brushes, and
+            // not the heuristic (that rendered Idle).
+            var expectedWorking = GetSettings(window).ActiveTheme.Blue.ToAvaloniaColor();
+            Assert.Equal(expectedWorking, DotColorOf(tabA));
+
+            // Finish: with the heuristic Idle and no markers, the dot must fall back
+            // to transparent — the running flag, not a stale paint, drove the blue.
+            registration.StatusMachine.NotifyCommandFinished(0);
+            window.RefreshTabStatuses();
+            Dispatcher.UIThread.RunJobs();
+            Assert.False(window.IsTabRunningCommandForTest(tabA));
+            Assert.Equal(Avalonia.Media.Colors.Transparent, DotColorOf(tabA));
+        });
+    }
+}

--- a/tests/NovaTerminal.App.Tests/Core/TabTitleResolutionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/TabTitleResolutionTests.cs
@@ -39,4 +39,96 @@ public sealed class TabTitleResolutionTests
             fallbackHeader: null);
         Assert.Equal("Terminal", defaultTitle);
     }
+
+    // ---- Display-label truncation (ResolveTabDisplayLabels, the pure core of
+    // BuildTabDisplayLabels) ----
+    //
+    // includeMarkers:false is the vertical-header call: attention renders as trailing
+    // chips there, so the marker suffix must be neither appended nor reserved while
+    // truncating; the pinned/protected prefixes live in the base label and stay, and
+    // the ~id collision disambiguation keeps working.
+
+    private sealed record LabelTab(string Base, string Marker, string Hint);
+
+    private static Dictionary<LabelTab, string> ResolveLabels(
+        IReadOnlyList<LabelTab> tabs, int maxLength, bool includeMarkers)
+        => NovaTerminal.MainWindow.ResolveTabDisplayLabels<LabelTab>(
+            tabs, t => t.Base, t => t.Marker, t => t.Hint, maxLength, includeMarkers);
+
+    [Fact]
+    public void ResolveTabDisplayLabels_IncludeMarkersFalse_OmitsMarkerSuffix()
+    {
+        var tab = new List<LabelTab> { new("build", " 🔔", "~a1b2") };
+
+        var withoutMarkers = ResolveLabels(tab, maxLength: 44, includeMarkers: false);
+        var withMarkers = ResolveLabels(tab, maxLength: 44, includeMarkers: true);
+
+        Assert.Equal("build", withoutMarkers[tab[0]]);
+        Assert.Equal("build 🔔", withMarkers[tab[0]]);
+    }
+
+    [Fact]
+    public void ResolveTabDisplayLabels_IncludeMarkersFalse_PreservesPrefixes()
+    {
+        // Prefixes (pinned/protected, and the forwarding badge) are part of the base
+        // label, not the marker suffix — they must survive in both modes.
+        var tab = new List<LabelTab> { new("📌 🔒 deploy 🔁 2", string.Empty, "~a1b2") };
+
+        Assert.Equal("📌 🔒 deploy 🔁 2", ResolveLabels(tab, 44, includeMarkers: false)[tab[0]]);
+        Assert.Equal("📌 🔒 deploy 🔁 2", ResolveLabels(tab, 44, includeMarkers: true)[tab[0]]);
+    }
+
+    [Fact]
+    public void ResolveTabDisplayLabels_IncludeMarkersFalse_LongTitle_TruncatesWithoutReservingMarkerSpace()
+    {
+        string longTitle = new string('t', 60);
+        var tab = new List<LabelTab> { new(longTitle, " 🔔", "~a1b2") };
+
+        var vertical = ResolveLabels(tab, maxLength: 44, includeMarkers: false)[tab[0]];
+        // Plain TruncateTabLabel shape: 43 chars + ellipsis, no marker room reserved.
+        Assert.Equal(longTitle.Substring(0, 43) + "…", vertical);
+        Assert.DoesNotContain("🔔", vertical);
+
+        var horizontal = ResolveLabels(tab, maxLength: 44, includeMarkers: true)[tab[0]];
+        // Marker mode truncates the title harder and keeps the suffix visible.
+        Assert.EndsWith("🔔", horizontal);
+        Assert.True(horizontal.Length <= 44);
+    }
+
+    [Fact]
+    public void ResolveTabDisplayLabels_IncludeMarkersFalse_CollisionStillAppendsHint()
+    {
+        var tabs = new List<LabelTab>
+        {
+            new("same", " 🔔", "~a1b2"),
+            new("same", string.Empty, "~c3d4"),
+        };
+
+        var vertical = ResolveLabels(tabs, maxLength: 44, includeMarkers: false);
+
+        // Identical bases collide once the marker is dropped; each gets its own hint.
+        Assert.Equal("same~a1b2", vertical[tabs[0]]);
+        Assert.Equal("same~c3d4", vertical[tabs[1]]);
+        Assert.DoesNotContain("🔔", vertical[tabs[0]]);
+
+        // Marker mode: the different suffixes already disambiguate, so no hint is added.
+        var horizontal = ResolveLabels(tabs, maxLength: 44, includeMarkers: true);
+        Assert.Equal("same 🔔", horizontal[tabs[0]]);
+        Assert.Equal("same", horizontal[tabs[1]]);
+    }
+
+    [Fact]
+    public void ResolveTabDisplayLabels_IncludeMarkersTrue_CollisionPutsHintAfterMarker()
+    {
+        var tabs = new List<LabelTab>
+        {
+            new("same", " 🔔", "~a1b2"),
+            new("same", " 🔔", "~c3d4"),
+        };
+
+        var labels = ResolveLabels(tabs, maxLength: 44, includeMarkers: true);
+
+        Assert.Equal("same 🔔~a1b2", labels[tabs[0]]);
+        Assert.Equal("same 🔔~c3d4", labels[tabs[1]]);
+    }
 }

--- a/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
@@ -440,14 +440,15 @@ public sealed class VerticalTabStripTests
                 KeyModifiers.None, MouseButton.Left));
     }
 
-    // Vertical strip with extra plain tabs to reorder. Plain TabItems bypass AddTab (which
-    // would spawn a real PTY per tab - same trick as AddWidePlainTabs above); re-applying
-    // the layout rebuilds every header through the wired factories, so the added tabs get
-    // drag-wired vertical header hosts.
-    private static NovaTerminal.MainWindow CreateShownVerticalWindowWithPlainTabs(int plainTabCount)
+    // Strip (either orientation) with extra plain tabs to reorder. Plain TabItems bypass
+    // AddTab (which would spawn a real PTY per tab - same trick as AddWidePlainTabs
+    // above); re-applying the layout rebuilds every header through the wired factories,
+    // so the added tabs get drag-wired header hosts (vertical rows or plain horizontal
+    // headers, per <paramref name="orientation"/>).
+    private static NovaTerminal.MainWindow CreateShownStripWindowWithPlainTabs(int plainTabCount, string orientation)
     {
         var window = CreateShownWindow();
-        GetSettings(window).TabStripOrientation = "Vertical";
+        GetSettings(window).TabStripOrientation = orientation;
         window.ApplyTabLayout();
         Dispatcher.UIThread.RunJobs();
 
@@ -466,6 +467,9 @@ public sealed class VerticalTabStripTests
         Dispatcher.UIThread.RunJobs();
         return window;
     }
+
+    private static NovaTerminal.MainWindow CreateShownVerticalWindowWithPlainTabs(int plainTabCount)
+        => CreateShownStripWindowWithPlainTabs(plainTabCount, "Vertical");
 
     private static Point HeaderCenterInWindow(Control headerHost, Window window)
     {
@@ -520,6 +524,48 @@ public sealed class VerticalTabStripTests
         // Pointer below tab 2's center -> insert index 3 -> dragged tab (from slot 0) lands
         // at index 2; anything below the drop point (startup-restore tabs included) keeps
         // its relative order.
+        var expected = new List<TabItem> { before[1], before[2], dragged };
+        expected.AddRange(before.Skip(3));
+        Assert.Equal(expected, after);
+        Assert.Same(dragged, tabs.SelectedItem);
+    }
+
+    // The drag math is axis-generic (TabDragModel has no orientation concept), but the
+    // commit path above only exercised it vertically. This mirrors it along X through a
+    // real horizontal strip (orientation via _settings.TabStripOrientation +
+    // ApplyTabLayout, headers rebuilt through the wired horizontal factory) so the
+    // horizontal wiring - X axis selection, Height-side indicator thickness - is pinned
+    // end-to-end too.
+    [AvaloniaFact]
+    public void DragReorder_Commit_HorizontalStrip_ReordersAlongX_AndRestoresSelection()
+    {
+        var window = CreateShownStripWindowWithPlainTabs(plainTabCount: 2, orientation: "Horizontal");
+        var tabs = window.FindControl<TabControl>("Tabs")!;
+        var before = tabs.Items.Cast<TabItem>().ToList();
+        Assert.True(before.Count >= 3, "reorder needs at least three tabs");
+        var dragged = before[0];
+        var host0 = HeaderHostOf(dragged);
+        var host2 = HeaderHostOf(before[2]);
+
+        var driver = new PointerDriver();
+        var pressPos = HeaderCenterInWindow(host0, window);
+        driver.Press(host0, window, pressPos);
+
+        // Cross the start threshold (>= 5 DIP along the strip axis - X here), still over tab 0.
+        driver.Move(host0, window, new Point(pressPos.X + 6, pressPos.Y));
+        Assert.True(window.IsTabReorderDraggingForTest, "past-threshold move must begin the drag");
+        Assert.Equal(0.5, host0.Opacity, 5);
+
+        // Drop past tab 2's center: insert index = count, so the dragged tab lands last.
+        var pastTab2 = new Point(HeaderCenterInWindow(host2, window).X + 4, pressPos.Y);
+        driver.Move(host0, window, pastTab2);
+        driver.Release(host0, window, pastTab2);
+
+        Assert.False(window.IsTabReorderDraggingForTest);
+        Assert.Equal(1, host0.Opacity, 5);
+
+        var after = tabs.Items.Cast<TabItem>().ToList();
+        Assert.Equal(before.Count, after.Count);
         var expected = new List<TabItem> { before[1], before[2], dragged };
         expected.AddRange(before.Skip(3));
         Assert.Equal(expected, after);

--- a/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
@@ -348,6 +348,44 @@ public sealed class VerticalTabStripTests
         }
     }
 
+    // Vertical headers replaced the in-title attention markers with trailing chips
+    // (UpdateVerticalTabExtras), which is wired in UpdateTabVisuals as
+    // BuildTabDisplayLabels(..., includeMarkers: !_isVerticalTabStrip). This pins both
+    // halves of that split end-to-end through a bell: the title TextBlock must EXCLUDE
+    // the marker suffix (otherwise the bell is double-reported as chip AND title text),
+    // while the header host's tooltip - BuildFullTabLabel, marker-suffixed in both
+    // modes - must still INCLUDE it (otherwise the marker is lost entirely on hover).
+    [AvaloniaFact]
+    public void UpdateTabVisuals_Vertical_BellMarkerExcludedFromTitle_ButPresentInTooltip()
+    {
+        var window = CreateShownWindow();
+        try
+        {
+            GetSettings(window).TabStripOrientation = "Vertical";
+            window.ApplyTabLayout();
+            Dispatcher.UIThread.RunJobs();
+            var tab = AddPlainVerticalTab(window);
+
+            window.SetTabMarkerStateForTest(tab, hasBell: true, hasActivity: false, NovaTerminal.AgentHost.AgentAttentionTier.Idle);
+            window.UpdateTabVisuals();
+            Dispatcher.UIThread.RunJobs();
+
+            // The chip is the vertical surface for the bell...
+            Assert.True(ChipOf(tab, "TabBellChip").IsVisible);
+            // ...so the title text must not ALSO carry the marker suffix.
+            Assert.DoesNotContain("🔔", GetTabHeaderTextOf(window, tab));
+
+            // The tooltip reads the untruncated full label, which keeps its markers
+            // regardless of strip orientation.
+            var host = Assert.IsType<Border>(tab.Header);
+            Assert.Contains("🔔", Assert.IsType<string>(Avalonia.Controls.ToolTip.GetTip(host)));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
     [AvaloniaFact]
     public void RefreshTabStatuses_WorkingTracker_PaintsThemeDot_AndIdleClearsIt()
     {

--- a/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
@@ -1,8 +1,10 @@
 using System.Linq;
 using System.Reflection;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
 using Avalonia.Headless.XUnit;
+using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Threading;
 using NovaTerminal.Shell;
@@ -400,5 +402,247 @@ public sealed class VerticalTabStripTests
         var preview = NovaTerminal.MainWindow.FindTabHeaderDescendant<TextBlock>(tab.Header, "TabPreviewLine");
         Assert.NotNull(preview);
         Assert.False(window.GetTabPreviewDirtyForTest(tab), "the first vertical pass should have recomputed and cleared dirty");
+    }
+
+    // ---- Drag-to-reorder (MainWindow.WireTabHeaderReorderDrag + Shell/TabDragModel) ----
+    //
+    // Real pointer-event routing exists in the headless host (unlike the grip-drag tests
+    // further up, which had to fake state through a seam): each test drives the actual
+    // routed PointerPressed/Moved/Released/KeyDown events through a real Pointer instance
+    // with window-space positions translated from the laid-out header bounds.
+
+    /// <summary>Raises left-button press/move/release routed events through one real
+    /// pointer, mirroring how the platform input manager would deliver them (window-space
+    /// rootVisualPosition; the event args translate on demand via GetPosition).</summary>
+    private sealed class PointerDriver
+    {
+        private readonly Avalonia.Input.Pointer _pointer = new(Avalonia.Input.Pointer.GetNextFreeId(), PointerType.Mouse, isPrimary: true);
+        private ulong _timestamp;
+
+        public IPointer Pointer => _pointer;
+
+        public void Press(Control target, Window window, Point windowPosition)
+            => target.RaiseEvent(new PointerPressedEventArgs(
+                target, _pointer, window, windowPosition, ++_timestamp,
+                new PointerPointProperties(RawInputModifiers.LeftMouseButton, PointerUpdateKind.LeftButtonPressed),
+                KeyModifiers.None));
+
+        public void Move(Control target, Window window, Point windowPosition)
+            => target.RaiseEvent(new PointerEventArgs(
+                InputElement.PointerMovedEvent, target, _pointer, window, windowPosition, ++_timestamp,
+                new PointerPointProperties(RawInputModifiers.LeftMouseButton, PointerUpdateKind.Other),
+                KeyModifiers.None));
+
+        public void Release(Control target, Window window, Point windowPosition)
+            => target.RaiseEvent(new PointerReleasedEventArgs(
+                target, _pointer, window, windowPosition, ++_timestamp,
+                new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.LeftButtonReleased),
+                KeyModifiers.None, MouseButton.Left));
+    }
+
+    // Vertical strip with extra plain tabs to reorder. Plain TabItems bypass AddTab (which
+    // would spawn a real PTY per tab - same trick as AddWidePlainTabs above); re-applying
+    // the layout rebuilds every header through the wired factories, so the added tabs get
+    // drag-wired vertical header hosts.
+    private static NovaTerminal.MainWindow CreateShownVerticalWindowWithPlainTabs(int plainTabCount)
+    {
+        var window = CreateShownWindow();
+        GetSettings(window).TabStripOrientation = "Vertical";
+        window.ApplyTabLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        var tabs = window.FindControl<TabControl>("Tabs");
+        Assert.NotNull(tabs);
+        for (int i = 0; i < plainTabCount; i++)
+        {
+            tabs!.Items.Add(new TabItem
+            {
+                Header = new TextBlock { Text = $"DragPlain{i}" },
+                Content = new Border()
+            });
+        }
+
+        window.ApplyTabLayout();
+        Dispatcher.UIThread.RunJobs();
+        return window;
+    }
+
+    private static Point HeaderCenterInWindow(Control headerHost, Window window)
+    {
+        var center = headerHost.TranslatePoint(
+            new Point(headerHost.Bounds.Width / 2, headerHost.Bounds.Height / 2), window);
+        Assert.NotNull(center); // the header must be attached and laid out for the drag math
+        return center!.Value;
+    }
+
+    private static Border HeaderHostOf(TabItem tab)
+    {
+        var host = tab.Header as Border;
+        Assert.NotNull(host);
+        return host!;
+    }
+
+    private static Border? FindInsertIndicator(NovaTerminal.MainWindow window)
+        => Avalonia.VisualTree.VisualExtensions.GetVisualDescendants(window)
+            .OfType<Border>()
+            .FirstOrDefault(b => b.Name == "PART_TabInsertIndicator");
+
+    [AvaloniaFact]
+    public void DragReorder_Commit_MovesDraggedTabLast_AndRestoresSelection()
+    {
+        var window = CreateShownVerticalWindowWithPlainTabs(plainTabCount: 2);
+        var tabs = window.FindControl<TabControl>("Tabs")!;
+        var before = tabs.Items.Cast<TabItem>().ToList();
+        Assert.True(before.Count >= 3, "reorder needs at least three tabs");
+        var dragged = before[0];
+        var host0 = HeaderHostOf(dragged);
+        var host2 = HeaderHostOf(before[2]);
+
+        var driver = new PointerDriver();
+        var pressPos = HeaderCenterInWindow(host0, window);
+        driver.Press(host0, window, pressPos);
+
+        // Cross the start threshold (>= 5 DIP along the strip axis), still over tab 0.
+        driver.Move(host0, window, new Point(pressPos.X, pressPos.Y + 6));
+        Assert.True(window.IsTabReorderDraggingForTest, "past-threshold move must begin the drag");
+        Assert.Equal(0.5, host0.Opacity, 5);
+
+        // Drop below tab 2's center: insert index = count, so the dragged tab lands last.
+        var belowTab2 = new Point(pressPos.X, HeaderCenterInWindow(host2, window).Y + 4);
+        driver.Move(host0, window, belowTab2);
+        driver.Release(host0, window, belowTab2);
+
+        Assert.False(window.IsTabReorderDraggingForTest);
+        Assert.Equal(1, host0.Opacity, 5);
+
+        var after = tabs.Items.Cast<TabItem>().ToList();
+        Assert.Equal(before.Count, after.Count);
+        // Pointer below tab 2's center -> insert index 3 -> dragged tab (from slot 0) lands
+        // at index 2; anything below the drop point (startup-restore tabs included) keeps
+        // its relative order.
+        var expected = new List<TabItem> { before[1], before[2], dragged };
+        expected.AddRange(before.Skip(3));
+        Assert.Equal(expected, after);
+        Assert.Same(dragged, tabs.SelectedItem);
+    }
+
+    [AvaloniaFact]
+    public void DragReorder_SubThresholdMove_IsAPlainClick_NoDragNoReorder()
+    {
+        var window = CreateShownVerticalWindowWithPlainTabs(plainTabCount: 2);
+        var tabs = window.FindControl<TabControl>("Tabs")!;
+        var before = tabs.Items.Cast<TabItem>().ToList();
+        var dragged = before[0];
+        var host0 = HeaderHostOf(dragged);
+
+        var driver = new PointerDriver();
+        var pressPos = HeaderCenterInWindow(host0, window);
+        driver.Press(host0, window, pressPos);
+
+        // 2 DIP is under the 5 DIP start threshold.
+        driver.Move(host0, window, new Point(pressPos.X, pressPos.Y + 2));
+        Assert.False(window.IsTabReorderDraggingForTest);
+        Assert.Equal(1, host0.Opacity, 5);
+        Assert.False(FindInsertIndicator(window)!.IsVisible);
+
+        driver.Release(host0, window, pressPos);
+
+        Assert.False(window.IsTabReorderDraggingForTest);
+        Assert.Equal(before, tabs.Items.Cast<TabItem>().ToList());
+        Assert.Same(dragged, tabs.SelectedItem);
+    }
+
+    [AvaloniaFact]
+    public void DragReorder_Indicator_VisibleMidDrag_HiddenAfterRelease()
+    {
+        var window = CreateShownVerticalWindowWithPlainTabs(plainTabCount: 2);
+        var tabs = window.FindControl<TabControl>("Tabs")!;
+        var before = tabs.Items.Cast<TabItem>().ToList();
+        var indicator = FindInsertIndicator(window);
+        Assert.NotNull(indicator);
+        Assert.False(indicator!.IsVisible);
+
+        // Drag tab 1 (the middle tab) just past its own center so the drop lands back in
+        // its own slot - the indicator must appear mid-drag even when no reorder results.
+        var dragged = before[1];
+        var host1 = HeaderHostOf(dragged);
+        var pressPos = HeaderCenterInWindow(host1, window);
+
+        var driver = new PointerDriver();
+        driver.Press(host1, window, pressPos);
+        driver.Move(host1, window, new Point(pressPos.X, pressPos.Y + 6));
+
+        Assert.True(window.IsTabReorderDraggingForTest);
+        Assert.True(indicator.IsVisible, "insert indicator must be visible mid-drag");
+
+        driver.Release(host1, window, new Point(pressPos.X, pressPos.Y + 6));
+
+        Assert.False(indicator.IsVisible, "insert indicator must hide after release");
+        Assert.False(window.IsTabReorderDraggingForTest);
+        Assert.Equal(before, tabs.Items.Cast<TabItem>().ToList());
+    }
+
+    [AvaloniaFact]
+    public void DragReorder_Escape_CancelsWithoutReorder_AndLaterReleaseIsHarmless()
+    {
+        var window = CreateShownVerticalWindowWithPlainTabs(plainTabCount: 2);
+        var tabs = window.FindControl<TabControl>("Tabs")!;
+        var before = tabs.Items.Cast<TabItem>().ToList();
+        var dragged = before[0];
+        var host0 = HeaderHostOf(dragged);
+        var indicator = FindInsertIndicator(window)!;
+
+        var driver = new PointerDriver();
+        var pressPos = HeaderCenterInWindow(host0, window);
+        driver.Press(host0, window, pressPos);
+        driver.Move(host0, window, new Point(pressPos.X, pressPos.Y + 6));
+        Assert.True(window.IsTabReorderDraggingForTest);
+
+        window.RaiseEvent(new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Key = Key.Escape,
+            Source = window
+        });
+
+        Assert.False(window.IsTabReorderDraggingForTest, "Escape must cancel the drag");
+        Assert.False(indicator.IsVisible);
+        Assert.Equal(1, host0.Opacity, 5);
+        Assert.Equal(before, tabs.Items.Cast<TabItem>().ToList());
+
+        // A stray release (and the capture cleanup that already ran) must be a no-op.
+        driver.Release(host0, window, new Point(pressPos.X, pressPos.Y + 6));
+        Assert.Equal(before, tabs.Items.Cast<TabItem>().ToList());
+        Assert.Same(dragged, tabs.SelectedItem);
+    }
+
+    [AvaloniaFact]
+    public void DragReorder_DuringGripDrag_HeaderPressMustNotStartReorder()
+    {
+        var window = CreateShownVerticalWindowWithPlainTabs(plainTabCount: 2);
+        var tabs = window.FindControl<TabControl>("Tabs")!;
+        var before = tabs.Items.Cast<TabItem>().ToList();
+        var host0 = HeaderHostOf(before[0]);
+
+        // Mid-grip-drag state (the grip owns the pointer): a header press + threshold move
+        // arriving meanwhile must be ignored, not turned into a second concurrent drag.
+        window.IsTabStripGripDraggingForTest = true;
+        try
+        {
+            var driver = new PointerDriver();
+            var pressPos = HeaderCenterInWindow(host0, window);
+            driver.Press(host0, window, pressPos);
+            driver.Move(host0, window, new Point(pressPos.X, pressPos.Y + 6));
+
+            Assert.False(window.IsTabReorderDraggingForTest);
+            Assert.False(FindInsertIndicator(window)!.IsVisible);
+            driver.Release(host0, window, pressPos);
+        }
+        finally
+        {
+            window.IsTabStripGripDraggingForTest = false;
+        }
+
+        Assert.Equal(before, tabs.Items.Cast<TabItem>().ToList());
     }
 }

--- a/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
@@ -540,7 +540,9 @@ public sealed class VerticalTabStripTests
     {
         var method = typeof(NovaTerminal.MainWindow).GetMethod("PopulateTabListMenu", BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.NotNull(method);
-        method!.Invoke(window, new object[] { false });
+        // Reflection Invoke fills no optional parameters - the anchor override must be
+        // passed explicitly (null = title-bar anchor chain, the pre-pill behavior).
+        method!.Invoke(window, new object[] { false, null });
     }
 
     // Regression coverage for the perf fix: recomputing the preview line on every batched
@@ -918,5 +920,263 @@ public sealed class VerticalTabStripTests
         }
 
         Assert.Equal(before, tabs.Items.Cast<TabItem>().ToList());
+    }
+
+    // ---- Keyboard move-tab (MoveSelectedTab, sharing the drag commit path) ----
+    //
+    // MoveSelectedTab commits through the same ReorderTabInItems primitive as
+    // CommitTabReorder, so these pin the keyboard-specific half: clamped ±1 movement,
+    // selection restoration on the moved tab, and no MRU churn beyond the selection's own
+    // TouchTabMru (which is a no-op re-insert when the moved tab is already the MRU head).
+
+    private static List<TabItem> GetTabMru(NovaTerminal.MainWindow window)
+        => ((List<TabItem>)typeof(NovaTerminal.MainWindow)
+            .GetField("_tabMru", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(window)!).ToList();
+
+    /// <summary>Puts the strip in a deterministic selection state: two real selection
+    /// changes so MRU head is provably <paramref name="selected"/> before the move.</summary>
+    private static void SelectViaRealEvents(TabControl tabs, TabItem selected)
+    {
+        var other = tabs.Items.Cast<TabItem>().First(t => t != selected);
+        tabs.SelectedItem = other;
+        tabs.SelectedItem = selected;
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    [AvaloniaFact]
+    public void MoveSelectedTab_PlusOne_SwapsWithNext_KeepsSelection_MruUntouched()
+    {
+        var window = CreateShownVerticalWindowWithPlainTabs(plainTabCount: 2);
+        try
+        {
+            var tabs = window.FindControl<TabControl>("Tabs")!;
+            var before = tabs.Items.Cast<TabItem>().ToList();
+            Assert.True(before.Count >= 3, "move needs at least three tabs");
+
+            SelectViaRealEvents(tabs, before[0]);
+            var mruBefore = GetTabMru(window);
+
+            window.MoveSelectedTab(+1);
+
+            var after = tabs.Items.Cast<TabItem>().ToList();
+            Assert.Equal(before.Count, after.Count);
+            Assert.Equal(new[] { before[1], before[0] }.Concat(before.Skip(2)).ToList(), after);
+            Assert.Same(before[0], tabs.SelectedItem);
+            Assert.Equal(mruBefore, GetTabMru(window));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void MoveSelectedTab_MinusOneAtTopIndex_IsNoOp()
+    {
+        var window = CreateShownVerticalWindowWithPlainTabs(plainTabCount: 2);
+        try
+        {
+            var tabs = window.FindControl<TabControl>("Tabs")!;
+            var before = tabs.Items.Cast<TabItem>().ToList();
+            SelectViaRealEvents(tabs, before[0]);
+            var mruBefore = GetTabMru(window);
+
+            window.MoveSelectedTab(-1);
+
+            Assert.Equal(before, tabs.Items.Cast<TabItem>().ToList());
+            Assert.Same(before[0], tabs.SelectedItem);
+            Assert.Equal(mruBefore, GetTabMru(window));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    // Same tunneled-KeyDown path the Escape-cancel drag test uses: raising KeyDown on the
+    // window reaches the tunneled shortcut handler, which must recognize the catalogued
+    // Ctrl+Shift+PageDown chord and route it to MoveSelectedTab.
+    [AvaloniaFact]
+    public void KeyDown_CtrlShiftPageDown_MovesSelectedTabDown()
+    {
+        var window = CreateShownVerticalWindowWithPlainTabs(plainTabCount: 2);
+        try
+        {
+            var tabs = window.FindControl<TabControl>("Tabs")!;
+            var before = tabs.Items.Cast<TabItem>().ToList();
+            Assert.True(before.Count >= 3, "move needs at least three tabs");
+            SelectViaRealEvents(tabs, before[0]);
+
+            window.RaiseEvent(new KeyEventArgs
+            {
+                RoutedEvent = InputElement.KeyDownEvent,
+                Key = Key.PageDown,
+                KeyModifiers = KeyModifiers.Control | KeyModifiers.Shift,
+                Source = window
+            });
+            Dispatcher.UIThread.RunJobs();
+
+            var after = tabs.Items.Cast<TabItem>().ToList();
+            Assert.Equal(new[] { before[1], before[0] }.Concat(before.Skip(2)).ToList(), after);
+            Assert.Same(before[0], tabs.SelectedItem);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    // ---- Vertical overflow pill (PART_TabOverflowPill) ----
+
+    private static Button? FindOverflowPill(NovaTerminal.MainWindow window)
+        => Avalonia.VisualTree.VisualExtensions.GetVisualDescendants(window)
+            .OfType<Button>()
+            .FirstOrDefault(b => b.Name == "PART_TabOverflowPill");
+
+    /// <summary>The pill's text part. Read from Content rather than the visual tree for
+    /// the same reason production does: while the pill is hidden its own template has
+    /// never been applied, so the TextBlock has no visual-tree presence yet.</summary>
+    private static TextBlock? FindOverflowPillText(Button pill)
+        => pill.Content as TextBlock;
+
+    /// <summary>Small window (height set before Show so the first layout already measures
+    /// against it) plus enough vertical rows to overflow the sidebar viewport. Plain
+    /// TabItems bypass AddTab (which would spawn a real PTY per tab - same trick as
+    /// AddWidePlainTabs); re-applying the layout rebuilds their headers as vertical
+    /// rows.</summary>
+    private static NovaTerminal.MainWindow CreateShownVerticalWindowWithOverflow(
+        int plainTabCount, double height)
+    {
+        var window = TestMainWindowFactory.Create();
+        window.Height = height;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var settings = GetSettings(window);
+        settings.TabStripOrientation = "Vertical";
+        settings.VerticalTabStripWidth = 200;
+        window.ApplyTabLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        var tabs = window.FindControl<TabControl>("Tabs");
+        Assert.NotNull(tabs);
+        for (int i = 0; i < plainTabCount; i++)
+        {
+            tabs!.Items.Add(new TabItem
+            {
+                Header = new TextBlock { Text = $"OverflowRow{i}" },
+                Content = new Border()
+            });
+        }
+        window.ApplyTabLayout();
+        Dispatcher.UIThread.RunJobs();
+        return window;
+    }
+
+    [AvaloniaFact]
+    public void OverflowPill_VerticalWithHiddenTabs_ShowsCount_HorizontalHides()
+    {
+        var window = CreateShownVerticalWindowWithOverflow(plainTabCount: 6, height: 260);
+        try
+        {
+            var tabs = window.FindControl<TabControl>("Tabs")!;
+            // Second visual pass after the layout settle above: the pill update reads
+            // Bounds, which only reflect the added rows after a layout pass has run.
+            window.UpdateTabVisuals();
+            Dispatcher.UIThread.RunJobs();
+
+            var pill = FindOverflowPill(window);
+            Assert.NotNull(pill);
+            var pillText = FindOverflowPillText(pill!);
+            Assert.NotNull(pillText);
+            // XAML part-name contract.
+            Assert.Equal("PART_TabOverflowPillText", pillText!.Name);
+
+            // The expected count comes from the same pure math the production update
+            // uses, so the assertion pins wiring (visible + text), not arithmetic.
+            var scrollViewer = InvokeFindTabHeaderScrollViewer(window)!;
+            int expected = NovaTerminal.MainWindow.CountHiddenTabs(
+                scrollViewer.Bounds.Height,
+                tabs.Items.Cast<TabItem>().Select(t => t.Bounds.Height),
+                44);
+            Assert.True(expected > 0, "test premise: a 260px viewport cannot fit 7+ 44px rows");
+
+            Assert.True(pill!.IsVisible);
+            Assert.Equal($"+{expected} more", pillText!.Text);
+
+            // Horizontal mode: the title-bar TabOverflowBadge owns the affordance - the
+            // pill must hide on the mode flip's viewport pass.
+            GetSettings(window).TabStripOrientation = "Horizontal";
+            window.ApplyTabLayout();
+            Dispatcher.UIThread.RunJobs();
+            Assert.False(pill.IsVisible);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void OverflowPill_VerticalWithoutOverflow_StaysHidden()
+    {
+        var window = CreateShownWindow();
+        try
+        {
+            GetSettings(window).TabStripOrientation = "Vertical";
+            window.ApplyTabLayout();
+            Dispatcher.UIThread.RunJobs();
+
+            // The deterministic startup bundle creates dozens of tabs, so "no overflow"
+            // must be reached by enlarging the viewport, not by assuming a small strip:
+            // size the window to fit every actual row (with headroom) and let layout
+            // settle before the asserting pass.
+            var tabs = window.FindControl<TabControl>("Tabs")!;
+            int rowCount = tabs.Items.Count;
+            Assert.True(rowCount > 0);
+            window.Height = rowCount * 60 + 120;
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateTabVisuals();
+            Dispatcher.UIThread.RunJobs();
+
+            var pill = FindOverflowPill(window);
+            Assert.NotNull(pill);
+            Assert.False(pill!.IsVisible, "a viewport that fits every row must show no pill");
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    // Click wiring: the pill's Click opens the tab-list menu at the pill through
+    // PopulateTabListMenu's anchorOverride path, into the pill-dedicated flyout. Driving
+    // the routed ClickEvent directly stands in for a real pointer click (the same
+    // substitution the headless host makes for the drag tests' raw pointer events).
+    [AvaloniaFact]
+    public void OverflowPill_Click_OpensTabListMenuAtPill()
+    {
+        var window = CreateShownVerticalWindowWithOverflow(plainTabCount: 2, height: 400);
+        try
+        {
+            var pill = FindOverflowPill(window);
+            Assert.NotNull(pill);
+
+            pill!.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(
+                Avalonia.Controls.Button.ClickEvent));
+            Dispatcher.UIThread.RunJobs();
+
+            var flyout = (MenuFlyout?)typeof(NovaTerminal.MainWindow)
+                .GetField("_tabOverflowPillFlyout", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(window);
+            Assert.NotNull(flyout);
+            Assert.True(flyout!.IsOpen, "click must open the tab-list flyout");
+            Assert.NotEmpty(flyout.Items);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 }

--- a/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
@@ -158,6 +158,196 @@ public sealed class VerticalTabStripTests
         Assert.Null(NovaTerminal.MainWindow.FindTabHeaderDescendant<TextBlock>(tab.Header, "TabPreviewLine"));
     }
 
+    // ---- Agent-aware vertical headers: marker chips, dot precedence, accent bar ----
+
+    private static TabItem AddPlainVerticalTab(NovaTerminal.MainWindow window)
+    {
+        var tabs = window.FindControl<TabControl>("Tabs")!;
+        // Fresh, unselected tab (selection clears attention; these tests control state exactly).
+        var tab = new TabItem { Content = new Border() };
+        tabs.Items.Add(tab);
+        window.ApplyTabLayout(); // rebuild headers so the new tab gets a vertical row
+        Dispatcher.UIThread.RunJobs();
+        return tab;
+    }
+
+    private static TextBlock ChipOf(TabItem tab, string name)
+    {
+        var chip = NovaTerminal.MainWindow.FindTabHeaderDescendant<TextBlock>(tab.Header, name);
+        Assert.NotNull(chip);
+        return chip!;
+    }
+
+    private static Avalonia.Media.Color? DotColorOf(TabItem tab)
+    {
+        var dot = NovaTerminal.MainWindow.FindTabHeaderDescendant<Avalonia.Controls.Shapes.Ellipse>(tab.Header, "TabStatusDot");
+        return (dot?.Fill as Avalonia.Media.ISolidColorBrush)?.Color;
+    }
+
+    [AvaloniaFact]
+    public void VerticalHeader_MarkerChips_ExistHiddenByDefault_DotTransparent()
+    {
+        var window = CreateShownWindow();
+        try
+        {
+            GetSettings(window).TabStripOrientation = "Vertical";
+            window.ApplyTabLayout();
+            Dispatcher.UIThread.RunJobs();
+            var tab = AddPlainVerticalTab(window);
+
+            // All four chips exist, hidden until a marker says otherwise...
+            foreach (string name in new[] { "TabBellChip", "TabActivityChip", "TabAgentWroteChip", "TabAgentWatchedChip" })
+            {
+                var chip = ChipOf(tab, name);
+                Assert.False(chip.IsVisible, $"{name} must start hidden");
+                Assert.False(chip.IsHitTestVisible, $"{name} must not steal header presses");
+            }
+
+            // ...and a fresh tab paints no dot.
+            Assert.Equal(Avalonia.Media.Colors.Transparent, DotColorOf(tab));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void UpdateTabVisuals_Vertical_AccentBarOnEveryTab_HorizontalClearsIt()
+    {
+        var window = CreateShownWindow();
+        try
+        {
+            var settings = GetSettings(window);
+            settings.TabStripOrientation = "Vertical";
+            window.ApplyTabLayout();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateTabVisuals();
+
+            var tabs = window.FindControl<TabControl>("Tabs")!;
+            var allTabs = tabs.Items.Cast<TabItem>().ToList();
+            Assert.NotEmpty(allTabs);
+
+            // Constant 3px left thickness on every tab (selected AND not): the border brush
+            // paints the bar only on selection, but the thickness never toggles, so the
+            // title cannot shift 3px when selection changes.
+            foreach (var tab in allTabs)
+            {
+                Assert.Equal(new Avalonia.Thickness(3, 0, 0, 0), tab.BorderThickness);
+            }
+
+            // The selected tab's template border must actually render the left bar, not the
+            // App.axaml horizontal underline (0 0 0 2) — the local thickness must survive the
+            // template binding end to end.
+            var selected = Assert.IsType<TabItem>(tabs.SelectedItem);
+            var selectedBorder = Avalonia.VisualTree.VisualExtensions.GetVisualDescendants(selected)
+                .OfType<Border>()
+                .FirstOrDefault(b => b.Name == "PART_Border");
+            Assert.NotNull(selectedBorder);
+            Assert.Equal(new Avalonia.Thickness(3, 0, 0, 0), selectedBorder!.BorderThickness);
+
+            // Round-trip to horizontal: the local value must be cleared (not Thickness(0)),
+            // so the App.axaml selected style (0 0 0 2) keeps driving the underline.
+            settings.TabStripOrientation = "Horizontal";
+            window.ApplyTabLayout();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateTabVisuals();
+
+            foreach (var tab in tabs.Items.Cast<TabItem>())
+            {
+                Assert.Equal(default(Avalonia.Thickness), tab.BorderThickness);
+            }
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void UpdateVerticalTabExtras_BellState_BellChipVisible_ActivityChipSuppressed_DotAmber()
+    {
+        var window = CreateShownWindow();
+        try
+        {
+            GetSettings(window).TabStripOrientation = "Vertical";
+            window.ApplyTabLayout();
+            Dispatcher.UIThread.RunJobs();
+            var tab = AddPlainVerticalTab(window);
+
+            // Bell + activity together: bell wins both the chip and the dot.
+            window.SetTabMarkerStateForTest(tab, hasBell: true, hasActivity: true, NovaTerminal.AgentHost.AgentAttentionTier.Idle);
+            window.UpdateTabVisuals();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(ChipOf(tab, "TabBellChip").IsVisible);
+            Assert.False(ChipOf(tab, "TabActivityChip").IsVisible);
+            Assert.Equal(new Avalonia.Media.Color(0xFF, 0xFF, 0xD2, 0x5A), DotColorOf(tab)); // #FFD25A
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void UpdateVerticalTabExtras_AgentWrote_WroteChipVisible_DotAmberAgent()
+    {
+        var window = CreateShownWindow();
+        try
+        {
+            GetSettings(window).TabStripOrientation = "Vertical";
+            window.ApplyTabLayout();
+            Dispatcher.UIThread.RunJobs();
+            var tab = AddPlainVerticalTab(window);
+
+            window.SetTabMarkerStateForTest(tab, hasBell: false, hasActivity: false, NovaTerminal.AgentHost.AgentAttentionTier.Wrote);
+            window.UpdateTabVisuals();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(ChipOf(tab, "TabAgentWroteChip").IsVisible);
+            Assert.False(ChipOf(tab, "TabAgentWatchedChip").IsVisible);
+            Assert.Equal(new Avalonia.Media.Color(0xFF, 0xE8, 0xA3, 0x3D), DotColorOf(tab)); // #E8A33D
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void UpdateVerticalTabExtras_AgentWatched_VisibleOnlyUnderAllPolicy()
+    {
+        var window = CreateShownWindow();
+        try
+        {
+            GetSettings(window).TabStripOrientation = "Vertical";
+            window.ApplyTabLayout();
+            Dispatcher.UIThread.RunJobs();
+            var tab = AddPlainVerticalTab(window);
+            var settings = GetSettings(window);
+
+            // Default/WritesOnly policy: a watched tier shows neither chip nor dot.
+            settings.AgentIndicatorTabRollup = "WritesOnly";
+            window.SetTabMarkerStateForTest(tab, hasBell: false, hasActivity: false, NovaTerminal.AgentHost.AgentAttentionTier.Watched);
+            window.UpdateTabVisuals();
+            Dispatcher.UIThread.RunJobs();
+            Assert.False(ChipOf(tab, "TabAgentWatchedChip").IsVisible);
+            Assert.Equal(Avalonia.Media.Colors.Transparent, DotColorOf(tab));
+
+            // "All" rollup: chip visible, blue agent dot.
+            settings.AgentIndicatorTabRollup = "All";
+            window.UpdateTabVisuals();
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(ChipOf(tab, "TabAgentWatchedChip").IsVisible);
+            Assert.Equal(new Avalonia.Media.Color(0xFF, 0x4F, 0xB0, 0xD4), DotColorOf(tab)); // #4FB0D4
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
     [AvaloniaFact]
     public void RefreshTabStatuses_WorkingTracker_PaintsThemeDot_AndIdleClearsIt()
     {

--- a/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
@@ -764,7 +764,7 @@ public sealed class VerticalTabStripTests
     // commit path above only exercised it vertically. This mirrors it along X through a
     // real horizontal strip (orientation via _settings.TabStripOrientation +
     // ApplyTabLayout, headers rebuilt through the wired horizontal factory) so the
-    // horizontal wiring - X axis selection, Height-side indicator thickness - is pinned
+    // horizontal wiring - X axis selection, width-side indicator thickness - is pinned
     // end-to-end too.
     [AvaloniaFact]
     public void DragReorder_Commit_HorizontalStrip_ReordersAlongX_AndRestoresSelection()
@@ -785,6 +785,13 @@ public sealed class VerticalTabStripTests
         driver.Move(host0, window, new Point(pressPos.X + 6, pressPos.Y));
         Assert.True(window.IsTabReorderDraggingForTest, "past-threshold move must begin the drag");
         Assert.Equal(0.5, host0.Opacity, 5);
+
+        // Mirror of the vertical orientation pin: a horizontal strip shows a vertical bar
+        // at the drop gap (2-DIP wide, at least the 16-DIP minimum length).
+        var indicator = FindInsertIndicator(window)!;
+        Assert.True(indicator.IsVisible);
+        Assert.Equal(2, indicator.Width);
+        Assert.True(indicator.Height >= 16, $"indicator height {indicator.Height} must span the row");
 
         // Drop past tab 2's center: insert index = count, so the dragged tab lands last.
         var pastTab2 = new Point(HeaderCenterInWindow(host2, window).X + 4, pressPos.Y);
@@ -850,6 +857,11 @@ public sealed class VerticalTabStripTests
 
         Assert.True(window.IsTabReorderDraggingForTest);
         Assert.True(indicator.IsVisible, "insert indicator must be visible mid-drag");
+
+        // Orientation: a vertical strip shows a horizontal bar spanning the drop gap
+        // (2-DIP tall, at least the 16-DIP minimum length), not a vertical caret.
+        Assert.Equal(2, indicator.Height);
+        Assert.True(indicator.Width >= 16, $"indicator width {indicator.Width} must span the row");
 
         driver.Release(host1, window, new Point(pressPos.X, pressPos.Y + 6));
 

--- a/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
@@ -1128,10 +1128,11 @@ public sealed class VerticalTabStripTests
             window.ApplyTabLayout();
             Dispatcher.UIThread.RunJobs();
 
-            // The deterministic startup bundle creates dozens of tabs, so "no overflow"
-            // must be reached by enlarging the viewport, not by assuming a small strip:
-            // size the window to fit every actual row (with headroom) and let layout
-            // settle before the asserting pass.
+            // The startup tab count is machine-dependent (TryRestoreStartupSession
+            // restores whatever the real saved-session file holds), so "no overflow"
+            // cannot be reached by assuming any fixed strip size: the test is robust
+            // because it sizes the window from the ACTUAL row count (with headroom)
+            // and lets layout settle before the asserting pass.
             var tabs = window.FindControl<TabControl>("Tabs")!;
             int rowCount = tabs.Items.Count;
             Assert.True(rowCount > 0);

--- a/tests/NovaTerminal.App.Tests/TabDragModelTests.cs
+++ b/tests/NovaTerminal.App.Tests/TabDragModelTests.cs
@@ -1,0 +1,105 @@
+using System.Collections.Generic;
+using NovaTerminal.Shell;
+using Xunit;
+
+namespace NovaTerminal.Tests
+{
+    public sealed class TabDragModelTests
+    {
+        [Theory]
+        [InlineData(100, 100, false)] // no movement
+        [InlineData(100, 104.9, false)] // just under default threshold
+        [InlineData(100, 105, true)] // exactly at threshold
+        [InlineData(100, 106, true)] // past threshold
+        [InlineData(100, 95, true)] // either direction counts
+        [InlineData(100, 95.1, false)] // just under threshold in the negative direction
+        public void ShouldStartDrag_UsesAbsoluteDeltaVersusThreshold(double pressPos, double currentPos, bool expected)
+            => Assert.Equal(expected, TabDragModel.ShouldStartDrag(pressPos, currentPos));
+
+        [Theory]
+        [InlineData(100, 109.9, 10, false)]
+        [InlineData(100, 110, 10, true)]
+        [InlineData(100, 90, 10, true)]
+        [InlineData(100, 90.1, 10, false)]
+        public void ShouldStartDrag_HonorsCustomThreshold(double pressPos, double currentPos, double threshold, bool expected)
+            => Assert.Equal(expected, TabDragModel.ShouldStartDrag(pressPos, currentPos, threshold));
+
+        [Fact]
+        public void ComputeInsertIndex_EmptyListReturnsZero()
+            => Assert.Equal(0, TabDragModel.ComputeInsertIndex(new List<double>(), pointerPos: 100));
+
+        [Fact]
+        public void ComputeInsertIndex_PointerAboveAllHeadersReturnsZero()
+            => Assert.Equal(0, TabDragModel.ComputeInsertIndex(new List<double> { 100, 200, 300 }, pointerPos: 50));
+
+        [Fact]
+        public void ComputeInsertIndex_PointerBelowAllHeadersReturnsCount()
+            => Assert.Equal(3, TabDragModel.ComputeInsertIndex(new List<double> { 100, 200, 300 }, pointerPos: 350));
+
+        [Fact]
+        public void ComputeInsertIndex_PointerExactlyOnCenterStaysBeforeThatHeader()
+            => Assert.Equal(1, TabDragModel.ComputeInsertIndex(new List<double> { 100, 200, 300 }, pointerPos: 200));
+
+        [Theory]
+        [InlineData(150, 1)] // between first and second
+        [InlineData(250, 2)] // between second and third
+        [InlineData(100.5, 1)] // just past the first center
+        [InlineData(299.9, 2)] // just before the last center
+        public void ComputeInsertIndex_InterleavedPositionsCountPassedHeaders(double pointerPos, int expected)
+            => Assert.Equal(expected, TabDragModel.ComputeInsertIndex(new List<double> { 100, 200, 300 }, pointerPos));
+
+        [Theory]
+        [InlineData(300)] // well inside
+        [InlineData(24)] // exactly at the start boundary is inside the safe zone
+        [InlineData(576)] // exactly at the end boundary is inside the safe zone
+        public void ComputeAutoScrollDelta_PointerInsideSafeZoneReturnsZero(double pointerPos)
+            => Assert.Equal(0, TabDragModel.ComputeAutoScrollDelta(viewportStart: 0, viewportLength: 600, pointerPos));
+
+        [Theory]
+        [InlineData(0)] // at the very edge
+        [InlineData(23.9)] // just inside the edge zone
+        [InlineData(-10)] // dragged past the start of the viewport
+        public void ComputeAutoScrollDelta_NearStartEdgeScrollsTowardStart(double pointerPos)
+            => Assert.Equal(-TabDragModel.AutoScrollStep,
+                TabDragModel.ComputeAutoScrollDelta(viewportStart: 0, viewportLength: 600, pointerPos));
+
+        [Theory]
+        [InlineData(600)] // at the very edge
+        [InlineData(576.1)] // just inside the edge zone
+        [InlineData(610)] // dragged past the end of the viewport
+        public void ComputeAutoScrollDelta_NearEndEdgeScrollsTowardEnd(double pointerPos)
+            => Assert.Equal(TabDragModel.AutoScrollStep,
+                TabDragModel.ComputeAutoScrollDelta(viewportStart: 0, viewportLength: 600, pointerPos));
+
+        [Fact]
+        public void ComputeAutoScrollDelta_NonZeroViewportStartMeasuresZonesRelativeToToIt()
+        {
+            // Viewport [100..400]: start zone is [100..124), end zone is (376..400].
+            Assert.Equal(0, TabDragModel.ComputeAutoScrollDelta(viewportStart: 100, viewportLength: 300, pointerPos: 124));
+            Assert.Equal(-TabDragModel.AutoScrollStep,
+                TabDragModel.ComputeAutoScrollDelta(viewportStart: 100, viewportLength: 300, pointerPos: 123.9));
+            Assert.Equal(0, TabDragModel.ComputeAutoScrollDelta(viewportStart: 100, viewportLength: 300, pointerPos: 376));
+            Assert.Equal(TabDragModel.AutoScrollStep,
+                TabDragModel.ComputeAutoScrollDelta(viewportStart: 100, viewportLength: 300, pointerPos: 376.1));
+        }
+
+        [Fact]
+        public void ComputeAutoScrollDelta_HonorsCustomEdgeZoneAndStep()
+            => Assert.Equal(-20, TabDragModel.ComputeAutoScrollDelta(viewportStart: 0, viewportLength: 600, pointerPos: 29.9, edgeZone: 30, step: 20));
+
+        [Theory]
+        [InlineData(0)] // no viewport
+        [InlineData(-50)] // nonsensical length
+        [InlineData(48)] // edgeZone*2 == length leaves no safe zone
+        [InlineData(40)] // edgeZone*2 > length
+        public void ComputeAutoScrollDelta_DegenerateViewportReturnsZero(double viewportLength)
+            => Assert.Equal(0, TabDragModel.ComputeAutoScrollDelta(viewportStart: 0, viewportLength, pointerPos: 10));
+
+        [Theory]
+        [InlineData(double.NaN)]
+        [InlineData(double.PositiveInfinity)]
+        [InlineData(double.NegativeInfinity)]
+        public void ComputeAutoScrollDelta_NonFinitePointerReturnsZero(double pointerPos)
+            => Assert.Equal(0, TabDragModel.ComputeAutoScrollDelta(viewportStart: 0, viewportLength: 600, pointerPos));
+    }
+}

--- a/tests/NovaTerminal.App.Tests/TabDragModelTests.cs
+++ b/tests/NovaTerminal.App.Tests/TabDragModelTests.cs
@@ -24,6 +24,16 @@ namespace NovaTerminal.Tests
         public void ShouldStartDrag_HonorsCustomThreshold(double pressPos, double currentPos, double threshold, bool expected)
             => Assert.Equal(expected, TabDragModel.ShouldStartDrag(pressPos, currentPos, threshold));
 
+        [Theory]
+        [InlineData(double.NaN, 100)]
+        [InlineData(100, double.NaN)]
+        [InlineData(double.PositiveInfinity, 100)]
+        [InlineData(100, double.PositiveInfinity)]
+        [InlineData(double.NegativeInfinity, 100)]
+        [InlineData(100, double.NegativeInfinity)]
+        public void ShouldStartDrag_NonFinitePositionsReturnFalse(double pressPos, double currentPos)
+            => Assert.False(TabDragModel.ShouldStartDrag(pressPos, currentPos));
+
         [Fact]
         public void ComputeInsertIndex_EmptyListReturnsZero()
             => Assert.Equal(0, TabDragModel.ComputeInsertIndex(new List<double>(), pointerPos: 100));
@@ -49,6 +59,13 @@ namespace NovaTerminal.Tests
             => Assert.Equal(expected, TabDragModel.ComputeInsertIndex(new List<double> { 100, 200, 300 }, pointerPos));
 
         [Theory]
+        [InlineData(double.NaN)]
+        [InlineData(double.PositiveInfinity)]
+        [InlineData(double.NegativeInfinity)]
+        public void ComputeInsertIndex_NonFinitePointerReturnsZero(double pointerPos)
+            => Assert.Equal(0, TabDragModel.ComputeInsertIndex(new List<double> { 100, 200, 300 }, pointerPos));
+
+        [Theory]
         [InlineData(300)] // well inside
         [InlineData(24)] // exactly at the start boundary is inside the safe zone
         [InlineData(576)] // exactly at the end boundary is inside the safe zone
@@ -72,7 +89,7 @@ namespace NovaTerminal.Tests
                 TabDragModel.ComputeAutoScrollDelta(viewportStart: 0, viewportLength: 600, pointerPos));
 
         [Fact]
-        public void ComputeAutoScrollDelta_NonZeroViewportStartMeasuresZonesRelativeToToIt()
+        public void ComputeAutoScrollDelta_NonZeroViewportStartMeasuresZonesRelativeToIt()
         {
             // Viewport [100..400]: start zone is [100..124), end zone is (376..400].
             Assert.Equal(0, TabDragModel.ComputeAutoScrollDelta(viewportStart: 100, viewportLength: 300, pointerPos: 124));

--- a/tests/NovaTerminal.App.Tests/TabStatusPresentationTests.cs
+++ b/tests/NovaTerminal.App.Tests/TabStatusPresentationTests.cs
@@ -1,0 +1,153 @@
+using NovaTerminal.AgentHost;
+using NovaTerminal.Shell;
+using Xunit;
+
+namespace NovaTerminal.Tests
+{
+    /// <summary>
+    /// Full matrix for the pure vertical-header presentation rules: which marker chips
+    /// are visible (ResolveTabMarkers) and which single state the status dot paints
+    /// (ResolveTabDot). Plain facts, no window (same split as TabDragModelTests).
+    /// </summary>
+    public sealed class TabStatusPresentationTests
+    {
+        private static TabMarkerSet Markers(
+            bool bell = false, bool activity = false, bool wrote = false, bool watched = false)
+            => new(bell, activity, wrote, watched);
+
+        // ---- ResolveTabMarkers: bell/activity exclusivity ----
+
+        [Fact]
+        public void ResolveTabMarkers_NoSignals_AllFalse()
+            => Assert.Equal(Markers(), TabStatusPresentation.ResolveTabMarkers(
+                hasBell: false, hasActivity: false, AgentAttentionTier.Idle, rollupPolicy: "WritesOnly"));
+
+        [Fact]
+        public void ResolveTabMarkers_BellOnly_ShowsBellNotActivity()
+            => Assert.Equal(Markers(bell: true), TabStatusPresentation.ResolveTabMarkers(
+                hasBell: true, hasActivity: false, AgentAttentionTier.Idle, rollupPolicy: "WritesOnly"));
+
+        [Fact]
+        public void ResolveTabMarkers_ActivityOnly_ShowsActivity()
+            => Assert.Equal(Markers(activity: true), TabStatusPresentation.ResolveTabMarkers(
+                hasBell: false, hasActivity: true, AgentAttentionTier.Idle, rollupPolicy: "WritesOnly"));
+
+        [Fact]
+        public void ResolveTabMarkers_BellWinsOverActivity()
+            => Assert.Equal(Markers(bell: true), TabStatusPresentation.ResolveTabMarkers(
+                hasBell: true, hasActivity: true, AgentAttentionTier.Idle, rollupPolicy: "WritesOnly"));
+
+        // ---- ResolveTabMarkers: tier x rollup policy ----
+
+        [Theory]
+        [InlineData("WritesOnly")]
+        [InlineData("All")]
+        [InlineData(null)]
+        [InlineData("garbage")]
+        public void ResolveTabMarkers_WroteTier_AlwaysShows_RegardlessOfPolicy(string? policy)
+            => Assert.Equal(Markers(wrote: true), TabStatusPresentation.ResolveTabMarkers(
+                hasBell: false, hasActivity: false, AgentAttentionTier.Wrote, rollupPolicy: policy));
+
+        [Theory]
+        [InlineData("WritesOnly")]
+        [InlineData(null)]
+        [InlineData("garbage")]
+        public void ResolveTabMarkers_WatchedTier_HiddenUnderNonAllPolicies(string? policy)
+            => Assert.Equal(Markers(), TabStatusPresentation.ResolveTabMarkers(
+                hasBell: false, hasActivity: false, AgentAttentionTier.Watched, rollupPolicy: policy));
+
+        [Fact]
+        public void ResolveTabMarkers_WatchedTier_ShownUnderPolicyAll()
+            => Assert.Equal(Markers(watched: true), TabStatusPresentation.ResolveTabMarkers(
+                hasBell: false, hasActivity: false, AgentAttentionTier.Watched, rollupPolicy: "All"));
+
+        [Fact]
+        public void ResolveTabMarkers_TierIndependentOfBellAndActivity()
+            => Assert.Equal(Markers(bell: true, wrote: true), TabStatusPresentation.ResolveTabMarkers(
+                hasBell: true, hasActivity: true, AgentAttentionTier.Wrote, rollupPolicy: "WritesOnly"));
+
+        [Fact]
+        public void ResolveTabMarkers_WatchedWithBellAndAllPolicy_AllThreeMarkers()
+            => Assert.Equal(Markers(bell: true, watched: true), TabStatusPresentation.ResolveTabMarkers(
+                hasBell: true, hasActivity: false, AgentAttentionTier.Watched, rollupPolicy: "All"));
+
+        // ---- ResolveTabDot: precedence, highest first ----
+
+        [Fact]
+        public void ResolveTabDot_IdleTabNoMarkers_NoDot()
+            => Assert.Equal(TabDotVisual.None, TabStatusPresentation.ResolveTabDot(
+                TabTrackerStatus.Idle, Markers(), hasRunningCommand: false));
+
+        [Fact]
+        public void ResolveTabDot_AttentionStatus_BeatsEverything()
+        {
+            Assert.Equal(TabDotVisual.Attention, TabStatusPresentation.ResolveTabDot(
+                TabTrackerStatus.Attention, Markers(), hasRunningCommand: false));
+            Assert.Equal(TabDotVisual.Attention, TabStatusPresentation.ResolveTabDot(
+                TabTrackerStatus.Attention, Markers(wrote: true, watched: true), hasRunningCommand: true));
+        }
+
+        [Fact]
+        public void ResolveTabDot_BellMarker_SameAsAttention()
+            => Assert.Equal(TabDotVisual.Attention, TabStatusPresentation.ResolveTabDot(
+                TabTrackerStatus.Idle, Markers(bell: true), hasRunningCommand: false));
+
+        [Fact]
+        public void ResolveTabDot_AgentWrote_BeatsWorkingAndWatched()
+        {
+            Assert.Equal(TabDotVisual.AgentWrote, TabStatusPresentation.ResolveTabDot(
+                TabTrackerStatus.Idle, Markers(wrote: true), hasRunningCommand: false));
+            Assert.Equal(TabDotVisual.AgentWrote, TabStatusPresentation.ResolveTabDot(
+                TabTrackerStatus.Working, Markers(wrote: true), hasRunningCommand: true));
+            Assert.Equal(TabDotVisual.AgentWrote, TabStatusPresentation.ResolveTabDot(
+                TabTrackerStatus.Idle, Markers(wrote: true, watched: true), hasRunningCommand: false));
+        }
+
+        [Fact]
+        public void ResolveTabDot_AgentWrote_LosesOnlyToAttention()
+            => Assert.Equal(TabDotVisual.Attention, TabStatusPresentation.ResolveTabDot(
+                TabTrackerStatus.Idle, Markers(bell: true, wrote: true), hasRunningCommand: false));
+
+        [Fact]
+        public void ResolveTabDot_WorkingStatus_PaintsWorking()
+            => Assert.Equal(TabDotVisual.Working, TabStatusPresentation.ResolveTabDot(
+                TabTrackerStatus.Working, Markers(), hasRunningCommand: false));
+
+        [Fact]
+        public void ResolveTabDot_RunningCommand_FlipsNoneToWorking()
+        {
+            Assert.Equal(TabDotVisual.None, TabStatusPresentation.ResolveTabDot(
+                TabTrackerStatus.Idle, Markers(), hasRunningCommand: false));
+            Assert.Equal(TabDotVisual.Working, TabStatusPresentation.ResolveTabDot(
+                TabTrackerStatus.Idle, Markers(), hasRunningCommand: true));
+        }
+
+        [Fact]
+        public void ResolveTabDot_RunningCommand_DoesNotOverrideAttentionOrAgentWrote()
+        {
+            Assert.Equal(TabDotVisual.Attention, TabStatusPresentation.ResolveTabDot(
+                TabTrackerStatus.Attention, Markers(), hasRunningCommand: true));
+            Assert.Equal(TabDotVisual.Attention, TabStatusPresentation.ResolveTabDot(
+                TabTrackerStatus.Idle, Markers(bell: true), hasRunningCommand: true));
+            Assert.Equal(TabDotVisual.AgentWrote, TabStatusPresentation.ResolveTabDot(
+                TabTrackerStatus.Idle, Markers(wrote: true), hasRunningCommand: true));
+        }
+
+        [Fact]
+        public void ResolveTabDot_AgentWatched_LowestPrecedence()
+        {
+            // Alone it paints...
+            Assert.Equal(TabDotVisual.AgentWatched, TabStatusPresentation.ResolveTabDot(
+                TabTrackerStatus.Idle, Markers(watched: true), hasRunningCommand: false));
+            // ...but loses to working (status or running command), agent write, and attention.
+            Assert.Equal(TabDotVisual.Working, TabStatusPresentation.ResolveTabDot(
+                TabTrackerStatus.Working, Markers(watched: true), hasRunningCommand: false));
+            Assert.Equal(TabDotVisual.Working, TabStatusPresentation.ResolveTabDot(
+                TabTrackerStatus.Idle, Markers(watched: true), hasRunningCommand: true));
+            Assert.Equal(TabDotVisual.AgentWrote, TabStatusPresentation.ResolveTabDot(
+                TabTrackerStatus.Idle, Markers(wrote: true, watched: true), hasRunningCommand: false));
+            Assert.Equal(TabDotVisual.Attention, TabStatusPresentation.ResolveTabDot(
+                TabTrackerStatus.Attention, Markers(watched: true), hasRunningCommand: false));
+        }
+    }
+}

--- a/tests/NovaTerminal.App.Tests/TabStatusPresentationTests.cs
+++ b/tests/NovaTerminal.App.Tests/TabStatusPresentationTests.cs
@@ -71,6 +71,29 @@ namespace NovaTerminal.Tests
             => Assert.Equal(Markers(bell: true, watched: true), TabStatusPresentation.ResolveTabMarkers(
                 hasBell: true, hasActivity: false, AgentAttentionTier.Watched, rollupPolicy: "All"));
 
+        // ---- Parity with MainWindow's copy of the rollup-policy rule ----
+
+        // ResolveTabMarkers re-implements the same rollup-policy gate that
+        // MainWindow.ShouldShowTierInTabStrip applies when RefreshTabAgentAttention filters
+        // each tab's stored tier, so the two rules must agree on every policy input for the
+        // Watched tier — a divergence would let a tab show the read chip (or paint the
+        // watched dot) for a tier the strip-level rule says was filtered out, or hide a read
+        // the rollup setting says should surface. Both are deliberately Ordinal "All"
+        // (case-sensitive, so "all" hides reads); this theory pins that one shared decision
+        // across both copies so neither can drift silently.
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("WritesOnly")]
+        [InlineData("All")]
+        [InlineData("all")]
+        [InlineData("garbage")]
+        public void ResolveTabMarkers_WatchedTier_AgreesWithMainWindowTabStripRule(string? policy)
+            => Assert.Equal(
+                NovaTerminal.MainWindow.ShouldShowTierInTabStrip(policy, AgentAttentionTier.Watched),
+                TabStatusPresentation.ResolveTabMarkers(
+                    hasBell: false, hasActivity: false, AgentAttentionTier.Watched, rollupPolicy: policy).AgentWatched);
+
         // ---- ResolveTabDot: precedence, highest first ----
 
         [Fact]


### PR DESCRIPTION
## Summary

This PR makes the vertical tab strip fully usable for heavy multi-agent workflows (Claude Code / Codex / ZCode running across many tabs). Tabs can now be dragged to reorder in either strip orientation, vertical headers show agent-aware status at a glance, a "+N more" pill covers overflow, and keyboard shortcuts move tabs without touching the mouse.

## What's included

**Drag-to-reorder tabs (both orientations)**
- Threshold-based drag start (~5 DIP) so plain clicks still select; insert-gap indicator; edge auto-scroll on a drag-scoped DispatcherTimer; Escape cancels; capture-lost cleanup.
- Commit via a guarded `Items.RemoveAt`/`Insert` that reuses TabItem instances — MRU order and pane sessions untouched; order persists through existing session capture.
- Lifecycle hardening: zombie-drag guard for lost releases (e.g. quake-mode hide mid-drag), teardown timer stop, pre-scroll index math so drops land in the slot the user sees.
- Pure math extracted to `Shell/TabDragModel.cs` (no Avalonia types, plain xunit theories).

**Agent-aware vertical headers**
- Status markers (🔔 bell, • activity, ⌨ agent-typed, 👁 agent-reading) move out of the truncated title into trailing chips — the title gets its full width back; tooltips and the tab-list menu keep the markers.
- Single status dot with clear precedence: **attention > agent-typed > running/working > agent-reading** (colors match the in-pane agent segment language).
- Selected vertical tab gets a 3px left accent bar; horizontal visuals unchanged (still the bottom underline).
- Pure presentation logic in `Shell/TabStatusPresentation.cs`, pinned against the existing rollup-policy rule by a parity test.

**Precise "running" state on the dot**
- The 1 Hz vertical status pass aggregates `AgentSessionStatusKind.Running` from the agent-session registry per tab, so a silently-thinking agent CLI no longer decays to idle between output bursts (the 2 s output heuristic's blind spot). No per-output-path work added.

**Extras**
- "+N more" overflow pill pinned to the vertical sidebar bottom, opening the existing tab-list flyout (horizontal mode keeps the title-bar badge).
- `move_tab_prev` / `move_tab_next` shortcuts (`Ctrl+Shift+PageUp` / `Ctrl+Shift+PageDown`), command-palette entries ("Tab: Move Previous/Next"), sharing the same reorder core as the drag commit; guarded during an active drag.

## Design constraints kept

- No TabControl re-templating and no TabItem/content recreation (the `ApplyTabLayout` in-place-reconfiguration invariant).
- No changes to AgentHost machinery (read-only consumption), session persistence schema, or VT core; additive-only MainWindow changes following the file's existing code-behind conventions.
- All updates ride existing passes (status timer, throttled visual refreshes, pointer events) — nothing added to per-output paths.

## Testing

- ~110 new deterministic tests: pure theories for the two new Shell models; headless Avalonia tests driving **real routed pointer and key events** for drag commit/cancel/indicator/grip-exclusion in both orientations, chip/dot states, accent bar, running-state aggregation (registry-isolated), overflow pill, and move shortcuts.
- Full suite on the branch: **3361 passed / 19 skipped / 5 failed** — all five failures are pre-existing environment flakes (AgentObserveIndicator ×4, PtyReadFailure ×1) verified failing identically on clean `main` before this work.

🤖 This PR was implemented via subagent-driven development (one implementer + spec-compliance review + code-quality review per task, with fix rounds).
