### PR TITLE
chore(release): prepare v0.7.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
-    <Version>0.6.1</Version>
-    <AssemblyVersion>0.6.1.0</AssemblyVersion>
-    <FileVersion>0.6.1.0</FileVersion>
-    <InformationalVersion>0.6.1</InformationalVersion>
+    <Version>0.7.0</Version>
+    <AssemblyVersion>0.7.0.0</AssemblyVersion>
+    <FileVersion>0.7.0.0</FileVersion>
+    <InformationalVersion>0.7.0</InformationalVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Bumps `Directory.Build.props` to `0.7.0` ahead of tagging `v0.7.0`. One file, four properties, no behaviour change.

## Why now

`v0.7.0-rc.1` was cut this morning off the packaging branch tip to exercise the arm64 release lane, which had never run in any form. [Release run 33740981976](https://github.com/benyblack/NovaTerminal/actions/runs/33740981976) answered all three of its unknowns and published real assets, not merely green jobs:

- `vpk` runs on `linux-arm64`
- `ubuntu-24.04-arm` provides both a docker daemon and a `/dev/fuse` node
- the arm64 NativeAOT publish works inside the `ubuntu:22.04` container

That was the documented condition for removing the two `continue-on-error` lines that decoupled the arm64 chain from the rest of the release, and 32d44ff removed them. **`v0.7.0` is therefore the first tag where an arm64 failure withholds the Windows, macOS, and linux-x64 assets too.**

## Scope of the release

15 PRs since `v0.6.1`. `rc.1` covered #369–#382 (inline image decoding, VT capability contract, connection-manager window, login-shell default, theme expansion, macOS signing). Landed on `main` since:

- #386 — Linux AppImage + `.deb` publishing
- #387 — agent-aware vertical tabs, drag-to-reorder, overflow pill
- #388, #392 — live theme switching, light-theme chrome, SGR state across RIS
- #393 — packaging retrospective

## Note

The release workflow derives its version from the tag (`-p:Version=${tag#v}`), so this property is not what ships. It is kept in step so a local build reports the same version as the release it corresponds to — the same convention as #366, #353, #204, and #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
