### PR TITLE
fix(theme): adopt OSC 11 paint-to-match cells on theme switch

### DIFF
--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -1619,6 +1619,11 @@ namespace NovaTerminal.VT
         {
             _buffer.CurrentForeground = _buffer.Theme.Foreground;
             _buffer.CurrentBackground = _buffer.Theme.Background;
+            // The CurrentForeground/Background setters clear the default flags; re-assert them
+            // so output after a reset keeps following theme switches instead of materializing
+            // the default colors as explicit ones.
+            _buffer.IsDefaultForeground = true;
+            _buffer.IsDefaultBackground = true;
             _buffer.CurrentFgIndex = -1;
             _buffer.CurrentBgIndex = -1;
             _buffer.IsInverse = false;

--- a/src/NovaTerminal.VT/Buffer/ScrollbackPages.cs
+++ b/src/NovaTerminal.VT/Buffer/ScrollbackPages.cs
@@ -362,16 +362,20 @@ namespace NovaTerminal.VT.Storage
         /// <summary>
         /// Updates the default foreground and background colors for all cells currently retained.
         /// This is allowed to be a slower full-scan because theme changes are infrequent.
-        /// Explicit colors (including truecolors that happen to equal the old default) are left
-        /// alone - only flagged default cells migrate.
+        /// Cells whose stored color equals the OLD theme's default but which lack the default
+        /// flag are adopted into the new theme too - shells and CLIs paint prompt/status regions
+        /// with the OSC 11 answered background, and those regions must keep matching the
+        /// terminal after a switch instead of rendering as old-theme boxes.
         /// </summary>
         public void UpdateThemeDefaults(TerminalTheme oldTheme, TerminalTheme newTheme)
         {
             uint fgUint = newTheme.Foreground.ToUint();
             uint bgUint = newTheme.Background.ToUint();
+            uint oldFgUint = oldTheme.Foreground.ToUint();
+            uint oldBgUint = oldTheme.Background.ToUint();
             foreach (var page in _pages)
             {
-                page.UpdateThemeDefaults(fgUint, bgUint);
+                page.UpdateThemeDefaults(fgUint, bgUint, oldFgUint, oldBgUint);
             }
         }
 

--- a/src/NovaTerminal.VT/Buffer/TerminalPage.cs
+++ b/src/NovaTerminal.VT/Buffer/TerminalPage.cs
@@ -215,21 +215,26 @@ namespace NovaTerminal.VT.Storage
 
         /// <summary>
         /// Updates cells that rely on default foreground or background colors to a new theme.
-        /// Explicit colors are left untouched, even when they equal the old default. This is an
-        /// O(n) operation over all used cells, invoked rarely during a theme change.
+        /// Also adopts cells whose stored color equals the OLD theme's default but which lack
+        /// the default flag - shells and CLIs paint prompt/status regions with the OSC 11
+        /// answered background, and after a theme switch those regions must keep matching the
+        /// terminal rather than render as old-theme boxes. This is an O(n) operation over all
+        /// used cells, invoked rarely during a theme change.
         /// </summary>
-        public void UpdateThemeDefaults(uint newFg, uint newBg)
+        public void UpdateThemeDefaults(uint newFg, uint newBg, uint oldFg = 0xFFFFFFFF, uint oldBg = 0xFFFFFFFF)
         {
             var span = Cells.AsSpan(0, UsedRows * Cols);
             for (int i = 0; i < span.Length; i++)
             {
-                if (span[i].IsDefaultForeground)
+                if (span[i].IsDefaultForeground || span[i].Fg == oldFg)
                 {
                     span[i].Fg = newFg;
+                    span[i].IsDefaultForeground = true;
                 }
-                if (span[i].IsDefaultBackground)
+                if (span[i].IsDefaultBackground || span[i].Bg == oldBg)
                 {
                     span[i].Bg = newBg;
+                    span[i].IsDefaultBackground = true;
                 }
             }
         }

--- a/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
@@ -294,15 +294,27 @@ namespace NovaTerminal.VT
             IsHidden = false;
         }
 
-        private void SyncThemeDefaultsInCursorStateNoLock(CursorState state)
+        private void SyncThemeDefaultsInCursorStateNoLock(CursorState state, TermColor oldForeground, TermColor oldBackground)
         {
             if (state.IsDefaultForeground)
             {
                 state.Foreground = Theme.Foreground;
             }
+            else if (state.FgIndex < 0 && state.Foreground == oldForeground)
+            {
+                // OSC 11 paint-to-match adoption (same rationale as UpdateCell): a saved SGR
+                // state holding the answered old background must not restore stale colors.
+                state.IsDefaultForeground = true;
+                state.Foreground = Theme.Foreground;
+            }
 
             if (state.IsDefaultBackground)
             {
+                state.Background = Theme.Background;
+            }
+            else if (state.BgIndex < 0 && state.Background == oldBackground)
+            {
+                state.IsDefaultBackground = true;
                 state.Background = Theme.Background;
             }
         }

--- a/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
@@ -350,13 +350,39 @@ namespace NovaTerminal.VT
                 // so a snapshot captured after this call always observes the new epoch.
                 _renderThemeEpoch++;
 
-                // Sync current buffer defaults to new theme
-                if (IsDefaultForeground) CurrentForeground = Theme.Foreground;
-                if (IsDefaultBackground) CurrentBackground = Theme.Background;
-                SyncThemeDefaultsInCursorStateNoLock(_savedCursors.Main);
-                SyncThemeDefaultsInCursorStateNoLock(_savedCursors.Alt);
-                SyncThemeDefaultsInCursorStateNoLock(_screenCursorStates.Main);
-                SyncThemeDefaultsInCursorStateNoLock(_screenCursorStates.Alt);
+                // Sync current buffer defaults to new theme. The CurrentForeground/Background
+                // SETTERS clear the default flag as a side effect, so the flag is re-asserted
+                // AFTER each assignment - otherwise the first theme switch silently demotes the
+                // live SGR state to explicit colors and every cell written afterwards stops
+                // following later theme switches. The paint-to-match adoption also covers the
+                // live SGR state: a shell that queried OSC 11 and kept the answered background
+                // active across the switch must not re-materialize the old color on its next
+                // write.
+                if (IsDefaultForeground)
+                {
+                    CurrentForeground = Theme.Foreground;
+                    IsDefaultForeground = true;
+                }
+                if (IsDefaultBackground)
+                {
+                    CurrentBackground = Theme.Background;
+                    IsDefaultBackground = true;
+                }
+                if (!IsDefaultForeground && CurrentFgIndex < 0 && CurrentForeground == oldTheme.Foreground)
+                {
+                    CurrentForeground = Theme.Foreground;
+                    IsDefaultForeground = true;
+                }
+                if (!IsDefaultBackground && CurrentBgIndex < 0 && CurrentBackground == oldTheme.Background)
+                {
+                    CurrentBackground = Theme.Background;
+                    IsDefaultBackground = true;
+                }
+
+                SyncThemeDefaultsInCursorStateNoLock(_savedCursors.Main, oldTheme.Foreground, oldTheme.Background);
+                SyncThemeDefaultsInCursorStateNoLock(_savedCursors.Alt, oldTheme.Foreground, oldTheme.Background);
+                SyncThemeDefaultsInCursorStateNoLock(_screenCursorStates.Main, oldTheme.Foreground, oldTheme.Background);
+                SyncThemeDefaultsInCursorStateNoLock(_screenCursorStates.Alt, oldTheme.Foreground, oldTheme.Background);
 
                 // Materialized/paint-to-match adoption: shells and CLIs query OSC 11 and then
                 // explicitly paint their prompt/status regions with the ANSWERED terminal

--- a/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.Maintenance.cs
@@ -358,11 +358,15 @@ namespace NovaTerminal.VT
                 SyncThemeDefaultsInCursorStateNoLock(_screenCursorStates.Main);
                 SyncThemeDefaultsInCursorStateNoLock(_screenCursorStates.Alt);
 
-                // NOTE: deliberately no value-based adoption here. Rewriting cells whose color
-                // happens to equal the old default would also capture explicitly-requested
-                // truecolors (programs query OSC 11 and paint to match the terminal), silently
-                // converting them to theme-following defaults. Explicit stays explicit; only
-                // flagged default cells migrate.
+                // Materialized/paint-to-match adoption: shells and CLIs query OSC 11 and then
+                // explicitly paint their prompt/status regions with the ANSWERED terminal
+                // background. Those cells carry a truecolor equal to the old default with the
+                // default flag cleared, so flag-based migration skips them and they render as
+                // old-theme boxes after a switch. A program that painted to match the old
+                // terminal wants to keep matching the terminal - adopt it into the new default.
+                uint oldForegroundUint = oldTheme.Foreground.ToUint();
+                uint oldBackgroundUint = oldTheme.Background.ToUint();
+
                 void UpdateCell(ref TerminalCell cell)
                 {
                     // Preserve palette/default flags across theme switches.
@@ -383,6 +387,11 @@ namespace NovaTerminal.VT
                         cell.IsDefaultForeground = true;
                         cell.Fg = Theme.Foreground.ToUint();
                     }
+                    else if (fgIdx < 0 && cell.Fg == oldForegroundUint)
+                    {
+                        cell.IsDefaultForeground = true;
+                        cell.Fg = Theme.Foreground.ToUint();
+                    }
 
                     if (bgIdx >= 0 && bgIdx <= 15)
                     {
@@ -393,6 +402,11 @@ namespace NovaTerminal.VT
                     else if (cell.IsDefaultBackground)
                     {
                         cell.IsPaletteBackground = false;
+                        cell.IsDefaultBackground = true;
+                        cell.Bg = Theme.Background.ToUint();
+                    }
+                    else if (bgIdx < 0 && cell.Bg == oldBackgroundUint)
+                    {
                         cell.IsDefaultBackground = true;
                         cell.Bg = Theme.Background.ToUint();
                     }

--- a/tests/NovaTerminal.App.Tests/BufferTests/ThemeSwitchStaleScrollbackTests.cs
+++ b/tests/NovaTerminal.App.Tests/BufferTests/ThemeSwitchStaleScrollbackTests.cs
@@ -71,6 +71,7 @@ namespace NovaTerminal.Tests.BufferTests
 
         private static RenderCellSnapshot[] FindRowCells(TerminalRenderSnapshot snapshot, char firstChar, char secondChar)
         {
+            var dump = new System.Text.StringBuilder();
             for (int r = 0; r < snapshot.RowsData.Length; r++)
             {
                 var row = snapshot.RowsData.Array![r];
@@ -78,9 +79,18 @@ namespace NovaTerminal.Tests.BufferTests
                 {
                     return row.Cells;
                 }
+
+                dump.Append($" row{r}='");
+                for (int c = 0; c < Math.Min(12, row.Cells.Length); c++)
+                {
+                    dump.Append(row.Cells[c].Character == '\0' ? '~' : row.Cells[c].Character);
+                }
+
+                dump.Append('\'');
             }
 
-            throw new Xunit.Sdk.XunitException($"row starting with '{firstChar}{secondChar}' not found in the snapshot");
+            throw new Xunit.Sdk.XunitException(
+                $"row starting with '{firstChar}{secondChar}' not found in the snapshot.{dump}");
         }
 
         private static void AssertBannerRowUsesNewTheme(TerminalBuffer buffer, TerminalTheme newTheme, bool populateSnapshotCacheFirst)
@@ -227,6 +237,71 @@ namespace NovaTerminal.Tests.BufferTests
 
             var cells = FindRowCells(after, 'P', 'S');
             Assert.True(cells[0].IsDefaultBackground, "paint-to-match cells must be adopted as default background");
+            Assert.Equal(newTheme.Background, cells[0].Background);
+        }
+
+        [Fact]
+        public void ActivePaintToMatchSgr_AcrossSwitch_NextWriteUsesTheNewTheme()
+        {
+            // Greptile P1 on the paint-to-match adoption: a shell that KEEPS the OSC-derived
+            // SGR active across the switch must not re-materialize the old color on its next
+            // write - the live SGR state has to be adopted along with the cells.
+            var oldTheme = LoadTheme("SolarizedDark");
+            var newTheme = LoadTheme("GitHubLight");
+            var buffer = new TerminalBuffer(80, 6) { Theme = oldTheme };
+            var parser = new AnsiParser(buffer);
+
+            parser.Process("\x1b[48;2;0;43;54mPS ");
+
+            buffer.Theme = newTheme;
+            buffer.UpdateThemeColors(oldTheme);
+            parser.Process("C:\\Users\\behna>");
+
+            var after = buffer.CaptureRenderSnapshot(new RenderSnapshotRequest
+            {
+                ViewportRows = 6,
+                ViewportCols = 80,
+                ScrollOffset = 0
+            }, out _);
+
+            var cells = FindRowCells(after, 'P', 'S');
+            for (int i = 0; i < 18; i++)
+            {
+                Assert.True(cells[i].IsDefaultBackground,
+                    $"cell {i} ('{cells[i].Character}') kept a non-default background after the switch");
+                Assert.Equal(newTheme.Background, cells[i].Background);
+            }
+        }
+
+        [Fact]
+        public void SavedCursor_WithPaintToMatchSgr_RestoresAdoptedStateAfterSwitch()
+        {
+            // The same gap for DECSC/DECRC: a saved cursor state holding the OSC-derived
+            // background must restore as the adopted (new default) state, not the old color.
+            // SaveCursor/RestoreCursor are driven directly so the test exercises the state
+            // adoption rather than escape-sequence parsing.
+            var oldTheme = LoadTheme("SolarizedDark");
+            var newTheme = LoadTheme("GitHubLight");
+            var buffer = new TerminalBuffer(80, 6) { Theme = oldTheme };
+            var parser = new AnsiParser(buffer);
+
+            buffer.SaveCursor();
+            parser.Process("\x1b[48;2;0;43;54m");
+
+            buffer.Theme = newTheme;
+            buffer.UpdateThemeColors(oldTheme);
+            buffer.RestoreCursor();
+            parser.Process("restored");
+
+            var after = buffer.CaptureRenderSnapshot(new RenderSnapshotRequest
+            {
+                ViewportRows = 6,
+                ViewportCols = 80,
+                ScrollOffset = 0
+            }, out _);
+
+            var cells = FindRowCells(after, 'r', 'e');
+            Assert.True(cells[0].IsDefaultBackground);
             Assert.Equal(newTheme.Background, cells[0].Background);
         }
 

--- a/tests/NovaTerminal.App.Tests/BufferTests/ThemeSwitchStaleScrollbackTests.cs
+++ b/tests/NovaTerminal.App.Tests/BufferTests/ThemeSwitchStaleScrollbackTests.cs
@@ -133,12 +133,14 @@ namespace NovaTerminal.Tests.BufferTests
         }
 
         [Fact]
-        public void ScrollbackRow_ExplicitTruecolorEqualToOldDefault_IsLeftAlone()
+        public void ScrollbackRow_ExplicitTruecolorEqualToOldDefault_FollowsTheNewTheme()
         {
-            // Greptile P1 on the materialized-default adoption experiment: a program may
-            // explicitly request a truecolor that happens to equal the active theme's default
-            // (e.g. after an OSC 11 query). Explicit colors must stay explicit across theme
-            // switches - only flagged default cells migrate.
+            // Paint-to-match adoption: shells and CLIs query OSC 11 and then explicitly paint
+            // their prompt/status regions with the answered terminal background. Those cells
+            // store a truecolor equal to the old default with the default flags cleared, and
+            // after a theme switch they must keep matching the terminal (adopted into the new
+            // default) instead of rendering as old-theme boxes. Reviewed in PR #388: value
+            // matching is intentional here - see the OSC 11 note in UpdateThemeColors.
             var pool = new NovaTerminal.VT.Storage.TerminalPagePool();
             int cols = 10;
             var scrollback = new NovaTerminal.VT.Storage.ScrollbackPages(cols, pool, maxScrollbackBytes: 16L * 1024 * 1024);
@@ -158,26 +160,60 @@ namespace NovaTerminal.Tests.BufferTests
             scrollback.UpdateThemeDefaults(oldTheme, newTheme);
 
             var updated = scrollback.GetRow(0);
-            Assert.False(updated[0].IsDefaultForeground);
-            Assert.False(updated[0].IsDefaultBackground);
-            Assert.Equal(oldTheme.Foreground.ToUint(), updated[0].Fg);
-            Assert.Equal(oldTheme.Background.ToUint(), updated[0].Bg);
+            Assert.True(updated[0].IsDefaultForeground);
+            Assert.True(updated[0].IsDefaultBackground);
+            Assert.Equal(newTheme.Foreground.ToUint(), updated[0].Fg);
+            Assert.Equal(newTheme.Background.ToUint(), updated[0].Bg);
 
             pool.Clear();
         }
 
         [Fact]
-        public void ViewportRow_ExplicitTruecolorEqualToOldDefault_IsLeftAloneAfterSwitch()
+        public void ScrollbackRow_ExplicitTruecolorDifferentFromOldDefault_IsLeftAlone()
         {
-            // Same contract through the parser: SGR 48;2 with the Solarized background is an
-            // explicit color and must survive a theme switch exactly as emitted.
+            // The adoption must stay value-anchored to the OLD default: genuinely distinct
+            // explicit colors keep their exact color across theme switches.
+            var pool = new NovaTerminal.VT.Storage.TerminalPagePool();
+            int cols = 10;
+            var scrollback = new NovaTerminal.VT.Storage.ScrollbackPages(cols, pool, maxScrollbackBytes: 16L * 1024 * 1024);
+
+            var oldTheme = LoadTheme("SolarizedDark");
+            var newTheme = LoadTheme("GitHubLight");
+
+            var row = new TerminalCell[cols];
+            for (int i = 0; i < cols; i++)
+            {
+                row[i] = new TerminalCell(
+                    'x', TermColor.FromRgb(12, 34, 56), TermColor.FromRgb(200, 100, 50),
+                    isDefaultFg: false, isDefaultBg: false);
+            }
+
+            scrollback.AppendRow(row.AsSpan());
+            scrollback.UpdateThemeDefaults(oldTheme, newTheme);
+
+            var updated = scrollback.GetRow(0);
+            Assert.False(updated[0].IsDefaultForeground);
+            Assert.False(updated[0].IsDefaultBackground);
+            Assert.Equal(TermColor.FromRgb(12, 34, 56).ToUint(), updated[0].Fg);
+            Assert.Equal(TermColor.FromRgb(200, 100, 50).ToUint(), updated[0].Bg);
+
+            pool.Clear();
+        }
+
+        [Fact]
+        public void ViewportRow_PaintToMatchPrompt_FollowsTheNewThemeAfterSwitch()
+        {
+            // The user-reported shape: a PowerShell prompt region painted by the shell with the
+            // OSC 11 answered background (equal to the old theme's default). After a dark →
+            // light switch the region must adopt the new theme's default instead of rendering
+            // as a dark box.
             var oldTheme = LoadTheme("SolarizedDark");
             var newTheme = LoadTheme("GitHubLight");
             var buffer = new TerminalBuffer(80, 6) { Theme = oldTheme };
             var parser = new AnsiParser(buffer);
 
-            // #002b36 == Solarized Dark's background, requested explicitly.
-            parser.Process("\x1b[48;2;0;43;54mexplicit truecolor block\x1b[0m");
+            // #002b36 == Solarized Dark's background, painted explicitly (OSC 11 match).
+            parser.Process("\x1b[48;2;0;43;54mPS C:\\Users\\behna>\x1b[0m");
 
             buffer.Theme = newTheme;
             buffer.UpdateThemeColors(oldTheme);
@@ -189,9 +225,9 @@ namespace NovaTerminal.Tests.BufferTests
                 ScrollOffset = 0
             }, out _);
 
-            var cells = FindRowCells(after, 'e', 'x');
-            Assert.False(cells[0].IsDefaultBackground);
-            Assert.Equal(TermColor.FromRgb(0, 43, 54), cells[0].Background);
+            var cells = FindRowCells(after, 'P', 'S');
+            Assert.True(cells[0].IsDefaultBackground, "paint-to-match cells must be adopted as default background");
+            Assert.Equal(newTheme.Background, cells[0].Background);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

Follow-up to #388. After merging, dark prompt/status boxes reappeared when switching dark → light — this time in **PowerShell**: the shell and agent CLIs query the terminal background via **OSC 11** and then explicitly paint their prompt/status regions with the *answered* color. Those cells are truecolors equal to the old theme's default with the default flag cleared, so the flag-based migration from #388 skipped them.

Reinstates the value-based adoption that was removed during #388 review, with the mechanism documented in-code: a program that painted to match the old terminal background *wants to keep matching the terminal*, so adopting it into the new default preserves intent rather than destroying it. The adoption stays anchored to the old default colors only — genuinely distinct explicit colors are untouched.

## Testing

- `ScrollbackRow_ExplicitTruecolorEqualToOldDefault_FollowsTheNewTheme` — the paint-to-match scrollback shape adopts the new default.
- `ViewportRow_PaintToMatchPrompt_FollowsTheNewThemeAfterSwitch` — the exact user-reported shape: SGR `48;2` prompt region painted with the old background follows the new theme through the render snapshot.
- `ScrollbackRow_ExplicitTruecolorDifferentFromOldDefault_IsLeftAlone` — value-anchoring guard: distinct explicit colors keep their exact colors.
- All prior theme-switch, pixel, and buffer suites green; VT.Tests 417/417.