### PR TITLE
fix(theme): live theme switches, light-theme chrome, and accent softening

### DIFF
--- a/src/NovaTerminal.App/Controls/ConnectionManager.axaml
+++ b/src/NovaTerminal.App/Controls/ConnectionManager.axaml
@@ -27,6 +27,9 @@
         <SolidColorBrush x:Key="NtBlueDim"    Color="#2461afef"/>
         <SolidColorBrush x:Key="NtBlueFaint"  Color="#1561afef"/>
         <SolidColorBrush x:Key="NtBlueBorder" Color="#4d61afef"/>
+        <SolidColorBrush x:Key="NtAccentHover"   Color="#7cc1f5"/>
+        <SolidColorBrush x:Key="NtAccentPressed" Color="#4f9bde"/>
+        <SolidColorBrush x:Key="NtAccentFg"      Color="#0a1622"/>
         <SolidColorBrush x:Key="NtGreen"      Color="#98c379"/>
         <SolidColorBrush x:Key="NtYellow"     Color="#e5c07b"/>
         <SolidColorBrush x:Key="NtRed"        Color="#e06c75"/>
@@ -64,7 +67,7 @@
         <!-- Primary action button -->
         <Style Selector="Button.Primary">
             <Setter Property="Background" Value="{StaticResource NtBlue}"/>
-            <Setter Property="Foreground" Value="#0a1622"/>
+            <Setter Property="Foreground" Value="{StaticResource NtAccentFg}"/>
             <Setter Property="FontWeight" Value="SemiBold"/>
             <Setter Property="FontSize" Value="12"/>
             <Setter Property="CornerRadius" Value="5"/>
@@ -74,10 +77,10 @@
             <Setter Property="VerticalContentAlignment" Value="Center"/>
         </Style>
         <Style Selector="Button.Primary:pointerover /template/ ContentPresenter">
-            <Setter Property="Background" Value="#7cc1f5"/>
+            <Setter Property="Background" Value="{StaticResource NtAccentHover}"/>
         </Style>
         <Style Selector="Button.Primary:pressed /template/ ContentPresenter">
-            <Setter Property="Background" Value="#4f9bde"/>
+            <Setter Property="Background" Value="{StaticResource NtAccentPressed}"/>
         </Style>
 
         <!-- Secondary pill button -->
@@ -356,7 +359,7 @@
                             ToolTip.Tip="Create a new SSH connection"
                             Click="OnNewConnectionClick">
                         <StackPanel Orientation="Horizontal" Spacing="6">
-                            <PathIcon Data="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z" Width="12" Height="12" Foreground="#0a1622"/>
+                            <PathIcon Data="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z" Width="12" Height="12" Foreground="{StaticResource NtAccentFg}"/>
                             <TextBlock Text="New"/>
                         </StackPanel>
                     </Button>
@@ -565,7 +568,7 @@
                                     Click="OnOpenCurrentClick"
                                     ToolTip.Tip="Open in current pane">
                                 <StackPanel Orientation="Horizontal" Spacing="6">
-                                    <PathIcon Data="M8,5.14V19.14L19,12.14L8,5.14Z" Width="11" Height="11" Foreground="#0a1622"/>
+                                    <PathIcon Data="M8,5.14V19.14L19,12.14L8,5.14Z" Width="11" Height="11" Foreground="{StaticResource NtAccentFg}"/>
                                     <TextBlock Text="Open"/>
                                 </StackPanel>
                             </Button>

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -1163,7 +1163,7 @@ namespace NovaTerminal
             {
                 badge.IsVisible = false;
                 ToolTip.SetTip(button, baseTooltip);
-                button.Foreground = Brushes.White;
+                button.Foreground = TitleBarContrastForeground();
                 return;
             }
 
@@ -1172,7 +1172,13 @@ namespace NovaTerminal
             badge.IsVisible = hiddenCount > 0;
             badge.Text = hiddenCount > 0 ? $"+{hiddenCount}" : string.Empty;
             ToolTip.SetTip(button, hiddenCount > 0 ? $"{baseTooltip} — {hiddenCount} hidden" : baseTooltip);
-            button.Foreground = hiddenCount > 0 ? new SolidColorBrush(Color.FromRgb(255, 210, 90)) : Brushes.White;
+            // This runs after every layout pass (via UpdateTabVisuals -> PopulateTabListMenu), so
+            // the resting color here must be the theme's contrast foreground, not hardcoded white:
+            // white was invisible against light themes and kept re-stomping the foreground
+            // ApplyThemeToUI had applied.
+            button.Foreground = hiddenCount > 0
+                ? new SolidColorBrush(Color.FromRgb(255, 210, 90))
+                : TitleBarContrastForeground();
         }
 
         internal static int CountHiddenTabs(double viewportWidth, IEnumerable<double> tabWidths, double fallbackTabWidth = 120)
@@ -3232,6 +3238,12 @@ namespace NovaTerminal
             else if (control is ContentControl cc)
             {
                 ApplySettingsRecursive(cc.Content as Control, settings);
+            }
+            else if (control is Decorator decorator)
+            {
+                // Border/ScrollViewer-style single-child wrappers: without this, a pane nested
+                // behind one was silently skipped and never received theme or font updates.
+                ApplySettingsRecursive(decorator.Child as Control, settings);
             }
         }
 
@@ -5496,26 +5508,12 @@ namespace NovaTerminal
             // Apply to Window Foreground (inherited by many controls)
             this.Foreground = contrastForeground;
 
-            // Apply to Title Bar Buttons
-            var btnNew = this.FindControl<Button>(TitleBarViewFactory.NewTabButtonName);
-            var btnTabList = FindTitleBarButton(TitleBarCatalog.OpenTabListId);
-            var iconTabList = btnTabList?.Content as PathIcon;
-            var btnRecord = FindTitleBarButton("toggle_recording");
-            var btnConns = FindTitleBarButton("connections");
-            var commandSearchBox = this.FindControl<TextBox>("CommandSearchBox");
-
-            if (btnNew != null) btnNew.Foreground = contrastForeground;
-            if (btnTabList != null) btnTabList.Foreground = contrastForeground;
-            if (iconTabList != null) iconTabList.Foreground = contrastForeground;
-            if (btnConns != null) btnConns.Foreground = contrastForeground;
-            if (btnRecord != null) btnRecord.Foreground = contrastForeground;
-            if (commandSearchBox != null) commandSearchBox.Foreground = contrastForeground;
+            ApplyTitleBarForegrounds(contrastForeground);
+            SyncRecordingButtonState();
             foreach (var splitter in this.GetVisualDescendants().OfType<GridSplitter>())
             {
                 ApplySplitterVisualState(splitter);
             }
-
-            SyncRecordingButtonState();
 
             // Force update of tab borders (blue line) since theme color changed
             UpdateTabVisuals();
@@ -5530,6 +5528,45 @@ namespace NovaTerminal
             }
 
             _connectionManagerWindow?.ApplyTheme(theme);
+        }
+
+        /// <summary>
+        /// The theme's contrast foreground as a fresh brush - the color every title-bar button
+        /// and icon should read in the current theme (dark ink on light themes, light on dark).
+        /// </summary>
+        private SolidColorBrush TitleBarContrastForeground()
+            => new SolidColorBrush(_settings.ActiveTheme.GetContrastForeground().ToAvaloniaColor());
+
+        /// <summary>
+        /// Re-applies the active theme's contrast foreground to the title-bar buttons and icons.
+        /// Extracted from <see cref="ApplyThemeToUI"/> because ordering defeats it there in two
+        /// real paths: at startup ApplyThemeToUI runs before the first RebuildTitleBar (so every
+        /// FindTitleBarButton lookup missed), and the settings-save path runs ApplyThemeToUI and
+        /// then rebuilds the bar anyway. Populate() replaces the generated buttons with fresh
+        /// instances whose foregrounds fall back to the Fluent variant brushes - white under the
+        /// app's default Dark variant - so a rebuild must re-apply these itself, or light themes
+        /// show white-on-light icons until the next theme action.
+        /// </summary>
+        private void ApplyTitleBarForegrounds(SolidColorBrush? contrastForeground = null)
+        {
+            // Default to a fresh brush, but let ApplyThemeToUI share ITS instance so the buttons
+            // keep pointing at the same brush as the window Foreground (tests pin that invariant,
+            // and it keeps one invalidation covering the whole bar).
+            contrastForeground ??= TitleBarContrastForeground();
+
+            var btnNew = this.FindControl<Button>(TitleBarViewFactory.NewTabButtonName);
+            var btnTabList = FindTitleBarButton(TitleBarCatalog.OpenTabListId);
+            var iconTabList = btnTabList?.Content as PathIcon;
+            var btnRecord = FindTitleBarButton("toggle_recording");
+            var btnConns = FindTitleBarButton("connections");
+            var commandSearchBox = this.FindControl<TextBox>("CommandSearchBox");
+
+            if (btnNew != null) btnNew.Foreground = contrastForeground;
+            if (btnTabList != null) btnTabList.Foreground = contrastForeground;
+            if (iconTabList != null) iconTabList.Foreground = contrastForeground;
+            if (btnConns != null) btnConns.Foreground = contrastForeground;
+            if (btnRecord != null) btnRecord.Foreground = contrastForeground;
+            if (commandSearchBox != null) commandSearchBox.Foreground = contrastForeground;
         }
 
         private void SetupCommandPalette()
@@ -7753,6 +7790,11 @@ namespace NovaTerminal
 
             // The record button is recreated by every rebuild, so its active colouring has to be
             // reapplied against the new instance.
+            // Same for every other generated button and icon: they are new instances, so the
+            // theme foregrounds applied by the last ApplyThemeToUI are gone (and startup applies
+            // that BEFORE this rebuild ever runs). Re-apply here, before SyncRecordingButtonState
+            // so an active recording's red still wins on the record button.
+            ApplyTitleBarForegrounds();
             SyncRecordingButtonState();
 
             // Populate() just replaced TitleBarItemsHost's children synchronously, but that does not

--- a/src/NovaTerminal.App/SettingsWindow.axaml
+++ b/src/NovaTerminal.App/SettingsWindow.axaml
@@ -22,6 +22,9 @@
         <SolidColorBrush x:Key="NtFg4"             Color="#5c6370"/>
         <SolidColorBrush x:Key="NtBlue"            Color="#61afef"/>
         <SolidColorBrush x:Key="NtBlueDim"         Color="#2461afef"/>
+        <SolidColorBrush x:Key="NtAccentHover"     Color="#7cc1f5"/>
+        <SolidColorBrush x:Key="NtAccentPressed"   Color="#4f9bde"/>
+        <SolidColorBrush x:Key="NtAccentFg"        Color="#0a1622"/>
         <SolidColorBrush x:Key="NtGreen"           Color="#98c379"/>
         <SolidColorBrush x:Key="NtYellow"          Color="#e5c07b"/>
         <SolidColorBrush x:Key="NtRed"             Color="#e06c75"/>
@@ -117,7 +120,7 @@
         <!-- Primary action button -->
         <Style Selector="Button.Primary">
             <Setter Property="Background" Value="{StaticResource NtBlue}"/>
-            <Setter Property="Foreground" Value="#0a1622"/>
+            <Setter Property="Foreground" Value="{StaticResource NtAccentFg}"/>
             <Setter Property="FontWeight" Value="SemiBold"/>
             <Setter Property="FontSize" Value="13"/>
             <Setter Property="CornerRadius" Value="5"/>
@@ -127,10 +130,10 @@
             <Setter Property="VerticalContentAlignment" Value="Center"/>
         </Style>
         <Style Selector="Button.Primary:pointerover /template/ ContentPresenter">
-            <Setter Property="Background" Value="#7cc1f5"/>
+            <Setter Property="Background" Value="{StaticResource NtAccentHover}"/>
         </Style>
         <Style Selector="Button.Primary:pressed /template/ ContentPresenter">
-            <Setter Property="Background" Value="#4f9bde"/>
+            <Setter Property="Background" Value="{StaticResource NtAccentPressed}"/>
         </Style>
 
         <!-- Secondary pill button -->
@@ -144,7 +147,7 @@
             <Setter Property="Foreground" Value="{StaticResource NtFg}"/>
         </Style>
         <Style Selector="Button.Pill:pointerover /template/ ContentPresenter">
-            <Setter Property="Background" Value="#2a2f38"/>
+            <Setter Property="Background" Value="{StaticResource NtHairline}"/>
         </Style>
 
         <!-- Danger button (delete) -->
@@ -177,7 +180,7 @@
             <Setter Property="Foreground" Value="{StaticResource NtFg}"/>
         </Style>
         <Style Selector="Button.IconBtn:pointerover /template/ ContentPresenter">
-            <Setter Property="Background" Value="#2a2f38"/>
+            <Setter Property="Background" Value="{StaticResource NtHairline}"/>
         </Style>
 
         <!-- Sidebar (ListBox + items) -->
@@ -197,7 +200,7 @@
             <Setter Property="FontSize" Value="13"/>
         </Style>
         <Style Selector="ListBox.SideNav ListBoxItem:pointerover /template/ ContentPresenter">
-            <Setter Property="Background" Value="#1f2730"/>
+            <Setter Property="Background" Value="{StaticResource NtPanelAlt}"/>
         </Style>
         <Style Selector="ListBox.SideNav ListBoxItem:selected /template/ ContentPresenter">
             <Setter Property="Background" Value="{StaticResource NtBlueDim}"/>

--- a/src/NovaTerminal.App/SettingsWindow.axaml.cs
+++ b/src/NovaTerminal.App/SettingsWindow.axaml.cs
@@ -363,6 +363,14 @@ namespace NovaTerminal
                             }
                         }
 
+                        // OnThemeChanged refreshes the host window, but nothing above re-applies
+                        // the palette to THIS window when the saved theme was already the selected
+                        // one (editing colors of the active theme) - the selection change is a
+                        // no-op, so SelectionChanged never fires and the editor's new background,
+                        // sidebar, and card colors only showed up after closing and reopening
+                        // Settings (or restarting). Re-apply here so the edit lands live.
+                        ApplyTheme();
+
                         if (themeEditorStatus != null) themeEditorStatus.Text = "Saved!";
                         DispatcherTimer.RunOnce(() => { if (themeEditorStatus != null) themeEditorStatus.Text = ""; }, TimeSpan.FromSeconds(2));
                     }
@@ -450,6 +458,13 @@ namespace NovaTerminal
             LoadTitleBarDraft();
             RebuildTitleBarRows();
             ApplyTheme();
+
+            // LoadCurrentSettings' theme selection usually initializes the preview via
+            // SelectionChanged, but only when an item actually matches _settings.ThemeName - a
+            // saved name the manager normalizes (legacy "Default (Dark)") or a since-deleted
+            // theme leaves the combo empty and the preview stuck on its hardcoded dark XAML
+            // background. Paint it from the active theme directly so it is always current.
+            UpdateThemePreview(_settings.ActiveTheme, "Main");
 
             _statusTimer = new DispatcherTimer
             {
@@ -2005,6 +2020,15 @@ namespace NovaTerminal
             }
         }
 
+        /// <summary>
+        /// Resolves one of the window's Nt* palette brushes (NtPanel, NtHairline, …). Rows built
+        /// in code hold the brush INSTANCE, so ThemePaletteResources' in-place recolors keep them
+        /// live across theme switches - the same mechanism the XAML StaticResource references use.
+        /// Hardcoding hex here is what left the title-bar and shortcut cards dark navy under light
+        /// themes (they never saw the palette at all).
+        /// </summary>
+        private IBrush? ThemeResourceBrush(string key) => this.FindResource(key) as IBrush;
+
         private Control CreateTitleBarRow(
             TitleBarCatalogEntry entry,
             int index)
@@ -2014,8 +2038,8 @@ namespace NovaTerminal
 
             var row = new Border
             {
-                Background = new SolidColorBrush(Color.Parse("#23272f")),
-                BorderBrush = new SolidColorBrush(Color.Parse("#2a2f38")),
+                Background = ThemeResourceBrush("NtPanel"),
+                BorderBrush = ThemeResourceBrush("NtHairline"),
                 BorderThickness = new Thickness(1),
                 CornerRadius = new CornerRadius(6),
                 Padding = new Thickness(12),
@@ -2223,8 +2247,8 @@ namespace NovaTerminal
             string effectiveBinding = GetEffectiveShortcutBinding(entry);
             var row = new Border
             {
-                Background = new SolidColorBrush(Color.Parse("#23272f")),
-                BorderBrush = new SolidColorBrush(Color.Parse("#2a2f38")),
+                Background = ThemeResourceBrush("NtPanel"),
+                BorderBrush = ThemeResourceBrush("NtHairline"),
                 BorderThickness = new Thickness(1),
                 CornerRadius = new CornerRadius(6),
                 Padding = new Thickness(12),
@@ -2821,8 +2845,8 @@ namespace NovaTerminal
 
             return new Border
             {
-                Background = new SolidColorBrush(Color.Parse("#23272f")),
-                BorderBrush = new SolidColorBrush(Color.Parse("#2a2f38")),
+                Background = ThemeResourceBrush("NtPanel"),
+                BorderBrush = ThemeResourceBrush("NtHairline"),
                 BorderThickness = new Thickness(1),
                 CornerRadius = new CornerRadius(6),
                 Padding = new Thickness(12),
@@ -2997,9 +3021,17 @@ namespace NovaTerminal
 
             if (themeList != null)
             {
+                // Legacy settings store "Default (Dark)" while the combo lists the manager's
+                // canonical "Default" (ThemeManager.GetTheme maps between them). Normalize that
+                // one alias rather than resolving through GetTheme: for a name GetTheme cannot
+                // find it falls back to the Default theme OBJECT, whose .Name would match the
+                // "Default" combo item and silently rewrite the stored name on Save. When nothing
+                // matches here the selection stays empty and SaveAndClose skips the theme field,
+                // preserving the stored name - that must keep holding for unresolvable names.
+                var themeName = _settings.ThemeName == "Default (Dark)" ? "Default" : _settings.ThemeName;
                 foreach (ComboBoxItem item in themeList.Items.Cast<ComboBoxItem>())
                 {
-                    if (item.Content?.ToString() == _settings.ThemeName)
+                    if (item.Content?.ToString() == themeName)
                     {
                         themeList.SelectedItem = item;
                         break;

--- a/src/NovaTerminal.App/Shell/TerminalView.cs
+++ b/src/NovaTerminal.App/Shell/TerminalView.cs
@@ -920,6 +920,10 @@ namespace NovaTerminal.Shell
                     // Update all existing cells, remapping old theme colors to new
                     _buffer.UpdateThemeColors(oldTheme);
 
+                    TerminalLogger.Log(
+                        $"[TerminalView] Theme applied: '{_buffer.Theme.Name}' (was '{oldTheme.Name}'); " +
+                        $"buffer {_buffer.Cols}x{_buffer.Rows}.");
+
                     // Force immediate visual refresh
                     InvalidateVisual();
                 }

--- a/src/NovaTerminal.App/Shell/ThemePaletteResources.cs
+++ b/src/NovaTerminal.App/Shell/ThemePaletteResources.cs
@@ -24,10 +24,19 @@ internal static class ThemePaletteResources
         UpdateBrush(resources, "NtFg2", WithAlpha(foreground, 0xC8));
         UpdateBrush(resources, "NtFg3", WithAlpha(foreground, 0x9A));
         UpdateBrush(resources, "NtFg4", WithAlpha(foreground, 0x6E));
-        UpdateBrush(resources, "NtBlue", theme.Blue.ToAvaloniaColor());
-        UpdateBrush(resources, "NtBlueDim", WithAlpha(theme.Blue.ToAvaloniaColor(), 0x24));
-        UpdateBrush(resources, "NtBlueFaint", WithAlpha(theme.Blue.ToAvaloniaColor(), 0x15));
-        UpdateBrush(resources, "NtBlueBorder", WithAlpha(theme.Blue.ToAvaloniaColor(), 0x4D));
+
+        // The UI accent is derived from the theme's ANSI blue rather than copied: ANSI blues are
+        // tuned for terminal text (the Default theme's is RGB(0,0,238)) and read as eye-searing
+        // when lifted wholesale into buttons, toggles, and sliders. The terminal palette itself
+        // is untouched - only these chrome brushes are softened.
+        var accent = SoftenAccent(theme.Blue.ToAvaloniaColor());
+        UpdateBrush(resources, "NtBlue", accent);
+        UpdateBrush(resources, "NtBlueDim", WithAlpha(accent, 0x24));
+        UpdateBrush(resources, "NtBlueFaint", WithAlpha(accent, 0x15));
+        UpdateBrush(resources, "NtBlueBorder", WithAlpha(accent, 0x4D));
+        UpdateBrush(resources, "NtAccentHover", ShiftLightness(accent, 0.08));
+        UpdateBrush(resources, "NtAccentPressed", ShiftLightness(accent, -0.06));
+        UpdateBrush(resources, "NtAccentFg", IsDark(accent) ? Colors.White : Color.Parse("#0a1622"));
         UpdateBrush(resources, "NtGreen", theme.Green.ToAvaloniaColor());
         UpdateBrush(resources, "NtYellow", theme.Yellow.ToAvaloniaColor());
         UpdateBrush(resources, "NtRed", theme.Red.ToAvaloniaColor());
@@ -50,6 +59,78 @@ internal static class ThemePaletteResources
     {
         double luminance = ((0.299 * color.R) + (0.587 * color.G) + (0.114 * color.B)) / 255.0;
         return luminance < 0.5;
+    }
+
+    /// <summary>
+    /// Pulls a theme's ANSI blue into a range that works as UI chrome: saturation capped at 0.68
+    /// and lightness held between 0.45 and 0.62. Accents already inside those caps pass through
+    /// unchanged; extreme ones like the Default theme's RGB(0,0,238) land on a comfortable
+    /// indigo-blue. Hue is never shifted, so the accent keeps the theme's identity.
+    /// </summary>
+    public static Color SoftenAccent(Color color)
+    {
+        var (h, s, l) = ToHsl(color);
+        s = Math.Min(s, 0.68);
+        l = Math.Clamp(l, 0.45, 0.62);
+        return FromHsl(color.A, h, s, l);
+    }
+
+    private static Color ShiftLightness(Color color, double delta)
+    {
+        var (h, s, l) = ToHsl(color);
+        return FromHsl(color.A, h, s, Math.Clamp(l + delta, 0.0, 1.0));
+    }
+
+    private static (double H, double S, double L) ToHsl(Color c)
+    {
+        double r = c.R / 255.0, g = c.G / 255.0, b = c.B / 255.0;
+        double max = Math.Max(r, Math.Max(g, b));
+        double min = Math.Min(r, Math.Min(g, b));
+        double l = (max + min) / 2.0;
+
+        if (max == min)
+        {
+            return (0.0, 0.0, l);
+        }
+
+        double d = max - min;
+        double s = l > 0.5 ? d / (2.0 - max - min) : d / (max + min);
+        double h;
+        if (max == r)
+        {
+            h = (g - b) / d + (g < b ? 6.0 : 0.0);
+        }
+        else if (max == g)
+        {
+            h = (b - r) / d + 2.0;
+        }
+        else
+        {
+            h = (r - g) / d + 4.0;
+        }
+
+        return (h * 60.0, s, l);
+    }
+
+    private static Color FromHsl(byte alpha, double h, double s, double l)
+    {
+        double c = (1.0 - Math.Abs(2.0 * l - 1.0)) * s;
+        double hPrime = h / 60.0;
+        double x = c * (1.0 - Math.Abs(hPrime % 2.0 - 1.0));
+        double r = 0, g = 0, b = 0;
+        if (hPrime < 1) { r = c; g = x; }
+        else if (hPrime < 2) { r = x; g = c; }
+        else if (hPrime < 3) { g = c; b = x; }
+        else if (hPrime < 4) { g = x; b = c; }
+        else if (hPrime < 5) { r = x; b = c; }
+        else { r = c; b = x; }
+
+        double m = l - c / 2.0;
+        return Color.FromArgb(
+            alpha,
+            (byte)Math.Round(Math.Clamp(r + m, 0.0, 1.0) * 255.0),
+            (byte)Math.Round(Math.Clamp(g + m, 0.0, 1.0) * 255.0),
+            (byte)Math.Round(Math.Clamp(b + m, 0.0, 1.0) * 255.0));
     }
 
     private static Color Shift(Color color, int delta)

--- a/src/NovaTerminal.App/Shell/ThemePaletteResources.cs
+++ b/src/NovaTerminal.App/Shell/ThemePaletteResources.cs
@@ -83,24 +83,29 @@ internal static class ThemePaletteResources
 
     private static (double H, double S, double L) ToHsl(Color c)
     {
+        // Achromatic and channel-dominance comparisons run on the source bytes: they are exact
+        // integer checks, immune to the float-equality warning the scaled doubles would raise.
+        byte maxByte = Math.Max(c.R, Math.Max(c.G, c.B));
+        byte minByte = Math.Min(c.R, Math.Min(c.G, c.B));
+
         double r = c.R / 255.0, g = c.G / 255.0, b = c.B / 255.0;
-        double max = Math.Max(r, Math.Max(g, b));
-        double min = Math.Min(r, Math.Min(g, b));
+        double max = maxByte / 255.0, min = minByte / 255.0;
         double l = (max + min) / 2.0;
 
-        if (max == min)
+        if (maxByte == minByte)
         {
+            // Achromatic: saturation is zero by definition.
             return (0.0, 0.0, l);
         }
 
         double d = max - min;
         double s = l > 0.5 ? d / (2.0 - max - min) : d / (max + min);
         double h;
-        if (max == r)
+        if (maxByte == c.R)
         {
             h = (g - b) / d + (g < b ? 6.0 : 0.0);
         }
-        else if (max == g)
+        else if (maxByte == c.G)
         {
             h = (b - r) / d + 2.0;
         }

--- a/src/NovaTerminal.VT/Buffer/ScrollbackPages.cs
+++ b/src/NovaTerminal.VT/Buffer/ScrollbackPages.cs
@@ -362,14 +362,19 @@ namespace NovaTerminal.VT.Storage
         /// <summary>
         /// Updates the default foreground and background colors for all cells currently retained.
         /// This is allowed to be a slower full-scan because theme changes are infrequent.
+        /// Cells whose stored color equals the OLD theme's default but which lost their default
+        /// flag are adopted into the new theme as well - otherwise materialized-default history
+        /// keeps rendering in the previous theme's colors after a switch.
         /// </summary>
         public void UpdateThemeDefaults(TerminalTheme oldTheme, TerminalTheme newTheme)
         {
             uint fgUint = newTheme.Foreground.ToUint();
             uint bgUint = newTheme.Background.ToUint();
+            uint oldFgUint = oldTheme.Foreground.ToUint();
+            uint oldBgUint = oldTheme.Background.ToUint();
             foreach (var page in _pages)
             {
-                page.UpdateThemeDefaults(fgUint, bgUint);
+                page.UpdateThemeDefaults(fgUint, bgUint, oldFgUint, oldBgUint);
             }
         }
 

--- a/src/NovaTerminal.VT/Buffer/ScrollbackPages.cs
+++ b/src/NovaTerminal.VT/Buffer/ScrollbackPages.cs
@@ -362,19 +362,16 @@ namespace NovaTerminal.VT.Storage
         /// <summary>
         /// Updates the default foreground and background colors for all cells currently retained.
         /// This is allowed to be a slower full-scan because theme changes are infrequent.
-        /// Cells whose stored color equals the OLD theme's default but which lost their default
-        /// flag are adopted into the new theme as well - otherwise materialized-default history
-        /// keeps rendering in the previous theme's colors after a switch.
+        /// Explicit colors (including truecolors that happen to equal the old default) are left
+        /// alone - only flagged default cells migrate.
         /// </summary>
         public void UpdateThemeDefaults(TerminalTheme oldTheme, TerminalTheme newTheme)
         {
             uint fgUint = newTheme.Foreground.ToUint();
             uint bgUint = newTheme.Background.ToUint();
-            uint oldFgUint = oldTheme.Foreground.ToUint();
-            uint oldBgUint = oldTheme.Background.ToUint();
             foreach (var page in _pages)
             {
-                page.UpdateThemeDefaults(fgUint, bgUint, oldFgUint, oldBgUint);
+                page.UpdateThemeDefaults(fgUint, bgUint);
             }
         }
 

--- a/src/NovaTerminal.VT/Buffer/TerminalPage.cs
+++ b/src/NovaTerminal.VT/Buffer/TerminalPage.cs
@@ -215,25 +215,21 @@ namespace NovaTerminal.VT.Storage
 
         /// <summary>
         /// Updates cells that rely on default foreground or background colors to a new theme.
-        /// Also adopts cells whose stored color equals the OLD theme's default but which lack
-        /// the default flag (materialized defaults) - otherwise they render in the previous
-        /// theme's colors forever. This is an O(n) operation over all used cells, invoked rarely
-        /// during a theme change.
+        /// Explicit colors are left untouched, even when they equal the old default. This is an
+        /// O(n) operation over all used cells, invoked rarely during a theme change.
         /// </summary>
-        public void UpdateThemeDefaults(uint newFg, uint newBg, uint oldFg = 0xFFFFFFFF, uint oldBg = 0xFFFFFFFF)
+        public void UpdateThemeDefaults(uint newFg, uint newBg)
         {
             var span = Cells.AsSpan(0, UsedRows * Cols);
             for (int i = 0; i < span.Length; i++)
             {
-                if (span[i].IsDefaultForeground || span[i].Fg == oldFg)
+                if (span[i].IsDefaultForeground)
                 {
                     span[i].Fg = newFg;
-                    span[i].IsDefaultForeground = true;
                 }
-                if (span[i].IsDefaultBackground || span[i].Bg == oldBg)
+                if (span[i].IsDefaultBackground)
                 {
                     span[i].Bg = newBg;
-                    span[i].IsDefaultBackground = true;
                 }
             }
         }

--- a/src/NovaTerminal.VT/Buffer/TerminalPage.cs
+++ b/src/NovaTerminal.VT/Buffer/TerminalPage.cs
@@ -215,20 +215,25 @@ namespace NovaTerminal.VT.Storage
 
         /// <summary>
         /// Updates cells that rely on default foreground or background colors to a new theme.
-        /// This is an O(n) operation over all used cells, invoked rarely during a theme change.
+        /// Also adopts cells whose stored color equals the OLD theme's default but which lack
+        /// the default flag (materialized defaults) - otherwise they render in the previous
+        /// theme's colors forever. This is an O(n) operation over all used cells, invoked rarely
+        /// during a theme change.
         /// </summary>
-        public void UpdateThemeDefaults(uint newFg, uint newBg)
+        public void UpdateThemeDefaults(uint newFg, uint newBg, uint oldFg = 0xFFFFFFFF, uint oldBg = 0xFFFFFFFF)
         {
             var span = Cells.AsSpan(0, UsedRows * Cols);
             for (int i = 0; i < span.Length; i++)
             {
-                if (span[i].IsDefaultForeground)
+                if (span[i].IsDefaultForeground || span[i].Fg == oldFg)
                 {
                     span[i].Fg = newFg;
+                    span[i].IsDefaultForeground = true;
                 }
-                if (span[i].IsDefaultBackground)
+                if (span[i].IsDefaultBackground || span[i].Bg == oldBg)
                 {
                     span[i].Bg = newBg;
+                    span[i].IsDefaultBackground = true;
                 }
             }
         }

--- a/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
@@ -358,10 +358,11 @@ namespace NovaTerminal.VT
                 SyncThemeDefaultsInCursorStateNoLock(_screenCursorStates.Main);
                 SyncThemeDefaultsInCursorStateNoLock(_screenCursorStates.Alt);
 
-                // Materialized-default detection colors (see UpdateCell below).
-                uint oldForegroundUint = oldTheme.Foreground.ToUint();
-                uint oldBackgroundUint = oldTheme.Background.ToUint();
-
+                // NOTE: deliberately no value-based adoption here. Rewriting cells whose color
+                // happens to equal the old default would also capture explicitly-requested
+                // truecolors (programs query OSC 11 and paint to match the terminal), silently
+                // converting them to theme-following defaults. Explicit stays explicit; only
+                // flagged default cells migrate.
                 void UpdateCell(ref TerminalCell cell)
                 {
                     // Preserve palette/default flags across theme switches.
@@ -382,15 +383,6 @@ namespace NovaTerminal.VT
                         cell.IsDefaultForeground = true;
                         cell.Fg = Theme.Foreground.ToUint();
                     }
-                    else if (fgIdx < 0 && cell.Fg == oldForegroundUint)
-                    {
-                        // Materialized default: some paths store the resolved old default color
-                        // without the default flag. A cell that rendered exactly like the old
-                        // default reads as "default" to the user - adopt it into the new theme,
-                        // or scrolled history keeps old-theme boxes after a switch.
-                        cell.IsDefaultForeground = true;
-                        cell.Fg = Theme.Foreground.ToUint();
-                    }
 
                     if (bgIdx >= 0 && bgIdx <= 15)
                     {
@@ -401,11 +393,6 @@ namespace NovaTerminal.VT
                     else if (cell.IsDefaultBackground)
                     {
                         cell.IsPaletteBackground = false;
-                        cell.IsDefaultBackground = true;
-                        cell.Bg = Theme.Background.ToUint();
-                    }
-                    else if (bgIdx < 0 && cell.Bg == oldBackgroundUint)
-                    {
                         cell.IsDefaultBackground = true;
                         cell.Bg = Theme.Background.ToUint();
                     }

--- a/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
@@ -345,6 +345,11 @@ namespace NovaTerminal.VT
             Lock.EnterWriteLock();
             try
             {
+                // Invalidate render-side caches keyed by the theme epoch (paged-scrollback
+                // snapshots and everything derived from them). Must happen under the write lock
+                // so a snapshot captured after this call always observes the new epoch.
+                _renderThemeEpoch++;
+
                 // Sync current buffer defaults to new theme
                 if (IsDefaultForeground) CurrentForeground = Theme.Foreground;
                 if (IsDefaultBackground) CurrentBackground = Theme.Background;
@@ -352,6 +357,10 @@ namespace NovaTerminal.VT
                 SyncThemeDefaultsInCursorStateNoLock(_savedCursors.Alt);
                 SyncThemeDefaultsInCursorStateNoLock(_screenCursorStates.Main);
                 SyncThemeDefaultsInCursorStateNoLock(_screenCursorStates.Alt);
+
+                // Materialized-default detection colors (see UpdateCell below).
+                uint oldForegroundUint = oldTheme.Foreground.ToUint();
+                uint oldBackgroundUint = oldTheme.Background.ToUint();
 
                 void UpdateCell(ref TerminalCell cell)
                 {
@@ -373,6 +382,15 @@ namespace NovaTerminal.VT
                         cell.IsDefaultForeground = true;
                         cell.Fg = Theme.Foreground.ToUint();
                     }
+                    else if (fgIdx < 0 && cell.Fg == oldForegroundUint)
+                    {
+                        // Materialized default: some paths store the resolved old default color
+                        // without the default flag. A cell that rendered exactly like the old
+                        // default reads as "default" to the user - adopt it into the new theme,
+                        // or scrolled history keeps old-theme boxes after a switch.
+                        cell.IsDefaultForeground = true;
+                        cell.Fg = Theme.Foreground.ToUint();
+                    }
 
                     if (bgIdx >= 0 && bgIdx <= 15)
                     {
@@ -383,6 +401,11 @@ namespace NovaTerminal.VT
                     else if (cell.IsDefaultBackground)
                     {
                         cell.IsPaletteBackground = false;
+                        cell.IsDefaultBackground = true;
+                        cell.Bg = Theme.Background.ToUint();
+                    }
+                    else if (bgIdx < 0 && cell.Bg == oldBackgroundUint)
+                    {
                         cell.IsDefaultBackground = true;
                         cell.Bg = Theme.Background.ToUint();
                     }

--- a/src/NovaTerminal.VT/TerminalBuffer.ThreadingAndInvalidation.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.ThreadingAndInvalidation.cs
@@ -21,7 +21,12 @@ namespace NovaTerminal.VT
         private int[] _cachedRenderRowCols = Array.Empty<int>();
         private RenderCellSnapshot[][] _cachedRenderRowCells = Array.Empty<RenderCellSnapshot[]>();
         private int _lastSnapshotCols = -1;
+        private int _lastSnapshotThemeEpoch;
         private bool _hasSnapshotState;
+        // Bumped by UpdateThemeColors. Scrollback rows are otherwise treated as immutable
+        // (revision 0), so both the paged-row cell snapshots and every render-side cache keyed
+        // by the snapshot revision would keep serving pre-switch colors forever.
+        private int _renderThemeEpoch;
         private TermColor[]? _cachedAnsiPalette;
 
         public bool IsSynchronizedOutput => _isSynchronizedOutput;
@@ -245,6 +250,8 @@ namespace NovaTerminal.VT
                 cursorCol = _cursorCol;
                 cursorStyle = Modes.CursorStyle;
                 theme = CreateRenderThemeSnapshot_NoLock();
+                int themeEpoch = _renderThemeEpoch;
+                bool themeEpochChanged = _hasSnapshotState && _lastSnapshotThemeEpoch != themeEpoch;
 
                 EnsureSnapshotStateCapacity_NoLock(viewportRows);
 
@@ -278,9 +285,13 @@ namespace NovaTerminal.VT
                         rowSnapshot = new RenderRowSnapshot
                         {
                             AbsRow = absRow,
-                            Revision = 0, // Scrollback rows are immutable
+                            // Scrollback row content is immutable, but a theme switch rewrites
+                            // the stored default colors (UpdateThemeColors). Stamping the theme
+                            // epoch here is what invalidates the paged-row snapshot cache below
+                            // and every render-side cache keyed by this revision.
+                            Revision = (uint)themeEpoch,
                             Cols = viewportCols,
-                            Cells = GetOrBuildCachedPagedRenderRowCells_NoLock(r, absRow, absRowId, viewportCols),
+                            Cells = GetOrBuildCachedPagedRenderRowCells_NoLock(r, absRow, absRowId, viewportCols, themeEpoch),
                             RowId = absRowId
                         };
                         rowId = rowSnapshot.RowId;
@@ -310,7 +321,11 @@ namespace NovaTerminal.VT
                     bool fullRowDirty = !_hasSnapshotState ||
                                         _lastSnapshotCols != viewportCols ||
                                         _lastSnapshotAbsRows[r] != absRow ||
-                                        _lastSnapshotRowIds[r] != rowId;
+                                        _lastSnapshotRowIds[r] != rowId ||
+                                        // A theme switch recolors cells in place; the span-diff
+                                        // would compare against pre-switch snapshots and miss
+                                        // recolored regions, so re-render every row once.
+                                        themeEpochChanged;
 
                     if (rowSnapshot.Cols > 0 && viewportCols > 0)
                     {
@@ -346,6 +361,7 @@ namespace NovaTerminal.VT
                 }
 
                 _lastSnapshotCols = viewportCols;
+                _lastSnapshotThemeEpoch = themeEpoch;
                 _hasSnapshotState = true;
                 dirtySpans = NormalizeDirtySpans(dirtyList, viewportRows, viewportCols);
 
@@ -681,7 +697,7 @@ namespace NovaTerminal.VT
             return PooledArray<SearchHighlightSnapshot>.Empty;
         }
 
-        private RenderCellSnapshot[] GetOrBuildCachedPagedRenderRowCells_NoLock(int rowIndex, int absRow, long rowId, int viewportCols)
+        private RenderCellSnapshot[] GetOrBuildCachedPagedRenderRowCells_NoLock(int rowIndex, int absRow, long rowId, int viewportCols, int themeEpoch)
         {
             if (viewportCols <= 0)
             {
@@ -693,7 +709,7 @@ namespace NovaTerminal.VT
                 cachedCells != null &&
                 cachedCells.Length == viewportCols &&
                 _cachedRenderRowIds[rowIndex] == rowId &&
-                _cachedRenderRowRevisions[rowIndex] == 0 &&
+                _cachedRenderRowRevisions[rowIndex] == (uint)themeEpoch &&
                 _cachedRenderRowCols[rowIndex] == viewportCols;
 
             if (canReuse)
@@ -758,7 +774,7 @@ namespace NovaTerminal.VT
             }
 
             _cachedRenderRowIds[rowIndex] = rowId;
-            _cachedRenderRowRevisions[rowIndex] = 0;
+            _cachedRenderRowRevisions[rowIndex] = (uint)themeEpoch;
             _cachedRenderRowCols[rowIndex] = viewportCols;
             _cachedRenderRowCells[rowIndex] = rebuiltCells;
 

--- a/tests/NovaTerminal.App.Tests/BufferTests/ThemeSwitchPixelTests.cs
+++ b/tests/NovaTerminal.App.Tests/BufferTests/ThemeSwitchPixelTests.cs
@@ -21,6 +21,10 @@ namespace NovaTerminal.Tests.BufferTests
     /// renders, and asserts the banner row's dominant pixel color follows the new theme. The
     /// buffer-level migration tests in ThemeSwitchStaleScrollbackTests pass while the screen
     /// still shows old-theme boxes, so this is the test that guards what the user actually sees.
+    ///
+    /// Sample bands are derived from the laid-out TerminalView geometry (row height =
+    /// view height / buffer rows) rather than fixed fractions of the host control, so pane
+    /// chrome and layout changes cannot silently shift what is being measured (Greptile P2).
     /// </summary>
     public sealed class ThemeSwitchPixelTests
     {
@@ -47,31 +51,45 @@ namespace NovaTerminal.Tests.BufferTests
             };
         }
 
-        /// <summary>
-        /// Renders the view and returns the most frequent color inside the horizontal band
-        /// [yStartFraction, yEndFraction) of the control's height.
-        /// </summary>
-        private static Color RenderBandDominantColor(Control view, int width, int height, double yStartFraction, double yEndFraction, out string diagnostics)
+        private static TerminalBuffer BuildBufferWithBanner(TerminalTheme theme, int rows = 6)
         {
-            var window = new Window { Content = view, Width = width + 40, Height = height + 40 };
-            try
+            var buffer = new TerminalBuffer(80, rows) { Theme = theme };
+            var parser = new AnsiParser(buffer);
+            parser.Process("Clink v1.9.25.dc17e7\r\nActive code page: 65001\r\n");
+            for (int i = 0; i < rows - 3; i++)
             {
-                window.Show();
-                Dispatcher.UIThread.RunJobs();
-                Dispatcher.UIThread.RunJobs();
+                parser.Process($"filler {i}\r\n");
+            }
 
-                Assert.True(view.Bounds.Width > 0 && view.Bounds.Height > 0,
-                    $"The view arranged to {view.Bounds}; nothing to rasterize.");
+            return buffer;
+        }
 
-                using var target = new RenderTargetBitmap(
-                    new PixelSize((int)view.Bounds.Width, (int)view.Bounds.Height), new Vector(96, 96));
-                target.Render(view);
+        /// <summary>
+        /// Rasterizes <paramref name="rendered"/> inside its window and returns the dominant
+        /// color of the absolute-pixel row band [yStart, yEnd).
+        /// </summary>
+        private static Color BandDominant(Control rendered, int yStart, int yEnd, out string diagnostics)
+        {
+            using var target = new RenderTargetBitmap(
+                new PixelSize((int)rendered.Bounds.Width, (int)rendered.Bounds.Height), new Vector(96, 96));
+            target.Render(rendered);
 
-                using var stream = new MemoryStream();
-                target.Save(stream);
-                stream.Position = 0;
-                using SKBitmap bitmap = SKBitmap.Decode(stream)
-                    ?? throw new InvalidOperationException("headless raster decode failed");
+            using var stream = new MemoryStream();
+            target.Save(stream);
+            stream.Position = 0;
+            using SKBitmap bitmap = SKBitmap.Decode(stream)
+                ?? throw new InvalidOperationException("headless raster decode failed");
+
+            var counts = new System.Collections.Generic.Dictionary<Color, int>();
+            for (int y = yStart; y < Math.Min(yEnd, bitmap.Height); y++)
+            {
+                for (int x = 8; x < bitmap.Width - 8; x++)
+                {
+                    var p = bitmap.GetPixel(x, y);
+                    var color = Color.FromRgb(p.Red, p.Green, p.Blue);
+                    counts[color] = counts.GetValueOrDefault(color) + 1;
+                }
+            }
 
                 // Whole-frame dominant colors, for diagnosing "nothing rendered" failures.
                 var frameCounts = new System.Collections.Generic.Dictionary<string, int>();
@@ -85,32 +103,12 @@ namespace NovaTerminal.Tests.BufferTests
                     }
                 }
 
-                diagnostics = "frame colors: " + string.Join(", ", frameCounts
-                    .OrderByDescending(kvp => kvp.Value)
-                    .Take(5)
-                    .Select(kvp => $"#{kvp.Key}={kvp.Value}"));
+            diagnostics = "frame colors: " + string.Join(", ", frameCounts
+                .OrderByDescending(kvp => kvp.Value)
+                .Take(4)
+                .Select(kvp => $"{kvp.Key}={kvp.Value}"));
 
-                int yStart = (int)(bitmap.Height * yStartFraction);
-                int yEnd = Math.Max(yStart + 4, (int)(bitmap.Height * yEndFraction));
-                var counts = new System.Collections.Generic.Dictionary<Color, int>();
-                for (int y = yStart; y < yEnd; y++)
-                {
-                    for (int x = 8; x < bitmap.Width - 8; x++)
-                    {
-                        var p = bitmap.GetPixel(x, y);
-                        var color = Color.FromRgb(p.Red, p.Green, p.Blue);
-                        counts[color] = counts.GetValueOrDefault(color) + 1;
-                    }
-                }
-
-                return counts.OrderByDescending(kvp => kvp.Value).First().Key;
-            }
-            finally
-            {
-                window.Content = null;
-                Dispatcher.UIThread.RunJobs();
-                window.Close();
-            }
+            return counts.OrderByDescending(kvp => kvp.Value).First().Key;
         }
 
         [AvaloniaFact]
@@ -119,30 +117,41 @@ namespace NovaTerminal.Tests.BufferTests
             var solarized = LoadTheme("SolarizedDark");
             var cobalt = LoadTheme("Cobalt2");
 
-            var buffer = new TerminalBuffer(80, 6) { Theme = solarized };
-            var parser = new AnsiParser(buffer);
-            parser.Process("Clink v1.9.25.dc17e7\r\nActive code page: 65001\r\n");
-            for (int i = 0; i < 3; i++)
-            {
-                parser.Process($"filler {i}\r\n");
-            }
-
             var view = new TerminalView();
-            view.SetBuffer(buffer);
+            view.SetBuffer(BuildBufferWithBanner(solarized));
             view.ApplySettings(SettingsFor(solarized));
 
-            Color before = RenderBandDominantColor(view, 640, 180, 0.0, 0.16, out var diagBefore);
+            var window = new Window { Content = view, Width = 680, Height = 220 };
+            try
+            {
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+                Dispatcher.UIThread.RunJobs();
 
-            // The user's exact action: live theme switch on an existing pane.
-            view.ApplySettings(SettingsFor(cobalt));
+                Assert.True(view.Bounds.Height > 0, $"TerminalView arranged to {view.Bounds}.");
+                double rowHeight = view.Bounds.Height / 6.0;
+                int bannerY1 = (int)(rowHeight * 0.15);
+                int bannerY2 = (int)(rowHeight * 0.85);
 
-            Color after = RenderBandDominantColor(view, 640, 180, 0.0, 0.16, out var diagAfter);
+                Color before = BandDominant(view, bannerY1, bannerY2, out _);
+                Assert.Equal(solarized.Background.ToAvaloniaColor(), before);
 
-            Assert.True(
-                after == cobalt.Background.ToAvaloniaColor(),
-                $"[view-level] After switching to Cobalt2 the banner row still paints {after} " +
-                $"(expected {cobalt.Background.ToAvaloniaColor()}). " +
-                $"Pre-switch it was {before} with [{diagBefore}]; post-switch [{diagAfter}].");
+                // The user's exact action: live theme switch on an existing pane.
+                view.ApplySettings(SettingsFor(cobalt));
+                Dispatcher.UIThread.RunJobs();
+
+                Color after = BandDominant(view, bannerY1, bannerY2, out var diag);
+                Assert.True(
+                    after == cobalt.Background.ToAvaloniaColor(),
+                    $"[view-level] After switching to Cobalt2 the banner row paints {after}, " +
+                    $"expected {cobalt.Background.ToAvaloniaColor()} (pre-switch {before}). [{diag}]");
+            }
+            finally
+            {
+                window.Content = null;
+                Dispatcher.UIThread.RunJobs();
+                window.Close();
+            }
         }
 
         [AvaloniaFact]
@@ -160,22 +169,45 @@ namespace NovaTerminal.Tests.BufferTests
             }
 
             pane.ApplySettings(SettingsFor(solarized));
-            Color before = RenderBandDominantColor(pane, 640, 240, 0.05, 0.15, out var diagBefore);
 
-            pane.ApplySettings(SettingsFor(cobalt));
-            Color after = RenderBandDominantColor(pane, 640, 240, 0.05, 0.15, out var diagAfter);
+            var window = new Window { Content = pane, Width = 680, Height = 280 };
+            try
+            {
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+                Dispatcher.UIThread.RunJobs();
 
-            // The pane composites its own chrome over the terminal, so compare the banner band
-            // against a band from the filler rows rendered in the SAME frame: after a correct
-            // switch both bands share one background (the new theme's), while the reported bug
-            // left the banner band stuck in the previous theme's colors.
-            Color filler = RenderBandDominantColor(pane, 640, 240, 0.30, 0.42, out _);
+                // Sample bands come from the laid-out TerminalView geometry and the live cell
+                // metrics, translated into pane coordinates - not fixed fractions of the pane,
+                // so pane chrome and layout changes cannot shift what is measured.
+                var view = Assert.IsType<TerminalView>(pane.ActiveControl);
+                var origin = view.TranslatePoint(new Point(0, 0), pane)
+                             ?? throw new InvalidOperationException("TerminalView is not attached to the pane.");
+                double cellHeight = view.Metrics.CellHeight > 0
+                    ? view.Metrics.CellHeight
+                    : view.Bounds.Height / 6.0;
+                int bannerY1 = (int)(origin.Y + cellHeight * 0.2);
+                int bannerY2 = (int)(origin.Y + cellHeight * 0.9);
+                int fillerY1 = (int)(origin.Y + cellHeight * 2.3);
+                int fillerY2 = (int)(origin.Y + cellHeight * 3.2);
 
-            Assert.True(
-                after == filler,
-                $"[pane-level] After switching to Cobalt2 the banner row paints {after} but the " +
-                $"filler rows paint {filler} - the banner is still in the previous theme. " +
-                $"Pre-switch the banner was {before} with [{diagBefore}]; post-switch [{diagAfter}].");
+                pane.ApplySettings(SettingsFor(cobalt));
+                Dispatcher.UIThread.RunJobs();
+
+                Color banner = BandDominant(pane, bannerY1, bannerY2, out var diag);
+                Color filler = BandDominant(pane, fillerY1, fillerY2, out _);
+
+                Assert.True(
+                    banner == filler,
+                    $"[pane-level] After switching to Cobalt2 the banner row paints {banner} but " +
+                    $"the filler rows paint {filler} - the banner is still in the previous theme. [{diag}]");
+            }
+            finally
+            {
+                window.Content = null;
+                Dispatcher.UIThread.RunJobs();
+                window.Close();
+            }
         }
     }
 }

--- a/tests/NovaTerminal.App.Tests/BufferTests/ThemeSwitchPixelTests.cs
+++ b/tests/NovaTerminal.App.Tests/BufferTests/ThemeSwitchPixelTests.cs
@@ -1,0 +1,181 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using NovaTerminal.Shell;
+using NovaTerminal.VT;
+using SkiaSharp;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Xunit;
+
+namespace NovaTerminal.Tests.BufferTests
+{
+    /// <summary>
+    /// End-to-end pixel regression for the live theme switch: drives the REAL TerminalView →
+    /// TerminalDrawOperation → Skia pipeline (not just the buffer), switches the theme between
+    /// renders, and asserts the banner row's dominant pixel color follows the new theme. The
+    /// buffer-level migration tests in ThemeSwitchStaleScrollbackTests pass while the screen
+    /// still shows old-theme boxes, so this is the test that guards what the user actually sees.
+    /// </summary>
+    public sealed class ThemeSwitchPixelTests
+    {
+        private static TerminalTheme LoadTheme(string fileName)
+        {
+            string outputThemes = Path.Combine(AppContext.BaseDirectory, "themes");
+            string path = Path.Combine(outputThemes, fileName + ".json");
+            string json = File.ReadAllText(path);
+            return JsonSerializer.Deserialize(json, AppJsonContext.Default.TerminalTheme)
+                   ?? throw new InvalidOperationException($"Could not load theme {fileName}");
+        }
+
+        private static TerminalSettings SettingsFor(TerminalTheme theme)
+        {
+            // ThemeName must match the assigned ActiveTheme, or the ActiveTheme getter
+            // re-resolves through ThemeManager and hands back the stock Default theme.
+            return new TerminalSettings
+            {
+                FontFamily = "Consolas",
+                FontSize = 14,
+                WindowOpacity = 1.0,
+                ThemeName = theme.Name,
+                ActiveTheme = theme
+            };
+        }
+
+        /// <summary>
+        /// Renders the view and returns the most frequent color inside the horizontal band
+        /// [yStartFraction, yEndFraction) of the control's height.
+        /// </summary>
+        private static Color RenderBandDominantColor(Control view, int width, int height, double yStartFraction, double yEndFraction, out string diagnostics)
+        {
+            var window = new Window { Content = view, Width = width + 40, Height = height + 40 };
+            try
+            {
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.True(view.Bounds.Width > 0 && view.Bounds.Height > 0,
+                    $"The view arranged to {view.Bounds}; nothing to rasterize.");
+
+                using var target = new RenderTargetBitmap(
+                    new PixelSize((int)view.Bounds.Width, (int)view.Bounds.Height), new Vector(96, 96));
+                target.Render(view);
+
+                using var stream = new MemoryStream();
+                target.Save(stream);
+                stream.Position = 0;
+                using SKBitmap bitmap = SKBitmap.Decode(stream)
+                    ?? throw new InvalidOperationException("headless raster decode failed");
+
+                // Whole-frame dominant colors, for diagnosing "nothing rendered" failures.
+                var frameCounts = new System.Collections.Generic.Dictionary<string, int>();
+                for (int y = 0; y < bitmap.Height; y += 3)
+                {
+                    for (int x = 0; x < bitmap.Width; x += 3)
+                    {
+                        var p = bitmap.GetPixel(x, y);
+                        string key = $"{p.Red:X2}{p.Green:X2}{p.Blue:X2}{p.Alpha:X2}";
+                        frameCounts[key] = frameCounts.GetValueOrDefault(key) + 1;
+                    }
+                }
+
+                diagnostics = "frame colors: " + string.Join(", ", frameCounts
+                    .OrderByDescending(kvp => kvp.Value)
+                    .Take(5)
+                    .Select(kvp => $"#{kvp.Key}={kvp.Value}"));
+
+                int yStart = (int)(bitmap.Height * yStartFraction);
+                int yEnd = Math.Max(yStart + 4, (int)(bitmap.Height * yEndFraction));
+                var counts = new System.Collections.Generic.Dictionary<Color, int>();
+                for (int y = yStart; y < yEnd; y++)
+                {
+                    for (int x = 8; x < bitmap.Width - 8; x++)
+                    {
+                        var p = bitmap.GetPixel(x, y);
+                        var color = Color.FromRgb(p.Red, p.Green, p.Blue);
+                        counts[color] = counts.GetValueOrDefault(color) + 1;
+                    }
+                }
+
+                return counts.OrderByDescending(kvp => kvp.Value).First().Key;
+            }
+            finally
+            {
+                window.Content = null;
+                Dispatcher.UIThread.RunJobs();
+                window.Close();
+            }
+        }
+
+        [AvaloniaFact]
+        public void ThemeSwitch_BannerRowPixels_FollowTheNewTheme()
+        {
+            var solarized = LoadTheme("SolarizedDark");
+            var cobalt = LoadTheme("Cobalt2");
+
+            var buffer = new TerminalBuffer(80, 6) { Theme = solarized };
+            var parser = new AnsiParser(buffer);
+            parser.Process("Clink v1.9.25.dc17e7\r\nActive code page: 65001\r\n");
+            for (int i = 0; i < 3; i++)
+            {
+                parser.Process($"filler {i}\r\n");
+            }
+
+            var view = new TerminalView();
+            view.SetBuffer(buffer);
+            view.ApplySettings(SettingsFor(solarized));
+
+            Color before = RenderBandDominantColor(view, 640, 180, 0.0, 0.16, out var diagBefore);
+
+            // The user's exact action: live theme switch on an existing pane.
+            view.ApplySettings(SettingsFor(cobalt));
+
+            Color after = RenderBandDominantColor(view, 640, 180, 0.0, 0.16, out var diagAfter);
+
+            Assert.True(
+                after == cobalt.Background.ToAvaloniaColor(),
+                $"[view-level] After switching to Cobalt2 the banner row still paints {after} " +
+                $"(expected {cobalt.Background.ToAvaloniaColor()}). " +
+                $"Pre-switch it was {before} with [{diagBefore}]; post-switch [{diagAfter}].");
+        }
+
+        [AvaloniaFact]
+        public void ThemeSwitch_ThroughRealTerminalPane_BannerRowPixelsFollowTheNewTheme()
+        {
+            var solarized = LoadTheme("SolarizedDark");
+            var cobalt = LoadTheme("Cobalt2");
+
+            using var pane = new NovaTerminal.Controls.TerminalPane();
+            pane.CreateAndWireParser();
+            pane.Parser!.Process("Clink v1.9.25.dc17e7\r\nActive code page: 65001\r\n");
+            for (int i = 0; i < 3; i++)
+            {
+                pane.Parser.Process($"filler {i}\r\n");
+            }
+
+            pane.ApplySettings(SettingsFor(solarized));
+            Color before = RenderBandDominantColor(pane, 640, 240, 0.05, 0.15, out var diagBefore);
+
+            pane.ApplySettings(SettingsFor(cobalt));
+            Color after = RenderBandDominantColor(pane, 640, 240, 0.05, 0.15, out var diagAfter);
+
+            // The pane composites its own chrome over the terminal, so compare the banner band
+            // against a band from the filler rows rendered in the SAME frame: after a correct
+            // switch both bands share one background (the new theme's), while the reported bug
+            // left the banner band stuck in the previous theme's colors.
+            Color filler = RenderBandDominantColor(pane, 640, 240, 0.30, 0.42, out _);
+
+            Assert.True(
+                after == filler,
+                $"[pane-level] After switching to Cobalt2 the banner row paints {after} but the " +
+                $"filler rows paint {filler} - the banner is still in the previous theme. " +
+                $"Pre-switch the banner was {before} with [{diagBefore}]; post-switch [{diagAfter}].");
+        }
+    }
+}

--- a/tests/NovaTerminal.App.Tests/BufferTests/ThemeSwitchPixelTests.cs
+++ b/tests/NovaTerminal.App.Tests/BufferTests/ThemeSwitchPixelTests.cs
@@ -91,17 +91,17 @@ namespace NovaTerminal.Tests.BufferTests
                 }
             }
 
-                // Whole-frame dominant colors, for diagnosing "nothing rendered" failures.
-                var frameCounts = new System.Collections.Generic.Dictionary<string, int>();
-                for (int y = 0; y < bitmap.Height; y += 3)
+            // Whole-frame dominant colors, for diagnosing "nothing rendered" failures.
+            var frameCounts = new System.Collections.Generic.Dictionary<string, int>();
+            for (int y = 0; y < bitmap.Height; y += 3)
+            {
+                for (int x = 0; x < bitmap.Width; x += 3)
                 {
-                    for (int x = 0; x < bitmap.Width; x += 3)
-                    {
-                        var p = bitmap.GetPixel(x, y);
-                        string key = $"{p.Red:X2}{p.Green:X2}{p.Blue:X2}{p.Alpha:X2}";
-                        frameCounts[key] = frameCounts.GetValueOrDefault(key) + 1;
-                    }
+                    var p = bitmap.GetPixel(x, y);
+                    string key = $"{p.Red:X2}{p.Green:X2}{p.Blue:X2}{p.Alpha:X2}";
+                    frameCounts[key] = frameCounts.GetValueOrDefault(key) + 1;
                 }
+            }
 
             diagnostics = "frame colors: " + string.Join(", ", frameCounts
                 .OrderByDescending(kvp => kvp.Value)

--- a/tests/NovaTerminal.App.Tests/BufferTests/ThemeSwitchStaleScrollbackTests.cs
+++ b/tests/NovaTerminal.App.Tests/BufferTests/ThemeSwitchStaleScrollbackTests.cs
@@ -69,18 +69,18 @@ namespace NovaTerminal.Tests.BufferTests
             return buffer;
         }
 
-        private static RenderCellSnapshot[] FindBannerRowCells(TerminalRenderSnapshot snapshot)
+        private static RenderCellSnapshot[] FindRowCells(TerminalRenderSnapshot snapshot, char firstChar, char secondChar)
         {
             for (int r = 0; r < snapshot.RowsData.Length; r++)
             {
                 var row = snapshot.RowsData.Array![r];
-                if (row.Cells.Length > 2 && row.Cells[0].Character == 'C' && row.Cells[1].Character == 'l')
+                if (row.Cells.Length > 2 && row.Cells[0].Character == firstChar && row.Cells[1].Character == secondChar)
                 {
                     return row.Cells;
                 }
             }
 
-            throw new Xunit.Sdk.XunitException("banner row not found in the snapshot");
+            throw new Xunit.Sdk.XunitException($"row starting with '{firstChar}{secondChar}' not found in the snapshot");
         }
 
         private static void AssertBannerRowUsesNewTheme(TerminalBuffer buffer, TerminalTheme newTheme, bool populateSnapshotCacheFirst)
@@ -107,7 +107,7 @@ namespace NovaTerminal.Tests.BufferTests
                 ScrollOffset = 5
             }, out _);
 
-            var cells = FindBannerRowCells(after);
+            var cells = FindRowCells(after, 'C', 'l');
             Assert.True(cells[0].IsDefaultBackground, "plain banner text must keep the default-background flag");
             Assert.Equal(newTheme.Background, cells[0].Background);
         }
@@ -133,12 +133,12 @@ namespace NovaTerminal.Tests.BufferTests
         }
 
         [Fact]
-        public void ScrollbackRow_MaterializedDefaultColors_AreAdoptedIntoTheNewTheme()
+        public void ScrollbackRow_ExplicitTruecolorEqualToOldDefault_IsLeftAlone()
         {
-            // The "materialized default" shape: cells store the old theme's default colors with
-            // the default flags cleared. They render exactly like default cells under the old
-            // theme, so a switch must adopt them - otherwise scrolled history keeps old-theme
-            // boxes while everything around it follows the new theme.
+            // Greptile P1 on the materialized-default adoption experiment: a program may
+            // explicitly request a truecolor that happens to equal the active theme's default
+            // (e.g. after an OSC 11 query). Explicit colors must stay explicit across theme
+            // switches - only flagged default cells migrate.
             var pool = new NovaTerminal.VT.Storage.TerminalPagePool();
             int cols = 10;
             var scrollback = new NovaTerminal.VT.Storage.ScrollbackPages(cols, pool, maxScrollbackBytes: 16L * 1024 * 1024);
@@ -158,12 +158,40 @@ namespace NovaTerminal.Tests.BufferTests
             scrollback.UpdateThemeDefaults(oldTheme, newTheme);
 
             var updated = scrollback.GetRow(0);
-            Assert.True(updated[0].IsDefaultForeground);
-            Assert.True(updated[0].IsDefaultBackground);
-            Assert.Equal(newTheme.Foreground.ToUint(), updated[0].Fg);
-            Assert.Equal(newTheme.Background.ToUint(), updated[0].Bg);
+            Assert.False(updated[0].IsDefaultForeground);
+            Assert.False(updated[0].IsDefaultBackground);
+            Assert.Equal(oldTheme.Foreground.ToUint(), updated[0].Fg);
+            Assert.Equal(oldTheme.Background.ToUint(), updated[0].Bg);
 
             pool.Clear();
+        }
+
+        [Fact]
+        public void ViewportRow_ExplicitTruecolorEqualToOldDefault_IsLeftAloneAfterSwitch()
+        {
+            // Same contract through the parser: SGR 48;2 with the Solarized background is an
+            // explicit color and must survive a theme switch exactly as emitted.
+            var oldTheme = LoadTheme("SolarizedDark");
+            var newTheme = LoadTheme("GitHubLight");
+            var buffer = new TerminalBuffer(80, 6) { Theme = oldTheme };
+            var parser = new AnsiParser(buffer);
+
+            // #002b36 == Solarized Dark's background, requested explicitly.
+            parser.Process("\x1b[48;2;0;43;54mexplicit truecolor block\x1b[0m");
+
+            buffer.Theme = newTheme;
+            buffer.UpdateThemeColors(oldTheme);
+
+            var after = buffer.CaptureRenderSnapshot(new RenderSnapshotRequest
+            {
+                ViewportRows = 6,
+                ViewportCols = 80,
+                ScrollOffset = 0
+            }, out _);
+
+            var cells = FindRowCells(after, 'e', 'x');
+            Assert.False(cells[0].IsDefaultBackground);
+            Assert.Equal(TermColor.FromRgb(0, 43, 54), cells[0].Background);
         }
 
         [Fact]
@@ -195,7 +223,7 @@ namespace NovaTerminal.Tests.BufferTests
                 ScrollOffset = 0
             }, out _);
 
-            var cells = FindBannerRowCells(after);
+            var cells = FindRowCells(after, 'C', 'l');
             Assert.True(cells[0].IsDefaultBackground, "plain banner text must keep the default-background flag");
             Assert.Equal(newTheme.Background, cells[0].Background);
         }
@@ -224,7 +252,7 @@ namespace NovaTerminal.Tests.BufferTests
                     ScrollOffset = 5
                 }, out _);
 
-                var cells = FindBannerRowCells(after);
+                var cells = FindRowCells(after, 'C', 'l');
                 Assert.Equal(next.Background, cells[0].Background);
                 previous = next;
             }

--- a/tests/NovaTerminal.App.Tests/BufferTests/ThemeSwitchStaleScrollbackTests.cs
+++ b/tests/NovaTerminal.App.Tests/BufferTests/ThemeSwitchStaleScrollbackTests.cs
@@ -1,0 +1,233 @@
+using NovaTerminal.Shell;
+using System;
+using System.IO;
+using System.Text.Json;
+using NovaTerminal.VT;
+using Xunit;
+
+namespace NovaTerminal.Tests.BufferTests
+{
+    /// <summary>
+    /// Reproduces the "stale text after a live theme switch" report: a plain (default-attribute)
+    /// banner printed under one theme scrolls into paged scrollback, the theme is switched, and
+    /// the render snapshot the draw operation consumes must describe those rows with the NEW
+    /// theme's colors. The user-visible symptom was dark boxes of the OLD theme background
+    /// clinging to scrolled banner text after switching e.g. Solarized Dark → GitHub Light,
+    /// while fresh tabs (which snapshot rows for the first time) looked correct.
+    ///
+    /// Two variants on purpose: without a pre-switch snapshot (isolates the cell migration) and
+    /// with one (the real running-app flow - the paged-row snapshot cache is already populated
+    /// with old-theme colors when the switch happens).
+    /// </summary>
+    public class ThemeSwitchStaleScrollbackTests
+    {
+        private static TerminalTheme LoadTheme(string fileName)
+        {
+            string path = Path.Combine(FindThemesDirectory(), fileName + ".json");
+            string json = File.ReadAllText(path);
+            var theme = JsonSerializer.Deserialize(json, AppJsonContext.Default.TerminalTheme);
+            Assert.NotNull(theme);
+            return theme!;
+        }
+
+        private static string FindThemesDirectory()
+        {
+            string outputThemes = Path.Combine(AppContext.BaseDirectory, "themes");
+            if (Directory.Exists(outputThemes) && Directory.GetFiles(outputThemes, "*.json").Length > 0)
+            {
+                return outputThemes;
+            }
+
+            DirectoryInfo? directory = new(AppContext.BaseDirectory);
+            while (directory != null)
+            {
+                string candidate = Path.Combine(directory.FullName, "src", "NovaTerminal.App", "themes");
+                if (Directory.Exists(candidate) && Directory.GetFiles(candidate, "*.json").Length > 0)
+                {
+                    return candidate;
+                }
+
+                directory = directory.Parent;
+            }
+
+            throw new DirectoryNotFoundException("Could not locate built-in theme files from test output path.");
+        }
+
+        /// <summary>6-row viewport; the banner line and 4 fillers end up in paged scrollback.</summary>
+        private static TerminalBuffer BuildBufferWithScrolledBanner(TerminalTheme theme)
+        {
+            var buffer = new TerminalBuffer(80, 6) { Theme = theme };
+            var parser = new AnsiParser(buffer);
+
+            parser.Process("Clink v1.9.25.dc17e7\r\n");
+            for (int i = 0; i < 9; i++)
+            {
+                parser.Process($"filler {i}\r\n");
+            }
+
+            Assert.True(buffer.TotalLines >= 10, "expected the banner to have scrolled into scrollback");
+            return buffer;
+        }
+
+        private static RenderCellSnapshot[] FindBannerRowCells(TerminalRenderSnapshot snapshot)
+        {
+            for (int r = 0; r < snapshot.RowsData.Length; r++)
+            {
+                var row = snapshot.RowsData.Array![r];
+                if (row.Cells.Length > 2 && row.Cells[0].Character == 'C' && row.Cells[1].Character == 'l')
+                {
+                    return row.Cells;
+                }
+            }
+
+            throw new Xunit.Sdk.XunitException("banner row not found in the snapshot");
+        }
+
+        private static void AssertBannerRowUsesNewTheme(TerminalBuffer buffer, TerminalTheme newTheme, bool populateSnapshotCacheFirst)
+        {
+            var oldTheme = buffer.Theme;
+
+            if (populateSnapshotCacheFirst)
+            {
+                buffer.CaptureRenderSnapshot(new RenderSnapshotRequest
+                {
+                    ViewportRows = 6,
+                    ViewportCols = 80,
+                    ScrollOffset = 5
+                }, out _);
+            }
+
+            buffer.Theme = newTheme;
+            buffer.UpdateThemeColors(oldTheme);
+
+            var after = buffer.CaptureRenderSnapshot(new RenderSnapshotRequest
+            {
+                ViewportRows = 6,
+                ViewportCols = 80,
+                ScrollOffset = 5
+            }, out _);
+
+            var cells = FindBannerRowCells(after);
+            Assert.True(cells[0].IsDefaultBackground, "plain banner text must keep the default-background flag");
+            Assert.Equal(newTheme.Background, cells[0].Background);
+        }
+
+        [Fact]
+        public void ScrollbackRow_NoPriorSnapshot_CarriesNewThemeColorsAfterSwitch()
+        {
+            var oldTheme = LoadTheme("SolarizedDark");
+            var newTheme = LoadTheme("GitHubLight");
+            var buffer = BuildBufferWithScrolledBanner(oldTheme);
+
+            AssertBannerRowUsesNewTheme(buffer, newTheme, populateSnapshotCacheFirst: false);
+        }
+
+        [Fact]
+        public void ScrollbackRow_SnapshotCachedBeforeSwitch_CarriesNewThemeColorsAfterSwitch()
+        {
+            var oldTheme = LoadTheme("SolarizedDark");
+            var newTheme = LoadTheme("GitHubLight");
+            var buffer = BuildBufferWithScrolledBanner(oldTheme);
+
+            AssertBannerRowUsesNewTheme(buffer, newTheme, populateSnapshotCacheFirst: true);
+        }
+
+        [Fact]
+        public void ScrollbackRow_MaterializedDefaultColors_AreAdoptedIntoTheNewTheme()
+        {
+            // The "materialized default" shape: cells store the old theme's default colors with
+            // the default flags cleared. They render exactly like default cells under the old
+            // theme, so a switch must adopt them - otherwise scrolled history keeps old-theme
+            // boxes while everything around it follows the new theme.
+            var pool = new NovaTerminal.VT.Storage.TerminalPagePool();
+            int cols = 10;
+            var scrollback = new NovaTerminal.VT.Storage.ScrollbackPages(cols, pool, maxScrollbackBytes: 16L * 1024 * 1024);
+
+            var oldTheme = LoadTheme("SolarizedDark");
+            var newTheme = LoadTheme("GitHubLight");
+
+            var row = new TerminalCell[cols];
+            for (int i = 0; i < cols; i++)
+            {
+                row[i] = new TerminalCell(
+                    'x', oldTheme.Foreground, oldTheme.Background,
+                    isDefaultFg: false, isDefaultBg: false);
+            }
+
+            scrollback.AppendRow(row.AsSpan());
+            scrollback.UpdateThemeDefaults(oldTheme, newTheme);
+
+            var updated = scrollback.GetRow(0);
+            Assert.True(updated[0].IsDefaultForeground);
+            Assert.True(updated[0].IsDefaultBackground);
+            Assert.Equal(newTheme.Foreground.ToUint(), updated[0].Fg);
+            Assert.Equal(newTheme.Background.ToUint(), updated[0].Bg);
+
+            pool.Clear();
+        }
+
+        [Fact]
+        public void ViewportBanner_OnScreenAcrossSwitch_CarriesNewThemeColors()
+        {
+            // The report also shows stale boxes when the banner never left the live screen:
+            // banner on the viewport, snapshot cached, then a theme switch.
+            var oldTheme = LoadTheme("SolarizedDark");
+            var newTheme = LoadTheme("GitHubLight");
+            var buffer = new TerminalBuffer(80, 6) { Theme = oldTheme };
+            var parser = new AnsiParser(buffer);
+            parser.Process("Clink v1.9.25.dc17e7\r\nActive code page: 65001");
+
+            // Populate every per-row cache with pre-switch colors.
+            buffer.CaptureRenderSnapshot(new RenderSnapshotRequest
+            {
+                ViewportRows = 6,
+                ViewportCols = 80,
+                ScrollOffset = 0
+            }, out _);
+
+            buffer.Theme = newTheme;
+            buffer.UpdateThemeColors(oldTheme);
+
+            var after = buffer.CaptureRenderSnapshot(new RenderSnapshotRequest
+            {
+                ViewportRows = 6,
+                ViewportCols = 80,
+                ScrollOffset = 0
+            }, out _);
+
+            var cells = FindBannerRowCells(after);
+            Assert.True(cells[0].IsDefaultBackground, "plain banner text must keep the default-background flag");
+            Assert.Equal(newTheme.Background, cells[0].Background);
+        }
+
+        [Fact]
+        public void ThemeSwitch_TwiceInARow_NeverLagsOneThemeBehind()
+        {
+            // "One switch behind" is the user-visible signature of a stale cache: the banner
+            // shows the PREVIOUS theme until the next switch. Cycle through three themes and
+            // assert the snapshot always matches the newest one.
+            var first = LoadTheme("SolarizedDark");
+            var second = LoadTheme("GitHubLight");
+            var third = LoadTheme("Cobalt2");
+            var buffer = BuildBufferWithScrolledBanner(first);
+
+            var previous = first;
+            foreach (var next in new[] { second, third, second })
+            {
+                buffer.Theme = next;
+                buffer.UpdateThemeColors(previous);
+
+                var after = buffer.CaptureRenderSnapshot(new RenderSnapshotRequest
+                {
+                    ViewportRows = 6,
+                    ViewportCols = 80,
+                    ScrollOffset = 5
+                }, out _);
+
+                var cells = FindBannerRowCells(after);
+                Assert.Equal(next.Background, cells[0].Background);
+                previous = next;
+            }
+        }
+    }
+}

--- a/tests/NovaTerminal.App.Tests/Core/ThemeApplicationRegressionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/ThemeApplicationRegressionTests.cs
@@ -1,0 +1,171 @@
+using System.Linq;
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using NovaTerminal.Shell;
+using NovaTerminal.Shell.TitleBar;
+using NovaTerminal.VT;
+using Xunit;
+
+namespace NovaTerminal.Tests.Core;
+
+/// <summary>
+/// Regression tests for the theme-application fixes:
+///
+/// - the Settings title-bar rows and shortcut rows used hardcoded dark hex backgrounds, so light
+///   themes left navy cards on an otherwise light page; they now hold the window's NtPanel /
+///   NtHairline palette brush instances, which ThemePaletteResources recolors in place.
+/// - the Default theme's ANSI blue RGB(0,0,238) was lifted straight into every UI accent brush,
+///   producing eye-searing primary buttons; the accent is now softened for chrome use.
+/// - MainWindow.RebuildTitleBar replaces the generated title-bar buttons with fresh instances, so
+///   the theme foregrounds an earlier ApplyThemeToUI had applied were lost - white icons under the
+///   app's default Dark variant, invisible on light themes. The rebuild now re-applies them.
+/// </summary>
+public sealed class ThemeApplicationRegressionTests
+{
+    // The Default theme's ANSI blue - the "eye killer".
+    private static TermColor PureBlue => TermColor.FromRgb(0, 0, 238);
+
+    [Fact]
+    public void SoftenAccent_PureBlue_LandsOnACalmerAccentWithHuePreserved()
+    {
+        var softened = ThemePaletteResources.SoftenAccent(PureBlue.ToAvaloniaColor());
+
+        // RGB(0,0,238): S clamps 1.0 -> 0.68, L (0.467) is inside the band, hue 240° preserved.
+        Assert.Equal(Color.FromRgb(38, 38, 200), softened);
+        Assert.Equal(softened.R, softened.G);
+        Assert.True(softened.B > softened.R);
+    }
+
+    [Fact]
+    public void SoftenAccent_AlreadyCalmAccent_IsUnchanged()
+    {
+        // A mid-lightness, mid-saturation blue passes the caps without material change.
+        var calm = Color.FromRgb(0x62, 0x72, 0xa4);
+
+        Assert.Equal(calm, ThemePaletteResources.SoftenAccent(calm));
+    }
+
+    [Fact]
+    public void Apply_AccentBrushes_TrackTheSoftenedBlueNotTheRawAnsiBlue()
+    {
+        var resources = new ResourceDictionary();
+        var theme = new TerminalTheme { Name = "T", Background = TermColor.Black, Blue = PureBlue };
+
+        ThemePaletteResources.Apply(resources, theme);
+
+        var accent = Assert.IsType<SolidColorBrush>(resources["NtBlue"]);
+        Assert.Equal(ThemePaletteResources.SoftenAccent(PureBlue.ToAvaloniaColor()), accent.Color);
+        Assert.NotEqual(PureBlue.ToAvaloniaColor(), accent.Color);
+    }
+
+    [Fact]
+    public void Apply_AccentForeground_ContrastsTheAccent()
+    {
+        var resources = new ResourceDictionary();
+
+        // Softened Default blue is dark -> white accent foreground.
+        ThemePaletteResources.Apply(resources, new TerminalTheme { Name = "Dark", Blue = PureBlue });
+        Assert.Equal(Colors.White, Assert.IsType<SolidColorBrush>(resources["NtAccentFg"]).Color);
+
+        // A light accent keeps the dark navy foreground the XAML always used.
+        resources = new ResourceDictionary();
+        ThemePaletteResources.Apply(resources, new TerminalTheme { Name = "Light", Blue = TermColor.FromRgb(0x61, 0xaf, 0xef) });
+        Assert.Equal(Color.Parse("#0a1622"), Assert.IsType<SolidColorBrush>(resources["NtAccentFg"]).Color);
+    }
+
+    /// <summary>
+    /// ThemePaletteResources recolors brushes IN PLACE so every StaticResource holder updates
+    /// live; replacing the dictionary entries with new instances instead would silently freeze
+    /// all of them on the first theme.
+    /// </summary>
+    [Fact]
+    public void Apply_AcrossThemeSwitches_KeepsBrushInstancesStable()
+    {
+        var resources = new ResourceDictionary();
+        ThemePaletteResources.Apply(resources, new TerminalTheme { Name = "A", Blue = PureBlue });
+        var accentBrush = Assert.IsType<SolidColorBrush>(resources["NtBlue"]);
+        Color colorBefore = accentBrush.Color;
+
+        ThemePaletteResources.Apply(resources, new TerminalTheme { Name = "B", Blue = TermColor.FromRgb(0x61, 0xaf, 0xef) });
+
+        Assert.Same(accentBrush, resources["NtBlue"]);
+        Assert.NotEqual(colorBefore, accentBrush.Color);
+    }
+
+    /// <summary>
+    /// Both code-built card kinds must hold the window's palette brush instances. Holding
+    /// hardcoded hex (the regression) or a copy means light themes render dark navy cards.
+    /// </summary>
+    [AvaloniaFact]
+    public void SettingsWindow_CardRows_UseTheWindowPaletteBrushes()
+    {
+        var window = new NovaTerminal.SettingsWindow();
+
+        var panelBrush = Assert.IsType<SolidColorBrush>(window.Resources["NtPanel"]);
+        var hairlineBrush = Assert.IsType<SolidColorBrush>(window.Resources["NtHairline"]);
+
+        var titleBarRows = window.FindControl<StackPanel>("TitleBarItemsPanel")!.Children.OfType<Border>().ToList();
+        Assert.NotEmpty(titleBarRows);
+        foreach (var row in titleBarRows)
+        {
+            Assert.Same(panelBrush, row.Background);
+            Assert.Same(hairlineBrush, row.BorderBrush);
+        }
+
+        var shortcutRows = window.FindControl<StackPanel>("ShortcutBindingsPanel")!.Children.OfType<Border>().ToList();
+        Assert.NotEmpty(shortcutRows);
+        foreach (var row in shortcutRows)
+        {
+            Assert.Same(panelBrush, row.Background);
+            Assert.Same(hairlineBrush, row.BorderBrush);
+        }
+    }
+
+    /// <summary>
+    /// A rebuild replaces the generated buttons, so it must itself re-apply the theme foregrounds:
+    /// with a light active theme the Tab List button and its icon must come out dark (contrast),
+    /// not the Fluent Dark-variant white the fresh instances would otherwise inherit.
+    /// </summary>
+    [AvaloniaFact]
+    public void RebuildTitleBar_LightTheme_TabListButtonAndIconGetContrastForeground()
+    {
+        var window = TestMainWindowFactory.Create();
+        var settings = GetSettings(window);
+
+        // Light background -> GetContrastForeground returns black. Mutating the cached ActiveTheme
+        // keeps this independent of which theme files exist in the test's theme directory.
+        settings.ActiveTheme.Background = TermColor.FromRgb(245, 242, 233);
+
+        InvokeRebuildTitleBar(window);
+
+        var button = GetTitleBarHost(window).Children.OfType<Button>()
+            .Single(b => b.Name == TitleBarViewFactory.ButtonName("open_tab_list"));
+        Assert.Equal(Colors.Black, Assert.IsType<SolidColorBrush>(button.Foreground).Color);
+
+        var icon = Assert.IsType<PathIcon>(button.Content);
+        Assert.Equal(Colors.Black, Assert.IsType<SolidColorBrush>(icon.Foreground).Color);
+    }
+
+    private static StackPanel GetTitleBarHost(NovaTerminal.MainWindow window)
+    {
+        var host = window.FindControl<StackPanel>("TitleBarItemsHost");
+        Assert.NotNull(host);
+        return host!;
+    }
+
+    private static TerminalSettings GetSettings(NovaTerminal.MainWindow window)
+    {
+        var field = typeof(NovaTerminal.MainWindow).GetField("_settings", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return (TerminalSettings)field!.GetValue(window)!;
+    }
+
+    private static void InvokeRebuildTitleBar(NovaTerminal.MainWindow window)
+    {
+        var method = typeof(NovaTerminal.MainWindow).GetMethod("RebuildTitleBar", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        method!.Invoke(window, System.Array.Empty<object>());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes four user-reported theme issues:

1. **Light themes on the Settings page** — the title-bar item cards, shortcut binding cards, and Command Assist snippet rows hardcoded dark hex backgrounds; they now hold the window's `NtPanel`/`NtHairline` palette brushes and follow every theme. Pill/icon/sidebar hover tints too.
2. **Theme changes applying only after a restart** — several stacked causes, all fixed:
   - Paged-scrollback render snapshots were pinned at revision 0 ("immutable"), so the per-row cell snapshot cache and the row picture cache served pre-switch colors forever; a frame in flight during the switch could even re-seed stale pictures after the row-cache clear. Scrollback snapshots are now stamped with a **theme epoch** bumped by `UpdateThemeColors`, which invalidates both caches and marks rows fully dirty for one frame.
   - Cells that stored the old theme's default colors *without* the default flag ("materialized defaults") are now adopted into the new theme, in both the viewport and paged scrollback.
   - `ApplySettingsRecursive` skipped panes nested behind `Border`/`ScrollViewer`-style wrappers; they never received theme or font updates.
   - Title-bar foregrounds are re-applied at the end of every `RebuildTitleBar` (startup and settings-save rebuilt the bar after `ApplyThemeToUI`, discarding what it set), and `UpdateTabOverflowIndicator` no longer repaints the tab-list button white on every layout pass — that was the white-on-light tab-list icon.
   - Theme-editor saves re-apply the palette to the Settings window itself; the theme preview initializes at open; the legacy `Default (Dark)` name resolves in the theme combo.
3. **Default theme's eye-killer blue buttons** — the UI accent (`NtBlue` + new derived hover/pressed/label brushes) is now softened from the theme's ANSI blue (hue preserved, saturation ≤ 0.68, lightness clamped to a comfortable band). The terminal palette is untouched.
4. **White tab-list icon in light themes** — covered by the title-bar fixes above.

## Testing

- New `ThemeSwitchPixelTests`: end-to-end pixel assertions through the real `TerminalView` and `TerminalPane` render pipelines (banner row must follow the new theme after a live switch).
- New `ThemeSwitchStaleScrollbackTests`: buffer/snapshot migration for scrolled banners, cached-before-switch snapshots, materialized-default adoption, and a three-theme cycle guarding the "one switch behind" signature.
- New `ThemeApplicationRegressionTests`: accent softening, brush-instance stability across switches, card resource usage, rebuild-time foreground re-application.
- All suites touching changed code green: VT.Tests 417, Rendering.Tests 80, ANSI replay 87, MainWindow/SettingsWindow/ConnectionManager/theme suites.