### PR TITLE
site: bring the Install section and feature list up to date for 0.8.0

### DIFF
--- a/site/src/components/AgentHost.astro
+++ b/site/src/components/AgentHost.astro
@@ -22,6 +22,7 @@ const tiers = [
       'list_sessions',
       'read_screen',
       'read_scrollback',
+      'get_session_status',
       'wait_for_events',
       'export_replay',
       'capture_screen',

--- a/site/src/components/Features.astro
+++ b/site/src/components/Features.astro
@@ -20,10 +20,13 @@ const groups = [
     items: [
       'Tabs, split panes, and workspace templates',
       'Vertical tab sidebar with per-tab status and output preview',
+      'Markdown panel for agent output — fenced code, tables, and diffs',
       'Command palette (Ctrl+Shift+P) and tab list',
       'Search overlay with regex support',
       'Profiles for local and SSH sessions',
       'Themes, fonts, and font sizing',
+      'Bundled JetBrains Mono NL with a Nerd Font symbol fallback, so icon glyphs render on a fresh install',
+      'About window with an inline update check',
       'Live settings — no restart required',
     ],
   },

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -18,7 +18,7 @@ const groups = [
       { href: `${repoUrl}`, label: 'Repository' },
       { href: `${repoUrl}#architecture`, label: 'Architecture' },
       { href: `${repoUrl}#build--test`, label: 'Build & test' },
-      { href: `${repoUrl}/blob/main/ROADMAP.md`, label: 'Roadmap' },
+      { href: `${repoUrl}/blob/main/docs/ROADMAP.md`, label: 'Roadmap' },
     ],
   },
   {

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -42,7 +42,7 @@ const releases = [
       'chmod +x NovaTerminal-linux-x64-<tag>.AppImage\n' +
       './NovaTerminal-linux-x64-<tag>.AppImage',
     extraNote:
-      'The .deb adds a desktop entry, icons, the nova command on your PATH, and a man page, and updates via your package manager: sudo apt install ./novaterminal_0.7.0-1_amd64.deb. Its filename changes every release and the suffix must match your machine — copy the exact one for your architecture (amd64 or arm64) from the release page. A portable .tar.gz is there too.',
+      'The .deb adds a desktop entry, icons, the nova command on your PATH, and a man page, and updates via your package manager: sudo apt install ./<exact .deb filename from the release page>. Its filename changes every release and the suffix must match your machine — copy the exact one for your architecture (amd64 or arm64) from the release page. A portable .tar.gz is there too.',
   },
 ];
 

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -1,7 +1,9 @@
 ---
-// Release asset names follow the workflow in `.github/workflows/release.yml`:
+// Release asset names follow the workflows in `.github/workflows/release.yml`:
 // installers are `NovaTerminal-Setup-{rid}-{tag}.{exe,pkg}`, portable bundles are
-// `NovaTerminal-{rid}-{tag}.zip`. The Windows winget package id lives in
+// `NovaTerminal-{rid}-{tag}.zip`, and Linux ships `NovaTerminal-linux-{arch}-{tag}.AppImage`,
+// `NovaTerminal-linux-{arch}-{tag}.tar.gz`, and `novaterminal_{version}-1_{debarch}.deb`
+// from the publish_linux / release_linux lanes. The winget package id lives in
 // `packaging/winget/0.3.0/benyblack.NovaTerminal.yaml`.
 //
 // Ordered Windows, macOS, Linux: the two platforms with an installer come first,
@@ -21,7 +23,7 @@ const releases = [
     arch: 'arm64',
     installer: 'NovaTerminal-Setup-osx-arm64-<tag>.pkg',
     installerNote:
-      'Installs a proper NovaTerminal.app bundle, and updates itself in the background.',
+      'Installs a proper NovaTerminal.app bundle, and updates itself in the background. Signed and notarized — Gatekeeper opens it with no warnings.',
     asset: 'NovaTerminal-osx-arm64-<tag>.zip',
     cmd:
       'unzip NovaTerminal-osx-arm64-<tag>.zip\n' +
@@ -29,13 +31,18 @@ const releases = [
   },
   {
     platform: 'Linux',
-    arch: 'x64',
-    installer: null,
-    installerNote: null,
-    asset: 'NovaTerminal-linux-x64-<tag>.zip',
+    arch: 'x64 · arm64',
+    installer: 'NovaTerminal-linux-x64-<tag>.AppImage',
+    installerLabel: 'AppImage — recommended',
+    installerNote:
+      'Self-updating, like the Windows and macOS installers. Needs glibc 2.35+ (Ubuntu 22.04+, Debian 12+, Fedora 36+); arm64 builds on the same release page.',
+    asset: 'novaterminal_0.7.0-1_amd64.deb',
+    assetLabel: 'Or the .deb — system integration',
     cmd:
-      'unzip NovaTerminal-linux-x64-<tag>.zip\n' +
-      'chmod +x NovaTerminal && ./NovaTerminal',
+      'sudo apt install ./novaterminal_0.7.0-1_amd64.deb\n' +
+      'nova',
+    extraNote:
+      'The .deb adds a desktop entry, icons, `nova` on your PATH, and `man nova`, and updates via your package manager. Copy its exact filename from the release page. A portable .tar.gz is there too.',
   },
 ];
 
@@ -85,14 +92,16 @@ const buildSteps = [
       <p class="lede mt-4 max-w-2xl">
         Windows and macOS have one-click installers that keep themselves up to
         date — a new version downloads in the background and applies on your next
-        restart. Every platform also ships a portable Native AOT bundle for
-        <code class="rounded bg-ink-800/60 px-1.5 py-0.5 text-nova-200">win-x64</code>,
-        <code class="rounded bg-ink-800/60 px-1.5 py-0.5 text-nova-200">linux-x64</code>, and
-        <code class="rounded bg-ink-800/60 px-1.5 py-0.5 text-nova-200">osx-arm64</code>; portable builds have no updater. Every release runs the gating unit-test lane on all three OSes before any bundle is published. Replace <code class="rounded bg-ink-800/60 px-1.5 py-0.5 text-nova-200">&lt;tag&gt;</code> with the version you downloaded.
+        restart. Linux ships a self-updating AppImage, a system
+        <code class="rounded bg-ink-800/60 px-1.5 py-0.5 text-nova-200">.deb</code>, and a portable tarball, for
+        <code class="rounded bg-ink-800/60 px-1.5 py-0.5 text-nova-200">x64</code> and
+        <code class="rounded bg-ink-800/60 px-1.5 py-0.5 text-nova-200">arm64</code> alike. Every release runs the gating unit-test lane on all three OSes before any bundle is published. Replace <code class="rounded bg-ink-800/60 px-1.5 py-0.5 text-nova-200">&lt;tag&gt;</code> with the version you downloaded.
       </p>
       <p class="mt-4 max-w-2xl text-sm text-ink-400">
-        Installers are not code-signed yet, so Windows SmartScreen and macOS
-        Gatekeeper will warn on first run — see
+        macOS builds are signed and notarized (since v0.7.0), so Gatekeeper
+        opens them normally. Windows installers are not code-signed yet, so
+        SmartScreen will warn on first run — choose{' '}
+        <em>More info → Run anyway</em>; see
         {' '}
         <a
           href="https://github.com/benyblack/NovaTerminal/issues/91"
@@ -131,7 +140,7 @@ const buildSteps = [
             {rel.installer && (
               <div class="mt-4">
                 <p class="text-xs font-semibold uppercase tracking-wider text-nova-300">
-                  Installer — recommended
+                  {rel.installerLabel ?? 'Installer — recommended'}
                 </p>
                 <p class="mt-1 font-mono text-[11px] text-ink-400">
                   {rel.installer}
@@ -141,12 +150,17 @@ const buildSteps = [
             )}
 
             <p class="mt-4 text-xs font-semibold uppercase tracking-wider text-ink-400">
-              {rel.installer ? 'Portable — no updater' : 'Portable'}
+              {rel.assetLabel ?? (rel.installer ? 'Portable — no updater' : 'Portable')}
             </p>
             <p class="mt-1 font-mono text-[11px] text-ink-400">
               {rel.asset}
             </p>
             <pre class="code-block mt-3 text-xs leading-relaxed"><code>{rel.cmd}</code></pre>
+            {rel.extraNote && (
+              <p class="mt-3 text-xs leading-relaxed text-ink-400">
+                {rel.extraNote}
+              </p>
+            )}
           </article>
         ))
       }

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -35,14 +35,14 @@ const releases = [
     installer: 'NovaTerminal-linux-x64-<tag>.AppImage',
     installerLabel: 'AppImage — recommended',
     installerNote:
-      'Self-updating, like the Windows and macOS installers. Needs glibc 2.35+ (Ubuntu 22.04+, Debian 12+, Fedora 36+); arm64 builds on the same release page.',
-    asset: 'novaterminal_0.7.0-1_amd64.deb',
+      'Self-updating, like the Windows and macOS installers. Needs glibc 2.35+ (Ubuntu 22.04+, Debian 12+, Fedora 36+); arm64 builds are on the same release page. Ubuntu 22.04+/Debian 12 ship no FUSE 2 — install it (sudo apt install fuse) or launch with --appimage-extract-and-run.',
+    asset: 'novaterminal_<version>-1_<amd64|arm64>.deb',
     assetLabel: 'Or the .deb — system integration',
     cmd:
-      'sudo apt install ./novaterminal_0.7.0-1_amd64.deb\n' +
-      'nova',
+      'chmod +x NovaTerminal-linux-x64-<tag>.AppImage\n' +
+      './NovaTerminal-linux-x64-<tag>.AppImage',
     extraNote:
-      'The .deb adds a desktop entry, icons, `nova` on your PATH, and `man nova`, and updates via your package manager. Copy its exact filename from the release page. A portable .tar.gz is there too.',
+      'The .deb adds a desktop entry, icons, the nova command on your PATH, and a man page, and updates via your package manager: sudo apt install ./novaterminal_0.7.0-1_amd64.deb. Its filename changes every release and the suffix must match your machine — copy the exact one for your architecture (amd64 or arm64) from the release page. A portable .tar.gz is there too.',
   },
 ];
 

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -43,7 +43,7 @@ const releases = [
       'chmod +x NovaTerminal-linux-<x64|arm64>-<tag>.AppImage\n' +
       './NovaTerminal-linux-<x64|arm64>-<tag>.AppImage',
     extraNote:
-      'The .deb adds a desktop entry, icons, the nova command on your PATH, and a man page, and updates via your package manager. Its filename carries both the version and the architecture and changes every release — copy the exact one for your machine (amd64 or arm64) from the release page. A portable .tar.gz is there too.',
+      'The .deb adds a desktop entry, icons, the nova command on your PATH, and a man page. It does not update itself: there is no APT repository yet, so apt upgrade will not see new releases — download and reinstall each one. Its filename carries both the version and the architecture and changes every release — copy the exact one for your machine (amd64 or arm64) from the release page. A portable .tar.gz is there too.',
   },
 ];
 

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -23,7 +23,7 @@ const releases = [
     arch: 'arm64',
     installer: 'NovaTerminal-Setup-osx-arm64-<tag>.pkg',
     installerNote:
-      'Installs a proper NovaTerminal.app bundle, and updates itself in the background. Signed and notarized — Gatekeeper opens it with no warnings.',
+      'Installs a proper NovaTerminal.app bundle, and updates itself in the background. Signed and notarized since v0.7.0, so Gatekeeper opens it with no warnings.',
     asset: 'NovaTerminal-osx-arm64-<tag>.zip',
     cmd:
       'unzip NovaTerminal-osx-arm64-<tag>.zip\n' +
@@ -32,17 +32,18 @@ const releases = [
   {
     platform: 'Linux',
     arch: 'x64 · arm64',
-    installer: 'NovaTerminal-linux-x64-<tag>.AppImage',
+    installer: 'NovaTerminal-linux-<x64|arm64>-<tag>.AppImage',
     installerLabel: 'AppImage — recommended',
     installerNote:
-      'Self-updating, like the Windows and macOS installers. Needs glibc 2.35+ (Ubuntu 22.04+, Debian 12+, Fedora 36+); arm64 builds are on the same release page. Ubuntu 22.04+/Debian 12 ship no FUSE 2 — install it (sudo apt install fuse) or launch with --appimage-extract-and-run.',
+      'Self-updating, like the Windows and macOS installers. Needs glibc 2.35+ (Ubuntu 22.04+, Debian 12+, Fedora 36+). Ubuntu 22.04+/Debian 12 ship no FUSE 2 — install it (sudo apt install fuse) or launch with --appimage-extract-and-run.',
     asset: 'novaterminal_<version>-1_<amd64|arm64>.deb',
     assetLabel: 'Or the .deb — system integration',
-    cmd:
-      'chmod +x NovaTerminal-linux-x64-<tag>.AppImage\n' +
-      './NovaTerminal-linux-x64-<tag>.AppImage',
+    cmd: 'sudo apt install ./<exact .deb filename from the release page>',
+    installerCmd:
+      'chmod +x NovaTerminal-linux-<x64|arm64>-<tag>.AppImage\n' +
+      './NovaTerminal-linux-<x64|arm64>-<tag>.AppImage',
     extraNote:
-      'The .deb adds a desktop entry, icons, the nova command on your PATH, and a man page, and updates via your package manager: sudo apt install ./<exact .deb filename from the release page>. Its filename changes every release and the suffix must match your machine — copy the exact one for your architecture (amd64 or arm64) from the release page. A portable .tar.gz is there too.',
+      'The .deb adds a desktop entry, icons, the nova command on your PATH, and a man page, and updates via your package manager. Its filename carries both the version and the architecture and changes every release — copy the exact one for your machine (amd64 or arm64) from the release page. A portable .tar.gz is there too.',
   },
 ];
 
@@ -146,6 +147,9 @@ const buildSteps = [
                   {rel.installer}
                 </p>
                 <p class="mt-1.5 text-sm text-ink-300">{rel.installerNote}</p>
+                {rel.installerCmd && (
+                  <pre class="code-block mt-3 text-xs leading-relaxed"><code>{rel.installerCmd}</code></pre>
+                )}
               </div>
             )}
 


### PR DESCRIPTION
## What

The landing page predated the v0.7.0 packaging work and was actively pointing visitors at a download that no longer exists, plus still claiming every installer is unsigned.

## Fixes

- **Linux card pointed at a dead asset.** It instructed people to download `NovaTerminal-linux-x64-<tag>.zip` — the release lane stopped producing Linux zips in 0.7.0 (replaced by AppImage + .deb + tarball). The card now recommends the **self-updating AppImage**, shows the **.deb** for system integration, and mentions the portable tarball, arm64 builds, and the glibc 2.35 floor (Ubuntu 22.04+, Debian 12+, Fedora 36+).
- **Stale signing claim.** The blanket *"Installers are not code-signed yet, so Windows SmartScreen and macOS Gatekeeper will warn"* is now split accurately: **macOS is signed and notarized as of v0.7.0** (the headline of that release — the page was underselling it), while Windows installers remain unsigned with the SmartScreen workaround, still tracked in #91.
- **Footer Roadmap link was a 404** — it pointed at `ROADMAP.md` in the repo root; the file lives at `docs/ROADMAP.md`.
- **AgentHost Observe tier** was missing `get_session_status` from its tool list (present in the README's MCP section).

## Verification

- `npm ci --ignore-scripts && npm run build` passes; the built `dist/index.html` contains the new AppImage/.deb/signing content and zero references to the removed Linux zip or the old Roadmap path.
- Asset names cross-checked against the v0.7.0 release assets and the `publish_linux` / `release_linux` lanes in `.github/workflows/release.yml`.

Merging deploys automatically via the Pages workflow (push to `main`).
